### PR TITLE
doc(MPS/FT): correct CPSV line 246 subsection

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
@@ -192,7 +192,7 @@ lemma combined_family_eventually_li
 /-- **Coefficient norm bound under the line-246 normalization.**
 
 A direct consequence of the structural field `weight_norm_le_one`
-(CPSV16 §II.A line 246): the sector coefficient
+(CPSV16 §II.C line 246): the sector coefficient
 `P.coeff N j = ∑_q (P.weight j q)^N` is bounded in modulus by the
 multiplicity `P.copies j`.  This is the structural-field reading of the
 prior explicit-hypothesis lemma
@@ -205,7 +205,7 @@ lemma norm_coeff_le_copies
 
 /-- **Global unit-modulus weight witness from the canonical-form normalization.**
 
-Re-states the structural field `weight_unit_exists` (CPSV16 §II.A
+Re-states the structural field `weight_unit_exists` (CPSV16 §II.C
 line 246) for direct access by downstream callers that want to extract a
 global unit-modulus weight without depending on the structure layout. -/
 lemma weight_unit_exists_of_struct (h : IsBNTCanonicalForm P) :
@@ -221,7 +221,7 @@ copy witness `hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`, the power-sum coefficie
 
 The per-block unit-modulus hypothesis `hUnit` is taken as an explicit
 theorem-level argument rather than a structural field of
-`IsBNTCanonicalForm`: CPSV16 §II.A line 246 records only the *global*
+`IsBNTCanonicalForm`: CPSV16 §II.C line 246 records only the *global*
 normalization $\exists j, \exists q, \|\mu_{j,q}\| = 1$, while CPSV21
 Section IV.A uses Definition 4.2 (lines 1846–1850) for the BNT basis and
 the display at lines 1864–1884 for the two-layer expansion.  It normalizes
@@ -251,14 +251,14 @@ For any sector `j : Fin P.basisCount` such that every copy weight satisfies
 `P.coeff N j = ∑_q (P.weight j q)^N` tends to `0` as `N → ∞`.
 
 This is the **converse** of `coeff_not_tendsto_zero_at_block`: under the
-CPSV16 §II.A line-246 normalization (`weight_norm_le_one`), if **no** copy of
+CPSV16 §II.C line-246 normalization (`weight_norm_le_one`), if **no** copy of
 sector `j` carries a unit-modulus weight, then the sector's coefficient
 decays exponentially.  The argument is elementary: each summand
 `(P.weight j q)^N` tends to `0` because the closed-unit-disk strict
 inequality `‖w‖ < 1` makes the geometric sequence vanish, and a finite sum
 of vanishing sequences vanishes.
 
-Paper anchor: CPSV16 §II.A line 246 + line 1244 (the convergence half of
+Paper anchor: CPSV16 §II.C line 246 + line 1244 (the convergence half of
 the line-246 dichotomy: unit-modulus weights survive; subnormal weights
 decay).  After the Phase D per-block normalization this lemma is no longer
 on the FT critical path, but it remains a useful peripheral/subnormal-sector
@@ -286,7 +286,7 @@ theorem coeff_tendsto_zero_of_all_weights_subnorm
 A user-facing alias for `coeff_not_tendsto_zero_at_block`, named
 in the language of the audit memo
 `thermodynamic_limit_normalization_audit_2026-05-14` §Q-C: the
-CPSV16 §II.A line-246 normalization picks out the unit-modulus block(s)
+CPSV16 §II.C line-246 normalization picks out the unit-modulus block(s)
 whose power-sum coefficient does **not** vanish in the thermodynamic
 limit.
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -23,13 +23,13 @@ a `SectorDecomposition`.  It records:
 * **block distinctness** in the cast-compatible gauge-phase shape, ruling out
   gauge-phase equivalence between distinct basis blocks of equal bond
   dimension;
-* the CPSV16 §II.A line-246 **normalization convention** on the raw sector
+* the CPSV16 §II.C line-246 **normalization convention** on the raw sector
   weights `μ_{j,q}`: `|μ_{j,q}| ≤ 1` and at least one of them equals one
   (lines 246 and 1244).
 
 The per-block unit-modulus convention `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — implicit
 in CPSV16 §II.C line 1182's projection step and not explicitly stated in
-CPSV16 §II.A line 246 (which is global) nor in CPSV21 Section IV.A,
+CPSV16 §II.C line 246 (which is global) nor in CPSV21 Section IV.A,
 lines 1846–1884 (which normalizes the spectral radius of the BNT *basis
 tensors*, not the copy coefficients) — is **not** a structural field of
 `IsBNTCanonicalForm`.
@@ -143,7 +143,7 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
       ¬ GaugePhaseEquiv
           (cast (congr_arg (MPSTensor d) h) (P.basis j)) (P.basis k)
   /-- **CPSV16 line-246 normalization, modulus bound.**  Every raw sector
-  weight has modulus at most one.  CPSV16 §II.A line 246: "we can always
+  weight has modulus at most one.  CPSV16 §II.C line 246: "we can always
   choose `|μ_k| ≤ 1`"; reinvoked in the body of the FT proof at line 1244
   ("the assumed normalization `|μ_{jq}| ≤ 1` … implies that `𝔼^N` converges").
   This convention admits all counter-examples of the prior audit
@@ -153,7 +153,7 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   weight_norm_le_one : ∀ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ ≤ 1
   /-- **CPSV16 line-246 global unit witness.**  At least one copy of one
-  basis sector has unit-modulus weight.  CPSV16 §II.A line 246: "we can
+  basis sector has unit-modulus weight.  CPSV16 §II.C line 246: "we can
   always choose `|μ_k| ≤ 1` and at least one of them equals one."  This
   is the global (not per-block) normalization condition; the per-block
   refinement `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` is paper-implicit in CPSV16 §II.C

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
@@ -145,7 +145,7 @@ Let `μ : Fin r → ℂ` satisfy `‖μ q‖ ≤ 1` for every `q` and let some
 `q*` satisfy `‖μ q*‖ = 1`.  Then the sequence
 `N ↦ ∑ q, (μ q)^N` does not tend to `0`.
 
-This is the analytic lemma underlying the CPSV16 §II.A line-246
+This is the analytic lemma underlying the CPSV16 §II.C line-246
 "`|μ_k| ≤ 1` and `∃ k, |μ_k| = 1`" normalization convention when that
 normalization is read sector-by-sector in the CPSV16 §II.C line-1182
 projection argument.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
@@ -35,7 +35,7 @@ The block matching at a **user-supplied** sector index
 `j₀ : Fin P.basisCount` (with an externally provided unit-modulus
 witness) does not single out any particular sector internally: the
 `IsBNTCanonicalForm` fields are deliberately invariant under
-relabelling of sectors.  Following the CPSV16 §II.A line-246
+relabelling of sectors.  Following the CPSV16 §II.C line-246
 normalization convention, `IsBNTCanonicalForm` carries the modulus-bound
 field
 
@@ -179,7 +179,7 @@ the `j₀`-th `P`-block).
   – `basis_normalized_self_overlap` at `j = j₀` (`overlap → 1`);
   – `cross_overlap_basis_tendsto_zero` at `j ≠ j₀` (`overlap → 0`);
   – the structural field `weight_norm_le_one` of `IsBNTCanonicalForm`
-    (CPSV16 §II.A line 246) feeds into
+    (CPSV16 §II.C line 246) feeds into
     `norm_coeff_le_copies_of_norm_weight_le_one` (`Api.lean`) and gives
     the coefficient bound `‖P.coeff N j‖ ≤ P.copies j`.
 
@@ -200,7 +200,7 @@ gauge-phase equivalence, via the contrapositive of
 `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`.
 
 Hypothesis disclosure: the modulus bound `weight_norm_le_one` is a
-structural field of `IsBNTCanonicalForm` (CPSV16 §II.A line 246) and
+structural field of `IsBNTCanonicalForm` (CPSV16 §II.C line 246) and
 need not be supplied externally.  The unit-modulus witness at the
 chosen sector `j₀` is supplied externally because CPSV16 line 246 is
 **global** (the unit-modulus copy can sit in any sector); the
@@ -230,7 +230,7 @@ theorem exists_block_match_of_sameMPVPos
   -- used directly in the proof.
   have _hP_pos_used : 0 < P.basisCount := hP_pos
   have _hQ_pos_used : 0 < Q.basisCount := hQ_pos
-  -- Derive the CPSV16 §II.A line-246 modulus bounds from the strengthened
+  -- Derive the CPSV16 §II.C line-246 modulus bounds from the strengthened
   -- `IsBNTCanonicalForm` predicate.  The structural fields replace what
   -- used to be supplied as explicit parameters at the call site.
   have hP_weight_le := hP.weight_norm_le_one

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -22,7 +22,7 @@ core examples have a single BNT basis sector (`basisCount = 1`):
   equal-modulus grouping with a non-trivial phase.
 * **Example 5** — `C ⊕ (1/2)C` (`halvedDecomp`): single sector, two
   copies with raw weights `(1, 1/2)`.  Demonstrates that unequal-modulus
-  copies are admissible by the CPSV16 §II.A line-246 normalization
+  copies are admissible by the CPSV16 §II.C line-246 normalization
   (`weight_norm_le_one` holds because both `1` and `1/2` have modulus
   `≤ 1`; `weight_unit_exists` is witnessed by the first copy).
 
@@ -305,7 +305,7 @@ noncomputable example
 /-! ## Example 5 — `C ⊕ (1/2)C`, unequal-modulus admissibility
 
 This example demonstrates that the strengthened `IsBNTCanonicalForm`
-predicate (with the CPSV16 §II.A line-246 fields `weight_norm_le_one`
+predicate (with the CPSV16 §II.C line-246 fields `weight_norm_le_one`
 and `weight_unit_exists`) admits decompositions whose copies have
 **unequal** moduli: the construction below has one unit-modulus copy
 and one `1/2`-modulus copy.  This is exactly the
@@ -342,7 +342,7 @@ not a scalar power.  Demonstrates that the strengthened
 holds because `‖1‖ ≤ 1` and `‖1/2‖ = 1/2 ≤ 1`, and `weight_unit_exists`
 is witnessed by the first copy with weight `1`.
 
-Paper anchor: CPSV16 §II.A line 246, the line-246 normalization
+Paper anchor: CPSV16 §II.C line 246, the line-246 normalization
 convention permits any `|μ_{j,q}| ≤ 1` provided at least one of them
 equals `1`.  See also
 `audits/2026-05-13_cpsv16_sector_bnt_phase_1_multiplicity_audit.md` §Q4

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -27,7 +27,7 @@ $B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$.
 
 The paper's "given $k$" is *iterated externally* over each unit-block
 sector of `Q` (those with at least one unit-modulus weight, per the
-CPSV16 §II.A line-246 normalization which is recorded **globally** —
+CPSV16 §II.C line-246 normalization which is recorded **globally** —
 not per-block — in `IsBNTCanonicalForm.weight_unit_exists`).  Non-unit
 blocks contribute coefficients that decay exponentially and so do not
 constrain the matching; the paper restricts attention to the
@@ -93,7 +93,7 @@ with `(P, Q)` swapped, so it consumes the per-block unit-modulus
 witnesses on the *swapped* side, namely `hUnitQ : ∀ k, ∃ q, ‖μ_{k,q}‖ = 1`
 for $Q$.  The per-block unit-modulus convention is paper-implicit in
 CPSV16 §II.C line 1182's projection argument; it is taken here as an
-explicit theorem-level hypothesis (CPSV16 §II.A line 246 records only
+explicit theorem-level hypothesis (CPSV16 §II.C line 246 records only
 the global unit witness).
 
 Paper anchor: CPSV16 §II.C line 1182 (arXiv:1606.00608), CPSV21
@@ -162,7 +162,7 @@ once with $(Q,P)$, hence it consumes per-block unit-modulus witnesses on
 both sides: `hUnitP : ∀ j, ∃ q, ‖μ_{j,q}^P‖ = 1` and `hUnitQ : ∀ k, ∃ q,
 ‖μ_{k,q}^Q‖ = 1`.  These are paper-implicit in CPSV16 §II.C line 1182's
 projection argument and are taken as explicit theorem-level hypotheses
-here (CPSV16 §II.A line 246 records only the global unit witness). -/
+here (CPSV16 §II.C line 246 records only the global unit witness). -/
 theorem bijective_match_of_sameMPVPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.Overlap.PeripheralToSpectralGap
 # Prepared-block SectorBNT constructor
 
 Given a finite family of **already prepared** TP / primitive / irreducible /
-injective blocks with nonzero weights satisfying the CPSV16 §II.A line-246
+injective blocks with nonzero weights satisfying the CPSV16 §II.C line-246
 normalization (`|μ_k| ≤ 1` and at least one `|μ_k| = 1`), this file produces a
 `SectorDecomposition` `P` together with a proof that
 
@@ -383,7 +383,7 @@ left-canonical, primitive, irreducible, and one-site injective, with nonzero
 weights, and matching the blocked input in positive-length MPVs.
 
 This is the "everything except the weight normalization" layer.  The
-remaining ingredient is the CPSV16 §II.A line 246 normalization
+remaining ingredient is the CPSV16 §II.C line 246 normalization
 (absolute value of every weight at most one and at least one of unit modulus),
 which the source paper makes an explicit user choice ("we can always choose
 this normalization, which we will assume").  A separate normalization layer
@@ -414,7 +414,7 @@ positive blocking length `p` and a finite family of prepared blocks
 weights and positive bond dimensions) whose direct-sum tensor matches the
 `p`-blocked input `blockTensor A p` at every positive length.
 
-The CPSV16 §II.A line 246 weight normalization is **not** delivered
+The CPSV16 §II.C line 246 weight normalization is **not** delivered
 here, since the source paper makes this an explicit user assumption.  A
 separate normalization hypothesis is composed with the prepared
 blocks here to feed the `IsBNTCanonicalForm` constructor
@@ -602,10 +602,10 @@ arbitrary-input path on the SectorBNT construction, with one explicit user assum
 
 The CPSV16 paper makes the weight normalization (absolute value of every weight
 at most one and at least one of unit modulus) an explicit user choice: see
-arXiv:1606.00608, §II.A line 246 ("we can always *choose* this normalization,
+arXiv:1606.00608, §II.C line 246 ("we can always *choose* this normalization,
 which we will assume from now on").  Accordingly the end-to-end entry below
 exposes the prepared-block family produced by blocking and lets the user
-supply the §II.A line 246 normalization on those specific weights, after which
+supply the §II.C line 246 normalization on those specific weights, after which
 the prepared-block BNT constructor delivers a full `IsBNTCanonicalForm`
 decomposition together with positive-length MPV agreement.
 -/
@@ -670,7 +670,7 @@ theorem exists_isBNTCanonicalForm_afterBlocking_pos
 
 This is a bookkeeping refinement of
 `exists_isBNTCanonicalForm_afterBlocking_pos`.  The theorem keeps the same
-prepared-block output and the same CPSV16 §II.A line-246 normalization
+prepared-block output and the same CPSV16 §II.C line-246 normalization
 hypotheses.  In addition, after a normalized BNT sector decomposition is
 chosen, it records that the positive-length MPV identity upgrades to full
 `SameMPV₂` as soon as the zero-length trace identity is supplied in the

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -578,7 +578,7 @@ factorization is assumed.
     converges to $1$; the basis MPV family is eventually linearly
     independent; distinct same-dimension basis blocks are not gauge-phase
     equivalent after identifying equal bond dimensions; and the
-    \cite[\S II.A, line 246]{Cirac2017MPDO_AnnPhys} normalization holds,
+    \cite[\S II.C, line 246]{Cirac2017MPDO_AnnPhys} normalization holds,
     \[
         \forall (j,q),\ \lVert \mu_{j,q} \rVert \le 1,
         \qquad
@@ -695,7 +695,7 @@ factorization is assumed.
     \leanok
     \uses{def:sector_bnt_cf, lem:sector_bnt_norm_coeff_le_copies}
     Under the BNT canonical form, the
-    \cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} normalization yields
+    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization yields
     directly
     \[
         \bigl\lVert c_N^{(j)} \bigr\rVert \le r_j
@@ -715,7 +715,7 @@ factorization is assumed.
     \leanok
     \uses{def:sector_bnt_cf}
     Under the BNT canonical form, the
-    \cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} unit-modulus existential
+    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} unit-modulus existential
     provides indices $(j_*, q_*)$ with
     $\lVert \mu_{j_*, q_*} \rVert = 1$.
 \end{lemma}
@@ -736,7 +736,7 @@ factorization is assumed.
     $\lVert 1 \rVert \le 1$ and $\lVert 1/2 \rVert = 1/2 \le 1$, and the
     unit-modulus existential is witnessed by the first copy with
     weight $1$. This is the
-    \cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} normalization in
+    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization in
     positive form, applied to the $C \oplus (1/2)C$ example.
 \end{example}
 
@@ -773,7 +773,7 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     sequence $N \mapsto \sum_{q=0}^{r-1} (\mu_q)^N$ does not tend to $0$
     as $N \to \infty$. This is the analytic content of the unit-block
     non-decay step at
-    \cite[\S~II.A, line~246 and \S~II.C, line~1182]
+    \cite[\S~II.C, lines~246 and 1182]
         {Cirac2017MPDO_AnnPhys}.
 \end{lemma}
 
@@ -792,7 +792,7 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     sector-$j_0$ coefficient $c_N^{(j_0)} = \sum_q \mu_{j_0, q}^N$ does not
     tend to $0$ as $N \to \infty$.
 
-    This reads the \cite[\S~II.A, lines 246 and 1244]{Cirac2017MPDO_AnnPhys}
+    This reads the \cite[\S~II.C, lines 246 and 1244]{Cirac2017MPDO_AnnPhys}
     normalization sector by sector. The unit-modulus witness is supplied
     externally (as the hypothesis above) because the source statement is
     global (``at least one of them equals one'' over the two-layer index
@@ -812,7 +812,7 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     supplies the non-decay step on $c_N^{(j_0)}$. The matching theorem takes
     the unit-modulus sector and witness as explicit parameters, mirroring
     the global character of the source normalization at
-    \cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys}.
+    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys}.
 \end{remark}
 
 \subsection{Matched-sector weight multiset equality}
@@ -915,7 +915,7 @@ a single $\forall k, \exists j$ statement on the original $(P, Q)$,
 iterated externally over each $Q$-side unit-modulus sector.
 
 The unit-modulus restriction on $k$ matches the source convention:
-\cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} records the
+\cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} records the
 modulus-one hypothesis as a single \emph{global} existential over the
 two-layer $(j, q)$ index of the BNT display, not a per-block one. Sectors
 whose weights all have modulus strictly less than one have coefficients
@@ -1115,7 +1115,7 @@ The non-matched decay clause is delivered in full.
         J_1'(Q) := \{ k \in J(Q) \mid \exists q,\ \lVert \nu_{k, q}\rVert = 1 \}
     \]
     be the unit-modulus subset of $Q$-sectors
-    (\cite[\S~II.A, line~246]{Cirac2017MPDO_AnnPhys} normalization), and
+    (\cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization), and
     let $\varphi : J_1'(Q) \hookrightarrow J(P)$ be an injection equipped
     with per-pair matched-gauge witnesses for every $k \in J_1'(Q)$. Then:
     \begin{enumerate}


### PR DESCRIPTION
## Summary

This documentation-only PR corrects the source subsection used for the CPSV16 line-246 normalization in the SectorBNT files.

The local TeX source `Papers/1606.00608/MPDO-22-12-17-2.tex` has subsection "Canonical forms" beginning at line 184. The canonical-form display `eq:II_CF1` is labelled at line 240, and the normalization sentence `|μ_k| ≤ 1` with a unit-modulus witness is line 246. Thus these citations should read `§II.C line 246`, not `§II.A line 246`.

No theorem statements, proof terms, imports, or blueprint tags change.

## Checks

- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean`
- `git diff --check -- TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean blueprint/src/chapter/ch10_bnt.tex`
- `cd blueprint && leanblueprint web`

Refs #1685 and #1753.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are citation/comment updates only and do not modify theorem statements, proof terms, or behavior.
> 
> **Overview**
> Updates documentation strings and explanatory comments in the SectorBNT Lean modules and `blueprint/src/chapter/ch10_bnt.tex` to cite the CPSV16 line-246 normalization as **§II.C line 246** (instead of **§II.A line 246**).
> 
> No functional changes: imports, definitions, theorem statements, and proofs remain unchanged; this is purely a reference/citation correction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c2404097561530c058280fc38302eb6b7ab0be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

