### PR TITLE
doc(parent-hamiltonian): mark spectral gap capstone notready

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2813,7 +2813,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \end{theorem}
 
 \begin{proof}
-    \leanok
+    \notready
     This follows immediately from Theorem~\ref{thm:friedrichs_gap_bound} by taking as
     $\gamma$ the explicit constant produced there, which yields the required existential
     spectral-gap constant.


### PR DESCRIPTION
### Motivation

Chapter 14 currently marks the proof of the MPS parent-Hamiltonian spectral-gap capstone as complete, but the Lean theorem `MPSTensor.parentHamiltonian_gapped` still depends on the Friedrichs-angle estimate `parentHamiltonianES_gap_bound_of_friedrichs`, whose proof is a documented `sorry`.

### Description

- Keeps the statement-level `\leanok` on `thm:parent_hamiltonian_gapped`; the Lean declaration has the intended statement.
- Replaces the proof-level `\leanok` by `\notready` until the Friedrichs-angle estimate tracked by #952/#460 is discharged.
- Keeps the `\lean{MPSTensor.parentHamiltonian_gapped}` declaration tag so the intended Lean target remains visible.

### Testing

- `git diff --check`
- `leanblueprint web` (passes; existing bibliography and renderer warnings remain)

Closes #1802

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adjusts blueprint readiness markers and does not alter any Lean declarations or mathematical statements.
> 
> **Overview**
> Marks the proof of the Chapter 14 spectral-gap capstone theorem `thm:parent_hamiltonian_gapped` as **not yet complete** by replacing the proof’s `\leanok` with `\notready`.
> 
> The theorem statement remains tagged `\leanok`/`\lean{MPSTensor.parentHamiltonian_gapped}`, but the blueprint now reflects that the proof still depends on the unfinished Friedrichs-angle gap bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a76bade9e3aba5f159c9b5b3a454562eec3eae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->