### PR TITLE
feat(MPS/FT/PaperBNT): basic API for paper-faithful BNT canonical form (#1686)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -236,6 +236,8 @@ import TNLean.MPS.FundamentalTheorem.SectorDecomposition.RenormalizedNonCancella
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.CrossFamilyRateDecay
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition.RateQuantifiedDischarge
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
+import TNLean.MPS.FundamentalTheorem.PaperBNT.EqualModulus
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Api
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Examples
 import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.FundamentalTheorem

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
+import TNLean.MPS.BNT.Basic
+import TNLean.MPS.Overlap.CastDecay
+import TNLean.Spectral.SpectralGapNT
+
+/-!
+# Paper-faithful BNT canonical form: basic API
+
+This module supplies the elementary downstream API for the paper-faithful
+core predicate `IsBNTCanonicalForm` introduced in
+`PaperBNT/Basic.lean`.  All lemmas here use the **raw** sector data
+`P.weight j q` and `P.coeff N j = ∑_q (P.weight j q)^N`; no equal-modulus
+factorisation is assumed.  The optional `HasEqualModulusWeightLayer`
+specialisation lives in `PaperBNT/EqualModulus.lean` and is intentionally
+not imported here.
+
+## API
+
+* `coeff_eq_sum_weight_pow` — definitional unfolding
+  `P.coeff N j = ∑_q (P.weight j q)^N`
+  (CPSV16 lines 287–301; CPSV21 lines 1864–1884).
+* `norm_coeff_le_copies_of_norm_weight_le_one` — bound the sector
+  coefficient by the multiplicity when every copy has unit-or-less
+  modulus (CPSV16 lines 287–301 with the optional normalization
+  convention of lines 217–246).
+* `cross_overlap_basis_tendsto_zero` — cross-overlap between distinct
+  basis blocks decays, dispatched by bond-dimension equality
+  (CPSV16 lines 1080–1091; CPSV16 lines 264–279).
+* `combined_family_eventually_li` — combined-family eventual linear
+  independence for two paper-faithful BNT canonical forms with mutually
+  vanishing cross-overlaps (CPSV16 corollary `Lem1`, lines 1121–1132;
+  CPSV21 line 1850 BNT linear-independence input).
+
+## References
+
+* CPSV16: Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608.
+  Lines 217–246 (optional global modulus normalization), 264–279
+  (gauge-phase sector grouping), 287–301 (raw two-layer BNT display),
+  349–352 (`thm1`), 1080–1091 (normal-tensor overlap dichotomy),
+  1121–1132 (`Lem1`, combined-family eventual linear independence).
+* CPSV21: Cirac–Pérez-García–Schuch–Verstraete, arXiv:2011.12127.
+  Lines 1846–1884 (BNT and two-layer BNT decomposition with raw
+  `μ_{j,q}`).
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+namespace IsBNTCanonicalForm
+
+variable {P Q : SectorDecomposition d}
+
+/-- **Raw two-layer sector coefficient identity** (definitional).
+
+CPSV16 lines 287–301 and CPSV21 lines 1864–1884 specify the BNT sector
+coefficient as the raw power sum `∑_q (μ_{j,q})^N` over the copies of
+the `j`-th basis block.  In our formalisation `P.coeff N j` is exactly
+this sum, so the identity is by `rfl` after unfolding the abbreviations. -/
+lemma coeff_eq_sum_weight_pow (P : SectorDecomposition d)
+    (N : ℕ) (j : Fin P.basisCount) :
+    P.coeff N j = ∑ q : Fin (P.copies j), (P.weight j q) ^ N := rfl
+
+/-- **Sector coefficient bound by multiplicity** under a unit-or-less
+modulus hypothesis on every copy weight.
+
+CPSV16 lines 287–301 give the raw coefficient `∑_q (μ_{j,q})^N`.  When
+the optional global normalization of CPSV16 lines 217–246 (or any
+other unit-bound on the raw weights) is in force, `‖μ_{j,q}‖ ≤ 1` for
+every `q`, and the triangle inequality bounds the norm of the
+coefficient by the multiplicity `r_j`.  This lemma does not require the
+full `HasEqualModulusWeightLayer` factorisation; it only consumes a
+direct bound on the raw weights. -/
+lemma norm_coeff_le_copies_of_norm_weight_le_one
+    (P : SectorDecomposition d) (N : ℕ) (j : Fin P.basisCount)
+    (hWeightLe : ∀ q : Fin (P.copies j), ‖P.weight j q‖ ≤ 1) :
+    ‖P.coeff N j‖ ≤ (P.copies j : ℝ) := by
+  classical
+  have hsum :
+      ‖∑ q : Fin (P.copies j), (P.weight j q) ^ N‖
+        ≤ ∑ q : Fin (P.copies j), ‖(P.weight j q) ^ N‖ :=
+    norm_sum_le _ _
+  have hPow : ∀ q : Fin (P.copies j),
+      ‖(P.weight j q) ^ N‖ ≤ 1 := by
+    intro q
+    have hbound := hWeightLe q
+    have hnn : (0 : ℝ) ≤ ‖P.weight j q‖ := norm_nonneg _
+    have hpow : ‖P.weight j q‖ ^ N ≤ 1 ^ N :=
+      pow_le_pow_left₀ hnn hbound N
+    simpa [norm_pow, one_pow] using hpow
+  have hSumBound :
+      (∑ q : Fin (P.copies j), ‖(P.weight j q) ^ N‖)
+        ≤ ∑ _q : Fin (P.copies j), (1 : ℝ) :=
+    Finset.sum_le_sum (fun q _ => hPow q)
+  have hCard :
+      (∑ _q : Fin (P.copies j), (1 : ℝ)) = (P.copies j : ℝ) := by
+    simp
+  calc
+    ‖P.coeff N j‖
+        = ‖∑ q : Fin (P.copies j), (P.weight j q) ^ N‖ := by
+          rw [coeff_eq_sum_weight_pow]
+    _ ≤ ∑ q : Fin (P.copies j), ‖(P.weight j q) ^ N‖ := hsum
+    _ ≤ ∑ _q : Fin (P.copies j), (1 : ℝ) := hSumBound
+    _ = (P.copies j : ℝ) := hCard
+
+/-- **Cross-overlap between distinct basis blocks decays.**
+
+For any two distinct basis indices `j ≠ k` of a paper-faithful BNT
+canonical form, the MPV overlap `mpvOverlap (P.basis j) (P.basis k) N`
+tends to `0` as `N → ∞`.
+
+The dispatch follows CPSV16 lines 1080–1091 (the normal-tensor overlap
+dichotomy):
+
+* if `P.basisDim j ≠ P.basisDim k`, decay follows from
+  `mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP`;
+* if the bond dimensions agree, the `basis_distinct` field of
+  `IsBNTCanonicalForm` rules out gauge-phase equivalence in the
+  cast-compatible shape, and decay follows from
+  `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`
+  (CPSV16 lines 264–279 gauge-phase sector grouping). -/
+lemma cross_overlap_basis_tendsto_zero
+    (h : IsBNTCanonicalForm P) {j k : Fin P.basisCount} (hjk : j ≠ k) :
+    Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis j) (P.basis k) N)
+      atTop (𝓝 0) := by
+  haveI hjpos : NeZero (P.basisDim j) := ⟨(h.basis_dim_pos j).ne'⟩
+  haveI hkpos : NeZero (P.basisDim k) := ⟨(h.basis_dim_pos k).ne'⟩
+  by_cases hdim : P.basisDim j = P.basisDim k
+  · exact mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP
+      (hdim := hdim) (A := P.basis j) (B := P.basis k)
+      (hA_irr := h.basis_irreducible j)
+      (hB_irr := h.basis_irreducible k)
+      (hA_norm := h.basis_left_canonical j)
+      (hB_norm := h.basis_left_canonical k)
+      (hNot := h.basis_distinct j k hjk hdim)
+  · exact mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP
+      (P.basis j) (P.basis k)
+      (h.basis_irreducible j) (h.basis_irreducible k)
+      (h.basis_left_canonical j) (h.basis_left_canonical k)
+      hdim
+
+/-- **Combined-family eventual linear independence** for two
+paper-faithful BNT canonical forms with mutually vanishing cross-overlaps.
+
+This is the paper-faithful instantiation of the corollary `Lem1`
+(CPSV16 lines 1121–1132): once the cross-overlaps between the two BNT
+families vanish, the union of basis MPV states is linearly independent
+for all sufficiently large lengths.  CPSV21 line 1850 states the same
+linear-independence input as part of the BNT definition.
+
+The proof feeds the per-family normalised self-overlaps, the
+within-family cross-decay supplied by
+`cross_overlap_basis_tendsto_zero`, and the inter-family decay
+hypothesis `hAB` into
+`eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal`
+(`TNLean/MPS/BNT/Basic.lean`). -/
+lemma combined_family_eventually_li
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hAB : ∀ (j : Fin P.basisCount) (k : Fin Q.basisCount),
+      Tendsto (fun N : ℕ =>
+        mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0)) :
+    ∀ᶠ N in atTop,
+      LinearIndependent ℂ
+        (Sum.elim
+          (fun j : Fin P.basisCount => mpvState (d := d) (P.basis j) N)
+          (fun k : Fin Q.basisCount => mpvState (d := d) (Q.basis k) N)) :=
+  eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal
+    (A := P.basis) (B := Q.basis)
+    (hA_self := hP.basis_normalized_self_overlap)
+    (hA_off := fun _ _ hij => hP.cross_overlap_basis_tendsto_zero hij)
+    (hB_self := hQ.basis_normalized_self_overlap)
+    (hB_off := fun _ _ hk => hQ.cross_overlap_basis_tendsto_zero hk)
+    (hAB := hAB)
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
@@ -8,9 +8,9 @@ import TNLean.MPS.Overlap.CastDecay
 import TNLean.Spectral.SpectralGapNT
 
 /-!
-# Paper-faithful BNT canonical form: basic API
+# Paper-faithful BNT canonical form: basic lemmas
 
-This module supplies the elementary downstream API for the paper-faithful
+This module provides the elementary lemmas for the paper-faithful
 core predicate `IsBNTCanonicalForm` introduced in
 `PaperBNT/Basic.lean`.  All lemmas here use the **raw** sector data
 `P.weight j q` and `P.coeff N j = ∑_q (P.weight j q)^N`; no equal-modulus
@@ -18,30 +18,30 @@ factorisation is assumed.  The optional `HasEqualModulusWeightLayer`
 specialisation lives in `PaperBNT/EqualModulus.lean` and is intentionally
 not imported here.
 
-## API
+## Contents
 
-* `coeff_eq_sum_weight_pow` — definitional unfolding
+* `SectorDecomposition.coeff_eq_sum_weight_pow` — definitional unfolding
   `P.coeff N j = ∑_q (P.weight j q)^N`
   (CPSV16 lines 287–301; CPSV21 lines 1864–1884).
-* `norm_coeff_le_copies_of_norm_weight_le_one` — bound the sector
-  coefficient by the multiplicity when every copy has unit-or-less
-  modulus (CPSV16 lines 287–301 with the optional normalization
-  convention of lines 217–246).
-* `cross_overlap_basis_tendsto_zero` — cross-overlap between distinct
-  basis blocks decays, dispatched by bond-dimension equality
+* `SectorDecomposition.norm_coeff_le_copies_of_norm_weight_le_one` — bound
+  the sector coefficient by the multiplicity when every copy has unit-or-less
+  modulus (CPSV16 lines 287–301 with the optional normalization convention
+  of lines 217–246).
+* `IsBNTCanonicalForm.cross_overlap_basis_tendsto_zero` — cross-overlap
+  between distinct basis blocks decays, dispatched by bond-dimension equality
   (CPSV16 lines 1080–1091; CPSV16 lines 264–279).
-* `combined_family_eventually_li` — combined-family eventual linear
-  independence for two paper-faithful BNT canonical forms with mutually
-  vanishing cross-overlaps (CPSV16 corollary `Lem1`, lines 1121–1132;
-  CPSV21 line 1850 BNT linear-independence input).
+* `IsBNTCanonicalForm.combined_family_eventually_li` — combined-family
+  eventual linear independence for two paper-faithful BNT canonical forms
+  with mutually vanishing cross-overlaps (CPSV16 corollary Lem1,
+  lines 1121–1132; CPSV21 line 1850 BNT linear-independence input).
 
 ## References
 
 * CPSV16: Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608.
   Lines 217–246 (optional global modulus normalization), 264–279
   (gauge-phase sector grouping), 287–301 (raw two-layer BNT display),
-  349–352 (`thm1`), 1080–1091 (normal-tensor overlap dichotomy),
-  1121–1132 (`Lem1`, combined-family eventual linear independence).
+  349–352 (thm1), 1080–1091 (normal-tensor overlap dichotomy),
+  1121–1132 (Lem1, combined-family eventual linear independence).
 * CPSV21: Cirac–Pérez-García–Schuch–Verstraete, arXiv:2011.12127.
   Lines 1846–1884 (BNT and two-layer BNT decomposition with raw
   `μ_{j,q}`).
@@ -54,9 +54,7 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-namespace IsBNTCanonicalForm
-
-variable {P Q : SectorDecomposition d}
+namespace SectorDecomposition
 
 /-- **Raw two-layer sector coefficient identity** (definitional).
 
@@ -110,6 +108,12 @@ lemma norm_coeff_le_copies_of_norm_weight_le_one
     _ ≤ ∑ _q : Fin (P.copies j), (1 : ℝ) := hSumBound
     _ = (P.copies j : ℝ) := hCard
 
+end SectorDecomposition
+
+namespace IsBNTCanonicalForm
+
+variable {P Q : SectorDecomposition d}
+
 /-- **Cross-overlap between distinct basis blocks decays.**
 
 For any two distinct basis indices `j ≠ k` of a paper-faithful BNT
@@ -149,18 +153,17 @@ lemma cross_overlap_basis_tendsto_zero
 /-- **Combined-family eventual linear independence** for two
 paper-faithful BNT canonical forms with mutually vanishing cross-overlaps.
 
-This is the paper-faithful instantiation of the corollary `Lem1`
+This is the paper-faithful instantiation of corollary Lem1
 (CPSV16 lines 1121–1132): once the cross-overlaps between the two BNT
 families vanish, the union of basis MPV states is linearly independent
 for all sufficiently large lengths.  CPSV21 line 1850 states the same
 linear-independence input as part of the BNT definition.
 
 The proof feeds the per-family normalised self-overlaps, the
-within-family cross-decay supplied by
-`cross_overlap_basis_tendsto_zero`, and the inter-family decay
-hypothesis `hAB` into
+within-family cross-decay from `cross_overlap_basis_tendsto_zero`, and
+the inter-family decay hypothesis into
 `eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal`
-(`TNLean/MPS/BNT/Basic.lean`). -/
+(`TNLean.MPS.BNT.Basic`, line 195). -/
 lemma combined_family_eventually_li
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hAB : ∀ (j : Fin P.basisCount) (k : Fin Q.basisCount),

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -629,7 +629,7 @@ and~\cite{Cirac2021Matrix}.
 
 This section records the basic API for the paper-faithful BNT canonical-form
 predicate \texttt{IsBNTCanonicalForm} of
-\cite[\S II, lines 287--301]{Cirac2017Matrix} and
+\cite[\S II, lines 287--301]{Cirac2017MPDO_AnnPhys} and
 \cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.  The predicate
 operates on a \texttt{SectorDecomposition} carrying raw sector weights
 \(\mu_{j,q}\) and a coefficient
@@ -646,7 +646,7 @@ factorization is assumed.
 		P.\operatorname{coeff}\,N\,j \;=\;
 		\sum_{q=1}^{r_j} (P.\operatorname{weight}\,j\,q)^N.
 	\]
-	This is \cite[eq.~II, lines 287--301]{Cirac2017Matrix} and
+	This is \cite[eq.~II, lines 287--301]{Cirac2017MPDO_AnnPhys} and
 	\cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.
 \end{lemma}
 
@@ -660,7 +660,7 @@ factorization is assumed.
 	\leanok
 	\uses{lem:paper_bnt_coeff_eq_sum_weight_pow}
 	Under the optional global modulus normalization
-	\cite[\S II, lines 217--246]{Cirac2017Matrix}, every raw weight satisfies
+	\cite[\S II, lines 217--246]{Cirac2017MPDO_AnnPhys}, every raw weight satisfies
 	\(\lVert\mu_{j,q}\rVert \le 1\), and the triangle inequality bounds
 	the norm of the sector coefficient by the multiplicity:
 	\[
@@ -683,10 +683,10 @@ factorization is assumed.
 	then \(O_{P_j P_k}(N) \to 0\) as \(N \to \infty\), where \(P_j\) and
 	\(P_k\) are the basis blocks at indices \(j\) and \(k\).  The dispatch
 	follows the normal-tensor overlap dichotomy of
-	\cite[lines 1080--1091]{Cirac2017Matrix}: differing bond dimensions
+	\cite[lines 1080--1091]{Cirac2017MPDO_AnnPhys}: differing bond dimensions
 	force decay, and matching bond dimensions are ruled out by the
 	gauge-phase distinctness clause of
-	\cite[lines 264--279]{Cirac2017Matrix}.
+	\cite[lines 264--279]{Cirac2017MPDO_AnnPhys}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -716,7 +716,7 @@ factorization is assumed.
 	\]
 	is linearly independent for all sufficiently large~\(N\).  This is the
 	paper-faithful instantiation of the corollary~Lem1 of
-	\cite[lines 1121--1132]{Cirac2017Matrix} and matches the BNT
+	\cite[lines 1121--1132]{Cirac2017MPDO_AnnPhys} and matches the BNT
 	linear-independence input recorded at
 	\cite[line 1850]{Cirac2021Matrix}.
 \end{lemma}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -623,3 +623,108 @@ and~\cite{Cirac2021Matrix}.
 	The BNT multiplicity lemmas handle this recovery directly rather than through
 	a separate explicit-coefficient equal-case theorem.
 \end{remark}
+
+\section{Paper-faithful BNT canonical form: basic API}
+\label{sec:paper_bnt_api}
+
+This section records the basic API for the paper-faithful BNT canonical-form
+predicate \texttt{IsBNTCanonicalForm} of
+\cite[\S II, lines 287--301]{Cirac2017Matrix} and
+\cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.  The predicate
+operates on a \texttt{SectorDecomposition} carrying raw sector weights
+\(\mu_{j,q}\) and a coefficient
+\(\operatorname{coeff} N\,j = \sum_q \mu_{j,q}^{\,N}\); no equal-modulus
+factorization is assumed.
+
+\begin{lemma}[Raw two-layer sector coefficient identity]%
+	\label{lem:paper_bnt_coeff_eq_sum_weight_pow}
+	\lean{MPSTensor.IsBNTCanonicalForm.coeff_eq_sum_weight_pow}
+	\leanok
+	For every sector decomposition \(P\), every length \(N\), and every basis
+	index \(j\), the sector coefficient is the raw power sum
+	\[
+		P.\operatorname{coeff}\,N\,j \;=\;
+		\sum_{q=1}^{r_j} (P.\operatorname{weight}\,j\,q)^N.
+	\]
+	This is \cite[eq.~II, lines 287--301]{Cirac2017Matrix} and
+	\cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.
+\end{lemma}
+
+\begin{proof}\leanok
+	Definitional unfolding of \texttt{SectorDecomposition.coeff}.
+\end{proof}
+
+\begin{lemma}[Sector coefficient bound by multiplicity]%
+	\label{lem:paper_bnt_norm_coeff_le_copies}
+	\lean{MPSTensor.IsBNTCanonicalForm.norm_coeff_le_copies_of_norm_weight_le_one}
+	\leanok
+	\uses{lem:paper_bnt_coeff_eq_sum_weight_pow}
+	Under the optional global modulus normalization
+	\cite[\S II, lines 217--246]{Cirac2017Matrix}, every raw weight satisfies
+	\(\lVert\mu_{j,q}\rVert \le 1\), and the triangle inequality bounds
+	the norm of the sector coefficient by the multiplicity:
+	\[
+		\lVert P.\operatorname{coeff}\,N\,j \rVert \;\le\; r_j.
+	\]
+\end{lemma}
+
+\begin{proof}\leanok
+	Apply the triangle inequality to the raw power sum from
+	Lemma~\ref{lem:paper_bnt_coeff_eq_sum_weight_pow} and bound each term by
+	\(1\) using \(\lVert\mu_{j,q}\rVert \le 1\).
+\end{proof}
+
+\begin{lemma}[Cross-overlap decay between distinct basis blocks]%
+	\label{lem:paper_bnt_cross_overlap_basis_tendsto_zero}
+	\lean{MPSTensor.IsBNTCanonicalForm.cross_overlap_basis_tendsto_zero}
+	\leanok
+	\uses{def:mpv_overlap}
+	If \(P\) carries a paper-faithful BNT canonical form and \(j \neq k\),
+	then \(O_{P_j P_k}(N) \to 0\) as \(N \to \infty\), where \(P_j\) and
+	\(P_k\) are the basis blocks at indices \(j\) and \(k\).  The dispatch
+	follows the normal-tensor overlap dichotomy of
+	\cite[lines 1080--1091]{Cirac2017Matrix}: differing bond dimensions
+	force decay, and matching bond dimensions are ruled out by the
+	gauge-phase distinctness clause of
+	\cite[lines 264--279]{Cirac2017Matrix}.
+\end{lemma}
+
+\begin{proof}\leanok
+	Case on \texttt{basisDim j = basisDim k}.  If the dimensions differ,
+	apply the dimension-mismatch overlap-decay theorem
+	\texttt{mpvOverlap\_tendsto\_zero\_of\_dim\_ne\_of\_irreducible\_TP}.
+	If they agree, the \texttt{basis\_distinct} field of
+	\texttt{IsBNTCanonicalForm} rules out gauge-phase equivalence in the
+	cast-compatible shape, so the equal-dimension overlap-decay theorem
+	\texttt{mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP}
+	applies.
+\end{proof}
+
+\begin{lemma}[Combined-family eventual linear independence]%
+	\label{lem:paper_bnt_combined_family_eventually_li}
+	\lean{MPSTensor.IsBNTCanonicalForm.combined_family_eventually_li}
+	\leanok
+	\uses{lem:bnt_two_family_overlap_orthonormal_li,
+		lem:paper_bnt_cross_overlap_basis_tendsto_zero}
+	Let \(P\) and \(Q\) each carry a paper-faithful BNT canonical form, and
+	suppose every mixed overlap \(O_{P_j Q_k}(N)\) tends to~\(0\).  Then the
+	union family
+	\[
+		\bigl\{\ket{V^{(N)}(P_j)}\bigr\}_{j=1}^{g_P}
+		\cup
+		\bigl\{\ket{V^{(N)}(Q_k)}\bigr\}_{k=1}^{g_Q}
+	\]
+	is linearly independent for all sufficiently large~\(N\).  This is the
+	paper-faithful instantiation of the corollary~Lem1 of
+	\cite[lines 1121--1132]{Cirac2017Matrix} and matches the BNT
+	linear-independence input recorded at
+	\cite[line 1850]{Cirac2021Matrix}.
+\end{lemma}
+
+\begin{proof}\leanok
+	Feed the per-family normalized self-overlaps (from the canonical-form
+	data), the within-family cross-overlap decay
+	(Lemma~\ref{lem:paper_bnt_cross_overlap_basis_tendsto_zero}), and the
+	inter-family decay hypothesis into the two-family overlap-orthonormality
+	criterion (Lemma~\ref{lem:bnt_two_family_overlap_orthonormal_li}).
+\end{proof}


### PR DESCRIPTION
Adds PaperBNT/Api.lean with four basic lemmas on the paper-faithful core `IsBNTCanonicalForm`. Raw `P.weight` / `P.coeff` only (no spectralLevel/phaseWeight). Closes #1686.

## Summary

New file: `TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean` (188 lines).

Four new lemmas:

1. `SectorDecomposition.coeff_eq_sum_weight_pow` — definitional unfolding `P.coeff N j = ∑_q (P.weight j q)^N` (CPSV16 lines 287–301).
2. `SectorDecomposition.norm_coeff_le_copies_of_norm_weight_le_one` — bounds the sector coefficient by the multiplicity under `‖weight‖ ≤ 1`.
3. `IsBNTCanonicalForm.cross_overlap_basis_tendsto_zero` — distinct basis blocks have decaying MPV overlap (CPSV16 lines 1080–1091).
4. `IsBNTCanonicalForm.combined_family_eventually_li` — paper-faithful instantiation of CPSV16 Lem1 (lines 1121–1132).

## Review fixes (commit 3de47c76)

**Cursor bugbot (namespace correctness):**
- Moved `coeff_eq_sum_weight_pow` and `norm_coeff_le_copies_of_norm_weight_le_one`
  from `namespace IsBNTCanonicalForm` to `namespace SectorDecomposition`.
  Neither lemma consumes an `IsBNTCanonicalForm` hypothesis; placing them in
  `IsBNTCanonicalForm` was misleading.  The two lemmas for cross-overlap decay
  and combined-family linear independence correctly remain in `IsBNTCanonicalForm`
  since both take an `IsBNTCanonicalForm` argument.

**Prose cleanup:**
- Replaced banned 'API' (×3) with 'basic lemmas' / 'Contents'.
- Removed 'downstream' (software pipeline metaphor).
- Dropped backtick formatting from paper-internal labels thm1 and Lem1.
- Removed proof-script variable name `hAB` from declaration docstring.
- Replaced file-path reference with qualified module name.
- Updated Contents list to use fully-qualified names.

## Hard constraints met

* ✅ No reference to `IsCanonicalFormBNT`.
* ✅ Raw `P.weight` / `P.coeff` only (no spectralLevel/phaseWeight).
* ✅ No new `sorry` / `axiom` / `unsafe`.

## Build verification

* `lake build TNLean.MPS.FundamentalTheorem.PaperBNT.Api` ✅
* `lake build TNLean` ✅