### PR TITLE
doc(blueprint): remove stale direct-sum duplicate

### DIFF
--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -207,28 +207,6 @@ recorded in the accompanying paper-gap note.\footnote{%
     block permutation together with per-block inner automorphisms.
 \end{proof}
 
-\begin{lemma}[Per-block same-MPV condition gives global gauge equivalence]\label{lem:per_block_gauge}
-    \lean{MPSTensor.fundamentalTheorem_multiBlock_full}
-    \leanok
-    \uses{def:injective, def:gauge_equiv, def:block_diagonal_tensor}
-    If all block tensors $A_k$ are injective, and $B_k$ are
-    block tensors of the same bond dimensions such that the per-block
-    same-MPV condition holds, then each pair $(A_k, B_k)$ is gauge
-    equivalent, and the block-diagonal tensors
-    $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \mu_k B_k$
-    are globally gauge equivalent.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    \uses{thm:ft_single, lem:multi_block_global}
-    Per-block gauge equivalence follows from the single-block
-    fundamental theorem (Theorem~\ref{thm:ft_single}) applied to each block.
-    Global gauge equivalence follows by placing the
-    per-block gauge matrices on the block diagonal
-    (Lemma~\ref{lem:multi_block_global}).
-\end{proof}
-
 \section{Burnside and invariant projections}
 
 \begin{lemma}[The algebra span reaches a finite cumulative span]\label{lem:algspan_cumulative_span}
@@ -545,9 +523,9 @@ We use this notation throughout the block-separation argument.
 
 \begin{proof}
     \leanok
-    \uses{lem:block_sep, lem:per_block_gauge}
+    \uses{lem:block_sep, lem:fundamentalTheorem_multiBlock_full}
     Lemma~\ref{lem:block_sep} gives per-block same MPV.
-    Lemma~\ref{lem:per_block_gauge} then converts this to
+    Lemma~\ref{lem:fundamentalTheorem_multiBlock_full} then converts this to
     per-block gauge equivalence and then to global gauge equivalence
     of the block-diagonal tensors.
 \end{proof}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -591,7 +591,7 @@ factorization is assumed.
         \sum_{j=1}^{g} \left(\sum_{q=1}^{r_j} \mu_{j,q}^N\right)
         V^{(N)}(P_j)_\sigma,
     \]
-    matching \cite[\S~II, lines 271--301]{Cirac2017MPDO_AnnPhys}
+    matching \cite[\S~II.C, lines 271--301]{Cirac2017MPDO_AnnPhys}
     and \cite[Definition~4.2, Proposition~4.3, and lines 1864--1884]
         {Cirac2021Matrix}.
     The line-246 normalization admits every example of the source paper
@@ -610,7 +610,9 @@ factorization is assumed.
     \[
         c_N^{(j)} = \sum_{q=1}^{r_j} \mu_{j,q}^N.
     \]
-    This is \cite[eq.~II, lines 287--301]{Cirac2017MPDO_AnnPhys} and
+    This is
+    \cite[two-layer BNT and coefficient-expansion displays,
+    lines 287--301]{Cirac2017MPDO_AnnPhys} and
     \cite[lines 1864--1884]{Cirac2021Matrix}.
 \end{lemma}
 
@@ -828,13 +830,13 @@ recovery (Theorem~\ref{thm:power_sum_multiset}), and the
 \emph{matched-sector weight-permutation extractor} upgrading the multiset
 equality to an explicit per-copy indexing. Together they realise the
 $\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ recovery of
-\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
+\cite[Appendix proof, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
 the preceding block-selection argument supplies the matched normal sectors
-\cite[\S~II, line 1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
+\cite[Appendix proof, line 1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
 used here is the equal-MPV coefficient comparison of
-\cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
+\cite[Appendix proof, lines 1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
 global-gauge assembly in
-\cite[\S~II, lines 1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
+\cite[Appendix proof, lines 1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
 is supplied by the substitution argument of
 Section~\ref{subsec:sector_bnt_substitution} below.
 
@@ -852,7 +854,7 @@ Section~\ref{subsec:sector_bnt_substitution} below.
     \]
     Then the per-sector multiplicities agree, $r_{j_0}(P) = r_{\tilde k_0}(Q)$,
     and the rescaled per-copy weight multisets coincide.
-    This is \cite[\S~II, lines 1184--1188]{Cirac2017MPDO_AnnPhys}
+    This is \cite[Appendix proof, lines 1184--1188]{Cirac2017MPDO_AnnPhys}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ and matching
     multiplicities $r_{a,j} = r_{b,j}$) read on a single matched sector.
 \end{lemma}
@@ -887,7 +889,7 @@ Section~\ref{subsec:sector_bnt_substitution} below.
         \nu_{\tilde k_0, \tau(q)} = \zeta^{-1} \cdot \mu_{j_0, q}.
     \]
     This is the per-copy realisation of
-    \cite[\S~II, line 1188]{Cirac2017MPDO_AnnPhys}
+    \cite[Appendix proof, line 1188]{Cirac2017MPDO_AnnPhys}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$): the multiset equality
     from Lemma~\ref{lem:sector_bnt_matched_sector_weight_multiset_eq} is
     upgraded to a concrete indexing between the matched $P$- and
@@ -984,7 +986,7 @@ Applying the same theorem once more with the roles of $P$ and $Q$
 swapped (and the trivially symmetric flip of the proportional-MPV
 hypothesis) gives the other direction. The two matchings, combined
 with the basis-distinctness clause of the canonical-form predicate
-\cite[\S~II, lines 264--279]{Cirac2017MPDO_AnnPhys}, force injectivity
+\cite[\S~II.C, lines 264--279]{Cirac2017MPDO_AnnPhys}, force injectivity
 in both directions.
 
 \paragraph{Scope.}
@@ -1048,7 +1050,7 @@ argument of Section~\ref{subsec:sector_bnt_substitution}.
     dimension equality
     $\dim_Q(k_1) = \dim_Q(k_2)$. The basis-distinctness clause of the
     canonical-form predicate on $Q$
-    (\cite[\S~II, lines 264--279]{Cirac2017MPDO_AnnPhys}) then forces
+    (\cite[\S~II.C, lines 264--279]{Cirac2017MPDO_AnnPhys}) then forces
     $k_1 = k_2$. Backward injectivity is symmetric.
 
     \emph{Injective embeddings.} The injective functions, paired with the


### PR DESCRIPTION
## Summary
- remove the stale Chapter 9 blueprint entry for `MPSTensor.fundamentalTheorem_multiBlock_full`
- retarget the Chapter 9 canonical-form comparison proof to the Chapter 13 direct-sum lemma
- keep Chapter 9 focused on block permutation and block separation, with direct-sum gauge assembly recorded only once

## Checks
- `git diff --check -- blueprint/src/chapter/ch09_block_perm.tex`
- `leanblueprint web`

Closes #1923.
Refs #1918.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to LaTeX blueprint prose/`\uses` references and citation annotations, with no impact on Lean code or mathematical statements formalized elsewhere.
> 
> **Overview**
> Removes the duplicate Chapter 9 lemma that restated `MPSTensor.fundamentalTheorem_multiBlock_full` (per-block same-MPV ⇒ per-block gauges ⇒ block-diagonal gauge), keeping that direct-sum gauge assembly recorded only once.
> 
> Retargets the Chapter 9 canonical-form comparison proof to cite `lem:fundamentalTheorem_multiBlock_full` (now referenced from its Chapter 13 location) instead of the removed local wrapper lemma.
> 
> Updates Chapter 10 BNT section citations/attributions to point to the correct sub-sections and “Appendix proof” line ranges in `Cirac2017MPDO_AnnPhys`, without changing the underlying statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d457df2168770027b93b8a30c1cc2f9f00a7dfdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->