### PR TITLE
feat(canonical): record exact rescaled PGVWC07 dichotomy

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -37,6 +37,7 @@ The imported modules provide the original public declarations:
 * `MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`
 * `MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`
+* `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`
 * `MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -308,6 +308,54 @@ theorem exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_m
     _ = mpv (toTensorFromBlocks (d := d) (μ := ν) W.blocks) σ := by
         simp [hpow]
 
+/-- Arbitrary-input zero/nonzero dichotomy for the exact rescaled PGVWC07
+canonical-form statement.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
+742--763 and proof lines 765--766.  This is the exact positive-length analogue
+of `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`:
+either every positive-length MPV coefficient vanishes, or, after a positive
+global rescaling of the original tensor, the normalized PGVWC07 block tensor
+has exactly the same positive-length MPV coefficients.
+
+**Scope restriction:** This theorem keeps the zero positive-length branch
+explicit and therefore does not remove the final length-zero convention needed
+for a source-facing unrestricted statement of PGVWC07 Theorem Th:TIcanonical. -/
+theorem exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero
+    (A : MPSTensor d D) :
+    (∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = 0) ∨
+    ∃ (scale : ℝ) (r : ℕ) (dim : Fin r → ℕ)
+      (ν : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      0 < scale ∧
+      0 < r ∧
+      (∀ k,
+        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
+      (∀ k,
+        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          transferMap (d := d) (D := dim k) (blocks k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
+      (∀ k, ‖ν k‖ ≤ 1) ∧
+      (∃ k, ‖ν k‖ = 1) ∧
+      (∀ k, 0 < dim k) ∧
+      SameMPV₂Pos
+        (fun i => (((scale : ℂ)⁻¹) • A i))
+        (toTensorFromBlocks (d := d) (μ := ν) blocks) ∧
+      ∑ k : Fin r, dim k ≤ D := by
+  classical
+  by_cases hA : ∃ (N : ℕ), 0 < N ∧ ∃ σ : Fin N → Fin d, mpv A σ ≠ 0
+  · exact Or.inr
+      (exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv A hA)
+  · refine Or.inl ?_
+    intro N hN σ
+    by_contra hσ
+    exact hA ⟨N, hN, σ, hσ⟩
+
 /-- Arbitrary-input zero/nonzero dichotomy for the projective PGVWC07
 canonical-form statement.
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1157,6 +1157,23 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     cancel at every positive length.
 \end{proof}
 
+\begin{theorem}[Zero/nonzero dichotomy for exact rescaled PGVWC07 form]%
+    \label{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
+    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero}
+    \leanok
+    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+    For every MPS tensor \(A\), either every positive-length MPV coefficient of
+    \(A\) is zero, or the exact rescaled normalized PGVWC07 form of
+    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form} exists.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+    If some positive-length coefficient is nonzero, apply
+    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}.  Otherwise,
+    every positive-length coefficient is zero.
+\end{proof}
+
 \begin{theorem}[Zero/nonzero dichotomy for projective PGVWC07 form]%
     \label{thm:pgvwc07_projective_form_zero_nonzero_dichotomy}
     \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -351,6 +351,15 @@ The earlier existence path now has the following formal pieces.
           Theorem~\texttt{Th:TIcanonical}, lines 765--766.
 
     \item
+          \path|MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero|
+          records the arbitrary-input zero/nonzero dichotomy for the exact
+          rescaled formulation.  Either all positive-length MPV coefficients of
+          the original tensor vanish, or the preceding exact rescaled normalized
+          PGVWC07 form exists.  This still keeps the zero positive-length branch
+          explicit and therefore does not by itself settle the final length-zero
+          convention for Theorem~\texttt{Th:TIcanonical}.
+
+    \item
           \path|MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero|
           records the arbitrary-input zero/nonzero dichotomy for this
           projective formulation.  Either all positive-length MPV coefficients
@@ -440,9 +449,10 @@ At the current frontier, the block construction, nonempty-ring exact-MPV
 witness, finite-family weight normalization, and projective interpretation of
 the global scalar factor are available.  For tensors with at least one nonzero
 positive-length MPV coefficient, these pieces have been composed into a
-nonempty normalized projective PGVWC07 form.  There is also an arbitrary-input
-dichotomy separating this nonzero case from the case in which every
-positive-length MPV coefficient vanishes.  The remaining formal work is to
+nonempty normalized projective PGVWC07 form and into an exact normalized form
+after a positive global rescaling of the original tensor.  There are also
+arbitrary-input dichotomies separating this nonzero case from the case in which
+every positive-length MPV coefficient vanishes.  The remaining formal work is to
 decide whether the unrestricted source-facing theorem should be stated in exact
 positive-length coefficients, in nonzero projective MPV families with a
 nonzero-state hypothesis, or with an explicit zero-block/length-zero convention,


### PR DESCRIPTION
## Summary

This PR adds the arbitrary-input zero/nonzero dichotomy for the exact rescaled PGVWC07 normalization theorem.

The new Lean declaration is:

- `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`

It states that for any MPS tensor \(A\), either every positive-length MPV coefficient of \(A\) vanishes, or the exact rescaled normalized PGVWC07 form from `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv` exists. In the nonzero branch, a positive scalar \(s\) rescales the original tensor so that \(s^{-1}A\) and the normalized weighted block tensor have the same positive-length MPV coefficients.

This is still canonical-form existence work only. It is not the PGVWC07 Fundamental-Theorem uniqueness statement `thm-uniq`, and it does not address #1529. The zero positive-length branch remains explicit, so the unrestricted source-facing convention for PGVWC07 `Th:TIcanonical` is still open.

## Files

- `TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`
- `TNLean/MPS/CanonicalForm/NormalReduction.lean`
- `blueprint/src/chapter/ch08_canonical.tex`
- `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction`
- `lake exe lint_style --github`
- `git diff --check`
- `cd blueprint && leanblueprint web`

Closes part of #1857.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean theorem and documentation references without changing existing definitions or computational behavior.
> 
> **Overview**
> Adds `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`, an arbitrary-input **zero/nonzero dichotomy** for the *exact rescaled* normalized PGVWC07 form: either all positive-length MPV coefficients vanish, or a positive global rescaling yields exact positive-length MPV agreement with the normalized weighted block tensor.
> 
> Updates the `NormalReduction` public export list and extends the blueprint and scope-audit docs to cite and explain the new dichotomy theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c666ebda0deaf0ff600cf31dac27edab056d969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->