### PR TITLE
doc(PEPS): fix pullback extensionality lean tag

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -287,7 +287,6 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Extensionality of physical-to-virtual pullback]%
     \label{thm:peps_localVirtualOpOfPhysicalOp_eq_of_projected_action_eq}
-    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_of_projected_action_eq}
     \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_iff_projected_action_eq}
     \leanok
     \uses{def:IsVertexInjective,


### PR DESCRIPTION
### Motivation

- The blueprint entry `thm:peps_localVirtualOpOfPhysicalOp_eq_of_projected_action_eq` in `blueprint/src/chapter/ch13a_peps_ft.tex` states a biconditional, but carried two `\lean{}` tags — one for the full iff theorem and one for a one-way (sufficiency-only) lemma. A `\lean{}` tag on a biconditional blueprint entry claims the tagged declaration formalizes the biconditional; the one-way lemma does not.
- Addresses the tag mismatch identified in #2020, a follow-up to #2018.
- Mathematical source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`.

### Description

- `blueprint/src/chapter/ch13a_peps_ft.tex`: removed `\lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_of_projected_action_eq}` from the biconditional entry, leaving `\lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_iff_projected_action_eq}` as the sole `\lean{}` tag on `thm:peps_localVirtualOpOfPhysicalOp_eq_of_projected_action_eq`.
- The one-way lemma remains in Lean as an auxiliary result used in the proof of the iff, but is no longer tagged as formalizing the biconditional statement.

### Testing

- `git diff --check`: no whitespace errors.
- `cd blueprint && leanblueprint checkdecls`: the corrected PEPS declaration is found; pre-existing missing declarations elsewhere are unaffected.
- Relies on Blueprint Lint CI (`lint-blueprint.yml`) to validate blueprint references.

---
Addresses #2020

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates a Lean declaration reference; no executable code or mathematical statements are altered.
> 
> **Overview**
> Updates the blueprint theorem *"Extensionality of physical-to-virtual pullback"* to reference the correct Lean formalization: removes the one-way lemma tag and keeps only the biconditional `TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_iff_projected_action_eq` to match the stated iff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c765ff7e057e5cb48921e18c28032c99412488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->