### PR TITLE
feat(MPS/MPDO): expose eta-local GSNNCH consequences

### DIFF
--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -148,19 +148,23 @@ theorem isGSNNCH (data : EtaLocalStructureData M) : IsGSNNCH M := by
   intro N hN
   exact data.isGSNNCHAt N hN
 
+/-- The explicit `η`-local structure yields the global commuting-form property. -/
+theorem hasCommutingForm (data : EtaLocalStructureData M) : HasCommutingForm M := by
+  intro N hN
+  exact ⟨data.formAt N hN, data.formAt_realizes N hN⟩
+
 end EtaLocalStructureData
 
 /-- Once the explicit neighboring operators `η_{k,h}` have been assembled into
 `EtaLocalStructureData`, the global commuting-form property follows
 immediately. -/
 theorem hasCommutingForm_of_etaLocalStructure {M : MPOTensor d D}
-    (hEta : EtaLocalStructureData M) : HasCommutingForm M := by
-  intro N hN
-  exact ⟨hEta.bondData.toCommutingFormData (N := N) hN, hEta.realizes_mpo N hN⟩
+    (hEta : EtaLocalStructureData M) : HasCommutingForm M :=
+  hEta.hasCommutingForm
 
 /-- The explicit local `η`-structure also yields the GSNNCH condition. -/
 theorem isGSNNCH_of_etaLocalStructure {M : MPOTensor d D}
     (hEta : EtaLocalStructureData M) : IsGSNNCH M :=
-  isGSNNCH_of_hasCommutingForm (hasCommutingForm_of_etaLocalStructure hEta)
+  hEta.isGSNNCH
 
 end MPOTensor

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1675,17 +1675,58 @@ the elementary trace-power identity for diagonal matrices.
     on every periodic chain and realize the MPO at every finite length.
 \end{definition}
 
+\begin{theorem}[$\eta$-local structure carries commuting form]
+    \label{thm:mpdo_eta_local_structure_has_commuting_form}
+    \lean{MPOTensor.EtaLocalStructureData.hasCommutingForm}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data, def:mpdo_has_commuting_form}
+    The $\eta$-local structure itself determines a commuting-form witness for every
+    chain length $N \ge 2$.
+\end{theorem}
+
+\begin{proof}\leanok
+    At length $N$, apply the commuting two-site bond and realization identity
+    provided by the $\eta$-local structure.
+\end{proof}
+
+\begin{theorem}[$\eta$-local structure gives GSNNCH]
+    \label{thm:mpdo_eta_local_structure_is_gsnnch}
+    \lean{MPOTensor.EtaLocalStructureData.isGSNNCH}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data, def:mpdo_is_gsnnch}
+    The same $\eta$-local structure gives a GSNNCH witness on every finite
+    periodic chain.
+\end{theorem}
+
+\begin{proof}\leanok
+    Evaluate the local structure at each chain length $N \ge 2$.
+\end{proof}
+
 \begin{theorem}[$\eta$-local structure implies commuting form]
     \label{thm:mpdo_has_commuting_form_of_eta_local_structure}
     \lean{MPOTensor.hasCommutingForm_of_etaLocalStructure}
     \leanok
-    \uses{def:mpdo_eta_local_structure_data, def:mpdo_has_commuting_form}
+    \uses{thm:mpdo_eta_local_structure_has_commuting_form}
     Once the explicit neighboring operators $\eta_{k,h}$ have been assembled
-    into the data above, the global commuting-form property follows.
+    into an $\eta$-local structure, the global commuting-form property follows.
 \end{theorem}
 
 \begin{proof}\leanok
-    For each $N \ge 2$, take the commuting-form datum given by these data.
+    This is the commuting-form consequence already carried by the
+    $\eta$-local structure.
+\end{proof}
+
+\begin{theorem}[$\eta$-local structure implies GSNNCH]
+    \label{thm:mpdo_is_gsnnch_of_eta_local_structure}
+    \lean{MPOTensor.isGSNNCH_of_etaLocalStructure}
+    \leanok
+    \uses{thm:mpdo_eta_local_structure_is_gsnnch}
+    Once the explicit neighboring operators $\eta_{k,h}$ have been assembled
+    into the $\eta$-local structure, the GSNNCH condition follows.
+\end{theorem}
+
+\begin{proof}\leanok
+    This is the GSNNCH witness already carried by the $\eta$-local structure.
 \end{proof}
 
 \begin{remark}[Entropy-side construction]


### PR DESCRIPTION
### Motivation

- The `EtaLocalStructureData` namespace lacked direct theorems for its two immediate global consequences (commuting-form witness and GSNNCH property), so callers of `hasCommutingForm_of_etaLocalStructure` and `isGSNNCH_of_etaLocalStructure` reached past the namespace to re-derive consequences already implicit in the extracted structure data.
- Appendix C.2 of arXiv:1606.00608 derives both consequences directly from eta-local structure; the Lean development should reflect this derivation order.
- The Chapter 2b blueprint entry for the eta-local consequences was missing `\lean{}` and `\leanok` tags for the newly proved namespace theorems.

### Description

- `TNLean/MPS/MPDO/CommutingFormBridge.lean`: adds `EtaLocalStructureData.hasCommutingForm`, proving `HasCommutingForm` at each chain length from `formAt` / `formAt_realizes`; rewrites `hasCommutingForm_of_etaLocalStructure` and `isGSNNCH_of_etaLocalStructure` to forward to the new namespace theorem and the existing `EtaLocalStructureData.isGSNNCH` respectively (GSNNCH no longer routes through commuting-form first).
- `blueprint/src/chapter/ch02b_mpdo.tex`: records the two eta-local consequences in the Chapter 2b blueprint with `\lean{}` and `\leanok` tags; reframes the "implies" entries as corollaries of the namespace theorems.
- Does not construct the SAL+ZCL-to-eta-local assembly theorem; that gap remains tracked in #823.

### Testing

- `lake env lean TNLean/MPS/MPDO/CommutingFormBridge.lean`
- `lake build TNLean.MPS.MPDO.CommutingFormBridge`
- `lake build TNLean`
- `git diff --check`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/MPDO/CommutingFormBridge.lean || true`
- `cd blueprint && leanblueprint checkdecls` — new eta-local declarations not reported missing; failures are pre-existing.

---
Addresses #823

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor and blueprint tagging in `CommutingFormBridge.lean`; no runtime, auth, or API behavior changes.
> 
> **Overview**
> **`EtaLocalStructureData`** now exposes **`hasCommutingForm`** and reuses the existing **`isGSNNCH`**, so the global commuting-form and GSNNCH properties are proved directly from **`formAt`** / **`formAt_realizes`** at each chain length instead of going through **`bondData.toCommutingFormData`** and a separate realization path.
> 
> The top-level lemmas **`hasCommutingForm_of_etaLocalStructure`** and **`isGSNNCH_of_etaLocalStructure`** are thin forwards to those namespace theorems; **`isGSNNCH_of_etaLocalStructure`** no longer derives GSNNCH via **`isGSNNCH_of_hasCommutingForm`** first, matching Appendix C.2’s order (both consequences from η-local structure).
> 
> **`ch02b_mpdo.tex`** adds blueprint theorems for the namespace results with `\lean{}` / `\leanok` tags and reframes the older “η-local structure implies …” entries as corollaries of those theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f1e9389e7f1fa5cc5ac5119600984893145f905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->