### PR TITLE
doc(MPS): cite invariant subspace source lines

### DIFF
--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -19,14 +19,15 @@ equivalent to a block-diagonal tensor with two smaller bond dimensions.
 This is the "invariant subspace ⇒ direct sum decomposition" step used in canonical-form existence
 arguments before blocking/normalization.
 
-## External input — Perez-Garcia et al. canonical-form recursion
+## External input — Pérez-García et al. canonical-form recursion
 
 This file formalizes the direct-sum decomposition step once an invariant
-projection has already been obtained.  For PGVWC07 this is deliberately the
-second part of the argument, not a replacement for the positive fixed-point
-argument that produces the projection:
+projection has already been obtained.  In Pérez-García, Verstraete, Wolf, and
+Cirac this is deliberately the second part of the singular fixed-point
+argument, not a replacement for the positive fixed-point argument that produces
+the projection:
 
-> **Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+> **Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
 > proof lines 771–815.**
 > The source first derives the invariant support projection from a singular
 > positive fixed point in lines 771–783.  The results below take such an
@@ -36,7 +37,7 @@ argument that produces the projection:
 > (`exists_twoBlock_decomp_of_lowerZero_strict`) guarantees termination of the
 > canonical-form recursion.
 
-> **Cirac et al., arXiv:1606.00608, Section 2.3.**
+> **Cirac et al., arXiv:1606.00608, lines 201–217.**
 > The same step in the "canonical forms" reduction: invariant projection ⇒
 > block upper-triangular ⇒ drop strict off-diagonal blocks ⇒ explicit 2-block
 > direct sum.  This is the Wolf/Cirac/Verstraete canonical-form reduction.
@@ -429,9 +430,10 @@ both returned block dimensions are *strictly smaller* than `D`. This is the key
 ingredient for proving termination of the canonical-form recursion.
 
 References:
-* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
+* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
   proof lines 771–815: invariant support and finite-ring trace split.
-* Cirac et al., arXiv:1606.00608, Section 2.3: the same step in the "canonical forms" reduction.
+* Cirac et al., arXiv:1606.00608, lines 201–217: the corresponding
+  invariant-subspace step in the "canonical forms" reduction.
 -/
 
 section StrictDimDecrease

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -23,9 +23,9 @@ arguments before blocking/normalization.
 
 This file formalizes the direct-sum decomposition step once an invariant
 projection has already been obtained.  In Pérez-García, Verstraete, Wolf, and
-Cirac this is deliberately the second part of the singular fixed-point
-argument, not a replacement for the positive fixed-point argument that produces
-the projection:
+Cirac this is deliberately the trace-splitting part of the singular positive
+fixed-point argument, not a replacement for the preceding singular positive
+fixed-point step that produces the projection:
 
 > **Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
 > proof lines 771–815.**


### PR DESCRIPTION
This is a source-faithfulness prose cleanup for the canonical-form proof chain tracked in #1685.

The invariant-subspace decomposition file already separated the two steps in `Papers/quant-ph_0608197/MPSarchive.tex`: first the singular positive fixed point gives the invariant support projection, then the finite-ring trace is split on the support and its orthogonal complement. This PR makes the reader-facing source prose match that separation more carefully.

Changes:
- Replace PGVWC07 shorthand and the backticked source label with an ordinary citation to Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof lines 771--815.
- Keep the line split explicit: lines 771--783 produce the invariant support projection, and lines 785--815 perform the trace split into smaller blocks.
- Replace the loose CPSV section reference with the exact arXiv:1606.00608 line range 201--217 for the corresponding invariant-subspace reduction.

No theorem statements, proof terms, imports, or blueprint tags change.

Refs #1685.

Validation:
- `lake env lean TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits update citations and clarify which parts of the external proofs correspond to the formalized lemmas, with no changes to theorem statements or proof terms.
> 
> **Overview**
> Updates the module docstring and the strict-dimension-decrease section comments in `TNLean/MPS/Structure/InvariantSubspaceDecomp.lean` to use correct author names/diacritics and to cite precise line ranges in the external sources.
> 
> Clarifies that the file formalizes the *trace-splitting* step (after obtaining an invariant projection) and replaces the previous looser references with explicit citations to quant-ph/0608197 (lines 771–815, split 771–783 vs 785–815) and arXiv:1606.00608 (lines 201–217).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5fa8ada5278bb368ab6911d2f35a0d0a10a7c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->