### PR TITLE
feat(MPS/CanonicalForm): compose PGVWC07 irreducible block data

### DIFF
--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -369,4 +369,60 @@ theorem exists_tp_data_of_irreducible
   -- GaugeEquiv: A' matches the stated rescaled tensor.
   · convert hB_gauge using 1
 
+/-- **Unital gauge data for an irreducible MPS tensor.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+lines 765--770.  For an irreducible nonzero tensor, the Perron--Frobenius
+eigenvector of the transfer map gives a positive scalar `r` and a positive
+definite matrix `ρ`; the spectral gauge
+`B i = r^{-1/2} ρ^{-1/2} A i ρ^{1/2}` is unital and gauge-equivalent to the
+rescaled tensor `r^{-1/2} A`. -/
+theorem exists_unital_data_of_irreducible
+    [NeZero D]
+    (A : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
+    (hA : ∃ i, A i ≠ 0) :
+    ∃ (B : MPSTensor d D) (r : ℝ) (ρ : Matrix (Fin D) (Fin D) ℂ),
+      ρ.PosDef ∧ 0 < r ∧
+      (∀ i : Fin d,
+        B i =
+          (↑((Real.sqrt r)⁻¹) : ℂ) •
+            ((CFC.sqrt ρ)⁻¹ * A i * CFC.sqrt ρ)) ∧
+      (∑ i : Fin d, B i * (B i)ᴴ = 1) ∧
+      GaugeEquiv (d := d) (D := D)
+        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
+  classical
+  let Aadj : MPSTensor d D := fun i => (A i)ᴴ
+  have hIrrAdjMap :
+      IsIrreducibleMap (transferMap (d := d) (D := D) Aadj) := by
+    simpa [Aadj] using
+      isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor
+        (d := d) (D := D) A hIrr
+  have hIrrAdj : IsIrreducibleTensor (d := d) (D := D) Aadj :=
+    isIrreducibleTensor_of_isIrreducibleMap Aadj hIrrAdjMap
+  have hAadj : ∃ i, Aadj i ≠ 0 := by
+    rcases hA with ⟨i, hi⟩
+    refine ⟨i, ?_⟩
+    intro h
+    exact hi (Matrix.conjTranspose_eq_zero.mp (by simpa [Aadj] using h))
+  obtain ⟨ρ, r, hρ, hr, hρ_eig_adj⟩ :=
+    exists_posDef_adjoint_eigenvector (d := d) (D := D) Aadj hIrrAdj hAadj
+  have hρ_eig : transferMap (d := d) (D := D) A ρ = (r : ℂ) • ρ := by
+    simpa [Aadj, Matrix.conjTranspose_conjTranspose] using hρ_eig_adj
+  let B : MPSTensor d D := spectralUnitalGauge (d := d) (D := D) A r ρ
+  have hB_unital : ∑ i : Fin d, B i * (B i)ᴴ = 1 := by
+    simpa [B] using
+      spectralUnitalGauge_isUnital_of_transferMap_eigenvector
+        (d := d) (D := D) A ρ r hρ hr hρ_eig
+  have hGauge : GaugeEquiv (d := d) (D := D)
+      (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B := by
+    convert
+      gaugeEquiv_unitalGauge (d := d) (D := D)
+        (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) ρ hρ using 1
+    ext i
+    simp [B, spectralUnitalGauge, unitalGauge]
+  refine ⟨B, r, ρ, hρ, hr, ?_, hB_unital, hGauge⟩
+  intro i
+  rfl
+
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.MatrixFunctionalCalculus
+import TNLean.MPS.Irreducible.ScalarFixedPoint
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.SharedInfra.Scaling
 import TNLean.MPS.CanonicalForm.Existence
@@ -114,6 +115,90 @@ private theorem isIrreducibleTensor_tpGauge_of_isIrreducibleTensor
   exact
     isIrreducibleTensor_of_isIrreducibleAction
       (d := d) (D := D) (tpGauge (d := d) (D := D) A σ) hActionGauge
+
+/-- **Single irreducible-block PGVWC07 canonical-form data.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+lines 765--770 and 816--832.  For one irreducible nonzero block, the
+Perron--Frobenius eigenvector gives the source theorem's unital gauge.  In
+that unital gauge every fixed point is scalar, and a final unitary conjugation
+diagonalizes a positive-definite fixed point of the dual transfer map.
+
+This is still a single-block statement.  It does not yet thread the construction
+through the recursive finite-ring block decomposition, nor does it prove the
+total bond-dimension bound of the full translation-invariant canonical-form
+theorem. -/
+theorem exists_pgvwc07_unital_dualDiag_data_of_irreducible
+    [NeZero D]
+    (A : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
+    (hA : ∃ i, A i ≠ 0) :
+    ∃ (B C : MPSTensor d D)
+      (r : ℝ)
+      (ρ Λ : Matrix (Fin D) (Fin D) ℂ)
+      (U : Matrix.unitaryGroup (Fin D) ℂ),
+        ρ.PosDef ∧
+        0 < r ∧
+        (∀ i : Fin d,
+          B i =
+            (↑((Real.sqrt r)⁻¹) : ℂ) •
+              ((CFC.sqrt ρ)⁻¹ * A i * CFC.sqrt ρ)) ∧
+        GaugeEquiv (d := d) (D := D)
+          (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • A i) B ∧
+        (∑ i : Fin d, B i * (B i)ᴴ = 1) ∧
+        (∀ X : Matrix (Fin D) (Fin D) ℂ,
+          transferMap (d := d) (D := D) B X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin D) (Fin D) ℂ)) ∧
+        (let C' : MPSTensor d D :=
+          fun i =>
+            (↑U : Matrix (Fin D) (Fin D) ℂ)ᴴ * B i *
+              (↑U : Matrix (Fin D) (Fin D) ℂ);
+          C = C' ∧
+          SameMPV₂ B C ∧
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, C i * (C i)ᴴ = 1) ∧
+          transferMap (d := d) (D := D) (fun i => (C i)ᴴ) Λ = Λ) := by
+  classical
+  obtain ⟨B, r, ρ, hρ, hr, hB_form, hB_unital, hGauge⟩ :=
+    exists_unital_data_of_irreducible (d := d) (D := D) A hIrr hA
+  let c : ℂ := (↑((Real.sqrt r)⁻¹) : ℂ)
+  have hroot_ne : (↑(Real.sqrt r) : ℂ) ≠ 0 := by
+    exact_mod_cast (Real.sqrt_ne_zero'.mpr hr)
+  have hc_ne : c ≠ 0 := by
+    dsimp [c]
+    simp [hroot_ne]
+  have hIrr_scaled :
+      IsIrreducibleTensor (d := d) (D := D) (fun i => c • A i) :=
+    isIrreducibleTensor_smul (d := d) (D := D) hc_ne A hIrr
+  have hActionScaled :
+      IsIrreducibleAction (d := d) (D := D) (fun i => c • A i) :=
+    isIrreducibleAction_of_isIrreducibleTensor
+      (d := d) (D := D) (fun i => c • A i) hIrr_scaled
+  have hActionB : IsIrreducibleAction (d := d) (D := D) B :=
+    isIrreducibleAction_gaugeEquiv (d := d) (D := D) hGauge hActionScaled
+  have hIrrB : IsIrreducibleTensor (d := d) (D := D) B :=
+    isIrreducibleTensor_of_isIrreducibleAction (d := d) (D := D) B hActionB
+  have hB_unital_map : transferMap (d := d) (D := D) B 1 = 1 := by
+    simpa [transferMap_apply, Matrix.mul_one] using hB_unital
+  haveI : Nonempty (Fin D) := ⟨⟨0, NeZero.pos D⟩⟩
+  have hScalar :
+      ∀ X : Matrix (Fin D) (Fin D) ℂ,
+        transferMap (d := d) (D := D) B X = X →
+          ∃ c : ℂ, X = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    intro X hX
+    exact fixed_eq_scalar_of_isIrreducibleTensor_unital
+      (d := d) (D := D) B hIrrB hB_unital_map X hX
+  obtain ⟨U, Λ, hSame, hΛ_pd, hΛ_diag, hC_unital, hΛ_fix⟩ :=
+    exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor
+      (d := d) (D := D) B hB_unital hIrrB (NeZero.pos D)
+  let C : MPSTensor d D :=
+    fun i =>
+      (↑U : Matrix (Fin D) (Fin D) ℂ)ᴴ * B i *
+        (↑U : Matrix (Fin D) (Fin D) ℂ)
+  refine ⟨B, C, r, ρ, Λ, U, hρ, hr, hB_form, ?_, hB_unital, hScalar, ?_⟩
+  · simpa [c] using hGauge
+  · exact ⟨rfl, hSame, hΛ_pd, hΛ_diag, hC_unital, hΛ_fix⟩
 
 /-- Blockwise Perron--Frobenius / TP-gauge stage for an irreducible block decomposition.
 

--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -568,6 +568,37 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
     satisfies $\sum_i (B^i)^\dagger B^i = \Id$.
 \end{proof}
 
+\begin{theorem}[Unital-gauge existence for irreducible tensors]%
+    \label{thm:unital_data_irreducible}
+    \lean{MPSTensor.exists_unital_data_of_irreducible}
+    \leanok
+    \uses{def:irreducible_tensor, thm:posDef_adjoint_eigenvector,
+        thm:unital_gauge_of_pd_fixed_point}
+    Let $A$ be an irreducible MPS tensor with $D > 0$
+    and some $A^i \neq 0$.
+    Then there exist a positive real~$r$, a positive definite
+    matrix~$\rho$, and a gauge-equivalent tensor~$B$ such that
+    \[
+        B^i = r^{-1/2}\rho^{-1/2}A^i\rho^{1/2}
+    \]
+    is unital:
+    $\sum_i B^i(B^i)^\dagger = \Id$.
+
+    This is the Perron--Frobenius unital-gauge orientation used in
+    \cite[Theorem~Th:TIcanonical, lines~765--770]{PerezGarcia2007Matrix},
+    stated for one irreducible nonzero block.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply Theorem~\ref{thm:posDef_adjoint_eigenvector} to the
+    conjugate-transposed Kraus family.  Irreducibility transfers to that
+    family, and the nonzero Kraus hypothesis is preserved by taking adjoints.
+    Translating the resulting adjoint eigenvector equation back gives
+    $\E_A(\rho)=r\rho$ with $\rho$ positive definite and $r>0$.  The unital
+    gauge theorem then gives the displayed unital representative, and the
+    same square-root similarity gives gauge equivalence to $r^{-1/2}A$.
+\end{proof}
+
 \section{Exponential positivity for irreducible CP maps}
 
 \begin{theorem}[Exponential truncation is positive definite]

--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -572,8 +572,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
     \label{thm:unital_data_irreducible}
     \lean{MPSTensor.exists_unital_data_of_irreducible}
     \leanok
-    \uses{def:irreducible_tensor, thm:posDef_adjoint_eigenvector,
-        thm:unital_gauge_of_pd_fixed_point}
+    \uses{def:irreducible_tensor}
     Let $A$ be an irreducible MPS tensor with $D > 0$
     and some $A^i \neq 0$.
     Then there exist a positive real~$r$, a positive definite
@@ -590,6 +589,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:posDef_adjoint_eigenvector, thm:unital_gauge_of_pd_fixed_point}
     Apply Theorem~\ref{thm:posDef_adjoint_eigenvector} to the
     conjugate-transposed Kraus family.  Irreducibility transfers to that
     family, and the nonzero Kraus hypothesis is preserved by taking adjoints.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -801,7 +801,7 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     \label{thm:pgvwc07_irreducible_unital_dual_package}
     \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible}
     \leanok
-    \uses{def:irreducible_tensor, thm:unital_gauge_of_pd_fixed_point,
+    \uses{def:irreducible_tensor, thm:unital_data_irreducible,
         thm:irreducible_unital_scalar_fixed_point,
         thm:pgvwc07_dual_diag_unital}
     Let $A$ be an irreducible nonzero MPS block with positive bond dimension.
@@ -830,7 +830,7 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
 \end{theorem}
 
 \begin{proof}\leanok
-    Theorem~\ref{thm:unital_gauge_of_pd_fixed_point} gives the unital gauge.
+    Theorem~\ref{thm:unital_data_irreducible} gives the unital gauge.
     Gauge equivalence preserves irreducibility of the bond-space action, so
     Theorem~\ref{thm:irreducible_unital_scalar_fixed_point} gives the scalar
     fixed-point endpoint for the unital representative.  Then

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -797,6 +797,47 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     the displayed equations for $B$.
 \end{proof}
 
+\begin{theorem}[Single irreducible-block PGVWC07 canonical-form data]%
+    \label{thm:pgvwc07_irreducible_unital_dual_package}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible}
+    \leanok
+    \uses{def:irreducible_tensor, thm:unital_gauge_of_pd_fixed_point,
+        thm:irreducible_unital_scalar_fixed_point,
+        thm:pgvwc07_dual_diag_unital}
+    Let $A$ be an irreducible nonzero MPS block with positive bond dimension.
+    Then the Perron--Frobenius eigenvector produces a positive scalar $r$ and a
+    positive definite matrix $\rho$ such that
+    \[
+        B^i := r^{-1/2}\rho^{-1/2} A^i\rho^{1/2}
+    \]
+    is unital.  In this unital gauge every fixed point of $\E_B$ is a scalar
+    multiple of the identity.  Moreover a unitary conjugate $C^i=U^\dagger
+    B^iU$ remains unital and has a diagonal positive definite dual fixed point
+    $\Lambda$:
+    \[
+        \sum_i C^i(C^i)^\dagger=\Id,
+        \qquad
+        \sum_i (C^i)^\dagger\Lambda C^i=\Lambda .
+    \]
+    The construction preserves the finite-ring coefficients up to the
+    spectral-radius weight carried by the rescaling from $A$ to $B$.
+
+    This composes the single-block canonical-form existence steps of
+    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
+        {PerezGarcia2007Matrix}.  It is not yet the full theorem, because the
+    recursive finite-ring block decomposition and the final bond-dimension
+    bound have not been threaded through this package.
+\end{theorem}
+
+\begin{proof}\leanok
+    Theorem~\ref{thm:unital_gauge_of_pd_fixed_point} gives the unital gauge.
+    Gauge equivalence preserves irreducibility of the bond-space action, so
+    Theorem~\ref{thm:irreducible_unital_scalar_fixed_point} gives the scalar
+    fixed-point endpoint for the unital representative.  Then
+    Theorem~\ref{thm:pgvwc07_dual_diag_unital} gives the unitary
+    diagonalization of the dual fixed point.
+\end{proof}
+
 \begin{theorem}[Irreducible block decomposition with left-canonical normalization]%
     \label{thm:irreducible_block_decomp_with_cfii}
     \lean{MPSTensor.exists_irreducible_blockDecomp_with_CFII}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -801,9 +801,7 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     \label{thm:pgvwc07_irreducible_unital_dual_package}
     \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible}
     \leanok
-    \uses{def:irreducible_tensor, thm:unital_data_irreducible,
-        thm:irreducible_unital_scalar_fixed_point,
-        thm:pgvwc07_dual_diag_unital}
+    \uses{def:irreducible_tensor}
     Let $A$ be an irreducible nonzero MPS block with positive bond dimension.
     Then the Perron--Frobenius eigenvector produces a positive scalar $r$ and a
     positive definite matrix $\rho$ such that
@@ -830,6 +828,9 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:unital_data_irreducible,
+        thm:irreducible_unital_scalar_fixed_point,
+        thm:pgvwc07_dual_diag_unital}
     Theorem~\ref{thm:unital_data_irreducible} gives the unital gauge.
     Gauge equivalence preserves irreducibility of the bond-space action, so
     Theorem~\ref{thm:irreducible_unital_scalar_fixed_point} gives the scalar

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -210,6 +210,18 @@ The earlier existence path now has the following formal pieces.
           for diagonal positive-definite \(\Lambda\).
 
     \item
+          \path|MPSTensor.exists_unital_data_of_irreducible| formalizes the
+          Perron--Frobenius unital-gauge step in
+          Theorem~\texttt{Th:TIcanonical}, lines 765--770, for a single
+          irreducible nonzero block.  It obtains a positive-definite
+          eigenvector \(\rho\) for the transfer map by applying the adjoint
+          Perron--Frobenius theorem to the conjugate-transposed Kraus family,
+          and then forms
+          \(B_i=r^{-1/2}\rho^{-1/2}A_i\rho^{1/2}\) with
+          \(\sum_i B_iB_i^\dagger=\mathbf{1}\).  This is a scoped
+          single-block input, not the full recursive canonical-form theorem.
+
+    \item
           \path|MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible|
           composes the single-block source steps in
           Theorem~\texttt{Th:TIcanonical}, lines 765--770 and 816--832.  Starting

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -209,6 +209,21 @@ The earlier existence path now has the following formal pieces.
           \]
           for diagonal positive-definite \(\Lambda\).
 
+    \item
+          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible|
+          composes the single-block source steps in
+          Theorem~\texttt{Th:TIcanonical}, lines 765--770 and 816--832.  Starting
+          from one irreducible nonzero block, it constructs the
+          Perron--Frobenius unital representative
+          \(B_i=r^{-1/2}\rho^{-1/2}A_i\rho^{1/2}\), proves that the fixed
+          points of \(\mathcal{E}_B\) are scalar multiples of the identity, and
+          then applies the dual fixed-point diagonalization to a unitary
+          conjugate of \(B\).  This removes a previous composition gap for a
+          single block.  It is still not the full source theorem, because the
+          construction has not yet been threaded through the recursive
+          finite-ring block decomposition, the positive weights, and the
+          total bond-dimension bound.
+
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an


### PR DESCRIPTION
## Summary
- add a single irreducible-block PGVWC07 canonical-form data theorem
- compose the Perron-Frobenius unital gauge, scalar fixed-point endpoint, and dual fixed-point diagonalization
- update the canonical-form blueprint and PGVWC07 scope audit

## Scope
This is canonical-form existence work only. It does not prove a fundamental-theorem uniqueness/gauge statement, does not compare two canonical forms, and does not yet thread the construction through the full recursive block decomposition or the final bond-dimension bound.

## Checks
- lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
- lake env lean TNLean.lean
- git diff --check HEAD~1..HEAD
- cd blueprint && leanblueprint checkdecls (fails only on pre-existing missing declarations; the new declaration resolves)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Lean theorems composing Perron–Frobenius unital gauging, fixed-point scalarity, and dual fixed-point diagonalization for irreducible tensors; risk is mainly proof/lemma dependency churn and potential downstream breakage in the canonical-form pipeline.
> 
> **Overview**
> Implements the missing **single irreducible-block PGVWC07 canonical-form package**: constructs a Perron–Frobenius unital representative `B` for an irreducible nonzero tensor, proves fixed points of `transferMap B` are scalar, and then applies a unitary conjugation to obtain a unital tensor `C` with a diagonal positive-definite dual fixed point.
> 
> Adds the underlying unital-gauge existence theorem `MPSTensor.exists_unital_data_of_irreducible` (built via adjoint PF on the conjugate-transposed family), wires it into `TPGauge.lean` (new import for scalar fixed-point results), and updates the blueprint/scope-audit docs to reference these new formalized steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1661435a2ca1e612c4355f6abc7ab1568f132a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->