### PR TITLE
feat(PEPS): record local T cover obstruction

### DIFF
--- a/TNLean/PEPS/NormalEdgeComplementCover.lean
+++ b/TNLean/PEPS/NormalEdgeComplementCover.lean
@@ -71,6 +71,72 @@ abbrev NormalSquareEdgeComplementRectangleCover {width height : ℕ} (xStart ySt
   SquareLatticeRectangleCover
     (normalSquareEdgeComplementRegion (width := width) (height := height) xStart yStart)
 
+/-- The current normalized \(5\times6\) local-window model for \(T\) has no
+rectangular cover by contained source-paper \(2\times3\) and \(3\times2\)
+rectangles.
+
+This is a diagnostic statement about the present coordinate model
+`normalSquareRegionT`, not a claim about the source theorem.  The source says
+that \(T\) is injective for sufficiently large PEPS; this lemma records that
+the present local-window complement is not yet the source rectangular cover
+needed to prove that sentence.
+
+Source context: arXiv:1804.04964, Section 3, proof of Theorem 3,
+lines 1430--1444 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem not_normalSquareRegionT_rectangleCover_five_by_six :
+    ¬ Nonempty (NormalSquareRegionTRectangleCover (width := 5) (height := 6) 0 0) := by
+  rintro ⟨cover⟩
+  let p : SquareLatticeVertex 5 6 := (⟨0, by omega⟩, ⟨0, by omega⟩)
+  have hpT : p ∈ normalSquareRegionT (width := 5) (height := 6) 0 0 := by
+    simp [p]
+  have hpUnion : p ∈ cover.regions.biUnion cover.region := by
+    rw [cover.cover]
+    exact hpT
+  rcases Finset.mem_biUnion.mp hpUnion with ⟨i, hi, hpi⟩
+  rcases cover.rectangular i hi with hRect | hRect
+  · rcases hRect with ⟨xStart, yStart, _hx, _hy, hRegion⟩
+    let q : SquareLatticeVertex 5 6 := (⟨0, by omega⟩, ⟨2, by omega⟩)
+    have hpRect :
+        p ∈ (squareLatticeContiguousRectangle xStart yStart 2 3 :
+          Finset (SquareLatticeVertex 5 6)) := by
+      simpa [hRegion] using hpi
+    have hqRect :
+        q ∈ (squareLatticeContiguousRectangle xStart yStart 2 3 :
+          Finset (SquareLatticeVertex 5 6)) := by
+      rw [mem_squareLatticeContiguousRectangle] at hpRect ⊢
+      simp [p, q] at hpRect ⊢
+      omega
+    have hqRegion : q ∈ cover.region i := by
+      simpa [hRegion] using hqRect
+    have hqUnion : q ∈ cover.regions.biUnion cover.region :=
+      Finset.mem_biUnion.mpr ⟨i, hi, hqRegion⟩
+    have hqT : q ∈ normalSquareRegionT (width := 5) (height := 6) 0 0 := by
+      rwa [cover.cover] at hqUnion
+    have hqNotT : q ∉ normalSquareRegionT (width := 5) (height := 6) 0 0 := by
+      simp [q]
+    exact hqNotT hqT
+  · rcases hRect with ⟨xStart, yStart, _hx, _hy, hRegion⟩
+    let q : SquareLatticeVertex 5 6 := (⟨2, by omega⟩, ⟨1, by omega⟩)
+    have hpRect :
+        p ∈ (squareLatticeContiguousRectangle xStart yStart 3 2 :
+          Finset (SquareLatticeVertex 5 6)) := by
+      simpa [hRegion] using hpi
+    have hqRect :
+        q ∈ (squareLatticeContiguousRectangle xStart yStart 3 2 :
+          Finset (SquareLatticeVertex 5 6)) := by
+      rw [mem_squareLatticeContiguousRectangle] at hpRect ⊢
+      simp [p, q] at hpRect ⊢
+      omega
+    have hqRegion : q ∈ cover.region i := by
+      simpa [hRegion] using hqRect
+    have hqUnion : q ∈ cover.regions.biUnion cover.region :=
+      Finset.mem_biUnion.mpr ⟨i, hi, hqRegion⟩
+    have hqT : q ∈ normalSquareRegionT (width := 5) (height := 6) 0 0 := by
+      rwa [cover.cover] at hqUnion
+    have hqNotT : q ∉ normalSquareRegionT (width := 5) (height := 6) 0 0 := by
+      simp [q]
+    exact hqNotT hqT
+
 /-- In the normalized horizontal-edge \(5\times7\) frame, the finite-lattice
 edge-complementary block is the local \(T\)-region together with two top-collar
 contiguous \(3\times2\) rectangles.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1675,6 +1675,27 @@ injective and normal PEPS, following Theorems~2 and~3 of
 % Maintainer note: this definition records sufficient coordinate criteria.
 % The concrete local T cover remains to be constructed.
 
+\begin{lemma}[The present \(5\times6\) local \(T\)-window has no rectangular cover]%
+    \label{lem:peps_normalSquareRegionT_no_five_by_six_cover}
+    \lean{TNLean.PEPS.not_normalSquareRegionT_rectangleCover_five_by_six}
+    \leanok
+    \uses{def:peps_normalSquareRectangleCover,
+        lem:peps_normalSquareRegionT_window_complement}
+    The present normalized \(5\times6\) local-window model for the displayed
+    \(T\)-region admits no nonempty finite cover by contained contiguous
+    \(2\times3\) and \(3\times2\) rectangles.
+\end{lemma}
+% Maintainer note: this is a local-model obstruction, not a statement of the
+% source theorem.  It records that the current coordinate model is not yet the
+% source cover needed for the \(T\)-injectivity sentence.
+\begin{proof}\leanok
+    The lower-left point of the local window belongs to the present \(T\)
+    model.  Any contiguous \(2\times3\) rectangle containing it also contains
+    a point of the removed vertical edge block, while any contiguous
+    \(3\times2\) rectangle containing it also contains a point of the removed
+    horizontal edge block.
+\end{proof}
+
 \begin{lemma}[Injectivity from a rectangular cover]%
     \label{lem:peps_normalSquareRectangleCover_injective}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.injective_of_rectangleCover}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -136,12 +136,16 @@ nonempty cover by contiguous $2\times3$ and $3\times2$ rectangles, then
 rectangular injectivity and finite union closure imply injectivity of that
 region. The formalized special cases are the local-window $T$-region and the
 finite-lattice complementary block. This is only a sufficient criterion, not
-the only source route. The normalized $5\times7$ horizontal-edge geometry is
-now also formalized: $A_3$ is the local-window $T$-region together with two
-top-collar contiguous $3\times2$ rectangles, so injectivity of local $T$
-implies injectivity of $A_3$ by union closure and rectangular injectivity.
-The concrete local $T$ cover and the translated every-edge construction remain
-open.
+the only source route. The present normalized $5\times6$ local-window model for
+$T$ is now also known not to admit such a rectangular cover. This local
+obstruction does not contradict the paper's statement; it shows that the
+source cover still has to be realigned with the finite PEPS geometry rather
+than read directly from the current local-window complement. The normalized
+$5\times7$ horizontal-edge geometry is also formalized: $A_3$ is the
+local-window $T$-region together with two top-collar contiguous $3\times2$
+rectangles, so injectivity of local $T$ implies injectivity of $A_3$ by union
+closure and rectangular injectivity. The realigned local $T$ cover and the
+translated every-edge construction remain open.
 
 Verdict: the earlier vocabulary gap for contiguous rectangular blocks is closed.
 The earlier packaging gap for coordinate rectangular injectivity is also
@@ -151,10 +155,10 @@ also formalized, and the two edge blocks removed from the displayed $T$-window
 are injective under the coordinate rectangular hypotheses. The finite-lattice
 complementary block around the chosen edge is now defined set-theoretically.
 The remaining open gap is the source-paper injectivity argument: prove the
-tensor-level union theorem, prove local $T$-injectivity from the source
-rectangular hypotheses, translate the $5\times7$ collar decomposition around
-each edge, and then prove the unconditional injectivity of $R$, $S$, and the
-edge-complementary block.
+tensor-level union theorem, realign the local $T$-injectivity argument with the
+source finite PEPS geometry, translate the $5\times7$ collar decomposition
+around each edge, and then prove the unconditional injectivity of $R$, $S$, and
+the edge-complementary block.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -198,8 +202,11 @@ alone. The following additional obligations remain.
           edge $5\times7$ frame, the complementary block is also formalized as
           the union of local $T$ and two contiguous $3\times2$ collar
           rectangles, so local $T$-injectivity implies injectivity of this
-          block. The remaining coordinate work is to construct the concrete
-          local $T$ cover and translate this decomposition around every edge.
+          block. The present normalized $5\times6$ local-window $T$ model is
+          now known not to admit a rectangular-cover witness of the above
+          form. The remaining coordinate work is to realign the source
+          local $T$ cover with the finite PEPS geometry and translate this
+          decomposition around every edge.
     \item Prove that the edge-centered red, blue, and complementary regions form a
           three-site injective chain around every edge. This is the normal analog of
           the injective edge-blocking bridge tracked by \ghissue{1366}.
@@ -233,6 +240,10 @@ alone. The following additional obligations remain.
     \item Rectangular-cover criterion for injectivity of the displayed
           $T$-region: blueprint
           \path{lem:peps_normalSquareRegionT_injective_of_cover}, issue
+          \#2004.
+    \item Obstruction to applying that criterion directly to the present
+          normalized $5\times6$ local-window $T$ model: blueprint
+          \path{lem:peps_normalSquareRegionT_no_five_by_six_cover}, issue
           \#2004.
     \item Finite-lattice complementary block around an edge: blueprint
           \path{lem:peps_normalSquareEdgeComplementRegion}, issue \#2004.


### PR DESCRIPTION
### Motivation

The source proof of the normal PEPS fundamental theorem, in MGRPG+18 Section 3, proves the injectivity of the region denoted T by using rectangular injectivity for 2 by 3 and 3 by 2 blocks. I reread the relevant passage before making this change: proof of Theorem 3, local lines 1430--1444 of `Papers/1804.04964/paper_normal.tex`.

The present formal 5 by 6 local-window model of the displayed T-region does not yet realize that rectangular-cover argument. The lower-left point belongs to the present T-window, but any contiguous 2 by 3 rectangle covering that point also contains a point of the removed vertical edge block, and any contiguous 3 by 2 rectangle covering that point also contains a point of the removed horizontal edge block.

### Description

- `TNLean/PEPS/NormalEdgeComplementCover.lean`: adds `not_normalSquareRegionT_rectangleCover_five_by_six`, proving that the present normalized 5 by 6 local-window model of T admits no nonempty cover by contained contiguous 2 by 3 and 3 by 2 rectangles.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds the corresponding blueprint lemma.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: records that the source local T-cover must be realigned with the finite PEPS geometry rather than read directly from the present local-window complement.

This does not claim that the source theorem is false. It records a local-model obstruction in the present coordinate formalization.

### Testing

- `lake env lean TNLean/PEPS/NormalEdgeComplementCover.lean`
- `lake build TNLean`
- `leanblueprint web`
- `leanblueprint checkdecls` failed only on pre-existing missing blueprint declarations unrelated to this PR.

---

Refs #2004.
