### PR TITLE
feat(canonical): package PGVWC07 positive-length data

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -28,6 +28,7 @@ The imported modules provide the original public declarations:
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`
+* `MPSTensor.exists_pgvwc07_positiveLengthWitness`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -33,6 +33,8 @@ Its public outputs are:
   the preceding theorem together with the length-zero bond-dimension identity.
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` —
   the positive-length version with the explicit zero-block summand removed.
+* `MPSTensor.exists_pgvwc07_positiveLengthWitness` — the same positive-length
+  theorem recorded as a single structured witness.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
   arbitrary-input result obtained after zero-block separation.
 
@@ -44,6 +46,61 @@ this the ``zero block'' case).
 namespace MPSTensor
 
 variable {d D : ℕ}
+
+/-- Witness for the exact positive-length form of the PGVWC07
+translation-invariant canonical-form construction.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
+lines 742--763, for nonempty rings and exact MPV equality.  The fields record
+the weighted nonzero-block direct sum, the unital block condition, the
+diagonal positive-definite dual fixed point, the scalar fixed-point conclusion,
+positive weights, positive block dimensions, and the total bond-dimension
+bound.
+
+**Scope restriction:** The source theorem also writes the weights with
+`1 ≥ λ_j > 0`, after the proof says that the spectral radius is normalized
+without loss of generality at lines 765--766.  That global normalization is not
+part of this exact positive-length witness; extending the witness by
+the upper-bound normalization is the remaining source-facing statement step.
+The boundary is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
+structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
+  /-- Number of nonzero canonical blocks. -/
+  r : ℕ
+  /-- Bond dimension of each nonzero canonical block. -/
+  dim : Fin r → ℕ
+  /-- Positive block weights. -/
+  weights : Fin r → ℂ
+  /-- Nonzero canonical blocks in the unital orientation. -/
+  blocks : (k : Fin r) → MPSTensor d (dim k)
+  /-- Each block has a diagonal positive-definite fixed point for the adjoint
+  transfer map and satisfies the unital condition. -/
+  dual_fixed :
+    ∀ k,
+      ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+        Λ.PosDef ∧
+        Λ.IsDiag ∧
+        (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+        transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ
+  /-- The fixed points of each block transfer map are exactly the scalar
+  multiples of the identity. -/
+  scalar_fixed :
+    ∀ k,
+      ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+        transferMap (d := d) (D := dim k) (blocks k) X = X →
+          ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+  /-- Every block weight is a positive real number, embedded into `ℂ`. -/
+  weight_pos : ∀ k, ∃ a : ℝ, 0 < a ∧ weights k = (a : ℂ)
+  /-- Every block weight is nonzero. -/
+  weight_ne_zero : ∀ k, weights k ≠ 0
+  /-- Every nonzero block has positive bond dimension. -/
+  dim_pos : ∀ k, 0 < dim k
+  /-- On nonempty rings, the original tensor and the weighted block tensor have
+  the same MPV coefficients. -/
+  sameMPV_pos : SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := weights) blocks)
+  /-- The total bond dimension of the nonzero canonical blocks is at most the
+  original bond dimension. -/
+  bondDim_le : ∑ k : Fin r, dim k ≤ D
 
 private noncomputable def gaugeMulVecLinearEquiv {D : ℕ} (X : GL (Fin D) ℂ) :
     (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) where
@@ -129,7 +186,7 @@ private theorem isIrreducibleTensor_tpGauge_of_isIrreducibleTensor
 
 /-- **Single irreducible-block PGVWC07 canonical-form data.**
 
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof
 lines 765--770 and 816--832.  For one irreducible nonzero block, the
 Perron--Frobenius eigenvector gives the source theorem's unital gauge.  In
 that unital gauge every fixed point is scalar, and a final unitary conjugation
@@ -271,7 +328,7 @@ private theorem scalar_fixedPoints_unitaryConj
 
 /-- **Blockwise PGVWC07 unital and dual-diagonal theorem.**
 
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof
 lines 765--770 and 816--832, after the recursive invariant-subspace splitting
 has already produced a nonzero irreducible block family.  The theorem applies
 `exists_pgvwc07_unital_dualDiag_data_of_irreducible` to every block, records
@@ -605,7 +662,7 @@ through the construction.
 
 /-- **Arbitrary-input PGVWC07 unital dual-diagonal form with zero blocks.**
 
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof
 lines 765--770 and 816--832, after the recursive invariant-subspace splitting
 and all-zero-block separation have been carried out.  From any tensor `A`, the
 theorem separates a zero-block contribution and applies
@@ -619,7 +676,7 @@ weights are positive real spectral-radius weights, and the MPV family of `A`
 is the sum of the zero-block contribution and the weighted nonzero-block
 direct sum.
 
-**Scope restriction:** This is still not the full `Th:TIcanonical` statement:
+**Scope restriction:** This is still not the full Th:TIcanonical statement:
 the zero block is kept explicitly, and the final total bond-dimension bound is
 not included.  The boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
@@ -768,6 +825,39 @@ theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
         simp [Nat.ne_of_gt hN]
     _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
         simp
+
+/-- **Structured positive-length PGVWC07 canonical-form witness.**
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
+lines 742--763, after omitting the explicit zero block from positive-length
+MPV coefficients.  This theorem is the corresponding structured form of
+`exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`.
+
+**Scope restriction:** The source theorem's normalization `1 ≥ λ_j > 0` is not
+included here.  The theorem records positive real weights and exact
+positive-length MPV equality; the remaining source-facing step is to formalize
+the global spectral-radius normalization convention from lines 765--766.
+The boundary is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
+theorem exists_pgvwc07_positiveLengthWitness
+    (A : MPSTensor d D) :
+    Nonempty (PGVWC07PositiveLengthWitness (d := d) (D := D) A) := by
+  classical
+  obtain ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, hSame, hBound⟩ :=
+    exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
+      (d := d) (D := D) A
+  exact ⟨
+    { r := r
+      dim := dim
+      weights := μ
+      blocks := blocks
+      dual_fixed := hΛ
+      scalar_fixed := hScalar
+      weight_pos := hμPos
+      weight_ne_zero := hμNe
+      dim_pos := hDim
+      sameMPV_pos := hSame
+      bondDim_le := hBound }⟩
 
 /-- **Arbitrary-input trace-preserving gauge reduction.**
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -969,6 +969,42 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     bound \(\sum_k D_k\leq D\) is one of the conclusions of that theorem.
 \end{proof}
 
+\begin{definition}[Positive-length PGVWC07 canonical-form witness]%
+    \label{def:pgvwc07_positive_length_witness}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness}
+    \leanok
+    A positive-length PGVWC07 canonical-form witness for an MPS tensor \(A\)
+    consists of a finite family of nonzero unital blocks, positive real
+    weights, diagonal positive-definite dual fixed points, scalar fixed-point
+    conclusions, positive block dimensions, positive-length MPV equality with
+    \(A\), and the total bond-dimension bound \(\sum_k D_k\leq D\).
+
+    This definition records the exact-MPV, nonempty-ring part of the PGVWC07
+    construction.  It still does not include the source theorem's upper
+    normalization \(1\geq\lambda_k\), which depends on the global
+    spectral-radius normalization convention of
+    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
+\end{definition}
+
+\begin{theorem}[Existence of the positive-length PGVWC07 witness]%
+    \label{thm:pgvwc07_positive_length_witness}
+    \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    For every MPS tensor \(A\), the conclusions of
+    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    give a positive-length PGVWC07 canonical-form witness.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    Unpack
+    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    and use its conclusions as the fields of the witness.
+\end{proof}
+
 \begin{theorem}[Irreducible block decomposition with left-canonical normalization]%
     \label{thm:irreducible_block_decomp_with_cfii}
     \lean{MPSTensor.exists_irreducible_blockDecomp_with_CFII}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -284,6 +284,18 @@ The earlier existence path now has the following formal pieces.
           also quantifies over the empty word must either keep the zero block or
           separately account for its bond dimension.
 
+    \item
+          \path|MPSTensor.PGVWC07PositiveLengthWitness| and
+          \path|MPSTensor.exists_pgvwc07_positiveLengthWitness| record the
+          preceding positive-length theorem as a single package of data.  The
+          fields contain the nonzero unital blocks, positive real weights,
+          diagonal positive-definite dual fixed points, scalar fixed-point
+          conclusions, positive block dimensions, positive-length MPV equality,
+          and the total bond-dimension bound.  This is not a new proof route;
+          it is an equivalent formulation of the proved positive-length
+          theorem, intended to prevent later arguments from repeating the long
+          existential conclusion.
+
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an
@@ -321,6 +333,12 @@ Thus no current \verb|\leanok| statement in the canonical-form
 chapter should be read as the full PGVWC07 translation-invariant canonical-form
 theorem. The blueprint now records the source theorem as a separate not-ready
 statement, and the checked reductions are marked as partial or scoped results.
+After the positive-length witness theorem, the remaining source-level
+normalization gap is the paper's convention \(1\geq \lambda_j>0\): the exact
+MPV statement has positive real weights, but it does not yet formalize the
+``without loss of generality'' spectral-radius normalization from
+Theorem~\texttt{Th:TIcanonical}, lines 765--766, as a transformation compatible
+with the chosen notion of equality of finite-ring coefficients.
 
 \section{Formal boundary}
 
@@ -354,6 +372,13 @@ non-scalar fixed point; and, finally, the dual-map fixed point and unitary
 diagonalization.  None of these steps may be replaced by a theorem that starts
 from an already prepared primitive or trace-preserving block family, because
 those hypotheses are not present in Theorem~\texttt{Th:TIcanonical}.
+
+At the current frontier, the block construction and nonempty-ring exact-MPV
+witness are available.  The remaining formal work is to state and prove the
+global normalization convention that turns the positive real weights into
+weights satisfying \(1\geq \lambda_j>0\), or to make explicit the precise
+state-equivalence relation under which the paper's spectral-radius
+renormalization is ``without loss of generality''.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- add `MPSTensor.PGVWC07PositiveLengthWitness`, a structured witness for the checked positive-length PGVWC07 canonical-form conclusions
- prove `MPSTensor.exists_pgvwc07_positiveLengthWitness` by reusing the existing positive-length theorem, without introducing a second proof route
- record in the blueprint and paper-gap note that the remaining source-level gap is the paper's weight normalization `1 ≥ λ_j > 0` from the spectral-radius convention in PGVWC07 lines 765--766

## Scope

This continues the PGVWC07 canonical-form existence path only. It does not formalize the Fundamental Theorem or the PGVWC07 uniqueness theorem.

The full source theorem remains not-ready because the exact positive-length MPV statement currently gives positive real weights, but not yet the source's upper normalization `1 ≥ λ_j`.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction`
- `lake exe lint_style --github`
- `git diff --check TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/CanonicalForm/NormalReduction.lean blueprint/src/chapter/ch08_canonical.tex docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`
- `cd blueprint && leanblueprint web`

`cd blueprint && leanblueprint checkdecls` still fails on pre-existing not-ready PEPS and parent-Hamiltonian declarations; it does not report the new PGVWC07 witness declarations as missing.

Progress on #1857.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this mainly packages an existing proven positive-length PGVWC07 result into a new structured witness and updates documentation, without altering underlying canonical-form proofs.
> 
> **Overview**
> Adds `MPSTensor.PGVWC07PositiveLengthWitness`, a new structure that packages the positive-length PGVWC07 canonical-form outputs (nonzero unital blocks, positive weights, dual fixed points, scalar fixed-point property, MPV equality for `N>0`, and bond-dimension bound).
> 
> Introduces `MPSTensor.exists_pgvwc07_positiveLengthWitness`, which constructs that witness by reusing the existing `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` theorem, and exposes it via the historical `NormalReduction` import path.
> 
> Updates the blueprint and paper-gap note to document the new witness and to explicitly track the remaining source-level gap: the paper’s global weight normalization `1 ≥ λ_j > 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723beaf4447e6915378d47c82dd8b968587fe3a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->