### PR TITLE
feat(PEPS): compare edge middle region injectivity

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.Blocking
+import TNLean.PEPS.InjectiveRegion
 
 /-!
 # Middle physical indices for edge-blocked PEPS
@@ -175,6 +176,24 @@ structure EdgeBlockedThreeSiteInjective (A : Tensor G d) (e : Edge G) : Prop whe
   middle_injective : EdgeMiddleTensorInjective (G := G) A e
   right_injective : Function.Injective (localTensorMap A e.1.2)
 
+/-- A comparison from finite-region injectivity to the middle tensor in the
+edge-blocked three-site chain.
+
+The source proof uses that contracting injective tensors over a finite region
+gives an injective blocked tensor. This proposition records the part of that
+claim needed for the middle region \(V\setminus\{u,v\}\) attached to an edge
+\(e=(u,v)\), without asserting the full contraction theorem.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+structure EdgeMiddleRegionInjectivityComparison
+    (κ : RegionInjectivityData V) (A : Tensor G d) : Prop where
+  /-- Region injectivity of \(V\setminus\{u,v\}\) gives injectivity of the
+  corresponding edge-middle tensor family. -/
+  middle_tensor_injective :
+    ∀ e : Edge G, κ.IsInjective (edgeMiddleVertices e) →
+      EdgeMiddleTensorInjective (G := G) A e
+
 /-- Vertex injectivity supplies the two endpoint injectivity assertions in the
 edge-blocked three-site chain.
 
@@ -197,6 +216,25 @@ theorem IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle {A : Tensor G 
     (hMiddle : EdgeMiddleTensorInjective (G := G) A e) :
     EdgeBlockedThreeSiteInjective (G := G) A e :=
   ⟨hA.localTensorMap_injective e.1.1, hMiddle, hA.localTensorMap_injective e.1.2⟩
+
+/-- Region injectivity of the edge-middle block, together with the comparison to
+the edge-middle tensor family, gives the edge-blocked three-site injectivity
+statement.
+
+This is a conditional form of the assertion after `eq:block_to_mps`; the
+unconditional paper statement still requires a proof of the finite-region
+contraction theorem.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hA : IsVertexInjective A) (e : Edge G)
+    (hMiddleRegion : κ.IsInjective (edgeMiddleVertices e)) :
+    EdgeBlockedThreeSiteInjective (G := G) A e :=
+  hA.edgeBlockedThreeSiteInjective_of_middle e
+    (hComparison.middle_tensor_injective e hMiddleRegion)
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -949,8 +949,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     records the following assertion: if the middle vertex region
     \(V\setminus\{u,v\}\) is injective after blocking, then the middle tensor
     in the edge-blocked three-site chain is injective. This isolates the
-    finite-region contraction claim used after
-    \(\textup{eq:block\_to\_mps}\).
+    finite-region contraction claim in
+    \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{definition}
 
 \begin{theorem}[Endpoint injectivity in the edge-blocked chain]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -939,6 +939,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
     the right endpoint tensor map are all injective.
 \end{definition}
 
+\begin{definition}[Region injectivity supplies the edge-middle tensor]%
+    \label{def:peps_edgeMiddleRegionInjectivityComparison}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison}
+    \leanok
+    \uses{def:peps_regionInjectivityData,
+        def:peps_edgeMiddleTensorFamily}
+    A comparison from finite-region injectivity to the edge-middle tensor
+    records the following assertion: if the middle vertex region
+    \(V\setminus\{u,v\}\) is injective after blocking, then the middle tensor
+    in the edge-blocked three-site chain is injective. This isolates the
+    finite-region contraction claim used after
+    \(\textup{eq:block\_to\_mps}\).
+\end{definition}
+
 \begin{theorem}[Endpoint injectivity in the edge-blocked chain]%
     \label{thm:peps_edgeBlockedEndpointTensorMaps_injective}
     \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective}
@@ -966,11 +980,29 @@ injective and normal PEPS, following Theorems~2 and~3 of
     assertion is the assumed injectivity of the blocked middle tensor.
 \end{proof}
 
+\begin{theorem}[Region injectivity gives edge-blocked injectivity]%
+    \label{thm:peps_edgeBlockedThreeSiteInjective_of_region}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
+        def:peps_edgeMiddleRegionInjectivityComparison,
+        thm:peps_edgeBlockedThreeSiteInjective_of_middle}
+    Suppose the middle region \(V\setminus\{u,v\}\) is injective after
+    blocking, and suppose this region-injectivity assertion has been identified
+    with injectivity of the corresponding edge-middle tensor family. Then a
+    vertex-injective PEPS tensor gives an injective edge-blocked three-site
+    chain at the edge \(e=(u,v)\).
+\end{theorem}
+\begin{proof}\leanok
+    The comparison gives injectivity of the middle tensor. The previous reduction
+    combines this with vertex injectivity at the two endpoints.
+\end{proof}
+
 \begin{theorem}[Edge blocking preserves injectivity]%
     \label{thm:peps_edgeBlockedThreeSiteInjective}
     \notready
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
-        thm:peps_edgeBlockedThreeSiteInjective_of_middle}
+        thm:peps_edgeBlockedThreeSiteInjective_of_region}
     If \(A\) is vertex-injective, then for every edge \(e=(u,v)\), the two
     endpoint tensors together with the tensor obtained by blocking all vertices
     outside \(u\) and \(v\) form an injective three-site MPS. This is the

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -134,7 +134,14 @@ Theorem can be proved in the manner of the paper.
   and
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle}
   reduces the remaining work to the middle-block injectivity statement. The
-  full transfer remains the not-yet-formalized theorem
+  comparison
+  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective}
+  records the conditional passage from finite-region injectivity of
+  \(V\setminus\{u,v\}\) to the edge-middle tensor family. The missing
+  mathematical step is still the contraction theorem used in the paper:
+  contracting vertex-injective tensors over that finite middle region gives an
+  injective blocked tensor. The full transfer remains the not-yet-formalized
+  theorem
   \path{thm:peps_edgeBlockedThreeSiteInjective}.
 \item The two internal steps in Lemma \path{inj_isomorph} must be formalized for
   the edge-blocked three-site MPS. The local endpoint part of the

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -135,13 +135,15 @@ Theorem can be proved in the manner of the paper.
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle}
   reduces the remaining work to the middle-block injectivity statement. The
   comparison
-  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective}
+  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison}
   records the conditional passage from finite-region injectivity of
-  \(V\setminus\{u,v\}\) to the edge-middle tensor family. The missing
-  mathematical step is still the contraction theorem used in the paper:
-  contracting vertex-injective tensors over that finite middle region gives an
-  injective blocked tensor. The full transfer remains the not-yet-formalized
-  theorem
+  \(V\setminus\{u,v\}\) to the edge-middle tensor family. Its theorem
+  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective}
+  then combines this comparison with vertex injectivity to obtain the
+  edge-blocked three-site assertion. The missing mathematical step is still the
+  contraction theorem used in the paper: contracting vertex-injective tensors
+  over that finite middle region gives an injective blocked tensor. The full
+  transfer remains the not-yet-formalized theorem
   \path{thm:peps_edgeBlockedThreeSiteInjective}.
 \item The two internal steps in Lemma \path{inj_isomorph} must be formalized for
   the edge-blocked three-site MPS. The local endpoint part of the


### PR DESCRIPTION
### Motivation
- The MGRPG+18 edge-blocking argument (arXiv:1804.04964, Section 3, immediately after `eq:block_to_mps`, local lines 981–1009 of `Papers/1804.04964/paper_normal.tex`) requires that blocking injective tensors over a finite region produces an injective tensor; this comparison is a prerequisite for the unconditional theorem `thm:peps_edgeBlockedThreeSiteInjective`.
- Issue #1366 identifies this obligation: without establishing injectivity of the edge-middle tensor family, the three-site injective-chain theorem cannot be applied to the edge-blocked object.

### Description
- Added `EdgeMiddleRegionInjectivityComparison` in `TNLean/PEPS/EdgeMiddlePhysical.lean`: states that finite-region injectivity of the middle region $V \setminus \{u,v\}$ implies injectivity of the concrete edge-middle tensor family (arXiv:1804.04964, Section 3, after `eq:block_to_mps`).
- Added `EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective`: derives a conditional edge-blocked three-site injectivity theorem combining the comparison above with vertex injectivity at the two endpoints and the existing middle-block injectivity reduction.
- Updated `blueprint/src/chapter/ch13a_peps_ft.tex` to record the conditional comparison and document `thm:peps_edgeBlockedThreeSiteInjective` as not yet proved.
- Updated `docs/paper-gaps/peps_injective_ft_section3_route.tex` to record the remaining contraction theorem gap.
- The unconditional theorem `thm:peps_edgeBlockedThreeSiteInjective` is not marked proved by this PR.

### Testing
- `lake env lean TNLean/PEPS/EdgeMiddlePhysical.lean`
- `lake build TNLean.PEPS.EdgeMiddlePhysical`
- `git diff --check`
- `rg -n "\\b(sorry|admit|axiom|native_decide|unsafeCast)\\b" TNLean/PEPS/EdgeMiddlePhysical.lean`
- `leanblueprint checkdecls` run; fails only on pre-existing missing blueprint targets, not on the new declarations.

---
Addresses #1366

> [!NOTE]
> **Low Risk**
> Proof-structure and documentation only in Lean/blueprint; no change to runtime behavior, auth, or data paths. Residual risk is mathematical completeness—the unconditional contraction theorem is still unproved.
> 
> **Overview**
> This PR formalizes the **conditional** step in the MGRPG+18 edge-blocking route after `eq:block_to_mps`: finite-region injectivity on the middle block \(V\setminus\{u,v\}\) is meant to imply injectivity of the concrete **edge-middle tensor family**.
> 
> In `EdgeMiddlePhysical.lean` it adds **`EdgeMiddleRegionInjectivityComparison`** (the bridge hypothesis, not the full contraction theorem) and **`EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective`**, which combines that comparison with existing vertex-injectivity endpoint lemmas and **`IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle`** to obtain **`EdgeBlockedThreeSiteInjective`**. Blueprint (`ch13a_peps_ft.tex`) and the Section 3 route note are updated accordingly; **`thm:peps_edgeBlockedThreeSiteInjective`** stays **not ready** and now cites the new conditional theorem as the documented dependency chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa04dbc7b26b21f673f3944f1eeca9d120359c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only LaTeX/blueprint wording changes; no runtime, auth, or data-path impact. Residual risk is proof-status clarity—the unconditional contraction theorem is still unproved.
> 
> **Overview**
> This PR **tightens documentation** for the conditional edge-blocking injectivity step (issue #1366): it does not add new Lean proofs or mark the unconditional theorem proved.
> 
> The blueprint definition `def:peps_edgeMiddleRegionInjectivityComparison` now cites **Molnar et al. Section 3** for the finite-region contraction claim, instead of referring to a post–`eq:block_to_mps` step in the formalization route.
> 
> The Section 3 route note (`peps_injective_ft_section3_route.tex`) **splits naming**: the comparison object is `TNLean.PEPS.EdgeMiddleRegionInjectivityComparison`, and the derived conditional theorem is `…edgeBlockedThreeSiteInjective`, which is described as combining that comparison with vertex injectivity. The **open gap** is unchanged—the paper’s contraction theorem from region injectivity on \(V\setminus\{u,v\}\) to the edge-middle tensor family, and `thm:peps_edgeBlockedThreeSiteInjective` remains not ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed565d9be690715b786710b3f435ab2abe1caae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->