### PR TITLE
refactor(Spectral): remove trace expansion wrappers

### DIFF
--- a/TNLean/Spectral/MPVOverlapDecay.lean
+++ b/TNLean/Spectral/MPVOverlapDecay.lean
@@ -32,7 +32,7 @@ equivalent, then the MPV overlaps decay to `0` as `N → ∞`.
 1. Use `trace_mixedTransferMap_pow_eq_mpvOverlap` to rewrite the overlap as the
    operator trace of `((mixedTransferMap A B)^N)`.
 2. Expand `LinearMap.trace` as a finite double sum over matrix units
-   `Matrix.single p q 1` using `linearMap_trace_eq_sum_apply_single`.
+   `Matrix.single p q 1` using `linearMap_trace_eq_sum_apply_single₂`.
 3. For each fixed `(p,q)`, apply the spectral-gap lemma `mixedTransfer_pow_tendsto_zero`
    to get `((mixedTransferMap A B)^N) (Matrix.single p q 1) → 0`.
 4. Extract the `(p,q)` entry using the continuous linear functional
@@ -97,7 +97,7 @@ theorem mpvOverlap_tendsto_zero
   have htraceEq : ∀ N : ℕ,
       (LinearMap.trace ℂ (Matrix (Fin D) (Fin D) ℂ)) ((mixedTransferMap A B) ^ N)
         = ∑ p : Fin D, ∑ q : Fin D, term p q N := fun N => by
-    simpa [term] using linearMap_trace_eq_sum_apply_single (T := ((mixedTransferMap A B) ^ N))
+    simpa [term] using linearMap_trace_eq_sum_apply_single₂ (T := ((mixedTransferMap A B) ^ N))
   -- Step 1: lift convergence from the sum-of-terms to the operator trace.
   have htrace :
       Filter.Tendsto

--- a/TNLean/Spectral/MPVOverlapTrace.lean
+++ b/TNLean/Spectral/MPVOverlapTrace.lean
@@ -26,19 +26,15 @@ This module proves the key identity (standard in the MPS literature) expressing 
 \]
 as the trace of the $N$-th power of the mixed transfer operator.
 
-The trace-expansion helpers (`linearMap_trace_eq_sum_apply_single`,
-`entry_mul_single_mul`) are now provided by
-`TNLean.Spectral.TraceExpansion` and are also available from this module
-for backwards compatibility.
-
-## Rectangular (heterogeneous bond dimensions)
+## Rectangular trace expansion
 
 `trace_mixedTransferMap₂_pow_eq_mpvOverlap` is the rectangular analogue, where
 `A : MPSTensor d D₁` and `B : MPSTensor d D₂` may have different bond dimensions and the
 mixed transfer map acts on `Matrix (Fin D₁) (Fin D₂) ℂ`.
 
-The rectangular trace-expansion helpers (`linearMap_trace_eq_sum_apply_single₂`,
-`entry_mul_single_mul₂`) are provided by `TNLean.Spectral.TraceExpansion`.
+Both the square and rectangular proofs below use the rectangular trace-expansion helpers
+`linearMap_trace_eq_sum_apply_single₂` and `entry_mul_single_mul₂` from
+`TNLean.Spectral.TraceExpansion`.
 -/
 
 section Main
@@ -54,11 +50,11 @@ theorem trace_mixedTransferMap_pow_eq_mpvOverlap {d D : ℕ} [NeZero D]
       = mpvOverlap (d := d) A B N := by
   classical
   -- Expand the operator trace as a sum over matrix units.
-  rw [linearMap_trace_eq_sum_apply_single (T := ((mixedTransferMap A B) ^ N))]
+  rw [linearMap_trace_eq_sum_apply_single₂ (T := ((mixedTransferMap A B) ^ N))]
   -- Expand the iterated mixed transfer map on each matrix unit.
   simp only [mixedTransferMap_pow_apply (A := A) (B := B) (N := N)]
   -- Push the `(p,q)` entry inside the σ-sum using `Finset.sum_apply`, then
-  -- apply `entry_mul_single_mul` to simplify each summand.
+  -- apply `entry_mul_single_mul₂` to simplify each summand.
   have h1 :
       (∑ p : Fin D, ∑ q : Fin D,
           (∑ σ : Fin N → Fin d,
@@ -67,7 +63,7 @@ theorem trace_mixedTransferMap_pow_eq_mpvOverlap {d D : ℕ} [NeZero D]
         = ∑ p : Fin D, ∑ q : Fin D, ∑ σ : Fin N → Fin d,
             evalWord A (List.ofFn σ) p p * (evalWord B (List.ofFn σ))ᴴ q q := by
     refine Fintype.sum_congr _ _ fun p => Fintype.sum_congr _ _ fun q => ?_
-    simp only [Matrix.sum_apply, entry_mul_single_mul]
+    simp only [Matrix.sum_apply, entry_mul_single_mul₂]
   -- Reorder the triple sum so that σ is outermost.
   have hswap :
       (∑ p : Fin D, ∑ q : Fin D, ∑ σ : Fin N → Fin d,

--- a/TNLean/Spectral/SpectralGap.lean
+++ b/TNLean/Spectral/SpectralGap.lean
@@ -88,11 +88,6 @@ The definition and basic lemmas (`frobSq`, `frobSq_nonneg`, `frobSq_eq_zero_iff`
 provided by `TNLean.Spectral.FrobeniusNorm` for general rectangular matrices.
 Below we add the square-matrix-specific lemma `frobSq_mul_le`. -/
 
-/-- `frobSq X = ∑ i j, ‖X i j‖²` (definitional; kept for backward compatibility). -/
-lemma frobSq_eq_sum (X : Matrix (Fin D) (Fin D) ℂ) :
-    frobSq X = ∑ i : Fin D, ∑ j : Fin D, ‖X i j‖ ^ 2 := rfl
-
-
 /-! ### Eigenvector iteration -/
 
 /-- If `F(v) = μ • v`, then `F^n(v) = μ^n • v`. -/

--- a/TNLean/Spectral/TraceExpansion.lean
+++ b/TNLean/Spectral/TraceExpansion.lean
@@ -23,8 +23,6 @@ complex-number imports. Downstream files instantiate `𝕜 := ℂ`.
   (rectangular, general bond dimensions).
 - `entry_mul_single_mul₂`: `(p, q)` entry of `M * single p q 1 * N` equals `M p p * N q q`
   (rectangular, general).
-- `linearMap_trace_eq_sum_apply_single`: square specialization of `…single₂`.
-- `entry_mul_single_mul`: square specialization of `…mul₂`.
 -/
 
 open scoped Matrix BigOperators
@@ -86,30 +84,5 @@ lemma entry_mul_single_mul₂
   · simp
 
 end TraceExpansion
-
-section SingleEntrySquare
-
-variable {𝕜 : Type*} [CommRing 𝕜]
-
-/-- Square specialization of `linearMap_trace_eq_sum_apply_single₂`.
-
-Provided for backwards compatibility with lemmas in `MPVOverlapTrace`. -/
-lemma linearMap_trace_eq_sum_apply_single
-    {D : ℕ} [NeZero D]
-    (T : Matrix (Fin D) (Fin D) 𝕜 →ₗ[𝕜] Matrix (Fin D) (Fin D) 𝕜) :
-    (LinearMap.trace 𝕜 (Matrix (Fin D) (Fin D) 𝕜)) T
-      = ∑ p : Fin D, ∑ q : Fin D, (T (Matrix.single p q (1 : 𝕜))) p q :=
-  linearMap_trace_eq_sum_apply_single₂ T
-
-/-- Square specialization of `entry_mul_single_mul₂`.
-
-Provided for backwards compatibility with lemmas in `MPVOverlapTrace`. -/
-lemma entry_mul_single_mul
-    {D : ℕ} [NeZero D]
-    (M N : Matrix (Fin D) (Fin D) 𝕜) (p q : Fin D) :
-    (M * Matrix.single p q (1 : 𝕜) * N) p q = M p p * N q q :=
-  entry_mul_single_mul₂ M N p q
-
-end SingleEntrySquare
 
 end MPSTensor

--- a/TNLean/Wielandt/Primitivity/TracePairing.lean
+++ b/TNLean/Wielandt/Primitivity/TracePairing.lean
@@ -61,7 +61,7 @@ private theorem sum_trace_mul_star_eq [NeZero D]
       simp only [Matrix.mul_assoc]
     rw [hdist, Matrix.sum_apply]
     congr 1; ext σ
-    exact entry_mul_single_mul
+    exact entry_mul_single_mul₂
       (Bᴴ * evalWord A (List.ofFn σ))
       ((evalWord A (List.ofFn σ))ᴴ * B) i k
   simp_rw [hpush]


### PR DESCRIPTION
Part of the first-14-chapter cleanup of the spectral and Wielandt material.

This removes the square-only compatibility wrappers in `TNLean.Spectral.TraceExpansion` and rewrites their callers to use the rectangular trace-expansion lemmas directly:

- `linearMap_trace_eq_sum_apply_single₂` now serves both square and rectangular mixed-transfer traces.
- `entry_mul_single_mul₂` now serves both square and rectangular matrix-unit entry calculations.
- the unused square Frobenius identity `frobSq_eq_sum` in `SpectralGap.lean` is removed; the rectangular definition `frobSq` remains the single source of truth.

No theorem statement about MPV overlaps, spectral gaps, or Wielandt primitivity is changed; this only removes local synonym lemmas and updates proofs to call the general lemmas.

Verification:
- `git diff --check`
- `rg -n "(lemma|theorem) (linearMap_trace_eq_sum_apply_single|entry_mul_single_mul)\\s|frobSq_eq_sum|backwards compatibility|backward compatibility" TNLean/Spectral TNLean/Wielandt/Primitivity/TracePairing.lean || true`

Blocked locally:
- `lake env lean TNLean/Spectral/TraceExpansion.lean`
- `lake env lean TNLean/Spectral/MPVOverlapTrace.lean`
- `lake env lean TNLean/Wielandt/Primitivity/TracePairing.lean`

These Lean checks currently fail before reaching TNLean because the shared `.lake` cache is missing `Mathlib/Algebra/Group/Defs.olean`; CI should provide the clean kernel check.
