### PR TITLE
feat(MPS/MPDO): derive BNT idempotent chi trace form

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -278,6 +278,33 @@ theorem eq_trace_pow (h : PositiveBNTLabelChiTracePowerForm c)
 
 end PositiveBNTLabelChiTracePowerForm
 
+namespace BNTLabelTraceScalarFamily
+
+variable {Λ : Type*} {c : BNTLabelCoefficientFamily Λ}
+  {m : BNTLabelTraceScalarFamily Λ}
+
+/-- The BNT idempotent scalar identity, after substituting the length-one
+trace formula supplied by a positive BNT-label chi witness.
+
+This is the coefficient-level combination of the idempotent condition in
+arXiv:1606.00608, Theorem IV.13(ii), lines 981--985, with the trace-power
+formula for \(c^{(1)}_{\alpha,\beta,\gamma}\). -/
+theorem HasIdempotentCoefficientForm.eq_sum_chi_trace [Fintype Λ]
+    (hm : m.HasIdempotentCoefficientForm c)
+    (hχ : PositiveBNTLabelChiTracePowerForm c) (γ : Λ) :
+    m.traceScalar γ =
+      ∑ α : Λ, ∑ β : Λ,
+        (hχ.chi.matrix α β γ).trace * (m.traceScalar α * m.traceScalar β) := by
+  rw [BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum (m := m) hm γ]
+  refine Finset.sum_congr rfl ?_
+  intro α _hα
+  refine Finset.sum_congr rfl ?_
+  intro β _hβ
+  rw [hχ.eq_trace_pow 1 Nat.zero_lt_one α β γ]
+  simp
+
+end BNTLabelTraceScalarFamily
+
 namespace BNTBlockedBasisCoefficientComparison
 
 variable {data : AlgebraStructureData d D} {Λ : Type*} {c : BNTLabelCoefficientFamily Λ}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1401,6 +1401,28 @@ the elementary trace-power identity for diagonal matrices.
     from the witness.
 \end{proof}
 
+\begin{theorem}[BNT idempotent coefficients as chi traces]%
+    \label{thm:mpdo_bnt_label_idempotent_eq_sum_chi_trace}
+    \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.
+        eq_sum_chi_trace}
+    \leanok
+    \uses{thm:mpdo_bnt_label_idempotent_coefficient_eq_sum,
+        thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
+    If the BNT trace scalars satisfy the idempotent coefficient condition and
+    the BNT-label coefficients come from a positive length-independent
+    \(\chi\)-witness, then
+    \[
+        m_\gamma =
+          \sum_{\alpha,\beta}
+            \operatorname{tr}(\chi_{\alpha,\beta,\gamma})
+            m_\alpha m_\beta .
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Substitute the length-one trace-power formula into the idempotent
+    coefficient identity.
+\end{proof}
+
 \begin{theorem}[Blocked coefficients inherit BNT trace powers]%
     \label{thm:mpdo_bnt_blocked_basis_coefficient_eq_trace_pow}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -156,6 +156,11 @@ Once both the comparison predicate and a positive BNT-label \(\chi\)-witness are
 available, the coefficient-level blocked trace-power formula is formalized as a
 direct corollary.\footnote{%
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow}.}
+Likewise, once the idempotent coefficient condition and the positive
+BNT-label \(\chi\)-witness are available, the length-one idempotent identity is
+formalized with the coefficients rewritten as traces of the corresponding
+\(\chi\)-matrices.\footnote{%
+\leanid{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum_chi_trace}.}
 
 To eliminate the remaining gap, the formalization should introduce:
 \begin{enumerate}


### PR DESCRIPTION
### Motivation

- Continues formalization of arXiv:1606.00608, Theorem IV.13(ii), establishing the chi trace-power formula for BNT-label coefficients; tracked in #2000.
- The `HasIdempotentCoefficientForm` predicate asserts the idempotent scalar identity in terms of the length-one chi trace; this result provides the rewriting step that connects the abstract predicate to a `PositiveBNTLabelChiTracePowerForm` witness.
- The chi-uniformity paper-gap note requires updating to record this derived coefficient-level consequence.

### Description

- `TNLean/MPS/MPDO/BNTCoefficients.lean`: adds theorem `BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum_chi_trace`, rewriting the BNT idempotent scalar identity using the length-one trace formula from a `PositiveBNTLabelChiTracePowerForm` witness.
- `blueprint/src/chapter/ch02b_mpdo.tex`: adds the corresponding Chapter 2b blueprint entry with `\lean{}` and `\leanok` tags.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`: records this derived coefficient-level consequence in the chi-uniformity paper-gap note.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients`
- `lake build TNLean`
- `git diff --check`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/MPDO/BNTCoefficients.lean`
- `leanblueprint checkdecls` (pre-existing missing declarations outside this MPDO change only)

---
Refs #2000