### PR TITLE
doc(blueprint): clarify FT placement boundary

### DIFF
--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -69,8 +69,12 @@ separation, bases of normal tensors, and the power-sum comparison. The
 after-blocking reductions of Chapter~\ref{ch:canonical_after_blocking} give
 the common primitive block decompositions used immediately in
 Chapter~\ref{ch:ft_proof}, which records the conditional non-periodic theorem
-statements. The remaining BNT matching and fixed-length span inputs are kept
-as explicit hypotheses until the corresponding source steps are supplied.
+statements. The auxiliary direct-sum reductions used after the block
+correspondence has been fixed are also kept in the proof chapter, rather than
+in the canonical-form chapters, because they assemble single-block conclusions
+into block-diagonal gauge statements. The remaining BNT matching and
+fixed-length span inputs are kept as explicit hypotheses until the
+corresponding source steps are supplied.
 
 The chapters after Chapter~\ref{ch:ft_proof} collect applications,
 alternative formulations, and later tensor-network material.

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -19,7 +19,11 @@ chapter because they produce the common primitive block decompositions used in
 the equal-MPV comparison. The auxiliary direct-sum reductions remain in
 Section~\ref{sec:ft_auxiliary_from_ch08}, inside the proof chapter, because
 they turn the single-block Fundamental Theorem into the block-diagonal
-gauge statements used after the block correspondence has been fixed.
+gauge statements used after the block correspondence has been fixed. Thus the
+chapter boundary separates the preparation of the common blocked surface from
+the later assembly of gauges and MPV equalities; it does not place any
+channel-representation or semigroup material among the hypotheses of the
+aperiodic Fundamental Theorem.
 
 The theorems in this chapter follow the approach of
 \cite{Cirac2017MPDO_AnnPhys}:


### PR DESCRIPTION
This PR addresses #1900 by making the current chapter placement explicit in the compiled blueprint prose.

Changes:

- In `ch01_intro.tex`, the aperiodic proof-route paragraph now states that the auxiliary direct-sum reductions live in the Fundamental-Theorem proof chapter, rather than in the canonical-form chapters, because they assemble single-block conclusions into block-diagonal gauge statements after the block correspondence has been fixed.
- In `ch11_fundamental_theorem_proof.tex`, the chapter opening now separates the preparation of the common blocked surface from the later assembly of gauges and MPV equalities, and states that channel-representation and semigroup material are not among the hypotheses of the aperiodic Fundamental Theorem.

No Lean files, theorem statements, blueprint tags, or dependencies are changed.

Closes #1900.

Validation:

- `git diff --check`
- `cd blueprint && leanblueprint web`

Note: `python3 scripts/blueprint_lean_sync.py --root . --ci` still reports pre-existing missing Lean references in `ch14_parent_hamiltonian.tex` and the existing placeholder tag in `ch04a_channel_representations.tex`; this PR does not touch those chapters or tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: prose-only edits that clarify where auxiliary reductions live and what is (not) assumed in the aperiodic Fundamental Theorem route, without changing any Lean, statements, or dependencies.
> 
> **Overview**
> Clarifies in the blueprint prose that the *auxiliary direct-sum reductions* are intentionally kept inside the Fundamental Theorem proof chapter (to assemble single-block conclusions into block-diagonal gauge statements after block correspondence), rather than being part of the canonical-form chapters.
> 
> Updates the opening of `ch11_fundamental_theorem_proof.tex` to explicitly frame the chapter boundary as separating blocked-surface preparation from later gauge/MPV assembly, and to state that channel-representation/semigroup material is not among the hypotheses for the aperiodic theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef381639900d27ce9dac410e4559de2f7329b319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->