### PR TITLE
doc(audits): record historical title cleanup

### DIFF
--- a/audits/2026-04-29_issue1003_title_scan.md
+++ b/audits/2026-04-29_issue1003_title_scan.md
@@ -3,6 +3,50 @@
 This scan records repository titles that still visibly differ from the naming
 conventions in `docs/CONTRIBUTING.md`.
 
+## Status after 2026-05-20 cleanup
+
+The 2026-04-29 scan below is preserved as the original audit record. On
+2026-05-20, a historical metadata cleanup renamed 194 issue and pull-request
+titles from that audit family:
+
+- old issue titles beginning with `formalization(...)`, `infrastructure(...)`,
+  `cleanup(...)`, `refactor:`, or bracketed source tags were rewritten as plain
+  mathematical issue titles;
+- old pull-request titles beginning with `feat: formalization(...)`,
+  `cleanup(...)`, bracketed agent tags, or bare `ci:` / `chore:` / `style:`
+  prefixes were rewritten into the current `type(scope): description` form;
+- old daily-record titles using the long dash separator were rewritten as
+  `Daily Standup -- YYYY-MM-DD`.
+
+The final scan was:
+
+```bash
+gh issue list --state all --limit 1000 --json number,title,state,url \
+  > /tmp/tnlean_issues_after2.json
+jq -r '.[] | select(.title|test("^(formalization|infrastructure|feat|fix|doc|style|ci|chore|refactor|cleanup)\\(|^(feat|fix|doc|style|ci|chore|refactor):|^\\[|—|=>")) | "#\(.number) [\(.state)] \(.title)"' \
+  /tmp/tnlean_issues_after2.json
+
+gh pr list --state all --limit 1000 --json number,title,state,url \
+  > /tmp/tnlean_prs_after2.json
+jq -r '.[] | select(.title|test("formalization\\(|^\\[|^(feat|fix|doc|style|ci|chore|refactor): |^cleanup\\(|^Unconditionalize|^Fix Docs|=>")) | "#\(.number) [\(.state)] \(.title)"' \
+  /tmp/tnlean_prs_after2.json
+```
+
+The pull-request scan returned no hits. The issue scan returned only
+GitHub Agentic Workflows records:
+
+- #1810 `[aw] Docs & Blueprint Sync failed`;
+- #1394 `[aw] Docs & Blueprint Sync failed`;
+- #1208 `[aw] No-Op Runs`;
+- #1116 `[aw] Docs & Blueprint Sync failed`;
+- #1076 `[aw] Docs & Blueprint Sync failed`;
+- #1059 `[aw] Docs & Blueprint Sync failed`.
+
+These `[aw]` issues are generated and managed by GitHub Agentic Workflows.
+The live record #1208 explicitly says not to assign or close it, so the
+bracketed workflow marker is treated as an external-system exception rather
+than a TNLean naming-convention violation.
+
 Commands used on 2026-04-29:
 
 ```bash


### PR DESCRIPTION
## Purpose

This PR records the completion evidence for #1003 after the historical GitHub-title metadata cleanup.

## Metadata cleanup already applied

Using the GitHub issue API, this pass renamed 194 historical issue and pull-request titles from the #1003 audit family:

- issue titles with old `formalization(...)`, `infrastructure(...)`, `cleanup(...)`, bracketed source tags, or old daily-record separators;
- pull-request titles with old `feat: formalization(...)`, `cleanup(...)`, bracketed agent tags, or bare `ci:` / `chore:` / `style:` prefixes.

## Audit update

The audit file now records the 2026-05-20 status and the final scan commands. The pull-request scan returns no hits. The issue scan returns only GitHub Agentic Workflows `[aw]` records, including #1208, whose body explicitly says not to assign or close it; those are recorded as external-system exceptions.

## Validation

- `git diff --check -- audits/2026-04-29_issue1003_title_scan.md`
- fresh GitHub issue-title scan for old issue forms
- fresh GitHub PR-title scan for old PR forms

Closes #1003.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only update to an audit record; no code or automation behavior changes.
> 
> **Overview**
> Updates the `audits/2026-04-29_issue1003_title_scan.md` audit record with a new **post-2026-05-20 cleanup** status section, documenting that 194 historical GitHub issue/PR titles were renamed to match current conventions.
> 
> Records the final `gh`/`jq` scan commands and outcomes (no PR title violations; remaining issue hits are `[aw]` GitHub Agentic Workflows exceptions), while preserving the original 2026-04-29 scan content below.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a0ec0e73ac81c4ef102f6b27d16236e8694b08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->