### PR TITLE
doc(MPS): record length-zero MPV bridge

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -469,12 +469,6 @@ theorem mpv_zeroMPSTensor {N : ℕ} (σ : Fin N → Fin d') (D' : ℕ) :
     exact mpv_eq_zero_of_all_zero (zeroMPSTensor d' D')
       (fun _ => rfl) σ hpos
 
-/-- At `N = 0`, the mpv of an arbitrary tensor `A : MPSTensor d D` on the unique
-spin configuration `σ : Fin 0 → Fin d` equals `(D : ℂ)` (the trace of the identity). -/
-private theorem mpv_eq_dim_at_zero (A : MPSTensor d' D') (σ : Fin 0 → Fin d') :
-    mpv A σ = (D' : ℂ) := by
-  simp [mpv, coeff, Matrix.trace_one]
-
 /-- **Zero-block separation** (arXiv:1606.00608 Section 2.3).
 
 The paper states that in the canonical form $A^i = \oplus_{k=1}^r \mu_k A_k^i$, some blocks may
@@ -591,7 +585,7 @@ theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
         -- Each block contributes `dim₀ k` at N=0 (trace of identity).
         have : zeroSet.sum (fun k => mpv (blocks₀ k) σ) =
             zeroSet.sum (fun k => (dim₀ k : ℂ)) :=
-          Finset.sum_congr rfl (fun k _ => mpv_eq_dim_at_zero (blocks₀ k) σ)
+          Finset.sum_congr rfl (fun k _ => mpv_zero_length (blocks₀ k) σ)
         rw [this, ← Nat.cast_sum]
       case isFalse hN =>
         apply Finset.sum_eq_zero

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -197,6 +197,23 @@ boundary conditions (PBC).
     $\ket{V^{(N)}(A)} = \ket{V^{(N)}(B)}$ for every $N > 0$.
 \end{definition}
 
+\begin{lemma}[Length-zero MPV coefficient]\label{lem:mpv_zero_length}
+    \lean{MPSTensor.mpv_zero_length}
+    \leanok
+    \uses{def:mpv}
+    For any MPS tensor $A$ with bond dimension $D$, the length-zero MPV
+    coefficient is $D$, the trace of the identity on the bond space.
+\end{lemma}
+
+\begin{lemma}[Positive-length equality with equal bond dimensions]%
+    \label{lem:samempv2pos_to_samempv2_of_bonddim_eq}
+    \lean{MPSTensor.SameMPV₂Pos.toSameMPV₂_of_bondDim_eq}
+    \leanok
+    \uses{def:same_mpv2_pos, def:same_mpv2, lem:mpv_zero_length}
+    If two tensors have the same positive-length MPV family and the same bond
+    dimension, then they have the same MPV family at every length.
+\end{lemma}
+
 \begin{remark}\leanok
     Definition~\ref{def:same_mpv} is the same-bond-dimension
     specialization of Definition~\ref{def:same_mpv2}.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1075,7 +1075,8 @@ BNT construction.
     \leanok
     \uses{thm:paperbnt_supplier_after_blocking,
         def:same_mpv2,
-        def:same_mpv2_pos}
+        def:same_mpv2_pos,
+        lem:samempv2pos_to_samempv2_of_bonddim_eq}
     In the setting of Theorem~\ref{thm:paperbnt_supplier_after_blocking}, the
     same prepared blocks may be chosen so that, after the normalized BNT sector
     decomposition $P$ is constructed, the positive-length MPV identity upgrades


### PR DESCRIPTION
Closes #1846.\nCloses #1847.\n\nThis PR records the length-zero MPV coefficient and the positive-length-to-full MPV upgrade in the blueprint, and removes the duplicate private zero-length lemma from `CanonicalForm/Existence.lean` in favor of `MPSTensor.mpv_zero_length`.\n\nChecks run locally:\n- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`\n- `chktex -q -l ../.chktexrc chapter/ch02_mps.tex chapter/ch08_canonical.tex`\n- `leanblueprint web`\n- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/MPS/CanonicalForm/Existence.lean`\n- `git diff --check`\n\nNotes: global blueprint sync/checkdecls still reports pre-existing missing parent-Hamiltonian and PEPS declarations; the two declarations added here are not among the missing names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to proof refactoring and blueprint documentation, with no changes to core definitions or algorithms.
> 
> **Overview**
> Removes a duplicate private `N = 0` MPV lemma in `CanonicalForm/Existence.lean` and rewires the zero-block separation proof to use the shared `MPSTensor.mpv_zero_length` lemma.
> 
> Updates the blueprint to explicitly record the length-zero MPV coefficient lemma and the upgrade from positive-length MPV equality to all-length equality when bond dimensions match, and references this bridge in the after-blocking BNT theorem; also fixes a minor LaTeX EOF/newline issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f26fe91a3a4e6130bd425b2e5437bedd625ea088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->