### PR TITLE
doc(MPS/BNT): mark normal BNT scope

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -76,6 +76,12 @@ not retain repeated equal-modulus sectors; the full multiplicity structure (weig
 `μ_{j,q}` and multiplicities `M_j` as in arXiv:1606.00608) is recorded in
 `SectorDecomposition` and the sector-weight comparison theorems.
 
+**Scope restriction (one-copy-per-sector):** This is the already grouped
+single-representative surface, not the full CPSV16 BNT multiplicity structure.
+CPSV16 lines 287-301 keep the repeated copies of one basis tensor visible
+through the raw coefficients `μ_{j,q}`. The restriction is documented in
+`docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
+
 `IsNormalCanonicalFormBNT` uses the spectral/primitive-transfer-map version of normality
 (`IsNormalCanonicalForm`), while the later `IsBNT` hypotheses ask for blockwise
 `IsNormal` (the equivalent algebraic eventual-block-injectivity notion). The
@@ -149,8 +155,14 @@ lemma mu_norm_le_one (hNCF : IsNormalCanonicalFormBNT μ A) (k : Fin r) :
     exact hanti
   · exact absurd k.isLt (by omega)
 
-/-- Rebuild `IsNormalCanonicalFormBNT` from the additive split formulation plus the BNT separation
-assumption and the CPSV dominant-block normalization `‖μ ⟨0, _⟩‖ = 1`. -/
+/-- Rebuild `IsNormalCanonicalFormBNT` from the additive split formulation plus
+the BNT separation assumption and the CPSV dominant-block normalization
+`‖μ ⟨0, _⟩‖ = 1`.
+
+**Scope restriction (one-copy-per-sector):** The strict weight-ordering input
+selects one representative per modulus class. This constructor does not recover
+the multiplicity data of the full CPSV16 BNT decomposition at lines 287-301;
+see `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 def ofSeparatedData
     (hIrr : HasIrreducibleBlocks (d := d) A)
     (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
@@ -368,7 +380,11 @@ namespace IsNormalCanonicalFormBNT
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
-/-- Cross-overlap decay for normal-CF-BNT blocks. -/
+/-- Cross-overlap decay for normal-CF-BNT blocks.
+
+**Scope restriction (one-copy-per-sector):** The hypothesis
+`IsNormalCanonicalFormBNT` is the separated, already grouped variant documented
+in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 theorem cross_overlap_tendsto_zero
     [∀ k, NeZero (dim k)]
     (hNCF : IsNormalCanonicalFormBNT μ A) (j k : Fin r) (hjk : j ≠ k) :
@@ -381,7 +397,11 @@ theorem cross_overlap_tendsto_zero
 
 /-- A normal-canonical-form decomposition with BNT separation yields a valid `IsBNT`
 structure once the equivalent blockwise `IsNormal` witnesses (eventual block injectivity) are
-supplied explicitly. -/
+supplied explicitly.
+
+**Scope restriction (one-copy-per-sector):** The hypothesis
+`IsNormalCanonicalFormBNT` is the separated, already grouped variant documented
+in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma isBNT [∀ k, NeZero (dim k)]
     (hNCF : IsNormalCanonicalFormBNT μ A)
     (hNormal : ∀ j, IsNormal (A j)) :

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -139,6 +139,11 @@ and~\cite{Cirac2021Matrix}.
         \item the dominant block has unit modulus, $\|\mu_1\| = 1$
               (\cite[paragraph after \texttt{eq:II\_CF1}]{Cirac2016MPDO_arXiv}).
     \end{enumerate}
+    This is a scope-restricted one-copy-per-sector surface: it keeps one
+    representative for each strict weight-modulus class and does not encode
+    the full CPSV16 BNT multiplicity data. The missing general multiplicity
+    route is recorded in
+    \path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}.
     The strict ordering describes an already selected or grouped
     representative family. It is not the source BNT expansion
     \[
@@ -236,6 +241,9 @@ and~\cite{Cirac2021Matrix}.
     If a family is in normal canonical form with BNT separation and each block
     is also known to be normal in the algebraic sense, then the blocks form a
     basis of normal tensors for the associated block-diagonal tensor.
+    This is the one-copy-per-sector variant documented in
+    \path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}, not the full
+    CPSV16 BNT multiplicity statement.
 \end{lemma}
 
 \begin{proof}\leanok\uses{rem:normalcf_bnt_gap}


### PR DESCRIPTION
### Motivation
- Addresses part of #1618.
- The normal-CF-BNT surface is an already grouped one-copy-per-sector variant. Readers should not mistake it for the full CPSV16 BNT multiplicity decomposition.

### Source
- CPSV16: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 287-301.
- Source label: `eq:II_CF1` / BNT expansion following the canonical-form discussion.
- Quote: `|V^{N}(A)\rangle = \sum_{j=1}^g (\sum_{q=1}^{r_j} \mu_{j,q}^N) |V^{(N)}(A_j)\rangle.`

### Description
- Adds explicit `**Scope restriction (one-copy-per-sector):**` markers to `IsNormalCanonicalFormBNT`, its separated-data constructor, and its public cross-overlap / `IsBNT` conversion API.
- Mirrors the same warning in the BNT blueprint chapter at the definition and restricted conversion lemma.
- Points each warning to `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.

### Testing
- `lake exe cache get`
- `lake build TNLean.MPS.BNT.Construction`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/comment updates only, with no modifications to proofs, definitions, or runtime behavior.
> 
> **Overview**
> Adds explicit **“Scope restriction (one-copy-per-sector)”** notes to the `IsNormalCanonicalFormBNT` definition, its `ofSeparatedData` constructor, and the public theorems `cross_overlap_tendsto_zero` and `isBNT`, clarifying they assume an already-grouped single representative per modulus class rather than the full CPSV16 multiplicity surface.
> 
> Mirrors the same warning in the blueprint’s BNT chapter (at the normal-CF-BNT definition and the lemma converting restricted normal-CF-BNT hypotheses to `IsBNT`), linking all notes to `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64dff5177a8f51f33e7611dc7a8d4c6e5383c8f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->