### PR TITLE
feat(PEPS): iterate region union injectivity

### DIFF
--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -60,6 +60,28 @@ structure RegionInjectivityUnionClosure (κ : RegionInjectivityData V) : Prop wh
   union_injective :
     ∀ {A B : Finset V}, κ.IsInjective A → κ.IsInjective B → κ.IsInjective (A ∪ B)
 
+/-- A nonempty finite union of injective regions is injective under union closure.
+
+This is the finite iteration of the source lemma used when the displayed
+regions \(R\), \(S\), and \(T\) are described as unions of smaller injective
+rectangles.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and the
+examples following it, lines 1322--1430 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem RegionInjectivityUnionClosure.biUnion_injective
+    {ι : Type*} {κ : RegionInjectivityData V} (hUnion : RegionInjectivityUnionClosure κ)
+    {s : Finset ι} (hs : s.Nonempty) (R : ι → Finset V)
+    (hR : ∀ i ∈ s, κ.IsInjective (R i)) :
+    κ.IsInjective (s.biUnion R) := by
+  classical
+  induction hs using Finset.Nonempty.cons_induction with
+  | singleton i =>
+      simpa using hR i (by simp)
+  | cons i s hi _ ih =>
+      rw [Finset.cons_eq_insert, Finset.biUnion_insert]
+      exact hUnion.union_injective (hR i (by simp)) (ih fun j hj => hR j (by simp [hj]))
+
 /-- The part of the left region outside the right region. -/
 def regionOnlyLeft (A B : Finset V) : Finset V :=
   A \ B

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1469,6 +1469,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
     the union of two injective regions is injective.
 \end{definition}
 
+\begin{lemma}[Finite unions of injective regions]%
+    \label{lem:peps_regionInjectivityUnionClosure_finite}
+    \lean{TNLean.PEPS.RegionInjectivityUnionClosure.biUnion_injective}
+    \leanok
+    \uses{def:peps_regionInjectivityData}
+    Under the union-closure hypothesis for region injectivity, any nonempty
+    finite union of injective finite regions is injective.
+\end{lemma}
+\begin{proof}\leanok
+    Induct on the nonempty finite indexing set.  The singleton case is the
+    given injectivity hypothesis, and the induction step is one application of
+    binary union closure.
+\end{proof}
+
 \begin{definition}[Complement of a finite region]%
     \label{def:peps_regionComplement}
     \lean{TNLean.PEPS.regionComplement}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -75,6 +75,8 @@ The present blueprint nodes are the following.
 \begin{itemize}
     \item \path{lem:peps_injectiveRegion_union} states the union-of-injective
           regions lemma. It is tracked by \ghissue{1374}.
+    \item \path{lem:peps_regionInjectivityUnionClosure_finite} records the
+          finite nonempty iteration of the binary union-closure assertion.
     \item \path{def:peps_normalSquareBlockingRegions} records the square-lattice
           regions $R$, $S$, and $T$. It is part of \ghissue{1375}.
     \item \path{thm:peps_normalEdgeBlockingToInjectiveChain} states that the
@@ -110,10 +112,13 @@ statement that they differ in one site: $R$ is contained in $S$, and
 $S\setminus R$ is the lower-right site of the displayed $3\times3$ square.
 Assuming the union-closure assertion supplied by the source lemma on unions of
 injective regions, these rectangular decompositions now give conditional
-injectivity proofs for $R$ and $S$. The displayed region $T$ is now present as
-the complement, inside the source $5\times6$ local window, of the two edge
-blocks shown in the source picture; the two removed edge blocks are now
-formalized separately as one contiguous $2\times3$ rectangle and one contiguous
+injectivity proofs for $R$ and $S$. The finite nonempty iteration of this
+union-closure assertion is also formalized, matching the paper's use of
+repeated unions of smaller injective rectangles after Lemma
+\path{injective_union}. The displayed region $T$ is now present as the
+complement, inside the source $5\times6$ local window, of the two edge blocks
+shown in the source picture; the two removed edge blocks are now formalized
+separately as one contiguous $2\times3$ rectangle and one contiguous
 $3\times2$ rectangle. They are disjoint from each other, and the three-part
 cover by $T$ and the two removed blocks reconstructs the local window. This
 does not yet prove unconditional injectivity of $R$, $S$, or injectivity of
@@ -158,9 +163,10 @@ alone. The following additional obligations remain.
           displayed rectangular shapes. The local-window complement identity for
           $T$ is also formalized, including the three-part cover by $T$ and the
           two removed blocks. The conditional derivations of injectivity for
-          $R$ and $S$ from a union-closure hypothesis are formalized. The union
-          lemma is then used repeatedly, and the remaining coordinate step is
-          the corresponding source-faithful derivation for $T$.
+          $R$ and $S$ from a union-closure hypothesis are formalized. The
+          nonempty finite iteration of union closure is now formalized. The
+          remaining coordinate step is the corresponding source-faithful
+          derivation for $T$.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.
@@ -180,6 +186,8 @@ alone. The following additional obligations remain.
 \begin{itemize}
     \item Lemma \path{injective_union}: blueprint
           \path{lem:peps_injectiveRegion_union}, issue \#1374.
+    \item Finite iteration of Lemma \path{injective_union}: blueprint
+          \path{lem:peps_regionInjectivityUnionClosure_finite}, issue \#1374.
     \item Regions $R$, $S$, and $T$: blueprint
           \path{def:peps_normalSquareBlockingRegions}, issue \#1375.
     \item Edge blocking into red, blue, and complementary injective regions:


### PR DESCRIPTION
### Motivation
- Formalize the finite-union injectivity consequence of the two-region union closure (arXiv:1804.04964, Section 3, Lemma `injective_union` and the following examples; `Papers/1804.04964/paper_normal.tex`, lines 1322--1430).
- The source examples after Lemma `injective_union` use repeated unions of smaller injective regions to obtain larger injective regions such as R, S, and T.
- This is a preparatory step for #1374; it does not claim the tensor-level proof of `lem:peps_injectiveRegion_union`.

### Description
- `TNLean/PEPS/InjectiveRegion.lean`: adds the nonempty finite-union consequence of `RegionInjectivityUnionClosure`, derived by iterating the two-region case.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: records `lem:peps_regionInjectivityUnionClosure_finite` with `\lean{}` and `\leanok` tags.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: updates the paper-gap ledger to distinguish this iteration result from the tensor-level union proof.

### Testing
- `lake env lean TNLean/PEPS/InjectiveRegion.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build`
- `git diff --check`
- `cd docs/paper-gaps && pdflatex -interaction=nonstopmode peps_normal_ft_section3_route.tex`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls` reports only existing future declarations; `TNLean.PEPS.RegionInjectivityUnionClosure.biUnion_injective` is present in `blueprint/lean_decls`.

---
Refs #1374