### PR TITLE
feat(PEPS): strengthen four-region decomposition

### DIFF
--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -117,6 +117,19 @@ theorem regionFourPart_union [Fintype V] (A B : Finset V) :
     _ = Finset.univ :=
       Finset.union_sdiff_of_subset (Finset.subset_univ (A ∪ B))
 
+/-- Every vertex belongs to one of the four regions in the decomposition. -/
+theorem regionFourPart_cases [Fintype V] (A B : Finset V) (v : V) :
+    v ∈ regionOnlyLeft A B ∨ v ∈ regionOverlap A B ∨
+      v ∈ regionOnlyRight A B ∨ v ∈ regionOutsideUnion A B := by
+  by_cases hvA : v ∈ A
+  · by_cases hvB : v ∈ B
+    · exact Or.inr <| Or.inl <| by simp [regionOverlap, hvA, hvB]
+    · exact Or.inl <| by simp [regionOnlyLeft, hvA, hvB]
+  · by_cases hvB : v ∈ B
+    · exact Or.inr <| Or.inr <| Or.inl <| by simp [regionOnlyRight, hvA, hvB]
+    · exact Or.inr <| Or.inr <| Or.inr <| by
+        simp [regionOutsideUnion, hvA, hvB]
+
 /-- The left-only region is disjoint from the overlap. -/
 theorem regionOnlyLeft_disjoint_overlap (A B : Finset V) :
     Disjoint (regionOnlyLeft A B) (regionOverlap A B) := by
@@ -133,6 +146,30 @@ theorem regionOnlyLeft_disjoint_onlyRight (A B : Finset V) :
     Disjoint (regionOnlyLeft A B) (regionOnlyRight A B) := by
   simpa [regionOnlyLeft, regionOnlyRight] using
     (disjoint_sdiff_sdiff : Disjoint (A \ B) (B \ A))
+
+/-- The left-only region is disjoint from the outside region. -/
+theorem regionOnlyLeft_disjoint_outside [Fintype V] (A B : Finset V) :
+    Disjoint (regionOnlyLeft A B) (regionOutsideUnion A B) := by
+  rw [Finset.disjoint_left]
+  intro v hvLeft hvOutside
+  exact (mem_regionOutsideUnion A B v).mp hvOutside |>.1 <|
+    (mem_regionOnlyLeft A B v).mp hvLeft |>.1
+
+/-- The overlap is disjoint from the outside region. -/
+theorem regionOverlap_disjoint_outside [Fintype V] (A B : Finset V) :
+    Disjoint (regionOverlap A B) (regionOutsideUnion A B) := by
+  rw [Finset.disjoint_left]
+  intro v hvOverlap hvOutside
+  exact (mem_regionOutsideUnion A B v).mp hvOutside |>.1 <|
+    (mem_regionOverlap A B v).mp hvOverlap |>.1
+
+/-- The right-only region is disjoint from the outside region. -/
+theorem regionOnlyRight_disjoint_outside [Fintype V] (A B : Finset V) :
+    Disjoint (regionOnlyRight A B) (regionOutsideUnion A B) := by
+  rw [Finset.disjoint_left]
+  intro v hvRight hvOutside
+  exact (mem_regionOutsideUnion A B v).mp hvOutside |>.2 <|
+    (mem_regionOnlyRight A B v).mp hvRight |>.1
 
 /-- The outside region is disjoint from the union of the three inside regions. -/
 theorem regionInside_disjoint_outside [Fintype V] (A B : Finset V) :

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1278,12 +1278,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionOnlyLeft_union_overlap}
     \lean{TNLean.PEPS.regionOverlap_union_onlyRight}
     \lean{TNLean.PEPS.regionThreePart_union, TNLean.PEPS.regionFourPart_union}
+    \lean{TNLean.PEPS.regionFourPart_cases}
     \leanok
     \uses{def:peps_regionUnionDecomposition}
     Let $V$ be a finite vertex set and let $A,B\subseteq V$. The left-only
     and overlap regions reconstruct $A$, the overlap and right-only regions
     reconstruct $B$, the three inside regions reconstruct $A\cup B$, and
-    all four regions reconstruct $V$.
+    all four regions reconstruct $V$. Equivalently, each vertex lies in one
+    of the four regions.
 \end{lemma}
 \begin{proof}\leanok
     Check membership of an arbitrary vertex in $A$ and in $B$.
@@ -1294,13 +1296,16 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionOnlyLeft_disjoint_overlap}
     \lean{TNLean.PEPS.regionOnlyRight_disjoint_overlap}
     \lean{TNLean.PEPS.regionOnlyLeft_disjoint_onlyRight}
+    \lean{TNLean.PEPS.regionOnlyLeft_disjoint_outside}
+    \lean{TNLean.PEPS.regionOverlap_disjoint_outside}
+    \lean{TNLean.PEPS.regionOnlyRight_disjoint_outside}
     \lean{TNLean.PEPS.regionInside_disjoint_outside}
     \leanok
     \uses{def:peps_regionUnionDecomposition,
         lem:peps_regionUnionDecomposition_identities}
     In the four-region decomposition, the left-only and right-only parts are
-    disjoint from the overlap and from each other. The union of the three
-    inside regions is disjoint from the outside region.
+    disjoint from the overlap and from each other. Each inside part, and hence
+    the union of the three inside regions, is disjoint from the outside region.
 \end{lemma}
 \begin{proof}\leanok
     Use the standard disjointness identities for set difference and


### PR DESCRIPTION
### Motivation

- Continues #1374 by making the four-region partition used in Lemma `injective_union` more explicit.
- Records the exhaustive vertex case split and direct outside-disjointness facts needed by the tensor-level blocked-region argument.

### Description

- `TNLean/PEPS/InjectiveRegion.lean` adds `regionFourPart_cases`, showing every vertex lies in one of `A \ B`, `A ∩ B`, `B \ A`, or `(A ∪ B)^c`.
- Adds direct disjointness lemmas between each of the three inside parts and the outside region.
- Updates Chapter 13a so the decomposition identities and disjointness blueprint entries name these new facts.

### Testing

- `lake env lean TNLean/PEPS/InjectiveRegion.lean`
- `lake build TNLean.PEPS.InjectiveRegion`
- `lake build TNLean`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/PEPS/InjectiveRegion.lean` — no occurrences.
- `leanblueprint checkdecls` — new PEPS declarations are not reported missing; the command still reports the known pre-existing missing declarations.

---
Refs #1374

> [!NOTE]
> **Low Risk**
> Pure Mathlib finset lemmas and blueprint wiring for the PEPS formalization; no runtime, auth, or data paths.
>
> **Overview**
> Strengthens the **four-region** partition (`A \ B`, `A ∩ B`, `B \ A`, outside `A ∪ B`) used ahead of the injective-union lemma.
>
> In `TNLean/PEPS/InjectiveRegion.lean`, adds **`regionFourPart_cases`**: every vertex lies in exactly one of the four regions (via membership in `A` and `B`). Adds three **pairwise disjointness** lemmas—left-only, overlap, and right-only each disjoint from the outside region—proved by contradicting the `mem_*` characterizations.
>
> Chapter **13a** blueprint lemmas now cite these facts: the identities lemma states the exhaustive vertex split, and the disjointness lemma records per-part (not only aggregate) separation from the outside.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb30c149429deec9d782be22aee65d39ea645d16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>