### PR TITLE
feat(PEPS): recover pullbacks from projected realizations

### DIFF
--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -478,5 +478,17 @@ theorem physRealizeLocalOp_localVirtualOpOfPhysicalOp (A : Tensor G d)
   simp [physRealizeLocalOp, localVirtualOpOfPhysicalOp, localProjector,
     LinearMap.comp_assoc]
 
+/-- If the projected physical action of \(O\) is the canonical physical
+realization of a virtual operation \(T\), then pulling back \(O\) recovers
+\(T\). -/
+theorem localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq
+    (A : Tensor G d) (hA : IsVertexInjective A) (v : V)
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (T : LocalVirtualOp A v)
+    (hO : (localProjector A hA v).comp (O.comp (localProjector A hA v)) =
+      physRealizeLocalOp A hA v T) :
+    localVirtualOpOfPhysicalOp A hA v O = T := by
+  apply physRealizeLocalOp_injective A hA v
+  rw [physRealizeLocalOp_localVirtualOpOfPhysicalOp, hO]
+
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -213,6 +213,21 @@ injective and normal PEPS, following Theorems~2 and~3 of
     This is immediate from $\Psi_v \circ \Phi_v = \Id$.
 \end{proof}
 
+\begin{theorem}[Injectivity of local physical realization]%
+    \label{thm:peps_physRealizeLocalOp_injective}
+    \lean{TNLean.PEPS.physRealizeLocalOp_injective}
+    \leanok
+    \uses{def:peps_physRealizeLocalOp,
+        thm:peps_physRealizeLocalOp_spec,
+        def:IsVertexInjective}
+    If two virtual operations have the same canonical physical realization,
+    then they agree.
+\end{theorem}
+\begin{proof}\leanok
+    Evaluate both physical realizations on vectors in the image of the local
+    tensor map and use vertex injectivity.
+\end{proof}
+
 \begin{definition}[Local projector]%
     \label{def:peps_localProjector}
     \lean{TNLean.PEPS.localProjector}
@@ -340,6 +355,23 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     Expand the definitions of the physical realization, the virtual pullback,
     and the local projector.
+\end{proof}
+
+\begin{theorem}[Projected local recovery]%
+    \label{thm:peps_localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}
+    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}
+    \leanok
+    \uses{thm:peps_physRealizeLocalOp_injective,
+        thm:peps_physRealizeLocalOp_localVirtualOpOfPhysicalOp}
+    Suppose that the compressed physical action \(P_v O P_v\) agrees with the
+    canonical physical realization of a virtual operation \(T\). Then the
+    virtual pullback of \(O\) is \(T\).
+\end{theorem}
+\begin{proof}\leanok
+    The physical realization of the virtual pullback of \(O\) is
+    \(P_v O P_v\).  By hypothesis this is the physical realization of \(T\).
+    Injectivity of the canonical physical realization gives equality of the
+    virtual operations.
 \end{proof}
 
 \begin{definition}[Matrix action on one incident virtual edge]%


### PR DESCRIPTION
### Motivation

- Continues formalization of the physical-to-virtual recovery step in the PEPS insertion-algebra isomorphism (arXiv:1804.04964, Section 3); see #1370.
- Records injectivity of the canonical local physical realization in the Chapter 13a blueprint.
- Adds the projected local recovery lemma: if the compressed physical action $P_v O P_v$ agrees with the canonical physical realization of a virtual operation $T$, then the virtual pullback of $O$ is $T$.

### Description

- `TNLean/PEPS/VirtualInsertion.lean` — adds `localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq`: given that the projected action $P_v O P_v$ equals the canonical physical realization of a virtual operation $T$, the virtual pullback of $O$ equals $T$; proved via `physRealizeLocalOp_localVirtualOpOfPhysicalOp` and `physRealizeLocalOp_injective`.
- `blueprint/src/chapter/ch13a_peps_ft.tex` — adds injectivity of local physical realization and the projected local recovery theorem to the Chapter 13a blueprint, aligned with the existing formal lemmas.
- This is a local vertex-injectivity statement. It does not close #1370; the remaining step is shared-bond recovery in the edge-blocked three-site argument.

### Testing

- `lake env lean TNLean/PEPS/VirtualInsertion.lean`
- `lake build TNLean.PEPS.VirtualInsertion`
- `lake build TNLean`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/PEPS/VirtualInsertion.lean` — no occurrences.
- `leanblueprint checkdecls` — new PEPS declarations are not reported missing; pre-existing failures are unrelated to this change.

---
Refs #1370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, local formal and documentation additions to existing PEPS virtual-insertion lemmas with no runtime or security impact.
> 
> **Overview**
> Adds a **projected local recovery** step to the PEPS physical-to-virtual layer: when the compressed physical action **P_v O P_v** matches the canonical physical realization of a virtual operation **T**, the virtual pullback of **O** is **T**. In Lean this is `localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq`, proved by matching physical realizations via `physRealizeLocalOp_localVirtualOpOfPhysicalOp` and **`physRealizeLocalOp_injective`**.
> 
> The Chapter 13a blueprint now states **injectivity of local physical realization** and the new **projected local recovery** theorem, aligned with the existing formal lemmas. Scope stays **local** (vertex injectivity); it does not address shared-bond recovery in the edge-blocked three-site argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7767d1be8589ecb848b12662c62c82b23700f62c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->