### PR TITLE
refactor(blueprint): remove unused LPDO diagram macro

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -41,7 +41,6 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNTransferMap": "tensor",
     "TNMPOCell": "tensor top bottom",
     "TNMPOChain": "tensor top_left bottom_left top_right bottom_right length",
-    "TNLPDO": "upper lower bond top bottom",
     "TNGaugeConjugation": "left physical right",
     "TNPhysicalRealization": "virtual physical",
     "TNLinearTwist": "twist label",

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -185,23 +185,6 @@
   \end{tikzpicture}%
 }
 
-\newcommand{\TNLPDO}[5]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnA}{(0,\TN@doublelayersep)}
-    \TN@tensordot{tnB}{(0,-\TN@doublelayersep)}
-    \TN@leftleg{tnA}{0.8}
-    \TN@leftleg{tnB}{0.8}
-    \TN@rightleg{tnA}{0.8}
-    \TN@rightleg{tnB}{0.8}
-    \TN@upleg{tnA}{\TN@physleglen}
-    \TN@downleg{tnB}{\TN@physleglen}
-    \TN@uplabel{tnA}{\TN@physlabeloff}{#4}
-    \TN@downlabel{tnB}{\TN@physlabeloff}{#5}
-    \draw[tn leg] (tnA.south) -- (tnB.north);
-    \node at ($(tnA.south)!0.5!(tnB.north)+(0.28,0)$) {$#3$};
-  \end{tikzpicture}%
-}
-
 \newcommand{\TNGaugeConjugation}[3]{%
   \begin{tikzpicture}[tn picture]
     \TN@opdotabove{tnXl}{(-1.10,0)}{#1}

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -1,4 +1,4 @@
-name: TNMPSLocal TNMPSWord TNMPV TNTransferMap TNMPOCell TNMPOChain TNLPDO
+name: TNMPSLocal TNMPSWord TNMPV TNTransferMap TNMPOCell TNMPOChain
 {{ obj.tn_svg_html }}
 
 name: TNGaugeConjugation TNPhysicalRealization TNLinearTwist


### PR DESCRIPTION
Follow-up to #1814.

This removes the remaining unused LPDO diagram primitive from the blueprint diagram layer:

- deletes `\TNLPDO` from `blueprint/src/macros/tn_print.tex`;
- removes its plasTeX argument-table entry;
- removes its template registration.

The MPDO chapter still states the LPDO definitions and theorems, but it does not call this diagram macro. The previous compatibility aliases were already removed in #1814.

Verification:
- `rg -n "TNLPDO\b|TNLPDODiagram" blueprint/src || true`
- `git diff --check`
- `cd blueprint && leanblueprint web`

The local web build completed with the repository's existing plasTeX bibliography/default-renderer warnings and no missing LPDO diagram command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a pure deletion of an unused diagram macro and its registrations; impact is limited to builds or docs that still reference `\TNLPDO`.
> 
> **Overview**
> Removes the unused `\TNLPDO` diagram macro from `macros/tn_print.tex`.
> 
> Drops `TNLPDO` from the plasTeX diagram argument table (`Packages/tn_diagrams.py`) and from the template registration list (`plastex_templates/TensorNetworkDiagrams.jinja2s`), so the web blueprint no longer tries to render it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9711d376245fd6bf9514913c3d79f6f64ec869d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->