### PR TITLE
feat(PEPS): realize endpoint inserted coefficients

### DIFF
--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -455,6 +455,62 @@ instance instFintypeEdgeInsertedBoundaryConfig (A : Tensor G d) (e : Edge G) :
       ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e))
     (edgeInsertedBoundaryConfigEquivProd (G := G) A e).symm
 
+/-- Inserted-edge boundary data are the same as ordinary edge-boundary data
+together with an independent left distinguished-edge index.
+
+The ordinary boundary supplies the right distinguished-edge index and both
+endpoint residual configurations; the extra index supplies the left endpoint
+distinguished-edge index. This is the finite reindexing used when a physical
+operator on the left endpoint realizes a virtual matrix insertion. -/
+def edgeBoundaryLeftIndexEquivInsertedBoundaryConfig (A : Tensor G d) (e : Edge G) :
+    (Σ _ : EdgeBoundaryConfig (G := G) A e, Fin (A.bondDim e)) ≃
+      EdgeInsertedBoundaryConfig (G := G) A e where
+  toFun x :=
+    { leftEdgeIndex := x.2
+      rightEdgeIndex := x.1.edgeIndex
+      leftResidual := x.1.leftResidual
+      rightResidual := x.1.rightResidual }
+  invFun β :=
+    ⟨{ edgeIndex := β.rightEdgeIndex
+       leftResidual := β.leftResidual
+       rightResidual := β.rightResidual },
+      β.leftEdgeIndex⟩
+  left_inv x := by
+    rcases x with ⟨β, leftEdgeIndex⟩
+    cases β
+    rfl
+  right_inv β := by
+    rcases β with ⟨leftEdgeIndex, rightEdgeIndex, leftResidual, rightResidual⟩
+    rfl
+
+/-- Inserted-edge boundary data are the same as ordinary edge-boundary data
+together with an independent right distinguished-edge index.
+
+The ordinary boundary supplies the left distinguished-edge index and both
+endpoint residual configurations; the extra index supplies the right endpoint
+distinguished-edge index. This is the finite reindexing used when a physical
+operator on the right endpoint realizes a virtual matrix insertion. -/
+def edgeBoundaryRightIndexEquivInsertedBoundaryConfig (A : Tensor G d) (e : Edge G) :
+    (Σ _ : EdgeBoundaryConfig (G := G) A e, Fin (A.bondDim e)) ≃
+      EdgeInsertedBoundaryConfig (G := G) A e where
+  toFun x :=
+    { leftEdgeIndex := x.1.edgeIndex
+      rightEdgeIndex := x.2
+      leftResidual := x.1.leftResidual
+      rightResidual := x.1.rightResidual }
+  invFun β :=
+    ⟨{ edgeIndex := β.leftEdgeIndex
+       leftResidual := β.leftResidual
+       rightResidual := β.rightResidual },
+      β.rightEdgeIndex⟩
+  left_inv x := by
+    rcases x with ⟨β, rightEdgeIndex⟩
+    cases β
+    rfl
+  right_inv β := by
+    rcases β with ⟨leftEdgeIndex, rightEdgeIndex, leftResidual, rightResidual⟩
+    rfl
+
 /-- The diagonal part of inserted-edge boundary data, where the two distinguished
 bond indices agree. This is the part selected by inserting the identity matrix
 on the edge. -/
@@ -544,6 +600,30 @@ omit [Fintype V] in
     edgeInsertedLeftLocalConfig (G := G) A e
         (edgeBoundaryToInsertedBoundaryConfig (G := G) A e β) =
       edgeLeftLocalConfig (G := G) A e β :=
+  rfl
+
+omit [Fintype V] in
+@[simp] theorem edgeInsertedLeftLocalConfig_edgeBoundary_rightIndex
+    (A : Tensor G d) (e : Edge G) (β : EdgeBoundaryConfig (G := G) A e)
+    (y : Fin (A.bondDim e)) :
+    edgeInsertedLeftLocalConfig (G := G) A e
+        { leftEdgeIndex := β.edgeIndex
+          rightEdgeIndex := y
+          leftResidual := β.leftResidual
+          rightResidual := β.rightResidual } =
+      edgeLeftLocalConfig (G := G) A e β :=
+  rfl
+
+omit [Fintype V] in
+@[simp] theorem edgeInsertedRightLocalConfig_edgeBoundary_leftIndex
+    (A : Tensor G d) (e : Edge G) (β : EdgeBoundaryConfig (G := G) A e)
+    (y : Fin (A.bondDim e)) :
+    edgeInsertedRightLocalConfig (G := G) A e
+        { leftEdgeIndex := y
+          rightEdgeIndex := β.edgeIndex
+          leftResidual := β.leftResidual
+          rightResidual := β.rightResidual } =
+      edgeRightLocalConfig (G := G) A e β :=
   rfl
 
 omit [Fintype V] in

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -13,6 +13,13 @@ corresponding endpoint.
 
 - `edgeVirtualInsertionPhysicalRealization`: an arbitrary matrix on an edge is
   physically realizable at either endpoint.
+- `edgeInsertedCoeff_eq_sum_left_physicalRealization`: the left endpoint
+  physical realization, with the transpose convention, gives the inserted-edge
+  coefficient.
+- `edgeInsertedCoeff_eq_sum_right_physicalRealization`: the right endpoint
+  physical realization gives the inserted-edge coefficient.
+- `edgeInsertedCoeff_endpointPhysicalRealization`: vertex injectivity gives
+  endpoint physical realizations of the inserted-edge coefficient.
 -/
 
 namespace TNLean
@@ -29,11 +36,9 @@ Lemma \(\mathrm{inj\_isomorph}\) in arXiv:1804.04964, Section 3. The left and
 right physical operators realize the same matrix on the distinguished incident
 edge of the corresponding endpoint tensor.
 
-**Scope restriction (endpoint realization):** This theorem proves the local
-endpoint realization, not yet the coefficient-level equality with
-the edge-inserted three-site coefficient in the full edge-blocked three-site
-contraction. The remaining step is recorded in
-`docs/paper-gaps/peps_injective_ft_section3_route.tex`. -/
+**Companion coefficient statement:** This theorem proves the local endpoint
+realization. The corresponding equality with the edge-inserted three-site
+coefficient is recorded in `edgeInsertedCoeff_endpointPhysicalRealization`. -/
 theorem edgeVirtualInsertionPhysicalRealization (A : Tensor G d)
     (hA : IsVertexInjective A) (e : Edge G)
     (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
@@ -52,6 +57,183 @@ theorem edgeVirtualInsertionPhysicalRealization (A : Tensor G d)
       (A := A) hA (edgeLeftIncident (G := G) e) M
   · exact localIncidentMatrixOp_physicalRealization
       (A := A) hA (edgeRightIncident (G := G) e) M
+
+/-- The left-endpoint physical realization of a virtual matrix insertion
+reproduces the full inserted-edge coefficient.
+
+This is the coefficient-level part of the local \(X \mapsto O_1,O_2\) step in
+Lemma \(\mathrm{inj\_isomorph}\) of arXiv:1804.04964, Section 3, in the
+left-endpoint orientation. Since the ordinary edge boundary supplies the right
+distinguished-edge index, the left endpoint realizes \(M^{\mathsf T}\), so that
+the resulting inserted-edge coefficient has matrix coefficient
+\(M_{\mathrm{left},\mathrm{right}}\). -/
+theorem edgeInsertedCoeff_eq_sum_left_physicalRealization (A : Tensor G d)
+    (e : Edge G) (σ : V → Fin d)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (O₁ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hO₁ : ∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+      O₁ (localTensorMap A e.1.1 c) =
+        localTensorMap A e.1.1
+          (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose c)) :
+    edgeInsertedCoeff (G := G) A e σ M =
+      ∑ β : EdgeBoundaryConfig (G := G) A e,
+        O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2) := by
+  classical
+  let φ := edgeBoundaryLeftIndexEquivInsertedBoundaryConfig (G := G) A e
+  let F : EdgeInsertedBoundaryConfig (G := G) A e → ℂ := fun β =>
+    A.component e.1.1 (edgeInsertedLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+      M β.leftEdgeIndex β.rightEdgeIndex *
+      edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+      A.component e.1.2 (edgeInsertedRightLocalConfig (G := G) A e β) (σ e.1.2)
+  have hLeft :
+      ∀ β : EdgeBoundaryConfig (G := G) A e,
+        O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) =
+          ∑ y : Fin (A.bondDim e),
+            M y β.edgeIndex *
+              A.component e.1.1
+                (edgeInsertedLeftLocalConfig (G := G) A e
+                  { leftEdgeIndex := y
+                    rightEdgeIndex := β.edgeIndex
+                    leftResidual := β.leftResidual
+                    rightResidual := β.rightResidual })
+                (σ e.1.1) := by
+    intro β
+    have h := congrFun
+      (hO₁ (Pi.single (edgeLeftLocalConfig (G := G) A e β) (1 : ℂ))) (σ e.1.1)
+    rw [localTensorMap_apply_single] at h
+    have hTensor := congrFun
+      (localTensorMap_localIncidentMatrixOp_single (G := G) A
+        (edgeLeftIncident (G := G) e) M.transpose β.edgeIndex β.leftResidual) (σ e.1.1)
+    simpa [edgeLeftLocalConfig, edgeInsertedLeftLocalConfig, Matrix.transpose_apply]
+      using h.trans hTensor
+  calc
+    edgeInsertedCoeff (G := G) A e σ M = ∑ β : EdgeInsertedBoundaryConfig (G := G) A e,
+        F β := by
+      rfl
+    _ = ∑ x : (Σ β : EdgeBoundaryConfig (G := G) A e, Fin (A.bondDim e)),
+        F (φ x) := by
+      exact (φ.sum_comp F).symm
+    _ = ∑ β : EdgeBoundaryConfig (G := G) A e,
+        ∑ y : Fin (A.bondDim e), F (φ ⟨β, y⟩) := by
+      exact Fintype.sum_sigma' (fun β y => F (φ ⟨β, y⟩))
+    _ = ∑ β : EdgeBoundaryConfig (G := G) A e,
+        O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2) := by
+      refine Finset.sum_congr rfl ?_
+      intro β _
+      rw [hLeft β]
+      simp [F, φ, edgeBoundaryLeftIndexEquivInsertedBoundaryConfig, Finset.mul_sum,
+        mul_assoc, mul_left_comm, mul_comm]
+
+/-- The right-endpoint physical realization of a virtual matrix insertion
+reproduces the full inserted-edge coefficient.
+
+This is the coefficient-level part of the local \(X \mapsto O_1,O_2\) step in
+Lemma \(\mathrm{inj\_isomorph}\) of arXiv:1804.04964, Section 3, in the
+right-endpoint orientation. The ordinary edge boundary provides the left
+distinguished-edge index, while the right physical action supplies the
+independent right distinguished-edge index of the inserted-edge coefficient. -/
+theorem edgeInsertedCoeff_eq_sum_right_physicalRealization (A : Tensor G d)
+    (e : Edge G) (σ : V → Fin d)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hO₂ : ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+      O₂ (localTensorMap A e.1.2 c) =
+        localTensorMap A e.1.2
+          (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c)) :
+    edgeInsertedCoeff (G := G) A e σ M =
+      ∑ β : EdgeBoundaryConfig (G := G) A e,
+        A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2) := by
+  classical
+  let φ := edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e
+  let F : EdgeInsertedBoundaryConfig (G := G) A e → ℂ := fun β =>
+    A.component e.1.1 (edgeInsertedLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+      M β.leftEdgeIndex β.rightEdgeIndex *
+      edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+      A.component e.1.2 (edgeInsertedRightLocalConfig (G := G) A e β) (σ e.1.2)
+  have hRight :
+      ∀ β : EdgeBoundaryConfig (G := G) A e,
+        O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2) =
+          ∑ y : Fin (A.bondDim e),
+            M β.edgeIndex y *
+              A.component e.1.2
+                (edgeInsertedRightLocalConfig (G := G) A e
+                  { leftEdgeIndex := β.edgeIndex
+                    rightEdgeIndex := y
+                    leftResidual := β.leftResidual
+                    rightResidual := β.rightResidual })
+                (σ e.1.2) := by
+    intro β
+    have h := congrFun
+      (hO₂ (Pi.single (edgeRightLocalConfig (G := G) A e β) (1 : ℂ))) (σ e.1.2)
+    rw [localTensorMap_apply_single] at h
+    have hTensor := congrFun
+      (localTensorMap_localIncidentMatrixOp_single (G := G) A
+        (edgeRightIncident (G := G) e) M β.edgeIndex β.rightResidual) (σ e.1.2)
+    simpa [edgeRightLocalConfig, edgeInsertedRightLocalConfig] using h.trans hTensor
+  calc
+    edgeInsertedCoeff (G := G) A e σ M = ∑ β : EdgeInsertedBoundaryConfig (G := G) A e,
+        F β := by
+      rfl
+    _ = ∑ x : (Σ β : EdgeBoundaryConfig (G := G) A e, Fin (A.bondDim e)),
+        F (φ x) := by
+      exact (φ.sum_comp F).symm
+    _ = ∑ β : EdgeBoundaryConfig (G := G) A e,
+        ∑ y : Fin (A.bondDim e), F (φ ⟨β, y⟩) := by
+      exact Fintype.sum_sigma' (fun β y => F (φ ⟨β, y⟩))
+    _ = ∑ β : EdgeBoundaryConfig (G := G) A e,
+        A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2) := by
+      refine Finset.sum_congr rfl ?_
+      intro β _
+      rw [hRight β]
+      simp [F, φ, edgeBoundaryRightIndexEquivInsertedBoundaryConfig, Finset.mul_sum,
+        mul_assoc, mul_left_comm, mul_comm]
+
+/-- Vertex injectivity realizes an inserted edge matrix by physical operators at
+the two endpoint tensors.
+
+For an inserted matrix \(M\), the left endpoint realizes \(M^{\mathsf T}\) and
+the right endpoint realizes \(M\). Both physical realizations give the same
+inserted-edge coefficient after the edge-centered three-site decomposition. -/
+theorem edgeInsertedCoeff_endpointPhysicalRealization (A : Tensor G d)
+    (hA : IsVertexInjective A) (e : Edge G) (σ : V → Fin d)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    (∃ O₁ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ),
+      (∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+        O₁ (localTensorMap A e.1.1 c) =
+          localTensorMap A e.1.1
+            (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose c)) ∧
+      edgeInsertedCoeff (G := G) A e σ M =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)) ∧
+    (∃ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ),
+      (∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+        O₂ (localTensorMap A e.1.2 c) =
+          localTensorMap A e.1.2
+            (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c)) ∧
+      edgeInsertedCoeff (G := G) A e σ M =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2)) := by
+  constructor
+  · obtain ⟨O₁, hO₁⟩ := localIncidentMatrixOp_physicalRealization
+      (A := A) hA (edgeLeftIncident (G := G) e) M.transpose
+    exact ⟨O₁, hO₁, edgeInsertedCoeff_eq_sum_left_physicalRealization
+      (G := G) A e σ M O₁ hO₁⟩
+  · obtain ⟨O₂, hO₂⟩ := localIncidentMatrixOp_physicalRealization
+      (A := A) hA (edgeRightIncident (G := G) e) M
+    exact ⟨O₂, hO₂, edgeInsertedCoeff_eq_sum_right_physicalRealization
+      (G := G) A e σ M O₂ hO₂⟩
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -216,6 +216,86 @@ omit [Fintype V] in
             (x, (localVirtualConfigSplitAt (G := G) A ie η').2)) :=
   rfl
 
+/-- Acting on one distinguished-edge basis configuration only changes the
+distinguished index and keeps the residual local boundary fixed. -/
+theorem localIncidentMatrixOp_single (A : Tensor G d) {v : V}
+    (ie : IncidentEdge G v)
+    (M : Matrix (Fin (A.bondDim ie.1)) (Fin (A.bondDim ie.1)) ℂ)
+    (x : Fin (A.bondDim ie.1)) (r : ResidualLocalConfig (G := G) A ie) :
+    localIncidentMatrixOp A ie M
+      (Pi.single ((localVirtualConfigSplitAt (G := G) A ie).symm (x, r)) (1 : ℂ)) =
+      ∑ y : Fin (A.bondDim ie.1),
+        Pi.single ((localVirtualConfigSplitAt (G := G) A ie).symm (y, r)) (M x y) := by
+  classical
+  ext η
+  simp only [localIncidentMatrixOp_apply, Finset.sum_apply]
+  let φ := localVirtualConfigSplitAt (G := G) A ie
+  have hfst : (φ η).1 = η ie := by simp [φ]
+  by_cases hres : (φ η).2 = r
+  · have hη : φ.symm (η ie, r) = η := by
+      have hp : (η ie, r) = φ η := by
+        ext <;> simp [hfst, hres]
+      rw [hp]
+      exact Equiv.symm_apply_apply φ η
+    rw [Fintype.sum_eq_single x]
+    · rw [Fintype.sum_eq_single (η ie)]
+      · have hcfg : φ.symm (x, (φ η).2) = φ.symm (x, r) := by simp [hres]
+        rw [hcfg, Pi.single_eq_same, mul_one, hη, Pi.single_eq_same]
+      · intro y hy
+        have hcfg : φ.symm (y, r) ≠ η := by
+          intro h
+          apply hy
+          have hp := congrArg φ h
+          simpa [φ, hfst, hres] using congrArg Prod.fst hp
+        rw [Pi.single_eq_of_ne (Ne.symm hcfg)]
+    · intro y hy
+      have hcfg : φ.symm (y, (φ η).2) ≠ φ.symm (x, r) := by
+        intro h
+        apply hy
+        have hp := congrArg φ h
+        simpa using congrArg Prod.fst hp
+      rw [Pi.single_eq_of_ne hcfg, mul_zero]
+  · rw [Fintype.sum_eq_single x]
+    · rw [Fintype.sum_eq_single (η ie)]
+      · have hcfg₁ : φ.symm (x, (φ η).2) ≠ φ.symm (x, r) := by
+          intro h
+          apply hres
+          have hp := congrArg φ h
+          simpa using congrArg Prod.snd hp
+        have hcfg₂ : φ.symm (η ie, r) ≠ η := by
+          intro h
+          apply hres
+          have hp := congrArg φ h
+          simpa [φ, hfst] using (congrArg Prod.snd hp).symm
+        rw [Pi.single_eq_of_ne hcfg₁, mul_zero, Pi.single_eq_of_ne (Ne.symm hcfg₂)]
+      · intro y hy
+        have hcfg : φ.symm (y, r) ≠ η := by
+          intro h
+          apply hy
+          have hp := congrArg φ h
+          simpa [φ, hfst] using congrArg Prod.fst hp
+        rw [Pi.single_eq_of_ne (Ne.symm hcfg)]
+    · intro y hy
+      have hcfg : φ.symm (y, (φ η).2) ≠ φ.symm (x, r) := by
+        intro h
+        apply hy
+        have hp := congrArg φ h
+        simpa using congrArg Prod.fst hp
+      rw [Pi.single_eq_of_ne hcfg, mul_zero]
+
+/-- The local tensor map after a one-edge matrix action on a basis virtual
+configuration. -/
+theorem localTensorMap_localIncidentMatrixOp_single (A : Tensor G d) {v : V}
+    (ie : IncidentEdge G v)
+    (M : Matrix (Fin (A.bondDim ie.1)) (Fin (A.bondDim ie.1)) ℂ)
+    (x : Fin (A.bondDim ie.1)) (r : ResidualLocalConfig (G := G) A ie) :
+    localTensorMap A v (localIncidentMatrixOp A ie M
+      (Pi.single ((localVirtualConfigSplitAt (G := G) A ie).symm (x, r)) (1 : ℂ))) =
+      ∑ y : Fin (A.bondDim ie.1),
+        M x y • A.component v ((localVirtualConfigSplitAt (G := G) A ie).symm (y, r)) := by
+  rw [localIncidentMatrixOp_single]
+  simp [map_sum]
+
 /-- Physical realization of a local virtual endomorphism.
 
 Since the local tensor map is injective, a virtual operator on the coefficient

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -224,6 +224,37 @@ injective and normal PEPS, following Theorems~2 and~3 of
     configuration fixed.
 \end{definition}
 
+\begin{theorem}[One-edge matrix action on a basis configuration]%
+    \label{thm:peps_localIncidentMatrixOp_single}
+    \lean{TNLean.PEPS.localIncidentMatrixOp_single}
+    \leanok
+    \uses{def:peps_localIncidentMatrixOp,
+        def:peps_localVirtualConfigSplitAt}
+    If a coefficient function is supported on one local virtual configuration,
+    and the matrix acts on the distinguished incident edge, the result is the
+    sum over the new distinguished edge index with the residual local boundary
+    held fixed.
+\end{theorem}
+\begin{proof}\leanok
+    Evaluate both sides on a local virtual configuration and split into the
+    two cases according to whether the residual boundary agrees with the fixed
+    residual boundary.
+\end{proof}
+
+\begin{theorem}[Local tensor form of a one-edge basis action]%
+    \label{thm:peps_localTensorMap_localIncidentMatrixOp_single}
+    \lean{TNLean.PEPS.localTensorMap_localIncidentMatrixOp_single}
+    \leanok
+    \uses{thm:peps_localIncidentMatrixOp_single, def:peps_localTensorMap}
+    Applying the local tensor map after a one-edge matrix action on a basis
+    virtual configuration gives the corresponding linear combination of local
+    tensor components.
+\end{theorem}
+\begin{proof}\leanok
+    Use the preceding coefficient identity and linearity of the local tensor
+    map.
+\end{proof}
+
 \begin{theorem}[Physical realization of one-edge virtual matrix action]%
     \label{thm:peps_localIncidentMatrixOp_physicalRealization}
     \lean{TNLean.PEPS.localIncidentMatrixOp_physicalRealization}
@@ -410,6 +441,28 @@ injective and normal PEPS, following Theorems~2 and~3 of
     by using the same bond index at both endpoints. This is the diagonal
     boundary datum selected by the identity matrix in the edge-insertion
     coefficient.
+\end{definition}
+
+\begin{definition}[Right-endpoint inserted-boundary reindexing]%
+    \label{def:peps_edgeBoundaryRightIndexEquivInsertedBoundaryConfig}
+    \lean{TNLean.PEPS.edgeBoundaryRightIndexEquivInsertedBoundaryConfig}
+    \leanok
+    \uses{def:peps_edgeBoundaryConfig, def:peps_edgeInsertedBoundaryConfig}
+    Ordinary edge-boundary data together with an independent right endpoint
+    bond index are equivalent to inserted-edge boundary data. The ordinary
+    boundary supplies the left bond index and the two residual endpoint
+    boundaries.
+\end{definition}
+
+\begin{definition}[Left-endpoint inserted-boundary reindexing]%
+    \label{def:peps_edgeBoundaryLeftIndexEquivInsertedBoundaryConfig}
+    \lean{TNLean.PEPS.edgeBoundaryLeftIndexEquivInsertedBoundaryConfig}
+    \leanok
+    \uses{def:peps_edgeBoundaryConfig, def:peps_edgeInsertedBoundaryConfig}
+    Ordinary edge-boundary data together with an independent left endpoint
+    bond index are equivalent to inserted-edge boundary data. The ordinary
+    boundary supplies the right bond index and the two residual endpoint
+    boundaries.
 \end{definition}
 
 \begin{definition}[Diagonal inserted-boundary configurations]%
@@ -658,16 +711,71 @@ injective and normal PEPS, following Theorems~2 and~3 of
         \TNPEPSInsertionPhysicalRealization
     \end{center}
 
-    % Scope restriction: this formalized theorem is the local endpoint part of
-    % the X -> O_1,O_2 step in Lemma inj_isomorph of Molnar2018NormalPEPS,
-    % Section 3.  It does not yet identify the resulting physical action with
-    % the full edge-inserted three-site coefficient; that coefficient-level
-    % statement is recorded in
-    % docs/paper-gaps/peps_injective_ft_section3_route.tex.
+    % This is the local endpoint part of the X -> O_1,O_2 step in
+    % Lemma inj_isomorph of Molnar2018NormalPEPS, Section 3.  The corresponding
+    % coefficient identity is
+    % thm:peps_edgeInsertedCoeff_endpointPhysicalRealization.
 \end{theorem}
 \begin{proof}\leanok
     Apply the one-edge realization theorem to the two endpoint incidences of
     the distinguished edge.
+\end{proof}
+
+\begin{theorem}[Right-endpoint physical realization of the inserted coefficient]%
+    \label{thm:peps_edgeInsertedCoeff_rightPhysicalRealization}
+    \lean{TNLean.PEPS.edgeInsertedCoeff_eq_sum_right_physicalRealization}
+    \leanok
+    \uses{def:peps_edgeInsertedCoeff,
+        def:peps_edgeBoundaryRightIndexEquivInsertedBoundaryConfig,
+        thm:peps_localTensorMap_localIncidentMatrixOp_single}
+    Let $e=(u,v)$. If a physical operator on $v$ realizes the one-edge
+    virtual matrix action on the distinguished incident edge, then the
+    inserted-edge coefficient is obtained by leaving the left endpoint and
+    open middle contraction explicit and applying that physical operator to the
+    right endpoint tensor.
+\end{theorem}
+\begin{proof}\leanok
+    Expand the physical realization on a basis local configuration at the
+    right endpoint. The resulting sum over the right bond index is then
+    reindexed together with the ordinary edge-boundary data.
+\end{proof}
+
+\begin{theorem}[Left-endpoint physical realization of the inserted coefficient]%
+    \label{thm:peps_edgeInsertedCoeff_leftPhysicalRealization}
+    \lean{TNLean.PEPS.edgeInsertedCoeff_eq_sum_left_physicalRealization}
+    \leanok
+    \uses{def:peps_edgeInsertedCoeff,
+        def:peps_edgeBoundaryLeftIndexEquivInsertedBoundaryConfig,
+        thm:peps_localTensorMap_localIncidentMatrixOp_single}
+    Let $e=(u,v)$. If a physical operator on $u$ realizes the one-edge
+    virtual action of $M^{\mathsf T}$ on the distinguished incident edge,
+    then the inserted-edge coefficient for $M$ is obtained by applying that
+    physical operator to the left endpoint tensor and leaving the open middle
+    contraction and the right endpoint explicit.
+\end{theorem}
+\begin{proof}\leanok
+    Expand the physical realization on a basis local configuration at the left
+    endpoint. The transpose converts the ordinary right bond index and the new
+    left bond index into the coefficient $M_{ij}$; the resulting finite sum
+    is then reindexed with the ordinary edge-boundary data.
+\end{proof}
+
+\begin{theorem}[Endpoint physical realizations of the inserted coefficient]%
+    \label{thm:peps_edgeInsertedCoeff_endpointPhysicalRealization}
+    \lean{TNLean.PEPS.edgeInsertedCoeff_endpointPhysicalRealization}
+    \leanok
+    \uses{thm:peps_localIncidentMatrixOp_physicalRealization,
+        thm:peps_edgeInsertedCoeff_leftPhysicalRealization,
+        thm:peps_edgeInsertedCoeff_rightPhysicalRealization}
+    If the PEPS tensor is vertex-injective, then each inserted edge matrix is
+    realized by physical operators at the endpoint tensors: the left endpoint
+    realizes $M^{\mathsf T}$, the right endpoint realizes $M$, and both
+    realizations reproduce the same inserted-edge coefficient in the
+    edge-centered three-site decomposition.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the local physical-realization theorem at the two endpoints and then
+    use the two coefficient identities above.
 \end{proof}
 
 \begin{theorem}[Equal neighboring physical actions recover a virtual insertion]%
@@ -689,6 +797,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \notready
     \uses{thm:peps_edgeBlockedThreeSiteInjective,
         thm:peps_virtualInsertionPhysicalRealization,
+        thm:peps_edgeInsertedCoeff_endpointPhysicalRealization,
         thm:peps_physicalToVirtualInsertion,
         thm:peps_sameState_edgeBlockedCoeff_eq, def:peps_edgeInsertedCoeff}
     Applying the three-site injective-chain theorem to the edge-blocked MPS

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -230,10 +230,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_localIncidentMatrixOp,
         def:peps_localVirtualConfigSplitAt}
-    If a coefficient function is supported on one local virtual configuration,
-    and the matrix acts on the distinguished incident edge, the result is the
-    sum over the new distinguished edge index with the residual local boundary
-    held fixed.
+    If the coefficient function is the unit basis function at one local virtual
+    configuration, and the matrix acts on the distinguished incident edge, the
+    result is the sum over the new distinguished edge index with the residual
+    local boundary held fixed.
 \end{theorem}
 \begin{proof}\leanok
     Evaluate both sides on a local virtual configuration and split into the
@@ -728,11 +728,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_edgeInsertedCoeff,
         def:peps_edgeBoundaryRightIndexEquivInsertedBoundaryConfig,
         thm:peps_localTensorMap_localIncidentMatrixOp_single}
-    Let $e=(u,v)$. If a physical operator on $v$ realizes the one-edge
-    virtual matrix action on the distinguished incident edge, then the
-    inserted-edge coefficient is obtained by leaving the left endpoint and
-    open middle contraction explicit and applying that physical operator to the
-    right endpoint tensor.
+    Let $e=(u,v)$ and let $\sigma$ be a physical configuration. If a physical
+    operator on $v$ realizes the one-edge virtual matrix action on the
+    distinguished incident edge, then the inserted-edge coefficient at
+    $\sigma$ is obtained by leaving the left endpoint and open middle
+    contraction explicit and applying that physical operator to the right
+    endpoint tensor.
 \end{theorem}
 \begin{proof}\leanok
     Expand the physical realization on a basis local configuration at the
@@ -747,11 +748,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_edgeInsertedCoeff,
         def:peps_edgeBoundaryLeftIndexEquivInsertedBoundaryConfig,
         thm:peps_localTensorMap_localIncidentMatrixOp_single}
-    Let $e=(u,v)$. If a physical operator on $u$ realizes the one-edge
-    virtual action of $M^{\mathsf T}$ on the distinguished incident edge,
-    then the inserted-edge coefficient for $M$ is obtained by applying that
-    physical operator to the left endpoint tensor and leaving the open middle
-    contraction and the right endpoint explicit.
+    Let $e=(u,v)$ and let $\sigma$ be a physical configuration. If a physical
+    operator on $u$ realizes the one-edge virtual action of $M^{\mathsf T}$ on
+    the distinguished incident edge, then the inserted-edge coefficient for
+    $M$ at $\sigma$ is obtained by applying that physical operator to the left
+    endpoint tensor and leaving the open middle contraction and the right
+    endpoint explicit.
 \end{theorem}
 \begin{proof}\leanok
     Expand the physical realization on a basis local configuration at the left
@@ -767,10 +769,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{thm:peps_localIncidentMatrixOp_physicalRealization,
         thm:peps_edgeInsertedCoeff_leftPhysicalRealization,
         thm:peps_edgeInsertedCoeff_rightPhysicalRealization}
-    If the PEPS tensor is vertex-injective, then each inserted edge matrix is
-    realized by physical operators at the endpoint tensors: the left endpoint
-    realizes $M^{\mathsf T}$, the right endpoint realizes $M$, and both
-    realizations reproduce the same inserted-edge coefficient in the
+    If the PEPS tensor is vertex-injective, then for every physical
+    configuration $\sigma$, each inserted edge matrix is realized by physical
+    operators at the endpoint tensors: the left endpoint realizes
+    $M^{\mathsf T}$, the right endpoint realizes $M$, and both realizations
+    reproduce the same inserted-edge coefficient at $\sigma$ in the
     edge-centered three-site decomposition.
 \end{theorem}
 \begin{proof}\leanok

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -61,7 +61,11 @@ vertex is represented in \path{TNLean/PEPS/VirtualInsertion.lean}. The chosen
 left inverse of the local tensor map and the resulting physical realization of
 local virtual endomorphisms correspond to the same observation used in the
 three-site MPS proof: a virtual operation can be represented by a physical
-operation on a neighboring site.
+operation on a neighboring site. The basis computation
+\leanid{TNLean.PEPS.localIncidentMatrixOp_single} and its tensor-map form
+\leanid{TNLean.PEPS.localTensorMap_localIncidentMatrixOp_single} identify the
+one-edge matrix action on a single local virtual boundary with the expected
+sum over the new distinguished edge index.
 
 The edge-centered blocking data are represented in
 \path{TNLean/PEPS/Blocking.lean}. The existing declarations split local virtual
@@ -77,7 +81,9 @@ The next formal layer is the matrix-insertion comparison. The declarations
 \leanid{TNLean.PEPS.edgeMiddleConfigToOpenMiddleConfig},
 \leanid{TNLean.PEPS.edgeOpenMiddleConfigToMiddleConfig},
 \leanid{TNLean.PEPS.edgeMiddleConfigEquivOpenMiddleConfig},
-\leanid{TNLean.PEPS.edgeOpenMiddleWeight}, and
+\leanid{TNLean.PEPS.edgeOpenMiddleWeight},
+\leanid{TNLean.PEPS.edgeBoundaryLeftIndexEquivInsertedBoundaryConfig},
+\leanid{TNLean.PEPS.edgeBoundaryRightIndexEquivInsertedBoundaryConfig}, and
 \leanid{TNLean.PEPS.edgeInsertedCoeff} represent the open edge contraction used
 when an arbitrary matrix is inserted on the distinguished edge. These
 definitions are the formal counterpart of the matrix insertion appearing before
@@ -124,10 +130,13 @@ Theorem can be proved in the manner of the paper.
   virtual-to-physical realization $X\mapsto O_1,O_2$ is formalized by
   \path{thm:peps_virtualInsertionPhysicalRealization}: vertex injectivity turns
   the one-leg virtual matrix action at either endpoint into a physical operator
-  on that endpoint. The coefficient-level statement remains open: one must still
-  prove that these physical endpoint actions reproduce the full
-  \path{TNLean.PEPS.edgeInsertedCoeff} contraction in the edge-blocked
-  three-site coefficient. The converse recovery $O_1,O_2\mapsto W$ is
+  on that endpoint. The endpoint coefficient-level direction is formalized by
+  \path{thm:peps_edgeInsertedCoeff_endpointPhysicalRealization}: after fixing
+  ordinary edge-boundary data, the left and right physical operators supply the
+  independent inserted-edge index at the corresponding endpoint. On the left
+  endpoint the formal statement uses the transpose of the inserted matrix,
+  because the ordinary boundary supplies the right bond index. The converse
+  recovery $O_1,O_2\mapsto W$ remains open as
   \path{thm:peps_physicalToVirtualInsertion}.
 \item Equality of PEPS states must be upgraded to equality of edge-inserted
   coefficients after the three-site reduction. This is the step that produces
@@ -178,7 +187,11 @@ It is meant to prevent the proof from drifting away from the source argument.
   \path{thm:peps_edgeInsertedCoeff_identity} is reduced to finite diagonal
   reindexing, tracked by issue~\#1372.
 \item Lemma \path{inj_isomorph}, $X\mapsto O_1,O_2$:
-  \path{thm:peps_virtualInsertionPhysicalRealization}, tracked by issue~\#1369.
+  \path{thm:peps_virtualInsertionPhysicalRealization} formalizes the endpoint
+  realization, and
+  \path{thm:peps_edgeInsertedCoeff_endpointPhysicalRealization} formalizes the
+  endpoint coefficient expansion. These are tracked by issues~\#1369
+  and~\#1995.
 \item Lemma \path{inj_isomorph}, $O_1,O_2\mapsto W$:
   \path{thm:peps_physicalToVirtualInsertion}, tracked by issue~\#1370.
 \item Matrix-insertion algebra isomorphism:


### PR DESCRIPTION
### Motivation

- Formalizing arXiv:1804.04964, Section 3, Lemma `inj_isomorph` requires not only the existence of physical operators realizing a one-edge virtual matrix action (established in #1994), but also the coefficient-level identity: the physical operators agree with the full `edgeInsertedCoeff` contraction in the edge-blocked three-site tensor chain.
- This obligation was recorded in the scope-restriction docstring of `edgeVirtualInsertionPhysicalRealization` and in `docs/paper-gaps/peps_injective_ft_section3_route.tex`. See #1995.

### Description

- `TNLean/PEPS/VirtualInsertion.lean`: adds basis-action lemmas for the one-edge virtual matrix operation on a local boundary configuration.
- `TNLean/PEPS/Blocking.lean`: adds left and right finite reindexings between ordinary edge-boundary data and inserted-edge boundary data.
- `TNLean/PEPS/InsertionRealization.lean`: adds coefficient identities showing that a physical operator realizing the one-edge virtual matrix action reproduces `edgeInsertedCoeff`; introduces `edgeInsertedCoeff_endpointPhysicalRealization`, combining both orientations (left endpoint uses the transpose convention, right endpoint uses the inserted matrix itself).
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds blueprint entries and marks the endpoint coefficient comparison as formalized.
- `docs/paper-gaps/peps_injective_ft_section3_route.tex`: updates the paper-gap ledger to reflect the completed coefficient-level statement.

### Testing

- `lake env lean TNLean/PEPS/VirtualInsertion.lean`
- `lake env lean TNLean/PEPS/Blocking.lean`
- `lake build TNLean.PEPS.InsertionRealization`
- `lake build`
- `rg -n "\b(sorry|axiom|admit|unsafeCast|native_decide)\b" TNLean/PEPS/VirtualInsertion.lean TNLean/PEPS/Blocking.lean TNLean/PEPS/InsertionRealization.lean`
- `python3 scripts/blueprint_lean_sync.py --root .` reports only the existing 64 repository-wide sync issues, none from the new PEPS declarations.
- `lake exe checkdecls blueprint/lean_decls` still reports the existing repository-wide missing declarations, none from the new PEPS declarations.

---
Closes #1995

> [!NOTE]
> **Medium Risk**
> Adds several new equivalences and coefficient-level theorems around inserted-edge contractions; while non-executable, the proofs are nontrivial and may impact downstream rewriting/automation or later PEPS arguments.
> 
> **Overview**
> Implements the missing *coefficient-level* part of the PEPS "virtual insertion → physical endpoint action" step: proves that if an endpoint operator realizes the one-edge virtual matrix action, then the resulting contraction equals `edgeInsertedCoeff` (with a transpose convention on the left endpoint), and packages both orientations into `edgeInsertedCoeff_endpointPhysicalRealization`.
> 
> To support these equalities, it adds finite reindexing equivalences between ordinary edge-boundary data plus an extra bond index and `EdgeInsertedBoundaryConfig`, plus basis-expansion lemmas for `localIncidentMatrixOp` and corresponding simp lemmas for inserted-vs-ordinary endpoint local configs. Blueprint and paper-gap documentation are updated to reference the new Lean declarations and mark the endpoint coefficient comparison as formalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c3e65833ddb10344cacf394d2e9eaf202e76f90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to adding several new Lean equivalences and nontrivial sum-reindexing proofs that may affect downstream rewriting/simp behavior in the PEPS formalization.
> 
> **Overview**
> Completes the missing *coefficient-level* step of the PEPS “virtual insertion → physical endpoint action” argument by proving that endpoint physical operators reproducing the one-edge virtual matrix action also reproduce `edgeInsertedCoeff` (left endpoint uses `M.transpose`, right uses `M`).
> 
> To support these identities, it adds new finite reindexing equivalences between `EdgeBoundaryConfig` plus an extra bond index and `EdgeInsertedBoundaryConfig`, plus new basis-expansion lemmas for `localIncidentMatrixOp` and additional simp lemmas relating inserted-vs-ordinary endpoint local configs. Blueprint and paper-gap docs are updated to reference the new theorems and mark this proof obligation as discharged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc854cbf6d981d5045036f2bcb4447f6b4f7c8b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->