### PR TITLE
feat(canonical): compose nonzero projective PGVWC07 form

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -34,6 +34,8 @@ The imported modules provide the original public declarations:
 * `MPSTensor.exists_pgvwc07_positiveLengthWitness`
 * `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization`
 * `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`
+* `MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`
+* `MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -28,7 +28,7 @@ maximum normalization, the original tensor and the normalized weighted block
 tensor are `NonzeroProportionalMPV₂`.
 -/
 
-open scoped Matrix BigOperators ComplexOrder MatrixOrder
+open scoped Matrix ComplexOrder
 
 namespace MPSTensor
 
@@ -203,8 +203,8 @@ theorem PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv
       _ = 0 := hblock
   exact hσ hAeq
 
-/-- Normalized projective PGVWC07 canonical-form data for a nonzero
-positive-length state family.
+/-- Normalized projective PGVWC07 canonical-form blocks and weights for a
+nonzero positive-length state family.
 
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
 742--763 and proof lines 765--766.  This theorem composes the arbitrary-input

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -28,6 +28,8 @@ maximum normalization, the original tensor and the normalized weighted block
 tensor are `NonzeroProportionalMPV₂`.
 -/
 
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+
 namespace MPSTensor
 
 variable {d D : ℕ}
@@ -169,5 +171,79 @@ theorem PGVWC07PositiveLengthWitness.exists_weight_normalization_projective
     refine ⟨(scale : ℂ) ^ N, pow_ne_zero N ?_, fun σ => ?_⟩
     · exact Complex.ofReal_ne_zero.mpr (ne_of_gt hscale_pos)
     · exact hMPV N hNpos σ
+
+/-- A nonzero positive-length MPV coefficient forces the PGVWC07 witness to
+have at least one block.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
+742--763, describes the nonzero canonical-form blocks.  In the positive-length
+witness, an empty block family would make the weighted nonzero-block tensor
+have zero positive-length MPV coefficients.  Thus a tensor with a nonzero
+positive-length coefficient has a nonempty witness. -/
+theorem PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv
+    {A : MPSTensor d D} (W : PGVWC07PositiveLengthWitness (d := d) (D := D) A)
+    (hA : ∃ (N : ℕ), 0 < N ∧ ∃ σ : Fin N → Fin d, mpv A σ ≠ 0) :
+    0 < W.r := by
+  classical
+  obtain ⟨N, hN, σ, hσ⟩ := hA
+  by_contra hnot
+  have hr0 : W.r = 0 := Nat.eq_zero_of_not_pos hnot
+  have hblock :
+      mpv (toTensorFromBlocks (d := d) (μ := W.weights) W.blocks) σ = 0 := by
+    haveI : IsEmpty (Fin W.r) := by
+      rw [hr0]
+      infer_instance
+    rw [mpv_toTensorFromBlocks_eq_sum]
+    simp
+  have hAeq : mpv A σ = 0 := by
+    calc
+      mpv A σ =
+          mpv (toTensorFromBlocks (d := d) (μ := W.weights) W.blocks) σ :=
+            W.sameMPV_pos N hN σ
+      _ = 0 := hblock
+  exact hσ hAeq
+
+/-- Normalized projective PGVWC07 canonical-form data for a nonzero
+positive-length state family.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
+742--763 and proof lines 765--766.  This theorem composes the arbitrary-input
+positive-length PGVWC07 witness with the projective weight normalization above.
+
+**Scope restriction:** The statement assumes that some positive-length MPV
+coefficient of the original tensor is nonzero.  This excludes the empty
+nonzero-block case and lets the normalization include a block of unit weight.
+The remaining source-facing choice for the unrestricted theorem is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
+theorem exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv
+    (A : MPSTensor d D)
+    (hA : ∃ (N : ℕ), 0 < N ∧ ∃ σ : Fin N → Fin d, mpv A σ ≠ 0) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ)
+      (ν : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      0 < r ∧
+      (∀ k,
+        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
+      (∀ k,
+        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          transferMap (d := d) (D := dim k) (blocks k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
+      (∀ k, ‖ν k‖ ≤ 1) ∧
+      (∃ k, ‖ν k‖ = 1) ∧
+      (∀ k, 0 < dim k) ∧
+      NonzeroProportionalMPV₂ A (toTensorFromBlocks (d := d) (μ := ν) blocks) ∧
+      ∑ k : Fin r, dim k ≤ D := by
+  classical
+  obtain ⟨W⟩ := exists_pgvwc07_positiveLengthWitness (d := d) (D := D) A
+  have hr : 0 < W.r := W.block_count_pos_of_exists_ne_zero_mpv hA
+  obtain ⟨_scale, ν, _hscale_pos, hν_pos, hν_le, hν_unit, _hweight, hMPV⟩ :=
+    W.exists_weight_normalization_projective hr
+  exact ⟨W.r, W.dim, ν, W.blocks, hr, W.dual_fixed, W.scalar_fixed, hν_pos,
+    hν_le, hν_unit, W.dim_pos, hMPV, W.bondDim_le⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1076,6 +1076,54 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     two traces.
 \end{proof}
 
+\begin{lemma}[Nonzero positive-length coefficient gives a nonempty PGVWC07 witness]%
+    \label{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:mpv_decomposition}
+    Let a positive-length PGVWC07 canonical-form witness for $A$ be given.
+    If some positive-length MPV coefficient of $A$ is nonzero, then the
+    witness has at least one block.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:mpv_decomposition}
+    If the block family were empty, the block-diagonal MPV expansion would be
+    an empty sum at every positive length.  The positive-length MPV equality in
+    the witness would then force all positive-length coefficients of $A$ to
+    vanish, contradicting the hypothesis.
+\end{proof}
+
+\begin{theorem}[Nonzero projective PGVWC07 normalized form]%
+    \label{thm:pgvwc07_nonzero_normalized_projective_form}
+    \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv}
+    \leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+    Suppose that some positive-length MPV coefficient of an MPS tensor $A$ is
+    nonzero.  Then $A$ has a nonempty finite family of nonzero PGVWC07 blocks
+    $C_k$ with positive normalized weights $\nu_k$ satisfying
+    $|\nu_k|\leq 1$ for all $k$ and $|\nu_{k_0}|=1$ for some block $k_0$.
+    Each block is in the unital orientation, has only scalar fixed points for
+    its transfer map, and has a diagonal positive-definite fixed point
+    $\Lambda_k$ for the dual transfer map.  Moreover the original tensor and
+    the normalized weighted block tensor generate nonzero proportional MPV
+    families, and the block dimensions satisfy $\sum_k D_k\leq D$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+    First use Theorem~\ref{thm:pgvwc07_positive_length_witness}.  The nonzero
+    positive-length coefficient makes the witness nonempty by
+    Lemma~\ref{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}.
+    Apply the projective weight-normalization theorem to this nonempty witness.
+\end{proof}
+
 \begin{theorem}[Existence of the positive-length PGVWC07 witness]%
     \label{thm:pgvwc07_positive_length_witness}
     \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -320,6 +320,24 @@ The earlier existence path now has the following formal pieces.
           tensor determine the same nonzero projective finite-ring state family
           whenever the witness has at least one block.
 
+    \item
+          \path|MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv|
+          proves that a positive-length witness is nonempty whenever the
+          original tensor has at least one nonzero positive-length MPV
+          coefficient.  If the block family were empty, the block-diagonal MPV
+          expansion would be an empty sum at every positive length, contradicting
+          the witness equality with the chosen nonzero coefficient.
+
+    \item
+          \path|MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv|
+          composes the arbitrary-input witness theorem with the preceding
+          nonemptiness lemma and the projective weight-normalization theorem.
+          Under the explicit nonzero positive-length MPV hypothesis, it gives
+          nonempty normalized PGVWC07 block data with \(|\nu_k|\leq 1\),
+          equality for one block, unital blocks, scalar fixed-point endpoints,
+          diagonal positive-definite dual fixed points, the nonzero projective
+          MPV relation, and the bound \(\sum_k D_k\leq D\).
+
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an
@@ -401,11 +419,13 @@ those hypotheses are not present in Theorem~\texttt{Th:TIcanonical}.
 
 At the current frontier, the block construction, nonempty-ring exact-MPV
 witness, finite-family weight normalization, and projective interpretation of
-the global scalar factor are available for nonempty witnesses.  The remaining
-formal work is to decide whether the final source-facing theorem should be
-stated in exact positive-length coefficients, in nonzero projective MPV
-families, or with an explicit zero-block/length-zero convention, and then to
-promote the corresponding statement as the theorem cited against
+the global scalar factor are available.  For tensors with at least one nonzero
+positive-length MPV coefficient, these pieces have been composed into a
+nonempty normalized projective PGVWC07 form.  The remaining formal work is to
+decide whether the unrestricted source-facing theorem should be stated in exact
+positive-length coefficients, in nonzero projective MPV families with a
+nonzero-state hypothesis, or with an explicit zero-block/length-zero convention,
+and then to promote the corresponding statement as the theorem cited against
 Theorem~\texttt{Th:TIcanonical}.
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
Progress toward #1857.

This PR adds the next scoped canonical-form existence step for PGVWC07. It does not restate or prove the Fundamental Theorem, and it is not the unrestricted source theorem.

Changes:
- prove that PGVWC07PositiveLengthWitness is nonempty when the original tensor has a nonzero positive-length MPV coefficient;
- compose the arbitrary-input positive-length witness, the nonemptiness lemma, and projective weight normalization to obtain nonempty normalized projective PGVWC07 block data;
- update Chapter 8 and the PGVWC07 scope note to record the precise remaining zero/length-zero convention issue.

Scope restriction:
- the new theorem assumes there is N > 0 and a word sigma with mpv A sigma nonzero;
- the remaining unrestricted source-facing theorem still needs the final choice between exact positive-length coefficients, nonzero projective MPV families with a nonzero-state hypothesis, or an explicit zero-block/length-zero convention.

Validation:
- lake build TNLean.MPS.CanonicalForm.NormalReduction.WeightNormalization
- lake build TNLean.MPS.CanonicalForm.NormalReduction
- lake build TNLean
- git diff --check
- lake exe lint_style --github
- leanblueprint web (passes with the usual local package/bibliography warnings)

Note: leanblueprint checkdecls could not run in this fresh worktree because the local command could not find blueprint/lean_decls; leanblueprint web also did not generate that file in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Lean theorems/lemmas and documentation about PGVWC07 canonical-form normalization without changing runtime behavior or existing APIs beyond additional exported statements.
> 
> **Overview**
> Adds a new scoped canonical-form step for PGVWC07 under the explicit hypothesis that **some positive-length MPV coefficient of `A` is nonzero**.
> 
> Formally proves that such a nonzero coefficient forces any `PGVWC07PositiveLengthWitness` to be **nonempty** (`block_count_pos_of_exists_ne_zero_mpv`), then composes witness existence with projective weight normalization to produce **nonempty normalized block data** with `‖ν k‖ ≤ 1` and `∃k, ‖ν k‖ = 1`, plus a `NonzeroProportionalMPV₂` relation (`exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`). Documentation/blueprint text is updated to record this scope restriction and the remaining zero/length-zero convention gap, and `NormalReduction.lean` re-exports the new declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0652b84af5b340d050e92e7279af2d90c4570149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->