### PR TITLE
doc(blueprint): name FT auxiliary reductions

### DIFF
--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -939,13 +939,13 @@ facts used to recover the lists of weights from those power sums.
     componentwise power-sum identities.
 \end{remark}
 
-\section{Auxiliary constructions relocated from Chapter~\ref{ch:canonical}}%
+\section{Auxiliary reductions for the Fundamental Theorem}%
 \label{sec:ft_auxiliary_from_ch08}
 
-The following auxiliary results were previously presented in
-Chapter~\ref{ch:canonical}. They are reduction steps of the fundamental-theorem
-proof rather than statements about canonical-form data, so they are collected
-here.
+The following auxiliary results are reduction steps of the Fundamental-Theorem
+proof rather than statements about canonical-form data. They are collected here
+because they turn blockwise single-block conclusions into statements about the
+direct-sum tensors appearing in the proof.
 
 \subsection{Block-diagonal corollaries of the single-block theorem}%
 \label{subsec:ft_block_sum_corollaries}

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -6,7 +6,9 @@ two tensors with the same MPV family. Each side is written as the direct sum of
 an all-zero tensor $\mathbf{0}_{d,D_0}$ and a weighted direct sum of
 left-canonical, primitive, irreducible blocks over a common physical alphabet;
 these decompositions are the input to the equal-MPV comparison of
-Chapter~\ref{ch:ft_proof}.
+Chapter~\ref{ch:ft_proof}. Thus this chapter is placed immediately before the
+proof of the Fundamental Theorem: it records the reductions needed to put the
+two tensors on the common blocked surface used in the comparison argument.
 
 \section{Zero-tail separation}%
 \label{sec:zero_block_separation}


### PR DESCRIPTION
## Summary

This PR resolves the concrete MPS-placement part of #1863.

- renames the Fundamental-Theorem proof section formerly titled `Auxiliary constructions relocated from Chapter ...` to `Auxiliary reductions for the Fundamental Theorem`
- replaces the historical opening prose with a mathematical description of the section's role
- clarifies why the after-blocking chapter is placed immediately before the Fundamental-Theorem proof

The larger channel-representation relocation in #1863 is left for a separate PR because the placement audit found that the fixed-point algebra material after Chapter 4's `Representations` section is still used by the spectral chapter before the Fundamental-Theorem proof.

## Validation

- `git diff --check`
- `cd blueprint && leanblueprint web` completed, with the repository's existing plasTeX renderer warnings
- `cd blueprint && leanblueprint checkdecls` was run and failed on the repository's existing missing-declaration inventory; this PR adds no `\lean{}` tags or declaration references

Closes part of #1863.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that renames a section and rewrites introductory prose; no math statements, labels, or Lean references are altered.
> 
> **Overview**
> Renames the Fundamental-Theorem proof section heading from a historical relocation note to **"Auxiliary reductions for the Fundamental Theorem"**, and rewrites the opening paragraph to explain its role as a reduction step from single-block results to direct-sum tensors.
> 
> Clarifies the introductory text of `ch11b_after_blocking.tex` to explicitly justify why the after-blocking reductions chapter is placed immediately before the Fundamental-Theorem proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03b36705840c999ed547ba745ad79591939ea6c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->