### PR TITLE
doc(MPS/FT): separate coefficient nondecay source lines

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -66,8 +66,8 @@ core BNT predicate.
   Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.  Source-line tags used
   below: 217–246 (global modulus normalization), 264–279 (gauge-phase
   grouping rule), 271–301 (two-layer BNT display with raw `μ_{j,q}`),
-  1121–1132 (combined-family LI input), 1181–1188 (multiplicity recovery
-  via power-sum comparison).
+  1121–1132 (combined-family LI input), 1182 (BNT projection step),
+  and 1184–1188 (equal-case multiplicity recovery via power-sum comparison).
 * CPSV21: Cirac–Pérez-García–Schuch–Verstraete, *Matrix product states and
   projected entangled pair states: Concepts, symmetries, theorems*,
   Rev. Mod. Phys. **93**, 045003 (2021); arXiv:2011.12127.  Source-line tags
@@ -175,8 +175,8 @@ rules out the pathological cancellation that would obstruct the CPSV16 §II
 Step 1 coefficient-comparison argument: once combined-family LI isolates
 the `j`-th sector coefficient (CPSV16 lines 1121–1132), the surviving
 relation cannot be `0 = 0` for large `N`, so the multiplicity-recovery
-argument of CPSV16 lines 1181–1188 has a nonvanishing left-hand side to
-compare against.
+argument of CPSV16 lines 1184–1188 has a nonvanishing left-hand side to
+compare against after the line-1182 matching step.
 
 The proof feeds nonzero weights `P.weight j q ≠ 0` (from
 `P.weight_ne_zero`) into `geom_sum_eventually_zero`

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
@@ -14,10 +14,10 @@ import Mathlib.Data.Fintype.BigOperators
 /-!
 # Cesàro non-decay for finite power sums on the closed unit disk
 
-This module proves the pure-analytic lemma underlying the dominant-block
-coefficient non-decay step of the CPSV16 §II fundamental-theorem proof
-(lines 1181–1188).  The lemma is independent of MPS data and is stated in
-terms of complex numbers only.
+This module proves the pure-analytic lemma underlying the sector-coefficient
+non-decay input used when the CPSV16 §II.C proof projects onto a matched BNT
+block.  The lemma is independent of MPS data and is stated in terms of complex
+numbers only.
 
 ## Main result
 
@@ -52,9 +52,9 @@ limit is `≥ 1 > 0`, contradicting the previous limit `0`.
 ## References
 
 * CPSV16: Cirac–Pérez-García–Schuch–Verstraete, *Matrix Product Density
-  Operators*, arXiv:1606.00608.  Lines 246 (the `|μ_k| ≤ 1` and
-  `∃ k, |μ_k| = 1` normalization convention), 1181–1188 (the
-  dominant-block coefficient non-decay step that this lemma replaces).
+  Operators*, arXiv:1606.00608.  Line 246 gives the `|μ_k| ≤ 1` and
+  `∃ k, |μ_k| = 1` normalization convention; line 1182 is the BNT
+  projection step where a nonzero sector coefficient is needed.
 * Cesàro mean limit: `Filter.Tendsto.cesaro_smul` in
   `Mathlib.Analysis.Asymptotics.SpecificAsymptotics`.
 -/
@@ -73,10 +73,11 @@ For `z : ℂ` with `‖z‖ ≤ 1`, the average `(T)⁻¹ · ∑_{N < T} z^N` te
 * `0` if `z ≠ 1` (the partial sum is bounded by `2 / ‖z - 1‖`, divided
   by `T → ∞`).
 
-Paper context: this is the workhorse of the CPSV16 §II.A line-246
-dominant-block non-decay argument (lines 1181–1188).  The unit case
-captures the contribution of pairs with `μ_p · conj(μ_q) = 1`; the
-non-unit case shows all other pairs contribute `0`. -/
+Paper context: this is the analytic workhorse behind the line-246
+normalization when it is used in the CPSV16 §II.C line-1182 projection
+argument.  The unit case captures the contribution of pairs with
+`μ_p · conj(μ_q) = 1`; the non-unit case shows all other pairs contribute
+`0`. -/
 lemma tendsto_cesaro_geom (z : ℂ) (hz : ‖z‖ ≤ 1) :
     Tendsto (fun T : ℕ => (T : ℂ)⁻¹ * ∑ N ∈ Finset.range T, z ^ N)
       atTop (𝓝 (if z = 1 then 1 else 0)) := by
@@ -145,8 +146,9 @@ Let `μ : Fin r → ℂ` satisfy `‖μ q‖ ≤ 1` for every `q` and let some
 `N ↦ ∑ q, (μ q)^N` does not tend to `0`.
 
 This is the analytic lemma underlying the CPSV16 §II.A line-246
-"`|μ_k| ≤ 1` and `∃ k, |μ_k| = 1`" normalization convention and the
-dominant-block coefficient non-decay step at CPSV16 lines 1181–1188.
+"`|μ_k| ≤ 1` and `∃ k, |μ_k| = 1`" normalization convention when that
+normalization is read sector-by-sector in the CPSV16 §II.C line-1182
+projection argument.
 
 The proof is the elementary Cesàro-mean argument outlined in the module
 docstring. -/

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/WeakExistential.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/WeakExistential.lean
@@ -46,8 +46,8 @@ overlap does not decay)` is a stronger statement that requires induction on
   Theories*, arXiv:1606.00608.  Lines 287–301 (raw two-layer BNT display
   with coefficient `∑_q μ_{j,q}^N`), 1080–1091 (normal-tensor overlap
   dichotomy), 1121–1132 (combined-family linear-independence corollary),
-  1184–1188 (multiplicity recovery via raw power-sum coefficient comparison),
-  1172–1192 (equal-MPV corollary,
+  1182 (BNT projection/matching step), 1184–1188 (multiplicity recovery via
+  raw power-sum coefficient comparison), 1172–1192 (equal-MPV corollary,
   fixed `k_0` move-everything-else argument).
 * CPSV21: Cirac–Pérez-García–Schuch–Verstraete,
   *Matrix product states and projected entangled pair states*,

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -77,13 +77,18 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     \cite[Theorem~\texttt{Th:TIcanonical}]{PerezGarcia2007Matrix}
     in its given order. Lines~765--770 normalize the spectral radius and use a
     full-rank positive fixed point to obtain the unital gauge. Lines~771--783
-    show that the support of a singular positive fixed point is invariant.
-    Lines~785--815 split the finite-ring trace into the supported and
-    orthogonal summands. Lines~816--826 iterate this decomposition and use a
-    non-scalar fixed point to split further until the identity is the only
-    fixed point of each block. Finally, lines~827--832 repeat the fixed-point
-    argument for the dual map and diagonalize the resulting full-rank positive
-    fixed point by a unitary gauge.
+    derive the invariant support projection from a singular positive fixed
+    point, using the positivity contradiction in lines~775--783; this
+    projection is not a prepared hypothesis. Lines~785--815 split the
+    finite-ring trace into the supported and orthogonal summands. Lines~816--826
+    iterate this decomposition and use a non-scalar fixed point to split further
+    until the identity is the only fixed point of each block. Finally,
+    lines~827--832 repeat the fixed-point argument for the dual map and
+    diagonalize the resulting full-rank positive fixed point by a unitary gauge.
+    Thus a formal proof should reconstruct the proof from an arbitrary
+    translation-invariant representation in this order, using later
+    primitive-block or prepared-family results only after their hypotheses have
+    been obtained from the source argument.
 \end{remark}
 
 \begin{theorem}[Blocked CPSV canonical-form reduction]%

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -747,7 +747,7 @@ This section formalizes the analytic input that supplies, for any
 sector $j_0$ carrying a unit-modulus weight, the
 ``sector-$j_0$ coefficient does not asymptotically vanish''
 ingredient used in the matching step of
-\cite[\S~II, lines~1181--1188]{Cirac2017MPDO_AnnPhys}.
+\cite[\S~II.C, line~1182]{Cirac2017MPDO_AnnPhys}.
 The reduction is to a pure-analytic statement: a finite sum of $N$-th
 powers of complex numbers in the closed unit disk, with at least one
 unit-modulus summand, cannot tend to zero.
@@ -773,7 +773,8 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     sequence $N \mapsto \sum_{q=0}^{r-1} (\mu_q)^N$ does not tend to $0$
     as $N \to \infty$. This is the analytic content of the unit-block
     non-decay step at
-    \cite[\S~II.A, lines~246, 1181--1188]{Cirac2017MPDO_AnnPhys}.
+    \cite[\S~II.A, line~246 and \S~II.C, line~1182]
+        {Cirac2017MPDO_AnnPhys}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -807,7 +808,7 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
 
 \begin{remark}
     Used inside the matching theorem of
-    \cite[\S~II, lines 1181--1188]{Cirac2017MPDO_AnnPhys} this lemma
+    \cite[\S~II.C, line~1182]{Cirac2017MPDO_AnnPhys} this lemma
     supplies the non-decay step on $c_N^{(j_0)}$. The matching theorem takes
     the unit-modulus sector and witness as explicit parameters, mirroring
     the global character of the source normalization at


### PR DESCRIPTION
## Summary

This PR tightens source-line references in the BNT coefficient non-decay layer and records one additional PGVWC07 proof-order guardrail.

- separates the CPSV16 line-1182 BNT projection/matching step from the later equal-MPV power-sum comparison at lines 1184--1188
- retargets the Cesaro non-decay prose to the line-246 normalization as used in the line-1182 projection argument
- sharpens the Chapter 8 PGVWC07 remark: in `Papers/quant-ph_0608197/MPSarchive.tex`, lines 771--783 derive the invariant support projection from a singular positive fixed point, with the positivity contradiction in lines 775--783; prepared-block results may only be used after those hypotheses are obtained in the source proof order

No theorem statements, proof terms, imports, or blueprint declaration tags are changed.

Refs #1685.

## Validation

- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/WeakExistential.lean`
- `lake build TNLean`
- `leanblueprint web`
- `git diff --check`

`leanblueprint checkdecls` could not run locally because this checkout's plasTeX executable uses Python 3.14 while LeanBlueprint is installed for the Xcode Python 3.9 environment, so the LeanBlueprint plasTeX package did not emit `blueprint/lean_decls`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/comments and blueprint prose, with no modifications to theorem statements, proofs, or imports.
> 
> **Overview**
> Clarifies CPSV16 source anchors in the Sector-BNT coefficient non-decay layer by **separating the line-1182 BNT projection/matching step from the later lines 1184–1188 power-sum multiplicity recovery**, updating related references in `SectorBNT/Basic.lean`, `CesaroNonDecay.lean`, and `WeakExistential.lean`.
> 
> Retargets the Cesàro non-decay module commentary to describe its role in the **line-246 normalization as used in the line-1182 projection argument**, and updates the blueprint (`ch10_bnt.tex`) accordingly.
> 
> Adds a guardrail to the canonical-form blueprint remark (`ch08_canonical.tex`) emphasizing PGVWC07 proof-order fidelity: the invariant-support projection must be *derived* from a singular positive fixed point (via the positivity contradiction) before invoking later prepared/primitive-block results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e999c894832bdac41cfe1da4c3caaa3f82d6529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->