### PR TITLE
feat(canonical): record exact rescaled PGVWC07 form

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -36,6 +36,7 @@ The imported modules provide the original public declarations:
 * `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`
 * `MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`
 * `MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`
+* `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`
 * `MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -246,6 +246,68 @@ theorem exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv
   exact ⟨W.r, W.dim, ν, W.blocks, hr, W.dual_fixed, W.scalar_fixed, hν_pos,
     hν_le, hν_unit, W.dim_pos, hMPV, W.bondDim_le⟩
 
+/-- Normalized PGVWC07 canonical-form blocks with exact positive-length MPV
+equality after the global tensor rescaling.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof
+lines 765--766, says that the spectral radius may be normalized without loss
+of generality.  This theorem records the exact-coefficient version of that
+convention: for a tensor with a nonzero positive-length MPV coefficient, the
+finite positive weights may be divided by their maximum, and the original
+tensor may be divided by the same positive scalar.  After this global tensor
+rescaling, the normalized block tensor has exactly the same positive-length MPV
+coefficients. -/
+theorem exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv
+    (A : MPSTensor d D)
+    (hA : ∃ (N : ℕ), 0 < N ∧ ∃ σ : Fin N → Fin d, mpv A σ ≠ 0) :
+    ∃ (scale : ℝ) (r : ℕ) (dim : Fin r → ℕ)
+      (ν : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      0 < scale ∧
+      0 < r ∧
+      (∀ k,
+        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
+      (∀ k,
+        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          transferMap (d := d) (D := dim k) (blocks k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
+      (∀ k, ‖ν k‖ ≤ 1) ∧
+      (∃ k, ‖ν k‖ = 1) ∧
+      (∀ k, 0 < dim k) ∧
+      SameMPV₂Pos
+        (fun i => (((scale : ℂ)⁻¹) • A i))
+        (toTensorFromBlocks (d := d) (μ := ν) blocks) ∧
+      ∑ k : Fin r, dim k ≤ D := by
+  classical
+  obtain ⟨W⟩ := exists_pgvwc07_positiveLengthWitness (d := d) (D := D) A
+  have hr : 0 < W.r := W.block_count_pos_of_exists_ne_zero_mpv hA
+  obtain ⟨scale, ν, hscale_pos, hν_pos, hν_le, hν_unit, _hweight, hMPV⟩ :=
+    W.exists_weight_normalization hr
+  have hscale_ne : (scale : ℂ) ≠ 0 := by
+    exact_mod_cast (ne_of_gt hscale_pos)
+  refine ⟨scale, W.r, W.dim, ν, W.blocks, hscale_pos, hr, W.dual_fixed,
+    W.scalar_fixed, hν_pos, hν_le, hν_unit, W.dim_pos, ?_, W.bondDim_le⟩
+  intro N hN σ
+  have hpow : ((scale : ℂ) ^ N)⁻¹ * (scale : ℂ) ^ N = 1 := by
+    simp [pow_ne_zero N hscale_ne]
+  calc
+    mpv (fun i => (((scale : ℂ)⁻¹) • A i)) σ
+        = ((scale : ℂ)⁻¹) ^ N * mpv A σ := mpv_smul ((scale : ℂ)⁻¹) A σ
+    _ = ((scale : ℂ)⁻¹) ^ N *
+          ((scale : ℂ) ^ N *
+            mpv (toTensorFromBlocks (d := d) (μ := ν) W.blocks) σ) := by
+        rw [hMPV N hN σ]
+    _ = (((scale : ℂ)⁻¹) ^ N * (scale : ℂ) ^ N) *
+          mpv (toTensorFromBlocks (d := d) (μ := ν) W.blocks) σ := by
+        ring
+    _ = mpv (toTensorFromBlocks (d := d) (μ := ν) W.blocks) σ := by
+        simp [hpow]
+
 /-- Arbitrary-input zero/nonzero dichotomy for the projective PGVWC07
 canonical-form statement.
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1124,6 +1124,37 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     Apply the projective weight-normalization theorem to this nonempty witness.
 \end{proof}
 
+\begin{theorem}[Exact normalized PGVWC07 form after global rescaling]%
+    \label{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv}
+    \leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization}
+    Suppose that some positive-length MPV coefficient of an MPS tensor \(A\) is
+    nonzero.  Then there is a positive scalar \(s\) and a nonempty finite family
+    of PGVWC07 blocks \(C_k\) with positive normalized weights \(\nu_k\)
+    satisfying \(|\nu_k|\leq 1\) for all \(k\) and
+    \(|\nu_{k_0}|=1\) for some block \(k_0\).  Each block is in the unital
+    orientation, has only scalar fixed points for its transfer map, and has a
+    diagonal positive-definite fixed point for the dual transfer map.  Moreover
+    the globally rescaled tensor \(s^{-1}A\) and the normalized weighted block
+    tensor have the same positive-length MPV coefficients, and the block
+    dimensions satisfy \(\sum_k D_k\leq D\).
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization}
+    Start from the positive-length witness and use the nonzero coefficient to
+    make the block family nonempty.  Divide the positive weights by their
+    maximum.  The exact coefficient identity for \(A\) contains the global
+    factor \(s^N\) at length \(N\); applying the scalar rescaling \(s^{-1}\) to
+    every matrix of \(A\) contributes the factor \(s^{-N}\), so the two factors
+    cancel at every positive length.
+\end{proof}
+
 \begin{theorem}[Zero/nonzero dichotomy for projective PGVWC07 form]%
     \label{thm:pgvwc07_projective_form_zero_nonzero_dichotomy}
     \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1146,7 +1146,8 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
 \begin{proof}\leanok
     \uses{thm:pgvwc07_positive_length_witness,
         lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization}
+        thm:pgvwc07_positive_length_witness_weight_normalization,
+        lem:mpv_smul}
     Start from the positive-length witness and use the nonzero coefficient to
     make the block family nonempty.  Divide the positive weights by their
     maximum.  The exact coefficient identity for \(A\) contains the global

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1137,10 +1137,11 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     satisfying \(|\nu_k|\leq 1\) for all \(k\) and
     \(|\nu_{k_0}|=1\) for some block \(k_0\).  Each block is in the unital
     orientation, has only scalar fixed points for its transfer map, and has a
-    diagonal positive-definite fixed point for the dual transfer map.  Moreover
-    the globally rescaled tensor \(s^{-1}A\) and the normalized weighted block
-    tensor have the same positive-length MPV coefficients, and the block
-    dimensions satisfy \(\sum_k D_k\leq D\).
+    diagonal positive-definite fixed point for the dual transfer map.  Each
+    block has positive bond dimension.  Moreover the globally rescaled tensor
+    \(s^{-1}A\) and the normalized weighted block tensor have the same
+    positive-length MPV coefficients, and the block dimensions satisfy
+    \(\sum_k D_k\leq D\).
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -339,6 +339,18 @@ The earlier existence path now has the following formal pieces.
           MPV relation, and the bound \(\sum_k D_k\leq D\).
 
     \item
+          \path|MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv|
+          records the exact-coefficient counterpart of the preceding
+          projective theorem.  Under the same nonzero positive-length MPV
+          hypothesis, it produces a positive scalar \(s\) and normalized
+          weights \(|\nu_k|\leq 1\), with equality for one block, such that the
+          globally rescaled tensor \(s^{-1}A\) has exactly the same
+          positive-length MPV coefficients as the normalized weighted block
+          tensor.  This formalizes the exact finite-ring effect of the
+          ``without loss of generality'' spectral-radius normalization in
+          Theorem~\texttt{Th:TIcanonical}, lines 765--766.
+
+    \item
           \path|MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero|
           records the arbitrary-input zero/nonzero dichotomy for this
           projective formulation.  Either all positive-length MPV coefficients


### PR DESCRIPTION
## Summary
- add the exact positive-length PGVWC07 normalized form after global tensor rescaling
- keep the statement on the canonical-form existence path: normalized weights have modulus at most one, one has modulus one, and the rescaled original tensor has exact positive-length MPV equality with the normalized block tensor
- record the new theorem in Chapter 8 and the PGVWC07 paper-gap audit

## Scope
This is not a Fundamental-Theorem or uniqueness step. It formalizes the finite-ring effect of the spectral-radius normalization convention in PGVWC07 Th:TIcanonical, proof lines 765--766, for the already established positive-length witness.

## Validation
- lake env lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
- lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean
- lake build TNLean.MPS.CanonicalForm.NormalReduction
- lake exe lint_style --github
- git diff --check
- cd blueprint && leanblueprint web
- cd blueprint && leanblueprint checkdecls (expected local failure: blueprint/lean_decls is absent)

Closes part of #1857.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean theorem and corresponding documentation/audit entries without changing existing behavior or interfaces beyond exposing an additional public declaration.
> 
> **Overview**
> Adds `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`, an **exact-coefficient** counterpart to the existing projective PGVWC07 normalization: after normalizing weights by their maximum, globally rescaling the original tensor by `scale⁻¹` yields *exact* equality of all positive-length MPV coefficients with the normalized weighted block tensor.
> 
> Updates the public `NormalReduction` import-path docs plus the blueprint Chapter 8 and the PGVWC07 scope/audit notes to reference and explain this new “global rescaling cancels `scale^N`” result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510405697599f4340d01cf7a48df8d36b620240a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->