### PR TITLE
doc(blueprint): align chapter 8 hypotheses

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1021,10 +1021,10 @@ Chapter~\ref{ch:periodic_ft_apps}.
 
 \begin{lemma}[Canonical form from peripheral primitivity]%
     \label{thm:canonical_from_primitive}
-    \uses{def:is_canonical_form, def:irreducible_tensor, def:tp_kraus}
-    Let $(\mu_k,A_k)_{k=1}^r$ be a family of nonzero weights and left-canonical
-    irreducible blocks with positive bond dimensions, with strictly decreasing
-    moduli $|\mu_1|>\cdots>|\mu_r|>0$ and $|\mu_1|=1$, and assume each transfer
+    \uses{def:is_canonical_form, def:injective, def:tp_kraus}
+    Let $(\mu_k,A_k)_{k=1}^r$ be a family of nonzero weights and injective,
+    left-canonical blocks with positive bond dimensions, with strictly
+    decreasing moduli $|\mu_1|>\cdots>|\mu_r|>0$, and assume each transfer
     map satisfies $\sigma_\partial(\E_{A_k}) = \{1\}$ (peripheral-spectrum
     primitivity). Then $(\mu_k,A_k)_{k=1}^r$ satisfies the canonical-form
     conditions of Definition~\ref{def:is_canonical_form}. In particular,
@@ -1124,7 +1124,7 @@ Chapter~\ref{ch:periodic_ft_apps}.
     \label{thm:iterated_blocking_transfer}
     \lean{MPSTensor.transferMap_blockTensor_mul}\leanok
     \uses{def:blocked_tensor, def:transfer_map}
-    For any MPS tensor $A$ and integers $m,n \ge 1$,
+    For any MPS tensor $A$ and natural numbers $m,n \ge 0$,
     \[
         \E_{(A^{[m]})^{[n]}} =  \E_{A^{[mn]}}.
     \]


### PR DESCRIPTION
### Motivation

Issue #1755 records Chapter 8 blueprint drift after PR #1754. Since this branch was opened, #1777 landed the stale aggregate `CommonBlockedCyclicSectorFamily` tag cleanup on `main`; this PR now supplies the remaining two statement corrections from #1755.

### Description

- Changes the peripheral-primitivity canonical-form prose from irreducible blocks to injective blocks and removes the extra $|\mu_1|=1$ hypothesis.
- Changes the iterated blocking statement from positive integers to natural numbers $m,n \ge 0$, matching `MPSTensor.transferMap_blockTensor_mul`.

### Testing

- `git diff --check origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (Chapter 8 remains 45/45 after #1777; remaining reports are pre-existing Chapter 14 entries and stale ignored declaration-list entries outside this PR)

---

Closes #1755

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that relax/adjust lemma hypotheses and fix Lean cross-references; no executable code changes, but could affect downstream readers relying on the previous assumptions.
> 
> **Overview**
> Updates Chapter 8 blueprint auxiliary lemmas to better match the corresponding Lean declarations.
> 
> The `Canonical form from peripheral primitivity` lemma now assumes *injective* left-canonical blocks (instead of irreducible blocks) and drops the extra `|μ₁|=1` requirement, while keeping the strictly-decreasing weight-modulus ordering. The `Iterated blocking at the transfer-map level` statement is relaxed from integers `m,n ≥ 1` to natural numbers `m,n ≥ 0` to match `MPSTensor.transferMap_blockTensor_mul`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b6f66722cb5f21277d1c9f6f28c46b41bdfc3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->