### PR TITLE
doc(blueprint): record PGVWC07 canonical proof lines

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -92,12 +92,18 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     normal tensors. If $r>0$, the weights $\mu_k$ may be normalized so that
     $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
 
-    In the source, the canonical-form display is
-    \texttt{eq:II\_Aiplusk1} at lines~216--225 and
-    \texttt{eq:II\_CF1} at lines~237--246 of
-    \cite{Cirac2017MPDO_AnnPhys}. The basis-of-normal-tensors refinement is
-    \texttt{prop:char-BNT} at lines~271--279, and the two-layer display
-    \texttt{eq:II\_ABasicTensors}--\texttt{decBSV} is at lines~287--301.
+    In the source, the canonical-form construction is recorded in
+    \cite[display labelled \texttt{eq:II\_Aiplusk1}, lines~216--225]
+        {Cirac2017MPDO_AnnPhys}
+    and in
+    \cite[definition labelled \texttt{eq:II\_CF1}, lines~237--246]
+        {Cirac2017MPDO_AnnPhys}.
+    The basis-of-normal-tensors refinement is
+    \cite[proposition labelled \texttt{prop:char-BNT}, lines~271--279]
+        {Cirac2017MPDO_AnnPhys},
+    and the two-layer display is
+    \cite[displays labelled \texttt{eq:II\_ABasicTensors} and
+    \texttt{decBSV}, lines~287--301]{Cirac2017MPDO_AnnPhys}.
     The review exposition records the same normal-tensor and canonical-form
     definitions at lines~1827--1837, the basis-of-normal-tensors definition and
     characterization at lines~1846--1859, and the two-layer decomposition at

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -75,7 +75,7 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     \label{thm:cpgsv_canonical_form_source}
     \notready
     This is the canonical-form reduction of
-    \cite[Section~II.A, lines~217--246]{Cirac2017MPDO_AnnPhys}; see also
+    \cite[Section~II.C, lines~217--246]{Cirac2017MPDO_AnnPhys}; see also
     \cite[Section~IV.A, lines~1815--1837]{Cirac2021Matrix}. Every
     translation-invariant MPS tensor $A$ is, after blocking by a period
     $p \ge 1$, replaced by a tensor $B$ generating the same MPV family and
@@ -99,11 +99,11 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     \cite[definition labelled \texttt{eq:II\_CF1}, lines~237--246]
         {Cirac2017MPDO_AnnPhys}.
     The basis-of-normal-tensors refinement is
-    \cite[proposition labelled \texttt{prop:char-BNT}, lines~271--279]
+    \cite[proposition labelled \texttt{prop:char-BNT}, lines~278--280]
         {Cirac2017MPDO_AnnPhys},
     and the two-layer display is
     \cite[displays labelled \texttt{eq:II\_ABasicTensors} and
-    \texttt{decBSV}, lines~287--301]{Cirac2017MPDO_AnnPhys}.
+    \texttt{decBSV}, lines~285--301]{Cirac2017MPDO_AnnPhys}.
     The review exposition records the same normal-tensor and canonical-form
     definitions at lines~1827--1837, the basis-of-normal-tensors definition and
     characterization at lines~1846--1859, and the two-layer decomposition at

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -56,12 +56,27 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     of~\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
 \end{theorem}
 
+\begin{remark}[Source proof order for PGVWC07]\label{rem:pgvwc07_ti_canonical_source_order}
+    A faithful proof of Theorem~\ref{thm:pgvwc07_ti_canonical_form}
+    should follow the proof of
+    \cite[Theorem~\texttt{Th:TIcanonical}]{PerezGarcia2007Matrix}
+    in its given order. Lines~765--770 normalize the spectral radius and use a
+    full-rank positive fixed point to obtain the unital gauge. Lines~771--783
+    show that the support of a singular positive fixed point is invariant.
+    Lines~785--815 split the finite-ring trace into the supported and
+    orthogonal summands. Lines~816--826 iterate this decomposition and use a
+    non-scalar fixed point to split further until the identity is the only
+    fixed point of each block. Finally, lines~827--832 repeat the fixed-point
+    argument for the dual map and diagonalize the resulting full-rank positive
+    fixed point by a unitary gauge.
+\end{remark}
+
 \begin{theorem}[Blocked CPSV canonical-form reduction]%
     \label{thm:cpgsv_canonical_form_source}
     \notready
     This is the canonical-form reduction of
-    \cite[Section~II.A]{Cirac2017MPDO_AnnPhys}; see also
-    \cite[Theorems~4.2 and~4.4]{Cirac2021Matrix}. Every
+    \cite[Section~II.A, lines~217--246]{Cirac2017MPDO_AnnPhys}; see also
+    \cite[Section~IV.A, lines~1815--1837]{Cirac2021Matrix}. Every
     translation-invariant MPS tensor $A$ is, after blocking by a period
     $p \ge 1$, replaced by a tensor $B$ generating the same MPV family and
     whose nonzero part is in canonical form. Thus, for each physical index $i$,
@@ -76,6 +91,17 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     dimension $d^{[p]}$ and bond dimension $D_0$, and the tensors $B_k$ are
     normal tensors. If $r>0$, the weights $\mu_k$ may be normalized so that
     $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
+
+    In the source, the canonical-form display is
+    \texttt{eq:II\_Aiplusk1} at lines~216--225 and
+    \texttt{eq:II\_CF1} at lines~237--246 of
+    \cite{Cirac2017MPDO_AnnPhys}. The basis-of-normal-tensors refinement is
+    \texttt{prop:char-BNT} at lines~271--279, and the two-layer display
+    \texttt{eq:II\_ABasicTensors}--\texttt{decBSV} is at lines~287--301.
+    The review exposition records the same normal-tensor and canonical-form
+    definitions at lines~1827--1837, the basis-of-normal-tensors definition and
+    characterization at lines~1846--1859, and the two-layer decomposition at
+    lines~1864--1884 of~\cite{Cirac2021Matrix}.
 \end{theorem}
 
 Theorem~\ref{thm:pgvwc07_ti_canonical_form} is not yet formalized. This


### PR DESCRIPTION
## Summary

This PR adds a Chapter 8 blueprint remark recording the proof order of PGVWC07 Theorem `Th:TIcanonical` by local source line range. The note separates the PGVWC07 translation-invariant canonical-form existence proof from the blocked CPSV canonical-form reduction, so later formalization work follows the original invariant-support and finite-ring trace-splitting argument.

It also annotates the blocked CPSV canonical-form statement with the precise source labels and line ranges for `eq:II_Aiplusk1`, `eq:II_CF1`, `prop:char-BNT`, and the two-layer BNT display, together with the corresponding review-article exposition lines.

## Validation

- `git diff --check`
- `cd blueprint && leanblueprint web` (completed with the repository's existing bibliography/renderer warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adds citations/line-range annotations and a new remark, with no impact on Lean code or algorithms.
> 
> **Overview**
> Adds a new Chapter 8 remark (`rem:pgvwc07_ti_canonical_source_order`) that records the **intended proof order** and specific source line ranges for the PGVWC07 translation-invariant canonical-form theorem, to guide later formalization.
> 
> Tightens and expands the blocked CPSV canonical-form theorem’s references by pointing to the exact source sections/line ranges and equation/proposition labels (and corresponding review-article line ranges) for the canonical-form construction, BNT refinement, and two-layer decomposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c31d13b83419be0d30645e676053d4059a0fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->