### PR TITLE
feat(PEPS): pull physical actions back to virtual space

### DIFF
--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -355,6 +355,18 @@ noncomputable def localProjector (A : Tensor G d) (hA : IsVertexInjective A)
     (v : V) : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ) :=
   physRealizeLocalOp A hA v LinearMap.id
 
+/-- Pull a local physical operator back to the virtual coefficient space.
+
+This is the local injectivity step used in the \(O_1,O_2 \mapsto W\) part of
+arXiv:1804.04964, Section 3: the chosen left inverse identifies the action of a
+physical operator on the image of the local tensor map with a virtual operation
+on local boundary coefficients. -/
+noncomputable def localVirtualOpOfPhysicalOp (A : Tensor G d)
+    (hA : IsVertexInjective A) (v : V)
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) :
+    LocalVirtualOp A v :=
+  (localLeftInverse A hA v).comp (O.comp (localTensorMap A v))
+
 @[simp] theorem localProjector_apply_localTensorMap (A : Tensor G d)
     (hA : IsVertexInjective A) (v : V) (c : LocalVirtualConfig A v → ℂ) :
     localProjector A hA v (localTensorMap A v c) = localTensorMap A v c := by
@@ -373,6 +385,46 @@ theorem localProjector_idempotent (A : Tensor G d) (hA : IsVertexInjective A)
       localProjector A hA v := by
   simpa [localProjector] using
     (physRealizeLocalOp_comp A hA v LinearMap.id LinearMap.id).symm
+
+/-- The virtual pullback realizes the projected physical action on the image of
+the local tensor map. -/
+theorem localVirtualOpOfPhysicalOp_spec (A : Tensor G d) (hA : IsVertexInjective A)
+    (v : V) (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (c : LocalVirtualConfig A v → ℂ) :
+    localTensorMap A v (localVirtualOpOfPhysicalOp A hA v O c) =
+      localProjector A hA v (O (localTensorMap A v c)) := by
+  simp [localVirtualOpOfPhysicalOp, localProjector, physRealizeLocalOp]
+
+/-- If a local physical operator preserves the image of the local tensor map,
+then its virtual pullback gives exactly the same action on that image. -/
+theorem localVirtualOpOfPhysicalOp_realizes_of_projector (A : Tensor G d)
+    (hA : IsVertexInjective A) (v : V)
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hO : ∀ c : LocalVirtualConfig A v → ℂ,
+      localProjector A hA v (O (localTensorMap A v c)) = O (localTensorMap A v c))
+    (c : LocalVirtualConfig A v → ℂ) :
+    localTensorMap A v (localVirtualOpOfPhysicalOp A hA v O c) =
+      O (localTensorMap A v c) := by
+  rw [localVirtualOpOfPhysicalOp_spec, hO]
+
+/-- A virtual operator is recovered by pulling back any physical operator that
+realizes it on the image of the local tensor map. -/
+theorem localVirtualOpOfPhysicalOp_eq_of_realizes (A : Tensor G d)
+    (hA : IsVertexInjective A) (v : V)
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (T : LocalVirtualOp A v)
+    (hO : ∀ c : LocalVirtualConfig A v → ℂ,
+      O (localTensorMap A v c) = localTensorMap A v (T c)) :
+    localVirtualOpOfPhysicalOp A hA v O = T := by
+  apply LinearMap.ext
+  intro c
+  apply hA.localTensorMap_injective v
+  calc
+    localTensorMap A v (localVirtualOpOfPhysicalOp A hA v O c) =
+        localProjector A hA v (O (localTensorMap A v c)) := by
+      rw [localVirtualOpOfPhysicalOp_spec]
+    _ = localTensorMap A v (T c) := by
+      rw [hO c]
+      simp
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -213,6 +213,65 @@ injective and normal PEPS, following Theorems~2 and~3 of
     This is immediate from $\Psi_v \circ \Phi_v = \Id$.
 \end{proof}
 
+\begin{definition}[Virtual pullback of a local physical operator]%
+    \label{def:peps_localVirtualOpOfPhysicalOp}
+    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp}
+    \leanok
+    \uses{def:peps_localTensorMap, def:peps_localLeftInverse}
+    For a physical operator \(O\) on the local physical space at \(v\), define
+    its virtual pullback by
+    \[
+        \Psi_v \circ O \circ \Phi_v .
+    \]
+    This is the local injectivity step used in the
+    \(O_1,O_2\mapsto W\) direction of
+    Lemma~\(\mathrm{inj\_isomorph}\) in
+    \cite[Section~3]{Molnar2018NormalPEPS}.
+\end{definition}
+
+\begin{theorem}[Virtual pullback realizes the projected physical action]%
+    \label{thm:peps_localVirtualOpOfPhysicalOp_spec}
+    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_spec}
+    \leanok
+    \uses{def:peps_localVirtualOpOfPhysicalOp,
+        def:peps_physRealizeLocalOp}
+    For every coefficient function \(c\), applying the local tensor map after
+    the virtual pullback gives the projection of \(O(\Phi_v(c))\) onto the
+    image of \(\Phi_v\).
+\end{theorem}
+\begin{proof}\leanok
+    Expand the definitions. The chosen left inverse gives
+    \(\Psi_v\Phi_v=\Id\), and the remaining map is the local projector.
+\end{proof}
+
+\begin{theorem}[Virtual pullback for image-preserving physical actions]%
+    \label{thm:peps_localVirtualOpOfPhysicalOp_realizes_of_projector}
+    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_realizes_of_projector}
+    \leanok
+    \uses{thm:peps_localVirtualOpOfPhysicalOp_spec}
+    If \(O\) sends every vector in the image of \(\Phi_v\) back into that image,
+    then its virtual pullback realizes exactly the action of \(O\) on
+    \(\Phi_v(c)\).
+\end{theorem}
+\begin{proof}\leanok
+    Use the preceding theorem and the image-preservation hypothesis.
+\end{proof}
+
+\begin{theorem}[Recovery of a virtual operation from a physical realization]%
+    \label{thm:peps_localVirtualOpOfPhysicalOp_eq_of_realizes}
+    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_of_realizes}
+    \leanok
+    \uses{def:IsVertexInjective,
+        thm:peps_localVirtualOpOfPhysicalOp_spec}
+    If a physical operator \(O\) realizes a virtual operation \(T\) on every
+    vector in the image of \(\Phi_v\), then pulling back \(O\) recovers \(T\).
+\end{theorem}
+\begin{proof}\leanok
+    After applying the local tensor map, both virtual operations have the same
+    image. Vertex injectivity makes the local tensor map injective, so the
+    virtual operations agree.
+\end{proof}
+
 \begin{definition}[Matrix action on one incident virtual edge]%
     \label{def:peps_localIncidentMatrixOp}
     \lean{TNLean.PEPS.localIncidentMatrixOp}


### PR DESCRIPTION
### Motivation

- Preparatory step for the physical-to-virtual direction in the edge-blocked three-site insertion argument of arXiv:1804.04964 (PEPS Fundamental Theorem, Section 3), which formalizes `thm:peps_physicalToVirtualInsertion` from Chapter 13a of the blueprint.
- The local injectivity ingredient is needed: given an injective local tensor map, a physical operator on one site can be pulled back to a virtual operation on the local boundary coefficients. This step precedes the shared-bond recovery that will close #1370.

### Description

- Modified `TNLean/PEPS/VirtualInsertion.lean`: added definition `localVirtualOpOfPhysicalOp`, which constructs a virtual boundary operator from a physical linear operator on a single site by composing with the chosen left inverse of the injective local tensor map.
- Proved three accompanying correctness lemmas:
  - `localVirtualOpOfPhysicalOp_spec`: the pulled-back virtual operator agrees with the physical action on the image of the local tensor, up to projection.
  - `localVirtualOpOfPhysicalOp_realizes_of_projector`: if the physical action preserves the local tensor image, the pulled-back virtual operator realizes the physical action exactly on that image.
  - `localVirtualOpOfPhysicalOp_eq_of_realizes`: if the physical action is already known to be realized by some virtual operator, the pullback recovers it.
- Modified `blueprint/src/chapter/ch13a_peps_ft.tex`: added blueprint entries for the above definition and lemmas in Chapter 13a.
- Does not close #1370: the remaining step is to use equality of the two neighboring physical actions in the edge-blocked three-site state to show that the recovered virtual operator acts on the shared bond only.

### Testing

- `lake env lean TNLean/PEPS/VirtualInsertion.lean`
- `lake build TNLean.PEPS.VirtualInsertion`
- `lake build TNLean.PEPS.Blocking TNLean.PEPS.InsertionRealization TNLean.PEPS.LocalGauge`
- `lake env lean --stdin` checks for the four new declarations after importing `TNLean.PEPS.VirtualInsertion` and after importing root `TNLean`.
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` was run; the four new declarations are visible from root `TNLean` and are not among the reported missing declarations. Pre-existing failures concern declarations intentionally outside the current root import surface.

---
Refs #1370