### PR TITLE
doc(github): align issue templates with sub-issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/formalization-task.yml
+++ b/.github/ISSUE_TEMPLATE/formalization-task.yml
@@ -86,7 +86,10 @@ body:
     id: tracking
     attributes:
       label: Tracking issue
-      description: Parent tracking issue if applicable
+      description: >-
+        Parent tracking issue if applicable. After creation, attach this issue
+        through GitHub's native Sub-issues panel rather than a Markdown
+        checklist.
       placeholder: "e.g., #190"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/tracking-issue.yml
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.yml
@@ -53,20 +53,18 @@ body:
   - type: textarea
     id: tasks
     attributes:
-      label: Sub-issues
+      label: Initial sub-issue references
       description: |
-        List issue numbers that should be attached in GitHub's native
-        Sub-issues panel after this issue is created. Each line should contain
-        only an issue reference. Put mathematical descriptions in the
-        sub-issue titles and bodies.
-      value: |
-        #42
-        #43
+        Optional: list existing issue numbers that should be attached using
+        GitHub's native Sub-issues panel after this issue is created. This
+        field is not the authoritative child-issue list; it is only a reminder
+        for the initial attachment step. Put mathematical descriptions in the
+        child issue titles and bodies.
       placeholder: |
         #42
         #43
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: notes


### PR DESCRIPTION
### Motivation
- Issue #1003 asks for consistent issue conventions and for tracking work to use GitHub's native Sub-issues relation rather than Markdown task lists.
- The tracking-issue template still made a sub-issue reference textarea required and pre-filled it with placeholder issue numbers, which could be mistaken for the authoritative child-issue list.

### Description
- Makes the tracking template's sub-issue reference field optional and explicitly describes it as only an initial attachment reminder.
- Removes the default `#42` / `#43` values from the tracking template.
- Updates the formalization-task template to say that parent tracking issues should be connected through GitHub's native Sub-issues panel, not a Markdown checklist.
- As a related metadata cleanup for #1003, I also renamed an initial group of open issues with vague or nonconforming titles and recorded the list in #1003.

### Testing
- `git diff --check -- .github/ISSUE_TEMPLATE/tracking-issue.yml .github/ISSUE_TEMPLATE/formalization-task.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/tracking-issue.yml .github/ISSUE_TEMPLATE/formalization-task.yml`

Addresses #1003

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes to GitHub issue templates, with no impact on runtime code or data handling.
> 
> **Overview**
> Updates the GitHub issue templates to **standardize on GitHub’s native Sub-issues** workflow instead of Markdown checklists.
> 
> The `tracking-issue` template makes the sub-issue reference field optional, removes any implied authoritative child list, and drops prefilled example issue numbers. The `formalization-task` template clarifies that parent tracking issues should be connected via the Sub-issues panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c48a9a5ccfaca56c9be495c1af5e0d2afabd570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->