### PR TITLE
feat(MPS/MPDO): expose BNT chi positivity

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -459,6 +459,15 @@ theorem coeff_eq_trace_pow (L : ℕ) (hL : 0 < L) (α β γ : Λ) :
       (H.positiveChi.chi.matrix α β γ ^ L).trace :=
   H.positiveChi.eq_trace_pow L hL α β γ
 
+/-- The diagonal entries of the chi matrices in theorem data are positive.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem chi_entry_pos (α β γ : Λ)
+    (k : Fin (H.positiveChi.chi.dim α β γ)) :
+    0 < H.positiveChi.chi.entry α β γ k :=
+  H.positiveChi.posEntries α β γ k
+
 /-- The same-length BNT product equation carried by theorem data.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985 of
@@ -612,6 +621,16 @@ theorem coeff_eq_trace_pow (L : ℕ) (hL : 0 < L) (α β γ : W.Label) :
   letI := W.operatorModule
   letI := W.operatorMul
   exact W.toTheoremData.coeff_eq_trace_pow L hL α β γ
+
+/-- The diagonal entries of the chi matrices in an existential witness are
+positive.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem chi_entry_pos (α β γ : W.Label)
+    (k : Fin (W.positiveChi.chi.dim α β γ)) :
+    0 < W.positiveChi.chi.entry α β γ k :=
+  W.positiveChi.posEntries α β γ k
 
 /-- The same-length BNT product equation carried by an existential witness.
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1643,6 +1643,20 @@ the elementary trace-power identity for diagonal matrices.
     positive BNT-label $\chi$-witness in the theorem data.
 \end{proof}
 
+\begin{theorem}[BNT theorem data give positive chi entries]%
+    \label{thm:mpdo_bnt_label_theorem_data_chi_entry_pos}
+    \lean{MPOTensor.BNTLabelTheoremData.chi_entry_pos}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        def:mpdo_positive_bnt_label_chi_trace_power_form}
+    BNT-label theorem data give positivity of every diagonal entry of
+    \(\chi_{\alpha,\beta,\gamma}\).
+\end{theorem}
+\begin{proof}\leanok
+    This is the positivity condition carried by the positive BNT-label
+    \(\chi\)-witness in the theorem data.
+\end{proof}
+
 \begin{theorem}[BNT theorem data give the chi-trace product law]%
     \label{thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum_chi_trace_pow}
     \lean{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow}
@@ -1733,6 +1747,20 @@ the elementary trace-power identity for diagonal matrices.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
+\end{proof}
+
+\begin{theorem}[BNT theorem witnesses give positive chi entries]%
+    \label{thm:mpdo_bnt_label_theorem_witness_chi_entry_pos}
+    \lean{MPOTensor.BNTLabelTheoremWitness.chi_entry_pos}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_data_chi_entry_pos}
+    An existential BNT-label theorem witness gives positivity of every
+    diagonal entry of \(\chi_{\alpha,\beta,\gamma}\).
+\end{theorem}
+\begin{proof}\leanok
+    Apply the corresponding theorem-data positivity statement carried by the
+    witness.
 \end{proof}
 
 \begin{theorem}[BNT theorem witnesses give the same-length product law]%

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -180,13 +180,14 @@ not an additional mathematical assumption in the source theorem; it is the
 single formal object collecting the source data supplied by the Appendix
 C.3--C.4 construction from an MPDO tensor.  From such data, the same-length
 product law, the idempotent scalar law, the coefficient trace-power formula,
-the same-length chi-trace product law, the chi-trace idempotent law, the
-blocked-basis coefficient trace-power formula, and the positive blocked
-\(\chi\)-witness are immediate
+positivity of the diagonal \(\chi\)-entries, the same-length chi-trace product
+law, the chi-trace idempotent law, the blocked-basis coefficient trace-power
+formula, and the positive blocked \(\chi\)-witness are immediate
 consequences.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum},
 \leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum},
 \leanid{MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremData.chi_entry_pos},
 \leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_chi_trace},
 \leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_trace_pow},
@@ -202,13 +203,15 @@ algebraic structure, and the corresponding theorem data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.positiveChi},
 \leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison}.}  Such a witness
 immediately gives the coefficient trace-power formula, the same-length product
-law, the idempotent scalar law, the same-length chi-trace product law, the
-chi-trace idempotent law, the blocked-basis coefficient trace-power formula,
-and the positive blocked-basis \(\chi\)-witness for the chosen
+law, the idempotent scalar law, positivity of the diagonal \(\chi\)-entries,
+the same-length chi-trace product law, the chi-trace idempotent law, the
+blocked-basis coefficient trace-power formula, and the positive blocked-basis
+\(\chi\)-witness for the chosen
 algebra-structure data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum},
 \leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum},
+\leanid{MPOTensor.BNTLabelTheoremWitness.chi_entry_pos},
 \leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum_chi_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_chi_trace},
 \leanid{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_trace_pow},


### PR DESCRIPTION
### Motivation

- Continues #2000 toward the source-faithful BNT-label formulation of CPGSV17a Theorem IV.13(ii).
- Theorem IV.13(ii) states not only the trace-power formula for the fixed matrices $\chi_{\alpha,\beta,\gamma}$, but also that their diagonal entries are positive.
- Previous formalization steps surfaced the source equations from `MPOTensor.BNTLabelTheoremData` and `MPOTensor.BNTLabelTheoremWitness`; this PR adds the corresponding positivity consequence at the same level.

### Description

- `TNLean/MPS/MPDO/BNTCoefficients.lean`: adds `MPOTensor.BNTLabelTheoremData.chi_entry_pos` and `MPOTensor.BNTLabelTheoremWitness.chi_entry_pos`, both delegating to the positive BNT-label chi witness already stored in the theorem data.
- `blueprint/src/chapter/ch02b_mpdo.tex`: records the two new source-side positivity consequences.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`: updates the theorem-data and existential-witness consequence lists.

Source: CPGSV17a Theorem IV.13(ii), lines 972--985, and Appendix C.3--C.4, lines 1830--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.

### Testing

- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients`
- `lake env lean TNLean.lean`
- `printf 'import TNLean\n#check MPOTensor.BNTLabelTheoremData.chi_entry_pos\n#check MPOTensor.BNTLabelTheoremWitness.chi_entry_pos\n' | lake env lean /dev/stdin`
- `lake build TNLean` (passes with existing unrelated warnings)
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- Line-length check on touched files
- `leanblueprint web`
- `leanblueprint checkdecls` (fails only on pre-existing missing declarations; the new `chi_entry_pos` names are not listed)

---
Refs #2000
