### PR TITLE
refactor(SectorBNT): drop raw copy-weight gauge wrapper

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -231,70 +231,11 @@ theorem sector_bnt_global_gauge_of_copy_weight_matching
   sector_bnt_global_gauge_of_matched_weights
     (P := P) (Q := Q) β hDim W.copy_equiv ζ Xblock hζ_ne hConj W.weight_eq
 
-/-- **Conditional proportional global gauge from matched copy weights.**
-
-For proportional MPV families, the proportional sector-matching theorem supplies
-the matched BNT basis, unit phases, and block gauges of CPSV16 Appendix MPV
-theorem statement, lines 1167--1170, and Appendix MPV proof, line 1182. If the
-remaining coefficient-comparison step supplies copy permutations whose weights
-obey the same phases, then the direct-sum gauge assembly uses the same algebra
-as the equal-MPV corollary in CPSV16 Appendix MPV proof, lines 1189--1192.
-
-This theorem isolates the exact residual input for the proportional
-global-gauge upgrade: the copy-weight identity. That residual input is not
-provided by the CPSV16 proportional theorem; Appendix MPV proof,
-lines 1187--1192, prove the equal-MPV corollary, where the length-dependent
-proportionality scalar is identically one. -/
-theorem ft_sector_bnt_proportional_global_gauge_of_weight_data
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
-    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
-    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
-      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
-      (ζ : Fin Q.basisCount → ℂ)
-      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
-      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
-      (∀ (k : Fin Q.basisCount) (i : Fin d),
-        Q.basis k i =
-          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
-            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
-            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
-              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
-      ∀ (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))),
-        (∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
-          Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ k q)) →
-        ∃ X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ,
-          X = globalGaugeOfBlocks (matched_block_gauge (Q := Q) Xblock) ∧
-          ∀ i : Fin d,
-            toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis i =
-              (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-                (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
-                toTensorFromBlocks (d := d)
-                  (μ := matched_p_weight (P := P) (Q := Q) β τ)
-                  (matched_p_basis (P := P) (Q := Q) β hDim) i *
-                (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
-                  Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-                    (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
-  classical
-  obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, _hMpv⟩ :=
-    ft_sector_bnt_proportional_sector_match_witnesses
-      (P := P) (Q := Q) hP hQ hUnitP hUnitQ hProp
-  refine ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ?_⟩
-  intro τ hWeight
-  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
-    intro k hzero
-    have hnorm := hζ_norm k
-    simp [hzero] at hnorm
-  exact sector_bnt_global_gauge_of_matched_weights
-    (P := P) (Q := Q) β hDim τ ζ Xblock hζ_ne hConj hWeight
-
 /-- **Conditional proportional global gauge from a copy-weight matching.**
 
-This reformulates `ft_sector_bnt_proportional_global_gauge_of_weight_data` with
-the remaining copy-weight comparison recorded as a single
-`SectorBNTCopyWeightMatching` input.
+This records the remaining copy-weight comparison as a single
+`SectorBNTCopyWeightMatching` input, instead of exposing separate copy
+permutations and pointwise identities as separate hypotheses.
 
 The theorem therefore separates the two mathematical ingredients:
 
@@ -335,12 +276,17 @@ theorem ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching
                   Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
                     (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
   classical
-  obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, hAssemble⟩ :=
-    ft_sector_bnt_proportional_global_gauge_of_weight_data
+  obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, _hMpv⟩ :=
+    ft_sector_bnt_proportional_sector_match_witnesses
       (P := P) (Q := Q) hP hQ hUnitP hUnitQ hProp
   refine ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ?_⟩
   intro W
-  exact hAssemble W.copy_equiv W.weight_eq
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
+    intro k hzero
+    have hnorm := hζ_norm k
+    simp [hzero] at hnorm
+  exact sector_bnt_global_gauge_of_copy_weight_matching
+    (P := P) (Q := Q) β hDim ζ Xblock hζ_ne hConj W
 
 /-- **Conditional proportional global gauge from coefficient identities.**
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1463,53 +1463,6 @@ matching covers the whole BNT basis.
     Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
 \end{proof}
 
-\begin{theorem}[Conditional proportional global gauge from copy weights]%
-    \label{thm:sector_bnt_proportional_global_gauge_of_weight_data}
-    \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_weight_data}
-    \leanok
-    \uses{thm:sector_bnt_proportional_sector_match_witnesses,
-        thm:sector_bnt_global_gauge_of_matched_weights}
-    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
-    eventually nonzero proportional MPV families. Assume that every sector of
-    $P$ and every sector of $Q$ has at least one copy weight of modulus $1$.
-    Then there are a bijection $\beta:J(Q)\simeq J(P)$, bond-dimension
-    equalities, unit-modulus phases $\zeta_k$, and block gauges $X_k$ such
-    that
-    \[
-        Q_k^i=\zeta_k X_kP_{\beta(k)}^iX_k^{-1}.
-    \]
-    Moreover, if copy permutations $\tau_k$ satisfy
-    \[
-        \nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)},
-    \]
-    then the flattened $Q$-tensor is obtained from the matched-coordinate
-    $P$-tensor by the block-diagonal gauge
-    \[
-        X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
-    \]
-    Thus, after the remaining proportional coefficient comparison supplies
-    the displayed copy-weight identities, the direct-sum gauge assembly uses
-    the same algebra as the equal-MPV corollary in
-    \cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}.
-    The source proportional theorem itself stops at the sector matching in
-    \cite[Appendix MPV theorem statement, lines~1167--1170]
-        {Cirac2017MPDO_AnnPhys} and
-    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys};
-    the coefficient-comparison passage at
-    \cite[Appendix MPV proof, lines~1187--1192]{Cirac2017MPDO_AnnPhys}
-    does not supply the missing proportional coefficient comparison, because
-    in the equal-MPV corollary the length-dependent proportionality scalar is
-    identically~$1$.
-\end{theorem}
-
-\begin{proof}\leanok
-    The proportional sector-matching theorem supplies $\beta$, the
-    bond-dimension equalities, the phases, and the block gauges. The
-    unit-modulus conclusion gives nonzero phases. With the displayed
-    copy-weight identities as input, apply
-    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
-\end{proof}
-
 \begin{theorem}[Conditional proportional global gauge from a copy-weight matching]%
     \label{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
     \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching}


### PR DESCRIPTION
This PR removes the now-redundant raw copy-weight proportional gauge wrapper after PRs #1952, #1955, and #1956 introduced the structured `SectorBNTCopyWeightMatching` route.

Mathematically, the public proportional path now has one residual-input shape: a copy-weight matching, or the coefficient identities that construct it. The deleted theorem exposed the same residual input as separate copy permutations and pointwise weight equations; it duplicated the structured theorem without adding a paper step.

Changes:

- Delete `MPSTensor.ft_sector_bnt_proportional_global_gauge_of_weight_data`.
- Prove `MPSTensor.ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching` directly from the proportional sector-matching witnesses and `sector_bnt_global_gauge_of_copy_weight_matching`.
- Remove the corresponding Chapter 10 blueprint entry.

Local validation:

- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean`
- `lake env lean TNLean.lean`
- `lake exe lint_style --github`
- `git diff --check`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in theorem packaging/proofs: it removes a redundant wrapper theorem and rewires an existing proportional gauge result to use the structured `SectorBNTCopyWeightMatching` input, with no change to underlying algebraic lemmas.
> 
> **Overview**
> Removes the redundant proportional-gauge wrapper `ft_sector_bnt_proportional_global_gauge_of_weight_data`, which previously exposed the residual proportional input as explicit copy permutations plus pointwise weight equalities.
> 
> Updates `ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching` to be proved directly from `ft_sector_bnt_proportional_sector_match_witnesses` and `sector_bnt_global_gauge_of_copy_weight_matching`, making `SectorBNTCopyWeightMatching` the single public “remaining input” shape for the proportional global-gauge upgrade.
> 
> Deletes the corresponding theorem entry from the Chapter 10 blueprint, keeping documentation aligned with the structured matching route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeef8b3acb4eb423f77e16442e25de8b430c7e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->