### PR TITLE
doc(blueprint): clarify equal-case power-sum prose

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -995,10 +995,10 @@ forms. The theorem below delivers the symmetric injective matching
 (the source's $g_a \ge g_b \wedge g_b \ge g_a$ step) in the following
 form: two injective embeddings, one in each direction, with codomains
 in the full basis of $P$ and $Q$ respectively. Upgrading the codomains to
-the unit-modulus subsets (and packaging as a bijection) requires the
-additional per-sector weight-equivariance argument of
-\cite[Lemma~\texttt{Lem:app\_simple}, lines~1155--1163]{Cirac2017MPDO_AnnPhys}
-combined with the
+the unit-modulus subsets, and then obtaining a bijection between those subsets,
+requires the additional per-sector weight-equivariance argument supplied by the
+appendix power-sum lemma
+\cite[lines~1155--1163]{Cirac2017MPDO_AnnPhys} combined with the
 gauge-phase identity on the weighted sectors
 $\sum_q \mu_{j,q}^N \ket{V^{(N)}(P_j)}$; the non-decay output of the
 strong existential theorem is on the basis MPV states, not on the

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -894,10 +894,13 @@ facts used to recover the lists of weights from those power sums.
         B_j^i=e^{i\phi_j}Y_jA_j^iY_j^{-1}.
     \]
     Only after this representative matching does the equal case compare the scalar
-    coefficient power sums: for each matched block $j$ and every positive length
-    $N$, the sum of the $N$th powers of the $A$-copy weights equals the
-    corresponding sum of the $B$-copy weights after multiplication by
-    $e^{i\phi_j}$.
+    coefficient power sums. For each matched block $j$ and every positive length
+    $N$,
+    \[
+        \sum_{q=1}^{r^A_j}(\mu^A_{j,q})^N
+        =
+        \sum_{q=1}^{r^B_j}(\mu^B_{j,q}e^{i\phi_j})^N .
+    \]
     Newton--Girard then recovers the multiplicities and weight multisets, and the
     block gauges $Y_j$ are placed on the diagonal to give the global conjugating
     matrix. This is the equal-case corollary

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -34,7 +34,7 @@ with an extra $Z$-gauge degree of freedom.
 % BNT canonical-form statements, see Chapter~\ref{ch:bnt}.
 % Lean targets: \texttt{MPSTensor.ft\_sector\_bnt\_equal\_sector\_data},
 % \texttt{MPSTensor.ft\_sector\_bnt\_equal\_global\_gauge}.
-% The literal $\mathrm{II\_cor2}$ coordinate packaging (CPSV16 lines 1184--1192)
+% The literal $\mathrm{II\_cor2}$ coordinate form (CPSV16 lines 1184--1192)
 % is recorded in Chapter~\ref{ch:bnt} for the unit-modulus BNT normalization.
 
 \section{Source theorems}\label{sec:ft_source_theorems}
@@ -159,7 +159,7 @@ sums.
 The block-matching conclusion (block-count, bond-dimension, and
 gauge-phase identification of corresponding sectors) and the global
 gauge identification are formalised on the BNT canonical form of
-Chapter~\ref{ch:bnt}. The literal coordinate packaging of
+Chapter~\ref{ch:bnt}. The literal coordinate form of
 \cite[Corollary~II.2 and \S~II.C, lines 1184--1192]
     {Cirac2017MPDO_AnnPhys}
 is recorded there under the unit-modulus-copy normalization.
@@ -894,12 +894,10 @@ facts used to recover the lists of weights from those power sums.
         B_j^i=e^{i\phi_j}Y_jA_j^iY_j^{-1}.
     \]
     Only after this representative matching does the equal case compare the scalar
-    coefficient power sums, for $j=1,\ldots,g$ and $N\ge 1$:
-    \[
-        \sum_{q=1}^{r^A_j}(\mu^A_{j,q})^N
-        =
-        \sum_{q=1}^{r^B_j}(\mu^B_{j,q}e^{i\phi_j})^N.
-    \]
+    coefficient power sums: for each matched block $j$ and every positive length
+    $N$, the sum of the $N$th powers of the $A$-copy weights equals the
+    corresponding sum of the $B$-copy weights after multiplication by
+    $e^{i\phi_j}$.
     Newton--Girard then recovers the multiplicities and weight multisets, and the
     block gauges $Y_j$ are placed on the diagonal to give the global conjugating
     matrix. This is the equal-case corollary
@@ -907,10 +905,10 @@ facts used to recover the lists of weights from those power sums.
     restated in \cite[Corollary~IV.5]{Cirac2021Matrix}.
 
     The formalization of this route is split into two theorems. The first
-    packages the BNT basis bijection $\beta$, the per-block gauge-phase
+    gives the BNT basis bijection $\beta$, the per-block gauge-phase
     witnesses, copy-count equality, and the scalar coefficient comparison
-    $\nu_{k,q} = \zeta_k^{-1} \mu_{\beta(k),\tau(q)}$
-    matching the source power-sum identity displayed above. The second
+    $\nu_{k,q} = \zeta_k^{-1} \mu_{\beta(k),\tau(q)}$ that follows from the
+    source power-sum comparison. The second
     assembles the per-block gauge matrices $Y_j = X_k$ on the flattened
     direct sum to produce the global conjugation $X$, matching the appendix
     construction at \cite[lines 1189--1192]{Cirac2017MPDO_AnnPhys}.

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -894,13 +894,10 @@ facts used to recover the lists of weights from those power sums.
         B_j^i=e^{i\phi_j}Y_jA_j^iY_j^{-1}.
     \]
     Only after this representative matching does the equal case compare the scalar
-    coefficient power sums. For each matched block $j$ and every positive length
-    $N$,
-    \[
-        \sum_{q=1}^{r^A_j}(\mu^A_{j,q})^N
-        =
-        \sum_{q=1}^{r^B_j}(\mu^B_{j,q}e^{i\phi_j})^N .
-    \]
+    coefficient power sums: for each matched block $j$ and every positive length
+    $N$, the sum of the $N$th powers of the $A$-copy weights equals the
+    corresponding sum of the $B$-copy weights after multiplication by
+    $e^{i\phi_j}$.
     Newton--Girard then recovers the multiplicities and weight multisets, and the
     block gauges $Y_j$ are placed on the diagonal to give the global conjugating
     matrix. This is the equal-case corollary

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -894,10 +894,9 @@ facts used to recover the lists of weights from those power sums.
         B_j^i=e^{i\phi_j}Y_jA_j^iY_j^{-1}.
     \]
     Only after this representative matching does the equal case compare the scalar
-    coefficient power sums: for each matched block $j$ and every positive length
-    $N$, the sum of the $N$th powers of the $A$-copy weights equals the
-    corresponding sum of the $B$-copy weights after multiplication by
-    $e^{i\phi_j}$.
+    coefficient power sums: for each $j=1,\ldots,g$ and $N\ge 1$, the sums
+    $\sum_{q=1}^{r^A_j}(\mu^A_{j,q})^N$ and
+    $\sum_{q=1}^{r^B_j}(\mu^B_{j,q}e^{i\phi_j})^N$ are equal.
     Newton--Girard then recovers the multiplicities and weight multisets, and the
     block gauges $Y_j$ are placed on the diagonal to give the global conjugating
     matrix. This is the equal-case corollary


### PR DESCRIPTION
This PR addresses a remaining concrete prose item from #1530 around the equal-case comparison remarks.

Changes:

- In `ch11_fundamental_theorem_proof.tex`, the equal-case remark no longer displays the scalar copy-weight power-sum comparison as a standalone equation. It describes the comparison in prose after the BNT representative matching step, matching the source proof order.
- The same remark now says the first formal theorem gives the BNT bijection, gauge-phase witnesses, copy-count equality, and coefficient comparison, rather than using process-flavored wording.
- In `ch10_bnt.tex`, the strong matching scope paragraph describes the appendix power-sum lemma mathematically and removes the remaining packaging-as-a-bijection phrasing.

No Lean files, theorem statements, or blueprint tags are changed.

Refs #1530.

Validation:

- `git diff --check origin/main...HEAD`
- `cd blueprint && leanblueprint web`

Note: `python3 scripts/blueprint_lean_sync.py --root . --ci` still reports pre-existing missing Lean references in `ch14_parent_hamiltonian.tex`; this PR does not touch that chapter or those tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits in LaTeX sources; no changes to Lean code, theorem statements, or tagged references, so risk is limited to wording/clarity regressions.
> 
> **Overview**
> Clarifies blueprint prose around the equal-MPV corollary to better match the source proof order: BNT representative matching is stated as preceding (and motivating) the scalar power-sum comparison, which is now described inline rather than displayed as a standalone equation.
> 
> Tightens wording in `ch10_bnt.tex` and `ch11_fundamental_theorem_proof.tex` about what is delivered (injective embeddings vs. unit-modulus-subset bijections) and explicitly attributes the needed upgrade step to the appendix power-sum lemma plus gauge-phase identities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d8cec829faf9b59ea15df49ed9063893db2fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->