### PR TITLE
feat(PEPS): specialize endpoint projected recovery

### DIFF
--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -58,6 +58,42 @@ theorem edgeVirtualInsertionPhysicalRealization (A : Tensor G d)
   · exact localIncidentMatrixOp_physicalRealization
       (A := A) hA (edgeRightIncident (G := G) e) M
 
+/-- Projected recovery at the left endpoint of an edge.
+
+For the left endpoint, the matrix inserted on the edge is represented by
+\(M^{\mathsf T}\) on the distinguished incident edge. This is the endpoint
+specialization of the local \(O_1,O_2 \mapsto W\) recovery step in
+Lemma \(\mathrm{inj\_isomorph}\) of arXiv:1804.04964, Section 3. -/
+theorem edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
+    (A : Tensor G d) (hA : IsVertexInjective A) (e : Edge G)
+    (O₁ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    localVirtualOpOfPhysicalOp A hA e.1.1 O₁ =
+        localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose ↔
+      (localProjector A hA e.1.1).comp (O₁.comp (localProjector A hA e.1.1)) =
+        physRealizeLocalOp A hA e.1.1
+          (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose) :=
+  localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq A hA e.1.1 O₁
+    (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose)
+
+/-- Projected recovery at the right endpoint of an edge.
+
+For the right endpoint, the inserted matrix acts directly on the distinguished
+incident edge. This is the endpoint specialization of the local
+\(O_1,O_2 \mapsto W\) recovery step in Lemma \(\mathrm{inj\_isomorph}\) of
+arXiv:1804.04964, Section 3. -/
+theorem edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
+    (A : Tensor G d) (hA : IsVertexInjective A) (e : Edge G)
+    (O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    localVirtualOpOfPhysicalOp A hA e.1.2 O₂ =
+        localIncidentMatrixOp A (edgeRightIncident (G := G) e) M ↔
+      (localProjector A hA e.1.2).comp (O₂.comp (localProjector A hA e.1.2)) =
+        physRealizeLocalOp A hA e.1.2
+          (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M) :=
+  localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq A hA e.1.2 O₂
+    (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M)
+
 /-- The left-endpoint physical realization of a virtual matrix insertion
 reproduces the full inserted-edge coefficient.
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -898,6 +898,38 @@ injective and normal PEPS, following Theorems~2 and~3 of
     the distinguished edge.
 \end{proof}
 
+\begin{theorem}[Left-endpoint projected recovery]%
+    \label{thm:peps_edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq}
+    \lean{TNLean.PEPS.edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq}
+    \leanok
+    \uses{thm:peps_localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq,
+        def:peps_localIncidentMatrixOp}
+    Let \(e=(u,v)\). A physical operator at the left endpoint pulls back to
+    the one-edge virtual action of \(M^{\mathsf T}\) if and only if its
+    compressed physical action is the canonical realization of that
+    one-edge virtual action.
+\end{theorem}
+\begin{proof}\leanok
+    This is the projected local recovery equivalence applied to the left
+    incident edge of \(e\), with the transpose convention used by the
+    left-endpoint coefficient identity.
+\end{proof}
+
+\begin{theorem}[Right-endpoint projected recovery]%
+    \label{thm:peps_edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq}
+    \lean{TNLean.PEPS.edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq}
+    \leanok
+    \uses{thm:peps_localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq,
+        def:peps_localIncidentMatrixOp}
+    Let \(e=(u,v)\). A physical operator at the right endpoint pulls back to
+    the one-edge virtual action of \(M\) if and only if its compressed physical
+    action is the canonical realization of that one-edge virtual action.
+\end{theorem}
+\begin{proof}\leanok
+    This is the projected local recovery equivalence applied to the right
+    incident edge of \(e\).
+\end{proof}
+
 \begin{theorem}[Right-endpoint physical realization of the inserted coefficient]%
     \label{thm:peps_edgeInsertedCoeff_rightPhysicalRealization}
     \lean{TNLean.PEPS.edgeInsertedCoeff_eq_sum_right_physicalRealization}


### PR DESCRIPTION
### Motivation

- Continues #1370 by isolating the endpoint-local recovery consequences needed before the full shared-bond `O_1,O_2 -> W` theorem.
- Makes the transpose convention at the left endpoint and the direct right-endpoint convention explicit in the projected-recovery API.

### Description

- `TNLean/PEPS/InsertionRealization.lean` adds left and right endpoint specializations of `localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq`.
- The left endpoint recovers the one-edge action of `M.transpose`; the right endpoint recovers the one-edge action of `M`.
- Chapter 13a records both endpoint projected-recovery consequences with `\leanok` tags.

### Testing

- `lake env lean TNLean/PEPS/InsertionRealization.lean`
- `lake build TNLean.PEPS.InsertionRealization`
- `lake build TNLean`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/PEPS/InsertionRealization.lean` — no occurrences.
- `leanblueprint checkdecls` — new PEPS declarations are not reported missing; the command still reports the known pre-existing missing declarations.

---
Refs #1370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New results are direct specializations of existing proved equivalences with no changes to core PEPS logic or security-sensitive code.
> 
> **Overview**
> Adds **endpoint specializations** of projected local recovery for edge PEPS insertions, ahead of the full shared-bond \(O_1,O_2 \mapsto W\) step.
> 
> In `InsertionRealization.lean`, two new iff theorems state that a physical operator at the **left** endpoint pulls back to the one-edge virtual action of **`M.transpose`**, and at the **right** endpoint to **`M`**, exactly when the **projector-compressed** physical action matches the canonical realization of that virtual action. Proofs are one-line applications of the existing vertex-level `localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq`.
> 
> Chapter 13a documents the same statements with `\leanok` links and short proofs referencing the general projected-recovery equivalence and `localIncidentMatrixOp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ca40c8cab64e199c0ffce2041e71ee715906195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->