### PR TITLE
refactor(MPS/CanonicalForm): share blockwise gauge calc and remove dead-end siblings

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -354,7 +354,7 @@ theorem isIrreducibleTensor_allZero_dim_le_one
 The arbitrary-input part of this file stops at the irreducible block decomposition and the
 zero-block bookkeeping below. The irreducible-to-TP-gauge, CFII normalization, and
 periodicity-removal theorems remain available for individual blocks satisfying their hypotheses,
-but this file does not package them as unconditional siblings of the block decomposition.
+but this file does not combine them into unconditional companions of the block decomposition.
 
 The normal-canonical-form file starts from a primitive weighted block family with positive bond
 dimensions and distinct nonzero weights. This file does **not** construct that input from an

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -351,11 +351,10 @@ theorem isIrreducibleTensor_allZero_dim_le_one
 /-!
 ## Conditional reductions from arbitrary input
 
-The strongest arbitrary-input statement proved here is the blockwise PF / TP-gauge reduction below:
-after decomposing `A` into irreducible blocks, one may apply the theorem to each block once one
-separately knows that the block has a nonzero Kraus operator. This explicit side condition records
-the length-zero sector: an all-zero block contributes its bond dimension at length zero, even though
-it contributes nothing at every positive length.
+The arbitrary-input part of this file stops at the irreducible block decomposition and the
+zero-block bookkeeping below. The irreducible-to-TP-gauge, CFII normalization, and
+periodicity-removal theorems remain available for individual blocks satisfying their hypotheses,
+but this file does not package them as unconditional siblings of the block decomposition.
 
 The normal-canonical-form file starts from a primitive weighted block family with positive bond
 dimensions and distinct nonzero weights. This file does **not** construct that input from an
@@ -370,90 +369,6 @@ Remaining gap for a complete canonical-form existence theorem:
 * Use the resulting data to reach the stronger normal / injective-by-blocking hypotheses needed by
   the normal-canonical-form lemmas and the `IsCanonicalForm` constructors.
 -/
-
-/-- **Unconditional trace-preserving gauge reduction for the 1606 theorem.**
-
-From an arbitrary tensor `A` we produce an irreducible block decomposition. For each
-resulting block, if one separately knows that the block has some nonzero Kraus operator, then the
-Perron--Frobenius / TP-gauge step can be applied to that block.
-
-This is the unconditional reduction from arbitrary input proved here. The nonzero side condition is
-explicit because the length-zero sector records the bond dimension of an all-zero scalar block. -/
-theorem exists_irreducible_blockDecomp_with_tpGauge
-    (A : MPSTensor d D) :
-    ∃ r : ℕ, ∃ dim : Fin r → ℕ,
-    ∃ blocks : (k : Fin r) → MPSTensor d (dim k),
-      (∀ k, IsIrreducibleTensor (blocks k)) ∧
-      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks) ∧
-      (∀ k,
-        (∃ i, blocks k i ≠ 0) →
-        ∃ (B : MPSTensor d (dim k)) (r : ℝ) (σ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
-          σ.PosDef ∧ 0 < r ∧
-          (∀ i : Fin d,
-            B i = CFC.sqrt σ *
-              ((↑((Real.sqrt r)⁻¹) : ℂ) • blocks k i) * (CFC.sqrt σ)⁻¹) ∧
-          (∑ i : Fin d, (B i)ᴴ * B i = 1) ∧
-          GaugeEquiv (d := d) (D := dim k)
-            (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • blocks k i) B) := by
-  classical
-  obtain ⟨r, dim, blocks, hIrr, hSame⟩ :=
-    exists_irreducible_blockDecomp (d := d) (D := D) A
-  refine ⟨r, dim, blocks, hIrr, hSame, ?_⟩
-  intro k hNonzero
-  have hdim_ne : dim k ≠ 0 := by
-    intro hk0
-    rcases hNonzero with ⟨i, hi⟩
-    have hEmpty : IsEmpty (Fin (dim k)) := by
-      rw [hk0]
-      infer_instance
-    have hzero : blocks k i = 0 := by
-      ext a b
-      exact (hEmpty.false a).elim
-    exact hi hzero
-  letI : NeZero (dim k) := ⟨hdim_ne⟩
-  simpa using
-    (exists_tp_data_of_irreducible (d := d) (D := dim k)
-      (A := blocks k) (hIrr := hIrr k) (hA := hNonzero))
-
-/-- **CFII fixed-point data for the 1606 reduction.**
-
-From an arbitrary tensor `A` we produce an irreducible block decomposition. For each
-block, assuming one has already supplied (i) a TP representative and (ii) positive bond dimension,
-we can produce CFII fixed-point data (unitary conjugation + diagonal PD fixed point).
-
-This is the CFII fixed-point part of the source proof, not a complete existence theorem:
-it does not carry the Perron-Frobenius
-/ TP-gauge or periodicity-removal arguments through the block decomposition. The normal canonical
-form, for primitive weighted blocks already in hand, is treated in the normal-canonical-form
-file. -/
-theorem exists_irreducible_blockDecomp_with_CFII
-    (A : MPSTensor d D) :
-    ∃ r : ℕ, ∃ dim : Fin r → ℕ,
-    ∃ blocks : (k : Fin r) → MPSTensor d (dim k),
-      (∀ k, IsIrreducibleTensor (blocks k)) ∧
-      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks) ∧
-      (∀ k,
-        (∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1) →
-        0 < dim k →
-        ∃ (U : Matrix.unitaryGroup (Fin (dim k)) ℂ)
-          (Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
-            let B : MPSTensor d (dim k) :=
-              fun i => (↑U : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)ᴴ *
-                blocks k i *
-                (↑U : Matrix (Fin (dim k)) (Fin (dim k)) ℂ);
-            SameMPV₂ (blocks k) B ∧
-            Λ.PosDef ∧ Λ.IsDiag ∧
-            (∑ i : Fin d, (B i)ᴴ * (B i) = 1) ∧
-            transferMap (d := d) (D := dim k) B Λ = Λ) := by
-  classical
-  obtain ⟨r, dim, blocks, hIrr, hSame⟩ :=
-    exists_irreducible_blockDecomp (d := d) (D := D) A
-  refine ⟨r, dim, blocks, hIrr, hSame, ?_⟩
-  intro k hTPk hDk
-  -- Apply the collected CFII lemma to the k-th block.
-  simpa using
-    (exists_CFII_data_of_TP_of_isIrreducibleTensor (d := d) (D := dim k)
-      (A := blocks k) (hTP := hTPk) (hIrr := hIrr k) (hD := hDk))
 
 /-!
 ## Zero-block separation

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -337,6 +337,106 @@ private theorem scalar_fixedPoints_unitaryConj
     _ = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
           simp [hVV]
 
+private theorem bond_dim_ne_zero_of_exists_nonzero
+    {D : ℕ} (A : MPSTensor d D) (hA : ∃ i, A i ≠ 0) :
+    D ≠ 0 := by
+  intro hD
+  rcases hA with ⟨i, hi⟩
+  have hzero : A i = 0 := by
+    ext a b
+    exfalso
+    have ha : (a : ℕ) < 0 := by
+      simpa [hD] using a.2
+    omega
+  exact hi hzero
+
+private theorem gauge_blockwise_shared
+    (A : MPSTensor d D)
+    {r0 : ℕ} {dim0 : Fin r0 → ℕ}
+    (blocks0 : (k : Fin r0) → MPSTensor d (dim0 k))
+    (hSame0 :
+      SameMPV₂ A
+        (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0))
+    (hNonzero0 : ∀ k, ∃ i, blocks0 k i ≠ 0)
+    (blocks1 : (k : Fin r0) → MPSTensor d (dim0 k))
+    (r1 : Fin r0 → ℝ)
+    (hr1_pos : ∀ k, 0 < r1 k)
+    (hSameGauge :
+      ∀ k,
+        SameMPV
+          (fun i => (↑((Real.sqrt (r1 k))⁻¹) : ℂ) • blocks0 k i)
+          (blocks1 k)) :
+    SameMPV₂ A
+        (toTensorFromBlocks
+          (d := d) (μ := fun k : Fin r0 => (↑(Real.sqrt (r1 k)) : ℂ)) blocks1) ∧
+      (∀ k : Fin r0, (↑(Real.sqrt (r1 k)) : ℂ) ≠ 0) ∧
+      (∀ k, 0 < dim0 k) := by
+  classical
+  let μ1 : Fin r0 → ℂ := fun k => (↑(Real.sqrt (r1 k)) : ℂ)
+  have hdim0_ne : ∀ k : Fin r0, dim0 k ≠ 0 := by
+    intro k
+    exact bond_dim_ne_zero_of_exists_nonzero
+      (d := d) (D := dim0 k) (blocks0 k) (hNonzero0 k)
+  have hSameBlocks :
+      SameMPV₂
+        (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0)
+        (toTensorFromBlocks (d := d) (μ := μ1) blocks1) := by
+    intro N σ
+    calc
+      mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0) σ
+          = ∑ k : Fin r0, (1 : ℂ) ^ N * mpv (blocks0 k) σ := by
+              simpa [smul_eq_mul] using
+                (mpv_toTensorFromBlocks_eq_sum
+                  (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) (A := blocks0) (σ := σ))
+      _ = ∑ k : Fin r0, (μ1 k) ^ N * mpv (blocks1 k) σ := by
+            refine Finset.sum_congr rfl ?_
+            intro k _
+            let c : ℂ := (↑((Real.sqrt (r1 k))⁻¹) : ℂ)
+            have hGaugeSame : SameMPV (fun i => c • blocks0 k i) (blocks1 k) := by
+              simpa [c] using hSameGauge k
+            have hscale : mpv (blocks1 k) σ = c ^ N * mpv (blocks0 k) σ := by
+              calc
+                mpv (blocks1 k) σ = mpv (fun i => c • blocks0 k i) σ :=
+                  (hGaugeSame N σ).symm
+                _ = c ^ N * mpv (blocks0 k) σ := mpv_smul c (blocks0 k) σ
+            have hroot_ne : (↑(Real.sqrt (r1 k)) : ℂ) ≠ 0 := by
+              exact_mod_cast (Real.sqrt_ne_zero'.mpr (hr1_pos k))
+            have hμc : μ1 k * c = 1 := by
+              dsimp [μ1, c]
+              simp [hroot_ne]
+            have hmulpow : (μ1 k) ^ N * c ^ N = 1 := by
+              rw [← mul_pow, hμc, one_pow]
+            have hmulpow_apply :
+                (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ) = mpv (blocks0 k) σ := by
+              calc
+                (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ)
+                    = ((μ1 k) ^ N * c ^ N) * mpv (blocks0 k) σ := by ring
+                _ = mpv (blocks0 k) σ := by simp [hmulpow]
+            calc
+              (1 : ℂ) ^ N * mpv (blocks0 k) σ = mpv (blocks0 k) σ := by simp
+              _ = (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ) := hmulpow_apply.symm
+              _ = (μ1 k) ^ N * mpv (blocks1 k) σ := by rw [hscale]
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ1) blocks1) σ := by
+            symm
+            simpa [smul_eq_mul] using
+              (mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μ1) (A := blocks1) (σ := σ))
+  have hSame1 :
+      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ1) blocks1) := by
+    intro N σ
+    calc
+      mpv A σ
+          = mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0) σ :=
+              hSame0 N σ
+      _ = mpv (toTensorFromBlocks (d := d) (μ := μ1) blocks1) σ := hSameBlocks N σ
+  have hμne1 : ∀ k : Fin r0, μ1 k ≠ 0 := by
+    intro k
+    dsimp [μ1]
+    exact_mod_cast (Real.sqrt_ne_zero'.mpr (hr1_pos k))
+  have hDim1 : ∀ k : Fin r0, 0 < dim0 k := by
+    intro k
+    exact Nat.pos_of_ne_zero (hdim0_ne k)
+  exact ⟨hSame1, hμne1, hDim1⟩
+
 /-- **Blockwise PGVWC07 unital and dual-diagonal theorem.**
 
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof
@@ -378,16 +478,6 @@ theorem exists_pgvwc07_unital_dualDiag_blockwise
         (∀ k, μ1 k ≠ 0) ∧
         (∀ k, 0 < dim1 k) := by
   classical
-  have hdim0_ne : ∀ k : Fin r0, dim0 k ≠ 0 := by
-    intro k hk0
-    rcases hNonzero0 k with ⟨i, hi⟩
-    have hzero : blocks0 k i = 0 := by
-      ext a b
-      exfalso
-      have ha : (a : ℕ) < 0 := by
-        simpa [hk0] using a.2
-      omega
-    exact hi hzero
   have hcanon :
       ∀ k : Fin r0,
         ∃ (B C : MPSTensor d (dim0 k))
@@ -417,64 +507,32 @@ theorem exists_pgvwc07_unital_dualDiag_blockwise
               (∑ i : Fin d, C i * (C i)ᴴ = 1) ∧
               transferMap (d := d) (D := dim0 k) (fun i => (C i)ᴴ) Λ = Λ) := by
     intro k
-    letI : NeZero (dim0 k) := ⟨hdim0_ne k⟩
+    letI : NeZero (dim0 k) :=
+      ⟨bond_dim_ne_zero_of_exists_nonzero
+        (d := d) (D := dim0 k) (blocks0 k) (hNonzero0 k)⟩
     exact exists_pgvwc07_unital_dualDiag_data_of_irreducible
       (A := blocks0 k) (hIrr := hIrr0 k) (hA := hNonzero0 k)
   choose blocksB blocks1 r1 ρ1 Λ1 U1 hρpd1 hrpos1 hform1 hGauge1 hUnitalB1
     hScalarB1 hFinal1 using hcanon
+  have hSameGauge :
+      ∀ k : Fin r0,
+        SameMPV
+          (fun i => (↑((Real.sqrt (r1 k))⁻¹) : ℂ) • blocks0 k i)
+          (blocks1 k) := by
+    intro k
+    let c : ℂ := (↑((Real.sqrt (r1 k))⁻¹) : ℂ)
+    have hGaugeSame : SameMPV (fun i => c • blocks0 k i) (blocksB k) :=
+      GaugeEquiv.sameMPV (hGauge1 k)
+    have hSameBC : SameMPV₂ (blocksB k) (blocks1 k) := (hFinal1 k).2.1
+    intro N σ
+    calc
+      mpv (fun i => (↑((Real.sqrt (r1 k))⁻¹) : ℂ) • blocks0 k i) σ
+          = mpv (blocksB k) σ := by
+              simpa [c] using hGaugeSame N σ
+      _ = mpv (blocks1 k) σ := hSameBC N σ
   let μ1 : Fin r0 → ℂ := fun k => (↑(Real.sqrt (r1 k)) : ℂ)
-  have hSameBlocks :
-      SameMPV₂
-        (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0)
-        (toTensorFromBlocks (d := d) (μ := μ1) blocks1) := by
-    intro N σ
-    calc
-      mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0) σ
-          = ∑ k : Fin r0, (1 : ℂ) ^ N * mpv (blocks0 k) σ := by
-              simpa [smul_eq_mul] using
-                (mpv_toTensorFromBlocks_eq_sum
-                  (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) (A := blocks0) (σ := σ))
-      _ = ∑ k : Fin r0, (μ1 k) ^ N * mpv (blocks1 k) σ := by
-            refine Finset.sum_congr rfl ?_
-            intro k _
-            let c : ℂ := (↑((Real.sqrt (r1 k))⁻¹) : ℂ)
-            have hGaugeSame : SameMPV (fun i => c • blocks0 k i) (blocksB k) :=
-              GaugeEquiv.sameMPV (hGauge1 k)
-            have hSameBC : SameMPV₂ (blocksB k) (blocks1 k) := (hFinal1 k).2.1
-            have hscale : mpv (blocks1 k) σ = c ^ N * mpv (blocks0 k) σ := by
-              calc
-                mpv (blocks1 k) σ = mpv (blocksB k) σ := (hSameBC N σ).symm
-                _ = mpv (fun i => c • blocks0 k i) σ := (hGaugeSame N σ).symm
-                _ = c ^ N * mpv (blocks0 k) σ := mpv_smul c (blocks0 k) σ
-            have hroot_ne : (↑(Real.sqrt (r1 k)) : ℂ) ≠ 0 := by
-              exact_mod_cast (Real.sqrt_ne_zero'.mpr (hrpos1 k))
-            have hμc : μ1 k * c = 1 := by
-              dsimp [μ1, c]
-              simp [hroot_ne]
-            have hmulpow : (μ1 k) ^ N * c ^ N = 1 := by
-              rw [← mul_pow, hμc, one_pow]
-            have hmulpow_apply :
-                (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ) = mpv (blocks0 k) σ := by
-              calc
-                (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ)
-                    = ((μ1 k) ^ N * c ^ N) * mpv (blocks0 k) σ := by ring
-                _ = mpv (blocks0 k) σ := by simp [hmulpow]
-            calc
-              (1 : ℂ) ^ N * mpv (blocks0 k) σ = mpv (blocks0 k) σ := by simp
-              _ = (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ) := hmulpow_apply.symm
-              _ = (μ1 k) ^ N * mpv (blocks1 k) σ := by rw [hscale]
-      _ = mpv (toTensorFromBlocks (d := d) (μ := μ1) blocks1) σ := by
-            symm
-            simpa [smul_eq_mul] using
-              (mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μ1) (A := blocks1) (σ := σ))
-  have hSame1 :
-      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ1) blocks1) := by
-    intro N σ
-    calc
-      mpv A σ
-          = mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0) σ :=
-              hSame0 N σ
-      _ = mpv (toTensorFromBlocks (d := d) (μ := μ1) blocks1) σ := hSameBlocks N σ
+  obtain ⟨hSame1, hμne1, hDim1⟩ :=
+    gauge_blockwise_shared A blocks0 hSame0 hNonzero0 blocks1 r1 hrpos1 hSameGauge
   have hΛData :
       ∀ k : Fin r0,
         ∃ Λ : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ,
@@ -498,13 +556,6 @@ theorem exists_pgvwc07_unital_dualDiag_blockwise
   have hμpos1 : ∀ k : Fin r0, ∃ a : ℝ, 0 < a ∧ μ1 k = (a : ℂ) := by
     intro k
     exact ⟨Real.sqrt (r1 k), Real.sqrt_pos.2 (hrpos1 k), rfl⟩
-  have hμne1 : ∀ k : Fin r0, μ1 k ≠ 0 := by
-    intro k
-    dsimp [μ1]
-    exact_mod_cast (Real.sqrt_ne_zero'.mpr (hrpos1 k))
-  have hDim1 : ∀ k : Fin r0, 0 < dim0 k := by
-    intro k
-    exact Nat.pos_of_ne_zero (hdim0_ne k)
   exact ⟨r0, dim0, μ1, blocks1, hSame1, hΛData, hScalarC, hμpos1, hμne1, hDim1⟩
 
 /-- Blockwise Perron--Frobenius / TP-gauge stage for an irreducible block decomposition.
@@ -539,16 +590,6 @@ theorem exists_tp_gauge_blockwise
         (∀ k, μ1 k ≠ 0) ∧
         (∀ k, 0 < dim1 k) := by
   classical
-  have hdim0_ne : ∀ k : Fin r0, dim0 k ≠ 0 := by
-    intro k hk0
-    rcases hNonzero0 k with ⟨i, hi⟩
-    have hzero : blocks0 k i = 0 := by
-      ext a b
-      exfalso
-      have ha : (a : ℕ) < 0 := by
-        simpa [hk0] using a.2
-      omega
-    exact hi hzero
   have htp :
       ∀ k : Fin r0,
         ∃ (B : MPSTensor d (dim0 k)) (r : ℝ) (σ : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ),
@@ -560,15 +601,26 @@ theorem exists_tp_gauge_blockwise
           GaugeEquiv (d := d) (D := dim0 k)
             (fun i => (↑((Real.sqrt r)⁻¹) : ℂ) • blocks0 k i) B := by
     intro k
-    letI : NeZero (dim0 k) := ⟨hdim0_ne k⟩
+    letI : NeZero (dim0 k) :=
+      ⟨bond_dim_ne_zero_of_exists_nonzero
+        (d := d) (D := dim0 k) (blocks0 k) (hNonzero0 k)⟩
     exact
       exists_tp_data_of_irreducible
         (A := blocks0 k) (hIrr := hIrr0 k) (hA := hNonzero0 k)
   choose blocks1 r1 σ1 hσpd1 hrpos1 hform1 hLeft1 hGauge1 using htp
+  have hSameGauge :
+      ∀ k : Fin r0,
+        SameMPV
+          (fun i => (↑((Real.sqrt (r1 k))⁻¹) : ℂ) • blocks0 k i)
+          (blocks1 k) := by
+    intro k
+    exact GaugeEquiv.sameMPV (hGauge1 k)
   let μ1 : Fin r0 → ℂ := fun k => (↑(Real.sqrt (r1 k)) : ℂ)
+  obtain ⟨hSame1, hμne1, hDim1⟩ :=
+    gauge_blockwise_shared A blocks0 hSame0 hNonzero0 blocks1 r1 hrpos1 hSameGauge
   have hIrr1 : ∀ k : Fin r0, IsIrreducibleTensor (blocks1 k) := by
     intro k
-    letI : NeZero (dim0 k) := ⟨hdim0_ne k⟩
+    letI : NeZero (dim0 k) := ⟨Nat.pos_iff_ne_zero.mp (hDim1 k)⟩
     let c : ℂ := (↑((Real.sqrt (r1 k))⁻¹) : ℂ)
     have hroot_ne : (↑(Real.sqrt (r1 k)) : ℂ) ≠ 0 := by
       exact_mod_cast (Real.sqrt_ne_zero'.mpr (hrpos1 k))
@@ -589,64 +641,6 @@ theorem exists_tp_gauge_blockwise
       funext i
       simpa [tpGauge, c] using hform1 k i
     simpa [hEq] using hIrr_gauge
-  have hSameBlocks :
-      SameMPV₂
-        (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0)
-        (toTensorFromBlocks (d := d) (μ := μ1) blocks1) := by
-    intro N σ
-    calc
-      mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0) σ
-          = ∑ k : Fin r0, (1 : ℂ) ^ N * mpv (blocks0 k) σ := by
-              simpa [smul_eq_mul] using
-                (mpv_toTensorFromBlocks_eq_sum
-                  (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) (A := blocks0) (σ := σ))
-      _ = ∑ k : Fin r0, (μ1 k) ^ N * mpv (blocks1 k) σ := by
-            refine Finset.sum_congr rfl ?_
-            intro k _
-            let c : ℂ := (↑((Real.sqrt (r1 k))⁻¹) : ℂ)
-            have hGaugeSame : SameMPV (fun i => c • blocks0 k i) (blocks1 k) :=
-              GaugeEquiv.sameMPV (hGauge1 k)
-            have hscale : mpv (blocks1 k) σ = c ^ N * mpv (blocks0 k) σ := by
-              calc
-                mpv (blocks1 k) σ = mpv (fun i => c • blocks0 k i) σ :=
-                  (hGaugeSame N σ).symm
-                _ = c ^ N * mpv (blocks0 k) σ := mpv_smul c (blocks0 k) σ
-            have hroot_ne : (↑(Real.sqrt (r1 k)) : ℂ) ≠ 0 := by
-              exact_mod_cast (Real.sqrt_ne_zero'.mpr (hrpos1 k))
-            have hμc : μ1 k * c = 1 := by
-              dsimp [μ1, c]
-              simp [hroot_ne]
-            have hmulpow : (μ1 k) ^ N * c ^ N = 1 := by
-              rw [← mul_pow, hμc, one_pow]
-            have hmulpow_apply :
-                (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ) = mpv (blocks0 k) σ := by
-              calc
-                (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ)
-                    = ((μ1 k) ^ N * c ^ N) * mpv (blocks0 k) σ := by ring
-                _ = mpv (blocks0 k) σ := by simp [hmulpow]
-            calc
-              (1 : ℂ) ^ N * mpv (blocks0 k) σ = mpv (blocks0 k) σ := by simp
-              _ = (μ1 k) ^ N * (c ^ N * mpv (blocks0 k) σ) := hmulpow_apply.symm
-              _ = (μ1 k) ^ N * mpv (blocks1 k) σ := by rw [hscale]
-      _ = mpv (toTensorFromBlocks (d := d) (μ := μ1) blocks1) σ := by
-            symm
-            simpa [smul_eq_mul] using
-              (mpv_toTensorFromBlocks_eq_sum (d := d) (μ := μ1) (A := blocks1) (σ := σ))
-  have hSame1 :
-      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ1) blocks1) := by
-    intro N σ
-    calc
-      mpv A σ
-          = mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0) σ :=
-              hSame0 N σ
-      _ = mpv (toTensorFromBlocks (d := d) (μ := μ1) blocks1) σ := hSameBlocks N σ
-  have hμne1 : ∀ k : Fin r0, μ1 k ≠ 0 := by
-    intro k
-    dsimp [μ1]
-    exact_mod_cast (Real.sqrt_ne_zero'.mpr (hrpos1 k))
-  have hDim1 : ∀ k : Fin r0, 0 < dim0 k := by
-    intro k
-    exact Nat.pos_of_ne_zero (hdim0_ne k)
   exact ⟨r0, dim0, μ1, blocks1, hSame1, hIrr1, hLeft1, hμne1, hDim1⟩
 
 /-!
@@ -669,6 +663,27 @@ The PGVWC07 unital statement below is the strongest unconditional arbitrary-inpu
 step available here before the final total bond-dimension bound is threaded
 through the construction.
 -/
+
+private theorem mpv_zero_tail_chain_of_sameMPV₂
+    {Dnz r : ℕ} {zeroTailDim : ℕ}
+    {dim : Fin r → ℕ} {μ : Fin r → ℂ}
+    {blocks : (k : Fin r) → MPSTensor d (dim k)}
+    (A : MPSTensor d D)
+    (A_nonzero : MPSTensor d Dnz)
+    (hMPV₀ :
+      ∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ + mpv A_nonzero σ)
+    (hSame₁ : SameMPV₂ A_nonzero (toTensorFromBlocks (d := d) (μ := μ) blocks)) :
+    ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ +
+        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+  intro N σ
+  calc
+    mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ + mpv A_nonzero σ := hMPV₀ N σ
+    _ = mpv (zeroMPSTensor d zeroTailDim) σ +
+          mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ := by
+        congr 1
+        exact hSame₁ N σ
 
 /-- **Arbitrary-input PGVWC07 unital dual-diagonal form with zero blocks.**
 
@@ -722,15 +737,10 @@ theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail
     hDim₁⟩ :=
     exists_pgvwc07_unital_dualDiag_blockwise A_nonzero blocks₀ hIrr₀ hSame_refl
       hNonzero₀
-  refine ⟨zeroTailDim, r₁, dim₁, μ₁, blocks₁, hΛData₁, hScalar₁, hμPos₁, hμNe₁,
-    hDim₁, ?_⟩
-  intro N σ
-  calc
-    mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ + mpv A_nonzero σ := hMPV₀ N σ
-    _ = mpv (zeroMPSTensor d zeroTailDim) σ +
-          mpv (toTensorFromBlocks (d := d) (μ := μ₁) blocks₁) σ := by
-        congr 1
-        exact hSame₁ N σ
+  refine ⟨zeroTailDim, r₁, dim₁, μ₁, blocks₁, hΛData₁, hScalar₁,
+    hμPos₁, hμNe₁, hDim₁, ?_⟩
+  exact mpv_zero_tail_chain_of_sameMPV₂
+    (d := d) (D := D) (zeroTailDim := zeroTailDim) A A_nonzero hMPV₀ hSame₁
 
 /-- **Bond-dimension identity for the arbitrary-input PGVWC07 zero-block form.**
 
@@ -922,14 +932,8 @@ theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
     exists_tp_gauge_blockwise A_nonzero blocks₀ hIrr₀ hSame_refl hNonzero₀
   -- Step 3: Assemble the result.
   refine ⟨zeroTailDim, r₁, dim₁, μ₁, blocks₁, hIrr₁, hLeft₁, hμNe₁, hDim₁, ?_⟩
-  -- The MPV relationship chains through the zero-block separation and TP gauge.
-  intro N σ
-  calc mpv A σ
-      = mpv (zeroMPSTensor d zeroTailDim) σ + mpv A_nonzero σ := hMPV₀ N σ
-    _ = mpv (zeroMPSTensor d zeroTailDim) σ +
-          mpv (toTensorFromBlocks (d := d) (μ := μ₁) blocks₁) σ := by
-        congr 1
-        exact hSame₁ N σ
+  exact mpv_zero_tail_chain_of_sameMPV₂
+    (d := d) (D := D) (zeroTailDim := zeroTailDim) A A_nonzero hMPV₀ hSame₁
 
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -620,7 +620,9 @@ theorem exists_tp_gauge_blockwise
     gauge_blockwise_shared A blocks0 hSame0 hNonzero0 blocks1 r1 hrpos1 hSameGauge
   have hIrr1 : ∀ k : Fin r0, IsIrreducibleTensor (blocks1 k) := by
     intro k
-    letI : NeZero (dim0 k) := ⟨Nat.pos_iff_ne_zero.mp (hDim1 k)⟩
+    letI : NeZero (dim0 k) :=
+      ⟨bond_dim_ne_zero_of_exists_nonzero
+        (d := d) (D := dim0 k) (blocks0 k) (hNonzero0 k)⟩
     let c : ℂ := (↑((Real.sqrt (r1 k))⁻¹) : ℂ)
     have hroot_ne : (↑(Real.sqrt (r1 k)) : ℂ) ≠ 0 := by
       exact_mod_cast (Real.sqrt_ne_zero'.mpr (hrpos1 k))

--- a/blueprint/comments20260407/ch08_09_lean_audit.md
+++ b/blueprint/comments20260407/ch08_09_lean_audit.md
@@ -23,11 +23,11 @@ Quick status:
    - Lean states only `SameMPV₂ A (toTensorFromBlocks (fun _ => 1) blocks)` with irreducible blocks. See `TNLean/MPS/CanonicalForm/Reduction.lean:106`.
    - Suggested fix: drop "up to unitary equivalence" from the theorem statement.
 
-3. `ch08` `MPSTensor.exists_irreducible_blockDecomp_with_CFII` has an editorial glitch.
+3. `ch08` formerly had a CFII block-decomposition entry with an editorial glitch.
    - Blueprint: [blueprint/src/chapter/ch08_canonical.tex](/Users/siruilu/Library/Mobile%20Documents/com~apple~CloudDocs/Research/Agent-Physics/MPSLean/blueprint/src/chapter/ch08_canonical.tex):753 is a sentence fragment: "The conclusion is the left-canonical normalization; the remaining reduction to normal canonical form."
-   - Lean-side content is fine; this just reads unfinished.
+   - The entry has since been removed, so the old prose issue is obsolete.
 
-4. `ch08` seriously compresses `MPSTensor.exists_irreducible_blockDecomp_with_tpGauge` past what Lean actually says.
+4. `ch08` formerly compressed the TP-gauge block-decomposition sibling past what Lean said.
    - Blueprint: [blueprint/src/chapter/ch08_canonical.tex](/Users/siruilu/Library/Mobile%20Documents/com~apple~CloudDocs/Research/Agent-Physics/MPSLean/blueprint/src/chapter/ch08_canonical.tex):1457 says: "After removing a trivial block, one obtains a block decomposition into irreducible blocks with a trace-preserving gauge."
    - Lean theorem is more conditional: from an irreducible block decomposition, each block with a nonzero Kraus operator admits a TP-gauge representative; zero blocks cannot just be dropped because `SameMPV₂` remembers the `N = 0` sector. See `TNLean/MPS/CanonicalForm/Existence.lean:306`.
    - Suggested fix: mention the nonzero-Kraus side condition explicitly, or rewrite this as a continuation theorem rather than a global decomposition theorem.

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -17,21 +17,21 @@ theorem of~\cite{PerezGarcia2007Matrix}.
 \section*{Notation}
 
 \begin{center}
-\begin{tabular}{ll}
-    $\C$, $\N$, $\Z$ & complex numbers, natural numbers, integers \\
-    $\MN{D}$, $\GL_D(\C)$ & complex matrices and invertible complex matrices \\
-    $\tr(X)$, $\spn_{\C}(S)$ & trace and complex linear span \\
-    $A=\{A^i\}_{i=0}^{d-1}$ & a translation-invariant MPS tensor \\
-    $w=(i_1,\ldots,i_L)$, $A^w$ & a word and the product
-        $A^{i_1}\cdots A^{i_L}$ \\
-    $\ket{V^{(N)}(A)}$ & the length-$N$ matrix product vector \\
-    $V^{(N)}(A)_\sigma$ & the coefficient of $\ket{V^{(N)}(A)}$ at
-        $\sigma$ \\
-    $O_{AB}(N)$ & the bilinear overlap
-        $\overline{\braket{V^{(N)}(A)}{V^{(N)}(B)}}$ \\
-    $\E_A(X)$ & the transfer map $\sum_i A^i X(A^i)^\dagger$ \\
-    $A^{[L]}$ & the length-$L$ blocked tensor \\
-\end{tabular}
+    \begin{tabular}{ll}
+        $\C$, $\N$, $\Z$            & complex numbers, natural numbers, integers       \\
+        $\MN{D}$, $\GL_D(\C)$       & complex matrices and invertible complex matrices \\
+        $\tr(X)$, $\spn_{\C}(S)$    & trace and complex linear span                    \\
+        $A=\{A^i\}_{i=0}^{d-1}$     & a translation-invariant MPS tensor               \\
+        $w=(i_1,\ldots,i_L)$, $A^w$ & a word and the product
+        $A^{i_1}\cdots A^{i_L}$                                                        \\
+        $\ket{V^{(N)}(A)}$          & the length-$N$ matrix product vector             \\
+        $V^{(N)}(A)_\sigma$         & the coefficient of $\ket{V^{(N)}(A)}$ at
+        $\sigma$                                                                       \\
+        $O_{AB}(N)$                 & the bilinear overlap
+        $\overline{\braket{V^{(N)}(A)}{V^{(N)}(B)}}$                                   \\
+        $\E_A(X)$                   & the transfer map $\sum_i A^i X(A^i)^\dagger$     \\
+        $A^{[L]}$                   & the length-$L$ blocked tensor                    \\
+    \end{tabular}
 \end{center}
 
 In canonical form one writes

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -145,7 +145,7 @@ legs cyclically and taking the resulting trace.
     \]
     This is the mixed-state analogue of the renormalization fixed-point
     condition for MPS tensors; see \cite[definition of MPDO zero correlation
-    length, lines~736--741]{Cirac2017MPDO_AnnPhys} and
+        length, lines~736--741]{Cirac2017MPDO_AnnPhys} and
     \cite[Section~II.E.2, lines~937--939]{Cirac2021Matrix}.
 \end{definition}
 
@@ -255,7 +255,7 @@ legs cyclically and taking the resulting trace.
     witness whose purifying MPS tensor is a pure-state renormalization
     fixed point.
     This is \cite[definition of purification RFP, lines~756--759]
-        {Cirac2017MPDO_AnnPhys}.
+    {Cirac2017MPDO_AnnPhys}.
 \end{definition}
 
 \begin{remark}[PRFP does not imply MPO ZCL]\label{rem:prfp_not_implies_zcl}
@@ -1244,8 +1244,8 @@ the elementary trace-power identity for diagonal matrices.
     same-length product form when, for every positive length \(L\),
     \[
         O_L(M_\alpha)O_L(M_\beta)
-          = \sum_\gamma
-              c^{(L)}_{\alpha,\beta,\gamma} O_L(M_\gamma).
+        = \sum_\gamma
+        c^{(L)}_{\alpha,\beta,\gamma} O_L(M_\gamma).
     \]
     This is the product identity appearing in Theorem~IV.13(ii), stated
     independently of the blocked-basis multiplication
@@ -1284,8 +1284,8 @@ the elementary trace-power identity for diagonal matrices.
     idempotent coefficient form when, for every BNT label \(\gamma\),
     \[
         m_\gamma =
-          \sum_{\alpha,\beta}
-            c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta.
+        \sum_{\alpha,\beta}
+        c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta.
     \]
     This is the idempotent condition in Theorem~IV.13(ii), stated separately
     from the trace-power formula.
@@ -1318,7 +1318,7 @@ the elementary trace-power identity for diagonal matrices.
     of \(\mathcal A_{2n}\) to the fixed BNT labels, together with the equality
     \[
         c^{(n)}_{i,j,k}
-          =
+        =
         c^{(n)}_{\sigma_n(i),\sigma_n(j),\tau_n(k)}.
     \]
     This is a blocked-basis comparison: the left hand side is expanded in the
@@ -1394,7 +1394,7 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_chi_eq_trace_matrix_pow}
     A positive BNT-label \(\chi\) witness gives, for every \(L>0\), the formula
     \(c^{(L)}_{\alpha,\beta,\gamma}
-      =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})\).
+    =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})\).
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace reformulation of the positive-length trace-power identity
@@ -1413,10 +1413,10 @@ the elementary trace-power identity for diagonal matrices.
     for every \(L>0\),
     \[
         O_L(M_\alpha)O_L(M_\beta)
-          = \sum_\gamma
-            \operatorname{tr}\bigl(
-              \chi_{\alpha,\beta,\gamma}^{\,L}
-            \bigr) O_L(M_\gamma).
+        = \sum_\gamma
+        \operatorname{tr}\bigl(
+        \chi_{\alpha,\beta,\gamma}^{\,L}
+        \bigr) O_L(M_\gamma).
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -1436,9 +1436,9 @@ the elementary trace-power identity for diagonal matrices.
     \(\chi\)-witness, then
     \[
         m_\gamma =
-          \sum_{\alpha,\beta}
-            \operatorname{tr}(\chi_{\alpha,\beta,\gamma})
-            m_\alpha m_\beta .
+        \sum_{\alpha,\beta}
+        \operatorname{tr}(\chi_{\alpha,\beta,\gamma})
+        m_\alpha m_\beta .
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -1460,10 +1460,10 @@ the elementary trace-power identity for diagonal matrices.
     \(\chi\)-matrix:
     \[
         c^{(n)}_{i,j,k}
-          = \operatorname{tr}
-              \bigl(
-                \chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}^{\,n}
-              \bigr).
+        = \operatorname{tr}
+        \bigl(
+        \chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}^{\,n}
+        \bigr).
     \]
 \end{theorem}
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -103,7 +103,7 @@ finite-dimensional quantum systems.
     \[
         (\tr_{AC} \rho_{ABC})_{b_1 b_2}
         = \sum_{a=0}^{d_A - 1} \sum_{c=0}^{d_C - 1}
-          (\rho_{ABC})_{(a, b_1, c)(a, b_2, c)}.
+        (\rho_{ABC})_{(a, b_1, c)(a, b_2, c)}.
     \]
 \end{definition}
 
@@ -264,7 +264,7 @@ later MPDO arguments.
     \lean{Entropy.ssaEquality_iff_exists_quantumMarkovDecomposition}
     \leanok
     \uses{def:ssa_equality, def:entropy_quantum_markov_decomposition,
-          thm:hayashi_ssa_equality_characterization}
+        thm:hayashi_ssa_equality_characterization}
     For any tripartite density matrix $\rho_{ABC}$, equality in strong
     subadditivity holds if and only if $\rho_{ABC}$ admits a quantum
     Markov decomposition on the middle subsystem $B$.
@@ -340,8 +340,8 @@ introduces a new axiom.
     \lean{Entropy.mutualInformation_monotone_tripartite}
     \leanok
     \uses{def:entropy_mutual_information, def:entropy_von_neumann_entropy,
-          def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC,
-          thm:entropy_strong_subadditivity}
+        def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC,
+        thm:entropy_strong_subadditivity}
     For any tripartite density matrix $\rho_{ABC}$ on
     $A \otimes B \otimes C$,
     \[
@@ -368,7 +368,7 @@ introduces a new axiom.
     \lean{Entropy.mutualInformation_le_log_dim_add_log_dim}
     \leanok
     \uses{def:entropy_mutual_information, thm:entropy_le_log_dim,
-          thm:entropy_nonneg_finite_index}
+        thm:entropy_nonneg_finite_index}
     For a bipartite density matrix $\rho_{AB}$ on
     $\mathbb{C}^{d_A} \otimes \mathbb{C}^{d_B}$ with $d_A, d_B \ge 1$
     whose single-system reduced states are obtained by partial trace,

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1700,7 +1700,7 @@ structure for completeness.
     \[
         \operatorname{MPV}_A
         =
-        \operatorname{MPV}_{_{D_0}}
+        \operatorname{MPV}_{0_{D_0}}
         +
         \operatorname{MPV}_{\oplus_k \mu_k C_k}.
     \]

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -438,7 +438,7 @@ definitions stated below.
 
     This is the spectral-radius normalization and full-rank fixed-point gauge
     used in \cite[Theorem~Th:TIcanonical, lines~765--769]
-        {PerezGarcia2007Matrix}.
+    {PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1622,7 +1622,7 @@ structure for completeness.
     \]
     is unital.  In this unital gauge every fixed point of $\E_B$ is a scalar
     multiple of the identity.  Moreover a unitary conjugate $C^i=U^\dagger
-    B^iU$ remains unital and has a diagonal positive definite dual fixed point
+        B^iU$ remains unital and has a diagonal positive definite dual fixed point
     $\Lambda$:
     \[
         \sum_i C^i(C^i)^\dagger=\Id,
@@ -1634,7 +1634,7 @@ structure for completeness.
 
     This composes the single-block canonical-form existence steps of
     \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
-        {PerezGarcia2007Matrix}.  It is not yet the full theorem, because the
+    {PerezGarcia2007Matrix}.  It is not yet the full theorem, because the
     recursive finite-ring block decomposition and the final bond-dimension
     bound have not been threaded through this construction.
 \end{theorem}
@@ -1673,7 +1673,7 @@ structure for completeness.
 
     This is the blockwise composition of
     \cite[Theorem~Th:TIcanonical, lines~765--770 and 816--832]
-        {PerezGarcia2007Matrix} after the recursive splitting has already
+    {PerezGarcia2007Matrix} after the recursive splitting has already
     produced the nonzero irreducible summands.  It is not yet the full source
     theorem, because it does not start from an arbitrary representation and
     does not prove the final total bond-dimension bound.
@@ -1700,7 +1700,7 @@ structure for completeness.
     \[
         \operatorname{MPV}_A
         =
-        \operatorname{MPV}_{0_{D_0}}
+        \operatorname{MPV}_{_{D_0}}
         +
         \operatorname{MPV}_{\oplus_k \mu_k C_k}.
     \]

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -736,27 +736,6 @@ statement is Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
     factor the common scalar power out of the sum.
 \end{proof}
 
-\begin{theorem}[Irreducible block decomposition with left-canonical normalization]%
-    \label{thm:irreducible_block_decomp_with_cfii}
-    \lean{MPSTensor.exists_irreducible_blockDecomp_with_CFII}
-    \leanok
-    \uses{def:irreducible_tensor}
-    For any MPS tensor~$A$, there exist irreducible blocks
-    $(A_k)_{k=1}^r$ that generate the same MPV family as~$A$.
-    Moreover, for each block~$k$,
-    if that block has already been placed in TP gauge and $D_k > 0$,
-    one obtains a left-canonical normalization (unitary, diagonal PD fixed point,
-    MPV preservation).
-    This yields the left-canonical normalization; the further reduction to
-    normal canonical form is carried out in the subsequent spectral analysis.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:irred_decomp, thm:CFII_data}
-    Combine Theorems~\ref{thm:irred_decomp}
-    and~\ref{thm:CFII_data}.
-\end{proof}
-
 \begin{theorem}[Normal canonical form from a primitive block decomposition]%
     \label{thm:exists_normal_canonical_form}
     \lean{MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -519,7 +519,7 @@ factorization is assumed.
     \]
     matching \cite[\S~II.C, lines~271--301]{Cirac2017MPDO_AnnPhys}
     and \cite[Definition~4.2, Proposition~4.3, and lines~1864--1884]
-        {Cirac2021Matrix}.
+    {Cirac2021Matrix}.
     The line-246 normalization admits every example of the source paper
     (in particular $C \oplus D$, $C \oplus (-C)$,
     $C \oplus (1/2) C$, and $C \oplus (-C) \oplus (1/2) C$) and is
@@ -538,7 +538,7 @@ factorization is assumed.
     \]
     This is
     \cite[two-layer BNT and coefficient-expansion displays,
-    lines~287--301]{Cirac2017MPDO_AnnPhys} and
+        lines~287--301]{Cirac2017MPDO_AnnPhys} and
     \cite[lines~1864--1884]{Cirac2021Matrix}.
 \end{lemma}
 
@@ -723,7 +723,7 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     This reads the \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys}
     normalization sector by sector, together with the convergence use at
     \cite[Appendix ``Proofs of Section MPS'', line~1244]
-        {Cirac2017MPDO_AnnPhys}. The unit-modulus witness is supplied
+    {Cirac2017MPDO_AnnPhys}. The unit-modulus witness is supplied
     externally (as the hypothesis above) because the source statement is
     global (``at least one of them equals one'' over the two-layer index
     $(j, q)$) and does not pin the witness to a specific sector.
@@ -903,7 +903,7 @@ basis, assuming the same per-sector unit-weight condition on both sides.
     (Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}) on the
     \emph{full} family $\{P_j\}_j \sqcup \{Q_k\}_k$, the corollary
     input of \cite[Appendix MPV corollary, lines~1131--1133]
-        {Cirac2017MPDO_AnnPhys}, not
+    {Cirac2017MPDO_AnnPhys}, not
     on any partial union.
 \end{remark}
 
@@ -1043,7 +1043,7 @@ matching covers the whole BNT basis.
     \]
     This records the per-block phase conclusion of
     \cite[Appendix MPV theorem statement, lines~1167--1170]
-        {Cirac2017MPDO_AnnPhys}; the proof step at
+    {Cirac2017MPDO_AnnPhys}; the proof step at
     \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys} is the
     corresponding argument. The following coefficient-comparison step is
     separate.
@@ -1390,7 +1390,7 @@ matching covers the whole BNT basis.
     matrices in $\MN{D}$ using the total bond-dimension equality. This is the
     normalized BNT form of
     \cite[Corollary~II.2 and Appendix MPV proof, lines~1189--1192]
-        {Cirac2017MPDO_AnnPhys}, under the same unit-modulus-copy normalization
+    {Cirac2017MPDO_AnnPhys}, under the same unit-modulus-copy normalization
     as Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -164,7 +164,7 @@ gauge-phase identification of corresponding sectors) and the global
 gauge identification are formalised on the BNT canonical form of
 Chapter~\ref{ch:bnt}. The literal coordinate form of
 \cite[Corollary~II.2 and \S~II.C, lines 1184--1192]
-    {Cirac2017MPDO_AnnPhys}
+{Cirac2017MPDO_AnnPhys}
 is recorded there under the unit-modulus-copy normalization.
 % Maintainer note (Lean): see the declarations
 % MPSTensor.ft_sector_bnt_equal_sector_data and

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -45,6 +45,22 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     For $N \ge 1$, every word product of a zero tensor is zero.
 \end{proof}
 
+\begin{lemma}[All-zero irreducible blocks have bond dimension at most one]%
+    \label{lem:irreducible_allZero_dim_le_one}
+    \lean{MPSTensor.isIrreducibleTensor_allZero_dim_le_one}
+    \leanok
+    \uses{def:irreducible_tensor}
+    If $A$ is an irreducible MPS tensor with every Kraus operator $A^i = 0$,
+    then $D \le 1$.
+\end{lemma}
+
+\begin{proof}\leanok
+    If $D \ge 2$, irreducibility forces some Kraus operator to be nonzero
+    (otherwise the bond space splits as the direct sum of any two complementary
+    subspaces, contradicting irreducibility). The hypothesis $A^i = 0$ for every
+    $i$ therefore implies $D \le 1$.
+\end{proof}
+
 \begin{theorem}[Zero-block separation]%
     \label{thm:zero_block_separation}
     \lean{MPSTensor.exists_irreducible_blockDecomp_nonzeroBlocks}
@@ -68,12 +84,13 @@ a single tensor $\mathbf{0}_{d,D_0}$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:irred_decomp, thm:mpv_zero_tensor}
+    \uses{thm:irred_decomp, thm:mpv_zero_tensor, lem:irreducible_allZero_dim_le_one}
     Apply the irreducible block decomposition
     (Theorem~\ref{thm:irred_decomp}) and partition the blocks
     by whether each has a nonzero Kraus operator.
-    The all-zero blocks satisfy a dimension bound via
-    irreducibility; their total bond dimension is $D_0$.
+    The all-zero blocks satisfy
+    Lemma~\ref{lem:irreducible_allZero_dim_le_one}, so their total bond
+    dimension $D_0$ accumulates the bond dimensions of the all-zero blocks.
     The MPV identity follows from the block structure and
     Theorem~\ref{thm:mpv_zero_tensor}.
 \end{proof}

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -84,12 +84,10 @@ a single tensor $\mathbf{0}_{d,D_0}$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:irred_decomp, thm:mpv_zero_tensor, lem:irreducible_allZero_dim_le_one}
+    \uses{thm:irred_decomp, thm:mpv_zero_tensor}
     Apply the irreducible block decomposition
     (Theorem~\ref{thm:irred_decomp}) and partition the blocks
-    by whether each has a nonzero Kraus operator.
-    The all-zero blocks satisfy
-    Lemma~\ref{lem:irreducible_allZero_dim_le_one}, so their total bond
+    by whether each has a nonzero Kraus operator.  Their total bond
     dimension $D_0$ accumulates the bond dimensions of the all-zero blocks.
     The MPV identity follows from the block structure and
     Theorem~\ref{thm:mpv_zero_tensor}.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -349,7 +349,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     operator \(O\). Then
     \[
         \Phi_v\circ T_O\circ\Psi_v
-            = P_v\circ O\circ P_v .
+        = P_v\circ O\circ P_v .
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -1335,16 +1335,16 @@ injective and normal PEPS, following Theorems~2 and~3 of
                 \node[tn tensor dot] (unionBA) at (2.00,0) {};
                 \node[tn tensor dot] (unionC) at (1.30,-0.70) {};
                 \foreach \n in {unionAB,unionI,unionBA,unionC} {
-                    \draw[tn phys leg] (\n.north) -- ++(0,0.42);
-                }
+                        \draw[tn phys leg] (\n.north) -- ++(0,0.42);
+                    }
                 \draw[tn leg] (unionAB) -- (unionI) -- (unionBA) -- (unionC) --
-                    (unionAB) -- (unionBA);
+                (unionAB) -- (unionBA);
                 \draw[tn leg] (unionI) -- (unionC);
                 \node[anchor=east] at ($(unionAB)+(-0.12,-0.20)$)
-                    {$A\setminus B$};
+                {$A\setminus B$};
                 \node[anchor=west] at ($(unionI)+(0.12,0.02)$) {$A\cap B$};
                 \node[anchor=west] at ($(unionBA)+(0.12,-0.20)$)
-                    {$B\setminus A$};
+                {$B\setminus A$};
                 \node at ($(unionC)+(0,-0.38)$) {$(A\cup B)^c$};
             \end{tikzpicture}%
         }
@@ -1440,7 +1440,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{definition}
 
 \begin{lemma}[Coordinate rectangular injectivity gives abstract rectangular
-    injectivity]%
+        injectivity]%
     \label{lem:peps_squareLatticeRectangleInjectivity_toRectangular}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.toRectangular}
     \leanok
@@ -1603,10 +1603,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
                     \node[tn tensor dot] (tiA) at (0,0) {};
                     \node[tn operator dot, label=left:$X$] (tiXL) at (-0.76,0) {};
                     \node[tn operator dot, label=right:$X^{-1}$] (tiXR)
-                        at (0.76,0) {};
+                    at (0.76,0) {};
                     \node[tn operator dot, label=below:$Y$] (tiYD) at (0,-0.76) {};
                     \node[tn operator dot, label=above:$Y^{-1}$] (tiYU)
-                        at (0,0.76) {};
+                    at (0,0.76) {};
                     \draw[tn phys leg] (tiA.north) -- ++(0,0.46);
                     \draw[tn leg] (tiXL.west) -- ++(-0.24,0);
                     \draw[tn leg] (tiXL.east) -- (tiA.west);

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -619,8 +619,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{lemma}[Ground-space suffix restriction]\label{lem:ground_space_in_tail_ground}
     \lean{MPSTensor.restrictLast_groundSpaceMap,
-          MPSTensor.tailRestrictₗ_groundSpaceMap,
-          MPSTensor.groundSpace_inTailGround}
+        MPSTensor.tailRestrictₗ_groundSpaceMap,
+        MPSTensor.groundSpace_inTailGround}
     \leanok
     \uses{def:in_tail_ground, def:ground_space_parent}
     If $\psi \in G_{K+L}(A)$, then every fixed-prefix suffix restriction of
@@ -745,7 +745,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{lemma}[Cyclic-window range antitonicity]%
     \label{lem:cyclic_window_range_antitonicity}
     \lean{MPSTensor.chainGroundSpace_le_chainGroundSpace_succ,
-          MPSTensor.chainGroundSpace_le_chainGroundSpace_of_le}
+        MPSTensor.chainGroundSpace_le_chainGroundSpace_of_le}
     \leanok
     \uses{rem:cyclic_window_operators}
     On a nonempty periodic chain, longer cyclic-window constraints imply all
@@ -1645,7 +1645,7 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \uses{def:has_commuting_parent_ham}
     By commutativity,
     $P_{XB} \circ P_K = P_{XB} \circ P_{AX} \circ P_{XB}
-    = P_{AX} \circ P_{XB} \circ P_{XB}$, and idempotence of $P_{XB}$
+        = P_{AX} \circ P_{XB} \circ P_{XB}$, and idempotence of $P_{XB}$
     yields $P_{XB} \circ P_K = P_K$.
 \end{proof}
 
@@ -1666,7 +1666,7 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \uses{def:has_commuting_parent_ham}
     By commutativity,
     $P_K \circ P_{AX} = P_{AX} \circ P_{XB} \circ P_{AX}
-    = P_{AX} \circ P_{AX} \circ P_{XB}$, and idempotence of $P_{AX}$
+        = P_{AX} \circ P_{AX} \circ P_{XB}$, and idempotence of $P_{AX}$
     yields $P_K \circ P_{AX} = P_K$.
 \end{proof}
 
@@ -1709,7 +1709,7 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \leanok
     \uses{def:has_commuting_parent_ham}
     Expanding both products and using $P_{AX} \circ P_{XB}
-    = P_{XB} \circ P_{AX}$ shows that the complementary projectors commute.
+        = P_{XB} \circ P_{AX}$ shows that the complementary projectors commute.
 \end{proof}
 
 \begin{theorem}[Commuting parent Hamiltonian implies decorrelation]%
@@ -2036,12 +2036,12 @@ Lucia~\cite{Kastoryano2018Martingale}.
     for every vector $v$,
     \[
         h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)
-            = h_{j,\mathrm{ES}}(h_{i,\mathrm{ES}}v),
+        = h_{j,\mathrm{ES}}(h_{i,\mathrm{ES}}v),
     \]
     and their ordered cross term is nonnegative:
     \[
         0\le \operatorname{Re}\langle h_{i,\mathrm{ES}}v,
-            h_{j,\mathrm{ES}}v\rangle .
+        h_{j,\mathrm{ES}}v\rangle .
     \]
 \end{lemma}
 
@@ -2088,7 +2088,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $v = \sum_k c_k \psi_k$ and projecting onto $(\ker H)^{\perp}$
     keeps only terms with $\lambda_k \ge \gamma$, so
     $\|H v\|^2 = \sum_k |c_k|^2 \lambda_k^2
-    \ge \gamma^2 \sum_k |c_k|^2 = \gamma^2 \|v\|^2$.
+        \ge \gamma^2 \sum_k |c_k|^2 = \gamma^2 \|v\|^2$.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian quadratic-form reduction]
@@ -2104,7 +2104,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         \gamma\,\operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}(A)v, v\rangle
         \le
         \operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}(A)v,
-            H_{N,L}^{\mathrm{ES}}(A)v\rangle
+        H_{N,L}^{\mathrm{ES}}(A)v\rangle
     \]
     for every $N \ge 2L$ and every vector $v$, then
     \[
@@ -2226,7 +2226,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Cauchy--Schwarz and symmetric idempotence turn the norm-compression estimate
     into
     $\operatorname{Re}\langle P_i v,P_jv\rangle
-    \ge -(1-\gamma)m^{-1}\operatorname{Re}\langle P_iv,v\rangle$.
+        \ge -(1-\gamma)m^{-1}\operatorname{Re}\langle P_iv,v\rangle$.
     If a separate coefficient $\eta$ is used, the assumption
     $\eta\le(1-\gamma)/m$ first weakens that estimate to the displayed one. The
     finite-overlap row-sum reduction then applies.
@@ -2251,7 +2251,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         \gamma\operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}v,v\rangle
         \le
         \operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}v,
-            H_{N,L}^{\mathrm{ES}}v\rangle
+        H_{N,L}^{\mathrm{ES}}v\rangle
     \]
     for every vector $v$.
 \end{lemma}
@@ -2306,11 +2306,11 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \[
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
         \ge -(1-\gamma)\frac{1}{m}
-              \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle,
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle,
     \]
     and the transported local terms are symmetric projections, then the
     transported Hamiltonian satisfies $H_{N,L}^{\mathrm{ES}}{}^2\ge
-    \gamma H_{N,L}^{\mathrm{ES}}$ as a quadratic form.
+        \gamma H_{N,L}^{\mathrm{ES}}$ as a quadratic form.
 \end{lemma}
 
 \begin{proof}
@@ -2401,7 +2401,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     transported local ES terms have nonnegative ordered cross term:
     \[
         0\le\operatorname{Re}\langle h_{i,\mathrm{ES}}v,
-             h_{j,\mathrm{ES}}v\rangle .
+        h_{j,\mathrm{ES}}v\rangle .
     \]
 \end{lemma}
 
@@ -2468,7 +2468,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \[
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
         \ge -(1-\tfrac{1}{4L})\frac{1}{2(L-1)}
-              \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
     \]
     Then $1/(4L)>0$, and the explicit norm lower bound with constant $1/(4L)$
     follows for vectors in $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
@@ -2501,7 +2501,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \[
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
         \ge -(1-\tfrac{1}{4L})\frac{1}{2(L-1)}
-              \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
     \]
     Then the explicit norm lower bound with constant $1/(4L)$ follows for
     vectors in $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
@@ -2527,7 +2527,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \[
         \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
         \le (1-\tfrac{1}{4L})\frac{1}{2(L-1)}
-             \|h_{i,\mathrm{ES}}v\|.
+        \|h_{i,\mathrm{ES}}v\|.
     \]
     Then the explicit norm lower bound with constant $1/(4L)$ follows for
     vectors in $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
@@ -2895,7 +2895,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     $A_{j}$ embeds into the chain ground space of the assembled tensor:
     \[
         \operatorname{ChainGround}_{N,L}(A_{j})
-            \subseteq \operatorname{ChainGround}_{N,L}(\operatorname{Assemble}(\mu, A)).
+        \subseteq \operatorname{ChainGround}_{N,L}(\operatorname{Assemble}(\mu, A)).
     \]
 \end{lemma}
 
@@ -2917,7 +2917,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     ground space:
     \[
         \bigsqcup_{j} \operatorname{ChainGround}_{N,L}(A_{j})
-            \subseteq \operatorname{ChainGround}_{N,L}(\operatorname{Assemble}(\mu, A)),
+        \subseteq \operatorname{ChainGround}_{N,L}(\operatorname{Assemble}(\mu, A)),
     \]
     where $j$ ranges over all block indices.
 \end{lemma}
@@ -2937,7 +2937,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     ground spaces is contained in the assembled parent ground space:
     \[
         \bigsqcup_{j} \operatorname{ChainGround}_{N,L}(A_{j})
-            \subseteq \operatorname{ParentGround}_{N,L}(A).
+        \subseteq \operatorname{ParentGround}_{N,L}(A).
     \]
 \end{lemma}
 

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -49,6 +49,16 @@ _LEAN_DECL_KEYWORD_ONLY_RE = re.compile(
 _TRACKED_REVERSE_DECL_KINDS = {"def", "theorem", "lemma"}
 _DIFF_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
+# Match a `private` modifier appearing before the declaration keyword on a
+# single line.  Used to skip private helpers in the "missing blueprint entry"
+# check: by project convention, private helpers are internal proof-engineering
+# scaffolding and do not require a blueprint anchor.
+_LEAN_PRIVATE_RE = re.compile(
+    r"^\s*(?:@\[.*?\]\s*)?"
+    r"(?:(?:noncomputable|protected)\s+)*"
+    r"private\s+",
+)
+
 _NAMESPACE_OPEN_RE = re.compile(r"^\s*namespace\s+([\w.]+)", re.MULTILINE)
 _SECTION_OPEN_RE = re.compile(
     r"^\s*(?:(?:noncomputable|private|protected|local)\s+)*section\s+([\w.]+)",
@@ -107,6 +117,7 @@ class LeanDecl:
     kind: str
     short_name: str
     end_line: int
+    is_private: bool = False  # declaration carries the `private` modifier
 
 
 @dataclass
@@ -181,6 +192,8 @@ def collect_file_lean_decls(lean_file: Path, lean_root: Path) -> list[LeanDecl]:
             short_name = m.group(2)
             prefix = ".".join(ns_stack) + "." if ns_stack else ""
             fqn = prefix + short_name
+            decl_source = m.string[m.start():m.end(1) + 1]
+            is_private = bool(_LEAN_PRIVATE_RE.match(decl_source))
             decls.append(
                 LeanDecl(
                     file=rel,
@@ -189,6 +202,7 @@ def collect_file_lean_decls(lean_file: Path, lean_root: Path) -> list[LeanDecl]:
                     kind=kind,
                     short_name=short_name,
                     end_line=len(lines),
+                    is_private=is_private,
                 )
             )
 
@@ -451,6 +465,10 @@ def find_changed_decls_missing_from_blueprint(
 
         for decl in collect_file_lean_decls(abs_path, lean_root):
             if decl.kind not in _TRACKED_REVERSE_DECL_KINDS:
+                continue
+            if decl.is_private:
+                # By project convention, `private` helpers are internal
+                # proof scaffolding and do not require a blueprint anchor.
                 continue
             if not any(decl.line <= line <= decl.end_line for line in changed_lines):
                 continue


### PR DESCRIPTION
### Motivation

The arbitrary-tensor canonical-form reduction in
`TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean` carried two parallel
pipelines — the PGVWC07 unital orientation (Pérez-García–Verstraete–Wolf–Cirac
2007, Theorem `Th:TIcanonical`, lines 765–832, source-faithful side) and the
CPSV trace-preserving / left-canonical orientation (used by the rest of the
canonical-form, normal-canonical-form, and Fundamental Theorem chain) — whose
blockwise gauge theorems and arbitrary-input wrappers contained byte-identical
proof fragments:

- the `hSameBlocks` calc block establishing the MPV identity under the scalar
  substitution `μₖ · (√rₖ)⁻¹ = 1`,
- the per-block `dim ≠ 0` derivation from the nonzero-Kraus hypothesis, and
- the zero-tail MPV chaining at the arbitrary-input layer.

In parallel, `TNLean/MPS/CanonicalForm/Existence.lean` retained two conditional
arbitrary-input siblings (`exists_irreducible_blockDecomp_with_tpGauge` and
`exists_irreducible_blockDecomp_with_CFII`) that had been superseded by the
unconditional `exists_tp_gauge_blockwise` and
`exists_pgvwc07_unital_dualDiag_blockwise` pipelines and were not invoked by
any other Lean file. The blueprint anchor
`thm:irreducible_block_decomp_with_cfii` (`ch08_canonical.tex`, line 739) was a
derived combination of the already-recorded `thm:irred_decomp` and
`thm:CFII_data`, with no `\ref` consumer.

### Description

Two commits on this branch.

**`daefd41c4` — refactor(MPS/CanonicalForm): share blockwise gauge calc between PGVWC07 and TP pipelines**

Introduces three private helpers in
`TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`:

- `bond_dim_ne_zero_of_exists_nonzero` — the per-block `dim ≠ 0` consequence of
  having a nonzero Kraus operator.
- `gauge_blockwise_shared` — the shared blockwise MPV identity. Given a
  per-block gauge witness consisting of new blocks `B_k`, positive scalars
  `r_k`, and same-MPV witnesses
  `SameMPV (i ↦ ((√rₖ)⁻¹ : ℂ) • Aₖ ⁱ) Bₖ`, it produces the global identity
  `SameMPV₂ A (toTensorFromBlocks (μ ≡ √rₖ) B)` together with the
  weights-nonzero and positive-dim consequences.
- `mpv_zero_tail_chain_of_sameMPV₂` — chains the zero-tail MPV identity
  `mpv A σ = mpv (zeroMPSTensor d zeroTailDim) σ + mpv A_nonzero σ`
  with a `SameMPV₂ A_nonzero (toTensorFromBlocks μ blocks)` witness.

Both blockwise theorems (`exists_pgvwc07_unital_dualDiag_blockwise`,
`exists_tp_gauge_blockwise`) and both arbitrary-input wrappers
(`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`,
`exists_tp_gauge_from_arbitrary_with_zeroTail`) keep their original public
names and signatures and now route through the private helpers. The 40-line
`hSameBlocks` calc block lives in exactly one site, and the same is true for
the zero-tail chaining. No blueprint `\lean{...}` anchor changes.

**`739e5af3e` — refactor(MPS/CanonicalForm): remove dead-end Existence.lean conditional siblings**

Deletes the two unused conditional siblings from
`TNLean/MPS/CanonicalForm/Existence.lean`
(`exists_irreducible_blockDecomp_with_tpGauge` and
`exists_irreducible_blockDecomp_with_CFII`), refreshes the surrounding
*Conditional reductions from arbitrary input* narrative, drops the
corresponding `thm:irreducible_block_decomp_with_cfii` entry from
`blueprint/src/chapter/ch08_canonical.tex`, and cleans the retired
theorem-name mentions from `blueprint/comments20260407/ch08_09_lean_audit.md`.

Pre-deletion `rg` confirmed zero external Lean consumers of either deleted
theorem and no `\ref` consumer of the deleted blueprint label.

**Net delta vs `origin/main`:** 4 files changed, 167 insertions(+), 269
deletions(−), net **−102 lines**.

### Testing

- `cd /Users/siruilu/Local/agentFormalization/TNLean-canonical-refactor && lake build`
  — succeeds (8732 jobs). Only pre-existing `sorry`-warnings on untouched
  files (`MPS/Periodic/Overlap/Case3.lean`, `MPS/Periodic/Overlap/Dichotomy.lean`).
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean` —
  succeeds cleanly.
- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean` — succeeds cleanly.
- `rg -n "sorry|axiom |native_decide|unsafeCast" TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean TNLean/MPS/CanonicalForm/Existence.lean`
  — no hits.
- `rg -n "exists_irreducible_blockDecomp_with_tpGauge|exists_irreducible_blockDecomp_with_CFII" TNLean/ blueprint/`
  — no hits.
- `rg -n "thm:irreducible_block_decomp_with_cfii" blueprint/`
  — no hits.
- `cd blueprint && leanblueprint checkdecls` — fails on the same 141
  pre-existing unresolved declarations in `PEPS/`, `parentHamiltonian`, and
  `BNT/` areas that already fail on `origin/main`; none touched by this PR.

### Audit reference

This refactor implements the cleanup recommended by the canonical-form
duplication audit (subagent `b54c62259e84`). Audit step 1 (parametrised
per-block PF gauge core) was assessed as redundant on inspection: the per-block
lemmas already share `MPSTensor.exists_posDef_adjoint_eigenvector`; their
divergence reflects genuine mathematical content (primal vs adjoint
Perron–Frobenius, `tpGauge` vs `spectralUnitalGauge`) rather than duplicated
proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor and removal of unreferenced theorems; public blockwise and arbitrary-input theorem statements in `TPGauge.lean` are unchanged.
> 
> **Overview**
> This PR **deduplicates** blockwise canonical-form gauge proofs in `TPGauge.lean` and **removes** unused conditional existence theorems, with matching blueprint and tooling updates.
> 
> **Lean (`TPGauge.lean`):** Three private helpers—`bond_dim_ne_zero_of_exists_nonzero`, `gauge_blockwise_shared`, and `mpv_zero_tail_chain_of_sameMPV₂`—now hold the repeated per-block bond-dimension argument, the weighted `SameMPV₂` calc for `μₖ = √rₖ`, and zero-tail MPV chaining. `exists_pgvwc07_unital_dualDiag_blockwise`, `exists_tp_gauge_blockwise`, and the two arbitrary-input wrappers keep the same public names and conclusions but call these helpers instead of inlined copies.
> 
> **Lean (`Existence.lean`):** `exists_irreducible_blockDecomp_with_tpGauge` and `exists_irreducible_blockDecomp_with_CFII` are deleted; the module commentary now states that arbitrary-input work stops at irreducible decomposition plus zero-block separation, with blockwise TP/CFII only via the `NormalReduction` pipeline.
> 
> **Blueprint / docs:** `thm:irreducible_block_decomp_with_cfii` is removed from `ch08_canonical.tex`. `ch11b_after_blocking.tex` adds `lem:irreducible_allZero_dim_le_one` anchored to the existing Lean lemma. The ch08/ch09 audit note is updated for the retired entries.
> 
> **Tooling:** `scripts/blueprint_lean_sync.py` skips `private` declarations when flagging changed Lean theorems without a `\lean{...}` anchor.
> 
> Other touched `.tex` files are mostly alignment/whitespace only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 452fe5327fea3aae372f274ab1bee2e430cc44e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->