### PR TITLE
feat(MPS/MPDO): state BNT same-length product form

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -52,8 +52,9 @@ In addition to the blocked coefficients, this file now formalizes the
 statement shape of Theorem IV.13(ii): the special diagonal matrices
 $\chi_{\alpha,\beta,\gamma}$ are represented as a `DiagonalChiFamily`, the
 BNT-label coefficient system is represented as `BNTLabelCoefficientFamily`, and
-`PositiveBNTLabelChiTracePowerForm` records positivity together with the
-positive-length identity
+`BNTLabelOperatorFamily.HasSameLengthProductForm` records the same-length
+product identity.  The structure `PositiveBNTLabelChiTracePowerForm` records
+positivity together with the positive-length identity
 $c_{\alpha,\beta,\gamma}^{(L)} =
   \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$.
 For the blocked support tower, `AlgebraStructureData.BlockedStructureChiFamily`,
@@ -627,14 +628,15 @@ scalar multiplying the length-`L` BNT operator with label `γ` in the product of
 the length-`L` operators with labels `α` and `β`.
 
 This structure only stores the coefficient system.  Its role is to keep the
-BNT-label indices from the paper distinct from chosen blocked-basis indices.  It
-does not yet assert the same-length product formula
+BNT-label indices from the paper distinct from chosen blocked-basis indices.
+The same-length product formula is recorded separately by
+`BNTLabelOperatorFamily.HasSameLengthProductForm`:
 \[
   O_L(M_\alpha)O_L(M_\beta)
     = \sum_\gamma c^{(L)}_{\alpha,\beta,\gamma}O_L(M_\gamma),
 \]
-nor does it compare these coefficients with the chosen blocked-basis
-coefficients of the support algebras.  Those two comparison steps are the
+It also does not yet compare these coefficients with the chosen blocked-basis
+coefficients of the support algebras.  That comparison step is one of the
 remaining obligations recorded in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
@@ -670,6 +672,57 @@ theorem HasPositiveLengthChiTracePowerForm.eq_trace_matrix_pow
 
 end BNTLabelCoefficientFamily
 
+/-- BNT-label operators \(O_L(M_\alpha)\) at each positive chain length.
+
+Here `Λ` is the fixed BNT-label type, and `O L` is the ambient algebra of
+length-`L` operators.  This structure records only the family
+\(\alpha \mapsto O_L(M_\alpha)\) for each length; the product law is the
+separate predicate `BNTLabelOperatorFamily.HasSameLengthProductForm`.
+Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTLabelOperatorFamily (Λ : Type*) (O : ℕ → Type*) where
+  /-- The length-`L` operator \(O_L(M_\alpha)\). -/
+  operator : ∀ L : ℕ, Λ → O L
+
+namespace BNTLabelOperatorFamily
+
+variable {Λ : Type*} {O : ℕ → Type*} (op : BNTLabelOperatorFamily Λ O)
+
+/-- Same-length BNT product formula from Theorem IV.13(ii).
+
+For every positive length `L`, the product of the two length-`L` BNT operators
+with labels `α` and `β` expands again in the length-`L` BNT operators, with
+coefficients \(c^{(L)}_{\alpha,\beta,\gamma}\):
+\[
+  O_L(M_\alpha)O_L(M_\beta)
+    = \sum_\gamma c^{(L)}_{\alpha,\beta,\gamma}O_L(M_\gamma).
+\]
+The predicate is abstract in the ambient length-`L` algebra.  Later comparison
+theorems must relate this same-length algebra to the chosen blocked support
+algebras.
+Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+def HasSameLengthProductForm [Fintype Λ]
+    [∀ L : ℕ, AddCommMonoid (O L)] [∀ L : ℕ, Module ℂ (O L)]
+    [∀ L : ℕ, Mul (O L)]
+    (c : BNTLabelCoefficientFamily Λ) : Prop :=
+  ∀ L : ℕ, 0 < L → ∀ α β : Λ,
+    op.operator L α * op.operator L β =
+      ∑ γ : Λ, c.coeff L α β γ • op.operator L γ
+
+/-- Restatement of the same-length BNT product formula as an equality. -/
+theorem HasSameLengthProductForm.eq_sum [Fintype Λ]
+    [∀ L : ℕ, AddCommMonoid (O L)] [∀ L : ℕ, Module ℂ (O L)]
+    [∀ L : ℕ, Mul (O L)]
+    {c : BNTLabelCoefficientFamily Λ}
+    (h : op.HasSameLengthProductForm c)
+    (L : ℕ) (hL : 0 < L) (α β : Λ) :
+    op.operator L α * op.operator L β =
+      ∑ γ : Λ, c.coeff L α β γ • op.operator L γ :=
+  h L hL α β
+
+end BNTLabelOperatorFamily
+
 /-- A positive BNT-label chi witness for Theorem IV.13(ii).
 
 The witness consists of the paper's positive diagonal matrices
@@ -679,8 +732,8 @@ the BNT-label coefficient system.
 
 This is not yet a proof of Theorem IV.13(ii) from an MPDO tensor: it is the
 paper-faithful coefficient statement to be constructed.  The construction of
-this witness, the same-length product formula, and the comparison to blocked
-bases remain the obligations described in
+this witness and the comparison to blocked bases remain the obligations
+described in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
 lines 1925--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1224,6 +1224,47 @@ the elementary trace-power identity for diagonal matrices.
     \(\mathcal A_n\times\mathcal A_n\to\mathcal A_{2n}\).
 \end{definition}
 
+\begin{definition}[BNT-label operator family]%
+    \label{def:mpdo_bnt_label_operator_family}
+    \lean{MPOTensor.BNTLabelOperatorFamily}
+    \leanok
+    A BNT-label operator family records, for each chain length \(L\), the
+    operators \(O_L(M_\alpha)\) indexed by the fixed BNT labels \(\alpha\).
+    The ambient algebra at length \(L\) is left abstract here; the later
+    comparison step must relate it to the chosen blocked support algebras.
+\end{definition}
+
+\begin{definition}[Same-length BNT product form]%
+    \label{def:mpdo_bnt_label_same_length_product_form}
+    \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm}
+    \leanok
+    \uses{def:mpdo_bnt_label_operator_family,
+        def:mpdo_bnt_label_coefficient_family}
+    A BNT-label operator family and a BNT-label coefficient system have
+    same-length product form when, for every positive length \(L\),
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
+          = \sum_\gamma
+              c^{(L)}_{\alpha,\beta,\gamma} O_L(M_\gamma).
+    \]
+    This is the product identity appearing in Theorem~IV.13(ii), stated
+    independently of the blocked-basis multiplication
+    \(\mathcal A_n\times\mathcal A_n\to\mathcal A_{2n}\).
+\end{definition}
+
+\begin{theorem}[Same-length BNT product expansion]%
+    \label{thm:mpdo_bnt_label_same_length_product_eq_sum}
+    \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum}
+    \leanok
+    \uses{def:mpdo_bnt_label_same_length_product_form}
+    Under same-length BNT product form, the product of two length-\(L\)
+    BNT-label operators is the corresponding finite linear combination of
+    length-\(L\) BNT-label operators.
+\end{theorem}
+\begin{proof}\leanok
+    This is exactly the defining equality of same-length product form.
+\end{proof}
+
 \begin{definition}[Positive-length BNT-label trace-power form]%
     \label{def:mpdo_bnt_label_positive_length_chi_trace_power_form}
     \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -121,21 +121,29 @@ uniform BNT-label statement has been separated from the chosen blocked bases.
 The same-length coefficient family \(c^{(L)}_{\alpha,\beta,\gamma}\), indexed
 by fixed BNT labels, is represented separately from the blocked-basis
 coefficients.\footnote{\leanid{MPOTensor.BNTLabelCoefficientFamily}.}  A
+same-length BNT product predicate records the algebra identity
+\[
+    O_L(M_\alpha)O_L(M_\beta)
+      = \sum_\gamma c^{(L)}_{\alpha,\beta,\gamma}O_L(M_\gamma)
+\]
+for an abstract family of length-\(L\) BNT operators.\footnote{%
+\leanid{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm}.}  A
 positive BNT-label \(\chi\)-witness consists of a length-independent diagonal
 family \(\chi_{\alpha,\beta,\gamma}\), positivity of every diagonal entry, and
 the positive-length trace-power identity.\footnote{%
 \leanid{MPOTensor.PositiveBNTLabelChiTracePowerForm}.}
 These declarations specify the BNT-label coefficient objects, but they do not
-yet construct the coefficients or \(\chi\)-matrices from an MPDO tensor, and
-they do not yet compare BNT-label coefficients with the chosen blocked bases.
+yet construct the operators, coefficients, or \(\chi\)-matrices from an MPDO
+tensor, and they do not yet compare BNT-label coefficients with the chosen
+blocked bases.
 
 To eliminate the remaining gap, the formalization should introduce:
 \begin{enumerate}
     \item a comparison theorem relating the BNT-label coefficients to the
         chosen blocked bases of \(\mathcal A_n\);
-    \item a same-length operator-algebra product statement matching
-        \(O_L(M_\alpha)O_L(M_\beta)\), together with the comparison to the
-        blocked support-algebra product
+    \item construction of the same-length BNT operator family and product law
+        from the MPDO tensor, together with the comparison to the blocked
+        support-algebra product
         \(\mathcal A_n \times \mathcal A_n \to \mathcal A_{2n}\);
     \item construction of the positive BNT-label
         \(\chi_{\alpha,\beta,\gamma}\)-witness from the paper's Appendix C.3


### PR DESCRIPTION
### Motivation

Refs #2000.

Cirac--Perez-Garcia--Schuch--Verstraete Theorem IV.13(ii) uses the same-length algebra identity

```tex
O_L(M_\alpha)O_L(M_\beta) = \sum_\gamma c^{(L)}_{\alpha,\beta,\gamma}O_L(M_\gamma).
```

The previous MPDO statement separated the BNT-label coefficients and the positive chi trace-power witness, but did not yet name this same-length product relation.

### Description

This PR introduces `MPOTensor.BNTLabelOperatorFamily` and `MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm`, together with the direct equality lemma `HasSameLengthProductForm.eq_sum`. The statement is abstract in the length-`L` operator algebra, so it records the paper's product identity without identifying it with the blocked support-algebra product `A_n x A_n -> A_{2n}`.

The MPDO blueprint and the chi-uniformity paper-gap note now record that the same-length product predicate exists, while construction from an MPDO tensor and comparison with blocked bases remain open.

### Testing

- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake build`
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` fails on pre-existing repository-wide missing MPS/PEPS declarations; the new MPDO declarations are not among the reported missing declarations.

---
Addresses #2000

> [!NOTE]
> **Low Risk**
> Adds new Lean structures/predicates to state the BNT same-length product identity and updates documentation; no existing algebra/RFP logic is modified, so behavioral risk is minimal.
>
> **Overview**
> Introduces an explicit abstraction for the *same-length* BNT operator algebra identity from Theorem IV.13(ii): a new `BNTLabelOperatorFamily` plus predicate `HasSameLengthProductForm` (and lemma `eq_sum`) tying length-`L` operator products to the existing BNT-label coefficient family.
>
> Updates the `BNTLabelCoefficientFamily` and `PositiveBNTLabelChiTracePowerForm` docs to clarify that the product law is recorded separately, and extends the blueprint + paper-gap note to document the new operator-family/product-form layer and remaining open comparison/construction work.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1acee6eafdc3254db0f1bf8eff82675208f06e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>