### PR TITLE
doc(PEPS): clarify normal T complement status

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -320,9 +320,11 @@ theorem normalSquareRegionTHole_rectangular_decomposition {width height : ℕ}
 
 /-- The displayed region \(T\) in the normal square-lattice proof.
 
-The source picture describes \(T\) as the complement, inside a local
-\(5\times6\) coordinate window, of the two edge blocks recorded in
-`normalSquareRegionTHole`.
+This local coordinate model records the part of the source picture lying inside
+the displayed \(5\times6\) window: the window with the two edge blocks recorded
+in `normalSquareRegionTHole` removed.  The injective complementary block used
+later in the proof of Theorem 3 is a finite-lattice complement around an edge,
+not yet this local-window region by itself.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443
 of `Papers/1804.04964/paper_normal.tex`, where the text states that \(T\) is
@@ -852,13 +854,17 @@ Section 3, derives them from the \(2\times 3\) and \(3\times 2\) rectangular
 injectivity assumptions using the union-of-injective-regions lemma. The
 coordinate regions \(R\), \(S\), and \(T\) are now recorded separately, and
 \(R\) and \(S\) have conditional injectivity lemmas assuming union closure, but
-this abstract structure still assumes its three region fields directly. It does
-not yet identify them with translated coordinate regions or supply the per-edge
-red, blue, and complementary regions used in the proof of Theorem 3. Documented
-in `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Remaining mathematical
+the local-window \(T\) region still has no source-faithful injectivity
+derivation. In particular, the complementary region used as the third block in
+Theorem 3 is a finite-lattice complement around an edge, and this abstract
+structure still assumes its three region fields directly. It does not yet
+identify them with translated coordinate regions or supply the per-edge red,
+blue, and complementary regions used in the proof of Theorem 3. Documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Remaining mathematical
 obligations 1--5. Elimination: derive these assertions from rectangular
-injectivity after the tensor-level union theorem is formalized, then construct
-the translated edge blockings.
+injectivity after the tensor-level union theorem and the finite-lattice
+complement construction are formalized, then construct the translated edge
+blockings.
 
 Source: arXiv:1804.04964, Section 3, Theorem 3 and its proof, lines
 1407--1504 of `Papers/1804.04964/paper_normal.tex`. -/

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1522,9 +1522,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     extending one column to the right.  The displayed region \(S\) is the union
     of two \(2\times3\) contiguous rectangles shifted by one horizontal
     coordinate, hence the full \(3\times3\) square spanned by them.  The
-    displayed region \(T\) is the complement, inside a local \(5\times6\)
-    coordinate window, of the vertical \(2\times3\) edge block and the
-    horizontal \(3\times2\) edge block shown in the source picture.
+    displayed local-window model for \(T\) is the complement, inside a local
+    \(5\times6\) coordinate window, of the vertical \(2\times3\) edge block
+    and the horizontal \(3\times2\) edge block shown in the source picture.
+    % Maintainer note: the finite-lattice complementary block around the edge,
+    % which serves as the third injective region in
+    % \cite[Theorem~3]{Molnar2018NormalPEPS}, is not yet defined; this
+    % definition records only the local-window complement.
 \end{definition}
 
 \begin{lemma}[Basic identities for square-lattice coordinate regions]%
@@ -1551,10 +1555,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
     membership in the \(2\times3\) lower-left piece or in the shifted
     \(3\times2\) upper piece.  Membership in \(S\) is the disjunction of
     membership in the left \(2\times3\) piece or in the horizontally shifted
-    \(2\times3\) piece.  Membership in \(T\) is membership in the local
-    \(5\times6\) window together with nonmembership in the union of the two
-    displayed edge blocks.  Bounded contiguous coordinate rectangles of sizes
-    \(2\times3\) and \(3\times2\) satisfy, respectively, the predicates for
+    \(2\times3\) piece.  Membership in the local-window \(T\) region is
+    membership in the local \(5\times6\) window together with nonmembership in
+    the union of the two displayed edge blocks.  Bounded contiguous coordinate
+    rectangles of sizes \(2\times3\) and \(3\times2\) satisfy, respectively,
+    the predicates for
     contiguous \(2\times3\) and contiguous \(3\times2\) square-lattice
     rectangles.  The cardinality of a coordinate rectangle is the
     product of the two coordinate cardinalities, and the full coordinate
@@ -1607,7 +1612,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     with the coordinate bounds which make them valid contiguous rectangles.
 \end{proof}
 
-\begin{lemma}[The $T$-region and its removed edge blocks fill the local window]%
+\begin{lemma}[The local $T$-region and its removed edge blocks fill the window]%
     \label{lem:peps_normalSquareRegionT_window_complement}
     \lean{TNLean.PEPS.normalSquareRegionTHole_subset_window}
     \lean{TNLean.PEPS.normalSquareRegionTVerticalBlock_disjoint_horizontalBlock}
@@ -1619,9 +1624,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_squareLatticeCoordinateRegions,
         lem:peps_squareLatticeCoordinateRegion_identities}
-    The two edge blocks removed from the displayed $T$-region lie inside the
-    local $5\times6$ coordinate window.  They are disjoint from each other and
-    from $T$, and their union with $T$ is exactly that local window.
+    The two edge blocks removed from the displayed local $T$-region lie inside
+    the local $5\times6$ coordinate window.  They are disjoint from each other
+    and from this local $T$ region, and their union with it is exactly that
+    local window.
 \end{lemma}
 \begin{proof}\leanok
     This follows by unfolding the definition of $T$ as the set-theoretic
@@ -1703,7 +1709,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_regionInjectivityData,
         def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_normalSquareRegionTHole_rectangular_decomposition}
-    For the displayed $T$-region inside its local $5\times6$ coordinate window,
+    For the displayed local $T$-region inside its $5\times6$ coordinate window,
     if the smaller edge-block bounds
     $x_0 + 5 \leq n$ and $y_0 + 5 \leq m$ hold in the finite $n\times m$
     square lattice, then the coordinate square-lattice rectangular injectivity
@@ -1712,6 +1718,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     region injectivity is closed under unions, then the union of these two
     removed edge blocks is injective.
 \end{lemma}
+% Maintainer note: this does not prove injectivity of the finite-lattice
+% complementary block used as the third region in
+% \cite[Theorem~3]{Molnar2018NormalPEPS}; that region is not yet defined.
 \begin{proof}\leanok
     Apply the rectangular injectivity hypotheses to the already identified
     contiguous rectangle shapes of the two edge blocks.  The final assertion is

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -37,9 +37,12 @@ the remaining $A\cap B$ and $B\setminus A$ part.
 Second, for the translationally invariant square-lattice theorem, the paper
 assumes that every $2\times 3$ and $3\times 2$ region is injective. By
 repeatedly applying the union lemma, the regions denoted $R$, $S$, and $T$
-in the paper are injective. The regions $R$ and $S$ differ by one site,
-and their complements are injective when the system is large enough. These are
-the regions used in the last comparison step.
+in the paper are injective. The finite-lattice block denoted $A_3$ in the proof
+of Theorem~\path{3} has the same complementary shape as $T$ but lives in the
+full finite lattice around the chosen edge; the present coordinate definition
+records only the displayed local-window complement. The regions $R$ and $S$
+differ by one site, and their complements are injective when the system is
+large enough. These are the regions used in the last comparison step.
 \footnote{The regions $R$, $S$, and $T$ are drawn at
     \path{Papers/1804.04964/paper_normal.tex:1407--1443}.}
 
@@ -115,15 +118,18 @@ injective regions, these rectangular decompositions now give conditional
 injectivity proofs for $R$ and $S$. The finite nonempty iteration of this
 union-closure assertion is also formalized, matching the paper's use of
 repeated unions of smaller injective rectangles after Lemma
-\path{injective_union}. The displayed region $T$ is now present as the
-complement, inside the source $5\times6$ local window, of the two edge blocks
-shown in the source picture; the two removed edge blocks are now formalized
-separately as one contiguous $2\times3$ rectangle and one contiguous
-$3\times2$ rectangle. Under the coordinate square-lattice rectangular
-injectivity hypotheses, these two edge blocks are now known to be injective.
-They are disjoint from each other, and the three-part cover by $T$ and the two
-removed blocks reconstructs the local window. This does not yet prove
-unconditional injectivity of $R$, $S$, or injectivity of $T$.
+\path{injective_union}. The displayed local-window model for $T$ is now
+present as the complement, inside the source $5\times6$ local window, of the
+two edge blocks shown in the source picture; the two removed edge blocks are
+now formalized separately as one contiguous $2\times3$ rectangle and one
+contiguous $3\times2$ rectangle. Under the coordinate square-lattice
+rectangular injectivity hypotheses, these two edge blocks are now known to be
+injective. They are disjoint from each other, and the three-part cover by the
+local-window $T$ region and the two removed blocks reconstructs the local
+window. This local-window region should not be confused with the
+finite-lattice complementary block used later in the proof of
+Theorem~\path{3}. The latter still has to be defined and proved injective from
+rectangular injectivity and the union theorem.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
@@ -160,18 +166,19 @@ alone. The following additional obligations remain.
           under those hypotheses. The displayed regions $R$ and $S$ are now
           defined as unions of contiguous rectangles, with their rectangular
           decompositions and the expected one-site difference formalized. The
-          displayed region $T$ is now
-          defined as the complement of the two edge blocks in the source
-          $5\times6$ local window, and the two removed edge blocks have the
-          displayed rectangular shapes. The local-window complement identity for
-          $T$ is also formalized, including the three-part cover by $T$ and the
-          two removed blocks. The conditional derivations of injectivity for
-          $R$ and $S$ from a union-closure hypothesis are formalized. The
+          displayed local-window model for $T$ is now defined as the complement
+          of the two edge blocks in the source $5\times6$ local window, and
+          the two removed edge blocks have the displayed rectangular shapes.
+          The local-window complement identity for this $T$ region is also
+          formalized, including the three-part cover by $T$ and the two removed
+          blocks. The conditional derivations of injectivity for $R$ and $S$
+          from a union-closure hypothesis are formalized. The
           nonempty finite iteration of union closure is now formalized. The
           two edge blocks removed from the $T$-window are now injective under
           rectangular injectivity, and their union is injective under the
-          source union-closure hypothesis. The remaining coordinate step is
-          the corresponding source-faithful derivation for $T$.
+          source union-closure hypothesis. The remaining coordinate step is to
+          construct the finite-lattice complementary region around an edge and
+          prove its source-faithful injectivity.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.


### PR DESCRIPTION
### Motivation

- The current PEPS normal route has a local coordinate model for the displayed region `T` from arXiv:1804.04964, Section 3.
- Rereading the source around lines 1430--1499 shows that the finite-lattice block denoted A_3 in the proof of Theorem 3 has the same complementary shape as T but lives in the full lattice around the chosen edge; the current formal `normalSquareRegionT` records only the local-window complement of the two displayed edge blocks.
- The documentation should keep these two regions distinct before any future injectivity claim is made.

### Description

- Clarifies the `normalSquareRegionT` docstring and the `NormalSquareBlockingRegions` scope restriction.
- Updates Chapter 13a to describe the current `T` geometry as a local-window model, not the finite-lattice complementary block used in Theorem 3.
- Updates `docs/paper-gaps/peps_normal_ft_section3_route.tex` so the remaining obligation is the finite-lattice complementary region and its source-faithful injectivity proof.

No Lean declarations, theorem statements, or `\leanok` statuses are changed.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `git diff --check`
- `awk 'length($0) > 100 {print FILENAME ":" FNR ":" length($0) ":" $0}' TNLean/PEPS/NormalBlocking.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_normal_ft_section3_route.tex`
- `cd blueprint && leanblueprint web`

---
Refs #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint/gap-doc edits only; no Lean definitions, theorems, or proof status changes.
> 
> **Overview**
> Documentation-only clarification for the normal square-lattice **T** geometry: **`normalSquareRegionT`** is the **local 5×6 window** minus the two displayed edge blocks, **not** the **finite-lattice complement around an edge** (**A₃**) used as the third injective block in Theorem 3.
> 
> Lean updates the **`normalSquareRegionT`** docstring and **`NormalSquareBlockingRegions`** scope note so **R/S** conditional injectivity is unchanged but **local-window T** still lacks a source-faithful injectivity proof; the open work is framed as **union theorem + finite-lattice complement construction**, then edge blockings. Chapter 13a and **`peps_normal_ft_section3_route.tex`** use the same **local-window vs edge-complement** distinction and retarget the remaining obligation to defining and proving injectivity for the **edge complementary region**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79fb9a8b74b9572526b925d41a6f913e2815b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

