### PR TITLE
doc(blueprint): add literal BNT gauge entry

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1373,3 +1373,40 @@ BNT basis.
     conjugacies into the flattened direct-sum conjugation by
     $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
 \end{proof}
+
+\begin{theorem}[Literal equal-MPV gauge after sector-coordinate permutation]%
+    \label{thm:paper_bnt_equal_mps_gaugeEquiv_literal}
+    \lean{MPSTensor.ft_paper_bnt_equal_mps_gaugeEquiv_literal}
+    \leanok
+    \uses{def:paper_bnt_cf}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
+    MPV family. Assume that every sector of $P$ and every sector of $Q$ has at
+    least one copy weight of modulus $1$. Then the total bond dimensions agree,
+    and there is
+    \[
+        Y\in \GL_{\dim Q_{\mathrm{tot}}}(\C)
+    \]
+    such that, for every physical index $i$,
+    \[
+        Q_{\mathrm{tot}}^i
+        =
+        Y\,\bigl(\operatorname{cast}_{\dim P_{\mathrm{tot}}=\dim Q_{\mathrm{tot}}}
+            P_{\mathrm{tot}}^i\bigr)\,Y^{-1}.
+    \]
+    This is the literal cast-of-$P_{\mathrm{tot}}$ form of
+    \cite[Corollary~II.2 and \S~II.C, lines 1189--1192]
+        {Cirac2017MPDO_AnnPhys},
+    under the same unit-modulus-copy normalization as
+    Theorem~\ref{thm:paper_bnt_equal_global_gauge}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:paper_bnt_equal_global_gauge}
+    Apply Theorem~\ref{thm:paper_bnt_equal_global_gauge} to obtain the
+    matched-coordinate flattened gauge. The sector-coordinate permutation
+    induced by the basis matching, the copy permutations, and the
+    bond-dimension equalities identifies the matched $P$-coordinates with the
+    literal total tensor $P_{\mathrm{tot}}$, transported along the total
+    bond-dimension equality. Composing this permutation gauge with the
+    matched-coordinate gauge gives the displayed single matrix $Y$.
+\end{proof}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1269,7 +1269,7 @@ The non-matched decay clause is delivered in full.
 \label{subsec:paper_bnt_full_basis_global_gauge}
 
 The preceding substitution theorem works on the unit-modulus subset. The
-following two statements record the full-basis form used by the matched-coordinate
+following two statements record the full-basis form used by the sector-permuted
 global gauge. Their hypotheses explicitly require a unit-modulus copy in every
 sector on both sides; under this normalization, the matching covers the whole
 BNT basis.
@@ -1381,32 +1381,33 @@ BNT basis.
     \uses{def:paper_bnt_cf}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
     MPV family. Assume that every sector of $P$ and every sector of $Q$ has at
-    least one copy weight of modulus $1$. Then the total bond dimensions agree,
-    and there is
+    least one copy weight of modulus $1$. Then the total bond dimensions agree;
+    write their common value as $D$. There is
     \[
-        Y\in \GL_{\dim Q_{\mathrm{tot}}}(\C)
+        Y\in \GL_D(\C)
     \]
     such that, for every physical index $i$,
     \[
         Q_{\mathrm{tot}}^i
         =
-        Y\,\bigl(\operatorname{cast}_{\dim P_{\mathrm{tot}}=\dim Q_{\mathrm{tot}}}
-            P_{\mathrm{tot}}^i\bigr)\,Y^{-1}.
+        Y\,P_{\mathrm{tot}}^i\,Y^{-1},
     \]
-    This is the literal cast-of-$P_{\mathrm{tot}}$ form of
+    where $P_{\mathrm{tot}}^i$ and $Q_{\mathrm{tot}}^i$ are both regarded as
+    matrices in $\MN{D}$ using the total bond-dimension equality. This is the
+    normalized BNT form of
     \cite[Corollary~II.2 and \S~II.C, lines 1189--1192]
-        {Cirac2017MPDO_AnnPhys},
-    under the same unit-modulus-copy normalization as
-    Theorem~\ref{thm:paper_bnt_equal_global_gauge}.
+        {Cirac2017MPDO_AnnPhys}, under the same unit-modulus-copy normalization
+    as Theorem~\ref{thm:paper_bnt_equal_global_gauge}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:paper_bnt_equal_global_gauge}
     Apply Theorem~\ref{thm:paper_bnt_equal_global_gauge} to obtain the
-    matched-coordinate flattened gauge. The sector-coordinate permutation
-    induced by the basis matching, the copy permutations, and the
-    bond-dimension equalities identifies the matched $P$-coordinates with the
-    literal total tensor $P_{\mathrm{tot}}$, transported along the total
-    bond-dimension equality. Composing this permutation gauge with the
-    matched-coordinate gauge gives the displayed single matrix $Y$.
+    flattened gauge after the sectors of $P$ have been reindexed by the
+    bijection between basis blocks of $P$ and $Q$. The sector-coordinate
+    permutation $\rho$, induced by this bijection, the copy permutations, and
+    the bond-dimension equalities, identifies the reindexed $P$-side direct sum
+    with the total tensor $P_{\mathrm{tot}}$, transported along the total
+    bond-dimension equality. Composing the permutation gauge for $\rho$ with
+    the sector-permuted gauge gives the displayed single matrix $Y$.
 \end{proof}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -28,8 +28,7 @@ with an extra $Z$-gauge degree of freedom.
 % Lean targets: \texttt{MPSTensor.ft\_paper\_bnt\_equal\_sector\_data},
 % \texttt{MPSTensor.ft\_paper\_bnt\_equal\_global\_gauge}.
 % The literal $\mathrm{II\_cor2}$ coordinate packaging (CPSV16 lines 1184--1192)
-% is the in-flight follow-up; the matched-coordinate global gauge is already
-% complete.
+% is recorded in Chapter~\ref{ch:bnt} for the unit-modulus BNT normalization.
 
 \section{Source theorems}\label{sec:ft_source_theorems}
 
@@ -147,12 +146,14 @@ sums.
 The block-matching conclusion (block-count, bond-dimension, and
 gauge-phase identification of corresponding sectors) and the global
 gauge identification are formalised on the BNT canonical form of
-Chapter~\ref{ch:bnt}. The coordinate packaging of
-\cite[\S~II.C, lines 1184--1192]{Cirac2017MPDO_AnnPhys} is the
-in-flight follow-up.
+Chapter~\ref{ch:bnt}. The literal coordinate packaging of
+\cite[Corollary~II.2 and \S~II.C, lines 1184--1192]
+    {Cirac2017MPDO_AnnPhys}
+is recorded there under the unit-modulus-copy normalization.
 % Maintainer note (Lean): see the declarations
 % MPSTensor.ft_paper_bnt_equal_sector_data and
-% MPSTensor.ft_paper_bnt_equal_global_gauge.
+% MPSTensor.ft_paper_bnt_equal_global_gauge, and
+% MPSTensor.ft_paper_bnt_equal_mps_gaugeEquiv_literal.
 
 \begin{theorem}[Bond dimension equality from unit overlap]%
     \label{thm:equalMPS_dimension_from_unit_overlap}


### PR DESCRIPTION
### Motivation

`MPSTensor.ft_paper_bnt_equal_mps_gaugeEquiv_literal` gives the ordinary equal-MPV gauge theorem after the total bond dimensions of the two BNT tensors have been identified. It corresponds to CPSV16 Corollary II.2 and the coordinate assembly in §II.C lines 1189--1192. The theorem had no blueprint entry.

### Description

This PR adds a checked Chapter 10 theorem entry for `MPSTensor.ft_paper_bnt_equal_mps_gaugeEquiv_literal`.

The blueprint statement explicitly includes the theorem's unit-modulus-copy hypotheses on every BNT sector. For this reason it is added as a scope-restricted BNT-normalized entry, rather than attaching `\leanok` to the unrestricted source Corollary II.2 statement in Chapter 11.

The Chapter 11 equal-MPV discussion now points to the Chapter 10 coordinate-packaging theorem instead of saying that the literal II.2 packaging is still pending.

### Testing

- `git diff --check`
- `cd blueprint && leanblueprint web`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`

The sync report shows Chapter 10 at `46 / 46`; the known unrelated missing declarations in later periodic, PEPS, and parent-Hamiltonian material remain unchanged.

---
Closes #1751

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: LaTeX blueprint-only changes that add a new theorem statement/proof entry and adjust nearby cross-references; no executable code or mathematical content changes beyond documentation/structuring.
> 
> **Overview**
> Adds a new Chapter 10 blueprint theorem, `thm:paper_bnt_equal_mps_gaugeEquiv_literal` (`MPSTensor.ft_paper_bnt_equal_mps_gaugeEquiv_literal`), stating the *literal* equal-MPV global conjugacy `Q_tot^i = Y P_tot^i Y^{-1}` after the sector-coordinate permutation, under the unit-modulus-copy hypothesis.
> 
> Updates Chapter 11 commentary to point readers to this now-recorded coordinate-packaging result (and tweaks wording around the “sector-permuted” global gauge), replacing prior notes that the literal Corollary II.2 packaging was still pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe29ba16ed3cccec2ea2c94a65ec7200c4cadbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->