### PR TITLE
refactor(MPS,Channel,Algebra,Wielandt): golf proofs and consolidate helpers across chapters 1-14

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -47,15 +47,7 @@ theorem sum_mul_mul {α : Type*} [NonUnitalNonAssocSemiring α]
     {d l m n r : ℕ} (L : Matrix (Fin l) (Fin m) α)
     (M : Fin d → Matrix (Fin m) (Fin n) α) (R : Matrix (Fin n) (Fin r) α) :
     ∑ i : Fin d, L * M i * R = L * (∑ i : Fin d, M i) * R := by
-  calc
-    ∑ i : Fin d, L * M i * R = (∑ i : Fin d, L * M i) * R := by
-      simpa [Matrix.mul_assoc] using
-        (Matrix.sum_mul (s := (Finset.univ : Finset (Fin d)))
-          (f := fun i : Fin d => L * M i) (M := R)).symm
-    _ = (L * ∑ i : Fin d, M i) * R := by
-      exact congrArg (fun T => T * R) <|
-        (Matrix.mul_sum (s := (Finset.univ : Finset (Fin d)))
-          (f := fun i : Fin d => M i) (M := L)).symm
+  simp only [← Matrix.sum_mul, ← Matrix.mul_sum, Matrix.mul_assoc]
 
 /-- If multiplication by a rectangular matrix has trivial kernel, then the source dimension is at
 most the target dimension. -/

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -47,7 +47,7 @@ theorem sum_mul_mul {α : Type*} [NonUnitalNonAssocSemiring α]
     {d l m n r : ℕ} (L : Matrix (Fin l) (Fin m) α)
     (M : Fin d → Matrix (Fin m) (Fin n) α) (R : Matrix (Fin n) (Fin r) α) :
     ∑ i : Fin d, L * M i * R = L * (∑ i : Fin d, M i) * R := by
-  simp only [← Matrix.sum_mul, ← Matrix.mul_sum, Matrix.mul_assoc]
+  simp only [← Matrix.sum_mul, ← Matrix.mul_sum]
 
 /-- If multiplication by a rectangular matrix has trivial kernel, then the source dimension is at
 most the target dimension. -/

--- a/TNLean/Algebra/MatrixFrobenius.lean
+++ b/TNLean/Algebra/MatrixFrobenius.lean
@@ -20,8 +20,6 @@ variable {D : ℕ}
 
 /-- Positive-definiteness of the identity matrix, used to define the Frobenius inner product. -/
 theorem frobenius_posDef_one :
-    (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := by
-  classical
-  simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ))
+    (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := Matrix.PosDef.one
 
 end Matrix

--- a/TNLean/Algebra/UnitModulusPowerSum.lean
+++ b/TNLean/Algebra/UnitModulusPowerSum.lean
@@ -168,13 +168,9 @@ theorem unitModulus_power_sum_not_tendsto_zero
         = ∑ p : Fin r × Fin r, (μ p.1 * star (μ p.2)) ^ N := by
     intro N
     have hnormSq : ((‖S N‖ ^ 2 : ℝ) : ℂ) = S N * star (S N) := by
-      have h1 : Complex.normSq (S N) = ‖S N‖ ^ 2 :=
-        Complex.normSq_eq_norm_sq (S N)
-      have h2 : S N * (starRingEnd ℂ) (S N) = (Complex.normSq (S N) : ℂ) :=
-        Complex.mul_conj (S N)
-      have h3 : S N * star (S N) = ((‖S N‖ ^ 2 : ℝ) : ℂ) := by
-        rw [show star (S N) = (starRingEnd ℂ) (S N) from rfl, h2, h1]
-      exact h3.symm
+      rw [show star (S N) = (starRingEnd ℂ) (S N) from rfl]
+      push_cast
+      exact (Complex.mul_conj' (S N)).symm
     rw [hnormSq, hS_def]
     -- S N = ∑_q μ_q^N; star (S N) = ∑_q' star (μ_q')^N
     have hStar : star (∑ q : Fin r, (μ q) ^ N)
@@ -206,14 +202,7 @@ theorem unitModulus_power_sum_not_tendsto_zero
     intro p hp
     rcases Finset.mem_image.mp hp with ⟨q, _, rfl⟩
     have hμq_sq : μ q * star (μ q) = 1 := by
-      have h := Complex.mul_conj (μ q)
-      have h2 : Complex.normSq (μ q) = 1 := by
-        have := Complex.normSq_eq_norm_sq (μ q)
-        rw [this, hμ q, one_pow]
-      have h3 : μ q * (starRingEnd ℂ) (μ q) = 1 := by
-        rw [h, h2]; norm_num
-      rw [show star (μ q) = (starRingEnd ℂ) (μ q) from rfl]
-      exact h3
+      rw [show star (μ q) = (starRingEnd ℂ) (μ q) from rfl, Complex.mul_conj', hμ q]; simp
     exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, hμq_sq⟩
   have hDiag_card : (Finset.univ.image (fun q : Fin r => (q, q))).card = r := by
     rw [Finset.card_image_of_injective _ (fun a b h => (Prod.mk.inj h).1)]

--- a/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
+++ b/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
@@ -78,8 +78,7 @@ theorem isUnit_peripheral_eigenvector
             * KadisonSchwarz.krausMap (d := d) (D := D) K X := by
     simpa [Kraus.map, KadisonSchwarz.krausMap] using hKS_map
   have hμ_star_mul : star μ * μ = 1 := by
-    rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
-    simp [Complex.normSq_eq_norm_sq, hμ]
+    rw [← starRingEnd_apply, Complex.conj_mul', hμ]; simp
   have hfix_kraus : KadisonSchwarz.krausMap (d := d) (D := D) K (Xᴴ * X) = Xᴴ * X := by
     calc
       KadisonSchwarz.krausMap (d := d) (D := D) K (Xᴴ * X)

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/CyclicProjections.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/CyclicProjections.lean
@@ -39,10 +39,9 @@ private abbrev cyclicOneIdx (m : ℕ) [NeZero m] : ℕ := ((1 : Fin m) : ℕ)
 /-- A primitive root has unit modulus, written as `star γ * γ = 1`. -/
 private lemma star_mul_self_of_primitiveRoot {γ : ℂ} (hγprim : IsPrimitiveRoot γ m) :
     star γ * γ = 1 := by
-  have hm0 : m ≠ 0 := NeZero.ne m
-  have hγ_norm : ‖γ‖ = 1 := Complex.norm_eq_one_of_pow_eq_one hγprim.pow_eq_one hm0
-  rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
-  simp only [normSq_eq_norm_sq, hγ_norm, one_pow, ofReal_one]
+  have hγ_norm : ‖γ‖ = 1 :=
+    Complex.norm_eq_one_of_pow_eq_one hγprim.pow_eq_one (NeZero.ne m)
+  rw [← starRingEnd_apply, Complex.conj_mul', hγ_norm]; simp
 
 /-- A primitive root has unit modulus, written as `γ * star γ = 1`. -/
 private lemma self_mul_star_of_primitiveRoot {γ : ℂ} (hγprim : IsPrimitiveRoot γ m) :

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
@@ -128,8 +128,7 @@ private theorem hermitian_fixed_eq_scalar_of_irreducible_unital
             (c0 : ℂ) • transferMap (d := r) (D := D) K 1 := by
               rw [LinearMap.map_smul]
       _ = H - (c0 : ℂ) • 1 := by simp only [hfix, hone_fix, Complex.coe_smul]
-  have hone_psd : (1 : MatrixAlg D).PosSemidef := by
-    simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ)).posSemidef
+  have hone_psd : (1 : MatrixAlg D).PosSemidef := Matrix.PosSemidef.one
   rcases posSemidef_fixedPoint_unique_of_irreducible (A := K) hIrr
       (1 : MatrixAlg D) (H - (c0 : ℂ) • 1) hone_psd one_ne_zero hshift_psd hone_fix hshift_fix with
     ⟨d, hd⟩
@@ -285,8 +284,7 @@ theorem exists_peripheral_unitary_of_irreducible_schwarz
     intro h
     apply hX_ne
     exact Matrix.conjTranspose_mul_self_eq_zero.mp h
-  have hone_psd : (1 : MatrixAlg D).PosSemidef := by
-    simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ)).posSemidef
+  have hone_psd : (1 : MatrixAlg D).PosSemidef := Matrix.PosSemidef.one
   have hone_fix : transferMap (d := r) (D := D) K (1 : MatrixAlg D) = 1 := by
     simpa [MPSTensor.transferMap_apply, KadisonSchwarz.krausMap,
       KadisonSchwarz.IsUnitalKraus] using hUnital

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
@@ -431,17 +431,10 @@ theorem exists_normalized_peripheral_unitary_of_irreducible_schwarz
   have hα_unit : star α * α = 1 := by
     simpa [Complex.star_def, mul_comm] using hα_unit_mul
   have hα_sq : ‖α‖ ^ 2 = 1 := by
-    have hnormSqC : (↑(Complex.normSq α) : ℂ) = 1 := by
-      calc
-        (↑(Complex.normSq α) : ℂ) = star α * α := by
-          rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
-        _ = 1 := hα_unit
-    have hnormSq : Complex.normSq α = 1 := by
-      exact_mod_cast hnormSqC
-    simpa [Complex.normSq_eq_norm_sq] using hnormSq
+    have h : (starRingEnd ℂ) α * α = 1 := by rwa [starRingEnd_apply]
+    exact_mod_cast Complex.conj_mul' α ▸ h
   have hα_norm : ‖α‖ = 1 := by
-    have hnonneg : 0 ≤ ‖α‖ := norm_nonneg α
-    nlinarith
+    nlinarith [norm_nonneg α]
   set β : ℂ := α⁻¹ ^ (m⁻¹ : ℂ)
   have hβm : β ^ m = α⁻¹ := by
     simpa [β] using (Complex.cpow_nat_inv_pow (α⁻¹) (NeZero.ne m))

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
@@ -262,10 +262,9 @@ theorem exists_peripheral_unitary_of_irreducible_schwarz
     Kraus.ks_equality_of_peripheral_eigenvector_of_fixedPoint
       K hUnital' hρ hρfix X γ hEig_map hγ_norm
   have hγ_star_mul : star γ * γ = 1 := by
-    rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
-    simp only [normSq_eq_norm_sq, hγ_norm, one_pow, ofReal_one]
+    rw [← starRingEnd_apply, Complex.conj_mul', hγ_norm]; simp
   have hγ_starRing_mul : (starRingEnd ℂ) γ * γ = 1 := by
-    simpa [Complex.star_def] using hγ_star_mul
+    rwa [starRingEnd_apply]
   have hXX_fix_map : Kraus.map K (Xᴴ * X) = Xᴴ * X := by
     calc
       Kraus.map K (Xᴴ * X) = (Kraus.map K X)ᴴ * Kraus.map K X := hKS_map
@@ -454,10 +453,9 @@ theorem exists_normalized_peripheral_unitary_of_irreducible_schwarz
   have hβ_norm : ‖β‖ = 1 :=
     (pow_eq_one_iff_of_nonneg (norm_nonneg β) (NeZero.ne m)).1 hβ_norm_pow
   have hβ_unit : star β * β = 1 := by
-    rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
-    simp only [normSq_eq_norm_sq, hβ_norm, one_pow, ofReal_one]
+    rw [← starRingEnd_apply, Complex.conj_mul', hβ_norm]; simp
   have hβ_starRing_mul : (starRingEnd ℂ) β * β = 1 := by
-    simpa [Complex.star_def] using hβ_unit
+    rwa [starRingEnd_apply]
   have hU_star_mul : ((U : MatrixAlg D)ᴴ * (U : MatrixAlg D)) = 1 :=
     Matrix.UnitaryGroup.star_mul_self U
   refine ⟨⟨β • (U : MatrixAlg D), by

--- a/TNLean/Channel/Schwarz/Basic.lean
+++ b/TNLean/Channel/Schwarz/Basic.lean
@@ -254,15 +254,8 @@ theorem ks_equality_of_peripheral_eigenvector_of_fixedPoint
     -- Second term: use the eigenvector equation `E(X)=μX` and `‖μ‖=1`.
     have h2 : Matrix.trace (ρ * ((map K X)ᴴ * map K X)) = Matrix.trace (ρ * (Xᴴ * X)) := by
       -- Rewrite `‖μ‖ = 1` as `conj μ * μ = 1`.
-      have hnormSq : Complex.normSq μ = 1 := by
-        calc
-          Complex.normSq μ = ‖μ‖ ^ 2 := Complex.normSq_eq_norm_sq μ
-          _ = 1 := by simp [hμ]
       have hconjmul : (starRingEnd ℂ) μ * μ = (1 : ℂ) := by
-        calc
-          (starRingEnd ℂ) μ * μ = (↑(Complex.normSq μ) : ℂ) := by
-            simpa using (Complex.normSq_eq_conj_mul_self (z := μ)).symm
-          _ = 1 := by simp [hnormSq]
+        rw [Complex.conj_mul', hμ]; simp
       have hmulconj : μ * (starRingEnd ℂ) μ = (1 : ℂ) := by
         simpa [mul_comm] using hconjmul
       have hkey : (μ • X)ᴴ * (μ • X) = Xᴴ * X := by

--- a/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
@@ -98,8 +98,7 @@ theorem ks_equality_of_peripheral_eigenvector (K : Fin d → Matrix (Fin D) (Fin
       -- i.e., star μ * μ * trace(X†X) = trace(X†X)
       rw [smul_smul]
       have hμ_norm : star μ * μ = 1 := by
-        rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
-        simp [Complex.normSq_eq_norm_sq, hμ]
+        rw [← starRingEnd_apply, Complex.conj_mul', hμ]; simp
       rw [hμ_norm, one_smul]
     rw [h1, h2, sub_self]
   -- PSD + trace 0 → gap = 0

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -727,19 +727,6 @@ theorem reindexed_sameMPV₂ (F : CommonBlockedCyclicSectorFamily blocks) (k : F
       (F.commonReindexedBlock k) :=
   F.nestedBlock_sameMPV₂_commonReindexedBlock k
 
-/-- The nonzero-part decomposition of a weighted block sum `⨁_k μ_k B_k` transports
-through the common-alphabet identification: the common-alphabet sectors have the same
-nonzero-part decomposition as the direct `p`-blocked tensors.  Here
-`commonReindexedBlock k` is definitionally the direct $p$-blocked tensor $B_k^{[p]}$
-transferred to the common alphabet $d^{[p]}$. -/
-theorem reindexed_nonzero_part (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
-    SameMPV₂
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) (F.commonReindexedBlock))
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) :=
-  F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ
-
 /-- Direct blocking at length `p = m_k * e_k` and iterated blocking
 `(B_k^{[m_k]})^{[e_k]}` produce the same MPV family after the canonical
 alphabet identification. -/
@@ -750,7 +737,36 @@ theorem blocked_word_comparison (F : CommonBlockedCyclicSectorFamily blocks)
       (F.commonReindexedBlock k) :=
   F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k
     (groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
-      (fun hp_eq h_card i => flattenWordOfBlock_cast_eq hp_eq h_card i) F k)
+      (fun hp_eq => flattenWordOfBlock_cast_eq hp_eq) F k)
+
+/-- The nonzero-part decomposition of a weighted block sum $\bigoplus_k \mu_k B_k$
+transports through the common-alphabet identification: the common-alphabet sectors
+have the same nonzero-part decomposition as the direct $p$-blocked tensors. -/
+theorem reindexed_nonzero_part (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) := by
+  intro N σ
+  have hCommon : ∀ k, mpv (blockTensor (d := d) (D := dim k) (blocks k) F.p) σ =
+      mpv (F.commonReindexedBlock k) σ := fun k => F.blocked_word_comparison k N σ
+  calc mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+            (μ := fun k => (μ k) ^ F.p)
+            (fun k => blockTensor (blocks k) F.p)) σ
+      = ∑ k : Fin r,
+          ((μ k) ^ F.p) ^ N • mpv (blockTensor (blocks k) F.p) σ :=
+        mpv_toTensorFromBlocks_eq_sum _ _ σ
+    _ = ∑ k : Fin r,
+          ((μ k) ^ F.p) ^ N • mpv (F.commonReindexedBlock k) σ :=
+        Finset.sum_congr rfl fun k _ => by rw [hCommon k]
+    _ = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+              (μ := fun k => (μ k) ^ F.p) (F.commonReindexedBlock)) σ :=
+        (mpv_toTensorFromBlocks_eq_sum _ _ σ).symm
+    _ = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
+              (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ :=
+        F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ
 
 end CommonBlockedCyclicSectorFamily
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -702,7 +702,7 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed
 
 /-- Each sector tensor in the common reblocked cyclic-sector family is trace-preserving,
 has primitive transfer map, is tensor-irreducible, and has positive bond dimension. -/
-theorem derivedProperties (F : CommonBlockedCyclicSectorFamily blocks)
+theorem derived_properties (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :
     (∑ i : Fin (blockPhysDim d F.p),
         (F.commonSectorBlock k s i)ᴴ * F.commonSectorBlock k s i = 1) ∧
@@ -717,7 +717,7 @@ theorem derivedProperties (F : CommonBlockedCyclicSectorFamily blocks)
 /-- The iterated blocked tensor `(B_k^{[m_k]})^{[e_k]}` agrees with the directly blocked
 tensor `B_k^{[p]}` (under the canonical alphabet identification) in the sense of
 generating the same MPV family. -/
-theorem reindexed_sameMPV (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
+theorem reindexed_sameMPV₂ (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     SameMPV₂
       (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
         (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
@@ -728,7 +728,7 @@ theorem reindexed_sameMPV (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin 
 /-- The nonzero-part decomposition of a weighted block sum `⨁_k μ_k B_k` transports
 through the common-alphabet identification: the common-alphabet sectors have the same
 nonzero-part decomposition as the direct `p`-blocked tensors. -/
-theorem reindexed_nonzeroPart (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
+theorem reindexed_nonzero_part (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
     SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := fun k : Fin r => (μ k) ^ F.p) (F.commonReindexedBlock))

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -700,6 +700,52 @@ theorem sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed
   simpa [commonFlatBlocksAt] using
     F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μ hRelabel
 
+/-- Each sector tensor in the common reblocked cyclic-sector family is trace-preserving,
+has primitive transfer map, is tensor-irreducible, and has positive bond dimension. -/
+theorem derivedProperties (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) (s : Fin (F.period k)) :
+    (∑ i : Fin (blockPhysDim d F.p),
+        (F.commonSectorBlock k s i)ᴴ * F.commonSectorBlock k s i = 1) ∧
+    _root_.IsPrimitive
+        (transferMap (d := blockPhysDim d F.p) (D := F.sectorDim k s)
+          (F.commonSectorBlock k s)) ∧
+    IsIrreducibleTensor (F.commonSectorBlock k s) ∧
+    0 < F.sectorDim k s :=
+  ⟨F.commonSectorBlock_tp k s, F.commonSectorBlock_primitive k s,
+    F.commonSectorBlock_irreducible k s, F.commonSectorBlock_dim_pos k s⟩
+
+/-- The iterated blocked tensor `(B_k^{[m_k]})^{[e_k]}` agrees with the directly blocked
+tensor `B_k^{[p]}` (under the canonical alphabet identification) in the sense of
+generating the same MPV family. -/
+theorem reindexed_sameMPV (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
+    SameMPV₂
+      (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
+        (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
+          (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k)))
+      (F.commonReindexedBlock k) :=
+  F.nestedBlock_sameMPV₂_commonReindexedBlock k
+
+/-- The nonzero-part decomposition of a weighted block sum `⨁_k μ_k B_k` transports
+through the common-alphabet identification: the common-alphabet sectors have the same
+nonzero-part decomposition as the direct `p`-blocked tensors. -/
+theorem reindexed_nonzeroPart (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
+    SameMPV₂
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := fun k : Fin r => (μ k) ^ F.p) (F.commonReindexedBlock))
+      (toTensorFromBlocks (d := blockPhysDim d F.p)
+        (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) :=
+  F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ
+
+/-- Direct blocking at length `p = m_k * e_k` and iterated blocking
+`(B_k^{[m_k]})^{[e_k]}` produce the same MPV family after the canonical
+alphabet identification. -/
+theorem blocked_word_comparison (F : CommonBlockedCyclicSectorFamily blocks)
+    (k : Fin r) (hCast : F.groupedBlockCastAgrees k) :
+    SameMPV₂
+      (blockTensor (d := d) (D := dim k) (blocks k) F.p)
+      (F.commonReindexedBlock k) :=
+  F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k hCast
+
 end CommonBlockedCyclicSectorFamily
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -740,11 +740,13 @@ theorem reindexed_nonzero_part (F : CommonBlockedCyclicSectorFamily blocks) (μ 
 `(B_k^{[m_k]})^{[e_k]}` produce the same MPV family after the canonical
 alphabet identification. -/
 theorem blocked_word_comparison (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) (hCast : F.groupedBlockCastAgrees k) :
+    (k : Fin r) :
     SameMPV₂
       (blockTensor (d := d) (D := dim k) (blocks k) F.p)
       (F.commonReindexedBlock k) :=
-  F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k hCast
+  F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k
+    (groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+      (fun hp_eq h_card i => flattenWordOfBlock_cast_eq hp_eq h_card i) F k)
 
 end CommonBlockedCyclicSectorFamily
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -716,7 +716,9 @@ theorem derived_properties (F : CommonBlockedCyclicSectorFamily blocks)
 
 /-- The iterated blocked tensor `(B_k^{[m_k]})^{[e_k]}` agrees with the directly blocked
 tensor `B_k^{[p]}` (under the canonical alphabet identification) in the sense of
-generating the same MPV family. -/
+generating the same MPV family.  By definition, `commonReindexedBlock k` is the direct
+$p$-blocked tensor of block $k$, transported to the common alphabet $d^{[p]}$ via the
+canonical reindexing. -/
 theorem reindexed_sameMPV₂ (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     SameMPV₂
       (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
@@ -727,7 +729,9 @@ theorem reindexed_sameMPV₂ (F : CommonBlockedCyclicSectorFamily blocks) (k : F
 
 /-- The nonzero-part decomposition of a weighted block sum `⨁_k μ_k B_k` transports
 through the common-alphabet identification: the common-alphabet sectors have the same
-nonzero-part decomposition as the direct `p`-blocked tensors. -/
+nonzero-part decomposition as the direct `p`-blocked tensors.  Here
+`commonReindexedBlock k` is definitionally the direct $p$-blocked tensor $B_k^{[p]}$
+transferred to the common alphabet $d^{[p]}$. -/
 theorem reindexed_nonzero_part (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
     SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
@@ -110,8 +110,7 @@ theorem transferMap_adjoint_blocked_eq_pow
     transferMap (d := blockPhysDim d m) (D := D) (fun j => (blockTensor A m j)ᴴ) X =
       ((transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) ^ m) X := by
   classical
-  have hM : (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := by
-    simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ))
+  have hM : (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := Matrix.PosDef.one
   letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM
   letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -32,8 +32,10 @@ def evalWord (A : MPSTensor d D) : List (Fin d) → Matrix (Fin D) (Fin D) ℂ
   | [] => 1
   | i :: w => A i * evalWord A w
 
+/-- The empty word evaluates to the identity. -/
 @[simp] lemma evalWord_nil (A : MPSTensor d D) : evalWord A [] = 1 := rfl
 
+/-- The word `i :: w` evaluates to `A i` times the evaluation of `w`. -/
 @[simp] lemma evalWord_cons (A : MPSTensor d D) (i : Fin d) (w : List (Fin d)) :
     evalWord A (i :: w) = A i * evalWord A w := rfl
 

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -35,7 +35,7 @@ def evalWord (A : MPSTensor d D) : List (Fin d) → Matrix (Fin D) (Fin D) ℂ
 /-- The empty word evaluates to the identity. -/
 @[simp] lemma evalWord_nil (A : MPSTensor d D) : evalWord A [] = 1 := rfl
 
-/-- The word `i :: w` evaluates to `A i` times the evaluation of `w`. -/
+/-- The word with head $i$ followed by $w$ evaluates to $A_i$ times the evaluation of $w$. -/
 @[simp] lemma evalWord_cons (A : MPSTensor d D) (i : Fin d) (w : List (Fin d)) :
     evalWord A (i :: w) = A i * evalWord A w := rfl
 

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Periodic.Defs
 import TNLean.Algebra.ScalarPowerSumIdentity
-import TNLean.MPS.FundamentalTheorem.Full
 import TNLean.MPS.Overlap.Basic
 import TNLean.MPS.Periodic.Overlap
 import TNLean.MPS.Periodic.ZGauge

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.Overlap.CastDecay
 import TNLean.MPS.FundamentalTheorem.Basic
-import TNLean.MPS.FundamentalTheorem.Full
 import TNLean.MPS.Chain.OneSidedInverse
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.CanonicalForm.CyclicSectors
@@ -111,9 +110,7 @@ private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
   obtain ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
     conjTranspose_kraus_setup A hP.leftCanonical hP.irreducible
   obtain ⟨ω, hωprim⟩ := hP.primitiveRoot
-  have hM : (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := by
-    classical
-    simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ))
+  have hM : (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := Matrix.PosDef.one
   letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
     Matrix.toMatrixNormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM
   letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
@@ -280,9 +277,7 @@ private lemma cornerRestriction_primitive_and_irreducible_of_cyclicDecomp
       KadisonSchwarz.krausMap_mul_left_of_mem_multiplicativeDomain
         (K := K) (hMulDomain k) X
   obtain ⟨ω, hωprim⟩ := hP.primitiveRoot
-  have hM : (1 : MatrixAlg D).PosDef := by
-    classical
-    simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ))
+  have hM : (1 : MatrixAlg D).PosDef := Matrix.PosDef.one
   letI : NormedAddCommGroup (MatrixAlg D) :=
     Matrix.toMatrixNormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM
   letI : SeminormedAddCommGroup (MatrixAlg D) :=

--- a/TNLean/MPS/SharedInfra/Scaling.lean
+++ b/TNLean/MPS/SharedInfra/Scaling.lean
@@ -33,10 +33,7 @@ theorem leftCanonical_smul_of_norm_one (c : ℂ) (hc : ‖c‖ = 1)
   simp_rw [smul_mul_smul_comm]
   rw [← Finset.smul_sum, hA]
   have hsc : (star c : ℂ) * c = 1 := by
-    change starRingEnd ℂ c * c = 1
-    have h1 : starRingEnd ℂ c * c = ↑(Complex.normSq c) := by
-      rw [mul_comm, Complex.mul_conj]
-    rw [h1, Complex.normSq_eq_norm_sq, hc, one_pow, Complex.ofReal_one]
+    rw [← starRingEnd_apply, Complex.conj_mul', hc]; simp
   rw [hsc, one_smul]
 
 /-- Unit-norm scaling preserves periodicity data. -/
@@ -52,9 +49,7 @@ theorem isPeriodic_smul_of_norm_one
     ext X : 1
     rw [transferMap_smul]
     have hsc : c * starRingEnd ℂ c = 1 := by
-      have h1 : c * starRingEnd ℂ c = ↑(Complex.normSq c) := by
-        rw [Complex.mul_conj]
-      rw [h1, Complex.normSq_eq_norm_sq, hc, one_pow, Complex.ofReal_one]
+      rw [Complex.mul_conj', hc]; simp
     simp [hsc]
   refine ⟨isIrreducibleTensor_smul hc_ne A hA.irreducible,
     leftCanonical_smul_of_norm_one c hc A hA.leftCanonical,

--- a/TNLean/MPS/Symmetry/GaugeUniqueness.lean
+++ b/TNLean/MPS/Symmetry/GaugeUniqueness.lean
@@ -91,7 +91,13 @@ theorem gauge_unique_up_to_scalar {A B : MPSTensor d D} (hA : IsInjective A)
               simp
 
 /-- A Same-MPV corollary: after obtaining any two gauges from the single-block FT,
-they are unique up to a nonzero scalar. -/
+they are unique up to a nonzero scalar.
+
+The hypothesis `_hAB : SameMPV A B` matches the blueprint's statement
+(the theorem is stated for tensors generating the same MPV family), but the proof
+does not use it: gauge uniqueness follows from injectivity alone, together with
+the explicit gauge equations `hX` and `hY`.  The hypothesis is retained for
+faithfulness to the blueprint declaration. -/
 theorem gauge_unique_up_to_scalar_of_sameMPV {A B : MPSTensor d D}
     (hA : IsInjective A) (_hAB : SameMPV A B)
     {X Y : GL (Fin D) ℂ}

--- a/TNLean/MPS/Symmetry/GaugeUniqueness.lean
+++ b/TNLean/MPS/Symmetry/GaugeUniqueness.lean
@@ -93,11 +93,10 @@ theorem gauge_unique_up_to_scalar {A B : MPSTensor d D} (hA : IsInjective A)
 /-- A Same-MPV corollary: after obtaining any two gauges from the single-block FT,
 they are unique up to a nonzero scalar.
 
-The hypothesis `_hAB : SameMPV A B` matches the blueprint's statement
-(the theorem is stated for tensors generating the same MPV family), but the proof
-does not use it: gauge uniqueness follows from injectivity alone, together with
-the two gauge equations $B_i = X A_i X^{-1}$ and $B_i = Y A_i Y^{-1}$.
-The hypothesis is retained for faithfulness to the blueprint declaration. -/
+Although the matching-MPV hypothesis is not needed for the conclusion — gauge
+uniqueness follows from injectivity alone, together with the two gauge equations
+$B_i = X A_i X^{-1}$ and $B_i = Y A_i Y^{-1}$ — it is retained to match the
+blueprint statement faithfully. -/
 theorem gauge_unique_up_to_scalar_of_sameMPV {A B : MPSTensor d D}
     (hA : IsInjective A) (_hAB : SameMPV A B)
     {X Y : GL (Fin D) ℂ}

--- a/TNLean/MPS/Symmetry/GaugeUniqueness.lean
+++ b/TNLean/MPS/Symmetry/GaugeUniqueness.lean
@@ -96,8 +96,8 @@ they are unique up to a nonzero scalar.
 The hypothesis `_hAB : SameMPV A B` matches the blueprint's statement
 (the theorem is stated for tensors generating the same MPV family), but the proof
 does not use it: gauge uniqueness follows from injectivity alone, together with
-the explicit gauge equations `hX` and `hY`.  The hypothesis is retained for
-faithfulness to the blueprint declaration. -/
+the two gauge equations $B_i = X A_i X^{-1}$ and $B_i = Y A_i Y^{-1}$.
+The hypothesis is retained for faithfulness to the blueprint declaration. -/
 theorem gauge_unique_up_to_scalar_of_sameMPV {A B : MPSTensor d D}
     (hA : IsInjective A) (_hAB : SameMPV A B)
     {X Y : GL (Fin D) ℂ}

--- a/TNLean/MPS/Symmetry/StringOrder.lean
+++ b/TNLean/MPS/Symmetry/StringOrder.lean
@@ -219,18 +219,9 @@ lemma hasStringOrder_of_localSymmetry
       ∀ L : ℕ, ((twistedTransferMap A u) ^ L) V = μ ^ L • V := by
     intro L
     induction L with
-    | zero =>
-        simp
+    | zero => simp
     | succ n ih =>
-        calc
-          ((twistedTransferMap A u) ^ (n + 1)) V
-              = twistedTransferMap A u (((twistedTransferMap A u) ^ n) V) := by
-                  simp [pow_succ']
-          _ = twistedTransferMap A u (μ ^ n • V) := by rw [ih]
-          _ = μ ^ n • twistedTransferMap A u V := by simp
-          _ = μ ^ n • (μ • V) := by rw [hEig]
-          _ = μ ^ (n + 1) • V := by
-                simp [pow_succ, smul_smul, mul_comm]
+        rw [pow_succ', Module.End.mul_apply, ih, map_smul, hEig, smul_smul, ← pow_succ]
   refine ⟨Vᴴ, V, (1 / 2 : ℝ), by norm_num, ?_⟩
   intro L
   have hparam :
@@ -240,10 +231,8 @@ lemma hasStringOrder_of_localSymmetry
           = Matrix.trace (Λ * Vᴴ * (((twistedTransferMap A u) ^ L) V)) := by
               simp [stringOrderBoundaryParam, twistedTransferIter]
       _ = Matrix.trace (Λ * Vᴴ * (μ ^ L • V)) := by rw [hpow L]
-      _ = Matrix.trace ((μ ^ L) • (Λ * (Vᴴ * V))) := by
-            simp [Matrix.mul_assoc]
-      _ = μ ^ L * Matrix.trace (Λ * (Vᴴ * V)) := by
-            simp [Matrix.trace_smul]
+      _ = Matrix.trace ((μ ^ L) • (Λ * (Vᴴ * V))) := by simp [Matrix.mul_assoc]
+      _ = μ ^ L * Matrix.trace (Λ * (Vᴴ * V)) := by simp [Matrix.trace_smul]
       _ = μ ^ L := by simp [hV', hΛtr]
   have hnorm_pow : ‖μ ^ L‖ = 1 := by
     simp [norm_pow, hμ]

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -429,12 +429,12 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
       have hbad := hX_mul_inv
       simp [X, Xin, hX0] at hbad
     exact hX_ne this
+  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+    injective_implies_irreducibleCP A hA
+  have hCPA : IsCPMap (transferMap (d := d) (D := D) A) :=
+    transferMap_isCPMap A
+  have hone_psd : (1 : Matrix (Fin D) (Fin D) ℂ).PosSemidef := Matrix.PosSemidef.one
   have hζ_sq_eq_one : Complex.normSq ζ = 1 := by
-    have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
-      injective_implies_irreducibleCP A hA
-    have hCPA : IsCPMap (transferMap (d := d) (D := D) A) :=
-      transferMap_isCPMap A
-    have hone_psd : (1 : Matrix (Fin D) (Fin D) ℂ).PosSemidef := Matrix.PosSemidef.one
     have hone_eig : transferMap A 1 = ((1 : ℝ) : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
       simpa using hNorm
     exact
@@ -445,9 +445,6 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
         (Complex.normSq_pos.2 hζ) hone_eig hQ_eigA |>.symm
   have hQ_fix : transferMap A Q = Q := by
     simpa [hζ_sq_eq_one] using hQ_eigA
-  have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
-    injective_implies_irreducibleCP A hA
-  have hone_psd : (1 : Matrix (Fin D) (Fin D) ℂ).PosSemidef := Matrix.PosSemidef.one
   rcases posSemidef_fixedPoint_unique_of_irreducible (A := A) hIrrA
       (1 : Matrix (Fin D) (Fin D) ℂ) Q hone_psd one_ne_zero hQ_psd hNorm hQ_fix with
     ⟨c, hQ_scalar⟩

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -274,60 +274,37 @@ theorem twistedTPGaugeSetup_hasEigenvalue [NeZero D]
             setup.S * (A i * V * (setup.B i)ᴴ) * setup.Sᴴ := by
       intro i
       have hAeq : setup.A' i = setup.S * A i * setup.S⁻¹ := by
-        rw [setup.hA'_def, tpGauge, setup.hS_def]
-        rfl
-      have hBstar :
-          (setup.B' i)ᴴ = setup.S⁻¹ * (setup.B i)ᴴ * setup.S := by
-        calc
-          (setup.B' i)ᴴ
-              = ((setup.S * setup.B i * setup.S⁻¹ : Matrix (Fin D) (Fin D) ℂ))ᴴ := by
-                  rw [setup.hB'_def, tpGauge, setup.hS_def]
-                  rfl
-          _ = (setup.S⁻¹)ᴴ * (setup.B i)ᴴ * setup.Sᴴ := by
-                simp [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+        rw [setup.hA'_def, tpGauge, setup.hS_def]; rfl
+      have hBstar : (setup.B' i)ᴴ = setup.S⁻¹ * (setup.B i)ᴴ * setup.S := by
+        have hB'eq : setup.B' i = setup.S * setup.B i * setup.S⁻¹ := by
+          rw [setup.hB'_def, tpGauge, setup.hS_def]; rfl
+        calc (setup.B' i)ᴴ
+            = (setup.S⁻¹)ᴴ * (setup.B i)ᴴ * setup.Sᴴ := by
+                  rw [hB'eq]; simp [Matrix.conjTranspose_mul, Matrix.mul_assoc]
           _ = setup.S⁻¹ * (setup.B i)ᴴ * setup.S := by
-                simp [setup.hS_herm, setup.hS_inv_herm]
-      calc
-        setup.A' i * (setup.S * V * setup.Sᴴ) * (setup.B' i)ᴴ
-            = (setup.S * A i * setup.S⁻¹) * (setup.S * V * setup.S) *
-                (setup.S⁻¹ * (setup.B i)ᴴ * setup.S) := by
-                  rw [hAeq, hBstar, setup.hS_herm]
-        _ = setup.S * (A i * V * (setup.B i)ᴴ) * setup.S := by
-              calc
-                (setup.S * A i * setup.S⁻¹) * (setup.S * V * setup.S) *
-                    (setup.S⁻¹ * (setup.B i)ᴴ * setup.S)
-                    = setup.S * A i * (setup.S⁻¹ * (setup.S * V * setup.S)) *
-                        (setup.S⁻¹ * (setup.B i)ᴴ * setup.S) := by
-                        simp [Matrix.mul_assoc]
-                _ = setup.S * A i * (V * setup.S) *
-                      (setup.S⁻¹ * (setup.B i)ᴴ * setup.S) := by
-                      have hSV :
-                          setup.S⁻¹ * (setup.S * V * setup.S) = V * setup.S := by
-                        calc
-                          setup.S⁻¹ * (setup.S * V * setup.S)
-                              = (setup.S⁻¹ * setup.S) * V * setup.S := by
-                                  simp [Matrix.mul_assoc]
-                          _ = V * setup.S := by simp [setup.hS_inv_mul]
-                      rw [hSV]
-                _ = setup.S * A i * (V * (setup.B i)ᴴ * setup.S) := by
-                      calc
-                        setup.S * A i * (V * setup.S) *
-                            (setup.S⁻¹ * (setup.B i)ᴴ * setup.S)
-                            = setup.S * A i *
-                                ((V * setup.S) * (setup.S⁻¹ * (setup.B i)ᴴ * setup.S)) := by
-                                simp [Matrix.mul_assoc]
-                        _ = setup.S * A i * (V * (setup.B i)ᴴ * setup.S) := by
-                              congr 1
-                              calc
-                                (V * setup.S) * (setup.S⁻¹ * (setup.B i)ᴴ * setup.S)
-                                    = V * (setup.S * setup.S⁻¹) * (setup.B i)ᴴ * setup.S := by
-                                        simp [Matrix.mul_assoc]
-                                _ = V * (setup.B i)ᴴ * setup.S := by
-                                      simp [setup.hS_mul_inv, Matrix.mul_assoc]
-                _ = setup.S * (A i * V * (setup.B i)ᴴ) * setup.S := by
-                      simp [Matrix.mul_assoc]
+                rw [setup.hS_inv_herm, setup.hS_herm]
+      -- Extract the two inner cancellations as local helpers.
+      have hSV : setup.S⁻¹ * (setup.S * V * setup.S) = V * setup.S :=
+        calc setup.S⁻¹ * (setup.S * V * setup.S)
+            = (setup.S⁻¹ * setup.S) * V * setup.S := by simp [Matrix.mul_assoc]
+          _ = V * setup.S := by rw [setup.hS_inv_mul, Matrix.one_mul]
+      have hVSB : (V * setup.S) * (setup.S⁻¹ * (setup.B i)ᴴ * setup.S) =
+                  V * (setup.B i)ᴴ * setup.S :=
+        calc V * setup.S * (setup.S⁻¹ * (setup.B i)ᴴ * setup.S)
+            = V * (setup.S * setup.S⁻¹) * (setup.B i)ᴴ * setup.S := by simp [Matrix.mul_assoc]
+          _ = V * (setup.B i)ᴴ * setup.S := by rw [setup.hS_mul_inv, Matrix.mul_one]
+      calc setup.A' i * (setup.S * V * setup.Sᴴ) * (setup.B' i)ᴴ
+          = (setup.S * A i * setup.S⁻¹) * (setup.S * V * setup.S) *
+              (setup.S⁻¹ * (setup.B i)ᴴ * setup.S) := by rw [hAeq, hBstar, setup.hS_herm]
+        _ = setup.S * A i * (setup.S⁻¹ * (setup.S * V * setup.S)) *
+              (setup.S⁻¹ * (setup.B i)ᴴ * setup.S) := by simp [Matrix.mul_assoc]
+        _ = setup.S * A i * (V * setup.S) *
+              (setup.S⁻¹ * (setup.B i)ᴴ * setup.S) := by rw [hSV]
+        _ = setup.S * A i * ((V * setup.S) *
+              (setup.S⁻¹ * (setup.B i)ᴴ * setup.S)) := by simp [Matrix.mul_assoc]
+        _ = setup.S * A i * (V * (setup.B i)ᴴ * setup.S) := by rw [hVSB]
         _ = setup.S * (A i * V * (setup.B i)ᴴ) * setup.Sᴴ := by
-              simp [setup.hS_herm]
+              simp [Matrix.mul_assoc, setup.hS_herm]
     calc
       mixedTransferMap setup.A' setup.B' (setup.S * V * setup.Sᴴ)
           = ∑ i : Fin d,
@@ -345,13 +322,12 @@ theorem twistedTPGaugeSetup_hasEigenvalue [NeZero D]
   have hGauge_ne : setup.S * V * setup.Sᴴ ≠ 0 := by
     intro hZero
     apply hV
-    have h' : setup.S⁻¹ * (setup.S * V * setup.Sᴴ) * (setup.Sᴴ)⁻¹ = 0 := by
+    have h : setup.S⁻¹ * (setup.S * V * setup.Sᴴ) * (setup.Sᴴ)⁻¹ = 0 := by
       simp [hZero]
-    have h'' : setup.S⁻¹ * (setup.S * V) = 0 := by
-      simpa [Matrix.mul_assoc, setup.hS_hMul_inv] using h'
-    have h''' : (setup.S⁻¹ * setup.S) * V = 0 := by
-      simpa [Matrix.mul_assoc] using h''
-    simpa [setup.hS_inv_mul] using h'''
+    have h1 : setup.S⁻¹ * (setup.S * V) = 0 := by
+      simpa [Matrix.mul_assoc, setup.hS_hMul_inv] using h
+    rw [← Matrix.mul_assoc, setup.hS_inv_mul, Matrix.one_mul] at h1
+    exact h1
   rw [Module.End.hasEigenvalue_iff]
   intro hBot
   have hMem :
@@ -791,12 +767,8 @@ theorem boundaryState_invariant_of_virtualUnitary
             simp [transferMap_apply]
       _ = ρ := by simp [ρ, hBfix, Matrix.mul_assoc]
   have hρ_tr : Matrix.trace ρ = 1 := by
-    calc
-      Matrix.trace ρ = Matrix.trace (V * Λ * Vᴴ) := rfl
-      _ = Matrix.trace (Vᴴ * (V * Λ)) := by
-            simpa [Matrix.mul_assoc] using Matrix.trace_mul_cycle V Λ Vᴴ
-      _ = Matrix.trace ((Vᴴ * V) * Λ) := by simp [Matrix.mul_assoc]
-      _ = 1 := by simpa [hV'] using hΛtr
+    have hρ_unf : ρ = V * Λ * Vᴴ := rfl
+    rw [hρ_unf, Matrix.trace_mul_cycle, hV', Matrix.one_mul, hΛtr]
   have hρ_ne : ρ ≠ 0 := by
     intro hρ0
     simp [hρ0] at hρ_tr
@@ -816,12 +788,10 @@ theorem boundaryState_invariant_of_virtualUnitary
     rw [hρ_scalar, Matrix.trace_smul, hΛtr] at hρ_tr
     simpa using hρ_tr
   have hρ_eq : ρ = Λ := by simpa [hc] using hρ_scalar
-  calc
-    Vᴴ * Λ * V = Vᴴ * ρ * V := by
-      simpa [Matrix.mul_assoc] using congrArg (fun M => Vᴴ * M * V) hρ_eq.symm
-    _ = Vᴴ * (V * (Λ * (Vᴴ * V))) := by simp [ρ, Matrix.mul_assoc]
-    _ = Vᴴ * (V * Λ) := by simp [hV']
-    _ = (Vᴴ * V) * Λ := by simp [Matrix.mul_assoc]
+  calc Vᴴ * Λ * V
+      = Vᴴ * ρ * V := by rw [← hρ_eq]
+    _ = (Vᴴ * V) * Λ * (Vᴴ * V) := by
+          simp [show ρ = V * Λ * Vᴴ from rfl, Matrix.mul_assoc]
     _ = Λ := by simp [hV']
 
 end MPSTensor

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -516,9 +516,8 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
   · simpa using hU_unitary_right
   · simpa using hU_unitary_left
   · have hζ_norm : ‖ζ‖ = 1 := by
-      have hsq : ‖ζ‖ ^ 2 = 1 := by
-        simpa [Complex.normSq_eq_norm_sq] using hζ_sq_eq_one
-      nlinarith [norm_nonneg ζ]
+      nlinarith [norm_nonneg ζ,
+        show ‖ζ‖ ^ 2 = 1 from by simpa [Complex.normSq_eq_norm_sq] using hζ_sq_eq_one]
     simp [norm_inv, hζ_norm]
   · intro i
     have hBi : ∀ j : Fin d, B j = ζ • (U * A j * Uᴴ) := by

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -622,8 +622,7 @@ theorem twistedTransfer_eigen_of_virtualUnitary
     (hC1μ : ∀ i : Fin d,
       ∑ j : Fin d, u i j • A j = μ • (V * A i * Vᴴ)) :
     twistedTransferMap A u V = μ • V := by
-  have hV' : Vᴴ * V = 1 := by
-    simpa using (mul_eq_one_comm.mp hV)
+  have hV' : Vᴴ * V = 1 := mul_eq_one_comm.mp hV
   calc
     twistedTransferMap A u V
         = ∑ i : Fin d, (∑ j : Fin d, u i j • A j) * V * (A i)ᴴ := by
@@ -671,17 +670,11 @@ theorem boundaryState_invariant_of_virtualUnitary
   haveI : NeZero D := ⟨hD⟩
   let B : MPSTensor d D := twistedMixedCompanion A u
   have hμ_ne : μ ≠ 0 := by
-    intro hμ0
-    have : ‖μ‖ = 0 := by simp [hμ0]
-    rw [hμ] at this
-    norm_num at this
+    intro h; simp [h] at hμ
   have hμ_sq : star μ * μ = 1 := by
-    have hsq : ‖μ‖ * ‖μ‖ = 1 := by
-      nlinarith [hμ]
     have hsqR : Complex.normSq μ = 1 := by
-      simpa [Complex.normSq_eq_norm_sq, sq] using hsq
-    have hsq' : (Complex.normSq μ : ℂ) = 1 := by
-      exact_mod_cast hsqR
+      simpa [Complex.normSq_eq_norm_sq, sq] using by nlinarith [hμ]
+    have hsq' : (Complex.normSq μ : ℂ) = 1 := by exact_mod_cast hsqR
     rw [Complex.normSq_eq_conj_mul_self] at hsq'
     simpa using hsq'
   have huc : uᴴ * u = 1 := mul_eq_one_comm.mp hu

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -667,11 +667,7 @@ theorem boundaryState_invariant_of_virtualUnitary
   have hμ_ne : μ ≠ 0 := by
     intro h; simp [h] at hμ
   have hμ_sq : star μ * μ = 1 := by
-    have hsqR : Complex.normSq μ = 1 := by
-      simpa [Complex.normSq_eq_norm_sq, sq] using by nlinarith [hμ]
-    have hsq' : (Complex.normSq μ : ℂ) = 1 := by exact_mod_cast hsqR
-    rw [Complex.normSq_eq_conj_mul_self] at hsq'
-    simpa using hsq'
+    rw [← starRingEnd_apply, Complex.conj_mul', hμ]; simp
   have huc : uᴴ * u = 1 := mul_eq_one_comm.mp hu
   have hcoeff :
       ∀ k j : Fin d,

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -379,15 +379,12 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
     funext i
     simpa [B, C, X, Xin] using hX i
   have hXinQ : Xin * Q * Xinᴴ = 1 := by
-    calc
-      Xin * Q * Xinᴴ = (Xin * X) * Xᴴ * Xinᴴ := by
-        simp [Q, Matrix.mul_assoc]
-      _ = Xᴴ * Xinᴴ := by
-        simp [hX_inv_mul]
-      _ = (Xin * X)ᴴ := by
-        simp [Matrix.conjTranspose_mul]
-      _ = 1 := by
-        simp [hX_inv_mul]
+    have hXhXinh : Xᴴ * Xinᴴ = 1 :=
+      calc Xᴴ * Xinᴴ = (Xin * X)ᴴ := (Matrix.conjTranspose_mul Xin X).symm
+        _ = 1 := by rw [hX_inv_mul, Matrix.conjTranspose_one]
+    calc Xin * Q * Xinᴴ
+        = Xin * X * (Xᴴ * Xinᴴ) := by simp [Q, Matrix.mul_assoc]
+      _ = 1 := by rw [hX_inv_mul, Matrix.one_mul, hXhXinh]
   have hQ_eigC : transferMap C Q = Q := by
     calc
       transferMap C Q = X * transferMap A (Xin * Q * Xinᴴ) * Xᴴ := by
@@ -437,8 +434,7 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
       injective_implies_irreducibleCP A hA
     have hCPA : IsCPMap (transferMap (d := d) (D := D) A) :=
       transferMap_isCPMap A
-    have hone_psd : (1 : Matrix (Fin D) (Fin D) ℂ).PosSemidef := by
-      simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ)).posSemidef
+    have hone_psd : (1 : Matrix (Fin D) (Fin D) ℂ).PosSemidef := Matrix.PosSemidef.one
     have hone_eig : transferMap A 1 = ((1 : ℝ) : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
       simpa using hNorm
     exact
@@ -451,8 +447,7 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
     simpa [hζ_sq_eq_one] using hQ_eigA
   have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
     injective_implies_irreducibleCP A hA
-  have hone_psd : (1 : Matrix (Fin D) (Fin D) ℂ).PosSemidef := by
-    simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ)).posSemidef
+  have hone_psd : (1 : Matrix (Fin D) (Fin D) ℂ).PosSemidef := Matrix.PosSemidef.one
   rcases posSemidef_fixedPoint_unique_of_irreducible (A := A) hIrrA
       (1 : Matrix (Fin D) (Fin D) ℂ) Q hone_psd one_ne_zero hQ_psd hNorm hQ_fix with
     ⟨c, hQ_scalar⟩

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -413,22 +413,13 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
   have hQ_ne : Q ≠ 0 := by
     intro hQ0
     have hXh_inv_mul : Xᴴ * Xinᴴ = 1 := by
-      calc
-        Xᴴ * Xinᴴ = (Xin * X)ᴴ := by
-          simp [Matrix.conjTranspose_mul]
-        _ = 1 := by
-          simp [hX_inv_mul]
-    have : X = 0 := by
-      calc
-        X = X * 1 := by simp
-        _ = X * (Xᴴ * Xinᴴ) := by rw [hXh_inv_mul]
-        _ = (X * Xᴴ) * Xinᴴ := by simp [Matrix.mul_assoc]
-        _ = 0 := by simp [Q, hQ0]
-    have hX_ne : X ≠ 0 := by
-      intro hX0
-      have hbad := hX_mul_inv
-      simp [X, Xin, hX0] at hbad
-    exact hX_ne this
+      rw [← Matrix.conjTranspose_mul, hX_inv_mul, Matrix.conjTranspose_one]
+    have hX_zero : X = 0 := by
+      have hQXin : (X * Xᴴ) * Xinᴴ = 0 := by simp [Q, hQ0]
+      calc X = X * (Xᴴ * Xinᴴ) := by rw [hXh_inv_mul, Matrix.mul_one]
+           _ = (X * Xᴴ) * Xinᴴ := (Matrix.mul_assoc X Xᴴ Xinᴴ).symm
+           _ = 0 := hQXin
+    simp [X, Xin, hX_zero] at hX_mul_inv
   have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
     injective_implies_irreducibleCP A hA
   have hCPA : IsCPMap (transferMap (d := d) (D := D) A) :=

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -283,7 +283,7 @@ theorem twistedTPGaugeSetup_hasEigenvalue [NeZero D]
                   rw [hB'eq]; simp [Matrix.conjTranspose_mul, Matrix.mul_assoc]
           _ = setup.S⁻¹ * (setup.B i)ᴴ * setup.S := by
                 rw [setup.hS_inv_herm, setup.hS_herm]
-      -- Extract the two inner cancellations as local helpers.
+      -- Extract the two inner cancellations as auxiliary lemmas.
       have hSV : setup.S⁻¹ * (setup.S * V * setup.S) = V * setup.S :=
         calc setup.S⁻¹ * (setup.S * V * setup.S)
             = (setup.S⁻¹ * setup.S) * V * setup.S := by simp [Matrix.mul_assoc]

--- a/TNLean/MPS/Symmetry/StringOrderDefs.lean
+++ b/TNLean/MPS/Symmetry/StringOrderDefs.lean
@@ -54,6 +54,7 @@ noncomputable def twistedTransferMap (A : MPSTensor d D)
       ((LinearMap.mulLeft ℂ (A n)).comp
         (LinearMap.mulRight ℂ (A n')ᴴ))
 
+/-- Computation rule for the twisted transfer map: `ℰ_u(X) = ∑_{n,n'} u_{n'n} A_n X A_{n'}†`. -/
 @[simp]
 lemma twistedTransferMap_apply (A : MPSTensor d D)
     (u : Matrix (Fin d) (Fin d) ℂ)
@@ -115,12 +116,15 @@ noncomputable def twistedTransferIter (A : MPSTensor d D)
       Matrix (Fin D) (Fin D) ℂ :=
   (twistedTransferMap A u) ^ N
 
+/-- The zeroth iterate of the twisted transfer map is the identity. -/
 @[simp]
 lemma twistedTransferIter_zero (A : MPSTensor d D)
     (u : Matrix (Fin d) (Fin d) ℂ) :
     twistedTransferIter A u 0 = LinearMap.id :=
   pow_zero _
 
+/-- The `(N+1)`-th iterate of the twisted transfer map is the twisted transfer
+map composed with the `N`-th iterate: `ℰ_u^{N+1} = ℰ_u ∘ ℰ_u^N`. -/
 lemma twistedTransferIter_succ (A : MPSTensor d D)
     (u : Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
     twistedTransferIter A u (N + 1) =

--- a/TNLean/MPS/Symmetry/StringOrderDefs.lean
+++ b/TNLean/MPS/Symmetry/StringOrderDefs.lean
@@ -54,7 +54,8 @@ noncomputable def twistedTransferMap (A : MPSTensor d D)
       ((LinearMap.mulLeft ℂ (A n)).comp
         (LinearMap.mulRight ℂ (A n')ᴴ))
 
-/-- Computation rule for the twisted transfer map: `ℰ_u(X) = ∑_{n,n'} u_{n'n} A_n X A_{n'}†`. -/
+/-- The twisted transfer map acts on $X$ by
+$\mathcal{E}_u(X) = \sum_{n, n'} u_{n' n}\, A_n X A_{n'}^{\dagger}$. -/
 @[simp]
 lemma twistedTransferMap_apply (A : MPSTensor d D)
     (u : Matrix (Fin d) (Fin d) ℂ)

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -229,8 +229,7 @@ lemma smul_mul_conjTranspose_of_norm_eq_one {m n : ℕ}
     (μ : ℂ) (hμ : ‖μ‖ = 1) (N : Matrix (Fin m) (Fin n) ℂ) :
     (μ • N) * (μ • N)ᴴ = N * Nᴴ := by
   have hμ_star_mul : star μ * μ = 1 := by
-    rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
-    simp only [Complex.normSq_eq_norm_sq, hμ, one_pow, Complex.ofReal_one]
+    rw [← starRingEnd_apply, Complex.conj_mul', hμ]; simp
   calc
     (μ • N) * (μ • N)ᴴ = (star μ * μ) • (N * Nᴴ) := by
       simp only [Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul]

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -108,7 +108,6 @@ theorem transferMap_pow_conjTranspose_eigenvector_of_root_of_unity
 
 /-! ### Step 3: Hermitian parts are fixed points -/
 
-
 /-- `i • (X† - X)` is always Hermitian. -/
 private lemma isHermitian_smul_I_sub_conjTranspose
     (X : Matrix (Fin D) (Fin D) ℂ) :

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -108,13 +108,6 @@ theorem transferMap_pow_conjTranspose_eigenvector_of_root_of_unity
 
 /-! ### Step 3: Hermitian parts are fixed points -/
 
-/-- `X + X†` is always Hermitian. -/
-private lemma isHermitian_add_conjTranspose
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    (X + Xᴴ).IsHermitian := by
-  unfold Matrix.IsHermitian
-  rw [Matrix.conjTranspose_add, Matrix.conjTranspose_conjTranspose]
-  abel
 
 /-- `i • (X† - X)` is always Hermitian. -/
 private lemma isHermitian_smul_I_sub_conjTranspose
@@ -253,11 +246,11 @@ theorem exists_hermitian_ne_zero_trace_zero_pow_fixedPoint
   have htr := trace_eigenvector_eq_zero A hNorm hEig hμ_ne
   rcases hermitianParts_not_both_zero hX_ne with h | h
   · exact ⟨X + Xᴴ,
-      isHermitian_add_conjTranspose X, h,
+      Matrix.isHermitian_add_transpose_self X, h,
       trace_hermitianPart_eq_zero htr,
       transferMap_pow_hermitianPart_fixedPoint A hEig hroot,
       not_posSemidef_of_hermitian_ne_zero_trace_eq_zero
-        (isHermitian_add_conjTranspose X) h (trace_hermitianPart_eq_zero htr)⟩
+        (Matrix.isHermitian_add_transpose_self X) h (trace_hermitianPart_eq_zero htr)⟩
   · exact ⟨Complex.I • (Xᴴ - X),
       isHermitian_smul_I_sub_conjTranspose X, h,
       trace_antiHermitianPart_eq_zero htr,

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1155,10 +1155,7 @@ Chapter~\ref{ch:periodic_ft_apps}.
 
 \begin{lemma}[Structural properties of the common reblocked sectors]%
     \label{thm:common_blocked_cyclic_sector_derived_properties}
-    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks_tp,
-        MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks_primitive,
-        MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatBlocks_irreducible,
-        MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatDim_pos}\leanok
+    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.derived_properties}\leanok
     \uses{thm:exists_common_blocked_cyclic_sector_family}
     Each sector tensor in the common reblocked cyclic-sector family of
     Lemma~\ref{thm:exists_common_blocked_cyclic_sector_family} is
@@ -1167,14 +1164,9 @@ Chapter~\ref{ch:periodic_ft_apps}.
     and has positive bond dimension.
 \end{lemma}
 
-% TODO(lean): the next two lemmas claim aggregate statements about the common
-% reblocked family.  The Lean library has the sector-by-sector comparison
-% lemmas (e.g. `blockTensor_sameMPV2_commonReindexedBlock_of_word_eq` and the
-% `sameMPV2_weightedCanonicalBlock_commonFlat_of_blockwise` family) but no
-% single bundled `reindexed_sameMPV` / `reindexed_nonzeroPart` declaration;
-% the \lean{} tags are removed until a faithful Lean statement exists.
 \begin{lemma}[Common-alphabet flattening]%
     \label{thm:common_blocked_cyclic_sector_reindexed_samempv}
+    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.reindexed_sameMPV₂}\leanok
     \uses{thm:exists_common_blocked_cyclic_sector_family}
     With $p = m_k e_k$ for each $k$, the iterated blocked tensor $(B_k^{[m_k]})^{[e_k]}$
     agrees with the directly blocked tensor $B_k^{[p]}$ in the sense of generating
@@ -1185,6 +1177,7 @@ Chapter~\ref{ch:periodic_ft_apps}.
 
 \begin{lemma}[Reindexed nonzero-part transport]%
     \label{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
+    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.reindexed_nonzero_part}\leanok
     \uses{thm:common_blocked_cyclic_sector_reindexed_samempv}
     The nonzero-part decomposition of a weighted block sum
     $\bigoplus_k \mu_k B_k$ transports through the common-alphabet
@@ -1213,13 +1206,9 @@ Chapter~\ref{ch:periodic_ft_apps}.
     $(d^{[m]})^{n}$ are equal under the canonical alphabet identification.
 \end{lemma}
 
-% TODO(lean): no single bundled `blocked_word_comparison` declaration exists
-% in `CommonBlockedCyclicSectorFamily.lean`; the per-letter and per-block
-% identifications are stated separately (e.g. `flattenWordOfBlock_cast_eq`,
-% `blockTensor_eq_commonReindexedBlock_of_word_eq`).  Drop the \lean{} tag
-% until a faithful bundled statement is added in Lean.
 \begin{lemma}[Direct and iterated blocking comparison]%
     \label{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.blocked_word_comparison}\leanok
     \uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
         def:common_blocked_cyclic_sector_grouped_block_cast}
     Direct blocking at length $p = m_k e_k$ and iterated blocking


### PR DESCRIPTION
## Summary

Cleanup pass over Lean code for blueprint chapters 1–14 (intro through "Symmetries and String Order"), targeting pass-through layers, indirection, duplicate lemmas, and over-long proofs flagged by the user.

**18 files touched, 15 commits, net −120 lines** across in-scope modules.

## Largest reductions

| File | Δ lines | Change |
|---|---:|---|
| `MPS/Symmetry/StringOrderAux.lean` | **−59** | Golf `hpow`, `hTerm`, `hGauge_ne`, `hρ_tr`, `hμ_sq`, `hQ_ne`; hoist duplicate `hIrrA`/`hCPA`/`hone_psd` |
| `MPS/Symmetry/StringOrder.lean` | **−11** | `hpow` induction → 1-line `rw` chain via `Module.End.mul_apply` |
| `Algebra/UnitModulusPowerSum.lean` | **−11** | `hμq_sq`, `hnormSq` via `Complex.mul_conj'` |
| `Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean` | **−11** | Star-norm unit proofs via `Complex.conj_mul'` |
| `Algebra/MatrixAux.lean` | **−8** | `sum_mul_mul` 9-line calc → 1-line `simp` |
| `Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean` | **−7** | Private `isHermitian_add_conjTranspose` → `Matrix.isHermitian_add_transpose_self` |

## Patterns addressed

1. **Mathlib scouting** — replaced ad-hoc lemmas with Mathlib equivalents:
   - `isHermitian_add_conjTranspose` (private, 6 lines) → `Matrix.isHermitian_add_transpose_self`
   - 5× `simpa using (Matrix.PosDef.one ...).posSemidef` → `Matrix.PosDef.one` / `Matrix.PosSemidef.one`
   - 7× `rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]; simp [normSq_eq_norm_sq, hμ]` → `rw [← starRingEnd_apply, Complex.conj_mul', hμ]; simp` (across 7 files)

2. **Over-long proofs golfed** — `StringOrderAux.lean` shrank by 59 lines via flatter `calc` chains and extracted helpers (`hSV`/`hVSB`).

3. **Pass-through patterns documented, not removed** — per the faithfulness rule:
   - `MPS/Symmetry/GaugeUniqueness.lean`: `gauge_unique_up_to_scalar_of_sameMPV` is a blueprint-tagged pass-through that silently ignores `_hAB : SameMPV A B`. Expanded the docstring to explain why removal is unsafe.
   - `Channel/WolfChapter6Wrappers.lean`: intentional stable Wolf-numbered API surface — left as-is.

4. **Bundled wrappers added** (commit `7fbb2023`) — `CommonBlockedCyclicSectorFamily` now exposes the four aggregate lemmas (`derivedProperties`, `reindexed_sameMPV`, `reindexed_nonzeroPart`, `blocked_word_comparison`) that the ch08 blueprint had tagged. Thin restatements of existing field-level lemmas, no new sorrys. **Coordinates with #1777** which drops those tags pending these declarations — restore the tags after merge.

5. **Duplicate lemmas left as-is**:
   - `sum_pad_zeros` is duplicated in `Channel/KrausFreedom` and `Channel/KrausRank`. Factoring into `Algebra/MatrixAux` would introduce a non-trivial import edge into `Channel/`; left untouched. Noted in report.

## Build status

- `lake build` clean (8501 jobs).
- `rg -n "sorry|admit"` on touched files: no new sorrys.
- `leanblueprint checkdecls` (in-scope ch01–ch14): clean.

## Faithfulness rule

No `\leanok`'d theorem statement was tightened or loosened. Pass-through wrappers carry the same hypothesis surface as their delegates. The bundled `CommonBlockedCyclicSectorFamily` wrappers preserve the source-faithfulness of the field-level lemmas they re-export.

## Out of scope (untouched)

`MPS/ParentHamiltonian/`, `MPS/MPDO/`, `PEPS/`, `PiAlgebra/`, `Archive/`, and any blueprint chapter after `ch13b_symmetry.tex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily proof refactors and new thin wrapper theorems; risk is low but broad touch points could cause downstream breakage if lemma names/simp behavior changed.
> 
> **Overview**
> Refactors a set of Lean proofs across Algebra/Channel/MPS/Wielandt modules by replacing ad‑hoc arguments with Mathlib lemmas (notably around `PosDef/PosSemidef.one`, unit‑modulus conjugation via `Complex.conj_mul'`, and sum/mul matrix simp lemmas), substantially shortening several long `calc` blocks.
> 
> Adds small API conveniences: new simp lemmas for `MPSTensor.evalWord` (`evalWord_nil`, `evalWord_cons`) and bundled comparison/structure theorems on `CommonBlockedCyclicSectorFamily` (`derived_properties`, `reindexed_sameMPV₂`, `blocked_word_comparison`, `reindexed_nonzero_part`), and updates the blueprint chapter 8 `\lean{}` tags to point at these new bundled statements.
> 
> Also drops some unused imports of `TNLean.MPS.FundamentalTheorem.Full` from periodic modules and removes a private Hermitian helper in favor of Mathlib’s `Matrix.isHermitian_add_transpose_self`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c575fd71e2497aa8be985ebd9f5f33b6b5b6d77b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->