### PR TITLE
feat(PEPS): add contiguous rectangle shape lemmas

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -157,6 +157,32 @@ def IsThreeByTwoContiguousSquareLatticeRectangle {width height : ℕ}
     xStart + 3 ≤ width ∧ yStart + 2 ≤ height ∧
       R = squareLatticeContiguousRectangle xStart yStart 3 2
 
+/-- A bounded contiguous coordinate rectangle of width two and height three has
+the \(2\times3\) source shape.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452
+of `Papers/1804.04964/paper_normal.tex`, where the proof assumes injectivity
+for all \(2\times3\) rectangular blocks. -/
+theorem isTwoByThreeContiguousSquareLatticeRectangle_of_bounds {width height : ℕ}
+    {xStart yStart : ℕ} (hx : xStart + 2 ≤ width) (hy : yStart + 3 ≤ height) :
+    IsTwoByThreeContiguousSquareLatticeRectangle
+      (squareLatticeContiguousRectangle xStart yStart 2 3 :
+        Finset (SquareLatticeVertex width height)) :=
+  ⟨xStart, yStart, hx, hy, rfl⟩
+
+/-- A bounded contiguous coordinate rectangle of width three and height two has
+the \(3\times2\) source shape.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452
+of `Papers/1804.04964/paper_normal.tex`, where the proof assumes injectivity
+for all \(3\times2\) rectangular blocks. -/
+theorem isThreeByTwoContiguousSquareLatticeRectangle_of_bounds {width height : ℕ}
+    {xStart yStart : ℕ} (hx : xStart + 3 ≤ width) (hy : yStart + 2 ≤ height) :
+    IsThreeByTwoContiguousSquareLatticeRectangle
+      (squareLatticeContiguousRectangle xStart yStart 3 2 :
+        Finset (SquareLatticeVertex width height)) :=
+  ⟨xStart, yStart, hx, hy, rfl⟩
+
 /-- The displayed region \(R\) in the normal square-lattice proof.
 
 It is the union of a contiguous \(2\times3\) rectangle and the overlapping

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1411,6 +1411,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.mem_normalSquareRegionS}
     \lean{TNLean.PEPS.mem_normalSquareRegionTHole}
     \lean{TNLean.PEPS.mem_normalSquareRegionT}
+    \lean{TNLean.PEPS.isTwoByThreeContiguousSquareLatticeRectangle_of_bounds}
+    \lean{TNLean.PEPS.isThreeByTwoContiguousSquareLatticeRectangle_of_bounds}
     \lean{TNLean.PEPS.card_squareLatticeRectangle}
     \lean{TNLean.PEPS.squareLatticeFull_eq_univ}
     \leanok
@@ -1424,7 +1426,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     membership in the left \(2\times3\) piece or in the horizontally shifted
     \(2\times3\) piece.  Membership in \(T\) is membership in the local
     \(5\times6\) window together with nonmembership in the union of the two
-    displayed edge blocks.  The cardinality of a coordinate rectangle is the
+    displayed edge blocks.  Bounded contiguous coordinate rectangles of sizes
+    \(2\times3\) and \(3\times2\) satisfy, respectively, the predicates for
+    contiguous \(2\times3\) and contiguous \(3\times2\) square-lattice
+    rectangles.  The cardinality of a coordinate rectangle is the
     product of the two coordinate cardinalities, and the full coordinate
     rectangle is the whole finite vertex set.
 \end{lemma}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -98,6 +98,9 @@ coordinate cardinalities, while the contiguous-rectangle predicates express the
 source-paper contiguous square-lattice blocks. The square-lattice rectangular
 injectivity hypotheses are now packaged using precisely these two contiguous
 rectangle predicates, and map to the abstract rectangular injectivity bundle.
+Bounded contiguous coordinate rectangles of sizes $2\times3$ and $3\times2$
+are now known to satisfy the corresponding source-rectangle predicates, which
+is the reusable local step needed before invoking rectangular injectivity.
 The displayed regions $R$ and $S$ are also present as explicit unions of such
 contiguous rectangles. Their coordinate definitions have been checked against
 the source statement that they differ in one site: $R$ is contained in $S$,


### PR DESCRIPTION
### Motivation

- arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407–1452 of `Papers/1804.04964/paper_normal.tex` assumes rectangular injectivity for all 2×3 and 3×2 blocks; the local step that each such block is a contiguous rectangle of the required shape must be established before invoking that hypothesis and the union theorem.
- Issue #2004 records five obligations needed to derive injectivity of the regions $R$, $S$, and $T$ from the rectangular injectivity hypothesis; the two shape lemmas here address the local prerequisite for obligations 1 and 2.
- The paper-gap note `docs/paper-gaps/peps_normal_ft_section3_route.tex` documents the full obligation list; the new lemmas are recorded there as a completed step.

### Description

- `TNLean/PEPS/NormalBlocking.lean`: two lemmas added.
  - For any in-bounds pair of coordinates, the contiguous 2×3 sub-rectangle of the square lattice satisfies `IsTwoByThreeContiguousSquareLatticeRectangle`.
  - For any in-bounds pair of coordinates, the contiguous 3×2 sub-rectangle satisfies `IsThreeByTwoContiguousSquareLatticeRectangle`.
  - Both proofs are witnessed by `rfl` after supplying the coordinate bounds.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: `\lean{}` and `\leanok` tags added for the two new lemmas under `def:peps_squareLatticeCoordinateRegions`.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: obligations 1–5 note updated to mark the shape-witness step as supplied.
- No injectivity of $R$, $S$, or $T$ is proved in this PR.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls` (fails only on pre-existing missing declarations; the new declarations are not reported missing)
- `git diff --check`
- Line-length check on changed files

---
Refs #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small definitional additions and documentation only; no changes to injectivity logic, auth, or runtime behavior.
> 
> **Overview**
> Adds two **witness lemmas** in `TNLean/PEPS/NormalBlocking.lean`: in-bounds `squareLatticeContiguousRectangle` blocks are shown to satisfy `IsTwoByThreeContiguousSquareLatticeRectangle` and `IsThreeByTwoContiguousSquareLatticeRectangle` (proofs are definitional witnesses with `rfl`). This is the local shape step before applying the packaged **2×3 / 3×2 rectangular injectivity** hypotheses; it does **not** prove injectivity of \(R\), \(S\), or \(T\).
> 
> Blueprint `ch13a_peps_ft.tex` links the new declarations under the square-lattice coordinate-region lemma, and `docs/paper-gaps/peps_normal_ft_section3_route.tex` records that bounded contiguous blocks now match the source-rectangle predicates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392fec3985e64eb65ea5d84fe763e1111975f418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->