### PR TITLE
doc(canonical): align PGVWC07 blueprint dependencies

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -935,7 +935,8 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package,
+        lem:mpv_zero_length}
     Evaluate the MPV identity of
     Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package} on the
     empty word.  The length-zero coefficient of a bond-\(D\) tensor is \(D\);

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -437,7 +437,7 @@ definitions stated below.
 
 \begin{proof}
     \leanok
-    \uses{thm:two_block_decomp, thm:pf_eigenvector_existence}
+    \uses{thm:two_block_decomp}
     By strong induction on the bond dimension~$D$.
     If $A$ is already irreducible, take $r = 1$.
     Otherwise, by Definition~\ref{def:irreducible_tensor},
@@ -450,21 +450,10 @@ definitions stated below.
     Iterating this splitting produces a block-diagonal tensor
     $\bigoplus_k A_k$ whose blocks are irreducible.
     Apply the induction hypothesis to each block and concatenate.
-    (If one prefers a positive-eigenvector argument without assuming TP
-    normalization, the correct replacement for the channel-specific
-    Ces\`aro theorem is Theorem~\ref{thm:pf_eigenvector_existence};
-    the induction itself needs only the invariant projection.)
 
     Both~\cite[Theorem~4]{PerezGarcia2007Matrix} and~\cite[Section~IV.A.1]{Cirac2021Matrix}
     obtain the block decomposition by
     the same invariant-projection splitting used here.
-    An alternative derivation, developed
-    in~\cite[Theorem~6.14]{Wolf2012Quantum},
-    characterises the fixed-point set of a quantum channel
-    as a $*$-algebra and then applies the
-    Wedderburn--Artin decomposition
-    (\cite[Equation~(1.39)]{Wolf2012Quantum})
-    to read off the block structure directly.
     The block decomposition is obtained by iterating
     the invariant-projection splitting and using strong
     induction on~$D$ to ensure termination.


### PR DESCRIPTION
## Summary
- add `lem:mpv_zero_length` to the blueprint proof dependencies for the zero-block PGVWC07 bond-dimension theorem
- remove a stale `thm:pf_eigenvector_existence` dependency after the proof prose no longer uses the positive-eigenvector alternative route
- keep the blueprint prose focused on the invariant-projection splitting route used for the PGVWC07 decomposition

## Scope
This resolves #1944 and also addresses the review finding about the adjacent stale `\uses` entry. There are no Lean changes.

Mathematically, the zero-block bond-dimension proof uses the length-zero MPV coefficient lemma: evaluating any bond-`D` tensor on the empty word gives `D`. The irreducible-decomposition proof uses the two-block invariant-projection decomposition, not the Perron-Frobenius eigenvector theorem, so its dependency list now records only that route.

## Checks
- `git diff --check blueprint/src/chapter/ch08_canonical.tex`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adjusts blueprint dependency annotations (`\uses`) and removes stale explanatory prose, without touching Lean code or mathematical statements.
> 
> **Overview**
> Tightens blueprint proof dependency tracking in `ch08_canonical.tex`.
> 
> Updates the `Irreducible block decomposition` proof to depend only on `thm:two_block_decomp` (dropping the unused `thm:pf_eigenvector_existence` route and related alternative-derivation prose), and amends the zero-block PGVWC07 bond-dimension bound proof to explicitly include `lem:mpv_zero_length` since the argument evaluates the MPV identity on the empty word.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b31b976a671c45b75928c8936d6616b8ba8aa54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->