### PR TITLE
refactor(MPS/BNT): remove retired IsCanonicalFormBNT structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ The source lives in `TNLean/` and is organized into **layers 0-6 with sublayers*
 - `IsInjective A` — matrices of `A` span the full matrix algebra
 - `SameMPV A B` / `SameMPV₂` — same matrix product vector family
 - `GaugeEquiv A B` — conjugation by invertible matrix (`B i = X * A i * X⁻¹`)
-- `IsCanonicalFormBNT` — basis-normal-triangular canonical form predicate
+- `IsBNTCanonicalForm` — paper-faithful basis-of-normal-tensors canonical form predicate
 - `cumulativeSpan A n` — span of all products of length <= n
 - `IsNormal A` — the project's normality notion for Wielandt theory
 - `transferMap A` — the CP map `rho -> sum_i A_i * rho * (A_i)^H`

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -11,38 +11,33 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
 /-!
-# Basis of normal tensors from canonical form
+# Basis of normal tensors from separated block hypotheses
 
-This module introduces `IsCanonicalFormBNT`: hypotheses on a family of tensors
-`A_j` with weights `μ_j` that require
-
-* `IsCanonicalForm` — the tensors are in left-canonical form, with antitone weight moduli,
-* strict ordering `‖μ_j‖ > ‖μ_{j+1}‖`, and
-* distinct blocks with equal dimension are not gauge-phase equivalent.
-
-Equivalent blocks are therefore already merged into a single BNT representative.
-This is not the general BNT normal form of arXiv:1606.00608, which allows repeated
-copies inside a sector with coefficients `μ_{j,q}` and multiplicities `M_j`; those are
-obtained from `SectorDecomposition` and the sector-weight comparison theorems.
+This module records the separated blockwise hypotheses used to pass from
+canonical-form and normal-canonical-form hypotheses to the basis-of-normal-tensors
+formulation. The source BNT expansion in arXiv:1606.00608, Section II keeps
+repeated copies inside a sector with coefficients `μ_{j,q}` and multiplicities
+`M_j`; that paper-faithful structure is represented by `IsBNTCanonicalForm` in the
+fundamental-theorem files. The results here are auxiliary tools for already
+separated finite block families.
 
 ## Main results
 
-1. **`IsCanonicalFormBNT`**: A restricted already-grouped canonical form where no two
-   distinct blocks are gauge-phase equivalent and the representative weight moduli are
-   strictly decreasing.
+1. **`BlocksNotGaugePhaseEquiv`**: the separation condition asserting that distinct
+   equal-dimension blocks are not gauge-phase equivalent.
 
-2. **`cross_overlap_tendsto_zero_of_separated_CFBNT_data`**: distinct CF-BNT blocks have
-   decaying cross-overlaps.  The theorem
-   **`IsCanonicalFormBNT.cross_overlap_tendsto_zero`** states the same conclusion from
-   `IsCanonicalFormBNT`. The proof combines:
+2. **`cross_overlap_tendsto_zero_of_separated_CFBNT_data`**: separated injective
+   left-canonical blocks have decaying cross-overlaps. The proof combines:
    - Dimension-mismatch case: `mpvOverlap_tendsto_zero_of_dim_ne`
    - Same-dimension case: `mpvOverlap_tendsto_zero` (using `blocks_not_equiv` to supply
      `¬GaugePhaseEquiv`)
 
-3. **`isBNT_of_separated_CFBNT_data`**: the restricted separated block hypotheses give
+3. **`isBNT_of_separated_CFBNT_data`**: the separated block hypotheses give
    a valid `IsBNT` structure with the required overlap and independence properties.
-   The lemma **`IsCanonicalFormBNT.isBNT`** states the same implication under
-   `IsCanonicalFormBNT`.
+
+4. **`IsNormalCanonicalFormBNT`**: normal-canonical separated hypotheses retained for
+   the primitive-transfer-map route. Its forgetful projections feed the explicit
+   separated-hypotheses lemmas.
 
 ## Design note on coefficients
 
@@ -50,12 +45,10 @@ In the full paper (arXiv:1606.00608, eq. decBSV), the decomposition into a basis
 tensors uses summed coefficients `c_j(N) = Σ_{q in group j} μ_{j,q}^N`.
 In the strict-dominance branch one first normalizes by the dominant weight, so the relevant
 coefficients are `(μ j / μ 0)^N` and the discarded factor `μ 0^N` is absorbed into the overall
-proportionality constant. In the grouped setting, the normalized sums can still oscillate: unit-
-modulus terms may survive inside a single group. The present `IsCanonicalFormBNT` hypotheses
-sidestep that issue by requiring that the grouping has already been done (each block in the
-basis of normal tensors corresponds to a single CF block).  The previous theorem layer that took
-explicit proportional-decomposition coefficient arrays as hypotheses has been removed: those
-arrays are not the source statement of CPSV16 Theorem II.1.
+proportionality constant. In the grouped setting, the normalized sums can still oscillate:
+unit-modulus terms may survive inside a single group. The source-faithful treatment of these
+coefficients is carried out in the sector-decomposition results and the paper-BNT canonical
+form constructions.
 -/
 
 open scoped Matrix BigOperators
@@ -71,103 +64,6 @@ abbrev BlocksNotGaugePhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
   ∀ j k : Fin r, j ≠ k →
     ∀ h : dim j = dim k,
       ¬ GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (A j)) (A k)
-
-/-! ### `IsCanonicalFormBNT` hypotheses -/
-
-/-- **Canonical form with basis-of-normal-tensors (BNT) separation**: extends
-`IsCanonicalForm` with the requirement that distinct blocks are not gauge-phase equivalent
-and that the block weight moduli are **strictly decreasing**.
-
-The strictly decreasing condition is a special already-grouped hypothesis.  The base
-`IsCanonicalForm` only requires non-increasing (`Antitone`) moduli, and the general BNT
-comparison in arXiv:1606.00608 keeps repeated copies inside sectors rather than forcing every
-equal-modulus family into a single strict-norm representative.
-
-In the language of arXiv:2011.12127 Definition 4.2, this corresponds to a canonical form where
-each basis element has already been represented by one CF block. It is not the paper's biCF
-condition; block-injectivity is a further fixed-length span input.
-
-**Scope restriction (one-copy-per-sector)**: Every theorem whose hypothesis includes
-`IsCanonicalFormBNT` is restricted to the special case where every sector contains exactly
-one BNT block (multiplicity `r_j = 1` for all `j`).  The paper's general Corollary II.2
-(arXiv:1606.00608) allows `r_j ≥ 1` copies per sector with weights `μ_{j,1}, …, μ_{j,r_j}`,
-and recovers multiplicities via Newton–Girard (`Lem:app_simple`) applied to the identity
-`∑_q μ_{j,q}^N = ∑_q (ν_{j,q} e^{iφ_j})^N`.  That recovery step is absent from the
-current formalization.  See `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
--- SCOPE(one-copy-per-sector): mu_strict_anti forces r_j = 1; all downstream FT theorems
--- are restricted to this special case. See ft_one_copy_scope_restriction.tex.
-structure IsCanonicalFormBNT {r : ℕ} {dim : Fin r → ℕ}
-    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) : Prop extends
-    IsCanonicalForm μ A where
-  /-- Strict ordering of block weight moduli.  This forces one representative per modulus
-  class (multiplicity `r_j = 1`); the general BNT allows equal-modulus copies within a
-  sector.  See the scope-restriction note on `IsCanonicalFormBNT`. -/
-  -- SCOPE(one-copy-per-sector): this field is the load-bearing restriction.
-  mu_strict_anti : StrictAnti (fun k : Fin r => ‖μ k‖)
-  /-- Distinct blocks are not gauge-phase equivalent (BNT separation). -/
-  blocks_not_equiv : ∀ j k : Fin r, j ≠ k →
-    ∀ (h : dim j = dim k),
-      ¬ GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (A j)) (A k)
-
-namespace IsCanonicalFormBNT
-
-variable {r : ℕ} {dim : Fin r → ℕ}
-variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
-
-/-- Project CF-BNT hypotheses to blockwise injectivity. -/
-def toHasInjectiveBlocks (hCF : IsCanonicalFormBNT μ A) : HasInjectiveBlocks (d := d) A :=
-  hCF.toIsCanonicalForm.toHasInjectiveBlocks
-
-/-- Project CF-BNT hypotheses to left-canonical block-family normalization. -/
-def toIsLeftCanonicalBlockFamily (hCF : IsCanonicalFormBNT μ A) :
-    IsLeftCanonicalBlockFamily (d := d) A :=
-  hCF.toIsCanonicalForm.toIsLeftCanonicalBlockFamily
-
-/-- Project restricted CF-BNT hypotheses to strict weight inequalities.
-
-This projection is for the already-grouped single-representative special case, not
-for the full CPSV multiplicity BNT surface. -/
-def toHasStrictOrderedNonzeroWeights (hCF : IsCanonicalFormBNT μ A) :
-    HasStrictOrderedNonzeroWeights μ where
-  mu_strict_anti := hCF.mu_strict_anti
-  mu_ne_zero := hCF.toIsCanonicalForm.mu_ne_zero
-
-/-- Project CF-BNT hypotheses to self-overlap normalization. -/
-def toHasNormalizedSelfOverlap (hCF : IsCanonicalFormBNT μ A) :
-    HasNormalizedSelfOverlap (d := d) A :=
-  hCF.toIsCanonicalForm.toHasNormalizedSelfOverlap
-
-/-- Rebuild `IsCanonicalFormBNT` from the additive split formulation plus the BNT
-separation assumption. -/
-def ofSeparatedData
-    (hInj : HasInjectiveBlocks (d := d) A)
-    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
-    (hμ : HasStrictOrderedNonzeroWeights μ)
-    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
-    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A) :
-    IsCanonicalFormBNT μ A where
-  toIsCanonicalForm := IsCanonicalForm.ofStrictSeparatedData hInj hLeft hμ hOverlap
-  mu_strict_anti := hμ.mu_strict_anti
-  blocks_not_equiv := hBlocks
-
-end IsCanonicalFormBNT
-
-/-- An `IsCanonicalForm` family with pairwise distinct block dimensions and strictly
-decreasing moduli automatically satisfies `IsCanonicalFormBNT`, since the separation assumption
-is vacuous. -/
-theorem IsCanonicalForm.toIsCanonicalFormBNT_of_distinct_dims
-    {r : ℕ} {dim : Fin r → ℕ}
-    {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
-    (hCF : IsCanonicalForm μ A)
-    (hStrict : StrictAnti (fun k : Fin r => ‖μ k‖))
-    (hDistinct : Function.Injective dim) :
-    IsCanonicalFormBNT μ A :=
-  IsCanonicalFormBNT.ofSeparatedData
-    hCF.toHasInjectiveBlocks
-    hCF.toIsLeftCanonicalBlockFamily
-    ⟨hStrict, hCF.mu_ne_zero⟩
-    hCF.toHasNormalizedSelfOverlap
-    (fun _ _ hjk h => absurd (hDistinct h) hjk)
 
 /-! ### `IsNormalCanonicalFormBNT` hypotheses -/
 
@@ -371,7 +267,7 @@ theorem cross_overlap_tendsto_zero_of_separated_CFBNT_data
       (hLeft.leftCanonical k)
       hdim
 
-/-- Separated-hypotheses version of `IsCanonicalFormBNT.isBNT`.
+/-- Separated-hypotheses construction of an `IsBNT` witness.
 
 The only role of `μ` is to specify the block-diagonal tensor `toTensorFromBlocks μ A` and its
 obvious coefficient decomposition.  Strict weight ordering is not used here. -/
@@ -392,45 +288,6 @@ lemma isBNT_of_separated_CFBNT_data [∀ k, NeZero (dim k)]
         cross_overlap_tendsto_zero_of_separated_CFBNT_data A hInj hLeft hBlocks i j hij)
 
 end SeparatedCFBNT
-
-namespace IsCanonicalFormBNT
-
-variable {r : ℕ} {dim : Fin r → ℕ}
-variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
-
-/-! ### Cross-overlap decay -/
-
-/-- **Cross-overlap decay for CF-BNT blocks**: distinct blocks have
-`mpvOverlap (A j) (A k) N → 0` as `N → ∞`.
-
-This theorem is a direct consequence of
-`cross_overlap_tendsto_zero_of_separated_CFBNT_data`. -/
-theorem cross_overlap_tendsto_zero
-    [∀ k, NeZero (dim k)]
-    (hCF : IsCanonicalFormBNT μ A) (j k : Fin r) (hjk : j ≠ k) :
-    Tendsto (fun N => mpvOverlap (d := d) (A j) (A k) N) atTop (nhds 0) :=
-  cross_overlap_tendsto_zero_of_separated_CFBNT_data A
-    hCF.toHasInjectiveBlocks
-    hCF.toIsLeftCanonicalBlockFamily
-    hCF.blocks_not_equiv
-    j k hjk
-
-/-! ### BNT structure from CF-BNT -/
-
-/-- A canonical-form decomposition into a basis of normal tensors yields a valid `IsBNT`
-structure.
-
-This lemma is a direct consequence of `isBNT_of_separated_CFBNT_data`. -/
-lemma isBNT [∀ k, NeZero (dim k)]
-    (hCF : IsCanonicalFormBNT μ A) :
-    IsBNT (toTensorFromBlocks μ A) r dim A :=
-  isBNT_of_separated_CFBNT_data μ A
-    hCF.toHasInjectiveBlocks
-    hCF.toIsLeftCanonicalBlockFamily
-    hCF.toHasNormalizedSelfOverlap
-    hCF.blocks_not_equiv
-
-end IsCanonicalFormBNT
 
 /-! ### Cross-overlap decay from separated normal-CF-BNT hypotheses -/
 

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean
@@ -55,12 +55,12 @@ sector's coefficient is then derived inside the proof via
 `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block`
 (`PaperBNT/Api.lean`), now also taking the same per-block hypothesis.
 
-These hypotheses are weaker than the legacy `IsCanonicalFormBNT` package
-(which baked in `mu_strict_anti` + a single per-sector "spectral level"
-weight); they are also weaker than the optional `HasEqualModulusWeightLayer`
-layer of `PaperBNT/EqualModulus.lean`, which would imply both bounds via the
-`spectral_level_dom_norm_one` + `spectral_level_antitone` + `phase_weight`
-factorisation.
+These hypotheses are weaker than the older already-separated canonical-form
+hypotheses, which combined strict weight-modulus ordering with a single
+per-sector spectral-level weight. They are also weaker than the optional
+`HasEqualModulusWeightLayer` layer of `PaperBNT/EqualModulus.lean`, which would
+imply both bounds via the `spectral_level_dom_norm_one` +
+`spectral_level_antitone` + `phase_weight` factorisation.
 
 ## Output for Phase 4b-iii
 

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -420,9 +420,9 @@ This structure is a deliberate parameterization — the analytic half of the
 overlap-rigidity route.  It records the per-family convergence properties that follow
 from the basis-of-normal-tensors definition in arXiv:1606.00608, Section II, lines 271–274.
 The combined two-family structure `SectorBasisOverlapSpanHypotheses` adds the injectivity
-and span-comparison fields.  When the after-blocking BNT cover is discharged
+and span-comparison fields. When the after-blocking BNT cover is discharged
 (tracker #1498, sub-issue #1501), the fields recorded here are consequences of the
-CF-BNT structure already present in `IsCanonicalFormBNT`. -/
+paper-faithful sector structure recorded in `IsBNTCanonicalForm`. -/
 structure SectorBasisOverlapOrthoHypotheses (P : SectorDecomposition d) : Prop where
   /-- The basis blocks have nonzero bond dimension. -/
   dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/Span.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/Span.lean
@@ -360,11 +360,12 @@ certificates required by `hPad`.
 Wielandt-bound construction is not formalized here. The auxiliary results
 `exists_pairTraceSeparatingAt_of_not_gaugePhaseEquiv_of_pairWordTupleSpanTop_period_window`
 (single-pair, same-dimension case) and
-`exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_identity_period_windows`
-(canonical-form BNT family) reduce the missing implication to a
-period-window hypothesis on the homogeneous pair span. A formal
-Wielandt-bound theorem would produce that period-window hypothesis from
-the canonical-form hypotheses and thereby establish `hPad`. -/
+`exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv`
+(finite-family separated blocks, with the direct-sum injectivity hypotheses
+still explicit) isolate the missing input as a homogeneous pair-span
+period-window hypothesis. A formal Wielandt-bound theorem would produce that
+period-window hypothesis from the canonical-form hypotheses and thereby
+establish `hPad`. -/
 theorem pairWordTupleSpanTop_of_pairCumulativeWordTupleSpanTop_of_identity_padding
     {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S T : ℕ}
     (hST : S ≤ T)

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -125,55 +125,6 @@ and~\cite{Cirac2021Matrix}.
     blocks are not gauge-phase equivalent.
 \end{definition}
 
-\begin{definition}[Canonical form with BNT separation]\label{def:cf_bnt}
-    \lean{MPSTensor.IsCanonicalFormBNT}
-    \leanok
-    \uses{def:is_canonical_form, def:blocks_not_gauge_phase_equiv}
-    A family is in \emph{canonical form with BNT separation}
-    if it satisfies Definition~\ref{def:is_canonical_form} and,
-    in addition:
-    \begin{enumerate}
-        \item the moduli are \emph{strictly} decreasing:
-              $|\mu_1| > |\mu_2| > \cdots > |\mu_r|$
-              (strengthened from the non-increasing ordering
-              of Definition~\ref{def:is_canonical_form}),
-        \item distinct blocks of the same bond dimension are
-              \emph{not} gauge-phase equivalent.
-    \end{enumerate}
-    This is an already grouped special case. In the source BNT expansion
-    of \cite[Section~2.3]{Cirac2016MPDO_arXiv}, repeated copies of a
-    selected basis tensor appear as
-    \[
-        A^i
-        = \bigoplus_{j=1}^g \bigoplus_{q=1}^{r_j}
-        \mu_{j,q} X_{j,q} A_j^i X_{j,q}^{-1}.
-    \]
-    The coefficients $\mu_{j,q}$, multiplicities $r_j$, and gauges
-    $X_{j,q}$ are not part of this restricted single-representative
-    definition. This definition therefore records only strict weight
-    ordering and the absence of phase-gauge equivalence among the selected
-    blocks. It is not the source notion of block-injective canonical form,
-    which is the fixed-length direct-sum span condition discussed in
-    Chapter~\ref{ch:wielandt} and Chapter~\ref{ch:ft_proof}.
-\end{definition}
-
-\begin{theorem}[Distinct bond dimensions force BNT separation]
-    \label{thm:cf_bnt_distinct_dims}
-    \lean{MPSTensor.IsCanonicalForm.toIsCanonicalFormBNT_of_distinct_dims}
-    \leanok
-    \uses{def:is_canonical_form, def:cf_bnt}
-    If a canonical-form family has strictly decreasing weight moduli and
-    pairwise distinct bond dimensions, then it is in canonical form with BNT
-    separation.
-\end{theorem}
-
-\begin{proof}\leanok
-    The only new clause in Definition~\ref{def:cf_bnt} is the prohibition on
-    gauge-phase equivalence between distinct blocks of the same bond
-    dimension. When the bond dimensions are pairwise distinct, this clause is
-    vacuous.
-\end{proof}
-
 \begin{definition}[Normal canonical form with BNT separation]\label{def:normal_cf_bnt}
     \lean{MPSTensor.IsNormalCanonicalFormBNT}\leanok
     \uses{def:is_normal_canonical_form, def:blocks_not_gauge_phase_equiv}
@@ -188,9 +139,8 @@ and~\cite{Cirac2021Matrix}.
         \item the dominant block has unit modulus, $\|\mu_1\| = 1$
               (\cite[paragraph after \texttt{eq:II\_CF1}]{Cirac2016MPDO_arXiv}).
     \end{enumerate}
-    As in Definition~\ref{def:cf_bnt}, the strict ordering describes an
-    already selected or grouped representative family. It is not the source
-    BNT expansion
+    The strict ordering describes an already selected or grouped
+    representative family. It is not the source BNT expansion
     \[
         A^i
         = \bigoplus_{j=1}^g \bigoplus_{q=1}^{r_j}
@@ -243,20 +193,6 @@ and~\cite{Cirac2021Matrix}.
     Theorem~\ref{thm:overlap_decay} gives the decay.
 \end{proof}
 
-\begin{theorem}[Cross-overlap decay for BNT-separated blocks]\label{thm:cross_overlap_zero}
-    \lean{MPSTensor.IsCanonicalFormBNT.cross_overlap_tendsto_zero}
-    \leanok
-    \uses{def:cf_bnt, def:mpv_overlap}
-    If $((\mu_k), (A_k))$ is in canonical form with BNT separation and
-    $j \neq k$, then $O_{A_j A_k}(N) \to 0$.
-\end{theorem}
-
-\begin{proof}\leanok\uses{def:cf_bnt, thm:cross_overlap_zero_split}
-    Definition~\ref{def:cf_bnt} supplies injectivity, left-canonical
-    normalization, and the BNT separation hypothesis, so
-    Theorem~\ref{thm:cross_overlap_zero_split} applies directly.
-\end{proof}
-
 \begin{lemma}[BNT from explicit blockwise hypotheses]
     \label{lem:cf_bnt_is_bnt_split}
     \lean{MPSTensor.isBNT_of_separated_CFBNT_data}
@@ -277,21 +213,6 @@ and~\cite{Cirac2021Matrix}.
     Theorem~\ref{thm:cross_overlap_zero_split} supplies the off-diagonal
     decay. Therefore Lemma~\ref{lem:bnt_overlap_orthonormal_li} gives the
     eventual linear independence required in Definition~\ref{def:bnt}.
-\end{proof}
-
-\begin{lemma}[Restricted CF-BNT hypotheses yield a basis of normal tensors]\label{lem:cf_bnt_is_bnt}
-    \lean{MPSTensor.IsCanonicalFormBNT.isBNT}
-    \leanok
-    \uses{def:cf_bnt, def:bnt}
-    If $((\mu_k), (A_k))$ is in canonical form with BNT separation, then
-    the block tensors form a basis of normal tensors for the
-    block-diagonal tensor $\bigoplus_k \mu_k A_k$.
-\end{lemma}
-
-\begin{proof}\leanok\uses{def:cf_bnt, lem:cf_bnt_is_bnt_split}
-    Definition~\ref{def:cf_bnt} provides injective blocks, left-canonical
-    normalization, normalized self-overlaps, and BNT separation. Hence
-    Lemma~\ref{lem:cf_bnt_is_bnt_split} applies.
 \end{proof}
 
 \begin{remark}[Comparing the two normality conditions]%
@@ -449,7 +370,6 @@ and~\cite{Cirac2021Matrix}.
 \begin{lemma}[Strict-dominance coefficient ratios]
     \label{lem:strict_dominance_coefficient_ratios}
     \notready
-    \uses{def:cf_bnt}
     Let $(\mu_k)_k$ be a strictly ordered nonzero weight family with
     $\mu_0$ dominant. Then the normalized powers
     $(\mu_k/\mu_0)^N$ converge to $1$ for the dominant block and to

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -156,7 +156,7 @@ subject of \emph{Option~2} in the design memo
 not addressed in this note. The hypothesis is needed to discharge the
 non-dominant branch of the abstract $\leanid{hNoCancel}$ field on the
 two-layer surface and ultimately to close the
-\leanid{IsCanonicalFormBNT}-surface declarations
+\leanid{IsNormalCanonicalFormBNT}-formulation declarations
 \leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}
 and its symmetric counterpart
 in

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -8,7 +8,7 @@
 \input{command}
 
 \title{Non-Dominant Per-Block Projection in CPSV16 \S II Step~1\\
-       under the One-Copy \leanid{IsCanonicalFormBNT} Surface}
+       under the One-Copy Normal-Canonical BNT Formulation}
 \author{}
 \date{2026-05-13}
 
@@ -43,14 +43,15 @@ $c_N\ne 0$ cofinally,
 formalized as
 \leanid{EventuallyNonzeroProportionalMPV\textsubscript{2}}.
 
-The BNT canonical form \leanid{IsCanonicalFormBNT} carries a single
-weight $\mu_k$ per sector with strict ordering
+The surviving one-copy normal-canonical BNT formulation
+\leanid{IsNormalCanonicalFormBNT} carries a single weight $\mu_k$ per
+sector with strict ordering
 \begin{align}
     \|\mu_1\|>\|\mu_2\|>\cdots>\|\mu_r\|
     \tag{\leanid{mu\_strict\_anti}}
 \end{align}
 across the entire family.\footnote{%
-    \leanid{MPSTensor.IsCanonicalFormBNT.mu\_strict\_anti} in
+    \leanid{MPSTensor.IsNormalCanonicalFormBNT.mu\_strict\_anti} in
     \doclink{TNLean/MPS/BNT/Construction}.}
 Together with the dominant normalization $\|\mu_1\|=1$, every
 sub-dominant block has modulus strictly less than~$1$.
@@ -59,7 +60,7 @@ source structure as a two-layer canonical form: spectral levels
 $\lambda_j$ with $\|\lambda_1\|>\cdots>\|\lambda_g\|$ factored from
 within-sector unit-modulus weights $\mu_{j,q}$ ($\|\mu_{j,q}\|=1$)
 with sector multiplicities $r_j\ge 1$. The
-\leanid{IsCanonicalFormBNT} surface is the one-copy specialization
+\leanid{IsNormalCanonicalFormBNT} formulation is the one-copy specialization
 $r_j=1$ of that structure; see
 \path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}.
 
@@ -89,7 +90,8 @@ The formal target is, for $k_0:\mathrm{Fin}\,r_B$ arbitrary,\footnote{%
     \leanid{MPSTensor.fixed\_left\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}
     at line~152.}
 \leanid{MPSTensor.fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}:
-given \leanid{IsCanonicalFormBNT} on both $\mu^A,A$ and $\mu^B,B$,
+given the one-copy normal-canonical BNT hypotheses on both $\mu^A,A$ and
+$\mu^B,B$,
 \leanid{EventuallyNonzeroProportionalMPV\textsubscript{2}} between the
 assembled tensors, an index $k_0:\mathrm{Fin}\,r_B$ and the hypothesis
 $\forall j,\langle V^{(N)}(A_j),V^{(N)}(B_{k_0})\rangle\to 0$, derive
@@ -119,7 +121,9 @@ and $\mathrm{RHS}_N:=c_N\langle V^{(N)}(B_{\mathrm{tot}}),V^{(N)}(B_{k_0})\rangl
 With $\|\mu^A_j\|\le 1$, every $(\mu^A_j)^N$ is bounded; together with
 \eqref{eq:Hk0} this forces $\mathrm{LHS}_N\to 0$. For $\mathrm{RHS}_N$,
 BNT cross-overlap decay\footnote{%
-    \leanid{MPSTensor.IsCanonicalFormBNT.cross\_overlap\_tendsto\_zero}.}
+    \leanid{MPSTensor.IsNormalCanonicalFormBNT.cross\_overlap\_tendsto\_zero};
+    the explicit separated-hypotheses form is
+    \leanid{MPSTensor.cross\_overlap\_tendsto\_zero\_of\_separated\_CFBNT\_data}.}
 gives $\langle V^{(N)}(B_k),V^{(N)}(B_{k_0})\rangle\to 0$ for $k\ne k_0$
 and a nonzero limit $\ell$ at $k=k_0$, so
 $\mathrm{RHS}_N=c_N(\mu^B_{k_0})^N(\ell+o(1))$.
@@ -218,8 +222,8 @@ because the cited mechanism requires either
 The collapse $r_j=1$ enforced by \leanid{mu\_strict\_anti}
 identifies the two layers into a single weight; once collapsed, the
 non-dominant Step~1 conclusion cannot be reached by per-block
-projection on the \leanid{IsCanonicalFormBNT} surface because both
-sides of the projected proportionality decay together.
+projection under the one-copy normal-canonical BNT formulation because
+both sides of the projected proportionality decay together.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -81,9 +81,10 @@ The three conditions are a \emph{specialization} (additional hypotheses
 on top of \eqref{eq:bnt-general}), not a deviation: every
 \leanid{IsBNTCanonicalFormSD} instance arises from a valid
 \eqref{eq:bnt-general} decomposition by grouping and normalizing.
-The adapter \leanid{IsCanonicalFormBNT.toIsBNTCanonicalFormSD} constructs
-this decomposition from the one-copy-per-sector
-\leanid{IsCanonicalFormBNT} predicate via rescaling by $\rho = \|\mu_0\|$.
+The planned adapter from the one-copy normal-canonical BNT formulation to
+\leanid{IsBNTCanonicalFormSD} must now be stated from
+\leanid{IsNormalCanonicalFormBNT}, or from explicit separated-block
+hypotheses, via rescaling by $\rho = \|\mu_0\|$.
 
 \section{Scope restriction}
 
@@ -108,8 +109,8 @@ The relevant formal declarations are:
         the unit-modulus factorization accessor.
   \item \leanid{IsBNTCanonicalFormSD.spectralLevel\_dom\_norm\_one} -
         the dominant normalization accessor.
-  \item \leanid{IsCanonicalFormBNT.toIsBNTCanonicalFormSD} -
-        the adapter from the one-copy-per-sector surface.
+  \item A future adapter from \leanid{IsNormalCanonicalFormBNT}, or from
+        explicit separated-block hypotheses, to \leanid{IsBNTCanonicalFormSD}.
 \end{itemize}
 See also \ghpr{1657} (branch \path{feat/mps-ft-path-beta-pr1-two-layer})
 and the audit memo

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -141,14 +141,12 @@ The two branches are combined for all ordered pairs of distinct blocks of a
 BNT family at the common length $3L$, and the result is fed into the
 selector and product-span construction.\footnote{%
 \leanid{MPSTensor.forall\_pairTraceSeparatingAt\_threeBlock\_of\_blocksNotGaugePhaseEquiv};
-\leanid{MPSTensor.exists\_pos\_productWordSpan\_of\_isCanonicalFormBNT\_of\_directSum\_threeBlock}.}
+\leanid{MPSTensor.exists\_forall\_pairTraceSeparatingAt\_threeBlock\_of\_blocksNotGaugePhaseEquiv}.}
 
-The already-injective BNT surface is closed by three wrapper
-theorems:\footnote{%
-\leanid{MPSTensor.forall\_pairTraceSeparatingAt\_of\_isCanonicalFormBNT\_of\_directSum\_injectiveBlocks},
-\leanid{MPSTensor.exists\_pos\_productWordSpan\_of\_isCanonicalFormBNT\_of\_directSum\_injectiveBlocks},
-\leanid{MPSTensor.exists\_wordTupleSpanTop\_of\_isCanonicalFormBNT\_of\_directSum\_injectiveBlocks}.}
-when the selected BNT blocks are already injective at the required common
+The already-injective BNT conclusion should now be stated either from
+\leanid{IsNormalCanonicalFormBNT} together with the required injective-block
+hypotheses, or directly from explicit separated-block hypotheses. In that
+form, when the selected BNT blocks are already injective at the required common
 length, the exact-length direct-sum span is a theorem rather than a remaining
 identity-padding assumption.
 
@@ -167,17 +165,19 @@ exact-length span for a canonical-form BNT family.\footnote{%
 \section{Conclusion}
 
 The formalized wrappers cover the $L_0=1$ case: when the selected BNT blocks
-are already injective at length one (as supplied by \leanid{IsCanonicalFormBNT}
-combined with irreducible-block hypotheses), their pairwise
-not-gauge-phase-equivalence data and the fixed lengths from one-site injectivity
-imply the homogeneous pair-trace separation and product-word-span conclusions
-needed downstream. For this special case the formal result matches the
+are already injective at length one (as supplied by the one-copy
+normal-canonical BNT formulation together with irreducible-block hypotheses),
+their pairwise not-gauge-phase-equivalence data and the fixed lengths from
+one-site injectivity imply the homogeneous pair-trace separation and
+product-word-span conclusions needed downstream. For this special case the
+formal result matches the
 paper's conclusion: distinct BNT representatives yield a direct-sum span at a
 common finite length. However, it does not formalize the full generality of the
 paper's direct-sum theorem. The older representation paper states the result for
 arbitrary $L_0$, ordered block sizes, and $b\ge2$ blocks; those features are
-replaced here by the \leanid{IsCanonicalFormBNT} assumptions. The general-$L_0$
-case, in which each normal block needs a Wielandt-type blocking step to reach
+replaced here by one-copy normal-canonical BNT and explicit separated-block
+hypotheses. The general-$L_0$ case, in which each normal block needs a
+Wielandt-type blocking step to reach
 length-$L_0$ injectivity, is not covered by these wrappers alone; it requires
 the separate bounded and common injective-blocking results. The old warning
 against replacing exact-length span by cumulative span therefore remains

--- a/docs/paper-gaps/ft_one_copy_scope_restriction.tex
+++ b/docs/paper-gaps/ft_one_copy_scope_restriction.tex
@@ -62,9 +62,10 @@ identities in $N$, without any passage to a limit.
 
 \section{The one-copy-per-sector restriction}
 
-The formal canonical form structures\footnote{%
-    \path{TNLean/MPS/BNT/Construction.lean}: \leanid{IsCanonicalFormBNT} at lines
-    96--104, \leanid{IsNormalCanonicalFormBNT} at lines 181--198.} impose
+The surviving formal one-copy canonical form structure\footnote{%
+    \path{TNLean/MPS/BNT/Construction.lean}: \leanid{IsNormalCanonicalFormBNT}.
+    The earlier non-normal wrapper was retired after its downstream consumers
+    were replaced by explicit separated-block hypotheses.} imposes
 \emph{strict} decreasing moduli across the entire index set: every block has a
 distinct modulus. This is a stronger condition than the source structure, which
 only requires strict ordering of the modulus \emph{classes} while allowing
@@ -110,13 +111,14 @@ linear-independence data and the equal-MPV condition is still not carried out.
 This derivation is logically prior to applying \texttt{Lem:app\_simple}.
 
 \textbf{Multi-copy sector structure.}
-The formal structures \leanid{IsCanonicalFormBNT} and
-\leanid{IsNormalCanonicalFormBNT} would need a field allowing equal-modulus
-groups: rather than a global strict ordering on the full index set, the
-condition should be a strict ordering on the set of modulus classes, with each
-class admitting an arbitrary finite number of representative blocks. Relaxing
-\leanid{mu\_strict\_anti} to this weaker form is the necessary type-level
-change. Without it, the general-multiplicity versions of
+The surviving one-copy structure \leanid{IsNormalCanonicalFormBNT}, and any
+future non-normal analogue stated with explicit separated-block hypotheses,
+would need a field allowing equal-modulus groups: rather than a global strict
+ordering on the full index set, the condition should be a strict ordering on
+the set of modulus classes, with each class admitting an arbitrary finite
+number of representative blocks. Relaxing \leanid{mu\_strict\_anti} to this
+weaker form is the necessary type-level change. Without it, the
+general-multiplicity versions of
 Corollary~\texttt{II\_cor2} and of the gauge assembly step cannot be stated.
 
 \textbf{Global gauge assembly.}

--- a/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
@@ -480,13 +480,13 @@ The source comparison above translates into the following formal targets.
 The present formalization already separates the source theorem into the same
 mathematical layers.
 
-The canonical-form BNT surface is encoded as canonical form plus strict weight
-ordering and non-equivalence of distinct
-representatives.\footnote{\leanid{IsCanonicalFormBNT},
+The surviving one-copy normal-canonical BNT formulation is encoded by
+\leanid{IsNormalCanonicalFormBNT}, together with the explicit separated-block
+hypotheses used by the BNT comparison lemmas.\footnote{%
 \path{TNLean/MPS/BNT/Construction.lean}.}
-This is a restricted already-grouped surface: it suppresses the repeated-copy
-data $r_j,\mu_{j,q}$ that appear in the BNT expansion and Appendix BNT
-characterization of \cite{Cirac2016MPDO_arXiv}.
+This is a restricted already-grouped formulation: it suppresses the
+repeated-copy data $r_j,\mu_{j,q}$ that appear in the BNT expansion and
+Appendix BNT characterization of \cite{Cirac2016MPDO_arXiv}.
 The former coefficient-array structures and conditional proportional comparison
 theorems have been deleted. Their one-shot bounded coefficient hypotheses did
 not encode the residual peeling or power-sum comparison in the source paper.


### PR DESCRIPTION
### Motivation

- `IsCanonicalFormBNT` was a wrapper structure bundling one-copy canonical-form hypotheses for BNT tensors. Its downstream consumers were removed in previous cleanup waves (#1736, #1738, #1740, #1743, #1737, #1711, #1715), leaving it with no remaining call sites.
- Removing it completes Phase 7 of the paper-faithful restatement effort tracked in #1691, while keeping the explicit separated-block hypotheses and the `IsNormalCanonicalFormBNT` route.

### Description

- Deletes the `IsCanonicalFormBNT` structure, its four forgetful projections, the `ofSeparatedData` reconstructor, the `toIsCanonicalFormBNT_of_distinct_dims` corollary, and the wrapper lemmas `IsCanonicalFormBNT.isBNT` and `IsCanonicalFormBNT.cross_overlap_tendsto_zero` from `TNLean/MPS/BNT/Construction.lean`.
- Retains the explicit separated-hypotheses results (`BlocksNotGaugePhaseEquiv`, `cross_overlap_tendsto_zero_of_separated_CFBNT_data`, `isBNT_of_separated_CFBNT_data`) and the `IsNormalCanonicalFormBNT` pathway.
- Rewrites docstring mentions in `SectorDecomposition.lean`, `PaperBNT/DominantMatch.lean`, and `PairHomogenization/Span.lean` to reference `IsBNTCanonicalForm`, `IsNormalCanonicalFormBNT`, or explicit separated-block hypotheses.
- Removes the corresponding Chapter 10 blueprint entries from `blueprint/src/chapter/ch10_bnt.tex` and the now-stale `\uses{def:cf_bnt}` dependency.
- Updates six paper-gap notes so the mathematical traceability documents no longer cite the retired declaration; the planned adapter is now described as a future map from `IsNormalCanonicalFormBNT` or explicit separated-block hypotheses.
- No MPDO, parent-Hamiltonian, `Channel/Semigroup/Resolvent.lean`, or PEPS module is deleted.

### Testing

- `lake env lean TNLean/MPS/BNT/Construction.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/PaperBNT/DominantMatch.lean`
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/Span.lean`
- `lake build TNLean`
- `rg -n "IsCanonicalFormBNT|isCanonicalFormBNT" TNLean docs/paper-gaps` returned no hits
- `leanblueprint web` completed with the repository's usual local renderer and bibliography warnings
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` reports Chapter 10 as `42 / 42`; remaining missing declarations are pre-existing later-chapter entries (parent-Hamiltonian, periodic, and PEPS)

---
Closes #1756

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a deletion of an unused wrapper structure plus doc/comment/blueprint updates, with no changes to core proofs or algorithms beyond switching references to existing separated-block hypotheses and `IsNormalCanonicalFormBNT`. Main risk is broken downstream imports/references if any missed call sites remain.
> 
> **Overview**
> Removes the legacy `IsCanonicalFormBNT` wrapper from `TNLean/MPS/BNT/Construction.lean` (and its projections/reconstructors and wrapper lemmas), leaving the explicit separated-block hypotheses (`BlocksNotGaugePhaseEquiv`, `cross_overlap_tendsto_zero_of_separated_CFBNT_data`, `isBNT_of_separated_CFBNT_data`) and the `IsNormalCanonicalFormBNT` pathway as the supported interfaces.
> 
> Updates surrounding documentation and blueprint/paper-gap notes to stop citing the retired structure, and to refer instead to `IsBNTCanonicalForm`, `IsNormalCanonicalFormBNT`, or the explicit separated-block hypotheses (including removing the corresponding Chapter 10 blueprint entries for the deleted wrapper theorems).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81da340f9da9635eb7343ed5a410a48effc7065a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->