### PR TITLE
feat(MPS/FT/PaperBNT): Phase A course correction — retire weight_unit_at_dominant_block (#1725)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
@@ -39,6 +39,10 @@ not imported here.
   of the multiplicity bound (CPSV16 line 246 via `weight_norm_le_one`).
 * `IsBNTCanonicalForm.weight_unit_exists_of_struct` — the existential
   unit-modulus witness re-exposed at the API layer (CPSV16 line 246).
+* `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_unit_block` — the
+  Cesàro non-decay reading of CPSV16 line 246 + line 1244, parametrised
+  by the unit-modulus block witness (issue #1725 Phase A; audit memo
+  `/tmp/phase_4c_drift_audit_2026-05-14.md`).
 
 ## References
 
@@ -212,64 +216,62 @@ lemma weight_unit_exists_of_struct (h : IsBNTCanonicalForm P) :
     ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
       ‖P.weight j q‖ = 1 := h.weight_unit_exists
 
-/-- **Dominant-block coefficient non-decay.**
+/-- **CPSV16 line 246 + line 1244 generalization.**
 
-Under the CPSV16 §II.A line-246 normalization carried by
-`IsBNTCanonicalForm` (every weight has modulus `≤ 1`, and at index `0`
-some copy has unit modulus — `weight_norm_le_one` and
-`weight_unit_at_dominant_block`), the dominant-sector coefficient
-`P.coeff N ⟨0, hP_pos⟩ = ∑_q (P.weight ⟨0, hP_pos⟩ q)^N` does **not**
-tend to `0` as `N → ∞`.
+For any sector `j₀ : Fin P.basisCount` that contains at least one
+unit-modulus weight, the power-sum coefficient
+`P.coeff N j₀ = ∑_q (P.weight j₀ q)^N` does **not** tend to `0` as
+`N → ∞`.
 
-This is the structural-field replacement of the residual
-`hP_dom_coeff_not_tendsto_zero` hypothesis previously carried by
-`exists_dominant_match_of_sameMPV` in `PaperBNT/DominantMatch.lean`.
-Its proof reduces directly to the Cesàro non-decay analytic lemma
-`MPSTensor.CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus`:
-both hypotheses of that lemma (`‖μ q‖ ≤ 1` and the unit-modulus witness
-in the dominant block) are exactly the two structural fields of
-`IsBNTCanonicalForm` at sector index `0`.
+The unit-modulus witness is supplied externally because the structural
+field `IsBNTCanonicalForm.weight_unit_exists` only asserts the
+**global** existence of some `(j, q)` with unit-modulus weight (CPSV16
+§II.A line 246, verbatim); it does not pin the witness to a specific
+sector.  Callers that have an arrow-specific unit-modulus witness (for
+example from a downstream matching argument that has already isolated a
+sector) pass it in here.
 
-Paper anchor: CPSV16 §II.A lines 1181–1188.  The body of the FT proof
-takes the assumed line-246 normalization and reads off non-decay of the
-dominant-block coefficient power-sum; this lemma formalises that
-reading. -/
-lemma coeff_dominant_not_tendsto_zero
-    (h : IsBNTCanonicalForm P) (hP_pos : 0 < P.basisCount) :
-    ¬ Tendsto (fun N : ℕ => P.coeff N ⟨0, hP_pos⟩) atTop (𝓝 0) := by
-  -- Extract the dominant-block weight family and its CPSV16 §II.A
-  -- line-246 properties at sector `0`.
-  have h_le : ∀ q : Fin (P.copies ⟨0, hP_pos⟩),
-      ‖P.weight ⟨0, hP_pos⟩ q‖ ≤ 1 := h.weight_norm_le_one ⟨0, hP_pos⟩
-  have h_unit : ∃ q : Fin (P.copies ⟨0, hP_pos⟩),
-      ‖P.weight ⟨0, hP_pos⟩ q‖ = 1 :=
-    h.weight_unit_at_dominant_block hP_pos
+Paper anchor: CPSV16 §II.A line 246 (the "at least one `|μ_k| = 1`"
+convention) combined with line 1244 (the assumed normalization makes
+the transfer-matrix-power sequence converge); proof via Cesàro
+non-decay (`PaperBNT/CesaroNonDecay.lean`,
+`sum_pow_not_tendsto_zero_of_unit_modulus`, CPSV16 lines 1158–1167). -/
+theorem coeff_not_tendsto_zero_at_unit_block
+    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
+    (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1) :
+    ¬ Tendsto (fun N : ℕ => P.coeff N j₀) atTop (𝓝 0) := by
+  -- Extract the unit-block weight family and its CPSV16 §II.A
+  -- line-246 properties at sector `j₀`.
+  have h_le : ∀ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ ≤ 1 :=
+    h.weight_norm_le_one j₀
   -- Apply the Cesàro non-decay analytic lemma.
   have hAnal := CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus
-    (P.weight ⟨0, hP_pos⟩) h_le h_unit
-  -- `P.coeff N ⟨0, hP_pos⟩ = ∑ q, (P.weight ⟨0, hP_pos⟩ q)^N` is `rfl`.
+    (P.weight j₀) h_le hUnit
+  -- `P.coeff N j₀ = ∑ q, (P.weight j₀ q)^N` is `rfl`.
   intro hTend
-  apply hAnal
-  exact hTend
+  exact hAnal hTend
 
-/-- **Thermodynamic-limit non-vanishing of the dominant coefficient.**
+/-- **Thermodynamic-limit non-vanishing of a unit-block coefficient.**
 
-A user-facing alias for `coeff_dominant_not_tendsto_zero`, named in the
-language of the audit memo
+A user-facing alias for `coeff_not_tendsto_zero_at_unit_block`, named
+in the language of the audit memo
 `thermodynamic_limit_normalization_audit_2026-05-14` §Q-C: the
-CPSV16 §II.A line-246 normalization picks out the dominant block whose
-power-sum coefficient does **not** vanish in the thermodynamic limit.
+CPSV16 §II.A line-246 normalization picks out the unit-modulus block(s)
+whose power-sum coefficient does **not** vanish in the thermodynamic
+limit.
 
 This is the coefficient form of the audit's "thermodynamic-limit
-non-vanishing" condition.  A self-overlap form
-`limsup_N ⟨A^⊕|A^⊕⟩^{(N)} ∈ (0, ∞)` is the implication
-recorded by the audit's Q-C equivalence (forward direction), which we
-do not formalise here — the coefficient form is the operational input
-to the FT proof; the self-overlap reading is a paraphrase. -/
+non-vanishing" condition, parametrised by the unit-modulus block
+witness supplied by the caller.  A self-overlap form
+`limsup_N ⟨A^⊕|A^⊕⟩^{(N)} ∈ (0, ∞)` is the implication recorded by
+the audit's Q-C equivalence (forward direction), which we do not
+formalise here — the coefficient form is the operational input to the
+FT proof; the self-overlap reading is a paraphrase. -/
 lemma thermodynamic_limit_nonvanishing
-    (h : IsBNTCanonicalForm P) (hP_pos : 0 < P.basisCount) :
-    ¬ Tendsto (fun N : ℕ => P.coeff N ⟨0, hP_pos⟩) atTop (𝓝 0) :=
-  h.coeff_dominant_not_tendsto_zero hP_pos
+    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
+    (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1) :
+    ¬ Tendsto (fun N : ℕ => P.coeff N j₀) atTop (𝓝 0) :=
+  h.coeff_not_tendsto_zero_at_unit_block j₀ hUnit
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
@@ -138,32 +138,26 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
     ‖P.weight j q‖ ≤ 1
   /-- **CPSV16 line-246 normalization, unit-witness existence.**  At least
   one copy of one basis sector has unit-modulus weight.  CPSV16 §II.A
-  line 246: "at least one of them equals one, something which we will
-  assume from now on"; used in the FT proof at line 1244 (the assumed
-  normalization makes the transfer-matrix-power sequence converge, picking
-  out the dominant block).  This is the existential form of the paper's
-  convention; relabelling sectors so the unit-modulus copy sits in
-  sector 0 specialises it to the index-0 reading used in the FT
-  dominant-block projection (CPSV16 lines 1181–1188). -/
+  line 246 (verbatim): "we can always choose `|μ_k| ≤ 1` and at least one
+  of them equals one, something which we will assume from now on."  The
+  paper states this **globally** over the two-layer index `(j, q)` of the
+  two-layer BNT display (CPSV16 lines 287–301): the existential ranges over
+  all `(j, q)` pairs and does **not** pin the witness to a specific
+  sector.  The witness is reinvoked in the body of the FT proof at
+  CPSV16 line 1244 ("the assumed normalization `|μ_{jq}| ≤ 1` … implies
+  that `𝔼^N` converges"), again read off the two-layer indexing without a
+  sector-specific reading.
+
+  A previous design carried an extra structural field pinning the
+  witness to sector index 0; this was an engineering artifact, removed
+  in the Phase A cleanup of issue #1725 (audit memo
+  `/tmp/phase_4c_drift_audit_2026-05-14.md`).  Downstream code that
+  needs a unit-modulus witness in a specific sector now supplies the
+  sector index and unit-modulus existential externally; see
+  `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_unit_block`
+  (`PaperBNT/Api.lean`). -/
   weight_unit_exists : ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ = 1
-  /-- **CPSV16 line-246 normalization, dominant-block reading.**  When the
-  decomposition has at least one basis sector, the sector at index `0`
-  carries a unit-modulus copy.  CPSV16 §II.A line 246 only states the
-  existential form `∃ j q, ‖μ_{j,q}‖ = 1`, but the body of the FT proof
-  (CPSV16 lines 1181–1188) **uses** the index-0 reading: the dominant
-  sector is selected by the unit-modulus weight, and the relabelling
-  convention places the dominant sector at index `0`.  This field records
-  that relabelling step structurally so it does not need to be supplied
-  externally; the proof of `coeff_dominant_not_tendsto_zero`
-  (PaperBNT/CesaroNonDecay.lean) reads off the dominant-block coefficient
-  non-decay directly from this field via the Cesàro-mean argument.
-
-  When `P.basisCount = 0`, the field is vacuous (no `hpos` premise is
-  available).  When `P.basisCount = 1`, the field collapses to
-  `weight_unit_exists` with the unique sector index. -/
-  weight_unit_at_dominant_block : ∀ (hpos : 0 < P.basisCount),
-    ∃ q : Fin (P.copies ⟨0, hpos⟩), ‖P.weight ⟨0, hpos⟩ q‖ = 1
 
 namespace IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
@@ -24,36 +24,40 @@ The module has three layers:
    (`exists_nondecaying_overlap_pair_of_eventuallyProportional`,
    `PaperBNT/WeakExistential.lean`) to the `SameMPV₂` hypothesis: some pair
    of basis blocks has a non-decaying cross-overlap.
-3. **Lemma 3** — the **dominant-pair matching** statement: for the dominant
-   block of `P` (index `⟨0, hP_pos⟩`), there is a block `k₀` of `Q` of equal
-   bond dimension, gauge-phase equivalent (cast-left shape) to the dominant
-   `P`-block, and with a non-decaying cross-overlap.
+3. **Lemma 3** — the **unit-block matching** statement: for any sector
+   `j₀ : Fin P.basisCount` carrying a unit-modulus copy (supplied
+   externally), there is a block `k₀` of `Q` of equal bond dimension,
+   gauge-phase equivalent (cast-left shape) to the `P`-block at `j₀`,
+   and with a non-decaying cross-overlap.
 
 ## Hypothesis disclosure (paper-faithful)
 
-The dominant-pair matching at the **fixed** index `⟨0, hP_pos⟩` does not
-follow from the core seven-field `IsBNTCanonicalForm` data alone: the core
-seven fields are deliberately invariant under relabelling of sectors and do
-not single out a dominant sector.  Following the CPSV16 §II.A line-246
-normalization convention, `IsBNTCanonicalForm` carries three additional
+The unit-block matching at a **user-supplied** sector index
+`j₀ : Fin P.basisCount` (with an externally provided unit-modulus
+witness) does not single out any particular sector internally: the core
+seven `IsBNTCanonicalForm` fields are deliberately invariant under
+relabelling of sectors.  Following the CPSV16 §II.A line-246
+normalization convention, `IsBNTCanonicalForm` carries two additional
 structural fields:
 
 * `weight_norm_le_one : ∀ j q, ‖weight j q‖ ≤ 1`  — CPSV16 line 246, the
   modulus bound.  Lemma 3 below feeds this in via `hP.weight_norm_le_one`
-  and `hQ.weight_norm_le_one`, replacing the prior explicit `hP_norm /
-  hQ_norm` parameters.
+  and `hQ.weight_norm_le_one`.
 * `weight_unit_exists : ∃ j q, ‖weight j q‖ = 1`  — CPSV16 line 246,
-  the unit-modulus existential.
-* `weight_unit_at_dominant_block : ∀ hpos, ∃ q, ‖weight ⟨0, hpos⟩ q‖ = 1`
-  — CPSV16 line 246 read at the **dominant** sector index `0`, which is
-  the form used in the FT proof (CPSV16 lines 1181–1188).
+  the unit-modulus existential (global, over the two-layer index
+  `(j, q)`).
 
-The dominant-block coefficient non-decay
-`¬ Tendsto (P.coeff · ⟨0, hP_pos⟩) atTop (𝓝 0)` is now **derived** from
-the third structural field above via the Cesàro non-decay analytic lemma
-in `PaperBNT/CesaroNonDecay.lean` and is no longer an explicit parameter
-on Lemma 3.  The reduction is recorded in
-`IsBNTCanonicalForm.coeff_dominant_not_tendsto_zero` (`PaperBNT/Api.lean`).
+Issue #1725 Phase A retired an auxiliary dominant-block structural
+field (audit memo `/tmp/phase_4c_drift_audit_2026-05-14.md` §Q-C):
+CPSV16 line 246 is
+**global** and does not pin the unit-modulus copy to sector 0.  The
+matching theorem below now takes the unit-modulus sector as an
+**explicit parameter** `j₀ : Fin P.basisCount` together with a
+per-sector unit-modulus existential
+`hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`.  The non-decay of the matched
+sector's coefficient is then derived inside the proof via
+`IsBNTCanonicalForm.coeff_not_tendsto_zero_at_unit_block`
+(`PaperBNT/Api.lean`).
 
 These hypotheses are weaker than the legacy `IsCanonicalFormBNT` package
 (which baked in `mu_strict_anti` + a single per-sector "spectral level"
@@ -137,38 +141,38 @@ theorem exists_nondecaying_overlap_pair_of_sameMPV
   exists_nondecaying_overlap_pair_of_eventuallyProportional
     (P := P) (Q := Q) hP hQ hQ_pos hEqual.toEventuallyNonzeroProportionalMPV₂
 
-/-! ### Lemma 3: dominant-pair matching at the fixed index `0`
+/-! ### Lemma 3: unit-block matching at a user-supplied index `j₀`
 
-The main result of Phase 4b-ii: under `SameMPV₂` plus the dominant-block
-coefficient non-decay assumption, the dominant block `P.basis ⟨0, hP_pos⟩`
-of `P` has a `Q`-side match `Q.basis k₀` of equal bond dimension,
-gauge-phase equivalent in the cast-left shape, and with a non-decaying
-cross-overlap.
+The main result of Phase 4b-ii: under `SameMPV₂` plus a unit-modulus
+witness `∃ q, ‖P.weight j₀ q‖ = 1` at a user-supplied sector index
+`j₀ : Fin P.basisCount`, the block `P.basis j₀` of `P` has a `Q`-side
+match `Q.basis k₀` of equal bond dimension, gauge-phase equivalent in
+the cast-left shape, and with a non-decaying cross-overlap.
 
-The proof is a direct read of the CPSV16 lines 1172–1188 dominant-block
+The proof is a direct read of the CPSV16 lines 1172–1188 unit-block
 projection: assume by contradiction that **all** cross-overlaps
-`mpvOverlap (P.basis ⟨0, _⟩) (Q.basis k)` decay; project the `SameMPV₂`
-identity onto `mpvState (P.basis ⟨0, _⟩)` (taking the bilinear overlap with
-the dominant `P`-block).
+`mpvOverlap (P.basis j₀) (Q.basis k)` decay; project the `SameMPV₂`
+identity onto `mpvState (P.basis j₀)` (taking the bilinear overlap with
+the `j₀`-th `P`-block).
 
-* The LHS = `∑_j P.coeff N j · overlap(P.basis j, P.basis ⟨0, _⟩) N`
-  is `P.coeff N ⟨0, _⟩ + (small)` thanks to:
-  – `basis_normalized_self_overlap` at `j = 0` (`overlap → 1`);
-  – `cross_overlap_basis_tendsto_zero` at `j ≠ 0` (`overlap → 0`);
+* The LHS = `∑_j P.coeff N j · overlap(P.basis j, P.basis j₀) N`
+  is `P.coeff N j₀ + (small)` thanks to:
+  – `basis_normalized_self_overlap` at `j = j₀` (`overlap → 1`);
+  – `cross_overlap_basis_tendsto_zero` at `j ≠ j₀` (`overlap → 0`);
   – the structural field `weight_norm_le_one` of `IsBNTCanonicalForm`
     (CPSV16 §II.A line 246) feeds into
     `norm_coeff_le_copies_of_norm_weight_le_one` (`Api.lean`) and gives
     the coefficient bound `‖P.coeff N j‖ ≤ P.copies j`.
 
-* The RHS = `∑_k Q.coeff N k · overlap(Q.basis k, P.basis ⟨0, _⟩) N`
+* The RHS = `∑_k Q.coeff N k · overlap(Q.basis k, P.basis j₀) N`
   vanishes asymptotically, again by coefficient boundedness from
   `hQ.weight_norm_le_one` and the contrapositive assumption that all
   `k`-overlaps decay.
 
-* `SameMPV₂` makes both sides equal, so `P.coeff N ⟨0, _⟩` tends to `0`,
-  contradicting `IsBNTCanonicalForm.coeff_dominant_not_tendsto_zero`
-  (derived from the structural field `weight_unit_at_dominant_block` via
-  the Cesàro non-decay lemma in `PaperBNT/CesaroNonDecay.lean`).
+* `SameMPV₂` makes both sides equal, so `P.coeff N j₀` tends to `0`,
+  contradicting `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_unit_block`
+  applied to the user-supplied unit-modulus witness `hUnit` via the
+  Cesàro non-decay lemma in `PaperBNT/CesaroNonDecay.lean`.
 
 The extracted `k₀` then satisfies (i) equal bond dimensions, via the
 contrapositive of
@@ -176,25 +180,29 @@ contrapositive of
 gauge-phase equivalence, via the contrapositive of
 `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`.
 
-Hypothesis disclosure: the modulus bounds `weight_norm_le_one` and the
-dominant-block unit-modulus witness `weight_unit_at_dominant_block` are
-both structural fields of `IsBNTCanonicalForm` (CPSV16 §II.A line 246)
-and need not be supplied externally.  The dominant-block coefficient
-non-decay is derived from these inside the proof via
-`IsBNTCanonicalForm.coeff_dominant_not_tendsto_zero` (`PaperBNT/Api.lean`).
--/
-theorem exists_dominant_match_of_sameMPV
+Hypothesis disclosure: the modulus bound `weight_norm_le_one` is a
+structural field of `IsBNTCanonicalForm` (CPSV16 §II.A line 246) and
+need not be supplied externally.  The unit-modulus witness at the
+chosen sector `j₀` is supplied externally because CPSV16 line 246 is
+**global** (the unit-modulus copy can sit in any sector); the
+structural field `weight_unit_exists` does not pin it to a specific
+sector.  Issue #1725 Phase A retired the auxiliary dominant-block
+structural field that previously fixed `j₀ = 0` and discharged the
+unit-modulus witness implicitly. -/
+theorem exists_unit_block_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hP_pos : 0 < P.basisCount) (hQ_pos : 0 < Q.basisCount)
+    (hQ_pos : 0 < Q.basisCount)
+    (j₀ : Fin P.basisCount)
+    (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ k₀ : Fin Q.basisCount,
-      ∃ h : P.basisDim ⟨0, hP_pos⟩ = Q.basisDim k₀,
+      ∃ h : P.basisDim j₀ = Q.basisDim k₀,
         GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (P.basis ⟨0, hP_pos⟩))
+            (cast (congr_arg (MPSTensor d) h) (P.basis j₀))
             (Q.basis k₀) ∧
         ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (P.basis ⟨0, hP_pos⟩) (Q.basis k₀) N)
+            mpvOverlap (d := d) (P.basis j₀) (Q.basis k₀) N)
           atTop (𝓝 0) := by
   classical
   -- The Q-side positivity hypothesis is part of the user-facing signature
@@ -207,12 +215,11 @@ theorem exists_dominant_match_of_sameMPV
   -- used to be supplied as explicit parameters at the call site.
   have hP_weight_le := hP.weight_norm_le_one
   have hQ_weight_le := hQ.weight_norm_le_one
-  -- Dominant-block coefficient non-decay derived from the structural
-  -- field `weight_unit_at_dominant_block` via the Cesàro non-decay lemma.
+  -- Unit-block coefficient non-decay derived from the user-supplied
+  -- unit-modulus witness `hUnit` via the Cesàro non-decay lemma.
   have hP_dom_coeff_not_tendsto_zero :
-      ¬ Tendsto (fun N : ℕ => P.coeff N ⟨0, hP_pos⟩) atTop (𝓝 0) :=
-    hP.coeff_dominant_not_tendsto_zero hP_pos
-  set j₀ : Fin P.basisCount := ⟨0, hP_pos⟩ with hj₀_def
+      ¬ Tendsto (fun N : ℕ => P.coeff N j₀) atTop (𝓝 0) :=
+    hP.coeff_not_tendsto_zero_at_unit_block j₀ hUnit
   -- Step 1: extract some k₀ with non-decaying overlap to `P.basis j₀`.
   have hExists_k :
       ∃ k₀ : Fin Q.basisCount,

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DropMatchedSector.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DropMatchedSector.lean
@@ -26,8 +26,9 @@ The matched-pair hypotheses (`hMpv` for the gauge-phase relation on basis
 MPVs, and `τ`/`hWeight` for the weight permutation) are exactly the data
 extracted, in the CPSV16 §II `II_cor2` proof outline, from:
 
-* `exists_dominant_match_of_sameMPV` (`PaperBNT/DominantMatch.lean`),
-  Phase 4b-ii, supplying `(k₀, h_dim, GaugePhaseEquiv)`;
+* `exists_unit_block_match_of_sameMPV` (`PaperBNT/DominantMatch.lean`),
+  Phase 4b-ii (parametrised by a unit-modulus block witness; issue #1725
+  Phase A), supplying `(k₀, h_dim, GaugePhaseEquiv)`;
 * `Multiset.eq_of_power_sum_eq` (`PaperBNT/NewtonGirard.lean`), Phase 4b-i,
   supplying the matched weight permutation via multiplicity recovery.
 
@@ -81,7 +82,8 @@ For each `(N, σ)`:
 
 Phase 4c (strong induction → full conjunction) will iterate:
 
-* invoke `exists_dominant_match_of_sameMPV` to extract a matched index;
+* invoke `exists_unit_block_match_of_sameMPV` to extract a matched index
+  (after supplying a unit-modulus block witness; issue #1725 Phase A);
 * invoke `Multiset.eq_of_power_sum_eq` (after coefficient extraction) to
   build the weight permutation `τ`;
 * invoke the present `sameMPV_dropSector_dropSector` to drop both matched

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DropSector.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DropSector.lean
@@ -217,23 +217,20 @@ Every field of the paper-faithful canonical-form predicate transfers from
   only non-pointwise field: dropping the sector that carried the unique
   unit-modulus weight would destroy the existential witness, so the
   caller must supply a unit-modulus witness on the *remaining*
-  decomposition.  In the CPSV16 §II `II_cor2` induction this is the
-  normalization step that re-orients the next-dominant block; the
-  `hUnitRem` hypothesis below records that step abstractly.
-* `weight_unit_at_dominant_block` (CPSV16 line 246, dominant-block
-  reading) is the index-0 specialisation of `weight_unit_exists`; the
-  `hUnitDomRem` hypothesis records the index-0 witness on the remaining
-  decomposition, again recording the relabelling step abstractly.
+  decomposition.  The `hUnitRem` hypothesis below records that step
+  abstractly.  (Issue #1725 Phase A retired the auxiliary dominant-block
+  structural field that previously required a second `hUnitDomRem`
+  parameter; that parameter is no longer needed here.)
 
-This is the foundational lemma for the CPSV16 §II `II_cor2` induction step
-(lines 1172–1192). -/
+This is a foundational lemma originally intended for the CPSV16 §II
+`II_cor2` strong-induction route (lines 1172–1192).  It is retained
+for completeness; the paper-faithful Phase 4c route favoured by the
+drift audit (`/tmp/phase_4c_drift_audit_2026-05-14.md` §8) does not
+chain `dropSector`-preservation on `IsBNTCanonicalForm`. -/
 def dropSector
     (hP : IsBNTCanonicalForm P) (h : P.basisCount = n + 1) (i₀ : Fin (n + 1))
     (hUnitRem : ∃ (j : Fin n) (q : Fin ((P.dropSector h i₀).copies j)),
-      ‖(P.dropSector h i₀).weight j q‖ = 1)
-    (hUnitDomRem : ∀ (hpos : 0 < n),
-      ∃ q : Fin ((P.dropSector h i₀).copies ⟨0, hpos⟩),
-        ‖(P.dropSector h i₀).weight ⟨0, hpos⟩ q‖ = 1) :
+      ‖(P.dropSector h i₀).weight j q‖ = 1) :
     IsBNTCanonicalForm (P.dropSector h i₀) where
   basis_dim_pos _ := hP.basis_dim_pos _
   basis_injective _ := hP.basis_injective _
@@ -291,7 +288,6 @@ def dropSector
     simpa [SectorDecomposition.dropSector_weight,
            SectorDecomposition.dropSector_copies] using this _
   weight_unit_exists := hUnitRem
-  weight_unit_at_dominant_block := hUnitDomRem
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
@@ -93,13 +93,6 @@ noncomputable example
     refine ⟨0, 0, ?_⟩
     change ‖(1 : ℂ)‖ = 1
     simp
-  -- CPSV16 line 246 (dominant-block reading): the unique weight at the
-  -- unique sector is the unit-modulus witness.
-  weight_unit_at_dominant_block := by
-    intro _
-    refine ⟨0, ?_⟩
-    change ‖(1 : ℂ)‖ = 1
-    simp
 
 /-! ## Example 2 — `C ⊕ (-C)` -/
 
@@ -153,13 +146,6 @@ noncomputable example
   -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
-    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else -1)‖ = 1
-    simp
-  -- CPSV16 line 246 (dominant-block reading): the first copy of the unique
-  -- sector carries weight `μ = 1`.
-  weight_unit_at_dominant_block := by
-    intro _
-    refine ⟨0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else -1)‖ = 1
     simp
 
@@ -222,13 +208,6 @@ noncomputable example
   -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
-    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ = 1
-    simp
-  -- CPSV16 line 246 (dominant-block reading): the first copy of the unique
-  -- sector carries weight `μ = 1`.
-  weight_unit_at_dominant_block := by
-    intro _
-    refine ⟨0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ = 1
     simp
 
@@ -346,13 +325,6 @@ noncomputable example
   -- CPSV16 line 246: the first copy `q = 0` carries the unit weight.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
-    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
-    simp
-  -- CPSV16 line 246 (dominant-block reading): the first copy of the unique
-  -- sector carries the unit weight.
-  weight_unit_at_dominant_block := by
-    intro _
-    refine ⟨0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
     simp
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongInduction.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongInduction.lean
@@ -133,7 +133,7 @@ Given:
   `mpv (Q.basis k₀') σ = ζ^N · mpv (P.basis j₀) σ` for every system size
   and configuration (this is the output of
   `MPSTensor.mpv_eq_pow_mul_of_gaugePhase` applied to the
-  `GaugePhaseEquiv` witness from `exists_dominant_match_of_sameMPV`,
+  `GaugePhaseEquiv` witness from `exists_unit_block_match_of_sameMPV`,
   CPSV16 line 1187);
 * `hCombLI` — combined-family eventual linear independence of
   `P.basis ⊔ (Q.dropSector k₀).basis` (the paper-faithful Lem1 input,

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1082,16 +1082,25 @@ of \cite[\S~II, lines~1184--1188]{Cirac2017MPDO_AnnPhys}.
 	Lemma~\ref{lem:paper_bnt_sameMPV_dropSector_dropSector}.
 \end{proof}
 
-\section{Ces\`aro non-decay and dominant-block coefficient}
+\section{Ces\`aro non-decay and unit-block coefficient}
 \label{sec:paper_bnt_cesaro_nondecay}
 
-This section formalizes the analytic input that lets us replace the
-residual ``dominant coefficient does not asymptotically vanish'' hypothesis
-on the dominant-pair matching of
-\cite[\S~II, lines~1181--1188]{Cirac2017MPDO_AnnPhys} by a derived lemma.
+This section formalizes the analytic input that supplies, for any
+sector \(j_0\) carrying a unit-modulus weight, the
+``sector-\(j_0\) coefficient does not asymptotically vanish''
+ingredient used in the matching step of
+\cite[\S~II, lines~1181--1188]{Cirac2017MPDO_AnnPhys}.
 The reduction is to a pure-analytic statement: a finite sum of $N$-th
 powers of complex numbers in the closed unit disk, with at least one
 unit-modulus summand, cannot tend to zero.
+
+Issue~\#1725 Phase~A parametrised the lemma below (and its consumer,
+\texttt{exists\_unit\_block\_match\_of\_sameMPV}) by an externally
+supplied unit-modulus block witness, faithfully mirroring the
+\emph{global} character of the CPSV16 line~246 normalization (audit memo
+\texttt{/tmp/phase\_4c\_drift\_audit\_2026-05-14.md} §Q-C).  A previous
+design carried a structural field pinning the unit-modulus copy to
+sector index~0; that field was retired as an engineering artifact.
 
 The proof is the elementary Ces\`aro-mean identity:
 \(
@@ -1114,7 +1123,7 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
 	Let $\mu : \{0, \dotsc, r-1\} \to \mathbb{C}$ satisfy $|\mu_q| \leq 1$
 	for every $q$ and let some $q^*$ satisfy $|\mu_{q^*}| = 1$.  Then the
 	sequence $N \mapsto \sum_{q=0}^{r-1} (\mu_q)^N$ does not tend to $0$
-	as $N \to \infty$.  This is the analytic content of the dominant-block
+	as $N \to \infty$.  This is the analytic content of the unit-block
 	non-decay step at
 	\cite[\S~II.A, lines~246, 1181--1188]{Cirac2017MPDO_AnnPhys}.
 \end{lemma}
@@ -1125,43 +1134,52 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
 	for the full elementary proof.
 \end{proof}
 
-\begin{lemma}[Dominant-block coefficient non-decay]%
-	\label{lem:paper_bnt_coeff_dominant_not_tendsto_zero}
-	\lean{MPSTensor.IsBNTCanonicalForm.coeff_dominant_not_tendsto_zero}
+\begin{lemma}[Unit-block coefficient non-decay]%
+	\label{lem:paper_bnt_coeff_not_tendsto_zero_at_unit_block}
+	\lean{MPSTensor.IsBNTCanonicalForm.coeff_not_tendsto_zero_at_unit_block}
 	\leanok
 	\uses{def:paper_bnt_cf, lem:paper_bnt_cesaro_nondecay}
 	Let \(P\) be a sector decomposition carrying a paper-faithful BNT
-	canonical form with \(P.\texttt{basisCount} > 0\).  Then the dominant
-	sector's coefficient
-	\(c_{0}(N) = \sum_q (P.\texttt{weight}\,\langle 0,\,h\rangle\,q)^N\)
-	does not tend to \(0\) as \(N \to \infty\).
+	canonical form and let \(j_0 : \mathrm{Fin}\,P.\texttt{basisCount}\) be
+	any sector index such that some copy of sector \(j_0\) carries a
+	unit-modulus weight, i.e.\ there exists
+	\(q\) with \(\lVert P.\texttt{weight}\,j_0\,q\rVert = 1\).  Then the
+	sector-\(j_0\) coefficient
+	\(c_{j_0}(N) = \sum_q (P.\texttt{weight}\,j_0\,q)^N\) does not tend to
+	\(0\) as \(N \to \infty\).
 
-	This is the structural-field reading of the CPSV16 \S~II.A line~246
-	normalization (every weight has modulus \(\leq 1\), and at index \(0\)
-	some copy has unit modulus); the proof reduces directly to
-	Lemma~\ref{lem:paper_bnt_cesaro_nondecay} with the dominant-block
-	weight family.
+	This is the paper-parametrised reading of the CPSV16 \S~II.A line~246
+	+ line~1244 normalization.  The unit-modulus witness is supplied
+	externally (as the hypothesis above) because CPSV16 line~246 is a
+	\emph{global} statement
+	(``at least one of them equals one'' over the two-layer index
+	\((j, q)\)) and does not pin the witness to a specific sector; the
+	structural field
+	\texttt{IsBNTCanonicalForm.weight\_unit\_exists}
+	carries only that global existential.
 \end{lemma}
 
 \begin{proof}\leanok
 	Apply Lemma~\ref{lem:paper_bnt_cesaro_nondecay} to the family
-	\(\mu := P.\texttt{weight}\,\langle 0,\,h\rangle\), feeding in the
-	two structural fields of \texttt{IsBNTCanonicalForm} at sector~\(0\):
-	\texttt{weight\_norm\_le\_one} supplies the modulus bound and
-	\texttt{weight\_unit\_at\_dominant\_block} supplies the unit-modulus
-	witness.
+	\(\mu := P.\texttt{weight}\,j_0\), feeding in the structural field
+	\texttt{weight\_norm\_le\_one} of \texttt{IsBNTCanonicalForm}
+	(modulus bound) and the supplied per-sector unit-modulus existential
+	\texttt{hUnit}.
 \end{proof}
 
 \begin{remark}
-	Consuming this lemma inside \texttt{exists\_dominant\_match\_of\_sameMPV}
+	Consuming this lemma inside
+	\texttt{exists\_unit\_block\_match\_of\_sameMPV}
 	(\texttt{TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean})
-	eliminates the prior explicit
-	\(\lnot \texttt{Tendsto}\,(P.\texttt{coeff}\,\cdot\,\langle 0,\,h\rangle)\,\texttt{atTop}\,(\nh\,0)\)
-	parameter from the dominant-pair matching theorem of
-	\cite[\S~II, lines~1181--1188]{Cirac2017MPDO_AnnPhys}.  After this
-	cleanup the matching theorem reads off purely from the strengthened
-	\texttt{IsBNTCanonicalForm} predicate plus the equal-MPV hypothesis,
-	with no analytic side conditions exposed at the call site.
+	supplies the
+	\(\lnot \texttt{Tendsto}\,(P.\texttt{coeff}\,\cdot\,j_0)\,\texttt{atTop}\,(\nh\,0)\)
+	internal step of the matching theorem of
+	\cite[\S~II, lines~1181--1188]{Cirac2017MPDO_AnnPhys}.  Issue~\#1725
+	Phase~A retired an auxiliary dominant-block structural field that
+	previously pinned \(j_0 = 0\); the matching theorem now takes the
+	unit-block sector and witness as explicit parameters, faithfully
+	mirroring the global character of CPSV16 line~246 (audit memo
+	\texttt{/tmp/phase\_4c\_drift\_audit\_2026-05-14.md} §Q-C).
 \end{remark}
 
 \subsection{Matched-sector coefficient identity and weight multiset equality}


### PR DESCRIPTION
## Phase A course correction (#1725): retire `weight_unit_at_dominant_block`

This is **Phase A** of the course correction set up in #1725, following the
drift audit `/tmp/phase_4c_drift_audit_2026-05-14.md`.

### Drift audit findings

The audit confirmed that the `IsBNTCanonicalForm` structural field
`weight_unit_at_dominant_block : ∀ hpos, ∃ q, ‖P.weight ⟨0, hpos⟩ q‖ = 1`
is an **engineering artifact** of the dominant-block-projection plus
drop-and-recurse strategy adopted in Phase 4b-ii/4c.  CPSV16 §II.A line 246
reads, verbatim:

> "we can always choose $|\mu_k| \le 1$ and at least one of them equals one,
> something which we will assume from now on."

This is a **global** statement over the two-layer index $(j, q)$.  The
paper never pins the witness to sector $0$; the "dominant block" reading
appears later only via the spectral selection of $\mathbb{E}^N$ (CPSV16
line 1244), not as a structural pre-sorted index.

The cleanest course correction is to remove the engineering field and
**parametrise the dependent API by the user-supplied unit-modulus block
witness**.

### Changes

**`Basic.lean`** — remove the field; the structure now has 9 fields:
`basis_dim_pos`, `basis_injective`, `basis_irreducible`,
`basis_left_canonical`, `basis_normalized_self_overlap`, `bnt_data`,
`basis_distinct`, `weight_norm_le_one`, `weight_unit_exists`.  The
docstring of `weight_unit_exists` now cites CPSV16 line 246 verbatim and
records the Phase A cleanup rationale.

**`Api.lean`** — replace `coeff_dominant_not_tendsto_zero` (fixed at
index 0) with the parametrised form

```lean
theorem coeff_not_tendsto_zero_at_unit_block
    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
    (hUnit : ∃ q, ‖P.weight j₀ q‖ = 1) :
    ¬ Tendsto (fun N => P.coeff N j₀) atTop (𝓝 0)
```

The proof is identical to the old `coeff_dominant_not_tendsto_zero` —
just parametrised differently.  `thermodynamic_limit_nonvanishing` is
generalised likewise.

**`DominantMatch.lean`** (option **c** per the task spec) — rename
`exists_dominant_match_of_sameMPV` → `exists_unit_block_match_of_sameMPV`,
parametrised by `j₀ : Fin P.basisCount` and
`hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`.  The proof body is unchanged modulo
the `j₀` substitution.  No existing callers (the lemma was only
referenced in module docstrings of `StrongInduction.lean` and
`DropMatchedSector.lean`, which are updated accordingly).

**`DropSector.lean`** — drop the `hUnitDomRem` parameter from
`IsBNTCanonicalForm.dropSector`.  The `hUnitRem` parameter is retained,
since `weight_unit_exists` is still not derivable on the remainder in
general (if every unit-modulus weight lived in the dropped sector, the
remainder has none).  No on-main code consumes this preservation lemma,
so simplification is the only change.

**`Examples.lean`** — drop the `weight_unit_at_dominant_block`
instantiation from each of the four examples (`singletonDecomp`,
`signFlipDecomp`, `phaseDecomp`, `halvedDecomp`).  All four examples
continue to satisfy the remaining paper-faithful fields and build green.

**`blueprint/src/chapter/ch10_bnt.tex`** — update the Cesàro
non-decay subsection: rename the section heading to
"Cesàro non-decay and unit-block coefficient"; replace the
`coeff_dominant_not_tendsto_zero` lemma statement with the parametrised
`coeff_not_tendsto_zero_at_unit_block`; cite the audit memo and Phase A
cleanup rationale in the section preamble and accompanying remark.

### Final-report answers (per task spec)

1. **Files touched + LoC**: 7 Lean files + 1 blueprint chapter; 202 ins,
   211 del (`git diff --stat` of the squashed commit).
2. **Build status**: `lake build` clean, 8692/8692 jobs.  No `sorry`,
   `axiom`, or `unsafe` introduced in `TNLean/MPS/FundamentalTheorem/PaperBNT/`.
3. **PR number**: this PR.
4. **API parametrisation chosen for `coeff_not_tendsto_zero_at_unit_block`**:
   the **explicit `j₀ : Fin P.basisCount` + `hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`**
   parametrisation specified in the task; the unit-modulus witness is
   supplied externally because `weight_unit_exists` only asserts the
   global existential.
5. **`DropSector.lean` preservation**: **simplified** (dropped the
   `hUnitDomRem` parameter; retained `hUnitRem`).  No external consumers.
6. **`DominantMatch.lean` change**: **option (c)** per the task spec —
   the matching lemma is parametrised by the user-supplied unit-block
   witness `(j₀, hUnit)`, not pinned to dominance.  The lemma is renamed
   `exists_unit_block_match_of_sameMPV`.

### Verification grep

```
$ grep -rn 'weight_unit_at_dominant_block' TNLean/ blueprint/
(empty)
$ grep -rn 'coeff_dominant_not_tendsto_zero' TNLean/ blueprint/
(empty)
```

### References

* Audit memo: `/tmp/phase_4c_drift_audit_2026-05-14.md` (read-only,
  generated 2026-05-14).
* CPSV16 §II.A line 246, line 1244, lines 1181–1188.
* Related: #1717, #1720, #1721, #1722, #1723, #1724.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This refactors core proof interfaces around `IsBNTCanonicalForm` by removing a structural field and threading an explicit per-sector unit-modulus witness through key theorems; risk is moderate due to potential downstream breakage or subtle proof obligations despite largely mechanical changes.
> 
> **Overview**
> Removes `weight_unit_at_dominant_block` from `IsBNTCanonicalForm` and updates documentation to reflect CPSV16 line-246’s *global* unit-modulus existential.
> 
> Generalizes the coefficient non-decay API from a fixed “sector 0 dominant block” lemma to `coeff_not_tendsto_zero_at_unit_block (j₀, hUnit)` (and updates `thermodynamic_limit_nonvanishing` accordingly), keeping the same Cesàro non-decay proof but requiring callers to provide the per-sector unit witness.
> 
> Refactors the Phase-4b matching theorem from `exists_dominant_match_of_sameMPV` to `exists_unit_block_match_of_sameMPV`, now parameterized by `(j₀, hUnit)`; simplifies `IsBNTCanonicalForm.dropSector` by dropping the extra dominant-block witness parameter; removes the retired field from examples; and updates blueprint text and cross-references to the new “unit-block” framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cba5d86770dd3f8ba0eafe75f64cc4aebbc6faa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->