### PR TITLE
feat(MPS/FT/SectorBNT): record supplier length-zero discharge

### DIFF
--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -75,6 +75,12 @@ def mpv (A : MPSTensor d D) {N : ℕ} (σ : Fin N → Fin d) : ℂ :=
 @[simp] lemma mpv_eq (A : MPSTensor d D) {N : ℕ} (σ : Fin N → Fin d) :
     mpv A σ = coeff A (List.ofFn σ) := rfl
 
+/-- At length zero, every MPV coefficient is the trace of the identity, hence the bond
+dimension. -/
+@[simp] lemma mpv_zero_length (A : MPSTensor d D) (σ : Fin 0 → Fin d) :
+    mpv A σ = (D : ℂ) := by
+  simp [mpv, coeff]
+
 /-- Gauge equivalence: `A` and `B` are related by simultaneous similarity
 `B i = X * A i * X⁻¹` for some `X ∈ GL(D,ℂ)`. -/
 def GaugeEquiv (A B : MPSTensor d D) : Prop :=
@@ -108,6 +114,19 @@ theorem SameMPV₂.toSameMPV₂Pos {d D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (h : SameMPV₂ A B) : SameMPV₂Pos A B :=
   fun N _hN σ => h N σ
+
+/-- Positive-length MPV equality plus equality of bond dimensions gives full MPV equality.
+
+This isolates the length-zero bookkeeping: at `N = 0`, the MPV coefficient is just the
+bond dimension. -/
+theorem SameMPV₂Pos.toSameMPV₂_of_bondDim_eq {d D₁ D₂ : ℕ}
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (h : SameMPV₂Pos A B) (hD : D₁ = D₂) : SameMPV₂ A B := by
+  intro N σ
+  by_cases hN : N = 0
+  · subst N
+    rw [mpv_zero_length, mpv_zero_length, hD]
+  · exact h N (Nat.pos_of_ne_zero hN) σ
 
 /-- Positive-length MPV equality is symmetric. -/
 theorem SameMPV₂Pos.symm {d D₁ D₂ : ℕ}

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -33,12 +33,11 @@ phase-equivalent TP/primitive/irreducible blocks.
   prepared-data setting (`A^i = ⊕_{j,q} μ_{j,q} A_j^i` with normal `A_j` and
   the §II.A normalization).
 
-## Scout memo
+## Gap record
 
-* `audits/2026-05-16_phase_C_feasibility_gpt55.md` §1, §2.3, §2.4 — the
-  feasibility analysis that identified this prepared-block constructor as the
-  pragmatic Phase C target (with the exact-`SameMPV₂` zero-tail and global
-  rescaling issues quarantined behind the prepared-data hypotheses).
+* `docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex` —
+  records the remaining canonical-form weight-normalization and length-zero
+  bookkeeping gaps for the arbitrary-input supplier path.
 
 ## Layering
 
@@ -521,5 +520,49 @@ theorem exists_isBNTCanonicalForm_afterBlocking_pos
   -- `hSame`:    `mpv P.toTensor σ = mpv (toTensorFromBlocks μ blocks) σ` for all `N`.
   intro N hN σ
   exact (hSamePos N hN σ).trans (hSame N σ).symm
+
+/-- **Arbitrary-input BNT block preparation with explicit length-zero discharge.**
+
+This is a bookkeeping refinement of
+`exists_isBNTCanonicalForm_afterBlocking_pos`.  The theorem keeps the same
+prepared-block output and the same CPSV16 §II.A line-246 normalization
+hypotheses.  In addition, after a normalized BNT sector decomposition is
+chosen, it records that the positive-length MPV identity upgrades to full
+`SameMPV₂` as soon as the zero-length trace identity is supplied in the
+concrete form `D = P.totalDim`.
+
+It does not prove the missing normalization or the total-dimension equality;
+those are precisely the remaining arbitrary-input bridge obligations recorded
+in `docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex`. -/
+theorem exists_isBNTCanonicalForm_afterBlocking_of_totalDim
+    {d D : ℕ} (A : MPSTensor d D) :
+    ∃ p : ℕ, 0 < p ∧
+    ∃ r : ℕ, ∃ dim : Fin r → ℕ, ∃ μ : Fin r → ℂ,
+    ∃ blocks : (k : Fin r) → MPSTensor (blockPhysDim d p) (dim k),
+      (∀ k, 0 < dim k) ∧
+      (∀ k, IsLeftCanonical (blocks k)) ∧
+      (∀ k, _root_.IsPrimitive (transferMap (blocks k))) ∧
+      (∀ k, IsIrreducibleTensor (blocks k)) ∧
+      (∀ k, IsInjective (blocks k)) ∧
+      (∀ k, μ k ≠ 0) ∧
+      SameMPV₂Pos (blockTensor (d := d) (D := D) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μ) blocks) ∧
+      (∀ (_hμLe : ∀ k, ‖μ k‖ ≤ 1) (_hμUnit : ∃ k, ‖μ k‖ = 1),
+        ∃ P : SectorDecomposition (blockPhysDim d p),
+          SameMPV₂Pos (blockTensor (d := d) (D := D) A p) P.toTensor ∧
+          (D = P.totalDim →
+            SameMPV₂ (blockTensor (d := d) (D := D) A p) P.toTensor) ∧
+          IsBNTCanonicalForm P) := by
+  classical
+  obtain ⟨p, hp, r, dim, μ, blocks, hDim, hTP, hPrim, hIrr, hInj, hμne,
+      hSamePos, hMake⟩ :=
+    exists_isBNTCanonicalForm_afterBlocking_pos (d := d) (D := D) A
+  refine ⟨p, hp, r, dim, μ, blocks, hDim, hTP, hPrim, hIrr, hInj, hμne,
+    hSamePos, ?_⟩
+  intro hμLe hμUnit
+  obtain ⟨P, hPPos, hBNT⟩ := hMake hμLe hμUnit
+  refine ⟨P, hPPos, ?_, hBNT⟩
+  intro hDimEq
+  exact hPPos.toSameMPV₂_of_bondDim_eq hDimEq
 
 end MPSTensor

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1069,6 +1069,28 @@ BNT construction.
     \cite[Proposition~\texttt{char-BNT}]{Cirac2017MPDO_AnnPhys}.
 \end{proof}
 
+\begin{theorem}[Conditional BNT form after blocking with length-zero discharge]%
+    \label{thm:paperbnt_supplier_after_blocking_total_dim}
+    \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_of_totalDim}
+    \leanok
+    \uses{thm:paperbnt_supplier_after_blocking,
+        def:same_mpv2,
+        def:same_mpv2_pos}
+    In the setting of Theorem~\ref{thm:paperbnt_supplier_after_blocking}, the
+    same prepared blocks may be chosen so that, after the normalized BNT sector
+    decomposition $P$ is constructed, the positive-length MPV identity upgrades
+    to all lengths whenever the total bond dimension of $P$ is equal to the
+    bond dimension of the blocked input tensor.
+\end{theorem}
+
+\begin{proof}\leanok
+    The positive-length statement is Theorem~\ref{thm:paperbnt_supplier_after_blocking}.
+    At length zero the MPV coefficient of a tensor is the trace of the identity
+    matrix on its bond space, hence its bond dimension. Therefore equality of
+    the two total bond dimensions supplies exactly the missing length-zero
+    coefficient, and the positive-length identity gives all remaining lengths.
+\end{proof}
+
 \begin{remark}[Arbitrary-input reduction]%
     \label{rem:arbitrary_input_reduction_gap}
     Theorem~\ref{thm:paperbnt_supplier_after_blocking} gives the


### PR DESCRIPTION
## Summary

This PR advances #1753 by isolating the length-zero part of the arbitrary-input SectorBNT supplier bridge.

It adds two general MPV bookkeeping lemmas in `TNLean/MPS/Defs.lean`:

```lean
MPSTensor.mpv_zero_length
MPSTensor.SameMPV₂Pos.toSameMPV₂_of_bondDim_eq
```

The first records that the length-zero MPV coefficient is the bond dimension. The second says that positive-length MPV equality becomes full all-length MPV equality once the two bond dimensions agree.

The supplier file then adds

```lean
MPSTensor.exists_isBNTCanonicalForm_afterBlocking_of_totalDim
```

as a refinement of `exists_isBNTCanonicalForm_afterBlocking_pos`: after the normalized BNT sector decomposition is constructed, a supplied equality `D = P.totalDim` upgrades the positive-length MPV identity to full `SameMPV₂`.

## Scope

This does not prove the remaining arbitrary-input bridge. It deliberately leaves the two substantive obligations visible:

- the CPSV16 §II.A line-246 weight normalization for the prepared blocks;
- the total-dimension, or equivalently length-zero, identity needed to pass from positive-length equality to full `SameMPV₂`.

The module docstring now points to `docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex`, replacing the stale audit path previously cited there.

A blueprint entry is added in Chapter 8 for the new supplier theorem.

## Validation

- `lake build TNLean.MPS.Defs`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

`checkdecls` still reports the pre-existing parent-Hamiltonian and PEPS declaration gaps, but it does not report `MPSTensor.exists_isBNTCanonicalForm_afterBlocking_of_totalDim`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds small, self-contained lemmas/theorems and documentation around the `N = 0` MPV coefficient, without changing existing algorithms or proof structure beyond reusing the new bookkeeping implication.
> 
> **Overview**
> Adds a simp lemma `mpv_zero_length` stating that the `N = 0` MPV coefficient is the bond dimension, and a helper theorem `SameMPV₂Pos.toSameMPV₂_of_bondDim_eq` to upgrade `SameMPV₂Pos` to full `SameMPV₂` given `D₁ = D₂`.
> 
> Extends the SectorBNT supplier with `exists_isBNTCanonicalForm_afterBlocking_of_totalDim`, which keeps the existing prepared-block/normalization pipeline but additionally returns a conditional proof that `D = P.totalDim` upgrades the resulting positive-length MPV identity to all lengths.
> 
> Updates the module docstring link to the current gap note and adds a corresponding blueprint theorem entry documenting the new conditional length-zero discharge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc496c1b0f03ccee57ab640ae19c4b3dd27e65d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->