### PR TITLE
doc(MPS/MPDO): update commuting bridge status

### DIFF
--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -17,17 +17,19 @@ The current repository already exposes the local entropy-side ingredients
 * `MPOTensor.sal_implies_eta_structure`, and
 * `MPOTensor.sal_zcl_implies_rank_one_T`,
 
-but the extraction of the explicit neighboring operators `η_{k,h}` from the
-Hayashi Markov decomposition is still open. We therefore introduce the exact
-local-to-global witness that the future extraction theorem should produce: a
-single translation-invariant positive two-site bond whose translated copies
-commute on all periodic chains and realize the MPO on every finite length.
+and `SimpleLocalStructure` now gives the sector-reduced neighboring operators
+`MPOTensor.ExplicitEtaOperators.ofHayashiMarkov`. The remaining Appendix C.2
+step is no longer merely to write down such sector-local operators; it is to
+assemble the simple-MPDO tensor coordinates into a single translation-invariant
+positive two-site bond whose translated copies commute on all periodic chains
+and realize the MPO on every finite length.
 
 This is the strongest unconditional forward step currently available.
-Once the explicit `η_{k,h}` operators are available, the intended future
-Proposition C.6 proof should first construct `EtaLocalStructureData M`; the
-existing theorem `hasCommutingForm_of_etaLocalStructure` will then discharge the
-global commuting-form target.
+The intended future Proposition C.6 proof should construct
+`EtaLocalStructureData M` from the SAL and ZCL hypotheses, using the
+sector-reduced `η_{k,h}` operators and the inverse-map layer; the existing
+theorem `hasCommutingForm_of_etaLocalStructure` will then discharge the global
+commuting-form target.
 
 ## Main declarations
 
@@ -95,16 +97,17 @@ def toCommutingFormData (data : TranslationInvariantBondData d) {N : ℕ}
 
 end TranslationInvariantBondData
 
-/-- The explicit `η`-local structure needed for Appendix C.2 once the abstract
-Hayashi decomposition has been converted into concrete neighboring operators.
+/-- The explicit `η`-local structure needed for Appendix C.2 after the
+sector-local neighboring operators have been assembled in the original tensor
+coordinates.
 
 Concretely, this structure stores the single translation-invariant bond extracted
 from the local simple-MPDO analysis, together with proofs that it realizes the
 finite-chain MPO operators. This is stronger than `HasCommutingForm M`, since
 it requires one bond that works for every chain length rather than a separate
-commuting-form witness at each length. The remaining extraction theorem should
-construct this data from `EtaStructure` and the rank-one factorization of the
-local transfer matrix. -/
+commuting-form witness at each length. The remaining assembly theorem should
+construct this data from the SAL and ZCL hypotheses, the sector-reduced
+`η_{k,h}` family, and the inverse-map realization layer. -/
 structure EtaLocalStructureData (M : MPOTensor d D) where
   /-- The chain-independent nearest-neighbor bond extracted from the local
   `η_{k,h}` operators. -/

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1619,11 +1619,15 @@ the elementary trace-power identity for diagonal matrices.
 \begin{remark}[Entropy-side construction]
     The entropy-side theorem still to be supplied constructs the local data needed for
     Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure} from the SAL
-    and ZCL hypotheses. In particular, one must extract explicit neighboring
-    operators $\eta_{k,h}$ from the Hayashi Markov decomposition. Once these
-    operators are available, Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
-    yields the commuting-form conclusion and hence the GSNNCH branch of the
-    simple-MPDO equivalence.
+    and ZCL hypotheses. The sector-reduced neighboring operators $\eta_{k,h}$
+    are already provided by Definition~\ref{def:mpdo_eta_of_hayashi_markov}.
+    What remains is to identify this sector family with the inverse-map
+    construction in the original simple-MPDO tensor coordinates and assemble it
+    into a single translation-invariant positive two-site bond realizing all
+    finite chains. Once this assembly is available,
+    Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure} yields the
+    commuting-form conclusion and hence the GSNNCH branch of the simple-MPDO
+    equivalence.
 \end{remark}
 
 \section{Blocked-RFP construction for simple MPDOs}


### PR DESCRIPTION
### Motivation

- The Hayashi--Markov sector-local eta extraction landed (see #833), so the docstring in `CommutingFormBridge.lean` no longer correctly identifies what remains open.
- The blueprint remark for #823 was still pointing at the sector-local extraction as the open gap, rather than at the remaining assembly step: constructing a single translation-invariant positive two-site bond from the sector-reduced operators.

### Description

- `TNLean/MPS/MPDO/CommutingFormBridge.lean`: updated the module docstring to reflect that `SimpleLocalStructure` now provides sector-reduced neighboring operators via `ExplicitEtaOperators.ofHayashiMarkov`; reframed the remaining Appendix C.2 work as assembling these into a translation-invariant commuting bond.
- `blueprint/src/chapter/ch02b_mpdo.tex`: adjusted the open-gap remark to point at the assembly and coordinate-identification step through the inverse-map layer, rather than at the already-formalized sector-local extraction.

No Lean definitions, lemma statements, or proof terms were changed; this is a documentation-only update.

### Testing

- `lake env lean TNLean/MPS/MPDO/CommutingFormBridge.lean`
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` (pre-existing failures outside this MPDO change only)

---
Refs #823
Related: #833