### PR TITLE
refactor(blueprint): split tensor-network diagram kernel

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -1,12 +1,14 @@
 r"""plasTeX renderers for TNLean tensor-network diagrams.
 
 The PDF blueprint renders the chapter-facing ``\TN...`` macros with TikZ from
-``macros/tn_print.tex``.  The web blueprint uses the same macro calls and asks
+``macros/tn_print.tex``.  Its private drawing kernel lives in
+``macros/tn_core.tex``.  The web blueprint uses the same macro calls and asks
 this package for a cached SVG.  Thus TikZ remains the single source of truth.
 """
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import logging
 import os
@@ -30,6 +32,7 @@ _CACHE_DIR = _SRC_DIR / ".tn_svg_cache"
 _SVG_SUBDIR = "tn_svg"
 _RENDER_SOURCE_FILES = (
     _SRC_DIR / "macros/common.tex",
+    _SRC_DIR / "macros/tn_core.tex",
     _SRC_DIR / "macros/tn_print.tex",
 )
 
@@ -82,6 +85,35 @@ _DIAGRAM_ARGS: dict[str, str] = {
 
 def _diagram_arity(args: str) -> int:
     return len(args.split())
+
+
+def _sample_arg_value(name: str) -> str:
+    values = {
+        "tensor": "A",
+        "label": "i",
+        "left": "i",
+        "middle": "j",
+        "right": "k",
+        "length": "L",
+        "top": "i",
+        "bottom": "j",
+        "top_left": "i_1",
+        "bottom_left": "j_1",
+        "top_right": "i_N",
+        "bottom_right": "j_N",
+        "physical": "i",
+        "virtual": "X",
+        "twist": "u",
+        "permutation": "\\sigma",
+        "left_virtual": "X",
+        "right_virtual": "Y",
+    }
+    return values.get(name, "x")
+
+
+def _sample_tex_call(name: str) -> str:
+    args = _DIAGRAM_ARGS[name].split()
+    return rf"\{name}" + "".join("{" + _sample_arg_value(arg) + "}" for arg in args)
 
 
 def _assert_diagram_args_match_print_macros() -> None:
@@ -313,6 +345,20 @@ def _compile_svg(tex_call: str, stem: str, svg_path: Path) -> str | None:
     return svg_path.name
 
 
+def _smoke_render(names: Iterable[str]) -> list[Path]:
+    rendered = []
+    for name in names:
+        if name not in _DIAGRAM_ARGS:
+            raise ValueError(f"Unknown tensor-network diagram macro: {name}")
+        tex_call = _sample_tex_call(name)
+        stem = f"tn-smoke-{name}"
+        svg_path = _CACHE_DIR / "smoke" / f"{stem}.svg"
+        if _compile_svg(tex_call, stem, svg_path) is None:
+            raise RuntimeError("TikZ SVG smoke check needs LaTeX and dvisvgm on PATH.")
+        rendered.append(svg_path)
+    return rendered
+
+
 def _svg_for(obj: Command, tex_call: str) -> str | None:
     stem = f"tn-{_hash_tex(tex_call)}"
     output_dir = _output_dir(obj.ownerDocument)
@@ -353,3 +399,43 @@ for _macro_name, _args in _DIAGRAM_ARGS.items():
         (_TNTikZDiagram,),
         {"args": _args, "macroName": _macro_name},
     )
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check TNLean tensor-network diagram TeX/Python synchronization."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="check that Python arities match public TeX macros",
+    )
+    parser.add_argument(
+        "--smoke-render",
+        nargs="*",
+        metavar="MACRO",
+        help=(
+            "render sample SVGs for the named public macros; with no names, "
+            "render every registered macro"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if not args.check and args.smoke_render is None:
+        parser.print_help()
+        return 0
+
+    if args.check:
+        _assert_diagram_args_match_print_macros()
+        print(f"checked {len(_DIAGRAM_ARGS)} tensor-network diagram arities")
+
+    if args.smoke_render is not None:
+        names = args.smoke_render or list(_DIAGRAM_ARGS)
+        rendered = _smoke_render(names)
+        print(f"rendered {len(rendered)} tensor-network diagram SVGs")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/blueprint/src/macros/tn_core.tex
+++ b/blueprint/src/macros/tn_core.tex
@@ -1,0 +1,84 @@
+% Private tensor-network TikZ kernel.
+%
+% The chapter-facing diagram commands live in macros/tn_print.tex. This file
+% contains only the common glyphs, lengths, and atomic drawing commands used by
+% those public diagrams.
+\usetikzlibrary{calc}
+
+\tikzset{
+  tn picture/.style={
+    baseline=-0.1cm,
+    transform shape,
+    font=\scriptsize
+  },
+  tn tensor dot/.style={
+    draw,
+    fill,
+    shape=circle,
+    inner sep=0.055cm
+  },
+  tn operator dot/.style={
+    tn tensor dot,
+    red
+  },
+  tn leg/.style={line width=0.4pt},
+  tn phys leg/.style={line width=0.7pt}
+}
+
+\makeatletter
+
+\def\TN@physleglen{0.42}
+\def\TN@physlabeloff{0.68}
+\def\TN@doublelayersep{0.50}
+
+% ---------- Atomic drawing commands ----------
+
+\newcommand{\TN@tensordot}[2]{%
+  \node[tn tensor dot] (#1) at #2 {};%
+}
+
+\newcommand{\TN@opdot}[2]{%
+  \node[tn operator dot] (#1) at #2 {};%
+}
+
+\newcommand{\TN@opdotabove}[3]{%
+  \node[tn operator dot, label=above:$#3$] (#1) at #2 {};%
+}
+
+\newcommand{\TN@opdotbelow}[3]{%
+  \node[tn operator dot, label=below:$#3$] (#1) at #2 {};%
+}
+
+\newcommand{\TN@opdotleft}[3]{%
+  \node[tn operator dot, label=left:$#3$] (#1) at #2 {};%
+}
+
+\newcommand{\TN@opdotright}[3]{%
+  \node[tn operator dot, label=right:$#3$] (#1) at #2 {};%
+}
+
+\newcommand{\TN@leftleg}[2]{%
+  \draw[tn leg] (#1.west) -- ++(-#2,0);%
+}
+
+\newcommand{\TN@rightleg}[2]{%
+  \draw[tn leg] (#1.east) -- ++(#2,0);%
+}
+
+\newcommand{\TN@upleg}[2]{%
+  \draw[tn phys leg] (#1.north) -- ++(0,#2);%
+}
+
+\newcommand{\TN@downleg}[2]{%
+  \draw[tn phys leg] (#1.south) -- ++(0,-#2);%
+}
+
+\newcommand{\TN@uplabel}[3]{%
+  \node at ($(#1.north)+(0,#2)$) {$#3$};%
+}
+
+\newcommand{\TN@downlabel}[3]{%
+  \node at ($(#1.south)+(0,-#2)$) {$#3$};%
+}
+
+\makeatother

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -5,86 +5,13 @@
 %
 % Layout policy:
 % - Public \TN... macros are chapter-facing and semantically named.
-% - Private \TN@... helpers provide the atomic drawing vocabulary.
+% - Private \TN@... helpers in macros/tn_core.tex provide the atomic drawing
+%   vocabulary.
 % - Public diagrams default to unlabeled tensor glyphs; the surrounding
 %   formula/prose carries the tensor names.
-\usetikzlibrary{calc}
-
-\tikzset{
-  tn picture/.style={
-    baseline=-0.1cm,
-    transform shape,
-    font=\scriptsize
-  },
-  tn tensor dot/.style={
-    draw,
-    fill,
-    shape=circle,
-    inner sep=0.055cm
-  },
-  tn operator dot/.style={
-    tn tensor dot,
-    red
-  },
-  tn leg/.style={line width=0.4pt},
-  tn phys leg/.style={line width=0.7pt}
-}
+\input{macros/tn_core}
 
 \makeatletter
-
-\def\TN@physleglen{0.42}
-\def\TN@physlabeloff{0.68}
-\def\TN@doublelayersep{0.50}
-
-% ---------- Atomic helpers ----------
-
-\newcommand{\TN@tensordot}[2]{%
-  \node[tn tensor dot] (#1) at #2 {};%
-}
-
-\newcommand{\TN@opdot}[2]{%
-  \node[tn operator dot] (#1) at #2 {};%
-}
-
-\newcommand{\TN@opdotabove}[3]{%
-  \node[tn operator dot, label=above:$#3$] (#1) at #2 {};%
-}
-
-\newcommand{\TN@opdotbelow}[3]{%
-  \node[tn operator dot, label=below:$#3$] (#1) at #2 {};%
-}
-
-\newcommand{\TN@opdotleft}[3]{%
-  \node[tn operator dot, label=left:$#3$] (#1) at #2 {};%
-}
-
-\newcommand{\TN@opdotright}[3]{%
-  \node[tn operator dot, label=right:$#3$] (#1) at #2 {};%
-}
-
-\newcommand{\TN@leftleg}[2]{%
-  \draw[tn leg] (#1.west) -- ++(-#2,0);%
-}
-
-\newcommand{\TN@rightleg}[2]{%
-  \draw[tn leg] (#1.east) -- ++(#2,0);%
-}
-
-\newcommand{\TN@upleg}[2]{%
-  \draw[tn phys leg] (#1.north) -- ++(0,#2);%
-}
-
-\newcommand{\TN@downleg}[2]{%
-  \draw[tn phys leg] (#1.south) -- ++(0,-#2);%
-}
-
-\newcommand{\TN@uplabel}[3]{%
-  \node at ($(#1.north)+(0,#2)$) {$#3$};%
-}
-
-\newcommand{\TN@downlabel}[3]{%
-  \node at ($(#1.south)+(0,-#2)$) {$#3$};%
-}
 
 % ---------- Public semantic macros ----------
 

--- a/blueprint/src/macros/tn_web.tex
+++ b/blueprint/src/macros/tn_web.tex
@@ -2,5 +2,6 @@
 % Packages/tn_diagrams.py and plastex_templates/TensorNetworkDiagrams.jinja2s.
 %
 % The chapter-facing \TN... API is intentionally the same as the print-side
-% TikZ API in macros/tn_print.tex.  TikZ remains the single source of truth;
-% the web renderer compiles those macro calls to cached SVG files.
+% TikZ API in macros/tn_print.tex, whose private glyph kernel is
+% macros/tn_core.tex.  TikZ remains the single source of truth; the web
+% renderer compiles those macro calls to cached SVG files.

--- a/docs/blueprint_style_guide.md
+++ b/docs/blueprint_style_guide.md
@@ -109,6 +109,15 @@ enforced by the dedicated `Blueprint Sync & Prose Review` CI workflow.
 Tensor-network diagram conventions are recorded separately in
 [`docs/tn_diagram_grammar.md`](tn_diagram_grammar.md).
 
+The tensor-network TikZ layer is split into private drawing primitives and a
+public mathematical vocabulary. The private primitives live in
+`blueprint/src/macros/tn_core.tex`; that file defines the common glyphs,
+lengths, and atomic drawing commands. Chapter-facing diagrams are defined in
+`blueprint/src/macros/tn_print.tex` and should be named by the mathematical
+move they depict. The web renderer in `blueprint/src/Packages/tn_diagrams.py`
+uses the same public commands and treats both TeX files as part of the diagram
+source.
+
 ## Lean Blueprint Macros
 - `\lean{Namespace.DeclName}` — links to Lean declaration
 - `\leanok` — marks definition/theorem/proof as fully formalized

--- a/docs/tn_diagram_grammar.md
+++ b/docs/tn_diagram_grammar.md
@@ -119,4 +119,6 @@ by a diagram before reading the surrounding proof.
   step is a specific contraction, insertion, blocking, or gauge absorption.
 - Public commands should be built from the common glyphs above. If a diagram
   requires a new glyph, first record the mathematical meaning here and then add
-  the corresponding TikZ and web-rendering support.
+  the corresponding private TikZ primitive and web-rendering support.
+- Private glyphs and lengths belong in `blueprint/src/macros/tn_core.tex`.
+  Chapter-facing diagrams belong in `blueprint/src/macros/tn_print.tex`.


### PR DESCRIPTION
### Motivation
- Addresses #1010 and #1019.
- The tensor-network diagram layer should separate private glyph primitives from chapter-facing mathematical commands, while keeping TikZ as the common source for PDF and web diagrams.

### Description
- Added `blueprint/src/macros/tn_core.tex` for the private TikZ glyphs, lengths, and atomic drawing commands.
- Kept `blueprint/src/macros/tn_print.tex` as the public `\TN...` diagram vocabulary by inputting the private core file before the public commands.
- Updated `blueprint/src/Packages/tn_diagrams.py` so the SVG cache digest includes both TeX files and added a command-line check/smoke-render path for registered diagram macros.
- Updated the blueprint diagram documentation to record the private/public boundary.

### Testing
- `cd blueprint/src && PYTHONPATH=Packages python3 -m py_compile Packages/tn_diagrams.py`
- `cd blueprint/src && PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check`
- `cd blueprint/src && PYTHONPATH=Packages python3 Packages/tn_diagrams.py --smoke-render TNMPSLocal TNTransferMap TNPEPSEdgeBlockingReduction TNPEPSEdgeGaugeAbsorption TNPEPSNormalEdgeBlockingReduction`
- `cd blueprint/src && PYTHONPATH=Packages python3 Packages/tn_diagrams.py --smoke-render`
- `git diff --check -- blueprint/src/macros/tn_core.tex blueprint/src/macros/tn_print.tex blueprint/src/macros/tn_web.tex blueprint/src/Packages/tn_diagrams.py docs/blueprint_style_guide.md docs/tn_diagram_grammar.md`
- `cd blueprint && leanblueprint web` completed with exit code 0; plasTeX still emitted existing default-renderer warnings for tensor-network commands.
- `cd blueprint && leanblueprint pdf`

---
Addresses #1010
Addresses #1019

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the TeX inputs that drive SVG caching/rendering and introduces new CLI paths; regressions would show up as missing/incorrect diagram SVGs or cache invalidation issues.
> 
> **Overview**
> Splits the tensor-network TikZ layer into a new private `macros/tn_core.tex` (shared glyph styles/lengths/atomic `\TN@...` drawing commands) and a slimmer `macros/tn_print.tex` that now `\input`s the core before defining the public `\TN...` diagrams.
> 
> Updates the web SVG renderer (`Packages/tn_diagrams.py`) to treat `tn_core.tex` as part of the render-source digest (forcing cache busts when primitives change) and adds a small CLI (`--check`, `--smoke-render`) to validate TeX/Python macro arities and optionally render sample SVGs. Docs and `tn_web.tex` comments are adjusted to reflect the new private/public boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50878359f399d779518abccce7732109e0594e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->