### PR TITLE
feat(canonical): record PGVWC07 projective dichotomy

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -36,6 +36,7 @@ The imported modules provide the original public declarations:
 * `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`
 * `MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`
 * `MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`
+* `MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -246,4 +246,48 @@ theorem exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv
   exact ⟨W.r, W.dim, ν, W.blocks, hr, W.dual_fixed, W.scalar_fixed, hν_pos,
     hν_le, hν_unit, W.dim_pos, hMPV, W.bondDim_le⟩
 
+/-- Arbitrary-input zero/nonzero dichotomy for the projective PGVWC07
+canonical-form statement.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
+742--763 and proof lines 765--766.  This is a scope-separating wrapper around
+the nonzero positive-length theorem above: either all positive-length MPV
+coefficients vanish, or the tensor has a nonempty normalized projective
+PGVWC07 block form.
+
+**Scope restriction:** This is not the unrestricted source theorem.  It records
+the zero positive-length branch explicitly; the source-facing convention for
+the length-zero/all-zero case is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
+theorem exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero
+    (A : MPSTensor d D) :
+    (∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = 0) ∨
+    ∃ (r : ℕ) (dim : Fin r → ℕ)
+      (ν : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      0 < r ∧
+      (∀ k,
+        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
+      (∀ k,
+        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          transferMap (d := d) (D := dim k) (blocks k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
+      (∀ k, ‖ν k‖ ≤ 1) ∧
+      (∃ k, ‖ν k‖ = 1) ∧
+      (∀ k, 0 < dim k) ∧
+      NonzeroProportionalMPV₂ A (toTensorFromBlocks (d := d) (μ := ν) blocks) ∧
+      ∑ k : Fin r, dim k ≤ D := by
+  classical
+  by_cases hA : ∃ (N : ℕ), 0 < N ∧ ∃ σ : Fin N → Fin d, mpv A σ ≠ 0
+  · exact Or.inr (exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv A hA)
+  · refine Or.inl ?_
+    intro N hN σ
+    by_contra hσ
+    exact hA ⟨N, hN, σ, hσ⟩
+
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -250,7 +250,7 @@ theorem exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv
 canonical-form statement.
 
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-742--763 and proof lines 765--766.  This is a scope-separating wrapper around
+742--763 and proof lines 765--766.  This is a scope-separating formulation of
 the nonzero positive-length theorem above: either all positive-length MPV
 coefficients vanish, or the tensor has a nonempty normalized projective
 PGVWC07 block form.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1124,6 +1124,23 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     Apply the projective weight-normalization theorem to this nonempty witness.
 \end{proof}
 
+\begin{theorem}[Zero/nonzero dichotomy for projective PGVWC07 form]%
+    \label{thm:pgvwc07_projective_form_zero_nonzero_dichotomy}
+    \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero}
+    \leanok
+    \uses{thm:pgvwc07_nonzero_normalized_projective_form}
+    For every MPS tensor $A$, either every positive-length MPV coefficient of
+    $A$ is zero, or $A$ has the nonempty normalized projective PGVWC07 form of
+    Theorem~\ref{thm:pgvwc07_nonzero_normalized_projective_form}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_nonzero_normalized_projective_form}
+    If some positive-length coefficient is nonzero, apply
+    Theorem~\ref{thm:pgvwc07_nonzero_normalized_projective_form}.  Otherwise,
+    every positive-length coefficient is zero.
+\end{proof}
+
 \begin{theorem}[Existence of the positive-length PGVWC07 witness]%
     \label{thm:pgvwc07_positive_length_witness}
     \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -338,6 +338,13 @@ The earlier existence path now has the following formal pieces.
           diagonal positive-definite dual fixed points, the nonzero projective
           MPV relation, and the bound \(\sum_k D_k\leq D\).
 
+    \item
+          \path|MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero|
+          records the arbitrary-input zero/nonzero dichotomy for this
+          projective formulation.  Either all positive-length MPV coefficients
+          of the original tensor vanish, or the preceding nonempty normalized
+          projective PGVWC07 form exists.
+
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an
@@ -421,7 +428,9 @@ At the current frontier, the block construction, nonempty-ring exact-MPV
 witness, finite-family weight normalization, and projective interpretation of
 the global scalar factor are available.  For tensors with at least one nonzero
 positive-length MPV coefficient, these pieces have been composed into a
-nonempty normalized projective PGVWC07 form.  The remaining formal work is to
+nonempty normalized projective PGVWC07 form.  There is also an arbitrary-input
+dichotomy separating this nonzero case from the case in which every
+positive-length MPV coefficient vanishes.  The remaining formal work is to
 decide whether the unrestricted source-facing theorem should be stated in exact
 positive-length coefficients, in nonzero projective MPV families with a
 nonzero-state hypothesis, or with an explicit zero-block/length-zero convention,


### PR DESCRIPTION
Progress toward #1857.

This PR adds a small arbitrary-input wrapper around the scoped PGVWC07 projective canonical-form theorem merged in #1961.

Changes:
- add `MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`;
- the theorem states that for every tensor, either all positive-length MPV coefficients vanish, or the nonempty normalized projective PGVWC07 form exists;
- update Chapter 8 and the PGVWC07 paper-gap note to record this as a zero/nonzero boundary theorem.

Scope:
- this is canonical-form existence progress only;
- it does not prove the unrestricted PGVWC07 `Th:TIcanonical` source theorem;
- it keeps the zero positive-length branch explicit, so the remaining source-facing choice is still the exact all-zero/length-zero convention.

Validation:
- `lake build TNLean.MPS.CanonicalForm.NormalReduction.WeightNormalization`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction`
- `git diff --check`
- `lake exe lint_style --github`
- `leanblueprint web` (passes with the usual local package/bibliography warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small wrapper theorem that splits the projective PGVWC07 canonical-form result into an explicit all-zero vs nonzero-positive-length branch, plus documentation updates; no existing proofs/definitions are refactored.
> 
> **Overview**
> Introduces `MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`, an arbitrary-input dichotomy theorem: **either** all positive-length `mpv` coefficients of `A` vanish **or** `A` admits the existing nonempty normalized projective PGVWC07 block form.
> 
> Updates the `NormalReduction` public statement list and extends the blueprint (Chapter 8) and the PGVWC07 scope note to document this new zero/nonzero boundary result and its intended scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4782f5d86b2725b5f3a49970844bb4c819503444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->