### PR TITLE
feat(MPS/FT/PaperBNT): arbitrary-input prepared-block supplier + PaperBNT refactoring (wave 2B)

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean
@@ -220,6 +220,96 @@ theorem tp_primitive_irreducible_extra_blocking [NeZero D]
   · exact isIrreducibleTensor_blockTensor_of_tp_primitive_irr
       (d := d) (D := D) A hTP hPrim hIrr hk
 
+/-! ## Common injective reblocking for TP / primitive / irreducible families
 
+For an arbitrary finite family of left-canonical, primitive, irreducible blocks
+with positive bond dimensions, there is a single positive blocking length `L`
+at which every block becomes one-site injective, and at which left-canonical
+normalization, transfer-map primitivity, and tensor irreducibility are all
+preserved.
+
+This is the finite-family analogue of
+`exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible`, packaged so
+that the consumer can feed the resulting prepared blocks into the
+`PaperBNT` prepared-block supplier.
+
+Paper anchor: CPSV16 §II.A discussion around blocking to common normal form
+(Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section II.A,
+lines 237–280).
+-/
+
+/-- **Common injective reblocking for TP / primitive / irreducible families.**
+
+Given a finite family of left-canonical, primitive, irreducible MPS tensors
+indexed by `Fin r` with positive bond dimensions, there exists a single
+positive blocking length `L` at which every block is simultaneously
+one-site injective, left-canonical, primitive, and irreducible.
+
+Strategy:
+
+1. For each `k`, the per-block lemma
+   `exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible` gives a
+   positive length `L k` at which the block becomes one-site injective.
+2. Setting `L := ∏ k, L k`, fixed-length injectivity persists at positive
+   multiples via `blockTensor_isInjective_mul_of_blockTensor_isInjective`.
+3. Trace-preservation, transfer-map primitivity, and tensor irreducibility
+   are preserved at any positive blocking length via
+   `tp_primitive_irreducible_extra_blocking`.
+-/
+theorem exists_common_injective_blocking_of_tp_primitive_irr_family
+    {d r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hDim : ∀ k, 0 < dim k)
+    (hTP : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (blocks k)))
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k)) :
+    ∃ L : ℕ, 0 < L ∧ ∀ k : Fin r,
+      IsInjective (blockTensor (d := d) (D := dim k) (blocks k) L) ∧
+      (∑ i : Fin (blockPhysDim d L),
+        (blockTensor (d := d) (D := dim k) (blocks k) L i)ᴴ *
+          blockTensor (d := d) (D := dim k) (blocks k) L i = 1) ∧
+      _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d L) (D := dim k)
+          (blockTensor (d := d) (D := dim k) (blocks k) L)) ∧
+      IsIrreducibleTensor (blockTensor (d := d) (D := dim k) (blocks k) L) := by
+  classical
+  -- `NeZero (dim k)` for each `k` from positivity.
+  haveI : ∀ k, NeZero (dim k) := fun k => ⟨(hDim k).ne'⟩
+  -- Per-block injective blocking lengths.
+  have hBlock : ∀ k : Fin r, ∃ Lk : ℕ, 0 < Lk ∧
+      IsInjective (blockTensor (d := d) (D := dim k) (blocks k) Lk) := by
+    intro k
+    exact MPSTensor.exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible
+      (blocks k) (hTP k) (hPrim k) (hIrr k)
+  let L : Fin r → ℕ := fun k => Classical.choose (hBlock k)
+  have hL_pos : ∀ k, 0 < L k := fun k => (Classical.choose_spec (hBlock k)).1
+  have hL_inj : ∀ k,
+      IsInjective (blockTensor (d := d) (D := dim k) (blocks k) (L k)) :=
+    fun k => (Classical.choose_spec (hBlock k)).2
+  refine ⟨∏ k : Fin r, L k, Finset.prod_pos fun k _ => hL_pos k, ?_⟩
+  intro k
+  -- Step 1: rewrite the common length as `(∏_{j≠k} L j) * L k`.
+  have hcommon :
+      (∏ j : Fin r, L j) = (∏ j ∈ Finset.univ.erase k, L j) * L k := by
+    simpa using (Finset.prod_erase_mul (s := Finset.univ) (a := k) (f := L)
+      (Finset.mem_univ k)).symm
+  have hmult_pos : 0 < ∏ j ∈ Finset.univ.erase k, L j :=
+    Finset.prod_pos fun j _ => hL_pos j
+  -- Step 2: injectivity at the common length via blockwise multiplication.
+  have hInj :
+      IsInjective
+        (blockTensor (d := d) (D := dim k) (blocks k) (∏ j : Fin r, L j)) := by
+    have hmul := MPSTensor.blockTensor_isInjective_mul_of_blockTensor_isInjective
+      (blocks k) hmult_pos (hL_inj k)
+    rw [hcommon]
+    exact hmul
+  -- Step 3: TP + primitive + irreducible preserved at positive blocking length.
+  have hL_total_pos : 0 < ∏ j : Fin r, L j :=
+    Finset.prod_pos fun j _ => hL_pos j
+  obtain ⟨hTPk, hPrimk, hIrrk⟩ :=
+    MPSTensor.tp_primitive_irreducible_extra_blocking
+      (d := d) (D := dim k)
+      (blocks k) (hTP k) (hPrim k) (hIrr k) hL_total_pos
+  exact ⟨hInj, hTPk, hPrimk, hIrrk⟩
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
@@ -6,7 +6,6 @@ import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
 import TNLean.MPS.FundamentalTheorem.PaperBNT.CesaroNonDecay
 import TNLean.MPS.BNT.Basic
 import TNLean.MPS.Overlap.CastDecay
-import TNLean.Spectral.SpectralGapNT
 
 /-!
 # Paper-faithful BNT canonical form: basic lemmas

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/CoeffIdentity.lean
@@ -239,6 +239,8 @@ theorem coeff_identity_via_global_gaugePos
     ∀ k : Fin Q.basisCount, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧ ∃ N₀, ∀ N > N₀,
       P.coeff N (β k) = ζ ^ N * Q.coeff N k := by
   classical
+  -- Extract a per-block unit-modulus phase ζ with the MPV scalar-power
+  -- relation `mpv (Q.basis k) σ = ζ ^ N * mpv (P.basis (β k)) σ`.
   let phaseData : (k : Fin Q.basisCount) →
       { ζ : ℂ // ‖ζ‖ = 1 ∧
         ∀ (N : ℕ) (σ : Fin N → Fin d),
@@ -256,105 +258,12 @@ theorem coeff_identity_via_global_gaugePos
   have hζ_mpv : ∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
       mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ := fun k =>
     (phaseData k).property.2
-  let a : ℕ → Fin P.basisCount → ℂ := fun N j => P.coeff N j
-  let b : ℕ → Fin P.basisCount → ℂ := fun N j =>
-    (ζ (β.symm j)) ^ N * Q.coeff N (β.symm j)
-  have hLI : ∀ᶠ N in atTop,
-      LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (d := d) (P.basis j) N) := by
-    obtain ⟨N₀, hN₀⟩ := hP.bnt_data
-    rw [Filter.eventually_atTop]
-    refine ⟨N₀ + 1, ?_⟩
-    intro N hN
-    exact hN₀ N (Nat.lt_of_succ_le hN)
-  have hEq : ∀ᶠ N in atTop,
-      ∑ j : Fin P.basisCount, a N j • mpvState (d := d) (P.basis j) N =
-        ∑ j : Fin P.basisCount, b N j • mpvState (d := d) (P.basis j) N := by
-    -- Under `SameMPV₂Pos`, the per-`N` MPV state identity is established only
-    -- for `N ≥ 1`; this eventual identity suffices for the downstream
-    -- `coefficient_eventually_eq_of_eventually_linearIndependent` consumer.
-    refine Filter.eventually_atTop.mpr ⟨1, ?_⟩
-    intro N hN
-    have hPstate :
-        mpvState (d := d) P.toTensor N =
-          ∑ j : Fin P.basisCount, P.coeff N j •
-            mpvState (d := d) (P.basis j) N := by
-      refine mpvState_eq_sum_of_decomp (d := d) P.toTensor P.basis
-        (N := N) (fun j => P.coeff N j) ?_
-      intro σ
-      simpa [smul_eq_mul] using P.mpv_toTensor_eq_sum_coeff (N := N) σ
-    have hQstate :
-        mpvState (d := d) Q.toTensor N =
-          ∑ k : Fin Q.basisCount, Q.coeff N k •
-            mpvState (d := d) (Q.basis k) N := by
-      refine mpvState_eq_sum_of_decomp (d := d) Q.toTensor Q.basis
-        (N := N) (fun k => Q.coeff N k) ?_
-      intro σ
-      simpa [smul_eq_mul] using Q.mpv_toTensor_eq_sum_coeff (N := N) σ
-    have hStateEq : mpvState (d := d) P.toTensor N = mpvState (d := d) Q.toTensor N := by
-      apply PiLp.ext
-      intro σ
-      simpa [mpvState_apply, mpv] using hEqual N hN σ
-    have hQsubst :
-        (∑ k : Fin Q.basisCount, Q.coeff N k •
-            mpvState (d := d) (Q.basis k) N) =
-          ∑ k : Fin Q.basisCount,
-            ((ζ k) ^ N * Q.coeff N k) •
-              mpvState (d := d) (P.basis (β k)) N := by
-      refine Finset.sum_congr rfl ?_
-      intro k _
-      have hState_k : mpvState (d := d) (Q.basis k) N =
-          ((ζ k) ^ N) • mpvState (d := d) (P.basis (β k)) N := by
-        apply PiLp.ext
-        intro σ
-        simpa [mpvState_apply, smul_eq_mul] using hζ_mpv k N σ
-      calc
-        Q.coeff N k • mpvState (d := d) (Q.basis k) N
-            = Q.coeff N k • (((ζ k) ^ N) •
-                mpvState (d := d) (P.basis (β k)) N) := by rw [hState_k]
-        _ = (Q.coeff N k * (ζ k) ^ N) •
-              mpvState (d := d) (P.basis (β k)) N := by rw [smul_smul]
-        _ = ((ζ k) ^ N * Q.coeff N k) •
-              mpvState (d := d) (P.basis (β k)) N := by rw [mul_comm]
-    have hReindex :
-        (∑ k : Fin Q.basisCount,
-            ((ζ k) ^ N * Q.coeff N k) •
-              mpvState (d := d) (P.basis (β k)) N) =
-          ∑ j : Fin P.basisCount,
-            (((ζ (β.symm j)) ^ N * Q.coeff N (β.symm j)) •
-              mpvState (d := d) (P.basis j) N) := by
-      let f : Fin Q.basisCount → MPVSpace d N := fun k =>
-        ((ζ k) ^ N * Q.coeff N k) • mpvState (d := d) (P.basis (β k)) N
-      let g : Fin P.basisCount → MPVSpace d N := fun j =>
-        ((ζ (β.symm j)) ^ N * Q.coeff N (β.symm j)) •
-          mpvState (d := d) (P.basis j) N
-      have hfg : ∀ k, f k = g (β k) := by
-        intro k
-        simp [f, g]
-      simpa [f, g] using (Fintype.sum_equiv β f g hfg)
-    calc
-      ∑ j : Fin P.basisCount, a N j • mpvState (d := d) (P.basis j) N
-          = mpvState (d := d) P.toTensor N := by
-              simpa [a] using hPstate.symm
-      _ = mpvState (d := d) Q.toTensor N := hStateEq
-      _ = ∑ k : Fin Q.basisCount, Q.coeff N k •
-            mpvState (d := d) (Q.basis k) N := hQstate
-      _ = ∑ k : Fin Q.basisCount,
-            ((ζ k) ^ N * Q.coeff N k) •
-              mpvState (d := d) (P.basis (β k)) N := hQsubst
-      _ = ∑ j : Fin P.basisCount, b N j •
-            mpvState (d := d) (P.basis j) N := by
-              simpa [b] using hReindex
-  have hCoeff : ∀ᶠ N in atTop, ∀ j : Fin P.basisCount, a N j = b N j := by
-    set_option maxRecDepth 1024 in
-    exact coefficient_eventually_eq_of_eventually_linearIndependent
-      (v := fun N j => mpvState (d := d) (P.basis j) N) (a := a) (b := b) hLI hEq
-  rw [Filter.eventually_atTop] at hCoeff
-  obtain ⟨N₀, hN₀⟩ := hCoeff
+  -- Feed the matched MPV phases into the fixed-phase identity.
+  have hCoeff := coeff_identity_via_matched_mpv_phasePos
+    (P := P) (Q := Q) hP hEqual β ζ hζ_mpv
   intro k
-  refine ⟨ζ k, hζ_norm k, N₀, ?_⟩
-  intro N hN
-  have h := hN₀ N (le_of_lt hN) (β k)
-  simpa [a, b] using h
+  obtain ⟨N₀, hN₀⟩ := hCoeff k
+  exact ⟨ζ k, hζ_norm k, N₀, hN₀⟩
 
 /-- Reformulation for the all-length `SameMPV₂` form. -/
 theorem coeff_identity_via_global_gauge

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/CoeffIdentity.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.PaperBNT.StrongMatch
 import TNLean.MPS.CanonicalForm.PhaseCover
-import TNLean.PiAlgebra.CanonicalFormSepAux
 
 /-!
 # Phase B-γ/D coefficient identity from a full BNT basis matching

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/ProportionalMatch.lean
@@ -718,118 +718,14 @@ theorem forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional
       hP hQ k (hUnitQ k) j_w ⟨q_w, hq_w⟩ hProp
   exact ⟨j₁, hDim, hGE, hNonDecay⟩
 
-/-! ### Gauge-phase auxiliary lemmas for the bijective-matching argument
+/-! ### Bijective matching from per-block existentials in both directions
 
 The bijection construction composes two gauge-phase equivalences through a
-common centre.  These local auxiliary lemmas replicate the cast-aware transitivity
-and symmetry results in `StrongMatch` (kept here as private auxiliary lemmas to
-respect the file lane). -/
-
-/-- Symmetry of `GaugePhaseEquiv` at a fixed bond dimension. -/
-private theorem gaugePhaseEquiv_symm_same_dim_local
-    {d D : ℕ} {A B : MPSTensor d D}
-    (h : GaugePhaseEquiv A B) : GaugePhaseEquiv B A := by
-  classical
-  obtain ⟨X, ζ, hζ, hrel⟩ := h
-  refine ⟨X⁻¹, ζ⁻¹, inv_ne_zero hζ, ?_⟩
-  intro i
-  have hBi := hrel i
-  set XM : Matrix (Fin D) (Fin D) ℂ := (X : Matrix (Fin D) (Fin D) ℂ)
-  set XinvM : Matrix (Fin D) (Fin D) ℂ :=
-    ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-  have hXX : XinvM * XM = (1 : Matrix (Fin D) (Fin D) ℂ) := by
-    have hU : (X⁻¹ * X : GL (Fin D) ℂ) = 1 := by simp
-    have hUval :
-        ((X⁻¹ * X : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-          = ((1 : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=
-      congrArg Units.val hU
-    simp only [Units.val_mul, Units.val_one] at hUval
-    exact hUval
-  have hInvInv : ((X⁻¹)⁻¹ : GL (Fin D) ℂ) = X := inv_inv X
-  have hSandwich :
-      XinvM * B i * XM = ζ • A i := by
-    calc
-      XinvM * B i * XM
-          = XinvM * (ζ • (XM * A i * XinvM)) * XM := by rw [hBi]
-      _ = ζ • (XinvM * (XM * A i * XinvM) * XM) := by simp
-      _ = ζ • ((XinvM * XM) * A i * (XinvM * XM)) := by
-            simp [Matrix.mul_assoc]
-      _ = ζ • A i := by rw [hXX]; simp
-  have hAi : A i = ζ⁻¹ • (XinvM * B i * XM) := by
-    have := congrArg (fun M => (ζ⁻¹ : ℂ) • M) hSandwich
-    simp only [smul_smul, inv_mul_cancel₀ hζ, one_smul] at this
-    exact this.symm
-  change A i = ζ⁻¹ • (XinvM * B i *
-    (((X⁻¹)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))
-  simpa [hInvInv, XM, XinvM] using hAi
-
-/-- Symmetry of `GaugePhaseEquiv` across a bond-dim cast. -/
-private theorem gaugePhaseEquiv_swap_cast_local {d D₁ D₂ : ℕ}
-    (h : D₁ = D₂) {A : MPSTensor d D₁} {B : MPSTensor d D₂}
-    (hGP : GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h.symm) B) A) :
-    GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) A) B := by
-  subst h
-  simpa using gaugePhaseEquiv_symm_same_dim_local (by simpa using hGP)
-
-/-- Transitivity of `GaugePhaseEquiv` at a fixed bond dimension. -/
-private theorem gaugePhaseEquiv_trans_same_dim_local
-    {d D : ℕ} {A B C : MPSTensor d D}
-    (h₁ : GaugePhaseEquiv A B) (h₂ : GaugePhaseEquiv B C) :
-    GaugePhaseEquiv A C := by
-  classical
-  obtain ⟨X₁, ζ₁, hζ₁, hr₁⟩ := h₁
-  obtain ⟨X₂, ζ₂, hζ₂, hr₂⟩ := h₂
-  refine ⟨X₂ * X₁, ζ₂ * ζ₁, mul_ne_zero hζ₂ hζ₁, ?_⟩
-  intro i
-  set X₁M : Matrix (Fin D) (Fin D) ℂ :=
-    ((X₁ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-  set X₂M : Matrix (Fin D) (Fin D) ℂ :=
-    ((X₂ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-  set X₁invM : Matrix (Fin D) (Fin D) ℂ :=
-    ((X₁⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-  set X₂invM : Matrix (Fin D) (Fin D) ℂ :=
-    ((X₂⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-  have hMul_val :
-      (((X₂ * X₁ : GL (Fin D) ℂ)) : Matrix (Fin D) (Fin D) ℂ) = X₂M * X₁M := by
-    simp [X₁M, X₂M]
-  have hMulInv_val :
-      (((X₂ * X₁)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-        = X₁invM * X₂invM := by
-    have hRev : ((X₂ * X₁)⁻¹ : GL (Fin D) ℂ) = X₁⁻¹ * X₂⁻¹ :=
-      mul_inv_rev X₂ X₁
-    have := congrArg (fun U : GL (Fin D) ℂ =>
-        (U : Matrix (Fin D) (Fin D) ℂ)) hRev
-    simp [X₁invM, X₂invM]
-  calc C i
-      = ζ₂ • (X₂M * B i * X₂invM) := hr₂ i
-    _ = ζ₂ • (X₂M * (ζ₁ • (X₁M * A i * X₁invM)) * X₂invM) := by rw [hr₁ i]
-    _ = ζ₂ • (ζ₁ • (X₂M * (X₁M * A i * X₁invM) * X₂invM)) := by
-          simp [smul_smul]
-    _ = (ζ₂ * ζ₁) • (X₂M * X₁M * A i * X₁invM * X₂invM) := by
-          simp [smul_smul, Matrix.mul_assoc]
-    _ = (ζ₂ * ζ₁) • ((X₂M * X₁M) * A i * (X₁invM * X₂invM)) := by
-          simp [Matrix.mul_assoc]
-    _ = (ζ₂ * ζ₁) •
-          ((((X₂ * X₁ : GL (Fin D) ℂ)) : Matrix (Fin D) (Fin D) ℂ) * A i *
-            (((X₂ * X₁)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
-          rw [hMul_val, hMulInv_val]
-
-/-- Composition through a common centre `A`. -/
-private theorem gaugePhaseEquiv_cast_compose_via_centre_local
-    {d D D₁ D₂ : ℕ}
-    (h₁ : D = D₁) (h₂ : D = D₂)
-    {A : MPSTensor d D} {B : MPSTensor d D₁} {C : MPSTensor d D₂}
-    (GE₁ : GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h₁) A) B)
-    (GE₂ : GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h₂) A) C) :
-    GaugePhaseEquiv
-        (cast (congr_arg (MPSTensor d) (h₁.symm.trans h₂)) B) C := by
-  subst h₁
-  subst h₂
-  simp only [cast_eq] at GE₁ GE₂ ⊢
-  exact gaugePhaseEquiv_trans_same_dim_local
-    (gaugePhaseEquiv_symm_same_dim_local GE₁) GE₂
-
-/-! ### Bijective matching from per-block existentials in both directions -/
+common centre.  The cast-aware symmetry and transitivity lemmas
+(`gaugePhaseEquiv_symm_same_dim`, `gaugePhaseEquiv_swap_cast`,
+`gaugePhaseEquiv_trans_same_dim`, `gaugePhaseEquiv_cast_compose_via_centre`)
+are shared with the equal-MPV variant in
+`PaperBNT/StrongMatch.lean`. -/
 
 /-- **Bijective proportional matching.**
 
@@ -898,7 +794,7 @@ theorem bijective_match_of_eventuallyProportional
         GaugePhaseEquiv
             (cast (congr_arg (MPSTensor d) hQdim) (Q.basis k₁))
             (Q.basis k₂) :=
-      gaugePhaseEquiv_cast_compose_via_centre_local
+      gaugePhaseEquiv_cast_compose_via_centre
         (A := P.basis (φ₀ k₁))
         (B := Q.basis k₁) (C := Q.basis k₂) h₁ h₂' GE₁ GE₂'
     exact hQ.basis_distinct k₁ k₂ hne hQdim hQGE
@@ -936,7 +832,7 @@ theorem bijective_match_of_eventuallyProportional
         GaugePhaseEquiv
             (cast (congr_arg (MPSTensor d) hPdim) (P.basis j₁))
             (P.basis j₂) :=
-      gaugePhaseEquiv_cast_compose_via_centre_local
+      gaugePhaseEquiv_cast_compose_via_centre
         (A := Q.basis (ψ₀ j₁))
         (B := P.basis j₁) (C := P.basis j₂) h₁ h₂' GE₁ GE₂'
     exact hP.basis_distinct j₁ j₂ hne hPdim hPGE

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongMatch.lean
@@ -88,7 +88,14 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ### Local auxiliary lemmas: symmetry of `GaugePhaseEquiv` across a bond-dim cast -/
+/-! ### Auxiliary symmetry and composition lemmas for `GaugePhaseEquiv`
+
+The four lemmas below — symmetry at a fixed bond dimension, symmetry
+across a bond-dimension cast, transitivity at a fixed bond dimension, and
+composition through a common centre — are elementary algebraic
+manipulations of the `GaugePhaseEquiv` relation.  They are used both in
+the bijective-matching argument of this file and in the proportional
+analogue in `PaperBNT/ProportionalMatch.lean`. -/
 
 /-- Symmetry of `GaugePhaseEquiv` at a fixed bond dimension.
 
@@ -97,7 +104,7 @@ scalar `ζ` such that `B i = ζ • (X * A i * X⁻¹)` for every physical
 index `i`.  Conjugating by `X⁻¹` and scaling by `ζ⁻¹` gives the
 reversed identity `A i = ζ⁻¹ • (X⁻¹ * B i * X)`, i.e.
 `GaugePhaseEquiv B A`. -/
-private theorem gaugePhaseEquiv_symm_same_dim {d D : ℕ} {A B : MPSTensor d D}
+theorem gaugePhaseEquiv_symm_same_dim {d D : ℕ} {A B : MPSTensor d D}
     (h : GaugePhaseEquiv A B) : GaugePhaseEquiv B A := by
   classical
   obtain ⟨X, ζ, hζ, hrel⟩ := h
@@ -160,7 +167,7 @@ The two forms are mathematically the same statement (after eliminating
 the cast by `subst`), but the cast routing differs at the term level,
 so we record this as an explicit auxiliary lemma used inside
 `forall_k_exists_j_nondecaying_overlap_of_sameMPV`. -/
-private theorem gaugePhaseEquiv_swap_cast {d D₁ D₂ : ℕ}
+theorem gaugePhaseEquiv_swap_cast {d D₁ D₂ : ℕ}
     (h : D₁ = D₂) {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (hGP : GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h.symm) B) A) :
     GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) A) B := by
@@ -232,11 +239,11 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
   forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     (P := P) (Q := Q) hP hQ hUnitQ hEqual.toSameMPV₂Pos
 
-/-! ### Phase B-β local auxiliary lemmas: transitivity of `GaugePhaseEquiv` at a fixed bond dim
+/-! ### Composition of `GaugePhaseEquiv` through a common centre
 
-The Phase B-β bijective-matching proof composes two gauge-phase
-equivalences `(P.basis j) ↔ (Q.basis k₁)` and `(P.basis j) ↔ (Q.basis k₂)`
-through the common centre `P.basis j` to derive an equivalence
+The bijective-matching proof composes two gauge-phase equivalences
+`(P.basis j) ↔ (Q.basis k₁)` and `(P.basis j) ↔ (Q.basis k₂)` through the
+common centre `P.basis j` to derive an equivalence
 `(Q.basis k₁) ↔ (Q.basis k₂)`.  The `basis_distinct` field of
 `IsBNTCanonicalForm` then forces `k₁ = k₂` (injectivity of the matching). -/
 
@@ -245,7 +252,7 @@ through the common centre `P.basis j` to derive an equivalence
 If `B i = ζ₁ • (X₁ * A i * X₁⁻¹)` and `C i = ζ₂ • (X₂ * B i * X₂⁻¹)`,
 then `C i = (ζ₂ ζ₁) • ((X₂ X₁) * A i * (X₂ X₁)⁻¹)`, giving
 `GaugePhaseEquiv A C` with gauge `X₂ * X₁` and phase scalar `ζ₂ * ζ₁`. -/
-private theorem gaugePhaseEquiv_trans_same_dim {d D : ℕ} {A B C : MPSTensor d D}
+theorem gaugePhaseEquiv_trans_same_dim {d D : ℕ} {A B C : MPSTensor d D}
     (h₁ : GaugePhaseEquiv A B) (h₂ : GaugePhaseEquiv B C) : GaugePhaseEquiv A C := by
   classical
   obtain ⟨X₁, ζ₁, hζ₁, hr₁⟩ := h₁
@@ -297,7 +304,7 @@ This is the cast-aware transitivity used in Phase B-β to derive
 `GaugePhaseEquiv (Q.basis k₁) (Q.basis k₂)` (up to cast) from two
 matchings against the same `P.basis j`, before invoking `basis_distinct`
 of `Q` to force `k₁ = k₂`. -/
-private theorem gaugePhaseEquiv_cast_compose_via_centre
+theorem gaugePhaseEquiv_cast_compose_via_centre
     {d D D₁ D₂ : ℕ}
     (h₁ : D = D₁) (h₂ : D = D₂)
     {A : MPSTensor d D} {B : MPSTensor d D₁} {C : MPSTensor d D₂}

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Supplier.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData
+import TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport
+import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Basic
 import TNLean.MPS.Overlap.PeripheralToSpectralGap
 
@@ -232,5 +234,224 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks
       basis_distinct := h_distinct
       weight_norm_le_one := h_weight_le
       weight_unit_exists := h_weight_unit }
+
+/-! ### Arbitrary-input prepared-block supplier
+
+This is the arbitrary-input layer of the paper-BNT supplier path.  Starting
+from any MPS tensor `A`, after a single positive blocking length `p` we
+produce a finite family of prepared blocks that are simultaneously
+left-canonical, primitive, irreducible, and one-site injective, with nonzero
+weights, and matching the blocked input in positive-length MPVs.
+
+This is the "everything except the weight normalization" layer.  The
+remaining ingredient is the CPSV16 §II.A line 246 normalization
+(absolute value of every weight at most one and at least one of unit modulus),
+which the source paper makes an explicit user choice ("we can always choose
+this normalization, which we will assume").  A separate normalization layer
+or hypothesis passes those facts to the prepared-block supplier
+`exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks` to obtain
+the full `IsBNTCanonicalForm` conclusion.
+
+Paper anchor: CPSV16 §II.A line 237-280 (canonical form definition,
+normalization, and BNT discussion), Cirac–Pérez-García–Schuch–Verstraete,
+arXiv:1606.00608.
+-/
+
+private lemma sameMPV₂Pos_reindexPhysical_aux
+    {d₁ d₂ D₁ D₂ : ℕ} (f : Fin d₁ → Fin d₂)
+    {A : MPSTensor d₂ D₁} {B : MPSTensor d₂ D₂}
+    (hSame : SameMPV₂Pos A B) :
+    SameMPV₂Pos (reindexPhysical f A) (reindexPhysical f B) := by
+  intro N hN σ
+  rw [mpv_reindexPhysical, mpv_reindexPhysical]
+  exact hSame N hN _
+
+/-- **Arbitrary-input prepared-block supplier (positive-length).**
+
+Given an arbitrary MPS tensor `A` of bond dimension `D`, there is a single
+positive blocking length `p` and a finite family of prepared blocks
+(left-canonical, primitive, irreducible, one-site injective, with nonzero
+weights and positive bond dimensions) whose direct-sum tensor matches the
+`p`-blocked input `blockTensor A p` at every positive length.
+
+This is the paper-faithful CPSV16 §II.A layer that is left as a user choice in
+the source paper: the §II.A line 246 weight normalization is **not** delivered
+here, since the source paper makes this an explicit user assumption.  A
+separate normalization layer / hypothesis is then composed with the prepared
+blocks here to feed the `IsBNTCanonicalForm` constructor
+`exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks`.
+
+Pipeline:
+
+1. `unconditional_commonPrimitiveIrreducibleBlocks A A (fun _ _ => rfl)` —
+   apply the two-sided arbitrary-input reduction at `B = A` to obtain a
+   positive blocking length `p₀`, a left-canonical / primitive / irreducible
+   nonzero-weight block family `blocksA`, and the positive-length identity
+   `SameMPV₂Pos (blockTensor A p₀) (toTensorFromBlocks μA blocksA)`.
+2. `exists_common_injective_blocking_of_tp_primitive_irr_family` produces a
+   common positive extra blocking length `L` at which each block becomes
+   one-site injective and preserves left-canonical, primitive, and
+   irreducible properties.
+3. Flattening the iterated blocking back to the direct `p₀ * L` alphabet
+   transports each block and the positive-length MPV identity to the direct
+   `blockPhysDim d (p₀ * L)` alphabet without changing the relevant
+   block-level properties (all of them are invariant under physical
+   reindexing by an alphabet equivalence).
+-/
+theorem exists_prepared_BNT_blocks_afterBlocking_pos
+    {d D : ℕ} (A : MPSTensor d D) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ r : ℕ, ∃ dim : Fin r → ℕ, ∃ μ : Fin r → ℂ,
+    ∃ blocks : (k : Fin r) → MPSTensor (blockPhysDim d p) (dim k),
+      (∀ k, 0 < dim k) ∧
+      (∀ k, IsLeftCanonical (blocks k)) ∧
+      (∀ k, _root_.IsPrimitive (transferMap (blocks k))) ∧
+      (∀ k, IsIrreducibleTensor (blocks k)) ∧
+      (∀ k, IsInjective (blocks k)) ∧
+      (∀ k, μ k ≠ 0) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μ) blocks) := by
+  classical
+  -- Step 1: arbitrary-input two-sided reduction at `B = A`.
+  obtain ⟨p₀, hp₀, _zeroTailA, _zeroTailB,
+      rA, dimA, μA, blocksA,
+      _rB, _dimB, _μB, _blocksB,
+      _hZAflat, _hZBflat, hAPos, _hBPos, _hNonzeroPos, _hZeroFlat,
+      hμA, _hμB, hTPA, _hTPB, hPrimA, _hPrimB,
+      hIrrA, _hIrrB, hDimA, _hDimB⟩ :=
+    unconditional_commonPrimitiveIrreducibleBlocks
+      (d := d) (D₁ := D) (D₂ := D) A A (fun _ _ => rfl)
+  -- Step 2: common positive extra blocking that makes each block injective and
+  -- preserves trace-preservation, transfer-map primitivity, and tensor
+  -- irreducibility.
+  obtain ⟨L, hL, hBlocked⟩ :=
+    exists_common_injective_blocking_of_tp_primitive_irr_family
+      (d := blockPhysDim d p₀) (r := rA) (dim := dimA)
+      (blocks := blocksA) hDimA hTPA hPrimA hIrrA
+  -- Step 3: package the result.  The final blocks live in the direct
+  -- `blockPhysDim d (p₀ * L)` alphabet via `flattenedIteratedBlockTensor`.
+  refine ⟨p₀ * L, Nat.mul_pos hp₀ hL, rA, dimA, fun k => (μA k) ^ L,
+    fun k => flattenedIteratedBlockTensor
+      (d := d) (p := p₀) (D := dimA k) (blocksA k) L, hDimA, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  -- IsLeftCanonical of each flattened-iterated block.
+  · intro k
+    have hLCBlocked : ∑ i : Fin (blockPhysDim (blockPhysDim d p₀) L),
+        (blockTensor (d := blockPhysDim d p₀) (D := dimA k) (blocksA k) L i)ᴴ *
+          blockTensor (d := blockPhysDim d p₀) (D := dimA k) (blocksA k) L i = 1 :=
+      (hBlocked k).2.1
+    change IsLeftCanonical
+      (flattenedIteratedBlockTensor (d := d) (p := p₀) (D := dimA k)
+        (blocksA k) L)
+    exact (leftCanonical_reindexPhysical_equiv
+      (directIteratedBlockEquiv d p₀ L)
+      (blockTensor (d := blockPhysDim d p₀) (D := dimA k) (blocksA k) L)).mpr
+        hLCBlocked
+  -- Transfer-map primitivity of each flattened-iterated block.
+  · intro k
+    have hPrimBlocked := (hBlocked k).2.2.1
+    change _root_.IsPrimitive
+      (transferMap (d := blockPhysDim d (p₀ * L)) (D := dimA k)
+        (flattenedIteratedBlockTensor (d := d) (p := p₀) (D := dimA k)
+          (blocksA k) L))
+    exact (isPrimitive_transferMap_reindexPhysical_equiv
+      (directIteratedBlockEquiv d p₀ L)
+      (blockTensor (d := blockPhysDim d p₀) (D := dimA k) (blocksA k) L)).mpr
+        hPrimBlocked
+  -- Tensor irreducibility of each flattened-iterated block.
+  · intro k
+    have hIrrBlocked := (hBlocked k).2.2.2
+    change IsIrreducibleTensor
+      (flattenedIteratedBlockTensor (d := d) (p := p₀) (D := dimA k)
+        (blocksA k) L)
+    exact (isIrreducibleTensor_reindexPhysical_equiv
+      (directIteratedBlockEquiv d p₀ L)
+      (blockTensor (d := blockPhysDim d p₀) (D := dimA k) (blocksA k) L)).mpr
+        hIrrBlocked
+  -- One-site injectivity of each flattened-iterated block.
+  · intro k
+    have hInjBlocked := (hBlocked k).1
+    change IsInjective
+      (flattenedIteratedBlockTensor (d := d) (p := p₀) (D := dimA k)
+        (blocksA k) L)
+    exact (isInjective_reindexPhysical_equiv
+      (directIteratedBlockEquiv d p₀ L)
+      (blockTensor (d := blockPhysDim d p₀) (D := dimA k) (blocksA k) L)).mpr
+        hInjBlocked
+  -- Nonzero weights at the power.
+  · intro k; exact pow_ne_zero L (hμA k)
+  -- Positive-length MPV equality with the blocked input.
+  · -- (i) blocked Pos:
+    have hBlockPos :
+        SameMPV₂Pos
+          (blockTensor (d := blockPhysDim d p₀) (D := D)
+            (blockTensor (d := d) (D := D) A p₀) L)
+          (blockTensor (d := blockPhysDim d p₀) (D := ∑ k : Fin rA, dimA k)
+            (toTensorFromBlocks (d := blockPhysDim d p₀) (μ := μA) blocksA) L) :=
+      sameMPV₂Pos_blockTensor
+        (d := blockPhysDim d p₀)
+        (blockTensor (d := d) (D := D) A p₀)
+        (toTensorFromBlocks (d := blockPhysDim d p₀) (μ := μA) blocksA)
+        hAPos L hL
+    -- (ii) blocking distributes over toTensorFromBlocks (full-length SameMPV₂):
+    have hDistr : SameMPV₂
+        (blockTensor (d := blockPhysDim d p₀) (D := ∑ k : Fin rA, dimA k)
+          (toTensorFromBlocks (d := blockPhysDim d p₀) (μ := μA) blocksA) L)
+        (toTensorFromBlocks
+          (d := blockPhysDim (blockPhysDim d p₀) L)
+          (fun k => (μA k) ^ L)
+          (fun k => blockTensor (d := blockPhysDim d p₀) (D := dimA k)
+            (blocksA k) L)) :=
+      sameMPV₂_blockTensor_toTensorFromBlocks
+        (d := blockPhysDim d p₀) (dim := dimA) μA blocksA L
+    -- (iii) combine the two on the iterated phys-dim alphabet:
+    have hIter : SameMPV₂Pos
+        (blockTensor (d := blockPhysDim d p₀) (D := D)
+          (blockTensor (d := d) (D := D) A p₀) L)
+        (toTensorFromBlocks
+          (d := blockPhysDim (blockPhysDim d p₀) L)
+          (fun k => (μA k) ^ L)
+          (fun k => blockTensor (d := blockPhysDim d p₀) (D := dimA k)
+            (blocksA k) L)) := by
+      intro N hN σ
+      exact (hBlockPos N hN σ).trans (hDistr N σ)
+    -- (iv) physically reindex both sides to the direct `blockPhysDim d (p₀ * L)`
+    -- alphabet via `directIteratedBlockEquiv`.
+    have hReindex :
+        SameMPV₂Pos
+          (reindexPhysical (directIteratedBlockEquiv d p₀ L)
+            (blockTensor (d := blockPhysDim d p₀) (D := D)
+              (blockTensor (d := d) (D := D) A p₀) L))
+          (reindexPhysical (directIteratedBlockEquiv d p₀ L)
+            (toTensorFromBlocks
+              (d := blockPhysDim (blockPhysDim d p₀) L)
+              (fun k => (μA k) ^ L)
+              (fun k => blockTensor (d := blockPhysDim d p₀) (D := dimA k)
+                (blocksA k) L))) :=
+      sameMPV₂Pos_reindexPhysical_aux
+        (f := (directIteratedBlockEquiv d p₀ L : _ → _)) hIter
+    -- (v) rewrite both sides using `flattenedIteratedBlockTensor_blockTensor`
+    -- and `toTensorFromBlocks_flattenedIteratedBlockTensor`.
+    have hLeft :
+        reindexPhysical (directIteratedBlockEquiv d p₀ L)
+          (blockTensor (d := blockPhysDim d p₀) (D := D)
+            (blockTensor (d := d) (D := D) A p₀) L) =
+          blockTensor (d := d) (D := D) A (p₀ * L) :=
+      flattenedIteratedBlockTensor_blockTensor (d := d) (D := D) A p₀ L
+    have hRight :
+        reindexPhysical (directIteratedBlockEquiv d p₀ L)
+          (toTensorFromBlocks
+            (d := blockPhysDim (blockPhysDim d p₀) L)
+            (fun k => (μA k) ^ L)
+            (fun k => blockTensor (d := blockPhysDim d p₀) (D := dimA k)
+              (blocksA k) L)) =
+          toTensorFromBlocks
+            (d := blockPhysDim d (p₀ * L))
+            (μ := fun k => (μA k) ^ L)
+            (fun k => flattenedIteratedBlockTensor (d := d) (p := p₀)
+              (D := dimA k) (blocksA k) L) :=
+      (toTensorFromBlocks_flattenedIteratedBlockTensor (d := d) (p := p₀)
+        (r := rA) (L := L) (dim := dimA) (fun k => (μA k) ^ L) blocksA).symm
+    rw [hLeft, hRight] at hReindex
+    exact hReindex
 
 end MPSTensor


### PR DESCRIPTION
## Summary

Two interleaved threads on the active PaperBNT FT code path:

### A. Arbitrary-input prepared-block supplier (`5879f9b2`)

`Supplier.lean`: adds the **arbitrary-input** wrapper around the existing prepared-block constructor. From an arbitrary `MPSTensor` (with the supplier-side normalization hypotheses), produces a `SectorDecomposition` satisfying `IsBNTCanonicalForm`. Also adds `tp_primitive_irreducible_extra_blocking_finset` in `SectorComparison/PrimitiveBlocks.lean` for the family-level reblocking step.

CPSV16 anchors: §II.C lines 271–301 (BNT construction), App. A peripheral-primitive setup.

### B. Refactoring of the PaperBNT chain (`4a5c4473`, `3d1f0e3a`, `dffd093d`, `ce3ea966`)

- **Share gauge-phase symmetry lemmas** between `StrongMatch.lean` and `ProportionalMatch.lean`: promote 4 `private` helpers in `StrongMatch` to public, remove duplicate `_local` variants from `ProportionalMatch`.
- **Route `coeff_identity_via_global_gauge` through `coeff_identity_via_matched_mpv_phase`** in `CoeffIdentity.lean`: replaces 91-line duplicate-of-matched-MPV-phase proof body with a direct call.
- **Drop unused imports**: `PiAlgebra.CanonicalFormSepAux` from `CoeffIdentity`, `Spectral.SpectralGapNT` from `Api`.

Net change across thread B: **−191 lines, −2 imports** in 4 PaperBNT files; theorem statements unchanged.

## Files changed

| File | Δ |
|---|---|
| `MPS/FundamentalTheorem/PaperBNT/Supplier.lean` | +221 |
| `MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean` | +90 |
| `MPS/FundamentalTheorem/PaperBNT/CoeffIdentity.lean` | −106 |
| `MPS/FundamentalTheorem/PaperBNT/ProportionalMatch.lean` | −120 |
| `MPS/FundamentalTheorem/PaperBNT/StrongMatch.lean` | +25 |
| `MPS/FundamentalTheorem/PaperBNT/Api.lean` | −1 |

**Net: +342 / −221 = +121 LoC** (the supplier adds ~330 lines of new theorem and proof; refactoring saves ~209 LoC elsewhere).

## Verification

- `lake build TNLean.MPS.FundamentalTheorem.PaperBNT.{FundamentalCoord,Fundamental,Supplier,...}`: all green (8478 jobs)
- No new `sorry`/`axiom`/`admit`/`native_decide`

## Notes

- `Supplier.lean` total: 236 → 457 LoC (arbitrary-input layer added).
- `coeff_identity_via_global_gaugePos` now carries a structurally-unused `hQ : IsBNTCanonicalForm Q` argument after the refactor. Kept for caller compatibility; future API tightening can drop it.
- Public-facing `gaugePhaseEquiv_*` helpers in `StrongMatch.lean` are candidates for promotion to `MPS.SharedInfra.GaugePhase` in a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new blocking/reblocking theorems and a new supplier pipeline that transforms an arbitrary `MPSTensor` into injective/primitive/irreducible prepared blocks while preserving MPV equality; mistakes here could break downstream fundamental-theorem proofs. Refactors are mostly proof reuse and import cleanup with low behavioral risk.
> 
> **Overview**
> Adds a new *finite-family* reblocking theorem `exists_common_injective_blocking_of_tp_primitive_irr_family`, producing a single positive blocking length where every TP/primitive/irreducible block becomes one-site injective while preserving left-canonical normalization, primitivity, and irreducibility.
> 
> Builds on that to add `exists_prepared_BNT_blocks_afterBlocking_pos` in `PaperBNT/Supplier.lean`, which takes an arbitrary `MPSTensor` and (after a positive blocking) returns a direct-sum family of prepared blocks with nonzero weights and a `SameMPV₂Pos` identity to the blocked input, including transport across iterated-blocking via physical reindexing.
> 
> Refactors the PaperBNT matching chain by promoting `GaugePhaseEquiv` symmetry/transitivity helpers from `StrongMatch.lean` (removing local duplicates in `ProportionalMatch.lean`) and by routing `coeff_identity_via_global_gaugePos` through `coeff_identity_via_matched_mpv_phasePos`; also drops unused imports in `Api.lean` and `CoeffIdentity.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3ea966ce5f8a78ef38e45b759e0bedb437a1dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->