### PR TITLE
doc(MPS/CanonicalForm): list PGVWC07 block data outputs

### DIFF
--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -39,6 +39,8 @@ The required density-matrix Brouwer theorem is proved in
     PosDef eigenvector for the adjoint transfer map
 * `MPSTensor.exists_tp_data_of_irreducible`:
     TP-normalized tensor from an irreducible one
+* `MPSTensor.exists_unital_data_of_irreducible`:
+    unital PGVWC07-orientation tensor from an irreducible one
 
 ## References
 

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -20,11 +20,11 @@ reduction.
 
 Its public outputs are:
 
-* `MPSTensor.exists_tp_gauge_blockwise` — blockwise Perron--Frobenius / TP-gauge
-  normalization for an irreducible block decomposition.
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` — the
   single-block PGVWC07 unital gauge, scalar fixed-point, and dual
   diagonalization package.
+* `MPSTensor.exists_tp_gauge_blockwise` — blockwise Perron--Frobenius / TP-gauge
+  normalization for an irreducible block decomposition.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
   arbitrary-input result obtained after zero-block separation.
 

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -22,6 +22,9 @@ Its public outputs are:
 
 * `MPSTensor.exists_tp_gauge_blockwise` — blockwise Perron--Frobenius / TP-gauge
   normalization for an irreducible block decomposition.
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` — the
+  single-block PGVWC07 unital gauge, scalar fixed-point, and dual
+  diagonalization package.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
   arbitrary-input result obtained after zero-block separation.
 


### PR DESCRIPTION
## Summary
- list the new PGVWC07 unital-gauge output in the Perron--Frobenius existence module overview
- list the single-block PGVWC07 unital dual-diagonal data theorem in the normal-reduction module overview

## Scope
This is a documentation-only follow-up to the merged PGVWC07 irreducible-block data work. It does not change declarations, proofs, imports, or blueprint statements.

## Checks
- lake env lean TNLean/Channel/PerronFrobenius/Existence.lean
- lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
- git diff --check HEAD~1..HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edits to module overviews with no changes to Lean declarations, proofs, or imports.
> 
> **Overview**
> Updates the top-level module documentation in `PerronFrobenius/Existence.lean` and `CanonicalForm/NormalReduction/TPGauge.lean` to include newly available PGVWC07 unital-gauge results in the listed *public outputs* (including the single-block unital/dual-diagonalization package).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ac1be09f1040f9c8c5ea7161c0b73000d890356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->