### PR TITLE
feat(MPS/MPDO): record algebra-fusion fixed-point consequences

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -544,10 +544,10 @@ theorem adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra
 side hypotheses, the stationary adjoint fixed-point tower is itself compatible
 with the MPO tensor.
 
-This packages the fixed-point equality above into the canonical stationary
-tower used by Wolf's adjoint fixed-point algebra theorem.  It is still only a
-consequence of the present algebra-tower predicate, not the source converse
-from Theorem IV.13(ii) to the fusion-isometry formulation.
+Applying the fixed-point equality above to the stationary tower constructed
+from the faithful fixed point yields compatibility with the MPO tensor.  It is
+still only a consequence of the present algebra-tower predicate, not the source
+converse from Theorem IV.13(ii) to the fusion-isometry formulation.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
 lines 2015--2067 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem stationaryOfFaithfulFixedPoint_compatible_of_isRFP_MPDO_via_algebra

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -523,6 +523,44 @@ theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply
         simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
       rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, ih, hX]
 
+/-- Under the current algebra-structure predicate, the adjoint fixed points of
+every positive blocked transfer map coincide with the adjoint fixed points of
+the unblocked transfer map.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
+lines 2015--2067. This equality is only the fixed-point consequence of the
+present algebra-tower predicate. It is not the converse
+`IsRFP_MPDO_via_algebra M → IsRFP_MPDO_via_fusion M`; the latter requires the
+positive trace-power coefficient comparison used in Appendix C.4. -/
+theorem adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra
+    {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
+    {n : ℕ} (hn : 0 < n) {X : Mat} :
+    (blockedTransferMap M n).adjoint X = X ↔ (transferMap M).adjoint X = X := by
+  constructor
+  · exact adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra hAlg hn
+  · exact adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply n
+
+/-- Under the current algebra-structure predicate and the faithful fixed-point
+side hypotheses, the stationary adjoint fixed-point tower is itself compatible
+with the MPO tensor.
+
+This packages the fixed-point equality above into the canonical stationary
+tower used by Wolf's adjoint fixed-point algebra theorem.  It is still only a
+consequence of the present algebra-tower predicate, not the source converse
+from Theorem IV.13(ii) to the fusion-isometry formulation.
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
+lines 2015--2067 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem stationaryOfFaithfulFixedPoint_compatible_of_isRFP_MPDO_via_algebra
+    {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
+    (h_tp : Kraus.IsTP M.toMPSTensor)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ) :
+    (AlgebraStructureData.stationaryOfFaithfulFixedPoint M h_tp hρ hρ_fix).CompatibleWith M :=
+  AlgebraStructureData.stationaryOfFaithfulFixedPoint_compatible_of_adjointFixedPoints_eq
+    (M := M) (h_tp := h_tp) hρ hρ_fix
+    (fun _ hn X =>
+      (adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra
+        (M := M) hAlg hn (X := X)).symm)
+
 /-! ### Diagonal $\chi$-matrices and the trace-power formula
 
 The paper arXiv:1606.00608 (Cirac--Perez-Garcia--Schuch--Verstraete 2017),

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -530,8 +530,8 @@ the unblocked transfer map.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
 lines 2015--2067. This equality is only the fixed-point consequence of the
 present algebra-tower predicate. It is not the converse
-`IsRFP_MPDO_via_algebra M → IsRFP_MPDO_via_fusion M`; the latter requires the
-positive trace-power coefficient comparison used in Appendix C.4. -/
+from the algebra formulation to the fusion formulation; the latter requires
+the positive trace-power coefficient comparison used in Appendix C.4. -/
 theorem adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     {n : ℕ} (hn : 0 < n) {X : Mat} :

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -147,6 +147,25 @@ theorem isRFP (F : FusionIsometryData M 1) : IsRFP M := by
 
 end FusionIsometryData
 
+/-- A one-site transfer-map fusion retract is equivalent to the MPDO RFP
+condition.
+
+The forward direction is the retract calculation
+\(E_1^2 = S_1T_1S_1T_1 = S_1T_1\).  The reverse direction factors the
+idempotent transfer map through its range.
+
+Source: arXiv:1606.00608, Theorem IV.13(i), and Appendix C.4, lines
+2065--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`, where the converse
+algebra-to-fusion proof constructs the one-step maps `T` and `S`. -/
+theorem fusionIsometryData_one_iff_isRFP (M : MPOTensor d D) :
+    Nonempty (FusionIsometryData M 1) ↔ IsRFP M := by
+  constructor
+  · rintro ⟨F⟩
+    exact F.isRFP
+  · intro hM
+    exact ⟨FusionIsometryData.ofBlockedTransferMapIdempotent
+      (M := M) (n := 1) (by simpa only [blockedTransferMap_one] using hM)⟩
+
 /-- If `M` is already an MPDO renormalization fixed point, then every positive
 blocked transfer map coincides with the original transfer map. -/
 theorem blockedTransferMap_eq_transferMap_of_isRFP {M : MPOTensor d D}
@@ -193,6 +212,16 @@ theorem isRFP_MPDO_via_fusion_iff_isRFP (M : MPOTensor d D) :
   constructor
   · exact isRFP_of_isRFP_MPDO_via_fusion
   · exact isRFP_MPDO_via_fusion_of_isRFP
+
+/-- The all-blocked transfer-map fusion formulation is equivalent to a
+one-site fusion retract.
+
+Thus, in the present transfer-map formulation, an algebra-to-fusion proof may
+be reduced to constructing the one-step retract appearing in Appendix C.4 of
+arXiv:1606.00608. -/
+theorem isRFP_MPDO_via_fusion_iff_fusionIsometryData_one (M : MPOTensor d D) :
+    IsRFP_MPDO_via_fusion M ↔ Nonempty (FusionIsometryData M 1) := by
+  rw [isRFP_MPDO_via_fusion_iff_isRFP, fusionIsometryData_one_iff_isRFP]
 
 /-- The transfer-map-level fusion formulation agrees with the pure-state RFP
 condition for the doubled-index MPS tensor. -/

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -156,7 +156,7 @@ idempotent transfer map through its range.
 
 Source: arXiv:1606.00608, Theorem IV.13(i), and Appendix C.4, lines
 2065--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`, where the converse
-algebra-to-fusion proof constructs the one-step maps `T` and `S`. -/
+algebra-to-fusion proof constructs the one-step maps \(T\) and \(S\). -/
 theorem fusionIsometryData_one_iff_isRFP (M : MPOTensor d D) :
     Nonempty (FusionIsometryData M 1) ↔ IsRFP M := by
   constructor

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -886,10 +886,13 @@ retract.
 
 \begin{theorem}[Fusion-isometry data imply the MPDO RFP condition]%
     \label{thm:mpdo_rfp_of_fusion}
+    \lean{MPOTensor.FusionIsometryData.isRFP}
     \lean{MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
-    The fusion-isometry formulation implies the MPDO RFP condition.
+    A one-site fusion-isometry datum implies the MPDO RFP condition.  Hence the
+    fusion-isometry formulation, which supplies such data at every positive
+    blocked size, implies the same condition.
 \end{theorem}
 \begin{proof}\leanok
     Apply the definition at blocked size $n = 1$.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -899,6 +899,20 @@ retract.
     condition.
 \end{proof}
 
+\begin{theorem}[One-site fusion retract criterion]%
+    \label{thm:mpdo_one_site_fusion_iff_rfp}
+    \lean{MPOTensor.fusionIsometryData_one_iff_isRFP}
+    \leanok
+    \uses{def:mpdo_fusion_isometry}
+    A one-site transfer-map fusion-isometry datum exists if and only if the MPO
+    transfer map is idempotent.
+\end{theorem}
+\begin{proof}\leanok
+    The forward implication is the retract calculation
+    $E_1^2 = S_1T_1S_1T_1 = S_1T_1$. Conversely, if $E_1$ is idempotent, then
+    it factors through its range, giving the required one-site datum.
+\end{proof}
+
 \begin{theorem}[Transfer-map fusion criterion for MPDO RFP]%
     \label{thm:mpdo_rfp_via_fusion_iff}
     \lean{MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP}
@@ -924,6 +938,21 @@ retract.
 \begin{proof}\leanok
     Combine Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} with the diagonal pure-state
     recovery theorem for the MPO predicate.
+\end{proof}
+
+\begin{theorem}[All-blocked fusion reduces to one-site fusion]%
+    \label{thm:mpdo_fusion_iff_one_site_fusion}
+    \lean{MPOTensor.isRFP_MPDO_via_fusion_iff_fusionIsometryData_one}
+    \leanok
+    \uses{def:mpdo_rfp_via_fusion, thm:mpdo_one_site_fusion_iff_rfp,
+        thm:mpdo_rfp_via_fusion_iff}
+    The fusion-isometry formulation for all positive blocked sizes is
+    equivalent to the existence of a one-site transfer-map fusion-isometry
+    datum.
+\end{theorem}
+\begin{proof}\leanok
+    Combine the one-site criterion with the equivalence between the all-blocked
+    fusion formulation and transfer-map idempotence.
 \end{proof}
 
 \section{Algebra structure}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1110,10 +1110,36 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     Induction on $n$ using $E_{n+1} = E_n \circ E_1$ and
     $(A \circ B)^{\dagger} = B^{\dagger} \circ A^{\dagger}$; the base case is
     $E_0 = \mathrm{id}$. This step does not require the algebra-structure data.
-    Combined with Theorem~\ref{thm:mpdo_adjoint_fix_descent} this yields the
-    fixed-point equality
-    $\mathrm{Fix}(E_n^{\dagger}) = \mathrm{Fix}(E_1^{\dagger})$ at every positive
-    blocking size under the algebra-structure predicate.
+\end{proof}
+
+\begin{theorem}[Adjoint fixed-point equality for algebra towers]%
+    \label{thm:mpdo_adjoint_fix_equality_from_algebra}
+    \lean{MPOTensor.adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra}
+    \leanok
+    \uses{def:mpdo_rfp_via_algebra, thm:mpdo_adjoint_fix_descent,
+        lem:mpdo_adjoint_fix_reverse}
+    If an MPO tensor satisfies the algebra-structure formulation, then for
+    every positive blocking size $n$ the adjoint fixed points of $E_n$ are
+    exactly the adjoint fixed points of $E_1$.
+\end{theorem}
+\begin{proof}\leanok
+    Combine Theorem~\ref{thm:mpdo_adjoint_fix_descent} with
+    Lemma~\ref{lem:mpdo_adjoint_fix_reverse}.
+\end{proof}
+
+\begin{theorem}[Algebra data give the stationary fixed-point tower]%
+    \label{thm:mpdo_stationary_tower_from_algebra}
+    \lean{MPOTensor.stationaryOfFaithfulFixedPoint_compatible_of_isRFP_MPDO_via_algebra}
+    \leanok
+    \uses{def:mpdo_rfp_via_algebra,
+        thm:mpdo_adjoint_fix_equality_from_algebra}
+    Under the trace-preserving normalization and a positive-definite fixed
+    point, any algebra-structure witness forces the stationary adjoint
+    fixed-point tower itself to be compatible with the MPO tensor.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the adjoint fixed-point equality obtained from the algebra-structure
+    predicate to the stationary tower constructed from the faithful fixed point.
 \end{proof}
 
 \begin{remark}[Why algebra data do not imply fusion data]%

--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -3,7 +3,7 @@
 \DeclareUnicodeCharacter{2082}{\ifmmode{}_{2}\else\textsubscript{2}\fi}
 
 \newcommand{\Lean}{\textsc{Lean}}
-\newcommand{\leanid}[1]{\textsf{#1}}
+\newcommand{\leanid}[1]{\textsf{\detokenize{#1}}}
 \providecommand{\tr}{\operatorname{tr}}
 \newcommand{\tnleanIssueBase}{https://github.com/LionSR/TNLean/issues/}
 \newcommand{\tnleanPrBase}{https://github.com/LionSR/TNLean/pull/}

--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -3,7 +3,7 @@
 \DeclareUnicodeCharacter{2082}{\ifmmode{}_{2}\else\textsubscript{2}\fi}
 
 \newcommand{\Lean}{\textsc{Lean}}
-\newcommand{\leanid}[1]{\textsf{\detokenize{#1}}}
+\newcommand{\leanid}[1]{\textsf{#1}}
 \providecommand{\tr}{\operatorname{tr}}
 \newcommand{\tnleanIssueBase}{https://github.com/LionSR/TNLean/issues/}
 \newcommand{\tnleanPrBase}{https://github.com/LionSR/TNLean/pull/}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -116,6 +116,42 @@ should not be cited as a formalization of Theorem~IV.13(ii). It is a local
 blocked-basis coefficient statement, useful only after the
 uniform BNT-label statement has been separated from the chosen blocked bases.
 
+\section{Relation to the algebra-to-fusion converse}
+
+The converse direction \((\mathrm{ii})\Rightarrow(\mathrm{i})\) in the proof of
+Theorem~IV.13 uses the uniform BNT-label coefficients in an essential way.  In
+Appendix~C.4, lines~2046--2085, the authors compare the two BNT expansions
+coming from the one-site and two-site decompositions.  The source identity
+\texttt{eq:algebra-appendix}, positivity of the coefficients, and
+Lemma~\texttt{Lem:app\_simple} imply that, after relabelling,
+\[
+    A_\gamma = U_\gamma M_\gamma U_\gamma^{-1}
+\]
+with \(U_\gamma\) unitary, and that
+\[
+    \operatorname{tr}(\nu_\gamma)
+      = \sum_{\alpha,\beta}m_\alpha m_\beta
+          c^{(1)}_{\alpha,\beta,\gamma}
+      = m_\gamma .
+\]
+Only after this trace equality is obtained do the maps
+\[
+    T=\widetilde R_2\widetilde T R_1,
+    \qquad
+    S=\widetilde R_1\widetilde S R_2
+\]
+have the normalizing factors required in lines~2065--2085.
+
+The present algebra predicate
+\leanid{MPOTensor.IsRFP_MPDO_via_algebra} does not include these BNT-label
+coefficients, the positive \(\chi_{\alpha,\beta,\gamma}\), or the
+length-one idempotent trace identity.  It can prove equality of adjoint
+fixed-point spaces across positive blocking lengths, but this is weaker than
+the coefficient comparison used above.  Thus the source-faithful route to the
+fusion formulation must first construct the BNT-label theorem witness and the
+idempotent trace-scalar identity, and then use the one-site retract criterion
+\leanid{MPOTensor.fusionIsometryData_one_iff_isRFP}.
+
 \section{BNT-label coefficient objects and remaining elimination plan}
 
 The same-length coefficient family \(c^{(L)}_{\alpha,\beta,\gamma}\), indexed

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -122,12 +122,20 @@ The converse direction \((\mathrm{ii})\Rightarrow(\mathrm{i})\) in the proof of
 Theorem~IV.13 uses the uniform BNT-label coefficients in an essential way.  In
 Appendix~C.4, lines~2046--2085, the authors compare the two BNT expansions
 coming from the one-site and two-site decompositions.  The source identity
-\texttt{eq:algebra-appendix}, positivity of the coefficients, and
-Lemma~\texttt{Lem:app\_simple} imply that, after relabelling,
+\texttt{eq:algebra-appendix} is stated at lines~1933--1936 and used in this
+converse at lines~2048--2050.  Together with positivity of the coefficients
+and Lemma~\texttt{Lem:app\_simple} (lines~1155--1163), it first gives, after
+relabelling,
+\[
+    A_\gamma
+      = e^{i\theta_\gamma} Z_\gamma M_\gamma Z_\gamma^{-1}.
+\]
+Proposition~IV.12 then removes the phase and identifies \(Z_\gamma\) with a
+unitary \(U_\gamma\), as in line~2057.  Thus
 \[
     A_\gamma = U_\gamma M_\gamma U_\gamma^{-1}
 \]
-with \(U_\gamma\) unitary, and that
+with \(U_\gamma\) unitary, and Lemma~\texttt{Lem:app\_simple} also gives
 \[
     \operatorname{tr}(\nu_\gamma)
       = \sum_{\alpha,\beta}m_\alpha m_\beta
@@ -143,14 +151,14 @@ Only after this trace equality is obtained do the maps
 have the normalizing factors required in lines~2065--2085.
 
 The present algebra predicate
-\leanid{MPOTensor.IsRFP_MPDO_via_algebra} does not include these BNT-label
+\leanid{MPOTensor.IsRFP\_MPDO\_via\_algebra} does not include these BNT-label
 coefficients, the positive \(\chi_{\alpha,\beta,\gamma}\), or the
 length-one idempotent trace identity.  It can prove equality of adjoint
 fixed-point spaces across positive blocking lengths, but this is weaker than
 the coefficient comparison used above.  Thus the source-faithful route to the
 fusion formulation must first construct the BNT-label theorem witness and the
 idempotent trace-scalar identity, and then use the one-site retract criterion
-\leanid{MPOTensor.fusionIsometryData_one_iff_isRFP}.
+\leanid{MPOTensor.fusionIsometryData\_one\_iff\_isRFP}.
 
 \section{BNT-label coefficient objects and remaining elimination plan}
 
@@ -167,11 +175,11 @@ family
 This is recorded separately so that the \(\chi\)-family can serve as the single
 source of those coefficients in the source-side special case.\footnote{%
 \leanid{MPOTensor.BNTLabelCoefficientFamily.ofChi},
-\leanid{MPOTensor.BNTLabelCoefficientFamily.ofChi_coeff},
+\leanid{MPOTensor.BNTLabelCoefficientFamily.ofChi\_coeff},
 \leanid{MPOTensor.BNTLabelCoefficientFamily.%
-ofChi_coeff_eq_trace_matrix_pow},
+ofChi\_coeff\_eq\_trace\_matrix\_pow},
 \leanid{MPOTensor.BNTLabelCoefficientFamily.%
-ofChi_hasPositiveLengthChiTracePowerForm}.}  A
+ofChi\_hasPositiveLengthChiTracePowerForm}.}  A
 same-length BNT product predicate records the algebra identity
 \[
     O_L(M_\alpha)O_L(M_\beta)
@@ -217,28 +225,28 @@ Once both the same-length BNT product form and a positive BNT-label
 coefficients written as \(\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)\)
 is formalized as a direct corollary.\footnote{%
 \leanid{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.%
-eq_sum_chi_trace_pow},
+eq\_sum\_chi\_trace\_pow},
 \leanid{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.%
-eq_sum_ofChi_trace_pow}.}
+eq\_sum\_ofChi\_trace\_pow}.}
 Once both the comparison predicate and a positive BNT-label \(\chi\)-witness are
 available, the coefficient-level blocked trace-power formula is formalized as a
 direct corollary.\footnote{%
-\leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow},
+\leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked\_coeff\_eq\_trace\_pow},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-blocked_coeff_eq_ofChi_trace_pow},
+blocked\_coeff\_eq\_ofChi\_trace\_pow},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-blocked_coeff_eq_pulledBlockedChi_trace_pow}.}
+blocked\_coeff\_eq\_pulledBlockedChi\_trace\_pow}.}
 The same hypotheses also give a positive blocked-basis \(\chi\)-witness by
 pulling back the uniform BNT-label \(\chi\)-family along the
 comparison maps.\footnote{%
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-pulledBlockedChiFamily_toDiagonal_of_pos},
+pulledBlockedChiFamily\_toDiagonal\_of\_pos},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-pulledBlockedChi_tracePowerCoeff_of_pos},
+pulledBlockedChi\_tracePowerCoeff\_of\_pos},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-pulledBlockedChi_dim_of_pos},
+pulledBlockedChi\_dim\_of\_pos},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-pulledBlockedChi_trace_matrix_pow_of_pos},
+pulledBlockedChi\_trace\_matrix\_pow\_of\_pos},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
 toPositiveBlockedStructureChiTracePowerForm}.}
 Likewise, once the idempotent coefficient condition and the positive
@@ -246,9 +254,9 @@ BNT-label \(\chi\)-witness are available, the length-one idempotent identity is
 formalized with the coefficients rewritten as traces of the corresponding
 \(\chi\)-matrices.\footnote{%
 \leanid{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.%
-eq_sum_chi_trace},
+eq\_sum\_chi\_trace},
 \leanid{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.%
-eq_sum_ofChi_trace}.}
+eq\_sum\_ofChi\_trace}.}
 
 The BNT-label objects above are now also gathered into one theorem-data record:
 fixed coefficients, same-length operators and product law, trace scalars and
@@ -271,41 +279,41 @@ trace-power formula, the blocked-basis coefficient comparison, the positive
 blocked \(\chi\)-witness, the pulled-back blocked trace-power predicate, and the
 pulled-back blocked-basis \(\chi\)-family with positive entries and trace-power
 formula are immediate consequences.\footnote{%
-\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_form},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent_coefficient_form},
-\leanid{MPOTensor.BNTLabelTheoremData.positive_chi_pos_entries},
-\leanid{MPOTensor.BNTLabelTheoremData.positive_chi_trace_power},
+\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_form},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_coefficient\_form},
+\leanid{MPOTensor.BNTLabelTheoremData.positive\_chi\_pos\_entries},
+\leanid{MPOTensor.BNTLabelTheoremData.positive\_chi\_trace\_power},
 \leanid{MPOTensor.BNTLabelTheoremData.labelAssignment},
 \leanid{MPOTensor.BNTLabelTheoremData.sourceLabel},
 \leanid{MPOTensor.BNTLabelTheoremData.targetLabel},
-\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum},
-\leanid{MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow},
-\leanid{MPOTensor.BNTLabelTheoremData.coeff_eq_ofChi_coeff},
-\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_form_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent_coefficient_form_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.chi_entry_pos},
-\leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq},
-\leanid{MPOTensor.BNTLabelTheoremData.blockedComparison_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_chi_trace},
-\leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_eq\_sum},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_eq\_sum},
+\leanid{MPOTensor.BNTLabelTheoremData.coeff\_eq\_trace\_pow},
+\leanid{MPOTensor.BNTLabelTheoremData.coeff\_eq\_ofChi\_coeff},
+\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_form\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_coefficient\_form\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_eq\_sum\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_eq\_sum\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.chi\_entry\_pos},
+\leanid{MPOTensor.BNTLabelTheoremData.blocked\_coeff\_eq},
+\leanid{MPOTensor.BNTLabelTheoremData.blockedComparison\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.blocked\_coeff\_eq\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_eq\_sum\_chi\_trace\_pow},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_eq\_sum\_chi\_trace},
+\leanid{MPOTensor.BNTLabelTheoremData.blocked\_coeff\_eq\_trace\_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm},
 \leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_toDiagonal_of_pos},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_toDiagonal\_of\_pos},
 \leanid{MPOTensor.BNTLabelTheoremData.%
-positiveBlockedChi_tracePowerCoeff_of_pos},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_dim_of_pos},
+positiveBlockedChi\_tracePowerCoeff\_of\_pos},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_dim\_of\_pos},
 \leanid{MPOTensor.BNTLabelTheoremData.%
-positiveBlockedChi_trace_matrix_pow_of_pos},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_tracePower},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_posEntries},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_entry_pos},
+positiveBlockedChi\_trace\_matrix\_pow\_of\_pos},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_tracePower},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_posEntries},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_entry\_pos},
 \leanid{MPOTensor.BNTLabelTheoremData.%
-blocked_coeff_eq_positiveBlockedChi_trace_pow}.}
+blocked\_coeff\_eq\_positiveBlockedChi\_trace\_pow}.}
 
 The same data can be stated in the existential form closest to the paper: one
 object records the BNT-label type, the same-length operator spaces, their
@@ -318,10 +326,10 @@ algebraic structure, and the corresponding theorem data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.traceScalars},
 \leanid{MPOTensor.BNTLabelTheoremWitness.positiveChi},
 \leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_form},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_coefficient_form},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_pos_entries},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_trace_power},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_form},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_coefficient\_form},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positive\_chi\_pos\_entries},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positive\_chi\_trace\_power},
 \leanid{MPOTensor.BNTLabelTheoremWitness.labelAssignment},
 \leanid{MPOTensor.BNTLabelTheoremWitness.sourceLabel},
 \leanid{MPOTensor.BNTLabelTheoremWitness.targetLabel},
@@ -332,20 +340,20 @@ equations written with \(c^{(L)}_{\alpha,\beta,\gamma}\), and the same two
 equations with coefficients written as \(\chi\)-traces; the blocked-basis
 \(\chi\)-family is also identified as the pullback of the BNT-label
 \(\chi\)-family along the comparison maps.\footnote{%
-\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists_source_predicates},
+\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists\_source\_predicates},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists_positive_length_coeff_eq_ofChi},
-\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists_source_ofChi_predicates},
-\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists_source_ofChi_equations},
-\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists_blocked_chi_pullback},
+exists\_positive\_length\_coeff\_eq\_ofChi},
+\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists\_source\_ofChi\_predicates},
+\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists\_source\_ofChi\_equations},
+\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists\_blocked\_chi\_pullback},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists_blocked_coefficient_comparison},
+exists\_blocked\_coefficient\_comparison},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists_blocked_coefficient_comparison_ofChi},
+exists\_blocked\_coefficient\_comparison\_ofChi},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists_source_coefficient_equations},
+exists\_source\_coefficient\_equations},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists_source_chi_trace_equations}.}
+exists\_source\_chi\_trace\_equations}.}
 The existential
 statement has the analogous canonical construction from a positive
 \(\chi\)-family, again leaving the product, idempotent, and blocked-comparison
@@ -353,7 +361,7 @@ statements as inputs rather than reconstructing them from an MPDO tensor.\footno
 \leanid{MPOTensor.BNTLabelTheoremWitness.ofChi},
 \leanid{MPOTensor.BNTLabelTheoremWitness.hasBNTLabelTheoremWitness},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-ofChi_hasBNTLabelTheoremWitness}.}  Such a witness
+ofChi\_hasBNTLabelTheoremWitness}.}  Such a witness
 immediately gives the source predicates and their consequences: the coefficient
 trace-power formula, the same-length product law, the idempotent scalar law,
 positivity of the diagonal \(\chi\)-entries, the blocked-basis coefficient
@@ -361,47 +369,47 @@ comparison, the same-length chi-trace product law, the chi-trace idempotent law,
 the blocked-basis coefficient trace-power formula, the positive blocked-basis
 \(\chi\)-witness, and the pulled-back blocked trace-power predicate and
 \(\chi\)-family for the chosen algebra-structure data.\footnote{%
-\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_form},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_coefficient_form},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_pos_entries},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_trace_power},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_form},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_coefficient\_form},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positive\_chi\_pos\_entries},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positive\_chi\_trace\_power},
 \leanid{MPOTensor.BNTLabelTheoremWitness.sourceLabel},
 \leanid{MPOTensor.BNTLabelTheoremWitness.targetLabel},
-\leanid{MPOTensor.BNTLabelTheoremWitness.coeff_eq_trace_pow},
-\leanid{MPOTensor.BNTLabelTheoremWitness.coeff_eq_ofChi_coeff},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_form_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_coefficient_form_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum},
-\leanid{MPOTensor.BNTLabelTheoremWitness.chi_entry_pos},
-\leanid{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq},
-\leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum_chi_trace_pow},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_chi_trace},
-\leanid{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.coeff\_eq\_trace\_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.coeff\_eq\_ofChi\_coeff},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_form\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_coefficient\_form\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_eq\_sum\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_eq\_sum\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_eq\_sum},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_eq\_sum},
+\leanid{MPOTensor.BNTLabelTheoremWitness.chi\_entry\_pos},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blocked\_coeff\_eq},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blocked\_coeff\_eq\_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_eq\_sum\_chi\_trace\_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_eq\_sum\_chi\_trace},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blocked\_coeff\_eq\_trace\_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
 toPositiveBlockedStructureChiTracePowerForm},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-positiveBlockedChi_toDiagonal_of_pos},
+positiveBlockedChi\_toDiagonal\_of\_pos},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-positiveBlockedChi_tracePowerCoeff_of_pos},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_dim_of_pos},
+positiveBlockedChi\_tracePowerCoeff\_of\_pos},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi\_dim\_of\_pos},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-positiveBlockedChi_trace_matrix_pow_of_pos},
+positiveBlockedChi\_trace\_matrix\_pow\_of\_pos},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-positive_blocked_chi_witness},
+positive\_blocked\_chi\_witness},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists_blocked_chi_trace_power_form},
+exists\_blocked\_chi\_trace\_power\_form},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists_blocked_coeff_eq_trace_pow},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_tracePower},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_posEntries},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_entry_pos},
+exists\_blocked\_coeff\_eq\_trace\_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi\_tracePower},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi\_posEntries},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi\_entry\_pos},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-blocked_coeff_eq_positiveBlockedChi_trace_pow}.}  The remaining step is still the
+blocked\_coeff\_eq\_positiveBlockedChi\_trace\_pow}.}  The remaining step is still the
 construction of this existential witness from the MPDO tensor.
 
 To eliminate the remaining gap, the formalization should introduce:


### PR DESCRIPTION
### Motivation

- Paper-faithful boundary step for arXiv:1606.00608, Theorem IV.13 and Appendix C.4 (`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 972--985 and 2015--2085).
- The current algebra predicate proves equality of adjoint fixed-point spaces across positive blocking lengths, but Appendix C.4 uses stronger BNT-label coefficient data and positivity before constructing the one-step maps T and S.

### Description

- Added `MPOTensor.adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra` in `TNLean/MPS/MPDO/AlgebraStructure.lean`, recording the honest fixed-point consequence of the algebra predicate.
- Added `MPOTensor.stationaryOfFaithfulFixedPoint_compatible_of_isRFP_MPDO_via_algebra` under the trace-preserving and faithful fixed-point side hypotheses.
- Added `MPOTensor.fusionIsometryData_one_iff_isRFP` and `MPOTensor.isRFP_MPDO_via_fusion_iff_fusionIsometryData_one` in `TNLean/MPS/MPDO/FusionIsometries.lean`, reducing the transfer-map fusion formulation to a one-site retract.
- Updated `blueprint/src/chapter/ch02b_mpdo.tex` and `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` to explain why the full algebra-to-fusion converse still needs the BNT-label coefficient witness and idempotent trace-scalar identity.

### Testing

- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake env lean TNLean/MPS/MPDO/FusionIsometries.lean`
- `lake build TNLean.MPS.MPDO.FusionIsometries`
- `lake build TNLean.MPS.MPDO.AlgebraStructure`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/MPDO/AlgebraStructure.lean TNLean/MPS/MPDO/FusionIsometries.lean blueprint/src/chapter/ch02b_mpdo.tex docs/paper-gaps/command.tex docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex --diff-base main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check main...HEAD`
- Touched-file line-length and proof-integrity scans.
- `leanblueprint web`
- `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv17_blocked_chi_uniformity.tex`

---
Refs #826.
Leaves issue #826 open.

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 542ef3c920277aebd60584b8d0059d3d006033c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and documentation additions in formalized MPDO theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> This PR records **honest intermediate consequences** of the current MPDO algebra-structure predicate and **reduces fusion to a one-site retract**, while documenting that the full **algebra → fusion** converse still needs BNT-label coefficient data (arXiv:1606.00608, Theorem IV.13 / Appendix C.4).
> 
> **Lean (`AlgebraStructure.lean`):** Adds `adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra` (adjoint fixed points of every positive `blockedTransferMap` agree with those of `transferMap`) and `stationaryOfFaithfulFixedPoint_compatible_of_isRFP_MPDO_via_algebra` (under trace-preserving + faithful fixed-point hypotheses, the stationary tower is `CompatibleWith` the tensor). Comments stress these are **not** the paper’s converse to fusion.
> 
> **Lean (`FusionIsometries.lean`):** Adds `fusionIsometryData_one_iff_isRFP` and `isRFP_MPDO_via_fusion_iff_fusionIsometryData_one`, so the all-blocked fusion formulation collapses to **one-site** `FusionIsometryData M 1` ↔ `IsRFP M`.
> 
> **Docs:** Blueprint `ch02b_mpdo.tex` gets matching theorems (one-site fusion ↔ RFP, adjoint fixed-point equality, stationary tower). `cpgsv17_blocked_chi_uniformity.tex` adds a section on the algebra-to-fusion gap and normalizes Lean identifier formatting in footnotes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3269729c330bcee73e74730a98881a27d8c92290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->