### PR TITLE
feat(MPS/FT/SectorBNT): expose proportional unit phase witnesses

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -33,6 +33,32 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+/-- **Unit phase from matched normalized BNT blocks.**
+
+If two normalized BNT basis tensors have MPV families related by a scalar
+power `ζ^N`, then `ζ` has norm one. This is the self-overlap normalization
+closure used after the equal-MPS lemma of CPSV16 (lines 1080–1097) in the
+non-periodic BNT setting. -/
+theorem IsBNTCanonicalForm.norm_phase_of_matched_mpv
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    {j : Fin P.basisCount} {k : Fin Q.basisCount} {ζ : ℂ}
+    (hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv (Q.basis k) σ = ζ ^ N * mpv (P.basis j) σ) :
+    ‖ζ‖ = 1 := by
+  have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) (P.basis j) (P.basis j) N‖)
+      atTop (𝓝 (1 : ℝ)) := by
+    have h1 := (hP.basis_normalized_self_overlap j).norm
+    simpa using h1
+  have hBB : Tendsto (fun N => ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k) N‖)
+      atTop (𝓝 (1 : ℝ)) := by
+    have h1 := (hQ.basis_normalized_self_overlap k).norm
+    simpa using h1
+  have hScale :=
+    mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis j) (B := Q.basis k)
+      (ζ := ζ) hmpv
+  exact norm_eq_one_of_selfOverlap_scale (ζ := ζ) hAA hBB hScale
+
 /-- **Auxiliary lemma: gauge-phase data gives an MPV-level scalar-power identity with unit phase.**
 
 Given a matched bond-dimension equality `h : P.basisDim j = Q.basisDim k`
@@ -56,18 +82,7 @@ private lemma extract_unit_gauge_phase_mpv
   obtain ⟨ζ, _hζne, hmpv⟩ :=
     MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast (P.basis j) (Q.basis k) h hGPE
   refine ⟨ζ, ?_, hmpv⟩
-  have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) (P.basis j) (P.basis j) N‖)
-      atTop (𝓝 (1 : ℝ)) := by
-    have h1 := (hP.basis_normalized_self_overlap j).norm
-    simpa using h1
-  have hBB : Tendsto (fun N => ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k) N‖)
-      atTop (𝓝 (1 : ℝ)) := by
-    have h1 := (hQ.basis_normalized_self_overlap k).norm
-    simpa using h1
-  have hScale :=
-    mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis j) (B := Q.basis k)
-      (ζ := ζ) hmpv
-  exact norm_eq_one_of_selfOverlap_scale (ζ := ζ) hAA hBB hScale
+  exact hP.norm_phase_of_matched_mpv hQ hmpv
 
 /-- **CPSV16 §II.C lines 1187–1188, coefficient identity from fixed MPV phases.**
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch.Core
+import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
 
 /-!
 # Proportional sector matching for two BNT canonical forms
@@ -237,12 +238,12 @@ the proportional BNT block matching of CPSV16 §II.C lines 1184–1186, the
 matched gauge-phase equivalences provide actual matrices `Xblock k` and
 scalars `ζ k`.  The BNT self-overlap normalization forces `‖ζ k‖ = 1`, so
 these are the unit phases appearing in the source text before the final
-coefficient comparison and block-diagonal gauge assembly of lines 1187–1192.
+coefficient comparison and block-diagonal gauge construction of lines 1187–1192.
 
 The theorem intentionally stops before the raw coefficient identity.  Under
 `EventuallyNonzeroProportionalMPV₂`, that step still has to control the
 length-dependent proportionality scalar; it is not the equal-MPV coefficient
-identity from `CoeffIdentity.lean`. -/
+identity proved by `coeff_identity_via_matched_mpv_phase`. -/
 theorem ft_sector_bnt_proportional_sector_match_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -291,20 +292,7 @@ theorem ft_sector_bnt_proportional_sector_match_witnesses
       mpv_cast_dim (hDim k) (P.basis (β k)) N σ]
   have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := by
     intro k
-    have hAA : Tendsto
-        (fun N => ‖mpvOverlap (d := d) (P.basis (β k)) (P.basis (β k)) N‖)
-        atTop (𝓝 (1 : ℝ)) := by
-      have h1 := (hP.basis_normalized_self_overlap (β k)).norm
-      simpa using h1
-    have hBB : Tendsto
-        (fun N => ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k) N‖)
-        atTop (𝓝 (1 : ℝ)) := by
-      have h1 := (hQ.basis_normalized_self_overlap k).norm
-      simpa using h1
-    have hScale :=
-      mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis (β k)) (B := Q.basis k)
-        (ζ := ζ k) (hMpv k)
-    exact norm_eq_one_of_selfOverlap_scale (ζ := ζ k) hAA hBB hScale
+    exact hP.norm_phase_of_matched_mpv hQ (hMpv k)
   exact ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, hMpv⟩
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -230,4 +230,81 @@ theorem ft_sector_bnt_proportional_sector_match
     obtain ⟨h, hGE, _⟩ := hβ k
     exact ⟨h, hGE⟩
 
+/-- **Proportional sector matching with explicit unit phases and block gauges.**
+
+This is the witness form of `ft_sector_bnt_proportional_sector_match`: after
+the proportional BNT block matching of CPSV16 §II.C lines 1184–1186, the
+matched gauge-phase equivalences provide actual matrices `Xblock k` and
+scalars `ζ k`.  The BNT self-overlap normalization forces `‖ζ k‖ = 1`, so
+these are the unit phases appearing in the source text before the final
+coefficient comparison and block-diagonal gauge assembly of lines 1187–1192.
+
+The theorem intentionally stops before the raw coefficient identity.  Under
+`EventuallyNonzeroProportionalMPV₂`, that step still has to control the
+length-dependent proportionality scalar; it is not the equal-MPV coefficient
+identity from `CoeffIdentity.lean`. -/
+theorem ft_sector_bnt_proportional_sector_match_witnesses
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
+    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
+      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+      (ζ : Fin Q.basisCount → ℂ)
+      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
+      (∀ (k : Fin Q.basisCount) (i : Fin d),
+        Q.basis k i =
+          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
+      (∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+        mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ) := by
+  classical
+  obtain ⟨β, hβ⟩ :=
+    bijective_match_of_eventuallyProportional hP hQ hUnitP hUnitQ hProp
+  let hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k :=
+    fun k => (hβ k).choose
+  let hGPE : ∀ k : Fin Q.basisCount,
+      GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) (Q.basis k) :=
+    fun k => (hβ k).choose_spec.1
+  let Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ :=
+    fun k => (hGPE k).choose
+  let ζ : Fin Q.basisCount → ℂ := fun k => (hGPE k).choose_spec.choose
+  have hConj : ∀ (k : Fin Q.basisCount) (i : Fin d),
+      Q.basis k i =
+        ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+          (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+          (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+            Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ)) := by
+    intro k i
+    exact (hGPE k).choose_spec.choose_spec.2 i
+  have hMpv : ∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ := by
+    intro k N σ
+    rw [mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k)))
+      (B := Q.basis k) (Xblock k) (ζ k) (hConj k) N σ,
+      mpv_cast_dim (hDim k) (P.basis (β k)) N σ]
+  have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := by
+    intro k
+    have hAA : Tendsto
+        (fun N => ‖mpvOverlap (d := d) (P.basis (β k)) (P.basis (β k)) N‖)
+        atTop (𝓝 (1 : ℝ)) := by
+      have h1 := (hP.basis_normalized_self_overlap (β k)).norm
+      simpa using h1
+    have hBB : Tendsto
+        (fun N => ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k) N‖)
+        atTop (𝓝 (1 : ℝ)) := by
+      have h1 := (hQ.basis_normalized_self_overlap k).norm
+      simpa using h1
+    have hScale :=
+      mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis (β k)) (B := Q.basis k)
+        (ζ := ζ k) (hMpv k)
+    exact norm_eq_one_of_selfOverlap_scale (ζ := ζ k) hAA hBB hScale
+  exact ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, hMpv⟩
+
 end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1202,31 +1202,53 @@ global gauge. Their hypotheses explicitly require a unit-modulus copy in every
 sector on both sides; under this normalization, the matching covers the whole
 BNT basis.
 
+\begin{lemma}[Unit phase from matched normalized BNT blocks]%
+    \label{lem:sector_bnt_norm_phase_of_matched_mpv}
+    \lean{MPSTensor.IsBNTCanonicalForm.norm_phase_of_matched_mpv}
+    \leanok
+    \uses{def:sector_bnt_cf}
+    Let $P$ and $Q$ be BNT canonical forms. If, for every length $N$ and word
+    $\sigma$, a sector $P_j$ and a sector $Q_k$ have MPV families related by
+    \[
+        V^{(N)}(Q_k)_\sigma=\zeta^N V^{(N)}(P_j)_\sigma
+    \]
+    then $|\zeta|=1$.
+\end{lemma}
+
+\begin{proof}\leanok
+    The BNT normalization gives self-overlap limits of modulus $1$ for both
+    sectors. The displayed MPV identity scales the $Q_k$ self-overlap by
+    $(\zeta\overline{\zeta})^N$ times the $P_j$ self-overlap. Taking limits
+    forces $|\zeta|=1$.
+\end{proof}
+
 \begin{theorem}[Proportional sector matching with unit phases]%
     \label{thm:sector_bnt_proportional_sector_match_witnesses}
     \lean{MPSTensor.ft_sector_bnt_proportional_sector_match_witnesses}
     \leanok
     \uses{def:sector_bnt_cf,
         def:gauge_phase_equiv,
-        thm:gauge_phase_mpv_scaling}
+        thm:gauge_phase_mpv_scaling,
+        lem:sector_bnt_norm_phase_of_matched_mpv}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
     eventually nonzero proportional MPV families. Assume that every sector of
     $P$ and every sector of $Q$ has at least one copy weight of modulus $1$.
     Then there are a bijection $\beta:J(Q)\simeq J(P)$, bond-dimension
     equalities $\dim P_{\beta(k)}=\dim Q_k$, scalars
-    $\zeta_k\in\C$, and block gauges $X_k$ such that $|\zeta_k|=1$ and
+    $\zeta_k\in\C$, and block gauges $X_k$ such that $|\zeta_k|=1$ and, for
+    every sector $k$ and physical index $i$,
     \[
         Q_k^i=\zeta_k X_k P_{\beta(k)}^i X_k^{-1}
     \]
-    for every sector $k$ and physical index $i$. Equivalently,
+    Equivalently, for every length $N$ and word $\sigma$,
     \[
         V^{(N)}(Q_k)_\sigma
         =
         \zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma
     \]
-    for every length $N$ and word $\sigma$. This is the per-block phase
-    output of
-    \cite[\S~II.C, lines 1184--1186]{Cirac2017MPDO_AnnPhys}; the following
+    This records the per-block phase conclusion of
+    \cite[\S~II.C, lines 1167--1170]{Cirac2017MPDO_AnnPhys}; lines
+    1184--1186 give the corresponding proof step. The following
     coefficient-comparison step is separate.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1202,6 +1202,43 @@ global gauge. Their hypotheses explicitly require a unit-modulus copy in every
 sector on both sides; under this normalization, the matching covers the whole
 BNT basis.
 
+\begin{theorem}[Proportional sector matching with unit phases]%
+    \label{thm:sector_bnt_proportional_sector_match_witnesses}
+    \lean{MPSTensor.ft_sector_bnt_proportional_sector_match_witnesses}
+    \leanok
+    \uses{def:sector_bnt_cf,
+        def:gauge_phase_equiv,
+        thm:gauge_phase_mpv_scaling}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
+    eventually nonzero proportional MPV families. Assume that every sector of
+    $P$ and every sector of $Q$ has at least one copy weight of modulus $1$.
+    Then there are a bijection $\beta:J(Q)\simeq J(P)$, bond-dimension
+    equalities $\dim P_{\beta(k)}=\dim Q_k$, scalars
+    $\zeta_k\in\C$, and block gauges $X_k$ such that $|\zeta_k|=1$ and
+    \[
+        Q_k^i=\zeta_k X_k P_{\beta(k)}^i X_k^{-1}
+    \]
+    for every sector $k$ and physical index $i$. Equivalently,
+    \[
+        V^{(N)}(Q_k)_\sigma
+        =
+        \zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma
+    \]
+    for every length $N$ and word $\sigma$. This is the per-block phase
+    output of
+    \cite[\S~II.C, lines 1184--1186]{Cirac2017MPDO_AnnPhys}; the following
+    coefficient-comparison step is separate.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the proportional sector-matching theorem to obtain the bijection and
+    dimension-compatible gauge-phase equivalences. Choosing the gauges and
+    scalars gives the displayed block identities. The normalized self-overlap
+    limits of the matched BNT blocks force the chosen scalars to have modulus
+    $1$, and the MPV scalar-power identity follows from gauge-phase
+    equivalence.
+\end{proof}
+
 \begin{lemma}[Full-basis coefficient identity from matched phases]%
     \label{lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
     \lean{MPSTensor.coeff_identity_via_matched_mpv_phase}


### PR DESCRIPTION
## Summary

This PR advances #1749, and hence the remaining proportional branch of #1685, by adding the witness form of proportional sector matching for SectorBNT canonical forms.

After the existing proportional matching theorem identifies the sectors, the new theorem `MPSTensor.ft_sector_bnt_proportional_sector_match_witnesses` chooses, for every matched sector, the scalar phase and the block gauge explicitly. It proves that the scalar has modulus one and records both the conjugation identity

```tex
Q_k^i = \zeta_k X_k P_{\beta(k)}^i X_k^{-1}
```

and the corresponding scalar-power identity for every finite word.

The source passage is CPSV16, §II.C, lines 1184-1186, with the following coefficient-comparison and block-diagonal assembly step at lines 1187-1192. The corresponding review passage is CPSV21, lines 1891-1894.

## Scope

This PR intentionally stops before the raw coefficient identity and global gauge assembly. In the proportional case the total MPV equality carries a length-dependent scalar, so the equal-MPV coefficient identity in `CoeffIdentity.lean` is not a faithful substitute for the remaining step of #1749.

A blueprint theorem is added in `blueprint/src/chapter/ch10_bnt.tex` for the new Lean declaration and marks the per-sector witness result as formalized.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

`checkdecls` still reports the pre-existing missing parent-Hamiltonian and PEPS declarations, but it does not report `MPSTensor.ft_sector_bnt_proportional_sector_match_witnesses`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems and refactors an internal proof without changing existing statement behavior, but may affect downstream proofs via new imports/lemma dependencies.
> 
> **Overview**
> Adds a reusable lemma `IsBNTCanonicalForm.norm_phase_of_matched_mpv` showing a phase `ζ` in an MPV power-scaling relation must satisfy `‖ζ‖ = 1`, and simplifies `extract_unit_gauge_phase_mpv` to use it.
> 
> Extends proportional BNT sector matching with a new witness theorem `ft_sector_bnt_proportional_sector_match_witnesses` that explicitly chooses per-sector block gauges `Xblock` and phases `ζ`, proves unit-modulus of each `ζ`, and records both the block conjugation and induced MPV scalar-power identities. Updates the blueprint to document these new formalized results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2b4a3bd68084b98a50ed0b9b3d395fbaf035ace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->