### PR TITLE
doc(SectorBNT): make coefficient boundary prose self-contained

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CopyWeightMatching.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CopyWeightMatching.lean
@@ -36,7 +36,8 @@ of the matched `P`-sector, and the corresponding raw weights satisfy
 The proportional theorem in CPSV16 gives the sector matching at the theorem
 statement lines 1167--1170 and the Appendix MPV proof line 1182.  The
 coefficient comparison that constructs this copy-weight matching is the
-remaining proportional task recorded in issue #1749. -/
+remaining source-faithful input before the proportional global-gauge theorem
+can be obtained without an explicit coefficient-identity hypothesis. -/
 structure SectorBNTCopyWeightMatching {P Q : SectorDecomposition d}
     (β : Fin Q.basisCount ≃ Fin P.basisCount)
     (ζ : Fin Q.basisCount → ℂ) where

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
@@ -205,9 +205,9 @@ need not be supplied externally.  The unit-modulus witness at the
 chosen sector `j₀` is supplied externally because CPSV16 line 246 is
 **global** (the unit-modulus copy can sit in any sector); the
 structural field `weight_unit_exists` does not pin it to a specific
-sector.  Issue #1725 Phase A retired the auxiliary dominant-block
-structural field that previously fixed `j₀ = 0` and discharged the
-unit-modulus witness implicitly. -/
+sector.  Earlier dominant-sector formulations fixed `j₀ = 0` as structural
+data, but the paper-faithful surface keeps the chosen sector and its
+unit-modulus copy witness explicit. -/
 theorem exists_block_match_of_sameMPVPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -297,8 +297,10 @@ block gauges.  If those same phases satisfy the eventual matched-sector
 coefficient identities, then the matched-sector coefficient comparison recovers
 the copy-weight matching and the direct-sum global gauge follows.
 
-The coefficient identity is the precise remaining CPSV16 Appendix MPV
-line-1188 input for issue #1749. -/
+The coefficient identity is the precise remaining CPSV16 Appendix MPV line
+1188 input; until it is derived from the proportional MPV hypothesis, this
+theorem is a conditional assembly statement rather than the unrestricted
+source theorem. -/
 theorem ft_sector_bnt_proportional_global_gauge_of_coeff_identity
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)


### PR DESCRIPTION
## Summary

This PR makes three SectorBNT docstrings self-contained for readers who are not following the issue history.

- Replaces issue-number references in TNLean/MPS/FundamentalTheorem/SectorBNT/CopyWeightMatching.lean, TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean, and TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean with direct mathematical descriptions of the remaining CPSV16 coefficient-comparison boundary.
- Keeps the same source anchors: CPSV16 Appendix MPV proof line 1182 for sector matching, line 1188 for the coefficient input, and line 246 for the global unit-modulus normalization.
- Changes prose only; no theorem statements, definitions, or proofs are changed.

## Validation

- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/CopyWeightMatching.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
- lake exe lint_style --github
- git diff --check -- TNLean/MPS/FundamentalTheorem/SectorBNT/CopyWeightMatching.lean TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean

Progress on #1685 and #1749.