### PR TITLE
feat(PEPS): split normal T window blocks

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -242,6 +242,28 @@ theorem normalSquareRegionS_rectangular_decomposition {width height : ℕ}
   · exact isTwoByThreeContiguousSquareLatticeRectangle_of_bounds (by omega) hy
   · exact isTwoByThreeContiguousSquareLatticeRectangle_of_bounds (by omega) hy
 
+/-- The vertical edge block removed from the local window in the displayed
+region \(T\).
+
+This is the \(2\times3\) block shown in the source picture.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+def normalSquareRegionTVerticalBlock {width height : ℕ} (xStart yStart : ℕ) :
+    Finset (SquareLatticeVertex width height) :=
+  squareLatticeContiguousRectangle xStart (yStart + 2) 2 3
+
+/-- The horizontal edge block removed from the local window in the displayed
+region \(T\).
+
+This is the shifted \(3\times2\) block shown in the source picture.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+def normalSquareRegionTHorizontalBlock {width height : ℕ} (xStart yStart : ℕ) :
+    Finset (SquareLatticeVertex width height) :=
+  squareLatticeContiguousRectangle (xStart + 2) (yStart + 1) 3 2
+
 /-- The two edge blocks removed from the local window in the displayed region
 \(T\).
 
@@ -252,8 +274,32 @@ Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
 of `Papers/1804.04964/paper_normal.tex`. -/
 def normalSquareRegionTHole {width height : ℕ} (xStart yStart : ℕ) :
     Finset (SquareLatticeVertex width height) :=
-  squareLatticeContiguousRectangle xStart (yStart + 2) 2 3 ∪
-    squareLatticeContiguousRectangle (xStart + 2) (yStart + 1) 3 2
+  normalSquareRegionTVerticalBlock xStart yStart ∪
+    normalSquareRegionTHorizontalBlock xStart yStart
+
+/-- The vertical edge block removed from the displayed \(T\)-region is a
+contiguous \(2\times3\) rectangle.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionTVerticalBlock_rectangular {width height : ℕ}
+    {xStart yStart : ℕ} (hx : xStart + 5 ≤ width) (hy : yStart + 5 ≤ height) :
+    IsTwoByThreeContiguousSquareLatticeRectangle
+      (normalSquareRegionTVerticalBlock xStart yStart :
+        Finset (SquareLatticeVertex width height)) := by
+  exact isTwoByThreeContiguousSquareLatticeRectangle_of_bounds (by omega) (by omega)
+
+/-- The horizontal edge block removed from the displayed \(T\)-region is a
+contiguous \(3\times2\) rectangle.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionTHorizontalBlock_rectangular {width height : ℕ}
+    {xStart yStart : ℕ} (hx : xStart + 5 ≤ width) (hy : yStart + 5 ≤ height) :
+    IsThreeByTwoContiguousSquareLatticeRectangle
+      (normalSquareRegionTHorizontalBlock xStart yStart :
+        Finset (SquareLatticeVertex width height)) := by
+  exact isThreeByTwoContiguousSquareLatticeRectangle_of_bounds (by omega) (by omega)
 
 /-- The two edge blocks removed in the displayed region \(T\) are one
 contiguous \(2\times3\) rectangle and one contiguous \(3\times2\) rectangle.
@@ -267,10 +313,10 @@ theorem normalSquareRegionTHole_rectangular_decomposition {width height : ℕ}
       IsTwoByThreeContiguousSquareLatticeRectangle T₂ ∧
         IsThreeByTwoContiguousSquareLatticeRectangle T₃ ∧
           normalSquareRegionTHole xStart yStart = T₂ ∪ T₃ := by
-  refine ⟨squareLatticeContiguousRectangle xStart (yStart + 2) 2 3,
-    squareLatticeContiguousRectangle (xStart + 2) (yStart + 1) 3 2, ?_, ?_, rfl⟩
-  · exact isTwoByThreeContiguousSquareLatticeRectangle_of_bounds (by omega) (by omega)
-  · exact isThreeByTwoContiguousSquareLatticeRectangle_of_bounds (by omega) (by omega)
+  refine ⟨normalSquareRegionTVerticalBlock xStart yStart,
+    normalSquareRegionTHorizontalBlock xStart yStart, ?_, ?_, rfl⟩
+  · exact normalSquareRegionTVerticalBlock_rectangular hx hy
+  · exact normalSquareRegionTHorizontalBlock_rectangular hx hy
 
 /-- The displayed region \(T\) in the normal square-lattice proof.
 
@@ -303,6 +349,20 @@ def normalSquareRegionT {width height : ℕ} (xStart yStart : ℕ) :
       (xStart + 1 ≤ v.1.1 ∧ v.1.1 < xStart + 3 ∧
         yStart ≤ v.2.1 ∧ v.2.1 < yStart + 3) := by
   simp [normalSquareRegionS]
+
+@[simp] theorem mem_normalSquareRegionTVerticalBlock {width height : ℕ}
+    (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
+    v ∈ normalSquareRegionTVerticalBlock xStart yStart ↔
+      xStart ≤ v.1.1 ∧ v.1.1 < xStart + 2 ∧
+        yStart + 2 ≤ v.2.1 ∧ v.2.1 < yStart + 5 := by
+  simp [normalSquareRegionTVerticalBlock]
+
+@[simp] theorem mem_normalSquareRegionTHorizontalBlock {width height : ℕ}
+    (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
+    v ∈ normalSquareRegionTHorizontalBlock xStart yStart ↔
+      xStart + 2 ≤ v.1.1 ∧ v.1.1 < xStart + 5 ∧
+        yStart + 1 ≤ v.2.1 ∧ v.2.1 < yStart + 3 := by
+  simp [normalSquareRegionTHorizontalBlock]
 
 @[simp] theorem mem_normalSquareRegionTHole {width height : ℕ}
     (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
@@ -337,6 +397,22 @@ theorem normalSquareRegionTHole_subset_window {width height : ℕ}
   rw [mem_squareLatticeContiguousRectangle]
   rcases hv with hv | hv <;> omega
 
+/-- The two edge blocks removed from the displayed \(T\)-region are disjoint.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionTVerticalBlock_disjoint_horizontalBlock {width height : ℕ}
+    (xStart yStart : ℕ) :
+    Disjoint
+      (normalSquareRegionTVerticalBlock xStart yStart :
+        Finset (SquareLatticeVertex width height))
+      (normalSquareRegionTHorizontalBlock xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hvVertical hvHorizontal
+  rw [mem_normalSquareRegionTVerticalBlock] at hvVertical
+  rw [mem_normalSquareRegionTHorizontalBlock] at hvHorizontal
+  omega
+
 /-- The displayed \(T\)-region is disjoint from the two edge blocks removed
 from the local \(5\times6\) window.
 
@@ -351,6 +427,38 @@ theorem normalSquareRegionT_disjoint_THole {width height : ℕ}
   unfold normalSquareRegionT
   exact disjoint_sdiff_self_left
 
+/-- The displayed \(T\)-region is disjoint from the vertical edge block removed
+from the local \(5\times6\) window.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionT_disjoint_verticalBlock {width height : ℕ}
+    (xStart yStart : ℕ) :
+    Disjoint
+      (normalSquareRegionT xStart yStart :
+        Finset (SquareLatticeVertex width height))
+      (normalSquareRegionTVerticalBlock xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hvT hvVertical
+  rw [mem_normalSquareRegionT] at hvT
+  exact hvT.2.2.2.2 (by simp [normalSquareRegionTHole, hvVertical])
+
+/-- The displayed \(T\)-region is disjoint from the horizontal edge block
+removed from the local \(5\times6\) window.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionT_disjoint_horizontalBlock {width height : ℕ}
+    (xStart yStart : ℕ) :
+    Disjoint
+      (normalSquareRegionT xStart yStart :
+        Finset (SquareLatticeVertex width height))
+      (normalSquareRegionTHorizontalBlock xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hvT hvHorizontal
+  rw [mem_normalSquareRegionT] at hvT
+  exact hvT.2.2.2.2 (by simp [normalSquareRegionTHole, hvHorizontal])
+
 /-- The displayed \(T\)-region and the two removed edge blocks reconstruct the
 local \(5\times6\) coordinate window.
 
@@ -363,6 +471,20 @@ theorem normalSquareRegionT_union_THole {width height : ℕ}
         Finset (SquareLatticeVertex width height)) := by
   unfold normalSquareRegionT
   exact Finset.sdiff_union_of_subset (normalSquareRegionTHole_subset_window xStart yStart)
+
+/-- The displayed \(T\)-region, the vertical removed block, and the horizontal
+removed block reconstruct the local \(5\times6\) coordinate window.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionT_union_verticalBlock_union_horizontalBlock {width height : ℕ}
+    (xStart yStart : ℕ) :
+    normalSquareRegionT xStart yStart ∪ normalSquareRegionTVerticalBlock xStart yStart ∪
+        normalSquareRegionTHorizontalBlock xStart yStart =
+      (squareLatticeContiguousRectangle xStart yStart 5 6 :
+        Finset (SquareLatticeVertex width height)) := by
+  rw [Finset.union_assoc]
+  simpa [normalSquareRegionTHole] using normalSquareRegionT_union_THole xStart yStart
 
 /-- The displayed region \(R\) is contained in the displayed region \(S\).
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1487,6 +1487,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.IsThreeByTwoContiguousSquareLatticeRectangle}
     \lean{TNLean.PEPS.normalSquareRegionR}
     \lean{TNLean.PEPS.normalSquareRegionS}
+    \lean{TNLean.PEPS.normalSquareRegionTVerticalBlock}
+    \lean{TNLean.PEPS.normalSquareRegionTHorizontalBlock}
     \lean{TNLean.PEPS.normalSquareRegionTHole}
     \lean{TNLean.PEPS.normalSquareRegionT}
     \leanok
@@ -1504,7 +1506,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     of two \(2\times3\) contiguous rectangles shifted by one horizontal
     coordinate, hence the full \(3\times3\) square spanned by them.  The
     displayed region \(T\) is the complement, inside a local \(5\times6\)
-    coordinate window, of the two edge blocks shown in the source picture.
+    coordinate window, of the vertical \(2\times3\) edge block and the
+    horizontal \(3\times2\) edge block shown in the source picture.
 \end{definition}
 
 \begin{lemma}[Basic identities for square-lattice coordinate regions]%
@@ -1514,6 +1517,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.mem_squareLatticeContiguousRectangle}
     \lean{TNLean.PEPS.mem_normalSquareRegionR}
     \lean{TNLean.PEPS.mem_normalSquareRegionS}
+    \lean{TNLean.PEPS.mem_normalSquareRegionTVerticalBlock}
+    \lean{TNLean.PEPS.mem_normalSquareRegionTHorizontalBlock}
     \lean{TNLean.PEPS.mem_normalSquareRegionTHole}
     \lean{TNLean.PEPS.mem_normalSquareRegionT}
     \lean{TNLean.PEPS.isTwoByThreeContiguousSquareLatticeRectangle_of_bounds}
@@ -1570,6 +1575,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{lemma}[The edge blocks removed from \(T\) are contiguous rectangles]%
     \label{lem:peps_normalSquareRegionTHole_rectangular_decomposition}
+    \lean{TNLean.PEPS.normalSquareRegionTVerticalBlock_rectangular}
+    \lean{TNLean.PEPS.normalSquareRegionTHorizontalBlock_rectangular}
     \lean{TNLean.PEPS.normalSquareRegionTHole_rectangular_decomposition}
     \leanok
     \uses{def:peps_squareLatticeCoordinateRegions,
@@ -1586,14 +1593,18 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{lemma}[The $T$-region and its removed edge blocks fill the local window]%
     \label{lem:peps_normalSquareRegionT_window_complement}
     \lean{TNLean.PEPS.normalSquareRegionTHole_subset_window}
+    \lean{TNLean.PEPS.normalSquareRegionTVerticalBlock_disjoint_horizontalBlock}
     \lean{TNLean.PEPS.normalSquareRegionT_disjoint_THole}
+    \lean{TNLean.PEPS.normalSquareRegionT_disjoint_verticalBlock}
+    \lean{TNLean.PEPS.normalSquareRegionT_disjoint_horizontalBlock}
     \lean{TNLean.PEPS.normalSquareRegionT_union_THole}
+    \lean{TNLean.PEPS.normalSquareRegionT_union_verticalBlock_union_horizontalBlock}
     \leanok
     \uses{def:peps_squareLatticeCoordinateRegions,
         lem:peps_squareLatticeCoordinateRegion_identities}
     The two edge blocks removed from the displayed $T$-region lie inside the
-    local $5\times6$ coordinate window.  They are disjoint from $T$, and their
-    union with $T$ is exactly that local window.
+    local $5\times6$ coordinate window.  They are disjoint from each other and
+    from $T$, and their union with $T$ is exactly that local window.
 \end{lemma}
 \begin{proof}\leanok
     This follows by unfolding the definition of $T$ as the set-theoretic

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -110,11 +110,11 @@ statement that they differ in one site: $R$ is contained in $S$, and
 $S\setminus R$ is the lower-right site of the displayed $3\times3$ square. The
 displayed region $T$ is now present as the complement, inside the source
 $5\times6$ local window, of the two edge blocks shown in the source picture;
-the two removed edge blocks are now formalized as one contiguous $2\times3$
-rectangle and one contiguous $3\times2$ rectangle. The complement relation is
-also formalized: the removed edge blocks lie inside the local window, are
-disjoint from $T$, and together with $T$ reconstruct that window. This does not
-yet prove injectivity of $R$, $S$, or $T$.
+the two removed edge blocks are now formalized separately as one contiguous
+$2\times3$ rectangle and one contiguous $3\times2$ rectangle. They are
+disjoint from each other, and the three-part cover by $T$ and the two removed
+blocks reconstructs the local window. This does not yet prove injectivity of
+$R$, $S$, or $T$.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
@@ -150,9 +150,10 @@ alone. The following additional obligations remain.
           decompositions and the expected one-site difference formalized. The
           displayed region $T$ is now
           defined as the complement of the two edge blocks in the source
-          $5\times6$ local window, and the removed edge blocks have the
+          $5\times6$ local window, and the two removed edge blocks have the
           displayed rectangular shapes. The local-window complement identity for
-          $T$ is also formalized. The union lemma is then used repeatedly.
+          $T$ is also formalized, including the three-part cover by $T$ and the
+          two removed blocks. The union lemma is then used repeatedly.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.


### PR DESCRIPTION
### Motivation

This PR continues the coordinate geometry preparatory to the normal PEPS fundamental theorem in arXiv:1804.04964, Section 3, lines 1430--1443. The source picture describes the displayed T-region by removing two rectangular edge blocks from a local 5\times6 window. Naming these two blocks separately is a prerequisite for invoking their rectangular injectivity independently in the later union-of-injective-regions argument.

### Description

- `TNLean/PEPS/NormalBlocking.lean` introduces the vertical 2\times3 block and horizontal 3\times2 block removed from the local T-region window, refactors `normalSquareRegionTHole` as their union, and proves the corresponding rectangular-shape, membership, disjointness, and three-part cover statements.
- `blueprint/src/chapter/ch13a_peps_ft.tex` records the new Lean declarations in the normal square-lattice geometry entries.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex` records this as preparatory geometry; injectivity of T is still not claimed here.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build TNLean`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/PEPS/NormalBlocking.lean`
- `cd blueprint && leanblueprint checkdecls` reports only pre-existing missing declarations, not the new names in this PR.
- `cd docs/paper-gaps && pdflatex -interaction=nonstopmode peps_normal_ft_section3_route.tex` keeps the existing undefined citation/cross-reference warnings.

Refs #2004