### PR TITLE
doc(PEPS): fix FT prose markers

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -698,7 +698,7 @@ If `X` and `Y` are two gauge families relating the same injective PEPS tensor
 `A` to the same tensor `B`, then their oriented endpoint actions differ by
 edge scalars `c_e` whose product around every vertex is `1`.
 
-**Local correction (balanced edge scalars):** The source states that the gauges
+**Local fix (balanced edge scalars):** The source states that the gauges
 are unique up to a multiplicative constant. On a general graph the connected
 triangle with one-dimensional bonds refutes uniqueness modulo one global scalar.
 The graph-correct quotient is uniqueness modulo vertex-balanced edge scalars;

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -782,11 +782,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     tensor. The three resulting tensors form an injective chain, so the
     one-dimensional injective comparison assigns an invertible matrix to the
     edge $e$. Repeating this for every edge and absorbing these matrices into
-    the second tensor family gives the post-absorption insertion equality
-    $\textup{eq:inj\_equal\_edge}$ of
-    \cite[Section~3]{Molnar2018NormalPEPS}. Applying the local extraction at
-    each vertex then gives one edge gauge family whose endpoint actions
-    transform the first tensor family into the second:
+    the second tensor family gives the post-absorption insertion equality of
+    \cite[Section~3]{Molnar2018NormalPEPS}: for every edge and every matrix,
+    inserting that matrix on the edge in the first PEPS gives the same state as
+    inserting it on the same edge in the modified second PEPS. Applying the
+    local extraction at each vertex then gives one edge gauge family whose
+    endpoint actions transform the first tensor family into the second:
     \begin{center}
         \TNPEPSGlobalConsistency
     \end{center}
@@ -1109,11 +1110,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     If two gauge families relate the same vertex-injective PEPS tensor to the
     same target tensor, then their edge gauges differ by nonzero scalars
     $c_e$ whose oriented product at every vertex is $1$. Thus the correct
-    graph quotient is by balanced edge scalars. The phrase ``unique up to a
-    multiplicative constant'' in the source is correct for the one-dimensional
-    chain situation, but for a general graph it must be read with this
-    vertex-balance condition; the correction is recorded in
-    \texttt{docs/paper-gaps/peps\_gauge\_edge\_scalars.tex}.
+    graph quotient is by balanced edge scalars.
+    % Correction documented in docs/paper-gaps/peps_gauge_edge_scalars.tex.
 \end{theorem}
 
 \begin{remark}


### PR DESCRIPTION
### Motivation

Issue #1854 records three prose-style corrections left after PR #1853 in the PEPS fundamental-theorem chapter and docstring.

### Description

- Replaces the source-label shorthand in the gauge-consistency blueprint statement by the mathematical insertion-equality content.
- Removes the maintainer paper-gap path from rendered blueprint theorem prose and keeps it as a LaTeX comment.
- Renames the Lean source-deviation marker from `Local correction` to the canonical `Local fix` form.

### Testing

- `lake build TNLean.PEPS.FundamentalTheorem`
- `lake build`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch13a_peps_ft.tex`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/PEPS/FundamentalTheorem.lean`
- `python3 scripts/blueprint_bibtex.py`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`

---
Closes #1854.

> [!NOTE]
> **Low Risk**
> Documentation-only wording tweaks in Lean docstrings and the LaTeX blueprint; no changes to proofs, definitions, or executable logic.
>
> **Overview**
> Tightens PEPS Fundamental Theorem documentation/prose.
>
> In `ch13a_peps_ft.tex`, expands the `Gauge consistency` theorem statement to spell out the post-absorption edge insertion equality (instead of relying on an internal label shorthand), and removes the rendered reference to `docs/paper-gaps/peps_gauge_edge_scalars.tex` from the `Gauge uniqueness modulo balanced edge scalars` theorem (kept as a LaTeX comment).
>
> In `FundamentalTheorem.lean`, renames the deviation marker heading from **"Local correction"** to the canonical **"Local fix"** in the `gauge_unique_mod_edge_scalars` docstring.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cfc86f92fc7c7bc4b5638157495e19e3c6eed6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>