### PR TITLE
doc(blueprint): polish CPGSV source displays

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -40,14 +40,14 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     \[
         B^i
         =
-        \mathbf{0}_{D_0}
+        \mathbf{0}_{d^{[p]},D_0}
         \oplus
         \bigoplus_{k=1}^{r} \mu_k B_k^i,
     \]
-    where $\mathbf{0}_{D_0}$ is the all-zero summand of bond dimension $D_0$
-    and the tensors $B_k$ are normal tensors. If $r>0$, the weights $\mu_k$
-    may be normalized so that $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for
-    at least one index $k$.
+    where $\mathbf{0}_{d^{[p]},D_0}$ is the all-zero summand of physical
+    dimension $d^{[p]}$ and bond dimension $D_0$, and the tensors $B_k$ are
+    normal tensors. If $r>0$, the weights $\mu_k$ may be normalized so that
+    $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
 \end{theorem}
 
 This chapter develops the constituent steps of this reduction:

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -74,7 +74,7 @@ Section~\ref{sec:ft_auxiliary_from_ch08}.
     \[
         A^i
         =
-        XB^iX^{-1}.
+        X\,B^i\,X^{-1}.
     \]
     Thus the equal case removes the blockwise phase freedom appearing in the
     proportional theorem and gives a single global conjugacy.


### PR DESCRIPTION
### Motivation

Polishes two minor annotation and formatting details in the CPGSV source-theorem displays corrected in #1776 (which addressed #1774), making the blueprint statements slightly more faithful and readable.

### Description

- `blueprint/src/chapter/ch08_canonical.tex` (`thm:cpgsv_canonical_form_source`): explicitly annotates the all-zero summand as `\mathbf{0}_{d^{[p]}, D_0}`, recording physical dimension `d^{[p]}` and bond dimension `D_0` (cf. CPGSV17a eq. `II_CF1`).
- `blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` (`thm:cpgsv_equal_case_source`): adds standard multiplication spacing in the global conjugacy formula (`X\,B^i\,X^{-1}`).

### Testing

- `git diff --check`
- `leanblueprint web` (succeeds; existing bibliography warnings remain)

---
<!-- No issue identified — author should link with Addresses #N. Nearest tracker: #1404. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: LaTeX-only wording/formatting tweaks that don't affect any implementation logic or APIs.
> 
> **Overview**
> Clarifies the canonical-form source theorem statement in `ch08_canonical.tex` by explicitly annotating the all-zero summand as `\mathbf{0}_{d^{[p]},D_0}` (physical dimension `d^{[p]}` and bond dimension `D_0`).
> 
> Improves readability of the equal-case global conjugacy display in `ch11_fundamental_theorem_proof.tex` by adding standard multiplication spacing: `X\,B^i\,X^{-1}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae6ee7f82606b1b0bf9263571546426f0827fc5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->