### PR TITLE
doc(blueprint): restore BNT unit-modulus hypothesis

### DIFF
--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1486,8 +1486,9 @@ which is then combined with overlap estimates and the leading-block peel.
     \leanok
     \uses{def:same_mpv, def:bnt, def:gauge_phase_equiv}
     Let $P$ and $Q$ be two BNT sector decompositions
-    (Definition~\ref{def:bnt}), possibly with different block counts and
-    different bond dimensions in corresponding blocks.
+    (Definition~\ref{def:bnt}), each admitting a unit-modulus copy weight in
+    every basis sector, possibly with different block counts and different bond
+    dimensions in corresponding blocks.
     If their block-diagonal tensors generate the same MPV family
     (Definition~\ref{def:same_mpv}), then the basis sectors are
     bijectively matched by a permutation $\beta$, each matched basis pair is


### PR DESCRIPTION
### Motivation

Issue #1770 notes that the Chapter 13 heterogeneous equal-case block matching entry links to `MPSTensor.ft_paper_bnt_equal_sector_data`, whose Lean statement assumes a unit-modulus copy weight in every basis sector of both sector decompositions.

### Description

- Adds the per-sector unit-modulus copy-weight hypothesis to `lem:fundamentalTheorem_equalMPV_CFBNT_hetero`.
- Leaves the existing `\lean{MPSTensor.ft_paper_bnt_equal_sector_data}` and `\leanok` tags in place, now with the missing hypothesis visible in the blueprint prose.

### Testing

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (reports existing unrelated missing declarations in Chapters 8 and 14)

---
Closes #1770

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts the statement of a LaTeX lemma to include a missing unit-modulus copy-weight assumption and does not change any executable code or proofs.
>
> **Overview**
> Aligns the blueprint statement of `lem:fundamentalTheorem_equalMPV_CFBNT_hetero` with its linked Lean theorem by **restoring the missing hypothesis** that both BNT sector decompositions admit a *unit-modulus copy weight in every basis sector*.
>
> No other content or Lean linkage tags are changed; this is a documentation/prose correction to make the stated assumptions match the formalized result.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b89c6cc855fd67d3432a65d275fc636b26ccfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->