### PR TITLE
doc(SectorBNT): correct appendix source locators

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
@@ -226,12 +226,12 @@ normalization $\exists j, \exists q, \|\mu_{j,q}\| = 1$, while CPSV21
 Section IV.A uses Definition 4.2 (lines 1846–1850) for the BNT basis and
 the display at lines 1864–1884 for the two-layer expansion.  It normalizes
 the spectral radius of the *basis* tensors, not the copy coefficients
-$\mu_{j,q}$.  The per-block witness is implicit in CPSV16 §II.C line 1182's
-projection step and is
+$\mu_{j,q}$.  The per-block witness is implicit in CPSV16 Appendix MPV proof,
+line 1182's projection step and is
 therefore exposed here as a per-theorem hypothesis.
 
 Paper anchor: CPSV16 appendix power-sum lemma, lines 1155--1163, and
-CPSV16 §II.C line 1182 (per-block
+CPSV16 Appendix MPV proof, line 1182 (per-block
 projection step). -/
 theorem coeff_not_tendsto_zero_at_block
     (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -28,8 +28,8 @@ a `SectorDecomposition`.  It records:
   (lines 246 and 1244).
 
 The per-block unit-modulus convention `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — implicit
-in CPSV16 §II.C line 1182's projection step and not explicitly stated in
-CPSV16 §II.C line 246 (which is global) nor in CPSV21 Section IV.A,
+in CPSV16 Appendix MPV proof, line 1182's projection step and not explicitly
+stated in CPSV16 §II.C line 246 (which is global) nor in CPSV21 Section IV.A,
 lines 1846–1884 (which normalizes the spectral radius of the BNT *basis
 tensors*, not the copy coefficients) — is **not** a structural field of
 `IsBNTCanonicalForm`.
@@ -66,8 +66,9 @@ core BNT predicate.
   Ann. Phys. **378**, 100 (2017); arXiv:1606.00608.  Source-line tags used
   below: 217–246 (global modulus normalization), 264–279 (gauge-phase
   grouping rule), 271–301 (two-layer BNT display with raw `μ_{j,q}`),
-  1121–1132 (combined-family LI input), 1182 (BNT projection step),
-  and 1184–1188 (equal-case multiplicity recovery via power-sum comparison).
+  1121–1132 (combined-family LI input), Appendix MPV proof line 1182
+  (BNT projection step), and Appendix MPV proof lines 1184–1188
+  (equal-case multiplicity recovery via power-sum comparison).
 * CPSV21: Cirac–Pérez-García–Schuch–Verstraete, *Matrix product states and
   projected entangled pair states: Concepts, symmetries, theorems*,
   Rev. Mod. Phys. **93**, 045003 (2021); arXiv:2011.12127.  Source-line tags
@@ -156,9 +157,9 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   basis sector has unit-modulus weight.  CPSV16 §II.C line 246: "we can
   always choose `|μ_k| ≤ 1` and at least one of them equals one."  This
   is the global (not per-block) normalization condition; the per-block
-  refinement `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` is paper-implicit in CPSV16 §II.C
-  line 1182's projection argument and is therefore taken as an explicit
-  per-theorem hypothesis on the fundamental-theorem theorems, rather
+  refinement `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` is paper-implicit in CPSV16 Appendix
+  MPV proof, line 1182's projection argument and is therefore taken as an
+  explicit per-theorem hypothesis on the fundamental-theorem theorems, rather
   than baked into this structural predicate. -/
   weight_unit_exists : ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ = 1
@@ -175,8 +176,8 @@ rules out the pathological cancellation that would obstruct the CPSV16 §II
 Step 1 coefficient-comparison argument: once combined-family LI isolates
 the `j`-th sector coefficient (CPSV16 lines 1121–1132), the surviving
 relation cannot be `0 = 0` for large `N`, so the multiplicity-recovery
-argument of CPSV16 lines 1184–1188 has a nonvanishing left-hand side to
-compare against after the line-1182 matching step.
+argument of CPSV16 Appendix MPV proof, lines 1184–1188, has a nonvanishing
+left-hand side to compare against after the line-1182 matching step.
 
 The proof feeds nonzero weights `P.weight j q ≠ 0` (from
 `P.weight_ne_zero`) into `geom_sum_eventually_zero`

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -6,9 +6,9 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.StrongMatch
 import TNLean.MPS.CanonicalForm.PhaseCover
 
 /-!
-# Coefficient identity for full BNT basis matching (CPSV16 §II.C lines 1187–1188)
+# Coefficient identity for full BNT basis matching
 
-This module contains the CPSV16 §II.C lines 1187–1188 coefficient
+This module contains the CPSV16 Appendix MPV proof, lines 1187–1188, coefficient
 comparison in the full-basis bijection form.  The full basis bijection
 `β : Fin Q.basisCount ≃ Fin P.basisCount` (from `StrongMatch`) together with
 `IsBNTCanonicalForm`'s CPSV21 Section IV.A / Definition 4.2 BNT input and
@@ -18,8 +18,9 @@ residual unmatched terms.  BNT linear independence of the `P`-basis
 
 Paper anchors:
 
-* CPSV16 §II.C lines 1182–1188: match every BNT basis tensor, substitute the
-  gauge-phase identities, and compare the coefficients of the BNT basis.
+* CPSV16 Appendix MPV proof, line 1182: match every BNT basis tensor.
+* CPSV16 Appendix MPV proof, lines 1187–1188: substitute the gauge-phase
+  identities and compare the coefficients of the BNT basis.
 * CPSV21 Definition 4.2 lines 1846–1850 and the two-layer display at
   lines 1864–1884: per-block BNT normalization that makes every sector
   participate in the full-basis matching.
@@ -85,7 +86,7 @@ private lemma extract_unit_gauge_phase_mpv
   refine ⟨ζ, ?_, hmpv⟩
   exact hP.norm_phase_of_matched_mpv hQ hmpv
 
-/-- **CPSV16 §II.C lines 1187–1188, coefficient identity from fixed MPV phases.**
+/-- **Coefficient identity from fixed MPV phases.**
 
 This auxiliary lemma isolates the linear-independence part of the global-gauge
 substitution.  If a full basis bijection `β` has already been equipped with
@@ -99,9 +100,10 @@ then `SameMPV₂ P.toTensor Q.toTensor` and the BNT linear independence of the
 `P.coeff N (β k) = (ζ k)^N * Q.coeff N k`.
 
 Unlike `coeff_identity_via_global_gauge`, this statement keeps the phase
-function explicit.  The coefficient/weight comparison is the line 1187--1188
-part of the equal-MPV corollary; the per-block gauge matrices are combined
-afterwards into `X = ⊕_k (𝟙_{r_k} ⊗ X_k)` in lines 1189--1192. -/
+function explicit.  The coefficient/weight comparison is the CPSV16 Appendix
+MPV proof, lines 1187--1188, part of the equal-MPV corollary; the per-block
+gauge matrices are combined afterwards into `X = ⊕_k (𝟙_{r_k} ⊗ X_k)` in
+lines 1189--1192. -/
 theorem coeff_identity_via_matched_mpv_phasePos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P)
@@ -227,7 +229,7 @@ theorem coeff_identity_via_matched_mpv_phase
   coeff_identity_via_matched_mpv_phasePos
     (P := P) (Q := Q) hP hEqual.toSameMPV₂Pos β ζ hζ_mpv
 
-/-- **CPSV16 §II.C lines 1187–1188, full-basis coefficient identity.**
+/-- **Full-basis coefficient identity.**
 
 Assume a full matched-basis equivalence `β : Fin Q.basisCount ≃
 Fin P.basisCount`, with every `Q`-block gauge-phase equivalent to the
@@ -238,9 +240,9 @@ an eventual exact coefficient identity
 
 `P.coeff N (β k) = ζ_k^N * Q.coeff N k`.
 
-This is the formal counterpart of CPSV16 line 1188's exact power-sum
-comparison; it deliberately avoids the unsound asymptotic-difference to
-full-multiset route noted in the multiplicity-audit memo. -/
+This is the formal counterpart of CPSV16 Appendix MPV proof, line 1188's exact
+power-sum comparison; it deliberately avoids the unsound asymptotic-difference
+to full-multiset route noted in the multiplicity-audit memo. -/
 theorem coeff_identity_via_global_gaugePos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
@@ -168,8 +168,8 @@ witness `∃ q, ‖P.weight j₀ q‖ = 1` at a user-supplied sector index
 match `Q.basis k₀` of equal bond dimension, gauge-phase equivalent in
 the cast-left shape, and with a non-decaying cross-overlap.
 
-The proof is a direct read of the CPSV16 lines 1172–1188 unit-block
-projection: assume by contradiction that **all** cross-overlaps
+The proof is a direct read of the CPSV16 Appendix MPV proof, lines 1172–1188,
+unit-block projection: assume by contradiction that **all** cross-overlaps
 `mpvOverlap (P.basis j₀) (Q.basis k)` decay; project the `SameMPV₂`
 identity onto `mpvState (P.basis j₀)` (taking the bilinear overlap with
 the `j₀`-th `P`-block).

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -29,7 +29,7 @@ core examples have a single BNT basis sector (`basisCount = 1`):
 Each example additionally exposes a named lemma `<example>_weight_unit_per_block`
 witnessing the per-block unit-modulus convention `∀ j, ∃ q, ‖μ_{j,q}‖ = 1`,
 which fundamental-theorem theorems consume as an explicit hypothesis
-(paper-implicit in CPSV16 §II.C line 1182's projection argument).
+(paper-implicit in CPSV16 Appendix MPV proof, line 1182's projection argument).
 
 A fourth example exercises the **optional** equal-modulus layer
 `HasEqualModulusWeightLayer` on top of `signFlipDecomp`, demonstrating
@@ -103,7 +103,7 @@ noncomputable example
 
 Fundamental-theorem theorems on `IsBNTCanonicalForm` take the per-block
 unit-modulus convention `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` (paper-implicit in
-CPSV16 §II.C line 1182's projection argument) as an explicit
+CPSV16 Appendix MPV proof, line 1182's projection argument) as an explicit
 hypothesis.  For `singletonDecomp C`, the unique copy carries
 weight `1`. -/
 lemma singletonDecomp_weight_unit_per_block (C : MPSTensor d D) :
@@ -174,7 +174,7 @@ noncomputable example
 
 For each (unique) BNT basis sector, the copy `q = 0` carries weight
 `μ = 1`.  Consumed by FT theorems on `IsBNTCanonicalForm` as the
-explicit per-block hypothesis (paper-implicit in CPSV16 §II.C
+explicit per-block hypothesis (paper-implicit in CPSV16 Appendix MPV proof,
 line 1182's projection argument). -/
 lemma signFlipDecomp_weight_unit_per_block (C : MPSTensor d D) :
     ∀ j : Fin (signFlipDecomp C).basisCount,
@@ -251,7 +251,7 @@ noncomputable example
 
 For each (unique) BNT basis sector, the copy `q = 0` carries weight
 `μ = 1`.  Consumed by FT theorems on `IsBNTCanonicalForm` as the
-explicit per-block hypothesis (paper-implicit in CPSV16 §II.C
+explicit per-block hypothesis (paper-implicit in CPSV16 Appendix MPV proof,
 line 1182's projection argument). -/
 lemma phaseDecomp_weight_unit_per_block (C : MPSTensor d D) (θ : ℝ) :
     ∀ j : Fin (phaseDecomp C θ).basisCount,
@@ -383,7 +383,7 @@ noncomputable example
 
 For each (unique) BNT basis sector, the copy `q = 0` carries the unit
 weight `μ = 1`.  Consumed by FT theorems on `IsBNTCanonicalForm` as the
-explicit per-block hypothesis (paper-implicit in CPSV16 §II.C
+explicit per-block hypothesis (paper-implicit in CPSV16 Appendix MPV proof,
 line 1182's projection argument). -/
 lemma halvedDecomp_weight_unit_per_block (C : MPSTensor d D) :
     ∀ j : Fin (halvedDecomp C).basisCount,

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.WeightEquiv
 import TNLean.MPS.FundamentalTheorem.Multi
 
 /-!
-# BNT equal-MPV sector witnesses (CPSV16 §II.C lines 1182–1192)
+# BNT equal-MPV sector witnesses
 
 This module combines the full-basis matching (`StrongMatch`) and the
 exact coefficient identity (`CoeffIdentity`) into the sector-witness
@@ -17,16 +17,17 @@ conclusion of the CPSV16/CPSV21 fundamental theorem on the
 
 Paper anchors:
 
-* CPSV16 §II.C line 1182: full BNT basis matching by the `Lem1`
+* CPSV16 Appendix MPV proof, line 1182: full BNT basis matching by the `Lem1`
   contradiction and symmetry argument.
-* CPSV16 §II.C lines 1187–1188: exact power-sum coefficient comparison,
-  recovering copy multiplicities and weights up to the matched phase.
+* CPSV16 Appendix MPV proof, lines 1187–1188: exact power-sum coefficient
+  comparison, recovering copy multiplicities and weights up to the matched
+  phase.
 * CPSV21 Definition 4.2 lines 1846–1850 and the two-layer display at
   lines 1864–1884: per-block BNT normalization on the basis tensors.
   The per-block convention on copy coefficients
-  `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — implicit in CPSV16 §II.C line 1182's
-  projection argument — is taken as an explicit theorem-level hypothesis
-  here, not as a structural field of `IsBNTCanonicalForm`.
+  `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — implicit in CPSV16 Appendix MPV proof,
+  line 1182's projection argument — is taken as an explicit theorem-level
+  hypothesis here, not as a structural field of `IsBNTCanonicalForm`.
 
 The theorem below exposes the sector-level witnesses needed before assembling
 the global CPSV16 gauge `⊕_j (𝟙_{r_j} ⊗ Y_j)`.  It does not use
@@ -47,8 +48,9 @@ For a matched basis bijection `β : Fin Q.basisCount ≃ Fin P.basisCount` and
 per-block copy permutations `τ k`, this is the weight array appearing in the
 coordinate-level direct sum
 `⊕_{(k,q)} P.weight (β k) (τ k q) • P.basis (β k)`.
-It is the Lean counterpart of the reindexing implicit in CPSV16 §II.C lines
-1189–1192 before forming the global gauge `⊕_k (𝟙_{r_k} ⊗ X_k)`. -/
+It is the Lean counterpart of the reindexing implicit in CPSV16 Appendix MPV
+proof, lines 1189–1192, before forming the global gauge
+`⊕_k (𝟙_{r_k} ⊗ X_k)`. -/
 noncomputable def matched_p_weight {P Q : SectorDecomposition d}
     (β : Fin Q.basisCount ≃ Fin P.basisCount)
     (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))) :
@@ -71,7 +73,8 @@ noncomputable def matched_p_basis {P Q : SectorDecomposition d}
 
 /-- Duplicate the per-basis gauge matrices over all copies in the flattened `Q` coordinates.
 
-This realizes the `𝟙_{r_k} ⊗ X_k` part of CPSV16 §II.C line 1191. -/
+This realizes the `𝟙_{r_k} ⊗ X_k` part of CPSV16 Appendix MPV proof,
+line 1191. -/
 noncomputable def matched_block_gauge {Q : SectorDecomposition d}
     (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ) :
     (s : Fin Q.totalCopies) → GL (Fin (Q.flatDim s)) ℂ := fun s => by
@@ -86,8 +89,9 @@ same phases. Then the flattened `Q`-tensor is obtained by conjugating the
 matched-coordinate `P`-tensor by the direct sum
 `⊕_k (𝟙_{r_k} ⊗ X_k)`.
 
-This is the pure assembly part of CPSV16 §II.C lines 1189–1192. It does not
-prove the coefficient comparison that supplies the weight identities. -/
+This is the pure assembly part of CPSV16 Appendix MPV proof, lines 1189–1192.
+It does not prove the coefficient comparison that supplies the weight
+identities. -/
 theorem sector_bnt_global_gauge_of_matched_weights
     {P Q : SectorDecomposition d}
     (β : Fin Q.basisCount ≃ Fin P.basisCount)
@@ -193,16 +197,17 @@ theorem sector_bnt_global_gauge_of_matched_weights
 /-- **Conditional proportional global gauge from matched copy weights.**
 
 For proportional MPV families, the proportional sector-matching theorem supplies
-the matched BNT basis, unit phases, and block gauges of CPSV16 §II.C lines
-1167--1170 and line 1182. If the remaining coefficient-comparison step supplies copy
-permutations whose weights obey the same phases, then the direct-sum gauge
-assembly uses the same algebra as the equal-MPV corollary in lines 1189--1192.
+the matched BNT basis, unit phases, and block gauges of CPSV16 Appendix MPV
+theorem statement, lines 1167--1170, and Appendix MPV proof, line 1182. If the
+remaining coefficient-comparison step supplies copy permutations whose weights
+obey the same phases, then the direct-sum gauge assembly uses the same algebra
+as the equal-MPV corollary in CPSV16 Appendix MPV proof, lines 1189--1192.
 
 This theorem isolates the exact residual input for the proportional
 global-gauge upgrade: the copy-weight identity. That residual input is not
-provided by the CPSV16 proportional theorem; lines 1187--1192 are the
-equal-MPV corollary, where the length-dependent proportionality scalar is
-identically one. -/
+provided by the CPSV16 proportional theorem; Appendix MPV proof,
+lines 1187--1192, prove the equal-MPV corollary, where the length-dependent
+proportionality scalar is identically one. -/
 theorem ft_sector_bnt_proportional_global_gauge_of_weight_data
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -248,7 +253,7 @@ theorem ft_sector_bnt_proportional_global_gauge_of_weight_data
   exact sector_bnt_global_gauge_of_matched_weights
     (P := P) (Q := Q) β hDim τ ζ Xblock hζ_ne hConj hWeight
 
-/-- **BNT equal-MPV sector-witness theorem (CPSV16 §II.C lines 1184–1188).**
+/-- **BNT equal-MPV sector-witness theorem.**
 
 If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
 same MPV family, then their BNT basis sectors are bijectively matched by
@@ -322,7 +327,7 @@ theorem ft_sector_bnt_equal_sector_data
   ft_sector_bnt_equal_sector_dataPos
     (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
 
-/-- **Global gauge in matched flattened coordinates (CPSV16 §II.C lines 1189–1192).**
+/-- **Global gauge in matched flattened coordinates.**
 
 This is the coordinate-level construction of the global gauge.  Starting
 from equal MPV families on the BNT canonical-form surface, it produces:
@@ -339,8 +344,8 @@ The final displayed equality says that the unfolded flattened presentation of
 matrix `⊕_k (𝟙_{r_k} ⊗ X_k)`.  The remaining conversion from this
 matched-coordinate presentation to a literal `GaugeEquiv P.toTensor Q.toTensor`
 is only a coordinate permutation/cast of the flattened direct sum and is
-intentionally not hidden here; the theorem exposes the explicit CPSV16 witness
-rather than an opaque existential. -/
+intentionally not hidden here; the theorem exposes the explicit CPSV16
+Appendix MPV proof witness rather than an opaque existential. -/
 theorem ft_sector_bnt_equal_global_gaugePos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -11,7 +11,7 @@ This module states the equal-MPV theorem `ft_sector_bnt_equal_global_gauge`
 in the form of the equal-MPV corollary labelled II_cor2 in CPSV16 §II.C:
 the main-text statement is at lines 354–361, the appendix restatement is at
 lines 1172–1179, the copy-weight comparison is at line 1188, and the
-global-gauge construction is at lines 1189–1192.
+global-gauge construction is at lines 1189–1192 of the Appendix MPV proof.
 
 The bundled-witness theorem `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses`
 exposes, for any two BNT sector decompositions $P$ and $Q$ satisfying
@@ -26,7 +26,8 @@ exposes, for any two BNT sector decompositions $P$ and $Q$ satisfying
 * the equality of total bond dimensions $\sum_k r_k D_k$;
 * the explicit global gauge $X \in \mathrm{GL}(\sum_s D^{(s)},\mathbb{C})$;
 
-together with the three CPSV16 conjugation identities from the appendix proof:
+together with the three CPSV16 conjugation identities from the Appendix MPV
+proof:
 
 * $B_k = ζ_k\,X_k\,A_{βk}\,X_k^{-1}$ (per basis block, lines 1182–1183);
 * $ν_{k,q} = ζ_k^{-1}\,μ_{βk,\,τ_k q}$ (per copy weight, line 1188);
@@ -34,7 +35,8 @@ together with the three CPSV16 conjugation identities from the appendix proof:
   flattened-copy coordinates, lines 1189–1192).
 
 The global equation is stated in the matched coordinates of $Q$'s flattened
-copy index; this is the direct-sum gauge construction of CPSV16 lines 1189–1192.
+copy index; this is the direct-sum gauge construction of CPSV16 Appendix MPV
+proof, lines 1189–1192.
 Converting the right-hand side from the matched-coordinate `toTensorFromBlocks`
 into a literal `cast`-of-`P.toTensor` requires assembling a sector-permutation
 matrix from `sectorFlatEquiv` and conjugating; the present module records the
@@ -43,13 +45,13 @@ the permutation-matrix conjugation is left for a follow-up module.
 
 Paper anchors:
 
-* CPSV16 §II.C lines 354–361 and 1172–1179: statement of the equal-MPV
-  corollary labelled II_cor2.
-* CPSV16 §II.C lines 1182–1183: per-basis-block gauge-phase matching from the
-  proportional theorem.
-* CPSV16 §II.C line 1188: copy multiplicity and copy-weight identification
-  from finite power-sum comparison.
-* CPSV16 §II.C lines 1189–1192: explicit global gauge
+* CPSV16 §II.C lines 354–361 and Appendix MPV proof lines 1172–1179:
+  statement of the equal-MPV corollary labelled II_cor2.
+* CPSV16 Appendix MPV proof, lines 1182–1183: per-basis-block gauge-phase
+  matching from the proportional theorem.
+* CPSV16 Appendix MPV proof, line 1188: copy multiplicity and copy-weight
+  identification from finite power-sum comparison.
+* CPSV16 Appendix MPV proof, lines 1189–1192: explicit global gauge
   $X = \bigoplus_k (𝟙_{r_k} \otimes X_k)$ and the global conjugation equation.
 -/
 
@@ -75,21 +77,21 @@ same MPV family, then there exist:
 * an explicit global gauge $X \in \mathrm{GL}\bigl(\sum_s D^{(s)},
   \mathbb{C}\bigr)$ of the form $X = \bigoplus_k (𝟙_{r_k}\otimes X_k)$,
 
-such that the three CPSV16 identities
+such that the three CPSV16 Appendix MPV proof identities
 
-* $B_k = ζ_k\,X_k\,A_{βk}\,X_k^{-1}$ (per basis block, CPSV16 lines 1182–1183),
-* $ν_{k,q} = ζ_k^{-1}\,μ_{βk,\,τ_k q}$ (per copy weight, CPSV16 line 1188),
+* $B_k = ζ_k\,X_k\,A_{βk}\,X_k^{-1}$ (per basis block, lines 1182–1183),
+* $ν_{k,q} = ζ_k^{-1}\,μ_{βk,\,τ_k q}$ (per copy weight, line 1188),
 * $V_Q^i = X\,V_P^i\,X^{-1}$ at every physical site $i$ (global gauge,
-  CPSV16 lines 1189–1192),
+  lines 1189–1192),
 
 hold simultaneously.  The final global identity is exposed here in the
 matched flattened-copy coordinates of $Q$: writing the $P$-side block tensors
 through the matched bijections gives the
 `toTensorFromBlocks`-tensor that conjugates to $Q.toTensor$ under $X$.
 
-CPSV16 §II.C lines 354–361 and 1172–1179 state the equal-MPV corollary;
-lines 1182–1192 supply the block matching, copy-weight comparison, and
-global-gauge construction used here. -/
+CPSV16 §II.C lines 354–361 and Appendix MPV proof lines 1172–1179 state the
+equal-MPV corollary; Appendix MPV proof lines 1182–1192 supply the block
+matching, copy-weight comparison, and global-gauge construction used here. -/
 theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -175,7 +177,8 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnesses
 
 If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
 same MPV family, their total bond dimensions agree and there exists a matrix $X$
-realizing the direct-sum global gauge of CPSV16 lines 1189–1192 in
+realizing the direct-sum global gauge of CPSV16 Appendix MPV proof,
+lines 1189–1192 in
 $Q$'s flattened sector coordinates.
 
 This is the CPSV16 equal-MPV corollary, labelled II_cor2, in gauge-equivalence
@@ -521,9 +524,10 @@ at every physical site $i$, where the inner factor is the bond-dim cast of the
 literal $P$-tensor along the total-dimension equality.
 
 This reformulates the matched-coordinate gauge equation
-`ft_sector_bnt_equal_mps_gaugeEquiv` (CPSV16 lines 1189–1192) into the
-equal-MPV corollary labelled II_cor2 in CPSV16 §II.C lines 354–361 by
-composing the matched-coordinate global gauge with the sector permutation.
+`ft_sector_bnt_equal_mps_gaugeEquiv` (CPSV16 Appendix MPV proof,
+lines 1189–1192) into the equal-MPV corollary labelled II_cor2 in CPSV16
+§II.C lines 354–361 by composing the matched-coordinate global gauge with the
+sector permutation.
 
 CPSV16 §II.C lines 354–361. -/
 theorem ft_sector_bnt_equal_mps_gaugeEquiv_literalPos

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -76,7 +76,7 @@ the forward one into an equivalence $\beta : \{1,\dots,g_Q\} \to
 \{1,\dots,g_P\}$, carrying the matched bond-dimension equality,
 gauge-phase equivalence, and non-decaying overlap for every sector of $Q$.
 
-Paper anchor: CPSV16 §II.C line 1182, the symmetry step
+Paper anchor: CPSV16 Appendix MPV proof, line 1182, the symmetry step
 "$g_A \ge g_B$ and $g_B \ge g_A$". -/
 theorem bijective_match_of_eventuallyProportional
     {P Q : SectorDecomposition d}
@@ -203,14 +203,15 @@ sides carries a unit-modulus copy weight, then the basis counts agree and
 there is a basis bijection carrying matched bond-dimension equality and
 per-block gauge-phase equivalence.
 
-Paper anchor: CPSV16 §II.C lines 349–352 (theorem `thm1`), lines 1167–1170
-(theorem statement), and line 1182 (matching proof); CPSV21 lines 1891–1894
-(proportional-MPV theorem-level target).  This is the proportional analogue
+Paper anchor: CPSV16 §II.C lines 349–352 (theorem `thm1`), Appendix MPV
+theorem statement lines 1167–1170, and Appendix MPV proof line 1182 (matching
+proof); CPSV21 lines 1891–1894 (proportional-MPV theorem-level target).
+This is the proportional analogue
 of `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses` (`SectorBNT/FundamentalCoord.lean`)
 in the matching layer. The source proportional theorem stops at sector
-matching; the weight comparison and global gauge in CPSV16 lines 1187–1192
-belong to the equal-MPV corollary unless an additional proportional
-coefficient theorem controls the length-dependent scalar. -/
+matching; the weight comparison and global gauge in CPSV16 Appendix MPV proof,
+lines 1187–1192, belong to the equal-MPV corollary unless an additional
+proportional coefficient theorem controls the length-dependent scalar. -/
 theorem ft_sector_bnt_proportional_sector_match
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -235,7 +236,7 @@ theorem ft_sector_bnt_proportional_sector_match
 /-- **Proportional sector matching with explicit unit phases and block gauges.**
 
 This is the witness form of `ft_sector_bnt_proportional_sector_match`: after
-the proportional BNT block matching of CPSV16 §II.C line 1182, the
+the proportional BNT block matching of CPSV16 Appendix MPV proof, line 1182, the
 matched gauge-phase equivalences provide actual matrices `Xblock k` and
 scalars `ζ k`.  The BNT self-overlap normalization forces `‖ζ k‖ = 1`, so
 these are the unit phases appearing in the source proportional theorem.
@@ -244,7 +245,8 @@ The theorem intentionally stops before the raw coefficient identity.  Under
 `EventuallyNonzeroProportionalMPV₂`, that step still has to control the
 length-dependent proportionality scalar; it is not the equal-MPV coefficient
 identity proved by `coeff_identity_via_matched_mpv_phase`, and it is not
-contained in CPSV16 lines 1187–1192 without the equal-MPV specialization. -/
+contained in CPSV16 Appendix MPV proof, lines 1187–1192, without the equal-MPV
+specialization. -/
 theorem ft_sector_bnt_proportional_sector_match_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
@@ -53,7 +53,7 @@ $P.\mathrm{coeff}(N,j)\cdot Q.\mathrm{coeff}(N,k)
 has a unit-modulus summand at $(q^*,p^*)$.  By
 `CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus` the sum does not
 tend to zero.  This is the analytic input used to formalize the non-decay
-contradiction in CPSV16 §II.C line 1182, together with the line-246
+contradiction in CPSV16 Appendix MPV proof, line 1182, together with the line-246
 normalization. -/
 lemma joint_coeff_not_tendsto_zero
     {P Q : SectorDecomposition d}
@@ -346,7 +346,8 @@ eventual nonzero proportionality and unit-modulus copy weights at $Q$-sector
 $k_0$ and auxiliary $P$-sector $j_0$, some $P$-block $j_1$ has matched bond
 dimension, cast-compatible gauge-phase equivalence, and non-decaying
 cross-overlap with $Q.\mathrm{basis}\,k_0$.  Paper anchor: CPSV16 §II.C
-lines 349–352, 1167–1170, and 1182. -/
+lines 349–352, Appendix MPV statement lines 1167–1170, and Appendix MPV
+proof line 1182. -/
 theorem exists_block_match_at_Q_of_eventuallyProportional
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -5,22 +5,24 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.FundamentalTheorem.SectorBNT.DominantMatch
 
 /-!
-# Strong existential and bijective sector matching (CPSV16 §II.C line 1182)
+# Strong existential and bijective sector matching
 
-The strong existential matching theorem states the CPSV16 §II.C line 1182
-*Step 1* conclusion directly on the original pair `(P, Q)` of BNT canonical
-forms, iterated over each sector `k` of `Q` that carries a unit-modulus copy.
+The strong existential matching theorem states the CPSV16 Appendix MPV proof,
+line 1182, matching conclusion directly on the original pair `(P, Q)` of BNT
+canonical forms, iterated over each sector `k` of `Q` that carries a
+unit-modulus copy.
 
-The coefficient identity of CPSV16 §II.C lines 1187–1188 (Corollary substitution)
-lives in the companion module `SectorBNT/CoeffIdentity.lean`.
+The coefficient identity of CPSV16 Appendix MPV proof, lines 1187–1188
+(Corollary substitution) lives in the companion module
+`SectorBNT/CoeffIdentity.lean`.
 
 ## Paper anchor
 
-CPSV16 (arXiv:1606.00608) §II.C line 1182 gives the *entire* matching step
-of the proportional theorem proof.  In mathematical terms, this step fixes a
-block $B_k$ and observes that its overlaps with the $A_j$ blocks cannot all
-decay to zero, since then the two MPV families would fail to be proportional
-for all lengths.  The equal-vector corollary then gives an index $j_k$ with
+CPSV16 (arXiv:1606.00608) Appendix MPV proof, line 1182, gives the matching
+step of the proportional theorem proof.  In mathematical terms, this step
+fixes a block $B_k$ and observes that its overlaps with the $A_j$ blocks cannot
+all decay to zero, since then the two MPV families would fail to be
+proportional for all lengths.  The equal-vector corollary then gives an index $j_k$ with
 $|V^{(N)}(B_k)\rangle = e^{i\phi_k N} |V^{(N)}(A_{j_k})\rangle$, and the
 single-block fundamental theorem gives
 $B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$.
@@ -80,9 +82,9 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ### Strong existential matching: CPSV16 §II.C line 1182 -/
+/-! ### Strong existential matching: CPSV16 Appendix MPV proof, line 1182 -/
 
-/-- **CPSV16 §II.C line 1182 Step 1 (full-basis form).**
+/-- **CPSV16 Appendix MPV proof, line 1182, Step 1 (full-basis form).**
 
 For every sector `k` of `Q`, there exists a sector `j` of `P` of equal
 bond dimension, gauge-phase equivalent to `Q.basis k` after the dimension
@@ -92,11 +94,11 @@ The proof iterates `exists_block_match_of_sameMPV` over every `Q`-sector
 with `(P, Q)` swapped, so it consumes the per-block unit-modulus
 witnesses on the *swapped* side, namely `hUnitQ : ∀ k, ∃ q, ‖μ_{k,q}‖ = 1`
 for $Q$.  The per-block unit-modulus convention is paper-implicit in
-CPSV16 §II.C line 1182's projection argument; it is taken here as an
-explicit theorem-level hypothesis (CPSV16 §II.C line 246 records only
+CPSV16 Appendix MPV proof, line 1182's projection argument; it is taken here
+as an explicit theorem-level hypothesis (CPSV16 §II.C line 246 records only
 the global unit witness).
 
-Paper anchor: CPSV16 §II.C line 1182 (arXiv:1606.00608), CPSV21
+Paper anchor: CPSV16 Appendix MPV proof, line 1182 (arXiv:1606.00608), CPSV21
 Definition 4.2 lines 1846–1850, and the two-layer display at lines 1864–1884. -/
 theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     {P Q : SectorDecomposition d}
@@ -146,7 +148,7 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
 
 /-! ### Bijective sector matching by symmetry -/
 
-/-- **CPSV16 §II.C line 1182 full-basis bijection.**
+/-- **CPSV16 Appendix MPV proof, line 1182, full-basis bijection.**
 
 Applying `forall_k_exists_j_nondecaying_overlap_of_sameMPV` in both
 directions gives injective maps `Fin Q.basisCount → Fin P.basisCount` and
@@ -160,9 +162,9 @@ and $g_B \geq g_A$".  The proof invokes
 `forall_k_exists_j_nondecaying_overlap_of_sameMPV` once with $(P,Q)$ and
 once with $(Q,P)$, hence it consumes per-block unit-modulus witnesses on
 both sides: `hUnitP : ∀ j, ∃ q, ‖μ_{j,q}^P‖ = 1` and `hUnitQ : ∀ k, ∃ q,
-‖μ_{k,q}^Q‖ = 1`.  These are paper-implicit in CPSV16 §II.C line 1182's
-projection argument and are taken as explicit theorem-level hypotheses
-here (CPSV16 §II.C line 246 records only the global unit witness). -/
+‖μ_{k,q}^Q‖ = 1`.  These are paper-implicit in CPSV16 Appendix MPV proof,
+line 1182's projection argument and are taken as explicit theorem-level
+hypotheses here (CPSV16 §II.C line 246 records only the global unit witness). -/
 theorem bijective_match_of_sameMPVPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/WeakExistential.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/WeakExistential.lean
@@ -46,9 +46,10 @@ overlap does not decay)` is a stronger statement that requires induction on
   Theories*, arXiv:1606.00608.  Lines 287–301 (raw two-layer BNT display
   with coefficient `∑_q μ_{j,q}^N`), 1080–1091 (normal-tensor overlap
   dichotomy), 1121–1132 (combined-family linear-independence corollary),
-  1182 (BNT projection/matching step), 1184–1188 (multiplicity recovery via
-  raw power-sum coefficient comparison), 1172–1192 (equal-MPV corollary,
-  fixed `k_0` move-everything-else argument).
+  Appendix MPV proof line 1182 (BNT projection/matching step),
+  Appendix MPV proof lines 1184–1188 (multiplicity recovery via raw power-sum
+  coefficient comparison), and Appendix MPV proof lines 1172–1192
+  (equal-MPV corollary, fixed `k_0` move-everything-else argument).
 * CPSV21: Cirac–Pérez-García–Schuch–Verstraete,
   *Matrix product states and projected entangled pair states*,
   arXiv:2011.12127.  Lines 1846–1884 (BNT and two-layer BNT decomposition
@@ -162,13 +163,14 @@ Paper anchors:
 
 * CPSV16 lines 1121–1132 — combined-family eventual
   linear-independence input;
-* CPSV16 lines 1172–1192 — the equal-MPV corollary's contrapositive route
-  via coefficient comparison after the combined-family input;
+* CPSV16 Appendix MPV proof, lines 1172–1192 — the equal-MPV corollary's
+  contrapositive route via coefficient comparison after the combined-family
+  input;
 * CPSV16 lines 287–301 — raw sector coefficient
   `P.coeff N j = ∑_q (P.weight j q)^N`;
-* CPSV16 lines 1184–1188 — raw power-sum coefficient comparison; combined
-  with `coeff_not_eventually_zero` (`SectorBNT/Basic.lean`) to
-  discharge the dominant block index.
+* CPSV16 Appendix MPV proof, lines 1184–1188 — raw power-sum coefficient
+  comparison; combined with `coeff_not_eventually_zero`
+  (`SectorBNT/Basic.lean`) to discharge the dominant block index.
 
 This is the weak `∃-∃` form.  The full pairwise conjunction (∀ j, ∃ k,
 overlap does not decay) ∧ (∀ k, ∃ j, overlap does not decay) is a stronger

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean
@@ -31,10 +31,10 @@ Newton--Girard inversion is involved.
 ## Paper anchors
 
 * CPSV16 appendix power-sum lemma, lines 1155--1163, and the equal-MPV
-  corollary proof, lines 1184--1188 (arXiv:1606.00608): for a fixed
-  matched sector, equal power sums and nonzero per-copy weights imply equal
-  cardinalities and equal weight multisets, hence the per-copy gauge-phase
-  identification `μ_{j,q} = ν_{j,τ(q)} · e^{i\phi_j}`.
+  corollary proof in the Appendix MPV proof, lines 1184--1188
+  (arXiv:1606.00608): for a fixed matched sector, equal power sums and nonzero
+  per-copy weights imply equal cardinalities and equal weight multisets, hence
+  the per-copy gauge-phase identification `μ_{j,q} = ν_{j,τ(q)} · e^{i\phi_j}`.
 
 ## Tags
 
@@ -57,8 +57,9 @@ per-copy weight multisets agree:
 `Multiset.map (P.weight j₀) Finset.univ.val
    = Multiset.map (fun q => ζ * Q.weight k₀' q) Finset.univ.val`.
 
-This is CPSV16 line 1188 read on a single matched sector, with the
-power-sum rigidity supplied by the appendix power-sum lemma, lines 1155--1163:
+This is CPSV16 Appendix MPV proof, line 1188, read on a single matched sector,
+with the power-sum rigidity supplied by the appendix power-sum lemma,
+lines 1155--1163:
 equal power sums (eventually in `N`) and nonzero entries imply
 equal multisets, hence equal cardinalities.
 
@@ -161,8 +162,9 @@ theorem matched_sector_weight_multiset_eq
 The multiset equality above is upgraded to an *explicit* permutation
 `τ : Fin (P.copies j₀) ≃ Fin (Q.copies k₀')` matching individual per-copy
 weights up to the gauge-phase factor `ζ`.  This is the per-copy form of
-CPSV16 line 1188 (`μ_{j,q} = ν_{j,q} · e^{i\phi_j}` after choosing the
-indexing of the `Q`-copies determined by the finite power-sum comparison).
+CPSV16 Appendix MPV proof, line 1188
+(`μ_{j,q} = ν_{j,q} · e^{i\phi_j}` after choosing the indexing of the
+`Q`-copies determined by the finite power-sum comparison).
 
 The proof reduces to a generic auxiliary lemma extracting an `Equiv.Perm` from a
 multiset-map equality on `Fin`, then composes with the cardinality cast
@@ -248,10 +250,10 @@ set_option linter.unusedVariables false in
 /-- **Matched-sector weight-permutation extractor.**
 
 Refines `matched_sector_weight_multiset_eq` into an explicit permutation
-`τ` realising CPSV16 line 1188's per-copy identification.
+`τ` realising CPSV16 Appendix MPV proof, line 1188's per-copy identification.
 
 Paper anchor: CPSV16 appendix power-sum lemma, lines 1155--1163, and the
-equal-MPV corollary proof lines 1184--1188
+equal-MPV corollary proof in the Appendix MPV proof, lines 1184--1188
 (arXiv:1606.00608). -/
 theorem matched_sector_weight_equiv
     {P Q : SectorDecomposition d}

--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -19,9 +19,9 @@ extrapolation and the Newton identities.
 In CPSV16, the relevant coefficient comparison is the equal-MPV corollary:
 after the BNT sectors have been matched, the proof compares the
 power sums of the copy weights in each matched sector
-(`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1184--1188).  The finite
-power-sum rigidity input is the appendix power-sum lemma at lines
-1155--1163.  The geometric extrapolation below is a formal
+(`Papers/1606.00608/MPDO-22-12-17-2.tex`, Appendix MPV proof,
+lines 1184--1188).  The finite power-sum rigidity input is the appendix
+power-sum lemma at lines 1155--1163.  The geometric extrapolation below is a formal
 strengthening needed because the Lean coefficient identity is often available
 eventually in the length parameter rather than at the first
 `max{x_a,x_b}` positive exponents.
@@ -212,7 +212,7 @@ exponents.  The finite-range unequal-cardinality power-sum theorem then gives th
 copy count and the multiset of weights, using the nonzero-entry hypotheses carried
 by `SectorWeightData`.  This is the formal counterpart of the CPSV16 appendix
 power-sum lemma, lines 1155--1163, applied to the matched-sector power sums in
-the equal-MPV corollary proof, lines 1184--1188. -/
+the Appendix MPV proof of the equal-MPV corollary, lines 1184--1188. -/
 lemma copies_eq_and_weight_multiset_eq_of_eventually_coeff_eq
     (S T : SectorWeightData g)
     {N0 : ℕ}


### PR DESCRIPTION
## Summary

This PR corrects the Lean docstring source map for the SectorBNT BNT matching, coefficient-comparison, and global-gauge path.

The local source lines 1182--1192 in Papers/1606.00608/MPDO-22-12-17-2.tex are in the Appendix MPV proof, not in Section II.C. The proportional theorem statement remains cited to Section II.C and the Appendix MPV theorem statement at lines 1167--1170, while the matching step is cited to Appendix MPV proof line 1182 and the equal-MPV coefficient/global-gauge algebra to Appendix MPV proof lines 1184--1192.

No theorem statements, proof terms, or imports change.

## Checks

- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/WeakExistential.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
- git diff --check -- TNLean/MPS/FundamentalTheorem/SectorBNT TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
- rg scan for stale Section II.C line 118x references in the touched SectorBNT path, with no matches

Closes no issue; contributes to #1685 and sharpens the source boundary for #1749.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docstrings/comments updating CPSV16 citations (Section II.C vs Appendix MPV proof) with no modifications to theorem statements or proof terms.
> 
> **Overview**
> Updates `SectorBNT` and `SectorWeightComparison` documentation to correct CPSV16 source anchors: references to lines 1182–1192 (matching, coefficient comparison, and global-gauge construction) are reattributed from §II.C to the **Appendix MPV proof**, while keeping proportional-theorem statement citations at §II.C/Appendix statement lines.
> 
> No functional changes: imports, definitions, theorem signatures, and proofs remain unchanged; only comments/docstrings are adjusted for accurate paper cross-references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74b4a7896647dc6b010adafcc5c6b4c56af8250e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->