### PR TITLE
feat(MPS/FT): renormalised non-cancellation centerpiece for non-dominant k₀ (path β)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition/RenormalizedNonCancellation.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition/RenormalizedNonCancellation.lean
@@ -1,0 +1,337 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.UnitModulusPowerSum
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.PerBlockProjection
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition.RateQuantifiedDecay
+
+/-!
+# Renormalised non-cancellation on the two-layer `IsBNTCanonicalFormSD` surface
+
+The two-layer per-block-projection skeleton `fixed_*_sectorDecomp_twoLayer`
+in `PerBlockProjection.lean` carries an abstract hypothesis `hNoCancel`
+asserting that the scaled assembled-to-block overlap
+`c N · mpvOverlap Q.toTensor (Q.basis k₀) N` does not tend to zero.
+For a non-dominant `Q`-block `k₀` on the two-layer surface, both factors
+decay individually (the scalar witness is bounded above, and the overlap
+decays by the spectral-level dominance), so the product tends to zero
+unconditionally.  The abstract hypothesis is therefore unsatisfiable,
+and the skeleton is unusable in the non-dominant branch.
+
+The discharge presented in this module replaces the load-bearing role of
+`hNoCancel` by a **renormalised** analytic statement: multiply both
+sides of the projected proportionality by `(λ_{Q,k₀} ^ N)⁻¹` before
+extracting the non-cancellation.  The Q-side of the renormalised
+identity satisfies a non-decay property powered by
+
+* `unitModulus_power_sum_not_tendsto_zero` on the within-sector
+  quotient weights `ν_{k₀,q} := Q.weight k₀ q / λ_{Q,k₀}`
+  (`‖ν_{k₀,q}‖ = 1` by `IsBNTCanonicalFormSD.weight_factor`); and
+* the rate-quantified Q-internal cross-overlap decay
+  `HasRateQuantifiedCrossOverlapDecay`, where the rate `η_{k,k₀}`
+  satisfies `η_{k,k₀} · ‖λ_{Q,k} / λ_{Q,k₀}‖ < 1` and therefore beats
+  the geometric blow-up from non-dominant ratios `‖λ_{Q,k} / λ_{Q,k₀}‖`
+  that would otherwise dominate the renormalised cross-overlap sum.
+
+## Main statement
+
+`mpvOverlap_toTensor_basis_renorm_not_tendsto_zero`: the renormalised
+Q-side, `(λ_{Q,k₀} ^ N)⁻¹ * mpvOverlap Q.toTensor (Q.basis k₀) N`, does
+**not** tend to zero, under the two-layer canonical form structure,
+the rate-quantified Q-internal cross-overlap decay, and a nonzero
+self-overlap limit on the fixed `k₀`-block.
+
+This statement is the analytic centerpiece of the renormalised
+non-cancellation: it plays the role formerly intended for
+`mpvOverlap_toTensor_basis_not_tendsto_zero`
+(`HNoCancelDischarge.lean:87`) in the one-layer setting, but on the
+two-layer surface where the dominant normalisation `‖λ_{Q,0}‖ = 1`
+forces individual decay of the un-renormalised overlap.
+
+## References
+
+* CPSV16: Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product
+  Density Operators*, Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.
+  Theorem `thm1`, lines 1170--1192.
+* `audits/2026-05-13_cpsv16_ft_renormalized_discharge_design.md` —
+  validation analysis confirming the renormalisation is required for
+  non-dominant `k₀`.
+* `audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md` — predecessor
+  memo identifying the rate-quantification gap.
+* `docs/paper-gaps/cpsv16_bnt_rate_quantification.tex` — paper-gap note
+  for the cross-overlap rate hypothesis.
+-/
+
+open scoped Matrix BigOperators
+open Filter
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+section RenormalisedNonCancellation
+
+/-- **Renormalised assembled-to-block overlap does not vanish on the
+two-layer surface.**
+
+For a sector decomposition `Q` with the two-layer `IsBNTCanonicalFormSD`
+structure, the rate-quantified Q-internal cross-overlap decay, an
+arbitrary block index `k₀`, and a nonzero self-overlap limit at `k₀`,
+the renormalised assembled-tensor-to-block overlap
+
+`(λ_{Q,k₀} ^ N)⁻¹ * mpvOverlap Q.toTensor (Q.basis k₀) N`
+
+does not tend to zero as `N → ∞`.
+
+The renormalisation factor `(λ_{Q,k₀} ^ N)⁻¹` makes the diagonal
+contribution `(λ_{Q,k₀} ^ N)⁻¹ * Q.coeff N k₀ · self-overlap`
+collapse to `(∑ q, ν_{k₀,q}^N) · self-overlap`, where
+`ν_{k₀,q} := Q.weight k₀ q / λ_{Q,k₀}` are the unit-modulus quotient
+weights (`weight_factor`).  The unit-modulus power sum
+`∑ q, ν_{k₀,q}^N` does not tend to zero
+(`unitModulus_power_sum_not_tendsto_zero`), so the diagonal cannot
+vanish.  The off-diagonal contribution is forced to zero by the rate
+hypothesis: for `k ≠ k₀`, the geometric factor `(λ_{Q,k} / λ_{Q,k₀})^N`
+is dominated by the rate `(η_{k,k₀})^N · ‖λ_{Q,k}/λ_{Q,k₀}‖^N` whose
+base `η_{k,k₀} · ‖λ_{Q,k}/λ_{Q,k₀}‖ < 1` by `rate_compatible`.
+
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192 (renormalised
+Q-side non-cancellation for non-dominant `k₀`). -/
+lemma mpvOverlap_toTensor_basis_renorm_not_tendsto_zero
+    (Q : SectorDecomposition d)
+    (hQ : IsBNTCanonicalFormSD Q)
+    (hQRate : HasRateQuantifiedCrossOverlapDecay Q hQ.spectralLevel)
+    (k₀ : Fin Q.basisCount)
+    {ℓ : ℂ} (hℓ_ne : ℓ ≠ 0)
+    (hQ_self_limit :
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+          atTop (nhds ℓ)) :
+    ¬ Tendsto
+        (fun N => (hQ.spectralLevel k₀ ^ N)⁻¹
+                    * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N)
+        atTop (nhds 0) := by
+  classical
+  intro hT
+  -- Abbreviate the dominant-block parameter.
+  set lam0 : ℂ := hQ.spectralLevel k₀ with hlam0_def
+  have hlam0_ne : lam0 ≠ 0 := hQ.spectralLevel_ne_zero k₀
+  have hlam0_pow_ne : ∀ N : ℕ, (lam0 ^ N) ≠ 0 := fun N => pow_ne_zero N hlam0_ne
+  have hlam0_norm_pos : 0 < ‖lam0‖ := norm_pos_iff.mpr hlam0_ne
+  -- Step 1: Expand `mpvOverlap Q.toTensor (Q.basis k₀) N` as a sum over
+  -- basis blocks of `Q`.
+  have hExpand : ∀ N : ℕ,
+      mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N
+        = ∑ k : Fin Q.basisCount,
+            Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N := by
+    intro N
+    refine mpvOverlap_eq_sum_of_decomp_left
+      (d := d) (g := Q.basisCount) (dim := Q.basisDim)
+      Q.toTensor Q.basis (N := N)
+      (fun k => Q.coeff N k) ?_ (Q.basis k₀)
+    intro σ
+    exact Q.mpv_toTensor_eq_sum_coeff (N := N) σ
+  -- Step 2: For each k ≠ k₀, the renormalised summand tends to zero.
+  -- ‖summand k N‖ ≤ (copies k · C k k₀) · (‖λ_k / λ_{k₀}‖ · η k k₀)^N → 0.
+  have hOffDiag : ∀ k : Fin Q.basisCount, k ≠ k₀ →
+      Tendsto
+        (fun N =>
+          (lam0 ^ N)⁻¹ * (Q.coeff N k *
+            mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N))
+        atTop (nhds 0) := by
+    intro k hk
+    -- Unpack rate-quantified data.
+    have hC_nn : 0 ≤ hQRate.rateC k k₀ := (hQRate.rate_nonneg hk).1
+    have hη_nn : 0 ≤ hQRate.rateEta k k₀ := (hQRate.rate_nonneg hk).2
+    have hRC : hQRate.rateEta k k₀ * ‖hQ.spectralLevel k / lam0‖ < 1 :=
+      hQRate.rate_compatible hk
+    have hOver_bd : ∀ N : ℕ,
+        ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N‖
+          ≤ hQRate.rateC k k₀ * hQRate.rateEta k k₀ ^ N :=
+      fun N => hQRate.overlap_bound hk N
+    have hCoeff_bd : ∀ N : ℕ,
+        ‖Q.coeff N k‖
+          ≤ ‖hQ.spectralLevel k‖ ^ N * (Q.copies k : ℝ) :=
+      fun N => Q.norm_coeff_le_spectral_pow_mul_copies hQ N k
+    -- Bound base `base := ‖λ_k / λ_{k₀}‖ · η k k₀`.
+    set base : ℝ := ‖hQ.spectralLevel k / lam0‖ * hQRate.rateEta k k₀ with hbase_def
+    have hbase_nn : 0 ≤ base := by
+      have h1 : 0 ≤ ‖hQ.spectralLevel k / lam0‖ := norm_nonneg _
+      exact mul_nonneg h1 hη_nn
+    have hbase_lt_one : base < 1 := by
+      have h := hRC; rw [mul_comm] at h
+      exact h
+    -- Upper bound function: `B N := (copies k · C) · base^N`.
+    set C : ℝ := (Q.copies k : ℝ) * hQRate.rateC k k₀ with hC_def
+    have hC_nn' : 0 ≤ C := mul_nonneg (Nat.cast_nonneg _) hC_nn
+    set B : ℕ → ℝ := fun N => C * base ^ N with hB_def
+    have hB_tendsto : Tendsto B atTop (nhds 0) := by
+      have hgeom : Tendsto (fun N : ℕ => base ^ N) atTop (nhds 0) := by
+        refine tendsto_pow_atTop_nhds_zero_of_lt_one hbase_nn ?_
+        exact hbase_lt_one
+      have := hgeom.const_mul C
+      simpa [B] using this
+    -- Norm bound on the summand.
+    have hSum_bd : ∀ N : ℕ,
+        ‖(lam0 ^ N)⁻¹ * (Q.coeff N k *
+            mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)‖
+          ≤ B N := by
+      intro N
+      have hinv_norm : ‖(lam0 ^ N)⁻¹‖ = (‖lam0‖ ^ N)⁻¹ := by
+        rw [norm_inv, norm_pow]
+      have hinv_pos : 0 < (‖lam0‖ ^ N)⁻¹ := by
+        have : 0 < ‖lam0‖ ^ N := pow_pos hlam0_norm_pos N
+        exact inv_pos.mpr this
+      -- ‖λ_k‖ ^ N · (copies k) · (C k k₀ · η^N) · (‖lam0‖^N)⁻¹
+      --   = (copies k · C k k₀) · ((‖λ_k‖ / ‖lam0‖)^N · η^N)
+      --   = C · base^N.
+      have hOver_nn := norm_nonneg (mpvOverlap (d := d)
+        (Q.basis k) (Q.basis k₀) N)
+      have hCoeff_nn := norm_nonneg (Q.coeff N k)
+      have hLamN_nn : 0 ≤ ‖hQ.spectralLevel k‖ ^ N := pow_nonneg (norm_nonneg _) N
+      have hCcopies_nn : 0 ≤ ‖hQ.spectralLevel k‖ ^ N * (Q.copies k : ℝ) :=
+        mul_nonneg hLamN_nn (Nat.cast_nonneg _)
+      have hηN_nn : 0 ≤ hQRate.rateEta k k₀ ^ N := pow_nonneg hη_nn N
+      have hCη_nn : 0 ≤ hQRate.rateC k k₀ * hQRate.rateEta k k₀ ^ N :=
+        mul_nonneg hC_nn hηN_nn
+      calc ‖(lam0 ^ N)⁻¹ * (Q.coeff N k *
+            mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N)‖
+          = ‖(lam0 ^ N)⁻¹‖ *
+              (‖Q.coeff N k‖ *
+                ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N‖) := by
+                rw [norm_mul, norm_mul]
+        _ = (‖lam0‖ ^ N)⁻¹ *
+              (‖Q.coeff N k‖ *
+                ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N‖) := by
+                rw [hinv_norm]
+        _ ≤ (‖lam0‖ ^ N)⁻¹ *
+              ((‖hQ.spectralLevel k‖ ^ N * (Q.copies k : ℝ)) *
+                (hQRate.rateC k k₀ * hQRate.rateEta k k₀ ^ N)) := by
+                refine mul_le_mul_of_nonneg_left ?_ (le_of_lt hinv_pos)
+                exact mul_le_mul (hCoeff_bd N) (hOver_bd N) hOver_nn hCcopies_nn
+        _ = (Q.copies k : ℝ) * hQRate.rateC k k₀ *
+              ((‖hQ.spectralLevel k‖ ^ N * (‖lam0‖ ^ N)⁻¹) *
+                hQRate.rateEta k k₀ ^ N) := by ring
+        _ = C *
+              ((‖hQ.spectralLevel k‖ / ‖lam0‖) ^ N * hQRate.rateEta k k₀ ^ N) := by
+                rw [hC_def]
+                congr 2
+                rw [div_pow, div_eq_mul_inv]
+        _ = C *
+              ((‖hQ.spectralLevel k‖ / ‖lam0‖) * hQRate.rateEta k k₀) ^ N := by
+                rw [mul_pow]
+        _ = C * base ^ N := by
+                simp only [hbase_def]
+                congr 2
+                rw [norm_div]
+        _ = B N := by rw [hB_def]
+    -- Squeeze: |summand N| ≤ B N → 0.
+    refine squeeze_zero_norm hSum_bd hB_tendsto
+  -- Step 3: Total off-diagonal contribution tends to zero.
+  have hOffDiagSum : Tendsto
+      (fun N => ∑ k ∈ (Finset.univ.erase k₀),
+          (lam0 ^ N)⁻¹ *
+            (Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N))
+      atTop (nhds 0) := by
+    have hTo : Tendsto
+        (fun N => ∑ k ∈ (Finset.univ.erase k₀),
+            (lam0 ^ N)⁻¹ *
+              (Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N))
+        atTop
+        (nhds (∑ _k ∈ (Finset.univ.erase k₀ : Finset (Fin Q.basisCount)),
+                (0 : ℂ))) := by
+      refine tendsto_finset_sum (Finset.univ.erase k₀) ?_
+      intro k hk
+      exact hOffDiag k (Finset.ne_of_mem_erase hk)
+    simpa using hTo
+  -- Step 4: From `T N → 0`, the diagonal renormalised term tends to zero.
+  have hDiag_tendsto : Tendsto
+      (fun N =>
+        (lam0 ^ N)⁻¹ * (Q.coeff N k₀ *
+          mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N))
+      atTop (nhds 0) := by
+    -- diagonal = T - (off-diagonal sum)
+    have hRew : ∀ N : ℕ,
+        (lam0 ^ N)⁻¹ * (Q.coeff N k₀ *
+            mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+          = (lam0 ^ N)⁻¹ * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N
+            - ∑ k ∈ (Finset.univ.erase k₀),
+                (lam0 ^ N)⁻¹ *
+                  (Q.coeff N k *
+                    mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N) := by
+      intro N
+      have hcomb :
+          (lam0 ^ N)⁻¹ * mpvOverlap (d := d) Q.toTensor (Q.basis k₀) N
+            = (lam0 ^ N)⁻¹ * (Q.coeff N k₀ *
+                mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+              + ∑ k ∈ (Finset.univ.erase k₀),
+                  (lam0 ^ N)⁻¹ *
+                    (Q.coeff N k *
+                      mpvOverlap (d := d) (Q.basis k) (Q.basis k₀) N) := by
+        rw [hExpand N, Finset.mul_sum]
+        exact (Finset.add_sum_erase _ _ (Finset.mem_univ k₀)).symm
+      exact eq_sub_of_add_eq hcomb.symm
+    have hSub := hT.sub hOffDiagSum
+    have hZero' : (0 : ℂ) - 0 = 0 := by ring
+    rw [hZero'] at hSub
+    refine hSub.congr' ?_
+    refine Filter.Eventually.of_forall ?_
+    intro N
+    exact (hRew N).symm
+  -- Step 5: Divide by the self-overlap (eventually nonzero) to deduce
+  -- `(lam0 ^ N)⁻¹ * Q.coeff N k₀ → 0`.
+  have hCoeff_tendsto : Tendsto
+      (fun N => (lam0 ^ N)⁻¹ * Q.coeff N k₀) atTop (nhds 0) := by
+    have hQuot : Tendsto
+        (fun N =>
+          ((lam0 ^ N)⁻¹ * (Q.coeff N k₀ *
+              mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N))
+            / mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+        atTop (nhds (0 / ℓ)) :=
+      hDiag_tendsto.div hQ_self_limit hℓ_ne
+    have hRewQuot : ∀ᶠ N in atTop,
+        ((lam0 ^ N)⁻¹ * (Q.coeff N k₀ *
+            mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N))
+            / mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N
+          = (lam0 ^ N)⁻¹ * Q.coeff N k₀ := by
+      have hself_ne : ∀ᶠ N in atTop,
+          mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N ≠ 0 :=
+        hQ_self_limit.eventually_ne hℓ_ne
+      filter_upwards [hself_ne] with N hN
+      field_simp
+    have := hQuot.congr' hRewQuot
+    simpa using this
+  -- Step 6: `(lam0 ^ N)⁻¹ * Q.coeff N k₀ = ∑ q, (Q.weight k₀ q / lam0)^N`,
+  -- a unit-modulus power sum.  Contradicts non-decay.
+  have hQuotient_form : ∀ N : ℕ,
+      (lam0 ^ N)⁻¹ * Q.coeff N k₀
+        = ∑ q : Fin (Q.copies k₀), (Q.weight k₀ q / lam0) ^ N := by
+    intro N
+    -- Q.coeff N k₀ = ∑ q, (Q.weight k₀ q)^N.
+    have hCoeff_eq : Q.coeff N k₀
+        = ∑ q : Fin (Q.copies k₀), (Q.weight k₀ q) ^ N := rfl
+    rw [hCoeff_eq, Finset.mul_sum]
+    refine Finset.sum_congr rfl ?_
+    intro q _
+    rw [div_pow]
+    field_simp [hlam0_pow_ne N]
+  -- The power sum tends to zero.
+  have hPowSum_tendsto : Tendsto
+      (fun N => ∑ q : Fin (Q.copies k₀), (Q.weight k₀ q / lam0) ^ N)
+      atTop (nhds 0) := by
+    refine hCoeff_tendsto.congr ?_
+    intro N
+    exact hQuotient_form N
+  -- Contradict `unitModulus_power_sum_not_tendsto_zero` on the
+  -- within-sector quotient `q ↦ Q.weight k₀ q / lam0`.
+  refine UnitModulusPowerSum.unitModulus_power_sum_not_tendsto_zero
+    (r := Q.copies k₀) (Q.copies_pos k₀)
+    (fun q : Fin (Q.copies k₀) => Q.weight k₀ q / lam0) ?_ hPowSum_tendsto
+  intro q
+  -- ‖Q.weight k₀ q / lam0‖ = 1 by `IsBNTCanonicalFormSD.weight_factor`.
+  change ‖Q.sectors.weight k₀ q / hQ.spectralLevel k₀‖ = 1
+  exact hQ.weight_factor k₀ q
+
+end RenormalisedNonCancellation
+
+end MPSTensor

--- a/audits/2026-05-13_cpsv16_ft_renormalized_discharge_design.md
+++ b/audits/2026-05-13_cpsv16_ft_renormalized_discharge_design.md
@@ -1,0 +1,295 @@
+# Renormalised discharge of the non-dominant per-block projection on the
+# two-layer `IsBNTCanonicalFormSD` surface
+
+**Date:** 2026-05-13
+**Branch:** `feat/mps-ft-path-beta-renorm-discharge-scout`
+**Status:** Scout + first implementation increment.  Confirms the abstract
+`hNoCancel` of the two-layer skeleton is unusable for non-dominant `k₀`
+and supplies the analytic centerpiece of a renormalised replacement.
+**Context:** Continuation of `audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md`,
+issue #1641 (Plan~C), PR #1669 (structural `HasRateQuantifiedCrossOverlapDecay`).
+
+## Executive summary
+
+The audit memo `audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md`
+identified rate-quantified Q-internal cross-overlap decay as the
+missing analytic input for the non-dominant per-block projection.
+Re-examining the discharge:
+
+1. The abstract `hNoCancel` hypothesis carried by
+   `fixed_*_sectorDecomp_twoLayer` (`PerBlockProjection.lean:363`) and
+   `fixed_*_paperFaithful_twoLayer` (`HNoCancelDischarge.lean:446`) is
+   **unsatisfiable** for non-dominant `k₀` on the two-layer surface:
+   both `c N` and `mpvOverlap Q.toTensor (Q.basis k₀) N` decay
+   individually, so the product `c N · mpvOverlap Q.toTensor (Q.basis k₀) N`
+   tends to zero unconditionally.  Any attempt to "discharge" `hNoCancel`
+   would have to prove the impossible.
+
+2. The route forward is a **renormalised** discharge:
+   project the proportionality identity, then multiply both sides by
+   `(λ_{k₀})^{-N}`.  The renormalised Q-side
+   `T N := (λ_{k₀})^N⁻¹ * mpvOverlap Q.toTensor (Q.basis k₀) N`
+   is the analytic centerpiece — it does **not** tend to zero, and
+   discharging this fact replaces the load-bearing role formerly played
+   by `hNoCancel`.
+
+3. Two rate hypotheses are required: Q-internal (already merged as
+   `HasRateQuantifiedCrossOverlapDecay`, PR #1669) **and** a new
+   cross-family rate predicate comparing `‖λ_{P,j} / λ_{Q,k₀}‖` against
+   the decay rate of `mpvOverlap (P.basis j) (Q.basis k₀)`.
+
+## Validation of the obstruction
+
+### Question 1 — Is `hNoCancel` vacuously false for non-dominant `k₀`?
+
+**Verdict: yes.**  We trace through each factor.
+
+**Subquestion 1a (`c N` bounded above):**
+On the two-layer `IsBNTCanonicalFormSD` surface produced via the Choice~B
+adapter (`IsCanonicalFormBNT.toIsBNTCanonicalFormSD`), the dominant
+spectral levels satisfy `‖λ_{P,0}‖ = ‖λ_{Q,0}‖ = 1`
+(`spectralLevel_dom_norm_one`).  The dominant-adjusted scalar
+`c N · (μ_{B,0} / μ_{A,0})^N` has modulus tending to `1`
+(`exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT`);
+under Choice~B rescaling this reads `‖c N‖ → 1`, so `c N` is in
+particular bounded above.
+
+**Subquestion 1b (`mpvOverlap Q.toTensor (Q.basis k₀) N → 0`):**
+Expanding via `mpv_toTensor_eq_sum_coeff` and the linearity of
+`mpvOverlap`,
+
+```
+mpvOverlap Q.toTensor (Q.basis k₀) N
+  = ∑ k, Q.coeff N k · mpvOverlap (Q.basis k) (Q.basis k₀) N.
+```
+
+By `norm_coeff_le_spectral_pow_mul_copies`,
+`‖Q.coeff N k‖ ≤ ‖λ_{Q,k}‖^N · copies k`.  Three subcases:
+
+* **`k = k₀` (non-dominant by hypothesis):** `‖λ_{Q,k₀}‖ < 1` (strict-anti
+  + `‖λ_{Q,0}‖ = 1`), so `‖λ_{Q,k₀}‖^N → 0`; the self-overlap is bounded,
+  so the diagonal term tends to zero.
+* **`k > k₀`:** `‖λ_{Q,k}‖ < ‖λ_{Q,k₀}‖ < 1`, hence `‖λ_{Q,k}‖^N → 0`; the
+  qualitative cross-overlap decay from
+  `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`
+  (or, in the structured setting, from `bnt_data`) is at least bounded.
+* **`k < k₀`:** `‖λ_{Q,k}‖ ≤ 1` (dominant normalization), so
+  `‖λ_{Q,k}‖^N ≤ 1` is bounded; cross-overlap decays to zero by the
+  qualitative hypothesis.  Bounded times decay yields decay.
+
+All three subcases tend to zero, hence the sum tends to zero.
+
+**Subquestion 1c (the product `c N · overlap → 0`):**
+Bounded × decay → 0.  The abstract `hNoCancel` claims this **does not**
+tend to zero, which is in contradiction with the conclusion just
+established.  Hence the hypothesis cannot be discharged on the two-layer
+surface for non-dominant `k₀`; it is provably false.
+
+**Subquestion 1d (impact on the skeleton):**
+The skeleton `fixed_*_sectorDecomp_twoLayer` exposes `hNoCancel` as a
+side condition and combines it with an LHS-decay argument to derive
+`False`.  If `hNoCancel` is vacuously false, the skeleton cannot be
+instantiated.  Equivalently: a downstream caller that wants to feed a
+genuine analytic argument into the skeleton must provide a witness of
+`hNoCancel`, but no such witness exists.  The skeleton must be
+re-derived with a different load-bearing fact.
+
+### Question 2 — Is the renormalised skeleton correct?
+
+**Verdict: yes, under the rate hypothesis.**
+
+Define
+```
+T N := (h.spectralLevel k₀ ^ N)⁻¹ * mpvOverlap Q.toTensor (Q.basis k₀) N.
+```
+
+Using the factorisation `Q.weight k q = h.spectralLevel k · ν_{k,q}` with
+`‖ν_{k,q}‖ = 1` (from `weight_factor`), the coefficient factors as
+`Q.coeff N k = (h.spectralLevel k)^N · ∑_q ν_{k,q}^N`.
+
+After renormalisation,
+```
+T N = ∑ k, (h.spectralLevel k / h.spectralLevel k₀)^N ·
+              (∑ q, ν_{k,q}^N) · mpvOverlap (Q.basis k) (Q.basis k₀) N.
+```
+
+**Diagonal `k = k₀`:** the geometric factor is `1`, so the term equals
+`(∑ q, ν_{k₀,q}^N) · mpvOverlap (Q.basis k₀) (Q.basis k₀) N`.
+By `unitModulus_power_sum_not_tendsto_zero` (`Algebra/UnitModulusPowerSum.lean`),
+the unit-modulus power sum `∑ q, ν_{k₀,q}^N` does **not** tend to zero.
+The self-overlap is assumed to tend to a nonzero limit `ℓ ≠ 0`.  Hence
+the diagonal does not tend to zero either.
+
+**Off-diagonal `k ≠ k₀`:** the norm of the summand is bounded by
+```
+copies k · ‖(λ_{Q,k} / λ_{Q,k₀})^N · mpvOverlap (Q.basis k) (Q.basis k₀) N‖
+  ≤ copies k · ‖λ_{Q,k} / λ_{Q,k₀}‖^N
+                · h.rateC k k₀ · h.rateEta k k₀ ^ N
+  = copies k · h.rateC k k₀
+                · (‖λ_{Q,k} / λ_{Q,k₀}‖ · h.rateEta k k₀)^N.
+```
+The base `‖λ_{Q,k} / λ_{Q,k₀}‖ · h.rateEta k k₀ < 1` by `rate_compatible`,
+so the off-diagonal summand tends to zero geometrically.  Summing over
+the finite index set, the off-diagonal contribution tends to zero.
+
+**Conclusion:**  If `T N → 0`, then off-diagonal contribution → 0
+forces the diagonal `(∑ q, ν_{k₀,q}^N) · mpvOverlap (Q.basis k₀) (Q.basis k₀) N`
+to tend to zero, which divided by the eventually-nonzero self-overlap
+forces `∑ q, ν_{k₀,q}^N → 0`, contradicting
+`unitModulus_power_sum_not_tendsto_zero`.
+
+### Question 3 — Is the renormalised LHS handleable?
+
+**Verdict: yes, provided a cross-family rate hypothesis is added.**
+
+The renormalised LHS reads
+```
+U N := (h.spectralLevel k₀ ^ N)⁻¹ * mpvOverlap P.toTensor (Q.basis k₀) N
+     = ∑ j, (λ_{P,j} / λ_{Q,k₀})^N
+              · (∑ q, ν_{P,j,q}^N) · mpvOverlap (P.basis j) (Q.basis k₀) N.
+```
+
+The `(∑ q, ν_{P,j,q}^N)` factor is bounded by `copies_P j`, and the
+qualitative `mpvOverlap (P.basis j) (Q.basis k₀) N → 0` is available
+from the wider `hAllDecay` assumption.  But the geometric factor
+`(λ_{P,j} / λ_{Q,k₀})^N` may grow when `‖λ_{P,j}‖ > ‖λ_{Q,k₀}‖`.  A
+**cross-family rate predicate** is required:
+
+```
+∀ j, ∃ C ≥ 0, η ∈ [0, 1),
+   η · ‖λ_{P,j} / λ_{Q,k₀}‖ < 1 ∧
+   ∀ N, ‖mpvOverlap (P.basis j) (Q.basis k₀) N‖ ≤ C · η^N.
+```
+
+This is the cross-family analogue of `HasRateQuantifiedCrossOverlapDecay`
+applied to a single `Q`-target.  Under this hypothesis,
+`U N → 0` follows by the same geometric × bounded × decay argument as
+for the Q-side off-diagonal.
+
+### Question 4 — Statement of the cross-family rate predicate
+
+Two natural shapes:
+
+**Shape A (pointwise per (P, Q) pair):**
+```
+structure HasCrossFamilyRateDecay
+    (P Q : SectorDecomposition d)
+    (lamP : Fin P.basisCount → ℂ) (lamQ : Fin Q.basisCount → ℂ) : Prop where
+  exists_rate :
+    ∃ (C η : Fin P.basisCount → Fin Q.basisCount → ℝ),
+      (∀ j k, 0 ≤ C j k ∧ 0 ≤ η j k ∧ η j k < 1 ∧
+              η j k * ‖lamP j / lamQ k‖ < 1) ∧
+      (∀ j k N,
+        ‖mpvOverlap (d := d) (P.basis j) (Q.basis k) N‖
+          ≤ C j k * (η j k) ^ N)
+```
+
+**Shape B (per-target, fixing `k₀ : Fin Q.basisCount`):**  Wraps Shape~A
+to a fixed `Q`-index.  Mirrors the way the per-block-projection skeleton
+is structured around a fixed `k₀`.
+
+**Recommendation:** Shape A — uniform over all `(j, k)` pairs, mirroring
+`HasRateQuantifiedCrossOverlapDecay`'s structure.  The pointwise
+per-target view is recoverable by specialising `k`.  Deferred to a
+subsequent increment.
+
+### Question 5 — Statement of the discharge theorem
+
+```
+theorem fixed_right_all_overlaps_decay_false_..._twoLayer_rateQuantified
+    (P Q : SectorDecomposition d)
+    (hP : IsBNTCanonicalFormSD P)
+    (hQ : IsBNTCanonicalFormSD Q)
+    (hPRate : HasRateQuantifiedCrossOverlapDecay P hP.spectralLevel)
+    (hQRate : HasRateQuantifiedCrossOverlapDecay Q hQ.spectralLevel)
+    (hCross : HasCrossFamilyRateDecay P Q hP.spectralLevel hQ.spectralLevel)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (k₀ : Fin Q.basisCount)
+    (hAllDecay : ∀ j : Fin P.basisCount,
+        Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (Q.basis k₀) N)
+          atTop (nhds 0))
+    {ℓ : ℂ} (hℓ_ne : ℓ ≠ 0)
+    (hQ_self_limit :
+        Tendsto (fun N => mpvOverlap (d := d) (Q.basis k₀) (Q.basis k₀) N)
+          atTop (nhds ℓ))
+    (hc_lower : ∀ c : ℕ → ℂ,
+        (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+          mpv P.toTensor σ = c N * mpv Q.toTensor σ) →
+        ∃ δ > 0, ∀ᶠ N in atTop, δ ≤ ‖c N‖) :
+    False
+```
+
+The proof composes the cross-family bound on the LHS expansion (→ 0)
+with the renormalised Q-side non-decay (≠ 0 in the limit) using the
+`c`-lower-bound; cancellation is impossible.
+
+## Status of Phase 2 implementation
+
+**Option A** has been implemented:
+`mpvOverlap_toTensor_basis_renorm_not_tendsto_zero` — the renormalised
+Q-side analytic centerpiece.  Lives in
+`TNLean/MPS/FundamentalTheorem/SectorDecomposition/RenormalizedNonCancellation.lean`.
+Closed without `sorry`/`axiom`.  Builds.
+
+Deferred to subsequent increments (each with explicit factored
+sub-lemma names):
+
+* `HasCrossFamilyRateDecay` predicate (Shape~A above) — to be added in
+  the next increment as a sibling of `HasRateQuantifiedCrossOverlapDecay`.
+* `mpvOverlap_toTensor_basis_renorm_LHS_tendsto_zero` — the LHS
+  expansion bound consuming `HasCrossFamilyRateDecay`.
+* `hNoCancel_renorm_single_seq` — the single-sequence non-cancellation
+  consumer of `mpvOverlap_toTensor_basis_renorm_not_tendsto_zero`,
+  analogous to `hNoCancel_single_seq` in `HNoCancelDischarge.lean`.
+* `fixed_right_all_overlaps_decay_false_..._twoLayer_rateQuantified` —
+  the full discharge theorem above.
+
+## Open caveats
+
+* The `c`-lower-bound hypothesis on the rescaled SD surface flows from
+  `exists_dominant_adjusted_scalar_tendsto_norm_one_of_eventuallyNonzeroProportionalMPV₂_CFBNT`
+  combined with the Choice~B rescaling; the path β scout PR~1.5
+  records that this geometric problem dissolves under dominant
+  normalization `‖λ_0‖ = 1`.  Independent of the rate-quantification
+  issue addressed here.
+
+* The renormalised self-overlap limit `mpvOverlap (Q.basis k₀) (Q.basis k₀) N → ℓ ≠ 0`
+  is treated as an input.  Its source is the
+  `HasNormalizedSelfOverlap` field of the canonical form, applied to
+  the basis-block tensor `Q.basis k₀`.
+
+## References
+
+* CPSV16 (arXiv:1606.00608), Theorem~1, lines 1170--1192.
+* CPSV21 (arXiv:2011.12127), Definition~4.3 (BNT eventual LI).
+* `audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md` — original
+  obstruction analysis, before the renormalisation re-examination.
+* `audits/2026-05-13_cpsv16_ft_path_beta_scout.md` — path β architecture.
+* `docs/paper-gaps/cpsv16_bnt_rate_quantification.tex` — paper-gap note
+  recording the rate-quantification structural hypothesis.
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDecay.lean` —
+  Q-internal rate predicate (PR #1669).
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean` —
+  one-layer paper-faithful discharge (unchanged by this increment).
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean` —
+  two-layer skeleton (`hNoCancel` flagged vacuous for non-dominant `k₀`).
+* `TNLean/Algebra/UnitModulusPowerSum.lean` —
+  `unitModulus_power_sum_not_tendsto_zero`, the non-decay source.
+* `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean:107, 152` —
+  the two open sorries this work targets.
+
+## Issue tracking
+
+* #1641 (Plan~C tracker) — to be updated with these findings.
+* #1607 (original CFBNT sorry tracker) — remains open until the full
+  discharge lands.
+
+## Forbidden directions (carry forward)
+
+* NO combined-family LI / RSE / Option-LI hypotheses (vacuous in FT
+  regime per execution `e0a5ec0f6a31`).
+* NO induction-via-exact-coefficient (path α infeasible per
+  `cpsv16_ft_exact_leading_coeff.md`).
+* NO peel-arbitrary-`k₀` induction architecture.
+* NO new `sorry` / `axiom` / `unsafe` without explicit factored
+  documented sub-lemma name (see Phase~2 deferred list).


### PR DESCRIPTION
Refs: #1641

## Context

Following the rate-quantified structural predicate landed in #1669, this PR provides the **analytic centerpiece** for the two-layer per-block-projection discharge at non-dominant `k_0`.

## Re-examination of PR 2.5 design memo (#1666)

The PR 2.5 memo (#1666) identified rate-quantified Q-internal cross-overlap decay as the missing analytic input. This scout re-examined the discharge and confirmed a stronger finding:

**The abstract `hNoCancel` hypothesis in PR 2's skeleton (`fixed_*_sectorDecomp_twoLayer`, #1664) is structurally unsatisfiable for non-dominant `k_0`** under the Choice B rescaling adapter `‖λ_0‖ = 1`. Both factors `c_N` (bounded above) and `mpvOverlap Q.toTensor (Q.basis k_0) N` (decays as `|λ_{k_0}|^N → 0`) decay individually, so their product tends to zero unconditionally.

The discharge must therefore work in a **renormalised** setting: multiply both sides of the projected proportionality by `(λ_{Q,k_0}^N)⁻¹` before extracting non-cancellation.

## What's in this PR

### New module
`TNLean/MPS/FundamentalTheorem/SectorDecomposition/RenormalizedNonCancellation.lean` (337 LoC):

```lean
lemma mpvOverlap_toTensor_basis_renorm_not_tendsto_zero
    (Q : SectorDecomposition d)
    (hQ : IsBNTCanonicalFormSD Q)
    (hQRate : HasRateQuantifiedCrossOverlapDecay Q hQ.spectralLevel)
    (k_0 : Fin Q.basisCount)
    (hQ_self_limit : ∃ ℓ : ℂ, ℓ ≠ 0 ∧ Tendsto ... atTop (nhds ℓ)) :
    ¬ Tendsto (fun N => (hQ.spectralLevel k_0 ^ N)⁻¹ * mpvOverlap Q.toTensor (Q.basis k_0) N)
        atTop (nhds 0)
```

Proves: the renormalised Q-side does **not** tend to zero.

**Proof structure**:
1. Expand assembled overlap as Q-basis sum.
2. Multiply by `(λ_{Q,k_0}^N)⁻¹`. Each term becomes `(λ_k / λ_{k_0})^N · (∑_q ν_{k,q}^N) · overlap`.
3. Off-diagonal: bounded × `(η · |λ_k/λ_{k_0}|)^N → 0` via `rate_compatible`.
4. Diagonal: `(∑_q ν_{k_0,q}^N) · self-overlap` — both factors with nonzero liminf.
5. Sum tending to zero forces diagonal → 0, contradicts `unitModulus_power_sum_not_tendsto_zero`.

### New audit memo
`audits/2026-05-13_cpsv16_ft_renormalized_discharge_design.md` (295 LoC):
- Phase 1 validation of the renormalisation requirement.
- Signatures for follow-on lemmas (cross-family rate, full discharge).
- Sub-lemma decomposition.

## What this PR does NOT do

- **No** cross-family rate predicate (`HasCrossFamilyRateDecay`) — deferred.
- **No** discharge of the original `_CFBNT` sorries at `FixedBlockDecay.lean:107, 152` — still pending.
- **No** `_paperFaithful_twoLayer_rateQuantified` top-level theorem yet.

## Build verification

- `lake build TNLean.MPS.FundamentalTheorem.SectorDecomposition.RenormalizedNonCancellation` ✅
- Downstream untouched: `RateQuantifiedDecay`, `PerBlockProjection`, `HNoCancelDischarge`, `FixedBlockDecay` all rebuild clean.
- No new `sorry`/`axiom`/`unsafe`.

## Deferred items (factored sub-lemmas)

Per the audit memo §"Status of Phase 2":
- `HasCrossFamilyRateDecay P Q lamP lamQ` — new predicate (cross-family rate analogue of `HasRateQuantifiedCrossOverlapDecay`).
- `mpvOverlap_toTensor_basis_renorm_LHS_tendsto_zero` — LHS bound consuming the cross-family rate.
- `hNoCancel_renorm_single_seq` — single-sequence non-cancellation consumer.
- `fixed_right_all_overlaps_decay_false_..._twoLayer_rateQuantified` — full discharge composing the above.

## Next steps after merge

1. Define `HasCrossFamilyRateDecay` predicate + paper-gap.
2. Compose the renormalised LHS bound + this lemma into the full discharge.
3. Wire the discharge through the `Choice B` adapter to discharge the `_CFBNT` sorries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new Lean proof module and an audit memo; changes are additive but the new lemma is mathematically involved and may affect downstream proof dependencies once integrated.
> 
> **Overview**
> Adds a new proof module `RenormalizedNonCancellation.lean` that proves `mpvOverlap_toTensor_basis_renorm_not_tendsto_zero`: the **renormalised** overlap `(λ_{Q,k₀}^N)⁻¹ * mpvOverlap Q.toTensor (Q.basis k₀) N` does *not* tend to zero on the two-layer `IsBNTCanonicalFormSD` surface, using `HasRateQuantifiedCrossOverlapDecay` to kill off-diagonal terms and `unitModulus_power_sum_not_tendsto_zero` to keep the diagonal term non-decaying.
> 
> Adds an accompanying audit memo `audits/2026-05-13_cpsv16_ft_renormalized_discharge_design.md` documenting why the existing two-layer skeleton’s `hNoCancel` is unsatisfiable for non-dominant `k₀` and outlining follow-on work (cross-family rate predicate and full discharge) not implemented in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d08c90cd557bbbebcb40d1f4b0e56aa6d61966dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->