### PR TITLE
feat(canonical): remove PGVWC07 zero block at positive length

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -27,6 +27,7 @@ The imported modules provide the original public declarations:
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise`
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -31,6 +31,8 @@ Its public outputs are:
   the arbitrary-input version with the all-zero summands kept as a zero block.
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` —
   the preceding theorem together with the length-zero bond-dimension identity.
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` —
+  the positive-length version with the explicit zero-block summand removed.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
   arbitrary-input result obtained after zero-block separation.
 
@@ -665,7 +667,7 @@ theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail
 
 /-- **Bond-dimension identity for the arbitrary-input PGVWC07 zero-block form.**
 
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, lines
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
 761--762, after the zero-block contribution has been retained explicitly.
 The length-zero coefficient of the MPV identity gives
 $D_0 + \sum_k D_k = D$; therefore the total bond dimension of the nonzero
@@ -718,6 +720,54 @@ theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound
     omega
   exact ⟨zeroTailDim, r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, hMPV,
     hBond, hBound⟩
+
+/-- **Positive-length PGVWC07 unital dual-diagonal form.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
+761--762 and 816--832.  This is the zero-block theorem above after omitting the
+explicit zero summand from the displayed MPV identity.  The omission is valid for
+nonempty rings because the all-zero summand has zero MPV coefficient in positive
+length.
+
+The theorem keeps the mathematically relevant bond-dimension estimate
+\(\sum_k D_k\leq D\).  It deliberately states MPV equality only for positive
+lengths; at length zero the omitted zero block would contribute its bond
+dimension. -/
+theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
+    (A : MPSTensor d D) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ)
+      (μ : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      (∀ k,
+        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
+      (∀ k,
+        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          transferMap (d := d) (D := dim k) (blocks k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ μ k = (a : ℂ)) ∧
+      (∀ k, μ k ≠ 0) ∧
+      (∀ k, 0 < dim k) ∧
+      SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      ∑ k : Fin r, dim k ≤ D := by
+  classical
+  obtain ⟨zeroTailDim, r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, hMPV,
+    _hBond, hBound⟩ :=
+    exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound
+      (d := d) (D := D) A
+  refine ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, ?_, hBound⟩
+  intro N hN σ
+  calc
+    mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := hMPV N σ
+    _ = 0 + mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+        rw [mpv_zeroMPSTensor]
+        simp [Nat.ne_of_gt hN]
+    _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+        simp
 
 /-- **Arbitrary-input trace-preserving gauge reduction.**
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -944,6 +944,41 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     the inequality follows because \(D_0\geq 0\).
 \end{proof}
 
+\begin{theorem}[Positive-length PGVWC07 unital dual-diagonal form]%
+    \label{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound}
+    \leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+    For any MPS tensor \(A\) of bond dimension \(D\), there are nonzero blocks
+    \(C_k\) and positive real weights \(\mu_k\) such that each block is in the
+    unital orientation,
+    \[
+        \sum_i C_k^i(C_k^i)^\dagger=\Id,
+    \]
+    has only scalar fixed points for its transfer map, and has a diagonal
+    positive-definite fixed point for the dual transfer map,
+    \[
+        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
+    \]
+    Moreover, for
+    every chain length \(N>0\) and word
+    \(\sigma\in\{0,\ldots,d-1\}^N\),
+    \[
+        \operatorname{MPV}_A(\sigma)
+        =
+        \operatorname{MPV}_{\bigoplus_k \mu_k C_k}(\sigma),
+    \]
+    and the nonzero block dimensions satisfy \(\sum_k D_k\leq D\).
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+    Apply Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}.
+    The all-zero summand contributes zero to every positive-length coefficient,
+    so it may be omitted from the displayed MPV identity for \(N>0\).  The
+    bound \(\sum_k D_k\leq D\) is one of the conclusions of that theorem.
+\end{proof}
+
 \begin{theorem}[Irreducible block decomposition with left-canonical normalization]%
     \label{thm:irreducible_block_decomp_with_cfii}
     \lean{MPSTensor.exists_irreducible_blockDecomp_with_CFII}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -260,8 +260,8 @@ The earlier existence path now has the following formal pieces.
           fixed points.  This removes the prepared-family hypothesis from the
           blockwise statement while still keeping the zero-block contribution
           explicit in the finite-ring MPV identity.  It is still not the full
-          source theorem, because the final total bond-dimension bound has not
-          yet been promoted to a separate conclusion.
+          source theorem; this theorem itself does not include the final
+          total bond-dimension bound.
 
     \item
           \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound|
@@ -272,6 +272,17 @@ The earlier existence path now has the following formal pieces.
           \(\sum_k D_k\leq D\), matching the total bond-dimension estimate in
           Theorem~\texttt{Th:TIcanonical}, lines 761--762, while still keeping
           the zero block explicit.
+
+    \item
+          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound|
+          removes the explicit zero-block summand from the displayed MPV
+          identity by restricting the equality to positive chain lengths.
+          The zero block has no positive-length coefficients, so the nonzero
+          weighted direct sum has the same positive-length MPV family as the
+          original tensor, and the estimate \(\sum_k D_k\leq D\) is retained.
+          This matches the source theorem on nonempty rings.  A statement that
+          also quantifies over the empty word must either keep the zero block or
+          separately account for its bond dimension.
 
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of


### PR DESCRIPTION
## Summary
- add the positive-length PGVWC07 unital dual-diagonal existence theorem
- omit the explicit zero-block summand from the MPV equality for nonempty rings
- record the theorem in the wrapper module, blueprint, and PGVWC07 paper-gap note

## Mathematical scope
This continues only the PGVWC07 translation-invariant canonical-form existence path. It does not formalize or invoke the Fundamental Theorem of MPS.

The new theorem starts from the zero-block theorem with the bond-dimension identity. Since the all-zero summand has zero MPV coefficient for every positive chain length, the positive-length MPV family is represented by the weighted nonzero blocks alone. The theorem keeps the PGVWC07 unital orientation, scalar fixed-point conclusion, diagonal positive definite dual fixed point, positive weights, positive block dimensions, and the bound `∑ k, D_k ≤ D`.

The length-zero coefficient is still accounted for by the preceding zero-block theorem, because the empty word detects the omitted zero-block bond dimension.

## Checks
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction`
- `lake exe lint_style --github`
- `git diff --check TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/CanonicalForm/NormalReduction.lean blueprint/src/chapter/ch08_canonical.tex docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls 2>&1 | rg "exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound|pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound"` returned no missing declaration for the new theorem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new theorem/proof and documentation updates without changing existing APIs or logic, aside from extending the public surface with an additional result.
> 
> **Overview**
> Adds `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`, a positive-length variant of the arbitrary-input PGVWC07 unital dual-diagonal form that **drops the explicit zero-block summand** in the MPV identity by restricting to `N>0`, while retaining the bound `∑ k, dim k ≤ D`.
> 
> Updates the wrapper module `NormalReduction.lean`, the blueprint (chapter 8), and the PGVWC07 scope/gap note to reference and explain the new positive-length statement, and includes a small docstring wording tweak for the source theorem citation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e4d9a1770b9f214a4e2c42c0a672ac84ba8077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->