### PR TITLE
feat(PEPS): index edge middle physical data

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -363,6 +363,7 @@ import TNLean.PEPS.Defs
 import TNLean.PEPS.InjectiveRegion
 import TNLean.PEPS.VirtualInsertion
 import TNLean.PEPS.Blocking
+import TNLean.PEPS.EdgeMiddlePhysical
 import TNLean.PEPS.NormalBlocking
 import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.InsertionRealization

--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -1,0 +1,145 @@
+import TNLean.PEPS.Blocking
+
+/-!
+# Middle physical indices for edge-blocked PEPS
+
+This file gives the middle tensor in the edge-centered three-site decomposition
+its own physical index.  For an edge \(e=(u,v)\), the middle physical
+configuration is the family of physical indices on \(V\setminus\{u,v\}\).
+
+## References
+
+- [Molnár, Schuch, Verstraete, Cirac, *Fundamental Theorem for injective PEPS*,
+  arXiv:1804.04964, Section 3, `eq:block_to_mps`](https://arxiv.org/abs/1804.04964)
+- `Papers/1804.04964/paper_normal.tex`, lines 981--1009.
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+omit [DecidableRel G.Adj] in
+private theorem edge_ne_of_middle_incident_for_physical (e : Edge G) {v : V}
+    (hv : v ∈ edgeMiddleVertices e) (ie : IncidentEdge G v) : ie.1 ≠ e := by
+  intro hie
+  have hvne := (mem_edgeMiddleVertices_iff e v).mp hv
+  rcases ie.2 with hleft | hright
+  · exact hvne.1 (hleft.symm.trans (congrArg (fun f : Edge G => f.1.1) hie))
+  · exact hvne.2 (hright.symm.trans (congrArg (fun f : Edge G => f.1.2) hie))
+
+/-- Physical configurations on the middle block \(V\setminus\{u,v\}\) in the
+edge-centered three-site decomposition at the edge \(e=(u,v)\).
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+abbrev EdgeMiddlePhysicalConfig (e : Edge G) : Type _ :=
+  (v : {v : V // v ∈ edgeMiddleVertices e}) → Fin d
+
+/-- Restrict a global physical configuration to the middle block of the
+edge-centered three-site decomposition.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+def edgeMiddlePhysicalConfigOf (e : Edge G) (σ : V → Fin d) :
+    EdgeMiddlePhysicalConfig (G := G) (d := d) e :=
+  fun v => σ v.1
+
+/-- The blocked middle tensor with the distinguished edge left open, written
+with its own middle physical index.
+
+The endpoint residual data are fixed, while the matrix index on the
+distinguished edge is absent from the middle region. This is the middle block
+of the edge-centered three-site chain in arXiv:1804.04964, Section 3. -/
+noncomputable def edgeOpenMiddleWeightOn (A : Tensor G d) (e : Edge G)
+    (τ : EdgeMiddlePhysicalConfig (G := G) (d := d) e)
+    (leftResidual : ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e))
+    (rightResidual : ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e)) :
+    ℂ :=
+  ∑ ζ : EdgeOpenMiddleConfig (G := G) A e leftResidual rightResidual,
+    ∏ v : {v : V // v ∈ edgeMiddleVertices e},
+      A.component v.1 (fun ie => edgeComplementValue (G := G) A e ζ.1 v.2 ie)
+        (τ v)
+
+/-- The ordinary blocked middle tensor, written with its own middle physical
+index. -/
+noncomputable def edgeMiddleWeightOn (A : Tensor G d) (e : Edge G)
+    (τ : EdgeMiddlePhysicalConfig (G := G) (d := d) e)
+    (β : EdgeBoundaryConfig (G := G) A e) : ℂ :=
+  ∑ η : EdgeMiddleConfig (G := G) A e β,
+    ∏ v : {v : V // v ∈ edgeMiddleVertices e},
+      A.component v.1 (fun ie => η.1 ie.1) (τ v)
+
+/-- The full-configuration form of the open middle tensor is the
+middle-indexed tensor evaluated on the restricted physical configuration. -/
+theorem edgeOpenMiddleWeight_eq_on (A : Tensor G d) (e : Edge G) (σ : V → Fin d)
+    (leftResidual : ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e))
+    (rightResidual : ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e)) :
+    edgeOpenMiddleWeight (G := G) A e σ leftResidual rightResidual =
+      edgeOpenMiddleWeightOn (G := G) A e
+        (edgeMiddlePhysicalConfigOf (G := G) (d := d) e σ)
+        leftResidual rightResidual :=
+  rfl
+
+/-- The full-configuration form of the ordinary middle tensor is the
+middle-indexed tensor evaluated on the restricted physical configuration. -/
+theorem edgeMiddleWeight_eq_on (A : Tensor G d) (e : Edge G) (σ : V → Fin d)
+    (β : EdgeBoundaryConfig (G := G) A e) :
+    edgeMiddleWeight (G := G) A e σ β =
+      edgeMiddleWeightOn (G := G) A e
+        (edgeMiddlePhysicalConfigOf (G := G) (d := d) e σ) β := by
+  classical
+  rw [edgeMiddleWeight, edgeMiddleWeightOn]
+  refine Finset.sum_congr rfl ?_
+  intro η _
+  rw [Finset.prod_subtype (F := inferInstance) (s := edgeMiddleVertices e)
+    (p := fun v => v ∈ edgeMiddleVertices e) (h := by intro v; rfl)]
+  rfl
+
+/-- The ordinary blocked middle tensor is the open middle tensor after restoring
+the fixed distinguished-edge index and reindexing the finite sum.
+
+This is the coefficient-level reindexing behind the identity specialization of
+an edge insertion, with the physical index already restricted to the middle
+block. -/
+theorem edgeMiddleWeightOn_eq_edgeOpenMiddleWeightOn (A : Tensor G d) (e : Edge G)
+    (τ : EdgeMiddlePhysicalConfig (G := G) (d := d) e)
+    (β : EdgeBoundaryConfig (G := G) A e) :
+    edgeMiddleWeightOn (G := G) A e τ β =
+      edgeOpenMiddleWeightOn (G := G) A e τ β.leftResidual β.rightResidual := by
+  classical
+  rw [edgeMiddleWeightOn, edgeOpenMiddleWeightOn]
+  let φ := edgeMiddleConfigEquivOpenMiddleConfig (G := G) A e β
+  calc
+    (∑ η : EdgeMiddleConfig (G := G) A e β,
+        ∏ v : {v : V // v ∈ edgeMiddleVertices e},
+          A.component v.1 (fun ie => η.1 ie.1) (τ v))
+        = ∑ ζ : EdgeOpenMiddleConfig (G := G) A e β.leftResidual β.rightResidual,
+            ∏ v : {v : V // v ∈ edgeMiddleVertices e},
+              A.component v.1 (fun ie => (φ.symm ζ).1 ie.1) (τ v) := by
+          refine Fintype.sum_equiv φ
+            (fun η : EdgeMiddleConfig (G := G) A e β =>
+              ∏ v : {v : V // v ∈ edgeMiddleVertices e},
+                A.component v.1 (fun ie => η.1 ie.1) (τ v))
+            (fun ζ : EdgeOpenMiddleConfig (G := G) A e β.leftResidual β.rightResidual =>
+              ∏ v : {v : V // v ∈ edgeMiddleVertices e},
+                A.component v.1 (fun ie => (φ.symm ζ).1 ie.1) (τ v)) ?_
+          intro η
+          simp [φ]
+    _ = ∑ ζ : EdgeOpenMiddleConfig (G := G) A e β.leftResidual β.rightResidual,
+          ∏ v : {v : V // v ∈ edgeMiddleVertices e},
+            A.component v.1 (fun ie => edgeComplementValue (G := G) A e ζ.1 v.2 ie)
+              (τ v) := by
+        refine Finset.sum_congr rfl ?_
+        intro ζ _
+        refine Fintype.prod_congr _ _ ?_
+        intro v
+        apply congrArg (fun cfg => A.component v.1 cfg (τ v))
+        funext ie
+        have hne := edge_ne_of_middle_incident_for_physical (G := G) e v.2 ie
+        simpa [φ, edgeComplementValue, edgeMiddleConfigEquivOpenMiddleConfig] using
+          edgeOpenMiddleConfigToMiddleConfig_apply_ne (G := G) A e β ζ ⟨ie.1, hne⟩
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -675,6 +675,46 @@ injective and normal PEPS, following Theorems~2 and~3 of
     data.
 \end{definition}
 
+\begin{definition}[Middle physical configurations at an edge]%
+    \label{def:peps_edgeMiddlePhysicalConfig}
+    \lean{TNLean.PEPS.EdgeMiddlePhysicalConfig}
+    \lean{TNLean.PEPS.edgeMiddlePhysicalConfigOf}
+    \leanok
+    \uses{def:peps_edgeMiddleVertices}
+    For an edge \(e=(u,v)\), the middle physical configurations are the
+    physical indices on the vertices in \(V\setminus\{u,v\}\). A global
+    physical configuration restricts to such a middle configuration.
+\end{definition}
+
+\begin{definition}[Middle tensor with middle physical index]%
+    \label{def:peps_edgeMiddleWeightOn}
+    \lean{TNLean.PEPS.edgeMiddleWeightOn}
+    \lean{TNLean.PEPS.edgeOpenMiddleWeightOn}
+    \leanok
+    \uses{def:peps_edgeMiddlePhysicalConfig,
+        def:peps_edgeMiddleConfig, def:peps_edgeOpenMiddleWeight}
+    The ordinary and open middle contractions may be written using only the
+    middle physical configuration, rather than a physical configuration on all
+    vertices. This is the middle tensor in the three-site chain obtained after
+    the edge blocking in arXiv:1804.04964, Section~3.
+\end{definition}
+
+\begin{theorem}[Middle restriction of the blocked tensor]%
+    \label{thm:peps_edgeMiddleWeight_eq_on}
+    \lean{TNLean.PEPS.edgeMiddleWeight_eq_on}
+    \lean{TNLean.PEPS.edgeOpenMiddleWeight_eq_on}
+    \leanok
+    \uses{def:peps_edgeMiddleWeightOn,
+        def:peps_edgeMiddlePhysicalConfig}
+    The middle contractions written with a global physical configuration are
+    the corresponding middle-indexed contractions evaluated on the restricted
+    middle physical configuration.
+\end{theorem}
+\begin{proof}\leanok
+    Rewrite the product over \(V\setminus\{u,v\}\) as the product over the
+    corresponding finite set of middle vertices.
+\end{proof}
+
 \begin{definition}[Restricting middle configurations away from the edge]%
     \label{def:peps_edgeMiddleConfigToOpenMiddleConfig}
     \lean{TNLean.PEPS.edgeMiddleConfigToOpenMiddleConfig}
@@ -707,6 +747,21 @@ injective and normal PEPS, following Theorems~2 and~3 of
     to compatible open-middle configurations. This is the finite reindexing
     used when the inserted matrix is the identity.
 \end{definition}
+
+\begin{theorem}[Middle-indexed open tensor reindexing]%
+    \label{thm:peps_edgeMiddleWeightOn_eq_edgeOpenMiddleWeightOn}
+    \lean{TNLean.PEPS.edgeMiddleWeightOn_eq_edgeOpenMiddleWeightOn}
+    \leanok
+    \uses{def:peps_edgeMiddleWeightOn,
+        def:peps_edgeMiddleConfigEquivOpenMiddleConfig}
+    The ordinary middle tensor and the open middle tensor agree after restoring
+    the fixed distinguished-edge index and reindexing the finite sum, with the
+    physical index already restricted to the middle block.
+\end{theorem}
+\begin{proof}\leanok
+    Reindex the ordinary middle configurations by the equivalence with
+    compatible open-middle configurations, then compare each local tensor entry.
+\end{proof}
 
 \begin{definition}[Edge insertion coefficient]%
     \label{def:peps_edgeInsertedCoeff}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -6,7 +6,7 @@
 \setlength{\emergencystretch}{2em}
 
 \input{command}
-\renewcommand{\leanid}[1]{\path{#1}}
+\providecommand{\leanid}[1]{\path{#1}}
 
 \title{Injective PEPS Fundamental Theorem: Section 3 Route}
 \author{}
@@ -123,8 +123,13 @@ Theorem can be proved in the manner of the paper.
   is inserted. This remaining finite-sum step is tracked by issue~\#1372.
 \item Vertex injectivity must be shown to pass to the edge-blocked three-site
   object. This is the formal version of the paper's assertion that the
-  regrouped MPS is injective. In the blueprint this is the not-yet-formalized
-  theorem \path{thm:peps_edgeBlockedThreeSiteInjective}.
+  regrouped MPS is injective. The middle physical index for this regrouped
+  object is now explicit as
+  \leanid{TNLean.PEPS.EdgeMiddlePhysicalConfig}, and the middle contractions
+  have the middle-indexed forms \leanid{TNLean.PEPS.edgeMiddleWeightOn} and
+  \leanid{TNLean.PEPS.edgeOpenMiddleWeightOn}. In the blueprint the
+  injectivity transfer itself remains the not-yet-formalized theorem
+  \path{thm:peps_edgeBlockedThreeSiteInjective}.
 \item The two internal steps in Lemma \path{inj_isomorph} must be formalized for
   the edge-blocked three-site MPS. The local endpoint part of the
   virtual-to-physical realization $X\mapsto O_1,O_2$ is formalized by
@@ -182,7 +187,8 @@ It is meant to prevent the proof from drifting away from the source argument.
 \item \path{eq:block_to_mps} edge blocking:
   \path{edgeBlockedCoeff_eq_stateCoeff} is locally proved; the injectivity
   bridge is \path{thm:peps_edgeBlockedThreeSiteInjective}, tracked by
-  issue~\#1366.
+  issue~\#1366. The middle physical index of this three-site object is
+  formalized by \leanid{TNLean.PEPS.EdgeMiddlePhysicalConfig}.
 \item Identity insertion on the chosen bond:
   \path{thm:peps_edgeInsertedCoeff_identity} is reduced to finite diagonal
   reindexing, tracked by issue~\#1372.


### PR DESCRIPTION
### Motivation

- The edge-blocked three-site object in the Section 3 argument of arXiv:1804.04964 requires an explicit type for the physical indices on $V \setminus \{u, v\}$ (all vertices except the endpoints of the chosen edge). Without this, the blocked middle tensor cannot be stated as a three-site MPS with typed physical data, and `thm:peps_edgeBlockedThreeSiteInjective` has no well-formed statement.
- Source: arXiv:1804.04964, Section 3, equation `eq:block_to_mps`; `Papers/1804.04964/paper_normal.tex`, lines 981–1009. The paper groups all vertices except the edge endpoints into the middle tensor and treats the result as a three-site MPS.
- Continues formalization of the edge-blocked three-site injectivity step, see #1366.

### Description

- **`TNLean/PEPS/Blocking.lean`**: Adds `EdgeMiddlePhysicalConfig` (the type of physical indices on $V \setminus \{u, v\}$) and `edgeMiddlePhysicalConfigOf` (the restriction map). Adds middle-indexed contractions `edgeMiddleWeightOn` and `edgeOpenMiddleWeightOn`, and proves `edgeMiddleWeight_eq_on`, `edgeOpenMiddleWeight_eq_on` (existing contractions agree on restricted configurations), and `edgeMiddleWeightOn_eq_edgeOpenMiddleWeightOn` (open vs. ordinary reindexing at the middle-indexed level). Rephrases `edgeMiddleWeight_eq_edgeOpenMiddleWeight` as a corollary.
- **`blueprint/src/chapter/ch13a_peps_ft.tex`**: Adds blueprint entries and `\lean{}`/`\leanok` tags for the new definitions and lemmas.
- **`docs/paper-gaps/peps_injective_ft_section3_route.tex`**: Updates the Section 3 route note and replaces `\renewcommand{\leanid}` with `\providecommand{\leanid}` so the note builds standalone.
- Does not prove `thm:peps_edgeBlockedThreeSiteInjective`; this PR provides the typed middle index needed as a precondition.

### Testing

- `lake env lean TNLean/PEPS/Blocking.lean`
- `lake build TNLean`
- `git diff --check`
- Line-length scan on touched files.
- `cd docs/paper-gaps && pdflatex -interaction=nonstopmode peps_injective_ft_section3_route.tex`
- `cd blueprint && leanblueprint checkdecls` — reports only pre-existing missing declarations; the new declarations are not among them.

---
Refs #1366

> [!NOTE]
> **Low Risk**
> Preparatory formalization and documentation in the PEPS blocking layer; no changes to auth, I/O, or runtime behavior, and injectivity is explicitly not claimed yet.
> 
> **Overview**
> This PR makes the **middle physical index** explicit for the edge-blocked three-site PEPS object in the Section 3 route (`eq:block_to_mps`), so the middle block is typed as physical data on \(V\setminus\{u,v\}\) rather than only as part of a full vertex configuration \(\sigma\).
> 
> In **`TNLean/PEPS/Blocking.lean`**, it adds `EdgeMiddlePhysicalConfig` and `edgeMiddlePhysicalConfigOf`, plus middle-indexed contractions `edgeMiddleWeightOn` and `edgeOpenMiddleWeightOn`. **Equality lemmas** show the existing `edgeMiddleWeight` / `edgeOpenMiddleWeight` agree with these forms on restricted \(\tau\). The open-vs-ordinary middle reindexing is proved at the middle-indexed level (`edgeMiddleWeightOn_eq_edgeOpenMiddleWeightOn`); `edgeMiddleWeight_eq_edgeOpenMiddleWeight` is a short corollary via the restriction theorems.
> 
> **Blueprint** Chapter 13a and **`docs/paper-gaps/peps_injective_ft_section3_route.tex`** document the new definitions and point the injectivity bridge at `thm:peps_edgeBlockedThreeSiteInjective` (still not proved). The route note uses `\providecommand{\leanid}` so it builds standalone. **No** claim of full three-site injectivity transfer yet—prep for #1366.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 505307b41d2c38d2281fddbe6d5761ca1dadeded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Lean definitions and documentation only; no runtime or security impact, and injectivity is explicitly not claimed in this change.
> 
> **Overview**
> This PR adds a dedicated **`TNLean/PEPS/EdgeMiddlePhysical.lean`** module (wired from **`TNLean.lean`**) so the edge-blocked three-site middle block has an explicit **physical index** on \(V\setminus\{u,v\}\), aligned with arXiv:1804.04964 Section 3 / `eq:block_to_mps`.
> 
> It introduces **`EdgeMiddlePhysicalConfig`** and **`edgeMiddlePhysicalConfigOf`**, plus middle-indexed contractions **`edgeMiddleWeightOn`** and **`edgeOpenMiddleWeightOn`**. **`edgeMiddleWeight_eq_on`** / **`edgeOpenMiddleWeight_eq_on`** identify the existing full-vertex **`edgeMiddleWeight`** / **`edgeOpenMiddleWeight`** with these forms on restricted \(\tau\). **`edgeMiddleWeightOn_eq_edgeOpenMiddleWeightOn`** proves open vs. ordinary middle reindexing at the middle-indexed level (using the existing config equivalence).
> 
> **Blueprint** Chapter 13a gains matching definitions and theorems with `\lean{}` links. The **Section 3 route** note records the new middle index for the injectivity bridge (**`thm:peps_edgeBlockedThreeSiteInjective`** still open, #1366) and switches **`\\leanid`** to **`\\providecommand`** for standalone builds.
> 
> No proof of three-site injectivity transfer yet—preparatory typing and reindexing only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c853fae235f904aa09e5c63c1783e7ad1e29b6a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->