### PR TITLE
feat(MPS/MPDO): state BNT idempotent condition

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -53,8 +53,11 @@ statement shape of Theorem IV.13(ii): the special diagonal matrices
 $\chi_{\alpha,\beta,\gamma}$ are represented as a `DiagonalChiFamily`, the
 BNT-label coefficient system is represented as `BNTLabelCoefficientFamily`, and
 `BNTLabelOperatorFamily.HasSameLengthProductForm` records the same-length
-product identity.  The structure `PositiveBNTLabelChiTracePowerForm` records
-positivity together with the positive-length identity
+product identity.  The predicate
+`BNTLabelTensorFamily.HasIdempotentCoefficientForm` records the idempotent
+coefficient condition on the BNT-labelled tensors.  The structure
+`PositiveBNTLabelChiTracePowerForm` records positivity together with the
+positive-length identity
 $c_{\alpha,\beta,\gamma}^{(L)} =
   \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$.
 For the blocked support tower, `AlgebraStructureData.BlockedStructureChiFamily`,
@@ -722,6 +725,52 @@ theorem HasSameLengthProductForm.eq_sum [Fintype Λ]
   h L hL α β
 
 end BNTLabelOperatorFamily
+
+/-- BNT-labelled tensors \(m_\alpha\) appearing in the idempotent condition of
+Theorem IV.13(ii).
+
+Here `Λ` is the fixed BNT-label type, and `A` is the ambient algebra containing
+the tensors \(m_\alpha\).  This structure only records the label-indexed
+family; the coefficient identity itself is the predicate
+`BNTLabelTensorFamily.HasIdempotentCoefficientForm`.
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 981--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTLabelTensorFamily (Λ : Type*) (A : Type*) where
+  /-- The tensor \(m_\alpha\) with BNT label `α`. -/
+  tensor : Λ → A
+
+namespace BNTLabelTensorFamily
+
+variable {Λ A : Type*} (m : BNTLabelTensorFamily Λ A)
+
+/-- Idempotent coefficient condition from Theorem IV.13(ii).
+
+The length-one BNT coefficients reconstruct each labelled tensor as
+\[
+  m_\gamma =
+    \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma} m_\alpha m_\beta.
+\]
+This predicate records only that algebraic identity; constructing it from an
+MPDO tensor and comparing it with the blocked support-algebra coefficients are
+separate obligations.
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 981--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+def HasIdempotentCoefficientForm [Fintype Λ]
+    [AddCommMonoid A] [Module ℂ A] [Mul A]
+    (c : BNTLabelCoefficientFamily Λ) : Prop :=
+  ∀ γ : Λ, m.tensor γ =
+    ∑ α : Λ, ∑ β : Λ, c.coeff 1 α β γ • (m.tensor α * m.tensor β)
+
+/-- Restatement of the BNT idempotent coefficient condition as an equality. -/
+theorem HasIdempotentCoefficientForm.eq_sum [Fintype Λ]
+    [AddCommMonoid A] [Module ℂ A] [Mul A]
+    {c : BNTLabelCoefficientFamily Λ}
+    (h : m.HasIdempotentCoefficientForm c) (γ : Λ) :
+    m.tensor γ =
+      ∑ α : Λ, ∑ β : Λ, c.coeff 1 α β γ • (m.tensor α * m.tensor β) :=
+  h γ
+
+end BNTLabelTensorFamily
 
 /-- A positive BNT-label chi witness for Theorem IV.13(ii).
 

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -54,8 +54,9 @@ $\chi_{\alpha,\beta,\gamma}$ are represented as a `DiagonalChiFamily`, the
 BNT-label coefficient system is represented as `BNTLabelCoefficientFamily`, and
 `BNTLabelOperatorFamily.HasSameLengthProductForm` records the same-length
 product identity.  The predicate
-`BNTLabelTensorFamily.HasIdempotentCoefficientForm` records the idempotent
-coefficient condition on the BNT-labelled tensors.  The structure
+`BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm` records the idempotent
+coefficient condition on the scalars \(m_\alpha=\operatorname{tr}(\mu_\alpha)\).
+The structure
 `PositiveBNTLabelChiTracePowerForm` records positivity together with the
 positive-length identity
 $c_{\alpha,\beta,\gamma}^{(L)} =
@@ -726,51 +727,51 @@ theorem HasSameLengthProductForm.eq_sum [Fintype Λ]
 
 end BNTLabelOperatorFamily
 
-/-- BNT-labelled tensors \(m_\alpha\) appearing in the idempotent condition of
-Theorem IV.13(ii).
+/-- The trace scalars \(m_\alpha=\operatorname{tr}(\mu_\alpha)\) appearing in
+the idempotent condition of Theorem IV.13(ii).
 
-Here `Λ` is the fixed BNT-label type, and `A` is the ambient algebra containing
-the tensors \(m_\alpha\).  This structure only records the label-indexed
-family; the coefficient identity itself is the predicate
-`BNTLabelTensorFamily.HasIdempotentCoefficientForm`.
+Here `Λ` is the fixed BNT-label type, and `traceScalar α` is the scalar
+\(m_\alpha\) attached to the positive diagonal matrix \(\mu_\alpha\) in the
+source proof.  The coefficient identity itself is the predicate
+`BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm`.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 981--985 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-structure BNTLabelTensorFamily (Λ : Type*) (A : Type*) where
-  /-- The tensor \(m_\alpha\) with BNT label `α`. -/
-  tensor : Λ → A
+structure BNTLabelTraceScalarFamily (Λ : Type*) where
+  /-- The scalar \(m_\alpha=\operatorname{tr}(\mu_\alpha)\). -/
+  traceScalar : Λ → ℂ
 
-namespace BNTLabelTensorFamily
+namespace BNTLabelTraceScalarFamily
 
-variable {Λ A : Type*} (m : BNTLabelTensorFamily Λ A)
+variable {Λ : Type*} (m : BNTLabelTraceScalarFamily Λ)
 
 /-- Idempotent coefficient condition from Theorem IV.13(ii).
 
-The length-one BNT coefficients reconstruct each labelled tensor as
+The length-one BNT coefficients reconstruct each trace scalar as
 \[
   m_\gamma =
     \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma} m_\alpha m_\beta.
 \]
-This predicate records only that algebraic identity; constructing it from an
-MPDO tensor and comparing it with the blocked support-algebra coefficients are
-separate obligations.
+This predicate records only that scalar identity; constructing the scalars from
+an MPDO tensor and comparing the coefficients with the blocked support-algebra
+coefficients are separate obligations.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 981--985 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def HasIdempotentCoefficientForm [Fintype Λ]
-    [AddCommMonoid A] [Module ℂ A] [Mul A]
     (c : BNTLabelCoefficientFamily Λ) : Prop :=
-  ∀ γ : Λ, m.tensor γ =
-    ∑ α : Λ, ∑ β : Λ, c.coeff 1 α β γ • (m.tensor α * m.tensor β)
+  ∀ γ : Λ, m.traceScalar γ =
+    ∑ α : Λ, ∑ β : Λ,
+      c.coeff 1 α β γ * (m.traceScalar α * m.traceScalar β)
 
 /-- Restatement of the BNT idempotent coefficient condition as an equality. -/
 theorem HasIdempotentCoefficientForm.eq_sum [Fintype Λ]
-    [AddCommMonoid A] [Module ℂ A] [Mul A]
     {c : BNTLabelCoefficientFamily Λ}
     (h : m.HasIdempotentCoefficientForm c) (γ : Λ) :
-    m.tensor γ =
-      ∑ α : Λ, ∑ β : Λ, c.coeff 1 α β γ • (m.tensor α * m.tensor β) :=
+    m.traceScalar γ =
+      ∑ α : Λ, ∑ β : Λ,
+        c.coeff 1 α β γ * (m.traceScalar α * m.traceScalar β) :=
   h γ
 
-end BNTLabelTensorFamily
+end BNTLabelTraceScalarFamily
 
 /-- A positive BNT-label chi witness for Theorem IV.13(ii).
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1265,22 +1265,22 @@ the elementary trace-power identity for diagonal matrices.
     This is exactly the defining equality of same-length product form.
 \end{proof}
 
-\begin{definition}[BNT-label tensor family]%
-    \label{def:mpdo_bnt_label_tensor_family}
-    \lean{MPOTensor.BNTLabelTensorFamily}
+\begin{definition}[BNT-label trace-scalar family]%
+    \label{def:mpdo_bnt_label_trace_scalar_family}
+    \lean{MPOTensor.BNTLabelTraceScalarFamily}
     \leanok
-    A BNT-label tensor family records the tensors \(m_\alpha\) indexed by the
-    fixed BNT labels \(\alpha\).  The ambient algebra containing the tensors is
-    left abstract here.
+    A BNT-label trace-scalar family records the scalars
+    \(m_\alpha=\operatorname{tr}(\mu_\alpha)\) indexed by the fixed BNT labels
+    \(\alpha\), as in the idempotent condition of Theorem~IV.13(ii).
 \end{definition}
 
 \begin{definition}[BNT idempotent coefficient form]%
     \label{def:mpdo_bnt_label_idempotent_coefficient_form}
-    \lean{MPOTensor.BNTLabelTensorFamily.HasIdempotentCoefficientForm}
+    \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm}
     \leanok
-    \uses{def:mpdo_bnt_label_tensor_family,
+    \uses{def:mpdo_bnt_label_trace_scalar_family,
         def:mpdo_bnt_label_coefficient_family}
-    A BNT-label tensor family and a BNT-label coefficient system have
+    A BNT-label trace-scalar family and a BNT-label coefficient system have
     idempotent coefficient form when, for every BNT label \(\gamma\),
     \[
         m_\gamma =
@@ -1293,7 +1293,8 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[BNT idempotent coefficient expansion]%
     \label{thm:mpdo_bnt_label_idempotent_coefficient_eq_sum}
-    \lean{MPOTensor.BNTLabelTensorFamily.HasIdempotentCoefficientForm.eq_sum}
+    \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.
+        eq_sum}
     \leanok
     \uses{def:mpdo_bnt_label_idempotent_coefficient_form}
     Under BNT idempotent coefficient form, each \(m_\gamma\) is the

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1265,6 +1265,45 @@ the elementary trace-power identity for diagonal matrices.
     This is exactly the defining equality of same-length product form.
 \end{proof}
 
+\begin{definition}[BNT-label tensor family]%
+    \label{def:mpdo_bnt_label_tensor_family}
+    \lean{MPOTensor.BNTLabelTensorFamily}
+    \leanok
+    A BNT-label tensor family records the tensors \(m_\alpha\) indexed by the
+    fixed BNT labels \(\alpha\).  The ambient algebra containing the tensors is
+    left abstract here.
+\end{definition}
+
+\begin{definition}[BNT idempotent coefficient form]%
+    \label{def:mpdo_bnt_label_idempotent_coefficient_form}
+    \lean{MPOTensor.BNTLabelTensorFamily.HasIdempotentCoefficientForm}
+    \leanok
+    \uses{def:mpdo_bnt_label_tensor_family,
+        def:mpdo_bnt_label_coefficient_family}
+    A BNT-label tensor family and a BNT-label coefficient system have
+    idempotent coefficient form when, for every BNT label \(\gamma\),
+    \[
+        m_\gamma =
+          \sum_{\alpha,\beta}
+            c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta.
+    \]
+    This is the idempotent condition in Theorem~IV.13(ii), stated separately
+    from the trace-power formula.
+\end{definition}
+
+\begin{theorem}[BNT idempotent coefficient expansion]%
+    \label{thm:mpdo_bnt_label_idempotent_coefficient_eq_sum}
+    \lean{MPOTensor.BNTLabelTensorFamily.HasIdempotentCoefficientForm.eq_sum}
+    \leanok
+    \uses{def:mpdo_bnt_label_idempotent_coefficient_form}
+    Under BNT idempotent coefficient form, each \(m_\gamma\) is the
+    corresponding finite linear combination of products \(m_\alpha m_\beta\)
+    with the length-one coefficients \(c^{(1)}_{\alpha,\beta,\gamma}\).
+\end{theorem}
+\begin{proof}\leanok
+    This is exactly the defining equality of BNT idempotent coefficient form.
+\end{proof}
+
 \begin{definition}[Positive-length BNT-label trace-power form]%
     \label{def:mpdo_bnt_label_positive_length_chi_trace_power_form}
     \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -127,15 +127,22 @@ same-length BNT product predicate records the algebra identity
       = \sum_\gamma c^{(L)}_{\alpha,\beta,\gamma}O_L(M_\gamma)
 \]
 for an abstract family of length-\(L\) BNT operators.\footnote{%
-\leanid{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm}.}  A
+\leanid{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm}.}  The
+idempotent condition
+\[
+    m_\gamma =
+      \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta
+\]
+is also represented as an abstract predicate on BNT-labelled tensors.\footnote{%
+\leanid{MPOTensor.BNTLabelTensorFamily.HasIdempotentCoefficientForm}.}  A
 positive BNT-label \(\chi\)-witness consists of a length-independent diagonal
 family \(\chi_{\alpha,\beta,\gamma}\), positivity of every diagonal entry, and
 the positive-length trace-power identity.\footnote{%
 \leanid{MPOTensor.PositiveBNTLabelChiTracePowerForm}.}
 These declarations specify the BNT-label coefficient objects, but they do not
-yet construct the operators, coefficients, or \(\chi\)-matrices from an MPDO
-tensor, and they do not yet compare BNT-label coefficients with the chosen
-blocked bases.
+yet construct the operators, tensors, coefficients, or \(\chi\)-matrices from
+an MPDO tensor, and they do not yet compare BNT-label coefficients with the
+chosen blocked bases.
 
 To eliminate the remaining gap, the formalization should introduce:
 \begin{enumerate}
@@ -148,10 +155,10 @@ To eliminate the remaining gap, the formalization should introduce:
     \item construction of the positive BNT-label
         \(\chi_{\alpha,\beta,\gamma}\)-witness from the paper's Appendix C.3
         and C.4 hypotheses;
-    \item the idempotent condition
+    \item construction of the idempotent condition
         \(m_\gamma =
           \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}
-          m_\alpha m_\beta\);
+          m_\alpha m_\beta\) from the MPDO tensor;
     \item the blocked-basis trace-power statement, with its source-length
         exponent convention, as a derived corollary of the uniform BNT-label
         theorem, rather than as the theorem itself.

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -133,16 +133,17 @@ idempotent condition
     m_\gamma =
       \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta
 \]
-is also represented as an abstract predicate on BNT-labelled tensors.\footnote{%
-\leanid{MPOTensor.BNTLabelTensorFamily.HasIdempotentCoefficientForm}.}  A
+is also represented as a predicate on the trace scalars
+\(m_\alpha=\operatorname{tr}(\mu_\alpha)\).\footnote{%
+\leanid{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm}.}  A
 positive BNT-label \(\chi\)-witness consists of a length-independent diagonal
 family \(\chi_{\alpha,\beta,\gamma}\), positivity of every diagonal entry, and
 the positive-length trace-power identity.\footnote{%
 \leanid{MPOTensor.PositiveBNTLabelChiTracePowerForm}.}
 These declarations specify the BNT-label coefficient objects, but they do not
-yet construct the operators, tensors, coefficients, or \(\chi\)-matrices from
-an MPDO tensor, and they do not yet compare BNT-label coefficients with the
-chosen blocked bases.
+yet construct the operators, trace scalars, coefficients, or
+\(\chi\)-matrices from an MPDO tensor, and they do not yet compare BNT-label
+coefficients with the chosen blocked bases.
 
 To eliminate the remaining gap, the formalization should introduce:
 \begin{enumerate}


### PR DESCRIPTION
### Motivation

Cirac--Pérez-García--Schuch--Verstraete 2017 (arXiv:1606.00608), Theorem IV.13(ii) includes the idempotent coefficient condition

```tex
m_\gamma = \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma} m_\alpha m_\beta.
```

The coefficient and same-length product predicates were separated in the previous MPDO steps; this PR records the remaining idempotent identity as its own BNT-labelled predicate. Continues the BNT-label uniform chi-matrix formalization from #2000.

### Description

- Introduces `MPOTensor.BNTLabelTensorFamily` and `MPOTensor.BNTLabelTensorFamily.HasIdempotentCoefficientForm` in `TNLean/MPS/MPDO/AlgebraStructure.lean`.
- Adds the direct equality lemma `HasIdempotentCoefficientForm.eq_sum`.
- The statement is abstract in the ambient algebra containing the tensors `m_α`. It records the source theorem condition without claiming that the tensors, coefficients, or comparison with blocked support algebras have been constructed from an MPDO tensor.
- Updates `blueprint/src/chapter/ch02b_mpdo.tex` and `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` to record that this idempotent predicate exists, while construction from the MPDO tensor remains open.

### Testing

- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake build`
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` fails on pre-existing repository-wide missing MPS/PEPS declarations; the new MPDO declarations are not among the reported missing declarations.

---
Addresses #2000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new abstract Lean definitions/lemmas and documentation updates without changing existing computational logic or proofs used elsewhere.
> 
> **Overview**
> Extends the MPDO Theorem IV.13(ii) formalization by introducing `BNTLabelTraceScalarFamily` and the predicate `HasIdempotentCoefficientForm` capturing the length-one idempotent scalar identity \(m_\gamma = \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma} m_\alpha m_\beta\), plus a direct rewrite lemma `HasIdempotentCoefficientForm.eq_sum`.
> 
> Updates the blueprint and the paper-gap note to document this newly separated idempotent-condition predicate alongside the existing same-length product and chi trace-power statements, clarifying that construction from an MPDO tensor remains future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6acda54b2ee025bfa89ddeb4cf6f3756a16298e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->