### PR TITLE
refactor(TNLean): remove unused aliases

### DIFF
--- a/TNLean/Channel/FixedPoint/CanonicalGauge.lean
+++ b/TNLean/Channel/FixedPoint/CanonicalGauge.lean
@@ -8,9 +8,7 @@ This file states the two standard one-sided similarity gauges extracted from
 fixed points of the transfer map and its adjoint. It is **not** a formalization
 of a doubly stochastic gauge. Instead, `gauged_unital` gives the
 right-canonical/unital gauge, while `gauged_tracePreserving` gives the
-left-canonical/trace-preserving gauge. The aliases `gauged_rightCanonical` and
-`gauged_leftCanonical` state the same formulas in the project's MPS
-terminology.
+left-canonical/trace-preserving gauge.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -60,16 +58,6 @@ theorem gauged_unital
       Matrix.mul_assoc, Matrix.mul_assoc, hStmul_inv, Matrix.mul_one, hSinv_mul]
 
 omit [NeZero D] in
-/-- Right-canonical alias of `gauged_unital`. -/
-theorem gauged_rightCanonical
-    (A : MPSTensor d D) (S : Matrix (Fin D) (Fin D) ℂ) (ρ : Matrix (Fin D) (Fin D) ℂ)
-    (hS_inv : S.det ≠ 0)
-    (hSS : S * Sᴴ = ρ)
-    (hfix : transferMap (d := d) (D := D) A ρ = ρ) :
-    ∑ i : Fin d, (S⁻¹ * A i * S) * (S⁻¹ * A i * S)ᴴ = 1 :=
-  gauged_unital A S ρ hS_inv hSS hfix
-
-omit [NeZero D] in
 /-- If `S` is invertible and `Sᴴ * S = σ`, then the gauged operators
 `A'_i = S * A_i * S⁻¹` satisfy `∑ A'_iᴴ * A'_i = I` whenever
 `E_A†(σ) = σ`.
@@ -100,15 +88,5 @@ theorem gauged_tracePreserving
     simpa [transferMap_apply] using hfix
   rw [← Finset.sum_mul, ← Finset.mul_sum, h_sum_eq, ← hStS,
     Matrix.mul_assoc, Matrix.mul_assoc, hSmul_inv, Matrix.mul_one, hStinv_mul]
-
-omit [NeZero D] in
-/-- Left-canonical alias of `gauged_tracePreserving`. -/
-theorem gauged_leftCanonical
-    (A : MPSTensor d D) (S : Matrix (Fin D) (Fin D) ℂ) (σ : Matrix (Fin D) (Fin D) ℂ)
-    (hS_inv : S.det ≠ 0)
-    (hStS : Sᴴ * S = σ)
-    (hfix : transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = σ) :
-    ∑ i : Fin d, (S * A i * S⁻¹)ᴴ * (S * A i * S⁻¹) = 1 :=
-  gauged_tracePreserving A S σ hS_inv hStS hfix
 
 end CanonicalGauge

--- a/TNLean/Channel/Schwarz/KadisonSchwarz.lean
+++ b/TNLean/Channel/Schwarz/KadisonSchwarz.lean
@@ -60,42 +60,16 @@ def IsTPKraus (K : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
 @[simp] theorem isTPKraus_iff (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
     IsTPKraus K ↔ ∑ i : Fin d, (K i)ᴴ * K i = 1 := Iff.rfl
 
-/-- Alias: unital Kraus families are right-canonical. -/
-abbrev IsRightCanonicalKraus (K : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
-  IsUnitalKraus K
-
-/-- Alias: trace-preserving Kraus families are left-canonical. -/
-abbrev IsLeftCanonicalKraus (K : Fin d → Matrix (Fin D) (Fin D) ℂ) : Prop :=
-  IsTPKraus K
-
-@[simp] theorem isRightCanonicalKraus_iff (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
-    IsRightCanonicalKraus K ↔ IsUnitalKraus K :=
-  Iff.rfl
-
-@[simp] theorem isLeftCanonicalKraus_iff (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
-    IsLeftCanonicalKraus K ↔ IsTPKraus K :=
-  Iff.rfl
-
 /-- If the Kraus operators satisfy `∑ Kᵢ Kᵢ† = I`, then `krausMap K 1 = 1`. -/
 theorem krausMap_one_of_unital (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (h : IsUnitalKraus K) : krausMap K 1 = 1 := by
   simp only [krausMap, mul_one]; exact h
-
-/-- Right-canonical alias of `krausMap_one_of_unital`. -/
-theorem krausMap_one_of_rightCanonical (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (h : IsRightCanonicalKraus K) : krausMap K 1 = 1 :=
-  krausMap_one_of_unital K h
 
 /-- If the Kraus operators satisfy `∑ Kᵢ† Kᵢ = I`, then the adjoint map is unital:
 `krausAdjointMap K 1 = 1`. -/
 theorem krausAdjointMap_one_of_TP (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (h : IsTPKraus K) : krausAdjointMap K 1 = 1 := by
   simp only [krausAdjointMap, mul_one]; exact h
-
-/-- Left-canonical alias of `krausAdjointMap_one_of_TP`. -/
-theorem krausAdjointMap_one_of_leftCanonical (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (h : IsLeftCanonicalKraus K) : krausAdjointMap K 1 = 1 :=
-  krausAdjointMap_one_of_TP K h
 
 /-- The adjoint Kraus map equals the Kraus map with conjugate-transposed operators. -/
 private theorem krausAdjointMap_eq (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (Y) :

--- a/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
@@ -19,12 +19,10 @@ that appear in Wolf's notes.
 
 * `KadisonSchwarz.IsSubnormal`
 * `KadisonSchwarz.schwarz_inequality_subnormal_operator`
-* `KadisonSchwarz.wolf_theorem_5_5`
 * `KadisonSchwarz.commuting_dominant_right_bound`
 * `KadisonSchwarz.kadison_schwarz_commuting_dominant_cp_of_two_sided_bound`
 * `KadisonSchwarz.kadison_schwarz_commuting_dominant_cp`
 * `KadisonSchwarz.schwarz_inequality_commuting_dominant_operator`
-* `KadisonSchwarz.wolf_theorem_5_6`
 
 The key new result is `commuting_dominant_right_bound`: if `D ≥ 0` commutes with
 `A` and dominates `A† A`, then it also dominates `A A†`.  The proof uses the
@@ -367,9 +365,6 @@ theorem schwarz_inequality_subnormal_operator
     topLeft_schwarz_of_normal_extension (D := D) T hPos hSub
       (Matrix.fromBlocks A B 0 C) hNormal
 
-/-- Alias for `schwarz_inequality_subnormal_operator` matching Wolf Theorem 5.5. -/
-alias wolf_theorem_5_5 := schwarz_inequality_subnormal_operator
-
 /-- Linear-map formulation for the canonical adjoint Kraus map.
 
 This bundles `KadisonSchwarz.krausAdjointMap` from `KadisonSchwarz.lean` as a
@@ -695,8 +690,5 @@ theorem schwarz_inequality_commuting_dominant_operator
         _ ≤ T Dom + (ε : ℂ) • 1 := by gcongr
   exact ⟨le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).1,
          le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).2⟩
-
-/-- Alias for `schwarz_inequality_commuting_dominant_operator` matching Wolf Theorem 5.6. -/
-alias wolf_theorem_5_6 := schwarz_inequality_commuting_dominant_operator
 
 end KadisonSchwarz

--- a/TNLean/MPS/Structure/PrimitivityBridge.lean
+++ b/TNLean/MPS/Structure/PrimitivityBridge.lean
@@ -98,20 +98,6 @@ def HasPrimitiveFixedPoint {d D : ℕ} [NeZero D] (A : MPSTensor d D) : Prop :=
 
 /-! ## Part 2: Derive overlap → 1 from primitivity -/
 
-/-- Alias emphasizing that `IsPrimitiveMPS.norm` is the one-sided
-trace-preserving normalization `∑ᵢ Aᵢ† Aᵢ = I`. -/
-theorem IsPrimitiveMPS.tp_gauge {d D : ℕ} [NeZero D]
-    {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ} (hP : IsPrimitiveMPS A ρ) :
-    ∑ i : Fin d, (A i)ᴴ * A i = 1 :=
-  hP.norm
-
-/-- Preferred alias for `IsPrimitiveMPS.tp_gauge` using the project's left-canonical
-terminology. -/
-theorem IsPrimitiveMPS.leftCanonical {d D : ℕ} [NeZero D]
-    {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ} (hP : IsPrimitiveMPS A ρ) :
-    ∑ i : Fin d, (A i)ᴴ * A i = 1 :=
-  hP.tp_gauge
-
 /-- A primitive MPS tensor has self-overlap converging to 1.
 
 This is a direct application of `mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one`

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -143,11 +143,6 @@ def ofForall (hA : ∀ k, ∑ i : Fin d, (A k i)ᴴ * (A k i) = 1) :
     IsLeftCanonicalBlockFamily (d := d) A where
   leftCanonical := hA
 
-/-- Alias emphasizing that left-canonical blocks are trace-preserving. -/
-theorem tp_gauge (hA : IsLeftCanonicalBlockFamily (d := d) A) :
-    ∀ k, ∑ i : Fin d, (A k i)ᴴ * (A k i) = 1 :=
-  hA.leftCanonical
-
 end IsLeftCanonicalBlockFamily
 
 /-- Non-increasing weight ordering together with nonvanishing coefficients.


### PR DESCRIPTION
## Summary

This PR removes unused aliases from the active Lean surface:

- `gauged_rightCanonical` and `gauged_leftCanonical`, which restated `gauged_unital` and `gauged_tracePreserving`;
- `IsRightCanonicalKraus`, `IsLeftCanonicalKraus`, and the two corresponding one-map theorem aliases in the Kadison-Schwarz file;
- `IsPrimitiveMPS.tp_gauge` and `IsPrimitiveMPS.leftCanonical`, which restated the `IsPrimitiveMPS.norm` field;
- `IsLeftCanonicalBlockFamily.tp_gauge`, which restated the `leftCanonical` field;
- the unused Wolf-number aliases `wolf_theorem_5_5` and `wolf_theorem_5_6`, keeping the descriptive theorem names cited by the blueprint.

The unital, trace-preserving, primitive-normalization, and Schwarz statements now have a single source in these files. The module docstring in `CanonicalGauge` now states this directly.

Related to #999.

## Verification

- `rg` check for the removed declaration names across `TNLean`, `blueprint`, and `docs`
- `git diff --check`
- `rg` check for proof-integrity blockers in the edited files

The targeted Lean checks are blocked locally before reaching TNLean because the shared `.lake` Mathlib cache is missing `Mathlib/Algebra/Group/Defs.olean`. I ran `lake exe cache get`, but the cache still did not provide that olean, so CI is the authoritative check for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only deletes alias declarations and slightly updates docstrings; main theorems/definitions remain unchanged, but downstream code may break if it referenced the removed names.
> 
> **Overview**
> **Removes unused alias declarations** across the channel/MPS formalization to keep a single authoritative name for each statement.
> 
> This drops the right/left-canonical gauge theorem aliases in `CanonicalGauge`, the right/left-canonical Kraus-family abbreviations and their one-map theorem wrappers in `KadisonSchwarz`, the Wolf-number theorem `alias`es in `SchwarzSubnormal`, and the primitivity/left-canonical and block-family `tp_gauge` convenience aliases in `PrimitivityBridge` and `CanonicalFormSepAux`. Docstrings are updated to reflect the streamlined naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa45cb031979f854f8952d6a852cf89d15b9ac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->