### PR TITLE
refactor(SectorBNT): record copy-weight matching data

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -81,6 +81,27 @@ noncomputable def matched_block_gauge {Q : SectorDecomposition d}
   change GL (Fin (Q.basisDim (Q.flatIndexEquiv.symm s).1)) ℂ
   exact Xblock (Q.flatIndexEquiv.symm s).1
 
+/-- **Copy-weight matching for matched BNT sectors.**
+
+For a matched sector bijection `β : Fin Q.basisCount ≃ Fin P.basisCount` and
+phases `ζ k`, this structure records the copy-level part of the CPSV16
+Appendix MPV proof, line 1188: each copy of a `Q`-sector is paired with a copy
+of the matched `P`-sector, and the corresponding raw weights satisfy
+`ν_{k,q} = (ζ k)⁻¹ μ_{β k, τ_k q}`.
+
+The proportional theorem in CPSV16 gives the sector matching at the theorem
+statement lines 1167--1170 and the Appendix MPV proof line 1182.  The
+coefficient comparison that would construct this copy-weight matching is the
+remaining proportional task recorded in issue #1749. -/
+structure SectorBNTCopyWeightMatching {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (ζ : Fin Q.basisCount → ℂ) where
+  /-- Copy permutation inside each matched sector. -/
+  copy_equiv : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))
+  /-- Matched copy-weight identity with the same phase as the sector gauge. -/
+  weight_eq : ∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
+    Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (copy_equiv k q)
+
 /-- **Global block gauge from matched sectors and copy weights.**
 
 Assume the sectors of two sector decompositions have already been matched, and
@@ -194,6 +215,43 @@ theorem sector_bnt_global_gauge_of_matched_weights
               (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
             rw [hLeft]
 
+/-- **Global block gauge from a copy-weight matching.**
+
+This is the same direct-sum gauge assembly as
+`sector_bnt_global_gauge_of_matched_weights`, with the copy permutations and
+weight identities supplied by `SectorBNTCopyWeightMatching`.
+
+It is the pure algebraic assembly of CPSV16 Appendix MPV proof, lines
+1189--1192, after the line-1188 copy-weight comparison has been supplied. -/
+theorem sector_bnt_global_gauge_of_copy_weight_matching
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+    (ζ : Fin Q.basisCount → ℂ)
+    (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ)
+    (hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0)
+    (hConj : ∀ (k : Fin Q.basisCount) (i : Fin d),
+      Q.basis k i =
+        ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+          (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+          (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+            Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ)))
+    (W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ) :
+    ∃ X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ,
+      X = globalGaugeOfBlocks (matched_block_gauge (Q := Q) Xblock) ∧
+      ∀ i : Fin d,
+        toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis i =
+          (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+            (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
+            toTensorFromBlocks (d := d)
+              (μ := matched_p_weight (P := P) (Q := Q) β W.copy_equiv)
+              (matched_p_basis (P := P) (Q := Q) β hDim) i *
+            (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
+              Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :=
+  sector_bnt_global_gauge_of_matched_weights
+    (P := P) (Q := Q) β hDim W.copy_equiv ζ Xblock hζ_ne hConj W.weight_eq
+
 /-- **Conditional proportional global gauge from matched copy weights.**
 
 For proportional MPV families, the proportional sector-matching theorem supplies
@@ -252,6 +310,58 @@ theorem ft_sector_bnt_proportional_global_gauge_of_weight_data
     simp [hzero] at hnorm
   exact sector_bnt_global_gauge_of_matched_weights
     (P := P) (Q := Q) β hDim τ ζ Xblock hζ_ne hConj hWeight
+
+/-- **Conditional proportional global gauge from a copy-weight matching.**
+
+This reformulates `ft_sector_bnt_proportional_global_gauge_of_weight_data` with
+the remaining copy-weight comparison recorded as a single
+`SectorBNTCopyWeightMatching` input.
+
+The theorem therefore separates the two mathematical ingredients:
+
+* CPSV16 Appendix MPV theorem statement, lines 1167--1170, and proof line 1182
+  give the sector bijection, unit phases, and block gauges;
+* the still-open proportional coefficient comparison must construct the
+  copy-weight matching.  Once it is available, the global gauge is the
+  equal-MPV corollary's direct-sum algebra from Appendix MPV proof,
+  lines 1189--1192. -/
+theorem ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
+    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
+      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+      (ζ : Fin Q.basisCount → ℂ)
+      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
+      (∀ (k : Fin Q.basisCount) (i : Fin d),
+        Q.basis k i =
+          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
+      ∀ W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ,
+        ∃ X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ,
+          X = globalGaugeOfBlocks (matched_block_gauge (Q := Q) Xblock) ∧
+          ∀ i : Fin d,
+            toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis i =
+              (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
+                toTensorFromBlocks (d := d)
+                  (μ := matched_p_weight (P := P) (Q := Q) β W.copy_equiv)
+                  (matched_p_basis (P := P) (Q := Q) β hDim) i *
+                (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
+                  Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                    (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
+  classical
+  obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, hAssemble⟩ :=
+    ft_sector_bnt_proportional_global_gauge_of_weight_data
+      (P := P) (Q := Q) hP hQ hUnitP hUnitQ hProp
+  refine ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ?_⟩
+  intro W
+  exact hAssemble W.copy_equiv W.weight_eq
 
 /-- **BNT equal-MPV sector-witness theorem.**
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1351,6 +1351,22 @@ matching covers the whole BNT basis.
     phases gives the eventual coefficient identities.
 \end{proof}
 
+\begin{definition}[Copy-weight matching for matched BNT sectors]%
+    \label{def:sector_bnt_copy_weight_matching}
+    \lean{MPSTensor.SectorBNTCopyWeightMatching}
+    \leanok
+    Let the sectors of two decompositions $P$ and $Q$ be matched by
+    $\beta:J(Q)\simeq J(P)$, and let $\zeta_k$ be the phase attached to
+    sector $k$. A copy-weight matching consists of copy permutations
+    $\tau_k$ and the following identities: for all sectors $k$ and copies $q$,
+    \[
+        \nu_{k,q}=\zeta_k^{-1}\,\mu_{\beta(k),\tau_k(q)}.
+    \]
+    This is the copy-level conclusion supplied by the equal-MPV coefficient comparison in
+    \cite[Appendix MPV proof, line~1188]{Cirac2017MPDO_AnnPhys}. For the
+    proportional theorem it remains the separate coefficient-comparison input.
+\end{definition}
+
 \begin{theorem}[Global gauge from matched sectors and copy weights]%
     \label{thm:sector_bnt_global_gauge_of_matched_weights}
     \lean{MPSTensor.sector_bnt_global_gauge_of_matched_weights}
@@ -1389,6 +1405,33 @@ matching covers the whole BNT basis.
     Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} to the flattened
     family assembles these block conjugacies into the displayed direct-sum
     gauge.
+\end{proof}
+
+\begin{theorem}[Global gauge from a copy-weight matching]%
+    \label{thm:sector_bnt_global_gauge_of_copy_weight_matching}
+    \lean{MPSTensor.sector_bnt_global_gauge_of_copy_weight_matching}
+    \leanok
+    \uses{def:sector_bnt_copy_weight_matching,
+        thm:sector_bnt_global_gauge_of_matched_weights}
+    Suppose that the sectors of $P$ and $Q$ are matched, with
+    bond-dimension equalities, nonzero phases, and block gauges satisfying
+    \[
+        Q_k^i=\zeta_k X_kP_{\beta(k)}^iX_k^{-1}.
+    \]
+    If the same phases also give a copy-weight matching, then the flattened
+    $Q$-tensor is obtained from the matched-coordinate $P$-tensor by the
+    direct-sum gauge
+    \[
+        X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
+    \]
+    This is only a reformulation of
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The copy-weight matching supplies the copy permutations and the weight
+    identities. Apply
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
 \end{proof}
 
 \begin{theorem}[Conditional proportional global gauge from copy weights]%
@@ -1436,6 +1479,33 @@ matching covers the whole BNT basis.
     unit-modulus conclusion gives nonzero phases. With the displayed
     copy-weight identities as input, apply
     Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
+\end{proof}
+
+\begin{theorem}[Conditional proportional global gauge from a copy-weight matching]%
+    \label{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
+    \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching}
+    \leanok
+    \uses{def:sector_bnt_copy_weight_matching,
+        thm:sector_bnt_proportional_sector_match_witnesses,
+        thm:sector_bnt_global_gauge_of_copy_weight_matching}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
+    eventually nonzero proportional MPV families. Assume that every sector of
+    $P$ and every sector of $Q$ has at least one copy weight of modulus $1$.
+    Then the proportional sector-matching theorem gives $\beta$, the
+    bond-dimension equalities, the unit phases $\zeta_k$, and the block gauges
+    $X_k$. If the remaining proportional coefficient comparison supplies a
+    copy-weight matching for these same phases, then the flattened
+    $Q$-tensor is obtained from the matched-coordinate $P$-tensor by the
+    direct-sum gauge
+    \[
+        X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the proportional sector-matching theorem. The unit-modulus phases
+    are nonzero, so the global-gauge theorem applies to any
+    copy-weight matching for the resulting phases.
 \end{proof}
 
 \begin{theorem}[Full-basis global gauge in matched coordinates]%


### PR DESCRIPTION
## Summary

This PR records the residual copy-weight comparison input for the proportional SectorBNT global-gauge path as a named structure:

- adds `MPSTensor.SectorBNTCopyWeightMatching`, carrying the copy permutations and identities `ν_{k,q} = ζ_k⁻¹ μ_{β(k),τ_k(q)}`;
- adds `MPSTensor.sector_bnt_global_gauge_of_copy_weight_matching`, a reformulation of the existing direct-sum gauge assembly using that structure;
- adds `MPSTensor.ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching`, which separates the already-proved proportional sector matching from the still-open proportional coefficient comparison;
- records the corresponding Chapter 10 blueprint entries.

This does not prove the proportional copy-weight comparison in #1749. It makes the exact remaining hypothesis a named mathematical object before the hard comparison theorem is attempted.

## Source boundary

- CPSV16 Appendix MPV theorem statement lines 1167--1170 and proof line 1182: proportional sector matching.
- CPSV16 Appendix MPV proof line 1188: equal-MPV copy-weight comparison, used here only as the form of the residual copy-weight matching.
- CPSV16 Appendix MPV proof lines 1189--1192: direct-sum global gauge assembly.

## Validation

- `git diff --check`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental`
- `lake exe lint_style --github`
- `cd blueprint && leanblueprint web` (with the repository's existing renderer warnings)

Progress toward #1749 and #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a refactor/abstraction in Lean proofs that packages existing hypotheses and adds wrapper theorems, without changing core algorithms or runtime behavior.
> 
> **Overview**
> Adds `SectorBNTCopyWeightMatching` to package the remaining *copy-level* proportionality data (copy permutations plus weight identities with the same phases as the sector gauge).
> 
> Refactors the global direct-sum gauge assembly by introducing `sector_bnt_global_gauge_of_copy_weight_matching` (a thin wrapper over `sector_bnt_global_gauge_of_matched_weights`) and a corresponding proportional theorem `ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching` that cleanly separates the proven sector-matching step from the still-missing copy-weight comparison.
> 
> Updates the Chapter 10 blueprint to document the new definition and the two reformulated theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bfb4f21487b07b9f1c1c03c5053fa60d4158cc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->