### PR TITLE
doc(canonical): trim Ch9/Ch10/Ch12 prefaces, remove legacy-dead entries, restructure PGVWC07 intermediates

### DIFF
--- a/audits/canonical_audit.md
+++ b/audits/canonical_audit.md
@@ -1,0 +1,559 @@
+# Canonical-form chapters: read-only audit
+
+Scope: blueprint chapters `ch08_canonical.tex`, `ch09_block_perm.tex`,
+`ch11b_after_blocking.tex` and their Lean files. No files modified.
+
+---
+
+## 1. Summary (~10 lines)
+
+* The PGVWC07 stack (one `structure` + 14 `exists_pgvwc07_*` theorems across
+  `NormalReduction/TPGauge.lean` and `NormalReduction/WeightNormalization.lean`)
+  is **entirely orphan**: no Lean file outside `NormalReduction/` and no
+  blueprint chapter outside `ch08_canonical.tex` consumes any `exists_pgvwc07_*`
+  or `PGVWC07PositiveLengthWitness.*` declaration. It exists solely to match
+  the literal statement of \cite[Th:TIcanonical]{PerezGarcia2007Matrix}.
+* The FT proof (`ch11_fundamental_theorem_proof.tex`) reaches Chapter 9 only
+  through `thm:tp_gauge_arbitrary` →
+  `thm:exists_common_blocked_cyclic_sector_family*` →
+  `thm:has_primitive_irreducible_cyclic_sectors_tp_irr`. None of those go
+  through PGVWC07.
+* Within the PGVWC07 stack a chain of seven intermediate "with_zeroTail",
+  "_bondDimBound", "_posMPV_bondDimBound", "_or_forall_pos_mpv_eq_zero",
+  "_allow_empty" theorems is exposed in the blueprint; only one
+  (`_allow_empty`) is plausibly worth a public statement.
+* Chapter 11b has four parallel `ft_after_blocking_*` theorems
+  (`_per_block_cyclic`, `_common_blocked_cyclic`, `_reindexed_common_sector`,
+  `_common_length_common_sector`) and one `_structural`. Only
+  `_common_length_common_sector_theorem` is consumed by Chapter 13's FT proof
+  (transitively through ch11's `unconditional_common_primitive_irreducible_blocks`).
+* `thm:cpgsv_canonical_form_source` in ch08 is `\notready` and unreferenced.
+* The Lean module `SectorComparison/CommonSectorTransport.lean` (679 lines) is
+  largely glue between `_of_blockwise / _of_word_eq /
+  _of_groupedBlockCastAgrees / _of_reindexed` formulations. After the
+  unconditional `flattenWordOfBlock_cast_eq` is proved the four are
+  interderivable; only one needs to be public.
+* Recommended action: keep
+  `thm:pgvwc07_ti_canonical_form` (= `_allow_empty`) as the single
+  blueprint-visible PGVWC07 statement; demote the rest to file-local Lean
+  lemmas. Delete `thm:cpgsv_canonical_form_source`. Collapse the
+  `ft_after_blocking_*` cluster around
+  `_common_length_common_sector_theorem`. Inline the
+  `_of_blockwise/_of_word_eq/_of_groupedBlockCastAgrees` triplets into the
+  single `_of_reindexed` form.
+
+---
+
+## 2. PGVWC07 stack classification
+
+Convention: **PRIMARY** = blueprint-visible, mathematically distinct;
+**INTERMEDIATE PLUMBING** = used only by the next member of the stack;
+**LEGACY DEAD BRANCH** = no consumers at all (Lean-file or blueprint).
+
+The dependency edges below were verified with
+`grep -rn 'NAME' TNLean blueprint/src` for each declaration. None of the
+listed declarations is consumed in `TNLean/MPS/FundamentalTheorem/**`,
+`TNLean/MPS/CanonicalForm/SectorComparison/**`,
+`TNLean/MPS/CanonicalForm/CyclicSectors/**`,
+`TNLean/MPS/BNT/**`, or in any blueprint chapter other than
+`ch08_canonical.tex`.
+
+| Lean name | Blueprint label | Classification | Downstream consumers |
+|---|---|---|---|
+| `exists_pgvwc07_unital_dualDiag_data_of_irreducible` | `thm:pgvwc07_irreducible_unital_dual_package` | INTERMEDIATE PLUMBING | only `exists_pgvwc07_unital_dualDiag_blockwise` (Lean) |
+| `exists_pgvwc07_unital_dualDiag_blockwise` | `thm:pgvwc07_blockwise_unital_dual_package` | INTERMEDIATE PLUMBING | only `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` |
+| `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` | `thm:pgvwc07_arbitrary_zero_tail_unital_dual_package` | INTERMEDIATE PLUMBING | only `_with_zeroTail_bondDimBound` |
+| `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` | `thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound` | INTERMEDIATE PLUMBING | only `_posMPV_bondDimBound` and `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail` |
+| `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` | `thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound` | INTERMEDIATE PLUMBING | only `exists_pgvwc07_positiveLengthWitness` |
+| `exists_pgvwc07_positiveLengthWitness` | `thm:pgvwc07_positive_length_witness` | INTERMEDIATE PLUMBING | only `WeightNormalization.lean` (witness packaging) |
+| `PGVWC07PositiveLengthWitness` (`structure`) | `def:pgvwc07_positive_length_witness` | INTERMEDIATE PLUMBING (data tuple bundling all witness fields; never used outside `NormalReduction/`) | only `WeightNormalization.lean` |
+| `PGVWC07PositiveLengthWitness.weight_ne_zero` | `lem:pgvwc07_positive_length_witness_weight_ne_zero` | LEGACY DEAD BRANCH | unreferenced (grep result: only its definition site). Inlinable in one line. |
+| `PGVWC07PositiveLengthWitness.exists_weight_normalization` | `thm:pgvwc07_positive_length_witness_weight_normalization` | INTERMEDIATE PLUMBING | only `_projective`, `_exact_form_after_rescaling_of_exists_ne_zero_mpv`, `_with_zeroTail` |
+| `PGVWC07PositiveLengthWitness.exists_weight_normalization_projective` | `thm:pgvwc07_positive_length_witness_weight_normalization_projective` | INTERMEDIATE PLUMBING | only `exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv` |
+| `PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv` | `lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv` | INTERMEDIATE PLUMBING | only the `_of_exists_ne_zero_mpv` projective and exact-form theorems |
+| `exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv` | `thm:pgvwc07_nonzero_normalized_projective_form` | INTERMEDIATE PLUMBING | only `_projective_form_or_forall_pos_mpv_eq_zero` |
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv` | `thm:pgvwc07_nonzero_normalized_exact_rescaled_form` | INTERMEDIATE PLUMBING | only `_or_forall_pos_mpv_eq_zero` |
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero` | `thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy` | INTERMEDIATE PLUMBING | only `_allow_empty` |
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` | `thm:pgvwc07_ti_canonical_form` (the chosen primary) | **PRIMARY** | source-faithful PGVWC07 statement; not consumed by FT path but is the headline theorem for the chapter |
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail` | `thm:pgvwc07_exact_rescaled_form_with_zero_tail` | LEGACY DEAD BRANCH | grep: not referenced in any other Lean file nor in any later blueprint chapter; ch08 mentions it only in a forward reference from the primary theorem's narrative |
+| `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero` | `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` | LEGACY DEAD BRANCH | grep: only the file that defines it; no Lean or blueprint consumer |
+
+Verification commands run for the LEGACY DEAD BRANCH entries:
+
+```
+grep -rn 'exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail'  TNLean blueprint
+grep -rn 'exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero' TNLean blueprint
+grep -rn 'PGVWC07PositiveLengthWitness.weight_ne_zero'                         TNLean blueprint
+```
+
+Each returned only the definition site (plus the import-summary docstring of
+`NormalReduction.lean` and the `thm:pgvwc07_*` blueprint entries that refer
+to them).
+
+**Refactor recommendation for the PGVWC07 stack.** Keep exactly one
+blueprint-visible PGVWC07 statement (`thm:pgvwc07_ti_canonical_form`,
+Lean: `exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`).
+Demote every other entry in this stack to a Lean-internal lemma without a
+`\lean{...}` blueprint tag — they are private to the proof of
+`_allow_empty`. The `with_zeroTail` and `_projective_form_or_forall_pos_mpv_eq_zero`
+variants are unused and can be deleted.
+
+---
+
+## 3. Duplicate / parallel naming clusters
+
+### Cluster A — PGVWC07 weight-normalization variants
+
+| Member | Differs from primary by |
+|---|---|
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` | **(primary)** |
+| `_after_rescaling_with_zeroTail` | retains an explicit zero block summand in the conclusion |
+| `_projective_form_or_forall_pos_mpv_eq_zero` | proportional MPV instead of exact after global scalar |
+| `_or_forall_pos_mpv_eq_zero` | nonzero/zero dichotomy unstapled from the empty-family conclusion |
+| `_of_exists_ne_zero_mpv` (exact and projective) | hypothesis `∃ N σ, V^{(N)}(A)_σ ≠ 0` instead of the empty-block escape |
+
+**Primary entry point to remember:** `_after_rescaling_allow_empty`.
+Drop the four others from the blueprint (they remain available in the Lean
+source as local lemmas, or can be deleted; cf. §2).
+
+### Cluster B — PGVWC07 unital-dualDiag chain
+
+| Member | Differs from primary by |
+|---|---|
+| `_data_of_irreducible` | single-block input |
+| `_blockwise` | finite-direct-sum input, unit weights |
+| `_from_arbitrary_with_zeroTail` | arbitrary input, zero block kept |
+| `_from_arbitrary_with_zeroTail_bondDimBound` | adds the length-zero `D_0 + Σ D_k = D` identity |
+| `_from_arbitrary_posMPV_bondDimBound` | strips the zero block, keeps the bound on `N ≥ 1` |
+
+**Primary entry point to remember:** `_from_arbitrary_posMPV_bondDimBound`
+(this is what feeds `exists_pgvwc07_positiveLengthWitness`).
+All preceding ones should be Lean-internal `private` / file-local lemmas
+without blueprint entries.
+
+### Cluster C — `cyclic_sector_decomp_*` triple
+
+| Member | Lean name | Public role |
+|---|---|---|
+| `thm:cyclic_sector_decomp_after_blocking` | `exists_cyclic_sector_decomp_after_blocking` | the underlying constructor (used by `_irr_tp` and `_prim_irr`) |
+| `thm:cyclic_sector_decomp_irr_tp` | `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` | LEGACY: unused outside `CyclicSectorDecomposition.lean` |
+| `thm:cyclic_sector_decomp_irr_tp_prim_irr` | `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` | feeds `hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor` (the actual FT-path input) |
+
+**Primary entry point to remember:** `_prim_irr`. The `_irr_tp` version is
+strictly weaker and is not used anywhere downstream — propose demoting to
+private.
+
+### Cluster D — `ft_after_blocking_*` family
+
+| Member | Position in dep chain | External consumer? |
+|---|---|---|
+| `thm:ft_after_blocking_structural` | duplicates `thm:tp_primitive_blockdecomp` for two tensors | no (only `\notready` narrative references) |
+| `thm:ft_after_blocking_per_block_cyclic_live_zero_tail` | input to `_common_blocked_cyclic` and `_common_length_common_sector` | only inside ch11b |
+| `thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail` | input to `_reindexed_common_sector` | only inside ch11b |
+| `thm:ft_after_blocking_reindexed_common_sector_live_zero_tail` | **never used** (verified by grep) | LEGACY DEAD |
+| `thm:ft_after_blocking_common_length_common_sector_theorem` | **the consumed one** | used by `thm:after_blocking_common_primitive_irreducible_blocks_reindexed` and (transitively) by ch11's `thm:unconditional_common_primitive_irreducible_blocks` |
+| `thm:ft_after_blocking_common_length_common_sector_reindexed` | restates the above with a word identification baked in | LEGACY DEAD (no consumer) |
+
+**Primary entry point to remember:** `_common_length_common_sector_theorem`.
+The `_per_block_cyclic_live_zero_tail` and
+`_common_blocked_cyclic_live_zero_tail` members are intermediate; they are
+fine to keep as proof steps but should not carry their own blueprint
+theorem entries (they should be folded into the proof of
+`_common_length_common_sector_theorem`).
+
+### Cluster E — zero-tail transport quadruple
+(`TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean`,
+all four variants exposed via `\lean{...}` in
+`thm:zero_tail_common_flat_of_blocked_word_comparison`)
+
+| Lean name | Differs from primary by |
+|---|---|
+| `zeroTail_commonFlat_of_blockwise` | takes a per-block `SameMPV₂` hypothesis |
+| `zeroTail_commonFlat_of_word_eq` | takes a per-block word-equation hypothesis |
+| `zeroTail_commonFlat_of_groupedBlockCastAgrees` | takes the `groupedBlockCastAgrees` predicate |
+| `zeroTail_commonFlat_of_reindexed` | takes a `SameMPV₂` between two `toTensorFromBlocks` expressions (the form actually used downstream) |
+
+The other three are intermediate lemmas. Once
+`CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq` is proved
+(it is — unconditionally), only `_of_reindexed` is needed externally.
+**Primary entry point:** `_of_reindexed`; the other three should be
+private. Symmetric for the `_commonFlatAt_*` and
+`_blockTensor_commonFlatAt_*` `\lean{...}` lists in the same blueprint
+theorem.
+
+### Cluster F — repeated bracket of "MPV phase cover" lemmas in ch11
+(`lem:common_phase_cover_of_block_matching`,
+`lem:common_phase_cover_of_equiv_phase`,
+`lem:nonzero_block_span_eq_of_common_phase_cover`,
+`lem:mpv_common_phase_cover_span_eq`,
+`lem:nonzero_block_span_eq_of_block_matching`,
+`lem:nonzero_block_span_eq_of_equiv_phase`)
+
+The pair `_of_block_matching` / `_of_equiv_phase` exists in three flavours
+(common-phase-cover, span-equality, and combined). Only the
+`_of_block_matching` chain is consumed by
+`thm:bnt_sectorDecomp_pair_overlapSpan_of_commonPhaseCover`. The
+`_of_equiv_phase` chain is not consumed by ch11/ch13. Recommend marking the
+`_of_equiv_phase` variants as auxiliary (no blueprint entry).
+
+---
+
+## 4. CPGSV17a Fundamental-Theorem bridge map
+
+### 4.1 What the FT proof actually consumes
+
+Tracing `\uses{...}` from `ch11_fundamental_theorem_proof.tex` outward:
+
+```
+ch11_fundamental_theorem_proof.tex
+├── thm:unconditional_common_primitive_irreducible_blocks  [line 858]
+│   └── thm:after_blocking_common_primitive_irreducible_blocks_reindexed  [ch11b, line 822]
+│       └── thm:ft_after_blocking_common_length_common_sector_theorem  [ch11b, line 660]
+│           ├── thm:ft_after_blocking_per_block_cyclic_live_zero_tail  [ch11b, line 511]
+│           │   ├── thm:tp_gauge_arbitrary               [ch08, line 1359]
+│           │   │   ├── thm:zero_block_separation       [ch11b, line 52]
+│           │   │   │   └── thm:irred_decomp             [ch08, line 441]
+│           │   │   └── thm:tp_data_irreducible          [ch08]
+│           │   ├── thm:nonzero_block_zero_tail_identity [ch11b, line 405]
+│           │   └── thm:has_primitive_irreducible_cyclic_sectors_tp_irr [ch08, line 2004]
+│           │       └── thm:cyclic_sector_decomp_irr_tp_prim_irr [ch08, line 1481]
+│           ├── thm:exists_common_blocked_cyclic_sector_family_common_multiple [ch08, line 2072]
+│           ├── thm:zero_tail_to_tensor_from_blocks_block_power [ch11b]
+│           ├── thm:nonzero_block_block_power_zero_tail_identity [ch11b]
+│           ├── thm:common_blocked_cyclic_sector_reindexed_samempv [ch08]
+│           └── thm:common_blocked_cyclic_sector_derived_properties [ch08]
+└── (BNT comparison lemmas, all internal to ch11/ch10)
+```
+
+### 4.2 Bridge questions answered
+
+* **Does `thm:pgvwc07_ti_canonical_form` feed into the FT proof?**
+  **No.** The label appears in `ch08_canonical.tex` only.
+  `grep -rn 'thm:pgvwc07_ti_canonical_form' blueprint/src` returns only
+  its own definition site and one self-referential paragraph. There is
+  no `\uses{thm:pgvwc07_ti_canonical_form}` anywhere in `blueprint/src/`.
+
+* **Is the only path used by the FT proof through `thm:tp_primitive_blockdecomp`?**
+  Almost. The FT proof reaches the same content one level higher, via
+  `thm:after_blocking_common_primitive_irreducible_blocks_reindexed`,
+  which uses `thm:ft_after_blocking_common_length_common_sector_theorem`,
+  not `thm:tp_primitive_blockdecomp` directly. (The two share the same
+  upstream theorems `thm:tp_gauge_arbitrary`, `thm:common_blocking_period`,
+  `thm:zero_tail_to_tensor_from_blocks_block_power`.)
+  `thm:tp_primitive_blockdecomp` is itself only consumed by the
+  one-tensor-flavoured `thm:ft_after_blocking_structural`, which is
+  unconsumed (see Cluster D).
+
+* **Does the PGVWC07 stack join the CPSV stack anywhere?**
+  No. The two stacks share only the shallow common dependencies
+  `def:irreducible_tensor`, `def:tp_kraus`, `def:transfer_map`,
+  `def:same_mpv2`, and `thm:irred_decomp`. The PGVWC07 stack uses the
+  **unital** orientation `Σ A^i (A^i)†=Id`; the CPSV / FT stack uses the
+  **left-canonical** TP orientation `Σ (A^i)† A^i=Id`. There is no
+  blueprint or Lean reduction that takes a PGVWC07 conclusion as a
+  hypothesis of a downstream theorem in ch11b or ch11.
+
+**Conclusion: the PGVWC07 stack is parallel and not bridged to the
+CPGSV17a FT chain.** The chapter preface should state this explicitly:
+the PGVWC07 stack reproduces the literal statement of
+\cite[Th:TIcanonical]{PerezGarcia2007Matrix} as a source-faithful target,
+and the canonical-form reduction used by Chapter 13's FT proof goes
+through Chapter 12 / `thm:tp_primitive_blockdecomp` /
+`thm:tp_gauge_arbitrary` / `thm:common_blocking_period` /
+`thm:has_primitive_irreducible_cyclic_sectors_tp_irr` instead.
+
+### 4.3 `thm:cpgsv_canonical_form_source` (ch08 line 108, `\notready`)
+
+* Grep result: defined once, referenced twice in the same chapter
+  (lines 172 and 185), nowhere else.
+* **No downstream `\uses{thm:cpgsv_canonical_form_source}` anywhere in
+  `blueprint/src/`.**
+* Recommendation: replace the `\begin{theorem}...\notready` block with
+  a `\begin{remark}` that cites
+  \cite[Section~II.C]{Cirac2017MPDO_AnnPhys} as the source statement,
+  and points the reader at `thm:tp_primitive_blockdecomp` /
+  `thm:paperbnt_supplier_after_blocking` as the closest checked
+  formalizations.
+
+---
+
+## 5. Concrete refactor actions, ordered by safety
+
+The orchestrator should apply these in this order; each step is locally
+verifiable.
+
+### Step 5.1 — blueprint-only (safest, no Lean recompile)
+
+1. **Delete `thm:cpgsv_canonical_form_source`** (`ch08_canonical.tex`
+   lines 108–168). Replace with a `\begin{remark}` of two sentences
+   citing \cite[Section~II.C]{Cirac2017MPDO_AnnPhys} and pointing at
+   `thm:tp_primitive_blockdecomp` and
+   `thm:paperbnt_supplier_after_blocking`. Update the two intra-chapter
+   references at lines 172 and 185.
+2. **Demote 11 of the 14 PGVWC07 blueprint entries** (those classified
+   INTERMEDIATE PLUMBING or LEGACY DEAD BRANCH in §2). For each:
+   * Remove the `\begin{theorem}...\end{theorem}` block and its
+     companion `\begin{proof}...\end{proof}`.
+   * Leave the corresponding Lean theorem in place (it remains a
+     well-named internal lemma).
+   * Re-state the closure as a single sentence in the proof sketch of
+     `thm:pgvwc07_ti_canonical_form`.
+   Specifically, drop from the blueprint:
+   ```
+   thm:pgvwc07_irreducible_unital_dual_package
+   thm:pgvwc07_blockwise_unital_dual_package
+   thm:pgvwc07_arbitrary_zero_tail_unital_dual_package
+   thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound
+   thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound
+   thm:pgvwc07_positive_length_witness
+   thm:pgvwc07_positive_length_witness_weight_normalization
+   thm:pgvwc07_positive_length_witness_weight_normalization_projective
+   thm:pgvwc07_nonzero_normalized_projective_form
+   thm:pgvwc07_nonzero_normalized_exact_rescaled_form
+   thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy
+   thm:pgvwc07_exact_rescaled_form_with_zero_tail
+   thm:pgvwc07_projective_form_zero_nonzero_dichotomy
+   lem:pgvwc07_positive_length_witness_weight_ne_zero
+   lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv
+   def:pgvwc07_positive_length_witness   ← this is the bundled `structure`; demote to Lean-only
+   ```
+   Keep `thm:pgvwc07_ti_canonical_form` (the `_allow_empty` headline).
+3. **Demote `thm:ft_after_blocking_reindexed_common_sector_live_zero_tail`
+   and `thm:ft_after_blocking_common_length_common_sector_reindexed`**
+   (both unconsumed; see Cluster D in §3). Delete their blueprint
+   entries; leave Lean declarations in place.
+4. **Demote `thm:ft_after_blocking_structural`** (line 261 of ch11b)
+   to a remark. Its Lean counterpart
+   `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂` is unused
+   outside its definition file.
+5. **Tighten the chapter prefaces** of `ch08_canonical.tex`,
+   `ch09_block_perm.tex`, `ch11b_after_blocking.tex` per
+   `docs/prose_style.md`:
+   * `ch08`: replace the four meta-paragraphs (lines 1–185) with a
+     single `\section{Scope}` (about 8 lines): names the source
+     theorem, states the unital vs left-canonical orientation
+     convention, and lists the headline statements of the chapter
+     (`thm:pgvwc07_ti_canonical_form`, `thm:irred_decomp`,
+     `thm:CFII_data`, `thm:cyclic_sector_decomp_irr_tp_prim_irr`,
+     `thm:tp_gauge_arbitrary`, `thm:exists_normal_canonical_form`).
+     Drop banned words "package" (occurs in three theorem titles —
+     `pgvwc07_irreducible_unital_dual_package`,
+     `pgvwc07_blockwise_unital_dual_package`,
+     `pgvwc07_arbitrary_zero_tail_unital_dual_package` — already
+     scheduled for removal in 5.1.2).
+   * `ch09`: cut the footnote on line 17 (move to a LaTeX comment;
+     paper-gap reference belongs in a comment, not in chapter prose).
+     The "scope distinction" sentence currently spans lines 7–18 and
+     repeats itself in `rem:pgvwc07_vs_local_cf` (line 340) — keep
+     only the remark.
+   * `ch11b`: lines 3–14 contain a five-sentence preface ending in
+     "those chapters no longer provide hypotheses for the
+     Fundamental-Theorem comparison." This phrasing repeats the
+     equivalent paragraph at the top of ch11. Replace with one
+     `\section{Scope}` of three sentences naming the two outputs
+     of the chapter: `thm:tp_primitive_blockdecomp` and
+     `thm:ft_after_blocking_common_length_common_sector_theorem`.
+6. **Sweep the "package" / "data" / "assembly" wording.** Per
+   `docs/prose_style.md` §2 these are banned. Affected blueprint
+   theorem titles (verified by grep `Definition\[.*[Dd]ata` and
+   `[Pp]ackage` in the three chapters):
+   * "unital and dual-diagonal data" → already removed in 5.1.2.
+   * `thm:pgvwc07_irreducible_unital_dual_package`,
+     `thm:pgvwc07_blockwise_unital_dual_package`,
+     `thm:pgvwc07_arbitrary_zero_tail_unital_dual_package` →
+     already removed in 5.1.2.
+   * `def:pgvwc07_positive_length_witness` "positive-length PGVWC07
+     canonical-form witness" — the bundled structure stays in Lean,
+     but the blueprint definition is removed (see 5.1.2).
+   * In ch11_fundamental_theorem_proof.tex the term "MPV phase cover
+     data" appears in the `def:mpv_common_phase_cover` definition
+     paragraph (line 605–615); the surrounding paragraphs use "data"
+     non-vaguely (it refers to the bundled tuple); per
+     `docs/prose_style.md` §3 this is allowed.
+
+### Step 5.2 — Lean refactor (touches no math content)
+
+7. **Move PGVWC07 declarations to a Lean-internal namespace.** Rename
+   `NormalReduction/TPGauge.lean` decls that are no longer
+   blueprint-visible into a `namespace MPSTensor.PGVWC07` and prefix
+   with `_aux_` (or move into a new file
+   `NormalReduction/Internal/PGVWC07Stack.lean`). This leaves the
+   public API as exactly
+   * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`
+     (kept; matches `thm:pgvwc07_ti_canonical_form`).
+   * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` (kept;
+     consumed by `CommonSectorData.lean` and `TPPrimitiveReduction.lean`).
+   No compile risk: every non-exported declaration loses only its
+   blueprint tag, not its Lean callers (which are all in the same
+   sub-folder).
+8. **Inline the three duplicate `zeroTail_commonFlat_of_*` lemmas.**
+   In `SectorComparison/CommonSectorTransport.lean`, mark
+   `zeroTail_commonFlat_of_blockwise`,
+   `zeroTail_commonFlat_of_word_eq`, and
+   `zeroTail_commonFlat_of_groupedBlockCastAgrees` `private`
+   (and likewise their `_commonFlatAt_*` and `sameMPV₂Pos_*` siblings).
+   The only public statement needed is `_of_reindexed`. Update the
+   `\lean{...}` block of
+   `thm:zero_tail_common_flat_of_blocked_word_comparison` to list one
+   declaration. Compile risk: low — the three "_of_blockwise/_of_word_eq
+   /_of_groupedBlockCastAgrees" variants are not referenced outside
+   the same file (verified by `grep -rn ... TNLean`).
+9. **Demote `exists_blockTensor_isPrimitive` and
+   `exists_blockTensor_leftCanonical_isPrimitive`** in
+   `CanonicalForm/Existence.lean` lines 216, 232 — these are `NeZero`-
+   wrappers around `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`
+   and are unused outside that file. Either inline at the one call
+   site or make them `private`. No blueprint impact (they carry no
+   `\lean{...}` blueprint tag).
+10. **Demote `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`**
+    (`SectorComparison/CyclicSectorDecomposition.lean` line 79). It is
+    unused outside its definition file; the consumed entry is
+    `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`.
+    Mark `private` or delete; drop the blueprint entry
+    `thm:cyclic_sector_decomp_irr_tp` (Cluster C in §3).
+11. **Reduce the `CommonSectorRelabelingHypothesis` /
+    `CommonGroupedBlockCastHypothesis` pair to one definition.**
+    `CommonSectorTransport.lean` lines 365 and 381 both define a
+    `Prop`-level abbreviation; their relationship is captured by
+    `CommonGroupedBlockCastHypothesis.toRelabelingHypothesis` and
+    `of_flattenWordOfBlock_cast_eq` proves the latter unconditionally.
+    Recommend collapsing to a single `private abbrev` and inlining the
+    proof of `unconditional_commonPrimitiveIrreducibleBlocks` so it
+    does not pass through the abbrev at all.
+
+### Step 5.3 — deletions (only after Steps 5.1–5.2 land)
+
+12. After Step 5.1, **delete the dead Lean theorems** identified as
+    LEGACY DEAD BRANCH in §2 once nothing references their `\lean{...}`
+    tags from the blueprint:
+    * `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail`
+    * `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`
+    * `PGVWC07PositiveLengthWitness.weight_ne_zero`
+    Compile risk: none after Step 5.1.2 (these are file-local).
+13. **Delete the dead Lean theorems behind the Cluster D entries:**
+    * `MPSTensor.afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂`
+      (`SectorComparison/CommonSectorData.lean`)
+    * `MPSTensor.afterBlocking_commonLengthCommonSectorData_of_reindexed`
+      (`SectorComparison/CommonSectorTransport.lean`)
+    * `MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`
+      (`SectorComparison/StructuralData.lean`)
+    Compile risk: low — `grep -rn` over `TNLean` returns only their
+    definition files.
+
+---
+
+## 6. Per-action file / label / replacement-name lists
+
+### 6.1 Files and labels for Step 5.1 (blueprint deletions)
+
+| File | Range / Label | Action | Replacement | Compile risk |
+|---|---|---|---|---|
+| `blueprint/src/chapter/ch08_canonical.tex` | lines 108–168 (`thm:cpgsv_canonical_form_source`) | delete | `\begin{remark}[CPSV blocked canonical form]\label{rem:cpgsv_canonical_form_source} …\end{remark}` with two-sentence pointer | none (blueprint only) |
+| `blueprint/src/chapter/ch08_canonical.tex` | `thm:pgvwc07_irreducible_unital_dual_package` (≈ line 802) | delete entry; inline into proof sketch of `thm:pgvwc07_ti_canonical_form` | n/a (no replacement label) | none |
+| same | `thm:pgvwc07_blockwise_unital_dual_package` (≈ 844) | delete | n/a | none |
+| same | `thm:pgvwc07_arbitrary_zero_tail_unital_dual_package` (≈ 882) | delete | n/a | none |
+| same | `thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound` (≈ 924) | delete | n/a | none |
+| same | `thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound` (≈ 950) | delete | n/a | none |
+| same | `def:pgvwc07_positive_length_witness` (≈ 985) | delete from blueprint; structure stays Lean-only | n/a | none |
+| same | `lem:pgvwc07_positive_length_witness_weight_ne_zero` (≈ 1002) | delete | n/a | none |
+| same | `thm:pgvwc07_positive_length_witness_weight_normalization` (≈ 1030) | delete | n/a | none |
+| same | `thm:pgvwc07_positive_length_witness_weight_normalization_projective` (≈ 1061) | delete | n/a | none |
+| same | `lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv` (≈ 1092) | delete | n/a | none |
+| same | `thm:pgvwc07_nonzero_normalized_projective_form` (≈ 1112) | delete | n/a | none |
+| same | `thm:pgvwc07_nonzero_normalized_exact_rescaled_form` (≈ 1140) | delete | n/a | none |
+| same | `thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy` (≈ 1173) | delete | n/a | none |
+| same | `thm:pgvwc07_exact_rescaled_form_with_zero_tail` (≈ 1216) | delete | n/a | none |
+| same | `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` (≈ 1246) | delete | n/a | none |
+| same | `thm:pgvwc07_ti_canonical_form` (≈ 41) | **keep**; trim the `% Source anchors` block (lines 46–60) into a single bibliographic citation; remove forward reference to the now-deleted `thm:pgvwc07_exact_rescaled_form_with_zero_tail` (line 85). | replace forward reference by a remark | none |
+| `blueprint/src/chapter/ch11b_after_blocking.tex` | `thm:ft_after_blocking_structural` (line 261) | demote to remark | `\begin{remark}…` cites `thm:tp_primitive_blockdecomp` | none |
+| same | `thm:ft_after_blocking_reindexed_common_sector_live_zero_tail` (line 614) | delete | n/a | none |
+| same | `thm:ft_after_blocking_common_length_common_sector_reindexed` (line 1011) | delete | n/a | none |
+| `blueprint/src/chapter/ch09_block_perm.tex` | preface (lines 1–18) and `rem:pgvwc07_vs_local_cf` (line 340) | consolidate into one `\section{Scope}` + one `\begin{remark}` | scope statement names the chapter's three outputs (`thm:pi_auto_decomp`, `thm:pi_linear_ext`, `lem:block_sep`/`lem:block_sep_normal`/`lem:ft_canonical`) | none |
+
+### 6.2 Files and decl names for Step 5.2 (Lean refactor)
+
+| File | Declaration | Action | Replacement / new name | Compile risk |
+|---|---|---|---|---|
+| `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_data_of_irreducible` | `private` (or rename to `MPSTensor.PGVWC07.unital_dualDiag_single_block`) | keep call sites | none — file-local |
+| same | `exists_pgvwc07_unital_dualDiag_blockwise` | `private` | `MPSTensor.PGVWC07.unital_dualDiag_blockwise` | none |
+| same | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` | `private` | `MPSTensor.PGVWC07.unital_dualDiag_arbitrary_with_zeroTail` | none |
+| same | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` | `private` | rename to `…_bondDim_total_eq` (the conclusion is `D_0 + Σ = D`, not a bound) | none |
+| same | `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` | `private` | rename to `…_positive_length` | none |
+| same | `exists_pgvwc07_positiveLengthWitness` | `private` | `MPSTensor.PGVWC07.positiveLengthWitness` | none |
+| same | `PGVWC07PositiveLengthWitness` (`structure`) | move to `namespace MPSTensor.PGVWC07`; rename to `Internal.PositiveLengthWitness` | keep all field names | none |
+| `TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean` | all `_normalized_*` theorems except `_allow_empty` | `private` | drop `pgvwc07_` from the names since the file is already `NormalReduction/` | none |
+| `TNLean/MPS/CanonicalForm/Existence.lean` | `exists_blockTensor_isPrimitive` (line 216), `exists_blockTensor_leftCanonical_isPrimitive` (line 232) | `private` (or delete and inline) | n/a | none — file-local |
+| `TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean` | `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` (line 79) | `private` | n/a | none — file-local |
+| `TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlat_of_blockwise`, `_of_word_eq`, `_of_groupedBlockCastAgrees`, and their `_commonFlatAt_*` and `sameMPV₂Pos_blockTensor_commonFlatAt_*` companions | `private` | keep public: `_of_reindexed`, `_commonFlatAt_of_reindexed`, `sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed`, `zeroTail_commonFlat_transport_of_reindexed`, and the abbrev pair | none — all callers in same file |
+| `TNLean/MPS/CanonicalForm/CommonPeriodCyclicSectors.lean` | `commonPeriodBlocking_apply` (`rfl`-lemma, line 60) | mark `@[simp]` or delete | n/a | none |
+
+### 6.3 Files and decl names for Step 5.3 (Lean deletions)
+
+| File | Declaration | Action | Compile risk |
+|---|---|---|---|
+| `TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail`, `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero` | delete | none — verified zero external references |
+| `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean` | `PGVWC07PositiveLengthWitness.weight_ne_zero` (after the `structure` move in 5.2) | delete (inline at single use) | none |
+| `TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean` | `afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂` | delete | none |
+| `TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean` | `afterBlocking_commonLengthCommonSectorData_of_reindexed` | delete | none |
+| `TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean` | `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂` (line 185) | delete | none — only consumer is the now-removed blueprint entry `thm:ft_after_blocking_structural` |
+
+### 6.4 Replacement-name guidance per `docs/blueprint_style_guide.md` + `docs/prose_style.md`
+
+* Banned in titles: "package", "assembly", "data" (as bare noun),
+  "wiring", "bridge", "plumbing". The current titles
+  "Single irreducible-block PGVWC07 canonical-form theorem" (line 802)
+  → after removal becomes a proof step "Single-block normalization" inside
+  the proof of `thm:pgvwc07_ti_canonical_form`. No new heading needed.
+* Theorem heading style: keep "Translation-invariant canonical form"
+  (line 41) — already source-faithful; remove the trailing
+  `% Source anchors` block (16 lines of LaTeX comments) and replace
+  with one `\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}` in the
+  body.
+* Lean section names with "Assembly" — verified via
+  `grep -rn 'section Assembly' TNLean/MPS/CanonicalForm` (no matches).
+  The Lean code is already clean on this point.
+
+---
+
+## 7. Verification log
+
+The following grep commands were used to verify the consumer claims in
+§2 and §4. The reported counts are the number of lines returned at audit
+time; the orchestrator can re-run them after applying each step.
+
+```
+grep -rn 'exists_pgvwc07_' TNLean blueprint
+    →  every hit is in NormalReduction/TPGauge.lean,
+       NormalReduction/WeightNormalization.lean,
+       NormalReduction.lean (import summary),
+       ch08_canonical.tex, or docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
+       Zero hits in FundamentalTheorem/, BNT/, SectorComparison/,
+       CyclicSectors/, ch09_block_perm.tex, ch11b_after_blocking.tex,
+       ch11_fundamental_theorem_proof.tex, ch10_bnt.tex, ch13_*.tex,
+       Periodic/, ParentHamiltonian/, Symmetry/.
+
+grep -rn 'thm:cpgsv_canonical_form_source' blueprint
+    →  3 hits, all in ch08_canonical.tex (definition + 2 self-references).
+
+grep -rn '\\uses{thm:pgvwc07' blueprint
+    →  0 hits.
+
+grep -rn 'thm:ft_after_blocking_common_length_common_sector_theorem' blueprint
+    → 6 hits, all in ch11b_after_blocking.tex (as expected — internal
+      chain) plus 1 indirect consumer through
+      thm:after_blocking_common_primitive_irreducible_blocks_reindexed,
+      which is `\uses`-cited by ch11_fundamental_theorem_proof.tex
+      line 862.
+
+grep -rn 'exists_tp_gauge_from_arbitrary_with_zeroTail' TNLean
+    →  consumed by SectorComparison/CommonSectorData.lean,
+       SectorComparison/TPPrimitiveReduction.lean, and listed in
+       StructuralData.lean's docstring. This is the actual
+       canonical-form input fed into Chapter 12's primitive
+       block decomposition.
+```
+
+The single canonical "bridge declaration" the user is looking for is
+`MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
+(`thm:tp_gauge_arbitrary`). The PGVWC07 stack is **parallel** to this
+bridge, not part of it.

--- a/audits/canonical_audit.md
+++ b/audits/canonical_audit.md
@@ -3,6 +3,19 @@
 Scope: blueprint chapters `ch08_canonical.tex`, `ch09_block_perm.tex`,
 `ch11b_after_blocking.tex` and their Lean files. No files modified.
 
+> **Post-audit decision.** After review, the recommendation in §5.1.2
+> below — to demote the 11 INTERMEDIATE PLUMBING PGVWC07 entries from
+> the blueprint — was *partially* reversed: the 13 intermediate entries
+> are restored as a dedicated reader-visible section
+> `sec:pgvwc07_intermediates` because they record the source proof
+> order of \cite[Th:TIcanonical]{PerezGarcia2007Matrix} and serve as
+> mathematical waypoints. Only the LEGACY DEAD BRANCH entries (no
+> consumer at all) stay deleted. See
+> `audits/pgvwc07_restoration_report.md` for the restoration log.
+> The summary and §5 recommendations below reflect the original audit
+> classification; §2 (the per-declaration classification table) and
+> §3–§4 remain accurate.
+
 ---
 
 ## 1. Summary (~10 lines)
@@ -298,6 +311,18 @@ verifiable.
      well-named internal lemma).
    * Re-state the closure as a single sentence in the proof sketch of
      `thm:pgvwc07_ti_canonical_form`.
+
+   > **Status update (post-audit).** After review, the INTERMEDIATE
+   > PLUMBING entries were restored as a dedicated blueprint section
+   > `sec:pgvwc07_intermediates` because they record the source proof
+   > order of \cite[Th:TIcanonical]{PerezGarcia2007Matrix} and are
+   > worth keeping as reader-visible mathematical waypoints. See
+   > `audits/pgvwc07_restoration_report.md` for the restoration log.
+   > The LEGACY DEAD BRANCH entries below (`_with_zero_tail`,
+   > `_projective_form_zero_nonzero_dichotomy`,
+   > `_weight_ne_zero`, and the duplicate
+   > `_exact_rescaled_form_allow_empty`) stay deleted.
+
    Specifically, drop from the blueprint:
    ```
    thm:pgvwc07_irreducible_unital_dual_package

--- a/audits/pgvwc07_restoration_report.md
+++ b/audits/pgvwc07_restoration_report.md
@@ -23,10 +23,10 @@ This report records a partial reversal of Step 5.1 (blueprint trim) and Step 5.2
 PGVWC07 entries listed in `audits/canonical_audit.md` §2 as INTERMEDIATE
 PLUMBING — recording the source proof structure of
 \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix} — have been restored to
-the blueprint, and their corresponding Lean declarations have been
-un-privatized. The four LEGACY DEAD BRANCH entries identified in the audit
-remain deleted from the blueprint, and the Lean code for those was already
-removed in Step 5.2 and stays removed.
+the blueprint (PR #1992), and their corresponding Lean declarations are
+un-privatized in companion PR #1993. The four LEGACY DEAD BRANCH entries
+identified in the audit remain deleted from the blueprint, and the Lean code
+for those is deleted in PR #1993.
 
 ## (a) Restored blueprint entries
 
@@ -94,9 +94,11 @@ The four LEGACY DEAD BRANCH labels classified in
 * `thm:pgvwc07_exact_rescaled_form_allow_empty` (duplicate of the headline
   `thm:pgvwc07_ti_canonical_form` — same Lean tag)
 * `thm:pgvwc07_exact_rescaled_form_with_zero_tail` (Lean decl deleted in
-  Step 5.2)
-* `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` (Lean decl deleted)
-* `lem:pgvwc07_positive_length_witness_weight_ne_zero` (Lean decl deleted)
+  companion PR #1993)
+* `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` (Lean decl deleted in
+  companion PR #1993)
+* `lem:pgvwc07_positive_length_witness_weight_ne_zero` (Lean decl deleted in
+  companion PR #1993)
 
 ## (b) `private` keywords removed
 

--- a/audits/pgvwc07_restoration_report.md
+++ b/audits/pgvwc07_restoration_report.md
@@ -1,0 +1,204 @@
+# PGVWC07 intermediate-step restoration report
+
+This report records a partial reversal of Step 5.1 (blueprint trim) and Step 5.2
+(Lean privatization) of the canonical-form refactor. The 13 intermediate
+PGVWC07 entries listed in `audits/canonical_audit.md` §2 as INTERMEDIATE
+PLUMBING — recording the source proof structure of
+\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix} — have been restored to
+the blueprint, and their corresponding Lean declarations have been
+un-privatized. The four LEGACY DEAD BRANCH entries identified in the audit
+remain deleted from the blueprint, and the Lean code for those was already
+removed in Step 5.2 and stays removed.
+
+## (a) Restored blueprint entries
+
+A new section
+`\section{Source-faithful PGVWC07 intermediate steps}\label{sec:pgvwc07_intermediates}`
+has been appended to `blueprint/src/chapter/ch08_canonical.tex`. It opens
+with an 8-line preface explaining that the 13 entries follow the source proof
+order and are not consumed by the canonical-form reduction used in the proof
+of the Fundamental Theorem. The 13 entries appear in the same order they had
+in the original (pre-Step-5.1) chapter:
+
+1. `thm:pgvwc07_irreducible_unital_dual_package`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible`)
+2. `thm:pgvwc07_blockwise_unital_dual_package`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise`)
+3. `thm:pgvwc07_arbitrary_zero_tail_unital_dual_package`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`)
+4. `thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`)
+5. `thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`)
+6. `def:pgvwc07_positive_length_witness`
+   (Lean: `MPSTensor.PGVWC07PositiveLengthWitness`)
+7. `thm:pgvwc07_positive_length_witness_weight_normalization`
+   (Lean: `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization`)
+8. `thm:pgvwc07_positive_length_witness_weight_normalization_projective`
+   (Lean: `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`)
+9. `lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv`
+   (Lean: `MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`)
+10. `thm:pgvwc07_nonzero_normalized_projective_form`
+    (Lean: `MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`)
+11. `thm:pgvwc07_nonzero_normalized_exact_rescaled_form`
+    (Lean: `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`)
+12. `thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy`
+    (Lean: `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`)
+13. `thm:pgvwc07_positive_length_witness`
+    (Lean: `MPSTensor.exists_pgvwc07_positiveLengthWitness`)
+
+### LaTeX title renames in the restored block
+
+In the original HEAD version, three of these entries used the banned word
+"package" (per `docs/prose_style.md` §2). Per the restoration task, the
+displayed titles have been renamed:
+
+* (entry 1) "Single irreducible-block PGVWC07 canonical-form theorem" — kept
+  as is (already source-faithful and free of banned terms).
+* (entry 2) "Blockwise PGVWC07 unital and dual-diagonal data" → "Blockwise
+  PGVWC07 unital and dual-diagonal block decomposition".
+* (entry 3) "Arbitrary-input PGVWC07 unital dual-diagonal form with zero
+  block" — kept as is (already neutral).
+
+The blueprint labels are unchanged. The Lean tags (the `\lean{...}` arguments)
+are unchanged: they remain `exists_pgvwc07_unital_dualDiag_*` and
+`PGVWC07PositiveLengthWitness*`.
+
+Inside the body of entry 2 the phrase "blockwise assembly of \cite[...]
+{PerezGarcia2007Matrix}" was replaced by "blockwise composition of \cite[...]
+{PerezGarcia2007Matrix}" to comply with the §2 ban on "assembly".
+
+### Legacy-dead entries kept removed
+
+The four LEGACY DEAD BRANCH labels classified in
+`audits/canonical_audit.md` §2 remain absent from the blueprint:
+
+* `thm:pgvwc07_exact_rescaled_form_allow_empty` (duplicate of the headline
+  `thm:pgvwc07_ti_canonical_form` — same Lean tag)
+* `thm:pgvwc07_exact_rescaled_form_with_zero_tail` (Lean decl deleted in
+  Step 5.2)
+* `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` (Lean decl deleted)
+* `lem:pgvwc07_positive_length_witness_weight_ne_zero` (Lean decl deleted)
+
+## (b) `private` keywords removed
+
+The following 10 theorems had their `private` keyword removed:
+
+In `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`:
+
+* `exists_pgvwc07_unital_dualDiag_data_of_irreducible`
+* `exists_pgvwc07_unital_dualDiag_blockwise`
+* `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`
+* `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`
+
+In `TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`:
+
+* `PGVWC07PositiveLengthWitness.exists_weight_normalization`
+* `PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`
+* `PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`
+* `exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`
+* `exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`
+* `exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`
+
+The structure `MPSTensor.PGVWC07PositiveLengthWitness` was already public
+during Step 5.2 (because of cross-file usage between `TPGauge.lean` and
+`WeightNormalization.lean`); confirmed by
+`grep -n "structure PGVWC07PositiveLengthWitness" TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
+returning `73:structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where`
+with no `private` keyword. Likewise the existence theorem
+`exists_pgvwc07_positiveLengthWitness` and the bond-dim bound theorem
+`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
+in `TPGauge.lean` were already public prior to this restoration.
+
+The three remaining `private theorem` declarations in `TPGauge.lean`
+(`isIrreducibleAction_gaugeEquiv`, `isIrreducibleTensor_tpGauge_of_isIrreducibleTensor`,
+and `scalar_fixedPoints_unitaryConj`) are auxiliary gauge-transport lemmas with
+no blueprint entry and no external API role; they stay `private`. This matches
+the module docstring updates in `TPGauge.lean` and `WeightNormalization.lean`,
+and the bullet list in the top-level `TNLean/MPS/CanonicalForm/NormalReduction.lean`
+docstring, which now lists all 12 restored declarations + the headline
+`exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`.
+
+## (c) Final blueprint LOC for `ch08_canonical.tex`
+
+```
+$ wc -l blueprint/src/chapter/ch08_canonical.tex
+    1987 blueprint/src/chapter/ch08_canonical.tex
+```
+
+(Up from 1608 LOC before restoration; the appended section adds 379 lines.)
+
+## (d) Final `lake build` time
+
+```
+Build completed successfully (8728 jobs).
+
+real    0m57.914s
+user    0m44.064s
+sys     0m33.618s
+```
+
+`lake build` exit 0. The pre-existing `sorry`-warnings in
+`TNLean/MPS/Periodic/Overlap/*.lean` and the single long-line style warning
+in `TNLean/Spectral/GaugeConstruction.lean` are unrelated to this restoration
+and are unchanged.
+
+## (e) Confirmation that `leanblueprint web` ran cleanly
+
+```
+$ cd blueprint && rm -f src/print.aux print/print.aux && leanblueprint web 2>&1 | tail -10
+... (chapter list, no errors)
+exit=0
+```
+
+`grep -iE 'error|undef|missing' /tmp/blueprint.log | grep -ivE 'unrecognized command'`
+returns empty. The only warnings in the leanblueprint output are pre-existing
+plasTeX `unrecognized command/environment` notes for TikZ macros and "Using
+default renderer" messages for PEPS environments — both pre-date this
+restoration and are unaffected by it.
+
+## Verification command results
+
+Verification step 3 from the task:
+
+```
+$ grep -nE '\\label\{(thm|def|lem):pgvwc07' blueprint/src/chapter/ch08_canonical.tex
+32:    \label{thm:pgvwc07_ti_canonical_form}
+697:    \label{thm:pgvwc07_dual_diag_unital}
+1626:    \label{thm:pgvwc07_irreducible_unital_dual_package}
+1667:    \label{thm:pgvwc07_blockwise_unital_dual_package}
+1704:    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+1741:    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+1766:    \label{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+1800:    \label{def:pgvwc07_positive_length_witness}
+1817:    \label{thm:pgvwc07_positive_length_witness_weight_normalization}
+1847:    \label{thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+1877:    \label{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}
+1896:    \label{thm:pgvwc07_nonzero_normalized_projective_form}
+1923:    \label{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+1955:    \label{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
+1971:    \label{thm:pgvwc07_positive_length_witness}
+```
+
+This lists 15 labels rather than the 14 stated in the task's verification
+clause. The 13 restored labels + the kept headline `thm:pgvwc07_ti_canonical_form`
+account for 14; the 15th label `thm:pgvwc07_dual_diag_unital` is the
+"Dual diagonalization for irreducible unital blocks" theorem at line 697 of
+the trimmed chapter — it was kept in the post-Step-5.1 trim because it is a
+prerequisite of the restored `thm:pgvwc07_irreducible_unital_dual_package`
+(used in its proof). It is not in the restoration list and is not a
+LEGACY DEAD BRANCH entry, so it is correct to leave it in place. The task's
+"exactly 14" count appears to have overlooked this pre-existing entry.
+
+Verification step 4 from the task:
+
+```
+$ grep -nE '\\lean\{MPSTensor\.(exists_pgvwc07_|PGVWC07)' blueprint/src/chapter/ch08_canonical.tex | wc -l
+      14
+```
+
+Exactly 14, as expected: 13 restored entries each have one such `\lean{...}`
+tag, and the headline `thm:pgvwc07_ti_canonical_form` carries one more. The
+`thm:pgvwc07_dual_diag_unital` entry uses the Lean tag
+`MPSTensor.exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor`,
+which is correctly excluded by this regex.

--- a/audits/pgvwc07_restoration_report.md
+++ b/audits/pgvwc07_restoration_report.md
@@ -1,5 +1,23 @@
 # PGVWC07 intermediate-step restoration report
 
+> **PR split note.** This report describes the *combined* restoration across
+> two stacked pull requests:
+>
+> * **PR #1992 (this PR, `cleanup/canonical-blueprint-trim`)** — restores the
+>   13 INTERMEDIATE PLUMBING entries to
+>   `blueprint/src/chapter/ch08_canonical.tex` in the new section
+>   `sec:pgvwc07_intermediates`. Section (a) below.
+> * **PR #1993 (companion, `cleanup/canonical-lean-trim`)** — un-privatizes
+>   the corresponding 10 Lean declarations whose blueprint entries are
+>   restored here. Section (b) below.
+>
+> All Lean declarations referenced by the restored blueprint entries are
+> *already public on `main`*, so PR #1992 stands alone:
+> `leanblueprint web` runs cleanly against `main`. The un-privatization
+> in PR #1993 only matters once the companion PR's privatization edits are
+> applied. Sections (b)–(e) below therefore describe state that exists on
+> the *stack of both PRs*, not on PR #1992 in isolation.
+
 This report records a partial reversal of Step 5.1 (blueprint trim) and Step 5.2
 (Lean privatization) of the canonical-form refactor. The 13 intermediate
 PGVWC07 entries listed in `audits/canonical_audit.md` §2 as INTERMEDIATE

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -115,7 +115,7 @@ obtained from primitive blocks).
     arbitrary translation-invariant MPS tensor becomes, after blocking by some
     period $p\ge 1$, the direct sum of an all-zero summand and a weighted
     family of normal tensors $\bigoplus_k \mu_k B_k$ with $|\mu_k|\le 1$ and
-    at least one $|\mu_k|=1$. The closest checked formalizations are
+    at least one $|\mu_k|=1$. The closest proved results in this chapter are
     Theorem~\ref{thm:tp_primitive_blockdecomp} and
     Theorem~\ref{thm:paperbnt_supplier_after_blocking}; neither yet supplies
     the source upper normalization $|\mu_k|\le 1$ with at least one

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2,41 +2,31 @@
 \chapter{Canonical Form Reduction}\label{ch:canonical}
 
 This chapter records reductions of MPS tensors to block-diagonal canonical
-forms. We use the standard convention that the physical ring has positive
-length. With this convention the all-zero summand contributes no coefficient,
-and the translation-invariant canonical form of
-\cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix}
-is stated as an exact positive-length theorem, after the global scalar
-normalization made in the proof at
-\cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
-The complementary statement retaining the zero block records the
-length-zero bookkeeping but is not the primary theorem statement.
+forms, following~\cite{PerezGarcia2007Matrix}, \cite{Cirac2017MPDO_AnnPhys},
+\cite{Cirac2021Matrix}, and \cite[Chapter~6]{Wolf2012Quantum}. The unital
+orientation $\sum_i A_k^i(A_k^i)^\dagger=\Id$ is used by
+\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}; the trace-preserving
+(left-canonical) orientation $\sum_i (A_k^i)^\dagger A_k^i=\Id$ is used by
+the reductions of Chapter~\ref{ch:canonical_after_blocking}. The two
+orientations exchange under the conjugate-transposed Kraus family
+$K_i:=(A^i)^\dagger$, whose transfer map is the Frobenius adjoint of $\E_A$.
 
-Two further reduction schemes are used later in the chapter. The
-block-injective reduction aims at injective TP-normalized blocks and the
-canonical form conditions of Chapter~\ref{ch:block_perm}. The normal-canonical
-reduction uses a weighted family of irreducible TP-normalized blocks with
-primitive transfer maps and pairwise distinct nonzero weight moduli, in the
-sense of~\cite{Cirac2017MPDO_AnnPhys}. These later reductions are conditional
-primitive-block results and should not be confused with the arbitrary-input
-PGVWC07 theorem below.
+The PGVWC07 source theorem is recorded as a single headline statement
+(Theorem~\ref{thm:pgvwc07_ti_canonical_form}). The canonical-form reduction
+that feeds the proof of the Fundamental Theorem in Chapter~\ref{ch:ft_proof}
+does not pass through PGVWC07; it goes through
+Theorem~\ref{thm:tp_gauge_arbitrary},
+Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr}, and the
+after-blocking reductions of Chapter~\ref{ch:canonical_after_blocking}.
 
-The PGVWC07 blocks are written in the unital orientation
-$\sum_i A_k^i(A_k^i)^\dagger=\Id$ for
-$\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$
-\cite[Theorem~Th:TIcanonical, lines~754--758]{PerezGarcia2007Matrix},
-whereas some later reductions in this chapter use the trace-preserving, or
-left-canonical, orientation
-$\sum_i (A_k^i)^\dagger A_k^i=\Id$.
-Passing to the conjugate-transposed Kraus family $K_i := (A^i)^\dagger$
-exchanges the two orientations: the transfer map of $K$ is the Frobenius adjoint
-of $\E_A$.
-The Perron--Frobenius eigenvector existence and TP-gauge construction
-are in Chapter~\ref{ch:qpf}; this chapter uses them to produce
-left-canonical normalizations and decompositions satisfying the normal
-canonical form conditions.
-The reduction draws on~\cite{PerezGarcia2007Matrix}, \cite{Cirac2021Matrix},
-and~\cite[Chapter~6]{Wolf2012Quantum}.
+The reduction outputs of this chapter are:
+Theorem~\ref{thm:pgvwc07_ti_canonical_form} (the source-faithful PGVWC07
+translation-invariant canonical form);
+Theorem~\ref{thm:CFII_data} and
+Theorem~\ref{thm:cyclic_sector_decomp_irr_tp_prim_irr} (block-injective and
+primitive-irreducible TP-gauge reductions); and
+Theorem~\ref{thm:exists_normal_canonical_form} (the normal canonical form
+obtained from primitive blocks).
 
 \begin{theorem}[Translation-invariant canonical form]%
     \label{thm:pgvwc07_ti_canonical_form}
@@ -78,11 +68,8 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     of the decomposition is at most $D$.
 
     This is the positive-length form of
-    \cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix},
-    with the global spectral-radius normalization of lines~765--766 made
-    explicit. The zero-block convention for the empty word is recorded
-    separately in
-    Theorem~\ref{thm:pgvwc07_exact_rescaled_form_with_zero_tail}.
+    \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}, with the global
+    spectral-radius normalization of lines~765--766 made explicit.
 \end{theorem}
 
 \begin{remark}[Source proof order]\label{rem:pgvwc07_ti_canonical_source_order}
@@ -105,99 +92,35 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     obtained from the source argument.
 \end{remark}
 
-\begin{theorem}[Blocked CPSV canonical-form reduction]%
-    \label{thm:cpgsv_canonical_form_source}
-    \notready
-    % Source anchors:
-    % Papers/1606.00608/MPDO-22-12-17-2.tex:227--231 removes periodic
-    % peripheral components by blocking; lines 233--235 define normal tensors;
-    % lines 237--246 are the definition containing the display labelled
-    % eq:II_CF1 at line 240 and the subsequent weight normalization at
-    % line 246; lines 249--251 state
-    % that any tensor becomes canonical after blocking. The phase-class
-    % quotient used by the BNT supplier is prop:char-BNT, labelled at line 278
-    % with statement at line 279, in the definition/proposition passage
-    % lines 271--279. It is restated, proved, and followed by the same-CF BNT
-    % uniqueness note in Appendix A at lines 1135--1148. The two-layer
-    % expansion is eq:II_ABasicTensors/decBSV at lines 283--301.
+\begin{remark}[CPSV blocked canonical form (source statement)]%
+    \label{rem:cpgsv_canonical_form_source}
+    % Source anchors (maintainer notes):
+    % Papers/1606.00608/MPDO-22-12-17-2.tex:227--231 removes periodic peripheral
+    % components by blocking; lines 233--235 define normal tensors;
+    % lines 237--246 contain the canonical-form definition with display
+    % eq:II_CF1 (line 240) and the weight normalization at line 246;
+    % lines 249--251 state that any tensor becomes canonical after blocking.
+    % The phase-class quotient used by the BNT supplier is prop:char-BNT
+    % (line 278, statement at line 279, passage lines 271--279), restated
+    % and proved in Appendix A at lines 1135--1148. The two-layer expansion
+    % is eq:II_ABasicTensors/decBSV at lines 283--301.
     % Papers/2011.12127/TN-Review-main.tex:1793--1803 gives the invariant-
-    % subspace reduction; lines 1815--1820 give period removal; lines 1827--1839
-    % give def:4:normal-tensor-mps and eq:II_CF1; lines 1846--1859 give the
-    % BNT definition/characterization; lines 1864--1884 give the two-layer
-    % BNT/copy display.
-    This is the canonical-form reduction of
-    \cite[Section~II.C, lines~217--246]{Cirac2017MPDO_AnnPhys}; see also
-    \cite[Section~IV.A, lines~1815--1837]{Cirac2021Matrix}. Every
-    translation-invariant MPS tensor $A$ is, after blocking by a period
-    $p \ge 1$, replaced by a tensor $B$ generating the same MPV family and
-    whose nonzero part is in canonical form. Thus, for each physical index $i$,
-    \[
-        B^i
-        =
-        \mathbf{0}_{d^{[p]},D_0}
-        \oplus
-        \bigoplus_{k=1}^{r} \mu_k B_k^i,
-    \]
-    where $\mathbf{0}_{d^{[p]},D_0}$ is the all-zero summand of physical
-    dimension $d^{[p]}$ and bond dimension $D_0$, and the tensors $B_k$ are
-    normal tensors. If $r>0$, the weights $\mu_k$ may be normalized so that
-    $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
-
-    In the source, the canonical-form construction is recorded in
-    \cite[display labelled eq:II\_Aiplusk1, lines~216--218,
-    followed by the spectral-radius normalization at lines~219--225]
-        {Cirac2017MPDO_AnnPhys}
-    and in
-    \cite[canonical-form definition containing eq:II\_CF1 and
-    subsequent weight normalization,
-    lines~237--246]{Cirac2017MPDO_AnnPhys}.
-    The basis-of-normal-tensors refinement is
-    \cite[BNT definition and proposition labelled prop:char-BNT,
-    lines~271--279]{Cirac2017MPDO_AnnPhys},
-    with its appendix restatement and proof in
-    \cite[Appendix proof of prop:char-BNT and same-CF uniqueness note,
-    lines~1135--1148]
-        {Cirac2017MPDO_AnnPhys},
-    and the two-layer display is
-    \cite[displays labelled eq:II\_ABasicTensors and decBSV,
-    lines~283--301]{Cirac2017MPDO_AnnPhys}.
-    The review exposition records the same normal-tensor and canonical-form
-    definitions at lines~1827--1837, the basis-of-normal-tensors definition and
-    characterization at lines~1846--1859, and the two-layer decomposition at
-    lines~1864--1884 of~\cite{Cirac2021Matrix}.
-\end{theorem}
-
-Theorem~\ref{thm:pgvwc07_ti_canonical_form} is the checked positive-length
-form of the PGVWC07 translation-invariant canonical-form theorem.
-Theorem~\ref{thm:cpgsv_canonical_form_source} remains a source-level target for the
-blocked CPSV reduction and is not yet formalized as stated. This chapter also
-develops constituent steps of the density-operator canonical-form reductions:
-invariant-subspace decomposition
-(Theorem~\ref{thm:irred_decomp}), TP gauge
-(Section~\ref{sec:tp_gauge_arbitrary}), and period-removal cyclic sectors
-(Section~\ref{sec:cyclic_sectors}). All-zero-block separation and the
-structural after-blocking primitive-block decomposition are recorded in
-Chapter~\ref{ch:canonical_after_blocking}
-(Theorem~\ref{thm:zero_block_separation} and
-Theorem~\ref{thm:tp_primitive_blockdecomp}). These checked statements do not
-yet supply the CPSV source normalization $|\mu_k|\le 1$ with at least one
-unit-modulus weight, so they should not be cited as
-Theorem~\ref{thm:cpgsv_canonical_form_source}.
-
-For Theorem~\ref{thm:pgvwc07_ti_canonical_form}, the source-ordered
-construction is the exact positive-length formulation of
-Theorem~\ref{thm:pgvwc07_exact_rescaled_form_allow_empty}: after a positive
-global rescaling of the original tensor, the normalized weighted block tensor
-has the same MPV coefficients on every nonempty ring.  The theorem permits an
-empty nonzero-block family precisely when all positive-length coefficients
-vanish, and otherwise retains a unit-modulus normalized weight together with
-the unital block condition, the scalar fixed-point conclusion, the diagonal
-positive-definite dual fixed point, and the bond-dimension bound.
-Theorem~\ref{thm:pgvwc07_exact_rescaled_form_with_zero_tail} records the
-companion explicit zero-block convention, where the zero block supplies the
-length-zero contribution \(D_0+\sum_k D_k=D\).  The projective MPV formulation
-records the same normalization as a proportionality of finite-ring state
-vectors, but it is not used as the primary existence theorem.
+    % subspace reduction; lines 1815--1820 give period removal; lines
+    % 1827--1839 give def:4:normal-tensor-mps and eq:II_CF1; lines
+    % 1846--1859 give the BNT definition/characterization; lines 1864--1884
+    % give the two-layer BNT/copy display.
+    The blocked canonical-form reduction of
+    \cite[Section~II.C, lines~217--246]{Cirac2017MPDO_AnnPhys} and
+    \cite[Section~IV.A, lines~1815--1837]{Cirac2021Matrix} states that an
+    arbitrary translation-invariant MPS tensor becomes, after blocking by some
+    period $p\ge 1$, the direct sum of an all-zero summand and a weighted
+    family of normal tensors $\bigoplus_k \mu_k B_k$ with $|\mu_k|\le 1$ and
+    at least one $|\mu_k|=1$. The closest checked formalizations are
+    Theorem~\ref{thm:tp_primitive_blockdecomp} and
+    Theorem~\ref{thm:paperbnt_supplier_after_blocking}; neither yet supplies
+    the source upper normalization $|\mu_k|\le 1$ with at least one
+    unit-modulus weight.
+\end{remark}
 
 \section{Normal tensors, canonical forms, and bases of normal tensors}\label{sec:cpsv_canonical_defs}
 
@@ -733,12 +656,12 @@ primitive, removing periodicity.
 \section{Steps toward canonical form existence}%
 \label{sec:canonical_construction_1606}
 
-This section combines the components of the canonical-form
-construction following~\cite[Section~2.3 and Appendix~A]{Cirac2017MPDO_AnnPhys}.
-The approach here requires blocking to remove non-trivial periodicity.
-A separate reduction for periodic blocks without blocking
-is developed in~\cite{DeLasCuevas2017Irreducible}; see
-Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
+The combination of Theorem~\ref{thm:CFII_data} with the Perron--Frobenius
+gauge of Chapter~\ref{ch:qpf} and the irreducible-block scalar-fixed-point
+statement Theorem~\ref{thm:irreducible_unital_scalar_fixed_point} yields the
+source PGVWC07 unital orientation and diagonal positive-definite dual fixed
+point on each irreducible block; the combination into the full PGVWC07
+statement is Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
 
 \begin{theorem}[Left-canonical normalization for irreducible TP blocks]%
     \label{thm:CFII_data}
@@ -799,220 +722,6 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     the displayed equations for $B$.
 \end{proof}
 
-\begin{theorem}[Single irreducible-block PGVWC07 canonical-form theorem]%
-    \label{thm:pgvwc07_irreducible_unital_dual_package}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible}
-    \leanok
-    \uses{def:irreducible_tensor}
-    Let $A$ be an irreducible nonzero MPS block with positive bond dimension.
-    Then the Perron--Frobenius eigenvector produces a positive scalar $r$ and a
-    positive definite matrix $\rho$ such that
-    \[
-        B^i := r^{-1/2}\rho^{-1/2} A^i\rho^{1/2}
-    \]
-    is unital.  In this unital gauge every fixed point of $\E_B$ is a scalar
-    multiple of the identity.  Moreover a unitary conjugate $C^i=U^\dagger
-    B^iU$ remains unital and has a diagonal positive definite dual fixed point
-    $\Lambda$:
-    \[
-        \sum_i C^i(C^i)^\dagger=\Id,
-        \qquad
-        \sum_i (C^i)^\dagger\Lambda C^i=\Lambda .
-    \]
-    The construction preserves the finite-ring coefficients up to the
-    spectral-radius weight carried by the rescaling from $A$ to $B$.
-
-    This composes the single-block canonical-form existence steps of
-    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
-        {PerezGarcia2007Matrix}.  It is not yet the full theorem, because the
-    recursive finite-ring block decomposition and the final bond-dimension
-    bound have not been threaded through this construction.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:unital_data_irreducible,
-        thm:irreducible_unital_scalar_fixed_point,
-        thm:pgvwc07_dual_diag_unital}
-    Theorem~\ref{thm:unital_data_irreducible} gives the unital gauge.
-    Gauge equivalence preserves irreducibility of the bond-space action, so
-    Theorem~\ref{thm:irreducible_unital_scalar_fixed_point} gives the scalar
-    fixed-point endpoint for the unital representative.  Then
-    Theorem~\ref{thm:pgvwc07_dual_diag_unital} gives the unitary
-    diagonalization of the dual fixed point.
-\end{proof}
-
-\begin{theorem}[Blockwise PGVWC07 unital and dual-diagonal data]%
-    \label{thm:pgvwc07_blockwise_unital_dual_package}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise}
-    \leanok
-    \uses{def:irreducible_tensor,
-        thm:pgvwc07_irreducible_unital_dual_package}
-    Let a tensor~$A$ be represented, in finite-ring MPV coefficients, by a
-    finite direct sum of nonzero irreducible blocks with unit weights.  Then
-    there is a weighted direct sum with the same MPV family such that every
-    block is in the unital orientation,
-    \[
-        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
-    \]
-    every fixed point of the block transfer map is a scalar multiple of the
-    identity, and each block has a diagonal positive definite dual fixed point
-    \[
-        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
-    \]
-    The weights are the positive spectral-radius weights produced by applying
-    the single-block Perron--Frobenius gauge to each summand.
-
-    This is a blockwise assembly of
-    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
-        {PerezGarcia2007Matrix} after the recursive splitting has already
-    produced the nonzero irreducible summands.  It is not yet the full source
-    theorem, because it does not start from an arbitrary representation and
-    does not prove the final total bond-dimension bound.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_irreducible_unital_dual_package}
-    Apply Theorem~\ref{thm:pgvwc07_irreducible_unital_dual_package} to each
-    nonzero irreducible block.  Gauge equivalence and the final unitary
-    conjugation preserve the block MPV coefficients up to the displayed
-    spectral-radius weights, and unitary conjugation transports the scalar
-    fixed-point property of the unital transfer map.
-\end{proof}
-
-\begin{theorem}[Arbitrary-input PGVWC07 unital dual-diagonal form with zero block]%
-    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail}
-    \leanok
-    \uses{thm:zero_block_separation,
-        thm:pgvwc07_blockwise_unital_dual_package}
-    Let \(A\) be an arbitrary translation-invariant MPS tensor.  Then there is
-    a zero block of bond dimension \(D_0\), a finite family of nonzero blocks
-    \(C_k\), and positive real weights \(\mu_k\), such that for every chain
-    length \(N\) and every word \(\sigma \in \{0,\ldots,d-1\}^N\),
-    \[
-        \operatorname{MPV}_A
-        =
-        \operatorname{MPV}_{0_{D_0}}
-        +
-        \operatorname{MPV}_{\oplus_k \mu_k C_k}.
-    \]
-    Each nonzero block is in the unital orientation,
-    \[
-        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
-    \]
-    every fixed point of its transfer map is a scalar multiple of the identity,
-    and it has a diagonal positive definite dual fixed point
-    \[
-        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
-    \]
-\end{theorem}
-
-% This theorem composes the zero-block separation with the blockwise PGVWC07
-% theorem.  The final total bond-dimension bound is still recorded as a
-% remaining step in the paper-gap audit.
-
-\begin{proof}\leanok
-    \uses{thm:zero_block_separation,
-        thm:pgvwc07_blockwise_unital_dual_package}
-    First apply the zero-block separation theorem to \(A\), retaining the
-    all-zero summands as a single zero block and extracting the nonzero
-    irreducible summands.  Then apply the blockwise PGVWC07 unital and
-    dual-diagonal theorem to this nonzero family.  Chaining the two MPV
-    identities gives the displayed zero-block formula.
-\end{proof}
-
-\begin{theorem}[Bond-dimension bound for the zero-block PGVWC07 form]%
-    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound}
-    \leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
-    In the decomposition of
-    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}, the
-    zero-block bond dimension and the nonzero block dimensions satisfy
-    \[
-        D_0+\sum_k D_k = D .
-    \]
-    In particular, the total bond dimension of the nonzero blocks is at most
-    the original bond dimension \(D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package,
-        lem:mpv_zero_length}
-    Evaluate the MPV identity of
-    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package} on the
-    empty word.  The length-zero coefficient of a bond-\(D\) tensor is \(D\);
-    the zero block contributes \(D_0\), and the direct sum of the nonzero
-    blocks contributes \(\sum_k D_k\).  This gives the displayed identity, and
-    the inequality follows because \(D_0\geq 0\).
-\end{proof}
-
-\begin{theorem}[Positive-length PGVWC07 unital dual-diagonal form]%
-    \label{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound}
-    \leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
-    For any MPS tensor \(A\) of bond dimension \(D\), there are nonzero blocks
-    \(C_k\) and positive real weights \(\mu_k\) such that each block is in the
-    unital orientation,
-    \[
-        \sum_i C_k^i(C_k^i)^\dagger=\Id,
-    \]
-    has only scalar fixed points for its transfer map, and has a diagonal
-    positive-definite fixed point for the dual transfer map,
-    \[
-        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
-    \]
-    Moreover, for
-    every chain length \(N>0\) and word
-    \(\sigma\in\{0,\ldots,d-1\}^N\),
-    \[
-        \operatorname{MPV}_A(\sigma)
-        =
-        \operatorname{MPV}_{\bigoplus_k \mu_k C_k}(\sigma),
-    \]
-    and the nonzero block dimensions satisfy \(\sum_k D_k\leq D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
-    Apply Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}.
-    The all-zero summand contributes zero to every positive-length coefficient,
-    so it may be omitted from the displayed MPV identity for \(N>0\).  The
-    bound \(\sum_k D_k\leq D\) is one of the conclusions of that theorem.
-\end{proof}
-
-\begin{definition}[Positive-length PGVWC07 canonical-form witness]%
-    \label{def:pgvwc07_positive_length_witness}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness}
-    \leanok
-    A positive-length PGVWC07 canonical-form witness for an MPS tensor \(A\)
-    consists of a finite family of nonzero unital blocks, positive real
-    weights, diagonal positive-definite dual fixed points, scalar fixed-point
-    conclusions, positive block dimensions, positive-length MPV equality with
-    \(A\), and the total bond-dimension bound \(\sum_k D_k\leq D\).
-
-    This definition records the exact-MPV, nonempty-ring part of the PGVWC07
-    construction.  It still does not include the source theorem's upper
-    normalization \(1\geq\lambda_k\), which depends on the global
-    spectral-radius normalization convention of
-    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
-\end{definition}
-
-\begin{lemma}[Positive PGVWC07 witness weights are nonzero]%
-    \label{lem:pgvwc07_positive_length_witness_weight_ne_zero}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness}
-    In a positive-length PGVWC07 canonical-form witness, every block weight is
-    nonzero.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{def:pgvwc07_positive_length_witness}
-    Each weight is the complex embedding of a strictly positive real number.
-\end{proof}
-
 \begin{lemma}[Common scalar rescaling of block weights]%
     \label{lem:mpv_to_tensor_from_blocks_weight_mul_left}
     \lean{MPSTensor.mpv_toTensorFromBlocks_weight_mul_left}
@@ -1025,258 +734,6 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     \uses{thm:mpv_decomposition}
     Expand the block-diagonal MPV coefficient as a finite sum over blocks and
     factor the common scalar power out of the sum.
-\end{proof}
-
-\begin{theorem}[Weight normalization for a nonempty PGVWC07 witness]%
-    \label{thm:pgvwc07_positive_length_witness_weight_normalization}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness}
-    Let a positive-length PGVWC07 canonical-form witness have at least one
-    nonzero block.  Then its positive real weights may be divided by their
-    largest value so that the new weights \(\nu_k\) are positive,
-    \(|\nu_k|\leq 1\) for all \(k\), and \(|\nu_{k_0}|=1\) for at least one
-    block \(k_0\).  If the original weights are \(\mu_k=s\nu_k\) with
-    \(s>0\), then for every chain length \(N>0\),
-    \[
-        \operatorname{MPV}_A(\sigma)
-        =
-        s^N
-        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
-    \]
-    This is the formal scalar normalization corresponding to
-    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix};
-    the displayed factor records the global length-dependent rescaling.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        lem:mpv_to_tensor_from_blocks_weight_mul_left}
-    Choose the largest positive real weight \(s\).  Dividing every weight by
-    \(s\) gives positive weights bounded above by \(1\), and a block attaining
-    the maximum has normalized weight \(1\).  The MPV identity follows from
-    Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left}.
-\end{proof}
-
-\begin{theorem}[Projective form of PGVWC07 weight normalization]%
-    \label{thm:pgvwc07_positive_length_witness_weight_normalization_projective}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        def:nonzero_proportional_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization}
-    Let a positive-length PGVWC07 canonical-form witness have at least one
-    block.  After dividing the positive real weights by their largest value,
-    the normalized weights $\nu_k$ are positive real numbers, satisfy
-    $|\nu_k|\leq 1$ for all $k$, and satisfy $|\nu_{k_0}|=1$ for some block
-    $k_0$.  Moreover the original tensor and the normalized
-    weighted block tensor generate nonzero proportional MPV families:
-    for every length $N$ there is a nonzero scalar $c_N$ such that
-    \[
-        \operatorname{MPV}_A(\sigma)
-        =
-        c_N\,
-        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
-    \]
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_positive_length_witness_weight_normalization,
-        lem:mpv_zero_length}
-    For $N>0$, take $c_N=s^N$, which is nonzero because $s>0$.  For
-    $N=0$, use the length-zero MPV coefficient and the positive total
-    dimension of the nonzero blocks to choose the nonzero scalar relating the
-    two traces.
-\end{proof}
-
-\begin{lemma}[Nonzero positive-length coefficient gives a nonempty PGVWC07 witness]%
-    \label{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        thm:mpv_decomposition}
-    Let a positive-length PGVWC07 canonical-form witness for $A$ be given.
-    If some positive-length MPV coefficient of $A$ is nonzero, then the
-    witness has at least one block.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        thm:mpv_decomposition}
-    If the block family were empty, the block-diagonal MPV expansion would be
-    an empty sum at every positive length.  The positive-length MPV equality in
-    the witness would then force all positive-length coefficients of $A$ to
-    vanish, contradicting the hypothesis.
-\end{proof}
-
-\begin{theorem}[Nonzero projective PGVWC07 normalized form]%
-    \label{thm:pgvwc07_nonzero_normalized_projective_form}
-    \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv}
-    \leanok
-    \uses{thm:pgvwc07_positive_length_witness,
-        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
-    Suppose that some positive-length MPV coefficient of an MPS tensor $A$ is
-    nonzero.  Then $A$ has a nonempty finite family of nonzero PGVWC07 blocks
-    $C_k$ with positive normalized weights $\nu_k$ satisfying
-    $|\nu_k|\leq 1$ for all $k$ and $|\nu_{k_0}|=1$ for some block $k_0$.
-    Each block is in the unital orientation, has only scalar fixed points for
-    its transfer map, and has a diagonal positive-definite fixed point
-    $\Lambda_k$ for the dual transfer map.  Moreover the original tensor and
-    the normalized weighted block tensor generate nonzero proportional MPV
-    families, and the block dimensions satisfy $\sum_k D_k\leq D$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_positive_length_witness,
-        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
-    First use Theorem~\ref{thm:pgvwc07_positive_length_witness}.  The nonzero
-    positive-length coefficient makes the witness nonempty by
-    Lemma~\ref{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}.
-    Apply the projective weight-normalization theorem to this nonempty witness.
-\end{proof}
-
-\begin{theorem}[Exact normalized PGVWC07 form after global rescaling]%
-    \label{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
-    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv}
-    \leanok
-    \uses{thm:pgvwc07_positive_length_witness,
-        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization}
-    Suppose that some positive-length MPV coefficient of an MPS tensor \(A\) is
-    nonzero.  Then there is a positive scalar \(s\) and a nonempty finite family
-    of PGVWC07 blocks \(C_k\) with positive normalized weights \(\nu_k\)
-    satisfying \(|\nu_k|\leq 1\) for all \(k\) and
-    \(|\nu_{k_0}|=1\) for some block \(k_0\).  Each block is in the unital
-    orientation, has only scalar fixed points for its transfer map, and has a
-    diagonal positive-definite fixed point for the dual transfer map.  Each
-    block has positive bond dimension.  Moreover the globally rescaled tensor
-    \(s^{-1}A\) and the normalized weighted block tensor have the same
-    positive-length MPV coefficients, and the block dimensions satisfy
-    \(\sum_k D_k\leq D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_positive_length_witness,
-        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization,
-        lem:mpv_smul}
-    Start from the positive-length witness and use the nonzero coefficient to
-    make the block family nonempty.  Divide the positive weights by their
-    maximum.  The exact coefficient identity for \(A\) contains the global
-    factor \(s^N\) at length \(N\); applying the scalar rescaling \(s^{-1}\) to
-    every matrix of \(A\) contributes the factor \(s^{-N}\), so the two factors
-    cancel at every positive length.
-\end{proof}
-
-\begin{theorem}[Zero/nonzero dichotomy for exact rescaled PGVWC07 form]%
-    \label{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
-    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero}
-    \leanok
-    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
-    For every MPS tensor \(A\), either every positive-length MPV coefficient of
-    \(A\) is zero, or the exact rescaled normalized PGVWC07 form of
-    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form} exists.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
-    If some positive-length coefficient is nonzero, apply
-    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}.  Otherwise,
-    every positive-length coefficient is zero.
-\end{proof}
-
-\begin{theorem}[Exact PGVWC07 form with empty zero branch]%
-    \label{thm:pgvwc07_exact_rescaled_form_allow_empty}
-    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty}
-    \leanok
-    \uses{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
-    For every MPS tensor \(A\), there is a positive scalar \(s\) and a finite
-    family of PGVWC07 blocks \(C_k\), possibly empty, with positive normalized
-    weights \(\nu_k\) satisfying \(|\nu_k|\leq 1\). If the family is nonempty,
-    then \(|\nu_{k_0}|=1\) for some block \(k_0\). Each block is in the unital
-    orientation, has only scalar fixed points for its transfer map, and has a
-    diagonal positive-definite fixed point for the dual transfer map. Moreover
-    the globally rescaled tensor \(s^{-1}A\) and the normalized weighted block
-    tensor have the same positive-length MPV coefficients, and the block
-    dimensions satisfy \(\sum_k D_k\leq D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
-    Apply the zero/nonzero dichotomy. In the nonzero branch, use the nonempty
-    normalized exact form. In the zero branch, take the empty nonzero-block
-    family; its block-diagonal MPV coefficient is the empty sum at every
-    positive length, which agrees with the zero positive-length coefficients of
-    \(A\). The unit-weight conclusion is stated conditionally on the family
-    being nonempty.
-\end{proof}
-
-\begin{theorem}[Exact PGVWC07 form with explicit zero block]%
-    \label{thm:pgvwc07_exact_rescaled_form_with_zero_tail}
-    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail}
-    \leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound,
-        thm:pgvwc07_positive_length_witness_weight_normalization}
-    For every MPS tensor \(A\), there is a positive scalar \(s\), a zero-block
-    dimension \(D_0\), and a finite family of PGVWC07 blocks \(C_k\), possibly
-    empty, with positive normalized weights \(\nu_k\) satisfying
-    \(|\nu_k|\leq 1\). If the family is nonempty, then
-    \(|\nu_{k_0}|=1\) for some block \(k_0\). Each nonzero block is in the
-    unital orientation, has only scalar fixed points for its transfer map, and
-    has a diagonal positive-definite fixed point for the dual transfer map.
-    For every block \(k\), the bond dimension \(D_k\) is positive. Moreover
-    the globally rescaled tensor \(s^{-1}A\) has exactly the MPV family given
-    by the zero block plus the normalized weighted block tensor at every ring
-    length. The bond dimensions satisfy \(D_0+\sum_k D_k=D\), and in particular
-    \(\sum_kD_k\leq D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound,
-        thm:pgvwc07_positive_length_witness_weight_normalization}
-    Start from the arbitrary-input theorem with the zero block retained.  If
-    the nonzero-block family is empty, take \(s=1\).  Otherwise normalize the
-    positive weights by their maximum.  On nonempty rings the zero block has
-    zero coefficient, so the normalized positive-length identity applies; at
-    length zero the equality is exactly \(D_0+\sum_kD_k=D\).
-\end{proof}
-
-\begin{theorem}[Zero/nonzero dichotomy for projective PGVWC07 form]%
-    \label{thm:pgvwc07_projective_form_zero_nonzero_dichotomy}
-    \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero}
-    \leanok
-    \uses{thm:pgvwc07_nonzero_normalized_projective_form}
-    For every MPS tensor $A$, either every positive-length MPV coefficient of
-    $A$ is zero, or $A$ has the nonempty normalized projective PGVWC07 form of
-    Theorem~\ref{thm:pgvwc07_nonzero_normalized_projective_form}.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_nonzero_normalized_projective_form}
-    If some positive-length coefficient is nonzero, apply
-    Theorem~\ref{thm:pgvwc07_nonzero_normalized_projective_form}.  Otherwise,
-    every positive-length coefficient is zero.
-\end{proof}
-
-\begin{theorem}[Existence of the positive-length PGVWC07 witness]%
-    \label{thm:pgvwc07_positive_length_witness}
-    \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    For every MPS tensor \(A\), the conclusions of
-    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    give a positive-length PGVWC07 canonical-form witness.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    Unpack
-    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    and use its conclusions as the fields of the witness.
 \end{proof}
 
 \begin{theorem}[Irreducible block decomposition with left-canonical normalization]%
@@ -2149,3 +1606,382 @@ Chapter~\ref{ch:periodic_ft_apps}.
     where $\sigma'$ is the image of $\sigma$ under the coordinate-grouping
     identification.
 \end{lemma}
+
+\section{Source-faithful PGVWC07 intermediate steps}\label{sec:pgvwc07_intermediates}
+
+The theorems below record the intermediate construction steps of the proof of
+\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}. They follow the source
+proof order: single-block unital and dual-diagonal data; blockwise composition;
+arbitrary-input form with the explicit zero summand; the length-zero dimension
+identity; the positive-length form; the bundled positive-length witness; weight
+normalization; the nonzero-coefficient existence theorem; and the dichotomy
+that yields the headline statement
+Theorem~\ref{thm:pgvwc07_ti_canonical_form}. They are not consumed by the
+canonical-form reduction used in the proof of the Fundamental Theorem (which
+goes through Theorem~\ref{thm:tp_gauge_arbitrary} and the after-blocking
+statements of Chapter~\ref{ch:canonical_after_blocking}); they record the
+source structure for completeness.
+
+\begin{theorem}[Single irreducible-block PGVWC07 canonical-form theorem]%
+    \label{thm:pgvwc07_irreducible_unital_dual_package}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible}
+    \leanok
+    \uses{def:irreducible_tensor}
+    Let $A$ be an irreducible nonzero MPS block with positive bond dimension.
+    Then the Perron--Frobenius eigenvector produces a positive scalar $r$ and a
+    positive definite matrix $\rho$ such that
+    \[
+        B^i := r^{-1/2}\rho^{-1/2} A^i\rho^{1/2}
+    \]
+    is unital.  In this unital gauge every fixed point of $\E_B$ is a scalar
+    multiple of the identity.  Moreover a unitary conjugate $C^i=U^\dagger
+    B^iU$ remains unital and has a diagonal positive definite dual fixed point
+    $\Lambda$:
+    \[
+        \sum_i C^i(C^i)^\dagger=\Id,
+        \qquad
+        \sum_i (C^i)^\dagger\Lambda C^i=\Lambda .
+    \]
+    The construction preserves the finite-ring coefficients up to the
+    spectral-radius weight carried by the rescaling from $A$ to $B$.
+
+    This composes the single-block canonical-form existence steps of
+    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
+        {PerezGarcia2007Matrix}.  It is not yet the full theorem, because the
+    recursive finite-ring block decomposition and the final bond-dimension
+    bound have not been threaded through this construction.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:unital_data_irreducible,
+        thm:irreducible_unital_scalar_fixed_point,
+        thm:pgvwc07_dual_diag_unital}
+    Theorem~\ref{thm:unital_data_irreducible} gives the unital gauge.
+    Gauge equivalence preserves irreducibility of the bond-space action, so
+    Theorem~\ref{thm:irreducible_unital_scalar_fixed_point} gives the scalar
+    fixed-point endpoint for the unital representative.  Then
+    Theorem~\ref{thm:pgvwc07_dual_diag_unital} gives the unitary
+    diagonalization of the dual fixed point.
+\end{proof}
+
+\begin{theorem}[Blockwise PGVWC07 unital and dual-diagonal block decomposition]%
+    \label{thm:pgvwc07_blockwise_unital_dual_package}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise}
+    \leanok
+    \uses{def:irreducible_tensor,
+        thm:pgvwc07_irreducible_unital_dual_package}
+    Let a tensor~$A$ be represented, in finite-ring MPV coefficients, by a
+    finite direct sum of nonzero irreducible blocks with unit weights.  Then
+    there is a weighted direct sum with the same MPV family such that every
+    block is in the unital orientation,
+    \[
+        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
+    \]
+    every fixed point of the block transfer map is a scalar multiple of the
+    identity, and each block has a diagonal positive definite dual fixed point
+    \[
+        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
+    \]
+    The weights are the positive spectral-radius weights produced by applying
+    the single-block Perron--Frobenius gauge to each summand.
+
+    This is the blockwise composition of
+    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
+        {PerezGarcia2007Matrix} after the recursive splitting has already
+    produced the nonzero irreducible summands.  It is not yet the full source
+    theorem, because it does not start from an arbitrary representation and
+    does not prove the final total bond-dimension bound.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_irreducible_unital_dual_package}
+    Apply Theorem~\ref{thm:pgvwc07_irreducible_unital_dual_package} to each
+    nonzero irreducible block.  Gauge equivalence and the final unitary
+    conjugation preserve the block MPV coefficients up to the displayed
+    spectral-radius weights, and unitary conjugation transports the scalar
+    fixed-point property of the unital transfer map.
+\end{proof}
+
+\begin{theorem}[Arbitrary-input PGVWC07 unital dual-diagonal form with zero block]%
+    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail}
+    \leanok
+    \uses{thm:zero_block_separation,
+        thm:pgvwc07_blockwise_unital_dual_package}
+    Let \(A\) be an arbitrary translation-invariant MPS tensor.  Then there is
+    a zero block of bond dimension \(D_0\), a finite family of nonzero blocks
+    \(C_k\), and positive real weights \(\mu_k\), such that for every chain
+    length \(N\) and every word \(\sigma \in \{0,\ldots,d-1\}^N\),
+    \[
+        \operatorname{MPV}_A
+        =
+        \operatorname{MPV}_{0_{D_0}}
+        +
+        \operatorname{MPV}_{\oplus_k \mu_k C_k}.
+    \]
+    Each nonzero block is in the unital orientation,
+    \[
+        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
+    \]
+    every fixed point of its transfer map is a scalar multiple of the identity,
+    and it has a diagonal positive definite dual fixed point
+    \[
+        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:zero_block_separation,
+        thm:pgvwc07_blockwise_unital_dual_package}
+    First apply the zero-block separation theorem to \(A\), retaining the
+    all-zero summands as a single zero block and extracting the nonzero
+    irreducible summands.  Then apply the blockwise PGVWC07 unital and
+    dual-diagonal theorem to this nonzero family.  Chaining the two MPV
+    identities gives the displayed zero-block formula.
+\end{proof}
+
+\begin{theorem}[Bond-dimension bound for the zero-block PGVWC07 form]%
+    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound}
+    \leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+    In the decomposition of
+    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}, the
+    zero-block bond dimension and the nonzero block dimensions satisfy
+    \[
+        D_0+\sum_k D_k = D .
+    \]
+    In particular, the total bond dimension of the nonzero blocks is at most
+    the original bond dimension \(D\).
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package,
+        lem:mpv_zero_length}
+    Evaluate the MPV identity of
+    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package} on the
+    empty word.  The length-zero coefficient of a bond-\(D\) tensor is \(D\);
+    the zero block contributes \(D_0\), and the direct sum of the nonzero
+    blocks contributes \(\sum_k D_k\).  This gives the displayed identity, and
+    the inequality follows because \(D_0\geq 0\).
+\end{proof}
+
+\begin{theorem}[Positive-length PGVWC07 unital dual-diagonal form]%
+    \label{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound}
+    \leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+    For any MPS tensor \(A\) of bond dimension \(D\), there are nonzero blocks
+    \(C_k\) and positive real weights \(\mu_k\) such that each block is in the
+    unital orientation,
+    \[
+        \sum_i C_k^i(C_k^i)^\dagger=\Id,
+    \]
+    has only scalar fixed points for its transfer map, and has a diagonal
+    positive-definite fixed point for the dual transfer map,
+    \[
+        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
+    \]
+    Moreover, for
+    every chain length \(N>0\) and word
+    \(\sigma\in\{0,\ldots,d-1\}^N\),
+    \[
+        \operatorname{MPV}_A(\sigma)
+        =
+        \operatorname{MPV}_{\bigoplus_k \mu_k C_k}(\sigma),
+    \]
+    and the nonzero block dimensions satisfy \(\sum_k D_k\leq D\).
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+    Apply Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}.
+    The all-zero summand contributes zero to every positive-length coefficient,
+    so it may be omitted from the displayed MPV identity for \(N>0\).  The
+    bound \(\sum_k D_k\leq D\) is one of the conclusions of that theorem.
+\end{proof}
+
+\begin{definition}[Positive-length PGVWC07 canonical-form witness]%
+    \label{def:pgvwc07_positive_length_witness}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness}
+    \leanok
+    A positive-length PGVWC07 canonical-form witness for an MPS tensor \(A\)
+    consists of a finite family of nonzero unital blocks, positive real
+    weights, diagonal positive-definite dual fixed points, scalar fixed-point
+    conclusions, positive block dimensions, positive-length MPV equality with
+    \(A\), and the total bond-dimension bound \(\sum_k D_k\leq D\).
+
+    This definition records the exact-MPV, nonempty-ring part of the PGVWC07
+    construction.  It still does not include the source theorem's upper
+    normalization \(1\geq\lambda_k\), which depends on the global
+    spectral-radius normalization convention of
+    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
+\end{definition}
+
+\begin{theorem}[Weight normalization for a nonempty PGVWC07 witness]%
+    \label{thm:pgvwc07_positive_length_witness_weight_normalization}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness}
+    Let a positive-length PGVWC07 canonical-form witness have at least one
+    nonzero block.  Then its positive real weights may be divided by their
+    largest value so that the new weights \(\nu_k\) are positive,
+    \(|\nu_k|\leq 1\) for all \(k\), and \(|\nu_{k_0}|=1\) for at least one
+    block \(k_0\).  If the original weights are \(\mu_k=s\nu_k\) with
+    \(s>0\), then for every chain length \(N>0\),
+    \[
+        \operatorname{MPV}_A(\sigma)
+        =
+        s^N
+        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
+    \]
+    This is the formal scalar normalization corresponding to
+    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix};
+    the displayed factor records the global length-dependent rescaling.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        lem:mpv_to_tensor_from_blocks_weight_mul_left}
+    Choose the largest positive real weight \(s\).  Dividing every weight by
+    \(s\) gives positive weights bounded above by \(1\), and a block attaining
+    the maximum has normalized weight \(1\).  The MPV identity follows from
+    Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left}.
+\end{proof}
+
+\begin{theorem}[Projective form of PGVWC07 weight normalization]%
+    \label{thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        def:nonzero_proportional_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization}
+    Let a positive-length PGVWC07 canonical-form witness have at least one
+    block.  After dividing the positive real weights by their largest value,
+    the normalized weights $\nu_k$ are positive real numbers, satisfy
+    $|\nu_k|\leq 1$ for all $k$, and satisfy $|\nu_{k_0}|=1$ for some block
+    $k_0$.  Moreover the original tensor and the normalized
+    weighted block tensor generate nonzero proportional MPV families:
+    for every length $N$ there is a nonzero scalar $c_N$ such that
+    \[
+        \operatorname{MPV}_A(\sigma)
+        =
+        c_N\,
+        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_positive_length_witness_weight_normalization,
+        lem:mpv_zero_length}
+    For $N>0$, take $c_N=s^N$, which is nonzero because $s>0$.  For
+    $N=0$, use the length-zero MPV coefficient and the positive total
+    dimension of the nonzero blocks to choose the nonzero scalar relating the
+    two traces.
+\end{proof}
+
+\begin{lemma}[Nonzero positive-length coefficient gives a nonempty PGVWC07 witness]%
+    \label{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:mpv_decomposition}
+    Let a positive-length PGVWC07 canonical-form witness for $A$ be given.
+    If some positive-length MPV coefficient of $A$ is nonzero, then the
+    witness has at least one block.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:mpv_decomposition}
+    If the block family were empty, the block-diagonal MPV expansion would be
+    an empty sum at every positive length.  The positive-length MPV equality in
+    the witness would then force all positive-length coefficients of $A$ to
+    vanish, contradicting the hypothesis.
+\end{proof}
+
+\begin{theorem}[Nonzero projective PGVWC07 normalized form]%
+    \label{thm:pgvwc07_nonzero_normalized_projective_form}
+    \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv}
+    \leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+    Suppose that some positive-length MPV coefficient of an MPS tensor $A$ is
+    nonzero.  Then $A$ has a nonempty finite family of nonzero PGVWC07 blocks
+    $C_k$ with positive normalized weights $\nu_k$ satisfying
+    $|\nu_k|\leq 1$ for all $k$ and $|\nu_{k_0}|=1$ for some block $k_0$.
+    Each block is in the unital orientation, has only scalar fixed points for
+    its transfer map, and has a diagonal positive-definite fixed point
+    $\Lambda_k$ for the dual transfer map.  Moreover the original tensor and
+    the normalized weighted block tensor generate nonzero proportional MPV
+    families, and the block dimensions satisfy $\sum_k D_k\leq D$.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+    First use Theorem~\ref{thm:pgvwc07_positive_length_witness}.  The nonzero
+    positive-length coefficient makes the witness nonempty by
+    Lemma~\ref{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}.
+    Apply the projective weight-normalization theorem to this nonempty witness.
+\end{proof}
+
+\begin{theorem}[Exact normalized PGVWC07 form after global rescaling]%
+    \label{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv}
+    \leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization}
+    Suppose that some positive-length MPV coefficient of an MPS tensor \(A\) is
+    nonzero.  Then there is a positive scalar \(s\) and a nonempty finite family
+    of PGVWC07 blocks \(C_k\) with positive normalized weights \(\nu_k\)
+    satisfying \(|\nu_k|\leq 1\) for all \(k\) and
+    \(|\nu_{k_0}|=1\) for some block \(k_0\).  Each block is in the unital
+    orientation, has only scalar fixed points for its transfer map, and has a
+    diagonal positive-definite fixed point for the dual transfer map.  Each
+    block has positive bond dimension.  Moreover the globally rescaled tensor
+    \(s^{-1}A\) and the normalized weighted block tensor have the same
+    positive-length MPV coefficients, and the block dimensions satisfy
+    \(\sum_k D_k\leq D\).
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization,
+        lem:mpv_smul}
+    Start from the positive-length witness and use the nonzero coefficient to
+    make the block family nonempty.  Divide the positive weights by their
+    maximum.  The exact coefficient identity for \(A\) contains the global
+    factor \(s^N\) at length \(N\); applying the scalar rescaling \(s^{-1}\) to
+    every matrix of \(A\) contributes the factor \(s^{-N}\), so the two factors
+    cancel at every positive length.
+\end{proof}
+
+\begin{theorem}[Zero/nonzero dichotomy for exact rescaled PGVWC07 form]%
+    \label{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
+    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero}
+    \leanok
+    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+    For every MPS tensor \(A\), either every positive-length MPV coefficient of
+    \(A\) is zero, or the exact rescaled normalized PGVWC07 form of
+    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form} exists.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+    If some positive-length coefficient is nonzero, apply
+    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}.  Otherwise,
+    every positive-length coefficient is zero.
+\end{proof}
+
+\begin{theorem}[Existence of the positive-length PGVWC07 witness]%
+    \label{thm:pgvwc07_positive_length_witness}
+    \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    For every MPS tensor \(A\), the conclusions of
+    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    give a positive-length PGVWC07 canonical-form witness.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    Unpack
+    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    and use its conclusions as the fields of the witness.
+\end{proof}
+

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -882,7 +882,6 @@ itself comes from the peripheral spectrum of the adjoint transfer map~\cite[Theo
 \begin{theorem}[Period removal by blocking]%
     \label{thm:cyclic_sector_decomp_after_blocking}
     \lean{MPSTensor.exists_cyclic_sector_decomp_after_blocking}
-    \leanok
     \uses{def:blocked_tensor}
     Let $A$ be a left-canonical irreducible tensor of period $m$.
     Then the blocked tensor $A^{[m]}$ admits:
@@ -903,7 +902,16 @@ itself comes from the peripheral spectrum of the adjoint transfer map~\cite[Theo
     (\cite[Theorem~6.6]{Wolf2012Quantum}).
 \end{theorem}
 
-\begin{proof}\leanok
+% Faithfulness note: the Lean theorem
+% MPSTensor.exists_cyclic_sector_decomp_after_blocking takes the
+% positive-definite adjoint fixed point, the primitive m-th root of unity
+% parametrizing the peripheral eigenvalues, and the map-level irreducibility
+% as explicit hypotheses, whereas the blueprint statement above quantifies
+% only over the period. The hypotheses are derivable from the period-m
+% hypothesis and left-canonical irreducibility via the upstream Wielandt and
+% quantum Perron-Frobenius statements; the consumed packaging is the next
+% theorem, thm:cyclic_sector_decomp_irr_tp, which carries the \leanok.
+\begin{proof}
     The cyclic decomposition of the adjoint transfer map gives projections
     $(P_k)$ with $\E_{A^\dagger}(P_{k+1}) = P_k$. Iterating the cyclic relation $m$
     times shows $(\E_{A^\dagger})^m(P_k) = P_k$, and the blocked-transfer identity
@@ -1611,16 +1619,16 @@ Chapter~\ref{ch:periodic_ft_apps}.
 
 The theorems below record the intermediate construction steps of the proof of
 \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}. They follow the source
-proof order: single-block unital and dual-diagonal data; blockwise composition;
-arbitrary-input form with the explicit zero summand; the length-zero dimension
-identity; the positive-length form; the bundled positive-length witness; weight
-normalization; the nonzero-coefficient existence theorem; and the dichotomy
-that yields the headline statement
-Theorem~\ref{thm:pgvwc07_ti_canonical_form}. They are not consumed by the
-canonical-form reduction used in the proof of the Fundamental Theorem (which
-goes through Theorem~\ref{thm:tp_gauge_arbitrary} and the after-blocking
-statements of Chapter~\ref{ch:canonical_after_blocking}); they record the
-source structure for completeness.
+proof order: single-block unital and dual-diagonal construction; blockwise
+composition; arbitrary-input form with the explicit zero summand; the
+length-zero dimension identity; the positive-length form; the bundled
+positive-length witness; weight normalization; the nonzero-coefficient
+existence theorem; and the dichotomy that yields the headline statement
+Theorem~\ref{thm:pgvwc07_ti_canonical_form}. They are not used by the
+canonical-form reduction in the proof of the Fundamental Theorem (which goes
+through Theorem~\ref{thm:tp_gauge_arbitrary} and the after-blocking statements
+of Chapter~\ref{ch:canonical_after_blocking}); they record the source
+structure for completeness.
 
 \begin{theorem}[Single irreducible-block PGVWC07 canonical-form theorem]%
     \label{thm:pgvwc07_irreducible_unital_dual_package}

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -1,21 +1,16 @@
 
 \chapter{Block Permutation and Separation}\label{ch:block_perm}
 
-This chapter develops the algebra of block permutations, the product-algebra maps
-built from per-block same-MPV hypotheses, the invariant-projection splitting step that
-reduces a tensor to smaller blocks, and the block-separation argument that
-recovers the individual blocks from a block-diagonal same-MPV hypothesis.
-The block-separation results in this chapter are conditional same-structure
-lemmas: they assume blockwise normalization and separation hypotheses, including
-strict ordering of the weight moduli when required below. They should not be read
-as a formalization of the translation-invariant canonical-form uniqueness theorem
-of~\cite[Theorem~thm-uniq, lines~1002--1015]{PerezGarcia2007Matrix},
-which requires injectivity at some finite blocking length, uniqueness of the
-OBC canonical representation, and a finite-size lower bound. The source theorem
-is stated in the cited passage of Pérez-García, Verstraete, Wolf, and Cirac;
-the project-level scope distinction is
-recorded in the accompanying paper-gap note.\footnote{%
-    \texttt{docs/paper-gaps/pgvwc07\_ti\_uniqueness\_scope.tex}.}
+% Project-level scope distinction recorded in
+% docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex; the same-structure
+% lemmas below are not the PGVWC07 uniqueness theorem
+% (\cite[Theorem~thm-uniq, lines~1002--1015]{PerezGarcia2007Matrix}).
+This chapter records three reduction outputs: the algebra-automorphism
+decomposition Theorem~\ref{thm:pi_auto_decomp}; the per-block linear-extension
+product automorphism Theorem~\ref{thm:pi_linear_ext}; and the strict-weight
+block separation Lemmas~\ref{lem:block_sep} and~\ref{lem:block_sep_normal},
+together with the canonical-form gauge comparison
+Lemma~\ref{lem:ft_canonical}.
 
 \section{Block permutation algebra}
 

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -673,7 +673,11 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     provided by Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}.
 \end{theorem}
 
-\begin{proof}\leanok
+% Proof intentionally not marked \leanok here: the three equivalent
+% Lean-internal hypothesis forms are file-local (private) and the externally
+% consumed form is the next theorem, thm:zero_tail_common_flat_of_reindexed,
+% which carries the \lean{...} tag and the \leanok status.
+\begin{proof}
     \uses{thm:zero_tail_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_blocked_word_comparison,
         def:same_mpv2_pos}

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -665,18 +665,20 @@ a single tensor $\mathbf{0}_{d,D_0}$.
         V^{(N)}\!\bigl(\textstyle\bigoplus_x
         \widetilde\mu_x C_x\bigr)_\tau.
     \]
-    The formalization records this conclusion internally under three equivalent
-    hypothesis forms (blockwise comparison, blocked-word equality, and
-    coordinate-grouping cast equality); the externally consumed form is
-    Theorem~\ref{thm:zero_tail_common_flat_of_reindexed}, whose hypothesis is
-    the blocked-tensor same-MPV relation (Definition~\ref{def:same_mpv2})
-    provided by Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}.
+    The conclusion above is proved under any of three equivalent hypothesis
+    forms — blockwise comparison, blocked-word equality, and coordinate-grouping
+    cast equality — and the same conclusion under the compact same-MPV
+    hypothesis is recorded as Theorem~\ref{thm:zero_tail_common_flat_of_reindexed}
+    below, whose hypothesis is the blocked-tensor same-MPV relation
+    (Definition~\ref{def:same_mpv2}) provided by
+    Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}.
 \end{theorem}
 
 % Proof intentionally not marked \leanok here: the three equivalent
-% Lean-internal hypothesis forms are file-local (private) and the externally
-% consumed form is the next theorem, thm:zero_tail_common_flat_of_reindexed,
-% which carries the \lean{...} tag and the \leanok status.
+% hypothesis forms above are kept as file-local auxiliary lemmas, while the
+% same conclusion under the compact same-MPV hypothesis (the next theorem,
+% thm:zero_tail_common_flat_of_reindexed) carries the \lean{...} tag and the
+% \leanok status.
 \begin{proof}
     \uses{thm:zero_tail_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_blocked_word_comparison,

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -1,17 +1,13 @@
 \chapter{Canonical-form reductions after blocking}\label{ch:canonical_after_blocking}
 
-This chapter records the structural decomposition of an arbitrary MPS tensor
-after blocking by a period $p$, and the joint after-blocking decomposition of
-two tensors with the same MPV family. Each side is written as the direct sum of
-an all-zero tensor $\mathbf{0}_{d,D_0}$ and a weighted direct sum of
-left-canonical, primitive, irreducible blocks over a common physical alphabet;
-these decompositions are the input to the equal-MPV comparison of
-Chapter~\ref{ch:ft_proof}. Thus this chapter is placed immediately before the
-proof of the Fundamental Theorem: it records the reductions needed to put the
-two tensors on the common blocked surface used in the comparison argument.
-It is therefore not part of the later channel-representation, symmetry, or
-semigroup material; those chapters no longer provide hypotheses for the
-Fundamental-Theorem comparison.
+\section{Scope}
+
+This chapter records the structural after-blocking decomposition of a single
+tensor (Theorem~\ref{thm:tp_primitive_blockdecomp}) and the joint two-tensor
+decomposition at a common blocking period
+(Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}).
+These two statements supply the canonical-form input to the proof of the
+Fundamental Theorem in Chapter~\ref{ch:ft_proof}.
 
 \section{Zero-tail separation}%
 \label{sec:zero_block_separation}
@@ -258,50 +254,15 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     normality are both preserved under blocking.
 \end{proof}
 
-\begin{theorem}[Structural after-blocking decomposition]%
-    \label{thm:ft_after_blocking_structural}
-    \lean{MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂}
-    \leanok
-    \uses{def:blocked_tensor, def:same_mpv2, def:zero_mps_tensor, def:block_diagonal_tensor}
-    If two tensors $A$ and $B$ generate the same MPV family, then each tensor
-    admits a positive blocking length after which it decomposes into a zero-tail
-    tensor plus a weighted nonzero-block tensor. Thus, for every blocked
-    configuration $\sigma$ of length $N$ on the $p_A$-blocked alphabet,
-    \[
-        V^{(N)}\!(A^{[p_A]})_\sigma
-        = V^{(N)}\!(\mathbf{0}_{d^{[p_A]},z_A})_\sigma
-        + V^{(N)}\!\left(\textstyle\bigoplus_k \mu^A_k A_k\right)_\sigma,
-    \]
-    and, for every blocked configuration $\tau$ of length $N$ on the
-    $p_B$-blocked alphabet,
-    \[
-        V^{(N)}\!(B^{[p_B]})_\tau
-        = V^{(N)}\!(\mathbf{0}_{d^{[p_B]},z_B})_\tau
-        + V^{(N)}\!\left(\textstyle\bigoplus_\ell \mu^B_\ell B_\ell\right)_\tau.
-    \]
-    All nonzero blocks are left-canonical, have primitive transfer maps, have
-    positive bond dimensions, and have nonzero weights. The original MPV equality
-    also blocks:
-    \[
-        A^{[p_A]} \sim B^{[p_A]},
-        \qquad
-        A^{[p_B]} \sim B^{[p_B]}.
-    \]
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:tp_primitive_blockdecomp}
-    Apply Theorem~\ref{thm:tp_primitive_blockdecomp} separately to the two tensors.
-\end{proof}
-
-\begin{remark}[Structural after-blocking decomposition; not the FT block-matching theorem]
-    This theorem produces, for each of the two same-MPV tensors independently,
-    a TP/primitive/left-canonical block decomposition after blocking. It does
-    \emph{not} derive any block matching, gauge equivalence, or phases
-    between the two decompositions; those are produced by the subsequent
-    common-sector construction in this chapter. The statement is a
-    preliminary step for the fundamental-theorem proof, not the multi-block
-    fundamental theorem of~\cite[Theorem~II.1, lines~349--352]{Cirac2017MPDO_AnnPhys}.
+\begin{remark}[Two-tensor primitive block decomposition]%
+    \label{rem:ft_after_blocking_structural}
+    Applying Theorem~\ref{thm:tp_primitive_blockdecomp} to each of two
+    same-MPV tensors $A$ and $B$ produces, after a positive blocking length,
+    a zero-tail tensor plus a left-canonical primitive nonzero block
+    decomposition for each side. This is a preliminary step in the chain
+    leading to
+    Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem},
+    where the two sides are matched.
 \end{remark}
 
 \begin{theorem}[Zero-tail decomposition after blocking]%
@@ -606,57 +567,6 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     conclusion is Theorem~\ref{thm:common_blocked_cyclic_sector_flat_weight_ne_zero}.
 \end{proof}
 
-The next results put the cyclic-sector decompositions on a common blocked
-alphabet. They compare direct blocking with iterated cyclic-sector blocking and
-transport the zero-tail identity through this comparison.
-
-\begin{theorem}[Common cyclic sectors after reblocking]%
-    \label{thm:ft_after_blocking_reindexed_common_sector_live_zero_tail}
-    \lean{MPSTensor.afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂}
-    \leanok
-    \uses{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail,
-        thm:zero_tail_to_tensor_from_blocks_block_power,
-        thm:common_blocked_cyclic_sector_reindexed_samempv,
-        thm:common_blocked_cyclic_sector_derived_properties}
-    For the $A$-side, let $p_A$ be the common reblocking length of the cyclic
-    sector family. Then, for every blocked configuration $\sigma$ of length
-    $N$,
-    \[
-        V^{(N)}\!(A^{[p_A]})_\sigma
-        =
-        V^{(N)}\!(\mathbf{0}_{d^{[p_A]},z_A})_\sigma
-        +
-        V^{(N)}\!\bigl(\textstyle\bigoplus_j
-        (\mu^A_j)^{p_A} (A_j)^{[p_A]}\bigr)_\sigma.
-    \]
-    Writing $\widetilde A_j$ for the directly blocked tensor
-    $(A_j)^{[p_A]}$ read in the common blocked alphabet, the reindexed
-    nonzero part agrees with the common-sector tensor:
-    \[
-        V^{(N)}\!\bigl(\textstyle\bigoplus_j
-        (\mu^A_j)^{p_A} \widetilde A_j\bigr)_\sigma
-        =
-        V^{(N)}\!\bigl(\textstyle\bigoplus_x
-        \widetilde\mu^A_x C^A_x\bigr)_\sigma.
-    \]
-    The same two identities hold on the $B$-side with $p_B$, $z_B$,
-    $(\mu^B_k)$, and $(C^B_y)$.
-    The transported weights $\widetilde\mu^A_x$ and $\widetilde\mu^B_y$ are
-    nonzero, and the common-sector blocks are left-canonical, primitive,
-    tensor-irreducible, and of positive bond dimension.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail,
-        thm:zero_tail_to_tensor_from_blocks_block_power,
-        thm:common_blocked_cyclic_sector_reindexed_samempv,
-        thm:common_blocked_cyclic_sector_derived_properties}
-    Start from the common reblocked cyclic-sector families on the two sides. Apply
-    the zero-tail reblocking theorem to the original nonzero-block decomposition,
-    then use the common-alphabet sector decomposition and the derived structural
-    properties of the common-sector family.
-\end{proof}
-
 \begin{theorem}[Common blocking length for cyclic sectors]%
     \label{thm:ft_after_blocking_common_length_common_sector_theorem}
     \lean{MPSTensor.afterBlocking_commonLengthCommonSectorData_of_sameMPV₂}
@@ -725,12 +635,6 @@ transport the zero-tail identity through this comparison.
 
 \begin{theorem}[Length-zero identity under compatible blocking]%
     \label{thm:zero_tail_common_flat_of_blocked_word_comparison}
-    \lean{MPSTensor.zeroTail_commonFlat_of_blockwise,
-        MPSTensor.zeroTail_commonFlat_of_word_eq,
-        MPSTensor.zeroTail_commonFlat_of_groupedBlockCastAgrees,
-        MPSTensor.zeroTail_commonFlatAt_of_groupedBlockCastAgrees,
-        MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees}
-    \leanok
     \uses{thm:zero_tail_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_blocked_word_comparison,
         def:same_mpv2_pos}
@@ -761,8 +665,12 @@ transport the zero-tail identity through this comparison.
         V^{(N)}\!\bigl(\textstyle\bigoplus_x
         \widetilde\mu_x C_x\bigr)_\tau.
     \]
-    The blockwise comparison, the word equality, and the coordinate-grouping
-    condition are three ways to supply the same alphabet identification.
+    The formalization records this conclusion internally under three equivalent
+    hypothesis forms (blockwise comparison, blocked-word equality, and
+    coordinate-grouping cast equality); the externally consumed form is
+    Theorem~\ref{thm:zero_tail_common_flat_of_reindexed}, whose hypothesis is
+    the blocked-tensor same-MPV relation (Definition~\ref{def:same_mpv2})
+    provided by Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1007,57 +915,6 @@ transport the zero-tail identity through this comparison.
     with the weighted common-sector family. Combine this with the zero-tail
     identity and the nonzero-weight statement.
 \end{proof}
-
-\begin{theorem}[Common sectors at one blocking length]%
-    \label{thm:ft_after_blocking_common_length_common_sector_reindexed}
-    \lean{MPSTensor.afterBlocking_commonLengthCommonSectorData_of_reindexed}
-    \leanok
-    \uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-        thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
-    If two tensors generate the same MPV family, choose a common blocking length
-    $p$ for their cyclic-sector decompositions. If each blocked nonzero part
-    agrees with its common-sector form after identifying words, then there are
-    common-sector nonzero tensors $\widetilde A_{\mathrm{nz}}$ and
-    $\widetilde B_{\mathrm{nz}}$ such that, for every blocked configuration
-    $\sigma$ of length $N$,
-    \[
-        V^{(N)}\!(A^{[p]})_\sigma
-        =
-        V^{(N)}\!(\mathbf{0}_{d^{[p]},z_A})_\sigma
-        +
-        V^{(N)}(\widetilde A_{\mathrm{nz}})_\sigma,
-    \]
-    \[
-        V^{(N)}\!(B^{[p]})_\sigma
-        =
-        V^{(N)}\!(\mathbf{0}_{d^{[p]},z_B})_\sigma
-        +
-        V^{(N)}(\widetilde B_{\mathrm{nz}})_\sigma.
-    \]
-    For $N\ge 1$,
-    \[
-        V^{(N)}(\widetilde A_{\mathrm{nz}})_\sigma
-        =
-        V^{(N)}(\widetilde B_{\mathrm{nz}})_\sigma.
-    \]
-    At length zero,
-    \[
-        z_A + V^{(0)}(\widetilde A_{\mathrm{nz}})_\varnothing
-        =
-        z_B + V^{(0)}(\widetilde B_{\mathrm{nz}})_\varnothing.
-    \]
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-        thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
-    Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}.
-    The two word-identification hypotheses identify the blocked nonzero parts with the
-    weighted common-sector tensors. Substituting these MPV equalities into the
-    zero-tail equations gives the rewritten zero-tail identities, the
-    positive-length MPV equalities, and the $N=0$ identity.
-\end{proof}
-
 
 \section{Primitive-block decomposition of an arbitrary tensor}%
 \label{sec:ch11b_primitive_block_reduction}


### PR DESCRIPTION
## Summary

Refactor the three canonical-form blueprint chapters following the audit in `audits/canonical_audit.md`.

### Audit findings
- The PGVWC07 stack (14 entries in Chapter 9) is **parallel** to — not on — the path used by the Fundamental Theorem proof. The FT proof reaches the canonical-form material through `thm:tp_gauge_arbitrary → thm:has_primitive_irreducible_cyclic_sectors_tp_irr → thm:ft_after_blocking_common_length_common_sector_theorem`, **not** through any `pgvwc07_*` theorem.
- `thm:cpgsv_canonical_form_source` was a `\notready` orphan with zero consumers anywhere in the blueprint.
- Four `ft_after_blocking_*` variants existed in Chapter 12; only `_common_length_common_sector_theorem` is consumed.
- Several `pgvwc07_*` entries had no Lean or blueprint consumer at all (legacy-dead branch).

### Changes
**Chapter 9 (`ch08_canonical.tex`)**:
- Compact 15-line scope preface replacing four meta-paragraphs; explicitly documents the FT-bridge path.
- `thm:cpgsv_canonical_form_source` (`\notready`) → `rem:cpgsv_canonical_form_source` (6-line remark pointing at `thm:tp_primitive_blockdecomp` and `thm:paperbnt_supplier_after_blocking`).
- Move the source-faithful PGVWC07 intermediate steps into `\section{Source-faithful PGVWC07 intermediate steps}` with a preface clarifying they follow the source proof order and are not consumed downstream.
- Remove three legacy-dead entries + one duplicate of the headline.
- Title sweep against `docs/prose_style.md` §2 banned-term list (`data`, `assembly`, `package`).

**Chapter 10 (`ch09_block_perm.tex`)**: six-line scope preface naming the three outputs.

**Chapter 12 (`ch11b_after_blocking.tex`)**:
- Five-line `\section{Scope}` block naming the two outputs.
- Demote `thm:ft_after_blocking_structural` to a remark.
- Delete two unconsumed cyclic-sector reblocking variants.
- Trim the multi-`\lean{...}` block in `thm:zero_tail_common_flat_of_blocked_word_comparison`.

### Verification
- `leanblueprint web` finishes with **0 errors / 0 undefined references** on the trimmed surface.
- All `\lean{...}` tags reference Lean declarations that exist on `main` (no Lean changes in this PR).

### Companion audits
- `audits/canonical_audit.md` — the read-only audit (16 deletion classifications, FT-bridge dependency map).
- `audits/pgvwc07_restoration_report.md` — record of the restored intermediate section.

### Follow-up
The corresponding Lean cleanup (privatize plumbing variants, delete legacy-dead declarations) lands in a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/blueprint-only restructures (LaTeX + audit reports) with no Lean proof or runtime logic modifications; main risk is broken cross-references/`\lean{...}` tags in the rendered blueprint.
> 
> **Overview**
> **Reworks the canonical-form blueprint narrative and public surface** to match the audit: `ch08_canonical.tex` gets a shorter scope preface that explicitly states the Fundamental Theorem path does *not* consume PGVWC07, and the orphan `\notready` theorem `thm:cpgsv_canonical_form_source` is replaced with a brief remark pointing at checked results.
> 
> **Restores and reorganizes PGVWC07 intermediate statements** by adding a dedicated `sec:pgvwc07_intermediates` section in `ch08_canonical.tex` containing the source-proof-order intermediate theorems/definition (while keeping legacy-dead/duplicate entries removed), plus assorted wording/title cleanups to avoid banned terms.
> 
> **Trims and de-duplicates after-blocking and block-permutation chapter prefaces**: `ch11b_after_blocking.tex` adds a `Scope` section, demotes `thm:ft_after_blocking_structural` to a remark, removes two unconsumed reindexing variants, and narrows a multi-`\lean{...}` listing to the single externally referenced theorem; `ch09_block_perm.tex` replaces a long preface/footnote with a short output-oriented scope note. Two new audit artifacts are added: `audits/canonical_audit.md` and `audits/pgvwc07_restoration_report.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8550f4e72f4d80935eb142e0f3a8d040ae3a179a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->