### PR TITLE
feat(MPS/MPDO): add BNT-label chi trace-power form

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -672,7 +672,7 @@ end BNTLabelCoefficientFamily
 
 /-- A positive BNT-label chi witness for Theorem IV.13(ii).
 
-This packages the paper's positive diagonal matrices
+The witness consists of the paper's positive diagonal matrices
 \(\chi_{\alpha,\beta,\gamma}\), indexed by fixed BNT labels and independent of
 the chain length, together with the positive-length trace-power identity for
 the BNT-label coefficient system.
@@ -819,10 +819,10 @@ theorem HasBlockedStructureChiTracePowerForm.eq_trace_matrix_pow
 
 /-- A positive blocked chi witness for the blocked multiplication coefficients.
 
-This packages the data corresponding to the positive diagonal matrices in
+The witness consists of the positive diagonal matrices in
 [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Theorem IV.13(ii)] together
-with the blocked-basis trace-power identity. It is a data-carrying version of
-`HasBlockedStructureChiTracePowerForm`, with positivity included as a field.
+with the blocked-basis trace-power identity. It records
+`HasBlockedStructureChiTracePowerForm` together with positivity.
 
 **Scope restriction (blocked bases):** As for
 `BlockedStructureChiFamily`, this is the length-dependent blocked-basis analogue

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -626,9 +626,9 @@ Here `Λ` is the type of BNT labels.  The coefficient `coeff L α β γ` is the
 scalar multiplying the length-`L` BNT operator with label `γ` in the product of
 the length-`L` operators with labels `α` and `β`.
 
-This structure only stores the coefficient system, and its wrapper records that
-the indices are BNT labels from the paper rather than chosen blocked-basis
-indices.  It does not yet assert the same-length product formula
+This structure only stores the coefficient system.  Its role is to keep the
+BNT-label indices from the paper distinct from chosen blocked-basis indices.  It
+does not yet assert the same-length product formula
 \[
   O_L(M_\alpha)O_L(M_\beta)
     = \sum_\gamma c^{(L)}_{\alpha,\beta,\gamma}O_L(M_\gamma),
@@ -637,8 +637,9 @@ nor does it compare these coefficients with the chosen blocked-basis
 coefficients of the support algebras.  Those two comparison steps are the
 remaining obligations recorded in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 1925--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
+Appendix C.4, lines 1925--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure BNTLabelCoefficientFamily (Λ : Type*) where
   /-- The coefficient \(c_{\alpha,\beta,\gamma}^{(L)}\). -/
   coeff : ℕ → Λ → Λ → Λ → ℂ

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -20,10 +20,11 @@ arXiv:1606.00608, Section 4.5.
 The paper's full statement uses coefficient systems
 $c_{\alpha,\beta,\gamma}^{(L)} =
   \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$
-and BNT data. That full coefficient layer is not yet formalized here. What we do
-formalize is the stationary C$^*$-algebra structure naturally attached to an MPO
-whose blocked transfer maps are idempotent, together with a first explicit
-coordinate layer obtained by choosing bases of the blocked support algebras.
+and BNT data. This file records the BNT-label coefficient statement separately
+from the currently available blocked-basis coordinate construction. It also
+formalizes the stationary C$^*$-algebra structure naturally attached to an MPO
+whose blocked transfer maps are idempotent, together with explicit coordinates
+obtained by choosing bases of the blocked support algebras.
 
 More precisely, `AlgebraStructureData` now contains a genuine tower of support
 `StarSubalgebra`s together with multiplication and inclusion maps realized by the
@@ -47,18 +48,21 @@ with the blocking length.
 
 ## Diagonal $\chi$-matrices and the trace-power formula
 
-On top of the blocked-coefficient layer, this file now formalizes the target
-shape of Theorem IV.13(ii): the special diagonal matrices
-$\chi_{\alpha,\beta,\gamma}$ are represented as a `DiagonalChiFamily`, and the
-identity $c_{\alpha,\beta,\gamma}^{(L)} = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$
-is encoded as the `HasChiTracePowerForm` predicate. For the blocked support
-tower, `AlgebraStructureData.BlockedStructureChiFamily`,
+In addition to the blocked coefficients, this file now formalizes the
+statement shape of Theorem IV.13(ii): the special diagonal matrices
+$\chi_{\alpha,\beta,\gamma}$ are represented as a `DiagonalChiFamily`, the
+BNT-label coefficient system is represented as `BNTLabelCoefficientFamily`, and
+`PositiveBNTLabelChiTracePowerForm` records positivity together with the
+positive-length identity
+$c_{\alpha,\beta,\gamma}^{(L)} =
+  \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$.
+For the blocked support tower, `AlgebraStructureData.BlockedStructureChiFamily`,
 `AlgebraStructureData.HasBlockedStructureChiTracePowerForm`, and
 `AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm` record the
 length-dependent blocked-basis analogue for
 `AlgebraStructureData.blockedStructureCoefficients`, including positivity of
-the diagonal entries. This is not yet the paper's uniform BNT-label chi family;
-the deviation is recorded in
+the diagonal entries. The remaining gap between the BNT-label system and the
+blocked-basis system is recorded in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. The basic trace-power
 identity `tr(χ_{α,β,γ}^L) = \sum_k \chi_{\alpha,\beta,\gamma,k}^L` is proved
 directly from `Matrix.diagonal_pow` and `Matrix.trace_diagonal`.
@@ -614,6 +618,91 @@ theorem HasChiTracePowerForm.eq_trace_matrix_pow {I : Type*}
     c L α β γ = (χ.matrix α β γ ^ L).trace := by
   rw [h L α β γ, χ.trace_matrix_pow]
 
+/-- The BNT-label structure coefficients \(c_{\alpha,\beta,\gamma}^{(L)}\)
+appearing in the same-length operator algebra of
+arXiv:1606.00608, Theorem IV.13(ii).
+
+Here `Λ` is the type of BNT labels.  The coefficient `coeff L α β γ` is the
+scalar multiplying the length-`L` BNT operator with label `γ` in the product of
+the length-`L` operators with labels `α` and `β`.
+
+This structure only stores the coefficient system.  It does not yet assert the
+same-length product formula
+\[
+  O_L(M_\alpha)O_L(M_\beta)
+    = \sum_\gamma c^{(L)}_{\alpha,\beta,\gamma}O_L(M_\gamma),
+\]
+nor does it compare these coefficients with the chosen blocked-basis
+coefficients of the support algebras.  Those two comparison steps are the
+remaining obligations recorded in
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 928--960, and Appendix C.3,
+lines 1830--1922 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTLabelCoefficientFamily (Λ : Type*) where
+  /-- The coefficient \(c_{\alpha,\beta,\gamma}^{(L)}\). -/
+  coeff : ℕ → Λ → Λ → Λ → ℂ
+
+namespace BNTLabelCoefficientFamily
+
+variable {Λ : Type*} (c : BNTLabelCoefficientFamily Λ)
+
+/-- Positive-length trace-power compatibility for BNT-label coefficients.
+
+This is the faithful quantifier shape of arXiv:1606.00608, Theorem IV.13(ii):
+for every positive chain length `L`, the coefficient
+`c^{(L)}_{\alpha,\beta,\gamma}` is the trace of the `L`-th power of the same
+diagonal matrix `χ_{\alpha,\beta,\gamma}`.  The matrix family is independent of
+`L`; only the exponent changes. -/
+def HasPositiveLengthChiTracePowerForm (χ : DiagonalChiFamily Λ) : Prop :=
+  ∀ L : ℕ, 0 < L → ∀ α β γ : Λ,
+    c.coeff L α β γ = χ.tracePowerCoeff α β γ L
+
+/-- Trace reformulation of positive-length BNT-label trace-power form. -/
+theorem HasPositiveLengthChiTracePowerForm.eq_trace_matrix_pow
+    {χ : DiagonalChiFamily Λ} (h : c.HasPositiveLengthChiTracePowerForm χ)
+    (L : ℕ) (hL : 0 < L) (α β γ : Λ) :
+    c.coeff L α β γ = (χ.matrix α β γ ^ L).trace := by
+  rw [h L hL α β γ, χ.trace_matrix_pow]
+
+end BNTLabelCoefficientFamily
+
+/-- A positive BNT-label chi witness for Theorem IV.13(ii).
+
+This packages the paper's positive diagonal matrices
+\(\chi_{\alpha,\beta,\gamma}\), indexed by fixed BNT labels and independent of
+the chain length, together with the positive-length trace-power identity for
+the BNT-label coefficient system.
+
+This is not yet a proof of Theorem IV.13(ii) from an MPDO tensor: it is the
+paper-faithful coefficient statement to be constructed.  The construction of
+this witness, the same-length product formula, and the comparison to blocked
+bases remain the obligations described in
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 928--960, and Appendix C.3,
+lines 1830--1922 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure PositiveBNTLabelChiTracePowerForm
+    {Λ : Type*} (c : BNTLabelCoefficientFamily Λ) where
+  /-- The length-independent BNT-label chi family. -/
+  chi : DiagonalChiFamily Λ
+  /-- Positivity of every diagonal entry. -/
+  posEntries : chi.PosEntries
+  /-- Positive-length trace-power form for the BNT-label coefficients. -/
+  tracePower : c.HasPositiveLengthChiTracePowerForm chi
+
+namespace PositiveBNTLabelChiTracePowerForm
+
+variable {Λ : Type*} {c : BNTLabelCoefficientFamily Λ}
+
+/-- A positive BNT-label chi witness gives the trace formula at every positive
+length. -/
+theorem eq_trace_pow (h : PositiveBNTLabelChiTracePowerForm c)
+    (L : ℕ) (hL : 0 < L) (α β γ : Λ) :
+    c.coeff L α β γ = (h.chi.matrix α β γ ^ L).trace :=
+  BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.eq_trace_matrix_pow
+    (c := c) h.tracePower L hL α β γ
+
+end PositiveBNTLabelChiTracePowerForm
+
 namespace AlgebraStructureData
 
 /-- A diagonal chi family indexed by the multiplication coefficients of a
@@ -631,7 +720,7 @@ fixed BNT labels and are uniform in the length parameter. This structure is
 instead indexed by the chosen blocked bases, so its data may depend on `n`.
 This deviation is documented in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. Elimination: introduce
-the BNT-label coefficient layer and a comparison map from blocked bases to those
+the BNT-label coefficients and a comparison map from blocked bases to those
 labels, then recover the uniform chi family from the paper's Appendix C.3. -/
 structure BlockedStructureChiFamily (data : AlgebraStructureData d D) where
   /-- For each blocked length `n`, a diagonal family on the disjoint union of

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -626,8 +626,9 @@ Here `Λ` is the type of BNT labels.  The coefficient `coeff L α β γ` is the
 scalar multiplying the length-`L` BNT operator with label `γ` in the product of
 the length-`L` operators with labels `α` and `β`.
 
-This structure only stores the coefficient system.  It does not yet assert the
-same-length product formula
+This structure only stores the coefficient system, and its wrapper records that
+the indices are BNT labels from the paper rather than chosen blocked-basis
+indices.  It does not yet assert the same-length product formula
 \[
   O_L(M_\alpha)O_L(M_\beta)
     = \sum_\gamma c^{(L)}_{\alpha,\beta,\gamma}O_L(M_\gamma),
@@ -636,8 +637,8 @@ nor does it compare these coefficients with the chosen blocked-basis
 coefficients of the support algebras.  Those two comparison steps are the
 remaining obligations recorded in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 928--960, and Appendix C.3,
-lines 1830--1922 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
+lines 1925--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure BNTLabelCoefficientFamily (Λ : Type*) where
   /-- The coefficient \(c_{\alpha,\beta,\gamma}^{(L)}\). -/
   coeff : ℕ → Λ → Λ → Λ → ℂ
@@ -652,7 +653,9 @@ This is the faithful quantifier shape of arXiv:1606.00608, Theorem IV.13(ii):
 for every positive chain length `L`, the coefficient
 `c^{(L)}_{\alpha,\beta,\gamma}` is the trace of the `L`-th power of the same
 diagonal matrix `χ_{\alpha,\beta,\gamma}`.  The matrix family is independent of
-`L`; only the exponent changes. -/
+`L`; only the exponent changes.  Unlike the unrestricted function-level
+predicate `HasChiTracePowerForm`, this predicate has exactly the positive-length
+quantifier used for Theorem IV.13(ii). -/
 def HasPositiveLengthChiTracePowerForm (χ : DiagonalChiFamily Λ) : Prop :=
   ∀ L : ℕ, 0 < L → ∀ α β γ : Λ,
     c.coeff L α β γ = χ.tracePowerCoeff α β γ L
@@ -678,8 +681,8 @@ paper-faithful coefficient statement to be constructed.  The construction of
 this witness, the same-length product formula, and the comparison to blocked
 bases remain the obligations described in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 928--960, and Appendix C.3,
-lines 1830--1922 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
+lines 1925--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure PositiveBNTLabelChiTracePowerForm
     {Λ : Type*} (c : BNTLabelCoefficientFamily Λ) where
   /-- The length-independent BNT-label chi family. -/

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1212,6 +1212,77 @@ the elementary trace-power identity for diagonal matrices.
     form''---is obtained by quantifying over $\chi$.
 \end{definition}
 
+\begin{definition}[BNT-label coefficient family]%
+    \label{def:mpdo_bnt_label_coefficient_family}
+    \lean{MPOTensor.BNTLabelCoefficientFamily}
+    \leanok
+    The same-length coefficient system
+    \(c^{(L)}_{\alpha,\beta,\gamma}\) from Theorem~IV.13(ii), indexed by
+    fixed BNT labels \(\alpha,\beta,\gamma\).  The coefficient is attached to
+    the length-\(L\) product
+    \(O_L(M_\alpha)O_L(M_\beta)\), not to the blocked-basis multiplication
+    \(\mathcal A_n\times\mathcal A_n\to\mathcal A_{2n}\).
+\end{definition}
+
+\begin{definition}[Positive-length BNT-label trace-power form]%
+    \label{def:mpdo_bnt_label_positive_length_chi_trace_power_form}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm}
+    \leanok
+    \uses{def:mpdo_bnt_label_coefficient_family,
+        def:mpdo_diagonal_chi_family}
+    A BNT-label coefficient system and a diagonal \(\chi\)-family are
+    compatible when, for every positive length \(L\),
+    \[
+        c^{(L)}_{\alpha,\beta,\gamma}
+        = \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr).
+    \]
+    The same matrix \(\chi_{\alpha,\beta,\gamma}\) is used for all positive
+    \(L\).
+\end{definition}
+
+\begin{theorem}[BNT-label coefficient as a positive-length trace power]%
+    \label{thm:mpdo_bnt_label_chi_eq_trace_matrix_pow}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.
+        eq_trace_matrix_pow}
+    \leanok
+    \uses{def:mpdo_bnt_label_positive_length_chi_trace_power_form,
+        thm:mpdo_trace_matrix_pow}
+    Under positive-length BNT-label trace-power form, for every \(L>0\),
+    \(c^{(L)}_{\alpha,\beta,\gamma}\) is the trace of
+    \(\chi_{\alpha,\beta,\gamma}^{L}\).
+\end{theorem}
+\begin{proof}\leanok
+    Combine the defining positive-length trace-power identity with the trace
+    formula for powers of a diagonal matrix.
+\end{proof}
+
+\begin{definition}[Positive BNT-label \(\chi\) trace-power witness]%
+    \label{def:mpdo_positive_bnt_label_chi_trace_power_form}
+    \lean{MPOTensor.PositiveBNTLabelChiTracePowerForm}
+    \leanok
+    \uses{def:mpdo_bnt_label_positive_length_chi_trace_power_form}
+    A positive BNT-label \(\chi\) witness consists of a length-independent
+    diagonal \(\chi_{\alpha,\beta,\gamma}\)-family, positivity of every
+    diagonal entry, and the positive-length trace-power identity for the
+    BNT-label coefficients.  This is the coefficient statement of
+    Theorem~IV.13(ii); constructing the witness from an MPDO tensor and
+    comparing it to blocked bases remain separate obligations.
+\end{definition}
+
+\begin{theorem}[Positive BNT-label witness gives trace powers]%
+    \label{thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
+    \lean{MPOTensor.PositiveBNTLabelChiTracePowerForm.eq_trace_pow}
+    \leanok
+    \uses{def:mpdo_positive_bnt_label_chi_trace_power_form,
+        thm:mpdo_bnt_label_chi_eq_trace_matrix_pow}
+    A positive BNT-label \(\chi\) witness gives, for every \(L>0\), the formula
+    \(c^{(L)}_{\alpha,\beta,\gamma}
+      =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})\).
+\end{theorem}
+\begin{proof}\leanok
+    Apply the trace reformulation of the trace-power field of the witness.
+\end{proof}
+
 \begin{definition}[Blocked $\chi$ family for multiplication coefficients]%
     \label{def:mpdo_blocked_structure_chi_family}
     \lean{MPOTensor.AlgebraStructureData.BlockedStructureChiFamily}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1260,7 +1260,8 @@ the elementary trace-power identity for diagonal matrices.
     \label{def:mpdo_positive_bnt_label_chi_trace_power_form}
     \lean{MPOTensor.PositiveBNTLabelChiTracePowerForm}
     \leanok
-    \uses{def:mpdo_bnt_label_positive_length_chi_trace_power_form}
+    \uses{def:mpdo_bnt_label_positive_length_chi_trace_power_form,
+        def:mpdo_diagonal_chi_family}
     A positive BNT-label \(\chi\) witness consists of a length-independent
     diagonal \(\chi_{\alpha,\beta,\gamma}\)-family, positivity of every
     diagonal entry, and the positive-length trace-power identity for the
@@ -1280,7 +1281,8 @@ the elementary trace-power identity for diagonal matrices.
       =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})\).
 \end{theorem}
 \begin{proof}\leanok
-    Apply the trace reformulation of the trace-power field of the witness.
+    Apply the trace reformulation of the positive-length trace-power identity
+    from the witness.
 \end{proof}
 
 \begin{definition}[Blocked $\chi$ family for multiplication coefficients]%
@@ -1373,7 +1375,7 @@ the elementary trace-power identity for diagonal matrices.
     \(c^{(n)}_{i,j,k}=\operatorname{tr}(\chi_{n,i,j,k}^{\,n})\).
 \end{theorem}
 \begin{proof}\leanok
-    Apply the trace reformulation of the trace-power field of the witness.
+    Apply the trace reformulation of the trace-power identity from the witness.
 \end{proof}
 
 \section{Commuting form and GSNNCH}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1357,7 +1357,7 @@ the elementary trace-power identity for diagonal matrices.
     A positive blocked $\chi$ trace-power witness consists of a blocked
     $\chi$ family, positivity of all its diagonal entries, and the
     positive-length trace-power identity for the blocked multiplication
-    coefficients. This packages the blocked-basis analogue of the positive
+    coefficients. This is the blocked-basis analogue of the positive
     diagonal matrices in
     \cite[Theorem~IV.13(ii)]{Cirac2017MPDO_AnnPhys}; the uniform BNT-label gap
     is recorded in

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -101,27 +101,33 @@ is therefore the source length of the two factors, not the codomain length.
 This convention is only a blocked-basis analogue; it is not a replacement for
 the same-length multiplication statement in Theorem~IV.13(ii).
 
+This note isolates the chi-uniformity and same-length coefficient comparison
+part of Theorem~IV.13(ii).  The idempotent condition
+\[
+    m_\gamma =
+      \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma} m_\alpha m_\beta
+\]
+from paper lines 981--985 is a separate condition in the same theorem; it is
+not represented by the blocked-basis trace-power predicate.
+
 Consequently,
 \leanid{MPOTensor.AlgebraStructureData.HasBlockedStructureChiTracePowerForm}
 should not be cited as a formalization of Theorem~IV.13(ii). It is a local
 blocked-basis coefficient statement, useful only after the
 uniform BNT-label statement has been separated from the chosen blocked bases.
 
-\section{Formalized coefficient statements and remaining elimination plan}
+\section{BNT-label coefficient objects and remaining elimination plan}
 
-The formalization now contains two coefficient statements:
-\begin{itemize}
-    \item \leanid{MPOTensor.BNTLabelCoefficientFamily}, the same-length
-        coefficient family \(c^{(L)}_{\alpha,\beta,\gamma}\) indexed by fixed
-        BNT labels;
-    \item \leanid{MPOTensor.PositiveBNTLabelChiTracePowerForm}, the positive
-        diagonal \(\chi_{\alpha,\beta,\gamma}\)-witness with the
-        positive-length trace-power identity.
-\end{itemize}
-
-These declarations state only the target coefficient objects.  They do not yet construct
-the coefficients or \(\chi\)-matrices from an MPDO tensor, and they do not yet
-compare BNT-label coefficients with the chosen blocked bases.
+The same-length coefficient family \(c^{(L)}_{\alpha,\beta,\gamma}\), indexed
+by fixed BNT labels, is represented separately from the blocked-basis
+coefficients.\footnote{\leanid{MPOTensor.BNTLabelCoefficientFamily}.}  A
+positive BNT-label \(\chi\)-witness consists of a length-independent diagonal
+family \(\chi_{\alpha,\beta,\gamma}\), positivity of every diagonal entry, and
+the positive-length trace-power identity.\footnote{%
+\leanid{MPOTensor.PositiveBNTLabelChiTracePowerForm}.}
+These declarations specify the BNT-label coefficient objects, but they do not
+yet construct the coefficients or \(\chi\)-matrices from an MPDO tensor, and
+they do not yet compare BNT-label coefficients with the chosen blocked bases.
 
 To eliminate the remaining gap, the formalization should introduce:
 \begin{enumerate}
@@ -134,6 +140,10 @@ To eliminate the remaining gap, the formalization should introduce:
     \item construction of the positive BNT-label
         \(\chi_{\alpha,\beta,\gamma}\)-witness from the paper's Appendix C.3
         and C.4 hypotheses;
+    \item the idempotent condition
+        \(m_\gamma =
+          \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}
+          m_\alpha m_\beta\);
     \item the blocked-basis trace-power statement, with its source-length
         exponent convention, as a derived corollary of the uniform BNT-label
         theorem, rather than as the theorem itself.

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -41,7 +41,7 @@ blocked length \(n\) in the Lean development.
 
 \section{Formalized blocked-basis analogue}
 
-The current blocked coefficient layer in
+The current blocked coefficient construction in
 \path{TNLean/MPS/MPDO/AlgebraStructure.lean} chooses bases of the support
 algebras \(\mathcal A_n\). Its multiplication coefficients have indices
 \[
@@ -104,23 +104,36 @@ the same-length multiplication statement in Theorem~IV.13(ii).
 Consequently,
 \leanid{MPOTensor.AlgebraStructureData.HasBlockedStructureChiTracePowerForm}
 should not be cited as a formalization of Theorem~IV.13(ii). It is a local
-blocked-basis interface for the coefficient layer, useful only after the
+blocked-basis coefficient statement, useful only after the
 uniform BNT-label statement has been separated from the chosen blocked bases.
 
-\section{Elimination plan}
+\section{Formalized coefficient statements and remaining elimination plan}
 
-To eliminate this gap, the formalization should introduce:
+The formalization now contains two coefficient statements:
+\begin{itemize}
+    \item \leanid{MPOTensor.BNTLabelCoefficientFamily}, the same-length
+        coefficient family \(c^{(L)}_{\alpha,\beta,\gamma}\) indexed by fixed
+        BNT labels;
+    \item \leanid{MPOTensor.PositiveBNTLabelChiTracePowerForm}, the positive
+        diagonal \(\chi_{\alpha,\beta,\gamma}\)-witness with the
+        positive-length trace-power identity.
+\end{itemize}
+
+These declarations state only the target coefficient objects.  They do not yet construct
+the coefficients or \(\chi\)-matrices from an MPDO tensor, and they do not yet
+compare BNT-label coefficients with the chosen blocked bases.
+
+To eliminate the remaining gap, the formalization should introduce:
 \begin{enumerate}
-    \item the BNT-label coefficient family used in Theorem~IV.13(ii);
-    \item the positive diagonal matrices
-        \(\chi_{\alpha,\beta,\gamma}\) indexed by BNT-label triples,
-        independent of the length parameter;
     \item a comparison theorem relating the BNT-label coefficients to the
         chosen blocked bases of \(\mathcal A_n\);
     \item a same-length operator-algebra product statement matching
         \(O_L(M_\alpha)O_L(M_\beta)\), together with the comparison to the
         blocked support-algebra product
         \(\mathcal A_n \times \mathcal A_n \to \mathcal A_{2n}\);
+    \item construction of the positive BNT-label
+        \(\chi_{\alpha,\beta,\gamma}\)-witness from the paper's Appendix C.3
+        and C.4 hypotheses;
     \item the blocked-basis trace-power statement, with its source-length
         exponent convention, as a derived corollary of the uniform BNT-label
         theorem, rather than as the theorem itself.


### PR DESCRIPTION
### Motivation

- arXiv:1606.00608 (CPSV 2017), Theorem IV.13(ii) asserts that there exist diagonal matrices χ_{α,β,γ} with positive entries, indexed by BNT labels α, β, γ independent of the length parameter L, such that c^{(L)}_{α,β,γ} = tr(χ_{α,β,γ}^L) for every positive length L.
- PR #1999 introduced a blocked-basis analogue (`HasBlockedStructureChiTracePowerForm`) that does not match this uniform BNT-label statement; the gap is documented in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
- This PR implements step 1 of the elimination plan from #2000: introduce the BNT-label coefficient family and the corresponding chi predicate as the paper-faithful interface.

### Description

- `TNLean/MPS/MPDO/AlgebraStructure.lean`: introduces `BNTLabelCoefficientFamily` for the same-length coefficients c^{(L)}_{α,β,γ}, the predicate `HasPositiveLengthChiTracePowerForm` asserting the trace-power formula c^{(L)}_{α,β,γ} = tr(χ^L) for a positive diagonal χ, the bundled structure `PositiveBNTLabelChiTracePowerForm`, and trace-to-matrix-power reformulations.
- `blueprint/src/chapter/ch02b_mpdo.tex`: adds blueprint entries separating the new BNT-label coefficient statement from the blocked-basis analogue.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`: updated to reflect the split and to record that the same-length product construction and comparison with blocked bases remain outstanding.
- Does not close #2000: the same-length operator-algebra product O_L(M_α) · O_L(M_β) and comparison with blocked bases are still missing.

### Testing

- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake build`
- `leanblueprint checkdecls`: pre-existing failures for future MPS/PEPS declarations only; the new MPDO declarations are not among the missing names.

---
Addresses #2000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean structures/predicates and blueprint/docs text without changing existing MPDO algebra logic; risk is mainly name/API churn for downstream proofs.
> 
> **Overview**
> Separates the paper’s **uniform BNT-label** coefficient statement from the existing blocked-basis analogue by introducing `BNTLabelCoefficientFamily`, a positive-length trace-power predicate (`HasPositiveLengthChiTracePowerForm`), and a bundled positive witness `PositiveBNTLabelChiTracePowerForm`, plus trace-to-matrix-power lemmas.
> 
> Updates the blueprint and `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` to document this split and clarify that the same-length product statement and comparison to blocked bases are still outstanding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11673eef5bc43bc0627977ad4934911fcaa9bbcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->