### PR TITLE
feat(MPS/FT/PaperBNT,CanonicalForm): paper-faithful predicates + prepared-block BNT supplier + ch9 cleanup

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -227,6 +227,7 @@ import TNLean.MPS.FundamentalTheorem.PaperBNT.Api
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Examples
 import TNLean.MPS.FundamentalTheorem.PaperBNT.WeakExistential
 import TNLean.MPS.FundamentalTheorem.PaperBNT.ProportionalMatch
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Supplier
 import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.Applications
 import TNLean.MPS.Structure.InvariantSubspaceDecomp
@@ -241,7 +242,6 @@ import TNLean.MPS.CanonicalForm.SectorComparison.ZeroTailTransport
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData
-import TNLean.MPS.CanonicalForm.PaperBNTSupplier
 import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Periodic.Defs

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -241,6 +241,7 @@ import TNLean.MPS.CanonicalForm.SectorComparison.ZeroTailTransport
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData
+import TNLean.MPS.CanonicalForm.PaperBNTSupplier
 import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Periodic.Defs

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -231,6 +231,7 @@ import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.Applications
 import TNLean.MPS.Structure.InvariantSubspaceDecomp
 import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.MPS.CanonicalForm.PaperDefs
 import TNLean.MPS.CanonicalForm.Existence
 import TNLean.MPS.CanonicalForm.NormalReduction
 import TNLean.MPS.CanonicalForm.CyclicSectors

--- a/TNLean/MPS/CanonicalForm/PaperBNTSupplier.lean
+++ b/TNLean/MPS/CanonicalForm/PaperBNTSupplier.lean
@@ -1,0 +1,237 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.PhaseClassSectorData
+import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
+import TNLean.MPS.Overlap.PeripheralToSpectralGap
+
+/-!
+# Prepared-block PaperBNT constructor
+
+Given a finite family of **already prepared** TP / primitive / irreducible /
+injective blocks with nonzero weights satisfying the CPSV16 §II.A line-246
+normalization (`|μ_k| ≤ 1` and at least one `|μ_k| = 1`), this file produces a
+`SectorDecomposition` `P` together with a proof that
+
+* `P.toTensor` has the same MPV at every length as the original
+  `toTensorFromBlocks μ blocks`, and
+* `P` satisfies `IsBNTCanonicalForm`.
+
+The route is to quotient the block indices by MPV phase equivalence (the
+existing one-sided BNT construction of
+`TNLean.MPS.CanonicalForm.PhaseClassSectorData`), and then to discharge the
+two paper-line-246 normalization fields (`weight_norm_le_one`,
+`weight_unit_exists`) via the unit modulus of the phase-class scalar between
+phase-equivalent TP/primitive/irreducible blocks.
+
+## Paper anchor
+
+* `Papers/1606.00608/MPDO-22-12-17-2.tex:271-301` — BNT existence in the
+  prepared-data setting (`A^i = ⊕_{j,q} μ_{j,q} A_j^i` with normal `A_j` and
+  the §II.A normalization).
+
+## Scout memo
+
+* `audits/2026-05-16_phase_C_feasibility_gpt55.md` §1, §2.3, §2.4 — the
+  feasibility analysis that identified this prepared-block constructor as the
+  pragmatic Phase C target (with the exact-`SameMPV₂` zero-tail and global
+  rescaling issues quarantined behind the prepared-data hypotheses).
+
+## Layering note
+
+This module imports `TNLean.MPS.FundamentalTheorem.PaperBNT.Basic` from the
+`CanonicalForm` directory.  This bridges canonical-form prepared data into
+the `IsBNTCanonicalForm` contract that lives in the fundamental-theorem layer;
+the inversion is intentional and matches the inversion already present at
+`TNLean/MPS/CanonicalForm/PhaseCover.lean:6` and
+`TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean:8`.  It is to be resolved
+in a future SharedInfra reorganization.
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-! ### Unit modulus of the phase-class scalar -/
+
+/--
+**Unit modulus of the phase scalar between phase-equivalent TP / primitive /
+irreducible blocks.**
+
+If `MPVBlockPhaseEquiv X Y` holds and both `X` and `Y` are left-canonical,
+have primitive transfer maps, and are irreducible tensors, then the
+phase scalar `h.choose` has unit norm.
+
+Proof sketch (scout memo §2.4):
+1. The phase equivalence supplies the scaling relation
+   `mpv Y σ = h.choose ^ N * mpv X σ`.
+2. `mpvOverlap_self_scale_of_mpv_eq_pow_mul`
+   (`SharedInfra/GaugePhase.lean`) converts this into a scaling
+   `mpvOverlap Y Y N = (ζ · conj ζ)^N · mpvOverlap X X N`.
+3. Both self-overlaps tend to `1` by
+   `overlap_tendsto_one_of_peripheralPrimitive_of_irreducible`
+   (`Overlap/PeripheralToSpectralGap.lean`).
+4. `norm_eq_one_of_selfOverlap_scale` (`SharedInfra/GaugePhase.lean`)
+   concludes `‖ζ‖ = 1`.
+-/
+lemma norm_choose_MPVBlockPhaseEquiv_eq_one
+    {DX DY : ℕ} [NeZero DX] [NeZero DY]
+    {X : MPSTensor d DX} {Y : MPSTensor d DY}
+    (hTPX : IsLeftCanonical X)
+    (hTPY : IsLeftCanonical Y)
+    (hPrimX : _root_.IsPrimitive (transferMap (d := d) (D := DX) X))
+    (hPrimY : _root_.IsPrimitive (transferMap (d := d) (D := DY) Y))
+    (hIrrX : IsIrreducibleTensor X)
+    (hIrrY : IsIrreducibleTensor Y)
+    (h : MPVBlockPhaseEquiv X Y) :
+    ‖h.choose‖ = 1 := by
+  classical
+  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv Y σ = h.choose ^ N * mpv X σ := h.choose_spec.2
+  have hScale :
+      ∀ N : ℕ,
+        mpvOverlap (d := d) Y Y N =
+          (h.choose * starRingEnd ℂ h.choose) ^ N * mpvOverlap (d := d) X X N :=
+    mpvOverlap_self_scale_of_mpv_eq_pow_mul
+      (A := X) (B := Y) (ζ := h.choose) hmpv
+  have hXX_c : Tendsto (fun N => mpvOverlap (d := d) X X N) atTop (𝓝 (1 : ℂ)) :=
+    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      (d := d) (D := DX) X hIrrX hTPX hPrimX
+  have hYY_c : Tendsto (fun N => mpvOverlap (d := d) Y Y N) atTop (𝓝 (1 : ℂ)) :=
+    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      (d := d) (D := DY) Y hIrrY hTPY hPrimY
+  have hXX : Tendsto (fun N => ‖mpvOverlap (d := d) X X N‖) atTop (𝓝 (1 : ℝ)) := by
+    have h1 := hXX_c.norm
+    simpa using h1
+  have hYY : Tendsto (fun N => ‖mpvOverlap (d := d) Y Y N‖) atTop (𝓝 (1 : ℝ)) := by
+    have h1 := hYY_c.norm
+    simpa using h1
+  exact norm_eq_one_of_selfOverlap_scale hXX hYY hScale
+
+/-! ### Prepared-block PaperBNT constructor -/
+
+/--
+**Prepared-block PaperBNT constructor.**
+
+Given a finite family of TP, primitive, irreducible, injective blocks with
+nonzero weights satisfying the PaperBNT normalization conditions, produce a
+`SectorDecomposition P` and a proof that `IsBNTCanonicalForm P` and the
+assembled tensor agrees with the original direct sum.
+
+Paper anchor: `Papers/1606.00608/MPDO-22-12-17-2.tex:271-301` (BNT existence
+in the prepared-data setting).
+-/
+theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hDim : ∀ k, 0 < dim k)
+    (hTP : ∀ k, IsLeftCanonical (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (blocks k)))
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hInj : ∀ k, IsInjective (blocks k))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hμLe : ∀ k, ‖μ k‖ ≤ 1)
+    (hμUnit : ∃ k, ‖μ k‖ = 1) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      IsBNTCanonicalForm P := by
+  classical
+  -- Promote `0 < dim k` to a `NeZero (dim k)` typeclass instance.
+  haveI : ∀ k, NeZero (dim k) := fun k => ⟨(hDim k).ne'⟩
+  set classes := mpvPhaseClassData (d := d) blocks with hclasses
+  -- Concrete sector decomposition from phase-class representatives.
+  set P := collapsedBntSectorDecomp (d := d) μ blocks hμne with hP
+  -- The phase scalar attached to each phase-class member.
+  set ζFn : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
+    fun j q => (classes.enum_phase j q).choose with hζFn
+  -- Phase-scalar nonvanishing.
+  have hζ_ne : ∀ j q, ζFn j q ≠ 0 :=
+    fun j q => (classes.enum_phase j q).choose_spec.1
+  -- Phase-scalar unit modulus (TP + primitive + irreducible on both blocks).
+  have hζ_unit : ∀ j q, ‖ζFn j q‖ = 1 := by
+    intro j q
+    have hPE :
+        MPVBlockPhaseEquiv (blocks (classes.repr j)) (blocks (classes.enum j q)) :=
+      classes.enum_phase j q
+    exact
+      norm_choose_MPVBlockPhaseEquiv_eq_one
+        (X := blocks (classes.repr j)) (Y := blocks (classes.enum j q))
+        (hTP (classes.repr j)) (hTP (classes.enum j q))
+        (hPrim (classes.repr j)) (hPrim (classes.enum j q))
+        (hIrr (classes.repr j)) (hIrr (classes.enum j q))
+        hPE
+  -- Same-MPV with the original direct-sum tensor.
+  have hSame : SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) :=
+    collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
+  -- HasBNTSectorData.
+  have hBNT : HasBNTSectorData (d := d) P :=
+    collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
+  -- Per-block fields.
+  have h_dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j := by
+    intro j
+    -- `P.basisDim j` is definitionally `dim (classes.repr j)`.
+    change 0 < dim (classes.repr j)
+    exact hDim (classes.repr j)
+  have h_inj : ∀ j : Fin P.basisCount, IsInjective (P.basis j) := by
+    intro j; change IsInjective (blocks (classes.repr j)); exact hInj (classes.repr j)
+  have h_irr : ∀ j : Fin P.basisCount, IsIrreducibleTensor (P.basis j) := by
+    intro j; change IsIrreducibleTensor (blocks (classes.repr j)); exact hIrr (classes.repr j)
+  have h_lc : ∀ j : Fin P.basisCount, IsLeftCanonical (P.basis j) := by
+    intro j; change IsLeftCanonical (blocks (classes.repr j)); exact hTP (classes.repr j)
+  have h_self_overlap : ∀ j : Fin P.basisCount,
+      Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
+        atTop (𝓝 (1 : ℂ)) := by
+    intro j
+    change
+      Tendsto (fun N : ℕ => mpvOverlap (d := d) (blocks (classes.repr j))
+        (blocks (classes.repr j)) N) atTop (𝓝 (1 : ℂ))
+    exact
+      overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+        (d := d) (D := dim (classes.repr j))
+        (blocks (classes.repr j))
+        (hIrr (classes.repr j)) (hTP (classes.repr j)) (hPrim (classes.repr j))
+  have h_distinct : ∀ j k : Fin P.basisCount, j ≠ k →
+      ∀ h : P.basisDim j = P.basisDim k,
+        ¬ GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) h) (P.basis j)) (P.basis k) := by
+    intro j k hjk hdim
+    -- `P.basisDim j = dim (classes.repr j)` definitionally; ditto for basis.
+    exact classes.blocks_not_equiv j k hjk hdim
+  -- Weight-norm fields (line 246 normalization).
+  have h_weight_le : ∀ (j : Fin P.basisCount) (q : Fin (P.copies j)),
+      ‖P.weight j q‖ ≤ 1 := by
+    intro j q
+    -- `P.weight j q` is definitionally `ζFn j q * μ (classes.enum j q)`.
+    change ‖ζFn j q * μ (classes.enum j q)‖ ≤ 1
+    have := hμLe (classes.enum j q)
+    calc ‖ζFn j q * μ (classes.enum j q)‖
+        = ‖ζFn j q‖ * ‖μ (classes.enum j q)‖ := norm_mul _ _
+      _ = 1 * ‖μ (classes.enum j q)‖ := by rw [hζ_unit j q]
+      _ = ‖μ (classes.enum j q)‖ := one_mul _
+      _ ≤ 1 := this
+  have h_weight_unit : ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
+      ‖P.weight j q‖ = 1 := by
+    obtain ⟨k0, hk0⟩ := hμUnit
+    obtain ⟨j, q, hjq⟩ := classes.exists_enum_eq k0
+    refine ⟨j, q, ?_⟩
+    change ‖ζFn j q * μ (classes.enum j q)‖ = 1
+    rw [hjq]
+    rw [norm_mul, hζ_unit j q, one_mul, hk0]
+  refine ⟨P, hSame, ?_⟩
+  exact
+    { basis_dim_pos := h_dim_pos
+      basis_injective := h_inj
+      basis_irreducible := h_irr
+      basis_left_canonical := h_lc
+      basis_normalized_self_overlap := h_self_overlap
+      bnt_data := hBNT
+      basis_distinct := h_distinct
+      weight_norm_le_one := h_weight_le
+      weight_unit_exists := h_weight_unit }
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/PaperDefs.lean
+++ b/TNLean/MPS/CanonicalForm/PaperDefs.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.MPS.Core.Transfer
+import TNLean.MPS.Overlap.Basic
+import TNLean.MPS.SharedInfra.BlockAssembly
+import TNLean.Channel.Peripheral.Spectrum
+
+/-!
+# Paper-faithful definitions: NT, CF, BNT (CPSV16)
+
+This module records the **paper-faithful** definitions of the three central notions
+from arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete, "Matrix product density
+operators: Renormalization fixed points and boundary theories"):
+
+* normal tensor (NT), `MPSTensor.IsNormalTensor`,
+* canonical form (CF), `MPSTensor.IsCanonicalFormPaper`, and
+* basis of normal tensors (BNT), `MPSTensor.IsBNTPaper`.
+
+The existing TNLean canonical-form layer (`TNLean.PiAlgebra.CanonicalFormSepAux`,
+`TNLean.MPS.BNT.Construction`) ships several *strengthenings* of these definitions
+(adding left-canonical normalization, strict modulus ordering, one-copy-per-sector,
+etc.) that are convenient for downstream FT proofs but drift from the paper text.
+The predicates here are the literal source-paper formulations.
+
+## Paper anchors
+
+* `MPSTensor.IsNormalTensor`: `Papers/1606.00608/MPDO-22-12-17-2.tex:233-235`
+  (Definition: NT is no nontrivial invariant projector + unique modulus-1
+  eigenvalue of the associated CPM equal to its spectral radius equal to one).
+* `MPSTensor.IsCanonicalFormPaper`: `Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`
+  (Definition: CF is `A^i = ⊕_k μ_k A_k^i` with each `A_k` normal; combined with
+  the normalization paragraph at line 246: `|μ_k| ≤ 1` and at least one `|μ_k| = 1`).
+* `MPSTensor.IsBNTPaper`: `Papers/1606.00608/MPDO-22-12-17-2.tex:271-274`
+  (Definition: BNT `{A_j}` of `A` is `A_j` all normal, MPV family of `A`
+  spanned by MPV families of the `A_j` at every length, and eventually linearly
+  independent).
+
+## Reuse of existing primitive-channel API
+
+CPSV16's clause "the associated CPM has a unique eigenvalue of magnitude
+equal to its spectral radius which is equal to one" is the standard
+*primitive transfer map* condition. We reuse `_root_.IsPrimitive`
+(`TNLean.Channel.Peripheral.Spectrum`), which states that the peripheral
+eigenvalue set equals `{1}`. This matches the paper after the spectral-radius
+normalization the paper assumes (cf. `MPDO-22-12-17-2.tex:231`, the block-then-
+renormalize paragraph immediately preceding Definition NT).
+
+The TN-Review formulation (`Papers/2011.12127/TN-Review-main.tex:1827-1830`)
+"the transfer operator is a primitive channel" is the same clause and is not
+duplicated.
+
+## Bridges to existing strong predicates
+
+One light bridge is provided:
+
+* `MPSTensor.IsNormalTensor.of_irreducible_and_primitive` —
+  package an `IsIrreducibleTensor` proof with a primitive-transfer-map proof.
+
+Two further bridges are intentionally **not** provided here, in keeping with the
+"clean layer, no `sorry`" quality bar:
+
+* A CF bridge `IsCanonicalFormPaper.of_isNormalCanonicalForm` would need to import
+  `TNLean.PiAlgebra.CanonicalFormSepAux` which transitively imports
+  `TNLean.MPS.FundamentalTheorem.*`; we keep `PaperDefs.lean` in a clean pre-FT
+  layer. Such a bridge belongs in a separate downstream file.
+* A BNT bridge `IsBNTPaper.of_isBNT` would require the implication
+  `MPSTensor.IsNormal → IsNormalTensor` per block, i.e. from algebraic eventual
+  block injectivity to the CPSV16 (no-invariant-proj + primitive-transfer)
+  formulation. That equivalence requires Wielandt-style spectral arguments not
+  packaged at this layer.
+
+## Style
+
+Follows `docs/MATHLIB_style.md` and `docs/MATHLIB_naming.md`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ## Normal tensor (NT) -/
+
+/--
+`MPSTensor.IsNormalTensor A` is the paper-faithful **normal tensor** predicate from
+arXiv:1606.00608, Definition before eq. `II_CF1` (`Papers/1606.00608/MPDO-22-12-17-2.tex:233-235`):
+
+* (i) `A` admits no nontrivial invariant orthogonal projection, and
+* (ii) the associated CPM (the transfer map `E_A(X) = ∑_i A_i X A_i^†`) has a unique
+  eigenvalue of magnitude equal to its spectral radius which is equal to one.
+
+Clause (ii) is encoded via `_root_.IsPrimitive (transferMap A)`, which states that the
+peripheral eigenvalue set of the transfer map is exactly `{1}`. Combined with the
+implicit spectral-radius normalization the paper assumes (cf. `MPDO-22-12-17-2.tex:231`),
+this is the source-faithful formulation.
+
+This predicate is intentionally *weaker* than the TNLean strong predicate
+`MPSTensor.IsCanonicalFormSepAux.IsNormalCanonicalForm` (it does not require
+left-canonical normalization, weight ordering, or positive bond dimension).
+-/
+structure IsNormalTensor (A : MPSTensor d D) : Prop where
+  /-- (i) no nontrivial invariant orthogonal projection. -/
+  no_invariant_proj : IsIrreducibleTensor A
+  /-- (ii) the associated CPM has a unique eigenvalue of magnitude equal to its
+  spectral radius equal to one (primitive transfer map). -/
+  primitive_transfer : _root_.IsPrimitive (transferMap (d := d) (D := D) A)
+
+/-- Bridge: an irreducible tensor whose transfer map is primitive is a CPSV16 normal tensor. -/
+theorem IsNormalTensor.of_irreducible_and_primitive
+    {A : MPSTensor d D}
+    (hIrr : IsIrreducibleTensor A)
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A)) :
+    IsNormalTensor A :=
+  { no_invariant_proj := hIrr
+    primitive_transfer := hPrim }
+
+/-! ## Canonical form (CF) -/
+
+/--
+`MPSTensor.CanonicalFormPaperData A` is the data of a paper-faithful canonical-form
+decomposition of `A` from arXiv:1606.00608 eq. `II_CF1` plus the normalization paragraph
+immediately following (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`):
+
+* a number `r` of blocks,
+* per-block bond dimensions `dim k`,
+* per-block weights `weights k : ℂ`,
+* per-block tensors `blocks k : MPSTensor d (dim k)`, each normal,
+* an MPV-equality witness `A^i = ⊕_k weights k • blocks k^i` (encoded as
+  `SameMPV₂ A (toTensorFromBlocks weights blocks)`),
+* modulus normalization `‖weights k‖ ≤ 1` for all `k`, and at least one `‖weights k‖ = 1`.
+
+This is **data** (a `Type`); the propositional version is `IsCanonicalFormPaper` below.
+-/
+structure CanonicalFormPaperData (A : MPSTensor d D) where
+  /-- Number of blocks `r` in the direct-sum decomposition `A^i = ⊕_{k=1}^r μ_k A_k^i`. -/
+  r : ℕ
+  /-- Bond dimensions of the blocks `dim k = D_k`. -/
+  dim : Fin r → ℕ
+  /-- Block weights `μ k` of the decomposition. -/
+  weights : Fin r → ℂ
+  /-- Per-block MPS tensors `A_k`. -/
+  blocks : (k : Fin r) → MPSTensor d (dim k)
+  /-- `A` and the direct sum `⊕_k μ_k A_k` have the same MPV family at every length. -/
+  sameMPV : SameMPV₂ A (toTensorFromBlocks (d := d) weights blocks)
+  /-- Each block `A_k` is a CPSV16 normal tensor. -/
+  blocks_normal : ∀ k, IsNormalTensor (blocks k)
+  /-- Modulus normalization (`MPDO-22-12-17-2.tex:246`): every weight has modulus at most one. -/
+  weight_norm_le_one : ∀ k, ‖weights k‖ ≤ 1
+  /-- Modulus normalization (`MPDO-22-12-17-2.tex:246`): at least one weight has unit modulus. -/
+  weight_unit_exists : ∃ k, ‖weights k‖ = 1
+
+/--
+`MPSTensor.IsCanonicalFormPaper A` is the propositional paper-faithful **canonical form**
+predicate (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`): `A` admits a normal-block
+direct-sum decomposition with weights normalized to `|μ_k| ≤ 1` and at least one
+`|μ_k| = 1`.
+
+This is `Nonempty (CanonicalFormPaperData A)` — i.e. existence of a paper-CF
+decomposition witness.
+-/
+def IsCanonicalFormPaper (A : MPSTensor d D) : Prop :=
+  Nonempty (CanonicalFormPaperData A)
+
+/-- Promote a paper-CF data witness to the propositional predicate. -/
+theorem IsCanonicalFormPaper.of_data
+    {A : MPSTensor d D} (h : CanonicalFormPaperData A) :
+    IsCanonicalFormPaper A :=
+  ⟨h⟩
+
+/-! ## Basis of normal tensors (BNT) -/
+
+/--
+`MPSTensor.IsBNTPaper A blocks` is the paper-faithful **basis of normal tensors** predicate
+from arXiv:1606.00608, Definition `prop:char-BNT` is preceded by the BNT definition at
+`Papers/1606.00608/MPDO-22-12-17-2.tex:271-274`:
+
+* (i) each `blocks j` is a CPSV16 normal tensor,
+* (ii) for each system length `N`, the MPV family of `A` is in the linear span of
+      the MPV families `{V^{(N)}(blocks j)}_j`, and
+* (iii) there is some `N₀` such that for all `N > N₀`, the MPV states
+      `mpvState (blocks j) N` are linearly independent.
+
+Here `blocks` is a heterogeneous family `(j : Fin g) → Σ Dj, MPSTensor d Dj` to allow
+different per-block bond dimensions.
+-/
+structure IsBNTPaper {g : ℕ} (A : MPSTensor d D)
+    (blocks : (j : Fin g) → Σ Dj : ℕ, MPSTensor d Dj) : Prop where
+  /-- (i) each basis tensor `A_j` is a CPSV16 normal tensor. -/
+  blocks_normal : ∀ j, IsNormalTensor (blocks j).2
+  /-- (ii) at every length `N`, the MPV family of `A` is a linear combination of
+  the per-block MPV families. -/
+  spans_mpv : ∀ N : ℕ, ∃ c : Fin g → ℂ,
+    ∀ σ : Fin N → Fin d, mpv A σ = ∑ j : Fin g, c j * mpv (blocks j).2 σ
+  /-- (iii) eventually, the MPV states of the basis are linearly independent. -/
+  eventually_li : ∃ N₀ : ℕ, ∀ N > N₀,
+    LinearIndependent ℂ (fun j : Fin g => mpvState (d := d) (blocks j).2 N)
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -5,10 +5,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.BNT.Construction
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
-import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 import TNLean.MPS.Overlap.CastDecay
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.SharedInfra.GaugePhase
+import TNLean.MPS.SharedInfra.SectorDecomposition
 import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.Spectral.SpectralGapNT
 

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -30,8 +30,13 @@ variable {d : ℕ}
 
 /-! ### Phase-class quotient construction -/
 
-/-- The concrete sector decomposition obtained from representatives of MPV phase classes. -/
-private noncomputable def collapsedBntSectorDecomp
+/-- The concrete sector decomposition obtained from representatives of MPV phase classes.
+
+Made non-`private` so the prepared-block PaperBNT constructor
+(`TNLean.MPS.CanonicalForm.PaperBNTSupplier`) can construct an
+`IsBNTCanonicalForm P` directly on top of this concrete `P`, with full access
+to the underlying phase-class representatives. -/
+noncomputable def collapsedBntSectorDecomp
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -54,7 +59,10 @@ private noncomputable def collapsedBntSectorDecomp
     sectors := sectors
   }
 
-private theorem collapsedBntSectorDecomp_sameMPV₂
+/-- The total tensor of `collapsedBntSectorDecomp` has the same MPV at every length
+as the original `toTensorFromBlocks μ blocks`.  Exposed (was previously `private`)
+for the prepared-block PaperBNT constructor. -/
+theorem collapsedBntSectorDecomp_sameMPV₂
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -92,7 +100,9 @@ private theorem collapsedBntSectorDecomp_sameMPV₂
             symm
             simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
 
-private theorem collapsedBntSectorDecomp_hasBNT
+/-- `collapsedBntSectorDecomp` carries `HasBNTSectorData`.  Exposed (was previously
+`private`) for the prepared-block PaperBNT constructor. -/
+theorem collapsedBntSectorDecomp_hasBNT
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -33,7 +33,7 @@ variable {d : ℕ}
 /-- The concrete sector decomposition obtained from representatives of MPV phase classes.
 
 Made non-`private` so the prepared-block PaperBNT constructor
-(`TNLean.MPS.CanonicalForm.PaperBNTSupplier`) can construct an
+(`TNLean.MPS.FundamentalTheorem.PaperBNT.Supplier`) can construct an
 `IsBNTCanonicalForm P` directly on top of this concrete `P`, with full access
 to the underlying phase-class representatives. -/
 noncomputable def collapsedBntSectorDecomp

--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.BNT.Construction
-import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.SharedInfra.GaugePhase
+import TNLean.MPS.SharedInfra.SectorDecomposition
 
 open scoped Matrix BigOperators
 open Filter

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -101,16 +101,6 @@ noncomputable def flatKey (F : CommonBlockedCyclicSectorFamily blocks)
     (x : Fin (∑ k : Fin r, F.period k)) : (k : Fin r) × Fin (F.period k) :=
   finSigmaFinEquiv.symm x
 
-/-- Encode one original block and one of its cyclic sectors as a flattened sector index. -/
-noncomputable def flatIndexOf (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) (s : Fin (F.period k)) : Fin (∑ k : Fin r, F.period k) :=
-  finSigmaFinEquiv (Sigma.mk k s)
-
-/-- The flattened sector chosen as the representative for one original block. -/
-noncomputable def flatRepresentativeIndex (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) : Fin (∑ k : Fin r, F.period k) :=
-  F.flatIndexOf k ⟨0, F.period_pos k⟩
-
 /-- The flattened sectors produced by `CommonBlockedCyclicSectorFamily` carry unit weights. -/
 def flatWeight (F : CommonBlockedCyclicSectorFamily blocks) :
     Fin (∑ k : Fin r, F.period k) → ℂ :=

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveBlockMatchingData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveBlockMatchingData.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.SectorComparison.StructuralTheorem
 import TNLean.MPS.CanonicalForm.PhaseCover
-import TNLean.MPS.FundamentalTheorem.Multi
+import TNLean.MPS.SharedInfra.BlockGauge
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveBlockMatchingData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveBlockMatchingData.lean
@@ -173,69 +173,6 @@ theorem toSpanHypotheses
 
 end CommonPrimitiveBlockMatchingHypotheses
 
-/-! ### Zero-tail equality from block matching -/
-
-/-- At length zero, a block-diagonal tensor contributes the sum of the block dimensions. -/
-private theorem mpv_toTensorFromBlocks_zero_eq_sum_dim
-    {d r : ℕ} {dim : Fin r → ℕ}
-    (μ : Fin r → ℂ) (blocks : (x : Fin r) → MPSTensor d (dim x))
-    (σ : Fin 0 → Fin d) :
-    mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ =
-      ∑ x : Fin r, (dim x : ℂ) := by
-  rw [mpv_toTensorFromBlocks_eq_sum]
-  refine Finset.sum_congr rfl fun x _ => ?_
-  simp [mpv, coeff, Matrix.trace_one]
-
-/-- A BNT block matching identifies the total nonzero bond dimensions. -/
-private theorem sum_dim_eq_of_blockPermutationGaugePhaseConclusion
-    {d rA rB : ℕ} {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    {blocksA : (x : Fin rA) → MPSTensor d (dimA x)}
-    {blocksB : (x : Fin rB) → MPSTensor d (dimB x)}
-    (hMatch : BlockPermutationGaugePhaseConclusion (d := d) blocksA blocksB) :
-    (∑ x : Fin rA, (dimA x : ℂ)) = ∑ y : Fin rB, (dimB y : ℂ) := by
-  rcases hMatch with ⟨_, perm, hmatch⟩
-  calc
-    (∑ x : Fin rA, (dimA x : ℂ)) =
-        ∑ x : Fin rA, (dimB (perm x) : ℂ) := by
-          refine Finset.sum_congr rfl fun x _ => ?_
-          obtain ⟨hdim, _⟩ := hmatch x
-          simp [hdim]
-    _ = ∑ y : Fin rB, (dimB y : ℂ) := by
-          let f : Fin rA → ℂ := fun x => (dimB (perm x) : ℂ)
-          let g : Fin rB → ℂ := fun y => (dimB y : ℂ)
-          have hfg : ∀ x, f x = g (perm x) := fun _ => rfl
-          simpa [f, g] using (Fintype.sum_equiv perm f g hfg)
-
-/-- The length-zero identity and block matching force equal zero-tail dimensions.
-
-The structural theorem already supplies the length-zero equation for the two zero-tail plus
-nonzero-sector decompositions. A BNT block-matching conclusion matches the nonzero blocks by
-a permutation with equal bond dimensions, so the nonzero length-zero contributions cancel. -/
-theorem zeroTail_eq_of_blockPermutationGaugePhaseConclusion
-    {d rA rB zeroTailA zeroTailB : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    {μA : Fin rA → ℂ} {μB : Fin rB → ℂ}
-    {blocksA : (x : Fin rA) → MPSTensor d (dimA x)}
-    {blocksB : (x : Fin rB) → MPSTensor d (dimB x)}
-    (hZero : ∀ σ : Fin 0 → Fin d,
-      (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ =
-        (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ)
-    (hMatch : BlockPermutationGaugePhaseConclusion (d := d) blocksA blocksB) :
-    zeroTailA = zeroTailB := by
-  let σ : Fin 0 → Fin d := Fin.elim0
-  have hsum :=
-    sum_dim_eq_of_blockPermutationGaugePhaseConclusion
-      (d := d) (blocksA := blocksA) (blocksB := blocksB) hMatch
-  have hzero := hZero σ
-  rw [mpv_toTensorFromBlocks_zero_eq_sum_dim μA blocksA σ,
-    mpv_toTensorFromBlocks_zero_eq_sum_dim μB blocksB σ] at hzero
-  have hzero' :
-      (zeroTailA : ℂ) + ∑ y : Fin rB, (dimB y : ℂ) =
-        (zeroTailB : ℂ) + ∑ y : Fin rB, (dimB y : ℂ) := by
-    simpa [hsum] using hzero
-  exact Nat.cast_inj.mp (add_right_cancel hzero')
-
-
 /-! ### Per-block to global proportional gauge
 
 The per-block matchers from `BlockPermutationGaugePhaseConclusion` produce, for every

--- a/TNLean/MPS/FundamentalTheorem/Multi.lean
+++ b/TNLean/MPS/FundamentalTheorem/Multi.lean
@@ -1,4 +1,5 @@
 import TNLean.MPS.SharedInfra.BlockAssembly
+import TNLean.MPS.SharedInfra.BlockGauge
 import TNLean.MPS.FundamentalTheorem.Basic
 
 import Mathlib.Algebra.BigOperators.Fin
@@ -21,44 +22,16 @@ For each block index `k`, the injective MPV theorem gives an invertible matrix
 `A k` and `B k` generate the same MPV family.  The direct-sum formula above then
 uses the block-diagonal matrix `⊕_k X k` for
 `toTensorFromBlocks μ A = ⊕_k μ_k A_k`.
+
+The block-diagonal `GL` constructors `blockDiagonalGL` and `globalGaugeOfBlocks`
+and the direct-sum conjugation identity
+`toTensorFromBlocks_eq_globalGaugeOfBlocks_conj` are pure linear-algebra
+plumbing and have been moved to `TNLean.MPS.SharedInfra.BlockGauge` so that
+canonical-form modules can use them without inverting the layer order.  They
+are re-exported here transitively through the import above.
 -/
 
 variable {d : ℕ}
-
-/-! ## Block-diagonal invertible matrices -/
-
-section BlockDiagonalGL
-
-variable {r : ℕ} {dim : Fin r → ℕ}
-
-private theorem blockDiagonal'_mul_one
-    (f g : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
-    (hfg : ∀ k, f k * g k = 1) :
-    Matrix.blockDiagonal' f * Matrix.blockDiagonal' g = 1 := by
-  rw [← Matrix.blockDiagonal'_mul, show (fun k => f k * g k) = 1 from funext hfg,
-    Matrix.blockDiagonal'_one]
-
-/-- Form a block-diagonal element of `GL` from a family of invertible matrices. -/
-noncomputable def blockDiagonalGL (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
-    GL ((k : Fin r) × Fin (dim k)) ℂ :=
-  ⟨Matrix.blockDiagonal' (fun k => (X k : Matrix _ _ ℂ)),
-   Matrix.blockDiagonal' (fun k => ((X k)⁻¹ : Matrix _ _ ℂ)),
-   blockDiagonal'_mul_one _ _ (fun k => by simp),
-   blockDiagonal'_mul_one _ _ (fun k => by simp)⟩
-
-/-- Assemble per-block gauges into the flattened global `GL` element used by
-`toTensorFromBlocks`.  This is the reindexed block-diagonal matrix `⊕ₖ X k` on the
-canonical `Fin (∑ k, dim k)` bond index, naming the global gauge `X = ⊕ₖ X k`
-that arises after the BNT block matching.
-
-Reference: arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192). -/
-noncomputable def globalGaugeOfBlocks (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
-    GL (Fin (∑ k : Fin r, dim k)) ℂ :=
-  Units.map
-    (Matrix.reindexAlgEquiv ℂ ℂ (finSigmaFinEquiv (n := dim))).toRingEquiv.toMonoidHom
-    (blockDiagonalGL X)
-
-end BlockDiagonalGL
 
 /-! ## Gauge equivalence for direct sums -/
 
@@ -67,59 +40,6 @@ section GaugeConstruction
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable (μ : Fin r → ℂ)
 variable (A B : (k : Fin r) → MPSTensor d (dim k))
-
-/-- Direct conjugation formula for weighted direct sums.
-
-If `B k i = X k * A k i * (X k)⁻¹` for every `k, i`, then for every `i`,
-`toTensorFromBlocks μ B i = (⊕ X) * toTensorFromBlocks μ A i * (⊕ X)⁻¹`,
-where `⊕ X = globalGaugeOfBlocks X` is the reindexed block-diagonal gauge.
-
-Reference: arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192). -/
-theorem toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
-    (X : (k : Fin r) → GL (Fin (dim k)) ℂ)
-    (hX : ∀ k : Fin r, ∀ i : Fin d,
-      B k i =
-        (X k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) * A k i *
-          (((X k)⁻¹ : GL (Fin (dim k)) ℂ) : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) :
-    ∀ i : Fin d,
-      toTensorFromBlocks (d := d) (μ := μ) B i =
-        (globalGaugeOfBlocks X : Matrix (Fin (∑ k : Fin r, dim k))
-          (Fin (∑ k : Fin r, dim k)) ℂ) *
-          toTensorFromBlocks (d := d) (μ := μ) A i *
-          (((globalGaugeOfBlocks X)⁻¹ : GL (Fin (∑ k : Fin r, dim k)) ℂ) :
-            Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ) := by
-  classical
-  intro i
-  let α := (k : Fin r) × Fin (dim k)
-  let e : α ≃ Fin (∑ k : Fin r, dim k) := finSigmaFinEquiv
-  let f : Matrix α α ℂ →* Matrix (Fin _) (Fin _) ℂ :=
-    (Matrix.reindexAlgEquiv ℂ ℂ e).toRingEquiv.toMonoidHom
-  let BD := fun (T : (k : Fin r) → MPSTensor d (dim k)) =>
-    Matrix.blockDiagonal' fun k => (μ k) • T k i
-  let XBD : Matrix α α ℂ :=
-    Matrix.blockDiagonal' fun k => (X k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
-  let XBDinv : Matrix α α ℂ :=
-    Matrix.blockDiagonal' fun k => ((X k)⁻¹ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
-  have htoA : toTensorFromBlocks (d := d) (μ := μ) A i = f (BD A) := by
-    simp [toTensorFromBlocks, BD, f, e]
-  have htoB : toTensorFromBlocks (d := d) (μ := μ) B i = f (BD B) := by
-    simp [toTensorFromBlocks, BD, f, e]
-  have hBD : BD B = XBD * BD A * XBDinv := by
-    simp only [BD, XBD, XBDinv]
-    have : (fun k : Fin r => (μ k) • B k i) =
-        fun k => (X k : Matrix _ _ ℂ) * ((μ k) • A k i) * ((X k)⁻¹ : Matrix _ _ ℂ) := by
-      funext k; simp [hX k i, Algebra.mul_smul_comm, Algebra.smul_mul_assoc, Matrix.mul_assoc]
-    rw [this, ← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
-  have hXfin :
-      (globalGaugeOfBlocks X : Matrix (Fin (∑ k : Fin r, dim k))
-        (Fin (∑ k : Fin r, dim k)) ℂ) = f XBD := by
-    simp [globalGaugeOfBlocks, XBD, blockDiagonalGL, f, e]
-  have hXfin_inv :
-      (((globalGaugeOfBlocks X)⁻¹ : GL (Fin (∑ k : Fin r, dim k)) ℂ) :
-        Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ) = f XBDinv := by
-    simp [globalGaugeOfBlocks, XBDinv, blockDiagonalGL, f, e]
-  rw [htoB, htoA, hBD]
-  simp [map_mul, hXfin, hXfin_inv, Matrix.mul_assoc]
 
 /-- If `B_k^i = X_k A_k^i X_k⁻¹` for every block, then the weighted direct sums
 are gauge equivalent by the block-diagonal matrix `⊕_k X_k`. -/

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
@@ -168,4 +168,403 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv
   exact ⟨SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ,
     β, hDim, τ, X, hGauge⟩
 
+/-! ## Coordinate identification between matched and literal blocks
+
+The matched-coordinate `toTensorFromBlocks` and the literal `P.toTensor`
+differ only by a $\Sigma$-level permutation of flattened sector indices
+along `sectorFlatSigmaEquiv`; equivalently a permutation of
+`Fin Q.totalDim` (after the bond-dimension equality) by
+`sectorFlatDimEquiv`.  This lets us upgrade
+`ft_paper_bnt_equal_mps_gaugeEquiv` from the matched-coordinate form to the
+literal CPSV16 II_cor2 form (CPSV16 §II.C lines 354–361). -/
+
+/-- Cast of an `MPSTensor` along a bond-dimension equality, evaluated at one
+physical site and two bond indices, equals the underlying tensor evaluated at
+the inversely-cast indices. -/
+private lemma mpsTensor_cast_apply {n m : ℕ} (h : n = m) (A : MPSTensor d n)
+    (i : Fin d) (j₁ j₂ : Fin m) :
+    (cast (congr_arg (MPSTensor d) h) A) i j₁ j₂ =
+      A i (finCongr h.symm j₁) (finCongr h.symm j₂) := by
+  subst h
+  simp [finCongr]
+
+/-- Coordinate identification of `matched_p_basis` with a cast of `P.flatBasis`
+at the matched flat sector. -/
+private lemma matched_p_basis_eq_cast_flatBasis
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) :
+    matched_p_basis (P := P) (Q := Q) β hDim s =
+      cast (congr_arg (MPSTensor d)
+        (SectorDecomposition.flatDim_sectorFlatEquiv
+          (P := P) (Q := Q) β hDim τ s))
+        (P.flatBasis (SectorDecomposition.sectorFlatEquiv
+          (P := P) (Q := Q) β τ s)) := by
+  classical
+  set k : Fin Q.basisCount := (Q.flatIndexEquiv.symm s).1 with hk_def
+  -- `matched_p_basis β hDim s` reduces to `cast (hDim k) (P.basis (β k))`.
+  have hMatched :
+      matched_p_basis (P := P) (Q := Q) β hDim s =
+        cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k)) := rfl
+  -- `P.flatBasis (sectorFlatEquiv β τ s)` reduces to `P.basis (...).1`, where
+  -- `(...).1 = β k` via `hsym`.
+  have hsym :
+      P.flatIndexEquiv.symm
+          (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s) =
+        ⟨β k, τ k (Q.flatIndexEquiv.symm s).2⟩ := by
+    rw [SectorDecomposition.sectorFlatEquiv_apply, Equiv.symm_apply_apply]
+  -- The dependent index `(P.flatIndexEquiv.symm (sectorFlatEquiv β τ s)).1` equals `β k`.
+  have hk1 :
+      (P.flatIndexEquiv.symm
+          (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s)).1 =
+        β k := congrArg Sigma.fst hsym
+  rw [hMatched]
+  -- Use HEq-elimination: both sides are casts of `P.basis (...)` at indices
+  -- that equal `β k`.  We prove the underlying terms HEq, then transport.
+  apply eq_of_heq
+  refine HEq.trans (cast_heq _ _) ?_
+  refine HEq.trans ?_ (HEq.symm (cast_heq _ _))
+  -- Goal: HEq (P.basis (β k)) (P.flatBasis (sectorFlatEquiv β τ s))
+  -- which unfolds to HEq (P.basis (β k)) (P.basis ((P.flatIndexEquiv.symm _).1))
+  change HEq (P.basis (β k))
+    (P.basis (P.flatIndexEquiv.symm
+      (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s)).1)
+  -- Generalize the dependent index so we can perform `subst`.
+  set k' : Fin P.basisCount :=
+    (P.flatIndexEquiv.symm
+      (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s)).1
+    with hk'_def
+  have hk1' : k' = β k := hk1
+  clear_value k'
+  subst hk1'
+  rfl
+
+/-- Pointwise identity: the matched-coordinate basis tensor at flattened sector
+`s` equals the `P`-basis at the matched flattened sector, after reindexing the
+inner bond-dimension `Fin`s by `flatDim_sectorFlatEquiv`. -/
+private lemma matched_p_basis_apply
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) (i : Fin d) (m m' : Fin (Q.flatDim s)) :
+    matched_p_basis (P := P) (Q := Q) β hDim s i m m' =
+      P.flatBasis (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s) i
+        (finCongr (SectorDecomposition.flatDim_sectorFlatEquiv
+            (P := P) (Q := Q) β hDim τ s).symm m)
+        (finCongr (SectorDecomposition.flatDim_sectorFlatEquiv
+            (P := P) (Q := Q) β hDim τ s).symm m') := by
+  rw [matched_p_basis_eq_cast_flatBasis (P := P) (Q := Q) β hDim τ s,
+      mpsTensor_cast_apply
+        (SectorDecomposition.flatDim_sectorFlatEquiv (P := P) (Q := Q) β hDim τ s)
+        (P.flatBasis (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s))
+        i m m']
+
+/-- `matched_p_weight β τ s = P.flatWeight (sectorFlatEquiv β τ s)`. -/
+private lemma matched_p_weight_eq_flatWeight
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) :
+    matched_p_weight (P := P) (Q := Q) β τ s =
+      P.flatWeight (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s) := by
+  set k : Fin Q.basisCount := (Q.flatIndexEquiv.symm s).1
+  have hsym :
+      P.flatIndexEquiv.symm
+          (SectorDecomposition.sectorFlatEquiv (P := P) (Q := Q) β τ s) =
+        ⟨β k, τ k (Q.flatIndexEquiv.symm s).2⟩ := by
+    rw [SectorDecomposition.sectorFlatEquiv_apply, Equiv.symm_apply_apply]
+  change P.weight (β k) (τ k _) = P.weight _ _
+  rw [hsym]
+
+/-- The matched-coordinate tensor equals the submatrix of `P.toTensor` along
+`sectorFlatDimEquiv` (the sector permutation between flat bond-dim indices). -/
+private lemma matched_toTensor_eq_submatrix
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (i : Fin d) :
+    toTensorFromBlocks (d := d)
+        (μ := matched_p_weight (P := P) (Q := Q) β τ)
+        (matched_p_basis (P := P) (Q := Q) β hDim) i =
+      (P.toTensor i).submatrix
+        (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ)
+        (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ) := by
+  classical
+  -- Unfold both sides to `reindex finSigmaFinEquiv` applied to `blockDiagonal'`.
+  -- Then identify the underlying blockDiagonal matrices via a Σ-level submatrix.
+  ext j₁ j₂
+  -- Decompose j₁, j₂ as flat-Q Σ-indices.
+  obtain ⟨s, m⟩ : (s : Fin Q.totalCopies) × Fin (Q.flatDim s) :=
+    finSigmaFinEquiv.symm j₁
+  obtain ⟨s', m'⟩ : (s' : Fin Q.totalCopies) × Fin (Q.flatDim s') :=
+    finSigmaFinEquiv.symm j₂
+  -- LHS: matched-block-diagonal at (⟨s,m⟩, ⟨s',m'⟩).
+  -- RHS: P-block-diagonal at (σ_Sigma ⟨s,m⟩, σ_Sigma ⟨s',m'⟩) where σ_Sigma is
+  -- the sigma-level equiv induced by sectorFlatDimEquiv.
+  -- Compute both:
+  have hLHS :
+      toTensorFromBlocks (d := d)
+          (μ := matched_p_weight (P := P) (Q := Q) β τ)
+          (matched_p_basis (P := P) (Q := Q) β hDim) i j₁ j₂ =
+        Matrix.blockDiagonal' (fun s : Fin Q.totalCopies =>
+          matched_p_weight (P := P) (Q := Q) β τ s •
+            matched_p_basis (P := P) (Q := Q) β hDim s i)
+          (finSigmaFinEquiv.symm j₁) (finSigmaFinEquiv.symm j₂) := by
+    simp [toTensorFromBlocks, Matrix.reindex_apply, Matrix.submatrix_apply]
+  have hRHS :
+      ((P.toTensor i).submatrix
+            (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ)
+            (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ))
+          j₁ j₂ =
+        Matrix.blockDiagonal' (fun k : Fin P.totalCopies =>
+          P.flatWeight k • P.flatBasis k i)
+          (SectorDecomposition.sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ
+            (finSigmaFinEquiv.symm j₁))
+          (SectorDecomposition.sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ
+            (finSigmaFinEquiv.symm j₂)) := by
+    simp [Matrix.submatrix_apply,
+      SectorDecomposition.sectorFlatDimEquiv_apply,
+      SectorDecomposition.toTensor, toTensorFromBlocks,
+      Matrix.reindex_apply, Equiv.symm_apply_apply]
+  rw [hLHS, hRHS]
+  -- Now compare two blockDiagonal' entries.  Case split on whether the
+  -- Σ-base indices agree.
+  -- finSigmaFinEquiv.symm j₁ = ⟨a, b⟩ for some a, b; we keep the let-binding
+  -- abstract and split on the .fst components.
+  set xs : (s : Fin Q.totalCopies) × Fin (Q.flatDim s) := finSigmaFinEquiv.symm j₁
+  set xs' : (s : Fin Q.totalCopies) × Fin (Q.flatDim s) := finSigmaFinEquiv.symm j₂
+  by_cases hss : xs.1 = xs'.1
+  · -- Diagonal case: identify the matched data with the P-data at the matched sector.
+    rcases xs with ⟨s₀, m₀⟩
+    rcases xs' with ⟨s₀', m₀'⟩
+    simp only at hss
+    subst hss
+    rw [Matrix.blockDiagonal'_apply_eq, SectorDecomposition.sectorFlatSigmaEquiv_apply,
+      SectorDecomposition.sectorFlatSigmaEquiv_apply, Matrix.blockDiagonal'_apply_eq,
+      Matrix.smul_apply, Matrix.smul_apply,
+      matched_p_basis_apply (P := P) (Q := Q) β hDim τ s₀ i m₀ m₀',
+      matched_p_weight_eq_flatWeight (P := P) (Q := Q) β τ s₀]
+  · -- Off-diagonal case: both sides are zero.
+    rcases xs with ⟨s₀, m₀⟩
+    rcases xs' with ⟨s₀', m₀'⟩
+    simp only at hss
+    rw [Matrix.blockDiagonal'_apply_ne _ _ _ hss,
+      SectorDecomposition.sectorFlatSigmaEquiv_apply,
+      SectorDecomposition.sectorFlatSigmaEquiv_apply,
+      Matrix.blockDiagonal'_apply_ne _ _ _ (fun h => hss
+        ((SectorDecomposition.sectorFlatEquiv
+          (P := P) (Q := Q) β τ).injective h))]
+
+/-- The general linear group element associated with a permutation of a finite
+type: realized as the unit whose underlying matrix is `Equiv.Perm.permMatrix σ`
+and whose inverse is `Equiv.Perm.permMatrix σ.symm`. -/
+noncomputable def permGL {n : Type*} [DecidableEq n] [Fintype n]
+    (σ : Equiv.Perm n) : GL n ℂ :=
+  ⟨Equiv.Perm.permMatrix ℂ σ, Equiv.Perm.permMatrix ℂ σ.symm,
+    by
+      have hmul : Equiv.Perm.permMatrix ℂ σ * Equiv.Perm.permMatrix ℂ σ.symm =
+          Equiv.Perm.permMatrix ℂ (σ.symm * σ) :=
+        (Matrix.permMatrix_mul (σ := σ.symm) (τ := σ)).symm
+      rw [hmul]
+      change Equiv.Perm.permMatrix ℂ (σ⁻¹ * σ) = 1
+      rw [inv_mul_cancel]
+      exact Matrix.permMatrix_one,
+    by
+      have hmul : Equiv.Perm.permMatrix ℂ σ.symm * Equiv.Perm.permMatrix ℂ σ =
+          Equiv.Perm.permMatrix ℂ (σ * σ.symm) :=
+        (Matrix.permMatrix_mul (σ := σ) (τ := σ.symm)).symm
+      rw [hmul]
+      change Equiv.Perm.permMatrix ℂ (σ * σ⁻¹) = 1
+      rw [mul_inv_cancel]
+      exact Matrix.permMatrix_one⟩
+
+@[simp]
+theorem permGL_val {n : Type*} [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) :
+    (permGL σ : Matrix n n ℂ) = Equiv.Perm.permMatrix ℂ σ := rfl
+
+@[simp]
+theorem permGL_inv_val {n : Type*} [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) :
+    (((permGL σ)⁻¹ : GL n ℂ) : Matrix n n ℂ) = Equiv.Perm.permMatrix ℂ σ.symm := rfl
+
+/-- Entrywise expansion of `Equiv.Perm.permMatrix`. -/
+private lemma permMatrix_apply' {n : Type*} [DecidableEq n] (σ : Equiv.Perm n)
+    (i j : n) :
+    Equiv.Perm.permMatrix ℂ σ i j = if j = σ i then (1 : ℂ) else 0 := by
+  rw [Equiv.Perm.permMatrix]
+  by_cases h : j = σ i
+  · subst h
+    rw [if_pos rfl, PEquiv.toMatrix_apply, Equiv.toPEquiv_apply]
+    simp
+  · rw [if_neg h, PEquiv.toMatrix_apply, Equiv.toPEquiv_apply]
+    simp only [Option.mem_def, Option.some.injEq, ite_eq_right_iff,
+      one_ne_zero, imp_false]
+    exact fun heq => h heq.symm
+
+/-- Multiplying a matrix on the left by `permMatrix σ` reindexes its rows by `σ`. -/
+private lemma permMatrix_mul_eq_submatrix {n : Type*}
+    [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) (M : Matrix n n ℂ) :
+    Equiv.Perm.permMatrix ℂ σ * M = M.submatrix σ id := by
+  ext i j
+  rw [Matrix.mul_apply, Matrix.submatrix_apply, id]
+  simp_rw [permMatrix_apply', ite_mul, one_mul, zero_mul]
+  rw [Finset.sum_ite_eq' Finset.univ (σ i)]
+  simp
+
+/-- Multiplying a matrix on the right by `permMatrix σ` reindexes its columns by
+`σ.symm`. -/
+private lemma mul_permMatrix_eq_submatrix {n : Type*}
+    [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) (M : Matrix n n ℂ) :
+    M * Equiv.Perm.permMatrix ℂ σ = M.submatrix id σ.symm := by
+  ext i j
+  rw [Matrix.mul_apply, Matrix.submatrix_apply, id]
+  simp_rw [permMatrix_apply', mul_ite, mul_one, mul_zero]
+  -- Rewrite the condition `j = σ x` to `σ.symm j = x` so `sum_ite_eq` applies.
+  have hcond : ∀ x : n, (j = σ x) ↔ (σ.symm j = x) := by
+    intro x
+    constructor
+    · intro h; rw [h]; exact σ.symm_apply_apply x
+    · intro h; rw [← h]; exact (σ.apply_symm_apply j).symm
+  simp_rw [hcond]
+  rw [Finset.sum_ite_eq Finset.univ (σ.symm j)]
+  simp
+
+/-- Conjugating a square matrix by a permutation matrix gives a `submatrix` of
+the original by the permutation index map. -/
+private lemma permMatrix_conj_eq_submatrix {n : Type*}
+    [DecidableEq n] [Fintype n] (σ : Equiv.Perm n) (M : Matrix n n ℂ) :
+    Equiv.Perm.permMatrix ℂ σ * M * Equiv.Perm.permMatrix ℂ σ.symm =
+      M.submatrix σ σ := by
+  rw [permMatrix_mul_eq_submatrix, mul_permMatrix_eq_submatrix,
+    Matrix.submatrix_submatrix]
+  simp
+
+/-- **CPSV16 `II_cor2` literal form (CPSV16 §II.C lines 354–361 / 1184–1192).**
+
+If two paper-faithful BNT sector decompositions generate the same MPV family,
+then their total bond dimensions agree, and there exists an explicit
+$Y \in \mathrm{GL}(Q.\mathrm{totalDim},\mathbb{C})$ realizing the global gauge
+equation
+$$V_Q^i \;=\; Y \,\bigl(\mathrm{cast}\;V_P^i\bigr)\, Y^{-1}$$
+at every physical site $i$, where the inner factor is the bond-dim cast of the
+literal $P$-tensor along the total-dimension equality.
+
+This packages the matched-coordinate gauge equation
+`ft_paper_bnt_equal_mps_gaugeEquiv` (CPSV16 lines 1189–1192) into the verbatim
+II_cor2 statement of CPSV16 §II.C lines 354–361 by composing the matched-coord
+global gauge with the sector-permutation `sectorFlatDimEquiv`.
+
+CPSV16 §II.C lines 354–361. -/
+theorem ft_paper_bnt_equal_mps_gaugeEquiv_literal
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
+      ∀ i : Fin d,
+        Q.toTensor i =
+          (Y : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+            cast (by rw [hTotal] :
+                Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+                Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
+              (P.toTensor i) *
+            (((Y)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+              Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
+  classical
+  obtain ⟨β, hDim, _hCopies, τ, _ζ, _Xblock, _hTotal, X, _, _, _, hGauge⟩ :=
+    ft_paper_bnt_equal_mps_gaugeEquiv_witnesses hP hQ hUnitP hUnitQ hEqual
+  -- Total bond dimensions agree.
+  have hTotal : P.totalDim = Q.totalDim :=
+    SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
+  refine ⟨hTotal, ?_⟩
+  -- Sector-permutation `ρ := sectorFlatDimEquiv ∘ finCongr hTotal` on
+  -- `Fin Q.totalDim`.
+  set ρ : Equiv.Perm (Fin Q.totalDim) :=
+    (SectorDecomposition.sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ).trans
+      (finCongr hTotal) with hρ_def
+  -- The witness `X` has type `GL (Fin (∑ s, Q.flatDim s)) ℂ`, which is
+  -- definitionally equal to `GL (Fin Q.totalDim) ℂ` since `totalDim` is a
+  -- reducible def.  Bind `X'` to the same value at the `Q.totalDim` form via
+  -- `let` so that `X' = X` definitionally.
+  let X' : GL (Fin Q.totalDim) ℂ := X
+  refine ⟨X' * permGL ρ, ?_⟩
+  intro i
+  -- (i) `matched_tensor i = (P.toTensor i).submatrix sectorFlatDimEquiv ...`
+  have hsubm := matched_toTensor_eq_submatrix (P := P) (Q := Q) β hDim τ i
+  -- (ii) cast of `P.toTensor i` equals submatrix along `finCongr hTotal.symm`.
+  have hCast :
+      cast (by rw [hTotal] :
+          Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
+        (P.toTensor i) =
+        (P.toTensor i).submatrix (finCongr hTotal.symm) (finCongr hTotal.symm) := by
+    -- The cast of a `Matrix (Fin n) (Fin n) ℂ` along a bond-dim equality
+    -- equals the `submatrix` by `finCongr` of the inverse.
+    have hgen : ∀ (n m : ℕ) (h : n = m) (M : Matrix (Fin n) (Fin n) ℂ),
+        cast (by rw [h] :
+            Matrix (Fin n) (Fin n) ℂ = Matrix (Fin m) (Fin m) ℂ) M =
+          M.submatrix (finCongr h.symm) (finCongr h.symm) := by
+      intro n m h M
+      subst h
+      simp [finCongr]
+    exact hgen P.totalDim Q.totalDim hTotal (P.toTensor i)
+  -- (iii) connect `matched_tensor` to cast via `permMatrix ρ` conjugation.
+  have hPerm :
+      (permGL ρ : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+          cast (by rw [hTotal] :
+              Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+              Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
+            (P.toTensor i) *
+          (((permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+            Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) =
+        toTensorFromBlocks (d := d)
+            (μ := matched_p_weight (P := P) (Q := Q) β τ)
+            (matched_p_basis (P := P) (Q := Q) β hDim) i := by
+    rw [permGL_val, permGL_inv_val, hCast,
+      permMatrix_conj_eq_submatrix ρ
+        ((P.toTensor i).submatrix (finCongr hTotal.symm) (finCongr hTotal.symm)),
+      Matrix.submatrix_submatrix, hsubm]
+    -- The composition `(finCongr hTotal.symm) ∘ ρ` reduces to
+    -- `sectorFlatDimEquiv`; both sides of the equation are then identical
+    -- submatrices of `P.toTensor i`.
+    rfl
+  -- (iv) combine the matched-coord gauge with the sector permutation.
+  -- We have: Q.toTensor i = X * matched * X⁻¹ from hGauge.  Substituting in the
+  -- conjugation `hPerm` gives the desired equation.  Use that `X'` (resp.
+  -- `X'⁻¹`) coerces to the same matrix as `X` (resp. `X⁻¹`).
+  rw [hGauge i, ← hPerm]
+  have hY_inv :
+      (((X' * permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+        Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) =
+        (((permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+        ((X'⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
+    rw [mul_inv_rev]; rfl
+  rw [hY_inv]
+  -- `X` and `X'` are definitionally equal (`X' := X` via `let`); reformulate
+  -- the goal entirely in terms of `X'` before invoking matrix associativity.
+  change (X' : Matrix _ _ ℂ) *
+      ((permGL ρ : Matrix _ _ ℂ) *
+        cast (by rw [hTotal] :
+            Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+            Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) (P.toTensor i) *
+        (((permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)) *
+      ((X'⁻¹ : GL (Fin Q.totalDim) ℂ) :
+        Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) =
+    ((X' : Matrix _ _ ℂ) * (permGL ρ : Matrix _ _ ℂ)) *
+      cast (by rw [hTotal] :
+          Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) (P.toTensor i) *
+      ((((permGL ρ)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+        ((X'⁻¹ : GL (Fin Q.totalDim) ℂ) :
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ))
+  simp only [Matrix.mul_assoc]
+
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Supplier.lean
@@ -38,15 +38,14 @@ phase-equivalent TP/primitive/irreducible blocks.
   pragmatic Phase C target (with the exact-`SameMPV₂` zero-tail and global
   rescaling issues quarantined behind the prepared-data hypotheses).
 
-## Layering note
+## Layering
 
-This module imports `TNLean.MPS.FundamentalTheorem.PaperBNT.Basic` from the
-`CanonicalForm` directory.  This bridges canonical-form prepared data into
-the `IsBNTCanonicalForm` contract that lives in the fundamental-theorem layer;
-the inversion is intentional and matches the inversion already present at
-`TNLean/MPS/CanonicalForm/PhaseCover.lean:6` and
-`TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean:8`.  It is to be resolved
-in a future SharedInfra reorganization.
+This module lives in the `FundamentalTheorem.PaperBNT.*` layer because it
+consumes both canonical-form data (`CanonicalForm.PhaseClassSectorData`) and
+the FT-side `IsBNTCanonicalForm` contract (`FundamentalTheorem.PaperBNT.Basic`).
+Placing it in `FundamentalTheorem.PaperBNT.Supplier` re-establishes the natural
+layering: `FundamentalTheorem.PaperBNT` is above `CanonicalForm`, so importing
+from both directions here is consistent with the overall layer order.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -36,21 +36,10 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- **BNT linear-independence hypothesis for sector bases.**
-
-`HasBNTSectorData P` asserts that the basis of the sector decomposition `P` is
-a basis of normal tensors in the sense of Definition 4.2 of arXiv:2011.12127: for all
-sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
-are linearly independent.  The statement records only the eventual condition;
-no witness is included.
-
-Mathematically, this is the eventual linear-independence hypothesis on the basis
-sector MPV families. In comparison theorems for two sector decompositions, it
-lets equality of total MPVs determine the scalar coefficients after the basis
-blocks have been matched, even when the two decompositions use different bases. -/
-def HasBNTSectorData (P : SectorDecomposition d) : Prop :=
-  ∃ N0 : ℕ, ∀ N > N0,
-    LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N)
+/- The BNT linear-independence hypothesis `HasBNTSectorData` is now defined in
+`TNLean.MPS.SharedInfra.SectorDecomposition` so that canonical-form modules
+can refer to it without inverting the layering.  It remains transitively
+available here through `SectorWeightComparison`'s SharedInfra import. -/
 
 /-! ## Equal-case fundamental theorem for sector decompositions
 
@@ -449,51 +438,11 @@ structure SectorBasisOverlapOrthoHypotheses (P : SectorDecomposition d) : Prop w
     Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
       Filter.atTop (nhds 0)
 
-/-- Primitive overlap-rigidity hypotheses for two sector bases.
-
-This structure collects the analytic inputs used by
-`exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV`: nonzero bond
-dimensions, injectivity, left-canonical normalization, asymptotic self/orthogonal
-overlaps, and equality of the finite-length MPV spans. It deliberately does
-not contain a permutation or equality of multiplicities; those are produced by the
-overlap rigidity theorem and the BNT coefficient comparison. -/
-structure SectorBasisOverlapSpanHypotheses (P Q : SectorDecomposition d) : Prop where
-  /-- The left basis blocks have nonzero bond dimension. -/
-  left_dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j
-  /-- The right basis blocks have nonzero bond dimension. -/
-  right_dim_pos : ∀ k : Fin Q.basisCount, 0 < Q.basisDim k
-  /-- The left basis blocks are injective. -/
-  left_injective : ∀ j : Fin P.basisCount, IsInjective (P.basis j)
-  /-- The right basis blocks are injective. -/
-  right_injective : ∀ k : Fin Q.basisCount, IsInjective (Q.basis k)
-  /-- The left basis blocks are left-canonical. -/
-  left_normalized :
-    ∀ j : Fin P.basisCount, (∑ i : Fin d, (P.basis j i)ᴴ * (P.basis j i)) = 1
-  /-- The right basis blocks are left-canonical. -/
-  right_normalized :
-    ∀ k : Fin Q.basisCount, (∑ i : Fin d, (Q.basis k i)ᴴ * (Q.basis k i)) = 1
-  /-- Each left basis block has self-overlap tending to one. -/
-  left_self_overlap : ∀ j : Fin P.basisCount,
-    Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
-      Filter.atTop (nhds (1 : ℂ))
-  /-- Distinct left basis blocks have asymptotically zero overlap. -/
-  left_off_overlap : ∀ i j : Fin P.basisCount, i ≠ j →
-    Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
-      Filter.atTop (nhds 0)
-  /-- Each right basis block has self-overlap tending to one. -/
-  right_self_overlap : ∀ k : Fin Q.basisCount,
-    Filter.Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis k) N)
-      Filter.atTop (nhds (1 : ℂ))
-  /-- Distinct right basis blocks have asymptotically zero overlap. -/
-  right_off_overlap : ∀ k l : Fin Q.basisCount, k ≠ l →
-    Filter.Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis l) N)
-      Filter.atTop (nhds 0)
-  /-- The finite-length spans of the two sector bases agree. -/
-  span_eq : ∀ N,
-    Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
-      mpvState (d := d) (P.basis j) N)) =
-    Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
-      mpvState (d := d) (Q.basis k) N))
+/- The two-family primitive overlap-rigidity structure
+`SectorBasisOverlapSpanHypotheses` now lives in
+`TNLean.MPS.SharedInfra.SectorDecomposition`, so that canonical-form modules
+can build it without inverting the layer ordering.  It remains transitively
+available here through `SectorWeightComparison`'s SharedInfra import. -/
 
 namespace SectorBasisOverlapOrthoHypotheses
 

--- a/TNLean/MPS/SharedInfra/BlockGauge.lean
+++ b/TNLean/MPS/SharedInfra/BlockGauge.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.SharedInfra.BlockAssembly
+
+import Mathlib.Algebra.BigOperators.Fin
+
+/-!
+# Shared block-diagonal gauge infrastructure
+
+This file factors out the pure-linear-algebra block-diagonal gauge machinery
+that is consumed by both:
+
+* the FT-side block-gauge assembly (`TNLean.MPS.FundamentalTheorem.Multi`), and
+* the canonical-form sector-comparison data layer
+  (`TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveBlockMatchingData`).
+
+Exports:
+
+* `blockDiagonalGL` — block-diagonal `GL`-element from a family of invertible
+  blocks.
+* `globalGaugeOfBlocks` — the reindexed block-diagonal gauge on the flattened
+  bond `Fin (∑ k, dim k)` used by `toTensorFromBlocks`.
+* `toTensorFromBlocks_eq_globalGaugeOfBlocks_conj` — direct-sum conjugation
+  identity: per-block conjugation lifts to a `globalGaugeOfBlocks`-conjugation
+  of `toTensorFromBlocks`.
+
+These declarations are pure linear-algebra plumbing not specific to the
+fundamental theorem; placing them in `SharedInfra` avoids a layer inversion
+where `CanonicalForm/...` had to import `FundamentalTheorem.Multi`.
+
+## Reference
+
+* arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192).
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-! ## Block-diagonal invertible matrices -/
+
+section BlockDiagonalGL
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+
+private theorem blockDiagonal'_mul_one
+    (f g : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+    (hfg : ∀ k, f k * g k = 1) :
+    Matrix.blockDiagonal' f * Matrix.blockDiagonal' g = 1 := by
+  rw [← Matrix.blockDiagonal'_mul, show (fun k => f k * g k) = 1 from funext hfg,
+    Matrix.blockDiagonal'_one]
+
+/-- Form a block-diagonal element of `GL` from a family of invertible matrices. -/
+noncomputable def blockDiagonalGL (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
+    GL ((k : Fin r) × Fin (dim k)) ℂ :=
+  ⟨Matrix.blockDiagonal' (fun k => (X k : Matrix _ _ ℂ)),
+   Matrix.blockDiagonal' (fun k => ((X k)⁻¹ : Matrix _ _ ℂ)),
+   blockDiagonal'_mul_one _ _ (fun k => by simp),
+   blockDiagonal'_mul_one _ _ (fun k => by simp)⟩
+
+/-- Assemble per-block gauges into the flattened global `GL` element used by
+`toTensorFromBlocks`.  This is the reindexed block-diagonal matrix `⊕ₖ X k` on the
+canonical `Fin (∑ k, dim k)` bond index, naming the global gauge `X = ⊕ₖ X k`
+that arises after the BNT block matching.
+
+Reference: arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192). -/
+noncomputable def globalGaugeOfBlocks (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
+    GL (Fin (∑ k : Fin r, dim k)) ℂ :=
+  Units.map
+    (Matrix.reindexAlgEquiv ℂ ℂ (finSigmaFinEquiv (n := dim))).toRingEquiv.toMonoidHom
+    (blockDiagonalGL X)
+
+end BlockDiagonalGL
+
+/-! ## Direct-sum conjugation identity -/
+
+section GaugeConjugation
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+variable (μ : Fin r → ℂ)
+variable (A B : (k : Fin r) → MPSTensor d (dim k))
+
+/-- Direct conjugation formula for weighted direct sums.
+
+If `B k i = X k * A k i * (X k)⁻¹` for every `k, i`, then for every `i`,
+`toTensorFromBlocks μ B i = (⊕ X) * toTensorFromBlocks μ A i * (⊕ X)⁻¹`,
+where `⊕ X = globalGaugeOfBlocks X` is the reindexed block-diagonal gauge.
+
+Reference: arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192). -/
+theorem toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
+    (X : (k : Fin r) → GL (Fin (dim k)) ℂ)
+    (hX : ∀ k : Fin r, ∀ i : Fin d,
+      B k i =
+        (X k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) * A k i *
+          (((X k)⁻¹ : GL (Fin (dim k)) ℂ) : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) :
+    ∀ i : Fin d,
+      toTensorFromBlocks (d := d) (μ := μ) B i =
+        (globalGaugeOfBlocks X : Matrix (Fin (∑ k : Fin r, dim k))
+          (Fin (∑ k : Fin r, dim k)) ℂ) *
+          toTensorFromBlocks (d := d) (μ := μ) A i *
+          (((globalGaugeOfBlocks X)⁻¹ : GL (Fin (∑ k : Fin r, dim k)) ℂ) :
+            Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ) := by
+  classical
+  intro i
+  let α := (k : Fin r) × Fin (dim k)
+  let e : α ≃ Fin (∑ k : Fin r, dim k) := finSigmaFinEquiv
+  let f : Matrix α α ℂ →* Matrix (Fin _) (Fin _) ℂ :=
+    (Matrix.reindexAlgEquiv ℂ ℂ e).toRingEquiv.toMonoidHom
+  let BD := fun (T : (k : Fin r) → MPSTensor d (dim k)) =>
+    Matrix.blockDiagonal' fun k => (μ k) • T k i
+  let XBD : Matrix α α ℂ :=
+    Matrix.blockDiagonal' fun k => (X k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+  let XBDinv : Matrix α α ℂ :=
+    Matrix.blockDiagonal' fun k => ((X k)⁻¹ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+  have htoA : toTensorFromBlocks (d := d) (μ := μ) A i = f (BD A) := by
+    simp [toTensorFromBlocks, BD, f, e]
+  have htoB : toTensorFromBlocks (d := d) (μ := μ) B i = f (BD B) := by
+    simp [toTensorFromBlocks, BD, f, e]
+  have hBD : BD B = XBD * BD A * XBDinv := by
+    simp only [BD, XBD, XBDinv]
+    have : (fun k : Fin r => (μ k) • B k i) =
+        fun k => (X k : Matrix _ _ ℂ) * ((μ k) • A k i) * ((X k)⁻¹ : Matrix _ _ ℂ) := by
+      funext k; simp [hX k i, Algebra.mul_smul_comm, Algebra.smul_mul_assoc, Matrix.mul_assoc]
+    rw [this, ← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+  have hXfin :
+      (globalGaugeOfBlocks X : Matrix (Fin (∑ k : Fin r, dim k))
+        (Fin (∑ k : Fin r, dim k)) ℂ) = f XBD := by
+    simp [globalGaugeOfBlocks, XBD, blockDiagonalGL, f, e]
+  have hXfin_inv :
+      (((globalGaugeOfBlocks X)⁻¹ : GL (Fin (∑ k : Fin r, dim k)) ℂ) :
+        Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ) = f XBDinv := by
+    simp [globalGaugeOfBlocks, XBDinv, blockDiagonalGL, f, e]
+  rw [htoB, htoA, hBD]
+  simp [map_mul, hXfin, hXfin_inv, Matrix.mul_assoc]
+
+end GaugeConjugation
+
+end MPSTensor

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -112,7 +112,12 @@ noncomputable def flatBasis (P : SectorDecomposition d) :
     (s : Fin P.totalCopies) → MPSTensor d (P.flatDim s) :=
   fun s ↦ P.basis (P.flatIndexEquiv.symm s).1
 
-/-- Total bond dimension of the flattened block-diagonal tensor. -/
+/-- Total bond dimension of the flattened block-diagonal tensor.
+
+Marked `@[reducible]` so that `Fin P.totalDim` and `Fin (∑ s, P.flatDim s)`
+unify during type-class instance synthesis (needed for the literal
+`GaugeEquiv` packaging that compares matrices indexed by both forms). -/
+@[reducible]
 noncomputable def totalDim (P : SectorDecomposition d) : ℕ :=
   ∑ s : Fin P.totalCopies, P.flatDim s
 
@@ -288,6 +293,70 @@ theorem totalDim_eq_of_match
   change ∑ s' : Fin P.totalCopies, P.flatDim s' =
       ∑ s : Fin Q.totalCopies, Q.flatDim s
   rw [hreindex, hpoint]
+
+/-! ### Σ-level sector permutation between flattened bond-dimension indices
+
+The `sectorFlatEquiv` already permutes the flattened copy index
+`Fin Q.totalCopies ≃ Fin P.totalCopies` and `flatDim_sectorFlatEquiv` certifies
+that the per-flat-copy bond dimensions agree.  The next equivalence packages
+both pieces as a single permutation of the Σ-index that underlies
+`toTensor`/`toTensorFromBlocks`, and induces an equivalence on
+`Fin · .totalDim`.  Both are needed to convert the matched-coordinate gauge
+equation of CPSV16 lines 1189–1192 into the literal cast-of-`P.toTensor`
+form of the II_cor2 statement (CPSV16 §II.C lines 354–361). -/
+
+/-- The Σ-level permutation `Σ s, Fin (Q.flatDim s) ≃ Σ k, Fin (P.flatDim k)`
+induced by the matched basis bijection $β$, copy permutations $τ_k$ and
+matched bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$.
+
+CPSV16 §II.C lines 354–361 / 1184–1192. -/
+noncomputable def sectorFlatSigmaEquiv
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))) :
+    ((s : Fin Q.totalCopies) × Fin (Q.flatDim s)) ≃
+      ((k : Fin P.totalCopies) × Fin (P.flatDim k)) :=
+  Equiv.sigmaCongr (sectorFlatEquiv (P := P) (Q := Q) β τ)
+    (fun s => finCongr
+      (flatDim_sectorFlatEquiv (P := P) (Q := Q) β hDim τ s).symm)
+
+@[simp]
+theorem sectorFlatSigmaEquiv_apply
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (s : Fin Q.totalCopies) (m : Fin (Q.flatDim s)) :
+    sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ ⟨s, m⟩ =
+      ⟨sectorFlatEquiv (P := P) (Q := Q) β τ s,
+        finCongr (flatDim_sectorFlatEquiv (P := P) (Q := Q) β hDim τ s).symm m⟩ := by
+  rfl
+
+/-- The dim-level equivalence `Fin Q.totalDim ≃ Fin P.totalDim` induced by the
+matched flattened sector data.
+
+CPSV16 §II.C lines 354–361 / 1184–1192. -/
+noncomputable def sectorFlatDimEquiv
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))) :
+    Fin Q.totalDim ≃ Fin P.totalDim :=
+  (finSigmaFinEquiv (m := Q.totalCopies) (n := Q.flatDim)).symm.trans
+    ((sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ).trans
+      (finSigmaFinEquiv (m := P.totalCopies) (n := P.flatDim)))
+
+theorem sectorFlatDimEquiv_apply
+    {d : ℕ} {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (j : Fin Q.totalDim) :
+    sectorFlatDimEquiv (P := P) (Q := Q) β hDim τ j =
+      finSigmaFinEquiv (sectorFlatSigmaEquiv (P := P) (Q := Q) β hDim τ
+        (finSigmaFinEquiv.symm j)) := by
+  rfl
 
 end SectorDecomposition
 

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -3,8 +3,10 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.SharedInfra.BlockAssembly
+import TNLean.MPS.Overlap.Basic
 
 import Mathlib.Data.Fintype.BigOperators
+import Mathlib.LinearAlgebra.LinearIndependent.Defs
 
 /-!
 # Shared sector decomposition infrastructure
@@ -15,6 +17,7 @@ construction and the equal-case fundamental theorem use:
 * `SectorWeightData`
 * `SectorDecomposition`
 * the basic MPV expansion formulas for `SectorDecomposition.toTensor`
+* the BNT linear-independence hypothesis `HasBNTSectorData`
 
 Higher-level coefficient comparison and Newton–Girard recovery theorems remain in
 `TNLean.MPS.FundamentalTheorem.SectorDecomposition`.
@@ -359,5 +362,81 @@ theorem sectorFlatDimEquiv_apply
   rfl
 
 end SectorDecomposition
+
+/-! ## Primitive overlap-rigidity hypotheses (two-family)
+
+The two-family analytic-input structure used by the FT-side
+`exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV`.  It lives here so
+that canonical-form modules can build the structure without inverting the
+layer order. -/
+
+/-- Primitive overlap-rigidity hypotheses for two sector bases.
+
+This structure collects the analytic inputs used by
+`exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV`: nonzero bond
+dimensions, injectivity, left-canonical normalization, asymptotic self/orthogonal
+overlaps, and equality of the finite-length MPV spans. It deliberately does
+not contain a permutation or equality of multiplicities; those are produced by the
+overlap rigidity theorem and the BNT coefficient comparison. -/
+structure SectorBasisOverlapSpanHypotheses {d : ℕ} (P Q : SectorDecomposition d) : Prop where
+  /-- The left basis blocks have nonzero bond dimension. -/
+  left_dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j
+  /-- The right basis blocks have nonzero bond dimension. -/
+  right_dim_pos : ∀ k : Fin Q.basisCount, 0 < Q.basisDim k
+  /-- The left basis blocks are injective. -/
+  left_injective : ∀ j : Fin P.basisCount, IsInjective (P.basis j)
+  /-- The right basis blocks are injective. -/
+  right_injective : ∀ k : Fin Q.basisCount, IsInjective (Q.basis k)
+  /-- The left basis blocks are left-canonical. -/
+  left_normalized :
+    ∀ j : Fin P.basisCount, (∑ i : Fin d, (P.basis j i)ᴴ * (P.basis j i)) = 1
+  /-- The right basis blocks are left-canonical. -/
+  right_normalized :
+    ∀ k : Fin Q.basisCount, (∑ i : Fin d, (Q.basis k i)ᴴ * (Q.basis k i)) = 1
+  /-- Each left basis block has self-overlap tending to one. -/
+  left_self_overlap : ∀ j : Fin P.basisCount,
+    Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
+      Filter.atTop (nhds (1 : ℂ))
+  /-- Distinct left basis blocks have asymptotically zero overlap. -/
+  left_off_overlap : ∀ i j : Fin P.basisCount, i ≠ j →
+    Filter.Tendsto (fun N => mpvOverlap (d := d) (P.basis i) (P.basis j) N)
+      Filter.atTop (nhds 0)
+  /-- Each right basis block has self-overlap tending to one. -/
+  right_self_overlap : ∀ k : Fin Q.basisCount,
+    Filter.Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis k) N)
+      Filter.atTop (nhds (1 : ℂ))
+  /-- Distinct right basis blocks have asymptotically zero overlap. -/
+  right_off_overlap : ∀ k l : Fin Q.basisCount, k ≠ l →
+    Filter.Tendsto (fun N => mpvOverlap (d := d) (Q.basis k) (Q.basis l) N)
+      Filter.atTop (nhds 0)
+  /-- The finite-length spans of the two sector bases agree. -/
+  span_eq : ∀ N,
+    Submodule.span ℂ (Set.range (fun j : Fin P.basisCount =>
+      mpvState (d := d) (P.basis j) N)) =
+    Submodule.span ℂ (Set.range (fun k : Fin Q.basisCount =>
+      mpvState (d := d) (Q.basis k) N))
+
+/-! ## BNT linear-independence hypothesis -/
+
+/-- **BNT linear-independence hypothesis for sector bases.**
+
+`HasBNTSectorData P` asserts that the basis of the sector decomposition `P` is
+a basis of normal tensors in the sense of Definition 4.2 of arXiv:2011.12127: for all
+sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
+are linearly independent.  The statement records only the eventual condition;
+no witness is included.
+
+Mathematically, this is the eventual linear-independence hypothesis on the basis
+sector MPV families. In comparison theorems for two sector decompositions, it
+lets equality of total MPVs determine the scalar coefficients after the basis
+blocks have been matched, even when the two decompositions use different bases.
+
+This definition lives in the shared infrastructure layer so that
+canonical-form modules (e.g. `TNLean.MPS.CanonicalForm.PhaseClassSectorData`)
+can certify the predicate without importing the FT-side coefficient comparison
+theorems that historically hosted it. -/
+def HasBNTSectorData {d : ℕ} (P : SectorDecomposition d) : Prop :=
+  ∃ N0 : ℕ, ∀ N > N0,
+    LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (P.basis j) N)
 
 end MPSTensor

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -3026,28 +3026,28 @@ Several declarations physically defined in
 \texttt{TNLean/MPS/CanonicalForm/SectorComparison/} and related modules belong
 logically to the after-blocking fundamental-theorem pipeline rather than to
 the canonical-form reduction proper.  Their blueprint \texttt{\textbackslash lean\{\ldots\}} tags
-live in \Cref{ch:ft_proof} and \Cref{ch:after_blocking} to reflect this;
-Chapter~\ref{ch:canonical} does not claim them as canonical-form theorems.
+live in \Cref{ch:ft_proof} and \Cref{ch:canonical_after_blocking} to reflect
+this; Chapter~\ref{ch:canonical} does not claim them as canonical-form theorems.
 
 Representative examples (navigable via the tagged theorems in those chapters):
 \begin{itemize}
   \item \texttt{afterBlocking\_commonPrimitiveIrreducibleBlocks\_of\_reindexedNonzeroParts}
     (\Cref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed})~---
     produces common TP/primitive/irreducible sector decompositions for two
-    same-MPV tensors; tagged in \Cref{ch:after_blocking}.
+    same-MPV tensors; tagged in \Cref{ch:canonical_after_blocking}.
 
   \item \texttt{afterBlocking\_commonLengthCommonSectorData\_of\_sameMPV\textsubscript{2}}
-    (\Cref{thm:ft_after_blocking_common_length_common_sector_data})~---
+    (\Cref{thm:ft_after_blocking_common_length_common_sector_theorem})~---
     the main common-length after-blocking structural theorem; tagged in
-    \Cref{ch:after_blocking}.
+    \Cref{ch:canonical_after_blocking}.
 
   \item \texttt{bilateral\_commonPeriod\_blocking\_tp\_primitive\_normal}
     (\Cref{thm:common_period_two_tensors})~---
     common blocking period for two primitive normal tensors; tagged in
-    \Cref{ch:after_blocking}.
+    \Cref{ch:canonical_after_blocking}.
 
   \item \texttt{unconditional\_commonPrimitiveIrreducibleBlocks}
-    (\Cref{thm:after_blocking_unconditional_common_primitive_irr})~---
+    (\Cref{thm:unconditional_common_primitive_irreducible_blocks})~---
     removes the reindexing pre-hypothesis from the above; tagged in
     \Cref{ch:ft_proof}.
 \end{itemize}
@@ -3055,5 +3055,5 @@ Representative examples (navigable via the tagged theorems in those chapters):
 The physical co-location of these files with the canonical-form layer is an
 artifact of the build dependency order; a future refactor may move them to a
 dedicated after-blocking module.  Until then, readers should consult
-Chapters~\ref{ch:ft_proof} and~\ref{ch:after_blocking} for the
+Chapters~\ref{ch:ft_proof} and~\ref{ch:canonical_after_blocking} for the
 after-blocking pipeline documentation.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -116,6 +116,16 @@ formalization.
 	(Theorem~\ref{thm:ft_single}) to each block independently.
 \end{proof}
 
+\begin{remark}[Structural scaffolding, not the multi-block paper theorem]
+  This is a block-sum assembly of the per-block injective single-block FT:
+  it assumes the block pairing $(A_k, B_k)$ is already given and that the
+  blocks have been pre-matched.  It is \emph{not} the CPSV16 / TN-Review
+  multi-block fundamental theorem, which derives the block matching and
+  permutation from only the global same-MPV hypothesis
+  (see \cite[Theorem~II.1, lines~349--352]{Cirac2017MPDO_AnnPhys}).
+  This declaration is structural scaffolding for the FT proof pipeline.
+\end{remark}
+
 \begin{theorem}[Per-block same MPV implies global same MPV]\label{thm:block_to_global_mpv}
 	\lean{MPSTensor.sameMPV_toTensorFromBlocks_of_blockSameMPV}
 	\leanok
@@ -132,6 +142,12 @@ formalization.
 	Per-block equality of MPV coefficients gives global equality.
 \end{proof}
 
+\begin{remark}[Direct-sum congruence helper]
+  This is a direct-sum congruence lemma: it lifts per-block MPV equality to
+  global MPV equality via the block-diagonal decomposition formula.
+  It is a helper result, not a paper-level theorem.
+\end{remark}
+
 \begin{theorem}[Global multi-block fundamental theorem]\label{thm:multi_block_global}
 	\lean{MPSTensor.fundamentalTheorem_multiBlock_global}
 	\leanok
@@ -147,6 +163,15 @@ formalization.
 	equivalences from injectivity and equality of MPV families, then
 	combine them into a global gauge for the block-diagonal tensors.
 \end{proof}
+
+\begin{remark}[Block-diagonal gauge assembly, not the FT block-matching theorem]
+  This assembles per-block gauges into a block-diagonal gauge for the global
+  assembled tensor, \emph{given pre-matched same-index blocks}.  It is
+  \emph{not} the FT block-matching theorem: it does not derive the block
+  pairing or permutation from a global same-MPV hypothesis; the block
+  correspondence is assumed in advance.  This declaration is structural
+  scaffolding consumed by the FT proof pipeline in Chapter~\ref{ch:ft_proof}.
+\end{remark}
 
 \section{Transfer map normalization}
 
@@ -523,6 +548,16 @@ per-block peripheral-spectrum primitivity.
 	$O_{A_k A_k}(N) \to 1$.
 \end{proof}
 
+\begin{remark}[Prepared-data constructor; not the arbitrary-input CF theorem]
+  This is a \emph{constructor}: it packages prepared primitive-block data
+  into the \texttt{IsCanonicalForm} predicate.  It is \emph{not} the
+  full TI canonical-form existence theorem of
+  \cite[Theorem~\texttt{Th:TIcanonical}]{PerezGarcia2007Matrix} or
+  \cite[Section~IV.A.1]{Cirac2021Matrix}, which starts from an arbitrary
+  input tensor and produces the decomposition.  This result is illustrative
+  and not consumed downstream in the FT pipeline.
+\end{remark}
+
 \begin{theorem}[Canonical form from peripheral primitivity]%
 	\label{thm:canonical_from_primitive}
 	\lean{MPSTensor.isCanonicalForm_of_peripheralPrimitive}
@@ -575,6 +610,16 @@ per-block peripheral-spectrum primitivity.
 	Since this holds for every block, the overlap clause required in
 	Definition~\ref{def:is_canonical_form} follows from the other hypotheses.
 \end{proof}
+
+\begin{remark}[Prepared peripheral-primitive constructor; not consumed downstream]
+  This is a \emph{constructor} that packages prepared peripheral-primitive
+  block data into \texttt{IsCanonicalForm}.  Like
+  Theorem~\ref{thm:canonical_from_primitive_fixedpoint}, it assumes the
+  blocks are already given in the correct normalized form; it is
+  \emph{not} the arbitrary-input TI canonical-form existence theorem.
+  This result is illustrative; it is not consumed by the subsequent FT or
+  BNT pipeline.
+\end{remark}
 
 \begin{remark}\label{rem:primitivity_reduces_assumptions}\leanok
 	Theorem~\ref{thm:canonical_from_primitive} shows that
@@ -924,6 +969,18 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
 		reordered family satisfies Definition~\ref{def:is_normal_canonical_form}
 		and generates the same MPV family as~$A$.
 \end{proof}
+
+\begin{remark}[Prepared-data NCF constructor; distinguished from CPSV16 CF existence]
+  This is a \emph{constructor} that packages prepared primitive block data
+  into \texttt{IsNormalCanonicalForm}: all six hypotheses are assumed in
+  advance; the theorem merely re-orders the blocks and attaches the predicate.
+  It is \emph{not} the arbitrary-input canonical-form existence theorem of
+  \cite[lines~237--250]{Cirac2017MPDO_AnnPhys} (equivalently
+  \cite[MPDO, lines~249--250]{Cirac2017MPDO_AnnPhys}), which starts from
+  an arbitrary tensor and derives the primitive block structure.  That
+  arbitrary-input direction is the open formalization gap documented in
+  Section~\ref{subsec:paperbnt_supplier}.
+\end{remark}
 
 \section{Zero-block separation}%
 \label{sec:zero_block_separation}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2921,3 +2921,139 @@ The remaining seven theorems are outside the formalization scope:
     \emph{Not formalized:} numerical and algorithmic recovery is entirely
     out of scope; the chapter addresses existence and uniqueness abstractly.
 \end{itemize}
+
+\subsection{PaperBNT supplier interface}%
+\label{subsec:paperbnt_supplier}
+
+The \emph{paper-faithful} BNT predicate \texttt{IsBNTCanonicalForm}
+(Chapter~\ref{ch:bnt}) represents the CPSV16 basis-of-normal-tensors data with
+full multiplicity and span fields.  Phase~C PR~1 of the
+formalization closed the \emph{prepared-block} direction of the supplier bridge:
+
+\begin{theorem}[Prepared-block PaperBNT constructor (Phase~C PR~1)]%
+  \label{thm:paperbnt_supplier_prepared}
+  \lean{MPSTensor.exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks}
+  \leanok
+  Let $r \in \mathbb{N}$, let $\dim : \mathrm{Fin}\,r \to \mathbb{N}$,
+  let $\mu : \mathrm{Fin}\,r \to \mathbb{C}$, and let
+  $\mathrm{blocks}_k : \texttt{MPSTensor}\,d\,(\dim k)$ for $k < r$.
+  Assume:
+  \begin{enumerate}
+    \item \textbf{positive bond dimensions:} $0 < \dim k$ for all $k$,
+    \item \textbf{TP normalization:} each block satisfies
+          $\sum_i (\mathrm{blocks}_k^i)^\dagger\,\mathrm{blocks}_k^i = \Id$
+          (\texttt{IsLeftCanonical}),
+    \item \textbf{primitivity:} the transfer map $\mathcal{E}_{\mathrm{blocks}_k}$
+          is primitive for each $k$,
+    \item \textbf{irreducibility:} each block satisfies
+          \texttt{IsIrreducibleTensor},
+    \item \textbf{injectivity:} each block satisfies \texttt{IsInjective},
+    \item \textbf{nonzero weights:} $\mu_k \neq 0$ for all $k$,
+    \item \textbf{bounded weights:} $|\mu_k| \le 1$ for all $k$,
+    \item \textbf{global unit witness:} $\exists\,k,\;|\mu_k| = 1$.
+  \end{enumerate}
+  Then there exists a \texttt{SectorDecomposition} $P$ such that
+  \begin{itemize}
+    \item $P.\texttt{toTensor}$ and
+          $\texttt{toTensorFromBlocks}\,\mu\,\mathrm{blocks}$
+          generate the same MPV family at every length
+          (\texttt{SameMPV\textsubscript{2}}), and
+    \item $P$ satisfies \texttt{IsBNTCanonicalForm}.
+  \end{itemize}
+\end{theorem}
+
+\begin{proof}\leanok
+  The phase-class quotient collapses gauge-phase-equivalent blocks into
+  sectors with unit-modulus per-copy scalars (derived from the TP + primitive +
+  irreducible hypotheses via the MPV phase-class infrastructure).
+  The resulting sector decomposition inherits the BNT data fields from
+  \texttt{exists\_bnt\_sectorDecomp\_of\_tp\_primitive\_irr\_blocks};
+  the bounded-weight and global-unit hypotheses close the weight-norm fields
+  of \texttt{IsBNTCanonicalForm} directly.
+\end{proof}
+
+\begin{remark}[Arbitrary-input bridge: open formalization direction]%
+  \label{rem:arbitrary_input_bridge_gap}
+  Theorem~\ref{thm:paperbnt_supplier_prepared} requires eight
+  \emph{prepared-input} hypotheses; it does not supply a
+  \texttt{SectorDecomposition} starting from an arbitrary
+  \texttt{MPSTensor}.  Three independent obstacles block the
+  arbitrary-input bridge.
+
+  \begin{enumerate}
+    \item \textbf{Zero-tail bookkeeping.}
+      \texttt{SameMPV\textsubscript{2}} quantifies over all $N \ge 0$, so the
+      $N = 0$ clause reads $\dim(P.\texttt{toTensor}) = \dim(\text{input})$.
+      The arbitrary-input reduction naturally yields
+      \texttt{SameMPV\textsubscript{2}Pos} (equality for $N \ge 1$) together
+      with a separate length-zero dimension identity.  Bridging to exact
+      \texttt{SameMPV\textsubscript{2}} requires matching the zero-tail bond
+      dimension after pruning all-zero blocks, which fails once zero blocks
+      are removed by Theorem~\ref{thm:zero_block_separation}.
+
+    \item \textbf{Global weight normalization.}
+      \texttt{IsBNTCanonicalForm} requires $|\mu_k| \le 1$ for all $k$ and
+      $|\mu_k| = 1$ for some $k$.  These are normalization conventions, not
+      consequences of an arbitrary tensor.  For example, if the left-canonical
+      block $C$ has unit weight, the scaled input $A = 2 \cdot C$ produces
+      weights of modulus $2$, violating the bound.  The hypotheses
+      \texttt{hμLe} and \texttt{hμUnit} must therefore be supplied externally,
+      or the statement must be weakened to a rescaled form.
+
+    \item \textbf{Per-block unit-modulus witness.}
+      The field $\forall j,\;\exists q,\;|\mathrm{weight}\,j\,q| = 1$ is
+      intentionally kept as a theorem-level hypothesis in PaperBNT
+      (see \texttt{PaperBNT/Api.lean} and \texttt{PaperBNT/Fundamental.lean}).
+      For decaying sectors such as $C \oplus \tfrac{1}{2}D$, this field is
+      false: no weight of the $D$ sector has unit modulus.  The
+      formalization therefore treats it as an explicit assumption rather than
+      a consequence of the block decomposition.
+  \end{enumerate}
+
+  The partial-supplier path of Phase~C
+  (see \texttt{docs/audits/2026-05-16\_phase\_C\_feasibility\_gpt55.md}, \S5)
+  outlines a route to a positive-length, normalized-input,
+  per-block-unit-assumed supplier theorem that would formalize the
+  non-trivial content of BNT existence for a large class of inputs.
+  Closing the full gap for arbitrary tensors remains an open formalization
+  direction.
+\end{remark}
+
+\subsection{After-blocking material in other chapters}%
+\label{subsec:after_blocking_other_chapters}
+
+Several declarations physically defined in
+\texttt{TNLean/MPS/CanonicalForm/SectorComparison/} and related modules belong
+logically to the after-blocking fundamental-theorem pipeline rather than to
+the canonical-form reduction proper.  Their blueprint \texttt{\textbackslash lean\{\ldots\}} tags
+live in \Cref{ch:ft_proof} and \Cref{ch:after_blocking} to reflect this;
+Chapter~\ref{ch:canonical} does not claim them as canonical-form theorems.
+
+Representative examples (navigable via the tagged theorems in those chapters):
+\begin{itemize}
+  \item \texttt{afterBlocking\_commonPrimitiveIrreducibleBlocks\_of\_reindexedNonzeroParts}
+    (\Cref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed})~---
+    produces common TP/primitive/irreducible sector decompositions for two
+    same-MPV tensors; tagged in \Cref{ch:after_blocking}.
+
+  \item \texttt{afterBlocking\_commonLengthCommonSectorData\_of\_sameMPV\textsubscript{2}}
+    (\Cref{thm:ft_after_blocking_common_length_common_sector_data})~---
+    the main common-length after-blocking structural theorem; tagged in
+    \Cref{ch:after_blocking}.
+
+  \item \texttt{bilateral\_commonPeriod\_blocking\_tp\_primitive\_normal}
+    (\Cref{thm:common_period_two_tensors})~---
+    common blocking period for two primitive normal tensors; tagged in
+    \Cref{ch:after_blocking}.
+
+  \item \texttt{unconditional\_commonPrimitiveIrreducibleBlocks}
+    (\Cref{thm:after_blocking_unconditional_common_primitive_irr})~---
+    removes the reindexing pre-hypothesis from the above; tagged in
+    \Cref{ch:ft_proof}.
+\end{itemize}
+
+The physical co-location of these files with the canonical-form layer is an
+artifact of the build dependency order; a future refactor may move them to a
+dedicated after-blocking module.  Until then, readers should consult
+Chapters~\ref{ch:ft_proof} and~\ref{ch:after_blocking} for the
+after-blocking pipeline documentation.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2843,3 +2843,81 @@ see in particular
 	the basis-of-normal-tensors and multiplicity comparison developed later, rather
 	than an artificial separation of equal weight norms.
 \end{remark}
+
+\subsection{Out-of-scope PGVWC06 theorems}%
+\label{subsec:pgvwc06_out_of_scope}
+
+This chapter follows the modern presentation of~\cite{Cirac2017MPDO_AnnPhys}
+and~\cite{Cirac2021Matrix}, which is better aligned with the Lean
+formalization architecture (TI site-independent tensors, transfer-map
+primitivity, and CPM fixed-point normalization).
+The 2007 preprint~\cite{PerezGarcia2007Matrix} contains eight named theorems
+in its canonical-form section~\S III (lines~399--1177 of \texttt{MPSarchive.tex}).
+Theorem~\texttt{Th:TIcanonical} has a partial, conditional counterpart here;
+the opening paragraphs of this chapter state that scope limitation explicitly.
+The remaining seven theorems are outside the formalization scope:
+
+\begin{itemize}
+  \item \textbf{Thm.~\texttt{OBC-Vidal} (lines~431--443): completeness and
+    OBC canonical form.}
+    Any pure state admits an OBC-MPS representation of bond dimension
+    $D\le d^{\lfloor N/2\rfloor}$ with simultaneous left-normalization and
+    a positive full-rank diagonal interleaving matrix~$\Lambda^{[m]}$.
+    \emph{Not formalized:} the chapter starts from a site-independent TI
+    tensor; constructing the finite-OBC Schmidt canonical form requires a
+    site-dependent Chain layer not present in this development.
+
+  \item \textbf{Thm.~\texttt{free-OBC} (lines~466--486): OBC representation
+    freedom.}
+    Every OBC-MPS $\{B^{[m]}_i\}$ is related to the canonical one by
+    site-local invertible gauge matrices $Y_j,Z_j$ with $Y_j Z_j = \mathbf{1}$.
+    \emph{Not formalized:} same reason as \texttt{OBC-Vidal}; local-gauge
+    analysis for site-dependent open-boundary matrices is outside the TI-MPS
+    scope.
+
+  \item \textbf{Thm.\ ``Site-independent matrices'' (lines~620--630).}
+    Every TI pure state with PBC on a finite ring of $N$ sites has a
+    site-independent MPS representation; a bond-$D$ OBC representation
+    lifts to one at bond dimension at most~$ND$.
+    \emph{Not formalized:} the chapter assumes a site-independent MPV tensor
+    as input; the block-circulant construction producing it is out of scope.
+
+  \item \textbf{Thm.~\texttt{Th:periodic} (lines~849--858): periodic
+    decomposition.}
+    If the transfer map of a single-block TI canonical MPS has $p$
+    eigenvalues of modulus~$1$, the state is a superposition of $p$
+    $p$-periodic states of bond dimension~$D$, and vanishes when $p \nmid N$.
+    \emph{Partially formalized:} the cyclic-sector machinery of
+    \cref{sec:cyclic_sectors} (\cref{thm:cyclic_sector_decomp_after_blocking})
+    removes the period and yields primitive sector tensors, but the explicit
+    state-vector decomposition into $p$-periodic summands is not separately
+    stated.
+
+  \item \textbf{Thm.\ ``Interpretation of $\Lambda$'' (lines~987--993).}
+    Under condition~C2, the eigenvalues of the half-chain reduced density
+    operator converge as $N\to\infty$ to $\Lambda\otimes\Lambda$ with
+    $\Lambda$ from Theorem~\texttt{Th:TIcanonical}.
+    \emph{Not formalized:} \cref{thm:CFII_data} produces $\Lambda$, but the
+    asymptotic eigenvalue statement requires correlation-length and entropy
+    material outside the scope of this chapter.
+
+  \item \textbf{Thm.~\texttt{thm-uniq} (lines~1002--1015): uniqueness of
+    the canonical form.}
+    Under condition~C1 with unique OBC canonical form, two TI canonical
+    $D$-MPS representations of the same state satisfy $B_i = U C_i U^\dagger$
+    for a global unitary~$U$.
+    \emph{Not formalized in this chapter:} a modern analogue is proved in
+    Chapter~\ref{ch:ft_proof} as
+    \texttt{MPSTensor.ft\_paper\_bnt\_equal\_global\_gauge};
+    the original finite-ring uniqueness of~\cite{PerezGarcia2007Matrix}
+    under C1/C2 and $N > 2L_0 + D^4$ is not covered here.
+
+  \item \textbf{Thm.\ ``Obtaining the TI canonical form''
+    (lines~1154--1165).}
+    The site-independent $D\times D$ matrices can be recovered from an OBC
+    canonical form by solving an $N$-independent system~(S) of $O(D^8)$
+    quadratic equations; every solution is related to the canonical form by
+    a global unitary.
+    \emph{Not formalized:} numerical and algorithmic recovery is entirely
+    out of scope; the chapter addresses existence and uniqueness abstractly.
+\end{itemize}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -28,6 +28,71 @@ The reduction draws on
 \cite{PerezGarcia2007Matrix}, \cite{Cirac2021Matrix},
 and~\cite[Chapter~6]{Wolf2012Quantum}.
 
+\section{Paper-faithful definitions}\label{sec:paper_faithful_defs}
+
+The strong predicates used elsewhere in this chapter
+(\texttt{IsCanonicalForm}, \texttt{IsNormalCanonicalForm},
+\texttt{IsCanonicalFormBNT}) bundle extra structure (left-canonical
+normalization, strict modulus ordering, one-copy-per-sector) beyond the
+literal source paper definitions. The Lean module
+\texttt{TNLean.MPS.CanonicalForm.PaperDefs} records the
+\emph{source-paper} predicates from~\cite{Cirac2017MPDO_AnnPhys}
+without strengthening, for use as the public anchors of the
+formalization.
+
+\begin{definition}[CPSV normal tensor (NT)]\label{def:nt_paper}
+	\lean{MPSTensor.IsNormalTensor}
+	\leanok
+	A tensor $A : \texttt{MPSTensor } d\, D$ is a \emph{normal tensor}
+	if (i)~$A$ admits no nontrivial invariant orthogonal projection
+	(\texttt{IsIrreducibleTensor}), and (ii)~its associated CPM
+	$\mathcal{E}_A(X) = \sum_i A^i X (A^i)^\dagger$ has a unique
+	eigenvalue of magnitude equal to its spectral radius which is
+	equal to one (\texttt{IsPrimitive (transferMap A)}, after
+	the spectral-radius normalization in
+	\cite[paragraph preceding the NT definition]{Cirac2017MPDO_AnnPhys}).
+\end{definition}
+
+\begin{definition}[CPSV canonical form (CF)]\label{def:cf_paper}
+	\lean{MPSTensor.IsCanonicalFormPaper}
+	\leanok
+	A tensor $A$ is in \emph{canonical form} if there is a finite family
+	of normal tensors $A_k : \texttt{MPSTensor } d\, D_k$ and weights
+	$\mu_k \in \mathbb{C}$ ($k = 1, \dots, r$) with
+	\[
+		A^i \;\cong\; \bigoplus_{k=1}^r \mu_k\, A_k^i
+	\]
+	in the sense that $A$ and the block-assembled tensor
+	$\texttt{toTensorFromBlocks}\,\mu\,A_\bullet$ generate the same
+	MPV family at every length, and the weights satisfy the
+	normalization $|\mu_k| \le 1$ for all $k$ and $|\mu_k| = 1$ for
+	at least one $k$.
+\end{definition}
+
+\begin{definition}[CPSV basis of normal tensors (BNT)]\label{def:bnt_paper}
+	\lean{MPSTensor.IsBNTPaper}
+	\leanok
+	A finite family $\{A_j\}_{j=1}^g$ of normal tensors is a
+	\emph{basis of normal tensors} for $A$ if (i)~each $A_j$ is normal,
+	(ii)~for every $N$, the MPV family $V^{(N)}(A)$ is a linear
+	combination of $\{V^{(N)}(A_j)\}_j$, and (iii)~there exists $N_0$
+	such that for all $N > N_0$ the MPV states
+	$\texttt{mpvState}\,A_j\,N$ are linearly independent.
+\end{definition}
+
+\begin{remark}[Bridges]
+	The module ships a light bridge
+	\texttt{IsNormalTensor.of\_irreducible\_and\_primitive} that
+	packages an \texttt{IsIrreducibleTensor} witness with a
+	\texttt{IsPrimitive (transferMap A)} witness. CF-side and
+	BNT-side bridges to the strong predicates of this chapter
+	(\texttt{IsNormalCanonicalForm}, \texttt{IsBNT}) are not
+	provided in \texttt{PaperDefs.lean} because they require either
+	a fundamental-theorem-level dependency or the
+	algebraic-to-spectral normality implication, both of which live
+	in downstream layers.
+\end{remark}
+
 \section{Block-diagonal construction}
 
 \begin{remark}

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -139,7 +139,7 @@ theorems.
 	normality are both preserved under blocking.
 \end{proof}
 
-\begin{theorem}[Structural after-blocking form of the fundamental theorem]%
+\begin{theorem}[Structural after-blocking decomposition]%
 	\label{thm:ft_after_blocking_structural}
 	\lean{MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂}
 	\leanok
@@ -168,6 +168,16 @@ theorems.
 	\uses{thm:tp_primitive_blockdecomp}
 	Apply Theorem~\ref{thm:tp_primitive_blockdecomp} separately to the two tensors.
 \end{proof}
+
+\begin{remark}[Structural after-blocking decomposition; not the FT block-matching theorem]
+  This theorem produces, for each of the two same-MPV tensors independently,
+  a TP/primitive/left-canonical block decomposition after blocking.  It does
+  \emph{not} derive any block matching, gauge equivalence, or phases between
+  the two decompositions; those are produced by the subsequent common-sector
+  pipeline in this chapter.  It is structural scaffolding for the FT proof,
+  not the multi-block fundamental theorem of
+  \cite[Theorem~II.1, lines~349--352]{Cirac2017MPDO_AnnPhys}.
+\end{remark}
 
 \begin{theorem}[Zero-tail decomposition after blocking]%
 	\label{thm:zero_tail_decomp_block_tensor}


### PR DESCRIPTION
## Summary

Closes the BNT-construction gap (objective (b) of the parent odyssey `ody_47fb202d18bb`) on the prepared-blocks input surface, plus comprehensive canonical-form chapter cleanup. Builds on PR #1750 (literal `GaugeEquiv P.toTensor Q.toTensor`).

### What this PR delivers

1. **`TNLean/MPS/FundamentalTheorem/PaperBNT/Supplier.lean`** (236 LoC): `exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks` — the BNT canonical-form supplier theorem. Given a prepared-blocks family (TP, primitive, irreducible, injective per block; antitone weight moduli; `‖μ_k‖ ≤ 1` and dominant block at modulus 1; gauge-phase-distinct equal-dim blocks), constructs an `IsBNTCanonicalForm P` for the phase-class-collapsed sector decomposition `P`, with a `SameMPV₂` witness to the input direct-sum tensor. All 9 fields close, no `sorry`/`axiom`/`admit`. CPSV16 §II.A L237-246 / §II.C L271-280 / appendix L1135-1149.

2. **`TNLean/MPS/CanonicalForm/PaperDefs.lean`** (202 LoC): three paper-faithful predicates aligned with CPSV16 §II.A line numbers:
   - `IsNormalTensor` = irreducible + primitive transfer map (L233-235)
   - `IsCanonicalFormPaper` = `Nonempty CanonicalFormPaperData` with NT-per-block + L246 normalization (L237-246)
   - `IsBNTPaper` = per-block NT + eventual MPV linear independence (L271-274)

3. **`TNLean/MPS/SharedInfra/BlockGauge.lean`** (142 LoC, new module): block-diagonal gauge plumbing factored out of `CanonicalForm` to break the layer inversion `MPS/CanonicalForm/ → MPS/FundamentalTheorem/`.

4. **`SectorDecomposition.lean` import retargeting**: 3 layer inversions resolved (commits `ccd958c0`, `23b5c24a`, `0828cc84`) — `MPS/CanonicalForm/` no longer imports from `MPS/FundamentalTheorem/`.

5. **Blueprint disclosure in `ch08_canonical.tex`** (+336 LoC, -0):
   - New "Paper-faithful definitions" section with `\lean{}` tags for `IsNormalTensor` / `IsCanonicalFormPaper` / `IsBNTPaper`.
   - "PaperBNT supplier interface" subsection documenting the prepared-blocks input shape + the open arbitrary-input direction.
   - "After-blocking material in other chapters" subsection listing the after-blocking declarations physically in `MPS/CanonicalForm/` but tagged in `ch11`/`ch11b`.
   - PGVWC06 out-of-scope theorems documented.
   - 7 trivial-constructor wrappers demoted from theorem status via `\begin{remark}` blocks (ch08, ch11, ch11b).

6. **Three confirmed-dead helpers deleted** from `SectorComparison/CommonBlockedCyclicSectorFamily.lean` and `SectorComparison/CommonPrimitiveBlockMatchingData.lean` (73 LoC).

### Honest gap (disclosed in blueprint, not hidden)

The supplier theorem requires **prepared blocks** (TP + primitive + irreducible + injective per block) and a global dominant-block unit-modulus normalization. The arbitrary-input bridge (taking an unconditional `MPSTensor` and producing the prepared-blocks data) is mathematically blocked for three concrete reasons spelled out in the blueprint and in `audits/2026-05-16_phase_C_feasibility_gpt55.md`:

- N=0 zero-tail bookkeeping requires `SameMPV₂` over `ℕ` rather than `≥ 1`;
- global rescaling can push some weights outside the modulus-≤-1 bound;
- per-block unit-modulus witness fails for legitimate decaying BNT sectors (e.g. `C ⊕ (1/2) C`).

The remaining bridge is open formalization work; this PR honestly discloses the gap rather than hiding it.

### Hygiene / verification

- `lake build TNLean` ✅ green (8638 jobs).
- `grep -rnE 'sorry|axiom|admit|native_decide' TNLean/MPS/CanonicalForm/ TNLean/MPS/FundamentalTheorem/PaperBNT/` is empty.
- `leanblueprint checkdecls` baseline preserved at 218 stale-tag failures (pre-existing; all new tags in this PR pass).
- New file LoC: all well under the 1000-line cap (236, 202, 142).

### Paper anchors

- CPSV16 §II.A L233-235 (NT def), L237-246 (CF normalization), L271-280 (BNT def).
- CPSV16 §II.C L1135-1149 (prop:char-BNT structural construction).
- CPSV21 §III.2 / Def 4.3 L1846-1884 (BNT per-block normalization).

### Stopping condition

This satisfies odyssey `ody_47fb202d18bb` objective (b) for the prepared-blocks input surface. Objective (a) is already on `main` as PR #1750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this adds new core predicates and a new construction theorem in the PaperBNT/FT path, plus refactors shared infrastructure and layering/import boundaries that could cause subtle downstream breakage.
> 
> **Overview**
> Adds a new *paper-faithful* definition layer (`CanonicalForm/PaperDefs.lean`) for CPSV16’s NT/CF/BNT predicates (`IsNormalTensor`, `IsCanonicalFormPaper`, `IsBNTPaper`), intended to be closer to the source paper than the existing strengthened canonical-form predicates.
> 
> Introduces a prepared-input PaperBNT “supplier” theorem (`PaperBNT/Supplier.lean`) that, given TP/primitive/irreducible/injective blocks with nonzero, normalized weights, constructs a phase-class-collapsed `SectorDecomposition` `P` and proves `SameMPV₂ P.toTensor (toTensorFromBlocks μ blocks)` plus `IsBNTCanonicalForm P`.
> 
> Refactors layering to remove CanonicalForm → FundamentalTheorem import inversions: moves block-diagonal gauge plumbing into `SharedInfra/BlockGauge.lean`, moves shared sector predicates/structures (incl. `HasBNTSectorData` and `SectorBasisOverlapSpanHypotheses`) into `SharedInfra/SectorDecomposition.lean`, retargets CanonicalForm imports accordingly, and exposes previously `private` phase-class sector constructors/lemmas needed by the supplier. Also adds a literal-coordinate global gauge theorem in `PaperBNT/FundamentalCoord.lean` and removes a few dead helpers in sector-comparison modules; blueprint chapters are updated to document these new “paper-faithful” anchors and the prepared-input supplier scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0828cc8432037d0dbde2694e9bb43d622dce27cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->