### PR TITLE
refactor(SectorBNT): extract copy-weight matching from coefficients

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -217,6 +217,7 @@ import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
+import TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching
 import TNLean.MPS.FundamentalTheorem.SectorBNT.DominantMatch
 import TNLean.MPS.FundamentalTheorem.SectorBNT.EqualModulus
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CopyWeightMatching.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CopyWeightMatching.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.SectorBNT.WeightEquiv
+
+/-!
+# Copy-weight matching for matched BNT sectors
+
+This module records the copy-level weight comparison used in the BNT
+Fundamental Theorem.
+
+After the sector bijection and per-sector gauge phases have been fixed, the
+CPSV16 Appendix MPV proof compares the resulting coefficient power sums and
+identifies the copy weights, up to the same phase, inside each matched sector.
+The source anchor is arXiv:1606.00608, Appendix MPV proof line 1188, with the
+finite power-sum lemma at lines 1155--1163.
+
+The results here are purely algebraic: they assume the eventual
+coefficient identity for each matched sector and produce the copy permutations
+and pointwise weight identities needed by the direct-sum gauge assembly.
+-/
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- **Copy-weight matching for matched BNT sectors.**
+
+For a matched sector bijection `β : Fin Q.basisCount ≃ Fin P.basisCount` and
+phases `ζ k`, this structure records the copy-level part of the CPSV16
+Appendix MPV proof, line 1188: each copy of a `Q`-sector is paired with a copy
+of the matched `P`-sector, and the corresponding raw weights satisfy
+`ν_{k,q} = (ζ k)⁻¹ μ_{β k, τ_k q}`.
+
+The proportional theorem in CPSV16 gives the sector matching at the theorem
+statement lines 1167--1170 and the Appendix MPV proof line 1182.  The
+coefficient comparison that constructs this copy-weight matching is the
+remaining proportional task recorded in issue #1749. -/
+structure SectorBNTCopyWeightMatching {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (ζ : Fin Q.basisCount → ℂ) where
+  /-- Copy permutation inside each matched sector. -/
+  copy_equiv : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))
+  /-- Matched copy-weight identity with the same phase as the sector gauge. -/
+  weight_eq : ∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
+    Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (copy_equiv k q)
+
+/-- **Construct copy-weight matching from matched-sector coefficient identities.**
+
+Assume that every matched sector satisfies the eventual coefficient identity
+
+`P.coeff N (β k) = (ζ k)^N * Q.coeff N k`.
+
+If each phase `ζ k` is nonzero, then the finite power-sum comparison recovers,
+sector by sector, the copy permutation and the pointwise identity
+
+`Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ_k q)`.
+
+This constructs the copy-weight matching established in CPSV16 Appendix MPV
+proof, line 1188, using the finite power-sum lemma from lines 1155--1163. -/
+noncomputable def SectorBNTCopyWeightMatching.of_coeff_identity
+    {P Q : SectorDecomposition d}
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (ζ : Fin Q.basisCount → ℂ)
+    (hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0)
+    (hCoeff : ∀ k : Fin Q.basisCount, ∃ N₀, ∀ N > N₀,
+      P.coeff N (β k) = (ζ k) ^ N * Q.coeff N k) :
+    SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ := by
+  classical
+  have hData : ∀ k : Fin Q.basisCount,
+      ∃ (_hCopies : P.copies (β k) = Q.copies k)
+        (τ : Fin (P.copies (β k)) ≃ Fin (Q.copies k)),
+        ∀ q : Fin (P.copies (β k)),
+          Q.weight k (τ q) = (ζ k)⁻¹ * P.weight (β k) q := by
+    intro k
+    obtain ⟨N₀, hCoeff_k⟩ := hCoeff k
+    exact matched_sector_weight_equiv (P := P) (Q := Q)
+      (j₀ := β k) (k₀' := k) (ζ := ζ k) (hζ_ne k) (N₀ := N₀) hCoeff_k
+  refine
+    { copy_equiv := fun k => (hData k).choose_spec.choose.symm
+      weight_eq := ?_ }
+  intro k q
+  have hPoint := (hData k).choose_spec.choose_spec ((hData k).choose_spec.choose.symm q)
+  simpa using hPoint
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
+import TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching
 import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch
-import TNLean.MPS.FundamentalTheorem.SectorBNT.WeightEquiv
 import TNLean.MPS.FundamentalTheorem.Multi
 
 /-!
@@ -80,27 +80,6 @@ noncomputable def matched_block_gauge {Q : SectorDecomposition d}
     (s : Fin Q.totalCopies) → GL (Fin (Q.flatDim s)) ℂ := fun s => by
   change GL (Fin (Q.basisDim (Q.flatIndexEquiv.symm s).1)) ℂ
   exact Xblock (Q.flatIndexEquiv.symm s).1
-
-/-- **Copy-weight matching for matched BNT sectors.**
-
-For a matched sector bijection `β : Fin Q.basisCount ≃ Fin P.basisCount` and
-phases `ζ k`, this structure records the copy-level part of the CPSV16
-Appendix MPV proof, line 1188: each copy of a `Q`-sector is paired with a copy
-of the matched `P`-sector, and the corresponding raw weights satisfy
-`ν_{k,q} = (ζ k)⁻¹ μ_{β k, τ_k q}`.
-
-The proportional theorem in CPSV16 gives the sector matching at the theorem
-statement lines 1167--1170 and the Appendix MPV proof line 1182.  The
-coefficient comparison that would construct this copy-weight matching is the
-remaining proportional task recorded in issue #1749. -/
-structure SectorBNTCopyWeightMatching {P Q : SectorDecomposition d}
-    (β : Fin Q.basisCount ≃ Fin P.basisCount)
-    (ζ : Fin Q.basisCount → ℂ) where
-  /-- Copy permutation inside each matched sector. -/
-  copy_equiv : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))
-  /-- Matched copy-weight identity with the same phase as the sector gauge. -/
-  weight_eq : ∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
-    Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (copy_equiv k q)
 
 /-- **Global block gauge from matched sectors and copy weights.**
 
@@ -362,6 +341,64 @@ theorem ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching
   refine ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ?_⟩
   intro W
   exact hAssemble W.copy_equiv W.weight_eq
+
+/-- **Conditional proportional global gauge from coefficient identities.**
+
+This is the proportional analogue of the equal-MPV coefficient-to-gauge passage,
+with the still-open coefficient comparison kept as an explicit input.  The
+proportional sector-matching theorem supplies the sector bijection, phases, and
+block gauges.  If those same phases satisfy the eventual matched-sector
+coefficient identities, then the matched-sector coefficient comparison recovers
+the copy-weight matching and the direct-sum global gauge follows.
+
+The coefficient identity is the precise remaining CPSV16 Appendix MPV
+line-1188 input for issue #1749. -/
+theorem ft_sector_bnt_proportional_global_gauge_of_coeff_identity
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
+    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
+      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+      (ζ : Fin Q.basisCount → ℂ)
+      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
+      (∀ (k : Fin Q.basisCount) (i : Fin d),
+        Q.basis k i =
+          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
+      ((∀ k : Fin Q.basisCount, ∃ N₀, ∀ N > N₀,
+        P.coeff N (β k) = (ζ k) ^ N * Q.coeff N k) →
+        ∃ W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ,
+          ∃ X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ,
+            X = globalGaugeOfBlocks (matched_block_gauge (Q := Q) Xblock) ∧
+            ∀ i : Fin d,
+              toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis i =
+                (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                  (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
+                  toTensorFromBlocks (d := d)
+                    (μ := matched_p_weight (P := P) (Q := Q) β W.copy_equiv)
+                    (matched_p_basis (P := P) (Q := Q) β hDim) i *
+                  (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
+                    Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
+                      (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ)) := by
+  classical
+  obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, hGlobal⟩ :=
+    ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching
+      (P := P) (Q := Q) hP hQ hUnitP hUnitQ hProp
+  refine ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ?_⟩
+  intro hCoeff
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
+    intro k hzero
+    have hnorm := hζ_norm k
+    simp [hzero] at hnorm
+  let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
+    SectorBNTCopyWeightMatching.of_coeff_identity
+      (P := P) (Q := Q) β ζ hζ_ne hCoeff
+  exact ⟨W, hGlobal W⟩
 
 /-- **BNT equal-MPV sector-witness theorem.**
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1367,6 +1367,35 @@ matching covers the whole BNT basis.
     proportional theorem it remains the separate coefficient-comparison input.
 \end{definition}
 
+\begin{lemma}[Copy-weight matching from matched-sector coefficient identities]%
+    \label{lem:sector_bnt_copy_weight_matching_of_coeff_identity}
+    \lean{MPSTensor.SectorBNTCopyWeightMatching.of_coeff_identity}
+    \leanok
+    \uses{def:sector_bnt_copy_weight_matching,
+        lem:sector_bnt_matched_sector_weight_equiv}
+    Let the sectors of two decompositions $P$ and $Q$ be matched by
+    $\beta:J(Q)\simeq J(P)$, and let $\zeta_k\neq 0$ be the phase attached to
+    sector $k$. Suppose that for every $k$ there is $N_0$ such that, for all
+    $N>N_0$,
+    \[
+        c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q).
+    \]
+    Then the phases $\zeta_k$ determine a copy-weight matching:
+    after a copy permutation inside each matched sector,
+    \[
+        \nu_{k,q}=\zeta_k^{-1}\,\mu_{\beta(k),\tau_k(q)}.
+    \]
+    This is, sector by sector, the content of the coefficient comparison in
+    \cite[Appendix MPV proof, line~1188]{Cirac2017MPDO_AnnPhys}.
+\end{lemma}
+
+\begin{proof}\leanok
+    Apply Lemma~\ref{lem:sector_bnt_matched_sector_weight_equiv} in each
+    matched sector.  The resulting copy permutations and pointwise weight
+    identities satisfy exactly the conditions of
+    Definition~\ref{def:sector_bnt_copy_weight_matching}.
+\end{proof}
+
 \begin{theorem}[Global gauge from matched sectors and copy weights]%
     \label{thm:sector_bnt_global_gauge_of_matched_weights}
     \lean{MPSTensor.sector_bnt_global_gauge_of_matched_weights}
@@ -1506,6 +1535,39 @@ matching covers the whole BNT basis.
     Apply the proportional sector-matching theorem. The unit-modulus phases
     are nonzero, so the global-gauge theorem applies to any
     copy-weight matching for the resulting phases.
+\end{proof}
+
+\begin{theorem}[Conditional proportional global gauge from coefficient identities]%
+    \label{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}
+    \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_coeff_identity}
+    \leanok
+    \uses{lem:sector_bnt_copy_weight_matching_of_coeff_identity,
+        thm:sector_bnt_proportional_sector_match_witnesses,
+        thm:sector_bnt_global_gauge_of_copy_weight_matching}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
+    eventually nonzero proportional MPV families. Assume that every sector of
+    $P$ and every sector of $Q$ has at least one copy weight of modulus $1$.
+    Then the proportional sector-matching theorem gives $\beta$, the
+    bond-dimension equalities, unit-modulus phases $\zeta_k$, and block gauges
+    $X_k$. If these same phases satisfy the matched-sector coefficient
+    identities
+    \[
+        c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q)
+    \]
+    for all sufficiently large $N$, then they determine a copy-weight matching
+    and hence the flattened $Q$-tensor is obtained from the matched-coordinate
+    $P$-tensor by the direct-sum gauge
+    \[
+        X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the proportional sector-matching theorem.  The unit-modulus phases
+    are nonzero.  Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity}
+    turns the coefficient identities into a copy-weight matching, and
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_copy_weight_matching} gives the
+    direct-sum gauge.
 \end{proof}
 
 \begin{theorem}[Full-basis global gauge in matched coordinates]%


### PR DESCRIPTION
## Summary

This PR isolates the CPSV16 copy-weight comparison step for matched BNT sectors.

It moves `MPSTensor.SectorBNTCopyWeightMatching` out of the global-gauge assembly file and into the new module `TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching`.  The new noncomputable extractor

`MPSTensor.SectorBNTCopyWeightMatching.of_coeff_identity`

packages the existing per-sector finite power-sum theorem: if the matched-sector coefficient identities

`P.coeff N (β k) = (ζ k)^N * Q.coeff N k`

hold eventually for nonzero phases, then the corresponding copy permutations and pointwise identities

`Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ_k q)`

form a `SectorBNTCopyWeightMatching`.

The PR also adds `MPSTensor.ft_sector_bnt_proportional_global_gauge_of_coeff_identity`, which says that after the proportional sector-matching theorem supplies `β`, the phases, and the block gauges, these coefficient identities are exactly enough to produce the copy-weight matching and hence the direct-sum global gauge.

## Source boundary

This is CPSV16 Appendix MPV proof line 1188, using the finite power-sum comparison from lines 1155--1163.  It does not assert the still-open proportional coefficient comparison from `EventuallyNonzeroProportionalMPV₂`; rather, it makes the remaining input explicit and immediately consumable by the global-gauge assembly.

Progress toward #1749 and #1685.

## Validation

- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental`
- `lake env lean TNLean.lean`
- `lake exe lint_style --github`
- `git diff --check`
- `cd blueprint && leanblueprint web`

`leanblueprint checkdecls` still fails on the repository's pre-existing missing-declaration list outside this PR; the new declarations are Lean-checked and imported through `TNLean.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SectorBNT fundamental-theorem plumbing by moving and re-wiring a key witness structure and adding a new proportional global-gauge theorem; while mostly additive/refactor, it can impact downstream imports and proof dependencies.
> 
> **Overview**
> Extracts `MPSTensor.SectorBNTCopyWeightMatching` into a new module `SectorBNT/CopyWeightMatching.lean` and adds `SectorBNTCopyWeightMatching.of_coeff_identity`, which derives per-sector copy permutations and weight equalities from the eventual matched-sector coefficient identities.
> 
> Updates the BNT fundamental theorem development to import/use this new module, and adds `ft_sector_bnt_proportional_global_gauge_of_coeff_identity`, making the previously-implicit “coefficient comparison ⇒ copy-weight matching ⇒ direct-sum global gauge” step explicit as a conditional theorem. The blueprint text is extended with the corresponding lemma/theorem statements and proofs, and the root `TNLean.lean` import surface now includes `CopyWeightMatching`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8aceff58252ae37fb1d299ab41436e762edf58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->