### PR TITLE
feat(PEPS): extend indexed injective-region geometry

### DIFF
--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -196,6 +196,34 @@ def regionUnionPart [Fintype V] (A B : Finset V) (i : Fin 4) : Finset V :=
   simp [regionUnionPart, show (3 : Fin 4) ≠ 0 by decide,
     show (3 : Fin 4) ≠ 1 by decide, show (3 : Fin 4) ≠ 2 by decide]
 
+/-- The first two indexed regions reconstruct `A`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the source proof identifies `A` with the union of
+`A \ B` and `A ∩ B` before applying injectivity of `A`. -/
+theorem regionUnionPart_zero_union_one [Fintype V] (A B : Finset V) :
+    regionUnionPart A B 0 ∪ regionUnionPart A B 1 = A := by
+  simpa using regionOnlyLeft_union_overlap A B
+
+/-- The middle two indexed regions reconstruct `B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after reinserting the overlap tensor, the source proof identifies
+`B` with the union of `A ∩ B` and `B \ A`. -/
+theorem regionUnionPart_one_union_two [Fintype V] (A B : Finset V) :
+    regionUnionPart A B 1 ∪ regionUnionPart A B 2 = B := by
+  simpa using regionOverlap_union_onlyRight A B
+
+/-- The first three indexed regions reconstruct `A ∪ B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the region whose injectivity is being proved is the union of the
+three inside parts of the four-region decomposition. -/
+theorem regionUnionPart_zero_union_one_union_two [Fintype V] (A B : Finset V) :
+    regionUnionPart A B 0 ∪ regionUnionPart A B 1 ∪ regionUnionPart A B 2 =
+      A ∪ B := by
+  simpa using regionThreePart_union A B
+
 /-- The indexed four regions cover the whole finite vertex set. -/
 theorem regionUnionPart_biUnion [Fintype V] (A B : Finset V) :
     Finset.univ.biUnion (regionUnionPart A B) = Finset.univ := by

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -122,6 +122,17 @@ def regionComplement [Fintype V] (R : Finset V) : Finset V :=
     v ∈ regionComplement R ↔ v ∉ R := by
   simp [regionComplement]
 
+/-- The outside block in the four-region decomposition is the complement of
+`A ∪ B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the fourth region in the blocked proof is written as
+`(A ∪ B)ᶜ`. -/
+theorem regionOutsideUnion_eq_regionComplement_union [Fintype V]
+    (A B : Finset V) :
+    regionOutsideUnion A B = regionComplement (A ∪ B) := by
+  rfl
+
 /-- The left-only and overlap regions reconstruct the left region. -/
 theorem regionOnlyLeft_union_overlap (A B : Finset V) :
     regionOnlyLeft A B ∪ regionOverlap A B = A := by
@@ -195,6 +206,16 @@ def regionUnionPart [Fintype V] (A B : Finset V) (i : Fin 4) : Finset V :=
     regionUnionPart A B 3 = regionOutsideUnion A B := by
   simp [regionUnionPart, show (3 : Fin 4) ≠ 0 by decide,
     show (3 : Fin 4) ≠ 1 by decide, show (3 : Fin 4) ≠ 2 by decide]
+
+/-- The fourth indexed region is the complement of `A ∪ B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the tensor called `X` is attached to `(A ∪ B)ᶜ`, the fourth
+piece of the blocked four-region picture. -/
+theorem regionUnionPart_three_eq_regionComplement_union [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 3 = regionComplement (A ∪ B) := by
+  rw [regionUnionPart_three, regionOutsideUnion_eq_regionComplement_union]
 
 /-- The first two indexed regions reconstruct `A`.
 

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -413,6 +413,32 @@ theorem regionInside_disjoint_outside [Fintype V] (A B : Finset V) :
     (disjoint_sdiff_self_right :
       Disjoint (A ∪ B) ((Finset.univ : Finset V) \ (A ∪ B)))
 
+/-- The indexed region \(A=(A\setminus B)\cup(A\cap B)\) is disjoint from the
+two indexed pieces forming its complement.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: in the first inversion step, the tensor over \(A\) is removed and
+the remaining diagram lives on the complementary indexed pieces. -/
+theorem regionUnionPart_zero_one_disjoint_two_three [Fintype V] (A B : Finset V) :
+    Disjoint (regionUnionPart A B 0 ∪ regionUnionPart A B 1)
+      (regionUnionPart A B 2 ∪ regionUnionPart A B 3) := by
+  rw [regionUnionPart_zero_union_one, regionUnionPart_two_union_three_eq_regionComplement_left]
+  simpa [regionComplement] using
+    (disjoint_sdiff_self_right : Disjoint A ((Finset.univ : Finset V) \ A))
+
+/-- The indexed region \(B=(A\cap B)\cup(B\setminus A)\) is disjoint from the
+two indexed pieces forming its complement.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: in the second inversion step, the tensor over \(B\) is removed and
+only the complementary indexed pieces remain. -/
+theorem regionUnionPart_one_two_disjoint_zero_three [Fintype V] (A B : Finset V) :
+    Disjoint (regionUnionPart A B 1 ∪ regionUnionPart A B 2)
+      (regionUnionPart A B 0 ∪ regionUnionPart A B 3) := by
+  rw [regionUnionPart_one_union_two, regionUnionPart_zero_union_three_eq_regionComplement_right]
+  simpa [regionComplement] using
+    (disjoint_sdiff_self_right : Disjoint B ((Finset.univ : Finset V) \ B))
+
 /-- The union of the three inside indexed regions is disjoint from the outside
 indexed region.
 

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -245,6 +245,20 @@ theorem regionUnionPart_zero_union_one_union_two [Fintype V] (A B : Finset V) :
       A ∪ B := by
   simpa using regionThreePart_union A B
 
+/-- The fourth indexed region is the complement of the three inside indexed
+regions.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the proof first blocks the three regions inside `A ∪ B`, while
+the fourth tensor is attached to their complement. -/
+theorem regionUnionPart_three_eq_regionComplement_inside [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 3 =
+      regionComplement
+        (regionUnionPart A B 0 ∪ regionUnionPart A B 1 ∪ regionUnionPart A B 2) := by
+  rw [regionUnionPart_zero_union_one_union_two,
+    regionUnionPart_three_eq_regionComplement_union]
+
 /-- The three inside indexed regions and the outside region reconstruct `V`.
 
 Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -506,6 +506,26 @@ theorem regionUnionPart_exists_unique [Fintype V] (A B : Finset V) (v : V) :
       intro j hj
       fin_cases j <;> simp [hvA, hvB] at hj ⊢
 
+/-- The source union-closure assertion, applied to the selected indexed
+subregions forming \(A\) and \(B\), makes the three inside indexed regions
+injective.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404.  In the source proof, injectivity of
+\((A\setminus B)\cup(A\cap B)\) and of
+\((A\cap B)\cup(B\setminus A)\) gives injectivity of their union, namely the
+three inside blocks \(A\setminus B\), \(A\cap B\), and \(B\setminus A\). -/
+theorem RegionInjectivityUnionClosure.regionUnionPart_inside_injective [Fintype V]
+    {κ : RegionInjectivityData V} (hUnion : RegionInjectivityUnionClosure κ)
+    {A B : Finset V}
+    (hA : κ.IsInjective (({0, 1} : Finset (Fin 4)).biUnion (regionUnionPart A B)))
+    (hB : κ.IsInjective (({1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B))) :
+    κ.IsInjective (({0, 1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B)) := by
+  rw [regionUnionPart_biUnion_zero_one] at hA
+  rw [regionUnionPart_biUnion_one_two] at hB
+  rw [regionUnionPart_biUnion_zero_one_two]
+  exact hUnion.union_injective hA hB
+
 /-- The left-only region is disjoint from the overlap. -/
 theorem regionOnlyLeft_disjoint_overlap (A B : Finset V) :
     Disjoint (regionOnlyLeft A B) (regionOverlap A B) := by

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -519,6 +519,21 @@ theorem regionUnionPart_zero_one_disjoint_two_three [Fintype V] (A B : Finset V)
   simpa [regionComplement] using
     (disjoint_sdiff_self_right : Disjoint A ((Finset.univ : Finset V) \ A))
 
+/-- The indexed subfamily forming `A` is disjoint from the indexed subfamily
+forming its complement.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the first inverse step separates the tensor over \(A\) from the
+two complementary indexed blocks. -/
+theorem regionUnionPart_biUnion_zero_one_disjoint_two_three [Fintype V]
+    (A B : Finset V) :
+    Disjoint (({0, 1} : Finset (Fin 4)).biUnion (regionUnionPart A B))
+      (({2, 3} : Finset (Fin 4)).biUnion (regionUnionPart A B)) := by
+  rw [regionUnionPart_biUnion_zero_one,
+    regionUnionPart_biUnion_two_three_eq_regionComplement_left]
+  simpa [regionComplement] using
+    (disjoint_sdiff_self_right : Disjoint A ((Finset.univ : Finset V) \ A))
+
 /-- The indexed region \(B=(A\cap B)\cup(B\setminus A)\) is disjoint from the
 two indexed pieces forming its complement.
 
@@ -529,6 +544,21 @@ theorem regionUnionPart_one_two_disjoint_zero_three [Fintype V] (A B : Finset V)
     Disjoint (regionUnionPart A B 1 ∪ regionUnionPart A B 2)
       (regionUnionPart A B 0 ∪ regionUnionPart A B 3) := by
   rw [regionUnionPart_one_union_two, regionUnionPart_zero_union_three_eq_regionComplement_right]
+  simpa [regionComplement] using
+    (disjoint_sdiff_self_right : Disjoint B ((Finset.univ : Finset V) \ B))
+
+/-- The indexed subfamily forming `B` is disjoint from the indexed subfamily
+forming its complement.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the second inverse step separates the tensor over \(B\) from the
+two complementary indexed blocks. -/
+theorem regionUnionPart_biUnion_one_two_disjoint_zero_three [Fintype V]
+    (A B : Finset V) :
+    Disjoint (({1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B))
+      (({0, 3} : Finset (Fin 4)).biUnion (regionUnionPart A B)) := by
+  rw [regionUnionPart_biUnion_one_two,
+    regionUnionPart_biUnion_zero_three_eq_regionComplement_right]
   simpa [regionComplement] using
     (disjoint_sdiff_self_right : Disjoint B ((Finset.univ : Finset V) \ B))
 

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -233,8 +233,8 @@ Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
 \(A=(A\setminus B)\cup(A\cap B)\). -/
 theorem regionUnionPart_biUnion_zero_one [Fintype V] (A B : Finset V) :
     ({0, 1} : Finset (Fin 4)).biUnion (regionUnionPart A B) = A := by
-  ext v
-  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+  simpa [Finset.biUnion_insert, Finset.singleton_biUnion] using
+    regionUnionPart_zero_union_one A B
 
 /-- The middle two indexed regions reconstruct `B`.
 
@@ -252,8 +252,8 @@ Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
 applied to \(B=(A\cap B)\cup(B\setminus A)\). -/
 theorem regionUnionPart_biUnion_one_two [Fintype V] (A B : Finset V) :
     ({1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B) = B := by
-  ext v
-  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+  simpa [Finset.biUnion_insert, Finset.singleton_biUnion] using
+    regionUnionPart_one_union_two A B
 
 /-- The first three indexed regions reconstruct `A ∪ B`.
 
@@ -272,18 +272,15 @@ Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
 indexed regions. -/
 theorem regionUnionPart_biUnion_zero_one_two [Fintype V] (A B : Finset V) :
     ({0, 1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B) = A ∪ B := by
-  ext v
-  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+  simpa [Finset.biUnion_insert, Finset.singleton_biUnion, Finset.union_assoc] using
+    regionUnionPart_zero_union_one_union_two A B
 
-/-- The selected subfamily `3` is the outside indexed region.
-
-Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
-1322--1404: the tensor called `X` is carried by the fourth blocked region. -/
+/-- Convenience form of `Finset.singleton_biUnion` for the outside indexed
+region. -/
 theorem regionUnionPart_biUnion_three [Fintype V] (A B : Finset V) :
     ({3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
       regionUnionPart A B 3 := by
-  ext v
-  simp
+  rw [Finset.singleton_biUnion]
 
 /-- The selected subfamily `3` is the complement of the selected inside
 subfamily `0,1,2`.
@@ -296,20 +293,6 @@ theorem regionUnionPart_biUnion_three_eq_regionComplement_zero_one_two [Fintype 
     ({3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
       regionComplement (({0, 1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B)) := by
   rw [regionUnionPart_biUnion_three, regionUnionPart_biUnion_zero_one_two,
-    regionUnionPart_three_eq_regionComplement_union]
-
-/-- The fourth indexed region is the complement of the three inside indexed
-regions.
-
-Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
-1322--1404: the proof first blocks the three regions inside `A ∪ B`, while
-the fourth tensor is attached to their complement. -/
-theorem regionUnionPart_three_eq_regionComplement_inside [Fintype V]
-    (A B : Finset V) :
-    regionUnionPart A B 3 =
-      regionComplement
-        (regionUnionPart A B 0 ∪ regionUnionPart A B 1 ∪ regionUnionPart A B 2) := by
-  rw [regionUnionPart_zero_union_one_union_two,
     regionUnionPart_three_eq_regionComplement_union]
 
 /-- The fourth indexed region is the intersection of the complements of `A`
@@ -334,7 +317,9 @@ theorem regionUnionPart_two_union_three_eq_regionComplement_left [Fintype V]
     (A B : Finset V) :
     regionUnionPart A B 2 ∪ regionUnionPart A B 3 = regionComplement A := by
   ext v
-  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+  simp only [regionUnionPart_two, regionUnionPart_three, Finset.mem_union,
+    mem_regionOnlyRight, mem_regionOutsideUnion, mem_regionComplement]
+  tauto
 
 /-- The indexed subfamily `2,3` reconstructs the complement of `A`.
 
@@ -345,8 +330,8 @@ theorem regionUnionPart_biUnion_two_three_eq_regionComplement_left [Fintype V]
     (A B : Finset V) :
     ({2, 3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
       regionComplement A := by
-  ext v
-  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+  simpa [Finset.biUnion_insert, Finset.singleton_biUnion] using
+    regionUnionPart_two_union_three_eq_regionComplement_left A B
 
 /-- The selected subfamily `2,3` is the complement of the selected subfamily
 `0,1`.
@@ -371,7 +356,9 @@ theorem regionUnionPart_zero_union_three_eq_regionComplement_right [Fintype V]
     (A B : Finset V) :
     regionUnionPart A B 0 ∪ regionUnionPart A B 3 = regionComplement B := by
   ext v
-  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+  simp only [regionUnionPart_zero, regionUnionPart_three, Finset.mem_union,
+    mem_regionOnlyLeft, mem_regionOutsideUnion, mem_regionComplement]
+  tauto
 
 /-- The indexed subfamily `0,3` reconstructs the complement of `B`.
 
@@ -382,8 +369,8 @@ theorem regionUnionPart_biUnion_zero_three_eq_regionComplement_right [Fintype V]
     (A B : Finset V) :
     ({0, 3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
       regionComplement B := by
-  ext v
-  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+  simpa [Finset.biUnion_insert, Finset.singleton_biUnion] using
+    regionUnionPart_zero_union_three_eq_regionComplement_right A B
 
 /-- The selected subfamily `0,3` is the complement of the selected subfamily
 `1,2`.
@@ -455,17 +442,6 @@ theorem regionUnionPart_one_union_two_eq_regionComplement_zero_union_three [Fint
   rw [regionUnionPart_one_union_two, regionUnionPart_zero_union_three_eq_regionComplement_right]
   ext v
   simp [regionComplement]
-
-/-- The three inside indexed regions and the outside region reconstruct `V`.
-
-Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
-1322--1404: after the three inside blocks form `A ∪ B`, the fourth block is
-the complementary tensor attached to `(A ∪ B)ᶜ`. -/
-theorem regionUnionPart_zero_union_one_union_two_union_three [Fintype V]
-    (A B : Finset V) :
-    regionUnionPart A B 0 ∪ regionUnionPart A B 1 ∪ regionUnionPart A B 2 ∪
-      regionUnionPart A B 3 = Finset.univ := by
-  simpa using regionFourPart_union A B
 
 /-- The indexed four regions cover the whole finite vertex set. -/
 theorem regionUnionPart_biUnion [Fintype V] (A B : Finset V) :

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -226,6 +226,16 @@ theorem regionUnionPart_zero_union_one [Fintype V] (A B : Finset V) :
     regionUnionPart A B 0 ∪ regionUnionPart A B 1 = A := by
   simpa using regionOnlyLeft_union_overlap A B
 
+/-- The subfamily of indexed regions `0,1` reconstructs `A`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the first inverse is applied to
+\(A=(A\setminus B)\cup(A\cap B)\). -/
+theorem regionUnionPart_biUnion_zero_one [Fintype V] (A B : Finset V) :
+    ({0, 1} : Finset (Fin 4)).biUnion (regionUnionPart A B) = A := by
+  ext v
+  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+
 /-- The middle two indexed regions reconstruct `B`.
 
 Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
@@ -234,6 +244,16 @@ Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
 theorem regionUnionPart_one_union_two [Fintype V] (A B : Finset V) :
     regionUnionPart A B 1 ∪ regionUnionPart A B 2 = B := by
   simpa using regionOverlap_union_onlyRight A B
+
+/-- The subfamily of indexed regions `1,2` reconstructs `B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after reinserting the overlap tensor, the second inverse is
+applied to \(B=(A\cap B)\cup(B\setminus A)\). -/
+theorem regionUnionPart_biUnion_one_two [Fintype V] (A B : Finset V) :
+    ({1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B) = B := by
+  ext v
+  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
 
 /-- The first three indexed regions reconstruct `A ∪ B`.
 
@@ -244,6 +264,16 @@ theorem regionUnionPart_zero_union_one_union_two [Fintype V] (A B : Finset V) :
     regionUnionPart A B 0 ∪ regionUnionPart A B 1 ∪ regionUnionPart A B 2 =
       A ∪ B := by
   simpa using regionThreePart_union A B
+
+/-- The subfamily of indexed regions `0,1,2` reconstructs `A ∪ B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the injectivity conclusion is for the union of the three inside
+indexed regions. -/
+theorem regionUnionPart_biUnion_zero_one_two [Fintype V] (A B : Finset V) :
+    ({0, 1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B) = A ∪ B := by
+  ext v
+  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
 
 /-- The fourth indexed region is the complement of the three inside indexed
 regions.
@@ -283,6 +313,18 @@ theorem regionUnionPart_two_union_three_eq_regionComplement_left [Fintype V]
   ext v
   by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
 
+/-- The indexed subfamily `2,3` reconstructs the complement of `A`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after injectivity of `A` is applied, the remaining diagram is
+carried by `B \ A` and the outside block. -/
+theorem regionUnionPart_biUnion_two_three_eq_regionComplement_left [Fintype V]
+    (A B : Finset V) :
+    ({2, 3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
+      regionComplement A := by
+  ext v
+  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+
 /-- The left-only indexed region together with the outside region reconstructs
 the complement of `B`.
 
@@ -292,6 +334,18 @@ the remaining outside tensor is attached to the complement of `B`. -/
 theorem regionUnionPart_zero_union_three_eq_regionComplement_right [Fintype V]
     (A B : Finset V) :
     regionUnionPart A B 0 ∪ regionUnionPart A B 3 = regionComplement B := by
+  ext v
+  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+
+/-- The indexed subfamily `0,3` reconstructs the complement of `B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after reinserting the overlap and applying injectivity of `B`, the
+remaining diagram is carried by `A \ B` and the outside block. -/
+theorem regionUnionPart_biUnion_zero_three_eq_regionComplement_right [Fintype V]
+    (A B : Finset V) :
+    ({0, 3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
+      regionComplement B := by
   ext v
   by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
 

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -224,6 +224,17 @@ theorem regionUnionPart_zero_union_one_union_two [Fintype V] (A B : Finset V) :
       A ∪ B := by
   simpa using regionThreePart_union A B
 
+/-- The three inside indexed regions and the outside region reconstruct `V`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after the three inside blocks form `A ∪ B`, the fourth block is
+the complementary tensor attached to `(A ∪ B)ᶜ`. -/
+theorem regionUnionPart_zero_union_one_union_two_union_three [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 0 ∪ regionUnionPart A B 1 ∪ regionUnionPart A B 2 ∪
+      regionUnionPart A B 3 = Finset.univ := by
+  simpa using regionFourPart_union A B
+
 /-- The indexed four regions cover the whole finite vertex set. -/
 theorem regionUnionPart_biUnion [Fintype V] (A B : Finset V) :
     Finset.univ.biUnion (regionUnionPart A B) = Finset.univ := by
@@ -288,6 +299,17 @@ theorem regionInside_disjoint_outside [Fintype V] (A B : Finset V) :
   simpa [regionOutsideUnion] using
     (disjoint_sdiff_self_right :
       Disjoint (A ∪ B) ((Finset.univ : Finset V) \ (A ∪ B)))
+
+/-- The union of the three inside indexed regions is disjoint from the outside
+indexed region.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the tensor called `X` in the proof is attached to the outside
+block, separated from the three blocks inside `A ∪ B`. -/
+theorem regionUnionPart_inside_disjoint_three [Fintype V] (A B : Finset V) :
+    Disjoint (regionUnionPart A B 0 ∪ regionUnionPart A B 1 ∪ regionUnionPart A B 2)
+      (regionUnionPart A B 3) := by
+  simpa using regionInside_disjoint_outside A B
 
 /-- The indexed four regions are pairwise disjoint. -/
 theorem regionUnionPart_pairwise_disjoint [Fintype V] (A B : Finset V) :

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -271,6 +271,30 @@ theorem regionUnionPart_biUnion [Fintype V] (A B : Finset V) :
     · exact Finset.mem_biUnion.mpr ⟨2, by simp, by simpa using hv⟩
     · exact Finset.mem_biUnion.mpr ⟨3, by simp, by simpa using hv⟩
 
+/-- Each vertex belongs to exactly one indexed part of the four-region
+decomposition.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the proof blocks the tensor network into the four disjoint
+regions `A \ B`, `A ∩ B`, `B \ A`, and `(A ∪ B)ᶜ`. -/
+theorem regionUnionPart_exists_unique [Fintype V] (A B : Finset V) (v : V) :
+    ∃! i : Fin 4, v ∈ regionUnionPart A B i := by
+  by_cases hvA : v ∈ A
+  · by_cases hvB : v ∈ B
+    · refine ⟨1, by simp [hvA, hvB], ?_⟩
+      intro j hj
+      fin_cases j <;> simp [hvA, hvB] at hj ⊢
+    · refine ⟨0, by simp [hvA, hvB], ?_⟩
+      intro j hj
+      fin_cases j <;> simp [hvA, hvB] at hj ⊢
+  · by_cases hvB : v ∈ B
+    · refine ⟨2, by simp [hvA, hvB], ?_⟩
+      intro j hj
+      fin_cases j <;> simp [hvA, hvB] at hj ⊢
+    · refine ⟨3, by simp [hvA, hvB], ?_⟩
+      intro j hj
+      fin_cases j <;> simp [hvA, hvB] at hj ⊢
+
 /-- The left-only region is disjoint from the overlap. -/
 theorem regionOnlyLeft_disjoint_overlap (A B : Finset V) :
     Disjoint (regionOnlyLeft A B) (regionOverlap A B) := by

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -259,6 +259,18 @@ theorem regionUnionPart_three_eq_regionComplement_inside [Fintype V]
   rw [regionUnionPart_zero_union_one_union_two,
     regionUnionPart_three_eq_regionComplement_union]
 
+/-- The fourth indexed region is the intersection of the complements of `A`
+and `B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after injectivity of `A` and then `B` are applied, the remaining
+tensor is supported on the outside region \((A \cup B)^c=A^c\cap B^c\). -/
+theorem regionUnionPart_three_eq_regionComplement_left_inter_right [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 3 = regionComplement A ∩ regionComplement B := by
+  ext v
+  simp [regionComplement]
+
 /-- The right-only indexed region together with the outside region reconstructs
 the complement of `A`.
 

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -283,6 +283,36 @@ theorem regionUnionPart_zero_union_three_eq_regionComplement_right [Fintype V]
   ext v
   by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
 
+/-- The first two indexed regions are the complement of the right-only and
+outside regions.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the first inversion step uses injectivity of the region
+`A = (A \ B) ∪ (A ∩ B)`, whose complement is the remaining two indexed
+pieces. -/
+theorem regionUnionPart_zero_union_one_eq_regionComplement_two_union_three [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 0 ∪ regionUnionPart A B 1 =
+      regionComplement (regionUnionPart A B 2 ∪ regionUnionPart A B 3) := by
+  rw [regionUnionPart_zero_union_one, regionUnionPart_two_union_three_eq_regionComplement_left]
+  ext v
+  simp [regionComplement]
+
+/-- The middle two indexed regions are the complement of the left-only and
+outside regions.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the second inversion step uses injectivity of the region
+`B = (A ∩ B) ∪ (B \ A)`, whose complement is the remaining two indexed
+pieces. -/
+theorem regionUnionPart_one_union_two_eq_regionComplement_zero_union_three [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 1 ∪ regionUnionPart A B 2 =
+      regionComplement (regionUnionPart A B 0 ∪ regionUnionPart A B 3) := by
+  rw [regionUnionPart_one_union_two, regionUnionPart_zero_union_three_eq_regionComplement_right]
+  ext v
+  simp [regionComplement]
+
 /-- The three inside indexed regions and the outside region reconstruct `V`.
 
 Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -275,6 +275,29 @@ theorem regionUnionPart_biUnion_zero_one_two [Fintype V] (A B : Finset V) :
   ext v
   by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
 
+/-- The selected subfamily `3` is the outside indexed region.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the tensor called `X` is carried by the fourth blocked region. -/
+theorem regionUnionPart_biUnion_three [Fintype V] (A B : Finset V) :
+    ({3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
+      regionUnionPart A B 3 := by
+  ext v
+  simp
+
+/-- The selected subfamily `3` is the complement of the selected inside
+subfamily `0,1,2`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: the proof starts with the three inside indexed blocks and a
+boundary tensor on their complement. -/
+theorem regionUnionPart_biUnion_three_eq_regionComplement_zero_one_two [Fintype V]
+    (A B : Finset V) :
+    ({3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
+      regionComplement (({0, 1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B)) := by
+  rw [regionUnionPart_biUnion_three, regionUnionPart_biUnion_zero_one_two,
+    regionUnionPart_three_eq_regionComplement_union]
+
 /-- The fourth indexed region is the complement of the three inside indexed
 regions.
 
@@ -325,6 +348,19 @@ theorem regionUnionPart_biUnion_two_three_eq_regionComplement_left [Fintype V]
   ext v
   by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
 
+/-- The selected subfamily `2,3` is the complement of the selected subfamily
+`0,1`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after applying injectivity of \(A\), the remaining indexed blocks
+are precisely the complement of the two blocks forming \(A\). -/
+theorem regionUnionPart_biUnion_two_three_eq_regionComplement_zero_one [Fintype V]
+    (A B : Finset V) :
+    ({2, 3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
+      regionComplement (({0, 1} : Finset (Fin 4)).biUnion (regionUnionPart A B)) := by
+  rw [regionUnionPart_biUnion_two_three_eq_regionComplement_left,
+    regionUnionPart_biUnion_zero_one]
+
 /-- The left-only indexed region together with the outside region reconstructs
 the complement of `B`.
 
@@ -348,6 +384,20 @@ theorem regionUnionPart_biUnion_zero_three_eq_regionComplement_right [Fintype V]
       regionComplement B := by
   ext v
   by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+
+/-- The selected subfamily `0,3` is the complement of the selected subfamily
+`1,2`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after reinserting the overlap and applying injectivity of \(B\),
+the remaining indexed blocks are precisely the complement of the two blocks
+forming \(B\). -/
+theorem regionUnionPart_biUnion_zero_three_eq_regionComplement_one_two [Fintype V]
+    (A B : Finset V) :
+    ({0, 3} : Finset (Fin 4)).biUnion (regionUnionPart A B) =
+      regionComplement (({1, 2} : Finset (Fin 4)).biUnion (regionUnionPart A B)) := by
+  rw [regionUnionPart_biUnion_zero_three_eq_regionComplement_right,
+    regionUnionPart_biUnion_one_two]
 
 /-- The right-only and outside indexed regions form the complement of the
 first two indexed regions.

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -295,6 +295,33 @@ theorem regionUnionPart_zero_union_three_eq_regionComplement_right [Fintype V]
   ext v
   by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
 
+/-- The right-only and outside indexed regions form the complement of the
+first two indexed regions.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after injectivity of \(A=(A\setminus B)\cup(A\cap B)\) is applied,
+the remaining diagram is carried by the two complementary indexed pieces. -/
+theorem regionUnionPart_two_union_three_eq_regionComplement_zero_union_one [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 2 ∪ regionUnionPart A B 3 =
+      regionComplement (regionUnionPart A B 0 ∪ regionUnionPart A B 1) := by
+  rw [regionUnionPart_two_union_three_eq_regionComplement_left,
+    regionUnionPart_zero_union_one]
+
+/-- The left-only and outside indexed regions form the complement of the middle
+two indexed regions.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after reinserting the overlap and applying injectivity of
+\(B=(A\cap B)\cup(B\setminus A)\), the remaining diagram is carried by the
+two complementary indexed pieces. -/
+theorem regionUnionPart_zero_union_three_eq_regionComplement_one_union_two [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 0 ∪ regionUnionPart A B 3 =
+      regionComplement (regionUnionPart A B 1 ∪ regionUnionPart A B 2) := by
+  rw [regionUnionPart_zero_union_three_eq_regionComplement_right,
+    regionUnionPart_one_union_two]
+
 /-- The first two indexed regions are the complement of the right-only and
 outside regions.
 

--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -259,6 +259,30 @@ theorem regionUnionPart_three_eq_regionComplement_inside [Fintype V]
   rw [regionUnionPart_zero_union_one_union_two,
     regionUnionPart_three_eq_regionComplement_union]
 
+/-- The right-only indexed region together with the outside region reconstructs
+the complement of `A`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after applying injectivity of `A`, the remaining diagram contains
+the `B \ A` block and the outside block. -/
+theorem regionUnionPart_two_union_three_eq_regionComplement_left [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 2 ∪ regionUnionPart A B 3 = regionComplement A := by
+  ext v
+  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+
+/-- The left-only indexed region together with the outside region reconstructs
+the complement of `B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines
+1322--1404: after the overlap is reinserted and injectivity of `B` is applied,
+the remaining outside tensor is attached to the complement of `B`. -/
+theorem regionUnionPart_zero_union_three_eq_regionComplement_right [Fintype V]
+    (A B : Finset V) :
+    regionUnionPart A B 0 ∪ regionUnionPart A B 3 = regionComplement B := by
+  ext v
+  by_cases hvA : v ∈ A <;> by_cases hvB : v ∈ B <;> simp [hvA, hvB]
+
 /-- The three inside indexed regions and the outside region reconstruct `V`.
 
 Source: arXiv:1804.04964, Section 3, Lemma `lem:injective_union`, lines

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1424,12 +1424,17 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_two, TNLean.PEPS.regionUnionPart_three}
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_union}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_zero_one}
     \lean{TNLean.PEPS.regionUnionPart_one_union_two}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_one_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_zero_one_two}
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_inside}
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_left_inter_right}
     \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_left}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_two_three_eq_regionComplement_left}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_right}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_zero_three_eq_regionComplement_right}
     \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_zero_union_one}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_eq_regionComplement_two_union_three}
@@ -1445,11 +1450,15 @@ injective and normal PEPS, following Theorems~2 and~3 of
     all four regions reconstruct $V$. The same identities also hold in the
     indexed four-region family: pieces $0$ and $1$ reconstruct $A$, pieces
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
+    These same reconstructions are available as finite unions over the
+    corresponding subfamilies of the indexed four-region family.
     Piece $3$ is the complement of \(A\cup B\), equivalently the complement of
     the three inside indexed pieces, and also \(A^c\cap B^c\); pieces \(2,3\)
     reconstruct \(A^c\), equivalently the complement of pieces \(0,1\), and
-    pieces \(0,3\) reconstruct \(B^c\), equivalently the complement of pieces
-    \(1,2\). Conversely, pieces \(0,1\) are the complement of pieces \(2,3\),
+    pieces \(0,3\) reconstruct \(B^c\), again both as explicit unions and as
+    finite unions over the indexed subfamilies.  Equivalently, pieces \(0,3\)
+    are the complement of pieces \(1,2\). Conversely, pieces \(0,1\) are the
+    complement of pieces \(2,3\),
     pieces \(1,2\) are the complement of pieces \(0,3\), and adding all four
     pieces reconstructs $V$.
     Equivalently, each vertex lies in one of the four regions, and the indexed

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1430,6 +1430,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_left_inter_right}
     \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_left}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_right}
+    \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_zero_union_one}
+    \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_eq_regionComplement_two_union_three}
     \lean{TNLean.PEPS.regionUnionPart_one_union_two_eq_regionComplement_zero_union_three}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two_union_three}
@@ -1445,9 +1447,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
     Piece $3$ is the complement of \(A\cup B\), equivalently the complement of
     the three inside indexed pieces, and also \(A^c\cap B^c\); pieces \(2,3\)
-    reconstruct \(A^c\), pieces \(0,3\) reconstruct \(B^c\), pieces \(0,1\)
-    are the complement of pieces \(2,3\), pieces \(1,2\) are the complement of
-    pieces \(0,3\), and adding all four pieces reconstructs $V$.
+    reconstruct \(A^c\), equivalently the complement of pieces \(0,1\), and
+    pieces \(0,3\) reconstruct \(B^c\), equivalently the complement of pieces
+    \(1,2\). Conversely, pieces \(0,1\) are the complement of pieces \(2,3\),
+    pieces \(1,2\) are the complement of pieces \(0,3\), and adding all four
+    pieces reconstructs $V$.
     Equivalently, each vertex lies in one of the four regions, and the indexed
     four-region family has union $V$. In fact, every vertex belongs to exactly
     one indexed piece.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1427,6 +1427,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_inside}
+    \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_left}
+    \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_right}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two_union_three}
     \lean{TNLean.PEPS.regionUnionPart_biUnion}
     \lean{TNLean.PEPS.regionUnionPart_exists_unique}
@@ -1439,7 +1441,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     indexed four-region family: pieces $0$ and $1$ reconstruct $A$, pieces
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
     Piece $3$ is the complement of \(A\cup B\), equivalently the complement of
-    the three inside indexed pieces; adding it reconstructs $V$.
+    the three inside indexed pieces; pieces \(2,3\) reconstruct \(A^c\), pieces
+    \(0,3\) reconstruct \(B^c\), and adding all four pieces reconstructs $V$.
     Equivalently, each vertex lies in one of the four regions, and the indexed
     four-region family has union $V$. In fact, every vertex belongs to exactly
     one indexed piece.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1429,6 +1429,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_inside}
     \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_left}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_right}
+    \lean{TNLean.PEPS.regionUnionPart_zero_union_one_eq_regionComplement_two_union_three}
+    \lean{TNLean.PEPS.regionUnionPart_one_union_two_eq_regionComplement_zero_union_three}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two_union_three}
     \lean{TNLean.PEPS.regionUnionPart_biUnion}
     \lean{TNLean.PEPS.regionUnionPart_exists_unique}
@@ -1442,7 +1444,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
     Piece $3$ is the complement of \(A\cup B\), equivalently the complement of
     the three inside indexed pieces; pieces \(2,3\) reconstruct \(A^c\), pieces
-    \(0,3\) reconstruct \(B^c\), and adding all four pieces reconstructs $V$.
+    \(0,3\) reconstruct \(B^c\), pieces \(0,1\) are the complement of pieces
+    \(2,3\), pieces \(1,2\) are the complement of pieces \(0,3\), and adding
+    all four pieces reconstructs $V$.
     Equivalently, each vertex lies in one of the four regions, and the indexed
     four-region family has union $V$. In fact, every vertex belongs to exactly
     one indexed piece.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1464,6 +1464,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionOverlap_disjoint_outside}
     \lean{TNLean.PEPS.regionOnlyRight_disjoint_outside}
     \lean{TNLean.PEPS.regionInside_disjoint_outside}
+    \lean{TNLean.PEPS.regionUnionPart_zero_one_disjoint_two_three}
+    \lean{TNLean.PEPS.regionUnionPart_one_two_disjoint_zero_three}
     \lean{TNLean.PEPS.regionUnionPart_inside_disjoint_three}
     \lean{TNLean.PEPS.regionUnionPart_pairwise_disjoint}
     \leanok
@@ -1472,7 +1474,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     In the four-region decomposition, the left-only and right-only parts are
     disjoint from the overlap and from each other. Each inside part, and hence
     the union of the three inside regions, is disjoint from the outside region.
-    The indexed four-region family is pairwise disjoint.
+    In indexed form, the pieces forming \(A\) are disjoint from the pieces
+    forming \(A^c\), and the pieces forming \(B\) are disjoint from the pieces
+    forming \(B^c\). The indexed four-region family is pairwise disjoint.
 \end{lemma}
 \begin{proof}\leanok
     Use the standard disjointness identities for set difference and

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1566,6 +1566,25 @@ injective and normal PEPS, following Theorems~2 and~3 of
     binary union closure.
 \end{proof}
 
+\begin{lemma}[Indexed inside union under closure]%
+    \label{lem:peps_regionInjectivityUnionClosure_inside}
+    \lean{TNLean.PEPS.RegionInjectivityUnionClosure.regionUnionPart_inside_injective}
+    \leanok
+    \uses{def:peps_regionInjectivityData,
+        lem:peps_regionUnionDecomposition_identities}
+    Under the union-closure hypothesis for region injectivity, if the indexed
+    subfamilies \(\{0,1\}\) and \(\{1,2\}\) in the four-region decomposition
+    are injective, then the inside subfamily \(\{0,1,2\}\) is injective.
+    Equivalently, injectivity of the two source-paper regions
+    \((A\setminus B)\cup(A\cap B)\) and
+    \((A\cap B)\cup(B\setminus A)\) gives injectivity of
+    \(A\setminus B\cup A\cap B\cup B\setminus A\).
+\end{lemma}
+\begin{proof}\leanok
+    Rewrite the three selected indexed unions as \(A\), \(B\), and \(A\cup B\),
+    then apply binary union closure.
+\end{proof}
+
 \begin{definition}[Complement of a finite region]%
     \label{def:peps_regionComplement}
     \lean{TNLean.PEPS.regionComplement}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1479,7 +1479,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionOnlyRight_disjoint_outside}
     \lean{TNLean.PEPS.regionInside_disjoint_outside}
     \lean{TNLean.PEPS.regionUnionPart_zero_one_disjoint_two_three}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_zero_one_disjoint_two_three}
     \lean{TNLean.PEPS.regionUnionPart_one_two_disjoint_zero_three}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_one_two_disjoint_zero_three}
     \lean{TNLean.PEPS.regionUnionPart_inside_disjoint_three}
     \lean{TNLean.PEPS.regionUnionPart_pairwise_disjoint}
     \leanok
@@ -1490,7 +1492,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     the union of the three inside regions, is disjoint from the outside region.
     In indexed form, the pieces forming \(A\) are disjoint from the pieces
     forming \(A^c\), and the pieces forming \(B\) are disjoint from the pieces
-    forming \(B^c\). The indexed four-region family is pairwise disjoint.
+    forming \(B^c\), both as explicit binary unions and as finite unions over
+    the corresponding selected indexed subfamilies. The indexed four-region
+    family is pairwise disjoint.
 \end{lemma}
 \begin{proof}\leanok
     Use the standard disjointness identities for set difference and

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1419,9 +1419,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionOverlap_union_onlyRight}
     \lean{TNLean.PEPS.regionThreePart_union, TNLean.PEPS.regionFourPart_union}
     \lean{TNLean.PEPS.regionFourPart_cases}
+    \lean{TNLean.PEPS.regionUnionPart_zero, TNLean.PEPS.regionUnionPart_one}
+    \lean{TNLean.PEPS.regionUnionPart_two, TNLean.PEPS.regionUnionPart_three}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one}
     \lean{TNLean.PEPS.regionUnionPart_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two}
+    \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two_union_three}
     \lean{TNLean.PEPS.regionUnionPart_biUnion}
     \leanok
     \uses{def:peps_regionUnionDecomposition}
@@ -1431,8 +1434,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     all four regions reconstruct $V$. The same identities also hold in the
     indexed four-region family: pieces $0$ and $1$ reconstruct $A$, pieces
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
-    Equivalently, each vertex lies in one of the four regions, and the indexed
-    four-region family has union $V$.
+    Adding piece $3$ reconstructs $V$. Equivalently, each vertex lies in one
+    of the four regions, and the indexed four-region family has union $V$.
 \end{lemma}
 \begin{proof}\leanok
     Check membership of an arbitrary vertex in $A$ and in $B$.
@@ -1447,6 +1450,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionOverlap_disjoint_outside}
     \lean{TNLean.PEPS.regionOnlyRight_disjoint_outside}
     \lean{TNLean.PEPS.regionInside_disjoint_outside}
+    \lean{TNLean.PEPS.regionUnionPart_inside_disjoint_three}
     \lean{TNLean.PEPS.regionUnionPart_pairwise_disjoint}
     \leanok
     \uses{def:peps_regionUnionDecomposition,

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1419,14 +1419,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionOverlap_union_onlyRight}
     \lean{TNLean.PEPS.regionThreePart_union, TNLean.PEPS.regionFourPart_union}
     \lean{TNLean.PEPS.regionFourPart_cases}
+    \lean{TNLean.PEPS.regionUnionPart_zero_union_one}
+    \lean{TNLean.PEPS.regionUnionPart_one_union_two}
+    \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_biUnion}
     \leanok
     \uses{def:peps_regionUnionDecomposition}
     Let $V$ be a finite vertex set and let $A,B\subseteq V$. The left-only
     and overlap regions reconstruct $A$, the overlap and right-only regions
     reconstruct $B$, the three inside regions reconstruct $A\cup B$, and
-    all four regions reconstruct $V$. Equivalently, each vertex lies in one
-    of the four regions, and the indexed four-region family has union $V$.
+    all four regions reconstruct $V$. The same identities also hold in the
+    indexed four-region family: pieces $0$ and $1$ reconstruct $A$, pieces
+    $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
+    Equivalently, each vertex lies in one of the four regions, and the indexed
+    four-region family has union $V$.
 \end{lemma}
 \begin{proof}\leanok
     Check membership of an arbitrary vertex in $A$ and in $B$.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1427,6 +1427,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_inside}
+    \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_left_inter_right}
     \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_left}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_right}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_eq_regionComplement_two_union_three}
@@ -1443,10 +1444,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     indexed four-region family: pieces $0$ and $1$ reconstruct $A$, pieces
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
     Piece $3$ is the complement of \(A\cup B\), equivalently the complement of
-    the three inside indexed pieces; pieces \(2,3\) reconstruct \(A^c\), pieces
-    \(0,3\) reconstruct \(B^c\), pieces \(0,1\) are the complement of pieces
-    \(2,3\), pieces \(1,2\) are the complement of pieces \(0,3\), and adding
-    all four pieces reconstructs $V$.
+    the three inside indexed pieces, and also \(A^c\cap B^c\); pieces \(2,3\)
+    reconstruct \(A^c\), pieces \(0,3\) reconstruct \(B^c\), pieces \(0,1\)
+    are the complement of pieces \(2,3\), pieces \(1,2\) are the complement of
+    pieces \(0,3\), and adding all four pieces reconstructs $V$.
     Equivalently, each vertex lies in one of the four regions, and the indexed
     four-region family has union $V$. In fact, every vertex belongs to exactly
     one indexed piece.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1417,10 +1417,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \label{lem:peps_regionUnionDecomposition_identities}
     \lean{TNLean.PEPS.regionOnlyLeft_union_overlap}
     \lean{TNLean.PEPS.regionOverlap_union_onlyRight}
+    \lean{TNLean.PEPS.regionOutsideUnion_eq_regionComplement_union}
     \lean{TNLean.PEPS.regionThreePart_union, TNLean.PEPS.regionFourPart_union}
     \lean{TNLean.PEPS.regionFourPart_cases}
     \lean{TNLean.PEPS.regionUnionPart_zero, TNLean.PEPS.regionUnionPart_one}
     \lean{TNLean.PEPS.regionUnionPart_two, TNLean.PEPS.regionUnionPart_three}
+    \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_union}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one}
     \lean{TNLean.PEPS.regionUnionPart_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two}
@@ -1434,8 +1436,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     all four regions reconstruct $V$. The same identities also hold in the
     indexed four-region family: pieces $0$ and $1$ reconstruct $A$, pieces
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
-    Adding piece $3$ reconstructs $V$. Equivalently, each vertex lies in one
-    of the four regions, and the indexed four-region family has union $V$.
+    Piece $3$ is the complement of $A\cup B$; adding it reconstructs $V$.
+    Equivalently, each vertex lies in one of the four regions, and the indexed
+    four-region family has union $V$.
 \end{lemma}
 \begin{proof}\leanok
     Check membership of an arbitrary vertex in $A$ and in $B$.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1428,6 +1428,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two_union_three}
     \lean{TNLean.PEPS.regionUnionPart_biUnion}
+    \lean{TNLean.PEPS.regionUnionPart_exists_unique}
     \leanok
     \uses{def:peps_regionUnionDecomposition}
     Let $V$ be a finite vertex set and let $A,B\subseteq V$. The left-only
@@ -1438,7 +1439,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
     Piece $3$ is the complement of $A\cup B$; adding it reconstructs $V$.
     Equivalently, each vertex lies in one of the four regions, and the indexed
-    four-region family has union $V$.
+    four-region family has union $V$. In fact, every vertex belongs to exactly
+    one indexed piece.
 \end{lemma}
 \begin{proof}\leanok
     Check membership of an arbitrary vertex in $A$ and in $B$.
@@ -1531,9 +1533,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{definition}[Complement of a finite region]%
     \label{def:peps_regionComplement}
     \lean{TNLean.PEPS.regionComplement}
+    \lean{TNLean.PEPS.mem_regionComplement}
     \leanok
     For a finite vertex region \(R\subseteq V\), its complement is
-    \(V\setminus R\).
+    \(V\setminus R\). Equivalently, a vertex lies in the complement exactly
+    when it does not lie in \(R\).
 \end{definition}
 
 \begin{definition}[Square-lattice coordinate regions]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1588,9 +1588,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionComplement}
     \lean{TNLean.PEPS.mem_regionComplement}
     \leanok
-    For a finite vertex region \(R\subseteq V\), its complement is
-    \(V\setminus R\). Equivalently, a vertex lies in the complement exactly
-    when it does not lie in \(R\).
+    For a finite vertex region $R\subseteq V$, its complement is
+    $V\setminus R$. Equivalently, a vertex lies in the complement exactly
+    when it does not lie in $R$.
 \end{definition}
 
 \begin{definition}[Square-lattice coordinate regions]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1429,12 +1429,16 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_biUnion_one_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_biUnion_zero_one_two}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_three}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_three_eq_regionComplement_zero_one_two}
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_inside}
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_left_inter_right}
     \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_left}
     \lean{TNLean.PEPS.regionUnionPart_biUnion_two_three_eq_regionComplement_left}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_two_three_eq_regionComplement_zero_one}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_right}
     \lean{TNLean.PEPS.regionUnionPart_biUnion_zero_three_eq_regionComplement_right}
+    \lean{TNLean.PEPS.regionUnionPart_biUnion_zero_three_eq_regionComplement_one_two}
     \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_zero_union_one}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_eq_regionComplement_two_union_three}
@@ -1453,11 +1457,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     These same reconstructions are available as finite unions over the
     corresponding subfamilies of the indexed four-region family.
     Piece $3$ is the complement of \(A\cup B\), equivalently the complement of
-    the three inside indexed pieces, and also \(A^c\cap B^c\); pieces \(2,3\)
+    the three inside indexed pieces, and also \(A^c\cap B^c\). The singleton
+    subfamily \(\{3\}\) gives the outside block. Pieces \(2,3\)
     reconstruct \(A^c\), equivalently the complement of pieces \(0,1\), and
-    pieces \(0,3\) reconstruct \(B^c\), again both as explicit unions and as
-    finite unions over the indexed subfamilies.  Equivalently, pieces \(0,3\)
-    are the complement of pieces \(1,2\). Conversely, pieces \(0,1\) are the
+    pieces \(0,3\) reconstruct \(B^c\), equivalently the complement of pieces
+    \(1,2\), again both as explicit unions and as finite unions over the
+    indexed subfamilies. Conversely, pieces \(0,1\) are the
     complement of pieces \(2,3\),
     pieces \(1,2\) are the complement of pieces \(0,3\), and adding all four
     pieces reconstructs $V$.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1426,6 +1426,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one}
     \lean{TNLean.PEPS.regionUnionPart_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two}
+    \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_inside}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two_union_three}
     \lean{TNLean.PEPS.regionUnionPart_biUnion}
     \lean{TNLean.PEPS.regionUnionPart_exists_unique}
@@ -1437,7 +1438,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     all four regions reconstruct $V$. The same identities also hold in the
     indexed four-region family: pieces $0$ and $1$ reconstruct $A$, pieces
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
-    Piece $3$ is the complement of $A\cup B$; adding it reconstructs $V$.
+    Piece $3$ is the complement of \(A\cup B\), equivalently the complement of
+    the three inside indexed pieces; adding it reconstructs $V$.
     Equivalently, each vertex lies in one of the four regions, and the indexed
     four-region family has union $V$. In fact, every vertex belongs to exactly
     one indexed piece.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1431,7 +1431,6 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_biUnion_zero_one_two}
     \lean{TNLean.PEPS.regionUnionPart_biUnion_three}
     \lean{TNLean.PEPS.regionUnionPart_biUnion_three_eq_regionComplement_zero_one_two}
-    \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_inside}
     \lean{TNLean.PEPS.regionUnionPart_three_eq_regionComplement_left_inter_right}
     \lean{TNLean.PEPS.regionUnionPart_two_union_three_eq_regionComplement_left}
     \lean{TNLean.PEPS.regionUnionPart_biUnion_two_three_eq_regionComplement_left}
@@ -1443,7 +1442,6 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.regionUnionPart_zero_union_three_eq_regionComplement_one_union_two}
     \lean{TNLean.PEPS.regionUnionPart_zero_union_one_eq_regionComplement_two_union_three}
     \lean{TNLean.PEPS.regionUnionPart_one_union_two_eq_regionComplement_zero_union_three}
-    \lean{TNLean.PEPS.regionUnionPart_zero_union_one_union_two_union_three}
     \lean{TNLean.PEPS.regionUnionPart_biUnion}
     \lean{TNLean.PEPS.regionUnionPart_exists_unique}
     \leanok
@@ -1456,15 +1454,15 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $1$ and $2$ reconstruct $B$, and pieces $0,1,2$ reconstruct $A\cup B$.
     These same reconstructions are available as finite unions over the
     corresponding subfamilies of the indexed four-region family.
-    Piece $3$ is the complement of \(A\cup B\), equivalently the complement of
-    the three inside indexed pieces, and also \(A^c\cap B^c\). The singleton
-    subfamily \(\{3\}\) gives the outside block. Pieces \(2,3\)
-    reconstruct \(A^c\), equivalently the complement of pieces \(0,1\), and
-    pieces \(0,3\) reconstruct \(B^c\), equivalently the complement of pieces
-    \(1,2\), again both as explicit unions and as finite unions over the
-    indexed subfamilies. Conversely, pieces \(0,1\) are the
-    complement of pieces \(2,3\),
-    pieces \(1,2\) are the complement of pieces \(0,3\), and adding all four
+    Piece $3$ is the complement of $A\cup B$, equivalently the complement of
+    the three inside indexed pieces, and also $A^c\cap B^c$. The singleton
+    subfamily $\{3\}$ gives the outside block. Pieces $2,3$
+    reconstruct $A^c$, equivalently the complement of pieces $0,1$, and
+    pieces $0,3$ reconstruct $B^c$, equivalently the complement of pieces
+    $1,2$, again both as explicit unions and as finite unions over the
+    indexed subfamilies. Conversely, pieces $0,1$ are the
+    complement of pieces $2,3$,
+    pieces $1,2$ are the complement of pieces $0,3$, and adding all four
     pieces reconstructs $V$.
     Equivalently, each vertex lies in one of the four regions, and the indexed
     four-region family has union $V$. In fact, every vertex belongs to exactly
@@ -1495,9 +1493,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     In the four-region decomposition, the left-only and right-only parts are
     disjoint from the overlap and from each other. Each inside part, and hence
     the union of the three inside regions, is disjoint from the outside region.
-    In indexed form, the pieces forming \(A\) are disjoint from the pieces
-    forming \(A^c\), and the pieces forming \(B\) are disjoint from the pieces
-    forming \(B^c\), both as explicit binary unions and as finite unions over
+    In indexed form, the pieces forming $A$ are disjoint from the pieces
+    forming $A^c$, and the pieces forming $B$ are disjoint from the pieces
+    forming $B^c$, both as explicit binary unions and as finite unions over
     the corresponding selected indexed subfamilies. The indexed four-region
     family is pairwise disjoint.
 \end{lemma}
@@ -1573,15 +1571,15 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_regionInjectivityData,
         lem:peps_regionUnionDecomposition_identities}
     Under the union-closure hypothesis for region injectivity, if the indexed
-    subfamilies \(\{0,1\}\) and \(\{1,2\}\) in the four-region decomposition
-    are injective, then the inside subfamily \(\{0,1,2\}\) is injective.
+    subfamilies $\{0,1\}$ and $\{1,2\}$ in the four-region decomposition
+    are injective, then the inside subfamily $\{0,1,2\}$ is injective.
     Equivalently, injectivity of the two source-paper regions
-    \((A\setminus B)\cup(A\cap B)\) and
-    \((A\cap B)\cup(B\setminus A)\) gives injectivity of
-    \(A\setminus B\cup A\cap B\cup B\setminus A\).
+    $(A\setminus B)\cup(A\cap B)$ and
+    $(A\cap B)\cup(B\setminus A)$ gives injectivity of
+    $(A\setminus B)\cup(A\cap B)\cup(B\setminus A)$.
 \end{lemma}
 \begin{proof}\leanok
-    Rewrite the three selected indexed unions as \(A\), \(B\), and \(A\cup B\),
+    Rewrite the three selected indexed unions as $A$, $B$, and $A\cup B$,
     then apply binary union closure.
 \end{proof}
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -112,8 +112,10 @@ $A\setminus B$, $A\cap B$, $B\setminus A$, and $(A\cup B)^c$. The indexed
 family reconstructs $A$, $B$, $A\cup B$, $A^c$, $B^c$, and the full vertex set.
 The same reconstructions are available as finite unions over the selected
 indexed subfamilies $\{0,1\}$, $\{1,2\}$, $\{0,1,2\}$, $\{2,3\}$, and
-$\{0,3\}$. Its selected complementary pairs match the two places where the
-source proof applies injectivity of $A$ and then injectivity of $B$. The
+$\{0,3\}$. The singleton subfamily $\{3\}$ gives the outside block and is the
+complement of the selected inside subfamily $\{0,1,2\}$. Its selected
+complementary pairs match the two places where the source proof applies
+injectivity of $A$ and then injectivity of $B$. The
 selected subfamilies $\{0,1\}$ and $\{2,3\}$ are disjoint, as are
 $\{1,2\}$ and $\{0,3\}$; these are the disjointness forms needed for the two
 inverse applications. Every vertex belongs to exactly one indexed piece. These

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -110,11 +110,14 @@ The four-region decomposition from Lemma \path{injective_union} is formalized
 both by named regions and by an indexed family in the source-paper order:
 $A\setminus B$, $A\cap B$, $B\setminus A$, and $(A\cup B)^c$. The indexed
 family reconstructs $A$, $B$, $A\cup B$, $A^c$, $B^c$, and the full vertex set.
-Its selected complementary pairs match the two places where the source proof
-applies injectivity of $A$ and then injectivity of $B$. The selected pieces are
-also disjoint in the forms needed for those two inverse applications, and every
-vertex belongs to exactly one indexed piece. These facts prepare the
-tensor-level boundary-contraction proof, but do not prove that theorem.
+The same reconstructions are available as finite unions over the selected
+indexed subfamilies $\{0,1\}$, $\{1,2\}$, $\{0,1,2\}$, $\{2,3\}$, and
+$\{0,3\}$. Its selected complementary pairs match the two places where the
+source proof applies injectivity of $A$ and then injectivity of $B$. The
+selected pieces are also disjoint in the forms needed for those two inverse
+applications, and every vertex belongs to exactly one indexed piece. These
+facts prepare the tensor-level boundary-contraction proof, but do not prove
+that theorem.
 
 The rectangular vocabulary separates coordinate products from source-paper
 contiguous blocks. Coordinate rectangles are products of finite coordinate

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -106,6 +106,16 @@ one of these orientations. With the ordered endpoints convention for edges,
 horizontal edges are coordinate right edges from their left endpoints, and
 vertical edges are coordinate upward edges from their lower endpoints.
 
+The four-region decomposition from Lemma \path{injective_union} is formalized
+both by named regions and by an indexed family in the source-paper order:
+$A\setminus B$, $A\cap B$, $B\setminus A$, and $(A\cup B)^c$. The indexed
+family reconstructs $A$, $B$, $A\cup B$, $A^c$, $B^c$, and the full vertex set.
+Its selected complementary pairs match the two places where the source proof
+applies injectivity of $A$ and then injectivity of $B$. The selected pieces are
+also disjoint in the forms needed for those two inverse applications, and every
+vertex belongs to exactly one indexed piece. These facts prepare the
+tensor-level boundary-contraction proof, but do not prove that theorem.
+
 The rectangular vocabulary separates coordinate products from source-paper
 contiguous blocks. Coordinate rectangles are products of finite coordinate
 sets, whereas contiguous coordinate rectangles are products of coordinate

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -114,8 +114,9 @@ The same reconstructions are available as finite unions over the selected
 indexed subfamilies $\{0,1\}$, $\{1,2\}$, $\{0,1,2\}$, $\{2,3\}$, and
 $\{0,3\}$. Its selected complementary pairs match the two places where the
 source proof applies injectivity of $A$ and then injectivity of $B$. The
-selected pieces are also disjoint in the forms needed for those two inverse
-applications, and every vertex belongs to exactly one indexed piece. These
+selected subfamilies $\{0,1\}$ and $\{2,3\}$ are disjoint, as are
+$\{1,2\}$ and $\{0,3\}$; these are the disjointness forms needed for the two
+inverse applications. Every vertex belongs to exactly one indexed piece. These
 facts prepare the tensor-level boundary-contraction proof, but do not prove
 that theorem.
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -118,9 +118,12 @@ complementary pairs match the two places where the source proof applies
 injectivity of $A$ and then injectivity of $B$. The
 selected subfamilies $\{0,1\}$ and $\{2,3\}$ are disjoint, as are
 $\{1,2\}$ and $\{0,3\}$; these are the disjointness forms needed for the two
-inverse applications. Every vertex belongs to exactly one indexed piece. These
-facts prepare the tensor-level boundary-contraction proof, but do not prove
-that theorem.
+inverse applications. The abstract union-closure hypothesis also has the
+corresponding indexed inside-union form: injectivity of the selected subfamilies
+$\{0,1\}$ and $\{1,2\}$ implies injectivity of the inside subfamily
+$\{0,1,2\}$. Every vertex belongs to exactly one indexed piece. These facts
+prepare the tensor-level boundary-contraction proof, but do not prove that
+theorem.
 
 The rectangular vocabulary separates coordinate products from source-paper
 contiguous blocks. Coordinate rectangles are products of finite coordinate
@@ -250,10 +253,12 @@ boundary geometry and the source-faithful local and rotated $T$ covers.
 Verdict: this note records an open gap with a scope restriction. The earlier
 vocabulary gap for contiguous rectangular blocks is closed. The earlier
 coordinate rectangular-injectivity structure is also present, and the
-rectangular decompositions of $R$ and $S$ are formalized. The conditional
-derivations of injectivity for $R$ and $S$ from union closure are also
-formalized, and the two edge blocks removed from the displayed $T$-window are
-injective under the coordinate rectangular hypotheses. The finite-lattice
+indexed finite-region geometry of Lemma \path{injective_union} is formalized
+down to the selected complement and closure forms used by the two inverse
+applications. The rectangular decompositions of $R$ and $S$ are formalized, and
+the conditional derivations of injectivity for $R$ and $S$ from union closure
+are also formalized. The two edge blocks removed from the displayed $T$-window
+are injective under the coordinate rectangular hypotheses. The finite-lattice
 complementary block around the chosen edge has a set-theoretic definition.
 The exact-cover criterion by $2\times3$ and $3\times2$ rectangles is only a
 restricted sufficient condition, and the origin-based instances above show


### PR DESCRIPTION
### Motivation

- The source proof of Lemma `injective_union` in arXiv:1804.04964, Section 3 (lines 1322–1404) decomposes two PEPS regions into four indexed parts — $A \setminus B$, $A \cap B$, $B \setminus A$, $(A \cup B)^c$ — and applies injectivity of $A$ and $B$ in sequence to show that a boundary tensor annihilating the union contraction must vanish. The prerequisite finite-region identities (indexed subfamilies, disjointness, complement reconstruction) must be in place before the tensor-level argument can proceed.
- Continues the PEPS FT formalization tracked in issue #1374.

### Description

- **`TNLean/PEPS/InjectiveRegion.lean`**: extends the indexed four-region decomposition (`regionUnionPart` on `Fin 4`) with the finite-set identities required by the source proof:
  - Subfamilies `{0,1}` and `{1,2}` reconstruct $A$ and $B$; subfamily `{0,1,2}` reconstructs $A \cup B$.
  - Complementary subfamilies `{2,3}`, `{0,3}`, and `{3}` reconstruct the corresponding complements.
  - Disjointness statements for the complementary pairs.
  - `RegionInjectivityUnionClosure.regionUnionPart_inside_injective`: injectivity on `{0,1}` and `{1,2}` implies injectivity on `{0,1,2}` via binary union closure.
  - These are finite-region geometry results only; the tensor-level boundary-contraction theorem (`lem:peps_injectiveRegion_union`) remains open.
- **`blueprint/src/chapter/ch13a_peps_ft.tex`**: records the new declarations under the four-region decomposition, disjointness, and indexed closure nodes; the PEPS union diagram remains attached to `lem:peps_injectiveRegion_union`.
- **`docs/paper-gaps/peps_normal_ft_section3_route.tex`**: updates the Section 3 PEPS route note to state that indexed complement and closure forms are now present while the tensor-level union theorem remains open.

### Testing

- `lake env lean TNLean/PEPS/InjectiveRegion.lean`
- `lake build TNLean.PEPS.InjectiveRegion`
- `lake build TNLean`
- `leanblueprint checkdecls` run; new declarations pass the blueprint sync check (no new missing declarations).
- Blueprint sync script, oversized-file guard, line-length scan, proof-integrity scan, and prose scan all passed.

---
Refs #1374.
Leaves issue #1374 open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Lean formalization and documentation for PEPS region combinatorics; no runtime, auth, or data-path changes.
> 
> **Overview**
> Extends **`TNLean/PEPS/InjectiveRegion.lean`** with the indexed four-region picture (`regionUnionPart` on `Fin 4`) needed for arXiv:1804.04964 Lemma `injective_union`: subfamilies `{0,1}`, `{1,2}`, `{0,1,2}` rebuild `A`, `B`, and `A ∪ B`; outside piece `3` matches `(A ∪ B)ᶜ` and the complementary indexed pairs used in the two inverse steps; **disjointness** between complementary subfamilies; **unique** vertex membership per index; and **`RegionInjectivityUnionClosure.regionUnionPart_inside_injective`** (injectivity on `{0,1}` and `{1,2}` ⇒ on `{0,1,2}` via union closure). These are **finite-region set lemmas only**—the tensor-level union lemma remains open.
> 
> **Blueprint** (`ch13a_peps_ft.tex`) links the new declarations to the four-region identity/disjointness lemmas and adds **`lem:peps_regionInjectivityUnionClosure_inside`**. **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** records that this indexed geometry is in place while the tensor-level union theorem is still outstanding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b5e276af1b77d1ce2eb2efa9f669dc49d698fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->