### PR TITLE
feat(MPS/FT): structural HasRateQuantifiedCrossOverlapDecay predicate (path β PR 3)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -229,6 +229,7 @@ import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.HNoCancelDischarge
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.IsBNTCanonicalFormSD
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.RateQuantifiedDecay
 import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.Applications

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean
@@ -80,6 +80,28 @@ within-sector multiplicities under `mu_strict_anti`.
 * `audits/2026-05-13_cpsv16_ft_path_beta_scout.md`, §"PR 1.5 amendment".
 * `docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex` for the
   paper-gap note recording the extra hypotheses beyond CPSV16 §II.
+
+## Rate-quantified strengthening (non-dominant projection branch)
+
+The two-layer per-block-projection lemmas
+`fixed_*_sectorDecomp_twoLayer` in
+`TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean`
+and `fixed_*_paperFaithful_twoLayer` in
+`TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean`
+carry an abstract `hNoCancel` hypothesis whose **non-dominant** branch
+is not dischargeable on the present `IsBNTCanonicalFormSD` surface
+alone.  The obstruction analysis recorded in
+`audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md` shows that an
+additional rate-quantified cross-overlap decay hypothesis is required,
+comparing the BNT spectral gap to the weight ratios `‖λ_j / λ_k‖`.
+The structural predicate
+`HasRateQuantifiedCrossOverlapDecay P lam` in
+`TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDecay.lean`
+captures this strengthened input; it is meant to be combined with
+`IsBNTCanonicalFormSD P` by instantiating `lam` with
+`h.spectralLevel`.  The paper-gap note
+`docs/paper-gaps/cpsv16_bnt_rate_quantification.tex` records the
+mathematical content of the strengthening.
 -/
 
 namespace MPSTensor
@@ -114,6 +136,13 @@ for every `j`, so per-length coefficients `coeff N j` are uniformly
 controlled by the within-sector multiplicities.  This uniform bound powers
 the analytic discharge of `HNoCancelDischarge` on the non-dominant `k₀`
 branch (see the PR 1.5 amendment to the audit memo).
+
+For the non-dominant branch of the two-layer per-block-projection
+discharge, this predicate must be combined with the rate-quantified
+cross-overlap decay predicate
+`HasRateQuantifiedCrossOverlapDecay P h.spectralLevel`
+(see `RateQuantifiedDecay.lean` and
+`docs/paper-gaps/cpsv16_bnt_rate_quantification.tex`).
 
 The spectral level is packaged inside an existential to keep the
 predicate `Prop`-valued; the five layer projections are exposed via

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDecay.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDecay.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.IsBNTCanonicalFormSD
+
+/-!
+# Rate-quantified BNT cross-overlap decay on `SectorDecomposition`
+
+This module introduces the `Prop`-level predicate
+`HasRateQuantifiedCrossOverlapDecay` over a `SectorDecomposition P` and a
+spectral level `lam : Fin P.basisCount → ℂ`.  The predicate strengthens the
+qualitative cross-overlap decay carried by `IsBNTCanonicalFormSD` (and by
+`mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`
+in `TNLean/MPS/Overlap/CastDecay.lean`) with a **quantitative geometric
+rate** that beats the spectral weight ratio.
+
+## Why a separate predicate
+
+The two-layer per-block-projection lemmas
+
+* `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer`
+  in
+  `TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean`
+  (line 363), and
+* `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_paperFaithful_twoLayer`
+  in
+  `TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean`
+  (line 446),
+
+carry an abstract hypothesis `hNoCancel` that rules out cancellation of
+the assembled overlap against the chosen projection block.  The analysis
+recorded in `audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md` shows
+that for a non-dominant projection index `k₀`, none of the three natural
+discharge strategies on the present `IsBNTCanonicalFormSD` surface
+succeeds.  In particular, factoring out the dominant weight
+`μ_B^{(k₀)}` and renormalising the assembled overlap leaves a sum whose
+`k < k₀` terms blow up like `(μ_B^{(k)} / μ_B^{(k₀)})^N`; the only way to
+suppress them is for the cross-overlap
+`⟨V^{(N)}(P.basis j), V^{(N)}(P.basis k)⟩` between distinct basis blocks
+to decay **faster** than this weight ratio.
+
+The qualitative limit
+`mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`
+guarantees decay with an implicit rate `< 1` controlled by the transfer
+matrix spectral gap, but the comparison
+
+```
+η_{j,k} · ‖λ_j / λ_k‖ < 1
+```
+
+is independent of the BNT structure and may fail generically.  We
+therefore make the rate an **explicit hypothesis** at the structural
+level and defer the analytic source (a derivation from the transfer
+matrix spectral gap) to a downstream module.
+
+## Why `lam` is an explicit parameter
+
+`IsBNTCanonicalFormSD` packages the spectral level inside an
+existential and exposes it through `Classical.choose`-based accessors
+(`IsBNTCanonicalFormSD.spectralLevel` and friends).  The
+rate-quantified predicate must compare `η_{j,k}` against the ratio
+`‖λ_j / λ_k‖`, so it needs *a specific* `lam` rather than the abstract
+existential.  Taking `lam` as an explicit parameter keeps the predicate
+free of any commitment to `Classical.choose`: a caller building on top
+of `IsBNTCanonicalFormSD P` instantiates `lam := h.spectralLevel`,
+while a caller working with a concrete sector decomposition (e.g. via
+`IsCanonicalFormBNT.toIsBNTCanonicalFormSD`) instantiates `lam` with
+its rescaled weights directly.
+
+## References
+
+* CPSV16: Cirac--Pérez-García--Schuch--Verstraete, *Matrix Product
+  Density Operators: Renormalization Fixed Points and Boundary
+  Theories*, Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.
+  - §II Step~1, lines 1170–1192: the BNT cross-overlap argument
+    implicitly assumes a rate fast enough to dominate any
+    weight-ratio blow-up; the assumption is not stated explicitly.
+* CPSV21: Cirac--Pérez-García--Schuch--Verstraete, *Matrix product
+  states and projected entangled pair states: Concepts, symmetries,
+  theorems*, Rev. Mod. Phys. **93**, 045003 (2021); arXiv:2011.12127.
+  - Definition 4.3 (`def:4:BNT`, lines 1846–1850): packages eventual
+    linear independence of the BNT vectors without quantifying the
+    decay rate.
+* `audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md` for the
+  obstruction analysis.
+* `docs/paper-gaps/cpsv16_bnt_rate_quantification.tex` for the
+  paper-gap note recording this structural hypothesis.
+* `TNLean/MPS/Overlap/CastDecay.lean` —
+  `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`
+  is the qualitative source from which a rate is in principle
+  recoverable via the transfer matrix spectral gap.
+-/
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- **Rate-quantified BNT cross-overlap decay** for a sector
+decomposition.
+
+Given a `SectorDecomposition P` and a spectral level
+`lam : Fin P.basisCount → ℂ`, the predicate
+`HasRateQuantifiedCrossOverlapDecay P lam` asserts the existence of
+nonnegative constants `C j k` and rates `η j k ∈ [0, 1)` for every
+ordered pair `j ≠ k`, such that
+
+* `η j k · ‖lam j / lam k‖ < 1` — the rate is strict enough to beat the
+  spectral weight ratio along the direction `j ⟶ k`; and
+* `‖mpvOverlap (P.basis j) (P.basis k) N‖ ≤ C j k · (η j k)^N` for every
+  `N`.
+
+The hypothesis is the missing analytic input identified by the path β
+PR 2.5 design memo
+(`audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md`): it is what
+lets the abstract `hNoCancel` field of the two-layer per-block-projection
+lemmas
+
+* `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_sectorDecomp_twoLayer`
+  (`PerBlockProjection.lean:363`), and
+* `fixed_right_all_overlaps_decay_false_of_eventuallyNonzeroProportionalMPV₂_paperFaithful_twoLayer`
+  (`HNoCancelDischarge.lean:446`)
+
+be discharged for non-dominant projection indices `k₀`.
+
+The spectral level `lam` is an **explicit parameter** rather than an
+existentially packaged field: the predicate is meant to be bundled with
+whatever `lam` a caller is working with.  A caller building on top of
+`IsBNTCanonicalFormSD P` instantiates `lam := h.spectralLevel`; a caller
+working with a concrete weight family instantiates `lam` directly.
+This decoupling avoids any commitment to `Classical.choose` at the
+structural level.
+
+Conceptually the rate
+`η_{j,k}` is controlled by the transfer matrix spectral gap of the
+mixed transfer operator
+`mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`
+in `TNLean/MPS/Overlap/CastDecay.lean`, but the comparison with
+`‖lam j / lam k‖` is independent of the BNT structure and may fail
+generically.  The downstream analytic derivation is the subject of
+"Option~2" of the design memo and is not addressed here.
+
+## References
+
+* CPSV16 §II Step~1, lines 1170–1192 (arXiv:1606.00608).
+* CPSV21 Definition~4.3, lines 1846–1850 (arXiv:2011.12127). -/
+structure HasRateQuantifiedCrossOverlapDecay (P : SectorDecomposition d)
+    (lam : Fin P.basisCount → ℂ) : Prop where
+  /-- There exist a constant family `C` and a rate family `η`, indexed by
+  ordered pairs of basis blocks, satisfying the four-fold conjunction of
+  nonnegativity, sub-unitality, weight-ratio compatibility, and a
+  geometric cross-overlap bound. -/
+  exists_rate :
+    ∃ (C η : Fin P.basisCount → Fin P.basisCount → ℝ),
+      (∀ j k, j ≠ k →
+        0 ≤ C j k ∧ 0 ≤ η j k ∧ η j k < 1 ∧
+        η j k * ‖lam j / lam k‖ < 1) ∧
+      (∀ j k, j ≠ k → ∀ N,
+        ‖mpvOverlap (d := d) (P.basis j) (P.basis k) N‖
+          ≤ C j k * (η j k) ^ N)
+
+namespace HasRateQuantifiedCrossOverlapDecay
+
+variable {P : SectorDecomposition d} {lam : Fin P.basisCount → ℂ}
+
+/-- **Rate constant** `C j k` for the cross-overlap bound between basis
+blocks `j` and `k`.  Only the off-diagonal values (`j ≠ k`) carry
+meaningful nonnegativity and bound assertions; see `rate_nonneg` and
+`overlap_bound`. -/
+noncomputable def rateC (h : HasRateQuantifiedCrossOverlapDecay P lam) :
+    Fin P.basisCount → Fin P.basisCount → ℝ :=
+  h.exists_rate.choose
+
+/-- **Geometric decay rate** `η j k ∈ [0, 1)` for the cross-overlap
+between basis blocks `j` and `k`.  Combined with `rate_compatible` this
+rate strictly beats the spectral weight ratio `‖lam j / lam k‖`. -/
+noncomputable def rateEta (h : HasRateQuantifiedCrossOverlapDecay P lam) :
+    Fin P.basisCount → Fin P.basisCount → ℝ :=
+  h.exists_rate.choose_spec.choose
+
+/-- Both the rate constant and the rate itself are nonnegative for every
+off-diagonal pair `j ≠ k`. -/
+theorem rate_nonneg (h : HasRateQuantifiedCrossOverlapDecay P lam)
+    {j k : Fin P.basisCount} (hjk : j ≠ k) :
+    0 ≤ h.rateC j k ∧ 0 ≤ h.rateEta j k :=
+  ⟨(h.exists_rate.choose_spec.choose_spec.1 j k hjk).1,
+   (h.exists_rate.choose_spec.choose_spec.1 j k hjk).2.1⟩
+
+/-- The rate is strictly less than `1` for every off-diagonal pair. -/
+theorem rate_lt_one (h : HasRateQuantifiedCrossOverlapDecay P lam)
+    {j k : Fin P.basisCount} (hjk : j ≠ k) :
+    h.rateEta j k < 1 :=
+  (h.exists_rate.choose_spec.choose_spec.1 j k hjk).2.2.1
+
+/-- **Weight-ratio compatibility.**  The rate is strict enough to beat
+the spectral weight ratio along the direction `j ⟶ k`:
+`η j k · ‖lam j / lam k‖ < 1`.  This is the critical inequality that
+the abstract `hNoCancel` hypothesis demands in the non-dominant
+projection branch of the two-layer per-block-projection lemmas. -/
+theorem rate_compatible (h : HasRateQuantifiedCrossOverlapDecay P lam)
+    {j k : Fin P.basisCount} (hjk : j ≠ k) :
+    h.rateEta j k * ‖lam j / lam k‖ < 1 :=
+  (h.exists_rate.choose_spec.choose_spec.1 j k hjk).2.2.2
+
+/-- **Geometric overlap bound.**  The cross-overlap between distinct
+basis blocks decays at least as fast as `C j k · (η j k)^N`. -/
+theorem overlap_bound (h : HasRateQuantifiedCrossOverlapDecay P lam)
+    {j k : Fin P.basisCount} (hjk : j ≠ k) (N : ℕ) :
+    ‖mpvOverlap (d := d) (P.basis j) (P.basis k) N‖
+      ≤ h.rateC j k * (h.rateEta j k) ^ N :=
+  h.exists_rate.choose_spec.choose_spec.2 j k hjk N
+
+end HasRateQuantifiedCrossOverlapDecay
+
+end MPSTensor

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -1,0 +1,168 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Rate-Quantified BNT Cross-Overlap Decay\\
+       on the \leanid{SectorDecomposition} Surface}
+\author{}
+\date{2026-05-13}
+
+\begin{document}
+\maketitle
+
+\section{Notation}
+
+Fix a sector decomposition $P$ with basis blocks
+$\{P.\mathtt{basis}\,j\}_{j=0}^{g-1}$ and a spectral level
+$\lambda_j\in\mathbb C\setminus\{0\}$ with
+$\|\lambda_0\|>\|\lambda_1\|>\cdots>\|\lambda_{g-1}\|$ and
+$\|\lambda_0\|=1$. The bilinear cross-overlap between basis blocks
+$j$ and $k$ at length $N$ is
+\begin{align}
+    O_{j,k}(N) := 
+    \mathtt{mpvOverlap}\bigl(P.\mathtt{basis}\,j,
+                             P.\mathtt{basis}\,k\bigr)(N)
+    = \sum_{\sigma}\mathtt{mpv}(P.\mathtt{basis}\,j)(\sigma)
+                     \overline{\mathtt{mpv}(P.\mathtt{basis}\,k)(\sigma)},
+\end{align}
+written \leanid{mpvOverlap} in the formalization.\footnote{%
+    Declaration \leanid{MPSTensor.mpvOverlap} in
+    \doclink{TNLean/MPS/Overlap/Basic}.}
+
+For every ordered pair $j\ne k$ we are interested in a geometric
+bound
+\begin{align}
+    \|O_{j,k}(N)\| \le C_{j,k} \eta_{j,k}^N
+    \qquad(\forall N\in\mathbb N),
+    \label{eq:rate}
+\end{align}
+with $C_{j,k}\ge 0$ and a rate $\eta_{j,k}\in[0,1)$.
+
+\section{Cited assertion}
+
+The Step~1 argument at
+\cite[lines~1170--1192]{Cirac2016MPDO_arXiv} relies on
+$O_{j,k_0}(N)\to 0$ for $j\ne k_0$ to discard
+cross-overlap terms when projecting an assembled BNT identity onto a
+distinguished basis block $V^{(N)}(P.\mathtt{basis}\,k_0)$. The
+qualitative limit is implicit in the BNT structure: distinct normal
+blocks satisfy
+\begin{align}
+    O_{j,k}(N)\xrightarrow[N\to\infty]{} 0
+    \qquad(j\ne k).
+    \label{eq:qual}
+\end{align}
+The argument as written does not quantify the rate of decay in
+\eqref{eq:qual}.
+
+Definition~4.3 of~\cite{Cirac2021Matrix} packages
+\eqref{eq:qual} indirectly under \emph{eventual linear independence} of
+the basis MPVs and does not state a rate. The formal counterpart is
+the predicate
+\leanid{MPSTensor.HasBNTSectorData}\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition} at
+    \leanid{HasBNTSectorData}.}
+in the formalization, and \eqref{eq:qual} is provided pointwise by
+\leanid{MPSTensor.mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP}.\footnote{%
+    \doclink{TNLean/MPS/Overlap/CastDecay}.}
+Neither source equips $\eta_{j,k}$ with a quantitative relation
+to the spectral weight ratios.
+
+\section{The formal hypothesis}
+
+The structural predicate
+\leanid{HasRateQuantifiedCrossOverlapDecay}\footnote{%
+    Declaration \leanid{MPSTensor.HasRateQuantifiedCrossOverlapDecay} in
+    \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDecay}.}
+takes a sector decomposition $P$ and an explicit spectral level
+$\lambda:\mathrm{Fin}\,P.\mathtt{basisCount}\to\mathbb C$ and asserts
+the existence of non-negative families $C,\eta$ such that for every
+$j\ne k$,
+\begin{align}
+    0\le C_{j,k},\quad 0\le\eta_{j,k}<1,
+        \qquad
+    \eta_{j,k}\cdot\|\lambda_j/\lambda_k\|<1,
+    \label{eq:hyp}
+\end{align}
+together with the geometric bound~\eqref{eq:rate} for all $N$.
+The accessors \leanid{rateC}, \leanid{rateEta}, \leanid{rate\_nonneg},
+\leanid{rate\_lt\_one}, \leanid{rate\_compatible}, and
+\leanid{overlap\_bound} expose the components individually.
+
+The spectral level $\lambda$ is an \emph{explicit parameter}, not an
+existentially packaged field. The accessors of
+\leanid{IsBNTCanonicalFormSD}\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}.}
+extract a specific $\lambda$ from its inner existential through
+\verb|Classical.choose|; the rate-quantified predicate avoids that
+coupling by taking $\lambda$ from the caller. A caller holding
+$h:\leanid{IsBNTCanonicalFormSD}\,P$ instantiates
+$\lambda:=h.\leanid{spectralLevel}$; a caller with concrete weights
+instantiates $\lambda$ directly.
+
+\section{Where the hypothesis is needed}
+
+The two-layer per-block-projection lemmas
+\begin{itemize}
+  \item \leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_sectorDecomp\_twoLayer}\\
+        in
+        \path{TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean}
+        (line~363), and
+  \item \leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_paperFaithful\_twoLayer}\\
+        in
+        \path{TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean}
+        (line~446),
+\end{itemize}
+carry an abstract hypothesis $\leanid{hNoCancel}$ that rules out
+asymptotic cancellation of the assembled overlap against the chosen
+projection block~$k_0$. The obstruction analysis in
+\path{audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md} shows that
+for a non-dominant $k_0$ the discharge requires, after isolating
+$V^{(N)}(P.\mathtt{basis}\,k_0)$ on the right and renormalising by
+$\lambda_{k_0}^N$, that every $j\ne k_0$ contribute a term whose modulus
+is bounded by
+\begin{align}
+    \|O_{j,k_0}(N)\|\cdot\|\lambda_j/\lambda_{k_0}\|^N
+    \le C_{j,k_0}(\eta_{j,k_0}\cdot\|\lambda_j/\lambda_{k_0}\|)^N.
+    \label{eq:product}
+\end{align}
+The right-hand side of~\eqref{eq:product} converges to $0$ exactly when
+\eqref{eq:hyp} holds. The qualitative limit~\eqref{eq:qual} alone
+gives $\eta_{j,k_0}<1$ but not the comparison
+$\eta_{j,k_0}\cdot\|\lambda_j/\lambda_{k_0}\|<1$, which is the
+content of the new hypothesis.
+
+\section{Classification}
+
+\emph{Open gap.}  The hypothesis
+\leanid{HasRateQuantifiedCrossOverlapDecay} is a structural input
+beyond what \cite[\S II]{Cirac2016MPDO_arXiv} and
+\cite[Definition~4.3]{Cirac2021Matrix} make explicit. Its rate is
+in principle derivable from the spectral gap of the mixed transfer
+operator that powers
+\leanid{mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP},
+but the compatibility inequality
+$\eta_{j,k}\cdot\|\lambda_j/\lambda_k\|<1$ is not implied by the
+BNT structure and must be either imposed or established analytically.
+
+The analytic derivation from the transfer matrix spectral gap is the
+subject of \emph{Option~2} in the design memo
+\path{audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md} and is
+not addressed in this note. The hypothesis is needed to discharge the
+non-dominant branch of the abstract $\leanid{hNoCancel}$ field on the
+two-layer surface and ultimately to close the
+\leanid{IsCanonicalFormBNT}-surface declarations
+\leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}
+and its symmetric counterpart
+in
+\path{TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
Refs: #1641

## Context

PR 2 (#1664) delivered the algebraic skeleton of the two-layer per-block-projection theorems with an abstract `hNoCancel` hypothesis. The design memo (#1666) identified that the discharge of `hNoCancel` for non-dominant `k_0` requires an additional analytic input: **rate-quantified cross-overlap decay** comparing the BNT spectral gap to weight ratios.

This PR delivers the **structural definition** of that input as a separate `Prop`-level predicate, plus paper-gap doc. **No analytic discharge proofs are in this PR** — the discharge is the subject of the follow-on PR.

## What's in this PR

### New module
`TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDecay.lean` (216 LoC):
- `structure HasRateQuantifiedCrossOverlapDecay (P : SectorDecomposition d) (lam : Fin P.basisCount → ℂ) : Prop`
- Accessors: `rateC`, `rateEta`, `rate_nonneg`, `rate_lt_one`, `rate_compatible`, `overlap_bound`
- Full module-level docstring documenting design choices (explicit `lam` parameter to avoid `Classical.choose` coupling).

### New paper-gap doc
`docs/paper-gaps/cpsv16_bnt_rate_quantification.tex` (167 LoC, 3-page PDF). Explains:
- Notation: spectral level `λ_j`, BNT cross-overlap, geometric rate `η_{j,k}`.
- Cited assertion: CPSV16 §II Step 1 lines 1170-1192 implicitly assume the rate; CPSV21 Def 4.3 packages it under "eventual LI" without quantifying.
- Statement of the new hypothesis.
- Why it's needed (cross-references the design memo).
- Open analytic source: derivable in principle from TM spectral gap via `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`; explicit construction is "Option 2" from the design memo.

### Touched
- `TNLean.lean` — added import.
- `TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean` — docstring-only addition cross-referencing the new predicate.

## What this PR does NOT do

- **No** analytic discharge of `hNoCancel` (that's the next PR).
- **No** changes to existing `PerBlockProjection.lean` or `HNoCancelDischarge.lean` proofs.
- **No** touching the two `_CFBNT` sorries at `FixedBlockDecay.lean:107, 152` (that's PR 4 work).

## Build verification

- `lake build TNLean.MPS.FundamentalTheorem.SectorDecomposition.RateQuantifiedDecay` — ✅ Build completed successfully (8398 jobs).
- LaTeX compile: 3-page PDF, no warnings.
- No new `sorry`, `axiom`, or `unsafe`.

## Next steps after merge

Dispatch the analytic discharge of `hNoCancel` for non-dominant `k_0` using `HasRateQuantifiedCrossOverlapDecay`:
1. Re-derive `hNoCancel_of_unitModulus_decay_c_norm_lower` for the two-layer case with the rate hypothesis.
2. Wire the discharge into a new `fixed_*_paperFaithful_twoLayer_rateQuantified` theorem.
3. Then PR 4: discharge the two `_CFBNT` sorries via the adapter + this new theorem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new structural `Prop` and documentation, with no changes to existing proofs or core algorithms; risk is limited to new API surface and import graph effects.
> 
> **Overview**
> Introduces a new `SectorDecomposition`-level structural hypothesis `HasRateQuantifiedCrossOverlapDecay P lam` that packages **geometric cross-overlap bounds** plus the key compatibility inequality `η j k * ‖lam j / lam k‖ < 1`, intended to later discharge the non-dominant `hNoCancel` branch in two-layer per-block-projection lemmas.
> 
> Wires the new module into the root import surface (`TNLean.lean`) and updates `IsBNTCanonicalFormSD` documentation to reference the strengthened hypothesis; adds a paper-gap LaTeX note (`docs/paper-gaps/cpsv16_bnt_rate_quantification.tex`) explaining the missing rate assumption and the formal predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaa3bfd795588d3e8c469b98220e75211b6a99a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->