### PR TITLE
doc(MPS/CanonicalForm): clarify existence boundary

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -19,7 +19,7 @@ open Filter
 This file collects the arbitrary-tensor reductions toward the canonical-form construction for
 MPS tensors from Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608.
 
-We currently have the following components:
+The file contains the following reductions:
 
 * Section 2.3: iterated invariant-projection splitting → irreducible block decomposition.
 * Appendix A (PF / TP gauge): irreducible + nonzero Kraus operator → Perron--Frobenius
@@ -220,8 +220,8 @@ theorem exists_blockTensor_leftCanonical_isPrimitive
     exists_blockTensor_isPrimitive (A := A) hTP hIrr
   refine ⟨p, hp, leftCanonical_blockTensor (d := d) (D := D) (A := A) (L := p) hTP, hPrim⟩
 
-/-- **Reduction compatibility theorem:** spectral-gap primitivity with a positive-definite
-fixed point implies normality. -/
+/-- **Reduction theorem:** spectral-gap primitivity with a positive-definite fixed point implies
+normality. -/
 theorem isNormal_of_isPrimitiveMPS
     [NeZero D]
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
@@ -330,12 +330,12 @@ theorem isIrreducibleTensor_allZero_dim_le_one
 The strongest arbitrary-input statement proved here is the blockwise PF / TP-gauge reduction below:
 after decomposing `A` into irreducible blocks, one may apply the theorem to each block once one
 separately knows that the block has a nonzero Kraus operator. This explicit side condition is
-essential because, under the current `SameMPV₂` relation, zero scalar blocks cannot simply be
-discarded: the `N = 0` sector is remembered.
+essential because `SameMPV₂` remembers the `N = 0` sector, so zero scalar blocks cannot simply be
+discarded.
 
 The normal-canonical-form file starts from a primitive weighted block family with positive bond
-dimensions and distinct nonzero weights. This file does **not** currently construct that input from
-an arbitrary tensor.
+dimensions and distinct nonzero weights. This file does **not** construct that input from an
+arbitrary tensor.
 
 Remaining gap for a complete canonical-form existence theorem:
 
@@ -353,9 +353,8 @@ From an arbitrary tensor `A` we produce an irreducible block decomposition. For 
 resulting block, if one separately knows that the block has some nonzero Kraus operator, then the
 Perron--Frobenius / TP-gauge step can be applied to that block.
 
-This is the available unconditional reduction from arbitrary input under the
-current statements. The nonzero side condition is explicit because `SameMPV₂`
-remembers the `N = 0` sector, so zero scalar blocks cannot be silently
+This is the unconditional reduction from arbitrary input proved here. The nonzero side condition is
+explicit because `SameMPV₂` remembers the `N = 0` sector, so zero scalar blocks cannot be silently
 discarded. -/
 theorem exists_irreducible_blockDecomp_with_tpGauge
     (A : MPSTensor d D) :
@@ -560,8 +559,9 @@ theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
       rw [h, mpv_toTensorFromBlocks_eq_sum]
       simp only [one_pow, one_smul]
     -- Expand the nonzero-block toTensorFromBlocks.
-    have hNonzero : mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ =
-        ∑ j : Fin r, mpv (newBlocks j) σ := by
+    have hNonzero :
+        mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ =
+          ∑ j : Fin r, mpv (newBlocks j) σ := by
       rw [mpv_toTensorFromBlocks_eq_sum]
       simp only [one_pow, one_smul]
     -- Split the original sum into nonzero and zero parts.


### PR DESCRIPTION
This PR makes the canonical-form existence reduction prose reader-facing.

Changes:

- Replaces “current state” phrasing in `TNLean/MPS/CanonicalForm/Existence.lean` with mathematical boundary statements.
- Describes the arbitrary-input result as the unconditional reduction proved in the file, with the `SameMPV₂` zero-sector side condition stated directly.
- Renames one docstring heading from “compatibility theorem” to “reduction theorem”.
- Folds one overlong proof line in the same file.

Local validation:

- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py`

GitHub Actions is currently subject to the repository Actions-budget failure; if it recurs on this PR, the failed jobs should be checked for the budget annotation before treating them as content failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only adjustments plus a minor formatting change in a proof; no changes to definitions or theorem statements.
> 
> **Overview**
> Clarifies the module-level and section docstrings in `TNLean/MPS/CanonicalForm/Existence.lean` to more explicitly state what reductions are proved, what remains unproved for full canonical-form existence, and why the `SameMPV₂` *zero-sector* prevents silently discarding zero blocks.
> 
> Renames a theorem doc heading from **“compatibility”** to **“reduction”**, and applies a small line-wrapping/formatting tweak inside a proof (no logic changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3fb1da80fd0d5d651247883bef3417a2241616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->