### PR TITLE
fix(blueprint): reorder after-blocking chapter and prose

### DIFF
--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1386,7 +1386,7 @@ spectral gap. It is connected to normality through the following results.
     Theorem~\ref{thm:primitive_implies_irreducible} gives
     irreducibility.
     Together with the Burnside argument below
-    (Section~\ref{subsec:burnside_bridge})
+    (Section~\ref{subsec:burnside_full_span})
     and Theorem~\ref{thm:algspan_to_normal}, one obtains
     \[
         \text{primitive} + \rho \text{ positive definite}
@@ -1450,7 +1450,7 @@ spectral gap. It is connected to normality through the following results.
 \end{proof}
 
 \subsection{From irreducibility to full spanning via Burnside's theorem}
-\label{subsec:burnside_bridge}
+\label{subsec:burnside_full_span}
 
 The irreducibility condition (Definition~\ref{def:irreducible_tensor}) is formulated
 in terms of invariant \emph{projections}.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1074,7 +1074,7 @@ BNT construction.
 \end{proof}
 
 \begin{remark}[Arbitrary-input reduction]%
-    \label{rem:arbitrary_input_bridge_gap}
+    \label{rem:arbitrary_input_reduction_gap}
     Theorem~\ref{thm:paperbnt_supplier_after_blocking} gives the
     arbitrary-input reduction used here, conditional on the two weight
     normalization hypotheses displayed in that theorem. The preparatory

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -1,12 +1,12 @@
-
-\chapter{Canonical-form data after blocking}\label{ch:canonical_after_blocking}
+\chapter{Canonical-form reductions after blocking}\label{ch:canonical_after_blocking}
 
 This chapter records the structural decomposition of an arbitrary MPS tensor
 after blocking by a period $p$, and the joint after-blocking decomposition of
-two tensors with the same MPV family. Each side splits into a zero-tail
-bond-dimension term plus a weighted direct sum of left-canonical, primitive,
-irreducible blocks over a common physical alphabet; these decompositions are the
-input to the equal-MPV comparison of Chapter~\ref{ch:ft_proof}.
+two tensors with the same MPV family. Each side is written as the direct sum of
+an all-zero tensor $\mathbf{0}_{d,D_0}$ and a weighted direct sum of
+left-canonical, primitive, irreducible blocks over a common physical alphabet;
+these decompositions are the input to the equal-MPV comparison of
+Chapter~\ref{ch:ft_proof}.
 
 \section{Zero-tail separation}%
 \label{sec:zero_block_separation}
@@ -1085,7 +1085,7 @@ blocking.
         thm:primitive_adjoint_equiv}
     Theorem~\ref{thm:sector_irred_unconditional} gives irreducibility of
     $(\E_A^\dagger)^m$ on each corner $P_u$.
-    The blocked cyclic-sector data provide compression equivalences
+    The blocked cyclic-sector hypotheses give compression equivalences
     $\varphi_u$ intertwining the adjoint transfer map of $C_u$ with the
     corresponding corner restriction of $(\E_A^\dagger)^m$.
     The same cyclic peripheral-spectrum argument that produces the sector

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -9,8 +9,8 @@
 \input{chapter/ch08_canonical}
 \input{chapter/ch09_block_perm}
 \input{chapter/ch10_bnt}
-\input{chapter/ch11_fundamental_theorem_proof}
 \input{chapter/ch11b_after_blocking}
+\input{chapter/ch11_fundamental_theorem_proof}
 \input{chapter/ch13b_symmetry}
 \input{chapter/ch11b_periodic_ft}
 \input{chapter/ch13_algebraic_ft}


### PR DESCRIPTION
### Motivation

The after-blocking reduction results are prerequisites for the non-periodic fundamental-theorem proof. The blueprint should therefore present the after-blocking chapter before the proof chapter, and the surrounding prose should name the mathematical reductions directly rather than using vague or non-mathematical wording.

### Description

This PR moves `ch11b_after_blocking` before `ch11_fundamental_theorem_proof` in `blueprint/src/content.tex`.

It also revises the after-blocking chapter title and introductory paragraph so that the displayed decomposition is described as an all-zero tensor plus a weighted direct sum of primitive irreducible blocks. The remaining raw `bridge` labels in the touched Chapter 7 and Chapter 8 passages are renamed to mathematical labels, with the Chapter 7 reference updated accordingly.

### Testing

- `git diff --check`
- `cd blueprint && leanblueprint web`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`

The sync report keeps Chapters 7, 8, 11, and 11b at 100%. It still reports the existing missing declarations in later periodic, PEPS, and parent-Hamiltonian material; those are not changed here.

---
Closes #1656

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes: reorders chapter inclusion and renames a few LaTeX labels/section titles, with minimal chance of broken cross-references if any label is referenced externally.
> 
> **Overview**
> Moves the after-blocking reductions chapter (`ch11b_after_blocking`) to appear *before* `ch11_fundamental_theorem_proof` in `content.tex`, aligning the narrative so prerequisites come first.
> 
> Cleans up blueprint prose and cross-references by renaming leftover "bridge" labels to more descriptive mathematical names (e.g. Burnside subsection label in Chapter 7, arbitrary-input reduction remark in Chapter 8) and updating the corresponding `\ref`s.
> 
> Retitles Chapter 11b and rewrites its opening paragraph to describe the decomposition explicitly as an all-zero tensor plus a weighted direct sum of primitive irreducible blocks; also fixes a missing trailing newline in Chapter 7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30db312e9bb2c8ffd8623ed7fdfe074db308e34d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>