### PR TITLE
style(blueprint+lean): drop process language and Lean-jargon prose from ch01-ch14

### DIFF
--- a/TNLean/Channel/FixedPoint/Algebra.lean
+++ b/TNLean/Channel/FixedPoint/Algebra.lean
@@ -41,7 +41,7 @@ variable {d D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-section Helpers
+section AuxiliaryLemmas
 
 @[simp] theorem map_add (K : Fin d → Mat) (X Y : Mat) :
     map K (X + Y) = map K X + map K Y := by
@@ -75,7 +75,7 @@ private theorem isUnital_conjTranspose_of_isTP (K : Fin d → Mat) (h_tp : IsTP 
     IsUnital (fun i => (K i)ᴴ) := by
   simpa [IsUnital, IsTP] using h_tp
 
-end Helpers
+end AuxiliaryLemmas
 
 section FixedPoints
 

--- a/TNLean/Channel/Irreducible/KrausSetup.lean
+++ b/TNLean/Channel/Irreducible/KrausSetup.lean
@@ -8,7 +8,7 @@ import TNLean.Channel.PerronFrobenius.Existence
 /-!
 # Shared Kraus setup for irreducible CP maps
 
-This file factors out the common boilerplate used when an irreducible
+This file factors out the routine setup when an irreducible
 completely positive map is converted into an irreducible Kraus family and then
 paired with the adjoint Perron--Frobenius eigenvector of that family.
 
@@ -82,7 +82,7 @@ theorem exists_nonzero_kraus
       MPSTensor.transferMap (d := hSetup.n) (D := D) hSetup.K = 0 :=
     LinearMap.ext fun X => by
       simp [MPSTensor.transferMap_apply, hK_zero]
-  exact hE (by simpa only [hSetup.map_eq] using htransfer_zero)
+  exact hE (hSetup.map_eq.trans htransfer_zero)
 
 /-- Shared adjoint Perron--Frobenius data extracted from an irreducible CP map. -/
 theorem exists_posDef_adjoint_eigenvector
@@ -92,10 +92,9 @@ theorem exists_posDef_adjoint_eigenvector
     ∃ (σ : Matrix (Fin D) (Fin D) ℂ) (r : ℝ),
       σ.PosDef ∧ 0 < r ∧
       MPSTensor.transferMap (d := hSetup.n) (D := D)
-        (fun i => (hSetup.K i)ᴴ) σ = (r : ℂ) • σ := by
-  exact
-    MPSTensor.exists_posDef_adjoint_eigenvector
-      (d := hSetup.n) (D := D) hSetup.K hSetup.irreducible
-      (hSetup.exists_nonzero_kraus hE)
+        (fun i => (hSetup.K i)ᴴ) σ = (r : ℂ) • σ :=
+  MPSTensor.exists_posDef_adjoint_eigenvector
+    (d := hSetup.n) (D := D) hSetup.K hSetup.irreducible
+    (hSetup.exists_nonzero_kraus hE)
 
 end IrreducibleCPKrausSetup

--- a/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
+++ b/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
@@ -149,7 +149,7 @@ private lemma shiftIndex_succ {m : ℕ} [NeZero m] (k : Fin m) (n : ℕ) :
 
 end CyclicShift
 
-section PreservesCornerHelper
+section CornerPreservation
 
 /-- Corner preservation is stable under taking powers. -/
 private lemma preserves_corner_pow {S : MatrixEnd D} {P : MatrixAlg D}
@@ -180,7 +180,7 @@ private lemma preserves_corner_pow {S : MatrixEnd D} {P : MatrixAlg D}
         _ = (S ^ n) (S (P * X * P)) := this
         _ = (S ^ (n + 1)) (P * X * P) := by simp [pow_succ]
 
-end PreservesCornerHelper
+end CornerPreservation
 
 section PerCycle
 
@@ -303,10 +303,10 @@ The permutation is the sigma-product of per-cycle cyclic shifts; the
 projections are the flattened family; the cyclic action on the sigma
 index matches the per-cycle action on each `Fin (period c)`.
 
-This provides an assembly point: given a Wolf Theorem 6.16 Wedderburn-based
-existence result (currently blocked on issues #27/#360), the resulting
-`MultiCycleDecomposition` can be flattened to a `CycleStructure` for use
-with the existing block-permutation formalization in
+This connects multi-cycle decompositions to the block-permutation theory:
+given a Wolf Theorem 6.16 Wedderburn-based existence result (currently blocked
+on issues #27/#360), the resulting `MultiCycleDecomposition` can be flattened
+to a `CycleStructure` for use with
 `TNLean.Channel.Peripheral.Cycles`. -/
 noncomputable def toCycleStructure (M : MultiCycleDecomposition T) :
     CycleStructure T :=

--- a/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
@@ -44,7 +44,7 @@ namespace KadisonSchwarz
 
 /-! ## Auxiliary lemmas -/
 
-section Helpers
+section AuxiliaryLemmas
 
 /-- Trace of `krausMap` equals trace of the original matrix times ∑ Kᵢ† Kᵢ. When TP, this
 equals the original trace. -/
@@ -69,7 +69,7 @@ private theorem krausMap_smul (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     krausMap K (μ • X) = μ • krausMap K X := by
   simp only [krausMap, smul_mul_assoc, mul_smul_comm, Finset.smul_sum]
 
-end Helpers
+end AuxiliaryLemmas
 
 /-! ## KS equality for peripheral eigenvectors -/
 

--- a/TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean
@@ -30,7 +30,7 @@ namespace KadisonSchwarz
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-section Helpers
+section AuxiliaryLemmas
 
 @[simp] theorem krausMap_add (K : Fin d → Mat) (X Y : Mat) :
     krausMap K (X + Y) = krausMap K X + krausMap K Y := by
@@ -52,7 +52,7 @@ theorem conjTranspose_krausMap (K : Fin d → Mat) (X : Mat) :
     (krausMap K X)ᴴ = krausMap K Xᴴ := by
   rw [krausMap_conjTranspose]
 
-end Helpers
+end AuxiliaryLemmas
 
 section Definitions
 

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -68,7 +68,7 @@ The formal Lean declaration:
 
 > `Wielandt.Primitivity.StronglyIrreducibleToFullRank` proves the implication
 > `IsStronglyIrreduciblePaper A → krausRank A = D` (equivalently,
-> `wordSpan A 1 = ⊤`).  This is the paper-faithful proof of the hardest direction
+> `wordSpan A 1 = ⊤`).  This proves the hardest direction
 > in the Sanz–Pérez-García–Wolf–Cirac primitivity equivalence.
 
 ## External input — Perez-Garcia et al. invariant subspace decomposition

--- a/TNLean/MPS/CanonicalForm/PaperDefs.lean
+++ b/TNLean/MPS/CanonicalForm/PaperDefs.lean
@@ -9,9 +9,9 @@ import TNLean.MPS.SharedInfra.BlockAssembly
 import TNLean.Channel.Peripheral.Spectrum
 
 /-!
-# Paper-faithful definitions: NT, CF, BNT (CPSV16)
+# Normal tensor, canonical form, and basis of normal tensors (CPSV16)
 
-This module records the **paper-faithful** definitions of the three central notions
+This module records the definitions of the three central notions
 from arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete, "Matrix product density
 operators: Renormalization fixed points and boundary theories"):
 
@@ -86,7 +86,7 @@ variable {d D : ℕ}
 /-! ## Normal tensor (NT) -/
 
 /--
-`MPSTensor.IsNormalTensor A` is the paper-faithful **normal tensor** predicate from
+`MPSTensor.IsNormalTensor A` is the **normal tensor** predicate from
 arXiv:1606.00608, Definition before eq. `II_CF1` (`Papers/1606.00608/MPDO-22-12-17-2.tex:233-235`):
 
 * (i) `A` admits no nontrivial invariant orthogonal projection, and
@@ -121,7 +121,7 @@ theorem IsNormalTensor.of_irreducible_and_primitive
 /-! ## Canonical form (CF) -/
 
 /--
-`MPSTensor.CanonicalFormPaperData A` is the data of a paper-faithful canonical-form
+`MPSTensor.CanonicalFormPaperData A` is the data of a canonical-form
 decomposition of `A` from arXiv:1606.00608 eq. `II_CF1` plus the normalization paragraph
 immediately following (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`):
 
@@ -154,8 +154,8 @@ structure CanonicalFormPaperData (A : MPSTensor d D) where
   weight_unit_exists : ∃ k, ‖weights k‖ = 1
 
 /--
-`MPSTensor.IsCanonicalFormPaper A` is the propositional paper-faithful **canonical form**
-predicate (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`): `A` admits a normal-block
+`MPSTensor.IsCanonicalFormPaper A` is the propositional **canonical form**
+predicate from arXiv:1606.00608 (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`): `A` admits a normal-block
 direct-sum decomposition with weights normalized to `|μ_k| ≤ 1` and at least one
 `|μ_k| = 1`.
 
@@ -174,9 +174,8 @@ theorem IsCanonicalFormPaper.of_data
 /-! ## Basis of normal tensors (BNT) -/
 
 /--
-`MPSTensor.IsBNTPaper A blocks` is the paper-faithful **basis of normal tensors** predicate
-from arXiv:1606.00608, Definition `prop:char-BNT` is preceded by the BNT definition at
-`Papers/1606.00608/MPDO-22-12-17-2.tex:271-274`:
+`MPSTensor.IsBNTPaper A blocks` is the **basis of normal tensors** predicate
+from arXiv:1606.00608 (`Papers/1606.00608/MPDO-22-12-17-2.tex:271-274`):
 
 * (i) each `blocks j` is a CPSV16 normal tensor,
 * (ii) for each system length `N`, the MPV family of `A` is in the linear span of

--- a/TNLean/MPS/CanonicalForm/SectorComparison.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison.lean
@@ -12,8 +12,7 @@ import TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData
 # Canonical-form reduction after blocking
 
 This module is the public entry point for the complete canonical-form
-reduction after blocking. It keeps the historical import path
-`TNLean.MPS.CanonicalForm.Assembly` available while the underlying development is
+reduction after blocking. The underlying development is
 split across focused supporting modules.
 
 The supporting modules are:
@@ -38,8 +37,8 @@ The supporting modules are:
   after the zero-tail and TP-gauge structural reduction.
 * `TNLean.MPS.CanonicalForm.SectorComparison.StructuralData` — common-period blocking
   and structural after-blocking data.
-* `TNLean.MPS.CanonicalForm.SectorComparison.StructuralTheorem` — historical re-export
-  path for structural data and common-sector transport.
+* `TNLean.MPS.CanonicalForm.SectorComparison.StructuralTheorem` — structural data and
+  common-sector transport.
 * `TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport` — zero-tail and
   common-sector transport after the structural theorem.
 * `TNLean.MPS.CanonicalForm.SectorComparison.CommonPrimitiveBlockMatchingData` —

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveBlockMatchingData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonPrimitiveBlockMatchingData.lean
@@ -275,7 +275,7 @@ noncomputable def globalX (G : BlockMatchingGaugePhaseData blocksA blocksB) :
     GL (Fin (∑ k : Fin rA, dimB (G.perm k))) ℂ :=
   globalGaugeOfBlocks G.X
 
-/-- Explicit global-gauge witness for the matched block assembly.
+/-- Explicit global-gauge witness for the matched block direct sum.
 
 When per-block phases are absorbed into the block weights via
 `μA k = μB (perm k) * phase k`, the weighted direct sum of the permuted right

--- a/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
@@ -69,8 +69,8 @@ canonical-form reduction.  It imports four Wielandt modules:
    reaches the full matrix algebra, with an explicit bound on the stopping time.
 
 3. **`Wielandt.RectangularSpan.Basic`** — the rectangular span theory for Wielandt
-   Lemma 2(b): provides the conditional assembly `wielandt_lemma2b_conditional` that
-   reduces the full-rank conclusion to finding a rank-one element in the word span.
+   Lemma 2(b): `wielandt_lemma2b_conditional` reduces the full-rank conclusion to
+   finding a rank-one element in the word span.
 
 4. **`Wielandt.Primitivity.StronglyIrreducibleToFullRank`** — the hardest direction
    of the primitivity equivalence (Proposition 3(a)→(c) of arXiv:0909.5347): strong

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Api.lean
@@ -8,10 +8,9 @@ import TNLean.MPS.BNT.Basic
 import TNLean.MPS.Overlap.CastDecay
 
 /-!
-# Paper-faithful BNT canonical form: basic lemmas
+# Auxiliary lemmas for the BNT canonical-form predicate `IsBNTCanonicalForm`
 
-This module provides the elementary lemmas for the paper-faithful
-core predicate `IsBNTCanonicalForm` introduced in
+Elementary lemmas for the predicate `IsBNTCanonicalForm` introduced in
 `PaperBNT/Basic.lean`.  All lemmas here use the **raw** sector data
 `P.weight j q` and `P.coeff N j = ∑_q (P.weight j q)^N`; no equal-modulus
 factorisation is assumed.  The optional `HasEqualModulusWeightLayer`
@@ -31,7 +30,7 @@ not imported here.
   between distinct basis blocks decays, dispatched by bond-dimension equality
   (CPSV16 lines 1080–1091; CPSV16 lines 264–279).
 * `IsBNTCanonicalForm.combined_family_eventually_li` — combined-family
-  eventual linear independence for two paper-faithful BNT canonical forms
+  eventual linear independence for two BNT canonical forms
   with mutually vanishing cross-overlaps (CPSV16 corollary Lem1,
   lines 1121–1132; CPSV21 line 1850 BNT linear-independence input).
 * `IsBNTCanonicalForm.norm_coeff_le_copies` — the structural-field reading
@@ -124,9 +123,9 @@ variable {P Q : SectorDecomposition d}
 
 /-- **Cross-overlap between distinct basis blocks decays.**
 
-For any two distinct basis indices `j ≠ k` of a paper-faithful BNT
-canonical form, the MPV overlap `mpvOverlap (P.basis j) (P.basis k) N`
-tends to `0` as `N → ∞`.
+For any two distinct basis indices `j ≠ k` of a BNT canonical form
+satisfying `IsBNTCanonicalForm`, the MPV overlap
+`mpvOverlap (P.basis j) (P.basis k) N` tends to `0` as `N → ∞`.
 
 The dispatch follows CPSV16 lines 1080–1091 (the normal-tensor overlap
 dichotomy):
@@ -158,14 +157,14 @@ lemma cross_overlap_basis_tendsto_zero
       (h.basis_left_canonical j) (h.basis_left_canonical k)
       hdim
 
-/-- **Combined-family eventual linear independence** for two
-paper-faithful BNT canonical forms with mutually vanishing cross-overlaps.
+/-- **Combined-family eventual linear independence** for two BNT canonical
+forms with mutually vanishing cross-overlaps.
 
-This is the paper-faithful instantiation of corollary Lem1
-(CPSV16 lines 1121–1132): once the cross-overlaps between the two BNT
-families vanish, the union of basis MPV states is linearly independent
-for all sufficiently large lengths.  CPSV21 line 1850 states the same
-linear-independence input as part of the BNT definition.
+This is the instantiation of corollary Lem1 (CPSV16 lines 1121–1132): once the
+cross-overlaps between the two BNT families vanish, the union of basis MPV
+states is linearly independent for all sufficiently large lengths.  CPSV21
+line 1850 states the same linear-independence input as part of the BNT
+definition.
 
 The proof feeds the per-family normalised self-overlaps, the
 within-family cross-decay from `cross_overlap_basis_tendsto_zero`, and
@@ -190,14 +189,13 @@ lemma combined_family_eventually_li
     (hB_off := fun _ _ hk => hQ.cross_overlap_basis_tendsto_zero hk)
     (hAB := hAB)
 
-/-- **Coefficient norm bound under the canonical-form line-246
-normalization.**
+/-- **Coefficient norm bound under the line-246 normalization.**
 
 A direct consequence of the structural field `weight_norm_le_one`
-(CPSV16 §II.A line 246): under the paper-faithful canonical form, the
-sector coefficient `P.coeff N j = ∑_q (P.weight j q)^N` is bounded in
-modulus by the multiplicity `P.copies j`.  This is the structural-field
-reading of the prior explicit-hypothesis lemma
+(CPSV16 §II.A line 246): the sector coefficient
+`P.coeff N j = ∑_q (P.weight j q)^N` is bounded in modulus by the
+multiplicity `P.copies j`.  This is the structural-field reading of the
+prior explicit-hypothesis lemma
 `SectorDecomposition.norm_coeff_le_copies_of_norm_weight_le_one`. -/
 lemma norm_coeff_le_copies
     (h : IsBNTCanonicalForm P) (N : ℕ) (j : Fin P.basisCount) :

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Basic.lean
@@ -9,9 +9,9 @@ import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.Overlap.Basic
 
 /-!
-# Paper-faithful BNT canonical form on a `SectorDecomposition`
+# BNT canonical form on a `SectorDecomposition`
 
-This module introduces the paper-faithful canonical-form predicate
+This module introduces the canonical-form predicate
 `IsBNTCanonicalForm` over a `SectorDecomposition d`.
 
 The structure is the minimal CPSV16/CPSV21 BNT canonical-form data on top of
@@ -35,9 +35,9 @@ copy coefficients) — is **not** a structural field of `IsBNTCanonicalForm`.
 The fundamental-theorem statements (`coeff_not_tendsto_zero_at_block`,
 `exists_block_match_of_sameMPV`, `bijective_match_of_sameMPV`,
 `ft_paper_bnt_equal_*`) take the per-block witness as an explicit
-hypothesis at the theorem level.  This keeps the canonical-form predicate
-maximally paper-faithful and quarantines the line-1182 paper-implicit
-convention to the theorems that actually need it.
+hypothesis at the theorem level, keeping the canonical-form predicate
+minimal and the line-1182 implicit convention local to the theorems
+that actually need it.
 
 The structure does **not** impose an equal-modulus or strict-order
 condition on the raw sector weights `P.weight j q`.  CPSV16
@@ -84,7 +84,7 @@ namespace MPSTensor
 variable {d : ℕ}
 
 /--
-**Paper-faithful BNT canonical form (core).**
+**BNT canonical form (core predicate `IsBNTCanonicalForm`).**
 
 Given `P : SectorDecomposition d`, this captures the minimal CPSV16/CPSV21
 BNT canonical-form data without any equal-modulus or strict-ordering

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/CoeffIdentity.lean
@@ -6,16 +6,15 @@ import TNLean.MPS.FundamentalTheorem.PaperBNT.StrongMatch
 import TNLean.MPS.CanonicalForm.PhaseCover
 
 /-!
-# Phase B-γ/D coefficient identity from a full BNT basis matching
+# Coefficient identity for full BNT basis matching (CPSV16 §II.C lines 1187–1188)
 
 This module contains the CPSV16 §II.C lines 1187–1188 coefficient
-comparison in the Phase D, full-basis form.  The earlier Phase B version
-worked over a unit-modulus subset and produced an asymptotic difference.  Phase D
-strengthens `IsBNTCanonicalForm` with CPSV21 §III.2 / Definition 4.3
-per-block spectral-radius-one normalization, upgrades matching to a full
-bijection `β : Fin Q.basisCount ≃ Fin P.basisCount`, and therefore the
-substitution has no residual unmatched terms.  A-only BNT linear
-independence gives eventual **exact** coefficient identities.
+comparison in the full-basis bijection form.  The full basis bijection
+`β : Fin Q.basisCount ≃ Fin P.basisCount` (from `StrongMatch`) together with
+`IsBNTCanonicalForm`'s CPSV21 §III.2 / Definition 4.3 per-block
+spectral-radius-one normalization ensures the substitution has no residual
+unmatched terms.  BNT linear independence of the `P`-basis
+(`hP.bnt_data`) then yields eventual **exact** coefficient identities.
 
 Paper anchors:
 
@@ -84,10 +83,9 @@ then `SameMPV₂ P.toTensor Q.toTensor` and the BNT linear independence of the
 `P.coeff N (β k) = (ζ k)^N * Q.coeff N k`.
 
 Unlike `coeff_identity_via_global_gauge`, this statement keeps the phase
-function explicit.  Phase E uses it to keep the coefficient/weight comparison
-coupled to the same per-block gauge matrices that are later assembled into
-`X = ⊕_k (𝟙_{r_k} ⊗ X_k)`; this is the paper-faithful reading of CPSV16 §II.C
-lines 1187–1192. -/
+function explicit.  The coefficient/weight comparison is coupled to the
+per-block gauge matrices that are later combined into
+`X = ⊕_k (𝟙_{r_k} ⊗ X_k)`, following CPSV16 §II.C lines 1187–1192. -/
 theorem coeff_identity_via_matched_mpv_phasePos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P)
@@ -226,7 +224,7 @@ an eventual exact coefficient identity
 
 This is the formal counterpart of CPSV16 line 1188's exact power-sum
 comparison; it deliberately avoids the unsound asymptotic-difference to
-full-multiset route identified in the Phase B completion audit. -/
+full-multiset route noted in the multiplicity-audit memo. -/
 theorem coeff_identity_via_global_gaugePos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
@@ -9,12 +9,11 @@ import TNLean.MPS.Overlap.CastDecay
 import TNLean.Analysis.ConvergenceHelpers
 
 /-!
-# Full-block matching on the paper-faithful BNT canonical-form surface
+# Single-block gauge-phase matching for BNT canonical forms
 
-This module is **Phase 4b-ii** of the CPSV16/CPSV21 fundamental-theorem
-clean-slate plan (issue #1688).  It produces the **gauge-phase match** for a
-single BNT basis block of one BNT canonical form against some block of the
-other, under `SameMPV₂` of the assembled tensors.
+This module produces the **gauge-phase match** for a single BNT basis block of
+one BNT canonical form against some block of the other, under `SameMPV₂` of
+the assembled tensors.
 
 The module has three layers:
 
@@ -30,7 +29,7 @@ The module has three layers:
    equivalent (cast-left shape) to the `P`-block at `j₀`,
    and with a non-decaying cross-overlap.
 
-## Hypothesis disclosure (paper-faithful)
+## Hypothesis structure
 
 The block matching at a **user-supplied** sector index
 `j₀ : Fin P.basisCount` (with an externally provided unit-modulus
@@ -89,7 +88,7 @@ strong-induction step of the CPSV16 `II_cor2` argument.
 ## Tags
 
 matrix product states, fundamental theorem, BNT, BNT basis block,
-gauge-phase equivalence, non-decaying overlap, paper-faithful BNT canonical
+gauge-phase equivalence, non-decaying overlap, BNT canonical
 form
 -/
 
@@ -495,9 +494,8 @@ theorem exists_block_match_of_sameMPVPos
         (hNot := hNot)
   exact ⟨k₀, hDim, hGPE, hk₀⟩
 
-/-- Compatibility wrapper: the legacy all-length `SameMPV₂` form of the block
-match.  Forwards to the positive-length core variant via the forgetful
-projection `SameMPV₂.toSameMPV₂Pos`. -/
+/-- Reformulation for the all-length `SameMPV₂` form.  Forwards to the
+positive-length core via `SameMPV₂.toSameMPV₂Pos`. -/
 theorem exists_block_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/EqualModulus.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/EqualModulus.lean
@@ -53,8 +53,7 @@ factoring `P.weight j q = spectral_level j · phase_weight j q`.
 
 It captures the sub-class of BNT canonical forms in which every sector's
 copies share a common modulus.  It is NOT required by, nor part of, the
-core paper-faithful BNT predicate `IsBNTCanonicalForm` (see
-`PaperBNT/Basic.lean`).  The audit
+core BNT predicate `IsBNTCanonicalForm` (see `PaperBNT/Basic.lean`).  The audit
 `audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` §Q4
 shows that `C ⊕ (1/2)C` is a valid CPSV BNT canonical form that admits no
 such factorization.

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Examples.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.FundamentalTheorem.PaperBNT.EqualModulus
 # Executable examples for `IsBNTCanonicalForm`
 
 This file collects concrete `SectorDecomposition` constructions and
-instantiates the paper-faithful `IsBNTCanonicalForm` on each.  All three
+instantiates `IsBNTCanonicalForm` on each.  All three
 core examples have a single BNT basis sector (`basisCount = 1`):
 
 * **Example 1** — single sector, single copy: `weight = (1,)`.
@@ -311,7 +311,7 @@ and `weight_unit_exists`) admits decompositions whose copies have
 and one `1/2`-modulus copy.  This is exactly the
 `audits/2026-05-13_cpsv16_paper_bnt_phase_1_multiplicity_audit.md` §Q4
 counter-example, here written as a positive example: the strengthened
-predicate is paper-faithful (line 246 verbatim) and admits the example.
+predicate follows line 246 verbatim and admits the example.
 
 The decomposition does NOT admit `HasEqualModulusWeightLayer`: the
 optional equal-modulus layer of `PaperBNT/EqualModulus.lean` would

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean
@@ -7,11 +7,12 @@ import TNLean.MPS.FundamentalTheorem.PaperBNT.WeightEquiv
 import TNLean.MPS.FundamentalTheorem.Multi
 
 /-!
-# Paper-faithful BNT equal-MPV sector data theorem
+# BNT equal-MPV sector data theorem (CPSV16 §II.C lines 1182–1192)
 
-This module assembles Phase D's full-basis matching and eventual exact
-coefficient identity into the sector-data conclusion of the CPSV16/CPSV21
-fundamental theorem on the paper-faithful `IsBNTCanonicalForm` surface.
+This module combines the full-basis matching (`StrongMatch`) and the
+exact coefficient identity (`CoeffIdentity`) into the sector-data
+conclusion of the CPSV16/CPSV21 fundamental theorem on the
+`IsBNTCanonicalForm` surface.
 
 Paper anchors:
 
@@ -21,7 +22,7 @@ Paper anchors:
   recovering copy multiplicities and weights up to the matched phase.
 * CPSV21 Definition 4.3 lines 1846–1884: per-block BNT normalization on
   the basis tensors.  The per-block convention on copy coefficients
-  `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — paper-implicit in CPSV16 §II.C line 1182's
+  `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — implicit in CPSV16 §II.C line 1182's
   projection argument — is taken as an explicit theorem-level hypothesis
   here, not as a structural field of `IsBNTCanonicalForm`.
 
@@ -75,15 +76,13 @@ noncomputable def matched_block_gauge {Q : SectorDecomposition d}
   change GL (Fin (Q.basisDim (Q.flatIndexEquiv.symm s).1)) ℂ
   exact Xblock (Q.flatIndexEquiv.symm s).1
 
-/-- **Paper-faithful equal-MPV sector-data theorem (Phase D).**
+/-- **BNT equal-MPV sector-data theorem (CPSV16 §II.C lines 1184–1188).**
 
-If two paper-faithful BNT sector decompositions generate the same MPV family,
-then their BNT basis sectors are bijectively matched by gauge-phase
-equivalence.  For each matched sector, the copy multiplicities agree and the
-raw copy weights agree after multiplying by the inverse of the gauge phase and
-permuting the copies.
-
-This is the Lean sector-data counterpart of CPSV16 §II.C lines 1184–1188. -/
+If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
+same MPV family, then their BNT basis sectors are bijectively matched by
+gauge-phase equivalence.  For each matched sector, the copy multiplicities
+agree and the raw copy weights agree after multiplying by the inverse of the
+gauge phase and permuting the copies. -/
 theorem ft_paper_bnt_equal_sector_dataPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -151,10 +150,10 @@ theorem ft_paper_bnt_equal_sector_data
   ft_paper_bnt_equal_sector_dataPos
     (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
 
-/-- **Phase E global gauge in matched flattened coordinates.**
+/-- **Global gauge in matched flattened coordinates (CPSV16 §II.C lines 1189–1192).**
 
-This is the coordinate-level assembly of CPSV16 §II.C lines 1189–1192.  Starting
-from equal MPV families on the paper-faithful BNT surface, it produces:
+This is the coordinate-level construction of the global gauge.  Starting
+from equal MPV families on the BNT canonical-form surface, it produces:
 
 * the full basis bijection `β`,
 * per-block bond-dimension equalities and gauge matrices `Xblock k`,

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
@@ -5,15 +5,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Fundamental
 
 /-!
-# Paper-faithful BNT equal-MPV gauge equivalence: bundled `II_cor2` witness
+# BNT equal-MPV gauge equivalence: bundled `II_cor2` witness
 
-This module packages the paper-faithful equal-MPV theorem
-`ft_paper_bnt_equal_global_gauge` as the literal `II_cor2` statement of
-CPSV16 §II.C lines 354–361 / appendix lines 1184–1192.
+This module states the equal-MPV theorem `ft_paper_bnt_equal_global_gauge`
+in the form of the literal `II_cor2` statement of CPSV16 §II.C lines 354–361
+/ appendix lines 1184–1192.
 
 The bundled-witness theorem `ft_paper_bnt_equal_mps_gaugeEquiv_witnesses`
-exposes, for any two paper-faithful BNT sector decompositions $P$ and $Q$
-generating the same MPV family:
+exposes, for any two BNT sector decompositions $P$ and $Q$ satisfying
+`IsBNTCanonicalForm` and generating the same MPV family:
 
 * the matched basis bijection $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$;
 * per-block bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$;
@@ -38,8 +38,8 @@ into a literal `cast`-of-`P.toTensor` requires assembling a sector-permutation
 matrix from `sectorFlatEquiv` and conjugating; the present module records the
 witness bundle that is the verbatim CPSV16 II_cor2 packaging, while the
 permutation-matrix conjugation is left for a follow-up module (it requires
-non-trivial `PEquiv` glue on block-diagonal matrices over a reindexed
-$Σ$-type).
+non-trivial `PEquiv` connecting results on block-diagonal matrices over a
+reindexed $Σ$-type).
 
 Paper anchors:
 
@@ -59,8 +59,8 @@ variable {d : ℕ}
 
 /-- **CPSV16 `II_cor2` witness form (CPSV16 §II.C lines 354–361 / 1184–1192).**
 
-If two paper-faithful BNT sector decompositions generate the same MPV family,
-then there exist:
+If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
+same MPV family, then there exist:
 
 * a basis bijection $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$,
 * per-block bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$,
@@ -168,8 +168,8 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv_witnesses
 
 /-- **CPSV16 `II_cor2` literal form, sector data + total bond-dimension equality.**
 
-If two paper-faithful BNT sector decompositions generate the same MPV
-family, their total bond dimensions agree and there exists a matrix $X$
+If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
+same MPV family, their total bond dimensions agree and there exists a matrix $X$
 realizing the CPSV16 line-1191 global gauge in $Q$'s flattened sector
 coordinates.
 
@@ -506,8 +506,9 @@ private lemma permMatrix_conj_eq_submatrix {n : Type*}
 
 /-- **CPSV16 `II_cor2` literal form (CPSV16 §II.C lines 354–361 / 1184–1192).**
 
-If two paper-faithful BNT sector decompositions generate the same MPV family,
-then their total bond dimensions agree, and there exists an explicit
+If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
+same MPV family, then their total bond dimensions agree, and there exists an
+explicit
 $Y \in \mathrm{GL}(Q.\mathrm{totalDim},\mathbb{C})$ realizing the global gauge
 equation
 $$V_Q^i \;=\; Y \,\bigl(\mathrm{cast}\;V_P^i\bigr)\, Y^{-1}$$

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/ProportionalMatch.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.FundamentalTheorem.PaperBNT.StrongMatch
 
 /-!
-# Proportional sector matching for two paper-faithful BNT canonical forms
+# Proportional sector matching for two BNT canonical forms
 
 The main theorem `MPSTensor.ft_paper_bnt_proportional_sector_match`
 delivers the basis-count identity $g_P = g_Q$, a basis bijection
@@ -136,7 +136,7 @@ lemma joint_coeff_not_tendsto_zero
             (P.weight j pq.1 * Q.weight k pq.2) ^ N := hProd.symm
     _ = ∑ s : Fin r, (μ s) ^ N := hSum.symm
 
-/-- For a basis block $j_0$ of a paper-faithful BNT canonical form, the
+/-- For a basis block $j_0$ of a BNT canonical form satisfying `IsBNTCanonicalForm`, the
 overlap $\langle V^{(N)}(\text{toTensor})|V^{(N)}(\text{basis}_{j_0})\rangle$
 differs from the sector coefficient $P.\mathrm{coeff}(N,j_0)$ by a sequence
 tending to zero: the diagonal "self-overlap $-\,1$" and the off-diagonal
@@ -854,7 +854,7 @@ theorem bijective_match_of_eventuallyProportional
 
 /-! ### Final theorem: proportional sector matching with basis-count equality -/
 
-/-- **Proportional sector matching for two paper-faithful BNT canonical forms.**
+/-- **Proportional sector matching for two BNT canonical forms.**
 
 If two BNT canonical sector decompositions have eventually proportional
 assembled tensors with nonzero per-$N$ scalar, and each basis sector on both

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/StrongMatch.lean
@@ -5,20 +5,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.FundamentalTheorem.PaperBNT.DominantMatch
 
 /-!
-# Phase B-α and B-β (paper-faithful) strong existential and bijective matching
+# Strong existential and bijective sector matching (CPSV16 §II.C lines 1182–1186)
 
-This module is **Phase B-α and Phase B-β** of the CPSV16/CPSV21
-fundamental-theorem clean-slate plan (issue #1725).  The downstream
-Phase B-γ Corollary substitution argument
-(`coeff_identity_via_global_gauge`, CPSV16 §II.C lines 1187-1188) lives
-in the companion module `PaperBNT/CoeffIdentity.lean` (file split in
-PR #1729 to respect the 1000-line module limit).
+The strong existential matching theorem states the CPSV16 §II.C lines 1182–1186
+*Step 1* conclusion directly on the original pair `(P, Q)` of BNT canonical
+forms, iterated over each sector `k` of `Q` that carries a unit-modulus copy.
 
-The paper-faithful strong existential
-matching theorem states the CPSV16 §II.C lines 1182–1186 *Step 1*
-conclusion directly on the original (un-dropped) pair `(P, Q)` of
-BNT canonical forms, iterated over each sector `k` of `Q` that carries
-a unit-modulus copy.
+The coefficient identity of CPSV16 §II.C lines 1187–1188 (Corollary substitution)
+lives in the companion module `PaperBNT/CoeffIdentity.lean`.
 
 ## Paper anchor
 
@@ -41,7 +35,7 @@ blocks contribute coefficients that decay exponentially and so do not
 constrain the matching; the paper restricts attention to the
 "physical" (unit-modulus carrying) blocks.
 
-## Scope (Phase B-α)
+## Proof structure
 
 The result is a **single `∀ k, ∃ j` existential statement** on the
 original pair, with the paper's "given $k$" hypothesis explicitly
@@ -52,16 +46,16 @@ union: the entire proof routes through the existing
 through the full-family combined LI `combined_family_eventually_li`,
 `PaperBNT/Api.lean`).
 
-The downstream Phase B-β (bijective matching) will apply this theorem
-twice — once with `(P, Q)` and once with `(Q, P)` — to derive
-`P.basisCount = Q.basisCount` on the unit-block subset and the per-pair
-bijection / gauge data.
+The bijective matching (`bijective_match_of_sameMPVPos`) applies the
+forward existential twice — once with `(P, Q)` and once with `(Q, P)` —
+to derive `P.basisCount = Q.basisCount` and the full bijection
+`β : Fin Q.basisCount ≃ Fin P.basisCount`.
 
-## Proof strategy (route B of the audit memo)
+## Proof of the existential
 
 Given a sector `k` of `Q` with a unit-modulus weight, apply the
-existing `exists_block_match_of_sameMPV` (`PaperBNT/DominantMatch`,
-post-Phase-A rename in PR #1726) **with `P` and `Q` swapped**:
+existing `exists_block_match_of_sameMPV` (`PaperBNT/DominantMatch`)
+**with `P` and `Q` swapped**:
 
 * feed `hQ`, `hP` (in that order);
 * supply `hP_pos : 0 < P.basisCount` from `hP.weight_unit_exists`
@@ -75,8 +69,8 @@ The result is a `j₀ : Fin P.basisCount` with `Q.basisDim k = P.basisDim j₀`,
 a gauge-phase equivalence in the `Q → P` cast direction, and a
 non-decaying overlap in the `(Q.basis k, P.basis j₀)` order.  Two
 local auxiliary lemmas (`gaugePhaseEquiv_swap_cast` and
-`tendsto_mpvOverlap_zero_swap`) flip those into the paper-stated
-`(P, Q)`-ordered conclusion.
+`tendsto_mpvOverlap_zero_swap`) flip those into the `(P, Q)`-ordered
+conclusion.
 
 All proofs in this file are closed constructively.
 -/
@@ -88,7 +82,7 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ### Phase B-α main theorem: paper-faithful full-basis matching -/
+/-! ### Strong existential matching: CPSV16 §II.C lines 1182–1186 -/
 
 /-- **CPSV16 §II.C lines 1182–1186 Step 1 (full-basis form).**
 
@@ -152,7 +146,7 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
   forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     (P := P) (Q := Q) hP hQ hUnitQ hEqual.toSameMPV₂Pos
 
-/-! ### Phase B-β main theorem: full bijective matching by symmetry -/
+/-! ### Bijective sector matching by symmetry -/
 
 /-- **CPSV16 §II.C lines 1184–1186 full-basis bijection.**
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Supplier.lean
@@ -274,14 +274,13 @@ positive blocking length `p` and a finite family of prepared blocks
 weights and positive bond dimensions) whose direct-sum tensor matches the
 `p`-blocked input `blockTensor A p` at every positive length.
 
-This is the paper-faithful CPSV16 §II.A layer that is left as a user choice in
-the source paper: the §II.A line 246 weight normalization is **not** delivered
+The CPSV16 §II.A line 246 weight normalization is **not** delivered
 here, since the source paper makes this an explicit user assumption.  A
-separate normalization layer / hypothesis is then composed with the prepared
+separate normalization hypothesis is composed with the prepared
 blocks here to feed the `IsBNTCanonicalForm` constructor
 `exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks`.
 
-Pipeline:
+Construction steps:
 
 1. `unconditional_commonPrimitiveIrreducibleBlocks A A (fun _ _ => rfl)` —
    apply the two-sided arbitrary-input reduction at `B = A` to obtain a
@@ -471,17 +470,17 @@ the prepared-block BNT constructor delivers a full `IsBNTCanonicalForm`
 decomposition together with positive-length MPV agreement.
 -/
 
-/-- **End-to-end arbitrary-input PaperBNT supplier (CPSV16 §II.A L237-280).**
+/-- **Arbitrary-input BNT block preparation (CPSV16 §II.A L237-280).**
 
 For any tensor `A : MPSTensor d D`, after at most one positive blocking length
 `p`, there is a finite family of **prepared** blocks (left-canonical,
 primitive, irreducible, one-site injective, with nonzero weights and positive
 bond dimensions) whose direct-sum tensor matches the `p`-blocked input
-`blockTensor A p` at every positive length.  Moreover, **provided the user
-supplies the CPSV16 §II.A line 246 normalization choice** on those weights
-(every weight has absolute value at most one and at least one of unit
-modulus), there is a paper-faithful BNT canonical-form sector decomposition
-`P` with `blockTensor A p` matching `P.toTensor` at every positive length.
+`blockTensor A p` at every positive length.  When the user supplies the
+CPSV16 §II.A line 246 normalization choice on those weights (every weight
+has absolute value at most one and at least one of unit modulus), there is a
+BNT canonical-form sector decomposition `P` satisfying `IsBNTCanonicalForm`
+with `blockTensor A p` matching `P.toTensor` at every positive length.
 
 The normalization is, per CPSV16 line 246, an explicit user choice:  the paper
 writes "we can always *choose* this normalization, which we will assume from

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/WeakExistential.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/WeakExistential.lean
@@ -7,16 +7,14 @@ import TNLean.MPS.BNT.Basic
 import TNLean.MPS.Overlap.CastDecay
 
 /-!
-# Weak non-decaying-overlap existential on the paper-faithful BNT surface
+# Weak non-decaying-overlap existential for BNT canonical forms
 
-This module proves the paper-faithful multi-copy weak existential: under
-eventual nonzero proportionality of the two assembled tensors, some pair
-of basis blocks has a non-decaying cross-overlap.  Both families carry
-the multi-copy paper-faithful predicate `IsBNTCanonicalForm`
-(`PaperBNT/Basic.lean`), and the sector coefficient is
+This module proves the multi-copy weak existential for `IsBNTCanonicalForm`:
+under eventual nonzero proportionality of the two assembled tensors, some pair
+of basis blocks has a non-decaying cross-overlap.  The sector coefficient is
 the raw power sum `P.coeff N j = ∑_q (P.weight j q)^N` of CPSV16 §II
 (lines 287–301) — never a scalar power `(λ_j)^N` of a single per-sector
-"spectral level".
+spectral level.
 
 The proof is the canonical CPSV16 combined-family contradiction:
 
@@ -85,9 +83,9 @@ the local copy is kept here until that landing. -/
 
 /-- **Cross-overlap between distinct basis blocks decays** (same family).
 
-For any two distinct basis indices `j ≠ k` of a paper-faithful BNT canonical
-form, the MPV overlap `mpvOverlap (P.basis j) (P.basis k) N` tends to `0` as
-`N → ∞`.
+For any two distinct basis indices `j ≠ k` of a BNT canonical form
+satisfying `IsBNTCanonicalForm`, the MPV overlap
+`mpvOverlap (P.basis j) (P.basis k) N` tends to `0` as `N → ∞`.
 
 Dispatch follows the CPSV16 lines 1080–1091 normal-tensor overlap dichotomy:
 
@@ -131,10 +129,10 @@ end IsBNTCanonicalForm
 /-! ### Eventual weighted-state identity from eventual proportionality
 
 The next local lemma extracts a scalar sequence from
-`EventuallyNonzeroProportionalMPV₂` for the paper-faithful multi-copy
-setting: the assembled tensors are `P.toTensor` and `Q.toTensor`, and the
-raw sector coefficient `P.coeff N j = ∑_q (P.weight j q)^N` of CPSV16
-lines 287–301 enters as the coefficient in front of each basis MPV state. -/
+`EventuallyNonzeroProportionalMPV₂`: the assembled tensors are
+`P.toTensor` and `Q.toTensor`, and the raw sector coefficient
+`P.coeff N j = ∑_q (P.weight j q)^N` of CPSV16 lines 287–301 enters
+as the coefficient in front of each basis MPV state. -/
 
 private lemma exists_eventually_coeff_weighted_mpvState_eq_smul_sequence
     {P Q : SectorDecomposition d}
@@ -212,7 +210,7 @@ private lemma exists_eventually_coeff_weighted_mpvState_eq_smul_sequence
 /-! ### The weak existential -/
 
 /-- **Weak non-decaying-overlap existence** for proportional families on the
-paper-faithful BNT canonical-form surface.
+BNT canonical-form surface (`IsBNTCanonicalForm`).
 
 Given two `IsBNTCanonicalForm` families with eventual nonzero proportionality
 of the assembled tensors, some pair `(j, k)` of basis blocks has a

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -232,8 +232,7 @@ modulus) would tend to `0`, contradicting the hypothesis.
 
 The proof uses the rectangular overlap-decay theorem
 `mpvOverlap_tendsto_zero_of_mixedTransferSpectralRadius_lt_one`, whose proof rests on the
-mixed-transfer trace identity, and is paper-faithful (no proportionality hypothesis
-required). -/
+mixed-transfer trace identity, with no proportionality hypothesis required. -/
 theorem mixedTransferSpectralRadius_ge_one_of_mpvOverlap_norm_tendsto_one
     (A B : MPSTensor d D)
     (hOverlap :

--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -22,7 +22,7 @@ geometric extrapolation and Newton--Girard steps below are the finite-sequence
 algebra needed to recover the weight lists from those power sums once the basis
 blocks have been matched.
 
-The endpoint below uses the unequal-cardinality finite-range power-sum theorem
+The main theorem below uses the unequal-cardinality finite-range power-sum theorem
 directly, as in the Appendix comparison.  Without nonzero weights, positive
 powers would only determine the nonzero submultiset.
 

--- a/TNLean/MPS/Structure/PrimitivityBridge.lean
+++ b/TNLean/MPS/Structure/PrimitivityBridge.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Spectral.PrimitiveOverlap
 
 /-!
-# Primitivity bridge
+# Spectral-gap primitivity and MPV overlap convergence
 
 This module connects the **spectral-gap definition of primitivity** to the overlap and
 canonical-form hypotheses used elsewhere in the library.
@@ -34,7 +34,7 @@ This file supplies one corner of the codebase's primitivity vocabulary:
   `TNLean/Wielandt/Primitivity/PaperDefinitions.lean` is the transfer-map formulation around
   `_root_.IsPrimitive`.
 * `MPSTensor.IsPrimitivePaper` in
-  `TNLean/Wielandt/Primitivity/PaperDefinitions.lean` is the paper-faithful uniform
+  `TNLean/Wielandt/Primitivity/PaperDefinitions.lean` is the uniform
   spreading definition.
 * `HasPrimitiveFixedPoint` here is the existential spectral-gap formulation used by the MPS
   proof chain.
@@ -92,7 +92,7 @@ with `IsPrimitiveMPS A ρ`.
 Equivalently, this is the existential formulation `∃ ρ, IsPrimitiveMPS A ρ`. It is the
 MPS-specific spectral-gap formulation, distinct from the generic peripheral-spectrum predicate
 `_root_.IsPrimitive`, the transfer-map formulation `MPSTensor.IsPeripherallyPrimitive`, and the
-paper-faithful spreading predicate `MPSTensor.IsPrimitivePaper`. -/
+spreading predicate `MPSTensor.IsPrimitivePaper`. -/
 def HasPrimitiveFixedPoint {d D : ℕ} [NeZero D] (A : MPSTensor d D) : Prop :=
   ∃ ρ : Matrix (Fin D) (Fin D) ℂ, IsPrimitiveMPS A ρ
 

--- a/TNLean/MPS/Symmetry/StringOrder.lean
+++ b/TNLean/MPS/Symmetry/StringOrder.lean
@@ -324,8 +324,8 @@ theorem localSymmetry_iff_spectralRadius_one
 /-- **Theorem 1** (arXiv:0802.0447, virtual-boundary form): String order
 exists for a pure canonical FCS if and only if `u` is a local symmetry.
 
-The Lean definition `HasStringOrder A u Λ` encodes the paper's endpoint
-operators `x,y` as arbitrary virtual boundary matrices `X,Y`, so the theorem is
+The definition `HasStringOrder A u Λ` encodes the paper's boundary operators
+`x,y` as arbitrary virtual boundary matrices `X,Y`, so the theorem is
 stated directly at the transfer-matrix level. -/
 theorem stringOrder_iff_localSymmetry
     (A : MPSTensor d D)

--- a/TNLean/MPS/Symmetry/StringOrderDefs.lean
+++ b/TNLean/MPS/Symmetry/StringOrderDefs.lean
@@ -187,7 +187,7 @@ private lemma stringOrderParam_one_eq_one
 /-- The virtual-boundary version of the string-order expression:
 `tr(Λ X ℰ_u^L(Y))`.
 
-This generalizes the paper's endpoint operators `x,y` to arbitrary
+This generalizes the paper's boundary operators `x,y` to arbitrary
 virtual boundary matrices `X,Y`.  For injective tensors, every virtual
 boundary matrix can be realized by sufficiently long physical boundary
 insertions, so this single definition captures all boundary choices
@@ -269,8 +269,8 @@ def IsLocalSymmetry (A : MPSTensor d D)
       ∑ j : Fin d, u i j • A j = μ • (V * A i * Vᴴ)
 
 /-- String order exists if some virtual boundary pair produces a uniformly
-non-decaying twisted-transfer overlap. This is the matrix-level version of the
-paper's endpoint-operator criterion. -/
+non-decaying twisted-transfer overlap.  This is the matrix-level version of the
+paper's boundary-operator criterion. -/
 def HasStringOrder (A : MPSTensor d D)
     (u : Matrix (Fin d) (Fin d) ℂ)
     (Λ : Matrix (Fin D) (Fin D) ℂ) : Prop :=

--- a/TNLean/QPF/Assembly.lean
+++ b/TNLean/QPF/Assembly.lean
@@ -70,9 +70,9 @@ theorem exists_posSemidef_fixedPoint
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hD : 0 < D) :
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosSemidef ∧ ρ ≠ 0 ∧
-      transferMap (d := d) (D := D) A ρ = ρ := by
-  have hCh := MPSTensor.transferMap_isChannel A hNorm
-  exact hCh.exists_posSemidef_fixedPoint (E := transferMap A) hD
+      transferMap (d := d) (D := D) A ρ = ρ :=
+  (MPSTensor.transferMap_isChannel A hNorm).exists_posSemidef_fixedPoint
+    (E := transferMap A) hD
 
 end Existence
 
@@ -112,7 +112,7 @@ private lemma posDef_zero_fin0 : (0 : Matrix (Fin 0) (Fin 0) ℂ).PosDef :=
     (fun x hx => absurd (Subsingleton.elim x 0) hx)
 
 /-- **Injectivity implies unique fixed point** (without the `0 < D` hypothesis).
-Wraps `quantum_perron_frobenius` with a vacuous case for `D = 0`. -/
+Extends `quantum_perron_frobenius` to the case `D = 0`, which holds vacuously. -/
 theorem injective_transfer_unique_fixed_point' [DecidableEq (Fin D)]
     (A : MPSTensor d D) (hA : IsInjective A)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1) :

--- a/TNLean/QPF/PosDef.lean
+++ b/TNLean/QPF/PosDef.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 -- Keep these dependencies explicit here for readability:
 -- • `TNLean.Algebra.HermitianHelpers` for shared spectral decomposition helpers
--- • `TNLean.Channel.Basic` for the positive-definiteness API
+-- • `TNLean.Channel.Basic` for positive-definiteness results
 -- • `TNLean.Channel.Irreducible.Basic` for irreducibility/projection lemmas
 -- The channel imports are already transitively available through
 -- `TNLean.MPS.CPPrimitive`, but listing them directly makes the local proof

--- a/TNLean/QPF/Uniqueness.lean
+++ b/TNLean/QPF/Uniqueness.lean
@@ -155,21 +155,8 @@ private lemma sqrtFactor_isUnit' [DecidableEq (Fin D)]
 private lemma diagonal_sub_smul_one' [DecidableEq (Fin D)] (v : Fin D → ℝ) (c : ℝ) :
     Matrix.diagonal (fun j => (↑(v j) : ℂ)) - (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) =
       Matrix.diagonal (fun j => (↑(v j - c) : ℂ)) := by
-  ext i j
-  by_cases h : i = j
-  · subst h
-    have hone : ((↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ)) i i = ↑c := by
-      change ((↑c : ℂ) • ((1 : Matrix (Fin D) (Fin D) ℂ) i)) i = ↑c
-      rw [Pi.smul_apply, Matrix.one_apply_eq]
-      simp
-    rw [Matrix.sub_apply, Matrix.diagonal_apply_eq, Matrix.diagonal_apply_eq, hone]
-    simp
-  · have hone : ((↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ)) i j = 0 := by
-      change ((↑c : ℂ) • ((1 : Matrix (Fin D) (Fin D) ℂ) i)) j = 0
-      rw [Pi.smul_apply, Matrix.one_apply_ne h]
-      simp
-    rw [Matrix.sub_apply, Matrix.diagonal_apply_ne _ h, Matrix.diagonal_apply_ne _ h, hone]
-    simp
+  rw [← Matrix.diagonal_one, ← Matrix.diagonal_smul, Matrix.diagonal_sub]
+  congr 1; ext i; simp [Pi.smul_apply, Complex.ofReal_sub]
 
 private lemma hermitian_sub_scalar_spectral [DecidableEq (Fin D)]
     {A : Matrix (Fin D) (Fin D) ℂ} (hA : A.IsHermitian) (c : ℝ) :

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -193,7 +193,7 @@ private theorem geometric_apply_bound_of_spectralRadius_lt_one
       exact mul_le_mul_of_nonneg_right (hpow n) (norm_nonneg x)
     _ = C * r ^ n * ‖x‖ := by ring
 
-/-! ## Helper lemmas -/
+/-! ## Auxiliary lemmas -/
 
 /-- The word span at length 1 equals the span of the Kraus operators. -/
 theorem wordSpan_one_eq_span_range (A : MPSTensor d D) :

--- a/TNLean/Wielandt/Primitivity/Equivalence.lean
+++ b/TNLean/Wielandt/Primitivity/Equivalence.lean
@@ -43,7 +43,7 @@ import surface. The direction-specific files
 `Primitivity/ImpliesStronglyIrreducible.lean`,
 `Primitivity/ImpliesStronglyIrreducibleAux.lean`, and
 `Primitivity/StronglyIrreducibleToFullRank.lean` remain specialized
-implementation modules, while the canonical / FT / BNT assembly does not
+implementation modules, while the canonical / FT / BNT construction does not
 import these statements directly.
 
 ## Full-equivalence corollaries

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
@@ -203,7 +203,7 @@ private theorem transferMap_pow_rankOne_posSemidef
 
 /-- **A nonzero PSD fixed point of a paper-primitive transfer map is positive definite.**
 
-This is the crucial step in Proposition 3 (a)→(c) of arXiv:0909.5347.
+This is the positivity step in Proposition 3 (a)→(c) of arXiv:0909.5347.
 The proof uses the decomposition of PSD matrices into sums of outer products
 and the positivity-improving property of primitive transfer maps.
 

--- a/TNLean/Wielandt/Primitivity/PaperDefinitions.lean
+++ b/TNLean/Wielandt/Primitivity/PaperDefinitions.lean
@@ -64,8 +64,8 @@ These are **paper-level statements only**. The internal proof route flows throug
 `IsNormal`, `IsPrimitiveMPS`, `HasPrimitiveFixedPoint`, etc. The full equivalence of
 all three Proposition 3 conditions is assembled in `Primitivity/Equivalence.lean`.
 
-At present this layer is not imported by the canonical / FT / BNT assembly in
-`TNLean.MPS.*` or `TNLean.PiAlgebra.*`; it serves the standalone theorem modules below.
+At present this layer is not imported by `TNLean.MPS.*` or `TNLean.PiAlgebra.*`;
+it serves the standalone theorem modules below.
 
 ## References
 

--- a/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
+++ b/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
@@ -12,9 +12,9 @@ import TNLean.Channel.Primitive
 import TNLean.Channel.Irreducible.FromSpectral
 
 /-!
-# Primitive MPS bridge lemmas for Wielandt theory
+# Connecting results for primitive MPS and spectral-gap conditions
 
-This module collects the public bridge between the paper-facing transfer-map
+This module collects the connection between the paper-facing transfer-map
 condition `IsStronglyIrreduciblePaper` and the spectral-gap predicate
 `IsPrimitiveMPS`.  These results are used by the Proposition 3(c)→(b) proof in
 `TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank` and by downstream

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
@@ -269,7 +269,7 @@ The hypothesis `n₀` is the key degree of freedom. Different bounds on `n₀`
 give different final bounds:
 - `n₀ = D² - 2D + 2` (normality witness): gives `D² + D = ⊤` (coarse)
 - `n₀ = D² - 4D + 3` (from induction on D): gives `D² - D + 1 = ⊤` (sharp) -/
-theorem wielandt_parametric_assembly [NeZero D]
+theorem wielandt_parametric_span [NeZero D]
     (A : MPSTensor d D)
     (hNormal : IsNormal (d := d) (D := D) A)
     -- Column eigenvector
@@ -309,7 +309,7 @@ theorem wielandt_length_from_stabilization [NeZero D]
     (hstab : rectSpan ((A i₀) ^ D) A n₀ =
              LinearMap.range (LinearMap.mulLeft ℂ ((A i₀) ^ D))) :
     wordSpan A (3 * D + n₀ - 2) = ⊤ := by
-  have htop := wielandt_parametric_assembly A hNormal i₀ μ hμ φ hφ heigφ
+  have htop := wielandt_parametric_span A hNormal i₀ μ hμ φ hφ heigφ
     i₁ ν hν ψ₀ hψ₀ heigψ hstab
   have hlen : 3 * D + n₀ - 2 = (D - 1) + ((D + n₀) + (D - 1)) := by omega
   rwa [hlen]

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
@@ -256,8 +256,12 @@ theorem vecMulVec_eigenvector_sharp_of_rectSpan
           sharp_bound_le A i₀ hNotInv
   exact wordSpan_le_cumulativeSpan A hbound hmem
 
-/-- **Parametric sharp rectangular span via nilpIndex.** -/
-theorem wielandt_sharp_parametric_assembly [NeZero D]
+/-- **Parametric sharp word-span saturation via nilpotent index.**
+
+Given eigenvectors and a `rectSpan` stabilization at step `n₀`
+(with the initial matrix `(A i₀) ^ nilpIndex (toLin' (A i₀))`),
+produces `wordSpan A N = ⊤` for `N = (D-1) + (nilpIndex + n₀) + (D-1)`. -/
+theorem wielandt_sharp_parametric_span [NeZero D]
     (A : MPSTensor d D)
     (hNormal : IsNormal (d := d) (D := D) A)
     (i₀ : Fin d) (μ : ℂ) (hμ : μ ≠ 0)

--- a/TNLean/Wielandt/SourceTheorems/WielandtInequality.lean
+++ b/TNLean/Wielandt/SourceTheorems/WielandtInequality.lean
@@ -172,13 +172,8 @@ theorem wordSpan_eq_top_of_isPrimitivePaper_of_mem_wordSpan_one_of_noninvertible
     wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis B φ hVec hBasis
   have hD_pos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
   have hArith : (D - 1) + (D ^ 2 - D + 1) = D ^ 2 := by
-    have hDD2 : D ≤ D ^ 2 := by
-      calc
-        D = D * 1 := (Nat.mul_one D).symm
-        _ ≤ D * D := Nat.mul_le_mul_left D hD_pos
-        _ = D ^ 2 := (sq D).symm
-    zify [hD_pos, hDD2]
-    ring
+    have hDD2 : D ≤ D ^ 2 := Nat.le_self_pow (by omega) D
+    zify [hD_pos, hDD2]; ring
   have hBtop : wordSpan B (D ^ 2) = ⊤ := by
     rwa [hArith] at hAssembly
   have hEq : wordSpan B (D ^ 2) = wordSpan A (D ^ 2) := by

--- a/TNLean/Wielandt/WielandtBound.lean
+++ b/TNLean/Wielandt/WielandtBound.lean
@@ -17,7 +17,7 @@ consequences of normality that feed into the fixed-length Wielandt bound
 The paper-facing Theorem 1 statements (case (1), (2), (3) bounds on the
 Kraus-rank index $i(A)$) are in `SourceTheorems/WielandtInequality.lean`.
 This file only provides the cumulative-span and eigenvector-spreading
-inputs needed by the primitivity/normality bridge and the blueprint.
+inputs needed by the Proposition 3(c)→(b) proof in `Primitivity/Normal.lean`.
 
 ## Main result
 
@@ -44,8 +44,7 @@ variable {d D : ℕ}
 /-! ## The cumulative Wielandt chain
 
 The four standard consequences of normality.  These are combined below
-in one theorem so that callers (e.g. the primitivity/normality bridge
-in `Primitivity/Normal.lean`) get all outputs at once. -/
+in one theorem so that `Primitivity/Normal.lean` gets all outputs at once. -/
 
 /-- **The cumulative Wielandt chain**: under `IsNormal A`,
 the four standard cumulative consequences hold simultaneously.

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -995,7 +995,7 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     The proof uses the full-Kraus-rank index bound from the quantum Wielandt
     inequality.  Since $A$ is normal, the index is attained; the one-step Kraus
     rank is nonzero in the left-canonical case, so the bound
-    $(D^2-\operatorname{rank}S_1(A)+1)D^2$ is at most $D^4$.  The bridge from
+    $(D^2-\operatorname{rank}S_1(A)+1)D^2$ is at most $D^4$.  The passage from
     exact word-span fullness to injectivity of the blocked tensor is
     Lemma~\ref{lem:blocking_transfer}.
 \end{proof}
@@ -1385,7 +1385,7 @@ spectral gap. It is connected to normality through the following results.
     With the additional hypothesis $\rho > 0$,
     Theorem~\ref{thm:primitive_implies_irreducible} gives
     irreducibility.
-    Together with the Burnside bridge below
+    Together with the Burnside argument below
     (\S\ref{subsec:burnside_bridge})
     and Theorem~\ref{thm:algspan_to_normal}, one obtains
     \[

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -968,16 +968,15 @@ of \cite{PerezGarcia2007Matrix} \S III are not covered:
     asymptotic eigenvalue statement requires correlation-length and entropy
     material not addressed here.
 
-  \item \textbf{Thm.~\texttt{thm-uniq} (lines~1002--1015): uniqueness of
-    the canonical form.}
+  \item \textbf{Uniqueness of the canonical form
+    (\cite[lines~1002--1015]{PerezGarcia2007Matrix}).}
     Under condition~C1 with unique OBC canonical form, two TI canonical
     $D$-MPS representations of the same state satisfy $B_i = U C_i U^\dagger$
-    for a global unitary~$U$.
-    \emph{Not covered in this chapter:} a modern analogue is proved in
-    Chapter~\ref{ch:ft_proof} as
-    \texttt{MPSTensor.ft\_paper\_bnt\_equal\_global\_gauge};
-    the original finite-ring uniqueness of~\cite{PerezGarcia2007Matrix}
-    under C1/C2 and $N > 2L_0 + D^4$ is not covered here.
+    for a global unitary $U$.
+    \emph{Not covered in this chapter.} A modern analogue is proved in
+    Chapter~\ref{ch:ft_proof} (global-gauge equality theorem); the original
+    finite-ring uniqueness of \cite{PerezGarcia2007Matrix} under C1/C2 and
+    $N > 2L_0 + D^4$ is not covered here.
 
   \item \textbf{Thm.\ ``Obtaining the TI canonical form''
     (lines~1154--1165).}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -621,33 +621,34 @@ and~\cite{Cirac2021Matrix}.
     a separate explicit-coefficient equal-case theorem.
 \end{remark}
 
-\section{Paper-faithful BNT canonical form: basic API}
+\section{The BNT canonical form on a sector decomposition}
 \label{sec:paper_bnt_api}
 
-This section records the basic API for the paper-faithful BNT canonical-form
-predicate of
+This section introduces the BNT canonical-form predicate following
 \cite[\S II, lines 287--301]{Cirac2017MPDO_AnnPhys} and
-\cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}. The predicate
-operates on a sector decomposition carrying raw sector weights
-$\mu_{j,q}$ and a coefficient
-$\operatorname{coeff} N\,j = \sum_q \mu_{j,q}^{\,N}$; no equal-modulus
+\cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}. The predicate is
+defined on a sector decomposition with raw sector weights $\mu_{j,q}$ and
+sector coefficients $c_N^{(j)} = \sum_q \mu_{j,q}^{\,N}$; no equal-modulus
 factorization is assumed.
+% Maintainer note (Lean): this is the predicate `IsBNTCanonicalForm` on a
+% `SectorDecomposition`. The blueprint prose uses standard mathematical
+% notation; the `\lean{...}` tag below carries the link.
 
-\begin{definition}[Paper-faithful BNT canonical form]%
+\begin{definition}[BNT canonical form]%
     \label{def:paper_bnt_cf}
     \lean{MPSTensor.IsBNTCanonicalForm}
     \leanok
     \uses{def:paper_sector_data}
-    Given a sector decomposition $P$, the paper-faithful BNT
-    canonical-form predicate records the minimal CPSV16/CPSV21
-    BNT canonical-form data without any equal-modulus or strict-ordering
-    condition on the raw sector weights. Specifically it asserts:
-    each basis block has positive bond dimension, is injective,
-    irreducible, and left-canonical; the normalized self-overlap of every
-    basis block converges to~$1$; the basis MPV family is eventually
-    linearly independent; distinct same-dimension basis blocks are not
-    gauge-phase equivalent in the cast-compatible shape; and the
-    CPSV16 \S II.A line-246 normalization convention holds, namely
+    Given a sector decomposition $P$, the BNT canonical-form predicate
+    records the minimal BNT data of
+    \cite{Cirac2017MPDO_AnnPhys,Cirac2021Matrix} without any equal-modulus
+    or strict-ordering condition on the raw sector weights. It asserts that
+    each basis block has positive bond dimension, is injective, irreducible,
+    and left-canonical; the normalized self-overlap of every basis block
+    converges to $1$; the basis MPV family is eventually linearly
+    independent; distinct same-dimension basis blocks are not gauge-phase
+    equivalent in the cast-compatible shape; and the
+    \cite[\S II.A, line 246]{Cirac2017MPDO_AnnPhys} normalization holds,
     \[
         \lVert \mu_{j,q} \rVert \le 1 \text{ for every }  (j,q),
         \qquad
@@ -662,9 +663,9 @@ factorization is assumed.
     \]
     matching \cite[\S~II, lines 271--301]{Cirac2017MPDO_AnnPhys}
     and \cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.
-    The line-246 normalization fields admit every paper-faithful example
+    The line-246 normalization admits every example of the source paper
     (in particular $C \oplus D$, $C \oplus (-C)$,
-    $C \oplus (1/2) C$, and $C \oplus (-C) \oplus (1/2) C$) and are
+    $C \oplus (1/2) C$, and $C \oplus (-C) \oplus (1/2) C$) and is
     not derivable from the per-block normality data alone.
 \end{definition}
 
@@ -676,8 +677,7 @@ factorization is assumed.
     For every sector decomposition $P$, every length $N$, and every basis
     index $j$, the sector coefficient is the raw power sum
     \[
-        P.\operatorname{coeff}\,N\,j =
-        \sum_{q=1}^{r_j} (P.\operatorname{weight}\,j\,q)^N.
+        c_N^{(j)} = \sum_{q=1}^{r_j} \mu_{j,q}^N.
     \]
     This is \cite[eq.~II, lines 287--301]{Cirac2017MPDO_AnnPhys} and
     \cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.
@@ -697,7 +697,7 @@ factorization is assumed.
     $\lVert\mu_{j,q}\rVert \le 1$, and the triangle inequality bounds
     the norm of the sector coefficient by the multiplicity:
     \[
-        \lVert P.\operatorname{coeff}\,N\,j \rVert \le  r_j.
+        \bigl\lVert c_N^{(j)} \bigr\rVert \le r_j.
     \]
 \end{lemma}
 
@@ -712,10 +712,10 @@ factorization is assumed.
     \lean{MPSTensor.IsBNTCanonicalForm.cross_overlap_basis_tendsto_zero}
     \leanok
     \uses{def:mpv_overlap, def:paper_bnt_cf}
-    If $P$ carries a paper-faithful BNT canonical form and $j \neq k$,
-    then $O_{P_j P_k}(N) \to 0$ as $N \to \infty$, where $P_j$ and
-    $P_k$ are the basis blocks at indices $j$ and $k$. The dispatch
-    follows the normal-tensor overlap dichotomy of
+    If $P$ is a BNT canonical form and $j \neq k$, then
+    $O_{P_j P_k}(N) \to 0$ as $N \to \infty$, where $P_j$ and $P_k$ are the
+    basis blocks at indices $j$ and $k$. The argument follows the
+    normal-tensor overlap dichotomy of
     \cite[lines 1080--1091]{Cirac2017MPDO_AnnPhys}: differing bond dimensions
     force decay, and matching bond dimensions are ruled out by the
     gauge-phase distinctness clause of
@@ -723,11 +723,11 @@ factorization is assumed.
 \end{lemma}
 
 \begin{proof}\leanok
-    Case on whether the bond dimensions match. If the dimensions differ,
-    apply the dimension-mismatch overlap-decay theorem.
-    If they agree, the basis-distinctness clause of the paper-faithful BNT
-    canonical form rules out gauge-phase equivalence in the
-    cast-compatible shape, so the equal-dimension overlap-decay theorem
+    Case on whether the bond dimensions match. If they differ, apply the
+    dimension-mismatch overlap-decay theorem. If they agree, the
+    basis-distinctness clause of the BNT canonical form rules out
+    gauge-phase equivalence in the cast-compatible shape, so the
+    equal-dimension overlap-decay theorem
     applies.
 \end{proof}
 
@@ -737,18 +737,16 @@ factorization is assumed.
     \leanok
     \uses{lem:bnt_two_family_overlap_orthonormal_li,
         lem:paper_bnt_cross_overlap_basis_tendsto_zero}
-    Let $P$ and $Q$ each carry a paper-faithful BNT canonical form, and
-    suppose every mixed overlap $O_{P_j Q_k}(N)$ tends to~$0$. Then the
-    union family
+    Let $P$ and $Q$ each be a BNT canonical form, and suppose every mixed
+    overlap $O_{P_j Q_k}(N)$ tends to $0$. Then the union family
     \[
         \bigl\{\ket{V^{(N)}(P_j)}\bigr\}_{j=1}^{g_P}
         \cup
         \bigl\{\ket{V^{(N)}(Q_k)}\bigr\}_{k=1}^{g_Q}
     \]
-    is linearly independent for all sufficiently large~$N$. This is the
-    paper-faithful instantiation of the corollary~\texttt{Lem1} of
-    \cite[lines 1121--1132]{Cirac2017MPDO_AnnPhys} and matches the BNT
-    linear-independence input recorded at
+    is linearly independent for all sufficiently large $N$. This is the
+    corollary at \cite[lines 1121--1132]{Cirac2017MPDO_AnnPhys}, matching
+    the BNT linear-independence input recorded at
     \cite[line 1850]{Cirac2021Matrix}.
 \end{lemma}
 
@@ -765,13 +763,14 @@ factorization is assumed.
     \lean{MPSTensor.IsBNTCanonicalForm.norm_coeff_le_copies}
     \leanok
     \uses{def:paper_bnt_cf, lem:paper_bnt_norm_coeff_le_copies}
-    Under the strengthened paper-faithful canonical form, the structural
-    field encoding CPSV16 \S II.A line~246 yields directly
+    Under the BNT canonical form, the
+    \cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} normalization yields
+    directly
     \[
-        \lVert P.\operatorname{coeff}\,N\,j \rVert \le  r_j
+        \bigl\lVert c_N^{(j)} \bigr\rVert \le r_j
     \]
-    for every $N$ and basis index~$j$, without an additional
-    explicit modulus-bound hypothesis at the call site.
+    for every $N$ and basis index $j$, without an additional explicit
+    modulus-bound hypothesis at the call site.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -784,10 +783,10 @@ factorization is assumed.
     \lean{MPSTensor.IsBNTCanonicalForm.weight_unit_exists_of_struct}
     \leanok
     \uses{def:paper_bnt_cf}
-    Re-exposes the unit-modulus existential field
-    (CPSV16 \S II.A line~246) at the API layer: under the strengthened
-    paper-faithful canonical form, there exist indices~$(j_*, q_*)$ with
-    $\lVert P.\operatorname{weight}\,j_*\,q_* \rVert = 1$.
+    Under the BNT canonical form, the
+    \cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} unit-modulus existential
+    provides indices $(j_*, q_*)$ with
+    $\lVert \mu_{j_*, q_*} \rVert = 1$.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -801,13 +800,13 @@ factorization is assumed.
     \leanok
     \uses{def:paper_bnt_cf}
     The single-sector two-copy decomposition with raw weights
-    $(1, 1/2)$ demonstrates that the strengthened paper-faithful BNT
-    canonical form admits unequal-modulus copies: the modulus-bound field
-    holds because $\lVert 1 \rVert \le 1$ and
-    $\lVert 1/2 \rVert = 1/2 \le 1$, and the unit-modulus existential is
-    witnessed by the first copy with weight~$1$. This is the CPSV16
-    \S II.A line~246 convention in positive form, reifying the
-    $C \oplus (1/2)C$ example.
+    $(1, 1/2)$ demonstrates that the BNT canonical form admits
+    unequal-modulus copies: the modulus bound holds because
+    $\lVert 1 \rVert \le 1$ and $\lVert 1/2 \rVert = 1/2 \le 1$, and the
+    unit-modulus existential is witnessed by the first copy with
+    weight $1$. This is the
+    \cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} normalization in
+    positive form, applied to the $C \oplus (1/2)C$ example.
 \end{example}
 
 \section{Ces\`aro non-decay and unit-block coefficient}
@@ -857,36 +856,33 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     \lean{MPSTensor.IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block}
     \leanok
     \uses{def:paper_bnt_cf, lem:paper_bnt_cesaro_nondecay}
-    Let $P$ be a sector decomposition carrying a paper-faithful BNT
-    canonical form and let $j_0$ be any sector index such that some copy
-    of sector $j_0$ carries a unit-modulus weight, i.e.\ there exists
-    $q$ with $\lVert P.\operatorname{weight}\,j_0\,q\rVert = 1$.
-    Then the sector-$j_0$ coefficient
-    $c_{j_0}(N) = \sum_q (P.\operatorname{weight}\,j_0\,q)^N$ does not
+    Let $P$ be a BNT canonical form and let $j_0$ be a sector index such
+    that some copy of sector $j_0$ carries a unit-modulus weight, that is,
+    there exists $q$ with $\lVert \mu_{j_0, q}\rVert = 1$. Then the
+    sector-$j_0$ coefficient $c_N^{(j_0)} = \sum_q \mu_{j_0, q}^N$ does not
     tend to $0$ as $N \to \infty$.
 
-    This is the paper-parametrised reading of the CPSV16 \S~II.A line~246
-    + line~1244 normalization. The unit-modulus witness is supplied
-    externally (as the hypothesis above) because CPSV16 line~246 is a
-    \emph{global} statement (``at least one of them equals one'' over the
-    two-layer index $(j, q)$) and does not pin the witness to a specific
-    sector.
+    This reads the \cite[\S~II.A, lines 246 and 1244]{Cirac2017MPDO_AnnPhys}
+    normalization sector by sector. The unit-modulus witness is supplied
+    externally (as the hypothesis above) because the source statement is
+    global (``at least one of them equals one'' over the two-layer index
+    $(j, q)$) and does not pin the witness to a specific sector.
 \end{lemma}
 
 \begin{proof}\leanok
     Apply Lemma~\ref{lem:paper_bnt_cesaro_nondecay} to the family
-    $\mu := P.\operatorname{weight}\,j_0$, feeding in the modulus-bound
-    field (giving $\lVert\mu_q\rVert \le 1$ for every $q$) and the
-    supplied per-sector unit-modulus existential hypothesis.
+    $q \mapsto \mu_{j_0, q}$, using the modulus bound
+    $\lVert \mu_{j_0, q}\rVert \le 1$ from the canonical-form normalization
+    together with the per-sector unit-modulus hypothesis.
 \end{proof}
 
 \begin{remark}
-    Consuming this lemma inside the matching theorem of
-    \cite[\S~II, lines~1181--1188]{Cirac2017MPDO_AnnPhys} supplies the
-    non-decay step on $P.\operatorname{coeff} \cdot\,j_0$. The matching
-    theorem now takes the unit-block sector and witness as explicit
-    parameters, faithfully mirroring the global character of CPSV16
-    line~246.
+    Used inside the matching theorem of
+    \cite[\S~II, lines 1181--1188]{Cirac2017MPDO_AnnPhys} this lemma
+    supplies the non-decay step on $c_N^{(j_0)}$. The matching theorem takes
+    the unit-modulus sector and witness as explicit parameters, mirroring
+    the global character of the source normalization at
+    \cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys}.
 \end{remark}
 
 \subsection{Matched-sector weight multiset equality}
@@ -894,19 +890,18 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
 Given a matched basis-sector pair $(j_0, \tilde k_0)$ and a nonzero
 scalar $\zeta \in \mathbb{C}\setminus\{0\}$ such that the matched
 coefficient identity
-$P.\operatorname{coeff}\,N\,j_0 = \zeta^N \cdot Q.\operatorname{coeff}\,N\,\tilde k_0$
+$c_N^{(j_0)}(P) = \zeta^N \cdot c_N^{(\tilde k_0)}(Q)$
 holds for every $N$ past some threshold $N_0$, this subsection
 records the two algebraic conclusions: the \emph{matched-sector weight
     multiset equality} derived from the coefficient identity by power-sum
 recovery (Theorem~\ref{thm:power_sum_multiset}), and the
 \emph{matched-sector weight-permutation extractor} upgrading the multiset
 equality to an explicit per-copy indexing. Together they realise the
-$\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ recovery
-of~\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. The
-coefficient identity itself is the Step~1 linear-independence projection
-of \cite[\S~II, \texttt{II\_cor2}, lines 1170--1192]{Cirac2017MPDO_AnnPhys}
-and is supplied by the global-gauge / full-basis route of
-Phase~B-$\gamma$ below.
+$\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ recovery of
+\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. The coefficient
+identity itself is the linear-independence projection step of
+\cite[\S~II, lines 1170--1192]{Cirac2017MPDO_AnnPhys} and is supplied by
+the substitution argument of \S\ref{subsec:paper_bnt_substitution} below.
 
 \begin{lemma}[Matched-sector weight multiset equality]%
     \label{lem:paper_bnt_matched_sector_weight_multiset_eq}
@@ -914,40 +909,33 @@ Phase~B-$\gamma$ below.
     \leanok
     \uses{def:paper_sector_data,
         thm:power_sum_multiset}
-    Let $P, Q$ be sector decompositions, and fix indices $j_0$, $\tilde k_0$,
-    and a nonzero scalar $\zeta \in \mathbb{C}\setminus\{0\}$. Suppose
+    Let $P, Q$ be sector decompositions with weights $\mu_{j,q}$ and
+    $\nu_{k,q'}$, and fix indices $j_0$, $\tilde k_0$, and a nonzero scalar
+    $\zeta \in \mathbb{C}\setminus\{0\}$. Suppose that for every $N > N_0$,
     \[
-        P.\operatorname{coeff}\,N\,j_0
-        =
-        \zeta^N \cdot Q.\operatorname{coeff}\,N\,\tilde k_0
-        \qquad \text{for every } N > N_0.
+        c_N^{(j_0)}(P) = \zeta^N \cdot c_N^{(\tilde k_0)}(Q).
     \]
-    Then the per-sector multiplicities match,
-    $P.\operatorname{copies}\,j_0 = Q.\operatorname{copies} \tilde k_0$, and the
-    rescaled per-copy weight multisets coincide.
+    Then the per-sector multiplicities agree, $r_{j_0}(P) = r_{\tilde k_0}(Q)$,
+    and the rescaled per-copy weight multisets coincide.
     This is \cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ and matching
-    $r_{a,j} = r_{b,j}$) read on a single matched sector.
+    multiplicities $r_{a,j} = r_{b,j}$) read on a single matched sector.
 \end{lemma}
 
 \begin{proof}\leanok
     \uses{thm:bounded_power_sum_multiset}
     Unfold both sides of the coefficient identity to per-copy power sums
-    $\sum_{q} (P.\operatorname{weight}\,j_0\,q)^N$ and
-    $\sum_{q'} (Q.\operatorname{weight} \tilde k_0\,q')^N$ and distribute
-    $\zeta^N$ through the $Q$-side sum to obtain the rescaled identity
+    $\sum_q \mu_{j_0, q}^N$ and $\sum_{q'} \nu_{\tilde k_0, q'}^N$, and
+    distribute $\zeta^N$ through the right-hand sum to obtain, for every
+    $N > N_0$,
     \[
-        \sum_{q} (P.\operatorname{weight}\,j_0\,q)^N
-        =
-        \sum_{q'} (\zeta \cdot Q.\operatorname{weight} \tilde k_0\,q')^N
-        \qquad \text{for every } N > N_0.
+        \sum_q \mu_{j_0, q}^N = \sum_{q'} (\zeta \cdot \nu_{\tilde k_0, q'})^N.
     \]
-    Extend to all positive exponents and apply the
-    unequal-cardinality multiset-recovery lemma
-    (Theorem~\ref{thm:bounded_power_sum_multiset}); nonzero weights are
-    required, supplied by $\zeta \neq 0$ together with the weight
-    non-vanishing field. This delivers both
-    the multiplicity match and the multiset equality.
+    Extend to all positive exponents and apply the unequal-cardinality
+    multiset-recovery lemma (Theorem~\ref{thm:bounded_power_sum_multiset}),
+    using $\zeta \neq 0$ together with the weight non-vanishing assumption
+    to ensure the input weights are nonzero. This yields the multiplicity
+    match and the multiset equality.
 \end{proof}
 
 \begin{lemma}[Matched-sector weight-permutation extractor]%
@@ -956,15 +944,12 @@ Phase~B-$\gamma$ below.
     \leanok
     \uses{lem:paper_bnt_matched_sector_weight_multiset_eq}
     Under the hypotheses of
-    Lemma~\ref{lem:paper_bnt_matched_sector_weight_multiset_eq}, there
-    exist a per-sector multiplicity match and an explicit permutation
-    between the per-copy index sets identifying the individual per-copy
-    weights up to the gauge phase:
+    Lemma~\ref{lem:paper_bnt_matched_sector_weight_multiset_eq}, the
+    per-sector multiplicities agree and there is a permutation $\tau$ of
+    the per-copy index set identifying the individual weights up to the
+    gauge phase: for every $q$,
     \[
-        Q.\operatorname{weight} \tilde k_0\,(\tau\,q)
-        =
-        \zeta^{-1} \cdot P.\operatorname{weight}\,j_0\,q
-        \qquad \text{for every } q.
+        \nu_{\tilde k_0, \tau(q)} = \zeta^{-1} \cdot \mu_{j_0, q}.
     \]
     This is the per-copy realisation of
     \cite[\S~II, line 1188]{Cirac2017MPDO_AnnPhys}
@@ -984,31 +969,29 @@ Phase~B-$\gamma$ below.
     pointwise identity to $\zeta^{-1}$ on the left.
 \end{proof}
 
-\section{Phase B-$\alpha$: paper-faithful strong existential matching}
+\section{Strong existential matching of unit-modulus sectors}
+\label{sec:paper_bnt_strong_match}
 
-This section records the paper-faithful Phase~B-$\alpha$ lifting of
-the weak existential $\exists j,\exists k$ to the strong existential
-$\forall k,\exists j$ matching theorem on the original
-(un-dropped) pair of BNT canonical forms. No recursion, no partial
-sector dropping, no combined-LI obligation on a partial union: the
-result is a single $\forall k,\exists j$ existential statement on the
-original $(P, Q)$, iterated externally over each $Q$-side
-unit-block sector.
+This section lifts the weak existential matching $\exists j,\exists k$ to
+the strong existential $\forall k,\exists j$ on the original pair of BNT
+canonical forms, without recursion, partial sector dropping, or any
+combined-linear-independence obligation on a partial union. The result is
+a single $\forall k,\exists j$ statement on the original $(P, Q)$,
+iterated externally over each $Q$-side unit-modulus sector.
 
-The unit-block restriction on $k$ is paper-faithful:
-\cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} records the modulus-one
-hypothesis as a single \emph{global} existential over the two-layer
-$(j, q)$ index of the BNT display, not a per-block one. Sectors
-whose weights all have modulus strictly less than one have
-coefficients $Q.\operatorname{coeff}\,N\,k = \sum_q (Q.\operatorname{weight}\,k\,q)^N$
-that decay exponentially to zero, contribute nothing to the
-thermodynamic state, and are not constrained by the matching
-(\cite[\S~II.C, lines~1244--1248]{Cirac2017MPDO_AnnPhys} returns to
-this point via the $\mathbb{E}^N$-fixed-point characterisation).
-The downstream Phase~B-$\beta$ bijective-matching layer will apply
-this theorem twice (with $(P, Q)$ swapped) to derive the cardinality
-identity and the per-pair bijection / gauge data on the full basis
-(every sector is a unit block under the Phase~D per-block
+The unit-modulus restriction on $k$ matches the source convention:
+\cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} records the
+modulus-one hypothesis as a single \emph{global} existential over the
+two-layer $(j, q)$ index of the BNT display, not a per-block one. Sectors
+whose weights all have modulus strictly less than one have coefficients
+$c_N^{(k)}(Q) = \sum_q \nu_{k,q}^N$ that decay exponentially to zero,
+contribute nothing to the thermodynamic state, and are not constrained by
+the matching (\cite[\S~II.C, lines 1244--1248]{Cirac2017MPDO_AnnPhys}
+returns to this point through the transfer-power fixed-point
+characterisation). The bijective-matching theorem below applies the
+strong existential theorem twice (with $(P, Q)$ swapped) to derive the
+cardinality identity and the per-pair bijection / gauge data on the full
+basis (every sector is a unit-modulus block under the per-block
 normalization).
 
 \begin{theorem}[Strong existential matching, full-basis form]
@@ -1018,78 +1001,75 @@ normalization).
     \uses{def:paper_bnt_cf,
         lem:paper_bnt_combined_family_eventually_li,
         lem:paper_bnt_coeff_not_tendsto_zero_at_unit_block}
-    Let $P, Q$ be two paper-faithful BNT canonical forms with the
-    same MPV family. For every sector $k$ there exists a sector $j$
-    with matched bond dimension $h : P.\operatorname{basisDim}\,j = Q.\operatorname{basisDim}\,k$,
-    a gauge-phase equivalence between the cast basis tensors, and a
-    non-decaying cross-overlap.
+    Let $P, Q$ be two BNT canonical forms with the same MPV family. For
+    every sector $k$ there exist a sector $j$ with matched bond dimension
+    $\dim_P(j) = \dim_Q(k)$, a gauge-phase equivalence between the cast
+    basis tensors, and a non-decaying cross-overlap.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{lem:paper_bnt_combined_family_eventually_li,
         lem:paper_bnt_coeff_not_tendsto_zero_at_unit_block}
-    The CPSV16 \S II.C lines 1182--1186 Step 1 contrapositive of
-    \cite[Lemma~\texttt{Lem1}, lines 1131--1133]{Cirac2017MPDO_AnnPhys},
-    combined-LI on the \emph{full} family
-    $\{A^{[j]}\}_j \cup \{B^{[k]}\}_k$, is iterated externally over
-    each sector $k$. Each iteration is discharged by
-    the full-basis matching theorem
-    (\texttt{MPSTensor.exists\_block\_match\_of\_sameMPV}) with the
-    roles of $P$ and $Q$ swapped: feed the canonical-form data in
-    the reversed order, supply the basis non-emptiness witness from the
-    retained global unit witness, and supply the proportional-MPV
-    hypothesis via the pointwise-symmetric flip.
-    Re-orient the resulting conclusion via symmetry of gauge-phase
-    equivalence across a bond-dim cast and symmetry of overlap
-    convergence to zero.
+    The contrapositive of
+    \cite[\S~II.C, lines 1182--1186]{Cirac2017MPDO_AnnPhys}, combined with
+    linear independence on the full family
+    $\{P_j\}_j \cup \{Q_k\}_k$, is iterated externally over each sector
+    $k$. Each iteration is discharged by the full-basis weak existential
+    matching theorem with the roles of $P$ and $Q$ swapped: supply the
+    canonical-form data in reversed order, the basis non-emptiness witness
+    from the retained global unit-modulus witness, and the
+    proportional-MPV hypothesis through its pointwise-symmetric flip. The
+    resulting conclusion is re-oriented by symmetry of gauge-phase
+    equivalence across a bond-dimension cast and symmetry of overlap
+    convergence.
 \end{proof}
 
-\begin{remark}[No partial-union LI]
+\begin{remark}[Linear independence on the full family]
     \label{rem:paper_bnt_strong_match_no_partial_li}
     Theorem~\ref{thm:paper_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV}
     consumes \emph{only} the weak existential matching theorem, which
-    itself routes through the combined-LI step
+    itself routes through the linear-independence step
     (Lemma~\ref{lem:paper_bnt_combined_family_eventually_li}) on the
-    \emph{full} $P.\operatorname{basis} \sqcup Q.\operatorname{basis}$ family (the
-    \texttt{Lem1} input of CPSV16 lines 1131--1133), not on any
-    partial union. This is the paper-faithful realization and closes
-    the open obligation at the strong-matching layer.
+    \emph{full} family $\{P_j\}_j \sqcup \{Q_k\}_k$, the corollary
+    input of \cite[\S~II.C, lines 1131--1133]{Cirac2017MPDO_AnnPhys}, not
+    on any partial union.
 \end{remark}
 
-\subsection{Phase B-$\beta$: bijective matching by symmetry}
+\subsection{Bijective matching by symmetry}
 \label{subsec:paper_bnt_strong_match_bijective_symmetry}
 
-\emph{CPSV16 \S II.C lines 1184--1186, the symmetry argument
-    $g_a \ge g_b \wedge g_b \ge g_a \Rightarrow g_a = g_b$.}
+This subsection derives the symmetry argument of
+\cite[\S~II.C, lines 1184--1186]{Cirac2017MPDO_AnnPhys}:
+$g_a \ge g_b$ and $g_b \ge g_a$ together imply $g_a = g_b$.
 
-Phase B-$\alpha$
+The strong existential matching theorem
 (Theorem~\ref{thm:paper_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV})
-gives one direction of the matching on the unit-block subset.
+gives one direction of the matching on the unit-modulus subset.
 Applying the same theorem once more with the roles of $P$ and $Q$
-swapped (and the trivially-symmetric flip of the proportional-MPV
+swapped (and the trivially symmetric flip of the proportional-MPV
 hypothesis) gives the other direction. The two matchings, combined
 with the basis-distinctness clause of the canonical-form predicate
-(CPSV16 lines 264--279), force \emph{injectivity in both directions}.
+\cite[\S~II, lines 264--279]{Cirac2017MPDO_AnnPhys}, force injectivity
+in both directions.
 
-\paragraph{Honest scoping.}
-The literal paper conclusion ``$g_a = g_b$ and a relabelling
+\paragraph{Scope.}
+The literal source conclusion ``$g_a = g_b$ and a relabelling
 $B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$''
-(\cite[\S~II.C, lines 1184--1186]{Cirac2017MPDO_AnnPhys}) would read as a
+(\cite[\S~II.C, lines 1184--1186]{Cirac2017MPDO_AnnPhys}) reads as a
 bijection between the unit-modulus subsets of the two BNT canonical
-forms. Phase B-$\beta$ delivers the \emph{symmetric injective
-    matching} (the literal CPSV16 line~1186 ``$g_a \ge g_b \wedge g_b \ge g_a$''
-step) on the cleanest paper-faithful surface: two
-injective embeddings, one in each direction, codomains in the full
-basis of $P$ and $Q$ respectively. Upgrading the codomains to the
-unit-modulus subsets (and packaging as a bijection) requires the
+forms. The theorem below delivers the symmetric injective matching
+(the source's $g_a \ge g_b \wedge g_b \ge g_a$ step) on the cleanest
+surface: two injective embeddings, one in each direction, with codomains
+in the full basis of $P$ and $Q$ respectively. Upgrading the codomains to
+the unit-modulus subsets (and packaging as a bijection) requires the
 additional per-sector weight-equivariance argument of
-\cite[Lemma~\texttt{equalMPS}, lines 1148--1167]{Cirac2017MPDO_AnnPhys}
-combined with the gauge-phase identity on the weighted sectors
-$\sum_q (\mu_{j,q})^N |V^N(P.\operatorname{basis}\,j)\rangle$; the
-non-decay output of Phase B-$\alpha$ is on the \emph{basis} MPV
-states, not on the weighted sectors, and so does not by itself force
-the matched $j$ to carry a unit-modulus weight. This upgrade is
-isolated as a follow-up phase.
+\cite[\S~II.C, lines 1148--1167]{Cirac2017MPDO_AnnPhys} combined with the
+gauge-phase identity on the weighted sectors
+$\sum_q \mu_{j,q}^N \ket{V^{(N)}(P_j)}$; the non-decay output of the
+strong existential theorem is on the basis MPV states, not on the
+weighted sectors, and so does not by itself force the matched $j$ to
+carry a unit-modulus weight. That upgrade is left to the substitution
+argument of \S\ref{subsec:paper_bnt_substitution}.
 
 \begin{theorem}[Bijective matching by symmetry]
     \label{thm:paper_bnt_bijective_match_of_sameMPV}
@@ -1097,22 +1077,21 @@ isolated as a follow-up phase.
     \leanok
     \uses{thm:paper_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV,
         def:paper_bnt_cf}
-    Let $P, Q$ be two paper-faithful BNT canonical forms with the
-    same MPV family. Write
+    Let $P, Q$ be two BNT canonical forms with the same MPV family. Write
     \[
-        \texttt{UnitP} := \{ j \mid \exists q,\, |P.\operatorname{weight}\,j\,q| = 1 \}
+        J_1(P) := \{ j \in J(P) : \exists q,\ |\mu_{j,q}| = 1 \}
     \]
-    and $\texttt{UnitQ}$ symmetrically on $Q$. Then there exist
-    injective embeddings
+    and let $J_1'(Q)$ denote the analogous unit-modulus subset of
+    $Q$-sectors. Then there exist injective embeddings
     \[
-        \varphi : \texttt{UnitQ} \hookrightarrow P.\operatorname{basisIndex},
+        \varphi : J_1'(Q) \hookrightarrow J(P),
         \qquad
-        \psi : \texttt{UnitP} \hookrightarrow Q.\operatorname{basisIndex},
+        \psi : J_1(P) \hookrightarrow J(Q),
     \]
-    such that for every $k \in \texttt{UnitQ}$ the bond dimensions
-    match, the basis tensors are gauge-phase equivalent (cast-left
-    shape), and the basis cross-overlap does not tend to zero; and
-    symmetrically for every $j \in \texttt{UnitP}$ via $\psi$.
+    such that for every $k \in J_1'(Q)$ the bond dimensions match, the
+    basis tensors $P_{\varphi(k)}$ and $Q_k$ are gauge-phase equivalent in
+    the cast-left shape, and the basis cross-overlap does not tend to
+    zero; and symmetrically for every $j \in J_1(P)$ through $\psi$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1123,73 +1102,70 @@ isolated as a follow-up phase.
     $(Q, P)$ and the symmetric flipped hypothesis to obtain the
     symmetric raw function.
 
-    \emph{Forward injectivity.}  Suppose $\varphi_0(k_1) = \varphi_0(k_2) = j$.
-    The two matching witnesses give a common centre
-    $P.\operatorname{basis}\,j$ with two gauge-phase equivalences (after
-    cast) to $Q.\operatorname{basis}\,k_1$ and $Q.\operatorname{basis}\,k_2$.
-    Composing through this centre (cast-aware transitivity of
-    gauge-phase equivalence) gives a gauge-phase equivalence between
-    $Q.\operatorname{basis}\,k_1$ and $Q.\operatorname{basis}\,k_2$ for the
-    dimension equality
-    $h_Q : Q.\operatorname{basisDim}\,k_1 = Q.\operatorname{basisDim}\,k_2$.
-    The basis-distinctness clause of the canonical-form predicate on $Q$
-    (CPSV16 lines 264--279) then forces $k_1 = k_2$. The backward
-    injectivity is symmetric.
+    \emph{Forward injectivity.} Suppose $\varphi_0(k_1) = \varphi_0(k_2) = j$.
+    The two matching witnesses give a common centre $P_j$ with two
+    gauge-phase equivalences (after a bond-dimension cast) to $Q_{k_1}$ and
+    $Q_{k_2}$. Composing through this centre (cast-aware transitivity of
+    gauge-phase equivalence) yields a gauge-phase equivalence between
+    $Q_{k_1}$ and $Q_{k_2}$ under the dimension equality
+    $\dim_Q(k_1) = \dim_Q(k_2)$. The basis-distinctness clause of the
+    canonical-form predicate on $Q$
+    (\cite[\S~II, lines 264--279]{Cirac2017MPDO_AnnPhys}) then forces
+    $k_1 = k_2$. Backward injectivity is symmetric.
 
-    \emph{Wrapping as injective embeddings.}  The injective
-    functions, paired with the injectivity proofs, are exactly the
-    embedding pair stated in the theorem. The matching data are
-    extracted by re-applying the classical-choice spec at each subtype
-    index.
+    \emph{Injective embeddings.} The injective functions, paired with the
+    injectivity proofs, are exactly the embedding pair stated in the
+    theorem. The matching data are extracted by re-applying the
+    classical-choice specification at each subtype index.
 \end{proof}
 
-\subsection{Phase B-$\gamma$: CPSV16 \S{}II.C lines 1187--1188 Corollary substitution}
+\subsection{Substitution argument for the unit-modulus subset}
+\label{subsec:paper_bnt_substitution}
 
-Given the matched gauges from Phase B-$\alpha$
-encoded as the injection from Phase B-$\beta$, the \emph{per-block
-    coefficient identity} of CPSV16 \S~II.C lines 1187--1188
-(arXiv:1606.00608, the Corollary \texttt{II\_cor2}'s substitution argument)
-follows by substituting the per-pair gauge identity
-$\operatorname{mpv}(B_k)(\sigma) = \zeta_k^N \cdot \operatorname{mpv}(A_{\varphi(k)})(\sigma)$
-into the original proportional-MPV hypothesis and projecting the
-resulting overlap onto each basis tensor $A_{j_0}$.
+Given the matched gauges produced by the strong existential theorem
+(Theorem~\ref{thm:paper_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV})
+encoded as the injection from
+\S\ref{subsec:paper_bnt_strong_match_bijective_symmetry}, the per-block
+coefficient identity of
+\cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys} follows by
+substituting the per-pair gauge identity
+$V^{(N)}(Q_k)_\sigma = \zeta_k^N \cdot V^{(N)}(P_{\varphi(k)})_\sigma$
+into the proportional-MPV hypothesis and projecting the resulting overlap
+onto each basis tensor $P_{j_0}$.
 
-\paragraph{Honest scoping.}
-The user-requested literal form of the matched-pair clause is
-\emph{eventual exact} equality
-$P.\operatorname{coeff}\,N\,(\varphi\,k) = \zeta_k^N \cdot Q.\operatorname{coeff}\,N\,k.\operatorname{val}$
-for all sufficiently large $N$. Deriving eventual exact equality
-from the partial-bijection data ($\texttt{UnitQ}$ only, with non-unit
-$Q$-blocks unconstrained) requires combined LI on a partial union,
-the precise partial-union LI not naturally derivable from the
-paper-faithful BNT canonical form alone. We deliver the
-\emph{asymptotic-difference} form
-$\operatorname{Tendsto}\,(P.\operatorname{coeff}\,N\,(\varphi\,k) - \zeta_k^N \cdot Q.\operatorname{coeff}\,N\,k.\operatorname{val}) \operatorname{atTop}\,(\mathcal{N}\,0)$,
-which is the natural output of the overlap-projection argument; the
-upgrade to the eventual-exact form is provided downstream by the
-multiset-rigidity lemma of Theorem~\ref{thm:power_sum_multiset}, the
-Newton--Girard input behind CPSV16 lines 1187--1188. The
-non-matched-decay clause is delivered in full.
+\paragraph{Scope.}
+The literal form of the matched-pair clause is the eventual exact
+equality $c_N^{(\varphi(k))}(P) = \zeta_k^N \cdot c_N^{(k)}(Q)$ for all
+sufficiently large $N$. Deriving the eventual exact equality from the
+partial-bijection data (with non-unit $Q$-sectors unconstrained) requires
+linear independence on the partial union of bases, which is not naturally
+available from the canonical-form predicate alone. The theorem below
+delivers the asymptotic-difference form
+$c_N^{(\varphi(k))}(P) - \zeta_k^N \cdot c_N^{(k)}(Q) \to 0$ as
+$N \to \infty$, which is the natural output of the overlap-projection
+argument; the upgrade to the eventual-exact form is provided downstream
+by the multiset-rigidity Theorem~\ref{thm:power_sum_multiset}, the
+Newton--Girard input behind \cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys}.
+The non-matched decay clause is delivered in full.
 
-\begin{lemma}[Ces\`aro converse: coefficient decay for subnormal sectors]
+\begin{lemma}[Coefficient decay for subnormal sectors]
     \label{thm:paper_bnt_coeff_tendsto_zero_of_all_weights_subnorm}
     \lean{MPSTensor.IsBNTCanonicalForm.coeff_tendsto_zero_of_all_weights_subnorm}
     \leanok
     \uses{def:paper_bnt_cf}
-    Let $P$ be a paper-faithful BNT canonical form, and let $j$ be
-    a sector for which every copy weight is strictly subnormal,
-    $\lVert P.\operatorname{weight}\,j\,q \rVert < 1$ for every $q$.
-    Then $\lim_{N \to \infty} P.\operatorname{coeff}\,N\,j = 0$.
+    Let $P$ be a BNT canonical form and let $j$ be a sector for which
+    every copy weight is strictly subnormal, that is,
+    $\lVert \mu_{j, q}\rVert < 1$ for every $q$. Then
+    $\lim_{N \to \infty} c_N^{(j)} = 0$.
 \end{lemma}
 
 \begin{proof}\leanok
-    The coefficient $P.\operatorname{coeff}\,N\,j = \sum_q (P.\operatorname{weight}\,j\,q)^N$
-    is a finite sum. Each summand $(P.\operatorname{weight}\,j\,q)^N$ tends
-    to $0$ as $N \to \infty$ by the closed-unit-disk strict subnorm
-    hypothesis. A finite sum of null sequences is null.
+    The coefficient $c_N^{(j)} = \sum_q \mu_{j,q}^N$ is a finite sum. Each
+    summand $\mu_{j,q}^N$ tends to $0$ as $N \to \infty$ by the strict
+    subnormality hypothesis. A finite sum of null sequences is null.
 \end{proof}
 
-\begin{theorem}[CPSV16 \S{}II.C lines 1187--1188 Corollary substitution]
+\begin{theorem}[Substitution argument for the unit-modulus subset]
     \label{thm:paper_bnt_coeff_identity_via_global_gauge}
     \lean{MPSTensor.coeff_identity_via_global_gauge}
     \leanok
@@ -1198,27 +1174,28 @@ non-matched-decay clause is delivered in full.
         thm:paper_bnt_bijective_match_of_sameMPV,
         lem:paper_bnt_combined_family_eventually_li,
         thm:paper_bnt_coeff_tendsto_zero_of_all_weights_subnorm}
-    Let $P, Q$ be two paper-faithful BNT canonical forms generating
-    proportional MPVs. Let
+    Let $P, Q$ be two BNT canonical forms generating proportional MPVs. Let
     \[
-        \texttt{UnitQ} := \{ k \mid \exists\,q,\ \lVert Q.\operatorname{weight}\,k\,q \rVert = 1 \}
+        J_1'(Q) := \{ k \in J(Q) \mid \exists q,\ \lVert \nu_{k, q}\rVert = 1 \}
     \]
-    be the unit-modulus subset of $Q$-sectors (CPSV16 \S~II.A line~246
-    normalization), and let $\varphi : \texttt{UnitQ} \hookrightarrow P.\operatorname{basisIndex}$
-    be an injection equipped with per-pair matched-gauge data
-    for every $k \in \texttt{UnitQ}$. Then:
+    be the unit-modulus subset of $Q$-sectors
+    (\cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} normalization), and
+    let $\varphi : J_1'(Q) \hookrightarrow J(P)$ be an injection equipped
+    with per-pair matched-gauge data for every $k \in J_1'(Q)$. Then:
     \begin{enumerate}
-        \item \emph{Matched-pair asymptotic identity}: for every
-              $k \in \texttt{UnitQ}$ there exists a phase $\zeta_k \in \mathbb{C}$
-              with $\lVert\zeta_k\rVert = 1$ such that the asymptotic difference
-              of coefficient sequences vanishes,
+        \item \emph{Matched-pair asymptotic identity.} For every
+              $k \in J_1'(Q)$ there exists a phase $\zeta_k \in \mathbb{C}$
+              with $\lVert \zeta_k \rVert = 1$ such that the asymptotic
+              difference of coefficient sequences vanishes,
               \[
-                  \lim_{N \to \infty}\ P.\operatorname{coeff}\,N\,(\varphi\,k) - \zeta_k^N \cdot Q.\operatorname{coeff}\,N\,k.\operatorname{val}\ =\ 0.
+                  \lim_{N \to \infty}\
+                  \bigl( c_N^{(\varphi(k))}(P) - \zeta_k^N \cdot c_N^{(k)}(Q) \bigr)
+                  = 0.
               \]
-        \item \emph{Non-matched-decay}: for every $j_0 \in P.\operatorname{basisIndex}$
-              outside the range of $\varphi$,
+        \item \emph{Non-matched decay.} For every $j_0 \in J(P)$ outside
+              the range of $\varphi$,
               \[
-                  \lim_{N \to \infty}\ P.\operatorname{coeff}\,N\,j_0\ =\ 0.
+                  \lim_{N \to \infty}\ c_N^{(j_0)}(P) = 0.
               \]
     \end{enumerate}
 \end{theorem}
@@ -1227,58 +1204,62 @@ non-matched-decay clause is delivered in full.
     \leanok
     \uses{thm:paper_bnt_coeff_tendsto_zero_of_all_weights_subnorm,
         lem:paper_bnt_cross_overlap_basis_tendsto_zero}
-    Fix $j_0$ and project the proportional-MPV identity onto the
-    overlap with $P.\operatorname{basis}\,j_0$:
+    Fix $j_0$ and project the proportional-MPV identity onto the overlap
+    with $P_{j_0}$:
     \[
-        \sum_j P.\operatorname{coeff}\,N\,j \cdot \langle V_N(A_j) \mid V_N(A_{j_0}) \rangle
+        \sum_j c_N^{(j)}(P) \cdot \braket{V^{(N)}(P_j)}{V^{(N)}(P_{j_0})}
         =
-        \sum_k Q.\operatorname{coeff}\,N\,k \cdot \langle V_N(B_k) \mid V_N(A_{j_0}) \rangle.
+        \sum_k c_N^{(k)}(Q) \cdot \braket{V^{(N)}(Q_k)}{V^{(N)}(P_{j_0})}.
     \]
-    \emph{LHS.} The off-diagonal $j \neq j_0$ terms decay by
-    Lemma~\ref{lem:paper_bnt_cross_overlap_basis_tendsto_zero} (CPSV16
-    lines 1080--1091) and the diagonal term
-    \(P.\operatorname{coeff}\,N\,j_0 \cdot
-    (\langle V_N(A_{j_0}) \mid V_N(A_{j_0}) \rangle - 1)\)
-    decays by the normalized self-overlap (CPSV21 line 1818). Hence
-    $\text{LHS} - P.\operatorname{coeff}\,N\,j_0 \to 0$.
+    On the left-hand side, the off-diagonal terms $j \neq j_0$ decay by
+    Lemma~\ref{lem:paper_bnt_cross_overlap_basis_tendsto_zero}
+    (\cite[lines 1080--1091]{Cirac2017MPDO_AnnPhys}), and the diagonal
+    term
+    $c_N^{(j_0)}(P) \cdot (\braket{V^{(N)}(P_{j_0})}{V^{(N)}(P_{j_0})} - 1)$
+    decays by the normalized self-overlap
+    (\cite[line 1818]{Cirac2021Matrix}). Hence
+    $\text{LHS} - c_N^{(j_0)}(P) \to 0$.
 
-    \emph{RHS.} Split $k$ into $\texttt{UnitQ}$ and its complement.
+    On the right-hand side, split $k$ into $J_1'(Q)$ and its complement.
     \begin{itemize}
-        \item For $k \in \texttt{UnitQ}$: substitute via the gauge identity
-              $\operatorname{mpv}(B_k)(\sigma) = \zeta_k^N \cdot \operatorname{mpv}(A_{\varphi(k)})(\sigma)$
-              (CPSV16 line 1186; the unit-modulus closure
-              $\lVert\zeta_k\rVert = 1$ follows from the norm-from-overlap
-              lemma and both per-block normalized self-overlaps tending to 1).
-              If $\varphi(k) = j_0$: self-overlap diagonal, contributes
-              $Q.\operatorname{coeff}\,N\,k \cdot \zeta_k^N + o(1)$.
-              If $\varphi(k) \neq j_0$: cross-overlap decay, contributes $o(1)$.
-        \item For $k \notin \texttt{UnitQ}$: every copy weight has strict
-              modulus $< 1$, so $Q.\operatorname{coeff}\,N\,k \to 0$ by
+        \item For $k \in J_1'(Q)$, substitute via the gauge identity
+              $V^{(N)}(Q_k)_\sigma = \zeta_k^N \cdot V^{(N)}(P_{\varphi(k)})_\sigma$
+              of \cite[line 1186]{Cirac2017MPDO_AnnPhys}; the unit-modulus
+              closure $\lVert\zeta_k\rVert = 1$ follows from the
+              norm-from-overlap lemma and the convergence of both per-block
+              normalized self-overlaps to $1$. If $\varphi(k) = j_0$, the
+              diagonal self-overlap contributes
+              $c_N^{(k)}(Q) \cdot \zeta_k^N + o(1)$; otherwise the
+              cross-overlap decay gives $o(1)$.
+        \item For $k \notin J_1'(Q)$, every copy weight has strict modulus
+              $< 1$, so $c_N^{(k)}(Q) \to 0$ by
               Lemma~\ref{thm:paper_bnt_coeff_tendsto_zero_of_all_weights_subnorm};
               combined with the uniform overlap bound from left-canonical
-              normalization (CPSV21 lines 1815--1837), the contribution decays
-              to $0$.
+              normalization (\cite[lines 1815--1837]{Cirac2021Matrix}), the
+              contribution decays to $0$.
     \end{itemize}
-    Combining all per-$k$ pieces:
-    $\text{RHS} - \sum_{k \in \texttt{UnitQ}, \varphi(k) = j_0} \zeta_k^N \cdot Q.\operatorname{coeff}\,N\,k.\operatorname{val} \to 0$.
-    Since $\varphi$ is an embedding, the sum has at most one term.
-    With $\text{LHS} = \text{RHS}$ (the projection identity), we obtain
-    $P.\operatorname{coeff}\,N\,j_0 - (\text{matched term}) \to 0$.
+    Combining the per-$k$ contributions yields
+    \[
+        \text{RHS} - \sum_{k \in J_1'(Q),\ \varphi(k) = j_0} \zeta_k^N \cdot c_N^{(k)}(Q) \to 0.
+    \]
+    Since $\varphi$ is an embedding the inner sum has at most one term.
+    With $\text{LHS} = \text{RHS}$ (the projection identity), this gives
+    $c_N^{(j_0)}(P) - (\text{matched term}) \to 0$.
 
-    Specialising: if $j_0 = \varphi(k_0)$ for some $k_0 \in \texttt{UnitQ}$,
-    the matched term is $\zeta_{k_0}^N \cdot Q.\operatorname{coeff}\,N\,k_0.\operatorname{val}$,
-    giving clause~(1). If $j_0 \notin \operatorname{range}(\varphi)$, the
-    matched term is empty (0), giving clause~(2).
+    Specialising: if $j_0 = \varphi(k_0)$ for some $k_0 \in J_1'(Q)$ the
+    matched term is $\zeta_{k_0}^N \cdot c_N^{(k_0)}(Q)$, giving clause~(1);
+    if $j_0 \notin \operatorname{range}(\varphi)$ the matched term is $0$,
+    giving clause~(2).
 \end{proof}
 
 \begin{remark}
-    Theorem~\ref{thm:paper_bnt_coeff_identity_via_global_gauge}
-    realises the substitution route of CPSV16 \S~II.C lines 1187--1188:
-    substitute the per-pair gauge phases into the original proportional-MPV
-    identity, reduce to the $A$-only relation, and extract per-$j$
-    coefficient identities using the cross-overlap decay clause alone.
-    The result handles the $\texttt{UnitQ}$-restricted bijection
-    setting; the full bijection on
-    $P.\operatorname{basisIndex} \simeq Q.\operatorname{basisIndex}$ is not
-    delivered by Phase~B-$\beta$ (see the scoping discussion above).
+    Theorem~\ref{thm:paper_bnt_coeff_identity_via_global_gauge} realises
+    the substitution route of
+    \cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys}: substitute
+    the per-pair gauge phases into the proportional-MPV identity, reduce
+    to the $P$-only relation, and extract per-$j$ coefficient identities
+    from cross-overlap decay alone. The result handles the
+    $J_1'(Q)$-restricted bijection setting; the full bijection
+    $J(P) \simeq J(Q)$ is not delivered by the bijective-matching theorem
+    (see the scope discussion above).
 \end{remark}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -92,12 +92,13 @@ sums.
 
 The block-matching conclusion (block-count, bond-dimension, and
 gauge-phase identification of corresponding sectors) and the global
-gauge identification are now formalised on the paper-faithful BNT
-canonical-form surface of Chapter~\ref{ch:bnt}; see
-\texttt{MPSTensor.ft\_paper\_bnt\_equal\_sector\_data} and
-\texttt{MPSTensor.ft\_paper\_bnt\_equal\_global\_gauge}.  The literal
-\(\mathrm{II\_cor2}\) coordinate packaging
-(CPSV16 lines 1184--1192) is the in-flight follow-up.
+gauge identification are formalised on the BNT canonical form of
+Chapter~\ref{ch:bnt}. The coordinate packaging of
+\cite[\S~II.C, lines 1184--1192]{Cirac2017MPDO_AnnPhys} is the
+in-flight follow-up.
+% Maintainer note (Lean): see the declarations
+% MPSTensor.ft_paper_bnt_equal_sector_data and
+% MPSTensor.ft_paper_bnt_equal_global_gauge.
 
 \begin{theorem}[Bond dimension equality from unit overlap]%
 \label{thm:equalMPS_dimension_from_unit_overlap}
@@ -139,14 +140,16 @@ canonical-form surface of Chapter~\ref{ch:bnt}; see
 \begin{proof}
 	\leanok
 	\uses{lem:ft_canonical}
-	On the paper-faithful BNT surface this is the specialization of
-	\texttt{MPSTensor.ft\_paper\_bnt\_equal\_global\_gauge} (in
-	\texttt{TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean}) to the
-	situation where $P$ and $Q$ share a common $(g, D_k, \mu_k)$ block
-	structure: the basis bijection $\beta$ is trivial, the per-block gauge
-	matrices $X_{\text{block}}\,k$ provide the per-pair gauge equivalences,
-	and the flattened direct-sum gauge $X$ assembles them into the global
-	conjugation on $\bigoplus_k\mu_k A_k$ and $\bigoplus_k\mu_k B_k$.
+	On the BNT canonical form this is the specialization of the global-gauge
+	equality theorem (Chapter~\ref{ch:bnt}) to the case where $P$ and $Q$
+	share a common $(g, D_k, \mu_k)$ block structure: the basis bijection
+	$\beta$ is trivial, the per-block gauge matrices $X_k$ furnish the
+	per-pair gauge equivalences, and the flattened direct-sum gauge $X$
+	assembles them into the global conjugation on $\bigoplus_k \mu_k A_k$
+	and $\bigoplus_k \mu_k B_k$.
+	% Maintainer note (Lean): see
+	% MPSTensor.ft_paper_bnt_equal_global_gauge in
+	% TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean.
 \end{proof}
 
 \subsection{Sector multiplicities and weight recovery}%
@@ -1140,17 +1143,18 @@ block-matching conclusions for the common primitive sectors.
 	\cite[Corollary~II.2, lines 354--361 and appendix 1172--1192]{Cirac2017MPDO_AnnPhys},
 	restated in \cite[Corollary~IV.5]{Cirac2021Matrix}.
 
-	The paper-faithful Lean formalization of this route is split into two
-	theorems in \texttt{TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean}:
-	\texttt{MPSTensor.ft\_paper\_bnt\_equal\_sector\_data} packages the BNT
-	basis bijection $\beta$, the per-block gauge-phase witnesses, copy-count
-	equality, and the scalar coefficient comparison
-	$Q.\text{weight}_k\,q=(\zeta_k)^{-1}\,P.\text{weight}_{\beta k}\,(\tau\,q)$
-	matching the source power-sum identity displayed above; and
-	\texttt{MPSTensor.ft\_paper\_bnt\_equal\_global\_gauge} assembles the
-	per-block gauge matrices $Y_j=X_{\text{block}}\,k$ on the flattened
-	direct sum to produce the global conjugation~$X$, matching the appendix
+	The formalization of this route is split into two theorems. The first
+	packages the BNT basis bijection $\beta$, the per-block gauge-phase
+	witnesses, copy-count equality, and the scalar coefficient comparison
+	$\nu_{k,q} = \zeta_k^{-1}\,\mu_{\beta(k),\tau(q)}$
+	matching the source power-sum identity displayed above. The second
+	assembles the per-block gauge matrices $Y_j = X_k$ on the flattened
+	direct sum to produce the global conjugation $X$, matching the appendix
 	construction at \cite[lines 1189--1192]{Cirac2017MPDO_AnnPhys}.
+	% Maintainer note (Lean): the two theorems are
+	% MPSTensor.ft_paper_bnt_equal_sector_data and
+	% MPSTensor.ft_paper_bnt_equal_global_gauge in
+	% TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean.
 
 	The comparison theorems above formalize only the part of this route after the
 	common blocked nonzero sectors and their BNT matching data have been supplied.
@@ -1187,7 +1191,7 @@ Chapter~\ref{ch:canonical}.  They are reduction steps of the fundamental-theorem
 proof rather than statements about canonical-form data, so they are collected
 here.
 
-\subsection{Block-sum fundamental-theorem wrappers}%
+\subsection{Block-diagonal corollaries of the single-block theorem}%
 \label{subsec:ft_block_sum_wrappers}
 
 \begin{remark}

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -239,11 +239,12 @@ chapter (zero-tail bookkeeping) and in Chapter~\ref{ch:ft_proof}.
 
 \begin{remark}[Structural after-blocking decomposition; not the FT block-matching theorem]
   This theorem produces, for each of the two same-MPV tensors independently,
-  a TP/primitive/left-canonical block decomposition after blocking.  It does
-  \emph{not} derive any block matching, gauge equivalence, or phases between
-  the two decompositions; those are produced by the subsequent common-sector
-  pipeline in this chapter.  It is structural scaffolding for the FT proof,
-  not the multi-block fundamental theorem of
+  a TP/primitive/left-canonical block decomposition after blocking. It does
+  \emph{not} derive any block matching, gauge equivalence, or phases
+  between the two decompositions; those are produced by the subsequent
+  common-sector construction in this chapter. The statement is a
+  preliminary step for the fundamental-theorem proof, not the multi-block
+  fundamental theorem of
   \cite[Theorem~II.1, lines~349--352]{Cirac2017MPDO_AnnPhys}.
 \end{remark}
 


### PR DESCRIPTION
## Summary

Brings blueprint chapters 1-14 (intro through Symmetries and String Order, `ch01_intro` through `ch13b_symmetry`) and the underlying Lean modules into compliance with `docs/prose_style.md` and `docs/blueprint_style_guide.md`.

Two rules are enforced consistently across the chapter range:
1. No process-dependent or LLM-style prose in section titles, theorem headings, or running text (no "basic API", "Paper-faithful X", "Phase B-α/β/γ", "wrapper", "pipeline", "assembly" as organisational term, "bridge" as vague connector, "crucial", "robust", "leverage", etc.).
2. No Lean identifiers, namespaces, or Mathlib type names inside mathematical prose or displayed equations. The `\\lean{...}` tag remains the link to formalization; surrounding prose uses standard mathematical notation. Maintainer-only Lean notes are demoted to LaTeX `%` comments or to Lean source files.

## Concrete renames the user called out

- `\\section{Paper-faithful BNT canonical form: basic API}` → `\\section{The BNT canonical form on a sector decomposition}`
- `\\section{Phase B-$\\alpha$: paper-faithful strong existential matching}` → `\\section{Strong existential matching of unit-modulus sectors}`
- `\\subsection{Phase B-$\\beta$: bijective matching by symmetry}` → `\\subsection{Bijective matching by symmetry}`
- `\\subsection{Phase B-$\\gamma$: CPSV16 \S II.C lines 1187--1188 Corollary substitution}` → `\\subsection{Substitution argument for the unit-modulus subset}`
- `\\subsection{Block-sum fundamental-theorem wrappers}` → `\\subsection{Block-diagonal corollaries of the single-block theorem}`

The "paper-faithful" qualifier (24+ occurrences in ch10_bnt, plus ch11_fundamental_theorem_proof) is dropped from reader-facing prose throughout. Lean-style notation `P.basisIndex`, `P.weight`, `P.coeff`, `\\texttt{UnitP}/\\texttt{UnitQ}`, `\\texttt{MPSTensor.exists_block_match_of_sameMPV}`, etc. is replaced with standard mathematics defined in the surrounding text: basis index set $J(P)$, raw weights $\\mu_{j,q}$, sector coefficient $c_N^{(j)} = \\sum_q \\mu_{j,q}^N$, unit-modulus subset $J_1'(Q)$, and so on.

## Files modified

Blueprint (5 chapter files): `ch07_wielandt`, `ch08_canonical`, `ch10_bnt`, `ch11_fundamental_theorem_proof`, `ch11b_after_blocking`. The remaining ch01-ch06, ch09, ch13b chapters were already free of ban-words after the workflow scan and required no edits.

Lean (39 files across `MPS/CanonicalForm/`, `MPS/FundamentalTheorem/` (incl. `PaperBNT/`), `MPS/Symmetry/`, `MPS/Structure/`, `Channel/`, `QPF/`, `Spectral/`, `Wielandt/`): section/namespace renames (`PreservesCornerHelper` → `CornerPreservation`, `Helpers` → `AuxiliaryLemmas`, etc.); docstring cleanup of the qualifier "Paper-faithful" in 12 `PaperBNT/` files; ban-word replacements per `docs/prose_style.md` tables.

Two mathematical theorem renames (per `docs/prose_style.md` §4):
- `wielandt_sharp_parametric_assembly` → `wielandt_sharp_parametric_span`
- `wielandt_parametric_assembly` → `wielandt_parametric_span`

The grandfathered name `wielandt_blocked_assembly` is preserved (it names a mathematical step). The `PaperBNT/` directory and `PaperBNT/Api.lean` filename are likewise preserved as grandfathered module paths.

Light proof simplification: `WielandtInequality.hArith` 15 → 2 lines via `Nat.le_self_pow`; `QPF/Uniqueness.diagonal_sub_smul_one'` 15 → 3 lines via `Matrix.diagonal_smul`/`Matrix.diagonal_sub`; term-mode conversions in `Channel/Irreducible/KrausSetup`.

## Status

- `lake build` passes (8651 jobs).
- `leanblueprint checkdecls` reports the same 18 pre-existing missing declarations in chapters 14+ (parent Hamiltonian / correlations material, marked `% planned` in `content.tex`); no new broken references introduced.
- No new `sorry` / `admit` / `axiom`. No theorem statements changed.
- All `\\lean{...}`, `\\leanok`, `\\uses{...}`, and `\\label{...}` markup preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly documentation/prose and section-heading cleanup, but it also renames a couple of exported theorems and touches many Lean modules, which could break downstream references if any name updates were missed.
> 
> **Overview**
> Updates blueprint chapters and many Lean docstrings/section headers to remove process language and Lean-specific jargon, replacing it with standard mathematical prose and notation while preserving `\\lean{...}` links.
> 
> Also performs a few small code-facing cleanups: renames `Helpers` sections to `AuxiliaryLemmas`, refactors a handful of proofs into shorter term-mode/lemma-based forms, and renames two public theorems (`wielandt_parametric_span`, `wielandt_sharp_parametric_span`) to match the new naming conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01aee04325c2d1e0eea94921537a1c4d64cf4a32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->