### PR TITLE
doc(blueprint): place representations before semigroups

### DIFF
--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -93,6 +93,7 @@ gives the fixed-length algebraic Fundamental Theorem of~\cite{Molnar2018NormalPE
 and Chapter~\ref{ch:peps_ft} records the PEPS analogs. Parent Hamiltonians,
 correlations, and examples are treated after the PEPS material. Channel
 representations and normal forms are then collected immediately before quantum
-dynamical semigroups; entropy and matrix product density operators follow.
-These later topics use the aperiodic theorem, or develop later
-finite-dimensional channel theory, rather than enter its proof.
+dynamical semigroups and the operator-convexity material; entropy and matrix
+product density operators follow. These later topics use the aperiodic
+theorem, or develop later finite-dimensional channel theory, rather than enter
+its proof.

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -90,8 +90,9 @@ rotation (Definition~\ref{def:rotate_physical} in Chapter~\ref{ch:symmetry}).
 % algebraic-FT chapter.
 Chapter~\ref{ch:algebraic_ft}
 gives the fixed-length algebraic Fundamental Theorem of~\cite{Molnar2018NormalPEPS},
-and Chapter~\ref{ch:peps_ft} records the PEPS analogs. Channel representations
-and normal forms, quantum dynamical semigroups, entropy, matrix product density
-operators, parent Hamiltonians, correlations, and examples are treated
-afterwards; these topics use the aperiodic theorem, or develop later
+and Chapter~\ref{ch:peps_ft} records the PEPS analogs. Parent Hamiltonians,
+correlations, and examples are treated after the PEPS material. Channel
+representations and normal forms are then collected immediately before quantum
+dynamical semigroups; entropy and matrix product density operators follow.
+These later topics use the aperiodic theorem, or develop later
 finite-dimensional channel theory, rather than enter its proof.

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -15,13 +15,12 @@
 \input{chapter/ch11b_periodic_ft}
 \input{chapter/ch13_algebraic_ft}
 \input{chapter/ch13a_peps_ft}
+\input{chapter/ch14_parent_hamiltonian}
+\input{chapter/ch15_correlations}
+\input{chapter/ch16_examples}
 \input{chapter/ch04a_channel_representations}
 \input{chapter/ch12_semigroup}
 \input{chapter/ch17_operator_convexity}
 \input{chapter/ch04b_entropy}
 \input{chapter/ch04c_entropy_corollaries}
 \input{chapter/ch02b_mpdo}
-% --- Parent Hamiltonians & Correlations (planned) ---
-\input{chapter/ch14_parent_hamiltonian}
-\input{chapter/ch15_correlations}
-\input{chapter/ch16_examples}


### PR DESCRIPTION
## Summary

This blueprint-only PR moves the later Wolf Chapter 2 channel-representation material to the place requested by the proof narrative: after the immediate post-FT application chapters and immediately before quantum dynamical semigroups.

- Reorders `blueprint/src/content.tex` so parent Hamiltonians, correlations, and examples follow the PEPS material before channel representations.
- Keeps `ch04a_channel_representations` immediately before `ch12_semigroup`.
- Updates the Chapter 1 roadmap sentence to match the new ordering.

No Lean declarations, proof terms, imports, or blueprint declaration tags change.

## Checks

- `git diff --check -- blueprint/src/content.tex blueprint/src/chapter/ch01_intro.tex`
- `leanblueprint web` — passed locally, with the repository's usual plasTeX package/default-renderer warnings

Closes LionSR/TNLean#1920.
Refs LionSR/TNLean#1809, LionSR/QICLean#49.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only reorders LaTeX blueprint chapter inclusion and adjusts narrative text, with no Lean code or proof artifacts affected.
> 
> **Overview**
> Updates the blueprint document structure so `ch04a_channel_representations` is moved to *immediately precede* `ch12_semigroup`, with parent Hamiltonians/correlations/examples now appearing right after the PEPS chapter.
> 
> Adjusts the Chapter 1 roadmap paragraph to reflect the new post-FT ordering (parent Hamiltonians/correlations/examples before representations/normal forms, then semigroups/operator convexity, then entropy/MPDO).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804e16636c4b1d12396a514666bbb0b1471334d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->