### PR TITLE
doc(ch5): refresh QPF and Schwarz audit

### DIFF
--- a/TNLean/Channel/Schwarz/OperatorMonotone.lean
+++ b/TNLean/Channel/Schwarz/OperatorMonotone.lean
@@ -19,9 +19,9 @@ Corollary 5.2 from the operator Jensen inequality
 (`OperatorConvexity.lean`).
 
 **Status note:** The Corollary 5.2 theorems in this file depend on Jensen-type lemmas
-imported from `OperatorConvexity.lean` that are currently `sorry` placeholders.
-They should be understood as conditional on those axioms and are not yet fully
-verified Lean theorems.
+imported from `OperatorConvexity.lean` that are proved from explicit axioms in
+`TNLean.Axioms.OperatorConvexity`. They should be understood as conditional on
+those matrix-analysis inputs and are not yet derived from Mathlib theorems alone.
 
 ### Proof strategy for Corollary 5.2
 

--- a/TNLean/Channel/Schwarz/OperatorMonotone.lean
+++ b/TNLean/Channel/Schwarz/OperatorMonotone.lean
@@ -19,9 +19,9 @@ Corollary 5.2 from the operator Jensen inequality
 (`OperatorConvexity.lean`).
 
 **Status note:** The Corollary 5.2 theorems in this file depend on Jensen-type lemmas
-imported from `OperatorConvexity.lean` that are proved from explicit axioms in
-`TNLean.Axioms.OperatorConvexity`. They should be understood as conditional on
-those matrix-analysis inputs and are not yet derived from Mathlib theorems alone.
+imported from `OperatorConvexity.lean` that are proved from four explicit
+operator-Jensen and Lieb concavity axioms. They should be understood as conditional
+on those matrix-analysis inputs and are not yet derived from Mathlib theorems alone.
 
 ### Proof strategy for Corollary 5.2
 

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -61,7 +61,8 @@ tensor family, the proof obtains the equality labelled `eq:inj_equal_edge`:
 for every edge and every matrix `X`, inserting `X` on that edge in the first
 PEPS gives the same state as inserting `X` on the same edge in the modified
 second PEPS. Blocking one vertex against its complement and applying
-`inj_equal_tensors_2` then gives `A_v = λ_v • Btilde_v`; the scalars `λ_v` are
+`inj_equal_tensors_2` then gives $A_v = \lambda_v \tilde{B}_v$; the scalars
+$\lambda_v$ are
 absorbed into the edge gauges.
 
 ## References

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -61,7 +61,7 @@ tensor family, the proof obtains the equality labelled `eq:inj_equal_edge`:
 for every edge and every matrix `X`, inserting `X` on that edge in the first
 PEPS gives the same state as inserting `X` on the same edge in the modified
 second PEPS. Blocking one vertex against its complement and applying
-`inj_equal_tensors_2` then gives `A_v = λ_v • B̃_v`; the scalars `λ_v` are
+`inj_equal_tensors_2` then gives `A_v = λ_v • Btilde_v`; the scalars `λ_v` are
 absorbed into the edge gauges.
 
 ## References

--- a/audits/2026-05-20_issue322_ch5_qpf_schwarz_status.md
+++ b/audits/2026-05-20_issue322_ch5_qpf_schwarz_status.md
@@ -1,0 +1,71 @@
+# Issue #322 status audit: QPF and Schwarz chapters
+
+Date: 2026-05-20.
+
+This audit refreshes issue #322 against current `main`
+(`465dfc171c64274d03e698bb3bb0aa75f9a66b7c`).  The older comments on the
+issue were useful at the time, but several of their concrete findings have
+since changed.
+
+## QPF chapter
+
+The QPF source files are still the four files under `TNLean/QPF/`, and they
+are free of `sorry` and `axiom`.
+
+The Chapter 5a blueprint already recorded the injective-tensor QPF theorem and
+the positive-definite fixed-point and uniqueness ingredients.  This audit adds
+the two remaining irreducible-transfer-map variants that were identified in the
+April 2026 audit comments:
+
+- `MPSTensor.posSemidef_fixedPoint_unique_of_irreducible`;
+- `MPSTensor.quantum_perron_frobenius_irreducible`.
+
+Both are statement-level and proof-level complete in Lean.
+
+## Schwarz chapter
+
+The Schwarz source area has expanded beyond the older 12-file count.  Current
+`TNLean/Channel/Schwarz/` contains 21 Lean files, counting the split
+`PositiveOnAbelian/` subdirectory.
+
+Current status:
+
+- The Kadison--Schwarz, two-positive, Douglas factorization, multiplicative
+  domain, normal/subnormal Schwarz, positive-map order, and Wolf Example 5.3
+  entries are still recorded in `blueprint/src/chapter/ch05_schwarz.tex`.
+- `PositiveOnAbelian.lean` is no longer a 1042-line monolith.  The public
+  synopsis file has 46 lines, and the proof is split across
+  `PositiveOnAbelian/Basic.lean`, `PositiveOnAbelian/Characterization.lean`,
+  and `PositiveOnAbelian/Consequences.lean`.
+- The operator Jensen, trace convexity, and Lieb concavity material is no
+  longer missing from the blueprint.  It is now collected in
+  `blueprint/src/chapter/ch17_operator_convexity.tex`, which is imported by
+  `blueprint/src/content.tex`, and Chapter 5b explicitly points the reader to
+  that chapter.
+
+The remaining inputs in this area that are not proved from Mathlib alone are
+not `sorry` proofs in `TNLean/Channel/Schwarz/OperatorMonotone.lean`.  They
+are the four explicit axioms in `TNLean/Axioms/OperatorConvexity.lean`:
+
+- `posMap_rpow_concave_jensen`;
+- `posMap_rpow_convex_jensen`;
+- `posMap_log_concave_jensen`;
+- `lieb_concavity_axiom`.
+
+The corresponding source statements are marked `\notready` in
+`blueprint/src/chapter/ch17_operator_convexity.tex`.  The map-form corollaries
+in the Schwarz namespace are statement-level `\leanok`, but their proofs depend
+on these cited inputs.
+
+## Tracker status
+
+Issue #322 can now be closed as a Chapter 5 audit issue after this refresh is
+merged.  The mathematical proof obligations that remain are more accurately
+tracked by:
+
+- #138, for the Wolf Chapter 5 operator-convexity and monotonicity route;
+- #21, for the broader Wolf Chapter 5 Schwarz tracking issue.
+
+The old requests to add missing operator-convexity blueprint entries and to
+split `PositiveOnAbelian.lean` have both been superseded by current repository
+state.

--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -286,9 +286,9 @@ and~\cite{Evans1978Spectral}.
     \leanok
     \uses{def:irreducible_cp, def:transfer_map, thm:psd_fp_exists,
         thm:psd_fp_pd_irred, thm:psd_fp_unique_irred}
-    Assume $D\ge 1$. Let $A$ be an MPS tensor whose transfer map is irreducible
-    and whose adjoint normalization satisfies
-    $\sum_i (A^i)^\dagger A^i=\Id$.
+    Assume $D\ge 1$. Let $A$ be an MPS tensor such that its transfer map is
+    irreducible and $\sum_i (A^i)^\dagger A^i=\Id$ (so that $\E_A$ is
+    trace-preserving).
     Then $\E_A$ has a unique positive definite fixed point, up to scalar
     multiple.
 \end{theorem}

--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -178,6 +178,22 @@ and~\cite{Evans1978Spectral}.
     matrix $H = (S^\dagger)^{-1} \sigma S^{-1}$.
 \end{remark}
 
+\begin{theorem}[Irreducible fixed-point uniqueness]\label{thm:psd_fp_unique_irred}
+    \lean{MPSTensor.posSemidef_fixedPoint_unique_of_irreducible}
+    \leanok
+    \uses{def:irreducible_cp, def:transfer_map, thm:psd_fp_pd_irred}
+    Let $A$ be an MPS tensor whose transfer map is irreducible.
+    If $\rho,\sigma\ge 0$ are fixed points of $\E_A$, and if
+    $\rho$ is nonzero, then $\sigma=c\rho$ for some scalar $c$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The irreducible positive-definiteness theorem
+    (Theorem~\ref{thm:psd_fp_pd_irred}) upgrades every nonzero positive
+    semidefinite fixed point to a positive definite one.  The same minimal
+    eigenvalue argument used in Theorem~\ref{thm:psd_fp_unique} then applies.
+\end{proof}
+
 \begin{theorem}[Uniqueness of positive eigenvalue for irreducible CP maps]%
     \label{thm:eigenvalue_unique_irred}
     \lean{eigenvalue_unique_of_irreducible_cp}
@@ -262,6 +278,26 @@ and~\cite{Evans1978Spectral}.
     \uses{thm:psd_fp_exists, thm:psd_fp_pd, thm:psd_fp_unique}
     Combine Theorems~\ref{thm:psd_fp_exists},~\ref{thm:psd_fp_pd},
     and~\ref{thm:psd_fp_unique}.
+\end{proof}
+
+\begin{theorem}[Quantum Perron--Frobenius for irreducible transfer maps]
+    \label{thm:qpf_irreducible}
+    \lean{MPSTensor.quantum_perron_frobenius_irreducible}
+    \leanok
+    \uses{def:irreducible_cp, def:transfer_map, thm:psd_fp_exists,
+        thm:psd_fp_pd_irred, thm:psd_fp_unique_irred}
+    Assume $D\ge 1$. Let $A$ be an MPS tensor whose transfer map is irreducible
+    and whose adjoint normalization satisfies
+    $\sum_i (A^i)^\dagger A^i=\Id$.
+    Then $\E_A$ has a unique positive definite fixed point, up to scalar
+    multiple.
+\end{theorem}
+
+\begin{proof}\leanok
+    Existence is the channel fixed-point theorem
+    (Theorem~\ref{thm:psd_fp_exists}).  Irreducibility upgrades the fixed point
+    to positive definite, and Theorem~\ref{thm:psd_fp_unique_irred} gives
+    uniqueness up to scalar multiple.
 \end{proof}
 
 \section{Right- and left-canonical gauges}


### PR DESCRIPTION
### Motivation

- Issue LionSR/TNLean#322 tracks the alignment of the Chapter 5 (QPF and Schwarz inequalities) blueprint against the Lean source; this PR brings the audit record current with `main` as of 2026-05-20.
- The Chapter 5a blueprint was missing entries for two irreducible-transfer-map fixed-point results now present in `TNLean/QPF/`.
- The status note in `OperatorMonotone.lean` referenced `sorry` placeholders for Jensen inequality inputs that had since been replaced by explicit axioms in `TNLean.Axioms.OperatorConvexity`.

### Description

- `blueprint/src/chapter/ch05_qpf.tex`: adds `\lean{}` entries for `MPSTensor.posSemidef_fixedPoint_unique_of_irreducible` and `MPSTensor.quantum_perron_frobenius_irreducible` (the two irreducible-transfer-map QPF results absent from the chapter); fixes a missing trailing newline.
- `TNLean/Channel/Schwarz/OperatorMonotone.lean`: updates the stale inline status note (3-line diff) to record that Jensen convexity inputs are now sourced from explicit axioms in `TNLean.Axioms.OperatorConvexity`, not `sorry` proofs.
- `audits/2026-05-20_issue322_ch5_qpf_schwarz_status.md`: new audit document recording that operator-convexity and Lieb material resides in Chapter 17 with `\notready` source inputs, that `PositiveOnAbelian` has been split, and that the remaining external inputs in `OperatorMonotone.lean` are explicit axioms.

### Testing

- `git diff --check` passed (no whitespace errors).
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch05_qpf.tex blueprint/src/chapter/ch05_schwarz.tex blueprint/src/chapter/ch17_operator_convexity.tex` ran without new errors.
- `lake env lean TNLean/Channel/Schwarz/OperatorMonotone.lean` succeeded.
- `lake env lean TNLean/QPF/Primitive.lean` succeeded.
- `cd blueprint && leanblueprint web` succeeded (existing plasTeX/bibliography warnings only).
- `leanblueprint checkdecls` was not run locally; `blueprint/lean_decls` is absent in this worktree and is generated by CI.

---
Addresses LionSR/TNLean#322

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/blueprint updates and a small comment clarification, with no functional Lean logic modified.
> 
> **Overview**
> Refreshes the Chapter 5 audit trail and blueprint to match current Lean sources.
> 
> Adds missing Chapter 5a blueprint statements for the irreducible-transfer-map results `MPSTensor.posSemidef_fixedPoint_unique_of_irreducible` and `MPSTensor.quantum_perron_frobenius_irreducible`, and fixes minor LaTeX formatting/newline issues. Updates `OperatorMonotone.lean`’s status note to reflect that its Jensen inputs are now **explicit axioms** (not `sorry` placeholders), and introduces a new audit markdown file documenting the updated QPF/Schwarz status and remaining axiom dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d56239ebb43a9dcb4d6ebc404438b67efccc8f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->