### PR TITLE
doc(paper-gaps): update retired Tier 3 references

### DIFF
--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -8,7 +8,7 @@
 \input{command}
 
 \title{Rate-Quantified BNT Cross-Overlap Decay\\
-       on the \leanid{SectorDecomposition} Surface}
+       on the \leanid{PaperBNT} Sector Surface}
 \author{}
 \date{2026-05-13}
 
@@ -62,26 +62,24 @@ The argument as written does not quantify the rate of decay in
 
 Definition~4.3 of~\cite{Cirac2021Matrix} packages
 \eqref{eq:qual} indirectly under \emph{eventual linear independence} of
-the basis MPVs and does not state a rate. The formal counterpart is
-the predicate
-\leanid{MPSTensor.HasBNTSectorData}\footnote{%
-    \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition} at
-    \leanid{HasBNTSectorData}.}
-in the formalization, and \eqref{eq:qual} is provided pointwise by
+the basis MPVs and does not state a rate. The formalization records this
+eventual linear-independence input in the shared sector-decomposition
+infrastructure,\footnote{%
+    \doclink{TNLean/MPS/SharedInfra/SectorDecomposition}.}
+while \eqref{eq:qual} is provided pointwise by
 \leanid{MPSTensor.mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP}.\footnote{%
     \doclink{TNLean/MPS/Overlap/CastDecay}.}
 Neither source equips $\eta_{j,k}$ with a quantitative relation
 to the spectral weight ratios.
 
-\section{The formal hypothesis}
+\section{The retired rate hypothesis}
 
-The structural predicate
-\leanid{HasRateQuantifiedCrossOverlapDecay}\footnote{%
-    Declaration \leanid{MPSTensor.HasRateQuantifiedCrossOverlapDecay} in
-    \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDecay}.}
-takes a sector decomposition $P$ and an explicit spectral level
-$\lambda:\mathrm{Fin}\,P.\mathtt{basisCount}\to\mathbb C$ and asserts
-the existence of non-negative families $C,\eta$ such that for every
+An earlier formal route introduced an explicit rate hypothesis on a
+sector decomposition $P$ and a chosen spectral level
+$\lambda:\mathrm{Fin}\,P.\mathtt{basisCount}\to\mathbb C$.  That route
+has since been retired together with the per-block-projection layer.  The
+mathematical hypothesis it was trying to isolate remains the following:
+there should exist non-negative families $C,\eta$ such that for every
 $j\ne k$,
 \begin{align}
     0\le C_{j,k},\quad 0\le\eta_{j,k}<1,
@@ -90,37 +88,25 @@ $j\ne k$,
     \label{eq:hyp}
 \end{align}
 together with the geometric bound~\eqref{eq:rate} for all $N$.
-The accessors \leanid{rateC}, \leanid{rateEta}, \leanid{rate\_nonneg},
-\leanid{rate\_lt\_one}, \leanid{rate\_compatible}, and
-\leanid{overlap\_bound} expose the components individually.
 
-The spectral level $\lambda$ is an \emph{explicit parameter}, not an
-existentially packaged field. The accessors of
-\leanid{IsBNTCanonicalFormSD}\footnote{%
-    \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}.}
-extract a specific $\lambda$ from its inner existential through
-\verb|Classical.choose|; the rate-quantified predicate avoids that
-coupling by taking $\lambda$ from the caller. A caller holding
-$h:\leanid{IsBNTCanonicalFormSD}\,P$ instantiates
-$\lambda:=h.\leanid{spectralLevel}$; a caller with concrete weights
-instantiates $\lambda$ directly.
+The surviving \leanid{PaperBNT} surface does not package such constants.
+It keeps the raw BNT weights in \leanid{SectorDecomposition} and records
+qualitative consequences in
+\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}: the coefficient
+bound \leanid{SectorDecomposition.norm\_coeff\_le\_copies\_of\_norm\_weight\_le\_one},
+within-family cross-decay
+\leanid{MPSTensor.IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero}, the
+combined-family linear-independence criterion
+\leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li}, and the
+non-vanishing coefficient statement
+\leanid{MPSTensor.IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}.  None of
+these declarations supplies the constants in~\eqref{eq:hyp}.
 
-\section{Where the hypothesis is needed}
+\section{Where such a hypothesis would be needed}
 
-The two-layer per-block-projection lemmas
-\begin{itemize}
-  \item \leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_sectorDecomp\_twoLayer}\\
-        in
-        \path{TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean}
-        (line~363), and
-  \item \leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_paperFaithful\_twoLayer}\\
-        in
-        \path{TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean}
-        (line~446),
-\end{itemize}
-carry an abstract hypothesis $\leanid{hNoCancel}$ that rules out
-asymptotic cancellation of the assembled overlap against the chosen
-projection block~$k_0$. The obstruction analysis in
+The retired per-block-projection route carried an abstract hypothesis
+excluding asymptotic cancellation of the assembled overlap against a
+chosen projection block~$k_0$.  The obstruction analysis in
 \path{audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md} shows that
 for a non-dominant $k_0$ the discharge requires, after isolating
 $V^{(N)}(P.\mathtt{basis}\,k_0)$ on the right and renormalising by
@@ -139,8 +125,7 @@ content of the new hypothesis.
 
 \section{Classification}
 
-\emph{Open gap.}  The hypothesis
-\leanid{HasRateQuantifiedCrossOverlapDecay} is a structural input
+\emph{Open gap.}  The rate condition~\eqref{eq:hyp} is a structural input
 beyond what \cite[\S II]{Cirac2016MPDO_arXiv} and
 \cite[Definition~4.3]{Cirac2021Matrix} make explicit. Its rate is
 in principle derivable from the spectral gap of the mixed transfer
@@ -153,14 +138,11 @@ BNT structure and must be either imposed or established analytically.
 The analytic derivation from the transfer matrix spectral gap is the
 subject of \emph{Option~2} in the design memo
 \path{audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md} and is
-not addressed in this note. The hypothesis is needed to discharge the
-non-dominant branch of the abstract $\leanid{hNoCancel}$ field on the
-two-layer surface and ultimately to close the
-\leanid{IsNormalCanonicalFormBNT}-formulation declarations
-\leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}
-and its symmetric counterpart
-in
-\path{TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean}.
+not addressed in this note. The current \leanid{PaperBNT} route instead
+keeps the coefficient comparison and the combined-family linear
+independence in \path{TNLean/MPS/FundamentalTheorem/PaperBNT}; any future
+rate-quantified argument should be stated against that surviving surface,
+not against the retired per-block-projection layer.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -65,12 +65,14 @@ The formal boundary in \cite{Cirac2016MPDO_arXiv} is narrower:
     \right)
     =r_A+1.
 \end{align}
-From this, formalized declarations of finite-weight eventual LI are available on
-both sides:
-\leanid{MPSTensor.eventually\_linearIndependent\_all\_left\_single\_right\_of\_all\_overlaps\_decay\_CFBNT}
-and
-\leanid{MPSTensor.eventually\_linearIndependent\_all\_right\_single\_left\_of\_all\_overlaps\_decay\_CFBNT}.
-The exact contradiction step is still open:
+The surviving \leanid{PaperBNT} API does not currently contain this
+single-block linear-independence formulation.  It supplies the stronger
+full-family mechanism
+\leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li},
+under all-pairwise cross-overlap decay; this is sufficient for the
+coefficient-comparison contradiction, but it is not the literal
+single-block statement displayed above.
+The exact fixed-block contradiction step is still open:
 \begin{align}
     (\forall j,  \langle V^{(N)}(B_{k_0}),V^{(N)}(A_j)\rangle\to 0)
     \Longrightarrow
@@ -80,11 +82,11 @@ The exact contradiction step is still open:
       c_N\sum_k \nu_k^N\,V^{(N)}(B_k)
     \right).
 \end{align}
-The two blocked theorems are the fixed-right and fixed-left cancellation
-statements.\footnote{\leanid{MPSTensor.fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT};
-\leanid{MPSTensor.fixed\_left\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}. Tracked in issue~\#1607.}
-which are the source-faithful fixed-block cancellations
-\cite[lines~1181--1185]{Cirac2016MPDO_arXiv}.
+No current Lean declaration carries the retired fixed-right or fixed-left
+one-copy fixed-block names.  The mathematical target remains the
+source-faithful fixed-block cancellation at
+\cite[lines~1181--1185]{Cirac2016MPDO_arXiv}, now to be stated on the
+\leanid{PaperBNT} sector surface.
 
 The earlier conditional helpers requiring combined-family linear independence
 (\path{_phase_sum_li}) and the residual-span variants have been retired in
@@ -119,8 +121,8 @@ all residual blocks on both sides.
 
 \textit{Classification: Scope restriction.}
 
-The non-cancellation conclusion is formally established under four explicit
-analytic hypotheses:
+The intended factored analytic discharge uses four explicit analytic
+hypotheses:
 \begin{enumerate}
   \item unit-modulus sector weights on both the $A$-family and the $B$-family;
   \item off-diagonal cross-overlap decay on the fixed-block family, i.e.,
@@ -135,14 +137,9 @@ directly supplied: the cited argument rules out cancellation by appeal to the
 dominant-adjusted scalar limit, but deriving the explicit lower bound
 $\|c_N\|\geq\delta$ from the structural data of the canonical form is not yet
 formalized and is recorded as an open obligation in
-\path{audits/2026-05-13_cpsv16_ft_sorry_discharge_plan.md}.\footnote{%
-  The universally-quantified non-cancellation discharge is
-  \leanid{MPSTensor.hNoCancel\_of\_unitModulus\_decay\_c\_norm\_lower}.
-  The two assembled contradictions are
-  \leanid{MPSTensor.fixed\_right\_all\_overlaps\_decay\_false\_paperFaithful}
-  and
-  \leanid{MPSTensor.fixed\_left\_all\_overlaps\_decay\_false\_paperFaithful};
-  both carry hypothesis~(4) as an explicit parameter.}
+\path{audits/2026-05-13_cpsv16_ft_sorry_discharge_plan.md}.  The earlier
+non-cancellation helpers carrying this lower-bound hypothesis were part of
+the retired Tier~3 route and should not be cited as present declarations.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -81,29 +81,21 @@ $\{V^{(N)}(A_j)\}_j\cup\{V^{(N)}(B_{k_0})\}$ from~\eqref{eq:Hk0} and
 combines it with the proportionality identity at
 \cite[eq.~\texttt{eq:II\_ABasicTensors}, line~286]{Cirac2016MPDO_arXiv}.
 
-\section{Formal statement}
+\section{Formal target}
 
-The formal target is, for $k_0:\mathrm{Fin}\,r_B$ arbitrary,\footnote{%
-    Declaration at
-    \path{TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean}
-    line~107; symmetric statement
-    \leanid{MPSTensor.fixed\_left\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}
-    at line~152.}
-\leanid{MPSTensor.fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}:
+The mathematical target is, for $k_0:\mathrm{Fin}\,r_B$ arbitrary:
 given the one-copy normal-canonical BNT hypotheses on both $\mu^A,A$ and
 $\mu^B,B$,
 \leanid{EventuallyNonzeroProportionalMPV\textsubscript{2}} between the
 assembled tensors, an index $k_0:\mathrm{Fin}\,r_B$ and the hypothesis
 $\forall j,\langle V^{(N)}(A_j),V^{(N)}(B_{k_0})\rangle\to 0$, derive
 $\bot$.
-The dominant specialization $k_0=\langle 0,\_\rangle$ is discharged
-separately by
-\leanid{MPSTensor.fixed\_right\_dominant\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}\footnote{%
-    Same file, line~178; the symmetric
-    \leanid{MPSTensor.fixed\_left\_dominant\_\ldots\_CFBNT} is at
-    line~458.}
-using the dominant-adjusted scalar limit. The universally quantified
-declarations remain open.
+The old one-copy fixed-block declarations for this target have been
+retired.  The surviving route is the \leanid{PaperBNT} proportional
+matching layer, which keeps the raw coefficients of
+\leanid{SectorDecomposition} visible and uses the API lemmas in
+\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.  The universally
+quantified fixed-block cancellation remains a mathematical obligation.
 
 \section{Where the per-block projection fails for non-dominant
 \texorpdfstring{$k_0$}{k0}}
@@ -120,16 +112,14 @@ and $\mathrm{RHS}_N:=c_N\langle V^{(N)}(B_{\mathrm{tot}}),V^{(N)}(B_{k_0})\rangl
 \end{align}
 With $\|\mu^A_j\|\le 1$, every $(\mu^A_j)^N$ is bounded; together with
 \eqref{eq:Hk0} this forces $\mathrm{LHS}_N\to 0$. For $\mathrm{RHS}_N$,
-BNT cross-overlap decay\footnote{%
-    \leanid{MPSTensor.IsNormalCanonicalFormBNT.cross\_overlap\_tendsto\_zero};
-    the explicit separated-hypotheses form is
-    \leanid{MPSTensor.cross\_overlap\_tendsto\_zero\_of\_separated\_CFBNT\_data}.}
-gives $\langle V^{(N)}(B_k),V^{(N)}(B_{k_0})\rangle\to 0$ for $k\ne k_0$
-and a nonzero limit $\ell$ at $k=k_0$, so
+the current cross-overlap decay statement
+\leanid{MPSTensor.IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero}
+gives $\langle V^{(N)}(B_k),V^{(N)}(B_{k_0})\rangle\to 0$ for $k\ne k_0$,
+while the diagonal block has a nonzero limiting coefficient, so
 $\mathrm{RHS}_N=c_N(\mu^B_{k_0})^N(\ell+o(1))$.
-The dominant-adjusted scalar limit\footnote{%
-    \leanid{MPSTensor.exists\_dominant\_adjusted\_scalar\_tendsto\_norm\_one\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}.}
-gives $\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$, hence
+In the dominant block, the proportionality identity and the BNT normalizations
+give the dominant-adjusted scalar limit
+$\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$.  Therefore
 \begin{align}
     \bigl\|c_N(\mu^B_{k_0})^N\bigr\|
     &\sim
@@ -143,7 +133,8 @@ $\mathrm{RHS}_N\to 0$ together with $\mathrm{LHS}_N$. No contradiction
 is available from the per-block projection. The dominant case
 $k_0=0$ is the unique index for which the ratio in~\eqref{eq:decay}
 is the constant~$1$ and the bound stays uniform; that is the analytic
-content of \leanid{fixed\_right\_dominant\_\ldots\_CFBNT}.
+content that the dominant fixed-block statement captured before the
+retirement of the old one-copy layer.
 
 Two independent probes confirm the obstruction. Path~$\alpha$
 (\path{audits/2026-05-13_cpsv16_ft_exact_leading_coeff.md},
@@ -183,25 +174,20 @@ identification, contradicting $c_N\ne 0$ and $\mu^B_{k_0}\ne 0$. The
 mechanism uses only the coefficient match forced by linear
 independence; it requires neither side to stay bounded away from~$0$.
 
-The formalization currently provides the smaller \texttt{Lem1} instance
-$\{V^{(N)}(A_j)\}\cup\{V^{(N)}(B_{k_0})\}$ as
-\leanid{MPSTensor.eventually\_linearIndependent\_all\_left\_single\_right\_of\_all\_overlaps\_decay\_CFBNT}
-and its symmetric
-\leanid{\ldots\_all\_right\_single\_left\_\ldots\_CFBNT}.\footnote{%
-    \path{TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean}
-    lines~710 and~769.}
-The larger combined-family instance \eqref{eq:largeLem1} is not
-formalized.
+The current \leanid{PaperBNT} API provides the combined-family
+linear-independence mechanism as
+\leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li}.
+The remaining task is to combine that statement with the proportional
+coefficient identity in the fixed-block setting, without appealing to the
+retired per-block-projection layer.
 
 \section{Classification}
 
-\emph{Scope restriction combined with an open gap.} The dominant
-declarations
-\leanid{fixed\_right\_dominant\_\ldots\_CFBNT} and
-\leanid{fixed\_left\_dominant\_\ldots\_CFBNT}
-prove the Step~1 conclusion for $k_0=\langle 0,\_\rangle$ on the
-one-copy surface. The universally quantified statements stay open
-because the cited mechanism requires either
+\emph{Scope restriction combined with an open gap.} The retired dominant
+fixed-block declarations proved the Step~1 conclusion for
+$k_0=\langle 0,\_\rangle$ on the one-copy surface. The universally
+quantified statements stay open because the cited mechanism requires
+either
 
 \begin{enumerate}
     \item the combined-family \texttt{Lem1} statement
@@ -211,12 +197,12 @@ because the cited mechanism requires either
     \item the two-layer paper-faithful structure of
           \cite[Definition~4.3]{Cirac2021Matrix}, separating spectral
           levels $\lambda_j$ from within-sector unit-modulus weights
-          $\mu_{j,q}$. The two-layer surface
-          \leanid{MPSTensor.IsBNTCanonicalFormSD}\footnote{%
-              \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}.}
-          permits the geometric factor in~\eqref{eq:decay} to be
-          cancelled against $c_N$ before projection, recovering a
-          constant lower bound. Tracked in \ghissue{1641}.
+          $\mu_{j,q}$.  On the surviving \leanid{SectorDecomposition}
+          surface this means keeping the raw coefficients
+          $\sum_q\mu_{j,q}^N$ visible and using
+          \leanid{MPSTensor.IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}
+          rather than collapsing the sector to a single weight before the
+          projection argument.  Tracked in \ghissue{1641}.
 \end{enumerate}
 
 The collapse $r_j=1$ enforced by \leanid{mu\_strict\_anti}

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -7,7 +7,7 @@
 \input{command}
 
 \title{Two-Layer Sector Refinement of CPSV16 \texttt{eq:II\_ABasicTensors}\\
-in \leanid{IsBNTCanonicalFormSD}}
+on the \leanid{PaperBNT} Sector Surface}
 \author{}
 \date{2026-05-13}
 
@@ -32,27 +32,26 @@ independence of the BNT vectors $\lvert V^{(N)}(A_j)\rangle$ is recorded
 separately in Definition~\texttt{def:4:BNT} of
 \cite{Cirac2021Matrix}.
 
-\section{The extra hypotheses in \leanid{IsBNTCanonicalFormSD}}
+\section{The retired specialization}
 
-The \Lean{} predicate \leanid{IsBNTCanonicalFormSD} in
-\doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}
-is a \emph{project-specific specialization} of
-\eqref{eq:bnt-general}. It adds three hypotheses beyond what
-\eqref{eq:bnt-general} asserts:
+An earlier formal route introduced a project-specific specialization of
+\eqref{eq:bnt-general}.  That route grouped equal-modulus blocks into
+sectors, extracted a common spectral factor, and imposed three hypotheses
+which are stronger than the source display:
 
 \begin{enumerate}
   \item \textbf{Strict spectral ordering.}
         The predicate requires the existence of spectral-level coefficients
         $\lambda_j \in \mathbb{C}$ (one per BNT sector $j$) with
         $\|\lambda_0\| > \|\lambda_1\| > \cdots > \|\lambda_{g-1}\|$
-        (recorded as \leanid{StrictAnti (fun j => \|spectralLevel j\|)}).
+        (formerly recorded as a strict-antitone condition on the chosen
+        spectral levels).
         No such ordering is present in \eqref{eq:bnt-general}.
 
   \item \textbf{Unit-modulus within-sector factors.}
         Each weight $\mu_{j,q}$ is required to factor as
         $\mu_{j,q} = \lambda_j \cdot \nu_{j,q}$ with $|\nu_{j,q}| = 1$,
-        recorded as $\|\textit{weight}_{j,q} / \lambda_j\| = 1$
-        (\leanid{weight\_factor}).
+        recorded by an explicit unit-modulus factorization condition.
         The general form \eqref{eq:bnt-general} allows $|\mu_{j,q}|$
         to vary arbitrarily within a sector. The unit-modulus factorization
         is conceptually related to the RFP characterization in
@@ -60,37 +59,38 @@ is a \emph{project-specific specialization} of
         (lines 543--555), which is a strict sub-class of the general BNT.
 
   \item \textbf{Dominant normalization.}
-        The dominant spectral level satisfies $\|\lambda_0\| = 1$
-        (\leanid{spectralLevel\_dom\_norm\_one}). This mirrors the
-        \leanid{IsNormalCanonicalFormBNT.mu\_dom\_norm\_one} convention in
-        \doclink{TNLean/MPS/BNT/Construction}; it is not imposed by
-        \eqref{eq:bnt-general}.
+        The dominant spectral level satisfies $\|\lambda_0\| = 1$.
+        This mirrors the \leanid{IsNormalCanonicalFormBNT.mu\_dom\_norm\_one}
+        convention in \doclink{TNLean/MPS/BNT/Construction}; it is not
+        imposed by \eqref{eq:bnt-general}.
 \end{enumerate}
 
-\section{What these hypotheses collectively define}
+\section{The surviving formal surface}
 
-Together, the three conditions define a \emph{specialization} of
-\eqref{eq:bnt-general} in which equal-modulus blocks have been grouped
-into sectors, a common spectral factor $\lambda_j$ extracted, and the
-dominant sector normalized to $|\lambda_0| = 1$. This is the
-structure computed by the \leanid{SectorDecomposition} grouping in the
-project, and it subsumes the RFP case of
-\texttt{thm:charact-MPS}~\cite{Cirac2016MPDO_arXiv}.
+The surviving surface separates the source display into two pieces.
+\leanid{SectorDecomposition} stores the basis blocks, their copy
+multiplicities, and the raw weights $\mu_{j,q}$ through the coefficient
+\[
+    P.\mathtt{coeff}\,N\,j=\sum_q (P.\mathtt{weight}\,j\,q)^N .
+\]
+\leanid{IsBNTCanonicalForm} then records the BNT hypotheses used by the
+fundamental-theorem route: irreducibility, left canonical normalization,
+gauge-phase distinctness of equal-dimensional basis blocks, eventual
+linear independence of the basis MPVs, bounded weights, and existence of
+at least one unit-modulus weight.
 
-The three conditions are a \emph{specialization} (additional hypotheses
-on top of \eqref{eq:bnt-general}), not a deviation: every
-\leanid{IsBNTCanonicalFormSD} instance arises from a valid
-\eqref{eq:bnt-general} decomposition by grouping and normalizing.
-The planned adapter from the one-copy normal-canonical BNT formulation to
-\leanid{IsBNTCanonicalFormSD} must now be stated from
-\leanid{IsNormalCanonicalFormBNT}, or from explicit separated-block
-hypotheses, via rescaling by $\rho = \|\mu_0\|$.
+This keeps the two-layer information visible without assuming strict
+ordering of spectral levels or a factorization
+$\mu_{j,q}=\lambda_j\nu_{j,q}$ as part of the BNT predicate.  When such a
+factorization is needed, it should be stated as an additional theorem
+hypothesis rather than hidden in the canonical-form predicate.
 
 \section{Scope restriction}
 
-The adapter absorbs only the one-copy-per-sector case ($r_j = 1$ for all $j$).
-The full multi-copy BNT form with $r_j > 1$ - and the associated
-Newton--Girard recovery of multiplicities from $\sum_q \mu_{j,q}^N$ - is a
+The one-copy normal-canonical formulation
+\leanid{IsNormalCanonicalFormBNT} covers only the case $r_j=1$ for all
+$j$.  The full multi-copy BNT form with $r_j>1$ -- and the associated
+Newton--Girard recovery of multiplicities from $\sum_q\mu_{j,q}^N$ -- is a
 separate paper-level gap documented in
 \path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}.
 The \leanid{SectorDecomposition} surface is multi-copy-ready
@@ -99,18 +99,21 @@ populate it beyond $r_j = 1$.
 
 \section{Formal declarations}
 
-The relevant formal declarations are:
+The relevant surviving formal declarations are:
 \begin{itemize}
-  \item \leanid{IsBNTCanonicalFormSD} -
-        the predicate (\doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}).
-  \item \leanid{IsBNTCanonicalFormSD.spectralLevel\_strict\_anti} -
-        the \leanid{StrictAnti} accessor.
-  \item \leanid{IsBNTCanonicalFormSD.weight\_factor} -
-        the unit-modulus factorization accessor.
-  \item \leanid{IsBNTCanonicalFormSD.spectralLevel\_dom\_norm\_one} -
-        the dominant normalization accessor.
+  \item \leanid{SectorDecomposition} -
+        the raw two-layer sector surface
+        (\doclink{TNLean/MPS/SharedInfra/SectorDecomposition}).
+  \item \leanid{IsBNTCanonicalForm} -
+        the BNT canonical-form predicate
+        (\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Basic}).
+  \item \leanid{MPSTensor.IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero},
+        \leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li},
+        \leanid{MPSTensor.IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block},
+        and \leanid{MPSTensor.IsBNTCanonicalForm.thermodynamic\_limit\_nonvanishing}
+        in \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.
   \item A future adapter from \leanid{IsNormalCanonicalFormBNT}, or from
-        explicit separated-block hypotheses, to \leanid{IsBNTCanonicalFormSD}.
+        explicit separated-block hypotheses, to \leanid{IsBNTCanonicalForm}.
 \end{itemize}
 See also \ghpr{1657} (branch \path{feat/mps-ft-path-beta-pr1-two-layer})
 and the audit memo


### PR DESCRIPTION
### Motivation

- Four CPSV16 paper-gap notes in `docs/paper-gaps/` cited deleted Lean declarations and source files removed by #1737 (`IsBNTCanonicalFormSD.lean`, `PerBlockProjection.lean`, `HNoCancelDischarge.lean`). Per `docs/paper-gaps/policy.tex` §Revision, notes must remain coherent accounts of current mathematical understanding; citing deleted formal artifacts renders them incoherent.

### Description

- `cpsv16_bnt_rate_quantification.tex`: removed stale footnotes referencing the deleted `IsBNTCanonicalFormSD` module and line citations to `PerBlockProjection.lean`/`HNoCancelDischarge.lean`; updated to describe the surviving `PaperBNT` sector surface and current `Api.*` declarations.
- `cpsv16_two_layer_sector_refinement.tex`: rewritten to describe the open cross-overlap decay obligations against the surviving `PaperBNT`/`SectorDecomposition` surfaces, replacing deleted `IsCanonicalFormBNT.toIsBNTCanonicalFormSD` adapter references.
- `cpsv16_fixed_block_cancellation.tex`: removed stale witnesses (`hNoCancel_of_unitModulus_decay_c_norm_lower`, `fixed_right/left_all_overlaps_decay_false_paperFaithful`); updated to reference current `Api.*` declarations for qualitative decay, coefficient bounds, combined-family linear independence, and non-vanishing coefficients. The ‖c_N‖ ≥ δ lower-bound obligation (arXiv:1606.00608, Theorem thm1, lines 1170–1192) remains open.
- `cpsv16_nondominant_per_block_projection.tex`: replaced stale `MPSTensor.IsBNTCanonicalFormSD` references with surviving `PaperBNT` API equivalents.
- Mathematical status is unchanged: universally quantified fixed-block cancellation and rate-quantified cross-overlap decay remain open obligations; the notes now record these without citing deleted Lean files or retired declaration names as live formal artifacts.

### Testing

- `rg -n "IsBNTCanonicalFormSD|PerBlockProjection|HNoCancelDischarge|RateQuantifiedDecay|HasRateQuantifiedCrossOverlapDecay|Full/NondecayingOverlap|_CFBNT|CFBNT" docs/paper-gaps/cpsv16_bnt_rate_quantification.tex docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex docs/paper-gaps/cpsv16_fixed_block_cancellation.tex docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex` — confirmed no stale identifiers remain in the four edited notes
- `git diff --check` — no whitespace errors
- `latexmk -pdf -interaction=nonstopmode -halt-on-error` on all four updated notes from `docs/paper-gaps`
- `lake build TNLean`

---
Closes #1739

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that retarget references from deleted/retired Lean declarations to the current `PaperBNT`/`SectorDecomposition` API, with no code or proof changes.
> 
> **Overview**
> Updates four CPSV16 paper-gap notes to **stop referencing retired Tier 3 Lean surfaces** (e.g., per-block projection, `IsBNTCanonicalFormSD`, rate-quantified decay predicates) and instead describe the surviving `PaperBNT`/`SectorDecomposition` route and its available `Api` lemmas.
> 
> Reframes the open obligations (rate-quantified cross-overlap decay and universally-quantified fixed-block cancellation) to match the current formal surface, clarifying that prior fixed-block and non-cancellation helper declarations were retired and should not be cited as existing artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c85eae876983aa2df021a52c476c1855479bc120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->