### PR TITLE
docs(PiAlgebra): migrate canonical-form docstring references to IsBNTCanonicalForm (#1690)

### DIFF
--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -601,8 +601,8 @@ lemma per_block_sameMPV_of_separated_canonical_data
 /-- Reformulation extracting per-block `SameMPV` from canonical-form data with a strict
 ordering witness. The strict ordering is not part of `IsCanonicalForm` (which only guarantees
 non-increasing moduli); it must be supplied by the caller via `StrictAnti (fun k => ‖μ k‖)`.
-The paper-faithful BNT surface `IsBNTCanonicalForm` (`MPS/FundamentalTheorem/PaperBNT/Basic.lean`)
-uses sector multiplicities and deliberately omits a strict-ordering field. -/
+The paper-faithful predicate `IsBNTCanonicalForm` uses sector multiplicities and deliberately
+omits a strict-ordering field. -/
 lemma per_block_sameMPV_of_canonical_form
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -599,8 +599,10 @@ lemma per_block_sameMPV_of_separated_canonical_data
       (summed_block_difference_eq_zero_of_sameMPV₂ μ A B hSame₂)
 
 /-- Reformulation extracting per-block `SameMPV` from canonical-form data with a strict
-ordering witness. The strict ordering is available at the BNT level (`IsCanonicalFormBNT.mu_strict_anti`)
-but not from the base `IsCanonicalForm` which only guarantees non-increasing moduli. -/
+ordering witness. The strict ordering is not part of `IsCanonicalForm` (which only guarantees
+non-increasing moduli); it must be supplied by the caller via `StrictAnti (fun k => ‖μ k‖)`.
+The paper-faithful BNT surface `IsBNTCanonicalForm` (`MPS/FundamentalTheorem/PaperBNT/Basic.lean`)
+uses sector multiplicities and deliberately omits a strict-ordering field. -/
 lemma per_block_sameMPV_of_canonical_form
     (μ : Fin r → ℂ)
     (A B : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -227,9 +227,8 @@ end HasNormalizedSelfOverlap
 
 The weight ordering is `Antitone` (non-increasing by modulus), matching the paper definitions
 (PGVWC07, Cirac--Perez-Garcia--Schuch--Verstraete 2021) which allow blocks with equal moduli. The strictly decreasing variant
-is a one-copy-per-sector artifact; the paper-faithful `IsBNTCanonicalForm`
-(`MPS/FundamentalTheorem/PaperBNT/Basic.lean`) uses sector multiplicities and does not require
-strict ordering. -/
+is a one-copy-per-sector artifact; the paper-faithful predicate `IsBNTCanonicalForm` uses sector
+multiplicities and does not require strict ordering. -/
 structure IsCanonicalForm {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) : Prop where
   /-- Each block is algebraically injective (`span (range (A k)) = ⊤`). -/

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -227,7 +227,9 @@ end HasNormalizedSelfOverlap
 
 The weight ordering is `Antitone` (non-increasing by modulus), matching the paper definitions
 (PGVWC07, Cirac--Perez-Garcia--Schuch--Verstraete 2021) which allow blocks with equal moduli. The strictly decreasing variant
-is enforced at the BNT level (`IsCanonicalFormBNT`) after the grouping step. -/
+is a one-copy-per-sector artifact; the paper-faithful `IsBNTCanonicalForm`
+(`MPS/FundamentalTheorem/PaperBNT/Basic.lean`) uses sector multiplicities and does not require
+strict ordering. -/
 structure IsCanonicalForm {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) : Prop where
   /-- Each block is algebraically injective (`span (range (A k)) = ⊤`). -/


### PR DESCRIPTION
## Summary

This PR updates two docstring-only narrative references in the `PiAlgebra` modules to point at the paper-faithful `IsBNTCanonicalForm` surface (`MPS/FundamentalTheorem/PaperBNT/Basic.lean`) in place of the legacy `IsCanonicalFormBNT` name.

Closes the docstring-migration scope of #1690 for these two files per the consumer scout audit `audits/2026-05-14_cpsv16_phase6_consumer_scout.md`.

## Files changed

- `TNLean/PiAlgebra/CanonicalFormSep.lean` (line 601–605): the docstring for `per_block_sameMPV_of_canonical_form` previously said the strict ordering witness is available at the BNT level via `IsCanonicalFormBNT.mu_strict_anti`. The new text explains that the strict ordering is not part of `IsCanonicalForm` and must be supplied by the caller, and that the paper-faithful `IsBNTCanonicalForm` deliberately omits a strict-ordering field in favour of sector multiplicities.

- `TNLean/PiAlgebra/CanonicalFormSepAux.lean` (line 229–232): the docstring for `IsCanonicalForm` previously attributed the strictly decreasing variant to the BNT level via `IsCanonicalFormBNT`. The new text characterises it as a one-copy-per-sector artifact and points readers at `IsBNTCanonicalForm` for the paper-faithful multi-copy surface.

## Scope confirmation

```
grep -nE 'IsCanonicalFormBNT|IsBNTCanonicalForm' TNLean/PiAlgebra/CanonicalFormSep*.lean
```

Before: 2 hits, both `IsCanonicalFormBNT` inside `/-- ... -/` docblocks.  
After: 2 hits, both `IsBNTCanonicalForm` inside `/-- ... -/` docblocks.  
No actual code, signatures, or proof terms were changed.

## No sorry / axiom / unsafe

Changes are documentation-only.

## Related

- Issue #1690 (CPSV16 paper-faithful FT programme)
- Audit memo: `audits/2026-05-14_cpsv16_phase6_consumer_scout.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits that adjust narrative references around strict weight ordering; no code, signatures, or proof terms change.
> 
> **Overview**
> Updates docstrings in `CanonicalFormSep.lean` and `CanonicalFormSepAux.lean` to stop referring to the legacy `IsCanonicalFormBNT` name and instead reference the paper-faithful `IsBNTCanonicalForm`.
> 
> Clarifies in documentation that strict weight ordering is *not* provided by `IsCanonicalForm` and must be supplied separately (or obtained via the BNT grouping/multiplicity viewpoint), without changing any underlying logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97efa72ae329548f35b1cd97ecd12528288e7e1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->