### PR TITLE
fix(MPS): blocked_word_comparison faithfulness + docstring follow-ups to #1778

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -734,14 +734,22 @@ theorem blocked_word_comparison (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) :
     SameMPV₂
       (blockTensor (d := d) (D := dim k) (blocks k) F.p)
-      (F.commonReindexedBlock k) :=
-  F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k
-    (groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
-      (fun hp_eq => flattenWordOfBlock_cast_eq hp_eq) F k)
+      (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
+        (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
+          (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k))) := by
+  intro N σ
+  have hDirect : mpv (blockTensor (d := d) (D := dim k) (blocks k) F.p) σ =
+      mpv (F.commonReindexedBlock k) σ :=
+    F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k
+      (groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+        (fun hp_eq => flattenWordOfBlock_cast_eq hp_eq) F k) N σ
+  exact hDirect.trans (F.reindexed_sameMPV₂ k N σ).symm
 
 /-- The nonzero-part decomposition of a weighted block sum $\bigoplus_k \mu_k B_k$
 transports through the common-alphabet identification: the common-alphabet sectors
-have the same nonzero-part decomposition as the direct $p$-blocked tensors. -/
+have the same nonzero-part decomposition as the direct $p$-blocked tensors. After
+blocking by length $p$, the per-block scalar weights $\mu_k$ become $\mu_k^{p}$ since
+each $B_k^{[p]}$ is a $p$-fold matrix product. -/
 theorem reindexed_nonzero_part (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
     SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)
@@ -751,7 +759,10 @@ theorem reindexed_nonzero_part (F : CommonBlockedCyclicSectorFamily blocks) (μ 
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) := by
   intro N σ
   have hCommon : ∀ k, mpv (blockTensor (d := d) (D := dim k) (blocks k) F.p) σ =
-      mpv (F.commonReindexedBlock k) σ := fun k => F.blocked_word_comparison k N σ
+      mpv (F.commonReindexedBlock k) σ := fun k =>
+    F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k
+      (groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+        (fun hp_eq => flattenWordOfBlock_cast_eq hp_eq) F k) N σ
   calc mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
             (μ := fun k => (μ k) ^ F.p)
             (fun k => blockTensor (blocks k) F.p)) σ

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -727,6 +727,19 @@ theorem reindexed_sameMPV₂ (F : CommonBlockedCyclicSectorFamily blocks) (k : F
       (F.commonReindexedBlock k) :=
   F.nestedBlock_sameMPV₂_commonReindexedBlock k
 
+/-- The direct $p$-blocked tensor $B_k^{[p]}$ has the same MPV family as its image in the
+common alphabet via `commonReindexedBlock`. This is the unconditional form of
+`blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees`, used as a building
+block in `blocked_word_comparison` and `reindexed_nonzero_part`. -/
+theorem blockTensor_sameMPV₂_commonReindexedBlock
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
+    SameMPV₂
+      (blockTensor (d := d) (D := dim k) (blocks k) F.p)
+      (F.commonReindexedBlock k) :=
+  F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k
+    (groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+      (fun hp_eq => flattenWordOfBlock_cast_eq hp_eq) F k)
+
 /-- Direct blocking at length `p = m_k * e_k` and iterated blocking
 `(B_k^{[m_k]})^{[e_k]}` produce the same MPV family after the canonical
 alphabet identification. -/
@@ -738,12 +751,8 @@ theorem blocked_word_comparison (F : CommonBlockedCyclicSectorFamily blocks)
         (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
           (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k))) := by
   intro N σ
-  have hDirect : mpv (blockTensor (d := d) (D := dim k) (blocks k) F.p) σ =
-      mpv (F.commonReindexedBlock k) σ :=
-    F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k
-      (groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
-        (fun hp_eq => flattenWordOfBlock_cast_eq hp_eq) F k) N σ
-  exact hDirect.trans (F.reindexed_sameMPV₂ k N σ).symm
+  exact (F.blockTensor_sameMPV₂_commonReindexedBlock k N σ).trans
+    (F.reindexed_sameMPV₂ k N σ).symm
 
 /-- The nonzero-part decomposition of a weighted block sum $\bigoplus_k \mu_k B_k$
 transports through the common-alphabet identification: the common-alphabet sectors
@@ -759,10 +768,8 @@ theorem reindexed_nonzero_part (F : CommonBlockedCyclicSectorFamily blocks) (μ 
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) := by
   intro N σ
   have hCommon : ∀ k, mpv (blockTensor (d := d) (D := dim k) (blocks k) F.p) σ =
-      mpv (F.commonReindexedBlock k) σ := fun k =>
-    F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k
-      (groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
-        (fun hp_eq => flattenWordOfBlock_cast_eq hp_eq) F k) N σ
+      mpv (F.commonReindexedBlock k) σ :=
+    fun k => F.blockTensor_sameMPV₂_commonReindexedBlock k N σ
   calc mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
             (μ := fun k => (μ k) ^ F.p)
             (fun k => blockTensor (blocks k) F.p)) σ

--- a/TNLean/MPS/Symmetry/GaugeUniqueness.lean
+++ b/TNLean/MPS/Symmetry/GaugeUniqueness.lean
@@ -93,10 +93,11 @@ theorem gauge_unique_up_to_scalar {A B : MPSTensor d D} (hA : IsInjective A)
 /-- A Same-MPV corollary: after obtaining any two gauges from the single-block FT,
 they are unique up to a nonzero scalar.
 
-Although the matching-MPV hypothesis is not needed for the conclusion — gauge
-uniqueness follows from injectivity alone, together with the two gauge equations
-$B_i = X A_i X^{-1}$ and $B_i = Y A_i Y^{-1}$ — it is retained to match the
-blueprint statement faithfully. -/
+Although the hypothesis that $A$ and $B$ generate the same matrix product vector
+family is not needed for the conclusion — gauge uniqueness follows from
+injectivity alone, together with the two gauge equations $B_i = X A_i X^{-1}$
+and $B_i = Y A_i Y^{-1}$ — it is retained to match the blueprint statement
+faithfully. -/
 theorem gauge_unique_up_to_scalar_of_sameMPV {A B : MPSTensor d D}
     (hA : IsInjective A) (_hAB : SameMPV A B)
     {X Y : GL (Fin D) ℂ}

--- a/TNLean/MPS/Symmetry/GaugeUniqueness.lean
+++ b/TNLean/MPS/Symmetry/GaugeUniqueness.lean
@@ -90,8 +90,9 @@ theorem gauge_unique_up_to_scalar {A B : MPSTensor d D} (hA : IsInjective A)
               (X : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
               simp
 
-/-- A Same-MPV corollary: after obtaining any two gauges from the single-block FT,
-they are unique up to a nonzero scalar.
+/-- Gauge uniqueness for tensors with identical matrix product vector families: after
+obtaining any two gauges from the single-block fundamental theorem, they are unique up
+to a nonzero scalar.
 
 Although the hypothesis that $A$ and $B$ generate the same matrix product vector
 family is not needed for the conclusion — gauge uniqueness follows from


### PR DESCRIPTION
## Summary

Follow-up to #1778 addressing three review comments from `claude[bot]` that landed after the PR was merged.

## Changes

### 1. `blocked_word_comparison` — match the blueprint statement

The blueprint claim `thm:common_blocked_cyclic_sector_blocked_word_comparison` compares the **direct** $p$-blocked tensor $B_k^{[p]}$ to the **iterated** $(B_k^{[m_k]})^{[e_k]}$. The previous Lean statement used `commonReindexedBlock k` (the direct tensor reindexed via `iteratedBlockIndex`), making the result a near-tautology in the canonical-alphabet coordinates — it never mentioned the iterated tensor.

Restate the RHS as the iterated blocked tensor (with the same `cast` as `reindexed_sameMPV₂`); the proof composes the previous direct ↔ `commonReindexedBlock` step with `reindexed_sameMPV₂.symm`.

### 2. `reindexed_nonzero_part` — document the weight relation

Blueprint writes $\bigoplus_k \mu_k B_k$ with pre-blocking weights $\mu_k$; Lean uses $\mu_k^{p}$ on the LHS. Both are correct — blocking by length $p$ turns scalars into their $p$-th power — but the relationship was implicit. Add a one-line note to the docstring.

Also inline the direct ↔ `commonReindexedBlock` step so the proof no longer depends on the (now restated) `blocked_word_comparison`.

### 3. `GaugeUniqueness.lean` docstring prose

"matching-MPV hypothesis" leaked the Lean predicate name `SameMPV` into prose. Replace with "the hypothesis that $A$ and $B$ generate the same matrix product vector family" per `docs/prose_style.md` §1.

## Verification

- `lake build` clean (verified locally via Lean server).
- `rg "sorry|admit|axiom|native_decide"` on touched files: no new occurrences.
- No blueprint changes: existing `\lean{}` tags and `\leanok` annotations remain accurate (the theorem names are unchanged; only statements and docstrings shift).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes a key theorem statement (`blocked_word_comparison`) and rewires downstream proofs; this could break dependent lemmas or subtly alter intended equivalences despite being proof-only Lean changes.
> 
> **Overview**
> Adjusts the cyclic-sector common-blocking comparison lemmas to better match the blueprint: `blocked_word_comparison` now relates the *direct* `p`-blocked tensor to the *iterated* blocked tensor (via the same `cast` used elsewhere) instead of to `commonReindexedBlock`.
> 
> Introduces a reusable lemma `blockTensor_sameMPV₂_commonReindexedBlock` and updates `reindexed_nonzero_part` to use it directly, plus documents that block weights become `μ_k^p` after length-`p` blocking. Also tightens prose in `GaugeUniqueness.lean` to avoid leaking predicate names in docstrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94fe69724ed23b2b944cf116f027b018af4716a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->