### PR TITLE
feat(PEPS): add contiguous square-lattice rectangles

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -77,6 +77,40 @@ def squareLatticeFull (width height : ℕ) : Finset (SquareLatticeVertex width h
   ext v
   simp [squareLatticeFull]
 
+/-- A contiguous interval of coordinates in one axis of a finite square lattice.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the normal square-lattice theorem
+uses contiguous \(2\times3\) and \(3\times2\) rectangular blocks. -/
+def squareLatticeCoordinateInterval {size : ℕ} (start length : ℕ) : Finset (Fin size) :=
+  Finset.univ.filter fun i ↦ start ≤ i.1 ∧ i.1 < start + length
+
+@[simp] theorem mem_squareLatticeCoordinateInterval {size : ℕ}
+    (start length : ℕ) (i : Fin size) :
+    i ∈ squareLatticeCoordinateInterval start length ↔
+      start ≤ i.1 ∧ i.1 < start + length := by
+  simp [squareLatticeCoordinateInterval]
+
+/-- A contiguous coordinate rectangle in a finite square lattice.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the regions \(R\), \(S\), and
+\(T\) are assembled from contiguous \(2\times3\) and \(3\times2\) rectangles. -/
+def squareLatticeContiguousRectangle {width height : ℕ}
+    (xStart yStart xLength yLength : ℕ) :
+    Finset (SquareLatticeVertex width height) :=
+  squareLatticeRectangle
+    (squareLatticeCoordinateInterval xStart xLength)
+    (squareLatticeCoordinateInterval yStart yLength)
+
+@[simp] theorem mem_squareLatticeContiguousRectangle {width height : ℕ}
+    (xStart yStart xLength yLength : ℕ)
+    (v : SquareLatticeVertex width height) :
+    v ∈ squareLatticeContiguousRectangle xStart yStart xLength yLength ↔
+      xStart ≤ v.1.1 ∧ v.1.1 < xStart + xLength ∧
+        yStart ≤ v.2.1 ∧ v.2.1 < yStart + yLength := by
+  simp [squareLatticeContiguousRectangle, and_assoc]
+
 /-- Coordinate-product regions with two horizontal and three vertical
 coordinates.
 
@@ -100,6 +134,28 @@ def IsThreeByTwoSquareLatticeProduct {width height : ℕ}
     (R : Finset (SquareLatticeVertex width height)) : Prop :=
   ∃ xs : Finset (Fin width), ∃ ys : Finset (Fin height),
     xs.card = 3 ∧ ys.card = 2 ∧ R = squareLatticeRectangle xs ys
+
+/-- Contiguous coordinate rectangles of width two and height three.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the normal square-lattice theorem
+assumes injectivity for contiguous \(2\times3\) rectangular blocks. -/
+def IsTwoByThreeContiguousSquareLatticeRectangle {width height : ℕ}
+    (R : Finset (SquareLatticeVertex width height)) : Prop :=
+  ∃ xStart yStart : ℕ,
+    xStart + 2 ≤ width ∧ yStart + 3 ≤ height ∧
+      R = squareLatticeContiguousRectangle xStart yStart 2 3
+
+/-- Contiguous coordinate rectangles of width three and height two.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the normal square-lattice theorem
+assumes injectivity for contiguous \(3\times2\) rectangular blocks. -/
+def IsThreeByTwoContiguousSquareLatticeRectangle {width height : ℕ}
+    (R : Finset (SquareLatticeVertex width height)) : Prop :=
+  ∃ xStart yStart : ℕ,
+    xStart + 3 ≤ width ∧ yStart + 2 ≤ height ∧
+      R = squareLatticeContiguousRectangle xStart yStart 3 2
 
 section EdgeBlocking
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1374,28 +1374,38 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.SquareLatticeVertex}
     \lean{TNLean.PEPS.squareLatticeRectangle}
     \lean{TNLean.PEPS.squareLatticeFull}
+    \lean{TNLean.PEPS.squareLatticeCoordinateInterval}
+    \lean{TNLean.PEPS.squareLatticeContiguousRectangle}
     \lean{TNLean.PEPS.IsTwoByThreeSquareLatticeProduct}
     \lean{TNLean.PEPS.IsThreeByTwoSquareLatticeProduct}
+    \lean{TNLean.PEPS.IsTwoByThreeContiguousSquareLatticeRectangle}
+    \lean{TNLean.PEPS.IsThreeByTwoContiguousSquareLatticeRectangle}
     \leanok
     The finite $n\times m$ square lattice is represented by pairs of
     coordinates.  A coordinate rectangle is a product of a horizontal
     coordinate set and a vertical coordinate set.  The $2\times3$ and
     $3\times2$ coordinate-product predicates assert only that these two
-    coordinate sets have cardinalities $2,3$ and $3,2$, respectively; they
-    do not yet assert that the coordinate sets are contiguous intervals.
+    coordinate sets have cardinalities $2,3$ and $3,2$, respectively.
+    Contiguous coordinate rectangles are products of contiguous coordinate
+    intervals, and the contiguous $2\times3$ and $3\times2$ predicates name the
+    rectangular blocks used in the normal square-lattice theorem.
 \end{definition}
 
 \begin{lemma}[Basic identities for square-lattice coordinate regions]%
     \label{lem:peps_squareLatticeCoordinateRegion_identities}
     \lean{TNLean.PEPS.mem_squareLatticeRectangle}
+    \lean{TNLean.PEPS.mem_squareLatticeCoordinateInterval}
+    \lean{TNLean.PEPS.mem_squareLatticeContiguousRectangle}
     \lean{TNLean.PEPS.card_squareLatticeRectangle}
     \lean{TNLean.PEPS.squareLatticeFull_eq_univ}
     \leanok
     \uses{def:peps_squareLatticeCoordinateRegions}
     Membership in a coordinate rectangle is coordinatewise membership, the
-    cardinality of a coordinate rectangle is the product of the two coordinate
-    cardinalities, and the full coordinate rectangle is the whole finite vertex
-    set.
+    contiguous coordinate interval has the expected coordinate inequalities,
+    membership in a contiguous coordinate rectangle is the conjunction of the
+    four bounding inequalities, the cardinality of a coordinate rectangle is
+    the product of the two coordinate cardinalities, and the full coordinate
+    rectangle is the whole finite vertex set.
 \end{lemma}
 \begin{proof}\leanok
     These are the standard identities for the product of two finite sets.

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -90,19 +90,19 @@ The present blueprint nodes are the following.
 \end{itemize}
 
 The formalization now also has a coordinate vocabulary for finite rectangular
-square lattices: vertices are pairs of horizontal and vertical coordinates, and
-coordinate rectangles are products of finite coordinate sets. The present
+square lattices. Vertices are pairs of horizontal and vertical coordinates;
+coordinate rectangles are products of finite coordinate sets; contiguous
+coordinate rectangles are products of finite coordinate intervals. The
 $2\times 3$ and $3\times 2$ coordinate-product predicates assert only the two
-coordinate cardinalities. They do not yet express the stronger source-paper
-condition that the relevant square-lattice blocks are contiguous rectangles.
-This supplies ambient language for the later construction of the displayed
-regions $R$, $S$, and $T$; it does not yet prove their injectivity.
+coordinate cardinalities, while the contiguous-rectangle predicates express the
+source-paper contiguous square-lattice blocks. This supplies ambient language
+for the later construction of the displayed regions $R$, $S$, and $T$; it does
+not yet prove their injectivity.
 
-Verdict: this is an open gap, not a source-faithful formalization of the
-square-lattice block hypothesis. The next step is to define contiguous
-coordinate intervals and the corresponding contiguous $2\times 3$ and
-$3\times 2$ rectangles, then state rectangular injectivity for those
-source-paper blocks.
+Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
+The remaining open gap is the source-paper injectivity argument: package
+rectangular injectivity using the contiguous predicates, define the displayed
+regions $R$, $S$, and $T$, and prove their injectivity from the union theorem.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -122,9 +122,7 @@ alone. The following additional obligations remain.
           source proof by applying the left inverses for $A$ and $B$ in sequence.
     \item Package the square-lattice normal hypotheses: every contiguous
           coordinate $2\times 3$ and $3\times 2$ rectangle is injective, and the
-          ambient size is large enough for the required complements. The present
-          coordinate-product predicates are only preliminary vocabulary for this
-          contiguous-rectangle statement.
+          ambient size is large enough for the required complements.
     \item Prove that the paper's regions $R$, $S$, and $T$ are injective
           under those hypotheses. This is where the union lemma is used repeatedly.
     \item Prove that the edge-centered red, blue, and complementary regions form a


### PR DESCRIPTION
### Motivation

- The normal PEPS blocking route in arXiv:1804.04964, Section 3 expresses the regions $R$, $S$, $T$ as unions of $2\times 3$ and $3\times 2$ sub-rectangles; a coordinate vocabulary for square-lattice sub-intervals and contiguous rectangles was missing from the formalization.
- Continues the formalization of obligations 1–5 recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`, addressing the first step of defining coordinate-aware sub-rectangles (see #2004 and tracking #1373).

### Description

- `TNLean/PEPS/NormalBlocking.lean`: adds
  - `squareLatticeCoordinateInterval` — contiguous one-axis coordinate intervals in finite square lattices
  - `squareLatticeContiguousRectangle` — products of two such intervals (contiguous coordinate rectangles)
  - `IsTwoByThreeContiguousSquareLatticeRectangle` / `IsThreeByTwoContiguousSquareLatticeRectangle` — predicates for $2\times 3$ and $3\times 2$ contiguous blocks with bounds ensuring the block fits in the lattice
  - Membership lemmas for the new interval and rectangle definitions
- `blueprint/src/chapter/ch13a_peps_ft.tex`: updated to record that contiguous-rectangle vocabulary is now present
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: updated to reflect that the $2\times 3$ / $3\times 2$ block definitions are formalized; the R/S/T injectivity argument (obligations 2–5) remains open

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build TNLean`
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` — fails only on pre-existing missing declarations; the new square-lattice declarations are not reported missing.

---
Refs #2004

> [!NOTE]
> **Low Risk**
> Definitions and documentation only; no changes to injectivity proofs, blocking structures, or runtime behavior.
>
> **Overview**
> Adds **contiguous** square-lattice coordinate vocabulary in `TNLean/PEPS/NormalBlocking.lean`: one-axis `squareLatticeCoordinateInterval`, `squareLatticeContiguousRectangle`, membership lemmas, and `IsTwoByThreeContiguousSquareLatticeRectangle` / `IsThreeByTwoContiguousSquareLatticeRectangle` (with bounds so blocks fit in the lattice).
>
> Chapter 13a and `docs/paper-gaps/peps_normal_ft_section3_route.tex` now say contiguous `2×3` / `3×2` blocks are formalized; the **open** work is defining paper regions **R/S/T**, proving injectivity, and connecting to `NormalEdgeBlockingHypotheses`—not more rectangle definitions.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3347a2f62d04a14c80be7c38a9ca330b7eb56c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

