### PR TITLE
doc(repository): require source quotations for formalization records

### DIFF
--- a/.github/ISSUE_TEMPLATE/formalization-task.yml
+++ b/.github/ISSUE_TEMPLATE/formalization-task.yml
@@ -36,13 +36,15 @@ body:
     attributes:
       label: Source location and quotation
       description: >-
-        Give a file path and line number when the source is in this repository,
-        plus a short quotation or precise paraphrase of the mathematical claim.
+        When the source is in this repository, give a file path, line range,
+        theorem/lemma/equation label when available, and a short quotation of
+        the mathematical claim. Use a precise paraphrase only when the source is
+        not available as repository text.
       placeholder: |
-        - Source: `blueprint/src/chapter/ch06_spectral.tex:142`
+        - Source: `blueprint/src/chapter/ch06_spectral.tex:142-148`
         - Label: `thm:peripheral-fixed-point`
-        - Claim: The peripheral fixed points form a finite-dimensional
-          C*-algebra under the stated hypotheses.
+        - Quote: "The peripheral fixed points form a finite-dimensional
+          C*-algebra under the stated hypotheses."
     validations:
       required: true
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,8 @@ Examples:
 <!-- Why this change is needed (1--3 bullets). -->
 <!-- Write in mathematical prose. Avoid AI or process slang in public mathematical discussion. -->
 <!-- For mathematical work, cite the source theorem, blueprint label, or issue. -->
+<!-- If the source is in blueprint/, Papers/, or Notes/, give the source file,
+     line range, theorem/lemma/equation label when available, and a short quote. -->
 
 -
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,6 +42,10 @@ Every PR body must contain three sections:
 - Why this change is needed (1--3 bullets).
 - For mathematical work, cite the paper theorem, blueprint entry, or issue
   that fixes the scope.
+- For mathematical work whose source is in `blueprint/`, `Papers/`, or
+  `Notes/`, give the source file path, line range,
+  theorem/lemma/definition/equation label when available, and a short quotation
+  of the source statement.
 
 ### Description
 - What was changed: files added/modified, definitions introduced, lemmas proved.
@@ -122,11 +126,12 @@ MPS/Symmetry: twisted tensor and on-site symmetry
 Label with **area** + **arXiv paper** + **topic** as applicable.
 
 The body must identify the mathematical source precisely. Include the paper or
-book citation, the theorem/lemma/definition label when available, the repository
-file path and line number when the source is in `blueprint/`, `Papers/`, or
-`Notes/`, and either a short quotation or a precise paraphrase of the claim.
-Avoid AI vocabulary, software-process metaphors, and local shorthand when
-describing the mathematics.
+book citation and, when the source is in `blueprint/`, `Papers/`, or `Notes/`,
+the repository file path, line range, theorem/lemma/definition/equation label
+when available, and a short quotation of the source statement. Use a precise
+paraphrase only when the source is not available as repository text. Avoid AI
+vocabulary, software-process metaphors, and local shorthand when describing the
+mathematics.
 
 ### Multi-part work
 


### PR DESCRIPTION
### Motivation
- Closes #932.
- Formalization issues and PRs should point a third reader to the exact mathematical source, not only to a broad paper citation.

### Description
- Tightened `docs/CONTRIBUTING.md` so mathematical PRs and formalization issues require a repository source path, line range, source label when available, and a short quotation when the source text is in `blueprint/`, `Papers/`, or `Notes/`.
- Updated the formalization issue template placeholder and description to ask for a line range, label, and quote.
- Added the same reminder to the pull request template.

### Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/formalization-task.yml"); puts "yaml ok"'`\n- `git diff --check -- docs/CONTRIBUTING.md .github/ISSUE_TEMPLATE/formalization-task.yml .github/pull_request_template.md`\n\n---\nCloses #932

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that tighten contributor guidance and GitHub templates; no code or CI behavior is modified.
> 
> **Overview**
> This PR tightens contributor-facing documentation and GitHub templates to require *more precise source anchoring* for mathematical work.
> 
> Formalization issues, PR bodies, and the contributing guide now ask for a repository source **file path + line range**, the relevant theorem/lemma/equation label when available, and a **short quotation** of the statement (with paraphrase allowed only when the source text is not present in the repo).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b69a71195db3e7e20176c6d62d10ab079bd153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->