### PR TITLE
feat(MPS/MPDO): add positive blocked chi trace-power witness

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -52,11 +52,13 @@ shape of Theorem IV.13(ii): the special diagonal matrices
 $\chi_{\alpha,\beta,\gamma}$ are represented as a `DiagonalChiFamily`, and the
 identity $c_{\alpha,\beta,\gamma}^{(L)} = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$
 is encoded as the `HasChiTracePowerForm` predicate. For the blocked support
-tower, `AlgebraStructureData.BlockedStructureChiFamily` and
-`AlgebraStructureData.HasBlockedStructureChiTracePowerForm` record the
+tower, `AlgebraStructureData.BlockedStructureChiFamily`,
+`AlgebraStructureData.HasBlockedStructureChiTracePowerForm`, and
+`AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm` record the
 length-dependent blocked-basis analogue for
-`AlgebraStructureData.blockedStructureCoefficients`. This is not yet the
-paper's uniform BNT-label chi family; the deviation is recorded in
+`AlgebraStructureData.blockedStructureCoefficients`, including positivity of
+the diagonal entries. This is not yet the paper's uniform BNT-label chi family;
+the deviation is recorded in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. The basic trace-power
 identity `tr(χ_{α,β,γ}^L) = \sum_k \chi_{\alpha,\beta,\gamma,k}^L` is proved
 directly from `Matrix.diagonal_pow` and `Matrix.trace_diagonal`.
@@ -721,6 +723,41 @@ theorem HasBlockedStructureChiTracePowerForm.eq_trace_matrix_pow
     data.blockedStructureCoefficients n i j k =
       (χ.matrix n i j k ^ n).trace := by
   rw [h n hn i j k, χ.trace_matrix_pow]
+
+/-- A positive blocked chi witness for the blocked multiplication coefficients.
+
+This packages the data corresponding to the positive diagonal matrices in
+[Cirac--Perez-Garcia--Schuch--Verstraete 2017, Theorem IV.13(ii)] together
+with the blocked-basis trace-power identity. It is a data-carrying version of
+`HasBlockedStructureChiTracePowerForm`, with positivity included as a field.
+
+**Scope restriction (blocked bases):** As for
+`BlockedStructureChiFamily`, this is the length-dependent blocked-basis analogue
+of the paper's uniform BNT-label chi family. The deviation and elimination plan
+are documented in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
+structure PositiveBlockedStructureChiTracePowerForm
+    (data : AlgebraStructureData d D) where
+  /-- The length-dependent blocked chi family. -/
+  chi : BlockedStructureChiFamily data
+  /-- Positivity of every diagonal entry in the blocked chi family. -/
+  posEntries : chi.PosEntries
+  /-- Trace-power form for the blocked multiplication coefficients. -/
+  tracePower : data.HasBlockedStructureChiTracePowerForm chi
+
+namespace PositiveBlockedStructureChiTracePowerForm
+
+variable {data : AlgebraStructureData d D}
+
+/-- The positive blocked chi witness gives the trace formula for every positive
+blocked multiplication coefficient. -/
+theorem eq_trace_pow (h : PositiveBlockedStructureChiTracePowerForm data)
+    (n : ℕ) (hn : 0 < n)
+    (i j : BlockedIndex data n) (k : BlockedIndex data (2 * n)) :
+    data.blockedStructureCoefficients n i j k =
+      (h.chi.matrix n i j k ^ n).trace :=
+  h.tracePower.eq_trace_matrix_pow n hn i j k
+
+end PositiveBlockedStructureChiTracePowerForm
 
 end AlgebraStructureData
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1275,6 +1275,36 @@ the elementary trace-power identity for diagonal matrices.
     powers of a diagonal matrix.
 \end{proof}
 
+\begin{definition}[Positive blocked $\chi$ trace-power witness]%
+    \label{def:mpdo_positive_blocked_structure_chi_trace_power_form}
+    \lean{MPOTensor.AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm}
+    \leanok
+    \uses{def:mpdo_has_blocked_structure_chi_trace_power_form,
+        def:mpdo_blocked_structure_chi_family}
+    A positive blocked $\chi$ trace-power witness consists of a blocked
+    $\chi$ family, positivity of all its diagonal entries, and the
+    positive-length trace-power identity for the blocked multiplication
+    coefficients. This packages the blocked-basis analogue of the positive
+    diagonal matrices in
+    \cite[Theorem~IV.13(ii)]{Cirac2017MPDO_AnnPhys}; the uniform BNT-label gap
+    is recorded in
+    \path{docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex}.
+\end{definition}
+
+\begin{theorem}[Positive blocked $\chi$ witness gives trace powers]%
+    \label{thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
+    \lean{MPOTensor.AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm.eq_trace_pow}
+    \leanok
+    \uses{def:mpdo_positive_blocked_structure_chi_trace_power_form,
+        thm:mpdo_blocked_structure_chi_eq_trace_matrix_pow}
+    A positive blocked $\chi$ trace-power witness gives, for every positive
+    blocked size $n$, the formula
+    \(c^{(n)}_{i,j,k}=\operatorname{tr}(\chi_{n,i,j,k}^{\,n})\).
+\end{theorem}
+\begin{proof}\leanok
+    Apply the trace reformulation of the trace-power field of the witness.
+\end{proof}
+
 \section{Commuting form and GSNNCH}
 
 \begin{definition}[Commuting-form data for an MPDO]


### PR DESCRIPTION
### Motivation

- Issue #825 calls for extracting the paper's distinguished diagonal matrices $\chi_{\alpha,\beta,\gamma}$ from the blocked-coefficient layer introduced in PR #814 and linking them to the coefficient families in the algebra-side MPDO RFP theorem.
- The trace-power formula $c^{(n)}_{\alpha,\beta,\gamma} = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^n)$ (arXiv:1606.00608 §4.5, lines 928–960 and Appendix C.3, lines 1830–1922) requires an explicit positive diagonal witness to be stated in Lean.

### Description

- `TNLean/MPS/MPDO/AlgebraStructure.lean`: adds `AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm`, a bundled structure combining a blocked $\chi$ family, positivity of all diagonal entries, and the blocked trace-power identity for `blockedStructureCoefficients`; adds the theorem `PositiveBlockedStructureChiTracePowerForm.eq_trace_pow` establishing $c^{(n)}_{i,j,k} = \operatorname{tr}(\chi_{i,j,k}^n)$.
- `blueprint/src/chapter/ch02b_mpdo.tex`: records the new definition and theorem with `\lean{}` and `\leanok` tags, keeping the blocked-basis scope restriction explicit.
- This remains a blocked-basis witness; the gap to the paper's uniform BNT-label chi family is documented in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.

### Testing

- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake build TNLean.MPS.MPDO.AlgebraStructure`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root .` (known unrelated baseline)
- `leanblueprint checkdecls` (known unrelated missing-declaration baseline; new declarations pass)
- Line-length and proof-integrity scans on `TNLean/MPS/MPDO/AlgebraStructure.lean`

---
Addresses #825

> [!NOTE]
> **Low Risk**
> Low risk: this is additive formalization work (new structures/lemmas and blueprint text) without changing existing computational behavior or core predicates.
>
> **Overview**
> Adds `AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm`, a bundled witness combining a blocked `χ` family, a proof that all diagonal entries are positive, and the blocked trace-power identity for `blockedStructureCoefficients`.
>
> Provides a convenience theorem `PositiveBlockedStructureChiTracePowerForm.eq_trace_pow` giving the `c^{(n)}_{i,j,k} = tr(χ_{n,i,j,k}^n)` formula from the bundled witness, and updates the MPDO blueprint to document the new definition/theorem (keeping the blocked-basis scope restriction explicit).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 319c9e81328d99fd30cbe5e43ae4db7ef96a84fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>