### PR TITLE
doc(blueprint): refine FT assembly wording

### DIFF
--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1081,8 +1081,9 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
     block-diagonal tensor construction.  The results in this subsection assume
     that the block correspondence has already been fixed; they do not prove
     \cite[Theorem~II.1]{Cirac2017MPDO_AnnPhys}.  They are therefore retained
-    here as same-index assembly corollaries, not in the source-path BNT
-    preparation or in the after-blocking canonical-form reduction.
+    here as same-index assembly corollaries, not among the BNT preparation
+    steps used in the source proof or in the after-blocking canonical-form
+    reduction.
 \end{remark}
 
 \begin{lemma}[Per-block application of the single-block theorem]\label{lem:multi_block_ft}


### PR DESCRIPTION
## Summary

This PR makes the Chapter 13 assembly-placement remark a little more explicit and avoids the compressed phrase "source-path BNT preparation".

The same-index direct-sum lemmas are described as assembly corollaries that are not among the BNT preparation steps used in the source proof and not part of the after-blocking canonical-form reduction. This preserves the mathematical distinction from #1927/#1928 without introducing a new label or theorem statement.

## Checks

- `git diff --check origin/main..HEAD -- blueprint/src/chapter/ch13_algebraic_ft.tex`

## Notes

Documentation-only. No Lean declarations, blueprint status tags, or mathematical statements change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording tweak in a LaTeX remark; no mathematical statements, Lean references, or proof structure change, so risk is minimal.
> 
> **Overview**
> Refines the Chapter 13 remark introducing the “same-index direct-sum” lemmas to more explicitly state that these results are **assembly corollaries** and are *not* part of the BNT preparation steps used in the source proof, nor part of the after-blocking canonical-form reduction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a32537b553ade0b052ef3441d892bba3d234b25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->