### PR TITLE
chore(MPS/BNT): split separation predicates

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -207,6 +207,7 @@ import TNLean.MPS.Core.MultiBlock
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic
+import TNLean.MPS.BNT.Separation
 import TNLean.MPS.BNT.PermutationRigidityPrimitive
 import TNLean.MPS.BNT.Construction
 import TNLean.MPS.Structure.PrimitivityBridge

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -2,6 +2,7 @@ import TNLean.PiAlgebra.CanonicalFormSep
 import TNLean.Spectral.SpectralGapRect
 import TNLean.Spectral.SpectralGapNT
 import TNLean.MPS.FundamentalTheorem.Proportional
+import TNLean.MPS.BNT.Separation
 import TNLean.MPS.BNT.Basic
 import TNLean.MPS.Overlap.CastDecay
 
@@ -57,13 +58,6 @@ open Filter
 namespace MPSTensor
 
 variable {d : ℕ}
-
-/-- Distinct equal-dimension blocks in a family are not gauge-phase equivalent. -/
-abbrev BlocksNotGaugePhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
-    (A : (k : Fin r) → MPSTensor d (dim k)) : Prop :=
-  ∀ j k : Fin r, j ≠ k →
-    ∀ h : dim j = dim k,
-      ¬ GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (A j)) (A k)
 
 /-! ### `IsNormalCanonicalFormBNT` hypotheses -/
 
@@ -412,28 +406,5 @@ lemma isBNT [∀ k, NeZero (dim k)]
     hNCF.blocks_not_equiv
 
 end IsNormalCanonicalFormBNT
-
-/-! ### Block-matching conclusion -/
-
-/-- Conclusion of the CPSV16 BNT block-matching step.
-
-Source: arXiv:1606.00608, Theorem `thm1`, statement lines 1167--1170 and proof
-line 1182.  The source proves this block-matching conclusion from
-canonical-form BNT data and proportional MPV families.  This abbreviation
-records only the conclusion, not a theorem asserting it from extra
-coefficient-array hypotheses; the copy-weight comparison and global gauge in
-lines 1184--1192 belong to the equal-MPV corollary. -/
-abbrev BlockPermutationGaugePhaseConclusion
-    {rA rB : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    (A : (j : Fin rA) → MPSTensor d (dimA j))
-    (B : (k : Fin rB) → MPSTensor d (dimB k)) : Prop :=
-  ∃ _h : rA = rB,
-    ∃ perm : Fin rA ≃ Fin rB,
-      ∀ j : Fin rA,
-        ∃ hdim : dimA j = dimB (perm j),
-          GaugePhaseEquiv (d := d)
-            (cast (congr_arg (MPSTensor d) hdim) (A j))
-            (B (perm j))
 
 end MPSTensor

--- a/TNLean/MPS/BNT/Separation.lean
+++ b/TNLean/MPS/BNT/Separation.lean
@@ -1,0 +1,52 @@
+import TNLean.MPS.SharedInfra.GaugePhase
+
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+/-!
+# BNT separation predicate
+
+This module contains the basic separation predicate for finite block families:
+distinct equal-dimension blocks are not gauge-phase equivalent.
+
+The predicate is used both by the older separated one-representative BNT
+surface and by canonical-form phase-class constructions. It is kept independent
+of the heavier BNT construction theorems so modules that only need the
+separation hypothesis do not import the whole construction layer.
+-/
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- Distinct equal-dimension blocks in a family are not gauge-phase equivalent. -/
+abbrev BlocksNotGaugePhaseEquiv {r : ℕ} {dim : Fin r → ℕ}
+    (A : (k : Fin r) → MPSTensor d (dim k)) : Prop :=
+  ∀ j k : Fin r, j ≠ k →
+    ∀ h : dim j = dim k,
+      ¬ GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (A j)) (A k)
+
+/-- Block-permutation gauge-phase matching between two block families.
+
+Source: arXiv:1606.00608, Theorem `thm1`, statement lines 1167--1170 and proof
+line 1182. The source proves this block-matching conclusion from canonical-form
+BNT data and proportional MPV families. This abbreviation records only the
+conclusion, not a theorem asserting it from extra coefficient-array hypotheses;
+the copy-weight comparison and global gauge in lines 1184--1192 belong to the
+equal-MPV corollary. -/
+abbrev BlockPermutationGaugePhaseConclusion
+    {rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    (A : (j : Fin rA) → MPSTensor d (dimA j))
+    (B : (k : Fin rB) → MPSTensor d (dimB k)) : Prop :=
+  ∃ _h : rA = rB,
+    ∃ perm : Fin rA ≃ Fin rB,
+      ∀ j : Fin rA,
+        ∃ hdim : dimA j = dimB (perm j),
+          GaugePhaseEquiv (d := d)
+            (cast (congr_arg (MPSTensor d) hdim) (A j))
+            (B (perm j))
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.BNT.Basic
+import TNLean.MPS.BNT.Construction
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.Overlap.CastDecay

--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.BNT.Construction
+import TNLean.MPS.BNT.Separation
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.MPS.SharedInfra.SectorDecomposition


### PR DESCRIPTION
## Summary
- split the lightweight BNT separation predicates into `TNLean.MPS.BNT.Separation`
- keep `BNT.Construction` focused on the separated one-representative construction theorems by importing the new predicate module
- make `CanonicalForm/PhaseCover` depend on the separation predicate module instead of the heavier construction layer
- make `PhaseClassSectorData` import `BNT.Construction` directly, since it uses construction lemmas rather than only the predicate surface

## Scope
This is a dependency cleanup toward the paper-faithful SectorBNT route in #1685. It does not change mathematical statements or proofs. The moved abbreviations record hypothesis/conclusion shapes only: distinct equal-dimension blocks not gauge-phase equivalent, and the block-permutation gauge-phase matching conclusion from CPSV16 Appendix MPV proof line 1182.

The remaining direct imports of `TNLean.MPS.BNT.Construction` are intentionally left in files that still use construction theorems or the restricted `IsNormalCanonicalFormBNT` surface.

## Checks
- lake build TNLean.MPS.BNT.Separation TNLean.MPS.BNT.Construction TNLean.MPS.CanonicalForm.PhaseCover TNLean.MPS.CanonicalForm.PhaseClassSectorData TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport
- lake env lean TNLean.lean
- lake build
- git diff --check HEAD~1..HEAD
- rg -n "\\b(sorry|axiom|native_decide|unsafeCast)\\b" TNLean/MPS/BNT/Separation.lean TNLean/MPS/BNT/Construction.lean TNLean/MPS/CanonicalForm/PhaseCover.lean TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean TNLean.lean

The Lake builds printed only pre-existing warnings outside the changed files: the long-line warning in `TNLean/Spectral/GaugeConstruction.lean` and existing periodic-overlap `sorry` warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only moves/re-exports lightweight abbreviations and adjusts imports; no proof logic or theorem statements change beyond module boundaries.
> 
> **Overview**
> Extracts the lightweight BNT separation abstractions into a new `TNLean.MPS.BNT.Separation` module, moving `BlocksNotGaugePhaseEquiv` and `BlockPermutationGaugePhaseConclusion` out of `BNT.Construction`.
> 
> Updates dependencies so `BNT.Construction` (and the root `TNLean.lean`) import the new module, while `CanonicalForm/PhaseCover` now depends only on `BNT.Separation` instead of the heavier construction layer; `PhaseClassSectorData` is adjusted to import `BNT.Construction` where construction results are still needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc103111f28ce9a32dcfe27b0cf2fc02d05b09c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->