### PR TITLE
feat(MPS/MPDO): expose BNT witness source equations

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -559,6 +559,124 @@ def toTheoremData :
       W.labelFintype W.operatorAddCommMonoid W.operatorModule W.operatorMul :=
   W.theoremData
 
+/-- The BNT-label coefficient system carried by an existential witness. -/
+def coeffs : BNTLabelCoefficientFamily W.Label := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.theoremData.coeffs
+
+/-- The same-length BNT operator family carried by an existential witness. -/
+def operators : BNTLabelOperatorFamily W.Label W.OperatorSpace := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.theoremData.operators
+
+/-- The BNT-label trace scalars carried by an existential witness. -/
+def traceScalars : BNTLabelTraceScalarFamily W.Label := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.theoremData.traceScalars
+
+/-- The positive BNT-label chi witness carried by an existential witness. -/
+def positiveChi : PositiveBNTLabelChiTracePowerForm W.coeffs := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.theoremData.positiveChi
+
+/-- The BNT-label coefficients carried by an existential witness are traces of
+powers of the length-independent chi matrices.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem coeff_eq_trace_pow (L : ℕ) (hL : 0 < L) (α β γ : W.Label) :
+    W.coeffs.coeff L α β γ =
+      (W.positiveChi.chi.matrix α β γ ^ L).trace := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.toTheoremData.coeff_eq_trace_pow L hL α β γ
+
+/-- The same-length BNT product equation carried by an existential witness.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem same_length_product_eq_sum (L : ℕ) (hL : 0 < L) (α β : W.Label) :
+    letI := W.labelFintype
+    letI := W.operatorAddCommMonoid L
+    letI := W.operatorModule L
+    letI := W.operatorMul L
+    W.operators.operator L α * W.operators.operator L β =
+      ∑ γ : W.Label, W.coeffs.coeff L α β γ • W.operators.operator L γ := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.toTheoremData.same_length_product_eq_sum L hL α β
+
+/-- The idempotent scalar equation carried by an existential witness.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), idempotent, lines 981--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem idempotent_eq_sum (γ : W.Label) :
+    W.traceScalars.traceScalar γ =
+      (@Finset.univ W.Label W.labelFintype).sum fun α ↦
+        (@Finset.univ W.Label W.labelFintype).sum fun β ↦
+          W.coeffs.coeff 1 α β γ *
+            (W.traceScalars.traceScalar α *
+              W.traceScalars.traceScalar β) := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.toTheoremData.idempotent_eq_sum γ
+
+/-- The BNT product expansion carried by an existential witness, with
+coefficients written as traces of the length-independent chi matrices.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem same_length_product_eq_sum_chi_trace_pow
+    (L : ℕ) (hL : 0 < L) (α β : W.Label) :
+    letI := W.labelFintype
+    letI := W.operatorAddCommMonoid L
+    letI := W.operatorModule L
+    letI := W.operatorMul L
+    W.operators.operator L α * W.operators.operator L β =
+      ∑ γ : W.Label, (W.positiveChi.chi.matrix α β γ ^ L).trace •
+        W.operators.operator L γ := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.toTheoremData.same_length_product_eq_sum_chi_trace_pow L hL α β
+
+/-- The idempotent scalar identity carried by an existential witness, with
+length-one coefficients written as traces of the chi matrices.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 981--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem idempotent_eq_sum_chi_trace (γ : W.Label) :
+    W.traceScalars.traceScalar γ =
+      (@Finset.univ W.Label W.labelFintype).sum fun α ↦
+        (@Finset.univ W.Label W.labelFintype).sum fun β ↦
+          (W.positiveChi.chi.matrix α β γ).trace *
+            (W.traceScalars.traceScalar α *
+              W.traceScalars.traceScalar β) := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.toTheoremData.idempotent_eq_sum_chi_trace γ
+
 /-- An existential BNT-label theorem witness gives a positive blocked
 trace-power witness for the chosen algebra-structure data. -/
 def toPositiveBlockedStructureChiTracePowerForm :

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -627,12 +627,12 @@ theorem same_length_product_eq_sum (L : ℕ) (hL : 0 < L) (α β : W.Label) :
 Source: arXiv:1606.00608, Theorem IV.13(ii), idempotent, lines 981--985 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem idempotent_eq_sum (γ : W.Label) :
+    letI := W.labelFintype
     W.traceScalars.traceScalar γ =
-      (@Finset.univ W.Label W.labelFintype).sum fun α ↦
-        (@Finset.univ W.Label W.labelFintype).sum fun β ↦
-          W.coeffs.coeff 1 α β γ *
-            (W.traceScalars.traceScalar α *
-              W.traceScalars.traceScalar β) := by
+      ∑ α : W.Label, ∑ β : W.Label,
+        W.coeffs.coeff 1 α β γ *
+          (W.traceScalars.traceScalar α *
+            W.traceScalars.traceScalar β) := by
   letI := W.labelFintype
   letI := W.operatorAddCommMonoid
   letI := W.operatorModule
@@ -665,12 +665,12 @@ length-one coefficients written as traces of the chi matrices.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 981--985 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem idempotent_eq_sum_chi_trace (γ : W.Label) :
+    letI := W.labelFintype
     W.traceScalars.traceScalar γ =
-      (@Finset.univ W.Label W.labelFintype).sum fun α ↦
-        (@Finset.univ W.Label W.labelFintype).sum fun β ↦
-          (W.positiveChi.chi.matrix α β γ).trace *
-            (W.traceScalars.traceScalar α *
-              W.traceScalars.traceScalar β) := by
+      ∑ α : W.Label, ∑ β : W.Label,
+        (W.positiveChi.chi.matrix α β γ).trace *
+          (W.traceScalars.traceScalar α *
+            W.traceScalars.traceScalar β) := by
   letI := W.labelFintype
   letI := W.operatorAddCommMonoid
   letI := W.operatorModule

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1775,9 +1775,11 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum_chi_trace_pow}
-    An existential BNT-label theorem witness gives the same-length product
-    identity with the coefficients written as traces of powers of the
-    $\chi$-matrices, for every positive length $L$.
+    An existential BNT-label theorem witness gives, for every positive length
+    $L$, the identity
+    $O_L(M_\alpha)O_L(M_\beta)
+      = \sum_\gamma
+        \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L}) O_L(M_\gamma)$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -1790,8 +1792,10 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_idempotent_eq_sum_chi_trace}
     An existential BNT-label theorem witness gives the idempotent scalar
-    identity with the length-one coefficients written as traces of the
-    $\chi$-matrices.
+    identity
+    $m_\gamma =
+      \sum_{\alpha,\beta}
+        \operatorname{tr}(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1731,9 +1731,9 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_coeff_eq_trace_pow}
     An existential BNT-label theorem witness gives the formula
-    \(c_{\alpha,\beta,\gamma}^{(L)}
-      = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})\)
-    for every positive length \(L\).
+    $c_{\alpha,\beta,\gamma}^{(L)}
+      = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})$
+    for every positive length $L$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -1746,9 +1746,9 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum}
     An existential BNT-label theorem witness gives the product identity
-    \(O_L(M_\alpha)O_L(M_\beta)
-      = \sum_\gamma c_{\alpha,\beta,\gamma}^{(L)} O_L(M_\gamma)\)
-    for every positive length \(L\).
+    $O_L(M_\alpha)O_L(M_\beta)
+      = \sum_\gamma c_{\alpha,\beta,\gamma}^{(L)} O_L(M_\gamma)$
+    for every positive length $L$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -1762,8 +1762,8 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_data_idempotent_eq_sum}
     An existential BNT-label theorem witness gives the idempotent scalar
     identity
-    \(m_\gamma =
-      \sum_{\alpha,\beta} c_{\alpha,\beta,\gamma}^{(1)}m_\alpha m_\beta\).
+    $m_\gamma =
+      \sum_{\alpha,\beta} c_{\alpha,\beta,\gamma}^{(1)}m_\alpha m_\beta$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -1777,7 +1777,7 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum_chi_trace_pow}
     An existential BNT-label theorem witness gives the same-length product
     identity with the coefficients written as traces of powers of the
-    \(\chi\)-matrices.
+    $\chi$-matrices, for every positive length $L$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -1791,7 +1791,7 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_data_idempotent_eq_sum_chi_trace}
     An existential BNT-label theorem witness gives the idempotent scalar
     identity with the length-one coefficients written as traces of the
-    \(\chi\)-matrices.
+    $\chi$-matrices.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1712,6 +1712,10 @@ the elementary trace-power identity for diagonal matrices.
 \begin{definition}[Existential BNT-label theorem witness]%
     \label{def:mpdo_bnt_label_theorem_witness}
     \lean{MPOTensor.BNTLabelTheoremWitness}
+    \lean{MPOTensor.BNTLabelTheoremWitness.coeffs}
+    \lean{MPOTensor.BNTLabelTheoremWitness.operators}
+    \lean{MPOTensor.BNTLabelTheoremWitness.traceScalars}
+    \lean{MPOTensor.BNTLabelTheoremWitness.positiveChi}
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data}
     An existential BNT-label theorem witness consists of the finite BNT-label
@@ -1719,6 +1723,79 @@ the elementary trace-power identity for diagonal matrices.
     corresponding BNT-label theorem data.  The construction of such a witness
     from an MPDO tensor is the outstanding step toward Theorem~IV.13(ii).
 \end{definition}
+
+\begin{theorem}[BNT theorem witnesses give coefficient trace powers]%
+    \label{thm:mpdo_bnt_label_theorem_witness_coeff_eq_trace_pow}
+    \lean{MPOTensor.BNTLabelTheoremWitness.coeff_eq_trace_pow}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_data_coeff_eq_trace_pow}
+    An existential BNT-label theorem witness gives the formula
+    \(c_{\alpha,\beta,\gamma}^{(L)}
+      = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})\)
+    for every positive length \(L\).
+\end{theorem}
+\begin{proof}\leanok
+    Apply the corresponding theorem-data identity carried by the witness.
+\end{proof}
+
+\begin{theorem}[BNT theorem witnesses give the same-length product law]%
+    \label{thm:mpdo_bnt_label_theorem_witness_same_length_product_eq_sum}
+    \lean{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum}
+    An existential BNT-label theorem witness gives the product identity
+    \(O_L(M_\alpha)O_L(M_\beta)
+      = \sum_\gamma c_{\alpha,\beta,\gamma}^{(L)} O_L(M_\gamma)\)
+    for every positive length \(L\).
+\end{theorem}
+\begin{proof}\leanok
+    Apply the corresponding theorem-data identity carried by the witness.
+\end{proof}
+
+\begin{theorem}[BNT theorem witnesses give the idempotent scalar law]%
+    \label{thm:mpdo_bnt_label_theorem_witness_idempotent_eq_sum}
+    \lean{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_data_idempotent_eq_sum}
+    An existential BNT-label theorem witness gives the idempotent scalar
+    identity
+    \(m_\gamma =
+      \sum_{\alpha,\beta} c_{\alpha,\beta,\gamma}^{(1)}m_\alpha m_\beta\).
+\end{theorem}
+\begin{proof}\leanok
+    Apply the corresponding theorem-data identity carried by the witness.
+\end{proof}
+
+\begin{theorem}[BNT theorem witnesses give the chi-trace product law]%
+    \label{thm:mpdo_bnt_label_theorem_witness_same_length_product_eq_sum_chi_trace_pow}
+    \lean{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum_chi_trace_pow}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum_chi_trace_pow}
+    An existential BNT-label theorem witness gives the same-length product
+    identity with the coefficients written as traces of powers of the
+    \(\chi\)-matrices.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the corresponding theorem-data identity carried by the witness.
+\end{proof}
+
+\begin{theorem}[BNT theorem witnesses give the chi-trace idempotent law]%
+    \label{thm:mpdo_bnt_label_theorem_witness_idempotent_eq_sum_chi_trace}
+    \lean{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_chi_trace}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_data_idempotent_eq_sum_chi_trace}
+    An existential BNT-label theorem witness gives the idempotent scalar
+    identity with the length-one coefficients written as traces of the
+    \(\chi\)-matrices.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the corresponding theorem-data identity carried by the witness.
+\end{proof}
 
 \begin{theorem}[BNT theorem witnesses give positive blocked \(\chi\) witnesses]%
     \label{thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -195,9 +195,20 @@ consequences.\footnote{%
 The same data can be stated in the existential form closest to the paper: one
 object records the BNT-label type, the same-length operator spaces, their
 algebraic structure, and the corresponding theorem data.\footnote{%
-\leanid{MPOTensor.BNTLabelTheoremWitness}.}  Such a witness immediately gives
-the positive blocked-basis \(\chi\)-witness for the chosen algebra-structure
-data.\footnote{%
+\leanid{MPOTensor.BNTLabelTheoremWitness},
+\leanid{MPOTensor.BNTLabelTheoremWitness.coeffs},
+\leanid{MPOTensor.BNTLabelTheoremWitness.operators},
+\leanid{MPOTensor.BNTLabelTheoremWitness.traceScalars},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveChi}.}  Such a witness
+immediately gives the coefficient trace-power formula, the same-length product
+law, the idempotent scalar law, the same-length chi-trace product law, the
+chi-trace idempotent law, and the positive blocked-basis \(\chi\)-witness for
+the chosen algebra-structure data.\footnote{%
+\leanid{MPOTensor.BNTLabelTheoremWitness.coeff_eq_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum_chi_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_chi_trace},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
 toPositiveBlockedStructureChiTracePowerForm}.}  The remaining step is still the
 construction of this existential witness from the MPDO tensor.


### PR DESCRIPTION
### Motivation

- `MPOTensor.BNTLabelTheoremWitness` carries a `BNTLabelTheoremData` value. This PR makes the coefficient family, same-length operators, trace scalars, and chi witness directly available from the witness.
- CPGSV17a, Theorem IV.13(ii) (`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 972--985) states the coefficient trace-power formula, the same-length product law, and the idempotent scalar law at the level of such an existential witness.

### Description

- `TNLean/MPS/MPDO/BNTCoefficients.lean` adds accessor projections `coeffs`, `operators`, `traceScalars`, and `positiveChi` to `MPOTensor.BNTLabelTheoremWitness`, together with witness-level theorems for the coefficient trace-power formula, the same-length product law, the idempotent scalar law, and the corresponding chi-trace rewritings.
- `blueprint/src/chapter/ch02b_mpdo.tex` records the new witness-level source equations and links the Lean declarations.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` records that the witness now immediately yields these identities. The remaining mathematical task is still to construct such a witness from an MPDO tensor.
- `leanblueprint checkdecls` reports no missing declarations for the new `MPOTensor.BNTLabelTheoremWitness.*` names; the remaining missing declarations are pre-existing blueprint entries.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/MPDO/BNTCoefficients.lean || true`
- Line-length check: `awk 'length($0) > 100 {print FILENAME ":" FNR ":" length($0) ":" $0}' TNLean/MPS/MPDO/BNTCoefficients.lean blueprint/src/chapter/ch02b_mpdo.tex docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`
- `git diff --check`
- `leanblueprint web`
- `lake build`

### Notes

- A standalone `pdflatex` run on `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` still fails on the existing undefined `\leanid` macro.

---
Refs #2000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin forwarding proofs and documentation only; no auth, runtime, or construction-from-tensor logic added.
> 
> **Overview**
> **`MPOTensor.BNTLabelTheoremWitness`** now exposes **`coeffs`**, **`operators`**, **`traceScalars`**, and **`positiveChi`** directly from its embedded theorem data, plus witness-level theorems for Theorem IV.13(ii): coefficient trace powers, same-length product law, idempotent scalars, and the corresponding **χ**-trace rewrites—all proved by forwarding to existing **`BNTLabelTheoremData`** results.
> 
> The blueprint (**`ch02b_mpdo.tex`**) and the paper-gap note (**`cpgsv17_blocked_chi_uniformity.tex`**) document these accessors and immediate consequences; building the witness from an MPDO tensor remains the open step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef0560203a834b4434a699cfe80ddb730890e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->