### PR TITLE
feat(MPS/FT/PaperBNT): expose unit global-gauge phases

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean
@@ -181,7 +181,7 @@ theorem ft_paper_bnt_equal_global_gaugePos
       (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
       (ζ : Fin Q.basisCount → ℂ)
       (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
-      (∀ k : Fin Q.basisCount, ζ k ≠ 0) ∧
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
       (∀ (k : Fin Q.basisCount) (i : Fin d),
         Q.basis k i =
           ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
@@ -213,8 +213,6 @@ theorem ft_paper_bnt_equal_global_gaugePos
   let Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ :=
     fun k => (hGPE k).choose
   let ζ : Fin Q.basisCount → ℂ := fun k => (hGPE k).choose_spec.choose
-  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := fun k =>
-    (hGPE k).choose_spec.choose_spec.1
   have hConj : ∀ (k : Fin Q.basisCount) (i : Fin d),
       Q.basis k i =
         ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
@@ -230,6 +228,24 @@ theorem ft_paper_bnt_equal_global_gaugePos
       (A := cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k)))
       (B := Q.basis k) (Xblock k) (ζ k) (hConj k) N σ,
       mpv_cast_dim (hDim k) (P.basis (β k)) N σ]
+  have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := by
+    intro k
+    have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) (P.basis (β k)) (P.basis (β k)) N‖)
+        atTop (𝓝 (1 : ℝ)) := by
+      have h1 := (hP.basis_normalized_self_overlap (β k)).norm
+      simpa using h1
+    have hBB : Tendsto (fun N => ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k) N‖)
+        atTop (𝓝 (1 : ℝ)) := by
+      have h1 := (hQ.basis_normalized_self_overlap k).norm
+      simpa using h1
+    have hScale :=
+      mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis (β k)) (B := Q.basis k)
+        (ζ := ζ k) (hMpv k)
+    exact norm_eq_one_of_selfOverlap_scale (ζ := ζ k) hAA hBB hScale
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
+    intro k hzero
+    have hnorm := hζ_norm k
+    simp [hzero] at hnorm
   have hCoeff := coeff_identity_via_matched_mpv_phasePos hP hEqual β ζ hMpv
   have hWeightData : ∀ k : Fin Q.basisCount,
       ∃ (hCopies : P.copies (β k) = Q.copies k)
@@ -297,7 +313,7 @@ theorem ft_paper_bnt_equal_global_gaugePos
         toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis := by
     funext i
     simp [toTensorFromBlocks]
-  refine ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_ne, hConj, hWeight, ?_⟩
+  refine ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, hWeight, ?_⟩
   refine ⟨globalGaugeOfBlocks Xcoord, rfl, ?_⟩
   intro i
   calc
@@ -337,7 +353,7 @@ theorem ft_paper_bnt_equal_global_gauge
       (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
       (ζ : Fin Q.basisCount → ℂ)
       (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
-      (∀ k : Fin Q.basisCount, ζ k ≠ 0) ∧
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
       (∀ (k : Fin Q.basisCount) (i : Fin d),
         Q.basis k i =
           ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *

--- a/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean
@@ -19,7 +19,7 @@ exposes, for any two BNT sector decompositions $P$ and $Q$ satisfying
 * per-block bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$;
 * matched copy multiplicities $r_{βk}^P = r_k^Q$;
 * matched copy permutations $τ_k$;
-* per-block gauge phases $ζ_k \in \mathbb{C}^\times$;
+* per-block unit-modulus gauge phases $ζ_k$;
 * per-block gauge matrices $X_k \in \mathrm{GL}(D_Q^{(k)},\mathbb{C})$;
 * the equality of total bond dimensions $\sum_k r_k D_k$;
 * the explicit global gauge $X \in \mathrm{GL}(\sum_s D^{(s)},\mathbb{C})$;
@@ -66,7 +66,7 @@ same MPV family, then there exist:
 * per-block bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$,
 * matched copy multiplicities $r_{βk}^P = r_k^Q$,
 * per-block copy permutations $τ_k$,
-* per-block gauge phases $ζ_k \in \mathbb{C}^\times$,
+* per-block unit-modulus gauge phases $ζ_k$,
 * per-block gauge matrices $X_k \in \mathrm{GL}(D_Q^{(k)},\mathbb{C})$,
 * a total bond-dimension equality $\sum_k r_k D_k = \sum_k r_k' D_k'$, and
 * an explicit global gauge $X \in \mathrm{GL}\bigl(\sum_s D^{(s)},
@@ -99,7 +99,7 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv_witnessesPos
       (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ)
       (_hTotal : P.totalDim = Q.totalDim)
       (X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ),
-      (∀ k : Fin Q.basisCount, ζ k ≠ 0) ∧
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
       (∀ (k : Fin Q.basisCount) (i : Fin d),
         Q.basis k i =
           ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
@@ -119,13 +119,13 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv_witnessesPos
               Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
                      (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ)) := by
   classical
-  obtain ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_ne, hConj, hWeight, X, _hXdef, hGauge⟩ :=
+  obtain ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, hWeight, X, _hXdef, hGauge⟩ :=
     ft_paper_bnt_equal_global_gaugePos hP hQ hUnitP hUnitQ hEqual
   -- `P.totalDim = Q.totalDim` follows from `sectorFlatEquiv` plus matched dims
   have hTotal : P.totalDim = Q.totalDim :=
     SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
   -- the bond-dimension index `Q.totalDim` and `∑ s, Q.flatDim s` agree definitionally
-  refine ⟨β, hDim, hCopies, τ, ζ, Xblock, hTotal, X, hζ_ne, hConj, hWeight, ?_⟩
+  refine ⟨β, hDim, hCopies, τ, ζ, Xblock, hTotal, X, hζ_norm, hConj, hWeight, ?_⟩
   intro i
   exact hGauge i
 
@@ -144,7 +144,7 @@ theorem ft_paper_bnt_equal_mps_gaugeEquiv_witnesses
       (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ)
       (_hTotal : P.totalDim = Q.totalDim)
       (X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ),
-      (∀ k : Fin Q.basisCount, ζ k ≠ 0) ∧
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
       (∀ (k : Fin Q.basisCount) (i : Fin d),
         Q.basis k i =
           ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1250,7 +1250,8 @@ BNT basis.
               $\dim P_{\beta(k)}=\dim Q_k$,
         \item copy-number equalities $r_{\beta(k)}(P)=r_k(Q)$ and
               copy permutations $\tau_k$,
-        \item phases $\zeta_k\neq 0$ and block gauges $X_k$,
+        \item unit-modulus phases $\zeta_k$ with $|\zeta_k|=1$ and block
+              gauges $X_k$,
     \end{itemize}
     such that, for every sector $k$, copy $q$, and physical index $i$,
     \[
@@ -1287,8 +1288,10 @@ BNT basis.
     identifications, and the gauge-phase equivalences between $Q_k$ and
     $P_{\beta(k)}$. Lemma~\ref{lem:paper_bnt_coeff_identity_via_matched_mpv_phase}
     gives the eventual exact coefficient identities for the same phases
-    $\zeta_k$. The matched-sector weight-permutation theorem then gives the
-    copy permutations and the displayed pointwise weight identities. Finally
+    $\zeta_k$. The normalized self-overlap limits in the BNT hypotheses force
+    $|\zeta_k|=1$ for every matched sector. The matched-sector
+    weight-permutation theorem then gives the copy permutations and the
+    displayed pointwise weight identities. Finally
     Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} assembles the block
     conjugacies into the flattened direct-sum conjugation by
     $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.


### PR DESCRIPTION
### Motivation

- `ft_paper_bnt_equal_global_gauge` exposed per-block scalars `ζ : Fin Q.basisCount → ℂ` with only `∀ k, ζ k ≠ 0`, whereas arXiv:1606.00608 §II.C (lines 1184–1192) derives `B_k = e^{iφ_k} X_k A_{j_k} X_k^{-1}` with `|e^{iφ_k}| = 1` throughout.
- The weaker nonzero condition is not faithful to the source's unit-modulus guarantee; the gap is documented in `docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex`. Continues faithfulness work from #1733.

### Description

- Strengthens `ft_paper_bnt_equal_global_gaugePos` and `ft_paper_bnt_equal_global_gauge` in `TNLean/MPS/FundamentalTheorem/PaperBNT/Fundamental.lean`: the per-block phase conclusion changes from `∀ k, ζ k ≠ 0` to `∀ k, ‖ζ k‖ = 1`.
- Proves the unit-modulus property locally from the gauge relation and normalized self-overlap limits (option 2 from issue #1735: derive the norm bound rather than modify `GaugePhaseEquiv`).
- `GaugePhaseEquiv` is unchanged; it remains a broad nonzero scalar-gauge predicate. The unit-modulus conclusion is proved only where BNT normalization hypotheses are available.
- Propagates the stronger conclusion to the bundled witness theorem and docstring in `TNLean/MPS/FundamentalTheorem/PaperBNT/FundamentalCoord.lean`.

### Testing

- `lake build TNLean.MPS.FundamentalTheorem.PaperBNT.Fundamental`
- `lake build TNLean.MPS.FundamentalTheorem.PaperBNT.FundamentalCoord`
- `lake build TNLean`
- `git diff --check`

---
Closes #1735

> [!NOTE]
> **Medium Risk**
> Changes the statement of core PaperBNT fundamental-theorem witness theorems by strengthening the phase condition from nonzero to unit-norm, which may require downstream lemma updates and could subtly affect proof obligations.
> 
> **Overview**
> Strengthens the PaperBNT global gauge witness theorems (`ft_paper_bnt_equal_global_gaugePos`/`ft_paper_bnt_equal_global_gauge`) to return **unit-modulus** per-block phases (`∀ k, ‖ζ k‖ = 1`) instead of merely `ζ k ≠ 0`.
> 
> Adds a local proof that the chosen phases have norm 1 (derived from the block gauge relation plus normalized self-overlap limits) and then derives nonzero as a corollary where needed. Propagates the updated phase condition through the bundled witness theorem in `FundamentalCoord.lean` and updates the associated documentation text accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58a3284b87d5eb368292092221bceaca73ef6fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public statements of key PaperBNT fundamental-theorem witness theorems by strengthening the phase condition from nonzero to unit-norm, which may break downstream proofs that pattern-match on the old `ζ ≠ 0` assumption. The new unit-modulus proof relies on asymptotic self-overlap limits, so regressions would surface as proof failures rather than runtime issues.
> 
> **Overview**
> **Strengthens the equal-MPV global-gauge witness output**: `ft_paper_bnt_equal_global_gaugePos`/`ft_paper_bnt_equal_global_gauge` (and the bundled witness `ft_paper_bnt_equal_mps_gaugeEquiv_witnesses(Pos)`) now conclude `∀ k, ‖ζ k‖ = 1` instead of `∀ k, ζ k ≠ 0`.
> 
> Adds a local proof in `Fundamental.lean` deriving `‖ζ k‖ = 1` from the gauge-induced MPV scaling plus the BNT normalized self-overlap limits, and then re-derives `ζ k ≠ 0` only where required for weight-permutation lemmas. Documentation in `FundamentalCoord.lean` and the blueprint (`ch10_bnt.tex`) is updated to match the unit-modulus phase claim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7ef1489b0e4a4fd1adb4d6b8150cc80931f3fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->