### PR TITLE
doc(MPS/MPDO): combine fusion RFP blueprint tags

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -886,8 +886,7 @@ retract.
 
 \begin{theorem}[Fusion-isometry data imply the MPDO RFP condition]%
     \label{thm:mpdo_rfp_of_fusion}
-    \lean{MPOTensor.FusionIsometryData.isRFP}
-    \lean{MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
+    \lean{MPOTensor.FusionIsometryData.isRFP, MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
     A one-site fusion-isometry datum implies the MPDO RFP condition.  Hence the


### PR DESCRIPTION
## Motivation

The blueprint entry `thm:mpdo_rfp_of_fusion` cites two Lean declarations associated with the fusion-isometry formulation of the MPDO renormalization fixed-point condition.  The source passage is arXiv:1606.00608, Appendix C.4, where the fusion data define the maps `T` and `S` used in the RFP condition.

With two separate `\lean{...}` commands, `leanblueprint` keeps only the later declaration for the dependency graph.

## Description

This combines the two declarations into one comma-separated `\lean{...}` command so that both declarations are recorded for the theorem entry.

Fixes #2082.

## Testing

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files blueprint/src/chapter/ch02b_mpdo.tex --diff-base main`
- `leanblueprint web`
- `leanblueprint checkdecls` *(fails on pre-existing missing PEPS and parent-Hamiltonian declarations; the MPDO declarations changed here are present in `blueprint/lean_decls` after generation)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint tagging; no runtime, auth, or proof logic changes.
> 
> **Overview**
> For **`thm:mpdo_rfp_of_fusion`** in `ch02b_mpdo.tex`, the blueprint now lists both Lean names in a **single** `\lean{MPOTensor.FusionIsometryData.isRFP, MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}` tag instead of two separate `\lean{...}` lines.
> 
> That keeps **`MPOTensor.FusionIsometryData.isRFP`** in the leanblueprint dependency graph alongside **`MPOTensor.isRFP_of_isRFP_MPDO_via_fusion`** (separate tags previously left only the latter). No mathematical or Lean proof content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64bfe14706d0b9cac396d3836bf9614c0c57cee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->