### PR TITLE
doc(overlap): cite CPSV block selection line precisely

### DIFF
--- a/TNLean/MPS/Overlap/Basic.lean
+++ b/TNLean/MPS/Overlap/Basic.lean
@@ -108,7 +108,7 @@ lemma mpvOverlap_eq_sum_of_decomp_left
 state vectors.
 
 This algebraic identity is used in the proof of arXiv:1606.00608,
-Theorem II.1, lines 1182--1186, to lift the BNT decomposition to a
+Theorem II.1, Appendix MPV proof line 1182, to lift the BNT decomposition to a
 state-vector identity before taking inner products with individual blocks. -/
 lemma mpvState_eq_sum_of_decomp
     {d g Dtot : ℕ} {dim : Fin g → ℕ}
@@ -130,8 +130,8 @@ lemma mpvState_eq_sum_of_decomp
 decomposition.
 
 This algebraic identity is used in the proof of arXiv:1606.00608,
-Theorem II.1, lines 1182--1186, when projecting the full proportionality
-relation onto one block MPV. -/
+Theorem II.1, Appendix MPV proof line 1182, when projecting the full
+proportionality relation onto one block MPV. -/
 lemma mpvInner_eq_sum_of_decomp_right
     {d g D Dtot : ℕ} {dim : Fin g → ℕ}
     (A_total : MPSTensor d Dtot)
@@ -153,7 +153,8 @@ decomposition.
 
 This is the conjugate-linear companion of
 `mpvInner_eq_sum_of_decomp_right`, used for the symmetric projection in the
-block-matching argument of arXiv:1606.00608, Theorem II.1, lines 1182--1186. -/
+block-matching argument of arXiv:1606.00608, Theorem II.1, Appendix MPV proof
+line 1182. -/
 lemma mpvInner_eq_sum_of_decomp_left
     {d g D Dtot : ℕ} {dim : Fin g → ℕ}
     (A_total : MPSTensor d Dtot)

--- a/TNLean/MPS/Overlap/SelfOverlapAux.lean
+++ b/TNLean/MPS/Overlap/SelfOverlapAux.lean
@@ -35,7 +35,7 @@ lemma tendsto_norm_selfOverlap_one
 
 /-- MPV-state norm-convergence form of normalized self-overlap convergence.
 
-Source: arXiv:1606.00608, Theorem `thm1`, lines 1182--1186. In the
+Source: arXiv:1606.00608, Theorem `thm1`, Appendix MPV proof line 1182. In the
 block-selection contradiction, normalized BNT blocks have self-overlap tending
 to one; this lemma rewrites that normalization as convergence of the Hilbert
 space norm of the corresponding MPV state. -/

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -15,8 +15,8 @@
 
 \section{Source passage}
 
-This note concerns the proof of CPSV16 Theorem~\texttt{thm1}, lines
-1181--1185 of \cite{Cirac2016MPDO_arXiv}. The paper fixes a block
+This note concerns the proof of CPSV16 Theorem~\texttt{thm1},
+Appendix MPV proof line~1182 of \cite{Cirac2016MPDO_arXiv}. The paper fixes a block
 $k_0\in\{1,\ldots,r_B\}$ and writes
 \begin{align}
     \forall j, 
@@ -50,7 +50,7 @@ decay, the family
 \end{align}
 for all sufficiently large $N$. Equivalently, the displayed family is linearly
 independent, so the selected block cannot be absorbed by the others without
-contradiction. \cite[lines~1181--1185]{Cirac2016MPDO_arXiv}
+contradiction. \cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}
 
 \section{Formal boundary}
 
@@ -85,7 +85,7 @@ The exact fixed-block contradiction step is still open:
 No current Lean declaration carries the retired fixed-right or fixed-left
 one-copy fixed-block names.  The mathematical target remains the
 CPSV fixed-block cancellation at
-\cite[lines~1181--1185]{Cirac2016MPDO_arXiv}, now to be stated on the
+\cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}, now to be stated on the
 \leanid{SectorBNT} sector surface.
 
 The earlier conditional helpers requiring combined-family linear independence
@@ -93,7 +93,7 @@ The earlier conditional helpers requiring combined-family linear independence
 the 2026-05-13 audit; see
 \path{audits/2026-05-13_cpsv16_ft_paper_vs_code_structural_map.md}.
 Those helpers should not be used as replacements for the fixed-block sentence at
-lines~1181--1185, because the needed combined-family independence is not
+Appendix MPV proof line~1182, because the needed combined-family independence is not
 supplied by Corollary~\texttt{Lem1}.  The remaining open obligation is the
 fixed-block cancellation itself, to be discharged without combined-family LI or
 residual-span exclusion.


### PR DESCRIPTION
## Summary

- replace remaining Overlap docstring references to CPSV16 lines 1182--1186 with the precise Appendix MPV proof line 1182 locator
- update the fixed-block cancellation paper-gap note from the broad 1181--1185 range to the same line-1182 source passage
- keep the later equal-MPV power-sum display at line 1186 separate from the block-selection/cancellation sentence

## Scope

Documentation and Lean comments only. No declarations or proofs changed.

## Validation

- git diff --check TNLean/MPS/Overlap/Basic.lean TNLean/MPS/Overlap/SelfOverlapAux.lean docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
- lake env lean TNLean/MPS/Overlap/Basic.lean
- lake env lean TNLean/MPS/Overlap/SelfOverlapAux.lean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to comment/doc citation wording in Lean files and a LaTeX note, with no proof or declaration logic modified.
> 
> **Overview**
> **Documentation-only update.** Refines remaining CPSV16 (arXiv:1606.00608) references in `Overlap/Basic.lean` and `Overlap/SelfOverlapAux.lean` from a broad line range to the specific *Appendix MPV proof line 1182* citation.
> 
> Also updates the `cpsv16_fixed_block_cancellation.tex` paper-gap note to cite the same precise source passage (including adjusting the in-text `\cite[...]` locators), keeping the block-selection/cancellation sentence distinct from later displayed equations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 932f13b3097aeb484c1d993b71c7e957ef416e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->