### PR TITLE
doc(MPS/FT): separate proportional theorem from equal corollary

### DIFF
--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -144,8 +144,8 @@ def ProportionalMPV₂ {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor
 
 /-- Nonzero proportionality of MPV families.
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. This is the
-formal reading of the source phrase that two tensors generate MPV that are
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1167--1170. This is the
+formal reading of the source statement that two tensors generate MPV that are
 proportional to each other: at each length the two MPV vectors lie on the same
 nonzero projective line, with proportionality scalar allowed to depend on the
 length.
@@ -176,7 +176,7 @@ def EventuallyNonzeroProportionalMPV₂ {d D₁ D₂ : ℕ}
 
 /-- Nonzero MPV proportionality forgets to weak MPV proportionality.
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. This is the
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1167--1170. This is the
 forgetful implication from the projective, nonzero reading of the paper's
 proportionality hypothesis to the weaker scalar-multiple predicate used by older
 single-block lemmas. -/
@@ -202,7 +202,7 @@ theorem NonzeroProportionalMPV₂.eventually {d D₁ D₂ : ℕ}
 
 /-- Nonzero MPV proportionality is symmetric.
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. The scalar at each
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1167--1170. The scalar at each
 length is inverted, using the nonvanishing part of the proportionality
 hypothesis. -/
 theorem NonzeroProportionalMPV₂.symm {d D₁ D₂ : ℕ}
@@ -241,7 +241,7 @@ theorem EventuallyNonzeroProportionalMPV₂.symm {d D₁ D₂ : ℕ}
 Source: arXiv:1606.00608, Corollary `II_cor2`, lines 1205--1217, supplies an
 equal-MPV hypothesis. This lemma only re-states that hypothesis as the
 corresponding instance of the proportional hypothesis in Theorem `thm1`, lines
-1170--1192. It is not a formalization of Corollary `II_cor2` itself. -/
+1167--1170. It is not a formalization of Corollary `II_cor2` itself. -/
 theorem SameMPV₂.toNonzeroProportionalMPV₂ {d D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (h : SameMPV₂ A B) :

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -201,7 +201,7 @@ This theorem isolates the exact residual input for the proportional
 global-gauge upgrade: the copy-weight identity. That residual input is not
 provided by the CPSV16 proportional theorem; lines 1187--1192 are the
 equal-MPV corollary, where the length-dependent proportionality scalar is
-identically `1`. -/
+identically one. -/
 theorem ft_sector_bnt_proportional_global_gauge_of_weight_data
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -195,10 +195,13 @@ For proportional MPV families, the proportional sector-matching theorem supplies
 the matched BNT basis, unit phases, and block gauges of CPSV16 §II.C lines
 1184--1186. If the remaining coefficient-comparison step supplies copy
 permutations whose weights obey the same phases, then the direct-sum gauge
-assembly of lines 1189--1192 follows.
+assembly uses the same algebra as the equal-MPV corollary in lines 1189--1192.
 
 This theorem isolates the exact residual input for the proportional
-global-gauge upgrade: the copy-weight identity. -/
+global-gauge upgrade: the copy-weight identity. That residual input is not
+provided by the CPSV16 proportional theorem; lines 1187--1192 are the
+equal-MPV corollary, where the length-dependent proportionality scalar is
+identically `1`. -/
 theorem ft_sector_bnt_proportional_global_gauge_of_weight_data
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -204,12 +204,13 @@ there is a basis bijection carrying matched bond-dimension equality and
 per-block gauge-phase equivalence.
 
 Paper anchor: CPSV16 §II.C lines 349–352 (theorem `thm1`), lines 1167–1170
-(theorem statement), lines 1182–1188 (proof); CPSV21 lines 1891–1894
+(theorem statement), lines 1182–1186 (proof); CPSV21 lines 1891–1894
 (proportional-MPV theorem-level target).  This is the proportional analogue
 of `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses` (`SectorBNT/FundamentalCoord.lean`)
-in the matching layer; the global-gauge upgrade further requires the
-per-block coefficient identification, which lies in the next module of the
-proof chain. -/
+in the matching layer. The source proportional theorem stops at sector
+matching; the weight comparison and global gauge in CPSV16 lines 1187–1192
+belong to the equal-MPV corollary unless an additional proportional
+coefficient theorem controls the length-dependent scalar. -/
 theorem ft_sector_bnt_proportional_sector_match
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -237,13 +238,13 @@ This is the witness form of `ft_sector_bnt_proportional_sector_match`: after
 the proportional BNT block matching of CPSV16 §II.C lines 1184–1186, the
 matched gauge-phase equivalences provide actual matrices `Xblock k` and
 scalars `ζ k`.  The BNT self-overlap normalization forces `‖ζ k‖ = 1`, so
-these are the unit phases appearing in the source text before the final
-coefficient comparison and block-diagonal gauge construction of lines 1187–1192.
+these are the unit phases appearing in the source proportional theorem.
 
 The theorem intentionally stops before the raw coefficient identity.  Under
 `EventuallyNonzeroProportionalMPV₂`, that step still has to control the
 length-dependent proportionality scalar; it is not the equal-MPV coefficient
-identity proved by `coeff_identity_via_matched_mpv_phase`. -/
+identity proved by `coeff_identity_via_matched_mpv_phase`, and it is not
+contained in CPSV16 lines 1187–1192 without the equal-MPV specialization. -/
 theorem ft_sector_bnt_proportional_sector_match_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -20,7 +20,7 @@ $B_k = \zeta_k X_k A_{\beta k} X_k^{-1}$.
 ## References
 
 * CPSV16: arXiv:1606.00608, lines 349–352 (theorem `thm1`), 1167–1170
-  (restatement), 1182–1188 (proof).
+  (restatement), 1182–1186 (proof).
 * CPSV21: arXiv:2011.12127, lines 1891–1894 (proportional target).
 -/
 
@@ -37,7 +37,7 @@ bond dimension, gauge-phase equivalent in the cast-compatible shape, and
 with non-decaying cross-overlap.  This is the proportional analogue of
 `StrongMatch.forall_k_exists_j_nondecaying_overlap_of_sameMPV`.
 
-Paper anchor: CPSV16 §II.C lines 349–352 / 1167–1170 / 1182–1188. -/
+Paper anchor: CPSV16 §II.C lines 349–352 / 1167–1170 / 1182–1186. -/
 theorem forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
@@ -32,7 +32,7 @@ equivalence then follow as in the equal case.
 ## References
 
 * CPSV16: arXiv:1606.00608, lines 349–352 (theorem `thm1`), 1167–1170
-  (restatement), 1182–1188 (proof).
+  (restatement), 1182–1186 (proof).
 * CPSV21: arXiv:2011.12127, lines 1891–1894 (proportional target).
 -/
 
@@ -345,7 +345,7 @@ eventual nonzero proportionality and unit-modulus copy weights at $Q$-sector
 $k_0$ and auxiliary $P$-sector $j_0$, some $P$-block $j_1$ has matched bond
 dimension, cast-compatible gauge-phase equivalence, and non-decaying
 cross-overlap with $Q.\mathrm{basis}\,k_0$.  Paper anchor: CPSV16 §II.C
-lines 349–352, 1167–1170, 1182–1188. -/
+lines 349–352, 1167–1170, 1182–1186. -/
 theorem exists_block_match_at_Q_of_eventuallyProportional
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/Overlap/Basic.lean
+++ b/TNLean/MPS/Overlap/Basic.lean
@@ -108,7 +108,7 @@ lemma mpvOverlap_eq_sum_of_decomp_left
 state vectors.
 
 This algebraic identity is used in the proof of arXiv:1606.00608,
-Theorem II.1, lines 1170--1192, to lift the BNT decomposition to a
+Theorem II.1, lines 1182--1186, to lift the BNT decomposition to a
 state-vector identity before taking inner products with individual blocks. -/
 lemma mpvState_eq_sum_of_decomp
     {d g Dtot : ℕ} {dim : Fin g → ℕ}
@@ -130,7 +130,7 @@ lemma mpvState_eq_sum_of_decomp
 decomposition.
 
 This algebraic identity is used in the proof of arXiv:1606.00608,
-Theorem II.1, lines 1170--1192, when projecting the full proportionality
+Theorem II.1, lines 1182--1186, when projecting the full proportionality
 relation onto one block MPV. -/
 lemma mpvInner_eq_sum_of_decomp_right
     {d g D Dtot : ℕ} {dim : Fin g → ℕ}
@@ -153,7 +153,7 @@ decomposition.
 
 This is the conjugate-linear companion of
 `mpvInner_eq_sum_of_decomp_right`, used for the symmetric projection in the
-block-matching argument of arXiv:1606.00608, Theorem II.1, lines 1170--1192. -/
+block-matching argument of arXiv:1606.00608, Theorem II.1, lines 1182--1186. -/
 lemma mpvInner_eq_sum_of_decomp_left
     {d g D Dtot : ℕ} {dim : Fin g → ℕ}
     (A_total : MPSTensor d Dtot)

--- a/TNLean/MPS/Overlap/SelfOverlapAux.lean
+++ b/TNLean/MPS/Overlap/SelfOverlapAux.lean
@@ -35,7 +35,7 @@ lemma tendsto_norm_selfOverlap_one
 
 /-- MPV-state norm-convergence form of normalized self-overlap convergence.
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192. In the
+Source: arXiv:1606.00608, Theorem `thm1`, lines 1182--1186. In the
 block-selection contradiction, normalized BNT blocks have self-overlap tending
 to one; this lemma rewrites that normalization as convergence of the Hilbert
 space norm of the corresponding MPV state. -/

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1364,8 +1364,13 @@ BNT basis.
         X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
     \]
     Thus, after the remaining proportional coefficient comparison supplies
-    the displayed copy-weight identities, the direct-sum gauge assembly of
-    \cite[\S~II.C, lines 1189--1192]{Cirac2017MPDO_AnnPhys} follows.
+    the displayed copy-weight identities, the direct-sum gauge assembly uses
+    the same algebra as the equal-MPV corollary in
+    \cite[\S~II.C, lines 1189--1192]{Cirac2017MPDO_AnnPhys}.
+    The source proportional theorem itself stops at the sector matching in
+    lines~1167--1186; lines~1187--1192 do not supply the missing
+    proportional coefficient comparison, because in the equal-MPV corollary
+    the length-dependent proportionality scalar is identically~$1$.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
This PR tightens the source annotations around the SectorBNT proportional fundamental-theorem path.

CPSV16 §II.C lines 1167--1186 prove the proportional theorem up to BNT sector matching. The following coefficient comparison and block-diagonal gauge construction in lines 1187--1192 occur in the equal-MPV corollary, where the length-dependent proportionality scalar is identically 1.

Changes:
- updates the `ProportionalMatch` theorem comments to cite lines 1182--1186 for the proportional proof and to state that lines 1187--1192 belong to the equal-MPV corollary unless an additional proportional coefficient theorem is supplied;
- narrows foundational proportionality and overlap-helper comments from the broad 1170--1192 span to the exact source passages they use: the statement at 1167--1170 and the sector-matching proof at 1182--1186;
- updates the conditional proportional global-gauge theorem comment to say its copy-weight identity is an extra residual input, not supplied by the proportional source theorem;
- mirrors the same distinction in the Chapter 10 blueprint paragraph.

Validation:
- `lake build TNLean.MPS.Defs TNLean.MPS.Overlap.Basic TNLean.MPS.Overlap.SelfOverlapAux TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental`
- `lake exe lint_style --github`
- `git diff --check`
- `cd blueprint && leanblueprint web`

Addresses part of #1685 and clarifies the remaining work in #1749.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are comment/documentation updates and citation/line-number corrections only, with no modification to theorem statements or proofs.
> 
> **Overview**
> Clarifies the **CPSV16 source mapping** for the SectorBNT proportional fundamental-theorem path by tightening citations to the exact line ranges used (notably `1167–1170` for the proportionality statement and `1182–1186` for the proportional sector-matching proof).
> 
> Updates docstrings in `Defs.lean`, overlap helper lemmas, and the SectorBNT proportional-match/global-gauge theorems to explicitly separate what is proved by the **proportional theorem** from what belongs to the **equal-MPV corollary** (`1187–1192`), and mirrors the same distinction in the Chapter 10 blueprint text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ea48564890736fef5e7f059c15a7febea5dd89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->