### PR TITLE
chore(MPS): trim legacy BNT imports

### DIFF
--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.BNT.Construction
+import TNLean.MPS.BNT.Basic
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.Overlap.CastDecay

--- a/TNLean/MPS/RFP/Convergence.lean
+++ b/TNLean/MPS/RFP/Convergence.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Core.Transfer
-import TNLean.MPS.BNT.Construction
+import TNLean.PiAlgebra.CanonicalFormSepAux
 import TNLean.Spectral.SpectralGap
 import TNLean.Spectral.QuantitativeGap
 import TNLean.MPS.RFP.Defs

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -5,8 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Core.Correlations
-import TNLean.MPS.BNT.Construction
-import TNLean.Spectral.SpectralGap
 
 /-!
 # Zero correlation length (ZCL) for MPS tensors


### PR DESCRIPTION
## Summary
- remove the old `MPS.BNT.Construction` import from two RFP modules that do not use BNT data
- make `PhaseClassSectorData` depend on `MPS.BNT.Basic` rather than the stronger construction layer
- keep the remaining old-BNT construction imports only where the one-copy separation predicate is still actually used

## Relation to #1685
This is a small dependency cleanup toward the CPSV16/CPSV21 paper-faithful BNT route. It reduces unnecessary dependence on the legacy one-copy BNT construction layer without changing theorem statements or proofs.

## Checks
- `lake env lean TNLean/MPS/RFP/ZeroCorrelationLength.lean`
- `lake env lean TNLean/MPS/RFP/Convergence.lean`
- `lake env lean TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean`
- `lake env lean TNLean.lean`
- `lake build TNLean.MPS.RFP.ZeroCorrelationLength TNLean.MPS.RFP.Convergence TNLean.MPS.CanonicalForm.PhaseClassSectorData`
- `git diff --check -- TNLean/MPS/RFP/ZeroCorrelationLength.lean TNLean/MPS/RFP/Convergence.lean TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/RFP/ZeroCorrelationLength.lean TNLean/MPS/RFP/Convergence.lean TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean` returned no matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency cleanup: only adjusts module imports to avoid pulling in legacy `MPS.BNT.Construction`, with no changes to theorem statements or proof logic.
> 
> **Overview**
> Removes unnecessary dependency on legacy `TNLean.MPS.BNT.Construction` across MPS modules.
> 
> `PhaseClassSectorData` now imports the lighter `TNLean.MPS.BNT.Basic`, `RFP/Convergence` switches its import to `TNLean.PiAlgebra.CanonicalFormSepAux`, and `RFP/ZeroCorrelationLength` drops unused `BNT`/spectral-gap imports to reduce coupling and compile surface area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b99f4551db97cc1429920fd72ea265ad956351e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->