### PR TITLE
feat(MPS/FT/PaperBNT): Phase 1 paper-faithful IsBNTCanonicalForm structure (clean-slate)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -235,6 +235,8 @@ import TNLean.MPS.FundamentalTheorem.SectorDecomposition.RateQuantifiedDecay
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.RenormalizedNonCancellation
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.CrossFamilyRateDecay
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.RateQuantifiedDischarge
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Examples
 import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.Applications

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
+import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.Overlap.Basic
@@ -10,46 +11,50 @@ import TNLean.MPS.Overlap.Basic
 /-!
 # Paper-faithful BNT canonical form on a `SectorDecomposition`
 
-This module introduces a paper-faithful canonical-form predicate
-`IsBNTCanonicalForm` over a `SectorDecomposition d`.  The structure
-implements the multi-copy BNT decomposition of CPSV16 §II
-(`eq:II_ABasicTensors`, line 286, arXiv:1606.00608) and CPSV21 Definition 4.3
-(lines 1846–1850, arXiv:2011.12127) by exposing:
+This module introduces the paper-faithful canonical-form predicate
+`IsBNTCanonicalForm` over a `SectorDecomposition d`.
 
-* a **spectral level** `spectralLevel j` with strictly decreasing modulus
-  and dominant normalization `‖spectralLevel ⟨0, _⟩‖ = 1`;
-* **within-sector unit-modulus phase weights** `phaseWeight j q` with
-  `‖phaseWeight j q‖ = 1`, factoring the bare sector weight as
-  `P.weight j q = spectralLevel j * phaseWeight j q`;
-* **per-block normality data**: each basis block is injective,
-  irreducible, left-canonical, and has self-overlap tending to one;
-* **eventual linear independence** of basis blocks
-  (`HasBNTSectorData`);
-* **block distinctness**: distinct basis blocks of equal bond dimension
-  are not gauge-phase equivalent.
+The structure is the minimal CPSV16/CPSV21 BNT canonical-form data on top of
+a `SectorDecomposition`.  It records:
 
-The resulting MPV decomposition reads
-```
-mpv P.toTensor σ
-  = ∑_j (spectralLevel j)^N · (∑_q (phaseWeight j q)^N) · mpv (P.basis j) σ,
-```
-where the within-sector unit-modulus power sum `∑_q (phaseWeight j q)^N`
-is the CPSV16 §II sector coefficient.  Specializing to one copy per
-sector (`P.copies j = 1`) collapses this to a single scalar power; that
-specialization is the one captured by the retired one-copy predicate
-discussed in issue #1678 (the `C ⊕ -C` example shows that `1 + (-1)^N`
-is not a scalar power, which is why the one-copy specialization is
-insufficient).
+* **per-block normality** (injective, irreducible, left-canonical) and
+  **self-overlap → 1** (non-periodic / after-blocking surface);
+* **eventual linear independence** of basis MPV states (`HasBNTSectorData`);
+* **block distinctness** in the cast-compatible gauge-phase shape, ruling out
+  gauge-phase equivalence between distinct basis blocks of equal bond
+  dimension.
+
+Crucially, the structure does **not** impose an equal-modulus or strict-order
+condition on the raw sector weights `P.weight j q`.  CPSV16
+`eq:II_ABasicTensors` (line 286) and CPSV21 Definition 4.3 (lines 1846–1884)
+use raw entries `μ_{j,q}` and a coefficient `∑_q μ_{j,q}^N`; they do not
+require `|μ_{j,q}|` to be constant in `q`, nor do they impose a strict order
+on the moduli of distinct BNT basis elements.  See the audit memo
+`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` for the
+counter-examples (`C ⊕ D`, `C ⊕ (1/2)C`, `C ⊕ (-C) ⊕ (1/2)C`) that motivated
+removing the equal-modulus layer from this core predicate.
+
+An optional equal-modulus weight layer is provided separately as
+`HasEqualModulusWeightLayer` in `PaperBNT/EqualModulus.lean`.  Some
+downstream estimates may consume that layer; it is not part of the
+source-faithful core.
 
 ## References
 
-* CPSV16: Cirac--Pérez-García--Schuch--Verstraete,
-  *Matrix Product Density Operators: Renormalization Fixed Points and
-  Boundary Theories*, Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.
-* CPSV21: Cirac--Pérez-García--Schuch--Verstraete,
-  *Matrix product states and projected entangled pair states: Concepts,
-  symmetries, theorems*, Rev. Mod. Phys. **93**, 045003 (2021);
-  arXiv:2011.12127.
+* CPSV16: Cirac–Pérez-García–Schuch–Verstraete, *Matrix Product Density
+  Operators: Renormalization Fixed Points and Boundary Theories*,
+  Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.  Source-line tags used
+  below: 217–246 (global modulus normalization), 264–279 (gauge-phase
+  grouping rule), 271–301 (two-layer BNT display with raw `μ_{j,q}`),
+  1121–1132 (combined-family LI input), 1181–1188 (multiplicity recovery
+  via power-sum comparison).
+* CPSV21: Cirac–Pérez-García–Schuch–Verstraete, *Matrix product states and
+  projected entangled pair states: Concepts, symmetries, theorems*,
+  Rev. Mod. Phys. **93**, 045003 (2021); arXiv:2011.12127.  Source-line tags
+  used below: 1815–1837 (normal tensors primitive after blocking; canonical
+  form `⊕_k μ_k A_k`), 1846–1884 (BNT and two-layer BNT decomposition with
+  raw `μ_{j,q}`), 1905–1908 (unital gauge optional; non-periodic theorem
+  separated from periodic generalization).
 -/
 
 open scoped Matrix BigOperators
@@ -60,55 +65,57 @@ namespace MPSTensor
 variable {d : ℕ}
 
 /--
-**Paper-faithful BNT canonical form on a sector decomposition.**
+**Paper-faithful BNT canonical form (core).**
 
-Given `P : SectorDecomposition d`, this structure carries the data of a
-two-layer multi-copy BNT canonical form (CPSV16
-`eq:II_ABasicTensors`, line 286; CPSV21 Definition 4.3,
-lines 1846--1850).  See the module docstring for the full mathematical
-content; the MPV decomposition reads
+Given `P : SectorDecomposition d`, this captures the minimal CPSV16/CPSV21
+BNT canonical-form data without any equal-modulus or strict-ordering
+assumption on the raw sector weights.  The MPV expansion that flows from
+this predicate is
+
 ```
 mpv P.toTensor σ
-  = ∑_j (spectralLevel j)^N · (∑_q (phaseWeight j q)^N) · mpv (P.basis j) σ.
+  = ∑_j (∑_q (P.weight j q)^N) · mpv (P.basis j) σ,
 ```
 
-This predicate is the paper-faithful surface used throughout the FT
-chain on multi-copy data.  The retired one-copy predicate discussed in
-issue #1678 is *not* a special case of this structure and is not
-referenced anywhere here.
+i.e. CPSV16 §II's two-layer BNT display (lines 271–301) and CPSV21
+Definition 4.3 (lines 1846–1884) with **raw** `μ_{j,q}` entries and
+coefficient `∑_q μ_{j,q}^N`.
+
+The audit `audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md`
+records the counter-examples that motivate keeping equal-modulus/spectral
+data out of this core predicate.
 -/
 structure IsBNTCanonicalForm (P : SectorDecomposition d) where
-  /-- Spectral level: one nonzero complex number per BNT sector. -/
-  spectralLevel : Fin P.basisCount → ℂ
-  /-- The spectral level is everywhere nonzero. -/
-  spectralLevel_ne_zero : ∀ j, spectralLevel j ≠ 0
-  /-- Spectral-level moduli are strictly decreasing in `j`. -/
-  spectralLevel_strict_anti :
-    StrictAnti (fun j : Fin P.basisCount => ‖spectralLevel j‖)
-  /-- **Dominant normalization** of the spectral level. -/
-  spectralLevel_dom_norm_one :
-    ∀ h : 0 < P.basisCount, ‖spectralLevel ⟨0, h⟩‖ = 1
-  /-- Within-sector unit-modulus phase weights `ν_{j,q}`. -/
-  phaseWeight : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ
-  /-- Every within-sector phase weight has unit modulus. -/
-  phaseWeight_norm_one : ∀ j q, ‖phaseWeight j q‖ = 1
-  /-- Factorization `μ_{j,q} = λ_j · ν_{j,q}` of the sector weights. -/
-  weight_factor : ∀ j q, P.weight j q = spectralLevel j * phaseWeight j q
-  /-- Per-block injectivity of the basis. -/
-  basis_injective : ∀ j, IsInjective (P.basis j)
-  /-- Per-block irreducibility of the basis. -/
-  basis_irreducible : ∀ j, IsIrreducibleTensor (P.basis j)
-  /-- Per-block left-canonical form of the basis. -/
-  basis_left_canonical : ∀ j, IsLeftCanonical (P.basis j)
-  /-- Per-block normalized self-overlap. -/
-  basis_normalized_self_overlap : ∀ j,
+  /-- Every basis bond dimension is positive (needed for `NeZero` typeclass
+  inference on `Fin (P.basisDim j)`; cf. CPSV21 lines 1815–1830 where the
+  primitive transfer map lives on a positive-dimension block). -/
+  basis_dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j
+  /-- **Per-block injectivity.**  Each basis block `P.basis j` is an
+  injective MPS tensor (CPSV21 lines 1815–1830). -/
+  basis_injective : ∀ j : Fin P.basisCount, IsInjective (P.basis j)
+  /-- **Per-block irreducibility.**  Each basis block has irreducible
+  transfer map after blocking (CPSV16 lines 233–234; CPSV21 lines
+  1815–1830). -/
+  basis_irreducible : ∀ j : Fin P.basisCount, IsIrreducibleTensor (P.basis j)
+  /-- **Per-block left-canonical form** (CPSV21 lines 1815–1837). -/
+  basis_left_canonical : ∀ j : Fin P.basisCount, IsLeftCanonical (P.basis j)
+  /-- **Per-block normalized self-overlap.**  Each basis block has
+  `mpvOverlap (P.basis j) (P.basis j) N → 1` as `N → ∞`.  This selects the
+  non-periodic / after-blocking BNT surface (CPSV21 line 1818; the periodic
+  generalization at CPSV21 lines 1905–1908 is deliberately not included
+  here). -/
+  basis_normalized_self_overlap : ∀ j : Fin P.basisCount,
     Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
       atTop (𝓝 1)
-  /-- Eventual linear independence of basis blocks (CPSV21 Def. 4.3). -/
+  /-- **BNT eventual linear independence** of the basis MPV states
+  (CPSV21 Definition 4.3, lines 1846–1850; combined-family LI input at
+  CPSV16 lines 1121–1132). -/
   bnt_data : HasBNTSectorData P
-  /-- **Block distinctness**: distinct equal-dimension basis blocks are
-  not gauge-phase equivalent.  This matches the convention used by
-  `BlocksNotGaugePhaseEquiv` in `TNLean/MPS/BNT/Construction.lean`. -/
+  /-- **Block distinctness.**  No gauge-phase equivalence between distinct
+  basis blocks of equal bond dimension; this is the cast-compatible shape
+  used by `BlocksNotGaugePhaseEquiv` in
+  `TNLean/MPS/BNT/Construction.lean`, matching the CPSV16 lines 264–279
+  grouping rule. -/
   basis_distinct : ∀ j k : Fin P.basisCount, j ≠ k →
     ∀ h : P.basisDim j = P.basisDim k,
       ¬ GaugePhaseEquiv
@@ -118,67 +125,53 @@ namespace IsBNTCanonicalForm
 
 variable {P : SectorDecomposition d}
 
-/-- **All spectral-level moduli are bounded by `1`.**
+/-- **Sector coefficient is not eventually zero.**
 
-Combines `spectralLevel_dom_norm_one` with `spectralLevel_strict_anti`:
-the dominant block has unit modulus and every other block has strictly
-smaller modulus, so every modulus is at most `1`. -/
-theorem spectralLevel_norm_le_one (h : IsBNTCanonicalForm P)
-    (j : Fin P.basisCount) : ‖h.spectralLevel j‖ ≤ 1 := by
-  have hpos : 0 < P.basisCount := Nat.lt_of_le_of_lt (Nat.zero_le _) j.isLt
-  have hdom : ‖h.spectralLevel ⟨0, hpos⟩‖ = 1 :=
-    h.spectralLevel_dom_norm_one hpos
-  have hle : (⟨0, hpos⟩ : Fin P.basisCount) ≤ j :=
-    Fin.mk_le_of_le_val (Nat.zero_le _)
-  have hanti : ‖h.spectralLevel j‖ ≤ ‖h.spectralLevel ⟨0, hpos⟩‖ :=
-    h.spectralLevel_strict_anti.antitone hle
-  rw [hdom] at hanti
-  exact hanti
+For any sector `j`, the power-sum coefficient
+`P.coeff N j = ∑_q (P.weight j q)^N` is not eventually zero in `N`.  This
+rules out the pathological cancellation that would obstruct the CPSV16 §II
+Step 1 coefficient-comparison argument: once combined-family LI isolates
+the `j`-th sector coefficient (CPSV16 lines 1121–1132), the surviving
+relation cannot be `0 = 0` for large `N`, so the multiplicity-recovery
+argument of CPSV16 lines 1181–1188 has a nonvanishing left-hand side to
+compare against.
 
-/-- Phase weights are nonzero (immediate from `phaseWeight_norm_one`). -/
-theorem phaseWeight_ne_zero (h : IsBNTCanonicalForm P)
-    (j : Fin P.basisCount) (q : Fin (P.copies j)) :
-    h.phaseWeight j q ≠ 0 := by
-  have hnorm := h.phaseWeight_norm_one j q
-  intro hzero
-  rw [hzero, norm_zero] at hnorm
-  exact one_ne_zero hnorm.symm
-
-/-- Sector weights are nonzero, re-derivable from
-`spectralLevel_ne_zero` and `phaseWeight_norm_one`. -/
-theorem weight_ne_zero_from_factor (h : IsBNTCanonicalForm P)
-    (j : Fin P.basisCount) (q : Fin (P.copies j)) :
-    P.weight j q ≠ 0 := by
-  rw [h.weight_factor j q]
-  exact mul_ne_zero (h.spectralLevel_ne_zero j) (h.phaseWeight_ne_zero j q)
-
-/-- **Sector coefficient identity.**
-
-The sector coefficient `coeff N j = ∑_q (μ_{j,q})^N` factors as the
-product of the `N`-th power of the spectral level and the within-sector
-unit-modulus power sum `∑_q (ν_{j,q})^N`. -/
-theorem coeff_eq_pow_unit_sum (h : IsBNTCanonicalForm P)
-    (N : ℕ) (j : Fin P.basisCount) :
-    P.coeff N j =
-      (h.spectralLevel j) ^ N *
-        ∑ q : Fin (P.copies j), (h.phaseWeight j q) ^ N := by
+The proof feeds nonzero weights `P.weight j q ≠ 0` (from
+`P.weight_ne_zero`) into `geom_sum_eventually_zero`
+(`TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean`): if the
+power-sum were eventually zero, the geometric-extrapolation lemma would
+force it to vanish at every exponent including `0`, contradicting the
+positivity of `P.copies j` (i.e. `∑_q 1 = P.copies j ≠ 0`).
+-/
+lemma coeff_not_eventually_zero
+    (_h : IsBNTCanonicalForm P) (j : Fin P.basisCount) :
+    ¬ (∀ᶠ N in Filter.atTop, P.coeff N j = 0) := by
   classical
-  unfold SectorDecomposition.coeff SectorWeightData.coeff
-  calc
-    ∑ q : Fin (P.copies j), (P.weight j q) ^ N
-        = ∑ q : Fin (P.copies j),
-            (h.spectralLevel j * h.phaseWeight j q) ^ N := by
-          refine Finset.sum_congr rfl ?_
-          intro q _
-          rw [h.weight_factor j q]
-    _ = ∑ q : Fin (P.copies j),
-          (h.spectralLevel j) ^ N * (h.phaseWeight j q) ^ N := by
-          refine Finset.sum_congr rfl ?_
-          intro q _
-          rw [mul_pow]
-    _ = (h.spectralLevel j) ^ N *
-          ∑ q : Fin (P.copies j), (h.phaseWeight j q) ^ N := by
-          rw [← Finset.mul_sum]
+  intro hEv
+  -- Extract an explicit threshold `M` past which the power sum vanishes.
+  rw [Filter.eventually_atTop] at hEv
+  obtain ⟨M, hM⟩ := hEv
+  -- Apply `geom_sum_eventually_zero` with weights `P.weight j` (all nonzero)
+  -- and constants `c q = 1`, to conclude vanishing at every exponent.
+  have hwne : ∀ q : Fin (P.copies j), P.weight j q ≠ 0 :=
+    fun q => P.weight_ne_zero j q
+  have hAll : ∀ k, ∑ q : Fin (P.copies j), (1 : ℂ) * (P.weight j q) ^ k = 0 := by
+    refine SectorWeightData.geom_sum_eventually_zero
+      (w := P.weight j) (c := fun _ => 1) hwne (M := M) ?_
+    intro N hN
+    have hzero : P.coeff N j = 0 := hM N hN
+    -- `∑ q, 1 * w^N = ∑ q, w^N = coeff`.
+    simpa [SectorDecomposition.coeff, SectorWeightData.coeff, one_mul] using hzero
+  -- Specialize at `k = 0` to get `(P.copies j : ℂ) = 0`, contradicting positivity.
+  have h0 := hAll 0
+  -- `∑ q, 1 * w^0 = ∑ q, 1 = P.copies j`.
+  have hcard : (∑ _q : Fin (P.copies j), (1 : ℂ) * (P.weight j _q) ^ 0)
+      = (P.copies j : ℂ) := by
+    simp
+  rw [hcard] at h0
+  -- But `0 < P.copies j` rules out `(P.copies j : ℂ) = 0`.
+  have hpos : 0 < P.copies j := P.copies_pos j
+  exact (Nat.cast_ne_zero.mpr hpos.ne') h0
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.SectorDecomposition
+import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.MPS.Periodic.Defs
+import TNLean.MPS.Overlap.Basic
+
+/-!
+# Paper-faithful BNT canonical form on a `SectorDecomposition`
+
+This module introduces a paper-faithful canonical-form predicate
+`IsBNTCanonicalForm` over a `SectorDecomposition d`.  The structure
+implements the multi-copy BNT decomposition of CPSV16 §II
+(`eq:II_ABasicTensors`, line 286, arXiv:1606.00608) and CPSV21 Definition 4.3
+(lines 1846–1850, arXiv:2011.12127) by exposing:
+
+* a **spectral level** `spectralLevel j` with strictly decreasing modulus
+  and dominant normalization `‖spectralLevel ⟨0, _⟩‖ = 1`;
+* **within-sector unit-modulus phase weights** `phaseWeight j q` with
+  `‖phaseWeight j q‖ = 1`, factoring the bare sector weight as
+  `P.weight j q = spectralLevel j * phaseWeight j q`;
+* **per-block normality data**: each basis block is injective,
+  irreducible, left-canonical, and has self-overlap tending to one;
+* **eventual linear independence** of basis blocks
+  (`HasBNTSectorData`);
+* **block distinctness**: distinct basis blocks of equal bond dimension
+  are not gauge-phase equivalent.
+
+The resulting MPV decomposition reads
+```
+mpv P.toTensor σ
+  = ∑_j (spectralLevel j)^N · (∑_q (phaseWeight j q)^N) · mpv (P.basis j) σ,
+```
+where the within-sector unit-modulus power sum `∑_q (phaseWeight j q)^N`
+is the CPSV16 §II sector coefficient.  Specializing to one copy per
+sector (`P.copies j = 1`) collapses this to a single scalar power; that
+specialization is the one captured by the retired one-copy predicate
+discussed in issue #1678 (the `C ⊕ -C` example shows that `1 + (-1)^N`
+is not a scalar power, which is why the one-copy specialization is
+insufficient).
+
+## References
+
+* CPSV16: Cirac--Pérez-García--Schuch--Verstraete,
+  *Matrix Product Density Operators: Renormalization Fixed Points and
+  Boundary Theories*, Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.
+* CPSV21: Cirac--Pérez-García--Schuch--Verstraete,
+  *Matrix product states and projected entangled pair states: Concepts,
+  symmetries, theorems*, Rev. Mod. Phys. **93**, 045003 (2021);
+  arXiv:2011.12127.
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/--
+**Paper-faithful BNT canonical form on a sector decomposition.**
+
+Given `P : SectorDecomposition d`, this structure carries the data of a
+two-layer multi-copy BNT canonical form (CPSV16
+`eq:II_ABasicTensors`, line 286; CPSV21 Definition 4.3,
+lines 1846--1850).  See the module docstring for the full mathematical
+content; the MPV decomposition reads
+```
+mpv P.toTensor σ
+  = ∑_j (spectralLevel j)^N · (∑_q (phaseWeight j q)^N) · mpv (P.basis j) σ.
+```
+
+This predicate is the paper-faithful surface used throughout the FT
+chain on multi-copy data.  The retired one-copy predicate discussed in
+issue #1678 is *not* a special case of this structure and is not
+referenced anywhere here.
+-/
+structure IsBNTCanonicalForm (P : SectorDecomposition d) where
+  /-- Spectral level: one nonzero complex number per BNT sector. -/
+  spectralLevel : Fin P.basisCount → ℂ
+  /-- The spectral level is everywhere nonzero. -/
+  spectralLevel_ne_zero : ∀ j, spectralLevel j ≠ 0
+  /-- Spectral-level moduli are strictly decreasing in `j`. -/
+  spectralLevel_strict_anti :
+    StrictAnti (fun j : Fin P.basisCount => ‖spectralLevel j‖)
+  /-- **Dominant normalization** of the spectral level. -/
+  spectralLevel_dom_norm_one :
+    ∀ h : 0 < P.basisCount, ‖spectralLevel ⟨0, h⟩‖ = 1
+  /-- Within-sector unit-modulus phase weights `ν_{j,q}`. -/
+  phaseWeight : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ
+  /-- Every within-sector phase weight has unit modulus. -/
+  phaseWeight_norm_one : ∀ j q, ‖phaseWeight j q‖ = 1
+  /-- Factorization `μ_{j,q} = λ_j · ν_{j,q}` of the sector weights. -/
+  weight_factor : ∀ j q, P.weight j q = spectralLevel j * phaseWeight j q
+  /-- Per-block injectivity of the basis. -/
+  basis_injective : ∀ j, IsInjective (P.basis j)
+  /-- Per-block irreducibility of the basis. -/
+  basis_irreducible : ∀ j, IsIrreducibleTensor (P.basis j)
+  /-- Per-block left-canonical form of the basis. -/
+  basis_left_canonical : ∀ j, IsLeftCanonical (P.basis j)
+  /-- Per-block normalized self-overlap. -/
+  basis_normalized_self_overlap : ∀ j,
+    Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
+      atTop (𝓝 1)
+  /-- Eventual linear independence of basis blocks (CPSV21 Def. 4.3). -/
+  bnt_data : HasBNTSectorData P
+  /-- **Block distinctness**: distinct equal-dimension basis blocks are
+  not gauge-phase equivalent.  This matches the convention used by
+  `BlocksNotGaugePhaseEquiv` in `TNLean/MPS/BNT/Construction.lean`. -/
+  basis_distinct : ∀ j k : Fin P.basisCount, j ≠ k →
+    ∀ h : P.basisDim j = P.basisDim k,
+      ¬ GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor d) h) (P.basis j)) (P.basis k)
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- **All spectral-level moduli are bounded by `1`.**
+
+Combines `spectralLevel_dom_norm_one` with `spectralLevel_strict_anti`:
+the dominant block has unit modulus and every other block has strictly
+smaller modulus, so every modulus is at most `1`. -/
+theorem spectralLevel_norm_le_one (h : IsBNTCanonicalForm P)
+    (j : Fin P.basisCount) : ‖h.spectralLevel j‖ ≤ 1 := by
+  have hpos : 0 < P.basisCount := Nat.lt_of_le_of_lt (Nat.zero_le _) j.isLt
+  have hdom : ‖h.spectralLevel ⟨0, hpos⟩‖ = 1 :=
+    h.spectralLevel_dom_norm_one hpos
+  have hle : (⟨0, hpos⟩ : Fin P.basisCount) ≤ j :=
+    Fin.mk_le_of_le_val (Nat.zero_le _)
+  have hanti : ‖h.spectralLevel j‖ ≤ ‖h.spectralLevel ⟨0, hpos⟩‖ :=
+    h.spectralLevel_strict_anti.antitone hle
+  rw [hdom] at hanti
+  exact hanti
+
+/-- Phase weights are nonzero (immediate from `phaseWeight_norm_one`). -/
+theorem phaseWeight_ne_zero (h : IsBNTCanonicalForm P)
+    (j : Fin P.basisCount) (q : Fin (P.copies j)) :
+    h.phaseWeight j q ≠ 0 := by
+  have hnorm := h.phaseWeight_norm_one j q
+  intro hzero
+  rw [hzero, norm_zero] at hnorm
+  exact one_ne_zero hnorm.symm
+
+/-- Sector weights are nonzero, re-derivable from
+`spectralLevel_ne_zero` and `phaseWeight_norm_one`. -/
+theorem weight_ne_zero_from_factor (h : IsBNTCanonicalForm P)
+    (j : Fin P.basisCount) (q : Fin (P.copies j)) :
+    P.weight j q ≠ 0 := by
+  rw [h.weight_factor j q]
+  exact mul_ne_zero (h.spectralLevel_ne_zero j) (h.phaseWeight_ne_zero j q)
+
+/-- **Sector coefficient identity.**
+
+The sector coefficient `coeff N j = ∑_q (μ_{j,q})^N` factors as the
+product of the `N`-th power of the spectral level and the within-sector
+unit-modulus power sum `∑_q (ν_{j,q})^N`. -/
+theorem coeff_eq_pow_unit_sum (h : IsBNTCanonicalForm P)
+    (N : ℕ) (j : Fin P.basisCount) :
+    P.coeff N j =
+      (h.spectralLevel j) ^ N *
+        ∑ q : Fin (P.copies j), (h.phaseWeight j q) ^ N := by
+  classical
+  unfold SectorDecomposition.coeff SectorWeightData.coeff
+  calc
+    ∑ q : Fin (P.copies j), (P.weight j q) ^ N
+        = ∑ q : Fin (P.copies j),
+            (h.spectralLevel j * h.phaseWeight j q) ^ N := by
+          refine Finset.sum_congr rfl ?_
+          intro q _
+          rw [h.weight_factor j q]
+    _ = ∑ q : Fin (P.copies j),
+          (h.spectralLevel j) ^ N * (h.phaseWeight j q) ^ N := by
+          refine Finset.sum_congr rfl ?_
+          intro q _
+          rw [mul_pow]
+    _ = (h.spectralLevel j) ^ N *
+          ∑ q : Fin (P.copies j), (h.phaseWeight j q) ^ N := by
+          rw [← Finset.mul_sum]
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/EqualModulus.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/EqualModulus.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
+
+/-!
+# Optional equal-modulus weight layer for BNT canonical forms
+
+This module introduces the **optional** structure
+`HasEqualModulusWeightLayer P`, which layers a spectral level
+`λ_j = spectral_level j` together with within-sector unit-modulus phase
+weights `ν_{j,q} = phase_weight j q` on top of a `SectorDecomposition P`,
+factoring the raw sector weights as `P.weight j q = λ_j · ν_{j,q}`.
+
+This layer captures the **sub-class** of BNT canonical forms in which every
+sector's copies share a common modulus.  It is NOT part of the
+source-faithful BNT predicate `IsBNTCanonicalForm` in
+`PaperBNT/Basic.lean`; see the audit memo
+`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` §Q4 for
+the counter-example `C ⊕ (1/2)C` (a single BNT basis element with coefficient
+`1 + (1/2)^N` whose copies have unequal moduli, so no `λ_j` factorization
+with unit `ν_{j,q}` is possible).
+
+The spectral level is required to be `Antitone` (≥) in `‖·‖`, not
+`StrictAnti`; the audit (§Q10) records the counter-example `C ⊕ D` with
+distinct non-gauge-equivalent normal basis tensors and weights `(1,1)`,
+which has two BNT basis elements of equal modulus.
+
+This layer is provided for downstream estimates that genuinely need an
+equal-modulus normalization; CPSV16 §II Step 1 does not need it.
+
+## References
+
+* CPSV16: arXiv:1606.00608 §II.  Lines 217–246 (global `|μ_k| ≤ 1` with
+  at least one of modulus 1).
+* CPSV21: arXiv:2011.12127 §4.  Lines 1905–1908 (unital gauge optional).
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/--
+**Optional equal-modulus weight layer.**
+
+This optional structure layers a spectral level `λ_j` and within-sector
+unit-modulus phase weights `ν_{j,q}` on top of a `SectorDecomposition`,
+factoring `P.weight j q = spectral_level j · phase_weight j q`.
+
+It captures the sub-class of BNT canonical forms in which every sector's
+copies share a common modulus.  It is NOT required by, nor part of, the
+core paper-faithful BNT predicate `IsBNTCanonicalForm` (see
+`PaperBNT/Basic.lean`).  The audit
+`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` §Q4
+shows that `C ⊕ (1/2)C` is a valid CPSV BNT canonical form that admits no
+such factorization.
+
+Paper anchors:
+
+* CPSV16 lines 217–246 — the optional global normalization
+  `|μ_k| ≤ 1` with at least one of modulus 1.
+* CPSV21 lines 1905–1908 — the unital gauge is optional.
+-/
+structure HasEqualModulusWeightLayer (P : SectorDecomposition d) where
+  /-- The spectral level `λ_j`, one complex scalar per basis block. -/
+  spectral_level : Fin P.basisCount → ℂ
+  /-- The spectral level is everywhere nonzero. -/
+  spectral_level_ne_zero : ∀ j : Fin P.basisCount, spectral_level j ≠ 0
+  /-- The spectral-level moduli are antitone in `j` (≥, not strict).  The
+  non-strict form admits equal-modulus distinct basis blocks; see the audit
+  §Q10. -/
+  spectral_level_antitone :
+    Antitone (fun j : Fin P.basisCount => ‖spectral_level j‖)
+  /-- **Dominant normalization**: the leading basis block has spectral
+  norm 1 (CPSV16 lines 217–246, optional convention). -/
+  spectral_level_dom_norm_one :
+    ∀ h : 0 < P.basisCount, ‖spectral_level ⟨0, h⟩‖ = 1
+  /-- Within-sector unit-modulus phase weights `ν_{j,q}`. -/
+  phase_weight : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ
+  /-- Every phase weight has unit modulus. -/
+  phase_weight_norm_one : ∀ (j : Fin P.basisCount) (q : Fin (P.copies j)),
+    ‖phase_weight j q‖ = 1
+  /-- Factorization of raw sector weights as `μ_{j,q} = λ_j · ν_{j,q}`. -/
+  weight_factor : ∀ (j : Fin P.basisCount) (q : Fin (P.copies j)),
+    P.weight j q = spectral_level j * phase_weight j q
+
+namespace HasEqualModulusWeightLayer
+
+variable {P : SectorDecomposition d}
+
+/-- **Phase weights are nonzero** (immediate from `phase_weight_norm_one`). -/
+lemma phase_weight_ne_zero (h : HasEqualModulusWeightLayer P)
+    (j : Fin P.basisCount) (q : Fin (P.copies j)) :
+    h.phase_weight j q ≠ 0 := by
+  intro hzero
+  have hnorm := h.phase_weight_norm_one j q
+  rw [hzero, norm_zero] at hnorm
+  exact one_ne_zero hnorm.symm
+
+/-- **All spectral-level moduli are bounded by `1`**, combining the
+dominant normalization with `Antitone`. -/
+lemma spectral_level_norm_le_one (h : HasEqualModulusWeightLayer P)
+    (j : Fin P.basisCount) : ‖h.spectral_level j‖ ≤ 1 := by
+  have hpos : 0 < P.basisCount := Nat.lt_of_le_of_lt (Nat.zero_le _) j.isLt
+  have hdom : ‖h.spectral_level ⟨0, hpos⟩‖ = 1 :=
+    h.spectral_level_dom_norm_one hpos
+  have hle : (⟨0, hpos⟩ : Fin P.basisCount) ≤ j :=
+    Fin.mk_le_of_le_val (Nat.zero_le _)
+  have hanti : ‖h.spectral_level j‖ ≤ ‖h.spectral_level ⟨0, hpos⟩‖ :=
+    h.spectral_level_antitone hle
+  rw [hdom] at hanti
+  exact hanti
+
+/-- **Sector coefficient identity** for the equal-modulus layer.
+
+When the equal-modulus factorization is available, the BNT sector
+coefficient `P.coeff N j = ∑_q (μ_{j,q})^N` factors as
+`(λ_j)^N · ∑_q (ν_{j,q})^N`. -/
+lemma coeff_eq_pow_unit_sum (h : HasEqualModulusWeightLayer P)
+    (N : ℕ) (j : Fin P.basisCount) :
+    P.coeff N j =
+      (h.spectral_level j) ^ N *
+        ∑ q : Fin (P.copies j), (h.phase_weight j q) ^ N := by
+  classical
+  unfold SectorDecomposition.coeff SectorWeightData.coeff
+  calc
+    ∑ q : Fin (P.copies j), (P.weight j q) ^ N
+        = ∑ q : Fin (P.copies j),
+            (h.spectral_level j * h.phase_weight j q) ^ N := by
+          refine Finset.sum_congr rfl ?_
+          intro q _
+          rw [h.weight_factor j q]
+    _ = ∑ q : Fin (P.copies j),
+          (h.spectral_level j) ^ N * (h.phase_weight j q) ^ N := by
+          refine Finset.sum_congr rfl ?_
+          intro q _
+          rw [mul_pow]
+    _ = (h.spectral_level j) ^ N *
+          ∑ q : Fin (P.copies j), (h.phase_weight j q) ^ N := by
+          rw [← Finset.mul_sum]
+
+end HasEqualModulusWeightLayer
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
@@ -3,29 +3,37 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
+import TNLean.MPS.FundamentalTheorem.PaperBNT.EqualModulus
 
 /-!
 # Executable examples for `IsBNTCanonicalForm`
 
-This file collects three concrete `SectorDecomposition` constructions and
-instantiates `IsBNTCanonicalForm` on each.  All three examples have a
-single BNT sector (`basisCount = 1`):
+This file collects concrete `SectorDecomposition` constructions and
+instantiates the paper-faithful `IsBNTCanonicalForm` on each.  All three
+core examples have a single BNT basis sector (`basisCount = 1`):
 
 * **Example 1** — single sector, single copy: `weight = (1,)`.
-* **Example 2** — `C ⊕ (-C)`: single sector, two copies with
-  phases `(1, -1)`; the coefficient is `1 + (-1)^N`, which is *not* a
-  scalar power.  This is the CPSV16 §II motivating example recorded in
-  the user's recommendation memo and in issue #1678.
-* **Example 3** — `C ⊕ e^{iθ}C`: single sector, two copies with
-  phases `(1, e^{iθ})`; the coefficient is `1 + e^{iNθ}`, illustrating
-  the equal-modulus grouping that the one-copy specialization cannot
-  represent.
+* **Example 2** — `C ⊕ (-C)`: single sector, two copies with raw weights
+  `(1, -1)`; the coefficient is `1 + (-1)^N`, which is *not* a scalar
+  power.  This is the CPSV16 §II motivating example recorded in the
+  audit memo and in issue #1678.
+* **Example 3** — `C ⊕ e^{iθ}C`: single sector, two copies with raw
+  weights `(1, e^{iθ})`; the coefficient is `1 + e^{iNθ}`, illustrating
+  equal-modulus grouping with a non-trivial phase.
+
+A fourth example exercises the **optional** equal-modulus layer
+`HasEqualModulusWeightLayer` on top of `signFlipDecomp`, demonstrating
+that the equal-modulus subclass is non-empty.  Following the audit
+counter-example `C ⊕ (1/2)C` (`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md`
+§Q4), an analogous decomposition with raw weights `(1, 1/2)` is admitted
+as `IsBNTCanonicalForm` by the same instance shape but cannot be lifted
+to `HasEqualModulusWeightLayer`; a brief commentary block records this.
 
 Each example takes the per-block normality data (injectivity,
 irreducibility, left-canonical, self-overlap, eventual linear
-independence) of `C` as hypotheses; this avoids reproving the
-underlying analytic facts here and keeps the file's focus on
-instantiating the new structure.
+independence) of `C` as hypotheses; this avoids reproving the underlying
+analytic facts here and keeps the file's focus on instantiating the new
+structure.
 -/
 
 open scoped Matrix BigOperators
@@ -52,21 +60,13 @@ variable {d D : ℕ}
 
 /-- **Example 1**: a single BNT sector with a single copy and weight `1`. -/
 noncomputable example
-    (C : MPSTensor d D)
+    (C : MPSTensor d D) (hDpos : 0 < D)
     (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
     IsBNTCanonicalForm (singletonDecomp C) where
-  spectralLevel := fun _ => 1
-  spectralLevel_ne_zero := fun _ => one_ne_zero
-  spectralLevel_strict_anti := by
-    intro a b hab
-    exact absurd (Subsingleton.elim a b) (ne_of_lt hab)
-  spectralLevel_dom_norm_one := fun _ => by simp
-  phaseWeight := fun _ _ => 1
-  phaseWeight_norm_one := fun _ _ => by simp
-  weight_factor := fun _ _ => by simp
+  basis_dim_pos := fun _ => hDpos
   basis_injective := fun _ => hCInj
   basis_irreducible := fun _ => hCIrr
   basis_left_canonical := fun _ => hCLeft
@@ -81,7 +81,8 @@ noncomputable example
 
 /-! ## Example 2 — `C ⊕ (-C)` -/
 
-/-- The single-sector two-copy decomposition of `C` with weights `(1, -1)`. -/
+/-- The single-sector two-copy decomposition of `C` with raw weights
+`(1, -1)`. -/
 @[reducible] noncomputable def signFlipDecomp (C : MPSTensor d D) :
     SectorDecomposition d where
   basisCount := 1
@@ -98,31 +99,17 @@ noncomputable example
         · exact neg_ne_zero.mpr one_ne_zero }
 
 /-- **Example 2** — `C ⊕ (-C)`: a single BNT sector with two copies of
-weights `(1, -1)`.  The sector coefficient is `1 + (-1)^N`, which is
-*not* a scalar power; this is the motivating example of issue #1678. -/
+raw weights `(1, -1)`.  The sector coefficient is `1 + (-1)^N`, which is
+*not* a scalar power; this is the motivating example of issue #1678 and
+the audit memo. -/
 noncomputable example
-    (C : MPSTensor d D)
+    (C : MPSTensor d D) (hDpos : 0 < D)
     (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
     IsBNTCanonicalForm (signFlipDecomp C) where
-  spectralLevel := fun _ => 1
-  spectralLevel_ne_zero := fun _ => one_ne_zero
-  spectralLevel_strict_anti := by
-    intro a b hab
-    exact absurd (Subsingleton.elim a b) (ne_of_lt hab)
-  spectralLevel_dom_norm_one := fun _ => by simp
-  phaseWeight := fun _ q => if q = 0 then (1 : ℂ) else -1
-  phaseWeight_norm_one := by
-    intro _ q
-    split_ifs with hq
-    · simp
-    · simp
-  weight_factor := by
-    intro _ q
-    change (if q = 0 then (1 : ℂ) else -1) = 1 * (if q = 0 then (1 : ℂ) else -1)
-    rw [one_mul]
+  basis_dim_pos := fun _ => hDpos
   basis_injective := fun _ => hCInj
   basis_irreducible := fun _ => hCIrr
   basis_left_canonical := fun _ => hCLeft
@@ -137,8 +124,9 @@ noncomputable example
 
 /-! ## Example 3 — `C ⊕ e^{iθ} C` -/
 
-/-- The single-sector two-copy decomposition of `C` with weights
-`(1, e^{iθ})`, illustrating equal-modulus grouping. -/
+/-- The single-sector two-copy decomposition of `C` with raw weights
+`(1, e^{iθ})`, illustrating equal-modulus grouping with a non-trivial
+phase. -/
 @[reducible] noncomputable def phaseDecomp (C : MPSTensor d D) (θ : ℝ) :
     SectorDecomposition d where
   basisCount := 1
@@ -156,37 +144,16 @@ noncomputable example
         · exact Complex.exp_ne_zero _ }
 
 /-- **Example 3** — `C ⊕ e^{iθ}C`: a single BNT sector with two copies of
-weights `(1, e^{iθ})`.  The sector coefficient is `1 + e^{iNθ}`,
-illustrating the equal-modulus grouping recorded in the user's
-recommendation memo (CPSV16 §II / issue #1678). -/
+raw weights `(1, e^{iθ})`.  The sector coefficient is `1 + e^{iNθ}`,
+illustrating equal-modulus grouping (CPSV16 §II / issue #1678). -/
 noncomputable example
-    (C : MPSTensor d D) (θ : ℝ)
+    (C : MPSTensor d D) (θ : ℝ) (hDpos : 0 < D)
     (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
     IsBNTCanonicalForm (phaseDecomp C θ) where
-  spectralLevel := fun _ => 1
-  spectralLevel_ne_zero := fun _ => one_ne_zero
-  spectralLevel_strict_anti := by
-    intro a b hab
-    exact absurd (Subsingleton.elim a b) (ne_of_lt hab)
-  spectralLevel_dom_norm_one := fun _ => by simp
-  phaseWeight := fun _ q =>
-    if q = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ)
-  phaseWeight_norm_one := by
-    intro _ q
-    split_ifs with hq
-    · simp
-    · -- `‖exp(I · θ)‖ = exp((I · θ).re) = exp 0 = 1` for real `θ`.
-      have hre : (Complex.I * (θ : ℂ)).re = 0 := by
-        simp [Complex.mul_re]
-      rw [Complex.norm_exp, hre, Real.exp_zero]
-  weight_factor := by
-    intro _ q
-    change (if q = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ)) =
-        1 * (if q = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))
-    rw [one_mul]
+  basis_dim_pos := fun _ => hDpos
   basis_injective := fun _ => hCInj
   basis_irreducible := fun _ => hCIrr
   basis_left_canonical := fun _ => hCLeft
@@ -198,6 +165,46 @@ noncomputable example
     exact LinearIndependent.of_subsingleton (i := (0 : Fin 1)) (hN0 N hN)
   basis_distinct := fun j k hjk _ =>
     absurd (Subsingleton.elim j k) hjk
+
+/-! ## Example 4 — equal-modulus weight layer on `signFlipDecomp`
+
+This example exercises the **optional** equal-modulus layer
+`HasEqualModulusWeightLayer` on top of `signFlipDecomp`, demonstrating
+that the equal-modulus subclass is non-empty.
+
+Note (audit §Q4 counter-example): replacing the weight `-1` by `1/2` in
+`signFlipDecomp` would give a decomposition `C ⊕ (1/2)C` that is still a
+valid `IsBNTCanonicalForm` (a single BNT basis tensor with coefficient
+`1 + (1/2)^N` and raw weights `(1, 1/2)`), but it would NOT extend to
+`HasEqualModulusWeightLayer`: the two copies have unequal moduli, so no
+choice of `spectral_level 0` makes both quotients unit-modulus.  The
+equal-modulus layer is therefore strictly stronger than the core BNT
+predicate; this is the central point of the audit. -/
+
+/-- **Example 4** — equal-modulus weight layer on `signFlipDecomp`:
+the factorization `(1, -1) = 1 · (1, -1)` with `spectral_level = 1`
+and `phase_weight = (1, -1)` lifts `signFlipDecomp C` to
+`HasEqualModulusWeightLayer`. -/
+noncomputable example
+    (C : MPSTensor d D) :
+    HasEqualModulusWeightLayer (signFlipDecomp C) where
+  spectral_level := fun _ => 1
+  spectral_level_ne_zero := fun _ => one_ne_zero
+  spectral_level_antitone := by
+    intro a b _
+    simp
+  spectral_level_dom_norm_one := fun _ => by simp
+  phase_weight := fun _ q => if q = 0 then (1 : ℂ) else -1
+  phase_weight_norm_one := by
+    intro _ q
+    split_ifs with hq
+    · simp
+    · simp
+  weight_factor := by
+    intro _ q
+    change (if q = 0 then (1 : ℂ) else -1) =
+        1 * (if q = 0 then (1 : ℂ) else -1)
+    rw [one_mul]
 
 end PaperBNT.Examples
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
+
+/-!
+# Executable examples for `IsBNTCanonicalForm`
+
+This file collects three concrete `SectorDecomposition` constructions and
+instantiates `IsBNTCanonicalForm` on each.  All three examples have a
+single BNT sector (`basisCount = 1`):
+
+* **Example 1** — single sector, single copy: `weight = (1,)`.
+* **Example 2** — `C ⊕ (-C)`: single sector, two copies with
+  phases `(1, -1)`; the coefficient is `1 + (-1)^N`, which is *not* a
+  scalar power.  This is the CPSV16 §II motivating example recorded in
+  the user's recommendation memo and in issue #1678.
+* **Example 3** — `C ⊕ e^{iθ}C`: single sector, two copies with
+  phases `(1, e^{iθ})`; the coefficient is `1 + e^{iNθ}`, illustrating
+  the equal-modulus grouping that the one-copy specialization cannot
+  represent.
+
+Each example takes the per-block normality data (injectivity,
+irreducibility, left-canonical, self-overlap, eventual linear
+independence) of `C` as hypotheses; this avoids reproving the
+underlying analytic facts here and keeps the file's focus on
+instantiating the new structure.
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+namespace PaperBNT.Examples
+
+variable {d D : ℕ}
+
+/-! ## Example 1 — single sector, single copy -/
+
+/-- The trivial single-sector single-copy decomposition of `C`. -/
+@[reducible] noncomputable def singletonDecomp (C : MPSTensor d D) :
+    SectorDecomposition d where
+  basisCount := 1
+  basisDim := fun _ => D
+  basis := fun _ => C
+  sectors :=
+    { copies := fun _ => 1
+      copies_pos := fun _ => Nat.one_pos
+      weight := fun _ _ => 1
+      weight_ne_zero := fun _ _ => one_ne_zero }
+
+/-- **Example 1**: a single BNT sector with a single copy and weight `1`. -/
+noncomputable example
+    (C : MPSTensor d D)
+    (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (hCLeft : IsLeftCanonical C)
+    (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
+    (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
+    IsBNTCanonicalForm (singletonDecomp C) where
+  spectralLevel := fun _ => 1
+  spectralLevel_ne_zero := fun _ => one_ne_zero
+  spectralLevel_strict_anti := by
+    intro a b hab
+    exact absurd (Subsingleton.elim a b) (ne_of_lt hab)
+  spectralLevel_dom_norm_one := fun _ => by simp
+  phaseWeight := fun _ _ => 1
+  phaseWeight_norm_one := fun _ _ => by simp
+  weight_factor := fun _ _ => by simp
+  basis_injective := fun _ => hCInj
+  basis_irreducible := fun _ => hCIrr
+  basis_left_canonical := fun _ => hCLeft
+  basis_normalized_self_overlap := fun _ => hCSelf
+  bnt_data := by
+    classical
+    obtain ⟨N0, hN0⟩ := hCNonzero
+    refine ⟨N0, fun N hN => ?_⟩
+    exact LinearIndependent.of_subsingleton (i := (0 : Fin 1)) (hN0 N hN)
+  basis_distinct := fun j k hjk _ =>
+    absurd (Subsingleton.elim j k) hjk
+
+/-! ## Example 2 — `C ⊕ (-C)` -/
+
+/-- The single-sector two-copy decomposition of `C` with weights `(1, -1)`. -/
+@[reducible] noncomputable def signFlipDecomp (C : MPSTensor d D) :
+    SectorDecomposition d where
+  basisCount := 1
+  basisDim := fun _ => D
+  basis := fun _ => C
+  sectors :=
+    { copies := fun _ => 2
+      copies_pos := fun _ => Nat.succ_pos 1
+      weight := fun _ q => if q = 0 then (1 : ℂ) else -1
+      weight_ne_zero := by
+        intro _ q
+        split_ifs with hq
+        · exact one_ne_zero
+        · exact neg_ne_zero.mpr one_ne_zero }
+
+/-- **Example 2** — `C ⊕ (-C)`: a single BNT sector with two copies of
+weights `(1, -1)`.  The sector coefficient is `1 + (-1)^N`, which is
+*not* a scalar power; this is the motivating example of issue #1678. -/
+noncomputable example
+    (C : MPSTensor d D)
+    (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (hCLeft : IsLeftCanonical C)
+    (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
+    (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
+    IsBNTCanonicalForm (signFlipDecomp C) where
+  spectralLevel := fun _ => 1
+  spectralLevel_ne_zero := fun _ => one_ne_zero
+  spectralLevel_strict_anti := by
+    intro a b hab
+    exact absurd (Subsingleton.elim a b) (ne_of_lt hab)
+  spectralLevel_dom_norm_one := fun _ => by simp
+  phaseWeight := fun _ q => if q = 0 then (1 : ℂ) else -1
+  phaseWeight_norm_one := by
+    intro _ q
+    split_ifs with hq
+    · simp
+    · simp
+  weight_factor := by
+    intro _ q
+    change (if q = 0 then (1 : ℂ) else -1) = 1 * (if q = 0 then (1 : ℂ) else -1)
+    rw [one_mul]
+  basis_injective := fun _ => hCInj
+  basis_irreducible := fun _ => hCIrr
+  basis_left_canonical := fun _ => hCLeft
+  basis_normalized_self_overlap := fun _ => hCSelf
+  bnt_data := by
+    classical
+    obtain ⟨N0, hN0⟩ := hCNonzero
+    refine ⟨N0, fun N hN => ?_⟩
+    exact LinearIndependent.of_subsingleton (i := (0 : Fin 1)) (hN0 N hN)
+  basis_distinct := fun j k hjk _ =>
+    absurd (Subsingleton.elim j k) hjk
+
+/-! ## Example 3 — `C ⊕ e^{iθ} C` -/
+
+/-- The single-sector two-copy decomposition of `C` with weights
+`(1, e^{iθ})`, illustrating equal-modulus grouping. -/
+@[reducible] noncomputable def phaseDecomp (C : MPSTensor d D) (θ : ℝ) :
+    SectorDecomposition d where
+  basisCount := 1
+  basisDim := fun _ => D
+  basis := fun _ => C
+  sectors :=
+    { copies := fun _ => 2
+      copies_pos := fun _ => Nat.succ_pos 1
+      weight := fun _ q =>
+        if q = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ)
+      weight_ne_zero := by
+        intro _ q
+        split_ifs with hq
+        · exact one_ne_zero
+        · exact Complex.exp_ne_zero _ }
+
+/-- **Example 3** — `C ⊕ e^{iθ}C`: a single BNT sector with two copies of
+weights `(1, e^{iθ})`.  The sector coefficient is `1 + e^{iNθ}`,
+illustrating the equal-modulus grouping recorded in the user's
+recommendation memo (CPSV16 §II / issue #1678). -/
+noncomputable example
+    (C : MPSTensor d D) (θ : ℝ)
+    (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (hCLeft : IsLeftCanonical C)
+    (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
+    (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
+    IsBNTCanonicalForm (phaseDecomp C θ) where
+  spectralLevel := fun _ => 1
+  spectralLevel_ne_zero := fun _ => one_ne_zero
+  spectralLevel_strict_anti := by
+    intro a b hab
+    exact absurd (Subsingleton.elim a b) (ne_of_lt hab)
+  spectralLevel_dom_norm_one := fun _ => by simp
+  phaseWeight := fun _ q =>
+    if q = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ)
+  phaseWeight_norm_one := by
+    intro _ q
+    split_ifs with hq
+    · simp
+    · -- `‖exp(I · θ)‖ = exp((I · θ).re) = exp 0 = 1` for real `θ`.
+      have hre : (Complex.I * (θ : ℂ)).re = 0 := by
+        simp [Complex.mul_re]
+      rw [Complex.norm_exp, hre, Real.exp_zero]
+  weight_factor := by
+    intro _ q
+    change (if q = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ)) =
+        1 * (if q = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))
+    rw [one_mul]
+  basis_injective := fun _ => hCInj
+  basis_irreducible := fun _ => hCIrr
+  basis_left_canonical := fun _ => hCLeft
+  basis_normalized_self_overlap := fun _ => hCSelf
+  bnt_data := by
+    classical
+    obtain ⟨N0, hN0⟩ := hCNonzero
+    refine ⟨N0, fun N hN => ?_⟩
+    exact LinearIndependent.of_subsingleton (i := (0 : Fin 1)) (hN0 N hN)
+  basis_distinct := fun j k hjk _ =>
+    absurd (Subsingleton.elim j k) hjk
+
+end PaperBNT.Examples
+end MPSTensor


### PR DESCRIPTION
Refs: #1678, #1641, #1683 (plan)

## Phase 1 of the paper-faithful clean-slate plan

This PR delivers the new primary BNT canonical-form structure built **from scratch** with **zero reference** to the retired one-copy `IsCanonicalFormBNT`. Per the user's directives in #1678:
* No adapter from the one-copy surface.
* No `_CFBNT` suffix.
* No `mu : Fin r → ℂ` parameter.
* Built on `SectorDecomposition` (already multi-copy).

## What's in this PR

### New module: `TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean` (185 LoC)

```lean
structure IsBNTCanonicalForm (P : SectorDecomposition d) where
  spectralLevel : Fin P.basisCount → ℂ
  spectralLevel_ne_zero, spectralLevel_strict_anti, spectralLevel_dom_norm_one
  phaseWeight : (j : Fin P.basisCount) → Fin (P.copies j) → ℂ
  phaseWeight_norm_one
  weight_factor : ∀ j q, P.weight j q = spectralLevel j * phaseWeight j q
  basis_injective, basis_irreducible, basis_left_canonical
  basis_normalized_self_overlap
  bnt_data : HasBNTSectorData P
  basis_distinct : ∀ j k, j ≠ k → ∀ h : P.basisDim j = P.basisDim k,
    ¬ GaugePhaseEquiv (cast _ (P.basis j)) (P.basis k)
```

Convenience accessors:
- `spectralLevel_norm_le_one` (from strict_anti + dom_norm_one)
- `phaseWeight_ne_zero` (from norm_one)
- `weight_ne_zero_from_factor`
- `coeff_eq_pow_unit_sum` — the MPV decomposition coefficient

### New module: `TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean` (203 LoC)

Three concrete examples validating the structure on the user-recommended cases:
1. **singletonDecomp**: one sector, one copy.
2. **signFlipDecomp**: `C ⊕ -C` (one sector, two copies, phases `(1, -1)`). Demonstrates the `1 + (-1)^N` coefficient that defeats the one-copy specialization.
3. **phaseDecomp**: `C ⊕ e^{iθ}C` (one sector, two copies, equal-modulus phases).

Each example takes per-block normality as hypotheses and constructs a full `IsBNTCanonicalForm` instance without any `sorry`/`axiom`.

### Wire imports
`TNLean.lean` gets two new `import` lines.

## Design deviation from plan

The plan specified `IsBNTCanonicalForm ... : Prop`. Lean 4 cannot host data fields (`spectralLevel`, `phaseWeight`) in `Prop`. The structure is `Type`-valued instead. This matches what the existing `IsBNTCanonicalFormSD` works around with an existential. The user explicitly asked for raw fields, so the `Type` rendering is correct.

## What this PR does NOT do (per plan)

- Does NOT touch any module in `Full/`, `SectorDecomposition/`, `RFP/`, `ParentHamiltonian/`, `PiAlgebra/`.
- Does NOT add any adapter from `IsCanonicalFormBNT`.
- Does NOT delete anything yet. Deletions follow in Phase 7 after all consumers are ported.

## Build verification

- `lake build TNLean.MPS.FundamentalTheorem.PaperBNT.Basic` ✅
- `lake build TNLean.MPS.FundamentalTheorem.PaperBNT.Examples` ✅
- `lake build TNLean` ✅ (8682/8682 jobs)
- No new `sorry`/`axiom`/`unsafe`.
- No reference to `IsCanonicalFormBNT` (verified via grep).

## Coordination with parallel audit (gpt55)

A parallel multiplicity audit (execution `5b169d3f0347`) is in flight, asking 13 questions about subtle multiplicity correctness vs CPSV16/CPSV21. If it identifies amendments, this PR will be amended on the same branch before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive: introduces new canonical-form structures and example constructions, and only wires them into the root import surface. Risk is limited to potential downstream breakage from the new public API and increased root-import dependency footprint.
> 
> **Overview**
> Adds a new `PaperBNT` canonical-form surface: `IsBNTCanonicalForm` over `SectorDecomposition`, intentionally **dropping any equal-modulus/strict spectral ordering assumptions** on raw sector weights and adding a supporting lemma `coeff_not_eventually_zero` for coefficient-comparison arguments.
> 
> Introduces an **optional** `HasEqualModulusWeightLayer` that factors weights into `spectral_level` and unit-modulus `phase_weight`, with helper lemmas (nonzero phase, `‖spectral_level‖ ≤ 1`, and coefficient factorization).
> 
> Adds `PaperBNT/Examples.lean` with concrete sector decompositions (`C`, `C ⊕ (-C)`, `C ⊕ e^{iθ}C`) instantiating `IsBNTCanonicalForm`, plus an example instantiating the optional equal-modulus layer, and wires `PaperBNT.Basic`/`PaperBNT.Examples` into the root `TNLean.lean` import list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb70241f10b72ae42781fff5d3df0b0cf755576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->