### PR TITLE
refactor(Spectral): generalize trace expansion names

### DIFF
--- a/TNLean/Spectral/MPVOverlapTrace.lean
+++ b/TNLean/Spectral/MPVOverlapTrace.lean
@@ -27,9 +27,7 @@ This module proves the key identity (standard in the MPS literature) expressing 
 as the trace of the $N$-th power of the mixed transfer operator.
 
 The trace-expansion helpers (`linearMap_trace_eq_sum_apply_single`,
-`entry_mul_single_mul`) are now provided by
-`TNLean.Spectral.TraceExpansion` and are also available from this module
-for backwards compatibility.
+`entry_mul_single_mul`) are provided by `TNLean.Spectral.TraceExpansion`.
 
 ## Rectangular (heterogeneous bond dimensions)
 
@@ -37,8 +35,7 @@ for backwards compatibility.
 `A : MPSTensor d D₁` and `B : MPSTensor d D₂` may have different bond dimensions and the
 mixed transfer map acts on `Matrix (Fin D₁) (Fin D₂) ℂ`.
 
-The rectangular trace-expansion helpers (`linearMap_trace_eq_sum_apply_single₂`,
-`entry_mul_single_mul₂`) are provided by `TNLean.Spectral.TraceExpansion`.
+The same trace-expansion helpers apply to this rectangular matrix space.
 -/
 
 section Main
@@ -57,8 +54,8 @@ theorem trace_mixedTransferMap_pow_eq_mpvOverlap {d D : ℕ} [NeZero D]
   rw [linearMap_trace_eq_sum_apply_single (T := ((mixedTransferMap A B) ^ N))]
   -- Expand the iterated mixed transfer map on each matrix unit.
   simp only [mixedTransferMap_pow_apply (A := A) (B := B) (N := N)]
-  -- Push the `(p,q)` entry inside the σ-sum using `Finset.sum_apply`, then
-  -- apply `entry_mul_single_mul` to simplify each summand.
+  -- Push the `(p,q)` entry inside the σ-sum, then use the matrix-unit identity
+  -- `(M E_pq N)_{pq} = M_{pp} N_{qq}` on each summand.
   have h1 :
       (∑ p : Fin D, ∑ q : Fin D,
           (∑ σ : Fin N → Fin d,
@@ -114,11 +111,11 @@ theorem trace_mixedTransferMap₂_pow_eq_mpvOverlap
       = mpvOverlap (d := d) A B N := by
   classical
   -- Expand the operator trace as a sum over matrix units.
-  rw [linearMap_trace_eq_sum_apply_single₂ (T := ((mixedTransferMap₂ A B) ^ N))]
+  rw [linearMap_trace_eq_sum_apply_single (T := ((mixedTransferMap₂ A B) ^ N))]
   -- Expand the iterated mixed transfer map on each matrix unit.
   simp only [mixedTransferMap₂_pow_apply (A := A) (B := B) (N := N)]
-  -- Push the `(p,q)` entry inside the σ-sum using `Matrix.sum_apply`, then
-  -- apply `entry_mul_single_mul₂` to simplify each summand.
+  -- Push the `(p,q)` entry inside the σ-sum, then use the matrix-unit identity
+  -- `(M E_pq N)_{pq} = M_{pp} N_{qq}` on each summand.
   have h1 :
       (∑ p : Fin D₁, ∑ q : Fin D₂,
           (∑ σ : Fin N → Fin d,
@@ -127,7 +124,7 @@ theorem trace_mixedTransferMap₂_pow_eq_mpvOverlap
         = ∑ p : Fin D₁, ∑ q : Fin D₂, ∑ σ : Fin N → Fin d,
             evalWord A (List.ofFn σ) p p * (evalWord B (List.ofFn σ))ᴴ q q := by
     refine Fintype.sum_congr _ _ fun p => Fintype.sum_congr _ _ fun q => ?_
-    simp only [Matrix.sum_apply, entry_mul_single_mul₂]
+    simp only [Matrix.sum_apply, entry_mul_single_mul]
   -- Reorder the triple sum so that σ is outermost.
   have hswap :
       (∑ p : Fin D₁, ∑ q : Fin D₂, ∑ σ : Fin N → Fin d,

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -88,11 +88,6 @@ The definition and basic lemmas (`frobSq`, `frobSq_nonneg`, `frobSq_eq_zero_iff`
 provided by `TNLean.Spectral.FrobeniusNorm` for general rectangular matrices.
 Below we add the square-matrix-specific lemma `frobSq_mul_le`. -/
 
-/-- `frobSq X = ∑ i j, ‖X i j‖²` (definitional; kept for backward compatibility). -/
-lemma frobSq_eq_sum (X : Matrix (Fin D) (Fin D) ℂ) :
-    frobSq X = ∑ i : Fin D, ∑ j : Fin D, ‖X i j‖ ^ 2 := rfl
-
-
 /-! ### Eigenvector iteration -/
 
 /-- If `F(v) = μ • v`, then `F^n(v) = μ^n • v`. -/

--- a/TNLean/Spectral/TraceExpansion.lean
+++ b/TNLean/Spectral/TraceExpansion.lean
@@ -19,12 +19,9 @@ complex-number imports. Downstream files instantiate `𝕜 := ℂ`.
 
 ## Main results
 
-- `linearMap_trace_eq_sum_apply_single₂`: operator trace as a double sum over matrix units
-  (rectangular, general bond dimensions).
-- `entry_mul_single_mul₂`: `(p, q)` entry of `M * single p q 1 * N` equals `M p p * N q q`
-  (rectangular, general).
-- `linearMap_trace_eq_sum_apply_single`: square specialization of `…single₂`.
-- `entry_mul_single_mul`: square specialization of `…mul₂`.
+- `linearMap_trace_eq_sum_apply_single`: operator trace as a double sum over matrix units,
+  for rectangular matrix spaces.
+- `entry_mul_single_mul`: `(p, q)` entry of `M * single p q 1 * N` equals `M p p * N q q`.
 -/
 
 open scoped Matrix BigOperators
@@ -38,8 +35,8 @@ variable {𝕜 : Type*} [CommRing 𝕜]
 /-- Expand the operator trace of an endomorphism of `Matrix (Fin D₁) (Fin D₂) 𝕜` as a sum over
 matrix units `Matrix.single p q 1`.
 
-This is the rectangular (general bond dimension) version. -/
-lemma linearMap_trace_eq_sum_apply_single₂
+This statement allows different row and column bond dimensions. -/
+lemma linearMap_trace_eq_sum_apply_single
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (T : Matrix (Fin D₁) (Fin D₂) 𝕜 →ₗ[𝕜] Matrix (Fin D₁) (Fin D₂) 𝕜) :
     (LinearMap.trace 𝕜 (Matrix (Fin D₁) (Fin D₂) 𝕜)) T
@@ -74,8 +71,8 @@ lemma linearMap_trace_eq_sum_apply_single₂
 
 /-- The `(p, q)` entry of `M * Matrix.single p q 1 * N` equals `M p p * N q q`.
 
-Rectangular version: `M : D₁ × D₁` and `N : D₂ × D₂`. -/
-lemma entry_mul_single_mul₂
+Here `M : D₁ × D₁` and `N : D₂ × D₂`. -/
+lemma entry_mul_single_mul
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (M : Matrix (Fin D₁) (Fin D₁) 𝕜) (N : Matrix (Fin D₂) (Fin D₂) 𝕜)
     (p : Fin D₁) (q : Fin D₂) :
@@ -86,30 +83,5 @@ lemma entry_mul_single_mul₂
   · simp
 
 end TraceExpansion
-
-section SingleEntrySquare
-
-variable {𝕜 : Type*} [CommRing 𝕜]
-
-/-- Square specialization of `linearMap_trace_eq_sum_apply_single₂`.
-
-Provided for backwards compatibility with lemmas in `MPVOverlapTrace`. -/
-lemma linearMap_trace_eq_sum_apply_single
-    {D : ℕ} [NeZero D]
-    (T : Matrix (Fin D) (Fin D) 𝕜 →ₗ[𝕜] Matrix (Fin D) (Fin D) 𝕜) :
-    (LinearMap.trace 𝕜 (Matrix (Fin D) (Fin D) 𝕜)) T
-      = ∑ p : Fin D, ∑ q : Fin D, (T (Matrix.single p q (1 : 𝕜))) p q :=
-  linearMap_trace_eq_sum_apply_single₂ T
-
-/-- Square specialization of `entry_mul_single_mul₂`.
-
-Provided for backwards compatibility with lemmas in `MPVOverlapTrace`. -/
-lemma entry_mul_single_mul
-    {D : ℕ} [NeZero D]
-    (M N : Matrix (Fin D) (Fin D) 𝕜) (p q : Fin D) :
-    (M * Matrix.single p q (1 : 𝕜) * N) p q = M p p * N q q :=
-  entry_mul_single_mul₂ M N p q
-
-end SingleEntrySquare
 
 end MPSTensor

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -115,16 +115,16 @@ mixed transfer power.
 \begin{lemma}[Trace expansion over matrix units]\label{lem:trace_expansion}
     \lean{MPSTensor.linearMap_trace_eq_sum_apply_single}
     \leanok
-    For any linear endomorphism $T$ on $\MN{D}$,
+    For any linear endomorphism $T$ on $M_{D_1 \times D_2}(\C)$,
     the operator trace can be expanded as
     \[
         \Tr(T)
         =
-        \sum_{p,q = 0}^{D-1}
+        \sum_{p=0}^{D_1-1} \sum_{q=0}^{D_2-1}
         (T(E_{pq}))_{pq},
     \]
-    where $E_{pq}$ is the matrix with $1$ in position $(p,q)$
-    and $0$ elsewhere.
+    where $E_{pq} \in M_{D_1 \times D_2}(\C)$ is the matrix with
+    $1$ in position $(p,q)$ and $0$ elsewhere.
 \end{lemma}
 
 \begin{proof}\leanok


### PR DESCRIPTION
### Motivation

- The trace-expansion lemmas in `TNLean/Spectral/TraceExpansion.lean` were split into square and rectangular variants, with the rectangular versions carrying `_₂` suffixes. This forced downstream proofs to call different lemmas for the same mathematical statement depending on whether the matrix was square.
- The trace expansion `\operatorname{tr}(\phi(e_{ij}))` is naturally a statement about `Matrix (Fin D₁) (Fin D₂)`; the square case `D₁ = D₂` is a specialization and requires no separate wrapper.

### Description

- `TNLean/Spectral/TraceExpansion.lean`: `linearMap_trace_eq_sum_apply_single` and `entry_mul_single_mul` are now stated for `Matrix (Fin D₁) (Fin D₂)`; the `_₂`-suffixed rectangular variants and the square-only wrapper lemmas are removed. The blueprint-linked lemma name is preserved and now points to the more general statement.
- `TNLean/Spectral/SpectralGap.lean`: Removes the unused `frobSq_eq_sum` restatement.
- `TNLean/Spectral/MPVOverlapTrace.lean`: Updates MPV overlap proofs, including the rectangular `mixedTransferMap₂` case, to use the shared generalized lemmas in both square and rectangular settings.
- No new `sorry`s are introduced; the full build has only pre-existing periodic-overlap `sorry` warnings.

### Testing

- `lake build TNLean.Spectral.TraceExpansion`
- `lake build TNLean.Spectral.SpectralGap`
- `lake env lean TNLean/Spectral/MPVOverlapTrace.lean`
- `lake env lean TNLean/Spectral/MPVOverlapDecay.lean`
- `lake env lean TNLean/Wielandt/Primitivity/TracePairing.lean`
- `lake build` (full build; only pre-existing periodic-overlap `sorry` warnings remain)

---

> [!NOTE]
> **Medium Risk**
> Mostly a lemma renaming/generalization refactor, but it changes public lemma names (`…single₂`/`…mul₂` removed) and could break downstream proofs that relied on the old API.
>
> **Overview**
> Unifies the trace-expansion API by making the previously "rectangular" lemmas the primary ones: `linearMap_trace_eq_sum_apply_single` and `entry_mul_single_mul` are now stated for `Matrix (Fin D₁) (Fin D₂)` and the `_₂`-suffixed versions plus square-only wrapper lemmas are removed.
>
> Updates the MPV overlap trace proofs (including the rectangular `mixedTransferMap₂` case) to use the shared generalized lemmas, and drops the redundant `frobSq_eq_sum` backward-compat lemma from `SpectralGap`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293acbd64b06e0eec5e47022abfb521bc3efdff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it removes the `_₂` rectangular lemma API and changes signatures to the generalized versions, which can break downstream proofs/imports despite minimal logical changes.
> 
> **Overview**
> **Unifies the trace-expansion API** by redefining `linearMap_trace_eq_sum_apply_single` and `entry_mul_single_mul` in `TraceExpansion.lean` to work directly over rectangular matrix spaces (`Matrix (Fin D₁) (Fin D₂)`), and deleting the old `_₂`-suffixed rectangular lemmas plus the square-only wrapper specializations.
> 
> **Updates downstream proofs and docs**: `MPVOverlapTrace.lean` switches both the square and rectangular overlap/trace theorems to the shared generalized lemmas, `SpectralGap.lean` drops the redundant backward-compat lemma `frobSq_eq_sum`, and the blueprint text is adjusted to describe the rectangular trace-expansion statement and index ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96db79d53f6cabf8c9014d70ec25bbbd2c4460ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->