### PR TITLE
doc(MPS): clarify CPSV source ranges

### DIFF
--- a/TNLean/Algebra/UnitModulusPowerSum.lean
+++ b/TNLean/Algebra/UnitModulusPowerSum.lean
@@ -32,8 +32,11 @@ Wiener / Cesaro one:
   contradiction.
 
 This is a general analytic ingredient about complex power sums of
-unit-modulus families (arXiv:1606.00608, Theorem `thm1`, lines
-1170--1192).
+unit-modulus families.  In the CPSV16 fundamental-theorem proof it belongs to
+the formal replacement for the non-vanishing obstruction used at line 1182,
+where the paper invokes Lemma `Lem1` to rule out the alternative that all
+overlaps with a fixed block decay.  It is not the equal-MPV coefficient
+comparison of lines 1184--1192.
 
 The module is purely about complex power sums; it has no MPS
 dependencies and uses no `sorry`/`axiom`/`unsafe`.
@@ -42,8 +45,8 @@ dependencies and uses no `sorry`/`axiom`/`unsafe`.
 
 * Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
   Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608
-  (2017), Theorem `thm1`, lines 1170--1192 (the unit-modulus power-sum
-  non-decay used inside the per-block projection step).
+  (2017), Theorem `thm1`, proof line 1182, together with Lemma `Lem1`
+  (lines 1131--1133).
 -/
 
 open scoped BigOperators
@@ -124,9 +127,11 @@ to zero.**
 For `μ : Fin r → ℂ` with `r > 0` and `‖μ q‖ = 1` for every `q`, the
 sequence `N ↦ ∑_q (μ q) ^ N` does not tend to `0` as `N → ∞`.
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192 (the
-unit-modulus power-sum non-decay used inside the per-block projection
-step).  Proof via Cesaro averaging of `‖S N‖²` in `ℂ`. -/
+Source context: arXiv:1606.00608, Theorem `thm1`, proof line 1182, where the
+projection step needs a non-vanishing obstruction after Lemma `Lem1`
+(lines 1131--1133).  This analytic lemma is a formal auxiliary for that
+obstruction, not a statement of the equal-MPV corollary in lines 1184--1192.
+Proof via Cesaro averaging of `‖S N‖²` in `ℂ`. -/
 theorem unitModulus_power_sum_not_tendsto_zero
     {r : ℕ} (hr : 0 < r) (μ : Fin r → ℂ) (hμ : ∀ q, ‖μ q‖ = 1) :
     ¬ Tendsto (fun N : ℕ => ∑ q : Fin r, (μ q) ^ N) atTop (nhds 0) := by

--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -188,10 +188,12 @@ lemma coefficient_eventually_eq_of_eventually_linearIndependent
 /-- Eventual linear independence for the union of two asymptotically orthonormal
 MPV families whose mixed overlaps vanish.
 
-Source context: arXiv:1606.00608, lines 1170--1192, where the
+Source context: arXiv:1606.00608, Lemma `Lem1`, lines 1131--1133, and the
+application in Theorem `thm1`, proof line 1182, where the
 linear-independence corollary is applied after adjoining one block from one BNT
 family to the other family.  This auxiliary lemma records the symmetric
-two-family strengthening of that Gram-matrix input. -/
+two-family strengthening of that Gram-matrix input; it is not the equal-MPV
+coefficient comparison of lines 1184--1192. -/
 lemma eventually_linearIndependent_of_two_family_overlap_tendsto_orthonormal
     {d : ℕ} {gA gB : ℕ} {dimA : Fin gA → ℕ} {dimB : Fin gB → ℕ}
     (A : (j : Fin gA) → MPSTensor d (dimA j))

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -417,10 +417,12 @@ end IsNormalCanonicalFormBNT
 
 /-- Conclusion of the CPSV16 BNT block-matching step.
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1170--1192.  The source proves
-this conclusion from canonical-form BNT data and proportional MPV families.  This
-abbreviation records only the conclusion, not a theorem asserting it from extra
-coefficient-array hypotheses. -/
+Source: arXiv:1606.00608, Theorem `thm1`, statement lines 1167--1170 and proof
+line 1182.  The source proves this block-matching conclusion from
+canonical-form BNT data and proportional MPV families.  This abbreviation
+records only the conclusion, not a theorem asserting it from extra
+coefficient-array hypotheses; the copy-weight comparison and global gauge in
+lines 1184--1192 belong to the equal-MPV corollary. -/
 abbrev BlockPermutationGaugePhaseConclusion
     {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -99,9 +99,9 @@ then `SameMPV₂ P.toTensor Q.toTensor` and the BNT linear independence of the
 `P.coeff N (β k) = (ζ k)^N * Q.coeff N k`.
 
 Unlike `coeff_identity_via_global_gauge`, this statement keeps the phase
-function explicit.  The coefficient/weight comparison is coupled to the
-per-block gauge matrices that are later combined into
-`X = ⊕_k (𝟙_{r_k} ⊗ X_k)`, following CPSV16 §II.C lines 1187–1192. -/
+function explicit.  The coefficient/weight comparison is the line 1187--1188
+part of the equal-MPV corollary; the per-block gauge matrices are combined
+afterwards into `X = ⊕_k (𝟙_{r_k} ⊗ X_k)` in lines 1189--1192. -/
 theorem coeff_identity_via_matched_mpv_phasePos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P)

--- a/TNLean/MPS/SharedInfra/BlockGauge.lean
+++ b/TNLean/MPS/SharedInfra/BlockGauge.lean
@@ -28,7 +28,8 @@ than statements of the fundamental theorem itself.
 
 ## Reference
 
-* arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192).
+* arXiv:1606.00608, Corollary II.2 (`eq:II_auxcor`, lines 1172--1178)
+  and its block-diagonal gauge construction in lines 1189--1192.
 -/
 
 open scoped Matrix BigOperators
@@ -63,7 +64,8 @@ noncomputable def blockDiagonalGL (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
 canonical `Fin (∑ k, dim k)` bond index, naming the global gauge `X = ⊕ₖ X k`
 that arises after the BNT block matching.
 
-Reference: arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192). -/
+Reference: arXiv:1606.00608, Corollary II.2 (`eq:II_auxcor`, lines 1172--1178)
+and the block-diagonal gauge construction in lines 1189--1192. -/
 noncomputable def globalGaugeOfBlocks (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
     GL (Fin (∑ k : Fin r, dim k)) ℂ :=
   Units.map
@@ -86,7 +88,8 @@ If `B k i = X k * A k i * (X k)⁻¹` for every `k, i`, then for every `i`,
 `toTensorFromBlocks μ B i = (⊕ X) * toTensorFromBlocks μ A i * (⊕ X)⁻¹`,
 where `⊕ X = globalGaugeOfBlocks X` is the reindexed block-diagonal gauge.
 
-Reference: arXiv:1606.00608, Corollary II.2 (`eq:II:A=XAX`, lines 1155–1192). -/
+Reference: arXiv:1606.00608, Corollary II.2 (`eq:II_auxcor`, lines 1172--1178)
+and the block-diagonal gauge construction in lines 1189--1192. -/
 theorem toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
     (X : (k : Fin r) → GL (Fin (dim k)) ℂ)
     (hX : ∀ k : Fin r, ∀ i : Fin d,


### PR DESCRIPTION
## Summary

This PR corrects source ranges in Lean prose around the CPSV16 BNT and coefficient-comparison path.

The affected comments previously used broad ranges such as lines 1170--1192, or the obsolete `eq:II:A=XAX` handle, for auxiliary lemmas that belong to different parts of the source proof. The updated comments separate:

- The proportional theorem statement, CPSV16 `thm1`, lines 1167--1170.
- The proportional proof's block-matching use of Lemma `Lem1`, line 1182, with `Lem1` at lines 1131--1133.
- The equal-MPV corollary coefficient comparison, lines 1187--1188.
- The block-diagonal gauge construction for Corollary `II_cor2`, lines 1189--1192.

This is a documentation-only source-faithfulness cleanup. No declarations or proofs are changed.

## Validation

- `git diff --check HEAD^..HEAD`
- stale-source scan for `1170--1192`, `1155--1192`, `1155–1192`, and `eq:II:A=XAX` in the touched files
- `lake env lean TNLean/Algebra/UnitModulusPowerSum.lean`
- `lake env lean TNLean/MPS/BNT/Basic.lean`
- `lake env lean TNLean/MPS/BNT/Construction.lean`
- `lake env lean TNLean/MPS/SharedInfra/BlockGauge.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to comment/prose updates adjusting CPSV16 line/label references, with no modifications to Lean declarations or proofs.
> 
> **Overview**
> Updates documentation comments across the BNT/fundamental-theorem related modules to **narrow and correct CPSV16 source references** (e.g., distinguishing `thm1` statement vs. proof line 1182/Lemma `Lem1`, separating the equal-MPV coefficient comparison at lines 1187–1188, and updating the Corollary II.2 handle to `eq:II_auxcor` with the block-gauge construction at lines 1189–1192).
> 
> No code, definitions, or proofs change—this is strictly a source-faithfulness/attribution cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca8db7ef772b2f23681637475253fbd5c08ff1df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->