### PR TITLE
doc(MPS/BNT): use rendered RMP BNT numbering

### DIFF
--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -14,7 +14,7 @@ This module combines two natural units:
 ## Part 1: Basic BNT definitions (from `BasisNormalTensors`)
 
 Introduces the basic definitions for the **basis of normal tensors** (BNT) notion, as in
-Definition 4.2 of arXiv:2011.12127.
+Definition 4.3 of arXiv:2011.12127, lines 1846–1850.
 
 A decomposition into a basis of normal tensors for a tensor `A_total` is a finite family of
 normal tensors which
@@ -66,7 +66,7 @@ namespace MPSTensor
 
 /--
 `IsBNT A_total g dim A_bnt` means that the family `A_bnt` is a **basis of normal tensors** (BNT)
-for `A_total` in the sense of Definition 4.2 of arXiv:2011.12127.
+for `A_total` in the sense of Definition 4.3 of arXiv:2011.12127, lines 1846–1850.
 
 Informally, `A_bnt` is a finite family of normal tensors which spans the MPV family of `A_total`
 and whose MPV states become linearly independent for large enough system size. Here `IsNormal`

--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -14,7 +14,7 @@ This module combines two natural units:
 ## Part 1: Basic BNT definitions (from `BasisNormalTensors`)
 
 Introduces the basic definitions for the **basis of normal tensors** (BNT) notion, as in
-Definition 4.3 of arXiv:2011.12127, lines 1846–1850.
+Definition 4.2 of arXiv:2011.12127, lines 1846–1850.
 
 A decomposition into a basis of normal tensors for a tensor `A_total` is a finite family of
 normal tensors which
@@ -66,7 +66,7 @@ namespace MPSTensor
 
 /--
 `IsBNT A_total g dim A_bnt` means that the family `A_bnt` is a **basis of normal tensors** (BNT)
-for `A_total` in the sense of Definition 4.3 of arXiv:2011.12127, lines 1846–1850.
+for `A_total` in the sense of Definition 4.2 of arXiv:2011.12127, lines 1846–1850.
 
 Informally, `A_bnt` is a finite family of normal tensors which spans the MPV family of `A_total`
 and whose MPV states become linearly independent for large enough system size. Here `IsNormal`

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
@@ -222,9 +222,10 @@ copy witness `hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`, the power-sum coefficie
 The per-block unit-modulus hypothesis `hUnit` is taken as an explicit
 theorem-level argument rather than a structural field of
 `IsBNTCanonicalForm`: CPSV16 §II.A line 246 records only the *global*
-normalization $\exists j, \exists q, \|\mu_{j,q}\| = 1$, and CPSV21 §III.2
-Definition 4.3 (lines 1846–1884) normalizes the spectral radius of the
-*basis* tensors, not the copy coefficients $\mu_{j,q}$.  The per-block
+normalization $\exists j, \exists q, \|\mu_{j,q}\| = 1$, while CPSV21 §III.2
+uses Definition 4.2 (lines 1846–1850) for the BNT basis and the display at
+lines 1864–1884 for the two-layer expansion.  It normalizes the spectral
+radius of the *basis* tensors, not the copy coefficients $\mu_{j,q}$.  The per-block
 witness is implicit in CPSV16 §II.C line 1182's projection step and is
 therefore exposed here as a per-theorem hypothesis.
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
@@ -222,11 +222,12 @@ copy witness `hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`, the power-sum coefficie
 The per-block unit-modulus hypothesis `hUnit` is taken as an explicit
 theorem-level argument rather than a structural field of
 `IsBNTCanonicalForm`: CPSV16 §II.A line 246 records only the *global*
-normalization $\exists j, \exists q, \|\mu_{j,q}\| = 1$, while CPSV21 §III.2
-uses Definition 4.2 (lines 1846–1850) for the BNT basis and the display at
-lines 1864–1884 for the two-layer expansion.  It normalizes the spectral
-radius of the *basis* tensors, not the copy coefficients $\mu_{j,q}$.  The per-block
-witness is implicit in CPSV16 §II.C line 1182's projection step and is
+normalization $\exists j, \exists q, \|\mu_{j,q}\| = 1$, while CPSV21
+Section IV.A uses Definition 4.2 (lines 1846–1850) for the BNT basis and
+the display at lines 1864–1884 for the two-layer expansion.  It normalizes
+the spectral radius of the *basis* tensors, not the copy coefficients
+$\mu_{j,q}$.  The per-block witness is implicit in CPSV16 §II.C line 1182's
+projection step and is
 therefore exposed here as a per-theorem hypothesis.
 
 Paper anchor: CPSV16 §II.C lines 1158–1167 (power-sum non-decay / exact

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -29,9 +29,10 @@ a `SectorDecomposition`.  It records:
 
 The per-block unit-modulus convention `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — implicit
 in CPSV16 §II.C line 1182's projection step and not explicitly stated in
-CPSV16 §II.A line 246 (which is global) nor in CPSV21 §III.2 lines 1846–1884
-(which normalizes the spectral radius of the BNT *basis tensors*, not the
-copy coefficients) — is **not** a structural field of `IsBNTCanonicalForm`.
+CPSV16 §II.A line 246 (which is global) nor in CPSV21 Section IV.A,
+lines 1846–1884 (which normalizes the spectral radius of the BNT *basis
+tensors*, not the copy coefficients) — is **not** a structural field of
+`IsBNTCanonicalForm`.
 The fundamental-theorem statements (`coeff_not_tendsto_zero_at_block`,
 `exists_block_match_of_sameMPV`, `bijective_match_of_sameMPV`,
 `ft_sector_bnt_equal_*`) take the per-block witness as an explicit

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -41,10 +41,11 @@ that actually need it.
 
 The structure does **not** impose an equal-modulus or strict-order
 condition on the raw sector weights `P.weight j q`.  CPSV16
-`eq:II_ABasicTensors` (line 286) and CPSV21 Definition 4.3 (lines 1846–1884)
-use raw entries `μ_{j,q}` and a coefficient `∑_q μ_{j,q}^N`; they do not
-require `|μ_{j,q}|` to be constant in `q`, nor do they impose a strict order
-on the moduli of distinct BNT basis elements.  The audit memo
+`eq:II_ABasicTensors` (line 286), CPSV21 Definition 4.2 (lines 1846–1850),
+and the CPSV21 two-layer display (lines 1864–1884) use raw entries
+`μ_{j,q}` and a coefficient `∑_q μ_{j,q}^N`; they do not require
+`|μ_{j,q}|` to be constant in `q`, nor do they impose a strict order on the
+moduli of distinct BNT basis elements.  The audit memo
 `audits/2026-05-13_cpsv16_sector_bnt_phase_1_multiplicity_audit.md` collects
 the counter-examples (`C ⊕ D`, `C ⊕ (1/2)C`, `C ⊕ (-C) ⊕ (1/2)C`) that
 motivate keeping the equal-modulus layer out of the core predicate; all of
@@ -97,7 +98,8 @@ mpv P.toTensor σ
 ```
 
 i.e. CPSV16 §II's two-layer BNT display (lines 271–301) and CPSV21
-Definition 4.3 (lines 1846–1884) with **raw** `μ_{j,q}` entries and
+Definition 4.2 (lines 1846–1850) together with the two-layer display
+(lines 1864–1884) with **raw** `μ_{j,q}` entries and
 coefficient `∑_q μ_{j,q}^N`.
 
 The audit `audits/2026-05-13_cpsv16_sector_bnt_phase_1_multiplicity_audit.md`
@@ -127,7 +129,7 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
     Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
       atTop (𝓝 1)
   /-- **BNT eventual linear independence** of the basis MPV states
-  (CPSV21 Definition 4.3, lines 1846–1850; combined-family LI input at
+  (CPSV21 Definition 4.2, lines 1846–1850; combined-family LI input at
   CPSV16 lines 1121–1132). -/
   bnt_data : HasBNTSectorData P
   /-- **Block distinctness.**  No gauge-phase equivalence between distinct

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.CanonicalForm.PhaseCover
 This module contains the CPSV16 §II.C lines 1187–1188 coefficient
 comparison in the full-basis bijection form.  The full basis bijection
 `β : Fin Q.basisCount ≃ Fin P.basisCount` (from `StrongMatch`) together with
-`IsBNTCanonicalForm`'s CPSV21 §III.2 / Definition 4.2 BNT input and
+`IsBNTCanonicalForm`'s CPSV21 Section IV.A / Definition 4.2 BNT input and
 per-block spectral-radius-one normalization ensure the substitution has no
 residual unmatched terms.  BNT linear independence of the `P`-basis
 (`hP.bnt_data`) then yields eventual **exact** coefficient identities.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -11,17 +11,18 @@ import TNLean.MPS.CanonicalForm.PhaseCover
 This module contains the CPSV16 §II.C lines 1187–1188 coefficient
 comparison in the full-basis bijection form.  The full basis bijection
 `β : Fin Q.basisCount ≃ Fin P.basisCount` (from `StrongMatch`) together with
-`IsBNTCanonicalForm`'s CPSV21 §III.2 / Definition 4.3 per-block
-spectral-radius-one normalization ensures the substitution has no residual
-unmatched terms.  BNT linear independence of the `P`-basis
+`IsBNTCanonicalForm`'s CPSV21 §III.2 / Definition 4.2 BNT input and
+per-block spectral-radius-one normalization ensure the substitution has no
+residual unmatched terms.  BNT linear independence of the `P`-basis
 (`hP.bnt_data`) then yields eventual **exact** coefficient identities.
 
 Paper anchors:
 
 * CPSV16 §II.C lines 1182–1188: match every BNT basis tensor, substitute the
   gauge-phase identities, and compare the coefficients of the BNT basis.
-* CPSV21 Definition 4.3 lines 1846–1884: per-block BNT normalization that
-  makes every sector participate in the full-basis matching.
+* CPSV21 Definition 4.2 lines 1846–1850 and the two-layer display at
+  lines 1864–1884: per-block BNT normalization that makes every sector
+  participate in the full-basis matching.
 
 No `dropSector` recursion and no partial-union combined LI are used here.
 -/

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
@@ -86,7 +86,8 @@ strong-induction step of the CPSV16 `II_cor2` argument.
   *Matrix product states and projected entangled pair states*, Rev. Mod.
   Phys. **93**, 045003 (2021); arXiv:2011.12127.  Definition 4.2
   (lines 1846–1850), Proposition 4.3 (lines 1852–1859), the two-layer
-  display (lines 1864–1884), and Theorem 4.5 (lines 1891–1900).
+  display (lines 1864–1884), Theorem 4.4 (lines 1891–1894), and
+  Corollary 4.5 (lines 1896–1900).
 
 ## Tags
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
@@ -45,9 +45,10 @@ field
 
 The per-block unit-modulus convention `∀ j, ∃ q, ‖weight j q‖ = 1` is
 **not** a structural field — CPSV16 line 246 is **global** (the
-unit-modulus copy can sit in any sector), while CPSV21 §III.2 Definition 4.2
-(lines 1846–1850) defines the BNT basis and the display at lines 1864–1884
-normalizes the spectral radius of the *basis* tensors, not the copy
+unit-modulus copy can sit in any sector), while CPSV21 Section IV.A,
+Definition 4.2 (lines 1846–1850), defines the BNT basis, and the display at
+lines 1864–1884 normalizes the spectral radius of the *basis* tensors, not
+the copy
 coefficients.  The matching theorem below therefore takes
 the unit-modulus sector as an **explicit parameter** `j₀ : Fin P.basisCount`
 together with a per-sector unit-modulus existential

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
@@ -45,9 +45,10 @@ field
 
 The per-block unit-modulus convention `∀ j, ∃ q, ‖weight j q‖ = 1` is
 **not** a structural field — CPSV16 line 246 is **global** (the
-unit-modulus copy can sit in any sector) and CPSV21 §III.2 Definition 4.3
-(lines 1846–1884) normalizes the spectral radius of the *basis* tensors,
-not the copy coefficients.  The matching theorem below therefore takes
+unit-modulus copy can sit in any sector), while CPSV21 §III.2 Definition 4.2
+(lines 1846–1850) defines the BNT basis and the display at lines 1864–1884
+normalizes the spectral radius of the *basis* tensors, not the copy
+coefficients.  The matching theorem below therefore takes
 the unit-modulus sector as an **explicit parameter** `j₀ : Fin P.basisCount`
 together with a per-sector unit-modulus existential
 `hUnitP_at_j₀ : ∃ q, ‖P.weight j₀ q‖ = 1`.  The non-decay of the matched
@@ -82,8 +83,9 @@ strong-induction step of the CPSV16 `II_cor2` argument.
   power-sum coefficient comparison).
 * CPSV21: Cirac–Pérez-García–Schuch–Verstraete,
   *Matrix product states and projected entangled pair states*, Rev. Mod.
-  Phys. **93**, 045003 (2021); arXiv:2011.12127.  Definition 4.3
-  (lines 1846–1884), Theorem 4.5 (lines 1891–1900).
+  Phys. **93**, 045003 (2021); arXiv:2011.12127.  Definition 4.2
+  (lines 1846–1850), Proposition 4.3 (lines 1852–1859), the two-layer
+  display (lines 1864–1884), and Theorem 4.5 (lines 1891–1900).
 
 ## Tags
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -21,8 +21,9 @@ Paper anchors:
   contradiction and symmetry argument.
 * CPSV16 §II.C lines 1187–1188: exact power-sum coefficient comparison,
   recovering copy multiplicities and weights up to the matched phase.
-* CPSV21 Definition 4.3 lines 1846–1884: per-block BNT normalization on
-  the basis tensors.  The per-block convention on copy coefficients
+* CPSV21 Definition 4.2 lines 1846–1850 and the two-layer display at
+  lines 1864–1884: per-block BNT normalization on the basis tensors.
+  The per-block convention on copy coefficients
   `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — implicit in CPSV16 §II.C line 1182's
   projection argument — is taken as an explicit theorem-level hypothesis
   here, not as a structural field of `IsBNTCanonicalForm`.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -98,8 +98,8 @@ CPSV16 §II.C line 1182's projection argument; it is taken here as an
 explicit theorem-level hypothesis (CPSV16 §II.A line 246 records only
 the global unit witness).
 
-Paper anchor: CPSV16 §II.C lines 1182–1186 (arXiv:1606.00608) and CPSV21
-Definition 4.3 lines 1846–1884. -/
+Paper anchor: CPSV16 §II.C lines 1182–1186 (arXiv:1606.00608), CPSV21
+Definition 4.2 lines 1846–1850, and the two-layer display at lines 1864–1884. -/
 theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -421,7 +421,7 @@ structure SectorBasisOverlapSpanHypotheses {d : ℕ} (P Q : SectorDecomposition 
 /-- **BNT linear-independence hypothesis for sector bases.**
 
 `HasBNTSectorData P` asserts that the basis of the sector decomposition `P` is
-a basis of normal tensors in the sense of Definition 4.3 of arXiv:2011.12127,
+a basis of normal tensors in the sense of Definition 4.2 of arXiv:2011.12127,
 lines 1846–1850: for all sufficiently large system sizes `N`, the MPV states
 `mpvState (P.basis j) N` are linearly independent.  The statement records only
 the eventual condition; no witness is included.

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -421,10 +421,10 @@ structure SectorBasisOverlapSpanHypotheses {d : ℕ} (P Q : SectorDecomposition 
 /-- **BNT linear-independence hypothesis for sector bases.**
 
 `HasBNTSectorData P` asserts that the basis of the sector decomposition `P` is
-a basis of normal tensors in the sense of Definition 4.2 of arXiv:2011.12127: for all
-sufficiently large system sizes `N`, the MPV states `mpvState (P.basis j) N`
-are linearly independent.  The statement records only the eventual condition;
-no witness is included.
+a basis of normal tensors in the sense of Definition 4.3 of arXiv:2011.12127,
+lines 1846–1850: for all sufficiently large system sizes `N`, the MPV states
+`mpvState (P.basis j) N` are linearly independent.  The statement records only
+the eventual condition; no witness is included.
 
 Mathematically, this is the eventual linear-independence hypothesis on the basis
 sector MPV families. In comparison theorems for two sector decompositions, it

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -32,7 +32,10 @@ and~\cite{Cirac2021Matrix}.
               vectors $\{\ket{V^{(N)}(A_j)}\}_{j=1}^g$ are
               linearly independent.
     \end{enumerate}
-    This is \cite[Definition~4.2]{Cirac2021Matrix}. In the canonical-form
+    This is \cite[Definition~4.3]{Cirac2021Matrix}, source label
+    \texttt{def:4:BNT} in
+    \texttt{Papers/2011.12127/TN-Review-main.tex}, lines~1846--1850.
+    In the canonical-form
     characterization of \cite[Section~2.3 and Appendix~A]{Cirac2016MPDO_arXiv},
     a BNT is a minimal family of representatives for the relation
     \[

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -32,10 +32,7 @@ and~\cite{Cirac2021Matrix}.
               vectors $\{\ket{V^{(N)}(A_j)}\}_{j=1}^g$ are
               linearly independent.
     \end{enumerate}
-    This is \cite[Definition~4.3]{Cirac2021Matrix}, source label
-    \texttt{def:4:BNT} in
-    \texttt{Papers/2011.12127/TN-Review-main.tex}, lines~1846--1850.
-    In the canonical-form
+    This is \cite[Definition~4.2]{Cirac2021Matrix}. In the canonical-form
     characterization of \cite[Section~2.3 and Appendix~A]{Cirac2016MPDO_arXiv},
     a BNT is a minimal family of representatives for the relation
     \[
@@ -558,7 +555,8 @@ and~\cite{Cirac2021Matrix}.
 
 This section introduces the BNT canonical-form predicate following
 \cite[\S II, lines 287--301]{Cirac2017MPDO_AnnPhys} and
-\cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}. The predicate is
+\cite[Definition~4.2, Proposition~4.3, and lines 1864--1884]{Cirac2021Matrix}.
+The predicate is
 defined on a sector decomposition with raw sector weights $\mu_{j,q}$ and
 sector coefficients $c_N^{(j)} = \sum_q \mu_{j,q}^{\,N}$; no equal-modulus
 factorization is assumed.
@@ -594,7 +592,8 @@ factorization is assumed.
         V^{(N)}(P_j)_\sigma,
     \]
     matching \cite[\S~II, lines 271--301]{Cirac2017MPDO_AnnPhys}
-    and \cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.
+    and \cite[Definition~4.2, Proposition~4.3, and lines 1864--1884]
+        {Cirac2021Matrix}.
     The line-246 normalization admits every example of the source paper
     (in particular $C \oplus D$, $C \oplus (-C)$,
     $C \oplus (1/2) C$, and $C \oplus (-C) \oplus (1/2) C$) and is
@@ -612,7 +611,7 @@ factorization is assumed.
         c_N^{(j)} = \sum_{q=1}^{r_j} \mu_{j,q}^N.
     \]
     This is \cite[eq.~II, lines 287--301]{Cirac2017MPDO_AnnPhys} and
-    \cite[Definition~4.3, lines 1846--1884]{Cirac2021Matrix}.
+    \cite[lines 1864--1884]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -60,7 +60,7 @@ blocks satisfy
 The argument as written does not quantify the rate of decay in
 \eqref{eq:qual}.
 
-Definition~4.3 of~\cite{Cirac2021Matrix} packages
+Definition~4.2 of~\cite{Cirac2021Matrix} packages
 \eqref{eq:qual} indirectly under \emph{eventual linear independence} of
 the basis MPVs and does not state a rate. The formalization records this
 eventual linear-independence input in the shared sector-decomposition
@@ -127,7 +127,7 @@ content of the new hypothesis.
 
 \emph{Open gap.}  The rate condition~\eqref{eq:hyp} is a structural input
 beyond what \cite[\S II]{Cirac2016MPDO_arXiv} and
-\cite[Definition~4.3]{Cirac2021Matrix} make explicit. Its rate is
+\cite[Definition~4.2]{Cirac2021Matrix} make explicit. Its rate is
 in principle derivable from the spectral gap of the mixed transfer
 operator that powers
 \leanid{mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP},

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -55,8 +55,8 @@ across the entire family.\footnote{%
     \doclink{TNLean/MPS/BNT/Construction}.}
 Together with the dominant normalization $\|\mu_1\|=1$, every
 sub-dominant block has modulus strictly less than~$1$.
-\cite[Definition~4.3]{Cirac2021Matrix} states the corresponding
-source structure as a two-layer canonical form: spectral levels
+\cite[Definition~4.2 and lines~1864--1884]{Cirac2021Matrix} states the
+corresponding source structure as a two-layer canonical form: spectral levels
 $\lambda_j$ with $\|\lambda_1\|>\cdots>\|\lambda_g\|$ factored from
 within-sector unit-modulus weights $\mu_{j,q}$ ($\|\mu_{j,q}\|=1$)
 with sector multiplicities $r_j\ge 1$. The
@@ -195,7 +195,8 @@ either
           enabling the coefficient-identification step
           of~\eqref{eq:isolate}; or
     \item the two-layer CPSV structure of
-          \cite[Definition~4.3]{Cirac2021Matrix}, separating spectral
+          \cite[Definition~4.2 and lines~1864--1884]{Cirac2021Matrix},
+          separating spectral
           levels $\lambda_j$ from within-sector unit-modulus weights
           $\mu_{j,q}$.  On the surviving \leanid{SectorDecomposition}
           surface this means keeping the raw coefficients


### PR DESCRIPTION
This PR fixes the RMP numbering and source anchors for BNT references.

The local TeX source `Papers/2011.12127/TN-Review-main.tex` places the BNT material in Section IV.A. With the shared theorem counter in that section, the BNT definition at lines 1846--1850 is rendered as Definition 4.2, and the BNT characterization at lines 1852--1859 is Proposition 4.3.

Changes:
- keeps the blueprint BNT definition as `\cite[Definition~4.2]{Cirac2021Matrix}` and removes local TeX labels/file paths from reader-facing blueprint prose;
- updates Lean BNT docstrings to cite Definition 4.2 with the local line range 1846--1850;
- updates SectorBNT comments that cited the broad 1846--1884 passage as “Definition 4.3” or as the wrong RMP section, so they now distinguish Section IV.A, Definition 4.2, Proposition 4.3, and the two-layer display at lines 1864--1884;
- leaves non-BNT MPDO/PRFP references to Definition 4.3 untouched.

Validation:
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Basic TNLean.MPS.FundamentalTheorem.SectorBNT.Api TNLean.MPS.FundamentalTheorem.SectorBNT.DominantMatch TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity`
- `lake exe lint_style --github`
- `git diff --check`

Addresses part of #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/comments and citation anchors (Definition/Proposition numbers and line ranges) with no functional or proof logic modifications.
> 
> **Overview**
> Updates BNT-related documentation to match the **rendered** CPSV21/RMP numbering and anchors: references are corrected from the previously-cited “Definition 4.3 / §III.2” range to **Section IV.A**, `Definition 4.2` (lines 1846–1850), `Proposition 4.3` (lines 1852–1859), and the two-layer display (lines 1864–1884).
> 
> This retags the same BNT concepts across Lean docstrings (`TNLean/MPS/BNT/Basic.lean`, `SectorBNT/*`, `SharedInfra/SectorDecomposition.lean`) and the LaTeX blueprint/paper-gap notes to use consistent source anchors, without changing any definitions, theorems, or proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95ed2564b429e97db89ea398e5357d7247bc454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->