### PR TITLE
feat(PEPS): name edge-blocked injectivity statement

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -155,7 +155,10 @@ noncomputable def edgeMiddleTensorFamily (A : Tensor G d) (e : Edge G) :
 /-- Injectivity of the middle tensor in the edge-blocked three-site chain.
 
 This is the middle-block part of the paper's assertion that the tensor network
-obtained after `eq:block_to_mps` is an injective three-site MPS. -/
+obtained after `eq:block_to_mps` is an injective three-site MPS.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
 def EdgeMiddleTensorInjective (A : Tensor G d) (e : Edge G) : Prop :=
   LinearIndependent ℂ (edgeMiddleTensorFamily (G := G) A e)
 
@@ -175,8 +178,8 @@ structure EdgeBlockedThreeSiteInjective (A : Tensor G d) (e : Edge G) : Prop whe
 /-- Vertex injectivity supplies the two endpoint injectivity assertions in the
 edge-blocked three-site chain.
 
-The remaining content of `thm:peps_edgeBlockedThreeSiteInjective` is the
-middle-block injectivity assertion. -/
+The unformalized content is middle-block injectivity: linear independence of the
+middle tensor family over the residual boundary configurations. -/
 theorem IsVertexInjective.edgeBlockedEndpointTensorMaps_injective {A : Tensor G d}
     (hA : IsVertexInjective A) (e : Edge G) :
     Function.Injective (localTensorMap A e.1.1) ∧

--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -141,5 +141,59 @@ theorem edgeMiddleWeightOn_eq_edgeOpenMiddleWeightOn (A : Tensor G d) (e : Edge 
         simpa [φ, edgeComplementValue, edgeMiddleConfigEquivOpenMiddleConfig] using
           edgeOpenMiddleConfigToMiddleConfig_apply_ne (G := G) A e β ζ ⟨ie.1, hne⟩
 
+/-- The middle tensor in the edge-blocked three-site chain, indexed by the two
+residual boundary configurations adjacent to the endpoints.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+noncomputable def edgeMiddleTensorFamily (A : Tensor G d) (e : Edge G) :
+    ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e) ×
+        ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e) →
+      EdgeMiddlePhysicalConfig (G := G) (d := d) e → ℂ :=
+  fun ρ τ => edgeOpenMiddleWeightOn (G := G) A e τ ρ.1 ρ.2
+
+/-- Injectivity of the middle tensor in the edge-blocked three-site chain.
+
+This is the middle-block part of the paper's assertion that the tensor network
+obtained after `eq:block_to_mps` is an injective three-site MPS. -/
+def EdgeMiddleTensorInjective (A : Tensor G d) (e : Edge G) : Prop :=
+  LinearIndependent ℂ (edgeMiddleTensorFamily (G := G) A e)
+
+/-- Injectivity of the three-site chain obtained by blocking around a
+chosen edge \(e=(u,v)\).
+
+The first and last assertions are the injectivity of the endpoint tensors. The
+middle assertion is the injectivity of the tensor obtained by blocking all
+vertices except the two endpoints. This is the formal statement targeted by the
+assertion after `eq:block_to_mps` in arXiv:1804.04964, Section 3,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+structure EdgeBlockedThreeSiteInjective (A : Tensor G d) (e : Edge G) : Prop where
+  left_injective : Function.Injective (localTensorMap A e.1.1)
+  middle_injective : EdgeMiddleTensorInjective (G := G) A e
+  right_injective : Function.Injective (localTensorMap A e.1.2)
+
+/-- Vertex injectivity supplies the two endpoint injectivity assertions in the
+edge-blocked three-site chain.
+
+The remaining content of `thm:peps_edgeBlockedThreeSiteInjective` is the
+middle-block injectivity assertion. -/
+theorem IsVertexInjective.edgeBlockedEndpointTensorMaps_injective {A : Tensor G d}
+    (hA : IsVertexInjective A) (e : Edge G) :
+    Function.Injective (localTensorMap A e.1.1) ∧
+      Function.Injective (localTensorMap A e.1.2) :=
+  ⟨hA.localTensorMap_injective e.1.1, hA.localTensorMap_injective e.1.2⟩
+
+/-- Once the middle block is injective, vertex injectivity gives the full
+edge-blocked three-site injectivity statement.
+
+This isolates the remaining proof obligation in the source argument: injectivity
+is preserved when the vertices away from the chosen edge are blocked into the
+middle tensor. -/
+theorem IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle {A : Tensor G d}
+    (hA : IsVertexInjective A) (e : Edge G)
+    (hMiddle : EdgeMiddleTensorInjective (G := G) A e) :
+    EdgeBlockedThreeSiteInjective (G := G) A e :=
+  ⟨hA.localTensorMap_injective e.1.1, hMiddle, hA.localTensorMap_injective e.1.2⟩
+
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -943,7 +943,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \label{thm:peps_edgeBlockedEndpointTensorMaps_injective}
     \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective}
     \leanok
-    \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective}
+    \uses{def:IsVertexInjective}
     If the original PEPS tensor is vertex-injective, then the two endpoint
     tensor maps in the edge-blocked three-site chain are injective.
 \end{theorem}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -916,11 +916,61 @@ injective and normal PEPS, following Theorems~2 and~3 of
     coefficients and apply the same-state hypothesis.
 \end{proof}
 
+\begin{definition}[Middle tensor family at an edge]%
+    \label{def:peps_edgeMiddleTensorFamily}
+    \lean{TNLean.PEPS.edgeMiddleTensorFamily}
+    \lean{TNLean.PEPS.EdgeMiddleTensorInjective}
+    \leanok
+    \uses{def:peps_edgeMiddleWeightOn}
+    For the edge-blocked three-site chain at $e=(u,v)$, the middle tensor is
+    the family obtained by fixing the two residual endpoint boundaries and
+    evaluating the open middle contraction on the middle physical index.
+    Its injectivity is the middle-block part of the assertion following
+    the edge-blocking diagram.
+\end{definition}
+
+\begin{definition}[Edge-blocked three-site injectivity]%
+    \label{def:peps_edgeBlockedThreeSiteInjective}
+    \lean{TNLean.PEPS.EdgeBlockedThreeSiteInjective}
+    \leanok
+    \uses{def:peps_localTensorMap, def:peps_edgeMiddleTensorFamily}
+    For a chosen edge $e=(u,v)$, the edge-blocked three-site chain is
+    injective when the left endpoint tensor map, the middle tensor family, and
+    the right endpoint tensor map are all injective.
+\end{definition}
+
+\begin{theorem}[Endpoint injectivity in the edge-blocked chain]%
+    \label{thm:peps_edgeBlockedEndpointTensorMaps_injective}
+    \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective}
+    If the original PEPS tensor is vertex-injective, then the two endpoint
+    tensor maps in the edge-blocked three-site chain are injective.
+\end{theorem}
+\begin{proof}\leanok
+    Apply vertex injectivity at the two endpoints of the chosen edge.
+\end{proof}
+
+\begin{theorem}[Reducing edge-blocked injectivity to the middle block]%
+    \label{thm:peps_edgeBlockedThreeSiteInjective_of_middle}
+    \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
+        def:peps_edgeMiddleTensorFamily}
+    For a vertex-injective PEPS tensor, injectivity of the edge-blocked middle
+    tensor gives the full injectivity statement for the edge-blocked three-site
+    chain.
+\end{theorem}
+\begin{proof}\leanok
+    The endpoint assertions are supplied by vertex injectivity. The middle
+    assertion is the assumed injectivity of the blocked middle tensor.
+\end{proof}
+
 \begin{theorem}[Edge blocking preserves injectivity]%
     \label{thm:peps_edgeBlockedThreeSiteInjective}
     \notready
-    \uses{def:IsVertexInjective, def:peps_edgeMiddleWeight,
-        def:peps_edgeBlockedCoeff}
+    \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
+        thm:peps_edgeBlockedThreeSiteInjective_of_middle}
     If \(A\) is vertex-injective, then for every edge \(e=(u,v)\), the two
     endpoint tensors together with the tensor obtained by blocking all vertices
     outside \(u\) and \(v\) form an injective three-site MPS. This is the

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -128,7 +128,13 @@ Theorem can be proved in the manner of the paper.
   \leanid{TNLean.PEPS.EdgeMiddlePhysicalConfig}, and the middle contractions
   have the middle-indexed forms \leanid{TNLean.PEPS.edgeMiddleWeightOn} and
   \leanid{TNLean.PEPS.edgeOpenMiddleWeightOn}. In the blueprint the
-  injectivity transfer itself remains the not-yet-formalized theorem
+  injectivity statement is \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective}.
+  Vertex injectivity supplies the two endpoint assertions by
+  \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective}
+  and
+  \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle}
+  reduces the remaining work to the middle-block injectivity statement. The
+  full transfer remains the not-yet-formalized theorem
   \path{thm:peps_edgeBlockedThreeSiteInjective}.
 \item The two internal steps in Lemma \path{inj_isomorph} must be formalized for
   the edge-blocked three-site MPS. The local endpoint part of the
@@ -188,7 +194,9 @@ It is meant to prevent the proof from drifting away from the source argument.
   \path{edgeBlockedCoeff_eq_stateCoeff} is locally proved; the injectivity
   bridge is \path{thm:peps_edgeBlockedThreeSiteInjective}, tracked by
   issue~\#1366. The middle physical index of this three-site object is
-  formalized by \leanid{TNLean.PEPS.EdgeMiddlePhysicalConfig}.
+  formalized by \leanid{TNLean.PEPS.EdgeMiddlePhysicalConfig}. The named
+  injectivity statement is \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective},
+  and the endpoint assertions are proved from vertex injectivity.
 \item Identity insertion on the chosen bond:
   \path{thm:peps_edgeInsertedCoeff_identity} is reduced to finite diagonal
   reindexing, tracked by issue~\#1372.


### PR DESCRIPTION
## Summary

This PR records the precise injectivity statement attached to the edge-blocked three-site MPS in arXiv:1804.04964, Section 3, equation `eq:block_to_mps` (local source `Papers/1804.04964/paper_normal.tex`, lines 981--1009).

It adds the middle tensor family for the edge-blocked chain, packages the three required injectivity assertions, and proves that vertex injectivity supplies the two endpoint assertions. The remaining mathematical content for the full edge-blocking injectivity theorem is the middle-block injectivity assertion coming from the source contraction argument.

The blueprint and Section 3 route note are updated so a later proof of `thm:peps_edgeBlockedThreeSiteInjective` can point to this decomposition without treating the full source assertion as already formalized.

## Validation

- `lake build TNLean.PEPS.EdgeMiddlePhysical`
- `lake build TNLean`
- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `cd docs/paper-gaps && pdflatex -interaction=nonstopmode peps_injective_ft_section3_route.tex`
- `cd blueprint && leanblueprint checkdecls` reports only pre-existing missing declarations; the new PEPS declarations are not missing.

Refs #1366

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint metadata only; no executable or proof logic changed.
> 
> **Overview**
> This PR **tightens documentation** around the edge-blocked three-site injectivity story already in `EdgeMiddlePhysical.lean` and the PEPS blueprint—no new definitions, theorems, or proof changes.
> 
> In Lean, the `EdgeMiddleTensorInjective` docblock now cites arXiv:1804.04964 Section 3 / `eq:block_to_mps` explicitly, and the comment on `IsVertexInjective.edgeBlockedEndpointTensorMaps_injective` states that the **remaining unformalized obligation** is middle-block injectivity (linear independence of `edgeMiddleTensorFamily` over residual boundary data), not the endpoint maps.
> 
> In `ch13a_peps_ft.tex`, the endpoint injectivity theorem’s `\uses` list drops `def:peps_edgeBlockedThreeSiteInjective` so the blueprint only depends on `def:IsVertexInjective`, matching the fact that endpoint injectivity is proved directly from vertex injectivity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e29ef6fb0ce2f4feb21018e82bf822789c52901e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->