### PR TITLE
feat(PEPS): decompose edge complement collar

### DIFF
--- a/TNLean/PEPS/NormalEdgeComplementCover.lean
+++ b/TNLean/PEPS/NormalEdgeComplementCover.lean
@@ -19,9 +19,9 @@ namespace PEPS
 /-- A finite rectangular cover of the edge-complementary block \(A_3\).
 
 Each member of the cover is required to be one of the source-paper contiguous
-\(2\times3\) or \(3\times2\) rectangles. The existence of such a cover is the
-remaining coordinate assertion needed before the union-of-injective-regions
-lemma can prove injectivity of the finite-lattice complementary block.
+\(2\times3\) or \(3\times2\) rectangles. Such a cover is a sufficient
+coordinate condition for the union-of-injective-regions lemma to prove
+injectivity of the finite-lattice complementary block.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499
 of `Papers/1804.04964/paper_normal.tex`. -/
@@ -42,6 +42,26 @@ structure NormalSquareEdgeComplementRectangleCover {width height : ℕ}
         IsThreeByTwoContiguousSquareLatticeRectangle (region i)
   /-- The rectangular pieces cover exactly the edge-complementary block. -/
   cover : regions.biUnion region = normalSquareEdgeComplementRegion xStart yStart
+
+/-- In the normalized horizontal-edge \(5\times7\) frame, the finite-lattice
+edge-complementary block is the local \(T\)-region together with two top-collar
+contiguous \(3\times2\) rectangles.
+
+This is the concrete set identity behind the passage from the local \(T\)
+picture to the \(A_3\) block in the proof of Theorem 3.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1499
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareEdgeComplementRegion_eq_T_union_topCollar :
+    (normalSquareEdgeComplementRegion (width := 5) (height := 7) 0 0) =
+      (normalSquareRegionT (width := 5) (height := 7) 0 0) ∪
+        squareLatticeContiguousRectangle 0 5 3 2 ∪
+          (squareLatticeContiguousRectangle 2 5 3 2 :
+            Finset (SquareLatticeVertex 5 7)) := by
+  ext v
+  simp only [Finset.mem_union, mem_normalSquareEdgeComplementRegion, mem_normalSquareRegionT,
+    mem_normalSquareRegionTHole, mem_squareLatticeContiguousRectangle]
+  omega
 
 namespace NormalSquareLatticeRectangleInjectivityHypotheses
 
@@ -70,6 +90,26 @@ theorem edgeComplement_injective
     rcases cover.rectangular i hi with hRect | hRect
     · exact h.twoByThree_injective _ hRect
     · exact h.threeByTwo_injective _ hRect
+
+/-- In the normalized horizontal-edge \(5\times7\) frame, the edge-complementary
+block is injective if the local \(T\)-region is injective.
+
+The two additional top-collar regions are contiguous \(3\times2\) rectangles,
+so rectangular injectivity and the union-of-injective-regions lemma add them to
+the local \(T\)-region.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
+Theorem 3, lines 1322--1499 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem topCollar_injective
+    {κ : RegionInjectivityData (SquareLatticeVertex 5 7)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hT : κ.IsInjective (normalSquareRegionT (width := 5) (height := 7) 0 0)) :
+    κ.IsInjective (normalSquareEdgeComplementRegion (width := 5) (height := 7) 0 0) := by
+  rw [normalSquareEdgeComplementRegion_eq_T_union_topCollar]
+  exact hUnion.union_injective
+    (hUnion.union_injective hT (h.rect32_injective (by omega) (by omega)))
+    (h.rect32_injective (by omega) (by omega))
 
 end NormalSquareLatticeRectangleInjectivityHypotheses
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1669,8 +1669,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     member of the family is a contiguous \(2\times3\) or \(3\times2\)
     rectangle.
 \end{definition}
-% Maintainer note: this definition records the coordinate assertion still
-% needed for the source proof.  It does not construct such a cover.
+% Maintainer note: this definition records a sufficient coordinate criterion.
+% The source proof may instead pass through the local T-region.
 
 \begin{lemma}[The normal regions \(R\) and \(S\) differ in one site]%
     \label{lem:peps_normalSquareRegionR_regionS_difference}
@@ -1782,6 +1782,29 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     Apply rectangular injectivity to every rectangle in the cover, then apply
     finite union closure to the nonempty family.
+\end{proof}
+
+\begin{lemma}[The normalized \(5\times7\) edge complement has a top collar]%
+    \label{lem:peps_normalSquareEdgeComplementRegion_topCollar}
+    \lean{TNLean.PEPS.normalSquareEdgeComplementRegion_eq_T_union_topCollar}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.topCollar_injective}
+    \leanok
+    \uses{lem:peps_normalSquareEdgeComplementRegion,
+        lem:peps_normalSquareRegionT_window_complement,
+        lem:peps_squareLatticeRectangleInjectivity_rectangles}
+    In the normalized horizontal-edge \(5\times7\) frame, the finite-lattice
+    complementary block \(A_3\) is the local-window \(T\)-region together with
+    two top-collar contiguous \(3\times2\) rectangles.  Consequently, if the
+    local \(T\)-region is injective, then rectangular injectivity and union
+    closure imply that \(A_3\) is injective.
+\end{lemma}
+% Maintainer note: this still leaves local T-injectivity and the translated
+% every-edge construction open.
+\begin{proof}\leanok
+    The set identity follows by expanding the coordinate inequalities.  The
+    injectivity statement applies union closure first to the local
+    \(T\)-region and the first collar rectangle, and then to the second collar
+    rectangle.
 \end{proof}
 
 \begin{lemma}[Conditional injectivity of the normal \(R\) and \(S\) regions]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -134,8 +134,12 @@ elementary disjointness and cover identities are formalized. A rectangular
 cover witness for this complementary block is also present: if such a cover by
 contiguous $2\times3$ and $3\times2$ rectangles is supplied, then rectangular
 injectivity and finite union closure imply injectivity of the complementary
-block. The concrete coordinate cover required by the source proof remains
-open.
+block. This is only a sufficient criterion, not the only source route. The
+normalized $5\times7$ horizontal-edge geometry is now also formalized:
+$A_3$ is the local-window $T$-region together with two top-collar contiguous
+$3\times2$ rectangles, so injectivity of local $T$ implies injectivity of
+$A_3$ by union closure and rectangular injectivity. Local $T$-injectivity and
+the translated every-edge construction remain open.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
@@ -145,9 +149,10 @@ also formalized, and the two edge blocks removed from the displayed $T$-window
 are injective under the coordinate rectangular hypotheses. The finite-lattice
 complementary block around the chosen edge is now defined set-theoretically.
 The remaining open gap is the source-paper injectivity argument: prove the
-tensor-level union theorem, construct the coordinate cover of this
-finite-lattice complement by contiguous source rectangles, and then prove the
-unconditional injectivity of $R$, $S$, and the edge-complementary block.
+tensor-level union theorem, prove local $T$-injectivity from the source
+rectangular hypotheses, translate the $5\times7$ collar decomposition around
+each edge, and then prove the unconditional injectivity of $R$, $S$, and the
+edge-complementary block.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -185,10 +190,13 @@ alone. The following additional obligations remain.
           rectangular injectivity, and their union is injective under the
           source union-closure hypothesis. The finite-lattice complementary
           region around an edge is now defined, and its elementary complement
-          identities are formalized. A cover witness now records the exact
-          remaining coordinate assertion: once this block is covered by
-          contiguous source rectangles, finite union closure gives its
-          injectivity. The concrete cover remains to be constructed.
+          identities are formalized. A direct rectangular-cover witness gives
+          one sufficient criterion for its injectivity. In the normalized
+          horizontal-edge $5\times7$ frame, the complementary block is also
+          formalized as the union of local $T$ and two contiguous $3\times2$
+          collar rectangles, so local $T$-injectivity implies injectivity of
+          this block. The remaining coordinate work is to prove local
+          $T$-injectivity and translate this decomposition around every edge.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.
@@ -221,6 +229,10 @@ alone. The following additional obligations remain.
     \item Rectangular-cover criterion for injectivity of that block: blueprint
           \path{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover},
           issue \#2004.
+    \item Normalized $5\times7$ top-collar decomposition of that block:
+          blueprint
+          \path{lem:peps_normalSquareEdgeComplementRegion_topCollar}, issue
+          \#2004.
     \item Edge blocking into red, blue, and complementary injective regions:
           blueprint \path{thm:peps_normalEdgeBlockingToInjectiveChain}, issue \#1375.
     \item Application of Lemma \path{inj_isomorph} after normal blocking:


### PR DESCRIPTION
### Motivation

- Continues formalization of arXiv:1804.04964, Section 3 (proof of Theorem 3), see #2004.
- In the normalized horizontal-edge 5×7 frame, the finite-lattice complementary block A₃ equals the local-window T-region together with two top-collar contiguous 3×2 rectangles; this decomposition allows injectivity of A₃ to follow from local T injectivity and rectangular injectivity via union closure.
- Corrects paper-gap language: the earlier direct rectangular-cover witness is a sufficient criterion, not the unique source route.

### Description

- `TNLean/PEPS/NormalEdgeComplementCover.lean`: adds `normalSquareEdgeComplementRegion_eq_T_union_topCollar` (decomposition of the complementary block as T-region union top-collar) and `NormalSquareLatticeRectangleInjectivityHypotheses.topCollar_injective` (injectivity of the top-collar region from rectangular hypotheses and union closure).
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds blueprint entry `lem:peps_normalSquareEdgeComplementRegion_topCollar` in Chapter 13a.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: updates route document to record local T-injectivity and per-edge translation of the collar decomposition as remaining coordinate work.
- Source: arXiv:1804.04964, Section 3, `lem:injective_union` and proof of Theorem 3, lines 1322–1499 of `Papers/1804.04964/paper_normal.tex`.

### Testing

- `lake env lean TNLean/PEPS/NormalEdgeComplementCover.lean`
- `lake build TNLean.PEPS.NormalEdgeComplementCover`
- `lake env lean TNLean.lean`
- `lake build TNLean` (passes with existing unrelated warnings)
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- Line-length check on touched files
- `leanblueprint web`
- `leanblueprint checkdecls` (fails only on pre-existing missing declarations; the new top-collar names are not listed)

---
Refs #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and documentation additions in normal PEPS coordinate geometry; no auth, security, or runtime behavior changes.
> 
> **Overview**
> Adds a **normalized \(5\times7\)** route for the finite-lattice edge-complementary block \(A_3\): in that frame, \(A_3\) equals the local-window **\(T\)** region union two top-collar contiguous **\(3\times2\)** rectangles (`normalSquareEdgeComplementRegion_eq_T_union_topCollar`). **Injectivity** of \(A_3\) then follows from injectivity of local \(T\) plus rectangular hypotheses and union closure (`topCollar_injective`).
> 
> Documentation is aligned: the direct rectangular-cover witness is described as a **sufficient** criterion (not the only paper route); blueprint **Chapter 13a** gains `lem:peps_normalSquareEdgeComplementRegion_topCollar`; the **paper-gaps** route doc reframes remaining work toward **local \(T\)-injectivity** and translating the collar decomposition around every edge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 737080caf9ce72e4c4a649169e83584a071c2086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
