### PR TITLE
doc(mps): remove local history markers

### DIFF
--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -572,8 +572,8 @@ theorem sameMPV₂_blockTensor_blockTensor_mul_reindex {D : ℕ}
 map returns the direct block tensor at length `m*n`.
 
 This lemma avoids the `Fin.cast` / `Fintype.equivFin` identification and instead uses the
-explicit bijection `directToIteratedBlockIndex` (PR #1096).  It gives a clean connection
-between iterated and direct blocking without needing `groupedBlockCastAgrees`. -/
+explicit bijection `directToIteratedBlockIndex`. It gives a direct connection between iterated
+and direct blocking without needing `groupedBlockCastAgrees`. -/
 theorem reindexPhysical_directToIteratedBlockIndex_blockTensor {D : ℕ}
     (A : MPSTensor d D) (m n : ℕ) :
     reindexPhysical (directToIteratedBlockIndex d m n)

--- a/TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean
@@ -92,9 +92,10 @@ theorem duplicateScalarBlocks_not_linearIndependent_wordEntryFamily (L : ℕ) :
     simpa [x0, x1] using congrArg Sigma.fst hx
   exact Fin.zero_ne_one h01
 
-/-- Concrete obstruction to the Issue-#822 target on the current hypotheses:
-blockwise injectivity, left-canonicality, and nonzero weights do not by
-themselves imply a finite-length `wordEntryFamily` witness. -/
+/-- Concrete obstruction to deriving biCF separation from the remaining
+horizontal-canonical-form hypotheses: blockwise injectivity, left-canonicality,
+and nonzero weights do not by themselves imply a finite-length
+`wordEntryFamily` witness. -/
 theorem duplicateScalarBlocks_not_exists_linearIndependent_wordEntryFamily :
     ¬ ∃ L, LinearIndependent ℂ (wordEntryFamily duplicateScalarBlocks L) := by
   rintro ⟨L, hL⟩


### PR DESCRIPTION
## Summary
- rewrites the duplicate scalar-block obstruction so it names the missing biCF separation hypothesis directly
- removes the PR-number reference from the direct-vs-iterated blocking lemma comment
- leaves all declarations and proofs unchanged

## Validation
- `lake env lean TNLean/MPS/Core/BlockingInfrastructure.lean`
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean`
- `lake exe lint_style --github TNLean/MPS/Core/BlockingInfrastructure.lean TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean`
- `git diff --check -- TNLean/MPS/Core/BlockingInfrastructure.lean TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean`
- `rg -n "PR #[0-9]+|Issue #[0-9]+|issue #[0-9]+|#[0-9]{3,4}" TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean TNLean/MPS/Core/BlockingInfrastructure.lean` (no matches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates docstrings/comments and does not change any definitions, statements, or proofs.
> 
> **Overview**
> Updates documentation comments in `BlockingInfrastructure.lean` and `BiCFDerivation/Counterexample.lean` to remove local history/issue references and rephrase the obstruction statement to name the missing biCF separation hypothesis more directly.
> 
> All declarations and proofs remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6134a051d03150de31b7fb6f742637c2d22f674a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->