### PR TITLE
doc(MPS): close normal BNT scope audit

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -17,9 +17,9 @@ This module records the separated blockwise hypotheses used to pass from
 canonical-form and normal-canonical-form hypotheses to the basis-of-normal-tensors
 formulation. The source BNT expansion in arXiv:1606.00608, Section II keeps
 repeated copies inside a sector with coefficients `μ_{j,q}` and multiplicities
-`M_j`; that CPSV sector structure is represented by `IsBNTCanonicalForm` in the
-fundamental-theorem files. The results here are auxiliary tools for already
-separated finite block families.
+`M_j`; that paper-faithful sector structure is represented by
+`IsBNTCanonicalForm` in the fundamental-theorem files. The results here are
+auxiliary tools for already separated finite block families.
 
 ## Main results
 
@@ -46,9 +46,9 @@ tensors uses summed coefficients `c_j(N) = Σ_{q in group j} μ_{j,q}^N`.
 In the strict-dominance branch one first normalizes by the dominant weight, so the relevant
 coefficients are `(μ j / μ 0)^N` and the discarded factor `μ 0^N` is absorbed into the overall
 proportionality constant. In the grouped setting, the normalized sums can still oscillate:
-unit-modulus terms may survive inside a single group. The CPSV treatment of these
-coefficients is carried out in the sector-decomposition results and BNT canonical
-form constructions.
+unit-modulus terms may survive inside a single group. The source-faithful
+treatment of these coefficients is carried out in the sector-decomposition
+results and BNT canonical-form constructions.
 -/
 
 open scoped Matrix BigOperators
@@ -78,8 +78,8 @@ not retain repeated equal-modulus sectors; the full multiplicity structure (weig
 
 **Scope restriction (one-copy-per-sector):** This is the already grouped
 single-representative surface, not the full CPSV16 BNT multiplicity structure.
-CPSV16 lines 287-301 keep the repeated copies of one basis tensor visible
-through the raw coefficients `μ_{j,q}`. The restriction is documented in
+The general source decomposition allows repeated equal-modulus copies inside a
+sector through the raw coefficients `μ_{j,q}`. The restriction is documented in
 `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
 
 `IsNormalCanonicalFormBNT` uses the spectral/primitive-transfer-map version of normality
@@ -156,13 +156,13 @@ lemma mu_norm_le_one (hNCF : IsNormalCanonicalFormBNT μ A) (k : Fin r) :
   · exact absurd k.isLt (by omega)
 
 /-- Rebuild `IsNormalCanonicalFormBNT` from the additive split formulation plus
-the BNT separation assumption and the CPSV dominant-block normalization
-`‖μ ⟨0, _⟩‖ = 1`.
+the BNT separation assumption and the source-faithful dominant-block
+normalization `‖μ ⟨0, _⟩‖ = 1`.
 
 **Scope restriction (one-copy-per-sector):** The strict weight-ordering input
 selects one representative per modulus class. This constructor does not recover
-the multiplicity data of the full CPSV16 BNT decomposition at lines 287-301;
-see `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
+the multiplicity data of the full CPSV16 BNT decomposition; see
+`docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 def ofSeparatedData
     (hIrr : HasIrreducibleBlocks (d := d) A)
     (hLeft : IsLeftCanonicalBlockFamily (d := d) A)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -48,7 +48,13 @@ representative weights are strictly ordered and the representatives are
 BNT-separated.
 
 It combines the representative normal-canonical-form statement with the
-explicit hypothesis that distinct representatives are not gauge-phase equivalent. -/
+explicit hypothesis that distinct representatives are not gauge-phase equivalent.
+
+**Scope restriction (one-copy-per-sector):** The output is an
+`IsNormalCanonicalFormBNT` structure on the already chosen representative
+family. It keeps one representative for each strict weight-modulus class and
+does not reconstruct the repeated-copy CPSV16 BNT sector data. The restriction
+is documented in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 lemma isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
     {d r : ℕ} {dim : Fin r → ℕ}
     {blocks : (k : Fin r) → MPSTensor d (dim k)}

--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -41,6 +41,12 @@ shows that blocking keeps normality.
 * `exists_common_blockTensor_isInjective_two_of_isNormalCanonicalFormBNT` — the
   same common-blocking conclusion simultaneously for two finite BNT families.
 
+The two normal-CF-BNT statements inherit the one-copy-per-sector restriction of
+`IsNormalCanonicalFormBNT`: the input family is already separated and strictly
+ordered by representative weight modulus. These statements give common injective
+blocking for that restricted surface; they do not recover the full CPSV16 BNT
+multiplicity data with repeated copies inside one sector.
+
 ## References
 
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3 + Appendix A]
@@ -411,7 +417,12 @@ irreducible, and has primitive transfer map.  Hence each block is normal, and
 the bounded Wielandt injective-blocking theorem gives a positive injective
 blocking length for that block.  Taking the product of these finitely many
 positive lengths gives one common positive length; fixed-length injectivity
-persists at positive multiples. -/
+persists at positive multiples.
+
+**Scope restriction (one-copy-per-sector):** The hypothesis
+`IsNormalCanonicalFormBNT` is the already separated representative surface, not
+the full CPSV16 BNT multiplicity decomposition. The restriction is documented in
+`docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 theorem exists_common_blockTensor_isInjective
     [∀ k, NeZero (dim k)]
     (h : IsNormalCanonicalFormBNT (d := d) μ blocks) :
@@ -449,7 +460,13 @@ end IsNormalCanonicalFormBNT
 
 Given two normal canonical BNT block families with the same physical dimension,
 there is a single positive blocking length at which every block on both sides is
-one-site injective. -/
+one-site injective.
+
+**Scope restriction (one-copy-per-sector):** Both `IsNormalCanonicalFormBNT`
+hypotheses are already separated representative families. This theorem is a
+two-family common-blocking result for that restricted surface, not the
+source-level CPSV16 multiplicity theorem. The restriction is documented in
+`docs/paper-gaps/ft_one_copy_scope_restriction.tex`. -/
 theorem exists_common_blockTensor_isInjective_two_of_isNormalCanonicalFormBNT
     {d rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1013,6 +1013,14 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     injective. The same conclusion holds simultaneously for two finite
     normal-canonical BNT families whose blocks have positive virtual bond
     dimension.
+
+    This is a common-blocking theorem for the scope-restricted
+    one-copy-per-sector surface of Definition~\ref{def:normal_cf_bnt}. It
+    assumes that the normal-CF-BNT representative families have already been
+    selected and strictly ordered; it does not reconstruct the full CPSV16 BNT
+    sector decomposition with repeated copies inside one sector. The restriction
+    is recorded in
+    \path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}.
 \end{corollary}
 
 \begin{proof}

--- a/docs/paper-gaps/ft_one_copy_scope_restriction.tex
+++ b/docs/paper-gaps/ft_one_copy_scope_restriction.tex
@@ -152,27 +152,28 @@ sub-dominant block has $\|\mu_j\| < 1$.
 
 \section{Downstream audit status}
 
-The downstream CPSV16 surfaces that currently consume
-\leanid{IsNormalCanonicalFormBNT} have been audited against the
-one-copy-per-sector boundary. The public BNT construction API marks
-\leanid{IsNormalCanonicalFormBNT}, the constructor
-\leanid{IsNormalCanonicalFormBNT.ofSeparatedData}, the cross-overlap theorem,
-and the restricted \leanid{IsNormalCanonicalFormBNT.isBNT} theorem as scoped
-one-copy-per-sector statements. The Fundamental Theorem files using
-\leanid{IsCanonicalFormBNT} in the proportional-MPV chain carry the same
-scope marker on their public theorem surfaces.
+The downstream CPSV16 surfaces that currently consume the restricted
+normal-CF-BNT predicate have been audited against the one-copy-per-sector
+boundary.\footnote{The relevant Lean surfaces are
+    \leanid{IsNormalCanonicalFormBNT},
+    \leanid{IsNormalCanonicalFormBNT.ofSeparatedData},
+    \leanid{IsNormalCanonicalFormBNT.cross\_overlap\_tendsto\_zero},
+    \leanid{IsNormalCanonicalFormBNT.isBNT},
+    \leanid{isNormalCanonicalFormBNT\_commonRepresentativeBlocksAt},
+    \leanid{IsNormalCanonicalFormBNT.exists\_common\_blockTensor\_isInjective},
+    and
+    \leanid{exists\_common\_blockTensor\_isInjective\_two\_of\_isNormalCanonicalFormBNT}.}
+Each of these public surfaces either assumes or constructs an already chosen
+representative family, strictly ordered by weight modulus. They do not
+introduce a source-faithful canonical-form existence theorem and do not recover
+the repeated-copy sector data of the source BNT decomposition. Their docstrings
+and the corresponding Wielandt blueprint corollary therefore carry the same
+one-copy-per-sector marker.
 
-The remaining normal-CF-BNT consumers are the common-sector representative
-constructor and the uniform injective-blocking theorems:
-\leanid{isNormalCanonicalFormBNT\_commonRepresentativeBlocksAt},
-\leanid{IsNormalCanonicalFormBNT.exists\_common\_blockTensor\_isInjective},
-and
-\leanid{exists\_common\_blockTensor\_isInjective\_two\_of\_isNormalCanonicalFormBNT}.
-These statements are conditional consequences of an already chosen
-representative family. They do not introduce a new canonical-form existence
-theorem and do not recover the repeated-copy sector data of the source BNT
-decomposition. Their docstrings and the corresponding Wielandt blueprint
-corollary therefore carry the same one-copy-per-sector marker.
+This audit does not apply that marker to the sector-BNT development based on
+\leanid{IsBNTCanonicalForm}. That predicate is the paper-faithful sector
+surface used for the CPSV16 coefficient and weight-multiplicity arguments,
+where repeated copies inside one sector remain explicit.
 
 \section{Conclusion}
 

--- a/docs/paper-gaps/ft_one_copy_scope_restriction.tex
+++ b/docs/paper-gaps/ft_one_copy_scope_restriction.tex
@@ -150,6 +150,30 @@ brings the dominant-block normalization into alignment with the source
 convention. Under this normalization and the strict modulus ordering, every
 sub-dominant block has $\|\mu_j\| < 1$.
 
+\section{Downstream audit status}
+
+The downstream CPSV16 surfaces that currently consume
+\leanid{IsNormalCanonicalFormBNT} have been audited against the
+one-copy-per-sector boundary. The public BNT construction API marks
+\leanid{IsNormalCanonicalFormBNT}, the constructor
+\leanid{IsNormalCanonicalFormBNT.ofSeparatedData}, the cross-overlap theorem,
+and the restricted \leanid{IsNormalCanonicalFormBNT.isBNT} theorem as scoped
+one-copy-per-sector statements. The Fundamental Theorem files using
+\leanid{IsCanonicalFormBNT} in the proportional-MPV chain carry the same
+scope marker on their public theorem surfaces.
+
+The remaining normal-CF-BNT consumers are the common-sector representative
+constructor and the uniform injective-blocking theorems:
+\leanid{isNormalCanonicalFormBNT\_commonRepresentativeBlocksAt},
+\leanid{IsNormalCanonicalFormBNT.exists\_common\_blockTensor\_isInjective},
+and
+\leanid{exists\_common\_blockTensor\_isInjective\_two\_of\_isNormalCanonicalFormBNT}.
+These statements are conditional consequences of an already chosen
+representative family. They do not introduce a new canonical-form existence
+theorem and do not recover the repeated-copy sector data of the source BNT
+decomposition. Their docstrings and the corresponding Wielandt blueprint
+corollary therefore carry the same one-copy-per-sector marker.
+
 \section{Conclusion}
 
 The present formalization proves the proportional Fundamental Theorem in the


### PR DESCRIPTION
### Motivation

- Theorems consuming `IsNormalCanonicalFormBNT` outside the `Full/` layer inherit a one-copy-per-sector restriction from the BNT canonical form (CPSV16, `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1135–1148); this restriction must be stated explicitly wherever those theorems are exported or cited in the blueprint.
- Completes the downstream CPSV16 scope audit begun after #1840 (see paper-gap note `docs/paper-gaps/ft_one_copy_scope_restriction.tex`).

### Description

- Adds scope-restriction markers to the common-sector representative constructor and the uniform injective-blocking theorems in `MPS/BNT/Construction.lean`, `MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean`, and `MPS/CanonicalForm/SectorComparison/NormalityChain.lean`.
- Adds the corresponding scope note to the Wielandt blueprint corollary for uniform injective blocking (`blueprint/src/chapter/ch07_wielandt.tex`).
- Records the completed downstream audit status in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
- Clarifies the BNT construction prose: `IsBNTCanonicalForm` is the paper-faithful sector structure; `IsNormalCanonicalFormBNT` is the restricted, one-representative-per-sector surface.

No theorem statements or proofs are changed.

### Testing

- `lake build TNLean.MPS.BNT.Construction`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport`
- `lake build` (passes; only pre-existing periodic-overlap `sorry` warnings)
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch07_wielandt.tex docs/paper-gaps/ft_one_copy_scope_restriction.tex`
- `leanblueprint web` (passes; only pre-existing plasTeX renderer warnings)
- `git diff --check`

---
Closes #1618

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/commentary updates clarifying the one-copy-per-sector scope restriction, with no modifications to theorem statements or proofs.
>
> **Overview**
> Clarifies that `IsNormalCanonicalFormBNT` and downstream lemmas/theorems are **scope-restricted to one representative per weight-modulus class** (i.e. *one-copy-per-sector*), rather than the full CPSV16 repeated-copy sector decomposition.
>
> Adds/updates docstrings in `BNT/Construction.lean`, `SectorComparison/CommonSectorTransport.lean`, and `SectorComparison/NormalityChain.lean`, plus a matching note in the Wielandt blueprint corollary, and records the completed downstream audit status in `docs/paper-gaps/ft_one_copy_scope_restriction.tex`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb85b179f8810c5da14329acf3415c911ee465ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docstrings/prose and blueprint/paper-gap documentation, with no modifications to Lean theorem statements or proofs.
> 
> **Overview**
> Clarifies across Lean docstrings and the blueprint that `IsNormalCanonicalFormBNT`-based results are **scope-restricted to one representative per weight-modulus class (one-copy-per-sector)**, and that the paper-faithful repeated-copy sector structure lives in `IsBNTCanonicalForm`.
> 
> Adds explicit scope-restriction notes to the common-sector representative constructor and the uniform injective-blocking theorems, updates related prose in `BNT/Construction.lean`, and records the completed downstream audit status in `docs/paper-gaps/ft_one_copy_scope_restriction.tex` (mirrored in the Wielandt chapter corollary).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636c2b9c6e54f59ebe84fc56c72724baaff8e650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->