### PR TITLE
doc(blueprint): remove remark status jargon

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -50,7 +50,7 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     at least one index $k$.
 \end{theorem}
 
-This chapter formalizes the constituent steps of this reduction:
+This chapter develops the constituent steps of this reduction:
 invariant-subspace decomposition (Theorem~\ref{thm:irred_decomp}), TP gauge
 (Section~\ref{sec:tp_gauge_arbitrary}), and period-removal cyclic sectors
 (Section~\ref{sec:cyclic_sectors}). Zero-tail separation and the combined
@@ -125,7 +125,7 @@ definitions stated below.
 
 \section{Transfer map normalization}\label{sec:transfer_map_normalization}
 
-\begin{remark}[Scalar normalization conventions]\leanok
+\begin{remark}[Scalar normalization conventions]
     The reductions in this chapter use four routine normalization facts:
     scaling preserves injectivity, the transfer map under a scalar~$\zeta$
     rescales by $|\zeta|^2$, unit-modulus phase rescaling preserves the
@@ -344,7 +344,7 @@ Theorem~\ref{thm:blocking_primitivity}: blocking an irreducible TP block by the
 least common multiple of its peripheral periods makes the resulting transfer map
 primitive, removing periodicity.
 
-\begin{remark}[Two routes to the canonical-form predicate from normal blocks]\leanok
+\begin{remark}[Two routes to the canonical-form predicate from normal blocks]
     Given a family of injective, left-canonical, strictly-ordered
     nonzero-weight blocks $(\mu_k, A_k)$, the canonical-form conditions of
     Definition~\ref{def:cf_paper} can be discharged from either of two
@@ -357,7 +357,7 @@ primitive, removing periodicity.
     arbitrary-input canonical-form existence theorem of~\cite[Theorem~\texttt{Th:TIcanonical}]{PerezGarcia2007Matrix}.
 \end{remark}
 
-\begin{remark}\label{rem:primitivity_reduces_assumptions}\leanok
+\begin{remark}\label{rem:primitivity_reduces_assumptions}
     The remark above shows that the overlap convergence hypothesis in the
     canonical form conditions is redundant once peripheral-spectrum
     primitivity is known.
@@ -405,7 +405,7 @@ primitive, removing periodicity.
     so $\E_{A^{[p]}}$ is primitive.
 \end{proof}
 
-\begin{remark}\label{rem:blocking_primitivity_appendixA}\leanok
+\begin{remark}\label{rem:blocking_primitivity_appendixA}
     Theorem~\ref{thm:blocking_primitivity} is the ``periodicity removal by blocking''
     step in~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys} for an irreducible block
     already placed in TP gauge. The later existence theorems then reuse
@@ -902,7 +902,6 @@ is the normality of a TP-primitive irreducible block.
 
 \begin{remark}[Canonical-form reduction before the equal-case comparison]%
     \label{rem:canonical_construction_gaps}
-    \leanok
     The MPS canonical-form reduction separates the all-zero summand, which
     contributes only to the length-zero trace, from the nonzero part. It then
     decomposes the nonzero part into irreducible blocks, places each block in TP
@@ -925,9 +924,9 @@ is the normality of a TP-primitive irreducible block.
     and~\cite{Cirac2021Matrix}, using site-independent translation-invariant
     tensors, transfer-map primitivity, and CPM fixed-point normalization. The
     period-removal step of~\cite[Theorem~Th:periodic]{PerezGarcia2007Matrix} is
-    formalized as Theorem~\ref{thm:cyclic_sector_decomp_after_blocking} of
+    recorded as Theorem~\ref{thm:cyclic_sector_decomp_after_blocking} of
     Section~\ref{sec:cyclic_sectors}; the explicit decomposition of the state
-    vector into $p$-periodic summands is not formalized here.
+    vector into $p$-periodic summands lies outside the present chapter.
 \end{remark}
 
 \subsection{Building a BNT from normal blocks with normalized weights}%
@@ -1076,7 +1075,6 @@ BNT construction.
 
 \begin{remark}[Arbitrary-input reduction]%
     \label{rem:arbitrary_input_bridge_gap}
-    \leanok
     Theorem~\ref{thm:paperbnt_supplier_after_blocking} gives the
     arbitrary-input reduction used here, conditional on the two weight
     normalization hypotheses displayed in that theorem. The preparatory

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1292,7 +1292,8 @@ which is then combined with overlap estimates and the leading-block peel.
 \end{definition}
 
 \begin{remark}
-    See Definition~\ref{def:is_normal_canonical_form} for the formalized normal canonical-form data statement.
+    See Definition~\ref{def:is_normal_canonical_form} for the normal canonical-form
+    data statement.
 \end{remark}
 
 \begin{lemma}[Block separation from weighted word identities]%


### PR DESCRIPTION
### Motivation

Chapter 8 and Chapter 13 contained explanatory blueprint prose using implementation-status language, and several Chapter 8 remarks carried `\leanok` despite having no `\lean{...}` declaration target. Such remarks are mathematical orientation text, not declarations checked by `checkdecls`, so the status marker was misleading.

Blueprint prose should state the mathematical reductions directly: canonical-form reductions, period-removal references, and normal-canonical-form cross-references should be readable without reference to the Lean development process.

### Description

- Remove `\leanok` from six untagged explanatory remarks in `blueprint/src/chapter/ch08_canonical.tex`.
- Rephrase Chapter 8 prose so the canonical-form chapter "develops" the reduction and the period-removal theorem is "recorded" in the blueprint, rather than described in terms of formalization status.
- Rephrase the Chapter 13 normal-canonical-form cross-reference to name the mathematical statement directly.

No Lean source files are changed.

### Testing

- `git diff --check`
- `cd blueprint && leanblueprint web`
- `awk` audit for untagged remarks carrying `\leanok` in the touched chapters
- `rg -n "formalized|formalization|formalizes|formalize" blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch13_algebraic_ft.tex`
- `lake build`

---
Closes #1651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only wording tweaks and removal of `\leanok` tags from `remark` environments; no Lean code or mathematical statements are changed.
> 
> **Overview**
> Updates blueprint prose in Chapters 8 and 13 to remove Lean-process/status signaling from `remark` blocks.
> 
> Specifically, drops `\leanok` annotations from non-declaration remarks and rephrases several cross-references to describe the mathematical content directly (e.g., “recorded” vs “formalized”, and clarifying out-of-scope material), plus minor wording cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e13c8b525ad212f5680012d18ec99223aa6f30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->