### PR TITLE
doc(paper-gaps): update retired BNT notes

### DIFF
--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -10,7 +10,7 @@
 \title{Rate-Quantified BNT Cross-Overlap Decay\\
        under an Equal-Modulus Refinement}
 \author{}
-\date{2026-05-13}
+\date{2026-05-18}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -8,7 +8,7 @@
 \input{command}
 
 \title{Rate-Quantified BNT Cross-Overlap Decay\\
-       for the Paper-Faithful BNT Surface}
+       under an Equal-Modulus Refinement}
 \author{}
 \date{2026-05-13}
 
@@ -18,11 +18,11 @@
 \section{Notation}
 
 Fix a sector decomposition $P$ with basis blocks
-$\{P.\mathtt{basis}\,j\}_{j=0}^{g-1}$ and a spectral level
-$\lambda_j\in\mathbb C\setminus\{0\}$ with
-$\|\lambda_0\|>\|\lambda_1\|>\cdots>\|\lambda_{g-1}\|$ and
-$\|\lambda_0\|=1$. The bilinear cross-overlap between basis blocks
-$j$ and $k$ at length $N$ is
+$\{P.\mathtt{basis}\,j\}_{j=0}^{g-1}$.  Suppose an additional
+equal-modulus refinement has supplied nonzero spectral levels
+$\lambda_j\in\mathbb C$ such that the moduli are non-increasing in $j$,
+and the first level has modulus $1$ when $g>0$.  The bilinear
+cross-overlap between basis blocks $j$ and $k$ at length $N$ is
 \begin{align}
     O_{j,k}(N) := 
     \mathtt{mpvOverlap}\bigl(P.\mathtt{basis}\,j,
@@ -65,7 +65,7 @@ Definition~4.3 of~\cite{Cirac2021Matrix} packages
 the basis MPVs and does not state a rate. The formal counterpart is
 the predicate
 \leanid{MPSTensor.HasBNTSectorData}\footnote{%
-    \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition} at
+    \doclink{TNLean/MPS/SharedInfra/SectorDecomposition} at
     \leanid{HasBNTSectorData}.}
 in the formalization, and \eqref{eq:qual} is provided pointwise by
 \leanid{MPSTensor.mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP}.\footnote{%
@@ -87,11 +87,11 @@ existence of non-negative families $C,\eta$ such that for every $j\ne k$,
 \end{align}
 together with the geometric bound~\eqref{eq:rate} for all $N$.
 
-This condition is not currently a formal declaration.  It arose during the
-retired two-layer sector-refinement route, where a common spectral level
-$\lambda_j$ was separated from within-sector phases.  The present
-paper-faithful route keeps the raw CPSV weights $\mu_{j,q}$ in the core BNT
-predicate and does not impose such a factorization.
+This condition is not currently a formal declaration.  It is meaningful only
+after choosing an equal-modulus refinement that separates a common spectral
+level $\lambda_j$ from within-sector phases.  The present paper-faithful route
+keeps the raw CPSV weights $\mu_{j,q}$ in the core BNT predicate and does not
+impose such a factorization.
 
 The surviving formal statements used in the current route are the qualitative
 and coefficient estimates in

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -8,7 +8,7 @@
 \input{command}
 
 \title{Rate-Quantified BNT Cross-Overlap Decay\\
-       on the \leanid{SectorDecomposition} Surface}
+       for the Paper-Faithful BNT Surface}
 \author{}
 \date{2026-05-13}
 
@@ -73,16 +73,12 @@ in the formalization, and \eqref{eq:qual} is provided pointwise by
 Neither source equips $\eta_{j,k}$ with a quantitative relation
 to the spectral weight ratios.
 
-\section{The formal hypothesis}
+\section{The rate condition}
 
-The structural predicate
-\leanid{HasRateQuantifiedCrossOverlapDecay}\footnote{%
-    Declaration \leanid{MPSTensor.HasRateQuantifiedCrossOverlapDecay} in
-    \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/RateQuantifiedDecay}.}
-takes a sector decomposition $P$ and an explicit spectral level
-$\lambda:\mathrm{Fin}\,P.\mathtt{basisCount}\to\mathbb C$ and asserts
-the existence of non-negative families $C,\eta$ such that for every
-$j\ne k$,
+The rate condition that would discharge the non-dominant projection argument
+takes a sector decomposition $P$ and a spectral level
+$\lambda:\mathrm{Fin}\,P.\mathtt{basisCount}\to\mathbb C$. It asserts the
+existence of non-negative families $C,\eta$ such that for every $j\ne k$,
 \begin{align}
     0\le C_{j,k},\quad 0\le\eta_{j,k}<1,
         \qquad
@@ -90,37 +86,30 @@ $j\ne k$,
     \label{eq:hyp}
 \end{align}
 together with the geometric bound~\eqref{eq:rate} for all $N$.
-The accessors \leanid{rateC}, \leanid{rateEta}, \leanid{rate\_nonneg},
-\leanid{rate\_lt\_one}, \leanid{rate\_compatible}, and
-\leanid{overlap\_bound} expose the components individually.
 
-The spectral level $\lambda$ is an \emph{explicit parameter}, not an
-existentially packaged field. The accessors of
-\leanid{IsBNTCanonicalFormSD}\footnote{%
-    \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}.}
-extract a specific $\lambda$ from its inner existential through
-\verb|Classical.choose|; the rate-quantified predicate avoids that
-coupling by taking $\lambda$ from the caller. A caller holding
-$h:\leanid{IsBNTCanonicalFormSD}\,P$ instantiates
-$\lambda:=h.\leanid{spectralLevel}$; a caller with concrete weights
-instantiates $\lambda$ directly.
+This condition is not currently a formal declaration.  It arose during the
+retired two-layer sector-refinement route, where a common spectral level
+$\lambda_j$ was separated from within-sector phases.  The present
+paper-faithful route keeps the raw CPSV weights $\mu_{j,q}$ in the core BNT
+predicate and does not impose such a factorization.
 
-\section{Where the hypothesis is needed}
+The surviving formal statements used in the current route are the qualitative
+and coefficient estimates in
+\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.  In particular,
+\leanid{IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero} gives
+the limit~\eqref{eq:qual},
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li} gives the
+combined-family linear-independence conclusion from vanishing cross-overlaps,
+\leanid{IsBNTCanonicalForm.norm\_coeff\_le\_copies} bounds the raw sector
+coefficient under the CPSV line-246 normalization, and
+\leanid{IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block} gives the
+non-vanishing conclusion for a block carrying a unit-modulus copy.
 
-The two-layer per-block-projection lemmas
-\begin{itemize}
-  \item \leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_sectorDecomp\_twoLayer}\\
-        in
-        \path{TNLean/MPS/FundamentalTheorem/SectorDecomposition/PerBlockProjection.lean}
-        (line~363), and
-  \item \leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_paperFaithful\_twoLayer}\\
-        in
-        \path{TNLean/MPS/FundamentalTheorem/SectorDecomposition/HNoCancelDischarge.lean}
-        (line~446),
-\end{itemize}
-carry an abstract hypothesis $\leanid{hNoCancel}$ that rules out
-asymptotic cancellation of the assembled overlap against the chosen
-projection block~$k_0$. The obstruction analysis in
+\section{Where the rate condition would be used}
+
+The retired two-layer per-block-projection lemmas carried an abstract
+non-cancellation hypothesis ruling out asymptotic cancellation of the assembled
+overlap against the chosen projection block~$k_0$.  The obstruction analysis in
 \path{audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md} shows that
 for a non-dominant $k_0$ the discharge requires, after isolating
 $V^{(N)}(P.\mathtt{basis}\,k_0)$ on the right and renormalising by
@@ -135,16 +124,15 @@ The right-hand side of~\eqref{eq:product} converges to $0$ exactly when
 \eqref{eq:hyp} holds. The qualitative limit~\eqref{eq:qual} alone
 gives $\eta_{j,k_0}<1$ but not the comparison
 $\eta_{j,k_0}\cdot\|\lambda_j/\lambda_{k_0}\|<1$, which is the
-content of the new hypothesis.
+content of the rate condition.
 
 \section{Classification}
 
-\emph{Open gap.}  The hypothesis
-\leanid{HasRateQuantifiedCrossOverlapDecay} is a structural input
-beyond what \cite[\S II]{Cirac2016MPDO_arXiv} and
-\cite[Definition~4.3]{Cirac2021Matrix} make explicit. Its rate is
-in principle derivable from the spectral gap of the mixed transfer
-operator that powers
+\emph{Open gap.}  The rate condition above is a structural input beyond what
+\cite[\S II]{Cirac2016MPDO_arXiv} and
+\cite[Definition~4.3]{Cirac2021Matrix} make explicit. Its rate is in
+principle derivable from the spectral gap of the mixed transfer operator that
+powers
 \leanid{mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP},
 but the compatibility inequality
 $\eta_{j,k}\cdot\|\lambda_j/\lambda_k\|<1$ is not implied by the
@@ -153,14 +141,13 @@ BNT structure and must be either imposed or established analytically.
 The analytic derivation from the transfer matrix spectral gap is the
 subject of \emph{Option~2} in the design memo
 \path{audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md} and is
-not addressed in this note. The hypothesis is needed to discharge the
-non-dominant branch of the abstract $\leanid{hNoCancel}$ field on the
-two-layer surface and ultimately to close the
-\leanid{IsNormalCanonicalFormBNT}-formulation declarations
-\leanid{fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}
-and its symmetric counterpart
-in
-\path{TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean}.
+not addressed in this note.  The current PaperBNT route instead records the
+source-faithful qualitative overlap decay, coefficient boundedness, and
+coefficient non-vanishing separately in
+\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}; any future use of the
+rate condition should be added as a theorem-level hypothesis or proved from
+the mixed-transfer spectral gap, not by reviving the deleted two-layer
+projection surface.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -8,7 +8,7 @@
 
 \title{The Fixed-Block Cancellation Step in CPSV16 Theorem II.1}
 \author{}
-\date{2026-05-11}
+\date{2026-05-18}
 
 \begin{document}
 \maketitle
@@ -98,10 +98,10 @@ supplied by Corollary~\texttt{Lem1}.  The remaining open obligation is the
 fixed-block cancellation itself, to be discharged without combined-family LI or
 residual-span exclusion.
 
-Retirement note: this note intentionally no longer lists the retired no-tail,
-leading-only, partner-identification, leading-tail, residual-span, or
-\path{_phase_sum_li} declarations.  They were deleted as wrong-direction or
-orphan scaffolding in the same audit.
+Thus the current note records the mathematical obligation rather than the
+former auxiliary surfaces: the contradiction must be obtained from the
+fixed-block hypothesis in the CPSV16 passage itself, not from a
+combined-family statement whose hypotheses belong to a different route.
 
 \section{Current discharge plan}
 

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -65,11 +65,11 @@ The formal boundary in \cite{Cirac2016MPDO_arXiv} is narrower:
     \right)
     =r_A+1.
 \end{align}
-From this, formalized declarations of finite-weight eventual LI are available on
-both sides:
-\leanid{MPSTensor.eventually\_linearIndependent\_all\_left\_single\_right\_of\_all\_overlaps\_decay\_CFBNT}
-and
-\leanid{MPSTensor.eventually\_linearIndependent\_all\_right\_single\_left\_of\_all\_overlaps\_decay\_CFBNT}.
+In the present PaperBNT development the relevant linear-independence input is
+the combined-family statement
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li}, which applies
+when all cross-overlaps between the two BNT basis families vanish.\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.}
 The exact contradiction step is still open:
 \begin{align}
     (\forall j,  \langle V^{(N)}(B_{k_0}),V^{(N)}(A_j)\rangle\to 0)
@@ -80,11 +80,10 @@ The exact contradiction step is still open:
       c_N\sum_k \nu_k^N\,V^{(N)}(B_k)
     \right).
 \end{align}
-The two blocked theorems are the fixed-right and fixed-left cancellation
-statements.\footnote{\leanid{MPSTensor.fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT};
-\leanid{MPSTensor.fixed\_left\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV₂\_CFBNT}. Tracked in issue~\#1607.}
-which are the source-faithful fixed-block cancellations
-\cite[lines~1181--1185]{Cirac2016MPDO_arXiv}.
+This is the source-faithful fixed-block cancellation step
+\cite[lines~1181--1185]{Cirac2016MPDO_arXiv}.  It remains a mathematical
+obligation in the proportional PaperBNT route rather than a live declaration on
+the retired one-copy surface.
 
 The earlier conditional helpers requiring combined-family linear independence
 (\path{_phase_sum_li}) and the residual-span variants have been retired in
@@ -130,19 +129,19 @@ analytic hypotheses:
   \item an eventual positive lower bound $\|c_N\| \geq \delta > 0$.
 \end{enumerate}
 Hypotheses~(1)--(3) are present in the source via the BNT structure
-\cite[Theorem~\texttt{thm1}]{Cirac2016MPDO_arXiv}.  Hypothesis~(4) is not
-directly supplied: the cited argument rules out cancellation by appeal to the
-dominant-adjusted scalar limit, but deriving the explicit lower bound
-$\|c_N\|\geq\delta$ from the structural data of the canonical form is not yet
-formalized and is recorded as an open obligation in
-\path{audits/2026-05-13_cpsv16_ft_sorry_discharge_plan.md}.\footnote{%
-  The universally-quantified non-cancellation discharge is
-  \leanid{MPSTensor.hNoCancel\_of\_unitModulus\_decay\_c\_norm\_lower}.
-  The two assembled contradictions are
-  \leanid{MPSTensor.fixed\_right\_all\_overlaps\_decay\_false\_paperFaithful}
-  and
-  \leanid{MPSTensor.fixed\_left\_all\_overlaps\_decay\_false\_paperFaithful};
-  both carry hypothesis~(4) as an explicit parameter.}
+\cite[Theorem~\texttt{thm1}]{Cirac2016MPDO_arXiv}.  On the present PaperBNT
+surface they are represented by the following formal statements:
+\leanid{IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero},
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li}, and
+\leanid{IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}; the
+coefficient boundedness used in the same estimates is
+\leanid{IsBNTCanonicalForm.norm\_coeff\_le\_copies}.\footnote{%
+  All four declarations are in
+  \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.}
+Hypothesis~(4) is not directly supplied: the cited argument rules out
+cancellation by appeal to the dominant-adjusted scalar limit, but deriving the
+explicit lower bound $\|c_N\|\geq\delta$ from the structural data of the
+canonical form remains an open obligation in the proportional route.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -70,6 +70,9 @@ the combined-family statement
 \leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li}, which applies
 when all cross-overlaps between the two BNT basis families vanish.\footnote{%
     \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.}
+This is a stronger input than the single-fixed-block family furnished by
+Corollary~\texttt{Lem1} in the source passage, and should not be read as a
+formalization of that corollary itself.
 The exact contradiction step is still open:
 \begin{align}
     (\forall j,  \langle V^{(N)}(B_{k_0}),V^{(N)}(A_j)\rangle\to 0)

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -120,8 +120,17 @@ BNT cross-overlap decay\footnote{%
 gives $\langle V^{(N)}(B_k),V^{(N)}(B_{k_0})\rangle\to 0$ for $k\ne k_0$
 and a nonzero limit $\ell$ at $k=k_0$, so
 $\mathrm{RHS}_N=c_N(\mu^B_{k_0})^N(\ell+o(1))$.
-The dominant-adjusted scalar calculation from the retired one-copy route gives
-$\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$, hence
+For the dominant pair, the proportionality identity projected onto the matched
+dominant block, together with normalized self-overlap and vanishing
+off-diagonal overlaps, gives the scalar comparison
+\begin{align}
+    \bigl\|c_N(\mu^B_0)^N\bigr\|
+    \sim \|(\mu^A_0)^N\|.
+\end{align}
+Equivalently,
+$\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$.  This is the dominant
+normalization calculation in the CPSV16 Step~1 argument
+\cite[lines~1170--1180]{Cirac2016MPDO_arXiv}.  Therefore
 \begin{align}
     \bigl\|c_N(\mu^B_{k_0})^N\bigr\|
     &\sim

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -10,7 +10,7 @@
 \title{Non-Dominant Per-Block Projection in CPSV16 \S II Step~1\\
        under the One-Copy Normal-Canonical BNT Formulation}
 \author{}
-\date{2026-05-13}
+\date{2026-05-18}
 
 \begin{document}
 \maketitle

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -81,29 +81,23 @@ $\{V^{(N)}(A_j)\}_j\cup\{V^{(N)}(B_{k_0})\}$ from~\eqref{eq:Hk0} and
 combines it with the proportionality identity at
 \cite[eq.~\texttt{eq:II\_ABasicTensors}, line~286]{Cirac2016MPDO_arXiv}.
 
-\section{Formal statement}
+\section{Formal boundary}
 
-The formal target is, for $k_0:\mathrm{Fin}\,r_B$ arbitrary,\footnote{%
-    Declaration at
-    \path{TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap/FixedBlockDecay.lean}
-    line~107; symmetric statement
-    \leanid{MPSTensor.fixed\_left\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}
-    at line~152.}
-\leanid{MPSTensor.fixed\_right\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}:
-given the one-copy normal-canonical BNT hypotheses on both $\mu^A,A$ and
-$\mu^B,B$,
-\leanid{EventuallyNonzeroProportionalMPV\textsubscript{2}} between the
-assembled tensors, an index $k_0:\mathrm{Fin}\,r_B$ and the hypothesis
-$\forall j,\langle V^{(N)}(A_j),V^{(N)}(B_{k_0})\rangle\to 0$, derive
-$\bot$.
-The dominant specialization $k_0=\langle 0,\_\rangle$ is discharged
-separately by
-\leanid{MPSTensor.fixed\_right\_dominant\_all\_overlaps\_decay\_false\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}\footnote{%
-    Same file, line~178; the symmetric
-    \leanid{MPSTensor.fixed\_left\_dominant\_\ldots\_CFBNT} is at
-    line~458.}
-using the dominant-adjusted scalar limit. The universally quantified
-declarations remain open.
+The earlier one-copy formal target tried to prove, for an arbitrary
+$k_0:\mathrm{Fin}\,r_B$, that eventual proportionality of the two assembled
+families contradicts
+$\forall j,\langle V^{(N)}(A_j),V^{(N)}(B_{k_0})\rangle\to 0$.  That route
+belonged to the retired one-copy fundamental-theorem development.
+
+The present PaperBNT route keeps the raw weights $\mu_{j,q}$ in a sector
+decomposition.  The available formal ingredients are
+\leanid{IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero},
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li},
+\leanid{IsBNTCanonicalForm.norm\_coeff\_le\_copies}, and
+\leanid{IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}.\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.}
+The obstruction below records why a direct per-block projection is not the
+right replacement for the source's linear-independence argument.
 
 \section{Where the per-block projection fails for non-dominant
 \texorpdfstring{$k_0$}{k0}}
@@ -121,15 +115,13 @@ and $\mathrm{RHS}_N:=c_N\langle V^{(N)}(B_{\mathrm{tot}}),V^{(N)}(B_{k_0})\rangl
 With $\|\mu^A_j\|\le 1$, every $(\mu^A_j)^N$ is bounded; together with
 \eqref{eq:Hk0} this forces $\mathrm{LHS}_N\to 0$. For $\mathrm{RHS}_N$,
 BNT cross-overlap decay\footnote{%
-    \leanid{MPSTensor.IsNormalCanonicalFormBNT.cross\_overlap\_tendsto\_zero};
-    the explicit separated-hypotheses form is
-    \leanid{MPSTensor.cross\_overlap\_tendsto\_zero\_of\_separated\_CFBNT\_data}.}
+    In the present PaperBNT surface this is
+    \leanid{IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero}.}
 gives $\langle V^{(N)}(B_k),V^{(N)}(B_{k_0})\rangle\to 0$ for $k\ne k_0$
 and a nonzero limit $\ell$ at $k=k_0$, so
 $\mathrm{RHS}_N=c_N(\mu^B_{k_0})^N(\ell+o(1))$.
-The dominant-adjusted scalar limit\footnote{%
-    \leanid{MPSTensor.exists\_dominant\_adjusted\_scalar\_tendsto\_norm\_one\_of\_eventuallyNonzeroProportionalMPV\textsubscript{2}\_CFBNT}.}
-gives $\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$, hence
+The dominant-adjusted scalar calculation from the retired one-copy route gives
+$\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$, hence
 \begin{align}
     \bigl\|c_N(\mu^B_{k_0})^N\bigr\|
     &\sim
@@ -143,7 +135,7 @@ $\mathrm{RHS}_N\to 0$ together with $\mathrm{LHS}_N$. No contradiction
 is available from the per-block projection. The dominant case
 $k_0=0$ is the unique index for which the ratio in~\eqref{eq:decay}
 is the constant~$1$ and the bound stays uniform; that is the analytic
-content of \leanid{fixed\_right\_dominant\_\ldots\_CFBNT}.
+content of the dominant special case.
 
 Two independent probes confirm the obstruction. Path~$\alpha$
 (\path{audits/2026-05-13_cpsv16_ft_exact_leading_coeff.md},
@@ -152,8 +144,7 @@ $c_N(\mu^B_0)^N\zeta^N=(\mu^A_0)^N$ fails at $r_A=r_B=2$ with distinct
 sub-dominant moduli. Path~$\beta$ scope adjustment
 (\path{audits/2026-05-13_cpsv16_ft_path_beta_scout.md},
 \ghpr{1664}) shows the lifted per-block projection on the
-\leanid{SectorDecomposition} surface inherits the same decay
-mismatch.
+sector-decomposition surface inherits the same decay mismatch.
 
 \section{The argument the source uses}
 
@@ -183,40 +174,36 @@ identification, contradicting $c_N\ne 0$ and $\mu^B_{k_0}\ne 0$. The
 mechanism uses only the coefficient match forced by linear
 independence; it requires neither side to stay bounded away from~$0$.
 
-The formalization currently provides the smaller \texttt{Lem1} instance
-$\{V^{(N)}(A_j)\}\cup\{V^{(N)}(B_{k_0})\}$ as
-\leanid{MPSTensor.eventually\_linearIndependent\_all\_left\_single\_right\_of\_all\_overlaps\_decay\_CFBNT}
-and its symmetric
-\leanid{\ldots\_all\_right\_single\_left\_\ldots\_CFBNT}.\footnote{%
-    \path{TNLean/MPS/FundamentalTheorem/Full/NondecayingOverlap.lean}
-    lines~710 and~769.}
-The larger combined-family instance \eqref{eq:largeLem1} is not
-formalized.
+The present formalization provides the combined-family eventual linear
+independence statement as
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li}, assuming the
+inter-family cross-overlaps vanish.  The remaining work is to use that
+linear-independence conclusion in the proportional PaperBNT argument without
+returning to the failed per-block projection.
 
 \section{Classification}
 
-\emph{Scope restriction combined with an open gap.} The dominant
-declarations
-\leanid{fixed\_right\_dominant\_\ldots\_CFBNT} and
-\leanid{fixed\_left\_dominant\_\ldots\_CFBNT}
-prove the Step~1 conclusion for $k_0=\langle 0,\_\rangle$ on the
-one-copy surface. The universally quantified statements stay open
-because the cited mechanism requires either
+\emph{Scope restriction combined with an open gap.}  The direct projection
+argument works only for a dominant block on the one-copy surface.  The
+universally quantified statement should instead proceed by one of the following
+mathematical routes:
 
 \begin{enumerate}
     \item the combined-family \texttt{Lem1} statement
           \eqref{eq:largeLem1} with all-pairwise cross-overlap decay,
           enabling the coefficient-identification step
           of~\eqref{eq:isolate}; or
-    \item the two-layer paper-faithful structure of
-          \cite[Definition~4.3]{Cirac2021Matrix}, separating spectral
-          levels $\lambda_j$ from within-sector unit-modulus weights
-          $\mu_{j,q}$. The two-layer surface
-          \leanid{MPSTensor.IsBNTCanonicalFormSD}\footnote{%
-              \doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}.}
-          permits the geometric factor in~\eqref{eq:decay} to be
-          cancelled against $c_N$ before projection, recovering a
-          constant lower bound. Tracked in \ghissue{1641}.
+    \item an additional equal-modulus factorization
+          $\mu_{j,q}=\lambda_j\nu_{j,q}$ with $|\nu_{j,q}|=1$, together
+          with the rate estimates needed to compare the cross-overlap decay
+          with $|\lambda_j/\lambda_{k_0}|^N$.  In the present formal
+          development such a factorization is represented only by the optional
+          structure \leanid{HasEqualModulusWeightLayer}\footnote{%
+              \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/EqualModulus}.}
+          and is not part of the core predicate
+          \leanid{IsBNTCanonicalForm}.\footnote{%
+              \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Basic}.}
+          Tracked in \ghissue{1641}.
 \end{enumerate}
 
 The collapse $r_j=1$ enforced by \leanid{mu\_strict\_anti}

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -6,10 +6,9 @@
 
 \input{command}
 
-\title{Two-Layer Sector Refinement of CPSV16 \texttt{eq:II\_ABasicTensors}\\
-in \leanid{IsBNTCanonicalFormSD}}
+\title{Equal-Modulus Refinements of CPSV16 \texttt{eq:II\_ABasicTensors}}
 \author{}
-\date{2026-05-13}
+\date{2026-05-18}
 
 \begin{document}
 \maketitle
@@ -17,104 +16,82 @@ in \leanid{IsBNTCanonicalFormSD}}
 \section{The source assertion}
 
 Cirac--P\'erez-Garc\'ia--Schuch--Verstraete 2016~\cite{Cirac2016MPDO_arXiv}
-expresses any tensor $A$ in canonical form in terms of its basis of normal
-tensors (BNT) $A_j$ as
+expresses a tensor $A$ in canonical form in terms of its basis of normal
+tensors $A_j$ as
 \begin{equation}
   \label{eq:bnt-general}
   A^i = \bigoplus_{j=1}^{g} \bigoplus_{q=1}^{r_j}
-        \mu_{j,q}\, X_{j,q}\, A^i_j\, X_{j,q}^{-1},
+        \mu_{j,q}\, X_{j,q}\, A^i_j\, X_{j,q}^{-1}.
   \tag{\texttt{eq:II\_ABasicTensors}}
 \end{equation}
-where $\mu_{j,q} \in \mathbb{C}$ are \emph{arbitrary} complex coefficients
-(no ordering or unit-modulus condition is imposed), $X_{j,q}$ are invertible
-gauge matrices, and $A_j$ are the BNT normal blocks. The eventual linear
-independence of the BNT vectors $\lvert V^{(N)}(A_j)\rangle$ is recorded
-separately in Definition~\texttt{def:4:BNT} of
-\cite{Cirac2021Matrix}.
+The coefficients $\mu_{j,q}$ are raw complex weights.  The display does not
+require the weights in a fixed sector $j$ to have the same modulus, nor does it
+strictly order the moduli of different sectors.  The normalization stated
+earlier in CPSV16 is only the global convention
+\begin{align}
+    |\mu_{j,q}|\leq 1
+    \quad\text{for every }j,q,
+    \qquad
+    |\mu_{j,q}|=1
+    \quad\text{for at least one }j,q.
+\end{align}
 
-\section{The extra hypotheses in \leanid{IsBNTCanonicalFormSD}}
+\section{The present formal surface}
 
-The \Lean{} predicate \leanid{IsBNTCanonicalFormSD} in
-\doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}
-is a \emph{project-specific specialization} of
-\eqref{eq:bnt-general}. It adds three hypotheses beyond what
-\eqref{eq:bnt-general} asserts:
+The current PaperBNT formulation follows \eqref{eq:bnt-general} directly.
+The core predicate
+\leanid{IsBNTCanonicalForm}\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Basic}.}
+keeps the raw coefficients $\mu_{j,q}$ and records only the CPSV line-246
+normalization:
+\begin{align}
+    |\mu_{j,q}|\leq 1
+    \quad\text{for every }j,q,
+    \qquad
+    \exists j,q,\ |\mu_{j,q}|=1.
+\end{align}
+The per-block unit-modulus condition needed in the projection step of the
+fundamental theorem is not a field of the predicate.  It appears as an explicit
+theorem-level hypothesis in the coefficient non-vanishing statement
+\leanid{IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}.\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.}
 
-\begin{enumerate}
-  \item \textbf{Strict spectral ordering.}
-        The predicate requires the existence of spectral-level coefficients
-        $\lambda_j \in \mathbb{C}$ (one per BNT sector $j$) with
-        $\|\lambda_0\| > \|\lambda_1\| > \cdots > \|\lambda_{g-1}\|$
-        (recorded as \leanid{StrictAnti (fun j => \|spectralLevel j\|)}).
-        No such ordering is present in \eqref{eq:bnt-general}.
+\section{The optional equal-modulus layer}
 
-  \item \textbf{Unit-modulus within-sector factors.}
-        Each weight $\mu_{j,q}$ is required to factor as
-        $\mu_{j,q} = \lambda_j \cdot \nu_{j,q}$ with $|\nu_{j,q}| = 1$,
-        recorded as $\|\textit{weight}_{j,q} / \lambda_j\| = 1$
-        (\leanid{weight\_factor}).
-        The general form \eqref{eq:bnt-general} allows $|\mu_{j,q}|$
-        to vary arbitrarily within a sector. The unit-modulus factorization
-        is conceptually related to the RFP characterization in
-        \texttt{thm:charact-MPS} of~\cite{Cirac2016MPDO_arXiv}
-        (lines 543--555), which is a strict sub-class of the general BNT.
+Some estimates become cleaner under the stronger factorization
+\begin{align}
+    \mu_{j,q}=\lambda_j\nu_{j,q},
+    \qquad
+    |\nu_{j,q}|=1.
+    \label{eq:equal-modulus-layer}
+\end{align}
+This is now represented only by the optional structure
+\leanid{HasEqualModulusWeightLayer}.\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/EqualModulus}.}
+It is not part of \leanid{IsBNTCanonicalForm}.  The separation is essential:
+the BNT form $C\oplus (1/2)C$ has a single basis tensor with two copies whose
+weights have distinct moduli, so it satisfies \eqref{eq:bnt-general} but does
+not admit \eqref{eq:equal-modulus-layer}.
 
-  \item \textbf{Dominant normalization.}
-        The dominant spectral level satisfies $\|\lambda_0\| = 1$
-        (\leanid{spectralLevel\_dom\_norm\_one}). This mirrors the
-        \leanid{IsNormalCanonicalFormBNT.mu\_dom\_norm\_one} convention in
-        \doclink{TNLean/MPS/BNT/Construction}; it is not imposed by
-        \eqref{eq:bnt-general}.
-\end{enumerate}
+The optional layer also uses a non-strict ordering of the moduli
+$|\lambda_j|$.  A strict ordering would exclude valid canonical forms such as
+$C\oplus D$ with two non-equivalent normal tensors and weights of equal
+modulus.
 
-\section{What these hypotheses collectively define}
+\section{Classification}
 
-Together, the three conditions define a \emph{specialization} of
-\eqref{eq:bnt-general} in which equal-modulus blocks have been grouped
-into sectors, a common spectral factor $\lambda_j$ extracted, and the
-dominant sector normalized to $|\lambda_0| = 1$. This is the
-structure computed by the \leanid{SectorDecomposition} grouping in the
-project, and it subsumes the RFP case of
-\texttt{thm:charact-MPS}~\cite{Cirac2016MPDO_arXiv}.
+\emph{Scope restriction.}  Any theorem that assumes
+\leanid{HasEqualModulusWeightLayer} proves a result for the equal-modulus
+subclass of the CPSV BNT form, not for the general statement
+\eqref{eq:bnt-general}.  Such a theorem may be used as a restricted result, but
+it should not be marked as the source theorem unless the displayed
+factorization \eqref{eq:equal-modulus-layer} is stated as an explicit
+hypothesis.
 
-The three conditions are a \emph{specialization} (additional hypotheses
-on top of \eqref{eq:bnt-general}), not a deviation: every
-\leanid{IsBNTCanonicalFormSD} instance arises from a valid
-\eqref{eq:bnt-general} decomposition by grouping and normalizing.
-The planned adapter from the one-copy normal-canonical BNT formulation to
-\leanid{IsBNTCanonicalFormSD} must now be stated from
-\leanid{IsNormalCanonicalFormBNT}, or from explicit separated-block
-hypotheses, via rescaling by $\rho = \|\mu_0\|$.
-
-\section{Scope restriction}
-
-The adapter absorbs only the one-copy-per-sector case ($r_j = 1$ for all $j$).
-The full multi-copy BNT form with $r_j > 1$ - and the associated
-Newton--Girard recovery of multiplicities from $\sum_q \mu_{j,q}^N$ - is a
-separate paper-level gap documented in
-\path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}.
-The \leanid{SectorDecomposition} surface is multi-copy-ready
-(\leanid{copies j} may exceed 1), but the current adapter does not
-populate it beyond $r_j = 1$.
-
-\section{Formal declarations}
-
-The relevant formal declarations are:
-\begin{itemize}
-  \item \leanid{IsBNTCanonicalFormSD} -
-        the predicate (\doclink{TNLean/MPS/FundamentalTheorem/SectorDecomposition/IsBNTCanonicalFormSD}).
-  \item \leanid{IsBNTCanonicalFormSD.spectralLevel\_strict\_anti} -
-        the \leanid{StrictAnti} accessor.
-  \item \leanid{IsBNTCanonicalFormSD.weight\_factor} -
-        the unit-modulus factorization accessor.
-  \item \leanid{IsBNTCanonicalFormSD.spectralLevel\_dom\_norm\_one} -
-        the dominant normalization accessor.
-  \item A future adapter from \leanid{IsNormalCanonicalFormBNT}, or from
-        explicit separated-block hypotheses, to \leanid{IsBNTCanonicalFormSD}.
-\end{itemize}
-See also \ghpr{1657} (branch \path{feat/mps-ft-path-beta-pr1-two-layer})
-and the audit memo
-\path{audits/2026-05-13_cpsv16_ft_path_beta_scout.md} §``PR~1.5 amendment''.
+The general PaperBNT route should use the raw-weight results in
+\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}: coefficient boundedness,
+cross-overlap decay, combined-family eventual linear independence, and
+coefficient non-vanishing under a supplied unit-modulus copy.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -2,7 +2,7 @@
 
 \usepackage{amsmath,amssymb}
 \usepackage{xurl}
-\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+\usepackage[hidelinks]{hyperref}
 
 \input{command}
 


### PR DESCRIPTION
## Summary

Closes #1739.

This updates the paper-gap notes that still described the retired two-layer and one-copy BNT proof surfaces. The notes now point to the current PaperBNT formulation:

- raw BNT weights in `IsBNTCanonicalForm`, with the optional equal-modulus layer separated into `HasEqualModulusWeightLayer`;
- qualitative cross-overlap decay, combined-family eventual linear independence, coefficient boundedness, and coefficient non-vanishing through `PaperBNT/Api.lean`;
- the remaining non-dominant and proportional scalar obligations stated without references to deleted declarations or files.

## Validation

- `git diff --check`
- `rg` check that the deleted Tier 3 / retired BNT references no longer occur in `docs/paper-gaps`
- standalone `latexmk` compile of the four changed notes with repository `docs/paper-gaps/command.tex` first in `TEXINPUTS`

`lake build` was not run because this PR changes only paper-gap documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that reframe gaps/assumptions and update references, with no impact on Lean code or runtime behavior.
> 
> **Overview**
> Updates several `docs/paper-gaps` notes to stop referencing the retired one-copy/two-layer BNT proof surfaces and instead point to the current *PaperBNT* formulation and its supported lemmas in `PaperBNT/Api` (qualitative cross-overlap decay, combined-family eventual LI, coefficient boundedness, and non-vanishing).
> 
> Rewrites the “rate quantified decay” note to describe the needed *rate condition* under an equal-modulus refinement as an **unformalized** assumption, and rewrites the per-block projection and fixed-block cancellation notes to restate the remaining non-dominant/proportional cancellation obligations without citing deleted declarations. Also refreshes titles/dates and standardizes `hyperref` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3ebc396c394684e5e914b373296e038682488d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->