### PR TITLE
doc(MPS): use rectangular bond-dimension prose

### DIFF
--- a/TNLean/MPS/CanonicalForm/CyclicSectors/CompressionPositive.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/CompressionPositive.lean
@@ -30,9 +30,10 @@ section CompressionPositiveMPV
 
 /-- A supported-projection compression preserves MPVs at all positive lengths.
 
-This is the usable replacement for a heterogeneous `SameMPV₂` statement: compression changes the
-`N = 0` coefficient from `trace 1 = D` to `trace P`, so exact all-length equality is false in
-general, but every positive-length MPV is preserved. -/
+This is the usable replacement for a rectangular `SameMPV₂` statement:
+compression changes the `N = 0` coefficient from `trace 1 = D` to `trace P`,
+so exact all-length equality is false in general, but every positive-length MPV
+is preserved. -/
 theorem exists_compressedTensor_of_supported_projection_pos_mpv
     (A : MPSTensor d D) (P : MatrixAlg D)
     (hP : IsOrthogonalProjection P)

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -184,8 +184,8 @@ from arXiv:1606.00608 (`Papers/1606.00608/MPDO-22-12-17-2.tex:271-274`):
 * (iii) there is some `N₀` such that for all `N > N₀`, the MPV states
       `mpvState (blocks j) N` are linearly independent.
 
-Here `blocks` is a heterogeneous family `(j : Fin g) → Σ Dj, MPSTensor d Dj` to allow
-different per-block bond dimensions.
+Here `blocks` is a family `(j : Fin g) → Σ Dj, MPSTensor d Dj`, allowing
+different bond dimensions for different blocks.
 -/
 structure IsCPSVBasisOfNormalTensors {g : ℕ} (A : MPSTensor d D)
     (blocks : (j : Fin g) → Σ Dj : ℕ, MPSTensor d Dj) : Prop where

--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -23,7 +23,7 @@ variable {d : ℕ}
 
 /-! ### Section 4. MPV phase-class representatives -/
 
-/-- Heterogeneous MPV phase equivalence between two individual blocks.
+/-- MPV phase equivalence between two individual blocks with possibly different bond dimensions.
 
 `MPVBlockPhaseEquiv A B` means that the finite-chain MPV of `B` is a nonzero
 scalar power times the finite-chain MPV of `A`, uniformly in the chain length and
@@ -34,11 +34,11 @@ def MPVBlockPhaseEquiv {d DA DB : ℕ} (A : MPSTensor d DA) (B : MPSTensor d DB)
 
 namespace MPVBlockPhaseEquiv
 
-/-- Reflexivity of heterogeneous MPV phase equivalence. -/
+/-- Reflexivity of MPV phase equivalence for different bond dimensions. -/
 lemma refl {D : ℕ} (A : MPSTensor d D) : MPVBlockPhaseEquiv A A :=
   ⟨1, one_ne_zero, fun N σ => by simp⟩
 
-/-- Symmetry of heterogeneous MPV phase equivalence. -/
+/-- Symmetry of MPV phase equivalence for different bond dimensions. -/
 lemma symm {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
     (h : MPVBlockPhaseEquiv A B) : MPVBlockPhaseEquiv B A := by
   rcases h with ⟨ζ, hζ, hmpv⟩
@@ -47,7 +47,7 @@ lemma symm {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
   rw [hmpv N σ]
   rw [inv_pow, ← mul_assoc, inv_mul_cancel₀ (pow_ne_zero N hζ), one_mul]
 
-/-- Transitivity of heterogeneous MPV phase equivalence. -/
+/-- Transitivity of MPV phase equivalence for different bond dimensions. -/
 lemma trans {DA DB DC : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
     {C : MPSTensor d DC} (hAB : MPVBlockPhaseEquiv A B)
     (hBC : MPVBlockPhaseEquiv B C) : MPVBlockPhaseEquiv A C := by
@@ -58,7 +58,7 @@ lemma trans {DA DB DC : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
   rw [hηmpv N σ, hζmpv N σ, mul_pow]
   ring
 
-/-- Gauge-phase equivalence after a dimension cast gives heterogeneous MPV phase equivalence. -/
+/-- Gauge-phase equivalence after a dimension cast gives rectangular MPV phase equivalence. -/
 lemma of_gaugePhaseEquiv_cast {DA DB : ℕ} (A : MPSTensor d DA) (B : MPSTensor d DB)
     (hdim : DA = DB)
     (hGPE : GaugePhaseEquiv (d := d)
@@ -71,7 +71,7 @@ lemma of_gaugePhaseEquiv_cast {DA DB : ℕ} (A : MPSTensor d DA) (B : MPSTensor 
     (A := cast (congr_arg (MPSTensor d) hdim) A) (B := B) X ζ hX N σ,
     mpv_cast_dim hdim A N σ]
 
-/-- Heterogeneous MPV phase equivalence gives a scalar-power equality of MPV state vectors. -/
+/-- MPV phase equivalence gives a scalar-power equality of MPV state vectors. -/
 lemma exists_mpvState_eq_smul {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
     (h : MPVBlockPhaseEquiv A B) (N : ℕ) :
     ∃ ζ : ℂ, ζ ≠ 0 ∧ mpvState (d := d) B N = ζ ^ N • mpvState (d := d) A N := by
@@ -113,8 +113,8 @@ finite family by this relation is enough to absorb all repeated scalar-power
 copies into sector weights.
 
 This is the family-indexed specialization of `MPVBlockPhaseEquiv`, so the
-homogeneous phase-class relation shares the heterogeneous block-level relation
-rather than duplicating it. -/
+fixed-family phase-class relation shares the block-level relation for different
+bond dimensions rather than duplicating it. -/
 def MPVPhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k)) (j k : Fin r) : Prop :=
   MPVBlockPhaseEquiv (blocks j) (blocks k)

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -715,7 +715,7 @@ assertion implies the coordinate-level one required by `groupedBlockCastAgrees`,
 sector-comparison theorem uses it to remove the former blocking-coordinate hypothesis.
 -/
 
-/-- Casting the physical dimension of both tensors preserves heterogeneous MPV equality. -/
+/-- Casting the physical dimension of both tensors preserves rectangular MPV equality. -/
 theorem sameMPV₂_cast_physDim {d₁ d₂ D₁ D₂ : ℕ} (h : d₁ = d₂)
     (A : MPSTensor d₁ D₁) (B : MPSTensor d₁ D₂) :
     SameMPV₂

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -93,8 +93,9 @@ def SameMPV (A B : MPSTensor d D) : Prop :=
 
 /-- MPV equality for possibly different bond dimensions.
 
-This is the heterogeneous version of `SameMPV`, used later when comparing
-block decompositions whose summands need not live in the same matrix algebra. -/
+This is the version of `SameMPV` for different bond dimensions, used later
+when comparing block decompositions whose summands need not live in the same
+matrix algebra. -/
 def SameMPV₂ {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
   ∀ (N : ℕ) (σ : Fin N → Fin d), mpv A σ = mpv B σ
 

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -64,11 +64,13 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ## Heterogeneous RepeatedBlocks -/
+/-! ## Repeated blocks for different bond dimensions -/
 
-/-- Heterogeneous version of `RepeatedBlocks`: allows blocks with different bond dimensions
-by packing a dimension-equality witness. This avoids explicit `cast` manipulation in
-theorems involving families of varying-dimension blocks (e.g., `IsIrreducibleForm`). -/
+/-- Version of `RepeatedBlocks` for blocks with different ambient bond dimensions.
+
+The witness includes equality of the two bond dimensions, avoiding explicit
+`cast` manipulation in theorems involving families of varying-dimension blocks
+(for example, `IsIrreducibleForm`). -/
 def HetRepeatedBlocks {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
   ∃ (h : D₁ = D₂), RepeatedBlocks (cast (congr_arg (MPSTensor d) h) A) B
 
@@ -97,7 +99,7 @@ theorem HetRepeatedBlocks.of_repeatedBlocks {D : ℕ} {A B : MPSTensor d D}
 /-! ## Periodic block matching witness -/
 
 /-- Witness for periodic block matching: equal block counts, a bijection, and per-block
-heterogeneous `RepeatedBlocks` equivalence. This is the periodic analogue of
+`RepeatedBlocks` equivalence after matching bond dimensions. This is the periodic analogue of
 `BlockPermutationGaugePhaseConclusion`. -/
 abbrev PeriodicBlockMatchingWitness
     {rA rB : ℕ}
@@ -291,8 +293,8 @@ The single-block proportional-to-equal reduction is now split explicitly.
 `PeripheralProportionalCaseRootFromRescaling` provides the missing phase-rescaling
 step, and `peripheralProportionalCase_periodicFT_of_rootFromRescaling` shows that,
 once this step is available, the exact-MPV theorem
-`peripheralProportionalCase_periodicFT_of_sameMPV` yields the heterogeneous
-repeated-block conclusion. Thus the remaining mathematical gap is the multi-block
+`peripheralProportionalCase_periodicFT_of_sameMPV` yields the repeated-block
+conclusion for different bond dimensions. Thus the remaining mathematical gap is the multi-block
 existence step that turns proportionality of the assembled tensors into the
 non-decaying cross-overlap hypotheses `exists_nondecaying_A/B`.
 

--- a/TNLean/Spectral/MPVOverlapDecay.lean
+++ b/TNLean/Spectral/MPVOverlapDecay.lean
@@ -39,7 +39,7 @@ equivalent, then the MPV overlaps decay to `0` as `N → ∞`.
    `Matrix.entryLinearMap ℂ ℂ p q`.
 5. Reassemble the finite sum using `tendsto_finset_sum`.
 
-## Rectangular (heterogeneous bond dimensions)
+## Rectangular overlaps for different bond dimensions
 
 `mpvOverlap_tendsto_zero_of_mixedTransferSpectralRadius_lt_one` handles the case where
 `A : MPSTensor d D₁` and `B : MPSTensor d D₂` may have different bond dimensions,
@@ -125,7 +125,7 @@ theorem mpvInner_tendsto_zero
 
 end
 
-/-! ## Rectangular (heterogeneous bond dimensions) -/
+/-! ## Rectangular overlaps for different bond dimensions -/
 
 section TraceDecay
 

--- a/TNLean/Spectral/MPVOverlapTrace.lean
+++ b/TNLean/Spectral/MPVOverlapTrace.lean
@@ -29,7 +29,7 @@ as the trace of the $N$-th power of the mixed transfer operator.
 The trace-expansion helpers (`linearMap_trace_eq_sum_apply_single`,
 `entry_mul_single_mul`) are provided by `TNLean.Spectral.TraceExpansion`.
 
-## Rectangular (heterogeneous bond dimensions)
+## Rectangular overlaps for different bond dimensions
 
 `trace_mixedTransferMap₂_pow_eq_mpvOverlap` is the rectangular analogue, where
 `A : MPSTensor d D₁` and `B : MPSTensor d D₂` may have different bond dimensions and the
@@ -99,7 +99,7 @@ theorem trace_mixedTransferMap_pow_eq_mpvOverlap {d D : ℕ} [NeZero D]
 
 end Main
 
-/-! ## Rectangular (heterogeneous bond dimensions) -/
+/-! ## Rectangular overlaps for different bond dimensions -/
 
 section MainRect
 

--- a/TNLean/Spectral/MixedTransfer.lean
+++ b/TNLean/Spectral/MixedTransfer.lean
@@ -24,7 +24,7 @@ multi-block fundamental theorem.
 * `mixedTransferMap_pow_apply`: `F_{AB}^N(X) = ∑_σ w_A(σ) X w_B(σ)†`
 * `trace_mixedTransferMap_pow_identity`: trace formula for MPV cross-correlations
 
-## Rectangular (heterogeneous bond dimensions)
+## Rectangular mixed transfer maps for different bond dimensions
 
 `mixedTransferMap₂` generalizes `mixedTransferMap` to tensors `A : MPSTensor d D₁` and
 `B : MPSTensor d D₂` with possibly different bond dimensions, acting on
@@ -158,7 +158,7 @@ theorem mpv_inner_product_via_trace (A B : MPSTensor d D) (N : ℕ)
 
 end IteratedTransfer
 
-/-! ## Rectangular (heterogeneous bond dimensions) -/
+/-! ## Rectangular mixed transfer maps for different bond dimensions -/
 
 variable {D₁ D₂ : ℕ}
 
@@ -171,7 +171,7 @@ It acts on `D₁ × D₂` matrices by
 `X ↦ ∑ i, A i * X * (B i)ᴴ`.
 
 We implement it using `mulLeftLinearMap` / `mulRightLinearMap` from
-`Mathlib.Data.Matrix.Bilinear` (these support heterogeneous matrix multiplication). -/
+`Mathlib.Data.Matrix.Bilinear`, which support rectangular matrix multiplication. -/
 noncomputable def mixedTransferMap₂ {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
     Matrix (Fin D₁) (Fin D₂) ℂ →ₗ[ℂ] Matrix (Fin D₁) (Fin D₂) ℂ :=


### PR DESCRIPTION
## Summary

This PR removes the remaining "heterogeneous" wording from live Lean and blueprint source files, replacing it with mathematical descriptions such as "rectangular" and "different bond dimensions".

The affected text is confined to docstrings, module comments, and section comments around `SameMPV₂`, rectangular mixed transfer maps, overlap decay, phase covers, and the periodic block-matching witness. It also removes a stale prose reference to the deleted `_CFBNT`/`Full.lean` block-matching template, replacing it by a source-neutral reference to the current SectorBNT finite matching pattern. No declaration names, theorem statements, or proofs are changed.

## Relation to #1685

This is a cleanup step for the paper-faithful CPSV/PGVWC formalization surface: the prose now describes rectangular comparisons directly instead of using legacy vocabulary that is banned by `docs/prose_style.md`, and no longer points readers to a deleted alternative proof route.

## Verification

- `rg -n "heterogeneous|Heterogeneous|CFBNT|Full\\.lean|blocks_match_of_sameMPV₂_CFBNT" TNLean/MPS/Periodic/FundamentalTheorem.lean TNLean/Spectral TNLean/MPS/Defs.lean TNLean/MPS/Core/BlockingInfrastructure.lean TNLean/MPS/CanonicalForm/PhaseCover.lean TNLean/MPS/CanonicalForm/CyclicSectors/CompressionPositive.lean TNLean/MPS/CanonicalForm/Definitions.lean` returns no matches
- `lake build TNLean.Spectral.MPVOverlapTrace TNLean.Spectral.MPVOverlapDecay TNLean.Spectral.MixedTransfer`
- `lake build TNLean.MPS.Defs TNLean.MPS.Core.BlockingInfrastructure TNLean.MPS.CanonicalForm.PhaseCover TNLean.MPS.CanonicalForm.CyclicSectors.CompressionPositive TNLean.MPS.CanonicalForm.Definitions TNLean.MPS.Periodic.FundamentalTheorem`
- `lake build TNLean.MPS.CanonicalForm.PhaseCover TNLean.MPS.Periodic.FundamentalTheorem`
- `lake exe lint_style --github`
- `git diff --check`

The periodic builds report only pre-existing `sorry` warnings in unchanged periodic overlap modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring/comment-only updates across several MPS/Spectral modules; no theorem statements or proofs are changed, so functional risk is minimal aside from potential minor documentation drift.
> 
> **Overview**
> Updates documentation throughout the MPS canonical-form, periodic FT, blocking, and spectral overlap/mixed-transfer modules to replace legacy *“heterogeneous”* terminology with mathematically explicit phrasing like **“rectangular”** and **“different bond dimensions”**.
> 
> Also refreshes a few explanatory comments (e.g., around `SameMPV₂`, phase covers, and periodic block matching) to describe the same concepts without referring to removed/legacy proof templates; all changes are prose-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06205aa0e96e2863363e53b5d3050f3816fecbeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->