### PR TITLE
feat(PEPS/NormalBlocking): add square-lattice rectangle injectivity structure

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -303,6 +303,61 @@ structure NormalRectangleInjectivityHypotheses where
   /-- Every \(3\times 2\) rectangular region is injective. -/
   threeByTwo_injective : ∀ R : Finset V, IsThreeByTwoRegion R → ι.IsInjective R
 
+/-- Coordinate square-lattice form of the rectangular injectivity hypotheses.
+
+Theorem 3 of arXiv:1804.04964 assumes injectivity for every contiguous
+\(2\times 3\) and \(3\times 2\) rectangular block in the finite square
+lattice. This is the coordinate specialization of
+`NormalRectangleInjectivityHypotheses` to the vertex set
+`SquareLatticeVertex width height`.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3 and proof, lines 1407--1452
+of `Papers/1804.04964/paper_normal.tex`. -/
+structure NormalSquareLatticeRectangleInjectivityHypotheses {width height : ℕ}
+    (κ : RegionInjectivityData (SquareLatticeVertex width height)) where
+  /-- Every contiguous \(2\times 3\) coordinate rectangle is injective. -/
+  twoByThree_injective :
+    ∀ R : Finset (SquareLatticeVertex width height),
+      IsTwoByThreeContiguousSquareLatticeRectangle R → κ.IsInjective R
+  /-- Every contiguous \(3\times 2\) coordinate rectangle is injective. -/
+  threeByTwo_injective :
+    ∀ R : Finset (SquareLatticeVertex width height),
+      IsThreeByTwoContiguousSquareLatticeRectangle R → κ.IsInjective R
+
+namespace NormalSquareLatticeRectangleInjectivityHypotheses
+
+variable {width height : ℕ}
+variable {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+
+/-- The coordinate square-lattice rectangular hypotheses as abstract
+rectangular injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3 and proof, lines 1407--1452
+of `Papers/1804.04964/paper_normal.tex`. -/
+def toRectangular
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ) :
+    NormalRectangleInjectivityHypotheses κ where
+  IsTwoByThreeRegion := IsTwoByThreeContiguousSquareLatticeRectangle
+  IsThreeByTwoRegion := IsThreeByTwoContiguousSquareLatticeRectangle
+  twoByThree_injective := h.twoByThree_injective
+  threeByTwo_injective := h.threeByTwo_injective
+
+@[simp] theorem toRectangular_twoByThreeRegion
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (R : Finset (SquareLatticeVertex width height)) :
+    h.toRectangular.IsTwoByThreeRegion R ↔
+      IsTwoByThreeContiguousSquareLatticeRectangle R :=
+  Iff.rfl
+
+@[simp] theorem toRectangular_threeByTwoRegion
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (R : Finset (SquareLatticeVertex width height)) :
+    h.toRectangular.IsThreeByTwoRegion R ↔
+      IsThreeByTwoContiguousSquareLatticeRectangle R :=
+  Iff.rfl
+
+end NormalSquareLatticeRectangleInjectivityHypotheses
+
 /-- Square-lattice normal PEPS blocking hypotheses for Theorem 3.
 
 This records the hypotheses used in the translationally invariant square-lattice

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1414,13 +1414,33 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{definition}[Normal rectangular injectivity hypotheses]%
     \label{def:peps_normalRectangleInjectivityHypotheses}
     \lean{TNLean.PEPS.NormalRectangleInjectivityHypotheses}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses}
     \leanok
-    \uses{def:peps_regionInjectivityData}
+    \uses{def:peps_regionInjectivityData,
+        def:peps_squareLatticeCoordinateRegions}
     In the square-lattice normal theorem, every \(2\times 3\) and
     \(3\times 2\) rectangular region is assumed injective.  The corresponding
-    hypotheses specify which finite regions have these two shapes and assert
-    injectivity for all of them.
+    abstract hypotheses specify which finite regions have these two shapes and
+    assert injectivity for all of them.  In the coordinate square-lattice
+    specialization, these two families are the contiguous coordinate
+    \(2\times 3\) and \(3\times 2\) rectangles.
 \end{definition}
+
+\begin{lemma}[Coordinate rectangular injectivity gives abstract rectangular
+    injectivity]%
+    \label{lem:peps_squareLatticeRectangleInjectivity_toRectangular}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.toRectangular}
+    \leanok
+    \uses{def:peps_normalRectangleInjectivityHypotheses}
+    The coordinate square-lattice rectangular injectivity hypotheses determine
+    abstract rectangular injectivity hypotheses, with the two abstract
+    rectangular families taken to be the contiguous coordinate \(2\times 3\)
+    and \(3\times 2\) rectangles.
+\end{lemma}
+\begin{proof}\leanok
+    This is the direct specialization of the abstract rectangular families to
+    the two contiguous coordinate-rectangle predicates.
+\end{proof}
 
 \begin{definition}[Normal edge-blocking hypotheses]%
     \label{def:peps_normalEdgeBlockingHypotheses}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -95,14 +95,17 @@ coordinate rectangles are products of finite coordinate sets; contiguous
 coordinate rectangles are products of finite coordinate intervals. The
 $2\times 3$ and $3\times 2$ coordinate-product predicates assert only the two
 coordinate cardinalities, while the contiguous-rectangle predicates express the
-source-paper contiguous square-lattice blocks. This supplies ambient language
-for the later construction of the displayed regions $R$, $S$, and $T$; it does
-not yet prove their injectivity.
+source-paper contiguous square-lattice blocks. The square-lattice rectangular
+injectivity hypotheses are now packaged using precisely these two contiguous
+rectangle predicates, and map to the abstract rectangular injectivity bundle.
+This supplies ambient language for the later construction of the displayed
+regions $R$, $S$, and $T$; it does not yet prove their injectivity.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
-The remaining open gap is the source-paper injectivity argument: package
-rectangular injectivity using the contiguous predicates, define the displayed
-regions $R$, $S$, and $T$, and prove their injectivity from the union theorem.
+The earlier packaging gap for coordinate rectangular injectivity is also
+closed. The remaining open gap is the source-paper injectivity argument:
+define the displayed regions $R$, $S$, and $T$, and prove their injectivity
+from the union theorem.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -120,9 +123,10 @@ alone. The following additional obligations remain.
           complements of such regions.
     \item Prove the union-of-injective-regions lemma. The proof must follow the
           source proof by applying the left inverses for $A$ and $B$ in sequence.
-    \item Package the square-lattice normal hypotheses: every contiguous
-          coordinate $2\times 3$ and $3\times 2$ rectangle is injective, and the
-          ambient size is large enough for the required complements.
+    \item Package the square-lattice normal hypotheses. The rectangular
+          injectivity part is now packaged for contiguous coordinate
+          $2\times 3$ and $3\times 2$ rectangles; the remaining size data must
+          be tied to the displayed regions and their required complements.
     \item Prove that the paper's regions $R$, $S$, and $T$ are injective
           under those hypotheses. This is where the union lemma is used repeatedly.
     \item Prove that the edge-centered red, blue, and complementary regions form a


### PR DESCRIPTION
### Motivation

- Continues the formalization of arXiv:1804.04964, Section 3, Theorem 3 (lines 1407–1452 of `Papers/1804.04964/paper_normal.tex`); see #2004.
- The existing `NormalRectangleInjectivityHypotheses` provides abstract rectangular injectivity, but no coordinate-level structure tied it to the square lattice, leaving the 2×3 and 3×2 injectivity assumptions unconnected to the abstract bundle.

### Description

- `TNLean/PEPS/NormalBlocking.lean`: adds `NormalSquareLatticeRectangleInjectivityHypotheses`, a structure asserting injectivity for every contiguous 2×3 and 3×2 block on `SquareLatticeVertex width height`, together with `toRectangular`, an embedding into the abstract `NormalRectangleInjectivityHypotheses` bundle (with `@[simp]` lemmas on the region predicates).
- `blueprint/src/chapter/ch13a_peps_ft.tex`: §13a updated to record that coordinate rectangle injectivity is now present and mapped to the abstract structure.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: Section 3 route note updated; the remaining open work is deriving injectivity of *R*, *S*, *T* via the union lemma, not repackaging the contiguous rectangles.
- No new `sorry`s introduced; this PR adds hypothesis structures only.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls` (fails only on pre-existing missing declarations; the new declarations are not reported missing)
- `git diff --check` and line-length check on changed files

---
Refs #2004

> [!NOTE]
> **Low Risk**
> Hypothesis-layer Lean and documentation only; no proofs of injectivity, gauge logic, or runtime behavior.
> 
> **Overview**
> Adds **`NormalSquareLatticeRectangleInjectivityHypotheses`** in `NormalBlocking.lean`, stating injectivity for every contiguous coordinate **2×3** and **3×2** block on `SquareLatticeVertex width height`, and **`toRectangular`** to embed that into the existing abstract **`NormalRectangleInjectivityHypotheses`** (with `@[simp]` lemmas on the region predicates).
> 
> Blueprint **§13a** and **`peps_normal_ft_section3_route.tex`** are updated to record that coordinate rectangular injectivity is packaged and mapped; the open work is shifted to defining **R/S/T** and proving injectivity via the union lemma, not repackaging contiguous rectangles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc754dfd4fb7901c4c9e40ed6b020401ce8a2807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hypothesis-layer Lean and documentation only; no injectivity proofs, gauge logic, or runtime behavior changes.
> 
> **Overview**
> Adds **`NormalSquareLatticeRectangleInjectivityHypotheses`** on `SquareLatticeVertex width height`, stating injectivity for every contiguous coordinate **2×3** and **3×2** block, plus **`toRectangular`** into the existing abstract **`NormalRectangleInjectivityHypotheses`** (with `@[simp]` lemmas identifying the region predicates).
> 
> Blueprint **§13a** and **`peps_normal_ft_section3_route.tex`** now record that coordinate rectangular injectivity is packaged and mapped; remaining work is framed as defining **R/S/T** and proving injectivity via the union lemma, not repackaging contiguous rectangles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad4f101647495c97b9b7ed97762235f3284db92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->