### PR TITLE
doc(blueprint): rename CPSV definition labels

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -69,7 +69,7 @@ structure---left-canonical normalization, strict modulus ordering,
 one-copy-per-sector---which is not present in the CPSV
 definitions stated below.
 
-\begin{definition}[CPSV normal tensor (NT)]\label{def:nt_paper}
+\begin{definition}[CPSV normal tensor (NT)]\label{def:nt_cpsv}
     \lean{MPSTensor.IsNormalTensor}
     \leanok
     A tensor $A$ of physical dimension $d$ and bond dimension $D$ is a
@@ -79,7 +79,7 @@ definitions stated below.
     after the spectral-radius normalization in~\cite[paragraph preceding the NT definition]{Cirac2017MPDO_AnnPhys}.
 \end{definition}
 
-\begin{definition}[CPSV canonical form (CF)]\label{def:cf_paper}
+\begin{definition}[CPSV canonical form (CF)]\label{def:cf_cpsv}
     \lean{MPSTensor.IsCPSVCanonicalForm}
     \leanok
     A tensor $A$ is in \emph{canonical form} if there is a finite family
@@ -95,13 +95,13 @@ definitions stated below.
     $|\mu_k| = 1$ for at least one $k$.
 \end{definition}
 
-\begin{definition}[CPSV basis of normal tensors (BNT)]\label{def:bnt_paper}
+\begin{definition}[CPSV basis of normal tensors (BNT)]\label{def:bnt_cpsv}
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors}
     \leanok
     A finite family $\{A_j\}_{j=1}^g$ of normal tensors, with bond dimension
     allowed to depend on $j$, is a \emph{basis of normal tensors} for $A$ if:
     \begin{enumerate}
-        \item each $A_j$ is normal in the sense of Definition~\ref{def:nt_paper};
+        \item each $A_j$ is normal in the sense of Definition~\ref{def:nt_cpsv};
         \item for every system length $N$ there exist coefficients
               $c_j^{(N)} \in \C$ with
               \[
@@ -116,7 +116,7 @@ definitions stated below.
 \begin{remark}[Relation to the strong predicates]
     A tensor $A$ which is both irreducible (Definition~\ref{def:irreducible_tensor})
     and has primitive transfer map is normal in the sense of
-    Definition~\ref{def:nt_paper}. The reverse implications from the
+    Definition~\ref{def:nt_cpsv}. The reverse implications from the
     stronger predicates of Definition~\ref{def:is_normal_canonical_form} and
     of Chapter~\ref{ch:bnt} require either the fundamental-theorem step or
     the algebraic-to-spectral normality equivalence; these appear in
@@ -335,7 +335,7 @@ see in particular Theorem~\ref{thm:irreducible_action_cumulative_span}.
 \section{Canonical form from primitivity}\label{sec:canonical_from_primitivity}
 
 The canonical form conditions
-(Definition~\ref{def:cf_paper})
+(Definition~\ref{def:cf_cpsv})
 include an explicit hypothesis
 that the self-overlap $O_{A_k A_k}(N) \to 1$
 for each block.
@@ -347,7 +347,7 @@ primitive, removing periodicity.
 \begin{remark}[Two routes to the canonical-form predicate from normal blocks]
     Given a family of injective, left-canonical, strictly-ordered
     nonzero-weight blocks $(\mu_k, A_k)$, the canonical-form conditions of
-    Definition~\ref{def:cf_paper} can be discharged from either of two
+    Definition~\ref{def:cf_cpsv} can be discharged from either of two
     spectral hypotheses on the per-block transfer map $\E_{A_k}$: a
     positive-definite primitive fixed point, or the peripheral-spectrum
     condition $\sigma_\partial(\E_{A_k}) = \{1\}$. In both cases the
@@ -837,7 +837,7 @@ is the normality of a TP-primitive irreducible block.
     \label{def:trivial_sector_decomp}
     \lean{MPSTensor.trivialSectorDecomp}
     \leanok
-    \uses{def:paper_sector_data}
+    \uses{def:sector_weight_data}
     Given nonzero weights $(\mu_k)_{k=1}^r$ and blocks $(B_k)_{k=1}^r$, the
     \emph{granular sector decomposition} has $r$ sectors, one basis block
     $B_k$ per sector, multiplicity~$1$ in each sector, and sector weight
@@ -933,7 +933,7 @@ is the normality of a TP-primitive irreducible block.
 \label{subsec:paperbnt_supplier}
 
 The basis-of-normal-tensors predicate of~\cite{Cirac2017MPDO_AnnPhys}
-(Definition~\ref{def:bnt_paper}) is strengthened in Chapter~\ref{ch:bnt} by
+(Definition~\ref{def:bnt_cpsv}) is strengthened in Chapter~\ref{ch:bnt} by
 multiplicity, span, and weight-norm conditions. The results below separate the
 after-blocking preparation of suitable blocks from the later normalized-weight
 BNT construction.
@@ -1019,7 +1019,7 @@ BNT construction.
         \item $P$ and the assembled tensor $\bigoplus_{k=1}^{r} \mu_k B_k$
               generate the same MPV family at every length, and
         \item $P$ satisfies the canonical-form basis-of-normal-tensors conditions
-              of Definition~\ref{def:bnt_paper}, together with the multiplicity,
+              of Definition~\ref{def:bnt_cpsv}, together with the multiplicity,
               span, and weight-bound conditions used in Chapter~\ref{ch:bnt}.
     \end{itemize}
 \end{theorem}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -559,7 +559,7 @@ factorization is assumed.
     \label{def:sector_bnt_cf}
     \lean{MPSTensor.IsBNTCanonicalForm}
     \leanok
-    \uses{def:paper_sector_data}
+    \uses{def:sector_weight_data}
     Given a sector decomposition $P$, the BNT canonical-form predicate
     records the minimal BNT hypotheses of
     \cite{Cirac2017MPDO_AnnPhys,Cirac2021Matrix} without any equal-modulus
@@ -594,7 +594,7 @@ factorization is assumed.
     \label{lem:sector_bnt_coeff_eq_sum_weight_pow}
     \lean{MPSTensor.SectorDecomposition.coeff_eq_sum_weight_pow}
     \leanok
-    \uses{def:paper_sector_data}
+    \uses{def:sector_weight_data}
     For every sector decomposition $P$, every length $N$, and every basis
     index $j$, the sector coefficient is the raw power sum
     \[
@@ -826,7 +826,7 @@ the substitution argument of Section~\ref{subsec:sector_bnt_substitution} below.
     \label{lem:sector_bnt_matched_sector_weight_multiset_eq}
     \lean{MPSTensor.matched_sector_weight_multiset_eq}
     \leanok
-    \uses{def:paper_sector_data,
+    \uses{def:sector_weight_data,
         thm:power_sum_multiset}
     Let $P, Q$ be sector decompositions with weights $\mu_{j,q}$ and
     $\nu_{k,q'}$, and fix indices $j_0$, $\tilde k_0$, and a nonzero scalar

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -249,7 +249,7 @@ geometric extrapolation and Newton--Girard steps are external finite-sequence
 facts used to recover the lists of weights from those power sums.
 
 \begin{definition}[Sector weights and sector decomposition]%
-    \label{def:paper_sector_data}
+    \label{def:sector_weight_data}
     \lean{MPSTensor.SectorWeightData, MPSTensor.SectorDecomposition}
     \leanok
     A sector-weight tuple over $g$ basis blocks consists of
@@ -268,7 +268,7 @@ facts used to recover the lists of weights from those power sums.
     \label{lem:paper_decomp_formula}
     \lean{MPSTensor.SectorDecomposition.mpv_toTensor_eq_sum_coeff}
     \leanok
-    \uses{def:paper_sector_data}
+    \uses{def:sector_weight_data}
     For a sector decomposition $S$ with associated tensor $A_{\mathrm{tot}}$,
     the MPV satisfies
     \[
@@ -281,7 +281,7 @@ facts used to recover the lists of weights from those power sums.
     \label{lem:coeff_eventually_eq}
     \lean{MPSTensor.SectorWeightData.coeff_eventually_eq_of_sameMPV}
     \leanok
-    \uses{def:paper_sector_data, def:bnt}
+    \uses{def:sector_weight_data, def:bnt}
     If two sector-weight tuples $S, T$ over the same basis, with coefficient arrays
     $c_{S,j}^{(N)}$ and $c_{T,j}^{(N)}$, produce equal total MPVs
     and the basis is eventually linearly independent (the BNT property),
@@ -296,7 +296,7 @@ facts used to recover the lists of weights from those power sums.
     \label{lem:bnt_power_sum_recover_copies_weights}
     \lean{MPSTensor.SectorWeightData.exists_copies_eq_and_weight_multiset_eq_of_sameMPV_bnt}
     \leanok
-    \uses{def:paper_sector_data, def:bnt}
+    \uses{def:sector_weight_data, def:bnt}
     Let $S$ and $T$ be two sector-weight tuples over the same basis, without assuming
     their multiplicities agree. If the basis is eventually linearly
     independent and the total MPVs of $S$ and $T$ agree, then there are
@@ -332,7 +332,7 @@ facts used to recover the lists of weights from those power sums.
     \label{lem:phase_match_recover_copies_weights}
     \lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies}
     \leanok
-    \uses{def:paper_sector_data}
+    \uses{def:sector_weight_data}
     Let $P$ and $Q$ be sector decompositions. Assume there is a permutation
     $\pi$ matching the basis blocks and, for each $j$, a nonzero complex
     number $\zeta_j$ such that
@@ -361,7 +361,7 @@ facts used to recover the lists of weights from those power sums.
     \label{lem:phase_match_sector_weights}
     \lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch}
     \leanok
-    \uses{def:paper_sector_data}
+    \uses{def:sector_weight_data}
     Let $P$ and $Q$ be sector decompositions. Assume there is a permutation
     $\pi$ matching the basis blocks, the multiplicities satisfy
     $r_j^P = r_{\pi(j)}^Q$, and for each $j$ there is a nonzero complex number
@@ -388,7 +388,7 @@ facts used to recover the lists of weights from those power sums.
     \label{lem:gauge_phase_matched_basis_sector_weights}
     \lean{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_matched_basis}
     \leanok
-    \uses{def:paper_sector_data, def:gauge_phase_equiv}
+    \uses{def:sector_weight_data, def:gauge_phase_equiv}
     Let $P$ and $Q$ be sector decompositions. Assume there is a permutation
     $\pi$ matching the basis blocks, the multiplicities satisfy
     $r_j^P = r_{\pi(j)}^Q$, and each matched pair of basis blocks is
@@ -412,7 +412,7 @@ facts used to recover the lists of weights from those power sums.
     \label{def:sector_basis_matching}
     \lean{MPSTensor.SectorBasisMatching}
     \leanok
-    \uses{def:paper_sector_data, def:gauge_phase_equiv}
+    \uses{def:sector_weight_data, def:gauge_phase_equiv}
     A \emph{sector basis matching} between two sector decompositions $P$ and $Q$
     consists of
     \begin{enumerate}
@@ -432,7 +432,7 @@ facts used to recover the lists of weights from those power sums.
     \label{def:sector_basis_pre_matching}
     \lean{MPSTensor.SectorBasisPreMatching}
     \leanok
-    \uses{def:paper_sector_data, def:gauge_phase_equiv}
+    \uses{def:sector_weight_data, def:gauge_phase_equiv}
     A \emph{sector basis pre-matching} between sector decompositions $P$
     and $Q$ consists of a permutation of their basis blocks, equality of the
     matched bond dimensions, and gauge-phase equivalence of each matched pair.
@@ -445,7 +445,7 @@ facts used to recover the lists of weights from those power sums.
     \label{def:sector_basis_overlap_ortho_hyps}
     \lean{MPSTensor.SectorBasisOverlapOrthoHypotheses}
     \leanok
-    \uses{def:paper_sector_data, def:mpv_overlap}
+    \uses{def:sector_weight_data, def:mpv_overlap}
     For one sector decomposition $P$, this condition states positive basis
     dimensions, trace-preserving normalization of all basis blocks,
     self-overlap limits equal to~$1$, and off-overlap limits equal to~$0$.
@@ -455,7 +455,7 @@ facts used to recover the lists of weights from those power sums.
     \label{def:sector_basis_overlap_span_hyps}
     \lean{MPSTensor.SectorBasisOverlapSpanHypotheses}
     \leanok
-    \uses{def:paper_sector_data, def:mpv_overlap, def:mpv_state,
+    \uses{def:sector_weight_data, def:mpv_overlap, def:mpv_state,
         def:sector_basis_overlap_ortho_hyps}
     For sector decompositions $P$ and $Q$, this condition states the
     primitive overlap-rigidity hypotheses for their basis blocks: nonzero
@@ -513,7 +513,7 @@ facts used to recover the lists of weights from those power sums.
     \label{thm:sector_basis_matching_from_overlap_ortho_span}
     \lean{MPSTensor.exists_sectorBasisMatching_of_overlapOrtho_span_sameMPV}
     \leanok
-    \uses{def:paper_sector_data, def:sector_basis_matching, def:mpv_overlap}
+    \uses{def:sector_weight_data, def:sector_basis_matching, def:mpv_overlap}
     Assume the basis blocks of two sector decompositions have nonzero bond
     dimensions, are trace-preserving and injective, have asymptotically
     orthonormal overlaps within each family, and span the same MPV subspace at


### PR DESCRIPTION
### Motivation

- Blueprint labels for the CPSV normal-tensor, canonical-form, BNT, and sector-weight definitions used a generic `paper` suffix. These labels are reader-facing anchors in the compiled blueprint and should name the mathematical objects they define, not their provenance.

### Description

Renames four blueprint `\label{...}` anchors and all corresponding `\ref{...}` / `\uses{...}` sites in chapters 8, 10, and 11:

- `def:nt_paper` → `def:nt_cpsv`
- `def:cf_paper` → `def:cf_cpsv`
- `def:bnt_paper` → `def:bnt_cpsv`
- `def:paper_sector_data` → `def:sector_weight_data`

There are no Lean source changes and no mathematical statement changes.

### Testing

- `git diff --check` passed.
- Searched `blueprint/src`, `TNLean`, `docs`, and `audits` for retired labels to confirm no reference sites were missed.
- Relies on Blueprint Lint CI (`lint-blueprint.yml`) to validate that all `\ref{...}` and `\uses{...}` references resolve.

---
Addresses #1170.
Addresses #1685.

> [!NOTE]
> **Low Risk**
> Low risk: this PR only renames LaTeX `\label{...}` anchors and updates corresponding `\ref`/`\uses` references, with no Lean or mathematical-content changes. Main risk is broken internal links if any reference sites were missed.
>
> **Overview**
> Renames several reader-facing blueprint anchors from generic `paper` naming to CPSV-specific labels, updating all in-text `\ref{...}` and `\uses{...}` sites accordingly.
>
> Specifically: `def:nt_paper`→`def:nt_cpsv`, `def:cf_paper`→`def:cf_cpsv`, `def:bnt_paper`→`def:bnt_cpsv`, and `def:paper_sector_data`→`def:sector_weight_data` across chapters 8, 10, and 11.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366462d03aedd5c2cf0a3feffd57215ff82b92a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>