### PR TITLE
doc(MPDO): fix BNT blueprint declaration links

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1293,8 +1293,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[BNT idempotent coefficient expansion]%
     \label{thm:mpdo_bnt_label_idempotent_coefficient_eq_sum}
-    \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.
-        eq_sum}
+    \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum}
     \leanok
     \uses{def:mpdo_bnt_label_idempotent_coefficient_form}
     Under BNT idempotent coefficient form, each \(m_\gamma\) is the
@@ -1358,8 +1357,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[BNT-label coefficient as a positive-length trace power]%
     \label{thm:mpdo_bnt_label_chi_eq_trace_matrix_pow}
-    \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.
-        eq_trace_matrix_pow}
+\lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.eq_trace_matrix_pow}
     \leanok
     \uses{def:mpdo_bnt_label_positive_length_chi_trace_power_form,
         thm:mpdo_trace_matrix_pow}
@@ -1403,8 +1401,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[Same-length BNT product with chi-trace coefficients]%
     \label{thm:mpdo_bnt_label_same_length_product_eq_sum_chi_trace_pow}
-    \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.
-        eq_sum_chi_trace_pow}
+    \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum_chi_trace_pow}
     \leanok
     \uses{thm:mpdo_bnt_label_same_length_product_eq_sum,
         thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
@@ -1426,8 +1423,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[BNT idempotent coefficients as chi traces]%
     \label{thm:mpdo_bnt_label_idempotent_eq_sum_chi_trace}
-    \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.
-        eq_sum_chi_trace}
+    \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum_chi_trace}
     \leanok
     \uses{thm:mpdo_bnt_label_idempotent_coefficient_eq_sum,
         thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
@@ -1553,8 +1549,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[BNT witnesses give blocked \(\chi\) witnesses]%
     \label{thm:mpdo_bnt_blocked_basis_to_positive_blocked_chi_trace_power_form}
-    \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.
-        toPositiveBlockedStructureChiTracePowerForm}
+\lean{MPOTensor.BNTBlockedBasisCoefficientComparison.toPositiveBlockedStructureChiTracePowerForm}
     \leanok
     \uses{def:mpdo_bnt_blocked_basis_coefficient_comparison,
         def:mpdo_positive_bnt_label_chi_trace_power_form,


### PR DESCRIPTION
### Motivation

- Chapter 2b contains several long MPDO BNT declaration tags for Theorem IV.13(ii) consequences.
- A few tags were split inside `\lean{...}` in a way that causes declaration extraction to insert a space into the Lean name.
- The affected statements are already formalized; this PR only makes the blueprint tags point at the existing declarations.

### Description

- Rewrites the affected `\lean{...}` tags in `blueprint/src/chapter/ch02b_mpdo.tex` so each declaration name is contiguous.
- Keeps the mathematical prose, theorem labels, and `\leanok` status unchanged.

### Testing

- `awk "length($0) > 100 {print FILENAME ":" FNR ":" length($0) ":" $0}" blueprint/src/chapter/ch02b_mpdo.tex`
- `git diff --check`
- `leanblueprint web`

Local note: `leanblueprint checkdecls` in this checkout still reads the ignored stale `blueprint/lean_decls` file, but the corrected source tags are now contiguous in `blueprint/src/chapter/ch02b_mpdo.tex` and should be regenerated cleanly by CI.

---
Refs #2000