### PR TITLE
doc(blueprint): clarify FT-adjacent chapter placement

### DIFF
--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -75,7 +75,9 @@ as explicit hypotheses until the corresponding source steps are supplied.
 The chapters after Chapter~\ref{ch:ft_proof} collect applications,
 alternative formulations, and later tensor-network material.
 Chapter~\ref{ch:symmetry} uses the Fundamental Theorem to obtain virtual
-symmetry gauges, projective bond representations, and string-order criteria.
+symmetry gauges, projective bond representations, and string-order criteria;
+its Kraus-mixing step appeals only to the later channel-representation chapter,
+not to any additional input for the Fundamental Theorem.
 Chapter~\ref{ch:periodic_ft_apps} develops the direct periodic theorem in
 irreducible form, together with the compatibility theorems for physical-index
 rotation (Definition~\ref{def:rotate_physical} in Chapter~\ref{ch:symmetry}).

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -57,7 +57,7 @@ $B^i = X A^i X^{-1}$ for all physical indices $i$.
 Chapters~\ref{ch:mps}--\ref{ch:ft_proof} contain the aperiodic proof route.
 Chapter~\ref{ch:mps} fixes the matrix product vector notation, word
 evaluations, transfer maps, gauge equivalence, injectivity, blocking, and
-periodic-chain tensor families. Chapter~\ref{ch:single} proves the
+site-periodic tensor families. Chapter~\ref{ch:single} proves the
 single-block theorem by trace pairings, linear extension, simplicity of matrix
 algebras, and Skolem--Noether. Chapters~\ref{ch:channels}, \ref{ch:schwarz},
 \ref{ch:qpf}, and~\ref{ch:spectral} develop the positive-map,
@@ -65,10 +65,12 @@ multiplicative-domain, Perron--Frobenius, and overlap-decay tools used to
 control normal blocks. Chapters~\ref{ch:wielandt} and~\ref{ch:canonical}
 supply the blocking, primitivity, irreducibility, and canonical-form reductions.
 Chapters~\ref{ch:block_perm} and~\ref{ch:bnt} isolate block permutation, block
-separation, bases of normal tensors, and the power-sum comparison.
-Chapter~\ref{ch:ft_proof} records the conditional non-periodic theorem
-statements; the remaining BNT matching and fixed-length span inputs are kept as
-explicit hypotheses until the corresponding source steps are supplied.
+separation, bases of normal tensors, and the power-sum comparison. The
+after-blocking reductions of Chapter~\ref{ch:canonical_after_blocking} give
+the common primitive block decompositions used immediately in
+Chapter~\ref{ch:ft_proof}, which records the conditional non-periodic theorem
+statements. The remaining BNT matching and fixed-length span inputs are kept
+as explicit hypotheses until the corresponding source steps are supplied.
 
 The chapters after Chapter~\ref{ch:ft_proof} collect applications,
 alternative formulations, and later tensor-network material.
@@ -82,7 +84,8 @@ rotation (Definition~\ref{def:rotate_physical} in Chapter~\ref{ch:symmetry}).
 % algebraic-FT chapter.
 Chapter~\ref{ch:algebraic_ft}
 gives the fixed-length algebraic Fundamental Theorem of~\cite{Molnar2018NormalPEPS},
-and Chapter~\ref{ch:peps_ft} records the PEPS analogs. The later chapters
-cover dynamical semigroups, entropy, matrix product density operators, parent
-Hamiltonians, correlations, and examples; these topics use the aperiodic theorem
-rather than enter its proof.
+and Chapter~\ref{ch:peps_ft} records the PEPS analogs. Channel representations
+and normal forms, quantum dynamical semigroups, entropy, matrix product density
+operators, parent Hamiltonians, correlations, and examples are treated
+afterwards; these topics use the aperiodic theorem, or develop later
+finite-dimensional channel theory, rather than enter its proof.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -116,13 +116,13 @@ boundary conditions (PBC).
     framework appears in Chapter~\ref{ch:channels}.
 \end{remark}
 
-\section{Site-dependent periodic chains}
+\section{Site-periodic tensor families}
 
-\begin{definition}[Periodic-chain tensor family]\label{def:periodic_mps_tensor}
+\begin{definition}[Site-periodic tensor family]\label{def:periodic_mps_tensor}
     \lean{MPSTensor.PeriodicMPSTensor}
     \leanok
-    For a fixed period $m$, a \emph{periodic-chain tensor family} is a
-    site-dependent family of local tensors indexed by $\{0,\ldots,m{-}1\}$, with
+    For a fixed period $m$, a \emph{site-periodic tensor family} is a
+    family of local tensors indexed by $\{0,\ldots,m{-}1\}$, with
     local physical dimension~$d$ and bond dimension~$D$.
 \end{definition}
 
@@ -131,9 +131,9 @@ boundary conditions (PBC).
     \lean{MPSTensor.PeriodicMPSTensor.GaugeEquiv}
     \leanok
     \uses{def:periodic_mps_tensor}
-    For periodic-chain tensors $A,B$ at fixed period~$m$:
+    For site-periodic tensors $A,B$ at fixed period~$m$:
     \begin{itemize}
-        \item equality of the induced periodic-chain states;
+        \item equality of the induced site-periodic states;
         \item cyclic gauge equivalence.
     \end{itemize}
 \end{definition}

--- a/blueprint/src/chapter/ch04a_channel_representations.tex
+++ b/blueprint/src/chapter/ch04a_channel_representations.tex
@@ -5,9 +5,8 @@ channels from \cite[Chapter~2]{Wolf2012Quantum}: the Choi--Jamio\l{}kowski
 isomorphism, Kraus representation theorems, Stinespring and Naimark dilations,
 ordered completely positive maps, Radon--Nikodym and open-system
 representations, trace-pairing expansions, SVD and Lorentz normal forms, and the
-channel determinant. These results are important for the channel theory
-developed in the following chapters, but they are not prerequisites for the
-matrix-product-state Fundamental Theorem.
+channel determinant. These results are important for the later channel theory,
+but they are not prerequisites for the matrix-product-state Fundamental Theorem.
 
 %% =========================================================
 \section{Representations}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -11,11 +11,11 @@
 \input{chapter/ch10_bnt}
 \input{chapter/ch11b_after_blocking}
 \input{chapter/ch11_fundamental_theorem_proof}
-\input{chapter/ch04a_channel_representations}
 \input{chapter/ch13b_symmetry}
 \input{chapter/ch11b_periodic_ft}
 \input{chapter/ch13_algebraic_ft}
 \input{chapter/ch13a_peps_ft}
+\input{chapter/ch04a_channel_representations}
 \input{chapter/ch12_semigroup}
 \input{chapter/ch17_operator_convexity}
 \input{chapter/ch04b_entropy}


### PR DESCRIPTION
## Mathematical purpose

This PR clarifies which blueprint chapters belong to the aperiodic Fundamental Theorem route and which belong to later channel-theoretic material.

It addresses item 1 of #1530 and the unambiguous part of #1893.

## Changes

- Rename the Chapter 2 section and definition from periodic-chain wording to `Site-periodic tensor families`.
- Update the introduction to say explicitly that `Canonical-form reductions after blocking` supplies the common primitive block decompositions used immediately in the proof chapter.
- Move `Channel Representations and Normal Forms` from immediately after the proof chapter to the later channel-theory block, just before quantum dynamical semigroups.
- Adjust the representation-chapter opening paragraph so it says these results belong to later channel theory and are not prerequisites for the MPS Fundamental Theorem.

The auxiliary direct-sum reductions remain inside the proof chapter, and the after-blocking chapter remains immediately before it. The local chapter prose says these are part of the proof route rather than later applications.

## Validation

- `git diff --check -- blueprint/src/content.tex blueprint/src/chapter/ch01_intro.tex blueprint/src/chapter/ch02_mps.tex blueprint/src/chapter/ch04a_channel_representations.tex`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch01_intro.tex blueprint/src/chapter/ch02_mps.tex blueprint/src/chapter/ch04a_channel_representations.tex`
- `cd blueprint && leanblueprint web`

Also ran `python3 scripts/blueprint_lean_sync.py --root . --ci`; it reports pre-existing missing Lean references in `blueprint/src/chapter/ch14_parent_hamiltonian.tex`, unrelated to these edited files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only LaTeX edits that rename terminology and reorder chapter inclusion, with no mathematical content or code logic changes.
> 
> **Overview**
> **Clarifies the aperiodic Fundamental Theorem proof route vs later channel-theory material.** The intro text is updated to explicitly place the `canonical_after_blocking` reductions as immediate prerequisites for `ch:ft_proof`, and to note `ch:symmetry`’s dependency on the later channel-representation chapter.
> 
> Terminology is standardized by renaming Chapter 2’s “periodic-chain” section/definition language to **“site-periodic tensor families.”**
> 
> The book build order in `content.tex` is adjusted to move `ch04a_channel_representations` out of the proof-route block to later (just before semigroups), and its opening paragraph is tweaked to state it supports later channel theory and is not a prerequisite for the MPS Fundamental Theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74b6f80f66f01417e4e2d2a957a5321af6c279b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->