### PR TITLE
feat(MPS/FT/PaperBNT): lift weight_unit_exists_per_block to per-theorem hypothesis

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
@@ -39,11 +39,10 @@ not imported here.
   of the multiplicity bound (CPSV16 line 246 via `weight_norm_le_one`).
 * `IsBNTCanonicalForm.weight_unit_exists_of_struct` — the global
   unit-modulus witness re-exposed at the API layer (CPSV16 line 246).
-* `IsBNTCanonicalForm.weight_unit_exists_per_block_of_struct` — the
-  per-block unit-modulus witnesses (CPSV21 §III.2 / Definition 4.3).
 * `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block` — the Cesàro
-  non-decay reading of per-block spectral-radius-one normalization, with
-  the unit witness discharged from the structure (Phase D, issue #1730).
+  non-decay reading of the line-1182 projection step, with the per-block
+  unit-modulus witness supplied as an explicit theorem-level hypothesis
+  `hUnit : ∃ q, ‖μ_{j₀,q}‖ = 1`.
 
 ## References
 
@@ -216,37 +215,30 @@ lemma weight_unit_exists_of_struct (h : IsBNTCanonicalForm P) :
     ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
       ‖P.weight j q‖ = 1 := h.weight_unit_exists
 
-/-- **Per-block unit-modulus weight witness from CPSV21 §III.2.**
-
-Re-exposes `weight_unit_exists_per_block`, the Phase D strengthening of
-`IsBNTCanonicalForm`: every BNT basis sector carries its own unit-modulus
-copy weight. -/
-lemma weight_unit_exists_per_block_of_struct
-    (h : IsBNTCanonicalForm P) (j : Fin P.basisCount) :
-    ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1 :=
-  h.weight_unit_exists_per_block j
-
 /-- **Per-block coefficient non-decay.**
 
-For every sector `j₀ : Fin P.basisCount`, the power-sum coefficient
+For a user-supplied sector `j₀ : Fin P.basisCount` carrying a unit-modulus
+copy witness `hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`, the power-sum coefficient
 `P.coeff N j₀ = ∑_q (P.weight j₀ q)^N` does **not** tend to `0` as
 `N → ∞`.
 
-Phase D strengthens the canonical-form surface with the CPSV21 §III.2 /
-Definition 4.3 per-block spectral-radius-one normalization, so the
-unit-modulus witness needed by the Cesàro non-decay lemma is discharged
-automatically from `h.weight_unit_exists_per_block j₀`.
+The per-block unit-modulus hypothesis `hUnit` is taken as an explicit
+theorem-level argument rather than a structural field of
+`IsBNTCanonicalForm`: CPSV16 §II.A line 246 records only the *global*
+normalization $\exists j, \exists q, \|\mu_{j,q}\| = 1$, and CPSV21 §III.2
+Definition 4.3 (lines 1846–1884) normalizes the spectral radius of the
+*basis* tensors, not the copy coefficients $\mu_{j,q}$.  The per-block
+witness is implicit in CPSV16 §II.C line 1182's projection step and is
+therefore exposed here as a per-theorem hypothesis.
 
-Paper anchor: CPSV21 §III.2 / Definition 4.3 lines 1846–1884
-(per-block spectral-radius-one BNT normalization), CPSV16 §II.C lines
-1158–1167 (power-sum non-decay / exact comparison input). -/
+Paper anchor: CPSV16 §II.C lines 1158–1167 (power-sum non-decay / exact
+comparison input), CPSV16 §II.C line 1182 (per-block projection step). -/
 theorem coeff_not_tendsto_zero_at_block
-    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount) :
+    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
+    (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1) :
     ¬ Tendsto (fun N : ℕ => P.coeff N j₀) atTop (𝓝 0) := by
   have h_le : ∀ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ ≤ 1 :=
     h.weight_norm_le_one j₀
-  have hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1 :=
-    h.weight_unit_exists_per_block j₀
   have hAnal := CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus
     (P.weight j₀) h_le hUnit
   intro hTend
@@ -300,15 +292,16 @@ limit.
 
 This is the coefficient form of the audit's "thermodynamic-limit
 non-vanishing" condition, with the per-block unit-modulus witness
-supplied by the structure.  A self-overlap form
+supplied as an explicit theorem-level hypothesis.  A self-overlap form
 `limsup_N ⟨A^⊕|A^⊕⟩^{(N)} ∈ (0, ∞)` is the implication recorded by
 the audit's Q-C equivalence (forward direction), which we do not
 formalise here — the coefficient form is the operational input to the
 FT proof; the self-overlap reading is a paraphrase. -/
 lemma thermodynamic_limit_nonvanishing
-    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount) :
+    (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
+    (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1) :
     ¬ Tendsto (fun N : ℕ => P.coeff N j₀) atTop (𝓝 0) :=
-  h.coeff_not_tendsto_zero_at_block j₀
+  h.coeff_not_tendsto_zero_at_block j₀ hUnit
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
@@ -25,9 +25,19 @@ a `SectorDecomposition`.  It records:
   dimension;
 * the CPSV16 §II.A line-246 **normalization convention** on the raw sector
   weights `μ_{j,q}`: `|μ_{j,q}| ≤ 1` and at least one of them equals one
-  (lines 246 and 1244);
-* the CPSV21 §III.2 / Definition 4.3 per-block spectral-radius-one
-  normalization: each BNT basis block has at least one unit-modulus copy.
+  (lines 246 and 1244).
+
+The per-block unit-modulus convention `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — implicit
+in CPSV16 §II.C line 1182's projection step and not explicitly stated in
+CPSV16 §II.A line 246 (which is global) nor in CPSV21 §III.2 lines 1846–1884
+(which normalizes the spectral radius of the BNT *basis tensors*, not the
+copy coefficients) — is **not** a structural field of `IsBNTCanonicalForm`.
+The fundamental-theorem statements (`coeff_not_tendsto_zero_at_block`,
+`exists_block_match_of_sameMPV`, `bijective_match_of_sameMPV`,
+`ft_paper_bnt_equal_*`) take the per-block witness as an explicit
+hypothesis at the theorem level.  This keeps the canonical-form predicate
+maximally paper-faithful and quarantines the line-1182 paper-implicit
+convention to the theorems that actually need it.
 
 Crucially, the structure does **not** impose an equal-modulus or strict-order
 condition on the raw sector weights `P.weight j q`.  CPSV16
@@ -139,37 +149,14 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   `C ⊕ (1/2)C` (weights `(1, 1/2)`), and `C ⊕ (-C) ⊕ (1/2)C`. -/
   weight_norm_le_one : ∀ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ ≤ 1
-  /-- **Per-block unit-modulus normalization (paper-implicit convention).**
-  Each BNT basis block contains at least one unit-modulus raw copy weight.
-
-  Source-faithfulness note.  CPSV16 §II.A line 246 states only a *global*
-  unit-modulus witness — "we can always choose `|μ_k| ≤ 1` and at least one
-  of them equals one" — and CPSV21 §III.2 Definition 4.3 (lines 1846–1884)
-  states a *per-NT-block* spectral-radius-one convention on the basis
-  tensors, not on the copy coefficients `μ_{j,q}`.  Strictly, CPSV16 and
-  CPSV21 do not explicitly assert `∀ j, ∃ q, ‖μ_{j,q}‖ = 1`.
-
-  However, the equal-MPV FT proof in CPSV16 §II.C lines 1182–1183
-  implicitly requires this hypothesis: the projection of `|V^{(N)}(B)⟩`
-  onto `|V^{(N)}(B_k)⟩` produces the contradiction `Q.coeff N k → 0`,
-  which is only impossible if some `‖Q.weight k q‖ = 1`.  Without this,
-  the matching argument fails for BNT blocks whose copy weights all have
-  modulus `< 1` (which are valid CPSV16 BNTs but contribute vanishingly
-  to the thermodynamic-limit MPV).
-
-  We therefore make this paper-implicit convention an explicit structural
-  field of `IsBNTCanonicalForm`.  This is stronger than the explicit
-  CPSV16/CPSV21 statements and excludes from our FT theorems any CPSV16
-  BNT with all-decaying blocks; that scope restriction is the honest
-  reading of CPSV16's L1182 projection argument. -/
-  weight_unit_exists_per_block : ∀ j : Fin P.basisCount,
-    ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1
   /-- **CPSV16 line-246 global unit witness.**  At least one copy of one
-  basis sector has unit-modulus weight.  This field is retained as the
-  global CPSV16 normalization/non-emptiness witness consumed by older
-  auxiliary lemmas; on all nonempty sector decompositions it follows
-  immediately from `weight_unit_exists_per_block` by choosing any basis
-  index. -/
+  basis sector has unit-modulus weight.  CPSV16 §II.A line 246: "we can
+  always choose `|μ_k| ≤ 1` and at least one of them equals one."  This
+  is the global (not per-block) normalization condition; the per-block
+  refinement `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` is paper-implicit in CPSV16 §II.C
+  line 1182's projection argument and is therefore taken as an explicit
+  per-theorem hypothesis on the fundamental-theorem theorems, rather
+  than baked into this structural predicate. -/
   weight_unit_exists : ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ = 1
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
@@ -34,30 +34,27 @@ The module has three layers:
 
 The block matching at a **user-supplied** sector index
 `j₀ : Fin P.basisCount` (with an externally provided unit-modulus
-witness) does not single out any particular sector internally: the core
-seven `IsBNTCanonicalForm` fields are deliberately invariant under
+witness) does not single out any particular sector internally: the
+`IsBNTCanonicalForm` fields are deliberately invariant under
 relabelling of sectors.  Following the CPSV16 §II.A line-246
-normalization convention, `IsBNTCanonicalForm` carries two additional
-structural fields:
+normalization convention, `IsBNTCanonicalForm` carries the modulus-bound
+field
 
 * `weight_norm_le_one : ∀ j q, ‖weight j q‖ ≤ 1`  — CPSV16 line 246, the
   modulus bound.  Lemma 3 below feeds this in via `hP.weight_norm_le_one`
   and `hQ.weight_norm_le_one`.
-* `weight_unit_exists_per_block : ∀ j, ∃ q, ‖weight j q‖ = 1` —
-  CPSV21 §III.2 / Definition 4.3 per-block spectral-radius-one
-  normalization.
 
-Issue #1725 Phase A retired an auxiliary dominant-block structural
-field (audit memo `/tmp/phase_4c_drift_audit_2026-05-14.md` §Q-C):
-CPSV16 line 246 is
-**global** and does not pin the unit-modulus copy to sector 0.  The
-matching theorem below now takes the unit-modulus sector as an
-**explicit parameter** `j₀ : Fin P.basisCount` together with a
-per-sector unit-modulus existential
-`hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`.  The non-decay of the matched
+The per-block unit-modulus convention `∀ j, ∃ q, ‖weight j q‖ = 1` is
+**not** a structural field — CPSV16 line 246 is **global** (the
+unit-modulus copy can sit in any sector) and CPSV21 §III.2 Definition 4.3
+(lines 1846–1884) normalizes the spectral radius of the *basis* tensors,
+not the copy coefficients.  The matching theorem below therefore takes
+the unit-modulus sector as an **explicit parameter** `j₀ : Fin P.basisCount`
+together with a per-sector unit-modulus existential
+`hUnitP_at_j₀ : ∃ q, ‖P.weight j₀ q‖ = 1`.  The non-decay of the matched
 sector's coefficient is then derived inside the proof via
 `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block`
-(`PaperBNT/Api.lean`).
+(`PaperBNT/Api.lean`), now also taking the same per-block hypothesis.
 
 These hypotheses are weaker than the legacy `IsCanonicalFormBNT` package
 (which baked in `mu_strict_anti` + a single per-sector "spectral level"
@@ -193,6 +190,7 @@ theorem exists_block_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (j₀ : Fin P.basisCount)
+    (hUnitP_at_j₀ : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1)
     (hP_pos : 0 < P.basisCount) (hQ_pos : 0 < Q.basisCount)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ k₀ : Fin Q.basisCount,
@@ -215,11 +213,11 @@ theorem exists_block_match_of_sameMPV
   -- used to be supplied as explicit parameters at the call site.
   have hP_weight_le := hP.weight_norm_le_one
   have hQ_weight_le := hQ.weight_norm_le_one
-  -- Block coefficient non-decay derived from the structural per-block
-  -- unit-modulus witness via the Cesàro non-decay lemma.
+  -- Block coefficient non-decay derived from the externally supplied
+  -- per-block unit-modulus witness via the Cesàro non-decay lemma.
   have hP_dom_coeff_not_tendsto_zero :
       ¬ Tendsto (fun N : ℕ => P.coeff N j₀) atTop (𝓝 0) :=
-    hP.coeff_not_tendsto_zero_at_block j₀
+    hP.coeff_not_tendsto_zero_at_block j₀ hUnitP_at_j₀
   -- Step 1: extract some k₀ with non-decaying overlap to `P.basis j₀`.
   have hExists_k :
       ∃ k₀ : Fin Q.basisCount,

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
@@ -24,7 +24,12 @@ core examples have a single BNT basis sector (`basisCount = 1`):
   copies with raw weights `(1, 1/2)`.  Demonstrates that unequal-modulus
   copies are admissible by the CPSV16 §II.A line-246 normalization
   (`weight_norm_le_one` holds because both `1` and `1/2` have modulus
-  `≤ 1`; `weight_unit_exists_per_block` and `weight_unit_exists` are witnessed by the first copy).
+  `≤ 1`; `weight_unit_exists` is witnessed by the first copy).
+
+Each example additionally exposes a named lemma `<example>_weight_unit_per_block`
+witnessing the per-block unit-modulus convention `∀ j, ∃ q, ‖μ_{j,q}‖ = 1`,
+which fundamental-theorem theorems consume as an explicit hypothesis
+(paper-implicit in CPSV16 §II.C line 1182's projection argument).
 
 A fourth example exercises the **optional** equal-modulus layer
 `HasEqualModulusWeightLayer` on top of `signFlipDecomp`, demonstrating
@@ -88,17 +93,27 @@ noncomputable example
     intro _ _
     change ‖(1 : ℂ)‖ ≤ 1
     simp
-  -- CPSV21 §III.2: the unique block has the unit-modulus witness.
-  weight_unit_exists_per_block := by
-    intro _
-    refine ⟨0, ?_⟩
-    change ‖(1 : ℂ)‖ = 1
-    simp
   -- CPSV16 line 246: the unique weight is the global unit-modulus witness.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
     change ‖(1 : ℂ)‖ = 1
     simp
+
+/-- **Per-block unit-modulus witness for `singletonDecomp`.**
+
+Fundamental-theorem theorems on `IsBNTCanonicalForm` take the per-block
+unit-modulus convention `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` (paper-implicit in
+CPSV16 §II.C line 1182's projection argument) as an explicit
+hypothesis.  For `singletonDecomp C`, the unique copy carries
+weight `1`. -/
+lemma singletonDecomp_weight_unit_per_block (C : MPSTensor d D) :
+    ∀ j : Fin (singletonDecomp C).basisCount,
+      ∃ q : Fin ((singletonDecomp C).copies j),
+        ‖(singletonDecomp C).weight j q‖ = 1 := by
+  intro _
+  refine ⟨0, ?_⟩
+  change ‖(1 : ℂ)‖ = 1
+  simp
 
 /-! ## Example 2 — `C ⊕ (-C)` -/
 
@@ -149,17 +164,26 @@ noncomputable example
     split_ifs with hq
     · simp
     · simp
-  -- CPSV21 §III.2: the single block has a unit copy at `q = 0`.
-  weight_unit_exists_per_block := by
-    intro _
-    refine ⟨0, ?_⟩
-    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else -1)‖ = 1
-    simp
   -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else -1)‖ = 1
     simp
+
+/-- **Per-block unit-modulus witness for `signFlipDecomp`.**
+
+For each (unique) BNT basis sector, the copy `q = 0` carries weight
+`μ = 1`.  Consumed by FT theorems on `IsBNTCanonicalForm` as the
+explicit per-block hypothesis (paper-implicit in CPSV16 §II.C
+line 1182's projection argument). -/
+lemma signFlipDecomp_weight_unit_per_block (C : MPSTensor d D) :
+    ∀ j : Fin (signFlipDecomp C).basisCount,
+      ∃ q : Fin ((signFlipDecomp C).copies j),
+        ‖(signFlipDecomp C).weight j q‖ = 1 := by
+  intro _
+  refine ⟨0, ?_⟩
+  change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else -1)‖ = 1
+  simp
 
 /-! ## Example 3 — `C ⊕ e^{iθ} C` -/
 
@@ -217,17 +241,26 @@ noncomputable example
         simp [Complex.mul_re]
       rw [this]
       simp
-  -- CPSV21 §III.2: the single block has a unit copy at `q = 0`.
-  weight_unit_exists_per_block := by
-    intro _
-    refine ⟨0, ?_⟩
-    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ = 1
-    simp
   -- CPSV16 line 246: the first copy `q = 0` carries weight `μ = 1`.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ = 1
     simp
+
+/-- **Per-block unit-modulus witness for `phaseDecomp`.**
+
+For each (unique) BNT basis sector, the copy `q = 0` carries weight
+`μ = 1`.  Consumed by FT theorems on `IsBNTCanonicalForm` as the
+explicit per-block hypothesis (paper-implicit in CPSV16 §II.C
+line 1182's projection argument). -/
+lemma phaseDecomp_weight_unit_per_block (C : MPSTensor d D) (θ : ℝ) :
+    ∀ j : Fin (phaseDecomp C θ).basisCount,
+      ∃ q : Fin ((phaseDecomp C θ).copies j),
+        ‖(phaseDecomp C θ).weight j q‖ = 1 := by
+  intro _
+  refine ⟨0, ?_⟩
+  change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else Complex.exp (Complex.I * θ))‖ = 1
+  simp
 
 /-! ## Example 4 — equal-modulus weight layer on `signFlipDecomp`
 
@@ -273,7 +306,7 @@ noncomputable example
 
 This example demonstrates that the strengthened `IsBNTCanonicalForm`
 predicate (with the CPSV16 §II.A line-246 fields `weight_norm_le_one`
-and `weight_unit_exists_per_block`) admits decompositions whose copies have
+and `weight_unit_exists`) admits decompositions whose copies have
 **unequal** moduli: the construction below has one unit-modulus copy
 and one `1/2`-modulus copy.  This is exactly the
 `audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` §Q4
@@ -306,7 +339,7 @@ unit modulus, which fails here because `|1| ≠ |1/2|`. -/
 raw weights `(1, 1/2)`.  The sector coefficient is `1 + (1/2)^N → 1`,
 not a scalar power.  Demonstrates that the strengthened
 `IsBNTCanonicalForm` admits unequal-modulus copies: `weight_norm_le_one`
-holds because `‖1‖ ≤ 1` and `‖1/2‖ = 1/2 ≤ 1`, and `weight_unit_exists_per_block`
+holds because `‖1‖ ≤ 1` and `‖1/2‖ = 1/2 ≤ 1`, and `weight_unit_exists`
 is witnessed by the first copy with weight `1`.
 
 Paper anchor: CPSV16 §II.A line 246, the line-246 normalization
@@ -340,17 +373,26 @@ noncomputable example
     split_ifs with hq
     · simp
     · simp; norm_num
-  -- CPSV21 §III.2: the single block has a unit copy at `q = 0`.
-  weight_unit_exists_per_block := by
-    intro _
-    refine ⟨0, ?_⟩
-    change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
-    simp
   -- CPSV16 line 246: the first copy `q = 0` carries the global unit weight.
   weight_unit_exists := by
     refine ⟨0, 0, ?_⟩
     change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
     simp
+
+/-- **Per-block unit-modulus witness for `halvedDecomp`.**
+
+For each (unique) BNT basis sector, the copy `q = 0` carries the unit
+weight `μ = 1`.  Consumed by FT theorems on `IsBNTCanonicalForm` as the
+explicit per-block hypothesis (paper-implicit in CPSV16 §II.C
+line 1182's projection argument). -/
+lemma halvedDecomp_weight_unit_per_block (C : MPSTensor d D) :
+    ∀ j : Fin (halvedDecomp C).basisCount,
+      ∃ q : Fin ((halvedDecomp C).copies j),
+        ‖(halvedDecomp C).weight j q‖ = 1 := by
+  intro _
+  refine ⟨0, ?_⟩
+  change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
+  simp
 
 end PaperBNT.Examples
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean
@@ -19,8 +19,11 @@ Paper anchors:
   contradiction and symmetry argument.
 * CPSV16 §II.C lines 1187–1188: exact power-sum coefficient comparison,
   recovering copy multiplicities and weights up to the matched phase.
-* CPSV21 Definition 4.3 lines 1846–1884: per-block spectral-radius-one
-  normalization, formalized in Phase D as `weight_unit_exists_per_block`.
+* CPSV21 Definition 4.3 lines 1846–1884: per-block BNT normalization on
+  the basis tensors.  The per-block convention on copy coefficients
+  `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — paper-implicit in CPSV16 §II.C line 1182's
+  projection argument — is taken as an explicit theorem-level hypothesis
+  here, not as a structural field of `IsBNTCanonicalForm`.
 
 The theorem below exposes the sector-level data needed before assembling
 the global CPSV16 gauge `⊕_j (𝟙_{r_j} ⊗ Y_j)`.  It does not use
@@ -84,6 +87,8 @@ This is the Lean sector-data counterpart of CPSV16 §II.C lines 1184–1188. -/
 theorem ft_paper_bnt_equal_sector_data
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount),
       (∀ k, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -93,7 +98,7 @@ theorem ft_paper_bnt_equal_sector_data
         ∀ k, ∃ τ : Fin (Q.copies k) ≃ Fin (P.copies (β k)),
           ∀ q : Fin (Q.copies k), Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ q) := by
   classical
-  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPV hP hQ hEqual
+  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPV hP hQ hUnitP hUnitQ hEqual
   let hMatch : ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
       GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k) :=
     fun k => by
@@ -151,6 +156,8 @@ rather than an opaque existential. -/
 theorem ft_paper_bnt_equal_global_gauge
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -180,7 +187,7 @@ theorem ft_paper_bnt_equal_global_gauge
                 Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
                   (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
   classical
-  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPV hP hQ hEqual
+  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPV hP hQ hUnitP hUnitQ hEqual
   let hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k :=
     fun k => (hβMatchFull k).choose
   let hGPE : ∀ k : Fin Q.basisCount,

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongMatch.lean
@@ -170,24 +170,26 @@ private theorem gaugePhaseEquiv_swap_cast {d D₁ D₂ : ℕ}
 
 /-! ### Phase B-α main theorem: paper-faithful full-basis matching -/
 
-/-- **CPSV16 §II.C lines 1182–1186 Step 1 (Phase D full-basis form).**
+/-- **CPSV16 §II.C lines 1182–1186 Step 1 (full-basis form).**
 
 For every sector `k` of `Q`, there exists a sector `j` of `P` of equal
 bond dimension, gauge-phase equivalent to `Q.basis k` after the dimension
 cast, and with non-decaying cross-overlap.
 
-The Phase D strengthening of `IsBNTCanonicalForm` adds the CPSV21 §III.2 /
-Definition 4.3 per-block spectral-radius-one normalization
-`weight_unit_exists_per_block`; hence every sector is a unit block and the
-previous unit-subset restriction disappears.  The proof applies
-`exists_block_match_of_sameMPV` with `(P, Q)` swapped and re-orients the
-result using the local symmetry helpers.
+The proof iterates `exists_block_match_of_sameMPV` over every `Q`-sector
+with `(P, Q)` swapped, so it consumes the per-block unit-modulus
+witnesses on the *swapped* side, namely `hUnitQ : ∀ k, ∃ q, ‖μ_{k,q}‖ = 1`
+for $Q$.  The per-block unit-modulus convention is paper-implicit in
+CPSV16 §II.C line 1182's projection argument; it is taken here as an
+explicit theorem-level hypothesis (CPSV16 §II.A line 246 records only
+the global unit witness).
 
 Paper anchor: CPSV16 §II.C lines 1182–1186 (arXiv:1606.00608) and CPSV21
 Definition 4.3 lines 1846–1884. -/
 theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∀ k : Fin Q.basisCount, ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
       GaugePhaseEquiv
@@ -198,9 +200,7 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
         atTop (𝓝 0) := by
   classical
   intro k
-  -- `P.basisCount > 0`: the retained global unit witness on `P` supplies a
-  -- sector index.  (The per-block field gives the full-basis upgrade; this
-  -- global field is still a convenient non-emptiness witness.)
+  -- `P.basisCount > 0`: the global unit witness on `P` supplies a sector index.
   have hP_pos : 0 < P.basisCount := by
     obtain ⟨j₀, _, _⟩ := hP.weight_unit_exists
     exact Nat.lt_of_le_of_lt (Nat.zero_le _) j₀.isLt
@@ -209,7 +209,7 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
     fun N σ => (hEqual N σ).symm
   obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
     exists_block_match_of_sameMPV
-      (P := Q) (Q := P) hQ hP k hQ_pos hP_pos hEqual_symm
+      (P := Q) (Q := P) hQ hP k (hUnitQ k) hQ_pos hP_pos hEqual_symm
   refine ⟨j, hsymDim.symm, ?_, ?_⟩
   · exact gaugePhaseEquiv_swap_cast hsymDim.symm
       (by simpa using hGE_swapped)
@@ -300,7 +300,7 @@ private theorem gaugePhaseEquiv_cast_compose_via_centre
 
 /-! ### Phase B-β main theorem: full bijective matching by symmetry -/
 
-/-- **CPSV16 §II.C lines 1184–1186 (Phase D full-basis bijection).**
+/-- **CPSV16 §II.C lines 1184–1186 full-basis bijection.**
 
 Applying `forall_k_exists_j_nondecaying_overlap_of_sameMPV` in both
 directions gives injective maps `Fin Q.basisCount → Fin P.basisCount` and
@@ -309,12 +309,19 @@ the forward injection into an equivalence `β : Fin Q.basisCount ≃
 Fin P.basisCount`, carrying the matched bond-dimension equality,
 gauge-phase equivalence, and non-decaying overlap for every sector of `Q`.
 
-This is the Lean counterpart of the CPSV16 symmetry step `g_A ≥ g_B` and
-`g_B ≥ g_A`, now over the **full** BNT basis because Phase D makes every
-basis block a unit block. -/
+This is the Lean counterpart of the CPSV16 symmetry step "$g_A \geq g_B$
+and $g_B \geq g_A$".  The proof invokes
+`forall_k_exists_j_nondecaying_overlap_of_sameMPV` once with $(P,Q)$ and
+once with $(Q,P)$, hence it consumes per-block unit-modulus witnesses on
+both sides: `hUnitP : ∀ j, ∃ q, ‖μ_{j,q}^P‖ = 1` and `hUnitQ : ∀ k, ∃ q,
+‖μ_{k,q}^Q‖ = 1`.  These are paper-implicit in CPSV16 §II.C line 1182's
+projection argument and are taken as explicit theorem-level hypotheses
+here (CPSV16 §II.A line 246 records only the global unit witness). -/
 theorem bijective_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ β : Fin Q.basisCount ≃ Fin P.basisCount,
       ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -325,10 +332,12 @@ theorem bijective_match_of_sameMPV
             mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N)
           atTop (𝓝 0) := by
   classical
-  have hFwd := forall_k_exists_j_nondecaying_overlap_of_sameMPV hP hQ hEqual
+  have hFwd :=
+    forall_k_exists_j_nondecaying_overlap_of_sameMPV hP hQ hUnitQ hEqual
   have hEqual_symm : SameMPV₂ Q.toTensor P.toTensor :=
     fun N σ => (hEqual N σ).symm
-  have hBwd := forall_k_exists_j_nondecaying_overlap_of_sameMPV hQ hP hEqual_symm
+  have hBwd :=
+    forall_k_exists_j_nondecaying_overlap_of_sameMPV hQ hP hUnitP hEqual_symm
   let φ₀ : Fin Q.basisCount → Fin P.basisCount := fun k => (hFwd k).choose
   have φ₀_spec : ∀ k : Fin Q.basisCount,
       ∃ h : P.basisDim (φ₀ k) = Q.basisDim k,


### PR DESCRIPTION
## Summary

User-approved paper-faithfulness fix (Option B, `docs/audits/2026-05-15.md` §2.3).

CPSV16 §II.A L246 states the *global* normalization "$|\mu_k| \le 1$ and at least one of them equals one".  The earlier structural strengthening (PR #1730) baked a per-block witness `weight_unit_exists_per_block` into `IsBNTCanonicalForm`, which goes beyond what CPSV16 / CPSV21 explicitly state.  The L1182 projection argument *does* implicitly need this per-block witness, but the honest move is to expose it as an explicit hypothesis on FT theorems, not as a structural field.

## Changes

- **`Basic.lean`**: remove field `weight_unit_exists_per_block` from `IsBNTCanonicalForm`. Keep global `weight_unit_exists` (CPSV16 L246 verbatim).
- **`Examples.lean`**: remove field assignments from singletonDecomp/signFlipDecomp/phaseDecomp/halvedDecomp; expose per-example named lemmas supplying the per-block witness.
- **`Api.lean`**: `coeff_not_tendsto_zero_at_block` and `thermodynamic_limit_nonvanishing` take `hUnit : ∃ q, ‖P.weight j₀ q‖ = 1` parameter.
- **`DominantMatch.lean`**: `exists_block_match_of_sameMPV` takes per-block unit witness for `j₀`.
- **`StrongMatch.lean`**: `forall_k_exists_j_nondecaying_overlap_of_sameMPV` and `bijective_match_of_sameMPV` take ∀-block hypotheses on both $ and $.
- **`Fundamental.lean`**: `ft_paper_bnt_equal_sector_data` and `ft_paper_bnt_equal_global_gauge` thread the new hypotheses through.

## Verification

`lean_diagnostics` clean on all 8 PaperBNT files; no `sorry`/`axiom`/`unsafe`. `grep -rn 'weight_unit_exists_per_block' TNLean/` returns empty.

## Refs

#1685. Supersedes structural per-block field from PR #1730.

## Coordinates with PR #1744

PR #1744 (`feat/mps-ft-literal-iicor2`, FundamentalCoord.lean) is independent on file lane. If both land, PR #1744 will need a tiny follow-up to thread the new per-block hypotheses through its wrappers `ft_paper_bnt_equal_mps_gaugeEquiv` and `ft_paper_bnt_equal_mps_gaugeEquiv_witnesses`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to widespread API/signature changes across multiple fundamental-theorem lemmas/theorems that may break downstream callers and require re-threading hypotheses, though the underlying proof logic is largely unchanged.
> 
> **Overview**
> Refactors the paper-faithful `IsBNTCanonicalForm` surface to **remove** the stronger structural field `weight_unit_exists_per_block`, keeping only CPSV16’s *global* `weight_unit_exists` normalization.
> 
> Updates the core FT pipeline to take per-block unit-modulus witnesses as **explicit theorem-level hypotheses** instead: `coeff_not_tendsto_zero_at_block`/`thermodynamic_limit_nonvanishing`, `exists_block_match_of_sameMPV`, full matching (`forall_k_exists_j_nondecaying_overlap_of_sameMPV`, `bijective_match_of_sameMPV`), and the final theorems `ft_paper_bnt_equal_sector_data`/`ft_paper_bnt_equal_global_gauge` now thread `∃ q, ‖weight …‖ = 1` (per block / ∀ blocks) through their statements.
> 
> Adjusts `PaperBNT/Examples.lean` to stop populating the removed structure field and instead provide per-example lemmas (e.g. `*_weight_unit_per_block`) to supply the new per-theorem hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08fd9224cd12d7bba8a0a3c1a3d163d46123ebaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->