### PR TITLE
feat(PEPS): index four-region decomposition

### DIFF
--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -1,6 +1,8 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.SDiff
+import Mathlib.Data.Finset.Union
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Tactic.FinCases
 
 /-!
 # Region decompositions for PEPS injectivity arguments
@@ -130,6 +132,50 @@ theorem regionFourPart_cases [Fintype V] (A B : Finset V) (v : V) :
     · exact Or.inr <| Or.inr <| Or.inr <| by
         simp [regionOutsideUnion, hvA, hvB]
 
+/-- The four regions, indexed in the order
+\(A\setminus B\), \(A\cap B\), \(B\setminus A\), \((A\cup B)^c\). -/
+def regionUnionPart [Fintype V] (A B : Finset V) (i : Fin 4) : Finset V :=
+  if i = 0 then
+    regionOnlyLeft A B
+  else if i = 1 then
+    regionOverlap A B
+  else if i = 2 then
+    regionOnlyRight A B
+  else
+    regionOutsideUnion A B
+
+@[simp] theorem regionUnionPart_zero [Fintype V] (A B : Finset V) :
+    regionUnionPart A B 0 = regionOnlyLeft A B := by
+  simp [regionUnionPart]
+
+@[simp] theorem regionUnionPart_one [Fintype V] (A B : Finset V) :
+    regionUnionPart A B 1 = regionOverlap A B := by
+  simp [regionUnionPart]
+
+@[simp] theorem regionUnionPart_two [Fintype V] (A B : Finset V) :
+    regionUnionPart A B 2 = regionOnlyRight A B := by
+  simp [regionUnionPart]
+
+@[simp] theorem regionUnionPart_three [Fintype V] (A B : Finset V) :
+    regionUnionPart A B 3 = regionOutsideUnion A B := by
+  simp [regionUnionPart, show (3 : Fin 4) ≠ 0 by decide,
+    show (3 : Fin 4) ≠ 1 by decide, show (3 : Fin 4) ≠ 2 by decide]
+
+/-- The indexed four regions cover the whole finite vertex set. -/
+theorem regionUnionPart_biUnion [Fintype V] (A B : Finset V) :
+    Finset.univ.biUnion (regionUnionPart A B) = Finset.univ := by
+  classical
+  ext v
+  constructor
+  · intro _
+    simp
+  · intro _
+    rcases regionFourPart_cases A B v with hv | hv | hv | hv
+    · exact Finset.mem_biUnion.mpr ⟨0, by simp, by simpa using hv⟩
+    · exact Finset.mem_biUnion.mpr ⟨1, by simp, by simpa using hv⟩
+    · exact Finset.mem_biUnion.mpr ⟨2, by simp, by simpa using hv⟩
+    · exact Finset.mem_biUnion.mpr ⟨3, by simp, by simpa using hv⟩
+
 /-- The left-only region is disjoint from the overlap. -/
 theorem regionOnlyLeft_disjoint_overlap (A B : Finset V) :
     Disjoint (regionOnlyLeft A B) (regionOverlap A B) := by
@@ -179,6 +225,30 @@ theorem regionInside_disjoint_outside [Fintype V] (A B : Finset V) :
   simpa [regionOutsideUnion] using
     (disjoint_sdiff_self_right :
       Disjoint (A ∪ B) ((Finset.univ : Finset V) \ (A ∪ B)))
+
+/-- The indexed four regions are pairwise disjoint. -/
+theorem regionUnionPart_pairwise_disjoint [Fintype V] (A B : Finset V) :
+    Pairwise fun i j : Fin 4 =>
+      Disjoint (regionUnionPart A B i) (regionUnionPart A B j) := by
+  classical
+  intro i j hij
+  fin_cases i <;> fin_cases j
+  · exact (hij rfl).elim
+  · simpa using regionOnlyLeft_disjoint_overlap A B
+  · simpa using regionOnlyLeft_disjoint_onlyRight A B
+  · simpa using regionOnlyLeft_disjoint_outside A B
+  · simpa using (regionOnlyLeft_disjoint_overlap A B).symm
+  · exact (hij rfl).elim
+  · simpa using (regionOnlyRight_disjoint_overlap A B).symm
+  · simpa using regionOverlap_disjoint_outside A B
+  · simpa using (regionOnlyLeft_disjoint_onlyRight A B).symm
+  · simpa using regionOnlyRight_disjoint_overlap A B
+  · exact (hij rfl).elim
+  · simpa using regionOnlyRight_disjoint_outside A B
+  · simpa using (regionOnlyLeft_disjoint_outside A B).symm
+  · simpa using (regionOverlap_disjoint_outside A B).symm
+  · simpa using (regionOnlyRight_disjoint_outside A B).symm
+  · exact (hij rfl).elim
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1266,11 +1266,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \label{def:peps_regionUnionDecomposition}
     \lean{TNLean.PEPS.regionOnlyLeft, TNLean.PEPS.regionOverlap}
     \lean{TNLean.PEPS.regionOnlyRight, TNLean.PEPS.regionOutsideUnion}
+    \lean{TNLean.PEPS.regionUnionPart}
     \leanok
     Let $V$ be a finite vertex set. For two regions $A,B\subseteq V$,
     define the four regions $A\setminus B$, $A\cap B$,
     $B\setminus A$, and $V\setminus(A\cup B)$. These are the four
     regions used in the proof of Lemma~\ref{lem:peps_injectiveRegion_union}.
+    They also form an indexed family over $\{0,1,2,3\}$ in the order
+    $A\setminus B$, $A\cap B$, $B\setminus A$, $V\setminus(A\cup B)$.
 \end{definition}
 
 \begin{lemma}[Identities for the four-region decomposition]%
@@ -1279,13 +1282,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionOverlap_union_onlyRight}
     \lean{TNLean.PEPS.regionThreePart_union, TNLean.PEPS.regionFourPart_union}
     \lean{TNLean.PEPS.regionFourPart_cases}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion}
     \leanok
     \uses{def:peps_regionUnionDecomposition}
     Let $V$ be a finite vertex set and let $A,B\subseteq V$. The left-only
     and overlap regions reconstruct $A$, the overlap and right-only regions
     reconstruct $B$, the three inside regions reconstruct $A\cup B$, and
     all four regions reconstruct $V$. Equivalently, each vertex lies in one
-    of the four regions.
+    of the four regions, and the indexed four-region family has union $V$.
 \end{lemma}
 \begin{proof}\leanok
     Check membership of an arbitrary vertex in $A$ and in $B$.
@@ -1300,12 +1304,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionOverlap_disjoint_outside}
     \lean{TNLean.PEPS.regionOnlyRight_disjoint_outside}
     \lean{TNLean.PEPS.regionInside_disjoint_outside}
+    \lean{TNLean.PEPS.regionUnionPart_pairwise_disjoint}
     \leanok
     \uses{def:peps_regionUnionDecomposition,
         lem:peps_regionUnionDecomposition_identities}
     In the four-region decomposition, the left-only and right-only parts are
     disjoint from the overlap and from each other. Each inside part, and hence
     the union of the three inside regions, is disjoint from the outside region.
+    The indexed four-region family is pairwise disjoint.
 \end{lemma}
 \begin{proof}\leanok
     Use the standard disjointness identities for set difference and


### PR DESCRIPTION
### Motivation

- Issue #1374 requests formalization of the union-of-injective-regions lemma from arXiv:1804.04964, Section 3; the source proof blocks the PEPS lattice into four regions (`A \ B`, `A ∩ B`, `B \ A`, `(A ∪ B)^c`) at lines 1324–1400 of `Papers/1804.04964/paper_normal.tex`.
- A `Fin 4`-indexed version of these four regions enables cleaner proof-term generation and blueprint linkage for the covering and disjointness arguments used downstream in the union-injectivity proof.

### Description

- Modified `TNLean/PEPS/InjectiveRegion.lean` (+70 lines): introduced `regionUnionPart`, a `Fin 4`-indexed family of the four regions in source-proof order, with `@[simp]` lemmas pinning each index to the corresponding named region.
- Proved covering: `regionUnionPart_biUnion` shows the indexed family covers `Finset.univ`, via `regionFourPart_cases`.
- Proved pairwise disjointness: `regionUnionPart_pairwise_disjoint`, by `Fin.cases` on `Fin 4` reusing the named-region disjointness lemmas.
- Modified `blueprint/src/chapter/ch13a_peps_ft.tex` (+8/−1 lines): extended Chapter 13a to record the indexed formulation alongside the named-region formulation, with `\lean{}` tags for the new declarations.

### Testing

- `lake env lean TNLean/PEPS/InjectiveRegion.lean`
- `lake build TNLean.PEPS.InjectiveRegion`
- `lake build TNLean`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/PEPS/InjectiveRegion.lean` (no matches)
- `leanblueprint checkdecls` passes for the new PEPS declarations; pre-existing failures unaffected.

---
Refs #1374

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and blueprint linkage for PEPS region combinatorics; no runtime, security, or data-path changes.
>
> **Overview**
> Introduces **`regionUnionPart`**, a `Fin 4`-indexed packaging of the four-region PEPS decomposition in source-proof order (`A \ B`, `A ∩ B`, `B \ A`, complement of `A ∪ B`), with `@[simp]` lemmas pinning each index to the existing named regions.
>
> Proves the indexed family **covers** `Finset.univ` (`regionUnionPart_biUnion`, via `regionFourPart_cases`) and is **pairwise disjoint** (`regionUnionPart_pairwise_disjoint`, by `fin_cases` on `Fin 4` reusing the named-region disjointness lemmas).
>
> Chapter 13a blueprint text is extended so the definition and the identity/disjointness lemmas also cite the indexed family and the new Lean declarations.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb6cf57e9f6d4882867ee7c1637e653c8d5ad5a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and blueprint tags for region combinatorics; no runtime, security, or behavioral changes outside Lean proofs.
> 
> **Overview**
> Adds a **`Fin 4`-indexed** packaging of the PEPS four-region split (`regionUnionPart`), in source order: `A \ B`, `A ∩ B`, `B \ A`, complement of `A ∪ B`, with `@[simp]` lemmas tying each index to the existing named regions.
> 
> Proves the indexed family **covers** all vertices (`regionUnionPart_biUnion`, from `regionFourPart_cases`) and is **pairwise disjoint** (`regionUnionPart_pairwise_disjoint`, by `fin_cases` on `Fin 4` reusing the named-region disjointness lemmas). New Mathlib imports support `biUnion` and `FinCases`.
> 
> Chapter 13a blueprint text and `\lean{}` tags now record the indexed formulation alongside the named-region lemmas for the union-injectivity proof path (#1374).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b71bfec15a5ba9d7a77fd93aa6027c5e2120b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->