### PR TITLE
doc(blueprint): separate proportional coefficient gap

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1182,7 +1182,8 @@ The non-matched decay clause is delivered in full.
 
 \begin{remark}
     Theorem~\ref{thm:sector_bnt_projected_substitution_unit_subset} is the
-    open proportional scalar-control target. It should not be identified with
+    open statement that the projected coefficient identities hold for
+    proportional MPV families. It should not be identified with
     Lemma~\ref{lem:sector_bnt_coeff_identity_via_global_gauge}, which is a
     full-basis equal-MPV statement. The projected theorem follows
     the substitution route of
@@ -1306,9 +1307,7 @@ matching covers the whole BNT basis.
     \lean{MPSTensor.coeff_identity_via_global_gauge}
     \leanok
     \uses{def:sector_bnt_cf,
-        def:gauge_phase_equiv,
-        lem:sector_bnt_norm_phase_of_matched_mpv,
-        lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
+        def:gauge_phase_equiv}
     Let $P$ and $Q$ be BNT canonical forms with the same MPV family. Suppose
     that there is a bijection
     \[
@@ -1316,8 +1315,8 @@ matching covers the whole BNT basis.
     \]
     and, for every $k\in J(Q)$, a bond-dimension equality and a gauge-phase
     equivalence between $Q_k$ and $P_{\beta(k)}$. Then for every $k$ there are
-    a unit-modulus scalar $\zeta_k$ and an integer $N_0$ such that, for all
-    $N>N_0$,
+    a unit-modulus scalar $\zeta_k$ and a natural number $N_0$ such that, for
+    all $N>N_0$,
     \[
         c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q).
     \]
@@ -1326,6 +1325,8 @@ matching covers the whole BNT basis.
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{lem:sector_bnt_norm_phase_of_matched_mpv,
+        lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
     Choose the scalar-power MPV identity associated to each gauge-phase
     equivalence. Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv} gives
     unit modulus for each scalar. Applying

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1096,10 +1096,8 @@ The non-matched decay clause is delivered in full.
     subnormality hypothesis. A finite sum of null sequences is null.
 \end{proof}
 
-\begin{theorem}[Substitution argument for the unit-modulus subset]
-    \label{thm:sector_bnt_coeff_identity_via_global_gauge}
-    \lean{MPSTensor.coeff_identity_via_global_gauge}
-    \leanok
+\begin{theorem}[Projected substitution for the unit-modulus subset]\notready
+    \label{thm:sector_bnt_projected_substitution_unit_subset}
     \uses{def:sector_bnt_cf,
         thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV,
         thm:sector_bnt_bijective_match_of_sameMPV,
@@ -1132,7 +1130,6 @@ The non-matched decay clause is delivered in full.
 \end{theorem}
 
 \begin{proof}
-    \leanok
     \uses{thm:sector_bnt_coeff_tendsto_zero_of_all_weights_subnorm,
         lem:sector_bnt_cross_overlap_basis_tendsto_zero}
     Fix $j_0$ and project the proportional-MPV identity onto the overlap
@@ -1184,7 +1181,10 @@ The non-matched decay clause is delivered in full.
 \end{proof}
 
 \begin{remark}
-    Theorem~\ref{thm:sector_bnt_coeff_identity_via_global_gauge} realises
+    Theorem~\ref{thm:sector_bnt_projected_substitution_unit_subset} is the
+    open proportional scalar-control target. It should not be identified with
+    Lemma~\ref{lem:sector_bnt_coeff_identity_via_global_gauge}, which is a
+    full-basis equal-MPV statement. The projected theorem follows
     the substitution route of
     \cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys}: substitute
     the per-pair gauge phases into the proportional-MPV identity, reduce
@@ -1198,11 +1198,11 @@ The non-matched decay clause is delivered in full.
 \subsection{Full-basis coefficient identity and global gauge}
 \label{subsec:sector_bnt_full_basis_global_gauge}
 
-The preceding substitution theorem works on the unit-modulus subset. The
-following two statements record the full-basis form used by the sector-permuted
-global gauge. Their hypotheses explicitly require a unit-modulus copy in every
-sector on both sides; under this normalization, the matching covers the whole
-BNT basis.
+The preceding substitution theorem is not yet formalized and works on the
+unit-modulus subset. The following statements record the full-basis form used by
+the sector-permuted global gauge. Their hypotheses explicitly require a
+unit-modulus copy in every sector on both sides; under this normalization, the
+matching covers the whole BNT basis.
 
 \begin{lemma}[Unit phase from matched normalized BNT blocks]%
     \label{lem:sector_bnt_norm_phase_of_matched_mpv}
@@ -1299,6 +1299,38 @@ BNT basis.
     resulting $Q$-sum by $\beta$. The BNT linear independence of the $P$-basis,
     through Lemma~\ref{lem:eventual_coeff_eq_of_eventual_li}, forces equality
     of the corresponding coefficients for all sufficiently large lengths.
+\end{proof}
+
+\begin{lemma}[Full-basis coefficient identity from global gauges]%
+    \label{lem:sector_bnt_coeff_identity_via_global_gauge}
+    \lean{MPSTensor.coeff_identity_via_global_gauge}
+    \leanok
+    \uses{def:sector_bnt_cf,
+        def:gauge_phase_equiv,
+        lem:sector_bnt_norm_phase_of_matched_mpv,
+        lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
+    Let $P$ and $Q$ be BNT canonical forms with the same MPV family. Suppose
+    that there is a bijection
+    \[
+        \beta : J(Q) \simeq J(P)
+    \]
+    and, for every $k\in J(Q)$, a bond-dimension equality and a gauge-phase
+    equivalence between $Q_k$ and $P_{\beta(k)}$. Then for every $k$ there are
+    a unit-modulus scalar $\zeta_k$ and an integer $N_0$ such that, for all
+    $N>N_0$,
+    \[
+        c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q).
+    \]
+    This is the full-basis equal-MPV coefficient comparison of
+    \cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys}.
+\end{lemma}
+
+\begin{proof}\leanok
+    Choose the scalar-power MPV identity associated to each gauge-phase
+    equivalence. Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv} gives
+    unit modulus for each scalar. Applying
+    Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase} to these
+    phases gives the eventual coefficient identities.
 \end{proof}
 
 \begin{theorem}[Global gauge from matched sectors and copy weights]%

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1129,7 +1129,7 @@ The non-matched decay clause is delivered in full.
     \end{enumerate}
 \end{theorem}
 
-\begin{proof}
+\begin{proof}\notready
     \uses{thm:sector_bnt_coeff_tendsto_zero_of_all_weights_subnorm,
         lem:sector_bnt_cross_overlap_basis_tendsto_zero}
     Fix $j_0$ and project the proportional-MPV identity onto the overlap


### PR DESCRIPTION
## Summary

This PR fixes the Chapter 10 blueprint entry around CPSV16 Section II.C coefficient comparison.

The previous blueprint text stated a proportional, unit-modulus-subset projected substitution theorem, but tagged it as `MPSTensor.coeff_identity_via_global_gauge`. That Lean declaration is a full-basis equal-MPV coefficient theorem: its hypothesis is `SameMPV₂`, not eventual proportionality with a length-dependent scalar.

Changes:

- mark the projected proportional substitution theorem as not ready and remove the incorrect Lean tag;
- add a separate blueprint lemma for `MPSTensor.coeff_identity_via_global_gauge` with the full-basis equal-MPV hypotheses it actually has;
- keep the source-line attribution to CPSV16 Section II.C lines 1187--1188, while making clear that the proportional scalar-control step remains open for #1749.

## Validation

- `git diff --check`
- `cd blueprint && leanblueprint web` completed with the repository's existing renderer/bibliography warnings
- `cd blueprint && leanblueprint checkdecls` could not run because `blueprint/lean_decls` is absent in this checkout
- `python3 scripts/blueprint_lean_sync.py --ci --changed-files TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean` still reports the repository's existing unrelated Chapter 14 missing-declaration entries; it does not report the BNT coefficient declaration touched here

Contributes to #1749 and #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that clarify theorem status/assumptions and fix a mis-linked Lean declaration, without modifying any executable logic.
> 
> **Overview**
> Corrects Chapter 10’s BNT coefficient-comparison narrative by **separating the open proportional (unit-modulus-subset) substitution statement from the proven equal-MPV full-basis result**.
> 
> Marks the projected substitution theorem as `\notready`, removes the incorrect `\lean{MPSTensor.coeff_identity_via_global_gauge}` tag from it, and updates surrounding remarks/text to explicitly call out the remaining proportional coefficient-comparison gap.
> 
> Adds a new lemma `lem:sector_bnt_coeff_identity_via_global_gauge` that properly states and proves `MPSTensor.coeff_identity_via_global_gauge` under **full-basis equal-MPV + global gauge/bijection** hypotheses, preserving the CPSV16 line attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52442c21306ed56096df015ad3b944b714ea00d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->