### PR TITLE
feat(PEPS): derive normal R S injectivity conditionally

### DIFF
--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -54,7 +54,7 @@ union-of-injective-regions lemma.  It is recorded separately so later
 coordinate arguments may use the source lemma without repeating its proof.
 
 Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
-1324--1400 of `Papers/1804.04964/paper_normal.tex`. -/
+1322--1404 of `Papers/1804.04964/paper_normal.tex`. -/
 structure RegionInjectivityUnionClosure (κ : RegionInjectivityData V) : Prop where
   /-- The union of two injective finite vertex regions is injective. -/
   union_injective :

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -47,6 +47,19 @@ structure RegionInjectivityData (V : Type*) where
   /-- The assertion that a finite vertex region is injective after blocking. -/
   IsInjective : Finset V → Prop
 
+/-- The union-closure assertion for region injectivity.
+
+This is the formal hypothesis supplied by the tensor-level
+union-of-injective-regions lemma.  It is recorded separately so later
+coordinate arguments may use the source lemma without repeating its proof.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1324--1400 of `Papers/1804.04964/paper_normal.tex`. -/
+structure RegionInjectivityUnionClosure (κ : RegionInjectivityData V) : Prop where
+  /-- The union of two injective finite vertex regions is injective. -/
+  union_injective :
+    ∀ {A B : Finset V}, κ.IsInjective A → κ.IsInjective B → κ.IsInjective (A ∪ B)
+
 /-- The part of the left region outside the right region. -/
 def regionOnlyLeft (A B : Finset V) : Finset V :=
   A \ B

--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -733,6 +733,68 @@ def toRectangular
       IsThreeByTwoContiguousSquareLatticeRectangle R :=
   Iff.rfl
 
+/-- A bounded contiguous \(2\times3\) coordinate rectangle is injective under
+the square-lattice rectangular injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3 and proof, lines 1407--1452
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem rect23_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 2 ≤ width) (hy : yStart + 3 ≤ height) :
+    κ.IsInjective
+      (squareLatticeContiguousRectangle xStart yStart 2 3 :
+        Finset (SquareLatticeVertex width height)) :=
+  h.twoByThree_injective _
+    (isTwoByThreeContiguousSquareLatticeRectangle_of_bounds hx hy)
+
+/-- A bounded contiguous \(3\times2\) coordinate rectangle is injective under
+the square-lattice rectangular injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3 and proof, lines 1407--1452
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem rect32_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 3 ≤ width) (hy : yStart + 2 ≤ height) :
+    κ.IsInjective
+      (squareLatticeContiguousRectangle xStart yStart 3 2 :
+        Finset (SquareLatticeVertex width height)) :=
+  h.threeByTwo_injective _
+    (isThreeByTwoContiguousSquareLatticeRectangle_of_bounds hx hy)
+
+/-- Region \(R\) is injective once rectangular injectivity is combined with
+the union-closure assertion from the source injective-union lemma.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
+Theorem 3, lines 1324--1430 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionR_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart : ℕ} (hx : xStart + 3 ≤ width) (hy : yStart + 3 ≤ height) :
+    κ.IsInjective (normalSquareRegionR xStart yStart) := by
+  rcases normalSquareRegionR_rectangular_decomposition hx hy with
+    ⟨R₂, R₃, hR₂, hR₃, hR⟩
+  rw [hR]
+  exact hUnion.union_injective
+    (h.twoByThree_injective R₂ hR₂)
+    (h.threeByTwo_injective R₃ hR₃)
+
+/-- Region \(S\) is injective once rectangular injectivity is combined with
+the union-closure assertion from the source injective-union lemma.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
+Theorem 3, lines 1324--1430 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionS_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart : ℕ} (hx : xStart + 3 ≤ width) (hy : yStart + 3 ≤ height) :
+    κ.IsInjective (normalSquareRegionS xStart yStart) := by
+  rcases normalSquareRegionS_rectangular_decomposition hx hy with
+    ⟨S₁, S₂, hS₁, hS₂, hS⟩
+  rw [hS]
+  exact hUnion.union_injective
+    (h.twoByThree_injective S₁ hS₁)
+    (h.twoByThree_injective S₂ hS₂)
+
 end NormalSquareLatticeRectangleInjectivityHypotheses
 
 /-- Square-lattice normal PEPS blocking hypotheses for Theorem 3.
@@ -747,16 +809,16 @@ to the tensor-level region-injectivity theorem.
 **Scope restriction (R/S/T injectivity):** The injectivity assertions for
 \(R\), \(S\), and \(T\) are assumed directly, whereas arXiv:1804.04964,
 Section 3, derives them from the \(2\times 3\) and \(3\times 2\) rectangular
-injectivity assumptions using the union-of-injective-regions lemma. The regions
-\(R\), \(S\), and \(T\) are also not yet tied to the displayed square-lattice
-geometry, to the two rectangular-region predicates, or to a square-lattice
-coordinate and adjacency model; the size fields only record \(|V|=width\cdot
-height\). This structure therefore does not yet supply the translated per-edge
+injectivity assumptions using the union-of-injective-regions lemma. The
+coordinate regions \(R\), \(S\), and \(T\) are now recorded separately, and
+\(R\) and \(S\) have conditional injectivity lemmas assuming union closure, but
+this abstract structure still assumes its three region fields directly. It does
+not yet identify them with translated coordinate regions or supply the per-edge
 red, blue, and complementary regions used in the proof of Theorem 3. Documented
 in `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Remaining mathematical
-obligations 1--5. Elimination: introduce the coordinate-aware square-lattice
-regions and derive these three assertions from rectangular injectivity after the
-tensor-level union theorem is formalized.
+obligations 1--5. Elimination: derive these assertions from rectangular
+injectivity after the tensor-level union theorem is formalized, then construct
+the translated edge blockings.
 
 Source: arXiv:1804.04964, Section 3, Theorem 3 and its proof, lines
 1407--1504 of `Papers/1804.04964/paper_normal.tex`. -/

--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -765,8 +765,8 @@ theorem rect32_injective
 the union-closure assertion from the source injective-union lemma.
 
 Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
-Theorem 3, lines 1324--1430 of `Papers/1804.04964/paper_normal.tex`. -/
-theorem regionR_injective
+Theorem 3, lines 1322--1430 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionR_injective_of_union
     (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
     {xStart yStart : ℕ} (hx : xStart + 3 ≤ width) (hy : yStart + 3 ≤ height) :
@@ -782,8 +782,8 @@ theorem regionR_injective
 the union-closure assertion from the source injective-union lemma.
 
 Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
-Theorem 3, lines 1324--1430 of `Papers/1804.04964/paper_normal.tex`. -/
-theorem regionS_injective
+Theorem 3, lines 1322--1430 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionS_injective_of_union
     (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
     {xStart yStart : ℕ} (hx : xStart + 3 ≤ width) (hy : yStart + 3 ≤ height) :

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1459,11 +1459,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{definition}[Injectivity predicate for blocked regions]%
     \label{def:peps_regionInjectivityData}
     \lean{TNLean.PEPS.RegionInjectivityData}
+    \lean{TNLean.PEPS.RegionInjectivityUnionClosure}
     \leanok
     A region-injectivity hypothesis assigns to each finite vertex region the
     assertion that the tensor obtained by blocking that region is injective.
     This predicate is used for regions such as \(R\), \(S\), \(T\), and their
-    complements in the normal PEPS proof.
+    complements in the normal PEPS proof.  The union-closure hypothesis records
+    the conclusion supplied by the source union-of-injective-regions lemma:
+    the union of two injective regions is injective.
 \end{definition}
 
 \begin{definition}[Complement of a finite region]%
@@ -1659,6 +1662,40 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     This is the direct specialization of the abstract rectangular families to
     the two contiguous coordinate-rectangle predicates.
+\end{proof}
+
+\begin{lemma}[Coordinate rectangular injectivity gives injective rectangles]%
+    \label{lem:peps_squareLatticeRectangleInjectivity_rectangles}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.rect23_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.rect32_injective}
+    \leanok
+    \uses{def:peps_normalRectangleInjectivityHypotheses,
+        lem:peps_squareLatticeCoordinateRegion_identities}
+    Under the coordinate square-lattice rectangular injectivity hypotheses,
+    every bounded contiguous \(2\times3\) rectangle and every bounded
+    contiguous \(3\times2\) rectangle is injective.
+\end{lemma}
+\begin{proof}\leanok
+    This is the defining rectangular injectivity hypothesis applied to the
+    coordinate witnesses for the two rectangle shapes.
+\end{proof}
+
+\begin{lemma}[Conditional injectivity of the normal \(R\) and \(S\) regions]%
+    \label{lem:peps_normalSquareRegionRS_injective_of_unionClosure}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionR_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionS_injective}
+    \leanok
+    \uses{def:peps_regionInjectivityData,
+        lem:peps_squareLatticeRectangleInjectivity_rectangles,
+        lem:peps_normalSquareRegionRS_rectangular_decomposition}
+    If region injectivity is closed under unions, then the coordinate
+    square-lattice rectangular injectivity hypotheses imply that the displayed
+    regions \(R\) and \(S\) are injective.
+\end{lemma}
+\begin{proof}\leanok
+    Region \(R\) is the union of one injective \(2\times3\) rectangle and one
+    injective \(3\times2\) rectangle.  Region \(S\) is the union of two
+    injective \(2\times3\) rectangles.  Apply union closure in each case.
 \end{proof}
 
 \begin{definition}[Normal edge-blocking hypotheses]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1682,8 +1682,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{lemma}[Conditional injectivity of the normal \(R\) and \(S\) regions]%
     \label{lem:peps_normalSquareRegionRS_injective_of_unionClosure}
-    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionR_injective}
-    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionS_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionR_injective_of_union}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionS_injective_of_union}
     \leanok
     \uses{def:peps_regionInjectivityData,
         def:peps_normalRectangleInjectivityHypotheses,

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1686,7 +1686,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionS_injective}
     \leanok
     \uses{def:peps_regionInjectivityData,
-        lem:peps_squareLatticeRectangleInjectivity_rectangles,
+        def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_normalSquareRegionRS_rectangular_decomposition}
     If region injectivity is closed under unions, then the coordinate
     square-lattice rectangular injectivity hypotheses imply that the displayed

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -107,22 +107,26 @@ $R$ is the union of one contiguous $2\times3$ rectangle and one contiguous
 $3\times2$ rectangle, while $S$ is the union of two contiguous $2\times3$
 rectangles. Their coordinate definitions have been checked against the source
 statement that they differ in one site: $R$ is contained in $S$, and
-$S\setminus R$ is the lower-right site of the displayed $3\times3$ square. The
-displayed region $T$ is now present as the complement, inside the source
-$5\times6$ local window, of the two edge blocks shown in the source picture;
-the two removed edge blocks are now formalized separately as one contiguous
-$2\times3$ rectangle and one contiguous $3\times2$ rectangle. They are
-disjoint from each other, and the three-part cover by $T$ and the two removed
-blocks reconstructs the local window. This does not yet prove injectivity of
-$R$, $S$, or $T$.
+$S\setminus R$ is the lower-right site of the displayed $3\times3$ square.
+Assuming the union-closure assertion supplied by the source lemma on unions of
+injective regions, these rectangular decompositions now give conditional
+injectivity proofs for $R$ and $S$. The displayed region $T$ is now present as
+the complement, inside the source $5\times6$ local window, of the two edge
+blocks shown in the source picture; the two removed edge blocks are now
+formalized separately as one contiguous $2\times3$ rectangle and one contiguous
+$3\times2$ rectangle. They are disjoint from each other, and the three-part
+cover by $T$ and the two removed blocks reconstructs the local window. This
+does not yet prove unconditional injectivity of $R$, $S$, or injectivity of
+$T$.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
 closed, and the rectangular decompositions of $R$ and $S$ are formalized. The
-remaining open gap is the source-paper injectivity argument: prove the
-appropriate coordinate covering argument for $T$ that supports repeated use of
-the union theorem, and then prove the injectivity of $R$, $S$, and $T$ from
-that theorem.
+conditional derivations of injectivity for $R$ and $S$ from union closure are
+also formalized. The remaining open gap is the source-paper injectivity
+argument: prove the tensor-level union theorem, prove the appropriate
+coordinate covering argument for $T$ that supports repeated use of that theorem,
+and then prove the unconditional injectivity of $R$, $S$, and $T$.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -153,7 +157,10 @@ alone. The following additional obligations remain.
           $5\times6$ local window, and the two removed edge blocks have the
           displayed rectangular shapes. The local-window complement identity for
           $T$ is also formalized, including the three-part cover by $T$ and the
-          two removed blocks. The union lemma is then used repeatedly.
+          two removed blocks. The conditional derivations of injectivity for
+          $R$ and $S$ from a union-closure hypothesis are formalized. The union
+          lemma is then used repeatedly, and the remaining coordinate step is
+          the corresponding source-faithful derivation for $T$.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.


### PR DESCRIPTION
### Motivation

This PR continues the normal PEPS square-lattice route in arXiv:1804.04964, Section 3, lines 1322--1430. The source first states the union-of-injective-regions lemma and then uses it to conclude that the displayed regions R and S are injective from their decompositions into 2\times3 and 3\times2 rectangles.

The tensor-level union theorem is still future work, so this PR records its conclusion as an explicit union-closure hypothesis and proves the R/S consequences conditionally. It does not claim injectivity of T.

### Description

- `TNLean/PEPS/InjectiveRegion.lean` adds `RegionInjectivityUnionClosure`, the abstract union-closure assertion supplied by the source lemma `lem:injective_union`.
- `TNLean/PEPS/NormalBlocking.lean` adds rectangular injectivity consequences for bounded coordinate rectangles and proves `regionR_injective_of_union` and `regionS_injective_of_union` under the union-closure hypothesis.
- Chapter 13a and `docs/paper-gaps/peps_normal_ft_section3_route.tex` are updated to record that R/S injectivity is now formalized conditionally, while the tensor-level union theorem and T derivation remain open.

### Testing

- `lake build TNLean.PEPS.NormalBlocking`
- `lake build TNLean`
- `git diff --check`
- `awk 'length($0) > 100 { print FILENAME ":" FNR ":" length($0) }' TNLean/PEPS/InjectiveRegion.lean TNLean/PEPS/NormalBlocking.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_normal_ft_section3_route.tex`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/PEPS/InjectiveRegion.lean TNLean/PEPS/NormalBlocking.lean`
- `cd docs/paper-gaps && pdflatex -interaction=nonstopmode peps_normal_ft_section3_route.tex`; grep only matched the package filename `fplots.errorbars.code.tex`.
- `cd blueprint && leanblueprint web && leanblueprint checkdecls`; after regenerating the web artifacts, checkdecls reports only existing future declarations, not the new names in this PR.

Refs #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation scaffolding with no runtime, auth, or data paths; proofs are conditional on an explicit hypothesis and do not change existing assumed fields in blocking structures.
> 
> **Overview**
> This PR advances the normal PEPS square-lattice formalization by **recording union closure as an explicit hypothesis** and **proving injectivity of the displayed regions \(R\) and \(S\) conditionally**, without yet formalizing the tensor-level union lemma or \(T\).
> 
> **Lean:** `RegionInjectivityUnionClosure` captures the conclusion of the source union-of-injective-regions lemma so coordinate arguments can cite it later. `rect23_injective` / `rect32_injective` package bounded contiguous \(2\times3\) and \(3\times2\) rectangles under the existing rectangular hypotheses. `regionR_injective_of_union` and `regionS_injective_of_union` combine the already-formalized rectangular decompositions of `normalSquareRegionR` / `normalSquareRegionS` with `union_injective`. The `NormalSquareBlockingRegions` docstring is revised to note that \(R\) and \(S\) now have conditional lemmas while the blocking bundle still assumes \(R\), \(S\), and \(T\) injectivity directly.
> 
> **Docs:** Chapter 13a and `peps_normal_ft_section3_route.tex` are updated to state that \(R\) and \(S\) injectivity is formalized **assuming** union closure; the tensor-level union theorem, unconditional injectivity, and \(T\) remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9b9b09c00aad2710202262b859d6587c6dde63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->