### PR TITLE
doc(PEPS): update local insertion diagram

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -651,8 +651,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:IsVertexInjective, def:peps_localIncidentMatrixOp,
         thm:peps_localIncidentMatrixOp_physicalRealization}
     Let \(A\) be vertex-injective and let \(e=(u,v)\) be an edge. For every
-    matrix \(X\) on the bond space of \(e\), the one-leg virtual action induced
-    by \(X\) on the local tensor at \(u\), and likewise at \(v\), is realized by
+    matrix \(M\) on the bond space of \(e\), the one-leg virtual action induced
+    by \(M\) on the local tensor at \(u\), and likewise at \(v\), is realized by
     a physical operator on that endpoint's physical space.
     \begin{center}
         \TNPEPSInsertionPhysicalRealization

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -446,7 +446,7 @@
       \node at ($(realRightA.south)+(0,-0.30)$) {$A_u$};
       \node at (-0.72,-0.36) {$\eta_e$};
       \node at (0.72,-0.36) {$\eta_{\widehat e}$};
-      \node at ($(realRightO.north)+(0,0.55)$) {$O(A_u c)$};
+      \node at ($(realRightO.north)+(0,0.55)$) {$O(A_u(\eta_e,\eta_{\widehat e}))$};
     \end{scope}
   \end{tikzpicture}%
 }

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -420,15 +420,33 @@
 \newcommand{\TNPEPSInsertionPhysicalRealization}{%
   \begin{tikzpicture}[tn picture]
     \begin{scope}
-      \TN@boxedThreeSiteInsertion{realA}{A_1}{A_2}{A_3}{X}
+      \TN@tensordot{realLeftA}{(0,0)}
+      \TN@upleg{realLeftA}{0.50}
+      \draw[tn leg] (realLeftA.east) -- ++(0.70,0);
+      \draw[tn leg] (realLeftA.south) -- ++(0,-0.58);
+      \draw[tn leg] (realLeftA.west) -- ++(-0.32,0);
+      \TN@opdotabove{realLeftM}{(-0.56,0)}{M}
+      \draw[tn leg, red] (realLeftM.west) -- ++(-0.42,0);
+      \draw[tn leg] (realLeftM.east) -- (realLeftA.west);
+      \node at ($(realLeftA.south)+(0,-0.30)$) {$A_u$};
+      \node at (-0.56,-0.35) {$e$};
+      \node at (0.72,-0.36) {$\eta_{\widehat e}$};
+      \node at ($(realLeftA.north)+(0,0.73)$) {$i$};
     \end{scope}
-    \node at (3.75,0) {$=$};
-    \begin{scope}[xshift=4.15cm]
-      \TN@boxedThreeSitePhysicalOne{realL}{A_1}{A_2}{A_3}{O_1}
-    \end{scope}
-    \node at (7.95,0) {$=$};
-    \begin{scope}[xshift=8.35cm]
-      \TN@boxedThreeSitePhysicalTwo{realR}{A_1}{A_2}{A_3}{O_2}
+    \node at (1.80,0) {$=$};
+    \begin{scope}[xshift=3.20cm]
+      \TN@tensordot{realRightA}{(0,0)}
+      \TN@upleg{realRightA}{0.30}
+      \TN@opdotleft{realRightO}{(0,0.62)}{O}
+      \draw[tn phys leg] (realRightA.north) -- (realRightO.south);
+      \draw[tn phys leg, red] (realRightO.north) -- ++(0,0.28);
+      \draw[tn leg] (realRightA.west) -- ++(-0.70,0);
+      \draw[tn leg] (realRightA.east) -- ++(0.70,0);
+      \draw[tn leg] (realRightA.south) -- ++(0,-0.58);
+      \node at ($(realRightA.south)+(0,-0.30)$) {$A_u$};
+      \node at (-0.72,-0.36) {$\eta_e$};
+      \node at (0.72,-0.36) {$\eta_{\widehat e}$};
+      \node at ($(realRightO.north)+(0,0.55)$) {$O(A_u c)$};
     \end{scope}
   \end{tikzpicture}%
 }

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -424,7 +424,6 @@
       \TN@upleg{realLeftA}{0.50}
       \draw[tn leg] (realLeftA.east) -- ++(0.70,0);
       \draw[tn leg] (realLeftA.south) -- ++(0,-0.58);
-      \draw[tn leg] (realLeftA.west) -- ++(-0.32,0);
       \TN@opdotabove{realLeftM}{(-0.56,0)}{M}
       \draw[tn leg, red] (realLeftM.west) -- ++(-0.42,0);
       \draw[tn leg] (realLeftM.east) -- (realLeftA.west);


### PR DESCRIPTION
### Motivation

Issue #1996 asks that the Chapter 13a diagram for `thm:peps_virtualInsertionPhysicalRealization` match the theorem now formalized in Lean: the local one-leg endpoint realization, not the still-open three-site coefficient equality.

### Description

This PR redraws `\TNPEPSInsertionPhysicalRealization` as a local endpoint diagram. The left side shows the endpoint tensor with a matrix on the distinguished incident virtual edge, and the right side shows the corresponding physical operator acting on the endpoint physical leg. The theorem prose now uses the same matrix name as the diagram.

### Testing

- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --smoke-render`
- `leanblueprint web`
- `leanblueprint pdf`
- `git diff --check`

---
Closes #1996

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates LaTeX prose and TikZ drawing without affecting any Lean/formal code or algorithms.
>
> **Overview**
> Aligns `thm:peps_virtualInsertionPhysicalRealization` with its Lean-formalized scope by renaming the inserted bond matrix from `X` to `M` in the theorem statement.
>
> Redraws `\TNPEPSInsertionPhysicalRealization` from a three-site chain equality into a *single-endpoint* diagram: a matrix `M` on the distinguished virtual edge at `A_u` is shown equal to a corresponding physical operator `O` acting on the physical leg (with updated labels for `e`, `\eta_e`, and `\eta_{\widehat e}`).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70a1b978cb596f907ce49311645a6ec5e1ebd9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update: adjusts LaTeX theorem prose and TikZ diagram without changing any Lean/formalization or computational code.
> 
> **Overview**
> Updates `thm:peps_virtualInsertionPhysicalRealization` to use matrix name `M` (matching the formalized statement) and redraws `\TNPEPSInsertionPhysicalRealization` from a three-site equality into a **single-endpoint** diagram.
> 
> The new figure explicitly shows a bond-space matrix `M` inserted on the distinguished virtual edge at `A_u` and its equality to a corresponding physical operator `O` acting on the physical leg, with updated edge/index labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a8bbca0f370d37a3963c6c14e535cff44f6833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->