### PR TITLE
feat(PEPS): add pullback extensionality

### DIFF
--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -426,6 +426,37 @@ theorem localVirtualOpOfPhysicalOp_eq_of_realizes (A : Tensor G d)
       rw [hO c]
       simp
 
+/-- Two physical endpoint operations have the same virtual pullback if their
+projected actions agree on the image of the local tensor map. -/
+theorem localVirtualOpOfPhysicalOp_eq_of_projected_action_eq (A : Tensor G d)
+    (hA : IsVertexInjective A) (v : V)
+    (O O' : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hOO' : ∀ c : LocalVirtualConfig A v → ℂ,
+      localProjector A hA v (O (localTensorMap A v c)) =
+        localProjector A hA v (O' (localTensorMap A v c))) :
+    localVirtualOpOfPhysicalOp A hA v O =
+      localVirtualOpOfPhysicalOp A hA v O' := by
+  apply LinearMap.ext
+  intro c
+  apply hA.localTensorMap_injective v
+  rw [localVirtualOpOfPhysicalOp_spec, localVirtualOpOfPhysicalOp_spec, hOO']
+
+/-- Equality of virtual pullbacks is equivalent to equality of the projected
+physical actions on the image of the local tensor map. -/
+theorem localVirtualOpOfPhysicalOp_eq_iff_projected_action_eq (A : Tensor G d)
+    (hA : IsVertexInjective A) (v : V)
+    (O O' : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) :
+    localVirtualOpOfPhysicalOp A hA v O =
+        localVirtualOpOfPhysicalOp A hA v O' ↔
+      ∀ c : LocalVirtualConfig A v → ℂ,
+        localProjector A hA v (O (localTensorMap A v c)) =
+          localProjector A hA v (O' (localTensorMap A v c)) := by
+  constructor
+  · intro h c
+    rw [← localVirtualOpOfPhysicalOp_spec A hA v O c,
+      ← localVirtualOpOfPhysicalOp_spec A hA v O' c, h]
+  · exact localVirtualOpOfPhysicalOp_eq_of_projected_action_eq A hA v O O'
+
 /-- Pulling back the canonical physical realization of a virtual operation
 recovers the original virtual operation. -/
 theorem localVirtualOpOfPhysicalOp_physRealizeLocalOp (A : Tensor G d)

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -285,6 +285,29 @@ injective and normal PEPS, following Theorems~2 and~3 of
     virtual operations agree.
 \end{proof}
 
+\begin{theorem}[Extensionality of physical-to-virtual pullback]%
+    \label{thm:peps_localVirtualOpOfPhysicalOp_eq_of_projected_action_eq}
+    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_of_projected_action_eq}
+    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_iff_projected_action_eq}
+    \leanok
+    \uses{def:IsVertexInjective,
+        thm:peps_localVirtualOpOfPhysicalOp_spec}
+    Two physical endpoint operations have the same virtual pullback exactly when
+    their projected actions agree on every vector in the image of the local
+    tensor map:
+    \[
+        T_O = T_{O'}
+        \quad\Longleftrightarrow\quad
+        P_v O \Phi_v(c)=P_v O'\Phi_v(c)
+        \quad\text{for all }c .
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Apply the local tensor map to the two virtual pullbacks and use the
+    pullback specification. The converse follows from vertex injectivity; the
+    forward direction is obtained by rewriting the two virtual pullbacks.
+\end{proof}
+
 \begin{theorem}[Pullback of the canonical physical realization]%
     \label{thm:peps_localVirtualOpOfPhysicalOp_physRealizeLocalOp}
     \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_physRealizeLocalOp}


### PR DESCRIPTION
## Summary

This PR adds a local extensionality statement for the physical-to-virtual pullback used in the PEPS insertion formalization. For a vertex-injective local tensor, two endpoint physical operations induce the same virtual pullback exactly when their projected actions agree on the image of the local tensor map.

The result is recorded both as a one-way equality theorem and as an iff theorem. The PEPS blueprint now contains the corresponding statement and proof sketch near the existing local pullback results.

This is a preparatory local step for the physical-to-virtual recovery problem in #1370. It does not prove the remaining shared-bond matrix recovery statement.

## Validation

- lake env lean TNLean/PEPS/VirtualInsertion.lean
- lake build TNLean.PEPS.VirtualInsertion
- lake build TNLean
- git diff --check
- cd blueprint && leanblueprint checkdecls (the new PEPS declarations are found; the command still reports pre-existing missing declarations elsewhere)

Refs #1370