### PR TITLE
doc(MPS/CanonicalForm): clean dual-step prose

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -65,10 +65,8 @@ spectral-radius normalization and the full-rank fixed-point gauge, lines
 771–815 for deriving the invariant support from a singular positive fixed point
 and then splitting the trace, lines 816–826 for iteration and non-scalar
 fixed-point splitting, and lines 827–832 for dual fixed-point diagonalization.
-The final dual step is now available for a single irreducible unital block in
-`MPSTensor.exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor`;
-what is still missing here is the source-level composition over the whole
-recursive decomposition.
+In this file the remaining problem is the source-level composition over the
+whole recursive decomposition, starting from an arbitrary representation.
 
 ## External input — Quantum Wielandt strong irreducibility ⇒ full Kraus rank
 

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -23,8 +23,8 @@ iterate the split and use a non-scalar fixed point to force uniqueness of the
 identity fixed point.  This file formalizes only the abstract splitting once an
 invariant projection is available; a faithful proof of the full theorem must
 also derive that projection from the singular positive fixed-point argument in
-lines 771–783 and compose the dual fixed-point diagonalization formalized in
-`TNLean.MPS.Irreducible.Adjoint` for lines 827–832.
+lines 771–783 and then compose the dual fixed-point diagonalization in
+lines 827–832.
 
 Starting from an arbitrary MPS tensor `A : MPSTensor d D`, we iteratively apply
 `MPSTensor.exists_twoBlock_decomp_of_lowerZero_strict` — which produces two blocks each with

--- a/TNLean/MPS/Irreducible/Adjoint.lean
+++ b/TNLean/MPS/Irreducible/Adjoint.lean
@@ -148,12 +148,10 @@ lines 827--832.  If an irreducible block is already in the unital orientation
 `∑ᵢ Aᵢ Aᵢ† = I`, then applying the fixed-point argument to the conjugate-transposed
 Kraus family gives a positive-definite fixed point of the dual map.  A unitary
 gauge diagonalizes that fixed point while preserving the unital normalization
-and the finite-ring matrix product vectors.
-
-This theorem is deliberately a wrapper around
-`exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor` applied to
-`i ↦ (A i)ᴴ`; it records the PGVWC07 orientation without duplicating the
-trace-preserving diagonalization proof. -/
+and the finite-ring matrix product vectors. -/
+/- Note (for maintainers): the proof reuses the trace-preserving diagonalization
+theorem for the conjugate-transposed Kraus family. This keeps the PGVWC07
+orientation explicit without repeating the spectral argument. -/
 theorem exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor
     (A : MPSTensor d D)
     (hUnital : ∑ i : Fin d, A i * (A i)ᴴ = 1)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -182,10 +182,8 @@ when that fixed point is singular, split the finite-ring trace over the support
 and its orthogonal complement, iterate this dimension-decreasing decomposition
 until the identity is the only fixed point of each block, and finally apply the
 dual fixed-point argument and unitary diagonalization that produces the
-matrices $\Lambda_k$.  The last step is now available for an irreducible
-unital block as Theorem~\ref{thm:pgvwc07_dual_diag_unital}; the remaining work
-is to thread it through the whole source recursion.  Only after these steps
-have been composed can the existing conditional TP-normalized and primitive-block results be used as
+matrices $\Lambda_k$.  Only after these steps have been composed can the
+existing conditional TP-normalized and primitive-block results be used as
 corollaries of the source theorem.
 
 \section{Normal tensors, canonical forms, and bases of normal tensors}\label{sec:cpsv_canonical_defs}


### PR DESCRIPTION
## Summary

Follow-up to PR #1934. This addresses Copilot's prose comments after that PR was merged.

Changes:

- Removes implementation/status framing from reader-facing Lean docstrings and blueprint prose.
- Keeps the PGVWC07 lines 827--832 mathematical source references intact.
- Moves the proof-reuse explanation in `Adjoint.lean` into a maintainer note rather than the theorem docstring.

## Checks

- `lake env lean TNLean/MPS/Irreducible/Adjoint.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Reduction.lean`
- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `git diff --check -- TNLean/MPS/Irreducible/Adjoint.lean TNLean/MPS/CanonicalForm/Reduction.lean TNLean/MPS/CanonicalForm/Existence.lean blueprint/src/chapter/ch08_canonical.tex`

Unrelated local workspace changes were not staged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits that adjust explanations of the PGVWC07 dual diagonalization step and remaining proof gaps; no functional Lean proofs or definitions are changed.
> 
> **Overview**
> Clarifies reader-facing documentation around the PGVWC07 Theorem `Th:TIcanonical` *dual fixed-point diagonalization* step, emphasizing that the main remaining gap is composing the full source-level recursion from arbitrary input.
> 
> Moves the explanation about reusing the trace-preserving diagonalization proof in `Irreducible/Adjoint.lean` into a maintainer note, and makes parallel wording cleanups in `CanonicalForm/Existence.lean`, `CanonicalForm/Reduction.lean`, and the blueprint text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd2c0694a4c5f91629e3ebeb085110a634162c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->