### PR TITLE
doc(MPS): normalize canonical source labels

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -88,7 +88,7 @@ The formal statement:
 ## External input — Pérez-García et al. invariant subspace decomposition
 
 The iterated invariant-projection splitting in arXiv:1606.00608, lines
-201–217 (Wolf/Cirac/Verstraete canonical-form reduction), is formalized in
+201–219 (Wolf/Cirac/Verstraete canonical-form reduction), is formalized in
 `TNLean.MPS.Structure.InvariantSubspaceDecomp`.
 This external input provides:
 

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -45,14 +45,15 @@ What is **not** yet proved here:
 
 Accordingly, this file gives reduction lemmas and explicit conditional statements,
 **not** a complete canonical-form existence theorem for arbitrary input tensors.
-Relative to PGVWC07, Theorem `Th:TIcanonical`, lines 742–763, the missing
-source-level conclusion is the single theorem that starts from an arbitrary
-translation-invariant representation and simultaneously constructs positive
-weights, unital blocks, diagonal full-rank dual fixed points, uniqueness of the
-identity fixed point for each block transfer map, and the stated bond-dimension
-bound. The audit boundary is recorded in
+Relative to Pérez-García, Verstraete, Wolf, and Cirac, Theorem
+Th:TIcanonical, lines 742–763, the missing source-level conclusion is the
+single theorem that starts from an arbitrary translation-invariant
+representation and simultaneously constructs positive weights, unital blocks,
+diagonal full-rank dual fixed points, uniqueness of the identity fixed point for
+each block transfer map, and the stated bond-dimension bound. The audit
+boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
-For PGVWC07 itself, the faithful proof order is the one in
+For Pérez-García, Verstraete, Wolf, and Cirac, the faithful proof order is the one in
 `Papers/quant-ph_0608197/MPSarchive.tex`: lines 765–770 for spectral-radius
 normalization and the full-rank fixed-point gauge, lines 771–815 for deriving
 the invariant support from a singular positive fixed point and then splitting
@@ -84,14 +85,15 @@ The formal statement:
 > `wordSpan A 1 = ⊤`).  This proves the hardest direction
 > in the Sanz–Pérez-García–Wolf–Cirac primitivity equivalence.
 
-## External input — Perez-Garcia et al. invariant subspace decomposition
+## External input — Pérez-García et al. invariant subspace decomposition
 
-The iterated invariant-projection splitting in Section 2.3 (Wolf/Cirac/Verstraete
-canonical-form reduction) is formalized in `TNLean.MPS.Structure.InvariantSubspaceDecomp`.
+The iterated invariant-projection splitting in arXiv:1606.00608, lines
+201–217 (Wolf/Cirac/Verstraete canonical-form reduction), is formalized in
+`TNLean.MPS.Structure.InvariantSubspaceDecomp`.
 This external input provides:
 
-> **Perez-Garcia et al., quant-ph/0608197, proof of Theorem
-> `Th:TIcanonical` (lines 765–833).**
+> **Pérez-García et al., quant-ph/0608197, proof of Theorem
+> Th:TIcanonical, lines 765–833.**
 > An invariant orthogonal projection `P` on the bond space (satisfying
 > `(1-P) A_i P = 0` for all `i`) yields an MPV-equivalent two-block direct-sum
 > tensor with strictly smaller block dimensions.

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -295,15 +295,15 @@ Every nonzero block satisfies:
 
 The MPV of `A` equals the zero-block contribution plus the weighted nonzero-block sum.
 
-**Scope restriction (PGVWC07 canonical-form proof step):** PGVWC07,
-Theorem `Th:TIcanonical`, lines 765--770 use a full-rank positive fixed point
-to gauge a block into the unital orientation
-`∑ i, B i * (B i)ᴴ = 1`. This theorem supplies the dual left-canonical TP
-orientation after the all-zero-block separation. It is therefore not the full
-PGVWC07 translation-invariant canonical form theorem: it does not also prove
-the source theorem's unital orientation, diagonal full-rank dual fixed points,
-uniqueness of the identity fixed point, or total bond-dimension bound. The
-boundary is recorded in
+**Scope restriction (translation-invariant canonical-form proof step):**
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
+lines 765--770 use a full-rank positive fixed point to gauge a block into the
+unital orientation `∑ i, B i * (B i)ᴴ = 1`. This theorem supplies the dual
+left-canonical TP orientation after the all-zero-block separation. It is therefore not the full
+translation-invariant canonical form theorem of Pérez-García, Verstraete,
+Wolf, and Cirac: it does not also prove the source theorem's unital orientation,
+diagonal full-rank dual fixed points, uniqueness of the identity fixed point, or
+total bond-dimension bound. The boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -10,10 +10,11 @@ open scoped Matrix BigOperators
 # Iterated invariant-projection splitting: irreducible block decomposition
 
 This module implements the "iterate until all blocks are irreducible" step from
-Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3
-(around eq. `\label{eq:II_Aiplusk1}`).
+Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–217
+(the display labelled eq:II_Aiplusk1 is at lines 214–217).
 It also corresponds to the invariant-subspace splitting used inside
-PGVWC07, Theorem `Th:TIcanonical`, lines 765–833.
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
+lines 765–833.
 The source proof is ordered as follows: lines 765–770 handle spectral-radius
 normalization and the full-rank fixed-point gauge; lines 771–783 derive the
 invariant support from a singular positive fixed point; lines 785–815 split the
@@ -21,7 +22,7 @@ finite-ring trace over that support and its orthogonal complement; lines 816–8
 iterate the split and use a non-scalar fixed point to force uniqueness of the
 identity fixed point.  This file formalizes only the abstract splitting once an
 invariant projection is available; a faithful proof of the full theorem must
-also derive that projection from the positive fixed-point argument in
+also derive that projection from the singular positive fixed-point argument in
 lines 771–783 and perform the dual fixed-point diagonalization at
 lines 827–832.
 
@@ -42,14 +43,16 @@ orthogonal projections. Strong induction on `D` guarantees termination.
 * Blocking to remove periodicity.
 * The positive weights, unital block orientation, diagonal full-rank dual fixed
   points, uniqueness of the identity fixed point, and total bond-dimension bound
-  in PGVWC07, Theorem `Th:TIcanonical`, lines 742–763.
+  in Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
+  lines 742–763.
 These are separate steps in the canonical-form construction.
 
 ## References
 
-* Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Section 2.3, eq. II_Aiplusk1.
-* Perez-Garcia et al., quant-ph/0608197, Theorem `Th:TIcanonical`,
-  proof lines 765–833.
+* Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–217,
+  with eq:II_Aiplusk1 at lines 214–217.
+* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical, proof
+  lines 765–833.
 -/
 
 namespace MPSTensor
@@ -126,7 +129,8 @@ private lemma mpv_twoBlockTensor_eq {n m : ℕ} (A₁ : MPSTensor d n) (A₂ : M
 
 /-! ## Main theorem: iterated irreducible block decomposition -/
 
-/-- **Iterated invariant-projection splitting** (Cirac–Pérez-García–Schuch–Verstraete Section 2.3).
+/-- **Iterated invariant-projection splitting**
+(Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–217).
 
 Every MPS tensor `A : MPSTensor d D` is `SameMPV₂`-equivalent to a block-diagonal tensor
 `toTensorFromBlocks (μ ≡ 1) blocks` whose every block is irreducible (has no nontrivial invariant
@@ -137,9 +141,10 @@ nontrivial invariant projection `P`, which we use via
 `exists_twoBlock_decomp_of_lowerZero_strict` to split `A` into two blocks of *strictly smaller*
 bond dimension, then apply the induction hypothesis to each block.
 
-**Scope restriction (PGVWC07 canonical-form proof step):** This theorem proves
-only the recursive invariant-projection splitting from the proof of
-PGVWC07, Theorem `Th:TIcanonical`, lines 771–826. It does not prove the full
+**Scope restriction (translation-invariant canonical-form proof step):** This
+theorem proves only the recursive invariant-projection splitting from the proof of
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
+lines 771–826. It does not prove the full
 source theorem's positive weights, unital normalization, diagonal full-rank dual
 fixed points, or final bond-dimension bound; it also does not perform the
 dual-map diagonalization of lines 827–832. The remaining source boundary is

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -10,8 +10,8 @@ open scoped Matrix BigOperators
 # Iterated invariant-projection splitting: irreducible block decomposition
 
 This module implements the "iterate until all blocks are irreducible" step from
-Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–217
-(the display labelled eq:II_Aiplusk1 is at lines 214–217).
+Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–219
+(the display labelled eq:II_Aiplusk1 is at lines 214–218).
 It also corresponds to the invariant-subspace splitting used inside
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
 lines 765–833.
@@ -49,8 +49,8 @@ These are separate steps in the canonical-form construction.
 
 ## References
 
-* Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–217,
-  with eq:II_Aiplusk1 at lines 214–217.
+* Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–219,
+  with eq:II_Aiplusk1 at lines 214–218.
 * Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical, proof
   lines 765–833.
 -/
@@ -130,7 +130,7 @@ private lemma mpv_twoBlockTensor_eq {n m : ℕ} (A₁ : MPSTensor d n) (A₂ : M
 /-! ## Main theorem: iterated irreducible block decomposition -/
 
 /-- **Iterated invariant-projection splitting**
-(Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–217).
+(Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–219).
 
 Every MPS tensor `A : MPSTensor d D` is `SameMPV₂`-equivalent to a block-diagonal tensor
 `toTensorFromBlocks (μ ≡ 1) blocks` whose every block is irreducible (has no nontrivial invariant


### PR DESCRIPTION
This is another small source-faithfulness prose cleanup for the canonical-form proof chain tracked in #1685.

The previous PRs tightened the support-projection and invariant-subspace files. This PR applies the same convention to the surrounding canonical-form reduction files: paper theorem labels are cited as paper labels, not as Lean identifiers, and the invariant-subspace recursion points to the original source lines.

Changes:
- Replace remaining reader-facing `PGVWC07` shorthand and backticked `Th:TIcanonical` labels in `CanonicalForm/Reduction.lean`, `CanonicalForm/Existence.lean`, and `CanonicalForm/NormalReduction/TPGauge.lean`.
- Cite Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical with the relevant line ranges: 742--763 for the theorem statement, 765--833 for the proof, 771--826 for recursive splitting, and 765--770 for the full-rank fixed-point gauge.
- Replace the loose CPSV Section 2.3 pointer in the iterated splitting documentation with `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 201--219, including eq:II_Aiplusk1 at lines 214--218.
- Keep the singular positive fixed-point step named as such when referring to lines 771--783.

No theorem statements, proof terms, imports, or blueprint tags change.

Refs #1685.

Validation:
- `lake env lean TNLean/MPS/CanonicalForm/Reduction.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docstring/prose updates (paper citations, theorem labels, and line references) with no modifications to definitions, theorem statements, or proof terms.
> 
> **Overview**
> Standardizes reader-facing citations in the canonical-form reduction docs by replacing `PGVWC07`/backticked identifiers with full Pérez-García–Verstraete–Wolf–Cirac references and consistent `Th:TIcanonical` labeling.
> 
> Updates the referenced source locations to precise line ranges (including arXiv:1606.00608 lines 201–219 / `eq:II_Aiplusk1`, and quant-ph/0608197 line spans for statement/proof/substeps), and clarifies wording like the *singular positive fixed-point* step and the scoped non-goals of the reduction lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878cc45aa4a30176d216b53daaabd2dcbf3164f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->