### PR TITLE
feat(PEPS): add square-lattice region coordinates

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -1,3 +1,5 @@
+import Mathlib.Data.Finset.Prod
+
 import TNLean.PEPS.Defs
 import TNLean.PEPS.InjectiveRegion
 
@@ -28,6 +30,76 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 variable {G : SimpleGraph V}
 
 variable (ι : RegionInjectivityData V)
+
+/-! ### Coordinate regions for the square-lattice normal theorem -/
+
+/-- The vertex type of a finite rectangular square lattice of size
+`width × height`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the normal theorem is specialized
+to finite square lattices. -/
+abbrev SquareLatticeVertex (width height : ℕ) :=
+  Fin width × Fin height
+
+/-- A coordinate rectangle in a finite square lattice, specified by its
+horizontal and vertical coordinate sets.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the regions \(R\), \(S\), and
+\(T\) are assembled from rectangular \(2\times3\) and \(3\times2\) blocks. -/
+def squareLatticeRectangle {width height : ℕ}
+    (xs : Finset (Fin width)) (ys : Finset (Fin height)) :
+    Finset (SquareLatticeVertex width height) :=
+  xs ×ˢ ys
+
+@[simp] theorem mem_squareLatticeRectangle {width height : ℕ}
+    (xs : Finset (Fin width)) (ys : Finset (Fin height))
+    (v : SquareLatticeVertex width height) :
+    v ∈ squareLatticeRectangle xs ys ↔ v.1 ∈ xs ∧ v.2 ∈ ys := by
+  simp [squareLatticeRectangle]
+
+@[simp] theorem card_squareLatticeRectangle {width height : ℕ}
+    (xs : Finset (Fin width)) (ys : Finset (Fin height)) :
+    (squareLatticeRectangle xs ys).card = xs.card * ys.card := by
+  simp [squareLatticeRectangle]
+
+/-- The full finite rectangular square lattice as a coordinate region.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the argument uses a finite
+rectangular square lattice as the ambient region. -/
+def squareLatticeFull (width height : ℕ) : Finset (SquareLatticeVertex width height) :=
+  squareLatticeRectangle Finset.univ Finset.univ
+
+@[simp] theorem squareLatticeFull_eq_univ (width height : ℕ) :
+    squareLatticeFull width height = Finset.univ := by
+  ext v
+  simp [squareLatticeFull]
+
+/-- Coordinate-product regions with two horizontal and three vertical
+coordinates.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. This is preliminary coordinate
+vocabulary for the \(2\times3\) rectangles appearing there, not yet the
+source-paper contiguous-block notion. -/
+def IsTwoByThreeSquareLatticeProduct {width height : ℕ}
+    (R : Finset (SquareLatticeVertex width height)) : Prop :=
+  ∃ xs : Finset (Fin width), ∃ ys : Finset (Fin height),
+    xs.card = 2 ∧ ys.card = 3 ∧ R = squareLatticeRectangle xs ys
+
+/-- Coordinate-product regions with three horizontal and two vertical
+coordinates.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. This is preliminary coordinate
+vocabulary for the \(3\times2\) rectangles appearing there, not yet the
+source-paper contiguous-block notion. -/
+def IsThreeByTwoSquareLatticeProduct {width height : ℕ}
+    (R : Finset (SquareLatticeVertex width height)) : Prop :=
+  ∃ xs : Finset (Fin width), ∃ ys : Finset (Fin height),
+    xs.card = 3 ∧ ys.card = 2 ∧ R = squareLatticeRectangle xs ys
 
 section EdgeBlocking
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1369,6 +1369,38 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \(V\setminus R\).
 \end{definition}
 
+\begin{definition}[Square-lattice coordinate regions]%
+    \label{def:peps_squareLatticeCoordinateRegions}
+    \lean{TNLean.PEPS.SquareLatticeVertex}
+    \lean{TNLean.PEPS.squareLatticeRectangle}
+    \lean{TNLean.PEPS.squareLatticeFull}
+    \lean{TNLean.PEPS.IsTwoByThreeSquareLatticeProduct}
+    \lean{TNLean.PEPS.IsThreeByTwoSquareLatticeProduct}
+    \leanok
+    The finite $n\times m$ square lattice is represented by pairs of
+    coordinates.  A coordinate rectangle is a product of a horizontal
+    coordinate set and a vertical coordinate set.  The $2\times3$ and
+    $3\times2$ coordinate-product predicates assert only that these two
+    coordinate sets have cardinalities $2,3$ and $3,2$, respectively; they
+    do not yet assert that the coordinate sets are contiguous intervals.
+\end{definition}
+
+\begin{lemma}[Basic identities for square-lattice coordinate regions]%
+    \label{lem:peps_squareLatticeCoordinateRegion_identities}
+    \lean{TNLean.PEPS.mem_squareLatticeRectangle}
+    \lean{TNLean.PEPS.card_squareLatticeRectangle}
+    \lean{TNLean.PEPS.squareLatticeFull_eq_univ}
+    \leanok
+    \uses{def:peps_squareLatticeCoordinateRegions}
+    Membership in a coordinate rectangle is coordinatewise membership, the
+    cardinality of a coordinate rectangle is the product of the two coordinate
+    cardinalities, and the full coordinate rectangle is the whole finite vertex
+    set.
+\end{lemma}
+\begin{proof}\leanok
+    These are the standard identities for the product of two finite sets.
+\end{proof}
+
 \begin{definition}[Normal rectangular injectivity hypotheses]%
     \label{def:peps_normalRectangleInjectivityHypotheses}
     \lean{TNLean.PEPS.NormalRectangleInjectivityHypotheses}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -89,6 +89,21 @@ The present blueprint nodes are the following.
           theorem following Theorem \path{3}. It is part of \ghissue{1375}.
 \end{itemize}
 
+The formalization now also has a coordinate vocabulary for finite rectangular
+square lattices: vertices are pairs of horizontal and vertical coordinates, and
+coordinate rectangles are products of finite coordinate sets. The present
+$2\times 3$ and $3\times 2$ coordinate-product predicates assert only the two
+coordinate cardinalities. They do not yet express the stronger source-paper
+condition that the relevant square-lattice blocks are contiguous rectangles.
+This supplies ambient language for the later construction of the displayed
+regions $R$, $S$, and $T$; it does not yet prove their injectivity.
+
+Verdict: this is an open gap, not a source-faithful formalization of the
+square-lattice block hypothesis. The next step is to define contiguous
+coordinate intervals and the corresponding contiguous $2\times 3$ and
+$3\times 2$ rectangles, then state rectangular injectivity for those
+source-paper blocks.
+
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
 \ghissue{1252}.
@@ -105,9 +120,11 @@ alone. The following additional obligations remain.
           complements of such regions.
     \item Prove the union-of-injective-regions lemma. The proof must follow the
           source proof by applying the left inverses for $A$ and $B$ in sequence.
-    \item Package the square-lattice normal hypotheses: every $2\times 3$ and
-          $3\times 2$ region is injective, and the ambient size is large enough for
-          the required complements.
+    \item Package the square-lattice normal hypotheses: every contiguous
+          coordinate $2\times 3$ and $3\times 2$ rectangle is injective, and the
+          ambient size is large enough for the required complements. The present
+          coordinate-product predicates are only preliminary vocabulary for this
+          contiguous-rectangle statement.
     \item Prove that the paper's regions $R$, $S$, and $T$ are injective
           under those hypotheses. This is where the union lemma is used repeatedly.
     \item Prove that the edge-centered red, blue, and complementary regions form a


### PR DESCRIPTION
### Motivation

- Addresses step 1 of the five obligations in `docs/paper-gaps/peps_normal_ft_section3_route.tex`: introduce a coordinate model for the $n \times m$ square lattice so that regions $R$, $S$, $T$ can be defined as explicit finite sets over that model (see #2004).
- The paper (arXiv:1804.04964, Section 3, lines 1407–1504 of `Papers/1804.04964/paper_normal.tex`) constructs $R$ and $S$ as unions of $2\times 3$ and $3\times 2$ rectangular blocks; the ambient coordinate space must exist before those unions can be formalized.

### Description

- `TNLean/PEPS/NormalBlocking.lean`: introduces `SquareLatticeVertex` as `Fin width × Fin height`, `squareLatticeRectangle` as the coordinate-set product of two `Finset` index ranges, `squareLatticeFull` equal to `Finset.univ`, and named predicates for $2\times 3$ and $3\times 2$ rectangular regions. Includes simp lemmas for membership, cardinality, and `squareLatticeFull = univ`. No new `sorry`s.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: records the new coordinate vocabulary in Chapter 13a.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: updates the normal-PEPS paper-gap note to reflect the coordinate definitions and clarify that obligations 2–5 remain open.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build TNLean`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/PEPS/NormalBlocking.lean` (no matches)
- `cd blueprint && leanblueprint checkdecls` (fails only on pre-existing missing declarations; new PEPS declarations are accepted)

---
Refs #2004

> [!NOTE]
> **Low Risk**
> New definitions and documentation only; no changes to authentication, runtime behavior, or existing PEPS proof obligations beyond naming coordinate regions.
> 
> **Overview**
> Introduces **finite square-lattice coordinate regions** in `TNLean/PEPS/NormalBlocking.lean`: vertices as `Fin width × Fin height`, rectangles as coordinate-set products (`squareLatticeRectangle`), the full lattice, and named **2×3** / **3×2** region predicates, with simp lemmas for membership, cardinality, and `squareLatticeFull = univ`.
> 
> Chapter 13a and the normal-PEPS paper-gap note are updated so the blueprint and gap tracker record this vocabulary and clarify that it is **language for later** construction of paper regions \(R\), \(S\), and \(T\)—not yet injectivity or edge blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76623660db623a8c8aa537704d95555a960c266f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New definitions and documentation only; no changes to proof obligations, runtime, or security-sensitive code.
> 
> **Overview**
> Adds **finite square-lattice coordinate vocabulary** in `TNLean/PEPS/NormalBlocking.lean`: vertices as `Fin width × Fin height`, rectangles as `squareLatticeRectangle` (`×ˢ` of horizontal/vertical `Finset`s), `squareLatticeFull`, and predicates `IsTwoByThreeSquareLatticeProduct` / `IsThreeByTwoSquareLatticeProduct` (cardinality 2×3 and 3×2 only—not contiguous intervals). Includes `@[simp]` lemmas for membership, cardinality, and `squareLatticeFull = univ`, plus `import Mathlib.Data.Finset.Prod`.
> 
> Chapter 13a gains matching blueprint definitions/lemmas; the normal-PEPS gap doc records this as **preliminary language** for later \(R,S,T\) and contiguous rectangles, and reframes remaining obligation (3) toward contiguous coordinate blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit febaef9c9bbc65464b49bedae48ca4a7cc6d1da8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->