### PR TITLE
refactor(MPS/FT/SectorBNT): factor matched-weight gauge assembly

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
+import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch
 import TNLean.MPS.FundamentalTheorem.SectorBNT.WeightEquiv
 import TNLean.MPS.FundamentalTheorem.Multi
 
@@ -187,6 +188,61 @@ theorem sector_bnt_global_gauge_of_matched_weights
             Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
               (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
             rw [hLeft]
+
+/-- **Conditional proportional global gauge from matched copy weights.**
+
+For proportional MPV families, the proportional sector-matching theorem supplies
+the matched BNT basis, unit phases, and block gauges of CPSV16 §II.C lines
+1184--1186. If the remaining coefficient-comparison step supplies copy
+permutations whose weights obey the same phases, then the direct-sum gauge
+assembly of lines 1189--1192 follows.
+
+This theorem isolates the exact residual input for the proportional
+global-gauge upgrade: the copy-weight identity. -/
+theorem ft_sector_bnt_proportional_global_gauge_of_weight_data
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
+    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
+      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+      (ζ : Fin Q.basisCount → ℂ)
+      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
+      (∀ (k : Fin Q.basisCount) (i : Fin d),
+        Q.basis k i =
+          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
+      ∀ (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))),
+        (∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
+          Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ k q)) →
+        ∃ X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ,
+          X = globalGaugeOfBlocks (matched_block_gauge (Q := Q) Xblock) ∧
+          ∀ i : Fin d,
+            toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis i =
+              (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
+                toTensorFromBlocks (d := d)
+                  (μ := matched_p_weight (P := P) (Q := Q) β τ)
+                  (matched_p_basis (P := P) (Q := Q) β hDim) i *
+                (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
+                  Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                    (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
+  classical
+  obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, _hMpv⟩ :=
+    ft_sector_bnt_proportional_sector_match_witnesses
+      (P := P) (Q := Q) hP hQ hUnitP hUnitQ hProp
+  refine ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ?_⟩
+  intro τ hWeight
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
+    intro k hzero
+    have hnorm := hζ_norm k
+    simp [hzero] at hnorm
+  exact sector_bnt_global_gauge_of_matched_weights
+    (P := P) (Q := Q) β hDim τ ζ Xblock hζ_ne hConj hWeight
 
 /-- **BNT equal-MPV sector-data theorem (CPSV16 §II.C lines 1184–1188).**
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -78,7 +78,7 @@ noncomputable def matched_block_gauge {Q : SectorDecomposition d}
 
 /-- **Global block gauge from matched sector and weight data.**
 
-Assume the sectors of two BNT decompositions have already been matched, and
+Assume the sectors of two sector decompositions have already been matched, and
 assume that the block gauges, phases, and copy-weight identities all use the
 same phases. Then the flattened `Q`-tensor is obtained by conjugating the
 matched-coordinate `P`-tensor by the direct sum

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -76,6 +76,118 @@ noncomputable def matched_block_gauge {Q : SectorDecomposition d}
   change GL (Fin (Q.basisDim (Q.flatIndexEquiv.symm s).1)) ℂ
   exact Xblock (Q.flatIndexEquiv.symm s).1
 
+/-- **Global block gauge from matched sector and weight data.**
+
+Assume the sectors of two BNT decompositions have already been matched, and
+assume that the block gauges, phases, and copy-weight identities all use the
+same phases. Then the flattened `Q`-tensor is obtained by conjugating the
+matched-coordinate `P`-tensor by the direct sum
+`⊕_k (𝟙_{r_k} ⊗ X_k)`.
+
+This is the pure assembly part of CPSV16 §II.C lines 1189–1192. It does not
+prove the coefficient comparison that supplies the weight identities. -/
+theorem sector_bnt_global_gauge_of_matched_weights
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
+    (ζ : Fin Q.basisCount → ℂ)
+    (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ)
+    (hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0)
+    (hConj : ∀ (k : Fin Q.basisCount) (i : Fin d),
+      Q.basis k i =
+        ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+          (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+          (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+            Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ)))
+    (hWeight : ∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
+      Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ k q)) :
+    ∃ X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ,
+      X = globalGaugeOfBlocks (matched_block_gauge (Q := Q) Xblock) ∧
+      ∀ i : Fin d,
+        toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis i =
+          (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
+            toTensorFromBlocks (d := d)
+              (μ := matched_p_weight (P := P) (Q := Q) β τ)
+              (matched_p_basis (P := P) (Q := Q) β hDim) i *
+            (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
+              Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
+  classical
+  let μP : Fin Q.totalCopies → ℂ := matched_p_weight (P := P) (Q := Q) β τ
+  let AP : (s : Fin Q.totalCopies) → MPSTensor d (Q.flatDim s) :=
+    matched_p_basis (P := P) (Q := Q) β hDim
+  let Xcoord : (s : Fin Q.totalCopies) → GL (Fin (Q.flatDim s)) ℂ :=
+    matched_block_gauge (Q := Q) Xblock
+  have hWeighted : ∀ (s : Fin Q.totalCopies) (i : Fin d),
+      (Q.flatWeight s) • Q.flatBasis s i =
+        (Xcoord s : Matrix (Fin (Q.flatDim s)) (Fin (Q.flatDim s)) ℂ) *
+          ((μP s) • AP s i) *
+          (((Xcoord s)⁻¹ : GL (Fin (Q.flatDim s)) ℂ) :
+            Matrix (Fin (Q.flatDim s)) (Fin (Q.flatDim s)) ℂ) := by
+    intro s i
+    let x := Q.flatIndexEquiv.symm s
+    let k : Fin Q.basisCount := x.1
+    let q : Fin (Q.copies k) := x.2
+    have hμ : μP s = Q.weight k q * ζ k := by
+      have hw := hWeight k q
+      change P.weight (β k) (τ k q) = Q.weight k q * ζ k
+      calc
+        P.weight (β k) (τ k q) = ζ k * Q.weight k q := by
+          rw [hw, ← mul_assoc, mul_inv_cancel₀ (hζ_ne k), one_mul]
+        _ = Q.weight k q * ζ k := by ring
+    change (Q.weight k q) • Q.basis k i =
+      (Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+        ((μP s) • (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i) *
+        (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+          Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ)
+    rw [hConj k i, hμ]
+    simp [smul_smul, Matrix.mul_assoc, Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
+  have hFormula :=
+    toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
+      (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
+      (A := fun s i => μP s • AP s i)
+      (B := fun s i => Q.flatWeight s • Q.flatBasis s i)
+      Xcoord hWeighted
+  have hLeft :
+      toTensorFromBlocks (d := d) (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
+        (fun s i => μP s • AP s i) =
+        toTensorFromBlocks (d := d) (μ := μP) AP := by
+    funext i
+    simp [toTensorFromBlocks]
+  have hRight :
+      toTensorFromBlocks (d := d) (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
+        (fun s i => Q.flatWeight s • Q.flatBasis s i) =
+        toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis := by
+    funext i
+    simp [toTensorFromBlocks]
+  refine ⟨globalGaugeOfBlocks Xcoord, rfl, ?_⟩
+  intro i
+  calc
+    toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis i =
+        toTensorFromBlocks (d := d) (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
+          (fun s i => Q.flatWeight s • Q.flatBasis s i) i := by
+            rw [hRight]
+    _ = (globalGaugeOfBlocks Xcoord : Matrix
+            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
+          toTensorFromBlocks (d := d) (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
+            (fun s i => μP s • AP s i) i *
+          (((globalGaugeOfBlocks Xcoord)⁻¹ :
+              GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
+            Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+              (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := hFormula i
+    _ = (globalGaugeOfBlocks Xcoord : Matrix
+            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
+          toTensorFromBlocks (d := d) (μ := μP) AP i *
+          (((globalGaugeOfBlocks Xcoord)⁻¹ :
+              GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
+            Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+              (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
+            rw [hLeft]
+
 /-- **BNT equal-MPV sector-data theorem (CPSV16 §II.C lines 1184–1188).**
 
 If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
@@ -266,79 +378,10 @@ theorem ft_sector_bnt_equal_global_gaugePos
     have hpoint := (hWeightData k).choose_spec.choose_spec
       ((hWeightData k).choose_spec.choose.symm q)
     simpa [τ] using hpoint
-  let μP : Fin Q.totalCopies → ℂ := matched_p_weight (P := P) (Q := Q) β τ
-  let AP : (s : Fin Q.totalCopies) → MPSTensor d (Q.flatDim s) :=
-    matched_p_basis (P := P) (Q := Q) β hDim
-  let Xcoord : (s : Fin Q.totalCopies) → GL (Fin (Q.flatDim s)) ℂ :=
-    matched_block_gauge (Q := Q) Xblock
-  have hWeighted : ∀ (s : Fin Q.totalCopies) (i : Fin d),
-      (Q.flatWeight s) • Q.flatBasis s i =
-        (Xcoord s : Matrix (Fin (Q.flatDim s)) (Fin (Q.flatDim s)) ℂ) *
-          ((μP s) • AP s i) *
-          (((Xcoord s)⁻¹ : GL (Fin (Q.flatDim s)) ℂ) :
-            Matrix (Fin (Q.flatDim s)) (Fin (Q.flatDim s)) ℂ) := by
-    intro s i
-    let x := Q.flatIndexEquiv.symm s
-    let k : Fin Q.basisCount := x.1
-    let q : Fin (Q.copies k) := x.2
-    have hμ : μP s = Q.weight k q * ζ k := by
-      have hw := hWeight k q
-      change P.weight (β k) (τ k q) = Q.weight k q * ζ k
-      calc
-        P.weight (β k) (τ k q) = ζ k * Q.weight k q := by
-          rw [hw, ← mul_assoc, mul_inv_cancel₀ (hζ_ne k), one_mul]
-        _ = Q.weight k q * ζ k := by ring
-    change (Q.weight k q) • Q.basis k i =
-      (Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
-        ((μP s) • (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i) *
-        (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
-          Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ)
-    rw [hConj k i, hμ]
-    simp [smul_smul, Matrix.mul_assoc, Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
-  have hFormula :=
-    toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
-      (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
-      (A := fun s i => μP s • AP s i)
-      (B := fun s i => Q.flatWeight s • Q.flatBasis s i)
-      Xcoord hWeighted
-  have hLeft :
-      toTensorFromBlocks (d := d) (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
-        (fun s i => μP s • AP s i) =
-        toTensorFromBlocks (d := d) (μ := μP) AP := by
-    funext i
-    simp [toTensorFromBlocks]
-  have hRight :
-      toTensorFromBlocks (d := d) (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
-        (fun s i => Q.flatWeight s • Q.flatBasis s i) =
-        toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis := by
-    funext i
-    simp [toTensorFromBlocks]
-  refine ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, hWeight, ?_⟩
-  refine ⟨globalGaugeOfBlocks Xcoord, rfl, ?_⟩
-  intro i
-  calc
-    toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis i =
-        toTensorFromBlocks (d := d) (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
-          (fun s i => Q.flatWeight s • Q.flatBasis s i) i := by
-            rw [hRight]
-    _ = (globalGaugeOfBlocks Xcoord : Matrix
-            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
-          toTensorFromBlocks (d := d) (μ := fun _ : Fin Q.totalCopies => (1 : ℂ))
-            (fun s i => μP s • AP s i) i *
-          (((globalGaugeOfBlocks Xcoord)⁻¹ :
-              GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
-            Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-              (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := hFormula i
-    _ = (globalGaugeOfBlocks Xcoord : Matrix
-            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
-          toTensorFromBlocks (d := d) (μ := μP) AP i *
-          (((globalGaugeOfBlocks Xcoord)⁻¹ :
-              GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
-            Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-              (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
-            rw [hLeft]
+  obtain ⟨X, hXdef, hGauge⟩ :=
+    sector_bnt_global_gauge_of_matched_weights
+      (P := P) (Q := Q) β hDim τ ζ Xblock hζ_ne hConj hWeight
+  exact ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, hWeight, X, hXdef, hGauge⟩
 
 /-- Reformulation for the all-length `SameMPV₂` form. -/
 theorem ft_sector_bnt_equal_global_gauge

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -61,9 +61,8 @@ tensor family, the proof obtains the equality labelled `eq:inj_equal_edge`:
 for every edge and every matrix `X`, inserting `X` on that edge in the first
 PEPS gives the same state as inserting `X` on the same edge in the modified
 second PEPS. Blocking one vertex against its complement and applying
-`inj_equal_tensors_2` then gives $A_v = \lambda_v \tilde{B}_v$; the scalars
-$\lambda_v$ are
-absorbed into the edge gauges.
+`inj_equal_tensors_2` then gives $A_v = \lambda_v \cdot \tilde{B}_v$; the
+scalars $\lambda_v$ are absorbed into the edge gauges.
 
 ## References
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1339,6 +1339,43 @@ BNT basis.
     gauge.
 \end{proof}
 
+\begin{theorem}[Conditional proportional global gauge from copy weights]%
+    \label{thm:sector_bnt_proportional_global_gauge_of_weight_data}
+    \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_weight_data}
+    \leanok
+    \uses{thm:sector_bnt_proportional_sector_match_witnesses,
+        thm:sector_bnt_global_gauge_of_matched_weights}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
+    eventually nonzero proportional MPV families. Assume that every sector of
+    $P$ and every sector of $Q$ has at least one copy weight of modulus $1$.
+    Then there are a bijection $\beta:J(Q)\simeq J(P)$, bond-dimension
+    equalities, unit-modulus phases $\zeta_k$, and block gauges $X_k$ such
+    that
+    \[
+        Q_k^i=\zeta_k X_kP_{\beta(k)}^iX_k^{-1}.
+    \]
+    Moreover, if copy permutations $\tau_k$ satisfy
+    \[
+        \nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)},
+    \]
+    then the flattened $Q$-tensor is obtained from the matched-coordinate
+    $P$-tensor by the block-diagonal gauge
+    \[
+        X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
+    \]
+    Thus, after the remaining proportional coefficient comparison supplies
+    the displayed copy-weight identities, the direct-sum gauge assembly of
+    \cite[\S~II.C, lines 1189--1192]{Cirac2017MPDO_AnnPhys} follows.
+\end{theorem}
+
+\begin{proof}\leanok
+    The proportional sector-matching theorem supplies $\beta$, the
+    bond-dimension equalities, the phases, and the block gauges. The
+    unit-modulus conclusion gives nonzero phases. With the displayed
+    copy-weight identities as input, apply
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
+\end{proof}
+
 \begin{theorem}[Full-basis global gauge in matched coordinates]%
     \label{thm:sector_bnt_equal_global_gauge}
     \lean{MPSTensor.ft_sector_bnt_equal_global_gauge}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1299,6 +1299,47 @@ BNT basis.
     of the corresponding coefficients for all sufficiently large lengths.
 \end{proof}
 
+\begin{theorem}[Global gauge from matched sector and weight data]%
+    \label{thm:sector_bnt_global_gauge_of_matched_weights}
+    \lean{MPSTensor.sector_bnt_global_gauge_of_matched_weights}
+    \leanok
+    \uses{def:sector_bnt_cf,
+        lem:tensor_from_blocks_globalGauge_conj}
+    Suppose that the sectors of two BNT decompositions $P$ and $Q$ are matched
+    by a bijection $\beta:J(Q)\simeq J(P)$, with bond-dimension equalities,
+    copy permutations $\tau_k$, nonzero phases $\zeta_k$, and block gauges
+    $X_k$. If, for every sector $k$, copy $q$, and physical index $i$,
+    \[
+        Q_k^i
+        =
+        \zeta_k\,X_k P_{\beta(k)}^i X_k^{-1},
+        \qquad
+        \nu_{k,q}
+        =
+        \zeta_k^{-1}\,\mu_{\beta(k),\tau_k(q)},
+    \]
+    then, in the flattened $Q$-coordinates,
+    \[
+        Q_{\mathrm{flat}}^i
+        =
+        X\,P_{\mathrm{matched}}^i\,X^{-1},
+        \qquad
+        X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
+    \]
+    This is the direct-sum gauge assembly of
+    \cite[\S~II.C, lines 1189--1192]{Cirac2017MPDO_AnnPhys}, separated from
+    the coefficient-comparison step that supplies the weight identities.
+\end{theorem}
+
+\begin{proof}\leanok
+    Multiply the displayed sector identity by the matching copy weight
+    identity. The phase $\zeta_k$ cancels against $\zeta_k^{-1}$, giving a
+    conjugation identity for every flattened weighted block. Applying
+    Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} to the flattened
+    family assembles these block conjugacies into the displayed direct-sum
+    gauge.
+\end{proof}
+
 \begin{theorem}[Full-basis global gauge in matched coordinates]%
     \label{thm:sector_bnt_equal_global_gauge}
     \lean{MPSTensor.ft_sector_bnt_equal_global_gauge}
@@ -1307,7 +1348,7 @@ BNT basis.
         thm:sector_bnt_bijective_match_of_sameMPV,
         lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
         lem:sector_bnt_matched_sector_weight_equiv,
-        lem:tensor_from_blocks_globalGauge_conj}
+        thm:sector_bnt_global_gauge_of_matched_weights}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
     MPV family. Assume that every sector of $P$ and every sector of $Q$ has at
     least one copy weight of modulus $1$. Then there exist:
@@ -1359,8 +1400,8 @@ BNT basis.
     $|\zeta_k|=1$ for every matched sector. The matched-sector
     weight-permutation theorem then gives the copy permutations and the
     displayed pointwise weight identities. Finally
-    Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} assembles the block
-    conjugacies into the flattened direct-sum conjugation by
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights} assembles the
+    block conjugacies into the flattened direct-sum conjugation by
     $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1303,9 +1303,8 @@ BNT basis.
     \label{thm:sector_bnt_global_gauge_of_matched_weights}
     \lean{MPSTensor.sector_bnt_global_gauge_of_matched_weights}
     \leanok
-    \uses{def:sector_bnt_cf,
-        lem:tensor_from_blocks_globalGauge_conj}
-    Suppose that the sectors of two BNT decompositions $P$ and $Q$ are matched
+    \uses{lem:tensor_from_blocks_globalGauge_conj}
+    Suppose that the sectors of two sector decompositions $P$ and $Q$ are matched
     by a bijection $\beta:J(Q)\simeq J(P)$, with bond-dimension equalities,
     copy permutations $\tau_k$, nonzero phases $\zeta_k$, and block gauges
     $X_k$. If, for every sector $k$, copy $q$, and physical index $i$,
@@ -1391,7 +1390,7 @@ BNT basis.
     \uses{thm:sector_bnt_bijective_match_of_sameMPV,
         lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
         lem:sector_bnt_matched_sector_weight_equiv,
-        lem:tensor_from_blocks_globalGauge_conj}
+        thm:sector_bnt_global_gauge_of_matched_weights}
     The full-basis matching theorem gives $\beta$, the bond-dimension
     identifications, and the gauge-phase equivalences between $Q_k$ and
     $P_{\beta(k)}$. Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase}


### PR DESCRIPTION
This PR factors out the direct-sum gauge assembly step used in the BNT fundamental theorem proof, and then applies that assembly to the proportional branch conditionally on the remaining copy-weight comparison.

It adds `MPSTensor.sector_bnt_global_gauge_of_matched_weights`, which assumes matched sectors, block gauges, phases, copy permutations, and the corresponding copy-weight identities, and then assembles these pointwise block identities into the flattened global gauge. This isolates the CPSV16 §II.C lines 1189-1192 assembly from the preceding coefficient-comparison argument.

It also adds `MPSTensor.ft_sector_bnt_proportional_global_gauge_of_weight_data`. This theorem uses proportional sector matching to obtain the matched BNT basis, unit phases, and block gauges, and proves that once the proportional coefficient comparison supplies copy permutations with `ν_{k,q} = ζ_k^{-1} μ_{β(k),τ_k(q)}`, the same block-diagonal global gauge follows. The blueprint records this as the conditional proportional global-gauge step.

The existing equal-MPV theorem `MPSTensor.ft_sector_bnt_equal_global_gaugePos` now calls the shared assembly theorem after it has produced the matched weight data.

This advances #1749 but does not close it. The remaining proportional work is still the coefficient identity under `EventuallyNonzeroProportionalMPV₂`, where the length-dependent proportionality scalar has to be controlled before the weight identities can be supplied to the assembly theorem.

Validation:
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental`
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `git diff --check`

The blueprint sync still reports the pre-existing parent-Hamiltonian and PEPS declaration gaps; the new declaration is present in `blueprint/lean_decls` and is not reported missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a proof refactor and theorem factoring in the Lean formalization, with only minor documentation/blueprint updates and no runtime behavior changes.
> 
> **Overview**
> Introduces `MPSTensor.sector_bnt_global_gauge_of_matched_weights`, factoring out the direct-sum/block-diagonal gauge *assembly step* that turns per-sector conjugacy + copy-weight identities into a flattened global conjugacy witness.
> 
> Adds `MPSTensor.ft_sector_bnt_proportional_global_gauge_of_weight_data`, which reuses proportional sector-matching data to produce the same global gauge **conditionally** on supplying the remaining per-copy weight identities. The existing equal-MPV global gauge proof (`ft_sector_bnt_equal_global_gaugePos`) is simplified to call the new shared assembly theorem.
> 
> Updates the blueprint to document the two new theorems and rewires references accordingly, and makes a small wording tweak in `PEPS/FundamentalTheorem.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69dcd5a98eedf0d51bdd2cbb6ef8348fea1eac4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->