### PR TITLE
doc(MPS): correct PGVWC07 proof citations

### DIFF
--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -25,7 +25,8 @@ then the support projection $P = \mathrm{supp}(\rho)$ is invariant under each Kr
 $$(1-P) A_i P = 0.$$
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem 3 (support projector argument)
+* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+  proof lines 771–783 (support projector argument)
 * Cirac et al., arXiv:1606.00608, Section 2.3
 -/
 
@@ -396,9 +397,9 @@ matrix, and are essential for the "strict dimension decrease" argument used when
 iterating the canonical-form splitting step.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem 3 (lines 769–803): the
-  recursion terminates because each irreducible block has strictly smaller bond
-  dimension.
+* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+  proof lines 771–815: invariant support, finite-ring trace split, and strict
+  decrease of the recursive blocks.
 * Cirac et al., arXiv:1606.00608, Section 2.3: the same argument in a slightly
   different presentation.
 -/
@@ -484,7 +485,8 @@ projection $P := \mathrm{supp}(\rho)$ is invariant under the Kraus operators `(A
 explicit two-block block-diagonal tensor which is MPV-equivalent to `A`.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem 3 (support projection argument)
+* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+  proof lines 771–783 (support projection argument)
 * Cirac et al., arXiv:1606.00608, Section 2.3
 -/
 
@@ -524,7 +526,8 @@ The proof composes:
 4. `exists_twoBlock_decomp_of_lowerZero_strict` — strict dimension bounds.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem 3
+* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+  proof lines 771–815
 * Cirac et al., arXiv:1606.00608, Section 2.3
 -/
 theorem exists_twoBlock_decomp_of_posSemidef_fixedPoint_strict

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -23,10 +23,12 @@ arguments before blocking/normalization.
 
 This file formalizes the invariant-subspace decomposition from two sources:
 
-> **Perez-Garcia et al., quant-ph/0608197, Theorem 3 (lines 769–803).**
-> The recursion on bond dimension: a PSD fixed point of the transfer map yields an
-> invariant support projection; after block-diagonalization, the tensor splits into
-> a direct sum of smaller blocks.  The strict dimension decrease
+> **Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+> proof lines 771–815.**
+> The recursion on bond dimension: a singular positive fixed point of the transfer
+> map yields an invariant support projection in lines 771–783; after the finite-ring
+> trace split of lines 785–815, the tensor is replaced by a direct sum of smaller
+> blocks.  The strict dimension decrease
 > (`exists_strict_twoBlock_decomp_of_lowerZero`) guarantees termination of the
 > canonical-form recursion.
 
@@ -423,7 +425,8 @@ both returned block dimensions are *strictly smaller* than `D`. This is the key
 ingredient for proving termination of the canonical-form recursion.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem 3 (lines 769–803): recursion on bond dimension.
+* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+  proof lines 771–815: invariant support and finite-ring trace split.
 * Cirac et al., arXiv:1606.00608, Section 2.3: the same step in the "canonical forms" reduction.
 -/
 


### PR DESCRIPTION
## Summary

This PR corrects Lean prose citations for the PGVWC07 canonical-form support-projection step.

The affected comments previously cited "Theorem 3" and lines 769--803. In the local source `Papers/quant-ph_0608197/MPSarchive.tex`, the relevant passage is the proof of Theorem `Th:TIcanonical`: lines 771--783 derive the invariant support projection from a singular positive fixed point, and lines 785--815 perform the finite-ring trace split. The strict recursive split is therefore cited to proof lines 771--815.

No declarations or proofs are changed.

## Validation

- `git diff --check`
- `lake env lean TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`
- `lake env lean TNLean/MPS/Irreducible/FixedPointProjection.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to reference the correct theorem/line ranges in an external paper; no Lean declarations or proofs are modified, so behavioral risk is minimal.
> 
> **Overview**
> Updates Lean module prose citations for the MPS canonical-form support-projection and invariant-subspace decomposition steps.
> 
> References that previously pointed to “Theorem 3” / lines 769–803 in Perez-Garcia et al. are corrected to cite the proof of Theorem `Th:TIcanonical`, specifically lines 771–783 for the support projector argument and lines 771–815 for the full recursion/strict dimension decrease discussion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c116e842e8ded786c85df1e2303d15c8d9c02a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->