### PR TITLE
fix(TNLean): restore periodic FT imports

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -229,7 +229,11 @@ import TNLean.MPS.FundamentalTheorem.PaperBNT.Examples
 import TNLean.MPS.FundamentalTheorem.PaperBNT.WeakExistential
 import TNLean.MPS.FundamentalTheorem.PaperBNT.ProportionalMatch
 import TNLean.MPS.FundamentalTheorem.PaperBNT.Supplier
+import TNLean.MPS.Periodic.Overlap
+import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.ZGauge
+import TNLean.MPS.Periodic.Symmetry
+import TNLean.MPS.Periodic.ProjectiveRep
 import TNLean.MPS.Periodic.Applications
 import TNLean.MPS.Structure.InvariantSubspaceDecomp
 import TNLean.MPS.CanonicalForm.Reduction


### PR DESCRIPTION
### Motivation

- Four periodic Fundamental Theorem modules (`MPS/Periodic/{Overlap,FundamentalTheorem,Symmetry,ProjectiveRep}`) were dropped from the root `TNLean.lean` manifest in the second commit of #1740, on the assumption they depended on the retired `Full/` chain (removed in #1738).
- Current `main` shows these modules elaborate correctly without the retired chain; they remain mathematically required for the arXiv:1708.00029 periodic FT path (Theorems 3.4, 3.8), tracked in #82 and #619.
- Deleting them would remove active periodic-FT statements — `Symmetry` is a public entry point over the split Section 4 modules, and `ProjectiveRep` builds on it.

### Description

- Restores four imports to `TNLean.lean`:
  - `TNLean.MPS.Periodic.Overlap`
  - `TNLean.MPS.Periodic.FundamentalTheorem`
  - `TNLean.MPS.Periodic.Symmetry`
  - `TNLean.MPS.Periodic.ProjectiveRep`
- No changes to the modules themselves; only the root manifest is modified.
- Pre-existing `sorry`s in the periodic-overlap submodules are now visible to `lake build TNLean` again; no new proof obligations are introduced.

### Testing

- `lake build TNLean.MPS.Periodic.Overlap`
- `lake build TNLean.MPS.Periodic.FundamentalTheorem`
- `lake build TNLean.MPS.Periodic.Symmetry`
- `lake build TNLean.MPS.Periodic.ProjectiveRep`
- `lake build TNLean`
- `git diff --check`

---
Closes #1741

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the root `TNLean.lean` import surface to re-expose periodic fundamental-theorem modules, which may surface existing elaboration issues (e.g., pre-existing `sorry`s) during `lake build` but does not alter logic within the modules.
>
> **Overview**
> Restores periodic Fundamental Theorem entry points to the root manifest by adding imports for `TNLean.MPS.Periodic.Overlap`, `TNLean.MPS.Periodic.FundamentalTheorem`, `TNLean.MPS.Periodic.Symmetry`, and `TNLean.MPS.Periodic.ProjectiveRep` in `TNLean.lean`.
>
> This makes these periodic-FT modules part of the default downstream import surface again and ensures they are built when importing `TNLean`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f4cf1851a3c4914e3a54f0fa15b52cf685f7469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->