### PR TITLE
doc(paper-gaps): update retired BNT notes

### DIFF
--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -8,9 +8,9 @@
 \input{command}
 
 \title{Rate-Quantified BNT Cross-Overlap Decay\\
-       on the \leanid{PaperBNT} Sector Surface}
+       under an Equal-Modulus Refinement}
 \author{}
-\date{2026-05-13}
+\date{2026-05-18}
 
 \begin{document}
 \maketitle
@@ -18,11 +18,11 @@
 \section{Notation}
 
 Fix a sector decomposition $P$ with basis blocks
-$\{P.\mathtt{basis}\,j\}_{j=0}^{g-1}$ and a spectral level
-$\lambda_j\in\mathbb C\setminus\{0\}$ with
-$\|\lambda_0\|>\|\lambda_1\|>\cdots>\|\lambda_{g-1}\|$ and
-$\|\lambda_0\|=1$. The bilinear cross-overlap between basis blocks
-$j$ and $k$ at length $N$ is
+$\{P.\mathtt{basis}\,j\}_{j=0}^{g-1}$.  Suppose an additional
+equal-modulus refinement has supplied nonzero spectral levels
+$\lambda_j\in\mathbb C$ such that the moduli are non-increasing in $j$,
+and the first level has modulus $1$ when $g>0$.  The bilinear
+cross-overlap between basis blocks $j$ and $k$ at length $N$ is
 \begin{align}
     O_{j,k}(N) := 
     \mathtt{mpvOverlap}\bigl(P.\mathtt{basis}\,j,
@@ -62,25 +62,23 @@ The argument as written does not quantify the rate of decay in
 
 Definition~4.3 of~\cite{Cirac2021Matrix} packages
 \eqref{eq:qual} indirectly under \emph{eventual linear independence} of
-the basis MPVs and does not state a rate. The formalization records this
-eventual linear-independence input in the shared sector-decomposition
-infrastructure,\footnote{%
-    \doclink{TNLean/MPS/SharedInfra/SectorDecomposition}.}
-while \eqref{eq:qual} is provided pointwise by
+the basis MPVs and does not state a rate. The formal counterpart is
+the predicate
+\leanid{MPSTensor.HasBNTSectorData}\footnote{%
+    \doclink{TNLean/MPS/SharedInfra/SectorDecomposition} at
+    \leanid{HasBNTSectorData}.}
+in the formalization, and \eqref{eq:qual} is provided pointwise by
 \leanid{MPSTensor.mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP}.\footnote{%
     \doclink{TNLean/MPS/Overlap/CastDecay}.}
 Neither source equips $\eta_{j,k}$ with a quantitative relation
 to the spectral weight ratios.
 
-\section{The retired rate hypothesis}
+\section{The rate condition}
 
-An earlier formal route introduced an explicit rate hypothesis on a
-sector decomposition $P$ and a chosen spectral level
-$\lambda:\mathrm{Fin}\,P.\mathtt{basisCount}\to\mathbb C$.  That route
-has since been retired together with the per-block-projection layer.  The
-mathematical hypothesis it was trying to isolate remains the following:
-there should exist non-negative families $C,\eta$ such that for every
-$j\ne k$,
+The rate condition that would discharge the non-dominant projection argument
+takes a sector decomposition $P$ and a spectral level
+$\lambda:\mathrm{Fin}\,P.\mathtt{basisCount}\to\mathbb C$. It asserts the
+existence of non-negative families $C,\eta$ such that for every $j\ne k$,
 \begin{align}
     0\le C_{j,k},\quad 0\le\eta_{j,k}<1,
         \qquad
@@ -89,24 +87,29 @@ $j\ne k$,
 \end{align}
 together with the geometric bound~\eqref{eq:rate} for all $N$.
 
-The surviving \leanid{PaperBNT} surface does not package such constants.
-It keeps the raw BNT weights in \leanid{SectorDecomposition} and records
-qualitative consequences in
-\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}: the coefficient
-bound \leanid{SectorDecomposition.norm\_coeff\_le\_copies\_of\_norm\_weight\_le\_one},
-within-family cross-decay
-\leanid{MPSTensor.IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero}, the
-combined-family linear-independence criterion
-\leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li}, and the
-non-vanishing coefficient statement
-\leanid{MPSTensor.IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}.  None of
-these declarations supplies the constants in~\eqref{eq:hyp}.
+This condition is not currently a formal declaration.  It is meaningful only
+after choosing an equal-modulus refinement that separates a common spectral
+level $\lambda_j$ from within-sector phases.  The present paper-faithful route
+keeps the raw CPSV weights $\mu_{j,q}$ in the core BNT predicate and does not
+impose such a factorization.
 
-\section{Where such a hypothesis would be needed}
+The surviving formal statements used in the current route are the qualitative
+and coefficient estimates in
+\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.  In particular,
+\leanid{IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero} gives
+the limit~\eqref{eq:qual},
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li} gives the
+combined-family linear-independence conclusion from vanishing cross-overlaps,
+\leanid{IsBNTCanonicalForm.norm\_coeff\_le\_copies} bounds the raw sector
+coefficient under the CPSV line-246 normalization, and
+\leanid{IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block} gives the
+non-vanishing conclusion for a block carrying a unit-modulus copy.
 
-The retired per-block-projection route carried an abstract hypothesis
-excluding asymptotic cancellation of the assembled overlap against a
-chosen projection block~$k_0$.  The obstruction analysis in
+\section{Where the rate condition would be used}
+
+The retired two-layer per-block-projection lemmas carried an abstract
+non-cancellation hypothesis ruling out asymptotic cancellation of the assembled
+overlap against the chosen projection block~$k_0$.  The obstruction analysis in
 \path{audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md} shows that
 for a non-dominant $k_0$ the discharge requires, after isolating
 $V^{(N)}(P.\mathtt{basis}\,k_0)$ on the right and renormalising by
@@ -121,15 +124,15 @@ The right-hand side of~\eqref{eq:product} converges to $0$ exactly when
 \eqref{eq:hyp} holds. The qualitative limit~\eqref{eq:qual} alone
 gives $\eta_{j,k_0}<1$ but not the comparison
 $\eta_{j,k_0}\cdot\|\lambda_j/\lambda_{k_0}\|<1$, which is the
-content of the new hypothesis.
+content of the rate condition.
 
 \section{Classification}
 
-\emph{Open gap.}  The rate condition~\eqref{eq:hyp} is a structural input
-beyond what \cite[\S II]{Cirac2016MPDO_arXiv} and
-\cite[Definition~4.3]{Cirac2021Matrix} make explicit. Its rate is
-in principle derivable from the spectral gap of the mixed transfer
-operator that powers
+\emph{Open gap.}  The rate condition above is a structural input beyond what
+\cite[\S II]{Cirac2016MPDO_arXiv} and
+\cite[Definition~4.3]{Cirac2021Matrix} make explicit. Its rate is in
+principle derivable from the spectral gap of the mixed transfer operator that
+powers
 \leanid{mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP},
 but the compatibility inequality
 $\eta_{j,k}\cdot\|\lambda_j/\lambda_k\|<1$ is not implied by the
@@ -138,11 +141,13 @@ BNT structure and must be either imposed or established analytically.
 The analytic derivation from the transfer matrix spectral gap is the
 subject of \emph{Option~2} in the design memo
 \path{audits/2026-05-13_cpsv16_ft_path_beta_pr2_5_design.md} and is
-not addressed in this note. The current \leanid{PaperBNT} route instead
-keeps the coefficient comparison and the combined-family linear
-independence in \path{TNLean/MPS/FundamentalTheorem/PaperBNT}; any future
-rate-quantified argument should be stated against that surviving surface,
-not against the retired per-block-projection layer.
+not addressed in this note.  The current PaperBNT route instead records the
+source-faithful qualitative overlap decay, coefficient boundedness, and
+coefficient non-vanishing separately in
+\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}; any future use of the
+rate condition should be added as a theorem-level hypothesis or proved from
+the mixed-transfer spectral gap, not by reviving the deleted two-layer
+projection surface.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -8,7 +8,7 @@
 
 \title{The Fixed-Block Cancellation Step in CPSV16 Theorem II.1}
 \author{}
-\date{2026-05-11}
+\date{2026-05-18}
 
 \begin{document}
 \maketitle
@@ -65,14 +65,15 @@ The formal boundary in \cite{Cirac2016MPDO_arXiv} is narrower:
     \right)
     =r_A+1.
 \end{align}
-The surviving \leanid{PaperBNT} API does not currently contain this
-single-block linear-independence formulation.  It supplies the stronger
-full-family mechanism
-\leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li},
-under all-pairwise cross-overlap decay; this is sufficient for the
-coefficient-comparison contradiction, but it is not the literal
-single-block statement displayed above.
-The exact fixed-block contradiction step is still open:
+In the present PaperBNT development the relevant linear-independence input is
+the combined-family statement
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li}, which applies
+when all cross-overlaps between the two BNT basis families vanish.\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.}
+This is a stronger input than the single-fixed-block family furnished by
+Corollary~\texttt{Lem1} in the source passage, and should not be read as a
+formalization of that corollary itself.
+The exact contradiction step is still open:
 \begin{align}
     (\forall j,  \langle V^{(N)}(B_{k_0}),V^{(N)}(A_j)\rangle\to 0)
     \Longrightarrow
@@ -82,11 +83,10 @@ The exact fixed-block contradiction step is still open:
       c_N\sum_k \nu_k^N\,V^{(N)}(B_k)
     \right).
 \end{align}
-No current Lean declaration carries the retired fixed-right or fixed-left
-one-copy fixed-block names.  The mathematical target remains the
-source-faithful fixed-block cancellation at
-\cite[lines~1181--1185]{Cirac2016MPDO_arXiv}, now to be stated on the
-\leanid{PaperBNT} sector surface.
+This is the source-faithful fixed-block cancellation step
+\cite[lines~1181--1185]{Cirac2016MPDO_arXiv}.  It remains a mathematical
+obligation in the proportional PaperBNT route rather than a live declaration on
+the retired one-copy surface.
 
 The earlier conditional helpers requiring combined-family linear independence
 (\path{_phase_sum_li}) and the residual-span variants have been retired in
@@ -98,10 +98,10 @@ supplied by Corollary~\texttt{Lem1}.  The remaining open obligation is the
 fixed-block cancellation itself, to be discharged without combined-family LI or
 residual-span exclusion.
 
-Retirement note: this note intentionally no longer lists the retired no-tail,
-leading-only, partner-identification, leading-tail, residual-span, or
-\path{_phase_sum_li} declarations.  They were deleted as wrong-direction or
-orphan scaffolding in the same audit.
+Thus the current note records the mathematical obligation rather than the
+former auxiliary surfaces: the contradiction must be obtained from the
+fixed-block hypothesis in the CPSV16 passage itself, not from a
+combined-family statement whose hypotheses belong to a different route.
 
 \section{Current discharge plan}
 
@@ -121,8 +121,8 @@ all residual blocks on both sides.
 
 \textit{Classification: Scope restriction.}
 
-The intended factored analytic discharge uses four explicit analytic
-hypotheses:
+The non-cancellation conclusion is formally established under four explicit
+analytic hypotheses:
 \begin{enumerate}
   \item unit-modulus sector weights on both the $A$-family and the $B$-family;
   \item off-diagonal cross-overlap decay on the fixed-block family, i.e.,
@@ -132,14 +132,19 @@ hypotheses:
   \item an eventual positive lower bound $\|c_N\| \geq \delta > 0$.
 \end{enumerate}
 Hypotheses~(1)--(3) are present in the source via the BNT structure
-\cite[Theorem~\texttt{thm1}]{Cirac2016MPDO_arXiv}.  Hypothesis~(4) is not
-directly supplied: the cited argument rules out cancellation by appeal to the
-dominant-adjusted scalar limit, but deriving the explicit lower bound
-$\|c_N\|\geq\delta$ from the structural data of the canonical form is not yet
-formalized and is recorded as an open obligation in
-\path{audits/2026-05-13_cpsv16_ft_sorry_discharge_plan.md}.  The earlier
-non-cancellation helpers carrying this lower-bound hypothesis were part of
-the retired Tier~3 route and should not be cited as present declarations.
+\cite[Theorem~\texttt{thm1}]{Cirac2016MPDO_arXiv}.  On the present PaperBNT
+surface they are represented by the following formal statements:
+\leanid{IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero},
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li}, and
+\leanid{IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}; the
+coefficient boundedness used in the same estimates is
+\leanid{IsBNTCanonicalForm.norm\_coeff\_le\_copies}.\footnote{%
+  All four declarations are in
+  \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.}
+Hypothesis~(4) is not directly supplied: the cited argument rules out
+cancellation by appeal to the dominant-adjusted scalar limit, but deriving the
+explicit lower bound $\|c_N\|\geq\delta$ from the structural data of the
+canonical form remains an open obligation in the proportional route.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -10,7 +10,7 @@
 \title{Non-Dominant Per-Block Projection in CPSV16 \S II Step~1\\
        under the One-Copy Normal-Canonical BNT Formulation}
 \author{}
-\date{2026-05-13}
+\date{2026-05-18}
 
 \begin{document}
 \maketitle
@@ -81,21 +81,23 @@ $\{V^{(N)}(A_j)\}_j\cup\{V^{(N)}(B_{k_0})\}$ from~\eqref{eq:Hk0} and
 combines it with the proportionality identity at
 \cite[eq.~\texttt{eq:II\_ABasicTensors}, line~286]{Cirac2016MPDO_arXiv}.
 
-\section{Formal target}
+\section{Formal boundary}
 
-The mathematical target is, for $k_0:\mathrm{Fin}\,r_B$ arbitrary:
-given the one-copy normal-canonical BNT hypotheses on both $\mu^A,A$ and
-$\mu^B,B$,
-\leanid{EventuallyNonzeroProportionalMPV\textsubscript{2}} between the
-assembled tensors, an index $k_0:\mathrm{Fin}\,r_B$ and the hypothesis
-$\forall j,\langle V^{(N)}(A_j),V^{(N)}(B_{k_0})\rangle\to 0$, derive
-$\bot$.
-The old one-copy fixed-block declarations for this target have been
-retired.  The surviving route is the \leanid{PaperBNT} proportional
-matching layer, which keeps the raw coefficients of
-\leanid{SectorDecomposition} visible and uses the API lemmas in
-\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.  The universally
-quantified fixed-block cancellation remains a mathematical obligation.
+The earlier one-copy formal target tried to prove, for an arbitrary
+$k_0:\mathrm{Fin}\,r_B$, that eventual proportionality of the two assembled
+families contradicts
+$\forall j,\langle V^{(N)}(A_j),V^{(N)}(B_{k_0})\rangle\to 0$.  That route
+belonged to the retired one-copy fundamental-theorem development.
+
+The present PaperBNT route keeps the raw weights $\mu_{j,q}$ in a sector
+decomposition.  The available formal ingredients are
+\leanid{IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero},
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li},
+\leanid{IsBNTCanonicalForm.norm\_coeff\_le\_copies}, and
+\leanid{IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}.\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.}
+The obstruction below records why a direct per-block projection is not the
+right replacement for the source's linear-independence argument.
 
 \section{Where the per-block projection fails for non-dominant
 \texorpdfstring{$k_0$}{k0}}
@@ -112,14 +114,23 @@ and $\mathrm{RHS}_N:=c_N\langle V^{(N)}(B_{\mathrm{tot}}),V^{(N)}(B_{k_0})\rangl
 \end{align}
 With $\|\mu^A_j\|\le 1$, every $(\mu^A_j)^N$ is bounded; together with
 \eqref{eq:Hk0} this forces $\mathrm{LHS}_N\to 0$. For $\mathrm{RHS}_N$,
-the current cross-overlap decay statement
-\leanid{MPSTensor.IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero}
-gives $\langle V^{(N)}(B_k),V^{(N)}(B_{k_0})\rangle\to 0$ for $k\ne k_0$,
-while the diagonal block has a nonzero limiting coefficient, so
+BNT cross-overlap decay\footnote{%
+    In the present PaperBNT surface this is
+    \leanid{IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero}.}
+gives $\langle V^{(N)}(B_k),V^{(N)}(B_{k_0})\rangle\to 0$ for $k\ne k_0$
+and a nonzero limit $\ell$ at $k=k_0$, so
 $\mathrm{RHS}_N=c_N(\mu^B_{k_0})^N(\ell+o(1))$.
-In the dominant block, the proportionality identity and the BNT normalizations
-give the dominant-adjusted scalar limit
-$\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$.  Therefore
+For the dominant pair, the proportionality identity projected onto the matched
+dominant block, together with normalized self-overlap and vanishing
+off-diagonal overlaps, gives the scalar comparison
+\begin{align}
+    \bigl\|c_N(\mu^B_0)^N\bigr\|
+    \sim \|(\mu^A_0)^N\|.
+\end{align}
+Equivalently,
+$\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$.  This is the dominant
+normalization calculation in the CPSV16 Step~1 argument
+\cite[lines~1170--1180]{Cirac2016MPDO_arXiv}.  Therefore
 \begin{align}
     \bigl\|c_N(\mu^B_{k_0})^N\bigr\|
     &\sim
@@ -133,8 +144,7 @@ $\mathrm{RHS}_N\to 0$ together with $\mathrm{LHS}_N$. No contradiction
 is available from the per-block projection. The dominant case
 $k_0=0$ is the unique index for which the ratio in~\eqref{eq:decay}
 is the constant~$1$ and the bound stays uniform; that is the analytic
-content that the dominant fixed-block statement captured before the
-retirement of the old one-copy layer.
+content of the dominant special case.
 
 Two independent probes confirm the obstruction. Path~$\alpha$
 (\path{audits/2026-05-13_cpsv16_ft_exact_leading_coeff.md},
@@ -143,8 +153,7 @@ $c_N(\mu^B_0)^N\zeta^N=(\mu^A_0)^N$ fails at $r_A=r_B=2$ with distinct
 sub-dominant moduli. Path~$\beta$ scope adjustment
 (\path{audits/2026-05-13_cpsv16_ft_path_beta_scout.md},
 \ghpr{1664}) shows the lifted per-block projection on the
-\leanid{SectorDecomposition} surface inherits the same decay
-mismatch.
+sector-decomposition surface inherits the same decay mismatch.
 
 \section{The argument the source uses}
 
@@ -174,35 +183,36 @@ identification, contradicting $c_N\ne 0$ and $\mu^B_{k_0}\ne 0$. The
 mechanism uses only the coefficient match forced by linear
 independence; it requires neither side to stay bounded away from~$0$.
 
-The current \leanid{PaperBNT} API provides the combined-family
-linear-independence mechanism as
-\leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li}.
-The remaining task is to combine that statement with the proportional
-coefficient identity in the fixed-block setting, without appealing to the
-retired per-block-projection layer.
+The present formalization provides the combined-family eventual linear
+independence statement as
+\leanid{IsBNTCanonicalForm.combined\_family\_eventually\_li}, assuming the
+inter-family cross-overlaps vanish.  The remaining work is to use that
+linear-independence conclusion in the proportional PaperBNT argument without
+returning to the failed per-block projection.
 
 \section{Classification}
 
-\emph{Scope restriction combined with an open gap.} The retired dominant
-fixed-block declarations proved the Step~1 conclusion for
-$k_0=\langle 0,\_\rangle$ on the one-copy surface. The universally
-quantified statements stay open because the cited mechanism requires
-either
+\emph{Scope restriction combined with an open gap.}  The direct projection
+argument works only for a dominant block on the one-copy surface.  The
+universally quantified statement should instead proceed by one of the following
+mathematical routes:
 
 \begin{enumerate}
     \item the combined-family \texttt{Lem1} statement
           \eqref{eq:largeLem1} with all-pairwise cross-overlap decay,
           enabling the coefficient-identification step
           of~\eqref{eq:isolate}; or
-    \item the two-layer paper-faithful structure of
-          \cite[Definition~4.3]{Cirac2021Matrix}, separating spectral
-          levels $\lambda_j$ from within-sector unit-modulus weights
-          $\mu_{j,q}$.  On the surviving \leanid{SectorDecomposition}
-          surface this means keeping the raw coefficients
-          $\sum_q\mu_{j,q}^N$ visible and using
-          \leanid{MPSTensor.IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}
-          rather than collapsing the sector to a single weight before the
-          projection argument.  Tracked in \ghissue{1641}.
+    \item an additional equal-modulus factorization
+          $\mu_{j,q}=\lambda_j\nu_{j,q}$ with $|\nu_{j,q}|=1$, together
+          with the rate estimates needed to compare the cross-overlap decay
+          with $|\lambda_j/\lambda_{k_0}|^N$.  In the present formal
+          development such a factorization is represented only by the optional
+          structure \leanid{HasEqualModulusWeightLayer}\footnote{%
+              \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/EqualModulus}.}
+          and is not part of the core predicate
+          \leanid{IsBNTCanonicalForm}.\footnote{%
+              \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Basic}.}
+          Tracked in \ghissue{1641}.
 \end{enumerate}
 
 The collapse $r_j=1$ enforced by \leanid{mu\_strict\_anti}

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -2,14 +2,13 @@
 
 \usepackage{amsmath,amssymb}
 \usepackage{xurl}
-\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+\usepackage[hidelinks]{hyperref}
 
 \input{command}
 
-\title{Two-Layer Sector Refinement of CPSV16 \texttt{eq:II\_ABasicTensors}\\
-on the \leanid{PaperBNT} Sector Surface}
+\title{Equal-Modulus Refinements of CPSV16 \texttt{eq:II\_ABasicTensors}}
 \author{}
-\date{2026-05-13}
+\date{2026-05-18}
 
 \begin{document}
 \maketitle
@@ -17,107 +16,82 @@ on the \leanid{PaperBNT} Sector Surface}
 \section{The source assertion}
 
 Cirac--P\'erez-Garc\'ia--Schuch--Verstraete 2016~\cite{Cirac2016MPDO_arXiv}
-expresses any tensor $A$ in canonical form in terms of its basis of normal
-tensors (BNT) $A_j$ as
+expresses a tensor $A$ in canonical form in terms of its basis of normal
+tensors $A_j$ as
 \begin{equation}
   \label{eq:bnt-general}
   A^i = \bigoplus_{j=1}^{g} \bigoplus_{q=1}^{r_j}
-        \mu_{j,q}\, X_{j,q}\, A^i_j\, X_{j,q}^{-1},
+        \mu_{j,q}\, X_{j,q}\, A^i_j\, X_{j,q}^{-1}.
   \tag{\texttt{eq:II\_ABasicTensors}}
 \end{equation}
-where $\mu_{j,q} \in \mathbb{C}$ are \emph{arbitrary} complex coefficients
-(no ordering or unit-modulus condition is imposed), $X_{j,q}$ are invertible
-gauge matrices, and $A_j$ are the BNT normal blocks. The eventual linear
-independence of the BNT vectors $\lvert V^{(N)}(A_j)\rangle$ is recorded
-separately in Definition~\texttt{def:4:BNT} of
-\cite{Cirac2021Matrix}.
+The coefficients $\mu_{j,q}$ are raw complex weights.  The display does not
+require the weights in a fixed sector $j$ to have the same modulus, nor does it
+strictly order the moduli of different sectors.  The normalization stated
+earlier in CPSV16 is only the global convention
+\begin{align}
+    |\mu_{j,q}|\leq 1
+    \quad\text{for every }j,q,
+    \qquad
+    |\mu_{j,q}|=1
+    \quad\text{for at least one }j,q.
+\end{align}
 
-\section{The retired specialization}
+\section{The present formal surface}
 
-An earlier formal route introduced a project-specific specialization of
-\eqref{eq:bnt-general}.  That route grouped equal-modulus blocks into
-sectors, extracted a common spectral factor, and imposed three hypotheses
-which are stronger than the source display:
+The current PaperBNT formulation follows \eqref{eq:bnt-general} directly.
+The core predicate
+\leanid{IsBNTCanonicalForm}\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Basic}.}
+keeps the raw coefficients $\mu_{j,q}$ and records only the CPSV line-246
+normalization:
+\begin{align}
+    |\mu_{j,q}|\leq 1
+    \quad\text{for every }j,q,
+    \qquad
+    \exists j,q,\ |\mu_{j,q}|=1.
+\end{align}
+The per-block unit-modulus condition needed in the projection step of the
+fundamental theorem is not a field of the predicate.  It appears as an explicit
+theorem-level hypothesis in the coefficient non-vanishing statement
+\leanid{IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}.\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.}
 
-\begin{enumerate}
-  \item \textbf{Strict spectral ordering.}
-        The predicate requires the existence of spectral-level coefficients
-        $\lambda_j \in \mathbb{C}$ (one per BNT sector $j$) with
-        $\|\lambda_0\| > \|\lambda_1\| > \cdots > \|\lambda_{g-1}\|$
-        (formerly recorded as a strict-antitone condition on the chosen
-        spectral levels).
-        No such ordering is present in \eqref{eq:bnt-general}.
+\section{The optional equal-modulus layer}
 
-  \item \textbf{Unit-modulus within-sector factors.}
-        Each weight $\mu_{j,q}$ is required to factor as
-        $\mu_{j,q} = \lambda_j \cdot \nu_{j,q}$ with $|\nu_{j,q}| = 1$,
-        recorded by an explicit unit-modulus factorization condition.
-        The general form \eqref{eq:bnt-general} allows $|\mu_{j,q}|$
-        to vary arbitrarily within a sector. The unit-modulus factorization
-        is conceptually related to the RFP characterization in
-        \texttt{thm:charact-MPS} of~\cite{Cirac2016MPDO_arXiv}
-        (lines 543--555), which is a strict sub-class of the general BNT.
+Some estimates become cleaner under the stronger factorization
+\begin{align}
+    \mu_{j,q}=\lambda_j\nu_{j,q},
+    \qquad
+    |\nu_{j,q}|=1.
+    \label{eq:equal-modulus-layer}
+\end{align}
+This is now represented only by the optional structure
+\leanid{HasEqualModulusWeightLayer}.\footnote{%
+    \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/EqualModulus}.}
+It is not part of \leanid{IsBNTCanonicalForm}.  The separation is essential:
+the BNT form $C\oplus (1/2)C$ has a single basis tensor with two copies whose
+weights have distinct moduli, so it satisfies \eqref{eq:bnt-general} but does
+not admit \eqref{eq:equal-modulus-layer}.
 
-  \item \textbf{Dominant normalization.}
-        The dominant spectral level satisfies $\|\lambda_0\| = 1$.
-        This mirrors the \leanid{IsNormalCanonicalFormBNT.mu\_dom\_norm\_one}
-        convention in \doclink{TNLean/MPS/BNT/Construction}; it is not
-        imposed by \eqref{eq:bnt-general}.
-\end{enumerate}
+The optional layer also uses a non-strict ordering of the moduli
+$|\lambda_j|$.  A strict ordering would exclude valid canonical forms such as
+$C\oplus D$ with two non-equivalent normal tensors and weights of equal
+modulus.
 
-\section{The surviving formal surface}
+\section{Classification}
 
-The surviving surface separates the source display into two pieces.
-\leanid{SectorDecomposition} stores the basis blocks, their copy
-multiplicities, and the raw weights $\mu_{j,q}$ through the coefficient
-\[
-    P.\mathtt{coeff}\,N\,j=\sum_q (P.\mathtt{weight}\,j\,q)^N .
-\]
-\leanid{IsBNTCanonicalForm} then records the BNT hypotheses used by the
-fundamental-theorem route: irreducibility, left canonical normalization,
-gauge-phase distinctness of equal-dimensional basis blocks, eventual
-linear independence of the basis MPVs, bounded weights, and existence of
-at least one unit-modulus weight.
+\emph{Scope restriction.}  Any theorem that assumes
+\leanid{HasEqualModulusWeightLayer} proves a result for the equal-modulus
+subclass of the CPSV BNT form, not for the general statement
+\eqref{eq:bnt-general}.  Such a theorem may be used as a restricted result, but
+it should not be marked as the source theorem unless the displayed
+factorization \eqref{eq:equal-modulus-layer} is stated as an explicit
+hypothesis.
 
-This keeps the two-layer information visible without assuming strict
-ordering of spectral levels or a factorization
-$\mu_{j,q}=\lambda_j\nu_{j,q}$ as part of the BNT predicate.  When such a
-factorization is needed, it should be stated as an additional theorem
-hypothesis rather than hidden in the canonical-form predicate.
-
-\section{Scope restriction}
-
-The one-copy normal-canonical formulation
-\leanid{IsNormalCanonicalFormBNT} covers only the case $r_j=1$ for all
-$j$.  The full multi-copy BNT form with $r_j>1$ -- and the associated
-Newton--Girard recovery of multiplicities from $\sum_q\mu_{j,q}^N$ -- is a
-separate paper-level gap documented in
-\path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}.
-The \leanid{SectorDecomposition} surface is multi-copy-ready
-(\leanid{copies j} may exceed 1), but the current adapter does not
-populate it beyond $r_j = 1$.
-
-\section{Formal declarations}
-
-The relevant surviving formal declarations are:
-\begin{itemize}
-  \item \leanid{SectorDecomposition} -
-        the raw two-layer sector surface
-        (\doclink{TNLean/MPS/SharedInfra/SectorDecomposition}).
-  \item \leanid{IsBNTCanonicalForm} -
-        the BNT canonical-form predicate
-        (\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Basic}).
-  \item \leanid{MPSTensor.IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero},
-        \leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li},
-        \leanid{MPSTensor.IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block},
-        and \leanid{MPSTensor.IsBNTCanonicalForm.thermodynamic\_limit\_nonvanishing}
-        in \doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}.
-  \item A future adapter from \leanid{IsNormalCanonicalFormBNT}, or from
-        explicit separated-block hypotheses, to \leanid{IsBNTCanonicalForm}.
-\end{itemize}
-See also \ghpr{1657} (branch \path{feat/mps-ft-path-beta-pr1-two-layer})
-and the audit memo
-\path{audits/2026-05-13_cpsv16_ft_path_beta_scout.md} §``PR~1.5 amendment''.
+The general PaperBNT route should use the raw-weight results in
+\doclink{TNLean/MPS/FundamentalTheorem/PaperBNT/Api}: coefficient boundedness,
+cross-overlap decay, combined-family eventual linear independence, and
+coefficient non-vanishing under a supplied unit-modulus copy.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Closes #1739.

This updates the paper-gap notes that still described the retired two-layer and one-copy BNT proof surfaces. The notes now point to the current PaperBNT formulation:

- raw BNT weights in `IsBNTCanonicalForm`, with the optional equal-modulus layer separated into `HasEqualModulusWeightLayer`;
- qualitative cross-overlap decay, combined-family eventual linear independence, coefficient boundedness, and coefficient non-vanishing through `PaperBNT/Api.lean`;
- the remaining non-dominant and proportional scalar obligations stated without references to deleted declarations or files.

The branch was rebased onto current `main` after an overlapping paper-gap cleanup landed, so this PR contains only the remaining reviewed corrections against the present base.

## Validation

- `git diff --check`
- `rg` check that the deleted Tier 3 / retired BNT references no longer occur in the four changed notes
- standalone `latexmk` compile of the four changed notes with repository `docs/paper-gaps/command.tex` first in `TEXINPUTS`

`lake build` was not run because this PR changes only paper-gap documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to LaTeX documentation updates clarifying assumptions and pointing to current `PaperBNT` APIs, with no code or formalization logic modified.
> 
> **Overview**
> Updates the CPSV16 paper-gap notes to reflect the current **PaperBNT** formalization surface, removing/rewriting references to retired one-copy/two-layer projection scaffolding and instead pointing to the surviving `IsBNTCanonicalForm` + `PaperBNT/Api` statements (qualitative cross-overlap decay, combined-family eventual LI, coefficient bounds, and non-vanishing).
> 
> Reframes the “equal-modulus/two-layer” discussion as an *optional* `HasEqualModulusWeightLayer` refinement (not part of the core predicate), and clarifies where a quantitative “rate condition” would be needed for non-dominant projection arguments; also refreshes titles/hyperref settings and dates across the four notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 163d1679d991179811ba548174270f9c0a458438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->