### PR TITLE
feat(MPS/CanonicalForm): thread PGVWC07 zero-tail package

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -25,6 +25,7 @@ The imported modules provide the original public declarations:
 
 * `MPSTensor.exists_tp_gauge_blockwise`
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise`
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -22,11 +22,13 @@ Its public outputs are:
 
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` — the
   single-block PGVWC07 unital gauge, scalar fixed-point, and dual
-  diagonalization package.
+  diagonalization theorem.
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise` — the same PGVWC07
-  package applied blockwise to a prepared nonzero irreducible decomposition.
+  construction applied blockwise to a prepared nonzero irreducible decomposition.
 * `MPSTensor.exists_tp_gauge_blockwise` — blockwise Perron--Frobenius / TP-gauge
   normalization for an irreducible block decomposition.
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` —
+  the arbitrary-input version with the all-zero summands kept as a zero block.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
   arbitrary-input result obtained after zero-block separation.
 
@@ -263,7 +265,7 @@ private theorem scalar_fixedPoints_unitaryConj
     _ = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
           simp [hVV]
 
-/-- **Blockwise PGVWC07 unital and dual-diagonal package.**
+/-- **Blockwise PGVWC07 unital and dual-diagonal theorem.**
 
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
 lines 765--770 and 816--832, after the recursive invariant-subspace splitting
@@ -576,24 +578,88 @@ theorem exists_tp_gauge_blockwise
   exact ⟨r0, dim0, μ1, blocks1, hSame1, hIrr1, hLeft1, hμne1, hDim1⟩
 
 /-!
-## Zero-block separation and trace-preserving gauge threading
+## Zero-block separation and blockwise gauge threading
 
 This section composes the zero-block separation from `Existence.lean` with the
-blockwise Perron–Frobenius / TP-gauge theorem `exists_tp_gauge_blockwise`, producing an
-arbitrary-input result: from any `A : MPSTensor d D`, we obtain:
+blockwise Perron--Frobenius gauge theorems above, producing arbitrary-input
+results: from any `A : MPSTensor d D`, we obtain:
 
 * a zero-block dimension `zeroTailDim` (accumulating all-zero irreducible blocks --
   the Lean formalization uses "zero tail" as a bookkeeping name; the source paper says
   "there can be zero blocks"), and
-* a TP-gauged family of irreducible blocks with nonzero weights.
+* a weighted family of nonzero blocks in either the PGVWC07 unital orientation
+  with dual-diagonal fixed points or the older TP-gauge orientation.
 
 The MPV relationship accounts exactly for both contributions:
 
   `mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ + mpv (toTensorFromBlocks μ blocks) σ`
 
-This is the furthest unconditional arbitrary-input step available before periodicity removal and
-the cyclic-sector and equal-weight arguments.
+The PGVWC07 unital statement below is the strongest unconditional arbitrary-input
+step available here before the final total bond-dimension bound is threaded
+through the construction.
 -/
+
+/-- **Arbitrary-input PGVWC07 unital dual-diagonal form with zero blocks.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+lines 765--770 and 816--832, after the recursive invariant-subspace splitting
+and all-zero-block separation have been carried out.  From any tensor `A`, the
+theorem separates a zero-block contribution and applies
+`exists_pgvwc07_unital_dualDiag_blockwise` to the remaining nonzero irreducible
+blocks.
+
+Every nonzero output block is in the source's unital orientation
+`∑ i, C i * (C i)ᴴ = 1`, has only scalar fixed points for its transfer map, and
+has a diagonal positive-definite fixed point for the adjoint transfer map.  The
+weights are positive real spectral-radius weights, and the MPV family of `A`
+is the sum of the zero-block contribution and the weighted nonzero-block
+direct sum.
+
+**Scope restriction:** This is still not the full `Th:TIcanonical` statement:
+the zero block is kept explicitly, and the final total bond-dimension bound is
+not included.  The boundary is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
+theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail
+    (A : MPSTensor d D) :
+    ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
+      (μ : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      (∀ k,
+        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
+      (∀ k,
+        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          transferMap (d := d) (D := dim k) (blocks k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ μ k = (a : ℂ)) ∧
+      (∀ k, μ k ≠ 0) ∧
+      (∀ k, 0 < dim k) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ +
+          mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ) := by
+  classical
+  obtain ⟨zeroTailDim, r₀, dim₀, blocks₀, hIrr₀, hNonzero₀, _hDim₀, hMPV₀⟩ :=
+    exists_irreducible_blockDecomp_nonzeroBlocks (d := d) (D := D) A
+  let A_nonzero := toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀
+  have hSame_refl : SameMPV₂ A_nonzero
+      (toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀) :=
+    fun _ _ => rfl
+  obtain ⟨r₁, dim₁, μ₁, blocks₁, hSame₁, hΛData₁, hScalar₁, hμPos₁, hμNe₁,
+    hDim₁⟩ :=
+    exists_pgvwc07_unital_dualDiag_blockwise A_nonzero blocks₀ hIrr₀ hSame_refl
+      hNonzero₀
+  refine ⟨zeroTailDim, r₁, dim₁, μ₁, blocks₁, hΛData₁, hScalar₁, hμPos₁, hμNe₁,
+    hDim₁, ?_⟩
+  intro N σ
+  calc
+    mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ + mpv A_nonzero σ := hMPV₀ N σ
+    _ = mpv (zeroMPSTensor d zeroTailDim) σ +
+          mpv (toTensorFromBlocks (d := d) (μ := μ₁) blocks₁) σ := by
+        congr 1
+        exact hSame₁ N σ
 
 /-- **Arbitrary-input trace-preserving gauge reduction.**
 
@@ -619,12 +685,11 @@ The MPV of `A` equals the zero-block contribution plus the weighted nonzero-bloc
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
 lines 765--770 use a full-rank positive fixed point to gauge a block into the
 unital orientation `∑ i, B i * (B i)ᴴ = 1`. This theorem supplies the dual
-left-canonical trace-preserving orientation after the all-zero-block
-separation. It is therefore not the full translation-invariant canonical form
-theorem of Pérez-García, Verstraete, Wolf, and Cirac: it does not also prove the
-source theorem's unital orientation, diagonal full-rank dual fixed points,
-uniqueness of the identity fixed point, or total bond-dimension bound. The
-boundary is recorded in
+left-canonical trace-preserving orientation after the all-zero-block separation.
+The PGVWC07 unital-orientation analogue is
+`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` above.  This
+theorem remains useful as a TP-gauge reduction but is not the source-facing
+canonical-form statement.  The boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
     ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -824,7 +824,7 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
         {PerezGarcia2007Matrix}.  It is not yet the full theorem, because the
     recursive finite-ring block decomposition and the final bond-dimension
-    bound have not been threaded through this package.
+    bound have not been threaded through this construction.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -875,6 +875,48 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     conjugation preserve the block MPV coefficients up to the displayed
     spectral-radius weights, and unitary conjugation transports the scalar
     fixed-point property of the unital transfer map.
+\end{proof}
+
+\begin{theorem}[Arbitrary-input PGVWC07 unital dual-diagonal form with zero block]%
+    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail}
+    \leanok
+    \uses{thm:zero_block_separation,
+        thm:pgvwc07_blockwise_unital_dual_package}
+    Let \(A\) be an arbitrary translation-invariant MPS tensor.  Then there is
+    a zero block of bond dimension \(D_0\), a finite family of nonzero blocks
+    \(C_k\), and positive real weights \(\mu_k\), such that for every chain
+    length \(N\) and every word \(\sigma \in \{0,\ldots,d-1\}^N\),
+    \[
+        \operatorname{MPV}_A
+        =
+        \operatorname{MPV}_{0_{D_0}}
+        +
+        \operatorname{MPV}_{\oplus_k \mu_k C_k}.
+    \]
+    Each nonzero block is in the unital orientation,
+    \[
+        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
+    \]
+    every fixed point of its transfer map is a scalar multiple of the identity,
+    and it has a diagonal positive definite dual fixed point
+    \[
+        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
+    \]
+\end{theorem}
+
+% This theorem composes the zero-block separation with the blockwise PGVWC07
+% theorem.  The final total bond-dimension bound is still recorded as a
+% remaining step in the paper-gap audit.
+
+\begin{proof}\leanok
+    \uses{thm:zero_block_separation,
+        thm:pgvwc07_blockwise_unital_dual_package}
+    First apply the zero-block separation theorem to \(A\), retaining the
+    all-zero summands as a single zero block and extracting the nonzero
+    irreducible summands.  Then apply the blockwise PGVWC07 unital and
+    dual-diagonal theorem to this nonzero family.  Chaining the two MPV
+    identities gives the displayed zero-block formula.
 \end{proof}
 
 \begin{theorem}[Irreducible block decomposition with left-canonical normalization]%

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -238,7 +238,7 @@ The earlier existence path now has the following formal pieces.
 
     \item
           \path|MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise|
-          applies the preceding single-block package to a prepared family of
+          applies the preceding single-block theorem to a prepared family of
           nonzero irreducible summands with unit weights.  It constructs the
           positive spectral-radius weights, unital block representatives,
           scalar fixed-point endpoints, and diagonal positive-definite dual
@@ -249,6 +249,19 @@ The earlier existence path now has the following formal pieces.
           nonzero irreducible decomposition and does not yet incorporate the
           arbitrary-input zero-block separation or the final total
           bond-dimension bound.
+
+    \item
+          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail|
+          composes the zero-block separation with the preceding blockwise
+          PGVWC07 theorem.  Starting from an arbitrary tensor, it retains the
+          all-zero summands as one zero block and puts the nonzero part into
+          the unital orientation, with positive spectral-radius weights,
+          scalar fixed-point endpoints, and diagonal positive-definite dual
+          fixed points.  This removes the prepared-family hypothesis from the
+          blockwise statement while still keeping the zero-block contribution
+          explicit in the finite-ring MPV identity.  It is still not the full
+          source theorem, because the final total bond-dimension bound has not
+          yet been promoted to a separate conclusion.
 
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of


### PR DESCRIPTION
## Summary

This PR continues the PGVWC07 canonical-form existence path from #1857.

It adds `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`, which composes the existing all-zero-block separation with the blockwise PGVWC07 unital/dual-diagonal package merged in #1941.

The new theorem starts from an arbitrary tensor and produces:

- an explicit zero-block dimension retaining all-zero summands;
- a weighted family of nonzero blocks with positive real weights;
- PGVWC07 unital block normalization `sum_i C_i C_i^† = 1`;
- scalar fixed-point uniqueness for each block transfer map;
- a diagonal positive-definite fixed point for each dual transfer map;
- the finite-ring MPV identity as zero-block contribution plus weighted nonzero part.

Refs #1857.

## Source and scope

This formalizes the next assembly step in Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof lines 765--832, after the recursive splitting and zero-block separation have been performed.

This is still not the full source theorem: the zero block is kept explicitly and the final total bond-dimension bound is not yet promoted to a separate conclusion. The boundary is recorded in `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.

## Checks

- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction`
- `lake exe lint_style --github`
- `git diff --check -- TNLean/MPS/CanonicalForm/NormalReduction.lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean blueprint/src/chapter/ch08_canonical.tex docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`
- `rg -n "\\b(sorry|axiom|native_decide|unsafeCast)\\b" TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls` still fails on pre-existing missing PEPS and parent-Hamiltonian declarations; the new declaration is not among the missing names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new top-level existence theorem by composing nontrivial Lean proofs across block decomposition and PGVWC07 normalization; risk is mainly proof/lemma brittleness and downstream compile impact rather than runtime behavior.
> 
> **Overview**
> Adds `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`, which composes zero-block separation with the existing blockwise PGVWC07 unital/dual-diagonal package to give an **arbitrary-input** statement: MPV of any tensor splits into an explicit zero block plus a weighted direct sum of nonzero blocks in unital gauge with scalar fixed points and diagonal PD dual fixed points.
> 
> Updates the public `NormalReduction` import-path docs, the blueprint (chapter 8) with a corresponding theorem/proof, and the paper-gap scope audit to reflect the new composition step and clarify remaining missing conclusions (notably the total bond-dimension bound).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a52a5230d0a45820a05379bda3f9caab2f64c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->