### PR TITLE
feat(MPS/MPDO): pull back BNT chi witnesses

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -554,6 +554,11 @@ namespace DiagonalChiFamily
 
 variable {I : Type*} (χ : DiagonalChiFamily I)
 
+/-- Reindex a diagonal chi family along a map of labels. -/
+def comap {J : Type*} (f : J → I) : DiagonalChiFamily J where
+  dim α β γ := χ.dim (f α) (f β) (f γ)
+  entry α β γ k := χ.entry (f α) (f β) (f γ) k
+
 /-- The underlying diagonal matrix `χ_{α,β,γ}` on the index set `Fin (dim α β γ)`. -/
 noncomputable def matrix (α β γ : I) :
     Matrix (Fin (χ.dim α β γ)) (Fin (χ.dim α β γ)) ℂ :=
@@ -582,6 +587,13 @@ Under the scoped `ComplexOrder` instance (opened at the top of the file), a
 strict inequality `0 < z` on `ℂ` is equivalent to `0 < z.re ∧ z.im = 0`. -/
 def PosEntries : Prop :=
   ∀ α β γ : I, ∀ k : Fin (χ.dim α β γ), 0 < χ.entry α β γ k
+
+/-- Reindexing preserves positivity of the diagonal entries. -/
+theorem PosEntries.comap {J : Type*} {χ : DiagonalChiFamily I}
+    (hχ : χ.PosEntries) (f : J → I) :
+    (χ.comap f).PosEntries := by
+  intro α β γ k
+  exact hχ (f α) (f β) (f γ) k
 
 end DiagonalChiFamily
 

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -23,7 +23,7 @@ comparison work.
   Theorem IV.13(ii) and Appendix C.3--C.4
 -/
 
-open scoped BigOperators
+open scoped BigOperators ComplexOrder
 
 namespace MPOTensor
 
@@ -335,6 +335,15 @@ namespace BNTBlockedBasisCoefficientComparison
 
 variable {data : AlgebraStructureData d D} {Λ : Type*} {c : BNTLabelCoefficientFamily Λ}
 
+/-- The label map on the disjoint union of source and target blocked basis
+indices at a positive blocked length. -/
+def blockedLabel (cmp : BNTBlockedBasisCoefficientComparison data c)
+    (n : ℕ) (hn : 0 < n) :
+    AlgebraStructureData.BlockedIndex data n ⊕
+      AlgebraStructureData.BlockedIndex data (2 * n) → Λ
+  | Sum.inl i => cmp.sourceLabel n hn i
+  | Sum.inr k => cmp.targetLabel n hn k
+
 /-- A blocked-basis/BNT-label coefficient comparison transports a positive
 BNT-label chi trace-power witness to each blocked-basis coefficient. -/
 theorem blocked_coeff_eq_trace_pow
@@ -349,6 +358,56 @@ theorem blocked_coeff_eq_trace_pow
   rw [cmp.blocked_coeff_eq n hn i j k]
   exact hχ.eq_trace_pow n hn
     (cmp.sourceLabel n hn i) (cmp.sourceLabel n hn j) (cmp.targetLabel n hn k)
+
+/-- The blocked chi family obtained by pulling back a BNT-label chi witness
+along a blocked-basis comparison.
+
+The comparison maps are defined only for positive lengths.  The value at
+`n = 0` is therefore filled by an arbitrary BNT label; this component is not
+used by the positive-length blocked trace-power identity. -/
+def pulledBlockedChiFamily [Inhabited Λ]
+    (cmp : BNTBlockedBasisCoefficientComparison data c)
+    (hχ : PositiveBNTLabelChiTracePowerForm c) :
+    AlgebraStructureData.BlockedStructureChiFamily data where
+  toDiagonal n :=
+    if hn : 0 < n then
+      hχ.chi.comap (cmp.blockedLabel n hn)
+    else
+      hχ.chi.comap fun _ => default
+
+/-- A positive BNT-label chi witness and a blocked-basis comparison give a
+positive blocked chi trace-power witness.
+
+This is a derived blocked-basis statement.  It does not construct the BNT-label
+coefficient family or comparison maps from an MPDO tensor; it only transports an
+already given uniform BNT-label witness along an already given comparison.  The
+`Inhabited Λ` assumption supplies the unused zero-length component of the
+blocked chi family.
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.3--C.4,
+lines 1830--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+def toPositiveBlockedStructureChiTracePowerForm [Inhabited Λ]
+    (cmp : BNTBlockedBasisCoefficientComparison data c)
+    (hχ : PositiveBNTLabelChiTracePowerForm c) :
+    AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm data where
+  chi := cmp.pulledBlockedChiFamily hχ
+  posEntries := by
+    intro n i j k r
+    by_cases hn : 0 < n
+    · have hpos : ((cmp.pulledBlockedChiFamily hχ).toDiagonal n).PosEntries := by
+        simpa only [pulledBlockedChiFamily, dif_pos hn] using
+          hχ.posEntries.comap (cmp.blockedLabel n hn)
+      exact hpos (Sum.inl i) (Sum.inl j) (Sum.inr k) r
+    · have hpos : ((cmp.pulledBlockedChiFamily hχ).toDiagonal n).PosEntries := by
+        simpa only [pulledBlockedChiFamily, dif_neg hn] using
+          hχ.posEntries.comap fun _ => default
+      exact hpos (Sum.inl i) (Sum.inl j) (Sum.inr k) r
+  tracePower := by
+    intro n hn i j k
+    rw [cmp.blocked_coeff_eq n hn i j k]
+    simpa only [AlgebraStructureData.BlockedStructureChiFamily.tracePowerCoeff,
+      pulledBlockedChiFamily, DiagonalChiFamily.comap, blockedLabel, dif_pos hn] using
+      hχ.tracePower n hn
+        (cmp.sourceLabel n hn i) (cmp.sourceLabel n hn j) (cmp.targetLabel n hn k)
 
 end BNTBlockedBasisCoefficientComparison
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1551,6 +1551,33 @@ the elementary trace-power identity for diagonal matrices.
     \path{docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex}.
 \end{definition}
 
+\begin{theorem}[BNT witnesses give blocked \(\chi\) witnesses]%
+    \label{thm:mpdo_bnt_blocked_basis_to_positive_blocked_chi_trace_power_form}
+    \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.
+        toPositiveBlockedStructureChiTracePowerForm}
+    \leanok
+    \uses{def:mpdo_bnt_blocked_basis_coefficient_comparison,
+        def:mpdo_positive_bnt_label_chi_trace_power_form,
+        def:mpdo_positive_blocked_structure_chi_trace_power_form,
+        thm:mpdo_bnt_blocked_basis_coefficient_eq}
+    Suppose that the chosen blocked-basis coefficients are compared with a
+    fixed BNT-label coefficient system, and that this BNT-label system has a
+    positive length-independent \(\chi\)-witness.  Assume also that the
+    BNT-label type is nonempty.  Then the chosen blocked bases carry a
+    positive blocked \(\chi\) trace-power witness.
+    The construction is obtained by pulling back the BNT-label
+    \(\chi_{\alpha,\beta,\gamma}\)-matrices along the source and target label
+    maps.  The auxiliary choice of a BNT label is used only to fill the
+    zero-length component, which is absent from the positive-length trace-power
+    statement.
+\end{theorem}
+\begin{proof}\leanok
+    Reindex the positive BNT-label \(\chi\)-family along the blocked-basis
+    label map.  Positivity is preserved by reindexing, and the trace-power
+    identity follows by substituting the blocked-basis comparison into the
+    BNT-label trace-power formula.
+\end{proof}
+
 \begin{theorem}[Positive blocked $\chi$ witness gives trace powers]%
     \label{thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
     \lean{MPOTensor.AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm.eq_trace_pow}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -161,6 +161,10 @@ Once both the comparison predicate and a positive BNT-label \(\chi\)-witness are
 available, the coefficient-level blocked trace-power formula is formalized as a
 direct corollary.\footnote{%
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow}.}
+The same hypotheses also give a positive blocked-basis \(\chi\)-witness by
+pulling back the uniform BNT-label \(\chi\)-family along the
+comparison maps.\footnote{%
+\leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.toPositiveBlockedStructureChiTracePowerForm}.}
 Likewise, once the idempotent coefficient condition and the positive
 BNT-label \(\chi\)-witness are available, the length-one idempotent identity is
 formalized with the coefficients rewritten as traces of the corresponding
@@ -185,8 +189,9 @@ To eliminate the remaining gap, the formalization should introduce:
     \item the blocked-basis trace-power statement, with its source-length
         exponent convention, as a derived corollary of the uniform BNT-label
         theorem, rather than as the theorem itself.  The coefficient-level
-        corollary is now formalized; the remaining work is to construct the
-        source BNT-label data and comparison maps from an MPDO tensor.
+        corollary and the corresponding positive blocked \(\chi\)-witness are
+        now formalized; the remaining work is to construct the source BNT-label
+        data and comparison maps from an MPDO tensor.
 \end{enumerate}
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
### Motivation

- Advances step 3 of the elimination plan documented in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` for the gap between the blocked-basis chi analogue (introduced in #1999) and the uniform BNT-label statement of arXiv:1606.00608, Theorem IV.13(ii).
- A bridge result is needed: given a positive uniform BNT-label chi family and blocked-basis comparison data, one can produce a positive blocked chi trace-power witness. This is a prerequisite for deriving `HasBlockedStructureChiTracePowerForm` as a corollary of the paper's uniform chi family, as called for by issue #2000.

### Description

- `TNLean/MPS/MPDO/BNTCoefficients.lean`: adds `DiagonalChiFamily.comap` (reindexing a diagonal chi family along a function) and a lemma that `PosEntries` is preserved under reindexing; adds `BNTBlockedBasisCoefficientComparison.blockedLabel` (combining source and target BNT-label maps into a single map on the blocked source/target index sum); adds `BNTBlockedBasisCoefficientComparison.pulledBlockedChiFamily` (the blocked chi family obtained by pulling back a uniform BNT-label chi family along `blockedLabel`); adds `BNTBlockedBasisCoefficientComparison.toPositiveBlockedStructureChiTracePowerForm` (derives a positive blocked chi trace-power witness from a positive BNT-label chi witness and comparison data — bridge step toward arXiv:1606.00608, Appendix C.3–C.4).
- `TNLean/MPS/MPDO/AlgebraStructure.lean`: minor additions (12 lines) supporting the above.
- `blueprint/src/chapter/ch02b_mpdo.tex`: adds blueprint entries for the new bridge theorem.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`: updates the paper-gap note to reference the new bridge theorem.
- This PR does not construct BNT-label data from an MPDO tensor; that remains the source-faithful Appendix C.3–C.4 obligation tracked in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` and issue #2000.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients`
- `lake build TNLean`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/MPDO/AlgebraStructure.lean TNLean/MPS/MPDO/BNTCoefficients.lean` — no new occurrences in changed files
- `cd blueprint && leanblueprint checkdecls` — new declaration not reported missing; pre-existing missing declarations unchanged
- Pre-existing build warnings in unrelated files (e.g., `TNLean/Spectral/GaugeConstruction.lean`) are not introduced by this PR.

---
Addresses #2000

> [!NOTE]
> **Low Risk**
> Mostly additive Lean definitions/lemmas that reindex existing `DiagonalChiFamily` witnesses and transport positivity/trace-power statements; low risk since it doesn't change existing semantics, but it touches foundational MPDO witness plumbing.
> 
> **Overview**
> Adds a `DiagonalChiFamily.comap` reindexing operation and a lemma that `PosEntries` is preserved under reindexing.
> 
> Builds a derived bridge from *uniform BNT-label* chi witnesses to the existing *blocked-basis* witness: it packages source/target label maps into a single `blockedLabel`, pulls back the BNT `χ` family to a blocked `χ` family (filling the unused `n=0` case via `Inhabited`), and defines `toPositiveBlockedStructureChiTracePowerForm` to transport positivity and the positive-length trace-power identity.
> 
> Updates the blueprint and paper-gap docs to state/reference this new "BNT witnesses give blocked `χ` witnesses" theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0c899fdb37038208fae14d83cbfe12c3617b22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive Lean definitions/lemmas that reindex existing `DiagonalChiFamily` data and transport positivity/trace-power statements; low risk because it doesn’t change existing semantics, but it adds new plumbing used by later MPDO witness derivations.
> 
> **Overview**
> Adds a reusable `DiagonalChiFamily.comap` reindexing operation plus a lemma that `PosEntries` is preserved under reindexing.
> 
> Builds a bridge from *uniform BNT-label* chi witnesses to the existing *blocked-basis* witness layer: it combines source/target label maps into a single `blockedLabel`, pulls back the BNT `χ` family into a blocked `χ` family (with an `Inhabited` filler for the unused `n = 0` case), and defines `toPositiveBlockedStructureChiTracePowerForm` to transport positivity and the positive-length trace-power identity.
> 
> Updates the blueprint and paper-gap documentation to state/reference the new bridge theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 469d2a226058114292b1b8b79223c3469a0990b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->