### PR TITLE
feat(MPS/Irreducible): add PGVWC07 dual diagonalization

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -65,6 +65,10 @@ spectral-radius normalization and the full-rank fixed-point gauge, lines
 771–815 for deriving the invariant support from a singular positive fixed point
 and then splitting the trace, lines 816–826 for iteration and non-scalar
 fixed-point splitting, and lines 827–832 for dual fixed-point diagonalization.
+The final dual step is now available for a single irreducible unital block in
+`MPSTensor.exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor`;
+what is still missing here is the source-level composition over the whole
+recursive decomposition.
 
 ## External input — Quantum Wielandt strong irreducibility ⇒ full Kraus rank
 

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -23,8 +23,8 @@ iterate the split and use a non-scalar fixed point to force uniqueness of the
 identity fixed point.  This file formalizes only the abstract splitting once an
 invariant projection is available; a faithful proof of the full theorem must
 also derive that projection from the singular positive fixed-point argument in
-lines 771–783 and perform the dual fixed-point diagonalization at
-lines 827–832.
+lines 771–783 and compose the dual fixed-point diagonalization formalized in
+`TNLean.MPS.Irreducible.Adjoint` for lines 827–832.
 
 Starting from an arbitrary MPS tensor `A : MPSTensor d D`, we iteratively apply
 `MPSTensor.exists_twoBlock_decomp_of_lowerZero_strict` — which produces two blocks each with

--- a/TNLean/MPS/Irreducible/Adjoint.lean
+++ b/TNLean/MPS/Irreducible/Adjoint.lean
@@ -141,6 +141,64 @@ lemma isIrreducibleTensor_of_isIrreducibleMap_conjTranspose
     simpa [Q, Matrix.conjTranspose_mul, hPH, h1PH, Matrix.mul_assoc] using h
   exact hAdjTensor ⟨Q, hQproj, hQ0, hQ1, hLowerAdj⟩
 
+/-- **Dual fixed-point diagonalization in PGVWC07 unital orientation.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+lines 827--832.  If an irreducible block is already in the unital orientation
+`∑ᵢ Aᵢ Aᵢ† = I`, then applying the fixed-point argument to the conjugate-transposed
+Kraus family gives a positive-definite fixed point of the dual map.  A unitary
+gauge diagonalizes that fixed point while preserving the unital normalization
+and the finite-ring matrix product vectors.
+
+This theorem is deliberately a wrapper around
+`exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor` applied to
+`i ↦ (A i)ᴴ`; it records the PGVWC07 orientation without duplicating the
+trace-preserving diagonalization proof. -/
+theorem exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor
+    (A : MPSTensor d D)
+    (hUnital : ∑ i : Fin d, A i * (A i)ᴴ = 1)
+    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
+    (hD : 0 < D) :
+    ∃ (U : Matrix.unitaryGroup (Fin D) ℂ)
+      (Λ : Matrix (Fin D) (Fin D) ℂ),
+        let B : MPSTensor d D :=
+          fun i =>
+            (↑U : Matrix (Fin D) (Fin D) ℂ)ᴴ * A i *
+              (↑U : Matrix (Fin D) (Fin D) ℂ);
+        SameMPV₂ A B ∧
+        Λ.PosDef ∧ Λ.IsDiag ∧
+        (∑ i : Fin d, B i * (B i)ᴴ = 1) ∧
+        transferMap (d := d) (D := D) (fun i => (B i)ᴴ) Λ = Λ := by
+  classical
+  let Aadj : MPSTensor d D := fun i => (A i)ᴴ
+  have hTPadj : ∑ i : Fin d, (Aadj i)ᴴ * Aadj i = 1 := by
+    simpa [Aadj, Matrix.conjTranspose_conjTranspose] using hUnital
+  have hIrrAdjMap :
+      IsIrreducibleMap (transferMap (d := d) (D := D) Aadj) := by
+    simpa [Aadj] using
+      isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor
+        (d := d) (D := D) A hIrr
+  have hIrrAdj : IsIrreducibleTensor (d := d) (D := D) Aadj :=
+    isIrreducibleTensor_of_isIrreducibleMap Aadj hIrrAdjMap
+  obtain ⟨U, Λ, hΛ_pd, hΛ_diag, hTP_conj, hΛ_fix⟩ :=
+    exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor
+      (d := d) (D := D) Aadj hTPadj hIrrAdj hD
+  refine ⟨U, Λ, ?_⟩
+  let B : MPSTensor d D :=
+    fun i =>
+      (↑U : Matrix (Fin D) (Fin D) ℂ)ᴴ * A i *
+        (↑U : Matrix (Fin D) (Fin D) ℂ)
+  have hSame : SameMPV₂ A B := by
+    simpa [B, Matrix.star_eq_conjTranspose] using
+      sameMPV_conj_unitary (d := d) (D := D) A U
+  have hUnitalB : ∑ i : Fin d, B i * (B i)ᴴ = 1 := by
+    simpa [B, Aadj, Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose,
+      Matrix.mul_assoc] using hTP_conj
+  have hΛ_fixB : transferMap (d := d) (D := D) (fun i => (B i)ᴴ) Λ = Λ := by
+    simpa [B, Aadj, Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose,
+      Matrix.mul_assoc] using hΛ_fix
+  exact ⟨hSame, hΛ_pd, hΛ_diag, hUnitalB, hΛ_fixB⟩
+
 end MPSTensor
 
 namespace KadisonSchwarz

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -182,8 +182,10 @@ when that fixed point is singular, split the finite-ring trace over the support
 and its orthogonal complement, iterate this dimension-decreasing decomposition
 until the identity is the only fixed point of each block, and finally apply the
 dual fixed-point argument and unitary diagonalization that produces the
-matrices $\Lambda_k$.  Only after these steps have been composed can the
-existing conditional TP-normalized and primitive-block results be used as
+matrices $\Lambda_k$.  The last step is now available for an irreducible
+unital block as Theorem~\ref{thm:pgvwc07_dual_diag_unital}; the remaining work
+is to thread it through the whole source recursion.  Only after these steps
+have been composed can the existing conditional TP-normalized and primitive-block results be used as
 corollaries of the source theorem.
 
 \section{Normal tensors, canonical forms, and bases of normal tensors}\label{sec:cpsv_canonical_defs}
@@ -766,6 +768,35 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     the diagonal PD fixed point.
     Unitary conjugation preserves trace-preservation and the MPV
     family (Theorem~\ref{thm:samempv_unitary}).
+\end{proof}
+
+\begin{theorem}[Dual diagonalization for irreducible unital blocks]%
+    \label{thm:pgvwc07_dual_diag_unital}
+    \lean{MPSTensor.exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor}
+    \leanok
+    \uses{def:irreducible_tensor}
+    Let $A$ be an irreducible MPS tensor in the unital gauge
+    $\sum_i A^i(A^i)^\dagger=\Id$ with positive bond dimension.
+    Then there exist a unitary~$U$ and a diagonal positive definite
+    matrix~$\Lambda$ such that, for $B^i:=U^\dagger A^iU$,
+    \[
+        \sum_i B^i(B^i)^\dagger=\Id,
+        \qquad
+        \sum_i (B^i)^\dagger\Lambda B^i=\Lambda,
+    \]
+    and $A$ and $B$ generate the same MPV family.
+    This is the dual-map fixed-point and unitary-diagonalization step of
+    \cite[Theorem~Th:TIcanonical, lines~827--832]{PerezGarcia2007Matrix},
+    stated after the preceding recursion has already produced an irreducible
+    unital block.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:CFII_data, thm:samempv_unitary}
+    Apply Theorem~\ref{thm:CFII_data} to the conjugate-transposed Kraus family
+    $i\mapsto (A^i)^\dagger$.  Unitality of $A$ is trace preservation for this
+    family, and its transfer map is the dual map of $A$.  Translating back gives
+    the displayed equations for $B$.
 \end{proof}
 
 \begin{theorem}[Irreducible block decomposition with left-canonical normalization]%

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -192,6 +192,23 @@ The earlier existence path now has the following formal pieces.
           (Wolf Theorem 6.6).  Thus the identity is the unique fixed point
           after the usual scalar normalization of the fixed-point line.
 
+    \item
+          \path|MPSTensor.exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor|
+          formalizes the dual-map diagonalization in
+          Theorem~\texttt{Th:TIcanonical}, lines 827--832, conditional on having
+          already reached an irreducible unital block.  The proof applies the
+          existing trace-preserving diagonalization theorem to the
+          conjugate-transposed Kraus family \(i\mapsto A_i^\dagger\).  This is
+          not a duplicate spectral proof: unitality of \(A\) is trace
+          preservation for \(A^\dagger\), and translating back gives a unitary
+          gauge \(B_i=U^\dagger A_iU\) with
+          \[
+              \sum_i B_iB_i^\dagger=\mathbf{1},
+              \qquad
+              \sum_i B_i^\dagger\Lambda B_i=\Lambda,
+          \]
+          for diagonal positive-definite \(\Lambda\).
+
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an


### PR DESCRIPTION
## Summary

This PR formalizes the PGVWC07 Theorem `Th:TIcanonical` dual fixed-point diagonalization step for a single irreducible unital block.

The new theorem is:

- `MPSTensor.exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor`

It assumes an irreducible tensor already in unital gauge, `∑ᵢ Aᵢ Aᵢ† = 1`, and produces a unitary conjugate `Bᵢ = U† Aᵢ U` and diagonal positive-definite `Λ` such that:

- `∑ᵢ Bᵢ Bᵢ† = 1`
- `∑ᵢ Bᵢ† Λ Bᵢ = Λ`
- the finite-ring MPV family is preserved.

Progress toward #1857.

## Mathematical Point

The proof does not duplicate the TP diagonalization argument. It applies the existing theorem
`MPSTensor.exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor`
to the conjugate-transposed Kraus family `i ↦ (A i)ᴴ`. Under this passage, unitality of `A` becomes TP normalization of the adjoint family, and translating back gives the PGVWC07 unital-orientation dual fixed-point statement.

The blueprint and paper-gap audit now record that lines 827--832 are formalized conditionally after the recursion has already produced an irreducible unital block. The full source theorem still remains the composition problem from an arbitrary translation-invariant representation.

## Checks

- `lake env lean TNLean/MPS/Irreducible/Adjoint.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Reduction.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `lake build TNLean.MPS.Irreducible.Adjoint`
- `git diff --check -- TNLean/MPS/CanonicalForm/Existence.lean TNLean/MPS/CanonicalForm/Reduction.lean TNLean/MPS/Irreducible/Adjoint.lean blueprint/src/chapter/ch08_canonical.tex docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/Irreducible/Adjoint.lean` returned no matches
- `leanblueprint web`
- `leanblueprint checkdecls` still fails on existing not-ready declarations outside this PR; the new declaration is not among the missing entries.

Note: the `blueprint-and-prose` failure is the known Claude weekly-limit failure, not a reported prose finding.
