### PR TITLE
feat(PEPS): add local T cover criterion

### DIFF
--- a/TNLean/PEPS/NormalEdgeComplementCover.lean
+++ b/TNLean/PEPS/NormalEdgeComplementCover.lean
@@ -1,10 +1,12 @@
 import TNLean.PEPS.NormalBlocking
 
 /-!
-# Rectangular covers of the normal PEPS edge complement
+# Rectangular covers in the normal PEPS proof
 
-This file records the conditional cover step for the finite-lattice
-edge-complementary block \(A_3\) in the square-lattice normal PEPS proof.
+This file records the parametric rectangular-cover structure and the
+conditional injectivity criteria for the local displayed \(T\)-region and the
+finite-lattice edge-complementary block \(A_3\) in the square-lattice normal
+PEPS proof.
 
 ## References
 
@@ -16,17 +18,17 @@ edge-complementary block \(A_3\) in the square-lattice normal PEPS proof.
 namespace TNLean
 namespace PEPS
 
-/-- A finite rectangular cover of the edge-complementary block \(A_3\).
+/-- A finite rectangular cover of a square-lattice region.
 
 Each member of the cover is required to be one of the source-paper contiguous
-\(2\times3\) or \(3\times2\) rectangles. Such a cover is a sufficient
-coordinate condition for the union-of-injective-regions lemma to prove
-injectivity of the finite-lattice complementary block.
+\(2\times3\) or \(3\times2\) rectangles. Such a cover is a sufficient coordinate
+condition for the union-of-injective-regions lemma to prove injectivity of the
+target region.
 
-Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499
-of `Papers/1804.04964/paper_normal.tex`. -/
-structure NormalSquareEdgeComplementRectangleCover {width height : ℕ}
-    (xStart yStart : ℕ) where
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
+Theorem 3, lines 1322--1499 of `Papers/1804.04964/paper_normal.tex`. -/
+structure SquareLatticeRectangleCover {width height : ℕ}
+    (target : Finset (SquareLatticeVertex width height)) where
   /-- The finite index set labelling the rectangular pieces. -/
   Index : Type*
   /-- The finite family of pieces used in the cover. -/
@@ -40,8 +42,34 @@ structure NormalSquareEdgeComplementRectangleCover {width height : ℕ}
     ∀ i ∈ regions,
       IsTwoByThreeContiguousSquareLatticeRectangle (region i) ∨
         IsThreeByTwoContiguousSquareLatticeRectangle (region i)
-  /-- The rectangular pieces cover exactly the edge-complementary block. -/
-  cover : regions.biUnion region = normalSquareEdgeComplementRegion xStart yStart
+  /-- The rectangular pieces cover exactly the target region. -/
+  cover : regions.biUnion region = target
+
+/-- A finite rectangular cover of the displayed local \(T\)-region.
+
+Each member of the cover is required to be one of the source-paper contiguous
+\(2\times3\) or \(3\times2\) rectangles. Such a cover is a sufficient
+coordinate condition for the union-of-injective-regions lemma to prove
+injectivity of \(T\).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1444
+of `Papers/1804.04964/paper_normal.tex`. -/
+abbrev NormalSquareRegionTRectangleCover {width height : ℕ} (xStart yStart : ℕ) :=
+  SquareLatticeRectangleCover
+    (normalSquareRegionT (width := width) (height := height) xStart yStart)
+
+/-- A finite rectangular cover of the edge-complementary block \(A_3\).
+
+Each member of the cover is required to be one of the source-paper contiguous
+\(2\times3\) or \(3\times2\) rectangles. Such a cover is a sufficient
+coordinate condition for the union-of-injective-regions lemma to prove
+injectivity of the finite-lattice complementary block.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499
+of `Papers/1804.04964/paper_normal.tex`. -/
+abbrev NormalSquareEdgeComplementRectangleCover {width height : ℕ} (xStart yStart : ℕ) :=
+  SquareLatticeRectangleCover
+    (normalSquareEdgeComplementRegion (width := width) (height := height) xStart yStart)
 
 /-- In the normalized horizontal-edge \(5\times7\) frame, the finite-lattice
 edge-complementary block is the local \(T\)-region together with two top-collar
@@ -68,6 +96,47 @@ namespace NormalSquareLatticeRectangleInjectivityHypotheses
 variable {width height : ℕ}
 variable {κ : RegionInjectivityData (SquareLatticeVertex width height)}
 
+/-- A square-lattice region is injective once it is covered by source-paper
+\(2\times3\) and \(3\times2\) rectangles.
+
+This is the common conditional step for the local \(T\)-region and for the
+edge-complementary block \(A_3\). It states that rectangular injectivity plus
+the union-of-injective-regions lemma proves injectivity once the coordinate
+cover is supplied.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
+Theorem 3, lines 1322--1499 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem injective_of_rectangleCover
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {target : Finset (SquareLatticeVertex width height)}
+    (cover : SquareLatticeRectangleCover target) :
+    κ.IsInjective target := by
+  rw [← cover.cover]
+  exact hUnion.biUnion_injective cover.nonempty cover.region fun i hi ↦ by
+    rcases cover.rectangular i hi with hRect | hRect
+    · exact h.twoByThree_injective _ hRect
+    · exact h.threeByTwo_injective _ hRect
+
+/-- The displayed local \(T\)-region is injective once it is covered by
+source-paper \(2\times3\) and \(3\times2\) rectangles.
+
+This is the formal conditional step for the source sentence that \(T\) is
+injective when the PEPS is large enough. It does not construct the cover; it
+states that rectangular injectivity plus the union-of-injective-regions lemma
+proves injectivity once the coordinate cover is supplied.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
+Theorem 3, lines 1322--1444 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionT_injective_of_cover
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart : ℕ}
+    (cover : NormalSquareRegionTRectangleCover (width := width) (height := height)
+      xStart yStart) :
+    κ.IsInjective (normalSquareRegionT xStart yStart) :=
+  h.injective_of_rectangleCover hUnion cover
+
 /-- The finite-lattice edge-complementary block is injective once it is covered
 by source-paper \(2\times3\) and \(3\times2\) rectangles.
 
@@ -84,12 +153,8 @@ theorem edgeComplement_injective
     {xStart yStart : ℕ}
     (cover : NormalSquareEdgeComplementRectangleCover (width := width) (height := height)
       xStart yStart) :
-    κ.IsInjective (normalSquareEdgeComplementRegion xStart yStart) := by
-  rw [← cover.cover]
-  exact hUnion.biUnion_injective cover.nonempty cover.region fun i hi ↦ by
-    rcases cover.rectangular i hi with hRect | hRect
-    · exact h.twoByThree_injective _ hRect
-    · exact h.threeByTwo_injective _ hRect
+    κ.IsInjective (normalSquareEdgeComplementRegion xStart yStart) :=
+  h.injective_of_rectangleCover hUnion cover
 
 /-- In the normalized horizontal-edge \(5\times7\) frame, the edge-complementary
 block is injective if the local \(T\)-region is injective.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1658,19 +1658,38 @@ injective and normal PEPS, following Theorems~2 and~3 of
     blocks.
 \end{proof}
 
-\begin{definition}[Rectangular covers of the edge-complementary block]%
-    \label{def:peps_normalSquareEdgeComplementRectangleCover}
+\begin{definition}[Rectangular covers of square-lattice regions]%
+    \label{def:peps_normalSquareRectangleCover}
+    \lean{TNLean.PEPS.SquareLatticeRectangleCover}
+    \lean{TNLean.PEPS.NormalSquareRegionTRectangleCover}
     \lean{TNLean.PEPS.NormalSquareEdgeComplementRectangleCover}
     \leanok
     \uses{def:peps_squareLatticeCoordinateRegions,
         lem:peps_normalSquareEdgeComplementRegion}
-    A rectangular cover of the finite-lattice complementary block \(A_3\) is a
-    nonempty finite family of regions whose union is exactly \(A_3\), and each
-    member of the family is a contiguous \(2\times3\) or \(3\times2\)
-    rectangle.
+    A rectangular cover of a square-lattice region is a nonempty finite family
+    of regions whose union is exactly the given region, and each member of the
+    family is a contiguous \(2\times3\) or \(3\times2\) rectangle.  The two
+    cases used in the proof are the cover of the local displayed \(T\)-region
+    and the cover of the finite-lattice complementary block \(A_3\).
 \end{definition}
-% Maintainer note: this definition records a sufficient coordinate criterion.
-% The source proof may instead pass through the local T-region.
+% Maintainer note: this definition records sufficient coordinate criteria.
+% The concrete local T cover remains to be constructed.
+
+\begin{lemma}[Injectivity from a rectangular cover]%
+    \label{lem:peps_normalSquareRectangleCover_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.injective_of_rectangleCover}
+    \leanok
+    \uses{def:peps_normalSquareRectangleCover,
+        def:peps_normalRectangleInjectivityHypotheses,
+        lem:peps_regionInjectivityUnionClosure_finite}
+    If a square-lattice region has a nonempty finite cover by contiguous
+    \(2\times3\) and \(3\times2\) rectangles, then rectangular injectivity and
+    finite union closure imply that the region is injective.
+\end{lemma}
+\begin{proof}\leanok
+    Apply rectangular injectivity to every rectangle in the cover, then apply
+    finite union closure to the nonempty family.
+\end{proof}
 
 \begin{lemma}[The normal regions \(R\) and \(S\) differ in one site]%
     \label{lem:peps_normalSquareRegionR_regionS_difference}
@@ -1765,12 +1784,32 @@ injective and normal PEPS, following Theorems~2 and~3 of
     one application of union closure to these two injective blocks.
 \end{proof}
 
+\begin{lemma}[Injectivity from a rectangular cover of the local \(T\)-region]%
+    \label{lem:peps_normalSquareRegionT_injective_of_cover}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionT_injective_of_cover}
+    \leanok
+    \uses{def:peps_normalSquareRectangleCover,
+        def:peps_normalRectangleInjectivityHypotheses,
+        lem:peps_normalSquareRectangleCover_injective,
+        lem:peps_regionInjectivityUnionClosure_finite}
+    If the displayed local \(T\)-region has a nonempty finite cover by
+    contiguous \(2\times3\) and \(3\times2\) rectangles, then rectangular
+    injectivity and finite union closure imply that \(T\) is injective.
+\end{lemma}
+% Maintainer note: this is still conditional; the concrete source cover is not
+% yet constructed.
+\begin{proof}\leanok
+    Apply rectangular injectivity to every rectangle in the cover, then apply
+    finite union closure to the nonempty family.
+\end{proof}
+
 \begin{lemma}[Injectivity from a rectangular cover of the edge complement]%
     \label{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective}
     \leanok
-    \uses{def:peps_normalSquareEdgeComplementRectangleCover,
+    \uses{def:peps_normalSquareRectangleCover,
         def:peps_normalRectangleInjectivityHypotheses,
+        lem:peps_normalSquareRectangleCover_injective,
         lem:peps_regionInjectivityUnionClosure_finite}
     If the finite-lattice complementary block \(A_3\) has a nonempty finite
     cover by contiguous \(2\times3\) and \(3\times2\) rectangles, then

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -130,16 +130,18 @@ window. This local-window region should not be confused with the
 finite-lattice complementary block used later in the proof of
 Theorem~\path{3}. The finite-lattice complementary block is now named as the
 complement of the two edge blocks in the full square lattice, and its
-elementary disjointness and cover identities are formalized. A rectangular
-cover witness for this complementary block is also present: if such a cover by
-contiguous $2\times3$ and $3\times2$ rectangles is supplied, then rectangular
-injectivity and finite union closure imply injectivity of the complementary
-block. This is only a sufficient criterion, not the only source route. The
-normalized $5\times7$ horizontal-edge geometry is now also formalized:
-$A_3$ is the local-window $T$-region together with two top-collar contiguous
-$3\times2$ rectangles, so injectivity of local $T$ implies injectivity of
-$A_3$ by union closure and rectangular injectivity. Local $T$-injectivity and
-the translated every-edge construction remain open.
+elementary disjointness and cover identities are formalized. The rectangular
+cover witness is now target-parametric: if a square-lattice region has a
+nonempty cover by contiguous $2\times3$ and $3\times2$ rectangles, then
+rectangular injectivity and finite union closure imply injectivity of that
+region. The formalized special cases are the local-window $T$-region and the
+finite-lattice complementary block. This is only a sufficient criterion, not
+the only source route. The normalized $5\times7$ horizontal-edge geometry is
+now also formalized: $A_3$ is the local-window $T$-region together with two
+top-collar contiguous $3\times2$ rectangles, so injectivity of local $T$
+implies injectivity of $A_3$ by union closure and rectangular injectivity.
+The concrete local $T$ cover and the translated every-edge construction remain
+open.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
@@ -190,13 +192,14 @@ alone. The following additional obligations remain.
           rectangular injectivity, and their union is injective under the
           source union-closure hypothesis. The finite-lattice complementary
           region around an edge is now defined, and its elementary complement
-          identities are formalized. A direct rectangular-cover witness gives
-          one sufficient criterion for its injectivity. In the normalized
-          horizontal-edge $5\times7$ frame, the complementary block is also
-          formalized as the union of local $T$ and two contiguous $3\times2$
-          collar rectangles, so local $T$-injectivity implies injectivity of
-          this block. The remaining coordinate work is to prove local
-          $T$-injectivity and translate this decomposition around every edge.
+          identities are formalized. Rectangular-cover witnesses give sufficient
+          criteria for injectivity of both the local displayed $T$-region and
+          the finite-lattice complementary block. In the normalized horizontal
+          edge $5\times7$ frame, the complementary block is also formalized as
+          the union of local $T$ and two contiguous $3\times2$ collar
+          rectangles, so local $T$-injectivity implies injectivity of this
+          block. The remaining coordinate work is to construct the concrete
+          local $T$ cover and translate this decomposition around every edge.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.
@@ -224,11 +227,19 @@ alone. The following additional obligations remain.
           $T$-window, and of their union under union closure: blueprint
           \path{lem:peps_normalSquareRegionT_edgeBlocks_injective}, issue
           \#2004.
+    \item General rectangular-cover criterion for square-lattice regions:
+          blueprint \path{lem:peps_normalSquareRectangleCover_injective}, issue
+          \#2004.
+    \item Rectangular-cover criterion for injectivity of the displayed
+          $T$-region: blueprint
+          \path{lem:peps_normalSquareRegionT_injective_of_cover}, issue
+          \#2004.
     \item Finite-lattice complementary block around an edge: blueprint
           \path{lem:peps_normalSquareEdgeComplementRegion}, issue \#2004.
     \item Rectangular-cover criterion for injectivity of that block: blueprint
           \path{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover},
-          issue \#2004.
+          using the cover definition
+          \path{def:peps_normalSquareRectangleCover}, issue \#2004.
     \item Normalized $5\times7$ top-collar decomposition of that block:
           blueprint
           \path{lem:peps_normalSquareEdgeComplementRegion_topCollar}, issue


### PR DESCRIPTION
### Motivation

- Refs #2004.
- arXiv:1804.04964 states that the displayed local region \(T\) is injective once the PEPS is sufficiently large. The concrete cover is still a geometric obligation, but the conditional finite-union step can be isolated now.

### Description

- Adds `TNLean.PEPS.SquareLatticeRectangleCover`, a target-parametrized nonempty finite cover by contiguous \(2\times3\) and \(3\times2\) rectangles.
- Adds local aliases for covers of the displayed \(T\)-region and the finite-lattice edge-complementary block \(A_3\).
- Adds `TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.injective_of_rectangleCover`, with `regionT_injective_of_cover` and `edgeComplement_injective` as special cases.
- Updates Chapter 13a and the Section 3 paper-gap note to record that the concrete local \(T\) cover remains open.

Source context: MGRPG+18, Section 3, Lemma `lem:injective_union` and proof of Theorem 3, local lines 1322--1499 of `Papers/1804.04964/paper_normal.tex`.

### Testing

- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake env lean TNLean/PEPS/NormalEdgeComplementCover.lean`
- `lake build TNLean` (passes; existing unrelated warnings remain)
- file-size check on touched Lean files
- line-length check on touched files
- `git diff --check`
- `leanblueprint web`
- `leanblueprint checkdecls` (fails only on pre-existing missing declarations; the new PEPS declarations are not listed)

---
Refs #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean formalization and blueprint/documentation only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Introduces a **target-parametric** rectangular-cover API (`SquareLatticeRectangleCover`) and factors the old edge-complement-only cover into aliases for the local **\(T\)** region and **\(A_3\)**.
> 
> The duplicated “cover + union closure ⇒ injective” proof becomes one theorem (`injective_of_rectangleCover`); `regionT_injective_of_cover` and `edgeComplement_injective` are thin specializations.
> 
> Blueprint Chapter 13a and the Section 3 paper-gap note are updated to record the general criterion, the new **\(T\)** cover lemma, and that the **concrete** local \(T\) cover is still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 305667869e5897a539a79e6f0a17a115cf57758b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->