### PR TITLE
doc(MPS/RFP): anchor convergence sources

### DIFF
--- a/TNLean/MPS/RFP/Convergence.lean
+++ b/TNLean/MPS/RFP/Convergence.lean
@@ -13,8 +13,9 @@ import TNLean.MPS.RFP.Defs
 
 This file proves the convergence result for the renormalization-group (RG) flow
 applied to MPS tensors in canonical form. The proof follows the spectral-gap
-argument from CPGSV21, Section 2.3 and Appendix B of arXiv:1606.00608
-(Cirac–Pérez-García–Schuch–Verstraete).
+argument from arXiv:1606.00608, Appendix B, lines 1211--1244; see also the
+transfer-matrix and RGFP discussion in arXiv:2011.12127, lines 433--442 and
+870--892.
 
 For a CF tensor, the transfer matrix decomposes as
 `E' = ⊕_{j,j'} μ_{j,q} μ'_{j',q'} E_{j,j'}`.
@@ -34,12 +35,14 @@ converges to an idempotent (the RFP).
 * [CPGSV21] Cirac, Pérez-García, Schuch, Verstraete,
   *Matrix Product States and Projected Entangled Pair States*,
   Rev. Mod. Phys. 93 (2021), arXiv:2011.12127.
-  Sec. 2.3 (correlations and transfer matrix).
+  Lines 433--442 (transfer matrix and correlations) and lines 870--892
+  (renormalization fixed points for MPS).
   Source: `Papers/2011.12127/`
-* [CPSV17] Cirac, Pérez-García, Schuch, Verstraete,
+* [CPSV16] Cirac, Pérez-García, Schuch, Verstraete,
   *Matrix Product Density Operators: Renormalization Fixed Points
   and Boundary Theories*, arXiv:1606.00608.
-  Appendix B (RFP as idempotent limit).
+  Appendix B, lines 1211--1244 (RFP as idempotent limit for canonical-form
+  tensors) and lines 1264--1268 (use of `Lem:app_simple`).
   Source: `Papers/1606.00608/`
 -/
 
@@ -49,8 +52,9 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- **Appendix B** (arXiv:1606.00608): For a tensor in canonical form, the
-iterated blocking `E^{2^n}` converges to an idempotent transfer map.
+/-- **Appendix B** (arXiv:1606.00608, lines 1211--1244): For a tensor in
+canonical form, the iterated blocking `E^{2^n}` converges to an idempotent
+transfer map.
 
 The convergence is entry-wise on the `D² × D²` transfer matrix space:
 `∀ ρ, (E^{2^n}) ρ → E_∞ ρ` where `E_∞ ∘ E_∞ = E_∞`.

--- a/TNLean/MPS/RFP/Convergence.lean
+++ b/TNLean/MPS/RFP/Convergence.lean
@@ -42,7 +42,7 @@ converges to an idempotent (the RFP).
   *Matrix Product Density Operators: Renormalization Fixed Points
   and Boundary Theories*, arXiv:1606.00608.
   Appendix B, lines 1211--1244 (RFP as idempotent limit for canonical-form
-  tensors) and lines 1264--1268 (use of `Lem:app_simple`).
+  tensors) and lines 1264--1268 (finite power-sum nonvanishing estimate).
   Source: `Papers/1606.00608/`
 -/
 


### PR DESCRIPTION
This PR tightens the source references for the RFP convergence scaffold.

It replaces the broad CPSV/RMP prose in `TNLean/MPS/RFP/Convergence.lean` with exact anchors:

- arXiv:1606.00608 Appendix B, lines 1211--1244, for the canonical-form transfer-matrix decomposition and convergence to the idempotent limit;
- arXiv:1606.00608, lines 1264--1268, for the use of `Lem:app_simple`;
- arXiv:2011.12127, lines 433--442, for the transfer-matrix/correlation discussion;
- arXiv:2011.12127, lines 870--892, for the renormalization fixed-point discussion.

It also changes the live shorthand `[CPSV17]` to `[CPSV16]`, since the cited source is arXiv:1606.00608.

Refs #1685 and #1565.

Validation:

- `git diff --check -- TNLean/MPS/RFP/Convergence.lean`
- `lake env lean TNLean/MPS/RFP/Convergence.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that tightens citations and labels; no proof code or behavior is modified.
> 
> **Overview**
> Updates `TNLean/MPS/RFP/Convergence.lean` documentation to **pin the RG-flow convergence proof to exact source anchors**, adding specific line ranges for arXiv:1606.00608 (Appendix B) and arXiv:2011.12127 (transfer matrix/RGFP discussion).
> 
> Also corrects the reference label from `[CPSV17]` to `[CPSV16]` to match the cited arXiv:1606.00608 paper and refines the theorem docstring to include the precise Appendix B line range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7197d7a7bcb75d00521394aa97853b433f634f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->