### PR TITLE
doc(MPS/CanonicalForm): audit PGVWC07 existence scope

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -45,6 +45,13 @@ What is **not** yet proved here:
 
 Accordingly, this file gives reduction lemmas and explicit conditional statements,
 **not** a complete canonical-form existence theorem for arbitrary input tensors.
+Relative to PGVWC07, Theorem `Th:TIcanonical`, lines 742–763, the missing
+source-level conclusion is the single theorem that starts from an arbitrary
+translation-invariant representation and simultaneously constructs positive
+weights, unital blocks, diagonal full-rank dual fixed points, uniqueness of the
+identity fixed point for each block transfer map, and the stated bond-dimension
+bound. The audit boundary is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
 
 ## External input — Quantum Wielandt strong irreducibility ⇒ full Kraus rank
 
@@ -77,7 +84,8 @@ The iterated invariant-projection splitting in Section 2.3 (Wolf/Cirac/Verstraet
 canonical-form reduction) is formalized in `TNLean.MPS.Structure.InvariantSubspaceDecomp`.
 This external input provides:
 
-> **Perez-Garcia et al., quant-ph/0608197, Theorem 3 (lines 769–803).**
+> **Perez-Garcia et al., quant-ph/0608197, proof of Theorem
+> `Th:TIcanonical` (lines 765–833).**
 > An invariant orthogonal projection `P` on the bond space (satisfying
 > `(1-P) A_i P = 0` for all `i`) yields an MPV-equivalent two-block direct-sum
 > tensor with strictly smaller block dimensions.

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -293,7 +293,15 @@ Every nonzero block satisfies:
 * positive bond dimension;
 * nonzero weight.
 
-The MPV of `A` equals the zero-block contribution plus the weighted nonzero-block sum. -/
+The MPV of `A` equals the zero-block contribution plus the weighted nonzero-block sum.
+
+**Scope restriction (PGVWC07 canonical-form proof step):** This theorem supplies
+the all-zero-block separation and left-canonical TP gauge for nonzero
+irreducible blocks. It is not the full PGVWC07 translation-invariant canonical
+form theorem: it does not also prove the source theorem's unital orientation,
+diagonal full-rank dual fixed points, uniqueness of the identity fixed point,
+or total bond-dimension bound. The boundary is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
       (μ : Fin r → ℂ)

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -12,6 +12,8 @@ open scoped Matrix BigOperators
 This module implements the "iterate until all blocks are irreducible" step from
 Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3
 (around eq. `\label{eq:II_Aiplusk1}`).
+It also corresponds to the invariant-subspace splitting used inside
+PGVWC07, Theorem `Th:TIcanonical`, lines 765–833.
 
 Starting from an arbitrary MPS tensor `A : MPSTensor d D`, we iteratively apply
 `MPSTensor.exists_twoBlock_decomp_of_lowerZero_strict` — which produces two blocks each with
@@ -28,12 +30,16 @@ orthogonal projections. Strong induction on `D` guarantees termination.
 * Periodicity removal / Perron–Frobenius normalization.
 * Gauge normalization (CFII, left-canonical gauge).
 * Blocking to remove periodicity.
+* The positive weights, unital block orientation, diagonal full-rank dual fixed
+  points, uniqueness of the identity fixed point, and total bond-dimension bound
+  in PGVWC07, Theorem `Th:TIcanonical`, lines 742–763.
 These are separate steps in the canonical-form construction.
 
 ## References
 
 * Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3, eq. II_Aiplusk1.
-* Perez-Garcia et al., quant-ph/0608197, Theorem 3, lines 769–803.
+* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+  proof lines 765–833.
 -/
 
 namespace MPSTensor
@@ -120,6 +126,14 @@ The proof proceeds by strong induction on `D`: in the inductive step, `HasInvari
 nontrivial invariant projection `P`, which we use via
 `exists_twoBlock_decomp_of_lowerZero_strict` to split `A` into two blocks of *strictly smaller*
 bond dimension, then apply the induction hypothesis to each block.
+
+**Scope restriction (PGVWC07 canonical-form proof step):** This theorem proves
+only the recursive invariant-projection splitting from the proof of
+PGVWC07, Theorem `Th:TIcanonical`, lines 765–833. It does not prove the full
+source theorem's positive weights, unital normalization, diagonal full-rank dual
+fixed points, uniqueness of the identity fixed point, or final bond-dimension
+bound. The remaining source boundary is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
 -/
 theorem exists_irreducible_blockDecomp (A : MPSTensor d D) :
     ∃ r : ℕ, ∃ dim : Fin r → ℕ,

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -28,7 +28,35 @@ canonical form conditions.
 The reduction draws on~\cite{PerezGarcia2007Matrix}, \cite{Cirac2021Matrix},
 and~\cite[Chapter~6]{Wolf2012Quantum}.
 
-\begin{theorem}[Translation-invariant canonical form]%
+\begin{theorem}[PGVWC07 translation-invariant canonical form]%
+    \label{thm:pgvwc07_ti_canonical_form}
+    \notready
+    Let a translation-invariant MPS representation on a finite ring have bond
+    dimension $D$. Then the matrices may be decomposed as
+    \[
+        A^i =
+        \begin{pmatrix}
+            \lambda_1 A_1^i &0                 &0\\
+            0               &\lambda_2 A_2^i   &0\\
+            0               &0                 &\cdots
+        \end{pmatrix},
+    \]
+    with $1 \ge \lambda_k > 0$. For each block,
+    \[
+        \sum_i A_k^i(A_k^i)^\dagger = \Id,
+        \qquad
+        \sum_i (A_k^i)^\dagger \Lambda_k A_k^i = \Lambda_k,
+    \]
+    where $\Lambda_k$ is diagonal, positive, and full-rank. Moreover $\Id$ is
+    the only fixed point of
+    $\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$, and the total bond dimension
+    of the decomposition is at most $D$.
+
+    This is the source statement
+    of~\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
+\end{theorem}
+
+\begin{theorem}[Blocked CPSV canonical-form reduction]%
     \label{thm:cpgsv_canonical_form_source}
     \notready
     This is the canonical-form reduction of
@@ -50,10 +78,11 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
 \end{theorem}
 
-This chapter develops the constituent steps of this reduction:
+Theorem~\ref{thm:pgvwc07_ti_canonical_form} is not yet formalized. This
+chapter develops constituent steps of the PGVWC07 and CPSV reductions:
 invariant-subspace decomposition (Theorem~\ref{thm:irred_decomp}), TP gauge
 (Section~\ref{sec:tp_gauge_arbitrary}), and period-removal cyclic sectors
-(Section~\ref{sec:cyclic_sectors}). Zero-tail separation and the combined
+(Section~\ref{sec:cyclic_sectors}). All-zero-block separation and the combined
 after-blocking statement are recorded in Chapter~\ref{ch:canonical_after_blocking}
 (Theorem~\ref{thm:zero_block_separation} and
 Theorem~\ref{thm:tp_primitive_blockdecomp}).

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -96,15 +96,57 @@ hypotheses are stronger and more structured than the source theorem's
 hypotheses. Treating them as the full source theorem would import extra
 assumptions into any later argument that cites canonical-form existence.
 
+\section{Current proof-path audit}
+\label{sec:current-proof-path-audit}
+
+The earlier existence path now has the following formal pieces.
+
+\begin{enumerate}
+    \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
+          recursive invariant-projection splitting used in the proof of
+          Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an
+          arbitrary tensor and gives a finite direct sum of irreducible blocks
+          with the same matrix-product-vector coefficients. This is a faithful
+          partial proof step. It is not the full source theorem, because it does
+          not construct the weights $\lambda_j$, the unital block orientation,
+          the diagonal full-rank matrices $\Lambda^j$, the uniqueness of the
+          identity fixed point, or the final bond-dimension bound.
+
+    \item \path|MPSTensor.exists_irreducible_blockDecomp_nonzeroBlocks|
+          separates the all-zero blocks from the irreducible summands and keeps
+          the length-zero trace contribution. This matches the paper's statement
+          that zero blocks may occur, but it is still only an intermediate
+          decomposition before Perron--Frobenius normalization.
+
+    \item \path|MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail|
+          applies Perron--Frobenius normalization block by block after the
+          all-zero summands have been separated. It produces nonzero
+          irreducible blocks in the local left-canonical orientation
+          $\sum_i (B_k^i)^\dagger B_k^i = \mathbf{1}$. This is the dual
+          orientation of the unital condition in
+          Theorem~\texttt{Th:TIcanonical}; the conversion is a convention issue
+          only when the adjoint transfer map is carried along explicitly.
+
+    \item \path|MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp|
+          is a prepared-block theorem. It assumes a weighted block decomposition,
+          irreducibility, trace-preserving normalization, primitivity, pairwise
+          distinct weight moduli, nonzero weights, and positive bond dimensions.
+          It should remain a conditional corollary, not a citation target for
+          PGVWC07 Theorem~\texttt{Th:TIcanonical}.
+\end{enumerate}
+
+Thus no current \verb|\leanok| statement in the canonical-form
+chapter should be read as the full PGVWC07 translation-invariant canonical-form
+theorem. The blueprint now records the source theorem as a separate not-ready
+statement, and the checked reductions are marked as partial or scoped results.
+
 \section{Formal boundary}
 
 The currently checked primitive, peripheral-primitive, and
 normal-canonical-form reductions should therefore be read as conditional
 canonical-form theorems rather than as
 formalizations of the full source theorem.\footnote{The formal declarations are
-    \texttt{MPSTensor.isCanonicalForm\_of\_primitive},
-    \texttt{MPSTensor.isCanonicalForm\_of\_peripheralPrimitive}, and
-    \texttt{MPSTensor.exists\_normalCanonicalForm\_of\_primitive\_blockDecomp}.}
+    listed in Section~\ref{sec:current-proof-path-audit}.}
 They may be used after their hypotheses have been proved from earlier
 source-faithful reductions, but they should not be cited as giving canonical
 form directly from an arbitrary translation-invariant MPS representation.


### PR DESCRIPTION
### Motivation

- The canonical-form chapter (`blueprint/src/chapter/ch08_canonical.tex`) previously conflated partial Lean proof steps with the full PGVWC07 translation-invariant canonical-form theorem (`Th:TIcanonical`, `Papers/quant-ph_0608197/MPSarchive.tex`, lines 742–763).
- Per the faithfulness rule (CLAUDE.md), a theorem is formalized only when its Lean signature matches the source's hypothesis set; conditional reductions must not be presented as the source theorem.
- Issue #1616 requested a comparison of every `\leanok` canonical-form entry against the hypotheses of `Th:TIcanonical`, identifying which assumptions exceed the source.

### Description

- `TNLean/MPS/CanonicalForm/Existence.lean`: adds a scope-restriction note clarifying that existing results formalize partial proof steps, not the full PGVWC07 source theorem.
- `TNLean/MPS/CanonicalForm/Reduction.lean`: adds scope-restriction notes to invariant-projection reduction results marking them as PGVWC07 proof steps.
- `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`: marks the arbitrary-input TP-gauge theorem as a PGVWC07 proof step, not the canonical-form existence conclusion.
- `blueprint/src/chapter/ch08_canonical.tex`: adds a separate `\notready` blueprint entry for the exact `Th:TIcanonical` statement, distinct from the blocked CPSV reduction.
- `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`: expands the paper-gap note with an audit enumerating which formal lemmas exist and which source-level conclusions remain missing.
- No new `\lean{...}` tags are introduced; `leanblueprint checkdecls` failures are pre-existing (PEPS and parent-Hamiltonian declarations outside this scope).

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/Reduction.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake build` (passes; existing periodic-overlap `sorry` warnings remain)
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/MPS/CanonicalForm/Reduction.lean TNLean/MPS/CanonicalForm/Existence.lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch08_canonical.tex`
- `python3 scripts/blueprint_bibtex.py`
- `leanblueprint web` (passes with existing diagram-renderer warnings)

---
Closes #1616
Addresses #1613 and #1632

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/commentary clarifying theorem scope and adding an audit note; no functional logic changes to the Lean proofs.
>
> **Overview**
> Clarifies that the current Lean canonical-form pipeline formalizes **partial PGVWC07 proof steps**, not the full translation-invariant canonical-form existence theorem, by adding explicit scope-restriction notes to `Existence.lean`, `Reduction.lean`, and the arbitrary-input TP-gauge theorem in `NormalReduction/TPGauge.lean`.
>
> Updates the blueprint to include a separate *not-ready* statement of the exact PGVWC07 theorem (distinct from the blocked CPSV reduction), and expands `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex` with a proof-path audit enumerating which formal lemmas exist today and which source-level conclusions remain missing.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f2c0ac9e9ad035a25aab9ea3c3b06d4ab5ba23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->