### PR TITLE
feat(MPS/FT/PaperBNT): matched-sector weight-permutation extractor (Phase 4c τ extractor #1721)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongInduction.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongInduction.lean
@@ -426,4 +426,131 @@ theorem matched_sector_weight_multiset_eq
             intro q _; rfl
   exact hMultiset.trans hReindex
 
+/-! ### Matched-sector weight-permutation extractor
+
+The multiset equality above is upgraded to an *explicit* permutation
+`τ : Fin (P.copies j₀) ≃ Fin (Q.copies k₀')` matching individual per-copy
+weights up to the gauge-phase factor `ζ`.  This is the per-copy form of
+CPSV16 line 1188 (`μ_{j,q} = ν_{j,q} · e^{i\phi_j}` for an indexing of
+the `Q`-copies determined by a matching).
+
+The proof reduces to a generic helper extracting an `Equiv.Perm` from a
+multiset-map equality on `Fin`, then composes with the cardinality cast
+and clears the `ζ` factor with `mul_inv_cancel₀ hζ`.
+-/
+
+/-- **Auxiliary: extract `Equiv.Perm (Fin n)` from a multiset map equality.**
+
+Given `f, g : Fin n → α` whose `Multiset.map`s over `Finset.univ.val`
+coincide, there exists a permutation `σ` of `Fin n` with
+`f q = g (σ q)` for every `q`.
+
+Proof by induction on `n`: at the successor step, locate an index `j`
+in the codomain of `g` matching `f 0`, decompose both multisets via
+`Fin.univ_succAbove`, apply the inductive hypothesis to the restricted
+functions on `Fin n`, and reassemble via `finSuccEquiv'` and
+`Equiv.optionCongr`. -/
+private lemma exists_perm_of_multiset_map_univ_eq {α : Type*} :
+    ∀ {n : ℕ} (f g : Fin n → α),
+      Multiset.map f (Finset.univ : Finset (Fin n)).val =
+        Multiset.map g (Finset.univ : Finset (Fin n)).val →
+      ∃ σ : Equiv.Perm (Fin n), ∀ q, f q = g (σ q) := by
+  intro n
+  induction n with
+  | zero =>
+    intro _ _ _
+    exact ⟨Equiv.refl _, fun q => q.elim0⟩
+  | succ n ih =>
+    intro f g hMap
+    classical
+    -- Locate `j : Fin (n+1)` with `g j = f 0`.
+    have hMem : f 0 ∈ Multiset.map g (Finset.univ : Finset (Fin (n+1))).val := by
+      rw [← hMap]
+      exact Multiset.mem_map_of_mem f (Finset.mem_univ_val 0)
+    obtain ⟨j, _hjMem, hj⟩ := Multiset.mem_map.mp hMem
+    -- `Multiset.map h univ = h p ::ₘ Multiset.map (h ∘ p.succAbove) univ`.
+    have decomp : ∀ (h : Fin (n+1) → α) (p : Fin (n+1)),
+        Multiset.map h (Finset.univ : Finset (Fin (n+1))).val =
+          h p ::ₘ Multiset.map (h ∘ p.succAbove)
+            (Finset.univ : Finset (Fin n)).val := by
+      intro h p
+      have hUniv : (Finset.univ : Finset (Fin (n+1))).val =
+          p ::ₘ ((Finset.univ : Finset (Fin n)).val.map p.succAboveEmb) := by
+        rw [Fin.univ_succAbove n p, Finset.cons_val, Finset.map_val]
+      rw [hUniv, Multiset.map_cons, Multiset.map_map]
+      rfl
+    -- Reduce to a multiset-map equality on `Fin n`.
+    have hRestricted :
+        Multiset.map (f ∘ (0 : Fin (n+1)).succAbove)
+            (Finset.univ : Finset (Fin n)).val =
+          Multiset.map (g ∘ j.succAbove)
+            (Finset.univ : Finset (Fin n)).val := by
+      have hEqCons :
+          f 0 ::ₘ Multiset.map (f ∘ (0 : Fin (n+1)).succAbove)
+              (Finset.univ : Finset (Fin n)).val =
+            g j ::ₘ Multiset.map (g ∘ j.succAbove)
+              (Finset.univ : Finset (Fin n)).val := by
+        rw [← decomp f 0, ← decomp g j]
+        exact hMap
+      rw [hj] at hEqCons
+      exact (Multiset.cons_inj_right (f 0)).mp hEqCons
+    -- Apply the inductive hypothesis.
+    obtain ⟨σ', hσ'⟩ := ih _ _ hRestricted
+    -- Assemble `σ : Fin (n+1) ≃ Fin (n+1)` via `finSuccEquiv'`.
+    refine ⟨((finSuccEquiv' (0 : Fin (n+1))).trans σ'.optionCongr).trans
+              (finSuccEquiv' j).symm, ?_⟩
+    intro q
+    refine q.cases ?_ ?_
+    · -- Case `q = 0`: `σ 0 = j`, and `g j = f 0` by `hj`.
+      simp only [Equiv.trans_apply, finSuccEquiv'_at,
+        Equiv.optionCongr_apply, Option.map_none, finSuccEquiv'_symm_none]
+      exact hj.symm
+    · -- Case `q = i.succ`: `σ i.succ = j.succAbove (σ' i)`.
+      intro i
+      have hRec := hσ' i
+      simp only [Function.comp_apply, Fin.zero_succAbove] at hRec
+      simp only [Equiv.trans_apply, ← Fin.zero_succAbove,
+        finSuccEquiv'_succAbove, Equiv.optionCongr_apply,
+        Option.map_some, finSuccEquiv'_symm_some]
+      exact hRec
+
+set_option linter.unusedVariables false in
+/-- **Matched-sector weight-permutation extractor.**
+
+Refines `matched_sector_weight_multiset_eq` into an explicit permutation
+`τ` realising CPSV16 line 1188's per-copy identification.
+
+Paper anchor: CPSV16 §II.C lines 1158-1167, 1184, 1188 (arXiv:1606.00608). -/
+theorem matched_sector_weight_equiv
+    {P Q : SectorDecomposition d}
+    (j₀ : Fin P.basisCount) (k₀' : Fin Q.basisCount)
+    (ζ : ℂ) (hζ : ζ ≠ 0)
+    {N₀ : ℕ}
+    (hCoeff : ∀ N > N₀, P.coeff N j₀ = ζ ^ N * Q.coeff N k₀') :
+    ∃ (hCopies : P.copies j₀ = Q.copies k₀')
+      (τ : Fin (P.copies j₀) ≃ Fin (Q.copies k₀')),
+      ∀ q : Fin (P.copies j₀),
+        Q.weight k₀' (τ q) = ζ⁻¹ * P.weight j₀ q := by
+  classical
+  obtain ⟨hCopies, hMultiset⟩ :=
+    matched_sector_weight_multiset_eq j₀ k₀' ζ hζ hCoeff
+  -- Extract `σ : Fin (P.copies j₀) ≃ Fin (P.copies j₀)` matching the
+  -- per-copy weights up to the gauge-phase factor `ζ`.
+  obtain ⟨σ, hσ⟩ :=
+    exists_perm_of_multiset_map_univ_eq
+      (P.weight j₀)
+      (fun q : Fin (P.copies j₀) => ζ * Q.weight k₀' (Fin.cast hCopies q))
+      hMultiset
+  -- Compose with the cardinality cast `Fin (P.copies j₀) ≃ Fin (Q.copies k₀')`.
+  let castEquiv : Fin (P.copies j₀) ≃ Fin (Q.copies k₀') :=
+    (Fin.castOrderIso hCopies).toEquiv
+  refine ⟨hCopies, σ.trans castEquiv, ?_⟩
+  intro q
+  have hPoint : P.weight j₀ q = ζ * Q.weight k₀' (Fin.cast hCopies (σ q)) :=
+    hσ q
+  have hQ : Q.weight k₀' ((σ.trans castEquiv) q)
+      = Q.weight k₀' (Fin.cast hCopies (σ q)) := by
+    simp [castEquiv]
+  rw [hQ, hPoint, ← mul_assoc, inv_mul_cancel₀ hζ, one_mul]
+
 end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1293,6 +1293,72 @@ of~\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}.
 	\(P\)-indexing as required.
 \end{proof}
 
+\begin{lemma}[Matched-sector weight-permutation extractor]%
+	\label{lem:paper_bnt_matched_sector_weight_equiv}
+	\lean{MPSTensor.matched_sector_weight_equiv}
+	\leanok
+	\uses{lem:paper_bnt_matched_sector_weight_multiset_eq}
+	Under the hypotheses of
+	Lemma~\ref{lem:paper_bnt_matched_sector_weight_multiset_eq}, there
+	exist a per-sector multiplicity match
+	\(h : P.\texttt{copies}\,j_0 = Q.\texttt{copies}\,\tilde k_0\) and an
+	explicit permutation
+	\[
+		\tau \;:\;
+		\texttt{Fin}\,(P.\texttt{copies}\,j_0)
+		\;\simeq\;
+		\texttt{Fin}\,(Q.\texttt{copies}\,\tilde k_0)
+	\]
+	identifying the individual per-copy weights up to the gauge phase:
+	\[
+		Q.\texttt{weight}\,\tilde k_0\,(\tau\,q)
+		\;=\;
+		\zeta^{-1} \cdot P.\texttt{weight}\,j_0\,q
+		\qquad \text{for every } q.
+	\]
+	This is the per-copy realisation of
+	\cite[\S~II, line 1188]{Cirac2017MPDO_AnnPhys}
+	(\(\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}\)): the multiset equality
+	from Lemma~\ref{lem:paper_bnt_matched_sector_weight_multiset_eq} is
+	upgraded to a concrete indexing between the matched \(P\)- and
+	\(Q\)-copies.
+\end{lemma}
+
+\begin{proof}\leanok
+	Invoke Lemma~\ref{lem:paper_bnt_matched_sector_weight_multiset_eq} to
+	obtain the cardinality match \(h\) and the multiset equality
+	\[
+		\texttt{Multiset.map}\,(P.\texttt{weight}\,j_0)\,
+			\texttt{Finset.univ.val}
+		\;=\;
+		\texttt{Multiset.map}\,\bigl(q \mapsto \zeta \cdot
+			Q.\texttt{weight}\,\tilde k_0\,(\texttt{Fin.cast}\,h\,q)\bigr)\,
+			\texttt{Finset.univ.val}.
+	\]
+	From this multiset-map equality on
+	\(\texttt{Fin}\,(P.\texttt{copies}\,j_0)\) extract a permutation
+	\(\sigma : \texttt{Equiv.Perm}\,(\texttt{Fin}\,(P.\texttt{copies}\,j_0))\)
+	satisfying
+	\[
+		P.\texttt{weight}\,j_0\,q
+		\;=\;
+		\zeta \cdot Q.\texttt{weight}\,\tilde k_0\,
+			(\texttt{Fin.cast}\,h\,(\sigma\,q))
+		\qquad \text{for every } q.
+	\]
+	The underlying combinatorial fact is that two equal multisets over
+	\(\texttt{Fin}\,n\) admit an index permutation matching their elements
+	pointwise (proved by induction on \(n\) via
+	\texttt{Fin.univ\_succAbove} for the multiset decomposition and
+	\texttt{finSuccEquiv$'$} for the assembly of the permutation at the
+	successor step).  Compose with the cardinality cast
+	\(\texttt{Fin.castOrderIso}\,h\) to define
+	\(\tau := \sigma \,;\, \texttt{Fin.castOrderIso}\,h\) and cancel
+	\(\zeta\) via \(\zeta \neq 0\) (\texttt{mul\_inv\_cancel}_0) to convert
+	the gauge factor on the right of the pointwise identity to
+	\(\zeta^{-1}\) on the left.
+\end{proof}
+
 \subsection{Cross-overlap decay against a dropped sector}
 \label{sec:paper_bnt_drop_sector_overlap_decay}
 


### PR DESCRIPTION
Closes (refines toward) #1721; advances #1713 and the broader CPSV16/CPSV21 fundamental-theorem effort (#1685).

## Summary

Adds `MPSTensor.matched_sector_weight_equiv` (and a private auxiliary
`exists_perm_of_multiset_map_univ_eq`) in
`TNLean/MPS/FundamentalTheorem/PaperBNT/StrongInduction.lean`,
immediately after `matched_sector_weight_multiset_eq`.

Given:

* `P, Q : SectorDecomposition d`;
* matched indices `j₀ : Fin P.basisCount`,
  `k₀' : Fin Q.basisCount`;
* gauge phase `ζ ∈ ℂ \ {0}`;
* eventual coefficient identity
  `∀ N > N₀, P.coeff N j₀ = ζ^N · Q.coeff N k₀'`;

the new theorem produces

* a cardinality match `hCopies : P.copies j₀ = Q.copies k₀'`, and
* an explicit permutation
  `τ : Fin (P.copies j₀) ≃ Fin (Q.copies k₀')` with
  `∀ q, Q.weight k₀' (τ q) = ζ⁻¹ · P.weight j₀ q`.

This is the per-copy realisation of CPSV16 line 1188
(`μ_{j,q} = ν_{j,q} · e^{iφ_j}`).

## How the bijection was extracted

**Hand-rolled, not a Mathlib drop-in.**  A search of Mathlib turned up
no direct extractor producing `Equiv.Perm (Fin n)` from a multiset-map
equality on `Fin n` (Batteries has `List.Perm.idxBij` but requires
`LawfulBEq` which `ℂ` does not carry as a registered instance).
The auxiliary

```lean
private lemma exists_perm_of_multiset_map_univ_eq {α : Type*} :
    ∀ {n : ℕ} (f g : Fin n → α),
      Multiset.map f (Finset.univ : Finset (Fin n)).val =
        Multiset.map g (Finset.univ : Finset (Fin n)).val →
      ∃ σ : Equiv.Perm (Fin n), ∀ q, f q = g (σ q)
```

is proved by induction on `n`:

* **`zero`**: `σ := Equiv.refl _`, the conclusion vacuous.
* **`succ`**: locate `j : Fin (n+1)` with `g j = f 0` via
  `Multiset.mem_map`; decompose both multisets through
  `Fin.univ_succAbove`; reduce to a multiset-map equality on
  `Fin n` using `Multiset.cons_inj_right`; apply the induction
  hypothesis; reassemble `σ` via
  `finSuccEquiv' (0 : Fin (n+1))`, `Equiv.optionCongr σ'`, and
  `(finSuccEquiv' j).symm` so that `σ 0 = j` and
  `σ i.succ = j.succAbove (σ' i)`.

The main theorem then composes this `σ` with the cardinality cast
`Fin.castOrderIso hCopies` and cancels `ζ` with
`mul_inv_cancel₀ hζ`.

## Files touched

* `TNLean/MPS/FundamentalTheorem/PaperBNT/StrongInduction.lean`
  (+127 LoC including docstrings and the auxiliary lemma).
* `blueprint/src/chapter/ch10_bnt.tex` (+66 LoC: new
  `lem:paper_bnt_matched_sector_weight_equiv` immediately after the
  multiset-equality lemma).

Total: +193 LoC, no `sorry`/`axiom`/`unsafe`.

## Build

`lake build TNLean.MPS.FundamentalTheorem.PaperBNT.StrongInduction`
completes cleanly (8.6s on a hot cache).  No new linter warnings
introduced; one `set_option linter.unusedVariables false in` shields
the named existential binder `hCopies` (the issue's spec asks for that
exact identifier in the statement, but Lean's linter flags it as unused
because the cardinality match is consumed only structurally to type
`τ`).

## Auxiliary lemmas

* `MPSTensor.exists_perm_of_multiset_map_univ_eq` (private to
  `StrongInduction.lean`).  Could be lifted to a more public location
  later if reused.

## References

* CPSV16 §II.C lines 1158–1167, 1184, 1188 (arXiv:1606.00608).
* Issues: #1721 (this), #1713 (cross-overlap decay obstacle), #1685
  (umbrella).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a nontrivial new combinatorial lemma to extract an `Equiv.Perm` from multiset-map equality and uses it to produce an explicit weight-matching equivalence; proof complexity means higher risk of subtle lemma/rewriting issues, but changes are localized to one module and documentation.
> 
> **Overview**
> Introduces `MPSTensor.matched_sector_weight_equiv`, strengthening `matched_sector_weight_multiset_eq` by producing an explicit `τ : Fin (P.copies j₀) ≃ Fin (Q.copies k₀')` such that `Q.weight k₀' (τ q) = ζ⁻¹ * P.weight j₀ q` (and returning the copy-count equality used to type the cast).
> 
> Adds a private helper `exists_perm_of_multiset_map_univ_eq` that extracts an `Equiv.Perm (Fin n)` from equality of `Multiset.map` over `Finset.univ`, and updates the blueprint (`ch10_bnt.tex`) with a corresponding lemma statement/proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f11d2094253ba51eba2f4f2be4f3930503ee59c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->