### PR TITLE
doc(MPS): address support projection review

### DIFF
--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -24,16 +24,16 @@ $$E_A(X) = \sum_i A_i X A_i^\dagger,$$
 then the support projection $P = \mathrm{supp}(\rho)$ is invariant under each Kraus operator:
 $$(1-P) A_i P = 0.$$
 
-In PGVWC07 this is the first half of the singular-fixed-point case in the proof
-of Theorem `Th:TIcanonical`: lines 771–774 introduce the spectral support
-projection $P_R$, and lines 775–783 prove the invariant relation by a
-positivity contradiction.  The finite-ring trace split is the subsequent
-step, lines 785–815, and is formalized in `InvariantSubspaceDecomp`.  Thus the
-results here should be used before, not instead of, the source trace-splitting
-argument.
+In Pérez-García, Verstraete, Wolf, and Cirac, this is the first half of the
+singular-fixed-point case in the proof of Theorem Th:TIcanonical: lines 771–774
+introduce the spectral support projection $P_R$, and lines 775–783 prove the
+invariant relation by a positivity contradiction.  The finite-ring trace split
+is the subsequent step, lines 785–815, and is handled by the
+invariant-subspace decomposition results.  Thus the results here should be used
+before, not instead of, the source trace-splitting argument.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
   proof lines 771–783 (singular positive fixed point gives an invariant
   support projection)
 -/
@@ -322,10 +322,11 @@ private lemma ker_invariant_under_adjoint
 /-- If `ρ` is a PSD fixed point of the transfer map, then its support projection is invariant:
 `(1 - P) * A i * P = 0` for all Kraus operators `A i`.
 
-This is the formal counterpart of PGVWC07, Theorem `Th:TIcanonical`, proof
-lines 771–783.  The source writes the fixed point as
-`X = ∑_α λ_α |α⟩⟨α|`, lets `P_R` be its support projection, and proves
-`A_i P_R = P_R A_i P_R` by the positivity contradiction in lines 775–783.
+This proves the support-projection assertion in Pérez-García et al., Theorem
+Th:TIcanonical, proof lines 771–783.  The source writes the fixed point as
+$X = \sum_\alpha \lambda_\alpha |\alpha\rangle\langle\alpha|$, lets $P_R$ be
+its support projection, and proves $A_i P_R = P_R A_i P_R$ by the positivity
+contradiction in lines 775–783.
 -/
 theorem lowerZero_of_posSemidef_fixedPoint
     (A : MPSTensor d D)
@@ -410,7 +411,7 @@ matrix, and are essential for the "strict dimension decrease" argument used when
 iterating the canonical-form splitting step.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
   proof lines 771–783 for the support projection and lines 785–815 for the
   finite-ring trace split whose recursive blocks have smaller dimensions.
 * Cirac et al., arXiv:1606.00608, lines 201–217: invariant subspaces are split
@@ -498,7 +499,7 @@ projection $P := \mathrm{supp}(\rho)$ is invariant under the Kraus operators `(A
 explicit two-block block-diagonal tensor which is MPV-equivalent to `A`.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
   proof lines 771–783 for the support projection and lines 785–815 for the
   finite-ring trace split.
 * Cirac et al., arXiv:1606.00608, lines 201–217 for the corresponding
@@ -541,7 +542,7 @@ The proof composes:
 4. `exists_twoBlock_decomp_of_lowerZero_strict` — strict dimension bounds.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
   proof lines 771–783 for deriving the invariant support projection and
   lines 785–815 for the trace split into two smaller blocks.
 * Cirac et al., arXiv:1606.00608, lines 201–217 for the invariant-subspace

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -317,11 +317,6 @@ definitions stated below.
     for each~$i$.
     Since $\rho$ is supported on the range of $P$,
     this forces $(\Id - P) A^i P = 0$.
-    This is the formal counterpart of the singular fixed-point step in
-    \cite[Theorem~\texttt{Th:TIcanonical}, lines~771--783]
-        {PerezGarcia2007Matrix}: the source derives the support projection from
-    the fixed point and proves the invariant relation before the trace split of
-    lines~785--815.
 
     This is the finite-dimensional version of~\cite[Proposition~6.10]{Wolf2012Quantum}
     (``Stationary subspaces'': the support projection
@@ -340,10 +335,10 @@ definitions stated below.
     % Papers/quant-ph_0608197/MPSarchive.tex:771--783 supplies the invariant
     % support projection from a singular positive fixed point; lines 785--815
     % split the finite-ring trace into supported and orthogonal summands.
-    If the transfer map has a PSD fixed point $\rho$ that is
-    \emph{not} positive definite (i.e.\ $\rho$ has a nontrivial
-    kernel), then there exist MPS tensors $A_1, A_2$ of smaller
-    bond dimensions such that the two-block tensor
+    If the transfer map has a nonzero PSD fixed point $\rho$ that is
+    \emph{not} positive definite (i.e.\ $\rho$ has a nontrivial kernel), then
+    there exist MPS tensors $A_1, A_2$ of smaller bond dimensions such that the
+    two-block tensor
     $A_1 \oplus A_2$ generates the same MPV family as~$A$:
     $\mc{V}(A) = \mc{V}(A_1 \oplus A_2)$.
 \end{theorem}
@@ -364,9 +359,6 @@ definitions stated below.
     of the diagonal-block traces, so the block-diagonal tensor
     obtained by discarding the off-diagonal blocks has the same MPV
     coefficients as the conjugated tensor, and hence as~$A$.
-    These are precisely the two halves of the singular fixed-point step in
-    \cite[Theorem~\texttt{Th:TIcanonical}, lines~771--815]
-        {PerezGarcia2007Matrix}.
 \end{proof}
 
 \section{Iterated reduction}


### PR DESCRIPTION
Follow-up to #1908, addressing the blueprint/prose review comments while keeping the source order for the singular fixed-point step faithful to `Papers/quant-ph_0608197/MPSarchive.tex`.

Changes:
- Add the missing nonzero fixed-point hypothesis to the blueprint statement of `thm:two_block_decomp`, matching `exists_twoBlock_decomp_of_posSemidef_fixedPoint_strict`.
- Remove the newly added visible source-mapping prose from the blueprint proof; the original-paper locations remain in `%` comments.
- Replace the newly introduced PGVWC07 shorthand, backticked paper label, and backticked paper formulas in Lean docstrings with ordinary mathematical prose and TeX formulas.

Refs #1685.

Validation:
- `lake env lean TNLean/MPS/Irreducible/FixedPointProjection.lean`
- `git diff --check`
- `cd blueprint && leanblueprint web` (exits 0 locally; the existing local plasTeX loader still reports `ModuleNotFoundError: No module named 'leanblueprint'` warnings before rendering)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/blueprint-only updates; the only semantic change is tightening a theorem statement to require a nonzero fixed point, matching the existing Lean theorem hypotheses.
> 
> **Overview**
> Updates Lean docstrings in `FixedPointProjection.lean` to replace the `PGVWC07` shorthand/backticked labels with standard prose and TeX-style formulas, clarifying the mapping to Pérez-García et al. without changing proofs.
> 
> Adjusts the blueprint canonical-form chapter: `thm:two_block_decomp` now explicitly assumes the PSD fixed point `ρ ≠ 0` (aligning with `exists_twoBlock_decomp_of_posSemidef_fixedPoint_strict`), and removes recently-added visible source-location prose from proofs while keeping source anchors as comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a4c73b996e6ddae18e014c07948efbc45734d8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->