### PR TITLE
doc(blueprint): relocate direct-sum FT reductions

### DIFF
--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -16,14 +16,12 @@ and the BNT permutation arguments of Chapter~\ref{ch:bnt}.
 The common after-blocking reductions of
 Chapter~\ref{ch:canonical_after_blocking} are placed immediately before this
 chapter because they produce the common primitive block decompositions used in
-the equal-MPV comparison. The auxiliary direct-sum reductions remain in
-Section~\ref{sec:ft_auxiliary_from_ch08}, inside the proof chapter, because
-they turn the single-block Fundamental Theorem into the block-diagonal
-gauge statements used after the block correspondence has been fixed. Thus the
-chapter boundary separates the preparation of the common blocked surface from
-the later assembly of gauges and MPV equalities; it does not place any
-channel-representation or semigroup material among the hypotheses of the
-aperiodic Fundamental Theorem.
+the equal-MPV comparison. The direct-sum gauge assembly statements belong to
+the algebraic assembly layer of Chapter~\ref{ch:algebraic_ft}, where the
+block correspondence is already fixed. Thus the chapter boundary separates the
+preparation of the common blocked surface from the later assembly of gauges and
+MPV equalities; it does not place any channel-representation or semigroup
+material among the hypotheses of the aperiodic Fundamental Theorem.
 
 The theorems in this chapter follow the approach of
 \cite{Cirac2017MPDO_AnnPhys}:
@@ -73,7 +71,7 @@ Chapter~\ref{ch:canonical_after_blocking}. The BNT matching and coefficient
 comparison are developed in Chapter~\ref{ch:bnt}; the per-block gauge-phase
 witnesses and the block-diagonal gauge are then assembled as
 Theorem~\ref{thm:multi_block_global} of
-Section~\ref{sec:ft_auxiliary_from_ch08}.
+Chapter~\ref{ch:algebraic_ft}.
 
 % Audit 2026-05-20 (#328): the old equal-case blockers #944, #1133, #1170,
 % and #1178 are closed.  This source corollary nevertheless stays not ready
@@ -947,93 +945,16 @@ facts used to recover the lists of weights from those power sums.
     componentwise power-sum identities.
 \end{remark}
 
-\section{Auxiliary reductions for the Fundamental Theorem}%
-\label{sec:ft_auxiliary_from_ch08}
+\section{Overlap and BNT preparation for the Fundamental Theorem}%
+\label{sec:ft_overlap_bnt_preparation}
 
-The following auxiliary results are reduction steps of the Fundamental-Theorem
-proof rather than statements about canonical-form decompositions. They are
-collected here because they turn blockwise single-block conclusions into
-statements about the direct-sum tensors appearing in the proof. In particular,
-this section is not part of the after-blocking canonical-form reduction: the
-block decomposition is already fixed, and the task here is to assemble the
-resulting gauges and MPV equalities.
-
-\subsection{Block-diagonal corollaries of the single-block theorem}%
-\label{subsec:ft_block_sum_corollaries}
-
-\begin{remark}
-    See Definition~\ref{def:block_diagonal_tensor} for the formalized block-diagonal tensor construction.
-\end{remark}
-
-\begin{theorem}[Per-block single-block FT]\label{thm:multi_block_ft}
-    \lean{MPSTensor.fundamentalTheorem_multiBlock_blocks}
-    \leanok
-    \uses{def:block_diagonal_tensor, def:injective}
-    If all block tensors $A_k$ are injective and the per-block
-    same-MPV condition holds ($A_k$ and $B_k$ generate the same
-    MPV family for each~$k$),
-    then each pair $(A_k, B_k)$ is gauge equivalent.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:ft_single}
-    Apply the single-block fundamental theorem
-    (Theorem~\ref{thm:ft_single}) to each block independently.
-\end{proof}
-
-\begin{remark}[Per-block restatement, not the multi-block paper theorem]
-    This is a block-sum reformulation of the per-block injective single-block FT:
-    the block pairing $(A_k, B_k)$ is assumed already given and the blocks already
-    matched. It is not the multi-block fundamental theorem of
-    \cite[Theorem~II.1, lines~349--352]{Cirac2017MPDO_AnnPhys}, which derives the
-    block matching and permutation from only the global same-MPV hypothesis.
-\end{remark}
-
-\begin{theorem}[Per-block same MPV implies global same MPV]\label{thm:block_to_global_mpv}
-    \lean{MPSTensor.sameMPV_toTensorFromBlocks_of_blockSameMPV}
-    \leanok
-    \uses{def:block_diagonal_tensor, def:same_mpv}
-    If $A_k$ and $B_k$ generate the same MPV family for each
-    block~$k$, then the block-diagonal tensors
-    $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
-    also generate the same MPV family.
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:mpv_decomposition}
-    By the MPV decomposition (Theorem~\ref{thm:mpv_decomposition}),
-    each MPV is $\sum_k \mu_k^N V^{(N)}(A_k)_\sigma$.
-    Per-block equality of MPV coefficients gives global equality.
-\end{proof}
-
-\begin{remark}[Direct-sum congruence]
-    This is a direct-sum congruence statement: per-block MPV equality lifts to
-    global MPV equality via the block-diagonal decomposition formula.
-\end{remark}
-
-\begin{theorem}[Global multi-block fundamental theorem]\label{thm:multi_block_global}
-    \lean{MPSTensor.fundamentalTheorem_multiBlock_global}
-    \leanok
-    \uses{def:block_diagonal_tensor, def:injective, def:same_mpv, thm:multi_block_ft}
-    If each block $A_k$ is injective and each pair $(A_k, B_k)$ generates
-    the same MPV family, then the block-diagonal tensors
-    $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$ are gauge equivalent.
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:multi_block_ft}
-    Apply the per-block single-block fundamental theorem
-    (Theorem~\ref{thm:multi_block_ft}) to obtain blockwise gauge
-    equivalences from injectivity and equality of MPV families, then
-    combine them into a global gauge for the block-diagonal tensors.
-\end{proof}
-
-\begin{remark}[Block-diagonal gauge assembly, not the FT block-matching theorem]
-    This combines per-block gauges into a block-diagonal gauge for the global
-    assembled tensor, given pre-matched same-index blocks. It is not the FT
-    block-matching theorem: it does not derive the block pairing or permutation
-    from a global same-MPV hypothesis; the block correspondence is assumed in
-    advance.
-\end{remark}
+The following results are source-relevant overlap and basis-of-normal-tensors
+preparation steps. They are not part of the after-blocking canonical-form
+reduction, and they are not direct consequences of the injective single-block
+Fundamental Theorem. Instead, they supply the overlap dichotomy, phase
+normalization, and eventual linear independence used when passing from normal
+blocks to BNT representatives. The purely same-index direct-sum assembly
+statements are collected in Chapter~\ref{ch:algebraic_ft}.
 
 \subsection{Proportional single-block ingredient}%
 \label{subsec:ft_proportional_single_block}

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1064,6 +1064,86 @@ decomposition.
     $\bigoplus_k \mu_A(k) A_k$ to $\bigoplus_k \mu_B(k) B_k$.
 \end{proof}
 
+\subsection{Same-index direct-sum consequences of the single-block theorem}%
+\label{subsec:ft_block_sum_corollaries}
+
+\begin{remark}
+    See Definition~\ref{def:block_diagonal_tensor} for the formalized
+    block-diagonal tensor construction.  The results in this subsection assume
+    that the block correspondence has already been fixed; they do not prove
+    \cite[Theorem~II.1]{Cirac2017MPDO_AnnPhys}.
+\end{remark}
+
+\begin{theorem}[Per-block single-block FT]\label{thm:multi_block_ft}
+    \lean{MPSTensor.fundamentalTheorem_multiBlock_blocks}
+    \leanok
+    \uses{def:block_diagonal_tensor, def:injective}
+    If all block tensors $A_k$ are injective and the per-block
+    same-MPV condition holds ($A_k$ and $B_k$ generate the same
+    MPV family for each~$k$),
+    then each pair $(A_k, B_k)$ is gauge equivalent.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ft_single}
+    Apply the single-block Fundamental Theorem
+    (Theorem~\ref{thm:ft_single}) to each block independently.
+\end{proof}
+
+\begin{remark}[Per-block restatement, not the multi-block paper theorem]
+    This is a block-sum reformulation of the per-block injective single-block FT:
+    the block pairing $(A_k, B_k)$ is assumed already given and the blocks already
+    matched. It is not the multi-block Fundamental Theorem of
+    \cite[Theorem~II.1, lines~349--352]{Cirac2017MPDO_AnnPhys}, which derives the
+    block matching and permutation from only the global same-MPV hypothesis.
+\end{remark}
+
+\begin{theorem}[Per-block same MPV implies global same MPV]\label{thm:block_to_global_mpv}
+    \lean{MPSTensor.sameMPV_toTensorFromBlocks_of_blockSameMPV}
+    \leanok
+    \uses{def:block_diagonal_tensor, def:same_mpv}
+    If $A_k$ and $B_k$ generate the same MPV family for each
+    block~$k$, then the block-diagonal tensors
+    $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
+    also generate the same MPV family.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:mpv_decomposition}
+    By the MPV decomposition (Theorem~\ref{thm:mpv_decomposition}),
+    each MPV is $\sum_k \mu_k^N V^{(N)}(A_k)_\sigma$.
+    Per-block equality of MPV coefficients gives global equality.
+\end{proof}
+
+\begin{remark}[Direct-sum congruence]
+    This is a direct-sum congruence statement: per-block MPV equality lifts to
+    global MPV equality via the block-diagonal decomposition formula.
+\end{remark}
+
+\begin{theorem}[Gauge equivalence for same-index direct sums]\label{thm:multi_block_global}
+    \lean{MPSTensor.fundamentalTheorem_multiBlock_global}
+    \leanok
+    \uses{def:block_diagonal_tensor, def:injective, def:same_mpv, thm:multi_block_ft}
+    If each block $A_k$ is injective and each pair $(A_k, B_k)$ generates
+    the same MPV family, then the block-diagonal tensors
+    $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$ are gauge equivalent.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:multi_block_ft}
+    Apply the per-block single-block Fundamental Theorem
+    (Theorem~\ref{thm:multi_block_ft}) to obtain blockwise gauge
+    equivalences from injectivity and equality of MPV families, then
+    combine them into a global gauge for the block-diagonal tensors.
+\end{proof}
+
+\begin{remark}[Block-diagonal gauge assembly, not the FT block-matching theorem]
+    This combines per-block gauges into a block-diagonal gauge for the global
+    assembled tensor, given pre-matched same-index blocks. It is not the FT
+    block-matching theorem: it does not derive the block pairing or permutation
+    from a global same-MPV hypothesis; the block correspondence is assumed in
+    advance.
+\end{remark}
+
 \begin{lemma}[Gauge equivalence of direct sums from per-block MPV equality]%
     \label{lem:fundamentalTheorem_multiBlock_full}
     \lean{MPSTensor.fundamentalTheorem_multiBlock_full}


### PR DESCRIPTION
### Motivation

Compiled Section 13.4 mixed two different kinds of statements: same-index direct-sum consequences of the injective single-block theorem, and source-relevant overlap/BNT preparation for the CPSV16 Fundamental Theorem route. This made the proof chapter look as if assumed per-block matching were part of the source block-matching theorem.

### Description

- Move the per-block single-block FT corollaries and same-index direct-sum gauge assembly to the algebraic direct-sum assembly layer in Chapter 13.
- Retitle the global statement as gauge equivalence for same-index direct sums, avoiding the misleading impression that it proves the CPSV16 block-matching theorem.
- Retain the proportional, unit-phase, and BNT phase-class inputs in the Fundamental Theorem proof chapter, with prose explaining that these are overlap and BNT preparation steps, not single-block FT consequences.
- Update cross-references from the proof chapter to point at Chapter 13 for direct-sum assembly.

### Testing

- `cd blueprint && leanblueprint web`
- `git diff --check -- blueprint/src/chapter/ch11_fundamental_theorem_proof.tex blueprint/src/chapter/ch13_algebraic_ft.tex`
- `cd blueprint && leanblueprint checkdecls` still fails on the existing PEPS/parent-Hamiltonian missing-declaration baseline; it did not report a new issue specific to the moved entries.

---
Closes #1905

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only refactor that moves/renames theorem statements and section structure without changing Lean declarations or mathematical content; main risk is broken LaTeX cross-references/labels.
> 
> **Overview**
> Clarifies the chapter boundary between the CPSV Fundamental Theorem proof and the algebraic “assembly” layer by **moving same-index direct-sum corollaries** (per-block single-block FT, per-block-to-global MPV lifting, and block-diagonal gauge assembly) out of `ch11_fundamental_theorem_proof.tex` and into `ch13_algebraic_ft.tex`.
> 
> Retitles `ch11`’s removed “auxiliary reductions” section to **“Overlap and BNT preparation”**, updates surrounding prose to emphasize these remaining lemmas are overlap/BNT prerequisites (not consequences of the single-block FT), and updates cross-references so direct-sum gauge assembly is now cited from Chapter `ch:algebraic_ft` (including renaming the global statement to `Gauge equivalence for same-index direct sums`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 681190e83c65c7711db42b4300811f6d13c5078e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->