### PR TITLE
doc(MPS): make scope notes reader-facing

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
@@ -299,11 +299,12 @@ Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
 Theorem Th:TIcanonical, lines 742--763, starts from an arbitrary
 translation-invariant MPS representation.
 
-**Scope restriction (prepared primitive block decomposition):** this theorem assumes an existing
-weighted block decomposition, irreducibility, trace-preserving normalization, primitivity,
-pairwise distinct weight moduli, nonzero weights, and positive bond dimensions. Those hypotheses
-are not assumptions of the source theorem. See
-`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
+**Scope restriction (prepared primitive block decomposition):** This theorem
+assumes an existing weighted block decomposition, irreducibility,
+trace-preserving normalization, primitivity, pairwise distinct weight moduli,
+nonzero weights, and positive bond dimensions. The cited source theorem starts
+from an arbitrary translation-invariant MPS representation and derives these
+structures; see `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_normalCanonicalForm_of_primitive_blockDecomp
     (A : MPSTensor d D)
     {r1 : ℕ} {dim1 : Fin r1 → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -322,9 +322,9 @@ together with the rigidity theorem
 `modulus_one_eigenvalue_implies_gauge_of_irreducible_TP`.
 
 **Scope restriction (same bond dimension):** The source Lemma equalMPS also
-concludes equality of the two bond dimensions in the unit-overlap case; this
-theorem assumes a common bond dimension as a hypothesis instead. The
-rectangular component is proved separately as
+concludes equality of the two bond dimensions in the unit-overlap case. This
+theorem proves the gauge recovery after the common bond dimension has already
+been identified. The rectangular component is proved separately as
 `dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP` in this file; together
 the two theorems recover the full structural conclusion of the source lemma. -/
 theorem gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -585,10 +585,6 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     $\bigoplus_k \nu_k B_k$, and $(\nu_k, B_k)$ satisfies the normal canonical
     form conditions.
 \end{theorem}
-% Scope restriction (prepared primitive block decomposition): not the
-% full source theorem (lines 742--763), which starts from
-% an arbitrary translation-invariant MPS representation. See
-% docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
 
 \begin{proof}\leanok
     \uses{def:is_normal_canonical_form}
@@ -1086,9 +1082,10 @@ BNT construction.
     summand in the block decomposition contributes only at length zero, so the
     nonzero primitive blocks identify the MPV family for $N\ge 1$. The proof
     that the prepared weights can always be rescaled to satisfy the displayed
-    normalization is not part of this entry; the theorem instead records the
-    sector-decomposition conclusion once that normalization choice is supplied.
-    This is a scope restriction relative to the source theorem; see
+    normalization remains the missing step recorded in the cited note. The
+    theorem records the sector-decomposition conclusion once that normalization
+    choice is supplied.
+    The corresponding unrestricted statement is recorded in
     \texttt{docs/paper-gaps/cpsv16\_cf\_normalization\_and\_proportional\_comparison.tex}.
     The length-zero trace identity and the fully unblocked canonical-form
     statement remain part of the surrounding reduction in


### PR DESCRIPTION
## Summary
- replace process-style scope markers with mathematical prose in the normal-reduction and proportionality docstrings
- remove a redundant hidden blueprint comment now covered by the visible remark
- rephrase the chapter 8 arbitrary-input reduction note to name the missing mathematical step directly

## Mathematical content
No theorem statements or proof terms change. The restrictions remain documented: one theorem assumes prepared primitive blocks, and the equalMPS gauge-recovery theorem assumes that the common bond dimension has already been identified.

## Checks
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/Main.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/Proportional.lean`
- `git diff --check`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docstrings/blueprint text and do not modify theorem statements, proofs, or executable logic.
> 
> **Overview**
> Rephrases the *scope restriction* documentation for `exists_normalCanonicalForm_of_primitive_blockDecomp` and `gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP` to be reader-facing mathematical prose that clearly contrasts the formal hypotheses with the cited source results.
> 
> Updates Chapter 8 of the blueprint to remove a redundant hidden comment and to restate the arbitrary-input reduction remark to explicitly name the missing weight-rescaling/normalization step and point to the existing gap note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c9d5e707947ad7fbf8b7d441d1d9d814b8caf12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->