### PR TITLE
doc(ft): state source theorem boundary directly

### DIFF
--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -41,9 +41,9 @@ with an extra $Z$-gauge degree of freedom.
 
 \section{Source theorems}\label{sec:ft_source_theorems}
 
-% Audit 2026-05-20 (#328): the old non-periodic obstruction list in issue #328
-% is stale; the source-level CPSV16 statements below remain not ready because
-% the paper-faithful multi-copy BNT comparison is tracked by #1685.
+% The source-level CPSV16 proportional theorem remains not ready here: the
+% paper-faithful proof requires the full multi-copy BNT coefficient comparison
+% of Chapter~\ref{ch:bnt}, not only the auxiliary sector-matching statements.
 \begin{theorem}[Multi-block fundamental theorem for normal tensors]%
     \label{thm:cpgsv_multiblock_ft_source}
     \notready
@@ -74,9 +74,9 @@ in Theorem~\ref{thm:sector_bnt_equal_global_gauge}. The same-index direct-sum
 corollaries of Chapter~\ref{ch:algebraic_ft} are useful algebraic consequences,
 but they are not the source proof of the BNT block matching.
 
-% Audit 2026-05-20 (#328): the old equal-case blockers #944, #1133, #1170,
-% and #1178 are closed.  This source corollary nevertheless stays not ready
-% until the unrestricted source-faithful theorem is formalized under #1685.
+% The equal-case source corollary remains not ready until the unrestricted
+% source theorem has been assembled from the common blocked surface, the
+% paper-faithful BNT coefficient comparison, and the global gauge construction.
 \begin{theorem}[Equal canonical-form representations are globally conjugate]%
     \label{thm:cpgsv_equal_case_source}
     \notready


### PR DESCRIPTION
## Summary

This PR removes stale issue-history comments from the Chapter 11 source-theorem entries and replaces them with the mathematical reason the entries remain not ready.

- The CPSV16 proportional source theorem is marked as still depending on the full multi-copy BNT coefficient comparison of Chapter 10.
- The equal-case source corollary is marked as still depending on assembly from the common blocked surface, the paper-faithful BNT coefficient comparison, and the global gauge construction.
- Comments only; no blueprint statements, Lean tags, declarations, or proofs are changed.

## Validation

- git diff --check -- blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
- rg -n "#328|#944|#1133|#1170|#1178|#1685|stale|old .*blocker|old non-periodic|Audit 2026-05-20" blueprint/src/chapter/ch11_fundamental_theorem_proof.tex

Notes: local `leanblueprint web` could not complete because this machine ran out of disk space while writing generated HTML; local `leanblueprint checkdecls` reports the repository-wide existing missing-declaration list unrelated to this comment-only edit. Remote CI will run the blueprint checks on a clean runner.

Progress on #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates LaTeX comments to replace stale issue-tracker audit notes with current dependency explanations; no statements, proofs, or Lean targets change.
> 
> **Overview**
> Updates Chapter 11’s *source theorem* section comments to remove stale audit/issue-history notes and instead state the concrete formalization dependencies blocking the CPSV16 proportional theorem and equal-case corollary (multi-copy BNT coefficient comparison and subsequent global-gauge assembly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee7c6f68fd07bb313804c01bd33c8c91b403672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->