### PR TITLE
feat(MPS/MPDO): rewrite BNT product coefficients as chi traces

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -278,6 +278,32 @@ theorem eq_trace_pow (h : PositiveBNTLabelChiTracePowerForm c)
 
 end PositiveBNTLabelChiTracePowerForm
 
+namespace BNTLabelOperatorFamily
+
+variable {Λ : Type*} {O : ℕ → Type*} {c : BNTLabelCoefficientFamily Λ}
+  {op : BNTLabelOperatorFamily Λ O}
+
+/-- The same-length BNT product formula, after substituting the trace-power
+formula supplied by a positive BNT-label chi witness.
+
+This is the coefficient-level combination of the product identity in
+arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, with the trace-power
+formula for \(c^{(L)}_{\alpha,\beta,\gamma}\). -/
+theorem HasSameLengthProductForm.eq_sum_chi_trace_pow [Fintype Λ]
+    [∀ L : ℕ, AddCommMonoid (O L)] [∀ L : ℕ, Module ℂ (O L)]
+    [∀ L : ℕ, Mul (O L)]
+    (hop : op.HasSameLengthProductForm c)
+    (hχ : PositiveBNTLabelChiTracePowerForm c)
+    (L : ℕ) (hL : 0 < L) (α β : Λ) :
+    op.operator L α * op.operator L β =
+      ∑ γ : Λ, (hχ.chi.matrix α β γ ^ L).trace • op.operator L γ := by
+  rw [BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum (op := op) hop L hL α β]
+  refine Finset.sum_congr rfl ?_
+  intro γ _hγ
+  rw [hχ.eq_trace_pow L hL α β γ]
+
+end BNTLabelOperatorFamily
+
 namespace BNTLabelTraceScalarFamily
 
 variable {Λ : Type*} {c : BNTLabelCoefficientFamily Λ}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1401,6 +1401,29 @@ the elementary trace-power identity for diagonal matrices.
     from the witness.
 \end{proof}
 
+\begin{theorem}[Same-length BNT product with chi-trace coefficients]%
+    \label{thm:mpdo_bnt_label_same_length_product_eq_sum_chi_trace_pow}
+    \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.
+        eq_sum_chi_trace_pow}
+    \leanok
+    \uses{thm:mpdo_bnt_label_same_length_product_eq_sum,
+        thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
+    If the same-length BNT product identity holds and the BNT-label
+    coefficients come from a positive length-independent \(\chi\)-witness, then
+    for every \(L>0\),
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
+          = \sum_\gamma
+            \operatorname{tr}\bigl(
+              \chi_{\alpha,\beta,\gamma}^{\,L}
+            \bigr) O_L(M_\gamma).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Substitute the positive-length trace-power formula into the same-length BNT
+    product expansion.
+\end{proof}
+
 \begin{theorem}[BNT idempotent coefficients as chi traces]%
     \label{thm:mpdo_bnt_label_idempotent_eq_sum_chi_trace}
     \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -152,6 +152,11 @@ it is not itself the same-length product statement of Theorem~IV.13(ii).
 These declarations specify the BNT-label coefficient objects and the comparison
 statement, but they do not yet construct the operators, trace scalars,
 coefficients, comparison maps, or \(\chi\)-matrices from an MPDO tensor.
+Once both the same-length BNT product form and a positive BNT-label
+\(\chi\)-witness are available, the same-length product expansion with
+coefficients written as \(\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)\)
+is formalized as a direct corollary.\footnote{%
+\leanid{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum_chi_trace_pow}.}
 Once both the comparison predicate and a positive BNT-label \(\chi\)-witness are
 available, the coefficient-level blocked trace-power formula is formalized as a
 direct corollary.\footnote{%


### PR DESCRIPTION
## Summary

This PR adds the same-length BNT product corollary obtained by substituting the positive BNT-label chi trace-power formula into the same-length BNT product identity. For every positive length L, the product expansion coefficients are rewritten as traces of the powers of the length-independent matrices chi_{alpha,beta,gamma}.

The result is a coefficient-level consequence of the already stated BNT product form and positive chi witness. It does not construct the BNT labels, operators, comparison maps, trace scalars, or chi witness from an MPDO tensor.

## Validation

- lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean
- lake build TNLean.MPS.MPDO.BNTCoefficients
- lake build TNLean
- git diff --check
- cd blueprint && leanblueprint checkdecls (the new MPDO declaration is found; the command still reports pre-existing missing declarations elsewhere)

Refs #2000