### PR TITLE
feat(canonical): normalize PGVWC07 positive weights

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.NormalReduction.Main
 import TNLean.MPS.CanonicalForm.NormalReduction.TPGauge
+import TNLean.MPS.CanonicalForm.NormalReduction.WeightNormalization
 
 /-!
 # Normal canonical-form reduction
@@ -18,6 +19,8 @@ The supporting modules are:
   primitive weighted block decomposition to blocked normal canonical-form data.
 * `TNLean.MPS.CanonicalForm.NormalReduction.TPGauge` — the blockwise TP-gauge
   normalization results, including the arbitrary-input zero-tail statement.
+* `TNLean.MPS.CanonicalForm.NormalReduction.WeightNormalization` — the
+  finite-family positive-weight normalization for the positive-length witness.
 
 ## Main statements
 
@@ -29,6 +32,7 @@ The imported modules provide the original public declarations:
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`
 * `MPSTensor.exists_pgvwc07_positiveLengthWitness`
+* `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.NormalReduction.TPGauge
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder TNMatrixCFC
+
+/-!
+# Positive-weight normalization for the PGVWC07 witness
+
+This module records the finite-family scalar normalization of the positive
+weights in the positive-length PGVWC07 canonical-form witness.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof
+lines 765--766, says that the spectral radius may be normalized without loss
+of generality.  The theorem below proves the finite positive-weight part of
+that convention: divide all weights by their largest value, so that every
+normalized weight has norm at most one and one has norm one.  The statement
+also records the global scalar factor on every positive-length MPV
+coefficient.
+
+The remaining source-facing boundary is not the finite maximum argument, but
+the state-equivalence convention under which the global length-dependent
+scalar is harmless.  This boundary is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Normalize the positive weights in a nonempty PGVWC07 positive-length
+witness by their largest value.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof
+lines 765--766, says that the spectral radius may be normalized without loss
+of generality.  This theorem records the corresponding scalar convention for
+the positive-length witness: after dividing all weights by their maximum, every
+new weight has norm at most one and one weight has norm one.  The conclusion
+also records the global factor `scale ^ N` on length-`N` MPV coefficients. -/
+theorem PGVWC07PositiveLengthWitness.exists_weight_normalization
+    {A : MPSTensor d D} (W : PGVWC07PositiveLengthWitness (d := d) (D := D) A)
+    (hr : 0 < W.r) :
+    ∃ (scale : ℝ) (ν : Fin W.r → ℂ),
+      0 < scale ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
+      (∀ k, ‖ν k‖ ≤ 1) ∧
+      (∃ k, ‖ν k‖ = 1) ∧
+      (∀ k, W.weights k = (scale : ℂ) * ν k) ∧
+      (∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
+        mpv A σ =
+          (scale : ℂ) ^ N *
+            mpv (toTensorFromBlocks (d := d) (μ := ν) W.blocks) σ) := by
+  classical
+  letI : Nonempty (Fin W.r) := ⟨⟨0, hr⟩⟩
+  let a : Fin W.r → ℝ := fun k => Classical.choose (W.weight_pos k)
+  have ha_pos : ∀ k, 0 < a k := by
+    intro k
+    exact (Classical.choose_spec (W.weight_pos k)).1
+  have ha_weight : ∀ k, W.weights k = (a k : ℂ) := by
+    intro k
+    exact (Classical.choose_spec (W.weight_pos k)).2
+  have hImageNonempty : (Finset.univ.image a).Nonempty :=
+    (Finset.univ_nonempty : (Finset.univ : Finset (Fin W.r)).Nonempty).image a
+  let scale : ℝ := (Finset.univ.image a).max' hImageNonempty
+  have hle : ∀ k, a k ≤ scale := by
+    intro k
+    exact Finset.le_max' _ _ (by simp [a])
+  have hscale_pos : 0 < scale := by
+    let k0 : Fin W.r := ⟨0, hr⟩
+    exact lt_of_lt_of_le (ha_pos k0) (hle k0)
+  have hscale_mem : scale ∈ Finset.univ.image a := by
+    exact Finset.max'_mem _ _
+  obtain ⟨kmax, _, hkmax⟩ := Finset.mem_image.mp hscale_mem
+  let ν : Fin W.r → ℂ := fun k => (((a k / scale) : ℝ) : ℂ)
+  have hscale_ne : scale ≠ 0 := ne_of_gt hscale_pos
+  have hweight_eq : ∀ k, W.weights k = (scale : ℂ) * ν k := by
+    intro k
+    calc
+      W.weights k = (a k : ℂ) := ha_weight k
+      _ = (scale : ℂ) * (((a k / scale : ℝ) : ℂ)) := by
+            rw [← Complex.ofReal_mul]
+            have hmul : scale * (a k / scale) = a k := by
+              field_simp [hscale_ne]
+            rw [hmul]
+      _ = (scale : ℂ) * ν k := rfl
+  refine ⟨scale, ν, hscale_pos, ?_, ?_, ?_, hweight_eq, ?_⟩
+  · intro k
+    exact ⟨a k / scale, div_pos (ha_pos k) hscale_pos, rfl⟩
+  · intro k
+    have hdiv_le : a k / scale ≤ 1 := (div_le_one hscale_pos).mpr (hle k)
+    calc
+      ‖ν k‖ = |a k| / |scale| := by simp [ν]
+      _ = a k / scale := by rw [abs_of_pos (ha_pos k), abs_of_pos hscale_pos]
+      _ ≤ 1 := hdiv_le
+  · refine ⟨kmax, ?_⟩
+    have hratio : a kmax / scale = 1 := by
+      rw [hkmax]
+      exact div_self hscale_ne
+    calc
+      ‖ν kmax‖ = |a kmax| / |scale| := by simp [ν]
+      _ = a kmax / scale := by
+        rw [abs_of_pos (ha_pos kmax), abs_of_pos hscale_pos]
+      _ = 1 := hratio
+  · intro N hN σ
+    calc
+      mpv A σ = mpv (toTensorFromBlocks (d := d) (μ := W.weights) W.blocks) σ :=
+        W.sameMPV_pos N hN σ
+      _ = mpv (toTensorFromBlocks (d := d) (μ := fun k => (scale : ℂ) * ν k)
+            W.blocks) σ := by
+          have hfun : W.weights = fun k => (scale : ℂ) * ν k := funext hweight_eq
+          rw [hfun]
+      _ = (scale : ℂ) ^ N *
+            mpv (toTensorFromBlocks (d := d) (μ := ν) W.blocks) σ :=
+          mpv_toTensorFromBlocks_weight_mul_left (d := d) (c := (scale : ℂ))
+            (μ := ν) W.blocks σ
+
+end MPSTensor

--- a/TNLean/MPS/SharedInfra/Scaling.lean
+++ b/TNLean/MPS/SharedInfra/Scaling.lean
@@ -130,4 +130,17 @@ theorem mpv_toTensorFromBlocks_normalize {r : ℕ} {dim : Fin r → ℕ}
   rw [mpv_smul, smul_eq_mul, smul_eq_mul, ← mul_assoc, ← mul_pow,
     div_mul_cancel₀ (μ k) hne]
 
+/-- Multiplying every block weight by the same scalar multiplies length-`N`
+MPV coefficients by `c ^ N`. -/
+theorem mpv_toTensorFromBlocks_weight_mul_left {r : ℕ} {dim : Fin r → ℕ}
+    (c : ℂ) (μ : Fin r → ℂ)
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {N : ℕ} (σ : Fin N → Fin d) :
+    mpv (toTensorFromBlocks (d := d) (μ := fun k => c * μ k) A) σ =
+      c ^ N * mpv (toTensorFromBlocks (d := d) (μ := μ) A) σ := by
+  rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  simp [mul_pow, smul_eq_mul, mul_assoc]
+
 end MPSTensor

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1000,6 +1000,49 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     Each weight is the complex embedding of a strictly positive real number.
 \end{proof}
 
+\begin{lemma}[Common scalar rescaling of block weights]%
+    \label{lem:mpv_to_tensor_from_blocks_weight_mul_left}
+    \lean{MPSTensor.mpv_toTensorFromBlocks_weight_mul_left}
+    \leanok
+    Multiplying every block weight in a block-diagonal MPS tensor by the same
+    scalar \(c\) multiplies every length-\(N\) MPV coefficient by \(c^N\).
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand the block-diagonal MPV coefficient as a finite sum over blocks and
+    factor the common scalar power out of the sum.
+\end{proof}
+
+\begin{theorem}[Weight normalization for a nonempty PGVWC07 witness]%
+    \label{thm:pgvwc07_positive_length_witness_weight_normalization}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        lem:mpv_to_tensor_from_blocks_weight_mul_left}
+    Let a positive-length PGVWC07 canonical-form witness have at least one
+    nonzero block.  Then its positive real weights may be divided by their
+    largest value so that the new weights \(\nu_k\) are positive,
+    \(|\nu_k|\leq 1\) for all \(k\), and \(|\nu_{k_0}|=1\) for at least one
+    block \(k_0\).  If the original weights are \(\mu_k=s\nu_k\) with
+    \(s>0\), then for every chain length \(N>0\),
+    \[
+        \operatorname{MPV}_A(\sigma)
+        =
+        s^N
+        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
+    \]
+    This is the formal scalar normalization corresponding to
+    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix};
+    the displayed factor records the global length-dependent rescaling.
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose the largest positive real weight \(s\).  Dividing every weight by
+    \(s\) gives positive weights bounded above by \(1\), and a block attaining
+    the maximum has normalized weight \(1\).  The MPV identity follows from
+    Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left}.
+\end{proof}
+
 \begin{theorem}[Existence of the positive-length PGVWC07 witness]%
     \label{thm:pgvwc07_positive_length_witness}
     \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -299,6 +299,16 @@ The earlier existence path now has the following formal pieces.
           positive-length theorem, intended to prevent later arguments from
           repeating the long existential conclusion.
 
+    \item
+          \path|MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization|
+          formalizes the finite-family scalar normalization corresponding to
+          Theorem~\texttt{Th:TIcanonical}, lines 765--766, for a witness with
+          at least one nonzero block.  Dividing the positive real weights by
+          their maximum gives normalized positive weights with
+          \(|\nu_k|\leq 1\) and equality for one block.  The theorem also
+          records the resulting global factor \(s^N\) in length-\(N\) MPV
+          coefficients.
+
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an
@@ -336,12 +346,14 @@ Thus no current \verb|\leanok| statement in the canonical-form
 chapter should be read as the full PGVWC07 translation-invariant canonical-form
 theorem. The blueprint now records the source theorem as a separate not-ready
 statement, and the checked reductions are marked as partial or scoped results.
-After the positive-length witness theorem, the remaining source-level
-normalization gap is the paper's convention \(1\geq \lambda_j>0\): the exact
-MPV statement has positive real weights, but it does not yet formalize the
-``without loss of generality'' spectral-radius normalization from
-Theorem~\texttt{Th:TIcanonical}, lines 765--766, as a transformation compatible
-with the chosen notion of equality of finite-ring coefficients.
+After the positive-length witness theorem, the finite-family part of the
+paper's convention \(1\geq \lambda_j>0\) is now formalized for a nonempty
+witness by rescaling all positive weights by their maximum.  The remaining
+source-level point is to connect this scalar normalization with the precise
+state-equivalence convention under which PGVWC07 treats the spectral-radius
+normalization in Theorem~\texttt{Th:TIcanonical}, lines 765--766, as
+``without loss of generality'': exact finite-ring coefficients acquire the
+global factor \(s^N\).
 
 \section{Formal boundary}
 
@@ -376,12 +388,12 @@ diagonalization.  None of these steps may be replaced by a theorem that starts
 from an already prepared primitive or trace-preserving block family, because
 those hypotheses are not present in Theorem~\texttt{Th:TIcanonical}.
 
-At the current frontier, the block construction and nonempty-ring exact-MPV
-witness are available.  The remaining formal work is to state and prove the
-global normalization convention that turns the positive real weights into
-weights satisfying \(1\geq \lambda_j>0\), or to make explicit the precise
-state-equivalence relation under which the paper's spectral-radius
-renormalization is ``without loss of generality''.
+At the current frontier, the block construction, nonempty-ring exact-MPV
+witness, and finite-family weight normalization are available.  The remaining
+formal work is to make explicit the precise state-equivalence relation under
+which the paper's spectral-radius renormalization is ``without loss of
+generality'', since the normalized exact-coefficient statement differs by the
+global factor \(s^N\).
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This PR formalizes the finite-family scalar normalization step for the positive-length PGVWC07 witness:

- adds `MPSTensor.mpv_toTensorFromBlocks_weight_mul_left`, saying that multiplying all block weights by a common scalar multiplies length-`N` MPV coefficients by `c^N`;
- adds `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization`, which divides the positive real weights of a nonempty witness by their maximum;
- records that the normalized weights are positive, have norm at most one, and have a unit-norm representative;
- records the resulting global factor `scale^N` in the positive-length MPV coefficients;
- updates the Chapter 8 blueprint and the PGVWC07 paper-gap note.

This does not claim the full PGVWC07 Theorem Th:TIcanonical normalization convention is closed. It isolates the finite-family part and leaves the remaining source-facing point as the state-equivalence convention under which the global factor is treated as harmless.

## Source boundary

- PGVWC07 Theorem Th:TIcanonical, proof lines 765--766: spectral-radius normalization without loss of generality.
- The new theorem handles the finite family of positive weights and explicitly records the length-dependent scalar factor.

## Validation

- `git diff --check`
- `lake env lean TNLean/MPS/SharedInfra/Scaling.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction.TPGauge`
- `lake exe lint_style --github`
- `cd blueprint && leanblueprint web` (with the repository's existing renderer warnings)

Progress toward #1857 and #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems/lemmas and documentation around weight rescaling, with no runtime behavior or external interfaces beyond new imports and names.
> 
> **Overview**
> Adds a new formal weight-rescaling step for the PGVWC07 positive-length witness: `PGVWC07PositiveLengthWitness.exists_weight_normalization` picks the maximal positive real weight, rescales all block weights to be positive with `‖ν k‖ ≤ 1` and some `‖ν k‖ = 1`, and records the induced global factor `(scale : ℂ)^N` on length-`N` MPV coefficients.
> 
> Introduces the supporting scaling lemma `mpv_toTensorFromBlocks_weight_mul_left` (common scalar multiplication of all block weights yields a `c^N` factor on MPVs), wires the new module into the historical `NormalReduction` import path, and updates the blueprint + paper-gap note to document the new normalization result and remaining state-equivalence gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceacd6210090d40482c2bd3e7e480ad32f12f5a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->