### PR TITLE
doc(MPS/Structure): clarify PGVWC projection input

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -77,7 +77,7 @@ step in the canonical-form existence argument: it upgrades the cumulative word
 span to single-site injectivity, which then yields block injectivity at every
 positive length.
 
-The formal Lean declaration:
+The formal statement:
 
 > `Wielandt.Primitivity.StronglyIrreducibleToFullRank` proves the implication
 > `IsStronglyIrreduciblePaper A → krausRank A = D` (equivalently,
@@ -96,11 +96,11 @@ This external input provides:
 > `(1-P) A_i P = 0` for all `i`) yields an MPV-equivalent two-block direct-sum
 > tensor with strictly smaller block dimensions.
 
-The formal Lean declaration:
+The formal statement:
 
 > `MPSTensor.exists_twoBlock_decomp_of_lowerZero` produces a two-block
 > block-diagonal tensor MPV-equivalent to the original, with a strict dimension
-> decrease (`exists_strict_twoBlock_decomp_of_lowerZero`).
+> decrease (`exists_twoBlock_decomp_of_lowerZero_strict`).
 
 ## External input — Wolf spectral theory: Perron-Frobenius fixed point
 

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -21,14 +21,18 @@ arguments before blocking/normalization.
 
 ## External input — Perez-Garcia et al. canonical-form recursion
 
-This file formalizes the invariant-subspace decomposition from two sources:
+This file formalizes the direct-sum decomposition step once an invariant
+projection has already been obtained.  For PGVWC07 this is deliberately the
+second part of the argument, not a replacement for the positive fixed-point
+argument that produces the projection:
 
 > **Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
 > proof lines 771–815.**
-> The recursion on bond dimension: a singular positive fixed point of the transfer
-> map yields an invariant support projection in lines 771–783; after the finite-ring
-> trace split of lines 785–815, the tensor is replaced by a direct sum of smaller
-> blocks.  The strict dimension decrease
+> The source first derives the invariant support projection from a singular
+> positive fixed point in lines 771–783.  The declarations below take such an
+> invariant projection as an input and formalize the finite-ring trace split of
+> lines 785–815, where the tensor is replaced by a direct sum of smaller blocks.
+> The strict dimension decrease
 > (`exists_strict_twoBlock_decomp_of_lowerZero`) guarantees termination of the
 > canonical-form recursion.
 

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -29,11 +29,11 @@ argument that produces the projection:
 > **Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
 > proof lines 771–815.**
 > The source first derives the invariant support projection from a singular
-> positive fixed point in lines 771–783.  The declarations below take such an
+> positive fixed point in lines 771–783.  The results below take such an
 > invariant projection as an input and formalize the finite-ring trace split of
 > lines 785–815, where the tensor is replaced by a direct sum of smaller blocks.
 > The strict dimension decrease
-> (`exists_strict_twoBlock_decomp_of_lowerZero`) guarantees termination of the
+> (`exists_twoBlock_decomp_of_lowerZero_strict`) guarantees termination of the
 > canonical-form recursion.
 
 > **Cirac et al., arXiv:1606.00608, Section 2.3.**
@@ -41,11 +41,11 @@ argument that produces the projection:
 > block upper-triangular ⇒ drop strict off-diagonal blocks ⇒ explicit 2-block
 > direct sum.  This is the Wolf/Cirac/Verstraete canonical-form reduction.
 
-The formal Lean declarations:
+The formal statements:
 
 * `exists_twoBlock_decomp_of_lowerZero` — invariant projection ⇒ two-block direct sum
   with MPV equivalence (`SameMPV₂`)
-* `exists_strict_twoBlock_decomp_of_lowerZero` — the strict dimension decrease variant
+* `exists_twoBlock_decomp_of_lowerZero_strict` — the strict dimension decrease variant
   (both block dimensions strictly smaller than `D`), which is the key ingredient for
   proving termination of the canonical-form recursion
 -/


### PR DESCRIPTION
This PR tightens the source boundary in `TNLean/MPS/Structure/InvariantSubspaceDecomp.lean` for the PGVWC07 canonical-form proof.

The module docstring now says explicitly that the formal declarations begin after the source proof has derived the invariant support projection from a singular positive fixed point. In PGVWC07 Theorem `Th:TIcanonical`, `Papers/quant-ph_0608197/MPSarchive.tex` lines 771--783 produce that projection; the declarations in this file take an invariant projection as input and formalize the finite-ring trace split at lines 785--815.

This is a documentation-only correction. It preserves the guardrail that the full canonical-form existence theorem must follow the original proof order rather than replacing lines 771--783 by an abstract block-splitting hypothesis.

Refs #1857 and #1685.

Validation:

- `git diff --check -- TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`
- `lake env lean TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits; no changes to definitions or proofs, so functional risk is minimal aside from potential confusion if references are incorrect.
> 
> **Overview**
> Clarifies module-level documentation around the Perez-Garcia et al. (PGVWC07) canonical-form recursion to explicitly state that `InvariantSubspaceDecomp.lean` assumes an already-derived invariant projection and only formalizes the subsequent finite-ring trace split/decomposition step.
> 
> Updates doc wording from “formal declaration(s)” to “formal statement(s)” and fixes the referenced strict-dimension-decrease lemma name to `exists_twoBlock_decomp_of_lowerZero_strict` in both `CanonicalForm/Existence.lean` and `Structure/InvariantSubspaceDecomp.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49fa89138291f816cd7c48ca167426a41560d6bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->