### PR TITLE
doc(MPS/FT): spell matched copy weights

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -77,7 +77,7 @@ noncomputable def matched_block_gauge {Q : SectorDecomposition d}
   change GL (Fin (Q.basisDim (Q.flatIndexEquiv.symm s).1)) ℂ
   exact Xblock (Q.flatIndexEquiv.symm s).1
 
-/-- **Global block gauge from matched sector and weight data.**
+/-- **Global block gauge from matched sectors and copy weights.**
 
 Assume the sectors of two sector decompositions have already been matched, and
 assume that the block gauges, phases, and copy-weight identities all use the

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1299,7 +1299,7 @@ BNT basis.
     of the corresponding coefficients for all sufficiently large lengths.
 \end{proof}
 
-\begin{theorem}[Global gauge from matched sector and weight data]%
+\begin{theorem}[Global gauge from matched sectors and copy weights]%
     \label{thm:sector_bnt_global_gauge_of_matched_weights}
     \lean{MPSTensor.sector_bnt_global_gauge_of_matched_weights}
     \leanok


### PR DESCRIPTION
## Summary

This PR replaces the phrase "weight data" by "copy weights" in the matched-sector global gauge theorem title and the corresponding Lean docstring.

The theorem hypothesis is a pointwise identity between copy weights, not a separate structured datum. The revised wording is meant to make the CPSV16/BNT bookkeeping statement readable without suggesting an additional formal object.

## Verification

- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental`
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (reports the existing parent-Hamiltonian blueprint gaps)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates theorem/documentation titles and docstrings; no Lean definitions, proofs, or interfaces change.
> 
> **Overview**
> Renames the `sector_bnt_global_gauge_of_matched_weights` theorem’s displayed description from **“matched sector and weight data”** to **“matched sectors and copy weights”** to better reflect that the hypothesis is a pointwise identity on copy weights.
> 
> Applies the same wording update in the blueprint theorem title to keep the Lean docs and LaTeX blueprint consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2eb8e35c129e4f79d31043f4a72f338bb132f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->