### PR TITLE
doc(bnt): remove norm-class collapse detour

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -155,32 +155,6 @@ and~\cite{Cirac2021Matrix}.
     their coefficients, multiplicities, and gauges.
 \end{definition}
 
-\begin{lemma}[Restricted norm-class collapse]
-    \label{lem:restricted_norm_class_collapse_bnt}
-    \uses{def:mpv}
-    Let $(\mu_k, A_k)_{k=1}^r$ be a weighted block family with
-    $\mu_k \neq 0$ for every $k$. Assume that whenever
-    $\|\mu_j\| = \|\mu_k\|$, the tensors $A_j$ and $A_k$ generate the
-    same MPV family. Then one can regroup the blocks into a sector
-    decomposition whose associated total tensor generates the same MPV family
-    as $\bigoplus_k \mu_k A_k$, and whose sector-weight norms are strictly
-    decreasing. This is a special-case regrouping lemma, not the full BNT
-    characterization of \cite[Section~2.3]{Cirac2016MPDO_arXiv}: the
-    hypothesis that equal-norm blocks already generate the same MPV family is
-    an assumption here, while the source BNT construction chooses a minimal family
-    of representatives for the phase-gauge equivalence classes of normal
-    blocks.
-\end{lemma}
-
-\begin{proof}
-    Order the distinct norms of the weights in decreasing order, choose one
-    representative block from each norm class, and retain the multiplicities
-    inside each class as sector copies. The equal-MPV hypothesis lets every
-    block in a class be replaced by the chosen representative, so the regrouped
-    decomposition has the same MPV family. By construction, the sector-weight
-    norms are strictly decreasing.
-\end{proof}
-
 \begin{theorem}[Cross-overlap decay from explicit BNT hypotheses]
     \label{thm:cross_overlap_zero_split}
     \lean{MPSTensor.cross_overlap_tendsto_zero_of_separated_bnt_data}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1008,10 +1008,6 @@ statements are collected in Chapter~\ref{ch:algebraic_ft}.
     so the gauge phase must have modulus one.
 \end{proof}
 
-\begin{remark}
-    See Lemma~\ref{lem:restricted_norm_class_collapse_bnt} for the formalized restricted norm-class collapse statement.
-\end{remark}
-
 \begin{theorem}[Existential BNT independence from overlap limits]%
     \label{thm:bnt_li_from_overlap_limits_exists}
     \lean{MPSTensor.exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal}


### PR DESCRIPTION
## Summary
- remove the unformalized restricted norm-class collapse lemma from Chapter 10
- remove the only Chapter 11 remark that referred to it as formalized
- keep the BNT blueprint focused on the active explicit separated-block hypotheses and SectorBNT coefficient route

## Validation
- `leanblueprint web`
- `git diff --check -- blueprint/src/chapter/ch10_bnt.tex blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edits that delete an unused lemma and a dangling cross-reference, without changing any Lean targets or mathematical statements used elsewhere.
> 
> **Overview**
> Removes the unformalized “restricted norm-class collapse” lemma (and its proof) from Chapter 10’s BNT discussion to keep the narrative focused on the explicit separated-block hypotheses.
> 
> Also deletes the Chapter 11 remark that pointed to that lemma as if it were formalized, eliminating a now-stale cross-reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dec2b3fe2a4fcddc8967813abe195d6af597082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->