### PR TITLE
feat(PEPS): define normal square region T

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -182,6 +182,33 @@ def normalSquareRegionS {width height : ℕ} (xStart yStart : ℕ) :
   squareLatticeContiguousRectangle xStart yStart 2 3 ∪
     squareLatticeContiguousRectangle (xStart + 1) yStart 2 3
 
+/-- The two edge blocks removed from the local window in the displayed region
+\(T\).
+
+The first block is the \(2\times3\) vertical block and the second block is the
+shifted \(3\times2\) horizontal block shown in the source picture.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+def normalSquareRegionTHole {width height : ℕ} (xStart yStart : ℕ) :
+    Finset (SquareLatticeVertex width height) :=
+  squareLatticeContiguousRectangle xStart (yStart + 2) 2 3 ∪
+    squareLatticeContiguousRectangle (xStart + 2) (yStart + 1) 3 2
+
+/-- The displayed region \(T\) in the normal square-lattice proof.
+
+The source picture describes \(T\) as the complement, inside a local
+\(5\times6\) coordinate window, of the two edge blocks recorded in
+`normalSquareRegionTHole`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`, where the text states that \(T\) is
+injective once the PEPS size is at least \(5\times6\). -/
+def normalSquareRegionT {width height : ℕ} (xStart yStart : ℕ) :
+    Finset (SquareLatticeVertex width height) :=
+  squareLatticeContiguousRectangle xStart yStart 5 6 \
+    normalSquareRegionTHole xStart yStart
+
 @[simp] theorem mem_normalSquareRegionR {width height : ℕ}
     (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
     v ∈ normalSquareRegionR xStart yStart ↔
@@ -199,6 +226,23 @@ def normalSquareRegionS {width height : ℕ} (xStart yStart : ℕ) :
       (xStart + 1 ≤ v.1.1 ∧ v.1.1 < xStart + 3 ∧
         yStart ≤ v.2.1 ∧ v.2.1 < yStart + 3) := by
   simp [normalSquareRegionS]
+
+@[simp] theorem mem_normalSquareRegionTHole {width height : ℕ}
+    (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
+    v ∈ normalSquareRegionTHole xStart yStart ↔
+      (xStart ≤ v.1.1 ∧ v.1.1 < xStart + 2 ∧
+        yStart + 2 ≤ v.2.1 ∧ v.2.1 < yStart + 5) ∨
+      (xStart + 2 ≤ v.1.1 ∧ v.1.1 < xStart + 5 ∧
+        yStart + 1 ≤ v.2.1 ∧ v.2.1 < yStart + 3) := by
+  simp [normalSquareRegionTHole]
+
+@[simp] theorem mem_normalSquareRegionT {width height : ℕ}
+    (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
+    v ∈ normalSquareRegionT xStart yStart ↔
+      xStart ≤ v.1.1 ∧ v.1.1 < xStart + 5 ∧
+        yStart ≤ v.2.1 ∧ v.2.1 < yStart + 6 ∧
+          v ∉ normalSquareRegionTHole xStart yStart := by
+  simp [normalSquareRegionT, and_assoc]
 
 /-- The displayed region \(R\) is contained in the displayed region \(S\).
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1382,6 +1382,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.IsThreeByTwoContiguousSquareLatticeRectangle}
     \lean{TNLean.PEPS.normalSquareRegionR}
     \lean{TNLean.PEPS.normalSquareRegionS}
+    \lean{TNLean.PEPS.normalSquareRegionTHole}
+    \lean{TNLean.PEPS.normalSquareRegionT}
     \leanok
     The finite $n\times m$ square lattice is represented by pairs of
     coordinates.  A coordinate rectangle is a product of a horizontal
@@ -1395,7 +1397,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     with the \(3\times2\) contiguous rectangle occupying its upper two rows and
     extending one column to the right.  The displayed region \(S\) is the union
     of two \(2\times3\) contiguous rectangles shifted by one horizontal
-    coordinate, hence the full \(3\times3\) square spanned by them.
+    coordinate, hence the full \(3\times3\) square spanned by them.  The
+    displayed region \(T\) is the complement, inside a local \(5\times6\)
+    coordinate window, of the two edge blocks shown in the source picture.
 \end{definition}
 
 \begin{lemma}[Basic identities for square-lattice coordinate regions]%
@@ -1405,6 +1409,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.mem_squareLatticeContiguousRectangle}
     \lean{TNLean.PEPS.mem_normalSquareRegionR}
     \lean{TNLean.PEPS.mem_normalSquareRegionS}
+    \lean{TNLean.PEPS.mem_normalSquareRegionTHole}
+    \lean{TNLean.PEPS.mem_normalSquareRegionT}
     \lean{TNLean.PEPS.card_squareLatticeRectangle}
     \lean{TNLean.PEPS.squareLatticeFull_eq_univ}
     \leanok
@@ -1416,7 +1422,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     membership in the \(2\times3\) lower-left piece or in the shifted
     \(3\times2\) upper piece.  Membership in \(S\) is the disjunction of
     membership in the left \(2\times3\) piece or in the horizontally shifted
-    \(2\times3\) piece.  The cardinality of a coordinate rectangle is the
+    \(2\times3\) piece.  Membership in \(T\) is membership in the local
+    \(5\times6\) window together with nonmembership in the union of the two
+    displayed edge blocks.  The cardinality of a coordinate rectangle is the
     product of the two coordinate cardinalities, and the full coordinate
     rectangle is the whole finite vertex set.
 \end{lemma}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -102,14 +102,15 @@ The displayed regions $R$ and $S$ are also present as explicit unions of such
 contiguous rectangles. Their coordinate definitions have been checked against
 the source statement that they differ in one site: $R$ is contained in $S$,
 and $S\setminus R$ is the lower-right site of the displayed $3\times3$
-square. This supplies ambient language for the later construction of the
-displayed region $T$; it does not yet prove injectivity of $R$, $S$, or $T$.
+square. The displayed region $T$ is now present as the complement, inside the
+source $5\times6$ local window, of the two edge blocks shown in the source
+picture. This does not yet prove injectivity of $R$, $S$, or $T$.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
 closed. The remaining open gap is the source-paper injectivity argument:
-define the displayed region $T$, and prove the injectivity of $R$, $S$, and
-$T$ from the union theorem.
+prove the rectangular decompositions and then prove the injectivity of $R$,
+$S$, and $T$ from the union theorem.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -134,8 +135,9 @@ alone. The following additional obligations remain.
     \item Prove that the paper's regions $R$, $S$, and $T$ are injective
           under those hypotheses. The displayed regions $R$ and $S$ are now
           defined as unions of contiguous rectangles, with the expected
-          one-site difference formalized; the displayed region $T$ still has
-          to be defined. The union lemma is then used repeatedly.
+          one-site difference formalized. The displayed region $T$ is now
+          defined as the complement of the two edge blocks in the source
+          $5\times6$ local window. The union lemma is then used repeatedly.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.


### PR DESCRIPTION
### Motivation

- The proof of Theorem 3 in arXiv:1804.04964, Section 3 (`Papers/1804.04964/paper_normal.tex`, lines 1430–1443) defines the region T as the complement of two edge blocks inside a 5×6 local window of the square lattice; this definition was absent from the formalization.
- The same passage asserts that T is injective when the PEPS has size at least 5×6; the injectivity derivation from rectangular injectivity and the union lemma remains part of #2004.
- Advances the formalization route recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.

### Description

- `TNLean/PEPS/NormalBlocking.lean`: defines `normalSquareRegionTHole` (the two removed edge blocks as contiguous 2×3 and 3×2 unions) and `normalSquareRegionT` as those blocks subtracted from the 5×6 local window; adds `@[simp]` membership characterizations.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds `\lean{normalSquareRegionT}` links and records that T is defined but not yet shown injective.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: updates the Section 3 paper-gap note.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls` (fails only on pre-existing missing declarations; the new declarations are not reported missing)
- `git diff --check` and line-length check on changed files

---
Refs #2004

> [!NOTE]
> **Low Risk**
> Pure coordinate-region definitions and documentation; no auth, runtime, or changes to existing proof obligations beyond closing the "T undefined" gap in text.
>
> **Overview**
> Adds the coordinate geometry for the normal PEPS region **T** on the square lattice: **`normalSquareRegionTHole`** (the two source edge blocks as contiguous \(2\times3\) and \(3\times2\) unions) and **`normalSquareRegionT`** as those blocks subtracted from a local \(5\times6\) window, with **`@[simp]`** membership characterizations.
>
> Blueprint Chapter 13a and the Section 3 paper-gap note are updated to link the new Lean names and to record that **T** is defined but **not** yet shown injective (that still depends on rectangular injectivity and the union lemma, per #2004).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f19bf7b8ebe0e22e6d1b6432f42d018edbf2457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>