### PR TITLE
doc(canonical): update PGVWC07 positive-length boundary

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -173,18 +173,19 @@ yet supply the source normalization $|\mu_k|\le 1$ with at least one
 unit-modulus weight, so they should not be cited as
 Theorem~\ref{thm:cpgsv_canonical_form_source}.
 
-For Theorem~\ref{thm:pgvwc07_ti_canonical_form}, what remains is not a
-different canonical-form theorem, but the composition of the source proof from
-its arbitrary initial representation.  One must use the positive
-Perron--Frobenius fixed point of the original transfer map to normalize the
-spectral radius and obtain the weights, derive the invariant support projection
-when that fixed point is singular, split the finite-ring trace over the support
-and its orthogonal complement, iterate this dimension-decreasing decomposition
-until the identity is the only fixed point of each block, and finally apply the
-dual fixed-point argument and unitary diagonalization that produces the
-matrices $\Lambda_k$.  Only after these steps have been composed can the
-existing conditional TP-normalized and primitive-block results be used as
-corollaries of the source theorem.
+For Theorem~\ref{thm:pgvwc07_ti_canonical_form}, the source statement itself
+remains \notready.  The source-ordered construction has now been composed into
+the exact positive-length formulation of
+Theorem~\ref{thm:pgvwc07_exact_rescaled_form_allow_empty}: after a positive
+global rescaling of the original tensor, the normalized weighted block tensor
+has the same MPV coefficients on every nonempty ring.  The theorem permits an
+empty nonzero-block family precisely when all positive-length coefficients
+vanish, and otherwise retains a unit-modulus normalized weight together with
+the unital block condition, the scalar fixed-point conclusion, the diagonal
+positive-definite dual fixed point, and the bond-dimension bound.  The remaining
+choice is whether this exact positive-length formulation, the projective MPV
+formulation, or an explicit zero-block/length-zero formulation should be the
+formal statement cited for the literal source theorem.
 
 \section{Normal tensors, canonical forms, and bases of normal tensors}\label{sec:cpsv_canonical_defs}
 
@@ -786,7 +787,7 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     the displayed equations for $B$.
 \end{proof}
 
-\begin{theorem}[Single irreducible-block PGVWC07 canonical-form data]%
+\begin{theorem}[Single irreducible-block PGVWC07 canonical-form theorem]%
     \label{thm:pgvwc07_irreducible_unital_dual_package}
     \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible}
     \leanok


### PR DESCRIPTION
This updates the Chapter 8 overview after #1976/#1977.

Changes:
- records that the source-level PGVWC07 `Th:TIcanonical` entry remains `\notready`;
- points the overview to the checked exact positive-length formulation `thm:pgvwc07_exact_rescaled_form_allow_empty`;
- states the remaining convention choice: exact positive-length, projective MPV, or explicit zero-block/length-zero;
- renames one blueprint theorem heading from “canonical-form data” to “canonical-form package” to avoid vague collection wording.

This is documentation-only and remains on the canonical-form existence path; it does not touch PGVWC07 uniqueness or #1529.

Validation:
- `git diff --check`
- `rg -n "source-facing|data are|canonical-form data|BNT surface|matched basis|frontier" blueprint/src/chapter/ch08_canonical.tex` (no matches)
- `lake exe lint_style --github`
- `cd blueprint && leanblueprint web`

`leanblueprint checkdecls` could not run locally because this environment did not produce `blueprint/lean_decls`; no `\lean{}` or `\leanok` tags changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits: updates the Chapter 8 overview text and a theorem caption without changing any Lean declarations or mathematical statements.
> 
> **Overview**
> Updates the Chapter 8 overview to explicitly mark the source-level PGVWC07 translation-invariant canonical form theorem as still `\notready`, and to instead point readers to the checked **exact positive-length** formulation `thm:pgvwc07_exact_rescaled_form_allow_empty` (including its empty/nonempty block-family boundary and global rescaling convention).
> 
> Renames the theorem caption for `thm:pgvwc07_irreducible_unital_dual_package` from “canonical-form data” to “canonical-form theorem” to avoid vague wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790d19cf3fe5437980cffc0d721a9320254b5d94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->