### PR TITLE
doc(MPS): split CPSV source ranges in gap notes

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -828,9 +828,13 @@ recovery (Theorem~\ref{thm:power_sum_multiset}), and the
 equality to an explicit per-copy indexing. Together they realise the
 $\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ recovery of
 \cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. The coefficient
-identity itself is the linear-independence projection step of
-\cite[\S~II, lines 1170--1192]{Cirac2017MPDO_AnnPhys} and is supplied by
-the substitution argument of Section~\ref{subsec:sector_bnt_substitution} below.
+identity itself belongs to the block-selection step in the proof of
+Theorem~\texttt{thm1}
+\cite[\S~II, line 1182]{Cirac2017MPDO_AnnPhys}; the later equal-MPV
+copy-weight and global-gauge argument is
+\cite[\S~II, lines 1184--1192]{Cirac2017MPDO_AnnPhys}. The coefficient
+identity is supplied by the substitution argument of
+Section~\ref{subsec:sector_bnt_substitution} below.
 
 \begin{lemma}[Matched-sector weight multiset equality]%
     \label{lem:sector_bnt_matched_sector_weight_multiset_eq}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -827,13 +827,14 @@ recovery (Theorem~\ref{thm:power_sum_multiset}), and the
 \emph{matched-sector weight-permutation extractor} upgrading the multiset
 equality to an explicit per-copy indexing. Together they realise the
 $\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ recovery of
-\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. The coefficient
-identity itself belongs to the block-selection step in the proof of
-Theorem~\texttt{thm1}
-\cite[\S~II, line 1182]{Cirac2017MPDO_AnnPhys}; the later equal-MPV
-copy-weight and global-gauge argument is
-\cite[\S~II, lines 1184--1192]{Cirac2017MPDO_AnnPhys}. The coefficient
-identity is supplied by the substitution argument of
+\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
+the preceding block-selection argument supplies the matched normal sectors
+\cite[\S~II, line 1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
+used here is the equal-MPV coefficient comparison of
+\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
+global-gauge assembly in
+\cite[\S~II, lines 1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
+is supplied by the substitution argument of
 Section~\ref{subsec:sector_bnt_substitution} below.
 
 \begin{lemma}[Matched-sector weight multiset equality]%

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -45,8 +45,8 @@ with $C_{j,k}\ge 0$ and a rate $\eta_{j,k}\in[0,1)$.
 
 \section{Cited assertion}
 
-The Step~1 argument at
-\cite[lines~1170--1192]{Cirac2016MPDO_arXiv} relies on
+The Step~1 argument in the proof of Theorem~\texttt{thm1}
+\cite[line~1182]{Cirac2016MPDO_arXiv} relies on
 $O_{j,k_0}(N)\to 0$ for $j\ne k_0$ to discard
 cross-overlap terms when projecting an assembled BNT identity onto a
 distinguished basis block $V^{(N)}(P.\mathtt{basis}\,k_0)$. The

--- a/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
+++ b/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
@@ -327,8 +327,11 @@ The remaining Lean interfaces keep the proportional matching conclusion as an
 explicit input until the source-faithful residual comparison theorem is
 available.
 
-What remains is the proof itself. The paper-faithful proof following
-\cite[lines~1170--1192]{Cirac2016MPDO_arXiv} will consume the per-$N$
+What remains is the proof itself. The paper-faithful proof follows the
+block-selection step of Theorem~\texttt{thm1}
+\cite[line~1182]{Cirac2016MPDO_arXiv}, followed in the equal-MPV corollary by
+the finite power-sum comparison and global gauge assembly
+\cite[lines~1184--1192]{Cirac2016MPDO_arXiv}. It will consume the per-$N$
 hypothesis set together with the missing residual comparison data: the
 lower-bound argument uses $\|b_{N,1}\|=1$ together with
 $\|b_{N,k}\|\le 1$ and $c_N\ne 0$ for the currently dominant surviving

--- a/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
+++ b/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
@@ -106,8 +106,9 @@ if the bond dimensions differ, the overlap tends to zero, contradicting the
 unit-modulus overlap hypothesis.
 
 This rectangular dimension recovery is genuinely needed in the proof of
-\cite[Theorem~II.1, lines~1170--1192]{Cirac2016MPDO_arXiv}. There the relevant
-overlaps are per-block overlaps
+Theorem~\texttt{thm1}
+\cite[statement lines~1167--1170; proof line~1182]{Cirac2016MPDO_arXiv}.
+There the relevant overlaps are per-block overlaps
 $\langle V^{(N)}(B_k)\,|\,V^{(N)}(A_j)\rangle$, and the source proof applies
 Lemma~\texttt{equalMPS} before the matching of bond dimensions has been
 established. The same-dimension theorem therefore covers the gauge step only

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -66,7 +66,8 @@ $r_j=1$ of that structure; see
 
 \section{Cited assertion}
 
-The Step~1 paragraph at \cite[lines~1170--1192]{Cirac2016MPDO_arXiv}
+The block-selection paragraph in the proof of Theorem~\texttt{thm1}
+\cite[line~1182]{Cirac2016MPDO_arXiv}
 fixes any $B$-block $B_{k_0}$ and rules out
 \begin{align}
     \langle V^{(N)}(A_j),V^{(N)}(B_{k_0})\rangle
@@ -148,7 +149,8 @@ mismatch.
 
 \section{The argument the source uses}
 
-The Step~1 contradiction in \cite[lines~1170--1192]{Cirac2016MPDO_arXiv}
+The Step~1 contradiction in the proof of Theorem~\texttt{thm1}
+\cite[line~1182]{Cirac2016MPDO_arXiv}
 does not project onto $V^{(N)}(B_{k_0})$. Isolating $V^{(N)}(B_{k_0})$
 in~\eqref{eq:prop} gives
 \begin{align}

--- a/docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex
+++ b/docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex
@@ -17,7 +17,7 @@
 \section{Source phrase}
 
 Cirac--P\'erez-Garc\'ia--Schuch--Verstraete state Theorem~\texttt{thm1}
-in \cite{Cirac2016MPDO_arXiv}, lines~1170--1192, for tensors whose
+in \cite[lines~1167--1170]{Cirac2016MPDO_arXiv}, for tensors whose
 matrix-product vectors are ``proportional to each other''. The displayed
 source statement does not spell out whether the proportionality scalar at a
 fixed length is required to be nonzero. The two formal readings are
@@ -86,7 +86,9 @@ for the proportional Fundamental Theorem.
 \section{Elimination plan}
 
 No extra mathematical theorem is needed for the present projective reading of
-CPSV16 lines~1170--1192. If a literal weak-scalar reading is later required,
+CPSV16 Theorem~\texttt{thm1}
+\cite[lines~1167--1170]{Cirac2016MPDO_arXiv}. If a literal weak-scalar
+reading is later required,
 it should be formalized as a separate bridge theorem: prove from the source
 canonical-form hypotheses that the relevant MPV vectors do not vanish at the
 lengths used in the argument, then derive

--- a/docs/paper-gaps/issue1530_ft_dependency_audit.tex
+++ b/docs/paper-gaps/issue1530_ft_dependency_audit.tex
@@ -29,9 +29,11 @@ The guiding source passages are the BNT definition, Proposition~\texttt{prop:cha
 the expansion \texttt{eq:II\_ABasicTensors}, the block-injective input
 Proposition~\texttt{propblockinj}, the proportional Fundamental Theorem
 \texttt{thm1}, and the equal-MPV Corollary~\texttt{II\_cor2} in
-\cite[lines~271--356]{Cirac2016MPDO_arXiv}, together with the proof appendix
-\cite[lines~1155--1192]{Cirac2016MPDO_arXiv}, which repeats \texttt{thm1} and
-proves the global gauge formula \texttt{eq:II:A=XAX}. The review version is
+\cite[lines~271--356]{Cirac2016MPDO_arXiv}. In the appendix,
+\texttt{Lem:app\_simple} is lines~1155--1163, \texttt{thm1} is restated at
+lines~1167--1170 and proved at line~1182, and \texttt{II\_cor2} is stated at
+lines~1172--1179. The global gauge formula is \texttt{eq:II\_auxcor}, stated
+at lines~1175--1177 and obtained in lines~1189--1192. The review version is
 \cite[Section~IV]{Cirac2021Matrix}. This note follows the same convention as
 the previous paper-gap notes: the source theorem is the standard of comparison,
 while formal helper structures are acceptable only when they are identified as

--- a/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
@@ -132,7 +132,7 @@ The phase-gauge relation used in the BNT characterization is labelled
   \tag{\texttt{eq:II:A=XAX}}
 \]
 The BNT characterization is \texttt{prop:char-BNT}
-\cite[lines~271--279 and 1135--1148]{Cirac2016MPDO_arXiv}, and the BNT
+\cite[lines~278--280 and 1135--1148]{Cirac2016MPDO_arXiv}, and the BNT
 decomposition is
 the subequation labelled \texttt{eq:II\_ABasicTensors}:
 \[
@@ -175,7 +175,7 @@ rules for the formal theorem surface.
   \item The phase-gauge relation \texttt{eq:II:A=XAX}
   \cite[lines~264--268]{Cirac2016MPDO_arXiv} and the characterization
   \texttt{prop:char-BNT}
-  \cite[lines~271--279 and 1135--1148]{Cirac2016MPDO_arXiv} quotient the
+  \cite[lines~278--280 and 1135--1148]{Cirac2016MPDO_arXiv} quotient the
   canonical-form blocks by phase and gauge.
   Thus the paper's BNT is a list of representatives of equivalence classes.
   A formal common phase cover on raw cyclic sectors is not yet the paper's BNT

--- a/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
@@ -131,7 +131,9 @@ The phase-gauge relation used in the BNT characterization is labelled
   \tilde A_k = e^{i\phi_k} X_k A_j X_k^{-1}
   \tag{\texttt{eq:II:A=XAX}}
 \]
-The BNT characterization is \texttt{prop:char-BNT}, and the BNT decomposition is
+The BNT characterization is \texttt{prop:char-BNT}
+\cite[lines~271--279 and 1135--1148]{Cirac2016MPDO_arXiv}, and the BNT
+decomposition is
 the subequation labelled \texttt{eq:II\_ABasicTensors}:
 \[
   A^i =
@@ -170,8 +172,11 @@ rules for the formal theorem surface.
   the omitted all-zero summand. It is not an additional normal tensor, a BNT
   representative, or a separate scalar weight in the paper decomposition.
 
-  \item The phase-gauge relation \texttt{eq:II:A=XAX} and the characterization
-  \texttt{prop:char-BNT} quotient the canonical-form blocks by phase and gauge.
+  \item The phase-gauge relation \texttt{eq:II:A=XAX}
+  \cite[lines~264--268]{Cirac2016MPDO_arXiv} and the characterization
+  \texttt{prop:char-BNT}
+  \cite[lines~271--279 and 1135--1148]{Cirac2016MPDO_arXiv} quotient the
+  canonical-form blocks by phase and gauge.
   Thus the paper's BNT is a list of representatives of equivalence classes.
   A formal common phase cover on raw cyclic sectors is not yet the paper's BNT
   matching statement until it has been pushed down to these representatives.
@@ -298,9 +303,11 @@ compares the coefficients in the BNT decompositions by the power-sum identity
   \sum_{q=1}^{r_{b,j}}(\nu_{j,q}e^{i\phi_j})^N
 \]
 for each matched basis tensor and all lengths $N$. The elementary power-sum
-lemma recovers the multiplicities and weights, and the blockwise gauges assemble
-into the global conjugating matrix
-\cite[lines~1155--1192]{Cirac2016MPDO_arXiv}.
+lemma \texttt{Lem:app\_simple}
+\cite[lines~1155--1163]{Cirac2016MPDO_arXiv} recovers the multiplicities and
+weights, and the blockwise gauges assemble into the global conjugating matrix in
+the proof of Corollary~\texttt{II\_cor2}
+\cite[lines~1184--1192]{Cirac2016MPDO_arXiv}.
 
 \section{Fixed-length span after blocking}
 
@@ -536,8 +543,9 @@ on published theorem names.
   positive-length MPVs; lines~214--255 give canonical form and period removal;
   lines~271--302 define and use BNTs; lines~317--345 define injectivity,
   block-injective canonical form, and the $3D^5$ bound; lines~347--360 state
-  the Fundamental Theorem and equal-case corollary; lines~1155--1192 contain
-  the power-sum comparison in the equal case; lines~1984--1988 use
+  the Fundamental Theorem and equal-case corollary; lines~1155--1163 state
+  \texttt{Lem:app\_simple}; lines~1184--1192 contain the power-sum comparison
+  and global gauge assembly in the equal case; lines~1984--1988 use
   $C_L(V)=\operatorname{span}(V^L)$ as an exact-length span.
 
   \item \path{Papers/quant-ph_0608197/MPSarchive.tex}: lines~742--763 state the
@@ -611,7 +619,7 @@ blocked not-gauge-phase equivalence, zero-tail identities, and the common
 injective blocking length through the nested-to-flat reblocking map, and then
 feed the resulting families into the BNT sector-data comparison.\footnote{%
 The live target side is the sector-data theorem
-\leanid{MPSTensor.ft_sector_bnt_equal_sector_data}; the now-available inputs are
+\leanid{MPSTensor.ft\_sector\_bnt\_equal\_sector\_data}; the now-available inputs are
 the bounded and common injective-blocking theorems for normal-CF-BNT blocks and
 the already-injective direct-sum trace-separation theorems.}  The
 paper suppresses this bookkeeping in notation; Lean must make it explicit.


### PR DESCRIPTION
## Summary

This PR continues the CPSV16 source-boundary cleanup for #1749 and #1685.

- separates the proportional theorem statement and block-selection proof step at CPSV16 lines 1167--1170 and line 1182 from the equal-MPV corollary lines 1184--1192 in Chapter 10 and the paper-gap notes
- records `Lem:app_simple`, `thm1`, `II_cor2`, and `eq:II_auxcor` with their separate appendix ranges instead of the earlier broad 1155--1192 or 1170--1192 citations
- adds precise source ranges for the BNT phase/gauge quotient passages in the nonperiodic BNT comparison note
- fixes one existing unescaped Lean identifier in that note so that it compiles under `latexmk`

This does not claim the remaining proportional coefficient-comparison theorem is formalized. It keeps #1749 focused on that open mathematical step.

## Validation

- `git diff --check` on the changed files
- `cd blueprint && leanblueprint web`
- `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error cpsv16_bnt_rate_quantification.tex cpsv16_cf_normalization_and_proportional_comparison.tex cpsv16_equalMPS_gauge_phase_gap.tex cpsv16_nondominant_per_block_projection.tex cpsv16_nonzero_proportionality_reading.tex issue1530_ft_dependency_audit.tex nonperiodic_mps_bnt_comparison_inputs.tex`
- `cd blueprint && leanblueprint checkdecls` fails on the repository-wide existing missing-declaration inventory; this PR adds no new `\lean{}` tags.

Refs #1749.
Refs #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that refine citations and wording without modifying Lean code or theorem statements.
> 
> **Overview**
> Clarifies the CPSV16/Cirac2017 source mapping in the blueprint and paper-gap notes by **splitting previously broad citations** into the specific theorem-statement, block-selection, power-sum, and global-gauge assembly line ranges (e.g., separating `thm1` statement/proof from `II_cor2` and `Lem:app_simple`).
> 
> Updates several gap notes to reference the correct substeps (block-selection vs equal-MPV coefficient comparison), adds missing pinpoint citations for BNT phase/gauge quotient passages, and includes minor LaTeX hygiene fixes (EOF newlines and a corrected `\leanid{...}` identifier for `MPSTensor.ft_sector_bnt_equal_sector_data`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3db9d6b3e34a72a373fa759d02d10e0004de0a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->