### PR TITLE
refactor(PEPS): move region injectivity API

### DIFF
--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -33,6 +33,18 @@ variable {V : Type*} [DecidableEq V]
 
 /-! ### Four-region decomposition for two finite regions -/
 
+/-- An abstract predicate assigning injectivity to finite vertex regions.
+
+This is the region-level injectivity hypothesis used in the normal PEPS
+blocking argument of arXiv:1804.04964, Section 3.  It is distinct from
+one-vertex injectivity, since the source proof applies injectivity to blocked
+regions such as \(R\), \(S\), \(T\), and their complements.
+Source: arXiv:1804.04964, Section 3, lines 1407--1545 of
+`Papers/1804.04964/paper_normal.tex`. -/
+structure RegionInjectivityData (V : Type*) where
+  /-- The assertion that a finite vertex region is injective after blocking. -/
+  IsInjective : Finset V → Prop
+
 /-- The part of the left region outside the right region. -/
 def regionOnlyLeft (A B : Finset V) : Finset V :=
   A \ B
@@ -49,6 +61,10 @@ def regionOnlyRight (A B : Finset V) : Finset V :=
 def regionOutsideUnion [Fintype V] (A B : Finset V) : Finset V :=
   Finset.univ \ (A ∪ B)
 
+/-- The complement of a finite region in the ambient vertex set. -/
+def regionComplement [Fintype V] (R : Finset V) : Finset V :=
+  Finset.univ \ R
+
 @[simp] theorem mem_regionOnlyLeft (A B : Finset V) (v : V) :
     v ∈ regionOnlyLeft A B ↔ v ∈ A ∧ v ∉ B := by
   simp [regionOnlyLeft]
@@ -64,6 +80,10 @@ def regionOutsideUnion [Fintype V] (A B : Finset V) : Finset V :=
 @[simp] theorem mem_regionOutsideUnion [Fintype V] (A B : Finset V) (v : V) :
     v ∈ regionOutsideUnion A B ↔ v ∉ A ∧ v ∉ B := by
   simp [regionOutsideUnion, not_or]
+
+@[simp] theorem mem_regionComplement [Fintype V] (R : Finset V) (v : V) :
+    v ∈ regionComplement R ↔ v ∉ R := by
+  simp [regionComplement]
 
 /-- The left-only and overlap regions reconstruct the left region. -/
 theorem regionOnlyLeft_union_overlap (A B : Finset V) :

--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.Defs
+import TNLean.PEPS.InjectiveRegion
 
 /-!
 # Normal PEPS blocking hypotheses
@@ -26,27 +27,7 @@ namespace PEPS
 variable {V : Type*} [Fintype V] [DecidableEq V]
 variable {G : SimpleGraph V}
 
-/-- An abstract predicate assigning injectivity to finite vertex regions.
-
-This is the region-level injectivity hypothesis used in the normal PEPS
-blocking argument of arXiv:1804.04964, Section 3.  It is distinct from
-one-vertex injectivity, since the source proof applies injectivity to blocked
-regions such as \(R\), \(S\), \(T\), and their complements.
-Source: arXiv:1804.04964, Section 3, lines 1407--1545 of
-`Papers/1804.04964/paper_normal.tex`. -/
-structure RegionInjectivityData (V : Type*) where
-  /-- The assertion that a finite vertex region is injective after blocking. -/
-  IsInjective : Finset V → Prop
-
 variable (ι : RegionInjectivityData V)
-
-/-- The complement of a finite region in the ambient vertex set. -/
-def regionComplement (R : Finset V) : Finset V :=
-  Finset.univ \ R
-
-@[simp] theorem mem_regionComplement (R : Finset V) (v : V) :
-    v ∈ regionComplement R ↔ v ∉ R := by
-  simp [regionComplement]
 
 section EdgeBlocking
 


### PR DESCRIPTION
### Motivation

- `RegionInjectivityData`, `regionComplement`, and `mem_regionComplement` were defined in `NormalBlocking.lean`, but belong conceptually with the four-region decomposition (`A ∖ B`, `A ∩ B`, `B ∖ A`, `(A ∪ B)ᶜ`) used by `lem:peps_injectiveRegion_union` (arXiv:1804.04964, Section 3, lines 1324–1400; see #1374).
- Colocating this API in `InjectiveRegion.lean` narrows `NormalBlocking` to the hypothesis layer and prepares the region infrastructure needed for the coordinate-aware construction in #2004.

### Description

- Moved `RegionInjectivityData`, `regionComplement`, and `mem_regionComplement` from `TNLean/PEPS/NormalBlocking.lean` to `TNLean/PEPS/InjectiveRegion.lean`.
- Public declaration names are unchanged.
- `TNLean/PEPS/NormalBlocking.lean` now imports `InjectiveRegion` and retains its role as the normal-theorem hypothesis layer.

### Testing

- `lake build TNLean.PEPS.InjectiveRegion TNLean.PEPS.NormalBlocking`
- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean` (8731 jobs, completed successfully)
- `git diff --check`
- Line-length check and proof-integrity grep on touched files.

---
Refs #1374.
Refs #2004.

> [!NOTE]
> **Low Risk**
> Low risk refactor that relocates shared region-injectivity definitions and a region complement helper; main risk is broken imports/namespaces for downstream files.
>
> **Overview**
> Moves the region-level injectivity predicate `RegionInjectivityData` and the helper `regionComplement`/`mem_regionComplement` out of `NormalBlocking.lean` into `InjectiveRegion.lean`, colocating them with the four-region decomposition utilities.
>
> `NormalBlocking.lean` now imports `InjectiveRegion` and relies on the shared definitions, keeping the public names unchanged while narrowing `NormalBlocking` to hypothesis-layer structures.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14485dfe38e58f19a3fca9cdb85a0919e9f1322a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>