### PR TITLE
feat(canonical): record PGVWC07 zero-tail dimension bound

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -26,6 +26,7 @@ The imported modules provide the original public declarations:
 * `MPSTensor.exists_tp_gauge_blockwise`
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise`
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -29,6 +29,8 @@ Its public outputs are:
   normalization for an irreducible block decomposition.
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` —
   the arbitrary-input version with the all-zero summands kept as a zero block.
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` —
+  the preceding theorem together with the length-zero bond-dimension identity.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
   arbitrary-input result obtained after zero-block separation.
 
@@ -660,6 +662,62 @@ theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail
           mpv (toTensorFromBlocks (d := d) (μ := μ₁) blocks₁) σ := by
         congr 1
         exact hSame₁ N σ
+
+/-- **Bond-dimension identity for the arbitrary-input PGVWC07 zero-block form.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, lines
+761--762, after the zero-block contribution has been retained explicitly.
+The length-zero coefficient of the MPV identity gives
+$D_0 + \sum_k D_k = D$; therefore the total bond dimension of the nonzero
+blocks is at most the original bond dimension.
+
+**Scope restriction:** This theorem still keeps the zero block as an explicit
+summand.  Removing the explicit zero-block summand from the existential
+conclusion is the remaining statement-level step, recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
+theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound
+    (A : MPSTensor d D) :
+    ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
+      (μ : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      (∀ k,
+        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
+      (∀ k,
+        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          transferMap (d := d) (D := dim k) (blocks k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ μ k = (a : ℂ)) ∧
+      (∀ k, μ k ≠ 0) ∧
+      (∀ k, 0 < dim k) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ +
+          mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ) ∧
+      zeroTailDim + ∑ k : Fin r, dim k = D ∧
+      ∑ k : Fin r, dim k ≤ D := by
+  classical
+  obtain ⟨zeroTailDim, r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, hMPV⟩ :=
+    exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail (d := d) (D := D) A
+  let σ0 : Fin 0 → Fin d := Fin.elim0
+  have hZero :
+      (D : ℂ) = (zeroTailDim + ∑ k : Fin r, dim k : ℕ) := by
+    calc
+      (D : ℂ) = mpv A σ0 := (mpv_zero_length A σ0).symm
+      _ = mpv (zeroMPSTensor d zeroTailDim) σ0 +
+            mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ0 := hMPV 0 σ0
+      _ = (zeroTailDim : ℂ) + (∑ k : Fin r, dim k : ℂ) := by
+            simp
+      _ = (zeroTailDim + ∑ k : Fin r, dim k : ℕ) := by
+            simp
+  have hBond : zeroTailDim + ∑ k : Fin r, dim k = D := by
+    exact_mod_cast hZero.symm
+  have hBound : ∑ k : Fin r, dim k ≤ D := by
+    omega
+  exact ⟨zeroTailDim, r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, hMPV,
+    hBond, hBound⟩
 
 /-- **Arbitrary-input trace-preserving gauge reduction.**
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -919,6 +919,31 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     identities gives the displayed zero-block formula.
 \end{proof}
 
+\begin{theorem}[Bond-dimension bound for the zero-block PGVWC07 form]%
+    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound}
+    \leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+    In the decomposition of
+    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}, the
+    zero-block bond dimension and the nonzero block dimensions satisfy
+    \[
+        D_0+\sum_k D_k = D .
+    \]
+    In particular, the total bond dimension of the nonzero blocks is at most
+    the original bond dimension \(D\).
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+    Evaluate the MPV identity of
+    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package} on the
+    empty word.  The length-zero coefficient of a bond-\(D\) tensor is \(D\);
+    the zero block contributes \(D_0\), and the direct sum of the nonzero
+    blocks contributes \(\sum_k D_k\).  This gives the displayed identity, and
+    the inequality follows because \(D_0\geq 0\).
+\end{proof}
+
 \begin{theorem}[Irreducible block decomposition with left-canonical normalization]%
     \label{thm:irreducible_block_decomp_with_cfii}
     \lean{MPSTensor.exists_irreducible_blockDecomp_with_CFII}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -263,6 +263,16 @@ The earlier existence path now has the following formal pieces.
           source theorem, because the final total bond-dimension bound has not
           yet been promoted to a separate conclusion.
 
+    \item
+          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound|
+          adds the length-zero trace calculation to the preceding arbitrary
+          tensor theorem.  It proves
+          \(D_0+\sum_k D_k=D\), where \(D_0\) is the retained zero-block bond
+          dimension and the \(D_k\) are the nonzero block dimensions.  Hence
+          \(\sum_k D_k\leq D\), matching the total bond-dimension estimate in
+          Theorem~\texttt{Th:TIcanonical}, lines 761--762, while still keeping
+          the zero block explicit.
+
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an


### PR DESCRIPTION
## Summary
- add the arbitrary-input PGVWC07 zero-block theorem with the length-zero bond-dimension identity
- prove that the retained zero-block dimension plus the nonzero block dimensions equals the original bond dimension
- record the corresponding blueprint theorem and paper-gap progress note

## Mathematical scope
This PR continues the PGVWC07 translation-invariant canonical-form existence route. It does not formalize the Fundamental Theorem of MPS. The new theorem starts from the existing arbitrary-input zero-block form and evaluates the MPV identity on the empty word, giving `D₀ + ∑ k, D_k = D` and hence `∑ k, D_k ≤ D`.

The zero block is still kept explicitly; removing that explicit summand from the final displayed source theorem remains recorded in `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.

## Checks
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction`
- `lake exe lint_style --github`
- `git diff --check TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/CanonicalForm/NormalReduction.lean blueprint/src/chapter/ch08_canonical.tex docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls` fails only on pre-existing PEPS and parent-Hamiltonian declarations; the new canonical-form theorem is not missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new derived theorem and documentation updates without altering existing normalization/gauge constructions or interfaces beyond exposing an additional statement.
> 
> **Overview**
> Adds a new public theorem `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` that extends the existing arbitrary-input PGVWC07 zero-block decomposition by extracting the length-zero MPV coefficient to prove `zeroTailDim + ∑ k, dim k = D` and hence `∑ k, dim k ≤ D`.
> 
> Updates the historical import wrapper `NormalReduction.lean`, the blueprint chapter, and the paper-gap audit note to reference and explain this new bond-dimension conclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e3229c99818852975b5893b15a197742985171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->