### PR TITLE
doc(blueprint): clarify FT reduction placement

### DIFF
--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -13,6 +13,13 @@ The results combine the canonical form reduction
 block separation (Chapter~\ref{ch:block_perm}),
 spectral gap (Chapter~\ref{ch:spectral}),
 and the BNT permutation arguments of Chapter~\ref{ch:bnt}.
+The common after-blocking reductions of
+Chapter~\ref{ch:canonical_after_blocking} are placed immediately before this
+chapter because they produce the common primitive block decompositions used in
+the equal-MPV comparison. The auxiliary direct-sum reductions remain in
+Section~\ref{sec:ft_auxiliary_from_ch08}, inside the proof chapter, because
+they turn the single-block Fundamental Theorem into the block-diagonal
+gauge statements used after the block correspondence has been fixed.
 
 The theorems in this chapter follow the approach of
 \cite{Cirac2017MPDO_AnnPhys}:
@@ -943,9 +950,12 @@ facts used to recover the lists of weights from those power sums.
 \label{sec:ft_auxiliary_from_ch08}
 
 The following auxiliary results are reduction steps of the Fundamental-Theorem
-proof rather than statements about canonical-form data. They are collected here
-because they turn blockwise single-block conclusions into statements about the
-direct-sum tensors appearing in the proof.
+proof rather than statements about canonical-form decompositions. They are
+collected here because they turn blockwise single-block conclusions into
+statements about the direct-sum tensors appearing in the proof. In particular,
+this section is not part of the after-blocking canonical-form reduction: the
+block decomposition is already fixed, and the task here is to assemble the
+resulting gauges and MPV equalities.
 
 \subsection{Block-diagonal corollaries of the single-block theorem}%
 \label{subsec:ft_block_sum_corollaries}

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -9,6 +9,9 @@ these decompositions are the input to the equal-MPV comparison of
 Chapter~\ref{ch:ft_proof}. Thus this chapter is placed immediately before the
 proof of the Fundamental Theorem: it records the reductions needed to put the
 two tensors on the common blocked surface used in the comparison argument.
+It is therefore not part of the later channel-representation, symmetry, or
+semigroup material; those chapters no longer provide hypotheses for the
+Fundamental-Theorem comparison.
 
 \section{Zero-tail separation}%
 \label{sec:zero_block_separation}


### PR DESCRIPTION
## Summary

This PR records the placement decision requested in #1884.

- Keeps the after-blocking reductions immediately before the Fundamental-Theorem proof, since they produce the common primitive block decompositions used in the equal-MPV comparison.
- Keeps the auxiliary direct-sum reductions inside the Fundamental-Theorem proof chapter, since they assemble the block-diagonal gauge and MPV equalities after the block correspondence has been fixed.
- Clarifies that the after-blocking chapter is not part of the later channel-representation, symmetry, or semigroup material.
- Does not change chapter order, Lean tags, theorem statements, or source code.

Closes #1884.

## Validation

- `git diff --check -- blueprint/src/chapter/ch11b_after_blocking.tex blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch11b_after_blocking.tex blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`
- `leanblueprint web`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` reports the changed chapters at 100% (`ch11_fundamental_theorem_proof.tex`: 49/49, `ch11b_after_blocking.tex`: 36/36), with pre-existing missing declarations in parent-Hamiltonian and PEPS material.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` reports the same pre-existing 64 sync issues outside the changed chapters.
- `leanblueprint checkdecls` reports the same pre-existing missing declarations, concentrated in parent-Hamiltonian/PEPS ground-space material; no `\lean{}` tags were changed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are purely LaTeX narrative clarifications about where reductions belong in the Fundamental Theorem proof flow, with no theorem statements, Lean tags, or code logic modified.
> 
> **Overview**
> Clarifies the documentation around the Fundamental Theorem proof to explicitly distinguish **after-blocking canonical-form reductions** (kept immediately before the proof because they produce the common primitive block decompositions used for equal-MPV comparison) from the **auxiliary direct-sum reductions** (kept inside `ch11_fundamental_theorem_proof.tex` because they assemble block-diagonal gauges and MPV equalities once block correspondence is fixed).
> 
> Also adds a brief note in `ch11b_after_blocking.tex` that this after-blocking material is *not* part of later channel-representation/symmetry/semigroup chapters, since those no longer feed hypotheses into the Fundamental-Theorem comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e35a0eb820316b29e1149a17b1fa86db044565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->