### PR TITLE
doc(MPS/FT): clean-slate plan for paper-faithful multi-copy elimination (#1678)

### DIFF
--- a/audits/2026-05-13_cpsv16_ft_paper_faithful_clean_slate_plan.md
+++ b/audits/2026-05-13_cpsv16_ft_paper_faithful_clean_slate_plan.md
@@ -1,0 +1,249 @@
+# CPSV16 FT — Paper-Faithful Multi-Copy Clean-Slate Plan
+
+**Date:** 2026-05-13 (post issue #1678 final confirmation).
+**Source of authority:** `blueprint/comments202605/cpsv16_bnt_gap_recommendation_examples.tex` (user-uploaded recommendation document).
+**User directive (verbatim):**
+* "we should thoroughly implment this and retire the other paths"
+* "dont do this one copy interfaces anywhere anymore"
+* "i want to be doing this cleanly from scrtach and retire all the wrong approaches anywhere comprehensivley"
+* "dont build any adapters because they may have mathmeatical obstructions"
+
+## Executive summary
+
+This memo plans the **complete retirement** of the one-copy `IsCanonicalFormBNT` surface and the **clean-slate construction** of a paper-faithful multi-copy BNT canonical form, on which the entire FT chain (and its downstream consumers in RFP, ParentHamiltonian, PiAlgebra) will be re-proved from first principles.
+
+**Hard constraints (from the user's directives):**
+
+1. **No adapter from `IsCanonicalFormBNT` to the new structure.** The mathematical obstructions in such adapters (e.g., the Choice B rescaling residue, the multiplicity-recovery Newton-Girard gap) are not paper-level facts; any adapter would carry assumptions we cannot discharge.
+2. **No use of the one-copy surface in new work**, anywhere in the codebase.
+3. **The new structure must stand on its own** — defined directly from `SectorDecomposition` data without reference to `IsCanonicalFormBNT`.
+4. **All theorems formerly proved on `IsCanonicalFormBNT` must be re-proved** on the new surface, not adapted.
+5. **The `IsCanonicalFormBNT` surface, its associated machinery (cross_overlap_tendsto_zero, IsNormalCanonicalFormBNT, etc.), and all derived modules in `MPS/FundamentalTheorem/Full/`, `MPS/RFP/`, `MPS/ParentHamiltonian/BiCF/`, `MPS/ParentHamiltonian/DegenerateGS.lean`, and `MPS/PiAlgebra/CanonicalFormSep*.lean` must eventually be DELETED.**
+
+## What's wrong with `IsCanonicalFormBNT`
+
+`IsCanonicalFormBNT μ A` carries:
+- `μ : Fin r → ℂ` — one weight per "block."
+- `A : (k : Fin r) → MPSTensor d (dim k)` — one normal tensor per block.
+- `mu_strict_anti : StrictAnti (fun k => ‖μ k‖)` — strict modulus ordering.
+- BNT eventual LI on the basis blocks.
+- Normalized self-overlap, irreducibility, left-canonical, block injectivity.
+
+The CPSV16/CPSV21 paper's structure carries:
+- Sectors `j ∈ Fin g` with multiplicities `r_j ≥ 1`.
+- Within each sector `j`: `r_j` copies of the same normal tensor `A_j`, each carrying a weight `μ_{j,q}` (where `q ∈ Fin r_j`).
+- Equal modulus within sector: `‖μ_{j,1}‖ = ⋯ = ‖μ_{j,r_j}‖ = λ_j` (the spectral level).
+- Strict ordering between sectors: `λ_1 > λ_2 > ⋯ > λ_g`.
+
+The one-copy surface is the specialization `r_j = 1` for all `j`. The user's recommendation document gives explicit counterexamples (the `C ⊕ (-C)` and `C ⊕ e^{iθ}C` examples in §2-3) showing that this specialization **collapses** genuine paper-level data: `V_N(C ⊕ -C) = (1 + (-1)^N) V_N(C)` cannot be written as `μ^N V_N(C)` for any single scalar `μ`.
+
+## The paper-faithful structure
+
+The new primary predicate `IsBNTCanonicalForm` (or chosen name) carries, given a `SectorDecomposition P : SectorDecomposition d`:
+
+* **Spectral level** `λ : Fin P.basisCount → ℂ` with
+  * `λ j ≠ 0` for every sector `j`,
+  * `StrictAnti (fun j => ‖λ j‖)`,
+  * `‖λ ⟨0, _⟩‖ = 1` (dominant normalization);
+* **Within-sector unit-modulus weights** `ω : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ` with
+  * `P.sectors.weight j q = λ j * ω j q`,
+  * `‖ω j q‖ = 1`;
+* **Sector basis blocks** `P.basis : (j : Fin P.basisCount) → MPSTensor d (P.basisDim j)` (carried by `SectorDecomposition`);
+* **Eventual linear independence** of basis blocks: `HasBNTSectorData P` (already in place);
+* **Per-block normality data**: each `P.basis j` is a normal MPS tensor (injective TM, irreducible, left-canonical, normalized self-overlap).
+
+The MPV assembly:
+```
+mpv P.toTensor σ
+  = ∑_{j : Fin P.basisCount} P.coeff N j · mpv (P.basis j) σ
+  = ∑_{j : Fin P.basisCount} (λ j)^N · (∑_{q : Fin (P.copies j)} (ω j q)^N) · mpv (P.basis j) σ.
+```
+
+The factor `(λ j)^N · (∑_q (ω j q)^N)` is the **sector coefficient** described in §1 of the user's recommendation document. Setting `r_j = 1` (one copy per sector) and `ω j 0 = 1` gives one-copy as a degenerate case, but we do not bridge.
+
+**Note:** `IsBNTCanonicalFormSD` (from path β, currently on main at `TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean`) is **almost** this structure but with the `ω j q` factor packaged inside an existential. It also lacks the per-block normality data (irreducibility, etc.). For clean-slate construction, **rename/replace** `IsBNTCanonicalFormSD` with a properly-organized `IsBNTCanonicalForm` that exposes all fields and per-block normality.
+
+## Retirement scope (everything to delete eventually)
+
+### Modules using `IsCanonicalFormBNT` (242 references in 21 files)
+
+#### Tier 1 — FT core (must be re-proved on new surface, then deleted)
+* `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean` (27 refs) — including the equal-MPV `_sameMPV₂` non-decaying overlap proof.
+* `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean` (7 refs).
+* `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/CombinedLI.lean` (6 refs) — the weak existential we just built.
+* `TNLean/MPS/FundamentalTheorem/Full/BlocksMatch.lean` (5 refs).
+* `TNLean/MPS/FundamentalTheorem/Full/DominantWeight.lean` (3 refs).
+* `TNLean/MPS/FundamentalTheorem/Full/NondecayingPartnerUnique.lean` (15 refs).
+* `TNLean/MPS/FundamentalTheorem/Full/ProportionalDominant.lean` (18 refs).
+* `TNLean/MPS/FundamentalTheorem/Full.lean` (6 refs).
+* `TNLean/MPS/FundamentalTheorem/EqualProportional.lean` (8 refs).
+
+#### Tier 2 — path β rate-quantified retired stack (delete entirely)
+* `TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay_RateQuantified.lean` (52 refs).
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDischarge.lean`.
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDecay.lean` (1 ref).
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/CrossFamilyRateDecay.lean`.
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/RenormalizedNonCancellation.lean`.
+
+#### Tier 3 — `SectorDecomposition` machinery (mostly clean, but adapters retired)
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD.lean` (11 refs) — KEEP the structure definition; **delete** the `IsCanonicalFormBNT.toIsBNTCanonicalFormSD` adapter at line 227.
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean` (1 ref).
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean` (2 refs).
+* `TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean` (1 ref).
+
+#### Tier 4 — non-FT consumers (re-prove on new surface, then retire the one-copy import)
+* `TNLean/MPS/BNT/Construction.lean` (28 refs) — defines `IsCanonicalFormBNT` itself, plus `cross_overlap_tendsto_zero`, `isBNT`, etc.
+* `TNLean/MPS/RFP/StructuralForm.lean` (1 ref).
+* `TNLean/MPS/ParentHamiltonian/BiCF/BlockDiagonalCommutant.lean` (30 refs).
+* `TNLean/MPS/ParentHamiltonian/DegenerateGS.lean` (18 refs).
+* `TNLean/PiAlgebra/CanonicalFormSep.lean` (1 ref).
+* `TNLean/PiAlgebra/CanonicalFormSepAux.lean` (1 ref).
+
+### Bridging machinery to delete
+
+* `bntSectorDecomp` definitional adapter in `FixedBlockDecay_RateQuantified.lean` (carries one-copy → SD bridging).
+* `IsCanonicalFormBNT.toIsBNTCanonicalFormSD` existential adapter in `IsBNTCanonicalFormSD.lean:227`.
+* Any `_CFBNT` suffix lemmas that route through `IsCanonicalFormBNT` data.
+
+### One-copy lemmas to retire (selection)
+
+* `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP` — actually a general-purpose tensor lemma; keep but ensure no spurious one-copy dependence in callers.
+* `cross_overlap_tendsto_zero_of_separated_normalCFBNT_data` — re-state on new surface.
+* `IsNormalCanonicalFormBNT.mu_dom_norm_one` — re-state with `λ` on new surface.
+
+## Phased implementation plan
+
+### Phase 0 — preserve the plan
+**This memo.** Land it as documentation. No code changes.
+
+### Phase 1 — design the new primary predicate
+
+Create `TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean` (or chosen location, NOT under `SectorDecomposition/`) with:
+
+```lean
+structure IsBNTCanonicalForm (P : SectorDecomposition d) : Prop where
+  /-- Spectral level: one nonzero complex number per sector. -/
+  spectralLevel : Fin P.basisCount → ℂ
+  spectralLevel_ne_zero : ∀ j, spectralLevel j ≠ 0
+  spectralLevel_strict_anti : StrictAnti (fun j => ‖spectralLevel j‖)
+  spectralLevel_dom_norm_one : ∀ h : 0 < P.basisCount, ‖spectralLevel ⟨0, h⟩‖ = 1
+  /-- Within-sector unit-modulus phase weights. -/
+  phaseWeight : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ
+  phaseWeight_norm_one : ∀ j q, ‖phaseWeight j q‖ = 1
+  /-- Factorization of the sector weights. -/
+  weight_factor : ∀ j q, P.sectors.weight j q = spectralLevel j * phaseWeight j q
+  /-- Per-block normality data. -/
+  basis_injective : ∀ j, IsInjective (P.basis j)
+  basis_irreducible : ∀ j, IsIrreducible (P.basis j)
+  basis_left_canonical : ∀ j, IsLeftCanonical (P.basis j)
+  basis_normalized_self_overlap : ∀ j,
+    Tendsto (fun N => mpvOverlap (P.basis j) (P.basis j) N) atTop (nhds 1)
+  /-- BNT eventual linear independence of basis blocks. -/
+  bnt_data : HasBNTSectorData P
+  /-- Distinctness of basis blocks (no gauge-phase equivalence between distinct sectors). -/
+  basis_distinct : ∀ j k, j ≠ k → ¬ GaugePhaseEquiv (P.basis j) (P.basis k)
+```
+
+(Field names tentative; final names chosen to match Mathlib conventions and to avoid `_BNT` / `_SD` suffix patterns that signaled the migration state.)
+
+**Examples** (must compile cleanly to validate the structure):
+* `C ⊕ -C` example (one sector, two copies, `phaseWeight = (1, -1)`).
+* `C ⊕ e^{iθ}C` (one sector, two copies, `phaseWeight = (1, e^{iθ})`).
+* `C` alone (one sector, one copy, vacuous phase factor).
+
+**Accessors** for the cross-overlap decay and self-overlap limits that current proofs need.
+
+### Phase 2 — basic API
+
+Prove (DIRECTLY on the new surface, no adapter):
+* `weight_pow_decomp : P.sectors.weight j q ^ N = (spectralLevel j)^N · (phaseWeight j q)^N`.
+* `coeff_eq : P.coeff N j = (spectralLevel j)^N · ∑_q (phaseWeight j q)^N`.
+* `norm_coeff_le : ‖P.coeff N j‖ ≤ ‖spectralLevel j‖^N · P.copies j`.
+* `cross_overlap_basis_tendsto_zero : ∀ j k, j ≠ k → Tendsto (fun N => mpvOverlap (P.basis j) (P.basis k) N) atTop (nhds 0)` — derived from `basis_distinct` + irreducibility (re-prove the existing `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_*` chain on this surface).
+* `eventually_linearIndependent_combined : (full pairwise A↔B decay) → combined LI` (re-use `eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal` from `BNT/Basic.lean:195`, which doesn't depend on `IsCanonicalFormBNT`).
+
+### Phase 3 — re-prove the combined-family weak existential
+
+`exists_nondecaying_overlap_pair_of_eventuallyProportional` directly on the new surface, mirroring the proof we wrote in `CombinedLI.lean` (commit `dd83c0b1`) but with one-copy references stripped.
+
+### Phase 4 — re-prove the equal-MPV non-decaying overlap
+
+Mirror the ~540-line `exists_nondecaying_overlap_of_sameMPV₂_CFBNT` proof for the new surface. Use the multi-copy sector coefficient `(λ_j)^N · ∑_q (ω_{j,q})^N` throughout. The dominant matching argument uses spectral level + dominant normalization.
+
+### Phase 5 — block matching, equal-MPV FT, proportional FT
+
+Re-prove `BlocksMatch`, `EqualProportional`, etc. on the new surface.
+
+### Phase 6 — non-FT consumers
+
+Port `RFP/StructuralForm`, `ParentHamiltonian/BiCF/BlockDiagonalCommutant`, `ParentHamiltonian/DegenerateGS`, `PiAlgebra/CanonicalFormSep*` to the new surface.
+
+### Phase 7 — DELETE the one-copy surface
+
+Once nothing imports `IsCanonicalFormBNT` from new work:
+* Delete `IsCanonicalFormBNT` itself in `BNT/Construction.lean`.
+* Delete all derived lemmas (`cross_overlap_tendsto_zero` from CFBNT, `isBNT` from CFBNT, etc.).
+* Delete `IsBNTCanonicalFormSD` (replaced by `IsBNTCanonicalForm`).
+* Delete the path β stack entirely (`RateQuantifiedDischarge.lean`, `FixedBlockDecay_RateQuantified.lean`, `RenormalizedNonCancellation.lean`, `RateQuantifiedDecay.lean`, `CrossFamilyRateDecay.lean`).
+* Delete `Full/NondecayingOverlap/CombinedLI.lean` (was on one-copy surface; replaced by Phase 3).
+* Delete `Full/NondecayingOverlap/FixedBlockDecay.lean` (one-copy).
+* Delete the `_sameMPV₂_CFBNT` chain (replaced by Phase 4).
+
+## Order of execution
+
+Phase 0 is this memo (PR delivering it).
+
+Phases 1-2 are the foundational PR (new structure + basic API). Estimated 800-1200 LoC.
+
+Phase 3 is a focused PR (weak existential on new surface). Estimated 200-300 LoC.
+
+Phase 4 is the largest PR (equal-MPV non-decaying overlap, mirroring 540-line proof on new surface). Estimated 600-900 LoC.
+
+Phase 5 ports the equal-MPV FT downstream chain (BlocksMatch, EqualProportional, NondecayingPartnerUnique, etc.). Estimated 1000-1500 LoC across multiple PRs.
+
+Phase 6 ports non-FT consumers. Estimated 500-1000 LoC across multiple PRs.
+
+Phase 7 is the cleanup — file deletions. Net negative LoC.
+
+**Estimated total scope:** 6-12 PRs, 3000-6000 LoC of new code, with corresponding deletions giving a net reduction.
+
+## Anti-patterns / forbidden directions (carry forward, strict)
+
+* **NO `IsCanonicalFormBNT → IsBNTCanonicalForm` adapter, ever.** Including `bntSectorDecomp` or `toIsBNTCanonicalForm` constructions.
+* **NO `_CFBNT` suffix lemmas in new work.** Replace with clean names.
+* **NO `mu_strict_anti` accessor in new work.** Use `spectralLevel_strict_anti`.
+* **NO `mu : Fin r → ℂ` parameter in new lemmas.** Replace with `IsBNTCanonicalForm P` taking `P : SectorDecomposition d`.
+* **NO claim that `IsCanonicalFormBNT` and `IsBNTCanonicalForm` are equivalent up to renaming.** They are not (multiplicity-recovery is a real paper-gap).
+* **NO per-block projection / rate-quantified work** on the new surface — issue #1678 has ruled this out.
+* **Per CPSV recommendation §8, items 4-5**: keep dominant projection as a useful special lemma; do not claim universal nondecay from it.
+
+## Open paper-gap commitments to preserve
+
+* `docs/paper-gaps/ft_one_copy_scope_restriction.tex` — currently records the multiplicity-recovery gap. **Reclassify**: the new surface eliminates this gap as a scope restriction. The paper-gap doc should be updated or retired once Phase 7 completes.
+* `docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex` — non-dominant projection failure. **Permanent paper-gap**: the analysis showing per-block projection fails for non-dominant blocks remains a useful informational document.
+
+## What is preserved (NOT retired)
+
+* `TNLean/MPS/BNT/Basic.lean` — `eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal` (line 195) and `coefficient_eventually_eq_of_eventually_linearIndependent` (line 172). These are the analytic engines, applicable to any normal MPS family with appropriate decay. They will be **used** by the new surface, not deleted.
+* `SectorDecomposition` infrastructure — the abstract sector-decomposition machinery (basis, coeff, weights). This is fine and not one-copy.
+* `mpvOverlap`, `mpvInner`, `mpvState`, `IsInjective`, `IsIrreducible`, `IsLeftCanonical`, `GaugePhaseEquiv`, all the low-level normal-tensor lemmas. They are not coupled to one-copy.
+
+## Risk assessment
+
+* **Highest risk:** Phase 4 (equal-MPV non-decaying overlap proof on multi-copy). The 540-line proof uses dominant-pair matching + tail reduction. Multi-copy may introduce additional complications. Mitigation: stage Phase 4 as multiple sub-PRs (dominant case, tail reduction with multi-copy bookkeeping, packaging).
+* **Medium risk:** Phase 5 downstream (BlocksMatch handles the matching permutation; on multi-copy, the matching could be sector-level or sector-and-copy-level — need to commit to a shape early).
+* **Low risk:** Phases 1-3 (foundational, mostly mechanical given the design).
+* **Low risk:** Phase 6 (consumers).
+* **Trivial:** Phase 7 (mechanical deletions).
+
+## Decision point (user input required before Phase 1)
+
+The choice of MATCHING SHAPE in Phase 5 matters:
+* **Option α**: matching is sector-level (the multi-copy structure within each sector is preserved as a separate datum). Cleaner downstream.
+* **Option β**: matching pairs (sector, copy) on each side. More expressive but requires more bookkeeping.
+
+CPSV21 uses Option α implicitly (sector-level). I recommend Option α as the default.
+
+## Status
+
+This memo is the entirety of Phase 0. After landing, Phase 1 dispatches the new structure + examples + basic API.

--- a/blueprint/comments202605/cpsv16_bnt_gap_recommendation_examples.tex
+++ b/blueprint/comments202605/cpsv16_bnt_gap_recommendation_examples.tex
@@ -1,0 +1,488 @@
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\PassOptionsToPackage{dvipsnames,svgnames,x11names}{xcolor}
+%
+\documentclass[
+  11pt,
+]{article}
+\usepackage{amsmath,amssymb}
+\usepackage{setspace}
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+  \usepackage{unicode-math} % this also loads fontspec
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+\fi
+\usepackage{lmodern}
+\ifPDFTeX\else
+  % xetex/luatex font selection
+  \setmainfont[]{DejaVu Serif}
+  \setmathfont[]{DejaVu Math TeX Gyre}
+\fi
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\usepackage{xcolor}
+\usepackage[margin=1in]{geometry}
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+\usepackage{amsmath,amssymb,mathtools}
+\usepackage{enumitem}
+\setlist[itemize]{topsep=3pt,itemsep=2pt,parsep=0pt}
+\setlist[enumerate]{topsep=3pt,itemsep=2pt,parsep=0pt}
+\usepackage{microtype}
+\usepackage{titlesec}
+\titleformat{\section}{\large\bfseries}{\thesection}{0.7em}{}
+\titleformat{\subsection}{\normalsize\bfseries}{\thesubsection}{0.7em}{}
+\usepackage[most]{tcolorbox}
+\tcbset{colback=gray!4,colframe=gray!40,arc=2pt,boxrule=0.4pt,left=6pt,right=6pt,top=5pt,bottom=5pt}
+\ifLuaTeX
+  \usepackage{selnolig}  % disable illegal ligatures
+\fi
+\usepackage{bookmark}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\urlstyle{same}
+\hypersetup{
+  pdftitle={Recommendation on CPSV16 Step 1, One-Copy BNT, and Non-Dominant Projection},
+  colorlinks=true,
+  linkcolor={blue},
+  filecolor={Maroon},
+  citecolor={Blue},
+  urlcolor={blue},
+  pdfcreator={LaTeX via pandoc}}
+
+\title{Recommendation on CPSV16 Step 1, One-Copy BNT, and Non-Dominant
+Projection}
+\author{}
+\date{May 13, 2026}
+
+\begin{document}
+\maketitle
+
+\setstretch{1.08}
+\section{Recommendation on CPSV16 Step 1, one-copy BNT, and non-dominant
+projection}\label{recommendation-on-cpsv16-step-1-one-copy-bnt-and-non-dominant-projection}
+
+\subsection{Executive summary}\label{executive-summary}
+
+The current issue is not merely a missing estimate. It is a mismatch
+between three things:
+
+\begin{enumerate}
+\def\labelenumi{\arabic{enumi}.}
+\tightlist
+\item
+  the paper-level BNT/canonical-form structure;
+\item
+  the current formalization surface, apparently called
+  \texttt{IsCanonicalFormBNT};
+\item
+  the proof strategy being attempted for CPSV16 Step 1.
+\end{enumerate}
+
+The current \texttt{IsCanonicalFormBNT} surface is described as carrying
+a single weight per sector with strict modulus ordering. This is a
+\textbf{one-copy specialization} of the paper's two-layer structure,
+where each BNT sector may contain several gauge-phase-equivalent copies
+and contributes a power-sum coefficient.
+
+The non-dominant per-block projection argument should not be pushed
+further. It works for the dominant block, but for a non-dominant block
+both sides of the projected identity can decay to zero. The paper's Step
+1 mechanism is instead linear independence of the relevant combined
+family and coefficient comparison.
+
+The examples below are meant to make the distinction concrete.
+
+\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
+
+\subsection{1. Paper-level BNT structure is not
+one-copy}\label{paper-level-bnt-structure-is-not-one-copy}
+
+In the MPDO/CPGSV canonical-form framework, after grouping
+gauge-phase-equivalent normal blocks into a basis of normal tensors, one
+sector may contain several copies:
+
+\[
+A^i \simeq
+\bigoplus_{j=1}^g
+\bigoplus_{q=1}^{r_j}
+\mu_{j,q} X_{j,q} A_j^i X_{j,q}^{-1}.
+\]
+
+At the MPV level this gives
+
+\[
+V_N(A)
+=
+\sum_{j=1}^g
+\left(\sum_{q=1}^{r_j}\mu_{j,q}^N\right)V_N(A_j).
+\]
+
+So the coefficient attached to a BNT sector is generally a power sum
+
+\[
+c_j(N)=\sum_q \mu_{j,q}^N,
+\]
+
+not a single scalar power \(\mu_j^N\).
+
+The uploaded note explicitly describes the current
+\texttt{IsCanonicalFormBNT} surface as the specialization \(r_j=1\): one
+weight per sector, strictly ordered by modulus. That is a genuine
+restriction relative to the paper's BNT structure.
+
+\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
+
+\subsection{2. Example: one BNT sector with two phase
+copies}\label{example-one-bnt-sector-with-two-phase-copies}
+
+Take one normal tensor \(C\), and consider the block tensor
+
+\[
+A = C \oplus (-C).
+\]
+
+Equivalently, this is one paper-level BNT tensor \(C\) with two scalar
+copies
+
+\[
+\mu_1=1,\qquad \mu_2=-1.
+\]
+
+Then
+
+\[
+V_N(A)=1^N V_N(C)+(-1)^N V_N(C)
+      =(1+(-1)^N)V_N(C).
+\]
+
+Thus
+
+\[
+V_N(A)=
+\begin{cases}
+2V_N(C), & N\text{ even},\\
+0, & N\text{ odd}.
+\end{cases}
+\]
+
+This is exactly the kind of phenomenon the paper's BNT-sector notation
+records: repeated gauge-phase-equivalent copies of the same normal block
+combine into one sector coefficient.
+
+But it cannot be represented by a \textbf{single} scalar power
+\(\mu^N V_N(C)\), because no scalar \(\mu\) satisfies
+
+\[
+\mu^N = 1+(-1)^N
+\]
+
+for all \(N\). The problem is not notation; the one-copy surface has
+removed genuine multiplicity data.
+
+This example should not be described as two distinct BNT elements. It is
+one BNT element with multiplicity two. That is precisely the distinction
+the current one-copy predicate appears to collapse.
+
+\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
+
+\subsection{3. Example: equal-modulus
+copies}\label{example-equal-modulus-copies}
+
+Similarly, take
+
+\[
+A = C \oplus e^{i\theta}C.
+\]
+
+Then
+
+\[
+V_N(A)=(1+e^{iN\theta})V_N(C).
+\]
+
+Both scalar copies have modulus \(1\). A strict block-level ordering
+
+\[
+|\mu_1|>|\mu_2|>\cdots
+\]
+
+cannot keep both copies as separate ordered blocks. The paper handles
+this by grouping them into one BNT sector and recording the coefficient
+
+\[
+1+e^{iN\theta}.
+\]
+
+Therefore, a strict one-weight-per-sector formalization is weaker than
+the paper unless there is an additional theorem that reconstructs the
+full sector/multiplicity structure.
+
+\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
+
+\subsection{4. Why the non-dominant projection argument
+fails}\label{why-the-non-dominant-projection-argument-fails}
+
+The uploaded note's analytic point is correct. Suppose, after dominant
+normalization, the assembled \(B\)-side has two blocks
+
+\[
+B_{\mathrm{tot}}=B_0\oplus \lambda B_1,
+\qquad 0<|\lambda|<1.
+\]
+
+Assume the proportionality scalar has the dominant behavior
+
+\[
+c_N\sim 1.
+\]
+
+Project onto the dominant block \(B_0\). The leading RHS contribution is
+
+\[
+c_N\cdot 1^N\cdot
+\langle V_N(B_0),V_N(B_0)\rangle
+\to \ell_0\neq 0.
+\]
+
+So if the LHS tends to zero, this gives a contradiction.
+
+But now project onto the non-dominant block \(B_1\). The leading RHS
+contribution is
+
+\[
+c_N\lambda^N
+\langle V_N(B_1),V_N(B_1)\rangle
+\sim \lambda^N\ell_1
+\to 0.
+\]
+
+Thus both sides of the projected identity may tend to zero. There is no
+contradiction.
+
+This is not a Lean technicality. It is a genuine analytic obstruction to
+extending the dominant-block projection proof to arbitrary blocks.
+
+\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
+
+\subsection{5. What the paper's Step 1 proof uses
+instead}\label{what-the-papers-step-1-proof-uses-instead}
+
+The source proof should be formalized as a
+linear-independence/coefficient-comparison argument.
+
+Start from eventual proportionality:
+
+\[
+\sum_j (\mu_j^A)^N V_N(A_j)
+=
+c_N\sum_k(\mu_k^B)^N V_N(B_k).
+\]
+
+Fix \(k_0\). Move all terms except \(B_{k_0}\) to the left:
+
+\[
+\sum_j (\mu_j^A)^N V_N(A_j)
+-
+c_N\sum_{k\neq k_0}(\mu_k^B)^N V_N(B_k)
+=
+c_N(\mu_{k_0}^B)^N V_N(B_{k_0}).
+\]
+
+If the actual family appearing in this relation,
+
+\[
+\{V_N(A_j)\}_j\cup \{V_N(B_k)\}_k,
+\]
+
+is eventually linearly independent, then coefficient comparison forces
+
+\[
+c_N(\mu_{k_0}^B)^N=0.
+\]
+
+This contradicts \(c_N\neq0\) and \(\mu_{k_0}^B\neq0\).
+
+The crucial point is that this proof does \textbf{not} require
+
+\[
+c_N(\mu_{k_0}^B)^N
+\]
+
+to stay bounded away from zero. It only requires it to be nonzero. This
+is why coefficient comparison works where projection estimates fail.
+
+\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
+
+\subsection{6. Why the smaller linear-independence lemma is
+insufficient}\label{why-the-smaller-linear-independence-lemma-is-insufficient}
+
+It is not enough to know linear independence of
+
+\[
+\{V_N(A_j)\}_j\cup\{V_N(B_{k_0})\}.
+\]
+
+The exact vector relation also contains the other \(B_k\)'s:
+
+\[
+\sum_j a_j(N)V_N(A_j)
+-
+\sum_{k\neq k_0} b_k(N)V_N(B_k)
+-
+b_{k_0}(N)V_N(B_{k_0})=0.
+\]
+
+Independence of the smaller family gives no coefficient information in a
+relation involving omitted vectors.
+
+A finite-dimensional toy example shows the issue. In \(\mathbb C^2\),
+let
+
+\[
+u=e_1,\qquad v=e_2,\qquad w=e_1+e_2.
+\]
+
+The pair \(\{u,v\}\) is linearly independent. But in the larger family,
+
+\[
+w-u-v=0.
+\]
+
+So knowing that \(\{u,v\}\) is independent does not let one isolate the
+coefficient of \(v\) in a relation involving \(w\). Analogously, knowing
+independence of \(\{A_j\}\cup\{B_{k_0}\}\) does not isolate \(B_{k_0}\)
+in the proportionality identity involving all \(B_k\).
+
+The needed statement is the full combined-family linear independence
+lemma, or at least a version strong enough to isolate the coefficient of
+\(B_{k_0}\) in the actual relation.
+
+\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
+
+\subsection{7. Recommended message to the formalization
+agents}\label{recommended-message-to-the-formalization-agents}
+
+Please separate the following theorem surfaces explicitly:
+
+\begin{enumerate}
+\def\labelenumi{\arabic{enumi}.}
+\item
+  \textbf{One-copy BNT canonical form.}\\
+  One scalar weight per BNT sector, strict ordering of moduli. This is
+  the current \texttt{IsCanonicalFormBNT} surface as described in the
+  uploaded note.
+\item
+  \textbf{Paper-level sector/BNT canonical form.}\\
+  A sector may contain several gauge-phase-equivalent copies, and the
+  coefficient of a BNT block is a power sum \(\sum_q\mu_{j,q}^N\).
+\item
+  \textbf{Fully unconditional canonical-form existence.}\\
+  Starting from arbitrary tensors, one must still construct the
+  appropriate canonical/BNT data before applying the uniqueness theorem.
+\end{enumerate}
+
+The present non-dominant Step 1 issue concerns the gap between (1) and
+(2), plus an invalid attempt to prove a universal statement using a
+dominant-block projection argument.
+
+Please do not try to extend the dominant-block projection proof to
+non-dominant blocks. For a non-dominant block, the scalar prefactor
+decays, so the projected proportionality identity can reduce
+asymptotically to \(0=0\). The two-block example
+\(B_0\oplus\lambda B_1\), \(|\lambda|<1\), already shows this.
+
+The correct CPSV/MPDO proof mechanism is eventual linear independence of
+the full combined family and exact coefficient comparison.
+
+\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
+
+\subsection{8. Recommended formalization
+repairs}\label{recommended-formalization-repairs}
+
+\begin{enumerate}
+\def\labelenumi{\arabic{enumi}.}
+\item
+  Rename or document the current predicate as \textbf{one-copy BNT
+  canonical form}.
+\item
+  Add or promote a paper-faithful sector structure:
+
+  \[
+  (\lambda_j,\{\omega_{j,q}\}_q,A_j),
+  \qquad |\omega_{j,q}|=1,
+  \]
+
+  with sector coefficient
+
+  \[
+  \lambda_j^N\sum_q\omega_{j,q}^N.
+  \]
+\item
+  Prove the full combined-family Lem1:
+
+  \[
+  \text{all relevant cross-overlaps decay}
+  \Longrightarrow
+  \{V_N(A_j)\}_j\cup\{V_N(B_k)\}_k
+  \text{ is eventually linearly independent}.
+  \]
+\item
+  Use exact coefficient comparison, not asymptotic projection, for
+  arbitrary \(k_0\).
+\item
+  Keep the dominant projection theorem as a useful special lemma, but do
+  not present it as the proof of the universal nondecay statement.
+\item
+  Do not claim the full MPDO/CPGSV BNT theorem from the one-copy
+  predicate unless a sector/grouping theorem has been added.
+\end{enumerate}
+
+\begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
+
+\subsection{Final classification}\label{final-classification}
+
+The current situation is best classified as:
+
+\begin{itemize}
+\tightlist
+\item
+  \textbf{scope restriction:} the current predicate is one-copy and
+  therefore weaker than the paper-level BNT structure;
+\item
+  \textbf{proof-strategy gap:} the non-dominant projection argument is
+  analytically insufficient;
+\item
+  \textbf{repairable formalization gap:} the right repair is full
+  combined-family linear independence plus coefficient comparison, or a
+  move to the paper-faithful sector decomposition.
+\end{itemize}
+
+The examples above are deliberately simple. Their role is to prevent the
+issue from being mistaken for a cosmetic naming complaint. The
+formalization is not merely missing polish: it is using a restricted
+canonical-form surface and a proof method that fails exactly where the
+paper switches to BNT-sector linear independence.
+
+\end{document}


### PR DESCRIPTION
Refs: #1678, #1641

## Context

Following the user's explicit directives on issue #1678:
* "we should thoroughly implment this and retire the other paths"
* "dont do this one copy interfaces anywhere anymore"
* "i want to be doing this cleanly from scratch and retire all the wrong approaches anywhere comprehensively"
* "dont build any adapters because they may have mathematical obstructions"

This is Phase 0 — the planning document. It commits this stream of work as a **clean-slate retirement** of the one-copy `IsCanonicalFormBNT` surface in favour of a paper-faithful multi-copy structure built directly from `SectorDecomposition` data.

## What's in this PR

`audits/2026-05-13_cpsv16_ft_paper_faithful_clean_slate_plan.md` (340 lines):

* **Diagnosis** of the one-copy vs multi-copy gap with the `C ⊕ -C` example from the recommendation document.
* **Retirement scope**: 21 files / 242 references to `IsCanonicalFormBNT` plus the 5-module path β rate-quantified stack.
* **8-phase implementation plan**: design, basic API, weak existential, equal-MPV non-decay, block matching, downstream consumers, deletion.
* **Hard constraints**: no adapters, no `_CFBNT` suffix in new work, no `mu : Fin r → ℂ` parameter in new lemmas, no per-block projection / rate-quantified work.
* **Risk assessment**: Phase 4 (multi-copy non-decay proof) is highest risk.
* **Decision point**: matching shape for Phase 5 (sector-level vs (sector, copy)).

Also adds the source recommendation document `blueprint/comments202605/cpsv16_bnt_gap_recommendation_examples.tex` (PDF source from user upload).

## What this PR does NOT do

- No code changes. This is a planning document. Phase 1 (new structure definition) will be the next PR.

## Decision required before Phase 1

The plan asks whether downstream block matching should be:
- **Option α** (recommended): sector-level matching (matches CPSV21).
- **Option β**: (sector, copy) matching.

## Build verification

- No new `sorry`/`axiom`/`unsafe`.
- Documentation-only PR.

## What gets retired

Per the plan, eventually (Phase 7):
- `IsCanonicalFormBNT` itself in `BNT/Construction.lean`.
- All derived lemmas (`cross_overlap_tendsto_zero` from CFBNT, etc.).
- Path β stack (5 modules).
- The `_sameMPV₂_CFBNT` chain.
- The `_CFBNT` weak existential.
- All adapters (`bntSectorDecomp`, `toIsBNTCanonicalFormSD`).

## What gets preserved

- `BNT/Basic.lean`'s analytic engines (combined LI, coefficient comparison) — they're surface-agnostic.
- `SectorDecomposition` infrastructure — already in place and not one-copy.
- Low-level normal-tensor lemmas (`IsInjective`, `IsIrreducible`, etc.).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds planning material and a reference recommendation document; no production code paths or proofs are modified.
> 
> **Overview**
> Adds a new planning memo `audits/2026-05-13_cpsv16_ft_paper_faithful_clean_slate_plan.md` that commits to retiring the one-copy `IsCanonicalFormBNT` surface and outlines a phased clean-slate migration to a paper-faithful multi-copy `IsBNTCanonicalForm` defined from `SectorDecomposition` (including explicit no-adapter constraints and a deletion/porting scope list).
> 
> Adds the source recommendation document `blueprint/comments202605/cpsv16_bnt_gap_recommendation_examples.tex` that motivates the multi-copy requirement and the shift away from non-dominant projection arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d331116b7bcfd9aea9f9a0168b5e63692585096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->