### PR TITLE
fix(blueprint): add missing dependency to PEPS canonical pullback theorem

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -290,6 +290,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_physRealizeLocalOp}
     \leanok
     \uses{def:peps_physRealizeLocalOp,
+        thm:peps_physRealizeLocalOp_spec,
         thm:peps_localVirtualOpOfPhysicalOp_eq_of_realizes}
     Pulling back the canonical physical realization of a virtual operation
     recovers the original virtual operation.


### PR DESCRIPTION
### Motivation

- The blueprint dependency list for the canonical pullback theorem omitted the local virtual-operation specification used by the Lean proof.
- The Lean proof of `thm:peps_localVirtualOpOfPhysicalOp_physRealizeLocalOp` directly invokes `physRealizeLocalOp_spec`, whose blueprint label `thm:peps_physRealizeLocalOp_spec` was absent from the `\uses` block, leaving the dependency graph incomplete.
- Issue #2013 records this as a blueprint-sync follow-up from PR #2011.

### Description

- Adds `thm:peps_physRealizeLocalOp_spec` to the `\uses` block of `thm:peps_localVirtualOpOfPhysicalOp_physRealizeLocalOp` in `blueprint/src/chapter/ch13a_peps_ft.tex`.
- No Lean statements or proofs are changed.

### Testing

- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` was run. It still reports the known pre-existing root-declaration gaps outside this change; the dependency added here is present and not among the missing declarations.

---
Closes #2013

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a `\uses` dependency list; no Lean statements or proofs are modified.
>
> **Overview**
> Updates the blueprint dependency annotation for `thm:peps_localVirtualOpOfPhysicalOp_physRealizeLocalOp` to include `thm:peps_physRealizeLocalOp_spec`, aligning the `\uses` list with what the Lean proof relies on.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c87d75f62ba329a1905f5716cf7f6b570dbcdb6.</sup>