### PR TITLE
feat(PEPS): prove normal T window complement

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -348,9 +348,8 @@ theorem normalSquareRegionT_disjoint_THole {width height : ℕ}
       (normalSquareRegionT xStart yStart :
         Finset (SquareLatticeVertex width height))
       (normalSquareRegionTHole xStart yStart) := by
-  rw [Finset.disjoint_left]
-  intro v hvT hvHole
-  exact (mem_normalSquareRegionT xStart yStart v).mp hvT |>.2.2.2.2 hvHole
+  unfold normalSquareRegionT
+  exact disjoint_sdiff_self_left
 
 /-- The displayed \(T\)-region and the two removed edge blocks reconstruct the
 local \(5\times6\) coordinate window.
@@ -362,22 +361,8 @@ theorem normalSquareRegionT_union_THole {width height : ℕ}
     normalSquareRegionT xStart yStart ∪ normalSquareRegionTHole xStart yStart =
       (squareLatticeContiguousRectangle xStart yStart 5 6 :
         Finset (SquareLatticeVertex width height)) := by
-  ext v
-  constructor
-  · intro hv
-    rcases (Finset.mem_union.mp hv) with hvT | hvHole
-    · have hT := (mem_normalSquareRegionT xStart yStart v).mp hvT
-      rw [mem_squareLatticeContiguousRectangle]
-      exact ⟨hT.1, hT.2.1, hT.2.2.1, hT.2.2.2.1⟩
-    · exact normalSquareRegionTHole_subset_window xStart yStart hvHole
-  · intro hvWindow
-    rw [mem_squareLatticeContiguousRectangle] at hvWindow
-    by_cases hvHole : v ∈ normalSquareRegionTHole xStart yStart
-    · exact Finset.mem_union.mpr (Or.inr hvHole)
-    · exact Finset.mem_union.mpr (Or.inl (by
-        rw [mem_normalSquareRegionT]
-        exact
-          ⟨hvWindow.1, hvWindow.2.1, hvWindow.2.2.1, hvWindow.2.2.2, hvHole⟩))
+  unfold normalSquareRegionT
+  exact Finset.sdiff_union_of_subset (normalSquareRegionTHole_subset_window xStart yStart)
 
 /-- The displayed region \(R\) is contained in the displayed region \(S\).
 

--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -321,6 +321,64 @@ def normalSquareRegionT {width height : ℕ} (xStart yStart : ℕ) :
           v ∉ normalSquareRegionTHole xStart yStart := by
   simp [normalSquareRegionT, and_assoc]
 
+/-- The two edge blocks removed from the displayed \(T\)-region lie inside the
+local \(5\times6\) coordinate window.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`, where \(T\) is drawn as the
+complement of the two shown edge blocks inside the displayed window. -/
+theorem normalSquareRegionTHole_subset_window {width height : ℕ}
+    (xStart yStart : ℕ) :
+    normalSquareRegionTHole xStart yStart ⊆
+      (squareLatticeContiguousRectangle xStart yStart 5 6 :
+        Finset (SquareLatticeVertex width height)) := by
+  intro v hv
+  rw [mem_normalSquareRegionTHole] at hv
+  rw [mem_squareLatticeContiguousRectangle]
+  rcases hv with hv | hv <;> omega
+
+/-- The displayed \(T\)-region is disjoint from the two edge blocks removed
+from the local \(5\times6\) window.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionT_disjoint_THole {width height : ℕ}
+    (xStart yStart : ℕ) :
+    Disjoint
+      (normalSquareRegionT xStart yStart :
+        Finset (SquareLatticeVertex width height))
+      (normalSquareRegionTHole xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hvT hvHole
+  exact (mem_normalSquareRegionT xStart yStart v).mp hvT |>.2.2.2.2 hvHole
+
+/-- The displayed \(T\)-region and the two removed edge blocks reconstruct the
+local \(5\times6\) coordinate window.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionT_union_THole {width height : ℕ}
+    (xStart yStart : ℕ) :
+    normalSquareRegionT xStart yStart ∪ normalSquareRegionTHole xStart yStart =
+      (squareLatticeContiguousRectangle xStart yStart 5 6 :
+        Finset (SquareLatticeVertex width height)) := by
+  ext v
+  constructor
+  · intro hv
+    rcases (Finset.mem_union.mp hv) with hvT | hvHole
+    · have hT := (mem_normalSquareRegionT xStart yStart v).mp hvT
+      rw [mem_squareLatticeContiguousRectangle]
+      exact ⟨hT.1, hT.2.1, hT.2.2.1, hT.2.2.2.1⟩
+    · exact normalSquareRegionTHole_subset_window xStart yStart hvHole
+  · intro hvWindow
+    rw [mem_squareLatticeContiguousRectangle] at hvWindow
+    by_cases hvHole : v ∈ normalSquareRegionTHole xStart yStart
+    · exact Finset.mem_union.mpr (Or.inr hvHole)
+    · exact Finset.mem_union.mpr (Or.inl (by
+        rw [mem_normalSquareRegionT]
+        exact
+          ⟨hvWindow.1, hvWindow.2.1, hvWindow.2.2.1, hvWindow.2.2.2, hvHole⟩))
+
 /-- The displayed region \(R\) is contained in the displayed region \(S\).
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1430

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1478,6 +1478,23 @@ injective and normal PEPS, following Theorems~2 and~3 of
     with the coordinate bounds which make them valid contiguous rectangles.
 \end{proof}
 
+\begin{lemma}[The $T$-region and its removed edge blocks fill the local window]%
+    \label{lem:peps_normalSquareRegionT_window_complement}
+    \lean{TNLean.PEPS.normalSquareRegionTHole_subset_window}
+    \lean{TNLean.PEPS.normalSquareRegionT_disjoint_THole}
+    \lean{TNLean.PEPS.normalSquareRegionT_union_THole}
+    \leanok
+    \uses{def:peps_squareLatticeCoordinateRegions,
+        lem:peps_squareLatticeCoordinateRegion_identities}
+    The two edge blocks removed from the displayed $T$-region lie inside the
+    local $5\times6$ coordinate window.  They are disjoint from $T$, and their
+    union with $T$ is exactly that local window.
+\end{lemma}
+\begin{proof}\leanok
+    This follows by unfolding the definition of $T$ as the set-theoretic
+    complement of the two displayed edge blocks inside the local window.
+\end{proof}
+
 \begin{lemma}[The normal regions \(R\) and \(S\) differ in one site]%
     \label{lem:peps_normalSquareRegionR_regionS_difference}
     \lean{TNLean.PEPS.normalSquareRegionR_subset_regionS}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -111,15 +111,18 @@ $S\setminus R$ is the lower-right site of the displayed $3\times3$ square. The
 displayed region $T$ is now present as the complement, inside the source
 $5\times6$ local window, of the two edge blocks shown in the source picture;
 the two removed edge blocks are now formalized as one contiguous $2\times3$
-rectangle and one contiguous $3\times2$ rectangle. This does not yet prove
-injectivity of $R$, $S$, or $T$.
+rectangle and one contiguous $3\times2$ rectangle. The complement relation is
+also formalized: the removed edge blocks lie inside the local window, are
+disjoint from $T$, and together with $T$ reconstruct that window. This does not
+yet prove injectivity of $R$, $S$, or $T$.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
 closed, and the rectangular decompositions of $R$ and $S$ are formalized. The
 remaining open gap is the source-paper injectivity argument: prove the
-appropriate coordinate covering or complement argument for $T$, and then prove
-the injectivity of $R$, $S$, and $T$ from the union theorem.
+appropriate coordinate covering argument for $T$ that supports repeated use of
+the union theorem, and then prove the injectivity of $R$, $S$, and $T$ from
+that theorem.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -148,7 +151,8 @@ alone. The following additional obligations remain.
           displayed region $T$ is now
           defined as the complement of the two edge blocks in the source
           $5\times6$ local window, and the removed edge blocks have the
-          displayed rectangular shapes. The union lemma is then used repeatedly.
+          displayed rectangular shapes. The local-window complement identity for
+          $T$ is also formalized. The union lemma is then used repeatedly.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.


### PR DESCRIPTION
### Motivation
- Continues formalization of arXiv:1804.04964, Section 3, proof of Theorem 3 (square-lattice normal PEPS), see #2004.
- The source text (lines 1430–1443 of `Papers/1804.04964/paper_normal.tex`) establishes that the two edge blocks removed from the region **T** lie inside the local 5×6 window, are disjoint from **T**, and together with **T** reconstruct that window. These coordinate-geometry facts underlie the injectivity derivation for **T**.

### Description
- `TNLean/PEPS/NormalBlocking.lean`: adds three theorems:
  - `normalSquareRegionTHole_subset_window` — the two removed edge blocks lie inside the 5×6 local window.
  - `normalSquareRegionT_disjoint_THole` — the region **T** and the removed edge blocks are disjoint.
  - `normalSquareRegionT_union_THole` — **T** together with the removed blocks equals the local window.
  Proofs proceed from existing membership lemmas using `omega` and case splits.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: records lemma `lem:peps_normalSquareRegionT_window_complement` with `\lean` links to the three new declarations.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: marks the complement identity as done and clarifies that the remaining obligation is the coordinate covering / repeated union step toward injectivity of **R**, **S**, and **T**.

### Testing
- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean`
- `git diff --check`
- Line-length scan on the touched Lean, blueprint, and paper-gap files.
- `cd blueprint && leanblueprint checkdecls` reports only pre-existing missing declarations outside this branch; the new PEPS declarations are not missing.

---
Refs #2004

> [!NOTE]
> **Low Risk**
> Adds coordinate-region Lean proofs and blueprint/paper-gap documentation only; no runtime, security, or API surface changes.
>
> **Overview**
> This PR formalizes the local-window complement geometry for the normal PEPS region **T**: the two removed edge blocks sit inside the **5×6** window, are **disjoint** from **T**, and **T ∪ holes = window**.
>
> In `TNLean/PEPS/NormalBlocking.lean`, three new theorems (`normalSquareRegionTHole_subset_window`, `normalSquareRegionT_disjoint_THole`, `normalSquareRegionT_union_THole`) prove that structure from the existing membership lemmas (mostly `omega` and case splits).
>
> Chapter **13a** adds lemma `lem:peps_normalSquareRegionT_window_complement` with `\lean` links to those declarations. The Section 3 **paper-gap** note is updated to record that the complement identity is done and to reframe what remains as a **coordinate covering / repeated union-lemma** step toward injectivity of **R**, **S**, and **T** — not injectivity itself.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac8f0118df909db0ab588935e2d65cae3026b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and documentation only in PEPS coordinate geometry; no runtime, auth, or API changes.
> 
> **Overview**
> Formalizes the **local 5×6 window complement** for the normal PEPS region **T**: the two removed edge blocks sit inside the window, are disjoint from **T**, and **T ∪ holes** equals the window.
> 
> In `TNLean/PEPS/NormalBlocking.lean`, three new theorems (`normalSquareRegionTHole_subset_window`, `normalSquareRegionT_disjoint_THole`, `normalSquareRegionT_union_THole`) prove that from existing membership lemmas (`omega` / set-difference facts). Blueprint chapter 13a adds `lem:peps_normalSquareRegionT_window_complement` with `\lean` links. The Section 3 paper-gap note records the complement identity as done and reframes what remains as a **coordinate covering / repeated union-lemma** step toward injectivity of **R**, **S**, and **T**—not injectivity itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108ce5a79d7653b7fd82cd1939540abfc02cbd73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->