### PR TITLE
feat(canonical): record PGVWC07 projective weight normalization

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -33,6 +33,7 @@ The imported modules provide the original public declarations:
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`
 * `MPSTensor.exists_pgvwc07_positiveLengthWitness`
 * `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization`
+* `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -20,8 +20,12 @@ coefficient.
 
 The remaining source-facing boundary is not the finite maximum argument, but
 the state-equivalence convention under which the global length-dependent
-scalar is harmless.  This boundary is recorded in
+scalar is treated as a projective normalization.  This boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
+
+The projective formulation below makes that convention explicit: after the
+maximum normalization, the original tensor and the normalized weighted block
+tensor are `NonzeroProportionalMPV₂`.
 -/
 
 namespace MPSTensor
@@ -113,5 +117,57 @@ theorem PGVWC07PositiveLengthWitness.exists_weight_normalization
             mpv (toTensorFromBlocks (d := d) (μ := ν) W.blocks) σ :=
           mpv_toTensorFromBlocks_weight_mul_left (d := d) (c := (scale : ℂ))
             (μ := ν) W.blocks σ
+
+/-- Normalized positive weights give the same projective finite-ring state
+family.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof
+lines 765--766, treats the spectral-radius normalization as a convention on the
+state family.  After the finite maximum normalization above, exact coefficients
+are multiplied by the global factor `scale ^ N` at positive length.  This
+theorem records the corresponding projective statement using
+`NonzeroProportionalMPV₂`: the proportionality scalar is nonzero at every
+length. -/
+theorem PGVWC07PositiveLengthWitness.exists_weight_normalization_projective
+    {A : MPSTensor d D} (W : PGVWC07PositiveLengthWitness (d := d) (D := D) A)
+    (hr : 0 < W.r) :
+    ∃ (scale : ℝ) (ν : Fin W.r → ℂ),
+      0 < scale ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
+      (∀ k, ‖ν k‖ ≤ 1) ∧
+      (∃ k, ‖ν k‖ = 1) ∧
+      (∀ k, W.weights k = (scale : ℂ) * ν k) ∧
+      NonzeroProportionalMPV₂ A (toTensorFromBlocks (d := d) (μ := ν) W.blocks) := by
+  classical
+  obtain ⟨scale, ν, hscale_pos, hν_pos, hν_le, hν_unit, hweight, hMPV⟩ :=
+    W.exists_weight_normalization hr
+  refine ⟨scale, ν, hscale_pos, hν_pos, hν_le, hν_unit, hweight, ?_⟩
+  have htotal_pos : 0 < ∑ k : Fin W.r, W.dim k := by
+    let k0 : Fin W.r := ⟨0, hr⟩
+    have hle : W.dim k0 ≤ ∑ k : Fin W.r, W.dim k :=
+      Finset.single_le_sum (fun _ _ => Nat.zero_le _) (by simp)
+    exact lt_of_lt_of_le (W.dim_pos k0) hle
+  have htotal_ne : ((∑ k : Fin W.r, W.dim k : ℕ) : ℂ) ≠ 0 := by
+    exact_mod_cast Nat.ne_of_gt htotal_pos
+  have hD_pos : 0 < D := lt_of_lt_of_le htotal_pos W.bondDim_le
+  have hD_ne : (D : ℂ) ≠ 0 := by
+    exact_mod_cast Nat.ne_of_gt hD_pos
+  intro N
+  by_cases hN : N = 0
+  · subst N
+    refine ⟨(D : ℂ) / ((∑ k : Fin W.r, W.dim k : ℕ) : ℂ),
+      div_ne_zero hD_ne htotal_ne, fun σ => ?_⟩
+    calc
+      mpv A σ = (D : ℂ) := mpv_zero_length A σ
+      _ = ((D : ℂ) / ((∑ k : Fin W.r, W.dim k : ℕ) : ℂ)) *
+            ((∑ k : Fin W.r, W.dim k : ℕ) : ℂ) := by
+              field_simp [htotal_ne]
+      _ = ((D : ℂ) / ((∑ k : Fin W.r, W.dim k : ℕ) : ℂ)) *
+            mpv (toTensorFromBlocks (d := d) (μ := ν) W.blocks) σ := by
+              simp
+  · have hNpos : 0 < N := Nat.pos_of_ne_zero hN
+    refine ⟨(scale : ℂ) ^ N, pow_ne_zero N ?_, fun σ => ?_⟩
+    · exact Complex.ofReal_ne_zero.mpr (ne_of_gt hscale_pos)
+    · exact hMPV N hNpos σ
 
 end MPSTensor

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1045,6 +1045,37 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left}.
 \end{proof}
 
+\begin{theorem}[Projective form of PGVWC07 weight normalization]%
+    \label{thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        def:nonzero_proportional_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization}
+    Let a positive-length PGVWC07 canonical-form witness have at least one
+    block.  After dividing the positive real weights by their largest value,
+    the normalized weights $\nu_k$ are positive real numbers, satisfy
+    $|\nu_k|\leq 1$ for all $k$, and satisfy $|\nu_{k_0}|=1$ for some block
+    $k_0$.  Moreover the original tensor and the normalized
+    weighted block tensor generate nonzero proportional MPV families:
+    for every length $N$ there is a nonzero scalar $c_N$ such that
+    \[
+        \operatorname{MPV}_A(\sigma)
+        =
+        c_N\,
+        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_positive_length_witness_weight_normalization,
+        lem:mpv_zero_length}
+    For $N>0$, take $c_N=s^N$, which is nonzero because $s>0$.  For
+    $N=0$, use the length-zero MPV coefficient and the positive total
+    dimension of the nonzero blocks to choose the nonzero scalar relating the
+    two traces.
+\end{proof}
+
 \begin{theorem}[Existence of the positive-length PGVWC07 witness]%
     \label{thm:pgvwc07_positive_length_witness}
     \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -309,6 +309,17 @@ The earlier existence path now has the following formal pieces.
           records the resulting global factor \(s^N\) in length-\(N\) MPV
           coefficients.
 
+    \item
+          \path|MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective|
+          turns the preceding scalar-factor identity into the existing
+          projective MPV relation \leanid{NonzeroProportionalMPV₂}.
+          For positive lengths the proportionality scalar is \(s^N\), while at
+          length zero the scalar is the ratio between the original bond
+          dimension and the positive total dimension of the nonzero normalized
+          blocks.  Thus the maximum-normalized block tensor and the original
+          tensor determine the same nonzero projective finite-ring state family
+          whenever the witness has at least one block.
+
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an
@@ -348,12 +359,12 @@ theorem. The blueprint now records the source theorem as a separate not-ready
 statement, and the checked reductions are marked as partial or scoped results.
 After the positive-length witness theorem, the finite-family part of the
 paper's convention \(1\geq \lambda_j>0\) is now formalized for a nonempty
-witness by rescaling all positive weights by their maximum.  The remaining
-source-level point is to connect this scalar normalization with the precise
-state-equivalence convention under which PGVWC07 treats the spectral-radius
-normalization in Theorem~\texttt{Th:TIcanonical}, lines 765--766, as
-``without loss of generality'': exact finite-ring coefficients acquire the
-global factor \(s^N\).
+witness by rescaling all positive weights by their maximum.  The accompanying
+projective theorem records the state-equivalence convention under which
+PGVWC07 treats the spectral-radius normalization in
+Theorem~\texttt{Th:TIcanonical}, lines 765--766, as ``without loss of
+generality'': exact finite-ring coefficients acquire the global factor \(s^N\),
+and this is precisely a nonzero proportionality of MPV state vectors.
 
 \section{Formal boundary}
 
@@ -389,11 +400,13 @@ from an already prepared primitive or trace-preserving block family, because
 those hypotheses are not present in Theorem~\texttt{Th:TIcanonical}.
 
 At the current frontier, the block construction, nonempty-ring exact-MPV
-witness, and finite-family weight normalization are available.  The remaining
-formal work is to make explicit the precise state-equivalence relation under
-which the paper's spectral-radius renormalization is ``without loss of
-generality'', since the normalized exact-coefficient statement differs by the
-global factor \(s^N\).
+witness, finite-family weight normalization, and projective interpretation of
+the global scalar factor are available for nonempty witnesses.  The remaining
+formal work is to decide whether the final source-facing theorem should be
+stated in exact positive-length coefficients, in nonzero projective MPV
+families, or with an explicit zero-block/length-zero convention, and then to
+promote the corresponding statement as the theorem cited against
+Theorem~\texttt{Th:TIcanonical}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- add `PGVWC07PositiveLengthWitness.exists_weight_normalization_projective` for the PGVWC07 canonical-form witness
- show that maximum-normalized positive weights give a `NonzeroProportionalMPV₂` family, with scalar `scale ^ N` for positive length and the trace-dimension ratio at length zero
- update the canonical-form blueprint and the PGVWC07 scope note

This is canonical-form existence work for `Th:TIcanonical`; it does not assert a Fundamental Theorem or uniqueness statement.

Progress toward #1857.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean`
- `lake env lean TNLean.lean`
- `lake exe lint_style --github`
- `git diff --check`
- `leanblueprint web` (passes with the repository's usual local plasTeX and bibliography warnings)

`leanblueprint checkdecls` is not useful in this local worktree because the generated declaration list is absent and the repository currently has pre-existing global missing-declaration output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean theorem and documentation to restate an existing weight-normalization result in projective form, without changing existing logic or APIs beyond exporting the new declaration.
> 
> **Overview**
> Adds `PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`, strengthening the existing weight-max normalization result by packaging it as `NonzeroProportionalMPV₂` between the original tensor and the normalized weighted block tensor (handling *both* `N>0` via `scale^N` and `N=0` via a nonzero trace/dimension ratio).
> 
> Updates the `NormalReduction` umbrella module export list, and extends the blueprint and PGVWC07 scope note to document this new projective interpretation of the spectral-radius/weight normalization convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697cdae5e5cb938b3240032fb0de741a791be034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->