### PR TITLE
feat(canonical): add normalized PGVWC07 zero-block form

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -38,6 +38,8 @@ The imported modules provide the original public declarations:
 * `MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`
+* `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`
+* `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail`
 * `MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -18,10 +18,12 @@ normalized weight has norm at most one and one has norm one.  The statement
 also records the global scalar factor on every positive-length MPV
 coefficient.
 
-The remaining source-facing boundary is not the finite maximum argument, but
-the state-equivalence convention under which the global length-dependent
-scalar is treated as a projective normalization.  This boundary is recorded in
-`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
+The remaining theorem-statement boundary is not the finite maximum argument,
+but which state-equivalence convention should be cited for the literal source
+theorem.  This file records both the projective convention and the exact
+convention after a positive global rescaling, with either positive-length
+equality or an explicit zero-block contribution at length zero.  The boundary
+is recorded in `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
 
 The projective formulation below makes that convention explicit: after the
 maximum normalization, the original tensor and the normalized weighted block
@@ -213,7 +215,7 @@ positive-length PGVWC07 witness with the projective weight normalization above.
 **Scope restriction:** The statement assumes that some positive-length MPV
 coefficient of the original tensor is nonzero.  This excludes the empty
 nonzero-block case and lets the normalization include a block of unit weight.
-The remaining source-facing choice for the unrestricted theorem is recorded in
+The remaining statement choice for the unrestricted theorem is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv
     (A : MPSTensor d D)
@@ -320,7 +322,7 @@ has exactly the same positive-length MPV coefficients.
 
 **Scope restriction:** This theorem keeps the zero positive-length branch
 explicit and therefore does not remove the final length-zero convention needed
-for a source-facing unrestricted statement of PGVWC07 Theorem Th:TIcanonical. -/
+for an unrestricted statement of PGVWC07 Theorem Th:TIcanonical. -/
 theorem exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero
     (A : MPSTensor d D) :
     (∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = 0) ∨
@@ -428,6 +430,127 @@ theorem exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty
     exact ⟨scale, r, dim, ν, blocks, hscale_pos, hdual, hscalar, hν_pos,
       hν_le, fun _ => hν_unit, hdim_pos, hMPV, hbond⟩
 
+/-- Exact normalized PGVWC07 canonical-form witness with an explicit zero-block
+summand.
+
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
+742--763 and proof lines 765--766.  This theorem combines the explicit
+zero-block decomposition with the finite-family maximum normalization of the
+nonzero weights.  After a positive global rescaling of the original tensor,
+the normalized nonzero blocks and the zero block reproduce all finite-ring MPV
+coefficients.  At length zero this is the dimension identity
+\(D_0 + \sum_k D_k = D\).
+
+The zero block contributes only at length zero.  Thus this is the explicit
+zero-block/length-zero convention complementary to the preceding exact
+positive-length theorem, which omits the zero block and states exact equality
+only at positive length. -/
+theorem exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail
+    (A : MPSTensor d D) :
+    ∃ (scale : ℝ) (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
+      (ν : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      0 < scale ∧
+      (∀ k,
+        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          Λ.PosDef ∧
+          Λ.IsDiag ∧
+          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
+          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
+      (∀ k,
+        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+          transferMap (d := d) (D := dim k) (blocks k) X = X →
+            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
+      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
+      (∀ k, ‖ν k‖ ≤ 1) ∧
+      (0 < r → ∃ k, ‖ν k‖ = 1) ∧
+      (∀ k, 0 < dim k) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv (fun i => (((scale : ℂ)⁻¹) • A i)) σ =
+          mpv (zeroMPSTensor d zeroTailDim) σ +
+            mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ) ∧
+      zeroTailDim + ∑ k : Fin r, dim k = D ∧
+      ∑ k : Fin r, dim k ≤ D := by
+  classical
+  obtain ⟨zeroTailDim, r, dim, μ, blocks, hdual, hscalar, hμ_pos, _hμ_ne,
+    hdim_pos, hMPV, hBond, hBound⟩ :=
+    exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound
+      (d := d) (D := D) A
+  by_cases hr : 0 < r
+  · let W : PGVWC07PositiveLengthWitness (d := d) (D := D) A :=
+      { r := r
+        dim := dim
+        weights := μ
+        blocks := blocks
+        dual_fixed := hdual
+        scalar_fixed := hscalar
+        weight_pos := hμ_pos
+        dim_pos := hdim_pos
+        sameMPV_pos := by
+          intro N hN σ
+          calc
+            mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ +
+                mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := hMPV N σ
+            _ = 0 + mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+                rw [mpv_zeroMPSTensor]
+                simp [Nat.ne_of_gt hN]
+            _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+                simp
+        bondDim_le := hBound }
+    obtain ⟨scale, ν, hscale_pos, hν_pos, hν_le, hν_unit, _hweight, hMPV_norm⟩ :=
+      W.exists_weight_normalization hr
+    have hscale_ne : (scale : ℂ) ≠ 0 := by
+      exact_mod_cast (ne_of_gt hscale_pos)
+    refine ⟨scale, zeroTailDim, r, dim, ν, blocks, hscale_pos, hdual, hscalar,
+      hν_pos, hν_le, fun _ => hν_unit, hdim_pos, ?_, hBond, hBound⟩
+    intro N σ
+    by_cases hN : 0 < N
+    · have hpow : ((scale : ℂ) ^ N)⁻¹ * (scale : ℂ) ^ N = 1 := by
+        simp [pow_ne_zero N hscale_ne]
+      calc
+        mpv (fun i => (((scale : ℂ)⁻¹) • A i)) σ =
+            ((scale : ℂ)⁻¹) ^ N * mpv A σ := mpv_smul ((scale : ℂ)⁻¹) A σ
+        _ = ((scale : ℂ)⁻¹) ^ N *
+              ((scale : ℂ) ^ N *
+                mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ) := by
+            rw [hMPV_norm N hN σ]
+        _ = (((scale : ℂ)⁻¹) ^ N * (scale : ℂ) ^ N) *
+              mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ := by
+            ring
+        _ = mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ := by
+            simp [hpow]
+        _ = mpv (zeroMPSTensor d zeroTailDim) σ +
+              mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ := by
+            rw [mpv_zeroMPSTensor]
+            simp [Nat.ne_of_gt hN]
+    · have hN0 : N = 0 := Nat.eq_zero_of_not_pos hN
+      subst N
+      have hBondC : (D : ℂ) = (zeroTailDim + ∑ k : Fin r, dim k : ℕ) := by
+        exact_mod_cast hBond.symm
+      calc
+        mpv (fun i => (((scale : ℂ)⁻¹) • A i)) σ =
+            (D : ℂ) := mpv_zero_length (fun i => (((scale : ℂ)⁻¹) • A i)) σ
+        _ = (zeroTailDim + ∑ k : Fin r, dim k : ℕ) := hBondC
+        _ = (zeroTailDim : ℂ) + ∑ k : Fin r, (dim k : ℂ) := by
+            simp
+        _ = mpv (zeroMPSTensor d zeroTailDim) σ +
+              mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ := by
+            simp
+            exact Finset.sum_congr rfl (fun _ _ => rfl)
+  · have hr0 : r = 0 := Nat.eq_zero_of_not_pos hr
+    subst r
+    refine ⟨1, zeroTailDim, 0, dim, μ, blocks, zero_lt_one, hdual, hscalar,
+      hμ_pos, ?_, ?_, hdim_pos, ?_, hBond, hBound⟩
+    · intro k
+      exact Fin.elim0 k
+    · intro hzero
+      exact (Nat.not_lt_zero 0 hzero).elim
+    · intro N σ
+      calc
+        mpv (fun i => (((1 : ℂ)⁻¹) • A i)) σ = mpv A σ := by simp
+        _ = mpv (zeroMPSTensor d zeroTailDim) σ +
+              mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := hMPV N σ
+
 /-- Arbitrary-input zero/nonzero dichotomy for the projective PGVWC07
 canonical-form statement.
 
@@ -438,7 +561,7 @@ coefficients vanish, or the tensor has a nonempty normalized projective
 PGVWC07 block form.
 
 **Scope restriction:** This is not the unrestricted source theorem.  It records
-the zero positive-length branch explicitly; the source-facing convention for
+the zero positive-length branch explicitly; the length-zero convention for
 the length-zero/all-zero case is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -182,10 +182,13 @@ has the same MPV coefficients on every nonempty ring.  The theorem permits an
 empty nonzero-block family precisely when all positive-length coefficients
 vanish, and otherwise retains a unit-modulus normalized weight together with
 the unital block condition, the scalar fixed-point conclusion, the diagonal
-positive-definite dual fixed point, and the bond-dimension bound.  The remaining
-choice is whether this exact positive-length formulation, the projective MPV
-formulation, or an explicit zero-block/length-zero formulation should be the
-formal statement cited for the literal source theorem.
+positive-definite dual fixed point, and the bond-dimension bound.
+Theorem~\ref{thm:pgvwc07_exact_rescaled_form_with_zero_tail} records the
+companion explicit zero-block convention, where the zero block supplies the
+length-zero contribution \(D_0+\sum_k D_k=D\).  The remaining choice is which
+of the exact positive-length, projective MPV, and explicit zero-block
+formulations should be the formal statement cited for the literal source
+theorem.
 
 \section{Normal tensors, canonical forms, and bases of normal tensors}\label{sec:cpsv_canonical_defs}
 
@@ -1199,6 +1202,36 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     positive length, which agrees with the zero positive-length coefficients of
     \(A\). The unit-weight conclusion is stated conditionally on the family
     being nonempty.
+\end{proof}
+
+\begin{theorem}[Exact PGVWC07 form with explicit zero block]%
+    \label{thm:pgvwc07_exact_rescaled_form_with_zero_tail}
+    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail}
+    \leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound,
+        thm:pgvwc07_positive_length_witness_weight_normalization}
+    For every MPS tensor \(A\), there is a positive scalar \(s\), a zero-block
+    dimension \(D_0\), and a finite family of PGVWC07 blocks \(C_k\), possibly
+    empty, with positive normalized weights \(\nu_k\) satisfying
+    \(|\nu_k|\leq 1\). If the family is nonempty, then
+    \(|\nu_{k_0}|=1\) for some block \(k_0\). Each nonzero block is in the
+    unital orientation, has only scalar fixed points for its transfer map, and
+    has a diagonal positive-definite fixed point for the dual transfer map.
+    For every block \(k\), the bond dimension \(D_k\) is positive. Moreover
+    the globally rescaled tensor \(s^{-1}A\) has exactly the MPV family given
+    by the zero block plus the normalized weighted block tensor at every ring
+    length. The bond dimensions satisfy \(D_0+\sum_k D_k=D\), and in particular
+    \(\sum_kD_k\leq D\).
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound,
+        thm:pgvwc07_positive_length_witness_weight_normalization}
+    Start from the arbitrary-input theorem with the zero block retained.  If
+    the nonzero-block family is empty, take \(s=1\).  Otherwise normalize the
+    positive weights by their maximum.  On nonempty rings the zero block has
+    zero coefficient, so the normalized positive-length identity applies; at
+    length zero the equality is exactly \(D_0+\sum_kD_k=D\).
 \end{proof}
 
 \begin{theorem}[Zero/nonzero dichotomy for projective PGVWC07 form]%

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -373,6 +373,16 @@ The earlier existence path now has the following formal pieces.
           nonempty ring, and \(\sum_k D_k\leq D\).
 
     \item
+          \path|MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail|
+          records the complementary explicit zero-block convention.  It keeps
+          the zero block from the arbitrary-input decomposition, normalizes the
+          positive nonzero-block weights by their maximum when the nonzero
+          family is nonempty, and proves exact MPV equality at every finite
+          length after the same positive global rescaling.  For positive
+          lengths the zero block contributes zero; at length zero the equality
+          is the dimension identity \(D_0+\sum_kD_k=D\).
+
+    \item
           \path|MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero|
           records the arbitrary-input zero/nonzero dichotomy for this
           projective formulation.  Either all positive-length MPV coefficients
@@ -458,7 +468,7 @@ diagonalization.  None of these steps may be replaced by a theorem that starts
 from an already prepared primitive or trace-preserving block family, because
 those hypotheses are not present in Theorem~\texttt{Th:TIcanonical}.
 
-At the current frontier, the block construction, nonempty-ring exact-MPV
+At the present stage, the block construction, nonempty-ring exact-MPV
 witness, finite-family weight normalization, and projective interpretation of
 the global scalar factor are available.  For tensors with at least one nonzero
 positive-length MPV coefficient, these pieces have been composed into a
@@ -466,11 +476,12 @@ nonempty normalized projective PGVWC07 form and into an exact normalized form
 after a positive global rescaling of the original tensor.  The exact
 positive-length formulation has also been stated for arbitrary input by
 allowing the nonzero-block family to be empty exactly in the branch where every
-positive-length coefficient vanishes.  The remaining formal work is to decide
-whether this positive-length formulation is the desired source theorem,
-or whether the projective MPV formulation or an explicit zero-block/length-zero
-statement should instead be promoted as the declaration cited against
-Theorem~\texttt{Th:TIcanonical}.
+positive-length coefficient vanishes.  The explicit zero-block/length-zero
+formulation has now also been stated: after the same positive global rescaling,
+the zero block and the normalized weighted nonzero blocks reproduce the MPV
+coefficients at every finite length, with \(D_0+\sum_kD_k=D\).  The remaining
+formal work is to decide which of these checked formulations should be promoted
+as the statement cited against Theorem~\texttt{Th:TIcanonical}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary
- add MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail
- compose the explicit zero-block decomposition with finite-family weight normalization
- record exact all-length MPV equality after positive global rescaling, including D0 + sum_k D_k = D at length zero
- update the Chapter 8 blueprint and PGVWC07 paper-gap note to include this explicit zero-block convention

This remains canonical-form existence work only. It does not address PGVWC07 thm-uniq or issue #1529.

## Validation
- lake env lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
- lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean
- lake exe lint_style --github
- lake build (passes; pre-existing warnings remain in TNLean/Spectral/GaugeConstruction.lean and periodic overlap files)
- git diff --check
- cd blueprint && leanblueprint web (passes with existing missing-bibliography/package warnings)
- cd blueprint && leanblueprint checkdecls cannot run locally because blueprint/lean_decls is absent in this environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new core canonical-form existence theorem and proof that composes prior zero-tail decomposition with weight normalization, which may affect downstream lemmas relying on canonical-form statements and length-zero conventions.
> 
> **Overview**
> Introduces an *explicit zero-block* variant of the normalized exact PGVWC07 reduction: `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail` proves that after a positive global rescaling, MPV coefficients match **at all lengths** as the sum of a `zeroMPSTensor` term and a normalized weighted block tensor, with the length-zero case encoding `D₀ + ∑ D_k = D`.
> 
> Updates module exports/documentation to surface this new statement (`NormalReduction.lean`) and extends the blueprint + paper-gap notes to describe and cite the new explicit length-zero convention alongside the existing exact positive-length and projective formulations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 943b3b0323ebe33181d7d95b0e2ae58429c25b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->