### PR TITLE
doc(MPS): record canonical proof source order

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -14,18 +14,24 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 open Filter
 
 /-!
-# Canonical form existence reduction (arXiv:1606.00608, Section 2.3 + Appendix A)
+# Canonical form existence reductions from the source proofs
 
 This file collects the arbitrary-tensor reductions toward the canonical-form construction for
 MPS tensors from Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608.
 
-The file contains the following reductions:
+The file contains the following reductions from arXiv:1606.00608 and the
+translation-invariant canonical-form theorem of Pérez-García, Verstraete, Wolf,
+and Cirac:
 
-* Section 2.3: iterated invariant-projection splitting → irreducible block decomposition.
-* Appendix A (PF / TP gauge): irreducible + nonzero Kraus operator → Perron--Frobenius
-  eigenvector → TP-normalized representative.
-* Appendix A (CFII part): inside that TP gauge, unitary conjugation → diagonal PD fixed point.
-* Appendix A (periodicity): TP + irreducible → primitive after blocking.
+* arXiv:1606.00608, lines 201-219: iterated invariant-projection splitting gives an
+  irreducible block decomposition.
+* arXiv:1606.00608, lines 1058-1077: after canonical form has been obtained,
+  the canonical-form-II gauge makes the associated maps trace-preserving and
+  gives diagonal full-rank fixed points.
+* Pérez-García, Verstraete, Wolf, and Cirac, proof of Theorem Th:TIcanonical,
+  lines 765-770 and 827-832: the full-rank fixed-point gauge and the final
+  dual fixed-point diagonalization.
+* arXiv:1606.00608, lines 227-231: blocking removes peripheral periodicity.
 
 We also keep a couple of formulations for already-normalized primitive / injective block families,
 but those are **not** obtained from arbitrary input in this file.
@@ -53,12 +59,12 @@ diagonal full-rank dual fixed points, uniqueness of the identity fixed point for
 each block transfer map, and the stated bond-dimension bound. The audit
 boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
-For Pérez-García, Verstraete, Wolf, and Cirac, the faithful proof order is the one in
-`Papers/quant-ph_0608197/MPSarchive.tex`: lines 765–770 for spectral-radius
-normalization and the full-rank fixed-point gauge, lines 771–815 for deriving
-the invariant support from a singular positive fixed point and then splitting
-the trace, lines 816–826 for iteration and non-scalar fixed-point splitting,
-and lines 827–832 for dual fixed-point diagonalization.
+For Pérez-García, Verstraete, Wolf, and Cirac, the faithful proof order is the
+one in `Papers/quant-ph_0608197/MPSarchive.tex`: lines 765–770 for
+spectral-radius normalization and the full-rank fixed-point gauge, lines
+771–815 for deriving the invariant support from a singular positive fixed point
+and then splitting the trace, lines 816–826 for iteration and non-scalar
+fixed-point splitting, and lines 827–832 for dual fixed-point diagonalization.
 
 ## External input — Quantum Wielandt strong irreducibility ⇒ full Kraus rank
 
@@ -85,14 +91,14 @@ The formal statement:
 > `wordSpan A 1 = ⊤`).  This proves the hardest direction
 > in the Sanz–Pérez-García–Wolf–Cirac primitivity equivalence.
 
-## External input — Pérez-García et al. invariant subspace decomposition
+## External input — invariant subspace decomposition in the canonical-form proof
 
 The iterated invariant-projection splitting in arXiv:1606.00608, lines
-201–219 (Wolf/Cirac/Verstraete canonical-form reduction), is formalized in
+201–219, is formalized in
 `TNLean.MPS.Structure.InvariantSubspaceDecomp`.
 This external input provides:
 
-> **Pérez-García et al., quant-ph/0608197, proof of Theorem
+> **Pérez-García, Verstraete, Wolf, and Cirac, proof of Theorem
 > Th:TIcanonical, lines 765–833.**
 > An invariant orthogonal projection `P` on the bond space (satisfying
 > `(1-P) A_i P = 0` for all `i`) yields an MPV-equivalent two-block direct-sum
@@ -124,14 +130,14 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-!
-## (1) Irreducible block decomposition (1606.00608 Section 2.3)
+## (1) Irreducible block decomposition
 
 We use `MPSTensor.exists_irreducible_blockDecomp` from `Reduction.lean` directly below.
 -/
 
 
 /-!
-## (2) Perron–Frobenius / TP gauge for irreducible blocks (1606.00608 Appendix A)
+## (2) Perron–Frobenius / trace-preserving gauge for irreducible blocks
 
 We use `MPSTensor.exists_tp_data_of_irreducible` from
 `Channel/PerronFrobenius/Existence.lean` directly below.
@@ -139,7 +145,7 @@ We use `MPSTensor.exists_tp_data_of_irreducible` from
 
 
 /-!
-## (3) CFII normalization for irreducible TP blocks (1606.00608 Appendix A)
+## (3) CFII normalization for irreducible trace-preserving blocks
 
 We collect `exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor` together with the
 fact that unitary conjugation preserves MPVs.
@@ -149,7 +155,7 @@ PF / TP-gauge step is generally a non-unitary similarity; the unitary appearing 
 after one has already moved into the one-sided TP gauge.
 -/
 
-/-- **Reduction step (1606.00608 Appendix A, CFII).**
+/-- **CFII fixed-point normalization for irreducible trace-preserving blocks.**
 
 For an irreducible tensor `A` in the TP gauge (`∑ Aᵢ†Aᵢ = I`) and with `0 < D`, there exist
 
@@ -195,13 +201,13 @@ theorem exists_CFII_data_of_TP_of_isIrreducibleTensor
 
 
 /-!
-## (4) Periodicity removal by blocking (1606.00608 Appendix A)
+## (4) Periodicity removal by blocking
 
 This is the Appendix-A periodicity-removal step for TP irreducible blocks, routed through the
 adjoint-transfer formulation.
 -/
 
-/-- **Reduction step (1606.00608 Appendix A): periodicity removal by blocking.**
+/-- **Periodicity removal by blocking for irreducible trace-preserving blocks.**
 
 If `A` is trace-preserving and irreducible (tensor sense), then some physical blocking makes the
 transfer map primitive. -/
@@ -217,7 +223,7 @@ theorem exists_blockTensor_isPrimitive
   simpa using
     (exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor (A := A) hTP hIrr hDpos)
 
-/-- **Reduction step (1606.00608 Appendix A, TP normalization after blocking).**
+/-- **Trace-preserving normalization after blocking.**
 
 If `A` is trace-preserving and irreducible, then some physical blocking makes the
 blocked transfer map primitive, and the blocked tensor remains left-canonical. -/
@@ -363,7 +369,7 @@ Remaining gap for a complete canonical-form existence theorem:
   the normal-canonical-form lemmas and the `IsCanonicalForm` constructors.
 -/
 
-/-- **Unconditional TP-gauge reduction for the 1606 theorem (1606.00608 Section 2.3 + App. A).**
+/-- **Unconditional trace-preserving gauge reduction for the 1606 theorem.**
 
 From an arbitrary tensor `A` we produce an irreducible block decomposition. For each
 resulting block, if one separately knows that the block has some nonzero Kraus operator, then the
@@ -408,13 +414,14 @@ theorem exists_irreducible_blockDecomp_with_tpGauge
     (exists_tp_data_of_irreducible (d := d) (D := dim k)
       (A := blocks k) (hIrr := hIrr k) (hA := hNonzero))
 
-/-- **CFII fixed-point data for the 1606 reduction (1606.00608 Section 2.3 + App. A).**
+/-- **CFII fixed-point data for the 1606 reduction.**
 
 From an arbitrary tensor `A` we produce an irreducible block decomposition. For each
 block, assuming one has already supplied (i) a TP representative and (ii) positive bond dimension,
 we can produce CFII fixed-point data (unitary conjugation + diagonal PD fixed point).
 
-This is the CFII part of Appendix A, not a complete existence theorem: it does not carry the PF
+This is the CFII fixed-point part of the source proof, not a complete existence theorem:
+it does not carry the Perron-Frobenius
 / TP-gauge or periodicity-removal arguments through the block decomposition. The normal canonical
 form, for primitive weighted blocks already in hand, is treated in the normal-canonical-form
 file. -/
@@ -448,7 +455,7 @@ theorem exists_irreducible_blockDecomp_with_CFII
       (A := blocks k) (hTP := hTPk) (hIrr := hIrr k) (hD := hDk))
 
 /-!
-## Zero-block separation (arXiv:1606.00608 Section 2.3: partition into zero + nonzero blocks)
+## Zero-block separation
 
 The irreducible block decomposition may produce all-zero blocks. Because `SameMPV₂`
 at `N = 0` includes the identity `trace(I_D) = D`, we cannot silently drop these.
@@ -485,7 +492,7 @@ theorem mpv_zeroMPSTensor {N : ℕ} (σ : Fin N → Fin d') (D' : ℕ) :
     exact mpv_eq_zero_of_all_zero (zeroMPSTensor d' D')
       (fun _ => rfl) σ hpos
 
-/-- **Zero-block separation** (arXiv:1606.00608 Section 2.3).
+/-- **Zero-block separation.**
 
 The paper states that in the canonical form $A^i = \oplus_{k=1}^r \mu_k A_k^i$, some blocks may
 be zero: "there can be zero blocks." Every MPS tensor `A : MPSTensor d D` admits an irreducible

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -258,7 +258,7 @@ theorem exists_tp_gauge_blockwise
   exact ⟨r0, dim0, μ1, blocks1, hSame1, hIrr1, hLeft1, hμne1, hDim1⟩
 
 /-!
-## Zero-block separation + TP gauge threading (arXiv:1606.00608 Section 2.3 + App. A)
+## Zero-block separation and trace-preserving gauge threading
 
 This section composes the zero-block separation from `Existence.lean` with the
 blockwise Perron–Frobenius / TP-gauge theorem `exists_tp_gauge_blockwise`, producing an
@@ -277,9 +277,11 @@ This is the furthest unconditional arbitrary-input step available before periodi
 the cyclic-sector and equal-weight arguments.
 -/
 
-/-- **Arbitrary-input TP-gauge reduction.**
+/-- **Arbitrary-input trace-preserving gauge reduction.**
 
-arXiv:1606.00608 Section 2.3 and Appendix A, with zero-block separation.
+This combines the invariant-subspace splitting of arXiv:1606.00608,
+lines 201-219, with zero-block separation and the canonical-form-II gauge
+passage at lines 1058-1077 for the nonzero irreducible blocks.
 
 From any `A : MPSTensor d D`, produce:
 * a zero block of dimension `zeroTailDim` accumulating all-zero irreducible blocks
@@ -299,11 +301,12 @@ The MPV of `A` equals the zero-block contribution plus the weighted nonzero-bloc
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
 lines 765--770 use a full-rank positive fixed point to gauge a block into the
 unital orientation `∑ i, B i * (B i)ᴴ = 1`. This theorem supplies the dual
-left-canonical TP orientation after the all-zero-block separation. It is therefore not the full
-translation-invariant canonical form theorem of Pérez-García, Verstraete,
-Wolf, and Cirac: it does not also prove the source theorem's unital orientation,
-diagonal full-rank dual fixed points, uniqueness of the identity fixed point, or
-total bond-dimension bound. The boundary is recorded in
+left-canonical trace-preserving orientation after the all-zero-block
+separation. It is therefore not the full translation-invariant canonical form
+theorem of Pérez-García, Verstraete, Wolf, and Cirac: it does not also prove the
+source theorem's unital orientation, diagonal full-rank dual fixed points,
+uniqueness of the identity fixed point, or total bond-dimension bound. The
+boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -51,8 +51,8 @@ These are separate steps in the canonical-form construction.
 
 * Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–219,
   with eq:II_Aiplusk1 at lines 214–218.
-* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical, proof
-  lines 765–833.
+* Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
+  proof lines 765–833.
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -33,7 +33,7 @@ invariant-subspace decomposition results.  Thus the results here should be used
 before, not instead of, the source trace-splitting argument.
 
 References:
-* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
+* Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
   proof lines 771–783 (singular positive fixed point gives an invariant
   support projection)
 -/
@@ -322,11 +322,11 @@ private lemma ker_invariant_under_adjoint
 /-- If `ρ` is a PSD fixed point of the transfer map, then its support projection is invariant:
 `(1 - P) * A i * P = 0` for all Kraus operators `A i`.
 
-This proves the support-projection assertion in Pérez-García et al., Theorem
-Th:TIcanonical, proof lines 771–783.  The source writes the fixed point as
-$X = \sum_\alpha \lambda_\alpha |\alpha\rangle\langle\alpha|$, lets $P_R$ be
-its support projection, and proves $A_i P_R = P_R A_i P_R$ by the positivity
-contradiction in lines 775–783.
+This proves the support-projection assertion in Pérez-García, Verstraete, Wolf,
+and Cirac, Theorem Th:TIcanonical, proof lines 771–783.  The source writes the
+fixed point as $X = \sum_\alpha \lambda_\alpha |\alpha\rangle\langle\alpha|$,
+lets $P_R$ be its support projection, and proves $A_i P_R = P_R A_i P_R$ by
+the positivity contradiction in lines 775–783.
 -/
 theorem lowerZero_of_posSemidef_fixedPoint
     (A : MPSTensor d D)
@@ -411,11 +411,12 @@ matrix, and are essential for the "strict dimension decrease" argument used when
 iterating the canonical-form splitting step.
 
 References:
-* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
+* Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
   proof lines 771–783 for the support projection and lines 785–815 for the
   finite-ring trace split whose recursive blocks have smaller dimensions.
-* Cirac et al., arXiv:1606.00608, lines 201–217: invariant subspaces are split
-  into diagonal blocks in the canonical-form construction.
+* Cirac, Pérez-García, Schuch, and Verstraete, arXiv:1606.00608,
+  lines 201–217: invariant subspaces are split into diagonal blocks in the
+  canonical-form construction.
 -/
 
 section SupportProjNontriviality
@@ -499,10 +500,11 @@ projection $P := \mathrm{supp}(\rho)$ is invariant under the Kraus operators `(A
 explicit two-block block-diagonal tensor which is MPV-equivalent to `A`.
 
 References:
-* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
+* Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
   proof lines 771–783 for the support projection and lines 785–815 for the
   finite-ring trace split.
-* Cirac et al., arXiv:1606.00608, lines 201–217 for the corresponding
+* Cirac, Pérez-García, Schuch, and Verstraete, arXiv:1606.00608,
+  lines 201–217 for the corresponding
   invariant-subspace block splitting in the canonical-form construction.
 -/
 
@@ -542,11 +544,12 @@ The proof composes:
 4. `exists_twoBlock_decomp_of_lowerZero_strict` — strict dimension bounds.
 
 References:
-* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
+* Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
   proof lines 771–783 for deriving the invariant support projection and
   lines 785–815 for the trace split into two smaller blocks.
-* Cirac et al., arXiv:1606.00608, lines 201–217 for the invariant-subspace
-  direct-sum step in the canonical-form construction.
+* Cirac, Pérez-García, Schuch, and Verstraete, arXiv:1606.00608,
+  lines 201–217 for the invariant-subspace direct-sum step in the
+  canonical-form construction.
 -/
 theorem exists_twoBlock_decomp_of_posSemidef_fixedPoint_strict
     (A : MPSTensor d D)

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -19,7 +19,7 @@ equivalent to a block-diagonal tensor with two smaller bond dimensions.
 This is the "invariant subspace ⇒ direct sum decomposition" step used in canonical-form existence
 arguments before blocking/normalization.
 
-## External input — Pérez-García et al. canonical-form recursion
+## External input — canonical-form recursion of Pérez-García, Verstraete, Wolf, and Cirac
 
 This file formalizes the direct-sum decomposition step once an invariant
 projection has already been obtained.  In Pérez-García, Verstraete, Wolf, and
@@ -27,7 +27,7 @@ Cirac this is deliberately the trace-splitting part of the singular positive
 fixed-point argument, not a replacement for the preceding singular positive
 fixed-point step that produces the projection:
 
-> **Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
+> **Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
 > proof lines 771–815.**
 > The source first derives the invariant support projection from a singular
 > positive fixed point in lines 771–783.  The results below take such an
@@ -37,7 +37,8 @@ fixed-point step that produces the projection:
 > (`exists_twoBlock_decomp_of_lowerZero_strict`) guarantees termination of the
 > canonical-form recursion.
 
-> **Cirac et al., arXiv:1606.00608, lines 201–217.**
+> **Cirac, Pérez-García, Schuch, and Verstraete, arXiv:1606.00608,
+> lines 201–217.**
 > The same step in the "canonical forms" reduction: invariant projection ⇒
 > block upper-triangular ⇒ drop strict off-diagonal blocks ⇒ explicit 2-block
 > direct sum.  This is the Wolf/Cirac/Verstraete canonical-form reduction.
@@ -430,9 +431,10 @@ both returned block dimensions are *strictly smaller* than `D`. This is the key
 ingredient for proving termination of the canonical-form recursion.
 
 References:
-* Pérez-García et al., quant-ph/0608197, Theorem Th:TIcanonical,
+* Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
   proof lines 771–815: invariant support and finite-ring trace split.
-* Cirac et al., arXiv:1606.00608, lines 201–217: the corresponding
+* Cirac, Pérez-García, Schuch, and Verstraete, arXiv:1606.00608,
+  lines 201–217: the corresponding
   invariant-subspace step in the "canonical forms" reduction.
 -/
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -10,11 +10,13 @@ primitive transfer maps and pairwise distinct nonzero weight moduli, in the
 sense of~\cite{Cirac2017MPDO_AnnPhys}.
 Thus the reductions recorded here are conditional
 primitive-block results. They should not be read as the full
-translation-invariant canonical-form theorem of~\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
+translation-invariant canonical-form theorem of
+\cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix}.
 The normalization convention is also dual to the one used in the cited theorem:
 the blocks are written in the unital orientation
 $\sum_i A_k^i(A_k^i)^\dagger=\Id$ for
-$\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$~\cite[Theorem~\texttt{Th:TIcanonical}, lines~754--758]{PerezGarcia2007Matrix},
+$\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$
+\cite[Theorem~Th:TIcanonical, lines~754--758]{PerezGarcia2007Matrix},
 whereas this chapter uses
 the trace-preserving, or left-canonical, orientation
 $\sum_i (A_k^i)^\dagger A_k^i=\Id$.
@@ -28,7 +30,7 @@ canonical form conditions.
 The reduction draws on~\cite{PerezGarcia2007Matrix}, \cite{Cirac2021Matrix},
 and~\cite[Chapter~6]{Wolf2012Quantum}.
 
-\begin{theorem}[PGVWC07 translation-invariant canonical form]%
+\begin{theorem}[Translation-invariant canonical form]%
     \label{thm:pgvwc07_ti_canonical_form}
     \notready
     % Source anchors for the exact source statement:
@@ -68,13 +70,13 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     of the decomposition is at most $D$.
 
     This is the source statement
-    of~\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}.
+    of~\cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix}.
 \end{theorem}
 
-\begin{remark}[Source proof order for PGVWC07]\label{rem:pgvwc07_ti_canonical_source_order}
+\begin{remark}[Source proof order]\label{rem:pgvwc07_ti_canonical_source_order}
     A faithful proof of Theorem~\ref{thm:pgvwc07_ti_canonical_form}
     should follow the proof of
-    \cite[Theorem~\texttt{Th:TIcanonical}]{PerezGarcia2007Matrix}
+    \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}
     in its given order. Lines~765--770 normalize the spectral radius and use a
     full-rank positive fixed point to obtain the unital gauge. Lines~771--783
     derive the invariant support projection from a singular positive fixed
@@ -98,7 +100,8 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     % Papers/1606.00608/MPDO-22-12-17-2.tex:227--231 removes periodic
     % peripheral components by blocking; lines 233--235 define normal tensors;
     % lines 237--246 are the definition containing the display labelled
-    % eq:II_CF1 and the subsequent weight normalization; lines 249--251 state
+    % eq:II_CF1 at line 240 and the subsequent weight normalization at
+    % line 246; lines 249--251 state
     % that any tensor becomes canonical after blocking. The phase-class
     % quotient used by the BNT supplier is prop:char-BNT, labelled at line 278
     % with statement at line 279, in the definition/proposition passage
@@ -129,7 +132,8 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
 
     In the source, the canonical-form construction is recorded in
-    \cite[display labelled eq:II\_Aiplusk1, lines~216--225]
+    \cite[display labelled eq:II\_Aiplusk1, lines~216--218,
+    followed by the spectral-radius normalization at lines~219--225]
         {Cirac2017MPDO_AnnPhys}
     and in
     \cite[canonical-form definition containing eq:II\_CF1 and
@@ -137,7 +141,7 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     lines~237--246]{Cirac2017MPDO_AnnPhys}.
     The basis-of-normal-tensors refinement is
     \cite[BNT definition and proposition labelled prop:char-BNT,
-    lines~271--280]{Cirac2017MPDO_AnnPhys},
+    lines~271--279]{Cirac2017MPDO_AnnPhys},
     with its appendix restatement and proof in
     \cite[Appendix proof of prop:char-BNT and same-CF uniqueness note,
     lines~1135--1148]
@@ -154,7 +158,8 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
 Theorems~\ref{thm:pgvwc07_ti_canonical_form}
 and~\ref{thm:cpgsv_canonical_form_source} are source-level targets and are
 not yet formalized as stated. This chapter develops constituent steps of the
-PGVWC07 and CPSV reductions: invariant-subspace decomposition
+translation-invariant and density-operator canonical-form reductions:
+invariant-subspace decomposition
 (Theorem~\ref{thm:irred_decomp}), TP gauge
 (Section~\ref{sec:tp_gauge_arbitrary}), and period-removal cyclic sectors
 (Section~\ref{sec:cyclic_sectors}). All-zero-block separation and the
@@ -472,7 +477,8 @@ primitive, removing periodicity.
     overlap clause $O_{A_k A_k}(N) \to 1$ follows from the spectral-gap
     criterion of Chapter~\ref{ch:spectral}. Both statements assume the
     blocks are already in the required normal form; they are not the
-    arbitrary-input canonical-form existence theorem of~\cite[Theorem~\texttt{Th:TIcanonical}]{PerezGarcia2007Matrix}.
+    arbitrary-input canonical-form existence theorem of
+    \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.
 \end{remark}
 
 \begin{remark}\label{rem:primitivity_reduces_assumptions}
@@ -1213,7 +1219,9 @@ BNT construction.
     \leanok
     % Source anchors:
     % The canonical-form source is
-    % Papers/1606.00608/MPDO-22-12-17-2.tex, eq:II_CF1 at lines 237--246.
+    % Papers/1606.00608/MPDO-22-12-17-2.tex, eq:II_CF1 labelled at
+    % line 240, with the surrounding definition and normalization at
+    % lines 237--246.
     % The phase-class quotient is prop:char-BNT, labelled at line 278 with
     % statement at line 279 in the passage lines 271--279, and its appendix
     % restatement/construction and same-CF BNT uniqueness note at
@@ -1261,7 +1269,7 @@ BNT construction.
     irreducible injective blocks and the positive-length MPV identity. The
     normalized-weight hypotheses are additional hypotheses in the formal
     statement, corresponding to the normalization that
-    \cite[Section~II.A, line~246]{Cirac2017MPDO_AnnPhys} treats as a choice.
+    \cite[Section~II.C, line~246]{Cirac2017MPDO_AnnPhys} treats as a choice.
     The missing rescaling step is recorded in
     \texttt{docs/paper-gaps/cpsv16\_cf\_normalization\_and\_proportional\_comparison.tex}.
     Applying Theorem~\ref{thm:paperbnt_supplier_prepared} to this prepared

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -9,10 +9,11 @@ The block-separation results in this chapter are conditional same-structure
 lemmas: they assume blockwise normalization and separation hypotheses, including
 strict ordering of the weight moduli when required below. They should not be read
 as a formalization of the translation-invariant canonical-form uniqueness theorem
-of~\cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007Matrix},
+of~\cite[Theorem~thm-uniq, lines~1002--1015]{PerezGarcia2007Matrix},
 which requires injectivity at some finite blocking length, uniqueness of the
 OBC canonical representation, and a finite-size lower bound. The source theorem
-is stated in the cited PGVWC07 passage; the project-level scope distinction is
+is stated in the cited passage of Pérez-García, Verstraete, Wolf, and Cirac;
+the project-level scope distinction is
 recorded in the accompanying paper-gap note.\footnote{%
     \texttt{docs/paper-gaps/pgvwc07\_ti\_uniqueness\_scope.tex}.}
 
@@ -360,7 +361,7 @@ We use this notation throughout the block-separation argument.
 
 \begin{remark}[Canonical-form theorem versus local predicates]\label{rem:pgvwc07_vs_local_cf}
     The translation-invariant canonical-form theorem
-    of~\cite[Theorem~\texttt{Th:TIcanonical}, lines~742--763]{PerezGarcia2007Matrix}
+    of~\cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix}
     starts from an arbitrary TI-MPS representation and constructs a block
     canonical form with positive weights, unital block normalization, full-rank
     diagonal invariant densities, and uniqueness of the identity fixed point.
@@ -538,8 +539,8 @@ We use this notation throughout the block-separation argument.
     Hence the block-diagonal tensors
     $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
     are gauge equivalent. This is a same-structure local comparison theorem,
-    not the full PGVWC07 uniqueness
-    theorem~\cite[Theorem~\texttt{thm-uniq}, lines~1002--1015]{PerezGarcia2007Matrix}.
+    not the full uniqueness theorem of
+    \cite[Theorem~thm-uniq, lines~1002--1015]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
@@ -559,4 +560,3 @@ We use this notation throughout the block-separation argument.
     the proof here formulates it as a same-structure block-separation lemma
     using overlap bounds and mixed-transfer decay.
 \end{remark}
-

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -68,10 +68,11 @@ with an extra $Z$-gauge degree of freedom.
 The same-MPV input is reduced to a common primitive block decomposition by
 Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} of
 Chapter~\ref{ch:canonical_after_blocking}. The BNT matching and coefficient
-comparison are developed in Chapter~\ref{ch:bnt}; the per-block gauge-phase
-witnesses and the block-diagonal gauge are then assembled as
-Theorem~\ref{thm:multi_block_global} of
-Chapter~\ref{ch:algebraic_ft}.
+comparison are developed in Chapter~\ref{ch:bnt}. The per-block gauge-phase
+witnesses, copy-weight identities, and block-diagonal gauge are then assembled
+in Theorem~\ref{thm:sector_bnt_equal_global_gauge}. The same-index direct-sum
+corollaries of Chapter~\ref{ch:algebraic_ft} are useful algebraic consequences,
+but they are not the source proof of the BNT block matching.
 
 % Audit 2026-05-20 (#328): the old equal-case blockers #944, #1133, #1170,
 % and #1178 are closed.  This source corollary nevertheless stays not ready
@@ -97,8 +98,8 @@ Chapter~\ref{ch:algebraic_ft}.
 
 The coefficient identities for the matched sectors are supplied by the BNT
 matching of Chapter~\ref{ch:bnt}; the weight recovery uses Newton--Girard. The
-resulting same-MPV comparison is recorded in
-Theorem~\ref{thm:multi_block_global}.
+resulting global conjugacy is recorded in
+Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}.
 
 \section{Homogeneous Pair-Span Padding}\label{sec:ft_pair_span_padding}
 

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -986,6 +986,15 @@ decomposition.
 \label{sec:multi_block_ft}
 %% ---------------------------------------------------------
 
+The first lemmas in this section are bookkeeping for block-diagonal tensors:
+they assemble already-known block gauges, and they record the easy consequences
+of applying the injective single-block theorem to each block separately. They do
+not derive the block matching appearing in
+\cite[Theorem~II.1]{Cirac2017MPDO_AnnPhys}. In the source proof, that matching
+is obtained from BNT overlap, independence, and coefficient comparison; the
+corresponding global gauge assembly is
+Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
+
 \begin{definition}[Flattened block-diagonal gauge]%
     \label{def:global_gauge_of_blocks}
     \lean{MPSTensor.blockDiagonalGL, MPSTensor.globalGaugeOfBlocks}


### PR DESCRIPTION
## Summary

This documentation-only PR tightens the source map for the canonical-form and Fundamental-Theorem proof paths.

- Records the proof order of Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, from `Papers/quant-ph_0608197/MPSarchive.tex` lines 765--833, especially the singular fixed-point support projection before the trace split.
- Replaces remaining reader-facing shorthand such as `PGVWC07`, `Pérez-García et al.`, and code-styled theorem labels in the touched canonical-form prose.
- Corrects the CPSV canonical-form reduction citation to Section II.C and records the exact local label lines for `eq:II_CF1` and `prop:char-BNT` in the blueprint comments, including the line-246 normalization citation.
- Clarifies that the 1606 Fundamental-Theorem route uses BNT matching, copy-weight comparison, and matched-sector gauge assembly; the same-index direct-sum statements are bookkeeping consequences rather than the source proof of block matching.

No theorem statements, proof terms, imports, or blueprint declaration tags change.

## Checks

- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Reduction.lean`
- `lake env lean TNLean/MPS/Irreducible/FixedPointProjection.lean`
- `lake env lean TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`
- `git diff --check -- TNLean/MPS/CanonicalForm/Existence.lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/CanonicalForm/Reduction.lean TNLean/MPS/Irreducible/FixedPointProjection.lean TNLean/MPS/Structure/InvariantSubspaceDecomp.lean blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch09_block_perm.tex`
- `git diff --check -- blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch11_fundamental_theorem_proof.tex blueprint/src/chapter/ch13_algebraic_ft.tex`
- `leanblueprint web` (passes locally with the existing plasTeX warnings)

Closes part of #1685.