### PR TITLE
doc(bnt): align coefficient gauge blueprint

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1542,15 +1542,17 @@ matching covers the whole BNT basis.
     \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_coeff_identity}
     \leanok
     \uses{lem:sector_bnt_copy_weight_matching_of_coeff_identity,
-        thm:sector_bnt_proportional_sector_match_witnesses,
-        thm:sector_bnt_global_gauge_of_copy_weight_matching}
+        thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
     eventually nonzero proportional MPV families. Assume that every sector of
     $P$ and every sector of $Q$ has at least one copy weight of modulus $1$.
-    Then the proportional sector-matching theorem gives $\beta$, the
-    bond-dimension equalities, unit-modulus phases $\zeta_k$, and block gauges
-    $X_k$. If these same phases satisfy the matched-sector coefficient
-    identities
+    Then there are a bijection $\beta:J(Q)\simeq J(P)$, bond-dimension
+    equalities, unit-modulus phases $\zeta_k$, and block gauges $X_k$ such that
+    \[
+        Q_k^i=\zeta_k X_kP_{\beta(k)}^iX_k^{-1}
+    \]
+    for every sector $k$ and physical index $i$. If these same phases satisfy
+    the matched-sector coefficient identities
     \[
         c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q)
     \]
@@ -1563,11 +1565,12 @@ matching covers the whole BNT basis.
 \end{theorem}
 
 \begin{proof}\leanok
-    Apply the proportional sector-matching theorem.  The unit-modulus phases
-    are nonzero.  Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity}
-    turns the coefficient identities into a copy-weight matching, and
-    Theorem~\ref{thm:sector_bnt_global_gauge_of_copy_weight_matching} gives the
-    direct-sum gauge.
+    Apply Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
+    to obtain the matched sectors, phases, block gauges, and the conditional
+    global gauge for any copy-weight matching. The unit-modulus phases are
+    nonzero. Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity}
+    turns the coefficient identities into such a copy-weight matching, and the
+    conditional global-gauge conclusion applies.
 \end{proof}
 
 \begin{theorem}[Full-basis global gauge in matched coordinates]%


### PR DESCRIPTION
This follow-up repairs the blueprint statement for the coefficient-identity version of the proportional BNT global gauge theorem after PR #1955.

The theorem now records the unconditional sector gauge formula returned by the Lean statement,
[
Q_k^i = zeta_k X_k P_{eta(k)}^i X_k^{-1},
]
and its `\uses{}` list names the wrapper theorem used by the Lean proof, rather than the transitive sector-matching theorem.

Local validation:

- `git diff --check`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates a blueprint theorem statement/proof wiring to match the corresponding Lean theorem, without affecting executable code.
> 
> **Overview**
> Updates the blueprint statement of `thm:sector_bnt_proportional_global_gauge_of_coeff_identity` to explicitly include the unconditional per-sector gauge formula `Q_k^i=\zeta_k X_k P_{\beta(k)}^i X_k^{-1}` before assuming coefficient identities.
> 
> Adjusts the theorem’s `\uses{}` list and proof to reference the wrapper theorem `thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching`, making the blueprint’s dependency/proof narrative consistent with the Lean implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb1eedc9c67d99e53c74688b5e300ca3bfa36fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->