### PR TITLE
doc(blueprint): clarify FT assembly placement

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -926,9 +926,9 @@ whose weights all have modulus strictly less than one have coefficients
 $c_N^{(k)}(Q) = \sum_q \nu_{k,q}^N$ that decay exponentially to zero,
 contribute nothing to the thermodynamic state, and are not constrained by
 the matching
-(\cite[Appendix ``Proofs of Section MPS'', lines~1244--1248]
-{Cirac2017MPDO_AnnPhys} returns to this point through the transfer-power
-fixed-point characterisation). The bijective-matching theorem below applies the
+(\cite[Appendix ``Proofs of Section MPS'', lines~1244--1248]{Cirac2017MPDO_AnnPhys}
+returns to this point through the transfer-power fixed-point characterisation).
+The bijective-matching theorem below applies the
 strong existential theorem twice (with $(P, Q)$ swapped) to derive the
 cardinality identity and the per-pair bijection and gauges on the full
 basis (every sector is a unit-modulus block under the per-block

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1080,7 +1080,9 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
     See Definition~\ref{def:block_diagonal_tensor} for the formalized
     block-diagonal tensor construction.  The results in this subsection assume
     that the block correspondence has already been fixed; they do not prove
-    \cite[Theorem~II.1]{Cirac2017MPDO_AnnPhys}.
+    \cite[Theorem~II.1]{Cirac2017MPDO_AnnPhys}.  They are therefore retained
+    here as same-index assembly corollaries, not in the source-path BNT
+    preparation or in the after-blocking canonical-form reduction.
 \end{remark}
 
 \begin{lemma}[Per-block application of the single-block theorem]\label{lem:multi_block_ft}


### PR DESCRIPTION
## Summary

Closes #1927.

This PR records the placement audit for the former auxiliary-reductions material around the Fundamental-Theorem proof.

- Clarifies in Chapter 13 that the same-index direct-sum lemmas are assembly corollaries: the block correspondence is assumed, so they are not part of the source-path BNT preparation or the after-blocking canonical-form reduction.
- Fixes the leftover Chapter 10 multi-line citation formatting from the merged BNT locator PR by keeping the Appendix MPS citation on one line.

## Checks

- `git diff --check -- blueprint/src/chapter/ch10_bnt.tex blueprint/src/chapter/ch13_algebraic_ft.tex`
- `cd blueprint && leanblueprint web`

## Notes

This is documentation-only. It does not change any Lean declaration, blueprint status tag, or mathematical statement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits: adjusts LaTeX citation formatting and clarifies narrative placement of existing lemmas without changing any statements or Lean links.
> 
> **Overview**
> Clarifies Chapter 13’s commentary that the same-index direct-sum lemmas are *assembly corollaries* that assume a fixed block correspondence, and therefore are not part of the BNT-preparation or canonical-form reduction path.
> 
> Fixes a Chapter 10 LaTeX citation formatting issue by keeping the Appendix MPS citation as a single parenthetical/citation line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2bfc680b11698de0b4f3134a9e4666d39da922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->