### PR TITLE
fix(blueprint): remove stale proof-block dependency in ch11

### DIFF
--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -569,7 +569,6 @@ facts used to recover the lists of weights from those power sums.
 
 \begin{proof}
     \leanok
-    \uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed}
     Apply the phase-class construction on both sides and expose the
     representative overlap/span data internally. The one-sided positive-dimension,
     injectivity, normalization, and overlap fields fill all fields of


### PR DESCRIPTION
### Motivation

The proof block for the representative sector-basis span theorem in Chapter 11 still listed the one-sided BNT sector-decomposition theorem as a proof dependency. After the Chapter 9 W6 refactor, the Lean proof constructs the two sector decompositions directly from the private phase-class auxiliary on each side. The one-sided theorem remains part of the surrounding mathematical context, but it is not the proof route for this result.

### Description

This PR removes the stale proof-block `\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed}` from the proof of `thm:bnt_sector_decomp_pair_overlap_span_of_block_span`. The theorem statement keeps its existing `\uses` entry, so the displayed mathematical dependencies of the statement are unchanged.

- File changed: `blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` (line 1482)

### Testing

- `git diff --check`
- `cd blueprint && leanblueprint web`
- `lake build`
- Ran `leanblueprint checkdecls`; Chapter 11 declarations remain complete. Pre-existing failures in the periodic, PEPS, and parent-Hamiltonian chapters are unaffected by this change.

---
Closes #1663

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: removes a single stale `\uses{...}` dependency marker from a proof block without changing any theorem statements or Lean references.
>
> **Overview**
> Removes the stale `\uses{thm:bnt_sector_decomp_tp_prim_irr_collapsed}` annotation from the *proof* of `thm:bnt_sector_decomp_pair_overlap_span_of_block_span` in Chapter 11.
>
> The theorem's own `\uses{...}` list remains unchanged; only the displayed proof-block dependency metadata is updated.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9598d016552529da961d34c14ce5da050efd5eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->