### PR TITLE
doc(blueprint): add chapter-one notation table

### DIFF
--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -14,6 +14,26 @@ basis-of-normal-tensors argument of~\cite{Cirac2016MPDO_arXiv,Cirac2021Matrix},
 with the single-block injective case anchored in the earlier representation
 theorem of~\cite{PerezGarcia2007Matrix}.
 
+\section*{Notation}
+
+\begin{center}
+\begin{tabular}{ll}
+    $\C$, $\N$, $\Z$ & complex numbers, natural numbers, integers \\
+    $\MN{D}$, $\GL_D(\C)$ & complex matrices and invertible complex matrices \\
+    $\tr(X)$, $\spn_{\C}(S)$ & trace and complex linear span \\
+    $A=\{A^i\}_{i=0}^{d-1}$ & a translation-invariant MPS tensor \\
+    $w=(i_1,\ldots,i_L)$, $A^w$ & a word and the product
+        $A^{i_1}\cdots A^{i_L}$ \\
+    $\ket{V^{(N)}(A)}$ & the length-$N$ matrix product vector \\
+    $V^{(N)}(A)_\sigma$ & the coefficient of $\ket{V^{(N)}(A)}$ at
+        $\sigma$ \\
+    $O_{AB}(N)$ & the bilinear overlap
+        $\overline{\braket{V^{(N)}(A)}{V^{(N)}(B)}}$ \\
+    $\E_A(X)$ & the transfer map $\sum_i A^i X(A^i)^\dagger$ \\
+    $A^{[L]}$ & the length-$L$ blocked tensor \\
+\end{tabular}
+\end{center}
+
 In canonical form one writes
 \[
     A^i = \bigoplus_{j=1}^{g} \mu_j A_j^i,
@@ -46,9 +66,9 @@ control normal blocks. Chapters~\ref{ch:wielandt} and~\ref{ch:canonical}
 supply the blocking, primitivity, irreducibility, and canonical-form reductions.
 Chapters~\ref{ch:block_perm} and~\ref{ch:bnt} isolate block permutation, block
 separation, bases of normal tensors, and the power-sum comparison.
-Chapter~\ref{ch:ft_proof} records the current conditional non-periodic theorem
+Chapter~\ref{ch:ft_proof} records the conditional non-periodic theorem
 statements; the remaining BNT matching and fixed-length span inputs are kept as
-explicit hypotheses until the corresponding source steps are formalized.
+explicit hypotheses until the corresponding source steps are supplied.
 
 The chapters after Chapter~\ref{ch:ft_proof} collect applications,
 alternative formulations, and later tensor-network material.
@@ -64,5 +84,5 @@ Chapter~\ref{ch:algebraic_ft}
 gives the fixed-length algebraic Fundamental Theorem of~\cite{Molnar2018NormalPEPS},
 and Chapter~\ref{ch:peps_ft} records the PEPS analogs. The later chapters
 cover dynamical semigroups, entropy, matrix product density operators, parent
-Hamiltonians, correlations, and examples; these are downstream of the
-aperiodic proof rather than part of its dependency chain.
+Hamiltonians, correlations, and examples; these topics use the aperiodic theorem
+rather than enter its proof.


### PR DESCRIPTION
### Motivation

- `blueprint/src/chapter/ch01_intro.tex` lacked a notation table defining the core symbols ($A^i$, $A^w$, $\mathcal{E}_A$, etc.) used throughout the later chapters, making the blueprint harder to read without cross-referencing the Lean source.
- Several introductory sentences used proof-status phrasing ("formalized", "current") instead of mathematical source-step wording, conflicting with the blueprint prose guide.
- Issue #318 identifies both gaps and requests style-guide compliance for this chapter.

### Description

- Added a compact notation table to `blueprint/src/chapter/ch01_intro.tex` defining MPS and transfer-map conventions (MPS tensors, words and products, overlap matrices, transfer maps, and blocking) that are referenced in later chapters.
- Replaced remaining proof-status phrasing with source-step wording (e.g., "source steps supplied", "conditional on") to keep the introduction mathematical throughout.
- No Lean source or formal statements changed; only `.tex` documentation modified.

### Testing

- `git diff --check`
- `rg -n "formalized|formalization|formalizes|formalize|Lean|implementation|pipeline|surface|version|data|API|endpoint|dependency chain|downstream" blueprint/src/chapter/ch01_intro.tex || true` (banned-term scan)
- `cd blueprint && leanblueprint web` (completed; existing bibliography and renderer warnings remain)

---
Closes #318

> [!NOTE]
> **Low Risk**
> Low risk: LaTeX-only documentation edits that adjust presentation and terminology without affecting any formal statements or code.
> 
> **Overview**
> Adds a new **Chapter 1 "Notation"** table in `ch01_intro.tex`, defining the core symbols used later (MPS tensors, words/products, overlaps, transfer maps, and blocking).
> 
> Rewords a few introductory sentences to remove proof-status phrasing (e.g., "current"/"formalized") in favor of "conditional"/"source steps supplied", and clarifies that later topics *use* the aperiodic theorem rather than being part of its proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09cdb28edfee38500b92de4997bc4cdc0463e862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: LaTeX-only documentation changes that add a notation reference table and slightly reword introductory prose without affecting any formal statements or code.
> 
> **Overview**
> Adds a new *Chapter 1* `Notation` table to `ch01_intro.tex`, defining the core symbols used throughout the blueprint (MPS tensors, words/products, overlaps, transfer map, and blocking).
> 
> Rewords a few introduction sentences to remove proof-status phrasing (e.g., “current”, “formalized/dependency chain”) in favor of mathematical wording (“conditional”, “source steps supplied”) and clarifies that later topics *use* the aperiodic theorem rather than being part of its proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 278528752f1e42638a810ad2d32eb1955da4b94b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->