### PR TITLE
doc(PiAlgebra): correct RMP citation

### DIFF
--- a/TNLean/PiAlgebra/Construction.lean
+++ b/TNLean/PiAlgebra/Construction.lean
@@ -27,7 +27,8 @@ product algebra automorphism, then applies the block-permutation decomposition t
 ## References
 
 * [PerezGarcia2007String] Pérez-García, Verstraete, Wolf, Cirac (quant-ph/0608197)
-* [Cirac2017MPS] De las Cuevas, Schuch, Pérez-García, Cirac (arXiv:2011.12127)
+* [CPSV21] Cirac, Pérez-García, Schuch, Verstraete,
+  *Matrix product states and projected entangled pair states*, arXiv:2011.12127.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
+++ b/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
@@ -28,7 +28,8 @@ It also handles the single-block case where `SameMPV₂` directly gives `SameMPV
 ## References
 
 * [PerezGarcia2007String] Pérez-García, Verstraete, Wolf, Cirac (quant-ph/0608197)
-* [Cirac2017MPS] De las Cuevas, Schuch, Pérez-García, Cirac (arXiv:2011.12127)
+* [CPSV21] Cirac, Pérez-García, Schuch, Verstraete,
+  *Matrix product states and projected entangled pair states*, arXiv:2011.12127.
 -/
 
 open scoped Matrix BigOperators


### PR DESCRIPTION
## Summary

This PR corrects two Pi-algebra module references to the RMP review arXiv:2011.12127.

The old text paired the arXiv number for the Cirac--Perez-Garcia--Schuch--Verstraete review with the authors of a different 2017 paper. The corrected reference names CPSV21 and gives the review title, *Matrix product states and projected entangled pair states*.

No declaration names, theorem statements, or proofs are changed.

## Relation to #1685

This is a source-accuracy cleanup for the formalization surface around the 2007 MPS theorem and the 2021 RMP review: comments should point readers to the correct paper when they compare the Pi-algebra block-permutation material with the cited review.

## Verification

- `lake build TNLean.PiAlgebra.Construction TNLean.PiAlgebra.FundamentalTheoremComplete`
- `lake exe lint_style --github`
- `git diff --check`
- `rg -n "Cirac2017MPS|De las Cuevas, Schuch, Pérez-García, Cirac \\(arXiv:2011\\.12127\\)" TNLean/PiAlgebra --glob '*.lean'` returns no matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only changes updating bibliographic references; no declarations, statements, or proofs are modified.
> 
> **Overview**
> Updates the **References** sections in `TNLean/PiAlgebra/Construction.lean` and `TNLean/PiAlgebra/FundamentalTheoremComplete.lean` to replace the incorrect “Cirac2017MPS” entry with a corrected citation labeled `CPSV21`, including the proper author list and the review title for arXiv:2011.12127.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baae131b1f27b2ca59886537973821d4cb0509bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->