### PR TITLE
feat(MPS/MPDO): derive blocked trace powers from BNT chi

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -278,4 +278,25 @@ theorem eq_trace_pow (h : PositiveBNTLabelChiTracePowerForm c)
 
 end PositiveBNTLabelChiTracePowerForm
 
+namespace BNTBlockedBasisCoefficientComparison
+
+variable {data : AlgebraStructureData d D} {Λ : Type*} {c : BNTLabelCoefficientFamily Λ}
+
+/-- A blocked-basis/BNT-label coefficient comparison transports a positive
+BNT-label chi trace-power witness to each blocked-basis coefficient. -/
+theorem blocked_coeff_eq_trace_pow
+    (cmp : BNTBlockedBasisCoefficientComparison data c)
+    (hχ : PositiveBNTLabelChiTracePowerForm c)
+    (n : ℕ) (hn : 0 < n)
+    (i j : AlgebraStructureData.BlockedIndex data n)
+    (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
+    data.blockedStructureCoefficients n i j k =
+      (hχ.chi.matrix (cmp.sourceLabel n hn i) (cmp.sourceLabel n hn j)
+        (cmp.targetLabel n hn k) ^ n).trace := by
+  rw [cmp.blocked_coeff_eq n hn i j k]
+  exact hχ.eq_trace_pow n hn
+    (cmp.sourceLabel n hn i) (cmp.sourceLabel n hn j) (cmp.targetLabel n hn k)
+
+end BNTBlockedBasisCoefficientComparison
+
 end MPOTensor

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1401,6 +1401,32 @@ the elementary trace-power identity for diagonal matrices.
     from the witness.
 \end{proof}
 
+\begin{theorem}[Blocked coefficients inherit BNT trace powers]%
+    \label{thm:mpdo_bnt_blocked_basis_coefficient_eq_trace_pow}
+    \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow}
+    \leanok
+    \uses{def:mpdo_bnt_blocked_basis_coefficient_comparison,
+        def:mpdo_positive_bnt_label_chi_trace_power_form,
+        thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
+    If the chosen blocked-basis coefficients are compared with the fixed
+    BNT-label coefficient system, and that BNT-label system has a positive
+    length-independent \(\chi\)-witness, then each positive-length blocked
+    coefficient is the trace power of the corresponding BNT-label
+    \(\chi\)-matrix:
+    \[
+        c^{(n)}_{i,j,k}
+          = \operatorname{tr}
+              \bigl(
+                \chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}^{\,n}
+              \bigr).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Use the comparison equality to replace the blocked-basis coefficient by the
+    corresponding BNT-label coefficient, and then apply the BNT-label
+    trace-power formula.
+\end{proof}
+
 \begin{definition}[Blocked $\chi$ family for multiplication coefficients]%
     \label{def:mpdo_blocked_structure_chi_family}
     \lean{MPOTensor.AlgebraStructureData.BlockedStructureChiFamily}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -152,6 +152,10 @@ it is not itself the same-length product statement of Theorem~IV.13(ii).
 These declarations specify the BNT-label coefficient objects and the comparison
 statement, but they do not yet construct the operators, trace scalars,
 coefficients, comparison maps, or \(\chi\)-matrices from an MPDO tensor.
+Once both the comparison predicate and a positive BNT-label \(\chi\)-witness are
+available, the coefficient-level blocked trace-power formula is formalized as a
+direct corollary.\footnote{%
+\leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow}.}
 
 To eliminate the remaining gap, the formalization should introduce:
 \begin{enumerate}
@@ -170,7 +174,9 @@ To eliminate the remaining gap, the formalization should introduce:
           m_\alpha m_\beta\) from the MPDO tensor;
     \item the blocked-basis trace-power statement, with its source-length
         exponent convention, as a derived corollary of the uniform BNT-label
-        theorem, rather than as the theorem itself.
+        theorem, rather than as the theorem itself.  The coefficient-level
+        corollary is now formalized; the remaining work is to construct the
+        source BNT-label data and comparison maps from an MPDO tensor.
 \end{enumerate}
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
### Motivation

- Continue the #2000 elimination plan for CPGSV17 Theorem IV.13(ii).
- The BNT-label chi witness and the blocked-basis comparison predicate already exist. This PR proves the coefficient-level corollary connecting them: once the comparison and a positive BNT-label chi witness are supplied, each blocked-basis coefficient is the trace power of the corresponding BNT-label chi matrix.
- This is a preparatory theorem. It does not construct the BNT labels, comparison maps, operator family, trace scalars, or chi witness from an MPDO tensor, so #2000 remains open.

### Description

- Adds `MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow` in `TNLean/MPS/MPDO/BNTCoefficients.lean`.
- Adds the matching Chapter 2b blueprint theorem.
- Updates `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` to record that this coefficient-level corollary is formalized while the source-data construction remains open.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients`
- `lake build TNLean`
- `lake env lean --stdin` root import check for `MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow`
- `git diff --check`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/MPDO/BNTCoefficients.lean`
- `cd blueprint && leanblueprint checkdecls` was run. It still reports the known pre-existing root-declaration gaps outside this change; the declaration added here is visible from `import TNLean`.

Refs #2000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small derived lemma connecting existing comparison and χ-trace-power assumptions; changes are purely additive and proof-level, with no runtime/data-handling impact.
> 
> **Overview**
> Derives a new corollary `MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow` showing that, given a `BNTBlockedBasisCoefficientComparison` and a `PositiveBNTLabelChiTracePowerForm`, each positive-length blocked-basis multiplication coefficient equals the trace of the corresponding BNT-label `χ` matrix raised to the source length.
> 
> Updates the blueprint and the paper-gaps note to document this blocked coefficient trace-power corollary as formalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b42a796248fc53353acb63f8bf3071901b6d6e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->