### PR TITLE
doc(periodic): name BDCF converse gap directly

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -532,7 +532,7 @@ private theorem mpvOverlap_blockTensor_self_eq
 
 /-- Orthogonal-corner trace rigidity for compressed cyclic sectors.
 
-**Gap analysis (Issue #871).**  This lemma asserts that distinct compressed
+**Remaining BDCF converse.**  This lemma asserts that distinct compressed
 sectors from the same cyclic decomposition cannot be gauge-phase equivalent.
 The mathematical proof in arXiv:1708.00029 (Appendix A, lines 930–950) relies
 on the block-diagonal canonical form (BDCF) lemma: distinct cyclic sectors


### PR DESCRIPTION
## Summary
- replaces an issue-number heading in the periodic self-overlap gap analysis with the mathematical missing ingredient
- states the gap as the remaining BDCF converse for orthogonal cyclic sectors
- leaves the lemma statement and proof body unchanged

## Validation
- `lake env lean TNLean/MPS/Periodic/Overlap/SelfOverlap.lean` (passes with the pre-existing `sorry` warning at the documented gap lemma)
- `lake exe lint_style --github TNLean/MPS/Periodic/Overlap/SelfOverlap.lean`
- `git diff --check -- TNLean/MPS/Periodic/Overlap/SelfOverlap.lean`
- `rg -n "Issue #[0-9]+|#[0-9]{3,4}|issue #[0-9]+|Audit 2026|tracked by" TNLean/MPS/Periodic/Overlap/SelfOverlap.lean` (no matches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that does not modify any lemma statements, proofs, or behavior.
> 
> **Overview**
> Updates the gap documentation in `TNLean/MPS/Periodic/Overlap/SelfOverlap.lean` to name the missing ingredient directly as the **remaining BDCF converse**, replacing the prior issue-number framing while leaving the lemma and its `sorry`-backed proof unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cece158e145172c078c0760709cc78f8e2dbb014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->