### PR TITLE
doc(PEPS): clean fundamental theorem prose

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -3,9 +3,9 @@ import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
--- The forward direction and contraction algebra are formalized. The converse
--- PEPS fundamental theorem still depends on the mathematical hypotheses listed
--- below.
+-- The contraction algebra is proved. The forward PEPS theorem is stated with
+-- the remaining bond-dimension obligation separated below, and the converse
+-- still depends on the mathematical hypotheses listed below.
 --
 -- Provability note: `IsVertexInjective` in `PEPS.Defs` is the
 -- linear-independence formulation `∀ v, LinearIndependent ℂ (A.component v)`
@@ -39,9 +39,9 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 **Root-only.** This module is currently not imported downstream — it
 records the full statement of the PEPS Fundamental Theorem
-(arXiv:1804.04964 §3, Theorem 2) with its forward direction fully proved
-and the converse gaps documented explicitly.  See issue #1512 for the
-root-only audit.
+(arXiv:1804.04964 §3, Theorem 2), with the forward bond-dimension
+obligation and converse gaps documented explicitly.  See issue #1512 for
+the root-only audit.
 
 This file develops the Fundamental Theorem for injective PEPS on simple graphs
 (arXiv:1804.04964, Theorem 2, Section 3):

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -448,8 +448,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_edgeMiddleConfigToOpenMiddleConfig,
         def:peps_edgeOpenMiddleConfigToMiddleConfig}
     For fixed edge-boundary data, ordinary middle configurations are equivalent
-    to compatible open-middle configurations. This packages the finite
-    reindexing used when the inserted matrix is the identity.
+    to compatible open-middle configurations. This is the finite reindexing
+    used when the inserted matrix is the identity.
 \end{definition}
 
 \begin{definition}[Edge insertion coefficient]%
@@ -581,7 +581,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     If \(A\) is vertex-injective, then for every edge \(e=(u,v)\), the two
     endpoint tensors together with the tensor obtained by blocking all vertices
     outside \(u\) and \(v\) form an injective three-site MPS. This is the
-    formal version of the assertion after the diagram
+    precise assertion after the diagram
     \(\textup{eq:block\_to\_mps}\) in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
@@ -728,9 +728,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     steps in that argument are recorded separately as
     Theorems~\ref{thm:peps_virtualInsertionPhysicalRealization} and
     \ref{thm:peps_physicalToVirtualInsertion}.
-    In the paper route, once the post-absorption insertion equality of
-    Theorem~\ref{thm:peps_postAbsorptionEdgeInsertionEquality} has supplied the
-    factorized local gauge hypothesis, injectivity on the star neighborhood
+    After Theorem~\ref{thm:peps_postAbsorptionEdgeInsertionEquality} supplies
+    the factorized local gauge hypothesis, injectivity on the star neighborhood
     provides a left inverse that isolates the local edge gauges:
     \begin{center}
         \TNPEPSLocalGaugeExtraction
@@ -993,7 +992,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The local left inverse $\Psi_v$, the realization map $T \mapsto O_T$,
     the split at one incident edge, and the partition
     $V = \{u\} \sqcup (V \setminus \{u,v\}) \sqcup \{v\}$ isolate the local
-    data needed for the edge-centered reduction of
+    indices and maps needed for the edge-centered reduction of
     \cite[Section~3]{Molnar2018NormalPEPS}. The middle-region blocked coefficient is
     constructed by the preceding definitions; the remaining local-gauge step is
     the comparison with the corresponding three-site injective chain.


### PR DESCRIPTION
Partial progress on #1418.

This is a narrow prose cleanup in the PEPS fundamental-theorem chapter and matching Lean comment. It removes four process-oriented phrases from the reader-facing material:

- `formalized` -> `proved` in the PEPS Fundamental Theorem module comment.
- `This packages...` -> a direct statement of the finite reindexing in `ch13a_peps_ft.tex`.
- `formal version` -> `precise assertion` for the three-site injective-chain statement.
- `paper route` and vague `data needed` phrasing are replaced by direct mathematical descriptions of the post-absorption implication and the local indices/maps used in the edge-centered reduction.

No theorem statement, blueprint status tag, Lean declaration, or proof term changes.

Verification:
- `rg -n "formalized|implementation|package|This packages|paper route|data needed|local data needed|formal version" TNLean/PEPS/FundamentalTheorem.lean blueprint/src/chapter/ch13a_peps_ft.tex || true`
- `git diff --check`
- `cd blueprint && leanblueprint web` (completed with the existing plasTeX citation/default-renderer warnings)

Known local blockers:
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean` currently fails before reaching TNLean because the shared `.lake` cache is missing `Batteries/Data/List/Basic.olean`.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` reports existing Chapter 14 blueprint/Lean mismatches unrelated to this PEPS prose change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only comment/blueprint wording changes with no modifications to Lean declarations, proofs, or theorem statements.
> 
> **Overview**
> Clarifies and tightens reader-facing prose around the PEPS Fundamental Theorem by replacing process-oriented phrasing with direct mathematical descriptions.
> 
> Updates the `FundamentalTheorem.lean` header comment and several explanations in `ch13a_peps_ft.tex` (reindexing equivalence, edge-blocking injectivity statement wording, post-absorption implication phrasing, and the remark about edge-centered reduction indices/maps), without changing any formal content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c30c243bd2b3eec055f4ecb4fdb8bf3ad51c296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->