### PR TITLE
feat(PEPS): record normal blocking hypotheses

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -362,6 +362,7 @@ import TNLean.PEPS.Defs
 import TNLean.PEPS.InjectiveRegion
 import TNLean.PEPS.VirtualInsertion
 import TNLean.PEPS.Blocking
+import TNLean.PEPS.NormalBlocking
 import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.InsertionRealization
 import TNLean.PEPS.LocalGauge

--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -1,0 +1,250 @@
+import TNLean.PEPS.Defs
+
+/-!
+# Normal PEPS blocking hypotheses
+
+The normal PEPS proof in arXiv:1804.04964 first blocks the lattice into
+injective regions, then applies the same three-site injective-chain argument
+used for injective PEPS.  We record the finite-region hypotheses
+needed for that reduction.
+
+The hypotheses below do not prove that a given geometric square-lattice region
+is injective.  Instead they make explicit the assumptions carried by the normal
+theorem: local rectangular injectivity, edge-centred three-region blockings, and
+one-site-different injective regions with injective complements.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, Theorem 3 and Theorem normal](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+variable {G : SimpleGraph V}
+
+/-- An abstract predicate assigning injectivity to finite vertex regions.
+
+This is the region-level injectivity hypothesis used in the normal PEPS
+blocking argument of arXiv:1804.04964, Section 3.  It is distinct from
+one-vertex injectivity, since the source proof applies injectivity to blocked
+regions such as \(R\), \(S\), \(T\), and their complements.
+Source: arXiv:1804.04964, Section 3, lines 1407--1545 of
+`Papers/1804.04964/paper_normal.tex`. -/
+structure RegionInjectivityData (V : Type*) where
+  /-- The assertion that a finite vertex region is injective after blocking. -/
+  IsInjective : Finset V → Prop
+
+variable (ι : RegionInjectivityData V)
+
+/-- The complement of a finite region in the ambient vertex set. -/
+def regionComplement (R : Finset V) : Finset V :=
+  Finset.univ \ R
+
+@[simp] theorem mem_regionComplement (R : Finset V) (v : V) :
+    v ∈ regionComplement R ↔ v ∉ R := by
+  simp [regionComplement]
+
+section EdgeBlocking
+
+variable [LinearOrder V]
+
+/-- Edge-centred blocking into three injective regions.
+
+For every edge, the normal PEPS proof blocks the network into a red region, a
+blue region, and the complementary region.  The edge endpoints lie in the red
+and blue regions respectively, the three regions are pairwise disjoint, their
+union is the whole vertex set, and each region is injective.  This records the
+hypotheses needed before applying the three-site injective-chain step.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500
+of `Papers/1804.04964/paper_normal.tex`. -/
+structure NormalEdgeBlockingHypotheses (G : SimpleGraph V) where
+  /-- The first injective block around each edge. -/
+  red : Edge G → Finset V
+  /-- The second injective block around each edge. -/
+  blue : Edge G → Finset V
+  /-- The complementary injective block around each edge. -/
+  complement : Edge G → Finset V
+  /-- The left endpoint of the edge lies in the red block. -/
+  left_mem_red : ∀ e : Edge G, e.1.1 ∈ red e
+  /-- The right endpoint of the edge lies in the blue block. -/
+  right_mem_blue : ∀ e : Edge G, e.1.2 ∈ blue e
+  /-- The red block is injective. -/
+  red_injective : ∀ e : Edge G, ι.IsInjective (red e)
+  /-- The blue block is injective. -/
+  blue_injective : ∀ e : Edge G, ι.IsInjective (blue e)
+  /-- The complementary block is injective. -/
+  complement_injective : ∀ e : Edge G, ι.IsInjective (complement e)
+  /-- The red and blue blocks are disjoint. -/
+  red_disjoint_blue : ∀ e : Edge G, Disjoint (red e) (blue e)
+  /-- The red and complementary blocks are disjoint. -/
+  red_disjoint_complement : ∀ e : Edge G, Disjoint (red e) (complement e)
+  /-- The blue and complementary blocks are disjoint. -/
+  blue_disjoint_complement : ∀ e : Edge G, Disjoint (blue e) (complement e)
+  /-- The three edge-centred blocks cover the vertex set. -/
+  cover_univ : ∀ e : Edge G, red e ∪ blue e ∪ complement e = Finset.univ
+
+namespace NormalEdgeBlockingHypotheses
+
+variable {ι}
+
+/-- The edge-centred blocking supplies a three-region injective chain at every
+edge. -/
+theorem injective_chain_at_edge (h : NormalEdgeBlockingHypotheses ι G) (e : Edge G) :
+    ι.IsInjective (h.red e) ∧ ι.IsInjective (h.blue e) ∧
+      ι.IsInjective (h.complement e) :=
+  ⟨h.red_injective e, h.blue_injective e, h.complement_injective e⟩
+
+end NormalEdgeBlockingHypotheses
+
+end EdgeBlocking
+
+/-- One-site-different injective regions with injective complements.
+
+The general normal PEPS theorem after Theorem 3 assumes that, for every site,
+there are two injective regions with injective complements that differ exactly
+at that site.  This structure records that hypothesis.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+structure NormalOneSiteSeparationHypotheses where
+  /-- The region containing the distinguished site. -/
+  withSite : V → Finset V
+  /-- The comparison region omitting the distinguished site. -/
+  withoutSite : V → Finset V
+  /-- The region containing the distinguished site is injective. -/
+  withSite_injective : ∀ v : V, ι.IsInjective (withSite v)
+  /-- The comparison region is injective. -/
+  withoutSite_injective : ∀ v : V, ι.IsInjective (withoutSite v)
+  /-- The complement of the first region is injective. -/
+  withSite_complement_injective : ∀ v : V, ι.IsInjective (regionComplement (withSite v))
+  /-- The complement of the comparison region is injective. -/
+  withoutSite_complement_injective :
+    ∀ v : V, ι.IsInjective (regionComplement (withoutSite v))
+  /-- The distinguished site belongs to the first region. -/
+  site_mem_withSite : ∀ v : V, v ∈ withSite v
+  /-- The distinguished site does not belong to the comparison region. -/
+  site_notMem_withoutSite : ∀ v : V, v ∉ withoutSite v
+  /-- Away from the distinguished site, the two regions have the same vertices. -/
+  agree_away :
+    ∀ v w : V, w ≠ v → (w ∈ withSite v ↔ w ∈ withoutSite v)
+
+namespace NormalOneSiteSeparationHypotheses
+
+variable {ι}
+
+/-- The two regions in the one-site comparison differ exactly at the
+distinguished site. -/
+theorem mem_withSite_iff (h : NormalOneSiteSeparationHypotheses ι) (v w : V) :
+    w ∈ h.withSite v ↔ w = v ∨ w ∈ h.withoutSite v := by
+  constructor
+  · intro hw
+    by_cases hvw : w = v
+    · exact Or.inl hvw
+    · exact Or.inr ((h.agree_away v w hvw).mp hw)
+  · intro hw
+    rcases hw with rfl | hw
+    · exact h.site_mem_withSite w
+    · by_cases hvw : w = v
+      · subst w
+        exact absurd hw (h.site_notMem_withoutSite v)
+      · exact ((h.agree_away v w hvw).mpr hw)
+
+end NormalOneSiteSeparationHypotheses
+
+section GeneralBlocking
+
+variable [LinearOrder V]
+
+/-- General normal PEPS blocking hypotheses.
+
+These are the two hypotheses stated in the general normal PEPS theorem after
+Theorem 3 of arXiv:1804.04964: edge-centred blockings into three injective
+regions, and one-site-different injective regions with injective complements.
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+structure NormalPEPSBlockingHypotheses (G : SimpleGraph V) where
+  /-- Blocking around every edge gives a three-region injective chain. -/
+  edgeBlocking : NormalEdgeBlockingHypotheses ι G
+  /-- Every site admits one-site-different injective comparison regions. -/
+  oneSiteSeparation : NormalOneSiteSeparationHypotheses ι
+
+end GeneralBlocking
+
+/-- Rectangular injectivity hypotheses for the square-lattice normal PEPS
+theorem.
+
+Theorem 3 of arXiv:1804.04964 assumes injectivity for every \(2\times 3\) and
+\(3\times 2\) rectangle.  The hypotheses specify the two families of
+rectangular regions and their injectivity assertions, without choosing a
+coordinate model for the square lattice.
+Source: arXiv:1804.04964, Section 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. -/
+structure NormalRectangleInjectivityHypotheses where
+  /-- The finite regions regarded as \(2\times 3\) rectangles. -/
+  IsTwoByThreeRegion : Finset V → Prop
+  /-- The finite regions regarded as \(3\times 2\) rectangles. -/
+  IsThreeByTwoRegion : Finset V → Prop
+  /-- Every \(2\times 3\) rectangular region is injective. -/
+  twoByThree_injective : ∀ R : Finset V, IsTwoByThreeRegion R → ι.IsInjective R
+  /-- Every \(3\times 2\) rectangular region is injective. -/
+  threeByTwo_injective : ∀ R : Finset V, IsThreeByTwoRegion R → ι.IsInjective R
+
+/-- Square-lattice normal PEPS blocking hypotheses for Theorem 3.
+
+This records the hypotheses used in the translationally invariant square-lattice
+case: all \(2\times 3\) and \(3\times 2\) regions are injective, the lattice is
+large enough for the edge-blocking proof, and the specific \(R\), \(S\), and
+\(T\) regions used in the source proof are injective.  The geometric statement
+that the displayed regions are unions of smaller injective rectangles is left
+to the tensor-level region-injectivity theorem.
+
+**Scope restriction (R/S/T injectivity):** The injectivity assertions for
+\(R\), \(S\), and \(T\) are assumed directly, whereas arXiv:1804.04964,
+Section 3, derives them from the \(2\times 3\) and \(3\times 2\) rectangular
+injectivity assumptions using the union-of-injective-regions lemma. The regions
+\(R\), \(S\), and \(T\) are also not yet tied to the displayed square-lattice
+geometry, to the two rectangular-region predicates, or to a square-lattice
+coordinate and adjacency model; the size fields only record \(|V|=width\cdot
+height\). This structure therefore does not yet supply the translated per-edge
+red, blue, and complementary regions used in the proof of Theorem 3. Documented
+in `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Remaining mathematical
+obligations 1--5. Elimination: introduce the coordinate-aware square-lattice
+regions and derive these three assertions from rectangular injectivity after the
+tensor-level union theorem is formalized.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3 and its proof, lines
+1407--1504 of `Papers/1804.04964/paper_normal.tex`. -/
+structure NormalSquareBlockingRegions where
+  /-- Horizontal size parameter in Theorem 3. -/
+  width : ℕ
+  /-- Vertical size parameter in Theorem 3. -/
+  height : ℕ
+  /-- The square-lattice proof assumes width at least seven. -/
+  seven_le_width : 7 ≤ width
+  /-- The square-lattice proof assumes height at least seven. -/
+  seven_le_height : 7 ≤ height
+  /-- The finite vertex set has the cardinality of the \(width\times height\)
+  rectangular square-lattice region under consideration. -/
+  card_eq_width_mul_height : Fintype.card V = width * height
+  /-- The rectangular injectivity assumptions of Theorem 3. -/
+  rectangles : NormalRectangleInjectivityHypotheses ι
+  /-- The region \(R\) used in the one-site comparison. -/
+  regionR : Finset V
+  /-- The region \(S\) used in the one-site comparison. -/
+  regionS : Finset V
+  /-- The region \(T\) used as the complementary injective block. -/
+  regionT : Finset V
+  /-- Region \(R\) is injective. -/
+  regionR_injective : ι.IsInjective regionR
+  /-- Region \(S\) is injective. -/
+  regionS_injective : ι.IsInjective regionS
+  /-- Region \(T\) is injective. -/
+  regionT_injective : ι.IsInjective regionT
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1131,13 +1131,98 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \end{center}
 \end{lemma}
 
+\begin{definition}[Injectivity predicate for blocked regions]%
+    \label{def:peps_regionInjectivityData}
+    \lean{TNLean.PEPS.RegionInjectivityData}
+    \leanok
+    A region-injectivity hypothesis assigns to each finite vertex region the
+    assertion that the tensor obtained by blocking that region is injective.
+    This predicate is used for regions such as \(R\), \(S\), \(T\), and their
+    complements in the normal PEPS proof.
+\end{definition}
+
+\begin{definition}[Complement of a finite region]%
+    \label{def:peps_regionComplement}
+    \lean{TNLean.PEPS.regionComplement}
+    \leanok
+    For a finite vertex region \(R\subseteq V\), its complement is
+    \(V\setminus R\).
+\end{definition}
+
+\begin{definition}[Normal rectangular injectivity hypotheses]%
+    \label{def:peps_normalRectangleInjectivityHypotheses}
+    \lean{TNLean.PEPS.NormalRectangleInjectivityHypotheses}
+    \leanok
+    \uses{def:peps_regionInjectivityData}
+    In the square-lattice normal theorem, every \(2\times 3\) and
+    \(3\times 2\) rectangular region is assumed injective.  The corresponding
+    hypotheses specify which finite regions have these two shapes and assert
+    injectivity for all of them.
+\end{definition}
+
+\begin{definition}[Normal edge-blocking hypotheses]%
+    \label{def:peps_normalEdgeBlockingHypotheses}
+    \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses}
+    \leanok
+    \uses{def:peps_edge, def:peps_regionInjectivityData}
+    Around each edge, the normal proof assumes a blocking into three injective
+    regions: a red region containing one endpoint, a blue region containing the
+    other endpoint, and an injective complementary region.  The three regions
+    are pairwise disjoint and cover the whole vertex set.
+\end{definition}
+
+\begin{theorem}[Injectivity supplied by normal edge blocking]%
+    \label{thm:peps_normalEdgeBlockingHypotheses_injectiveChain}
+    \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.injective_chain_at_edge}
+    \leanok
+    \uses{def:peps_normalEdgeBlockingHypotheses}
+    For every edge, the normal edge-blocking hypotheses supply three injective
+    regions: the red region, the blue region, and the complementary region.
+\end{theorem}
+\begin{proof}\leanok
+    This is exactly the injectivity part of the edge-blocking hypotheses.
+\end{proof}
+
+\begin{definition}[Normal one-site separation hypotheses]%
+    \label{def:peps_normalOneSiteSeparationHypotheses}
+    \lean{TNLean.PEPS.NormalOneSiteSeparationHypotheses}
+    \leanok
+    \uses{def:peps_regionInjectivityData, def:peps_regionComplement}
+    For each site, the normal theorem assumes two injective regions with
+    injective complements that differ exactly at that site.  This is the
+    one-site comparison used after the edge gauges have been obtained.
+\end{definition}
+
+\begin{theorem}[Membership in a one-site separated region]%
+    \label{thm:peps_normalOneSiteSeparation_mem_withSite_iff}
+    \lean{TNLean.PEPS.NormalOneSiteSeparationHypotheses.mem_withSite_iff}
+    \leanok
+    \uses{def:peps_normalOneSiteSeparationHypotheses}
+    For the two regions associated to a site \(v\), a vertex \(w\) belongs to
+    the region containing \(v\) if and only if either \(w=v\), or \(w\)
+    belongs to the comparison region omitting \(v\).
+\end{theorem}
+\begin{proof}\leanok
+    If \(w=v\), use the distinguished-site membership and nonmembership
+    assumptions.  If \(w\neq v\), use the equality of the two regions away
+    from the distinguished site.
+\end{proof}
+
 \begin{definition}[Normal square-lattice blocking regions]%
     \label{def:peps_normalSquareBlockingRegions}
-    \notready
+    \lean{TNLean.PEPS.NormalSquareBlockingRegions}
+    \leanok
+    \uses{def:peps_normalRectangleInjectivityHypotheses,
+        def:peps_regionInjectivityData}
     In the translationally invariant square-lattice proof, the source paper
     assumes that every \(2\times 3\) and \(3\times 2\) region is injective.
-    Lemma~\ref{lem:peps_injectiveRegion_union} then implies that the regions
-    \(R\), \(S\), and \(T\) below are injective:
+    The formal statement here is the corresponding abstract, scope-restricted
+    hypothesis bundle: it records the rectangular injectivity assumptions, the
+    size bound \(n,m\geq 7\) with \(|V|=nm\), and three finite regions
+    \(R\), \(S\), and \(T\) whose injectivity is assumed directly.  It does
+    not yet assert that these regions are the displayed square-lattice unions,
+    nor that their translated variants give the edge-centred blocking around
+    every edge.  The source regions are:
     \begin{center}
         \TNTikZDiagram{TNPEPSNormalRegionsRS}{%
             \begin{tikzpicture}[tn picture, scale=0.90]
@@ -1172,12 +1257,15 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \notready
     \uses{lem:peps_injectiveRegion_union,
         def:peps_normalSquareBlockingRegions,
+        def:peps_normalEdgeBlockingHypotheses,
+        thm:peps_normalEdgeBlockingHypotheses_injectiveChain,
         thm:peps_edgeBlockedInsertionAlgebraIsomorphism}
     Under the square-lattice normality hypotheses of
-    \cite[Theorem~3]{Molnar2018NormalPEPS}, the tensor network may be blocked
-    around each edge into three injective regions. Hence the same three-site
-    injective-chain insertion argument used in the injective PEPS theorem
-    applies to the blocked normal PEPS:
+    \cite[Theorem~3]{Molnar2018NormalPEPS}, the regions \(R\), \(S\), and
+    \(T\), together with their translated variants, give an edge-centred
+    blocking into red, blue, and complementary injective regions.  These are
+    the regions on which the three-site injective-chain insertion argument is
+    applied:
     \begin{center}
         \TNTikZDiagram{TNPEPSNormalEdgeBlockingReduction}{%
             \begin{tikzpicture}[tn picture, scale=0.90]
@@ -1255,10 +1343,23 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Theorem~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
+\begin{definition}[Normal PEPS blocking hypotheses]%
+    \label{def:peps_normalPEPSBlockingHypotheses}
+    \lean{TNLean.PEPS.NormalPEPSBlockingHypotheses}
+    \leanok
+    \uses{def:peps_normalEdgeBlockingHypotheses,
+        def:peps_normalOneSiteSeparationHypotheses}
+    The general normal theorem assumes both the edge-centred blockings into
+    three injective regions and the one-site comparison regions with injective
+    complements.  These two assumptions are collected as the normal PEPS
+    blocking hypotheses.
+\end{definition}
+
 \begin{theorem}[Fundamental Theorem for normal PEPS]%
     \label{thm:fundamentalTheorem_normalPEPS}
     \notready
-    \uses{thm:peps_normalEdgeBlockingToInjectiveChain,
+    \uses{thm:peps_normalEdgeBlockingHypotheses_injectiveChain,
+        def:peps_normalPEPSBlockingHypotheses,
         thm:peps_oneVertexComplementComparison,
         def:GaugeEquivPEPS}
     Suppose two normal PEPS generate the same state, can be blocked into


### PR DESCRIPTION
### Motivation
- Formalize the blocking hypotheses used in the normal-PEPS fundamental theorem, following arXiv:1804.04964, lines 1407--1585 (regions $R$, $S$, $T$; edge-centred three-region blocking; one-site separation; Theorem 3 for the square-lattice case).
- The normal proof first obtains injective regions by blocking and then applies the three-site injective-chain insertion argument already used for injective PEPS; recording these hypotheses precisely is a prerequisite for that reduction.
- Continues the normal-PEPS route tracker (#1373).

### Description
- Add `TNLean/PEPS/NormalBlocking.lean` introducing:
  - A region-injectivity predicate and region-complement notion.
  - The edge-centred three-region blocking hypotheses: `2 × 3` and `3 × 2` rectangular injectivity and one-site separation (arXiv:1804.04964, ~lines 1407--1585).
  - The square-lattice hypothesis bundle for Theorem 3, including `n, m ≥ 7` size assumptions.
  - A lemma relating edge-blocking to the injective-chain framework.
- Wire `TNLean.PEPS.NormalBlocking` into the root import surface (`TNLean.lean`).
- Update `blueprint/src/chapter/ch13a_peps_ft.tex`: normal-region and edge-blocking nodes now point to the new formal statements; later normal fundamental theorems remain marked `\notready`.
- This PR records the hypotheses only; geometric injectivity of blocking regions and the final normal PEPS fundamental theorem remain separate steps.

### Testing
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build`
- `git diff --check`
- `leanblueprint checkdecls` confirms none of the new normal-blocking declarations are reported missing.

---
Closes #1375

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new Lean structures/lemmas and blueprint documentation) and mainly affect the PEPS exploratory area plus a new root import, with minimal impact on existing logic.
> 
> **Overview**
> Adds a new `PEPS.NormalBlocking` module that *formalizes the hypothesis bundles* used in the normal-PEPS blocking argument: a region-level injectivity predicate with `regionComplement`, edge-centred three-region blocking assumptions, one-site separation assumptions (plus a small membership lemma), and abstract square-lattice rectangular/size hypothesis records.
> 
> Wires the new module into the root `TNLean.lean` import surface and updates the blueprint chapter to reference these new Lean declarations and adjust the normal-PEPS theorem dependency graph accordingly (the downstream normal FT statements remain `\notready`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11b650a6b24053ce1ae39564c260079763a79cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->