### PR TITLE
feat(MPS/MPDO): expose BNT theorem data source equations

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -472,7 +472,7 @@ theorem same_length_product_eq_sum
 
 /-- The idempotent scalar equation carried by theorem data.
 
-Source: arXiv:1606.00608, Theorem IV.13(ii), eq:idempotent, lines 981--985 of
+Source: arXiv:1606.00608, Theorem IV.13(ii), idempotent, lines 981--985 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem idempotent_eq_sum (γ : Λ) :
     H.traceScalars.traceScalar γ =

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -459,6 +459,29 @@ theorem coeff_eq_trace_pow (L : ℕ) (hL : 0 < L) (α β γ : Λ) :
       (H.positiveChi.chi.matrix α β γ ^ L).trace :=
   H.positiveChi.eq_trace_pow L hL α β γ
 
+/-- The same-length BNT product equation carried by theorem data.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem same_length_product_eq_sum
+    (L : ℕ) (hL : 0 < L) (α β : Λ) :
+    H.operators.operator L α * H.operators.operator L β =
+      ∑ γ : Λ, H.coeffs.coeff L α β γ • H.operators.operator L γ :=
+  BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum
+    (op := H.operators) H.sameLengthProduct L hL α β
+
+/-- The idempotent scalar equation carried by theorem data.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), eq:idempotent, lines 981--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem idempotent_eq_sum (γ : Λ) :
+    H.traceScalars.traceScalar γ =
+      ∑ α : Λ, ∑ β : Λ,
+        H.coeffs.coeff 1 α β γ *
+          (H.traceScalars.traceScalar α * H.traceScalars.traceScalar β) :=
+  BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum
+    (m := H.traceScalars) H.idempotent γ
+
 /-- The BNT product expansion with the coefficients written as traces of the
 length-independent chi matrices. -/
 theorem same_length_product_eq_sum_chi_trace_pow

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1597,6 +1597,41 @@ the elementary trace-power identity for diagonal matrices.
     consequences below are derived.
 \end{definition}
 
+\begin{theorem}[BNT theorem data give the same-length product law]%
+    \label{thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum}
+    \lean{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        thm:mpdo_bnt_label_same_length_product_eq_sum}
+    BNT-label theorem data give the same-length product equation
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
+          = \sum_\gamma
+              c^{(L)}_{\alpha,\beta,\gamma} O_L(M_\gamma)
+    \]
+    for every positive length $L$.
+\end{theorem}
+\begin{proof}\leanok
+    This is the same-length product law carried by the theorem data.
+\end{proof}
+
+\begin{theorem}[BNT theorem data give the idempotent scalar law]%
+    \label{thm:mpdo_bnt_label_theorem_data_idempotent_eq_sum}
+    \lean{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        thm:mpdo_bnt_label_idempotent_coefficient_eq_sum}
+    BNT-label theorem data give the idempotent scalar equation
+    \[
+        m_\gamma =
+          \sum_{\alpha,\beta}
+            c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta .
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    This is the idempotent coefficient law carried by the theorem data.
+\end{proof}
+
 \begin{theorem}[BNT theorem data give coefficient trace powers]%
     \label{thm:mpdo_bnt_label_theorem_data_coeff_eq_trace_pow}
     \lean{MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -179,10 +179,13 @@ comparison.\footnote{\leanid{MPOTensor.BNTLabelTheoremData}.}  This record is
 not an additional mathematical assumption in the source theorem; it is the
 single formal object collecting the source data supplied by the Appendix
 C.3--C.4 construction from an MPDO tensor.  From such data, the same-length
-coefficient trace-power formula, the same-length chi-trace product law, the
-chi-trace idempotent law, the blocked-basis coefficient trace-power formula,
-and the positive blocked \(\chi\)-witness are immediate
+product law, the idempotent scalar law, the coefficient trace-power formula,
+the same-length chi-trace product law, the chi-trace idempotent law, the
+blocked-basis coefficient trace-power formula, and the positive blocked
+\(\chi\)-witness are immediate
 consequences.\footnote{%
+\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum},
 \leanid{MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_chi_trace},


### PR DESCRIPTION
### Motivation

- `BNTLabelTheoremData` contains fields for the same-length BNT product law
  (`sameLengthProduct`, eq:algebra) and the idempotent scalar law (`idempotent`,
  eq:idempotent) from arXiv:1606.00608, Theorem IV.13(ii), lines 972–985 of
  `Papers/1606.00608/MPDO-22-12-17-2.tex`, but no named lemma projections expose
  these equations directly.
- Named projections let reviewers and downstream proofs reference the raw source
  equations without going through χ substitutions.
- Continues the formalization of the BNT-label uniform chi family; see #2000.

### Description

- `TNLean/MPS/MPDO/BNTCoefficients.lean`: adds two named projection lemmas on
  `BNTLabelTheoremData` — one for the same-length BNT product equation (eq:algebra)
  and one for the idempotent scalar equation (eq:idempotent). Each lemma is a
  one-step unpack of the corresponding record field.
- `blueprint/src/chapter/ch02b_mpdo.tex`: records the two new projections among the
  immediate consequences of theorem data, with `\lean{}` tags.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`: updated to cite the new
  lemmas explicitly.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean`
- `git diff --check`
- Line-length check: `awk 'length($0) > 100 { print FILENAME ":" FNR ":" length($0) ":" $0 }' TNLean/MPS/MPDO/BNTCoefficients.lean blueprint/src/chapter/ch02b_mpdo.tex docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`
- `cd blueprint && leanblueprint checkdecls` reports only pre-existing missing declarations outside this branch.

---
Refs #2000

> [!NOTE]
> **Low Risk**
> Thin Lean wrappers and blueprint/docs alignment only; no new assumptions or changes to blocked-basis or transfer-map logic.
>
> **Overview**
> Adds **named projections** on `BNTLabelTheoremData` for the same-length BNT product law (eq:algebra) and the idempotent scalar law (eq:idempotent), alongside the existing χ-trace corollaries. Each theorem is a one-step unpack of fields already in the record (`sameLengthProduct`, `idempotent`).
>
> The **blueprint** (`ch02b_mpdo.tex`) and the **CPGSV17 paper-gap note** now cite these lemmas explicitly and list them among the immediate consequences of theorem data, so reviewers can reference the raw source equations without going through χ substitutions first.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f892a76d27d654c81198e61d456c9441bd1a603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin Lean unpacks of existing record fields plus blueprint and gap-doc alignment; no new assumptions or changes to construction or blocked-basis logic.
> 
> **Overview**
> Adds **named Lean projections** on `BNTLabelTheoremData` for the same-length BNT product law (eq:algebra) and the idempotent scalar law (eq:idempotent). Each theorem is a one-step unpack of fields already in the record (`sameLengthProduct`, `idempotent`), parallel to the existing χ-trace corollaries.
> 
> The **blueprint** (`ch02b_mpdo.tex`) registers both lemmas as immediate consequences of theorem data with `\lean{}` tags. The **CPGSV17 gap note** now cites them explicitly so reviewers can reference the raw source equations without going through χ substitutions first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab5a1184e105990362a43793003738444b6f6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->