### PR TITLE
doc(MPS/MPDO): correct MPDO source citations

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -28,8 +28,9 @@ The supporting modules are:
   obstruction showing that blockwise injectivity, left-canonicality, and
   nonzero weights do not imply the biCF property.
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput` — the trace-dual algebraic
-  input from David--Perez-Garcia--Schuch--Wolf Lemma `lem:direct-sum` that
-  follows from the two-sided nonzero span lemma.
+  input from the direct-sum decomposition lemma of
+  David--Perez-Garcia--Schuch--Wolf that follows from the two-sided nonzero
+  span lemma.
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumGroundSpace` — the corresponding
   inclusion/equality of finite-chain image spaces.
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness` — the parent-Hamiltonian
@@ -44,7 +45,8 @@ The supporting modules are:
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, lines 340--345]
-* [David--Perez-Garcia--Schuch--Wolf 2006, Lemmas `lem1` and `lem:direct-sum`]
+* [David--Perez-Garcia--Schuch--Wolf 2006, two-sided nonzero span and direct-sum
+  decomposition lemmas]
 
 ## Tags
 

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -43,7 +43,8 @@ The supporting modules are:
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Proposition IV.3]
+* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition `propblockinj`, lines 340--345]
 * [David--Perez-Garcia--Schuch--Wolf 2006, Lemmas `lem1` and `lem:direct-sum`]
 
 ## Tags

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -43,8 +43,7 @@ The supporting modules are:
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-  Proposition `propblockinj`, lines 340--345]
+* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, lines 340--345]
 * [David--Perez-Garcia--Schuch--Wolf 2006, Lemmas `lem1` and `lem:direct-sum`]
 
 ## Tags

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -27,13 +27,12 @@ sufficient conditions for deriving that field.
    independent, then those tuple-valued word evaluations already span the full
    product algebra. This reduces biCF to a concrete linear-algebra condition.
 
-3. An abstract **`propblockinj` selector-data criterion**: if each block is
+3. An abstract **block-injectivity selector-data criterion**: if each block is
    block-injective at some common length and a second finite family of words
    isolates the individual blocks (identity on one block, zero on the others),
    then concatenating the two families yields the preceding span condition.
-   This captures the finite-length block-separation content of the proposition
-   labelled `propblockinj` in Cirac--Perez-Garcia--Schuch--Verstraete,
-   arXiv:1606.00608, lines 340--345.
+   This captures the finite-length block-separation content of
+   Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, lines 340--345.
 
 4. A **pairwise-to-global selector reduction**: if every ordered pair of
    distinct blocks admits a finite word polynomial that is the identity on the

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -27,12 +27,13 @@ sufficient conditions for deriving that field.
    independent, then those tuple-valued word evaluations already span the full
    product algebra. This reduces biCF to a concrete linear-algebra condition.
 
-3. An abstract **Proposition IV.3-style selector data criterion**: if each block is
+3. An abstract **`propblockinj` selector-data criterion**: if each block is
    block-injective at some common length and a second finite family of words
    isolates the individual blocks (identity on one block, zero on the others),
    then concatenating the two families yields the preceding span condition.
-   This captures the finite-length block-separation content of
-   [Cirac--Perez-Garcia--Schuch--Verstraete 2017], Proposition IV.3.
+   This captures the finite-length block-separation content of the proposition
+   labelled `propblockinj` in Cirac--Perez-Garcia--Schuch--Verstraete,
+   arXiv:1606.00608, lines 340--345.
 
 4. A **pairwise-to-global selector reduction**: if every ordered pair of
    distinct blocks admits a finite word polynomial that is the identity on the

--- a/TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean
@@ -16,8 +16,7 @@ exist.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-  Proposition `propblockinj`, lines 340--345]
+* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, lines 340--345]
 
 ## Tags
 

--- a/TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean
@@ -16,7 +16,8 @@ exist.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Proposition IV.3]
+* [Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition `propblockinj`, lines 340--345]
 
 ## Tags
 

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -393,7 +393,7 @@ theorem wordTupleSpanTop_of_wordEntryFamily_linearIndependent
     _ = M j a b := rfl
 
 /-- The linear-independence criterion above gives the abstract selector data
-modeled on arXiv:1606.00608, proposition `propblockinj`, lines 340--345. -/
+modeled on arXiv:1606.00608, lines 340--345. -/
 theorem hasBlockSelectorWords_of_wordEntryFamily_linearIndependent
     (A : (k : Fin r) → MPSTensor d (dim k))
     {L : ℕ} (hLI : LinearIndependent ℂ (wordEntryFamily A L)) :
@@ -410,8 +410,8 @@ theorem hasBiCF_of_wordEntryFamily_linearIndependent
   hasBiCF_of_wordTupleSpanTop A
     (wordTupleSpanTop_of_wordEntryFamily_linearIndependent A hLI)
 
-/-- Abstract finite-length data isolating the content of proposition
-`propblockinj` from arXiv:1606.00608, lines 340--345.
+/-- Abstract finite-length data isolating the content of the block-injectivity
+proposition from arXiv:1606.00608, lines 340--345.
 
 A family is `PropBlockInjective` if there is a common blocking length making
 all blocks injective, together with a second finite family of words selecting
@@ -422,7 +422,7 @@ def PropBlockInjective
   ∃ L S : ℕ, (∀ k, IsNBlkInjective (A k) L) ∧ HasBlockSelectorWords A S
 
 /-- Common block injectivity plus pairwise block-separating word polynomials
-produce the abstract `propblockinj` selector data. -/
+produce the abstract block-injectivity selector data. -/
 theorem propBlockInjective_of_common_blockInjective_of_pairBlockSeparatingWords
     (A : (k : Fin r) → MPSTensor d (dim k))
     {L S : ℕ}
@@ -556,7 +556,7 @@ theorem hasBiCF_of_common_blockInjective_of_pairBlockSeparatingWords
   hasBiCF_of_wordTupleSpanTop A
     (wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords A hInj hPair)
 
-/-- The abstract `propblockinj` selector data imply the finite-length word-tuple
+/-- The abstract block-injectivity selector data imply the finite-length word-tuple
 span condition. -/
 theorem wordTupleSpanTop_of_propBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -566,7 +566,7 @@ theorem wordTupleSpanTop_of_propBlockInjective
   exact ⟨L + S,
     wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords A hInj hSel⟩
 
-/-- The abstract `propblockinj` selector data imply `HasBiCF`. -/
+/-- The abstract block-injectivity selector data imply `HasBiCF`. -/
 theorem hasBiCF_of_propBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hProp : PropBlockInjective A) :
@@ -619,7 +619,7 @@ theorem horizontalCFData_of_wordEntryFamily_linearIndependent
   horizontalCFData_of_wordTupleSpanTop A hInj hLeft hμne
     ⟨L, MPSTensor.wordTupleSpanTop_of_wordEntryFamily_linearIndependent A hLI⟩
 
-/-- The abstract `propblockinj` selector data yield `HorizontalCFData` through
+/-- The abstract block-injectivity selector data yield `HorizontalCFData` through
 the finite-length span criterion. -/
 theorem horizontalCFData_of_propBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -658,7 +658,7 @@ The new predicate `PropBlockInjective` expresses one abstract finite-length rout
 while `wordEntryFamily` gives a second, equivalent linear-algebra criterion.
 What remains open is to derive either of those finite-length witnesses from the
 repository's current BNT / canonical-form hypotheses, i.e. to formalize the full
-content of arXiv:1606.00608, proposition `propblockinj`, lines 340--345.
+content of arXiv:1606.00608, lines 340--345.
 -/
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -392,8 +392,8 @@ theorem wordTupleSpanTop_of_wordEntryFamily_linearIndependent
             exact False.elim (hmem (Finset.mem_univ _))
     _ = M j a b := rfl
 
-/-- The linear-independence criterion above gives the abstract Proposition IV.3
-selector data as a corollary. -/
+/-- The linear-independence criterion above gives the abstract selector data
+modeled on arXiv:1606.00608, proposition `propblockinj`, lines 340--345. -/
 theorem hasBlockSelectorWords_of_wordEntryFamily_linearIndependent
     (A : (k : Fin r) → MPSTensor d (dim k))
     {L : ℕ} (hLI : LinearIndependent ℂ (wordEntryFamily A L)) :
@@ -410,8 +410,8 @@ theorem hasBiCF_of_wordEntryFamily_linearIndependent
   hasBiCF_of_wordTupleSpanTop A
     (wordTupleSpanTop_of_wordEntryFamily_linearIndependent A hLI)
 
-/-- Abstract finite-length data isolating the content of Proposition IV.3
-(`propblockinj`) from arXiv:1606.00608.
+/-- Abstract finite-length data isolating the content of proposition
+`propblockinj` from arXiv:1606.00608, lines 340--345.
 
 A family is `PropBlockInjective` if there is a common blocking length making
 all blocks injective, together with a second finite family of words selecting
@@ -422,7 +422,7 @@ def PropBlockInjective
   ∃ L S : ℕ, (∀ k, IsNBlkInjective (A k) L) ∧ HasBlockSelectorWords A S
 
 /-- Common block injectivity plus pairwise block-separating word polynomials
-produce the abstract Proposition IV.3 selector data. -/
+produce the abstract `propblockinj` selector data. -/
 theorem propBlockInjective_of_common_blockInjective_of_pairBlockSeparatingWords
     (A : (k : Fin r) → MPSTensor d (dim k))
     {L S : ℕ}
@@ -556,8 +556,8 @@ theorem hasBiCF_of_common_blockInjective_of_pairBlockSeparatingWords
   hasBiCF_of_wordTupleSpanTop A
     (wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords A hInj hPair)
 
-/-- The abstract Proposition IV.3 selector data imply the finite-length
-word-tuple span condition. -/
+/-- The abstract `propblockinj` selector data imply the finite-length word-tuple
+span condition. -/
 theorem wordTupleSpanTop_of_propBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hProp : PropBlockInjective A) :
@@ -566,7 +566,7 @@ theorem wordTupleSpanTop_of_propBlockInjective
   exact ⟨L + S,
     wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords A hInj hSel⟩
 
-/-- The abstract Proposition IV.3 selector data imply `HasBiCF`. -/
+/-- The abstract `propblockinj` selector data imply `HasBiCF`. -/
 theorem hasBiCF_of_propBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hProp : PropBlockInjective A) :
@@ -619,8 +619,8 @@ theorem horizontalCFData_of_wordEntryFamily_linearIndependent
   horizontalCFData_of_wordTupleSpanTop A hInj hLeft hμne
     ⟨L, MPSTensor.wordTupleSpanTop_of_wordEntryFamily_linearIndependent A hLI⟩
 
-/-- Proposition IV.3-style selector data yield `HorizontalCFData` through the
-finite-length span criterion. -/
+/-- The abstract `propblockinj` selector data yield `HorizontalCFData` through
+the finite-length span criterion. -/
 theorem horizontalCFData_of_propBlockInjective
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hInj : ∀ k, MPSTensor.IsInjective (A k))
@@ -658,7 +658,7 @@ The new predicate `PropBlockInjective` expresses one abstract finite-length rout
 while `wordEntryFamily` gives a second, equivalent linear-algebra criterion.
 What remains open is to derive either of those finite-length witnesses from the
 repository's current BNT / canonical-form hypotheses, i.e. to formalize the full
-content of Proposition IV.3 of arXiv:1606.00608.
+content of arXiv:1606.00608, proposition `propblockinj`, lines 340--345.
 -/
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/PRFP.lean
+++ b/TNLean/MPS/MPDO/PRFP.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.RFP.Defs
 
 This file collects the local purification data used by `MPOTensor.IsLPDO` and
 defines the mixed-state purification RFP condition from arXiv:1606.00608,
-Definition 4.3.
+Definition `def:Puri-RFP`, lines 756–759.
 
 ## Main definitions
 
@@ -69,7 +69,7 @@ theorem isLPDO_iff_exists_witness (M : MPOTensor d D) :
 purifying family `A` whose purifying MPS tensor is a pure-state renormalization
 fixed point: `IsLPDO M` and `MPSTensor.IsRFP (purifyingMPSTensor A)`.
 
-See arXiv:1606.00608, Definition 4.3. -/
+See arXiv:1606.00608, Definition `def:Puri-RFP`, lines 756–759. -/
 def IsPRFP (M : MPOTensor d D) : Prop :=
   ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
     (e : Fin D ≃ Fin D' × Fin D'),

--- a/TNLean/MPS/MPDO/PRFP.lean
+++ b/TNLean/MPS/MPDO/PRFP.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.RFP.Defs
 
 This file collects the local purification data used by `MPOTensor.IsLPDO` and
 defines the mixed-state purification RFP condition from arXiv:1606.00608,
-Definition `def:Puri-RFP`, lines 756–759.
+lines 756–759.
 
 ## Main definitions
 
@@ -69,7 +69,7 @@ theorem isLPDO_iff_exists_witness (M : MPOTensor d D) :
 purifying family `A` whose purifying MPS tensor is a pure-state renormalization
 fixed point: `IsLPDO M` and `MPSTensor.IsRFP (purifyingMPSTensor A)`.
 
-See arXiv:1606.00608, Definition `def:Puri-RFP`, lines 756–759. -/
+See arXiv:1606.00608, lines 756–759. -/
 def IsPRFP (M : MPOTensor d D) : Prop :=
   ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
     (e : Fin D ≃ Fin D' × Fin D'),

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -124,8 +124,8 @@ structure HorizontalCFData {r : ℕ} {dim : Fin r → ℕ}
   `Δ k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ` pairs to zero against every
   length-`L` block-diagonal product, then each `Δ k` vanishes individually.
 
-  This is the block-decomposed surrogate for the proposition labelled
-  `propblockinj` in Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  This is the block-decomposed surrogate for the block-injectivity proposition
+  in Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
   lines 340--345: after blocking at most `3 D^5` spins,
   where `D` denotes the bond dimension in the paper (in this block-decomposed
   setting one may take `D` to be a global bound such as `⨆ k, dim k`),
@@ -138,7 +138,7 @@ structure HorizontalCFData {r : ℕ} {dim : Fin r → ℕ}
   (`PropBlockInjective`), and from the more concrete linear-independence criterion
   `wordEntryFamily`. What is still open is to derive one of those finite-length
   witnesses from the remaining canonical-form/BNT data alone, i.e. the actual
-  proposition labelled `propblockinj` in Cirac--Perez-Garcia--Schuch--Verstraete,
+  block-injectivity proposition in Cirac--Perez-Garcia--Schuch--Verstraete,
   arXiv:1606.00608, lines 340--345. -/
   biCF : ∃ L : ℕ, ∀ (Δ : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
     (∀ w : Fin L → Fin d,

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -124,9 +124,9 @@ structure HorizontalCFData {r : ℕ} {dim : Fin r → ℕ}
   `Δ k : Matrix (Fin (dim k)) (Fin (dim k)) ℂ` pairs to zero against every
   length-`L` block-diagonal product, then each `Δ k` vanishes individually.
 
-  This is the block-decomposed surrogate for
-  [Cirac--Perez-Garcia--Schuch--Verstraete 2017], Proposition IV.3
-  (arXiv:1606.00608, "`propblockinj`"): after blocking at most `3 D^5` spins,
+  This is the block-decomposed surrogate for the proposition labelled
+  `propblockinj` in Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  lines 340--345: after blocking at most `3 D^5` spins,
   where `D` denotes the bond dimension in the paper (in this block-decomposed
   setting one may take `D` to be a global bound such as `⨆ k, dim k`),
   any tensor in CF is in biCF, which is what the paper's Lemma L invokes to
@@ -138,7 +138,8 @@ structure HorizontalCFData {r : ℕ} {dim : Fin r → ℕ}
   (`PropBlockInjective`), and from the more concrete linear-independence criterion
   `wordEntryFamily`. What is still open is to derive one of those finite-length
   witnesses from the remaining canonical-form/BNT data alone, i.e. the actual
-  Proposition IV.3 theorem from [Cirac--Perez-Garcia--Schuch--Verstraete 2017]. -/
+  proposition labelled `propblockinj` in Cirac--Perez-Garcia--Schuch--Verstraete,
+  arXiv:1606.00608, lines 340--345. -/
   biCF : ∃ L : ℕ, ∀ (Δ : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
     (∀ w : Fin L → Fin d,
         (∑ k : Fin r, Matrix.trace (Δ k * MPSTensor.evalWord (A k) (List.ofFn w))) = 0) →

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.RFP.Defs
 # Zero correlation length for MPO tensors
 
 Definitions of zero-correlation-length conditions for mixed-state tensor
-networks, following arXiv:1606.00608, Definition 4.2.
+networks, following arXiv:1606.00608, Definition `DefinitionZCL`, lines 736–741.
 
 ## Main definitions
 
@@ -31,7 +31,8 @@ variable {d D : ℕ}
 /-- An MPO tensor has **zero correlation length** when its transfer map is
 idempotent: `E_M ∘ E_M = E_M`.
 
-See arXiv:1606.00608, Definition 4.2 and arXiv:2011.12127, Definition 4.2. -/
+See arXiv:1606.00608, Definition `DefinitionZCL`, lines 736–741, and
+arXiv:2011.12127, Section III.C, lines 937–939. -/
 def IsZCL (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M
 

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.RFP.Defs
 # Zero correlation length for MPO tensors
 
 Definitions of zero-correlation-length conditions for mixed-state tensor
-networks, following arXiv:1606.00608, Definition `DefinitionZCL`, lines 736–741.
+networks, following arXiv:1606.00608, lines 736–741.
 
 ## Main definitions
 
@@ -31,8 +31,8 @@ variable {d D : ℕ}
 /-- An MPO tensor has **zero correlation length** when its transfer map is
 idempotent: `E_M ∘ E_M = E_M`.
 
-See arXiv:1606.00608, Definition `DefinitionZCL`, lines 736–741, and
-arXiv:2011.12127, Section III.C, lines 937–939. -/
+See arXiv:1606.00608, lines 736–741, and arXiv:2011.12127,
+Section II.E.2, lines 937–939. -/
 def IsZCL (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -766,14 +766,14 @@ strong subadditivity for a normalized three-site reduced state.
     but the block-injective canonical-form separation condition fails and no
     blocking length makes the entrywise family linearly independent.
 
-    The proposition labelled \texttt{propblockinj} in
-    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} gives a concrete sufficient criterion for the spanning
-    condition: after a common blocking length each block is block-injective,
-    and after a further finite blocking length one can form linear combinations
-    of word evaluations which equal the identity on one chosen block and vanish
-    on all others. Concatenating an injective prefix with this finite
-    block-separation data produces the product-algebra spanning condition, hence the
-    horizontal canonical-form data.
+    The block-injectivity proposition in
+    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} gives a concrete sufficient
+    criterion for the spanning condition: after a common blocking length each
+    block is block-injective, and after a further finite blocking length one
+    can form linear combinations of word evaluations which equal the identity
+    on one chosen block and vanish on all others. Concatenating an injective
+    prefix with this finite block-separation data produces the product-algebra
+    spanning condition, hence the horizontal canonical-form data.
 \end{remark}
 
 \begin{theorem}[Finite block-separation criterion]
@@ -782,8 +782,9 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{rem:word_tuple_span_top}
     If a block family admits the finite-length data described in
-    the proposition labelled \texttt{propblockinj} in
-    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys}, then it is in block-injective canonical form.
+    the block-injectivity proposition of
+    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys}, then it is in
+    block-injective canonical form.
 \end{theorem}
 
 \begin{proof}
@@ -791,9 +792,9 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{rem:word_tuple_span_top}
     This is the direct implication from the finite-length data to the
     finite-length trace-separation statement. What remains open in the full
-    proposition labelled \texttt{propblockinj} in
-    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} is the derivation of this finite witness from separated
-    canonical-form / BNT data.
+    block-injectivity proposition of
+    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} is the derivation of this
+    finite witness from separated canonical-form / BNT data.
 \end{proof}
 
 \begin{lemma}[Blockwise equality from agreement on the MPV family]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -766,7 +766,8 @@ strong subadditivity for a normalized three-site reduced state.
     but the block-injective canonical-form separation condition fails and no
     blocking length makes the entrywise family linearly independent.
 
-    \cite[Proposition~IV.3]{Cirac2021Matrix} gives a concrete sufficient criterion for the spanning
+    The proposition labelled \texttt{propblockinj} in
+    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} gives a concrete sufficient criterion for the spanning
     condition: after a common blocking length each block is block-injective,
     and after a further finite blocking length one can form linear combinations
     of word evaluations which equal the identity on one chosen block and vanish
@@ -781,7 +782,8 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{rem:word_tuple_span_top}
     If a block family admits the finite-length data described in
-    \cite[Proposition~IV.3]{Cirac2021Matrix}, then it is in block-injective canonical form.
+    the proposition labelled \texttt{propblockinj} in
+    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys}, then it is in block-injective canonical form.
 \end{theorem}
 
 \begin{proof}
@@ -789,7 +791,8 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{rem:word_tuple_span_top}
     This is the direct implication from the finite-length data to the
     finite-length trace-separation statement. What remains open in the full
-    \cite[Proposition~IV.3]{Cirac2021Matrix} is the derivation of this finite witness from separated
+    proposition labelled \texttt{propblockinj} in
+    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} is the derivation of this finite witness from separated
     canonical-form / BNT data.
 \end{proof}
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -144,7 +144,9 @@ legs cyclically and taking the resulting trace.
         \E_M \circ \E_M = \E_M.
     \]
     This is the mixed-state analogue of the renormalization fixed-point
-    condition for MPS tensors; see \cite[Definition~4.2]{Cirac2021Matrix}.
+    condition for MPS tensors; see \cite[definition of MPDO zero correlation
+    length, lines~736--741]{Cirac2017MPDO_AnnPhys} and
+    \cite[Section~III.C, lines~937--939]{Cirac2021Matrix}.
 \end{definition}
 
 \begin{theorem}[MPO ZCL iff doubled-index MPS RFP]%
@@ -252,7 +254,8 @@ legs cyclically and taking the resulting trace.
     An MPO tensor $M$ has a \emph{purification RFP} if it admits an LPDO
     witness whose purifying MPS tensor is a pure-state renormalization
     fixed point.
-    This is \cite[Definition~4.3]{Cirac2021Matrix}.
+    This is \cite[definition of purification RFP, lines~756--759]
+        {Cirac2017MPDO_AnnPhys}.
 \end{definition}
 
 \begin{remark}[PRFP does not imply MPO ZCL]\label{rem:prfp_not_implies_zcl}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -146,7 +146,7 @@ legs cyclically and taking the resulting trace.
     This is the mixed-state analogue of the renormalization fixed-point
     condition for MPS tensors; see \cite[definition of MPDO zero correlation
     length, lines~736--741]{Cirac2017MPDO_AnnPhys} and
-    \cite[Section~III.C, lines~937--939]{Cirac2021Matrix}.
+    \cite[Section~II.E.2, lines~937--939]{Cirac2021Matrix}.
 \end{definition}
 
 \begin{theorem}[MPO ZCL iff doubled-index MPS RFP]%

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3414,8 +3414,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     separator, then full block-selector words exist.  More precisely, multiplying
     the pairwise separators for a fixed block $k$ against all other blocks gives a
     selector of length $(r-1)S$ for $k$.  Hence common block injectivity plus
-    pairwise separators implies the finite product-word span in
-    \cite[Proposition~IV.3]{Cirac2021Matrix} and the block-injective
+    pairwise separators implies the finite product-word span in the proposition
+    labelled \texttt{propblockinj} in
+    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} and the block-injective
     canonical-form trace-separation condition.
 \end{lemma}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3414,8 +3414,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     separator, then full block-selector words exist.  More precisely, multiplying
     the pairwise separators for a fixed block $k$ against all other blocks gives a
     selector of length $(r-1)S$ for $k$.  Hence common block injectivity plus
-    pairwise separators implies the finite product-word span in the proposition
-    labelled \texttt{propblockinj} in
+    pairwise separators implies the finite product-word span in the block-injectivity
+    proposition in
     \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} and the block-injective
     canonical-form trace-separation condition.
 \end{lemma}

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{Finite-Length Block Separation in Cirac--Perez-Garcia--Schuch--Verstraete 2017 Proposition IV.3}
+\title{Finite-Length Block Separation in the CPGSV17 Proposition \texttt{propblockinj}}
 \author{}
 \date{2026-04-30}
 
@@ -16,9 +16,9 @@
 
 \section{The assertion}
 
-The finite-length block-separation step in Proposition IV.3 of Cirac,
-P\'erez-Garc\'ia, Schuch, and Verstraete is the point at issue
-\cite{Cirac2016MPDO_arXiv,Cirac2017MPDO_AnnPhys}.\footnote{For traceability,
+The finite-length block-separation step in the proposition labelled
+\texttt{propblockinj} in Cirac, P\'erez-Garc\'ia, Schuch, and Verstraete is the
+point at issue \cite[lines~340--345]{Cirac2016MPDO_arXiv}.\footnote{For traceability,
     this note corresponds to \href{https://github.com/LionSR/TNLean/issues/1043}{issue \#1043}.
     Related formal work is recorded in
     \href{https://github.com/LionSR/TNLean/issues/587}{issue \#587} and
@@ -45,11 +45,12 @@ cross-block step: if $L$ is a blocking length after which every normal block is
 injective, then after $3(L+1)(D-1)$ blockings the tensor is block
 injective. The proposition records the resulting bound in the following form: after
 blocking at most $3D^5$ spins, every tensor in canonical form is in
-block-injective canonical form. This is the assertion labelled Cirac--Perez-Garcia--Schuch--Verstraete 2017,
-Proposition~IV.3.
-The local source is
-\path{Papers/1606.00608/MPDO-22-12-17-2.tex}, lines 271--345. The cited
-reference is the paper's item \texttt{David2006}, namely
+block-injective canonical form. This is the assertion labelled
+\texttt{propblockinj} in the local source
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex}, lines~340--345. The definition of
+block-injective canonical form immediately preceding it is
+\texttt{defnbi}, lines~318--322. The cited reference is the paper's item
+\texttt{David2006}, namely
 P\'erez-Garc\'ia--Verstraete--Wolf--Cirac
 \cite{PerezGarcia2007MPSReps}.
 
@@ -78,7 +79,7 @@ entrywise linear-independence criterion: the scalar functions
 $w\mapsto (A_j^w)_{\alpha\beta}$, indexed by the block and by a matrix entry in
 that block, are linearly independent at one common length. This implies the
 product-algebra span, hence the trace-separation property. The third is a
-selector-word formulation of Proposition IV.3: after a common blocking length
+selector-word formulation of \texttt{propblockinj}: after a common blocking length
 each block is injective, and after a further finite length there are word
 polynomials which are the identity on one chosen block and vanish on all the
 others. Concatenating an injective prefix with such a selector suffix gives the
@@ -97,7 +98,7 @@ horizontal canonical-form trace-separation conclusion.\footnote{The criteria are
     \texttt{HorizontalCFData} constructors such as
     \texttt{horizontalCFData\_of\_propBlockInjective}. The blueprint records the same
     state in \path{blueprint/src/chapter/ch02b_mpdo.tex}, lines 708--787.}
-Thus Proposition IV.3 has not been asserted without proof. The formal statements
+Thus \texttt{propblockinj} has not been asserted without proof. The formal statements
 prove that several finite-length witnesses are sufficient, while the derivation
 of such a witness from the full canonical-form and basis-of-normal-tensors
 hypotheses remains open.
@@ -120,9 +121,9 @@ This example is formalized in
 \path{docs/counterexamples.md}, lines 29--35. It shows that the additional
 finite-length witness in the formal hypotheses is genuinely stronger than the
 other horizontal canonical-form assumptions. It does not refute
-Cirac--Perez-Garcia--Schuch--Verstraete 2017 Proposition IV.3. The duplicate scalar blocks are related by similarity
-and phase, and therefore do not form a minimal basis of normal tensors in the
-sense of the source characterization.
+the CPGSV17 proposition \texttt{propblockinj}. The duplicate scalar blocks are
+related by similarity and phase, and therefore do not form a minimal basis of
+normal tensors in the sense of the source characterization.
 
 \section{Conclusion}
 


### PR DESCRIPTION
## Summary

This PR corrects MPDO source citations that were pointing at the wrong rendered RMP definitions or review-article proposition references.

It now cites the actual MPDO passages for ZCL and PRFP: CPSV16 `DefinitionZCL` lines 736--741, `def:Puri-RFP` lines 756--759, and the RMP MPDO ZCL paragraph at lines 937--939.

It also updates the block-injective finite-witness comments, paper-gap note, and blueprint prose to cite the proposition labelled `propblockinj` in CPSV16/CPGSV17, lines 340--345, instead of referring to an RMP Proposition IV.3. The RMP parent-Hamiltonian discussion is left as review exposition, with the formal finite-witness source identified by the original paper label and lines.

## Validation

- `lake build TNLean.MPS.MPDO.ZCL TNLean.MPS.MPDO.PRFP`
- `lake build TNLean.MPS.MPDO.VerticalCF TNLean.MPS.MPDO.BiCFDerivation TNLean.MPS.MPDO.BiCFDerivation.Selectors TNLean.MPS.MPDO.ZCL TNLean.MPS.MPDO.PRFP`
- `lake build TNLean.MPS.MPDO.BiCFDerivation.Core TNLean.MPS.MPDO.BiCFDerivation.Counterexample`
- `lake exe lint_style --github`
- `git diff --check`
- `cd blueprint && leanblueprint web` (completed with the repository's existing bibliography/renderer warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/comment-only updates that retarget citations to the correct arXiv line ranges; no changes to definitions or proofs, so behavioral risk is minimal.
> 
> **Overview**
> Updates MPDO documentation/comments to cite the *actual* source locations in arXiv:1606.00608: `IsZCL` now references lines 736–741 and `IsPRFP` lines 756–759, and the biCF/block-separation discussion now points to the proposition labeled `propblockinj` (lines 340–345) instead of an RMP “Proposition IV.3” reference.
> 
> Carries these corrected citations consistently through the Lean module headers (`BiCFDerivation`, `Core`, `Selectors`, `Counterexample`, `VerticalCF`), the blueprint text (`ch02b_mpdo.tex`, `ch14_parent_hamiltonian.tex`), and the paper-gap note (`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76de2fc86a80785a3df372889d68b00ae9fd5ef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->