### PR TITLE
feat(PEPS): add injective-region decomposition

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -359,6 +359,7 @@ import TNLean.Channel.Determinant
 
 -- PEPS (exploratory)
 import TNLean.PEPS.Defs
+import TNLean.PEPS.InjectiveRegion
 import TNLean.PEPS.VirtualInsertion
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.IdentityInsertion

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -1,0 +1,127 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.SDiff
+import Mathlib.Data.Fintype.Basic
+
+/-!
+# Region decompositions for PEPS injectivity arguments
+
+The finite-region decomposition used in the proof that the union of two
+injective PEPS regions is injective consists of four canonical parts.
+
+For two regions \(A\) and \(B\), the source proof partitions the vertex set into
+four parts:
+
+* \(A \setminus B\),
+* \(A \cap B\),
+* \(B \setminus A\),
+* \((A \cup B)^c\).
+
+The elementary identities below are used in the tensor-level proof of the
+injective-union lemma.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, Lemma lem:injective_union](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [DecidableEq V]
+
+/-! ### Four-region decomposition for two finite regions -/
+
+/-- The part of the left region outside the right region. -/
+def regionOnlyLeft (A B : Finset V) : Finset V :=
+  A \ B
+
+/-- The overlap of two regions. -/
+def regionOverlap (A B : Finset V) : Finset V :=
+  A ∩ B
+
+/-- The part of the right region outside the left region. -/
+def regionOnlyRight (A B : Finset V) : Finset V :=
+  B \ A
+
+/-- The complement of the union of two regions. -/
+def regionOutsideUnion [Fintype V] (A B : Finset V) : Finset V :=
+  Finset.univ \ (A ∪ B)
+
+@[simp] theorem mem_regionOnlyLeft (A B : Finset V) (v : V) :
+    v ∈ regionOnlyLeft A B ↔ v ∈ A ∧ v ∉ B := by
+  simp [regionOnlyLeft]
+
+@[simp] theorem mem_regionOverlap (A B : Finset V) (v : V) :
+    v ∈ regionOverlap A B ↔ v ∈ A ∧ v ∈ B := by
+  simp [regionOverlap]
+
+@[simp] theorem mem_regionOnlyRight (A B : Finset V) (v : V) :
+    v ∈ regionOnlyRight A B ↔ v ∈ B ∧ v ∉ A := by
+  simp [regionOnlyRight]
+
+@[simp] theorem mem_regionOutsideUnion [Fintype V] (A B : Finset V) (v : V) :
+    v ∈ regionOutsideUnion A B ↔ v ∉ A ∧ v ∉ B := by
+  simp [regionOutsideUnion, not_or]
+
+/-- The left-only and overlap regions reconstruct the left region. -/
+theorem regionOnlyLeft_union_overlap (A B : Finset V) :
+    regionOnlyLeft A B ∪ regionOverlap A B = A := by
+  simpa [regionOnlyLeft, regionOverlap] using Finset.sdiff_union_inter A B
+
+/-- The overlap and right-only regions reconstruct the right region. -/
+theorem regionOverlap_union_onlyRight (A B : Finset V) :
+    regionOverlap A B ∪ regionOnlyRight A B = B := by
+  simpa [regionOverlap, regionOnlyRight, Finset.union_comm, Finset.inter_comm] using
+    Finset.sdiff_union_inter B A
+
+/-- The three regions inside `A ∪ B` reconstruct the union. -/
+theorem regionThreePart_union (A B : Finset V) :
+    regionOnlyLeft A B ∪ regionOverlap A B ∪ regionOnlyRight A B = A ∪ B := by
+  calc
+    regionOnlyLeft A B ∪ regionOverlap A B ∪ regionOnlyRight A B =
+        A ∪ regionOnlyRight A B := by rw [regionOnlyLeft_union_overlap]
+    _ = A ∪ B := by
+      simp [regionOnlyRight, Finset.union_sdiff_self_eq_union]
+
+/-- The four regions form a decomposition of the whole finite vertex set. -/
+theorem regionFourPart_union [Fintype V] (A B : Finset V) :
+    regionOnlyLeft A B ∪ regionOverlap A B ∪ regionOnlyRight A B ∪
+      regionOutsideUnion A B = Finset.univ := by
+  calc
+    regionOnlyLeft A B ∪ regionOverlap A B ∪ regionOnlyRight A B ∪
+        regionOutsideUnion A B =
+        (A ∪ B) ∪ (Finset.univ \ (A ∪ B)) := by
+          rw [regionThreePart_union, regionOutsideUnion]
+    _ = Finset.univ :=
+      Finset.union_sdiff_of_subset (Finset.subset_univ (A ∪ B))
+
+/-- The left-only region is disjoint from the overlap. -/
+theorem regionOnlyLeft_disjoint_overlap (A B : Finset V) :
+    Disjoint (regionOnlyLeft A B) (regionOverlap A B) := by
+  simpa [regionOnlyLeft, regionOverlap] using Finset.disjoint_sdiff_inter A B
+
+/-- The right-only region is disjoint from the overlap. -/
+theorem regionOnlyRight_disjoint_overlap (A B : Finset V) :
+    Disjoint (regionOnlyRight A B) (regionOverlap A B) := by
+  simpa [regionOnlyRight, regionOverlap, Finset.inter_comm] using
+    Finset.disjoint_sdiff_inter B A
+
+/-- The left-only and right-only regions are disjoint. -/
+theorem regionOnlyLeft_disjoint_onlyRight (A B : Finset V) :
+    Disjoint (regionOnlyLeft A B) (regionOnlyRight A B) := by
+  simpa [regionOnlyLeft, regionOnlyRight] using
+    (disjoint_sdiff_sdiff : Disjoint (A \ B) (B \ A))
+
+/-- The outside region is disjoint from the union of the three inside regions. -/
+theorem regionInside_disjoint_outside [Fintype V] (A B : Finset V) :
+    Disjoint (regionOnlyLeft A B ∪ regionOverlap A B ∪ regionOnlyRight A B)
+      (regionOutsideUnion A B) := by
+  rw [regionThreePart_union]
+  simpa [regionOutsideUnion] using
+    (disjoint_sdiff_self_right :
+      Disjoint (A ∪ B) ((Finset.univ : Finset V) \ (A ∪ B)))
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1053,10 +1053,56 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \section{Normal PEPS}
 
+\begin{definition}[Four-region decomposition for a union of regions]%
+    \label{def:peps_regionUnionDecomposition}
+    \lean{TNLean.PEPS.regionOnlyLeft, TNLean.PEPS.regionOverlap}
+    \lean{TNLean.PEPS.regionOnlyRight, TNLean.PEPS.regionOutsideUnion}
+    \leanok
+    Let $V$ be a finite vertex set. For two regions $A,B\subseteq V$,
+    define the four regions $A\setminus B$, $A\cap B$,
+    $B\setminus A$, and $V\setminus(A\cup B)$. These are the four
+    regions used in the proof of Lemma~\ref{lem:peps_injectiveRegion_union}.
+\end{definition}
+
+\begin{lemma}[Identities for the four-region decomposition]%
+    \label{lem:peps_regionUnionDecomposition_identities}
+    \lean{TNLean.PEPS.regionOnlyLeft_union_overlap}
+    \lean{TNLean.PEPS.regionOverlap_union_onlyRight}
+    \lean{TNLean.PEPS.regionThreePart_union, TNLean.PEPS.regionFourPart_union}
+    \leanok
+    \uses{def:peps_regionUnionDecomposition}
+    Let $V$ be a finite vertex set and let $A,B\subseteq V$. The left-only
+    and overlap regions reconstruct $A$, the overlap and right-only regions
+    reconstruct $B$, the three inside regions reconstruct $A\cup B$, and
+    all four regions reconstruct $V$.
+\end{lemma}
+\begin{proof}\leanok
+    Check membership of an arbitrary vertex in $A$ and in $B$.
+\end{proof}
+
+\begin{lemma}[Disjointness in the four-region decomposition]%
+    \label{lem:peps_regionUnionDecomposition_disjoint}
+    \lean{TNLean.PEPS.regionOnlyLeft_disjoint_overlap}
+    \lean{TNLean.PEPS.regionOnlyRight_disjoint_overlap}
+    \lean{TNLean.PEPS.regionOnlyLeft_disjoint_onlyRight}
+    \lean{TNLean.PEPS.regionInside_disjoint_outside}
+    \leanok
+    \uses{def:peps_regionUnionDecomposition,
+        lem:peps_regionUnionDecomposition_identities}
+    In the four-region decomposition, the left-only and right-only parts are
+    disjoint from the overlap and from each other. The union of the three
+    inside regions is disjoint from the outside region.
+\end{lemma}
+\begin{proof}\leanok
+    Use the standard disjointness identities for set difference and
+    intersection, together with the reconstruction of $A\cup B$.
+\end{proof}
+
 \begin{lemma}[Union of injective regions]%
     \label{lem:peps_injectiveRegion_union}
     \notready
-    \uses{def:IsVertexInjective}
+    \uses{def:IsVertexInjective, lem:peps_regionUnionDecomposition_identities,
+        lem:peps_regionUnionDecomposition_disjoint}
     If two regions of a PEPS are injective, then their union is injective.
     The proof in \cite[Section~3]{Molnar2018NormalPEPS} blocks the network into
     four parts \(A\setminus B\), \(A\cap B\), \(B\setminus A\), and


### PR DESCRIPTION
### Motivation

- Lemma `injective_union` in arXiv:1804.04964, Section 3 blocks two PEPS regions into four parts (`A \ B`, `A ∩ B`, `B \ A`, and `(A ∪ B)^c`) before applying injectivity arguments; this combinatorial decomposition must be formalized as a prerequisite.
- Continues the formalization of the normal PEPS fundamental theorem tracked in #1373 and #1374.
- Source: `Papers/1804.04964/paper_normal.tex`, lines 1324–1400, Lemma `injective_union`.

### Description

- Adds `TNLean/PEPS/InjectiveRegion.lean` introducing `TNLean.PEPS.InjectiveRegion` with the four finite regions (`A \ B`, `A ∩ B`, `B \ A`, `(A ∪ B)^c`), simp membership lemmas, union-reconstruction identities, and disjointness facts.
- Updates `TNLean.lean` to import the new module.
- Updates `blueprint/src/chapter/ch13a_peps_ft.tex` to document the decomposition and reference the new lemmas; the tensor-level union-injectivity node (`lem:peps_injectiveRegion_union`) remains marked not ready.
- Does not claim the full tensor-level `injective_union` theorem; only the combinatorial region infrastructure is formalized here.

### Testing

- `lake env lean TNLean/PEPS/InjectiveRegion.lean`
- `lake build TNLean.PEPS.InjectiveRegion`
- `lake env lean TNLean.lean` after building the new module
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root .` (known unrelated 64-item baseline remains; new declarations are synced)
- `leanblueprint checkdecls` (known unrelated missing-declaration baseline remains; new declarations are not missing)
- `git diff --check`; line-length scan; proof-integrity scan on the new Lean file

---
Addresses #1374

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Lean helper module and blueprint documentation for finset region decomposition; no existing PEPS proofs or core logic are modified beyond an additional root import.
> 
> **Overview**
> Adds `TNLean.PEPS.InjectiveRegion`, formalizing the four-part finite-region decomposition used in PEPS injectivity-union arguments (`A \ B`, `A ∩ B`, `B \ A`, and the complement of `A ∪ B`), along with simp membership lemmas, reconstruction-by-union identities, and key disjointness facts.
> 
> Exposes the new module via `TNLean.lean` and extends the PEPS fundamental-theorem blueprint to define the decomposition and cite the new Lean lemmas as prerequisites for the still-`notready` injective-union lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9848425cc33618a34df84c1d7323d7d1c131c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->