### PR TITLE
doc(MPS/FT): correct proportional matching source lines

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -17,7 +17,7 @@ conclusion of the CPSV16/CPSV21 fundamental theorem on the
 
 Paper anchors:
 
-* CPSV16 §II.C lines 1182–1186: full BNT basis matching by the `Lem1`
+* CPSV16 §II.C line 1182: full BNT basis matching by the `Lem1`
   contradiction and symmetry argument.
 * CPSV16 §II.C lines 1187–1188: exact power-sum coefficient comparison,
   recovering copy multiplicities and weights up to the matched phase.
@@ -194,7 +194,7 @@ theorem sector_bnt_global_gauge_of_matched_weights
 
 For proportional MPV families, the proportional sector-matching theorem supplies
 the matched BNT basis, unit phases, and block gauges of CPSV16 §II.C lines
-1184--1186. If the remaining coefficient-comparison step supplies copy
+1167--1170 and line 1182. If the remaining coefficient-comparison step supplies copy
 permutations whose weights obey the same phases, then the direct-sum gauge
 assembly uses the same algebra as the equal-MPV corollary in lines 1189--1192.
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -20,7 +20,7 @@ $B_k = \zeta_k X_k A_{\beta k} X_k^{-1}$.
 ## References
 
 * CPSV16: arXiv:1606.00608, lines 349–352 (theorem `thm1`), 1167–1170
-  (restatement), 1182–1186 (proof).
+  (restatement), and line 1182 (matching proof).
 * CPSV21: arXiv:2011.12127, lines 1891–1894 (proportional target).
 -/
 
@@ -37,7 +37,7 @@ bond dimension, gauge-phase equivalent in the cast-compatible shape, and
 with non-decaying cross-overlap.  This is the proportional analogue of
 `StrongMatch.forall_k_exists_j_nondecaying_overlap_of_sameMPV`.
 
-Paper anchor: CPSV16 §II.C lines 349–352 / 1167–1170 / 1182–1186. -/
+Paper anchor: CPSV16 §II.C lines 349–352 / 1167–1170 / 1182. -/
 theorem forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -76,7 +76,7 @@ the forward one into an equivalence $\beta : \{1,\dots,g_Q\} \to
 \{1,\dots,g_P\}$, carrying the matched bond-dimension equality,
 gauge-phase equivalence, and non-decaying overlap for every sector of $Q$.
 
-Paper anchor: CPSV16 §II.C lines 1184–1186, the symmetry step
+Paper anchor: CPSV16 §II.C line 1182, the symmetry step
 "$g_A \ge g_B$ and $g_B \ge g_A$". -/
 theorem bijective_match_of_eventuallyProportional
     {P Q : SectorDecomposition d}
@@ -204,7 +204,7 @@ there is a basis bijection carrying matched bond-dimension equality and
 per-block gauge-phase equivalence.
 
 Paper anchor: CPSV16 §II.C lines 349–352 (theorem `thm1`), lines 1167–1170
-(theorem statement), lines 1182–1186 (proof); CPSV21 lines 1891–1894
+(theorem statement), and line 1182 (matching proof); CPSV21 lines 1891–1894
 (proportional-MPV theorem-level target).  This is the proportional analogue
 of `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses` (`SectorBNT/FundamentalCoord.lean`)
 in the matching layer. The source proportional theorem stops at sector
@@ -235,7 +235,7 @@ theorem ft_sector_bnt_proportional_sector_match
 /-- **Proportional sector matching with explicit unit phases and block gauges.**
 
 This is the witness form of `ft_sector_bnt_proportional_sector_match`: after
-the proportional BNT block matching of CPSV16 §II.C lines 1184–1186, the
+the proportional BNT block matching of CPSV16 §II.C line 1182, the
 matched gauge-phase equivalences provide actual matrices `Xblock k` and
 scalars `ζ k`.  The BNT self-overlap normalization forces `‖ζ k‖ = 1`, so
 these are the unit phases appearing in the source proportional theorem.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
@@ -32,7 +32,7 @@ equivalence then follow as in the equal case.
 ## References
 
 * CPSV16: arXiv:1606.00608, lines 349–352 (theorem `thm1`), 1167–1170
-  (restatement), 1182–1186 (proof).
+  (restatement), and line 1182 (matching proof).
 * CPSV21: arXiv:2011.12127, lines 1891–1894 (proportional target).
 -/
 
@@ -52,8 +52,9 @@ $P.\mathrm{coeff}(N,j)\cdot Q.\mathrm{coeff}(N,k)
   = \sum_{q,p}(\mu_{j,q}^P\,\mu_{k,p}^Q)^N$
 has a unit-modulus summand at $(q^*,p^*)$.  By
 `CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus` the sum does not
-tend to zero.  Paper anchor: CPSV16 §II.A line 246 and §II.C lines
-1181–1188. -/
+tend to zero.  This is the analytic input used to formalize the non-decay
+contradiction in CPSV16 §II.C line 1182, together with the line-246
+normalization. -/
 lemma joint_coeff_not_tendsto_zero
     {P Q : SectorDecomposition d}
     (j : Fin P.basisCount) (k : Fin Q.basisCount)
@@ -345,7 +346,7 @@ eventual nonzero proportionality and unit-modulus copy weights at $Q$-sector
 $k_0$ and auxiliary $P$-sector $j_0$, some $P$-block $j_1$ has matched bond
 dimension, cast-compatible gauge-phase equivalence, and non-decaying
 cross-overlap with $Q.\mathrm{basis}\,k_0$.  Paper anchor: CPSV16 §II.C
-lines 349–352, 1167–1170, 1182–1186. -/
+lines 349–352, 1167–1170, and 1182. -/
 theorem exists_block_match_at_Q_of_eventuallyProportional
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -5,9 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.FundamentalTheorem.SectorBNT.DominantMatch
 
 /-!
-# Strong existential and bijective sector matching (CPSV16 §II.C lines 1182–1186)
+# Strong existential and bijective sector matching (CPSV16 §II.C line 1182)
 
-The strong existential matching theorem states the CPSV16 §II.C lines 1182–1186
+The strong existential matching theorem states the CPSV16 §II.C line 1182
 *Step 1* conclusion directly on the original pair `(P, Q)` of BNT canonical
 forms, iterated over each sector `k` of `Q` that carries a unit-modulus copy.
 
@@ -16,8 +16,8 @@ lives in the companion module `SectorBNT/CoeffIdentity.lean`.
 
 ## Paper anchor
 
-CPSV16 (arXiv:1606.00608) §II.C lines 1182–1186 give the *entire* "Step 1"
-of the equal-MPV corollary proof.  In mathematical terms, Step 1 fixes a
+CPSV16 (arXiv:1606.00608) §II.C line 1182 gives the *entire* matching step
+of the proportional theorem proof.  In mathematical terms, this step fixes a
 block $B_k$ and observes that its overlaps with the $A_j$ blocks cannot all
 decay to zero, since then the two MPV families would fail to be proportional
 for all lengths.  The equal-vector corollary then gives an index $j_k$ with
@@ -80,9 +80,9 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ### Strong existential matching: CPSV16 §II.C lines 1182–1186 -/
+/-! ### Strong existential matching: CPSV16 §II.C line 1182 -/
 
-/-- **CPSV16 §II.C lines 1182–1186 Step 1 (full-basis form).**
+/-- **CPSV16 §II.C line 1182 Step 1 (full-basis form).**
 
 For every sector `k` of `Q`, there exists a sector `j` of `P` of equal
 bond dimension, gauge-phase equivalent to `Q.basis k` after the dimension
@@ -96,7 +96,7 @@ CPSV16 §II.C line 1182's projection argument; it is taken here as an
 explicit theorem-level hypothesis (CPSV16 §II.A line 246 records only
 the global unit witness).
 
-Paper anchor: CPSV16 §II.C lines 1182–1186 (arXiv:1606.00608), CPSV21
+Paper anchor: CPSV16 §II.C line 1182 (arXiv:1606.00608), CPSV21
 Definition 4.2 lines 1846–1850, and the two-layer display at lines 1864–1884. -/
 theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     {P Q : SectorDecomposition d}
@@ -146,7 +146,7 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
 
 /-! ### Bijective sector matching by symmetry -/
 
-/-- **CPSV16 §II.C lines 1184–1186 full-basis bijection.**
+/-- **CPSV16 §II.C line 1182 full-basis bijection.**
 
 Applying `forall_k_exists_j_nondecaying_overlap_of_sameMPV` in both
 directions gives injective maps `Fin Q.basisCount → Fin P.basisCount` and

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -945,7 +945,7 @@ normalization).
     \uses{lem:sector_bnt_combined_family_eventually_li,
         lem:sector_bnt_coeff_not_tendsto_zero_at_unit_block}
     The contrapositive of
-    \cite[\S~II.C, lines 1182--1186]{Cirac2017MPDO_AnnPhys}, combined with
+    \cite[\S~II.C, line 1182]{Cirac2017MPDO_AnnPhys}, combined with
     linear independence on the full family
     $\{P_j\}_j \cup \{Q_k\}_k$, is iterated externally over each sector
     $k$. Each iteration is discharged by the full-basis weak existential
@@ -973,7 +973,7 @@ normalization).
 \label{subsec:sector_bnt_strong_match_bijective_symmetry}
 
 This subsection derives the symmetry argument of
-\cite[\S~II.C, lines 1184--1186]{Cirac2017MPDO_AnnPhys}:
+\cite[\S~II.C, line 1182]{Cirac2017MPDO_AnnPhys}:
 $g_a \ge g_b$ and $g_b \ge g_a$ together imply $g_a = g_b$.
 
 The strong existential matching theorem
@@ -989,7 +989,7 @@ in both directions.
 \paragraph{Scope.}
 The literal source conclusion ``$g_a = g_b$ and a relabelling
 $B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$''
-(\cite[\S~II.C, lines 1184--1186]{Cirac2017MPDO_AnnPhys}) reads as a
+(\cite[\S~II.C, line 1182]{Cirac2017MPDO_AnnPhys}) reads as a
 bijection between the unit-modulus subsets of the two BNT canonical
 forms. The theorem below delivers the symmetric injective matching
 (the source's $g_a \ge g_b \wedge g_b \ge g_a$ step) in the following
@@ -1256,8 +1256,8 @@ matching covers the whole BNT basis.
         \zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma
     \]
     This records the per-block phase conclusion of
-    \cite[\S~II.C, lines 1167--1170]{Cirac2017MPDO_AnnPhys}; lines
-    1184--1186 give the corresponding proof step. The following
+    \cite[\S~II.C, lines 1167--1170]{Cirac2017MPDO_AnnPhys}; line
+    1182 gives the corresponding proof step. The following
     coefficient-comparison step is separate.
 \end{theorem}
 
@@ -1409,7 +1409,7 @@ matching covers the whole BNT basis.
     the same algebra as the equal-MPV corollary in
     \cite[\S~II.C, lines 1189--1192]{Cirac2017MPDO_AnnPhys}.
     The source proportional theorem itself stops at the sector matching in
-    lines~1167--1186; lines~1187--1192 do not supply the missing
+    lines~1167--1170 and line~1182; lines~1187--1192 do not supply the missing
     proportional coefficient comparison, because in the equal-MPV corollary
     the length-dependent proportionality scalar is identically~$1$.
 \end{theorem}


### PR DESCRIPTION
This PR corrects stale CPSV16 source-line anchors around the proportional BNT sector-matching layer.

Changes:

- Retargets proportional and strong matching comments from the stale `1182--1186` / `1184--1186` ranges to the actual proportional matching proof line, `Papers/1606.00608/MPDO-22-12-17-2.tex` line 1182.
- Keeps CPSV16 lines 1167--1170 as the theorem statement and leaves lines 1187--1192 reserved for the equal-MPV corollary coefficient comparison and global gauge assembly.
- Updates the corresponding Chapter 10 blueprint prose so the proof route no longer points the proportional matching step into the equal-case power-sum display.

No theorem statements, proof terms, imports, or blueprint tags are changed.

Validation:

- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean`
- `git diff --check -- TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean blueprint/src/chapter/ch10_bnt.tex`
- `cd blueprint && leanblueprint web`

Refs #1685. Refs #1749.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to CPSV16 line references in Lean module docstrings and the blueprint; no theorem statements, proofs, or imports change, so runtime/logic risk is minimal.
> 
> **Overview**
> Updates stale CPSV16 source-line anchors across the proportional/strong BNT sector-matching layer to consistently point to **§II.C line 1182** (keeping `1167–1170` as the theorem statement and `1187–1192` for the equal-MPV corollary’s coefficient/global-gauge steps).
> 
> Mirrors the same citation corrections in the Chapter 10 blueprint prose so the proportional matching narrative no longer references the equal-case proof-line ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52074dd9641f49c7f97ed201dc45492fa9a19a7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->