### PR TITLE
doc(MPS/Periodic): clarify overlap interface gaps

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -41,9 +41,9 @@ tensor on the corner bond space, as produced by
 `exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`.
 
 The nontriviality hypothesis `dim u ≠ 0` excludes the degenerate
-zero-dimensional "missing sector" case. With the current definitions, an
-`MPSTensor _ 0` may satisfy block-injectivity/normality vacuously, so this
-assumption is used to focus on genuine nonempty sectors.
+zero-dimensional "missing sector" case. An `MPSTensor _ 0` may satisfy
+block-injectivity/normality vacuously, so this assumption focuses the statement
+on genuine nonempty sectors.
 
 The `hBlocks_mpv` hypothesis ties the compressed block decomposition back to
 the original blocked tensor, and `hCyclic` ensures the block indexing
@@ -241,10 +241,9 @@ equivalence carries a nonzero sector of `A` to a sector of `B`. The hypothesis
 `hNondegA` supplies the nonzero-sector condition for the returned `A` sector, while
 `hNondegB` provides the typeclass needed to apply the mixed-sector overlap dichotomy.
 Both come from the periodic sector decomposition constructed by
-`exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`.
-The current interface does not yet expose that uniqueness theorem in this
-compressed-sector form, so the missing step is isolated here as the only missing
-ingredient. -/
+`exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`. The missing
+mathematical input is the compressed-sector form of this uniqueness theorem,
+isolated here as the only missing ingredient. -/
 lemma exists_sector_match_of_gaugePhaseEquiv
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -616,9 +616,9 @@ Through `IsCyclicSectorDecomp`, those traces are
 decomposition are orthogonal corners, so for `u ≠ v` these corner states cannot
 be related by an invertible gauge and nonzero scalar.
 
-The current cyclic-sector interface exposes the trace formula and projection data
-but does not yet state this orthogonal-corner rigidity as a reusable theorem, so
-we isolate exactly that missing step here. -/
+The cyclic-sector decomposition supplies the trace formula and projection data. The
+missing mathematical input is orthogonal-corner rigidity: distinct cyclic corners
+cannot be related by an invertible gauge and a nonzero scalar. -/
 private lemma sectorBlocks_not_gaugePhaseEquiv_of_ne
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (_hP : IsPeriodic m A)
@@ -652,7 +652,7 @@ After blocking by the period, the cyclic sector decomposition should make each
 compressed sector a primitive normalized tensor, while distinct sectors are
 asymptotically orthogonal.
 
-This is the remaining step from the cyclic-sector decomposition interface to the
+This theorem isolates the passage from cyclic-sector decomposition data to the
 overlap-asymptotic statement. -/
 private theorem sectorOverlap_tendsto_delta_of_cyclicSectorDecomp
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]


### PR DESCRIPTION
This PR makes the adjacent periodic-overlap gap prose reader-facing.

Changes:

- Replaces “current definitions” language in Case 2 with the actual zero-dimensional-sector reason.
- Rephrases the sector-match gap as the missing compressed-sector uniqueness theorem.
- Rephrases the self-overlap gap as the missing orthogonal-corner rigidity input and the passage from cyclic-sector data to overlap asymptotics.

Local validation:

- `lake env lean TNLean/MPS/Periodic/Overlap/Case2.lean`
- `lake env lean TNLean/MPS/Periodic/Overlap/SelfOverlap.lean`
- `git diff --check`
- no over-100-character lines in the edited files
- `python3 scripts/check_oversized_lean_files.py`

The focused Lean checks report only the pre-existing `sorry` warnings in these files. GitHub Actions is still affected by the repository Actions-budget failure; if checks fail instantly, inspect the check-run annotations for the budget message before treating them as content failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits that rephrase and clarify existing gap/assumption explanations; no logic or theorem statements change.
> 
> **Overview**
> Clarifies prose in periodic overlap Case 2 and self-overlap modules to be more explicit about *why* certain hypotheses exist and what mathematical results are still missing.
> 
> Specifically, updates docstrings to (1) explain the `dim u ≠ 0` guard as avoiding vacuous `MPSTensor _ 0` normality/block-injectivity, (2) describe the sector-match step as needing a compressed-sector uniqueness theorem after blocking, and (3) label the self-overlap gap as missing orthogonal-corner rigidity plus the bridge from cyclic-sector data to overlap asymptotics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da968e059acf9b5fc35c44bf73ae5e766a77deb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->