### PR TITLE
doc(MPS/FT): clarify sector overlap provenance

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -416,13 +416,12 @@ convergence to `0`. It intentionally omits one-site injectivity and the
 finite-length span comparison between two different bases, because those are
 separate inputs in the after-blocking comparison.
 
-This structure is a deliberate parameterization — the analytic half of the
-overlap-rigidity route.  It records the per-family convergence properties that follow
-from the basis-of-normal-tensors definition in arXiv:1606.00608, Section II, lines 271–274.
-The combined two-family structure `SectorBasisOverlapSpanHypotheses` adds the injectivity
-and span-comparison fields. When the after-blocking BNT cover is discharged
-(tracker #1498, sub-issue #1501), the fields recorded here are consequences of the
-BNT sector structure recorded in `IsBNTCanonicalForm`. -/
+This is the analytic half of the overlap-rigidity route. It records the per-family
+convergence properties that follow from the basis-of-normal-tensors definition in
+arXiv:1606.00608, Section II, lines 271–274. The combined two-family structure
+`SectorBasisOverlapSpanHypotheses` adds the injectivity and span-comparison fields.
+In the full CPSV16 argument, after blocking to a BNT cover, these hypotheses follow from
+the BNT sector structure recorded in `IsBNTCanonicalForm`. -/
 structure SectorBasisOverlapOrthoHypotheses (P : SectorDecomposition d) : Prop where
   /-- The basis blocks have nonzero bond dimension. -/
   dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j


### PR DESCRIPTION
This PR removes procedural tracker wording from the sector-decomposition overlap hypotheses and replaces it with the mathematical provenance.

Changes:

- Rephrases the docstring for `SectorBasisOverlapOrthoHypotheses` so it says these per-family convergence hypotheses follow from the BNT sector structure after blocking to a BNT cover.
- Removes issue-tracker and sub-issue language from reader-facing mathematical prose.

Local validation:

- `lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean`
- `git diff --check`
- no over-100-character lines in the edited file
- `python3 scripts/check_oversized_lean_files.py`

GitHub Actions is still affected by the repository Actions-budget failure; if checks fail instantly, inspect the check-run annotations for the budget message before treating them as content failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change: rewords the `SectorBasisOverlapOrthoHypotheses` docstring without altering any definitions or proofs, so functional risk is minimal.
> 
> **Overview**
> Clarifies the docstring for `SectorBasisOverlapOrthoHypotheses` to focus on the mathematical provenance of the overlap/orthogonality convergence assumptions (derivable after blocking to a BNT cover from `IsBNTCanonicalForm`), and removes procedural issue-tracker wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55b58e7b044d28003e0f7d58739a745a9562d0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->