### PR TITLE
doc(mps): state zero-block contribution directly

### DIFF
--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -106,10 +106,10 @@ If every block in an MPV phase class has the same bond dimension as the
 chosen representative of that class, then the collapsed BNT sector
 decomposition has the same total bond dimension as the original direct sum.
 
-This is the dimension bookkeeping needed in the arbitrary-input supplier:
-without the displayed same-dimension hypothesis, the quotient is allowed to
-identify MPV-phase-equivalent blocks of differing bond dimensions, and the
-length-zero MPV coefficient need not be preserved by dimension counting
+This is the length-zero dimension statement needed in the arbitrary-input
+supplier: without the displayed same-dimension hypothesis, the quotient is
+allowed to identify MPV-phase-equivalent blocks of differing bond dimensions,
+and the length-zero MPV coefficient need not be preserved by dimension counting
 alone. -/
 theorem collapsedBntSectorDecomp_totalDim_eq_sum_dim
     {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -103,14 +103,14 @@ def SameMPV₂ {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
 
 This is useful when compressions or zero-block removals change the `N = 0`
 coefficient but preserve all nonempty-chain coefficients.  The source paper
-discusses "zero blocks" (arXiv:1606.00608, Section~2.3); the Lean formalization
-refers to these as the "zero tail" for bookkeeping. -/
+discusses "zero blocks" (arXiv:1606.00608, Section~2.3): they contribute their
+bond dimension at length zero and vanish from every positive-length coefficient. -/
 def SameMPV₂Pos {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
   ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = mpv B σ
 
 /-- Full MPV equality (all lengths, including `N = 0`) implies positive-length
 MPV equality. Used to reuse all-length theorems where only the positive-length
-data are needed, e.g. when comparing zero-tail-stripped block decompositions. -/
+data are needed, for example after removing all-zero blocks. -/
 theorem SameMPV₂.toSameMPV₂Pos {d D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (h : SameMPV₂ A B) : SameMPV₂Pos A B :=
@@ -118,7 +118,7 @@ theorem SameMPV₂.toSameMPV₂Pos {d D₁ D₂ : ℕ}
 
 /-- Positive-length MPV equality plus equality of bond dimensions gives full MPV equality.
 
-This isolates the length-zero bookkeeping: at `N = 0`, the MPV coefficient is just the
+This isolates the length-zero contribution: at `N = 0`, the MPV coefficient is just the
 bond dimension. -/
 theorem SameMPV₂Pos.toSameMPV₂_of_bondDim_eq {d D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -43,7 +43,7 @@ phase-equivalent TP/primitive/irreducible blocks.
 
 * `docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex` —
   records the remaining canonical-form weight-normalization and length-zero
-  bookkeeping gaps for the arbitrary-input supplier path.
+  dimension gaps for the arbitrary-input supplier path.
 
 ## Layering
 
@@ -668,13 +668,12 @@ theorem exists_isBNTCanonicalForm_afterBlocking_pos
 
 /-- **Arbitrary-input BNT block preparation with explicit length-zero discharge.**
 
-This is a bookkeeping refinement of
-`exists_isBNTCanonicalForm_afterBlocking_pos`.  The theorem keeps the same
-prepared-block output and the same CPSV16 §II.C line-246 normalization
-hypotheses.  In addition, after a normalized BNT sector decomposition is
-chosen, it records that the positive-length MPV identity upgrades to full
-`SameMPV₂` as soon as the zero-length trace identity is supplied in the
-concrete form `D = P.totalDim`.
+This theorem refines `exists_isBNTCanonicalForm_afterBlocking_pos` by adding the
+length-zero condition. It keeps the same prepared-block output and the same
+CPSV16 §II.C line-246 normalization hypotheses. In addition, after a normalized
+BNT sector decomposition is chosen, it records that the positive-length MPV
+identity upgrades to full `SameMPV₂` as soon as the zero-length trace identity is
+supplied in the concrete form `D = P.totalDim`.
 
 It does not prove the missing normalization or the total-dimension equality;
 those are precisely the remaining arbitrary-input bridge obligations recorded

--- a/TNLean/MPS/Tactic/Basic.lean
+++ b/TNLean/MPS/Tactic/Basic.lean
@@ -14,9 +14,8 @@ for recurring proof patterns in MPS / channel / overlap files.
 
 * `mps_block_words` : direct/iterated blocking maps, `wordOfBlock` expressions
 * `mps_transfer` : transfer map unfoldings
-* `mps_zero_tail` : zero-block MPV term simplification (the Lean formalization uses
-  "zero tail" as a bookkeeping term for the paper's "zero blocks"; see
-  `TNLean.MPS.CanonicalForm.Existence`)
+* `mps_zero_tail` : zero-block MPV term simplification; the zero block contributes
+  its bond dimension at length zero and vanishes at positive length
 
 ## Tactic macros
 
@@ -42,8 +41,7 @@ register_simp_attr mps_block_words
 /-- Simp set for transfer map unfoldings. -/
 register_simp_attr mps_transfer
 
-/-- Simp set for zero-block MPV term simplification (the paper calls these "zero blocks";
-the Lean formalization uses "zero tail" as a bookkeeping name). -/
+/-- Simp set for zero-block MPV term simplification. -/
 register_simp_attr mps_zero_tail
 
 /-! ### Tactic macros -/
@@ -117,7 +115,7 @@ rewrites `mpv (zeroMPSTensor d D) σ` to `if N = 0 then (D : ℂ) else 0`.
 The user is responsible for resolving the `if` by providing the length case (e.g.
 `hN : 0 < N` or `hN : N ≠ 0`).
 
-The name "zero tail" is a Lean internal bookkeeping term; the source paper
-(arXiv:1606.00608, Section~2.3) calls these "zero blocks."
+The source paper calls these summands "zero blocks" (arXiv:1606.00608,
+Section~2.3).
 -/
 macro "zero_tail_simp" : tactic => `(tactic| simp only [mps_zero_tail])


### PR DESCRIPTION
## Summary
- replaces internal zero-tail/bookkeeping prose with the mathematical zero-block contribution
- states that all-zero blocks contribute their bond dimension at length zero and vanish from positive-length MPV coefficients
- phrases the arbitrary-input supplier total-dimension condition as a length-zero trace identity
- leaves declarations and proofs unchanged

## Validation
- `lake env lean TNLean/MPS/Defs.lean`
- `lake env lean TNLean/MPS/Tactic/Basic.lean`
- `lake env lean TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean`
- `lake exe lint_style --github TNLean/MPS/Defs.lean TNLean/MPS/Tactic/Basic.lean TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean`
- `git diff --check -- TNLean/MPS/Defs.lean TNLean/MPS/Tactic/Basic.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean`
- `rg -n "bookkeeping|zero tail|zero-tail|source-facing|Audit 2026|PR #[0-9]+|Issue #[0-9]+|issue #[0-9]+|#[0-9]{3,4}" TNLean/MPS/Defs.lean TNLean/MPS/Tactic/Basic.lean TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean` (no matches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that rephrase existing “zero tail”/dimension bookkeeping without modifying any definitions or proofs, so behavioral risk is minimal.
> 
> **Overview**
> Clarifies documentation around **all-zero (“zero block”) summands**: they contribute their *bond dimension at length zero* and vanish from all positive-length MPV coefficients, replacing internal “zero tail/bookkeeping” phrasing.
> 
> Rewords the arbitrary-input SectorBNT supplier commentary and related theorems to frame the remaining obligation as an explicit **length-zero trace/total-dimension identity** (`D = P.totalDim`), with no changes to Lean declarations or proof terms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3283ebbcd3c852b573deb4a215c00e5678c1f218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->