### PR TITLE
cleanup(canonical): privatize plumbing variants, delete legacy-dead declarations

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -209,41 +209,6 @@ This is the Appendix-A periodicity-removal step for TP irreducible blocks, route
 adjoint-transfer formulation.
 -/
 
-/-- **Periodicity removal by blocking for irreducible trace-preserving blocks.**
-
-If `A` is trace-preserving and irreducible (tensor sense), then some physical blocking makes the
-transfer map primitive. -/
-theorem exists_blockTensor_isPrimitive
-    [NeZero D]
-    (A : MPSTensor d D)
-    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
-    ∃ p : ℕ, 0 < p ∧
-      _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d p) (D := D) (blockTensor (d := d) (D := D) A p)) := by
-  have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
-  simpa using
-    (exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor (A := A) hTP hIrr hDpos)
-
-/-- **Trace-preserving normalization after blocking.**
-
-If `A` is trace-preserving and irreducible, then some physical blocking makes the
-blocked transfer map primitive, and the blocked tensor remains left-canonical. -/
-theorem exists_blockTensor_leftCanonical_isPrimitive
-    [NeZero D]
-    (A : MPSTensor d D)
-    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
-    ∃ p : ℕ, 0 < p ∧
-      (∑ i : Fin (blockPhysDim d p),
-          (blockTensor (d := d) (D := D) A p i)ᴴ *
-            blockTensor (d := d) (D := D) A p i = 1) ∧
-      _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d p) (D := D) (blockTensor (d := d) (D := D) A p)) := by
-  obtain ⟨p, hp, hPrim⟩ :=
-    exists_blockTensor_isPrimitive (A := A) hTP hIrr
-  refine ⟨p, hp, leftCanonical_blockTensor (d := d) (D := D) (A := A) (L := p) hTP, hPrim⟩
-
 /-- **Reduction theorem:** spectral-gap primitivity with a positive-definite fixed point implies
 normality. -/
 theorem isNormal_of_isPrimitiveMPS

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -203,10 +203,13 @@ theorem exists_CFII_data_of_TP_of_isIrreducibleTensor
 
 
 /-!
-## (4) Periodicity removal by blocking
+## (4) Normality from primitive spectral-gap hypotheses
 
-This is the Appendix-A periodicity-removal step for TP irreducible blocks, routed through the
-adjoint-transfer formulation.
+The reduction from spectral-gap primitivity with a positive-definite fixed point to normality.
+The periodicity-removal step itself lives in
+`TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorDecomposition`; for overlap and
+canonical-form hypotheses involving primitive transfer maps, we use the results from
+`PeripheralToSpectralGap.lean` directly.
 -/
 
 /-- **Reduction theorem:** spectral-gap primitivity with a positive-definite fixed point implies
@@ -218,14 +221,6 @@ theorem isNormal_of_isPrimitiveMPS
     (hPD : ρ.PosDef) :
     IsNormal A :=
   isNormal_of_isPrimitiveMPS_with_posDef hPrim hPD
-
-
-/-!
-## (5) Normality from primitive spectral-gap hypotheses
-
-For overlap and canonical-form hypotheses involving primitive transfer maps, we use the results from
-`PeripheralToSpectralGap.lean` directly.
--/
 
 /-!
 ## Zero-block vanishing at positive length

--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -24,23 +24,54 @@ The supporting modules are:
 
 ## Main statements
 
-The imported modules provide the original public declarations:
+The imported modules expose the following public declarations:
 
-* `MPSTensor.exists_tp_gauge_blockwise`
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise`
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`
+* `MPSTensor.exists_tp_gauge_blockwise` — blockwise TP-gauge normalization for
+  finite-direct-sum input.
+* `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — TP-gauge
+  normalization for arbitrary input, keeping the explicit zero-block summand.
+  This is the canonical-form bridge declaration consumed by
+  `SectorComparison/CommonSectorData.lean` and
+  `SectorComparison/TPPrimitiveReduction.lean`.
+* `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp` — reduction
+  from a primitive blocked decomposition to blocked normal canonical-form data.
+
+### Source-faithful PGVWC07 intermediate steps
+
+The following declarations record the intermediate construction steps of
+\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.  They are not consumed by
+the canonical-form reduction used in the proof of the Fundamental Theorem
+(which goes through `exists_tp_gauge_from_arbitrary_with_zeroTail` and the
+after-blocking statements), but record the source proof structure for
+completeness.
+
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` — single
+  irreducible-block unital and dual-diagonal form.
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise` — blockwise composition
+  on a finite direct sum with unit weights.
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` —
+  arbitrary-input form with the explicit zero summand kept.
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
+  — the length-zero dimension identity for the zero-tail form.
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`
-* `MPSTensor.exists_pgvwc07_positiveLengthWitness`
-* `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization`
+  — positive-length form after stripping the zero summand.
+* `MPSTensor.PGVWC07PositiveLengthWitness` — structure bundling the
+  positive-length form.
+* `MPSTensor.exists_pgvwc07_positiveLengthWitness` — existence of the
+  positive-length witness for every MPS tensor.
+* `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization` —
+  weight normalization on a nonempty witness.
 * `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`
+  — projective form of the same weight normalization.
 * `MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`
+  — a nonzero positive-length MPV coefficient forces a nonempty witness.
 * `MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`
+  — the nonzero-coefficient projective normalized form.
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`
+  — the nonzero-coefficient exact normalized form after a global rescaling.
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`
+  — the zero/nonzero dichotomy for the exact normalized form.
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`
-* `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail`
-* `MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`
-* `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
-* `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
+  — the source-faithful PGVWC07 translation-invariant canonical-form headline
+  statement.
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -30,9 +30,10 @@ The imported modules expose the following public declarations:
   finite-direct-sum input.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — TP-gauge
   normalization for arbitrary input, keeping the explicit zero-block summand.
-  This is the canonical-form bridge declaration consumed by
+  This is the canonical-form input statement consumed by
   `SectorComparison/CommonSectorData.lean` and
-  `SectorComparison/TPPrimitiveReduction.lean`.
+  `SectorComparison/TPPrimitiveReduction.lean`, supplying the trace-preserving
+  irreducible block decomposition used in Chapter~12 of the blueprint.
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp` — reduction
   from a primitive blocked decomposition to blocked normal canonical-form data.
 

--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -33,16 +33,18 @@ The imported modules expose the following public declarations:
   This is the canonical-form input statement consumed by
   `SectorComparison/CommonSectorData.lean` and
   `SectorComparison/TPPrimitiveReduction.lean`, supplying the trace-preserving
-  irreducible block decomposition used in Chapter~12 of the blueprint.
+  irreducible block decomposition used in Chapter 12 of the blueprint
+  (`ch11b_after_blocking.tex`).
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp` — reduction
   from a primitive blocked decomposition to blocked normal canonical-form data.
 
 ### Source-faithful PGVWC07 intermediate steps
 
 The following declarations record the intermediate construction steps of
-\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.  They are not consumed by
-the canonical-form reduction used in the proof of the Fundamental Theorem
-(which goes through `exists_tp_gauge_from_arbitrary_with_zeroTail` and the
+[PGVWC07, Theorem Th:TIcanonical] (Pérez-García, Verstraete, Wolf, Cirac, 2007).
+They are not consumed by the canonical-form reduction used in the proof of the
+Fundamental Theorem (which goes through
+`exists_tp_gauge_from_arbitrary_with_zeroTail` and the
 after-blocking statements), but record the source proof structure for
 completeness.
 

--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -30,11 +30,10 @@ The imported modules expose the following public declarations:
   finite-direct-sum input.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — TP-gauge
   normalization for arbitrary input, keeping the explicit zero-block summand.
-  This is the canonical-form input statement consumed by
   `SectorComparison/CommonSectorData.lean` and
-  `SectorComparison/TPPrimitiveReduction.lean`, supplying the trace-preserving
-  irreducible block decomposition used in Chapter 12 of the blueprint
-  (`ch11b_after_blocking.tex`).
+  `SectorComparison/TPPrimitiveReduction.lean` build on this theorem to
+  obtain the trace-preserving irreducible block decomposition used in
+  Chapter 12 of the blueprint (`ch11b_after_blocking.tex`).
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp` — reduction
   from a primitive blocked decomposition to blocked normal canonical-form data.
 
@@ -42,11 +41,10 @@ The imported modules expose the following public declarations:
 
 The following declarations record the intermediate construction steps of
 [PGVWC07, Theorem Th:TIcanonical] (Pérez-García, Verstraete, Wolf, Cirac, 2007).
-They are not consumed by the canonical-form reduction used in the proof of the
+They are not used by the canonical-form reduction in the proof of the
 Fundamental Theorem (which goes through
-`exists_tp_gauge_from_arbitrary_with_zeroTail` and the
-after-blocking statements), but record the source proof structure for
-completeness.
+`exists_tp_gauge_from_arbitrary_with_zeroTail` and the after-blocking
+statements), but record the source proof structure for completeness.
 
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` — single
   irreducible-block unital and dual-diagonal form.

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -25,7 +25,8 @@ Its public outputs are:
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the arbitrary-input
   TP-gauge normalization, keeping the explicit zero-block summand.  This is the
   TP-gauge result consumed by `SectorComparison/` to supply the trace-preserving
-  block decomposition used in Chapter~12 of the blueprint.
+  block decomposition used in Chapter 12 of the blueprint
+  (`ch11b_after_blocking.tex`).
 * The source-faithful PGVWC07 unital and dual-diagonal chain:
   `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` (single
   irreducible block), then
@@ -42,8 +43,9 @@ Its public outputs are:
   which bundle the positive-length form for use in `WeightNormalization.lean`.
 
 These declarations correspond one-to-one to the intermediate construction
-steps of \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix} and are exposed
-in the blueprint as the source-faithful PGVWC07 chain.
+steps of [PGVWC07, Theorem Th:TIcanonical] (Pérez-García, Verstraete, Wolf,
+Cirac, 2007) and are exposed in the blueprint as the source-faithful PGVWC07
+chain.
 
 The remaining declarations in this file (gauge-transport and irreducibility
 preservation lemmas, the scalar fixed-point unitary-conjugation transport)

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -23,9 +23,9 @@ Its public outputs are:
 * `MPSTensor.exists_tp_gauge_blockwise` — blockwise Perron--Frobenius / TP-gauge
   normalization for an irreducible block decomposition.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the arbitrary-input
-  TP-gauge normalization, keeping the explicit zero-block summand.  This is the
-  TP-gauge result consumed by `SectorComparison/` to supply the trace-preserving
-  block decomposition used in Chapter 12 of the blueprint
+  TP-gauge normalization, keeping the explicit zero-block summand.  Files
+  under `SectorComparison/` build on this result to obtain the
+  trace-preserving block decomposition used in Chapter 12 of the blueprint
   (`ch11b_after_blocking.tex`).
 * The source-faithful PGVWC07 unital and dual-diagonal chain:
   `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` (single

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -24,7 +24,8 @@ Its public outputs are:
   normalization for an irreducible block decomposition.
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the arbitrary-input
   TP-gauge normalization, keeping the explicit zero-block summand.  This is the
-  bridge declaration consumed by `SectorComparison/`.
+  TP-gauge result consumed by `SectorComparison/` to supply the trace-preserving
+  block decomposition used in Chapter~12 of the blueprint.
 * The source-faithful PGVWC07 unital and dual-diagonal chain:
   `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` (single
   irreducible block), then
@@ -46,8 +47,8 @@ in the blueprint as the source-faithful PGVWC07 chain.
 
 The remaining declarations in this file (gauge-transport and irreducibility
 preservation lemmas, the scalar fixed-point unitary-conjugation transport)
-remain `private`: they are elementary supporting lemmas with no external API
-role.
+remain `private`: they are elementary supporting lemmas with no external
+mathematical role.
 -/
 
 namespace MPSTensor

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -20,27 +20,34 @@ reduction.
 
 Its public outputs are:
 
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` — the
-  single-block PGVWC07 unital gauge, scalar fixed-point, and dual
-  diagonalization theorem.
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise` — the same PGVWC07
-  construction applied blockwise to a prepared nonzero irreducible decomposition.
 * `MPSTensor.exists_tp_gauge_blockwise` — blockwise Perron--Frobenius / TP-gauge
   normalization for an irreducible block decomposition.
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` —
-  the arbitrary-input version with the all-zero summands kept as a zero block.
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` —
-  the preceding theorem together with the length-zero bond-dimension identity.
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` —
-  the positive-length version with the explicit zero-block summand removed.
-* `MPSTensor.exists_pgvwc07_positiveLengthWitness` — the same positive-length
-  theorem recorded as a single structured witness.
-* `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
-  arbitrary-input result obtained after zero-block separation.
+* `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the arbitrary-input
+  TP-gauge normalization, keeping the explicit zero-block summand.  This is the
+  bridge declaration consumed by `SectorComparison/`.
+* The source-faithful PGVWC07 unital and dual-diagonal chain:
+  `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible` (single
+  irreducible block), then
+  `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise` (blockwise composition),
+  then
+  `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`
+  (arbitrary input with explicit zero summand), then
+  `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
+  (length-zero dimension identity), then
+  `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`
+  (positive-length form).
+* The structure `MPSTensor.PGVWC07PositiveLengthWitness` and the
+  witness-existence theorem `MPSTensor.exists_pgvwc07_positiveLengthWitness`,
+  which bundle the positive-length form for use in `WeightNormalization.lean`.
 
-The auxiliary declarations stay file-local because they are elementary lemmas for
-rescaling, gauge transport, and the final zero-block identity (the paper calls
-this the ``zero block'' case).
+These declarations correspond one-to-one to the intermediate construction
+steps of \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix} and are exposed
+in the blueprint as the source-faithful PGVWC07 chain.
+
+The remaining declarations in this file (gauge-transport and irreducibility
+preservation lemmas, the scalar fixed-point unitary-conjugation transport)
+remain `private`: they are elementary supporting lemmas with no external API
+role.
 -/
 
 namespace MPSTensor
@@ -98,20 +105,6 @@ structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
   /-- The total bond dimension of the nonzero canonical blocks is at most the
   original bond dimension. -/
   bondDim_le : ∑ k : Fin r, dim k ≤ D
-
-/-- Positive PGVWC07 witness weights are nonzero.
-
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-751--752, writes the canonical-form weights as positive real numbers.  In the
-positive-length witness, nonvanishing is therefore a consequence of the
-positive-real weight field. -/
-theorem PGVWC07PositiveLengthWitness.weight_ne_zero
-    {A : MPSTensor d D} (W : PGVWC07PositiveLengthWitness (d := d) (D := D) A) :
-    ∀ k, W.weights k ≠ 0 := by
-  intro k
-  obtain ⟨a, ha_pos, hweight⟩ := W.weight_pos k
-  rw [hweight]
-  exact_mod_cast (ne_of_gt ha_pos)
 
 private noncomputable def gaugeMulVecLinearEquiv {D : ℕ} (X : GL (Fin D) ℂ) :
     (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) where

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -27,6 +27,28 @@ statement for the length-zero coefficient.  The convention is recorded in
 The projective formulation below makes that convention explicit: after the
 maximum normalization, the original tensor and the normalized weighted block
 tensor are `NonzeroProportionalMPV₂`.
+
+The source-faithful intermediate steps exposed by this file are:
+
+* `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization` — the
+  scalar normalization on a nonempty witness, with explicit `s^N` factor.
+* `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`
+  — the projective formulation of the same normalization.
+* `MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`
+  — a nonzero positive-length MPV coefficient forces the witness to have at
+  least one block.
+* `MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`
+  — the projective normalized form under the nonzero-coefficient hypothesis.
+* `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`
+  — the exact normalized form after a global rescaling, under the
+  nonzero-coefficient hypothesis.
+* `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`
+  — the zero/nonzero dichotomy for the exact normalized form.
+
+These six declarations sit between the positive-length witness produced in
+`TPGauge.lean` and the final headline statement
+`exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`, and are
+exposed in the blueprint as the source-faithful PGVWC07 intermediate steps.
 -/
 
 open scoped Matrix ComplexOrder
@@ -314,11 +336,10 @@ theorem exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_m
 canonical-form statement.
 
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-742--763 and proof lines 765--766.  This is the exact positive-length analogue
-of `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`:
-either every positive-length MPV coefficient vanishes, or, after a positive
-global rescaling of the original tensor, the normalized PGVWC07 block tensor
-has exactly the same positive-length MPV coefficients.
+742--763 and proof lines 765--766.  Either every positive-length MPV
+coefficient vanishes, or, after a positive global rescaling of the original
+tensor, the normalized PGVWC07 block tensor has exactly the same
+positive-length MPV coefficients.
 
 This theorem keeps the zero positive-length branch explicit.  The following
 theorem combines the two branches as the arbitrary-input positive-length
@@ -429,170 +450,5 @@ theorem exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty
         hν_le, hν_unit, hdim_pos, hMPV, hbond⟩
     exact ⟨scale, r, dim, ν, blocks, hscale_pos, hdual, hscalar, hν_pos,
       hν_le, fun _ => hν_unit, hdim_pos, hMPV, hbond⟩
-
-/-- Exact normalized PGVWC07 canonical-form witness with an explicit zero-block
-summand.
-
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-742--763 and proof lines 765--766.  This theorem combines the explicit
-zero-block decomposition with the finite-family maximum normalization of the
-nonzero weights.  After a positive global rescaling of the original tensor,
-the normalized nonzero blocks and the zero block reproduce all finite-ring MPV
-coefficients.  At length zero this is the dimension identity
-\(D_0 + \sum_k D_k = D\).
-
-The zero block contributes only at length zero.  Thus this is the explicit
-zero-block/length-zero convention complementary to the preceding exact
-positive-length theorem, which omits the zero block and states exact equality
-only at positive length. -/
-theorem exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail
-    (A : MPSTensor d D) :
-    ∃ (scale : ℝ) (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
-      (ν : Fin r → ℂ)
-      (blocks : (k : Fin r) → MPSTensor d (dim k)),
-      0 < scale ∧
-      (∀ k,
-        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          Λ.PosDef ∧
-          Λ.IsDiag ∧
-          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
-          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
-      (∀ k,
-        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          transferMap (d := d) (D := dim k) (blocks k) X = X →
-            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
-      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
-      (∀ k, ‖ν k‖ ≤ 1) ∧
-      (0 < r → ∃ k, ‖ν k‖ = 1) ∧
-      (∀ k, 0 < dim k) ∧
-      (∀ (N : ℕ) (σ : Fin N → Fin d),
-        mpv (fun i => (((scale : ℂ)⁻¹) • A i)) σ =
-          mpv (zeroMPSTensor d zeroTailDim) σ +
-            mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ) ∧
-      zeroTailDim + ∑ k : Fin r, dim k = D ∧
-      ∑ k : Fin r, dim k ≤ D := by
-  classical
-  obtain ⟨zeroTailDim, r, dim, μ, blocks, hdual, hscalar, hμ_pos, _hμ_ne,
-    hdim_pos, hMPV, hBond, hBound⟩ :=
-    exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound
-      (d := d) (D := D) A
-  by_cases hr : 0 < r
-  · let W : PGVWC07PositiveLengthWitness (d := d) (D := D) A :=
-      { r := r
-        dim := dim
-        weights := μ
-        blocks := blocks
-        dual_fixed := hdual
-        scalar_fixed := hscalar
-        weight_pos := hμ_pos
-        dim_pos := hdim_pos
-        sameMPV_pos := by
-          intro N hN σ
-          calc
-            mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ +
-                mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := hMPV N σ
-            _ = 0 + mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
-                rw [mpv_zeroMPSTensor]
-                simp [Nat.ne_of_gt hN]
-            _ = mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
-                simp
-        bondDim_le := hBound }
-    obtain ⟨scale, ν, hscale_pos, hν_pos, hν_le, hν_unit, _hweight, hMPV_norm⟩ :=
-      W.exists_weight_normalization hr
-    have hscale_ne : (scale : ℂ) ≠ 0 := by
-      exact_mod_cast (ne_of_gt hscale_pos)
-    refine ⟨scale, zeroTailDim, r, dim, ν, blocks, hscale_pos, hdual, hscalar,
-      hν_pos, hν_le, fun _ => hν_unit, hdim_pos, ?_, hBond, hBound⟩
-    intro N σ
-    by_cases hN : 0 < N
-    · have hpow : ((scale : ℂ) ^ N)⁻¹ * (scale : ℂ) ^ N = 1 := by
-        simp [pow_ne_zero N hscale_ne]
-      calc
-        mpv (fun i => (((scale : ℂ)⁻¹) • A i)) σ =
-            ((scale : ℂ)⁻¹) ^ N * mpv A σ := mpv_smul ((scale : ℂ)⁻¹) A σ
-        _ = ((scale : ℂ)⁻¹) ^ N *
-              ((scale : ℂ) ^ N *
-                mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ) := by
-            rw [hMPV_norm N hN σ]
-        _ = (((scale : ℂ)⁻¹) ^ N * (scale : ℂ) ^ N) *
-              mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ := by
-            ring
-        _ = mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ := by
-            simp [hpow]
-        _ = mpv (zeroMPSTensor d zeroTailDim) σ +
-              mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ := by
-            rw [mpv_zeroMPSTensor]
-            simp [Nat.ne_of_gt hN]
-    · have hN0 : N = 0 := Nat.eq_zero_of_not_pos hN
-      subst N
-      have hBondC : (D : ℂ) = (zeroTailDim + ∑ k : Fin r, dim k : ℕ) := by
-        exact_mod_cast hBond.symm
-      calc
-        mpv (fun i => (((scale : ℂ)⁻¹) • A i)) σ =
-            (D : ℂ) := mpv_zero_length (fun i => (((scale : ℂ)⁻¹) • A i)) σ
-        _ = (zeroTailDim + ∑ k : Fin r, dim k : ℕ) := hBondC
-        _ = (zeroTailDim : ℂ) + ∑ k : Fin r, (dim k : ℂ) := by
-            simp
-        _ = mpv (zeroMPSTensor d zeroTailDim) σ +
-              mpv (toTensorFromBlocks (d := d) (μ := ν) blocks) σ := by
-            simp
-            exact Finset.sum_congr rfl (fun _ _ => rfl)
-  · have hr0 : r = 0 := Nat.eq_zero_of_not_pos hr
-    subst r
-    refine ⟨1, zeroTailDim, 0, dim, μ, blocks, zero_lt_one, hdual, hscalar,
-      hμ_pos, ?_, ?_, hdim_pos, ?_, hBond, hBound⟩
-    · intro k
-      exact Fin.elim0 k
-    · intro hzero
-      exact (Nat.not_lt_zero 0 hzero).elim
-    · intro N σ
-      calc
-        mpv (fun i => (((1 : ℂ)⁻¹) • A i)) σ = mpv A σ := by simp
-        _ = mpv (zeroMPSTensor d zeroTailDim) σ +
-              mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := hMPV N σ
-
-/-- Arbitrary-input zero/nonzero dichotomy for the projective PGVWC07
-canonical-form statement.
-
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-742--763 and proof lines 765--766.  This is a scope-separating formulation of
-the nonzero positive-length theorem above: either all positive-length MPV
-coefficients vanish, or the tensor has a nonempty normalized projective
-PGVWC07 block form.
-
-**Scope restriction:** This is the projective branch statement, not the primary
-exact positive-length theorem.  It records the zero positive-length branch
-explicitly; the length-zero convention is recorded in
-`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
-theorem exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero
-    (A : MPSTensor d D) :
-    (∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = 0) ∨
-    ∃ (r : ℕ) (dim : Fin r → ℕ)
-      (ν : Fin r → ℂ)
-      (blocks : (k : Fin r) → MPSTensor d (dim k)),
-      0 < r ∧
-      (∀ k,
-        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          Λ.PosDef ∧
-          Λ.IsDiag ∧
-          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
-          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
-      (∀ k,
-        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          transferMap (d := d) (D := dim k) (blocks k) X = X →
-            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
-      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
-      (∀ k, ‖ν k‖ ≤ 1) ∧
-      (∃ k, ‖ν k‖ = 1) ∧
-      (∀ k, 0 < dim k) ∧
-      NonzeroProportionalMPV₂ A (toTensorFromBlocks (d := d) (μ := ν) blocks) ∧
-      ∑ k : Fin r, dim k ≤ D := by
-  classical
-  by_cases hA : ∃ (N : ℕ), 0 < N ∧ ∃ σ : Fin N → Fin d, mpv A σ ≠ 0
-  · exact Or.inr (exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv A hA)
-  · refine Or.inl ?_
-    intro N hN σ
-    by_contra hσ
-    exact hA ⟨N, hN, σ, hσ⟩
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -19,14 +19,11 @@ also records the global scalar factor on every positive-length MPV
 coefficient.
 
 The canonical-form existence theorem is stated with positive-length equality
-after a positive global rescaling of the original tensor.  This file also
-records the projective convention and the complementary explicit zero-block
-statement for the length-zero coefficient.  The convention is recorded in
-`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
-
-The projective formulation below makes that convention explicit: after the
+after a positive global rescaling of the original tensor.  This file records
+the projective formulation that makes that convention explicit: after the
 maximum normalization, the original tensor and the normalized weighted block
-tensor are `NonzeroProportionalMPV₂`.
+tensor are `NonzeroProportionalMPV₂`.  The source-paper convention is
+discussed in `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
 
 The source-faithful intermediate steps exposed by this file are:
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -24,10 +24,10 @@ corresponding to the CPSV allowance `∑ k, D_k ≤ D`.
 
 * `afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂` — per-block
   cyclic-sector data together with the zero-tail identity.
+* `afterBlocking_commonBlockedCyclicDataWithZeroTail_of_sameMPV₂` — common
+  blocked cyclic-sector data with the zero-tail identity.
 * `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` — a two-sided
   common blocking length with common-sector families.
-* `afterBlocking_commonLengthCommonSectorData_of_reindexed` — the same data
-  after the blocked-word relabeling hypotheses used downstream.
 
 ## References
 
@@ -123,10 +123,7 @@ dimension.  The flattened sectors are trace-preserving, have primitive transfer
 maps, are tensor-irreducible, have positive bond dimensions, and carry nonzero
 unit weights.  The statement keeps the checked zero-tail equations,
 positive-length equality of the nonzero parts, and the length-zero identity at the unblocked
-nonzero-block level.  The companion theorem
-`afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂`
-adds the explicitly relabeled cyclic-sector flattening available after
-the iterated-blocking comparison theorem. -/
+nonzero-block level. -/
 theorem afterBlocking_commonBlockedCyclicDataWithZeroTail_of_sameMPV₂
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -178,106 +175,6 @@ theorem afterBlocking_commonBlockedCyclicDataWithZeroTail_of_sameMPV₂
     exact familyA.flatWeight_ne_zero x
   · intro x
     exact familyB.flatWeight_ne_zero x
-
-/-- **Relabeled common-sector data with zero-tail reblocking.**
-
-This companion to
-`afterBlocking_commonBlockedCyclicDataWithZeroTail_of_sameMPV₂`
-uses the common cyclic-sector family to express the reindexed block data available
-after the iterated-blocking comparison theorem.  For each side, the cyclic
-sectors are expressed as derived common-alphabet blocks `family.commonFlatBlocks`,
-with weights `μ^family.p` and
-nonzero transported sector weights.  The theorem also gives the zero-tail
-identities after the corresponding common reblocking.
-
-The statement is deliberately explicit about the reindexing of blocked physical
-words: the relabeled block field is the block `B_k^[family.p]` after applying
-`iteratedBlockIndex`.  It does not assert that the canonical blocked family and
-the per-block reindexed family are identical as physical-word indexed tensors. -/
-theorem afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂
-    {d D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :
-    ∃ (zeroTailA : ℕ) (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
-      (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
-    ∃ (zeroTailB : ℕ) (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
-      (blocksB : (k : Fin rB) → MPSTensor d (dimB k)),
-    ∃ (familyA : CommonBlockedCyclicSectorFamily blocksA),
-    ∃ (familyB : CommonBlockedCyclicSectorFamily blocksB),
-      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d familyA.p)),
-        mpv (blockTensor (d := d) (D := D₁) A familyA.p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d familyA.p) zeroTailA) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d familyA.p)
-              (fun k => (μA k) ^ familyA.p)
-              (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) familyA.p)) σ) ∧
-      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d familyB.p)),
-        mpv (blockTensor (d := d) (D := D₂) B familyB.p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d familyB.p) zeroTailB) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d familyB.p)
-              (fun k => (μB k) ^ familyB.p)
-              (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) familyB.p)) σ) ∧
-      SameMPV₂
-        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
-          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.commonReindexedBlock)
-        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
-          (μ := familyA.commonFlatWeight μA) familyA.commonFlatBlocks) ∧
-      SameMPV₂
-        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
-          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.commonReindexedBlock)
-        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
-          (μ := familyB.commonFlatWeight μB) familyB.commonFlatBlocks) ∧
-      (∀ x, familyA.commonFlatWeight μA x ≠ 0) ∧
-      (∀ x, familyB.commonFlatWeight μB x ≠ 0) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d familyA.p),
-        (familyA.commonFlatBlocks x i)ᴴ * familyA.commonFlatBlocks x i = 1) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d familyB.p),
-        (familyB.commonFlatBlocks x i)ᴴ * familyB.commonFlatBlocks x i = 1) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d familyA.p) (D := familyA.commonFlatDim x)
-          (familyA.commonFlatBlocks x))) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d familyB.p) (D := familyB.commonFlatDim x)
-          (familyB.commonFlatBlocks x))) ∧
-      (∀ x, IsIrreducibleTensor (familyA.commonFlatBlocks x)) ∧
-      (∀ x, IsIrreducibleTensor (familyB.commonFlatBlocks x)) ∧
-      (∀ x, 0 < familyA.commonFlatDim x) ∧
-      (∀ x, 0 < familyB.commonFlatDim x) := by
-  obtain ⟨zeroTailA, rA, dimA, μA, blocksA,
-      zeroTailB, rB, dimB, μB, blocksB,
-      familyA, familyB, _hIrrA, _hIrrB, _hTPA, _hTPB, hμA, hμB, _hDimA, _hDimB,
-      hMPVA, hMPVB, _hPos, _hZero, _hUnitA, _hUnitB⟩ :=
-    afterBlocking_commonBlockedCyclicDataWithZeroTail_of_sameMPV₂ A B hSame
-  refine ⟨zeroTailA, rA, dimA, μA, blocksA,
-    zeroTailB, rB, dimB, μB, blocksB, familyA, familyB, ?_, ?_, ?_, ?_, ?_, ?_,
-    ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · exact zeroTail_toTensorFromBlocks_blockPower
-      (d := d) (D := D₁) (r := rA) (z := zeroTailA) (p := familyA.p) (dim := dimA)
-      A μA blocksA familyA.p_pos hMPVA
-  · exact zeroTail_toTensorFromBlocks_blockPower
-      (d := d) (D := D₂) (r := rB) (z := zeroTailB) (p := familyB.p) (dim := dimB)
-      B μB blocksB familyB.p_pos hMPVB
-  · exact familyA.sameMPV₂_weightedCommonReindexedBlock_commonFlat μA
-  · exact familyB.sameMPV₂_weightedCommonReindexedBlock_commonFlat μB
-  · intro x
-    exact familyA.commonFlatWeight_ne_zero μA hμA x
-  · intro x
-    exact familyB.commonFlatWeight_ne_zero μB hμB x
-  · intro x
-    exact familyA.commonFlatBlocks_tp x
-  · intro x
-    exact familyB.commonFlatBlocks_tp x
-  · intro x
-    exact familyA.commonFlatBlocks_primitive x
-  · intro x
-    exact familyB.commonFlatBlocks_primitive x
-  · intro x
-    exact familyA.commonFlatBlocks_irreducible x
-  · intro x
-    exact familyB.commonFlatBlocks_irreducible x
-  · intro x
-    exact familyA.commonFlatDim_pos x
-  · intro x
-    exact familyB.commonFlatDim_pos x
 
 set_option maxHeartbeats 800000 in
 -- The next theorem has a large dependent existential conclusion, matching the
@@ -429,171 +326,6 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
   · intro x
     exact familyB.commonFlatDim_pos x
 
-set_option maxHeartbeats 900000 in
--- The nested existential conclusion records both sides and the conditional
--- common-sector equalities.
-/-- **Common-length cyclic sectors after reindexing blocked words.**
-
-This theorem records the common-length data in the form used by the later
-sector comparison.  It first chooses one blocking length for both tensors and
-records the common cyclic-sector families.  If the canonical blocked nonzero
-families agree with the explicitly reindexed blocked-word families, then the
-nonzero parts are equal to the weighted common-sector families, and the zero-tail
-equations are rewritten with those common-sector families. -/
-theorem afterBlocking_commonLengthCommonSectorData_of_reindexed
-    {d D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :
-    ∃ (p : ℕ), 0 < p ∧
-    ∃ (zeroTailA : ℕ) (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
-      (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
-    ∃ (zeroTailB : ℕ) (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
-      (blocksB : (k : Fin rB) → MPSTensor d (dimB k)),
-    ∃ (familyA : CommonBlockedCyclicSectorFamily blocksA),
-    ∃ (familyB : CommonBlockedCyclicSectorFamily blocksB),
-    ∃ (hFamilyA : familyA.p = p), ∃ (hFamilyB : familyB.p = p),
-      (∀ x, familyA.commonFlatWeight μA x ≠ 0) ∧
-      (∀ x, familyB.commonFlatWeight μB x ≠ 0) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d familyA.p),
-        (familyA.commonFlatBlocks x i)ᴴ * familyA.commonFlatBlocks x i = 1) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d familyB.p),
-        (familyB.commonFlatBlocks x i)ᴴ * familyB.commonFlatBlocks x i = 1) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d familyA.p) (D := familyA.commonFlatDim x)
-          (familyA.commonFlatBlocks x))) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d familyB.p) (D := familyB.commonFlatDim x)
-          (familyB.commonFlatBlocks x))) ∧
-      (∀ x, IsIrreducibleTensor (familyA.commonFlatBlocks x)) ∧
-      (∀ x, IsIrreducibleTensor (familyB.commonFlatBlocks x)) ∧
-      (∀ x, 0 < familyA.commonFlatDim x) ∧
-      (∀ x, 0 < familyB.commonFlatDim x) ∧
-      (SameMPV₂
-        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
-          (μ := fun k : Fin rA => (μA k) ^ familyA.p)
-          (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) familyA.p))
-        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
-          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.commonReindexedBlock) →
-      SameMPV₂
-        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
-          (μ := fun k : Fin rB => (μB k) ^ familyB.p)
-          (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) familyB.p))
-        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
-          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.commonReindexedBlock) →
-        SameMPV₂
-          (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := fun k : Fin rA => (μA k) ^ p)
-            (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p))
-          (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) ∧
-        SameMPV₂
-          (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := fun k : Fin rB => (μB k) ^ p)
-            (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p))
-          (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) ∧
-        (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-          mpv (blockTensor (d := d) (D := D₁) A p) σ =
-            mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
-              mpv (toTensorFromBlocks (d := blockPhysDim d p)
-                (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ) ∧
-        (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-          mpv (blockTensor (d := d) (D := D₂) B p) σ =
-            mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
-              mpv (toTensorFromBlocks (d := blockPhysDim d p)
-                (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ) ∧
-        SameMPV₂Pos
-          (blockTensor (d := d) (D := D₁) A p)
-          (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) ∧
-        SameMPV₂Pos
-          (blockTensor (d := d) (D := D₂) B p)
-          (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) ∧
-        SameMPV₂Pos
-          (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA))
-          (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) ∧
-        (∀ σ : Fin 0 → Fin (blockPhysDim d p),
-          (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ =
-          (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ)) := by
-  obtain ⟨p, hp, zeroTailA, rA, dimA, μA, blocksA,
-      zeroTailB, rB, dimB, μB, blocksB, familyA, familyB,
-      hFamilyA, hFamilyB, hZA, hZB, hPos, hZero,
-      _hReindexA, _hReindexB, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB,
-      hIrrA, hIrrB, hDimA, hDimB⟩ :=
-    afterBlocking_commonLengthCommonSectorData_of_sameMPV₂ A B hSame
-  refine ⟨p, hp, zeroTailA, rA, dimA, μA, blocksA,
-    zeroTailB, rB, dimB, μB, blocksB, familyA, familyB, hFamilyA, hFamilyB,
-    hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB, ?_⟩
-  intro hRelabelA hRelabelB
-  have hFlatA := familyA.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed
-    μA hFamilyA hRelabelA
-  have hFlatB := familyB.sameMPV₂_weightedCanonicalBlock_commonFlatAt_of_reindexed
-    μB hFamilyB hRelabelB
-  have hZAflat : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-      mpv (blockTensor (d := d) (D := D₁) A p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailA) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ :=
-    zeroTail_eq_of_sameMPV₂ _ _ _ hZA hFlatA
-  have hZBflat : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-      mpv (blockTensor (d := d) (D := D₂) B p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d p) zeroTailB) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ :=
-    zeroTail_eq_of_sameMPV₂ _ _ _ hZB hFlatB
-  have hApos : SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
-      (toTensorFromBlocks (d := blockPhysDim d p)
-        (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) :=
-    sameMPV₂Pos_of_zeroTail_eq _ _ hZAflat
-  have hBpos : SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
-      (toTensorFromBlocks (d := blockPhysDim d p)
-        (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) :=
-    sameMPV₂Pos_of_zeroTail_eq _ _ hZBflat
-  have hFlatPos : SameMPV₂Pos
-      (toTensorFromBlocks (d := blockPhysDim d p)
-        (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA))
-      (toTensorFromBlocks (d := blockPhysDim d p)
-        (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) := by
-    intro N hN σ
-    calc
-      mpv (toTensorFromBlocks (d := blockPhysDim d p)
-          (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ =
-          mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (fun k => (μA k) ^ p)
-            (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ :=
-            (hFlatA N σ).symm
-      _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (fun k => (μB k) ^ p)
-            (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ :=
-            hPos N hN σ
-      _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
-          (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ :=
-            hFlatB N σ
-  have hZeroFlat : ∀ σ : Fin 0 → Fin (blockPhysDim d p),
-      (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
-        (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ =
-      (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
-        (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
-    intro σ
-    calc
-      (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
-          (μ := familyA.commonFlatWeight μA) (familyA.commonFlatBlocksAt hFamilyA)) σ =
-          (zeroTailA : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (fun k => (μA k) ^ p)
-            (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)) σ := by
-            rw [(hFlatA 0 σ).symm]
-      _ = (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (fun k => (μB k) ^ p)
-            (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) σ := hZero σ
-      _ = (zeroTailB : ℂ) + mpv (toTensorFromBlocks (d := blockPhysDim d p)
-          (μ := familyB.commonFlatWeight μB) (familyB.commonFlatBlocksAt hFamilyB)) σ := by
-            rw [hFlatB 0 σ]
-  exact ⟨hFlatA, hFlatB, hZAflat, hZBflat, hApos, hBpos, hFlatPos, hZeroFlat⟩
 
 /-!
 ### What remains for the full 1606.00608 Fundamental Theorem

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -37,7 +37,8 @@ leftover blocks in the block decomposition.  It is the dimension gap allowed by
   are two predicate forms of the same blocked-word identification.
   `CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq` proves the
   cast-equality form unconditionally; the two predicates are equivalent
-  reformulations kept for callers that prefer one form over the other.
+  reformulations of the same blocked-alphabet identification and either may be
+  used as the hypothesis of a downstream transport lemma.
 * `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
   and `unconditional_commonPrimitiveIrreducibleBlocks` turn the structural
   common-sector data into common primitive irreducible block decompositions.

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -32,12 +32,12 @@ leftover blocks in the block decomposition.  It is the dimension gap allowed by
   expose the two surviving equivalent hypothesis forms supplying the
   relabeling.  (A third intermediate form `_of_word_eq` and the orphan
   `_commonFlatAt_of_groupedBlockCastAgrees` were removed in the canonical
-  refactor recorded in `audits/canonical_lean_refactor_report.md`.)
+  reorganization recorded in `audits/canonical_lean_refactor_report.md`.)
 * `CommonSectorRelabelingHypothesis` and `CommonGroupedBlockCastHypothesis`
   are two predicate forms of the same blocked-word identification.
   `CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq` proves the
-  cast-equality form unconditionally; the two predicates are kept as a
-  thin compatibility layer for callers that prefer one form over the other.
+  cast-equality form unconditionally; the two predicates are equivalent
+  reformulations kept for callers that prefer one form over the other.
 * `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
   and `unconditional_commonPrimitiveIrreducibleBlocks` turn the structural
   common-sector data into common primitive irreducible block decompositions.

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -27,10 +27,12 @@ leftover blocks in the block decomposition.  It is the dimension gap allowed by
   `sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed`, and
   `zeroTail_commonFlat_transport_of_reindexed` transport zero-tail
   decompositions through the common-sector relabeling data.  These four are
-  the public reindexed form; the parallel `_of_blockwise`, `_of_word_eq`, and
-  `_of_groupedBlockCastAgrees` variants are file-local intermediates retained
-  only because they expose the three equivalent hypothesis forms that supply
-  the relabeling.
+  the public reindexed form; the parallel `_of_blockwise` and
+  `_of_groupedBlockCastAgrees` variants are file-local intermediates that
+  expose the two surviving equivalent hypothesis forms supplying the
+  relabeling.  (A third intermediate form `_of_word_eq` and the orphan
+  `_commonFlatAt_of_groupedBlockCastAgrees` were removed in the canonical
+  refactor recorded in `audits/canonical_lean_refactor_report.md`.)
 * `CommonSectorRelabelingHypothesis` and `CommonGroupedBlockCastHypothesis`
   are two predicate forms of the same blocked-word identification.
   `CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq` proves the
@@ -124,27 +126,6 @@ private lemma zeroTail_commonFlat_of_groupedBlockCastAgrees
             (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ :=
   zeroTail_commonFlat_of_blockwise A μ blocks F hMPV
     (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k (hCast k))
-
-/-- The preceding zero-tail rewriting from the coordinate-grouping condition, expressed at a
-prescribed common length. -/
-private lemma zeroTail_commonFlatAt_of_groupedBlockCastAgrees
-    {d D r z : ℕ} {dim : Fin r → ℕ}
-    (A : MPSTensor d D) (μ : Fin r → ℂ)
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (F : CommonBlockedCyclicSectorFamily blocks)
-    {p : ℕ} (hp : F.p = p)
-    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
-    (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
-    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-      mpv (blockTensor (d := d) (D := D) A p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) σ := by
-  subst p
-  simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocksAt] using
-    zeroTail_commonFlat_of_groupedBlockCastAgrees A μ blocks F hMPV hCast
 
 /-- If the canonical blocked nonzero part agrees with the common reindexed blocks,
 the zero-tail equation can be rewritten using the derived common-sector family.

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -23,12 +23,19 @@ leftover blocks in the block decomposition.  It is the dimension gap allowed by
 
 ## Main statements
 
-* `zeroTail_commonFlat_of_reindexed` and
-  `sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed` transport zero-tail
-  decompositions through the common-sector relabeling data.
-* `CommonSectorRelabelingHypothesis` and
-  `CommonGroupedBlockCastHypothesis` encode the remaining blocked-word
-  comparison data.
+* `zeroTail_commonFlat_of_reindexed`, `zeroTail_commonFlatAt_of_reindexed`,
+  `sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed`, and
+  `zeroTail_commonFlat_transport_of_reindexed` transport zero-tail
+  decompositions through the common-sector relabeling data.  These four are
+  the public reindexed form; the parallel `_of_blockwise`, `_of_word_eq`, and
+  `_of_groupedBlockCastAgrees` variants are file-local intermediates retained
+  only because they expose the three equivalent hypothesis forms that supply
+  the relabeling.
+* `CommonSectorRelabelingHypothesis` and `CommonGroupedBlockCastHypothesis`
+  are two predicate forms of the same blocked-word identification.
+  `CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq` proves the
+  cast-equality form unconditionally; the two predicates are kept as a
+  thin compatibility layer for callers that prefer one form over the other.
 * `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
   and `unconditional_commonPrimitiveIrreducibleBlocks` turn the structural
   common-sector data into common primitive irreducible block decompositions.
@@ -76,7 +83,7 @@ lemma isNormalCanonicalFormBNT_commonRepresentativeBlocksAt
 
 /-- If each directly blocked nonzero block agrees with its iterated-blocking version,
 the zero-tail equation can be written using the derived common-sector family. -/
-lemma zeroTail_commonFlat_of_blockwise
+private lemma zeroTail_commonFlat_of_blockwise
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -99,32 +106,9 @@ lemma zeroTail_commonFlat_of_blockwise
   have hFlat := F.sameMPV₂_weightedCanonicalBlock_commonFlat_of_blockwise μ hBlock
   exact zeroTail_eq_of_sameMPV₂ _ _ _ hCanon hFlat
 
-/-- If the blocked-word decodings agree for every nonzero block, the zero-tail equation
-can be written using the derived common-sector family. -/
-lemma zeroTail_commonFlat_of_word_eq
-    {d D r z : ℕ} {dim : Fin r → ℕ}
-    (A : MPSTensor d D) (μ : Fin r → ℂ)
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (F : CommonBlockedCyclicSectorFamily blocks)
-    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
-    (hWord : ∀ (k : Fin r) (i : Fin (blockPhysDim d F.p)),
-      wordOfBlock d F.p i =
-        wordOfBlock d (F.period k * F.extra k)
-          (iteratedBlockIndex d (F.period k) (F.extra k)
-            (Fin.cast ((F.blockPhysDim_nested_eq k).symm) i))) :
-    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d F.p)),
-      mpv (blockTensor (d := d) (D := D) A F.p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d F.p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-            (μ := F.commonFlatWeight μ) F.commonFlatBlocks) σ :=
-  zeroTail_commonFlat_of_blockwise A μ blocks F hMPV
-    (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_word_eq k (hWord k))
-
 /-- If the canonical identifications agree with consecutive grouping for every nonzero block,
 the zero-tail equation can be written using the derived common-sector family. -/
-lemma zeroTail_commonFlat_of_groupedBlockCastAgrees
+private lemma zeroTail_commonFlat_of_groupedBlockCastAgrees
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -143,7 +127,7 @@ lemma zeroTail_commonFlat_of_groupedBlockCastAgrees
 
 /-- The preceding zero-tail rewriting from the coordinate-grouping condition, expressed at a
 prescribed common length. -/
-lemma zeroTail_commonFlatAt_of_groupedBlockCastAgrees
+private lemma zeroTail_commonFlatAt_of_groupedBlockCastAgrees
     {d D r z : ℕ} {dim : Fin r → ℕ}
     (A : MPSTensor d D) (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -161,27 +145,6 @@ lemma zeroTail_commonFlatAt_of_groupedBlockCastAgrees
   subst p
   simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocksAt] using
     zeroTail_commonFlat_of_groupedBlockCastAgrees A μ blocks F hMPV hCast
-
-/-- At positive lengths, the blocked tensor has the same MPV coefficients as the
-weighted common-sector family whenever the coordinate-grouping condition holds. -/
-lemma sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees
-    {d D r z : ℕ} {dim : Fin r → ℕ}
-    (A : MPSTensor d D) (μ : Fin r → ℂ)
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (F : CommonBlockedCyclicSectorFamily blocks)
-    {p : ℕ} (hp : F.p = p)
-    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ)
-    (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
-    SameMPV₂Pos
-      (blockTensor (d := d) (D := D) A p)
-      (toTensorFromBlocks (d := blockPhysDim d p)
-        (μ := F.commonFlatWeight μ) (F.commonFlatBlocksAt hp)) := by
-  have hZeroTail := zeroTail_commonFlatAt_of_groupedBlockCastAgrees
-    (d := d) (D := D) (r := r) (z := z) (dim := dim)
-    A μ blocks F hp hMPV hCast
-  exact sameMPV₂Pos_of_zeroTail_eq _ _ hZeroTail
 
 /-- If the canonical blocked nonzero part agrees with the common reindexed blocks,
 the zero-tail equation can be rewritten using the derived common-sector family.

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -77,11 +77,11 @@ The proof derives all intermediate channel-level hypotheses
 peripheral spectrum structure) from `conjTranspose_kraus_setup` and
 passes them to `exists_cyclic_sector_decomp_after_blocking`.
 
-Note: this weaker variant is retained as a stepping stone; the version
-actually consumed downstream is
-`exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`,
-which additionally records the primitive/irreducible block properties used
-by `hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor`. -/
+Note: this weaker variant is retained for source-paper traceability; the
+stronger statement
+`exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
+additionally records the primitive/irreducible block properties and is used
+in the proof of `hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor`. -/
 theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)
@@ -126,9 +126,9 @@ The sequence of theorems proceeds through progressively weaker
 hypotheses (corner-irreducible → proj-step → fixed-algebra-rigidity
 → scalar-blocked-fixed-points) until the unconditional form
 `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking`
-is reached.  Only the unconditional form and the top-level existence theorem
-`exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
-are consumed by the downstream canonical-form proof chain.
+is reached.  Downstream canonical-form proofs use only the unconditional form
+together with the top-level existence theorem
+`exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`.
 -/
 
 open KadisonSchwarz
@@ -590,7 +590,7 @@ primitive, tensor-irreducible, trace-preserving sector blocks with
 positive bond dimensions.
 
 This encodes the unconditional sector-orbit lift into the single
-result consumed by the downstream common-blocking construction.  It is
+result used by the downstream common-blocking construction.  It is
 the period-removal counterpart of `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
 strengthened with primitivity and irreducibility. -/
 theorem exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -75,7 +75,13 @@ normal/BNT comparison in the non-periodic route of arXiv:1606.00608.
 The proof derives all intermediate channel-level hypotheses
 (`ρ.PosDef`, `Kraus.adjointMap` fixed point, `IsIrreducibleMap`,
 peripheral spectrum structure) from `conjTranspose_kraus_setup` and
-passes them to `exists_cyclic_sector_decomp_after_blocking`. -/
+passes them to `exists_cyclic_sector_decomp_after_blocking`.
+
+Note: this weaker variant is retained as a stepping stone; the version
+actually consumed downstream is
+`exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`,
+which additionally records the primitive/irreducible block properties used
+by `hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor`. -/
 theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean
@@ -20,9 +20,6 @@ sides have TP-primitive decompositions.
 * `bilateral_commonPeriod_blocking_tp_primitive_normal` — two tensors with
   primitive blocked transfer maps have a common positive blocking period that
   preserves primitivity, left-canonical normalization, and normality.
-* `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂` — two tensors with
-  the same MPV family have, after a common blocking, TP-primitive decompositions
-  on both sides retaining the blocked `SameMPV₂` relations and zero-tail equations.
 
 ## References
 
@@ -172,55 +169,6 @@ theorem bilateral_commonPeriod_blocking_tp_primitive_normal
   · exact leftCanonical_blockTensor (d := d) (D := D₂) (A := B) p hTPB
   · exact isNormal_blockTensor_of_isNormal (d := d) (D := D₁) A hp hNormalA
   · exact isNormal_blockTensor_of_isNormal (d := d) (D := D₂) B hp hNormalB
-
-/-- **Structural after-blocking theorem retaining zero-tail MPV equations.**
-
-This strengthens the structural shell by exposing the exact zero-tail identities
-returned by `exists_tp_primitive_blockDecomp_after_blocking`, in addition to the
-blocked `SameMPV₂` relations. The nonzero-weight blocks are trace-preserving, have
-primitive transfer maps, positive bond dimensions, and nonzero weights; the
-zero-tail equations explain precisely why these nonzero parts are only immediately
-identified at positive lengths unless the `N = 0` zero-tail identity is also
-resolved. -/
-theorem afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂
-    {d D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :
-    ∃ (zeroTailA : ℕ) (pA : ℕ) (_ : 0 < pA)
-      (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
-      (blocksA : (k : Fin rA) → MPSTensor (blockPhysDim d pA) (dimA k)),
-    ∃ (zeroTailB : ℕ) (pB : ℕ) (_ : 0 < pB)
-      (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
-      (blocksB : (k : Fin rB) → MPSTensor (blockPhysDim d pB) (dimB k)),
-      SameMPV₂ (blockTensor (d := d) (D := D₁) A pA)
-        (blockTensor (d := d) (D := D₂) B pA) ∧
-      SameMPV₂ (blockTensor (d := d) (D := D₁) A pB)
-        (blockTensor (d := d) (D := D₂) B pB) ∧
-      (∀ k, ∑ i, (blocksA k i)ᴴ * blocksA k i = 1) ∧
-      (∀ k, ∑ i, (blocksB k i)ᴴ * blocksB k i = 1) ∧
-      (∀ k, _root_.IsPrimitive (transferMap (blocksA k))) ∧
-      (∀ k, _root_.IsPrimitive (transferMap (blocksB k))) ∧
-      (∀ k, μA k ≠ 0) ∧
-      (∀ k, μB k ≠ 0) ∧
-      (∀ k, 0 < dimA k) ∧
-      (∀ k, 0 < dimB k) ∧
-      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d pA)),
-        mpv (blockTensor (d := d) (D := D₁) A pA) σ =
-          mpv (zeroMPSTensor (blockPhysDim d pA) zeroTailA) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d pA) (μ := μA) blocksA) σ) ∧
-      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d pB)),
-        mpv (blockTensor (d := d) (D := D₂) B pB) σ =
-          mpv (zeroMPSTensor (blockPhysDim d pB) zeroTailB) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d pB) (μ := μB) blocksB) σ) := by
-  obtain ⟨zeroTailA, pA, hpA, rA, dimA, μA, blocksA, hTPA, hPrimA, hDimA, hμA, hMPVA⟩ :=
-    exists_tp_primitive_blockDecomp_after_blocking A
-  obtain ⟨zeroTailB, pB, hpB, rB, dimB, μB, blocksB, hTPB, hPrimB, hDimB, hμB, hMPVB⟩ :=
-    exists_tp_primitive_blockDecomp_after_blocking B
-  refine ⟨zeroTailA, pA, hpA, rA, dimA, μA, blocksA,
-    zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
-    ?_, ?_, hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, hMPVA, hMPVB⟩
-  · exact sameMPV₂_blockTensor A B hSame pA
-  · exact sameMPV₂_blockTensor A B hSame pB
 
 
 end FundamentalTheoremAfterBlocking

--- a/audits/canonical_audit.md
+++ b/audits/canonical_audit.md
@@ -1,0 +1,559 @@
+# Canonical-form chapters: read-only audit
+
+Scope: blueprint chapters `ch08_canonical.tex`, `ch09_block_perm.tex`,
+`ch11b_after_blocking.tex` and their Lean files. No files modified.
+
+---
+
+## 1. Summary (~10 lines)
+
+* The PGVWC07 stack (one `structure` + 14 `exists_pgvwc07_*` theorems across
+  `NormalReduction/TPGauge.lean` and `NormalReduction/WeightNormalization.lean`)
+  is **entirely orphan**: no Lean file outside `NormalReduction/` and no
+  blueprint chapter outside `ch08_canonical.tex` consumes any `exists_pgvwc07_*`
+  or `PGVWC07PositiveLengthWitness.*` declaration. It exists solely to match
+  the literal statement of \cite[Th:TIcanonical]{PerezGarcia2007Matrix}.
+* The FT proof (`ch11_fundamental_theorem_proof.tex`) reaches Chapter 9 only
+  through `thm:tp_gauge_arbitrary` →
+  `thm:exists_common_blocked_cyclic_sector_family*` →
+  `thm:has_primitive_irreducible_cyclic_sectors_tp_irr`. None of those go
+  through PGVWC07.
+* Within the PGVWC07 stack a chain of seven intermediate "with_zeroTail",
+  "_bondDimBound", "_posMPV_bondDimBound", "_or_forall_pos_mpv_eq_zero",
+  "_allow_empty" theorems is exposed in the blueprint; only one
+  (`_allow_empty`) is plausibly worth a public statement.
+* Chapter 11b has four parallel `ft_after_blocking_*` theorems
+  (`_per_block_cyclic`, `_common_blocked_cyclic`, `_reindexed_common_sector`,
+  `_common_length_common_sector`) and one `_structural`. Only
+  `_common_length_common_sector_theorem` is consumed by Chapter 13's FT proof
+  (transitively through ch11's `unconditional_common_primitive_irreducible_blocks`).
+* `thm:cpgsv_canonical_form_source` in ch08 is `\notready` and unreferenced.
+* The Lean module `SectorComparison/CommonSectorTransport.lean` (679 lines) is
+  largely glue between `_of_blockwise / _of_word_eq /
+  _of_groupedBlockCastAgrees / _of_reindexed` formulations. After the
+  unconditional `flattenWordOfBlock_cast_eq` is proved the four are
+  interderivable; only one needs to be public.
+* Recommended action: keep
+  `thm:pgvwc07_ti_canonical_form` (= `_allow_empty`) as the single
+  blueprint-visible PGVWC07 statement; demote the rest to file-local Lean
+  lemmas. Delete `thm:cpgsv_canonical_form_source`. Collapse the
+  `ft_after_blocking_*` cluster around
+  `_common_length_common_sector_theorem`. Inline the
+  `_of_blockwise/_of_word_eq/_of_groupedBlockCastAgrees` triplets into the
+  single `_of_reindexed` form.
+
+---
+
+## 2. PGVWC07 stack classification
+
+Convention: **PRIMARY** = blueprint-visible, mathematically distinct;
+**INTERMEDIATE PLUMBING** = used only by the next member of the stack;
+**LEGACY DEAD BRANCH** = no consumers at all (Lean-file or blueprint).
+
+The dependency edges below were verified with
+`grep -rn 'NAME' TNLean blueprint/src` for each declaration. None of the
+listed declarations is consumed in `TNLean/MPS/FundamentalTheorem/**`,
+`TNLean/MPS/CanonicalForm/SectorComparison/**`,
+`TNLean/MPS/CanonicalForm/CyclicSectors/**`,
+`TNLean/MPS/BNT/**`, or in any blueprint chapter other than
+`ch08_canonical.tex`.
+
+| Lean name | Blueprint label | Classification | Downstream consumers |
+|---|---|---|---|
+| `exists_pgvwc07_unital_dualDiag_data_of_irreducible` | `thm:pgvwc07_irreducible_unital_dual_package` | INTERMEDIATE PLUMBING | only `exists_pgvwc07_unital_dualDiag_blockwise` (Lean) |
+| `exists_pgvwc07_unital_dualDiag_blockwise` | `thm:pgvwc07_blockwise_unital_dual_package` | INTERMEDIATE PLUMBING | only `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` |
+| `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` | `thm:pgvwc07_arbitrary_zero_tail_unital_dual_package` | INTERMEDIATE PLUMBING | only `_with_zeroTail_bondDimBound` |
+| `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` | `thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound` | INTERMEDIATE PLUMBING | only `_posMPV_bondDimBound` and `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail` |
+| `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` | `thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound` | INTERMEDIATE PLUMBING | only `exists_pgvwc07_positiveLengthWitness` |
+| `exists_pgvwc07_positiveLengthWitness` | `thm:pgvwc07_positive_length_witness` | INTERMEDIATE PLUMBING | only `WeightNormalization.lean` (witness packaging) |
+| `PGVWC07PositiveLengthWitness` (`structure`) | `def:pgvwc07_positive_length_witness` | INTERMEDIATE PLUMBING (data tuple bundling all witness fields; never used outside `NormalReduction/`) | only `WeightNormalization.lean` |
+| `PGVWC07PositiveLengthWitness.weight_ne_zero` | `lem:pgvwc07_positive_length_witness_weight_ne_zero` | LEGACY DEAD BRANCH | unreferenced (grep result: only its definition site). Inlinable in one line. |
+| `PGVWC07PositiveLengthWitness.exists_weight_normalization` | `thm:pgvwc07_positive_length_witness_weight_normalization` | INTERMEDIATE PLUMBING | only `_projective`, `_exact_form_after_rescaling_of_exists_ne_zero_mpv`, `_with_zeroTail` |
+| `PGVWC07PositiveLengthWitness.exists_weight_normalization_projective` | `thm:pgvwc07_positive_length_witness_weight_normalization_projective` | INTERMEDIATE PLUMBING | only `exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv` |
+| `PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv` | `lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv` | INTERMEDIATE PLUMBING | only the `_of_exists_ne_zero_mpv` projective and exact-form theorems |
+| `exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv` | `thm:pgvwc07_nonzero_normalized_projective_form` | INTERMEDIATE PLUMBING | only `_projective_form_or_forall_pos_mpv_eq_zero` |
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv` | `thm:pgvwc07_nonzero_normalized_exact_rescaled_form` | INTERMEDIATE PLUMBING | only `_or_forall_pos_mpv_eq_zero` |
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero` | `thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy` | INTERMEDIATE PLUMBING | only `_allow_empty` |
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` | `thm:pgvwc07_ti_canonical_form` (the chosen primary) | **PRIMARY** | source-faithful PGVWC07 statement; not consumed by FT path but is the headline theorem for the chapter |
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail` | `thm:pgvwc07_exact_rescaled_form_with_zero_tail` | LEGACY DEAD BRANCH | grep: not referenced in any other Lean file nor in any later blueprint chapter; ch08 mentions it only in a forward reference from the primary theorem's narrative |
+| `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero` | `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` | LEGACY DEAD BRANCH | grep: only the file that defines it; no Lean or blueprint consumer |
+
+Verification commands run for the LEGACY DEAD BRANCH entries:
+
+```
+grep -rn 'exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail'  TNLean blueprint
+grep -rn 'exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero' TNLean blueprint
+grep -rn 'PGVWC07PositiveLengthWitness.weight_ne_zero'                         TNLean blueprint
+```
+
+Each returned only the definition site (plus the import-summary docstring of
+`NormalReduction.lean` and the `thm:pgvwc07_*` blueprint entries that refer
+to them).
+
+**Refactor recommendation for the PGVWC07 stack.** Keep exactly one
+blueprint-visible PGVWC07 statement (`thm:pgvwc07_ti_canonical_form`,
+Lean: `exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`).
+Demote every other entry in this stack to a Lean-internal lemma without a
+`\lean{...}` blueprint tag — they are private to the proof of
+`_allow_empty`. The `with_zeroTail` and `_projective_form_or_forall_pos_mpv_eq_zero`
+variants are unused and can be deleted.
+
+---
+
+## 3. Duplicate / parallel naming clusters
+
+### Cluster A — PGVWC07 weight-normalization variants
+
+| Member | Differs from primary by |
+|---|---|
+| `exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` | **(primary)** |
+| `_after_rescaling_with_zeroTail` | retains an explicit zero block summand in the conclusion |
+| `_projective_form_or_forall_pos_mpv_eq_zero` | proportional MPV instead of exact after global scalar |
+| `_or_forall_pos_mpv_eq_zero` | nonzero/zero dichotomy unstapled from the empty-family conclusion |
+| `_of_exists_ne_zero_mpv` (exact and projective) | hypothesis `∃ N σ, V^{(N)}(A)_σ ≠ 0` instead of the empty-block escape |
+
+**Primary entry point to remember:** `_after_rescaling_allow_empty`.
+Drop the four others from the blueprint (they remain available in the Lean
+source as local lemmas, or can be deleted; cf. §2).
+
+### Cluster B — PGVWC07 unital-dualDiag chain
+
+| Member | Differs from primary by |
+|---|---|
+| `_data_of_irreducible` | single-block input |
+| `_blockwise` | finite-direct-sum input, unit weights |
+| `_from_arbitrary_with_zeroTail` | arbitrary input, zero block kept |
+| `_from_arbitrary_with_zeroTail_bondDimBound` | adds the length-zero `D_0 + Σ D_k = D` identity |
+| `_from_arbitrary_posMPV_bondDimBound` | strips the zero block, keeps the bound on `N ≥ 1` |
+
+**Primary entry point to remember:** `_from_arbitrary_posMPV_bondDimBound`
+(this is what feeds `exists_pgvwc07_positiveLengthWitness`).
+All preceding ones should be Lean-internal `private` / file-local lemmas
+without blueprint entries.
+
+### Cluster C — `cyclic_sector_decomp_*` triple
+
+| Member | Lean name | Public role |
+|---|---|---|
+| `thm:cyclic_sector_decomp_after_blocking` | `exists_cyclic_sector_decomp_after_blocking` | the underlying constructor (used by `_irr_tp` and `_prim_irr`) |
+| `thm:cyclic_sector_decomp_irr_tp` | `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` | LEGACY: unused outside `CyclicSectorDecomposition.lean` |
+| `thm:cyclic_sector_decomp_irr_tp_prim_irr` | `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` | feeds `hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor` (the actual FT-path input) |
+
+**Primary entry point to remember:** `_prim_irr`. The `_irr_tp` version is
+strictly weaker and is not used anywhere downstream — propose demoting to
+private.
+
+### Cluster D — `ft_after_blocking_*` family
+
+| Member | Position in dep chain | External consumer? |
+|---|---|---|
+| `thm:ft_after_blocking_structural` | duplicates `thm:tp_primitive_blockdecomp` for two tensors | no (only `\notready` narrative references) |
+| `thm:ft_after_blocking_per_block_cyclic_live_zero_tail` | input to `_common_blocked_cyclic` and `_common_length_common_sector` | only inside ch11b |
+| `thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail` | input to `_reindexed_common_sector` | only inside ch11b |
+| `thm:ft_after_blocking_reindexed_common_sector_live_zero_tail` | **never used** (verified by grep) | LEGACY DEAD |
+| `thm:ft_after_blocking_common_length_common_sector_theorem` | **the consumed one** | used by `thm:after_blocking_common_primitive_irreducible_blocks_reindexed` and (transitively) by ch11's `thm:unconditional_common_primitive_irreducible_blocks` |
+| `thm:ft_after_blocking_common_length_common_sector_reindexed` | restates the above with a word identification baked in | LEGACY DEAD (no consumer) |
+
+**Primary entry point to remember:** `_common_length_common_sector_theorem`.
+The `_per_block_cyclic_live_zero_tail` and
+`_common_blocked_cyclic_live_zero_tail` members are intermediate; they are
+fine to keep as proof steps but should not carry their own blueprint
+theorem entries (they should be folded into the proof of
+`_common_length_common_sector_theorem`).
+
+### Cluster E — zero-tail transport quadruple
+(`TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean`,
+all four variants exposed via `\lean{...}` in
+`thm:zero_tail_common_flat_of_blocked_word_comparison`)
+
+| Lean name | Differs from primary by |
+|---|---|
+| `zeroTail_commonFlat_of_blockwise` | takes a per-block `SameMPV₂` hypothesis |
+| `zeroTail_commonFlat_of_word_eq` | takes a per-block word-equation hypothesis |
+| `zeroTail_commonFlat_of_groupedBlockCastAgrees` | takes the `groupedBlockCastAgrees` predicate |
+| `zeroTail_commonFlat_of_reindexed` | takes a `SameMPV₂` between two `toTensorFromBlocks` expressions (the form actually used downstream) |
+
+The other three are intermediate lemmas. Once
+`CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq` is proved
+(it is — unconditionally), only `_of_reindexed` is needed externally.
+**Primary entry point:** `_of_reindexed`; the other three should be
+private. Symmetric for the `_commonFlatAt_*` and
+`_blockTensor_commonFlatAt_*` `\lean{...}` lists in the same blueprint
+theorem.
+
+### Cluster F — repeated bracket of "MPV phase cover" lemmas in ch11
+(`lem:common_phase_cover_of_block_matching`,
+`lem:common_phase_cover_of_equiv_phase`,
+`lem:nonzero_block_span_eq_of_common_phase_cover`,
+`lem:mpv_common_phase_cover_span_eq`,
+`lem:nonzero_block_span_eq_of_block_matching`,
+`lem:nonzero_block_span_eq_of_equiv_phase`)
+
+The pair `_of_block_matching` / `_of_equiv_phase` exists in three flavours
+(common-phase-cover, span-equality, and combined). Only the
+`_of_block_matching` chain is consumed by
+`thm:bnt_sectorDecomp_pair_overlapSpan_of_commonPhaseCover`. The
+`_of_equiv_phase` chain is not consumed by ch11/ch13. Recommend marking the
+`_of_equiv_phase` variants as auxiliary (no blueprint entry).
+
+---
+
+## 4. CPGSV17a Fundamental-Theorem bridge map
+
+### 4.1 What the FT proof actually consumes
+
+Tracing `\uses{...}` from `ch11_fundamental_theorem_proof.tex` outward:
+
+```
+ch11_fundamental_theorem_proof.tex
+├── thm:unconditional_common_primitive_irreducible_blocks  [line 858]
+│   └── thm:after_blocking_common_primitive_irreducible_blocks_reindexed  [ch11b, line 822]
+│       └── thm:ft_after_blocking_common_length_common_sector_theorem  [ch11b, line 660]
+│           ├── thm:ft_after_blocking_per_block_cyclic_live_zero_tail  [ch11b, line 511]
+│           │   ├── thm:tp_gauge_arbitrary               [ch08, line 1359]
+│           │   │   ├── thm:zero_block_separation       [ch11b, line 52]
+│           │   │   │   └── thm:irred_decomp             [ch08, line 441]
+│           │   │   └── thm:tp_data_irreducible          [ch08]
+│           │   ├── thm:nonzero_block_zero_tail_identity [ch11b, line 405]
+│           │   └── thm:has_primitive_irreducible_cyclic_sectors_tp_irr [ch08, line 2004]
+│           │       └── thm:cyclic_sector_decomp_irr_tp_prim_irr [ch08, line 1481]
+│           ├── thm:exists_common_blocked_cyclic_sector_family_common_multiple [ch08, line 2072]
+│           ├── thm:zero_tail_to_tensor_from_blocks_block_power [ch11b]
+│           ├── thm:nonzero_block_block_power_zero_tail_identity [ch11b]
+│           ├── thm:common_blocked_cyclic_sector_reindexed_samempv [ch08]
+│           └── thm:common_blocked_cyclic_sector_derived_properties [ch08]
+└── (BNT comparison lemmas, all internal to ch11/ch10)
+```
+
+### 4.2 Bridge questions answered
+
+* **Does `thm:pgvwc07_ti_canonical_form` feed into the FT proof?**
+  **No.** The label appears in `ch08_canonical.tex` only.
+  `grep -rn 'thm:pgvwc07_ti_canonical_form' blueprint/src` returns only
+  its own definition site and one self-referential paragraph. There is
+  no `\uses{thm:pgvwc07_ti_canonical_form}` anywhere in `blueprint/src/`.
+
+* **Is the only path used by the FT proof through `thm:tp_primitive_blockdecomp`?**
+  Almost. The FT proof reaches the same content one level higher, via
+  `thm:after_blocking_common_primitive_irreducible_blocks_reindexed`,
+  which uses `thm:ft_after_blocking_common_length_common_sector_theorem`,
+  not `thm:tp_primitive_blockdecomp` directly. (The two share the same
+  upstream theorems `thm:tp_gauge_arbitrary`, `thm:common_blocking_period`,
+  `thm:zero_tail_to_tensor_from_blocks_block_power`.)
+  `thm:tp_primitive_blockdecomp` is itself only consumed by the
+  one-tensor-flavoured `thm:ft_after_blocking_structural`, which is
+  unconsumed (see Cluster D).
+
+* **Does the PGVWC07 stack join the CPSV stack anywhere?**
+  No. The two stacks share only the shallow common dependencies
+  `def:irreducible_tensor`, `def:tp_kraus`, `def:transfer_map`,
+  `def:same_mpv2`, and `thm:irred_decomp`. The PGVWC07 stack uses the
+  **unital** orientation `Σ A^i (A^i)†=Id`; the CPSV / FT stack uses the
+  **left-canonical** TP orientation `Σ (A^i)† A^i=Id`. There is no
+  blueprint or Lean reduction that takes a PGVWC07 conclusion as a
+  hypothesis of a downstream theorem in ch11b or ch11.
+
+**Conclusion: the PGVWC07 stack is parallel and not bridged to the
+CPGSV17a FT chain.** The chapter preface should state this explicitly:
+the PGVWC07 stack reproduces the literal statement of
+\cite[Th:TIcanonical]{PerezGarcia2007Matrix} as a source-faithful target,
+and the canonical-form reduction used by Chapter 13's FT proof goes
+through Chapter 12 / `thm:tp_primitive_blockdecomp` /
+`thm:tp_gauge_arbitrary` / `thm:common_blocking_period` /
+`thm:has_primitive_irreducible_cyclic_sectors_tp_irr` instead.
+
+### 4.3 `thm:cpgsv_canonical_form_source` (ch08 line 108, `\notready`)
+
+* Grep result: defined once, referenced twice in the same chapter
+  (lines 172 and 185), nowhere else.
+* **No downstream `\uses{thm:cpgsv_canonical_form_source}` anywhere in
+  `blueprint/src/`.**
+* Recommendation: replace the `\begin{theorem}...\notready` block with
+  a `\begin{remark}` that cites
+  \cite[Section~II.C]{Cirac2017MPDO_AnnPhys} as the source statement,
+  and points the reader at `thm:tp_primitive_blockdecomp` /
+  `thm:paperbnt_supplier_after_blocking` as the closest checked
+  formalizations.
+
+---
+
+## 5. Concrete refactor actions, ordered by safety
+
+The orchestrator should apply these in this order; each step is locally
+verifiable.
+
+### Step 5.1 — blueprint-only (safest, no Lean recompile)
+
+1. **Delete `thm:cpgsv_canonical_form_source`** (`ch08_canonical.tex`
+   lines 108–168). Replace with a `\begin{remark}` of two sentences
+   citing \cite[Section~II.C]{Cirac2017MPDO_AnnPhys} and pointing at
+   `thm:tp_primitive_blockdecomp` and
+   `thm:paperbnt_supplier_after_blocking`. Update the two intra-chapter
+   references at lines 172 and 185.
+2. **Demote 11 of the 14 PGVWC07 blueprint entries** (those classified
+   INTERMEDIATE PLUMBING or LEGACY DEAD BRANCH in §2). For each:
+   * Remove the `\begin{theorem}...\end{theorem}` block and its
+     companion `\begin{proof}...\end{proof}`.
+   * Leave the corresponding Lean theorem in place (it remains a
+     well-named internal lemma).
+   * Re-state the closure as a single sentence in the proof sketch of
+     `thm:pgvwc07_ti_canonical_form`.
+   Specifically, drop from the blueprint:
+   ```
+   thm:pgvwc07_irreducible_unital_dual_package
+   thm:pgvwc07_blockwise_unital_dual_package
+   thm:pgvwc07_arbitrary_zero_tail_unital_dual_package
+   thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound
+   thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound
+   thm:pgvwc07_positive_length_witness
+   thm:pgvwc07_positive_length_witness_weight_normalization
+   thm:pgvwc07_positive_length_witness_weight_normalization_projective
+   thm:pgvwc07_nonzero_normalized_projective_form
+   thm:pgvwc07_nonzero_normalized_exact_rescaled_form
+   thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy
+   thm:pgvwc07_exact_rescaled_form_with_zero_tail
+   thm:pgvwc07_projective_form_zero_nonzero_dichotomy
+   lem:pgvwc07_positive_length_witness_weight_ne_zero
+   lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv
+   def:pgvwc07_positive_length_witness   ← this is the bundled `structure`; demote to Lean-only
+   ```
+   Keep `thm:pgvwc07_ti_canonical_form` (the `_allow_empty` headline).
+3. **Demote `thm:ft_after_blocking_reindexed_common_sector_live_zero_tail`
+   and `thm:ft_after_blocking_common_length_common_sector_reindexed`**
+   (both unconsumed; see Cluster D in §3). Delete their blueprint
+   entries; leave Lean declarations in place.
+4. **Demote `thm:ft_after_blocking_structural`** (line 261 of ch11b)
+   to a remark. Its Lean counterpart
+   `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂` is unused
+   outside its definition file.
+5. **Tighten the chapter prefaces** of `ch08_canonical.tex`,
+   `ch09_block_perm.tex`, `ch11b_after_blocking.tex` per
+   `docs/prose_style.md`:
+   * `ch08`: replace the four meta-paragraphs (lines 1–185) with a
+     single `\section{Scope}` (about 8 lines): names the source
+     theorem, states the unital vs left-canonical orientation
+     convention, and lists the headline statements of the chapter
+     (`thm:pgvwc07_ti_canonical_form`, `thm:irred_decomp`,
+     `thm:CFII_data`, `thm:cyclic_sector_decomp_irr_tp_prim_irr`,
+     `thm:tp_gauge_arbitrary`, `thm:exists_normal_canonical_form`).
+     Drop banned words "package" (occurs in three theorem titles —
+     `pgvwc07_irreducible_unital_dual_package`,
+     `pgvwc07_blockwise_unital_dual_package`,
+     `pgvwc07_arbitrary_zero_tail_unital_dual_package` — already
+     scheduled for removal in 5.1.2).
+   * `ch09`: cut the footnote on line 17 (move to a LaTeX comment;
+     paper-gap reference belongs in a comment, not in chapter prose).
+     The "scope distinction" sentence currently spans lines 7–18 and
+     repeats itself in `rem:pgvwc07_vs_local_cf` (line 340) — keep
+     only the remark.
+   * `ch11b`: lines 3–14 contain a five-sentence preface ending in
+     "those chapters no longer provide hypotheses for the
+     Fundamental-Theorem comparison." This phrasing repeats the
+     equivalent paragraph at the top of ch11. Replace with one
+     `\section{Scope}` of three sentences naming the two outputs
+     of the chapter: `thm:tp_primitive_blockdecomp` and
+     `thm:ft_after_blocking_common_length_common_sector_theorem`.
+6. **Sweep the "package" / "data" / "assembly" wording.** Per
+   `docs/prose_style.md` §2 these are banned. Affected blueprint
+   theorem titles (verified by grep `Definition\[.*[Dd]ata` and
+   `[Pp]ackage` in the three chapters):
+   * "unital and dual-diagonal data" → already removed in 5.1.2.
+   * `thm:pgvwc07_irreducible_unital_dual_package`,
+     `thm:pgvwc07_blockwise_unital_dual_package`,
+     `thm:pgvwc07_arbitrary_zero_tail_unital_dual_package` →
+     already removed in 5.1.2.
+   * `def:pgvwc07_positive_length_witness` "positive-length PGVWC07
+     canonical-form witness" — the bundled structure stays in Lean,
+     but the blueprint definition is removed (see 5.1.2).
+   * In ch11_fundamental_theorem_proof.tex the term "MPV phase cover
+     data" appears in the `def:mpv_common_phase_cover` definition
+     paragraph (line 605–615); the surrounding paragraphs use "data"
+     non-vaguely (it refers to the bundled tuple); per
+     `docs/prose_style.md` §3 this is allowed.
+
+### Step 5.2 — Lean refactor (touches no math content)
+
+7. **Move PGVWC07 declarations to a Lean-internal namespace.** Rename
+   `NormalReduction/TPGauge.lean` decls that are no longer
+   blueprint-visible into a `namespace MPSTensor.PGVWC07` and prefix
+   with `_aux_` (or move into a new file
+   `NormalReduction/Internal/PGVWC07Stack.lean`). This leaves the
+   public API as exactly
+   * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`
+     (kept; matches `thm:pgvwc07_ti_canonical_form`).
+   * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` (kept;
+     consumed by `CommonSectorData.lean` and `TPPrimitiveReduction.lean`).
+   No compile risk: every non-exported declaration loses only its
+   blueprint tag, not its Lean callers (which are all in the same
+   sub-folder).
+8. **Inline the three duplicate `zeroTail_commonFlat_of_*` lemmas.**
+   In `SectorComparison/CommonSectorTransport.lean`, mark
+   `zeroTail_commonFlat_of_blockwise`,
+   `zeroTail_commonFlat_of_word_eq`, and
+   `zeroTail_commonFlat_of_groupedBlockCastAgrees` `private`
+   (and likewise their `_commonFlatAt_*` and `sameMPV₂Pos_*` siblings).
+   The only public statement needed is `_of_reindexed`. Update the
+   `\lean{...}` block of
+   `thm:zero_tail_common_flat_of_blocked_word_comparison` to list one
+   declaration. Compile risk: low — the three "_of_blockwise/_of_word_eq
+   /_of_groupedBlockCastAgrees" variants are not referenced outside
+   the same file (verified by `grep -rn ... TNLean`).
+9. **Demote `exists_blockTensor_isPrimitive` and
+   `exists_blockTensor_leftCanonical_isPrimitive`** in
+   `CanonicalForm/Existence.lean` lines 216, 232 — these are `NeZero`-
+   wrappers around `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`
+   and are unused outside that file. Either inline at the one call
+   site or make them `private`. No blueprint impact (they carry no
+   `\lean{...}` blueprint tag).
+10. **Demote `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`**
+    (`SectorComparison/CyclicSectorDecomposition.lean` line 79). It is
+    unused outside its definition file; the consumed entry is
+    `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`.
+    Mark `private` or delete; drop the blueprint entry
+    `thm:cyclic_sector_decomp_irr_tp` (Cluster C in §3).
+11. **Reduce the `CommonSectorRelabelingHypothesis` /
+    `CommonGroupedBlockCastHypothesis` pair to one definition.**
+    `CommonSectorTransport.lean` lines 365 and 381 both define a
+    `Prop`-level abbreviation; their relationship is captured by
+    `CommonGroupedBlockCastHypothesis.toRelabelingHypothesis` and
+    `of_flattenWordOfBlock_cast_eq` proves the latter unconditionally.
+    Recommend collapsing to a single `private abbrev` and inlining the
+    proof of `unconditional_commonPrimitiveIrreducibleBlocks` so it
+    does not pass through the abbrev at all.
+
+### Step 5.3 — deletions (only after Steps 5.1–5.2 land)
+
+12. After Step 5.1, **delete the dead Lean theorems** identified as
+    LEGACY DEAD BRANCH in §2 once nothing references their `\lean{...}`
+    tags from the blueprint:
+    * `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail`
+    * `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`
+    * `PGVWC07PositiveLengthWitness.weight_ne_zero`
+    Compile risk: none after Step 5.1.2 (these are file-local).
+13. **Delete the dead Lean theorems behind the Cluster D entries:**
+    * `MPSTensor.afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂`
+      (`SectorComparison/CommonSectorData.lean`)
+    * `MPSTensor.afterBlocking_commonLengthCommonSectorData_of_reindexed`
+      (`SectorComparison/CommonSectorTransport.lean`)
+    * `MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`
+      (`SectorComparison/StructuralData.lean`)
+    Compile risk: low — `grep -rn` over `TNLean` returns only their
+    definition files.
+
+---
+
+## 6. Per-action file / label / replacement-name lists
+
+### 6.1 Files and labels for Step 5.1 (blueprint deletions)
+
+| File | Range / Label | Action | Replacement | Compile risk |
+|---|---|---|---|---|
+| `blueprint/src/chapter/ch08_canonical.tex` | lines 108–168 (`thm:cpgsv_canonical_form_source`) | delete | `\begin{remark}[CPSV blocked canonical form]\label{rem:cpgsv_canonical_form_source} …\end{remark}` with two-sentence pointer | none (blueprint only) |
+| `blueprint/src/chapter/ch08_canonical.tex` | `thm:pgvwc07_irreducible_unital_dual_package` (≈ line 802) | delete entry; inline into proof sketch of `thm:pgvwc07_ti_canonical_form` | n/a (no replacement label) | none |
+| same | `thm:pgvwc07_blockwise_unital_dual_package` (≈ 844) | delete | n/a | none |
+| same | `thm:pgvwc07_arbitrary_zero_tail_unital_dual_package` (≈ 882) | delete | n/a | none |
+| same | `thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound` (≈ 924) | delete | n/a | none |
+| same | `thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound` (≈ 950) | delete | n/a | none |
+| same | `def:pgvwc07_positive_length_witness` (≈ 985) | delete from blueprint; structure stays Lean-only | n/a | none |
+| same | `lem:pgvwc07_positive_length_witness_weight_ne_zero` (≈ 1002) | delete | n/a | none |
+| same | `thm:pgvwc07_positive_length_witness_weight_normalization` (≈ 1030) | delete | n/a | none |
+| same | `thm:pgvwc07_positive_length_witness_weight_normalization_projective` (≈ 1061) | delete | n/a | none |
+| same | `lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv` (≈ 1092) | delete | n/a | none |
+| same | `thm:pgvwc07_nonzero_normalized_projective_form` (≈ 1112) | delete | n/a | none |
+| same | `thm:pgvwc07_nonzero_normalized_exact_rescaled_form` (≈ 1140) | delete | n/a | none |
+| same | `thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy` (≈ 1173) | delete | n/a | none |
+| same | `thm:pgvwc07_exact_rescaled_form_with_zero_tail` (≈ 1216) | delete | n/a | none |
+| same | `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` (≈ 1246) | delete | n/a | none |
+| same | `thm:pgvwc07_ti_canonical_form` (≈ 41) | **keep**; trim the `% Source anchors` block (lines 46–60) into a single bibliographic citation; remove forward reference to the now-deleted `thm:pgvwc07_exact_rescaled_form_with_zero_tail` (line 85). | replace forward reference by a remark | none |
+| `blueprint/src/chapter/ch11b_after_blocking.tex` | `thm:ft_after_blocking_structural` (line 261) | demote to remark | `\begin{remark}…` cites `thm:tp_primitive_blockdecomp` | none |
+| same | `thm:ft_after_blocking_reindexed_common_sector_live_zero_tail` (line 614) | delete | n/a | none |
+| same | `thm:ft_after_blocking_common_length_common_sector_reindexed` (line 1011) | delete | n/a | none |
+| `blueprint/src/chapter/ch09_block_perm.tex` | preface (lines 1–18) and `rem:pgvwc07_vs_local_cf` (line 340) | consolidate into one `\section{Scope}` + one `\begin{remark}` | scope statement names the chapter's three outputs (`thm:pi_auto_decomp`, `thm:pi_linear_ext`, `lem:block_sep`/`lem:block_sep_normal`/`lem:ft_canonical`) | none |
+
+### 6.2 Files and decl names for Step 5.2 (Lean refactor)
+
+| File | Declaration | Action | Replacement / new name | Compile risk |
+|---|---|---|---|---|
+| `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_data_of_irreducible` | `private` (or rename to `MPSTensor.PGVWC07.unital_dualDiag_single_block`) | keep call sites | none — file-local |
+| same | `exists_pgvwc07_unital_dualDiag_blockwise` | `private` | `MPSTensor.PGVWC07.unital_dualDiag_blockwise` | none |
+| same | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` | `private` | `MPSTensor.PGVWC07.unital_dualDiag_arbitrary_with_zeroTail` | none |
+| same | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` | `private` | rename to `…_bondDim_total_eq` (the conclusion is `D_0 + Σ = D`, not a bound) | none |
+| same | `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` | `private` | rename to `…_positive_length` | none |
+| same | `exists_pgvwc07_positiveLengthWitness` | `private` | `MPSTensor.PGVWC07.positiveLengthWitness` | none |
+| same | `PGVWC07PositiveLengthWitness` (`structure`) | move to `namespace MPSTensor.PGVWC07`; rename to `Internal.PositiveLengthWitness` | keep all field names | none |
+| `TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean` | all `_normalized_*` theorems except `_allow_empty` | `private` | drop `pgvwc07_` from the names since the file is already `NormalReduction/` | none |
+| `TNLean/MPS/CanonicalForm/Existence.lean` | `exists_blockTensor_isPrimitive` (line 216), `exists_blockTensor_leftCanonical_isPrimitive` (line 232) | `private` (or delete and inline) | n/a | none — file-local |
+| `TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean` | `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` (line 79) | `private` | n/a | none — file-local |
+| `TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlat_of_blockwise`, `_of_word_eq`, `_of_groupedBlockCastAgrees`, and their `_commonFlatAt_*` and `sameMPV₂Pos_blockTensor_commonFlatAt_*` companions | `private` | keep public: `_of_reindexed`, `_commonFlatAt_of_reindexed`, `sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed`, `zeroTail_commonFlat_transport_of_reindexed`, and the abbrev pair | none — all callers in same file |
+| `TNLean/MPS/CanonicalForm/CommonPeriodCyclicSectors.lean` | `commonPeriodBlocking_apply` (`rfl`-lemma, line 60) | mark `@[simp]` or delete | n/a | none |
+
+### 6.3 Files and decl names for Step 5.3 (Lean deletions)
+
+| File | Declaration | Action | Compile risk |
+|---|---|---|---|
+| `TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail`, `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero` | delete | none — verified zero external references |
+| `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean` | `PGVWC07PositiveLengthWitness.weight_ne_zero` (after the `structure` move in 5.2) | delete (inline at single use) | none |
+| `TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean` | `afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂` | delete | none |
+| `TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean` | `afterBlocking_commonLengthCommonSectorData_of_reindexed` | delete | none |
+| `TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean` | `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂` (line 185) | delete | none — only consumer is the now-removed blueprint entry `thm:ft_after_blocking_structural` |
+
+### 6.4 Replacement-name guidance per `docs/blueprint_style_guide.md` + `docs/prose_style.md`
+
+* Banned in titles: "package", "assembly", "data" (as bare noun),
+  "wiring", "bridge", "plumbing". The current titles
+  "Single irreducible-block PGVWC07 canonical-form theorem" (line 802)
+  → after removal becomes a proof step "Single-block normalization" inside
+  the proof of `thm:pgvwc07_ti_canonical_form`. No new heading needed.
+* Theorem heading style: keep "Translation-invariant canonical form"
+  (line 41) — already source-faithful; remove the trailing
+  `% Source anchors` block (16 lines of LaTeX comments) and replace
+  with one `\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}` in the
+  body.
+* Lean section names with "Assembly" — verified via
+  `grep -rn 'section Assembly' TNLean/MPS/CanonicalForm` (no matches).
+  The Lean code is already clean on this point.
+
+---
+
+## 7. Verification log
+
+The following grep commands were used to verify the consumer claims in
+§2 and §4. The reported counts are the number of lines returned at audit
+time; the orchestrator can re-run them after applying each step.
+
+```
+grep -rn 'exists_pgvwc07_' TNLean blueprint
+    →  every hit is in NormalReduction/TPGauge.lean,
+       NormalReduction/WeightNormalization.lean,
+       NormalReduction.lean (import summary),
+       ch08_canonical.tex, or docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
+       Zero hits in FundamentalTheorem/, BNT/, SectorComparison/,
+       CyclicSectors/, ch09_block_perm.tex, ch11b_after_blocking.tex,
+       ch11_fundamental_theorem_proof.tex, ch10_bnt.tex, ch13_*.tex,
+       Periodic/, ParentHamiltonian/, Symmetry/.
+
+grep -rn 'thm:cpgsv_canonical_form_source' blueprint
+    →  3 hits, all in ch08_canonical.tex (definition + 2 self-references).
+
+grep -rn '\\uses{thm:pgvwc07' blueprint
+    →  0 hits.
+
+grep -rn 'thm:ft_after_blocking_common_length_common_sector_theorem' blueprint
+    → 6 hits, all in ch11b_after_blocking.tex (as expected — internal
+      chain) plus 1 indirect consumer through
+      thm:after_blocking_common_primitive_irreducible_blocks_reindexed,
+      which is `\uses`-cited by ch11_fundamental_theorem_proof.tex
+      line 862.
+
+grep -rn 'exists_tp_gauge_from_arbitrary_with_zeroTail' TNLean
+    →  consumed by SectorComparison/CommonSectorData.lean,
+       SectorComparison/TPPrimitiveReduction.lean, and listed in
+       StructuralData.lean's docstring. This is the actual
+       canonical-form input fed into Chapter 12's primitive
+       block decomposition.
+```
+
+The single canonical "bridge declaration" the user is looking for is
+`MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
+(`thm:tp_gauge_arbitrary`). The PGVWC07 stack is **parallel** to this
+bridge, not part of it.

--- a/audits/canonical_audit.md
+++ b/audits/canonical_audit.md
@@ -3,6 +3,19 @@
 Scope: blueprint chapters `ch08_canonical.tex`, `ch09_block_perm.tex`,
 `ch11b_after_blocking.tex` and their Lean files. No files modified.
 
+> **Post-audit decision.** After review, the recommendation in §5.1.2
+> below — to demote the 11 INTERMEDIATE PLUMBING PGVWC07 entries from
+> the blueprint — was *partially* reversed: the 13 intermediate entries
+> are restored as a dedicated reader-visible section
+> `sec:pgvwc07_intermediates` because they record the source proof
+> order of \cite[Th:TIcanonical]{PerezGarcia2007Matrix} and serve as
+> mathematical waypoints. Only the LEGACY DEAD BRANCH entries (no
+> consumer at all) stay deleted. See
+> `audits/pgvwc07_restoration_report.md` for the restoration log.
+> The summary and §5 recommendations below reflect the original audit
+> classification; §2 (the per-declaration classification table) and
+> §3–§4 remain accurate.
+
 ---
 
 ## 1. Summary (~10 lines)
@@ -298,6 +311,18 @@ verifiable.
      well-named internal lemma).
    * Re-state the closure as a single sentence in the proof sketch of
      `thm:pgvwc07_ti_canonical_form`.
+
+   > **Status update (post-audit).** After review, the INTERMEDIATE
+   > PLUMBING entries were restored as a dedicated blueprint section
+   > `sec:pgvwc07_intermediates` because they record the source proof
+   > order of \cite[Th:TIcanonical]{PerezGarcia2007Matrix} and are
+   > worth keeping as reader-visible mathematical waypoints. See
+   > `audits/pgvwc07_restoration_report.md` for the restoration log.
+   > The LEGACY DEAD BRANCH entries below (`_with_zero_tail`,
+   > `_projective_form_zero_nonzero_dichotomy`,
+   > `_weight_ne_zero`, and the duplicate
+   > `_exact_rescaled_form_allow_empty`) stay deleted.
+
    Specifically, drop from the blueprint:
    ```
    thm:pgvwc07_irreducible_unital_dual_package

--- a/audits/canonical_lean_refactor_report.md
+++ b/audits/canonical_lean_refactor_report.md
@@ -25,34 +25,51 @@ are out of scope here).
 
 ## 2. Declarations privatized
 
+> **Audit-vs-final-state correction (post-review).** A first version of this
+> report described 13 declarations as "privatized"; in fact only the
+> SectorComparison/CommonSectorTransport.lean entries received the `private`
+> keyword.  The PGVWC07 declarations in TPGauge.lean and WeightNormalization.lean
+> were planned for privatization in Step 5.2 but later restored to public
+> visibility in the PGVWC07 restoration step (see
+> `audits/pgvwc07_restoration_report.md` and the `rev:` note in the next
+> subsection below).  Only the public/private columns of the table below
+> reflect the *final state on the PR HEAD*; the "PGVWC07 stack" rows are kept
+> for historical traceability.
+
 All call-graph verifications were done with
 `grep -rln 'DeclName' TNLean --include='*.lean'` and confirmed the only
 hits were either the definition file itself or module-summary docstrings
-(no real call sites).  Lean `private` is file-scoped: I only privatized
-declarations whose call sites all live in the same `.lean` file.
+(no real call sites).  Lean `private` is file-scoped: only declarations whose
+call sites all live in the same `.lean` file are eligible for `private`.
+
+Declarations marked `private` on PR HEAD (final state):
 
 | File | Declaration | Reason |
 |---|---|---|
-| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_data_of_irreducible` | file-local; intermediate PGVWC07 step |
-| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_blockwise` | file-local; intermediate PGVWC07 step |
-| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` | file-local; intermediate PGVWC07 step |
-| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` | file-local; intermediate PGVWC07 step |
-| `NormalReduction/WeightNormalization.lean` | `PGVWC07PositiveLengthWitness.exists_weight_normalization` | file-local; weight-normalization chain |
-| `NormalReduction/WeightNormalization.lean` | `PGVWC07PositiveLengthWitness.exists_weight_normalization_projective` | file-local |
-| `NormalReduction/WeightNormalization.lean` | `PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv` | file-local |
-| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv` | file-local |
-| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv` | file-local |
-| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero` | file-local |
 | `SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlat_of_blockwise` | file-local; intermediate-hypothesis form |
 | `SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlat_of_groupedBlockCastAgrees` | file-local; intermediate-hypothesis form |
-| `SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlatAt_of_groupedBlockCastAgrees` | file-local; intermediate-hypothesis form |
 
-Privatization-deferred (kept public; only docstring updates):
+PGVWC07 stack — planned `private` (Step 5.2), then restored to public:
+
+| File | Declaration | Original Step-5.2 plan | Final state |
+|---|---|---|---|
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_data_of_irreducible` | privatize (file-local) | **public** (blueprint entry restored in `sec:pgvwc07_intermediates`) |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_blockwise` | privatize (file-local) | **public** (blueprint entry restored) |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` | privatize (file-local) | **public** (blueprint entry restored) |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` | privatize (file-local) | **public** (blueprint entry restored) |
+| `NormalReduction/WeightNormalization.lean` | `PGVWC07PositiveLengthWitness.exists_weight_normalization` | privatize | **public** (blueprint entry restored) |
+| `NormalReduction/WeightNormalization.lean` | `PGVWC07PositiveLengthWitness.exists_weight_normalization_projective` | privatize | **public** (blueprint entry restored) |
+| `NormalReduction/WeightNormalization.lean` | `PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv` | privatize | **public** (blueprint entry restored) |
+| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv` | privatize | **public** (blueprint entry restored) |
+| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv` | privatize | **public** (blueprint entry restored) |
+| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero` | privatize | **public** (blueprint entry restored) |
+
+Always public (cross-file callees, never privatized):
 
 | File | Declaration | Reason for keeping public |
 |---|---|---|
-| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` | cross-file: called from `WeightNormalization.lean:477` |
-| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_positiveLengthWitness` | cross-file: called from `WeightNormalization.lean:244, 289` |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` | cross-file: called from `WeightNormalization.lean` |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_positiveLengthWitness` | cross-file: called from `WeightNormalization.lean` |
 | `NormalReduction/TPGauge.lean` | `PGVWC07PositiveLengthWitness` (structure) | cross-file: used as type in `WeightNormalization.lean` |
 | `SectorComparison/CyclicSectorDecomposition.lean` | `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` | blueprint tag `thm:cyclic_sector_decomp_irr_tp` survives Step 5.1; docstring expanded to note `_prim_irr` is the consumed variant |
 | `SectorComparison/CommonSectorTransport.lean` | `CommonSectorRelabelingHypothesis`, `CommonGroupedBlockCastHypothesis` | both blueprint-tagged; collapsing would touch >1 downstream file (audit S5.2.11 fallback). Module-head docstring now records that they are a thin compatibility layer over the unconditional `of_flattenWordOfBlock_cast_eq`. |
@@ -63,10 +80,10 @@ Privatization-deferred (kept public; only docstring updates):
 `exists_pgvwc07_positiveLengthWitness`, and the structure
 `PGVWC07PositiveLengthWitness` are used across the
 `TPGauge.lean` ↔ `WeightNormalization.lean` file split.  Lean 4 `private`
-is file-scoped, so privatizing them would break the build.  Following the
-orchestrator's Plan (B), they remain public; their disappearance from the
-`NormalReduction.lean` module-header docstring removes them from the
-externally-advertised API surface without breaking the call graph.
+is file-scoped, so privatizing them would break the build.  They remain
+public; the `NormalReduction.lean` module-header docstring is shortened
+to the headline plus a pointer to `sec:pgvwc07_intermediates` rather than
+enumerating every intermediate.
 
 ## 3. Declarations deleted
 
@@ -114,22 +131,25 @@ downstream consumer.
 
 ## 5. Blueprint cross-edits
 
+These blueprint edits land in the **companion PR #1992**, not in this PR.
+They are described here because the Lean-side privatizations and deletions
+in this PR motivated them.
+
 `blueprint/src/chapter/ch11b_after_blocking.tex`, theorem
 `thm:zero_tail_common_flat_of_blocked_word_comparison`:
 
 * The five-name `\lean{...}` block and the `\leanok` were removed (all
-  five Lean declarations are now `private` or deleted).
+  five Lean declarations are now `private` or deleted on this PR's HEAD).
 * The trailing sentence "The blockwise comparison, the word equality, and
   the coordinate-grouping condition are three ways to supply the same
   alphabet identification" was rewritten to a sentence pointing the reader
   to `thm:zero_tail_common_flat_of_reindexed` for the externally consumed
-  form.  The blueprint `\uses{...}` chain (lines 877 and 912 — consumers
-  in `thm:zero_tail_common_flat_transport_of_grouped_block_cast` and the
-  proof block above `thm:afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`)
-  was left intact: the theorem still exists as a mathematical waypoint,
-  it just no longer claims a Lean tag.
+  form.  The blueprint `\uses{...}` chain to consumers was left intact:
+  the theorem still exists as a mathematical waypoint, it just no longer
+  claims a Lean tag.
 
-No other `blueprint/src/chapter/` files were modified.
+No `blueprint/src/chapter/` files were modified by this PR; the edits
+above land in PR #1992.
 
 ## 6. Risky things deliberately not done
 

--- a/audits/canonical_lean_refactor_report.md
+++ b/audits/canonical_lean_refactor_report.md
@@ -72,7 +72,7 @@ Always public (cross-file callees, never privatized):
 | `NormalReduction/TPGauge.lean` | `exists_pgvwc07_positiveLengthWitness` | cross-file: called from `WeightNormalization.lean` |
 | `NormalReduction/TPGauge.lean` | `PGVWC07PositiveLengthWitness` (structure) | cross-file: used as type in `WeightNormalization.lean` |
 | `SectorComparison/CyclicSectorDecomposition.lean` | `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` | blueprint tag `thm:cyclic_sector_decomp_irr_tp` survives Step 5.1; docstring expanded to note `_prim_irr` is the consumed variant |
-| `SectorComparison/CommonSectorTransport.lean` | `CommonSectorRelabelingHypothesis`, `CommonGroupedBlockCastHypothesis` | both blueprint-tagged; collapsing would touch >1 downstream file (audit S5.2.11 fallback). Module-head docstring now records that they are a thin compatibility layer over the unconditional `of_flattenWordOfBlock_cast_eq`. |
+| `SectorComparison/CommonSectorTransport.lean` | `CommonSectorRelabelingHypothesis`, `CommonGroupedBlockCastHypothesis` | both blueprint-tagged; collapsing would touch >1 downstream file (audit S5.2.11 fallback). Module-head docstring now records that they are equivalent reformulations connected by the unconditional `of_flattenWordOfBlock_cast_eq`. |
 
 ### Privatization rationale: cross-file PGVWC07 callees
 

--- a/audits/canonical_lean_refactor_report.md
+++ b/audits/canonical_lean_refactor_report.md
@@ -159,16 +159,24 @@ above land in PR #1992.
 The orchestrator's follow-up explicitly called out three risk classes; I
 honored them.
 
-* **Cross-file PGVWC07 privatization was declined.** Three declarations
-  (`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`,
-  `exists_pgvwc07_positiveLengthWitness`, `PGVWC07PositiveLengthWitness`)
-  are called across the `TPGauge.lean` / `WeightNormalization.lean` file
-  split.  Plan (C) — folding `WeightNormalization.lean` into `TPGauge.lean`
-  — would push the combined file to ≈1 350 LOC; this is within the
-  orchestrator's 1 500 cap but the merge would touch the
-  `exists_weight_normalization` proofs (≈250 LOC of weight-rescaling
-  algebra), which is more invasive than this refactor was meant to be.
-  I left it for a follow-up.
+* **Cross-file PGVWC07 privatization was declined.** Two declarations —
+  `exists_pgvwc07_positiveLengthWitness` and the
+  `PGVWC07PositiveLengthWitness` structure — are called across the
+  `TPGauge.lean` / `WeightNormalization.lean` file split.  Lean 4 `private`
+  is file-scoped, so privatizing them would break the build.  A third
+  declaration, `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`,
+  has only same-file callers on PR HEAD (its previous cross-file caller, the
+  now-deleted `_after_rescaling_with_zeroTail`, was removed in §3), but the
+  declaration carries the blueprint tag
+  `thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound` at
+  `ch08_canonical.tex:1742`, and a `private` declaration cannot be referenced
+  from a `\lean{...}` tag.  All three remain public.
+
+  Plan (C) — folding `WeightNormalization.lean` into `TPGauge.lean` — would
+  push the combined file to ≈1 350 LOC; this is within the orchestrator's
+  1 500 cap but the merge would touch the `exists_weight_normalization`
+  proofs (≈250 LOC of weight-rescaling algebra), which is more invasive
+  than this refactor was meant to be.  Left for a follow-up.
 
 * **`exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` was not
   privatized.**  The blueprint tag `thm:cyclic_sector_decomp_irr_tp`

--- a/audits/canonical_lean_refactor_report.md
+++ b/audits/canonical_lean_refactor_report.md
@@ -99,6 +99,11 @@ the definition site + module docstring lines.
 | `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail` | grep: def site + `NormalReduction.lean` docstring only |
 | `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero` | grep: def site + `NormalReduction.lean` docstring + an unused intra-file comment line (cleaned up) |
 | `NormalReduction/TPGauge.lean` | `PGVWC07PositiveLengthWitness.weight_ne_zero` | grep: def site only |
+| `Existence.lean` | `exists_blockTensor_isPrimitive` | thin `NeZero`-wrapper; grep: def site only |
+| `Existence.lean` | `exists_blockTensor_leftCanonical_isPrimitive` | thin `NeZero`-wrapper; grep: def site only |
+| `SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlat_of_word_eq` | grep: def site only after privatization of the `_of_blockwise` / `_of_groupedBlockCastAgrees` siblings |
+| `SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlatAt_of_groupedBlockCastAgrees` | grep: def site only; flagged in review of commit `e7172034` and deleted in `135fbb5f` |
+| `SectorComparison/CommonSectorTransport.lean` | `sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees` | grep: def site only |
 | `SectorComparison/CommonSectorData.lean` | `afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂` | grep: def site + an intra-file companion-comment reference (cleaned up) |
 | `SectorComparison/CommonSectorData.lean` | `afterBlocking_commonLengthCommonSectorData_of_reindexed` | grep: def site + module docstring bullet (cleaned up) |
 | `SectorComparison/StructuralData.lean` | `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂` | grep: def site + module docstring bullet (cleaned up) |
@@ -110,27 +115,31 @@ removed from `CommonSectorData.lean` line 340.
 
 ## 4. Plumbing trims applied (S5.4)
 
+The LOC numbers below were obtained with `wc -l` on the file's state
+upstream of `origin/main` and on PR HEAD (after the docstring corrections
+in commits `2ebaa2df`, `57356c18`, `12669658`, `ddcdbcd0`).
+
 | File | Before LOC | After LOC | Delta | Trim description |
 |---|---|---|---|---|
-| `NormalReduction/TPGauge.lean` | 935 | 918 | −17 | Deleted `PGVWC07PositiveLengthWitness.weight_ne_zero` (a 6-line theorem that was already a one-line `obtain ⟨a, ha_pos, h⟩ := W.weight_pos k; …`); no remaining callers. |
-| `NormalReduction/WeightNormalization.lean` | 598 | 432 | −166 | Deleted two dead theorems (`_after_rescaling_with_zeroTail`, `_projective_form_or_forall_pos_mpv_eq_zero`) plus tidied the docstring on `_or_forall_pos_mpv_eq_zero` private theorem. |
-| `Existence.lean` | 630 | 595 | −35 | After privatization, both `exists_blockTensor_isPrimitive` and `exists_blockTensor_leftCanonical_isPrimitive` had no remaining external callers (and only the latter consumed the former).  Both are thin `NeZero`-wrappers around `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`.  Deleted both. |
-| `SectorComparison/CommonSectorTransport.lean` | 679 | 642 | −37 | After privatizing the five `_of_blockwise / _of_word_eq / _of_groupedBlockCastAgrees` variants, two of them (`zeroTail_commonFlat_of_word_eq` and `sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees`) had no remaining intra-file callers.  Deleted both. |
-| `SectorComparison/CommonSectorData.lean` | 634 | 366 | −268 | Combined effect of the two S5.3 deletions in this file (the dead `WithZeroTail_of_sameMPV₂` and `commonLengthCommonSectorData_of_reindexed` theorems with their docstrings). |
-| `SectorComparison/StructuralData.lean` | 228 | 176 | −52 | S5.3 deletion of `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`. |
-| `NormalReduction.lean` | 46 | 46 | ±0 | Module docstring rewritten (LOC unchanged): the bullet list is reorganized into a 3-bullet headline summary plus a 13-bullet "Source-faithful PGVWC07 intermediate steps" subsection (the latter restored after the PGVWC07 reorganization recorded in `pgvwc07_restoration_report.md`). |
+| `NormalReduction.lean` | 46 | 78 | +32 | Module docstring expanded after the PGVWC07 reorganization recorded in `pgvwc07_restoration_report.md`: a 3-bullet headline summary plus a 13-bullet "Source-faithful PGVWC07 intermediate steps" subsection. |
+| `NormalReduction/TPGauge.lean` | 935 | 931 | −4 | Deleted `PGVWC07PositiveLengthWitness.weight_ne_zero` (a short theorem inlinable at its single use site); docstring expanded to enumerate the source-faithful PGVWC07 chain. |
+| `NormalReduction/WeightNormalization.lean` | 598 | 451 | −147 | Deleted two dead theorems (`_after_rescaling_with_zeroTail`, `_projective_form_or_forall_pos_mpv_eq_zero`) and tightened the intro docstring to match the surviving six declarations. |
+| `Existence.lean` | 630 | 590 | −40 | Both `exists_blockTensor_isPrimitive` and `exists_blockTensor_leftCanonical_isPrimitive` had no remaining external callers (and only the latter consumed the former).  Both are thin `NeZero`-wrappers around `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`.  Deleted both, plus the orphaned `## (4) Periodicity removal by blocking` section header. |
+| `SectorComparison/CommonSectorTransport.lean` | 679 | 624 | −55 | Privatized two intermediate-hypothesis lemmas (`zeroTail_commonFlat_of_blockwise`, `zeroTail_commonFlat_of_groupedBlockCastAgrees`); deleted three orphans (`zeroTail_commonFlat_of_word_eq`, `zeroTail_commonFlatAt_of_groupedBlockCastAgrees`, `sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees`). |
+| `SectorComparison/CommonSectorData.lean` | 634 | 366 | −268 | Combined effect of the two §3 deletions in this file (`afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂` and `afterBlocking_commonLengthCommonSectorData_of_reindexed`, both with their docstrings). |
+| `SectorComparison/StructuralData.lean` | 228 | 176 | −52 | §3 deletion of `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`. |
 
 Aggregate canonical-form LOC delta:
 
 ```
-Baseline   (canonical-form files listed above): 4386
-After      (canonical-form files listed above): 3817
-Delta:                                          −569 LOC (−13%)
+Baseline   (canonical-form files listed above): 3750
+After      (canonical-form files listed above): 3216
+Delta:                                          −534 LOC (−14%)
 ```
 
 The single biggest reduction is in `CommonSectorData.lean` (−268 LOC),
-driven by removal of the two giant existential statements that had no
-downstream consumer.
+driven by removal of the two large existential statements that had no
+downstream caller.
 
 ## 5. Blueprint cross-edits
 

--- a/audits/canonical_lean_refactor_report.md
+++ b/audits/canonical_lean_refactor_report.md
@@ -1,0 +1,221 @@
+# Canonical-form Lean refactor — Step 5.2 + 5.3 + 5.4 report
+
+Scope: `TNLean/MPS/CanonicalForm/` and `blueprint/src/chapter/ch11b_after_blocking.tex`.
+
+## 1. Build times
+
+Cached-warm baseline `lake build` (full project, before refactor):
+incremental rebuild on clean tree ≈ 4 s; cold uncached time not measured
+(local cache served).  Cold uncached time was not available at the start of
+the session because the workspace was already cached.
+
+Post-refactor checkpoint after privatization + deletions (incremental from
+the cache):
+
+```
+lake build  # full project — exit 0, 8728 jobs replayed/built
+```
+
+The two intermediate build checkpoints during the refactor took 45–55 s
+wall-clock (driven by the changed files' downstream rebuilds in
+`SectorComparison/`, `BNTGrouping`, and `PhaseClassSectorData`).
+After the final trim the full `lake build` completed cleanly (exit 0;
+sorries warnings preserved from `MPS/Periodic/Overlap/Case*.lean`, which
+are out of scope here).
+
+## 2. Declarations privatized
+
+All call-graph verifications were done with
+`grep -rln 'DeclName' TNLean --include='*.lean'` and confirmed the only
+hits were either the definition file itself or module-summary docstrings
+(no real call sites).  Lean `private` is file-scoped: I only privatized
+declarations whose call sites all live in the same `.lean` file.
+
+| File | Declaration | Reason |
+|---|---|---|
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_data_of_irreducible` | file-local; intermediate PGVWC07 step |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_blockwise` | file-local; intermediate PGVWC07 step |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` | file-local; intermediate PGVWC07 step |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` | file-local; intermediate PGVWC07 step |
+| `NormalReduction/WeightNormalization.lean` | `PGVWC07PositiveLengthWitness.exists_weight_normalization` | file-local; weight-normalization chain |
+| `NormalReduction/WeightNormalization.lean` | `PGVWC07PositiveLengthWitness.exists_weight_normalization_projective` | file-local |
+| `NormalReduction/WeightNormalization.lean` | `PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv` | file-local |
+| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv` | file-local |
+| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv` | file-local |
+| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero` | file-local |
+| `SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlat_of_blockwise` | file-local; intermediate-hypothesis form |
+| `SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlat_of_groupedBlockCastAgrees` | file-local; intermediate-hypothesis form |
+| `SectorComparison/CommonSectorTransport.lean` | `zeroTail_commonFlatAt_of_groupedBlockCastAgrees` | file-local; intermediate-hypothesis form |
+
+Privatization-deferred (kept public; only docstring updates):
+
+| File | Declaration | Reason for keeping public |
+|---|---|---|
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` | cross-file: called from `WeightNormalization.lean:477` |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_positiveLengthWitness` | cross-file: called from `WeightNormalization.lean:244, 289` |
+| `NormalReduction/TPGauge.lean` | `PGVWC07PositiveLengthWitness` (structure) | cross-file: used as type in `WeightNormalization.lean` |
+| `SectorComparison/CyclicSectorDecomposition.lean` | `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` | blueprint tag `thm:cyclic_sector_decomp_irr_tp` survives Step 5.1; docstring expanded to note `_prim_irr` is the consumed variant |
+| `SectorComparison/CommonSectorTransport.lean` | `CommonSectorRelabelingHypothesis`, `CommonGroupedBlockCastHypothesis` | both blueprint-tagged; collapsing would touch >1 downstream file (audit S5.2.11 fallback). Module-head docstring now records that they are a thin compatibility layer over the unconditional `of_flattenWordOfBlock_cast_eq`. |
+
+### Privatization rationale: cross-file PGVWC07 callees
+
+`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`,
+`exists_pgvwc07_positiveLengthWitness`, and the structure
+`PGVWC07PositiveLengthWitness` are used across the
+`TPGauge.lean` ↔ `WeightNormalization.lean` file split.  Lean 4 `private`
+is file-scoped, so privatizing them would break the build.  Following the
+orchestrator's Plan (B), they remain public; their disappearance from the
+`NormalReduction.lean` module-header docstring removes them from the
+externally-advertised API surface without breaking the call graph.
+
+## 3. Declarations deleted
+
+Each deletion was preceded by
+`grep -rn 'DeclName' TNLean blueprint/src` and verified to return only
+the definition site + module docstring lines.
+
+| File | Declaration | Verification |
+|---|---|---|
+| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail` | grep: def site + `NormalReduction.lean` docstring only |
+| `NormalReduction/WeightNormalization.lean` | `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero` | grep: def site + `NormalReduction.lean` docstring + an unused intra-file comment line (cleaned up) |
+| `NormalReduction/TPGauge.lean` | `PGVWC07PositiveLengthWitness.weight_ne_zero` | grep: def site only |
+| `SectorComparison/CommonSectorData.lean` | `afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂` | grep: def site + an intra-file companion-comment reference (cleaned up) |
+| `SectorComparison/CommonSectorData.lean` | `afterBlocking_commonLengthCommonSectorData_of_reindexed` | grep: def site + module docstring bullet (cleaned up) |
+| `SectorComparison/StructuralData.lean` | `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂` | grep: def site + module docstring bullet (cleaned up) |
+
+Note: the audit recipe noted (for deletion #4) that the candidate
+`afterBlocking_commonLengthCommonSectorData_of_reindexed` is in
+`CommonSectorData.lean`, not `CommonSectorTransport.lean`.  Confirmed and
+removed from `CommonSectorData.lean` line 340.
+
+## 4. Plumbing trims applied (S5.4)
+
+| File | Before LOC | After LOC | Delta | Trim description |
+|---|---|---|---|---|
+| `NormalReduction/TPGauge.lean` | 935 | 918 | −17 | Deleted `PGVWC07PositiveLengthWitness.weight_ne_zero` (a 6-line theorem that was already a one-line `obtain ⟨a, ha_pos, h⟩ := W.weight_pos k; …`); no remaining callers. |
+| `NormalReduction/WeightNormalization.lean` | 598 | 432 | −166 | Deleted two dead theorems (`_after_rescaling_with_zeroTail`, `_projective_form_or_forall_pos_mpv_eq_zero`) plus tidied the docstring on `_or_forall_pos_mpv_eq_zero` private theorem. |
+| `Existence.lean` | 630 | 595 | −35 | After privatization, both `exists_blockTensor_isPrimitive` and `exists_blockTensor_leftCanonical_isPrimitive` had no remaining external callers (and only the latter consumed the former).  Both are thin `NeZero`-wrappers around `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`.  Deleted both. |
+| `SectorComparison/CommonSectorTransport.lean` | 679 | 642 | −37 | After privatizing the five `_of_blockwise / _of_word_eq / _of_groupedBlockCastAgrees` variants, two of them (`zeroTail_commonFlat_of_word_eq` and `sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees`) had no remaining intra-file callers.  Deleted both. |
+| `SectorComparison/CommonSectorData.lean` | 634 | 366 | −268 | Combined effect of the two S5.3 deletions in this file (the dead `WithZeroTail_of_sameMPV₂` and `commonLengthCommonSectorData_of_reindexed` theorems with their docstrings). |
+| `SectorComparison/StructuralData.lean` | 228 | 176 | −52 | S5.3 deletion of `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`. |
+| `NormalReduction.lean` | 46 | 46 | ±0 | Module docstring rewritten (LOC unchanged, but reduced from a 17-bullet list to a 4-bullet headline list). |
+
+Aggregate canonical-form LOC delta:
+
+```
+Baseline   (canonical-form files listed above): 4386
+After      (canonical-form files listed above): 3817
+Delta:                                          −569 LOC (−13%)
+```
+
+The single biggest reduction is in `CommonSectorData.lean` (−268 LOC),
+driven by removal of the two giant existential statements that had no
+downstream consumer.
+
+## 5. Blueprint cross-edits
+
+`blueprint/src/chapter/ch11b_after_blocking.tex`, theorem
+`thm:zero_tail_common_flat_of_blocked_word_comparison`:
+
+* The five-name `\lean{...}` block and the `\leanok` were removed (all
+  five Lean declarations are now `private` or deleted).
+* The trailing sentence "The blockwise comparison, the word equality, and
+  the coordinate-grouping condition are three ways to supply the same
+  alphabet identification" was rewritten to a sentence pointing the reader
+  to `thm:zero_tail_common_flat_of_reindexed` for the externally consumed
+  form.  The blueprint `\uses{...}` chain (lines 877 and 912 — consumers
+  in `thm:zero_tail_common_flat_transport_of_grouped_block_cast` and the
+  proof block above `thm:afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`)
+  was left intact: the theorem still exists as a mathematical waypoint,
+  it just no longer claims a Lean tag.
+
+No other `blueprint/src/chapter/` files were modified.
+
+## 6. Risky things deliberately not done
+
+The orchestrator's follow-up explicitly called out three risk classes; I
+honored them.
+
+* **Cross-file PGVWC07 privatization was declined.** Three declarations
+  (`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`,
+  `exists_pgvwc07_positiveLengthWitness`, `PGVWC07PositiveLengthWitness`)
+  are called across the `TPGauge.lean` / `WeightNormalization.lean` file
+  split.  Plan (C) — folding `WeightNormalization.lean` into `TPGauge.lean`
+  — would push the combined file to ≈1 350 LOC; this is within the
+  orchestrator's 1 500 cap but the merge would touch the
+  `exists_weight_normalization` proofs (≈250 LOC of weight-rescaling
+  algebra), which is more invasive than this refactor was meant to be.
+  I left it for a follow-up.
+
+* **`exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` was not
+  privatized.**  The blueprint tag `thm:cyclic_sector_decomp_irr_tp`
+  survived Step 5.1, so the audit's "fallback A" applies: leave public
+  and add a docstring sentence pointing at the consumed `_prim_irr`
+  variant.
+
+* **`CommonSectorRelabelingHypothesis` / `CommonGroupedBlockCastHypothesis`
+  collapse was deferred.**  Audit S5.2.11 says collapse only if it does
+  not touch more than one downstream file.  Both predicates are
+  blueprint-tagged (`thm:zero_tail_common_flat_transport_of_grouped_block_cast`
+  and the surrounding theorems consume the predicate forms).  Collapsing
+  would force matching changes in `CommonSectorData.lean` and in three
+  consumer theorems in the same file.  Added a head-of-section comment
+  in `CommonSectorTransport.lean` recording that the pair is a thin
+  compatibility layer and that `of_flattenWordOfBlock_cast_eq` already
+  proves the conversion unconditionally; left the two predicates alone
+  pending a separate refactor.
+
+* **No `noncomputable def` / `@[simp] rfl` → `abbrev` conversions
+  applied.**  I scanned the touched files for them; the only `noncomputable def`s
+  in `CanonicalForm/` (e.g. `gaugeMulVecLinearEquiv` in `TPGauge.lean`)
+  are not `rfl`-shaped (they bundle four `LinearEquiv` fields), so they
+  cannot become `abbrev`s.  No safe one-line collapses were found in the
+  files in scope.
+
+* **No collapse of `intro/refine/exact ⟨..., ..., ...⟩` proof patterns
+  attempted.**  The dependent-product proofs in `CommonSectorData.lean`
+  and `StructuralData.lean` use `refine ⟨…, ?_, ?_, …⟩` followed by
+  bullet sub-goals where each branch typically calls a named lemma; the
+  bullets are not all single-`simp`-closable, so the audit's S5.4
+  recommendation does not apply cleanly.  Leaving alone.
+
+* **Parallel "with weights / without weights" pair candidates.**  Two
+  parallel lemma pairs in `SectorComparison/CommonSectorTransport.lean`
+  look superficially like trivial-corollary pairs:
+  `zeroTail_commonFlat_of_reindexed`  vs. its `_commonFlatAt_of_reindexed`
+  companion, and `sameMPV₂Pos_blockTensor_commonFlatAt_of_reindexed`
+  vs. `zeroTail_commonFlat_transport_of_reindexed`.  All four are public
+  and blueprint-tagged (see `thm:zero_tail_common_flat_of_reindexed` and
+  `thm:zero_tail_common_flat_transport_of_reindexed`), so consolidation
+  is a blueprint-touching action and out of scope for this Lean-only
+  step.  Listed here per the user's S5.4 reporting requirement.
+
+## 7. Verification commands re-run after refactor
+
+For every declaration that was privatized or deleted I re-ran
+`grep -rn 'DeclName' TNLean blueprint/src` and confirmed no new caller
+appeared during the refactor.  For the surviving public declarations I
+verified the blueprint `\lean{...}` tags by extracting the tag list:
+
+```
+grep -roh '\\lean{[^}]*}' blueprint/src/chapter/ \
+  | sed 's/\\lean{//;s/}//' | tr ',' '\n' \
+  | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sort -u
+```
+
+PROTECTED list cross-checked against this output: every declaration
+required by the audit's "PROTECTED" set still has a public Lean
+counterpart with a matching blueprint tag.
+
+## 8. Final status
+
+* `lake build` exits 0 (8728 jobs).
+* No new sorries introduced.
+* Style-linter warnings unchanged (the pre-existing
+  `Spectral/GaugeConstruction.lean:669` long-line and the two `simp`
+  flexibility infos in `WeightNormalization.lean` lines 538–539 are
+  pre-existing and out of scope).
+* Pre-existing sorries in `MPS/Periodic/Overlap/` are untouched.
+* No file under `MPS/FundamentalTheorem/`, `MPS/BNT/`, `MPS/Periodic/`,
+  `MPS/ParentHamiltonian/`, or `Archive/` was modified.
+* `lakefile.toml` and `lean-toolchain` are unchanged.

--- a/audits/canonical_lean_refactor_report.md
+++ b/audits/canonical_lean_refactor_report.md
@@ -68,21 +68,24 @@ Always public (cross-file callees, never privatized):
 
 | File | Declaration | Reason for keeping public |
 |---|---|---|
-| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` | cross-file: called from `WeightNormalization.lean` |
-| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_positiveLengthWitness` | cross-file: called from `WeightNormalization.lean` |
-| `NormalReduction/TPGauge.lean` | `PGVWC07PositiveLengthWitness` (structure) | cross-file: used as type in `WeightNormalization.lean` |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` | carries blueprint tag `thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound` at `ch08_canonical.tex:1742`; called only from the same file (`TPGauge.lean:821`), but `private` would break the `\lean{...}` resolution |
+| `NormalReduction/TPGauge.lean` | `exists_pgvwc07_positiveLengthWitness` | cross-file: called from `WeightNormalization.lean`; also carries blueprint tag `thm:pgvwc07_positive_length_witness` |
+| `NormalReduction/TPGauge.lean` | `PGVWC07PositiveLengthWitness` (structure) | cross-file: used as type in `WeightNormalization.lean`; also carries blueprint tag `def:pgvwc07_positive_length_witness` |
 | `SectorComparison/CyclicSectorDecomposition.lean` | `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` | blueprint tag `thm:cyclic_sector_decomp_irr_tp` survives Step 5.1; docstring expanded to note `_prim_irr` is the consumed variant |
 | `SectorComparison/CommonSectorTransport.lean` | `CommonSectorRelabelingHypothesis`, `CommonGroupedBlockCastHypothesis` | both blueprint-tagged; collapsing would touch >1 downstream file (audit S5.2.11 fallback). Module-head docstring now records that they are equivalent reformulations connected by the unconditional `of_flattenWordOfBlock_cast_eq`. |
 
-### Privatization rationale: cross-file PGVWC07 callees
+### Rationale for keeping the public PGVWC07 declarations
 
-`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`,
-`exists_pgvwc07_positiveLengthWitness`, and the structure
+`exists_pgvwc07_positiveLengthWitness` and the structure
 `PGVWC07PositiveLengthWitness` are used across the
 `TPGauge.lean` ↔ `WeightNormalization.lean` file split.  Lean 4 `private`
-is file-scoped, so privatizing them would break the build.  They remain
-public; the `NormalReduction.lean` module-header docstring is shortened
-to the headline plus a pointer to `sec:pgvwc07_intermediates` rather than
+is file-scoped, so privatizing them would break the build.
+`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
+has only same-file callers, but it carries a blueprint `\lean{...}` tag in
+the restored `sec:pgvwc07_intermediates` section, and a `private` declaration
+cannot be referenced from the blueprint.  All three remain public; the
+`NormalReduction.lean` module-header docstring is shortened to the headline
+plus a pointer to `sec:pgvwc07_intermediates` rather than
 enumerating every intermediate.
 
 ## 3. Declarations deleted
@@ -115,7 +118,7 @@ removed from `CommonSectorData.lean` line 340.
 | `SectorComparison/CommonSectorTransport.lean` | 679 | 642 | −37 | After privatizing the five `_of_blockwise / _of_word_eq / _of_groupedBlockCastAgrees` variants, two of them (`zeroTail_commonFlat_of_word_eq` and `sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees`) had no remaining intra-file callers.  Deleted both. |
 | `SectorComparison/CommonSectorData.lean` | 634 | 366 | −268 | Combined effect of the two S5.3 deletions in this file (the dead `WithZeroTail_of_sameMPV₂` and `commonLengthCommonSectorData_of_reindexed` theorems with their docstrings). |
 | `SectorComparison/StructuralData.lean` | 228 | 176 | −52 | S5.3 deletion of `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`. |
-| `NormalReduction.lean` | 46 | 46 | ±0 | Module docstring rewritten (LOC unchanged, but reduced from a 17-bullet list to a 4-bullet headline list). |
+| `NormalReduction.lean` | 46 | 46 | ±0 | Module docstring rewritten (LOC unchanged): the bullet list is reorganized into a 3-bullet headline summary plus a 13-bullet "Source-faithful PGVWC07 intermediate steps" subsection (the latter restored after the PGVWC07 reorganization recorded in `pgvwc07_restoration_report.md`). |
 
 Aggregate canonical-form LOC delta:
 

--- a/audits/pgvwc07_restoration_report.md
+++ b/audits/pgvwc07_restoration_report.md
@@ -23,10 +23,10 @@ This report records a partial reversal of Step 5.1 (blueprint trim) and Step 5.2
 PGVWC07 entries listed in `audits/canonical_audit.md` §2 as INTERMEDIATE
 PLUMBING — recording the source proof structure of
 \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix} — have been restored to
-the blueprint, and their corresponding Lean declarations have been
-un-privatized. The four LEGACY DEAD BRANCH entries identified in the audit
-remain deleted from the blueprint, and the Lean code for those was already
-removed in Step 5.2 and stays removed.
+the blueprint (PR #1992), and their corresponding Lean declarations are
+un-privatized in companion PR #1993. The four LEGACY DEAD BRANCH entries
+identified in the audit remain deleted from the blueprint, and the Lean code
+for those is deleted in PR #1993.
 
 ## (a) Restored blueprint entries
 
@@ -94,9 +94,11 @@ The four LEGACY DEAD BRANCH labels classified in
 * `thm:pgvwc07_exact_rescaled_form_allow_empty` (duplicate of the headline
   `thm:pgvwc07_ti_canonical_form` — same Lean tag)
 * `thm:pgvwc07_exact_rescaled_form_with_zero_tail` (Lean decl deleted in
-  Step 5.2)
-* `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` (Lean decl deleted)
-* `lem:pgvwc07_positive_length_witness_weight_ne_zero` (Lean decl deleted)
+  companion PR #1993)
+* `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` (Lean decl deleted in
+  companion PR #1993)
+* `lem:pgvwc07_positive_length_witness_weight_ne_zero` (Lean decl deleted in
+  companion PR #1993)
 
 ## (b) `private` keywords removed
 

--- a/audits/pgvwc07_restoration_report.md
+++ b/audits/pgvwc07_restoration_report.md
@@ -1,0 +1,204 @@
+# PGVWC07 intermediate-step restoration report
+
+This report records a partial reversal of Step 5.1 (blueprint trim) and Step 5.2
+(Lean privatization) of the canonical-form refactor. The 13 intermediate
+PGVWC07 entries listed in `audits/canonical_audit.md` §2 as INTERMEDIATE
+PLUMBING — recording the source proof structure of
+\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix} — have been restored to
+the blueprint, and their corresponding Lean declarations have been
+un-privatized. The four LEGACY DEAD BRANCH entries identified in the audit
+remain deleted from the blueprint, and the Lean code for those was already
+removed in Step 5.2 and stays removed.
+
+## (a) Restored blueprint entries
+
+A new section
+`\section{Source-faithful PGVWC07 intermediate steps}\label{sec:pgvwc07_intermediates}`
+has been appended to `blueprint/src/chapter/ch08_canonical.tex`. It opens
+with an 8-line preface explaining that the 13 entries follow the source proof
+order and are not consumed by the canonical-form reduction used in the proof
+of the Fundamental Theorem. The 13 entries appear in the same order they had
+in the original (pre-Step-5.1) chapter:
+
+1. `thm:pgvwc07_irreducible_unital_dual_package`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible`)
+2. `thm:pgvwc07_blockwise_unital_dual_package`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise`)
+3. `thm:pgvwc07_arbitrary_zero_tail_unital_dual_package`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`)
+4. `thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`)
+5. `thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound`
+   (Lean: `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`)
+6. `def:pgvwc07_positive_length_witness`
+   (Lean: `MPSTensor.PGVWC07PositiveLengthWitness`)
+7. `thm:pgvwc07_positive_length_witness_weight_normalization`
+   (Lean: `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization`)
+8. `thm:pgvwc07_positive_length_witness_weight_normalization_projective`
+   (Lean: `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`)
+9. `lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv`
+   (Lean: `MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`)
+10. `thm:pgvwc07_nonzero_normalized_projective_form`
+    (Lean: `MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`)
+11. `thm:pgvwc07_nonzero_normalized_exact_rescaled_form`
+    (Lean: `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`)
+12. `thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy`
+    (Lean: `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`)
+13. `thm:pgvwc07_positive_length_witness`
+    (Lean: `MPSTensor.exists_pgvwc07_positiveLengthWitness`)
+
+### LaTeX title renames in the restored block
+
+In the original HEAD version, three of these entries used the banned word
+"package" (per `docs/prose_style.md` §2). Per the restoration task, the
+displayed titles have been renamed:
+
+* (entry 1) "Single irreducible-block PGVWC07 canonical-form theorem" — kept
+  as is (already source-faithful and free of banned terms).
+* (entry 2) "Blockwise PGVWC07 unital and dual-diagonal data" → "Blockwise
+  PGVWC07 unital and dual-diagonal block decomposition".
+* (entry 3) "Arbitrary-input PGVWC07 unital dual-diagonal form with zero
+  block" — kept as is (already neutral).
+
+The blueprint labels are unchanged. The Lean tags (the `\lean{...}` arguments)
+are unchanged: they remain `exists_pgvwc07_unital_dualDiag_*` and
+`PGVWC07PositiveLengthWitness*`.
+
+Inside the body of entry 2 the phrase "blockwise assembly of \cite[...]
+{PerezGarcia2007Matrix}" was replaced by "blockwise composition of \cite[...]
+{PerezGarcia2007Matrix}" to comply with the §2 ban on "assembly".
+
+### Legacy-dead entries kept removed
+
+The four LEGACY DEAD BRANCH labels classified in
+`audits/canonical_audit.md` §2 remain absent from the blueprint:
+
+* `thm:pgvwc07_exact_rescaled_form_allow_empty` (duplicate of the headline
+  `thm:pgvwc07_ti_canonical_form` — same Lean tag)
+* `thm:pgvwc07_exact_rescaled_form_with_zero_tail` (Lean decl deleted in
+  Step 5.2)
+* `thm:pgvwc07_projective_form_zero_nonzero_dichotomy` (Lean decl deleted)
+* `lem:pgvwc07_positive_length_witness_weight_ne_zero` (Lean decl deleted)
+
+## (b) `private` keywords removed
+
+The following 10 theorems had their `private` keyword removed:
+
+In `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`:
+
+* `exists_pgvwc07_unital_dualDiag_data_of_irreducible`
+* `exists_pgvwc07_unital_dualDiag_blockwise`
+* `exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`
+* `exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`
+
+In `TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`:
+
+* `PGVWC07PositiveLengthWitness.exists_weight_normalization`
+* `PGVWC07PositiveLengthWitness.exists_weight_normalization_projective`
+* `PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`
+* `exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv`
+* `exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`
+* `exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`
+
+The structure `MPSTensor.PGVWC07PositiveLengthWitness` was already public
+during Step 5.2 (because of cross-file usage between `TPGauge.lean` and
+`WeightNormalization.lean`); confirmed by
+`grep -n "structure PGVWC07PositiveLengthWitness" TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
+returning `73:structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where`
+with no `private` keyword. Likewise the existence theorem
+`exists_pgvwc07_positiveLengthWitness` and the bond-dim bound theorem
+`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
+in `TPGauge.lean` were already public prior to this restoration.
+
+The three remaining `private theorem` declarations in `TPGauge.lean`
+(`isIrreducibleAction_gaugeEquiv`, `isIrreducibleTensor_tpGauge_of_isIrreducibleTensor`,
+and `scalar_fixedPoints_unitaryConj`) are auxiliary gauge-transport lemmas with
+no blueprint entry and no external API role; they stay `private`. This matches
+the module docstring updates in `TPGauge.lean` and `WeightNormalization.lean`,
+and the bullet list in the top-level `TNLean/MPS/CanonicalForm/NormalReduction.lean`
+docstring, which now lists all 12 restored declarations + the headline
+`exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`.
+
+## (c) Final blueprint LOC for `ch08_canonical.tex`
+
+```
+$ wc -l blueprint/src/chapter/ch08_canonical.tex
+    1987 blueprint/src/chapter/ch08_canonical.tex
+```
+
+(Up from 1608 LOC before restoration; the appended section adds 379 lines.)
+
+## (d) Final `lake build` time
+
+```
+Build completed successfully (8728 jobs).
+
+real    0m57.914s
+user    0m44.064s
+sys     0m33.618s
+```
+
+`lake build` exit 0. The pre-existing `sorry`-warnings in
+`TNLean/MPS/Periodic/Overlap/*.lean` and the single long-line style warning
+in `TNLean/Spectral/GaugeConstruction.lean` are unrelated to this restoration
+and are unchanged.
+
+## (e) Confirmation that `leanblueprint web` ran cleanly
+
+```
+$ cd blueprint && rm -f src/print.aux print/print.aux && leanblueprint web 2>&1 | tail -10
+... (chapter list, no errors)
+exit=0
+```
+
+`grep -iE 'error|undef|missing' /tmp/blueprint.log | grep -ivE 'unrecognized command'`
+returns empty. The only warnings in the leanblueprint output are pre-existing
+plasTeX `unrecognized command/environment` notes for TikZ macros and "Using
+default renderer" messages for PEPS environments — both pre-date this
+restoration and are unaffected by it.
+
+## Verification command results
+
+Verification step 3 from the task:
+
+```
+$ grep -nE '\\label\{(thm|def|lem):pgvwc07' blueprint/src/chapter/ch08_canonical.tex
+32:    \label{thm:pgvwc07_ti_canonical_form}
+697:    \label{thm:pgvwc07_dual_diag_unital}
+1626:    \label{thm:pgvwc07_irreducible_unital_dual_package}
+1667:    \label{thm:pgvwc07_blockwise_unital_dual_package}
+1704:    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+1741:    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+1766:    \label{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+1800:    \label{def:pgvwc07_positive_length_witness}
+1817:    \label{thm:pgvwc07_positive_length_witness_weight_normalization}
+1847:    \label{thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+1877:    \label{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}
+1896:    \label{thm:pgvwc07_nonzero_normalized_projective_form}
+1923:    \label{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+1955:    \label{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
+1971:    \label{thm:pgvwc07_positive_length_witness}
+```
+
+This lists 15 labels rather than the 14 stated in the task's verification
+clause. The 13 restored labels + the kept headline `thm:pgvwc07_ti_canonical_form`
+account for 14; the 15th label `thm:pgvwc07_dual_diag_unital` is the
+"Dual diagonalization for irreducible unital blocks" theorem at line 697 of
+the trimmed chapter — it was kept in the post-Step-5.1 trim because it is a
+prerequisite of the restored `thm:pgvwc07_irreducible_unital_dual_package`
+(used in its proof). It is not in the restoration list and is not a
+LEGACY DEAD BRANCH entry, so it is correct to leave it in place. The task's
+"exactly 14" count appears to have overlooked this pre-existing entry.
+
+Verification step 4 from the task:
+
+```
+$ grep -nE '\\lean\{MPSTensor\.(exists_pgvwc07_|PGVWC07)' blueprint/src/chapter/ch08_canonical.tex | wc -l
+      14
+```
+
+Exactly 14, as expected: 13 restored entries each have one such `\lean{...}`
+tag, and the headline `thm:pgvwc07_ti_canonical_form` carries one more. The
+`thm:pgvwc07_dual_diag_unital` entry uses the Lean tag
+`MPSTensor.exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleTensor`,
+which is correctly excluded by this regex.

--- a/audits/pgvwc07_restoration_report.md
+++ b/audits/pgvwc07_restoration_report.md
@@ -1,5 +1,23 @@
 # PGVWC07 intermediate-step restoration report
 
+> **PR split note.** This report describes the *combined* restoration across
+> two stacked pull requests:
+>
+> * **PR #1992 (this PR, `cleanup/canonical-blueprint-trim`)** — restores the
+>   13 INTERMEDIATE PLUMBING entries to
+>   `blueprint/src/chapter/ch08_canonical.tex` in the new section
+>   `sec:pgvwc07_intermediates`. Section (a) below.
+> * **PR #1993 (companion, `cleanup/canonical-lean-trim`)** — un-privatizes
+>   the corresponding 10 Lean declarations whose blueprint entries are
+>   restored here. Section (b) below.
+>
+> All Lean declarations referenced by the restored blueprint entries are
+> *already public on `main`*, so PR #1992 stands alone:
+> `leanblueprint web` runs cleanly against `main`. The un-privatization
+> in PR #1993 only matters once the companion PR's privatization edits are
+> applied. Sections (b)–(e) below therefore describe state that exists on
+> the *stack of both PRs*, not on PR #1992 in isolation.
+
 This report records a partial reversal of Step 5.1 (blueprint trim) and Step 5.2
 (Lean privatization) of the canonical-form refactor. The 13 intermediate
 PGVWC07 entries listed in `audits/canonical_audit.md` §2 as INTERMEDIATE

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -115,7 +115,7 @@ obtained from primitive blocks).
     arbitrary translation-invariant MPS tensor becomes, after blocking by some
     period $p\ge 1$, the direct sum of an all-zero summand and a weighted
     family of normal tensors $\bigoplus_k \mu_k B_k$ with $|\mu_k|\le 1$ and
-    at least one $|\mu_k|=1$. The closest checked formalizations are
+    at least one $|\mu_k|=1$. The closest proved results in this chapter are
     Theorem~\ref{thm:tp_primitive_blockdecomp} and
     Theorem~\ref{thm:paperbnt_supplier_after_blocking}; neither yet supplies
     the source upper normalization $|\mu_k|\le 1$ with at least one

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -2,41 +2,31 @@
 \chapter{Canonical Form Reduction}\label{ch:canonical}
 
 This chapter records reductions of MPS tensors to block-diagonal canonical
-forms. We use the standard convention that the physical ring has positive
-length. With this convention the all-zero summand contributes no coefficient,
-and the translation-invariant canonical form of
-\cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix}
-is stated as an exact positive-length theorem, after the global scalar
-normalization made in the proof at
-\cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
-The complementary statement retaining the zero block records the
-length-zero bookkeeping but is not the primary theorem statement.
+forms, following~\cite{PerezGarcia2007Matrix}, \cite{Cirac2017MPDO_AnnPhys},
+\cite{Cirac2021Matrix}, and \cite[Chapter~6]{Wolf2012Quantum}. The unital
+orientation $\sum_i A_k^i(A_k^i)^\dagger=\Id$ is used by
+\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}; the trace-preserving
+(left-canonical) orientation $\sum_i (A_k^i)^\dagger A_k^i=\Id$ is used by
+the reductions of Chapter~\ref{ch:canonical_after_blocking}. The two
+orientations exchange under the conjugate-transposed Kraus family
+$K_i:=(A^i)^\dagger$, whose transfer map is the Frobenius adjoint of $\E_A$.
 
-Two further reduction schemes are used later in the chapter. The
-block-injective reduction aims at injective TP-normalized blocks and the
-canonical form conditions of Chapter~\ref{ch:block_perm}. The normal-canonical
-reduction uses a weighted family of irreducible TP-normalized blocks with
-primitive transfer maps and pairwise distinct nonzero weight moduli, in the
-sense of~\cite{Cirac2017MPDO_AnnPhys}. These later reductions are conditional
-primitive-block results and should not be confused with the arbitrary-input
-PGVWC07 theorem below.
+The PGVWC07 source theorem is recorded as a single headline statement
+(Theorem~\ref{thm:pgvwc07_ti_canonical_form}). The canonical-form reduction
+that feeds the proof of the Fundamental Theorem in Chapter~\ref{ch:ft_proof}
+does not pass through PGVWC07; it goes through
+Theorem~\ref{thm:tp_gauge_arbitrary},
+Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr}, and the
+after-blocking reductions of Chapter~\ref{ch:canonical_after_blocking}.
 
-The PGVWC07 blocks are written in the unital orientation
-$\sum_i A_k^i(A_k^i)^\dagger=\Id$ for
-$\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$
-\cite[Theorem~Th:TIcanonical, lines~754--758]{PerezGarcia2007Matrix},
-whereas some later reductions in this chapter use the trace-preserving, or
-left-canonical, orientation
-$\sum_i (A_k^i)^\dagger A_k^i=\Id$.
-Passing to the conjugate-transposed Kraus family $K_i := (A^i)^\dagger$
-exchanges the two orientations: the transfer map of $K$ is the Frobenius adjoint
-of $\E_A$.
-The Perron--Frobenius eigenvector existence and TP-gauge construction
-are in Chapter~\ref{ch:qpf}; this chapter uses them to produce
-left-canonical normalizations and decompositions satisfying the normal
-canonical form conditions.
-The reduction draws on~\cite{PerezGarcia2007Matrix}, \cite{Cirac2021Matrix},
-and~\cite[Chapter~6]{Wolf2012Quantum}.
+The reduction outputs of this chapter are:
+Theorem~\ref{thm:pgvwc07_ti_canonical_form} (the source-faithful PGVWC07
+translation-invariant canonical form);
+Theorem~\ref{thm:CFII_data} and
+Theorem~\ref{thm:cyclic_sector_decomp_irr_tp_prim_irr} (block-injective and
+primitive-irreducible TP-gauge reductions); and
+Theorem~\ref{thm:exists_normal_canonical_form} (the normal canonical form
+obtained from primitive blocks).
 
 \begin{theorem}[Translation-invariant canonical form]%
     \label{thm:pgvwc07_ti_canonical_form}
@@ -78,11 +68,8 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     of the decomposition is at most $D$.
 
     This is the positive-length form of
-    \cite[Theorem~Th:TIcanonical, lines~742--763]{PerezGarcia2007Matrix},
-    with the global spectral-radius normalization of lines~765--766 made
-    explicit. The zero-block convention for the empty word is recorded
-    separately in
-    Theorem~\ref{thm:pgvwc07_exact_rescaled_form_with_zero_tail}.
+    \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}, with the global
+    spectral-radius normalization of lines~765--766 made explicit.
 \end{theorem}
 
 \begin{remark}[Source proof order]\label{rem:pgvwc07_ti_canonical_source_order}
@@ -105,99 +92,35 @@ and~\cite[Chapter~6]{Wolf2012Quantum}.
     obtained from the source argument.
 \end{remark}
 
-\begin{theorem}[Blocked CPSV canonical-form reduction]%
-    \label{thm:cpgsv_canonical_form_source}
-    \notready
-    % Source anchors:
-    % Papers/1606.00608/MPDO-22-12-17-2.tex:227--231 removes periodic
-    % peripheral components by blocking; lines 233--235 define normal tensors;
-    % lines 237--246 are the definition containing the display labelled
-    % eq:II_CF1 at line 240 and the subsequent weight normalization at
-    % line 246; lines 249--251 state
-    % that any tensor becomes canonical after blocking. The phase-class
-    % quotient used by the BNT supplier is prop:char-BNT, labelled at line 278
-    % with statement at line 279, in the definition/proposition passage
-    % lines 271--279. It is restated, proved, and followed by the same-CF BNT
-    % uniqueness note in Appendix A at lines 1135--1148. The two-layer
-    % expansion is eq:II_ABasicTensors/decBSV at lines 283--301.
+\begin{remark}[CPSV blocked canonical form (source statement)]%
+    \label{rem:cpgsv_canonical_form_source}
+    % Source anchors (maintainer notes):
+    % Papers/1606.00608/MPDO-22-12-17-2.tex:227--231 removes periodic peripheral
+    % components by blocking; lines 233--235 define normal tensors;
+    % lines 237--246 contain the canonical-form definition with display
+    % eq:II_CF1 (line 240) and the weight normalization at line 246;
+    % lines 249--251 state that any tensor becomes canonical after blocking.
+    % The phase-class quotient used by the BNT supplier is prop:char-BNT
+    % (line 278, statement at line 279, passage lines 271--279), restated
+    % and proved in Appendix A at lines 1135--1148. The two-layer expansion
+    % is eq:II_ABasicTensors/decBSV at lines 283--301.
     % Papers/2011.12127/TN-Review-main.tex:1793--1803 gives the invariant-
-    % subspace reduction; lines 1815--1820 give period removal; lines 1827--1839
-    % give def:4:normal-tensor-mps and eq:II_CF1; lines 1846--1859 give the
-    % BNT definition/characterization; lines 1864--1884 give the two-layer
-    % BNT/copy display.
-    This is the canonical-form reduction of
-    \cite[Section~II.C, lines~217--246]{Cirac2017MPDO_AnnPhys}; see also
-    \cite[Section~IV.A, lines~1815--1837]{Cirac2021Matrix}. Every
-    translation-invariant MPS tensor $A$ is, after blocking by a period
-    $p \ge 1$, replaced by a tensor $B$ generating the same MPV family and
-    whose nonzero part is in canonical form. Thus, for each physical index $i$,
-    \[
-        B^i
-        =
-        \mathbf{0}_{d^{[p]},D_0}
-        \oplus
-        \bigoplus_{k=1}^{r} \mu_k B_k^i,
-    \]
-    where $\mathbf{0}_{d^{[p]},D_0}$ is the all-zero summand of physical
-    dimension $d^{[p]}$ and bond dimension $D_0$, and the tensors $B_k$ are
-    normal tensors. If $r>0$, the weights $\mu_k$ may be normalized so that
-    $|\mu_k|\le 1$ for all $k$ and $|\mu_k|=1$ for at least one index $k$.
-
-    In the source, the canonical-form construction is recorded in
-    \cite[display labelled eq:II\_Aiplusk1, lines~216--218,
-    followed by the spectral-radius normalization at lines~219--225]
-        {Cirac2017MPDO_AnnPhys}
-    and in
-    \cite[canonical-form definition containing eq:II\_CF1 and
-    subsequent weight normalization,
-    lines~237--246]{Cirac2017MPDO_AnnPhys}.
-    The basis-of-normal-tensors refinement is
-    \cite[BNT definition and proposition labelled prop:char-BNT,
-    lines~271--279]{Cirac2017MPDO_AnnPhys},
-    with its appendix restatement and proof in
-    \cite[Appendix proof of prop:char-BNT and same-CF uniqueness note,
-    lines~1135--1148]
-        {Cirac2017MPDO_AnnPhys},
-    and the two-layer display is
-    \cite[displays labelled eq:II\_ABasicTensors and decBSV,
-    lines~283--301]{Cirac2017MPDO_AnnPhys}.
-    The review exposition records the same normal-tensor and canonical-form
-    definitions at lines~1827--1837, the basis-of-normal-tensors definition and
-    characterization at lines~1846--1859, and the two-layer decomposition at
-    lines~1864--1884 of~\cite{Cirac2021Matrix}.
-\end{theorem}
-
-Theorem~\ref{thm:pgvwc07_ti_canonical_form} is the checked positive-length
-form of the PGVWC07 translation-invariant canonical-form theorem.
-Theorem~\ref{thm:cpgsv_canonical_form_source} remains a source-level target for the
-blocked CPSV reduction and is not yet formalized as stated. This chapter also
-develops constituent steps of the density-operator canonical-form reductions:
-invariant-subspace decomposition
-(Theorem~\ref{thm:irred_decomp}), TP gauge
-(Section~\ref{sec:tp_gauge_arbitrary}), and period-removal cyclic sectors
-(Section~\ref{sec:cyclic_sectors}). All-zero-block separation and the
-structural after-blocking primitive-block decomposition are recorded in
-Chapter~\ref{ch:canonical_after_blocking}
-(Theorem~\ref{thm:zero_block_separation} and
-Theorem~\ref{thm:tp_primitive_blockdecomp}). These checked statements do not
-yet supply the CPSV source normalization $|\mu_k|\le 1$ with at least one
-unit-modulus weight, so they should not be cited as
-Theorem~\ref{thm:cpgsv_canonical_form_source}.
-
-For Theorem~\ref{thm:pgvwc07_ti_canonical_form}, the source-ordered
-construction is the exact positive-length formulation of
-Theorem~\ref{thm:pgvwc07_exact_rescaled_form_allow_empty}: after a positive
-global rescaling of the original tensor, the normalized weighted block tensor
-has the same MPV coefficients on every nonempty ring.  The theorem permits an
-empty nonzero-block family precisely when all positive-length coefficients
-vanish, and otherwise retains a unit-modulus normalized weight together with
-the unital block condition, the scalar fixed-point conclusion, the diagonal
-positive-definite dual fixed point, and the bond-dimension bound.
-Theorem~\ref{thm:pgvwc07_exact_rescaled_form_with_zero_tail} records the
-companion explicit zero-block convention, where the zero block supplies the
-length-zero contribution \(D_0+\sum_k D_k=D\).  The projective MPV formulation
-records the same normalization as a proportionality of finite-ring state
-vectors, but it is not used as the primary existence theorem.
+    % subspace reduction; lines 1815--1820 give period removal; lines
+    % 1827--1839 give def:4:normal-tensor-mps and eq:II_CF1; lines
+    % 1846--1859 give the BNT definition/characterization; lines 1864--1884
+    % give the two-layer BNT/copy display.
+    The blocked canonical-form reduction of
+    \cite[Section~II.C, lines~217--246]{Cirac2017MPDO_AnnPhys} and
+    \cite[Section~IV.A, lines~1815--1837]{Cirac2021Matrix} states that an
+    arbitrary translation-invariant MPS tensor becomes, after blocking by some
+    period $p\ge 1$, the direct sum of an all-zero summand and a weighted
+    family of normal tensors $\bigoplus_k \mu_k B_k$ with $|\mu_k|\le 1$ and
+    at least one $|\mu_k|=1$. The closest checked formalizations are
+    Theorem~\ref{thm:tp_primitive_blockdecomp} and
+    Theorem~\ref{thm:paperbnt_supplier_after_blocking}; neither yet supplies
+    the source upper normalization $|\mu_k|\le 1$ with at least one
+    unit-modulus weight.
+\end{remark}
 
 \section{Normal tensors, canonical forms, and bases of normal tensors}\label{sec:cpsv_canonical_defs}
 
@@ -733,12 +656,12 @@ primitive, removing periodicity.
 \section{Steps toward canonical form existence}%
 \label{sec:canonical_construction_1606}
 
-This section combines the components of the canonical-form
-construction following~\cite[Section~2.3 and Appendix~A]{Cirac2017MPDO_AnnPhys}.
-The approach here requires blocking to remove non-trivial periodicity.
-A separate reduction for periodic blocks without blocking
-is developed in~\cite{DeLasCuevas2017Irreducible}; see
-Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
+The combination of Theorem~\ref{thm:CFII_data} with the Perron--Frobenius
+gauge of Chapter~\ref{ch:qpf} and the irreducible-block scalar-fixed-point
+statement Theorem~\ref{thm:irreducible_unital_scalar_fixed_point} yields the
+source PGVWC07 unital orientation and diagonal positive-definite dual fixed
+point on each irreducible block; the combination into the full PGVWC07
+statement is Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
 
 \begin{theorem}[Left-canonical normalization for irreducible TP blocks]%
     \label{thm:CFII_data}
@@ -799,220 +722,6 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     the displayed equations for $B$.
 \end{proof}
 
-\begin{theorem}[Single irreducible-block PGVWC07 canonical-form theorem]%
-    \label{thm:pgvwc07_irreducible_unital_dual_package}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible}
-    \leanok
-    \uses{def:irreducible_tensor}
-    Let $A$ be an irreducible nonzero MPS block with positive bond dimension.
-    Then the Perron--Frobenius eigenvector produces a positive scalar $r$ and a
-    positive definite matrix $\rho$ such that
-    \[
-        B^i := r^{-1/2}\rho^{-1/2} A^i\rho^{1/2}
-    \]
-    is unital.  In this unital gauge every fixed point of $\E_B$ is a scalar
-    multiple of the identity.  Moreover a unitary conjugate $C^i=U^\dagger
-    B^iU$ remains unital and has a diagonal positive definite dual fixed point
-    $\Lambda$:
-    \[
-        \sum_i C^i(C^i)^\dagger=\Id,
-        \qquad
-        \sum_i (C^i)^\dagger\Lambda C^i=\Lambda .
-    \]
-    The construction preserves the finite-ring coefficients up to the
-    spectral-radius weight carried by the rescaling from $A$ to $B$.
-
-    This composes the single-block canonical-form existence steps of
-    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
-        {PerezGarcia2007Matrix}.  It is not yet the full theorem, because the
-    recursive finite-ring block decomposition and the final bond-dimension
-    bound have not been threaded through this construction.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:unital_data_irreducible,
-        thm:irreducible_unital_scalar_fixed_point,
-        thm:pgvwc07_dual_diag_unital}
-    Theorem~\ref{thm:unital_data_irreducible} gives the unital gauge.
-    Gauge equivalence preserves irreducibility of the bond-space action, so
-    Theorem~\ref{thm:irreducible_unital_scalar_fixed_point} gives the scalar
-    fixed-point endpoint for the unital representative.  Then
-    Theorem~\ref{thm:pgvwc07_dual_diag_unital} gives the unitary
-    diagonalization of the dual fixed point.
-\end{proof}
-
-\begin{theorem}[Blockwise PGVWC07 unital and dual-diagonal data]%
-    \label{thm:pgvwc07_blockwise_unital_dual_package}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise}
-    \leanok
-    \uses{def:irreducible_tensor,
-        thm:pgvwc07_irreducible_unital_dual_package}
-    Let a tensor~$A$ be represented, in finite-ring MPV coefficients, by a
-    finite direct sum of nonzero irreducible blocks with unit weights.  Then
-    there is a weighted direct sum with the same MPV family such that every
-    block is in the unital orientation,
-    \[
-        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
-    \]
-    every fixed point of the block transfer map is a scalar multiple of the
-    identity, and each block has a diagonal positive definite dual fixed point
-    \[
-        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
-    \]
-    The weights are the positive spectral-radius weights produced by applying
-    the single-block Perron--Frobenius gauge to each summand.
-
-    This is a blockwise assembly of
-    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
-        {PerezGarcia2007Matrix} after the recursive splitting has already
-    produced the nonzero irreducible summands.  It is not yet the full source
-    theorem, because it does not start from an arbitrary representation and
-    does not prove the final total bond-dimension bound.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_irreducible_unital_dual_package}
-    Apply Theorem~\ref{thm:pgvwc07_irreducible_unital_dual_package} to each
-    nonzero irreducible block.  Gauge equivalence and the final unitary
-    conjugation preserve the block MPV coefficients up to the displayed
-    spectral-radius weights, and unitary conjugation transports the scalar
-    fixed-point property of the unital transfer map.
-\end{proof}
-
-\begin{theorem}[Arbitrary-input PGVWC07 unital dual-diagonal form with zero block]%
-    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail}
-    \leanok
-    \uses{thm:zero_block_separation,
-        thm:pgvwc07_blockwise_unital_dual_package}
-    Let \(A\) be an arbitrary translation-invariant MPS tensor.  Then there is
-    a zero block of bond dimension \(D_0\), a finite family of nonzero blocks
-    \(C_k\), and positive real weights \(\mu_k\), such that for every chain
-    length \(N\) and every word \(\sigma \in \{0,\ldots,d-1\}^N\),
-    \[
-        \operatorname{MPV}_A
-        =
-        \operatorname{MPV}_{0_{D_0}}
-        +
-        \operatorname{MPV}_{\oplus_k \mu_k C_k}.
-    \]
-    Each nonzero block is in the unital orientation,
-    \[
-        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
-    \]
-    every fixed point of its transfer map is a scalar multiple of the identity,
-    and it has a diagonal positive definite dual fixed point
-    \[
-        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
-    \]
-\end{theorem}
-
-% This theorem composes the zero-block separation with the blockwise PGVWC07
-% theorem.  The final total bond-dimension bound is still recorded as a
-% remaining step in the paper-gap audit.
-
-\begin{proof}\leanok
-    \uses{thm:zero_block_separation,
-        thm:pgvwc07_blockwise_unital_dual_package}
-    First apply the zero-block separation theorem to \(A\), retaining the
-    all-zero summands as a single zero block and extracting the nonzero
-    irreducible summands.  Then apply the blockwise PGVWC07 unital and
-    dual-diagonal theorem to this nonzero family.  Chaining the two MPV
-    identities gives the displayed zero-block formula.
-\end{proof}
-
-\begin{theorem}[Bond-dimension bound for the zero-block PGVWC07 form]%
-    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound}
-    \leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
-    In the decomposition of
-    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}, the
-    zero-block bond dimension and the nonzero block dimensions satisfy
-    \[
-        D_0+\sum_k D_k = D .
-    \]
-    In particular, the total bond dimension of the nonzero blocks is at most
-    the original bond dimension \(D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package,
-        lem:mpv_zero_length}
-    Evaluate the MPV identity of
-    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package} on the
-    empty word.  The length-zero coefficient of a bond-\(D\) tensor is \(D\);
-    the zero block contributes \(D_0\), and the direct sum of the nonzero
-    blocks contributes \(\sum_k D_k\).  This gives the displayed identity, and
-    the inequality follows because \(D_0\geq 0\).
-\end{proof}
-
-\begin{theorem}[Positive-length PGVWC07 unital dual-diagonal form]%
-    \label{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound}
-    \leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
-    For any MPS tensor \(A\) of bond dimension \(D\), there are nonzero blocks
-    \(C_k\) and positive real weights \(\mu_k\) such that each block is in the
-    unital orientation,
-    \[
-        \sum_i C_k^i(C_k^i)^\dagger=\Id,
-    \]
-    has only scalar fixed points for its transfer map, and has a diagonal
-    positive-definite fixed point for the dual transfer map,
-    \[
-        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
-    \]
-    Moreover, for
-    every chain length \(N>0\) and word
-    \(\sigma\in\{0,\ldots,d-1\}^N\),
-    \[
-        \operatorname{MPV}_A(\sigma)
-        =
-        \operatorname{MPV}_{\bigoplus_k \mu_k C_k}(\sigma),
-    \]
-    and the nonzero block dimensions satisfy \(\sum_k D_k\leq D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
-    Apply Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}.
-    The all-zero summand contributes zero to every positive-length coefficient,
-    so it may be omitted from the displayed MPV identity for \(N>0\).  The
-    bound \(\sum_k D_k\leq D\) is one of the conclusions of that theorem.
-\end{proof}
-
-\begin{definition}[Positive-length PGVWC07 canonical-form witness]%
-    \label{def:pgvwc07_positive_length_witness}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness}
-    \leanok
-    A positive-length PGVWC07 canonical-form witness for an MPS tensor \(A\)
-    consists of a finite family of nonzero unital blocks, positive real
-    weights, diagonal positive-definite dual fixed points, scalar fixed-point
-    conclusions, positive block dimensions, positive-length MPV equality with
-    \(A\), and the total bond-dimension bound \(\sum_k D_k\leq D\).
-
-    This definition records the exact-MPV, nonempty-ring part of the PGVWC07
-    construction.  It still does not include the source theorem's upper
-    normalization \(1\geq\lambda_k\), which depends on the global
-    spectral-radius normalization convention of
-    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
-\end{definition}
-
-\begin{lemma}[Positive PGVWC07 witness weights are nonzero]%
-    \label{lem:pgvwc07_positive_length_witness_weight_ne_zero}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness}
-    In a positive-length PGVWC07 canonical-form witness, every block weight is
-    nonzero.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{def:pgvwc07_positive_length_witness}
-    Each weight is the complex embedding of a strictly positive real number.
-\end{proof}
-
 \begin{lemma}[Common scalar rescaling of block weights]%
     \label{lem:mpv_to_tensor_from_blocks_weight_mul_left}
     \lean{MPSTensor.mpv_toTensorFromBlocks_weight_mul_left}
@@ -1025,258 +734,6 @@ Chapter~\ref{ch:periodic_ft_apps} for that direct periodic extension.
     \uses{thm:mpv_decomposition}
     Expand the block-diagonal MPV coefficient as a finite sum over blocks and
     factor the common scalar power out of the sum.
-\end{proof}
-
-\begin{theorem}[Weight normalization for a nonempty PGVWC07 witness]%
-    \label{thm:pgvwc07_positive_length_witness_weight_normalization}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness}
-    Let a positive-length PGVWC07 canonical-form witness have at least one
-    nonzero block.  Then its positive real weights may be divided by their
-    largest value so that the new weights \(\nu_k\) are positive,
-    \(|\nu_k|\leq 1\) for all \(k\), and \(|\nu_{k_0}|=1\) for at least one
-    block \(k_0\).  If the original weights are \(\mu_k=s\nu_k\) with
-    \(s>0\), then for every chain length \(N>0\),
-    \[
-        \operatorname{MPV}_A(\sigma)
-        =
-        s^N
-        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
-    \]
-    This is the formal scalar normalization corresponding to
-    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix};
-    the displayed factor records the global length-dependent rescaling.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        lem:mpv_to_tensor_from_blocks_weight_mul_left}
-    Choose the largest positive real weight \(s\).  Dividing every weight by
-    \(s\) gives positive weights bounded above by \(1\), and a block attaining
-    the maximum has normalized weight \(1\).  The MPV identity follows from
-    Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left}.
-\end{proof}
-
-\begin{theorem}[Projective form of PGVWC07 weight normalization]%
-    \label{thm:pgvwc07_positive_length_witness_weight_normalization_projective}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        def:nonzero_proportional_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization}
-    Let a positive-length PGVWC07 canonical-form witness have at least one
-    block.  After dividing the positive real weights by their largest value,
-    the normalized weights $\nu_k$ are positive real numbers, satisfy
-    $|\nu_k|\leq 1$ for all $k$, and satisfy $|\nu_{k_0}|=1$ for some block
-    $k_0$.  Moreover the original tensor and the normalized
-    weighted block tensor generate nonzero proportional MPV families:
-    for every length $N$ there is a nonzero scalar $c_N$ such that
-    \[
-        \operatorname{MPV}_A(\sigma)
-        =
-        c_N\,
-        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
-    \]
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_positive_length_witness_weight_normalization,
-        lem:mpv_zero_length}
-    For $N>0$, take $c_N=s^N$, which is nonzero because $s>0$.  For
-    $N=0$, use the length-zero MPV coefficient and the positive total
-    dimension of the nonzero blocks to choose the nonzero scalar relating the
-    two traces.
-\end{proof}
-
-\begin{lemma}[Nonzero positive-length coefficient gives a nonempty PGVWC07 witness]%
-    \label{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}
-    \lean{MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        thm:mpv_decomposition}
-    Let a positive-length PGVWC07 canonical-form witness for $A$ be given.
-    If some positive-length MPV coefficient of $A$ is nonzero, then the
-    witness has at least one block.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        thm:mpv_decomposition}
-    If the block family were empty, the block-diagonal MPV expansion would be
-    an empty sum at every positive length.  The positive-length MPV equality in
-    the witness would then force all positive-length coefficients of $A$ to
-    vanish, contradicting the hypothesis.
-\end{proof}
-
-\begin{theorem}[Nonzero projective PGVWC07 normalized form]%
-    \label{thm:pgvwc07_nonzero_normalized_projective_form}
-    \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv}
-    \leanok
-    \uses{thm:pgvwc07_positive_length_witness,
-        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
-    Suppose that some positive-length MPV coefficient of an MPS tensor $A$ is
-    nonzero.  Then $A$ has a nonempty finite family of nonzero PGVWC07 blocks
-    $C_k$ with positive normalized weights $\nu_k$ satisfying
-    $|\nu_k|\leq 1$ for all $k$ and $|\nu_{k_0}|=1$ for some block $k_0$.
-    Each block is in the unital orientation, has only scalar fixed points for
-    its transfer map, and has a diagonal positive-definite fixed point
-    $\Lambda_k$ for the dual transfer map.  Moreover the original tensor and
-    the normalized weighted block tensor generate nonzero proportional MPV
-    families, and the block dimensions satisfy $\sum_k D_k\leq D$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_positive_length_witness,
-        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
-    First use Theorem~\ref{thm:pgvwc07_positive_length_witness}.  The nonzero
-    positive-length coefficient makes the witness nonempty by
-    Lemma~\ref{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}.
-    Apply the projective weight-normalization theorem to this nonempty witness.
-\end{proof}
-
-\begin{theorem}[Exact normalized PGVWC07 form after global rescaling]%
-    \label{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
-    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv}
-    \leanok
-    \uses{thm:pgvwc07_positive_length_witness,
-        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization}
-    Suppose that some positive-length MPV coefficient of an MPS tensor \(A\) is
-    nonzero.  Then there is a positive scalar \(s\) and a nonempty finite family
-    of PGVWC07 blocks \(C_k\) with positive normalized weights \(\nu_k\)
-    satisfying \(|\nu_k|\leq 1\) for all \(k\) and
-    \(|\nu_{k_0}|=1\) for some block \(k_0\).  Each block is in the unital
-    orientation, has only scalar fixed points for its transfer map, and has a
-    diagonal positive-definite fixed point for the dual transfer map.  Each
-    block has positive bond dimension.  Moreover the globally rescaled tensor
-    \(s^{-1}A\) and the normalized weighted block tensor have the same
-    positive-length MPV coefficients, and the block dimensions satisfy
-    \(\sum_k D_k\leq D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_positive_length_witness,
-        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
-        thm:pgvwc07_positive_length_witness_weight_normalization,
-        lem:mpv_smul}
-    Start from the positive-length witness and use the nonzero coefficient to
-    make the block family nonempty.  Divide the positive weights by their
-    maximum.  The exact coefficient identity for \(A\) contains the global
-    factor \(s^N\) at length \(N\); applying the scalar rescaling \(s^{-1}\) to
-    every matrix of \(A\) contributes the factor \(s^{-N}\), so the two factors
-    cancel at every positive length.
-\end{proof}
-
-\begin{theorem}[Zero/nonzero dichotomy for exact rescaled PGVWC07 form]%
-    \label{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
-    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero}
-    \leanok
-    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
-    For every MPS tensor \(A\), either every positive-length MPV coefficient of
-    \(A\) is zero, or the exact rescaled normalized PGVWC07 form of
-    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form} exists.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
-    If some positive-length coefficient is nonzero, apply
-    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}.  Otherwise,
-    every positive-length coefficient is zero.
-\end{proof}
-
-\begin{theorem}[Exact PGVWC07 form with empty zero branch]%
-    \label{thm:pgvwc07_exact_rescaled_form_allow_empty}
-    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty}
-    \leanok
-    \uses{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
-    For every MPS tensor \(A\), there is a positive scalar \(s\) and a finite
-    family of PGVWC07 blocks \(C_k\), possibly empty, with positive normalized
-    weights \(\nu_k\) satisfying \(|\nu_k|\leq 1\). If the family is nonempty,
-    then \(|\nu_{k_0}|=1\) for some block \(k_0\). Each block is in the unital
-    orientation, has only scalar fixed points for its transfer map, and has a
-    diagonal positive-definite fixed point for the dual transfer map. Moreover
-    the globally rescaled tensor \(s^{-1}A\) and the normalized weighted block
-    tensor have the same positive-length MPV coefficients, and the block
-    dimensions satisfy \(\sum_k D_k\leq D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
-    Apply the zero/nonzero dichotomy. In the nonzero branch, use the nonempty
-    normalized exact form. In the zero branch, take the empty nonzero-block
-    family; its block-diagonal MPV coefficient is the empty sum at every
-    positive length, which agrees with the zero positive-length coefficients of
-    \(A\). The unit-weight conclusion is stated conditionally on the family
-    being nonempty.
-\end{proof}
-
-\begin{theorem}[Exact PGVWC07 form with explicit zero block]%
-    \label{thm:pgvwc07_exact_rescaled_form_with_zero_tail}
-    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail}
-    \leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound,
-        thm:pgvwc07_positive_length_witness_weight_normalization}
-    For every MPS tensor \(A\), there is a positive scalar \(s\), a zero-block
-    dimension \(D_0\), and a finite family of PGVWC07 blocks \(C_k\), possibly
-    empty, with positive normalized weights \(\nu_k\) satisfying
-    \(|\nu_k|\leq 1\). If the family is nonempty, then
-    \(|\nu_{k_0}|=1\) for some block \(k_0\). Each nonzero block is in the
-    unital orientation, has only scalar fixed points for its transfer map, and
-    has a diagonal positive-definite fixed point for the dual transfer map.
-    For every block \(k\), the bond dimension \(D_k\) is positive. Moreover
-    the globally rescaled tensor \(s^{-1}A\) has exactly the MPV family given
-    by the zero block plus the normalized weighted block tensor at every ring
-    length. The bond dimensions satisfy \(D_0+\sum_k D_k=D\), and in particular
-    \(\sum_kD_k\leq D\).
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound,
-        thm:pgvwc07_positive_length_witness_weight_normalization}
-    Start from the arbitrary-input theorem with the zero block retained.  If
-    the nonzero-block family is empty, take \(s=1\).  Otherwise normalize the
-    positive weights by their maximum.  On nonempty rings the zero block has
-    zero coefficient, so the normalized positive-length identity applies; at
-    length zero the equality is exactly \(D_0+\sum_kD_k=D\).
-\end{proof}
-
-\begin{theorem}[Zero/nonzero dichotomy for projective PGVWC07 form]%
-    \label{thm:pgvwc07_projective_form_zero_nonzero_dichotomy}
-    \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero}
-    \leanok
-    \uses{thm:pgvwc07_nonzero_normalized_projective_form}
-    For every MPS tensor $A$, either every positive-length MPV coefficient of
-    $A$ is zero, or $A$ has the nonempty normalized projective PGVWC07 form of
-    Theorem~\ref{thm:pgvwc07_nonzero_normalized_projective_form}.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:pgvwc07_nonzero_normalized_projective_form}
-    If some positive-length coefficient is nonzero, apply
-    Theorem~\ref{thm:pgvwc07_nonzero_normalized_projective_form}.  Otherwise,
-    every positive-length coefficient is zero.
-\end{proof}
-
-\begin{theorem}[Existence of the positive-length PGVWC07 witness]%
-    \label{thm:pgvwc07_positive_length_witness}
-    \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}
-    \leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    For every MPS tensor \(A\), the conclusions of
-    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    give a positive-length PGVWC07 canonical-form witness.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:pgvwc07_positive_length_witness,
-        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    Unpack
-    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    and use its conclusions as the fields of the witness.
 \end{proof}
 
 \begin{theorem}[Irreducible block decomposition with left-canonical normalization]%
@@ -2149,3 +1606,382 @@ Chapter~\ref{ch:periodic_ft_apps}.
     where $\sigma'$ is the image of $\sigma$ under the coordinate-grouping
     identification.
 \end{lemma}
+
+\section{Source-faithful PGVWC07 intermediate steps}\label{sec:pgvwc07_intermediates}
+
+The theorems below record the intermediate construction steps of the proof of
+\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}. They follow the source
+proof order: single-block unital and dual-diagonal data; blockwise composition;
+arbitrary-input form with the explicit zero summand; the length-zero dimension
+identity; the positive-length form; the bundled positive-length witness; weight
+normalization; the nonzero-coefficient existence theorem; and the dichotomy
+that yields the headline statement
+Theorem~\ref{thm:pgvwc07_ti_canonical_form}. They are not consumed by the
+canonical-form reduction used in the proof of the Fundamental Theorem (which
+goes through Theorem~\ref{thm:tp_gauge_arbitrary} and the after-blocking
+statements of Chapter~\ref{ch:canonical_after_blocking}); they record the
+source structure for completeness.
+
+\begin{theorem}[Single irreducible-block PGVWC07 canonical-form theorem]%
+    \label{thm:pgvwc07_irreducible_unital_dual_package}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_data_of_irreducible}
+    \leanok
+    \uses{def:irreducible_tensor}
+    Let $A$ be an irreducible nonzero MPS block with positive bond dimension.
+    Then the Perron--Frobenius eigenvector produces a positive scalar $r$ and a
+    positive definite matrix $\rho$ such that
+    \[
+        B^i := r^{-1/2}\rho^{-1/2} A^i\rho^{1/2}
+    \]
+    is unital.  In this unital gauge every fixed point of $\E_B$ is a scalar
+    multiple of the identity.  Moreover a unitary conjugate $C^i=U^\dagger
+    B^iU$ remains unital and has a diagonal positive definite dual fixed point
+    $\Lambda$:
+    \[
+        \sum_i C^i(C^i)^\dagger=\Id,
+        \qquad
+        \sum_i (C^i)^\dagger\Lambda C^i=\Lambda .
+    \]
+    The construction preserves the finite-ring coefficients up to the
+    spectral-radius weight carried by the rescaling from $A$ to $B$.
+
+    This composes the single-block canonical-form existence steps of
+    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
+        {PerezGarcia2007Matrix}.  It is not yet the full theorem, because the
+    recursive finite-ring block decomposition and the final bond-dimension
+    bound have not been threaded through this construction.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:unital_data_irreducible,
+        thm:irreducible_unital_scalar_fixed_point,
+        thm:pgvwc07_dual_diag_unital}
+    Theorem~\ref{thm:unital_data_irreducible} gives the unital gauge.
+    Gauge equivalence preserves irreducibility of the bond-space action, so
+    Theorem~\ref{thm:irreducible_unital_scalar_fixed_point} gives the scalar
+    fixed-point endpoint for the unital representative.  Then
+    Theorem~\ref{thm:pgvwc07_dual_diag_unital} gives the unitary
+    diagonalization of the dual fixed point.
+\end{proof}
+
+\begin{theorem}[Blockwise PGVWC07 unital and dual-diagonal block decomposition]%
+    \label{thm:pgvwc07_blockwise_unital_dual_package}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise}
+    \leanok
+    \uses{def:irreducible_tensor,
+        thm:pgvwc07_irreducible_unital_dual_package}
+    Let a tensor~$A$ be represented, in finite-ring MPV coefficients, by a
+    finite direct sum of nonzero irreducible blocks with unit weights.  Then
+    there is a weighted direct sum with the same MPV family such that every
+    block is in the unital orientation,
+    \[
+        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
+    \]
+    every fixed point of the block transfer map is a scalar multiple of the
+    identity, and each block has a diagonal positive definite dual fixed point
+    \[
+        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
+    \]
+    The weights are the positive spectral-radius weights produced by applying
+    the single-block Perron--Frobenius gauge to each summand.
+
+    This is the blockwise composition of
+    \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
+        {PerezGarcia2007Matrix} after the recursive splitting has already
+    produced the nonzero irreducible summands.  It is not yet the full source
+    theorem, because it does not start from an arbitrary representation and
+    does not prove the final total bond-dimension bound.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_irreducible_unital_dual_package}
+    Apply Theorem~\ref{thm:pgvwc07_irreducible_unital_dual_package} to each
+    nonzero irreducible block.  Gauge equivalence and the final unitary
+    conjugation preserve the block MPV coefficients up to the displayed
+    spectral-radius weights, and unitary conjugation transports the scalar
+    fixed-point property of the unital transfer map.
+\end{proof}
+
+\begin{theorem}[Arbitrary-input PGVWC07 unital dual-diagonal form with zero block]%
+    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail}
+    \leanok
+    \uses{thm:zero_block_separation,
+        thm:pgvwc07_blockwise_unital_dual_package}
+    Let \(A\) be an arbitrary translation-invariant MPS tensor.  Then there is
+    a zero block of bond dimension \(D_0\), a finite family of nonzero blocks
+    \(C_k\), and positive real weights \(\mu_k\), such that for every chain
+    length \(N\) and every word \(\sigma \in \{0,\ldots,d-1\}^N\),
+    \[
+        \operatorname{MPV}_A
+        =
+        \operatorname{MPV}_{0_{D_0}}
+        +
+        \operatorname{MPV}_{\oplus_k \mu_k C_k}.
+    \]
+    Each nonzero block is in the unital orientation,
+    \[
+        \sum_i C_k^i(C_k^i)^\dagger=\Id ,
+    \]
+    every fixed point of its transfer map is a scalar multiple of the identity,
+    and it has a diagonal positive definite dual fixed point
+    \[
+        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:zero_block_separation,
+        thm:pgvwc07_blockwise_unital_dual_package}
+    First apply the zero-block separation theorem to \(A\), retaining the
+    all-zero summands as a single zero block and extracting the nonzero
+    irreducible summands.  Then apply the blockwise PGVWC07 unital and
+    dual-diagonal theorem to this nonzero family.  Chaining the two MPV
+    identities gives the displayed zero-block formula.
+\end{proof}
+
+\begin{theorem}[Bond-dimension bound for the zero-block PGVWC07 form]%
+    \label{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound}
+    \leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}
+    In the decomposition of
+    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package}, the
+    zero-block bond dimension and the nonzero block dimensions satisfy
+    \[
+        D_0+\sum_k D_k = D .
+    \]
+    In particular, the total bond dimension of the nonzero blocks is at most
+    the original bond dimension \(D\).
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package,
+        lem:mpv_zero_length}
+    Evaluate the MPV identity of
+    Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package} on the
+    empty word.  The length-zero coefficient of a bond-\(D\) tensor is \(D\);
+    the zero block contributes \(D_0\), and the direct sum of the nonzero
+    blocks contributes \(\sum_k D_k\).  This gives the displayed identity, and
+    the inequality follows because \(D_0\geq 0\).
+\end{proof}
+
+\begin{theorem}[Positive-length PGVWC07 unital dual-diagonal form]%
+    \label{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound}
+    \leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+    For any MPS tensor \(A\) of bond dimension \(D\), there are nonzero blocks
+    \(C_k\) and positive real weights \(\mu_k\) such that each block is in the
+    unital orientation,
+    \[
+        \sum_i C_k^i(C_k^i)^\dagger=\Id,
+    \]
+    has only scalar fixed points for its transfer map, and has a diagonal
+    positive-definite fixed point for the dual transfer map,
+    \[
+        \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
+    \]
+    Moreover, for
+    every chain length \(N>0\) and word
+    \(\sigma\in\{0,\ldots,d-1\}^N\),
+    \[
+        \operatorname{MPV}_A(\sigma)
+        =
+        \operatorname{MPV}_{\bigoplus_k \mu_k C_k}(\sigma),
+    \]
+    and the nonzero block dimensions satisfy \(\sum_k D_k\leq D\).
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
+    Apply Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}.
+    The all-zero summand contributes zero to every positive-length coefficient,
+    so it may be omitted from the displayed MPV identity for \(N>0\).  The
+    bound \(\sum_k D_k\leq D\) is one of the conclusions of that theorem.
+\end{proof}
+
+\begin{definition}[Positive-length PGVWC07 canonical-form witness]%
+    \label{def:pgvwc07_positive_length_witness}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness}
+    \leanok
+    A positive-length PGVWC07 canonical-form witness for an MPS tensor \(A\)
+    consists of a finite family of nonzero unital blocks, positive real
+    weights, diagonal positive-definite dual fixed points, scalar fixed-point
+    conclusions, positive block dimensions, positive-length MPV equality with
+    \(A\), and the total bond-dimension bound \(\sum_k D_k\leq D\).
+
+    This definition records the exact-MPV, nonempty-ring part of the PGVWC07
+    construction.  It still does not include the source theorem's upper
+    normalization \(1\geq\lambda_k\), which depends on the global
+    spectral-radius normalization convention of
+    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
+\end{definition}
+
+\begin{theorem}[Weight normalization for a nonempty PGVWC07 witness]%
+    \label{thm:pgvwc07_positive_length_witness_weight_normalization}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness}
+    Let a positive-length PGVWC07 canonical-form witness have at least one
+    nonzero block.  Then its positive real weights may be divided by their
+    largest value so that the new weights \(\nu_k\) are positive,
+    \(|\nu_k|\leq 1\) for all \(k\), and \(|\nu_{k_0}|=1\) for at least one
+    block \(k_0\).  If the original weights are \(\mu_k=s\nu_k\) with
+    \(s>0\), then for every chain length \(N>0\),
+    \[
+        \operatorname{MPV}_A(\sigma)
+        =
+        s^N
+        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
+    \]
+    This is the formal scalar normalization corresponding to
+    \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix};
+    the displayed factor records the global length-dependent rescaling.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        lem:mpv_to_tensor_from_blocks_weight_mul_left}
+    Choose the largest positive real weight \(s\).  Dividing every weight by
+    \(s\) gives positive weights bounded above by \(1\), and a block attaining
+    the maximum has normalized weight \(1\).  The MPV identity follows from
+    Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left}.
+\end{proof}
+
+\begin{theorem}[Projective form of PGVWC07 weight normalization]%
+    \label{thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        def:nonzero_proportional_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization}
+    Let a positive-length PGVWC07 canonical-form witness have at least one
+    block.  After dividing the positive real weights by their largest value,
+    the normalized weights $\nu_k$ are positive real numbers, satisfy
+    $|\nu_k|\leq 1$ for all $k$, and satisfy $|\nu_{k_0}|=1$ for some block
+    $k_0$.  Moreover the original tensor and the normalized
+    weighted block tensor generate nonzero proportional MPV families:
+    for every length $N$ there is a nonzero scalar $c_N$ such that
+    \[
+        \operatorname{MPV}_A(\sigma)
+        =
+        c_N\,
+        \operatorname{MPV}_{\bigoplus_k \nu_k C_k}(\sigma).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_positive_length_witness_weight_normalization,
+        lem:mpv_zero_length}
+    For $N>0$, take $c_N=s^N$, which is nonzero because $s>0$.  For
+    $N=0$, use the length-zero MPV coefficient and the positive total
+    dimension of the nonzero blocks to choose the nonzero scalar relating the
+    two traces.
+\end{proof}
+
+\begin{lemma}[Nonzero positive-length coefficient gives a nonempty PGVWC07 witness]%
+    \label{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}
+    \lean{MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:mpv_decomposition}
+    Let a positive-length PGVWC07 canonical-form witness for $A$ be given.
+    If some positive-length MPV coefficient of $A$ is nonzero, then the
+    witness has at least one block.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:mpv_decomposition}
+    If the block family were empty, the block-diagonal MPV expansion would be
+    an empty sum at every positive length.  The positive-length MPV equality in
+    the witness would then force all positive-length coefficients of $A$ to
+    vanish, contradicting the hypothesis.
+\end{proof}
+
+\begin{theorem}[Nonzero projective PGVWC07 normalized form]%
+    \label{thm:pgvwc07_nonzero_normalized_projective_form}
+    \lean{MPSTensor.exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv}
+    \leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+    Suppose that some positive-length MPV coefficient of an MPS tensor $A$ is
+    nonzero.  Then $A$ has a nonempty finite family of nonzero PGVWC07 blocks
+    $C_k$ with positive normalized weights $\nu_k$ satisfying
+    $|\nu_k|\leq 1$ for all $k$ and $|\nu_{k_0}|=1$ for some block $k_0$.
+    Each block is in the unital orientation, has only scalar fixed points for
+    its transfer map, and has a diagonal positive-definite fixed point
+    $\Lambda_k$ for the dual transfer map.  Moreover the original tensor and
+    the normalized weighted block tensor generate nonzero proportional MPV
+    families, and the block dimensions satisfy $\sum_k D_k\leq D$.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization_projective}
+    First use Theorem~\ref{thm:pgvwc07_positive_length_witness}.  The nonzero
+    positive-length coefficient makes the witness nonempty by
+    Lemma~\ref{lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv}.
+    Apply the projective weight-normalization theorem to this nonempty witness.
+\end{proof}
+
+\begin{theorem}[Exact normalized PGVWC07 form after global rescaling]%
+    \label{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv}
+    \leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization}
+    Suppose that some positive-length MPV coefficient of an MPS tensor \(A\) is
+    nonzero.  Then there is a positive scalar \(s\) and a nonempty finite family
+    of PGVWC07 blocks \(C_k\) with positive normalized weights \(\nu_k\)
+    satisfying \(|\nu_k|\leq 1\) for all \(k\) and
+    \(|\nu_{k_0}|=1\) for some block \(k_0\).  Each block is in the unital
+    orientation, has only scalar fixed points for its transfer map, and has a
+    diagonal positive-definite fixed point for the dual transfer map.  Each
+    block has positive bond dimension.  Moreover the globally rescaled tensor
+    \(s^{-1}A\) and the normalized weighted block tensor have the same
+    positive-length MPV coefficients, and the block dimensions satisfy
+    \(\sum_k D_k\leq D\).
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_positive_length_witness,
+        lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
+        thm:pgvwc07_positive_length_witness_weight_normalization,
+        lem:mpv_smul}
+    Start from the positive-length witness and use the nonzero coefficient to
+    make the block family nonempty.  Divide the positive weights by their
+    maximum.  The exact coefficient identity for \(A\) contains the global
+    factor \(s^N\) at length \(N\); applying the scalar rescaling \(s^{-1}\) to
+    every matrix of \(A\) contributes the factor \(s^{-N}\), so the two factors
+    cancel at every positive length.
+\end{proof}
+
+\begin{theorem}[Zero/nonzero dichotomy for exact rescaled PGVWC07 form]%
+    \label{thm:pgvwc07_exact_rescaled_form_zero_nonzero_dichotomy}
+    \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero}
+    \leanok
+    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+    For every MPS tensor \(A\), either every positive-length MPV coefficient of
+    \(A\) is zero, or the exact rescaled normalized PGVWC07 form of
+    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form} exists.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
+    If some positive-length coefficient is nonzero, apply
+    Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}.  Otherwise,
+    every positive-length coefficient is zero.
+\end{proof}
+
+\begin{theorem}[Existence of the positive-length PGVWC07 witness]%
+    \label{thm:pgvwc07_positive_length_witness}
+    \lean{MPSTensor.exists_pgvwc07_positiveLengthWitness}
+    \leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    For every MPS tensor \(A\), the conclusions of
+    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    give a positive-length PGVWC07 canonical-form witness.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:pgvwc07_positive_length_witness,
+        thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    Unpack
+    Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
+    and use its conclusions as the fields of the witness.
+\end{proof}
+

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -882,7 +882,6 @@ itself comes from the peripheral spectrum of the adjoint transfer map~\cite[Theo
 \begin{theorem}[Period removal by blocking]%
     \label{thm:cyclic_sector_decomp_after_blocking}
     \lean{MPSTensor.exists_cyclic_sector_decomp_after_blocking}
-    \leanok
     \uses{def:blocked_tensor}
     Let $A$ be a left-canonical irreducible tensor of period $m$.
     Then the blocked tensor $A^{[m]}$ admits:
@@ -903,7 +902,16 @@ itself comes from the peripheral spectrum of the adjoint transfer map~\cite[Theo
     (\cite[Theorem~6.6]{Wolf2012Quantum}).
 \end{theorem}
 
-\begin{proof}\leanok
+% Faithfulness note: the Lean theorem
+% MPSTensor.exists_cyclic_sector_decomp_after_blocking takes the
+% positive-definite adjoint fixed point, the primitive m-th root of unity
+% parametrizing the peripheral eigenvalues, and the map-level irreducibility
+% as explicit hypotheses, whereas the blueprint statement above quantifies
+% only over the period. The hypotheses are derivable from the period-m
+% hypothesis and left-canonical irreducibility via the upstream Wielandt and
+% quantum Perron-Frobenius statements; the consumed packaging is the next
+% theorem, thm:cyclic_sector_decomp_irr_tp, which carries the \leanok.
+\begin{proof}
     The cyclic decomposition of the adjoint transfer map gives projections
     $(P_k)$ with $\E_{A^\dagger}(P_{k+1}) = P_k$. Iterating the cyclic relation $m$
     times shows $(\E_{A^\dagger})^m(P_k) = P_k$, and the blocked-transfer identity
@@ -1611,16 +1619,16 @@ Chapter~\ref{ch:periodic_ft_apps}.
 
 The theorems below record the intermediate construction steps of the proof of
 \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}. They follow the source
-proof order: single-block unital and dual-diagonal data; blockwise composition;
-arbitrary-input form with the explicit zero summand; the length-zero dimension
-identity; the positive-length form; the bundled positive-length witness; weight
-normalization; the nonzero-coefficient existence theorem; and the dichotomy
-that yields the headline statement
-Theorem~\ref{thm:pgvwc07_ti_canonical_form}. They are not consumed by the
-canonical-form reduction used in the proof of the Fundamental Theorem (which
-goes through Theorem~\ref{thm:tp_gauge_arbitrary} and the after-blocking
-statements of Chapter~\ref{ch:canonical_after_blocking}); they record the
-source structure for completeness.
+proof order: single-block unital and dual-diagonal construction; blockwise
+composition; arbitrary-input form with the explicit zero summand; the
+length-zero dimension identity; the positive-length form; the bundled
+positive-length witness; weight normalization; the nonzero-coefficient
+existence theorem; and the dichotomy that yields the headline statement
+Theorem~\ref{thm:pgvwc07_ti_canonical_form}. They are not used by the
+canonical-form reduction in the proof of the Fundamental Theorem (which goes
+through Theorem~\ref{thm:tp_gauge_arbitrary} and the after-blocking statements
+of Chapter~\ref{ch:canonical_after_blocking}); they record the source
+structure for completeness.
 
 \begin{theorem}[Single irreducible-block PGVWC07 canonical-form theorem]%
     \label{thm:pgvwc07_irreducible_unital_dual_package}

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -1,21 +1,16 @@
 
 \chapter{Block Permutation and Separation}\label{ch:block_perm}
 
-This chapter develops the algebra of block permutations, the product-algebra maps
-built from per-block same-MPV hypotheses, the invariant-projection splitting step that
-reduces a tensor to smaller blocks, and the block-separation argument that
-recovers the individual blocks from a block-diagonal same-MPV hypothesis.
-The block-separation results in this chapter are conditional same-structure
-lemmas: they assume blockwise normalization and separation hypotheses, including
-strict ordering of the weight moduli when required below. They should not be read
-as a formalization of the translation-invariant canonical-form uniqueness theorem
-of~\cite[Theorem~thm-uniq, lines~1002--1015]{PerezGarcia2007Matrix},
-which requires injectivity at some finite blocking length, uniqueness of the
-OBC canonical representation, and a finite-size lower bound. The source theorem
-is stated in the cited passage of Pérez-García, Verstraete, Wolf, and Cirac;
-the project-level scope distinction is
-recorded in the accompanying paper-gap note.\footnote{%
-    \texttt{docs/paper-gaps/pgvwc07\_ti\_uniqueness\_scope.tex}.}
+% Project-level scope distinction recorded in
+% docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex; the same-structure
+% lemmas below are not the PGVWC07 uniqueness theorem
+% (\cite[Theorem~thm-uniq, lines~1002--1015]{PerezGarcia2007Matrix}).
+This chapter records three reduction outputs: the algebra-automorphism
+decomposition Theorem~\ref{thm:pi_auto_decomp}; the per-block linear-extension
+product automorphism Theorem~\ref{thm:pi_linear_ext}; and the strict-weight
+block separation Lemmas~\ref{lem:block_sep} and~\ref{lem:block_sep_normal},
+together with the canonical-form gauge comparison
+Lemma~\ref{lem:ft_canonical}.
 
 \section{Block permutation algebra}
 

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -673,7 +673,11 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     provided by Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}.
 \end{theorem}
 
-\begin{proof}\leanok
+% Proof intentionally not marked \leanok here: the three equivalent
+% Lean-internal hypothesis forms are file-local (private) and the externally
+% consumed form is the next theorem, thm:zero_tail_common_flat_of_reindexed,
+% which carries the \lean{...} tag and the \leanok status.
+\begin{proof}
     \uses{thm:zero_tail_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_blocked_word_comparison,
         def:same_mpv2_pos}

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -665,18 +665,20 @@ a single tensor $\mathbf{0}_{d,D_0}$.
         V^{(N)}\!\bigl(\textstyle\bigoplus_x
         \widetilde\mu_x C_x\bigr)_\tau.
     \]
-    The formalization records this conclusion internally under three equivalent
-    hypothesis forms (blockwise comparison, blocked-word equality, and
-    coordinate-grouping cast equality); the externally consumed form is
-    Theorem~\ref{thm:zero_tail_common_flat_of_reindexed}, whose hypothesis is
-    the blocked-tensor same-MPV relation (Definition~\ref{def:same_mpv2})
-    provided by Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}.
+    The conclusion above is proved under any of three equivalent hypothesis
+    forms — blockwise comparison, blocked-word equality, and coordinate-grouping
+    cast equality — and the same conclusion under the compact same-MPV
+    hypothesis is recorded as Theorem~\ref{thm:zero_tail_common_flat_of_reindexed}
+    below, whose hypothesis is the blocked-tensor same-MPV relation
+    (Definition~\ref{def:same_mpv2}) provided by
+    Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}.
 \end{theorem}
 
 % Proof intentionally not marked \leanok here: the three equivalent
-% Lean-internal hypothesis forms are file-local (private) and the externally
-% consumed form is the next theorem, thm:zero_tail_common_flat_of_reindexed,
-% which carries the \lean{...} tag and the \leanok status.
+% hypothesis forms above are kept as file-local auxiliary lemmas, while the
+% same conclusion under the compact same-MPV hypothesis (the next theorem,
+% thm:zero_tail_common_flat_of_reindexed) carries the \lean{...} tag and the
+% \leanok status.
 \begin{proof}
     \uses{thm:zero_tail_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_blocked_word_comparison,

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -1,17 +1,13 @@
 \chapter{Canonical-form reductions after blocking}\label{ch:canonical_after_blocking}
 
-This chapter records the structural decomposition of an arbitrary MPS tensor
-after blocking by a period $p$, and the joint after-blocking decomposition of
-two tensors with the same MPV family. Each side is written as the direct sum of
-an all-zero tensor $\mathbf{0}_{d,D_0}$ and a weighted direct sum of
-left-canonical, primitive, irreducible blocks over a common physical alphabet;
-these decompositions are the input to the equal-MPV comparison of
-Chapter~\ref{ch:ft_proof}. Thus this chapter is placed immediately before the
-proof of the Fundamental Theorem: it records the reductions needed to put the
-two tensors on the common blocked surface used in the comparison argument.
-It is therefore not part of the later channel-representation, symmetry, or
-semigroup material; those chapters no longer provide hypotheses for the
-Fundamental-Theorem comparison.
+\section{Scope}
+
+This chapter records the structural after-blocking decomposition of a single
+tensor (Theorem~\ref{thm:tp_primitive_blockdecomp}) and the joint two-tensor
+decomposition at a common blocking period
+(Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}).
+These two statements supply the canonical-form input to the proof of the
+Fundamental Theorem in Chapter~\ref{ch:ft_proof}.
 
 \section{Zero-tail separation}%
 \label{sec:zero_block_separation}
@@ -258,50 +254,15 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     normality are both preserved under blocking.
 \end{proof}
 
-\begin{theorem}[Structural after-blocking decomposition]%
-    \label{thm:ft_after_blocking_structural}
-    \lean{MPSTensor.afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂}
-    \leanok
-    \uses{def:blocked_tensor, def:same_mpv2, def:zero_mps_tensor, def:block_diagonal_tensor}
-    If two tensors $A$ and $B$ generate the same MPV family, then each tensor
-    admits a positive blocking length after which it decomposes into a zero-tail
-    tensor plus a weighted nonzero-block tensor. Thus, for every blocked
-    configuration $\sigma$ of length $N$ on the $p_A$-blocked alphabet,
-    \[
-        V^{(N)}\!(A^{[p_A]})_\sigma
-        = V^{(N)}\!(\mathbf{0}_{d^{[p_A]},z_A})_\sigma
-        + V^{(N)}\!\left(\textstyle\bigoplus_k \mu^A_k A_k\right)_\sigma,
-    \]
-    and, for every blocked configuration $\tau$ of length $N$ on the
-    $p_B$-blocked alphabet,
-    \[
-        V^{(N)}\!(B^{[p_B]})_\tau
-        = V^{(N)}\!(\mathbf{0}_{d^{[p_B]},z_B})_\tau
-        + V^{(N)}\!\left(\textstyle\bigoplus_\ell \mu^B_\ell B_\ell\right)_\tau.
-    \]
-    All nonzero blocks are left-canonical, have primitive transfer maps, have
-    positive bond dimensions, and have nonzero weights. The original MPV equality
-    also blocks:
-    \[
-        A^{[p_A]} \sim B^{[p_A]},
-        \qquad
-        A^{[p_B]} \sim B^{[p_B]}.
-    \]
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:tp_primitive_blockdecomp}
-    Apply Theorem~\ref{thm:tp_primitive_blockdecomp} separately to the two tensors.
-\end{proof}
-
-\begin{remark}[Structural after-blocking decomposition; not the FT block-matching theorem]
-    This theorem produces, for each of the two same-MPV tensors independently,
-    a TP/primitive/left-canonical block decomposition after blocking. It does
-    \emph{not} derive any block matching, gauge equivalence, or phases
-    between the two decompositions; those are produced by the subsequent
-    common-sector construction in this chapter. The statement is a
-    preliminary step for the fundamental-theorem proof, not the multi-block
-    fundamental theorem of~\cite[Theorem~II.1, lines~349--352]{Cirac2017MPDO_AnnPhys}.
+\begin{remark}[Two-tensor primitive block decomposition]%
+    \label{rem:ft_after_blocking_structural}
+    Applying Theorem~\ref{thm:tp_primitive_blockdecomp} to each of two
+    same-MPV tensors $A$ and $B$ produces, after a positive blocking length,
+    a zero-tail tensor plus a left-canonical primitive nonzero block
+    decomposition for each side. This is a preliminary step in the chain
+    leading to
+    Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem},
+    where the two sides are matched.
 \end{remark}
 
 \begin{theorem}[Zero-tail decomposition after blocking]%
@@ -606,57 +567,6 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     conclusion is Theorem~\ref{thm:common_blocked_cyclic_sector_flat_weight_ne_zero}.
 \end{proof}
 
-The next results put the cyclic-sector decompositions on a common blocked
-alphabet. They compare direct blocking with iterated cyclic-sector blocking and
-transport the zero-tail identity through this comparison.
-
-\begin{theorem}[Common cyclic sectors after reblocking]%
-    \label{thm:ft_after_blocking_reindexed_common_sector_live_zero_tail}
-    \lean{MPSTensor.afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV₂}
-    \leanok
-    \uses{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail,
-        thm:zero_tail_to_tensor_from_blocks_block_power,
-        thm:common_blocked_cyclic_sector_reindexed_samempv,
-        thm:common_blocked_cyclic_sector_derived_properties}
-    For the $A$-side, let $p_A$ be the common reblocking length of the cyclic
-    sector family. Then, for every blocked configuration $\sigma$ of length
-    $N$,
-    \[
-        V^{(N)}\!(A^{[p_A]})_\sigma
-        =
-        V^{(N)}\!(\mathbf{0}_{d^{[p_A]},z_A})_\sigma
-        +
-        V^{(N)}\!\bigl(\textstyle\bigoplus_j
-        (\mu^A_j)^{p_A} (A_j)^{[p_A]}\bigr)_\sigma.
-    \]
-    Writing $\widetilde A_j$ for the directly blocked tensor
-    $(A_j)^{[p_A]}$ read in the common blocked alphabet, the reindexed
-    nonzero part agrees with the common-sector tensor:
-    \[
-        V^{(N)}\!\bigl(\textstyle\bigoplus_j
-        (\mu^A_j)^{p_A} \widetilde A_j\bigr)_\sigma
-        =
-        V^{(N)}\!\bigl(\textstyle\bigoplus_x
-        \widetilde\mu^A_x C^A_x\bigr)_\sigma.
-    \]
-    The same two identities hold on the $B$-side with $p_B$, $z_B$,
-    $(\mu^B_k)$, and $(C^B_y)$.
-    The transported weights $\widetilde\mu^A_x$ and $\widetilde\mu^B_y$ are
-    nonzero, and the common-sector blocks are left-canonical, primitive,
-    tensor-irreducible, and of positive bond dimension.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:ft_after_blocking_common_blocked_cyclic_live_zero_tail,
-        thm:zero_tail_to_tensor_from_blocks_block_power,
-        thm:common_blocked_cyclic_sector_reindexed_samempv,
-        thm:common_blocked_cyclic_sector_derived_properties}
-    Start from the common reblocked cyclic-sector families on the two sides. Apply
-    the zero-tail reblocking theorem to the original nonzero-block decomposition,
-    then use the common-alphabet sector decomposition and the derived structural
-    properties of the common-sector family.
-\end{proof}
-
 \begin{theorem}[Common blocking length for cyclic sectors]%
     \label{thm:ft_after_blocking_common_length_common_sector_theorem}
     \lean{MPSTensor.afterBlocking_commonLengthCommonSectorData_of_sameMPV₂}
@@ -725,12 +635,6 @@ transport the zero-tail identity through this comparison.
 
 \begin{theorem}[Length-zero identity under compatible blocking]%
     \label{thm:zero_tail_common_flat_of_blocked_word_comparison}
-    \lean{MPSTensor.zeroTail_commonFlat_of_blockwise,
-        MPSTensor.zeroTail_commonFlat_of_word_eq,
-        MPSTensor.zeroTail_commonFlat_of_groupedBlockCastAgrees,
-        MPSTensor.zeroTail_commonFlatAt_of_groupedBlockCastAgrees,
-        MPSTensor.sameMPV₂Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees}
-    \leanok
     \uses{thm:zero_tail_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_blocked_word_comparison,
         def:same_mpv2_pos}
@@ -761,8 +665,12 @@ transport the zero-tail identity through this comparison.
         V^{(N)}\!\bigl(\textstyle\bigoplus_x
         \widetilde\mu_x C_x\bigr)_\tau.
     \]
-    The blockwise comparison, the word equality, and the coordinate-grouping
-    condition are three ways to supply the same alphabet identification.
+    The formalization records this conclusion internally under three equivalent
+    hypothesis forms (blockwise comparison, blocked-word equality, and
+    coordinate-grouping cast equality); the externally consumed form is
+    Theorem~\ref{thm:zero_tail_common_flat_of_reindexed}, whose hypothesis is
+    the blocked-tensor same-MPV relation (Definition~\ref{def:same_mpv2})
+    provided by Theorem~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1007,57 +915,6 @@ transport the zero-tail identity through this comparison.
     with the weighted common-sector family. Combine this with the zero-tail
     identity and the nonzero-weight statement.
 \end{proof}
-
-\begin{theorem}[Common sectors at one blocking length]%
-    \label{thm:ft_after_blocking_common_length_common_sector_reindexed}
-    \lean{MPSTensor.afterBlocking_commonLengthCommonSectorData_of_reindexed}
-    \leanok
-    \uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-        thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
-    If two tensors generate the same MPV family, choose a common blocking length
-    $p$ for their cyclic-sector decompositions. If each blocked nonzero part
-    agrees with its common-sector form after identifying words, then there are
-    common-sector nonzero tensors $\widetilde A_{\mathrm{nz}}$ and
-    $\widetilde B_{\mathrm{nz}}$ such that, for every blocked configuration
-    $\sigma$ of length $N$,
-    \[
-        V^{(N)}\!(A^{[p]})_\sigma
-        =
-        V^{(N)}\!(\mathbf{0}_{d^{[p]},z_A})_\sigma
-        +
-        V^{(N)}(\widetilde A_{\mathrm{nz}})_\sigma,
-    \]
-    \[
-        V^{(N)}\!(B^{[p]})_\sigma
-        =
-        V^{(N)}\!(\mathbf{0}_{d^{[p]},z_B})_\sigma
-        +
-        V^{(N)}(\widetilde B_{\mathrm{nz}})_\sigma.
-    \]
-    For $N\ge 1$,
-    \[
-        V^{(N)}(\widetilde A_{\mathrm{nz}})_\sigma
-        =
-        V^{(N)}(\widetilde B_{\mathrm{nz}})_\sigma.
-    \]
-    At length zero,
-    \[
-        z_A + V^{(0)}(\widetilde A_{\mathrm{nz}})_\varnothing
-        =
-        z_B + V^{(0)}(\widetilde B_{\mathrm{nz}})_\varnothing.
-    \]
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-        thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
-    Apply Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem}.
-    The two word-identification hypotheses identify the blocked nonzero parts with the
-    weighted common-sector tensors. Substituting these MPV equalities into the
-    zero-tail equations gives the rewritten zero-tail identities, the
-    positive-length MPV equalities, and the $N=0$ identity.
-\end{proof}
-
 
 \section{Primitive-block decomposition of an arbitrary tensor}%
 \label{sec:ch11b_primitive_block_reduction}

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -287,17 +287,17 @@ The earlier existence path now has the following formal pieces.
     \item
           \path|MPSTensor.PGVWC07PositiveLengthWitness| and
           \path|MPSTensor.exists_pgvwc07_positiveLengthWitness| record the
-          preceding positive-length theorem as a single package of data.  The
-          fields contain the nonzero unital blocks, positive real weights,
+          preceding positive-length theorem as a single bundled structure.
+          The fields contain the nonzero unital blocks, positive real weights,
           diagonal positive-definite dual fixed points, scalar fixed-point
           conclusions, positive block dimensions, positive-length MPV equality,
-          and the total bond-dimension bound.  The companion theorem
-          \path|MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero| derives
-          nonvanishing of the weights from their positive-real form, so that
-          nonvanishing is not an additional field of the witness.  This is not
-          a new proof route; it is an equivalent formulation of the proved
-          positive-length theorem, intended to prevent later arguments from
-          repeating the long existential conclusion.
+          and the total bond-dimension bound.  Nonvanishing of the weights
+          follows from their positive-real form (each weight is the complex
+          embedding of a strictly positive real), so it is not an additional
+          field of the witness.  This is not a new proof route; it is an
+          equivalent formulation of the proved positive-length theorem,
+          intended to prevent later arguments from repeating the long
+          existential conclusion.
 
     \item
           \path|MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization|
@@ -372,22 +372,16 @@ The earlier existence path now has the following formal pieces.
           normalized weighted block tensor has the same coefficients on every
           nonempty ring, and \(\sum_k D_k\leq D\).
 
-    \item
-          \path|MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail|
-          records the complementary explicit zero-block convention.  It keeps
-          the zero block from the arbitrary-input decomposition, normalizes the
-          positive nonzero-block weights by their maximum when the nonzero
-          family is nonempty, and proves exact MPV equality at every finite
-          length after the same positive global rescaling.  For positive
-          lengths the zero block contributes zero; at length zero the equality
-          is the dimension identity \(D_0+\sum_kD_k=D\).
-
-    \item
-          \path|MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero|
-          records the arbitrary-input zero/nonzero dichotomy for this
-          projective formulation.  Either all positive-length MPV coefficients
-          of the original tensor vanish, or the preceding nonempty normalized
-          projective PGVWC07 form exists.
+          %% Previously listed here: the explicit-zero-block exact form
+          %% \path|MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail|
+          %% and the projective zero/nonzero dichotomy
+          %% \path|MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero|.
+          %% Both were removed from the formalization as unused leaf orphans;
+          %% see audits/canonical_audit.md and audits/canonical_lean_refactor_report.md.
+          %% The zero-block dimension identity \(D_0+\sum_k D_k=D\) is recorded
+          %% by \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound|
+          %% (an upstream member of the same chain), so no source-content gap
+          %% is introduced by the deletion.
 
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -466,12 +466,19 @@ scalar factor are available.  These pieces have been composed into the
 arbitrary-input exact positive-length theorem, allowing the nonzero-block
 family to be empty exactly in the branch where every positive-length
 coefficient vanishes.  This is the statement promoted in the blueprint as the
-formal positive-length version of Theorem~\texttt{Th:TIcanonical}.  The
-explicit zero-block/length-zero formulation is also available: after the same
-positive global rescaling, the zero block and the normalized weighted nonzero
-blocks reproduce the MPV coefficients at every finite length, with
-\(D_0+\sum_kD_k=D\).  It is kept as the companion bookkeeping convention rather
-than as the primary existence theorem.
+formal positive-length version of Theorem~\texttt{Th:TIcanonical}.
+
+The length-zero dimension identity \(D_0+\sum_kD_k=D\) is also recorded, but
+under the spectral-radius unital normalization rather than the
+maximum-weight positive global rescaling.  It is the companion theorem
+\path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound|,
+which separates the zero block from the unital nonzero blocks at the level of
+the original tensor before any weight normalization is applied.  The combined
+``positive global rescaling + zero block + exact MPV equality at every finite
+length'' statement is not formalized in the present development; recovering it
+from the two surviving pieces (the spectral-radius zero-tail dimension
+identity and the maximum-normalized positive-length exact form) is the
+remaining bookkeeping step.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Lean-side companion to PR #1992 (blueprint trim). Privatizes file-local
intermediate declarations whose `\lean{...}` blueprint tags were removed
by the blueprint trim, and deletes leaf-orphan declarations with no
caller anywhere in `TNLean` or `blueprint/src/chapter/`. Stacked on top
of `cleanup/canonical-blueprint-trim`.

### Privatization (file-local intermediates)
- `CommonSectorTransport.lean`: `zeroTail_commonFlat_of_blockwise`, `zeroTail_commonFlat_of_groupedBlockCastAgrees`, `zeroTail_commonFlatAt_of_groupedBlockCastAgrees`. Only `_of_reindexed` is externally consumed.

### Deletions (leaf orphans, verified by `grep -rn` against `TNLean` + `blueprint/src/chapter/`)
- `WeightNormalization.lean`: `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail`, `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`.
- `TPGauge.lean`: `PGVWC07PositiveLengthWitness.weight_ne_zero`.
- `Existence.lean`: `exists_blockTensor_isPrimitive`, `exists_blockTensor_leftCanonical_isPrimitive` (NeZero-wrapper helpers around `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`).
- `CommonSectorTransport.lean`: `zeroTail_commonFlat_of_word_eq`, `sameMPV2Pos_blockTensor_commonFlatAt_of_groupedBlockCastAgrees` (leaf orphans after privatization).
- `CommonSectorData.lean`: `afterBlocking_reindexedCommonSectorDataWithZeroTail_of_sameMPV2`, `afterBlocking_commonLengthCommonSectorData_of_reindexed`.
- `StructuralData.lean`: `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV2`.

### Docstring updates
- `NormalReduction.lean`: public PGVWC07 surface is now `exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` (headline) plus intermediates documented in the blueprint's `Section sec:pgvwc07_intermediates`.
- `CyclicSectorDecomposition.lean`: docstring on `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` points to the consumed `_prim_irr` variant.

### Cross-file privatization deliberately not done
Three PGVWC07 declarations (`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`, `exists_pgvwc07_positiveLengthWitness`, `PGVWC07PositiveLengthWitness`) are called across the `TPGauge.lean` <-> `WeightNormalization.lean` boundary. Lean 4 `private` is file-scoped, so privatization would break the build. The blueprint trim already shortened their headline bullet in the `NormalReduction.lean` module-summary docstring; the API-surface reduction is sufficient.

### Verification
- `lake build` completes successfully (8728 jobs).
- Pre-existing `sorry`s in `MPS/Periodic/Overlap` are not in scope.

### Net effect
**-569 LOC** in the canonical-form folder.

### Companion audit
`audits/canonical_lean_refactor_report.md` records the per-file LOC deltas, privatization rationale, and "things deliberately not done" with justifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly refactors and documentation, but it removes/privatizes multiple Lean declarations, which is an API-surface change that could break downstream imports if any external users relied on the deleted lemmas.
> 
> **Overview**
> Removes several legacy/dead canonical-form declarations (thin wrapper theorems, unused PGVWC07 convenience results, and large after-blocking existential statements) and updates surrounding proofs to rely on the remaining canonical theorems.
> 
> Privatizes file-local intermediate “plumbing” lemmas in common-sector zero-tail transport, leaving only the reindexed/public variants, and refreshes module docstrings to reflect the streamlined public API and where periodicity removal/PGVWC07 intermediate steps now live. Adds an audit report documenting the refactor, and updates `pgvwc07_ti_canonical_form_scope.tex` to stop referencing deleted theorems and clarify what bookkeeping statements remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5be94a498dbcef8b586d41b013c5191d1ca7245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->