### PR TITLE
feat(MPS/MPDO): expose BNT witness blocked comparison

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -591,6 +591,14 @@ def positiveChi : PositiveBNTLabelChiTracePowerForm W.coeffs := by
   letI := W.operatorMul
   exact W.theoremData.positiveChi
 
+/-- The blocked-basis comparison carried by an existential witness. -/
+def blockedComparison : BNTBlockedBasisCoefficientComparison data W.coeffs := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.theoremData.blockedComparison
+
 /-- The BNT-label coefficients carried by an existential witness are traces of
 powers of the length-independent chi matrices.
 
@@ -676,6 +684,27 @@ theorem idempotent_eq_sum_chi_trace (γ : W.Label) :
   letI := W.operatorModule
   letI := W.operatorMul
   exact W.toTheoremData.idempotent_eq_sum_chi_trace γ
+
+/-- The blocked-basis coefficients pulled back by an existential witness are
+traces of powers of the BNT-label chi matrices.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem blocked_coeff_eq_trace_pow
+    (n : ℕ) (hn : 0 < n)
+    (i j : AlgebraStructureData.BlockedIndex data n)
+    (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
+    data.blockedStructureCoefficients n i j k =
+      (W.positiveChi.chi.matrix
+        (W.blockedComparison.sourceLabel n hn i)
+        (W.blockedComparison.sourceLabel n hn j)
+        (W.blockedComparison.targetLabel n hn k) ^ n).trace := by
+  letI := W.labelFintype
+  letI := W.operatorAddCommMonoid
+  letI := W.operatorModule
+  letI := W.operatorMul
+  exact W.toTheoremData.blocked_coeff_eq_trace_pow n hn i j k
 
 /-- An existential BNT-label theorem witness gives a positive blocked
 trace-power witness for the chosen algebra-structure data. -/

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1716,6 +1716,7 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelTheoremWitness.operators}
     \lean{MPOTensor.BNTLabelTheoremWitness.traceScalars}
     \lean{MPOTensor.BNTLabelTheoremWitness.positiveChi}
+    \lean{MPOTensor.BNTLabelTheoremWitness.blockedComparison}
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data}
     An existential BNT-label theorem witness consists of the finite BNT-label
@@ -1796,6 +1797,20 @@ the elementary trace-power identity for diagonal matrices.
     $m_\gamma =
       \sum_{\alpha,\beta}
         \operatorname{tr}(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta$.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the corresponding theorem-data identity carried by the witness.
+\end{proof}
+
+\begin{theorem}[BNT theorem witnesses give blocked coefficient trace powers]%
+    \label{thm:mpdo_bnt_label_theorem_witness_blocked_coeff_eq_trace_pow}
+    \lean{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_trace_pow}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_data_blocked_coeff_eq_trace_pow}
+    An existential BNT-label theorem witness gives the blocked-basis
+    coefficient trace-power formula obtained by pulling the BNT-label
+    \(\chi\)-matrices back along the blocked-basis comparison maps.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -199,16 +199,19 @@ algebraic structure, and the corresponding theorem data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.coeffs},
 \leanid{MPOTensor.BNTLabelTheoremWitness.operators},
 \leanid{MPOTensor.BNTLabelTheoremWitness.traceScalars},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positiveChi}.}  Such a witness
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison}.}  Such a witness
 immediately gives the coefficient trace-power formula, the same-length product
 law, the idempotent scalar law, the same-length chi-trace product law, the
-chi-trace idempotent law, and the positive blocked-basis \(\chi\)-witness for
-the chosen algebra-structure data.\footnote{%
+chi-trace idempotent law, the blocked-basis coefficient trace-power formula,
+and the positive blocked-basis \(\chi\)-witness for the chosen
+algebra-structure data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum},
 \leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum},
 \leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum_chi_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_chi_trace},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
 toPositiveBlockedStructureChiTracePowerForm}.}  The remaining step is still the
 construction of this existential witness from the MPDO tensor.


### PR DESCRIPTION
### Motivation

- CPGSV17a Theorem IV.13(ii), local lines 972--985, gives the BNT-label coefficient trace-power formula and idempotent condition.
- Appendix C.3--C.4, local lines 1830--1942, supplies the BNT-label construction and the comparison data that should ultimately produce the existential witness from an MPDO tensor.
- `MPOTensor.BNTLabelTheoremWitness` already exposes most immediate source equations from its theorem-data record, but not the blocked-basis comparison or the corresponding blocked coefficient trace-power consequence.

### Description

- Adds `MPOTensor.BNTLabelTheoremWitness.blockedComparison`.
- Adds `MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_trace_pow`, delegating to the theorem-data record.
- Updates Chapter 2b and `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` so the witness surface and gap note mention these immediate consequences.

This is a projection/API step only. It does not construct the existential witness from an MPDO tensor, so #2000 remains open.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients` (passes; reports an existing long-line warning in `TNLean/Spectral/GaugeConstruction.lean`)
- `awk "length($0) > 100 {print FILENAME ":" FNR ":" length($0) ":" $0}" TNLean/MPS/MPDO/BNTCoefficients.lean blueprint/src/chapter/ch02b_mpdo.tex docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`
- `git diff --check`
- `leanblueprint web`
- `leanblueprint checkdecls` still reports pre-existing missing blueprint declarations, but not `MPOTensor.BNTLabelTheoremWitness.blockedComparison` or `MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_trace_pow`.

---
Refs #2000