### PR TITLE
doc: sharpen canonical anchors and clean docstrings

### DIFF
--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -218,8 +218,8 @@ subsystem `B`: after a unitary change of basis on `B`, the Hilbert space of
 block-diagonal form
 `⊕_j p_j (ρ_{A B_jᴸ} ⊗ ρ_{B_jᴿ C})`.
 
-The right-hand side is packaged by the structure
-`HayashiMarkovDecomposition ρ_ABC`, which stores the explicit dimensions, the
+The right-hand side is recorded by the structure
+`HayashiMarkovDecomposition ρ_ABC`, whose fields store the explicit dimensions, the
 unitary basis change on `B`, the probabilities `p_j`, the component density
 matrices, and the block-diagonal equality.
 

--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -12,7 +12,7 @@ import Mathlib.LinearAlgebra.Matrix.PosDef
 
 This file states algebraic lemmas for the finite-POVM / compression route to
 operator Jensen inequalities. The main target is the concave real-power case in
-Wolf Corollary 5.2, but the final Löwner-integral packaging is still absent.
+Wolf Corollary 5.2, but the final Löwner-integral argument is still absent.
 
 ## Main statements
 
@@ -39,7 +39,7 @@ These lemmas formalize the compression / finite-POVM half of the direct proof
 route for the concave real-power Jensen inequality. The diagonal-inverse formula
 (`povmDiagonal_inv`) and the finite-POVM resolvent inequality
 (`povm_resolvent_inv_le`) are now proved. The remaining unfinished step is the
-Löwner-integral packaging that carries the pointwise resolvent inequality
+Löwner-integral argument that carries the pointwise resolvent inequality
 through the integral representation of `rpow` to discharge
 `posMap_rpow_concave_jensen`.
 -/

--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -364,7 +364,7 @@ Given a finite family of MPS tensors `A j` (with possibly different bond dimensi
 whose pairwise overlaps converge to the Kronecker delta, the MPV states `mpvState (A j) N` are
 linearly independent for all sufficiently large `N`.
 
-This is a direct repackaging of
+This is a direct restatement of
 `MPSTensor.eventually_linearIndependent_of_overlap_tendsto_orthonormal`
 in the exact form used by the BNT permutation-matching argument.
 -/

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -57,7 +57,7 @@ duplicated.
 One direct connection is provided:
 
 * `MPSTensor.IsNormalTensor.of_irreducible_and_primitive` —
-  package an `IsIrreducibleTensor` proof with a primitive-transfer-map proof.
+  combine an `IsIrreducibleTensor` proof with a primitive-transfer-map proof.
 
 Two further connections are intentionally **not** provided here, in keeping with the
 "clean layer, no `sorry`" quality bar:
@@ -70,7 +70,7 @@ Two further connections are intentionally **not** provided here, in keeping with
   `MPSTensor.IsNormal → IsNormalTensor` per block, i.e. from algebraic eventual
   block injectivity to the CPSV16 (no-invariant-proj + primitive-transfer)
   formulation. That equivalence requires Wielandt-style spectral arguments not
-  packaged at this layer.
+  developed at this layer.
 
 ## Style
 

--- a/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
@@ -18,7 +18,7 @@ weight moduli and produces blocked normal canonical-form data.
 
 The supporting private declarations show that the present development already
 has a common blocking at length `p = 1` and that the block family can be
-reordered by decreasing weight norm before the final packaging step.
+reordered by decreasing weight norm before the final normal-form statement.
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -602,7 +602,7 @@ The complete fundamental theorem should take two tensors `A, B` with `SameMPV₂
 and pass from the blocked reduction data to the CPSV basis-of-normal-tensors
 sector comparison. The one-sided phase-class BNT construction is available as
 `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`; the remaining overlap/span
-data are packaged at the two-sided comparison layer.
+data are supplied at the two-sided comparison layer.
 The sector matching extraction is available from primitive overlap-rigidity
 hypotheses through `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching`.
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -120,7 +120,7 @@ The sequence of theorems proceeds through progressively weaker
 hypotheses (corner-irreducible → proj-step → fixed-algebra-rigidity
 → scalar-blocked-fixed-points) until the unconditional form
 `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking`
-is reached.  Only the unconditional form and the top-level packaging
+is reached.  Only the unconditional form and the top-level existence theorem
 `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
 are consumed by the downstream canonical-form proof chain.
 -/

--- a/TNLean/MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean
@@ -229,7 +229,7 @@ normalization, transfer-map primitivity, and tensor irreducibility are all
 preserved.
 
 This is the finite-family analogue of
-`exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible`, packaged so
+`exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible`, stated so
 that the consumer can feed the resulting prepared blocks into the
 `SectorBNT` prepared-block supplier.
 

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/BurnsideJacobson.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/BurnsideJacobson.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.MPDO.BiCFDerivation.PairHomogenization.Span
 This module contains the finite-family separation and the Burnside–Jacobson
 connection to the existence of a homogeneous trace-separating length.  It
 imports the algebra-density and identity-padding parts of the
-pair-homogenization subpackage and completes the pair-span homogenization
+pair-homogenization development and completes the pair-span homogenization
 layer.
 -/
 

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -155,7 +155,7 @@ its proof transitively depends on admitted lemmas in the split overlap developme
 `TNLean.MPS.Periodic.Overlap.Case2` for the no-sector-match decay route,
 `TNLean.MPS.Periodic.Overlap.Case3` for the sector-match repeated-block route, and
 `TNLean.MPS.Periodic.Overlap.Dichotomy` for the final dichotomy and eventual
-linear-independence packaging. Subsequent users of this constructor therefore inherit
+linear-independence statement. Subsequent users of this constructor therefore inherit
 those obligations and
 should not treat the resulting `PeriodicOverlapHypothesis` as unconditionally proven. -/
 def PeriodicOverlapHypothesis.ofIsPeriodic

--- a/TNLean/MPS/Periodic/ProjectiveRep.lean
+++ b/TNLean/MPS/Periodic/ProjectiveRep.lean
@@ -27,7 +27,7 @@ representation data — the cocycle identity and the construction of a
 
 ## Main definitions and results
 
-* `MPSTensor.PeriodicProjectiveRigidity` — the analytic hypothesis packaging
+* `MPSTensor.PeriodicProjectiveRigidity` — the analytic hypothesis recording
   the existence of a compatible family `Y : G → GL (Fin D) ℂ` together with a
   scalar 2-cochain `u : G × G → ℂˣ` satisfying the projective law on the
   bond space while every `Y g` realises the Corollary-4.1 intertwining with
@@ -150,7 +150,7 @@ theorem cor_4_1_projective_rep_cocycle
 
 /-- **Projective representation from the periodic projective-rigidity hypothesis.**
 
-High-level packaging of `cor_4_1_projective_rep` together with the cocycle
+High-level consequence of `cor_4_1_projective_rep` together with the cocycle
 condition of `cor_4_1_projective_rep_cocycle`: the rigidity hypothesis upgrades
 the bond-space symmetry data of Corollary 4.1 to a coherent projective
 representation of `G` on the bond space, with factor system satisfying the

--- a/TNLean/MPS/SharedInfra/GaugePhase.lean
+++ b/TNLean/MPS/SharedInfra/GaugePhase.lean
@@ -221,7 +221,7 @@ theorem gaugePhaseEquiv_symm_same_dim {d D : ℕ} {A B : MPSTensor d D}
     have := congrArg (fun M => (ζ⁻¹ : ℂ) • M) hSandwich
     simp only [smul_smul, inv_mul_cancel₀ hζ, one_smul] at this
     exact this.symm
-  -- Repackage with the inverse of `X⁻¹` being `X`.
+  -- Use the inverse of `X⁻¹`, which is `X`.
   -- The goal expects `((X⁻¹)⁻¹ : GL).val = X.val`.
   change A i = ζ⁻¹ • (XinvM * B i *
     (((X⁻¹)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -119,7 +119,7 @@ noncomputable def flatBasis (P : SectorDecomposition d) :
 
 Marked `@[reducible]` so that `Fin P.totalDim` and `Fin (∑ s, P.flatDim s)`
 unify during type-class instance synthesis (needed for the literal
-`GaugeEquiv` packaging that compares matrices indexed by both forms). -/
+`GaugeEquiv` statement that compares matrices indexed by both forms). -/
 @[reducible]
 noncomputable def totalDim (P : SectorDecomposition d) : ℕ :=
   ∑ s : Fin P.totalCopies, P.flatDim s
@@ -301,7 +301,7 @@ theorem totalDim_eq_of_match
 
 The `sectorFlatEquiv` already permutes the flattened copy index
 `Fin Q.totalCopies ≃ Fin P.totalCopies` and `flatDim_sectorFlatEquiv` certifies
-that the per-flat-copy bond dimensions agree.  The next equivalence packages
+that the per-flat-copy bond dimensions agree.  The next equivalence combines
 both pieces as a single permutation of the Σ-index that underlies
 `toTensor`/`toTensorFromBlocks`, and induces an equivalence on
 `Fin · .totalDim`.  Both are needed to convert the matched-coordinate gauge

--- a/TNLean/MPS/Structure/PrimitivityBridge.lean
+++ b/TNLean/MPS/Structure/PrimitivityBridge.lean
@@ -101,7 +101,8 @@ def HasPrimitiveFixedPoint {d D : ℕ} [NeZero D] (A : MPSTensor d D) : Prop :=
 /-- A primitive MPS tensor has self-overlap converging to 1.
 
 This is a direct application of `mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one`
-from `PrimitiveOverlap.lean`, packaging the hypotheses from the `IsPrimitiveMPS` structure. -/
+from `PrimitiveOverlap.lean`, using the hypotheses recorded in the `IsPrimitiveMPS`
+structure. -/
 theorem IsPrimitiveMPS.overlap_tendsto_one {d D : ℕ} [NeZero D]
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ} (hP : IsPrimitiveMPS A ρ) :
     Tendsto (fun N ↦ mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ)) :=

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -586,7 +586,7 @@ theorem isUnit_det_of_self_mul_conjTranspose_scalar [NeZero D]
         simp only [smul_smul, inv_mul_cancel₀ hc, one_smul]
   exact Matrix.isUnit_det_of_right_inverse hX_right_inv
 
-/-- Generic square endgame: once the gauged intertwiner is invertible, it upgrades to
+/-- Generic square gauge construction: once the gauged intertwiner is invertible, it upgrades to
 gauge-phase equivalence for the original tensors. -/
 theorem gaugePhaseEquiv_of_gauged_intertwining [NeZero D]
     (A B : MPSTensor d D)
@@ -666,7 +666,7 @@ theorem gaugePhaseEquiv_of_gauged_intertwining [NeZero D]
     simp only [A', gaugeTensor, Ymat, Yinv, Matrix.mul_assoc]
   simpa [Ygl] using this
 
-/-- Generic rectangular endgame: the two intertwining relations force equality of dimensions
+/-- Generic rectangular dimension comparison: the two intertwining relations force equality of dimensions
 once both gauged tensor families are injective. -/
 theorem dim_eq_of_gauged_intertwining [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
+++ b/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
@@ -29,7 +29,7 @@ normality/canonical-form reductions.
 * `isIrreducibleMap_of_isPrimitiveMPS_of_posDef` — primitive spectral-gap data
   with a positive-definite fixed point gives irreducibility of the transfer map.
 * `isStronglyIrreduciblePaper_of_isPrimitiveMPS_of_posDef` — the previous two
-  implications packaged as paper strong irreducibility.
+  implications stated as paper strong irreducibility.
 * `IsPrimitiveMPS.transferMap_pow_apply_tendsto` — pointwise convergence of
   transfer-map powers to the fixed-point projection.
 

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
@@ -205,7 +205,7 @@ theorem eigenvector_mem_range_toLin_pow'
   rw [Matrix.toLin'_apply, Matrix.mulVec_smul, hpow, smul_smul,
       ← mul_pow, inv_mul_cancel₀ hμ, one_pow, one_smul]
 
-/-! ### Combined packaging: eigenvector rank-one in wordSpan -/
+/-! ### Combining eigenvector range data with rectangular span universality -/
 
 /-- **Eigenvector rank-one matrices land in `wordSpan` via stabilized `rectSpan`.**
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -31,10 +31,11 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
 \begin{theorem}[PGVWC07 translation-invariant canonical form]%
     \label{thm:pgvwc07_ti_canonical_form}
     \notready
-    % Source anchors:
-    % Papers/quant-ph_0608197/MPSarchive.tex:742 label Th:TIcanonical.
+    % Source anchors for the exact source statement:
+    % Papers/quant-ph_0608197/MPSarchive.tex:742 labels Th:TIcanonical.
     % Lines 742--752 state the block decomposition; lines 753--758 state the
     % three block conditions; lines 761--762 state the bond-dimension bound.
+    % Source proof order to preserve:
     % The proof order is lines 765--770 for spectral-radius normalization and
     % the full-rank fixed-point gauge; lines 771--815 for the invariant support
     % split when the positive fixed point is not full rank; lines 816--826 for
@@ -94,10 +95,11 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     % lines 237--246 are the definition containing the display labelled
     % eq:II_CF1 and the subsequent weight normalization; lines 249--251 state
     % that any tensor becomes canonical after blocking. The phase-class
-    % quotient used by the BNT supplier is prop:char-BNT at lines 271--280,
-    % restated and proved in
-    % Appendix A at lines 1135--1146. The two-layer expansion is
-    % eq:II_ABasicTensors/decBSV at lines 283--301.
+    % quotient used by the BNT supplier is prop:char-BNT, labelled at line 278
+    % with statement at line 279, in the definition/proposition passage
+    % lines 271--279. It is restated, proved, and followed by the same-CF BNT
+    % uniqueness note in Appendix A at lines 1135--1148. The two-layer
+    % expansion is eq:II_ABasicTensors/decBSV at lines 283--301.
     % Papers/2011.12127/TN-Review-main.tex:1793--1803 gives the invariant-
     % subspace reduction; lines 1815--1820 give period removal; lines 1827--1839
     % give def:4:normal-tensor-mps and eq:II_CF1; lines 1846--1859 give the
@@ -1173,8 +1175,10 @@ BNT construction.
     \lean{MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr}
     \leanok
     % Source anchors:
-    % Papers/1606.00608/MPDO-22-12-17-2.tex:271--280 states prop:char-BNT;
-    % lines 1135--1146 restate it and give the construction.
+    % Papers/1606.00608/MPDO-22-12-17-2.tex:278 labels prop:char-BNT;
+    % the statement is line 279, in the surrounding definition/proposition
+    % passage lines 271--279. Lines 1135--1148 restate it, give the
+    % construction, and record the same-CF BNT uniqueness note.
     In a prepared family of positive-bond-dimension blocks, assume that every
     block is trace-preserving, primitive, and irreducible. Then every block in
     an MPV phase class has the same bond dimension as the representative of
@@ -1193,8 +1197,10 @@ BNT construction.
     % Source anchors:
     % The canonical-form source is
     % Papers/1606.00608/MPDO-22-12-17-2.tex, eq:II_CF1 at lines 237--246.
-    % The phase-class quotient is prop:char-BNT at lines 271--280 and its
-    % appendix restatement/construction at lines 1135--1146.
+    % The phase-class quotient is prop:char-BNT, labelled at line 278 with
+    % statement at line 279 in the passage lines 271--279, and its appendix
+    % restatement/construction and same-CF BNT uniqueness note at
+    % lines 1135--1148.
     For prepared trace-preserving, primitive, irreducible blocks of positive
     bond dimension, with all copy weights nonzero, the phase-class quotient
     used in the BNT supplier does not change the total bond dimension: the


### PR DESCRIPTION
This PR combines two documentation-only cleanups that are natural to review together.

## Source anchors

- Separates the PGVWC07 source-statement anchors from the source proof-order anchors for `Th:TIcanonical` in `Papers/quant-ph_0608197/MPSarchive.tex`.
- Records that `prop:char-BNT` is labelled at line 278, with the statement at line 279 in the surrounding lines 271--279, and that the appendix restatement, construction, and same-CF BNT uniqueness note occupy lines 1135--1148.
- Carries the same exact `eq:II_CF1` and `prop:char-BNT` line anchors into the later BNT supplier comments.

## Lean prose cleanup

- Rewrites the remaining live Lean docstring/comment occurrences of `packag*` and `endgame` into mathematical descriptions such as "recording", "restatement", "existence theorem", "gauge construction", or "dimension comparison".
- Leaves theorem names, declarations, proofs, imports, and blueprint tags unchanged.
- Does not touch documentation under `docs/` or archived prose; the prose cleanup is limited to live Lean source comments/docstrings.

Refs #1530.
Refs #1685.

Validation:

- `rg -n "packag|endgame" TNLean --glob '*.lean'` returns no matches.
- `git diff --check origin/main...HEAD`
- `cd blueprint && leanblueprint web`
- `lake env lean` on each edited Lean file:
  - `TNLean/Axioms/Entropy.lean`
  - `TNLean/Channel/Schwarz/OperatorJensenAux.lean`
  - `TNLean/MPS/BNT/Basic.lean`
  - `TNLean/MPS/CanonicalForm/Definitions.lean`
  - `TNLean/MPS/CanonicalForm/NormalReduction/Main.lean`
  - `TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean`
  - `TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean`
  - `TNLean/MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean`
  - `TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/BurnsideJacobson.lean`
  - `TNLean/MPS/Periodic/FundamentalTheorem.lean`
  - `TNLean/MPS/Periodic/ProjectiveRep.lean`
  - `TNLean/MPS/SharedInfra/GaugePhase.lean`
  - `TNLean/MPS/SharedInfra/SectorDecomposition.lean`
  - `TNLean/MPS/Structure/PrimitivityBridge.lean`
  - `TNLean/Spectral/GaugeConstruction.lean`
  - `TNLean/Wielandt/Primitivity/PrimitiveBridge.lean`
  - `TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean`

Note: `python3 scripts/blueprint_lean_sync.py --root . --ci` still reports pre-existing missing Lean references in `ch14_parent_hamiltonian.tex` and the existing placeholder tag in `ch04a_channel_representations.tex`; this PR does not touch those declarations or tags.
