### PR TITLE
feat(PEPS): name normal edge complement region

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -334,6 +334,19 @@ def normalSquareRegionT {width height : ℕ} (xStart yStart : ℕ) :
   squareLatticeContiguousRectangle xStart yStart 5 6 \
     normalSquareRegionTHole xStart yStart
 
+/-- The finite-lattice complementary block around the edge in the normal
+square-lattice proof.
+
+This is the full finite square lattice with the two displayed edge blocks
+removed.  In the proof of Theorem 3 it is the region denoted \(A_3\), the
+third block after the red and blue edge blocks.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499
+of `Papers/1804.04964/paper_normal.tex`. -/
+def normalSquareEdgeComplementRegion {width height : ℕ} (xStart yStart : ℕ) :
+    Finset (SquareLatticeVertex width height) :=
+  regionComplement (normalSquareRegionTHole xStart yStart)
+
 @[simp] theorem mem_normalSquareRegionR {width height : ℕ}
     (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
     v ∈ normalSquareRegionR xStart yStart ↔
@@ -382,6 +395,12 @@ def normalSquareRegionT {width height : ℕ} (xStart yStart : ℕ) :
         yStart ≤ v.2.1 ∧ v.2.1 < yStart + 6 ∧
           v ∉ normalSquareRegionTHole xStart yStart := by
   simp [normalSquareRegionT, and_assoc]
+
+@[simp] theorem mem_normalSquareEdgeComplementRegion {width height : ℕ}
+    (xStart yStart : ℕ) (v : SquareLatticeVertex width height) :
+    v ∈ normalSquareEdgeComplementRegion xStart yStart ↔
+      v ∉ normalSquareRegionTHole xStart yStart := by
+  simp [normalSquareEdgeComplementRegion]
 
 /-- The two edge blocks removed from the displayed \(T\)-region lie inside the
 local \(5\times6\) coordinate window.
@@ -487,6 +506,62 @@ theorem normalSquareRegionT_union_verticalBlock_union_horizontalBlock {width hei
         Finset (SquareLatticeVertex width height)) := by
   rw [Finset.union_assoc]
   simpa [normalSquareRegionTHole] using normalSquareRegionT_union_THole xStart yStart
+
+/-- The local-window \(T\)-region is contained in the finite-lattice
+complementary block around the edge.
+
+Source: arXiv:1804.04964, Section 3, lines 1430--1499 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareRegionT_subset_edgeComplementRegion {width height : ℕ}
+    (xStart yStart : ℕ) :
+    normalSquareRegionT xStart yStart ⊆
+      (normalSquareEdgeComplementRegion xStart yStart :
+        Finset (SquareLatticeVertex width height)) := by
+  intro v hv
+  rw [mem_normalSquareRegionT] at hv
+  rw [mem_normalSquareEdgeComplementRegion]
+  exact hv.2.2.2.2
+
+/-- The finite-lattice complementary block is disjoint from the two edge blocks
+removed around the edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareEdgeComplementRegion_disjoint_THole {width height : ℕ}
+    (xStart yStart : ℕ) :
+    Disjoint
+      (normalSquareEdgeComplementRegion xStart yStart :
+        Finset (SquareLatticeVertex width height))
+      (normalSquareRegionTHole xStart yStart) := by
+  unfold normalSquareEdgeComplementRegion regionComplement
+  exact disjoint_sdiff_self_left
+
+/-- The finite-lattice complementary block and the two edge blocks reconstruct
+the full square lattice.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareEdgeComplementRegion_union_THole {width height : ℕ}
+    (xStart yStart : ℕ) :
+    normalSquareEdgeComplementRegion xStart yStart ∪ normalSquareRegionTHole xStart yStart =
+      (Finset.univ : Finset (SquareLatticeVertex width height)) := by
+  unfold normalSquareEdgeComplementRegion regionComplement
+  exact Finset.sdiff_union_of_subset (Finset.subset_univ _)
+
+/-- The finite-lattice complementary block together with the vertical and
+horizontal edge blocks reconstructs the full square lattice.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareEdgeComplementRegion_union_verticalBlock_union_horizontalBlock
+    {width height : ℕ} (xStart yStart : ℕ) :
+    normalSquareEdgeComplementRegion xStart yStart ∪
+        normalSquareRegionTVerticalBlock xStart yStart ∪
+          normalSquareRegionTHorizontalBlock xStart yStart =
+      (Finset.univ : Finset (SquareLatticeVertex width height)) := by
+  rw [Finset.union_assoc]
+  simpa [normalSquareRegionTHole] using
+    normalSquareEdgeComplementRegion_union_THole xStart yStart
 
 /-- The displayed region \(R\) is contained in the displayed region \(S\).
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1508,6 +1508,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.normalSquareRegionTHorizontalBlock}
     \lean{TNLean.PEPS.normalSquareRegionTHole}
     \lean{TNLean.PEPS.normalSquareRegionT}
+    \lean{TNLean.PEPS.normalSquareEdgeComplementRegion}
     \leanok
     The finite $n\times m$ square lattice is represented by pairs of
     coordinates.  A coordinate rectangle is a product of a horizontal
@@ -1525,10 +1526,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
     displayed local-window model for \(T\) is the complement, inside a local
     \(5\times6\) coordinate window, of the vertical \(2\times3\) edge block
     and the horizontal \(3\times2\) edge block shown in the source picture.
-    % Maintainer note: the finite-lattice complementary block around the edge,
-    % which serves as the third injective region in
-    % \cite[Theorem~3]{Molnar2018NormalPEPS}, is not yet defined; this
-    % definition records only the local-window complement.
+    The finite-lattice complementary block is the whole finite square lattice
+    with those two edge blocks removed; this is the block denoted \(A_3\) in
+    the proof of \cite[Theorem~3]{Molnar2018NormalPEPS}.
+    % Maintainer note: injectivity of this finite-lattice complementary block
+    % is not yet proved; this definition only names the region.
 \end{definition}
 
 \begin{lemma}[Basic identities for square-lattice coordinate regions]%
@@ -1542,6 +1544,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.mem_normalSquareRegionTHorizontalBlock}
     \lean{TNLean.PEPS.mem_normalSquareRegionTHole}
     \lean{TNLean.PEPS.mem_normalSquareRegionT}
+    \lean{TNLean.PEPS.mem_normalSquareEdgeComplementRegion}
     \lean{TNLean.PEPS.isTwoByThreeContiguousSquareLatticeRectangle_of_bounds}
     \lean{TNLean.PEPS.isThreeByTwoContiguousSquareLatticeRectangle_of_bounds}
     \lean{TNLean.PEPS.card_squareLatticeRectangle}
@@ -1634,6 +1637,27 @@ injective and normal PEPS, following Theorems~2 and~3 of
     complement of the two displayed edge blocks inside the local window.
 \end{proof}
 
+\begin{lemma}[The edge-complementary block fills the finite lattice]%
+    \label{lem:peps_normalSquareEdgeComplementRegion}
+    \lean{TNLean.PEPS.normalSquareRegionT_subset_edgeComplementRegion}
+    \lean{TNLean.PEPS.normalSquareEdgeComplementRegion_disjoint_THole}
+    \lean{TNLean.PEPS.normalSquareEdgeComplementRegion_union_THole}
+    \lean{TNLean.PEPS.normalSquareEdgeComplementRegion_union_verticalBlock_union_horizontalBlock}
+    \leanok
+    \uses{def:peps_squareLatticeCoordinateRegions,
+        lem:peps_squareLatticeCoordinateRegion_identities}
+    The finite-lattice complementary block around the edge is disjoint from
+    the two displayed edge blocks, and its union with them is the full finite
+    square lattice.  The local-window \(T\) region is contained in this
+    finite-lattice complementary block.
+\end{lemma}
+\begin{proof}\leanok
+    This is the set-theoretic complement of the two displayed edge blocks in
+    the full finite square lattice.  The containment of the local-window
+    \(T\) region follows because its points also avoid the two removed edge
+    blocks.
+\end{proof}
+
 \begin{lemma}[The normal regions \(R\) and \(S\) differ in one site]%
     \label{lem:peps_normalSquareRegionR_regionS_difference}
     \lean{TNLean.PEPS.normalSquareRegionR_subset_regionS}
@@ -1720,7 +1744,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{lemma}
 % Maintainer note: this does not prove injectivity of the finite-lattice
 % complementary block used as the third region in
-% \cite[Theorem~3]{Molnar2018NormalPEPS}; that region is not yet defined.
+% \cite[Theorem~3]{Molnar2018NormalPEPS}.
 \begin{proof}\leanok
     Apply the rectangular injectivity hypotheses to the already identified
     contiguous rectangle shapes of the two edge blocks.  The final assertion is

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -128,19 +128,23 @@ injective. They are disjoint from each other, and the three-part cover by the
 local-window $T$ region and the two removed blocks reconstructs the local
 window. This local-window region should not be confused with the
 finite-lattice complementary block used later in the proof of
-Theorem~\path{3}. The latter still has to be defined and proved injective from
-rectangular injectivity and the union theorem.
+Theorem~\path{3}. The finite-lattice complementary block is now named as the
+complement of the two edge blocks in the full square lattice, and its
+elementary disjointness and cover identities are formalized. Its injectivity
+from rectangular injectivity and the union theorem remains open.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
 closed, and the rectangular decompositions of $R$ and $S$ are formalized. The
 conditional derivations of injectivity for $R$ and $S$ from union closure are
 also formalized, and the two edge blocks removed from the displayed $T$-window
-are injective under the coordinate rectangular hypotheses. The remaining open
-gap is the source-paper injectivity argument: prove the tensor-level union
-theorem, prove the appropriate coordinate covering argument for $T$ that
-supports repeated use of that theorem, and then prove the unconditional
-injectivity of $R$, $S$, and $T$.
+are injective under the coordinate rectangular hypotheses. The finite-lattice
+complementary block around the chosen edge is now defined set-theoretically.
+The remaining open gap is the source-paper injectivity argument: prove the
+tensor-level union theorem, prove the appropriate coordinate covering argument
+for this finite-lattice complement that supports repeated use of that theorem,
+and then prove the unconditional injectivity of $R$, $S$, and the
+edge-complementary block.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -176,9 +180,10 @@ alone. The following additional obligations remain.
           nonempty finite iteration of union closure is now formalized. The
           two edge blocks removed from the $T$-window are now injective under
           rectangular injectivity, and their union is injective under the
-          source union-closure hypothesis. The remaining coordinate step is to
-          construct the finite-lattice complementary region around an edge and
-          prove its source-faithful injectivity.
+          source union-closure hypothesis. The finite-lattice complementary
+          region around an edge is now defined, and its elementary complement
+          identities are formalized. The remaining coordinate step is to prove
+          its source-faithful injectivity.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.
@@ -206,6 +211,8 @@ alone. The following additional obligations remain.
           $T$-window, and of their union under union closure: blueprint
           \path{lem:peps_normalSquareRegionT_edgeBlocks_injective}, issue
           \#2004.
+    \item Finite-lattice complementary block around an edge: blueprint
+          \path{lem:peps_normalSquareEdgeComplementRegion}, issue \#2004.
     \item Edge blocking into red, blue, and complementary injective regions:
           blueprint \path{thm:peps_normalEdgeBlockingToInjectiveChain}, issue \#1375.
     \item Application of Lemma \path{inj_isomorph} after normal blocking:


### PR DESCRIPTION
### Motivation

- The source proof of Theorem 3 uses a third edge-centered block, denoted $A_3$, which is the full finite square lattice with the red and blue edge blocks removed.
- PR #2061 clarified that the existing `normalSquareRegionT` is only the displayed local-window complement.
- The next source-faithful step is to name the finite-lattice complementary block and record its elementary set identities before proving injectivity.

### Description

- Adds `normalSquareEdgeComplementRegion`, the finite-lattice complement of `normalSquareRegionTHole`.
- Proves membership, disjointness, full-lattice cover, and containment of the local-window $T$ region in this finite complement.
- Updates Chapter 13a and `docs/paper-gaps/peps_normal_ft_section3_route.tex` to mark the region as defined while leaving its injectivity proof open.

This does not prove injectivity of the finite-lattice complement.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `printf 'import TNLean\n#check TNLean.PEPS.normalSquareEdgeComplementRegion\n#check TNLean.PEPS.mem_normalSquareEdgeComplementRegion\n#check TNLean.PEPS.normalSquareRegionT_subset_edgeComplementRegion\n' | lake env lean --stdin`
- `git diff --check`
- `awk 'length($0) > 100 {print FILENAME ":" FNR ":" length($0) ":" $0}' TNLean/PEPS/NormalBlocking.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_normal_ft_section3_route.tex`
- `cd blueprint && leanblueprint web`

Local note: `cd blueprint && leanblueprint checkdecls` still fails on existing unrelated missing blueprint declarations, but after building `TNLean.PEPS.NormalBlocking` the new edge-complement declarations are visible from `import TNLean` and are not among the missing names.

---
Refs #2004

> [!NOTE]
> **Low Risk**
> Documentation and coordinate-region definitions with standard finset proofs; no auth, runtime, or injectivity logic changes.
>
> **Overview**
> Introduces **`normalSquareEdgeComplementRegion`**, the full finite square lattice minus the two displayed edge blocks (`normalSquareRegionTHole`), matching source block \(A_3\) in Theorem 3. Adds a membership characterization and finset lemmas: the local-window **`normalSquareRegionT`** lies inside this complement; the complement is disjoint from the hole and unions with the hole (or with the vertical and horizontal blocks) to recover **`Finset.univ`**.
>
> Blueprint Chapter 13a and **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** now treat this region as defined and document the new lemma, while **injectivity of the finite-lattice complement** is still explicitly open.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2e84d63c959c61432b46782b50aca25f908cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
