### PR TITLE
feat(PEPS): prove normal T edge-block decomposition

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -255,6 +255,23 @@ def normalSquareRegionTHole {width height : ℕ} (xStart yStart : ℕ) :
   squareLatticeContiguousRectangle xStart (yStart + 2) 2 3 ∪
     squareLatticeContiguousRectangle (xStart + 2) (yStart + 1) 3 2
 
+/-- The two edge blocks removed in the displayed region \(T\) are one
+contiguous \(2\times3\) rectangle and one contiguous \(3\times2\) rectangle.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`, where the source depicts \(T\) as
+the complement of the two shown edge blocks. -/
+theorem normalSquareRegionTHole_rectangular_decomposition {width height : ℕ}
+    {xStart yStart : ℕ} (hx : xStart + 5 ≤ width) (hy : yStart + 5 ≤ height) :
+    ∃ T₂ T₃ : Finset (SquareLatticeVertex width height),
+      IsTwoByThreeContiguousSquareLatticeRectangle T₂ ∧
+        IsThreeByTwoContiguousSquareLatticeRectangle T₃ ∧
+          normalSquareRegionTHole xStart yStart = T₂ ∪ T₃ := by
+  refine ⟨squareLatticeContiguousRectangle xStart (yStart + 2) 2 3,
+    squareLatticeContiguousRectangle (xStart + 2) (yStart + 1) 3 2, ?_, ?_, rfl⟩
+  · exact isTwoByThreeContiguousSquareLatticeRectangle_of_bounds (by omega) (by omega)
+  · exact isThreeByTwoContiguousSquareLatticeRectangle_of_bounds (by omega) (by omega)
+
 /-- The displayed region \(T\) in the normal square-lattice proof.
 
 The source picture describes \(T\) as the complement, inside a local

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1456,6 +1456,21 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \(2\times3\) and \(3\times2\) rectangles.
 \end{proof}
 
+\begin{lemma}[The edge blocks removed from \(T\) are contiguous rectangles]%
+    \label{lem:peps_normalSquareRegionTHole_rectangular_decomposition}
+    \lean{TNLean.PEPS.normalSquareRegionTHole_rectangular_decomposition}
+    \leanok
+    \uses{def:peps_squareLatticeCoordinateRegions,
+        lem:peps_squareLatticeCoordinateRegion_identities}
+    If the two edge blocks cut out of the displayed \(T\)-region lie in the
+    finite square lattice, then they are respectively a contiguous
+    \(2\times3\) rectangle and a contiguous \(3\times2\) rectangle.
+\end{lemma}
+\begin{proof}\leanok
+    This is the defining description of the two removed edge blocks, together
+    with the coordinate bounds which make them valid contiguous rectangles.
+\end{proof}
+
 \begin{lemma}[The normal regions \(R\) and \(S\) differ in one site]%
     \label{lem:peps_normalSquareRegionR_regionS_difference}
     \lean{TNLean.PEPS.normalSquareRegionR_subset_regionS}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -109,15 +109,17 @@ rectangles. Their coordinate definitions have been checked against the source
 statement that they differ in one site: $R$ is contained in $S$, and
 $S\setminus R$ is the lower-right site of the displayed $3\times3$ square. The
 displayed region $T$ is now present as the complement, inside the source
-$5\times6$ local window, of the two edge blocks shown in the source picture.
-This does not yet prove injectivity of $R$, $S$, or $T$.
+$5\times6$ local window, of the two edge blocks shown in the source picture;
+the two removed edge blocks are now formalized as one contiguous $2\times3$
+rectangle and one contiguous $3\times2$ rectangle. This does not yet prove
+injectivity of $R$, $S$, or $T$.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
 closed, and the rectangular decompositions of $R$ and $S$ are formalized. The
 remaining open gap is the source-paper injectivity argument: prove the
-corresponding decomposition for $T$ and then prove the injectivity of $R$, $S$,
-and $T$ from the union theorem.
+appropriate coordinate covering or complement argument for $T$, and then prove
+the injectivity of $R$, $S$, and $T$ from the union theorem.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -145,7 +147,8 @@ alone. The following additional obligations remain.
           decompositions and the expected one-site difference formalized. The
           displayed region $T$ is now
           defined as the complement of the two edge blocks in the source
-          $5\times6$ local window. The union lemma is then used repeatedly.
+          $5\times6$ local window, and the removed edge blocks have the
+          displayed rectangular shapes. The union lemma is then used repeatedly.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.


### PR DESCRIPTION
### Motivation

- The region $T$ in the square-lattice normal PEPS blocking construction (arXiv:1804.04964, Section 3, proof of Theorem 3; `Papers/1804.04964/paper_normal.tex` lines 1430–1443) is defined as the complement of two removed edge blocks. Completing the injectivity proof for $T$ requires knowing those blocks are rectangular; this lemma records that they are one contiguous $2\times3$ rectangle and one contiguous $3\times2$ rectangle.
- This separates the geometric decomposition of the T hole from the still-open injectivity proof, addressing one obligation in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
- Continues the PEPS FT normal blocking route from #2003; see #2004.

### Description

- `TNLean/PEPS/NormalBlocking.lean`: added `normalSquareRegionTHole_rectangular_decomposition`, showing the two edge blocks of `normalSquareRegionTHole` are a $2\times3$ rectangle and a $3\times2$ rectangle. Follows the same pattern as the existing R and S decomposition lemmas.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: added blueprint entry `lem:peps_normalSquareRegionTHole_rectangular_decomposition` with `\lean{}` and `\leanok` tags.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: updated the Section 3 paper-gap note to distinguish the T hole block shapes (now proved) from the still-open injectivity proof for $R$, $S$, and $T$.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- Line-length check: `awk 'length($0) > 100 { print FILENAME ":" FNR ":" length($0) ":" $0 }' TNLean/PEPS/NormalBlocking.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_normal_ft_section3_route.tex`
- `git diff --check`
- `leanblueprint checkdecls`: new declaration not reported missing; remaining failures are pre-existing.

---
Refs #2004

> [!NOTE]
> **Low Risk**
> Pure Lean geometry/documentation aligned with existing R/S lemmas; no runtime, security, or data-path changes.
>
> **Overview**
> Adds **`normalSquareRegionTHole_rectangular_decomposition`**, showing the two edge blocks in `normalSquareRegionTHole` are a contiguous **2×3** and **3×2** rectangle (same pattern as the existing **R**/**S** decomposition lemmas, with **5×5** lattice bounds).
>
> The blueprint gains matching lemma **`lem:peps_normalSquareRegionTHole_rectangular_decomposition`**, and the Section 3 paper-gap note now records that the **T** "hole" blocks have the right rectangular shapes while **injectivity of R, S, and T** (and the full **T** covering argument) stay open.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c43759b996c3905d8fab3735efe1631ed4f57d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>