### PR TITLE
feat(MPS/MPDO): add blocked-coefficient trace-power to BNT theorem data

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -467,6 +467,19 @@ theorem idempotent_eq_sum_chi_trace (γ : Λ) :
           (H.traceScalars.traceScalar α * H.traceScalars.traceScalar β) :=
   H.idempotent.eq_sum_chi_trace H.positiveChi γ
 
+/-- The blocked-basis coefficients obtained from BNT-label theorem data are
+traces of powers of the pulled-back BNT-label chi matrices. -/
+theorem blocked_coeff_eq_trace_pow
+    (n : ℕ) (hn : 0 < n)
+    (i j : AlgebraStructureData.BlockedIndex data n)
+    (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
+    data.blockedStructureCoefficients n i j k =
+      (H.positiveChi.chi.matrix
+        (H.blockedComparison.sourceLabel n hn i)
+        (H.blockedComparison.sourceLabel n hn j)
+        (H.blockedComparison.targetLabel n hn k) ^ n).trace :=
+  H.blockedComparison.blocked_coeff_eq_trace_pow H.positiveChi n hn i j k
+
 /-- The positive blocked chi witness obtained from the BNT-label theorem data
 and the blocked-basis comparison. -/
 def toPositiveBlockedStructureChiTracePowerForm :

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1627,6 +1627,22 @@ the elementary trace-power identity for diagonal matrices.
     positive BNT-label \(\chi\)-witness belonging to the theorem data.
 \end{proof}
 
+\begin{theorem}[BNT theorem data give blocked coefficient trace powers]%
+    \label{thm:mpdo_bnt_label_theorem_data_blocked_coeff_eq_trace_pow}
+    \lean{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_trace_pow}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        thm:mpdo_bnt_blocked_basis_coefficient_eq_trace_pow}
+    BNT-label theorem data give the blocked-basis coefficient trace-power
+    formula obtained by pulling the BNT-label
+    \(\chi_{\alpha,\beta,\gamma}\)-matrices back along the blocked-basis
+    comparison maps.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the blocked-basis coefficient trace-power theorem to the comparison
+    and the positive BNT-label \(\chi\)-witness belonging to the theorem data.
+\end{proof}
+
 \begin{theorem}[BNT theorem data give a positive blocked \(\chi\) witness]%
     \label{thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
     \lean{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -164,7 +164,8 @@ direct corollary.\footnote{%
 The same hypotheses also give a positive blocked-basis \(\chi\)-witness by
 pulling back the uniform BNT-label \(\chi\)-family along the
 comparison maps.\footnote{%
-\leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.toPositiveBlockedStructureChiTracePowerForm}.}
+\leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
+toPositiveBlockedStructureChiTracePowerForm}.}
 Likewise, once the idempotent coefficient condition and the positive
 BNT-label \(\chi\)-witness are available, the length-one idempotent identity is
 formalized with the coefficients rewritten as traces of the corresponding
@@ -178,11 +179,13 @@ comparison.\footnote{\leanid{MPOTensor.BNTLabelTheoremData}.}  This record is
 not an additional mathematical assumption in the source theorem; it is the
 single formal object collecting the source data supplied by the Appendix
 C.3--C.4 construction from an MPDO tensor.  From such data, the same-length
-chi-trace product law, the chi-trace idempotent law, and the positive blocked
-\(\chi\)-witness are immediate
+chi-trace product law, the chi-trace idempotent law, the blocked-basis
+coefficient trace-power formula, and the positive blocked \(\chi\)-witness
+are immediate
 consequences.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_chi_trace},
+\leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm}.}
 
 To eliminate the remaining gap, the formalization should introduce:


### PR DESCRIPTION
### Motivation

- Follow-up to #1999, which introduced the bundled BNT-label theorem structure (`BNTLabelTheoremData`). The consequence that blocked-basis structure coefficients equal $\mathrm{tr}(\chi^n)$ for the BNT chi witness was not yet stated as a direct corollary of the bundled structure.
- The gap between the current blocked-basis formalization and the uniform BNT-label statement in arXiv:1606.00608, Theorem IV.13(ii) is documented in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
- Continues the formalization of the BNT-label uniform chi family tracked in #2000.

### Description

- `TNLean/MPS/MPDO/BNTCoefficients.lean`: adds `BNTLabelTheoremData.blocked_coeff_eq_trace_pow`, stating that blocked-basis structure coefficients equal $\mathrm{tr}(\chi^n)$ via the bundled comparison maps and positive chi witness. Implemented as a one-line delegate to `BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow`.
- `blueprint/src/chapter/ch02b_mpdo.tex`: records the new consequence in Chapter 2b with `\lean{}` and `\leanok` tags.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`: updates the CPGSV17 chi-uniformity gap note to list the blocked-coefficient trace-power formula among the derived consequences of bundled BNT theorem data.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients`
- `lake build TNLean`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/MPDO/BNTCoefficients.lean` (no matches)
- `cd blueprint && leanblueprint checkdecls` (fails only on pre-existing missing declarations; the new declaration is accepted)

---
Refs #2000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin Lean wrapper over an existing theorem plus blueprint and documentation updates; no auth, runtime, or construction logic changes.
>
> **Overview**
> Exposes the **blocked-basis coefficient trace-power** identity as a first-class consequence of bundled **`BNTLabelTheoremData`**, alongside the existing chi-trace product and idempotent corollaries.
>
> Lean adds **`BNTLabelTheoremData.blocked_coeff_eq_trace_pow`**, which states that blocked structure coefficients equal \(\mathrm{tr}(\chi^{\sigma_n(i),\sigma_n(j),\tau_n(k)\,n})\) via the record's comparison maps and positive \(\chi\) witness—implemented as a one-line delegate to **`BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow`**. The blueprint (Chapter 2b) and the CPGSV17 blocked-\(\chi\) uniformity gap note are updated so theorem data is documented to imply this formula immediately, without new assumptions.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23cc3d3268c1c6b31f7976c83506cf12a0872836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->