### PR TITLE
doc(PEPS): add top collar blueprint dependency

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1791,6 +1791,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{lem:peps_normalSquareEdgeComplementRegion,
         lem:peps_normalSquareRegionT_window_complement,
+        def:peps_regionInjectivityData,
         lem:peps_squareLatticeRectangleInjectivity_rectangles}
     In the normalized horizontal-edge \(5\times7\) frame, the finite-lattice
     complementary block \(A_3\) is the local-window \(T\)-region together with


### PR DESCRIPTION
### Motivation

- Addresses #2065, a blueprint dependency omission in the top-collar entry added by PR #2064.
- The entry uses the region-injectivity closure data through the `topCollar_injective` theorem, so the dependency graph should include the region-injectivity data label.

### Description

- Adds `def:peps_regionInjectivityData` to the `\uses{}` block of `lem:peps_normalSquareEdgeComplementRegion_topCollar` in Chapter 13a.
- No Lean declarations or mathematical statements change.

Source context: MGRPG+18, Section 3, displayed \(T\)-region and Theorem 3 blocking, local lines 1430--1499 of `Papers/1804.04964/paper_normal.tex`.

### Testing

- Line-length check on `blueprint/src/chapter/ch13a_peps_ft.tex`
- `git diff --check`
- `leanblueprint web`
- `leanblueprint checkdecls` (fails only on pre-existing missing declarations; this PR adds no new declaration names)

---
Addresses #2065
Refs #1373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line blueprint `\uses{}` metadata only; no runtime, Lean, or proof logic changes.
> 
> **Overview**
> Fixes a **blueprint dependency graph** gap for the top-collar lemma `lem:peps_normalSquareEdgeComplementRegion_topCollar` in Chapter 13a: its injectivity step (`topCollar_injective`) chains **rectangular injectivity** with **region injectivity union closure**, so `def:peps_regionInjectivityData` is now listed in that lemma’s `\uses{}` block alongside the existing set-theoretic lemmas.
> 
> No Lean code or mathematical statements change—only documentation wiring so `leanblueprint` reflects how the proof is structured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376b8aa046e9e3ea3fc99aec7ded0677d5bf4afb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->