### PR TITLE
refactor(wielandt): centralize zero word-span bound

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -204,12 +204,8 @@ theorem exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible [NeZero D
     by_contra hL_nonpos
     have hL_zero : L = 0 := Nat.eq_zero_of_not_pos hL_nonpos
     subst L
-    have hzero :
-        wordSpan A 0 = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) :=
-      (wordSpan_eq_top_iff_isNBlkInjective A 0).mpr
-        ((isNBlkInjective_iff_blockTensor_isInjective A 0).2 hL)
     have hInj0 : IsNBlkInjective A 0 :=
-      (wordSpan_eq_top_iff_isNBlkInjective A 0).mp hzero
+      (isNBlkInjective_iff_blockTensor_isInjective A 0).2 hL
     have hD_one := bondDim_eq_one_of_isNBlkInjective_zero A hInj0
     omega
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -177,19 +177,6 @@ private theorem isInjective_of_dim_one_of_exists_nonzero
     rw [← hsingle]
     exact Submodule.span_mono (Set.singleton_subset_iff.mpr (Set.mem_range_self i₀))
 
-/-- Zero-length word products cannot span a matrix algebra of dimension at least two. -/
-private theorem wordSpan_zero_ne_top_of_two_le [NeZero D]
-    (A : MPSTensor d D) (hD : 2 ≤ D) :
-    wordSpan A 0 ≠ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) := by
-  intro h
-  have h1 : Module.finrank ℂ (wordSpan A 0) = 1 := by
-    rw [wordSpan_zero, finrank_span_singleton one_ne_zero]
-  rw [h, finrank_top] at h1
-  simp only [Module.finrank_matrix, Fintype.card_fin,
-    Module.finrank_self, mul_one] at h1
-  have hfour : 2 * 2 ≤ D * D := Nat.mul_le_mul hD hD
-  omega
-
 /-- **TP + primitive + irreducible → injective after positive blocking**.
 
 The normality witness may be zero in scalar bond dimension, so the positivity

--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -208,7 +208,10 @@ theorem exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible [NeZero D
         wordSpan A 0 = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) :=
       (wordSpan_eq_top_iff_isNBlkInjective A 0).mpr
         ((isNBlkInjective_iff_blockTensor_isInjective A 0).2 hL)
-    exact wordSpan_zero_ne_top_of_two_le A hD_ge hzero
+    have hInj0 : IsNBlkInjective A 0 :=
+      (wordSpan_eq_top_iff_isNBlkInjective A 0).mp hzero
+    have hD_one := bondDim_eq_one_of_isNBlkInjective_zero A hInj0
+    omega
 
 /-!
 ## Combined reduction: arbitrary → IsNormal (per block, for primitive blocks)
@@ -281,7 +284,10 @@ theorem exists_pos_blockTensor_isInjective_le_pow_four_of_isNormal_leftCanonical
       have hL0 : L = 0 := Nat.eq_zero_of_not_pos hnot
       have hzeroTop : wordSpan A 0 = (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) := by
         simpa [hL0] using hTop
-      exact wordSpan_zero_ne_top_of_two_le A hD2 hzeroTop
+      have hInj0 : IsNBlkInjective A 0 :=
+        (wordSpan_eq_top_iff_isNBlkInjective A 0).mp hzeroTop
+      have hD_one := bondDim_eq_one_of_isNBlkInjective_zero A hInj0
+      omega
     refine ⟨L, hLpos, hBound, ?_⟩
     exact (isNBlkInjective_iff_blockTensor_isInjective A L).1
       ((wordSpan_eq_top_iff_isNBlkInjective A L).mp hTop)

--- a/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
@@ -263,4 +263,31 @@ theorem wordSpan_zero (A : MPSTensor d D) :
   · intro hx
     exact ⟨Fin.elim0, by simp [hx]⟩
 
+/-- Zero-length word products do not span a matrix algebra of dimension at
+least two. -/
+theorem wordSpan_zero_ne_top_of_two_le [NeZero D]
+    (A : MPSTensor d D) (hD : 2 ≤ D) :
+    wordSpan A 0 ≠ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) := by
+  intro h
+  have h1 : Module.finrank ℂ (wordSpan A 0) = 1 := by
+    rw [wordSpan_zero, finrank_span_singleton one_ne_zero]
+  rw [h, finrank_top] at h1
+  simp only [Module.finrank_matrix, Fintype.card_fin,
+    Module.finrank_self, mul_one] at h1
+  have hfour : 2 * 2 ≤ D * D := Nat.mul_le_mul hD hD
+  omega
+
+/-- If the zero-length word products span the full matrix algebra, then the
+bond dimension is one. -/
+theorem bondDim_eq_one_of_isNBlkInjective_zero [NeZero D]
+    (A : MPSTensor d D) (hA : IsNBlkInjective A 0) :
+    D = 1 := by
+  by_contra hD_ne
+  have hD_pos : 0 < D := NeZero.pos D
+  have hD_ge : 2 ≤ D := by omega
+  have htop : wordSpan A 0 =
+      (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) :=
+    (wordSpan_eq_top_iff_isNBlkInjective A 0).mpr hA
+  exact wordSpan_zero_ne_top_of_two_le A hD_ge htop
+
 end MPSTensor

--- a/TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
+++ b/TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
@@ -386,22 +386,6 @@ The key insight is that the positive-level cumulative span
 stabilization properties as the full cumulative span `T_n`, so
 `V_{D²−d'+1} = M_D(ℂ)` for `D ≥ 2`. -/
 
-/-- For `D ≥ 2`, `wordSpan A 0 ≠ ⊤`: the span of the identity alone does not
-fill `M_D(ℂ)` when `D ≥ 2`. -/
-private theorem wordSpan_zero_ne_top (A : MPSTensor d D)
-    [NeZero D] (hD : 2 ≤ D) : wordSpan A 0 ≠ ⊤ := by
-  intro h
-  -- wordSpan A 0 = ℂ ∙ 1 has finrank 1
-  have h1 : Module.finrank ℂ (wordSpan A 0) = 1 := by
-    rw [wordSpan_zero, finrank_span_singleton one_ne_zero]
-  -- But wordSpan A 0 = ⊤ has finrank D² ≥ 4
-  rw [h, finrank_top] at h1
-  simp only [Module.finrank_matrix, Fintype.card_fin,
-    Module.finrank_self, mul_one] at h1
-  -- h1 : D * D = 1, but D ≥ 2
-  have : 2 * 2 ≤ D * D := Nat.mul_le_mul hD hD
-  omega
-
 /-- For `D ≥ 2` and `IsNormal A`, the index `N` with `wordSpan A N = ⊤` is ≥ 1. -/
 private theorem isNormal_index_pos [NeZero D] (hD : 2 ≤ D)
     (A : MPSTensor d D) (hN : IsNormal A) :
@@ -412,7 +396,7 @@ private theorem isNormal_index_pos [NeZero D] (hD : 2 ≤ D)
   by_contra hN0
   push Not at hN0
   interval_cases N
-  exact wordSpan_zero_ne_top A hD hNtop
+  exact wordSpan_zero_ne_top_of_two_le A hD hNtop
 
 /-- **Lemma 1, sharp positive-length version** (arXiv:0909.5347):
 For D ≥ 2, under `IsNormal`, there exists a **positive-length** word `w` with

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -98,6 +98,34 @@ The results follow~\cite{Sanz2010Quantum}.
     length~$L$ equals $\MN{D}$.
 \end{proof}
 
+\begin{lemma}[Zero-length word span]
+    \label{lem:wordspan_zero_ne_top}
+    \lean{MPSTensor.wordSpan_zero_ne_top_of_two_le}
+    \leanok
+    \uses{def:word_span}
+    If $D \ge 2$, then $S_0(A) \ne \MN{D}$.
+\end{lemma}
+
+\begin{proof}\leanok\uses{def:word_span}
+    The zero-length products consist only of the identity, so
+    $S_0(A)=\spn_{\C}\{\Id\}$ has dimension~$1$.  Since
+    $\dim \MN{D}=D^2 \ge 4$, this span cannot be all of $\MN{D}$.
+\end{proof}
+
+\begin{corollary}[$0$-block injectivity]
+    \label{cor:blk_inj_zero_dim_one}
+    \lean{MPSTensor.bondDim_eq_one_of_isNBlkInjective_zero}
+    \leanok
+    \uses{lem:wordspan_blk_inj, lem:wordspan_zero_ne_top}
+    If $A$ is $0$-block injective, then $D=1$.
+\end{corollary}
+
+\begin{proof}\leanok\uses{lem:wordspan_blk_inj, lem:wordspan_zero_ne_top}
+    By Lemma~\ref{lem:wordspan_blk_inj}, $0$-block injectivity gives
+    $S_0(A)=\MN{D}$.  Lemma~\ref{lem:wordspan_zero_ne_top} excludes
+    $D \ge 2$, hence the nonzero bond dimension must be~$1$.
+\end{proof}
+
 \begin{lemma}[Two-sided span from one nonzero matrix]
     \label{lem:two_sided_nonzero_matrix_span}
     \lean{Matrix.span_range_mul_nonzero_mul_eq_top}

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -116,8 +116,8 @@ The results follow~\cite{Sanz2010Quantum}.
     \label{cor:blk_inj_zero_dim_one}
     \lean{MPSTensor.bondDim_eq_one_of_isNBlkInjective_zero}
     \leanok
-    \uses{lem:wordspan_blk_inj, lem:wordspan_zero_ne_top}
-    If $A$ is $0$-block injective, then $D=1$.
+    \uses{lem:wordspan_blk_inj}
+    If $D \ge 1$ and $A$ is $0$-block injective, then $D=1$.
 \end{corollary}
 
 \begin{proof}\leanok\uses{lem:wordspan_blk_inj, lem:wordspan_zero_ne_top}


### PR DESCRIPTION
## Summary
- add a public `wordSpan_zero_ne_top_of_two_le` lemma next to `wordSpan_zero`
- add `bondDim_eq_one_of_isNBlkInjective_zero` for the degenerate zero-block injective case
- replace duplicated private zero-length word-span proofs in Wielandt and canonical-form normality code
- add matching blueprint entries for the two new public declarations

Progress toward #1808: this isolates the elementary fact needed for the `L₀ = 0` branch, without claiming to close the parent-Hamiltonian containment theorem.

## Validation
- `lake env lean TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean`
- `lake env lean TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean`
- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean`
- `lake build TNLean.Wielandt.SpanGrowth.NonzeroTraceProduct TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain`
- `lake exe lint_style --github TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean`
- `git diff --check`

The targeted build succeeds. During dependency rebuilding, Lean reports existing warnings in unrelated modules (`Spectral/GaugeConstruction.lean` and `NormalReduction/WeightNormalization.lean`); this PR does not touch those files. `lake exe checkdecls blueprint/lean_decls` reports existing missing declarations outside this PR, but no longer reports either new Wielandt declaration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of Lean proofs: centralizes an elementary zero-length word-span lemma and updates callers without changing theorem statements or algorithms, but touches core normality/blocking proof paths.
> 
> **Overview**
> Centralizes the previously duplicated “zero-length word products can’t span `M_D(ℂ)` for `D ≥ 2`” argument by introducing a public lemma `MPSTensor.wordSpan_zero_ne_top_of_two_le` in `CumulativeSpan.lean`, plus a derived corollary `MPSTensor.bondDim_eq_one_of_isNBlkInjective_zero` to discharge the degenerate `L = 0` injectivity case.
> 
> Updates proofs in `NormalityChain.lean` and `NonzeroTraceProduct.lean` to use these shared lemmas (removing local/private versions) and adjusts the `L = 0` contradiction branches accordingly. The blueprint is extended with matching lemma/corollary entries documenting the new public declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8051af07adae88fd32faaacbc6db7ad50c6ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->