### PR TITLE
feat(MPS/FT/PaperBNT): strengthen IsBNTCanonicalForm with CPSV16 line-246 normalization (#1716)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
@@ -34,6 +34,10 @@ not imported here.
   eventual linear independence for two paper-faithful BNT canonical forms
   with mutually vanishing cross-overlaps (CPSV16 corollary Lem1,
   lines 1121–1132; CPSV21 line 1850 BNT linear-independence input).
+* `IsBNTCanonicalForm.norm_coeff_le_copies` — the structural-field reading
+  of the multiplicity bound (CPSV16 line 246 via `weight_norm_le_one`).
+* `IsBNTCanonicalForm.weight_unit_exists_of_struct` — the existential
+  unit-modulus witness re-exposed at the API layer (CPSV16 line 246).
 
 ## References
 
@@ -181,6 +185,31 @@ lemma combined_family_eventually_li
     (hB_self := hQ.basis_normalized_self_overlap)
     (hB_off := fun _ _ hk => hQ.cross_overlap_basis_tendsto_zero hk)
     (hAB := hAB)
+
+/-- **Coefficient norm bound under the canonical-form line-246
+normalization.**
+
+A direct consequence of the structural field `weight_norm_le_one`
+(CPSV16 §II.A line 246): under the paper-faithful canonical form, the
+sector coefficient `P.coeff N j = ∑_q (P.weight j q)^N` is bounded in
+modulus by the multiplicity `P.copies j`.  This is the structural-field
+reading of the prior explicit-hypothesis lemma
+`SectorDecomposition.norm_coeff_le_copies_of_norm_weight_le_one`. -/
+lemma norm_coeff_le_copies
+    (h : IsBNTCanonicalForm P) (N : ℕ) (j : Fin P.basisCount) :
+    ‖P.coeff N j‖ ≤ (P.copies j : ℝ) :=
+  P.norm_coeff_le_copies_of_norm_weight_le_one (N := N) (j := j)
+    (hWeightLe := h.weight_norm_le_one j)
+
+/-- **Unit-modulus weight witness from the canonical-form line-246
+normalization.**
+
+Re-exposes the structural field `weight_unit_exists` (CPSV16 §II.A
+line 246) at the API layer for downstream callers that want to extract a
+unit-modulus weight without depending on the structure layout. -/
+lemma weight_unit_exists_of_struct (h : IsBNTCanonicalForm P) :
+    ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
+      ‖P.weight j q‖ = 1 := h.weight_unit_exists
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
@@ -22,17 +22,23 @@ a `SectorDecomposition`.  It records:
 * **eventual linear independence** of basis MPV states (`HasBNTSectorData`);
 * **block distinctness** in the cast-compatible gauge-phase shape, ruling out
   gauge-phase equivalence between distinct basis blocks of equal bond
-  dimension.
+  dimension;
+* the CPSV16 §II.A line-246 **normalization convention** on the raw sector
+  weights `μ_{j,q}`: `|μ_{j,q}| ≤ 1` and at least one of them equals one
+  (lines 246 and 1244).
 
 Crucially, the structure does **not** impose an equal-modulus or strict-order
 condition on the raw sector weights `P.weight j q`.  CPSV16
 `eq:II_ABasicTensors` (line 286) and CPSV21 Definition 4.3 (lines 1846–1884)
 use raw entries `μ_{j,q}` and a coefficient `∑_q μ_{j,q}^N`; they do not
 require `|μ_{j,q}|` to be constant in `q`, nor do they impose a strict order
-on the moduli of distinct BNT basis elements.  See the audit memo
-`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` for the
-counter-examples (`C ⊕ D`, `C ⊕ (1/2)C`, `C ⊕ (-C) ⊕ (1/2)C`) that motivated
-removing the equal-modulus layer from this core predicate.
+on the moduli of distinct BNT basis elements.  The audit memo
+`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` collects
+the counter-examples (`C ⊕ D`, `C ⊕ (1/2)C`, `C ⊕ (-C) ⊕ (1/2)C`) that
+motivate keeping the equal-modulus layer out of the core predicate; all of
+them are admitted by the line-246 normalization fields below (every weight
+has modulus `≤ 1`, and at least one copy of one basis sector has unit
+modulus).
 
 An optional equal-modulus weight layer is provided separately as
 `HasEqualModulusWeightLayer` in `PaperBNT/EqualModulus.lean`.  Some
@@ -120,6 +126,27 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
     ∀ h : P.basisDim j = P.basisDim k,
       ¬ GaugePhaseEquiv
           (cast (congr_arg (MPSTensor d) h) (P.basis j)) (P.basis k)
+  /-- **CPSV16 line-246 normalization, modulus bound.**  Every raw sector
+  weight has modulus at most one.  CPSV16 §II.A line 246: "we can always
+  choose `|μ_k| ≤ 1`"; reinvoked in the body of the FT proof at line 1244
+  ("the assumed normalization `|μ_{jq}| ≤ 1` … implies that `𝔼^N` converges").
+  This convention admits all counter-examples of the prior audit
+  (`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md`):
+  `C ⊕ D` (weights `(1, 1)`), `C ⊕ (-C)` (weights `(1, -1)`),
+  `C ⊕ (1/2)C` (weights `(1, 1/2)`), and `C ⊕ (-C) ⊕ (1/2)C`. -/
+  weight_norm_le_one : ∀ (j : Fin P.basisCount) (q : Fin (P.copies j)),
+    ‖P.weight j q‖ ≤ 1
+  /-- **CPSV16 line-246 normalization, unit-witness existence.**  At least
+  one copy of one basis sector has unit-modulus weight.  CPSV16 §II.A
+  line 246: "at least one of them equals one, something which we will
+  assume from now on"; used in the FT proof at line 1244 (the assumed
+  normalization makes the transfer-matrix-power sequence converge, picking
+  out the dominant block).  This is the existential form of the paper's
+  convention; relabelling sectors so the unit-modulus copy sits in
+  sector 0 specialises it to the index-0 reading used in the FT
+  dominant-block projection (CPSV16 lines 1181–1188). -/
+  weight_unit_exists : ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
+    ‖P.weight j q‖ = 1
 
 namespace IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
@@ -32,19 +32,31 @@ The module has three layers:
 ## Hypothesis disclosure (paper-faithful)
 
 The dominant-pair matching at the **fixed** index `⟨0, hP_pos⟩` does not
-follow from the core `IsBNTCanonicalForm` data alone: the core predicate is
-deliberately invariant under relabelling of sectors and does not single out
-a dominant sector.  Lemma 3 therefore explicitly assumes the **CPSV16
-lines 217–246** global modulus normalization data, in two parts:
+follow from the core seven-field `IsBNTCanonicalForm` data alone: the core
+seven fields are deliberately invariant under relabelling of sectors and do
+not single out a dominant sector.  Following the CPSV16 §II.A line-246
+normalization convention, `IsBNTCanonicalForm` now carries two additional
+structural fields:
 
-* `(hP_norm hQ_norm : ∀ … ‖weight‖ ≤ 1)` — every raw weight has unit-or-less
-  modulus after the CPSV16 lines 217–246 normalisation;
-* `(hP_dom_coeff_not_tendsto_zero : ¬ Tendsto (P.coeff · ⟨0, hP_pos⟩) atTop (𝓝 0))`
-  — the dominant sector coefficient does not asymptotically vanish.  This is
-  the paper-faithful reading of "block `0` is dominant"
-  (CPSV16 lines 234–246) without committing to the equal-modulus weight
-  factorisation `HasEqualModulusWeightLayer`; it captures exactly what the
-  CPSV16 dominant-block projection argument needs.
+* `weight_norm_le_one : ∀ j q, ‖weight j q‖ ≤ 1`  — CPSV16 line 246, the
+  modulus bound.  Lemma 3 below feeds this in via `hP.weight_norm_le_one`
+  and `hQ.weight_norm_le_one`, replacing the prior explicit `hP_norm /
+  hQ_norm` parameters.
+* `weight_unit_exists : ∃ j q, ‖weight j q‖ = 1`  — CPSV16 line 246,
+  the unit-modulus existential.
+
+The remaining external hypothesis on Lemma 3,
+`(hP_dom_coeff_not_tendsto_zero : ¬ Tendsto (P.coeff · ⟨0, hP_pos⟩) atTop (𝓝 0))`,
+records that the **dominant sector**'s coefficient does not asymptotically
+vanish.  This is the index-0 reading of the existential
+`weight_unit_exists`; deriving the index-0 form from the existential would
+require relabelling sectors so the unit-modulus copy sits in sector 0
+together with a Bohr/Kronecker–Weyl non-decay argument for power-sums of
+unit-modulus complex numbers (CPSV16 lines 1181–1188 paper-side; see also
+the audit memos `extra_hypotheses_audit_2026-05-14` §Q2 and
+`thermodynamic_limit_normalization_audit_2026-05-14` §Q-C).  The general
+non-decay result is tracked separately and will replace this explicit
+parameter once available.
 
 These hypotheses are weaker than the legacy `IsCanonicalFormBNT` package
 (which baked in `mu_strict_anti` + a single per-sector "spectral level"
@@ -173,10 +185,6 @@ theorem exists_dominant_match_of_sameMPV
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hP_pos : 0 < P.basisCount) (hQ_pos : 0 < Q.basisCount)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor)
-    (hP_norm : ∀ (j : Fin P.basisCount) (q : Fin (P.copies j)),
-      ‖P.weight j q‖ ≤ 1)
-    (hQ_norm : ∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
-      ‖Q.weight k q‖ ≤ 1)
     (hP_dom_coeff_not_tendsto_zero :
       ¬ Tendsto (fun N : ℕ => P.coeff N ⟨0, hP_pos⟩) atTop (𝓝 0)) :
     ∃ k₀ : Fin Q.basisCount,
@@ -193,6 +201,11 @@ theorem exists_dominant_match_of_sameMPV
   -- the contradiction route below also forces it, so it is recorded but not
   -- used directly in the proof.
   have _hQ_pos_used : 0 < Q.basisCount := hQ_pos
+  -- Derive the CPSV16 line-246 modulus bounds from the strengthened
+  -- `IsBNTCanonicalForm` predicate; these used to be explicit parameters
+  -- `hP_norm / hQ_norm` and have been folded into the structure.
+  have hP_norm := hP.weight_norm_le_one
+  have hQ_norm := hQ.weight_norm_le_one
   set j₀ : Fin P.basisCount := ⟨0, hP_pos⟩ with hj₀_def
   -- Step 1: extract some k₀ with non-decaying overlap to `P.basis j₀`.
   have hExists_k :

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
@@ -142,11 +142,11 @@ theorem exists_nondecaying_overlap_pair_of_sameMPV
 
 /-! ### Lemma 3: dominant-pair matching at the fixed index `0`
 
-The main result of Phase 4b-ii: under `SameMPV₂` plus the CPSV16
-lines 217–246 normalisation data (and the dominant-coefficient non-decay
-hypothesis), the dominant block `P.basis ⟨0, hP_pos⟩` of `P` has a `Q`-side
-match `Q.basis k₀` of equal bond dimension, gauge-phase equivalent in the
-cast-left shape, and with a non-decaying cross-overlap.
+The main result of Phase 4b-ii: under `SameMPV₂` plus the dominant-block
+coefficient non-decay assumption, the dominant block `P.basis ⟨0, hP_pos⟩`
+of `P` has a `Q`-side match `Q.basis k₀` of equal bond dimension,
+gauge-phase equivalent in the cast-left shape, and with a non-decaying
+cross-overlap.
 
 The proof is a direct read of the CPSV16 lines 1172–1188 dominant-block
 projection: assume by contradiction that **all** cross-overlaps
@@ -158,12 +158,15 @@ the dominant `P`-block).
   is `P.coeff N ⟨0, _⟩ + (small)` thanks to:
   – `basis_normalized_self_overlap` at `j = 0` (`overlap → 1`);
   – `cross_overlap_basis_tendsto_zero` at `j ≠ 0` (`overlap → 0`);
-  – `norm_coeff_le_copies_of_norm_weight_le_one` (`Api.lean`) gives the
-    coefficient bound `‖P.coeff N j‖ ≤ P.copies j` from `hP_norm`.
+  – the structural field `weight_norm_le_one` of `IsBNTCanonicalForm`
+    (CPSV16 §II.A line 246) feeds into
+    `norm_coeff_le_copies_of_norm_weight_le_one` (`Api.lean`) and gives
+    the coefficient bound `‖P.coeff N j‖ ≤ P.copies j`.
 
 * The RHS = `∑_k Q.coeff N k · overlap(Q.basis k, P.basis ⟨0, _⟩) N`
   vanishes asymptotically, again by coefficient boundedness from
-  `hQ_norm` and the contrapositive assumption that all `k`-overlaps decay.
+  `hQ.weight_norm_le_one` and the contrapositive assumption that all
+  `k`-overlaps decay.
 
 * `SameMPV₂` makes both sides equal, so `P.coeff N ⟨0, _⟩` tends to `0`,
   contradicting `hP_dom_coeff_not_tendsto_zero`.
@@ -174,11 +177,15 @@ contrapositive of
 gauge-phase equivalence, via the contrapositive of
 `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`.
 
-Hypothesis disclosure: the extra normalisation hypotheses `hP_norm`,
-`hQ_norm`, and `hP_dom_coeff_not_tendsto_zero` are NOT part of
-`IsBNTCanonicalForm` (the core predicate is deliberately label-invariant).
-They are the paper-faithful reading of CPSV16 lines 217–246 and 234–246;
-see the module docstring above for the design rationale.
+Hypothesis disclosure: the modulus bounds `weight_norm_le_one` are part
+of the strengthened `IsBNTCanonicalForm` predicate (CPSV16 §II.A
+line 246) and need not be supplied externally.  The non-decay hypothesis
+`hP_dom_coeff_not_tendsto_zero` is the index-0 specialisation of the
+structural field `weight_unit_exists`; its derivation requires a
+Bohr/Kronecker–Weyl non-decay step for unit-modulus power sums (audit
+memo `extra_hypotheses_audit_2026-05-14` §Q2,
+`thermodynamic_limit_normalization_audit_2026-05-14` §Q-C) and is tracked
+as a follow-up.
 -/
 theorem exists_dominant_match_of_sameMPV
     {P Q : SectorDecomposition d}
@@ -201,11 +208,11 @@ theorem exists_dominant_match_of_sameMPV
   -- the contradiction route below also forces it, so it is recorded but not
   -- used directly in the proof.
   have _hQ_pos_used : 0 < Q.basisCount := hQ_pos
-  -- Derive the CPSV16 line-246 modulus bounds from the strengthened
-  -- `IsBNTCanonicalForm` predicate; these used to be explicit parameters
-  -- `hP_norm / hQ_norm` and have been folded into the structure.
-  have hP_norm := hP.weight_norm_le_one
-  have hQ_norm := hQ.weight_norm_le_one
+  -- Derive the CPSV16 §II.A line-246 modulus bounds from the strengthened
+  -- `IsBNTCanonicalForm` predicate.  The structural fields replace what
+  -- used to be supplied as explicit parameters at the call site.
+  have hP_weight_le := hP.weight_norm_le_one
+  have hQ_weight_le := hQ.weight_norm_le_one
   set j₀ : Fin P.basisCount := ⟨0, hP_pos⟩ with hj₀_def
   -- Step 1: extract some k₀ with non-decaying overlap to `P.basis j₀`.
   have hExists_k :
@@ -269,7 +276,7 @@ theorem exists_dominant_match_of_sameMPV
       refine squeeze_zero_norm (fun N => ?_) hBound
       have hC :=
         P.norm_coeff_le_copies_of_norm_weight_le_one (N := N) (j := j)
-          (hWeightLe := hP_norm j)
+          (hWeightLe := hP_weight_le j)
       calc
         ‖P.coeff N j * mpvOverlap (d := d) (P.basis j) (P.basis j₀) N‖
             = ‖P.coeff N j‖ *
@@ -311,7 +318,7 @@ theorem exists_dominant_match_of_sameMPV
       refine squeeze_zero_norm (fun N => ?_) hBound
       have hC :=
         P.norm_coeff_le_copies_of_norm_weight_le_one (N := N) (j := j₀)
-          (hWeightLe := hP_norm j₀)
+          (hWeightLe := hP_weight_le j₀)
       calc
         ‖P.coeff N j₀ *
             (mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1)‖
@@ -389,7 +396,7 @@ theorem exists_dominant_match_of_sameMPV
       refine squeeze_zero_norm (fun N => ?_) hBound
       have hC :=
         Q.norm_coeff_le_copies_of_norm_weight_le_one (N := N) (j := k)
-          (hWeightLe := hQ_norm k)
+          (hWeightLe := hQ_weight_le k)
       calc
         ‖Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N‖
             = ‖Q.coeff N k‖ *

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DropSector.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DropSector.lean
@@ -210,12 +210,23 @@ Every field of the paper-faithful canonical-form predicate transfers from
 * `basis_distinct` transfers because the reindexing map is injective, so
   pairs of distinct basis indices on the dropped decomposition correspond
   to pairs of distinct basis indices on the original (CPSV16 lines 264–279
-  gauge-phase grouping rule).
+  gauge-phase grouping rule);
+* `weight_norm_le_one` (CPSV16 line 246, modulus bound) transfers
+  pointwise after reindexing;
+* `weight_unit_exists` (CPSV16 line 246, unit-modulus witness) is the
+  only non-pointwise field: dropping the sector that carried the unique
+  unit-modulus weight would destroy the existential witness, so the
+  caller must supply a unit-modulus witness on the *remaining*
+  decomposition.  In the CPSV16 §II `II_cor2` induction this is the
+  normalization step that re-orients the next-dominant block; the
+  `hUnitRem` hypothesis below records that step abstractly.
 
 This is the foundational lemma for the CPSV16 §II `II_cor2` induction step
 (lines 1172–1192). -/
 def dropSector
-    (hP : IsBNTCanonicalForm P) (h : P.basisCount = n + 1) (i₀ : Fin (n + 1)) :
+    (hP : IsBNTCanonicalForm P) (h : P.basisCount = n + 1) (i₀ : Fin (n + 1))
+    (hUnitRem : ∃ (j : Fin n) (q : Fin ((P.dropSector h i₀).copies j)),
+      ‖(P.dropSector h i₀).weight j q‖ = 1) :
     IsBNTCanonicalForm (P.dropSector h i₀) where
   basis_dim_pos _ := hP.basis_dim_pos _
   basis_injective _ := hP.basis_injective _
@@ -263,6 +274,16 @@ def dropSector
     exact hP.basis_distinct
       (Fin.cast h.symm (i₀.succAbove j)) (Fin.cast h.symm (i₀.succAbove k))
       hjk' hdim
+  weight_norm_le_one := by
+    -- Pointwise: a copy of the dropped decomposition corresponds to a copy
+    -- of the original at the reindexed sector position.
+    intro j q
+    have := hP.weight_norm_le_one (Fin.cast h.symm (i₀.succAbove j))
+    -- `(P.dropSector h i₀).weight j q = P.weight (Fin.cast h.symm (i₀.succAbove j)) q`
+    -- after the corresponding `Fin.cast` of `q`.
+    simpa [SectorDecomposition.dropSector_weight,
+           SectorDecomposition.dropSector_copies] using this _
+  weight_unit_exists := hUnitRem
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
@@ -20,14 +20,19 @@ core examples have a single BNT basis sector (`basisCount = 1`):
 * **Example 3** — `C ⊕ e^{iθ}C`: single sector, two copies with raw
   weights `(1, e^{iθ})`; the coefficient is `1 + e^{iNθ}`, illustrating
   equal-modulus grouping with a non-trivial phase.
+* **Example 5** — `C ⊕ (1/2)C` (`halvedDecomp`): single sector, two
+  copies with raw weights `(1, 1/2)`.  Demonstrates that unequal-modulus
+  copies are admissible by the CPSV16 §II.A line-246 normalization
+  (`weight_norm_le_one` holds because both `1` and `1/2` have modulus
+  `≤ 1`; `weight_unit_exists` is witnessed by the first copy).
 
 A fourth example exercises the **optional** equal-modulus layer
 `HasEqualModulusWeightLayer` on top of `signFlipDecomp`, demonstrating
 that the equal-modulus subclass is non-empty.  Following the audit
 counter-example `C ⊕ (1/2)C` (`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md`
-§Q4), an analogous decomposition with raw weights `(1, 1/2)` is admitted
-as `IsBNTCanonicalForm` by the same instance shape but cannot be lifted
-to `HasEqualModulusWeightLayer`; a brief commentary block records this.
+§Q4), the `halvedDecomp` construction below admits `IsBNTCanonicalForm`
+but does not admit `HasEqualModulusWeightLayer` (its two copies have
+unequal moduli, ruling out a single per-sector spectral level).
 
 Each example takes the per-block normality data (injectivity,
 irreducibility, left-canonical, self-overlap, eventual linear
@@ -78,6 +83,16 @@ noncomputable example
     exact LinearIndependent.of_subsingleton (i := (0 : Fin 1)) (hN0 N hN)
   basis_distinct := fun j k hjk _ =>
     absurd (Subsingleton.elim j k) hjk
+  -- CPSV16 line 246: the unique weight `μ = 1` has `‖μ‖ = 1 ≤ 1`.
+  weight_norm_le_one := by
+    intro _ _
+    change ‖(1 : ℂ)‖ ≤ 1
+    simp
+  -- CPSV16 line 246: the unique weight is the unit-modulus witness.
+  weight_unit_exists := by
+    refine ⟨0, 0, ?_⟩
+    change ‖(1 : ℂ)‖ = 1
+    simp
 
 /-! ## Example 2 — `C ⊕ (-C)` -/
 
@@ -121,6 +136,18 @@ noncomputable example
     exact LinearIndependent.of_subsingleton (i := (0 : Fin 1)) (hN0 N hN)
   basis_distinct := fun j k hjk _ =>
     absurd (Subsingleton.elim j k) hjk
+  -- CPSV16 line 246: both weights `(1, -1)` have unit modulus.
+  weight_norm_le_one := by
+    intro _ q
+    change ‖(if q = 0 then (1 : ℂ) else -1)‖ ≤ 1
+    split_ifs with hq
+    · simp
+    · simp
+  -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
+  weight_unit_exists := by
+    refine ⟨0, 0, ?_⟩
+    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else -1)‖ = 1
+    simp
 
 /-! ## Example 3 — `C ⊕ e^{iθ} C` -/
 
@@ -165,6 +192,24 @@ noncomputable example
     exact LinearIndependent.of_subsingleton (i := (0 : Fin 1)) (hN0 N hN)
   basis_distinct := fun j k hjk _ =>
     absurd (Subsingleton.elim j k) hjk
+  -- CPSV16 line 246: both weights `(1, exp(I·θ))` have unit modulus.
+  weight_norm_le_one := by
+    intro _ q
+    -- Unfold the `phaseDecomp.weight` to its `if`.
+    change ‖(if q = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ ≤ 1
+    split_ifs with hq
+    · simp
+    · -- `‖exp (I·θ)‖ = 1`; here `θ` is a real (cast to ℂ).
+      rw [Complex.norm_exp]
+      have : (Complex.I * ↑θ).re = 0 := by
+        simp [Complex.mul_re]
+      rw [this]
+      simp
+  -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
+  weight_unit_exists := by
+    refine ⟨0, 0, ?_⟩
+    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ = 1
+    simp
 
 /-! ## Example 4 — equal-modulus weight layer on `signFlipDecomp`
 
@@ -205,6 +250,83 @@ noncomputable example
     change (if q = 0 then (1 : ℂ) else -1) =
         1 * (if q = 0 then (1 : ℂ) else -1)
     rw [one_mul]
+
+/-! ## Example 5 — `C ⊕ (1/2)C`, unequal-modulus admissibility
+
+This example demonstrates that the strengthened `IsBNTCanonicalForm`
+predicate (with the CPSV16 §II.A line-246 fields `weight_norm_le_one`
+and `weight_unit_exists`) admits decompositions whose copies have
+**unequal** moduli: the construction below has one unit-modulus copy
+and one `1/2`-modulus copy.  This is exactly the
+`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` §Q4
+counter-example, here written as a positive example: the strengthened
+predicate is paper-faithful (line 246 verbatim) and admits the example.
+
+The decomposition does NOT admit `HasEqualModulusWeightLayer`: the
+optional equal-modulus layer of `PaperBNT/EqualModulus.lean` would
+require a single per-sector `spectral_level` with all phase weights of
+unit modulus, which fails here because `|1| ≠ |1/2|`. -/
+
+/-- The single-sector two-copy decomposition of `C` with raw weights
+`(1, 1/2)`, demonstrating admissibility of unequal-modulus copies. -/
+@[reducible] noncomputable def halvedDecomp (C : MPSTensor d D) :
+    SectorDecomposition d where
+  basisCount := 1
+  basisDim := fun _ => D
+  basis := fun _ => C
+  sectors :=
+    { copies := fun _ => 2
+      copies_pos := fun _ => Nat.succ_pos 1
+      weight := fun _ q => if q = 0 then (1 : ℂ) else (1 / 2 : ℂ)
+      weight_ne_zero := by
+        intro _ q
+        split_ifs with hq
+        · exact one_ne_zero
+        · norm_num }
+
+/-- **Example 5** — `C ⊕ (1/2)C`: a single BNT sector with two copies of
+raw weights `(1, 1/2)`.  The sector coefficient is `1 + (1/2)^N → 1`,
+not a scalar power.  Demonstrates that the strengthened
+`IsBNTCanonicalForm` admits unequal-modulus copies: `weight_norm_le_one`
+holds because `‖1‖ ≤ 1` and `‖1/2‖ = 1/2 ≤ 1`, and `weight_unit_exists`
+is witnessed by the first copy with weight `1`.
+
+Paper anchor: CPSV16 §II.A line 246, the line-246 normalization
+convention permits any `|μ_{j,q}| ≤ 1` provided at least one of them
+equals `1`.  See also
+`audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` §Q4
+for the original counter-example. -/
+noncomputable example
+    (C : MPSTensor d D) (hDpos : 0 < D)
+    (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (hCLeft : IsLeftCanonical C)
+    (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
+    (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
+    IsBNTCanonicalForm (halvedDecomp C) where
+  basis_dim_pos := fun _ => hDpos
+  basis_injective := fun _ => hCInj
+  basis_irreducible := fun _ => hCIrr
+  basis_left_canonical := fun _ => hCLeft
+  basis_normalized_self_overlap := fun _ => hCSelf
+  bnt_data := by
+    classical
+    obtain ⟨N0, hN0⟩ := hCNonzero
+    refine ⟨N0, fun N hN => ?_⟩
+    exact LinearIndependent.of_subsingleton (i := (0 : Fin 1)) (hN0 N hN)
+  basis_distinct := fun j k hjk _ =>
+    absurd (Subsingleton.elim j k) hjk
+  -- CPSV16 line 246: `‖1‖ = 1 ≤ 1` and `‖1/2‖ = 1/2 ≤ 1`.
+  weight_norm_le_one := by
+    intro _ q
+    change ‖(if q = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ ≤ 1
+    split_ifs with hq
+    · simp
+    · simp; norm_num
+  -- CPSV16 line 246: the first copy `q = 0` carries the unit weight.
+  weight_unit_exists := by
+    refine ⟨0, 0, ?_⟩
+    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
+    simp
 
 end PaperBNT.Examples
 end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -648,9 +648,16 @@ factorization is assumed.
 	each basis block has positive bond dimension, is injective,
 	irreducible, and left-canonical; the normalized self-overlap of every
 	basis block converges to~\(1\); the basis MPV family is eventually
-	linearly independent (\texttt{HasBNTSectorData}); and distinct
+	linearly independent (\texttt{HasBNTSectorData}); distinct
 	same-dimension basis blocks are not gauge-phase equivalent in the
-	cast-compatible shape.  The MPV expansion takes the raw two-layer form
+	cast-compatible shape; and the CPSV16 \S II.A line-246 normalization
+	convention holds, namely
+	\[
+		\lVert \mu_{j,q} \rVert \le 1 \;\text{for every}\; (j,q),
+		\qquad
+		\exists\, (j_*, q_*) :\; \lVert \mu_{j_*, q_*} \rVert = 1.
+	\]
+	The MPV expansion takes the raw two-layer form
 	\[
 		V^{(N)}(P)_\sigma
 		\;=\;
@@ -659,6 +666,10 @@ factorization is assumed.
 	\]
 	matching \cite[\S~II, lines 271--301]{Cirac2017MPDO_AnnPhys}
 	and \cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.
+	The line-246 normalization fields admit every paper-faithful example
+	(in particular \(C \oplus D\), \(C \oplus (-C)\),
+	\(C \oplus (1/2) C\), and \(C \oplus (-C) \oplus (1/2) C\)) and are
+	NOT derivable from the per-block normality data alone.
 \end{definition}
 
 \begin{lemma}[Raw two-layer sector coefficient identity]%
@@ -866,17 +877,21 @@ following file.
 	\leanok
 	\uses{def:paper_sector_data, def:paper_bnt_cf}
 	If \(P\) carries a paper-faithful BNT canonical form
-	(\texttt{IsBNTCanonicalForm}~\(P\)) and \(P.\texttt{basisCount} = n+1\),
-	then for every index \(i_0 \in \{0,\dotsc,n\}\) the dropped
-	decomposition \(P.\texttt{dropSector}\,h\,i_0\) also carries a
-	paper-faithful BNT canonical form.  Every pointwise field (bond
-	dimension positivity, injectivity, irreducibility, left-canonical form,
-	normalized self-overlap) transfers by evaluation at the reindexed
-	position; eventual linear independence transfers via
-	\texttt{LinearIndependent.comp} applied to the injective
+	(\texttt{IsBNTCanonicalForm}~\(P\)) with \(P.\texttt{basisCount} = n+1\),
+	if \(i_0 \in \{0,\dotsc,n\}\) is the index to drop, and if the
+	dropped decomposition retains a unit-modulus weight (\texttt{hUnitRem})
+	—~i.e.\ the CPSV16 \S II.A line-246 unit-witness convention survives the
+	drop—~then \(P.\texttt{dropSector}\,h\,i_0\) carries a paper-faithful BNT
+	canonical form.  Every pointwise field (bond dimension positivity,
+	injectivity, irreducibility, left-canonical form, normalized self-overlap,
+	and the modulus bound \(\lVert\mu_{j,q}\rVert \le 1\)) transfers by
+	evaluation at the reindexed position; eventual linear independence
+	transfers via \texttt{LinearIndependent.comp} applied to the injective
 	\(\texttt{Fin.succAbove}\) embedding
-	(\cite[Definition~4.3, line 1850]{Cirac2021Matrix});
-	block distinctness transfers because the reindexing is injective.
+	(\cite[Definition~4.3, line 1850]{Cirac2021Matrix}); block distinctness
+	transfers because the reindexing is injective; and the unit-witness
+	existential is supplied by \texttt{hUnitRem} (faithful to the CPSV16
+	renormalization step at each induction iteration).
 	This is the foundational induction step of
 	\cite[\S~II, \texttt{II\_cor2}, lines 1172--1192]{Cirac2017MPDO_AnnPhys}
 	and \cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -765,6 +765,58 @@ factorization is assumed.
 	criterion (Lemma~\ref{lem:bnt_two_family_overlap_orthonormal_li}).
 \end{proof}
 
+\begin{lemma}[Sector coefficient bound from the line-246 structural field]%
+	\label{lem:paper_bnt_norm_coeff_le_copies_struct}
+	\lean{MPSTensor.IsBNTCanonicalForm.norm_coeff_le_copies}
+	\leanok
+	\uses{def:paper_bnt_cf, lem:paper_bnt_norm_coeff_le_copies}
+	Under the strengthened paper-faithful canonical form, the structural
+	field \texttt{weight\_norm\_le\_one} (CPSV16 \S II.A line~246) yields
+	directly
+	\[
+		\lVert P.\operatorname{coeff}\,N\,j \rVert \;\le\; r_j
+	\]
+	for every \(N\) and basis index~\(j\), without an additional
+	explicit modulus-bound hypothesis at the call site.
+\end{lemma}
+
+\begin{proof}\leanok
+	Feed the structural field \texttt{weight\_norm\_le\_one} into
+	Lemma~\ref{lem:paper_bnt_norm_coeff_le_copies}.
+\end{proof}
+
+\begin{lemma}[Unit-modulus weight witness from the line-246 structural field]%
+	\label{lem:paper_bnt_weight_unit_exists_of_struct}
+	\lean{MPSTensor.IsBNTCanonicalForm.weight_unit_exists_of_struct}
+	\leanok
+	\uses{def:paper_bnt_cf}
+	Re-exposes the structural field \texttt{weight\_unit\_exists}
+	(CPSV16 \S II.A line~246) at the API layer: under the strengthened
+	paper-faithful canonical form, there exist indices~\((j_*, q_*)\) with
+	\(\lVert P.\operatorname{weight}\,j_*\,q_* \rVert = 1\).
+\end{lemma}
+
+\begin{proof}\leanok
+	Direct projection onto the \texttt{weight\_unit\_exists} field.
+\end{proof}
+
+\begin{example}[\(C \oplus (1/2)C\), unequal-modulus admissibility]%
+	\label{ex:paper_bnt_halvedDecomp}
+	\lean{MPSTensor.PaperBNT.Examples.halvedDecomp}
+	\leanok
+	\uses{def:paper_bnt_cf}
+	The single-sector two-copy decomposition with raw weights
+	\((1, 1/2)\) demonstrates that the strengthened
+	\texttt{IsBNTCanonicalForm} admits unequal-modulus copies:
+	\texttt{weight\_norm\_le\_one} holds because
+	\(\lVert 1 \rVert \le 1\) and \(\lVert 1/2 \rVert = 1/2 \le 1\),
+	and \texttt{weight\_unit\_exists} is witnessed by the first
+	copy with weight~\(1\).  This is the CPSV16 \S II.A line~246
+	convention in positive form, reifying the audit
+	\(C \oplus (1/2)C\) counter-example of
+	\texttt{audits/2026-05-13\_cpsv16\_paper\_bnt\_phase\_1\_multiplicity\_audit.md}.
+\end{example}
+
 \section{Dropping a BNT sector}
 \label{sec:paper_bnt_drop_sector}
 


### PR DESCRIPTION
Strengthens `IsBNTCanonicalForm` with the CPSV16 §II.A line-246
normalization fields and drops the now-redundant explicit hypotheses
from the downstream `exists_dominant_match_of_sameMPV` API.

Closes/refs #1716 (tracking issue). See #1685 for the parent FT plan.

## Summary

**Two new structural fields on `IsBNTCanonicalForm`** (CPSV16 §II.A
line 246 verbatim):

```lean
weight_norm_le_one : ∀ j q, ‖P.weight j q‖ ≤ 1
weight_unit_exists : ∃ j q, ‖P.weight j q‖ = 1
```

Both are CPSV16 line-246 conventions ("we can always choose |μ_k| ≤ 1
and at least one of them equals one"), re-invoked at line 1244 in the
FT proof. Audit memos
`extra_hypotheses_audit_2026-05-14.md` and
`thermodynamic_limit_normalization_audit_2026-05-14.md` document the
counter-examples showing these are NOT derivable from the prior
seven-field predicate.

All prior counter-examples (`C ⊕ D`, `C ⊕ -C`, `C ⊕ (1/2)C`,
`C ⊕ -C ⊕ (1/2)C`) remain admissible — see new `halvedDecomp` example
in `Examples.lean`.

## Commits

1. **`a8614ab7`** — Strengthen `IsBNTCanonicalForm` (Basic.lean: +32/-5).
2. **`c89c598c`** — Supply line-246 fields in `Examples.lean` +
   `DropSector.lean`; add `halvedDecomp` example (Examples: +128/-2,
   DropSector: +20/-3).
3. **`74c8f8b8`** — Drop `hP_norm`, `hQ_norm` from
   `exists_dominant_match_of_sameMPV` (now derived from structural
   fields); add API lemmas `norm_coeff_le_copies`,
   `weight_unit_exists_of_struct`.
4. **`5d780398`** — Docstring + blueprint refresh.

## Honest scoping

This PR delivers **two of three** hypothesis-eliminations in
`exists_dominant_match_of_sameMPV`:

* ✅ `hP_norm` — derived from `hP.weight_norm_le_one`.
* ✅ `hQ_norm` — derived from `hQ.weight_norm_le_one`.
* ⏳ `hP_dom_coeff_not_tendsto_zero` — retained as explicit parameter.

The third hypothesis is the index-0 specialisation of the new
`weight_unit_exists` field. Eliminating it requires a Bohr/Kronecker–Weyl
non-decay lemma for sums of unit-modulus complex powers
(`∑_q μ_q^N` with `|μ_q| ≤ 1` and ∃ `|μ_q*| = 1` does not tend to 0).
That machinery is not yet in TNLean or Mathlib and is non-trivial
(Cesàro mean of `|c(N)|²` or simultaneous Kronecker recurrence on
the torus). A follow-up issue will track it.

Per the user's instruction "if too hard for one pass, fall back to the
partial strategy", this PR lands the parts that are clean (two
modulus-bound hypotheses are now structural) and defers the Bohr
lemma to a tracked follow-up rather than committing a `sorry` shim.

## Follow-up issues to open

* **Bohr/Kronecker–Weyl non-decay lemma** for `coeff_dominant_not_tendsto_zero`
  → eliminates the third hypothesis from `exists_dominant_match_of_sameMPV`.
* **Cascade simplification** through `StrongInduction.lean` (PR #1712
  branch `feat/mps-ft-paper-bnt-phase-4c`) and
  `DropSectorOverlapDecay.lean` (PR #1714 branch
  `feat/mps-ft-paper-bnt-phase-4c-cross-overlap-decay`): once this PR
  lands on `main`, those branches need a rebase to absorb the
  strengthened signature. They will lose their `hP_norm`/`hQ_norm`
  parameters automatically; the residual `hP_dom_coeff_not_tendsto_zero`
  becomes whatever the Bohr lemma settles on.

## Grep audit (per orchestrator request)

```
$ grep -rn "hP_norm\|hQ_norm\|hP_dom_coeff_not_tendsto_zero" TNLean/ blueprint/ \
    | grep -v "SectorDecomposition.lean"  # different unrelated lemma
TNLean/.../DominantMatch.lean:43-44  -- docstring transition note (a/b OK)
TNLean/.../DominantMatch.lean:49     -- docstring transition note
TNLean/.../DominantMatch.lean:172    -- docstring transition note
TNLean/.../DominantMatch.lean:183    -- docstring transition note
TNLean/.../DominantMatch.lean:195    -- retained parameter (deferred)
TNLean/.../DominantMatch.lean:442    -- retained parameter usage
```

All matches are either documentation of the transition (allowed per
rule (b)) or the retained `hP_dom_coeff_not_tendsto_zero` parameter
(deferred). No callers in `TNLean/` outside `DominantMatch.lean` or
`SectorDecomposition.lean` (unrelated lemma).

## Build verification

```
$ lake build
... 8689 jobs ...
Build completed successfully (8689 jobs).
```

No `sorry`, no `axiom`, no `unsafe`, no new banned terms.

## Memory + blueprint updates

* `blueprint/src/chapter/ch10_bnt.tex`: updated
  `def:paper_bnt_cf` (added two normalization fields) and
  `lem:paper_bnt_drop_sector_cf` (mentions new `hUnitRem`
  precondition).
* `/memories/cpsv16-ft-paper-faithful-clean-slate-plan.md`: appended
  2026-05-14 strengthening note to Phase 1 entry and refreshed the
  structure-design block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes the core `IsBNTCanonicalForm` structure and updates dependent lemmas/APIs, which can ripple through downstream proofs and instances, though the changes are mostly additive and mechanically propagated.
> 
> **Overview**
> Strengthens `IsBNTCanonicalForm` by adding CPSV16 §II.A line-246 normalization as two new structural fields: `weight_norm_le_one` (all sector weights have norm ≤ 1) and `weight_unit_exists` (some weight has norm = 1).
> 
> Updates downstream development to consume these fields instead of passing explicit modulus-bound hypotheses, notably simplifying `exists_dominant_match_of_sameMPV` by removing its `hP_norm`/`hQ_norm` parameters and deriving the coefficient bounds internally. Adds small API lemmas (`norm_coeff_le_copies`, `weight_unit_exists_of_struct`), adjusts `dropSector` to require an explicit post-drop unit-weight witness, expands executable examples to populate the new fields, and refreshes blueprint documentation (including a new `C ⊕ (1/2)C` `halvedDecomp` example).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4171ddc83255b7c8f4fa460f12135dcce5278163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->