### PR TITLE
feat(PEPS): define normal square regions R and S

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -157,6 +157,49 @@ def IsThreeByTwoContiguousSquareLatticeRectangle {width height : ℕ}
     xStart + 3 ≤ width ∧ yStart + 2 ≤ height ∧
       R = squareLatticeContiguousRectangle xStart yStart 3 2
 
+/-- The displayed region \(R\) in the normal square-lattice proof.
+
+It is the union of a contiguous \(2\times3\) rectangle and the overlapping
+contiguous \(3\times2\) rectangle covering the upper two rows of the
+\(2\times3\) block and extending one column to the right.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1430
+of `Papers/1804.04964/paper_normal.tex`. -/
+def normalSquareRegionR {width height : ℕ} (xStart yStart : ℕ) :
+    Finset (SquareLatticeVertex width height) :=
+  squareLatticeContiguousRectangle xStart yStart 2 3 ∪
+    squareLatticeContiguousRectangle xStart (yStart + 1) 3 2
+
+/-- The displayed region \(S\) in the normal square-lattice proof.
+
+It is the union of two overlapping contiguous \(2\times3\) rectangles, shifted
+by one horizontal coordinate.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1430
+of `Papers/1804.04964/paper_normal.tex`. -/
+def normalSquareRegionS {width height : ℕ} (xStart yStart : ℕ) :
+    Finset (SquareLatticeVertex width height) :=
+  squareLatticeContiguousRectangle xStart yStart 2 3 ∪
+    squareLatticeContiguousRectangle (xStart + 1) yStart 2 3
+
+@[simp] theorem mem_normalSquareRegionR {width height : ℕ}
+    (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
+    v ∈ normalSquareRegionR xStart yStart ↔
+      (xStart ≤ v.1.1 ∧ v.1.1 < xStart + 2 ∧
+        yStart ≤ v.2.1 ∧ v.2.1 < yStart + 3) ∨
+      (xStart ≤ v.1.1 ∧ v.1.1 < xStart + 3 ∧
+        yStart + 1 ≤ v.2.1 ∧ v.2.1 < yStart + 3) := by
+  simp [normalSquareRegionR]
+
+@[simp] theorem mem_normalSquareRegionS {width height : ℕ}
+    (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
+    v ∈ normalSquareRegionS xStart yStart ↔
+      (xStart ≤ v.1.1 ∧ v.1.1 < xStart + 2 ∧
+        yStart ≤ v.2.1 ∧ v.2.1 < yStart + 3) ∨
+      (xStart + 1 ≤ v.1.1 ∧ v.1.1 < xStart + 3 ∧
+        yStart ≤ v.2.1 ∧ v.2.1 < yStart + 3) := by
+  simp [normalSquareRegionS]
+
 section EdgeBlocking
 
 variable [LinearOrder V]

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1380,6 +1380,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.IsThreeByTwoSquareLatticeProduct}
     \lean{TNLean.PEPS.IsTwoByThreeContiguousSquareLatticeRectangle}
     \lean{TNLean.PEPS.IsThreeByTwoContiguousSquareLatticeRectangle}
+    \lean{TNLean.PEPS.normalSquareRegionR}
+    \lean{TNLean.PEPS.normalSquareRegionS}
     \leanok
     The finite $n\times m$ square lattice is represented by pairs of
     coordinates.  A coordinate rectangle is a product of a horizontal
@@ -1388,7 +1390,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     coordinate sets have cardinalities $2,3$ and $3,2$, respectively.
     Contiguous coordinate rectangles are products of contiguous coordinate
     intervals, and the contiguous $2\times3$ and $3\times2$ predicates name the
-    rectangular blocks used in the normal square-lattice theorem.
+    rectangular blocks used in the normal square-lattice theorem.  The
+    displayed region \(R\) is the union of a \(2\times3\) contiguous rectangle
+    with the \(3\times2\) contiguous rectangle occupying its upper two rows and
+    extending one column to the right.  The displayed region \(S\) is the union
+    of two \(2\times3\) contiguous rectangles shifted by one horizontal
+    coordinate, hence the full \(3\times3\) square spanned by them.
 \end{definition}
 
 \begin{lemma}[Basic identities for square-lattice coordinate regions]%
@@ -1396,6 +1403,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.mem_squareLatticeRectangle}
     \lean{TNLean.PEPS.mem_squareLatticeCoordinateInterval}
     \lean{TNLean.PEPS.mem_squareLatticeContiguousRectangle}
+    \lean{TNLean.PEPS.mem_normalSquareRegionR}
+    \lean{TNLean.PEPS.mem_normalSquareRegionS}
     \lean{TNLean.PEPS.card_squareLatticeRectangle}
     \lean{TNLean.PEPS.squareLatticeFull_eq_univ}
     \leanok
@@ -1403,8 +1412,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Membership in a coordinate rectangle is coordinatewise membership, the
     contiguous coordinate interval has the expected coordinate inequalities,
     membership in a contiguous coordinate rectangle is the conjunction of the
-    four bounding inequalities, the cardinality of a coordinate rectangle is
-    the product of the two coordinate cardinalities, and the full coordinate
+    four bounding inequalities, and membership in \(R\) is the disjunction of
+    membership in the \(2\times3\) lower-left piece or in the shifted
+    \(3\times2\) upper piece.  Membership in \(S\) is the disjunction of
+    membership in the left \(2\times3\) piece or in the horizontally shifted
+    \(2\times3\) piece.  The cardinality of a coordinate rectangle is the
+    product of the two coordinate cardinalities, and the full coordinate
     rectangle is the whole finite vertex set.
 \end{lemma}
 \begin{proof}\leanok

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -98,14 +98,16 @@ coordinate cardinalities, while the contiguous-rectangle predicates express the
 source-paper contiguous square-lattice blocks. The square-lattice rectangular
 injectivity hypotheses are now packaged using precisely these two contiguous
 rectangle predicates, and map to the abstract rectangular injectivity bundle.
-This supplies ambient language for the later construction of the displayed
-regions $R$, $S$, and $T$; it does not yet prove their injectivity.
+The displayed regions $R$ and $S$ are also present as explicit unions of such
+contiguous rectangles. This supplies ambient language for the later
+construction of the displayed region $T$; it does not yet prove injectivity of
+$R$, $S$, or $T$.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
 closed. The remaining open gap is the source-paper injectivity argument:
-define the displayed regions $R$, $S$, and $T$, and prove their injectivity
-from the union theorem.
+define the displayed region $T$, and prove the injectivity of $R$, $S$, and
+$T$ from the union theorem.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -128,7 +130,9 @@ alone. The following additional obligations remain.
           $2\times 3$ and $3\times 2$ rectangles; the remaining size data must
           be tied to the displayed regions and their required complements.
     \item Prove that the paper's regions $R$, $S$, and $T$ are injective
-          under those hypotheses. This is where the union lemma is used repeatedly.
+          under those hypotheses. The displayed regions $R$ and $S$ are now
+          defined as unions of contiguous rectangles; the displayed region $T$
+          still has to be defined. The union lemma is then used repeatedly.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.


### PR DESCRIPTION
### Motivation

- arXiv:1804.04964, Section 3 (proof of Theorem 3, lines 1407–1430 of
  `Papers/1804.04964/paper_normal.tex`) specifies the normal square-lattice
  regions $R$ and $S$ as explicit overlapping unions of $2\times 3$ and
  $3\times 2$ rectangular blocks.
- The previous `NormalSquareBlockingRegions` structure (introduced in #2003)
  assumed injectivity of $R$ and $S$ directly; the explicit coordinate geometry
  is a prerequisite for deriving injectivity from
  `NormalRectangleInjectivityHypotheses` via the union-of-injective-regions
  lemma (see #2004).
- Blueprint Chapter 13a and the Section 3 paper-gap note required updating to
  reflect which obligations of #2004 are now resolved.

### Description

- `TNLean/PEPS/NormalBlocking.lean`: defines `R` as the union of a contiguous
  $2\times 3$ rectangle and an overlapping contiguous $3\times 2$ rectangle;
  defines `S` as the union of two overlapping contiguous $2\times 3$
  rectangles; adds `@[simp]` membership lemmas spelling out vertex membership
  as disjunctions of bounding inequalities.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: links the new Lean definitions
  and marks $R$ and $S$ as explicit geometry.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: records that
  obligations 1–2 (defining $R$ and $S$) are now addressed; obligations 3–5
  (region $T$, injectivity derivation, edge variants) remain open.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls` (fails only on pre-existing
  missing declarations; the new declarations are not reported missing)
- `git diff --check` and line-length check on changed files

---
Refs #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New definitions and documentation only; no changes to injectivity proofs, blocking hypotheses, or runtime behavior.
> 
> **Overview**
> This PR adds **explicit coordinate geometry** for the normal square-lattice displayed regions **\(R\)** and **\(S\)** from arXiv:1804.04964 Section 3, instead of only assuming injective finite sets in `NormalSquareBlockingRegions`.
> 
> In **`TNLean/PEPS/NormalBlocking.lean`**, **`normalSquareRegionR`** and **`normalSquareRegionS`** are unions of contiguous **`squareLatticeContiguousRectangle`** blocks (the \(2\times3\) / \(3\times2\) overlap pattern from the paper). **`mem_normalSquareRegionR`** and **`mem_normalSquareRegionS`** give **`@[simp]`** membership as disjunctions of coordinate inequalities.
> 
> **Blueprint** (`ch13a_peps_ft.tex`) and **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** are updated to link the new Lean names and to record that defining **\(R\)** and **\(S\)** is done; **\(T\)**, proving injectivity from rectangular hypotheses via the union lemma, and wiring into edge blocking remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f12e867e2b044f82c8dd711986465ea001cc202b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->