### PR TITLE
doc(blueprint): separate PGVWC07 trace-split source lines

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -39,15 +39,16 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     % three block conditions; lines 761--762 state the bond-dimension bound.
     % Source proof order to preserve:
     % The proof order is lines 765--770 for spectral-radius normalization and
-    % the full-rank fixed-point gauge; lines 771--815 for the invariant support
-    % split when the positive fixed point is not full rank; lines 816--826 for
-    % iteration and further splitting when a block has a non-scalar fixed point;
-    % and lines 827--832 for the dual fixed point and final unitary
-    % diagonalization. Follow this order when formalizing the theorem: derive
-    % the invariant support from the singular positive fixed point as in
-    % lines 771--783 before invoking any abstract block-splitting lemma, and do
-    % not replace the source proof by a later primitive-block or prepared-family
-    % canonical-form theorem.
+    % the full-rank fixed-point gauge; lines 771--783 for deriving the
+    % invariant support projection from a singular positive fixed point;
+    % lines 785--815 for the finite-ring trace split into the supported and
+    % orthogonal summands; lines 816--826 for iteration and further splitting
+    % when a block has a non-scalar fixed point; and lines 827--832 for the dual
+    % fixed point and final unitary diagonalization. Follow this order when
+    % formalizing the theorem: derive the invariant support from the singular
+    % positive fixed point before invoking any abstract block-splitting lemma,
+    % and do not replace the source proof by a later primitive-block or
+    % prepared-family canonical-form theorem.
     Let a translation-invariant MPS representation on a finite ring have bond
     dimension $D$. Then the matrices may be decomposed as
     \[

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -926,9 +926,9 @@ whose weights all have modulus strictly less than one have coefficients
 $c_N^{(k)}(Q) = \sum_q \nu_{k,q}^N$ that decay exponentially to zero,
 contribute nothing to the thermodynamic state, and are not constrained by
 the matching
-(\cite[Appendix ``Proofs of Section MPS'', lines~1244--1248]
-{Cirac2017MPDO_AnnPhys} returns to this point through the transfer-power
-fixed-point characterisation). The bijective-matching theorem below applies the
+(\cite[Appendix ``Proofs of Section MPS'', lines~1244--1248]{Cirac2017MPDO_AnnPhys}
+returns to this point through the transfer-power fixed-point characterisation).
+The bijective-matching theorem below applies the
 strong existential theorem twice (with $(P, Q)$ swapped) to derive the
 cardinality identity and the per-pair bijection and gauges on the full
 basis (every sector is a unit-modulus block under the per-block

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -926,9 +926,9 @@ whose weights all have modulus strictly less than one have coefficients
 $c_N^{(k)}(Q) = \sum_q \nu_{k,q}^N$ that decay exponentially to zero,
 contribute nothing to the thermodynamic state, and are not constrained by
 the matching
-(\cite[Appendix ``Proofs of Section MPS'', lines~1244--1248]{Cirac2017MPDO_AnnPhys}
-returns to this point through the transfer-power fixed-point characterisation).
-The bijective-matching theorem below applies the
+(\cite[Appendix ``Proofs of Section MPS'', lines~1244--1248]
+{Cirac2017MPDO_AnnPhys} returns to this point through the transfer-power
+fixed-point characterisation). The bijective-matching theorem below applies the
 strong existential theorem twice (with $(P, Q)$ swapped) to derive the
 cardinality identity and the per-pair bijection and gauges on the full
 basis (every sector is a unit-modulus block under the per-block


### PR DESCRIPTION
## Summary

This PR refines the source comment on the not-ready PGVWC07 translation-invariant canonical-form theorem in Chapter 8.

The comment now separates the two distinct proof passages in `Papers/quant-ph_0608197/MPSarchive.tex`:

- lines 771--783 derive the invariant support projection from a singular positive fixed point;
- lines 785--815 perform the finite-ring trace split into supported and orthogonal summands.

This keeps the blueprint comment aligned with the source proof order and with the paper-gap note for #1857.

## Checks

- `git diff --check -- blueprint/src/chapter/ch08_canonical.tex`
- `cd blueprint && leanblueprint web`

## Tracker

Progress for #1857 and #1685. This is a source-comment cleanup only; no theorem statement or Lean declaration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates an internal source-reference comment without altering any theorem statements, Lean declarations, or build behavior.
> 
> **Overview**
> Refines the source-proof-order comment on the `PGVWC07` translation-invariant canonical-form theorem to **separately cite** (1) the derivation of the invariant support projection (lines 771–783) and (2) the subsequent finite-ring trace split (lines 785–815), keeping the blueprint’s guidance aligned with the paper’s proof order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf152d5ae3f9c697bd37604bd93654f564ac47b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->