### PR TITLE
doc(periodic): state blueprint theorem boundary directly

### DIFF
--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -366,9 +366,10 @@ final comparison still assumes periodic-overlap and power-equality hypotheses,
 so the literature theorem has not yet been obtained here as a single
 unconditional result.
 
-% Audit 2026-05-20 (#328): this main periodic theorem remains not ready.  The
-% current issues are #81 for the periodic overlap dichotomy, #82 for the
-% periodic Fundamental Theorem statements, and #829 for the Z-gauge/root step.
+% The source-level equal-case theorem remains not ready as a single theorem:
+% the present Lean statements still assume the periodic-overlap and
+% coefficient-power hypotheses which the paper derives from equality of the
+% MPV family.  The Z-gauge/root-of-unity construction is already formalized.
 \begin{theorem}[Periodic Fundamental Theorem]\notready
     \label{thm:periodic_ft}
     \lean{MPSTensor.zgauge_construction, MPSTensor.equalCase_zgauge_of_power_sums,
@@ -443,10 +444,10 @@ unconditional result.
     adjoint-transfer relation.
 \end{definition}
 
-% Audit 2026-05-20 (#328): the remaining overlap proof obligations are now
-% tracked by #448, #450, and #1807.  The self-overlap and no-sector-match
-% theorems below are already statement-level leanok; the surrounding dichotomy
-% is still not ready.
+% The overlap component lemmas below are part of the source dichotomy proof.
+% The self-overlap and no-sector-match theorems are already formal statements;
+% the full periodic overlap dichotomy still requires assembling these pieces
+% with the remaining sector-match argument.
 \begin{theorem}[Self-overlap along period multiples]\label{thm:periodic_self_overlap_tendsto}
     \lean{MPSTensor.periodicSelfOverlap_tendsto}
     \leanok


### PR DESCRIPTION
## Summary
- replaces dated audit and issue-number comments in Chapter 11b with direct mathematical boundary statements
- records that the periodic equal-case theorem is still conditional on overlap and coefficient-power hypotheses derived in the paper from MPV equality
- describes the overlap lemmas as components of the source dichotomy, with the full dichotomy still requiring the remaining sector-match assembly

## Validation
- `git diff --check -- blueprint/src/chapter/ch11b_periodic_ft.tex`
- `rg -n "Audit 2026|#[0-9]+|tracked by|current issues" blueprint/src/chapter/ch11b_periodic_ft.tex` (no matches)
- `cd blueprint && leanblueprint checkdecls` (fails on existing unrelated missing declarations, including PGVWC07, PEPS, and ParentHamiltonian entries; no new declaration references were added)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates explanatory comments in the LaTeX blueprint to clarify which periodic-theorem pieces remain conditional vs formalized; no Lean declarations or mathematical statements change.
> 
> **Overview**
> Updates Chapter 11b’s narrative around the periodic equal-case Fundamental Theorem to state the current *theorem boundary* directly: the Lean statements are still conditional on periodic-overlap and coefficient-power hypotheses, while the `Z`-gauge/root-of-unity construction is already formalized.
> 
> Similarly rewrites the overlap-section preface to describe the self-overlap/no-sector-match results as component lemmas of the still-incomplete periodic overlap dichotomy, removing dated audit/issue-tracker commentary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de697f992dac20b073fb37d79ea900adce50c25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->