### PR TITLE
feat(canonical): allow empty PGVWC07 exact branch

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -356,6 +356,78 @@ theorem exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_e
     by_contra hσ
     exact hA ⟨N, hN, σ, hσ⟩
 
+/-- Exact positive-length PGVWC07 canonical-form witness, allowing the empty
+nonzero-block family in the zero positive-length branch.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
+742--763, is a theorem about finite rings of positive length.  The preceding
+dichotomy separates the case in which all positive-length MPV coefficients
+vanish.  This theorem records the corresponding positive-length convention for
+that branch: the nonzero-block family is empty.  Thus the positive-weight,
+unital, scalar-fixed-point, and dual-diagonal requirements are vacuous in the
+zero branch, while the positive-length MPV equality is exact after the same
+global rescaling convention used in the nonzero branch.
+
+When the block family is nonempty, at least one normalized weight has norm
+one.  This is the precise replacement for the unit-weight conclusion in the
+zero branch, where no positive block exists. -/
+theorem exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty
+    (A : MPSTensor d D) :
+    ∃ (scale : ℝ) (r : ℕ) (dim : Fin r → ℕ)
+      (ν : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      0 < scale ∧
+      (∀ k,
+        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
+      (∀ k,
+        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          transferMap (d := d) (D := dim k) (blocks k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
+      (∀ k, ‖ν k‖ ≤ 1) ∧
+      (0 < r → ∃ k, ‖ν k‖ = 1) ∧
+      (∀ k, 0 < dim k) ∧
+      SameMPV₂Pos
+        (fun i => (((scale : ℂ)⁻¹) • A i))
+        (toTensorFromBlocks (d := d) (μ := ν) blocks) ∧
+      ∑ k : Fin r, dim k ≤ D := by
+  classical
+  rcases exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero
+      (d := d) (D := D) A with hZero | hNonzero
+  · let dim : Fin 0 → ℕ := fun k => Fin.elim0 k
+    let ν : Fin 0 → ℂ := fun k => Fin.elim0 k
+    let blocks : (k : Fin 0) → MPSTensor d (dim k) := fun k => Fin.elim0 k
+    refine ⟨1, 0, dim, ν, blocks, by norm_num, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    · intro k
+      exact Fin.elim0 k
+    · intro k
+      exact Fin.elim0 k
+    · intro k
+      exact Fin.elim0 k
+    · intro k
+      exact Fin.elim0 k
+    · intro hr
+      exact (Nat.not_lt_zero 0 hr).elim
+    · intro k
+      exact Fin.elim0 k
+    · intro N hN σ
+      calc
+        mpv (fun i => (((1 : ℂ)⁻¹) • A i)) σ = mpv A σ := by simp
+        _ = 0 := hZero N hN σ
+        _ = mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ := by
+          rw [mpv_toTensorFromBlocks_eq_sum]
+          simp [ν, blocks]
+    · simp [dim]
+  · rcases hNonzero with
+      ⟨scale, r, dim, ν, blocks, hscale_pos, hr, hdual, hscalar, hν_pos,
+        hν_le, hν_unit, hdim_pos, hMPV, hbond⟩
+    exact ⟨scale, r, dim, ν, blocks, hscale_pos, hdual, hscalar, hν_pos,
+      hν_le, fun _ => hν_unit, hdim_pos, hMPV, hbond⟩
+
 /-- Arbitrary-input zero/nonzero dichotomy for the projective PGVWC07
 canonical-form statement.
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1174,6 +1174,32 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     every positive-length coefficient is zero.
 \end{proof}
 
+\begin{theorem}[Exact PGVWC07 form with empty zero branch]%
+    \label{thm:pgvwc07_exact_rescaled_form_allow_empty}
+    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty}
+    \leanok
+    \uses{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
+    For every MPS tensor \(A\), there is a positive scalar \(s\) and a finite
+    family of PGVWC07 blocks \(C_k\), possibly empty, with positive normalized
+    weights \(\nu_k\) satisfying \(|\nu_k|\leq 1\). If the family is nonempty,
+    then \(|\nu_{k_0}|=1\) for some block \(k_0\). Each block is in the unital
+    orientation, has only scalar fixed points for its transfer map, and has a
+    diagonal positive-definite fixed point for the dual transfer map. Moreover
+    the globally rescaled tensor \(s^{-1}A\) and the normalized weighted block
+    tensor have the same positive-length MPV coefficients, and the block
+    dimensions satisfy \(\sum_k D_k\leq D\).
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
+    Apply the zero/nonzero dichotomy. In the nonzero branch, use the nonempty
+    normalized exact form. In the zero branch, take the empty nonzero-block
+    family; its block-diagonal MPV coefficient is the empty sum at every
+    positive length, which agrees with the zero positive-length coefficients of
+    \(A\). The unit-weight conclusion is stated conditionally on the family
+    being nonempty.
+\end{proof}
+
 \begin{theorem}[Zero/nonzero dichotomy for projective PGVWC07 form]%
     \label{thm:pgvwc07_projective_form_zero_nonzero_dichotomy}
     \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -360,6 +360,19 @@ The earlier existence path now has the following formal pieces.
           convention for Theorem~\texttt{Th:TIcanonical}.
 
     \item
+          \path|MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty|
+          removes the disjunction in the preceding theorem by adopting the
+          positive-length convention that the zero branch has an empty
+          nonzero-block family.  Thus the positive-weight, unital,
+          scalar-fixed-point, and dual-diagonal block conditions are vacuous in
+          the branch where every positive-length MPV coefficient vanishes.  In
+          the nonzero branch the family is nonempty and still has a normalized
+          weight of norm one.  This is an exact positive-length formulation:
+          after a positive global rescaling of the original tensor, the
+          normalized weighted block tensor has the same coefficients on every
+          nonempty ring, and \(\sum_k D_k\leq D\).
+
+    \item
           \path|MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero|
           records the arbitrary-input zero/nonzero dichotomy for this
           projective formulation.  Either all positive-length MPV coefficients
@@ -450,13 +463,13 @@ witness, finite-family weight normalization, and projective interpretation of
 the global scalar factor are available.  For tensors with at least one nonzero
 positive-length MPV coefficient, these pieces have been composed into a
 nonempty normalized projective PGVWC07 form and into an exact normalized form
-after a positive global rescaling of the original tensor.  There are also
-arbitrary-input dichotomies separating this nonzero case from the case in which
-every positive-length MPV coefficient vanishes.  The remaining formal work is to
-decide whether the unrestricted source-facing theorem should be stated in exact
-positive-length coefficients, in nonzero projective MPV families with a
-nonzero-state hypothesis, or with an explicit zero-block/length-zero convention,
-and then to promote the corresponding statement as the theorem cited against
+after a positive global rescaling of the original tensor.  The exact
+positive-length formulation has also been stated for arbitrary input by
+allowing the nonzero-block family to be empty exactly in the branch where every
+positive-length coefficient vanishes.  The remaining formal work is to decide
+whether this positive-length formulation is the desired source theorem,
+or whether the projective MPV formulation or an explicit zero-block/length-zero
+statement should instead be promoted as the declaration cited against
 Theorem~\texttt{Th:TIcanonical}.
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
This is a contained #1857 step on the PGVWC07 canonical-form existence path only; it does not touch the PGVWC07 uniqueness theorem or the CPSV Fundamental Theorem path.

Mathematical content:
- adds `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`;
- removes the zero/nonzero disjunction in the exact positive-length formulation by allowing an empty nonzero-block family exactly when all positive-length MPV coefficients vanish;
- keeps the unit-weight conclusion conditional on the block family being nonempty;
- preserves the unital block condition, scalar fixed-point conclusion, diagonal positive-definite dual fixed point, exact positive-length MPV equality after global rescaling, and the bond-dimension bound.

Documentation:
- adds the corresponding Chapter 8 blueprint entry with `\leanok`;
- updates the PGVWC07 paper-gap note to record the empty-family convention and the remaining choice for the final theorem statement.

Validation:
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`
- `lake exe lint_style --github`
- `git diff --check`

`leanblueprint checkdecls` could not be completed locally in the fresh worktree because `blueprint/lean_decls` was not generated there; CI should run the normal blueprint pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new theorem that packages an existing zero/nonzero dichotomy by choosing an empty block family in the all-zero case, plus corresponding documentation updates; existing results are unchanged.
> 
> **Overview**
> Introduces `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`, which removes the explicit zero/nonzero disjunction in the exact positive-length PGVWC07 statement by *allowing the block family to be empty exactly when all positive-length MPV coefficients vanish* (with the “unit weight” conclusion made conditional on `0 < r`).
> 
> Updates the blueprint (Chapter 8) and the PGVWC07 scope/paper-gap note to document this empty-family convention and its implications for the exact rescaled formulation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc9bbaf5605183b3c29119c1f32625e05872656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->