### PR TITLE
refactor(canonical): derive PGVWC07 witness weight nonzero

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -91,8 +91,6 @@ structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
           ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
   /-- Every block weight is a positive real number, embedded into `ℂ`. -/
   weight_pos : ∀ k, ∃ a : ℝ, 0 < a ∧ weights k = (a : ℂ)
-  /-- Every block weight is nonzero. -/
-  weight_ne_zero : ∀ k, weights k ≠ 0
   /-- Every nonzero block has positive bond dimension. -/
   dim_pos : ∀ k, 0 < dim k
   /-- On nonempty rings, the original tensor and the weighted block tensor have
@@ -101,6 +99,20 @@ structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
   /-- The total bond dimension of the nonzero canonical blocks is at most the
   original bond dimension. -/
   bondDim_le : ∑ k : Fin r, dim k ≤ D
+
+/-- Positive PGVWC07 witness weights are nonzero.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
+751--752, writes the canonical-form weights as positive real numbers.  In the
+positive-length witness, nonvanishing is therefore a consequence of the
+positive-real weight field. -/
+theorem PGVWC07PositiveLengthWitness.weight_ne_zero
+    {A : MPSTensor d D} (W : PGVWC07PositiveLengthWitness (d := d) (D := D) A) :
+    ∀ k, W.weights k ≠ 0 := by
+  intro k
+  obtain ⟨a, ha_pos, hweight⟩ := W.weight_pos k
+  rw [hweight]
+  exact_mod_cast (ne_of_gt ha_pos)
 
 private noncomputable def gaugeMulVecLinearEquiv {D : ℕ} (X : GL (Fin D) ℂ) :
     (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) where
@@ -843,7 +855,7 @@ theorem exists_pgvwc07_positiveLengthWitness
     (A : MPSTensor d D) :
     Nonempty (PGVWC07PositiveLengthWitness (d := d) (D := D) A) := by
   classical
-  obtain ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, hSame, hBound⟩ :=
+  obtain ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, _, hDim, hSame, hBound⟩ :=
     exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
       (d := d) (D := D) A
   exact ⟨
@@ -854,7 +866,6 @@ theorem exists_pgvwc07_positiveLengthWitness
       dual_fixed := hΛ
       scalar_fixed := hScalar
       weight_pos := hμPos
-      weight_ne_zero := hμNe
       dim_pos := hDim
       sameMPV_pos := hSame
       bondDim_le := hBound }⟩

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -986,6 +986,20 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
 \end{definition}
 
+\begin{lemma}[Positive PGVWC07 witness weights are nonzero]%
+    \label{lem:pgvwc07_positive_length_witness_weight_ne_zero}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness}
+    In a positive-length PGVWC07 canonical-form witness, every block weight is
+    nonzero.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:pgvwc07_positive_length_witness}
+    Each weight is the complex embedding of a strictly positive real number.
+\end{proof}
+
 \begin{theorem}[Existence of the positive-length PGVWC07 witness]%
     \label{thm:pgvwc07_positive_length_witness}
     \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -291,10 +291,13 @@ The earlier existence path now has the following formal pieces.
           fields contain the nonzero unital blocks, positive real weights,
           diagonal positive-definite dual fixed points, scalar fixed-point
           conclusions, positive block dimensions, positive-length MPV equality,
-          and the total bond-dimension bound.  This is not a new proof route;
-          it is an equivalent formulation of the proved positive-length
-          theorem, intended to prevent later arguments from repeating the long
-          existential conclusion.
+          and the total bond-dimension bound.  The companion theorem
+          \path|MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero| derives
+          nonvanishing of the weights from their positive-real form, so that
+          nonvanishing is not an additional field of the witness.  This is not
+          a new proof route; it is an equivalent formulation of the proved
+          positive-length theorem, intended to prevent later arguments from
+          repeating the long existential conclusion.
 
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of


### PR DESCRIPTION
Progress on #1857.

This keeps the positive-length PGVWC07 witness closer to the mathematical data: the structure now stores positive real weights only, and `MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero` derives nonvanishing from positivity. The theorem keeps the same dot-name that consumers would naturally use, but avoids making nonvanishing a separate field.

Changes:
- remove the redundant `weight_ne_zero` field from `PGVWC07PositiveLengthWitness`;
- add the derived theorem `MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero`;
- add the corresponding Chapter 8 blueprint lemma;
- update the PGVWC07 scope note to record that nonvanishing is derived from the positive-real weight condition.

Validation:
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction`
- `lake exe lint_style --github`
- `git diff --check -- TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean blueprint/src/chapter/ch08_canonical.tex docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls` reports only pre-existing not-ready PEPS and parent-Hamiltonian declarations; the new PGVWC07 lemma is present in `blueprint/lean_decls`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in the Lean canonical-form witness: removes a redundant data field and replaces it with a derived lemma, with corresponding minor proof and documentation updates.
> 
> **Overview**
> Refactors `PGVWC07PositiveLengthWitness` to **stop storing `weight_ne_zero` as a field** and instead derive nonvanishing from the existing `weight_pos` assumption.
> 
> Adds lemma `MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero` proving `weights k ≠ 0`, updates `exists_pgvwc07_positiveLengthWitness` to ignore the previously-extracted nonzero-weight proof, and updates the blueprint and scope-note docs to reflect the new derived lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a42ece32e82d4c6f3a14e14aec7425ca8412eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->