### PR TITLE
doc(blueprint): correct BNT appendix locators

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -554,8 +554,8 @@ and~\cite{Cirac2021Matrix}.
 \label{sec:sector_bnt_api}
 
 This section introduces the BNT canonical-form predicate following
-\cite[\S II, lines 287--301]{Cirac2017MPDO_AnnPhys} and
-\cite[Definition~4.2, Proposition~4.3, and lines 1864--1884]{Cirac2021Matrix}.
+\cite[\S II, lines~287--301]{Cirac2017MPDO_AnnPhys} and
+\cite[Definition~4.2, Proposition~4.3, and lines~1864--1884]{Cirac2021Matrix}.
 The predicate is
 defined on a sector decomposition with raw sector weights $\mu_{j,q}$ and
 sector coefficients $c_N^{(j)} = \sum_q \mu_{j,q}^{\,N}$; no equal-modulus
@@ -578,7 +578,7 @@ factorization is assumed.
     converges to $1$; the basis MPV family is eventually linearly
     independent; distinct same-dimension basis blocks are not gauge-phase
     equivalent after identifying equal bond dimensions; and the
-    \cite[\S II.C, line 246]{Cirac2017MPDO_AnnPhys} normalization holds,
+    \cite[\S II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization holds,
     \[
         \forall (j,q),\ \lVert \mu_{j,q} \rVert \le 1,
         \qquad
@@ -591,8 +591,8 @@ factorization is assumed.
         \sum_{j=1}^{g} \left(\sum_{q=1}^{r_j} \mu_{j,q}^N\right)
         V^{(N)}(P_j)_\sigma,
     \]
-    matching \cite[\S~II.C, lines 271--301]{Cirac2017MPDO_AnnPhys}
-    and \cite[Definition~4.2, Proposition~4.3, and lines 1864--1884]
+    matching \cite[\S~II.C, lines~271--301]{Cirac2017MPDO_AnnPhys}
+    and \cite[Definition~4.2, Proposition~4.3, and lines~1864--1884]
         {Cirac2021Matrix}.
     The line-246 normalization admits every example of the source paper
     (in particular $C \oplus D$, $C \oplus (-C)$,
@@ -612,8 +612,8 @@ factorization is assumed.
     \]
     This is
     \cite[two-layer BNT and coefficient-expansion displays,
-    lines 287--301]{Cirac2017MPDO_AnnPhys} and
-    \cite[lines 1864--1884]{Cirac2021Matrix}.
+    lines~287--301]{Cirac2017MPDO_AnnPhys} and
+    \cite[lines~1864--1884]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -626,7 +626,7 @@ factorization is assumed.
     \leanok
     \uses{lem:sector_bnt_coeff_eq_sum_weight_pow}
     Under the optional global modulus normalization
-    \cite[\S II, lines 217--246]{Cirac2017MPDO_AnnPhys}, every raw weight satisfies
+    \cite[\S II, lines~217--246]{Cirac2017MPDO_AnnPhys}, every raw weight satisfies
     $\lVert \mu_{j,q} \rVert \le 1$, and the triangle inequality bounds
     the norm of the sector coefficient by the multiplicity:
     \[
@@ -649,10 +649,10 @@ factorization is assumed.
     $O_{P_j P_k}(N) \to 0$ as $N \to \infty$, where $P_j$ and $P_k$ are the
     basis blocks at indices $j$ and $k$. The argument follows the
     normal-tensor overlap dichotomy of
-    \cite[lines 1080--1091]{Cirac2017MPDO_AnnPhys}: differing bond dimensions
+    \cite[lines~1080--1091]{Cirac2017MPDO_AnnPhys}: differing bond dimensions
     force decay, and matching bond dimensions are ruled out by the
     gauge-phase distinctness clause of
-    \cite[lines 264--279]{Cirac2017MPDO_AnnPhys}.
+    \cite[lines~264--279]{Cirac2017MPDO_AnnPhys}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -678,9 +678,9 @@ factorization is assumed.
         \bigl\{\ket{V^{(N)}(Q_k)}\bigr\}_{k=1}^{g_Q}
     \]
     is linearly independent for all sufficiently large $N$. This is the
-    corollary at \cite[lines 1121--1132]{Cirac2017MPDO_AnnPhys}, matching
+    corollary at \cite[lines~1121--1132]{Cirac2017MPDO_AnnPhys}, matching
     the BNT linear-independence input recorded at
-    \cite[line 1850]{Cirac2021Matrix}.
+    \cite[line~1850]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -832,13 +832,13 @@ recovery (Theorem~\ref{thm:power_sum_multiset}), and the
 \emph{matched-sector weight-permutation extractor} upgrading the multiset
 equality to an explicit per-copy indexing. Together they realise the
 $\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ recovery of
-\cite[Appendix proof, lines 1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
+\cite[Appendix proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
 the preceding block-selection argument supplies the matched normal sectors
-\cite[Appendix proof, line 1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
+\cite[Appendix proof, line~1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
 used here is the equal-MPV coefficient comparison of
-\cite[Appendix proof, lines 1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
+\cite[Appendix proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
 global-gauge assembly in
-\cite[Appendix proof, lines 1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
+\cite[Appendix proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
 is supplied by the substitution argument of
 Section~\ref{subsec:sector_bnt_substitution} below.
 
@@ -856,7 +856,7 @@ Section~\ref{subsec:sector_bnt_substitution} below.
     \]
     Then the per-sector multiplicities agree, $r_{j_0}(P) = r_{\tilde k_0}(Q)$,
     and the rescaled per-copy weight multisets coincide.
-    This is \cite[Appendix proof, lines 1184--1188]{Cirac2017MPDO_AnnPhys}
+    This is \cite[Appendix proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ and matching
     multiplicities $r_{a,j} = r_{b,j}$) read on a single matched sector.
 \end{lemma}
@@ -891,7 +891,7 @@ Section~\ref{subsec:sector_bnt_substitution} below.
         \nu_{\tilde k_0, \tau(q)} = \zeta^{-1} \cdot \mu_{j_0, q}.
     \]
     This is the per-copy realisation of
-    \cite[Appendix proof, line 1188]{Cirac2017MPDO_AnnPhys}
+    \cite[Appendix proof, line~1188]{Cirac2017MPDO_AnnPhys}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$): the multiset equality
     from Lemma~\ref{lem:sector_bnt_matched_sector_weight_multiset_eq} is
     upgraded to a concrete indexing between the matched $P$- and
@@ -926,7 +926,7 @@ whose weights all have modulus strictly less than one have coefficients
 $c_N^{(k)}(Q) = \sum_q \nu_{k,q}^N$ that decay exponentially to zero,
 contribute nothing to the thermodynamic state, and are not constrained by
 the matching
-(\cite[Appendix ``Proofs of Section MPS'', lines 1244--1248]
+(\cite[Appendix ``Proofs of Section MPS'', lines~1244--1248]
 {Cirac2017MPDO_AnnPhys} returns to this point through the transfer-power
 fixed-point characterisation). The bijective-matching theorem below applies the
 strong existential theorem twice (with $(P, Q)$ swapped) to derive the
@@ -971,7 +971,7 @@ normalization).
     itself routes through the linear-independence step
     (Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}) on the
     \emph{full} family $\{P_j\}_j \sqcup \{Q_k\}_k$, the corollary
-    input of \cite[Appendix MPV corollary, lines 1131--1133]
+    input of \cite[Appendix MPV corollary, lines~1131--1133]
         {Cirac2017MPDO_AnnPhys}, not
     on any partial union.
 \end{remark}
@@ -990,7 +990,7 @@ Applying the same theorem once more with the roles of $P$ and $Q$
 swapped (and the trivially symmetric flip of the proportional-MPV
 hypothesis) gives the other direction. The two matchings, combined
 with the basis-distinctness clause of the canonical-form predicate
-\cite[\S~II.C, lines 264--279]{Cirac2017MPDO_AnnPhys}, force injectivity
+\cite[\S~II.C, lines~264--279]{Cirac2017MPDO_AnnPhys}, force injectivity
 in both directions.
 
 \paragraph{Scope.}
@@ -1054,7 +1054,7 @@ argument of Section~\ref{subsec:sector_bnt_substitution}.
     dimension equality
     $\dim_Q(k_1) = \dim_Q(k_2)$. The basis-distinctness clause of the
     canonical-form predicate on $Q$
-    (\cite[\S~II.C, lines 264--279]{Cirac2017MPDO_AnnPhys}) then forces
+    (\cite[\S~II.C, lines~264--279]{Cirac2017MPDO_AnnPhys}) then forces
     $k_1 = k_2$. Backward injectivity is symmetric.
 
     \emph{Injective embeddings.} The injective functions, paired with the
@@ -1071,7 +1071,7 @@ Given the matched gauges produced by the strong existential theorem
 encoded as the injection from
 Section~\ref{subsec:sector_bnt_strong_match_bijective_symmetry}, the per-block
 coefficient identity of
-\cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys} follows by
+\cite[Appendix MPV proof, lines~1187--1188]{Cirac2017MPDO_AnnPhys} follows by
 substituting the per-pair gauge identity
 $V^{(N)}(Q_k)_\sigma = \zeta_k^N \cdot V^{(N)}(P_{\varphi(k)})_\sigma$
 into the proportional-MPV hypothesis and projecting the resulting overlap
@@ -1090,7 +1090,7 @@ $N \to \infty$, which is the natural output of the overlap-projection
 argument; the upgrade to the eventual-exact form is provided by the
 multiset-rigidity Theorem~\ref{thm:power_sum_multiset}, the
 Newton--Girard input behind
-\cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys}.
+\cite[Appendix MPV proof, lines~1187--1188]{Cirac2017MPDO_AnnPhys}.
 The non-matched decay clause is delivered in full.
 
 \begin{lemma}[Coefficient decay for subnormal sectors]
@@ -1155,18 +1155,18 @@ The non-matched decay clause is delivered in full.
     \]
     On the left-hand side, the off-diagonal terms $j \neq j_0$ decay by
     Lemma~\ref{lem:sector_bnt_cross_overlap_basis_tendsto_zero}
-    (\cite[lines 1080--1091]{Cirac2017MPDO_AnnPhys}), and the diagonal
+    (\cite[lines~1080--1091]{Cirac2017MPDO_AnnPhys}), and the diagonal
     term
     $c_N^{(j_0)}(P) \cdot (\braket{V^{(N)}(P_{j_0})}{V^{(N)}(P_{j_0})} - 1)$
     decays by the normalized self-overlap
-    (\cite[line 1818]{Cirac2021Matrix}). Hence
+    (\cite[line~1818]{Cirac2021Matrix}). Hence
     $\text{LHS} - c_N^{(j_0)}(P) \to 0$.
 
     On the right-hand side, split $k$ into $J_1'(Q)$ and its complement.
     \begin{itemize}
         \item For $k \in J_1'(Q)$, substitute via the gauge identity
               $V^{(N)}(Q_k)_\sigma = \zeta_k^N \cdot V^{(N)}(P_{\varphi(k)})_\sigma$
-              of \cite[line 1186]{Cirac2017MPDO_AnnPhys}; the unit-modulus
+              of \cite[line~1186]{Cirac2017MPDO_AnnPhys}; the unit-modulus
               closure $\lVert\zeta_k\rVert = 1$ follows from the
               norm-from-overlap lemma and the convergence of both per-block
               normalized self-overlaps to $1$. If $\varphi(k) = j_0$, the
@@ -1177,7 +1177,7 @@ The non-matched decay clause is delivered in full.
               $< 1$, so $c_N^{(k)}(Q) \to 0$ by
               Lemma~\ref{thm:sector_bnt_coeff_tendsto_zero_of_all_weights_subnorm};
               combined with the uniform overlap bound from left-canonical
-              normalization (\cite[lines 1815--1837]{Cirac2021Matrix}), the
+              normalization (\cite[lines~1815--1837]{Cirac2021Matrix}), the
               contribution decays to $0$.
     \end{itemize}
     Combining the per-$k$ contributions yields
@@ -1201,7 +1201,7 @@ The non-matched decay clause is delivered in full.
     Lemma~\ref{lem:sector_bnt_coeff_identity_via_global_gauge}, which is a
     full-basis equal-MPV statement. The projected theorem follows
     the substitution route of
-    \cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys}: substitute
+    \cite[Appendix MPV proof, lines~1187--1188]{Cirac2017MPDO_AnnPhys}: substitute
     the per-pair gauge phases into the proportional-MPV identity, reduce
     to the $P$-only relation, and extract per-$j$ coefficient identities
     from cross-overlap decay alone. The result handles the
@@ -1264,7 +1264,7 @@ matching covers the whole BNT basis.
         \zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma
     \]
     This records the per-block phase conclusion of
-    \cite[Appendix MPV theorem statement, lines 1167--1170]
+    \cite[Appendix MPV theorem statement, lines~1167--1170]
         {Cirac2017MPDO_AnnPhys}; the proof step at
     \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys} is the
     corresponding argument. The following coefficient-comparison step is
@@ -1305,7 +1305,7 @@ matching covers the whole BNT basis.
         \zeta_k^N\,c_N^{(k)}(Q).
     \]
     This is the coefficient-comparison step of
-    \cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys} in full-basis
+    \cite[Appendix MPV proof, lines~1187--1188]{Cirac2017MPDO_AnnPhys} in full-basis
     form.
 \end{lemma}
 
@@ -1337,7 +1337,7 @@ matching covers the whole BNT basis.
         c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q).
     \]
     This is the full-basis equal-MPV coefficient comparison of
-    \cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys}.
+    \cite[Appendix MPV proof, lines~1187--1188]{Cirac2017MPDO_AnnPhys}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1377,7 +1377,7 @@ matching covers the whole BNT basis.
         X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
     \]
     This is the direct-sum gauge assembly of
-    \cite[Appendix MPV proof, lines 1189--1192]{Cirac2017MPDO_AnnPhys}, separated from
+    \cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}, separated from
     the coefficient-comparison step that supplies the weight identities.
 \end{theorem}
 
@@ -1417,9 +1417,9 @@ matching covers the whole BNT basis.
     Thus, after the remaining proportional coefficient comparison supplies
     the displayed copy-weight identities, the direct-sum gauge assembly uses
     the same algebra as the equal-MPV corollary in
-    \cite[Appendix MPV proof, lines 1189--1192]{Cirac2017MPDO_AnnPhys}.
+    \cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}.
     The source proportional theorem itself stops at the sector matching in
-    \cite[Appendix MPV theorem statement, lines 1167--1170]
+    \cite[Appendix MPV theorem statement, lines~1167--1170]
         {Cirac2017MPDO_AnnPhys} and
     \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys};
     lines~1187--1192 do not supply the missing proportional coefficient
@@ -1479,7 +1479,7 @@ matching covers the whole BNT basis.
     \]
     for every physical index $i$. This is the explicit direct-sum gauge
     construction of
-    \cite[Appendix MPV proof, lines 1189--1192]{Cirac2017MPDO_AnnPhys}.
+    \cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1521,7 +1521,7 @@ matching covers the whole BNT basis.
     where $P_{\mathrm{tot}}^i$ and $Q_{\mathrm{tot}}^i$ are both regarded as
     matrices in $\MN{D}$ using the total bond-dimension equality. This is the
     normalized BNT form of
-    \cite[Corollary~II.2 and Appendix MPV proof, lines 1189--1192]
+    \cite[Corollary~II.2 and Appendix MPV proof, lines~1189--1192]
         {Cirac2017MPDO_AnnPhys}, under the same unit-modulus-copy normalization
     as Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
 \end{theorem}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1422,9 +1422,11 @@ matching covers the whole BNT basis.
     \cite[Appendix MPV theorem statement, lines~1167--1170]
         {Cirac2017MPDO_AnnPhys} and
     \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys};
-    lines~1187--1192 do not supply the missing proportional coefficient
-    comparison, because in the equal-MPV corollary the length-dependent
-    proportionality scalar is identically~$1$.
+    the coefficient-comparison passage at
+    \cite[Appendix MPV proof, lines~1187--1192]{Cirac2017MPDO_AnnPhys}
+    does not supply the missing proportional coefficient comparison, because
+    in the equal-MPV corollary the length-dependent proportionality scalar is
+    identically~$1$.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -749,7 +749,7 @@ This section formalizes the analytic input that supplies, for any
 sector $j_0$ carrying a unit-modulus weight, the
 ``sector-$j_0$ coefficient does not asymptotically vanish''
 ingredient used in the matching step of
-\cite[\S~II.C, line~1182]{Cirac2017MPDO_AnnPhys}.
+\cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}.
 The reduction is to a pure-analytic statement: a finite sum of $N$-th
 powers of complex numbers in the closed unit disk, with at least one
 unit-modulus summand, cannot tend to zero.
@@ -775,8 +775,8 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     sequence $N \mapsto \sum_{q=0}^{r-1} (\mu_q)^N$ does not tend to $0$
     as $N \to \infty$. This is the analytic content of the unit-block
     non-decay step at
-    \cite[\S~II.C, lines~246 and 1182]
-        {Cirac2017MPDO_AnnPhys}.
+    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} and
+    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -794,8 +794,10 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     sector-$j_0$ coefficient $c_N^{(j_0)} = \sum_q \mu_{j_0, q}^N$ does not
     tend to $0$ as $N \to \infty$.
 
-    This reads the \cite[\S~II.C, lines 246 and 1244]{Cirac2017MPDO_AnnPhys}
-    normalization sector by sector. The unit-modulus witness is supplied
+    This reads the \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys}
+    normalization sector by sector, together with the convergence use at
+    \cite[Appendix ``Proofs of Section MPS'', line~1244]
+        {Cirac2017MPDO_AnnPhys}. The unit-modulus witness is supplied
     externally (as the hypothesis above) because the source statement is
     global (``at least one of them equals one'' over the two-layer index
     $(j, q)$) and does not pin the witness to a specific sector.
@@ -810,7 +812,7 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
 
 \begin{remark}
     Used inside the matching theorem of
-    \cite[\S~II.C, line~1182]{Cirac2017MPDO_AnnPhys} this lemma
+    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys} this lemma
     supplies the non-decay step on $c_N^{(j_0)}$. The matching theorem takes
     the unit-modulus sector and witness as explicit parameters, mirroring
     the global character of the source normalization at
@@ -923,9 +925,10 @@ two-layer $(j, q)$ index of the BNT display, not a per-block one. Sectors
 whose weights all have modulus strictly less than one have coefficients
 $c_N^{(k)}(Q) = \sum_q \nu_{k,q}^N$ that decay exponentially to zero,
 contribute nothing to the thermodynamic state, and are not constrained by
-the matching (\cite[\S~II.C, lines 1244--1248]{Cirac2017MPDO_AnnPhys}
-returns to this point through the transfer-power fixed-point
-characterisation). The bijective-matching theorem below applies the
+the matching
+(\cite[Appendix ``Proofs of Section MPS'', lines 1244--1248]
+{Cirac2017MPDO_AnnPhys} returns to this point through the transfer-power
+fixed-point characterisation). The bijective-matching theorem below applies the
 strong existential theorem twice (with $(P, Q)$ swapped) to derive the
 cardinality identity and the per-pair bijection and gauges on the full
 basis (every sector is a unit-modulus block under the per-block
@@ -948,7 +951,7 @@ normalization).
     \uses{lem:sector_bnt_combined_family_eventually_li,
         lem:sector_bnt_coeff_not_tendsto_zero_at_unit_block}
     The contrapositive of
-    \cite[\S~II.C, line 1182]{Cirac2017MPDO_AnnPhys}, combined with
+    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}, combined with
     linear independence on the full family
     $\{P_j\}_j \cup \{Q_k\}_k$, is iterated externally over each sector
     $k$. Each iteration is discharged by the full-basis weak existential
@@ -968,7 +971,8 @@ normalization).
     itself routes through the linear-independence step
     (Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}) on the
     \emph{full} family $\{P_j\}_j \sqcup \{Q_k\}_k$, the corollary
-    input of \cite[\S~II.C, lines 1131--1133]{Cirac2017MPDO_AnnPhys}, not
+    input of \cite[Appendix MPV corollary, lines 1131--1133]
+        {Cirac2017MPDO_AnnPhys}, not
     on any partial union.
 \end{remark}
 
@@ -976,7 +980,7 @@ normalization).
 \label{subsec:sector_bnt_strong_match_bijective_symmetry}
 
 This subsection derives the symmetry argument of
-\cite[\S~II.C, line 1182]{Cirac2017MPDO_AnnPhys}:
+\cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}:
 $g_a \ge g_b$ and $g_b \ge g_a$ together imply $g_a = g_b$.
 
 The strong existential matching theorem
@@ -992,7 +996,7 @@ in both directions.
 \paragraph{Scope.}
 The literal source conclusion ``$g_a = g_b$ and a relabelling
 $B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$''
-(\cite[\S~II.C, line 1182]{Cirac2017MPDO_AnnPhys}) reads as a
+(\cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}) reads as a
 bijection between the unit-modulus subsets of the two BNT canonical
 forms. The theorem below delivers the symmetric injective matching
 (the source's $g_a \ge g_b \wedge g_b \ge g_a$ step) in the following
@@ -1067,7 +1071,7 @@ Given the matched gauges produced by the strong existential theorem
 encoded as the injection from
 Section~\ref{subsec:sector_bnt_strong_match_bijective_symmetry}, the per-block
 coefficient identity of
-\cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys} follows by
+\cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys} follows by
 substituting the per-pair gauge identity
 $V^{(N)}(Q_k)_\sigma = \zeta_k^N \cdot V^{(N)}(P_{\varphi(k)})_\sigma$
 into the proportional-MPV hypothesis and projecting the resulting overlap
@@ -1085,7 +1089,8 @@ $c_N^{(\varphi(k))}(P) - \zeta_k^N \cdot c_N^{(k)}(Q) \to 0$ as
 $N \to \infty$, which is the natural output of the overlap-projection
 argument; the upgrade to the eventual-exact form is provided by the
 multiset-rigidity Theorem~\ref{thm:power_sum_multiset}, the
-Newton--Girard input behind \cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys}.
+Newton--Girard input behind
+\cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys}.
 The non-matched decay clause is delivered in full.
 
 \begin{lemma}[Coefficient decay for subnormal sectors]
@@ -1196,7 +1201,7 @@ The non-matched decay clause is delivered in full.
     Lemma~\ref{lem:sector_bnt_coeff_identity_via_global_gauge}, which is a
     full-basis equal-MPV statement. The projected theorem follows
     the substitution route of
-    \cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys}: substitute
+    \cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys}: substitute
     the per-pair gauge phases into the proportional-MPV identity, reduce
     to the $P$-only relation, and extract per-$j$ coefficient identities
     from cross-overlap decay alone. The result handles the
@@ -1259,9 +1264,11 @@ matching covers the whole BNT basis.
         \zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma
     \]
     This records the per-block phase conclusion of
-    \cite[\S~II.C, lines 1167--1170]{Cirac2017MPDO_AnnPhys}; line
-    1182 gives the corresponding proof step. The following
-    coefficient-comparison step is separate.
+    \cite[Appendix MPV theorem statement, lines 1167--1170]
+        {Cirac2017MPDO_AnnPhys}; the proof step at
+    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys} is the
+    corresponding argument. The following coefficient-comparison step is
+    separate.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1298,7 +1305,7 @@ matching covers the whole BNT basis.
         \zeta_k^N\,c_N^{(k)}(Q).
     \]
     This is the coefficient-comparison step of
-    \cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys} in full-basis
+    \cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys} in full-basis
     form.
 \end{lemma}
 
@@ -1330,7 +1337,7 @@ matching covers the whole BNT basis.
         c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q).
     \]
     This is the full-basis equal-MPV coefficient comparison of
-    \cite[\S~II.C, lines 1187--1188]{Cirac2017MPDO_AnnPhys}.
+    \cite[Appendix MPV proof, lines 1187--1188]{Cirac2017MPDO_AnnPhys}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1370,7 +1377,7 @@ matching covers the whole BNT basis.
         X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
     \]
     This is the direct-sum gauge assembly of
-    \cite[\S~II.C, lines 1189--1192]{Cirac2017MPDO_AnnPhys}, separated from
+    \cite[Appendix MPV proof, lines 1189--1192]{Cirac2017MPDO_AnnPhys}, separated from
     the coefficient-comparison step that supplies the weight identities.
 \end{theorem}
 
@@ -1410,11 +1417,14 @@ matching covers the whole BNT basis.
     Thus, after the remaining proportional coefficient comparison supplies
     the displayed copy-weight identities, the direct-sum gauge assembly uses
     the same algebra as the equal-MPV corollary in
-    \cite[\S~II.C, lines 1189--1192]{Cirac2017MPDO_AnnPhys}.
+    \cite[Appendix MPV proof, lines 1189--1192]{Cirac2017MPDO_AnnPhys}.
     The source proportional theorem itself stops at the sector matching in
-    lines~1167--1170 and line~1182; lines~1187--1192 do not supply the missing
-    proportional coefficient comparison, because in the equal-MPV corollary
-    the length-dependent proportionality scalar is identically~$1$.
+    \cite[Appendix MPV theorem statement, lines 1167--1170]
+        {Cirac2017MPDO_AnnPhys} and
+    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys};
+    lines~1187--1192 do not supply the missing proportional coefficient
+    comparison, because in the equal-MPV corollary the length-dependent
+    proportionality scalar is identically~$1$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1469,7 +1479,7 @@ matching covers the whole BNT basis.
     \]
     for every physical index $i$. This is the explicit direct-sum gauge
     construction of
-    \cite[\S~II.C, lines 1189--1192]{Cirac2017MPDO_AnnPhys}.
+    \cite[Appendix MPV proof, lines 1189--1192]{Cirac2017MPDO_AnnPhys}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1511,7 +1521,7 @@ matching covers the whole BNT basis.
     where $P_{\mathrm{tot}}^i$ and $Q_{\mathrm{tot}}^i$ are both regarded as
     matrices in $\MN{D}$ using the total bond-dimension equality. This is the
     normalized BNT form of
-    \cite[Corollary~II.2 and \S~II.C, lines 1189--1192]
+    \cite[Corollary~II.2 and Appendix MPV proof, lines 1189--1192]
         {Cirac2017MPDO_AnnPhys}, under the same unit-modulus-copy normalization
     as Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
 \end{theorem}


### PR DESCRIPTION
## Summary

This PR corrects the remaining Chapter 10 source locators that pointed appendix line numbers back to CPSV16 Section II.C.

- Lines 1131--1133 are now identified as the Appendix MPV corollary supplying eventual linear independence.
- Line 1182 and lines 1187--1192 are now identified as the Appendix MPV proof of the theorem/corollary, separating sector matching, coefficient comparison, and direct-sum gauge assembly.
- Lines 1244--1248 are now identified as the appendix proof of Section MPS, not as the canonical-form subsection.

The Section II.C citations are kept for the actual canonical-form normalization line 246 and BNT definition lines 264--279.

## Checks

- `git diff --check -- blueprint/src/chapter/ch10_bnt.tex`
- `cd blueprint && leanblueprint web`

## Tracker

Progress for #1685 and #1749. This is a source-map cleanup only; it does not prove the proportional copy-weight comparison.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates LaTeX citations/locators without altering any Lean code or mathematical statements.
> 
> **Overview**
> Updates Chapter 10’s BNT blueprint citations to point to the correct locations in `Cirac2017MPDO_AnnPhys`, especially **Appendix MPV proof/corollary** lines (e.g. 1131–1133, 1182, 1187–1192) and the **Appendix “Proofs of Section MPS”** lines (1244–1248), instead of incorrectly attributing them to `\S II.C`.
> 
> Also normalizes citation formatting (e.g. `lines~...`, consistent `\S` usage) while keeping `\S II.C` references for the canonical-form normalization and distinctness lines (e.g. line~246 and lines~264–279).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24e97461bca160c7111428ee535b3b8efc7c96a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->