### PR TITLE
doc(MPS/FT): correct sector-weight source anchors

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean
@@ -26,15 +26,15 @@ These statements are exact-algebraic: they consume only
 `SectorWeightComparison.lean`, together with a generic
 `Multiset.map`-permutation extractor over `Fin n` proved by induction
 on `n`.  No dominant-pair-matching surface, drop-sector recursion, or
-Newton–Girard inversion is involved.
+Newton--Girard inversion is involved.
 
 ## Paper anchors
 
-* CPSV16 §II.C lines 1158–1167, 1184, 1188 (arXiv:1606.00608): for a
-  fixed matched sector, equal power sums (eventually in `N`) and nonzero
-  per-copy weights imply equal cardinalities and equal weight multisets,
-  hence the per-copy gauge-phase identification
-  `μ_{j,q} = ν_{j,τ(q)} · e^{i\phi_j}`.
+* CPSV16 Appendix Lemma `Lem:app_simple`, lines 1155--1163, and the
+  `II_cor2` proof, lines 1184--1188 (arXiv:1606.00608): for a fixed
+  matched sector, equal power sums and nonzero per-copy weights imply equal
+  cardinalities and equal weight multisets, hence the per-copy gauge-phase
+  identification `μ_{j,q} = ν_{j,τ(q)} · e^{i\phi_j}`.
 
 ## Tags
 
@@ -57,9 +57,10 @@ per-copy weight multisets agree:
 `Multiset.map (P.weight j₀) Finset.univ.val
    = Multiset.map (fun q => ζ * Q.weight k₀' q) Finset.univ.val`.
 
-This is CPSV16 line 1188 read on a single matched sector: equal power
-sums (eventually in `N`) and nonzero entries imply equal multisets, hence
-equal cardinalities.
+This is CPSV16 line 1188 read on a single matched sector, with the
+power-sum rigidity supplied by Appendix Lemma `Lem:app_simple`, lines
+1155--1163: equal power sums (eventually in `N`) and nonzero entries imply
+equal multisets, hence equal cardinalities.
 
 The proof composes `power_sums_eq_of_eventually_eq_hetero` (extension
 from eventual to all positive exponents) with
@@ -160,8 +161,8 @@ theorem matched_sector_weight_multiset_eq
 The multiset equality above is upgraded to an *explicit* permutation
 `τ : Fin (P.copies j₀) ≃ Fin (Q.copies k₀')` matching individual per-copy
 weights up to the gauge-phase factor `ζ`.  This is the per-copy form of
-CPSV16 line 1188 (`μ_{j,q} = ν_{j,q} · e^{i\phi_j}` for an indexing of
-the `Q`-copies determined by a matching).
+CPSV16 line 1188 (`μ_{j,q} = ν_{j,q} · e^{i\phi_j}` after choosing the
+indexing of the `Q`-copies determined by Appendix Lemma `Lem:app_simple`).
 
 The proof reduces to a generic auxiliary lemma extracting an `Equiv.Perm` from a
 multiset-map equality on `Fin`, then composes with the cardinality cast
@@ -249,7 +250,8 @@ set_option linter.unusedVariables false in
 Refines `matched_sector_weight_multiset_eq` into an explicit permutation
 `τ` realising CPSV16 line 1188's per-copy identification.
 
-Paper anchor: CPSV16 §II.C lines 1158-1167, 1184, 1188 (arXiv:1606.00608). -/
+Paper anchor: CPSV16 Appendix Lemma `Lem:app_simple`, lines 1155--1163,
+and `II_cor2` proof lines 1184--1188 (arXiv:1606.00608). -/
 theorem matched_sector_weight_equiv
     {P Q : SectorDecomposition d}
     (j₀ : Fin P.basisCount) (k₀' : Fin Q.basisCount)

--- a/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
@@ -13,7 +13,7 @@ import Mathlib.Data.Fintype.BigOperators
 /-!
 # Sector decomposition comparison theorems
 
-This chapter compares two finite sector decompositions that describe the same
+This module compares two finite sector decompositions that describe the same
 matrix-product vector family.  It combines the coefficient comparison, the
 recovery of sector weights from power sums, and the equal-case corollaries
 needed to match sectors up to permutation and nonzero phase factors.
@@ -22,9 +22,10 @@ needed to match sectors up to permutation and nonzero phase factors.
 
 - [PGVWC07] Pérez-García, Verstraete, Wolf, Cirac, *Matrix Product State Representations*,
   Quantum Inf. Comput. 7 (2007), arXiv:quant-ph/0608197.
-- [CPSV17] Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density
+- [CPSV16] Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density
   Operators: Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608
-  (2017).
+  (2016), especially Appendix Lemma `Lem:app_simple`, lines 1155--1163, and
+  the equal-MPV corollary proof, lines 1184--1192.
 - [CPSV21] Cirac, Pérez-García, Schuch, Verstraete, *Matrix product states and projected
   entangled pair states: Concepts, symmetries, theorems*, Rev. Mod. Phys. 93 (2021),
   arXiv:2011.12127.
@@ -52,9 +53,9 @@ The result formalized here is the BNT coefficient comparison that recovers both
 multiplicities and sector weights. A global gauge-equivalence statement for the
 block-diagonal tensors still requires deriving the block matching and phase
 relations from bare equality of matrix-product vectors. In sector form the
-coefficients are finite sums of powers of unit-modulus weights, so convergence is
-not automatic without a dominant weight, normalization, or an explicit
-common-phase comparison.
+coefficients are finite sums of powers of nonzero weights, so comparison is
+carried out through the CPSV16 Appendix `Lem:app_simple` power-sum argument,
+not through a limiting coefficient argument.
 -/
 
 /-- **Phase matching and total MPV equality recover multiplicities and sector weights.**
@@ -66,8 +67,11 @@ independent, then the multiplicities are forced to agree. After absorbing the sa
 phases into the weights of `Q`, the per-basis sector weight multisets agree.
 
 This is the coefficient-extraction part of the comparison: equality of multiplicities
-is recovered from the exponent-zero case of the power-sum identity after eventual
-coefficient equality has been extrapolated to all exponents. -/
+is recovered by the unequal-cardinality power-sum identity after eventual
+coefficient equality has been extrapolated to all exponents.  This is the
+formal version of the CPSV16 `II_cor2` coefficient comparison, lines
+1184--1188, with Appendix Lemma `Lem:app_simple`, lines 1155--1163, providing
+the finite power-sum rigidity. -/
 lemma fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_phaseMatch_exists_copies
     (P Q : SectorDecomposition d)
     (perm : Fin P.basisCount ≃ Fin Q.basisCount)

--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -16,14 +16,18 @@ sector decompositions over a common BNT basis.  Eventual coefficient equality is
 upgraded to equality of the sector-weight multisets by a geometric-sequence
 extrapolation and the Newton identities.
 
-In arXiv:1606.00608, Theorem IV.13 and its appendix proof use positive diagonal
-matrices whose traces enter the structure coefficients as power sums.  The
-geometric extrapolation and Newton--Girard steps below are the finite-sequence
-algebra needed to recover the weight lists from those power sums once the basis
-blocks have been matched.
+In CPSV16, the relevant coefficient comparison is the equal-MPV corollary
+`II_cor2`: after the BNT sectors have been matched, the proof compares the
+power sums of the copy weights in each matched sector
+(`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1184--1188).  The finite
+power-sum rigidity input is Appendix Lemma `Lem:app_simple`
+(lines 1155--1163).  The geometric extrapolation below is a formal
+strengthening needed because the Lean coefficient identity is often available
+eventually in the length parameter rather than at the first
+`max{x_a,x_b}` positive exponents.
 
-The main theorem below uses the unequal-cardinality finite-range power-sum theorem
-directly, as in the Appendix comparison.  Without nonzero weights, positive
+The main theorem below uses the unequal-cardinality finite-range power-sum
+theorem directly, as in `Lem:app_simple`.  Without nonzero weights, positive
 powers would only determine the nonzero submultiset.
 
 ## References
@@ -31,7 +35,8 @@ powers would only determine the nonzero submultiset.
 - [PGVWC07] Pérez-García, Verstraete, Wolf, Cirac, *Matrix Product State Representations*,
   Quantum Inf. Comput. 7 (2007), arXiv:quant-ph/0608197.
 - [CPSV16] Cirac, Pérez-García, Schuch, Verstraete, *Matrix Product Density Operators:
-  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2016).
+  Renormalization Fixed Points and Boundary Theories*, arXiv:1606.00608 (2016),
+  `Lem:app_simple` lines 1155--1163 and `II_cor2` proof lines 1184--1188.
 - [CPSV21] Cirac, Pérez-García, Schuch, Verstraete, *Matrix product states and projected
   entangled pair states: Concepts, symmetries, theorems*, Rev. Mod. Phys. 93 (2021),
   arXiv:2011.12127.
@@ -57,7 +62,7 @@ is eventually linearly independent (the BNT property), then the coefficient arra
 `S.coeff N j` and `T.coeff N j` agree for all sufficiently large `N`.
 
 This is the key step converting MPV equality into the algebraic statement needed for
-Newton–Girard. -/
+Newton--Girard. -/
 lemma coeff_eventually_eq_of_sameMPV
     {dim : Fin g → ℕ}
     (basis : (j : Fin g) → MPSTensor d (dim j))
@@ -204,8 +209,9 @@ weight multisets.
 For each basis tensor, eventual equality is first extrapolated to all positive
 exponents.  The finite-range unequal-cardinality power-sum theorem then gives the
 copy count and the multiset of weights, using the nonzero-entry hypotheses carried
-by `SectorWeightData`.  This is the formal counterpart of the Appendix power-sum
-comparison in arXiv:1606.00608. -/
+by `SectorWeightData`.  This is the formal counterpart of CPSV16 Appendix
+Lemma `Lem:app_simple`, lines 1155--1163, applied to the matched-sector
+power sums in the proof of `II_cor2`, lines 1184--1188. -/
 lemma copies_eq_and_weight_multiset_eq_of_eventually_coeff_eq
     (S T : SectorWeightData g)
     {N0 : ℕ}


### PR DESCRIPTION
## Summary

This PR corrects the source anchors for the sector-weight comparison layer of the non-periodic Fundamental Theorem proof.

The affected module prose now points to the actual CPSV16 passages used by the formal argument: Appendix Lemma Lem:app_simple at lines 1155--1163 for finite power-sum rigidity, and the equal-MPV corollary II_cor2 proof at lines 1184--1188 for the matched-sector coefficient comparison. It removes the old vague reference to a Theorem IV.13 route and stops describing the comparison as a limiting coefficient argument.

No declarations, theorem statements, or proofs are changed.

## Validation

- rg -n "Theorem IV\\.13|1158|1167|1181|Newton–|CPSV17|unit-modulus weights|Appendix comparison" TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
- git diff --check -- TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorDecomposition.lean

Refs #1685.
Refs #1749.
Refs #1565.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust paper citations and explanatory prose; no theorem statements or proofs are modified, so behavioral risk is minimal.
> 
> **Overview**
> Updates module/theorem docstrings in `SectorWeightComparison.lean`, `SectorBNT/WeightEquiv.lean`, and `SectorDecomposition.lean` to point to the **actual CPSV16 sources** used by the formal argument (Appendix Lemma `Lem:app_simple` and the `II_cor2` proof) and to clarify that the comparison proceeds via **finite power-sum rigidity** rather than a limiting/unit-modulus or Theorem IV.13 route.
> 
> Also normalizes wording/typography (e.g., `Newton--Girard`, year/citation text) without changing any declarations, statements, or proof terms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b7724af36f1066cb8975c076ae37b58b2a9eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->