### PR TITLE
feat(MPS/MPDO): expose BNT coefficient trace powers

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -449,6 +449,16 @@ variable {data : AlgebraStructureData d D} {Λ : Type*} {O : ℕ → Type*}
   [Fintype Λ] [∀ L : ℕ, AddCommMonoid (O L)] [∀ L : ℕ, Module ℂ (O L)]
   [∀ L : ℕ, Mul (O L)] (H : BNTLabelTheoremData data Λ O)
 
+/-- The BNT-label coefficients in theorem data are traces of powers of the
+length-independent chi matrices.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem coeff_eq_trace_pow (L : ℕ) (hL : 0 < L) (α β γ : Λ) :
+    H.coeffs.coeff L α β γ =
+      (H.positiveChi.chi.matrix α β γ ^ L).trace :=
+  H.positiveChi.eq_trace_pow L hL α β γ
+
 /-- The BNT product expansion with the coefficients written as traces of the
 length-independent chi matrices. -/
 theorem same_length_product_eq_sum_chi_trace_pow

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1597,6 +1597,22 @@ the elementary trace-power identity for diagonal matrices.
     consequences below are derived.
 \end{definition}
 
+\begin{theorem}[BNT theorem data give coefficient trace powers]%
+    \label{thm:mpdo_bnt_label_theorem_data_coeff_eq_trace_pow}
+    \lean{MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
+    BNT-label theorem data give the coefficient identity
+    $c^{(L)}_{\alpha,\beta,\gamma}
+      = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$
+    for every positive length $L$.
+\end{theorem}
+\begin{proof}\leanok
+    This is the positive-length $\chi$-trace identity belonging to the
+    positive BNT-label $\chi$-witness in the theorem data.
+\end{proof}
+
 \begin{theorem}[BNT theorem data give the chi-trace product law]%
     \label{thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum_chi_trace_pow}
     \lean{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -179,10 +179,11 @@ comparison.\footnote{\leanid{MPOTensor.BNTLabelTheoremData}.}  This record is
 not an additional mathematical assumption in the source theorem; it is the
 single formal object collecting the source data supplied by the Appendix
 C.3--C.4 construction from an MPDO tensor.  From such data, the same-length
-chi-trace product law, the chi-trace idempotent law, the blocked-basis
-coefficient trace-power formula, and the positive blocked \(\chi\)-witness
-are immediate
+coefficient trace-power formula, the same-length chi-trace product law, the
+chi-trace idempotent law, the blocked-basis coefficient trace-power formula,
+and the positive blocked \(\chi\)-witness are immediate
 consequences.\footnote{%
+\leanid{MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_chi_trace},
 \leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_trace_pow},


### PR DESCRIPTION
### Motivation

- arXiv:1606.00608, Theorem IV.13(ii) asserts: there exist positive diagonal matrices χ_{α,β,γ}, independent of L, such that c^{(L)}_{α,β,γ} = tr(χ_{α,β,γ}^L) for every positive length L; the coefficient identity is a direct consequence of the bundled BNT-label theorem data.
- `MPOTensor.BNTLabelTheoremData` already witnesses the positive χ-matrices; this PR exposes the coefficient-trace-power identity directly on the bundled data type so callers need not re-derive it through the chi-trace corollary chain.
- Continues the formalization plan documented in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`; tracked in #2000.

### Description

- Added `MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow` in `TNLean/MPS/MPDO/BNTCoefficients.lean`: for every BNT-label triple (α, β, γ) and every positive length L, c^{(L)}_{α,β,γ} = tr(χ_{α,β,γ}^L), forwarding to the existing `positiveChi.eq_trace_pow` witness.
- Recorded the theorem in `blueprint/src/chapter/ch02b_mpdo.tex` (Chapter 2b) with `\lean{MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow}` and `\leanok` tags.
- Updated `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` to list the raw coefficient trace-power identity first among immediate consequences derivable from theorem data.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- Line-length check: `awk 'length($0) > 100 { print FILENAME ":" FNR ":" length($0) ":" $0 }' TNLean/MPS/MPDO/BNTCoefficients.lean blueprint/src/chapter/ch02b_mpdo.tex docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls`: new declaration is not reported missing; remaining failures are pre-existing.

---
Refs #2000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin forwarding lemma plus blueprint and documentation updates; no new assumptions or changes to authentication, data handling, or core infrastructure.
> 
> **Overview**
> **Adds** `MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow`, stating that for positive length \(L\), bundled BNT-label coefficients satisfy \(c^{(L)}_{\alpha,\beta,\gamma} = \mathrm{tr}(\chi_{\alpha,\beta,\gamma}^L)\) by forwarding to the existing `positiveChi` witness—so consumers of `BNTLabelTheoremData` can cite the raw coefficient identity without unpacking the chi witness first.
> 
> The **blueprint** (`ch02b_mpdo.tex`) records a matching theorem with `\leanok`, and **`cpgsv17_blocked_chi_uniformity.tex`** lists this identity first among immediate consequences derivable from theorem data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8038fb2c35ef84e8166a0940e1419f54156fa6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->