### PR TITLE
ci(blueprint): check tensor-network diagrams

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Install leanblueprint
         run: pip install -r .github/requirements/blueprint-python.txt
 
+      - name: Check tensor-network diagram macros
+        run: |
+          cd blueprint/src
+          PYTHONPATH=Packages python3 Packages/tn_diagrams.py \
+            --check \
+            --check-peps-usage \
+            --smoke-render
+
       - name: Write status badges
         run: python3 scripts/write_badges.py
 

--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -59,6 +59,14 @@ jobs:
       - name: Install blueprint Python dependencies
         run: python3 -m pip install -r .github/requirements/blueprint-python.txt
 
+      - name: Check tensor-network diagram macros
+        run: |
+          cd blueprint/src
+          PYTHONPATH=Packages python3 Packages/tn_diagrams.py \
+            --check \
+            --check-peps-usage \
+            --smoke-render
+
       - name: Lint LaTeX (chktex)
         run: |
           find blueprint/src -name '*.tex' -not -path '*/Packages/*' -print0 \

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -141,6 +141,30 @@ def _assert_diagram_args_match_print_macros() -> None:
         )
 
 
+def _assert_peps_macros_used_in_chapter() -> None:
+    intentionally_unused: set[str] = set()
+    pattern = re.compile(r"\\newcommand\{\\(TNPEPS\w+)\}(?:\[\d+\])?")
+    source = (_SRC_DIR / "macros/tn_print.tex").read_text(encoding="utf-8")
+    peps_macros = sorted(set(pattern.findall(source)))
+    chapter = (_SRC_DIR / "chapter/ch13a_peps_ft.tex").read_text(encoding="utf-8")
+    stale_records = sorted(intentionally_unused - set(peps_macros))
+    if stale_records:
+        raise RuntimeError(
+            "Recorded intentionally unused PEPS diagram macros are not public "
+            f"macros in tn_print.tex: {stale_records}"
+        )
+    unused = [
+        name
+        for name in peps_macros
+        if rf"\{name}" not in chapter and name not in intentionally_unused
+    ]
+    if unused:
+        raise RuntimeError(
+            "Public PEPS diagram macros must be used in Chapter 13a or recorded "
+            f"as intentionally unused: {unused}"
+        )
+
+
 _assert_diagram_args_match_print_macros()
 
 
@@ -411,6 +435,11 @@ def _main(argv: list[str] | None = None) -> int:
         help="check that Python arities match public TeX macros",
     )
     parser.add_argument(
+        "--check-peps-usage",
+        action="store_true",
+        help="check that public PEPS diagram macros are used in Chapter 13a",
+    )
+    parser.add_argument(
         "--smoke-render",
         nargs="*",
         metavar="MACRO",
@@ -421,13 +450,17 @@ def _main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if not args.check and args.smoke_render is None:
+    if not args.check and not args.check_peps_usage and args.smoke_render is None:
         parser.print_help()
         return 0
 
     if args.check:
         _assert_diagram_args_match_print_macros()
         print(f"checked {len(_DIAGRAM_ARGS)} tensor-network diagram arities")
+
+    if args.check_peps_usage:
+        _assert_peps_macros_used_in_chapter()
+        print("checked public PEPS diagram usage in Chapter 13a")
 
     if args.smoke_render is not None:
         names = args.smoke_render or list(_DIAGRAM_ARGS)

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -248,6 +248,14 @@ runs only after a maintainer has checked the mathematical source and added
 
 **No label required** — this runs on all PRs automatically.
 
+The "Lint blueprint" and "Blueprint" workflows also run
+`Packages/tn_diagrams.py --check --check-peps-usage --smoke-render` after the
+blueprint dependencies are installed. This checks that public tensor-network
+diagram commands in `tn_print.tex` have the same arities as their Python
+renderers, that every public PEPS diagram command is either used in Chapter
+13a or explicitly recorded as intentionally unused, and that the registered
+diagrams render to SVG.
+
 ---
 
 ### Oversized Lean File Guard (`oversized-lean-files.yml`)


### PR DESCRIPTION
## Summary
- run tensor-network diagram arity, PEPS-use, and SVG smoke-render checks in both blueprint workflows
- add a PEPS public-macro usage check to `tn_diagrams.py`
- document the new blueprint diagram gate

Closes #1257.
Addresses #1010.
Addresses #1019.

## Local checks
- `PYTHONPATH=Packages python3 -m py_compile Packages/tn_diagrams.py`
- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage`
- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --smoke-render`
- `ruby -e 'require "yaml"; %w[.github/workflows/lint-blueprint.yml .github/workflows/blueprint.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'`\n- `actionlint .github/workflows/lint-blueprint.yml .github/workflows/blueprint.yml`\n- `git diff --check -- blueprint/src/Packages/tn_diagrams.py .github/workflows/lint-blueprint.yml .github/workflows/blueprint.yml docs/ci-automation.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CI gates to both blueprint workflows that run LaTeX/dvisvgm-based smoke rendering and enforce PEPS macro usage, which may introduce new failure modes and slowdowns in CI if tooling/macro usage drifts.
> 
> **Overview**
> **Blueprint CI now validates tensor-network diagrams as a first-class gate.** Both `lint-blueprint.yml` and `blueprint.yml` run `Packages/tn_diagrams.py --check --check-peps-usage --smoke-render` after installing blueprint Python deps.
> 
> `tn_diagrams.py` gains a new `--check-peps-usage` mode that enforces all public `TNPEPS...` macros in `macros/tn_print.tex` are referenced in `chapter/ch13a_peps_ft.tex` (or explicitly recorded as intentionally unused), alongside the existing arity sync check and SVG smoke-rendering. Documentation is updated to describe this new workflow check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76704df8be5548fdb9fbafe6420a33a2c9846b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->