### PR TITLE
feat(MPS/MPDO): derive blocked chi family from BNT label theorem data

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -528,6 +528,42 @@ def toPositiveBlockedStructureChiTracePowerForm :
     AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm data :=
   H.blockedComparison.toPositiveBlockedStructureChiTracePowerForm H.positiveChi
 
+/-- The blocked-basis chi family obtained by pulling back the uniform
+BNT-label chi family in theorem data along the blocked-basis comparison maps.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+def positiveBlockedChi : AlgebraStructureData.BlockedStructureChiFamily data :=
+  H.toPositiveBlockedStructureChiTracePowerForm.chi
+
+/-- The pulled-back blocked-basis chi entries obtained from BNT-label theorem
+data are positive.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem positiveBlockedChi_entry_pos
+    (n : ℕ) (i j : AlgebraStructureData.BlockedIndex data n)
+    (k : AlgebraStructureData.BlockedIndex data (2 * n))
+    (r : Fin (H.positiveBlockedChi.dim n i j k)) :
+    0 < H.positiveBlockedChi.entry n i j k r :=
+  H.toPositiveBlockedStructureChiTracePowerForm.posEntries n i j k r
+
+/-- The blocked-basis coefficients obtained from BNT-label theorem data are
+traces of powers of the pulled-back blocked-basis chi matrices.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem blocked_coeff_eq_positiveBlockedChi_trace_pow
+    (n : ℕ) (hn : 0 < n)
+    (i j : AlgebraStructureData.BlockedIndex data n)
+    (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
+    data.blockedStructureCoefficients n i j k =
+      (H.positiveBlockedChi.matrix n i j k ^ n).trace :=
+  H.toPositiveBlockedStructureChiTracePowerForm.eq_trace_pow n hn i j k
+
 end BNTLabelTheoremData
 
 /-- Existential BNT-label theorem witness for the source statement.
@@ -537,8 +573,9 @@ same-length operator spaces.  This structure collects those choices together
 with the corresponding theorem data.  The construction of such a witness from
 an MPDO tensor is the outstanding step toward Theorem IV.13(ii).
 
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.3--C.4,
-lines 1830--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure BNTLabelTheoremWitness (data : AlgebraStructureData d D) where
   /-- The finite type of BNT labels. -/
   Label : Type
@@ -734,6 +771,44 @@ def toPositiveBlockedStructureChiTracePowerForm :
   letI := W.operatorModule
   letI := W.operatorMul
   exact W.theoremData.toPositiveBlockedStructureChiTracePowerForm
+
+/-- The blocked-basis chi family obtained by pulling back the uniform
+BNT-label chi family in an existential witness along the blocked-basis
+comparison maps.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+def positiveBlockedChi : AlgebraStructureData.BlockedStructureChiFamily data :=
+  W.toPositiveBlockedStructureChiTracePowerForm.chi
+
+/-- The pulled-back blocked-basis chi entries obtained from an existential
+BNT-label theorem witness are positive.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem positiveBlockedChi_entry_pos
+    (n : ℕ) (i j : AlgebraStructureData.BlockedIndex data n)
+    (k : AlgebraStructureData.BlockedIndex data (2 * n))
+    (r : Fin (W.positiveBlockedChi.dim n i j k)) :
+    0 < W.positiveBlockedChi.entry n i j k r :=
+  W.toPositiveBlockedStructureChiTracePowerForm.posEntries n i j k r
+
+/-- The blocked-basis coefficients obtained from an existential BNT-label
+theorem witness are traces of powers of the pulled-back blocked-basis chi
+matrices.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem blocked_coeff_eq_positiveBlockedChi_trace_pow
+    (n : ℕ) (hn : 0 < n)
+    (i j : AlgebraStructureData.BlockedIndex data n)
+    (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
+    data.blockedStructureCoefficients n i j k =
+      (W.positiveBlockedChi.matrix n i j k ^ n).trace :=
+  W.toPositiveBlockedStructureChiTracePowerForm.eq_trace_pow n hn i j k
 
 end BNTLabelTheoremWitness
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1576,6 +1576,7 @@ the elementary trace-power identity for diagonal matrices.
 \begin{definition}[BNT-label theorem data]%
     \label{def:mpdo_bnt_label_theorem_data}
     \lean{MPOTensor.BNTLabelTheoremData}
+    \lean{MPOTensor.BNTLabelTheoremData.positiveBlockedChi}
     \leanok
     \uses{def:mpdo_bnt_label_coefficient_family,
         def:mpdo_bnt_label_operator_family,
@@ -1588,7 +1589,8 @@ the elementary trace-power identity for diagonal matrices.
     system, the same-length BNT operator family and product identity, the trace
     scalars and idempotent condition, the positive length-independent
     \(\chi\)-witness, and the comparison with the chosen blocked bases.
-    These data are the source-side hypotheses from which the blocked-basis
+    They also determine the pulled-back blocked-basis \(\chi\)-family.  These
+    data are the source-side hypotheses from which the blocked-basis
     consequences below are derived.
 \end{definition}
 
@@ -1718,6 +1720,35 @@ the elementary trace-power identity for diagonal matrices.
     positive BNT-label \(\chi\)-witness belonging to the theorem data.
 \end{proof}
 
+\begin{theorem}[BNT theorem data give positive pulled-back blocked entries]%
+    \label{thm:mpdo_bnt_label_theorem_data_positive_blocked_chi_entry_pos}
+    \lean{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_entry_pos}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
+    The pulled-back blocked-basis \(\chi\)-entries obtained from BNT-label
+    theorem data are positive.
+\end{theorem}
+\begin{proof}\leanok
+    This is the positivity part of the positive blocked-basis
+    \(\chi\)-witness obtained from the theorem data.
+\end{proof}
+
+\begin{theorem}[BNT theorem data give pulled-back blocked trace powers]%
+    \label{thm:mpdo_bnt_label_theorem_data_blocked_coeff_eq_positive_blocked_chi_trace_pow}
+    \lean{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_positiveBlockedChi_trace_pow}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_data,
+        thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form,
+        thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
+    The blocked-basis coefficients are traces of powers of the pulled-back
+    blocked-basis \(\chi\)-matrices obtained from BNT-label theorem data.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the trace-power identity of the positive blocked-basis
+    \(\chi\)-witness obtained from the theorem data.
+\end{proof}
+
 \begin{definition}[Existential BNT-label theorem witness]%
     \label{def:mpdo_bnt_label_theorem_witness}
     \lean{MPOTensor.BNTLabelTheoremWitness}
@@ -1726,12 +1757,14 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelTheoremWitness.traceScalars}
     \lean{MPOTensor.BNTLabelTheoremWitness.positiveChi}
     \lean{MPOTensor.BNTLabelTheoremWitness.blockedComparison}
+    \lean{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi}
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data}
     An existential BNT-label theorem witness consists of the finite BNT-label
     type, the same-length operator spaces, their algebraic structure, and the
-    corresponding BNT-label theorem data.  The construction of such a witness
-    from an MPDO tensor is the outstanding step toward Theorem~IV.13(ii).
+    corresponding BNT-label theorem data, including the pulled-back
+    blocked-basis \(\chi\)-family.  The construction of such a witness from an
+    MPDO tensor is the outstanding step toward Theorem~IV.13(ii).
 \end{definition}
 
 \begin{theorem}[BNT theorem witnesses give coefficient trace powers]%
@@ -1850,6 +1883,36 @@ the elementary trace-power identity for diagonal matrices.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data consequence carried by the witness.
+\end{proof}
+
+\begin{theorem}[BNT theorem witnesses give positive pulled-back blocked entries]%
+    \label{thm:mpdo_bnt_label_theorem_witness_positive_blocked_chi_entry_pos}
+    \lean{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_entry_pos}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form}
+    The pulled-back blocked-basis \(\chi\)-entries obtained from an
+    existential BNT-label theorem witness are positive.
+\end{theorem}
+\begin{proof}\leanok
+    This is the positivity part of the positive blocked-basis
+    \(\chi\)-witness obtained from the existential witness.
+\end{proof}
+
+\begin{theorem}[BNT theorem witnesses give pulled-back blocked trace powers]%
+    \label{thm:mpdo_bnt_label_theorem_witness_blocked_coeff_eq_positive_blocked_chi_trace_pow}
+    \lean{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_positiveBlockedChi_trace_pow}
+    \leanok
+    \uses{def:mpdo_bnt_label_theorem_witness,
+        thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form,
+        thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
+    The blocked-basis coefficients are traces of powers of the pulled-back
+    blocked-basis \(\chi\)-matrices obtained from an existential BNT-label
+    theorem witness.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the trace-power identity of the positive blocked-basis
+    \(\chi\)-witness obtained from the existential witness.
 \end{proof}
 
 \begin{theorem}[Positive blocked $\chi$ witness gives trace powers]%

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1741,8 +1741,9 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form,
         thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
-    The blocked-basis coefficients are traces of powers of the pulled-back
-    blocked-basis \(\chi\)-matrices obtained from BNT-label theorem data.
+    The positive-length blocked-basis coefficients are traces of powers of the
+    pulled-back blocked-basis \(\chi\)-matrices obtained from BNT-label
+    theorem data.
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace-power identity of the positive blocked-basis
@@ -1906,9 +1907,9 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form,
         thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
-    The blocked-basis coefficients are traces of powers of the pulled-back
-    blocked-basis \(\chi\)-matrices obtained from an existential BNT-label
-    theorem witness.
+    The positive-length blocked-basis coefficients are traces of powers of the
+    pulled-back blocked-basis \(\chi\)-matrices obtained from an existential
+    BNT-label theorem witness.
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace-power identity of the positive blocked-basis

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -182,8 +182,9 @@ C.3--C.4 construction from an MPDO tensor.  From such data, the same-length
 product law, the idempotent scalar law, the coefficient trace-power formula,
 positivity of the diagonal \(\chi\)-entries, the same-length chi-trace product
 law, the chi-trace idempotent law, the blocked-basis coefficient trace-power
-formula, and the positive blocked \(\chi\)-witness are immediate
-consequences.\footnote{%
+formula, the positive blocked \(\chi\)-witness, and the pulled-back
+blocked-basis \(\chi\)-family with positive entries and trace-power formula
+are immediate consequences.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum},
 \leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum},
 \leanid{MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow},
@@ -191,7 +192,11 @@ consequences.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_chi_trace},
 \leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_trace_pow},
-\leanid{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm}.}
+\leanid{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_entry_pos},
+\leanid{MPOTensor.BNTLabelTheoremData.%
+blocked_coeff_eq_positiveBlockedChi_trace_pow}.}
 
 The same data can be stated in the existential form closest to the paper: one
 object records the BNT-label type, the same-length operator spaces, their
@@ -201,12 +206,13 @@ algebraic structure, and the corresponding theorem data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.operators},
 \leanid{MPOTensor.BNTLabelTheoremWitness.traceScalars},
 \leanid{MPOTensor.BNTLabelTheoremWitness.positiveChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison}.}  Such a witness
+\leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi}.}  Such a witness
 immediately gives the coefficient trace-power formula, the same-length product
 law, the idempotent scalar law, positivity of the diagonal \(\chi\)-entries,
 the same-length chi-trace product law, the chi-trace idempotent law, the
-blocked-basis coefficient trace-power formula, and the positive blocked-basis
-\(\chi\)-witness for the chosen
+blocked-basis coefficient trace-power formula, the positive blocked-basis
+\(\chi\)-witness, and the pulled-back blocked-basis \(\chi\)-family for the chosen
 algebra-structure data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum},
@@ -216,7 +222,10 @@ algebra-structure data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_chi_trace},
 \leanid{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-toPositiveBlockedStructureChiTracePowerForm}.}  The remaining step is still the
+toPositiveBlockedStructureChiTracePowerForm},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_entry_pos},
+\leanid{MPOTensor.BNTLabelTheoremWitness.%
+blocked_coeff_eq_positiveBlockedChi_trace_pow}.}  The remaining step is still the
 construction of this existential witness from the MPDO tensor.
 
 To eliminate the remaining gap, the formalization should introduce:


### PR DESCRIPTION
### Motivation
- Establishes the blocked-basis chi family as an immediate consequence of the BNT-label theorem data and existential witness, continuing the formalization of Cirac–Pérez-García–Schuch–Verstraete 2017 (arXiv:1606.00608), Theorem IV.13(ii), lines 972–985 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.
- The BNT-label theorem structures (`MPOTensor.BNTLabelTheoremData`, `MPOTensor.BNTLabelTheoremWitness`) already carry a positive blocked-structure chi trace-power witness; this PR derives its consequences explicitly.
- Continues #2000; does not yet construct the existential witness from an MPDO tensor.

### Description
Modified files:
- `TNLean/MPS/MPDO/BNTCoefficients.lean`: adds `positiveBlockedChi` (the pulled-back blocked chi-family, on both `BNTLabelTheoremData` and `BNTLabelTheoremWitness`), `positiveBlockedChi_entry_pos` (positivity of entries), and `blocked_coeff_eq_positiveBlockedChi_trace_pow` (the blocked-basis coefficients equal traces of powers of the chi matrices).
- `blueprint/src/chapter/ch02b_mpdo.tex`: documents that theorem data and existential witnesses include the blocked chi family and the two corollaries, adding matching `\lean` links.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`: updates the gap note to reflect that the blocked-basis chi family is now formalized.

Source: arXiv:1606.00608, Theorem IV.13(ii) (lines 972–985) and Appendix C.3–C.4 (lines 1830–1942) of `Papers/1606.00608/MPDO-22-12-17-2.tex`.

### Testing
- `lake env lean TNLean/MPS/MPDO/BNTCoefficients.lean`
- `lake build TNLean.MPS.MPDO.BNTCoefficients` succeeds (unrelated long-line warning in `TNLean/Spectral/GaugeConstruction.lean`)
- `git diff --check`
- Line-length check on edited files
- `cd blueprint && leanblueprint web` succeeds (existing renderer warnings only)
- `cd blueprint && leanblueprint checkdecls` — new MPDO declarations are not listed among missing; existing PEPS and parent-Hamiltonian warnings remain

---
Refs #2000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin Lean wrappers and blueprint/gap-doc updates on top of existing proofs; no auth, runtime, or MPDO construction logic.
> 
> **Overview**
> This PR **surfaces** the blocked-basis χ family that was already implicit in `toPositiveBlockedStructureChiTracePowerForm`, instead of adding a new construction from an MPDO tensor.
> 
> On **`BNTLabelTheoremData`** and **`BNTLabelTheoremWitness`**, it adds **`positiveBlockedChi`** (the `.chi` of the positive blocked trace-power witness), **`positiveBlockedChi_entry_pos`**, and **`blocked_coeff_eq_positiveBlockedChi_trace_pow`**, each proved by delegating to the existing witness. Blueprint **`ch02b_mpdo.tex`** and **`cpgsv17_blocked_chi_uniformity.tex`** are updated with matching `\lean` links and wording that theorem data / existential witnesses now include this pulled-back family and its two corollaries.
> 
> Constructing **`BNTLabelTheoremWitness`** from an MPDO tensor remains out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40cbdcdf93b1650363c1885da1efe6e556588110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->