### PR TITLE
feat(MPS/MPDO): bridge eta-local data to RFP assembly

### DIFF
--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.CommutingForm
+import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.SimpleLocalStructure
 
@@ -18,6 +18,8 @@ side live in separate modules:
 
 * `SimpleLocalStructure.lean` isolates the local SAL/SSA and rank-one-`T`
   consequences of Lemmas C.3--C.4.
+* `CommutingFormBridge.lean` isolates the post-extraction `η`-local structure
+  that carries the commuting-form witness of Proposition C.6.
 * `CommutingForm.lean` states the GSNNCH / commuting-form target side of
   Proposition C.6 and Theorem 4.9(iii).
 
@@ -41,7 +43,9 @@ once the remaining local-to-global implication has been formalized.
 
 * `MPOTensor.SimpleMPDOLocalStructureData`
 * `MPOTensor.SimpleMPDOBlockedRFPData`
+* `MPOTensor.SimpleMPDOBlockedRFPData.ofEtaLocalStructure`
 * `MPOTensor.structural_implies_rfp_blocked`
+* `MPOTensor.simple_mpdo_rfp_chain_of_etaLocalStructure`
 * `MPOTensor.simple_mpdo_rfp_chain`
 
 ## References
@@ -161,6 +165,22 @@ def ofSALZCLAndCommutingForm
   commutingForm := hCommuting
   zcl := hZCL
 
+/-- Construct the blocked-RFP data from the post-extraction `η`-local structure.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+once the local neighboring operators `η_{k,h}` have been assembled into a
+positive nearest-neighbor bond product, the translated bond operators commute
+and realize the finite-chain MPDO. In Lean this post-extraction datum is
+`EtaLocalStructureData K`; its commuting-form consequence supplies the
+`commutingForm` field. -/
+def ofEtaLocalStructure
+    (localData : SimpleMPDOLocalStructureData)
+    (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    SimpleMPDOBlockedRFPData K where
+  localData := localData
+  commutingForm := hEta.hasCommutingForm
+  zcl := hZCL
+
 /-- Commuting-form data together with MPO ZCL yield the GSNNCH-with-ZCL branch of
 Theorem 4.9. -/
 theorem isGSNNCHWithZCL (data : SimpleMPDOBlockedRFPData K) : IsGSNNCHWithZCL K :=
@@ -213,6 +233,21 @@ theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
       IsRFP_MPDO_via_fusion K := by
   refine ⟨data.isGSNNCHWithZCL, structural_implies_rfp_blocked_of_data data,
     data.isRFPViaFusion⟩
+
+/-- Direct form of the simple-MPDO assembly once the post-extraction `η`-local
+structure has been constructed.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+the neighboring `η_{k,h}` operators assemble into commuting two-site bonds
+whose product realizes the MPDO. The Lean hypothesis `EtaLocalStructureData K`
+is precisely this assembled positive commuting-bond datum. -/
+theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
+    (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
+      IsRFP_MPDO_via_fusion K := by
+  refine ⟨?_, structural_implies_rfp_blocked (K := K) hZCL, ?_⟩
+  · exact hEta.isGSNNCHWithZCL hZCL
+  · exact isRFP_MPDO_via_fusion_of_isRFP (M := K) (show IsRFP K from hZCL)
 
 /-- Direct-argument form of Theorem 4.9 using only the hypotheses that enter the
 current theorem. -/

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -19,10 +19,10 @@ side live in separate modules:
 * `SimpleLocalStructure.lean` isolates the local SAL/SSA and rank-one-`T`
   consequences of Lemmas C.3--C.4.
 * `CommutingFormBridge.lean` isolates the `η`-local structure that carries the
-  commuting-form witness of Proposition C.6 after the sector-local neighboring
-  operators have been assembled.
+  commuting-form witness of arXiv:1606.00608, Appendix C.2, Proposition C.6,
+  after the sector-local neighboring operators have been assembled.
 * `CommutingForm.lean` states the GSNNCH / commuting-form target side of
-  Proposition C.6 and Theorem 4.9(iii).
+  arXiv:1606.00608, Appendix C.2, Proposition C.6 and Theorem 4.9(iii).
 
 What is still missing is the preceding theorem turning the local simple-MPDO data
 into the global commuting-form property. Because of that gap, the present file
@@ -234,7 +234,7 @@ theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
   refine ⟨data.isGSNNCHWithZCL, structural_implies_rfp_blocked_of_data data,
     data.isRFPViaFusion⟩
 
-/-- Direct form of the simple-MPDO assembly once the assembled `η`-local
+/-- Direct form of the simple-MPDO construction once the assembled `η`-local
 structure has been constructed.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -168,7 +168,7 @@ def ofSALZCLAndCommutingForm
 
 /-- Construct the blocked-RFP data from the assembled `η`-local structure.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
 once the local neighboring operators `η_{k,h}` have been assembled into a
 positive nearest-neighbor bond product, the translated bond operators commute
 and realize the finite-chain MPDO. This eta-local structure gives the
@@ -247,7 +247,7 @@ theorem simple_mpdo_rfp_chain {K : MPOTensor d D}
 /-- Direct form of the simple-MPDO construction once the assembled `η`-local
 structure has been constructed.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
 the neighboring `η_{k,h}` operators assemble into commuting two-site bonds
 whose product realizes the MPDO. The eta-local structure is precisely this
 assembled positive commuting-bond form. -/

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -10,16 +10,17 @@ import TNLean.MPS.MPDO.SimpleLocalStructure
 /-!
 # Blocked-RFP construction for simple MPDOs
 
-This file states the current blocked-RFP theorem for the simple-MPDO
-branch of arXiv:1606.00608, Appendix C.2 / Theorem 4.9.
+This file states the current blocked-RFP theorem for the simple-MPDO case of
+arXiv:1606.00608, Appendix C.2 / Theorem 4.9.
 
 At the present repository state, the local entropy side and the commuting-form
 side live in separate modules:
 
 * `SimpleLocalStructure.lean` isolates the local SAL/SSA and rank-one-`T`
   consequences of Lemmas C.3--C.4.
-* `CommutingFormBridge.lean` isolates the post-extraction `η`-local structure
-  that carries the commuting-form witness of Proposition C.6.
+* `CommutingFormBridge.lean` isolates the `η`-local structure that carries the
+  commuting-form witness of Proposition C.6 after the sector-local neighboring
+  operators have been assembled.
 * `CommutingForm.lean` states the GSNNCH / commuting-form target side of
   Proposition C.6 and Theorem 4.9(iii).
 
@@ -33,7 +34,7 @@ The current consequences are:
 
 * a **blocked fusion-isometry witness** at size `2`, formalized as
   `Nonempty (FusionIsometryData K 2)`;
-* the GSNNCH-with-ZCL branch of Theorem 4.9;
+* the GSNNCH-with-ZCL case of Theorem 4.9;
 * the transfer-map fusion formulation of MPDO RFP.
 
 Thus this file supplies the Appendix C conclusion that later work can use
@@ -165,12 +166,12 @@ def ofSALZCLAndCommutingForm
   commutingForm := hCommuting
   zcl := hZCL
 
-/-- Construct the blocked-RFP data from the post-extraction `η`-local structure.
+/-- Construct the blocked-RFP data from the assembled `η`-local structure.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
 once the local neighboring operators `η_{k,h}` have been assembled into a
 positive nearest-neighbor bond product, the translated bond operators commute
-and realize the finite-chain MPDO. In Lean this post-extraction datum is
+and realize the finite-chain MPDO. In Lean this eta-local structure is
 `EtaLocalStructureData K`; its commuting-form consequence supplies the
 `commutingForm` field. -/
 def ofEtaLocalStructure
@@ -181,7 +182,7 @@ def ofEtaLocalStructure
   commutingForm := hEta.hasCommutingForm
   zcl := hZCL
 
-/-- Commuting-form data together with MPO ZCL yield the GSNNCH-with-ZCL branch of
+/-- Commuting-form data together with MPO ZCL yield the GSNNCH-with-ZCL case of
 Theorem 4.9. -/
 theorem isGSNNCHWithZCL (data : SimpleMPDOBlockedRFPData K) : IsGSNNCHWithZCL K :=
   (isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL K).2 ⟨data.commutingForm, data.zcl⟩
@@ -220,7 +221,7 @@ theorem structural_implies_rfp_blocked_of_data {K : MPOTensor d D}
 
 From the explicit simple-MPDO hypotheses one simultaneously recovers:
 
-* the GSNNCH-with-ZCL branch of Theorem 4.9(iii),
+* the GSNNCH-with-ZCL case of Theorem 4.9(iii),
 * the blocked fusion-isometry witness at size `2`, and
 * the transfer-map fusion formulation of MPDO RFP.
 
@@ -234,7 +235,7 @@ theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
   refine ⟨data.isGSNNCHWithZCL, structural_implies_rfp_blocked_of_data data,
     data.isRFPViaFusion⟩
 
-/-- Direct form of the simple-MPDO assembly once the post-extraction `η`-local
+/-- Direct form of the simple-MPDO assembly once the assembled `η`-local
 structure has been constructed.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -234,21 +234,6 @@ theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
   refine ⟨data.isGSNNCHWithZCL, structural_implies_rfp_blocked_of_data data,
     data.isRFPViaFusion⟩
 
-/-- Direct form of the simple-MPDO construction once the assembled `η`-local
-structure has been constructed.
-
-Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
-the neighboring `η_{k,h}` operators assemble into commuting two-site bonds
-whose product realizes the MPDO. The eta-local structure is precisely this
-assembled positive commuting-bond datum. -/
-theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
-    (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
-    IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
-      IsRFP_MPDO_via_fusion K := by
-  refine ⟨?_, structural_implies_rfp_blocked (K := K) hZCL, ?_⟩
-  · exact hEta.isGSNNCHWithZCL hZCL
-  · exact isRFP_MPDO_via_fusion_of_isRFP (M := K) (show IsRFP K from hZCL)
-
 /-- Direct-argument form of Theorem 4.9 using only the hypotheses that enter the
 current theorem. -/
 theorem simple_mpdo_rfp_chain {K : MPOTensor d D}
@@ -258,5 +243,18 @@ theorem simple_mpdo_rfp_chain {K : MPOTensor d D}
   refine ⟨?_, structural_implies_rfp_blocked (K := K) hZCL, ?_⟩
   · exact (isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL K).2 ⟨hCommuting, hZCL⟩
   · exact isRFP_MPDO_via_fusion_of_isRFP (M := K) (show IsRFP K from hZCL)
+
+/-- Direct form of the simple-MPDO construction once the assembled `η`-local
+structure has been constructed.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+the neighboring `η_{k,h}` operators assemble into commuting two-site bonds
+whose product realizes the MPDO. The eta-local structure is precisely this
+assembled positive commuting-bond form. -/
+theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
+    (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
+      IsRFP_MPDO_via_fusion K :=
+  simple_mpdo_rfp_chain hEta.hasCommutingForm hZCL
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -100,8 +100,8 @@ structure SimpleMPDOLocalStructureData where
 
 namespace SimpleMPDOLocalStructureData
 
-/-- Construct the local simple-MPDO structure from the scoped Lemma C.3/C.4
-inputs already available in `SimpleLocalStructure.lean`. -/
+/-- Construct the local simple-MPDO structure from the Lemma C.3/C.4 hypotheses
+already available in `SimpleLocalStructure.lean`. -/
 def ofSALZCL
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -147,7 +147,7 @@ namespace SimpleMPDOBlockedRFPData
 
 variable {K : MPOTensor d D}
 
-/-- Construct this structure directly from the scoped local lemmas of
+/-- Construct this structure directly from the local lemmas of
 `SimpleLocalStructure.lean`, the commuting-form hypothesis, and MPO ZCL. -/
 def ofSALZCLAndCommutingForm
     {dA dB dC n : ℕ}

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -131,10 +131,10 @@ end SimpleMPDOLocalStructureData
 
 /-- Auxiliary structure for the simple-MPDO blocked-RFP argument.
 
-The field `localData` contains the Appendix C.2 local structure; the fields
-`commutingForm` and `zcl` contain the commuting-form conclusion and the MPO
-zero-correlation-length hypothesis. The missing theorem is the derivation of
-`commutingForm` from the entropy-side hypotheses attached to `K`. -/
+It consists of the Appendix C.2 local structure, the commuting-form conclusion,
+and the MPO zero-correlation-length hypothesis. The missing theorem is the
+derivation of the commuting-form conclusion from the entropy-side hypotheses
+attached to `K`. -/
 structure SimpleMPDOBlockedRFPData (K : MPOTensor d D) where
   /-- Local SAL/SSA/rank-one data from Appendix C.2. -/
   localData : SimpleMPDOLocalStructureData
@@ -171,9 +171,8 @@ def ofSALZCLAndCommutingForm
 Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
 once the local neighboring operators `η_{k,h}` have been assembled into a
 positive nearest-neighbor bond product, the translated bond operators commute
-and realize the finite-chain MPDO. In Lean this eta-local structure is
-`EtaLocalStructureData K`; its commuting-form consequence supplies the
-`commutingForm` field. -/
+and realize the finite-chain MPDO. This eta-local structure gives the
+commuting-form property required in the blocked-RFP argument. -/
 def ofEtaLocalStructure
     (localData : SimpleMPDOLocalStructureData)
     (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
@@ -209,7 +208,7 @@ theorem structural_implies_rfp_blocked {K : MPOTensor d D}
 /-- Hypothesis-parameterized blocked fusion-isometry witness.
 
 Relative to the current convention `IsRFP = IsZCL`, the present conclusion uses
-only `data.zcl`. The fields `localData` and `commutingForm` record the local
+only `data.zcl`. The components `localData` and `commutingForm` record the local
 Appendix C structure and the global commuting-form conclusion used in the
 larger simple-MPDO statement. -/
 theorem structural_implies_rfp_blocked_of_data {K : MPOTensor d D}
@@ -240,8 +239,8 @@ structure has been constructed.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
 the neighboring `η_{k,h}` operators assemble into commuting two-site bonds
-whose product realizes the MPDO. The Lean hypothesis `EtaLocalStructureData K`
-is precisely this assembled positive commuting-bond datum. -/
+whose product realizes the MPDO. The eta-local structure is precisely this
+assembled positive commuting-bond datum. -/
 theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
     (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -141,7 +141,7 @@ theorem formAt_realizes (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N
 /-- The translated nearest-neighbor bonds carried by the `η`-local structure
 commute at every finite chain length.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
 the assembled two-site bonds \(B_{n,n+1}\) commute. -/
 theorem formAt_bondAt_comm (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N)
     (i j : Fin N) :
@@ -153,7 +153,7 @@ theorem formAt_bondAt_comm (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 �
 \(\sigma^{(N)}(\mathcal K) \propto \prod_n B_{n,n+1}\) at every finite chain
 length.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
 after assembling the neighboring operators, the MPDO is a positive scalar
 multiple of the product of the translated nearest-neighbor bonds. -/
 theorem exists_positive_scalar_mpo_eq_product
@@ -165,7 +165,7 @@ theorem exists_positive_scalar_mpo_eq_product
 positive commuting nearest-neighbor product form appearing in Proposition C.6
 of arXiv:1606.00608.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
 the MPDO has the form \(\sigma^{(N)}(\mathcal K) \propto \prod_n B_{n,n+1}\),
 where the nearest-neighbor factors are positive and commute. -/
 theorem positive_commuting_product_form
@@ -198,7 +198,7 @@ theorem hasCommutingForm (data : EtaLocalStructureData M) : HasCommutingForm M :
 /-- The explicit `η`-local structure, together with ZCL, gives the
 GSNNCH-with-ZCL case of the simple-MPDO equivalence.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
 the assembled neighboring operators give a commuting nearest-neighbor product
 form. Adding ZCL gives item (iii) of Theorem 4.9 in the simple-MPDO case. -/
 theorem isGSNNCHWithZCL (data : EtaLocalStructureData M) (hZCL : IsZCL M) :

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -36,6 +36,7 @@ commuting-form target.
 * `MPOTensor.TranslationInvariantBondData`
 * `MPOTensor.EtaLocalStructureData`
 * `MPOTensor.hasCommutingForm_of_etaLocalStructure`
+* `MPOTensor.isGSNNCHWithZCL_of_etaLocalStructure`
 
 ## References
 
@@ -136,6 +137,29 @@ theorem formAt_realizes (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N
     (data.formAt N hN).Realizes (mpo M N) :=
   data.realizes_mpo N hN
 
+/-- The translated nearest-neighbor bonds carried by the `η`-local structure
+commute at every finite chain length.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+the assembled two-site bonds \(B_{n,n+1}\) commute. -/
+theorem formAt_bondAt_comm (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N)
+    (i j : Fin N) :
+    (data.formAt N hN).bondAt i * (data.formAt N hN).bondAt j =
+      (data.formAt N hN).bondAt j * (data.formAt N hN).bondAt i :=
+  (data.formAt N hN).bondAt_comm i j
+
+/-- The `η`-local structure gives the source product form
+\(\sigma^{(N)}(\mathcal K) \propto \prod_n B_{n,n+1}\) at every finite chain
+length.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+after assembling the neighboring operators, the MPDO is a positive scalar
+multiple of the product of the translated nearest-neighbor bonds. -/
+theorem exists_positive_scalar_mpo_eq_product
+    (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N) :
+    ∃ c : ℝ, 0 < c ∧ mpo M N = (c : ℂ) • (data.formAt N hN).product :=
+  data.formAt_realizes N hN
+
 /-- The chain-level GSNNCH witness induced by the local `η`-structure at a fixed
 chain length. -/
 theorem isGSNNCHAt (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N) :
@@ -153,6 +177,16 @@ theorem hasCommutingForm (data : EtaLocalStructureData M) : HasCommutingForm M :
   intro N hN
   exact ⟨data.formAt N hN, data.formAt_realizes N hN⟩
 
+/-- The explicit `η`-local structure, together with ZCL, gives the
+GSNNCH-with-ZCL branch of the simple-MPDO equivalence.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+the assembled neighboring operators give a commuting nearest-neighbor product
+form. Adding ZCL gives item (iii) of Theorem 4.9 in the simple-MPDO branch. -/
+theorem isGSNNCHWithZCL (data : EtaLocalStructureData M) (hZCL : IsZCL M) :
+    IsGSNNCHWithZCL M :=
+  (isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL M).2 ⟨data.hasCommutingForm, hZCL⟩
+
 end EtaLocalStructureData
 
 /-- Once the explicit neighboring operators `η_{k,h}` have been assembled into
@@ -166,5 +200,11 @@ theorem hasCommutingForm_of_etaLocalStructure {M : MPOTensor d D}
 theorem isGSNNCH_of_etaLocalStructure {M : MPOTensor d D}
     (hEta : EtaLocalStructureData M) : IsGSNNCH M :=
   hEta.isGSNNCH
+
+/-- Once the explicit local `η`-structure has been assembled, adding ZCL gives
+the GSNNCH-with-ZCL branch of the simple-MPDO equivalence. -/
+theorem isGSNNCHWithZCL_of_etaLocalStructure {M : MPOTensor d D}
+    (hEta : EtaLocalStructureData M) (hZCL : IsZCL M) : IsGSNNCHWithZCL M :=
+  hEta.isGSNNCHWithZCL hZCL
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -162,8 +162,8 @@ theorem exists_positive_scalar_mpo_eq_product
   data.formAt_realizes N hN
 
 /-- At a fixed chain length, the `η`-local structure gives precisely the
-positive commuting nearest-neighbor product form appearing in Proposition
-`3to4`.
+positive commuting nearest-neighbor product form appearing in Proposition C.6
+of arXiv:1606.00608.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
 the MPDO has the form \(\sigma^{(N)}(\mathcal K) \propto \prod_n B_{n,n+1}\),

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -160,6 +160,23 @@ theorem exists_positive_scalar_mpo_eq_product
     ∃ c : ℝ, 0 < c ∧ mpo M N = (c : ℂ) • (data.formAt N hN).product :=
   data.formAt_realizes N hN
 
+/-- At a fixed chain length, the `η`-local structure gives precisely the
+positive commuting nearest-neighbor product form appearing in Proposition
+`3to4`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
+the MPDO has the form \(\sigma^{(N)}(\mathcal K) \propto \prod_n B_{n,n+1}\),
+where the nearest-neighbor factors are positive and commute. -/
+theorem positive_commuting_product_form
+    (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N) :
+    (data.formAt N hN).bond.PosSemidef ∧
+      (∀ i j : Fin N,
+        (data.formAt N hN).bondAt i * (data.formAt N hN).bondAt j =
+          (data.formAt N hN).bondAt j * (data.formAt N hN).bondAt i) ∧
+      ∃ c : ℝ, 0 < c ∧ mpo M N = (c : ℂ) • (data.formAt N hN).product :=
+  ⟨(data.formAt N hN).bond_pos, data.formAt_bondAt_comm N hN,
+    data.exists_positive_scalar_mpo_eq_product N hN⟩
+
 /-- The chain-level GSNNCH witness induced by the local `η`-structure at a fixed
 chain length. -/
 theorem isGSNNCHAt (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N) :

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -7,9 +7,10 @@ import TNLean.MPS.MPDO.CommutingForm
 /-!
 # Local-to-global commuting-form data
 
-This file states the exact post-extraction output still needed from the
-simple-MPDO SAL + ZCL analysis of arXiv:1606.00608 Appendix C.2 in order to
-conclude `MPOTensor.HasCommutingForm`.
+This file states the exact eta-local structure still needed after the
+sector-local operators have been obtained in the simple-MPDO SAL + ZCL analysis
+of arXiv:1606.00608 Appendix C.2, in order to conclude
+`MPOTensor.HasCommutingForm`.
 
 The current repository already exposes the local entropy-side ingredients
 
@@ -107,7 +108,7 @@ from the local simple-MPDO analysis, together with proofs that it realizes the
 finite-chain MPO operators. This is stronger than `HasCommutingForm M`, since
 it requires one bond that works for every chain length rather than a separate
 commuting-form witness at each length. The remaining assembly theorem should
-construct this data from the SAL and ZCL hypotheses, the sector-reduced
+construct this structure from the SAL and ZCL hypotheses, the sector-reduced
 `η_{k,h}` family, and the inverse-map realization layer. -/
 structure EtaLocalStructureData (M : MPOTensor d D) where
   /-- The chain-independent nearest-neighbor bond extracted from the local
@@ -195,11 +196,11 @@ theorem hasCommutingForm (data : EtaLocalStructureData M) : HasCommutingForm M :
   exact ⟨data.formAt N hN, data.formAt_realizes N hN⟩
 
 /-- The explicit `η`-local structure, together with ZCL, gives the
-GSNNCH-with-ZCL branch of the simple-MPDO equivalence.
+GSNNCH-with-ZCL case of the simple-MPDO equivalence.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593:
 the assembled neighboring operators give a commuting nearest-neighbor product
-form. Adding ZCL gives item (iii) of Theorem 4.9 in the simple-MPDO branch. -/
+form. Adding ZCL gives item (iii) of Theorem 4.9 in the simple-MPDO case. -/
 theorem isGSNNCHWithZCL (data : EtaLocalStructureData M) (hZCL : IsZCL M) :
     IsGSNNCHWithZCL M :=
   (isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL M).2 ⟨data.hasCommutingForm, hZCL⟩
@@ -219,7 +220,7 @@ theorem isGSNNCH_of_etaLocalStructure {M : MPOTensor d D}
   hEta.isGSNNCH
 
 /-- Once the explicit local `η`-structure has been assembled, adding ZCL gives
-the GSNNCH-with-ZCL branch of the simple-MPDO equivalence. -/
+the GSNNCH-with-ZCL case of the simple-MPDO equivalence. -/
 theorem isGSNNCHWithZCL_of_etaLocalStructure {M : MPOTensor d D}
     (hEta : EtaLocalStructureData M) (hZCL : IsZCL M) : IsGSNNCHWithZCL M :=
   hEta.isGSNNCHWithZCL hZCL

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2495,34 +2495,48 @@ the elementary trace-power identity for diagonal matrices.
 
 \section{Blocked-RFP construction for simple MPDOs}
 
-\begin{definition}[Local simple-MPDO structure data]
+\begin{definition}[Local simple-MPDO structure]
     \label{def:simple_mpdo_local_structure_data}
     \lean{MPOTensor.SimpleMPDOLocalStructureData}
-    \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCL}
     \leanok
     \uses{thm:sal_implies_eta_structure, thm:sal_zcl_implies_rank_one_t}
-    This structure collects the local Appendix~C.2 data: a normalized
+    This structure records the local Appendix~C.2 ingredients: a normalized
     three-site reduced state with equality in strong subadditivity, the
     resulting local $\eta$-structure, and the rank-one conclusion for the
-    auxiliary primitive matrix $T$. The hypotheses of Lemmas C.3--C.4 determine
-    such a structure.
+    auxiliary primitive matrix $T$.
 \end{definition}
 
-\begin{definition}[Simple-MPDO blocked-RFP data]
+\begin{theorem}[Local simple-MPDO structure from SAL--ZCL hypotheses]
+    \label{thm:simple_mpdo_local_structure_data_of_sal_zcl}
+    \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCL}
+    \leanok
+    \uses{def:simple_mpdo_local_structure_data, thm:sal_implies_eta_structure,
+        thm:sal_zcl_implies_rank_one_t}
+    The hypotheses of Lemmas C.3--C.4 determine the local simple-MPDO structure.
+\end{theorem}
+
+\begin{definition}[Simple-MPDO blocked-RFP structure]
     \label{def:simple_mpdo_blocked_rfp_data}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData}
-    \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndCommutingForm}
     \leanok
     \uses{def:simple_mpdo_local_structure_data, def:mpdo_has_commuting_form,
         def:mpo_is_zcl}
-    For an MPO tensor $K$, this consists of the local Appendix~C.2 data, the
+    For an MPO tensor $K$, this records the local Appendix~C.2 ingredients, the
     commuting-form property, and zero correlation length. The local component
     consists of the hypotheses used in the entropy-side argument for commuting form.
-    The alternative construction takes the SAL--ZCL hypotheses together with an
-    already-supplied commuting-form witness.
 \end{definition}
 
-\begin{theorem}[Blocked-RFP data from $\eta$-local structure]
+\begin{theorem}[Blocked-RFP structure from SAL--ZCL and commuting form]
+    \label{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_commuting_form}
+    \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndCommutingForm}
+    \leanok
+    \uses{def:simple_mpdo_blocked_rfp_data,
+        thm:simple_mpdo_local_structure_data_of_sal_zcl}
+    The SAL--ZCL hypotheses together with a commuting-form witness determine
+    the simple-MPDO blocked-RFP structure.
+\end{theorem}
+
+\begin{theorem}[Blocked-RFP structure from $\eta$-local structure]
     \label{thm:simple_mpdo_blocked_rfp_data_of_eta_local_structure}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofEtaLocalStructure}
     \leanok

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2367,12 +2367,21 @@ the elementary trace-power identity for diagonal matrices.
     on every periodic chain and realize the MPO at every finite length.
 \end{definition}
 
-\begin{theorem}[$\eta$-local structure carries commuting form]
-    \label{thm:mpdo_eta_local_structure_has_commuting_form}
+\begin{definition}[Finite-chain data from a translation-invariant bond]
+    \label{def:mpdo_translation_invariant_bond_to_commuting_form_data}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_bond}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_hN}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_bondAt}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data, def:mpdo_commuting_form_data}
+    A translation-invariant positive two-site bond determines finite-chain
+    commuting-form data at every length $N \ge 2$. The factor at site $i$ is
+    the translated copy of the same local two-site bond.
+\end{definition}
+
+\begin{theorem}[$\eta$-local structure carries commuting form]
+    \label{thm:mpdo_eta_local_structure_has_commuting_form}
     \lean{MPOTensor.EtaLocalStructureData.hasCommutingForm}
     \lean{MPOTensor.EtaLocalStructureData.formAt_realizes}
     \lean{MPOTensor.EtaLocalStructureData.formAt_bondAt_comm}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2361,7 +2361,7 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.EtaLocalStructureData}
     \leanok
     \uses{def:mpdo_has_commuting_form}
-    This defines the post-extraction form of Appendix~C.2: a single
+    This defines the eta-local form of Appendix~C.2: a single
     translation-invariant positive two-site bond whose translated copies commute
     on every periodic chain and realize the MPO at every finite length.
 \end{definition}
@@ -2407,8 +2407,8 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{thm:mpdo_eta_local_structure_has_commuting_form,
         thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}
-    Once the $\eta$-local structure supplies the commuting nearest-neighbor
-    product form, adding zero correlation length gives the GSNNCH--ZCL branch
+    Once the $\eta$-local structure gives the commuting nearest-neighbor
+    product form, adding zero correlation length gives the GSNNCH--ZCL case
     of the simple-MPDO equivalence.
 \end{theorem}
 
@@ -2480,9 +2480,9 @@ the elementary trace-power identity for diagonal matrices.
         def:mpo_is_zcl}
     For an MPO tensor $K$, this consists of the local Appendix~C.2 data, the
     commuting-form property, and zero correlation length. The local component
-    consists of the hypotheses used in the entropy-side route to commuting form.
-    The direct constructor packages the scoped SAL--ZCL local data together
-    with an already-supplied commuting-form witness.
+    consists of the hypotheses used in the entropy-side argument for commuting form.
+    The auxiliary constructor takes the scoped SAL--ZCL local hypotheses
+    together with an already-supplied commuting-form witness.
 \end{definition}
 
 \begin{definition}[Blocked-RFP data from $\eta$-local structure]
@@ -2492,10 +2492,10 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:simple_mpdo_local_structure_data,
         def:simple_mpdo_blocked_rfp_data,
         def:mpdo_eta_local_structure_data}
-    Once the post-extraction $\eta$-local structure has been assembled, it
+    Once the $\eta$-local structure has been assembled, it
     supplies the commuting-form field of the blocked-RFP data. Together with
     the local Appendix~C.2 data and zero correlation length, this gives the
-    explicit data package used by the simple-MPDO assembly theorem.
+    explicit hypotheses used by the simple-MPDO construction theorem.
 \end{definition}
 
 \begin{theorem}[Zero correlation length gives a blocked fusion-isometry witness]
@@ -2525,15 +2525,15 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_eta_local_structure_data, def:mpo_is_zcl,
         thm:mpdo_eta_local_structure_is_gsnnch_zcl,
         thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion}
-    If the post-extraction $\eta$-local structure has been constructed for an
-    MPO tensor \(K\), then zero correlation length gives the GSNNCH-with-ZCL
-    branch, the blocked fusion-isometry witness at size \(2\), and the
+    If the $\eta$-local structure has been constructed for an
+    MPO tensor $K$, then zero correlation length gives the GSNNCH-with-ZCL
+    case, the blocked fusion-isometry witness at size $2$, and the
     transfer-map fusion formulation of MPDO RFP.
 \end{theorem}
 
 \begin{proof}\leanok
     The $\eta$-local structure supplies the commuting-form property. Combining
-    this with zero correlation length gives the GSNNCH-with-ZCL branch; zero
+    this with zero correlation length gives the GSNNCH-with-ZCL case; zero
     correlation length also gives the blocked fusion-isometry witness and the
     transfer-map fusion formulation.
 \end{proof}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2394,8 +2394,8 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_translation_invariant_bond_data, def:mpdo_commuting_form_data}
     The finite-chain data associated to a translation-invariant bond retains
-    the original local bond, and the factor at site $i$ is the translated copy
-    of that local two-site bond.
+    the original local bond and the supplied lower bound $2 \le N$, and the
+    factor at site $i$ is the translated copy of that local two-site bond.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2356,7 +2356,7 @@ the elementary trace-power identity for diagonal matrices.
     Theorem~\ref{thm:mpdo_is_gsnnch_iff_has_commuting_form}.
 \end{proof}
 
-\begin{definition}[Translation-invariant two-site bond data]
+\begin{definition}[Translation-invariant two-site bond]
     \label{def:mpdo_translation_invariant_bond_data}
     \lean{MPOTensor.TranslationInvariantBondData}
     \leanok

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2544,14 +2544,14 @@ the elementary trace-power identity for diagonal matrices.
         def:simple_mpdo_blocked_rfp_data,
         def:mpdo_eta_local_structure_data}
     Once the $\eta$-local structure has been assembled, it
-    supplies the commuting-form property required by the blocked-RFP data. Together with
-    the local Appendix~C.2 data and zero correlation length, this gives the
+    supplies the commuting-form property required by the blocked-RFP structure. Together with
+    the local Appendix~C.2 ingredients and zero correlation length, this gives the
     explicit hypotheses used by the simple-MPDO construction theorem.
 \end{theorem}
 
 \begin{proof}\leanok
     Use the commuting-form property carried by the $\eta$-local structure and
-    keep the local Appendix~C.2 data and zero-correlation-length hypothesis
+    keep the local Appendix~C.2 ingredients and zero-correlation-length hypothesis
     unchanged.
 \end{proof}
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2356,22 +2356,32 @@ the elementary trace-power identity for diagonal matrices.
     Theorem~\ref{thm:mpdo_is_gsnnch_iff_has_commuting_form}.
 \end{proof}
 
+\begin{definition}[Translation-invariant two-site bond data]
+    \label{def:mpdo_translation_invariant_bond_data}
+    \lean{MPOTensor.TranslationInvariantBondData}
+    \leanok
+    \uses{def:mpdo_commuting_form_data}
+    This records a single positive two-site bond together with its translated
+    copies on every finite periodic chain, requiring those translated copies to
+    commute pairwise.
+\end{definition}
+
 \begin{definition}[$\eta$-local commuting-form data]
     \label{def:mpdo_eta_local_structure_data}
-    \lean{MPOTensor.TranslationInvariantBondData}
     \lean{MPOTensor.EtaLocalStructureData}
     \leanok
-    \uses{def:mpdo_has_commuting_form}
-    This defines the eta-local form of Appendix~C.2: a single
-    translation-invariant positive two-site bond whose translated copies commute
-    on every periodic chain and realize the MPO at every finite length.
+    \uses{def:mpdo_translation_invariant_bond_data, def:mpdo_has_commuting_form}
+    This defines the eta-local form of Appendix~C.2: the
+    translation-invariant positive two-site bond data together with the
+    requirement that the corresponding product realizes the MPO at every finite
+    length.
 \end{definition}
 
 \begin{definition}[Finite-chain data from a translation-invariant bond]
     \label{def:mpdo_translation_invariant_bond_to_commuting_form_data}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData}
     \leanok
-    \uses{def:mpdo_eta_local_structure_data, def:mpdo_commuting_form_data}
+    \uses{def:mpdo_translation_invariant_bond_data, def:mpdo_commuting_form_data}
     A translation-invariant positive two-site bond determines finite-chain
     commuting-form data at every length $N \ge 2$.
 \end{definition}
@@ -2382,7 +2392,7 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_hN}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_bondAt}
     \leanok
-    \uses{def:mpdo_eta_local_structure_data, def:mpdo_commuting_form_data}
+    \uses{def:mpdo_translation_invariant_bond_data, def:mpdo_commuting_form_data}
     The finite-chain data associated to a translation-invariant bond retains
     the original local bond, and the factor at site $i$ is the translated copy
     of that local two-site bond.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2370,15 +2370,27 @@ the elementary trace-power identity for diagonal matrices.
 \begin{definition}[Finite-chain data from a translation-invariant bond]
     \label{def:mpdo_translation_invariant_bond_to_commuting_form_data}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data, def:mpdo_commuting_form_data}
+    A translation-invariant positive two-site bond determines finite-chain
+    commuting-form data at every length $N \ge 2$.
+\end{definition}
+
+\begin{theorem}[Component identities for finite-chain bond data]
+    \label{thm:mpdo_translation_invariant_bond_to_commuting_form_data_components}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_bond}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_hN}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_bondAt}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_commuting_form_data}
-    A translation-invariant positive two-site bond determines finite-chain
-    commuting-form data at every length $N \ge 2$. The factor at site $i$ is
-    the translated copy of the same local two-site bond.
-\end{definition}
+    The finite-chain data associated to a translation-invariant bond retains
+    the original local bond, and the factor at site $i$ is the translated copy
+    of that local two-site bond.
+\end{theorem}
+
+\begin{proof}\leanok
+    These are the component identities for the finite-chain construction.
+\end{proof}
 
 \begin{theorem}[$\eta$-local structure carries commuting form]
     \label{thm:mpdo_eta_local_structure_has_commuting_form}
@@ -2392,7 +2404,7 @@ the elementary trace-power identity for diagonal matrices.
     The $\eta$-local structure itself determines a commuting-form witness for every
     chain length $N \ge 2$.  In particular, the translated nearest-neighbor
     bonds commute and the MPDO at length $N$ is a positive scalar multiple of
-    their product, as in Proposition~C.6.
+    their product, as in \cite[Proposition~C.6]{Cirac2017MPDO_AnnPhys}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2466,7 +2478,7 @@ the elementary trace-power identity for diagonal matrices.
     What remains is to identify this sector family with the inverse-map
     construction in the original simple-MPDO tensor coordinates and assemble it
     into a single translation-invariant positive two-site bond realizing all
-    finite chains. Once this assembly is available,
+    finite chains. Once this construction is available,
     Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure} yields the
     commuting-form conclusion and hence the GSNNCH branch of the simple-MPDO
     equivalence.
@@ -2477,12 +2489,14 @@ the elementary trace-power identity for diagonal matrices.
 \begin{definition}[Local simple-MPDO structure data]
     \label{def:simple_mpdo_local_structure_data}
     \lean{MPOTensor.SimpleMPDOLocalStructureData}
+    \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCL}
     \leanok
     \uses{thm:sal_implies_eta_structure, thm:sal_zcl_implies_rank_one_t}
     This structure collects the local Appendix~C.2 data: a normalized
     three-site reduced state with equality in strong subadditivity, the
     resulting local $\eta$-structure, and the rank-one conclusion for the
-    auxiliary primitive matrix $T$.
+    auxiliary primitive matrix $T$. The scoped local hypotheses from Lemmas
+    C.3--C.4 determine such a structure.
 \end{definition}
 
 \begin{definition}[Simple-MPDO blocked-RFP data]
@@ -2537,10 +2551,23 @@ the elementary trace-power identity for diagonal matrices.
     produces the blocked witness.
 \end{proof}
 
+\begin{theorem}[Blocked-RFP data give a blocked fusion-isometry witness]
+    \label{thm:structural_implies_rfp_blocked_of_data}
+    \lean{MPOTensor.structural_implies_rfp_blocked_of_data}
+    \leanok
+    \uses{def:simple_mpdo_blocked_rfp_data, thm:structural_implies_rfp_blocked}
+    Given the blocked-RFP data for an MPO tensor $K$, one obtains a blocked
+    fusion-isometry witness at size $2$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the zero-correlation-length theorem to the ZCL component of the
+    blocked-RFP data.
+\end{proof}
+
 \begin{theorem}[Simple-MPDO RFP chain from blocked-RFP data]
     \label{thm:simple_mpdo_rfp_chain_of_data}
     \lean{MPOTensor.simple_mpdo_rfp_chain_of_data}
-    \lean{MPOTensor.structural_implies_rfp_blocked_of_data}
     \leanok
     \uses{def:simple_mpdo_blocked_rfp_data,
         thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2369,10 +2369,14 @@ the elementary trace-power identity for diagonal matrices.
 \begin{theorem}[$\eta$-local structure carries commuting form]
     \label{thm:mpdo_eta_local_structure_has_commuting_form}
     \lean{MPOTensor.EtaLocalStructureData.hasCommutingForm}
+    \lean{MPOTensor.EtaLocalStructureData.formAt_bondAt_comm}
+    \lean{MPOTensor.EtaLocalStructureData.exists_positive_scalar_mpo_eq_product}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_has_commuting_form}
     The $\eta$-local structure itself determines a commuting-form witness for every
-    chain length $N \ge 2$.
+    chain length $N \ge 2$.  In particular, the translated nearest-neighbor
+    bonds commute and the MPDO at length \(N\) is a positive scalar multiple of
+    their product, as in Proposition~C.6.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2382,6 +2386,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[$\eta$-local structure gives GSNNCH]
     \label{thm:mpdo_eta_local_structure_is_gsnnch}
+    \lean{MPOTensor.EtaLocalStructureData.isGSNNCHAt}
     \lean{MPOTensor.EtaLocalStructureData.isGSNNCH}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_is_gsnnch}
@@ -2391,6 +2396,23 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{proof}\leanok
     Evaluate the local structure at each chain length $N \ge 2$.
+\end{proof}
+
+\begin{theorem}[$\eta$-local structure with ZCL gives GSNNCH--ZCL]
+    \label{thm:mpdo_eta_local_structure_is_gsnnch_zcl}
+    \lean{MPOTensor.EtaLocalStructureData.isGSNNCHWithZCL}
+    \lean{MPOTensor.isGSNNCHWithZCL_of_etaLocalStructure}
+    \leanok
+    \uses{thm:mpdo_eta_local_structure_has_commuting_form,
+        thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}
+    Once the $\eta$-local structure supplies the commuting nearest-neighbor
+    product form, adding zero correlation length gives the GSNNCH--ZCL branch
+    of the simple-MPDO equivalence.
+\end{theorem}
+
+\begin{proof}\leanok
+    Use the commuting-form witness carried by the $\eta$-local structure and
+    combine it with the ZCL hypothesis.
 \end{proof}
 
 \begin{theorem}[$\eta$-local structure implies commuting form]
@@ -2450,12 +2472,28 @@ the elementary trace-power identity for diagonal matrices.
 \begin{definition}[Simple-MPDO blocked-RFP data]
     \label{def:simple_mpdo_blocked_rfp_data}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData}
+    \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndCommutingForm}
     \leanok
     \uses{def:simple_mpdo_local_structure_data, def:mpdo_has_commuting_form,
         def:mpo_is_zcl}
     For an MPO tensor $K$, this consists of the local Appendix~C.2 data, the
     commuting-form property, and zero correlation length. The local component
     consists of the hypotheses used in the entropy-side route to commuting form.
+    The direct constructor packages the scoped SAL--ZCL local data together
+    with an already-supplied commuting-form witness.
+\end{definition}
+
+\begin{definition}[Blocked-RFP data from $\eta$-local structure]
+    \label{def:simple_mpdo_blocked_rfp_data_of_eta_local_structure}
+    \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofEtaLocalStructure}
+    \leanok
+    \uses{def:simple_mpdo_local_structure_data,
+        def:simple_mpdo_blocked_rfp_data,
+        def:mpdo_eta_local_structure_data}
+    Once the post-extraction $\eta$-local structure has been assembled, it
+    supplies the commuting-form field of the blocked-RFP data. Together with
+    the local Appendix~C.2 data and zero correlation length, this gives the
+    explicit data package used by the simple-MPDO assembly theorem.
 \end{definition}
 
 \begin{theorem}[Zero correlation length gives a blocked fusion-isometry witness]
@@ -2475,6 +2513,27 @@ the elementary trace-power identity for diagonal matrices.
     Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to that RFP witness yields
     fusion-isometry data at every positive blocked size; evaluating it at size $2$
     produces the blocked witness.
+\end{proof}
+
+\begin{theorem}[Simple-MPDO RFP chain from $\eta$-local structure]
+    \label{thm:simple_mpdo_rfp_chain_of_eta_local_structure}
+    \lean{MPOTensor.simple_mpdo_rfp_chain_of_etaLocalStructure}
+    \lean{MPOTensor.simple_mpdo_rfp_chain_of_data}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data, def:mpo_is_zcl,
+        thm:mpdo_eta_local_structure_is_gsnnch_zcl,
+        thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion}
+    If the post-extraction $\eta$-local structure has been constructed for an
+    MPO tensor \(K\), then zero correlation length gives the GSNNCH-with-ZCL
+    branch, the blocked fusion-isometry witness at size \(2\), and the
+    transfer-map fusion formulation of MPDO RFP.
+\end{theorem}
+
+\begin{proof}\leanok
+    The $\eta$-local structure supplies the commuting-form property. Combining
+    this with zero correlation length gives the GSNNCH-with-ZCL branch; zero
+    correlation length also gives the blocked fusion-isometry witness and the
+    transfer-map fusion formulation.
 \end{proof}
 
 \begin{theorem}[Simple-MPDO RFP chain from commuting form and ZCL]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2358,6 +2358,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{definition}[$\eta$-local commuting-form data]
     \label{def:mpdo_eta_local_structure_data}
+    \lean{MPOTensor.TranslationInvariantBondData}
     \lean{MPOTensor.EtaLocalStructureData}
     \leanok
     \uses{def:mpdo_has_commuting_form}
@@ -2368,6 +2369,10 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[$\eta$-local structure carries commuting form]
     \label{thm:mpdo_eta_local_structure_has_commuting_form}
+    \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData}
+    \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_bond}
+    \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_hN}
+    \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData_bondAt}
     \lean{MPOTensor.EtaLocalStructureData.hasCommutingForm}
     \lean{MPOTensor.EtaLocalStructureData.formAt_realizes}
     \lean{MPOTensor.EtaLocalStructureData.formAt_bondAt_comm}
@@ -2377,7 +2382,7 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_has_commuting_form}
     The $\eta$-local structure itself determines a commuting-form witness for every
     chain length $N \ge 2$.  In particular, the translated nearest-neighbor
-    bonds commute and the MPDO at length \(N\) is a positive scalar multiple of
+    bonds commute and the MPDO at length $N$ is a positive scalar multiple of
     their product, as in Proposition~C.6.
 \end{theorem}
 
@@ -2481,22 +2486,28 @@ the elementary trace-power identity for diagonal matrices.
     For an MPO tensor $K$, this consists of the local Appendix~C.2 data, the
     commuting-form property, and zero correlation length. The local component
     consists of the hypotheses used in the entropy-side argument for commuting form.
-    The auxiliary constructor takes the scoped SAL--ZCL local hypotheses
+    The alternative construction takes the scoped SAL--ZCL local hypotheses
     together with an already-supplied commuting-form witness.
 \end{definition}
 
-\begin{definition}[Blocked-RFP data from $\eta$-local structure]
-    \label{def:simple_mpdo_blocked_rfp_data_of_eta_local_structure}
+\begin{theorem}[Blocked-RFP data from $\eta$-local structure]
+    \label{thm:simple_mpdo_blocked_rfp_data_of_eta_local_structure}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofEtaLocalStructure}
     \leanok
     \uses{def:simple_mpdo_local_structure_data,
         def:simple_mpdo_blocked_rfp_data,
         def:mpdo_eta_local_structure_data}
     Once the $\eta$-local structure has been assembled, it
-    supplies the commuting-form field of the blocked-RFP data. Together with
+    supplies the commuting-form property required by the blocked-RFP data. Together with
     the local Appendix~C.2 data and zero correlation length, this gives the
     explicit hypotheses used by the simple-MPDO construction theorem.
-\end{definition}
+\end{theorem}
+
+\begin{proof}\leanok
+    Use the commuting-form property carried by the $\eta$-local structure and
+    keep the local Appendix~C.2 data and zero-correlation-length hypothesis
+    unchanged.
+\end{proof}
 
 \begin{theorem}[Zero correlation length gives a blocked fusion-isometry witness]
     \label{thm:structural_implies_rfp_blocked}
@@ -2517,10 +2528,27 @@ the elementary trace-power identity for diagonal matrices.
     produces the blocked witness.
 \end{proof}
 
+\begin{theorem}[Simple-MPDO RFP chain from blocked-RFP data]
+    \label{thm:simple_mpdo_rfp_chain_of_data}
+    \lean{MPOTensor.simple_mpdo_rfp_chain_of_data}
+    \lean{MPOTensor.structural_implies_rfp_blocked_of_data}
+    \leanok
+    \uses{def:simple_mpdo_blocked_rfp_data,
+        thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion}
+    Given the blocked-RFP data for an MPO tensor $K$, one obtains the
+    GSNNCH-with-ZCL case, the blocked fusion-isometry witness at size $2$, and
+    the transfer-map fusion formulation of MPDO RFP.
+\end{theorem}
+
+\begin{proof}\leanok
+    The commuting-form and zero-correlation-length assumptions give the
+    GSNNCH-with-ZCL case. Zero correlation length also gives the blocked
+    fusion-isometry witness and the transfer-map fusion formulation.
+\end{proof}
+
 \begin{theorem}[Simple-MPDO RFP chain from $\eta$-local structure]
     \label{thm:simple_mpdo_rfp_chain_of_eta_local_structure}
     \lean{MPOTensor.simple_mpdo_rfp_chain_of_etaLocalStructure}
-    \lean{MPOTensor.simple_mpdo_rfp_chain_of_data}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpo_is_zcl,
         thm:mpdo_eta_local_structure_is_gsnnch_zcl,

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2369,8 +2369,10 @@ the elementary trace-power identity for diagonal matrices.
 \begin{theorem}[$\eta$-local structure carries commuting form]
     \label{thm:mpdo_eta_local_structure_has_commuting_form}
     \lean{MPOTensor.EtaLocalStructureData.hasCommutingForm}
+    \lean{MPOTensor.EtaLocalStructureData.formAt_realizes}
     \lean{MPOTensor.EtaLocalStructureData.formAt_bondAt_comm}
     \lean{MPOTensor.EtaLocalStructureData.exists_positive_scalar_mpo_eq_product}
+    \lean{MPOTensor.EtaLocalStructureData.positive_commuting_product_form}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_has_commuting_form}
     The $\eta$-local structure itself determines a commuting-form witness for every

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2505,8 +2505,8 @@ the elementary trace-power identity for diagonal matrices.
     This structure collects the local Appendix~C.2 data: a normalized
     three-site reduced state with equality in strong subadditivity, the
     resulting local $\eta$-structure, and the rank-one conclusion for the
-    auxiliary primitive matrix $T$. The scoped local hypotheses from Lemmas
-    C.3--C.4 determine such a structure.
+    auxiliary primitive matrix $T$. The hypotheses of Lemmas C.3--C.4 determine
+    such a structure.
 \end{definition}
 
 \begin{definition}[Simple-MPDO blocked-RFP data]
@@ -2519,8 +2519,8 @@ the elementary trace-power identity for diagonal matrices.
     For an MPO tensor $K$, this consists of the local Appendix~C.2 data, the
     commuting-form property, and zero correlation length. The local component
     consists of the hypotheses used in the entropy-side argument for commuting form.
-    The alternative construction takes the scoped SAL--ZCL local hypotheses
-    together with an already-supplied commuting-form witness.
+    The alternative construction takes the SAL--ZCL hypotheses together with an
+    already-supplied commuting-form witness.
 \end{definition}
 
 \begin{theorem}[Blocked-RFP data from $\eta$-local structure]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2424,7 +2424,6 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[$\eta$-local structure gives GSNNCH]
     \label{thm:mpdo_eta_local_structure_is_gsnnch}
-    \lean{MPOTensor.EtaLocalStructureData.isGSNNCHAt}
     \lean{MPOTensor.EtaLocalStructureData.isGSNNCH}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_is_gsnnch}


### PR DESCRIPTION
### Motivation

- Continues the MPDO renormalization-fixed-point formalization from arXiv:1606.00608 Appendix C.2, Proposition C.6.
- Records the fixed-length consequences of an assembled eta-local structure: the translated two-site bonds commute and the MPDO is a positive scalar multiple of their product.
- Connects eta-local structure plus zero correlation length to the GSNNCH-with-ZCL conclusion and the existing blocked-RFP construction.

### Description

- `TNLean/MPS/MPDO/CommutingFormBridge.lean` adds the per-chain-length commuting-bond and positive-product consequences of eta-local structure, with source reference to `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1571--1593.
- `TNLean/MPS/MPDO/BlockedRFPConstruction.lean` adds `SimpleMPDOBlockedRFPData.ofEtaLocalStructure` and `simple_mpdo_rfp_chain_of_etaLocalStructure`.
- `blueprint/src/chapter/ch02b_mpdo.tex` records the new eta-local consequences and blocked-RFP theorem nodes.

This PR does not prove the raw SAL/ZCL-to-eta-local construction. That remains the open part of issue #823.

### Testing

- `lake env lean TNLean/MPS/MPDO/CommutingFormBridge.lean`
- `lake build TNLean.MPS.MPDO.CommutingFormBridge`
- `lake env lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean`
- `lake build TNLean.MPS.MPDO.BlockedRFPConstruction`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/MPDO/CommutingFormBridge.lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean blueprint/src/chapter/ch02b_mpdo.tex --diff-base main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- touched-file 100-column scan
- touched-file proof-integrity scan
- `leanblueprint web`

Refs #823.
Leaves issue #823 open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and blueprint documentation only; no runtime, auth, or data paths. The hard entropy-side assembly theorem remains explicitly out of scope.
> 
> **Overview**
> This PR wires **assembled η-local structure** into the existing simple-MPDO blocked-RFP story, without proving the still-open SAL/ZCL → η-local construction (#823).
> 
> In **`CommutingFormBridge.lean`**, `EtaLocalStructureData` gains explicit per-length consequences: translated bonds commute, the finite-chain MPDO is a **positive scalar multiple** of their product, and (with ZCL) **`IsGSNNCHWithZCL`** via `isGSNNCHWithZCL` / `isGSNNCHWithZCL_of_etaLocalStructure`. Module docs now point at this bridge layer after sector-local η operators are assembled.
> 
> **`BlockedRFPConstruction.lean`** imports the bridge module and adds **`SimpleMPDOBlockedRFPData.ofEtaLocalStructure`** (commuting form from `hEta.hasCommutingForm`) plus **`simple_mpdo_rfp_chain_of_etaLocalStructure`**, which reuses the existing `simple_mpdo_rfp_chain` once η-local data and ZCL are assumed.
> 
> **`ch02b_mpdo.tex`** documents translation-invariant bond data, the new η-local/GSNNCH–ZCL theorems, and the blocked-RFP constructors/chains aligned with the Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e60e286afec57d0ecfe9c06ff29aad3e6aa3db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->