### PR TITLE
doc(mpdo): state RMP boundaries directly

### DIFF
--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -161,8 +161,8 @@ def ofSALZCLAndCommutingForm
   commutingForm := hCommuting
   zcl := hZCL
 
-/-- The issue-#782 commuting-form data together with MPO ZCL yield the
-GSNNCH-with-ZCL branch of Theorem 4.9. -/
+/-- Commuting-form data together with MPO ZCL yield the GSNNCH-with-ZCL branch of
+Theorem 4.9. -/
 theorem isGSNNCHWithZCL (data : SimpleMPDOBlockedRFPData K) : IsGSNNCHWithZCL K :=
   (isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL K).2 ⟨data.commutingForm, data.zcl⟩
 
@@ -204,8 +204,9 @@ From the explicit simple-MPDO hypotheses one simultaneously recovers:
 * the blocked fusion-isometry witness at size `2`, and
 * the transfer-map fusion formulation of MPDO RFP.
 
-Relative to the current repository state, this is the final construction layer
-on top of issues #781 and #782. -/
+Relative to the current formalization, this is the construction layer after the
+local simple-MPDO structure, commuting form, and zero-correlation-length
+hypotheses have been supplied explicitly. -/
 theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
     (data : SimpleMPDOBlockedRFPData K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -16,8 +16,8 @@ semidefinite two-site matrix `B`, together with proofs that its translated
 copies on the periodic chain pairwise commute and that their product
 reproduces `ρ` up to a positive scalar. This is the projector-limit version of
 the commuting-form definition in arXiv:1606.00608. The actual entropy-side derivation
-`SAL ⟹ HasCommutingForm` is not yet formalized here; it is isolated as the
-preceding missing theorem stated in the accompanying audit for issue #782.
+`SAL ⟹ HasCommutingForm` is not yet formalized here; this file starts from the
+commuting-form witness and proves the GSNNCH equivalence built from that data.
 
 ## Main declarations
 

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -102,9 +102,9 @@ Concretely, this structure stores the single translation-invariant bond extracte
 from the local simple-MPDO analysis, together with proofs that it realizes the
 finite-chain MPO operators. This is stronger than `HasCommutingForm M`, since
 it requires one bond that works for every chain length rather than a separate
-commuting-form witness at each length. The future issue-#833 extraction theorem
-should construct this data from `EtaStructure` and the rank-one factorization
-of the local transfer matrix. -/
+commuting-form witness at each length. The remaining extraction theorem should
+construct this data from `EtaStructure` and the rank-one factorization of the
+local transfer matrix. -/
 structure EtaLocalStructureData (M : MPOTensor d D) where
   /-- The chain-independent nearest-neighbor bond extracted from the local
   `η_{k,h}` operators. -/

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -39,17 +39,17 @@ surrogate for the paper's vertical canonical form.
   canonical-form (biCF) field of `HorizontalCFData`.
 
 The full passage from horizontal to vertical canonical form
-(Proposition IV.12 / Proposition 4.13 of arXiv:1606.00608) is deferred to a
-follow-up PR: its blueprint entry `thm:vertical_cf_of_horizontal_cf` is marked
+(Proposition IV.12 / Proposition 4.13 of arXiv:1606.00608) is still outside
+this file: its blueprint entry `thm:vertical_cf_of_horizontal_cf` is marked
 `\notready`, and the corresponding Lean statement will be introduced together
 with its proof rather than as an empty placeholder.
 
 ## Module location
 
-The MPO/MPDO/LPDO foundations introduced by issue #235 live under `TNLean/MPS/MPDO/`
-(imported as layer 3b in `TNLean.lean`) rather than as a top-level `TNLean/MPDO/`
-namespace: they sit on top of the `MPSTensor` framework from `TNLean/MPS/`, so
-the MPS-scoped location matches the existing layering.
+The MPO/MPDO/LPDO foundations live under `TNLean/MPS/MPDO/` (imported as layer
+3b in `TNLean.lean`) rather than as a top-level `TNLean/MPDO/` namespace: they
+sit on top of the `MPSTensor` framework from `TNLean/MPS/`, so the MPS-scoped
+location matches the existing layering.
 
 ## References
 
@@ -326,7 +326,7 @@ theorem blockwise_insert_eq_of_mpv_agree
 -- of arXiv:1606.00608) — every MPDO in horizontal canonical form is in vertical
 -- canonical form — is tracked by the blueprint entry
 -- `thm:vertical_cf_of_horizontal_cf` (currently `\notready`) and will be added
--- as a theorem in a follow-up PR together with its proof. See the RFP/MPDO 3/5
--- milestone in issue #235 for the forward plan.
+-- as a theorem together with its proof once the horizontal-to-vertical
+-- canonical-form argument has been formalized.
 
 end MPOTensor


### PR DESCRIPTION
## Summary
- replaces issue-number and process references in the MPDO/RMP comments with direct mathematical boundary statements
- states the commuting-form, eta-local extraction, vertical-canonical-form, and Theorem 4.9 construction surfaces in terms of the hypotheses currently supplied
- leaves all declarations and proofs unchanged

## Validation
- `lake env lean TNLean/MPS/MPDO/CommutingForm.lean`
- `lake env lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean`
- `lake env lean TNLean/MPS/MPDO/CommutingFormBridge.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake exe lint_style --github TNLean/MPS/MPDO/CommutingForm.lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean TNLean/MPS/MPDO/CommutingFormBridge.lean TNLean/MPS/MPDO/VerticalCF.lean`
- `git diff --check -- TNLean/MPS/MPDO/CommutingForm.lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean TNLean/MPS/MPDO/CommutingFormBridge.lean TNLean/MPS/MPDO/VerticalCF.lean`
- `rg -n "issue #[0-9]+|Issue #[0-9]+|#[0-9]{3,4}|follow-up PR|milestone|audit" TNLean/MPS/MPDO/CommutingForm.lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean TNLean/MPS/MPDO/CommutingFormBridge.lean TNLean/MPS/MPDO/VerticalCF.lean` (no matches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits that clarify current hypotheses and remaining gaps; no definitions or proofs change, so behavioral risk is low.
> 
> **Overview**
> Clarifies MPDO/RFP boundary documentation by replacing issue/process references with direct statements of the currently-assumed hypotheses and what each layer proves (commuting form/GSNNCH, eta-local extraction target, vertical CF, and Theorem 4.9 construction).
> 
> No Lean declarations or proofs are modified; changes are limited to docstrings and explanatory comments/wording across the affected MPDO modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91b82b4815313024e5bb781c788b198ef7f853d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->