### PR TITLE
doc(bnt): correct projected substitution source line

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1166,8 +1166,9 @@ The non-matched decay clause is delivered in full.
     \begin{itemize}
         \item For $k \in J_1'(Q)$, substitute via the gauge identity
               $V^{(N)}(Q_k)_\sigma = \zeta_k^N \cdot V^{(N)}(P_{\varphi(k)})_\sigma$
-              of \cite[line~1186]{Cirac2017MPDO_AnnPhys}; the unit-modulus
-              closure $\lVert\zeta_k\rVert = 1$ follows from the
+              supplied by the matched-sector step of
+              \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys};
+              the unit-modulus closure $\lVert\zeta_k\rVert = 1$ follows from the
               norm-from-overlap lemma and the convergence of both per-block
               normalized self-overlaps to $1$. If $\varphi(k) = j_0$, the
               diagonal self-overlap contributes


### PR DESCRIPTION
## Summary

- correct the Chapter 10 projected-substitution proof prose so the per-pair gauge identity is cited to the matched-sector step in the Appendix MPV proof, line 1182
- keep Appendix MPV lines 1187--1188 reserved for the coefficient comparison step

## Scope

Blueprint prose only. No Lean declarations or theorem statements changed.

## Validation

- git diff --check blueprint/src/chapter/ch10_bnt.tex
- cd blueprint && leanblueprint web

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small documentation/prose-only change that updates a citation in the Chapter 10 proof, with no code or theorem changes.
> 
> **Overview**
> Updates the Chapter 10 BNT projected-substitution proof prose to cite the per-pair gauge identity as coming from the matched-sector step in \\cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}, rather than the later coefficient-comparison lines.
> 
> This keeps the subsequent Appendix MPV proof line references reserved for the coefficient comparison step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88e5fa12d31d672254e3bae0433b8c36964cd5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->