### PR TITLE
ci(workflows): detect Claude provider limits

### DIFF
--- a/.github/workflows/claude-provider-limit-guard.yml
+++ b/.github/workflows/claude-provider-limit-guard.yml
@@ -181,11 +181,18 @@ jobs:
           now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           reenabled_any=false
 
-          get_variable() {
+          get_variable_json() {
             local variable_name="$1"
-            gh variable list \
-              --json name,value \
-              --jq ".[] | select(.name == \"$variable_name\") | .value" || true
+            gh api "repos/$GH_REPO/actions/variables/$variable_name" 2>/dev/null || true
+          }
+
+          json_field() {
+            local json="$1"
+            local field="$2"
+            if [ -z "$json" ]; then
+              return 0
+            fi
+            jq -r "$field // \"\"" <<<"$json"
           }
 
           check_switch() {
@@ -193,12 +200,38 @@ jobs:
             local until_name="$2"
             local reason_name="$3"
 
+            local switch_json
+            local until_json
+            local reason_json
             local switch_value
+            local switch_updated_at
             local disabled_until
-            switch_value="$(get_variable "$switch_name")"
-            disabled_until="$(get_variable "$until_name")"
+            local until_updated_at
+            local reason_value
+
+            switch_json="$(get_variable_json "$switch_name")"
+            until_json="$(get_variable_json "$until_name")"
+            reason_json="$(get_variable_json "$reason_name")"
+            switch_value="$(json_field "$switch_json" '.value')"
+            switch_updated_at="$(json_field "$switch_json" '.updated_at')"
+            disabled_until="$(json_field "$until_json" '.value')"
+            until_updated_at="$(json_field "$until_json" '.updated_at')"
+            reason_value="$(json_field "$reason_json" '.value')"
 
             if [ "$switch_value" != "false" ] || [ -z "$disabled_until" ]; then
+              return 0
+            fi
+
+            if [[ "$reason_value" != Provider-limit\ failure\ detected* ]]; then
+              echo "$switch_name remains disabled; no guard-owned reason was found." \
+                >> "$GITHUB_STEP_SUMMARY"
+              return 0
+            fi
+
+            if [ -n "$switch_updated_at" ] && [ -n "$until_updated_at" ] &&
+               [[ "$switch_updated_at" > "$until_updated_at" ]]; then
+              echo "$switch_name remains disabled; it was changed after the cooldown metadata." \
+                >> "$GITHUB_STEP_SUMMARY"
               return 0
             fi
 

--- a/.github/workflows/claude-provider-limit-guard.yml
+++ b/.github/workflows/claude-provider-limit-guard.yml
@@ -18,7 +18,7 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   detect-provider-limit:
@@ -89,7 +89,7 @@ jobs:
         if: steps.classify.outputs.matched == 'true'
         id: disable
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_PAT || github.token }}
           GH_REPO: ${{ github.repository }}
           SWITCH_NAME: ${{ steps.switch.outputs.switch_name }}
           UNTIL_NAME: ${{ steps.switch.outputs.until_name }}
@@ -139,7 +139,7 @@ jobs:
       - name: Comment on pull request
         if: steps.classify.outputs.matched == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_PAT || github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
           SWITCH_NAME: ${{ steps.switch.outputs.switch_name }}
@@ -153,16 +153,16 @@ jobs:
             exit 0
           fi
           body="$RUNNER_TEMP/claude-provider-limit-comment.md"
-          cat > "$body" <<EOF
-          Claude automation was paused after a provider-limit failure.
-
-          - Provider: \`$PROVIDER\`
-          - Disabled switch: \`$SWITCH_NAME=false\`
-          - Re-enable time: \`$DISABLED_UNTIL\`
-          - Source run: $RUN_URL
-
-          The scheduled guard will set the switch back to \`true\` after the cooldown.
-          EOF
+          {
+            printf '%s\n' "Claude automation was paused after a provider-limit failure."
+            printf '\n'
+            printf '%s\n' "- Provider: \`$PROVIDER\`"
+            printf '%s\n' "- Disabled switch: \`$SWITCH_NAME=false\`"
+            printf '%s\n' "- Re-enable time: \`$DISABLED_UNTIL\`"
+            printf '%s\n' "- Source run: $RUN_URL"
+            printf '\n'
+            printf '%s\n' "The scheduled guard will set the switch back to \`true\` after the cooldown."
+          } > "$body"
           gh pr comment "$PR_NUMBER" --body-file "$body"
 
   reenable-after-cooldown:
@@ -171,7 +171,7 @@ jobs:
     steps:
       - name: Re-enable expired Claude switches
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_PAT || github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/claude-provider-limit-guard.yml
+++ b/.github/workflows/claude-provider-limit-guard.yml
@@ -22,7 +22,10 @@ permissions:
 
 jobs:
   detect-provider-limit:
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure'
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-provider-limit-guard.yml
+++ b/.github/workflows/claude-provider-limit-guard.yml
@@ -1,0 +1,226 @@
+name: Claude Provider Limit Guard
+
+on:
+  workflow_run:
+    workflows:
+      - Auto Fix (Lean)
+      - Claude Code Review (Lean)
+      - Lean linter-warning auto-fix
+      - Blueprint Sync & Prose Review
+      - PR Cleanup (bot-generated)
+      - Issue Tracker
+    types: [completed]
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  detect-provider-limit:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Map workflow to switch
+        id: switch
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          set -euo pipefail
+          case "$WORKFLOW_NAME" in
+            "Auto Fix (Lean)"|"Lean linter-warning auto-fix")
+              switch_name="CLAUDE_AUTO_FIX_ENABLED"
+              until_name="CLAUDE_AUTO_FIX_DISABLED_UNTIL"
+              reason_name="CLAUDE_AUTO_FIX_DISABLE_REASON"
+              ;;
+            "Claude Code Review (Lean)"|\
+            "Blueprint Sync & Prose Review"|\
+            "PR Cleanup (bot-generated)"|\
+            "Issue Tracker")
+              switch_name="CLAUDE_REVIEW_ENABLED"
+              until_name="CLAUDE_REVIEW_DISABLED_UNTIL"
+              reason_name="CLAUDE_REVIEW_DISABLE_REASON"
+              ;;
+            *)
+              switch_name=""
+              until_name=""
+              reason_name=""
+              ;;
+          esac
+          {
+            echo "switch_name=$switch_name"
+            echo "until_name=$until_name"
+            echo "reason_name=$reason_name"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download workflow logs
+        if: steps.switch.outputs.switch_name != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/claude-run-logs"
+          curl -fsSL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$GITHUB_API_URL/repos/$REPOSITORY/actions/runs/$RUN_ID/logs" \
+            -o "$RUNNER_TEMP/claude-run-logs.zip"
+          unzip -q "$RUNNER_TEMP/claude-run-logs.zip" -d "$RUNNER_TEMP/claude-run-logs"
+
+      - name: Classify provider-limit failure
+        if: steps.switch.outputs.switch_name != ''
+        id: classify
+        run: |
+          python3 scripts/classify_claude_provider_limit.py \
+            "$RUNNER_TEMP/claude-run-logs" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Disable matching Claude switch
+        if: steps.classify.outputs.matched == 'true'
+        id: disable
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          SWITCH_NAME: ${{ steps.switch.outputs.switch_name }}
+          UNTIL_NAME: ${{ steps.switch.outputs.until_name }}
+          REASON_NAME: ${{ steps.switch.outputs.reason_name }}
+          PROVIDER: ${{ steps.classify.outputs.provider }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          set -euo pipefail
+          disabled_until="$(date -u -d '+6 hours' '+%Y-%m-%dT%H:%M:%SZ')"
+          reason="Provider-limit failure detected for ${PROVIDER} in ${WORKFLOW_NAME}: ${RUN_URL}"
+
+          gh variable set "$SWITCH_NAME" --body false
+          gh variable set "$UNTIL_NAME" --body "$disabled_until"
+          gh variable set "$REASON_NAME" --body "$reason"
+
+          {
+            echo "disabled_until=$disabled_until"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Summarize classification
+        if: steps.switch.outputs.switch_name != ''
+        env:
+          MATCHED: ${{ steps.classify.outputs.matched }}
+          CLASSIFICATION: ${{ steps.classify.outputs.json }}
+          SWITCH_NAME: ${{ steps.switch.outputs.switch_name }}
+          DISABLED_UNTIL: ${{ steps.disable.outputs.disabled_until }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Claude provider-limit guard"
+            echo
+            echo "- Workflow run: $RUN_URL"
+            echo "- Switch: \`$SWITCH_NAME\`"
+            echo "- Provider-limit match: \`$MATCHED\`"
+            if [ -n "$DISABLED_UNTIL" ]; then
+              echo "- Disabled until: \`$DISABLED_UNTIL\`"
+            fi
+            echo
+            echo '```json'
+            printf '%s\n' "$CLASSIFICATION"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on pull request
+        if: steps.classify.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
+          SWITCH_NAME: ${{ steps.switch.outputs.switch_name }}
+          PROVIDER: ${{ steps.classify.outputs.provider }}
+          DISABLED_UNTIL: ${{ steps.disable.outputs.disabled_until }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No pull request is attached to this workflow run; no comment will be posted."
+            exit 0
+          fi
+          body="$RUNNER_TEMP/claude-provider-limit-comment.md"
+          cat > "$body" <<EOF
+          Claude automation was paused after a provider-limit failure.
+
+          - Provider: \`$PROVIDER\`
+          - Disabled switch: \`$SWITCH_NAME=false\`
+          - Re-enable time: \`$DISABLED_UNTIL\`
+          - Source run: $RUN_URL
+
+          The scheduled guard will set the switch back to \`true\` after the cooldown.
+          EOF
+          gh pr comment "$PR_NUMBER" --body-file "$body"
+
+  reenable-after-cooldown:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-enable expired Claude switches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+          reenabled_any=false
+
+          get_variable() {
+            local variable_name="$1"
+            gh variable list \
+              --json name,value \
+              --jq ".[] | select(.name == \"$variable_name\") | .value" || true
+          }
+
+          check_switch() {
+            local switch_name="$1"
+            local until_name="$2"
+            local reason_name="$3"
+
+            local switch_value
+            local disabled_until
+            switch_value="$(get_variable "$switch_name")"
+            disabled_until="$(get_variable "$until_name")"
+
+            if [ "$switch_value" != "false" ] || [ -z "$disabled_until" ]; then
+              return 0
+            fi
+
+            if [[ "$disabled_until" > "$now" ]]; then
+              echo "$switch_name remains disabled until $disabled_until." >> "$GITHUB_STEP_SUMMARY"
+              return 0
+            fi
+
+            gh variable set "$switch_name" --body true
+            gh variable delete "$until_name" || true
+            gh variable delete "$reason_name" || true
+            echo "$switch_name re-enabled at $now after cooldown ending $disabled_until." \
+              >> "$GITHUB_STEP_SUMMARY"
+            reenabled_any=true
+          }
+
+          check_switch \
+            CLAUDE_AUTO_FIX_ENABLED \
+            CLAUDE_AUTO_FIX_DISABLED_UNTIL \
+            CLAUDE_AUTO_FIX_DISABLE_REASON
+          check_switch \
+            CLAUDE_REVIEW_ENABLED \
+            CLAUDE_REVIEW_DISABLED_UNTIL \
+            CLAUDE_REVIEW_DISABLE_REASON
+
+          if [ "$reenabled_any" = "false" ]; then
+            echo "No Claude switch was ready for re-enable at $now." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -434,7 +434,8 @@ blueprint, review, and prompt failures are not enough to trip the guard.
 
 - On failed completed runs of `auto-fix.yml`, `claude-code-review.yml`,
   `lean-linter-warning-autofix.yml`, `blueprint-prose-review.yml`,
-  `pr-cleanup.yml`, and `tracking-issue-sync.yml`.
+  `pr-cleanup.yml`, and `tracking-issue-sync.yml`, only when the failed run's
+  head repository is the TNLean repository itself.
 - Hourly by schedule, to re-enable switches whose cooldown has elapsed.
 - Manually through `workflow_dispatch`, which runs the same re-enable check.
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -523,9 +523,12 @@ that case it also writes one of these cooldown variables:
 | `CLAUDE_REVIEW_DISABLE_REASON` | Source run and provider for the review pause |
 
 The scheduled guard restores the corresponding switch to `true` after the
-timestamp has passed. To restore earlier, set the switch back to `true` by hand.
-Repository variable writes use `BOT_PAT` when that secret is available, falling
-back to `GITHUB_TOKEN`.
+timestamp has passed, provided the disable reason still records a
+provider-limit guard pause and the switch has not been changed after the
+cooldown metadata was written. This prevents an old cooldown timestamp from
+undoing a later manual disable. To restore earlier, set the switch back to
+`true` by hand. Repository variable writes use `BOT_PAT` when that secret is
+available, falling back to `GITHUB_TOKEN`.
 
 ### Fork Guard
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -457,7 +457,9 @@ switch, source run, and re-enable time.
 
 The log classifier is `scripts/classify_claude_provider_limit.py`. It is meant
 to be conservative: it recognizes API-limit phrases, not arbitrary appearances
-of the words "quota" or "limit" in ordinary output.
+of the words "quota" or "limit" in ordinary output. It also requires the
+matching line to identify Anthropic, Claude, or DeepSeek, so unrelated GitHub
+API throttling does not pause Claude automation.
 
 ---
 
@@ -521,6 +523,8 @@ that case it also writes one of these cooldown variables:
 
 The scheduled guard restores the corresponding switch to `true` after the
 timestamp has passed. To restore earlier, set the switch back to `true` by hand.
+Repository variable writes use `BOT_PAT` when that secret is available, falling
+back to `GITHUB_TOKEN`.
 
 ### Fork Guard
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -23,6 +23,7 @@ This repository uses [Claude Code](https://docs.anthropic.com/en/docs/claude-cod
   - [DeepSeek Mention Handler](#deepseek-mention-handler-deepseekyml)
   - [Shared CI Auto-Fix Template](#shared-ci-auto-fix-template-_ci-auto-fix-sharedyml)
   - [Shared CI Auto-Fix Template (Codex)](#shared-ci-auto-fix-template-codex-_codex-auto-fix-sharedyml)
+  - [Claude Provider Limit Guard](#claude-provider-limit-guard-claude-provider-limit-guardyml)
 - [Safety Mechanisms](#safety-mechanisms)
 - [How to Use](#how-to-use)
   - [For any PR (automatic)](#for-any-pr-automatic)
@@ -422,6 +423,44 @@ attach, shared iteration guarding, failed-job log collection, and `openai/codex-
 
 ---
 
+### Claude Provider Limit Guard (`claude-provider-limit-guard.yml`)
+
+**What it does**: Watches selected Claude-backed workflows after they fail,
+downloads the completed run logs, and classifies whether the failure was a hard
+provider limit such as an API quota, credit, or HTTP 429 limit. Ordinary Lean,
+blueprint, review, and prompt failures are not enough to trip the guard.
+
+**When it runs**:
+
+- On failed completed runs of `auto-fix.yml`, `claude-code-review.yml`,
+  `lean-linter-warning-autofix.yml`, `blueprint-prose-review.yml`,
+  `pr-cleanup.yml`, and `tracking-issue-sync.yml`.
+- Hourly by schedule, to re-enable switches whose cooldown has elapsed.
+- Manually through `workflow_dispatch`, which runs the same re-enable check.
+
+**What it disables**:
+
+- Provider-limit failures in auto-fix workflows set
+  `CLAUDE_AUTO_FIX_ENABLED=false`.
+- Provider-limit failures in review, prose-review, cleanup, or tracking
+  workflows set `CLAUDE_REVIEW_ENABLED=false`.
+- Codex workflows are not touched by this guard. They are controlled by their
+  own `CODEX_*` variables.
+
+**Cooldown path**: The guard also writes a matching
+`CLAUDE_AUTO_FIX_DISABLED_UNTIL` or `CLAUDE_REVIEW_DISABLED_UNTIL` repository
+variable, six hours after the detected failure. The scheduled job sets the
+disabled switch back to `true` once that timestamp is in the past and removes
+the cooldown metadata variables. If the failed run is attached to a pull
+request, the guard comments on that pull request with the provider, disabled
+switch, source run, and re-enable time.
+
+The log classifier is `scripts/classify_claude_provider_limit.py`. It is meant
+to be conservative: it recognizes API-limit phrases, not arbitrary appearances
+of the words "quota" or "limit" in ordinary output.
+
+---
+
 ## Safety Mechanisms
 
 These workflows have several safeguards to prevent runaway automation:
@@ -468,6 +507,20 @@ gh variable set CODEX_MENTION_ENABLED --body false
 
 Re-enable by deleting the variable or setting it to any value other than
 `false`.
+
+The Claude provider-limit guard may set `CLAUDE_AUTO_FIX_ENABLED=false` or
+`CLAUDE_REVIEW_ENABLED=false` automatically after a provider-limit failure. In
+that case it also writes one of these cooldown variables:
+
+| Variable | Meaning |
+|----------|---------|
+| `CLAUDE_AUTO_FIX_DISABLED_UNTIL` | UTC timestamp after which Claude auto-fix may be restored |
+| `CLAUDE_REVIEW_DISABLED_UNTIL` | UTC timestamp after which Claude review automation may be restored |
+| `CLAUDE_AUTO_FIX_DISABLE_REASON` | Source run and provider for the auto-fix pause |
+| `CLAUDE_REVIEW_DISABLE_REASON` | Source run and provider for the review pause |
+
+The scheduled guard restores the corresponding switch to `true` after the
+timestamp has passed. To restore earlier, set the switch back to `true` by hand.
 
 ### Fork Guard
 

--- a/scripts/classify_claude_provider_limit.py
+++ b/scripts/classify_claude_provider_limit.py
@@ -96,6 +96,8 @@ def classify(paths: list[Path], fallback_provider: str, max_excerpts: int) -> di
                 continue
             if any(pattern.search(line) for pattern in LIMIT_PATTERNS):
                 provider = detect_provider(line, fallback_provider)
+                if provider == "unknown":
+                    continue
                 provider_votes[provider] = provider_votes.get(provider, 0) + 1
                 if len(matches) < max_excerpts:
                     matches.append({"file": str(path), "provider": provider, "line": line})

--- a/scripts/classify_claude_provider_limit.py
+++ b/scripts/classify_claude_provider_limit.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Classify Claude provider-limit failures in GitHub Actions logs.
+
+The classifier is deliberately narrow.  It reports a provider-limit failure only
+for lines that look like API quota, credit, or HTTP 429 failures, so ordinary
+Lean, blueprint, or review failures do not disable automation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+PROVIDER_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("deepseek", re.compile(r"\bdeepseek\b", re.IGNORECASE)),
+    ("anthropic", re.compile(r"\banthropic\b|\bclaude\b", re.IGNORECASE)),
+]
+
+LIMIT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"\b(?:error|failed|exception|request failed|api error|status code)"
+        r"[^\n]{0,80}\b429\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b429\b[^\n]{0,80}\b(?:too many requests|rate[_ -]?limit|quota|credit)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:anthropic|claude|deepseek|api|provider)\b[^\n]{0,120}"
+        r"\b(?:rate[_ -]?limit(?:ed|s)?|too many requests|quota exceeded|"
+        r"insufficient[_ -]?quota|credit balance|usage limit|billing hard limit)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:rate[_ -]?limit(?:ed|s)?|too many requests|quota exceeded|"
+        r"insufficient[_ -]?quota|credit balance|usage limit|billing hard limit)\b"
+        r"[^\n]{0,120}\b(?:anthropic|claude|deepseek|api|provider)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:insufficient[_ -]?quota|quota exceeded|credit balance is too low|"
+        r"usage limit exceeded|billing hard limit)\b",
+        re.IGNORECASE,
+    ),
+]
+
+
+def iter_log_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_file():
+            files.append(path)
+        elif path.is_dir():
+            files.extend(p for p in path.rglob("*") if p.is_file())
+    return sorted(files)
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def clean_line(line: str) -> str:
+    line = re.sub(r"\x1b\[[0-9;]*m", "", line)
+    line = "".join(
+        ch if ch == "\t" or ch == "\n" or 32 <= ord(ch) <= 126 else " " for ch in line
+    )
+    line = re.sub(r"\s+", " ", line).strip()
+    return line[:500]
+
+
+def detect_provider(text: str, fallback: str) -> str:
+    for provider, pattern in PROVIDER_PATTERNS:
+        if pattern.search(text):
+            return provider
+    return fallback
+
+
+def classify(paths: list[Path], fallback_provider: str, max_excerpts: int) -> dict[str, object]:
+    matches: list[dict[str, str]] = []
+    provider_votes: dict[str, int] = {}
+
+    for path in iter_log_files(paths):
+        text = read_text(path)
+        if not text:
+            continue
+        for raw_line in text.splitlines():
+            line = clean_line(raw_line)
+            if not line:
+                continue
+            if any(pattern.search(line) for pattern in LIMIT_PATTERNS):
+                provider = detect_provider(line, fallback_provider)
+                provider_votes[provider] = provider_votes.get(provider, 0) + 1
+                if len(matches) < max_excerpts:
+                    matches.append({"file": str(path), "provider": provider, "line": line})
+
+    matched = bool(provider_votes)
+    provider = fallback_provider
+    if provider_votes:
+        provider = max(provider_votes.items(), key=lambda item: item[1])[0]
+
+    return {
+        "matched": matched,
+        "category": "provider-limit" if matched else "none",
+        "provider": provider,
+        "match_count": sum(provider_votes.values()),
+        "excerpts": matches,
+    }
+
+
+def write_github_output(path: Path, result: dict[str, object]) -> None:
+    def write_one(name: str, value: str) -> None:
+        delimiter = f"__{name}_EOF__"
+        with path.open("a", encoding="utf-8") as out:
+            out.write(f"{name}<<{delimiter}\n")
+            out.write(value)
+            out.write(f"\n{delimiter}\n")
+
+    write_one("matched", "true" if result["matched"] else "false")
+    write_one("category", str(result["category"]))
+    write_one("provider", str(result["provider"]))
+    write_one("match_count", str(result["match_count"]))
+    write_one("json", json.dumps(result, sort_keys=True))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path, help="Log files or directories to inspect.")
+    parser.add_argument("--provider", default="unknown", help="Provider fallback when logs do not name it.")
+    parser.add_argument("--max-excerpts", type=int, default=5, help="Maximum evidence lines to report.")
+    parser.add_argument("--github-output", type=Path, help="Optional GITHUB_OUTPUT file.")
+    args = parser.parse_args()
+
+    result = classify(args.paths, args.provider, args.max_excerpts)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if args.github_output:
+        write_github_output(args.github_output, result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Issue #1250 requires a stateful detection mechanism: when a Claude-backed workflow encounters provider quota exhaustion or an HTTP 429 rate-limit error, the relevant repository variable (`CLAUDE_AUTO_FIX_ENABLED` or `CLAUDE_REVIEW_ENABLED`) should be automatically disabled and a timed re-enable arranged.
- Follow-up from #1246 and #1249, which fixed the immediate skip-before-build behavior; this addresses the separate stateful quota-detection part.

### Description

- Added `.github/workflows/claude-provider-limit-guard.yml`: a `workflow_run`-triggered guard that downloads run logs on failure, classifies them via the script below, and sets the relevant repository variable to `false` with six-hour cooldown metadata (`*_DISABLED_UNTIL`, `*_DISABLE_REASON`); a scheduled job re-enables variables once cooldowns expire.
- Added `scripts/classify_claude_provider_limit.py`: a log classifier that identifies quota, credit, and HTTP 429 provider-limit failures and returns `provider-limit` or `none`.
- Modified `docs/ci-automation.md`: documents the guard, switch mapping, cooldown variables, and manual recovery path.
- The guard maps auto-fix failures to `CLAUDE_AUTO_FIX_ENABLED=false` and review/prose/cleanup/tracking failures to `CLAUDE_REVIEW_ENABLED=false`; Codex workflow variables are not altered.

### Testing

- `python3 -m py_compile scripts/classify_claude_provider_limit.py`
- `actionlint .github/workflows/claude-provider-limit-guard.yml`
- `git diff --check`
- Positive classifier test: `DeepSeek API error: 429 too many requests` classified as `provider-limit`.
- Negative classifier test: Lean unsolved-goal output and prose mentioning quota/limit classified as `none`.

---
Closes #1250

> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Actions workflow that can automatically toggle repository variables and comment on PRs based on log classification, which could unintentionally pause automation if the matcher is too broad or logs fail to download/parse correctly.
> 
> **Overview**
> Adds a new `claude-provider-limit-guard.yml` workflow that watches specific Claude-backed workflows on failure, downloads their run logs, and uses a new conservative classifier (`scripts/classify_claude_provider_limit.py`) to detect API quota/credit/HTTP 429 provider-limit errors.
> 
> On a match, it automatically flips the relevant repository kill switch (`CLAUDE_AUTO_FIX_ENABLED` or `CLAUDE_REVIEW_ENABLED`) to `false`, writes cooldown metadata (`*_DISABLED_UNTIL` and `*_DISABLE_REASON`) for a 6-hour pause, and comments on the associated PR when present; a scheduled/dispatch job later re-enables switches once cooldowns expire. Documentation (`docs/ci-automation.md`) is updated to describe the guard, switch mapping, and recovery variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77cea63036d86a8744ecf0b1e7d32266c137af97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Actions workflow that can automatically flip repository variables (and comment on PRs) based on log classification; misclassification or log-download issues could unintentionally pause Claude automation.
> 
> **Overview**
> Introduces a new **Claude provider-limit guard** workflow (`claude-provider-limit-guard.yml`) that watches failures from selected Claude-backed workflows, downloads run logs, and disables either `CLAUDE_AUTO_FIX_ENABLED` or `CLAUDE_REVIEW_ENABLED` for a 6-hour cooldown when a provider-limit (quota/credit/HTTP 429) is detected; it also posts a PR comment when a PR is attached.
> 
> Adds `scripts/classify_claude_provider_limit.py`, a conservative log classifier that searches for provider-identified limit errors and emits structured results via `GITHUB_OUTPUT`, plus scheduled/dispatch logic to automatically re-enable switches once cooldown metadata expires. Documentation updates (`docs/ci-automation.md`) describe the new guard, switch mapping, and cooldown variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d199ed01735fcd03bfc403a4ddf1687df363182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->