### PR TITLE
feat(PEPS): prove normal T edge blocks injective

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -761,6 +761,30 @@ theorem rect32_injective
   h.threeByTwo_injective _
     (isThreeByTwoContiguousSquareLatticeRectangle_of_bounds hx hy)
 
+/-- The vertical edge block removed from the displayed \(T\)-region is injective
+under the square-lattice rectangular injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1405--1444
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem tVerticalBlock_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 5 ≤ width) (hy : yStart + 5 ≤ height) :
+    κ.IsInjective (normalSquareRegionTVerticalBlock xStart yStart) :=
+  h.twoByThree_injective _
+    (normalSquareRegionTVerticalBlock_rectangular hx hy)
+
+/-- The horizontal edge block removed from the displayed \(T\)-region is
+injective under the square-lattice rectangular injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1405--1444
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem tHorizontalBlock_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 5 ≤ width) (hy : yStart + 5 ≤ height) :
+    κ.IsInjective (normalSquareRegionTHorizontalBlock xStart yStart) :=
+  h.threeByTwo_injective _
+    (normalSquareRegionTHorizontalBlock_rectangular hx hy)
+
 /-- Region \(R\) is injective once rectangular injectivity is combined with
 the union-closure assertion from the source injective-union lemma.
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1694,6 +1694,22 @@ injective and normal PEPS, following Theorems~2 and~3 of
     coordinate witnesses for the two rectangle shapes.
 \end{proof}
 
+\begin{lemma}[Rectangular injectivity gives injective \(T\)-edge blocks]%
+    \label{lem:peps_normalSquareRegionT_edgeBlocks_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.tVerticalBlock_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.tHorizontalBlock_injective}
+    \leanok
+    \uses{def:peps_normalRectangleInjectivityHypotheses,
+        lem:peps_normalSquareRegionTHole_rectangular_decomposition}
+    Under the coordinate square-lattice rectangular injectivity hypotheses, the
+    vertical \(2\times3\) block and horizontal \(3\times2\) block removed from
+    the displayed \(T\)-window are injective.
+\end{lemma}
+\begin{proof}\leanok
+    Apply the rectangular injectivity hypotheses to the already identified
+    contiguous rectangle shapes of the two edge blocks.
+\end{proof}
+
 \begin{lemma}[Conditional injectivity of the normal \(R\) and \(S\) regions]%
     \label{lem:peps_normalSquareRegionRS_injective_of_unionClosure}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionR_injective_of_union}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1701,9 +1701,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_normalSquareRegionTHole_rectangular_decomposition}
-    Under the coordinate square-lattice rectangular injectivity hypotheses, the
-    vertical \(2\times3\) block and horizontal \(3\times2\) block removed from
-    the displayed \(T\)-window are injective.
+    If the displayed \(T\)-window edge blocks lie inside the finite square
+    lattice, then the coordinate square-lattice rectangular injectivity
+    hypotheses imply that the vertical \(2\times3\) block and horizontal
+    \(3\times2\) block removed from the window are injective.
 \end{lemma}
 \begin{proof}\leanok
     Apply the rectangular injectivity hypotheses to the already identified

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -119,19 +119,22 @@ repeated unions of smaller injective rectangles after Lemma
 complement, inside the source $5\times6$ local window, of the two edge blocks
 shown in the source picture; the two removed edge blocks are now formalized
 separately as one contiguous $2\times3$ rectangle and one contiguous
-$3\times2$ rectangle. They are disjoint from each other, and the three-part
-cover by $T$ and the two removed blocks reconstructs the local window. This
-does not yet prove unconditional injectivity of $R$, $S$, or injectivity of
-$T$.
+$3\times2$ rectangle. Under the coordinate square-lattice rectangular
+injectivity hypotheses, these two edge blocks are now known to be injective.
+They are disjoint from each other, and the three-part cover by $T$ and the two
+removed blocks reconstructs the local window. This does not yet prove
+unconditional injectivity of $R$, $S$, or injectivity of $T$.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
 closed, and the rectangular decompositions of $R$ and $S$ are formalized. The
 conditional derivations of injectivity for $R$ and $S$ from union closure are
-also formalized. The remaining open gap is the source-paper injectivity
-argument: prove the tensor-level union theorem, prove the appropriate
-coordinate covering argument for $T$ that supports repeated use of that theorem,
-and then prove the unconditional injectivity of $R$, $S$, and $T$.
+also formalized, and the two edge blocks removed from the displayed $T$-window
+are injective under the coordinate rectangular hypotheses. The remaining open
+gap is the source-paper injectivity argument: prove the tensor-level union
+theorem, prove the appropriate coordinate covering argument for $T$ that
+supports repeated use of that theorem, and then prove the unconditional
+injectivity of $R$, $S$, and $T$.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -165,8 +168,9 @@ alone. The following additional obligations remain.
           two removed blocks. The conditional derivations of injectivity for
           $R$ and $S$ from a union-closure hypothesis are formalized. The
           nonempty finite iteration of union closure is now formalized. The
-          remaining coordinate step is the corresponding source-faithful
-          derivation for $T$.
+          two edge blocks removed from the $T$-window are now injective under
+          rectangular injectivity. The remaining coordinate step is the
+          corresponding source-faithful derivation for $T$.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.
@@ -190,6 +194,10 @@ alone. The following additional obligations remain.
           \path{lem:peps_regionInjectivityUnionClosure_finite}, issue \#1374.
     \item Regions $R$, $S$, and $T$: blueprint
           \path{def:peps_normalSquareBlockingRegions}, issue \#1375.
+    \item Injectivity of the two edge blocks removed from the displayed
+          $T$-window: blueprint
+          \path{lem:peps_normalSquareRegionT_edgeBlocks_injective}, issue
+          \#2004.
     \item Edge blocking into red, blue, and complementary injective regions:
           blueprint \path{thm:peps_normalEdgeBlockingToInjectiveChain}, issue \#1375.
     \item Application of Lemma \path{inj_isomorph} after normal blocking:


### PR DESCRIPTION
### Motivation
- arXiv:1804.04964, Section 3, proof of Theorem 3, assumes every contiguous 2×3 and 3×2 rectangular block is injective.
- The displayed T-window contains two named edge blocks: one vertical 2×3 block and one horizontal 3×2 block. Their rectangular shapes were already formalized, but their injectivity had not yet been recorded as named consequences.
- Source: `Papers/1804.04964/paper_normal.tex`, lines 1405--1444.

### Description
- `TNLean/PEPS/NormalBlocking.lean`: adds `tVerticalBlock_injective` and `tHorizontalBlock_injective`, proving the two removed T-window edge blocks injective under the coordinate rectangular injectivity hypotheses.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds `lem:peps_normalSquareRegionT_edgeBlocks_injective` with `\lean{}` and `\leanok` tags.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: records that these two edge-block injectivity facts are proved, while injectivity of T itself remains open.

### Testing
- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake build`
- `git diff --check`
- `cd docs/paper-gaps && pdflatex -interaction=nonstopmode peps_normal_ft_section3_route.tex`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls` reports only existing future declarations; the two new T-edge-block injectivity declarations are present in `blueprint/lean_decls`.

---
Refs #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, proof-by-existing-decomposition additions plus documentation; no auth, runtime, or broad API changes.
> 
> **Overview**
> This PR records **injectivity of the two edge blocks** cut out of the displayed normal square-lattice \(T\)-window, under the existing coordinate **\(2\times3\) / \(3\times2\)** rectangular injectivity hypotheses.
> 
> In **`TNLean/PEPS/NormalBlocking.lean`**, it adds **`tVerticalBlock_injective`** and **`tHorizontalBlock_injective`**: each applies the corresponding rectangular hypothesis to the already-proved contiguous-rectangle witnesses for **`normalSquareRegionTVerticalBlock`** and **`normalSquareRegionTHorizontalBlock`** (same pattern as **`rect23_injective`** / **`rect32_injective`**).
> 
> The **blueprint** gains **`lem:peps_normalSquareRegionT_edgeBlocks_injective`** with `\leanok` links to those declarations. **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** is updated to mark this sub-step done; **unconditional injectivity of \(T\)** (and the full union/covering argument) remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52c3a565d4ed9b01c9592d54524cd4cf9db6192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->