### PR TITLE
feat(MPS/MPDO): package BNT theorem witnesses

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -521,4 +521,53 @@ def toPositiveBlockedStructureChiTracePowerForm :
 
 end BNTLabelTheoremData
 
+/-- Existential BNT-label theorem witness for the source statement.
+
+Theorem-data records are parameterized by a chosen BNT-label type and by the
+same-length operator spaces.  This witness packages those choices together with
+the corresponding theorem data.  It is the formal target for the remaining
+construction from an MPDO tensor.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.3--C.4,
+lines 1830--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTLabelTheoremWitness (data : AlgebraStructureData d D) where
+  /-- The finite type of BNT labels. -/
+  Label : Type
+  /-- The ambient type of length-`L` BNT operators. -/
+  OperatorSpace : ℕ → Type
+  /-- The BNT-label type is finite. -/
+  labelFintype : Fintype Label
+  /-- Each length-`L` operator space is an additive commutative monoid. -/
+  operatorAddCommMonoid : ∀ L : ℕ, AddCommMonoid (OperatorSpace L)
+  /-- Each length-`L` operator space is a complex module. -/
+  operatorModule : ∀ L : ℕ, Module ℂ (OperatorSpace L)
+  /-- Each length-`L` operator space has the product used in the source algebra. -/
+  operatorMul : ∀ L : ℕ, Mul (OperatorSpace L)
+  /-- The BNT-label theorem data for these choices. -/
+  theoremData : @BNTLabelTheoremData d D data Label OperatorSpace
+    labelFintype operatorAddCommMonoid operatorModule operatorMul
+
+namespace BNTLabelTheoremWitness
+
+variable {data : AlgebraStructureData d D} (W : BNTLabelTheoremWitness data)
+
+/-- The theorem data carried by an existential witness, with its instances
+available. -/
+def toTheoremData :
+    @BNTLabelTheoremData d D data W.Label W.OperatorSpace
+      W.labelFintype W.operatorAddCommMonoid W.operatorModule W.operatorMul :=
+  W.theoremData
+
+/-- An existential BNT-label theorem witness gives a positive blocked
+trace-power witness for the chosen algebra-structure data. -/
+def toPositiveBlockedStructureChiTracePowerForm :
+    AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm data := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.theoremData.toPositiveBlockedStructureChiTracePowerForm
+
+end BNTLabelTheoremWitness
+
 end MPOTensor

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -523,10 +523,10 @@ end BNTLabelTheoremData
 
 /-- Existential BNT-label theorem witness for the source statement.
 
-Theorem-data records are parameterized by a chosen BNT-label type and by the
-same-length operator spaces.  This witness packages those choices together with
-the corresponding theorem data.  It is the formal target for the remaining
-construction from an MPDO tensor.
+The BNT-label theorem data depend on a choice of BNT-label type and
+same-length operator spaces.  This structure collects those choices together
+with the corresponding theorem data.  The construction of such a witness from
+an MPDO tensor is the outstanding step toward Theorem IV.13(ii).
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.3--C.4,
 lines 1830--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
@@ -551,8 +551,9 @@ namespace BNTLabelTheoremWitness
 
 variable {data : AlgebraStructureData d D} (W : BNTLabelTheoremWitness data)
 
-/-- The theorem data carried by an existential witness, with its instances
-available. -/
+/-- The BNT-label theorem data carried by an existential witness, with the
+algebraic structures on the label type and operator spaces supplied by the
+witness. -/
 def toTheoremData :
     @BNTLabelTheoremData d D data W.Label W.OperatorSpace
       W.labelFintype W.operatorAddCommMonoid W.operatorModule W.operatorMul :=

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1709,6 +1709,30 @@ the elementary trace-power identity for diagonal matrices.
     positive BNT-label \(\chi\)-witness belonging to the theorem data.
 \end{proof}
 
+\begin{definition}[Existential BNT-label theorem witness]%
+    \label{def:mpdo_bnt_label_theorem_witness}
+    \lean{MPOTensor.BNTLabelTheoremWitness}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data}
+    An existential BNT-label theorem witness packages the finite BNT-label
+    type, the same-length operator spaces, their algebraic structure, and the
+    corresponding BNT-label theorem data.  This is the source-shaped target
+    for constructing the data of Theorem~IV.13(ii) from an MPDO tensor.
+\end{definition}
+
+\begin{theorem}[BNT theorem witnesses give positive blocked \(\chi\) witnesses]%
+    \label{thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form}
+    \lean{MPOTensor.BNTLabelTheoremWitness.toPositiveBlockedStructureChiTracePowerForm}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
+    An existential BNT-label theorem witness gives a positive blocked-basis
+    \(\chi\) trace-power witness for the chosen algebra-structure data.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the corresponding theorem-data consequence carried by the witness.
+\end{proof}
+
 \begin{theorem}[Positive blocked $\chi$ witness gives trace powers]%
     \label{thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
     \lean{MPOTensor.AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm.eq_trace_pow}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1714,10 +1714,10 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelTheoremWitness}
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data}
-    An existential BNT-label theorem witness packages the finite BNT-label
+    An existential BNT-label theorem witness consists of the finite BNT-label
     type, the same-length operator spaces, their algebraic structure, and the
-    corresponding BNT-label theorem data.  This is the source-shaped target
-    for constructing the data of Theorem~IV.13(ii) from an MPDO tensor.
+    corresponding BNT-label theorem data.  The construction of such a witness
+    from an MPDO tensor is the outstanding step toward Theorem~IV.13(ii).
 \end{definition}
 
 \begin{theorem}[BNT theorem witnesses give positive blocked \(\chi\) witnesses]%

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -192,6 +192,16 @@ consequences.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm}.}
 
+The same data can be packaged in the existential form closest to the paper:
+one object records the BNT-label type, the same-length operator spaces, their
+algebraic structure, and the corresponding theorem-data record.\footnote{%
+\leanid{MPOTensor.BNTLabelTheoremWitness}.}  Such a witness immediately gives
+the positive blocked-basis \(\chi\)-witness for the chosen algebra-structure
+data.\footnote{%
+\leanid{MPOTensor.BNTLabelTheoremWitness.%
+toPositiveBlockedStructureChiTracePowerForm}.}  The remaining task is still the
+construction of this existential witness from the MPDO tensor.
+
 To eliminate the remaining gap, the formalization should introduce:
 \begin{enumerate}
     \item construction of the comparison maps relating the BNT-label
@@ -208,8 +218,10 @@ To eliminate the remaining gap, the formalization should introduce:
           \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}
           m_\alpha m_\beta\) from the MPDO tensor;
     \item construction of the single
-        \leanid{MPOTensor.BNTLabelTheoremData} record from these source
-        objects.  The blocked-basis trace-power statement, with its
+        \leanid{MPOTensor.BNTLabelTheoremWitness} from these source
+        objects, and hence of the underlying
+        \leanid{MPOTensor.BNTLabelTheoremData} record.  The blocked-basis
+        trace-power statement, with its
         source-length exponent convention, is then a derived corollary of the
         uniform BNT-label theorem, rather than a separate replacement for the
         theorem itself.

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -192,14 +192,14 @@ consequences.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm}.}
 
-The same data can be packaged in the existential form closest to the paper:
-one object records the BNT-label type, the same-length operator spaces, their
-algebraic structure, and the corresponding theorem-data record.\footnote{%
+The same data can be stated in the existential form closest to the paper: one
+object records the BNT-label type, the same-length operator spaces, their
+algebraic structure, and the corresponding theorem data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness}.}  Such a witness immediately gives
 the positive blocked-basis \(\chi\)-witness for the chosen algebra-structure
 data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-toPositiveBlockedStructureChiTracePowerForm}.}  The remaining task is still the
+toPositiveBlockedStructureChiTracePowerForm}.}  The remaining step is still the
 construction of this existential witness from the MPDO tensor.
 
 To eliminate the remaining gap, the formalization should introduce:


### PR DESCRIPTION
### Motivation
- Formalizes the witness structure for [Cirac--Pérez-García--Schuch--Verstraete 2017, arXiv:1606.00608, Theorem IV.13(ii)]: there exist diagonal matrices χ_{α,β,γ} with positive entries, indexed by BNT labels α,β,γ independent of the length parameter L, such that c^{(L)}_{α,β,γ} = tr(χ_{α,β,γ}^L) for every positive length L.
- Bridges the gap between the blocked-basis analogue `HasBlockedStructureChiTracePowerForm` (introduced in #1999) and the paper's uniform BNT-label statement, documented in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
- Continues the formalization of Theorem IV.13(ii) in `TNLean/MPS/MPDO/`; see #2000.

### Description
- `TNLean/MPS/MPDO/BNTCoefficients.lean`: introduces `MPOTensor.BNTLabelTheoremWitness`, an existential structure fixing the BNT-label type, same-length operator spaces with their algebraic instances, and a `BNTLabelTheoremData` record; adds projections `toTheoremData` and `toPositiveBlockedStructureChiTracePowerForm`, the latter deriving a positive blocked chi trace-power witness from the theorem-data path.
- `blueprint/src/chapter/ch02b_mpdo.tex`: updates Chapter 2b so that `BNTLabelTheoremWitness` is the explicit construction target, referencing arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.3--C.4, lines 1830--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`: identifies `BNTLabelTheoremWitness` as the pending construction in the elimination plan for the blocked-basis / uniform-BNT-label gap.

### Testing
- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean`
- `git diff --check` and line-length scan on touched Lean, blueprint, and paper-gap files
- `cd blueprint && leanblueprint checkdecls`: new witness declarations are not missing; only pre-existing missing declarations outside this branch are reported.

---
Refs #2000

> [!NOTE]
> **Low Risk**
> Lean definitions and blueprint/paper-gap documentation only; no runtime, auth, or data-path changes.
>
> **Overview**
> Introduces **`MPOTensor.BNTLabelTheoremWitness`**, an existential package that fixes the BNT label type, same-length operator spaces, their algebraic instances, and the existing **`BNTLabelTheoremData`** record—aligned with Theorem IV.13(ii) as the object still to be built from an MPDO tensor.
>
> Adds **`toTheoremData`** and **`toPositiveBlockedStructureChiTracePowerForm`**, which reuses the theorem-data path so a witness immediately yields a positive blocked-basis χ trace-power witness for the chosen algebra-structure data.
>
> Blueprint Chapter 2b and **`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`** are updated so the remaining construction goal is explicitly this witness (and thus the underlying theorem data), not only assembling **`BNTLabelTheoremData`** in isolation.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a82d798e4ea75e7411c27b2272357cb2570663b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean definitions plus blueprint and paper-gap documentation only; no runtime, security, or data-path changes.
> 
> **Overview**
> Introduces **`MPOTensor.BNTLabelTheoremWitness`**, an existential Lean structure that fixes the BNT label type, length-indexed operator spaces, their algebraic instances, and an embedded **`BNTLabelTheoremData`** record—making the still-missing step “build this witness from an MPDO tensor” explicit for Theorem IV.13(ii).
> 
> Adds **`toTheoremData`** and **`toPositiveBlockedStructureChiTracePowerForm`**, which thread the witness’s instances into the existing theorem-data projection so any witness immediately yields a positive blocked-basis χ trace-power witness for the chosen algebra-structure data.
> 
> Blueprint Chapter 2b and **`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`** are updated so the gap-elimination target is this existential witness (and thus the underlying theorem data), not assembling **`BNTLabelTheoremData`** in isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001088a4c2bab52916440f14841045ba5bbeb0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->