### PR TITLE
doc(MPS): cite SectorBNT supplier source lines

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -617,12 +617,14 @@ For any tensor `A : MPSTensor d D`, after at most one positive blocking length
 primitive, irreducible, one-site injective, with nonzero weights and positive
 bond dimensions) whose direct-sum tensor matches the `p`-blocked input
 `blockTensor A p` at every positive length.  When the user supplies the
-CPSV16 §II.A line 246 normalization choice on those weights (every weight
-has absolute value at most one and at least one of unit modulus), there is a
-BNT canonical-form sector decomposition `P` satisfying `IsBNTCanonicalForm`
-with `blockTensor A p` matching `P.toTensor` at every positive length.
+arXiv:1606.00608, line 246 normalization choice on those weights (every
+weight has absolute value at most one and at least one of unit modulus), there
+is a BNT canonical-form sector decomposition `P` satisfying
+`IsBNTCanonicalForm` with `blockTensor A p` matching `P.toTensor` at every
+positive length.
 
-The normalization is, per CPSV16 line 246, an explicit user choice:  the paper
+The normalization is, per arXiv:1606.00608, line 246, an explicit user choice:
+the paper
 writes "we can always *choose* this normalization, which we will assume from
 now on".  We therefore expose the prepared-block family and embed the
 conditional sector-decomposition supplier inside the existential.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -29,9 +29,15 @@ phase-equivalent TP/primitive/irreducible blocks.
 
 ## Paper anchor
 
-* `Papers/1606.00608/MPDO-22-12-17-2.tex:271-301` — BNT existence in the
-  prepared-data setting (`A^i = ⊕_{j,q} μ_{j,q} A_j^i` with normal `A_j` and
-  the §II.A normalization).
+* `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 237–246 — the canonical-form
+  display labelled eq:II_CF1 and the subsequent weight normalization.
+* `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 271–279 and 1135–1148 —
+  the BNT characterization labelled prop:char-BNT, its appendix construction,
+  and the same-CF uniqueness note.
+* `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 283–301 — the two-layer
+  expansion in terms of BNT sectors and copy weights.
+* `Papers/2011.12127/TN-Review-main.tex`, lines 1827–1839, 1846–1859, and
+  1864–1884 — the review-paper canonical-form, BNT, and two-layer display.
 
 ## Gap record
 
@@ -125,10 +131,12 @@ bond dimensions inside each phase class.
 /--
 **Bond dimensions of prepared phase-equivalent blocks agree.**
 
-Source: arXiv:1606.00608, Lemma `equalMPS` in
+Source: arXiv:1606.00608, Lemma equalMPS in
 `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1080-1117, especially
 the dimension conclusion at lines 1090 and 1115-1117; the phase-class
-quotient is `prop:char-BNT`, lines 271-279 and 1135-1148.
+quotient is prop:char-BNT, labelled at line 278 with statement at line 279;
+the appendix restatement, construction, and same-CF uniqueness note are lines
+1135–1148.
 
 If two left-canonical, primitive, irreducible blocks have MPV families related
 by a nonzero scalar power, then their bond dimensions are equal.  The proof
@@ -186,10 +194,12 @@ theorem dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
 /--
 **Prepared phase classes preserve the original bond dimensions.**
 
-Source: arXiv:1606.00608, `equalMPS` in
+Source: arXiv:1606.00608, Lemma equalMPS in
 `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1080-1117, supplies the
-same-dimension conclusion; `prop:char-BNT` at lines 271-279 and 1135-1148
-uses this comparison to form phase classes.
+same-dimension conclusion.  The source phase-class quotient is prop:char-BNT,
+labelled at line 278 with statement at line 279, and its appendix
+restatement/construction plus same-CF uniqueness note are lines 1135–1148.
+This comparison is the dimension input for those phase classes.
 In a prepared family of left-canonical, primitive, irreducible blocks, every
 member of an MPV phase class has the same bond dimension as its chosen
 representative.
@@ -221,11 +231,11 @@ theorem mpvPhaseClassData_dim_eq_of_tp_primitive_irr
 /--
 **Total bond dimension of the prepared collapsed BNT decomposition.**
 
-Source: arXiv:1606.00608, `eq:II_CF1` and `prop:char-BNT` in
-`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 237-246, 271-279, and
-1135-1148.  For prepared blocks, the phase-class quotient does not change the
-total bond dimension: quotienting only groups phase-equivalent copies with the
-same bond dimension.
+Source: arXiv:1606.00608, eq:II_CF1 at lines 237–246 and prop:char-BNT
+labelled at line 278 with statement at line 279.  Appendix A restates and
+constructs the BNT quotient at lines 1135–1148.  For prepared blocks, the
+phase-class quotient does not change the total bond dimension: quotienting only
+groups phase-equivalent copies with the same bond dimension.
 -/
 theorem collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr
     {r : ℕ} {dim : Fin r → ℕ}
@@ -251,8 +261,9 @@ nonzero weights satisfying the SectorBNT normalization conditions, produce a
 `SectorDecomposition P` and a proof that `IsBNTCanonicalForm P` and the
 assembled tensor agrees with the original direct sum.
 
-Paper anchor: `Papers/1606.00608/MPDO-22-12-17-2.tex:271-301` (BNT existence
-in the prepared-data setting).
+Paper anchor: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 271–279 and
+1135–1148 for prop:char-BNT, and lines 283–301 for the two-layer BNT/copy
+expansion.
 -/
 theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks
     {r : ℕ} {dim : Fin r → ℕ}
@@ -380,9 +391,10 @@ or hypothesis passes those facts to the prepared-block supplier
 `exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks` to obtain
 the full `IsBNTCanonicalForm` conclusion.
 
-Paper anchor: CPSV16 §II.A line 237-280 (canonical form definition,
-normalization, and BNT discussion), Cirac–Pérez-García–Schuch–Verstraete,
-arXiv:1606.00608.
+Paper anchor: Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608,
+lines 237–246 for eq:II_CF1 and the weight normalization, lines 249–251 for
+after-blocking canonical-form existence, and lines 271–279 for the BNT
+definition and prop:char-BNT statement.
 -/
 
 private lemma sameMPV₂Pos_reindexPhysical_aux
@@ -598,7 +610,7 @@ the prepared-block BNT constructor delivers a full `IsBNTCanonicalForm`
 decomposition together with positive-length MPV agreement.
 -/
 
-/-- **Arbitrary-input BNT block preparation (CPSV16 §II.A L237-280).**
+/-- **Arbitrary-input BNT block preparation (CPSV16 §II.A lines 237–280).**
 
 For any tensor `A : MPSTensor d D`, after at most one positive blocking length
 `p`, there is a finite family of **prepared** blocks (left-canonical,
@@ -615,8 +627,10 @@ writes "we can always *choose* this normalization, which we will assume from
 now on".  We therefore expose the prepared-block family and embed the
 conditional sector-decomposition supplier inside the existential.
 
-Paper anchor: arXiv:1606.00608 §II.A line 237-280; proposition
-char-BNT line 1135-1149. -/
+Paper anchor: arXiv:1606.00608, lines 237–246 for eq:II_CF1 and the weight
+normalization, lines 271–279 for the BNT definition and prop:char-BNT
+statement, lines 1135–1148 for its appendix construction and same-CF uniqueness
+note, and lines 283–301 for the two-layer BNT/copy expansion. -/
 theorem exists_isBNTCanonicalForm_afterBlocking_pos
     {d D : ℕ} (A : MPSTensor d D) :
     ∃ p : ℕ, 0 < p ∧

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -610,7 +610,7 @@ the prepared-block BNT constructor delivers a full `IsBNTCanonicalForm`
 decomposition together with positive-length MPV agreement.
 -/
 
-/-- **Arbitrary-input BNT block preparation (CPSV16 §II.A lines 237–280).**
+/-- **Arbitrary-input BNT block preparation from the canonical-form and BNT source lines.**
 
 For any tensor `A : MPSTensor d D`, after at most one positive blocking length
 `p`, there is a finite family of **prepared** blocks (left-canonical,

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -108,7 +108,8 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     % Papers/2011.12127/TN-Review-main.tex:1793--1803 gives the invariant-
     % subspace reduction; lines 1815--1820 give period removal; lines 1827--1839
     % give def:4:normal-tensor-mps and eq:II_CF1; lines 1846--1859 give the
-    % BNT definition/characterization.
+    % BNT definition/characterization; lines 1864--1884 give the two-layer
+    % BNT/copy display.
     This is the canonical-form reduction of
     \cite[Section~II.C, lines~217--246]{Cirac2017MPDO_AnnPhys}; see also
     \cite[Section~IV.A, lines~1815--1837]{Cirac2021Matrix}. Every
@@ -135,14 +136,15 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     subsequent weight normalization,
     lines~237--246]{Cirac2017MPDO_AnnPhys}.
     The basis-of-normal-tensors refinement is
-    \cite[definition and proposition around \texttt{prop:char-BNT},
+    \cite[BNT definition and proposition labelled prop:char-BNT,
     lines~271--280]{Cirac2017MPDO_AnnPhys},
     with its appendix restatement and proof in
-    \cite[Appendix proof of \texttt{prop:char-BNT}, lines~1135--1146]
+    \cite[Appendix proof of prop:char-BNT and same-CF uniqueness note,
+    lines~1135--1148]
         {Cirac2017MPDO_AnnPhys},
     and the two-layer display is
-    \cite[displays labelled \texttt{eq:II\_ABasicTensors} and
-    \texttt{decBSV}, lines~285--301]{Cirac2017MPDO_AnnPhys}.
+    \cite[displays labelled eq:II\_ABasicTensors and decBSV,
+    lines~283--301]{Cirac2017MPDO_AnnPhys}.
     The review exposition records the same normal-tensor and canonical-form
     definitions at lines~1827--1837, the basis-of-normal-tensors definition and
     characterization at lines~1846--1859, and the two-layer decomposition at
@@ -1264,8 +1266,8 @@ BNT construction.
     \texttt{docs/paper-gaps/cpsv16\_cf\_normalization\_and\_proportional\_comparison.tex}.
     Applying Theorem~\ref{thm:paperbnt_supplier_prepared} to this prepared
     family gives the sector decomposition, in the spirit of the BNT selection
-    described in
-    \cite[Proposition~\texttt{char-BNT}]{Cirac2017MPDO_AnnPhys}.
+    described by prop:char-BNT in
+    \cite[lines~271--279 and 1135--1148]{Cirac2017MPDO_AnnPhys}.
 \end{proof}
 
 \begin{theorem}[Conditional BNT form after blocking with length-zero discharge]%

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1266,7 +1266,7 @@ BNT construction.
     \texttt{docs/paper-gaps/cpsv16\_cf\_normalization\_and\_proportional\_comparison.tex}.
     Applying Theorem~\ref{thm:paperbnt_supplier_prepared} to this prepared
     family gives the sector decomposition, in the spirit of the BNT selection
-    described by prop:char-BNT in
+    described by the source characterization in
     \cite[lines~271--279 and 1135--1148]{Cirac2017MPDO_AnnPhys}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -129,10 +129,10 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
 
     In the source, the canonical-form construction is recorded in
-    \cite[display labelled \texttt{eq:II\_Aiplusk1}, lines~216--225]
+    \cite[display labelled eq:II\_Aiplusk1, lines~216--225]
         {Cirac2017MPDO_AnnPhys}
     and in
-    \cite[canonical-form definition containing \texttt{eq:II\_CF1} and
+    \cite[canonical-form definition containing eq:II\_CF1 and
     subsequent weight normalization,
     lines~237--246]{Cirac2017MPDO_AnnPhys}.
     The basis-of-normal-tensors refinement is


### PR DESCRIPTION
This is a source-faithfulness cleanup for the SectorBNT supplier path tracked in #1685 and #1753.

The current arbitrary-input supplier remains intentionally conditional on the CPSV16 weight-normalization choice. This PR does not promote that theorem or change any proof term. It only tightens the source map around the prepared-block BNT supplier so future work on #1753 can see exactly which part is already represented and which part is still the missing normalization/assembly step.

Changes:
- In `TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean`, replace broad or stale BNT anchors such as `271-301`, `237-280`, and `1135-1149` with exact source locations:
  - CPSV16 eq:II_CF1 and weight normalization: `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 237--246.
  - After-blocking CF existence: lines 249--251.
  - BNT definition and prop:char-BNT statement: lines 271--279, with label at line 278 and statement at line 279.
  - Appendix restatement, construction, and same-CF uniqueness note: lines 1135--1148.
  - Two-layer BNT/copy expansion: lines 283--301.
- Add the review-paper counterparts in `Papers/2011.12127/TN-Review-main.tex`: lines 1827--1839, 1846--1859, and 1864--1884.
- In `blueprint/src/chapter/ch08_canonical.tex`, mirror the same source locations and extend the review-paper comment to include the two-layer BNT/copy display.

No theorem statements, proof terms, imports, or blueprint declaration tags change.

Refs #1685. Refs #1753.

Validation:
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean`
- `git diff --check`
- `cd blueprint && leanblueprint web` (exits 0 locally; the existing local plasTeX loader still reports `ModuleNotFoundError: No module named 'leanblueprint'` warnings before rendering)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to comments/citations in Lean docs and the blueprint, with no theorem statements, proof terms, or behavior affected.
> 
> **Overview**
> Updates `TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean` and `blueprint/src/chapter/ch08_canonical.tex` to replace broad/stale CPSV16/BNT references with **precise line ranges and labels** (e.g. eq:II_CF1 + weight normalization, prop:char-BNT + appendix construction/uniqueness note, and the two-layer BNT/copy expansion), and adds the corresponding review-paper line anchors.
> 
> No Lean definitions, theorem statements, proofs, imports, or blueprint tags change; this PR is purely documentation/source-faithfulness cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d176c795b257a7facf6cacade2be5c19b6489cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->