### PR TITLE
feat(PEPS): characterize projected local recovery

### DIFF
--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -490,5 +490,18 @@ theorem localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq
   apply physRealizeLocalOp_injective A hA v
   rw [physRealizeLocalOp_localVirtualOpOfPhysicalOp, hO]
 
+/-- The compressed physical action of \(O\) is the canonical physical
+realization of \(T\) exactly when the virtual pullback of \(O\) is \(T\). -/
+theorem localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
+    (A : Tensor G d) (hA : IsVertexInjective A) (v : V)
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (T : LocalVirtualOp A v) :
+    localVirtualOpOfPhysicalOp A hA v O = T ↔
+      (localProjector A hA v).comp (O.comp (localProjector A hA v)) =
+        physRealizeLocalOp A hA v T := by
+  constructor
+  · intro h
+    rw [← h, physRealizeLocalOp_localVirtualOpOfPhysicalOp]
+  · exact localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq A hA v O T
+
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -374,6 +374,22 @@ injective and normal PEPS, following Theorems~2 and~3 of
     virtual operations.
 \end{proof}
 
+\begin{theorem}[Projected local recovery equivalence]%
+    \label{thm:peps_localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq}
+    \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq}
+    \leanok
+    \uses{thm:peps_physRealizeLocalOp_localVirtualOpOfPhysicalOp,
+        thm:peps_localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}
+    The compressed physical action \(P_v O P_v\) is the canonical physical
+    realization of a virtual operation \(T\) if and only if the virtual
+    pullback of \(O\) is \(T\).
+\end{theorem}
+\begin{proof}\leanok
+    One implication follows by realizing both virtual operations physically and
+    using the formula for the physical realization of a pulled-back operator.
+    The converse is the preceding recovery theorem.
+\end{proof}
+
 \begin{definition}[Matrix action on one incident virtual edge]%
     \label{def:peps_localIncidentMatrixOp}
     \lean{TNLean.PEPS.localIncidentMatrixOp}


### PR DESCRIPTION
### Motivation

- Continues the local physical-to-virtual recovery formalization for the PEPS insertion algebra (arXiv:1804.04964, Section 3); see #1370.
- Strengthens the projected-recovery implication to an equivalence: the compressed physical action agrees with a canonical physical realization precisely when the virtual pullback recovers the corresponding virtual operation.

### Description

- `TNLean/PEPS/VirtualInsertion.lean` adds `localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq`.
- `blueprint/src/chapter/ch13a_peps_ft.tex` records the matching Chapter 13a theorem and proof sketch.
- The shared-bond theorem in the edge-blocked three-site argument remains the next source-paper step.

### Testing

- `lake env lean TNLean/PEPS/VirtualInsertion.lean`
- `lake build TNLean.PEPS.VirtualInsertion`
- `lake build TNLean`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/PEPS/VirtualInsertion.lean` — no occurrences.
- `leanblueprint checkdecls` — new PEPS declaration is not reported missing; the command still reports the known pre-existing missing declarations.

---
Addresses #1370

> [!NOTE]
> **Low Risk**
> Small formalization-only addition reusing existing lemmas; no runtime, auth, or data-path changes.
>
> **Overview**
> This PR turns the existing **projected local recovery** implication into a full **equivalence**: for vertex-injective PEPS, the virtual pullback `localVirtualOpOfPhysicalOp` equals a virtual operation `T` **iff** the compressed physical map `P_v ∘ O ∘ P_v` equals `physRealizeLocalOp` of `T`.
>
> Lean adds `localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq` in `VirtualInsertion.lean` (forward direction via `physRealizeLocalOp_localVirtualOpOfPhysicalOp`, converse via the prior `localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq`). The blueprint chapter records the matching theorem and a short proof sketch.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b69df91264bf95ad5636cd6603e269b2e1cf55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>