### PR TITLE
feat(PEPS): realize virtual pullbacks as projected physical maps

### DIFF
--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -435,5 +435,17 @@ theorem localVirtualOpOfPhysicalOp_physRealizeLocalOp (A : Tensor G d)
     (physRealizeLocalOp A hA v T) T
     (physRealizeLocalOp_spec A hA v T)
 
+/-- The physical realization of the virtual pullback of \(O\) is
+\(P \circ O \circ P\), where \(P\) is the local projector onto the image of the
+local tensor map. -/
+theorem physRealizeLocalOp_localVirtualOpOfPhysicalOp (A : Tensor G d)
+    (hA : IsVertexInjective A) (v : V)
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) :
+    physRealizeLocalOp A hA v (localVirtualOpOfPhysicalOp A hA v O) =
+      (localProjector A hA v).comp (O.comp (localProjector A hA v)) := by
+  ext x
+  simp [physRealizeLocalOp, localVirtualOpOfPhysicalOp, localProjector,
+    LinearMap.comp_assoc]
+
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -213,6 +213,18 @@ injective and normal PEPS, following Theorems~2 and~3 of
     This is immediate from $\Psi_v \circ \Phi_v = \Id$.
 \end{proof}
 
+\begin{definition}[Local projector]%
+    \label{def:peps_localProjector}
+    \lean{TNLean.PEPS.localProjector}
+    \leanok
+    \uses{def:peps_physRealizeLocalOp}
+    The local projector is the physical realization of the identity virtual
+    operator:
+    \[
+        P_v = \Phi_v \circ \Psi_v .
+    \]
+\end{definition}
+
 \begin{definition}[Virtual pullback of a local physical operator]%
     \label{def:peps_localVirtualOpOfPhysicalOp}
     \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp}
@@ -234,7 +246,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_spec}
     \leanok
     \uses{def:peps_localVirtualOpOfPhysicalOp,
-        def:peps_physRealizeLocalOp}
+        def:peps_physRealizeLocalOp,
+        def:peps_localProjector}
     For every coefficient function \(c\), applying the local tensor map after
     the virtual pullback gives the projection of \(O(\Phi_v(c))\) onto the
     image of \(\Phi_v\).
@@ -284,6 +297,26 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     The canonical physical realization agrees with the virtual operation on
     the image of the local tensor map. Apply the preceding recovery theorem.
+\end{proof}
+
+\begin{theorem}[Physical realization of a pulled-back physical operator]%
+    \label{thm:peps_physRealizeLocalOp_localVirtualOpOfPhysicalOp}
+    \lean{TNLean.PEPS.physRealizeLocalOp_localVirtualOpOfPhysicalOp}
+    \leanok
+    \uses{def:peps_physRealizeLocalOp,
+        def:peps_localVirtualOpOfPhysicalOp,
+        def:peps_localProjector}
+    Let \(P_v=\Phi_v\circ\Psi_v\) be the local projector, and let
+    \(T_O=\Psi_v\circ O\circ\Phi_v\) be the virtual pullback of a physical
+    operator \(O\). Then
+    \[
+        \Phi_v\circ T_O\circ\Psi_v
+            = P_v\circ O\circ P_v .
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Expand the definitions of the physical realization, the virtual pullback,
+    and the local projector.
 \end{proof}
 
 \begin{definition}[Matrix action on one incident virtual edge]%


### PR DESCRIPTION
### Motivation

- Establishes a preparatory local algebra identity toward the three-site insertion recovery in arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, as tracked in #1370.
- For a vertex-injective PEPS tensor, the reverse projection identity states that realizing the pulled-back virtual operator equals compressing the original physical operator to the image of the local tensor map on both sides.
- The shared-bond recovery theorem remains open after this PR.

### Description

- `TNLean/PEPS/VirtualInsertion.lean`: adds `physRealizeLocalOp_localVirtualOpOfPhysicalOp`, proving the identity `R_v(T_O) = P_v ∘ O ∘ P_v`.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds the local-projector blueprint entry and the corresponding theorem statement with its displayed formula.
- This PR does not prove the shared-bond recovery theorem.

### Testing

- `lake env lean TNLean/PEPS/VirtualInsertion.lean`
- `lake build TNLean.PEPS.VirtualInsertion`
- `git diff --check`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/VirtualInsertion.lean`
- Root import check: `TNLean.PEPS.localProjector` and `TNLean.PEPS.physRealizeLocalOp_localVirtualOpOfPhysicalOp` are visible from `import TNLean`.
- `cd blueprint && leanblueprint checkdecls` still reports pre-existing root-import missing declarations outside this change; the two declarations touched by this PR are visible.

Refs #1370