### PR TITLE
doc(MPDO): correct witness chi positivity dependencies

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1754,13 +1754,13 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelTheoremWitness.chi_entry_pos}
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness,
-        thm:mpdo_bnt_label_theorem_data_chi_entry_pos}
+        def:mpdo_positive_bnt_label_chi_trace_power_form}
     An existential BNT-label theorem witness gives positivity of every
     diagonal entry of \(\chi_{\alpha,\beta,\gamma}\).
 \end{theorem}
 \begin{proof}\leanok
-    Apply the corresponding theorem-data positivity statement carried by the
-    witness.
+    This follows from the positivity condition in the positive BNT-label
+    \(\chi\)-witness.
 \end{proof}
 
 \begin{theorem}[BNT theorem witnesses give the same-length product law]%


### PR DESCRIPTION
### Motivation

- Addresses #2068, a blueprint dependency inaccuracy introduced by PR #2066.
- The witness-level positivity theorem uses the positive BNT-label \(\chi\)-witness carried by `MPOTensor.BNTLabelTheoremWitness`, rather than applying the theorem-data positivity theorem.

### Description

- Replaces the spurious `thm:mpdo_bnt_label_theorem_data_chi_entry_pos` dependency with `def:mpdo_positive_bnt_label_chi_trace_power_form` in `thm:mpdo_bnt_label_theorem_witness_chi_entry_pos`.
- Updates the proof sketch to match the Lean proof through `W.positiveChi.posEntries`.
- No Lean declarations or mathematical statements change.

Source context: CPGSV17a Theorem IV.13(ii), local lines 972--985 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.

### Testing

- Line-length check on `blueprint/src/chapter/ch02b_mpdo.tex`
- `git diff --check`
- `leanblueprint web`
- `leanblueprint checkdecls` (fails only on pre-existing missing declarations; this PR adds no new declaration names)

---
Addresses #2068
Refs #2000
