### PR TITLE
refactor(blueprint): remove unused diagram aliases

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -78,9 +78,6 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNPEPSGaugeCancellation": "",
     "TNPEPSLocalGaugeExtraction": "",
     "TNPEPSGlobalConsistency": "",
-    "TNMPOCellDiagram": "tensor top bottom",
-    "TNMPOChainDiagram": "",
-    "TNLPDODiagram": "",
 }
 
 

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1112,18 +1112,4 @@
   \end{tikzpicture}%
 }
 
-% ---------- Compatibility wrappers ----------
-
-\newcommand{\TNMPOCellDiagram}[3]{%
-  \TNMPOCell{#1}{#2}{#3}%
-}
-
-\newcommand{\TNMPOChainDiagram}{%
-  \TNMPOChain{M}{\sigma_1}{\tau_1}{\sigma_N}{\tau_N}{N}%
-}
-
-\newcommand{\TNLPDODiagram}{%
-  \TNLPDO{A}{A^\dagger}{k}{i}{j}%
-}
-
 \makeatother

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -21,6 +21,3 @@ name: TNPEPSEdgeGaugeOrientation TNPEPSGaugeVertexAction
 
 name: TNPEPSGaugeCancellation TNPEPSLocalGaugeExtraction TNPEPSGlobalConsistency
 {{ obj.tn_svg_html }}
-
-name: TNMPOCellDiagram TNMPOChainDiagram TNLPDODiagram
-{{ obj.tn_svg_html }}


### PR DESCRIPTION
Part of #1170.

This removes three unused tensor-diagram compatibility aliases from the blueprint source:

- `\TNMPOCellDiagram`
- `\TNMPOChainDiagram`
- `\TNLPDODiagram`

The chapters already use the mathematical diagram macros directly (`\TNMPOCell`, `\TNMPOChain`, and `\TNLPDO`), so the alias layer no longer has callers. The matching plasTeX registrations are removed as well, keeping the macro definitions and web-renderer table in agreement.

Verification:
- `rg -n "TNMPOCellDiagram|TNMPOChainDiagram|TNLPDODiagram|Compatibility wrappers" blueprint/src blueprint/web || true`
- `git diff --check`
- `cd blueprint && leanblueprint web`

The web build completed with the repository's existing plasTeX bibliography/default-renderer warnings, and with no missing tensor-diagram command from this deletion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes unused compatibility macros and their plasTeX registrations without changing the underlying diagram macros or rendering logic; main risk is only if any downstream content still referenced the deleted aliases.
> 
> **Overview**
> Removes three unused tensor-diagram compatibility aliases (the `\TNMPOCellDiagram`, `\TNMPOChainDiagram`, and `\TNLPDODiagram` wrappers) from `macros/tn_print.tex`.
> 
> Updates the web blueprint renderer to match by dropping these names from the plasTeX diagram registration tables (`tn_diagrams.py` and `TensorNetworkDiagrams.jinja2s`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be12d606e8d28a284b3cf8bcaea69fbe4a635cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->