### PR TITLE
style(MPS/BNT): rename separated BNT helpers

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -308,7 +308,7 @@ section SeparatedNormalBNT
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
-/-- Separated-hypotheses version of normal-CF-BNT cross-overlap decay.
+/-- Separated-hypotheses version of normal BNT cross-overlap decay.
 
 Only irreducibility, left-canonical normalization, and the BNT non-equivalence
 assumption are used. -/

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -26,13 +26,13 @@ auxiliary tools for already separated finite block families.
 1. **`BlocksNotGaugePhaseEquiv`**: the separation condition asserting that distinct
    equal-dimension blocks are not gauge-phase equivalent.
 
-2. **`cross_overlap_tendsto_zero_of_separated_CFBNT_data`**: separated injective
+2. **`cross_overlap_tendsto_zero_of_separated_bnt_data`**: separated injective
    left-canonical blocks have decaying cross-overlaps. The proof combines:
    - Dimension-mismatch case: `mpvOverlap_tendsto_zero_of_dim_ne`
    - Same-dimension case: `mpvOverlap_tendsto_zero` (using `blocks_not_equiv` to supply
      `¬GaugePhaseEquiv`)
 
-3. **`isBNT_of_separated_CFBNT_data`**: the separated block hypotheses give
+3. **`isBNT_of_separated_bnt_data`**: the separated block hypotheses give
    a valid `IsBNT` structure with the required overlap and independence properties.
 
 4. **`IsNormalCanonicalFormBNT`**: normal-canonical separated hypotheses retained for
@@ -246,17 +246,17 @@ lemma exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal
   obtain ⟨N0, hN0⟩ := Filter.mem_atTop_sets.mp hOrtho
   exact ⟨N0, fun N hN => hN0 N (le_of_lt hN)⟩
 
-/-! ### Cross-overlap decay from separated CF-BNT hypotheses -/
+/-! ### Cross-overlap decay from separated BNT hypotheses -/
 
-section SeparatedCFBNT
+section SeparatedBNT
 
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
-/-- Separated-hypotheses version of CF-BNT cross-overlap decay.
+/-- Separated-hypotheses version of BNT cross-overlap decay.
 
 Only injectivity, left-canonical normalization, and the BNT non-equivalence assumption are used. -/
-theorem cross_overlap_tendsto_zero_of_separated_CFBNT_data
+theorem cross_overlap_tendsto_zero_of_separated_bnt_data
     [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hInj : HasInjectiveBlocks (d := d) A)
@@ -283,7 +283,7 @@ theorem cross_overlap_tendsto_zero_of_separated_CFBNT_data
 
 The only role of `μ` is to specify the block-diagonal tensor `toTensorFromBlocks μ A` and its
 obvious coefficient decomposition.  Strict weight ordering is not used here. -/
-lemma isBNT_of_separated_CFBNT_data [∀ k, NeZero (dim k)]
+lemma isBNT_of_separated_bnt_data [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hInj : HasInjectiveBlocks (d := d) A)
@@ -297,13 +297,13 @@ lemma isBNT_of_separated_CFBNT_data [∀ k, NeZero (dim k)]
     exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal A
       hOverlap.overlap_tendsto_one
       (fun i j hij =>
-        cross_overlap_tendsto_zero_of_separated_CFBNT_data A hInj hLeft hBlocks i j hij)
+        cross_overlap_tendsto_zero_of_separated_bnt_data A hInj hLeft hBlocks i j hij)
 
-end SeparatedCFBNT
+end SeparatedBNT
 
-/-! ### Cross-overlap decay from separated normal-CF-BNT hypotheses -/
+/-! ### Cross-overlap decay from separated normal BNT hypotheses -/
 
-section SeparatedNormalCFBNT
+section SeparatedNormalBNT
 
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
@@ -312,7 +312,7 @@ variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
 Only irreducibility, left-canonical normalization, and the BNT non-equivalence
 assumption are used. -/
-theorem cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
+theorem cross_overlap_tendsto_zero_of_separated_normal_bnt_data
     [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hIrr : HasIrreducibleBlocks (d := d) A)
@@ -338,7 +338,7 @@ theorem cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
 /-- The NT hypotheses already supply the `spans_mpv` and `eventually_li` hypotheses used by the
 proportional-FT / permutation arguments. The only missing ingredient for a full `IsBNT`
 construction is blockwise `IsNormal`. -/
-theorem spans_mpv_and_eventually_li_of_separated_normalCFBNT_data [∀ k, NeZero (dim k)]
+theorem spans_mpv_and_eventually_li_of_separated_normal_bnt_data [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hNCF : IsNormalCanonicalForm μ A)
@@ -351,7 +351,7 @@ theorem spans_mpv_and_eventually_li_of_separated_normalCFBNT_data [∀ k, NeZero
    exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal A
      (fun j => hNCF.overlap_tendsto_one j)
      (fun i j hij =>
-       cross_overlap_tendsto_zero_of_separated_normalCFBNT_data A
+       cross_overlap_tendsto_zero_of_separated_normal_bnt_data A
          hNCF.toHasIrreducibleBlocks
          hNCF.toIsLeftCanonicalBlockFamily
          hBlocks i j hij)⟩
@@ -362,7 +362,7 @@ Here `hNCF` supplies normality via the primitive-transfer-map characterization f
 `IsNormalCanonicalForm`, while `hNormal` supplies the equivalent algebraic `IsNormal` hypotheses
 (eventual block injectivity) required by `IsBNT`. In applications `hNormal` comes from the
 Wielandt / primitive-to-normal implication. -/
-theorem isBNT_of_separated_normalCFBNT_data [∀ k, NeZero (dim k)]
+theorem isBNT_of_separated_normal_bnt_data [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ)
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hNCF : IsNormalCanonicalForm μ A)
@@ -370,10 +370,10 @@ theorem isBNT_of_separated_normalCFBNT_data [∀ k, NeZero (dim k)]
     (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A) :
     IsBNT (toTensorFromBlocks μ A) r dim A := by
   obtain ⟨hSpans, hLI⟩ :=
-    spans_mpv_and_eventually_li_of_separated_normalCFBNT_data μ A hNCF hBlocks
+    spans_mpv_and_eventually_li_of_separated_normal_bnt_data μ A hNCF hBlocks
   exact ⟨hNormal, hSpans, hLI⟩
 
-end SeparatedNormalCFBNT
+end SeparatedNormalBNT
 
 namespace IsNormalCanonicalFormBNT
 
@@ -389,7 +389,7 @@ theorem cross_overlap_tendsto_zero
     [∀ k, NeZero (dim k)]
     (hNCF : IsNormalCanonicalFormBNT μ A) (j k : Fin r) (hjk : j ≠ k) :
     Tendsto (fun N => mpvOverlap (d := d) (A j) (A k) N) atTop (nhds 0) :=
-  cross_overlap_tendsto_zero_of_separated_normalCFBNT_data A
+  cross_overlap_tendsto_zero_of_separated_normal_bnt_data A
     hNCF.toHasIrreducibleBlocks
     hNCF.toIsLeftCanonicalBlockFamily
     hNCF.blocks_not_equiv
@@ -406,7 +406,7 @@ lemma isBNT [∀ k, NeZero (dim k)]
     (hNCF : IsNormalCanonicalFormBNT μ A)
     (hNormal : ∀ j, IsNormal (A j)) :
     IsBNT (toTensorFromBlocks μ A) r dim A :=
-  isBNT_of_separated_normalCFBNT_data μ A
+  isBNT_of_separated_normal_bnt_data μ A
     hNCF.toIsNormalCanonicalForm
     hNormal
     hNCF.blocks_not_equiv

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -124,7 +124,7 @@ theorem collapsedBntSectorDecomp_hasBNT
         (blocks (classes.repr j)) (hIrr (classes.repr j))
         (hTP (classes.repr j)) (hPrim (classes.repr j))
     · intro i j hij
-      exact cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
+      exact cross_overlap_tendsto_zero_of_separated_normal_bnt_data
         (fun j : Fin classes.g => blocks (classes.repr j))
         (HasIrreducibleBlocks.ofForall (fun j => hIrr (classes.repr j)))
         (IsLeftCanonicalBlockFamily.ofForall (fun j => hTP (classes.repr j)))
@@ -207,7 +207,7 @@ private theorem bntSectorDecomp_overlapData_basisSpan_aux
       (hPrim (classes.repr j))
   · intro i j hij
     simpa [P, collapsedBntSectorDecomp] using
-      cross_overlap_tendsto_zero_of_separated_normalCFBNT_data
+      cross_overlap_tendsto_zero_of_separated_normal_bnt_data
       (fun j : Fin classes.g => blocks (classes.repr j))
       (HasIrreducibleBlocks.ofForall (fun j => hIrr (classes.repr j)))
       (IsLeftCanonicalBlockFamily.ofForall (fun j => hTP (classes.repr j)))

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -55,7 +55,8 @@ The Z-gauge construction (Theorem 3.8 steps 5–7) is fully proved.
 ## Key references
 
 * arXiv:1708.00029 (De las Cuevas–Schuch–Pérez-García–Cirac, 2017)
-* `blocks_match_of_sameMPV₂_CFBNT` in `Full.lean` — structural template for Theorem 3.4
+* `MPSTensor.ft_sector_bnt_proportional_sector_match` — current
+  sector-decomposition matching template for the non-periodic theorem
 * Z-gauge construction lemmas in `ZGauge.lean` (PR #94)
 -/
 
@@ -279,7 +280,8 @@ their bases of periodic tensors match: equal block counts, a bijection, and per-
 In the paper, proportional MPVs imply the overlap dichotomy; here the dichotomy is
 taken as a direct hypothesis via `PeriodicOverlapHypothesis`.
 
-The proof mirrors `blocks_match_of_sameMPV₂_CFBNT` in `Full.lean`:
+The proof follows the same finite-matching pattern as the current
+sector-decomposition matching theorem:
 1. Non-decaying overlap → `HetRepeatedBlocks` matching for each block.
 2. Injectivity from `HetRepeatedBlocks.trans` + non-repetition.
 3. Injective maps on finite types → equal cardinalities.

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -578,7 +578,7 @@ converse true.  Once that converse is proved, the `sorry` below can be
 discharged by the procedure outlined above. -/
   -- (Implementation: the forward BDCF direction follows from
   --  `exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal` together with
-  --  `cross_overlap_tendsto_zero_of_separated_normalCFBNT_data`; the missing converse
+  --  `cross_overlap_tendsto_zero_of_separated_normal_bnt_data`; the missing converse
   --  would be a lemma in `CanonicalForm/BlockDiagonalCommutant`.)
 private lemma not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -61,9 +61,8 @@ tensor family, the proof obtains the equality labelled `eq:inj_equal_edge`:
 for every edge and every matrix `X`, inserting `X` on that edge in the first
 PEPS gives the same state as inserting `X` on the same edge in the modified
 second PEPS. Blocking one vertex against its complement and applying
-`inj_equal_tensors_2` then gives $A_v = \lambda_v \tilde{B}_v$; the scalars
-$\lambda_v$ are
-absorbed into the edge gauges.
+`inj_equal_tensors_2` then gives $A_v = \lambda_v \cdot \tilde{B}_v$; the
+scalars $\lambda_v$ are absorbed into the edge gauges.
 
 ## References
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -183,7 +183,7 @@ and~\cite{Cirac2021Matrix}.
 
 \begin{theorem}[Cross-overlap decay from explicit BNT hypotheses]
     \label{thm:cross_overlap_zero_split}
-    \lean{MPSTensor.cross_overlap_tendsto_zero_of_separated_CFBNT_data}
+    \lean{MPSTensor.cross_overlap_tendsto_zero_of_separated_bnt_data}
     \leanok
     \uses{def:mpv_overlap, def:gauge_phase_equiv}
     Let $(A_j)_{j=1}^r$ be injective and trace-preserving normalized.
@@ -200,7 +200,7 @@ and~\cite{Cirac2021Matrix}.
 
 \begin{lemma}[BNT from explicit blockwise hypotheses]
     \label{lem:cf_bnt_is_bnt_split}
-    \lean{MPSTensor.isBNT_of_separated_CFBNT_data}
+    \lean{MPSTensor.isBNT_of_separated_bnt_data}
     \leanok
     \uses{def:bnt, def:mpv_overlap}
     Let $(\mu_k, A_k)_{k=1}^r$ be a weighted block family. Assume that the

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1485,13 +1485,13 @@ which is then combined with overlap estimates and the leading-block peel.
     \label{lem:ft_sector_bnt_equal_sector_data_different_dims}
     \lean{MPSTensor.ft_sector_bnt_equal_sector_data}
     \leanok
-    \uses{def:same_mpv, def:bnt, def:gauge_phase_equiv}
+    \uses{def:same_mpv2, def:bnt, def:gauge_phase_equiv}
     Let $P$ and $Q$ be two BNT sector decompositions
     (Definition~\ref{def:bnt}), each admitting a unit-modulus copy weight in
     every basis sector, possibly with different block counts and different bond
     dimensions in corresponding blocks.
     If their block-diagonal tensors generate the same MPV family
-    (Definition~\ref{def:same_mpv}), then the basis sectors are
+    (Definition~\ref{def:same_mpv2}), then the basis sectors are
     bijectively matched by a permutation $\beta$, each matched basis pair is
     gauge-phase equivalent (Definition~\ref{def:gauge_phase_equiv}), the
     matched copy multiplicities agree, and the copy weights agree up to a

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1477,12 +1477,12 @@ which is then combined with overlap estimates and the leading-block peel.
 \end{proof}
 
 %% ---------------------------------------------------------
-\section{Heterogeneous equal-case block matching}%
-\label{sec:hetero_equal_case_ft}
+\section{Equal-case block matching with differing bond dimensions}%
+\label{sec:different_bond_dimension_equal_case_ft}
 %% ---------------------------------------------------------
 
-\begin{lemma}[Heterogeneous equal-case block matching]%
-    \label{lem:fundamentalTheorem_equalMPV_CFBNT_hetero}
+\begin{lemma}[Equal-case block matching with differing bond dimensions]%
+    \label{lem:ft_sector_bnt_equal_sector_data_different_dims}
     \lean{MPSTensor.ft_sector_bnt_equal_sector_data}
     \leanok
     \uses{def:same_mpv, def:bnt, def:gauge_phase_equiv}


### PR DESCRIPTION
This PR removes old `_CFBNT` vocabulary from live separated-block helper declarations in the BNT construction layer.

The renamed declarations are:
- `MPSTensor.cross_overlap_tendsto_zero_of_separated_CFBNT_data` → `MPSTensor.cross_overlap_tendsto_zero_of_separated_bnt_data`
- `MPSTensor.isBNT_of_separated_CFBNT_data` → `MPSTensor.isBNT_of_separated_bnt_data`

It also renames the internal separated normal-BNT helper declarations in the same file from `normalCFBNT` to `normal_bnt`, updates dependent references in `PhaseClassSectorData.lean` and `Periodic/Overlap/SelfOverlap.lean`, and updates the Chapter 10 blueprint `\lean{}` tags. The mathematical statements and proofs are unchanged; this is a reader-facing cleanup toward #1685's removal of one-copy/path-dependent naming from the BNT proof surface.

**No compatibility alias is provided.** The old names encode retired internal `_CFBNT` shorthand for separated BNT conclusions, rather than a mathematical object to preserve as public vocabulary (see [`docs/CONTRIBUTING.md` Section Mathematical-language renames](docs/CONTRIBUTING.md#mathematical-language-renames)).

The PR also updates a periodic-overlap comment to the renamed separated normal-BNT cross-overlap theorem, renames the Chapter 13 sector-data label away from `_CFBNT`, and points that differing-bond-dimension entry to `def:same_mpv2`, matching the Lean theorem `MPSTensor.ft_sector_bnt_equal_sector_data`.

The PEPS docstring tilde is written in LaTeX notation so the style gate is clean on this branch.

Validation:
- `lake build TNLean.MPS.BNT.Construction`
- `lake build TNLean.MPS.BNT.Construction TNLean.PEPS.FundamentalTheorem`
- `lake build TNLean.MPS.CanonicalForm.PhaseClassSectorData TNLean.MPS.Periodic.Overlap.SelfOverlap TNLean.PEPS.FundamentalTheorem`
- `lake build TNLean.MPS.Periodic.FundamentalTheorem`
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `git diff --check`

The blueprint sync still reports the pre-existing parent-Hamiltonian and PEPS declaration gaps; the renamed declarations are present in `blueprint/lean_decls` and are not reported missing.

Refs #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low functional risk (pure renames/docs), but **medium integration impact** because the old `_CFBNT` lemma names are removed with no compatibility aliases, so downstream code will break until updated.
> 
> **Overview**
> Removes the legacy `_CFBNT` naming from the separated-block helper API in `MPS/BNT/Construction.lean`, renaming the main lemmas to `cross_overlap_tendsto_zero_of_separated_bnt_data` and `isBNT_of_separated_bnt_data`, and similarly renaming the “normal” variants to `*_normal_bnt_data`.
> 
> Updates all in-repo call sites and documentation pointers to the new names (e.g. `CanonicalForm/PhaseClassSectorData.lean`, a periodic-overlap comment, and blueprint `\lean{}` tags), plus minor narrative/doc cleanups in periodic FT and PEPS/blueprint text. **No compatibility aliases are provided**, so this is a source-breaking rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c5e5e61fda9baa4a253fdd925532c54cea8e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
