### PR TITLE
doc(BNT): trim coefficient design note

### DIFF
--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -14,13 +14,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 /-!
 # Basis of normal tensors from separated block hypotheses
 
-This module records the separated blockwise hypotheses used to pass from
-canonical-form and normal-canonical-form hypotheses to the basis-of-normal-tensors
-formulation. The source BNT expansion in arXiv:1606.00608, Section II keeps
-repeated copies inside a sector with coefficients `μ_{j,q}` and multiplicities
-`M_j`; that paper-faithful sector structure is represented by
-`IsBNTCanonicalForm` in the fundamental-theorem files. The results here are
-auxiliary tools for already separated finite block families.
+Separated blockwise hypotheses pass from canonical-form and
+normal-canonical-form hypotheses to the basis-of-normal-tensors formulation.
+The source BNT expansion in arXiv:1606.00608, Section II keeps repeated copies
+inside a sector with coefficients `μ_{j,q}` and multiplicities `M_j`; that
+paper-faithful sector structure is represented by `IsBNTCanonicalForm` in the
+fundamental-theorem files. The results here are auxiliary tools for already
+separated finite block families.
 
 ## Main results
 
@@ -44,12 +44,10 @@ auxiliary tools for already separated finite block families.
 
 In the full paper (arXiv:1606.00608, eq. decBSV), the decomposition into a basis of normal
 tensors uses summed coefficients `c_j(N) = Σ_{q in group j} μ_{j,q}^N`.
-In the strict-dominance branch one first normalizes by the dominant weight, so the relevant
-coefficients are `(μ j / μ 0)^N` and the discarded factor `μ 0^N` is absorbed into the overall
-proportionality constant. In the grouped setting, the normalized sums can still oscillate:
-unit-modulus terms may survive inside a single group. The source-faithful
-treatment of these coefficients is carried out in the sector-decomposition
-results and BNT canonical-form constructions.
+The results below concern already separated one-representative block families
+and do not perform the raw coefficient comparison for the two-layer BNT
+decomposition. That comparison is carried out for sector decompositions, where
+the sums `Σ_q μ_{j,q}^N` and their multiplicities remain visible.
 -/
 
 open scoped Matrix BigOperators


### PR DESCRIPTION
This PR trims the coefficient design note in `TNLean/MPS/BNT/Construction.lean` after the Chapter 10 strict-dominance detour was removed in #1959.

The note no longer describes a strict-dominance branch. It now states only the relevant distinction:

- this module concerns already separated one-representative block families;
- the raw two-layer BNT coefficient comparison belongs to the sector-decomposition surface, where the sums `Σ_q μ_{j,q}^N` remain visible.

No declarations or proofs change.

Local validation:

- `lake env lean TNLean/MPS/BNT/Construction.lean`
- `lake env lean TNLean.lean`
- `lake exe lint_style --github`
- `git diff --check`
- `rg -n "strict-dominance branch|strict dominance|coefficient convergence|dominant-weight|dominant weight" TNLean/MPS/BNT TNLean/MPS/FundamentalTheorem TNLean/MPS/CanonicalForm blueprint/src docs/paper-gaps`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `TNLean/MPS/BNT/Construction.lean` that remove obsolete discussion of a strict-dominance/coefficient-normalization branch; no definitions or proofs change.
> 
> **Overview**
> Updates the module header docs in `TNLean/MPS/BNT/Construction.lean` to **remove the outdated strict-dominance coefficient discussion** and reframe the coefficient note around the module’s actual scope (already separated, one-representative block families), pointing coefficient/multiplicity comparisons to the sector-decomposition results.
> 
> No Lean declarations, lemmas, or proofs are modified—only comment wording and formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c745e1759dbb682487f6b734f46440e01aabce46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->