### PR TITLE
doc(PEPS): make normal diagrams readable

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -38,6 +38,7 @@ _RENDER_SOURCE_FILES = (
 
 
 _DIAGRAM_ARGS: dict[str, str] = {
+    "TNTikZDiagram": "rendered body",
     "TNMPSLocal": "tensor label",
     "TNMPSWord": "tensor left right length",
     "TNMPV": "tensor left right length",
@@ -107,6 +108,12 @@ def _sample_arg_value(name: str) -> str:
         "permutation": "\\sigma",
         "left_virtual": "X",
         "right_virtual": "Y",
+        "rendered": "\\TNPEPSNormalRegionT",
+        "body": (
+            "\\begin{tikzpicture}[tn picture]"
+            "\\node[tn tensor dot] at (0,0) {};"
+            "\\end{tikzpicture}"
+        ),
     }
     return values.get(name, "x")
 
@@ -156,7 +163,11 @@ def _assert_peps_macros_used_in_chapter() -> None:
     unused = [
         name
         for name in peps_macros
-        if rf"\{name}" not in chapter and name not in intentionally_unused
+        if (
+            rf"\{name}" not in chapter
+            and rf"\TNTikZDiagram{{{name}}}" not in chapter
+            and name not in intentionally_unused
+        )
     ]
     if unused:
         raise RuntimeError(
@@ -169,6 +180,13 @@ _assert_diagram_args_match_print_macros()
 
 
 def _tex_call(obj: Command) -> str:
+    if obj.macroName == "TNTikZDiagram":
+        rendered = stringify_tex_item(obj.attributes.get("rendered", "")).strip()
+        if rendered:
+            if rendered.startswith("\\"):
+                return rendered
+            return "\\" + rendered
+
     source = getattr(obj, "source", "").strip()
     if source.startswith(rf"\{obj.macroName}"):
         return source
@@ -347,7 +365,8 @@ def _missing_tools_html(tex_call: str) -> str:
 def _compile_svg(tex_call: str, stem: str, svg_path: Path) -> str | None:
     svg_path.parent.mkdir(parents=True, exist_ok=True)
     _CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    (_CACHE_DIR / f"{stem}.tex").write_text(_latex_document(tex_call), encoding="utf-8")
+    tex_path = _CACHE_DIR / f"{stem}.tex"
+    tex_path.write_text(_latex_document(tex_call), encoding="utf-8")
 
     engine = _engine_command(stem)
     if engine is None:
@@ -366,6 +385,7 @@ def _compile_svg(tex_call: str, stem: str, svg_path: Path) -> str | None:
         log_path.write_text(svg_result.stdout, encoding="utf-8")
         raise RuntimeError(f"dvisvgm failed for {tex_call}; see {log_path}")
 
+    tex_path.unlink(missing_ok=True)
     return svg_path.name
 
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -869,7 +869,26 @@ injective and normal PEPS, following Theorems~2 and~3 of
     four parts \(A\setminus B\), \(A\cap B\), \(B\setminus A\), and
     \((A\cup B)^c\), and applies the two available left inverses in sequence:
     \begin{center}
-        \TNPEPSInjectiveRegionUnion
+        \TNTikZDiagram{TNPEPSInjectiveRegionUnion}{%
+            \begin{tikzpicture}[tn picture]
+                \node[tn tensor dot] (unionAB) at (0,0) {};
+                \node[tn tensor dot] (unionI) at (0.70,0.70) {};
+                \node[tn tensor dot] (unionBA) at (2.00,0) {};
+                \node[tn tensor dot] (unionC) at (1.30,-0.70) {};
+                \foreach \n in {unionAB,unionI,unionBA,unionC} {
+                    \draw[tn phys leg] (\n.north) -- ++(0,0.42);
+                }
+                \draw[tn leg] (unionAB) -- (unionI) -- (unionBA) -- (unionC) --
+                    (unionAB) -- (unionBA);
+                \draw[tn leg] (unionI) -- (unionC);
+                \node[anchor=east] at ($(unionAB)+(-0.12,-0.20)$)
+                    {$A\setminus B$};
+                \node[anchor=west] at ($(unionI)+(0.12,0.02)$) {$A\cap B$};
+                \node[anchor=west] at ($(unionBA)+(0.12,-0.20)$)
+                    {$B\setminus A$};
+                \node at ($(unionC)+(0,-0.38)$) {$(A\cup B)^c$};
+            \end{tikzpicture}%
+        }
     \end{center}
 \end{lemma}
 
@@ -881,11 +900,31 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Lemma~\ref{lem:peps_injectiveRegion_union} then implies that the regions
     \(R\), \(S\), and \(T\) below are injective:
     \begin{center}
-        \TNPEPSNormalRegionsRS
+        \TNTikZDiagram{TNPEPSNormalRegionsRS}{%
+            \begin{tikzpicture}[tn picture, scale=0.90]
+                \begin{scope}
+                    \clip (-0.25,0.75) rectangle (2.25,3.25);
+                    \pepsNormalSquareLattice
+                    \pepsNormalRegionR
+                \end{scope}
+                \node at (2.85,2.00) {and};
+                \begin{scope}[xshift=3.55cm]
+                    \clip (-0.25,0.75) rectangle (2.25,3.25);
+                    \pepsNormalSquareLattice
+                    \pepsNormalRegionS
+                \end{scope}
+            \end{tikzpicture}%
+        }
 
         \vspace{0.5em}
 
-        \TNPEPSNormalRegionT
+        \TNTikZDiagram{TNPEPSNormalRegionT}{%
+            \begin{tikzpicture}[tn picture, scale=0.90]
+                \clip (-0.25,0.25) rectangle (3.25,3.25);
+                \pepsNormalSquareLattice
+                \pepsNormalRegionT
+            \end{tikzpicture}%
+        }
     \end{center}
 \end{definition}
 
@@ -901,7 +940,22 @@ injective and normal PEPS, following Theorems~2 and~3 of
     injective-chain insertion argument used in the injective PEPS theorem
     applies to the blocked normal PEPS:
     \begin{center}
-        \TNPEPSNormalEdgeBlockingReduction
+        \TNTikZDiagram{TNPEPSNormalEdgeBlockingReduction}{%
+            \begin{tikzpicture}[tn picture, scale=0.90]
+                \begin{scope}
+                    \clip (-0.25,-0.25) rectangle (3.25,3.25);
+                    \pepsNormalSquareLatticeLines
+                    \pepsNormalDistinguishedEdge
+                    \pepsNormalSquareLatticeDots
+                    \pepsNormalRedBlock
+                    \pepsNormalBlueBlock
+                \end{scope}
+                \node at (3.75,1.45) {$\Rightarrow$};
+                \begin{scope}[xshift=4.45cm,yshift=1.50cm]
+                    \pepsBlockedNormalChain
+                \end{scope}
+            \end{tikzpicture}%
+        }
     \end{center}
 \end{theorem}
 
@@ -916,7 +970,34 @@ injective and normal PEPS, following Theorems~2 and~3 of
     matrices into \(B\) gives a tensor \(\widetilde B\), equivalently the final
     local gauge formula of \cite[Theorem~3]{Molnar2018NormalPEPS}:
     \begin{center}
-        \TNPEPSTINormalGaugeAbsorption
+        \TNTikZDiagram{TNPEPSTINormalGaugeAbsorption}{%
+            \begin{tikzpicture}[tn picture]
+                \begin{scope}
+                    \pepsSquareTensor{tiB}{(0,0)}
+                    \node at ($(tiB.south)+(0,-0.88)$) {$B$};
+                \end{scope}
+                \node at (1.25,0) {$=$};
+                \begin{scope}[xshift=2.35cm]
+                    \node[tn tensor dot] (tiA) at (0,0) {};
+                    \node[tn operator dot, label=left:$X$] (tiXL) at (-0.76,0) {};
+                    \node[tn operator dot, label=right:$X^{-1}$] (tiXR)
+                        at (0.76,0) {};
+                    \node[tn operator dot, label=below:$Y$] (tiYD) at (0,-0.76) {};
+                    \node[tn operator dot, label=above:$Y^{-1}$] (tiYU)
+                        at (0,0.76) {};
+                    \draw[tn phys leg] (tiA.north) -- ++(0,0.46);
+                    \draw[tn leg] (tiXL.west) -- ++(-0.24,0);
+                    \draw[tn leg] (tiXL.east) -- (tiA.west);
+                    \draw[tn leg] (tiA.east) -- (tiXR.west);
+                    \draw[tn leg] (tiXR.east) -- ++(0.24,0);
+                    \draw[tn leg] (tiYD.south) -- ++(0,-0.24);
+                    \draw[tn leg] (tiYD.north) -- (tiA.south);
+                    \draw[tn leg] (tiA.north) -- (tiYU.south);
+                    \draw[tn leg] (tiYU.north) -- ++(0,0.24);
+                    \node at ($(tiA.south)+(0,-1.20)$) {$\lambda A$};
+                \end{scope}
+            \end{tikzpicture}%
+        }
     \end{center}
 \end{theorem}
 

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -15,6 +15,8 @@
 
 % ---------- Public semantic macros ----------
 
+\newcommand{\TNTikZDiagram}[2]{#2}
+
 \newcommand{\TNMPSLocal}[2]{%
   \begin{tikzpicture}[tn picture]
     \TN@tensordot{tnA}{(0,0)}
@@ -578,14 +580,79 @@
   \end{tikzpicture}%
 }
 
+\newcommand{\pepsNormalSquareLattice}{%
+  \TN@normalPepsGrid%
+}
+
+\newcommand{\pepsNormalSquareLatticeLines}{%
+  \TN@normalPepsGridLines%
+}
+
+\newcommand{\pepsNormalSquareLatticeDots}{%
+  \TN@normalPepsGridDots%
+}
+
+\newcommand{\pepsNormalRegionR}{%
+  \draw[red, fill=red!35, thick, rounded corners=1mm]
+    (0.3,1.3) -- (1.2,1.3) -- (1.2,1.8) -- (1.7,1.8) --
+    (1.7,2.7) -- (0.3,2.7) -- cycle;
+  \node at (0.75,2.0) {$R$};%
+}
+
+\newcommand{\pepsNormalRegionS}{%
+  \draw[red, fill=red!35, thick, rounded corners=1mm]
+    (0.3,1.3) rectangle (1.7,2.7);
+  \node at (1.00,2.00) {$S$};%
+}
+
+\newcommand{\pepsNormalRegionT}{%
+  \filldraw[draw=red, fill=red!35, thick, rounded corners=1mm,
+    even odd rule]
+    (0.3,2.7) -- (1.2,2.7) -- (1.2,1.7) -- (2.7,1.7) --
+    (2.7,0.8) -- (1.3,0.8) -- (1.3,1.3) -- (0.3,1.3) -- cycle
+    (-0.25,0.25) rectangle (3.25,3.25);
+  \node at (2.0,2.3) {$T$};%
+}
+
+\newcommand{\pepsNormalDistinguishedEdge}{%
+  \draw[line width=0.6mm, green!65!black] (1,1.5) -- (1.5,1.5);%
+}
+
+\newcommand{\pepsNormalRedBlock}{%
+  \draw[red, thick, rounded corners=1mm] (0.3,1.3) rectangle (1.2,2.7);%
+}
+
+\newcommand{\pepsNormalBlueBlock}{%
+  \draw[blue, thick, rounded corners=1mm] (1.3,1.7) rectangle (2.7,0.8);%
+}
+
+\newcommand{\pepsBlockedNormalChain}{%
+  \draw[tn leg] (0.50,0) rectangle (3.50,-0.46);
+  \draw[line width=0.6mm, green!65!black] (1.00,0) -- (2.00,0);
+  \foreach \x/\c/\lab in {1/red/A_1,2/blue/A_2,3/black/A_3} {
+    \TN@tensordot{normalBlock\x}{(\x,0)}
+    \TN@upleg{normalBlock\x}{0.46}
+    \node[\c] at ($(normalBlock\x.south)+(0,-0.30)$) {$\lab$};
+  }%
+}
+
+\newcommand{\pepsSquareTensor}[2]{%
+  \TN@tensordot{#1}{#2}
+  \TN@upleg{#1}{0.46}
+  \draw[tn leg] (#1.west) -- ++(-0.60,0);
+  \draw[tn leg] (#1.east) -- ++(0.60,0);
+  \draw[tn leg] (#1.south) -- ++(0,-0.60);
+  \draw[tn leg] (#1.north) -- ++(0,0.38);%
+}
+
 \newcommand{\TNPEPSInjectiveRegionUnion}{%
   \begin{tikzpicture}[tn picture]
-    \TN@tensordot{unionAB}{(0,0)}
-    \TN@tensordot{unionI}{(0.70,0.70)}
-    \TN@tensordot{unionBA}{(2.00,0)}
-    \TN@tensordot{unionC}{(1.30,-0.70)}
+    \node[tn tensor dot] (unionAB) at (0,0) {};
+    \node[tn tensor dot] (unionI) at (0.70,0.70) {};
+    \node[tn tensor dot] (unionBA) at (2.00,0) {};
+    \node[tn tensor dot] (unionC) at (1.30,-0.70) {};
     \foreach \n in {unionAB,unionI,unionBA,unionC} {
-      \TN@upleg{\n}{0.42}
+      \draw[tn phys leg] (\n.north) -- ++(0,0.42);
     }
     \draw[tn leg] (unionAB) -- (unionI) -- (unionBA) -- (unionC) --
       (unionAB) -- (unionBA);
@@ -601,19 +668,14 @@
   \begin{tikzpicture}[tn picture, scale=0.90]
     \begin{scope}
       \clip (-0.25,0.75) rectangle (2.25,3.25);
-      \TN@normalPepsGrid
-      \draw[red, fill=red!35, thick, rounded corners=1mm]
-        (0.3,1.3) -- (1.2,1.3) -- (1.2,1.8) -- (1.7,1.8) --
-        (1.7,2.7) -- (0.3,2.7) -- cycle;
-      \node at (0.75,2.0) {$R$};
+      \pepsNormalSquareLattice
+      \pepsNormalRegionR
     \end{scope}
     \node at (2.85,2.00) {and};
     \begin{scope}[xshift=3.55cm]
       \clip (-0.25,0.75) rectangle (2.25,3.25);
-      \TN@normalPepsGrid
-      \draw[red, fill=red!35, thick, rounded corners=1mm]
-        (0.3,1.3) rectangle (1.7,2.7);
-      \node at (1.00,2.00) {$S$};
+      \pepsNormalSquareLattice
+      \pepsNormalRegionS
     \end{scope}
   \end{tikzpicture}%
 }
@@ -621,13 +683,8 @@
 \newcommand{\TNPEPSNormalRegionT}{%
   \begin{tikzpicture}[tn picture, scale=0.90]
     \clip (-0.25,0.25) rectangle (3.25,3.25);
-    \TN@normalPepsGrid
-    \filldraw[draw=red, fill=red!35, thick, rounded corners=1mm,
-      even odd rule]
-      (0.3,2.7) -- (1.2,2.7) -- (1.2,1.7) -- (2.7,1.7) --
-      (2.7,0.8) -- (1.3,0.8) -- (1.3,1.3) -- (0.3,1.3) -- cycle
-      (-0.25,0.25) rectangle (3.25,3.25);
-    \node at (2.0,2.3) {$T$};
+    \pepsNormalSquareLattice
+    \pepsNormalRegionT
   \end{tikzpicture}%
 }
 
@@ -635,21 +692,15 @@
   \begin{tikzpicture}[tn picture, scale=0.90]
     \begin{scope}
       \clip (-0.25,-0.25) rectangle (3.25,3.25);
-      \TN@normalPepsGridLines
-      \draw[line width=0.6mm, green!65!black] (1,1.5) -- (1.5,1.5);
-      \TN@normalPepsGridDots
-      \draw[red, thick, rounded corners=1mm] (0.3,1.3) rectangle (1.2,2.7);
-      \draw[blue, thick, rounded corners=1mm] (1.3,1.7) rectangle (2.7,0.8);
+      \pepsNormalSquareLatticeLines
+      \pepsNormalDistinguishedEdge
+      \pepsNormalSquareLatticeDots
+      \pepsNormalRedBlock
+      \pepsNormalBlueBlock
     \end{scope}
     \node at (3.75,1.45) {$\Rightarrow$};
     \begin{scope}[xshift=4.45cm,yshift=1.50cm]
-      \draw[tn leg] (0.50,0) rectangle (3.50,-0.46);
-      \draw[line width=0.6mm, green!65!black] (1.00,0) -- (2.00,0);
-      \foreach \x/\c/\lab in {1/red/A_1,2/blue/A_2,3/black/A_3} {
-        \TN@tensordot{normalBlock\x}{(\x,0)}
-        \TN@upleg{normalBlock\x}{0.46}
-        \node[\c] at ($(normalBlock\x.south)+(0,-0.30)$) {$\lab$};
-      }
+      \pepsBlockedNormalChain
     \end{scope}
   \end{tikzpicture}%
 }
@@ -657,22 +708,17 @@
 \newcommand{\TNPEPSTINormalGaugeAbsorption}{%
   \begin{tikzpicture}[tn picture]
     \begin{scope}
-      \TN@tensordot{tiB}{(0,0)}
-      \TN@upleg{tiB}{0.46}
-      \draw[tn leg] (tiB.west) -- ++(-0.60,0);
-      \draw[tn leg] (tiB.east) -- ++(0.60,0);
-      \draw[tn leg] (tiB.south) -- ++(0,-0.60);
-      \draw[tn leg] (tiB.north) -- ++(0,0.38);
+      \pepsSquareTensor{tiB}{(0,0)}
       \node at ($(tiB.south)+(0,-0.88)$) {$B$};
     \end{scope}
     \node at (1.25,0) {$=$};
     \begin{scope}[xshift=2.35cm]
-      \TN@tensordot{tiA}{(0,0)}
-      \TN@upleg{tiA}{0.46}
-      \TN@opdotleft{tiXL}{(-0.76,0)}{X}
-      \TN@opdotright{tiXR}{(0.76,0)}{X^{-1}}
-      \TN@opdotbelow{tiYD}{(0,-0.76)}{Y}
-      \TN@opdotabove{tiYU}{(0,0.76)}{Y^{-1}}
+      \node[tn tensor dot] (tiA) at (0,0) {};
+      \node[tn operator dot, label=left:$X$] (tiXL) at (-0.76,0) {};
+      \node[tn operator dot, label=right:$X^{-1}$] (tiXR) at (0.76,0) {};
+      \node[tn operator dot, label=below:$Y$] (tiYD) at (0,-0.76) {};
+      \node[tn operator dot, label=above:$Y^{-1}$] (tiYU) at (0,0.76) {};
+      \draw[tn phys leg] (tiA.north) -- ++(0,0.46);
       \draw[tn leg] (tiXL.west) -- ++(-0.24,0);
       \draw[tn leg] (tiXL.east) -- (tiA.west);
       \draw[tn leg] (tiA.east) -- (tiXR.west);

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -1,3 +1,6 @@
+name: TNTikZDiagram
+{{ obj.tn_svg_html }}
+
 name: TNMPSLocal TNMPSWord TNMPV TNTransferMap TNMPOCell TNMPOChain
 {{ obj.tn_svg_html }}
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -147,27 +147,30 @@ alone. The following additional obligations remain.
 
 \section{Blueprint diagrams}
 
-The normal route now has its own semantic tensor-network commands. These are
-not substitutes for the injective theorem diagrams; they attach the additional
-normal blocking layer to named proof nodes.
+The normal route has its own tensor-network diagrams. These are not substitutes
+for the injective theorem diagrams; they attach the additional normal blocking
+layer to named proof nodes.\footnote{In Chapter~13a these pictures are local
+TikZ figures wrapped in $\backslash$\texttt{TNTikZDiagram}, which also records
+the corresponding registered diagram command used by the web blueprint. The
+local figures and the registered commands share the normal-lattice commands in
+\path{blueprint/src/macros/tn_print.tex}.}
 
 \begin{itemize}
-    \item $\backslash$\texttt{TNPEPSInjectiveRegionUnion} depicts the four
-          regions used in Lemma \path{injective_union}.
-    \item $\backslash$\texttt{TNPEPSNormalRegionsRS} depicts the regions $R$
-          and $S$ from the square-lattice proof.
-    \item $\backslash$\texttt{TNPEPSNormalRegionT} depicts the region $T$.
-    \item $\backslash$\texttt{TNPEPSNormalEdgeBlockingReduction} depicts the
+    \item Lemma \path{injective_union} shows the four regions
+          $A\setminus B$, $A\cap B$, $B\setminus A$, and $(A\cup B)^c$.
+    \item Definition \path{peps_normalSquareBlockingRegions} shows the regions
+          $R$, $S$, and $T$ from the square-lattice proof.
+    \item Theorem \path{peps_normalEdgeBlockingToInjectiveChain} shows the
           red/blue/complementary blocking around a distinguished edge and the
           resulting three-site chain.
-    \item $\backslash$\texttt{TNPEPSTINormalGaugeAbsorption} depicts the final
-          translationally invariant local gauge formula with horizontal gauge $X$ and
-          vertical gauge $Y$.
+    \item Theorem \path{peps_tiNormalGaugeAbsorption} shows the final
+          translationally invariant local gauge formula with horizontal gauge
+          $X$ and vertical gauge $Y$.
 \end{itemize}
 
-All of these commands are registered in
-\path{blueprint/src/Packages/tn_diagrams.py}, so the PDF and web blueprint use
-the same public diagram names.
+The wrapper command and the five normal-PEPS diagram commands are registered in
+\path{blueprint/src/Packages/tn_diagrams.py}, so the web blueprint renders the
+same mathematical diagrams rather than a separate hand-written fallback.
 
 \section{Conclusion}
 

--- a/docs/tn_diagram_grammar.md
+++ b/docs/tn_diagram_grammar.md
@@ -127,5 +127,15 @@ by a diagram before reading the surrounding proof.
   comparison pair, or a trivalent residual-gauge vertex, should likewise be
   factored through private layout commands before being used in theorem-level
   public diagrams.
+- If a theorem needs a diagram whose mathematical content is clearer in the
+  chapter source than behind a single figure command, wrap the local TikZ
+  picture in `\TNTikZDiagram{RegisteredDiagram}{...}`. The first argument is
+  the registered diagram used by the web blueprint; the second is the local
+  picture used by the printed blueprint. The two pictures must depict the same
+  diagram. Shared helpers such as `\pepsNormalSquareLattice`,
+  `\pepsNormalRegionR`, `\pepsNormalRegionS`, `\pepsNormalRegionT`,
+  `\pepsNormalDistinguishedEdge`, `\pepsNormalRedBlock`,
+  `\pepsNormalBlueBlock`, `\pepsBlockedNormalChain`, and `\pepsSquareTensor`
+  are used to keep the registered and local forms aligned.
 - Private glyphs and lengths belong in `blueprint/src/macros/tn_core.tex`.
   Chapter-facing diagrams belong in `blueprint/src/macros/tn_print.tex`.


### PR DESCRIPTION
### Motivation

- Chapter 13a of the blueprint (`ch13a_peps_ft.tex`) represents five normal-PEPS diagrams from arXiv:1804.04964, Section 3 using opaque `\TNPEPS*` macro calls, making the diagram source unreadable in the PDF output.
- Attach the normal-section diagrams to their named blueprint nodes with readable, inline TikZ source, as specified in issue #1376.

### Description

- Replaces opaque `\TNPEPS*` macro calls in `blueprint/src/chapter/ch13a_peps_ft.tex` with inline TikZ figures wrapped in the new `\TNTikZDiagram{<RegisteredMacro>}{...}` convention, covering `TNPEPSInjectiveRegionUnion`, `TNPEPSNormalRegionsRS`, `TNPEPSNormalRegionT`, `TNPEPSNormalEdgeBlockingReduction`, and `TNPEPSTINormalGaugeAbsorption`.
- Adds `\TNTikZDiagram` as a no-op TeX macro in `blueprint/src/macros/tn_print.tex` and factors repeated normal-square-lattice drawing elements into shared helper macros.
- Registers `TNTikZDiagram` for SVG rendering in `blueprint/src/Packages/tn_diagrams.py`, with `_tex_call` handling, and updates the PEPS macro usage check to recognize wrapper references (`{TNPEPS...}`).
- Updates `blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s` to render the wrapper in the web blueprint.
- Documents the new convention in `docs/tn_diagram_grammar.md` and updates the normal-route paper-gap note `docs/paper-gaps/peps_normal_ft_section3_route.tex`.

### Testing

- `python3 blueprint/src/Packages/tn_diagrams.py --check --check-peps-usage --smoke-render TNTikZDiagram TNPEPSInjectiveRegionUnion TNPEPSNormalRegionsRS TNPEPSNormalRegionT TNPEPSNormalEdgeBlockingReduction TNPEPSTINormalGaugeAbsorption`
- `cd blueprint/src && chktex -q -l ../.chktexrc chapter/ch13a_peps_ft.tex macros/tn_print.tex`
- `git diff --check`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint pdf`

---
Closes #1376

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new diagram macro path that affects how TikZ commands are converted to SVG for the web blueprint, so mistakes could break diagram rendering or the PEPS macro-usage checks. Changes are localized to diagram rendering/templates and TeX macros, with minimal impact on core math content.
> 
> **Overview**
> Makes Chapter 13a’s normal-PEPS diagrams readable by replacing opaque `\TNPEPS*` figure calls with inline TikZ wrapped in a new `\TNTikZDiagram{RegisteredDiagram}{...}` convention.
> 
> Adds `\TNTikZDiagram` as a no-op TeX macro, factors repeated normal square-lattice drawing pieces into shared helper macros in `macros/tn_print.tex`, and registers the wrapper for web rendering by teaching `tn_diagrams.py`/`TensorNetworkDiagrams.jinja2s` to render the *registered* diagram macro when the wrapper is encountered (including updating the Chapter-13a PEPS usage check to recognize wrapper references). Documentation is updated to describe the new wrapper pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71af3e0b8abf6ea4c6b49b71c946bd0812131c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->