### PR TITLE
feat(PEPS): prove normal regions R S differ by one site

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -200,6 +200,54 @@ def normalSquareRegionS {width height : ℕ} (xStart yStart : ℕ) :
         yStart ≤ v.2.1 ∧ v.2.1 < yStart + 3) := by
   simp [normalSquareRegionS]
 
+/-- The displayed region \(R\) is contained in the displayed region \(S\).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1430
+and 1544--1546 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionR_subset_regionS {width height : ℕ}
+    (xStart yStart : ℕ) :
+    normalSquareRegionR xStart yStart ⊆
+      (normalSquareRegionS xStart yStart :
+        Finset (SquareLatticeVertex width height)) := by
+  intro v hv
+  rw [mem_normalSquareRegionR] at hv
+  rw [mem_normalSquareRegionS]
+  rcases hv with hv | hv
+  · exact Or.inl hv
+  · rcases hv with ⟨hx0, hx3, hy1, hy3⟩
+    by_cases hx2 : v.1.1 < xStart + 2
+    · exact Or.inl ⟨hx0, hx2, by omega, hy3⟩
+    · exact Or.inr ⟨by omega, hx3, by omega, hy3⟩
+
+/-- The displayed regions \(R\) and \(S\) differ by the lower-right site of
+the \(3\times3\) square.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1430
+and 1544--1546 of `Papers/1804.04964/paper_normal.tex`. -/
+@[simp] theorem mem_normalSquareRegionS_sdiff_regionR {width height : ℕ}
+    (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
+    v ∈ normalSquareRegionS xStart yStart \ normalSquareRegionR xStart yStart ↔
+      v.1.1 = xStart + 2 ∧ v.2.1 = yStart := by
+  rw [Finset.mem_sdiff, mem_normalSquareRegionS, mem_normalSquareRegionR]
+  constructor
+  · rintro ⟨hvS, hvR⟩
+    rcases hvS with hvS | hvS
+    · exfalso
+      exact hvR (Or.inl hvS)
+    · rcases hvS with ⟨hx1, hx3, hy0, hy3⟩
+      by_contra h
+      push Not at h
+      apply hvR
+      by_cases hy1 : yStart + 1 ≤ v.2.1
+      · exact Or.inr ⟨by omega, hx3, hy1, hy3⟩
+      · exact Or.inl ⟨by omega, by omega, hy0, by omega⟩
+  · rintro ⟨hx, hy⟩
+    constructor
+    · exact Or.inr ⟨by omega, by omega, by omega, by omega⟩
+    · rintro (hvR | hvR)
+      · omega
+      · omega
+
 section EdgeBlocking
 
 variable [LinearOrder V]

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1424,6 +1424,25 @@ injective and normal PEPS, following Theorems~2 and~3 of
     These are the standard identities for the product of two finite sets.
 \end{proof}
 
+\begin{lemma}[The normal regions \(R\) and \(S\) differ in one site]%
+    \label{lem:peps_normalSquareRegionR_regionS_difference}
+    \lean{TNLean.PEPS.normalSquareRegionR_subset_regionS}
+    \lean{TNLean.PEPS.mem_normalSquareRegionS_sdiff_regionR}
+    \leanok
+    \uses{def:peps_squareLatticeCoordinateRegions,
+        lem:peps_squareLatticeCoordinateRegion_identities}
+    For the displayed regions \(R\) and \(S\) with the same lower-left corner,
+    \(R\) is contained in \(S\).  The difference \(S\setminus R\) is exactly
+    the lower-right site of the \(3\times3\) square: in coordinates, the site
+    one obtains by shifting two steps horizontally and zero steps vertically
+    from the lower-left corner.
+\end{lemma}
+\begin{proof}\leanok
+    Expand the two displayed unions.  The only point of the second
+    \(2\times3\) piece of \(S\) which is not already in the union defining
+    \(R\) is its lower-right point.
+\end{proof}
+
 \begin{definition}[Normal rectangular injectivity hypotheses]%
     \label{def:peps_normalRectangleInjectivityHypotheses}
     \lean{TNLean.PEPS.NormalRectangleInjectivityHypotheses}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -99,9 +99,11 @@ source-paper contiguous square-lattice blocks. The square-lattice rectangular
 injectivity hypotheses are now packaged using precisely these two contiguous
 rectangle predicates, and map to the abstract rectangular injectivity bundle.
 The displayed regions $R$ and $S$ are also present as explicit unions of such
-contiguous rectangles. This supplies ambient language for the later
-construction of the displayed region $T$; it does not yet prove injectivity of
-$R$, $S$, or $T$.
+contiguous rectangles. Their coordinate definitions have been checked against
+the source statement that they differ in one site: $R$ is contained in $S$,
+and $S\setminus R$ is the lower-right site of the displayed $3\times3$
+square. This supplies ambient language for the later construction of the
+displayed region $T$; it does not yet prove injectivity of $R$, $S$, or $T$.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
@@ -131,8 +133,9 @@ alone. The following additional obligations remain.
           be tied to the displayed regions and their required complements.
     \item Prove that the paper's regions $R$, $S$, and $T$ are injective
           under those hypotheses. The displayed regions $R$ and $S$ are now
-          defined as unions of contiguous rectangles; the displayed region $T$
-          still has to be defined. The union lemma is then used repeatedly.
+          defined as unions of contiguous rectangles, with the expected
+          one-site difference formalized; the displayed region $T$ still has
+          to be defined. The union lemma is then used repeatedly.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.


### PR DESCRIPTION
### Motivation

- arXiv:1804.04964, Section 3, proof of Theorem 3: the displayed square-lattice regions `R` and `S` satisfy `R ⊆ S`, and `S \ R` consists of exactly one site — the lower-right corner of the displayed `3×3` block. This geometric fact is a prerequisite for the normal PEPS blocking route tracked in #2004.
- Source: `Papers/1804.04964/paper_normal.tex`, lines 1407–1430 (regions `R` and `S` drawn) and lines 1544–1546 (one-site difference stated).

### Description

- `TNLean/PEPS/NormalBlocking.lean`: adds two lemmas proving `R ⊆ S` and that `S \ R` equals the single site at coordinates `(xStart + 2, yStart)` of the displayed `3×3` block.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: records the new lemmas with `\lean{}` and `\leanok` tags in Chapter 13a.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: narrows the Section 3 paper-gap route note to mark the `R`/`S` geometric check as complete; injectivity of `R`, `S`, `T` and the definition of `T` remain open.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls` (fails only on pre-existing missing declarations; the new declarations are not reported missing)
- `git diff --check` and line-length check on changed files

---
Refs #2004

> [!NOTE]
> **Low Risk**
> Pure combinatorial finset/coordinate lemmas and documentation; no auth, runtime, or API surface changes.
>
> **Overview**
> This PR **formalizes the paper's one-site relationship** between the displayed normal square-lattice regions `R` and `S`: `R ⊆ S`, and membership in `S \ R` is equivalent to the lower-right corner of the displayed `3×3` block at coordinates `(xStart + 2, yStart)`.
>
> The proofs live in `TNLean/PEPS/NormalBlocking.lean` and are wired into Chapter 13a as a new lemma with `\leanok` links. The Section 3 route note in `docs/paper-gaps/peps_normal_ft_section3_route.tex` is updated to record that this geometric check is done; **injectivity** of `R`, `S`, and `T` and definition of `T` remain open.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cdecb5dd9056dc2dd753fd7afd4fa87a6637754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Combinatorial finset/coordinate lemmas and documentation only; no runtime, auth, or API changes.
> 
> **Overview**
> This PR **formalizes the paper’s one-site geometry** between the displayed normal square-lattice regions `R` and `S`: **`R ⊆ S`**, and **`S \ R`** is exactly the lower-right corner of the displayed `3×3` block at coordinates `(xStart + 2, yStart)`.
> 
> The proofs are new lemmas in `TNLean/PEPS/NormalBlocking.lean`, linked in Chapter 13a as **“The normal regions R and S differ in one site”** with `\leanok` tags. The Section 3 route note in `docs/paper-gaps/peps_normal_ft_section3_route.tex` is updated to record that this geometric check is done; **injectivity** of `R`, `S`, and `T` and the definition of **`T`** remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 552f2fa667e17193ef4b9dc1d30bed2eebd28d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->