### PR TITLE
feat(PEPS): prove identity edge insertion reindexing

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -358,6 +358,7 @@ import TNLean.Channel.Determinant
 import TNLean.PEPS.Defs
 import TNLean.PEPS.VirtualInsertion
 import TNLean.PEPS.Blocking
+import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.LocalGauge
 -- The PEPS fundamental theorem is an exploratory capstone with recorded
 -- paper-alignment gaps; it is deliberately not part of the default root.

--- a/TNLean/PEPS/IdentityInsertion.lean
+++ b/TNLean/PEPS/IdentityInsertion.lean
@@ -1,0 +1,114 @@
+import TNLean.PEPS.Blocking
+
+import Mathlib.Data.Matrix.Basic
+
+/-!
+# Identity edge insertions for PEPS coefficients
+
+This file proves the finite reindexing step for the identity specialization of
+an edge insertion. The inserted-boundary data split into diagonal and
+off-diagonal parts; the identity matrix kills the off-diagonal part, while the
+diagonal part is equivalent to the ordinary edge-boundary data.
+
+## Main results
+
+- `edgeInsertedCoeff_identity`: inserting the identity matrix on the
+  distinguished edge recovers the edge-blocked coefficient.
+- `edgeInsertedCoeff_identity_eq_stateCoeff`: the same coefficient is the
+  original PEPS coefficient.
+- `SameState.edgeInsertedCoeff_identity_eq`: equal PEPS states have equal
+  identity-inserted edge coefficients.
+
+## References
+
+- [Molnár, Schuch, Verstraete, Cirac, *Fundamental Theorem for injective PEPS*,
+  arXiv:1804.04964, Section 3](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- Inserting the identity matrix on the distinguished edge recovers the
+ordinary edge-blocked coefficient.
+
+The proof first splits the inserted-boundary sum into diagonal and off-diagonal
+parts. The off-diagonal part vanishes by the identity matrix, and the diagonal
+part reindexes through the equivalence with ordinary edge-boundary data. -/
+theorem edgeInsertedCoeff_identity (A : Tensor G d) (e : Edge G) (σ : V → Fin d) :
+    edgeInsertedCoeff (G := G) A e σ
+        (1 : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
+      edgeBlockedCoeff (G := G) A e σ := by
+  classical
+  let insertedSummand : EdgeInsertedBoundaryConfig (G := G) A e → ℂ := fun β =>
+    A.component e.1.1 (edgeInsertedLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+      (1 : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+        β.leftEdgeIndex β.rightEdgeIndex *
+      edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+      A.component e.1.2 (edgeInsertedRightLocalConfig (G := G) A e β) (σ e.1.2)
+  let blockedSummand : EdgeBoundaryConfig (G := G) A e → ℂ := fun β =>
+    A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+      edgeMiddleWeight (G := G) A e σ β *
+      A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)
+  have hoffdiag :
+      (∑ β : {β : EdgeInsertedBoundaryConfig (G := G) A e //
+          ¬ β.leftEdgeIndex = β.rightEdgeIndex}, insertedSummand β.1) = 0 := by
+    apply Fintype.sum_eq_zero
+    intro β
+    simpa only [insertedSummand] using
+      edgeInsertedCoeff_identity_offDiagonal_summand (G := G) A e σ β.1 β.2
+  have hdiag :
+      (∑ β : EdgeDiagonalInsertedBoundaryConfig (G := G) A e, insertedSummand β.1) =
+        ∑ β : EdgeBoundaryConfig (G := G) A e, blockedSummand β := by
+    let φ := edgeBoundaryConfigEquivDiagonalInsertedBoundaryConfig (G := G) A e
+    calc
+      (∑ β : EdgeDiagonalInsertedBoundaryConfig (G := G) A e, insertedSummand β.1)
+          = ∑ β : EdgeBoundaryConfig (G := G) A e, insertedSummand (φ β).1 := by
+            exact (φ.sum_comp fun β => insertedSummand β.1).symm
+      _ = ∑ β : EdgeBoundaryConfig (G := G) A e, blockedSummand β := by
+            refine Finset.sum_congr rfl ?_
+            intro β _
+            change
+              insertedSummand (edgeBoundaryToInsertedBoundaryConfig (G := G) A e β) =
+                blockedSummand β
+            simpa only [insertedSummand, blockedSummand] using
+              edgeInsertedCoeff_identity_diagonal_summand (G := G) A e σ β
+  calc
+    edgeInsertedCoeff (G := G) A e σ
+        (1 : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+        = ∑ β : EdgeInsertedBoundaryConfig (G := G) A e, insertedSummand β := by
+          rfl
+    _ = ∑ β : EdgeDiagonalInsertedBoundaryConfig (G := G) A e, insertedSummand β.1 := by
+          have hsplit :=
+            Fintype.sum_subtype_add_sum_subtype
+              (p := fun β : EdgeInsertedBoundaryConfig (G := G) A e =>
+                β.leftEdgeIndex = β.rightEdgeIndex) insertedSummand
+          rw [← hsplit, hoffdiag, add_zero]
+    _ = ∑ β : EdgeBoundaryConfig (G := G) A e, blockedSummand β := hdiag
+    _ = edgeBlockedCoeff (G := G) A e σ := by
+          rfl
+
+/-- Identity insertion on the distinguished edge recovers the original PEPS
+coefficient. -/
+theorem edgeInsertedCoeff_identity_eq_stateCoeff (A : Tensor G d) (e : Edge G)
+    (σ : V → Fin d) :
+    edgeInsertedCoeff (G := G) A e σ
+        (1 : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
+      stateCoeff A σ := by
+  rw [edgeInsertedCoeff_identity, edgeBlockedCoeff_eq_stateCoeff]
+
+/-- Equality of PEPS states gives equality of the identity-inserted
+edge-centered coefficients at every edge. -/
+theorem SameState.edgeInsertedCoeff_identity_eq {A B : Tensor G d} (hAB : SameState A B)
+    (e : Edge G) (σ : V → Fin d) :
+    edgeInsertedCoeff (G := G) A e σ
+        (1 : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
+      edgeInsertedCoeff (G := G) B e σ
+        (1 : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) := by
+  rw [edgeInsertedCoeff_identity_eq_stateCoeff, edgeInsertedCoeff_identity_eq_stateCoeff]
+  exact hAB σ
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -503,18 +503,22 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Identity insertion recovers the edge-blocked coefficient]%
     \label{thm:peps_edgeInsertedCoeff_identity}
-    \notready
+    \lean{TNLean.PEPS.edgeInsertedCoeff_identity}
+    \leanok
     \uses{def:peps_edgeInsertedCoeff, def:peps_edgeBlockedCoeff,
         def:peps_edgeBoundaryToInsertedBoundaryConfig,
         def:peps_edgeBoundaryConfigEquivDiagonalInsertedBoundaryConfig,
         thm:peps_edgeInsertedCoeff_identity_diagonal_summand,
         thm:peps_edgeInsertedCoeff_identity_offDiagonal_summand}
     If the inserted matrix on the distinguished edge is the identity, then the
-    edge insertion coefficient is the ordinary edge-blocked coefficient. After
-    the diagonal summand comparison, the remaining proof is the finite
-    reindexing of the inserted-boundary sum along the diagonal and the
-    off-diagonal vanishing of the identity matrix.
+    edge insertion coefficient is the ordinary edge-blocked coefficient.
 \end{theorem}
+\begin{proof}\leanok
+    Split the inserted-boundary sum into the diagonal part, where the two
+    inserted bond indices agree, and the off-diagonal part. The off-diagonal
+    summands vanish for the identity matrix, while the diagonal summands
+    reindex through the equivalence with ordinary edge-boundary data.
+\end{proof}
 
 \begin{definition}[Blocked middle tensor at an edge]%
     \label{def:peps_edgeMiddleWeight}
@@ -560,6 +564,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
     factors are reconstructed from the same boundary data.
 \end{proof}
 
+\begin{theorem}[Identity insertion equals the PEPS coefficient]%
+    \label{thm:peps_edgeInsertedCoeff_identity_eq_stateCoeff}
+    \lean{TNLean.PEPS.edgeInsertedCoeff_identity_eq_stateCoeff}
+    \leanok
+    \uses{thm:peps_edgeInsertedCoeff_identity,
+        thm:peps_edgeBlockedCoeff_eq_stateCoeff}
+    If the inserted matrix on the distinguished edge is the identity, then the
+    edge insertion coefficient is the original PEPS state coefficient.
+\end{theorem}
+\begin{proof}\leanok
+    Combine the identity-insertion reindexing with the edge-blocking
+    reindexing of the ordinary PEPS coefficient.
+\end{proof}
+
 \begin{theorem}[Same state gives the same edge-blocked coefficients]%
     \label{thm:peps_sameState_edgeBlockedCoeff_eq}
     \lean{TNLean.PEPS.SameState.edgeBlockedCoeff_eq}
@@ -570,6 +588,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{theorem}
 \begin{proof}\leanok
     Rewrite both edge-blocked coefficients as the corresponding PEPS state
+    coefficients and apply the same-state hypothesis.
+\end{proof}
+
+\begin{theorem}[Same state gives the same identity insertions]%
+    \label{thm:peps_sameState_edgeInsertedCoeff_identity_eq}
+    \lean{TNLean.PEPS.SameState.edgeInsertedCoeff_identity_eq}
+    \leanok
+    \uses{def:peps_same_state,
+        thm:peps_edgeInsertedCoeff_identity_eq_stateCoeff}
+    If two PEPS tensors have the same state, then their edge-centered identity
+    insertions agree at every edge and every physical configuration.
+\end{theorem}
+\begin{proof}\leanok
+    Rewrite both identity insertions as the corresponding PEPS state
     coefficients and apply the same-state hypothesis.
 \end{proof}
 


### PR DESCRIPTION
### Motivation

- The PEPS edge-insertion comparison (issue #1255) requires a finite-sum reindexing identity: inserting the identity matrix on the distinguished edge of a PEPS coefficient should recover the ordinary edge-blocked coefficient.
- The prerequisite summand lemmas and diagonal subtype are established in issue #1372; this PR assembles them into the full `edgeInsertedCoeff_identity` theorem.
- Source: `blueprint/src/chapter/ch13a_peps_ft.tex`, label `thm:peps_edgeInsertedCoeff_identity` (arXiv:1804.04964).

### Description

- `TNLean/PEPS/IdentityInsertion.lean`: proves `TNLean.PEPS.edgeInsertedCoeff_identity`, showing that inserting the identity matrix on the distinguished edge collapses `edgeInsertedCoeff` to `edgeBlockedCoeff`. The proof splits the inserted-boundary sum into diagonal and off-diagonal parts, kills off-diagonal terms via `edgeInsertedCoeff_identity_offDiagonal_summand`, and reindexes the diagonal via `edgeBoundaryConfigEquivDiagonalInsertedBoundaryConfig`.
- Adds two corollaries: `edgeInsertedCoeff_identity_eq_stateCoeff` (identity insertion recovers the ordinary state coefficient) and `SameState.edgeInsertedCoeff_identity_eq` (same-state identity insertion identity).
- `TNLean.lean`: imports the new PEPS identity-insertion module.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: marks `thm:peps_edgeInsertedCoeff_identity` as formalized with `lean{TNLean.PEPS.edgeInsertedCoeff_identity}` and `leanok`, adds its proof block, and adds blueprint entries for the two corollaries.

### Testing

- `lake build TNLean.PEPS.IdentityInsertion` passes.
- `lake build` passes.
- `python3 scripts/check_oversized_lean_files.py --root .` passes.
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch13a_peps_ft.tex` passes.
- `git diff --check` passes.
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/Blocking.lean TNLean/PEPS/IdentityInsertion.lean` reports no matches.
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web` passes.
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint pdf` passes.
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint checkdecls`: new declarations appear in `blueprint/lean_decls` and are not among the pre-existing missing blueprint names.

---
Closes #1372