### PR TITLE
feat(MPS/FT/PaperBNT): literal II_cor2 GaugeEquiv packaging (witness form)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -220,6 +220,7 @@ import TNLean.MPS.FundamentalTheorem.PaperBNT.CoeffIdentity
 import TNLean.MPS.FundamentalTheorem.PaperBNT.DominantMatch
 import TNLean.MPS.FundamentalTheorem.PaperBNT.EqualModulus
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Fundamental
+import TNLean.MPS.FundamentalTheorem.PaperBNT.FundamentalCoord
 import TNLean.MPS.FundamentalTheorem.PaperBNT.StrongMatch
 import TNLean.MPS.FundamentalTheorem.PaperBNT.WeightEquiv
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Api

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
@@ -96,7 +96,7 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv_witnesses
       (ζ : Fin Q.basisCount → ℂ)
       (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ)
       (_hTotal : P.totalDim = Q.totalDim)
-      (X : GL (Fin Q.totalDim) ℂ),
+      (X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ),
       (∀ k : Fin Q.basisCount, ζ k ≠ 0) ∧
       (∀ (k : Fin Q.basisCount) (i : Fin d),
         Q.basis k i =
@@ -108,12 +108,14 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv_witnesses
         Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ k q)) ∧
       (∀ i : Fin d,
         Q.toTensor i =
-          (X : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+          (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                      (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
             toTensorFromBlocks (d := d)
               (μ := matched_p_weight (P := P) (Q := Q) β τ)
               (matched_p_basis (P := P) (Q := Q) β hDim) i *
-            (((X)⁻¹ : GL (Fin Q.totalDim) ℂ) :
-              Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)) := by
+            (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
+              Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                     (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ)) := by
   classical
   obtain ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_ne, hConj, hWeight, X, _hXdef, hGauge⟩ :=
     ft_paper_bnt_equal_global_gauge hP hQ hEqual
@@ -145,15 +147,17 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv
       ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
         (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
         (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
-        (X : GL (Fin Q.totalDim) ℂ),
+        (X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ),
         ∀ i : Fin d,
           Q.toTensor i =
-            (X : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+            (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                        (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
               toTensorFromBlocks (d := d)
                 (μ := matched_p_weight (P := P) (Q := Q) β τ)
                 (matched_p_basis (P := P) (Q := Q) β hDim) i *
-              (((X)⁻¹ : GL (Fin Q.totalDim) ℂ) :
-                Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
+              (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
+                Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                       (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
   classical
   obtain ⟨β, hDim, _hCopies, τ, _ζ, _Xblock, _hTotal, X, _, _, _, hGauge⟩ :=
     ft_paper_bnt_equal_mps_gaugeEquiv_witnesses hP hQ hEqual

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
@@ -88,6 +88,8 @@ CPSV16 §II.C lines 354–361 / 1184–1192. -/
 theorem ft_paper_bnt_equal_mps_gaugeEquiv_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -118,7 +120,7 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv_witnesses
                      (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ)) := by
   classical
   obtain ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_ne, hConj, hWeight, X, _hXdef, hGauge⟩ :=
-    ft_paper_bnt_equal_global_gauge hP hQ hEqual
+    ft_paper_bnt_equal_global_gauge hP hQ hUnitP hUnitQ hEqual
   -- `P.totalDim = Q.totalDim` follows from `sectorFlatEquiv` plus matched dims
   have hTotal : P.totalDim = Q.totalDim :=
     SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
@@ -142,6 +144,8 @@ CPSV16 §II.C lines 354–361. -/
 theorem ft_paper_bnt_equal_mps_gaugeEquiv
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (_hTotal : P.totalDim = Q.totalDim),
       ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
@@ -160,7 +164,7 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv
                        (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
   classical
   obtain ⟨β, hDim, _hCopies, τ, _ζ, _Xblock, _hTotal, X, _, _, _, hGauge⟩ :=
-    ft_paper_bnt_equal_mps_gaugeEquiv_witnesses hP hQ hEqual
+    ft_paper_bnt_equal_mps_gaugeEquiv_witnesses hP hQ hUnitP hUnitQ hEqual
   exact ⟨SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ,
     β, hDim, τ, X, hGauge⟩
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Fundamental
+
+/-!
+# Paper-faithful BNT equal-MPV gauge equivalence: bundled `II_cor2` witness
+
+This module packages the paper-faithful equal-MPV theorem
+`ft_paper_bnt_equal_global_gauge` as the literal `II_cor2` statement of
+CPSV16 §II.C lines 354–361 / appendix lines 1184–1192.
+
+The bundled-witness theorem `ft_paper_bnt_equal_mps_gaugeEquiv_witnesses`
+exposes, for any two paper-faithful BNT sector decompositions $P$ and $Q$
+generating the same MPV family:
+
+* the matched basis bijection $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$;
+* per-block bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$;
+* matched copy multiplicities $r_{βk}^P = r_k^Q$;
+* matched copy permutations $τ_k$;
+* per-block gauge phases $ζ_k \in \mathbb{C}^\times$;
+* per-block gauge matrices $X_k \in \mathrm{GL}(D_Q^{(k)},\mathbb{C})$;
+* the equality of total bond dimensions $\sum_k r_k D_k$;
+* the explicit global gauge $X \in \mathrm{GL}(\sum_s D^{(s)},\mathbb{C})$;
+
+together with the three CPSV16 line-1188/1191 conjugation identities:
+
+* $B_k = ζ_k\,X_k\,A_{βk}\,X_k^{-1}$ (per basis block);
+* $ν_{k,q} = ζ_k^{-1}\,μ_{βk,\,τ_k q}$ (per copy weight);
+* $V_Q = X\,V_P\,X^{-1}$ at every site (global gauge equation, in matched
+  flattened-copy coordinates).
+
+The global equation is stated in the matched coordinates of $Q$'s flattened
+copy index (this is the literal Phase E output of CPSV16 lines 1189–1192).
+Converting the right-hand side from the matched-coordinate `toTensorFromBlocks`
+into a literal `cast`-of-`P.toTensor` requires assembling a sector-permutation
+matrix from `sectorFlatEquiv` and conjugating; the present module records the
+witness bundle that is the verbatim CPSV16 II_cor2 packaging, while the
+permutation-matrix conjugation is left for a follow-up module (it requires
+non-trivial `PEquiv` glue on block-diagonal matrices over a reindexed
+$Σ$-type).
+
+Paper anchors:
+
+* CPSV16 §II.C lines 354–361: `II_cor2` statement of gauge equivalence
+  between two BNT canonical forms with the same expectation values.
+* CPSV16 §II.C lines 1184–1192: BNT block matching, sector weight
+  identification, and explicit global gauge $X = \bigoplus_k (𝟙_{r_k}
+  \otimes X_k)$.
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- **CPSV16 `II_cor2` witness form (CPSV16 §II.C lines 354–361 / 1184–1192).**
+
+If two paper-faithful BNT sector decompositions generate the same MPV family,
+then there exist:
+
+* a basis bijection $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$,
+* per-block bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$,
+* matched copy multiplicities $r_{βk}^P = r_k^Q$,
+* per-block copy permutations $τ_k$,
+* per-block gauge phases $ζ_k \in \mathbb{C}^\times$,
+* per-block gauge matrices $X_k \in \mathrm{GL}(D_Q^{(k)},\mathbb{C})$,
+* a total bond-dimension equality $\sum_k r_k D_k = \sum_k r_k' D_k'$, and
+* an explicit global gauge $X \in \mathrm{GL}\bigl(\sum_s D^{(s)},
+  \mathbb{C}\bigr)$ of the form $X = \bigoplus_k (𝟙_{r_k}\otimes X_k)$,
+
+such that the three CPSV16 identities
+
+* $B_k = ζ_k\,X_k\,A_{βk}\,X_k^{-1}$ (per basis block, CPSV16 line 1191),
+* $ν_{k,q} = ζ_k^{-1}\,μ_{βk,\,τ_k q}$ (per copy weight, CPSV16 line 1190),
+* $V_Q^i = X\,V_P^i\,X^{-1}$ at every physical site $i$ (global gauge,
+  CPSV16 lines 1191–1192),
+
+hold simultaneously.  The final global identity is exposed here in the
+matched flattened-copy coordinates of $Q$: writing the $P$-side block
+data through the matched bijections gives the
+`toTensorFromBlocks`-tensor that conjugates to $Q.toTensor$ under $X$.
+
+CPSV16 §II.C lines 354–361 / 1184–1192. -/
+theorem ft_paper_bnt_equal_mps_gaugeEquiv_witnesses
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
+      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+      (_hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k)
+      (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+      (ζ : Fin Q.basisCount → ℂ)
+      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ)
+      (_hTotal : P.totalDim = Q.totalDim)
+      (X : GL (Fin Q.totalDim) ℂ),
+      (∀ k : Fin Q.basisCount, ζ k ≠ 0) ∧
+      (∀ (k : Fin Q.basisCount) (i : Fin d),
+        Q.basis k i =
+          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
+      (∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
+        Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ k q)) ∧
+      (∀ i : Fin d,
+        Q.toTensor i =
+          (X : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+            toTensorFromBlocks (d := d)
+              (μ := matched_p_weight (P := P) (Q := Q) β τ)
+              (matched_p_basis (P := P) (Q := Q) β hDim) i *
+            (((X)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+              Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)) := by
+  classical
+  obtain ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_ne, hConj, hWeight, X, _hXdef, hGauge⟩ :=
+    ft_paper_bnt_equal_global_gauge hP hQ hEqual
+  -- `P.totalDim = Q.totalDim` follows from `sectorFlatEquiv` plus matched dims
+  have hTotal : P.totalDim = Q.totalDim :=
+    SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
+  -- the bond-dimension index `Q.totalDim` and `∑ s, Q.flatDim s` agree definitionally
+  refine ⟨β, hDim, hCopies, τ, ζ, Xblock, hTotal, X, hζ_ne, hConj, hWeight, ?_⟩
+  intro i
+  exact hGauge i
+
+/-- **CPSV16 `II_cor2` literal form, sector data + total bond-dimension equality.**
+
+If two paper-faithful BNT sector decompositions generate the same MPV
+family, their total bond dimensions agree and there exists a matrix $X$
+realizing the CPSV16 line-1191 global gauge in $Q$'s flattened sector
+coordinates.
+
+This is the literal CPSV16 II_cor2 statement of gauge equivalence between
+two BNT canonical forms with the same expectation values; the witness
+bundle is provided by `ft_paper_bnt_equal_mps_gaugeEquiv_witnesses`.
+
+CPSV16 §II.C lines 354–361. -/
+theorem ft_paper_bnt_equal_mps_gaugeEquiv
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ (_hTotal : P.totalDim = Q.totalDim),
+      ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
+        (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+        (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+        (X : GL (Fin Q.totalDim) ℂ),
+        ∀ i : Fin d,
+          Q.toTensor i =
+            (X : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+              toTensorFromBlocks (d := d)
+                (μ := matched_p_weight (P := P) (Q := Q) β τ)
+                (matched_p_basis (P := P) (Q := Q) β hDim) i *
+              (((X)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+                Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
+  classical
+  obtain ⟨β, hDim, _hCopies, τ, _ζ, _Xblock, _hTotal, X, _, _, _, hGauge⟩ :=
+    ft_paper_bnt_equal_mps_gaugeEquiv_witnesses hP hQ hEqual
+  exact ⟨SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ,
+    β, hDim, τ, X, hGauge⟩
+
+end MPSTensor

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -198,6 +198,97 @@ lemma mpv_toTensor_eq_sum_coeff (P : SectorDecomposition d) {N : ℕ}
     _ = ∑ j : Fin P.basisCount, P.coeff N j * mpv (P.basis j) σ := by
           simp [SectorDecomposition.coeff, SectorWeightData.coeff]
 
+/-! ## Matched-sector flattened equivalences
+
+When two paper-faithful sector decompositions $P$ and $Q$ share an MPV
+family, the equal-MPV matching theorem (CPSV16 §II.C lines 1184–1192)
+produces a basis bijection $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$,
+matched copy permutations $τ_k$, and per-block bond-dimension equalities
+$D_P^{(βk)} = D_Q^{(k)}$.  These data induce an equivalence between the
+flattened sector indices of $P$ and $Q$, and an equality of the total
+bond dimensions $\sum_k r_k D_k$.  We package these here for downstream
+use in the literal `GaugeEquiv` packaging of `II_cor2`. -/
+
+/-- Flattened-sector permutation induced by a matched basis bijection and
+matched copy permutations.
+
+For matched data $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$ and copy
+permutations $τ_k : \{1,\dots,r_k^Q\} \simeq \{1,\dots,r_{βk}^P\}$, this
+sends a flat $Q$-sector index $s \leftrightarrow (k,q)$ to the flat
+$P$-sector index $\leftrightarrow (βk, τ_k q)$.
+
+CPSV16 §II.C lines 1184–1192 (matched flattened-copy reindexing). -/
+noncomputable def sectorFlatEquiv
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))) :
+    Fin Q.totalCopies ≃ Fin P.totalCopies :=
+  (Q.flatIndexEquiv.symm.trans
+    ((Equiv.sigmaCongrRight τ).trans
+      (Equiv.sigmaCongrLeft (β := fun k' : Fin P.basisCount =>
+        Fin (P.copies k')) β))).trans P.flatIndexEquiv
+
+@[simp]
+theorem sectorFlatEquiv_apply
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) :
+    sectorFlatEquiv (P := P) (Q := Q) β τ s =
+      P.flatIndexEquiv ⟨β (Q.flatIndexEquiv.symm s).1,
+        τ (Q.flatIndexEquiv.symm s).1 (Q.flatIndexEquiv.symm s).2⟩ := by
+  simp [sectorFlatEquiv, Equiv.sigmaCongrLeft_apply,
+    Equiv.sigmaCongrRight_apply]
+
+/-- Flat-sector dimensions of $P$ and $Q$ agree along `sectorFlatEquiv`,
+using the matched per-block bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$.
+
+CPSV16 §II.C lines 1184–1192. -/
+theorem flatDim_sectorFlatEquiv
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) :
+    P.flatDim (sectorFlatEquiv (P := P) (Q := Q) β τ s) = Q.flatDim s := by
+  -- both sides reduce to a basis dimension of the matched block
+  simp [SectorDecomposition.flatDim, sectorFlatEquiv_apply, hDim]
+
+/-- **Total bond dimension matches across paper-faithful sector matchings.**
+
+If $P$ and $Q$ admit a matched basis bijection with matched per-block bond
+dimensions and matched copy permutations, then their total bond dimensions
+$\sum_s D_s$ coincide.
+
+CPSV16 §II.C lines 1184–1192. -/
+theorem totalDim_eq_of_match
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))) :
+    P.totalDim = Q.totalDim := by
+  classical
+  -- reindex the P-side sum across `sectorFlatEquiv` and use `flatDim_sectorFlatEquiv`
+  have hreindex :
+      ∑ s' : Fin P.totalCopies, P.flatDim s' =
+        ∑ s : Fin Q.totalCopies,
+          P.flatDim (sectorFlatEquiv (P := P) (Q := Q) β τ s) := by
+    refine (Fintype.sum_equiv (sectorFlatEquiv (P := P) (Q := Q) β τ)
+      (fun s => P.flatDim (sectorFlatEquiv (P := P) (Q := Q) β τ s))
+      (fun s' => P.flatDim s') ?_).symm
+    intro s
+    rfl
+  -- finish: replace the inner P.flatDim by Q.flatDim along the matched indices
+  have hpoint :
+      (fun s : Fin Q.totalCopies =>
+          P.flatDim (sectorFlatEquiv (P := P) (Q := Q) β τ s)) =
+        fun s => Q.flatDim s := by
+    funext s
+    exact flatDim_sectorFlatEquiv (P := P) (Q := Q) β hDim τ s
+  change ∑ s' : Fin P.totalCopies, P.flatDim s' =
+      ∑ s : Fin Q.totalCopies, Q.flatDim s
+  rw [hreindex, hpoint]
+
 end SectorDecomposition
 
 end MPSTensor


### PR DESCRIPTION
## Summary

Adds the bundled-witness form of CPSV16 `II_cor2` (§II.C lines 354-361 / appendix 1184-1192) on the paper-faithful BNT canonical-form surface.

## What's new

**`SharedInfra/SectorDecomposition.lean`** (+91 LoC):
- `sectorFlatEquiv`: induced flattened-sector permutation `Fin Q.totalCopies ≃ Fin P.totalCopies` from matched basis bijection �$ and matched copy permutations �_k$.
- `flatDim_sectorFlatEquiv`: flat-sector dimensions agree along `sectorFlatEquiv`.
- `totalDim_eq_of_match`: total bond dimension $\sum_s D_s$ matches across paper-faithful sector matchings.

**`PaperBNT/FundamentalCoord.lean`** (new, 163 LoC):
- `ft_paper_bnt_equal_mps_gaugeEquiv_witnesses`: bundled witness theorem exposing �, h_{Dim}, h_{Copies}, τ, ζ, X_{\text{block}}$, total bond-dim equality, and the global gauge $, with the three CPSV16 line-1188/1191 identities.
- `ft_paper_bnt_equal_mps_gaugeEquiv`: literal $\exists h_{\text{tot}}, X, \dots$ form exposing total bond-dim equality and global gauge witness in matched flattened-copy coordinates.

## Honest scope

The final .\text{toTensor} = X \cdot \text{cast}\,P.\text{toTensor} \cdot X^{-1}$ step (collapsing matched-coordinate `toTensorFromBlocks` into a literal cast of `P.toTensor`) requires assembling a sector-permutation matrix from `sectorFlatEquiv` and conjugating block-diagonal matrices over a reindexed $\SigmahBctype. This is left for a follow-up; the present packaging records the verbatim CPSV16 II_cor2 witness bundle plus the total bond-dim equality.

## Verification

- `lean_diagnostics` clean on `PaperBNT/FundamentalCoord.lean` and modified `SharedInfra/SectorDecomposition.lean`.
- No `sorry` / `axiom` / `unsafe`.

## Refs

References #1685. Coordinates with sibling PR-B (`feat/mps-ft-perblock-hypothesis`, lifting `weight_unit_exists_per_block` to per-theorem hypothesis); merge order is independent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean definitions/theorems to package an existing equal-MPV gauge result and a small amount of supporting reindexing infrastructure; no existing logic is modified beyond adding these lemmas and a new root import.
> 
> **Overview**
> Adds a new `PaperBNT/FundamentalCoord` module that repackages `ft_paper_bnt_equal_global_gauge` into a CPSV16 `II_cor2`-shaped *bundled witness* theorem (`ft_paper_bnt_equal_mps_gaugeEquiv_witnesses`) and a smaller existential wrapper (`ft_paper_bnt_equal_mps_gaugeEquiv`), exposing matched sector bijections/per-copy permutations, per-block phases/matrices, **total bond-dimension equality**, and the global conjugation statement in matched flattened-copy coordinates.
> 
> Extends `SharedInfra/SectorDecomposition` with `sectorFlatEquiv`, `flatDim_sectorFlatEquiv`, and `totalDim_eq_of_match` to formalize the induced flattened-sector reindexing and derive `P.totalDim = Q.totalDim`, and makes the new module available from the root `TNLean.lean` import surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa137e3d42efe143e7e76d37833e49ea467e17b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->