### PR TITLE
doc(SectorBNT): resolve prose review follow-up

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
@@ -289,10 +289,8 @@ power-sum coefficient does **not** vanish in the thermodynamic limit.
 
 This is the coefficient form of that thermodynamic-limit non-vanishing
 condition, with the per-block unit-modulus witness supplied as an explicit
-theorem-level hypothesis.  A self-overlap form
-`limsup_N ⟨A^⊕|A^⊕⟩^{(N)} ∈ (0, ∞)` is the implication recorded by
-the corresponding analytic equivalence in the source-facing discussion; here
-the coefficient form is the input used in the Fundamental Theorem proof. -/
+theorem-level hypothesis.  This coefficient form is the input used in the
+Fundamental Theorem proof. -/
 lemma thermodynamic_limit_nonvanishing
     (h : IsBNTCanonicalForm P) (j₀ : Fin P.basisCount)
     (hUnit : ∃ q : Fin (P.copies j₀), ‖P.weight j₀ q‖ = 1) :

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -101,9 +101,9 @@ Definition 4.2 (lines 1846–1850) together with the two-layer display
 (lines 1864–1884) with **raw** `μ_{j,q}` entries and
 coefficient `∑_q μ_{j,q}^N`.
 
-Equal-modulus or spectral-level data are therefore kept outside this core
-predicate and supplied only when a theorem genuinely assumes that additional
-normalization.
+The equal-modulus layer (`HasEqualModulusWeightLayer`) is therefore kept
+outside this core predicate and assumed only by theorems that genuinely require
+it.
 -/
 structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   /-- Every basis bond dimension is positive (needed for `NeZero` typeclass
@@ -121,9 +121,9 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   basis_left_canonical : ∀ j : Fin P.basisCount, IsLeftCanonical (P.basis j)
   /-- **Per-block normalized self-overlap.**  Each basis block has
   `mpvOverlap (P.basis j) (P.basis j) N → 1` as `N → ∞`.  This selects the
-  non-periodic / after-blocking BNT surface (CPSV21 line 1818; the periodic
-  generalization at CPSV21 lines 1905–1908 is deliberately not included
-  here). -/
+  non-periodic after-blocking BNT formulation (CPSV21 line 1818; the
+  periodic generalization at CPSV21 lines 1905–1908 is deliberately not
+  included here). -/
   basis_normalized_self_overlap : ∀ j : Fin P.basisCount,
     Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis j) (P.basis j) N)
       atTop (𝓝 1)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -17,7 +17,8 @@ The bundled-witness theorem `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses`
 exposes, for any two BNT sector decompositions $P$ and $Q$ satisfying
 `IsBNTCanonicalForm` and generating the same MPV family:
 
-* the matched basis bijection $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$;
+* the basis bijection $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$ between
+  corresponding BNT sectors;
 * per-block bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$;
 * matched copy multiplicities $r_{βk}^P = r_k^Q$;
 * matched copy permutations $τ_k$;


### PR DESCRIPTION
This follow-up resolves the prose-review comments that remained visible after #1973 was merged.

Changes:
- name the equal-modulus layer directly instead of using the vague grammatical subject “data”;
- remove the unanchored self-overlap/source-facing aside from the non-vanishing coefficient lemma docstring;
- replace the remaining “matched basis” phrasing in the global-gauge witness module.

No declarations or proofs are changed.

Validation:
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean`
- `lake exe lint_style --github`
- `git diff --check`

Follow-up to #1973. Part of #1685 / #1749.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits that adjust wording in module/lemma docstrings; no declarations, proofs, or behavior change. Low risk aside from possible minor doc/reference drift.
> 
> **Overview**
> Tightens prose in the `SectorBNT` Fundamental Theorem modules without changing any Lean declarations or proofs.
> 
> Docstrings are clarified to (1) explicitly name `HasEqualModulusWeightLayer` instead of vague “data” wording in `IsBNTCanonicalForm`, (2) remove an unanchored aside about self-overlap from `thermodynamic_limit_nonvanishing` in `Api.lean`, and (3) replace “matched basis” phrasing with a clearer description of the basis bijection between BNT sectors in `FundamentalCoord.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19df362f6bdd3d65e64b3f19be7cad3e06834b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->