### PR TITLE
doc(parent): state martingale boundary directly

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -12,8 +12,8 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 **Root-only.** This module is currently not imported downstream — it
 formalizes the martingale-method infrastructure for the MPS
 parent-Hamiltonian spectral gap. The Friedrichs-angle estimate needed
-to close `parentHamiltonian_gapped` is tracked by issues #952 and #460
-(#190). See issue #1512 for the root-only audit.
+to close `parentHamiltonian_gapped` is the remaining analytic step; the
+root module is kept out of downstream imports until that estimate is proved.
 
 This file collects the three proof-complete infrastructure submodules:
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -32,7 +32,6 @@ variable {d D : ℕ}
 -- Maintainer note: the proof of `parentHamiltonianES_gap_bound_of_friedrichs` reduces to
 -- a Friedrichs-angle estimate for pairs of overlapping cyclic-window projectors with the
 -- coefficient required by the finite-overlap row reduction in `Martingale.Reduction`.
--- Tracked by issues #952 and #460 (#190).
 /-- Friedrichs-angle and row-sum estimate for the MPS parent Hamiltonian.
 
 This is the remaining MPS-specific martingale estimate: it should produce a
@@ -53,7 +52,6 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
   -- estimate required by `parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs`.
   -- Local projection structure, row cardinality, non-overlap positivity, kernel
   -- identification, and the spectral-theorem conversion are already formalized above.
-  -- Proof obligation tracked by #952 and #460 (#190).
   sorry
 
 /--

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -405,9 +405,8 @@ private theorem wrapping_window_matEq {A : MPSTensor d D} [NeZero D]
   exact key
 
 /-- Block injectivity strips the wrapped tail block and yields the one-sided
-compatibility `C_τ * A j * X = Y_τ * A j`.  This is the valid local
-replacement identified by the #730 audit; issue #761 asks for the missing mirror
-comparison on top of this step. -/
+compatibility `C_τ * A j * X = Y_τ * A j`. The complementary mirror comparison
+is the remaining local step needed for the two-sided wrapped-window relation. -/
 theorem wrapping_window_compatibility_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)


### PR DESCRIPTION
## Summary
- removes issue-history references from the parent-Hamiltonian martingale comments
- states the remaining step as the Friedrichs-angle estimate for overlapping cyclic-window projectors
- states the wrapped-window theorem boundary as the one-sided compatibility plus the remaining mirror comparison
- leaves declarations and proofs unchanged

## Validation
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean` (passes with the pre-existing `sorry` warning at the documented gap theorem)
- `lake env lean TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
- `lake exe lint_style --github TNLean/MPS/ParentHamiltonian/Martingale.lean TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
- `git diff --check -- TNLean/MPS/ParentHamiltonian/Martingale.lean TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
- `rg -n "issue #[0-9]+|Issue #[0-9]+|#[0-9]{3,4}|root-only audit|tracked by issues|replacement identified|audit" TNLean/MPS/ParentHamiltonian/Martingale.lean TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean TNLean/MPS/ParentHamiltonian/WrappingWindow.lean` (no matches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only updates that clarify which analytic lemmas remain to complete the martingale spectral-gap proof and the wrapped-window argument; no definitions or proofs change.
> 
> **Overview**
> Updates documentation in the root-only parent-Hamiltonian martingale modules to state the remaining missing step explicitly as the *overlapping cyclic-window Friedrichs-angle estimate* needed to close `parentHamiltonian_gapped`.
> 
> Also rewrites the `WrappingWindow` theorem comment boundary to describe the proven one-sided compatibility and identify the remaining *mirror comparison* needed for a two-sided wrapped-window relation. No Lean declarations or proof terms are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6886375ee015b88ece6a4e70aeae0c5fabf169b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->