### PR TITLE
doc(blueprint): cite remaining entropy and direct-sum sources

### DIFF
--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -176,12 +176,10 @@ finite-dimensional quantum systems.
     the middle subsystem $B$.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
-    It is the equality criterion needed
-    by Appendix~C of arXiv:1606.00608. We cite Hayashi,
-    \emph{J. Phys. A} 37 (2004) L205--L208, and Ruskai,
-    \emph{J. Math. Phys.} 43 (2002) 4358; the structural block-decomposition
-    formulation used for MPDOs also appears in Hayden--Jozsa--Petz--
-    Winter, \emph{Commun. Math. Phys.} 246 (2004) 359--374.
+    It is the equality criterion needed by Appendix~C of arXiv:1606.00608.
+    The equality conditions are reviewed in \cite{Ruskai2002Inequalities};
+    the structural block-decomposition formulation used for MPDOs appears in
+    \cite{Hayden2004Structure}.
 \end{theorem}
 
 \section{Mutual information}
@@ -243,7 +241,7 @@ later MPDO arguments.
     This formulation introduces no new axiom: it is the same
     strong-subadditivity statement as
     Theorem~\ref{thm:strong_subadditivity}. The underlying axiom's
-    proof (Lieb--Ruskai 1973) is deferred to the umbrella entropy
+    proof in \cite{LiebRuskai1973Proof} is deferred to the umbrella entropy
     issue.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -161,6 +161,10 @@ finite-dimensional quantum systems.
     \[
         \bigoplus_j p_j\, \rho_{A B_j^L} \otimes \rho_{B_j^R C}.
     \]
+    The terminology follows Hayashi's presentation of quantum Markov
+    structure~\cite{Hayashi2006QuantumInformation}; the block decomposition
+    used by the MPDO argument is the structure theorem of
+    \cite{Hayden2004Structure}.
 \end{definition}
 
 \begin{theorem}[Hayashi SSA-equality characterization]
@@ -177,7 +181,8 @@ finite-dimensional quantum systems.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.
-    The equality conditions are reviewed in \cite{Ruskai2002Inequalities};
+    The equality conditions are reviewed in
+    \cite{Hayashi2006QuantumInformation, Ruskai2002Inequalities};
     the structural block-decomposition formulation used for MPDOs appears in
     \cite{Hayden2004Structure}.
 \end{theorem}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3354,8 +3354,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     homogeneous pair spans, then the simultaneous identity pair lies in all
     sufficiently large homogeneous pair spans.  Combined with all-length pair
     trace separation, this period-window input gives one homogeneous
-    pair trace-separation length.  This does not prove the
-    David--Perez-Garcia direct-sum input by itself: fullness of spans up to a
+    pair trace-separation length.  This does not prove the direct-sum input of
+    \cite{PerezGarcia2007Matrix} by itself: fullness of spans up to a
     bounded length is weaker than the exact homogeneous input used here.
 \end{lemma}
 

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -396,6 +396,39 @@
   doi          = {10.1016/0001-8708(73)90011-x},
 }
 
+@article{LiebRuskai1973Proof,
+  author       = {Lieb, Elliott H. and Ruskai, Mary Beth},
+  title        = {Proof of the Strong Subadditivity of Quantum-Mechanical Entropy},
+  journal      = {Journal of Mathematical Physics},
+  volume       = {14},
+  number       = {12},
+  pages        = {1938--1941},
+  year         = {1973},
+  doi          = {10.1063/1.1666274},
+}
+
+@article{Ruskai2002Inequalities,
+  author       = {Ruskai, Mary Beth},
+  title        = {Inequalities for Quantum Entropy: A Review with Conditions for Equality},
+  journal      = {Journal of Mathematical Physics},
+  volume       = {43},
+  number       = {9},
+  pages        = {4358--4375},
+  year         = {2002},
+  doi          = {10.1063/1.1497701},
+}
+
+@article{Hayden2004Structure,
+  author       = {Hayden, Patrick and Jozsa, Richard and Petz, D{\'e}nes and Winter, Andreas},
+  title        = {Structure of States Which Satisfy Strong Subadditivity of Quantum Entropy with Equality},
+  journal      = {Communications in Mathematical Physics},
+  volume       = {246},
+  number       = {2},
+  pages        = {359--374},
+  year         = {2004},
+  doi          = {10.1007/s00220-004-1049-z},
+}
+
 @article{Ando1979Concavity,
   author       = {Ando, T.},
   title        = {Concavity of Certain Maps on Positive Definite Matrices and Applications to {Hadamard} Products},

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -418,6 +418,16 @@
   doi          = {10.1063/1.1497701},
 }
 
+@book{Hayashi2006QuantumInformation,
+  author       = {Hayashi, Masahito},
+  title        = {Quantum Information: An Introduction},
+  publisher    = {Springer},
+  address      = {Berlin, Heidelberg},
+  year         = {2006},
+  doi          = {10.1007/3-540-30266-2},
+  isbn         = {978-3-540-30265-0},
+}
+
 @article{Hayden2004Structure,
   author       = {Hayden, Patrick and Jozsa, Richard and Petz, D{\'e}nes and Winter, Andreas},
   title        = {Structure of States Which Satisfy Strong Subadditivity of Quantum Entropy with Equality},


### PR DESCRIPTION
## Summary

This PR replaces the remaining prose-only blueprint citations from issue #1530 item 14 with bibliography-backed citations.

It changes the entropy chapter to cite Lieb--Ruskai for strong subadditivity, Ruskai for equality conditions, and Hayden--Jozsa--Petz--Winter for the structural equality case. It also replaces the remaining named direct-sum reference in the parent-Hamiltonian chapter by a citation to PGVWC07.

## Source Notes

The Appendix C input of arXiv:1606.00608 cites the structural equality result as its reference Hay03, namely Hayden--Jozsa--Petz--Winter, Commun. Math. Phys. 246 (2004) 359--374. The blueprint now cites that paper directly. The earlier prose also named a Hayashi source, but the source paper's Appendix C uses HJPW for the block-decomposition statement needed here; Ruskai's review is retained for equality conditions, while HJPW is retained for the structural form used by the MPDO argument.

## Validation

- `git diff --check -- blueprint/src/chapter/ch04b_entropy.tex blueprint/src/chapter/ch14_parent_hamiltonian.tex blueprint/src/references.bib`
- `cd blueprint/src && latexmk -C print.tex && latexmk -lualatex -interaction=nonstopmode print.tex`
- `cd blueprint/src && cp print.bbl web.bbl && leanblueprint web`

The blueprint web build still reports the existing renderer warnings for path, TikZ, and PEPS diagram macros. The generated bibliography contains the new `HJPW04`, `LR73`, and `Rus02` entries.

`cd blueprint && leanblueprint checkdecls` was also run. It still fails on existing missing declarations in the PEPS and parent-Hamiltonian blueprint chapters; this PR does not change any `\lean{...}` tags.

Refs #1530.
Refs #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that update citations and bibliography entries without affecting Lean declarations or mathematical statements.
> 
> **Overview**
> Replaces remaining prose-only references in the blueprint with explicit BibTeX-backed citations.
> 
> In `ch04b_entropy.tex`, updates the SSA equality/quantum Markov decomposition discussion to cite Hayashi, Ruskai, and Hayden–Jozsa–Petz–Winter, and changes the strong subadditivity proof attribution to a formal `LiebRuskai1973Proof` citation.
> 
> In `ch14_parent_hamiltonian.tex`, replaces a named “David–Perez-Garcia” direct-sum reference with a citation to `PerezGarcia2007Matrix`. Adds the corresponding new bibliography entries (`LiebRuskai1973Proof`, `Ruskai2002Inequalities`, `Hayashi2006QuantumInformation`, `Hayden2004Structure`) in `references.bib`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f47641995f3989ef7e16705f83384884d9ba13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->