### PR TITLE
doc(canonical): update PGVWC07 normalization boundary

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -60,9 +60,8 @@ bound.
 **Scope restriction:** The source theorem also writes the weights with
 `1 ≥ λ_j > 0`, after the proof says that the spectral radius is normalized
 without loss of generality at lines 765--766.  That global normalization is not
-part of this exact positive-length witness; extending the witness by
-the upper-bound normalization is the remaining step for the statement matching
-the theorem as printed.
+part of this exact positive-length witness; it is supplied later by the
+finite-family weight-normalization theorem.
 The boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
@@ -846,9 +845,9 @@ MPV coefficients.  This theorem is the corresponding structured form of
 
 **Scope restriction:** The source theorem's normalization `1 ≥ λ_j > 0` is not
 included here.  The theorem records positive real weights and exact
-positive-length MPV equality; the remaining step for the theorem as printed is
-to formalize the global spectral-radius normalization convention from
-lines 765--766.
+positive-length MPV equality; the global spectral-radius normalization
+convention from lines 765--766 is supplied later by the finite-family
+weight-normalization theorem.
 The boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_pgvwc07_positiveLengthWitness

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -403,7 +403,7 @@ theorem exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty
   · let dim : Fin 0 → ℕ := fun k => Fin.elim0 k
     let ν : Fin 0 → ℂ := fun k => Fin.elim0 k
     let blocks : (k : Fin 0) → MPSTensor d (dim k) := fun k => Fin.elim0 k
-    refine ⟨1, 0, dim, ν, blocks, by norm_num, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    refine ⟨1, 0, dim, ν, blocks, zero_lt_one, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
     · intro k
       exact Fin.elim0 k
     · intro k


### PR DESCRIPTION
## Summary
- updates the positive-length PGVWC07 witness comments now that finite-family weight normalization is formalized separately
- removes wording that described the upper-bound normalization as still unformalized
- replaces a small proof of `0 < 1` by `zero_lt_one`

## Validation
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`
- `lake exe lint_style --github TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake exe lint_style --github TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`
- `git diff --check`
- `rg -n "remaining step for the theorem as printed|remaining step for the statement matching|by norm_num" TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean` (no matches)

Closes no issue; continues #1857.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation wording around the PGVWC07 normalization boundary and a trivial proof tactic swap with no impact on theorem statements or core logic.
> 
> **Overview**
> Updates the *scope restriction* comments for the PGVWC07 positive-length witness and structured witness theorem to state that the missing `1 ≥ λ_j` normalization is now handled later by the finite-family weight-normalization theorem (rather than being an unformalized remaining step).
> 
> In `WeightNormalization.lean`, replaces a `by norm_num` proof of `0 < 1` in the empty-block branch with the lemma `zero_lt_one`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ef1f2d1498bc772119eea29ac4e211167dc630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->