### PR TITLE
doc(SectorBNT): phrase coefficient path positively

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -27,7 +27,7 @@ Paper anchors:
 
 The argument is a direct full-basis coefficient comparison: after the BNT
 basis tensors have been matched, all remaining terms are expressed in the
-matched basis and separated by the eventual linear independence of that basis.
+same BNT basis tensor family and separated by its eventual linear independence.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -25,7 +25,9 @@ Paper anchors:
   lines 1864–1884: per-block BNT normalization that makes every sector
   participate in the full-basis matching.
 
-No `dropSector` recursion and no partial-union combined LI are used here.
+The argument is a direct full-basis coefficient comparison: after the BNT
+basis tensors have been matched, all remaining terms are expressed in the
+matched basis and separated by the eventual linear independence of that basis.
 -/
 
 open scoped Matrix BigOperators
@@ -241,8 +243,9 @@ an eventual exact coefficient identity
 `P.coeff N (β k) = ζ_k^N * Q.coeff N k`.
 
 This is the formal counterpart of CPSV16 Appendix MPV proof, line 1188's exact
-power-sum comparison; it deliberately avoids the unsound asymptotic-difference
-to full-multiset route noted in the multiplicity-audit memo. -/
+power-sum comparison.  The finite power-sum recovery of copy weights is a
+separate algebraic step, applied after these eventual coefficient identities
+have been obtained. -/
 theorem coeff_identity_via_global_gaugePos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -15,8 +15,8 @@ core examples have a single BNT basis sector (`basisCount = 1`):
 * **Example 1** — single sector, single copy: `weight = (1,)`.
 * **Example 2** — `C ⊕ (-C)`: single sector, two copies with raw weights
   `(1, -1)`; the coefficient is `1 + (-1)^N`, which is *not* a scalar
-  power.  This shows why the BNT surface keeps raw copy weights rather than
-  replacing a sector coefficient by one scalar power.
+  power.  This shows why `IsBNTCanonicalForm` records raw copy weights rather
+  than replacing a sector coefficient by one scalar power.
 * **Example 3** — `C ⊕ e^{iθ}C`: single sector, two copies with raw
   weights `(1, e^{iθ})`; the coefficient is `1 + e^{iNθ}`, illustrating
   equal-modulus grouping with a non-trivial phase.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -15,8 +15,8 @@ core examples have a single BNT basis sector (`basisCount = 1`):
 * **Example 1** — single sector, single copy: `weight = (1,)`.
 * **Example 2** — `C ⊕ (-C)`: single sector, two copies with raw weights
   `(1, -1)`; the coefficient is `1 + (-1)^N`, which is *not* a scalar
-  power.  This is the CPSV16 §II motivating example recorded in the
-  audit memo and in issue #1678.
+  power.  This shows why the BNT surface keeps raw copy weights rather than
+  replacing a sector coefficient by one scalar power.
 * **Example 3** — `C ⊕ e^{iθ}C`: single sector, two copies with raw
   weights `(1, e^{iθ})`; the coefficient is `1 + e^{iNθ}`, illustrating
   equal-modulus grouping with a non-trivial phase.
@@ -33,11 +33,10 @@ which fundamental-theorem theorems consume as an explicit hypothesis
 
 A fourth example exercises the **optional** equal-modulus layer
 `HasEqualModulusWeightLayer` on top of `signFlipDecomp`, demonstrating
-that the equal-modulus subclass is non-empty.  Following the audit
-counter-example `C ⊕ (1/2)C` (`audits/2026-05-13_cpsv16_sector_bnt_phase_1_multiplicity_audit.md`
-§Q4), the `halvedDecomp` construction below admits `IsBNTCanonicalForm`
-but does not admit `HasEqualModulusWeightLayer` (its two copies have
-unequal moduli, ruling out a single per-sector spectral level).
+that the equal-modulus subclass is non-empty.  The `halvedDecomp`
+construction below admits `IsBNTCanonicalForm` but does not admit
+`HasEqualModulusWeightLayer`: its two copies have unequal moduli, ruling out
+a single per-sector spectral level.
 
 Each example takes the per-block normality data (injectivity,
 irreducibility, left-canonical, self-overlap, eventual linear
@@ -136,8 +135,8 @@ lemma singletonDecomp_weight_unit_per_block (C : MPSTensor d D) :
 
 /-- **Example 2** — `C ⊕ (-C)`: a single BNT sector with two copies of
 raw weights `(1, -1)`.  The sector coefficient is `1 + (-1)^N`, which is
-*not* a scalar power; this is the motivating example of issue #1678 and
-the audit memo. -/
+*not* a scalar power.  This is the smallest example showing that a BNT sector
+must retain the raw copy weights in its coefficient. -/
 noncomputable example
     (C : MPSTensor d D) (hDpos : 0 < D)
     (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
@@ -208,7 +207,8 @@ phase. -/
 
 /-- **Example 3** — `C ⊕ e^{iθ}C`: a single BNT sector with two copies of
 raw weights `(1, e^{iθ})`.  The sector coefficient is `1 + e^{iNθ}`,
-illustrating equal-modulus grouping (CPSV16 §II / issue #1678). -/
+illustrating equal-modulus grouping in the CPSV16 two-layer BNT
+decomposition. -/
 noncomputable example
     (C : MPSTensor d D) (θ : ℝ) (hDpos : 0 < D)
     (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -30,9 +30,9 @@ Paper anchors:
   hypothesis here, not as a structural field of `IsBNTCanonicalForm`.
 
 The theorem below exposes the sector-level witnesses needed before assembling
-the global CPSV16 gauge `⊕_j (𝟙_{r_j} ⊗ Y_j)`.  It does not use
-`dropSector` recursion, partial-union combined LI, or asymptotic-difference
-multiset recovery.
+the global CPSV16 gauge `⊕_j (𝟙_{r_j} ⊗ Y_j)`.  The proof path is:
+full-basis matching, exact coefficient comparison, copy-weight recovery, and
+then the direct-sum gauge assembly.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -44,9 +44,9 @@ variable {d : ℕ}
 
 /-- The `P`-side copy weight transported into the flattened copy coordinates of `Q`.
 
-For a matched basis bijection `β : Fin Q.basisCount ≃ Fin P.basisCount` and
-per-block copy permutations `τ k`, this is the weight array appearing in the
-coordinate-level direct sum
+For a bijection `β : Fin Q.basisCount ≃ Fin P.basisCount` between BNT basis
+sectors and per-block copy permutations `τ k`, this is the weight array
+appearing in the coordinate-level direct sum
 `⊕_{(k,q)} P.weight (β k) (τ k q) • P.basis (β k)`.
 It is the Lean counterpart of the reindexing implicit in CPSV16 Appendix MPV
 proof, lines 1189–1192, before forming the global gauge


### PR DESCRIPTION
## Summary

This PR makes the SectorBNT prose describe the present CPSV16 proof path directly, rather than by contrast with discarded or issue-local routes.

- Rephrases the `CoeffIdentity.lean` and `Fundamental.lean` module docstrings around the full-basis coefficient comparison and direct-sum gauge path.
- Replaces issue-history references in `SectorBNT/Examples.lean` with the actual mathematical role of the examples: raw copy weights are needed because sector coefficients such as `1 + (-1)^N` need not be scalar powers, and `C ⊕ (1/2)C` shows the equal-modulus layer is optional.
- Changes prose only; no declarations or proofs are changed.

## Validation

- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
- lake exe lint_style --github
- git diff --check -- TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean

Progress on #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only wording updates in `SectorBNT` modules; no changes to definitions or proofs, so behavioral risk is minimal.
> 
> **Overview**
> Rephrases `SectorBNT` module prose to describe the CPSV16 proof path directly (full-basis coefficient comparison and direct-sum gauge assembly) rather than via contrast/issue-history framing.
> 
> Clarifies the motivation of the executable examples: raw copy weights are kept because sector coefficients like `1 + (-1)^N` are not scalar powers, and `C ⊕ (1/2)C` illustrates that the equal-modulus layer is optional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc902d59ed6e910fb8c7137f43ca392e0d15496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->