### PR TITLE
doc(SectorBNT): inline BNT counterexamples

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
@@ -283,20 +283,16 @@ theorem coeff_tendsto_zero_of_all_weights_subnorm
 
 /-- **Thermodynamic-limit non-vanishing of a unit-block coefficient.**
 
-A user-facing alias for `coeff_not_tendsto_zero_at_block`, named
-in the language of the audit memo
-`thermodynamic_limit_normalization_audit_2026-05-14` §Q-C: the
-CPSV16 §II.C line-246 normalization picks out the unit-modulus block(s)
-whose power-sum coefficient does **not** vanish in the thermodynamic
-limit.
+A user-facing alias for `coeff_not_tendsto_zero_at_block`.  The CPSV16
+§II.C line-246 normalization picks out the unit-modulus copies whose
+power-sum coefficient does **not** vanish in the thermodynamic limit.
 
-This is the coefficient form of the audit's "thermodynamic-limit
-non-vanishing" condition, with the per-block unit-modulus witness
-supplied as an explicit theorem-level hypothesis.  A self-overlap form
+This is the coefficient form of that thermodynamic-limit non-vanishing
+condition, with the per-block unit-modulus witness supplied as an explicit
+theorem-level hypothesis.  A self-overlap form
 `limsup_N ⟨A^⊕|A^⊕⟩^{(N)} ∈ (0, ∞)` is the implication recorded by
-the audit's Q-C equivalence (forward direction), which we do not
-formalise here — the coefficient form is the operational input to the
-FT proof; the self-overlap reading is a paraphrase. -/
+the corresponding analytic equivalence in the source-facing discussion; here
+the coefficient form is the input used in the Fundamental Theorem proof. -/
 lemma thermodynamic_limit_nonvanishing
     (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
     (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1) :

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -46,13 +46,10 @@ condition on the raw sector weights `P.weight j q`.  CPSV16
 and the CPSV21 two-layer display (lines 1864–1884) use raw entries
 `μ_{j,q}` and a coefficient `∑_q μ_{j,q}^N`; they do not require
 `|μ_{j,q}|` to be constant in `q`, nor do they impose a strict order on the
-moduli of distinct BNT basis elements.  The audit memo
-`audits/2026-05-13_cpsv16_sector_bnt_phase_1_multiplicity_audit.md` collects
-the counter-examples (`C ⊕ D`, `C ⊕ (1/2)C`, `C ⊕ (-C) ⊕ (1/2)C`) that
-motivate keeping the equal-modulus layer out of the core predicate; all of
-them are admitted by the line-246 normalization fields below (every weight
-has modulus `≤ 1`, and at least one copy of one basis sector has unit
-modulus).
+moduli of distinct BNT basis elements.  The examples `C ⊕ D`,
+`C ⊕ (1/2)C`, and `C ⊕ (-C) ⊕ (1/2)C` illustrate the point: each is
+compatible with the line-246 normalization fields below, but none should force
+an equal-modulus or strict-order structure into the core predicate.
 
 An optional equal-modulus weight layer is provided separately as
 `HasEqualModulusWeightLayer` in `SectorBNT/EqualModulus.lean`.  Some
@@ -104,9 +101,9 @@ Definition 4.2 (lines 1846–1850) together with the two-layer display
 (lines 1864–1884) with **raw** `μ_{j,q}` entries and
 coefficient `∑_q μ_{j,q}^N`.
 
-The audit `audits/2026-05-13_cpsv16_sector_bnt_phase_1_multiplicity_audit.md`
-records the counter-examples that motivate keeping equal-modulus/spectral
-data out of this core predicate.
+Equal-modulus or spectral-level data are therefore kept outside this core
+predicate and supplied only when a theorem genuinely assumes that additional
+normalization.
 -/
 structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   /-- Every basis bond dimension is positive (needed for `NeZero` typeclass
@@ -147,8 +144,7 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   weight has modulus at most one.  CPSV16 §II.C line 246: "we can always
   choose `|μ_k| ≤ 1`"; reinvoked in the body of the FT proof at line 1244
   ("the assumed normalization `|μ_{jq}| ≤ 1` … implies that `𝔼^N` converges").
-  This convention admits all counter-examples of the prior audit
-  (`audits/2026-05-13_cpsv16_sector_bnt_phase_1_multiplicity_audit.md`):
+  This convention admits equal-modulus and unequal-modulus examples such as
   `C ⊕ D` (weights `(1, 1)`), `C ⊕ (-C)` (weights `(1, -1)`),
   `C ⊕ (1/2)C` (weights `(1, 1/2)`), and `C ⊕ (-C) ⊕ (1/2)C`. -/
   weight_norm_le_one : ∀ (j : Fin P.basisCount) (q : Fin (P.copies j)),

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/EqualModulus.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/EqualModulus.lean
@@ -16,16 +16,14 @@ factoring the raw sector weights as `P.weight j q = λ_j · ν_{j,q}`.
 This layer captures the **sub-class** of BNT canonical forms in which every
 sector's copies share a common modulus.  It is NOT part of the
 core BNT predicate `IsBNTCanonicalForm` in
-`SectorBNT/Basic.lean`; see the audit memo
-`audits/2026-05-13_cpsv16_sector_bnt_phase_1_multiplicity_audit.md` §Q4 for
-the counter-example `C ⊕ (1/2)C` (a single BNT basis element with coefficient
+`SectorBNT/Basic.lean`.  The counter-example `C ⊕ (1/2)C` is a single
+BNT basis element with coefficient
 `1 + (1/2)^N` whose copies have unequal moduli, so no `λ_j` factorization
-with unit `ν_{j,q}` is possible).
+with unit `ν_{j,q}` is possible.
 
 The spectral level is required to be `Antitone` (≥) in `‖·‖`, not
-`StrictAnti`; the audit (§Q10) records the counter-example `C ⊕ D` with
-distinct non-gauge-equivalent normal basis tensors and weights `(1,1)`,
-which has two BNT basis elements of equal modulus.
+`StrictAnti`: `C ⊕ D` with distinct non-gauge-equivalent normal basis tensors
+and weights `(1,1)` has two BNT basis elements of equal modulus.
 
 This layer is provided for downstream estimates that genuinely need an
 equal-modulus normalization; CPSV16 §II Step 1 does not need it.
@@ -53,10 +51,8 @@ factoring `P.weight j q = spectral_level j · phase_weight j q`.
 
 It captures the sub-class of BNT canonical forms in which every sector's
 copies share a common modulus.  It is NOT required by, nor part of, the
-core BNT predicate `IsBNTCanonicalForm` (see `SectorBNT/Basic.lean`).  The audit
-`audits/2026-05-13_cpsv16_sector_bnt_phase_1_multiplicity_audit.md` §Q4
-shows that `C ⊕ (1/2)C` is a valid CPSV BNT canonical form that admits no
-such factorization.
+core BNT predicate `IsBNTCanonicalForm` (see `SectorBNT/Basic.lean`).  The
+valid CPSV BNT canonical form `C ⊕ (1/2)C` admits no such factorization.
 
 Paper anchors:
 
@@ -70,8 +66,7 @@ structure HasEqualModulusWeightLayer (P : SectorDecomposition d) where
   /-- The spectral level is everywhere nonzero. -/
   spectral_level_ne_zero : ∀ j : Fin P.basisCount, spectral_level j ≠ 0
   /-- The spectral-level moduli are antitone in `j` (≥, not strict).  The
-  non-strict form admits equal-modulus distinct basis blocks; see the audit
-  §Q10. -/
+  non-strict form admits equal-modulus distinct basis blocks. -/
   spectral_level_antitone :
     Antitone (fun j : Fin P.basisCount => ‖spectral_level j‖)
   /-- **Dominant normalization**: the leading basis block has spectral


### PR DESCRIPTION
## Summary

This PR makes the SectorBNT canonical-form prose self-contained by stating the relevant examples directly instead of pointing readers to audit-note labels.

- Replaces audit-file references in `Basic.lean`, `Api.lean`, and `EqualModulus.lean` with the actual examples `C ⊕ D`, `C ⊕ (-C)`, `C ⊕ (1/2)C`, and `C ⊕ (-C) ⊕ (1/2)C`.
- Keeps the mathematical boundary unchanged: the core `IsBNTCanonicalForm` uses raw weights and does not assume equal-modulus or strict-order data; `HasEqualModulusWeightLayer` remains optional.
- Changes prose only; no declarations or proofs are changed.

## Validation

- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
- lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/EqualModulus.lean
- lake exe lint_style --github
- git diff --check -- TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean TNLean/MPS/FundamentalTheorem/SectorBNT/EqualModulus.lean

Progress on #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation-only, replacing audit-note references with inline examples and clarifying prose without modifying any declarations or proofs.
> 
> **Overview**
> Makes the `SectorBNT` canonical-form docs self-contained by removing references to external audit memos and instead inlining the key counterexamples (`C ⊕ D`, `C ⊕ (-C)`, `C ⊕ (1/2)C`, `C ⊕ (-C) ⊕ (1/2)C`) in `Basic.lean`, `Api.lean`, and `EqualModulus.lean`.
> 
> Also tightens wording around the intended boundary between the core `IsBNTCanonicalForm` (raw weights, no equal-modulus/strict-order assumptions) and the optional `HasEqualModulusWeightLayer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530323c9bf45c311ef7dd035673af7633b1dbe95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->