### PR TITLE
doc(blueprint): reorganize channel normal forms

### DIFF
--- a/blueprint/src/chapter/ch04a_channel_representations.tex
+++ b/blueprint/src/chapter/ch04a_channel_representations.tex
@@ -1220,7 +1220,7 @@ a common dilation space.
 
 %% =========================================================
 \section{Trace-pairing expansion in transfer-matrix form}
-\label{subsec:trace_pairing_expansion}
+\label{sec:trace_pairing_expansion}
 %% =========================================================
 
 \begin{definition}[Trace-self-dual basis]\label{def:trace_pairing_self_dual_basis}
@@ -1268,7 +1268,7 @@ a common dilation space.
 
 %% =========================================================
 \section{SVD normal form (existence)}
-\label{subsec:svd_normal_form}
+\label{sec:svd_normal_form}
 %% =========================================================
 
 \cite[Section~2.3]{Wolf2012Quantum} discusses two families of normal forms for
@@ -1279,7 +1279,7 @@ normal form is proved below. The Lorentz normal form theorem
 (Theorem~\ref{thm:lorentz_normal_form_qubit}) requires the compactness and
 minimisation argument for $\SL(2, \C)$ filterings in
 \cite[Propositions~2.9 and~2.11]{Wolf2012Quantum}; see
-Section~\ref{subsec:lorentz_normal_form}.
+Section~\ref{sec:lorentz_normal_form}.
 
 \begin{theorem}[SVD for positive semidefinite matrices]
     \label{thm:svd_posSemidef}
@@ -1350,7 +1350,7 @@ Section~\ref{subsec:lorentz_normal_form}.
 
 %% =========================================================
 \section{Lorentz normal form}
-\label{subsec:lorentz_normal_form}
+\label{sec:lorentz_normal_form}
 %% =========================================================
 
 This section states the existence theorems from

--- a/blueprint/src/chapter/ch04a_channel_representations.tex
+++ b/blueprint/src/chapter/ch04a_channel_representations.tex
@@ -3,8 +3,10 @@
 This chapter collects the representation material for finite-dimensional quantum
 channels from \cite[Chapter~2]{Wolf2012Quantum}: the Choi--Jamio\l{}kowski
 isomorphism, Kraus representation theorems, Stinespring and Naimark dilations,
-and normal forms. These results are important for the channel theory developed
-in the following chapters, but they are not prerequisites for the
+ordered completely positive maps, Radon--Nikodym and open-system
+representations, trace-pairing expansions, SVD and Lorentz normal forms, and the
+channel determinant. These results are important for the channel theory
+developed in the following chapters, but they are not prerequisites for the
 matrix-product-state Fundamental Theorem.
 
 %% =========================================================
@@ -1217,7 +1219,7 @@ a common dilation space.
 \end{proof}
 
 %% =========================================================
-\subsection{Trace-pairing expansion in transfer-matrix form}
+\section{Trace-pairing expansion in transfer-matrix form}
 \label{subsec:trace_pairing_expansion}
 %% =========================================================
 
@@ -1265,7 +1267,7 @@ a common dilation space.
 \end{proof}
 
 %% =========================================================
-\subsection{SVD normal form (existence)}
+\section{SVD normal form (existence)}
 \label{subsec:svd_normal_form}
 %% =========================================================
 
@@ -1277,7 +1279,7 @@ normal form is proved below. The Lorentz normal form theorem
 (Theorem~\ref{thm:lorentz_normal_form_qubit}) requires the compactness and
 minimisation argument for $\SL(2, \C)$ filterings in
 \cite[Propositions~2.9 and~2.11]{Wolf2012Quantum}; see
-Subsection~\ref{subsec:lorentz_normal_form}.
+Section~\ref{subsec:lorentz_normal_form}.
 
 \begin{theorem}[SVD for positive semidefinite matrices]
     \label{thm:svd_posSemidef}
@@ -1332,7 +1334,7 @@ Subsection~\ref{subsec:lorentz_normal_form}.
 
 \begin{proof}\leanok
     Direct specialisation of Theorem~\ref{thm:svd_of_isUnit} to the index type
-    $\{1,\ldots,D\} \times \{1,\ldots,D\}$ used by the transfer-matrix
+    $\{0,\ldots,D-1\} \times \{0,\ldots,D-1\}$ used by the transfer-matrix
     representation.
 \end{proof}
 
@@ -1347,13 +1349,13 @@ Subsection~\ref{subsec:lorentz_normal_form}.
 \end{remark}
 
 %% =========================================================
-\subsection{Lorentz normal form}
+\section{Lorentz normal form}
 \label{subsec:lorentz_normal_form}
 %% =========================================================
 
-This subsection states the existence theorems from
+This section states the existence theorems from
 \cite[Section~2.3]{Wolf2012Quantum}.
-% The Wolf.* declarations referenced in this subsection live in
+% The Wolf.* declarations referenced in this section live in
 % TNLean/Channel/LorentzNormalForm.lean, which is not in the root import
 % graph because its core minimisation lemma is still on `sorry`. The
 % `\lean{...}` tags are omitted here so that checkdecls passes; the Lean


### PR DESCRIPTION
Closes LionSR/QICLean#155.

This PR cleans up the channel-representation chapter after the Chapter 4 relocation. The trace-pairing expansion, SVD normal form, and Lorentz normal form blocks are now top-level sections rather than sitting under POVMs and Naimark dilation. The chapter opening paragraph now names the ordered-CP/Radon--Nikodym/open-system material, trace-pairing expansions, normal forms, and the channel determinant.

The Lean tags and theorem statements are preserved. The labels for the promoted blocks now use the `sec:` prefix appropriate for top-level sections. One inherited index sentence in the SVD transfer-matrix proof is also aligned with the `Fin` convention by using `{0, ..., D-1}`.

Validation:
- `git diff --check -- blueprint/src/chapter/ch04a_channel_representations.tex`
- duplicate-label scan across `blueprint/src/chapter/*.tex`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only reorganization that changes section structure and cross-references but not any mathematical statements or Lean tags; main risk is broken LaTeX labels/refs due to heading/label changes.
> 
> **Overview**
> Updates the Chapter 4 channel-representation blueprint to better surface key normal-form material: the intro paragraph now explicitly lists ordered-CP/Radon–Nikodym/open-system representations, trace-pairing expansions, normal forms, and the channel determinant.
> 
> Promotes trace-pairing expansion, SVD normal form, and Lorentz normal form blocks from subsections to top-level `\section`s (updating labels and internal references accordingly), and aligns one transfer-matrix index set in the SVD proof to the `\{0,\ldots,D-1\}^2` convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01dce4d6488ada08197efb2ae9dd5763069d1b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->