### PR TITLE
doc(blueprint): tighten BNT source locators

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -591,7 +591,7 @@ factorization is assumed.
         \sum_{j=1}^{g} \left(\sum_{q=1}^{r_j} \mu_{j,q}^N\right)
         V^{(N)}(P_j)_\sigma,
     \]
-    matching \cite[\S~II, lines 271--301]{Cirac2017MPDO_AnnPhys}
+    matching \cite[\S~II.C, lines 271--301]{Cirac2017MPDO_AnnPhys}
     and \cite[Definition~4.2, Proposition~4.3, and lines 1864--1884]
         {Cirac2021Matrix}.
     The line-246 normalization admits every example of the source paper
@@ -610,7 +610,9 @@ factorization is assumed.
     \[
         c_N^{(j)} = \sum_{q=1}^{r_j} \mu_{j,q}^N.
     \]
-    This is \cite[eq.~II, lines 287--301]{Cirac2017MPDO_AnnPhys} and
+    This is
+    \cite[two-layer BNT and coefficient-expansion displays,
+    lines 287--301]{Cirac2017MPDO_AnnPhys} and
     \cite[lines 1864--1884]{Cirac2021Matrix}.
 \end{lemma}
 
@@ -828,13 +830,13 @@ recovery (Theorem~\ref{thm:power_sum_multiset}), and the
 \emph{matched-sector weight-permutation extractor} upgrading the multiset
 equality to an explicit per-copy indexing. Together they realise the
 $\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ recovery of
-\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
+\cite[Appendix proof, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
 the preceding block-selection argument supplies the matched normal sectors
-\cite[\S~II, line 1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
+\cite[Appendix proof, line 1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
 used here is the equal-MPV coefficient comparison of
-\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
+\cite[Appendix proof, lines 1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
 global-gauge assembly in
-\cite[\S~II, lines 1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
+\cite[Appendix proof, lines 1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
 is supplied by the substitution argument of
 Section~\ref{subsec:sector_bnt_substitution} below.
 
@@ -852,7 +854,7 @@ Section~\ref{subsec:sector_bnt_substitution} below.
     \]
     Then the per-sector multiplicities agree, $r_{j_0}(P) = r_{\tilde k_0}(Q)$,
     and the rescaled per-copy weight multisets coincide.
-    This is \cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}
+    This is \cite[Appendix proof, lines 1184--1188]{Cirac2017MPDO_AnnPhys}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ and matching
     multiplicities $r_{a,j} = r_{b,j}$) read on a single matched sector.
 \end{lemma}
@@ -887,7 +889,7 @@ Section~\ref{subsec:sector_bnt_substitution} below.
         \nu_{\tilde k_0, \tau(q)} = \zeta^{-1} \cdot \mu_{j_0, q}.
     \]
     This is the per-copy realisation of
-    \cite[\S~II, line 1188]{Cirac2017MPDO_AnnPhys}
+    \cite[Appendix proof, line 1188]{Cirac2017MPDO_AnnPhys}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$): the multiset equality
     from Lemma~\ref{lem:sector_bnt_matched_sector_weight_multiset_eq} is
     upgraded to a concrete indexing between the matched $P$- and
@@ -984,7 +986,7 @@ Applying the same theorem once more with the roles of $P$ and $Q$
 swapped (and the trivially symmetric flip of the proportional-MPV
 hypothesis) gives the other direction. The two matchings, combined
 with the basis-distinctness clause of the canonical-form predicate
-\cite[\S~II, lines 264--279]{Cirac2017MPDO_AnnPhys}, force injectivity
+\cite[\S~II.C, lines 264--279]{Cirac2017MPDO_AnnPhys}, force injectivity
 in both directions.
 
 \paragraph{Scope.}
@@ -1048,7 +1050,7 @@ argument of Section~\ref{subsec:sector_bnt_substitution}.
     dimension equality
     $\dim_Q(k_1) = \dim_Q(k_2)$. The basis-distinctness clause of the
     canonical-form predicate on $Q$
-    (\cite[\S~II, lines 264--279]{Cirac2017MPDO_AnnPhys}) then forces
+    (\cite[\S~II.C, lines 264--279]{Cirac2017MPDO_AnnPhys}) then forces
     $k_1 = k_2$. Backward injectivity is symmetric.
 
     \emph{Injective embeddings.} The injective functions, paired with the


### PR DESCRIPTION
## Summary

This blueprint-only PR tightens Chapter 10 source locators for the BNT proof path.

- Cites the BNT definition and two-layer display at CPSV16 Section II.C, lines 271--301.
- Names the displays labelled `eq:II_ABasicTensors` and `decBSV` instead of the vague `eq. II` wording.
- Describes the line 1182 and 1184--1192 arguments as the appendix proof, since those local line numbers are in the appendix proof of the Section II.C theorem/corollary rather than in the body subsection.

No Lean declarations, proof terms, imports, or blueprint declaration tags change.

## Checks

- `git diff --check -- blueprint/src/chapter/ch10_bnt.tex`
- `rg -n "\\S~?II[^.C]|\\S~II,|eq\\.~II" blueprint/src/chapter/ch10_bnt.tex`

Refs #1685 and #1749.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: blueprint-only LaTeX citation/wording adjustments with no Lean code, proofs, or APIs changed.
> 
> **Overview**
> Tightens Chapter 10 (BNT) source references by updating CPSV16 citations to the correct subsection/appendix locations (e.g. `\S~II.C` and *Appendix proof* line ranges) and making the referenced displays more explicit.
> 
> No mathematical statements, Lean tags, or proof content change; this PR only improves citation precision/traceability in `ch10_bnt.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12fa1af2dad8803a21221b9353313904c676103c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->