### PR TITLE
fix(ci): avoid duplicate Claude review cache saves

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -120,6 +120,8 @@ jobs:
       - name: Set up Lean toolchain and cache
         if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true' && steps.provider-token.outputs.skip != 'true'
         uses: ./.trusted-actions/.github/actions/setup-lean
+        with:
+          use-github-cache: false
 
       - name: Run Claude Code Review
         if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true' && steps.provider-token.outputs.skip != 'true'


### PR DESCRIPTION
Closes #1659.

## Summary

The Claude review workflow runs a provider matrix. Each job used the shared Lean setup action with GitHub Lake caching enabled, so concurrent review jobs could both restore the same cache and then race to reserve the same save key. One job then emitted the warning reported in #1659:

> Cache save failed.

This PR disables the GitHub Lake cache only for the Claude review workflow. The shared setup action and the Mathlib cache remain unchanged for the other CI jobs.

## Verification

- yaml ok
- 
- 

No Lean declarations or mathematical statements are changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only a GitHub Actions workflow input to avoid cache-save contention; no product/runtime code is affected.
> 
> **Overview**
> Prevents duplicate cache-save attempts in the Claude provider matrix by passing `use-github-cache: false` to the shared `setup-lean` action in `.github/workflows/claude-code-review.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e1e82e5bcc40126aed6d71cf123d4c6c1d08f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->