### PR TITLE
ci(github): report Claude Code provider mode

### DIFF
--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -372,6 +372,7 @@ runs:
         write_output anthropic_api_key "$anthropic_api_key"
         write_output base_url "$base_url"
         write_output model "$model"
+        write_output model_tier "$model_tier"
         write_output provider "$provider"
         write_output allowed_bots "$allowed_bots"
         write_output branch_name_template "$branch_name_template"
@@ -386,18 +387,19 @@ runs:
 
     - name: Report provider and model
       shell: bash
+      env:
+        RESOLVED_PROVIDER: ${{ steps.resolve.outputs.provider }}
+        RESOLVED_MODEL: ${{ steps.resolve.outputs.model }}
+        RESOLVED_MODEL_TIER: ${{ steps.resolve.outputs.model_tier }}
       run: |
         set -euo pipefail
-        provider="${{ steps.resolve.outputs.provider }}"
-        model="${{ steps.resolve.outputs.model }}"
-        model_tier="${{ inputs['model-tier'] }}"
-        echo "::notice title=Claude Code provider::provider=${provider}, model=${model}, tier=${model_tier}"
+        echo "::notice title=Claude Code provider::provider=${RESOLVED_PROVIDER}, model=${RESOLVED_MODEL}, tier=${RESOLVED_MODEL_TIER}"
         {
           echo "### Claude Code provider"
           echo
-          echo "- Provider: \`${provider}\`"
-          echo "- Model: \`${model}\`"
-          echo "- Tier: \`${model_tier}\`"
+          echo "- Provider: \`${RESOLVED_PROVIDER}\`"
+          echo "- Model: \`${RESOLVED_MODEL}\`"
+          echo "- Tier: \`${RESOLVED_MODEL_TIER}\`"
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Run Claude Code

--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -384,6 +384,22 @@ runs:
         write_output claude_args "$claude_args"
         write_output append_system_prompt "$append_system_prompt"
 
+    - name: Report provider and model
+      shell: bash
+      run: |
+        set -euo pipefail
+        provider="${{ steps.resolve.outputs.provider }}"
+        model="${{ steps.resolve.outputs.model }}"
+        model_tier="${{ inputs['model-tier'] }}"
+        echo "::notice title=Claude Code provider::provider=${provider}, model=${model}, tier=${model_tier}"
+        {
+          echo "### Claude Code provider"
+          echo
+          echo "- Provider: \`${provider}\`"
+          echo "- Model: \`${model}\`"
+          echo "- Tier: \`${model_tier}\`"
+        } >> "$GITHUB_STEP_SUMMARY"
+
     - name: Run Claude Code
       uses: anthropics/claude-code-action@v1
       env:

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -654,6 +654,12 @@ review runs use the same wrapper in `deepseek` provider mode and select
 Codex-based workflows run via `openai/codex-action` and use their own
 model/configuration mechanism rather than Claude `--model` flags.
 
+Every workflow that calls `.github/actions/claude-code-with-provider` writes a
+GitHub Actions notice and job summary section named `Claude Code provider`. It
+records the resolved provider, model, and tier for that run, so maintainers can
+distinguish Anthropic-backed and DeepSeek-backed runs without reading the
+workflow environment.
+
 ### Review providers
 
 To run one or both review engines, set this repository variable:


### PR DESCRIPTION
Closes #1474.

### Motivation

Several workflows can run through the shared Claude Code wrapper with either the Anthropic or DeepSeek backend. Maintainers should be able to see which provider and model a run used without reconstructing it from repository variables.

### Description

- Adds a shared reporting step to `.github/actions/claude-code-with-provider/action.yml`.
- Emits a GitHub Actions notice with the resolved provider, model, and tier.
- Writes the same information to the job summary under `Claude Code provider`.
- Documents this location in `docs/ci-automation.md`.

This keeps provider reporting in the same action that resolves provider settings, so mention handlers, review, auto-fix, audit, and cleanup jobs all use the same mechanism.

### Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/claude-code-with-provider/action.yml"); puts "yaml ok"'`\n- `actionlint .github/workflows/claude.yml .github/workflows/claude-code-review.yml .github/workflows/deepseek.yml .github/workflows/auto-fix.yml`\n- `git diff --check -- .github/actions/claude-code-with-provider/action.yml docs/ci-automation.md`\n\nNo Lean declarations or mathematical statements are changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI reporting (a new notice and step summary) and do not alter the resolved credentials or execution flow beyond exporting `model_tier`.
> 
> **Overview**
> Maintainers can now see which backend a Claude Code run used without inspecting repo variables.
> 
> The shared `.github/actions/claude-code-with-provider` action now exports `model_tier` and adds a new step that emits a GitHub Actions `::notice` and writes a `Claude Code provider` section to `$GITHUB_STEP_SUMMARY` with the resolved provider/model/tier. The CI automation docs are updated to point reviewers to this notice/summary output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8333126381f64984b2fb09fb5048af9bf4a643cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->