### PR TITLE
feat(PEPS): add edge complement cover criterion

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -365,6 +365,7 @@ import TNLean.PEPS.VirtualInsertion
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.EdgeMiddlePhysical
 import TNLean.PEPS.NormalBlocking
+import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.InsertionRealization
 import TNLean.PEPS.LocalGauge

--- a/TNLean/PEPS/NormalEdgeComplementCover.lean
+++ b/TNLean/PEPS/NormalEdgeComplementCover.lean
@@ -1,0 +1,77 @@
+import TNLean.PEPS.NormalBlocking
+
+/-!
+# Rectangular covers of the normal PEPS edge complement
+
+This file records the conditional cover step for the finite-lattice
+edge-complementary block \(A_3\) in the square-lattice normal PEPS proof.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, Lemma `lem:injective_union` and Theorem 3]
+-/
+
+namespace TNLean
+namespace PEPS
+
+/-- A finite rectangular cover of the edge-complementary block \(A_3\).
+
+Each member of the cover is required to be one of the source-paper contiguous
+\(2\times3\) or \(3\times2\) rectangles. The existence of such a cover is the
+remaining coordinate assertion needed before the union-of-injective-regions
+lemma can prove injectivity of the finite-lattice complementary block.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499
+of `Papers/1804.04964/paper_normal.tex`. -/
+structure NormalSquareEdgeComplementRectangleCover {width height : ℕ}
+    (xStart yStart : ℕ) where
+  /-- The finite index set labelling the rectangular pieces. -/
+  Index : Type*
+  /-- The finite family of pieces used in the cover. -/
+  regions : Finset Index
+  /-- The cover is nonempty, so finite union closure applies. -/
+  nonempty : regions.Nonempty
+  /-- The rectangular piece indexed by `i`. -/
+  region : Index → Finset (SquareLatticeVertex width height)
+  /-- Every piece is one of the two rectangular shapes assumed injective. -/
+  rectangular :
+    ∀ i ∈ regions,
+      IsTwoByThreeContiguousSquareLatticeRectangle (region i) ∨
+        IsThreeByTwoContiguousSquareLatticeRectangle (region i)
+  /-- The rectangular pieces cover exactly the edge-complementary block. -/
+  cover : regions.biUnion region = normalSquareEdgeComplementRegion xStart yStart
+
+namespace NormalSquareLatticeRectangleInjectivityHypotheses
+
+variable {width height : ℕ}
+variable {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+
+/-- The finite-lattice edge-complementary block is injective once it is covered
+by source-paper \(2\times3\) and \(3\times2\) rectangles.
+
+This is the formal conditional step for the block denoted \(A_3\) in the proof
+of Theorem 3. It does not construct the cover; it states that rectangular
+injectivity plus the union-of-injective-regions lemma proves injectivity after
+the coordinate cover is supplied.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
+Theorem 3, lines 1322--1499 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeComplement_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart : ℕ}
+    (cover : NormalSquareEdgeComplementRectangleCover (width := width) (height := height)
+      xStart yStart) :
+    κ.IsInjective (normalSquareEdgeComplementRegion xStart yStart) := by
+  rw [← cover.cover]
+  exact hUnion.biUnion_injective cover.nonempty cover.region fun i hi ↦ by
+    rcases cover.rectangular i hi with hRect | hRect
+    · exact h.twoByThree_injective _ hRect
+    · exact h.threeByTwo_injective _ hRect
+
+end NormalSquareLatticeRectangleInjectivityHypotheses
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1658,6 +1658,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
     blocks.
 \end{proof}
 
+\begin{definition}[Rectangular covers of the edge-complementary block]%
+    \label{def:peps_normalSquareEdgeComplementRectangleCover}
+    \lean{TNLean.PEPS.NormalSquareEdgeComplementRectangleCover}
+    \leanok
+    \uses{def:peps_squareLatticeCoordinateRegions,
+        lem:peps_normalSquareEdgeComplementRegion}
+    A rectangular cover of the finite-lattice complementary block \(A_3\) is a
+    nonempty finite family of regions whose union is exactly \(A_3\), and each
+    member of the family is a contiguous \(2\times3\) or \(3\times2\)
+    rectangle.
+\end{definition}
+% Maintainer note: this definition records the coordinate assertion still
+% needed for the source proof.  It does not construct such a cover.
+
 \begin{lemma}[The normal regions \(R\) and \(S\) differ in one site]%
     \label{lem:peps_normalSquareRegionR_regionS_difference}
     \lean{TNLean.PEPS.normalSquareRegionR_subset_regionS}
@@ -1749,6 +1763,25 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Apply the rectangular injectivity hypotheses to the already identified
     contiguous rectangle shapes of the two edge blocks.  The final assertion is
     one application of union closure to these two injective blocks.
+\end{proof}
+
+\begin{lemma}[Injectivity from a rectangular cover of the edge complement]%
+    \label{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective}
+    \leanok
+    \uses{def:peps_normalSquareEdgeComplementRectangleCover,
+        def:peps_normalRectangleInjectivityHypotheses,
+        lem:peps_regionInjectivityUnionClosure_finite}
+    If the finite-lattice complementary block \(A_3\) has a nonempty finite
+    cover by contiguous \(2\times3\) and \(3\times2\) rectangles, then
+    rectangular injectivity and finite union closure imply that \(A_3\) is
+    injective.
+\end{lemma}
+% Maintainer note: the concrete cover required by
+% \cite[Theorem~3]{Molnar2018NormalPEPS} remains to be constructed.
+\begin{proof}\leanok
+    Apply rectangular injectivity to every rectangle in the cover, then apply
+    finite union closure to the nonempty family.
 \end{proof}
 
 \begin{lemma}[Conditional injectivity of the normal \(R\) and \(S\) regions]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -130,8 +130,12 @@ window. This local-window region should not be confused with the
 finite-lattice complementary block used later in the proof of
 Theorem~\path{3}. The finite-lattice complementary block is now named as the
 complement of the two edge blocks in the full square lattice, and its
-elementary disjointness and cover identities are formalized. Its injectivity
-from rectangular injectivity and the union theorem remains open.
+elementary disjointness and cover identities are formalized. A rectangular
+cover witness for this complementary block is also present: if such a cover by
+contiguous $2\times3$ and $3\times2$ rectangles is supplied, then rectangular
+injectivity and finite union closure imply injectivity of the complementary
+block. The concrete coordinate cover required by the source proof remains
+open.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
@@ -141,10 +145,9 @@ also formalized, and the two edge blocks removed from the displayed $T$-window
 are injective under the coordinate rectangular hypotheses. The finite-lattice
 complementary block around the chosen edge is now defined set-theoretically.
 The remaining open gap is the source-paper injectivity argument: prove the
-tensor-level union theorem, prove the appropriate coordinate covering argument
-for this finite-lattice complement that supports repeated use of that theorem,
-and then prove the unconditional injectivity of $R$, $S$, and the
-edge-complementary block.
+tensor-level union theorem, construct the coordinate cover of this
+finite-lattice complement by contiguous source rectangles, and then prove the
+unconditional injectivity of $R$, $S$, and the edge-complementary block.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -182,8 +185,10 @@ alone. The following additional obligations remain.
           rectangular injectivity, and their union is injective under the
           source union-closure hypothesis. The finite-lattice complementary
           region around an edge is now defined, and its elementary complement
-          identities are formalized. The remaining coordinate step is to prove
-          its source-faithful injectivity.
+          identities are formalized. A cover witness now records the exact
+          remaining coordinate assertion: once this block is covered by
+          contiguous source rectangles, finite union closure gives its
+          injectivity. The concrete cover remains to be constructed.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.
@@ -213,6 +218,9 @@ alone. The following additional obligations remain.
           \#2004.
     \item Finite-lattice complementary block around an edge: blueprint
           \path{lem:peps_normalSquareEdgeComplementRegion}, issue \#2004.
+    \item Rectangular-cover criterion for injectivity of that block: blueprint
+          \path{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover},
+          issue \#2004.
     \item Edge blocking into red, blue, and complementary injective regions:
           blueprint \path{thm:peps_normalEdgeBlockingToInjectiveChain}, issue \#1375.
     \item Application of Lemma \path{inj_isomorph} after normal blocking:


### PR DESCRIPTION
## Mathematical statement

For the finite-lattice complementary block \(A_3\) used in the proof of Theorem 3, this PR introduces a rectangular cover witness: a nonempty finite family of contiguous \(2\times3\) and \(3\times2\) regions whose union is the edge-complementary block. It proves the conditional consequence that such a cover, together with coordinate rectangular injectivity and finite union closure, implies injectivity of \(A_3\).

This does not construct the concrete cover and does not claim the source theorem's injectivity statement is complete.

## Source

arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of Theorem 3, local lines 1322--1499 of `Papers/1804.04964/paper_normal.tex`.

## Changes

- Adds `TNLean.PEPS.NormalEdgeComplementCover` for the cover witness and criterion.
- Adds `NormalSquareEdgeComplementRectangleCover`.
- Adds `NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective`.
- Imports the new module from `TNLean.lean` so blueprint declarations are visible.
- Updates Chapter 13a and `docs/paper-gaps/peps_normal_ft_section3_route.tex` to record that the concrete coordinate cover remains open.

## Checks

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake build TNLean.PEPS.NormalBlocking`
- `lake env lean TNLean/PEPS/NormalEdgeComplementCover.lean`
- `lake build TNLean.PEPS.NormalEdgeComplementCover`
- `lake build TNLean` (passes with existing unrelated warnings)
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- line-length check on touched files
- `leanblueprint web`
- `leanblueprint checkdecls` (fails only on pre-existing missing declarations; the new cover names are not listed)

Refs #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and exploratory Lean scaffolding only; no changes to authentication, runtime behavior, or proved unconditional theorems.
> 
> **Overview**
> This PR formalizes the **conditional** step for injectivity of the finite-lattice edge-complementary block \(A_3\) in the normal square-lattice PEPS route (arXiv:1804.04964, Theorem 3).
> 
> It introduces **`NormalSquareEdgeComplementRectangleCover`**, a witness for a nonempty finite cover of `normalSquareEdgeComplementRegion` whose pieces are contiguous \(2\times3\) or \(3\times2\) rectangles. **`edgeComplement_injective`** then shows that coordinate rectangular injectivity plus **`RegionInjectivityUnionClosure`** implies injectivity of \(A_3\) by rewriting to the cover’s `biUnion` and applying the same finite-union pattern already used for \(R\), \(S\), and the \(T\)-window edge blocks. The PR does **not** construct the source-paper coordinate cover.
> 
> The root import, blueprint (`ch13a_peps_ft.tex`), and **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** are updated so the remaining obligation is stated explicitly: prove the tensor-level union lemma, **build** the concrete rectangular cover, then obtain unconditional injectivity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea116762c5351db2307d58497132e5589a122c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->