### PR TITLE
feat(MPS/FT/PaperBNT): Phase D per-block normalization + full-basis FT (#1730)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -242,6 +242,7 @@ import TNLean.MPS.FundamentalTheorem.PaperBNT.DropMatchedSector
 import TNLean.MPS.FundamentalTheorem.PaperBNT.DropSector
 import TNLean.MPS.FundamentalTheorem.PaperBNT.DropSectorOverlapDecay
 import TNLean.MPS.FundamentalTheorem.PaperBNT.EqualModulus
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Fundamental
 import TNLean.MPS.FundamentalTheorem.PaperBNT.NewtonGirard
 import TNLean.MPS.FundamentalTheorem.PaperBNT.StrongInduction
 import TNLean.MPS.FundamentalTheorem.PaperBNT.StrongMatch

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
@@ -37,12 +37,13 @@ not imported here.
   lines 1121–1132; CPSV21 line 1850 BNT linear-independence input).
 * `IsBNTCanonicalForm.norm_coeff_le_copies` — the structural-field reading
   of the multiplicity bound (CPSV16 line 246 via `weight_norm_le_one`).
-* `IsBNTCanonicalForm.weight_unit_exists_of_struct` — the existential
+* `IsBNTCanonicalForm.weight_unit_exists_of_struct` — the global
   unit-modulus witness re-exposed at the API layer (CPSV16 line 246).
-* `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_unit_block` — the
-  Cesàro non-decay reading of CPSV16 line 246 + line 1244, parametrised
-  by the unit-modulus block witness (issue #1725 Phase A; audit memo
-  `/tmp/phase_4c_drift_audit_2026-05-14.md`).
+* `IsBNTCanonicalForm.weight_unit_exists_per_block_of_struct` — the
+  per-block unit-modulus witnesses (CPSV21 §III.2 / Definition 4.3).
+* `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block` — the Cesàro
+  non-decay reading of per-block spectral-radius-one normalization, with
+  the unit witness discharged from the structure (Phase D, issue #1730).
 
 ## References
 
@@ -53,7 +54,7 @@ not imported here.
   1121–1132 (Lem1, combined-family eventual linear independence).
 * CPSV21: Cirac–Pérez-García–Schuch–Verstraete, arXiv:2011.12127.
   Lines 1846–1884 (BNT and two-layer BNT decomposition with raw
-  `μ_{j,q}`).
+  `μ_{j,q}` and per-block spectral-radius-one normalization).
 -/
 
 open scoped Matrix BigOperators
@@ -206,48 +207,48 @@ lemma norm_coeff_le_copies
   P.norm_coeff_le_copies_of_norm_weight_le_one (N := N) (j := j)
     (hWeightLe := h.weight_norm_le_one j)
 
-/-- **Unit-modulus weight witness from the canonical-form line-246
-normalization.**
+/-- **Global unit-modulus weight witness from the canonical-form normalization.**
 
 Re-exposes the structural field `weight_unit_exists` (CPSV16 §II.A
 line 246) at the API layer for downstream callers that want to extract a
-unit-modulus weight without depending on the structure layout. -/
+global unit-modulus weight without depending on the structure layout. -/
 lemma weight_unit_exists_of_struct (h : IsBNTCanonicalForm P) :
     ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
       ‖P.weight j q‖ = 1 := h.weight_unit_exists
 
-/-- **CPSV16 line 246 + line 1244 generalization.**
+/-- **Per-block unit-modulus weight witness from CPSV21 §III.2.**
 
-For any sector `j₀ : Fin P.basisCount` that contains at least one
-unit-modulus weight, the power-sum coefficient
+Re-exposes `weight_unit_exists_per_block`, the Phase D strengthening of
+`IsBNTCanonicalForm`: every BNT basis sector carries its own unit-modulus
+copy weight. -/
+lemma weight_unit_exists_per_block_of_struct
+    (h : IsBNTCanonicalForm P) (j : Fin P.basisCount) :
+    ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1 :=
+  h.weight_unit_exists_per_block j
+
+/-- **Per-block coefficient non-decay.**
+
+For every sector `j₀ : Fin P.basisCount`, the power-sum coefficient
 `P.coeff N j₀ = ∑_q (P.weight j₀ q)^N` does **not** tend to `0` as
 `N → ∞`.
 
-The unit-modulus witness is supplied externally because the structural
-field `IsBNTCanonicalForm.weight_unit_exists` only asserts the
-**global** existence of some `(j, q)` with unit-modulus weight (CPSV16
-§II.A line 246, verbatim); it does not pin the witness to a specific
-sector.  Callers that have an arrow-specific unit-modulus witness (for
-example from a downstream matching argument that has already isolated a
-sector) pass it in here.
+Phase D strengthens the canonical-form surface with the CPSV21 §III.2 /
+Definition 4.3 per-block spectral-radius-one normalization, so the
+unit-modulus witness needed by the Cesàro non-decay lemma is discharged
+automatically from `h.weight_unit_exists_per_block j₀`.
 
-Paper anchor: CPSV16 §II.A line 246 (the "at least one `|μ_k| = 1`"
-convention) combined with line 1244 (the assumed normalization makes
-the transfer-matrix-power sequence converge); proof via Cesàro
-non-decay (`PaperBNT/CesaroNonDecay.lean`,
-`sum_pow_not_tendsto_zero_of_unit_modulus`, CPSV16 lines 1158–1167). -/
-theorem coeff_not_tendsto_zero_at_unit_block
-    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
-    (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1) :
+Paper anchor: CPSV21 §III.2 / Definition 4.3 lines 1846–1884
+(per-block spectral-radius-one BNT normalization), CPSV16 §II.C lines
+1158–1167 (power-sum non-decay / exact comparison input). -/
+theorem coeff_not_tendsto_zero_at_block
+    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount) :
     ¬ Tendsto (fun N : ℕ => P.coeff N j₀) atTop (𝓝 0) := by
-  -- Extract the unit-block weight family and its CPSV16 §II.A
-  -- line-246 properties at sector `j₀`.
   have h_le : ∀ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ ≤ 1 :=
     h.weight_norm_le_one j₀
-  -- Apply the Cesàro non-decay analytic lemma.
+  have hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1 :=
+    h.weight_unit_exists_per_block j₀
   have hAnal := CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus
     (P.weight j₀) h_le hUnit
-  -- `P.coeff N j₀ = ∑ q, (P.weight j₀ q)^N` is `rfl`.
   intro hTend
   exact hAnal hTend
 
@@ -257,7 +258,7 @@ For any sector `j : Fin P.basisCount` such that every copy weight satisfies
 `‖P.weight j q‖ < 1` (strictly), the power-sum coefficient
 `P.coeff N j = ∑_q (P.weight j q)^N` tends to `0` as `N → ∞`.
 
-This is the **converse** of `coeff_not_tendsto_zero_at_unit_block`: under the
+This is the **converse** of `coeff_not_tendsto_zero_at_block`: under the
 CPSV16 §II.A line-246 normalization (`weight_norm_le_one`), if **no** copy of
 sector `j` carries a unit-modulus weight, then the sector's coefficient
 decays exponentially.  The argument is elementary: each summand
@@ -267,9 +268,9 @@ of vanishing sequences vanishes.
 
 Paper anchor: CPSV16 §II.A line 246 + line 1244 (the convergence half of
 the line-246 dichotomy: unit-modulus weights survive; subnormal weights
-decay).  This is the lemma the Phase B-γ matched-pair argument
-(`PaperBNT/StrongMatch.lean`) uses to dismiss non-unit sectors of `Q` that
-do not appear in the matching `φ : UnitQ ↪ Fin P.basisCount`. -/
+decay).  After the Phase D per-block normalization this lemma is no longer
+on the FT critical path, but it remains a useful peripheral/subnormal-sector
+estimate. -/
 theorem coeff_tendsto_zero_of_all_weights_subnorm
     (_h : IsBNTCanonicalForm P) (j : Fin P.basisCount)
     (hSubnorm : ∀ q : Fin (P.copies j), ‖P.weight j q‖ < 1) :
@@ -290,7 +291,7 @@ theorem coeff_tendsto_zero_of_all_weights_subnorm
 
 /-- **Thermodynamic-limit non-vanishing of a unit-block coefficient.**
 
-A user-facing alias for `coeff_not_tendsto_zero_at_unit_block`, named
+A user-facing alias for `coeff_not_tendsto_zero_at_block`, named
 in the language of the audit memo
 `thermodynamic_limit_normalization_audit_2026-05-14` §Q-C: the
 CPSV16 §II.A line-246 normalization picks out the unit-modulus block(s)
@@ -298,17 +299,16 @@ whose power-sum coefficient does **not** vanish in the thermodynamic
 limit.
 
 This is the coefficient form of the audit's "thermodynamic-limit
-non-vanishing" condition, parametrised by the unit-modulus block
-witness supplied by the caller.  A self-overlap form
+non-vanishing" condition, with the per-block unit-modulus witness
+supplied by the structure.  A self-overlap form
 `limsup_N ⟨A^⊕|A^⊕⟩^{(N)} ∈ (0, ∞)` is the implication recorded by
 the audit's Q-C equivalence (forward direction), which we do not
 formalise here — the coefficient form is the operational input to the
 FT proof; the self-overlap reading is a paraphrase. -/
 lemma thermodynamic_limit_nonvanishing
-    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
-    (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1) :
+    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount) :
     ¬ Tendsto (fun N : ℕ => P.coeff N j₀) atTop (𝓝 0) :=
-  h.coeff_not_tendsto_zero_at_unit_block j₀ hUnit
+  h.coeff_not_tendsto_zero_at_block j₀
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
@@ -25,7 +25,9 @@ a `SectorDecomposition`.  It records:
   dimension;
 * the CPSV16 §II.A line-246 **normalization convention** on the raw sector
   weights `μ_{j,q}`: `|μ_{j,q}| ≤ 1` and at least one of them equals one
-  (lines 246 and 1244).
+  (lines 246 and 1244);
+* the CPSV21 §III.2 / Definition 4.3 per-block spectral-radius-one
+  normalization: each BNT basis block has at least one unit-modulus copy.
 
 Crucially, the structure does **not** impose an equal-modulus or strict-order
 condition on the raw sector weights `P.weight j q`.  CPSV16
@@ -59,8 +61,9 @@ source-faithful core.
   Rev. Mod. Phys. **93**, 045003 (2021); arXiv:2011.12127.  Source-line tags
   used below: 1815–1837 (normal tensors primitive after blocking; canonical
   form `⊕_k μ_k A_k`), 1846–1884 (BNT and two-layer BNT decomposition with
-  raw `μ_{j,q}`), 1905–1908 (unital gauge optional; non-periodic theorem
-  separated from periodic generalization).
+  raw `μ_{j,q}` and per-block spectral-radius-one normalization),
+  1905–1908 (unital gauge optional; non-periodic theorem separated from
+  periodic generalization).
 -/
 
 open scoped Matrix BigOperators
@@ -136,26 +139,22 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   `C ⊕ (1/2)C` (weights `(1, 1/2)`), and `C ⊕ (-C) ⊕ (1/2)C`. -/
   weight_norm_le_one : ∀ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ ≤ 1
-  /-- **CPSV16 line-246 normalization, unit-witness existence.**  At least
-  one copy of one basis sector has unit-modulus weight.  CPSV16 §II.A
-  line 246 (verbatim): "we can always choose `|μ_k| ≤ 1` and at least one
-  of them equals one, something which we will assume from now on."  The
-  paper states this **globally** over the two-layer index `(j, q)` of the
-  two-layer BNT display (CPSV16 lines 287–301): the existential ranges over
-  all `(j, q)` pairs and does **not** pin the witness to a specific
-  sector.  The witness is reinvoked in the body of the FT proof at
-  CPSV16 line 1244 ("the assumed normalization `|μ_{jq}| ≤ 1` … implies
-  that `𝔼^N` converges"), again read off the two-layer indexing without a
-  sector-specific reading.
-
-  A previous design carried an extra structural field pinning the
-  witness to sector index 0; this was an engineering artifact, removed
-  in the Phase A cleanup of issue #1725 (audit memo
-  `/tmp/phase_4c_drift_audit_2026-05-14.md`).  Downstream code that
-  needs a unit-modulus witness in a specific sector now supplies the
-  sector index and unit-modulus existential externally; see
-  `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_unit_block`
-  (`PaperBNT/Api.lean`). -/
+  /-- **CPSV21 per-block unit normalization.**  Each BNT basis block
+  contains at least one unit-modulus raw copy weight.  This is the
+  per-block spectral-radius-one normalization used in CPSV21 §III.2 /
+  Definition 4.3 (lines 1846–1884): after grouping copies into a BNT
+  basis tensor, every basis block is represented with spectral radius
+  one in its own copy layer.  It strengthens the global CPSV16 line-246
+  witness and is the key Phase D correction that turns the previous
+  unit-subset matching theorem into a full-basis matching theorem. -/
+  weight_unit_exists_per_block : ∀ j : Fin P.basisCount,
+    ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1
+  /-- **CPSV16 line-246 global unit witness.**  At least one copy of one
+  basis sector has unit-modulus weight.  This field is retained as the
+  global CPSV16 normalization/non-emptiness witness consumed by older
+  auxiliary lemmas; on all nonempty sector decompositions it follows
+  immediately from `weight_unit_exists_per_block` by choosing any basis
+  index. -/
   weight_unit_exists : ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ = 1
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/CoeffIdentity.lean
@@ -7,48 +7,25 @@ import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.PiAlgebra.CanonicalFormSepAux
 
 /-!
-# Phase B-γ (paper-faithful) CPSV16 §II.C lines 1187-1188 Corollary substitution
+# Phase B-γ/D coefficient identity from a full BNT basis matching
 
-This module is **Phase B-γ** of the CPSV16/CPSV21 fundamental-theorem
-clean-slate plan (issue #1725) — the paper-faithful Corollary `II_cor2`
-substitution argument.  Given matched gauges from Phase B-α
-(`forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV`,
-`PaperBNT/StrongMatch.lean`) encoded as the injection
-`φ : UnitQ ↪ Fin P.basisCount` from Phase B-β
-(`bijective_match_of_sameMPV`, `PaperBNT/StrongMatch.lean`), substitute
-the per-pair gauge identity
-`mpv (Q.basis k) σ = ζ_k^N · mpv (P.basis (φ k)) σ` into the original
-`SameMPV₂` proportionality and project the resulting overlap onto each
-`P.basis j₀` to read off the per-block coefficient identity directly,
-without recursion or `dropSector`.
+This module contains the CPSV16 §II.C lines 1187–1188 coefficient
+comparison in the Phase D, full-basis form.  The earlier Phase B version
+worked over a unit-modulus subset and produced an asymptotic difference.  Phase D
+strengthens `IsBNTCanonicalForm` with CPSV21 §III.2 / Definition 4.3
+per-block spectral-radius-one normalization, upgrades matching to a full
+bijection `β : Fin Q.basisCount ≃ Fin P.basisCount`, and therefore the
+substitution has no residual unmatched terms.  A-only BNT linear
+independence gives eventual **exact** coefficient identities.
 
-## Paper anchor
+Paper anchors:
 
-CPSV16 (arXiv:1606.00608) §II.C lines 1187-1188 (the substitution
-argument of the Corollary's proof, after the Step 1 matching has been
-established).  Gauge-to-MPV translation: Lemma `equalMPS`, CPSV16 lines
-1080-1097.  Unit-modulus closure: CPSV16 §II.A line 246 normalization
-combined with the per-block normalized self-overlap (CPSV21 line 1818).
+* CPSV16 §II.C lines 1182–1188: match every BNT basis tensor, substitute the
+  gauge-phase identities, and compare the coefficients of the BNT basis.
+* CPSV21 Definition 4.3 lines 1846–1884: per-block BNT normalization that
+  makes every sector participate in the full-basis matching.
 
-## Scope (Phase B-γ)
-
-The single main result is the matched-pair *asymptotic-difference*
-identity plus the non-matched-decay statement; together they
-characterize the structure of the matched coefficient sequences
-directly, without recursion or `dropSector`.  See the docstring of
-`coeff_identity_via_global_gauge` for the precise statement and the
-"Scoping note" therein for the relationship to the eventual-exact
-form requested by issue #1725 Phase B-γ.
-
-## File split (PR #1729 follow-up)
-
-This file was extracted from `PaperBNT/StrongMatch.lean` to keep that
-file under the 1000-line module limit.  Phase B-α
-(`forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV`) and Phase B-β
-(`bijective_match_of_sameMPV`) remain in `StrongMatch.lean`; this file
-contains only Phase B-γ content.
-
-No `sorry`, no `axiom`, no `unsafe`.
+No `dropSector` recursion and no partial-union combined LI are used here.
 -/
 
 open scoped Matrix BigOperators
@@ -58,66 +35,15 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ### Phase B-γ: CPSV16 §II.C lines 1187-1188 Corollary substitution
-
-This section implements the **Corollary `II_cor2` substitution argument**
-(CPSV16 §II.C lines 1187-1188): given matched gauges from Phase B-α
-(`forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV`), encoded as
-the injection `φ : UnitQ ↪ Fin P.basisCount` from Phase B-β
-(`bijective_match_of_sameMPV`), substitute the per-pair gauge identity
-`mpv (Q.basis k) σ = ζ_k^N · mpv (P.basis (φ k)) σ` into the
-`SameMPV₂` proportionality and read off the per-block coefficient
-identity by projecting the overlap onto each `P.basis j₀`.
-
-## Honest scoping (per task brief, §"Honest scoping")
-
-The user-requested target form for the matched-pair clause is
-*eventual exact equality*:
-
-  `∀ k : UnitQ, ∃ ζ, ‖ζ‖ = 1 ∧ ∃ N₀, ∀ N > N₀,`
-  `    P.coeff N (φ k) = ζ^N · Q.coeff N k.val`.
-
-Deriving eventual exact equality from the partial-bijection data (UnitQ
-only, with non-unit Q-blocks unconstrained) requires either a full
-bijection or substantial new analysis (combined LI on a partial union
-is the very obstacle that #1722 flagged).  We deliver the
-**asymptotic-difference** form
-
-  `Tendsto (fun N => P.coeff N (φ k) - ζ^N · Q.coeff N k.val) atTop (𝓝 0)`,
-
-which is the natural output of the overlap-projection argument and is
-equivalent to the eventual exact form via the multiset-rigidity step
-(Newton–Girard, `PaperBNT/NewtonGirard.lean`) when both sides are power
-sums over closed-unit-disk weights.  The non-matched-decay clause is
-delivered in full.
-
-Paper anchor: CPSV16 §II.C lines 1187-1188 (arXiv:1606.00608); the
-substitution `Y = ⊕_j (𝟙_{r_j} ⊗ Y_j)` is a *single* global gauge
-followed by a *single* coefficient comparison.  We avoid `dropSector`
-entirely (Phase 4c drift, per
-`/tmp/phase_4c_drift_audit_2026-05-14.md`). -/
-
-/-- **Helper: gauge-phase data ⇒ MPV-level scalar power identity with `‖ζ‖ = 1`.**
+/-- **Helper: gauge-phase data gives an MPV-level scalar-power identity with unit phase.**
 
 Given a matched bond-dimension equality `h : P.basisDim j = Q.basisDim k`
-and a cast-left gauge-phase equivalence
-`GaugePhaseEquiv (cast h (P.basis j)) (Q.basis k)` between BNT basis
-blocks, extract a gauge phase `ζ : ℂ` with `‖ζ‖ = 1` and the MPV-level
-scalar power identity
+and a cast-left gauge-phase equivalence between `P.basis j` and `Q.basis k`,
+extract a phase `ζ` with `‖ζ‖ = 1` and
+`mpv (Q.basis k) σ = ζ^N * mpv (P.basis j) σ` for all lengths and words.
 
-  `mpv (Q.basis k) σ = ζ^N · mpv (P.basis j) σ` for every `N, σ`.
-
-The proof combines `MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast`
-(which packages the cast-aware gauge-to-MPV translation) with the
-unit-modulus closure `norm_eq_one_of_selfOverlap_scale`
-(`MPS/SharedInfra/GaugePhase.lean`), fed by the normalized self-overlaps
-of the BNT basis blocks (`basis_normalized_self_overlap` field of
-`IsBNTCanonicalForm`).
-
-Paper anchor: CPSV16 §II.A Lemma `equalMPS` (lines 1080–1097) for the
-gauge-to-MPV translation, and CPSV16 §II.A line-246 normalization
-(`weight_norm_le_one`) combined with the per-block normalized
-self-overlap (CPSV21 line 1818) for the unit-modulus closure on `ζ`. -/
+This is CPSV16's Lemma `equalMPS` (lines 1080–1097) plus the normalized
+self-overlap/unit-phase closure used in the non-periodic setting. -/
 private lemma extract_unit_gauge_phase_mpv
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -129,11 +55,9 @@ private lemma extract_unit_gauge_phase_mpv
       ∀ (N : ℕ) (σ : Fin N → Fin d),
         mpv (Q.basis k) σ = ζ ^ N * mpv (P.basis j) σ := by
   classical
-  obtain ⟨ζ, hζne, hmpv⟩ :=
+  obtain ⟨ζ, _hζne, hmpv⟩ :=
     MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast (P.basis j) (Q.basis k) h hGPE
   refine ⟨ζ, ?_, hmpv⟩
-  -- ‖ζ‖ = 1 via `norm_eq_one_of_selfOverlap_scale`, fed by both
-  -- self-overlaps tending to 1 and the scale identity from `hmpv`.
   have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) (P.basis j) (P.basis j) N‖)
       atTop (𝓝 (1 : ℝ)) := by
     have h1 := (hP.basis_normalized_self_overlap j).norm
@@ -147,717 +71,143 @@ private lemma extract_unit_gauge_phase_mpv
       (ζ := ζ) hmpv
   exact norm_eq_one_of_selfOverlap_scale (ζ := ζ) hAA hBB hScale
 
-/-- **Helper: gauge substitution propagates to `mpvOverlap`.**
+/-- **CPSV16 §II.C lines 1187–1188, full-basis coefficient identity.**
 
-From the MPV-level scalar power identity
-`mpv (Q.basis k) σ = ζ^N · mpv (P.basis j) σ`, the overlap with any
-third tensor `X` satisfies
-`mpvOverlap (Q.basis k) X N = ζ^N · mpvOverlap (P.basis j) X N`.
+Assume a full matched-basis equivalence `β : Fin Q.basisCount ≃
+Fin P.basisCount`, with every `Q`-block gauge-phase equivalent to the
+corresponding `P`-block.  Substituting the MPV phase relation for each
+matched pair into `SameMPV₂ P.toTensor Q.toTensor`, reindexing the `Q`-sum
+by `β`, and applying A-only BNT linear independence (`hP.bnt_data`) gives
+an eventual exact coefficient identity
 
-This is the elementary linearity of `mpvOverlap` in its first argument,
-specialised to the gauge-substitution shape used by the Phase B-γ
-projection argument. -/
-private lemma mpvOverlap_subst_via_mpv_pow
-    {D₁ D₂ D₃ : ℕ} {ζ : ℂ}
-    {A : MPSTensor d D₁} {B : MPSTensor d D₂} (X : MPSTensor d D₃)
-    (hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ)
-    (N : ℕ) :
-    mpvOverlap (d := d) B X N = ζ ^ N * mpvOverlap (d := d) A X N := by
-  classical
-  simp only [mpvOverlap]
-  rw [Finset.mul_sum]
-  refine Finset.sum_congr rfl ?_
-  intro σ _
-  rw [hmpv N σ]
-  ring
+`P.coeff N (β k) = ζ_k^N * Q.coeff N k`.
 
-/-- **CPSV16 §II.C lines 1187-1188 Corollary substitution (paper-faithful
-Phase B-γ).**
-
-Given matched gauges from Phase B-α
-(`forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV`) encoded as the
-injection `φ : UnitQ ↪ Fin P.basisCount` from Phase B-β
-(`bijective_match_of_sameMPV`), the **per-block coefficient identity**
-holds in the following two-part shape:
-
-* **Matched pair (`k : UnitQ`, `j = φ k`):** there is a unit-modulus
-  gauge phase `ζ_k : ℂ` with `‖ζ_k‖ = 1` for which the **asymptotic
-  difference** `P.coeff N (φ k) - ζ_k^N · Q.coeff N k.val` tends to `0`.
-* **Non-matched (`j ∉ range(φ)`):** the coefficient `P.coeff N j` itself
-  tends to `0`.
-
-Together these characterize the structure of the matched coefficient
-sequences directly, without recursion or `dropSector`.
-
-## Scoping note (honest scoping)
-
-The user-requested literal form of the matched-pair clause is
-*eventual exact* equality `P.coeff N (φ k) = ζ_k^N · Q.coeff N k.val`
-for all sufficiently large `N`.  Deriving eventual exact equality from
-the partial-bijection data (UnitQ ⊂ Fin Q.basisCount only, with non-unit
-Q-blocks unconstrained by the matching) requires combined LI on
-`P.basis ⊔ {Q.basis k : k ∉ UnitQ}`, the precise partial-union LI that
-issue #1722 flagged as not naturally derivable.  We deliver the
-**asymptotic-difference** form `Tendsto (· - ·) atTop (𝓝 0)`, which is
-the natural output of the overlap-projection argument and which the
-multiset-rigidity step (`PaperBNT/NewtonGirard.lean`,
-`Multiset.eq_of_power_sum_eq`) upgrades to multiset equality of weights
-when consumed downstream.
-
-## Proof outline
-
-For each `j₀ : Fin P.basisCount`, project the SameMPV₂ identity onto
-the overlap with `P.basis j₀`:
-
-  `∑_j P.coeff N j · ⟨P.basis j | P.basis j₀⟩_N`
-    `= ∑_k Q.coeff N k · ⟨Q.basis k | P.basis j₀⟩_N`.
-
-* **LHS analysis** (mirrors `DominantMatch.exists_dominant_match_of_sameMPV`
-  Steps 2–4): `LHS - P.coeff N j₀ → 0`.  The off-diagonal terms
-  (`j ≠ j₀`) decay by `cross_overlap_basis_tendsto_zero` (CPSV16 lines
-  1080–1091) and the diagonal term `coeff · (self_overlap - 1)` decays
-  by `basis_normalized_self_overlap` (CPSV21 line 1818).
-* **RHS analysis**: split `k : Fin Q.basisCount` into the unit-modulus
-  subset `UnitQ` and its complement.
-  * For `k ∈ UnitQ`: substitute via
-    `mpv (Q.basis k) σ = ζ_k^N · mpv (P.basis (φ k)) σ`
-    (CPSV16 line 1186, gauge-phase equivalence).  The resulting term
-    `Q.coeff N k · ζ_k^N · ⟨P.basis (φ k) | P.basis j₀⟩_N` tends to
-    `Q.coeff N k · ζ_k^N` when `j₀ = φ k` (diagonal, self → 1) and to
-    `0` otherwise (off-diagonal, cross-decay).
-  * For `k ∉ UnitQ`: `Q.coeff N k → 0` by
-    `coeff_tendsto_zero_of_all_weights_subnorm` (CPSV16 line 246 +
-    line 1244 dichotomy, `PaperBNT/Api.lean`); combined with the
-    `leftCanonical_mpvOverlap_bound` uniform bound on `mpvOverlap`
-    (left-canonical, CPSV21 lines 1815–1837), the contribution
-    `Q.coeff N k · mpvOverlap (Q.basis k) (P.basis j₀) N` decays to `0`.
-* **Combine**: `LHS = RHS` pointwise (by `SameMPV₂`); the analyses then
-  give
-    `P.coeff N j₀ - ∑_{k ∈ UnitQ, φ k = j₀} ζ_k^N · Q.coeff N k.val → 0`.
-
-  * If `j₀ ∈ range(φ)`: by injectivity of `φ`, the sum has exactly one
-    term (the unique `k₀ : UnitQ` with `φ k₀ = j₀`), giving the
-    matched-pair clause.
-  * If `j₀ ∉ range(φ)`: the sum is empty, giving the non-matched clause.
-
-Paper anchor: CPSV16 §II.C lines 1187-1188 (arXiv:1606.00608);
-combined-family LI `Lem1` at CPSV16 lines 1131-1132; gauge-to-MPV
-translation Lemma `equalMPS` at CPSV16 lines 1080-1097. -/
+This is the formal counterpart of CPSV16 line 1188's exact power-sum
+comparison; it deliberately avoids the unsound asymptotic-difference to
+full-multiset route identified in the Phase B completion audit. -/
 theorem coeff_identity_via_global_gauge
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    let UnitQ := { k : Fin Q.basisCount // ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1 }
-    ∀ (φ : UnitQ ↪ Fin P.basisCount)
-      (_hMatch : ∀ k : UnitQ, ∃ h : P.basisDim (φ k) = Q.basisDim k.val,
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (P.basis (φ k))) (Q.basis k.val) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (P.basis (φ k)) (Q.basis k.val) N)
-          atTop (𝓝 0)),
-      (∀ k : UnitQ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
-          Tendsto (fun N : ℕ =>
-              P.coeff N (φ k) - ζ ^ N * Q.coeff N k.val)
-            atTop (𝓝 0)) ∧
-      (∀ j : Fin P.basisCount, (∀ k : UnitQ, φ k ≠ j) →
-          Tendsto (fun N : ℕ => P.coeff N j) atTop (𝓝 0)) := by
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor)
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hMatch : ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
+      GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k)) :
+    ∀ k : Fin Q.basisCount, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧ ∃ N₀, ∀ N > N₀,
+      P.coeff N (β k) = ζ ^ N * Q.coeff N k := by
   classical
-  -- The `let UnitQ := ...` in the goal introduces a let-binding that
-  -- `intro` consumes BEFORE the explicit `∀` binders.  We name it `UnitQ`.
-  intro UnitQ φ hMatch
-  -- For each `k : UnitQ`, extract the matched gauge data `(h, hGPE, _)`
-  -- and feed it into `extract_unit_gauge_phase_mpv` to obtain `(ζ, ‖ζ‖=1, hmpv)`.
-  let gaugeData : (k : UnitQ) →
+  let phaseData : (k : Fin Q.basisCount) →
       { ζ : ℂ // ‖ζ‖ = 1 ∧
         ∀ (N : ℕ) (σ : Fin N → Fin d),
-          mpv (Q.basis k.val) σ = ζ ^ N * mpv (P.basis (φ k)) σ } := fun k =>
+          mpv (Q.basis k) σ = ζ ^ N * mpv (P.basis (β k)) σ } := fun k =>
     let hm := hMatch k
-    let h : P.basisDim (φ k) = Q.basisDim k.val := hm.choose
+    let hdim : P.basisDim (β k) = Q.basisDim k := hm.choose
     let hGPE : GaugePhaseEquiv
-        (cast (congr_arg (MPSTensor d) h) (P.basis (φ k))) (Q.basis k.val) :=
-      hm.choose_spec.1
-    let res := extract_unit_gauge_phase_mpv hP hQ h hGPE
+        (cast (congr_arg (MPSTensor d) hdim) (P.basis (β k))) (Q.basis k) :=
+      hm.choose_spec
+    let res := extract_unit_gauge_phase_mpv hP hQ hdim hGPE
     ⟨res.choose, res.choose_spec⟩
-  let ζ : UnitQ → ℂ := fun k => (gaugeData k).val
-  have hζ_norm : ∀ k : UnitQ, ‖ζ k‖ = 1 := fun k => (gaugeData k).property.1
-  have hζ_mpv : ∀ (k : UnitQ) (N : ℕ) (σ : Fin N → Fin d),
-      mpv (Q.basis k.val) σ = (ζ k) ^ N * mpv (P.basis (φ k)) σ := fun k =>
-    (gaugeData k).property.2
-  -- Weight bounds for both canonical forms (CPSV16 line 246).
-  have hP_weight_le : ∀ j : Fin P.basisCount,
-      ∀ q : Fin (P.copies j), ‖P.weight j q‖ ≤ 1 := hP.weight_norm_le_one
-  have hQ_weight_le : ∀ k : Fin Q.basisCount,
-      ∀ q : Fin (Q.copies k), ‖Q.weight k q‖ ≤ 1 := hQ.weight_norm_le_one
-  -- For each k ∉ UnitQ, every weight is strictly subnormal, hence the
-  -- Q-side coefficient decays (Cesàro converse, `PaperBNT/Api.lean`).
-  have hQ_coeff_zero_of_nonunit : ∀ k : Fin Q.basisCount,
-      (¬ ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1) →
-      Tendsto (fun N : ℕ => Q.coeff N k) atTop (𝓝 0) := by
-    intro k hnone
-    apply hQ.coeff_tendsto_zero_of_all_weights_subnorm
-    intro q
-    have hle := hQ_weight_le k q
-    have hne : ‖Q.weight k q‖ ≠ 1 := by
-      intro h1
-      exact hnone ⟨q, h1⟩
-    exact lt_of_le_of_ne hle hne
-  -- Auxiliary `NeZero` instances for the left-canonical mpvOverlap bound.
-  have hP_dimPos : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
-    fun j => ⟨(hP.basis_dim_pos j).ne'⟩
-  have hQ_dimPos : ∀ k : Fin Q.basisCount, NeZero (Q.basisDim k) :=
-    fun k => ⟨(hQ.basis_dim_pos k).ne'⟩
-  -- ============================================================
-  -- The per-`j₀` projection result.
-  -- ============================================================
-  -- For each `j₀ : Fin P.basisCount`, define the "matched RHS contribution"
-  -- as the sum over UnitQ of conditional terms.
-  let matchedRHS : Fin P.basisCount → ℕ → ℂ := fun j₀ N =>
-    ∑ k : UnitQ, (if φ k = j₀ then (ζ k) ^ N * Q.coeff N k.val else 0)
-  -- ============================================================
-  -- Master per-`j₀` tendsto: `P.coeff N j₀ - matchedRHS j₀ N → 0`.
-  -- ============================================================
-  have master_tendsto : ∀ j₀ : Fin P.basisCount,
-      Tendsto (fun N : ℕ => P.coeff N j₀ - matchedRHS j₀ N) atTop (𝓝 0) := by
-    intro j₀
-    haveI hj₀dim : NeZero (P.basisDim j₀) := hP_dimPos j₀
-    -- Overlap projection identity:
-    -- `∑_j P.coeff N j · ⟨P.basis j | P.basis j₀⟩_N
-    --    = ∑_k Q.coeff N k · ⟨Q.basis k | P.basis j₀⟩_N`.
-    have hProj_identity :
-        ∀ N : ℕ,
-          (∑ j : Fin P.basisCount, P.coeff N j *
-              mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
-            = ∑ k : Fin Q.basisCount, Q.coeff N k *
-                mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N := by
-      intro N
-      have hLHS :=
-        mpvOverlap_eq_sum_of_decomp_left (d := d) (g := P.basisCount)
-          (dim := P.basisDim) (A_total := P.toTensor) (A := P.basis)
-          (N := N) (c := fun j => P.coeff N j)
-          (hdecomp := fun σ => P.mpv_toTensor_eq_sum_coeff (N := N) σ)
-          (B := P.basis j₀)
-      have hRHS :=
-        mpvOverlap_eq_sum_of_decomp_left (d := d) (g := Q.basisCount)
-          (dim := Q.basisDim) (A_total := Q.toTensor) (A := Q.basis)
-          (N := N) (c := fun k => Q.coeff N k)
-          (hdecomp := fun σ => Q.mpv_toTensor_eq_sum_coeff (N := N) σ)
-          (B := P.basis j₀)
-      have hPQ :
-          mpvOverlap (d := d) P.toTensor (P.basis j₀) N
-            = mpvOverlap (d := d) Q.toTensor (P.basis j₀) N := by
-        simp only [mpvOverlap]
-        refine Finset.sum_congr rfl ?_
-        intro σ _
-        rw [hEqual N σ]
-      exact (hLHS.symm.trans hPQ).trans hRHS
-    -- LHS analysis: each `j ≠ j₀` term tends to `0` (cross-decay × bounded).
-    have hP_cross : ∀ j : Fin P.basisCount, j ≠ j₀ →
-        Tendsto (fun N : ℕ =>
-            P.coeff N j * mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
-          atTop (𝓝 0) := by
-      intro j hj
-      have hOverlap : Tendsto (fun N : ℕ =>
-          mpvOverlap (d := d) (P.basis j) (P.basis j₀) N) atTop (𝓝 0) :=
-        hP.cross_overlap_basis_tendsto_zero hj
-      have hBound :
-          Tendsto (fun N : ℕ =>
-              (P.copies j : ℝ) *
-              ‖mpvOverlap (d := d) (P.basis j) (P.basis j₀) N‖)
-            atTop (𝓝 0) := by
-        have := hOverlap.norm.const_mul ((P.copies j : ℝ))
-        simpa using this
-      refine squeeze_zero_norm (fun N => ?_) hBound
-      have hC := P.norm_coeff_le_copies_of_norm_weight_le_one (N := N) (j := j)
-        (hWeightLe := hP_weight_le j)
-      calc
-        ‖P.coeff N j * mpvOverlap (d := d) (P.basis j) (P.basis j₀) N‖
-            = ‖P.coeff N j‖ *
-              ‖mpvOverlap (d := d) (P.basis j) (P.basis j₀) N‖ := norm_mul _ _
-        _ ≤ (P.copies j : ℝ) *
-              ‖mpvOverlap (d := d) (P.basis j) (P.basis j₀) N‖ :=
-            mul_le_mul_of_nonneg_right hC (norm_nonneg _)
-    have hP_tail_tendsto_zero :
-        Tendsto (fun N : ℕ =>
-            ∑ j ∈ (Finset.univ : Finset (Fin P.basisCount)).erase j₀,
-              P.coeff N j *
-                mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
-          atTop (𝓝 0) := by
-      have := tendsto_finset_sum
-        ((Finset.univ : Finset (Fin P.basisCount)).erase j₀)
-        (fun (j : Fin P.basisCount) hj =>
-          hP_cross j (Finset.ne_of_mem_erase hj))
-      simpa using this
-    -- Diagonal: `P.coeff N j₀ · (self_overlap - 1) → 0`.
-    have hP_self_minus_one : Tendsto (fun N : ℕ =>
-        mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1)
-        atTop (𝓝 0) := by
-      have := (hP.basis_normalized_self_overlap j₀).sub_const (1 : ℂ)
-      simpa using this
-    have hP_diag_minus_coeff : Tendsto (fun N : ℕ =>
-        P.coeff N j₀ *
-          (mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1))
-        atTop (𝓝 0) := by
-      have hBound : Tendsto (fun N : ℕ =>
-          (P.copies j₀ : ℝ) *
-          ‖mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1‖)
-          atTop (𝓝 0) := by
-        have := hP_self_minus_one.norm.const_mul ((P.copies j₀ : ℝ))
-        simpa using this
-      refine squeeze_zero_norm (fun N => ?_) hBound
-      have hC := P.norm_coeff_le_copies_of_norm_weight_le_one (N := N) (j := j₀)
-        (hWeightLe := hP_weight_le j₀)
-      calc
-        ‖P.coeff N j₀ *
-            (mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1)‖
-            = ‖P.coeff N j₀‖ *
-              ‖mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1‖ :=
-            norm_mul _ _
-        _ ≤ (P.copies j₀ : ℝ) *
-              ‖mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1‖ :=
-            mul_le_mul_of_nonneg_right hC (norm_nonneg _)
-    have hLHS_minus_coeff : Tendsto (fun N : ℕ =>
-        (∑ j : Fin P.basisCount, P.coeff N j *
-            mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
-          - P.coeff N j₀)
-        atTop (𝓝 0) := by
-      have hCombined : Tendsto (fun N : ℕ =>
-          P.coeff N j₀ *
-            (mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1)
-          + ∑ j ∈ (Finset.univ : Finset (Fin P.basisCount)).erase j₀,
-              P.coeff N j *
-                mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
-          atTop (𝓝 0) := by
-        have h := hP_diag_minus_coeff.add hP_tail_tendsto_zero
-        simpa using h
-      refine hCombined.congr ?_
-      intro N
-      have hSplit : (∑ j : Fin P.basisCount, P.coeff N j *
-          mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
-          = P.coeff N j₀ *
-              mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N
-            + ∑ j ∈ (Finset.univ : Finset (Fin P.basisCount)).erase j₀,
-                P.coeff N j *
-                  mpvOverlap (d := d) (P.basis j) (P.basis j₀) N := by
-        rw [← Finset.add_sum_erase
-          (Finset.univ : Finset (Fin P.basisCount))
-          (fun j => P.coeff N j *
-            mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
-          (Finset.mem_univ j₀)]
-      have hRw : P.coeff N j₀ *
-          mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N
-          = P.coeff N j₀ *
-              (mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1)
-            + P.coeff N j₀ := by ring
-      rw [hSplit, hRw]; ring
-    -- RHS analysis: split `k : Fin Q.basisCount` into `UnitQ` and complement.
-    -- For each `k : Fin Q.basisCount`, compute its `Q.coeff N k · overlap` term.
-    -- We will partition `Finset.univ : Finset (Fin Q.basisCount)` into
-    -- "is unit-modulus on Q" and "is not", and analyse each side.
-    -- For each k ∈ UnitQ with φ k = j₀: term tends to (Q.coeff N k · ζ_k^N) eventually.
-    -- For each k ∈ UnitQ with φ k ≠ j₀: term → 0.
-    -- For each k ∉ UnitQ: term → 0.
-    --
-    -- We work with a per-k analysis function.  For each `k : Fin Q.basisCount`,
-    -- consider the term `tQ k N := Q.coeff N k * mpvOverlap (Q.basis k) (P.basis j₀) N`.
-    -- We aim: `Tendsto (fun N => tQ k N - tQ_target k N) atTop (𝓝 0)`, where
-    -- `tQ_target k N := if (∃ kU : UnitQ, kU.val = k ∧ φ kU = j₀)`
-    --                  `then ζ_{kU}^N · Q.coeff N k else 0`.
-    --
-    -- Step 1: For k ∈ UnitQ, rewrite `mpvOverlap (Q.basis k) (P.basis j₀) N
-    --                                  = ζ_k^N · mpvOverlap (P.basis (φ k)) (P.basis j₀) N`.
-    have hQ_unit_overlap_subst : ∀ (kU : UnitQ) (N : ℕ),
-        mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-          = (ζ kU) ^ N * mpvOverlap (d := d) (P.basis (φ kU)) (P.basis j₀) N := by
-      intro kU N
-      exact mpvOverlap_subst_via_mpv_pow (X := P.basis j₀) (hζ_mpv kU) N
-    -- Step 2: For k ∈ UnitQ with φ k ≠ j₀, the term `Q.coeff N k.val · overlap → 0`.
-    have hQ_unit_unmatched_tendsto_zero : ∀ kU : UnitQ, φ kU ≠ j₀ →
-        Tendsto (fun N : ℕ =>
-            Q.coeff N kU.val *
-              mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N)
-          atTop (𝓝 0) := by
-      intro kU hne
-      -- Rewrite via gauge substitution: term = Q.coeff · ζ^N · ⟨A_{φ k} | A_{j₀}⟩.
-      have hOverlap_decay : Tendsto (fun N : ℕ =>
-          mpvOverlap (d := d) (P.basis (φ kU)) (P.basis j₀) N) atTop (𝓝 0) :=
-        hP.cross_overlap_basis_tendsto_zero hne
-      -- Bound: |Q.coeff N k| ≤ Q.copies k, |ζ_k^N| = 1.
-      have hBound : Tendsto (fun N : ℕ =>
-          (Q.copies kU.val : ℝ) *
-          ‖mpvOverlap (d := d) (P.basis (φ kU)) (P.basis j₀) N‖)
-          atTop (𝓝 0) := by
-        have := hOverlap_decay.norm.const_mul ((Q.copies kU.val : ℝ))
-        simpa using this
-      refine squeeze_zero_norm (fun N => ?_) hBound
-      rw [hQ_unit_overlap_subst kU N]
-      have hC := Q.norm_coeff_le_copies_of_norm_weight_le_one (N := N) (j := kU.val)
-        (hWeightLe := hQ_weight_le kU.val)
-      have hζN : ‖(ζ kU) ^ N‖ = 1 := by
-        rw [norm_pow, hζ_norm kU, one_pow]
-      calc
-        ‖Q.coeff N kU.val *
-            ((ζ kU) ^ N *
-              mpvOverlap (d := d) (P.basis (φ kU)) (P.basis j₀) N)‖
-            = ‖Q.coeff N kU.val‖ * (‖(ζ kU) ^ N‖ *
-              ‖mpvOverlap (d := d) (P.basis (φ kU)) (P.basis j₀) N‖) := by
-              rw [norm_mul, norm_mul]
-        _ = ‖Q.coeff N kU.val‖ *
-              ‖mpvOverlap (d := d) (P.basis (φ kU)) (P.basis j₀) N‖ := by
-              rw [hζN, one_mul]
-        _ ≤ (Q.copies kU.val : ℝ) *
-              ‖mpvOverlap (d := d) (P.basis (φ kU)) (P.basis j₀) N‖ :=
-            mul_le_mul_of_nonneg_right hC (norm_nonneg _)
-    -- Step 3: For k ∉ UnitQ, `Q.coeff N k → 0` and overlap bounded by D₁·D₂.
-    have hQ_nonunit_tendsto_zero : ∀ k : Fin Q.basisCount,
-        (¬ ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1) →
-        Tendsto (fun N : ℕ =>
-            Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)
-          atTop (𝓝 0) := by
-      intro k hnone
-      have hCoeff := hQ_coeff_zero_of_nonunit k hnone
-      -- Uniform overlap bound (left-canonical Cauchy-Schwarz).
-      haveI : NeZero (Q.basisDim k) := hQ_dimPos k
-      haveI : NeZero (P.basisDim j₀) := hP_dimPos j₀
-      have hOverlap_bound : ∀ N : ℕ,
-          ‖mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N‖
-            ≤ (Q.basisDim k : ℝ) * (P.basisDim j₀ : ℝ) := fun N =>
-        leftCanonical_mpvOverlap_bound (Q.basis k) (P.basis j₀)
-          (hQ.basis_left_canonical k) (hP.basis_left_canonical j₀) N
-      -- Combined: |coeff · overlap| ≤ |coeff| · D₁·D₂, with |coeff| → 0.
-      have hBoundProd : Tendsto (fun N : ℕ =>
-          ‖Q.coeff N k‖ *
-          ((Q.basisDim k : ℝ) * (P.basisDim j₀ : ℝ)))
-          atTop (𝓝 0) := by
-        have hc := hCoeff.norm
-        have : Tendsto (fun N : ℕ => ‖Q.coeff N k‖) atTop (𝓝 0) := by
-          simpa using hc
-        have := this.mul_const ((Q.basisDim k : ℝ) * (P.basisDim j₀ : ℝ))
-        simpa using this
-      refine squeeze_zero_norm (fun N => ?_) hBoundProd
-      have hCS := hOverlap_bound N
-      calc
-        ‖Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N‖
-            = ‖Q.coeff N k‖ *
-              ‖mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N‖ := norm_mul _ _
-        _ ≤ ‖Q.coeff N k‖ * ((Q.basisDim k : ℝ) * (P.basisDim j₀ : ℝ)) :=
-            mul_le_mul_of_nonneg_left hCS (norm_nonneg _)
-    -- Step 4: For k ∈ UnitQ with φ k = j₀, the term equals
-    -- `ζ_k^N · Q.coeff N k.val · mpvOverlap (P.basis j₀) (P.basis j₀) N`,
-    -- which equals `ζ_k^N · Q.coeff N k.val + ζ_k^N · Q.coeff N k.val · (self - 1)`,
-    -- and the second part tends to `0`.
-    have hQ_unit_matched_minus : ∀ kU : UnitQ, φ kU = j₀ →
-        Tendsto (fun N : ℕ =>
-            Q.coeff N kU.val *
-              mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-            - (ζ kU) ^ N * Q.coeff N kU.val)
-          atTop (𝓝 0) := by
-      intro kU hEq
-      have hSelf_minus_one : Tendsto (fun N : ℕ =>
-          mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1)
-          atTop (𝓝 0) := by
-        have := (hP.basis_normalized_self_overlap j₀).sub_const (1 : ℂ)
-        simpa using this
-      -- After substitution and using φ kU = j₀:
-      -- Q.coeff N kU.val · ⟨B_{kU} | A_{j₀}⟩ = ζ_{kU}^N · Q.coeff N kU.val · ⟨A_{j₀} | A_{j₀}⟩
-      have hRewrite : ∀ N : ℕ,
-          Q.coeff N kU.val *
-              mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-            - (ζ kU) ^ N * Q.coeff N kU.val
-            = (ζ kU) ^ N * Q.coeff N kU.val *
-              (mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1) := by
-        intro N
-        rw [hQ_unit_overlap_subst kU N]
-        -- Goal: Q.coeff N kU.val * (ζ_{kU}^N * mpvOverlap (P.basis (φ kU)) (P.basis j₀) N)
-        --   - (ζ_{kU}^N * Q.coeff N kU.val)
-        --   = (ζ_{kU}^N * Q.coeff N kU.val) *
-        --       (mpvOverlap (P.basis j₀) (P.basis j₀) N - 1)
-        -- Use φ kU = j₀ to identify P.basis (φ kU) with P.basis j₀.
-        rw [hEq]
-        ring
-      refine Tendsto.congr (fun N => (hRewrite N).symm) ?_
-      have hBound : Tendsto (fun N : ℕ =>
-          (Q.copies kU.val : ℝ) *
-          ‖mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1‖)
-          atTop (𝓝 0) := by
-        have := hSelf_minus_one.norm.const_mul ((Q.copies kU.val : ℝ))
-        simpa using this
-      refine squeeze_zero_norm (fun N => ?_) hBound
-      have hC := Q.norm_coeff_le_copies_of_norm_weight_le_one
-        (N := N) (j := kU.val) (hWeightLe := hQ_weight_le kU.val)
-      have hζN : ‖(ζ kU) ^ N‖ = 1 := by
-        rw [norm_pow, hζ_norm kU, one_pow]
-      calc
-        ‖(ζ kU) ^ N * Q.coeff N kU.val *
-            (mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1)‖
-            = (‖(ζ kU) ^ N‖ * ‖Q.coeff N kU.val‖) *
-              ‖mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1‖ := by
-              rw [norm_mul, norm_mul]
-        _ = ‖Q.coeff N kU.val‖ *
-              ‖mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1‖ := by
-              rw [hζN, one_mul]
-        _ ≤ (Q.copies kU.val : ℝ) *
-              ‖mpvOverlap (d := d) (P.basis j₀) (P.basis j₀) N - 1‖ :=
-            mul_le_mul_of_nonneg_right hC (norm_nonneg _)
-    -- Combine all per-k pieces:
-    -- For each k : Fin Q.basisCount, define a "per-k delta":
-    --   `Δ k N := (Q.coeff N k · overlap(Q.basis k, P.basis j₀, N))
-    --              - (kU_match_contrib k N)`,
-    -- where `kU_match_contrib k N = ζ_{kU}^N · Q.coeff N k` if `k = kU.val` for
-    -- some `kU : UnitQ` with `φ kU = j₀`, else `0`.
-    -- We claim `Δ k N → 0` for all k, and `∑_k Δ k N → 0` is what we want.
-    --
-    -- Define the bridge function piece-wise on `Fin Q.basisCount`:
-    -- `bridge k N := if (∃ kU : UnitQ, kU.val = k ∧ φ kU = j₀)
-    --                  then (ζ kU)^N · Q.coeff N k else 0`.
-    -- The key identity: `bridge k N = matchedRHS j₀ N` when summed over `k`,
-    -- modulo the conversion from `UnitQ` to a Fin-indexed sum.
-    --
-    -- Approach: sum `tQ k N - bridge k N` over `k : Fin Q.basisCount`.
-    -- LHS sum = RHS - ∑_k bridge k N = RHS - matchedRHS j₀ N
-    --   (since the sum over k = sum over UnitQ ∪ complement, and only UnitQ
-    --    with φ kU = j₀ contributes).
-    -- We show the LHS sum tends to 0 by combining per-k pieces.
-    -- For convenience, we work with the "matched bridge" form via UnitQ.
-    -- Concretely: `∑_{k : Fin Q.basisCount} tQ k N`
-    --   = `∑_{kU : UnitQ} tQ kU.val N + ∑_{k ∉ image of UnitQ} tQ k N`.
-    -- And `matchedRHS j₀ N = ∑_{kU : UnitQ, φ kU = j₀} (ζ kU)^N · Q.coeff N kU.val`.
-    --
-    -- Since φ is an Embedding, injectivity gives at most one such `kU`.
-    -- We'll re-express things using `Finset.sum` on a partition.
-    -- ============================================================
-    -- The cleanest combinatorial path: introduce the inclusion
-    --   `inc : UnitQ → Fin Q.basisCount := Subtype.val`,
-    -- which is injective.  Sum decomposition:
-    -- `∑_k tQ k N = ∑_{kU} tQ kU.val N + ∑_{k ∈ univ \ image inc} tQ k N`.
-    -- The first sum: by per-`kU` cases (matched/unmatched), it tends to
-    -- `matchedRHS j₀ N` (asymptotically).
-    -- The second sum: by `hQ_nonunit_tendsto_zero`, tends to `0`.
-    -- ============================================================
-    -- Step A: `∑_{k ∉ image inc} tQ k N → 0`.
-    -- These `k`'s have no `q` with `‖Q.weight k q‖ = 1` (otherwise k ∈ UnitQ).
-    have hQ_complement_set :
-        (Finset.univ : Finset (Fin Q.basisCount)).filter
-          (fun k => ¬ ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
-        = (Finset.univ : Finset (Fin Q.basisCount)).filter
-          (fun k => ¬ ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1) := rfl
-    have h_complement_tendsto_zero :
-        Tendsto (fun N : ℕ =>
-            ∑ k ∈ (Finset.univ : Finset (Fin Q.basisCount)).filter
-              (fun k => ¬ ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1),
-              Q.coeff N k * mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)
-          atTop (𝓝 0) := by
-      have := tendsto_finset_sum
-        ((Finset.univ : Finset (Fin Q.basisCount)).filter
-          (fun k => ¬ ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1))
-        (fun k hk => hQ_nonunit_tendsto_zero k
-          (by
-            have := Finset.mem_filter.mp hk
-            exact this.2))
-      simpa using this
-    -- Step B: `∑_{k ∈ image inc} tQ k N → matchedRHS j₀ N` (asymptotically).
-    -- We index this sum via the embedding `UnitQ ↪ Fin Q.basisCount` (Subtype.val).
-    -- The matched-kU contributions give `ζ_{kU}^N · Q.coeff N kU.val` (modulo o(1)).
-    -- The unmatched-kU contributions give `0` (modulo o(1)).
-    -- ∑_{kU : UnitQ} (Q.coeff N kU.val · overlap - matched_term kU N) → 0.
-    have hQ_unit_sum_minus :
-        Tendsto (fun N : ℕ =>
-            ∑ kU : UnitQ,
-              (Q.coeff N kU.val *
-                mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-                - (if φ kU = j₀ then (ζ kU) ^ N * Q.coeff N kU.val else 0)))
-          atTop (𝓝 0) := by
-      have hPer : ∀ kU : UnitQ,
-          Tendsto (fun N : ℕ =>
-              Q.coeff N kU.val *
-                mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-                - (if φ kU = j₀ then (ζ kU) ^ N * Q.coeff N kU.val else 0))
-            atTop (𝓝 0) := by
-        intro kU
-        by_cases hCase : φ kU = j₀
-        · rw [show (fun N : ℕ =>
-              Q.coeff N kU.val *
-                mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-              - (if φ kU = j₀ then (ζ kU) ^ N * Q.coeff N kU.val else 0))
-            = (fun N : ℕ =>
-              Q.coeff N kU.val *
-                mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-              - (ζ kU) ^ N * Q.coeff N kU.val) from by
-            funext N; rw [if_pos hCase]]
-          exact hQ_unit_matched_minus kU hCase
-        · rw [show (fun N : ℕ =>
-              Q.coeff N kU.val *
-                mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-              - (if φ kU = j₀ then (ζ kU) ^ N * Q.coeff N kU.val else 0))
-            = (fun N : ℕ =>
-              Q.coeff N kU.val *
-                mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N) from by
-            funext N; rw [if_neg hCase]; ring]
-          exact hQ_unit_unmatched_tendsto_zero kU hCase
-      have := tendsto_finset_sum (Finset.univ : Finset UnitQ)
-        (fun (kU : UnitQ) _ => hPer kU)
-      simpa using this
-    -- Identify the sum over `UnitQ` with the sum over `image inc ⊂ Fin Q.basisCount`.
-    -- This is the bijection `UnitQ ≃ image inc` from `Subtype.val` injectivity.
-    -- We'll convert via `Finset.sum_subtype`.
-    -- Combine: `RHS - matchedRHS j₀ N → 0` where RHS is the full Q-sum.
-    have hRHS_minus_matchedRHS :
-        Tendsto (fun N : ℕ =>
-            (∑ k : Fin Q.basisCount, Q.coeff N k *
-                mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)
-              - matchedRHS j₀ N)
-          atTop (𝓝 0) := by
-      -- Rewrite `RHS - matchedRHS = unit_sum_minus_matchedRHS + complement_sum`.
-      -- Strategy:
-      --   RHS = ∑_{kU : UnitQ} f kU.val + ∑_{k ∈ CFilter} f k  (partition);
-      --   matchedRHS = ∑_{kU : UnitQ} (if φ kU = j₀ then … else 0);
-      --   RHS - matchedRHS = ∑_{kU : UnitQ} (f kU.val - …) + ∑_{CFilter} f k.
-      -- The first summand → 0 by `hQ_unit_sum_minus`; the second → 0 by
-      -- `h_complement_tendsto_zero`.
-      have hSplitSum : ∀ N : ℕ,
-          (∑ k : Fin Q.basisCount, Q.coeff N k *
-              mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)
-            - matchedRHS j₀ N
-            = (∑ kU : UnitQ,
-                  (Q.coeff N kU.val *
-                    mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-                    - (if φ kU = j₀ then (ζ kU) ^ N * Q.coeff N kU.val else 0)))
-              + (∑ k ∈ (Finset.univ : Finset (Fin Q.basisCount)).filter
-                    (fun k => ¬ ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1),
-                  Q.coeff N k *
-                    mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N) := by
-        intro N
-        classical
-        -- Partition: ∑ k ∈ univ, f k = ∑ k ∈ univ.filter p, f k + ∑ k ∈ univ.filter (¬ p), f k.
-        have hPartition :
-            (∑ k : Fin Q.basisCount, Q.coeff N k *
-                mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)
-              = (∑ k ∈ (Finset.univ : Finset (Fin Q.basisCount)).filter
-                    (fun k => ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1),
-                  Q.coeff N k *
-                    mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)
-                + (∑ k ∈ (Finset.univ : Finset (Fin Q.basisCount)).filter
-                    (fun k => ¬ ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1),
-                  Q.coeff N k *
-                    mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N) := by
-          rw [← Finset.sum_filter_add_sum_filter_not
-            (Finset.univ : Finset (Fin Q.basisCount))
-            (fun k => ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
-            (fun k => Q.coeff N k *
-              mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)]
-        -- Convert the filter-sum (positive side) to a UnitQ sum.
-        have hFilterToSub :
-            (∑ k ∈ (Finset.univ : Finset (Fin Q.basisCount)).filter
-                (fun k => ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1),
-              Q.coeff N k *
-                mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)
-              = ∑ kU : UnitQ, Q.coeff N kU.val *
-                mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N := by
-          refine Finset.sum_subtype
-            ((Finset.univ : Finset (Fin Q.basisCount)).filter
-              (fun k => ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1))
-            ?_ _
-          intro x
-          simp
-        -- Express `matchedRHS j₀ N` as a sum over UnitQ.
-        have hMatched_def : matchedRHS j₀ N = ∑ kU : UnitQ,
-            (if φ kU = j₀ then (ζ kU) ^ N * Q.coeff N kU.val else 0) := rfl
-        rw [hPartition, hFilterToSub, hMatched_def]
-        rw [show
-          ∑ kU : UnitQ,
-            (Q.coeff N kU.val *
-                mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N
-              - (if φ kU = j₀ then (ζ kU) ^ N * Q.coeff N kU.val else 0))
-            = (∑ kU : UnitQ, Q.coeff N kU.val *
-                mpvOverlap (d := d) (Q.basis kU.val) (P.basis j₀) N)
-              - ∑ kU : UnitQ,
-                (if φ kU = j₀ then (ζ kU) ^ N * Q.coeff N kU.val else 0)
-          from Finset.sum_sub_distrib _ _]
-        ring
-      refine Tendsto.congr (fun N => (hSplitSum N).symm) ?_
-      have := hQ_unit_sum_minus.add h_complement_tendsto_zero
-      simpa using this
-    -- Now use the projection identity to pivot from LHS to RHS.
-    -- `(LHS - P.coeff N j₀) - (RHS - matchedRHS j₀ N) = matchedRHS j₀ N - P.coeff N j₀`.
-    -- And `LHS = RHS` (projection identity), so the LHS difference is exactly
-    -- `matchedRHS j₀ N - P.coeff N j₀`.  Hence both `(LHS - P.coeff N j₀)` and
-    -- `(RHS - matchedRHS j₀ N)` differ by a constant per N — combined they
-    -- give `P.coeff N j₀ - matchedRHS j₀ N → 0`.
-    have hDiff : Tendsto (fun N : ℕ =>
-        (∑ j : Fin P.basisCount, P.coeff N j *
-            mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
-          - P.coeff N j₀
-          - ((∑ k : Fin Q.basisCount, Q.coeff N k *
-                mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)
-            - matchedRHS j₀ N))
-        atTop (𝓝 (0 - 0)) :=
-      hLHS_minus_coeff.sub hRHS_minus_matchedRHS
-    have hDiff_zero : Tendsto (fun N : ℕ =>
-        (∑ j : Fin P.basisCount, P.coeff N j *
-            mpvOverlap (d := d) (P.basis j) (P.basis j₀) N)
-          - P.coeff N j₀
-          - ((∑ k : Fin Q.basisCount, Q.coeff N k *
-                mpvOverlap (d := d) (Q.basis k) (P.basis j₀) N)
-            - matchedRHS j₀ N))
-        atTop (𝓝 0) := by simpa using hDiff
-    -- Use the projection identity LHS = RHS pointwise to collapse the
-    -- difference to `matchedRHS j₀ N - P.coeff N j₀`.
-    have hMatched_minus_coeff : Tendsto (fun N : ℕ =>
-        matchedRHS j₀ N - P.coeff N j₀)
-        atTop (𝓝 0) := by
-      refine hDiff_zero.congr ?_
-      intro N
-      have hId := hProj_identity N
-      -- `(LHS - coeff) - (RHS - matched) = matched - coeff` when LHS = RHS.
-      linear_combination hId
-    -- Negate to obtain the desired `P.coeff N j₀ - matchedRHS j₀ N → 0`.
-    have hFinal := hMatched_minus_coeff.neg
-    simp only [neg_sub, neg_zero] at hFinal
-    exact hFinal
-  -- ============================================================
-  -- Specialize the master tendsto to derive the two clauses.
-  -- ============================================================
-  refine ⟨?_, ?_⟩
-  · -- Matched-pair clause: for each k : UnitQ, with j₀ := φ k, the matched sum
-    -- has exactly one nonzero term (the k itself), giving the asymptotic identity.
-    intro k
-    refine ⟨ζ k, hζ_norm k, ?_⟩
-    have hM := master_tendsto (φ k)
-    refine hM.congr ?_
+  let ζ : Fin Q.basisCount → ℂ := fun k => (phaseData k).val
+  have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := fun k =>
+    (phaseData k).property.1
+  have hζ_mpv : ∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ := fun k =>
+    (phaseData k).property.2
+  let a : ℕ → Fin P.basisCount → ℂ := fun N j => P.coeff N j
+  let b : ℕ → Fin P.basisCount → ℂ := fun N j =>
+    (ζ (β.symm j)) ^ N * Q.coeff N (β.symm j)
+  have hLI : ∀ᶠ N in atTop,
+      LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (d := d) (P.basis j) N) := by
+    obtain ⟨N₀, hN₀⟩ := hP.bnt_data
+    rw [Filter.eventually_atTop]
+    refine ⟨N₀ + 1, ?_⟩
+    intro N hN
+    exact hN₀ N (Nat.lt_of_succ_le hN)
+  have hEq : ∀ᶠ N in atTop,
+      ∑ j : Fin P.basisCount, a N j • mpvState (d := d) (P.basis j) N =
+        ∑ j : Fin P.basisCount, b N j • mpvState (d := d) (P.basis j) N := by
+    refine Filter.Eventually.of_forall ?_
     intro N
-    -- Show: P.coeff N (φ k) - matchedRHS (φ k) N = P.coeff N (φ k) - ζ k ^ N · Q.coeff N k.val.
-    -- Equivalently: matchedRHS (φ k) N = ζ k ^ N · Q.coeff N k.val.
-    have hSum : matchedRHS (φ k) N = (ζ k) ^ N * Q.coeff N k.val := by
-      change (∑ kU : UnitQ,
-          (if φ kU = φ k then (ζ kU) ^ N * Q.coeff N kU.val else 0))
-        = (ζ k) ^ N * Q.coeff N k.val
-      have hφ_inj : Function.Injective (φ : UnitQ → Fin P.basisCount) :=
-        φ.injective
-      have h_unique : ∀ kU : UnitQ, kU ≠ k →
-          (if φ kU = φ k then (ζ kU) ^ N * Q.coeff N kU.val else 0) = 0 := by
-        intro kU hne
-        rw [if_neg]
-        intro hEq
-        exact hne (hφ_inj hEq)
-      rw [Finset.sum_eq_single k]
-      · rw [if_pos rfl]
-      · intro kU _ hne
-        exact h_unique kU hne
-      · intro hMem
-        exfalso
-        exact hMem (Finset.mem_univ k)
-    rw [hSum]
-  · -- Non-matched clause: for each j ∉ range(φ), matchedRHS j N = 0,
-    -- hence P.coeff N j → 0.
-    intro j₀ hUnmatched
-    have hM := master_tendsto j₀
-    refine hM.congr ?_
-    intro N
-    have hSum : matchedRHS j₀ N = 0 := by
-      change (∑ kU : UnitQ,
-          (if φ kU = j₀ then (ζ kU) ^ N * Q.coeff N kU.val else 0)) = 0
-      apply Finset.sum_eq_zero
-      intro kU _
-      rw [if_neg (hUnmatched kU)]
-    rw [hSum, sub_zero]
+    have hPstate :
+        mpvState (d := d) P.toTensor N =
+          ∑ j : Fin P.basisCount, P.coeff N j •
+            mpvState (d := d) (P.basis j) N := by
+      refine mpvState_eq_sum_of_decomp (d := d) P.toTensor P.basis
+        (N := N) (fun j => P.coeff N j) ?_
+      intro σ
+      simpa [smul_eq_mul] using P.mpv_toTensor_eq_sum_coeff (N := N) σ
+    have hQstate :
+        mpvState (d := d) Q.toTensor N =
+          ∑ k : Fin Q.basisCount, Q.coeff N k •
+            mpvState (d := d) (Q.basis k) N := by
+      refine mpvState_eq_sum_of_decomp (d := d) Q.toTensor Q.basis
+        (N := N) (fun k => Q.coeff N k) ?_
+      intro σ
+      simpa [smul_eq_mul] using Q.mpv_toTensor_eq_sum_coeff (N := N) σ
+    have hStateEq : mpvState (d := d) P.toTensor N = mpvState (d := d) Q.toTensor N := by
+      apply PiLp.ext
+      intro σ
+      simpa [mpvState_apply, mpv] using hEqual N σ
+    have hQsubst :
+        (∑ k : Fin Q.basisCount, Q.coeff N k •
+            mpvState (d := d) (Q.basis k) N) =
+          ∑ k : Fin Q.basisCount,
+            ((ζ k) ^ N * Q.coeff N k) •
+              mpvState (d := d) (P.basis (β k)) N := by
+      refine Finset.sum_congr rfl ?_
+      intro k _
+      have hState_k : mpvState (d := d) (Q.basis k) N =
+          ((ζ k) ^ N) • mpvState (d := d) (P.basis (β k)) N := by
+        apply PiLp.ext
+        intro σ
+        simpa [mpvState_apply, smul_eq_mul] using hζ_mpv k N σ
+      calc
+        Q.coeff N k • mpvState (d := d) (Q.basis k) N
+            = Q.coeff N k • (((ζ k) ^ N) •
+                mpvState (d := d) (P.basis (β k)) N) := by rw [hState_k]
+        _ = (Q.coeff N k * (ζ k) ^ N) •
+              mpvState (d := d) (P.basis (β k)) N := by rw [smul_smul]
+        _ = ((ζ k) ^ N * Q.coeff N k) •
+              mpvState (d := d) (P.basis (β k)) N := by rw [mul_comm]
+    have hReindex :
+        (∑ k : Fin Q.basisCount,
+            ((ζ k) ^ N * Q.coeff N k) •
+              mpvState (d := d) (P.basis (β k)) N) =
+          ∑ j : Fin P.basisCount,
+            (((ζ (β.symm j)) ^ N * Q.coeff N (β.symm j)) •
+              mpvState (d := d) (P.basis j) N) := by
+      let f : Fin Q.basisCount → MPVSpace d N := fun k =>
+        ((ζ k) ^ N * Q.coeff N k) • mpvState (d := d) (P.basis (β k)) N
+      let g : Fin P.basisCount → MPVSpace d N := fun j =>
+        ((ζ (β.symm j)) ^ N * Q.coeff N (β.symm j)) •
+          mpvState (d := d) (P.basis j) N
+      have hfg : ∀ k, f k = g (β k) := by
+        intro k
+        simp [f, g]
+      simpa [f, g] using (Fintype.sum_equiv β f g hfg)
+    calc
+      ∑ j : Fin P.basisCount, a N j • mpvState (d := d) (P.basis j) N
+          = mpvState (d := d) P.toTensor N := by
+              simpa [a] using hPstate.symm
+      _ = mpvState (d := d) Q.toTensor N := hStateEq
+      _ = ∑ k : Fin Q.basisCount, Q.coeff N k •
+            mpvState (d := d) (Q.basis k) N := hQstate
+      _ = ∑ k : Fin Q.basisCount,
+            ((ζ k) ^ N * Q.coeff N k) •
+              mpvState (d := d) (P.basis (β k)) N := hQsubst
+      _ = ∑ j : Fin P.basisCount, b N j •
+            mpvState (d := d) (P.basis j) N := by
+              simpa [b] using hReindex
+  have hCoeff : ∀ᶠ N in atTop, ∀ j : Fin P.basisCount, a N j = b N j := by
+    set_option maxRecDepth 1024 in
+    exact coefficient_eventually_eq_of_eventually_linearIndependent
+      (v := fun N j => mpvState (d := d) (P.basis j) N) (a := a) (b := b) hLI hEq
+  rw [Filter.eventually_atTop] at hCoeff
+  obtain ⟨N₀, hN₀⟩ := hCoeff
+  intro k
+  refine ⟨ζ k, hζ_norm k, N₀, ?_⟩
+  intro N hN
+  have h := hN₀ N (le_of_lt hN) (β k)
+  simpa [a, b] using h
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
@@ -9,11 +9,11 @@ import TNLean.MPS.Overlap.CastDecay
 import TNLean.Analysis.ConvergenceHelpers
 
 /-!
-# Dominant-pair matching on the paper-faithful BNT canonical-form surface
+# Full-block matching on the paper-faithful BNT canonical-form surface
 
 This module is **Phase 4b-ii** of the CPSV16/CPSV21 fundamental-theorem
 clean-slate plan (issue #1688).  It produces the **gauge-phase match** for a
-single dominant block of one BNT canonical form against some block of the
+single BNT basis block of one BNT canonical form against some block of the
 other, under `SameMPV₂` of the assembled tensors.
 
 The module has three layers:
@@ -24,15 +24,15 @@ The module has three layers:
    (`exists_nondecaying_overlap_pair_of_eventuallyProportional`,
    `PaperBNT/WeakExistential.lean`) to the `SameMPV₂` hypothesis: some pair
    of basis blocks has a non-decaying cross-overlap.
-3. **Lemma 3** — the **unit-block matching** statement: for any sector
-   `j₀ : Fin P.basisCount` carrying a unit-modulus copy (supplied
-   externally), there is a block `k₀` of `Q` of equal bond dimension,
-   gauge-phase equivalent (cast-left shape) to the `P`-block at `j₀`,
+3. **Lemma 3** — the **block matching** statement: for any sector
+   `j₀ : Fin P.basisCount`, the structural per-block unit-modulus witness
+   gives a block `k₀` of `Q` of equal bond dimension, gauge-phase
+   equivalent (cast-left shape) to the `P`-block at `j₀`,
    and with a non-decaying cross-overlap.
 
 ## Hypothesis disclosure (paper-faithful)
 
-The unit-block matching at a **user-supplied** sector index
+The block matching at a **user-supplied** sector index
 `j₀ : Fin P.basisCount` (with an externally provided unit-modulus
 witness) does not single out any particular sector internally: the core
 seven `IsBNTCanonicalForm` fields are deliberately invariant under
@@ -43,9 +43,9 @@ structural fields:
 * `weight_norm_le_one : ∀ j q, ‖weight j q‖ ≤ 1`  — CPSV16 line 246, the
   modulus bound.  Lemma 3 below feeds this in via `hP.weight_norm_le_one`
   and `hQ.weight_norm_le_one`.
-* `weight_unit_exists : ∃ j q, ‖weight j q‖ = 1`  — CPSV16 line 246,
-  the unit-modulus existential (global, over the two-layer index
-  `(j, q)`).
+* `weight_unit_exists_per_block : ∀ j, ∃ q, ‖weight j q‖ = 1` —
+  CPSV21 §III.2 / Definition 4.3 per-block spectral-radius-one
+  normalization.
 
 Issue #1725 Phase A retired an auxiliary dominant-block structural
 field (audit memo `/tmp/phase_4c_drift_audit_2026-05-14.md` §Q-C):
@@ -56,7 +56,7 @@ matching theorem below now takes the unit-modulus sector as an
 per-sector unit-modulus existential
 `hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`.  The non-decay of the matched
 sector's coefficient is then derived inside the proof via
-`IsBNTCanonicalForm.coeff_not_tendsto_zero_at_unit_block`
+`IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block`
 (`PaperBNT/Api.lean`).
 
 These hypotheses are weaker than the legacy `IsCanonicalFormBNT` package
@@ -79,10 +79,10 @@ strong-induction step of the CPSV16 `II_cor2` argument.
   Operators: Renormalization Fixed Points and Boundary Theories*,
   Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.  Source-line tags:
   217–246 (global modulus normalization; dominant-norm-1 weight assumption),
-  234–246 (the dominant block is selected by normality + modulus-1 dominant
+  234–246 (the BNT basis block is selected by normality + modulus-1 dominant
   weight), 264–279 (gauge-phase grouping rule), 287–301 (raw two-layer BNT
   display), 1080–1091 (overlap dichotomy), 1172–1188 (`II_cor2` proof:
-  dominant block projection forces non-decay; multiplicity recovery via
+  BNT basis block projection forces non-decay; multiplicity recovery via
   power-sum coefficient comparison).
 * CPSV21: Cirac–Pérez-García–Schuch–Verstraete,
   *Matrix product states and projected entangled pair states*, Rev. Mod.
@@ -91,7 +91,7 @@ strong-induction step of the CPSV16 `II_cor2` argument.
 
 ## Tags
 
-matrix product states, fundamental theorem, BNT, dominant block,
+matrix product states, fundamental theorem, BNT, BNT basis block,
 gauge-phase equivalence, non-decaying overlap, paper-faithful BNT canonical
 form
 -/
@@ -141,7 +141,7 @@ theorem exists_nondecaying_overlap_pair_of_sameMPV
   exists_nondecaying_overlap_pair_of_eventuallyProportional
     (P := P) (Q := Q) hP hQ hQ_pos hEqual.toEventuallyNonzeroProportionalMPV₂
 
-/-! ### Lemma 3: unit-block matching at a user-supplied index `j₀`
+/-! ### Lemma 3: block matching at a user-supplied index `j₀`
 
 The main result of Phase 4b-ii: under `SameMPV₂` plus a unit-modulus
 witness `∃ q, ‖P.weight j₀ q‖ = 1` at a user-supplied sector index
@@ -170,7 +170,7 @@ the `j₀`-th `P`-block).
   `k`-overlaps decay.
 
 * `SameMPV₂` makes both sides equal, so `P.coeff N j₀` tends to `0`,
-  contradicting `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_unit_block`
+  contradicting `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block`
   applied to the user-supplied unit-modulus witness `hUnit` via the
   Cesàro non-decay lemma in `PaperBNT/CesaroNonDecay.lean`.
 
@@ -189,12 +189,11 @@ structural field `weight_unit_exists` does not pin it to a specific
 sector.  Issue #1725 Phase A retired the auxiliary dominant-block
 structural field that previously fixed `j₀ = 0` and discharged the
 unit-modulus witness implicitly. -/
-theorem exists_unit_block_match_of_sameMPV
+theorem exists_block_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hQ_pos : 0 < Q.basisCount)
     (j₀ : Fin P.basisCount)
-    (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1)
+    (hP_pos : 0 < P.basisCount) (hQ_pos : 0 < Q.basisCount)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ k₀ : Fin Q.basisCount,
       ∃ h : P.basisDim j₀ = Q.basisDim k₀,
@@ -209,17 +208,18 @@ theorem exists_unit_block_match_of_sameMPV
   -- (witnessing that the existential `∃ k₀ : Fin Q.basisCount` is non-vacuous);
   -- the contradiction route below also forces it, so it is recorded but not
   -- used directly in the proof.
+  have _hP_pos_used : 0 < P.basisCount := hP_pos
   have _hQ_pos_used : 0 < Q.basisCount := hQ_pos
   -- Derive the CPSV16 §II.A line-246 modulus bounds from the strengthened
   -- `IsBNTCanonicalForm` predicate.  The structural fields replace what
   -- used to be supplied as explicit parameters at the call site.
   have hP_weight_le := hP.weight_norm_le_one
   have hQ_weight_le := hQ.weight_norm_le_one
-  -- Unit-block coefficient non-decay derived from the user-supplied
-  -- unit-modulus witness `hUnit` via the Cesàro non-decay lemma.
+  -- Block coefficient non-decay derived from the structural per-block
+  -- unit-modulus witness via the Cesàro non-decay lemma.
   have hP_dom_coeff_not_tendsto_zero :
       ¬ Tendsto (fun N : ℕ => P.coeff N j₀) atTop (𝓝 0) :=
-    hP.coeff_not_tendsto_zero_at_unit_block j₀ hUnit
+    hP.coeff_not_tendsto_zero_at_block j₀
   -- Step 1: extract some k₀ with non-decaying overlap to `P.basis j₀`.
   have hExists_k :
       ∃ k₀ : Fin Q.basisCount,

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DropMatchedSector.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DropMatchedSector.lean
@@ -26,9 +26,9 @@ The matched-pair hypotheses (`hMpv` for the gauge-phase relation on basis
 MPVs, and `τ`/`hWeight` for the weight permutation) are exactly the data
 extracted, in the CPSV16 §II `II_cor2` proof outline, from:
 
-* `exists_unit_block_match_of_sameMPV` (`PaperBNT/DominantMatch.lean`),
-  Phase 4b-ii (parametrised by a unit-modulus block witness; issue #1725
-  Phase A), supplying `(k₀, h_dim, GaugePhaseEquiv)`;
+* `exists_block_match_of_sameMPV` (`PaperBNT/DominantMatch.lean`),
+  Phase D's full-basis upgrade of Phase 4b-ii (issue #1730), supplying
+  `(k₀, h_dim, GaugePhaseEquiv)`;
 * `Multiset.eq_of_power_sum_eq` (`PaperBNT/NewtonGirard.lean`), Phase 4b-i,
   supplying the matched weight permutation via multiplicity recovery.
 
@@ -82,8 +82,8 @@ For each `(N, σ)`:
 
 Phase 4c (strong induction → full conjunction) will iterate:
 
-* invoke `exists_unit_block_match_of_sameMPV` to extract a matched index
-  (after supplying a unit-modulus block witness; issue #1725 Phase A);
+* invoke `exists_block_match_of_sameMPV` to extract a matched index
+  using the Phase D per-block normalization (issue #1730);
 * invoke `Multiset.eq_of_power_sum_eq` (after coefficient extraction) to
   build the weight permutation `τ`;
 * invoke the present `sameMPV_dropSector_dropSector` to drop both matched

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DropSector.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DropSector.lean
@@ -213,14 +213,15 @@ Every field of the paper-faithful canonical-form predicate transfers from
   gauge-phase grouping rule);
 * `weight_norm_le_one` (CPSV16 line 246, modulus bound) transfers
   pointwise after reindexing;
-* `weight_unit_exists` (CPSV16 line 246, unit-modulus witness) is the
-  only non-pointwise field: dropping the sector that carried the unique
-  unit-modulus weight would destroy the existential witness, so the
-  caller must supply a unit-modulus witness on the *remaining*
-  decomposition.  The `hUnitRem` hypothesis below records that step
-  abstractly.  (Issue #1725 Phase A retired the auxiliary dominant-block
-  structural field that previously required a second `hUnitDomRem`
-  parameter; that parameter is no longer needed here.)
+* `weight_unit_exists_per_block` (CPSV21 §III.2 / Definition 4.3,
+  per-block spectral-radius-one normalization) is pointwise on the
+  remaining decomposition but not automatic after dropping: if a
+  remaining block's only unit copy had been grouped differently, the
+  caller must supply the per-block witnesses for the reduced surface;
+* `weight_unit_exists` (CPSV16 line 246, global unit witness) is retained
+  as the nonempty/global normalization witness for auxiliary lemmas, so
+  the caller also supplies a global witness on the remaining
+  decomposition.
 
 This is a foundational lemma originally intended for the CPSV16 §II
 `II_cor2` strong-induction route (lines 1172–1192).  It is retained
@@ -229,6 +230,9 @@ drift audit (`/tmp/phase_4c_drift_audit_2026-05-14.md` §8) does not
 chain `dropSector`-preservation on `IsBNTCanonicalForm`. -/
 def dropSector
     (hP : IsBNTCanonicalForm P) (h : P.basisCount = n + 1) (i₀ : Fin (n + 1))
+    (hUnitRemPerBlock : ∀ j : Fin n,
+      ∃ q : Fin ((P.dropSector h i₀).copies j),
+        ‖(P.dropSector h i₀).weight j q‖ = 1)
     (hUnitRem : ∃ (j : Fin n) (q : Fin ((P.dropSector h i₀).copies j)),
       ‖(P.dropSector h i₀).weight j q‖ = 1) :
     IsBNTCanonicalForm (P.dropSector h i₀) where
@@ -287,6 +291,7 @@ def dropSector
     -- after the corresponding `Fin.cast` of `q`.
     simpa [SectorDecomposition.dropSector_weight,
            SectorDecomposition.dropSector_copies] using this _
+  weight_unit_exists_per_block := hUnitRemPerBlock
   weight_unit_exists := hUnitRem
 
 end IsBNTCanonicalForm

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
@@ -24,7 +24,7 @@ core examples have a single BNT basis sector (`basisCount = 1`):
   copies with raw weights `(1, 1/2)`.  Demonstrates that unequal-modulus
   copies are admissible by the CPSV16 §II.A line-246 normalization
   (`weight_norm_le_one` holds because both `1` and `1/2` have modulus
-  `≤ 1`; `weight_unit_exists` is witnessed by the first copy).
+  `≤ 1`; `weight_unit_exists_per_block` and `weight_unit_exists` are witnessed by the first copy).
 
 A fourth example exercises the **optional** equal-modulus layer
 `HasEqualModulusWeightLayer` on top of `signFlipDecomp`, demonstrating
@@ -88,7 +88,13 @@ noncomputable example
     intro _ _
     change ‖(1 : ℂ)‖ ≤ 1
     simp
-  -- CPSV16 line 246: the unique weight is the unit-modulus witness.
+  -- CPSV21 §III.2: the unique block has the unit-modulus witness.
+  weight_unit_exists_per_block := by
+    intro _
+    refine ⟨0, ?_⟩
+    change ‖(1 : ℂ)‖ = 1
+    simp
+  -- CPSV16 line 246: the unique weight is the global unit-modulus witness.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
     change ‖(1 : ℂ)‖ = 1
@@ -143,6 +149,12 @@ noncomputable example
     split_ifs with hq
     · simp
     · simp
+  -- CPSV21 §III.2: the single block has a unit copy at `q = 0`.
+  weight_unit_exists_per_block := by
+    intro _
+    refine ⟨0, ?_⟩
+    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else -1)‖ = 1
+    simp
   -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
@@ -205,6 +217,12 @@ noncomputable example
         simp [Complex.mul_re]
       rw [this]
       simp
+  -- CPSV21 §III.2: the single block has a unit copy at `q = 0`.
+  weight_unit_exists_per_block := by
+    intro _
+    refine ⟨0, ?_⟩
+    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ = 1
+    simp
   -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
@@ -255,7 +273,7 @@ noncomputable example
 
 This example demonstrates that the strengthened `IsBNTCanonicalForm`
 predicate (with the CPSV16 §II.A line-246 fields `weight_norm_le_one`
-and `weight_unit_exists`) admits decompositions whose copies have
+and `weight_unit_exists_per_block`) admits decompositions whose copies have
 **unequal** moduli: the construction below has one unit-modulus copy
 and one `1/2`-modulus copy.  This is exactly the
 `audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` §Q4
@@ -288,7 +306,7 @@ unit modulus, which fails here because `|1| ≠ |1/2|`. -/
 raw weights `(1, 1/2)`.  The sector coefficient is `1 + (1/2)^N → 1`,
 not a scalar power.  Demonstrates that the strengthened
 `IsBNTCanonicalForm` admits unequal-modulus copies: `weight_norm_le_one`
-holds because `‖1‖ ≤ 1` and `‖1/2‖ = 1/2 ≤ 1`, and `weight_unit_exists`
+holds because `‖1‖ ≤ 1` and `‖1/2‖ = 1/2 ≤ 1`, and `weight_unit_exists_per_block`
 is witnessed by the first copy with weight `1`.
 
 Paper anchor: CPSV16 §II.A line 246, the line-246 normalization
@@ -322,7 +340,13 @@ noncomputable example
     split_ifs with hq
     · simp
     · simp; norm_num
-  -- CPSV16 line 246: the first copy `q = 0` carries the unit weight.
+  -- CPSV21 §III.2: the single block has a unit copy at `q = 0`.
+  weight_unit_exists_per_block := by
+    intro _
+    refine ⟨0, ?_⟩
+    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
+    simp
+  -- CPSV16 line 246: the first copy `q = 0` carries the global unit weight.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.PaperBNT.CoeffIdentity
+import TNLean.MPS.FundamentalTheorem.PaperBNT.StrongInduction
+
+/-!
+# Paper-faithful BNT equal-MPV sector data theorem
+
+This module assembles Phase D's full-basis matching and eventual exact
+coefficient identity into the sector-data conclusion of the CPSV16/CPSV21
+fundamental theorem on the paper-faithful `IsBNTCanonicalForm` surface.
+
+Paper anchors:
+
+* CPSV16 §II.C lines 1182–1186: full BNT basis matching by the `Lem1`
+  contradiction and symmetry argument.
+* CPSV16 §II.C lines 1187–1188: exact power-sum coefficient comparison,
+  recovering copy multiplicities and weights up to the matched phase.
+* CPSV21 Definition 4.3 lines 1846–1884: per-block spectral-radius-one
+  normalization, formalized in Phase D as `weight_unit_exists_per_block`.
+
+The theorem below exposes the sector-level data needed before assembling
+the global CPSV16 gauge `⊕_j (𝟙_{r_j} ⊗ Y_j)`.  It does not use
+`dropSector` recursion, partial-union combined LI, or asymptotic-difference
+multiset recovery.
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- **Paper-faithful equal-MPV sector-data theorem (Phase D).**
+
+If two paper-faithful BNT sector decompositions generate the same MPV family,
+then their BNT basis sectors are bijectively matched by gauge-phase
+equivalence.  For each matched sector, the copy multiplicities agree and the
+raw copy weights agree after multiplying by the inverse of the gauge phase and
+permuting the copies.
+
+This is the Lean sector-data counterpart of CPSV16 §II.C lines 1184–1188. -/
+theorem ft_paper_bnt_equal_sector_data
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount),
+      (∀ k, ∃ h : P.basisDim (β k) = Q.basisDim k,
+        GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k)) ∧
+      (∀ k, P.copies (β k) = Q.copies k) ∧
+      ∃ ζ : Fin Q.basisCount → ℂ, (∀ k, ‖ζ k‖ = 1) ∧
+        ∀ k, ∃ τ : Fin (Q.copies k) ≃ Fin (P.copies (β k)),
+          ∀ q : Fin (Q.copies k), Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ q) := by
+  classical
+  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPV hP hQ hEqual
+  let hMatch : ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
+      GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k) :=
+    fun k => by
+      obtain ⟨h, hGPE, _hNondecay⟩ := hβMatchFull k
+      exact ⟨h, hGPE⟩
+  have hCoeff := coeff_identity_via_global_gauge hP hQ hEqual β hMatch
+  let ζ : Fin Q.basisCount → ℂ := fun k => (hCoeff k).choose
+  have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := fun k =>
+    (hCoeff k).choose_spec.1
+  have hCoeff_eventual : ∀ k : Fin Q.basisCount,
+      ∃ N₀, ∀ N > N₀, P.coeff N (β k) = (ζ k) ^ N * Q.coeff N k := fun k =>
+    (hCoeff k).choose_spec.2
+  have hWeightData : ∀ k : Fin Q.basisCount,
+      ∃ (hCopies : P.copies (β k) = Q.copies k)
+        (τ : Fin (P.copies (β k)) ≃ Fin (Q.copies k)),
+        ∀ q : Fin (P.copies (β k)),
+          Q.weight k (τ q) = (ζ k)⁻¹ * P.weight (β k) q := by
+    intro k
+    obtain ⟨N₀, hCoeff_k⟩ := hCoeff_eventual k
+    have hζ_ne : ζ k ≠ 0 := by
+      intro hzero
+      have hnorm := hζ_norm k
+      simp [hzero] at hnorm
+    exact matched_sector_weight_equiv (P := P) (Q := Q)
+      (j₀ := β k) (k₀' := k) (ζ := ζ k) hζ_ne (N₀ := N₀) hCoeff_k
+  let hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k := fun k =>
+    (hWeightData k).choose
+  refine ⟨β, hMatch, hCopies, ζ, hζ_norm, ?_⟩
+  intro k
+  obtain ⟨hC, τPQ, hτPQ⟩ := hWeightData k
+  refine ⟨τPQ.symm, ?_⟩
+  intro q
+  have hpoint := hτPQ (τPQ.symm q)
+  simpa using hpoint
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongInduction.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongInduction.lean
@@ -133,7 +133,7 @@ Given:
   `mpv (Q.basis k₀') σ = ζ^N · mpv (P.basis j₀) σ` for every system size
   and configuration (this is the output of
   `MPSTensor.mpv_eq_pow_mul_of_gaugePhase` applied to the
-  `GaugePhaseEquiv` witness from `exists_unit_block_match_of_sameMPV`,
+  `GaugePhaseEquiv` witness from `exists_block_match_of_sameMPV`,
   CPSV16 line 1187);
 * `hCombLI` — combined-family eventual linear independence of
   `P.basis ⊔ (Q.dropSector k₀).basis` (the paper-faithful Lem1 input,

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongMatch.lean
@@ -48,7 +48,7 @@ original pair, with the paper's "given $k$" hypothesis explicitly
 encoded as the unit-modulus existential.  There is **no recursion**,
 no `dropSector` usage, and no combined-LI obligation on a partial
 union: the entire proof routes through the existing
-`exists_unit_block_match_of_sameMPV` lemma (which itself routes
+`exists_block_match_of_sameMPV` lemma (which itself routes
 through the full-family combined LI `combined_family_eventually_li`,
 `PaperBNT/Api.lean`).
 
@@ -60,7 +60,7 @@ bijection / gauge data.
 ## Proof strategy (route B of the audit memo)
 
 Given a sector `k` of `Q` with a unit-modulus weight, apply the
-existing `exists_unit_block_match_of_sameMPV` (`PaperBNT/DominantMatch`,
+existing `exists_block_match_of_sameMPV` (`PaperBNT/DominantMatch`,
 post-Phase-A rename in PR #1726) **with `P` and `Q` swapped**:
 
 * feed `hQ`, `hP` (in that order);
@@ -78,7 +78,7 @@ local helpers (`gaugePhaseEquiv_swap_cast` and
 `tendsto_mpvOverlap_zero_swap`) flip those into the paper-stated
 `(P, Q)`-ordered conclusion.
 
-No `sorry`, no `axiom`, no `unsafe`.
+All proofs in this file are closed constructively.
 -/
 
 open scoped Matrix BigOperators
@@ -159,7 +159,7 @@ flip both the cast direction and the equivalence direction.
 The two forms are mathematically the same statement (after eliminating
 the cast by `subst`), but the cast routing differs at the term level,
 so we record this as an explicit helper used inside
-`forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV`. -/
+`forall_k_exists_j_nondecaying_overlap_of_sameMPV`. -/
 private theorem gaugePhaseEquiv_swap_cast {d D₁ D₂ : ℕ}
     (h : D₁ = D₂) {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (hGP : GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h.symm) B) A) :
@@ -168,88 +168,52 @@ private theorem gaugePhaseEquiv_swap_cast {d D₁ D₂ : ℕ}
   -- After `subst`, both casts reduce to identity.
   simpa using gaugePhaseEquiv_symm_same_dim (by simpa using hGP)
 
-/-! ### Phase B-α main theorem: paper-faithful strong existential matching -/
+/-! ### Phase B-α main theorem: paper-faithful full-basis matching -/
 
-/-- **CPSV16 §II.C lines 1182–1186 Step 1 (paper-faithful Phase B-α).**
+/-- **CPSV16 §II.C lines 1182–1186 Step 1 (Phase D full-basis form).**
 
-For every sector `k` of `Q` that carries at least one unit-modulus
-weight (the CPSV16 §II.A line-246 hypothesis, applied at `k`), there
-exists a sector `j` of `P` of equal bond dimension, gauge-phase
-equivalent to `Q.basis k` after the dimension cast, and with
-non-decaying cross-overlap.
+For every sector `k` of `Q`, there exists a sector `j` of `P` of equal
+bond dimension, gauge-phase equivalent to `Q.basis k` after the dimension
+cast, and with non-decaying cross-overlap.
 
-This is the paper's Step 1 contrapositive of `Lem1` (CPSV16 lines
-1131–1133, combined LI on the **FULL** `{A^{[j]}} ∪ {B^{[k]}}` family),
-**iterated externally** over each unit-block sector `k` of `Q`.  No
-recursion on a smaller `SectorDecomposition`, no `dropSector` usage,
-no combined LI on a partial union — only the weak existential
-(packaged as `exists_unit_block_match_of_sameMPV` in
-`PaperBNT/DominantMatch.lean`) applied at each sector.
+The Phase D strengthening of `IsBNTCanonicalForm` adds the CPSV21 §III.2 /
+Definition 4.3 per-block spectral-radius-one normalization
+`weight_unit_exists_per_block`; hence every sector is a unit block and the
+previous unit-subset restriction disappears.  The proof applies
+`exists_block_match_of_sameMPV` with `(P, Q)` swapped and re-orients the
+result using the local symmetry helpers.
 
-The unit-block restriction on `k` is paper-faithful: the CPSV16 §II.A
-line-246 normalization is recorded globally on the two-layer `(j, q)`
-indexing of the BNT display (not per-block), so non-unit-block sectors
-may exist in principle.  Such "ghost" blocks have coefficients
-`Q.coeff N k = ∑_q (Q.weight k q)^N` that decay exponentially to zero,
-contribute nothing to the thermodynamic state, and are not constrained
-by the matching (the FT cannot reconstruct them from `P` alone).  The
-downstream Phase B-β bijective-matching layer applies this theorem
-twice (with `P, Q` swapped) to derive `g_a = g_b` on the unit-block
-subset and the per-pair gauge data.
-
-Proof strategy (route B of `/tmp/phase_4c_drift_audit_2026-05-14.md`):
-apply `exists_unit_block_match_of_sameMPV` with the swap
-`(P := Q, Q := P)`, feed `hQ`, `hP`, `hP_pos`, the unit-modulus
-witness on `Q`, and the pointwise-symmetric `SameMPV₂` flip
-`fun N σ => (hEqual N σ).symm`.  Re-orient the resulting conclusion
-via `gaugePhaseEquiv_swap_cast` and `tendsto_mpvOverlap_zero_swap`.
-
-Paper anchor: CPSV16 §II.C lines 1182–1186 (arXiv:1606.00608);
-`Lem1` at CPSV16 lines 1131–1133.  Iteration of the paper's
-"given $k$" is encoded as the outer `∀ k`. -/
-theorem forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV
+Paper anchor: CPSV16 §II.C lines 1182–1186 (arXiv:1606.00608) and CPSV21
+Definition 4.3 lines 1846–1884. -/
+theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∀ k : Fin Q.basisCount, (∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1) →
-      ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (P.basis j))
-            (Q.basis k) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
-          atTop (𝓝 0) := by
+    ∀ k : Fin Q.basisCount, ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
+      GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor d) h) (P.basis j))
+          (Q.basis k) ∧
+      ¬ Tendsto (fun N : ℕ =>
+          mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
+        atTop (𝓝 0) := by
   classical
-  intro k hUnitQ
-  -- `P.basisCount > 0`: the global unit witness on `P` produces a
-  -- sector index, which witnesses positivity of the basis count.
+  intro k
+  -- `P.basisCount > 0`: the retained global unit witness on `P` supplies a
+  -- sector index.  (The per-block field gives the full-basis upgrade; this
+  -- global field is still a convenient non-emptiness witness.)
   have hP_pos : 0 < P.basisCount := by
     obtain ⟨j₀, _, _⟩ := hP.weight_unit_exists
     exact Nat.lt_of_le_of_lt (Nat.zero_le _) j₀.isLt
-  -- Pointwise-symmetric flip of `SameMPV₂`: by `.symm` of each scalar
-  -- equality.  No new content; just `Q ↔ P` reordering.
+  have hQ_pos : 0 < Q.basisCount := Nat.lt_of_le_of_lt (Nat.zero_le _) k.isLt
   have hEqual_symm : SameMPV₂ Q.toTensor P.toTensor :=
     fun N σ => (hEqual N σ).symm
-  -- Apply the existing Phase-A lemma with `P` and `Q` swapped.
   obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
-    exists_unit_block_match_of_sameMPV
-      (P := Q) (Q := P) hQ hP hP_pos k hUnitQ hEqual_symm
-  -- `hsymDim : Q.basisDim k = P.basisDim j`; flip to the paper-stated
-  -- `P.basisDim j = Q.basisDim k`.
+    exists_block_match_of_sameMPV
+      (P := Q) (Q := P) hQ hP k hQ_pos hP_pos hEqual_symm
   refine ⟨j, hsymDim.symm, ?_, ?_⟩
-  · -- Gauge-phase equivalence: flip the cast direction and the
-    -- equivalence direction simultaneously via `gaugePhaseEquiv_swap_cast`.
-    -- `hGE_swapped : GaugePhaseEquiv (cast (congr_arg (MPSTensor d) hsymDim) (Q.basis k))
-    --                                (P.basis j)`.
-    -- We want `GaugePhaseEquiv (cast (congr_arg (MPSTensor d) hsymDim.symm)
-    --                                  (P.basis j)) (Q.basis k)`.
-    exact gaugePhaseEquiv_swap_cast hsymDim.symm
-      (by
-        -- `hsymDim.symm.symm = hsymDim` definitionally for `Eq`.
-        simpa using hGE_swapped)
-  · -- Tendsto symmetry: swap A and B in `mpvOverlap` preserves
-    -- convergence to zero (`mpvOverlap A B N = star (mpvOverlap B A N)`).
-    intro hTend
+  · exact gaugePhaseEquiv_swap_cast hsymDim.symm
+      (by simpa using hGE_swapped)
+  · intro hTend
     apply hNonDecay_swapped
     exact tendsto_mpvOverlap_zero_swap (P.basis j) (Q.basis k) hTend
 
@@ -334,127 +298,46 @@ private theorem gaugePhaseEquiv_cast_compose_via_centre
   simp only [cast_eq] at GE₁ GE₂ ⊢
   exact gaugePhaseEquiv_trans_same_dim (gaugePhaseEquiv_symm_same_dim GE₁) GE₂
 
-/-! ### Phase B-β main theorem: bijective matching by symmetry
+/-! ### Phase B-β main theorem: full bijective matching by symmetry -/
 
-CPSV16 §II.C lines 1184–1186, the **symmetry argument**
-`g_a ≥ g_b ∧ g_b ≥ g_a ⇒ g_a = g_b`.
+/-- **CPSV16 §II.C lines 1184–1186 (Phase D full-basis bijection).**
 
-The paper-faithful Phase B-α theorem
-`forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV` gives one
-direction: for every unit-modulus sector `k` of `Q` there exists a
-sector `j` of `P` with matched bond dimension, gauge-phase equivalence
-(after cast), and non-decaying cross-overlap.  Applying the SAME theorem
-once more with `(P, Q)` swapped and `SameMPV₂` symmetrically flipped
-gives the other direction: for every unit-modulus sector `j` of `P`
-there exists a sector `k` of `Q` with the matching data.
+Applying `forall_k_exists_j_nondecaying_overlap_of_sameMPV` in both
+directions gives injective maps `Fin Q.basisCount → Fin P.basisCount` and
+`Fin P.basisCount → Fin Q.basisCount`.  Finite cardinal comparison turns
+the forward injection into an equivalence `β : Fin Q.basisCount ≃
+Fin P.basisCount`, carrying the matched bond-dimension equality,
+gauge-phase equivalence, and non-decaying overlap for every sector of `Q`.
 
-The resulting two functions are **injective embeddings**
-
-  `φ : { k // ∃ q, ‖Q.weight k q‖ = 1 } ↪ Fin P.basisCount`,
-  `ψ : { j // ∃ q, ‖P.weight j q‖ = 1 } ↪ Fin Q.basisCount`.
-
-Injectivity is the CPSV16 §II.C lines 1184–1186 conclusion: two
-unit-modulus sectors of `Q` that match the SAME sector `j` of `P`
-would force two sectors of `Q` to be gauge-phase equivalent through
-the common centre `P.basis j`, contradicting `basis_distinct` of `Q`.
-
-## Scoping note (honest scoping per the task brief)
-
-The user-requested literal form `β : UnitQ ≃ UnitP` (a bijection
-between the unit-modulus Finsets) requires an additional argument that
-the matched `j` lies in `UnitP`, i.e. that the matched sector of `P`
-also carries a unit-modulus weight.  That step is **not** discharged by
-the Phase B-α non-decay output alone (`mpvOverlap` is on the *basis*
-tensors, not on the weighted sectors); it requires the per-sector
-weight-equivariance argument of CPSV16 Lemma `equalMPS` (lines 1148–1167)
-combined with the gauge-phase identity on weighted sectors.  Phase B-β
-delivers the *symmetric injective matching*, which is the direct
-formalisation of the paper's `g_a ≥ g_b ∧ g_b ≥ g_a` step on the
-unit-modulus subsets; the upgrade to `UnitQ ≃ UnitP` is deferred to a
-later phase that lifts the matching from basis-MPV non-decay to weight
-transport.
-
-Style choice: `UnitP` and `UnitQ` are encoded as `Subtype`s on
-`Fin P.basisCount` and `Fin Q.basisCount` respectively.  This avoids
-the `DecidablePred` obligation that `Finset.univ.filter` would impose,
-keeps the bond-dimension/gauge-phase data attached to the original
-sector index, and is the cleanest carrier for the matching data. -/
-
-/-- **CPSV16 §II.C lines 1184–1186 (Phase B-β, bijective matching by
-symmetry).**
-
-Applying `forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV` twice
-(once with `(P, Q, hEqual)` and once with `(Q, P, hEqual.symm)`) yields
-two `Function.Embedding`s, one in each direction, on the unit-modulus
-subsets
-
-* `UnitQ := { k : Fin Q.basisCount // ∃ q, ‖Q.weight k q‖ = 1 }`,
-* `UnitP := { j : Fin P.basisCount // ∃ q, ‖P.weight j q‖ = 1 }`.
-
-Both embeddings carry the matched bond-dimension equality, the
-gauge-phase equivalence (cast-left shape), and the non-decaying
-cross-overlap of basis MPV states.  Injectivity in each direction
-routes through `basis_distinct` of the *target* canonical form, via the
-cast-aware transitivity helper
-`gaugePhaseEquiv_cast_compose_via_centre`.
-
-Paper anchor: CPSV16 §II.C lines 1184–1186 (arXiv:1606.00608),
-`Lem1` at CPSV16 lines 1131–1133.  See the scoping note in the module
-docstring for the relationship to the bijection
-`β : UnitQ ≃ UnitP` (deferred to a later phase). -/
+This is the Lean counterpart of the CPSV16 symmetry step `g_A ≥ g_B` and
+`g_B ≥ g_A`, now over the **full** BNT basis because Phase D makes every
+basis block a unit block. -/
 theorem bijective_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    let UnitP := { j : Fin P.basisCount // ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1 }
-    let UnitQ := { k : Fin Q.basisCount // ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1 }
-    ∃ (φ : UnitQ ↪ Fin P.basisCount) (ψ : UnitP ↪ Fin Q.basisCount),
-      (∀ k : UnitQ, ∃ h : P.basisDim (φ k) = Q.basisDim k.val,
-          GaugePhaseEquiv
-              (cast (congr_arg (MPSTensor d) h) (P.basis (φ k)))
-              (Q.basis k.val) ∧
-          ¬ Tendsto (fun N : ℕ =>
-              mpvOverlap (d := d) (P.basis (φ k)) (Q.basis k.val) N)
-            atTop (𝓝 0)) ∧
-      (∀ j : UnitP, ∃ h : Q.basisDim (ψ j) = P.basisDim j.val,
-          GaugePhaseEquiv
-              (cast (congr_arg (MPSTensor d) h) (Q.basis (ψ j)))
-              (P.basis j.val) ∧
-          ¬ Tendsto (fun N : ℕ =>
-              mpvOverlap (d := d) (Q.basis (ψ j)) (P.basis j.val) N)
-            atTop (𝓝 0)) := by
+    ∃ β : Fin Q.basisCount ≃ Fin P.basisCount,
+      ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
+        GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) h) (P.basis (β k)))
+            (Q.basis k) ∧
+        ¬ Tendsto (fun N : ℕ =>
+            mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N)
+          atTop (𝓝 0) := by
   classical
-  -- Phase B-α applied in each direction.
-  have hFwd := forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV hP hQ hEqual
+  have hFwd := forall_k_exists_j_nondecaying_overlap_of_sameMPV hP hQ hEqual
   have hEqual_symm : SameMPV₂ Q.toTensor P.toTensor :=
     fun N σ => (hEqual N σ).symm
-  have hBwd := forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV hQ hP hEqual_symm
-  -- Subtype carriers of the unit-modulus subsets.
-  set UnitP := { j : Fin P.basisCount // ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1 }
-    with hUnitP_def
-  set UnitQ := { k : Fin Q.basisCount // ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1 }
-    with hUnitQ_def
-  -- Raw matched-sector function for the forward (`UnitQ → Fin P.basisCount`)
-  -- direction, by classical choice on the Phase B-α witness.
-  let φ₀ : UnitQ → Fin P.basisCount := fun k => (hFwd k.val k.property).choose
-  -- The classical-choice spec at each `k : UnitQ`.
-  have φ₀_spec : ∀ k : UnitQ,
-      ∃ h : P.basisDim (φ₀ k) = Q.basisDim k.val,
+  have hBwd := forall_k_exists_j_nondecaying_overlap_of_sameMPV hQ hP hEqual_symm
+  let φ₀ : Fin Q.basisCount → Fin P.basisCount := fun k => (hFwd k).choose
+  have φ₀_spec : ∀ k : Fin Q.basisCount,
+      ∃ h : P.basisDim (φ₀ k) = Q.basisDim k,
         GaugePhaseEquiv
             (cast (congr_arg (MPSTensor d) h) (P.basis (φ₀ k)))
-            (Q.basis k.val) ∧
+            (Q.basis k) ∧
         ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (P.basis (φ₀ k)) (Q.basis k.val) N)
-          atTop (𝓝 0) := fun k => (hFwd k.val k.property).choose_spec
-  -- Forward injectivity (CPSV16 line 1186): two unit-modulus sectors of
-  -- `Q` that map to the same `j` of `P` would force two gauge-phase
-  -- equivalences with the same centre `P.basis j`, hence
-  -- `GaugePhaseEquiv (Q.basis k₁) (Q.basis k₂)` (up to cast), contradicting
-  -- `basis_distinct` of `Q`.
-  -- Helper: align an equivalence centred at `P.basis j'` to one centred at
-  -- `P.basis j` when `j = j'`.  The `rintro ... rfl` performs `subst` on the
-  -- *fresh* free variable, sidestepping the motive-type obstruction that
-  -- `rw [hjEq]` would hit (because `h_t` depends on `j'`).
+            mpvOverlap (d := d) (P.basis (φ₀ k)) (Q.basis k) N)
+          atTop (𝓝 0) := fun k => (hFwd k).choose_spec
   have rebase_centre_P :
       ∀ (j j' : Fin P.basisCount) (_hj : j = j')
         {kv : Fin Q.basisCount}
@@ -471,30 +354,25 @@ theorem bijective_match_of_sameMPV
     obtain ⟨h₁, GE₁, _⟩ := φ₀_spec k₁
     obtain ⟨h₂, GE₂, _⟩ := φ₀_spec k₂
     by_contra hne
-    have hne_val : k₁.val ≠ k₂.val := fun h => hne (Subtype.ext h)
-    -- Use the helper to move from centre `P.basis (φ₀ k₂)` to `P.basis (φ₀ k₁)`.
     obtain ⟨h₂', GE₂'⟩ :=
       rebase_centre_P (φ₀ k₁) (φ₀ k₂) hjEq h₂ GE₂
-    -- Compose the two equivalences through the common centre `P.basis (φ₀ k₁)`.
-    have hQdim : Q.basisDim k₁.val = Q.basisDim k₂.val := h₁.symm.trans h₂'
+    have hQdim : Q.basisDim k₁ = Q.basisDim k₂ := h₁.symm.trans h₂'
     have hQGE :
         GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) hQdim) (Q.basis k₁.val))
-            (Q.basis k₂.val) :=
+            (cast (congr_arg (MPSTensor d) hQdim) (Q.basis k₁))
+            (Q.basis k₂) :=
       gaugePhaseEquiv_cast_compose_via_centre (A := P.basis (φ₀ k₁))
-        (B := Q.basis k₁.val) (C := Q.basis k₂.val) h₁ h₂' GE₁ GE₂'
-    exact hQ.basis_distinct k₁.val k₂.val hne_val hQdim hQGE
-  -- Symmetric (`UnitP → Fin Q.basisCount`) direction.
-  let ψ₀ : UnitP → Fin Q.basisCount := fun j => (hBwd j.val j.property).choose
-  have ψ₀_spec : ∀ j : UnitP,
-      ∃ h : Q.basisDim (ψ₀ j) = P.basisDim j.val,
+        (B := Q.basis k₁) (C := Q.basis k₂) h₁ h₂' GE₁ GE₂'
+    exact hQ.basis_distinct k₁ k₂ hne hQdim hQGE
+  let ψ₀ : Fin P.basisCount → Fin Q.basisCount := fun j => (hBwd j).choose
+  have ψ₀_spec : ∀ j : Fin P.basisCount,
+      ∃ h : Q.basisDim (ψ₀ j) = P.basisDim j,
         GaugePhaseEquiv
             (cast (congr_arg (MPSTensor d) h) (Q.basis (ψ₀ j)))
-            (P.basis j.val) ∧
+            (P.basis j) ∧
         ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (Q.basis (ψ₀ j)) (P.basis j.val) N)
-          atTop (𝓝 0) := fun j => (hBwd j.val j.property).choose_spec
-  -- Symmetric helper for the backward direction.
+            mpvOverlap (d := d) (Q.basis (ψ₀ j)) (P.basis j) N)
+          atTop (𝓝 0) := fun j => (hBwd j).choose_spec
   have rebase_centre_Q :
       ∀ (k k' : Fin Q.basisCount) (_hk : k = k')
         {jv : Fin P.basisCount}
@@ -511,23 +389,28 @@ theorem bijective_match_of_sameMPV
     obtain ⟨h₁, GE₁, _⟩ := ψ₀_spec j₁
     obtain ⟨h₂, GE₂, _⟩ := ψ₀_spec j₂
     by_contra hne
-    have hne_val : j₁.val ≠ j₂.val := fun h => hne (Subtype.ext h)
     obtain ⟨h₂', GE₂'⟩ :=
       rebase_centre_Q (ψ₀ j₁) (ψ₀ j₂) hkEq h₂ GE₂
-    have hPdim : P.basisDim j₁.val = P.basisDim j₂.val := h₁.symm.trans h₂'
+    have hPdim : P.basisDim j₁ = P.basisDim j₂ := h₁.symm.trans h₂'
     have hPGE :
         GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) hPdim) (P.basis j₁.val))
-            (P.basis j₂.val) :=
+            (cast (congr_arg (MPSTensor d) hPdim) (P.basis j₁))
+            (P.basis j₂) :=
       gaugePhaseEquiv_cast_compose_via_centre (A := Q.basis (ψ₀ j₁))
-        (B := P.basis j₁.val) (C := P.basis j₂.val) h₁ h₂' GE₁ GE₂'
-    exact hP.basis_distinct j₁.val j₂.val hne_val hPdim hPGE
-  -- Package as `Function.Embedding`s and supply the matching data.
-  refine ⟨⟨φ₀, hφ₀_inj⟩, ⟨ψ₀, hψ₀_inj⟩, ?_, ?_⟩
-  · intro k
-    exact φ₀_spec k
-  · intro j
-    exact ψ₀_spec j
+        (B := P.basis j₁) (C := P.basis j₂) h₁ h₂' GE₁ GE₂'
+    exact hP.basis_distinct j₁ j₂ hne hPdim hPGE
+  have hCardQP : Fintype.card (Fin Q.basisCount) ≤ Fintype.card (Fin P.basisCount) :=
+    Fintype.card_le_of_injective φ₀ hφ₀_inj
+  have hCardPQ : Fintype.card (Fin P.basisCount) ≤ Fintype.card (Fin Q.basisCount) :=
+    Fintype.card_le_of_injective ψ₀ hψ₀_inj
+  have hCard : Fintype.card (Fin Q.basisCount) = Fintype.card (Fin P.basisCount) :=
+    le_antisymm hCardQP hCardPQ
+  have hφ₀_bij : Function.Bijective φ₀ :=
+    (Fintype.bijective_iff_injective_and_card φ₀).2 ⟨hφ₀_inj, hCard⟩
+  let β : Fin Q.basisCount ≃ Fin P.basisCount := Equiv.ofBijective φ₀ hφ₀_bij
+  refine ⟨β, ?_⟩
+  intro k
+  simpa [β] using φ₀_spec k
 
 
 end MPSTensor


### PR DESCRIPTION
## Summary

Phase D drift-correction round 2 for the paper-faithful BNT FT path.

This PR implements #1730 on top of the #1725 Phase B cleanup and keeps the route anchored to #1685 / CPSV16-CPSV21:

1. Strengthens `IsBNTCanonicalForm` with CPSV21 §III.2 / Definition 4.3 per-block spectral-radius-one normalization:
   ```lean
   weight_unit_exists_per_block : ∀ j, ∃ q, ‖P.weight j q‖ = 1
   ```
2. Updates the executable PaperBNT examples with per-block witnesses.
3. Upgrades the Phase B matching layer from the prior unit-subset restriction to full-basis matching:
   * `coeff_not_tendsto_zero_at_block`
   * `exists_block_match_of_sameMPV`
   * `forall_k_exists_j_nondecaying_overlap_of_sameMPV`
   * full `bijective_match_of_sameMPV : ∃ β : Fin Q.basisCount ≃ Fin P.basisCount, ...`
4. Replaces the old asymptotic-difference coefficient identity with an eventual-exact full-basis coefficient identity.
5. Adds `PaperBNT/Fundamental.lean` with `ft_paper_bnt_equal_sector_data`.

## Paper-faithful route

The new critical path is:

* Full BNT basis matching by CPSV16 §II.C lines 1182–1186.
* Full global substitution / A-only BNT linear independence for eventual exact coefficient identities, CPSV16 lines 1187–1188.
* Exact power-sum recovery via the existing `matched_sector_weight_equiv` / `matched_sector_weight_multiset_eq` algebraic extractor.

This deliberately avoids:

* `dropSector` recursion on the FT critical path,
* combined LI on partial unions,
* asymptotic-difference → full multiset equality (the unsound route flagged in the Phase B completion audit).

## Build

* `lake exe cache get` completed successfully in the worktree.
* `lake build TNLean.MPS.FundamentalTheorem.PaperBNT.Fundamental` completed successfully.
* Full `lake build` completed successfully (8695 jobs). Existing unrelated warnings/sorries remain in other modules; no new `sorry`, `axiom`, or `unsafe` in the changed PaperBNT files.

## Notes

`matched_sector_weight_multiset_eq` is kept as-is as the exact algebraic extractor. It is **not** used to bridge from asymptotic equality; it is fed by the new eventual-exact coefficient identity.

Closes/addresses #1730. Related: #1725, #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades core `IsBNTCanonicalForm` assumptions and rewires multiple FT lemmas from unit-subset to full-basis matching, which can affect downstream proof dependencies and invariants even though changes are localized to PaperBNT modules.
> 
> **Overview**
> Phase D upgrade of the PaperBNT fundamental-theorem path by strengthening `IsBNTCanonicalForm` with a new per-block unit-modulus normalization field `weight_unit_exists_per_block` and updating examples/`dropSector` preservation to supply these witnesses.
> 
> Refactors the matching/coefficients pipeline from a *unit-subset* approach to a *full-basis* approach: `coeff_not_tendsto_zero_at_block` no longer takes an external witness, `exists_block_match_of_sameMPV` matches any block, `forall_k_exists_j_nondecaying_overlap_of_sameMPV` and `bijective_match_of_sameMPV` become full `Fin`-basis matching, and `CoeffIdentity` is rewritten to give eventual **exact** coefficient identities under a basis equivalence.
> 
> Adds `PaperBNT/Fundamental.lean` and exposes it via `TNLean.lean`, assembling full-basis matching + exact coefficient identity into `ft_paper_bnt_equal_sector_data` (bijection, gauge-phase equivalence, copy-count equality, and per-copy weight transport up to phase/permutation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e8b59bd6abd06edf32282d64bc2a6f3cbb729f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->