### PR TITLE
doc(PEPS): state T-window bounds in blueprint

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1701,12 +1701,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_normalSquareRegionTHole_rectangular_decomposition}
-    If the displayed $5\times5$ coordinate $T$-window lies inside the finite
-    square lattice, equivalently if the offsets satisfy
-    $x_0 + 5 \leq \mathit{width}$ and $y_0 + 5 \leq \mathit{height}$, then the
-    coordinate square-lattice rectangular injectivity hypotheses imply that the
-    vertical $2\times3$ block and horizontal $3\times2$ block removed from the
-    window are injective.
+    For the displayed $T$-region inside its local $5\times6$ coordinate window,
+    if the smaller edge-block bounds
+    $x_0 + 5 \leq \mathit{width}$ and $y_0 + 5 \leq \mathit{height}$ hold, then
+    the coordinate square-lattice rectangular injectivity hypotheses imply that
+    the vertical $2\times3$ block and horizontal $3\times2$ block removed from
+    the window are injective.
 \end{lemma}
 \begin{proof}\leanok
     Apply the rectangular injectivity hypotheses to the already identified

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1703,10 +1703,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareRegionTHole_rectangular_decomposition}
     For the displayed $T$-region inside its local $5\times6$ coordinate window,
     if the smaller edge-block bounds
-    $x_0 + 5 \leq \mathit{width}$ and $y_0 + 5 \leq \mathit{height}$ hold, then
-    the coordinate square-lattice rectangular injectivity hypotheses imply that
-    the vertical $2\times3$ block and horizontal $3\times2$ block removed from
-    the window are injective.
+    $x_0 + 5 \leq n$ and $y_0 + 5 \leq m$ hold in the finite $n\times m$
+    square lattice, then the coordinate square-lattice rectangular injectivity
+    hypotheses imply that the vertical $2\times3$ block and horizontal
+    $3\times2$ block removed from the window are injective.
 \end{lemma}
 \begin{proof}\leanok
     Apply the rectangular injectivity hypotheses to the already identified

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1701,10 +1701,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_normalSquareRegionTHole_rectangular_decomposition}
-    If the displayed \(T\)-window edge blocks lie inside the finite square
-    lattice, then the coordinate square-lattice rectangular injectivity
-    hypotheses imply that the vertical \(2\times3\) block and horizontal
-    \(3\times2\) block removed from the window are injective.
+    If the displayed $5\times5$ coordinate $T$-window lies inside the finite
+    square lattice, equivalently if the offsets satisfy
+    $x_0 + 5 \leq \mathit{width}$ and $y_0 + 5 \leq \mathit{height}$, then the
+    coordinate square-lattice rectangular injectivity hypotheses imply that the
+    vertical $2\times3$ block and horizontal $3\times2$ block removed from the
+    window are injective.
 \end{lemma}
 \begin{proof}\leanok
     Apply the rectangular injectivity hypotheses to the already identified


### PR DESCRIPTION
### Motivation

- The blueprint lemma `lem:peps_normalSquareRegionT_edgeBlocks_injective` linked to Lean theorems with explicit finite-window bounds but did not state those bounds in the prose.
- MGRPG+18, proof of Theorem 3 (`Papers/1804.04964/paper_normal.tex`, lines 1405--1444), places the displayed `T`-region in a local $5\times6$ coordinate window.

### Description

- States that the displayed `T`-region belongs to its local $5\times6$ coordinate window.
- Adds the smaller edge-block bounds $x_0 + 5 \leq n$ and $y_0 + 5 \leq m$ in the finite $n\times m$ square lattice, matching the hypotheses of `tVerticalBlock_injective` and `tHorizontalBlock_injective`.
- Leaves the existing `\lean{...}` links and `\leanok` tags unchanged.

### Testing

- `awk 'length($0) > 100 {print FILENAME ":" FNR ":" length($0) ":" $0}' blueprint/src/chapter/ch13a_peps_ft.tex`
- `git diff --check`
- `leanblueprint web`

---
Closes #2055
Refs #1373
