### PR TITLE
refactor(Channel/PerronFrobenius): remove unused TP gauge alias

### DIFF
--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -24,9 +24,8 @@ The core existence theorem `exists_posSemidef_eigenvector` is proved via Brouwer
 fixed-point theorem applied to the normalization map
 `ρ ↦ E(ρ) / tr(E(ρ))` on the compact convex set of density matrices.
 
-The required density-matrix Brouwer theorem is now proved in
-`TNLean.Axioms.BrouwerFixedPointDensityMatrices` (the legacy path name is kept for
-backwards compatibility even though the file no longer introduces an axiom).
+The required density-matrix Brouwer theorem is proved in
+`TNLean.Axioms.BrouwerFixedPoint`.
 
 ## Main results
 
@@ -369,22 +368,5 @@ theorem exists_tp_data_of_irreducible
     rfl
   -- GaugeEquiv: A' matches the stated rescaled tensor.
   · convert hB_gauge using 1
-
-/-- Preferred alias for `exists_tp_data_of_irreducible` using the project's
-left-canonical terminology. -/
-theorem exists_leftCanonical_data_of_irreducible
-    [NeZero D]
-    (A : MPSTensor d D)
-    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
-    (hA : ∃ i, A i ≠ 0) :
-    ∃ (B : MPSTensor d D) (r : ℝ) (σ : Matrix (Fin D) (Fin D) ℂ),
-      σ.PosDef ∧ 0 < r ∧
-      (∀ i : Fin d,
-        B i = CFC.sqrt σ *
-          ((↑((Real.sqrt r)⁻¹) : ℂ) • A i) * (CFC.sqrt σ)⁻¹) ∧
-      (∑ i : Fin d, (B i)ᴴ * B i = 1) ∧
-      GaugeEquiv (d := d) (D := D)
-        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
-  simpa using exists_tp_data_of_irreducible (A := A) hIrr hA
 
 end MPSTensor


### PR DESCRIPTION
### Motivation

- `exists_leftCanonical_data_of_irreducible` was a direct alias of `exists_tp_data_of_irreducible` with no callers in `TNLean` or the blueprint, creating a redundant entry in the module's public interface.
- The module docstring referenced a stale import path for the density-matrix Brouwer fixed-point theorem.

### Description

- `TNLean/Channel/PerronFrobenius/Existence.lean`: removes `exists_leftCanonical_data_of_irreducible` (an equivalent reformulation of `exists_tp_data_of_irreducible`); `exists_tp_data_of_irreducible` remains as the single existence theorem for TP-normalized gauge quantities (positive definite σ and spectral radius r), following Wolf §6.2 Theorems 6.3/6.5.
- Updates the module docstring to point to `TNLean.Axioms.BrouwerFixedPoint` as the source of the density-matrix Brouwer fixed-point theorem.
- No downstream theorem statement changes: the removed declaration had no references in the project or blueprint.

### Testing

- `lake env lean TNLean/Channel/PerronFrobenius/Existence.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake build` — full build passes with only the pre-existing periodic-overlap `sorry` warnings.

---

> [!NOTE]
> **Low Risk**
> Low risk: this deletes a pure wrapper theorem and adjusts documentation/import paths without changing the underlying Perron–Frobenius or TP-gauge statements.
> 
> **Overview**
> Updates `Channel/PerronFrobenius/Existence.lean` prose (and its import) to point at the density-matrix Brouwer fixed-point theorem in `TNLean.Axioms.BrouwerFixedPoint` rather than the old `...DensityMatrices` path.
> 
> Removes `exists_leftCanonical_data_of_irreducible`, an unused alias of `exists_tp_data_of_irreducible`, leaving `exists_tp_data_of_irreducible` as the single theorem for TP/left-canonical gauge data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975fe700609d7878c610ae6fa42237531c9848b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>