### PR TITLE
feat(PEPS): extend edge complement rectangular covers

### DIFF
--- a/TNLean/PEPS/NormalEdgeComplementCover.lean
+++ b/TNLean/PEPS/NormalEdgeComplementCover.lean
@@ -251,6 +251,62 @@ theorem normalSquareEdgeComplementRegion_eq_T_union_topCollar :
     mem_normalSquareRegionTHole, mem_squareLatticeContiguousRectangle]
   omega
 
+/-- A rectangular cover of the local \(T\)-region extends to a rectangular
+cover of the normalized horizontal-edge \(5\times7\) complementary block by
+adding the two top-collar \(3\times2\) rectangles.
+
+**Scope restriction (T-cover):** This construction is conditional on a
+rectangular cover of the displayed local \(T\)-region. Under the present
+exact-cover criterion, `not_normalSquareRegionT_rectangleCover_at_origin`
+rules out such a cover for \(5 \leq\) `width` and \(6 \leq\) `height`, hence
+also for this \(5\times7\) frame. The source-faithful finite PEPS geometry is
+recorded as an open obligation in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1499
+of `Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def normalSquareEdgeComplementRectangleCoverOfT
+    (cover : NormalSquareRegionTRectangleCover (width := 5) (height := 7) 0 0) :
+    NormalSquareEdgeComplementRectangleCover (width := 5) (height := 7) 0 0 where
+  Index := Sum {i // i ∈ cover.regions} (Fin 2)
+  regions := Finset.univ
+  nonempty := Finset.univ_nonempty
+  region
+    | Sum.inl i => cover.region i.1
+    | Sum.inr 0 => squareLatticeContiguousRectangle 0 5 3 2
+    | Sum.inr 1 => squareLatticeContiguousRectangle 2 5 3 2
+  rectangular := by
+    intro i _
+    rcases i with i | j
+    · exact cover.rectangular i.1 i.2
+    · fin_cases j
+      · exact Or.inr ⟨0, 5, by omega, by omega, rfl⟩
+      · exact Or.inr ⟨2, 5, by omega, by omega, rfl⟩
+  cover := by
+    rw [normalSquareEdgeComplementRegion_eq_T_union_topCollar]
+    ext v
+    have hT :
+        (∃ a ∈ cover.regions, v ∈ cover.region a) ↔
+          v ∈ (normalSquareRegionT (width := 5) (height := 7) 0 0) := by
+      have hEq :
+          (∃ a ∈ cover.regions, v ∈ cover.region a) =
+            (v ∈ (normalSquareRegionT (width := 5) (height := 7) 0 0)) := by
+        simpa only [Finset.mem_biUnion] using
+          congrArg (fun s => v ∈ s) cover.cover
+      exact hEq.to_iff
+    simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, Finset.mem_union]
+    constructor
+    · rintro ⟨i | j, hv⟩
+      · exact Or.inl (Or.inl (hT.mp ⟨i.1, i.2, hv⟩))
+      · fin_cases j
+        · exact Or.inl (Or.inr hv)
+        · exact Or.inr hv
+    · rintro ((hvT | hvTopLeft) | hvTopRight)
+      · rcases hT.mpr hvT with ⟨i, hi, hvi⟩
+        exact ⟨Sum.inl ⟨i, hi⟩, hvi⟩
+      · exact ⟨Sum.inr 0, hvTopLeft⟩
+      · exact ⟨Sum.inr 1, hvTopRight⟩
+
 /-- In the normalized vertical-edge \(7\times5\) frame, the finite-lattice
 edge-complementary block is the local \(T\)-region together with two right-collar
 contiguous \(2\times3\) rectangles.
@@ -463,7 +519,6 @@ theorem normalSquareVerticalEdgeComplement_eq_verticalT_union_rightCollar :
     mem_normalSquareVerticalRegionT, mem_normalSquareVerticalRegionTHole,
     mem_squareLatticeContiguousRectangle]
   omega
-
 namespace NormalSquareLatticeRectangleInjectivityHypotheses
 
 variable {width height : ℕ}
@@ -546,6 +601,23 @@ theorem edgeComplement_injective
       xStart yStart) :
     κ.IsInjective (normalSquareEdgeComplementRegion xStart yStart) :=
   h.injective_of_rectangleCover hUnion cover
+
+/-- In the normalized horizontal-edge \(5\times7\) frame, a rectangular cover
+of the local \(T\)-region proves injectivity of the edge-complementary block.
+
+This applies the cover extension
+`normalSquareEdgeComplementRectangleCoverOfT` and the general rectangular-cover
+criterion.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
+Theorem 3, lines 1322--1499 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeComplement_injective_of_T_cover
+    {κ : RegionInjectivityData (SquareLatticeVertex 5 7)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (cover : NormalSquareRegionTRectangleCover (width := 5) (height := 7) 0 0) :
+    κ.IsInjective (normalSquareEdgeComplementRegion (width := 5) (height := 7) 0 0) :=
+  h.edgeComplement_injective hUnion (normalSquareEdgeComplementRectangleCoverOfT cover)
 
 /-- In the normalized horizontal-edge \(5\times7\) frame, the edge-complementary
 block is injective if the local \(T\)-region is injective.

--- a/TNLean/PEPS/NormalEdgeComplementCover.lean
+++ b/TNLean/PEPS/NormalEdgeComplementCover.lean
@@ -292,12 +292,15 @@ noncomputable def normalSquareEdgeComplementRectangleCoverOfT
     have hT :
         (∃ a ∈ cover.regions, v ∈ cover.region a) ↔
           v ∈ (normalSquareRegionT (width := 5) (height := 7) 0 0) := by
-      have hEq :
-          (∃ a ∈ cover.regions, v ∈ cover.region a) =
-            (v ∈ (normalSquareRegionT (width := 5) (height := 7) 0 0)) := by
-        simpa only [Finset.mem_biUnion] using
-          congrArg (fun s => v ∈ s) cover.cover
-      exact hEq.to_iff
+      constructor
+      · intro hv
+        rw [← cover.cover]
+        exact Finset.mem_biUnion.mpr hv
+      · intro hv
+        have hvCover : v ∈ cover.regions.biUnion cover.region := by
+          rw [cover.cover]
+          exact hv
+        exact Finset.mem_biUnion.mp hvCover
     simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, Finset.mem_union]
     constructor
     · rintro ⟨i | j, hv⟩

--- a/TNLean/PEPS/NormalEdgeComplementCover.lean
+++ b/TNLean/PEPS/NormalEdgeComplementCover.lean
@@ -257,11 +257,15 @@ adding the two top-collar \(3\times2\) rectangles.
 
 **Scope restriction (T-cover):** This construction is conditional on a
 rectangular cover of the displayed local \(T\)-region. Under the present
-exact-cover criterion, `not_normalSquareRegionT_rectangleCover_at_origin`
-rules out such a cover for \(5 \leq\) `width` and \(6 \leq\) `height`, hence
-also for this \(5\times7\) frame. The source-faithful finite PEPS geometry is
-recorded as an open obligation in
-`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+exact-cover criterion, the origin local \(T\)-region has no such cover for
+\(5 \leq\) `width` and \(6 \leq\) `height`, hence also for this \(5\times7\)
+frame. The source-faithful finite PEPS geometry is recorded as an open
+obligation in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+This is the rectangular-cover form of the top-collar decomposition of the
+edge-complementary block. It separates this finite-lattice collar step from
+the remaining task of constructing a rectangular cover of the local
+\(T\)-region.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1499
 of `Papers/1804.04964/paper_normal.tex`. -/
@@ -605,9 +609,8 @@ theorem edgeComplement_injective
 /-- In the normalized horizontal-edge \(5\times7\) frame, a rectangular cover
 of the local \(T\)-region proves injectivity of the edge-complementary block.
 
-This applies the cover extension
-`normalSquareEdgeComplementRectangleCoverOfT` and the general rectangular-cover
-criterion.
+The proof first adjoins the two top-collar rectangles to the \(T\)-cover, then
+applies the general rectangular-cover criterion.
 
 Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union` and proof of
 Theorem 3, lines 1322--1499 of `Papers/1804.04964/paper_normal.tex`. -/

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1917,8 +1917,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{lemma}[Injectivity from a rectangular cover of the edge complement]%
     \label{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover}
-    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective,
-        TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.%
         edgeComplement_injective_of_T_cover}
     \leanok
     \uses{def:peps_normalSquareRectangleCover,

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1917,8 +1917,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{lemma}[Injectivity from a rectangular cover of the edge complement]%
     \label{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover}
-    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective}
-    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective_of_T_cover}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective,
+        TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.
+        edgeComplement_injective_of_T_cover}
     \leanok
     \uses{def:peps_normalSquareRectangleCover,
         def:peps_normalRectangleInjectivityHypotheses,

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1918,21 +1918,44 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{lemma}[Injectivity from a rectangular cover of the edge complement]%
     \label{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective_of_T_cover}
     \leanok
     \uses{def:peps_normalSquareRectangleCover,
         def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_normalSquareRectangleCover_injective,
-        lem:peps_regionInjectivityUnionClosure_finite}
+        lem:peps_regionInjectivityUnionClosure_finite,
+        lem:peps_normalSquareEdgeComplementRegion_coverOfT}
     If the finite-lattice complementary block \(A_3\) has a nonempty finite
     cover by contiguous \(2\times3\) and \(3\times2\) rectangles, then
     rectangular injectivity and finite union closure imply that \(A_3\) is
-    injective.
+    injective.  In the normalized horizontal-edge \(5\times7\) frame, it is
+    enough to give such a cover of the local \(T\)-region, since adjoining the
+    two top-collar \(3\times2\) rectangles gives a cover of \(A_3\).
 \end{lemma}
 % Maintainer note: the concrete cover required by
 % \cite[Theorem~3]{Molnar2018NormalPEPS} remains to be constructed.
 \begin{proof}\leanok
     Apply rectangular injectivity to every rectangle in the cover, then apply
-    finite union closure to the nonempty family.
+    finite union closure to the nonempty family.  For the normalized
+    \(5\times7\) edge complement, first extend the local \(T\)-cover by the
+    two top-collar rectangles.
+\end{proof}
+
+\begin{lemma}[A cover of \(T\) extends to a cover of the edge complement]%
+    \label{lem:peps_normalSquareEdgeComplementRegion_coverOfT}
+    \lean{TNLean.PEPS.normalSquareEdgeComplementRectangleCoverOfT}
+    \leanok
+    \uses{def:peps_normalSquareRectangleCover,
+        lem:peps_normalSquareEdgeComplementRegion_topCollar}
+    In the normalized horizontal-edge \(5\times7\) frame, any rectangular cover
+    of the local \(T\)-region extends to a rectangular cover of the
+    edge-complementary block \(A_3\) by adjoining the two top-collar
+    contiguous \(3\times2\) rectangles.
+\end{lemma}
+\begin{proof}\leanok
+    Index the new cover by the old cover indices together with two extra
+    indices for the top-collar rectangles.  The set equality is exactly the
+    top-collar decomposition of the edge-complementary block.
 \end{proof}
 
 \begin{lemma}[The normalized edge complements have collars]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -344,6 +344,11 @@ alone. The following additional obligations remain.
           \path{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover},
           using the cover definition
           \path{def:peps_normalSquareRectangleCover}, issue \#2004.
+    \item Extension of a local $T$ rectangular cover to a rectangular cover of
+          the normalized horizontal-edge complementary block by adjoining the
+          two top-collar rectangles: blueprint
+          \path{lem:peps_normalSquareEdgeComplementRegion_coverOfT}, issue
+          \#2004.
     \item Normalized $5\times7$ top-collar decomposition of that block:
           blueprint
           \path{lem:peps_normalSquareEdgeComplementRegion_topCollar}, issue

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -88,6 +88,8 @@ def _split_lean_decls(payload: str) -> list[str]:
     with ``leanblueprint web``, whose generated ``lean_decls`` file includes
     declarations from both one-line and multi-line tags.
     """
+    payload = re.sub(r"%[^\n]*\n\s*", "", payload)
+    payload = re.sub(r"%[^\n]*$", "", payload)
     normalised = re.sub(r"\s+", " ", payload)
     return [decl.strip() for decl in normalised.split(",") if decl.strip()]
 
@@ -651,7 +653,10 @@ def _print_report(report: SyncReport, root: Path) -> None:
     # leanok but missing
     if report.leanok_but_missing:
         print()
-        print(f"WARNING: \\leanok on items whose Lean decl is MISSING ({len(report.leanok_but_missing)}):")
+        print(
+            "WARNING: \\leanok on items whose Lean decl is MISSING "
+            f"({len(report.leanok_but_missing)}):"
+        )
         seen2: set[str] = set()
         for entry in report.leanok_but_missing:
             if entry.lean_decl not in seen2:
@@ -668,7 +673,10 @@ def _print_report(report: SyncReport, root: Path) -> None:
     # Missing from lean_decls
     if report.missing_from_lean_decls_file:
         print()
-        print(f"Blueprint refs missing from lean_decls file ({len(report.missing_from_lean_decls_file)}):")
+        print(
+            "Blueprint refs missing from lean_decls file "
+            f"({len(report.missing_from_lean_decls_file)}):"
+        )
         for name in report.missing_from_lean_decls_file:
             print(f"  + {name}")
 


### PR DESCRIPTION
### Motivation

This PR advances the MGRPG+18 normal PEPS route for Theorem 3, following arXiv:1804.04964, Section 3, lines 1430--1499 of `Papers/1804.04964/paper_normal.tex`.

In the normalized horizontal-edge `5 x 7` frame, the finite-lattice edge-complementary block is the local region `T` together with two top-collar `3 x 2` rectangles. The PR adds the corresponding rectangular-cover construction: a cover of the local `T` region gives a cover of the edge-complementary block by adjoining those two collar rectangles.

Refs #2004. Leaves issue #2004 open.

### Description

- Adds `TNLean.PEPS.normalSquareEdgeComplementRectangleCoverOfT`, which extends a rectangular cover of local `T` to a rectangular cover of the normalized horizontal edge complement.
- Adds `TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective_of_T_cover`, which applies rectangular injectivity and union closure after this cover extension.
- Updates Chapter 13a of the blueprint with `lem:peps_normalSquareEdgeComplementRegion_coverOfT` and the corresponding `\leanok` tag.
- Updates `docs/paper-gaps/peps_normal_ft_section3_route.tex` to record this collar-extension obligation.

### Scope Note

The result is conditional on a rectangular cover of the displayed local `T` region. The present exact-cover model also records the point-forcing obstruction at the origin, so this PR does not complete the source-faithful finite-geometry cover required for the normal PEPS theorem. That remaining obligation stays with #2004.

### Local Checks

- `lake env lean TNLean/PEPS/NormalEdgeComplementCover.lean`
- `lake build TNLean.PEPS.NormalEdgeComplementCover`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/PEPS/NormalEdgeComplementCover.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_normal_ft_section3_route.tex scripts/blueprint_lean_sync.py --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `awk 'length($0) > 100 { print FILENAME ":" FNR ":" length($0) ":" $0 }' TNLean/PEPS/NormalEdgeComplementCover.lean scripts/blueprint_lean_sync.py`
- `rg -n "\\b(sorry|admit|axiom|native_decide|unsafeCast)\\b" TNLean/PEPS/NormalEdgeComplementCover.lean`
- `leanblueprint web`

`leanblueprint checkdecls` was also run. It still reports pre-existing missing blueprint declarations outside this PR; the changed-declaration sync check above reports no missing blueprint entry for the declarations changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and documentation changes on conditional PEPS geometry; no auth, runtime, or production paths affected.
> 
> **Overview**
> For the normalized horizontal-edge **5×7** frame, this PR formalizes the step where a rectangular cover of local **T** is extended to a cover of the edge-complementary block **A₃** by adjoining the two top-collar **3×2** rectangles.
> 
> Lean adds **`normalSquareEdgeComplementRectangleCoverOfT`** (indexed union of the **T** cover pieces with the two collar rectangles, using the existing **T** ∪ top-collar set identity) and **`edgeComplement_injective_of_T_cover`**, which derives **A₃** injectivity from a **T** cover via that extension plus the general rectangular-cover criterion. Docstrings note the result stays **conditional** on supplying a **T** cover and that the present exact-cover model still has no such cover at the origin.
> 
> The blueprint gains **`lem:peps_normalSquareEdgeComplementRegion_coverOfT`** and updates the edge-complement injectivity lemma so a **T** cover suffices in the **5×7** case. **`peps_normal_ft_section3_route.tex`** records the new obligation in the Section 3 ledger. **`blueprint_lean_sync.py`** strips TeX comments when parsing multi-line `\lean{...}` tags and wraps a few long warning strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad37a55a505a3e173ea9f66160ce29c3eba5c0a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->