### PR TITLE
style(root): clear build warnings

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -182,11 +182,13 @@ import TNLean.MPS.ParentHamiltonian.SuffixWindow
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
-import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 import TNLean.Axioms.Beigi
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.Martingale
+-- The finite-chain uniqueness capstone is kept out of the default root until
+-- the wrapped-window comparison and degenerate-window cases are proved.
+-- It remains available as `TNLean.MPS.ParentHamiltonian.UniqueGroundState`.
 
 -- Layer 4: Fundamental theorem (single block)
 import TNLean.MPS.Structure.LinearExtension
@@ -359,4 +361,5 @@ import TNLean.PEPS.Defs
 import TNLean.PEPS.VirtualInsertion
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.LocalGauge
-import TNLean.PEPS.FundamentalTheorem
+-- The PEPS fundamental theorem is an exploratory capstone with recorded
+-- paper-alignment gaps; it is deliberately not part of the default root.

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -234,8 +234,9 @@ theorem trace_ne_zero_of_injective [NeZero D] {A : MPSTensor d D}
     simpa [Matrix.traceLinearMap_apply] using congrArg (· 1) htr_zero
   simp [Matrix.trace_one, Fintype.card_fin, (Nat.cast_ne_zero (R := ℂ)).2 (NeZero.ne D)] at this
 
-/-- If $\Phi_A$ is injective and $\operatorname{range} \Phi_A \subseteq \operatorname{range} \Phi_B$,
-then $\ker \Phi_B = \{0\}$.
+/-- If $\Phi_A$ is injective and
+$\operatorname{range} \Phi_A \subseteq \operatorname{range} \Phi_B$, then
+$\ker \Phi_B = \{0\}$.
 
 By rank--nullity, $\dim(\operatorname{range} \Phi_A) = \dim V$,
 so $\dim(\operatorname{range} \Phi_B) \ge \dim V$, forcing $\ker \Phi_B = \{0\}$. -/

--- a/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
+++ b/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
@@ -82,7 +82,9 @@ finite-dimensional ℂ-algebra, being a subalgebra of `M_D(ℂ)`.
 
 This is a type alias for the subtype
 `↥(adjointFixedPointsStarSubalgebra K h_tp hρ hρ_fix)`. -/
-abbrev FixedPointAlgebra :=
+abbrev FixedPointAlgebra
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat}
+    (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) : Type _ :=
   ↥(adjointFixedPointsStarSubalgebra (d := d) (D := D) K h_tp hρ hρ_fix)
 
 /-- Every finite-dimensional `*`-subalgebra of `M_D(ℂ)` is a semisimple ring. -/

--- a/TNLean/Channel/Irreducible/Basic.lean
+++ b/TNLean/Channel/Irreducible/Basic.lean
@@ -26,7 +26,8 @@ on matrix algebras `M_D(ℂ)`.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2, Theorem 6.2][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2,
+  Theorem 6.2][Wolf2012QChannels]
 * [Evans, Høegh-Krohn, *Spectral properties of positive maps*, 1978][Evans1978Spectral]
 -/
 

--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -13,7 +13,8 @@ import Mathlib.Analysis.Matrix.Order
 # Lorentz normal form for quantum channels (Wolf Section 2.3, Propositions 2.8–2.11)
 
 This file formalises the existence results for normal forms of quantum channels
-under filtering operations, as described in Wolf Section 2.3 (Eqs. (2.35)-(2.43)).  The central idea is that
+under filtering operations, as described in Wolf Section 2.3
+(Eqs. (2.35)-(2.43)). The central idea is that
 every CP map with full Kraus rank can be brought to a doubly-stochastic normal
 form by pre- and post-composition with invertible Kraus-rank-1 CP maps (filtering
 operations).  For qubit channels (D = 2) the equivalence class under

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
@@ -231,9 +231,9 @@ section PeripheralUnitary
 /-- A peripheral eigenvalue of an irreducible unital Schwarz transfer map admits a unitary
 matrix eigenvector.
 
-This is the unitary part of Wolf Theorem 6.6. The formulation is stated for transfer maps of
-Kraus families because the available Kadison--Schwarz / multiplicative-domain interface is implemented
-at that level. -/
+This is the unitary part of Wolf Theorem 6.6. The formulation is stated for
+transfer maps of Kraus families because the available Kadison--Schwarz /
+multiplicative-domain interface is implemented at that level. -/
 theorem exists_peripheral_unitary_of_irreducible_schwarz
     {r D : ℕ} [NeZero D]
     (K : Fin r → MatrixAlg D)

--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -43,7 +43,8 @@ backwards compatibility even though the file no longer introduces an axiom).
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2 Theorems 6.3/6.5][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2
+  Theorems 6.3/6.5][Wolf2012QChannels]
 * [Cirac et al., arXiv:1606.00608, Appendix A][Cirac2017Annals]
 * [Evans–Høegh-Krohn, *Spectral properties of positive maps*, 1978][Evans1978Spectral]
 -/

--- a/TNLean/Channel/Primitive.lean
+++ b/TNLean/Channel/Primitive.lean
@@ -37,7 +37,8 @@ Within `section SpectralGapDecomposition`, we use local notation:
 * `N` for `E - P` (the complementary part)
 
 ## References
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.3 Theorem 6.7][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.3
+  Theorem 6.7][Wolf2012QChannels]
 -/
 
 open Matrix

--- a/TNLean/Channel/Schwarz/KadisonSchwarz.lean
+++ b/TNLean/Channel/Schwarz/KadisonSchwarz.lean
@@ -21,7 +21,8 @@ This file also proves the Hilbert–Schmidt contraction property.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 5, Equation (5.2)][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 5,
+  Equation (5.2)][Wolf2012QChannels]
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder

--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -255,9 +255,9 @@ lemma povmDiagonal_inv (w : ι → ℝ) (t : ℝ) (hw : ∀ i, w i ≠ 0) (ht : 
   congr 1
   funext a
   rcases a with ⟨i, _⟩ | _
-  · show ((w i : ℝ) : ℂ) * (((w i)⁻¹ : ℝ) : ℂ) = 1
+  · change ((w i : ℝ) : ℂ) * (((w i)⁻¹ : ℝ) : ℂ) = 1
     rw [← Complex.ofReal_mul, mul_inv_cancel₀ (hw i), Complex.ofReal_one]
-  · show ((t : ℝ) : ℂ) * (((t)⁻¹ : ℝ) : ℂ) = 1
+  · change ((t : ℝ) : ℂ) * (((t)⁻¹ : ℝ) : ℂ) = 1
     rw [← Complex.ofReal_mul, mul_inv_cancel₀ ht, Complex.ofReal_one]
 
 /-- Compressing the inverse of `povmDiagonal w t` by the POVM dilation. -/
@@ -269,6 +269,7 @@ lemma povmIsometry_compress_diagonal_inv
   rw [povmDiagonal_inv w t hw ht]
   exact povmIsometry_compress_diagonal (fun i => (w i)⁻¹) t⁻¹
 
+omit [DecidableEq ι] in
 /-- **Finite-POVM resolvent inequality.**
 
 Let `C_i` be a finite family of matrices defining POVM elements `B_i = C_i * (C_i)ᴴ`,

--- a/TNLean/Channel/Semigroup/Basic.lean
+++ b/TNLean/Channel/Semigroup/Basic.lean
@@ -41,7 +41,8 @@ finite-dimensional space is of the form `T_t = exp(tL)` for some generator `L`
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 7.1, Proposition 7.1][Wolf2012Quantum]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 7.1,
+  Proposition 7.1][Wolf2012Quantum]
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal TNOperatorSpace

--- a/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
@@ -62,7 +62,8 @@ i.e. `P(L⊗id)(|Ω⟩⟨Ω|)P ≥ 0`. Then Proposition 7.2 gives CCP.
 **Proof ingredients**:
 1. The CP hypothesis gives positivity of the Choi matrix of `exp(tL)`.
 2. Boundary differentiation of a PSD-valued curve yields positivity of the projected derivative.
-3. Wolf Proposition 7.2 identifies projected Choi positivity with conditional complete positivity. -/
+3. Wolf Proposition 7.2 identifies projected Choi positivity with conditional
+   complete positivity. -/
 theorem cp_semigroup_implies_ccp_generator
     (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hCP : ∀ t : ℝ, 0 ≤ t → IsCPMap (expSemigroup L t)) :

--- a/TNLean/Channel/Semigroup/Primitivity/Basic.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Basic.lean
@@ -59,7 +59,8 @@ space obtained from that slice.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 7.1, Proposition 7.5][Wolf2012Quantum]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 7.1,
+  Proposition 7.5][Wolf2012Quantum]
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators NNReal TNOperatorSpace

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -17,7 +17,6 @@ import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.WolfProps
 import TNLean.Channel.NormalForm
-import TNLean.Channel.LorentzNormalForm
 
 /-!
 # Wolf Lecture Notes — Chapter 2: Representations
@@ -25,6 +24,12 @@ import TNLean.Channel.LorentzNormalForm
 This file indexes the formalization of Chapter 2 of Wolf's
 *Quantum Channels & Operations: Guided Tour*, which covers the main
 representations of quantum channels.
+
+The Lorentz-normal-form statements are recorded in
+`TNLean.Channel.LorentzNormalForm`, but that file contains the compactness and
+classification proof obligations for Wolf Proposition 2.9. The index mentions
+those statements by name without importing the unfinished file into the
+default root.
 
 ## Coverage summary
 
@@ -229,11 +234,14 @@ representations of quantum channels.
 
 | Result | Notes |
 |--------|-------|
-| Theorem 2.5 (unitary form) | Reduced isometric form formalized; unitary form needs basis extension |
-| Section 2.3 Lorentz normal form (full proof) | Statement formalised (`exists_lorentz_normal_form_qubit`);
+| Theorem 2.5 (unitary form) | Reduced isometric form formalized; unitary form
+needs basis extension |
+| Section 2.3 Lorentz normal form (full proof) | Statement formalised
+(`exists_lorentz_normal_form_qubit`);
   proof blocked on compactness of bounded SL(n, ℂ) sets (`infimum_is_attained`) —
   see `LorentzNormalForm.lean` for details |
-| Section 2.3 Generic normal form (full proof) | Statement formalised (`exists_normal_form_generic`);
+| Section 2.3 Generic normal form (full proof) | Statement formalised
+(`exists_normal_form_generic`);
   proof blocked on same compactness lemma |
 | Section 2.3 Sorted singular values | Current SVD is unsorted; later uses want sorted values |
 

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -10,7 +10,8 @@ open scoped Matrix BigOperators
 # Iterated invariant-projection splitting: irreducible block decomposition
 
 This module implements the "iterate until all blocks are irreducible" step from
-Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3 (around eq. `\label{eq:II_Aiplusk1}`).
+Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3
+(around eq. `\label{eq:II_Aiplusk1}`).
 
 Starting from an arbitrary MPS tensor `A : MPSTensor d D`, we iteratively apply
 `MPSTensor.exists_twoBlock_decomp_of_lowerZero_strict` — which produces two blocks each with

--- a/TNLean/MPS/Examples/AKLT.lean
+++ b/TNLean/MPS/Examples/AKLT.lean
@@ -234,7 +234,8 @@ theorem aklt_isNormal : IsNormal akltTensor := ⟨2, aklt_isNBlkInjective_two⟩
 /-! ### Z₂ on-site symmetry -/
 
 /-- The Z₂ physical action on the spin-1 basis ${|+1\rangle, |0\rangle, |-1\rangle}$:
-the generator acts as the matrix $\begin{pmatrix} -1 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & 1 & 0 \end{pmatrix}$. -/
+the generator acts as the matrix
+$\begin{pmatrix} -1 & 0 & 0 \\ 0 & 0 & 1 \\ 0 & 1 & 0 \end{pmatrix}$. -/
 def akltZ2Action :
     Multiplicative (ZMod 2) →* Matrix (Fin 3) (Fin 3) ℂ where
   toFun g := if Multiplicative.toAdd g = 0 then 1

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -396,9 +396,11 @@ matrix, and are essential for the "strict dimension decrease" argument used when
 iterating the canonical-form splitting step.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem 3 (lines 769–803): the recursion terminates
-  because each irreducible block has strictly smaller bond dimension.
-* Cirac et al., arXiv:1606.00608, Section 2.3: the same argument in a slightly different presentation.
+* Perez-Garcia et al., quant-ph/0608197, Theorem 3 (lines 769–803): the
+  recursion terminates because each irreducible block has strictly smaller bond
+  dimension.
+* Cirac et al., arXiv:1606.00608, Section 2.3: the same argument in a slightly
+  different presentation.
 -/
 
 section SupportProjNontriviality

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -3,14 +3,16 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.Counterexample
-import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
 
 /-!
 # Finite-length sufficient conditions and obstructions for MPDO biCF
 
 This module retains the historical import path for the MPDO biCF derivation
 layer while the finite-length criteria are organized by their mathematical
-role.
+role. It imports the proof-complete obstruction and criterion layer. The
+direct-sum uniqueness capstone remains available from its own files, but is not
+imported here while it depends on the unfinished parent-Hamiltonian uniqueness
+argument.
 
 The supporting modules are:
 
@@ -36,7 +38,8 @@ The supporting modules are:
 * `TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum` — the BNT-facing direct-sum
   form that supplies that distinctness input from separated same-dimension
   blocks and gives the fixed three-block pair separation for all ordered pairs,
-  while keeping the direct-sum injectivity hypotheses explicit.
+  while keeping the direct-sum injectivity hypotheses explicit. This capstone
+  is imported directly by users who need the unfinished uniqueness route.
 
 ## References
 

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/Algebra.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/Algebra.lean
@@ -624,8 +624,9 @@ private theorem matrixAlgEquiv_dim_eq {D₁ D₂ : ℕ}
     (e : MatD D₁ ≃ₐ[ℂ] MatD D₂) :
     D₁ = D₂ := by
   have hfin := LinearEquiv.finrank_eq (e : MatD D₁ ≃ₗ[ℂ] MatD D₂)
-  simp [MatD, Module.finrank_matrix, Fintype.card_fin] at hfin
-  exact Nat.mul_self_inj.mp hfin
+  have hdim : D₁ * D₁ = D₂ * D₂ := by
+    simpa [MatD, Module.finrank_matrix, Fintype.card_fin] using hfin
+  exact Nat.mul_self_inj.mp hdim
 
 private noncomputable def matrixPairSubalgebra_algEquiv_of_axisIdealsHetero_eq_bot {D₁ D₂ : ℕ}
     (S : Subalgebra ℂ (MatD D₁ × MatD D₂))

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -47,7 +47,8 @@ once the remaining local-to-global implication has been formalized.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Appendix C.2, Proposition C.5 and Theorem 4.9
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Proposition C.5 and Theorem 4.9
 -/
 
 open scoped Matrix ComplexOrder

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -53,7 +53,8 @@ the MPS-scoped location matches the existing layering.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Proposition IV.12 and the auxiliary Lemma L in the appendix
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition IV.12 and the auxiliary Lemma L in the appendix
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -123,7 +124,8 @@ structure HorizontalCFData {r : ℕ} {dim : Fin r → ℕ}
   `Δ k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ` pairs to zero against every
   length-`L` block-diagonal product, then each `Δ k` vanishes individually.
 
-  This is the block-decomposed surrogate for [Cirac--Perez-Garcia--Schuch--Verstraete 2017], Proposition IV.3
+  This is the block-decomposed surrogate for
+  [Cirac--Perez-Garcia--Schuch--Verstraete 2017], Proposition IV.3
   (arXiv:1606.00608, "`propblockinj`"): after blocking at most `3 D^5` spins,
   where `D` denotes the bond dimension in the paper (in this block-decomposed
   setting one may take `D` to be a global bound such as `⨆ k, dim k`),

--- a/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
+++ b/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
@@ -8,7 +8,8 @@ import TNLean.MPS.ParentHamiltonian.SuffixWindow
 /-!
 # Right-extension for block-injective parent-Hamiltonian ground spaces
 
-This file proves the open-chain grow-back step from [Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section~4.3, lines 2049--2094].
+This file proves the open-chain grow-back step from
+[Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section~4.3, lines 2049--2094].
 Starting from the compatibility family extracted by
 `MPSTensor.exists_left_tail_compatibility`, we show that block injectivity forces
 all boundary matrices `Z j` to share a common right factor. This yields the

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -35,7 +35,9 @@ of the parent Hamiltonian (see `UniqueGroundState.lean`).
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, Section~4.3 (see in particular lines 1976--2000 for the parent Hamiltonian definition, lines 2013--2078 for the intersection property)
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+  Section~4.3 (see in particular lines 1976--2000 for the parent Hamiltonian
+  definition, lines 2013--2078 for the intersection property)
 * [MPGSC18] arXiv:1804.04964, Section 3 (one-sided inverse)
 * [FNW92] Sections 3–4
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
-import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 
 /-!
 # Martingale-method spectral-gap framework for parent Hamiltonians
@@ -16,17 +15,18 @@ parent-Hamiltonian spectral gap. The Friedrichs-angle estimate needed
 to close `parentHamiltonian_gapped` is tracked by issues #952 and #460
 (#190). See issue #1512 for the root-only audit.
 
-This file collects the four submodules:
+This file collects the three proof-complete infrastructure submodules:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale` (quadratic form ⟹ norm bound);
 * `Martingale.Transport` — Euclidean local projectors, ground-space /
   Hamiltonian transport, positivity, commutation, and kernel identification;
 * `Martingale.Reduction` — martingale quadratic-form reduction chain from
-  ordered cross-term bounds down to concrete cyclic-window Friedrichs;
-* `Martingale.Gap` — the final spectral-gap pair
-  `parentHamiltonianES_gap_bound_of_friedrichs` and
-  `parentHamiltonian_gapped`.
+  ordered cross-term bounds down to concrete cyclic-window Friedrichs.
+
+The final spectral-gap pair `parentHamiltonianES_gap_bound_of_friedrichs` and
+`parentHamiltonian_gapped` remains in `Martingale.Gap`; it is not imported here
+until the Friedrichs-angle estimate is proved.
 
 ## Proof route
 

--- a/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
@@ -14,7 +14,8 @@ This file provides a small reusable collection for transporting the parent-Hamil
 open-chain restriction maps (`contiguousRestrictₗ`, `tailRestrictₗ`,
 `restrictFirst`) across arithmetic-equal indexings of the total length. It is
 aimed at the periodic-chain normal-form range-reduction argument
-(see [Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section~4.3, lines 2049--2094]), where intermediate induction steps naturally produce
+(see [Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section~4.3,
+lines 2049--2094]), where intermediate induction steps naturally produce
 states indexed by `K + 1 + L₀` that have to be viewed as states indexed by
 `K + (L₀ + 1)`, or states indexed by `N - (L₀ + 1) + (L₀ + 1)` that have to be
 viewed as states indexed by `N`.

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -52,7 +52,9 @@ with the periodic boundary condition:
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, Section~4.3, lines 1976--2094 (parent Hamiltonian definition and uniqueness argument)
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+  Section~4.3, lines 1976--2094 (parent Hamiltonian definition and uniqueness
+  argument)
 * [FNW92] Sections 3–4
 * [PGVWC07] arXiv:quant-ph/0608197, Sections 5–6
 
@@ -856,7 +858,8 @@ with the span of the MPV with the reduced window `L > L₀` (instead of `2L₀`)
 
 The normality hypothesis enables the range reduction from `2L₀` to `L₀ + 1`
 via the structure theory of normal MPS (peripheral spectrum, canonical form).
-See [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, Section~4.3, lines 2049--2094. -/
+See [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+Section~4.3, lines 2049--2094. -/
 -- TODO(parent-hamiltonian): derive using the normal-form range reduction and
 -- the cyclic-window definition of `chainGroundSpace`.
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]

--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -463,24 +463,28 @@ def edgeBoundaryToInsertedBoundaryConfig (A : Tensor G d) (e : Edge G)
   leftResidual := β.leftResidual
   rightResidual := β.rightResidual
 
+omit [Fintype V] in
 @[simp] theorem edgeBoundaryToInsertedBoundaryConfig_leftEdgeIndex
     (A : Tensor G d) (e : Edge G) (β : EdgeBoundaryConfig (G := G) A e) :
     (edgeBoundaryToInsertedBoundaryConfig (G := G) A e β).leftEdgeIndex =
       β.edgeIndex :=
   rfl
 
+omit [Fintype V] in
 @[simp] theorem edgeBoundaryToInsertedBoundaryConfig_rightEdgeIndex
     (A : Tensor G d) (e : Edge G) (β : EdgeBoundaryConfig (G := G) A e) :
     (edgeBoundaryToInsertedBoundaryConfig (G := G) A e β).rightEdgeIndex =
       β.edgeIndex :=
   rfl
 
+omit [Fintype V] in
 @[simp] theorem edgeBoundaryToInsertedBoundaryConfig_leftResidual
     (A : Tensor G d) (e : Edge G) (β : EdgeBoundaryConfig (G := G) A e) :
     (edgeBoundaryToInsertedBoundaryConfig (G := G) A e β).leftResidual =
       β.leftResidual :=
   rfl
 
+omit [Fintype V] in
 @[simp] theorem edgeBoundaryToInsertedBoundaryConfig_rightResidual
     (A : Tensor G d) (e : Edge G) (β : EdgeBoundaryConfig (G := G) A e) :
     (edgeBoundaryToInsertedBoundaryConfig (G := G) A e β).rightResidual =
@@ -597,6 +601,7 @@ omit [Fintype V] in
     localVirtualConfigSplitAt_symm_apply_snd (G := G) A (edgeRightIncident (G := G) e)
       (β.rightEdgeIndex, β.rightResidual) ie
 
+omit [Fintype V] in
 @[simp] theorem edgeInsertedLeftLocalConfig_edgeBoundaryToInsertedBoundaryConfig
     (A : Tensor G d) (e : Edge G) (β : EdgeBoundaryConfig (G := G) A e) :
     edgeInsertedLeftLocalConfig (G := G) A e
@@ -604,6 +609,7 @@ omit [Fintype V] in
       edgeLeftLocalConfig (G := G) A e β :=
   rfl
 
+omit [Fintype V] in
 @[simp] theorem edgeInsertedRightLocalConfig_edgeBoundaryToInsertedBoundaryConfig
     (A : Tensor G d) (e : Edge G) (β : EdgeBoundaryConfig (G := G) A e) :
     edgeInsertedRightLocalConfig (G := G) A e
@@ -619,6 +625,7 @@ instance instFintypeEdgeComplementConfig (A : Tensor G d) (e : Edge G) :
     Fintype (EdgeComplementConfig (G := G) A e) :=
   inferInstance
 
+omit [DecidableRel G.Adj] in
 private theorem edge_ne_of_middle_incident (e : Edge G) {v : V}
     (hv : v ∈ edgeMiddleVertices e) (ie : IncidentEdge G v) : ie.1 ≠ e := by
   intro hie
@@ -627,12 +634,14 @@ private theorem edge_ne_of_middle_incident (e : Edge G) {v : V}
   · exact hvne.1 (hleft.symm.trans (congrArg (fun f : Edge G => f.1.1) hie))
   · exact hvne.2 (hright.symm.trans (congrArg (fun f : Edge G => f.1.2) hie))
 
+omit [Fintype V] [DecidableRel G.Adj] in
 private theorem otherLeft_edge_ne (e : Edge G)
     (ie : OtherIncidentEdge (G := G) e.1.1 (edgeLeftIncident (G := G) e)) :
     ie.1.1 ≠ e := by
   intro hie
   exact ie.2 (Subtype.ext hie)
 
+omit [Fintype V] [DecidableRel G.Adj] in
 private theorem otherRight_edge_ne (e : Edge G)
     (ie : OtherIncidentEdge (G := G) e.1.2 (edgeRightIncident (G := G) e)) :
     ie.1.1 ≠ e := by
@@ -680,6 +689,7 @@ def edgeMiddleConfigToOpenMiddleConfig (A : Tensor G d) (e : Edge G)
       · intro ie
         exact η.2.2.2 ie⟩
 
+omit [Fintype V] in
 @[simp] theorem edgeMiddleConfigToOpenMiddleConfig_apply (A : Tensor G d) (e : Edge G)
     (β : EdgeBoundaryConfig (G := G) A e)
     (η : EdgeMiddleConfig (G := G) A e β) (f : {f : Edge G // f ≠ e}) :
@@ -709,12 +719,14 @@ noncomputable def edgeOpenMiddleConfigToMiddleConfig (A : Tensor G d) (e : Edge 
           have hne := otherRight_edge_ne (G := G) e ie
           simpa [hne] using ζ.2.2 ie⟩
 
+omit [Fintype V] in
 @[simp] theorem edgeOpenMiddleConfigToMiddleConfig_edge (A : Tensor G d) (e : Edge G)
     (β : EdgeBoundaryConfig (G := G) A e)
     (ζ : EdgeOpenMiddleConfig (G := G) A e β.leftResidual β.rightResidual) :
     (edgeOpenMiddleConfigToMiddleConfig (G := G) A e β ζ).1 e = β.edgeIndex := by
   simp [edgeOpenMiddleConfigToMiddleConfig]
 
+omit [Fintype V] in
 @[simp] theorem edgeOpenMiddleConfigToMiddleConfig_apply_ne (A : Tensor G d) (e : Edge G)
     (β : EdgeBoundaryConfig (G := G) A e)
     (ζ : EdgeOpenMiddleConfig (G := G) A e β.leftResidual β.rightResidual)

--- a/TNLean/QPF/PosDef.lean
+++ b/TNLean/QPF/PosDef.lean
@@ -39,7 +39,8 @@ instead of `IsInjective A`.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2, Theorem 6.3 item 2][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2,
+  Theorem 6.3 item 2][Wolf2012QChannels]
 * [Evans, Høegh-Krohn, *Spectral properties of positive maps*, 1978][Evans1978Spectral]
 -/
 

--- a/TNLean/Wielandt/RankOne/Construction.lean
+++ b/TNLean/Wielandt/RankOne/Construction.lean
@@ -12,7 +12,8 @@ import Mathlib.Data.List.FinRange
 /-!
 # Rank-one construction (reductions)
 
-`TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean` already proves the **vector-to-matrix spanning step** of
+`TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean` already proves the
+**vector-to-matrix spanning step** of
 Wielandt Lemma 2(b): if
 
 * word products of length `n` applied to a vector `φ` span all of `ℂ^D`, and
@@ -395,7 +396,8 @@ theorem vecMulVec_pi_single_mem_wordSpan_of_rankOne
 single rank-one element `|φ⟩⟨ψ|` inside `wordSpan A m` together with a row
 spreading statement `rowSpreadSpan A ψ k = ⊤`, then `wordSpan A (n + (m+k)) = ⊤`.
 
-This composes the reduction above with the vector-to-matrix spanning lemma from `SpanGrowth/VectorToMatrixSpan.lean`.
+This composes the reduction above with the vector-to-matrix spanning lemma from
+`SpanGrowth/VectorToMatrixSpan.lean`.
 -/
 theorem wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOne
     (A : MPSTensor d D) (φ ψ : Fin D → ℂ) {n m k : ℕ}

--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -344,7 +344,8 @@ This combines the rank-one extraction with the blocked fixed-length matrix spann
 - When `N₀ = 0`: `wordSpan A 0 = ⊤` directly.
 - When `N₀ ≥ 1`: writing `B := blockTensor A N₀`, the rank-one extraction gives
   `vecMulVec φ ψ ∈ wordSpan B (D + N₀ + D)`, where the middle `N₀` is the
-  blocked-tensor full-span witness `wordSpan B N₀ = ⊤`; the blocked fixed-length matrix spanning then
+  blocked-tensor full-span witness `wordSpan B N₀ = ⊤`; the blocked
+  fixed-length matrix spanning then
   produces `wordSpan A ((4D - 2 + N₀) * N₀) = ⊤`.
 
 The bound `N = (4D - 2 + N₀) * N₀` is coarse. -/


### PR DESCRIPTION
### Motivation

- The default `TNLean` root build accumulated Lean linter and style warnings from long docstring lines, unused typeclass parameters, and proof-script steps that are better written explicitly.
- Capstone files with unresolved proof obligations (`ParentHamiltonian.UniqueGroundState`, `PEPS.FundamentalTheorem`, etc.) were imported by the root, obscuring genuine `sorry` obligations in the default build surface (see #1512 for the orphan-module audit).

### Description

- Wraps long mathematical reference and docstring lines across approximately 30 files to satisfy the 100-character line-length limit.
- Replaces two `show` tactic steps with `change` in `TNLean/Channel/Schwarz/OperatorJensenAux.lean`, where the goals are definitionally equal to the displayed expressions.
- Adds local `omit` scopes for unused typeclass parameters to suppress unused-variable warnings (notably in `TNLean/Channel/Schwarz/OperatorJensenAux.lean` and `TNLean/PEPS/Blocking.lean`).
- Replaces one `simp ... at hfin` step with an explicit dimension equality in `TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/Algebra.lean`.
- Makes the fixed-point algebra abbreviation's parameters explicit in `TNLean/Channel/FixedPoint/WedderburnDecomp.lean` to resolve abbreviation/implicit-argument warnings.
- Removes the following files from the default root import (`TNLean.lean`), leaving them available via direct import:
  - `TNLean.Channel.LorentzNormalForm`
  - `TNLean.PEPS.FundamentalTheorem`
  - `TNLean.MPS.ParentHamiltonian.UniqueGroundState`
  - `TNLean.MPS.ParentHamiltonian.Martingale.Gap`
  - the MPDO direct-sum uniqueness route depending on parent-Hamiltonian uniqueness.
- No new `sorry`, `axiom`, proof bypass, or linter-disabling option is introduced.

### Testing

- `lake build -q --log-level=info` completed with exit code 0 and no warning output after rebasing onto `origin/main` at `489dcc81cf452ce3bbdb7cd61081c25e31ae8558`.
- Additional spot-checks: `git diff --check`, `lake env lean TNLean/Channel/WolfChapter2Index.lean`, `lake env lean TNLean/MPS/ParentHamiltonian/Martingale.lean`, `lake env lean TNLean/MPS/MPDO/BiCFDerivation.lean`.

---

Partially addresses #1512

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly formatting/typeclass-scope tweaks, but it also changes the default `TNLean.lean` import surface by dropping several unfinished capstone modules, which could affect downstream users relying on implicit imports.
> 
> **Overview**
> Reduces default `TNLean` root build warnings by rewrapping long docstrings/references and applying small proof-script cleanups (e.g., `show`→`change`, more explicit intermediate equalities, and local `omit` scopes for unused typeclass parameters).
> 
> Adjusts the *public import surface* to keep known-unfinished capstone files out of the default root (e.g., `MPS.ParentHamiltonian.UniqueGroundState`, `Channel.LorentzNormalForm`, `PEPS.FundamentalTheorem`, and the martingale gap endpoint), while leaving them available via direct import; also makes `FixedPointAlgebra` parameters explicit to avoid abbreviation/implicit-argument issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b96f6debfda7d0898677132f9be1864c6d6beb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->