### PR TITLE
doc(canonical): promote positive-length PGVWC07 form

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -57,12 +57,11 @@ diagonal positive-definite dual fixed point, the scalar fixed-point conclusion,
 positive weights, positive block dimensions, and the total bond-dimension
 bound.
 
-**Scope restriction:** The source theorem also writes the weights with
-`1 ≥ λ_j > 0`, after the proof says that the spectral radius is normalized
-without loss of generality at lines 765--766.  That global normalization is not
-part of this exact positive-length witness; it is supplied later by the
-finite-family weight-normalization theorem.
-The boundary is recorded in
+This witness is the unnormalized positive-length form.  The source theorem also
+writes the weights with `1 ≥ λ_j > 0`, after the proof says that the spectral
+radius is normalized without loss of generality at lines 765--766.  That global
+normalization is supplied by the finite-family weight-normalization theorem.
+The positive-length convention is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
   /-- Number of nonzero canonical blocks. -/
@@ -798,9 +797,9 @@ nonempty rings because the all-zero summand has zero MPV coefficient in positive
 length.
 
 The theorem keeps the mathematically relevant bond-dimension estimate
-\(\sum_k D_k\leq D\).  It deliberately states MPV equality only for positive
-lengths; at length zero the omitted zero block would contribute its bond
-dimension. -/
+\(\sum_k D_k\leq D\).  The canonical-form existence theorem is stated with this
+positive-length convention; the explicit zero-block theorem records the
+length-zero bookkeeping separately. -/
 theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
     (A : MPSTensor d D) :
     ∃ (r : ℕ) (dim : Fin r → ℕ)
@@ -843,12 +842,11 @@ lines 742--763, after omitting the explicit zero block from positive-length
 MPV coefficients.  This theorem is the corresponding structured form of
 `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`.
 
-**Scope restriction:** The source theorem's normalization `1 ≥ λ_j > 0` is not
-included here.  The theorem records positive real weights and exact
-positive-length MPV equality; the global spectral-radius normalization
-convention from lines 765--766 is supplied later by the finite-family
-weight-normalization theorem.
-The boundary is recorded in
+This is the unnormalized positive-length witness.  The source theorem's
+normalization `1 ≥ λ_j > 0` is supplied later by the finite-family
+weight-normalization theorem, following the global spectral-radius
+normalization convention from lines 765--766.
+The positive-length convention is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_pgvwc07_positiveLengthWitness
     (A : MPSTensor d D) :

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -18,12 +18,11 @@ normalized weight has norm at most one and one has norm one.  The statement
 also records the global scalar factor on every positive-length MPV
 coefficient.
 
-The remaining theorem-statement boundary is not the finite maximum argument,
-but which state-equivalence convention should be cited for the literal source
-theorem.  This file records both the projective convention and the exact
-convention after a positive global rescaling, with either positive-length
-equality or an explicit zero-block contribution at length zero.  The boundary
-is recorded in `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
+The canonical-form existence theorem is stated with positive-length equality
+after a positive global rescaling of the original tensor.  This file also
+records the projective convention and the complementary explicit zero-block
+statement for the length-zero coefficient.  The convention is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
 
 The projective formulation below makes that convention explicit: after the
 maximum normalization, the original tensor and the normalized weighted block
@@ -215,7 +214,8 @@ positive-length PGVWC07 witness with the projective weight normalization above.
 **Scope restriction:** The statement assumes that some positive-length MPV
 coefficient of the original tensor is nonzero.  This excludes the empty
 nonzero-block case and lets the normalization include a block of unit weight.
-The remaining statement choice for the unrestricted theorem is recorded in
+The arbitrary-input positive-length theorem allows the empty branch separately;
+the convention is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv
     (A : MPSTensor d D)
@@ -320,9 +320,9 @@ either every positive-length MPV coefficient vanishes, or, after a positive
 global rescaling of the original tensor, the normalized PGVWC07 block tensor
 has exactly the same positive-length MPV coefficients.
 
-**Scope restriction:** This theorem keeps the zero positive-length branch
-explicit and therefore does not remove the final length-zero convention needed
-for an unrestricted statement of PGVWC07 Theorem Th:TIcanonical. -/
+This theorem keeps the zero positive-length branch explicit.  The following
+theorem combines the two branches as the arbitrary-input positive-length
+canonical-form statement. -/
 theorem exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero
     (A : MPSTensor d D) :
     (∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = 0) ∨
@@ -560,9 +560,9 @@ the nonzero positive-length theorem above: either all positive-length MPV
 coefficients vanish, or the tensor has a nonempty normalized projective
 PGVWC07 block form.
 
-**Scope restriction:** This is not the unrestricted source theorem.  It records
-the zero positive-length branch explicitly; the length-zero convention for
-the length-zero/all-zero case is recorded in
+**Scope restriction:** This is the projective branch statement, not the primary
+exact positive-length theorem.  It records the zero positive-length branch
+explicitly; the length-zero convention is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero
     (A : MPSTensor d D) :

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1,25 +1,32 @@
 
 \chapter{Canonical Form Reduction}\label{ch:canonical}
 
-This chapter records several steps in the reduction of MPS tensors to
-block-diagonal forms. Two reduction schemes are relevant. The block-injective
-reduction aims at injective TP-normalized blocks and the canonical form
-conditions of Chapter~\ref{ch:block_perm}. The normal-canonical reduction uses
-a weighted family of irreducible TP-normalized blocks with primitive transfer
-maps and pairwise distinct nonzero weight moduli, in the sense
-of~\cite{Cirac2017MPDO_AnnPhys}.
-The checked reductions in this chapter are therefore conditional
-primitive-block results. They do not yet give the full
-translation-invariant canonical-form theorem of
-\cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix}, whose
-input is an arbitrary translation-invariant representation on a finite ring.
-The normalization convention is also dual to the one used in the cited theorem:
-the blocks are written in the unital orientation
+This chapter records reductions of MPS tensors to block-diagonal canonical
+forms. We use the standard convention that the physical ring has positive
+length. With this convention the all-zero summand contributes no coefficient,
+and the translation-invariant canonical form of
+\cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix}
+is stated as an exact positive-length theorem, after the global scalar
+normalization made in the proof at
+\cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
+The complementary statement retaining the zero block records the
+length-zero bookkeeping but is not the primary theorem statement.
+
+Two further reduction schemes are used later in the chapter. The
+block-injective reduction aims at injective TP-normalized blocks and the
+canonical form conditions of Chapter~\ref{ch:block_perm}. The normal-canonical
+reduction uses a weighted family of irreducible TP-normalized blocks with
+primitive transfer maps and pairwise distinct nonzero weight moduli, in the
+sense of~\cite{Cirac2017MPDO_AnnPhys}. These later reductions are conditional
+primitive-block results and should not be confused with the arbitrary-input
+PGVWC07 theorem below.
+
+The PGVWC07 blocks are written in the unital orientation
 $\sum_i A_k^i(A_k^i)^\dagger=\Id$ for
 $\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$
 \cite[Theorem~Th:TIcanonical, lines~754--758]{PerezGarcia2007Matrix},
-whereas this chapter uses
-the trace-preserving, or left-canonical, orientation
+whereas some later reductions in this chapter use the trace-preserving, or
+left-canonical, orientation
 $\sum_i (A_k^i)^\dagger A_k^i=\Id$.
 Passing to the conjugate-transposed Kraus family $K_i := (A^i)^\dagger$
 exchanges the two orientations: the transfer map of $K$ is the Frobenius adjoint
@@ -33,7 +40,8 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
 
 \begin{theorem}[Translation-invariant canonical form]%
     \label{thm:pgvwc07_ti_canonical_form}
-    \notready
+    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty}
+    \leanok
     % Source anchors for the exact source statement:
     % Papers/quant-ph_0608197/MPSarchive.tex:742 labels Th:TIcanonical.
     % Lines 742--752 state the block decomposition; lines 753--758 state the
@@ -50,34 +58,36 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     % positive fixed point before invoking any abstract block-splitting lemma,
     % and do not replace the source proof by a later primitive-block or
     % prepared-family canonical-form theorem.
-    Let a translation-invariant MPS representation on a finite ring have bond
-    dimension $D$. Then the matrices may be decomposed as
+    Let $A$ be a translation-invariant MPS representation of bond
+    dimension $D$. There is a positive scalar $s$ and a finite family of
+    blocks $A_k$, possibly empty, such that the globally rescaled tensor
+    $s^{-1}A$ has the same MPV coefficients on every positive-length ring as
     \[
-        A^i =
-        \begin{pmatrix}
-            \lambda_1 A_1^i &0                 &0\\
-            0               &\lambda_2 A_2^i   &0\\
-            0               &0                 &\cdots
-        \end{pmatrix},
+        \bigoplus_k \lambda_k A_k^i .
     \]
-    with $1 \ge \lambda_k > 0$. For each block,
+    The weights are positive and satisfy $1\geq |\lambda_k|$; if the family is
+    nonempty, then some weight has norm $1$. For each block,
     \[
         \sum_i A_k^i(A_k^i)^\dagger = \Id,
         \qquad
         \sum_i (A_k^i)^\dagger \Lambda_k A_k^i = \Lambda_k,
     \]
-    where $\Lambda_k$ is diagonal, positive, and full-rank. Moreover $\Id$ is
-    the only fixed point of
+    where $\Lambda_k$ is diagonal, positive, and full-rank. Each block has
+    positive bond dimension. Moreover $\Id$ is the only fixed point of
     $\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$, and the total bond dimension
     of the decomposition is at most $D$.
 
-    This is the source statement
-    of~\cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix}.
+    This is the positive-length form of
+    \cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix},
+    with the global spectral-radius normalization of lines~765--766 made
+    explicit. The zero-block convention for the empty word is recorded
+    separately in
+    Theorem~\ref{thm:pgvwc07_exact_rescaled_form_with_zero_tail}.
 \end{theorem}
 
 \begin{remark}[Source proof order]\label{rem:pgvwc07_ti_canonical_source_order}
-    A faithful proof of Theorem~\ref{thm:pgvwc07_ti_canonical_form}
-    should follow the proof of
+    The proof path for Theorem~\ref{thm:pgvwc07_ti_canonical_form}
+    follows the proof of
     \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}
     in its given order. Lines~765--770 normalize the spectral radius and use a
     full-rank positive fixed point to obtain the unital gauge. Lines~771--783
@@ -89,10 +99,10 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     until the identity is the only fixed point of each block. Finally,
     lines~827--832 repeat the fixed-point argument for the dual map and
     diagonalize the resulting full-rank positive fixed point by a unitary gauge.
-    Thus a formal proof should reconstruct the proof from an arbitrary
-    translation-invariant representation in this order, using later
-    primitive-block or prepared-family results only after their hypotheses have
-    been obtained from the source argument.
+    Thus the formal proof reconstructs the theorem from an arbitrary
+    translation-invariant representation in this order; later primitive-block or
+    prepared-family results are used only after their hypotheses have been
+    obtained from the source argument.
 \end{remark}
 
 \begin{theorem}[Blocked CPSV canonical-form reduction]%
@@ -157,10 +167,11 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     lines~1864--1884 of~\cite{Cirac2021Matrix}.
 \end{theorem}
 
-Theorems~\ref{thm:pgvwc07_ti_canonical_form}
-and~\ref{thm:cpgsv_canonical_form_source} are source-level targets and are
-not yet formalized as stated. This chapter develops constituent steps of the
-translation-invariant and density-operator canonical-form reductions:
+Theorem~\ref{thm:pgvwc07_ti_canonical_form} is the checked positive-length
+form of the PGVWC07 translation-invariant canonical-form theorem.
+Theorem~\ref{thm:cpgsv_canonical_form_source} remains a source-level target for the
+blocked CPSV reduction and is not yet formalized as stated. This chapter also
+develops constituent steps of the density-operator canonical-form reductions:
 invariant-subspace decomposition
 (Theorem~\ref{thm:irred_decomp}), TP gauge
 (Section~\ref{sec:tp_gauge_arbitrary}), and period-removal cyclic sectors
@@ -169,13 +180,12 @@ structural after-blocking primitive-block decomposition are recorded in
 Chapter~\ref{ch:canonical_after_blocking}
 (Theorem~\ref{thm:zero_block_separation} and
 Theorem~\ref{thm:tp_primitive_blockdecomp}). These checked statements do not
-yet supply the source normalization $|\mu_k|\le 1$ with at least one
+yet supply the CPSV source normalization $|\mu_k|\le 1$ with at least one
 unit-modulus weight, so they should not be cited as
 Theorem~\ref{thm:cpgsv_canonical_form_source}.
 
-For Theorem~\ref{thm:pgvwc07_ti_canonical_form}, the source statement itself
-remains \notready.  The source-ordered construction has now been composed into
-the exact positive-length formulation of
+For Theorem~\ref{thm:pgvwc07_ti_canonical_form}, the source-ordered
+construction is the exact positive-length formulation of
 Theorem~\ref{thm:pgvwc07_exact_rescaled_form_allow_empty}: after a positive
 global rescaling of the original tensor, the normalized weighted block tensor
 has the same MPV coefficients on every nonempty ring.  The theorem permits an
@@ -185,10 +195,9 @@ the unital block condition, the scalar fixed-point conclusion, the diagonal
 positive-definite dual fixed point, and the bond-dimension bound.
 Theorem~\ref{thm:pgvwc07_exact_rescaled_form_with_zero_tail} records the
 companion explicit zero-block convention, where the zero block supplies the
-length-zero contribution \(D_0+\sum_k D_k=D\).  The remaining choice is which
-of the exact positive-length, projective MPV, and explicit zero-block
-formulations should be the formal statement cited for the literal source
-theorem.
+length-zero contribution \(D_0+\sum_k D_k=D\).  The projective MPV formulation
+records the same normalization as a proportionality of finite-ring state
+vectors, but it is not used as the primary existence theorem.
 
 \section{Normal tensors, canonical forms, and bases of normal tensors}\label{sec:cpsv_canonical_defs}
 

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -422,31 +422,29 @@ The earlier existence path now has the following formal pieces.
           PGVWC07 Theorem~\texttt{Th:TIcanonical}.
 \end{enumerate}
 
-Thus no current \verb|\leanok| statement in the canonical-form
-chapter should be read as the full PGVWC07 translation-invariant canonical-form
-theorem. The blueprint now records the source theorem as a separate not-ready
-statement, and the checked reductions are marked as partial or scoped results.
-After the positive-length witness theorem, the finite-family part of the
-paper's convention \(1\geq \lambda_j>0\) is now formalized for a nonempty
-witness by rescaling all positive weights by their maximum.  The accompanying
-projective theorem records the state-equivalence convention under which
-PGVWC07 treats the spectral-radius normalization in
-Theorem~\texttt{Th:TIcanonical}, lines 765--766, as ``without loss of
-generality'': exact finite-ring coefficients acquire the global factor \(s^N\),
-and this is precisely a nonzero proportionality of MPV state vectors.
+Thus the primitive, peripheral-primitive, and normal-canonical-form reductions
+listed above should not be read as the PGVWC07 translation-invariant
+canonical-form theorem.  The blueprint instead uses the checked positive-length
+statement as the theorem statement for
+Theorem~\texttt{Th:TIcanonical}.  The finite-family part of the paper's
+convention \(1\geq \lambda_j>0\) is formalized by rescaling all positive
+weights by their maximum.  In exact coefficients this introduces the global
+factor \(s^N\) at length \(N\), so the primary exact statement rescales the
+original tensor by \(s^{-1}\).  The accompanying projective theorem records the
+same scalar as a nonzero proportionality of MPV state vectors.
 
 \section{Formal boundary}
 
 The currently checked primitive, peripheral-primitive, and
 normal-canonical-form reductions should therefore be read as conditional
 canonical-form theorems rather than as
-formalizations of the full source theorem.\footnote{The formal declarations are
-    listed in Section~\ref{sec:current-proof-path-audit}.}
+formalizations of the arbitrary-input source theorem.\footnote{The formal
+declarations are listed in Section~\ref{sec:current-proof-path-audit}.}
 They may be used after their hypotheses have been proved from earlier
 source-faithful reductions, but they should not be cited as giving canonical
 form directly from an arbitrary translation-invariant MPS representation.
 
-\section{What remains}
+\section{Current conclusion}
 
 A faithful formalization of PGVWC07
 Theorem~\texttt{Th:TIcanonical} should start with an arbitrary
@@ -468,20 +466,18 @@ diagonalization.  None of these steps may be replaced by a theorem that starts
 from an already prepared primitive or trace-preserving block family, because
 those hypotheses are not present in Theorem~\texttt{Th:TIcanonical}.
 
-At the present stage, the block construction, nonempty-ring exact-MPV
-witness, finite-family weight normalization, and projective interpretation of
-the global scalar factor are available.  For tensors with at least one nonzero
-positive-length MPV coefficient, these pieces have been composed into a
-nonempty normalized projective PGVWC07 form and into an exact normalized form
-after a positive global rescaling of the original tensor.  The exact
-positive-length formulation has also been stated for arbitrary input by
-allowing the nonzero-block family to be empty exactly in the branch where every
-positive-length coefficient vanishes.  The explicit zero-block/length-zero
-formulation has now also been stated: after the same positive global rescaling,
-the zero block and the normalized weighted nonzero blocks reproduce the MPV
-coefficients at every finite length, with \(D_0+\sum_kD_k=D\).  The remaining
-formal work is to decide which of these checked formulations should be promoted
-as the statement cited against Theorem~\texttt{Th:TIcanonical}.
+At the present stage, the block construction, nonempty-ring exact-MPV witness,
+finite-family weight normalization, and projective interpretation of the global
+scalar factor are available.  These pieces have been composed into the
+arbitrary-input exact positive-length theorem, allowing the nonzero-block
+family to be empty exactly in the branch where every positive-length
+coefficient vanishes.  This is the statement promoted in the blueprint as the
+formal positive-length version of Theorem~\texttt{Th:TIcanonical}.  The
+explicit zero-block/length-zero formulation is also available: after the same
+positive global rescaling, the zero block and the normalized weighted nonzero
+blocks reproduce the MPV coefficients at every finite length, with
+\(D_0+\sum_kD_k=D\).  It is kept as the companion bookkeeping convention rather
+than as the primary existence theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
This PR updates the canonical-form chapter to use the positive-length convention as the theorem surface for the PGVWC07 translation-invariant canonical-form theorem.

The main blueprint theorem now cites the checked exact positive-length normalized form after global rescaling, while the explicit zero-block statement is described as the companion length-zero bookkeeping convention. The paper-gap note and Lean docstrings are adjusted to remove the old language that treated the choice between positive-length, projective, and zero-block formulations as unresolved.

Validation:
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`
- `lake exe lint_style --github TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`
- `git diff --check -- blueprint/src/chapter/ch08_canonical.tex TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`

`cd blueprint && leanblueprint checkdecls` still fails on existing missing declarations in other blueprint entries; the newly promoted PGVWC07 declaration is not among the missing names.

Part of #1685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that retarget which already-proved Lean theorem is cited as the primary PGVWC07 statement; no computational logic or proof code is modified.
> 
> **Overview**
> Promotes the **exact positive-length, globally rescaled** PGVWC07 canonical-form theorem as the primary statement in the blueprint, switching `Translation-invariant canonical form` to cite `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` and explicitly treating the explicit zero-block theorem as *companion length-zero bookkeeping*.
> 
> Updates Lean docstrings (`TPGauge.lean`, `WeightNormalization.lean`) and the scope note (`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`) to align terminology around the *positive-length convention* and remove prior “scope restriction/boundary unresolved” framing, clarifying that weight normalization is supplied later via finite-family max-normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd02c5468c571d9adb9f59597f84cdad930563a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->