### PR TITLE
feat(Channel/PerronFrobenius): add PGVWC07 unital gauge data

### DIFF
--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -369,4 +369,70 @@ theorem exists_tp_data_of_irreducible
   -- GaugeEquiv: A' matches the stated rescaled tensor.
   · convert hB_gauge using 1
 
+/-- **Unital / right-canonical gauge data for an irreducible MPS tensor.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+lines 765--770.  For an irreducible MPS tensor `A` with positive bond
+dimension and some nonzero Kraus operator, the Perron--Frobenius eigenvector of
+the transfer map gives a positive real `r` and a positive definite matrix `ρ`
+such that the rescaled right-canonical gauge
+`B i = r^{-1/2} ρ^{-1/2} A i ρ^{1/2}` is unital:
+`∑ᵢ Bᵢ Bᵢ† = I`.
+
+This is the source-oriented analogue of `exists_tp_data_of_irreducible`.  It is
+obtained by applying the adjoint-eigenvector theorem to the conjugate-transposed
+Kraus family. -/
+theorem exists_unital_data_of_irreducible
+    [NeZero D]
+    (A : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
+    (hA : ∃ i, A i ≠ 0) :
+    ∃ (B : MPSTensor d D) (r : ℝ) (ρ : Matrix (Fin D) (Fin D) ℂ),
+      ρ.PosDef ∧ 0 < r ∧
+      (∀ i : Fin d,
+        B i =
+          (↑((Real.sqrt r)⁻¹) : ℂ) •
+            ((CFC.sqrt ρ)⁻¹ * A i * CFC.sqrt ρ)) ∧
+      (∑ i : Fin d, B i * (B i)ᴴ = 1) ∧
+      GaugeEquiv (d := d) (D := D)
+        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
+  classical
+  let Aadj : MPSTensor d D := fun i => (A i)ᴴ
+  have hIrrAdjMap :
+      IsIrreducibleMap (transferMap (d := d) (D := D) Aadj) := by
+    simpa [Aadj] using
+      isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor
+        (d := d) (D := D) A hIrr
+  have hIrrAdj : IsIrreducibleTensor (d := d) (D := D) Aadj :=
+    isIrreducibleTensor_of_isIrreducibleMap Aadj hIrrAdjMap
+  have hAadj : ∃ i, Aadj i ≠ 0 := by
+    rcases hA with ⟨i, hi⟩
+    refine ⟨i, ?_⟩
+    intro hzero
+    apply hi
+    have h := congrArg Matrix.conjTranspose hzero
+    simpa [Aadj, Matrix.conjTranspose_conjTranspose] using h
+  obtain ⟨ρ, r, hρ_pd, hr_pos, hρ_eig_adj⟩ :=
+    exists_posDef_adjoint_eigenvector Aadj hIrrAdj hAadj
+  have hρ_eig : transferMap (d := d) (D := D) A ρ = (r : ℂ) • ρ := by
+    simpa [Aadj, Matrix.conjTranspose_conjTranspose] using hρ_eig_adj
+  let B : MPSTensor d D := spectralUnitalGauge (d := d) (D := D) A r ρ
+  have hB_unital : ∑ i : Fin d, B i * (B i)ᴴ = 1 := by
+    simpa [B] using
+      spectralUnitalGauge_isUnital_of_transferMap_eigenvector
+        (d := d) (D := D) A ρ r hρ_pd hr_pos hρ_eig
+  let c : ℂ := (↑((Real.sqrt r)⁻¹) : ℂ)
+  let A' : MPSTensor d D := fun i => c • A i
+  have hGauge : GaugeEquiv (d := d) (D := D) A' B := by
+    have hBase : GaugeEquiv (d := d) (D := D) A'
+        (unitalGauge (d := d) (D := D) A' ρ) :=
+      gaugeEquiv_unitalGauge (d := d) (D := D) A' ρ hρ_pd
+    convert hBase using 1
+    ext i a b
+    simp [B, A', c, spectralUnitalGauge, unitalGauge, Matrix.mul_assoc]
+  refine ⟨B, r, ρ, hρ_pd, hr_pos, ?_, hB_unital, ?_⟩
+  · intro i
+    rfl
+  · convert hGauge using 1
+
 end MPSTensor

--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -568,6 +568,41 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
     satisfies $\sum_i (B^i)^\dagger B^i = \Id$.
 \end{proof}
 
+\begin{theorem}[Unital-gauge existence for irreducible tensors]%
+    \label{thm:unital_data_irreducible}
+    \lean{MPSTensor.exists_unital_data_of_irreducible}
+    \leanok
+    \uses{def:irreducible_tensor}
+    Let $A$ be an irreducible MPS tensor with $D > 0$
+    and some $A^i \neq 0$.
+    Then there exist a positive real~$r$, a positive definite
+    matrix~$\rho$, and a gauge-equivalent tensor~$B$ such that
+    \[
+        B^i = r^{-1/2}\rho^{-1/2}A^i\rho^{1/2}
+    \]
+    is unital:
+    $\sum_i B^i(B^i)^\dagger = \Id$.
+
+    This is the right-canonical analogue of
+    Theorem~\ref{thm:tp_data_irreducible}.  In the
+    translation-invariant canonical-form proof of
+    \cite[Theorem~Th:TIcanonical, lines~765--770]
+    {PerezGarcia2007Matrix}, it is the Perron--Frobenius
+    eigenvector step that produces the unital block orientation.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:posDef_adjoint_eigenvector}
+    Apply Theorem~\ref{thm:posDef_adjoint_eigenvector} to the
+    conjugate-transposed Kraus family.  Irreducibility transfers to this
+    family by the invariant-projection argument, and a nonzero Kraus operator
+    remains nonzero after conjugate transpose.  The resulting adjoint
+    eigenvector equation for the conjugate-transposed family is exactly
+    $\E_A(\rho)=r\rho$.  The unital gauge construction then gives
+    $B^i=r^{-1/2}\rho^{-1/2}A^i\rho^{1/2}$ and proves
+    $\sum_i B^i(B^i)^\dagger=\Id$.
+\end{proof}
+
 \section{Exponential positivity for irreducible CP maps}
 
 \begin{theorem}[Exponential truncation is positive definite]

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -158,6 +158,17 @@ The earlier existence path now has the following formal pieces.
           \(B_i=r^{-1/2}\rho^{-1/2}A_i\rho^{1/2}\) satisfies
           \(\sum_i B_iB_i^\dagger=\mathbf{1}\).
 
+    \item
+          \path|MPSTensor.exists_unital_data_of_irreducible|
+          formalizes the Perron--Frobenius existence input for the same
+          source step, Theorem~\texttt{Th:TIcanonical}, lines 765--770,
+          conditional on a single irreducible nonzero block.  It obtains a
+          positive definite eigenvector of \(\mathcal{E}_A\), the positive
+          eigenvalue \(r\), and the unital rescaled gauge
+          \(B_i=r^{-1/2}\rho^{-1/2}A_i\rho^{1/2}\).  This closes the
+          single-block unital-orientation step but does not yet thread that
+          step through the recursive block decomposition.
+
     \item \path|MPSTensor.unitalGauge_isUnital_of_transferMap_fixedPoint|
           formalizes the full-rank fixed-point gauge in
           Theorem~\texttt{Th:TIcanonical}, lines 767--769.  Given a positive


### PR DESCRIPTION
## Summary

This PR adds the source-oriented unital Perron--Frobenius gauge step used in PGVWC07, Theorem `Th:TIcanonical`, proof lines 765--770.

New theorem:

- `MPSTensor.exists_unital_data_of_irreducible`

For a single irreducible nonzero block, it produces a positive Perron--Frobenius eigenvalue `r`, a positive definite eigenvector `ρ` of the original transfer map, and the rescaled right-canonical gauge

```text
B i = r^{-1/2} ρ^{-1/2} A i ρ^{1/2}
```

with `∑ᵢ Bᵢ Bᵢ† = 1`, together with gauge equivalence to the rescaled original tensor.

This is the unital-orientation analogue of the existing TP-gauge theorem `MPSTensor.exists_tp_data_of_irreducible`. The proof applies `MPSTensor.exists_posDef_adjoint_eigenvector` to the conjugate-transposed Kraus family and translates the resulting adjoint eigenvector equation back to `transferMap A ρ = r • ρ`.

The PR also adds a blueprint entry and updates the PGVWC07 paper-gap audit to record that this closes the single-block unital orientation step, but does not yet thread it through the recursive decomposition.

Progress toward #1857.

## Checks

- `lake env lean TNLean/Channel/PerronFrobenius/Existence.lean`
- `lake build TNLean.Channel.PerronFrobenius.Existence`
- `git diff --check -- TNLean/Channel/PerronFrobenius/Existence.lean blueprint/src/chapter/ch05_qpf.tex docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/Channel/PerronFrobenius/Existence.lean` returned no matches
- `leanblueprint web`
- `leanblueprint checkdecls` still fails on pre-existing missing declarations outside this PR; `MPSTensor.exists_unital_data_of_irreducible` is not among them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new existence theorem and accompanying documentation without altering existing normalization/gauge constructions or core Perron–Frobenius results.
> 
> **Overview**
> Adds `MPSTensor.exists_unital_data_of_irreducible`, a right-canonical/unital analogue of the existing TP-gauge existence theorem: from an irreducible nonzero tensor it produces `r>0`, `ρ` pos-def with `transferMap A ρ = r • ρ`, and a gauge-equivalent rescaled tensor `B` satisfying `∑ i, B i * (B i)ᴴ = 1`.
> 
> Updates the blueprint (`ch05_qpf.tex`) and the PGVWC07 scope audit to document this new unital-orientation Perron–Frobenius step for the single irreducible block case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc4e33b77c65eadf6739b91fbc955e17c20cb942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->