### PR TITLE
doc(SectorBNT): align MPV proof locators

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
@@ -38,7 +38,7 @@ not imported here.
 * `IsBNTCanonicalForm.weight_unit_exists_of_struct` — the global
   unit-modulus witness re-stated for direct access by downstream callers (CPSV16 line 246).
 * `IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block` — the Cesàro
-  non-decay reading of the line-1182 projection step, with the per-block
+  non-decay reading of the line 1182 projection step, with the per-block
   unit-modulus witness supplied as an explicit theorem-level hypothesis
   `hUnit : ∃ q, ‖μ_{j₀,q}‖ = 1`.
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -37,7 +37,7 @@ The fundamental-theorem statements (`coeff_not_tendsto_zero_at_block`,
 `exists_block_match_of_sameMPV`, `bijective_match_of_sameMPV`,
 `ft_sector_bnt_equal_*`) take the per-block witness as an explicit
 hypothesis at the theorem level, keeping the canonical-form predicate
-minimal and the line-1182 implicit convention local to the theorems
+minimal and the line 1182 implicit convention local to the theorems
 that actually need it.
 
 The structure does **not** impose an equal-modulus or strict-order
@@ -177,7 +177,7 @@ Step 1 coefficient-comparison argument: once combined-family LI isolates
 the `j`-th sector coefficient (CPSV16 lines 1121–1132), the surviving
 relation cannot be `0 = 0` for large `N`, so the multiplicity-recovery
 argument of CPSV16 Appendix MPV proof, lines 1184–1188, has a nonvanishing
-left-hand side to compare against after the line-1182 matching step.
+left-hand side to compare against after the line 1182 matching step.
 
 The proof feeds nonzero weights `P.weight j q ≠ 0` (from
 `P.weight_ne_zero`) into `geom_sum_eventually_zero`

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
@@ -15,9 +15,9 @@ import Mathlib.Data.Fintype.BigOperators
 # Cesàro non-decay for finite power sums on the closed unit disk
 
 This module proves the pure-analytic lemma underlying the sector-coefficient
-non-decay input used when the CPSV16 §II.C proof projects onto a matched BNT
-block.  The lemma is independent of MPS data and is stated in terms of complex
-numbers only.
+non-decay input used when the CPSV16 Appendix MPV proof, line 1182, projects
+onto a matched BNT block.  The lemma is independent of MPS data and is stated
+in terms of complex numbers only.
 
 ## Main result
 
@@ -53,8 +53,8 @@ limit is `≥ 1 > 0`, contradicting the previous limit `0`.
 
 * CPSV16: Cirac–Pérez-García–Schuch–Verstraete, *Matrix Product Density
   Operators*, arXiv:1606.00608.  Line 246 gives the `|μ_k| ≤ 1` and
-  `∃ k, |μ_k| = 1` normalization convention; line 1182 is the BNT
-  projection step where a nonzero sector coefficient is needed.
+  `∃ k, |μ_k| = 1` normalization convention; Appendix MPV proof, line 1182,
+  is the BNT projection step where a nonzero sector coefficient is needed.
 * Cesàro mean limit: `Filter.Tendsto.cesaro_smul` in
   `Mathlib.Analysis.Asymptotics.SpecificAsymptotics`.
 -/
@@ -74,8 +74,8 @@ For `z : ℂ` with `‖z‖ ≤ 1`, the average `(T)⁻¹ · ∑_{N < T} z^N` te
   by `T → ∞`).
 
 Paper context: this is the analytic workhorse behind the line-246
-normalization when it is used in the CPSV16 §II.C line-1182 projection
-argument.  The unit case captures the contribution of pairs with
+normalization when it is used in the CPSV16 Appendix MPV proof, line 1182,
+projection argument.  The unit case captures the contribution of pairs with
 `μ_p · conj(μ_q) = 1`; the non-unit case shows all other pairs contribute
 `0`. -/
 lemma tendsto_cesaro_geom (z : ℂ) (hz : ‖z‖ ≤ 1) :
@@ -147,8 +147,8 @@ Let `μ : Fin r → ℂ` satisfy `‖μ q‖ ≤ 1` for every `q` and let some
 
 This is the analytic lemma underlying the CPSV16 §II.C line-246
 "`|μ_k| ≤ 1` and `∃ k, |μ_k| = 1`" normalization convention when that
-normalization is read sector-by-sector in the CPSV16 §II.C line-1182
-projection argument.
+normalization is read sector-by-sector in the CPSV16 Appendix MPV proof,
+line 1182, projection argument.
 
 The proof is the elementary Cesàro-mean argument outlined in the module
 docstring. -/

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
@@ -73,7 +73,7 @@ For `z : ℂ` with `‖z‖ ≤ 1`, the average `(T)⁻¹ · ∑_{N < T} z^N` te
 * `0` if `z ≠ 1` (the partial sum is bounded by `2 / ‖z - 1‖`, divided
   by `T → ∞`).
 
-Paper context: this is the analytic workhorse behind the line 246
+Paper context: this is the analytic workhorse behind the source line 246
 normalization when it is used in the CPSV16 Appendix MPV proof, line 1182,
 projection argument.  The unit case captures the contribution of pairs with
 `μ_p · conj(μ_q) = 1`; the non-unit case shows all other pairs contribute
@@ -145,7 +145,7 @@ Let `μ : Fin r → ℂ` satisfy `‖μ q‖ ≤ 1` for every `q` and let some
 `q*` satisfy `‖μ q*‖ = 1`.  Then the sequence
 `N ↦ ∑ q, (μ q)^N` does not tend to `0`.
 
-This is the analytic lemma underlying the CPSV16 §II.C line 246
+This is the analytic lemma underlying the CPSV16 §II.C, line 246
 "`|μ_k| ≤ 1` and `∃ k, |μ_k| = 1`" normalization convention when that
 normalization is read sector-by-sector in the CPSV16 Appendix MPV proof,
 line 1182, projection argument.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
@@ -73,7 +73,7 @@ For `z : ℂ` with `‖z‖ ≤ 1`, the average `(T)⁻¹ · ∑_{N < T} z^N` te
 * `0` if `z ≠ 1` (the partial sum is bounded by `2 / ‖z - 1‖`, divided
   by `T → ∞`).
 
-Paper context: this is the analytic workhorse behind the line-246
+Paper context: this is the analytic workhorse behind the line 246
 normalization when it is used in the CPSV16 Appendix MPV proof, line 1182,
 projection argument.  The unit case captures the contribution of pairs with
 `μ_p · conj(μ_q) = 1`; the non-unit case shows all other pairs contribute
@@ -145,7 +145,7 @@ Let `μ : Fin r → ℂ` satisfy `‖μ q‖ ≤ 1` for every `q` and let some
 `q*` satisfy `‖μ q*‖ = 1`.  Then the sequence
 `N ↦ ∑ q, (μ q)^N` does not tend to `0`.
 
-This is the analytic lemma underlying the CPSV16 §II.C line-246
+This is the analytic lemma underlying the CPSV16 §II.C line 246
 "`|μ_k| ≤ 1` and `∃ k, |μ_k| = 1`" normalization convention when that
 normalization is read sector-by-sector in the CPSV16 Appendix MPV proof,
 line 1182, projection argument.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -37,7 +37,9 @@ bond dimension, gauge-phase equivalent in the cast-compatible shape, and
 with non-decaying cross-overlap.  This is the proportional analogue of
 `StrongMatch.forall_k_exists_j_nondecaying_overlap_of_sameMPV`.
 
-Paper anchor: CPSV16 §II.C lines 349–352 / 1167–1170 / 1182. -/
+Paper anchor: CPSV16 §II.C lines 349–352 (theorem `thm1`);
+Appendix MPV theorem statement lines 1167–1170 and Appendix MPV proof
+line 1182 (matching). -/
 theorem forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -20,7 +20,7 @@ $B_k = \zeta_k X_k A_{\beta k} X_k^{-1}$.
 ## References
 
 * CPSV16: arXiv:1606.00608, lines 349–352 (theorem `thm1`), 1167–1170
-  (restatement), and line 1182 (matching proof).
+  (restatement), and Appendix MPV proof, line 1182 (matching proof).
 * CPSV21: arXiv:2011.12127, lines 1891–1894 (proportional target).
 -/
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
@@ -32,7 +32,7 @@ equivalence then follow as in the equal case.
 ## References
 
 * CPSV16: arXiv:1606.00608, lines 349–352 (theorem `thm1`), 1167–1170
-  (restatement), and line 1182 (matching proof).
+  (restatement), and Appendix MPV proof, line 1182 (matching proof).
 * CPSV21: arXiv:2011.12127, lines 1891–1894 (proportional target).
 -/
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -832,13 +832,13 @@ recovery (Theorem~\ref{thm:power_sum_multiset}), and the
 \emph{matched-sector weight-permutation extractor} upgrading the multiset
 equality to an explicit per-copy indexing. Together they realise the
 $\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ recovery of
-\cite[Appendix proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
+\cite[Appendix MPV proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
 the preceding block-selection argument supplies the matched normal sectors
-\cite[Appendix proof, line~1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
+\cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
 used here is the equal-MPV coefficient comparison of
-\cite[Appendix proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
+\cite[Appendix MPV proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
 global-gauge assembly in
-\cite[Appendix proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
+\cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
 is supplied by the substitution argument of
 Section~\ref{subsec:sector_bnt_substitution} below.
 
@@ -856,7 +856,7 @@ Section~\ref{subsec:sector_bnt_substitution} below.
     \]
     Then the per-sector multiplicities agree, $r_{j_0}(P) = r_{\tilde k_0}(Q)$,
     and the rescaled per-copy weight multisets coincide.
-    This is \cite[Appendix proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}
+    This is \cite[Appendix MPV proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ and matching
     multiplicities $r_{a,j} = r_{b,j}$) read on a single matched sector.
 \end{lemma}
@@ -891,7 +891,7 @@ Section~\ref{subsec:sector_bnt_substitution} below.
         \nu_{\tilde k_0, \tau(q)} = \zeta^{-1} \cdot \mu_{j_0, q}.
     \]
     This is the per-copy realisation of
-    \cite[Appendix proof, line~1188]{Cirac2017MPDO_AnnPhys}
+    \cite[Appendix MPV proof, line~1188]{Cirac2017MPDO_AnnPhys}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$): the multiset equality
     from Lemma~\ref{lem:sector_bnt_matched_sector_weight_multiset_eq} is
     upgraded to a concrete indexing between the matched $P$- and


### PR DESCRIPTION
Summary

This PR is a narrow follow-up to #1931. It finishes aligning the nearby SectorBNT and Chapter 10 source locators for the CPSV16 lines 1182--1192 passage.

Changes:
- identifies the Cesaro non-decay use as the Appendix MPV proof, line 1182, projection step;
- updates the proportional matching module references so line 1182 is explicitly the Appendix MPV proof step;
- replaces the remaining Chapter 10 Appendix proof citations around lines 1184--1192 with Appendix MPV proof.

No theorem statements, proof terms, imports, or blueprint declaration tags change.

Checks

- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/CesaroNonDecay.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
- cd blueprint && leanblueprint web, with the repository existing plasTeX warnings
- git diff --check on the touched files
- stale-locator scan for Appendix proof, Section II.C proof, line-1182, and broad CPSV16 line 118x references in the touched SectorBNT path, with no matches

Closes no issue; contributes to #1685 and keeps #1749 source boundaries precise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update: adjusts narrative/comments and blueprint citations without changing any theorem statements, proofs, or imports.
> 
> **Overview**
> Updates SectorBNT module docstrings/comments and Chapter 10 blueprint citations to consistently attribute the line-1182 matching/projection step and the 1184–1192 coefficient/gauge steps to the **CPSV16 Appendix MPV proof** (instead of generic/Section II.C “Appendix proof” phrasing).
> 
> No Lean definitions, theorem statements, proof terms, or dependency structure change; this is purely source-locator and prose alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc4906706baa14eb03b08b7f1e9d05f0b47d3fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->