### PR TITLE
doc(PEPS): clarify coordinate-region proof sketch

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1434,7 +1434,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     rectangle is the whole finite vertex set.
 \end{lemma}
 \begin{proof}\leanok
-    These are the standard identities for the product of two finite sets.
+    The coordinate-rectangle statements follow from membership and cardinality
+    identities for Cartesian products of finite coordinate sets.  The
+    contiguous-rectangle statement then unfolds the two coordinate intervals.
+    The membership statements for \(R\), \(S\), and the two edge blocks removed
+    from \(T\) additionally unfold membership in a union of two such
+    rectangles, while membership in \(T\) also unfolds the set difference from
+    the local \(5\times6\) window.  The shape predicates follow by using the
+    displayed lower-left corners as witnesses.
 \end{proof}
 
 \begin{lemma}[The normal regions \(R\) and \(S\) are unions of contiguous


### PR DESCRIPTION
### Motivation

- The proof sketch for `lem:peps_squareLatticeCoordinateRegion_identities` in `blueprint/src/chapter/ch13a_peps_ft.tex` described only Cartesian-product membership, omitting the union step needed for membership in the displayed regions $R$ and $S$, the edge-block unions removed from $T$, and the set-difference characterization of membership in $T$.
- Continues the blueprint formalization of the geometry of normal square regions in the PEPS fundamental theorem (arXiv:1804.04964, Section 3, proof of Theorem 3); see #2036.

### Description

- Modified: `blueprint/src/chapter/ch13a_peps_ft.tex`, proof block for `lem:peps_squareLatticeCoordinateRegion_identities`.
- Replaced the old one-sentence proof sketch ("standard identities for products of finite sets") with a description covering: Cartesian-product membership and cardinality, contiguous coordinate intervals, union membership for $R$ and $S$, the corresponding unions for the two edge blocks removed from $T$, and the set-difference step for membership in $T$ within the local $5\times 6$ window.
- Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407–1443 of `Papers/1804.04964/paper_normal.tex`.

### Testing

- Line-length check: `awk 'length($0) > 100 { print FILENAME ":" FNR ":" length($0) ":" $0 }' blueprint/src/chapter/ch13a_peps_ft.tex`
- Whitespace check: `git diff --check`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Closes #2036

> [!NOTE]
> **Low Risk**
> Documentation-only edit to a LaTeX proof sketch in the blueprint; no code, auth, or data paths affected.
>
> **Overview**
> The proof sketch for **`lem:peps_squareLatticeCoordinateRegion_identities`** in `ch13a_peps_ft.tex` is expanded so it matches the lemma statement, not only Cartesian products.
>
> The old one-line "standard identities for products of finite sets" is replaced with a short outline: product membership/cardinality, contiguous intervals, **unions** for membership in \(R\), \(S\), and the two edge blocks removed from \(T\), **set difference** for \(T\) inside the local \(5\times6\) window, and shape witnesses from the displayed corners.
>
> No Lean or runtime behavior changes—blueprint documentation only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a05a4e9357dd0f21f6be39c0812d5dd89c8d631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>