### PR TITLE
doc(MPS): anchor support projection proof order

### DIFF
--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -16,18 +16,26 @@ import TNLean.MPS.Structure.InvariantSubspaceDecomp
 /-!
 # Fixed point ⇒ invariant support projection (MPS transfer map)
 
-This module implements the standard “support projection argument” used in canonical-form
-existence proofs for matrix product states.
+This module implements the fixed-point-to-support-projection step used in
+canonical-form existence proofs for matrix product states.
 
 If $\rho \succeq 0$ is a fixed point of the transfer map
 $$E_A(X) = \sum_i A_i X A_i^\dagger,$$
 then the support projection $P = \mathrm{supp}(\rho)$ is invariant under each Kraus operator:
 $$(1-P) A_i P = 0.$$
 
+In PGVWC07 this is the first half of the singular-fixed-point case in the proof
+of Theorem `Th:TIcanonical`: lines 771–774 introduce the spectral support
+projection $P_R$, and lines 775–783 prove the invariant relation by a
+positivity contradiction.  The finite-ring trace split is the subsequent
+step, lines 785–815, and is formalized in `InvariantSubspaceDecomp`.  Thus the
+results here should be used before, not instead of, the source trace-splitting
+argument.
+
 References:
 * Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
-  proof lines 771–783 (support projector argument)
-* Cirac et al., arXiv:1606.00608, Section 2.3
+  proof lines 771–783 (singular positive fixed point gives an invariant
+  support projection)
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -313,6 +321,11 @@ private lemma ker_invariant_under_adjoint
 
 /-- If `ρ` is a PSD fixed point of the transfer map, then its support projection is invariant:
 `(1 - P) * A i * P = 0` for all Kraus operators `A i`.
+
+This is the formal counterpart of PGVWC07, Theorem `Th:TIcanonical`, proof
+lines 771–783.  The source writes the fixed point as
+`X = ∑_α λ_α |α⟩⟨α|`, lets `P_R` be its support projection, and proves
+`A_i P_R = P_R A_i P_R` by the positivity contradiction in lines 775–783.
 -/
 theorem lowerZero_of_posSemidef_fixedPoint
     (A : MPSTensor d D)
@@ -398,10 +411,10 @@ iterating the canonical-form splitting step.
 
 References:
 * Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
-  proof lines 771–815: invariant support, finite-ring trace split, and strict
-  decrease of the recursive blocks.
-* Cirac et al., arXiv:1606.00608, Section 2.3: the same argument in a slightly
-  different presentation.
+  proof lines 771–783 for the support projection and lines 785–815 for the
+  finite-ring trace split whose recursive blocks have smaller dimensions.
+* Cirac et al., arXiv:1606.00608, lines 201–217: invariant subspaces are split
+  into diagonal blocks in the canonical-form construction.
 -/
 
 section SupportProjNontriviality
@@ -486,8 +499,10 @@ explicit two-block block-diagonal tensor which is MPV-equivalent to `A`.
 
 References:
 * Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
-  proof lines 771–783 (support projection argument)
-* Cirac et al., arXiv:1606.00608, Section 2.3
+  proof lines 771–783 for the support projection and lines 785–815 for the
+  finite-ring trace split.
+* Cirac et al., arXiv:1606.00608, lines 201–217 for the corresponding
+  invariant-subspace block splitting in the canonical-form construction.
 -/
 
 /-- If `ρ` is a PSD fixed point of the transfer map, then `A` is MPV-equivalent to a
@@ -527,8 +542,10 @@ The proof composes:
 
 References:
 * Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
-  proof lines 771–815
-* Cirac et al., arXiv:1606.00608, Section 2.3
+  proof lines 771–783 for deriving the invariant support projection and
+  lines 785–815 for the trace split into two smaller blocks.
+* Cirac et al., arXiv:1606.00608, lines 201–217 for the invariant-subspace
+  direct-sum step in the canonical-form construction.
 -/
 theorem exists_twoBlock_decomp_of_posSemidef_fixedPoint_strict
     (A : MPSTensor d D)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -297,6 +297,12 @@ definitions stated below.
     \lean{MPSTensor.lowerZero_of_posSemidef_fixedPoint}
     \leanok
     \uses{def:transfer_map}
+    % Source anchor:
+    % Papers/quant-ph_0608197/MPSarchive.tex:771--774 introduce the support
+    % projection of a singular positive fixed point in the proof of
+    % Th:TIcanonical, and lines 775--783 prove the invariant relation
+    % A_i P_R = P_R A_i P_R by positivity.  The finite-ring trace split begins
+    % only afterward, at lines 785--815.
     Let $\rho \ge 0$ be a fixed point of $\E_A$,
     and let $P$ be the support projection of $\rho$.
     Then for all~$i$, $(\Id - P) A^i P = 0$:
@@ -311,6 +317,11 @@ definitions stated below.
     for each~$i$.
     Since $\rho$ is supported on the range of $P$,
     this forces $(\Id - P) A^i P = 0$.
+    This is the formal counterpart of the singular fixed-point step in
+    \cite[Theorem~\texttt{Th:TIcanonical}, lines~771--783]
+        {PerezGarcia2007Matrix}: the source derives the support projection from
+    the fixed point and proves the invariant relation before the trace split of
+    lines~785--815.
 
     This is the finite-dimensional version of~\cite[Proposition~6.10]{Wolf2012Quantum}
     (``Stationary subspaces'': the support projection
@@ -325,6 +336,10 @@ definitions stated below.
     \lean{MPSTensor.exists_twoBlock_decomp_of_posSemidef_fixedPoint_strict}
     \leanok
     \uses{def:transfer_map, def:same_mpv2}
+    % Source anchor:
+    % Papers/quant-ph_0608197/MPSarchive.tex:771--783 supplies the invariant
+    % support projection from a singular positive fixed point; lines 785--815
+    % split the finite-ring trace into supported and orthogonal summands.
     If the transfer map has a PSD fixed point $\rho$ that is
     \emph{not} positive definite (i.e.\ $\rho$ has a nontrivial
     kernel), then there exist MPS tensors $A_1, A_2$ of smaller
@@ -349,6 +364,9 @@ definitions stated below.
     of the diagonal-block traces, so the block-diagonal tensor
     obtained by discarding the off-diagonal blocks has the same MPV
     coefficients as the conjugated tensor, and hence as~$A$.
+    These are precisely the two halves of the singular fixed-point step in
+    \cite[Theorem~\texttt{Th:TIcanonical}, lines~771--815]
+        {PerezGarcia2007Matrix}.
 \end{proof}
 
 \section{Iterated reduction}


### PR DESCRIPTION
## Summary

This PR tightens the PGVWC07 source anchors for the support-projection step in the canonical-form reduction.

- records that `FixedPointProjection.lean` formalizes the singular fixed-point step of `Papers/quant-ph_0608197/MPSarchive.tex`, lines 771--783
- makes explicit that lines 775--783 give the positivity contradiction proving `A_i P_R = P_R A_i P_R`
- separates this from the finite-ring trace split at lines 785--815, which belongs to the invariant-subspace decomposition step
- adds matching source-anchor comments and proof prose in Chapter 8

No theorem statements, proof terms, imports, or blueprint declaration tags are changed.

Refs #1685.

## Validation

- `lake env lean TNLean/MPS/Irreducible/FixedPointProjection.lean`
- `leanblueprint web`
- `git diff --check`

`leanblueprint checkdecls` was not run locally because this checkout's plasTeX executable uses Python 3.14 while LeanBlueprint is installed for the Xcode Python 3.9 environment, so the LeanBlueprint plasTeX package does not emit `blueprint/lean_decls`. The PR does not modify any `\lean{...}`, `\leanok`, or `\uses{...}` tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/comment-only changes that do not modify Lean theorem statements, proofs, or interfaces.
> 
> **Overview**
> Clarifies that `FixedPointProjection.lean` formalizes **only** the singular PSD fixed-point  invariant support projection step of PGVWC07 (lines 771783), and explicitly separates it from the subsequent finite-ring trace split (lines 785815) handled in `InvariantSubspaceDecomp`.
> 
> Updates the Chapter 8 blueprint (`ch08_canonical.tex`) with matching source-anchor comments and proof prose to reflect the same proof order and line-range attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a23c3f1d14eceafe254f436543daca7369ee2f1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->