### PR TITLE
doc(blueprint): correct equal-case BNT references

### DIFF
--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1485,11 +1485,11 @@ which is then combined with overlap estimates and the leading-block peel.
     \label{lem:ft_sector_bnt_equal_sector_data_different_dims}
     \lean{MPSTensor.ft_sector_bnt_equal_sector_data}
     \leanok
-    \uses{def:same_mpv2, def:bnt, def:gauge_phase_equiv}
-    Let $P$ and $Q$ be two BNT sector decompositions
-    (Definition~\ref{def:bnt}), each admitting a unit-modulus copy weight in
-    every basis sector, possibly with different block counts and different bond
-    dimensions in corresponding blocks.
+    \uses{def:same_mpv2, def:sector_bnt_cf, def:gauge_phase_equiv}
+    Let $P$ and $Q$ be two BNT canonical forms
+    (Definition~\ref{def:sector_bnt_cf}), each admitting a unit-modulus copy
+    weight in every basis sector, possibly with different sector counts and
+    different bond dimensions before matching.
     If their block-diagonal tensors generate the same MPV family
     (Definition~\ref{def:same_mpv2}), then the basis sectors are
     bijectively matched by a permutation $\beta$, each matched basis pair is


### PR DESCRIPTION
Updates the live Chapter 13 blueprint entry for `MPSTensor.ft_sector_bnt_equal_sector_data` after rebasing onto current `main`.

Mathematical scope:
- keeps the current section and lemma label for the equal-case theorem with differing bond dimensions;
- replaces the generic `def:bnt` dependency by `def:sector_bnt_cf`, matching the Lean hypotheses `IsBNTCanonicalForm P` and `IsBNTCanonicalForm Q`;
- states the hypotheses as BNT canonical forms, avoiding the Lean namespace phrase that the prose review objected to;
- keeps `def:same_mpv2`, matching the rectangular same-MPV hypothesis in the Lean theorem.

No Lean declarations, theorem statements, or proofs are changed.

Part of #1685 cleanup after the BNT theorem-surface rename.

Validation:
- `leanblueprint web`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates a single lemma’s stated dependencies and wording to reference `def:sector_bnt_cf`/BNT canonical forms instead of `def:bnt`, without touching any Lean code or proofs.
> 
> **Overview**
> Updates the Chapter 13 blueprint lemma `lem:ft_sector_bnt_equal_sector_data_different_dims` to describe the hypotheses in terms of **BNT canonical forms** (Definition `def:sector_bnt_cf`) rather than generic BNT sector decompositions.
> 
> Also adjusts the lemma’s `\uses{...}` dependencies and wording (e.g., “sector counts”/“bond dimensions before matching”) to match the current Lean theorem assumptions for `MPSTensor.ft_sector_bnt_equal_sector_data`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f74536f90674bdd0612d84f6b3d29501d376218e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->