### PR TITLE
refactor(MPS/Overlap): remove peripheral primitivity alias

### DIFF
--- a/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
+++ b/TNLean/MPS/Overlap/PeripheralToSpectralGap.lean
@@ -52,28 +52,6 @@ The formal Lean declaration:
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
 open Matrix Filter
 
-/-!
-## Step 0: naming hygiene
-
-`TNLean.Channel.Peripheral.Spectrum` currently defines its primitivity predicate and spectral-gap
-lemmas in the root namespace. For clarity (and to avoid confusion with
-`MPSTensor.HasPrimitiveFixedPoint`), we provide local aliases in the namespace
-`PeripheralSpectrum`.
--/
-
-namespace PeripheralSpectrum
-
-/-- Channel-level primitivity: `peripheralEigenvalues E = {1}`.
-
-This is an alias for the root-level definition from
-`TNLean.Channel.Peripheral.Spectrum`, placed in a dedicated namespace to avoid
-confusion with `MPSTensor.HasPrimitiveFixedPoint`. -/
-abbrev IsPrimitive {V : Type*} [AddCommGroup V] [Module ℂ V]
-    (E : V →ₗ[ℂ] V) : Prop :=
-  _root_.IsPrimitive E
-
-end PeripheralSpectrum
-
 namespace MPSTensor
 
 variable {d D : ℕ}
@@ -308,7 +286,7 @@ private theorem spectralRadius_compl_lt_one_of_peripheralPrimitive_aux
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hPrim : PeripheralSpectrum.IsPrimitive (transferMap (d := d) (D := D) A))
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
     (ρ : Matrix (Fin D) (Fin D) ℂ)
     (hρ_psd : ρ.PosSemidef)
     (hρ_ne : ρ ≠ 0)
@@ -379,7 +357,7 @@ theorem spectralRadius_compl_lt_one_of_peripheralPrimitive
     (A : MPSTensor d D)
     (hInj : IsInjective A)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hPrim : PeripheralSpectrum.IsPrimitive (transferMap (d := d) (D := D) A)) :
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A)) :
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ,
       ρ.PosSemidef ∧ ρ ≠ 0 ∧ transferMap (d := d) (D := D) A ρ = ρ ∧
         ∃ htr : Matrix.trace ρ ≠ 0,
@@ -420,7 +398,7 @@ theorem hasPrimitiveFixedPoint_of_peripheralPrimitive
     (A : MPSTensor d D)
     (hInj : IsInjective A)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hPrim : PeripheralSpectrum.IsPrimitive (transferMap (d := d) (D := D) A)) :
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A)) :
     MPSTensor.HasPrimitiveFixedPoint A := by
   classical
   rcases spectralRadius_compl_lt_one_of_peripheralPrimitive
@@ -438,7 +416,7 @@ theorem overlap_tendsto_one_of_peripheralPrimitive
     (A : MPSTensor d D)
     (hInj : IsInjective A)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hPrim : PeripheralSpectrum.IsPrimitive (transferMap (d := d) (D := D) A)) :
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A)) :
     Tendsto (fun N ↦ mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ)) := by
   classical
   have hP : MPSTensor.HasPrimitiveFixedPoint A :=
@@ -454,7 +432,7 @@ theorem spectralRadius_compl_lt_one_of_peripheralPrimitive_of_irreducible
     (A : MPSTensor d D)
     (hIrr : IsIrreducibleTensor A)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hPrim : PeripheralSpectrum.IsPrimitive (transferMap (d := d) (D := D) A)) :
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A)) :
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ,
       ρ.PosSemidef ∧ ρ ≠ 0 ∧ transferMap (d := d) (D := D) A ρ = ρ ∧
         ∃ htr : Matrix.trace ρ ≠ 0,
@@ -491,7 +469,7 @@ theorem hasPrimitiveFixedPoint_of_peripheralPrimitive_of_irreducible
     (A : MPSTensor d D)
     (hIrr : IsIrreducibleTensor A)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hPrim : PeripheralSpectrum.IsPrimitive (transferMap (d := d) (D := D) A)) :
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A)) :
     MPSTensor.HasPrimitiveFixedPoint A := by
   classical
   rcases spectralRadius_compl_lt_one_of_peripheralPrimitive_of_irreducible
@@ -508,7 +486,7 @@ theorem overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
     (A : MPSTensor d D)
     (hIrr : IsIrreducibleTensor A)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hPrim : PeripheralSpectrum.IsPrimitive (transferMap (d := d) (D := D) A)) :
+    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A)) :
     Tendsto (fun N ↦ mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ)) := by
   classical
   have hP : MPSTensor.HasPrimitiveFixedPoint A :=


### PR DESCRIPTION
This PR removes a local compatibility alias from the peripheral-to-spectral-gap bridge.

Changes:

- Deletes the local `PeripheralSpectrum.IsPrimitive` alias, which only wrapped the root channel-level `_root_.IsPrimitive` predicate.
- Rewrites the hypotheses in this file to use `_root_.IsPrimitive` directly.
- Removes the accompanying “naming hygiene” prose, including the stale “currently defines” wording.

Local validation:

- `lake env lean TNLean/MPS/Overlap/PeripheralToSpectralGap.lean`
- `git diff --check`
- no over-100-character lines in the edited file
- `python3 scripts/check_oversized_lean_files.py`

GitHub Actions is still affected by the repository Actions-budget failure; if checks fail instantly, inspect the check-run annotations for the budget message before treating them as content failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: removes a local alias and updates theorem hypotheses to reference `_root_.IsPrimitive` directly, with no change to proof structure or semantics.
> 
> **Overview**
> Removes the local `PeripheralSpectrum.IsPrimitive` compatibility alias (and its surrounding “naming hygiene” prose) from `PeripheralToSpectralGap.lean`.
> 
> Updates all affected lemmas/theorems to take `_root_.IsPrimitive (transferMap …)` directly, keeping the peripheral→spectral-gap bridge and overlap convergence statements unchanged aside from the hypothesis name/namespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7fbd026768583a51d42ec715d3d849635b9f444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->