### PR TITLE
feat(MPS/CanonicalForm): assemble PGVWC07 block data

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -24,6 +24,7 @@ The supporting modules are:
 The imported modules provide the original public declarations:
 
 * `MPSTensor.exists_tp_gauge_blockwise`
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -23,6 +23,8 @@ Its public outputs are:
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` — the
   single-block PGVWC07 unital gauge, scalar fixed-point, and dual
   diagonalization package.
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise` — the same PGVWC07
+  package applied blockwise to a prepared nonzero irreducible decomposition.
 * `MPSTensor.exists_tp_gauge_blockwise` — blockwise Perron--Frobenius / TP-gauge
   normalization for an irreducible block decomposition.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
@@ -202,6 +204,234 @@ theorem exists_pgvwc07_unital_dualDiag_data_of_irreducible
   refine ⟨B, C, r, ρ, Λ, U, hρ, hr, hB_form, ?_, hB_unital, hScalar, ?_⟩
   · simpa [c] using hGauge
   · exact ⟨rfl, hSame, hΛ_pd, hΛ_diag, hC_unital, hΛ_fix⟩
+
+private theorem scalar_fixedPoints_unitaryConj
+    {D : ℕ}
+    (A : MPSTensor d D)
+    (U : Matrix.unitaryGroup (Fin D) ℂ)
+    (hScalar :
+      ∀ X : Matrix (Fin D) (Fin D) ℂ,
+        transferMap (d := d) (D := D) A X = X →
+          ∃ c : ℂ, X = c • (1 : Matrix (Fin D) (Fin D) ℂ)) :
+    ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      transferMap (d := d) (D := D)
+          (fun i =>
+            (↑U : Matrix (Fin D) (Fin D) ℂ)ᴴ * A i *
+              (↑U : Matrix (Fin D) (Fin D) ℂ)) X = X →
+        ∃ c : ℂ, X = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+  classical
+  intro X hX
+  let V : Matrix (Fin D) (Fin D) ℂ := ↑U
+  let Y : Matrix (Fin D) (Fin D) ℂ := V * X * Vᴴ
+  have hVV : Vᴴ * V = 1 := by
+    rw [← Matrix.star_eq_conjTranspose]
+    exact Matrix.UnitaryGroup.star_mul_self U
+  have hVV' : V * Vᴴ = 1 := by
+    rw [← Matrix.star_eq_conjTranspose]
+    exact Unitary.mul_star_self_of_mem U.prop
+  have hconj :
+      transferMap (d := d) (D := D)
+          (fun i =>
+            (↑U : Matrix (Fin D) (Fin D) ℂ)ᴴ * A i *
+              (↑U : Matrix (Fin D) (Fin D) ℂ)) X =
+        Vᴴ * transferMap (d := d) (D := D) A Y * V := by
+    simpa [V, Y] using transferMap_unitaryConj (d := d) (D := D) A U X
+  have hmiddle :
+      Vᴴ * transferMap (d := d) (D := D) A Y * V = X := by
+    calc
+      Vᴴ * transferMap (d := d) (D := D) A Y * V
+          = transferMap (d := d) (D := D)
+              (fun i =>
+                (↑U : Matrix (Fin D) (Fin D) ℂ)ᴴ * A i *
+                  (↑U : Matrix (Fin D) (Fin D) ℂ)) X := hconj.symm
+      _ = X := hX
+  have hYfix : transferMap (d := d) (D := D) A Y = Y := by
+    calc
+      transferMap (d := d) (D := D) A Y
+          = (V * Vᴴ) * transferMap (d := d) (D := D) A Y * (V * Vᴴ) := by
+              simp [hVV']
+      _ = V * (Vᴴ * transferMap (d := d) (D := D) A Y * V) * Vᴴ := by
+              simp [Matrix.mul_assoc]
+      _ = V * X * Vᴴ := by rw [hmiddle]
+      _ = Y := rfl
+  obtain ⟨c, hc⟩ := hScalar Y hYfix
+  refine ⟨c, ?_⟩
+  calc
+    X = (Vᴴ * V) * X * (Vᴴ * V) := by simp [hVV]
+    _ = Vᴴ * Y * V := by simp [Y, Matrix.mul_assoc]
+    _ = Vᴴ * (c • (1 : Matrix (Fin D) (Fin D) ℂ)) * V := by rw [hc]
+    _ = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+          simp [hVV]
+
+/-- **Blockwise PGVWC07 unital and dual-diagonal package.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+lines 765--770 and 816--832, after the recursive invariant-subspace splitting
+has already produced a nonzero irreducible block family.  The theorem applies
+`exists_pgvwc07_unital_dualDiag_data_of_irreducible` to every block, records
+the positive spectral-radius weights, and preserves the finite-ring MPV family
+through the weighted direct sum.
+
+This is still a prepared-block statement.  It does not start from an arbitrary
+translation-invariant representation, does not separate all-zero blocks, and
+does not prove the total bond-dimension bound of the full source theorem. -/
+theorem exists_pgvwc07_unital_dualDiag_blockwise
+    (A : MPSTensor d D)
+    {r0 : ℕ} {dim0 : Fin r0 → ℕ}
+    (blocks0 : (k : Fin r0) → MPSTensor d (dim0 k))
+    (hIrr0 : ∀ k, IsIrreducibleTensor (blocks0 k))
+    (hSame0 :
+      SameMPV₂ A
+        (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0))
+    (hNonzero0 : ∀ k, ∃ i, blocks0 k i ≠ 0) :
+    ∃ r1 : ℕ,
+      ∃ dim1 : Fin r1 → ℕ,
+      ∃ μ1 : Fin r1 → ℂ,
+      ∃ blocks1 : (k : Fin r1) → MPSTensor d (dim1 k),
+        SameMPV₂ A
+          (toTensorFromBlocks (d := d) (μ := μ1) blocks1) ∧
+        (∀ k,
+          ∃ Λ : Matrix (Fin (dim1 k)) (Fin (dim1 k)) ℂ,
+            Λ.PosDef ∧
+            Λ.IsDiag ∧
+            (∑ i : Fin d, blocks1 k i * (blocks1 k i)ᴴ = 1) ∧
+            transferMap (d := d) (D := dim1 k) (fun i => (blocks1 k i)ᴴ) Λ = Λ) ∧
+        (∀ k,
+          ∀ X : Matrix (Fin (dim1 k)) (Fin (dim1 k)) ℂ,
+            transferMap (d := d) (D := dim1 k) (blocks1 k) X = X →
+              ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim1 k)) (Fin (dim1 k)) ℂ)) ∧
+        (∀ k, ∃ a : ℝ, 0 < a ∧ μ1 k = (a : ℂ)) ∧
+        (∀ k, μ1 k ≠ 0) ∧
+        (∀ k, 0 < dim1 k) := by
+  classical
+  have hdim0_ne : ∀ k : Fin r0, dim0 k ≠ 0 := by
+    intro k hk0
+    rcases hNonzero0 k with ⟨i, hi⟩
+    have hzero : blocks0 k i = 0 := by
+      ext a b
+      exfalso
+      have ha : (a : ℕ) < 0 := by
+        simpa [hk0] using a.2
+      omega
+    exact hi hzero
+  have hcanon :
+      ∀ k : Fin r0,
+        ∃ (B C : MPSTensor d (dim0 k))
+          (r : ℝ)
+          (ρ Λ : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ)
+          (U : Matrix.unitaryGroup (Fin (dim0 k)) ℂ),
+            ρ.PosDef ∧
+            0 < r ∧
+            (∀ i : Fin d,
+              B i =
+                (↑((Real.sqrt r)⁻¹) : ℂ) •
+                  ((CFC.sqrt ρ)⁻¹ * blocks0 k i * CFC.sqrt ρ)) ∧
+            GaugeEquiv (d := d) (D := dim0 k)
+              (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • blocks0 k i) B ∧
+            (∑ i : Fin d, B i * (B i)ᴴ = 1) ∧
+            (∀ X : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ,
+              transferMap (d := d) (D := dim0 k) B X = X →
+                ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ)) ∧
+            (let C' : MPSTensor d (dim0 k) :=
+              fun i =>
+                (↑U : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ)ᴴ * B i *
+                  (↑U : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ);
+              C = C' ∧
+              SameMPV₂ B C ∧
+              Λ.PosDef ∧
+              Λ.IsDiag ∧
+              (∑ i : Fin d, C i * (C i)ᴴ = 1) ∧
+              transferMap (d := d) (D := dim0 k) (fun i => (C i)ᴴ) Λ = Λ) := by
+    intro k
+    letI : NeZero (dim0 k) := ⟨hdim0_ne k⟩
+    exact exists_pgvwc07_unital_dualDiag_data_of_irreducible
+      (A := blocks0 k) (hIrr := hIrr0 k) (hA := hNonzero0 k)
+  choose blocksB blocks1 r1 ρ1 Λ1 U1 hρpd1 hrpos1 hform1 hGauge1 hUnitalB1
+    hScalarB1 hFinal1 using hcanon
+  let μ1 : Fin r0 → ℂ := fun k => (↑(Real.sqrt (r1 k)) : ℂ)
+  have hSameBlocks :
+      SameMPV₂
+        (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0)
+        (toTensorFromBlocks (d := d) (μ := μ1) blocks1) := by
+    intro N σ
+    calc
+      mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0) σ
+          = ∑ k : Fin r0, (1 : ℂ) ^ N * mpv (blocks0 k) σ := by
+              simpa [smul_eq_mul] using
+                (mpv_toTensorFromBlocks_eq_sum
+                  (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) (A := blocks0) (σ := σ))
+      _ = ∑ k : Fin r0, (μ1 k) ^ N * mpv (blocks1 k) σ := by
+            refine Finset.sum_congr rfl ?_
+            intro k _
+            let c : ℂ := (↑((Real.sqrt (r1 k))⁻¹) : ℂ)
+            have hGaugeSame : SameMPV (fun i => c • blocks0 k i) (blocksB k) :=
+              GaugeEquiv.sameMPV (hGauge1 k)
+            have hSameBC : SameMPV₂ (blocksB k) (blocks1 k) := (hFinal1 k).2.1
+            have hscale : mpv (blocks1 k) σ = c ^ N * mpv (blocks0 k) σ := by
+              calc
+                mpv (blocks1 k) σ = mpv (blocksB k) σ := (hSameBC N σ).symm
+                _ = mpv (fun i => c • blocks0 k i) σ := (hGaugeSame N σ).symm
+                _ = c ^ N * mpv (blocks0 k) σ := mpv_smul c (blocks0 k) σ
+            have hroot_ne : (↑(Real.sqrt (r1 k)) : ℂ) ≠ 0 := by
+              exact_mod_cast (Real.sqrt_ne_zero'.mpr (hrpos1 k))
+            have hμc : μ1 k * c = 1 := by
+              dsimp [μ1, c]
+              simp [hroot_ne]
+            have hmulpow : (μ1 k) ^ N * c ^ N = 1 := by
+              rw [← mul_pow, hμc, one_pow]
+            have hmulpow_apply :
+                (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ) = mpv (blocks0 k) σ := by
+              calc
+                (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ)
+                    = ((μ1 k) ^ N * c ^ N) * mpv (blocks0 k) σ := by ring
+                _ = mpv (blocks0 k) σ := by simp [hmulpow]
+            calc
+              (1 : ℂ) ^ N * mpv (blocks0 k) σ = mpv (blocks0 k) σ := by simp
+              _ = (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ) := hmulpow_apply.symm
+              _ = (μ1 k) ^ N * mpv (blocks1 k) σ := by rw [hscale]
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ1) blocks1) σ := by
+            symm
+            simpa [smul_eq_mul] using
+              (mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μ1) (A := blocks1) (σ := σ))
+  have hSame1 :
+      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ1) blocks1) := by
+    intro N σ
+    calc
+      mpv A σ
+          = mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0) σ :=
+              hSame0 N σ
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ1) blocks1) σ := hSameBlocks N σ
+  have hΛData :
+      ∀ k : Fin r0,
+        ∃ Λ : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks1 k i * (blocks1 k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim0 k) (fun i => (blocks1 k i)ᴴ) Λ = Λ := by
+    intro k
+    exact ⟨Λ1 k, (hFinal1 k).2.2.1, (hFinal1 k).2.2.2.1,
+      (hFinal1 k).2.2.2.2.1, (hFinal1 k).2.2.2.2.2⟩
+  have hScalarC :
+      ∀ k : Fin r0,
+        ∀ X : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ,
+          transferMap (d := d) (D := dim0 k) (blocks1 k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ) := by
+    intro k
+    have hCeq := (hFinal1 k).1
+    rw [hCeq]
+    exact scalar_fixedPoints_unitaryConj (d := d) (D := dim0 k)
+      (blocksB k) (U1 k) (hScalarB1 k)
+  have hμpos1 : ∀ k : Fin r0, ∃ a : ℝ, 0 < a ∧ μ1 k = (a : ℂ) := by
+    intro k
+    exact ⟨Real.sqrt (r1 k), Real.sqrt_pos.2 (hrpos1 k), rfl⟩
+  have hμne1 : ∀ k : Fin r0, μ1 k ≠ 0 := by
+    intro k
+    dsimp [μ1]
+    exact_mod_cast (Real.sqrt_ne_zero'.mpr (hrpos1 k))
+  have hDim1 : ∀ k : Fin r0, 0 < dim0 k := by
+    intro k
+    exact Nat.pos_of_ne_zero (hdim0_ne k)
+  exact ⟨r0, dim0, μ1, blocks1, hSame1, hΛData, hScalarC, hμpos1, hμne1, hDim1⟩
 
 /-- Blockwise Perron--Frobenius / TP-gauge stage for an irreducible block decomposition.
 

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -138,11 +138,7 @@ theorem isIrreducibleTensor_of_isIrreducibleMap
 
 section CFII
 
-/-- The transfer map of a unitary-conjugated tensor equals the
-conjugation of the original transfer map.
-
-For `B i = U† A i U`, we have `E_B(X) = U† E_A(U X U†) U`. -/
-theorem transferMap_unitaryConj
+private theorem transferMap_unitaryConj_of_decidable [DecidableEq (Fin D)]
     (A : MPSTensor d D) (U : Matrix.unitaryGroup (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     transferMap (d := d) (D := D)
@@ -165,8 +161,23 @@ theorem transferMap_unitaryConj
   -- Both sides equal Vᴴ * (A i * (V * (X * (Vᴴ * ((A i)ᴴ * V))))) after right-association
   repeat rw [Matrix.mul_assoc]
 
+/-- The transfer map of a unitary-conjugated tensor equals the
+conjugation of the original transfer map.
+
+For `B i = U† A i U`, we have `E_B(X) = U† E_A(U X U†) U`. -/
+theorem transferMap_unitaryConj
+    (A : MPSTensor d D) (U : Matrix.unitaryGroup (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    transferMap (d := d) (D := D)
+      (fun i => (↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ)) X =
+    (↑U : Matrix _ _ ℂ)ᴴ *
+      (transferMap (d := d) (D := D) A
+        ((↑U : Matrix _ _ ℂ) * X * (↑U : Matrix _ _ ℂ)ᴴ)) *
+    (↑U : Matrix _ _ ℂ) := by
+  exact transferMap_unitaryConj_of_decidable A U X
+
 /-- The TP condition is preserved by unitary conjugation. -/
-private lemma tp_of_unitaryConj
+private lemma tp_of_unitaryConj [DecidableEq (Fin D)]
     (A : MPSTensor d D) (U : Matrix.unitaryGroup (Fin D) ℂ)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     ∑ i : Fin d, ((↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ))ᴴ *
@@ -205,6 +216,7 @@ unitary `U` and a diagonal positive-definite matrix `Λ` such that:
 This is the key step in reducing to "Canonical Form II" from
 Cirac et al. arXiv:1606.00608 Appendix A. -/
 theorem exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor
+    [DecidableEq (Fin D)]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hIrr : IsIrreducibleTensor (d := d) (D := D) A)
@@ -261,7 +273,7 @@ theorem exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor
   -- Step 9: Λ is a fixed point of the conjugated transfer map.
   have hΛ_fix : transferMap (d := d) (D := D)
       (fun i => Umatᴴ * A i * Umat) Λ = Λ := by
-    rw [transferMap_unitaryConj A U_raw Λ, ← h_spectral, hρ_fix, ← hΛ_eq]
+    rw [transferMap_unitaryConj_of_decidable A U_raw Λ, ← h_spectral, hρ_fix, ← hΛ_eq]
   -- Step 10: Assemble
   -- The goal uses `star U` whereas our lemmas use `Uᴴ`; these are definitionally equal.
   refine ⟨U_raw, Λ, hΛ_pd, hΛ_diag, ?_, ?_⟩

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -142,7 +142,7 @@ section CFII
 conjugation of the original transfer map.
 
 For `B i = U† A i U`, we have `E_B(X) = U† E_A(U X U†) U`. -/
-theorem transferMap_unitaryConj [DecidableEq (Fin D)]
+theorem transferMap_unitaryConj
     (A : MPSTensor d D) (U : Matrix.unitaryGroup (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     transferMap (d := d) (D := D)
@@ -166,7 +166,7 @@ theorem transferMap_unitaryConj [DecidableEq (Fin D)]
   repeat rw [Matrix.mul_assoc]
 
 /-- The TP condition is preserved by unitary conjugation. -/
-private lemma tp_of_unitaryConj [DecidableEq (Fin D)]
+private lemma tp_of_unitaryConj
     (A : MPSTensor d D) (U : Matrix.unitaryGroup (Fin D) ℂ)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     ∑ i : Fin d, ((↑U : Matrix _ _ ℂ)ᴴ * A i * (↑U : Matrix _ _ ℂ))ᴴ *
@@ -205,7 +205,6 @@ unitary `U` and a diagonal positive-definite matrix `Λ` such that:
 This is the key step in reducing to "Canonical Form II" from
 Cirac et al. arXiv:1606.00608 Appendix A. -/
 theorem exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor
-    [DecidableEq (Fin D)]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hIrr : IsIrreducibleTensor (d := d) (D := D) A)

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -142,7 +142,7 @@ section CFII
 conjugation of the original transfer map.
 
 For `B i = U† A i U`, we have `E_B(X) = U† E_A(U X U†) U`. -/
-private lemma transferMap_unitaryConj [DecidableEq (Fin D)]
+theorem transferMap_unitaryConj [DecidableEq (Fin D)]
     (A : MPSTensor d D) (U : Matrix.unitaryGroup (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     transferMap (d := d) (D := D)

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -186,7 +186,7 @@ theorem rfp_nt_structural_of_leftCanonical [DecidableEq (Fin D)] [NeZero D]
 /-- Appendix B / CFII reduction step:
 after unitary conjugation, a left-canonical normal RFP tensor has a diagonal
 positive-definite fixed point for its transfer map. -/
-theorem rfp_nt_cfii_diagonal_fixedPoint [DecidableEq (Fin D)] [NeZero D]
+theorem rfp_nt_cfii_diagonal_fixedPoint [NeZero D]
     (A : MPSTensor d D)
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -839,6 +839,44 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     diagonalization of the dual fixed point.
 \end{proof}
 
+\begin{theorem}[Blockwise PGVWC07 unital and dual-diagonal data]%
+    \label{thm:pgvwc07_blockwise_unital_dual_package}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise}
+    \leanok
+    \uses{def:irreducible_tensor,
+        thm:pgvwc07_irreducible_unital_dual_package}
+    Let a tensor~$A$ be represented, in finite-ring MPV coefficients, by a
+    finite direct sum of nonzero irreducible blocks with unit weights.  Then
+    there is a weighted direct sum with the same MPV family such that every
+    block is in the unital orientation,
+    \[
+        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
+    \]
+    every fixed point of the block transfer map is a scalar multiple of the
+    identity, and each block has a diagonal positive definite dual fixed point
+    \[
+        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
+    \]
+    The weights are the positive spectral-radius weights produced by applying
+    the single-block Perron--Frobenius gauge to each summand.
+
+    This is a blockwise assembly of
+    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
+        {PerezGarcia2007Matrix} after the recursive splitting has already
+    produced the nonzero irreducible summands.  It is not yet the full source
+    theorem, because it does not start from an arbitrary representation and
+    does not prove the final total bond-dimension bound.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_irreducible_unital_dual_package}
+    Apply Theorem~\ref{thm:pgvwc07_irreducible_unital_dual_package} to each
+    nonzero irreducible block.  Gauge equivalence and the final unitary
+    conjugation preserve the block MPV coefficients up to the displayed
+    spectral-radius weights, and unitary conjugation transports the scalar
+    fixed-point property of the unital transfer map.
+\end{proof}
+
 \begin{theorem}[Irreducible block decomposition with left-canonical normalization]%
     \label{thm:irreducible_block_decomp_with_cfii}
     \lean{MPSTensor.exists_irreducible_blockDecomp_with_CFII}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -236,6 +236,20 @@ The earlier existence path now has the following formal pieces.
           finite-ring block decomposition, the positive weights, and the
           total bond-dimension bound.
 
+    \item
+          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise|
+          applies the preceding single-block package to a prepared family of
+          nonzero irreducible summands with unit weights.  It constructs the
+          positive spectral-radius weights, unital block representatives,
+          scalar fixed-point endpoints, and diagonal positive-definite dual
+          fixed points block by block, while preserving the weighted MPV
+          family.  This closes the blockwise assembly step after the
+          irreducible summands have already been obtained.  It is still not
+          the full source theorem, because the statement assumes the prepared
+          nonzero irreducible decomposition and does not yet incorporate the
+          arbitrary-input zero-block separation or the final total
+          bond-dimension bound.
+
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an


### PR DESCRIPTION
## Summary

This PR advances the PGVWC07 canonical-form existence path, not the fundamental-theorem uniqueness path.

It adds a blockwise assembly theorem for a prepared family of nonzero irreducible summands:

- exposes `MPSTensor.transferMap_unitaryConj`, previously a private helper, so scalar fixed-point uniqueness can be transported through the final unitary conjugation;
- keeps a private local-instance variant of the transfer-map conjugation lemma for older proofs written under an explicit `DecidableEq (Fin D)` context, while keeping the public theorem free of that redundant binder;
- adds `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise`, applying the existing single-block package to every nonzero irreducible block;
- records positive spectral-radius weights, unital block orientation, scalar fixed-point endpoints, diagonal positive-definite dual fixed points, and weighted MPV preservation;
- removes a redundant `DecidableEq (Fin D)` binder from the downstream RFP CFII wrapper theorem;
- updates the Chapter 8 blueprint and PGVWC07 paper-gap audit to mark this as a prepared-block step, not the full `Th:TIcanonical` theorem.

Refs #1857.

## Source and scope

The construction formalizes the blockwise assembly part of Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof lines 765--770 and 816--832, after the recursive invariant-subspace splitting has already produced nonzero irreducible summands.

This does not prove the full source theorem. It assumes the nonzero irreducible block family has already been obtained; the remaining source-level assembly still has to thread arbitrary-input zero-block separation and the total bond-dimension bound through the final statement. These limitations are recorded in `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.

## Checks

- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean`
- `lake env lean TNLean/MPS/Irreducible/FormII.lean`
- `lake env lean TNLean/MPS/RFP/StructuralForm.lean`
- `rg -n "\b(sorry|axiom|native_decide|unsafeCast)\b" TNLean/MPS/CanonicalForm/NormalReduction.lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/Irreducible/FormII.lean TNLean/MPS/RFP/StructuralForm.lean`
- `git diff --check main..HEAD -- TNLean/MPS/CanonicalForm/NormalReduction.lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/Irreducible/FormII.lean TNLean/MPS/RFP/StructuralForm.lean blueprint/src/chapter/ch08_canonical.tex docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`
- `lake exe lint_style --github`
- `lake build` passed; it reported only pre-existing warnings outside this PR, including `TNLean/Spectral/GaugeConstruction.lean` long-line warning and existing `sorry` warnings in periodic-overlap files.
- `cd blueprint && leanblueprint web` passed locally, with the usual plasTeX package and macro warnings.
- `cd blueprint && leanblueprint checkdecls` still fails on pre-existing missing PEPS and parent-Hamiltonian declarations; the new `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise` declaration is not among the missing names.