### PR TITLE
feat(Entropy): add mutual-information monotonicity and area-law bounds

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -23,6 +23,8 @@ the basic quantum entropy infrastructure needed for MPDO / RFP applications.
 
 ## Main results
 
+* `vonNeumannEntropy_nonneg_of_posSemidef_trace_one`: `S(ρ) ≥ 0` for
+  positive semidefinite matrices of trace `1`, over any finite index type
 * `vonNeumannEntropy_nonneg`: `S(ρ) ≥ 0` for density matrices
 * `traceA_ABC_isHermitian`, `traceC_ABC_isHermitian`, `traceAC_ABC_isHermitian`:
   tripartite partial traces preserve Hermiticity
@@ -42,7 +44,7 @@ subadditivity theorem lives in `TNLean.Axioms.Entropy`, which is imported from
 The entropy definition uses the eigenvalue-based formula via
 `Matrix.IsHermitian.eigenvalues` and Mathlib's `Real.negMulLog`. The index
 type `n` is kept polymorphic (`[Fintype n] [DecidableEq n]`) so that von
-Neumann entropy can be applied to matrices indexed by product types arising
+Neumann entropy can be applied to matrices indexed by product index sets arising
 from partial traces.
 
 Tripartite partial traces are defined directly as matrix entry sums, avoiding
@@ -85,7 +87,40 @@ noncomputable def vonNeumannEntropy
 
 end VonNeumannEntropy
 
-/-! ### Basic properties for `Fin D` density matrices -/
+/-! ### Basic properties for density matrices -/
+
+section VonNeumannEntropyDensity
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The eigenvalues of a positive semidefinite trace-one matrix sum to `1`. -/
+theorem posSemidef_trace_one_eigenvalues_sum_one
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1) :
+    ∑ i : n, hρ.isHermitian.eigenvalues i = 1 := by
+  have h := hρ.isHermitian.trace_eq_sum_eigenvalues
+  have key : (∑ i : n, (hρ.isHermitian.eigenvalues i : ℂ)) = 1 :=
+    h ▸ hρ_tr
+  exact_mod_cast key
+
+/-- The eigenvalues of a positive semidefinite trace-one matrix lie in `[0, 1]`. -/
+theorem posSemidef_trace_one_eigenvalues_le_one
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1) (i : n) :
+    hρ.isHermitian.eigenvalues i ≤ 1 := by
+  have h_nonneg := hρ.eigenvalues_nonneg
+  have h_sum := posSemidef_trace_one_eigenvalues_sum_one hρ hρ_tr
+  nlinarith [Finset.single_le_sum (f := fun j => hρ.isHermitian.eigenvalues j)
+    (fun j _ => h_nonneg j) (Finset.mem_univ i)]
+
+/-- Von Neumann entropy is nonnegative for positive semidefinite trace-one matrices. -/
+theorem vonNeumannEntropy_nonneg_of_posSemidef_trace_one
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1) :
+    0 ≤ vonNeumannEntropy ρ hρ.isHermitian := by
+  apply Finset.sum_nonneg
+  intro i _
+  exact negMulLog_nonneg (hρ.eigenvalues_nonneg i)
+    (posSemidef_trace_one_eigenvalues_le_one hρ hρ_tr i)
+
+end VonNeumannEntropyDensity
 
 section VonNeumannEntropyFinD
 
@@ -94,21 +129,14 @@ variable {D : ℕ}
 /-- The eigenvalues of a density matrix sum to 1 (real version). -/
 theorem densityMatrices_eigenvalues_sum_one
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D) :
-    ∑ i : Fin D, hρ.1.isHermitian.eigenvalues i = 1 := by
-  have h := hρ.1.isHermitian.trace_eq_sum_eigenvalues
-  have h_tr := hρ.2
-  have key : (∑ i : Fin D, (hρ.1.isHermitian.eigenvalues i : ℂ)) = 1 :=
-    h ▸ h_tr
-  exact_mod_cast key
+    ∑ i : Fin D, hρ.1.isHermitian.eigenvalues i = 1 :=
+  posSemidef_trace_one_eigenvalues_sum_one hρ.1 hρ.2
 
 /-- The eigenvalues of a density matrix lie in `[0, 1]`. -/
 theorem densityMatrices_eigenvalues_le_one
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D)
-    (i : Fin D) : hρ.1.isHermitian.eigenvalues i ≤ 1 := by
-  have h_nonneg := hρ.1.eigenvalues_nonneg
-  have h_sum := densityMatrices_eigenvalues_sum_one hρ
-  nlinarith [Finset.single_le_sum (f := fun j => hρ.1.isHermitian.eigenvalues j)
-    (fun j _ => h_nonneg j) (Finset.mem_univ i)]
+    (i : Fin D) : hρ.1.isHermitian.eigenvalues i ≤ 1 :=
+  posSemidef_trace_one_eigenvalues_le_one hρ.1 hρ.2 i
 
 /-- Von Neumann entropy is nonneg for density matrices.
 
@@ -119,11 +147,8 @@ Source: [Wolf, Chapter 8, Section 8.2][Wolf2012QChannels];
 blueprint `thm:entropy_nonneg`. -/
 theorem vonNeumannEntropy_nonneg
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ ∈ densityMatrices D) :
-    0 ≤ vonNeumannEntropy ρ hρ.1.isHermitian := by
-  apply Finset.sum_nonneg
-  intro i _
-  exact negMulLog_nonneg (hρ.1.eigenvalues_nonneg i)
-    (densityMatrices_eigenvalues_le_one hρ i)
+    0 ≤ vonNeumannEntropy ρ hρ.1.isHermitian :=
+  vonNeumannEntropy_nonneg_of_posSemidef_trace_one hρ.1 hρ.2
 
 /-- Von Neumann entropy is bounded above by `log D`.
 

--- a/TNLean/Entropy/MutualInformation.lean
+++ b/TNLean/Entropy/MutualInformation.lean
@@ -13,12 +13,23 @@ correlations (classical + quantum) between the two subsystems.
 
 This module exposes the bipartite mutual information of
 `TNLean.Analysis.Entropy` under the `Entropy` namespace via a
-Mathlib-style `alias` (rather than a `noncomputable def` re-statement), and
-adds a small algebraic corollary derived from
-`Entropy.strongSubadditivity`. Together with
-`Entropy.VonNeumann` and `Entropy.StrongSubadditivity`, it forms the
-entropy namespace used by the Simple MPDO RFP track
-(see issue #613, #236, #239).
+Mathlib-style `alias` (rather than a restated `noncomputable def`), adds
+the trivial-middle nonnegativity corollary, and provides two downstream
+consequences used by the MPDO / RFP track (issues #236, #239, #785):
+
+* a **monotonicity** inequality under enlargement of a subsystem
+  (`mutualInformation_monotone_tripartite`), which is the SSA-level
+  inequality underlying the MPDO `I_L ≤ I_{L+1}` monotonicity
+  (arXiv:1606.00608 Prop C.1);
+* an **elementary area-law bound**
+  `I(A:B) ≤ log d_A + log d_B`
+  (`mutualInformation_le_log_dim_add_log_dim`), which is the entropy
+  bound underlying the "`I_L ≤ 4 log D`" MPDO area-law estimate once one
+  specializes to MPDO bond-dimension hypotheses.
+
+Together with `Entropy.VonNeumann` and `Entropy.StrongSubadditivity`, it
+forms the entropy namespace used by the Simple MPDO RFP track
+(see issue #613, #236, #239, #785).
 
 ## Main declarations
 
@@ -29,12 +40,24 @@ entropy namespace used by the Simple MPDO RFP track
   of the tripartite mutual information in the trivial-middle form,
   derived from `subadditivity_ssa_trivial_B` with no extra reduced-trace
   hypothesis.
+* `Entropy.vonNeumannEntropy_nonneg_of_posSemidef_trace_one` — a
+  nonnegativity lemma for the von Neumann entropy of a PSD+trace-1
+  Hermitian matrix over an arbitrary finite index set; reused by the
+  area-law bound for bipartite `Fin dA × Fin dB` indices.
+* `Entropy.mutualInformation_monotone_tripartite` — mutual information
+  is monotone under enlargement of a subsystem, in the tripartite form
+  `I(A:B) ≤ I(A:BC)` directly used by the MPDO area-law argument.
+* `Entropy.mutualInformation_le_log_dim_add_log_dim` — elementary
+  area-law bound `I(A:B) ≤ log d_A + log d_B` for bipartite density
+  matrices with density-matrix reduced states.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8][Wolf2012QChannels]
-* arXiv:1606.00608 Section 4.4 (Proposition 4.5)
-* Blueprint `def:entropy_mutual_information`, `thm:mutual_information_nonneg`
+* arXiv:1606.00608 §4.4 (Prop 4.5) and Appendix C (Prop C.1)
+* Blueprint `def:entropy_mutual_information`, `thm:mutual_information_nonneg`,
+  `thm:mutual_information_monotone_tripartite`, and
+  `thm:mutual_information_le_log_dim_add_log_dim`
 -/
 
 open scoped Matrix ComplexOrder
@@ -50,6 +73,24 @@ between A and B. Definitionally equal to `_root_.mutualInformation`.
 
 Source: blueprint `def:entropy_mutual_information`. -/
 noncomputable alias mutualInformation := _root_.mutualInformation
+
+/-! ## Entropy nonnegativity for finite index sets
+
+The `Fin D`-restricted `_root_.vonNeumannEntropy_nonneg` does not directly
+apply to bipartite density matrices indexed by `Fin dA × Fin dB`. The
+following version records the same assertion for an arbitrary finite index set. -/
+
+section FiniteIndexEntropyNonneg
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- Nonnegativity of the von Neumann entropy for a PSD+trace-1
+Hermitian matrix. Mirrors `_root_.vonNeumannEntropy_nonneg` without the
+`Fin D`-index restriction. -/
+alias vonNeumannEntropy_nonneg_of_posSemidef_trace_one :=
+  _root_.vonNeumannEntropy_nonneg_of_posSemidef_trace_one
+
+end FiniteIndexEntropyNonneg
 
 /-! ## Nonnegativity via subadditivity (trivial-middle form)
 
@@ -84,5 +125,171 @@ theorem mutualInformation_ssa_trivial_B_nonneg
   linarith
 
 end Nonnegativity
+
+/-! ## Monotonicity under enlargement of a subsystem
+
+The MPDO mutual-information monotonicity `I_L ≤ I_{L+1}`
+(arXiv:1606.00608 Prop C.1) decomposes into two steps: an SSA-level
+monotonicity `I(A:B) ≤ I(A:BC)` on a tripartite state, and a
+translation-invariance step identifying contiguous-block entropies.
+The SSA-level step is the entropy-theoretic content formalised here;
+the translation-invariance step belongs to the downstream MPDO module. -/
+
+section Monotonicity
+
+variable {dA dB dC : ℕ}
+
+/-- The bipartite `B` reduced state matches the tripartite `B` reduced
+state: for any `ρ_ABC` on `A ⊗ B ⊗ C`,
+`tr_A (tr_C ρ_ABC) = tr_{AC} ρ_ABC` as matrices on `Fin dB`. -/
+private theorem traceLeft_traceC_ABC_eq_traceAC_ABC
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    Matrix.traceLeft (traceC_ABC (dA := dA) (dB := dB) (dC := dC) ρ_ABC)
+      = traceAC_ABC ρ_ABC := by
+  ext b₁ b₂
+  simp only [Matrix.traceLeft_apply, traceC_ABC, traceAC_ABC]
+
+/-- **Mutual information is monotone under enlargement of a subsystem**
+(tripartite form). For a tripartite density matrix `ρ_ABC` on
+`A ⊗ B ⊗ C`:
+
+`I(A:B)` evaluated on the reduced state `ρ_AB = tr_C(ρ_ABC)` is bounded
+above by `I(A:BC)` evaluated on the full state `ρ_ABC` viewed bipartitely
+as `A ⊗ (B ⊗ C)`:
+
+  `I(A:B) = S(ρ_A) + S(ρ_B) − S(ρ_AB)
+         ≤ S(ρ_A) + S(ρ_BC) − S(ρ_ABC) = I(A:BC)`.
+
+After cancelling `S(ρ_A)` on both sides, the inequality reduces to
+strong subadditivity
+`S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)` (Lieb–Ruskai 1973).
+
+The right-hand side uses the tripartite partial traces:
+`ρ_BC = tr_A(ρ_ABC)` (`traceA_ABC`). The left-hand side uses the bipartite
+mutual information of the reduced `ρ_AB = tr_C(ρ_ABC)` (`traceC_ABC`).
+
+This is the SSA-level monotonicity consumed by the MPDO area-law
+argument (arXiv:1606.00608 Prop C.1); translation invariance lifts it
+to the `I_L ≤ I_{L+1}` statement on contiguous-block mutual information. -/
+theorem mutualInformation_monotone_tripartite
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :
+    Entropy.mutualInformation (traceC_ABC ρ_ABC)
+        (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
+      ≤ Entropy.vonNeumannEntropy
+            (Matrix.traceRight (traceC_ABC ρ_ABC))
+            (Matrix.traceRight_isHermitian
+              (traceC_ABC_isHermitian hρ_dm.1.isHermitian))
+        + Entropy.vonNeumannEntropy (traceA_ABC ρ_ABC)
+            (traceA_ABC_isHermitian hρ_dm.1.isHermitian)
+        - Entropy.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian := by
+  have h_SSA :
+      Entropy.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
+        + Entropy.vonNeumannEntropy (traceAC_ABC ρ_ABC)
+            (traceAC_ABC_isHermitian hρ_dm.1.isHermitian)
+      ≤ Entropy.vonNeumannEntropy (traceC_ABC ρ_ABC)
+            (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
+        + Entropy.vonNeumannEntropy (traceA_ABC ρ_ABC)
+            (traceA_ABC_isHermitian hρ_dm.1.isHermitian) :=
+    Entropy.strongSubadditivity ρ_ABC hρ_dm
+  have h_rhoB_eq :=
+    traceLeft_traceC_ABC_eq_traceAC_ABC (dA := dA) (dB := dB) (dC := dC) ρ_ABC
+  have h_rhoB_entropy :
+      Entropy.vonNeumannEntropy
+          (Matrix.traceLeft (traceC_ABC ρ_ABC))
+          (Matrix.traceLeft_isHermitian
+            (traceC_ABC_isHermitian hρ_dm.1.isHermitian))
+        = Entropy.vonNeumannEntropy (traceAC_ABC ρ_ABC)
+            (traceAC_ABC_isHermitian hρ_dm.1.isHermitian) := by
+    cases h_rhoB_eq
+    rfl
+  change Entropy.vonNeumannEntropy
+          (Matrix.traceRight (traceC_ABC ρ_ABC))
+          (Matrix.traceRight_isHermitian
+            (traceC_ABC_isHermitian hρ_dm.1.isHermitian))
+        + Entropy.vonNeumannEntropy
+            (Matrix.traceLeft (traceC_ABC ρ_ABC))
+            (Matrix.traceLeft_isHermitian
+              (traceC_ABC_isHermitian hρ_dm.1.isHermitian))
+        - Entropy.vonNeumannEntropy (traceC_ABC ρ_ABC)
+            (traceC_ABC_isHermitian hρ_dm.1.isHermitian)
+      ≤ Entropy.vonNeumannEntropy
+            (Matrix.traceRight (traceC_ABC ρ_ABC))
+            (Matrix.traceRight_isHermitian
+              (traceC_ABC_isHermitian hρ_dm.1.isHermitian))
+        + Entropy.vonNeumannEntropy (traceA_ABC ρ_ABC)
+            (traceA_ABC_isHermitian hρ_dm.1.isHermitian)
+        - Entropy.vonNeumannEntropy ρ_ABC hρ_dm.1.isHermitian
+  rw [h_rhoB_entropy]
+  linarith
+
+end Monotonicity
+
+/-! ## Elementary area-law bound on mutual information
+
+Combining the single-system entropy bound `S(ρ) ≤ log D` with
+nonnegativity of the joint entropy gives the elementary area-law bound
+`I(A:B) ≤ log d_A + log d_B` for any bipartite density matrix whose
+reduced states are density matrices. This is the entropy bound underlying
+the MPDO area-law bound `I_L ≤ 4 log D` (arXiv:1606.00608 line 1319 and
+references therein), prior to the MPS/MPDO-specific
+bond-dimension refinement. -/
+
+section AreaLaw
+
+variable {dA dB : ℕ}
+
+/-- **Elementary area-law bound on mutual information**. For a bipartite
+density matrix `ρ_AB` on `Fin d_A × Fin d_B` with `0 < d_A`, `0 < d_B`
+and whose reduced states are density matrices, the quantum mutual
+information satisfies
+
+  `I(A:B) ≤ log d_A + log d_B`.
+
+The reduced states are density matrices because partial trace preserves
+positive semidefiniteness and trace. Then `S(ρ_A) ≤ log d_A` and
+`S(ρ_B) ≤ log d_B` by
+`vonNeumannEntropy_le_log_dim`, and `S(ρ_AB) ≥ 0` by
+`vonNeumannEntropy_nonneg_of_posSemidef_trace_one`.
+
+This is the entropy-level bound underlying the MPDO area-law bound
+`I_L ≤ 4 log D` (arXiv:1606.00608 line 1319); the MPS/MPDO-specific
+bond-dimension refinement specialises this bound by taking `d_A = d_B`
+to be controlled by the bond dimension via the MPDO representation. -/
+theorem mutualInformation_le_log_dim_add_log_dim
+    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρ_AB : ρ_AB.PosSemidef ∧ ρ_AB.trace = 1)
+    (hdA : 0 < dA) (hdB : 0 < dB) :
+    Entropy.mutualInformation ρ_AB hρ_AB.1.isHermitian
+      ≤ Real.log dA + Real.log dB := by
+  have h_A_dm : Matrix.traceRight ρ_AB ∈ densityMatrices dA := by
+    exact ⟨hρ_AB.1.traceRight, by
+      rw [← Matrix.trace_eq_trace_traceRight ρ_AB]
+      exact hρ_AB.2⟩
+  have h_B_dm : Matrix.traceLeft ρ_AB ∈ densityMatrices dB := by
+    exact ⟨hρ_AB.1.traceLeft, by
+      rw [← Matrix.trace_eq_trace_traceLeft ρ_AB]
+      exact hρ_AB.2⟩
+  have hSA : Entropy.vonNeumannEntropy (Matrix.traceRight ρ_AB)
+      (Matrix.traceRight_isHermitian hρ_AB.1.isHermitian)
+        ≤ Real.log dA :=
+    Entropy.vonNeumannEntropy_le_log_dim h_A_dm hdA
+  have hSB : Entropy.vonNeumannEntropy (Matrix.traceLeft ρ_AB)
+      (Matrix.traceLeft_isHermitian hρ_AB.1.isHermitian)
+        ≤ Real.log dB :=
+    Entropy.vonNeumannEntropy_le_log_dim h_B_dm hdB
+  have hSAB : 0 ≤ Entropy.vonNeumannEntropy ρ_AB hρ_AB.1.isHermitian :=
+    vonNeumannEntropy_nonneg_of_posSemidef_trace_one hρ_AB.1 hρ_AB.2
+  change Entropy.vonNeumannEntropy (Matrix.traceRight ρ_AB)
+            (Matrix.traceRight_isHermitian hρ_AB.1.isHermitian)
+        + Entropy.vonNeumannEntropy (Matrix.traceLeft ρ_AB)
+            (Matrix.traceLeft_isHermitian hρ_AB.1.isHermitian)
+        - Entropy.vonNeumannEntropy ρ_AB hρ_AB.1.isHermitian
+      ≤ Real.log dA + Real.log dB
+  linarith
+
+end AreaLaw
 
 end Entropy

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -300,3 +300,88 @@ later MPDO arguments.
     vanishes by Theorem~\ref{thm:entropy_fin_one_zero}.
     \uses{thm:entropy_strong_subadditivity, thm:trace_traceac_abc, thm:entropy_fin_one_zero}
 \end{proof}
+
+\section{Mutual information: monotonicity and area-law bound}
+
+The two inequalities below are the downstream MPDO-facing consequences
+of the entropy inequalities in this chapter. The monotonicity inequality
+is the strong-subadditivity content underlying the MPDO mutual-information
+monotonicity $I_L \le I_{L+1}$
+(arXiv:1606.00608, Proposition~C.1); the elementary area-law bound is
+the single-site entropy bound underlying the MPDO area-law bound
+$I_L \le 4\log D$ (arXiv:1606.00608, cited from the Wolf area-law
+bound). Both inequalities follow directly from strong subadditivity
+(taken as an axiom) and the single-system $S(\rho) \le \log D$ bound; neither
+introduces a new axiom.
+
+\begin{theorem}[Entropy nonnegativity for finite index sets]
+    \label{thm:entropy_nonneg_finite_index}
+    \lean{Entropy.vonNeumannEntropy_nonneg_of_posSemidef_trace_one}
+    \leanok
+    \uses{def:entropy_von_neumann_entropy}
+    For any PSD Hermitian matrix $\rho$ with $\tr(\rho) = 1$ on an
+    arbitrary finite index set, $S(\rho) \ge 0$. This is the
+    analogue of Theorem~\ref{thm:entropy_nonneg} for arbitrary finite
+    index sets: it does
+    not require the index set to be $\Fin{D}$, so it applies to
+    bipartite density matrices on
+    $\mathbb{C}^{d_A} \otimes \mathbb{C}^{d_B}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The eigenvalues of a PSD matrix are non-negative, and eigenvalues
+    of a trace-$1$ Hermitian matrix with non-negative eigenvalues are
+    bounded above by $1$ (each single eigenvalue is at most the total
+    sum). Apply $x\log x \le 0$ on $[0, 1]$ pointwise and sum.
+\end{proof}
+
+\begin{theorem}[Mutual information is monotone under enlargement]
+    \label{thm:mutual_information_monotone_tripartite}
+    \lean{Entropy.mutualInformation_monotone_tripartite}
+    \leanok
+    \uses{def:entropy_mutual_information, def:entropy_von_neumann_entropy,
+          def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC,
+          thm:entropy_strong_subadditivity}
+    For any tripartite density matrix $\rho_{ABC}$ on
+    $A \otimes B \otimes C$,
+    \[
+        I(A{:}B)_{\tr_C \rho_{ABC}} \;\le\; I(A{:}BC)_{\rho_{ABC}},
+    \]
+    where the left-hand side is the bipartite mutual information of
+    the reduced state $\rho_{AB} = \tr_C(\rho_{ABC})$ and the
+    right-hand side is evaluated by expanding
+    $I(A{:}BC) = S(\rho_A) + S(\rho_{BC}) - S(\rho_{ABC})$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:entropy_strong_subadditivity}
+    Expanding both sides in entropy form and cancelling the common
+    $S(\rho_A)$ term, the inequality reduces to strong subadditivity
+    $S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC})$. The
+    bipartite $B$-reduced state of $\rho_{AB}$ matches the tripartite
+    $B$-reduced state $\tr_{AC}(\rho_{ABC})$, ensuring the $S(\rho_B)$
+    term is the one supplied by Theorem~\ref{thm:entropy_strong_subadditivity}.
+\end{proof}
+
+\begin{theorem}[Elementary area-law bound on mutual information]
+    \label{thm:mutual_information_le_log_dim_add_log_dim}
+    \lean{Entropy.mutualInformation_le_log_dim_add_log_dim}
+    \leanok
+    \uses{def:entropy_mutual_information, thm:entropy_le_log_dim,
+          thm:entropy_nonneg_finite_index}
+    For a bipartite density matrix $\rho_{AB}$ on
+    $\mathbb{C}^{d_A} \otimes \mathbb{C}^{d_B}$ with $d_A, d_B \ge 1$
+    whose single-system reduced states are obtained by partial trace,
+    \[
+        I(A{:}B) \;\le\; \log d_A + \log d_B.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:entropy_le_log_dim, thm:entropy_nonneg_finite_index}
+    The reduced states are density matrices because partial trace preserves
+    positivity and trace. Combine $S(\rho_A) \le \log d_A$ and
+    $S(\rho_B) \le \log d_B$ (Theorem~\ref{thm:entropy_le_log_dim})
+    with $S(\rho_{AB}) \ge 0$
+    (Theorem~\ref{thm:entropy_nonneg_finite_index}).
+\end{proof}


### PR DESCRIPTION
### Motivation

- The MPDO/RFP formalization track (arXiv:1606.00608) requires entropy-level mutual-information inequalities before the translation-invariance specialization can be applied; issue #785 tracks this task.
- The strong subadditivity inequality already in `Entropy/MutualInformation.lean` provides a foundation; this PR adds the downstream consequence lemmas needed for the MPDO area-law bound.
- The blueprint entropy chapter (ch04b) was missing `\lean{}` and `\leanok` tags for these monotonicity and area-law results.

### Description

- `TNLean/Entropy/MutualInformation.lean`: adds three new declarations:
  - `vonNeumannEntropy_nonneg_of_posSemidef_trace_one` — polymorphic nonnegativity of the von Neumann entropy for arbitrary finite index types, generalizing the existing `Fin D`-indexed version.
  - `mutualInformation_monotone_tripartite` — the monotonicity inequality I(A:B) ≤ I(A:BC) for tripartite density matrices, derived from `strongSubadditivity` via S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC). This is the entropy-level statement underlying the MPDO monotonicity I_L ≤ I_{L+1} (arXiv:1606.00608, Prop C.1) before translation invariance is applied.
  - `mutualInformation_le_log_dim_add_log_dim` — the elementary bound I(A:B) ≤ log d_A + log d_B for a bipartite density matrix on `Fin d_A × Fin d_B` with density-matrix marginals, underlying the MPDO area-law bound I_L ≤ 4 log D (arXiv:1606.00608, line 1319) before bond-dimension specialization.
  - No new axioms introduced. `mutualInformation_monotone_tripartite` depends on the pre-existing `strong_subadditivity` axiom; the other two depend only on standard kernel axioms.
- `blueprint/src/chapter/ch04b_entropy.tex`: adds a section on monotonicity and area-law bounds with `\lean{}` declarations and proof sketches; three new `\leanok` entries for the declarations above.
- The MPDO-specific translation-invariance and bond-dimension specializations remain downstream tasks.

### Testing

- `lake env lean TNLean/Entropy/MutualInformation.lean`
- `lake build TNLean.Entropy.MutualInformation`
- `leanblueprint web`
- `leanblueprint checkdecls` — pre-existing failures in PEPS and parent-Hamiltonian declarations remain; no failures reported for the new entropy declarations.
- `git diff --check main...HEAD`

---
Closes #785

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new core entropy/mutual-information theorems (including SSA-derived inequalities) and generalizes entropy nonnegativity to arbitrary finite index types, which may affect downstream proofs and imports if statements/aliases change.
> 
> **Overview**
> Adds a polymorphic von Neumann entropy nonnegativity lemma `vonNeumannEntropy_nonneg_of_posSemidef_trace_one` (PSD + trace-one over any finite index type) and refactors the existing `Fin D`-specific nonnegativity/eigenvalue lemmas to reuse it.
> 
> Extends `Entropy/MutualInformation.lean` with two MPDO-facing consequences: `mutualInformation_monotone_tripartite` proving `I(A:B) ≤ I(A:BC)` for tripartite density matrices via strong subadditivity (plus a reduced-state trace identity), and `mutualInformation_le_log_dim_add_log_dim` giving the elementary bound `I(A:B) ≤ log dA + log dB` for bipartite density matrices.
> 
> Updates the blueprint (`ch04b_entropy.tex`) to document these new results with `\lean{}`/`\leanok` tags and proof sketches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843015edacfd9d1a6fed9fdcf1a0b6d7b256736f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->