### PR TITLE
doc(MPS/FT): anchor power-sum citation

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
@@ -230,8 +230,9 @@ $\mu_{j,q}$.  The per-block witness is implicit in CPSV16 §II.C line 1182's
 projection step and is
 therefore exposed here as a per-theorem hypothesis.
 
-Paper anchor: CPSV16 §II.C lines 1158–1167 (power-sum non-decay / exact
-comparison input), CPSV16 §II.C line 1182 (per-block projection step). -/
+Paper anchor: CPSV16 §II.C Lemma `Lem:app_simple`, lines 1155--1163
+(finite power-sum comparison), and CPSV16 §II.C line 1182 (per-block
+projection step). -/
 theorem coeff_not_tendsto_zero_at_block
     (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
     (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1) :

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -997,7 +997,8 @@ form: two injective embeddings, one in each direction, with codomains
 in the full basis of $P$ and $Q$ respectively. Upgrading the codomains to
 the unit-modulus subsets (and packaging as a bijection) requires the
 additional per-sector weight-equivariance argument of
-\cite[\S~II.C, lines 1148--1167]{Cirac2017MPDO_AnnPhys} combined with the
+\cite[Lemma~\texttt{Lem:app\_simple}, lines~1155--1163]{Cirac2017MPDO_AnnPhys}
+combined with the
 gauge-phase identity on the weighted sectors
 $\sum_q \mu_{j,q}^N \ket{V^{(N)}(P_j)}$; the non-decay output of the
 strong existential theorem is on the basis MPV states, not on the


### PR DESCRIPTION
This PR tightens one remaining CPSV16 power-sum source citation in the BNT Fundamental-Theorem path.

Changes:
- retargets `coeff_not_tendsto_zero_at_block` in `SectorBNT/Api.lean` from the broad range 1158--1167 to CPSV16 Lemma `Lem:app_simple`, lines 1155--1163;
- makes the analogous Chapter 10 blueprint scope note cite `Lem:app_simple`, lines 1155--1163, rather than the broad 1148--1167 range.

This is a citation/prose cleanup only. No declarations, theorem statements, or proofs are changed.

Validation:
- `git diff --check -- TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean blueprint/src/chapter/ch10_bnt.tex`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean`
- `cd blueprint && leanblueprint web`

Refs #1685. Refs #1749. Refs #1565.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/comment-only citation retargeting with no changes to Lean statements, proofs, or behavior.
> 
> **Overview**
> Retargets the CPSV16 source anchor for the power-sum non-decay step to the specific finite power-sum comparison lemma (`Lem:app_simple`, lines 1155–1163) instead of a broader line range.
> 
> This update is applied consistently in both the Lean docstring for `coeff_not_tendsto_zero_at_block` (`SectorBNT/Api.lean`) and the Chapter 10 blueprint scope note (`ch10_bnt.tex`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75468c8047ba0d3c3f12fe1aca1e5768291de208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->