### PR TITLE
feat(MPS/FT/PaperBNT/FundamentalCoord): literal II_cor2 GaugeEquiv (cast-of-P.toTensor form)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
@@ -168,4 +168,403 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv
   exact ⟨SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ,
     β, hDim, τ, X, hGauge⟩
 
+/-! ## Coordinate identification between matched and literal blocks
+
+The matched-coordinate `toTensorFromBlocks` and the literal `P.toTensor`
+differ only by a $\Sigma$-level permutation of flattened sector indices
+along `sectorFlatSigmaEquiv`; equivalently a permutation of
+`Fin Q.totalDim` (after the bond-dimension equality) by
+`sectorFlatDimEquiv`.  This lets us upgrade
+`ft_paper_bnt_equal_mps_gaugeEquiv` from the matched-coordinate form to the
+literal CPSV16 II_cor2 form (CPSV16 §II.C lines 354–361). -/
+
+/-- Cast of an `MPSTensor` along a bond-dimension equality, evaluated at one
+physical site and two bond indices, equals the underlying tensor evaluated at
+the inversely-cast indices. -/
+private lemma mpsTensor_cast_apply {n m : ℕ} (h : n = m) (A : MPSTensor d n)
+    (i : Fin d) (j₁ j₂ : Fin m) :
+    (cast (congr_arg (MPSTensor d) h) A) i j₁ j₂ =
+      A i (finCongr h.symm j₁) (finCongr h.symm j₂) := by
+  subst h
+  simp [finCongr]
+
+/-- Coordinate identification of `matched_p_basis` with a cast of `P.flatBasis`
+at the matched flat sector. -/
+private lemma matched_p_basis_eq_cast_flatBasis
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) :
+    matched_p_basis (P := P) (Q := Q) β hDim s =
+      cast (congr_arg (MPSTensor d)
+        (SectorDecomposition.flatDim_sectorFlatEquiv
+          (P := P) (Q := Q) β hDim τ s))
+        (P.flatBasis (SectorDecomposition.sectorFlatEquiv
+          (P := P) (Q := Q) β τ s)) := by
+  classical
+  set k : Fin Q.basisCount := (Q.flatIndexEquiv.symm s).1 with hk_def
+  -- `matched_p_basis β hDim s` reduces to `cast (hDim k) (P.basis (β k))`.
+  have hMatched :
+      matched_p_basis (P := P) (Q := Q) β hDim s =
+        cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k)) := rfl
+  -- `P.flatBasis (sectorFlatEquiv β τ s)` reduces to `P.basis (...).1`, where
+  -- `(...).1 = β k` via `hsym`.
+  have hsym :
+      P.flatIndexEquiv.symm
+          (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s) =
+        ⟨β k, τ k (Q.flatIndexEquiv.symm s).2⟩ := by
+    rw [SectorDecomposition.sectorFlatEquiv_apply, Equiv.symm_apply_apply]
+  -- The dependent index `(P.flatIndexEquiv.symm (sectorFlatEquiv β τ s)).1` equals `β k`.
+  have hk1 :
+      (P.flatIndexEquiv.symm
+          (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s)).1 =
+        β k := congrArg Sigma.fst hsym
+  rw [hMatched]
+  -- Use HEq-elimination: both sides are casts of `P.basis (...)` at indices
+  -- that equal `β k`.  We prove the underlying terms HEq, then transport.
+  apply eq_of_heq
+  refine HEq.trans (cast_heq _ _) ?_
+  refine HEq.trans ?_ (HEq.symm (cast_heq _ _))
+  -- Goal: HEq (P.basis (β k)) (P.flatBasis (sectorFlatEquiv β τ s))
+  -- which unfolds to HEq (P.basis (β k)) (P.basis ((P.flatIndexEquiv.symm _).1))
+  change HEq (P.basis (β k))
+    (P.basis (P.flatIndexEquiv.symm
+      (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s)).1)
+  -- Generalize the dependent index so we can perform `subst`.
+  set k' : Fin P.basisCount :=
+    (P.flatIndexEquiv.symm
+      (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s)).1
+    with hk'_def
+  have hk1' : k' = β k := hk1
+  clear_value k'
+  subst hk1'
+  rfl
+
+/-- Pointwise identity: the matched-coordinate basis tensor at flattened sector
+`s` equals the `P`-basis at the matched flattened sector, after reindexing the
+inner bond-dimension `Fin`s by `flatDim_sectorFlatEquiv`. -/
+private lemma matched_p_basis_apply
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) (i : Fin d) (m m' : Fin (Q.flatDim s)) :
+    matched_p_basis (P := P) (Q := Q) β hDim s i m m' =
+      P.flatBasis (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s) i
+        (finCongr (SectorDecomposition.flatDim_sectorFlatEquiv
+            (P := P) (Q := Q) β hDim τ s).symm m)
+        (finCongr (SectorDecomposition.flatDim_sectorFlatEquiv
+            (P := P) (Q := Q) β hDim τ s).symm m') := by
+  rw [matched_p_basis_eq_cast_flatBasis (P := P) (Q := Q) β hDim τ s,
+      mpsTensor_cast_apply
+        (SectorDecomposition.flatDim_sectorFlatEquiv (P := P) (Q := Q) β hDim τ s)
+        (P.flatBasis (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s))
+        i m m']
+
+/-- `matched_p_weight β τ s = P.flatWeight (sectorFlatEquiv β τ s)`. -/
+private lemma matched_p_weight_eq_flatWeight
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) :
+    matched_p_weight (P := P) (Q := Q) β τ s =
+      P.flatWeight (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s) := by
+  set k : Fin Q.basisCount := (Q.flatIndexEquiv.symm s).1
+  have hsym :
+      P.flatIndexEquiv.symm
+          (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s) =
+        ⟨β k, τ k (Q.flatIndexEquiv.symm s).2⟩ := by
+    rw [SectorDecomposition.sectorFlatEquiv_apply, Equiv.symm_apply_apply]
+  change P.weight (β k) (τ k _) = P.weight _ _
+  rw [hsym]
+
+/-- The matched-coordinate tensor equals the submatrix of `P.toTensor` along
+`sectorFlatDimEquiv` (the sector permutation between flat bond-dim indices). -/
+private lemma matched_toTensor_eq_submatrix
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (i : Fin d) :
+    toTensorFromBlocks (d := d)
+        (μ := matched_p_weight (P := P) (Q := Q) β τ)
+        (matched_p_basis (P := P) (Q := Q) β hDim) i =
+      (P.toTensor i).submatrix
+        (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ)
+        (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ) := by
+  classical
+  -- Unfold both sides to `reindex finSigmaFinEquiv` applied to `blockDiagonal'`.
+  -- Then identify the underlying blockDiagonal matrices via a Σ-level submatrix.
+  ext j₁ j₂
+  -- Decompose j₁, j₂ as flat-Q Σ-indices.
+  obtain ⟨s, m⟩ : (s : Fin Q.totalCopies) × Fin (Q.flatDim s) :=
+    finSigmaFinEquiv.symm j₁
+  obtain ⟨s', m'⟩ : (s' : Fin Q.totalCopies) × Fin (Q.flatDim s') :=
+    finSigmaFinEquiv.symm j₂
+  -- LHS: matched-block-diagonal at (⟨s,m⟩, ⟨s',m'⟩).
+  -- RHS: P-block-diagonal at (σ_Sigma ⟨s,m⟩, σ_Sigma ⟨s',m'⟩) where σ_Sigma is
+  -- the sigma-level equiv induced by sectorFlatDimEquiv.
+  -- Compute both:
+  have hLHS :
+      toTensorFromBlocks (d := d)
+          (μ := matched_p_weight (P := P) (Q := Q) β τ)
+          (matched_p_basis (P := P) (Q := Q) β hDim) i j₁ j₂ =
+        Matrix.blockDiagonal' (fun s : Fin Q.totalCopies =>
+          matched_p_weight (P := P) (Q := Q) β τ s •
+            matched_p_basis (P := P) (Q := Q) β hDim s i)
+          (finSigmaFinEquiv.symm j₁) (finSigmaFinEquiv.symm j₂) := by
+    simp [toTensorFromBlocks, Matrix.reindex_apply, Matrix.submatrix_apply]
+  have hRHS :
+      ((P.toTensor i).submatrix
+            (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ)
+            (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ))
+          j₁ j₂ =
+        Matrix.blockDiagonal' (fun k : Fin P.totalCopies =>
+          P.flatWeight k • P.flatBasis k i)
+          (SectorDecomposition.sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ
+            (finSigmaFinEquiv.symm j₁))
+          (SectorDecomposition.sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ
+            (finSigmaFinEquiv.symm j₂)) := by
+    simp [Matrix.submatrix_apply,
+      SectorDecomposition.sectorFlatDimEquiv_apply,
+      SectorDecomposition.toTensor, toTensorFromBlocks,
+      Matrix.reindex_apply, Equiv.symm_apply_apply]
+  rw [hLHS, hRHS]
+  -- Now compare two blockDiagonal' entries.  Case split on whether the
+  -- Σ-base indices agree.
+  -- finSigmaFinEquiv.symm j₁ = ⟨a, b⟩ for some a, b; we keep the let-binding
+  -- abstract and split on the .fst components.
+  set xs : (s : Fin Q.totalCopies) × Fin (Q.flatDim s) := finSigmaFinEquiv.symm j₁
+  set xs' : (s : Fin Q.totalCopies) × Fin (Q.flatDim s) := finSigmaFinEquiv.symm j₂
+  by_cases hss : xs.1 = xs'.1
+  · -- Diagonal case: identify the matched data with the P-data at the matched sector.
+    rcases xs with ⟨s₀, m₀⟩
+    rcases xs' with ⟨s₀', m₀'⟩
+    simp only at hss
+    subst hss
+    rw [Matrix.blockDiagonal'_apply_eq, SectorDecomposition.sectorFlatSigmaEquiv_apply,
+      SectorDecomposition.sectorFlatSigmaEquiv_apply, Matrix.blockDiagonal'_apply_eq,
+      Matrix.smul_apply, Matrix.smul_apply,
+      matched_p_basis_apply (P := P) (Q := Q) β hDim τ s₀ i m₀ m₀',
+      matched_p_weight_eq_flatWeight (P := P) (Q := Q) β τ s₀]
+  · -- Off-diagonal case: both sides are zero.
+    rcases xs with ⟨s₀, m₀⟩
+    rcases xs' with ⟨s₀', m₀'⟩
+    simp only at hss
+    rw [Matrix.blockDiagonal'_apply_ne _ _ _ hss,
+      SectorDecomposition.sectorFlatSigmaEquiv_apply,
+      SectorDecomposition.sectorFlatSigmaEquiv_apply,
+      Matrix.blockDiagonal'_apply_ne _ _ _ (fun h => hss
+        ((SectorDecomposition.sectorFlatEquiv
+          (P := P) (Q := Q) β τ).injective h))]
+
+/-- The general linear group element associated with a permutation of a finite
+type: realized as the unit whose underlying matrix is `Equiv.Perm.permMatrix σ`
+and whose inverse is `Equiv.Perm.permMatrix σ.symm`. -/
+noncomputable def permGL {n : Type*} [DecidableEq n] [Fintype n]
+    (σ : Equiv.Perm n) : GL n ℂ :=
+  ⟨Equiv.Perm.permMatrix ℂ σ, Equiv.Perm.permMatrix ℂ σ.symm,
+    by
+      have hmul : Equiv.Perm.permMatrix ℂ σ * Equiv.Perm.permMatrix ℂ σ.symm =
+          Equiv.Perm.permMatrix ℂ (σ.symm * σ) :=
+        (Matrix.permMatrix_mul (σ := σ.symm) (τ := σ)).symm
+      rw [hmul]
+      change Equiv.Perm.permMatrix ℂ (σ⁻¹ * σ) = 1
+      rw [inv_mul_cancel]
+      exact Matrix.permMatrix_one,
+    by
+      have hmul : Equiv.Perm.permMatrix ℂ σ.symm * Equiv.Perm.permMatrix ℂ σ =
+          Equiv.Perm.permMatrix ℂ (σ * σ.symm) :=
+        (Matrix.permMatrix_mul (σ := σ) (τ := σ.symm)).symm
+      rw [hmul]
+      change Equiv.Perm.permMatrix ℂ (σ * σ⁻¹) = 1
+      rw [mul_inv_cancel]
+      exact Matrix.permMatrix_one⟩
+
+@[simp]
+theorem permGL_val {n : Type*} [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) :
+    (permGL σ : Matrix n n ℂ) = Equiv.Perm.permMatrix ℂ σ := rfl
+
+@[simp]
+theorem permGL_inv_val {n : Type*} [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) :
+    (((permGL σ)⁻¹ : GL n ℂ) : Matrix n n ℂ) = Equiv.Perm.permMatrix ℂ σ.symm := rfl
+
+/-- Entrywise expansion of `Equiv.Perm.permMatrix`. -/
+private lemma permMatrix_apply' {n : Type*} [DecidableEq n] (σ : Equiv.Perm n)
+    (i j : n) :
+    Equiv.Perm.permMatrix ℂ σ i j = if j = σ i then (1 : ℂ) else 0 := by
+  rw [Equiv.Perm.permMatrix]
+  by_cases h : j = σ i
+  · subst h
+    rw [if_pos rfl, PEquiv.toMatrix_apply, Equiv.toPEquiv_apply]
+    simp
+  · rw [if_neg h, PEquiv.toMatrix_apply, Equiv.toPEquiv_apply]
+    simp only [Option.mem_def, Option.some.injEq, ite_eq_right_iff,
+      one_ne_zero, imp_false]
+    exact fun heq => h heq.symm
+
+/-- Multiplying a matrix on the left by `permMatrix σ` reindexes its rows by `σ`. -/
+private lemma permMatrix_mul_eq_submatrix {n : Type*}
+    [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) (M : Matrix n n ℂ) :
+    Equiv.Perm.permMatrix ℂ σ * M = M.submatrix σ id := by
+  ext i j
+  rw [Matrix.mul_apply, Matrix.submatrix_apply, id]
+  simp_rw [permMatrix_apply', ite_mul, one_mul, zero_mul]
+  rw [Finset.sum_ite_eq' Finset.univ (σ i)]
+  simp
+
+/-- Multiplying a matrix on the right by `permMatrix σ` reindexes its columns by
+`σ.symm`. -/
+private lemma mul_permMatrix_eq_submatrix {n : Type*}
+    [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) (M : Matrix n n ℂ) :
+    M * Equiv.Perm.permMatrix ℂ σ = M.submatrix id σ.symm := by
+  ext i j
+  rw [Matrix.mul_apply, Matrix.submatrix_apply, id]
+  simp_rw [permMatrix_apply', mul_ite, mul_one, mul_zero]
+  -- Rewrite the condition `j = σ x` to `σ.symm j = x` so `sum_ite_eq` applies.
+  have hcond : ∀ x : n, (j = σ x) ↔ (σ.symm j = x) := by
+    intro x
+    constructor
+    · intro h; rw [h]; exact σ.symm_apply_apply x
+    · intro h; rw [← h]; exact (σ.apply_symm_apply j).symm
+  simp_rw [hcond]
+  rw [Finset.sum_ite_eq Finset.univ (σ.symm j)]
+  simp
+
+/-- Conjugating a square matrix by a permutation matrix gives a `submatrix` of
+the original by the permutation index map. -/
+private lemma permMatrix_conj_eq_submatrix {n : Type*}
+    [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) (M : Matrix n n ℂ) :
+    Equiv.Perm.permMatrix ℂ σ * M * Equiv.Perm.permMatrix ℂ σ.symm =
+      M.submatrix σ σ := by
+  rw [permMatrix_mul_eq_submatrix, mul_permMatrix_eq_submatrix,
+    Matrix.submatrix_submatrix]
+  simp
+
+/-- **CPSV16 `II_cor2` literal form (CPSV16 §II.C lines 354–361 / 1184–1192).**
+
+If two paper-faithful BNT sector decompositions generate the same MPV family,
+then their total bond dimensions agree, and there exists an explicit
+$Y \in \mathrm{GL}(Q.\mathrm{totalDim},\mathbb{C})$ realizing the global gauge
+equation
+$$V_Q^i \;=\; Y \,\bigl(\mathrm{cast}\;V_P^i\bigr)\, Y^{-1}$$
+at every physical site $i$, where the inner factor is the bond-dim cast of the
+literal $P$-tensor along the total-dimension equality.
+
+This packages the matched-coordinate gauge equation
+`ft_paper_bnt_equal_mps_gaugeEquiv` (CPSV16 lines 1189–1192) into the verbatim
+II_cor2 statement of CPSV16 §II.C lines 354–361 by composing the matched-coord
+global gauge with the sector-permutation `sectorFlatDimEquiv`.
+
+CPSV16 §II.C lines 354–361. -/
+theorem ft_paper_bnt_equal_mps_gaugeEquiv_literal
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
+      ∀ i : Fin d,
+        Q.toTensor i =
+          (Y : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+            cast (by rw [hTotal] :
+                Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+                Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
+              (P.toTensor i) *
+            (((Y)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+              Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
+  classical
+  obtain ⟨β, hDim, _hCopies, τ, _ζ, _Xblock, _hTotal, X, _, _, _, hGauge⟩ :=
+    ft_paper_bnt_equal_mps_gaugeEquiv_witnesses hP hQ hUnitP hUnitQ hEqual
+  -- Total bond dimensions agree.
+  have hTotal : P.totalDim = Q.totalDim :=
+    SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
+  refine ⟨hTotal, ?_⟩
+  -- Sector-permutation `ρ := sectorFlatDimEquiv ∘ finCongr hTotal` on
+  -- `Fin Q.totalDim`.
+  set ρ : Equiv.Perm (Fin Q.totalDim) :=
+    (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ).trans
+      (finCongr hTotal) with hρ_def
+  -- The witness `X` has type `GL (Fin (∑ s, Q.flatDim s)) ℂ`, which is
+  -- definitionally equal to `GL (Fin Q.totalDim) ℂ` since `totalDim` is a
+  -- reducible def.  Bind `X'` to the same value at the `Q.totalDim` form via
+  -- `let` so that `X' = X` definitionally.
+  let X' : GL (Fin Q.totalDim) ℂ := X
+  refine ⟨X' * permGL ρ, ?_⟩
+  intro i
+  -- (i) `matched_tensor i = (P.toTensor i).submatrix sectorFlatDimEquiv ...`
+  have hsubm := matched_toTensor_eq_submatrix (P := P) (Q := Q) β hDim τ i
+  -- (ii) cast of `P.toTensor i` equals submatrix along `finCongr hTotal.symm`.
+  have hCast :
+      cast (by rw [hTotal] :
+          Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
+        (P.toTensor i) =
+        (P.toTensor i).submatrix (finCongr hTotal.symm) (finCongr hTotal.symm) := by
+    -- The cast of a `Matrix (Fin n) (Fin n) ℂ` along a bond-dim equality
+    -- equals the `submatrix` by `finCongr` of the inverse.
+    have hgen : ∀ (n m : ℕ) (h : n = m) (M : Matrix (Fin n) (Fin n) ℂ),
+        cast (by rw [h] :
+            Matrix (Fin n) (Fin n) ℂ = Matrix (Fin m) (Fin m) ℂ) M =
+          M.submatrix (finCongr h.symm) (finCongr h.symm) := by
+      intro n m h M
+      subst h
+      simp [finCongr]
+    exact hgen P.totalDim Q.totalDim hTotal (P.toTensor i)
+  -- (iii) connect `matched_tensor` to cast via `permMatrix ρ` conjugation.
+  have hPerm :
+      (permGL ρ : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+          cast (by rw [hTotal] :
+              Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+              Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
+            (P.toTensor i) *
+          (((permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+            Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) =
+        toTensorFromBlocks (d := d)
+            (μ := matched_p_weight (P := P) (Q := Q) β τ)
+            (matched_p_basis (P := P) (Q := Q) β hDim) i := by
+    rw [permGL_val, permGL_inv_val, hCast,
+      permMatrix_conj_eq_submatrix ρ
+        ((P.toTensor i).submatrix (finCongr hTotal.symm) (finCongr hTotal.symm)),
+      Matrix.submatrix_submatrix, hsubm]
+    -- The composition `(finCongr hTotal.symm) ∘ ρ` reduces to
+    -- `sectorFlatDimEquiv`; both sides of the equation are then identical
+    -- submatrices of `P.toTensor i`.
+    rfl
+  -- (iv) combine the matched-coord gauge with the sector permutation.
+  -- We have: Q.toTensor i = X * matched * X⁻¹ from hGauge.  Substituting in the
+  -- conjugation `hPerm` gives the desired equation.  Use that `X'` (resp.
+  -- `X'⁻¹`) coerces to the same matrix as `X` (resp. `X⁻¹`).
+  rw [hGauge i, ← hPerm]
+  have hY_inv :
+      (((X' * permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+        Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) =
+        (((permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+        ((X'⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
+    rw [mul_inv_rev]; rfl
+  rw [hY_inv]
+  -- `X` and `X'` are definitionally equal (`X' := X` via `let`); reformulate
+  -- the goal entirely in terms of `X'` before invoking matrix associativity.
+  change (X' : Matrix _ _ ℂ) *
+      ((permGL ρ : Matrix _ _ ℂ) *
+        cast (by rw [hTotal] :
+            Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+            Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) (P.toTensor i) *
+        (((permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)) *
+      ((X'⁻¹ : GL (Fin Q.totalDim) ℂ) :
+        Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) =
+    ((X' : Matrix _ _ ℂ) * (permGL ρ : Matrix _ _ ℂ)) *
+      cast (by rw [hTotal] :
+          Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) (P.toTensor i) *
+      ((((permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+        ((X'⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ))
+  simp only [Matrix.mul_assoc]
+
 end MPSTensor

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -112,7 +112,12 @@ noncomputable def flatBasis (P : SectorDecomposition d) :
     (s : Fin P.totalCopies) → MPSTensor d (P.flatDim s) :=
   fun s ↦ P.basis (P.flatIndexEquiv.symm s).1
 
-/-- Total bond dimension of the flattened block-diagonal tensor. -/
+/-- Total bond dimension of the flattened block-diagonal tensor.
+
+Marked `@[reducible]` so that `Fin P.totalDim` and `Fin (∑ s, P.flatDim s)`
+unify during type-class instance synthesis (needed for the literal
+`GaugeEquiv` packaging that compares matrices indexed by both forms). -/
+@[reducible]
 noncomputable def totalDim (P : SectorDecomposition d) : ℕ :=
   ∑ s : Fin P.totalCopies, P.flatDim s
 
@@ -288,6 +293,70 @@ theorem totalDim_eq_of_match
   change ∑ s' : Fin P.totalCopies, P.flatDim s' =
       ∑ s : Fin Q.totalCopies, Q.flatDim s
   rw [hreindex, hpoint]
+
+/-! ### Σ-level sector permutation between flattened bond-dimension indices
+
+The `sectorFlatEquiv` already permutes the flattened copy index
+`Fin Q.totalCopies ≃ Fin P.totalCopies` and `flatDim_sectorFlatEquiv` certifies
+that the per-flat-copy bond dimensions agree.  The next equivalence packages
+both pieces as a single permutation of the Σ-index that underlies
+`toTensor`/`toTensorFromBlocks`, and induces an equivalence on
+`Fin · .totalDim`.  Both are needed to convert the matched-coordinate gauge
+equation of CPSV16 lines 1189–1192 into the literal cast-of-`P.toTensor`
+form of the II_cor2 statement (CPSV16 §II.C lines 354–361). -/
+
+/-- The Σ-level permutation `Σ s, Fin (Q.flatDim s) ≃ Σ k, Fin (P.flatDim k)`
+induced by the matched basis bijection $β$, copy permutations $τ_k$ and
+matched bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$.
+
+CPSV16 §II.C lines 354–361 / 1184–1192. -/
+noncomputable def sectorFlatSigmaEquiv
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))) :
+    ((s : Fin Q.totalCopies) × Fin (Q.flatDim s)) ≃
+      ((k : Fin P.totalCopies) × Fin (P.flatDim k)) :=
+  Equiv.sigmaCongr (sectorFlatEquiv (P := P) (Q := Q) β τ)
+    (fun s => finCongr
+      (flatDim_sectorFlatEquiv (P := P) (Q := Q) β hDim τ s).symm)
+
+@[simp]
+theorem sectorFlatSigmaEquiv_apply
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) (m : Fin (Q.flatDim s)) :
+    sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ ⟨s, m⟩ =
+      ⟨sectorFlatEquiv (P := P) (Q := Q) β τ s,
+        finCongr (flatDim_sectorFlatEquiv (P := P) (Q := Q) β hDim τ s).symm m⟩ := by
+  rfl
+
+/-- The dim-level equivalence `Fin Q.totalDim ≃ Fin P.totalDim` induced by the
+matched flattened sector data.
+
+CPSV16 §II.C lines 354–361 / 1184–1192. -/
+noncomputable def sectorFlatDimEquiv
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))) :
+    Fin Q.totalDim ≃ Fin P.totalDim :=
+  (finSigmaFinEquiv (m := Q.totalCopies) (n := Q.flatDim)).symm.trans
+    ((sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ).trans
+      (finSigmaFinEquiv (m := P.totalCopies) (n := P.flatDim)))
+
+theorem sectorFlatDimEquiv_apply
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (j : Fin Q.totalDim) :
+    sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ j =
+      finSigmaFinEquiv (sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ
+        (finSigmaFinEquiv.symm j)) := by
+  rfl
 
 end SectorDecomposition
 


### PR DESCRIPTION
## Summary

Adds the literal CPSV16 `II_cor2` statement of gauge equivalence between two paper-faithful BNT canonical forms generating the same MPV family, packaged with the genuine `P.toTensor` (cast to `Q.totalDim` via the total-dim equality) as the inner factor:

```
∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
  ∀ i, Q.toTensor i = Y * cast _ (P.toTensor i) * Y⁻¹
```

This complements the existing matched-coordinate gauge equation `ft_paper_bnt_equal_mps_gaugeEquiv` (whose inner factor is in matched flattened-Q coordinates) by composing the matched-coord global matrix `X` with a sector permutation `permGL ρ`, where `ρ` is the permutation of `Fin Q.totalDim` induced by the flat-sector reindexing.

## Mathematical content

The matched-coordinate tensor `toTensorFromBlocks (matched_p_weight β τ) (matched_p_basis β hDim) i` differs from `P.toTensor i` only by a permutation of the flat-sector $\SigmahBcindex along the bijection
`sectorFlatSigmaEquiv := Equiv.sigmaCongr (sectorFlatEquiv β τ) (fun s => finCongr (flatDim_sectorFlatEquiv β hDim τ s).symm)`,
which lifts to an equivalence `sectorFlatDimEquiv : Fin Q.totalDim ≃ Fin P.totalDim` and, after composing with the bond-dim equality, to a permutation `ρ : Equiv.Perm (Fin Q.totalDim)`.  The matrix conjugation by the permutation matrix of `ρ` realizes the change of coordinates, giving the literal form with `Y = X * permGL ρ`.

## Paper anchors

- CPSV16 §II.C lines 354–361: `II_cor2` statement of gauge equivalence between two BNT canonical forms with the same expectation values.
- CPSV16 §II.C lines 1184–1192: BNT block matching, sector weight identification, and explicit global gauge $X = \bigoplus_k (\mathbb{1}_{r_k} \otimes X_k)$.

## Files changed

- `TNLean/MPS/SharedInfra/SectorDecomposition.lean` (+70 LoC):
  - new `sectorFlatSigmaEquiv` and `sectorFlatDimEquiv` definitions;
  - `totalDim` is now `@[reducible]` so `Fin Q.totalDim` and `Fin (∑ s, Q.flatDim s)` unify during type-class instance synthesis.
- `TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean` (+399 LoC):
  - new `permGL` definition (`Equiv.Perm n → GL n ℂ` via permutation matrices);
  - matrix-element identities `mpsTensor_cast_apply`, `matched_p_basis_eq_cast_flatBasis`, `matched_p_basis_apply`, `matched_p_weight_eq_flatWeight`;
  - intermediate Σ-level identity `matched_toTensor_eq_submatrix`;
  - permutation-matrix conjugation lemmas `permMatrix_mul_eq_submatrix`, `mul_permMatrix_eq_submatrix`, `permMatrix_conj_eq_submatrix`;
  - the literal theorem `ft_paper_bnt_equal_mps_gaugeEquiv_literal`.

## Build

`lake build` is green (8635 jobs).  Both touched files are well under the 1000-LoC cap (570 and 363 lines respectively).

## Constraints

No `sorry`/`axiom`/`unsafe`/`partial` (the existing `noncomputable` pattern for `Matrix`-valued defs is preserved).  No banned vocabulary in newly introduced text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds nontrivial index-casting/permutation and matrix conjugation lemmas and marks `SectorDecomposition.totalDim` as `@[reducible]`, which can affect typeclass unification and downstream proofs even though behavior is unchanged.
> 
> **Overview**
> Implements the *literal* CPSV16 `II_cor2` gauge-equivalence statement `ft_paper_bnt_equal_mps_gaugeEquiv_literal`, expressing `Q.toTensor i = Y * cast (P.toTensor i) * Y⁻¹` with `Y` built from the existing matched-coordinate gauge and an explicit sector-index permutation.
> 
> Adds supporting equivalences `sectorFlatSigmaEquiv`/`sectorFlatDimEquiv` in `SectorDecomposition` plus permutation-matrix/`submatrix` conjugation lemmas and coordinate-identification results showing the matched `toTensorFromBlocks` differs from `P.toTensor` only by this permutation. Also marks `SectorDecomposition.totalDim` as `@[reducible]` to make `Fin P.totalDim` definally align with `Fin (∑ s, P.flatDim s)` in the new packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3022e73c131dd8926329f98e4f4500cfaa52f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->