### PR TITLE
ci(github): add DeepSeek mention handler

### DIFF
--- a/.github/actions/auto-create-issue-pr/action.yml
+++ b/.github/actions/auto-create-issue-pr/action.yml
@@ -16,7 +16,8 @@ inputs:
     required: true
   autofix-label:
     description: 'Label to add when the trigger text contains an auto-fix keyword'
-    required: true
+    required: false
+    default: ''
   event-name:
     description: 'github.event_name; selects which fields to scan for the auto-fix keyword'
     required: true
@@ -132,7 +133,9 @@ runs:
           TRIGGER_TEXT="$ISSUE_BODY $ISSUE_TITLE_INPUT"
         fi
 
-        if echo "$TRIGGER_TEXT" | grep -qiE 'auto[_ -]?fix'; then
+        if echo "$TRIGGER_TEXT" | grep -qiE 'auto[_ -]?fix' && [ -n "$AUTOFIX_LABEL" ]; then
           echo "Autofix keyword detected — adding '${AUTOFIX_LABEL}' label to PR #${PR_NUM}"
           gh pr edit "$PR_NUM" --repo "$REPO" --add-label "$AUTOFIX_LABEL" || true
+        elif echo "$TRIGGER_TEXT" | grep -qiE 'auto[_ -]?fix'; then
+          echo "Autofix keyword detected, but no autofix label is configured for ${CREATOR_NAME}."
         fi

--- a/.github/workflows/deepseek.yml
+++ b/.github/workflows/deepseek.yml
@@ -1,0 +1,105 @@
+name: DeepSeek Code (Lean)
+
+# Mention-driven DeepSeek responder. This uses the shared Claude Code wrapper
+# in explicit DeepSeek provider mode; it is separate from claude.yml so
+# maintainers can choose the provider by writing @deepseek.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: bot-respond-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
+  cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+
+jobs:
+  deepseek:
+    # Skip when:
+    #   - repository variable DEEPSEEK_MENTION_ENABLED is exactly "false";
+    #   - sender is a bot;
+    #   - the triggering author lacks write access; or
+    #   - the same trigger also asks @claude or @chatgpt, in which case the
+    #     provider-specific workflow named by that mention handles the request.
+    if: |
+      vars.DEEPSEEK_MENTION_ENABLED != 'false' &&
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@deepseek') && !contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@chatgpt') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@deepseek') && !contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@chatgpt') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@deepseek') && !contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@chatgpt') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@deepseek') || contains(github.event.issue.title, '@deepseek')) && !(contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && !(contains(github.event.issue.body, '@chatgpt') || contains(github.event.issue.title, '@chatgpt')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      DEEPSEEK_BASE_URL: ${{ vars.DEEPSEEK_BASE_URL || 'https://api.deepseek.com/anthropic' }}
+      DEEPSEEK_OPUS_MODEL: ${{ vars.DEEPSEEK_OPUS_MODEL }}
+      DEEPSEEK_SONNET_MODEL: ${{ vars.DEEPSEEK_SONNET_MODEL }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          token: ${{ env.GH_TOKEN }}
+
+      - name: Set up Lean toolchain and cache
+        uses: ./.github/actions/setup-lean
+        with:
+          install-blueprint: 'true'
+
+      - name: Run DeepSeek Code
+        id: deepseek
+        uses: ./.github/actions/claude-code-with-provider
+        with:
+          provider: deepseek
+          model-tier: opus
+          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          deepseek-base-url: ${{ env.DEEPSEEK_BASE_URL }}
+          deepseek-opus-model: ${{ env.DEEPSEEK_OPUS_MODEL }}
+          deepseek-sonnet-model: ${{ env.DEEPSEEK_SONNET_MODEL }}
+          allowed-bots: 'claude,chatgpt-codex-connector,cursor[bot],cursor,copilot-pull-request-reviewer'
+          branch-name-template: "deepseek/{{entityType}}-{{entityNumber}}-{{description}}"
+          allowed_tools_preset: claude-interactive
+
+          additional-permissions: |
+            actions: read
+
+          plugin_marketplaces: 'https://github.com/leanprover/skills.git'
+          plugins: 'lean@leanprover'
+          system-prompt-file: .github/prompts/claude-code-system-prompt.md
+
+      - name: Auto-create PR for completed issue work
+        if: |
+          !cancelled() &&
+          steps.deepseek.outcome == 'success' &&
+          (github.event_name == 'issues' ||
+           (github.event_name == 'issue_comment' && !github.event.issue.pull_request))
+        uses: ./.github/actions/auto-create-issue-pr
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          repo: ${{ github.repository }}
+          branch-prefix: 'deepseek/issue-'
+          creator-name: 'DeepSeek Code action'
+          autofix-label: ''
+          event-name: ${{ github.event_name }}
+          comment-body: ${{ github.event.comment.body || '' }}
+          issue-body: ${{ github.event.issue.body || '' }}
+          issue-title: ${{ github.event.issue.title || '' }}
+          gh-token: ${{ env.GH_TOKEN }}

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -20,6 +20,7 @@ This repository uses [Claude Code](https://docs.anthropic.com/en/docs/claude-cod
   - [Review Comment Auto-Fix](#review-comment-auto-fix-auto-fixyml)
   - [Claude Mention Handler](#claude-mention-handler-claudeyml)
   - [Codex Mention Handler](#codex-mention-handler-codexyml)
+  - [DeepSeek Mention Handler](#deepseek-mention-handler-deepseekyml)
   - [Shared CI Auto-Fix Template](#shared-ci-auto-fix-template-_ci-auto-fix-sharedyml)
   - [Shared CI Auto-Fix Template (Codex)](#shared-ci-auto-fix-template-codex-_codex-auto-fix-sharedyml)
 - [Safety Mechanisms](#safety-mechanisms)
@@ -30,6 +31,7 @@ This repository uses [Claude Code](https://docs.anthropic.com/en/docs/claude-cod
   - [To enable the review-fix loop](#to-enable-the-review-fix-loop)
   - [Human intervention while auto-fix is active](#human-intervention-while-auto-fix-is-active)
   - [To ask Claude for help directly](#to-ask-claude-for-help-directly)
+  - [To ask DeepSeek for help directly](#to-ask-deepseek-for-help-directly)
 - [Commit Message Conventions](#commit-message-conventions)
 - [Permissions](#permissions)
 - [Changing the Configuration](#changing-the-configuration)
@@ -122,6 +124,13 @@ When you push to a PR branch, several things happen in parallel:
   │  │                                                              │
   │  │  Codex Mention Handler (codex.yml)                           │
   │  │  General-purpose Codex responder for ad-hoc requests.        │
+  │  └──────────────────────────────────────────────────────────────┘
+  │
+  │  ┌──────────────────────────────────────────────────────────────┐
+  │  │ Runs when someone writes "@deepseek" in a comment            │
+  │  │                                                              │
+  │  │  DeepSeek Mention Handler (deepseek.yml)                     │
+  │  │  General-purpose DeepSeek responder for ad-hoc requests.     │
   │  └──────────────────────────────────────────────────────────────┘
 ```
 
@@ -359,6 +368,32 @@ restore the default enabled behavior.
 
 ---
 
+### DeepSeek Mention Handler (`deepseek.yml`)
+
+**What it does**: A general-purpose responder for requests that mention
+`@deepseek`. It uses the shared Claude Code wrapper in explicit `deepseek`
+provider mode, with `DEEPSEEK_API_KEY`, `DEEPSEEK_BASE_URL`, and the optional
+`DEEPSEEK_OPUS_MODEL` / `DEEPSEEK_SONNET_MODEL` repository variables.
+
+**When it runs**: On issue comments, PR comments, PR review comments, PR review
+bodies, and issue title/body text that contain `@deepseek`; the triggering
+author must have write access to the repository, the event sender must not be a
+bot, and the same trigger must not also mention `@claude` or `@chatgpt`.
+
+**Branch naming**: Issue-started work uses `deepseek/issue-<number>-...`
+branches. If the DeepSeek run pushes such a branch, the follow-up step opens a
+pull request against `main`.
+
+**Auto-fix labels**: The DeepSeek mention handler is mention-only. It does not
+define a third label-gated repair loop and does not add an auto-fix label to
+issue-created pull requests, even if the trigger text contains `auto fix`.
+
+**Global switch**: Set repository variable `DEEPSEEK_MENTION_ENABLED=false` to
+disable the `@deepseek` responder globally. Unset it, or set another value, to
+restore the default enabled behavior.
+
+---
+
 ### Shared CI Auto-Fix Template (`_ci-auto-fix-shared.yml`)
 
 **What it does**: A reusable workflow template called by the CI-fix and
@@ -471,18 +506,19 @@ pull-request workflow needs opt-in.
 - Adding either label directly to an issue does not trigger TNLean's auto-fix
   workflows.
 
-**General issue-started workflow behavior.** The Claude responder starts from
-issue titles, issue bodies, or issue comments that contain `@claude`, provided
-the triggering author has write access to the repository and the GitHub event
-sender is not a bot. For issue titles and issue bodies, this applies when the
-issue is opened or assigned; for comments, it applies when the comment is
-created.
+**General issue-started workflow behavior.** The mention responders start from
+issue titles, issue bodies, or issue comments that contain their exact trigger
+(`@claude`, `@chatgpt`, or `@deepseek`), provided the triggering author has
+write access to the repository and the GitHub event sender is not a bot. For
+issue titles and issue bodies, this applies when the issue is opened or
+assigned; for comments, it applies when the comment is created.
 
 **TNLean issue-started workflow behavior.** When the responder creates a pull
 request from issue work, the follow-up action scans the same triggering text for
 the magic phrase `auto[_ -]?fix`, matching `auto-fix`, `auto fix`, or `autofix`.
 If it finds one of those forms, it adds `auto-fix-claude` to the created pull
-request.
+request. The Codex responder analogously adds `auto-fix-codex`. The DeepSeek
+responder intentionally adds no auto-fix label.
 
 **Pull-request comments are different.** The `auto fix` phrase in a
 pull-request comment does not enable the label-gated auto-fix loop. A comment
@@ -552,6 +588,12 @@ resulting pull request should receive an auto-fix label. For a pull request,
 add the label or make a direct one-off request without the `auto fix` trigger
 language after the label-gated loop has stopped.
 
+### To ask DeepSeek for help directly
+
+Write a comment on any issue or PR that includes `@deepseek` followed by the
+request. Do not combine it with `@claude` or `@chatgpt` in the same triggering
+comment; only one mention-handler workflow should own a task.
+
 ---
 
 ## Commit Message Conventions
@@ -605,7 +647,12 @@ label name, update `.github/workflows/auto-fix.yml` and the
 
 ### Model
 
-All Claude-based workflows use `claude-opus-4-7`, configured via `--model` in the `claude_args` parameter of the relevant workflow file. Codex-based workflows run via `openai/codex-action` and use their own model/configuration mechanism rather than Claude `--model` flags.
+Anthropic Claude workflows use `claude-opus-4-7`, configured via `--model` in
+the `claude_args` parameter of the relevant workflow file. DeepSeek mention and
+review runs use the same wrapper in `deepseek` provider mode and select
+`deepseek-v4-pro[1m]` by default unless the repository variables override it.
+Codex-based workflows run via `openai/codex-action` and use their own
+model/configuration mechanism rather than Claude `--model` flags.
 
 ### Review providers
 
@@ -615,6 +662,7 @@ To run one or both review engines, set this repository variable:
 |---|---|---|
 | `CLAUDE_CODE_REVIEW_PROVIDERS` | JSON array string, for example `["anthropic","deepseek"]` | Selects which review jobs run in parallel for `claude-code-review.yml`. If unset, the workflow uses `CLAUDE_CODE_PROVIDER` as a single default. |
 | `CLAUDE_CODE_PROVIDER` | `anthropic` or `deepseek` | Legacy fallback provider when no multi-provider list is set. |
+| `DEEPSEEK_MENTION_ENABLED` | `false` disables; unset or any other value enables | Controls only `deepseek.yml`, the `@deepseek` mention handler. |
 
 Set `CLAUDE_CODE_REVIEW_PROVIDERS` to `["anthropic"]` to force single Anthropic review.
 Set `CLAUDE_CODE_REVIEW_PROVIDERS` to `["deepseek"]` to force only DeepSeek review.

--- a/docs/pr_review_management.md
+++ b/docs/pr_review_management.md
@@ -34,7 +34,7 @@ PRs should follow the mathlib review checklist — review for: **style**, **docu
 - References should use BibTeX entries
 
 ### PR and issue title conventions
-@codex and @claude generate inconsistent titles. Unify before merging:
+@codex, @claude, and @deepseek can generate inconsistent titles. Unify before merging:
 - **Title format**: `type(scope): description`, for example
   `feat(Wolf Chapter 6): add conditional expectation (Theorem 6.15)`.
 - **Types**: `feat` (new formalization), `fix` (mathematical or proof correction),
@@ -47,7 +47,7 @@ PRs should follow the mathlib review checklist — review for: **style**, **docu
   theorem/proposition numbers where applicable.
 - **Body**: should have `### Motivation`, `### Description`, and
   `### Testing` sections. Reference the issue number. List files changed.
-- **Clean up bot-generated titles** before merging. Codex/Claude often produce
+- **Clean up bot-generated titles** before merging. Codex, Claude, and DeepSeek often produce
   verbose or inconsistent titles like `[PR #165 follow-up] BlockedChainFT style
   cleanups and term-mode endpoint`. Rename to, for example,
   `style(MPS/Chain): BlockedChainFT term-mode endpoint and naming cleanup`.
@@ -103,13 +103,13 @@ Interpretation:
 Three SEPARATE places comments live on a PR. Must check ALL three.
 
 ### 1. Inline review comments (on specific diff lines)
-- **What**: Bugbot (cursor[bot]), Copilot, Codex (chatgpt-codex-connector), and Claude inline findings on specific lines
+- **What**: Bugbot (cursor[bot]), Copilot, Codex (chatgpt-codex-connector), Claude, and DeepSeek inline findings on specific lines
 - **API**: `gh api repos/OWNER/REPO/pulls/N/comments`
 - **NOT returned by**: `gh pr view --json comments` or `--json reviews`
 - **Key fields**: `path`, `line`, `body`, `user.login`, `in_reply_to_id`
 
 ### 2. PR-level comments (conversation thread)
-- **What**: Claude review summaries, human comments, @codex/@claude responses
+- **What**: Claude or DeepSeek review summaries, human comments, @codex/@claude/@deepseek responses
 - **API**: `gh api repos/OWNER/REPO/issues/N/comments` OR `gh pr view N --json comments`
 - **Key fields**: `body`, `author.login`, `createdAt`
 - **Watch for**: Claude sometimes embeds inline-style nits here when it can't post inline
@@ -144,7 +144,8 @@ gh api "repos/$REPO/pulls/$PR/reviews" --jq '.[] | "REVIEW [\(.user.login)] stat
 The active review-repair loop is label-gated. A pull request with
 `auto-fix-claude` or `auto-fix-codex` is already assigned to the corresponding
 auto-fix workflow. Do not add `@claude auto fix`, `@chatgpt auto fix`, or
-similar trigger comments to a PR that already has one of these labels.
+`@deepseek auto fix` trigger comments to a PR that already has one of these
+labels.
 Do not use PR replies as an auto-fix control surface for labeled PRs.
 
 In particular, a PR reply such as `@claude auto fix ...` is not the
@@ -167,17 +168,21 @@ the review-fix loop. See `docs/ci-automation.md` for the workflow details.
 
 ### When to use direct mentions
 
-Direct `@claude` / `@chatgpt` mentions are separate from labeled auto-fix.
+Direct `@claude`, `@chatgpt`, and `@deepseek` mentions are separate from
+labeled auto-fix.
 Use them only for a new delegated task where a separate branch or explicit
 one-off answer is intended.
 They are not a repair mechanism for a PR that is already on the auto-fix label
 lane.
 
-Opening an issue whose body contains `@claude` or `@chatgpt` can trigger the
-mention handler, but editing an existing issue body later does not reliably
-create a new task. Post a new issue comment when an existing issue should start
-a mention-handler task. For new issue-based work, mention comments create fresh
-work from `main`, so do not use them for ordinary nits on an existing PR branch.
+Opening an issue whose body contains `@claude`, `@chatgpt`, or `@deepseek` can
+trigger the mention handler, but editing an existing issue body later does not
+reliably create a new task. Post a new issue comment when an existing issue
+should start a mention-handler task. For new issue-based work, mention comments
+create fresh work from `main`, so do not use them for ordinary nits on an
+existing PR branch.
+The DeepSeek mention path is mention-only: it uses `deepseek/issue-<number>-...`
+branches for issue-created work and does not add an auto-fix label.
 
 ### Branch-name caveat for mention handlers
 


### PR DESCRIPTION
Closes #1431.

### Motivation

Maintainer comments can already invoke the Anthropic Claude path with `@claude` and the Codex path with `@chatgpt`. This adds an explicit DeepSeek path so a maintainer can choose that provider directly.

### Description

- Adds `.github/workflows/deepseek.yml` for `@deepseek` on issue comments, PR comments, PR review comments, PR review bodies, and issue title/body triggers.
- Restricts the trigger to OWNER/MEMBER/COLLABORATOR authors and skips bot senders, matching the existing mention-handler policy.
- Runs the shared Claude Code wrapper with `provider: deepseek`, not the default provider.
- Uses `deepseek/issue-<number>-...` for issue-created branches.
- Keeps DeepSeek mention-only: no dedicated auto-fix label and no reuse of `auto-fix-claude` or `auto-fix-codex`.
- Documents the trigger semantics, branch naming, provider selection, global disable variable, and auto-fix-label decision.

### Testing

- `actionlint .github/workflows/deepseek.yml .github/workflows/claude.yml .github/workflows/codex.yml`
- YAML parse check for `.github/workflows/deepseek.yml` and `.github/actions/auto-create-issue-pr/action.yml`
- `git diff --check -- .github/workflows/deepseek.yml .github/actions/auto-create-issue-pr/action.yml docs/ci-automation.md docs/pr_review_management.md`

No Lean declarations or mathematical statements are changed.