### PR TITLE
doc(Channel/PerronFrobenius): correct Brouwer reference

### DIFF
--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -24,9 +24,8 @@ The core existence theorem `exists_posSemidef_eigenvector` is proved via Brouwer
 fixed-point theorem applied to the normalization map
 `ρ ↦ E(ρ) / tr(E(ρ))` on the compact convex set of density matrices.
 
-The required density-matrix Brouwer theorem is now proved in
-`TNLean.Axioms.BrouwerFixedPointDensityMatrices` (the legacy path name is kept for
-backwards compatibility even though the file no longer introduces an axiom).
+The required density-matrix Brouwer theorem is proved in
+`TNLean.Axioms.BrouwerFixedPoint`.
 
 ## Main results
 


### PR DESCRIPTION
Part of the early-channel cleanup around the Perron-Frobenius input to the spectral material.

This corrects the module docstring in `TNLean/Channel/PerronFrobenius/Existence.lean`: the density-matrix Brouwer theorem is provided by `TNLean.Axioms.BrouwerFixedPoint`, not by the old `BrouwerFixedPointDensityMatrices` path. The stale sentence also referred to a legacy compatibility path; that reference is removed.

No Lean declaration, theorem statement, or proof term is changed.

Verification:
- `rg -n "BrouwerFixedPointDensityMatrices|legacy path name|backwards compatibility|backward compatibility" TNLean/Channel/PerronFrobenius/Existence.lean || true`
- `git diff --check`

Blocked locally:
- `lake env lean TNLean/Channel/PerronFrobenius/Existence.lean`

The Lean check currently fails before reaching TNLean because the shared `.lake` cache is missing `Mathlib/Algebra/Group/Defs.olean`; CI should provide the clean build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only change updating a stale module reference; no Lean declarations or proofs are modified, so functional risk is minimal.
> 
> **Overview**
> Corrects the `TNLean/Channel/PerronFrobenius/Existence.lean` module documentation to reference `TNLean.Axioms.BrouwerFixedPoint` (and removes the outdated mention of `BrouwerFixedPointDensityMatrices`/legacy compatibility path) as the source of the density-matrix Brouwer fixed-point theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905a983b6cd431c9fa57414a7d3325066ae01b52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->