### PR TITLE
doc(core): replace process-oriented prose

### DIFF
--- a/TNLean/Channel/Schwarz/PositiveOnAbelian/Basic.lean
+++ b/TNLean/Channel/Schwarz/PositiveOnAbelian/Basic.lean
@@ -86,9 +86,10 @@ noncomputable def blockQuadraticForm {n D : ℕ}
 /-- A map is **positive on commuting block families** if it preserves
 block-quadratic-form positivity whenever the image family is pairwise commuting.
 
-This is the concrete stand-in for "the restriction to a commutative
-`*`-subalgebra is completely positive" that is sufficient for the normal-input
-Schwarz argument used later in the project. -/
+This formulation records the exact condition used by the normal-input Schwarz
+argument: after applying the map to each block, the resulting family commutes
+pairwise, and positivity of the original block quadratic form remains
+positivity of the transformed form. -/
 def IsPositiveOnCommuting
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) : Prop :=
   ∀ {n : ℕ} (a : Matrix (Fin n) (Fin n) (Matrix (Fin D) (Fin D) ℂ)),

--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -8,7 +8,7 @@ import TNLean.PiAlgebra.CanonicalFormSepAux
 # Separated canonical-form hypotheses and block separation
 
 This file proves the core block-separation result from the separated canonical-form hypotheses
-defined in `CanonicalFormSepAux`, and then rebuilds legacy canonical-form formulations on top.
+defined in `CanonicalFormSepAux`, and then derives the bundled canonical-form formulations.
 
 ## Main results
 

--- a/TNLean/QPF/Assembly.lean
+++ b/TNLean/QPF/Assembly.lean
@@ -6,7 +6,7 @@ import TNLean.QPF.PosDef
 import TNLean.QPF.Uniqueness
 import TNLean.MPS.Core.CPPrimitive
 -- Needed for `IsChannel.exists_posSemidef_fixedPoint`.
--- We import it directly here instead of relying on a legacy transitive route.
+-- The fixed-point existence theorem is used explicitly below.
 import TNLean.Channel.FixedPoint.Cesaro
 
 /-!


### PR DESCRIPTION
## Summary
- replace legacy-route wording in the QPF assembly import comment
- describe the pi-algebra canonical-form derivation without legacy framing
- state the commuting-block positivity condition as a mathematical formulation rather than a stand-in

## Mathematical content
No declarations, statements, imports, or proof terms change. This is reader-facing prose cleanup in active modules from the first fourteen blueprint chapters.

## Checks
- `lake env lean TNLean/QPF/Assembly.lean`
- `lake env lean TNLean/PiAlgebra/CanonicalFormSep.lean`
- `lake env lean TNLean/Channel/Schwarz/PositiveOnAbelian/Basic.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only edits with no changes to declarations, proofs, or imports that affect build behavior.
> 
> **Overview**
> Updates reader-facing prose only.
> 
> Clarifies the definition comment for `IsPositiveOnCommuting` to state the exact commuting-family condition used in the normal-input Schwarz argument, rewords `CanonicalFormSep`’s header to describe deriving bundled canonical-form formulations (rather than “rebuilding legacy” ones), and adjusts the `QPF/Assembly` import comment to explain the fixed-point theorem is used explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00debf21c6109d2d1ba4897ab17fc93f265f1ae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->