### PR TITLE
feat(MPS/MPDO): bundle BNT theorem data

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -413,4 +413,66 @@ def toPositiveBlockedStructureChiTracePowerForm
 
 end BNTBlockedBasisCoefficientComparison
 
+/-- The BNT-label data asserted by the source theorem, together with its
+blocked-basis comparison.
+
+This record gathers the objects that the remaining Appendix C.3--C.4
+construction must produce from an MPDO tensor: the fixed BNT-label coefficient
+system, the same-length BNT operator family and product law, the trace scalars
+and idempotent condition, the positive length-independent chi witness, and the
+comparison with the chosen blocked bases.
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTLabelTheoremData (data : AlgebraStructureData d D)
+    (Λ : Type*) (O : ℕ → Type*) [Fintype Λ]
+    [∀ L : ℕ, AddCommMonoid (O L)] [∀ L : ℕ, Module ℂ (O L)]
+    [∀ L : ℕ, Mul (O L)] where
+  /-- The BNT-label coefficient system \(c^{(L)}_{\alpha,\beta,\gamma}\). -/
+  coeffs : BNTLabelCoefficientFamily Λ
+  /-- The BNT-label operator family \(O_L(M_\alpha)\). -/
+  operators : BNTLabelOperatorFamily Λ O
+  /-- The trace scalars \(m_\alpha=\operatorname{tr}(\mu_\alpha)\). -/
+  traceScalars : BNTLabelTraceScalarFamily Λ
+  /-- The same-length BNT product law. -/
+  sameLengthProduct : operators.HasSameLengthProductForm coeffs
+  /-- The idempotent scalar condition. -/
+  idempotent : traceScalars.HasIdempotentCoefficientForm coeffs
+  /-- The positive length-independent BNT-label chi witness. -/
+  positiveChi : PositiveBNTLabelChiTracePowerForm coeffs
+  /-- Comparison of the chosen blocked-basis coefficients with the BNT labels. -/
+  blockedComparison : BNTBlockedBasisCoefficientComparison data coeffs
+
+namespace BNTLabelTheoremData
+
+variable {data : AlgebraStructureData d D} {Λ : Type*} {O : ℕ → Type*}
+  [Fintype Λ] [∀ L : ℕ, AddCommMonoid (O L)] [∀ L : ℕ, Module ℂ (O L)]
+  [∀ L : ℕ, Mul (O L)] (H : BNTLabelTheoremData data Λ O)
+
+/-- The BNT product expansion with the coefficients written as traces of the
+length-independent chi matrices. -/
+theorem same_length_product_eq_sum_chi_trace_pow
+    (L : ℕ) (hL : 0 < L) (α β : Λ) :
+    H.operators.operator L α * H.operators.operator L β =
+      ∑ γ : Λ, (H.positiveChi.chi.matrix α β γ ^ L).trace •
+        H.operators.operator L γ :=
+  H.sameLengthProduct.eq_sum_chi_trace_pow H.positiveChi L hL α β
+
+/-- The idempotent scalar identity with length-one coefficients written as
+traces of the chi matrices. -/
+theorem idempotent_eq_sum_chi_trace (γ : Λ) :
+    H.traceScalars.traceScalar γ =
+      ∑ α : Λ, ∑ β : Λ,
+        (H.positiveChi.chi.matrix α β γ).trace *
+          (H.traceScalars.traceScalar α * H.traceScalars.traceScalar β) :=
+  H.idempotent.eq_sum_chi_trace H.positiveChi γ
+
+/-- The positive blocked chi witness obtained from the BNT-label theorem data
+and the blocked-basis comparison. -/
+def toPositiveBlockedStructureChiTracePowerForm :
+    AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm data :=
+  H.blockedComparison.toPositiveBlockedStructureChiTracePowerForm H.positiveChi
+
+end BNTLabelTheoremData
+
 end MPOTensor

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1578,6 +1578,70 @@ the elementary trace-power identity for diagonal matrices.
     BNT-label trace-power formula.
 \end{proof}
 
+\begin{definition}[BNT-label theorem data]%
+    \label{def:mpdo_bnt_label_theorem_data}
+    \lean{MPOTensor.BNTLabelTheoremData}
+    \leanok
+    \uses{def:mpdo_bnt_label_coefficient_family,
+        def:mpdo_bnt_label_operator_family,
+        def:mpdo_bnt_label_trace_scalar_family,
+        def:mpdo_bnt_label_same_length_product_form,
+        def:mpdo_bnt_label_idempotent_coefficient_form,
+        def:mpdo_positive_bnt_label_chi_trace_power_form,
+        def:mpdo_bnt_blocked_basis_coefficient_comparison}
+    The BNT-label theorem data consist of the fixed BNT-label coefficient
+    system, the same-length BNT operator family and product identity, the trace
+    scalars and idempotent condition, the positive length-independent
+    \(\chi\)-witness, and the comparison with the chosen blocked bases.
+    These data are the source-side hypotheses from which the blocked-basis
+    consequences below are derived.
+\end{definition}
+
+\begin{theorem}[BNT theorem data give the chi-trace product law]%
+    \label{thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum_chi_trace_pow}
+    \lean{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        thm:mpdo_bnt_label_same_length_product_eq_sum_chi_trace_pow}
+    BNT-label theorem data give the same-length product expansion with
+    coefficients written as traces of powers of the length-independent
+    \(\chi_{\alpha,\beta,\gamma}\)-matrices.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the chi-trace product law to the product identity and the positive
+    BNT-label \(\chi\)-witness belonging to the theorem data.
+\end{proof}
+
+\begin{theorem}[BNT theorem data give the chi-trace idempotent law]%
+    \label{thm:mpdo_bnt_label_theorem_data_idempotent_eq_sum_chi_trace}
+    \lean{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_chi_trace}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        thm:mpdo_bnt_label_idempotent_eq_sum_chi_trace}
+    BNT-label theorem data give the idempotent scalar identity with the
+    length-one coefficients written as traces of the corresponding
+    \(\chi\)-matrices.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the chi-trace idempotent law to the idempotent condition and the
+    positive BNT-label \(\chi\)-witness belonging to the theorem data.
+\end{proof}
+
+\begin{theorem}[BNT theorem data give a positive blocked \(\chi\) witness]%
+    \label{thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
+    \lean{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        thm:mpdo_bnt_blocked_basis_to_positive_blocked_chi_trace_power_form}
+    BNT-label theorem data give a positive blocked-basis \(\chi\) trace-power
+    witness by pulling the length-independent BNT-label \(\chi\)-family back
+    along the blocked-basis comparison maps.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the BNT-to-blocked witness construction to the comparison and the
+    positive BNT-label \(\chi\)-witness belonging to the theorem data.
+\end{proof}
+
 \begin{theorem}[Positive blocked $\chi$ witness gives trace powers]%
     \label{thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
     \lean{MPOTensor.AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm.eq_trace_pow}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -171,6 +171,20 @@ formalized with the coefficients rewritten as traces of the corresponding
 \(\chi\)-matrices.\footnote{%
 \leanid{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum_chi_trace}.}
 
+The BNT-label objects above are now also gathered into one theorem-data record:
+fixed coefficients, same-length operators and product law, trace scalars and
+idempotent condition, positive BNT-label \(\chi\)-witness, and blocked-basis
+comparison.\footnote{\leanid{MPOTensor.BNTLabelTheoremData}.}  This record is
+not an additional mathematical assumption in the source theorem; it is the
+single formal object collecting the source data supplied by the Appendix
+C.3--C.4 construction from an MPDO tensor.  From such data, the same-length
+chi-trace product law, the chi-trace idempotent law, and the positive blocked
+\(\chi\)-witness are immediate
+consequences.\footnote{%
+\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_chi_trace},
+\leanid{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm}.}
+
 To eliminate the remaining gap, the formalization should introduce:
 \begin{enumerate}
     \item construction of the comparison maps relating the BNT-label
@@ -186,12 +200,12 @@ To eliminate the remaining gap, the formalization should introduce:
         \(m_\gamma =
           \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}
           m_\alpha m_\beta\) from the MPDO tensor;
-    \item the blocked-basis trace-power statement, with its source-length
-        exponent convention, as a derived corollary of the uniform BNT-label
-        theorem, rather than as the theorem itself.  The coefficient-level
-        corollary and the corresponding positive blocked \(\chi\)-witness are
-        now formalized; the remaining work is to construct the source BNT-label
-        data and comparison maps from an MPDO tensor.
+    \item construction of the single
+        \leanid{MPOTensor.BNTLabelTheoremData} record from these source
+        objects.  The blocked-basis trace-power statement, with its
+        source-length exponent convention, is then a derived corollary of the
+        uniform BNT-label theorem, rather than a separate replacement for the
+        theorem itself.
 \end{enumerate}
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
### Motivation

- Continues #2000 by identifying the single BNT-label theorem-data object that the remaining Appendix C.3--C.4 construction should produce from an MPDO tensor.
- Keeps the source objects for arXiv:1606.00608, Theorem IV.13(ii), together with the blocked-basis comparison, in one reusable record.

### Description

- `TNLean/MPS/MPDO/BNTCoefficients.lean` adds `MPOTensor.BNTLabelTheoremData`, bundling the BNT-label coefficients, same-length operator family and product law, trace scalars and idempotent condition, positive BNT-label chi witness, and blocked-basis comparison.
- Adds projection consequences from this record: the chi-trace same-length product law, the chi-trace idempotent law, and the positive blocked chi witness.
- Updates Chapter 2b and `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` to make this record the explicit remaining construction target.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients`
- `lake build TNLean`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/MPDO/BNTCoefficients.lean` — no occurrences.
- `leanblueprint checkdecls` — new MPDO declarations are not reported missing; the command still reports the known pre-existing missing declarations.

---
Refs #2000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; no runtime, auth, or data-path changes, and new theorems delegate to existing proofs.
> 
> **Overview**
> Introduces **`MPOTensor.BNTLabelTheoremData`**, a single Lean record that packages the BNT-label coefficient system, same-length operators and product law, trace scalars and idempotent condition, positive length-independent χ witness, and blocked-basis comparison—the objects Appendix C.3–C.4 should produce from an MPDO tensor.
> 
> The record adds thin **projection** lemmas: chi-trace same-length product, chi-trace idempotent identity, and **`toPositiveBlockedStructureChiTracePowerForm`**, each forwarding to proofs that already existed on the separate fields.
> 
> Chapter 2b and **`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`** are updated so the remaining formalization target is explicitly **one** constructed **`BNTLabelTheoremData`** instance (not treating blocked trace-power corollaries as separate top-level goals).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a3778b9cebd7759c54d16af6ee5ac1c3f84dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

