### PR TITLE
refactor(blueprint): factor PEPS diagram motifs

### DIFF
--- a/blueprint/src/macros/tn_core.tex
+++ b/blueprint/src/macros/tn_core.tex
@@ -172,6 +172,52 @@
   \draw[tn phys leg, red] (#1O.north) -- ++(0,0.36);%
 }
 
+\newcommand{\TN@pepsFiveSitePatch}[1]{%
+  \TN@tensordot{#1one}{(0,0)}
+  \TN@tensordot{#1two}{(1.00,0)}
+  \TN@tensordot{#1three}{(1.50,1.00)}
+  \TN@tensordot{#1four}{(0.60,1.50)}
+  \TN@tensordot{#1five}{(-0.60,1.50)}
+  \foreach \n in {#1one,#1two,#1three,#1four,#1five} {
+    \TN@upleg{\n}{0.50}
+  }
+  \draw[tn leg] (#1one) -- (#1two) -- (#1three) --
+    (#1four) -- (#1five) -- (#1one);
+  \draw[tn leg] (#1two) -- (#1five);%
+}
+
+\newcommand{\TN@pepsFiveSitePatchLabels}[6]{%
+  \node at ($(#1one.south)+(0,-0.25)$) {$#2$};
+  \node at ($(#1two.south)+(0,-0.25)$) {$#3$};
+  \node at ($(#1three.south)+(0,-0.25)$) {$#4$};
+  \node at ($(#1four.south)+(0,-0.25)$) {$#5$};
+  \node at ($(#1five.south)+(0,-0.25)$) {$#6$};%
+}
+
+\newcommand{\TN@twoInjectiveInsertionPair}[4]{%
+  \TN@tensordot{#1one}{(0,0)}
+  \TN@tensordot{#1two}{(2.50,0)}
+  \TN@upleg{#1one}{0.42}
+  \TN@upleg{#1two}{0.42}
+  \TN@opdotabove{#1X}{(1.25,0.45)}{#4}
+  \draw[tn leg] (#1one) to[out=30,in=180] (#1X.west);
+  \draw[tn leg] (#1X.east) to[out=0,in=150] (#1two);
+  \draw[tn leg] (#1one) to[bend right=12] (#1two);
+  \draw[tn leg] (#1one) to[bend right=38] (#1two);
+  \node at (1.25,-0.08) {$\vdots$};
+  \node at ($(#1one.south)+(0,-0.30)$) {$#2$};
+  \node at ($(#1two.south)+(0,-0.30)$) {$#3$};%
+}
+
+\newcommand{\TN@threeLegTensorFan}[2]{%
+  \TN@tensordot{#1}{(0,0)}
+  \TN@upleg{#1}{0.42}
+  \draw[tn leg] (#1) -- ++(0.75,0.45);
+  \draw[tn leg] (#1) -- ++(0.78,-0.05);
+  \draw[tn leg] (#1) -- ++(0.65,-0.55);
+  \node at ($(#1.south)+(0,-0.30)$) {$#2$};%
+}
+
 \newcommand{\TN@normalPepsGridLines}{%
   \draw[step=0.5, tn leg] (-1,-1) grid (4,4);%
 }

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -372,17 +372,7 @@
 \newcommand{\TNPEPSEdgeBlockingReduction}{%
   \begin{tikzpicture}[tn picture]
     \begin{scope}
-      \TN@tensordot{blockCone}{(0,0)}
-      \TN@tensordot{blockCtwo}{(1.00,0)}
-      \TN@tensordot{blockCthree}{(1.50,1.00)}
-      \TN@tensordot{blockCfour}{(0.60,1.50)}
-      \TN@tensordot{blockCfive}{(-0.60,1.50)}
-      \foreach \n in {blockCone,blockCtwo,blockCthree,blockCfour,blockCfive} {
-        \TN@upleg{\n}{0.50}
-      }
-      \draw[tn leg] (blockCone) -- (blockCtwo) -- (blockCthree) --
-        (blockCfour) -- (blockCfive) -- (blockCone);
-      \draw[tn leg] (blockCtwo) -- (blockCfive);
+      \TN@pepsFiveSitePatch{blockC}
       \draw[red, line width=0.45pt] (blockCone) circle (0.30cm);
       \draw[red, line width=0.45pt] (blockCfive) circle (0.30cm);
       \draw[red, rounded corners=2mm, line width=0.45pt]
@@ -460,42 +450,16 @@
 \newcommand{\TNPEPSEdgeInsertionEquality}{%
   \begin{tikzpicture}[tn picture]
     \begin{scope}
-      \TN@tensordot{edgeEqAone}{(0,0)}
-      \TN@tensordot{edgeEqAtwo}{(1.00,0)}
-      \TN@tensordot{edgeEqAthree}{(1.50,1.00)}
-      \TN@tensordot{edgeEqAfour}{(0.60,1.50)}
-      \TN@tensordot{edgeEqAfive}{(-0.60,1.50)}
-      \foreach \n in {edgeEqAone,edgeEqAtwo,edgeEqAthree,edgeEqAfour,edgeEqAfive} {
-        \TN@upleg{\n}{0.50}
-      }
-      \node at ($(edgeEqAone.south)+(0,-0.25)$) {$A_1$};
-      \node at ($(edgeEqAtwo.south)+(0,-0.25)$) {$A_2$};
-      \node at ($(edgeEqAthree.south)+(0,-0.25)$) {$A_3$};
-      \node at ($(edgeEqAfour.south)+(0,-0.25)$) {$A_4$};
-      \node at ($(edgeEqAfive.south)+(0,-0.25)$) {$A_5$};
-      \draw[tn leg] (edgeEqAone) -- (edgeEqAtwo) -- (edgeEqAthree) --
-        (edgeEqAfour) -- (edgeEqAfive) -- (edgeEqAone);
-      \draw[tn leg] (edgeEqAtwo) -- (edgeEqAfive);
+      \TN@pepsFiveSitePatch{edgeEqA}
+      \TN@pepsFiveSitePatchLabels{edgeEqA}{A_1}{A_2}{A_3}{A_4}{A_5}
       \TN@opdotright{edgeInsA}{($(edgeEqAtwo)!0.50!(edgeEqAfive)$)}{X}
     \end{scope}
     \node at (2.75,0.70) {$=$};
     \begin{scope}[xshift=4.15cm]
-      \TN@tensordot{edgeEqBone}{(0,0)}
-      \TN@tensordot{edgeEqBtwo}{(1.00,0)}
-      \TN@tensordot{edgeEqBthree}{(1.50,1.00)}
-      \TN@tensordot{edgeEqBfour}{(0.60,1.50)}
-      \TN@tensordot{edgeEqBfive}{(-0.60,1.50)}
-      \foreach \n in {edgeEqBone,edgeEqBtwo,edgeEqBthree,edgeEqBfour,edgeEqBfive} {
-        \TN@upleg{\n}{0.50}
-      }
-      \node at ($(edgeEqBone.south)+(0,-0.25)$) {$\widetilde B_1$};
-      \node at ($(edgeEqBtwo.south)+(0,-0.25)$) {$\widetilde B_2$};
-      \node at ($(edgeEqBthree.south)+(0,-0.25)$) {$\widetilde B_3$};
-      \node at ($(edgeEqBfour.south)+(0,-0.25)$) {$\widetilde B_4$};
-      \node at ($(edgeEqBfive.south)+(0,-0.25)$) {$\widetilde B_5$};
-      \draw[tn leg] (edgeEqBone) -- (edgeEqBtwo) -- (edgeEqBthree) --
-        (edgeEqBfour) -- (edgeEqBfive) -- (edgeEqBone);
-      \draw[tn leg] (edgeEqBtwo) -- (edgeEqBfive);
+      \TN@pepsFiveSitePatch{edgeEqB}
+      \TN@pepsFiveSitePatchLabels{edgeEqB}
+        {\widetilde B_1}{\widetilde B_2}{\widetilde B_3}
+        {\widetilde B_4}{\widetilde B_5}
       \TN@opdotright{edgeInsB}{($(edgeEqBtwo)!0.50!(edgeEqBfive)$)}{X}
     \end{scope}
   \end{tikzpicture}%
@@ -536,33 +500,11 @@
 \newcommand{\TNPEPSTwoInjectiveTensorInsertionComparison}{%
   \begin{tikzpicture}[tn picture]
     \begin{scope}
-      \TN@tensordot{twoInjAone}{(0,0)}
-      \TN@tensordot{twoInjAtwo}{(2.50,0)}
-      \TN@upleg{twoInjAone}{0.42}
-      \TN@upleg{twoInjAtwo}{0.42}
-      \TN@opdotabove{twoInjAX}{(1.25,0.45)}{X}
-      \draw[tn leg] (twoInjAone) to[out=30,in=180] (twoInjAX.west);
-      \draw[tn leg] (twoInjAX.east) to[out=0,in=150] (twoInjAtwo);
-      \draw[tn leg] (twoInjAone) to[bend right=12] (twoInjAtwo);
-      \draw[tn leg] (twoInjAone) to[bend right=38] (twoInjAtwo);
-      \node at (1.25,-0.08) {$\vdots$};
-      \node at ($(twoInjAone.south)+(0,-0.30)$) {$A_1$};
-      \node at ($(twoInjAtwo.south)+(0,-0.30)$) {$A_2$};
+      \TN@twoInjectiveInsertionPair{twoInjA}{A_1}{A_2}{X}
     \end{scope}
     \node at (3.20,0) {$=$};
     \begin{scope}[xshift=3.90cm]
-      \TN@tensordot{twoInjBone}{(0,0)}
-      \TN@tensordot{twoInjBtwo}{(2.50,0)}
-      \TN@upleg{twoInjBone}{0.42}
-      \TN@upleg{twoInjBtwo}{0.42}
-      \TN@opdotabove{twoInjBX}{(1.25,0.45)}{X}
-      \draw[tn leg] (twoInjBone) to[out=30,in=180] (twoInjBX.west);
-      \draw[tn leg] (twoInjBX.east) to[out=0,in=150] (twoInjBtwo);
-      \draw[tn leg] (twoInjBone) to[bend right=12] (twoInjBtwo);
-      \draw[tn leg] (twoInjBone) to[bend right=38] (twoInjBtwo);
-      \node at (1.25,-0.08) {$\vdots$};
-      \node at ($(twoInjBone.south)+(0,-0.30)$) {$B_1$};
-      \node at ($(twoInjBtwo.south)+(0,-0.30)$) {$B_2$};
+      \TN@twoInjectiveInsertionPair{twoInjB}{B_1}{B_2}{X}
     \end{scope}
   \end{tikzpicture}%
 }
@@ -570,34 +512,19 @@
 \newcommand{\TNPEPSTwoInjectiveGaugeScalarReduction}{%
   \begin{tikzpicture}[tn picture]
     \begin{scope}
-      \TN@tensordot{gaugeRedA}{(0,0)}
-      \TN@upleg{gaugeRedA}{0.42}
-      \draw[tn leg] (gaugeRedA) -- ++(0.75,0.45);
-      \draw[tn leg] (gaugeRedA) -- ++(0.78,-0.05);
-      \draw[tn leg] (gaugeRedA) -- ++(0.65,-0.55);
-      \node at ($(gaugeRedA.south)+(0,-0.30)$) {$A_1$};
+      \TN@threeLegTensorFan{gaugeRedA}{A_1}
     \end{scope}
     \node at (1.25,0) {$=$};
     \begin{scope}[xshift=2.05cm]
-      \TN@tensordot{gaugeRedBZ}{(0,0)}
-      \TN@upleg{gaugeRedBZ}{0.42}
-      \draw[tn leg] (gaugeRedBZ) -- ++(0.75,0.45);
-      \draw[tn leg] (gaugeRedBZ) -- ++(0.78,-0.05);
-      \draw[tn leg] (gaugeRedBZ) -- ++(0.65,-0.55);
+      \TN@threeLegTensorFan{gaugeRedBZ}{B_1}
       \draw[red, line width=0.9pt] (0.35,-0.46) arc (-55:5:0.55);
       \node[red] at (0.70,-0.24) {$Z$};
-      \node at ($(gaugeRedBZ.south)+(0,-0.30)$) {$B_1$};
     \end{scope}
     \node at (3.30,0) {$=$};
     \begin{scope}[xshift=4.10cm]
-      \TN@tensordot{gaugeRedBU}{(0,0)}
-      \TN@upleg{gaugeRedBU}{0.42}
-      \draw[tn leg] (gaugeRedBU) -- ++(0.75,0.45);
-      \draw[tn leg] (gaugeRedBU) -- ++(0.78,-0.05);
-      \draw[tn leg] (gaugeRedBU) -- ++(0.65,-0.55);
+      \TN@threeLegTensorFan{gaugeRedBU}{B_1}
       \draw[red, line width=0.9pt] (0.35,-0.06) arc (-10:45:0.55);
       \node[red] at (0.72,0.24) {$U$};
-      \node at ($(gaugeRedBU.south)+(0,-0.30)$) {$B_1$};
     \end{scope}
     \node at (5.35,0) {$=$};
     \begin{scope}[xshift=6.15cm]

--- a/docs/tn_diagram_grammar.md
+++ b/docs/tn_diagram_grammar.md
@@ -123,5 +123,9 @@ by a diagram before reading the surrounding proof.
 - Repeated chain and square-lattice diagrams should be built from the layout
   commands in `blueprint/src/macros/tn_core.tex`, so that the public command
   records the tensor network rather than a coordinate calculation.
+- Repeated PEPS graph motifs, such as a five-site edge patch, a two-injective
+  comparison pair, or a trivalent residual-gauge vertex, should likewise be
+  factored through private layout commands before being used in theorem-level
+  public diagrams.
 - Private glyphs and lengths belong in `blueprint/src/macros/tn_core.tex`.
   Chapter-facing diagrams belong in `blueprint/src/macros/tn_print.tex`.


### PR DESCRIPTION
Addresses #1010.

Continues #1019.

This PR factors repeated PEPS tensor-network motifs out of the public diagram commands and into the private TikZ kernel. In particular it adds private commands for the five-site PEPS edge patch, labeled five-site patch, two-injective insertion pair, and trivalent residual-gauge fan, then rewrites the corresponding Chapter 13a public diagrams through those motifs.

It also updates the tensor-network diagram grammar to record that repeated PEPS graph motifs should be expressed by private layout commands rather than repeated coordinate drawings.

Local checks run:
- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage`
- `chktex -q -l ../.chktexrc macros/tn_core.tex macros/tn_print.tex`
- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --smoke-render`
- `leanblueprint web`
- `leanblueprint pdf`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of LaTeX/TikZ macro structure only, primarily deduplicating PEPS diagram layout code; main risk is unintended visual/layout regressions in rendered diagrams.
> 
> **Overview**
> Extracts repeated PEPS drawing patterns into new private TikZ layout macros in `tn_core.tex` (five-site edge patch with optional labels, a two-injective insertion comparison pair, and a trivalent three-leg “fan”).
> 
> Rewrites the affected public PEPS diagram macros in `tn_print.tex` to call these helpers instead of duplicating coordinates, and updates `tn_diagram_grammar.md` to codify this factoring rule for repeated PEPS motifs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ddaa8cc4d8a474fdc3b8845e04ca4e7645f845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->