### PR TITLE
feat(MPS/FT/PaperBNT): Cesàro non-decay lemma + eliminate hP_dom_coeff_not_tendsto_zero (#1718)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
+import TNLean.MPS.FundamentalTheorem.PaperBNT.CesaroNonDecay
 import TNLean.MPS.BNT.Basic
 import TNLean.MPS.Overlap.CastDecay
 import TNLean.Spectral.SpectralGapNT
@@ -210,6 +211,65 @@ unit-modulus weight without depending on the structure layout. -/
 lemma weight_unit_exists_of_struct (h : IsBNTCanonicalForm P) :
     ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
       ‖P.weight j q‖ = 1 := h.weight_unit_exists
+
+/-- **Dominant-block coefficient non-decay.**
+
+Under the CPSV16 §II.A line-246 normalization carried by
+`IsBNTCanonicalForm` (every weight has modulus `≤ 1`, and at index `0`
+some copy has unit modulus — `weight_norm_le_one` and
+`weight_unit_at_dominant_block`), the dominant-sector coefficient
+`P.coeff N ⟨0, hP_pos⟩ = ∑_q (P.weight ⟨0, hP_pos⟩ q)^N` does **not**
+tend to `0` as `N → ∞`.
+
+This is the structural-field replacement of the residual
+`hP_dom_coeff_not_tendsto_zero` hypothesis previously carried by
+`exists_dominant_match_of_sameMPV` in `PaperBNT/DominantMatch.lean`.
+Its proof reduces directly to the Cesàro non-decay analytic lemma
+`MPSTensor.CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus`:
+both hypotheses of that lemma (`‖μ q‖ ≤ 1` and the unit-modulus witness
+in the dominant block) are exactly the two structural fields of
+`IsBNTCanonicalForm` at sector index `0`.
+
+Paper anchor: CPSV16 §II.A lines 1181–1188.  The body of the FT proof
+takes the assumed line-246 normalization and reads off non-decay of the
+dominant-block coefficient power-sum; this lemma formalises that
+reading. -/
+lemma coeff_dominant_not_tendsto_zero
+    (h : IsBNTCanonicalForm P) (hP_pos : 0 < P.basisCount) :
+    ¬ Tendsto (fun N : ℕ => P.coeff N ⟨0, hP_pos⟩) atTop (𝓝 0) := by
+  -- Extract the dominant-block weight family and its CPSV16 §II.A
+  -- line-246 properties at sector `0`.
+  have h_le : ∀ q : Fin (P.copies ⟨0, hP_pos⟩),
+      ‖P.weight ⟨0, hP_pos⟩ q‖ ≤ 1 := h.weight_norm_le_one ⟨0, hP_pos⟩
+  have h_unit : ∃ q : Fin (P.copies ⟨0, hP_pos⟩),
+      ‖P.weight ⟨0, hP_pos⟩ q‖ = 1 :=
+    h.weight_unit_at_dominant_block hP_pos
+  -- Apply the Cesàro non-decay analytic lemma.
+  have hAnal := CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus
+    (P.weight ⟨0, hP_pos⟩) h_le h_unit
+  -- `P.coeff N ⟨0, hP_pos⟩ = ∑ q, (P.weight ⟨0, hP_pos⟩ q)^N` is `rfl`.
+  intro hTend
+  apply hAnal
+  exact hTend
+
+/-- **Thermodynamic-limit non-vanishing of the dominant coefficient.**
+
+A user-facing alias for `coeff_dominant_not_tendsto_zero`, named in the
+language of the audit memo
+`thermodynamic_limit_normalization_audit_2026-05-14` §Q-C: the
+CPSV16 §II.A line-246 normalization picks out the dominant block whose
+power-sum coefficient does **not** vanish in the thermodynamic limit.
+
+This is the coefficient form of the audit's "thermodynamic-limit
+non-vanishing" condition.  A self-overlap form
+`limsup_N ⟨A^⊕|A^⊕⟩^{(N)} ∈ (0, ∞)` is the implication
+recorded by the audit's Q-C equivalence (forward direction), which we
+do not formalise here — the coefficient form is the operational input
+to the FT proof; the self-overlap reading is a paraphrase. -/
+lemma thermodynamic_limit_nonvanishing
+    (h : IsBNTCanonicalForm P) (hP_pos : 0 < P.basisCount) :
+    ¬ Tendsto (fun N : ℕ => P.coeff N ⟨0, hP_pos⟩) atTop (𝓝 0) :=
+  h.coeff_dominant_not_tendsto_zero hP_pos
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
@@ -147,6 +147,23 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   dominant-block projection (CPSV16 lines 1181–1188). -/
   weight_unit_exists : ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ = 1
+  /-- **CPSV16 line-246 normalization, dominant-block reading.**  When the
+  decomposition has at least one basis sector, the sector at index `0`
+  carries a unit-modulus copy.  CPSV16 §II.A line 246 only states the
+  existential form `∃ j q, ‖μ_{j,q}‖ = 1`, but the body of the FT proof
+  (CPSV16 lines 1181–1188) **uses** the index-0 reading: the dominant
+  sector is selected by the unit-modulus weight, and the relabelling
+  convention places the dominant sector at index `0`.  This field records
+  that relabelling step structurally so it does not need to be supplied
+  externally; the proof of `coeff_dominant_not_tendsto_zero`
+  (PaperBNT/CesaroNonDecay.lean) reads off the dominant-block coefficient
+  non-decay directly from this field via the Cesàro-mean argument.
+
+  When `P.basisCount = 0`, the field is vacuous (no `hpos` premise is
+  available).  When `P.basisCount = 1`, the field collapses to
+  `weight_unit_exists` with the unique sector index. -/
+  weight_unit_at_dominant_block : ∀ (hpos : 0 < P.basisCount),
+    ∃ q : Fin (P.copies ⟨0, hpos⟩), ‖P.weight ⟨0, hpos⟩ q‖ = 1
 
 namespace IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/CesaroNonDecay.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/CesaroNonDecay.lean
@@ -1,0 +1,286 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Asymptotics.SpecificAsymptotics
+import Mathlib.Algebra.Field.GeomSum
+import Mathlib.Algebra.BigOperators.Pi
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Analysis.Complex.Norm
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Topology.Algebra.Order.Field
+import Mathlib.Data.Fintype.BigOperators
+
+/-!
+# Cesàro non-decay for finite power sums on the closed unit disk
+
+This module proves the pure-analytic lemma underlying the dominant-block
+coefficient non-decay step of the CPSV16 §II fundamental-theorem proof
+(lines 1181–1188).  The lemma is independent of MPS data and is stated in
+terms of complex numbers only.
+
+## Main result
+
+* `MPSTensor.CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus`:
+  for a finite family `μ : Fin r → ℂ` with `‖μ q‖ ≤ 1` for every `q` and
+  some `q*` with `‖μ q*‖ = 1`, the sequence
+  `N ↦ ∑ q, (μ q)^N` does not tend to `0` as `N → ∞`.
+
+## Proof outline
+
+The proof uses the elementary **Cesàro mean** identity.  Let
+`c(N) := ∑_q (μ q)^N`.  If `c(N) → 0`, then
+`|c(N)|² = c(N) · conj(c(N)) → 0`, and by `Filter.Tendsto.cesaro_smul`
+the Cesàro mean of `|c|²` also tends to `0`.
+
+Expanding the product gives
+`|c(N)|² = ∑_{p,q} (μ_p · conj(μ_q))^N`, so the Cesàro mean is the
+finite sum (over pairs) of Cesàro means of geometric sequences
+`(μ_p · conj(μ_q))^N`.  Each such geometric Cesàro mean tends to:
+
+* `1` when `μ_p · conj(μ_q) = 1`, since `1^N = 1` and the average of `T`
+  ones over `T` is `1`;
+* `0` when `μ_p · conj(μ_q) ≠ 1`, since the partial sum is bounded by
+  `2 / ‖μ_p · conj(μ_q) - 1‖` (from the geometric-sum formula together
+  with `‖z^N - 1‖ ≤ ‖z‖^N + 1 ≤ 2`), divided by `T → ∞`.
+
+Therefore the Cesàro mean tends to the cardinality of
+`{(p, q) : μ_p · conj(μ_q) = 1}`.  The diagonal pair `(q*, q*)`
+contributes (since `μ_{q*} · conj(μ_{q*}) = ‖μ_{q*}‖² = 1`), so the
+limit is `≥ 1 > 0`, contradicting the previous limit `0`.
+
+## References
+
+* CPSV16: Cirac–Pérez-García–Schuch–Verstraete, *Matrix Product Density
+  Operators*, arXiv:1606.00608.  Lines 246 (the `|μ_k| ≤ 1` and
+  `∃ k, |μ_k| = 1` normalization convention), 1181–1188 (the
+  dominant-block coefficient non-decay step that this lemma replaces).
+* Cesàro mean limit: `Filter.Tendsto.cesaro_smul` in
+  `Mathlib.Analysis.Asymptotics.SpecificAsymptotics`.
+-/
+
+open scoped BigOperators
+open Filter Topology
+
+namespace MPSTensor
+namespace CesaroNonDecay
+
+/-- **Cesàro mean of a geometric sequence on the closed unit disk.**
+
+For `z : ℂ` with `‖z‖ ≤ 1`, the average `(T)⁻¹ · ∑_{N < T} z^N` tends to:
+
+* `1` if `z = 1` (each term is `1`);
+* `0` if `z ≠ 1` (the partial sum is bounded by `2 / ‖z - 1‖`, divided
+  by `T → ∞`).
+
+Paper context: this is the workhorse of the CPSV16 §II.A line-246
+dominant-block non-decay argument (lines 1181–1188).  The unit case
+captures the contribution of pairs with `μ_p · conj(μ_q) = 1`; the
+non-unit case shows all other pairs contribute `0`. -/
+lemma tendsto_cesaro_geom (z : ℂ) (hz : ‖z‖ ≤ 1) :
+    Tendsto (fun T : ℕ => (T : ℂ)⁻¹ * ∑ N ∈ Finset.range T, z ^ N)
+      atTop (𝓝 (if z = 1 then 1 else 0)) := by
+  classical
+  by_cases hz1 : z = 1
+  · subst hz1
+    rw [if_pos rfl]
+    -- Eventually (T ≥ 1), `(T)⁻¹ * T = 1`.
+    refine Tendsto.congr' ?_ tendsto_const_nhds
+    filter_upwards [eventually_ge_atTop 1] with T hT
+    have hTne : (T : ℂ) ≠ 0 := by
+      have hTge : (1 : ℕ) ≤ T := hT
+      exact_mod_cast Nat.one_le_iff_ne_zero.mp hTge
+    simp [one_pow, Finset.sum_const, Finset.card_range, inv_mul_cancel₀ hTne]
+  · rw [if_neg hz1]
+    -- Squeeze argument: `‖(T)⁻¹ * ∑ z^N‖ ≤ 2 / (T * ‖z - 1‖)` and the
+    -- bound tends to `0`.
+    have hzm1 : z - 1 ≠ 0 := sub_ne_zero.mpr hz1
+    have hC_pos : 0 < ‖z - 1‖ := norm_pos_iff.mpr hzm1
+    refine squeeze_zero_norm (a := fun T : ℕ => 2 / ((T : ℝ) * ‖z - 1‖)) ?_ ?_
+    · intro T
+      rw [geom_sum_eq hz1]
+      by_cases hT0 : T = 0
+      · subst hT0
+        simp
+      have hT_pos : (0 : ℝ) < (T : ℝ) := by
+        have hTge : 1 ≤ T := Nat.one_le_iff_ne_zero.mpr hT0
+        exact_mod_cast hTge
+      have hbnd : ‖z ^ T - 1‖ ≤ 2 := by
+        calc ‖z ^ T - 1‖
+            ≤ ‖z ^ T‖ + ‖(1 : ℂ)‖ := norm_sub_le _ _
+          _ = ‖z‖ ^ T + 1 := by rw [norm_pow]; simp
+          _ ≤ 1 + 1 := by
+              have h1 : ‖z‖ ^ T ≤ 1 ^ T :=
+                pow_le_pow_left₀ (norm_nonneg _) hz T
+              simpa using h1
+          _ = 2 := by norm_num
+      rw [norm_mul, norm_inv, Complex.norm_natCast, norm_div]
+      have hineq : (T : ℝ)⁻¹ * (‖z ^ T - 1‖ / ‖z - 1‖)
+          ≤ (T : ℝ)⁻¹ * (2 / ‖z - 1‖) := by
+        apply mul_le_mul_of_nonneg_left _ (inv_nonneg.mpr (le_of_lt hT_pos))
+        exact div_le_div_of_nonneg_right hbnd (le_of_lt hC_pos)
+      have heq : (2 : ℝ) / ((T : ℝ) * ‖z - 1‖)
+          = (T : ℝ)⁻¹ * (2 / ‖z - 1‖) := by
+        field_simp
+      change (T : ℝ)⁻¹ * (‖z ^ T - 1‖ / ‖z - 1‖) ≤ 2 / ((T : ℝ) * ‖z - 1‖)
+      rw [heq]
+      exact hineq
+    · -- `T ↦ 2 / (T * ‖z - 1‖) = (2 / ‖z - 1‖) / T → 0`.
+      have hcast : Tendsto (fun T : ℕ => (T : ℝ)) atTop atTop :=
+        tendsto_natCast_atTop_atTop
+      have h0 := hcast.const_div_atTop (2 / ‖z - 1‖)
+      refine h0.congr ?_
+      intro T
+      by_cases hT0 : T = 0
+      · subst hT0
+        simp
+      · have hTne : (T : ℝ) ≠ 0 := by exact_mod_cast hT0
+        field_simp
+
+/-- **Cesàro non-decay of a sum of `N`-th powers under the closed-unit-disk
+normalization.**
+
+Let `μ : Fin r → ℂ` satisfy `‖μ q‖ ≤ 1` for every `q` and let some
+`q*` satisfy `‖μ q*‖ = 1`.  Then the sequence
+`N ↦ ∑ q, (μ q)^N` does not tend to `0`.
+
+This is the analytic lemma underlying the CPSV16 §II.A line-246
+"`|μ_k| ≤ 1` and `∃ k, |μ_k| = 1`" normalization convention and the
+dominant-block coefficient non-decay step at CPSV16 lines 1181–1188.
+
+The proof is the elementary Cesàro-mean argument outlined in the module
+docstring. -/
+theorem sum_pow_not_tendsto_zero_of_unit_modulus
+    {r : ℕ} (μ : Fin r → ℂ)
+    (h_le : ∀ q, ‖μ q‖ ≤ 1)
+    (h_unit : ∃ q, ‖μ q‖ = 1) :
+    ¬ Tendsto (fun N : ℕ => ∑ q : Fin r, (μ q) ^ N) atTop (𝓝 0) := by
+  classical
+  intro hzero
+  obtain ⟨q_star, hq_star⟩ := h_unit
+  -- Let `c(N) = ∑ q, (μ q)^N`.  Its conjugate sequence also tends to `0`.
+  set c : ℕ → ℂ := fun N => ∑ q : Fin r, (μ q) ^ N with hc_def
+  have hconj_zero : Tendsto (fun N => (starRingEnd ℂ) (c N)) atTop (𝓝 0) := by
+    have hcont : Continuous (starRingEnd ℂ) := Complex.continuous_conj
+    have htend : Tendsto (starRingEnd ℂ) (𝓝 0) (𝓝 ((starRingEnd ℂ) 0)) :=
+      hcont.tendsto 0
+    have hcomp := htend.comp hzero
+    simpa using hcomp
+  -- `f N := c(N) · conj(c(N)) → 0 · 0 = 0`.
+  have hf_zero :
+      Tendsto (fun N : ℕ => c N * (starRingEnd ℂ) (c N)) atTop (𝓝 0) := by
+    have h := hzero.mul hconj_zero
+    simpa using h
+  -- Cesàro mean (real-scalar form) of `f` also tends to `0`.
+  have hCes_zero :
+      Tendsto (fun T : ℕ =>
+        (T : ℝ)⁻¹ • ∑ N ∈ Finset.range T, c N * (starRingEnd ℂ) (c N))
+        atTop (𝓝 0) := hf_zero.cesaro_smul
+  -- Convert the real-scalar Cesàro to multiplication by the complex inverse.
+  have hCes_mul :
+      Tendsto (fun T : ℕ =>
+        (T : ℂ)⁻¹ * ∑ N ∈ Finset.range T, c N * (starRingEnd ℂ) (c N))
+        atTop (𝓝 0) := by
+    refine hCes_zero.congr ?_
+    intro T
+    rw [Complex.real_smul]
+    congr 1
+    push_cast
+    rfl
+  -- Re-express the Cesàro mean as a finite sum over pairs `(p, q)`.
+  -- `c(N) · conj(c(N)) = ∑_{p, q} (μ p · conj (μ q))^N`.
+  have hf_eq : ∀ N,
+      c N * (starRingEnd ℂ) (c N)
+        = ∑ pq : Fin r × Fin r, (μ pq.1 * (starRingEnd ℂ) (μ pq.2)) ^ N := by
+    intro N
+    have hconj_c : (starRingEnd ℂ) (c N)
+        = ∑ q : Fin r, ((starRingEnd ℂ) (μ q)) ^ N := by
+      simp [hc_def, map_sum, map_pow]
+    rw [hc_def, hconj_c]
+    rw [Finset.sum_mul_sum]
+    rw [Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl ?_
+    intro p _
+    refine Finset.sum_congr rfl ?_
+    intro q _
+    rw [mul_pow]
+  -- For each pair, compute the Cesàro limit using `tendsto_cesaro_geom`.
+  -- Bound on `μ p · conj(μ q)`.
+  have h_norm_pair : ∀ pq : Fin r × Fin r,
+      ‖μ pq.1 * (starRingEnd ℂ) (μ pq.2)‖ ≤ 1 := by
+    intro pq
+    rw [norm_mul, Complex.norm_conj]
+    have h1 := h_le pq.1
+    have h2 := h_le pq.2
+    have hnn : (0 : ℝ) ≤ ‖μ pq.2‖ := norm_nonneg _
+    calc ‖μ pq.1‖ * ‖μ pq.2‖
+        ≤ 1 * ‖μ pq.2‖ :=
+          mul_le_mul_of_nonneg_right h1 hnn
+      _ ≤ 1 * 1 :=
+          mul_le_mul_of_nonneg_left h2 zero_le_one
+      _ = 1 := by ring
+  -- The diagonal pair `(q_star, q_star)` has `μ_{q_star} · conj(μ_{q_star}) = 1`.
+  have h_diag_eq_one :
+      μ q_star * (starRingEnd ℂ) (μ q_star) = 1 := by
+    have := Complex.mul_conj' (μ q_star)
+    rw [hq_star] at this
+    -- `this : μ q_star * conj (μ q_star) = ↑(1 : ℝ) ^ 2`
+    simpa using this
+  -- Per-pair Cesàro sequence.
+  set g : (Fin r × Fin r) → ℕ → ℂ := fun pq T =>
+    (T : ℂ)⁻¹ * ∑ N ∈ Finset.range T, (μ pq.1 * (starRingEnd ℂ) (μ pq.2)) ^ N
+    with hg_def
+  have hg_tendsto : ∀ pq : Fin r × Fin r,
+      Tendsto (g pq) atTop
+        (𝓝 (if μ pq.1 * (starRingEnd ℂ) (μ pq.2) = 1 then (1 : ℂ) else 0)) :=
+    fun pq => tendsto_cesaro_geom _ (h_norm_pair pq)
+  -- Finite sum of tendstos.
+  have h_sum_tendsto :
+      Tendsto (fun T : ℕ => ∑ pq : Fin r × Fin r, g pq T) atTop
+        (𝓝 (∑ pq : Fin r × Fin r,
+          (if μ pq.1 * (starRingEnd ℂ) (μ pq.2) = 1 then (1 : ℂ) else 0))) :=
+    tendsto_finset_sum (Finset.univ : Finset (Fin r × Fin r))
+      (fun pq _ => hg_tendsto pq)
+  -- Identify this sum with the Cesàro of `f`.
+  have h_cesaro_eq : ∀ T : ℕ,
+      (T : ℂ)⁻¹ * ∑ N ∈ Finset.range T, c N * (starRingEnd ℂ) (c N)
+        = ∑ pq : Fin r × Fin r, g pq T := by
+    intro T
+    have hcongr :
+        ∑ N ∈ Finset.range T, c N * (starRingEnd ℂ) (c N)
+          = ∑ N ∈ Finset.range T,
+              ∑ pq : Fin r × Fin r,
+                (μ pq.1 * (starRingEnd ℂ) (μ pq.2)) ^ N :=
+      Finset.sum_congr rfl (fun N _ => hf_eq N)
+    rw [hcongr, Finset.sum_comm, Finset.mul_sum]
+  -- The Cesàro of `f` equals the per-pair sum, so it converges to the same
+  -- limit.
+  have hCes_zero' :
+      Tendsto (fun T : ℕ => ∑ pq : Fin r × Fin r, g pq T) atTop (𝓝 0) := by
+    refine hCes_mul.congr ?_
+    intro T
+    exact h_cesaro_eq T
+  -- Uniqueness of limits forces the per-pair sum's limit to equal `0`.
+  have h_limit_eq : (∑ pq : Fin r × Fin r,
+      (if μ pq.1 * (starRingEnd ℂ) (μ pq.2) = 1 then (1 : ℂ) else 0))
+        = 0 := tendsto_nhds_unique h_sum_tendsto hCes_zero'
+  -- But the sum is positive: the diagonal `(q_star, q_star)` contributes `1`.
+  set S : Finset (Fin r × Fin r) :=
+    (Finset.univ : Finset (Fin r × Fin r)).filter
+      fun pq => μ pq.1 * (starRingEnd ℂ) (μ pq.2) = 1 with hS_def
+  have h_sum_eq : (∑ pq : Fin r × Fin r,
+      (if μ pq.1 * (starRingEnd ℂ) (μ pq.2) = 1 then (1 : ℂ) else 0))
+        = (S.card : ℂ) := by
+    rw [hS_def, ← Finset.sum_filter]
+    simp [Finset.sum_const, nsmul_eq_mul]
+  have hmem : (q_star, q_star) ∈ S := by
+    rw [hS_def]
+    refine Finset.mem_filter.mpr ⟨Finset.mem_univ _, ?_⟩
+    exact h_diag_eq_one
+  have hSpos : 0 < S.card := Finset.card_pos.mpr ⟨_, hmem⟩
+  rw [h_sum_eq] at h_limit_eq
+  have hScast : (S.card : ℕ) = 0 := by exact_mod_cast h_limit_eq
+  exact (Nat.pos_iff_ne_zero.mp hSpos) hScast
+
+end CesaroNonDecay
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
@@ -35,7 +35,7 @@ The dominant-pair matching at the **fixed** index `⟨0, hP_pos⟩` does not
 follow from the core seven-field `IsBNTCanonicalForm` data alone: the core
 seven fields are deliberately invariant under relabelling of sectors and do
 not single out a dominant sector.  Following the CPSV16 §II.A line-246
-normalization convention, `IsBNTCanonicalForm` now carries two additional
+normalization convention, `IsBNTCanonicalForm` carries three additional
 structural fields:
 
 * `weight_norm_le_one : ∀ j q, ‖weight j q‖ ≤ 1`  — CPSV16 line 246, the
@@ -44,19 +44,16 @@ structural fields:
   hQ_norm` parameters.
 * `weight_unit_exists : ∃ j q, ‖weight j q‖ = 1`  — CPSV16 line 246,
   the unit-modulus existential.
+* `weight_unit_at_dominant_block : ∀ hpos, ∃ q, ‖weight ⟨0, hpos⟩ q‖ = 1`
+  — CPSV16 line 246 read at the **dominant** sector index `0`, which is
+  the form used in the FT proof (CPSV16 lines 1181–1188).
 
-The remaining external hypothesis on Lemma 3,
-`(hP_dom_coeff_not_tendsto_zero : ¬ Tendsto (P.coeff · ⟨0, hP_pos⟩) atTop (𝓝 0))`,
-records that the **dominant sector**'s coefficient does not asymptotically
-vanish.  This is the index-0 reading of the existential
-`weight_unit_exists`; deriving the index-0 form from the existential would
-require relabelling sectors so the unit-modulus copy sits in sector 0
-together with a Bohr/Kronecker–Weyl non-decay argument for power-sums of
-unit-modulus complex numbers (CPSV16 lines 1181–1188 paper-side; see also
-the audit memos `extra_hypotheses_audit_2026-05-14` §Q2 and
-`thermodynamic_limit_normalization_audit_2026-05-14` §Q-C).  The general
-non-decay result is tracked separately and will replace this explicit
-parameter once available.
+The dominant-block coefficient non-decay
+`¬ Tendsto (P.coeff · ⟨0, hP_pos⟩) atTop (𝓝 0)` is now **derived** from
+the third structural field above via the Cesàro non-decay analytic lemma
+in `PaperBNT/CesaroNonDecay.lean` and is no longer an explicit parameter
+on Lemma 3.  The reduction is recorded in
+`IsBNTCanonicalForm.coeff_dominant_not_tendsto_zero` (`PaperBNT/Api.lean`).
 
 These hypotheses are weaker than the legacy `IsCanonicalFormBNT` package
 (which baked in `mu_strict_anti` + a single per-sector "spectral level"
@@ -169,7 +166,9 @@ the dominant `P`-block).
   `k`-overlaps decay.
 
 * `SameMPV₂` makes both sides equal, so `P.coeff N ⟨0, _⟩` tends to `0`,
-  contradicting `hP_dom_coeff_not_tendsto_zero`.
+  contradicting `IsBNTCanonicalForm.coeff_dominant_not_tendsto_zero`
+  (derived from the structural field `weight_unit_at_dominant_block` via
+  the Cesàro non-decay lemma in `PaperBNT/CesaroNonDecay.lean`).
 
 The extracted `k₀` then satisfies (i) equal bond dimensions, via the
 contrapositive of
@@ -177,23 +176,18 @@ contrapositive of
 gauge-phase equivalence, via the contrapositive of
 `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`.
 
-Hypothesis disclosure: the modulus bounds `weight_norm_le_one` are part
-of the strengthened `IsBNTCanonicalForm` predicate (CPSV16 §II.A
-line 246) and need not be supplied externally.  The non-decay hypothesis
-`hP_dom_coeff_not_tendsto_zero` is the index-0 specialisation of the
-structural field `weight_unit_exists`; its derivation requires a
-Bohr/Kronecker–Weyl non-decay step for unit-modulus power sums (audit
-memo `extra_hypotheses_audit_2026-05-14` §Q2,
-`thermodynamic_limit_normalization_audit_2026-05-14` §Q-C) and is tracked
-as a follow-up.
+Hypothesis disclosure: the modulus bounds `weight_norm_le_one` and the
+dominant-block unit-modulus witness `weight_unit_at_dominant_block` are
+both structural fields of `IsBNTCanonicalForm` (CPSV16 §II.A line 246)
+and need not be supplied externally.  The dominant-block coefficient
+non-decay is derived from these inside the proof via
+`IsBNTCanonicalForm.coeff_dominant_not_tendsto_zero` (`PaperBNT/Api.lean`).
 -/
 theorem exists_dominant_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hP_pos : 0 < P.basisCount) (hQ_pos : 0 < Q.basisCount)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor)
-    (hP_dom_coeff_not_tendsto_zero :
-      ¬ Tendsto (fun N : ℕ => P.coeff N ⟨0, hP_pos⟩) atTop (𝓝 0)) :
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ k₀ : Fin Q.basisCount,
       ∃ h : P.basisDim ⟨0, hP_pos⟩ = Q.basisDim k₀,
         GaugePhaseEquiv
@@ -213,6 +207,11 @@ theorem exists_dominant_match_of_sameMPV
   -- used to be supplied as explicit parameters at the call site.
   have hP_weight_le := hP.weight_norm_le_one
   have hQ_weight_le := hQ.weight_norm_le_one
+  -- Dominant-block coefficient non-decay derived from the structural
+  -- field `weight_unit_at_dominant_block` via the Cesàro non-decay lemma.
+  have hP_dom_coeff_not_tendsto_zero :
+      ¬ Tendsto (fun N : ℕ => P.coeff N ⟨0, hP_pos⟩) atTop (𝓝 0) :=
+    hP.coeff_dominant_not_tendsto_zero hP_pos
   set j₀ : Fin P.basisCount := ⟨0, hP_pos⟩ with hj₀_def
   -- Step 1: extract some k₀ with non-decaying overlap to `P.basis j₀`.
   have hExists_k :

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DropSector.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DropSector.lean
@@ -220,13 +220,20 @@ Every field of the paper-faithful canonical-form predicate transfers from
   decomposition.  In the CPSV16 §II `II_cor2` induction this is the
   normalization step that re-orients the next-dominant block; the
   `hUnitRem` hypothesis below records that step abstractly.
+* `weight_unit_at_dominant_block` (CPSV16 line 246, dominant-block
+  reading) is the index-0 specialisation of `weight_unit_exists`; the
+  `hUnitDomRem` hypothesis records the index-0 witness on the remaining
+  decomposition, again recording the relabelling step abstractly.
 
 This is the foundational lemma for the CPSV16 §II `II_cor2` induction step
 (lines 1172–1192). -/
 def dropSector
     (hP : IsBNTCanonicalForm P) (h : P.basisCount = n + 1) (i₀ : Fin (n + 1))
     (hUnitRem : ∃ (j : Fin n) (q : Fin ((P.dropSector h i₀).copies j)),
-      ‖(P.dropSector h i₀).weight j q‖ = 1) :
+      ‖(P.dropSector h i₀).weight j q‖ = 1)
+    (hUnitDomRem : ∀ (hpos : 0 < n),
+      ∃ q : Fin ((P.dropSector h i₀).copies ⟨0, hpos⟩),
+        ‖(P.dropSector h i₀).weight ⟨0, hpos⟩ q‖ = 1) :
     IsBNTCanonicalForm (P.dropSector h i₀) where
   basis_dim_pos _ := hP.basis_dim_pos _
   basis_injective _ := hP.basis_injective _
@@ -284,6 +291,7 @@ def dropSector
     simpa [SectorDecomposition.dropSector_weight,
            SectorDecomposition.dropSector_copies] using this _
   weight_unit_exists := hUnitRem
+  weight_unit_at_dominant_block := hUnitDomRem
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
@@ -93,6 +93,13 @@ noncomputable example
     refine ⟨0, 0, ?_⟩
     change ‖(1 : ℂ)‖ = 1
     simp
+  -- CPSV16 line 246 (dominant-block reading): the unique weight at the
+  -- unique sector is the unit-modulus witness.
+  weight_unit_at_dominant_block := by
+    intro _
+    refine ⟨0, ?_⟩
+    change ‖(1 : ℂ)‖ = 1
+    simp
 
 /-! ## Example 2 — `C ⊕ (-C)` -/
 
@@ -146,6 +153,13 @@ noncomputable example
   -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
+    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else -1)‖ = 1
+    simp
+  -- CPSV16 line 246 (dominant-block reading): the first copy of the unique
+  -- sector carries weight `μ = 1`.
+  weight_unit_at_dominant_block := by
+    intro _
+    refine ⟨0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else -1)‖ = 1
     simp
 
@@ -208,6 +222,13 @@ noncomputable example
   -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
+    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ = 1
+    simp
+  -- CPSV16 line 246 (dominant-block reading): the first copy of the unique
+  -- sector carries weight `μ = 1`.
+  weight_unit_at_dominant_block := by
+    intro _
+    refine ⟨0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ = 1
     simp
 
@@ -325,6 +346,13 @@ noncomputable example
   -- CPSV16 line 246: the first copy `q = 0` carries the unit weight.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
+    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
+    simp
+  -- CPSV16 line 246 (dominant-block reading): the first copy of the unique
+  -- sector carries the unit weight.
+  weight_unit_at_dominant_block := by
+    intro _
+    refine ⟨0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
     simp
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1081,3 +1081,85 @@ of \cite[\S~II, lines~1184--1188]{Cirac2017MPDO_AnnPhys}.
 	after absorbing the bond-dimension coercion.  Dispatch to
 	Lemma~\ref{lem:paper_bnt_sameMPV_dropSector_dropSector}.
 \end{proof}
+
+\section{Ces\`aro non-decay and dominant-block coefficient}
+\label{sec:paper_bnt_cesaro_nondecay}
+
+This section formalizes the analytic input that lets us replace the
+residual ``dominant coefficient does not asymptotically vanish'' hypothesis
+on the dominant-pair matching of
+\cite[\S~II, lines~1181--1188]{Cirac2017MPDO_AnnPhys} by a derived lemma.
+The reduction is to a pure-analytic statement: a finite sum of $N$-th
+powers of complex numbers in the closed unit disk, with at least one
+unit-modulus summand, cannot tend to zero.
+
+The proof is the elementary Ces\`aro-mean identity:
+\(
+M_T := T^{-1} \sum_{N=0}^{T-1} |c(N)|^2
+     = \sum_{p,q} T^{-1} \sum_{N=0}^{T-1} (\mu_p \overline{\mu_q})^N
+\)
+splits into:
+\(T^{-1}\) times the partial geometric sum for each pair $(p, q)$; each
+pair with $\mu_p \overline{\mu_q} = 1$ contributes the limit $1$, while
+each pair with $\mu_p \overline{\mu_q} \neq 1$ contributes the limit
+$0$ (since $|(z^T - 1)/(z - 1)| \leq 2/|z - 1|$ divided by $T \to 0$).
+The diagonal pair $(q^*, q^*)$ at a unit-modulus index $q^*$ contributes,
+so $M_T \to \#\{\text{matching pairs}\} \geq 1 > 0$, contradicting
+$c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
+
+\begin{lemma}[Ces\`aro non-decay of a finite power sum]%
+	\label{lem:paper_bnt_cesaro_nondecay}
+	\lean{MPSTensor.CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus}
+	\leanok
+	Let $\mu : \{0, \dotsc, r-1\} \to \mathbb{C}$ satisfy $|\mu_q| \leq 1$
+	for every $q$ and let some $q^*$ satisfy $|\mu_{q^*}| = 1$.  Then the
+	sequence $N \mapsto \sum_{q=0}^{r-1} (\mu_q)^N$ does not tend to $0$
+	as $N \to \infty$.  This is the analytic content of the dominant-block
+	non-decay step at
+	\cite[\S~II.A, lines~246, 1181--1188]{Cirac2017MPDO_AnnPhys}.
+\end{lemma}
+
+\begin{proof}\leanok
+	Ces\`aro-mean argument as described above; see the module docstring
+	of \texttt{TNLean/MPS/FundamentalTheorem/PaperBNT/CesaroNonDecay.lean}
+	for the full elementary proof.
+\end{proof}
+
+\begin{lemma}[Dominant-block coefficient non-decay]%
+	\label{lem:paper_bnt_coeff_dominant_not_tendsto_zero}
+	\lean{MPSTensor.IsBNTCanonicalForm.coeff_dominant_not_tendsto_zero}
+	\leanok
+	\uses{def:paper_bnt_cf, lem:paper_bnt_cesaro_nondecay}
+	Let \(P\) be a sector decomposition carrying a paper-faithful BNT
+	canonical form with \(P.\texttt{basisCount} > 0\).  Then the dominant
+	sector's coefficient
+	\(c_{0}(N) = \sum_q (P.\texttt{weight}\,\langle 0,\,h\rangle\,q)^N\)
+	does not tend to \(0\) as \(N \to \infty\).
+
+	This is the structural-field reading of the CPSV16 \S~II.A line~246
+	normalization (every weight has modulus \(\leq 1\), and at index \(0\)
+	some copy has unit modulus); the proof reduces directly to
+	Lemma~\ref{lem:paper_bnt_cesaro_nondecay} with the dominant-block
+	weight family.
+\end{lemma}
+
+\begin{proof}\leanok
+	Apply Lemma~\ref{lem:paper_bnt_cesaro_nondecay} to the family
+	\(\mu := P.\texttt{weight}\,\langle 0,\,h\rangle\), feeding in the
+	two structural fields of \texttt{IsBNTCanonicalForm} at sector~\(0\):
+	\texttt{weight\_norm\_le\_one} supplies the modulus bound and
+	\texttt{weight\_unit\_at\_dominant\_block} supplies the unit-modulus
+	witness.
+\end{proof}
+
+\begin{remark}
+	Consuming this lemma inside \texttt{exists\_dominant\_match\_of\_sameMPV}
+	(\texttt{TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean})
+	eliminates the prior explicit
+	\(\lnot \texttt{Tendsto}\,(P.\texttt{coeff}\,\cdot\,\langle 0,\,h\rangle)\,\texttt{atTop}\,(\nh\,0)\)
+	parameter from the dominant-pair matching theorem of
+	\cite[\S~II, lines~1181--1188]{Cirac2017MPDO_AnnPhys}.  After this
+	cleanup the matching theorem reads off purely from the strengthened
+	\texttt{IsBNTCanonicalForm} predicate plus the equal-MPV hypothesis,
+	with no analytic side conditions exposed at the call site.
+\end{remark}


### PR DESCRIPTION
Closes #1718.

Stacks on PR #1717 (`feat/mps-ft-paper-bnt-strengthen-normalization`).

## Summary

Adds the pure-analytic **Cesàro non-decay** lemma for finite sums of $N$-th powers on the closed unit disk, and uses it to derive the **dominant-block coefficient non-decay** structurally inside `IsBNTCanonicalForm`, eliminating the residual `hP_dom_coeff_not_tendsto_zero` parameter from `exists_dominant_match_of_sameMPV`.

## Mathematical content

**Cesàro non-decay lemma** (`MPSTensor.CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus`): for $\mu : \mathrm{Fin}\,r \to \mathbb{C}$ with $\|\mu_q\| \le 1$ for all $q$ and $\|\mu_{q^*}\| = 1$ for some $q^*$, the sequence $N \mapsto \sum_q (\mu_q)^N$ does not tend to $0$.

Proof: Cesàro mean of $|c(N)|^2 = \sum_{p,q} (\mu_p \overline{\mu_q})^N$ decomposes into per-pair Cesàro means of $(\mu_p \overline{\mu_q})^N$; the diagonal contribution at $q^*$ gives a strictly positive limit $\ge 1$, contradicting $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.

## Files

* **NEW** `TNLean/MPS/FundamentalTheorem/PaperBNT/CesaroNonDecay.lean` (~286 LoC): the analytic lemma above plus helper `tendsto_cesaro_geom` for geometric Cesàro means.
* `PaperBNT/Basic.lean` (+17 LoC): adds structural field `weight_unit_at_dominant_block : ∀ hpos, ∃ q, ‖weight ⟨0, hpos⟩ q‖ = 1`. This is the **Option A** from the audit (`extra_hypotheses_audit_2026-05-14.md` §Q4, `thermodynamic_limit_normalization_audit_2026-05-14.md` §Q-C): a third structural field anchored at CPSV16 §II.A line 246, recording the index-0 reading of the unit-modulus convention used by the FT proof body (CPSV16 lines 1181–1188).
* `PaperBNT/Api.lean` (+60 LoC):
  - `IsBNTCanonicalForm.coeff_dominant_not_tendsto_zero` — the dominant-sector coefficient does not tend to 0, derived from the two structural fields at sector 0 via the Cesàro lemma.
  - `IsBNTCanonicalForm.thermodynamic_limit_nonvanishing` — positively-named alias in the language of the Q-C audit memo (coefficient form).
* `PaperBNT/DominantMatch.lean` (+24/-27 LoC): `exists_dominant_match_of_sameMPV` no longer takes the explicit `hP_dom_coeff_not_tendsto_zero` parameter; it is derived internally.
* `PaperBNT/DropSector.lean` (+10 LoC): threads `weight_unit_at_dominant_block` via a new `hUnitDomRem` hypothesis.
* `PaperBNT/Examples.lean` (+28 LoC): supplies the new field on `singletonDecomp`, `signFlipDecomp`, `phaseDecomp`, `halvedDecomp`.
* `blueprint/src/chapter/ch10_bnt.tex` (+82 LoC): new section formalising the Cesàro non-decay lemma + the coefficient corollary + the elimination of the explicit parameter.

## Build

`lake build` passes clean (8690 jobs). No new `sorry`/`axiom`/`unsafe` in any touched file.

## Constraints

* No banned words in new content.
* CPSV16 line citations on every new lemma.
* Cesàro proof uses Mathlib `Filter.Tendsto.cesaro_smul`, `geom_sum_eq`, `Complex.mul_conj'`, `Complex.real_smul`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it extends the core `IsBNTCanonicalForm` structure with a new field and changes the signature/assumptions of `exists_dominant_match_of_sameMPV`, which may require downstream proof updates and could affect FT proof dependencies.
> 
> **Overview**
> Adds a new pure-analytic module `PaperBNT/CesaroNonDecay.lean` proving `sum_pow_not_tendsto_zero_of_unit_modulus` (finite power-sum on the closed unit disk cannot converge to `0` when a unit-modulus term exists).
> 
> Strengthens `IsBNTCanonicalForm` with `weight_unit_at_dominant_block` and uses it in `Api.lean` to derive `coeff_dominant_not_tendsto_zero` (and alias `thermodynamic_limit_nonvanishing`), then updates `DominantMatch.exists_dominant_match_of_sameMPV` to *derive* the non-decay contradiction internally instead of taking `hP_dom_coeff_not_tendsto_zero` as an argument.
> 
> Threads the new structural field through `DropSector` and updates `Examples.lean` and the blueprint (`ch10_bnt.tex`) to document/provide the new witness and the derived non-decay lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e6864406f95d5a074ebb1193407dc77532fb1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->