### PR TITLE
feat(MPS/MPDO): separate BNT label assignment

### DIFF
--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -250,14 +250,56 @@ theorem HasIdempotentCoefficientForm.eq_sum [Fintype Λ]
 
 end BNTLabelTraceScalarFamily
 
+/-- Assignment of BNT labels to chosen blocked-basis elements.
+
+For each positive blocked length `n`, the source map reads a chosen basis label
+of \(\mathcal A_n\) as a BNT label, while the target map reads a chosen basis
+label of \(\mathcal A_{2n}\) as a BNT label.  This is the source-side
+Appendix C.3 input needed before one can compare the blocked-basis
+coefficients with the BNT-label coefficient system.
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTBlockedBasisLabelAssignment (data : AlgebraStructureData d D)
+    (Λ : Type*) where
+  /-- BNT label attached to a chosen basis element of \(\mathcal A_n\).
+
+  Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+  `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+  sourceLabel :
+    ∀ n : ℕ, 0 < n → AlgebraStructureData.BlockedIndex data n → Λ
+  /-- BNT label attached to a chosen basis element of \(\mathcal A_{2n}\).
+
+  Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+  `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+  targetLabel :
+    ∀ n : ℕ, 0 < n → AlgebraStructureData.BlockedIndex data (2 * n) → Λ
+
+namespace BNTBlockedBasisLabelAssignment
+
+variable {data : AlgebraStructureData d D} {Λ : Type*}
+  (labels : BNTBlockedBasisLabelAssignment data Λ)
+
+/-- The single label map on the disjoint union of source- and target-length
+blocked-basis labels.
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+def blockedLabel (n : ℕ) (hn : 0 < n) :
+    AlgebraStructureData.BlockedIndex data n ⊕
+      AlgebraStructureData.BlockedIndex data (2 * n) → Λ
+  | Sum.inl i => labels.sourceLabel n hn i
+  | Sum.inr k => labels.targetLabel n hn k
+
+end BNTBlockedBasisLabelAssignment
+
 /-- Comparison between chosen blocked-basis multiplication coefficients and
 BNT-label coefficients.
 
-For each positive blocked length `n`, the maps `sourceLabel` and `targetLabel`
-read the chosen basis labels of \(\mathcal A_n\) and \(\mathcal A_{2n}\) as
-BNT labels.  The comparison equality says that the blocked-basis coefficient of
-the product of two chosen basis elements is the corresponding BNT-label
-coefficient:
+The label assignment reads chosen basis labels of \(\mathcal A_n\) and
+\(\mathcal A_{2n}\) as BNT labels.  The comparison equality says that the
+blocked-basis coefficient of the product of two chosen basis elements is the
+corresponding BNT-label coefficient:
 \[
   c^{(n)}_{i,j,k}
     =
@@ -283,18 +325,11 @@ Appendix C.3, lines 1830--1922 of
 structure BNTBlockedBasisCoefficientComparison
     (data : AlgebraStructureData d D) {Λ : Type*}
     (c : BNTLabelCoefficientFamily Λ) where
-  /-- BNT label attached to a chosen basis element of \(\mathcal A_n\).
+  /-- The Appendix C.3 BNT-label assignment for the chosen blocked bases.
 
   Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
   `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-  sourceLabel :
-    ∀ n : ℕ, 0 < n → AlgebraStructureData.BlockedIndex data n → Λ
-  /-- BNT label attached to a chosen basis element of \(\mathcal A_{2n}\).
-
-  Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
-  `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-  targetLabel :
-    ∀ n : ℕ, 0 < n → AlgebraStructureData.BlockedIndex data (2 * n) → Λ
+  labelAssignment : BNTBlockedBasisLabelAssignment data Λ
   /-- The blocked-basis coefficient is pulled back from the source-length
   BNT-label coefficient.
 
@@ -305,12 +340,25 @@ structure BNTBlockedBasisCoefficientComparison
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)),
     data.blockedStructureCoefficients n i j k =
-      c.coeff n (sourceLabel n hn i) (sourceLabel n hn j) (targetLabel n hn k)
+      c.coeff n (labelAssignment.sourceLabel n hn i)
+        (labelAssignment.sourceLabel n hn j) (labelAssignment.targetLabel n hn k)
 
 namespace BNTBlockedBasisCoefficientComparison
 
 variable {data : AlgebraStructureData d D} {Λ : Type*} {c : BNTLabelCoefficientFamily Λ}
   (cmp : BNTBlockedBasisCoefficientComparison data c)
+
+/-- The source BNT label attached to a chosen basis element of
+\(\mathcal A_n\). -/
+def sourceLabel (n : ℕ) (hn : 0 < n)
+    (i : AlgebraStructureData.BlockedIndex data n) : Λ :=
+  cmp.labelAssignment.sourceLabel n hn i
+
+/-- The target BNT label attached to a chosen basis element of
+\(\mathcal A_{2n}\). -/
+def targetLabel (n : ℕ) (hn : 0 < n)
+    (k : AlgebraStructureData.BlockedIndex data (2 * n)) : Λ :=
+  cmp.labelAssignment.targetLabel n hn k
 
 /-- Restatement of the blocked-basis/BNT-label coefficient comparison. -/
 theorem blocked_coeff_eq (n : ℕ) (hn : 0 < n)
@@ -495,9 +543,8 @@ IV.13(ii), lines 972--985 of
 def blockedLabel (cmp : BNTBlockedBasisCoefficientComparison data c)
     (n : ℕ) (hn : 0 < n) :
     AlgebraStructureData.BlockedIndex data n ⊕
-      AlgebraStructureData.BlockedIndex data (2 * n) → Λ
-  | Sum.inl i => cmp.sourceLabel n hn i
-  | Sum.inr k => cmp.targetLabel n hn k
+      AlgebraStructureData.BlockedIndex data (2 * n) → Λ :=
+  cmp.labelAssignment.blockedLabel n hn
 
 /-- A blocked-basis/BNT-label coefficient comparison transports a positive
 BNT-label chi trace-power witness to each blocked-basis coefficient. -/

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -349,13 +349,19 @@ variable {data : AlgebraStructureData d D} {Λ : Type*} {c : BNTLabelCoefficient
   (cmp : BNTBlockedBasisCoefficientComparison data c)
 
 /-- The source BNT label attached to a chosen basis element of
-\(\mathcal A_n\). -/
+\(\mathcal A_n\).
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def sourceLabel (n : ℕ) (hn : 0 < n)
     (i : AlgebraStructureData.BlockedIndex data n) : Λ :=
   cmp.labelAssignment.sourceLabel n hn i
 
 /-- The target BNT label attached to a chosen basis element of
-\(\mathcal A_{2n}\). -/
+\(\mathcal A_{2n}\).
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def targetLabel (n : ℕ) (hn : 0 < n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) : Λ :=
   cmp.labelAssignment.targetLabel n hn k

--- a/TNLean/MPS/MPDO/BNTTheoremData.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremData.lean
@@ -153,6 +153,13 @@ theorem positive_chi_trace_power :
     H.coeffs.HasPositiveLengthChiTracePowerForm H.positiveChi.chi :=
   H.positiveChi.tracePower
 
+/-- The Appendix C.3 BNT-label assignment carried by theorem data.
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+def labelAssignment : BNTBlockedBasisLabelAssignment data Λ :=
+  H.blockedComparison.labelAssignment
+
 /-- The source BNT label attached by theorem data to a chosen basis element of
 \(\mathcal A_n\).
 
@@ -160,7 +167,7 @@ Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def sourceLabel (n : ℕ) (hn : 0 < n)
     (i : AlgebraStructureData.BlockedIndex data n) : Λ :=
-  H.blockedComparison.sourceLabel n hn i
+  H.labelAssignment.sourceLabel n hn i
 
 /-- The target BNT label attached by theorem data to a chosen basis element of
 \(\mathcal A_{2n}\).
@@ -169,7 +176,7 @@ Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def targetLabel (n : ℕ) (hn : 0 < n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) : Λ :=
-  H.blockedComparison.targetLabel n hn k
+  H.labelAssignment.targetLabel n hn k
 
 /-- The BNT-label coefficients in theorem data are traces of powers of the
 length-independent chi matrices.
@@ -322,8 +329,7 @@ Appendix C.3--C.4, lines 1830--1942 of
 def blockedComparison_ofChi :
     BNTBlockedBasisCoefficientComparison data
       (BNTLabelCoefficientFamily.ofChi H.positiveChi.chi) where
-  sourceLabel := H.sourceLabel
-  targetLabel := H.targetLabel
+  labelAssignment := H.labelAssignment
   coeff_eq := by
     intro n hn i j k
     rw [H.blocked_coeff_eq n hn i j k]

--- a/TNLean/MPS/MPDO/BNTTheoremWitness.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremWitness.lean
@@ -321,6 +321,13 @@ theorem positive_chi_trace_power :
     W.coeffs.HasPositiveLengthChiTracePowerForm W.positiveChi.chi :=
   W.toTheoremData.positive_chi_trace_power
 
+/-- The Appendix C.3 BNT-label assignment carried by an existential witness.
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+def labelAssignment : BNTBlockedBasisLabelAssignment data W.Label :=
+  W.toTheoremData.labelAssignment
+
 /-- The source BNT label attached by an existential witness to a chosen basis
 element of \(\mathcal A_n\).
 
@@ -328,7 +335,7 @@ Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def sourceLabel (n : ℕ) (hn : 0 < n)
     (i : AlgebraStructureData.BlockedIndex data n) : W.Label :=
-  W.toTheoremData.sourceLabel n hn i
+  W.labelAssignment.sourceLabel n hn i
 
 /-- The target BNT label attached by an existential witness to a chosen basis
 element of \(\mathcal A_{2n}\).
@@ -337,7 +344,7 @@ Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def targetLabel (n : ℕ) (hn : 0 < n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) : W.Label :=
-  W.toTheoremData.targetLabel n hn k
+  W.labelAssignment.targetLabel n hn k
 
 /-- The BNT-label coefficients carried by an existential witness are traces of
 powers of the length-independent chi matrices.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1313,22 +1313,32 @@ the elementary trace-power identity for diagonal matrices.
     This is exactly the defining equality of BNT idempotent coefficient form.
 \end{proof}
 
-\begin{definition}[BNT comparison with blocked coefficients]%
-    \label{def:mpdo_bnt_blocked_basis_coefficient_comparison}
+\begin{definition}[Blocked-basis BNT-label assignment]%
+    \label{def:mpdo_bnt_blocked_basis_label_assignment}
     \lean{MPOTensor.BNTBlockedBasisLabelAssignment}
     \lean{MPOTensor.BNTBlockedBasisLabelAssignment.blockedLabel}
+    \leanok
+    \uses{def:mpdo_blocked_structure_coefficients}
+    The BNT-label assignment consists, for every positive blocked length $n$,
+    of a source label map $\sigma_n$ from the chosen basis of
+    $\mathcal A_n$ and a target label map $\tau_n$ from the chosen basis of
+    $\mathcal A_{2n}$ to the fixed BNT labels.  It also gives the combined
+    label map $\sigma_n \sqcup \tau_n$ on the disjoint union of these two
+    blocked bases.
+\end{definition}
+
+\begin{definition}[BNT comparison with blocked coefficients]%
+    \label{def:mpdo_bnt_blocked_basis_coefficient_comparison}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.sourceLabel}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.targetLabel}
     \leanok
     \uses{def:mpdo_bnt_label_coefficient_family,
-        def:mpdo_blocked_structure_coefficients}
-    The BNT-label assignment consists, for every positive blocked length $n$,
-    of a source label map $\sigma_n$ from the chosen basis of
-    $\mathcal A_n$ and a target label map $\tau_n$ from the chosen basis of
-    $\mathcal A_{2n}$ to the fixed BNT labels. A comparison between the
-    BNT-label coefficients and the chosen blocked-basis coefficients adds the
-    equality
+        def:mpdo_blocked_structure_coefficients,
+        def:mpdo_bnt_blocked_basis_label_assignment}
+    A comparison between the BNT-label coefficients and the chosen
+    blocked-basis coefficients consists of a BNT-label assignment together
+    with the equality
     \[
         c^{(n)}_{i,j,k}
         =
@@ -1686,6 +1696,7 @@ the elementary trace-power identity for diagonal matrices.
         def:mpdo_bnt_label_same_length_product_form,
         def:mpdo_bnt_label_idempotent_coefficient_form,
         def:mpdo_positive_bnt_label_chi_trace_power_form,
+        def:mpdo_bnt_blocked_basis_label_assignment,
         def:mpdo_bnt_blocked_basis_coefficient_comparison}
     The BNT-label theorem data consist of the fixed BNT-label coefficient
     system, the same-length BNT operator family and product identity, the trace

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1315,22 +1315,27 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{definition}[BNT comparison with blocked coefficients]%
     \label{def:mpdo_bnt_blocked_basis_coefficient_comparison}
+    \lean{MPOTensor.BNTBlockedBasisLabelAssignment}
+    \lean{MPOTensor.BNTBlockedBasisLabelAssignment.blockedLabel}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison}
+    \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.sourceLabel}
+    \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.targetLabel}
     \leanok
     \uses{def:mpdo_bnt_label_coefficient_family,
         def:mpdo_blocked_structure_coefficients}
-    A comparison between the BNT-label coefficients and the chosen
-    blocked-basis coefficients consists, for every positive blocked length
-    \(n\), of a source label map \(\sigma_n\) from the chosen basis of
-    \(\mathcal A_n\) and a target label map \(\tau_n\) from the chosen basis
-    of \(\mathcal A_{2n}\) to the fixed BNT labels, together with the equality
+    The BNT-label assignment consists, for every positive blocked length $n$,
+    of a source label map $\sigma_n$ from the chosen basis of
+    $\mathcal A_n$ and a target label map $\tau_n$ from the chosen basis of
+    $\mathcal A_{2n}$ to the fixed BNT labels. A comparison between the
+    BNT-label coefficients and the chosen blocked-basis coefficients adds the
+    equality
     \[
         c^{(n)}_{i,j,k}
         =
         c^{(n)}_{\sigma_n(i),\sigma_n(j),\tau_n(k)}.
     \]
     This is a blocked-basis comparison: the left hand side is expanded in the
-    chosen basis of \(\mathcal A_{2n}\), so the statement is not itself the
+    chosen basis of $\mathcal A_{2n}$, so the statement is not itself the
     same-length BNT product law.
     This records the coefficient-comparison statement separately from the
     construction of the label maps from the MPDO tensor.
@@ -1669,6 +1674,7 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_ofChi}
     \lean{MPOTensor.BNTLabelTheoremData.positive_chi_pos_entries}
     \lean{MPOTensor.BNTLabelTheoremData.positive_chi_trace_power}
+    \lean{MPOTensor.BNTLabelTheoremData.labelAssignment}
     \lean{MPOTensor.BNTLabelTheoremData.sourceLabel}
     \lean{MPOTensor.BNTLabelTheoremData.targetLabel}
     \lean{MPOTensor.BNTLabelTheoremData.positiveBlockedChi}
@@ -1926,6 +1932,7 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_ofChi}
     \lean{MPOTensor.BNTLabelTheoremWitness.positive_chi_pos_entries}
     \lean{MPOTensor.BNTLabelTheoremWitness.positive_chi_trace_power}
+    \lean{MPOTensor.BNTLabelTheoremWitness.labelAssignment}
     \lean{MPOTensor.BNTLabelTheoremWitness.sourceLabel}
     \lean{MPOTensor.BNTLabelTheoremWitness.targetLabel}
     \lean{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -149,22 +149,26 @@ idempotent condition
       \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta
 \]
 is also represented as a predicate on the trace scalars
-\(m_\alpha=\operatorname{tr}(\mu_\alpha)\).\footnote{%
+$m_\alpha=\operatorname{tr}(\mu_\alpha)$.\footnote{%
 \leanid{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm}.}  A
-positive BNT-label \(\chi\)-witness consists of a length-independent diagonal
-family \(\chi_{\alpha,\beta,\gamma}\), positivity of every diagonal entry, and
+positive BNT-label $\chi$-witness consists of a length-independent diagonal
+family $\chi_{\alpha,\beta,\gamma}$, positivity of every diagonal entry, and
 the positive-length trace-power identity.\footnote{%
 \leanid{MPOTensor.PositiveBNTLabelChiTracePowerForm}.}
-If the coefficients are chosen canonically from the same \(\chi\)-family, then
+If the coefficients are chosen canonically from the same $\chi$-family, then
 positivity of the diagonal entries alone gives such a witness.\footnote{%
 \leanid{MPOTensor.PositiveBNTLabelChiTracePowerForm.ofChi}.}
 A blocked-basis comparison predicate records that the chosen blocked
 multiplication coefficients are the pullback of the source-length BNT-label
-coefficients along a source label map from \(\mathcal A_n\) and a target label
-map from \(\mathcal A_{2n}\).\footnote{%
+coefficients along a source label map from $\mathcal A_n$ and a target label
+map from $\mathcal A_{2n}$.  The label-assignment datum is now separated from
+the coefficient equality, so the Appendix C.3 construction target can be stated
+without also assuming the comparison formula.\footnote{%
+\leanid{MPOTensor.BNTBlockedBasisLabelAssignment},
+\leanid{MPOTensor.BNTBlockedBasisLabelAssignment.blockedLabel},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison}.}  This predicate
 inherits the second scope restriction above: its left hand side is expanded in a
-basis of \(\mathcal A_{2n}\), while the source theorem's BNT product law is
+basis of $\mathcal A_{2n}$, while the source theorem's BNT product law is
 same-length. It therefore records the formal blocked-basis comparison
 predicate; constructing the source label maps from an MPDO tensor is still part
 of the Appendix C.3--C.4 witness construction. The predicate is not itself the
@@ -235,6 +239,7 @@ formula are immediate consequences.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremData.idempotent_coefficient_form},
 \leanid{MPOTensor.BNTLabelTheoremData.positive_chi_pos_entries},
 \leanid{MPOTensor.BNTLabelTheoremData.positive_chi_trace_power},
+\leanid{MPOTensor.BNTLabelTheoremData.labelAssignment},
 \leanid{MPOTensor.BNTLabelTheoremData.sourceLabel},
 \leanid{MPOTensor.BNTLabelTheoremData.targetLabel},
 \leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum},
@@ -281,6 +286,7 @@ algebraic structure, and the corresponding theorem data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_coefficient_form},
 \leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_pos_entries},
 \leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_trace_power},
+\leanid{MPOTensor.BNTLabelTheoremWitness.labelAssignment},
 \leanid{MPOTensor.BNTLabelTheoremWitness.sourceLabel},
 \leanid{MPOTensor.BNTLabelTheoremWitness.targetLabel},
 \leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi}.}  The existential

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -161,7 +161,7 @@ positivity of the diagonal entries alone gives such a witness.\footnote{%
 A blocked-basis comparison predicate records that the chosen blocked
 multiplication coefficients are the pullback of the source-length BNT-label
 coefficients along a source label map from $\mathcal A_n$ and a target label
-map from $\mathcal A_{2n}$.  The label-assignment datum is now separated from
+map from $\mathcal A_{2n}$.  The label-assignment datum is separated from
 the coefficient equality, so the Appendix C.3 construction target can be stated
 without also assuming the comparison formula.\footnote{%
 \leanid{MPOTensor.BNTBlockedBasisLabelAssignment},


### PR DESCRIPTION
### Motivation

This is a source-faithful step for arXiv:1606.00608, Appendix C.3 and Theorem IV.13(ii). The blocked-basis comparison already contained the maps from chosen blocked-basis labels to BNT labels, but those maps were only visible as part of the coefficient comparison. The Appendix C.3 construction first supplies the label assignment, before proving the coefficient equality.

### Description

- Add `MPOTensor.BNTBlockedBasisLabelAssignment` for the source and target BNT-label maps on `AlgebraStructureData.BlockedIndex` at lengths `n` and `2 * n`.
- Make `BNTBlockedBasisCoefficientComparison` carry that assignment and keep the existing `sourceLabel`, `targetLabel`, and `blockedLabel` accessors.
- Expose the assignment from `BNTLabelTheoremData` and `BNTLabelTheoremWitness`.
- Update Chapter 2b and `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` to record that the label-assignment datum is now separated from the coefficient equality.

### Testing

- `lake build TNLean.MPS.MPDO.BNTCoefficients`
- `lake build TNLean.MPS.MPDO.BNTTheoremData`
- `lake build TNLean.MPS.MPDO.BNTTheoremWitness`
- `lake build TNLean.MPS.MPDO.BNTTheoremWitnessConsequences`
- `lake env lean TNLean.lean`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/MPDO/BNTCoefficients.lean TNLean/MPS/MPDO/BNTTheoremData.lean TNLean/MPS/MPDO/BNTTheoremWitness.lean blueprint/src/chapter/ch02b_mpdo.tex docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- touched-file line-length and proof-integrity scans
- `leanblueprint web`

---
Refs #2000.
Leaves issue #2000 open.

> [!NOTE]
> **Low Risk**
> Refactor of formal predicates and accessors with no auth, I/O, or runtime behavior; API surface grows slightly but existing comparison theorems stay via delegating defs.
> 
> **Overview**
> Introduces **`BNTBlockedBasisLabelAssignment`** as its own Appendix C.3 datum (source/target maps from blocked basis indices at lengths `n` and `2n`, plus **`blockedLabel`** on the disjoint union). **`BNTBlockedBasisCoefficientComparison`** now holds a **`labelAssignment`** field and only **`coeff_eq`**; **`sourceLabel`**, **`targetLabel`**, and comparison **`blockedLabel`** delegate to that assignment.
> 
> **`BNTLabelTheoremData`** and **`BNTLabelTheoremWitness`** expose **`labelAssignment`** and route label accessors through it; **`blockedComparison_ofChi`** supplies **`labelAssignment`** instead of duplicating maps. Blueprint **ch02b** and **`cpgsv17_blocked_chi_uniformity.tex`** document that label assignment can be stated before assuming the coefficient pullback equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63949b7f3360822126170a6a1e022b8c48588b63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal predicate refactor and delegating accessors only; no runtime, auth, or data-path changes, with existing comparison theorems preserved via thin wrappers.
> 
> **Overview**
> This PR **splits Appendix C.3 label maps** from the blocked-basis coefficient comparison in the MPDO BNT formalization, so the paper order (assignment first, then `coeff_eq`) is explicit in Lean.
> 
> A new structure **`BNTBlockedBasisLabelAssignment`** holds `sourceLabel` / `targetLabel` on blocked indices at lengths `n` and `2n`, plus **`blockedLabel`** on the disjoint union. **`BNTBlockedBasisCoefficientComparison`** now has **`labelAssignment`** and **`coeff_eq`** only; **`sourceLabel`**, **`targetLabel`**, and comparison-level **`blockedLabel`** delegate to the assignment.
> 
> **`BNTLabelTheoremData`** and **`BNTLabelTheoremWitness`** expose **`labelAssignment`** and route label accessors through it; **`blockedComparison_ofChi`** supplies `labelAssignment` instead of duplicating maps. Blueprint **ch02b** and **`cpgsv17_blocked_chi_uniformity.tex`** document that label assignment can be stated without assuming the coefficient pullback equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 566dd719b19314c098f28ee4366bbd05e8fdfe12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->