### PR TITLE
refactor(canonical): omit redundant PGVWC07 nonzero conjunct

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -818,16 +818,15 @@ theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
           transferMap (d := d) (D := dim k) (blocks k) X = X →
             ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
       (∀ k, ∃ a : ℝ, 0 < a ∧ μ k = (a : ℂ)) ∧
-      (∀ k, μ k ≠ 0) ∧
       (∀ k, 0 < dim k) ∧
       SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
       ∑ k : Fin r, dim k ≤ D := by
   classical
-  obtain ⟨zeroTailDim, r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, hMPV,
+  obtain ⟨zeroTailDim, r, dim, μ, blocks, hΛ, hScalar, hμPos, _hμNe, hDim, hMPV,
     _hBond, hBound⟩ :=
     exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound
       (d := d) (D := D) A
-  refine ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, ?_, hBound⟩
+  refine ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, hDim, ?_, hBound⟩
   intro N hN σ
   calc
     mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ +
@@ -855,7 +854,7 @@ theorem exists_pgvwc07_positiveLengthWitness
     (A : MPSTensor d D) :
     Nonempty (PGVWC07PositiveLengthWitness (d := d) (D := D) A) := by
   classical
-  obtain ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, _, hDim, hSame, hBound⟩ :=
+  obtain ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, hDim, hSame, hBound⟩ :=
     exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
       (d := d) (D := D) A
   exact ⟨


### PR DESCRIPTION
Progress on #1857.

This is the follow-up suggested after PR #1950. The positive-length PGVWC07 theorem already states that every weight is the complex embedding of a strictly positive real number, so an additional existential conjunct saying that every weight is nonzero repeats the same mathematical fact.

Changes:
- remove the separate nonzero-weight conjunct from `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`;
- discard the corresponding conjunct when it is obtained from the zero-tail theorem;
- update `MPSTensor.exists_pgvwc07_positiveLengthWitness` to destructure the shorter theorem conclusion.

The blueprint theorem already says “positive real weights,” so no blueprint statement change is needed. Nonvanishing remains available for the structured witness through `MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero` from PR #1950.

Validation:
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction`
- `lake exe lint_style --github`
- `git diff --check -- TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only removes a redundant existential conjunct (`μ k ≠ 0`) from one theorem and updates downstream destructuring; it should not change any mathematical content, but may require minor updates to callers relying on the old tuple shape.
> 
> **Overview**
> Removes the separate `∀ k, μ k ≠ 0` conjunct from `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`, since `weight_pos` already implies nonvanishing.
> 
> Updates the proof to ignore the now-absent conjunct when unpacking `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`, and adjusts `exists_pgvwc07_positiveLengthWitness` to destructure the shortened result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 668859cfacc015e6705114c929dd1f109b8f019a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->