### PR TITLE
feat(PEPS): derive T-hole injectivity conditionally

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -785,6 +785,22 @@ theorem tHorizontalBlock_injective
   h.threeByTwo_injective _
     (normalSquareRegionTHorizontalBlock_rectangular hx hy)
 
+/-- The union of the two edge blocks removed from the displayed \(T\)-region is
+injective once rectangular injectivity is combined with the union-closure
+assertion from the source injective-union lemma.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
+Theorem 3, lines 1322--1444 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem tHole_injective_of_union
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart : ℕ} (hx : xStart + 5 ≤ width) (hy : yStart + 5 ≤ height) :
+    κ.IsInjective (normalSquareRegionTHole xStart yStart) := by
+  unfold normalSquareRegionTHole
+  exact hUnion.union_injective
+    (h.tVerticalBlock_injective hx hy)
+    (h.tHorizontalBlock_injective hx hy)
+
 /-- Region \(R\) is injective once rectangular injectivity is combined with
 the union-closure assertion from the source injective-union lemma.
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1698,19 +1698,24 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \label{lem:peps_normalSquareRegionT_edgeBlocks_injective}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.tVerticalBlock_injective}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.tHorizontalBlock_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.tHole_injective_of_union}
     \leanok
-    \uses{def:peps_normalRectangleInjectivityHypotheses,
+    \uses{def:peps_regionInjectivityData,
+        def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_normalSquareRegionTHole_rectangular_decomposition}
     For the displayed $T$-region inside its local $5\times6$ coordinate window,
     if the smaller edge-block bounds
     $x_0 + 5 \leq n$ and $y_0 + 5 \leq m$ hold in the finite $n\times m$
     square lattice, then the coordinate square-lattice rectangular injectivity
     hypotheses imply that the vertical $2\times3$ block and horizontal
-    $3\times2$ block removed from the window are injective.
+    $3\times2$ block removed from the window are injective.  If, in addition,
+    region injectivity is closed under unions, then the union of these two
+    removed edge blocks is injective.
 \end{lemma}
 \begin{proof}\leanok
     Apply the rectangular injectivity hypotheses to the already identified
-    contiguous rectangle shapes of the two edge blocks.
+    contiguous rectangle shapes of the two edge blocks.  The final assertion is
+    one application of union closure to these two injective blocks.
 \end{proof}
 
 \begin{lemma}[Conditional injectivity of the normal \(R\) and \(S\) regions]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -169,8 +169,9 @@ alone. The following additional obligations remain.
           $R$ and $S$ from a union-closure hypothesis are formalized. The
           nonempty finite iteration of union closure is now formalized. The
           two edge blocks removed from the $T$-window are now injective under
-          rectangular injectivity. The remaining coordinate step is the
-          corresponding source-faithful derivation for $T$.
+          rectangular injectivity, and their union is injective under the
+          source union-closure hypothesis. The remaining coordinate step is
+          the corresponding source-faithful derivation for $T$.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.
@@ -195,7 +196,7 @@ alone. The following additional obligations remain.
     \item Regions $R$, $S$, and $T$: blueprint
           \path{def:peps_normalSquareBlockingRegions}, issue \#1375.
     \item Injectivity of the two edge blocks removed from the displayed
-          $T$-window: blueprint
+          $T$-window, and of their union under union closure: blueprint
           \path{lem:peps_normalSquareRegionT_edgeBlocks_injective}, issue
           \#2004.
     \item Edge blocking into red, blue, and complementary injective regions:


### PR DESCRIPTION
### Motivation

- In arXiv:1804.04964, Section 3, Lemma `lem:injective_union` supplies closure of injectivity under unions for finite regions.
- In the proof of Theorem 3, local lines 1405--1444 identify the two edge blocks removed from the displayed T-window as rectangular injective regions.
- The next source-paper consequence is that the union of those two removed blocks is injective under the union-of-injective-regions lemma. This is still a preparatory step toward injectivity of the displayed region T itself.

### Description

- Adds `NormalSquareLatticeRectangleInjectivityHypotheses.tHole_injective_of_union`, proving injectivity of `normalSquareRegionTHole xStart yStart` from the two edge-block injectivity lemmas and `RegionInjectivityUnionClosure`.
- Updates Chapter 13a so `lem:peps_normalSquareRegionT_edgeBlocks_injective` records this union-closure consequence.
- Updates `docs/paper-gaps/peps_normal_ft_section3_route.tex` to state that the remaining coordinate step is still the source-faithful derivation of injectivity for T itself.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `awk "length($0) > 100 {print FILENAME ":" FNR ":" length($0) ":" $0}" TNLean/PEPS/NormalBlocking.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_normal_ft_section3_route.tex`
- `git diff --check`
- `leanblueprint web`
- `leanblueprint checkdecls` still reports pre-existing missing blueprint declarations, but not `TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.tHole_injective_of_union`.

---
Refs #2004
Refs #1373