### PR TITLE
refactor(MPS/MPDO): avoid label choice in chi pullback

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -554,6 +554,11 @@ namespace DiagonalChiFamily
 
 variable {I : Type*} (χ : DiagonalChiFamily I)
 
+/-- The diagonal chi family with empty diagonal matrices for every triple. -/
+def empty (I : Type*) : DiagonalChiFamily I where
+  dim _ _ _ := 0
+  entry _ _ _ k := Fin.elim0 k
+
 /-- Reindex a diagonal chi family along a map of labels. -/
 def comap {J : Type*} (f : J → I) : DiagonalChiFamily J where
   dim α β γ := χ.dim (f α) (f β) (f γ)
@@ -587,6 +592,11 @@ Under the scoped `ComplexOrder` instance (opened at the top of the file), a
 strict inequality `0 < z` on `ℂ` is equivalent to `0 < z.re ∧ z.im = 0`. -/
 def PosEntries : Prop :=
   ∀ α β γ : I, ∀ k : Fin (χ.dim α β γ), 0 < χ.entry α β γ k
+
+/-- The empty diagonal chi family has positive entries vacuously. -/
+theorem PosEntries.empty (I : Type*) : (empty I).PosEntries := by
+  intro α β γ k
+  exact Fin.elim0 k
 
 /-- Reindexing preserves positivity of the diagonal entries. -/
 theorem PosEntries.comap {J : Type*} {χ : DiagonalChiFamily I}

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -363,9 +363,9 @@ theorem blocked_coeff_eq_trace_pow
 along a blocked-basis comparison.
 
 The comparison maps are defined only for positive lengths.  The value at
-`n = 0` is therefore filled by an arbitrary BNT label; this component is not
-used by the positive-length blocked trace-power identity. -/
-def pulledBlockedChiFamily [Inhabited Λ]
+`n = 0` is therefore the empty diagonal family; this component is not used by
+the positive-length blocked trace-power identity. -/
+def pulledBlockedChiFamily
     (cmp : BNTBlockedBasisCoefficientComparison data c)
     (hχ : PositiveBNTLabelChiTracePowerForm c) :
     AlgebraStructureData.BlockedStructureChiFamily data where
@@ -373,7 +373,7 @@ def pulledBlockedChiFamily [Inhabited Λ]
     if hn : 0 < n then
       hχ.chi.comap (cmp.blockedLabel n hn)
     else
-      hχ.chi.comap fun _ => default
+      DiagonalChiFamily.empty _
 
 /-- A positive BNT-label chi witness and a blocked-basis comparison give a
 positive blocked chi trace-power witness.
@@ -381,11 +381,11 @@ positive blocked chi trace-power witness.
 This is a derived blocked-basis statement.  It does not construct the BNT-label
 coefficient family or comparison maps from an MPDO tensor; it only transports an
 already given uniform BNT-label witness along an already given comparison.  The
-`Inhabited Λ` assumption supplies the unused zero-length component of the
-blocked chi family.
+unused zero-length component of the blocked chi family is filled by empty
+diagonal matrices.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.3--C.4,
 lines 1830--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-def toPositiveBlockedStructureChiTracePowerForm [Inhabited Λ]
+def toPositiveBlockedStructureChiTracePowerForm
     (cmp : BNTBlockedBasisCoefficientComparison data c)
     (hχ : PositiveBNTLabelChiTracePowerForm c) :
     AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm data where
@@ -399,7 +399,9 @@ def toPositiveBlockedStructureChiTracePowerForm [Inhabited Λ]
       exact hpos (Sum.inl i) (Sum.inl j) (Sum.inr k) r
     · have hpos : ((cmp.pulledBlockedChiFamily hχ).toDiagonal n).PosEntries := by
         simpa only [pulledBlockedChiFamily, dif_neg hn] using
-          hχ.posEntries.comap fun _ => default
+          DiagonalChiFamily.PosEntries.empty
+            (AlgebraStructureData.BlockedIndex data n ⊕
+              AlgebraStructureData.BlockedIndex data (2 * n))
       exact hpos (Sum.inl i) (Sum.inl j) (Sum.inr k) r
   tracePower := by
     intro n hn i j k

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1562,14 +1562,14 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_blocked_basis_coefficient_eq}
     Suppose that the chosen blocked-basis coefficients are compared with a
     fixed BNT-label coefficient system, and that this BNT-label system has a
-    positive length-independent \(\chi\)-witness.  Assume also that the
-    BNT-label type is nonempty.  Then the chosen blocked bases carry a
-    positive blocked \(\chi\) trace-power witness.
+    positive length-independent \(\chi\)-witness.  Then the chosen blocked
+    bases carry a positive blocked \(\chi\) trace-power witness.
     The construction is obtained by pulling back the BNT-label
     \(\chi_{\alpha,\beta,\gamma}\)-matrices along the source and target label
-    maps.  The auxiliary choice of a BNT label is used only to fill the
-    zero-length component, which is absent from the positive-length trace-power
-    statement.
+    maps.
+    % Formalization note: the zero-length component of the blocked chi family is
+    % filled by empty diagonal matrices; it plays no role in the positive-length
+    % trace-power statement.
 \end{theorem}
 \begin{proof}\leanok
     Reindex the positive BNT-label \(\chi\)-family along the blocked-basis


### PR DESCRIPTION
### Motivation

- `BNTBlockedBasisCoefficientComparison.pulledBlockedChiFamily` (introduced in #2022) required `[Inhabited Λ]` to supply a default BNT label for the unused `n = 0` branch — an artificial hypothesis not present in arXiv:1606.00608, Theorem IV.13(ii).
- Removing it brings the statement closer to the paper-faithful formulation of the uniform BNT-label chi family tracked in #2000.
- The positive-length trace-power logic is unaffected; only the vacuous base case changes.

### Description

- `TNLean/MPS/MPDO/AlgebraStructure.lean`: adds `DiagonalChiFamily.empty` (a vacuous diagonal chi family for the empty-length case) and `DiagonalChiFamily.PosEntries.empty` (vacuous positivity instance).
- `TNLean/MPS/MPDO/BNTCoefficients.lean`: removes `[Inhabited Λ]` from `BNTBlockedBasisCoefficientComparison.pulledBlockedChiFamily` and `toPositiveBlockedStructureChiTracePowerForm`; uses `DiagonalChiFamily.empty` for the `n = 0` branch instead of `default`; positive-length branch is unchanged.
- `blueprint/src/chapter/ch02b_mpdo.tex`: updates the Chapter 2b statement to drop the nonemptiness / `[Inhabited Λ]` assumption and documents the empty-matrix fill-in for `n = 0`.

### Testing

- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients`
- `lake build TNLean`
- `git diff --check`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/MPDO/AlgebraStructure.lean TNLean/MPS/MPDO/BNTCoefficients.lean` — no occurrences in changed files.
- `cd blueprint && leanblueprint checkdecls` — fails only on pre-existing missing declarations; no new declaration reported missing.

---
Addresses #2000

> [!NOTE]
> **Low Risk**
> Low risk: this is a small refactor to remove an unnecessary `[Inhabited Λ]` assumption by using an empty/vacuous `DiagonalChiFamily` for the unused `n = 0` case; the positive-length trace-power logic is unchanged.
> 
> **Overview**
> Removes the need for an arbitrary default BNT label when pulling back a BNT `χ`-witness to blocked bases.
> 
> Introduces `DiagonalChiFamily.empty` plus a vacuous positivity lemma `DiagonalChiFamily.PosEntries.empty`, and switches `BNTBlockedBasisCoefficientComparison.pulledBlockedChiFamily`/`toPositiveBlockedStructureChiTracePowerForm` to use this empty family for the `n = 0` branch instead of `default`. The Chapter 2b blueprint theorem statement is updated to drop the corresponding nonemptiness/`[Inhabited Λ]` assumption and to document the empty-matrix fill-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e7e4633914e9d01ad7bb49b031cc12f8a0bbaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor removing an unnecessary typeclass assumption; positive-length trace-power behavior is unchanged and only the vacuous `n = 0` case is affected.
> 
> **Overview**
> Removes the artificial **`[Inhabited Λ]`** hypothesis from pulling a BNT-label χ witness to blocked bases by introducing a **vacuous** diagonal χ family for the unused **`n = 0`** branch.
> 
> **`DiagonalChiFamily.empty`** (zero-dimensional diagonals) and **`DiagonalChiFamily.PosEntries.empty`** supply a well-typed, positively vacuous filler. **`pulledBlockedChiFamily`** and **`toPositiveBlockedStructureChiTracePowerForm`** use that family when **`n = 0`** instead of reindexing with **`default`**. Positive-length pullback, trace-power proofs, and comparison logic are unchanged.
> 
> The Chapter 2b blueprint theorem drops the BNT-label nonemptiness assumption and notes that the zero-length blocked χ component is filled by empty matrices and does not enter the positive-length trace-power statement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec335d51e23599f82762ba9cde4913384b51ba0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->