### PR TITLE
feat(PEPS): recover virtual operations from canonical realization

### DIFF
--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -426,5 +426,14 @@ theorem localVirtualOpOfPhysicalOp_eq_of_realizes (A : Tensor G d)
       rw [hO c]
       simp
 
+/-- Pulling back the canonical physical realization of a virtual operation
+recovers the original virtual operation. -/
+theorem localVirtualOpOfPhysicalOp_physRealizeLocalOp (A : Tensor G d)
+    (hA : IsVertexInjective A) (v : V) (T : LocalVirtualOp A v) :
+    localVirtualOpOfPhysicalOp A hA v (physRealizeLocalOp A hA v T) = T :=
+  localVirtualOpOfPhysicalOp_eq_of_realizes A hA v
+    (physRealizeLocalOp A hA v T) T
+    (physRealizeLocalOp_spec A hA v T)
+
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -272,6 +272,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
     virtual operations agree.
 \end{proof}
 
+\begin{theorem}[Pullback of the canonical physical realization]%
+    \label{thm:peps_localVirtualOpOfPhysicalOp_physRealizeLocalOp}
+    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_physRealizeLocalOp}
+    \leanok
+    \uses{def:peps_physRealizeLocalOp,
+        thm:peps_localVirtualOpOfPhysicalOp_eq_of_realizes}
+    Pulling back the canonical physical realization of a virtual operation
+    recovers the original virtual operation.
+\end{theorem}
+\begin{proof}\leanok
+    The canonical physical realization agrees with the virtual operation on
+    the image of the local tensor map. Apply the preceding recovery theorem.
+\end{proof}
+
 \begin{definition}[Matrix action on one incident virtual edge]%
     \label{def:peps_localIncidentMatrixOp}
     \lean{TNLean.PEPS.localIncidentMatrixOp}


### PR DESCRIPTION
### Motivation

- Preparatory step for #1370, the physical-to-virtual direction in the edge-blocked three-site insertion argument of arXiv:1804.04964, Section 3.
- PR #2010 introduced the local pullback `localVirtualOpOfPhysicalOp`. Later uses should not need to unfold the chosen left inverse to know that pulling back the canonical physical realization recovers the virtual operation.

### Description

- Added `TNLean.PEPS.localVirtualOpOfPhysicalOp_physRealizeLocalOp`.
- Added the corresponding Chapter 13a blueprint theorem.

This does not close #1370: the remaining step is still to use equality of two neighboring physical actions in the edge-blocked three-site state to prove that the recovered operation acts on the shared bond only.

### Testing

- `lake env lean TNLean/PEPS/VirtualInsertion.lean`
- `lake build TNLean.PEPS.VirtualInsertion`
- `lake env lean --stdin` after importing root `TNLean` and checking the new declaration
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` was run. It still reports the known pre-existing declarations outside the current root import surface; the new declaration is visible from root `TNLean`.

---
Refs #1370