### PR TITLE
feat(MPS/CanonicalForm): record phase quotient total dimension

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -53,10 +53,11 @@ identity fixed point for each block transfer map, and the stated bond-dimension
 bound. The audit boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
 For PGVWC07 itself, the faithful proof order is the one in
-`Papers/quant-ph_0608197/MPSarchive.tex`: lines 765–770 for the full-rank
-fixed-point gauge, lines 771–815 for support splitting, lines 816–826 for
-iteration and non-scalar fixed-point splitting, and lines 827–832 for dual
-fixed-point diagonalization.
+`Papers/quant-ph_0608197/MPSarchive.tex`: lines 765–770 for spectral-radius
+normalization and the full-rank fixed-point gauge, lines 771–815 for deriving
+the invariant support from a singular positive fixed point and then splitting
+the trace, lines 816–826 for iteration and non-scalar fixed-point splitting,
+and lines 827–832 for dual fixed-point diagonalization.
 
 ## External input — Quantum Wielandt strong irreducibility ⇒ full Kraus rank
 

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -52,6 +52,11 @@ weights, unital blocks, diagonal full-rank dual fixed points, uniqueness of the
 identity fixed point for each block transfer map, and the stated bond-dimension
 bound. The audit boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
+For PGVWC07 itself, the faithful proof order is the one in
+`Papers/quant-ph_0608197/MPSarchive.tex`: lines 765–770 for the full-rank
+fixed-point gauge, lines 771–815 for support splitting, lines 816–826 for
+iteration and non-scalar fixed-point splitting, and lines 827–832 for dual
+fixed-point diagonalization.
 
 ## External input — Quantum Wielandt strong irreducibility ⇒ full Kraus rank
 

--- a/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
@@ -297,7 +297,9 @@ Conclusion: after a common blocking (currently `p = 1`) and reordering by decrea
 
 Source context: Perez-Garcia--Verstraete--Wolf--Cirac 2007,
 Theorem Th:TIcanonical, lines 742--763, starts from an arbitrary
-translation-invariant MPS representation.
+translation-invariant MPS representation. Its proof first performs the
+fixed-point gauge and invariant-support splitting of lines 765--826, then
+the dual fixed-point diagonalization of lines 827--832.
 
 **Scope restriction (prepared primitive block decomposition):** This theorem
 assumes an existing weighted block decomposition, irreducibility,

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -295,12 +295,15 @@ Every nonzero block satisfies:
 
 The MPV of `A` equals the zero-block contribution plus the weighted nonzero-block sum.
 
-**Scope restriction (PGVWC07 canonical-form proof step):** This theorem supplies
-the all-zero-block separation and left-canonical TP gauge for nonzero
-irreducible blocks. It is not the full PGVWC07 translation-invariant canonical
-form theorem: it does not also prove the source theorem's unital orientation,
-diagonal full-rank dual fixed points, uniqueness of the identity fixed point,
-or total bond-dimension bound. The boundary is recorded in
+**Scope restriction (PGVWC07 canonical-form proof step):** PGVWC07,
+Theorem `Th:TIcanonical`, lines 765--770 use a full-rank positive fixed point
+to gauge a block into the unital orientation
+`∑ i, B i * (B i)ᴴ = 1`. This theorem supplies the dual left-canonical TP
+orientation after the all-zero-block separation. It is therefore not the full
+PGVWC07 translation-invariant canonical form theorem: it does not also prove
+the source theorem's unital orientation, diagonal full-rank dual fixed points,
+uniqueness of the identity fixed point, or total bond-dimension bound. The
+boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -108,8 +108,9 @@ decomposition has the same total bond dimension as the original direct sum.
 
 This is the dimension bookkeeping needed in the arbitrary-input supplier:
 without the displayed same-dimension hypothesis, the quotient is allowed to
-identify heterogeneous MPV-phase-equivalent blocks, and the length-zero MPV
-coefficient need not be preserved by dimension counting alone. -/
+identify MPV-phase-equivalent blocks of differing bond dimensions, and the
+length-zero MPV coefficient need not be preserved by dimension counting
+alone. -/
 theorem collapsedBntSectorDecomp_totalDim_eq_sum_dim
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -100,6 +100,67 @@ theorem collapsedBntSectorDecomp_sameMPV₂
             symm
             simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
 
+/-- **Total dimension of a dimension-preserving phase-class quotient.**
+
+If every block in an MPV phase class has the same bond dimension as the
+chosen representative of that class, then the collapsed BNT sector
+decomposition has the same total bond dimension as the original direct sum.
+
+This is the dimension bookkeeping needed in the arbitrary-input supplier:
+without the displayed same-dimension hypothesis, the quotient is allowed to
+identify heterogeneous MPV-phase-equivalent blocks, and the length-zero MPV
+coefficient need not be preserved by dimension counting alone. -/
+theorem collapsedBntSectorDecomp_totalDim_eq_sum_dim
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hDim : ∀ j q,
+      dim ((mpvPhaseClassData blocks).enum j q) =
+        dim ((mpvPhaseClassData blocks).repr j)) :
+    (collapsedBntSectorDecomp (d := d) μ blocks hμne).totalDim =
+      ∑ k : Fin r, dim k := by
+  classical
+  let classes := mpvPhaseClassData blocks
+  let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
+  have hRegroupC :
+      (∑ j : Fin classes.g, ∑ q : Fin (classes.copies j),
+          (dim (classes.enum j q) : ℂ)) =
+        ∑ k : Fin r, (dim k : ℂ) :=
+    classes.regroup (fun k : Fin r => (dim k : ℂ))
+  have hRegroupN :
+      (∑ j : Fin classes.g, ∑ q : Fin (classes.copies j),
+          dim (classes.enum j q)) =
+        ∑ k : Fin r, dim k := by
+    exact_mod_cast hRegroupC
+  have hRepEnum :
+      (∑ j : Fin classes.g, ∑ q : Fin (classes.copies j), dim (classes.repr j)) =
+        ∑ j : Fin classes.g, ∑ q : Fin (classes.copies j),
+          dim (classes.enum j q) := by
+    refine Finset.sum_congr rfl fun j _ => ?_
+    refine Finset.sum_congr rfl fun q _ => ?_
+    exact (hDim j q).symm
+  have hFlat :
+      P.totalDim =
+        ∑ x : (j : Fin classes.g) × Fin (classes.copies j), dim (classes.repr x.1) := by
+    change (∑ s : Fin (∑ j : Fin classes.g, classes.copies j),
+        dim (classes.repr ((finSigmaFinEquiv.symm s).1))) =
+      ∑ x : (j : Fin classes.g) × Fin (classes.copies j), dim (classes.repr x.1)
+    symm
+    simpa using
+      (Equiv.sum_comp
+        (finSigmaFinEquiv (m := classes.g) (n := classes.copies))
+        (fun s : Fin (∑ j : Fin classes.g, classes.copies j) =>
+          dim (classes.repr ((finSigmaFinEquiv.symm s).1))))
+  calc
+    P.totalDim =
+        ∑ x : (j : Fin classes.g) × Fin (classes.copies j), dim (classes.repr x.1) := hFlat
+    _ = ∑ j : Fin classes.g, ∑ q : Fin (classes.copies j), dim (classes.repr j) := by
+      rw [Fintype.sum_sigma]
+    _ = ∑ j : Fin classes.g, ∑ q : Fin (classes.copies j), dim (classes.enum j q) :=
+      hRepEnum
+    _ = ∑ k : Fin r, dim k := hRegroupN
+
 /-- `collapsedBntSectorDecomp` carries `HasBNTSectorData`.  Exposed (was previously
 `private`) for the prepared-block SectorBNT constructor. -/
 theorem collapsedBntSectorDecomp_hasBNT

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -14,6 +14,12 @@ Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3
 (around eq. `\label{eq:II_Aiplusk1}`).
 It also corresponds to the invariant-subspace splitting used inside
 PGVWC07, Theorem `Th:TIcanonical`, lines 765–833.
+The source proof is ordered as follows: lines 765–770 handle the full-rank
+fixed-point gauge; lines 771–815 split along the support of a non-full-rank
+positive fixed point; lines 816–826 iterate the split and use a non-scalar fixed
+point to force uniqueness of the identity fixed point.  This file formalizes
+only that splitting part, not the dual fixed-point diagonalization at
+lines 827–832.
 
 Starting from an arbitrary MPS tensor `A : MPSTensor d D`, we iteratively apply
 `MPSTensor.exists_twoBlock_decomp_of_lowerZero_strict` — which produces two blocks each with
@@ -129,10 +135,11 @@ bond dimension, then apply the induction hypothesis to each block.
 
 **Scope restriction (PGVWC07 canonical-form proof step):** This theorem proves
 only the recursive invariant-projection splitting from the proof of
-PGVWC07, Theorem `Th:TIcanonical`, lines 765–833. It does not prove the full
+PGVWC07, Theorem `Th:TIcanonical`, lines 771–826. It does not prove the full
 source theorem's positive weights, unital normalization, diagonal full-rank dual
-fixed points, uniqueness of the identity fixed point, or final bond-dimension
-bound. The remaining source boundary is recorded in
+fixed points, or final bond-dimension bound; it also does not perform the
+dual-map diagonalization of lines 827–832. The remaining source boundary is
+recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
 -/
 theorem exists_irreducible_blockDecomp (A : MPSTensor d D) :

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -14,11 +14,15 @@ Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3
 (around eq. `\label{eq:II_Aiplusk1}`).
 It also corresponds to the invariant-subspace splitting used inside
 PGVWC07, Theorem `Th:TIcanonical`, lines 765–833.
-The source proof is ordered as follows: lines 765–770 handle the full-rank
-fixed-point gauge; lines 771–815 split along the support of a non-full-rank
-positive fixed point; lines 816–826 iterate the split and use a non-scalar fixed
-point to force uniqueness of the identity fixed point.  This file formalizes
-only that splitting part, not the dual fixed-point diagonalization at
+The source proof is ordered as follows: lines 765–770 handle spectral-radius
+normalization and the full-rank fixed-point gauge; lines 771–783 derive the
+invariant support from a singular positive fixed point; lines 785–815 split the
+finite-ring trace over that support and its orthogonal complement; lines 816–826
+iterate the split and use a non-scalar fixed point to force uniqueness of the
+identity fixed point.  This file formalizes only the abstract splitting once an
+invariant projection is available; a faithful proof of the full theorem must
+also derive that projection from the positive fixed-point argument in
+lines 771–783 and perform the dual fixed-point diagonalization at
 lines 827–832.
 
 Starting from an arbitrary MPS tensor `A : MPSTensor d D`, we iteratively apply

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -112,6 +112,133 @@ lemma norm_choose_MPVBlockPhaseEquiv_eq_one
     simpa using h1
   exact norm_eq_one_of_selfOverlap_scale hXX hYY hScale
 
+/-!
+### Bond dimensions inside a prepared phase class
+
+The phase quotient in `CanonicalForm.PhaseClassSectorData` is deliberately
+heterogeneous: `MPVBlockPhaseEquiv` only records proportional MPVs, not equality
+of bond dimensions.  For the prepared blocks used by the BNT supplier, the
+rectangular overlap gap forces equality of bond dimensions inside each phase
+class.
+-/
+
+/--
+**Bond dimensions of prepared phase-equivalent blocks agree.**
+
+Source: arXiv:1606.00608, Lemma `equalMPS` in
+`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1080-1117, especially
+the dimension conclusion at lines 1090 and 1115-1117; the phase-class
+quotient is `prop:char-BNT`, lines 271-279 and 1135-1148.
+
+If two left-canonical, primitive, irreducible blocks have MPV families related
+by a nonzero scalar power, then their bond dimensions are equal.  The proof
+uses the self-overlap normalization to show that the scalar has unit modulus;
+then a rectangular overlap of the two blocks has norm tending to `1`, whereas
+different bond dimensions would force that overlap to tend to `0`.
+-/
+theorem dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
+    {DX DY : ℕ} [NeZero DX] [NeZero DY]
+    {X : MPSTensor d DX} {Y : MPSTensor d DY}
+    (hTPX : IsLeftCanonical X)
+    (hTPY : IsLeftCanonical Y)
+    (hPrimX : _root_.IsPrimitive (transferMap (d := d) (D := DX) X))
+    (hPrimY : _root_.IsPrimitive (transferMap (d := d) (D := DY) Y))
+    (hIrrX : IsIrreducibleTensor X)
+    (hIrrY : IsIrreducibleTensor Y)
+    (h : MPVBlockPhaseEquiv X Y) :
+    DX = DY := by
+  classical
+  have hζ_norm : ‖h.choose‖ = 1 :=
+    norm_choose_MPVBlockPhaseEquiv_eq_one
+      (X := X) (Y := Y) hTPX hTPY hPrimX hPrimY hIrrX hIrrY h
+  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv Y σ = h.choose ^ N * mpv X σ := h.choose_spec.2
+  have hXX_c : Tendsto (fun N => mpvOverlap (d := d) X X N) atTop (𝓝 (1 : ℂ)) :=
+    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      (d := d) (D := DX) X hIrrX hTPX hPrimX
+  have hXX : Tendsto (fun N => ‖mpvOverlap (d := d) X X N‖) atTop (𝓝 (1 : ℝ)) := by
+    simpa using hXX_c.norm
+  have hYX_eq : ∀ N : ℕ,
+      mpvOverlap (d := d) Y X N =
+        h.choose ^ N * mpvOverlap (d := d) X X N := by
+    intro N
+    exact mpvOverlap_eq_mul_of_mpv_eq_mul
+      (d := d) (A := Y) (B := X) (N := N) (c := h.choose ^ N) (hmpv N) X
+  have hYX_norm_eq : ∀ N : ℕ,
+      ‖mpvOverlap (d := d) Y X N‖ = ‖mpvOverlap (d := d) X X N‖ := by
+    intro N
+    rw [hYX_eq N, norm_mul, norm_pow, hζ_norm, one_pow, one_mul]
+  have hYX : Tendsto (fun N => ‖mpvOverlap (d := d) Y X N‖) atTop (𝓝 (1 : ℝ)) :=
+    hXX.congr fun N => (hYX_norm_eq N).symm
+  have hDYDX : DY = DX := by
+    by_contra hD
+    have hzero :
+        Tendsto (fun N => mpvOverlap (d := d) Y X N) atTop (𝓝 (0 : ℂ)) :=
+      mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP
+        Y X hIrrY hIrrX hTPY hTPX hD
+    have hnorm_zero :
+        Tendsto (fun N => ‖mpvOverlap (d := d) Y X N‖) atTop (𝓝 (0 : ℝ)) := by
+      simpa using hzero.norm
+    have h10 : (1 : ℝ) = 0 := tendsto_nhds_unique hYX hnorm_zero
+    exact one_ne_zero h10
+  exact hDYDX.symm
+
+/--
+**Prepared phase classes preserve the original bond dimensions.**
+
+Source: arXiv:1606.00608, `prop:char-BNT` in
+`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 271-279 and 1135-1148.
+In a prepared family of left-canonical, primitive, irreducible blocks, every
+member of an MPV phase class has the same bond dimension as its chosen
+representative.
+-/
+theorem mpvPhaseClassData_dim_eq_of_tp_primitive_irr
+    {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hDim : ∀ k, 0 < dim k)
+    (hTP : ∀ k, IsLeftCanonical (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (blocks k)))
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k)) :
+    ∀ j q,
+      dim ((mpvPhaseClassData blocks).enum j q) =
+        dim ((mpvPhaseClassData blocks).repr j) := by
+  classical
+  haveI : ∀ k, NeZero (dim k) := fun k => ⟨(hDim k).ne'⟩
+  let classes := mpvPhaseClassData (d := d) blocks
+  intro j q
+  have hEq :
+      dim (classes.repr j) = dim (classes.enum j q) :=
+    dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
+      (X := blocks (classes.repr j)) (Y := blocks (classes.enum j q))
+      (hTP (classes.repr j)) (hTP (classes.enum j q))
+      (hPrim (classes.repr j)) (hPrim (classes.enum j q))
+      (hIrr (classes.repr j)) (hIrr (classes.enum j q))
+      (classes.enum_phase j q)
+  exact hEq.symm
+
+/--
+**Total bond dimension of the prepared collapsed BNT decomposition.**
+
+Source: arXiv:1606.00608, `eq:II_CF1` and `prop:char-BNT` in
+`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 237-246, 271-279, and
+1135-1148.  For prepared blocks, the phase-class quotient does not change the
+total bond dimension: quotienting only groups phase-equivalent copies with the
+same bond dimension.
+-/
+theorem collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hDim : ∀ k, 0 < dim k)
+    (hTP : ∀ k, IsLeftCanonical (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (blocks k)))
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hμne : ∀ k, μ k ≠ 0) :
+    (collapsedBntSectorDecomp (d := d) μ blocks hμne).totalDim =
+      ∑ k : Fin r, dim k :=
+  collapsedBntSectorDecomp_totalDim_eq_sum_dim (d := d) μ blocks hμne
+    (mpvPhaseClassData_dim_eq_of_tp_primitive_irr blocks hDim hTP hPrim hIrr)
+
 /-! ### Prepared-block SectorBNT constructor -/
 
 /--

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -116,10 +116,10 @@ lemma norm_choose_MPVBlockPhaseEquiv_eq_one
 ### Bond dimensions inside a prepared phase class
 
 The phase quotient in `CanonicalForm.PhaseClassSectorData` is deliberately
-heterogeneous: `MPVBlockPhaseEquiv` only records proportional MPVs, not equality
-of bond dimensions.  For the prepared blocks used by the BNT supplier, the
-rectangular overlap gap forces equality of bond dimensions inside each phase
-class.
+allowed to group blocks of differing bond dimensions: `MPVBlockPhaseEquiv` only
+records proportional MPVs, not equality of bond dimensions.  For the prepared
+blocks used by the BNT supplier, the rectangular overlap gap forces equality of
+bond dimensions inside each phase class.
 -/
 
 /--

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -133,8 +133,8 @@ quotient is `prop:char-BNT`, lines 271-279 and 1135-1148.
 If two left-canonical, primitive, irreducible blocks have MPV families related
 by a nonzero scalar power, then their bond dimensions are equal.  The proof
 uses the self-overlap normalization to show that the scalar has unit modulus;
-then a rectangular overlap of the two blocks has norm tending to `1`, whereas
-different bond dimensions would force that overlap to tend to `0`.
+then a rectangular overlap of the two blocks has norm tending to one, whereas
+different bond dimensions would force that overlap to tend to zero.
 -/
 theorem dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
     {DX DY : ℕ} [NeZero DX] [NeZero DY]

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -186,8 +186,10 @@ theorem dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
 /--
 **Prepared phase classes preserve the original bond dimensions.**
 
-Source: arXiv:1606.00608, `prop:char-BNT` in
-`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 271-279 and 1135-1148.
+Source: arXiv:1606.00608, `equalMPS` in
+`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1080-1117, supplies the
+same-dimension conclusion; `prop:char-BNT` at lines 271-279 and 1135-1148
+uses this comparison to form phase classes.
 In a prepared family of left-canonical, primitive, irreducible blocks, every
 member of an MPV phase class has the same bond dimension as its chosen
 representative.

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -61,9 +61,8 @@ tensor family, the proof obtains the equality labelled `eq:inj_equal_edge`:
 for every edge and every matrix `X`, inserting `X` on that edge in the first
 PEPS gives the same state as inserting `X` on the same edge in the modified
 second PEPS. Blocking one vertex against its complement and applying
-`inj_equal_tensors_2` then gives $A_v = \lambda_v \tilde{B}_v$; the scalars
-$\lambda_v$ are
-absorbed into the edge gauges.
+`inj_equal_tensors_2` then gives $A_v = \lambda_v \cdot \tilde{B}_v$; the
+scalars $\lambda_v$ are absorbed into the edge gauges.
 
 ## References
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1145,6 +1145,10 @@ BNT construction.
     \uses{lem:collapsed_bnt_sector_decomp_total_dim,
         lem:prepared_phase_class_dim_eq}
     % Source anchors:
+    % The canonical-form source is
+    % Papers/1606.00608/MPDO-22-12-17-2.tex, eq:II_CF1 at lines 237--246,
+    % and the phase-class quotient is prop:char-BNT at lines 271--279 and
+    % 1135--1148.
     % Papers/1606.00608/MPDO-22-12-17-2.tex:237--246 is eq:II_CF1 and the
     % canonical-form weight convention; lines 271--279 and 1135--1148 are
     % prop:char-BNT and its construction of phase classes.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -54,6 +54,10 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
 
     This is the source statement
     of~\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
+    In the local source file \texttt{Papers/quant-ph\_0608197/MPSarchive.tex},
+    the label \texttt{Th:TIcanonical} begins at line~742; the block
+    decomposition is lines~742--752, the three block conditions are
+    lines~753--758, and the final bond-dimension bound is lines~761--762.
 \end{theorem}
 
 \begin{theorem}[Blocked CPSV canonical-form reduction]%
@@ -76,16 +80,38 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     dimension $d^{[p]}$ and bond dimension $D_0$, and the tensors $B_k$ are
     normal tensors. If $r>0$, the weights $\mu_k$ may be normalized so that
     $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
+
+    Source locations in the local papers are as follows.  In
+    \texttt{Papers/1606.00608/MPDO-22-12-17-2.tex}, the removal of periodic
+    peripheral components by blocking is lines~227--231; the normal-tensor
+    definition is lines~233--235; the canonical-form display
+    \texttt{eq:II\_CF1} is lines~237--246; and the proposition that any tensor
+    becomes canonical after blocking is lines~249--251.  The BNT quotient
+    used later in the reduction is lines~271--279
+    (\texttt{prop:char-BNT}) and lines~283--301
+    (\texttt{eq:II\_ABasicTensors}, \texttt{decBSV}).  In the review
+    \texttt{Papers/2011.12127/TN-Review-main.tex}, the invariant-subspace
+    reduction is lines~1793--1803, the period-removal blocking step is
+    lines~1815--1820, the normal/canonical definition
+    \texttt{def:4:normal-tensor-mps} and display \texttt{eq:II\_CF1} are
+    lines~1827--1839, and the BNT definition/characterization is
+    lines~1846--1859.
 \end{theorem}
 
-Theorem~\ref{thm:pgvwc07_ti_canonical_form} is not yet formalized. This
-chapter develops constituent steps of the PGVWC07 and CPSV reductions:
-invariant-subspace decomposition (Theorem~\ref{thm:irred_decomp}), TP gauge
+Theorems~\ref{thm:pgvwc07_ti_canonical_form}
+and~\ref{thm:cpgsv_canonical_form_source} are source-level targets and are
+not yet formalized as stated. This chapter develops constituent steps of the
+PGVWC07 and CPSV reductions: invariant-subspace decomposition
+(Theorem~\ref{thm:irred_decomp}), TP gauge
 (Section~\ref{sec:tp_gauge_arbitrary}), and period-removal cyclic sectors
-(Section~\ref{sec:cyclic_sectors}). All-zero-block separation and the combined
-after-blocking statement are recorded in Chapter~\ref{ch:canonical_after_blocking}
+(Section~\ref{sec:cyclic_sectors}). All-zero-block separation and the
+structural after-blocking primitive-block decomposition are recorded in
+Chapter~\ref{ch:canonical_after_blocking}
 (Theorem~\ref{thm:zero_block_separation} and
-Theorem~\ref{thm:tp_primitive_blockdecomp}).
+Theorem~\ref{thm:tp_primitive_blockdecomp}). These checked statements do not
+yet supply the source normalization $|\mu_k|\le 1$ with at least one
+unit-modulus weight, so they should not be cited as
+Theorem~\ref{thm:cpgsv_canonical_form_source}.
 
 \section{Normal tensors, canonical forms, and bases of normal tensors}\label{sec:cpsv_canonical_defs}
 
@@ -1076,6 +1102,72 @@ BNT construction.
     The same-dimension hypothesis replaces each representative dimension by the
     dimension of the enumerated original block, and the phase-class regrouping
     identity then recovers the original direct-sum dimension.
+\end{proof}
+
+\begin{lemma}[Prepared phase-equivalent blocks have the same bond dimension]%
+    \label{lem:prepared_phase_equiv_dim_eq}
+    \lean{MPSTensor.dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr}
+    \leanok
+    Let $X$ and $Y$ be trace-preserving, primitive, irreducible MPS blocks of
+    positive bond dimension. If their MPV families differ by a nonzero scalar
+    power, then their bond dimensions are equal.
+
+    This is the dimension part of
+    \texttt{Papers/1606.00608/MPDO-22-12-17-2.tex}, Lemma
+    \texttt{equalMPS}: the label begins at line~1080, the dimension conclusion
+    is stated at line~1090, and the proof of the dimension equality is
+    lines~1115--1117.
+\end{lemma}
+
+\begin{proof}\leanok
+    The self-overlap normalization forces the scalar relating the two MPV
+    families to have unit modulus. Hence the rectangular overlap between the
+    two blocks has norm tending to $1$. If the two bond dimensions were
+    different, the rectangular overlap-decay theorem would force the same
+    overlap to tend to $0$, which is impossible.
+\end{proof}
+
+\begin{lemma}[Prepared phase classes preserve bond dimension]%
+    \label{lem:prepared_phase_class_dim_eq}
+    \lean{MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr}
+    \leanok
+    \uses{lem:prepared_phase_equiv_dim_eq}
+    In a prepared family of positive-bond-dimension blocks, assume that every
+    block is trace-preserving, primitive, and irreducible. Then every block in
+    an MPV phase class has the same bond dimension as the representative of
+    that class.
+
+    The phase-class source is
+    \texttt{Papers/1606.00608/MPDO-22-12-17-2.tex},
+    \texttt{prop:char-BNT}: the statement is lines~271--279, and the proof
+    restatement and construction are lines~1135--1148.
+\end{lemma}
+
+\begin{proof}\leanok
+    Apply Lemma~\ref{lem:prepared_phase_equiv_dim_eq} to each representative
+    and each member of its phase class.
+\end{proof}
+
+\begin{lemma}[Prepared collapsed BNT total dimension]%
+    \label{lem:prepared_collapsed_bnt_sector_decomp_total_dim}
+    \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr}
+    \leanok
+    \uses{lem:collapsed_bnt_sector_decomp_total_dim,
+        lem:prepared_phase_class_dim_eq}
+    For prepared trace-preserving, primitive, irreducible blocks of positive
+    bond dimension, the phase-class quotient used in the BNT supplier does not
+    change the total bond dimension: the collapsed sector decomposition has
+    total bond dimension equal to the sum of the original block dimensions.
+
+    The canonical-form source is
+    \texttt{Papers/1606.00608/MPDO-22-12-17-2.tex},
+    \texttt{eq:II\_CF1} at lines~237--246, and the phase-class quotient is
+    \texttt{prop:char-BNT} at lines~271--279 and 1135--1148.
+\end{lemma}
+
+\begin{proof}\leanok
+    The previous lemma supplies the same-dimension hypothesis in
+    Lemma~\ref{lem:collapsed_bnt_sector_decomp_total_dim}.
 \end{proof}
 
 \begin{theorem}[Conditional BNT form after blocking for an arbitrary tensor]%

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -31,6 +31,10 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
 \begin{theorem}[PGVWC07 translation-invariant canonical form]%
     \label{thm:pgvwc07_ti_canonical_form}
     \notready
+    % Source anchors:
+    % Papers/quant-ph_0608197/MPSarchive.tex:742 label Th:TIcanonical.
+    % Lines 742--752 state the block decomposition; lines 753--758 state the
+    % three block conditions; lines 761--762 state the bond-dimension bound.
     Let a translation-invariant MPS representation on a finite ring have bond
     dimension $D$. Then the matrices may be decomposed as
     \[
@@ -54,15 +58,22 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
 
     This is the source statement
     of~\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
-    In the local source file \texttt{Papers/quant-ph\_0608197/MPSarchive.tex},
-    the label \texttt{Th:TIcanonical} begins at line~742; the block
-    decomposition is lines~742--752, the three block conditions are
-    lines~753--758, and the final bond-dimension bound is lines~761--762.
 \end{theorem}
 
 \begin{theorem}[Blocked CPSV canonical-form reduction]%
     \label{thm:cpgsv_canonical_form_source}
     \notready
+    % Source anchors:
+    % Papers/1606.00608/MPDO-22-12-17-2.tex:227--231 removes periodic
+    % peripheral components by blocking; lines 233--235 define normal tensors;
+    % lines 237--246 are eq:II_CF1 and the weight normalization; lines 249--251
+    % state that any tensor becomes canonical after blocking.  The later BNT
+    % quotient used by the supplier is prop:char-BNT at lines 271--279 and the
+    % two-layer expansion eq:II_ABasicTensors/decBSV at lines 283--301.
+    % Papers/2011.12127/TN-Review-main.tex:1793--1803 gives the invariant-
+    % subspace reduction; lines 1815--1820 give period removal; lines 1827--1839
+    % give def:4:normal-tensor-mps and eq:II_CF1; lines 1846--1859 give the
+    % BNT definition/characterization.
     This is the canonical-form reduction of
     \cite[Section~II.A]{Cirac2017MPDO_AnnPhys}; see also
     \cite[Theorems~4.2 and~4.4]{Cirac2021Matrix}. Every
@@ -80,22 +91,6 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     dimension $d^{[p]}$ and bond dimension $D_0$, and the tensors $B_k$ are
     normal tensors. If $r>0$, the weights $\mu_k$ may be normalized so that
     $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
-
-    Source locations in the local papers are as follows.  In
-    \texttt{Papers/1606.00608/MPDO-22-12-17-2.tex}, the removal of periodic
-    peripheral components by blocking is lines~227--231; the normal-tensor
-    definition is lines~233--235; the canonical-form display
-    \texttt{eq:II\_CF1} is lines~237--246; and the proposition that any tensor
-    becomes canonical after blocking is lines~249--251.  The BNT quotient
-    used later in the reduction is lines~271--279
-    (\texttt{prop:char-BNT}) and lines~283--301
-    (\texttt{eq:II\_ABasicTensors}, \texttt{decBSV}).  In the review
-    \texttt{Papers/2011.12127/TN-Review-main.tex}, the invariant-subspace
-    reduction is lines~1793--1803, the period-removal blocking step is
-    lines~1815--1820, the normal/canonical definition
-    \texttt{def:4:normal-tensor-mps} and display \texttt{eq:II\_CF1} are
-    lines~1827--1839, and the BNT definition/characterization is
-    lines~1846--1859.
 \end{theorem}
 
 Theorems~\ref{thm:pgvwc07_ti_canonical_form}
@@ -1108,15 +1103,12 @@ BNT construction.
     \label{lem:prepared_phase_equiv_dim_eq}
     \lean{MPSTensor.dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr}
     \leanok
+    % Source anchors:
+    % Papers/1606.00608/MPDO-22-12-17-2.tex:1080 begins Lemma equalMPS;
+    % line 1090 states the dimension conclusion; lines 1115--1117 prove it.
     Let $X$ and $Y$ be trace-preserving, primitive, irreducible MPS blocks of
     positive bond dimension. If their MPV families differ by a nonzero scalar
     power, then their bond dimensions are equal.
-
-    This is the dimension part of
-    \texttt{Papers/1606.00608/MPDO-22-12-17-2.tex}, Lemma
-    \texttt{equalMPS}: the label begins at line~1080, the dimension conclusion
-    is stated at line~1090, and the proof of the dimension equality is
-    lines~1115--1117.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1132,15 +1124,13 @@ BNT construction.
     \lean{MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr}
     \leanok
     \uses{lem:prepared_phase_equiv_dim_eq}
+    % Source anchors:
+    % Papers/1606.00608/MPDO-22-12-17-2.tex:271--279 states prop:char-BNT;
+    % lines 1135--1148 restate it and give the construction.
     In a prepared family of positive-bond-dimension blocks, assume that every
     block is trace-preserving, primitive, and irreducible. Then every block in
     an MPV phase class has the same bond dimension as the representative of
     that class.
-
-    The phase-class source is
-    \texttt{Papers/1606.00608/MPDO-22-12-17-2.tex},
-    \texttt{prop:char-BNT}: the statement is lines~271--279, and the proof
-    restatement and construction are lines~1135--1148.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1154,15 +1144,14 @@ BNT construction.
     \leanok
     \uses{lem:collapsed_bnt_sector_decomp_total_dim,
         lem:prepared_phase_class_dim_eq}
+    % Source anchors:
+    % Papers/1606.00608/MPDO-22-12-17-2.tex:237--246 is eq:II_CF1 and the
+    % canonical-form weight convention; lines 271--279 and 1135--1148 are
+    % prop:char-BNT and its construction of phase classes.
     For prepared trace-preserving, primitive, irreducible blocks of positive
     bond dimension, the phase-class quotient used in the BNT supplier does not
     change the total bond dimension: the collapsed sector decomposition has
     total bond dimension equal to the sum of the original block dimensions.
-
-    The canonical-form source is
-    \texttt{Papers/1606.00608/MPDO-22-12-17-2.tex},
-    \texttt{eq:II\_CF1} at lines~237--246, and the phase-class quotient is
-    \texttt{prop:char-BNT} at lines~271--279 and 1135--1148.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1084,12 +1084,12 @@ BNT construction.
     \label{lem:collapsed_bnt_sector_decomp_total_dim}
     \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim}
     \leanok
-    \uses{thm:paperbnt_supplier_prepared}
     In the phase-class quotient used by the prepared-block BNT supplier,
-    suppose that every block in a phase class has the same bond dimension as
-    the chosen representative of that class. Then the total bond dimension of
-    the collapsed sector decomposition is the sum of the bond dimensions of the
-    original prepared blocks.
+    suppose that every original copy weight is nonzero and that every block in
+    a phase class has the same bond dimension as the chosen representative of
+    that class. Then the total bond dimension of the collapsed sector
+    decomposition is the sum of the bond dimensions of the original prepared
+    blocks.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1149,9 +1149,10 @@ BNT construction.
     % canonical-form weight convention; lines 271--279 and 1135--1148 are
     % prop:char-BNT and its construction of phase classes.
     For prepared trace-preserving, primitive, irreducible blocks of positive
-    bond dimension, the phase-class quotient used in the BNT supplier does not
-    change the total bond dimension: the collapsed sector decomposition has
-    total bond dimension equal to the sum of the original block dimensions.
+    bond dimension, with all copy weights nonzero, the phase-class quotient
+    used in the BNT supplier does not change the total bond dimension: the
+    collapsed sector decomposition has total bond dimension equal to the sum of
+    the original block dimensions.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1059,6 +1059,25 @@ BNT construction.
     weight-norm conditions.
 \end{proof}
 
+\begin{lemma}[Total dimension of a dimension-preserving phase-class quotient]%
+    \label{lem:collapsed_bnt_sector_decomp_total_dim}
+    \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim}
+    \leanok
+    \uses{thm:paperbnt_supplier_prepared}
+    In the phase-class quotient used by the prepared-block BNT supplier,
+    suppose that every block in a phase class has the same bond dimension as
+    the chosen representative of that class. Then the total bond dimension of
+    the collapsed sector decomposition is the sum of the bond dimensions of the
+    original prepared blocks.
+\end{lemma}
+
+\begin{proof}\leanok
+    Sum the representative bond dimensions over the copies in each phase class.
+    The same-dimension hypothesis replaces each representative dimension by the
+    dimension of the enumerated original block, and the phase-class regrouping
+    identity then recovers the original direct-sum dimension.
+\end{proof}
+
 \begin{theorem}[Conditional BNT form after blocking for an arbitrary tensor]%
     \label{thm:paperbnt_supplier_after_blocking}
     \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -35,6 +35,12 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     % Papers/quant-ph_0608197/MPSarchive.tex:742 label Th:TIcanonical.
     % Lines 742--752 state the block decomposition; lines 753--758 state the
     % three block conditions; lines 761--762 state the bond-dimension bound.
+    % The proof order is lines 765--770 for spectral-radius normalization and
+    % the full-rank fixed-point gauge; lines 771--815 for the invariant support
+    % split when the positive fixed point is not full rank; lines 816--826 for
+    % iteration and further splitting when a block has a non-scalar fixed point;
+    % and lines 827--832 for the dual fixed point and final unitary
+    % diagonalization. Follow this order when formalizing the theorem.
     Let a translation-invariant MPS representation on a finite ring have bond
     dimension $D$. Then the matrices may be decomposed as
     \[

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1129,7 +1129,6 @@ BNT construction.
     \label{lem:prepared_phase_class_dim_eq}
     \lean{MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr}
     \leanok
-    \uses{lem:prepared_phase_equiv_dim_eq}
     % Source anchors:
     % Papers/1606.00608/MPDO-22-12-17-2.tex:271--279 states prop:char-BNT;
     % lines 1135--1148 restate it and give the construction.
@@ -1139,7 +1138,7 @@ BNT construction.
     that class.
 \end{lemma}
 
-\begin{proof}\leanok
+\begin{proof}\leanok\uses{lem:prepared_phase_equiv_dim_eq}
     Apply Lemma~\ref{lem:prepared_phase_equiv_dim_eq} to each representative
     and each member of its phase class.
 \end{proof}
@@ -1148,8 +1147,6 @@ BNT construction.
     \label{lem:prepared_collapsed_bnt_sector_decomp_total_dim}
     \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr}
     \leanok
-    \uses{lem:collapsed_bnt_sector_decomp_total_dim,
-        lem:prepared_phase_class_dim_eq}
     % Source anchors:
     % The canonical-form source is
     % Papers/1606.00608/MPDO-22-12-17-2.tex, eq:II_CF1 at lines 237--246.
@@ -1162,7 +1159,8 @@ BNT construction.
     the original block dimensions.
 \end{lemma}
 
-\begin{proof}\leanok
+\begin{proof}\leanok\uses{lem:collapsed_bnt_sector_decomp_total_dim,
+        lem:prepared_phase_class_dim_eq}
     The previous lemma supplies the same-dimension hypothesis in
     Lemma~\ref{lem:collapsed_bnt_sector_decomp_total_dim}.
 \end{proof}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -40,7 +40,11 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     % split when the positive fixed point is not full rank; lines 816--826 for
     % iteration and further splitting when a block has a non-scalar fixed point;
     % and lines 827--832 for the dual fixed point and final unitary
-    % diagonalization. Follow this order when formalizing the theorem.
+    % diagonalization. Follow this order when formalizing the theorem: derive
+    % the invariant support from the singular positive fixed point as in
+    % lines 771--783 before invoking any abstract block-splitting lemma, and do
+    % not replace the source proof by a later primitive-block or prepared-family
+    % canonical-form theorem.
     Let a translation-invariant MPS representation on a finite ring have bond
     dimension $D$. Then the matrices may be decomposed as
     \[

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1117,7 +1117,7 @@ BNT construction.
     power, then their bond dimensions are equal.
 \end{lemma}
 
-\begin{proof}\leanok
+\begin{proof}\leanok\uses{thm:overlap_decay_rect_irr_tp}
     The self-overlap normalization forces the scalar relating the two MPV
     families to have unit modulus. Hence the rectangular overlap between the
     two blocks has norm tending to $1$. If the two bond dimensions were

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1152,12 +1152,9 @@ BNT construction.
         lem:prepared_phase_class_dim_eq}
     % Source anchors:
     % The canonical-form source is
-    % Papers/1606.00608/MPDO-22-12-17-2.tex, eq:II_CF1 at lines 237--246,
-    % and the phase-class quotient is prop:char-BNT at lines 271--279 and
-    % 1135--1148.
-    % Papers/1606.00608/MPDO-22-12-17-2.tex:237--246 is eq:II_CF1 and the
-    % canonical-form weight convention; lines 271--279 and 1135--1148 are
-    % prop:char-BNT and its construction of phase classes.
+    % Papers/1606.00608/MPDO-22-12-17-2.tex, eq:II_CF1 at lines 237--246.
+    % The phase-class quotient is prop:char-BNT at lines 271--279 and its
+    % appendix restatement/construction at lines 1135--1148.
     For prepared trace-preserving, primitive, irreducible blocks of positive
     bond dimension, with all copy weights nonzero, the phase-class quotient
     used in the BNT supplier does not change the total bond dimension: the

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -52,6 +52,42 @@ canonical form has been obtained
 and the generic uniqueness discussion is a separate theorem
 \cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007MPSReps}.
 
+\section{Faithful proof order}
+
+The proof of Theorem~\texttt{Th:TIcanonical} is short but highly ordered, and
+the formalization should preserve that order rather than replace it by later
+canonical-form theorems. The source proof proceeds as follows.
+
+\begin{enumerate}
+    \item Lines~765--770 normalize the spectral radius and, when the positive
+          fixed point is full rank, gauge the tensor by \(X^{-1/2}\) and
+          \(X^{1/2}\) to obtain the unital condition
+          \(\sum_i B_iB_i^\dagger=\mathbf{1}\).
+
+    \item Lines~771--815 treat a non-full-rank positive fixed point. The
+          support projection \(P_R\) is invariant, \(A_iP_R=P_RA_iP_R\), and
+          the trace over the finite ring splits into the direct sum of the
+          \(R\) and \(R^\perp\) restrictions. This is the source of the
+          recursive block decomposition and of the bond-dimension
+          non-increase.
+
+    \item Lines~816--826 iterate the same splitting on each block and then use
+          a non-scalar fixed point \(X\neq\mathbf{1}\) to produce the positive
+          non-full-rank fixed point
+          \(\mathbf{1}-\lambda_1^{-1}X\). This is the step that enforces
+          uniqueness of the identity fixed point in each final block.
+
+    \item Lines~827--832 apply the analogous argument to the dual map and use a
+          unitary conjugation to diagonalize the resulting full-rank positive
+          fixed point, producing the matrices \(\Lambda^j\) in the theorem.
+\end{enumerate}
+
+Thus the source theorem is not a primitive-block theorem, an injective-block
+theorem, or a prepared-family theorem. A formal proof of
+Theorem~\texttt{Th:TIcanonical} should reconstruct these steps from an
+arbitrary translation-invariant representation and use later notions only as
+lemmas after their hypotheses have been obtained in this proof order.
+
 \section{Normalization orientation}
 
 There is also a convention difference in the direction of the canonical

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -65,8 +65,11 @@ canonical-form theorems. The source proof proceeds as follows.
           \(\sum_i B_iB_i^\dagger=\mathbf{1}\).
 
     \item Lines~771--815 treat a non-full-rank positive fixed point. The
-          support projection \(P_R\) is invariant, \(A_iP_R=P_RA_iP_R\), and
-          the trace over the finite ring splits into the direct sum of the
+          support projection \(P_R\) is not an independent hypothesis: it is
+          derived from the spectral decomposition of the singular positive
+          fixed point, using the positivity contradiction in lines~775--783.
+          Only after this derivation does the proof use
+          \(A_iP_R=P_RA_iP_R\) to split the trace over the finite ring into the
           \(R\) and \(R^\perp\) restrictions. This is the source of the
           recursive block decomposition and of the bond-dimension
           non-increase.
@@ -83,7 +86,9 @@ canonical-form theorems. The source proof proceeds as follows.
 \end{enumerate}
 
 Thus the source theorem is not a primitive-block theorem, an injective-block
-theorem, or a prepared-family theorem. A formal proof of
+theorem, or a prepared-family theorem. Nor is the invariant-projection lemma by
+itself enough: the projection must be obtained from the positive fixed-point
+argument in the cited lines. A formal proof of
 Theorem~\texttt{Th:TIcanonical} should reconstruct these steps from an
 arbitrary translation-invariant representation and use later notions only as
 lemmas after their hypotheses have been obtained in this proof order.


### PR DESCRIPTION
This PR records the dimension bookkeeping condition behind the remaining length-zero part of #1753.

It adds `MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim` for the phase-class quotient used by the prepared-block BNT supplier. The lemma states that if every original copy weight is nonzero and every block in a phase class has the same bond dimension as the chosen representative, then the collapsed sector decomposition has total bond dimension equal to the sum of the original prepared block dimensions.

It also adds the prepared-block discharge of that same-dimension hypothesis: `MPSTensor.dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr`, `MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr`, and `MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr`. These use the TP, primitive, irreducible, positive-bond-dimension assumptions to rule out MPV-phase-equivalent blocks of differing bond dimensions.

This does not finish the arbitrary-input bridge. It separates the total-dimension obstruction from the positive-length supplier and leaves the CPSV16 §II.A weight-normalization input as an explicit remaining obligation.

Review response:
- The blueprint statements now include the nonzero-weight hypothesis `hμne`.
- The backwards statement-level `\uses{thm:paperbnt_supplier_prepared}` was removed.
- Docstrings no longer use the forbidden shorthand “heterogeneous”; they spell out blocks of differing bond dimensions.
- The requested local source anchors are kept in blueprint comments, including `eq:II_CF1` at `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 237-246 and `prop:char-BNT` at lines 271-279 and 1135-1148.
- The PGVWC07 canonical-form theorem entry now records the proof-order anchors from `Papers/quant-ph_0608197/MPSarchive.tex` lines 765-832, and `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex` states that a faithful formalization should follow that proof order from an arbitrary translation-invariant representation.
- The Lean module documentation in `CanonicalForm/Reduction.lean` and `CanonicalForm/Existence.lean` now separates the support-splitting proof step from the later dual fixed-point diagonalization in PGVWC07 lines 827-832.
- The normal-reduction docs now distinguish PGVWC07's unital full-rank fixed-point gauge from the local dual left-canonical TP-gauge theorem.

Validation:
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier`
- `lake build TNLean.MPS.CanonicalForm.Reduction TNLean.MPS.CanonicalForm.Existence`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction.TPGauge TNLean.MPS.CanonicalForm.NormalReduction.Main`
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `git diff --check`

The blueprint sync still reports the pre-existing parent-Hamiltonian and PEPS declaration gaps; the declarations added here are present and are not reported missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Lean theorems used for length-zero/bond-dimension bookkeeping in the BNT supplier path; risk is mainly proof fragility and subtle assumptions around bond-dimension equality inside phase classes.
> 
> **Overview**
> Records the missing *length-zero dimension bookkeeping* for the BNT phase-class quotient by proving `collapsedBntSectorDecomp.totalDim = ∑ dim` under nonzero weights plus a same-bond-dimension-in-class hypothesis (`collapsedBntSectorDecomp_totalDim_eq_sum_dim`).
> 
> Discharges that hypothesis for *prepared* TP/primitive/irreducible blocks by proving phase-equivalent blocks must have equal bond dimension (via overlap limits), and packages this into a prepared-only total-dimension corollary used by the SectorBNT supplier.
> 
> Separately tightens/clarifies documentation and blueprint/gap notes around canonical-form proof scope and source-proof ordering (PGVWC07/CPSV16), including small wording/math notation fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec207d1d6e1c7a21e655213a8e061eddaf4d140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

