### PR TITLE
refactor(Channel/Determinant): remove local matrix aliases

### DIFF
--- a/TNLean/Channel/Determinant/Basic.lean
+++ b/TNLean/Channel/Determinant/Basic.lean
@@ -76,18 +76,7 @@ noncomputable def matrixSpaceBasis (d : ℕ) :
 end Internal
 end ChannelDeterminant
 
-/-- File-local alias for the shared internal matrix-algebra model. -/
-private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
-
-/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
-
-/-- File-local alias for the shared basis index type. -/
-private abbrev MatrixBasisIndex (d : ℕ) := ChannelDeterminant.Internal.MatrixBasisIndex d
-
-/-- File-local alias for the shared standard basis of `M_d(ℂ)`. -/
-private noncomputable abbrev matrixSpaceBasis (d : ℕ) :=
-  ChannelDeterminant.Internal.matrixSpaceBasis d
+open ChannelDeterminant.Internal
 
 section Determinant
 

--- a/TNLean/Channel/Determinant/Bound.lean
+++ b/TNLean/Channel/Determinant/Bound.lean
@@ -35,21 +35,9 @@ quantum channel, determinant bound, positive map, trace-preserving map
 -/
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker Matrix.Norms.Frobenius
 open Matrix
+open ChannelDeterminant.Internal
 
 variable {d : ℕ}
-
-/-- File-local alias for the shared internal matrix-algebra model. -/
-private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
-
-/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
-
-/-- File-local alias for the shared basis index type. -/
-private abbrev MatrixBasisIndex (d : ℕ) := ChannelDeterminant.Internal.MatrixBasisIndex d
-
-/-- File-local alias for the shared standard basis of `M_d(ℂ)`. -/
-private noncomputable abbrev matrixSpaceBasis (d : ℕ) :=
-  ChannelDeterminant.Internal.matrixSpaceBasis d
 
 section WolfStatements
 

--- a/TNLean/Channel/Determinant/HeisenbergDual.lean
+++ b/TNLean/Channel/Determinant/HeisenbergDual.lean
@@ -33,21 +33,9 @@ quantum channel, Heisenberg dual, Kadison-Schwarz, multiplicative domain
 -/
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker Matrix.Norms.Frobenius
 open Matrix
+open ChannelDeterminant.Internal
 
 variable {d : ℕ}
-
-/-- File-local alias for the shared internal matrix-algebra model. -/
-private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
-
-/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
-
-/-- File-local alias for the shared basis index type. -/
-private abbrev MatrixBasisIndex (d : ℕ) := ChannelDeterminant.Internal.MatrixBasisIndex d
-
-/-- File-local alias for the shared standard basis of `M_d(ℂ)`. -/
-private noncomputable abbrev matrixSpaceBasis (d : ℕ) :=
-  ChannelDeterminant.Internal.matrixSpaceBasis d
 
 section WolfStatements
 

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -43,21 +43,9 @@ quantum channel, determinant, Hilbert-Schmidt norm, standard basis, AM-GM
 -/
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker Matrix.Norms.Frobenius
 open Matrix
+open ChannelDeterminant.Internal
 
 variable {d : ℕ}
-
-/-- File-local alias for the shared internal matrix-algebra model. -/
-private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
-
-/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
-
-/-- File-local alias for the shared basis index type. -/
-private abbrev MatrixBasisIndex (d : ℕ) := ChannelDeterminant.Internal.MatrixBasisIndex d
-
-/-- File-local alias for the shared standard basis of `M_d(ℂ)`. -/
-private noncomputable abbrev matrixSpaceBasis (d : ℕ) :=
-  ChannelDeterminant.Internal.matrixSpaceBasis d
 
 section WolfStatements
 

--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -39,14 +39,9 @@ quantum channel, determinant, unitary channel, Skolem-Noether
 -/
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker Matrix.Norms.Frobenius
 open Matrix
+open ChannelDeterminant.Internal
 
 variable {d : ℕ}
-
-/-- File-local alias for the shared internal matrix-algebra model. -/
-private abbrev MatrixAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
-
-/-- File-local alias for endomorphisms of `M_d(ℂ)`. -/
-private abbrev MatrixEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
 
 /-- Column-stacking vectorization as a linear equivalence. -/
 private noncomputable def matrixVecLinearEquiv (d : ℕ) :


### PR DESCRIPTION
## Summary

This PR removes repeated file-local private abbreviations for the determinant matrix algebra, endomorphism type, basis index, and standard basis. The determinant files now refer to the single definitions in `ChannelDeterminant.Internal` by opening that namespace locally.

No theorem statement or mathematical definition is changed; this is only a consolidation of names used inside the determinant section.

## Verification

- `git diff --check`
- `rg` check that the removed file-local alias declarations no longer occur in `TNLean/Channel/Determinant`
- proof-integrity grep for `sorry`, `axiom`, `unsafeCast`, `native_decide`, and `admit` in the five edited files
- attempted `lake env lean TNLean/Channel/Determinant/Basic.lean`
- attempted `lake env lean TNLean/Channel/Determinant/Bound.lean`

The two targeted Lean checks are blocked before reaching TNLean by the shared `.lake` cache: `Mathlib/Algebra/Group/Defs.olean` is missing. The shared `batteries` checkout also reports local changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to name/namespace usage in determinant-related Lean files; no theorem statements or definitions change, but minor risk of broken imports/namespace resolution.
> 
> **Overview**
> **What changed:** Replaced per-file `private abbrev` aliases for `MatrixAlg`, `MatrixEnd`, `MatrixBasisIndex`, and `matrixSpaceBasis` across the determinant modules with a single `open ChannelDeterminant.Internal` and direct references to the shared internal definitions.
> 
> No mathematical content is altered; this is a consolidation/refactor to reduce duplication and keep naming consistent across `Basic`, `Bound`, `HilbertSchmidt`, `HeisenbergDual`, and `UnitaryCharacterization`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2dfba4c47a4a4db24640af6d35d14d8429811cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->