### PR TITLE
doc(paper-gaps): detokenize Lean identifiers

### DIFF
--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -3,7 +3,7 @@
 \DeclareUnicodeCharacter{2082}{\ifmmode{}_{2}\else\textsubscript{2}\fi}
 
 \newcommand{\Lean}{\textsc{Lean}}
-\newcommand{\leanid}[1]{\textsf{#1}}
+\newcommand{\leanid}[1]{\textsf{\detokenize{#1}}}
 \providecommand{\tr}{\operatorname{tr}}
 \newcommand{\tnleanIssueBase}{https://github.com/LionSR/TNLean/issues/}
 \newcommand{\tnleanPrBase}{https://github.com/LionSR/TNLean/pull/}

--- a/docs/paper-gaps/common_sector_relabeling_hypothesis.tex
+++ b/docs/paper-gaps/common_sector_relabeling_hypothesis.tex
@@ -51,7 +51,7 @@ identity between two descriptions of the same blocked-word coordinates, and the
 formalization proves it unconditionally before using it in the sector-comparison
 theorems.\footnote{%
     The proof is
-    \leanid{CommonGroupedBlockCastHypothesis.of\_flattenWordOfBlock\_cast\_eq},
+    \leanid{CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq},
     and \leanid{CommonGroupedBlockCastHypothesis.toRelabelingHypothesis} gives
     the stated relabeling hypothesis. Both declarations are in
     \doclink{TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean}.}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -151,14 +151,14 @@ Only after this trace equality is obtained do the maps
 have the normalizing factors required in lines~2065--2085.
 
 The present algebra predicate
-\leanid{MPOTensor.IsRFP\_MPDO\_via\_algebra} does not include these BNT-label
+\leanid{MPOTensor.IsRFP_MPDO_via_algebra} does not include these BNT-label
 coefficients, the positive \(\chi_{\alpha,\beta,\gamma}\), or the
 length-one idempotent trace identity.  It can prove equality of adjoint
 fixed-point spaces across positive blocking lengths, but this is weaker than
 the coefficient comparison used above.  Thus the source-faithful route to the
 fusion formulation must first construct the BNT-label theorem witness and the
 idempotent trace-scalar identity, and then use the one-site retract criterion
-\leanid{MPOTensor.fusionIsometryData\_one\_iff\_isRFP}.
+\leanid{MPOTensor.fusionIsometryData_one_iff_isRFP}.
 
 \section{BNT-label coefficient objects and remaining elimination plan}
 
@@ -175,11 +175,11 @@ family
 This is recorded separately so that the \(\chi\)-family can serve as the single
 source of those coefficients in the source-side special case.\footnote{%
 \leanid{MPOTensor.BNTLabelCoefficientFamily.ofChi},
-\leanid{MPOTensor.BNTLabelCoefficientFamily.ofChi\_coeff},
+\leanid{MPOTensor.BNTLabelCoefficientFamily.ofChi_coeff},
 \leanid{MPOTensor.BNTLabelCoefficientFamily.%
-ofChi\_coeff\_eq\_trace\_matrix\_pow},
+ofChi_coeff_eq_trace_matrix_pow},
 \leanid{MPOTensor.BNTLabelCoefficientFamily.%
-ofChi\_hasPositiveLengthChiTracePowerForm}.}  A
+ofChi_hasPositiveLengthChiTracePowerForm}.}  A
 same-length BNT product predicate records the algebra identity
 \[
     O_L(M_\alpha)O_L(M_\beta)
@@ -225,28 +225,28 @@ Once both the same-length BNT product form and a positive BNT-label
 coefficients written as \(\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)\)
 is formalized as a direct corollary.\footnote{%
 \leanid{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.%
-eq\_sum\_chi\_trace\_pow},
+eq_sum_chi_trace_pow},
 \leanid{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.%
-eq\_sum\_ofChi\_trace\_pow}.}
+eq_sum_ofChi_trace_pow}.}
 Once both the comparison predicate and a positive BNT-label \(\chi\)-witness are
 available, the coefficient-level blocked trace-power formula is formalized as a
 direct corollary.\footnote{%
-\leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked\_coeff\_eq\_trace\_pow},
+\leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-blocked\_coeff\_eq\_ofChi\_trace\_pow},
+blocked_coeff_eq_ofChi_trace_pow},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-blocked\_coeff\_eq\_pulledBlockedChi\_trace\_pow}.}
+blocked_coeff_eq_pulledBlockedChi_trace_pow}.}
 The same hypotheses also give a positive blocked-basis \(\chi\)-witness by
 pulling back the uniform BNT-label \(\chi\)-family along the
 comparison maps.\footnote{%
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-pulledBlockedChiFamily\_toDiagonal\_of\_pos},
+pulledBlockedChiFamily_toDiagonal_of_pos},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-pulledBlockedChi\_tracePowerCoeff\_of\_pos},
+pulledBlockedChi_tracePowerCoeff_of_pos},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-pulledBlockedChi\_dim\_of\_pos},
+pulledBlockedChi_dim_of_pos},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
-pulledBlockedChi\_trace\_matrix\_pow\_of\_pos},
+pulledBlockedChi_trace_matrix_pow_of_pos},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison.%
 toPositiveBlockedStructureChiTracePowerForm}.}
 Likewise, once the idempotent coefficient condition and the positive
@@ -254,9 +254,9 @@ BNT-label \(\chi\)-witness are available, the length-one idempotent identity is
 formalized with the coefficients rewritten as traces of the corresponding
 \(\chi\)-matrices.\footnote{%
 \leanid{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.%
-eq\_sum\_chi\_trace},
+eq_sum_chi_trace},
 \leanid{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.%
-eq\_sum\_ofChi\_trace}.}
+eq_sum_ofChi_trace}.}
 
 The BNT-label objects above are now also gathered into one theorem-data record:
 fixed coefficients, same-length operators and product law, trace scalars and
@@ -279,41 +279,41 @@ trace-power formula, the blocked-basis coefficient comparison, the positive
 blocked \(\chi\)-witness, the pulled-back blocked trace-power predicate, and the
 pulled-back blocked-basis \(\chi\)-family with positive entries and trace-power
 formula are immediate consequences.\footnote{%
-\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_form},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_coefficient\_form},
-\leanid{MPOTensor.BNTLabelTheoremData.positive\_chi\_pos\_entries},
-\leanid{MPOTensor.BNTLabelTheoremData.positive\_chi\_trace\_power},
+\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_form},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent_coefficient_form},
+\leanid{MPOTensor.BNTLabelTheoremData.positive_chi_pos_entries},
+\leanid{MPOTensor.BNTLabelTheoremData.positive_chi_trace_power},
 \leanid{MPOTensor.BNTLabelTheoremData.labelAssignment},
 \leanid{MPOTensor.BNTLabelTheoremData.sourceLabel},
 \leanid{MPOTensor.BNTLabelTheoremData.targetLabel},
-\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_eq\_sum},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_eq\_sum},
-\leanid{MPOTensor.BNTLabelTheoremData.coeff\_eq\_trace\_pow},
-\leanid{MPOTensor.BNTLabelTheoremData.coeff\_eq\_ofChi\_coeff},
-\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_form\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_coefficient\_form\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_eq\_sum\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_eq\_sum\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.chi\_entry\_pos},
-\leanid{MPOTensor.BNTLabelTheoremData.blocked\_coeff\_eq},
-\leanid{MPOTensor.BNTLabelTheoremData.blockedComparison\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.blocked\_coeff\_eq\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremData.same\_length\_product\_eq\_sum\_chi\_trace\_pow},
-\leanid{MPOTensor.BNTLabelTheoremData.idempotent\_eq\_sum\_chi\_trace},
-\leanid{MPOTensor.BNTLabelTheoremData.blocked\_coeff\_eq\_trace\_pow},
+\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum},
+\leanid{MPOTensor.BNTLabelTheoremData.coeff_eq_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremData.coeff_eq_ofChi_coeff},
+\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_form_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent_coefficient_form_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.chi_entry_pos},
+\leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq},
+\leanid{MPOTensor.BNTLabelTheoremData.blockedComparison_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremData.same_length_product_eq_sum_chi_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum_chi_trace},
+\leanid{MPOTensor.BNTLabelTheoremData.blocked_coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm},
 \leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_toDiagonal\_of\_pos},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_toDiagonal_of_pos},
 \leanid{MPOTensor.BNTLabelTheoremData.%
-positiveBlockedChi\_tracePowerCoeff\_of\_pos},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_dim\_of\_pos},
+positiveBlockedChi_tracePowerCoeff_of_pos},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_dim_of_pos},
 \leanid{MPOTensor.BNTLabelTheoremData.%
-positiveBlockedChi\_trace\_matrix\_pow\_of\_pos},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_tracePower},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_posEntries},
-\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi\_entry\_pos},
+positiveBlockedChi_trace_matrix_pow_of_pos},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_tracePower},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_posEntries},
+\leanid{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_entry_pos},
 \leanid{MPOTensor.BNTLabelTheoremData.%
-blocked\_coeff\_eq\_positiveBlockedChi\_trace\_pow}.}
+blocked_coeff_eq_positiveBlockedChi_trace_pow}.}
 
 The same data can be stated in the existential form closest to the paper: one
 object records the BNT-label type, the same-length operator spaces, their
@@ -326,10 +326,10 @@ algebraic structure, and the corresponding theorem data.\footnote{%
 \leanid{MPOTensor.BNTLabelTheoremWitness.traceScalars},
 \leanid{MPOTensor.BNTLabelTheoremWitness.positiveChi},
 \leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_form},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_coefficient\_form},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positive\_chi\_pos\_entries},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positive\_chi\_trace\_power},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_form},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_coefficient_form},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_pos_entries},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_trace_power},
 \leanid{MPOTensor.BNTLabelTheoremWitness.labelAssignment},
 \leanid{MPOTensor.BNTLabelTheoremWitness.sourceLabel},
 \leanid{MPOTensor.BNTLabelTheoremWitness.targetLabel},
@@ -340,20 +340,20 @@ equations written with \(c^{(L)}_{\alpha,\beta,\gamma}\), and the same two
 equations with coefficients written as \(\chi\)-traces; the blocked-basis
 \(\chi\)-family is also identified as the pullback of the BNT-label
 \(\chi\)-family along the comparison maps.\footnote{%
-\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists\_source\_predicates},
+\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists_source_predicates},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists\_positive\_length\_coeff\_eq\_ofChi},
-\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists\_source\_ofChi\_predicates},
-\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists\_source\_ofChi\_equations},
-\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists\_blocked\_chi\_pullback},
+exists_positive_length_coeff_eq_ofChi},
+\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists_source_ofChi_predicates},
+\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists_source_ofChi_equations},
+\leanid{MPOTensor.HasBNTLabelTheoremWitness.exists_blocked_chi_pullback},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists\_blocked\_coefficient\_comparison},
+exists_blocked_coefficient_comparison},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists\_blocked\_coefficient\_comparison\_ofChi},
+exists_blocked_coefficient_comparison_ofChi},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists\_source\_coefficient\_equations},
+exists_source_coefficient_equations},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists\_source\_chi\_trace\_equations}.}
+exists_source_chi_trace_equations}.}
 The existential
 statement has the analogous canonical construction from a positive
 \(\chi\)-family, again leaving the product, idempotent, and blocked-comparison
@@ -361,7 +361,7 @@ statements as inputs rather than reconstructing them from an MPDO tensor.\footno
 \leanid{MPOTensor.BNTLabelTheoremWitness.ofChi},
 \leanid{MPOTensor.BNTLabelTheoremWitness.hasBNTLabelTheoremWitness},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-ofChi\_hasBNTLabelTheoremWitness}.}  Such a witness
+ofChi_hasBNTLabelTheoremWitness}.}  Such a witness
 immediately gives the source predicates and their consequences: the coefficient
 trace-power formula, the same-length product law, the idempotent scalar law,
 positivity of the diagonal \(\chi\)-entries, the blocked-basis coefficient
@@ -369,47 +369,47 @@ comparison, the same-length chi-trace product law, the chi-trace idempotent law,
 the blocked-basis coefficient trace-power formula, the positive blocked-basis
 \(\chi\)-witness, and the pulled-back blocked trace-power predicate and
 \(\chi\)-family for the chosen algebra-structure data.\footnote{%
-\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_form},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_coefficient\_form},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positive\_chi\_pos\_entries},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positive\_chi\_trace\_power},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_form},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_coefficient_form},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_pos_entries},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positive_chi_trace_power},
 \leanid{MPOTensor.BNTLabelTheoremWitness.sourceLabel},
 \leanid{MPOTensor.BNTLabelTheoremWitness.targetLabel},
-\leanid{MPOTensor.BNTLabelTheoremWitness.coeff\_eq\_trace\_pow},
-\leanid{MPOTensor.BNTLabelTheoremWitness.coeff\_eq\_ofChi\_coeff},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_form\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_coefficient\_form\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_eq\_sum\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_eq\_sum\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_eq\_sum},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_eq\_sum},
-\leanid{MPOTensor.BNTLabelTheoremWitness.chi\_entry\_pos},
-\leanid{MPOTensor.BNTLabelTheoremWitness.blocked\_coeff\_eq},
-\leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.blocked\_coeff\_eq\_ofChi},
-\leanid{MPOTensor.BNTLabelTheoremWitness.same\_length\_product\_eq\_sum\_chi\_trace\_pow},
-\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent\_eq\_sum\_chi\_trace},
-\leanid{MPOTensor.BNTLabelTheoremWitness.blocked\_coeff\_eq\_trace\_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.coeff_eq_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.coeff_eq_ofChi_coeff},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_form_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_coefficient_form_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum},
+\leanid{MPOTensor.BNTLabelTheoremWitness.chi_entry_pos},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blockedComparison_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_ofChi},
+\leanid{MPOTensor.BNTLabelTheoremWitness.same_length_product_eq_sum_chi_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.idempotent_eq_sum_chi_trace},
+\leanid{MPOTensor.BNTLabelTheoremWitness.blocked_coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
 toPositiveBlockedStructureChiTracePowerForm},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-positiveBlockedChi\_toDiagonal\_of\_pos},
+positiveBlockedChi_toDiagonal_of_pos},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-positiveBlockedChi\_tracePowerCoeff\_of\_pos},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi\_dim\_of\_pos},
+positiveBlockedChi_tracePowerCoeff_of_pos},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_dim_of_pos},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-positiveBlockedChi\_trace\_matrix\_pow\_of\_pos},
+positiveBlockedChi_trace_matrix_pow_of_pos},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-positive\_blocked\_chi\_witness},
+positive_blocked_chi_witness},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists\_blocked\_chi\_trace\_power\_form},
+exists_blocked_chi_trace_power_form},
 \leanid{MPOTensor.HasBNTLabelTheoremWitness.%
-exists\_blocked\_coeff\_eq\_trace\_pow},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi\_tracePower},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi\_posEntries},
-\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi\_entry\_pos},
+exists_blocked_coeff_eq_trace_pow},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_tracePower},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_posEntries},
+\leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_entry_pos},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-blocked\_coeff\_eq\_positiveBlockedChi\_trace\_pow}.}  The remaining step is still the
+blocked_coeff_eq_positiveBlockedChi_trace_pow}.}  The remaining step is still the
 construction of this existential witness from the MPDO tensor.
 
 To eliminate the remaining gap, the formalization should introduce:

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -67,7 +67,7 @@ eventual linear-independence input in the shared sector-decomposition
 infrastructure,\footnote{%
     \doclink{TNLean/MPS/SharedInfra/SectorDecomposition}.}
 while \eqref{eq:qual} is provided pointwise by
-\leanid{MPSTensor.mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP}.\footnote{%
+\leanid{MPSTensor.mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP}.\footnote{%
     \doclink{TNLean/MPS/Overlap/CastDecay}.}
 Neither source equips $\eta_{j,k}$ with a quantitative relation
 to the spectral weight ratios.
@@ -93,13 +93,13 @@ The surviving \leanid{SectorBNT} surface does not package such constants.
 It keeps the raw BNT weights in \leanid{SectorDecomposition} and records
 qualitative consequences in
 \doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/Api}: the coefficient
-bound \leanid{SectorDecomposition.norm\_coeff\_le\_copies\_of\_norm\_weight\_le\_one},
+bound \leanid{SectorDecomposition.norm_coeff_le_copies_of_norm_weight_le_one},
 within-family cross-decay
-\leanid{MPSTensor.IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero}, the
+\leanid{MPSTensor.IsBNTCanonicalForm.cross_overlap_basis_tendsto_zero}, the
 combined-family linear-independence criterion
-\leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li}, and the
+\leanid{MPSTensor.IsBNTCanonicalForm.combined_family_eventually_li}, and the
 non-vanishing coefficient statement
-\leanid{MPSTensor.IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}.  None of
+\leanid{MPSTensor.IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block}.  None of
 these declarations supplies the constants in~\eqref{eq:hyp}.
 
 \section{Where such a hypothesis would be needed}
@@ -130,7 +130,7 @@ beyond what \cite[\S II]{Cirac2016MPDO_arXiv} and
 \cite[Definition~4.2]{Cirac2021Matrix} make explicit. Its rate is
 in principle derivable from the spectral gap of the mixed transfer
 operator that powers
-\leanid{mpvOverlap\_tendsto\_zero\_of\_not\_gaugePhaseEquiv\_cast\_left\_of\_irreducible\_TP},
+\leanid{mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP},
 but the compatibility inequality
 $\eta_{j,k}\cdot\|\lambda_j/\lambda_k\|<1$ is not implied by the
 BNT structure and must be either imposed or established analytically.

--- a/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
+++ b/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
@@ -248,7 +248,7 @@ source.
 The first change is to record the source convention $|\mu_1|=1$. Once this
 normalization is present, the implicit bounds $|\mu_k|\le 1$ on the remaining
 blocks follow from the strict modulus ordering.\footnote{%
-    The formal field carrying this ordering is \leanid{mu\_strict\_anti} in
+    The formal field carrying this ordering is \leanid{mu_strict_anti} in
     \leanid{IsNormalCanonicalFormBNT}; see
     \path{TNLean/MPS/BNT/Construction.lean}, lines 184--185.} This should be a
 field of \leanid{IsNormalCanonicalFormBNT} and of the corresponding blueprint

--- a/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
+++ b/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
@@ -55,7 +55,7 @@ separating two mathematical steps. First, the spectral-radius theorem shows
 that asymptotically unit-modulus overlap forces the cross-transfer spectral
 radius to be at least $1$.\footnote{%
     This theorem is
-    \leanid{MPSTensor.mixedTransferSpectralRadius\_ge\_one\_of\_mpvOverlap\_norm\_tendsto\_one};
+    \leanid{MPSTensor.mixedTransferSpectralRadius_ge_one_of_mpvOverlap_norm_tendsto_one};
     it is in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean} and formalizes
     a step in the proof of Lemma~\texttt{equalMPS},
     \cite[lines~1093--1117]{Cirac2016MPDO_arXiv}.}
@@ -66,13 +66,13 @@ Second, the modulus-one spectral theorem turns the modulus-one spectral
 situation into gauge-phase equivalence by the Cauchy--Schwarz argument with the
 positive fixed point.\footnote{%
     This theorem is
-    \leanid{MPSTensor.modulus\_one\_eigenvalue\_implies\_gauge\_of\_irreducible\_TP};
+    \leanid{MPSTensor.modulus_one_eigenvalue_implies_gauge_of_irreducible_TP};
     it is in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}.}
 The resulting same-dimension gauge-phase theorem has the source's overlap
 hypothesis and no MPV proportionality hypothesis, but it is stated for two
 tensors with the same bond dimension.\footnote{%
     The theorem is
-    \leanid{MPSTensor.gaugePhaseEquiv\_of\_overlap\_norm\_tendsto\_one\_of\_irreducible\_TP};
+    \leanid{MPSTensor.gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP};
     it is in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}.}
 In this same-dimension component the formal theorem changes the normal-tensor
 hypothesis set in a controlled way: in CPSV16 a normal tensor has no
@@ -98,10 +98,10 @@ out a proper missing subspace, forcing equality of dimensions
 \cite[lines~1115--1117]{Cirac2016MPDO_arXiv}.
 
 The formalization records this conclusion as
-\leanid{MPSTensor.dim\_eq\_of\_overlap\_norm\_tendsto\_one\_of\_irreducible\_TP}
+\leanid{MPSTensor.dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP}
 in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}. Its proof uses the
 contrapositive of the rectangular overlap-decay theorem
-\leanid{MPSTensor.mpvOverlap\_tendsto\_zero\_of\_dim\_ne\_of\_irreducible\_TP}:
+\leanid{MPSTensor.mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP}:
 if the bond dimensions differ, the overlap tends to zero, contradicting the
 unit-modulus overlap hypothesis.
 

--- a/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
+++ b/docs/paper-gaps/cpsv16_fixed_block_cancellation.tex
@@ -68,7 +68,7 @@ The formal boundary in \cite{Cirac2016MPDO_arXiv} is narrower:
 The surviving \leanid{SectorBNT} API does not currently contain this
 single-block linear-independence formulation.  It supplies the stronger
 full-family mechanism
-\leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li},
+\leanid{MPSTensor.IsBNTCanonicalForm.combined_family_eventually_li},
 under all-pairwise cross-overlap decay; this is sufficient for the
 coefficient-comparison contradiction, but it is not the literal
 single-block statement displayed above.

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -29,7 +29,7 @@ $\mu^A_j,\mu^B_k\in\mathbb C$. The assembled MPV at length~$N$ is
 written $V^{(N)}(\mathtt{toTensorFromBlocks} \mu A)$ in the
 formalization.\footnote{%
     \leanid{MPSTensor.toTensorFromBlocks};
-    \leanid{MPSTensor.mpv\_toTensorFromBlocks\_eq\_sum}.}
+    \leanid{MPSTensor.mpv_toTensorFromBlocks_eq_sum}.}
 A cross-overlap $\langle V^{(N)}(A_j),V^{(N)}(B_k)\rangle$ is
 \leanid{MPSTensor.mpvOverlap}. \emph{Eventual proportionality} of the
 assembled families is the hypothesis that for some scalar sequence
@@ -48,10 +48,10 @@ The surviving one-copy normal-canonical BNT formulation
 sector with strict ordering
 \begin{align}
     \|\mu_1\|>\|\mu_2\|>\cdots>\|\mu_r\|
-    \tag{\leanid{mu\_strict\_anti}}
+    \tag{\leanid{mu_strict_anti}}
 \end{align}
 across the entire family.\footnote{%
-    \leanid{MPSTensor.IsNormalCanonicalFormBNT.mu\_strict\_anti} in
+    \leanid{MPSTensor.IsNormalCanonicalFormBNT.mu_strict_anti} in
     \doclink{TNLean/MPS/BNT/Construction}.}
 Together with the dominant normalization $\|\mu_1\|=1$, every
 sub-dominant block has modulus strictly less than~$1$.
@@ -114,7 +114,7 @@ and $\mathrm{RHS}_N:=c_N\langle V^{(N)}(B_{\mathrm{tot}}),V^{(N)}(B_{k_0})\rangl
 With $\|\mu^A_j\|\le 1$, every $(\mu^A_j)^N$ is bounded; together with
 \eqref{eq:Hk0} this forces $\mathrm{LHS}_N\to 0$. For $\mathrm{RHS}_N$,
 the current cross-overlap decay statement
-\leanid{MPSTensor.IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero}
+\leanid{MPSTensor.IsBNTCanonicalForm.cross_overlap_basis_tendsto_zero}
 gives $\langle V^{(N)}(B_k),V^{(N)}(B_{k_0})\rangle\to 0$ for $k\ne k_0$,
 while the diagonal block has a nonzero limiting coefficient, so
 $\mathrm{RHS}_N=c_N(\mu^B_{k_0})^N(\ell+o(1))$.
@@ -128,7 +128,7 @@ $\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$.  Therefore
     \bigl\|\mu^B_{k_0}/\mu^B_0\bigr\|^N.
     \label{eq:decay}
 \end{align}
-Under $\|\mu^A_0\|=1$ and \leanid{mu\_strict\_anti}, the second factor
+Under $\|\mu^A_0\|=1$ and \leanid{mu_strict_anti}, the second factor
 in~\eqref{eq:decay} decays geometrically whenever $k_0\ne 0$, so
 $\mathrm{RHS}_N\to 0$ together with $\mathrm{LHS}_N$. No contradiction
 is available from the per-block projection. The dominant case
@@ -178,7 +178,7 @@ independence; it requires neither side to stay bounded away from~$0$.
 
 The current \leanid{SectorBNT} API provides the combined-family
 linear-independence mechanism as
-\leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li}.
+\leanid{MPSTensor.IsBNTCanonicalForm.combined_family_eventually_li}.
 The remaining task is to combine that statement with the proportional
 coefficient identity in the fixed-block setting, without appealing to the
 retired per-block-projection layer.
@@ -203,12 +203,12 @@ either
           $\mu_{j,q}$.  On the surviving \leanid{SectorDecomposition}
           surface this means keeping the raw coefficients
           $\sum_q\mu_{j,q}^N$ visible and using
-          \leanid{MPSTensor.IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block}
+          \leanid{MPSTensor.IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block}
           rather than collapsing the sector to a single weight before the
           projection argument.  Tracked in \ghissue{1641}.
 \end{enumerate}
 
-The collapse $r_j=1$ enforced by \leanid{mu\_strict\_anti}
+The collapse $r_j=1$ enforced by \leanid{mu_strict_anti}
 identifies the two layers into a single weight; once collapsed, the
 non-dominant Step~1 conclusion cannot be reached by per-block
 projection under the one-copy normal-canonical BNT formulation because

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -60,7 +60,7 @@ which are stronger than the source display:
 
   \item \textbf{Dominant normalization.}
         The dominant spectral level satisfies $\|\lambda_0\| = 1$.
-        This mirrors the \leanid{IsNormalCanonicalFormBNT.mu\_dom\_norm\_one}
+        This mirrors the \leanid{IsNormalCanonicalFormBNT.mu_dom_norm_one}
         convention in \doclink{TNLean/MPS/BNT/Construction}; it is not
         imposed by \eqref{eq:bnt-general}.
 \end{enumerate}
@@ -107,10 +107,10 @@ The relevant surviving formal declarations are:
   \item \leanid{IsBNTCanonicalForm} -
         the BNT canonical-form predicate
         (\doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/Basic}).
-  \item \leanid{MPSTensor.IsBNTCanonicalForm.cross\_overlap\_basis\_tendsto\_zero},
-        \leanid{MPSTensor.IsBNTCanonicalForm.combined\_family\_eventually\_li},
-        \leanid{MPSTensor.IsBNTCanonicalForm.coeff\_not\_tendsto\_zero\_at\_block},
-        and \leanid{MPSTensor.IsBNTCanonicalForm.thermodynamic\_limit\_nonvanishing}
+  \item \leanid{MPSTensor.IsBNTCanonicalForm.cross_overlap_basis_tendsto_zero},
+        \leanid{MPSTensor.IsBNTCanonicalForm.combined_family_eventually_li},
+        \leanid{MPSTensor.IsBNTCanonicalForm.coeff_not_tendsto_zero_at_block},
+        and \leanid{MPSTensor.IsBNTCanonicalForm.thermodynamic_limit_nonvanishing}
         in \doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/Api}.
   \item A future adapter from \leanid{IsNormalCanonicalFormBNT}, or from
         explicit separated-block hypotheses, to \leanid{IsBNTCanonicalForm}.

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -86,8 +86,8 @@ identity as padding.
 
 The matrix-factorization content of Lemma~\texttt{lem1} from the source paper
 is now formalized in two steps.\footnote{%
-\leanid{Matrix.span\_range\_mul\_nonzero\_mul\_eq\_top} for the abstract
-matrix-algebra form; \leanid{MPSTensor.span\_range\_evalWord\_mul\_nonzero\_mul\_evalWord\_eq\_top}
+\leanid{Matrix.span_range_mul_nonzero_mul_eq_top} for the abstract
+matrix-algebra form; \leanid{MPSTensor.span_range_evalWord_mul_nonzero_mul_evalWord_eq_top}
 for the word-product translation.}
 The first says that, for any nonzero matrix $C$, the set of products
 $\{RCS : R,S\in M_D(\mathbb C)\}$ spans $M_D(\mathbb C)$. The second
@@ -101,47 +101,47 @@ an inclusion $\mathcal G_L^A\subseteq\mathcal G_L^B$ of length-$L$ image
 spaces. Since block injectivity identifies $\dim\mathcal G_L^A=D_A^2$ and
 $\dim\mathcal G_L^B=D_B^2$, the inclusion and the size ordering together
 force $D_A=D_B$ and $\mathcal G_L^A=\mathcal G_L^B$.\footnote{%
-\leanid{MPSTensor.bondDim\_eq\_and\_groundSpace\_eq\_of\_three\_block\_trace\_relation\_left\_of\_dim\_ge}.}
+\leanid{MPSTensor.bondDim_eq_and_groundSpace_eq_of_three_block_trace_relation_left_of_dim_ge}.}
 The strict-size branch - if $D_B<D_A$, no nonzero coefficient on the larger
 block can satisfy the homogeneous three-block trace relation - is formalized
 separately,\footnote{%
-\leanid{MPSTensor.not\_three\_block\_trace\_relation\_left\_of\_isNBlkInjective\_of\_dim\_gt};
-\leanid{MPSTensor.pairTraceSeparatingAt\_threeBlock\_of\_isNBlkInjective\_of\_dim\_gt}
-for the trace-separation form; \leanid{MPSTensor.pairTraceSeparatingAt\_threeBlock\_of\_isNBlkInjective\_of\_dim\_ne}
+\leanid{MPSTensor.not_three_block_trace_relation_left_of_isNBlkInjective_of_dim_gt};
+\leanid{MPSTensor.pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_gt}
+for the trace-separation form; \leanid{MPSTensor.pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_ne}
 for the convention-free version.}
 as is the conditional directness result: any external proof of the
 contradiction $\neg(D_A=D_B\wedge\mathcal G_L^A=\mathcal G_L^B)$ gives
 $\mathcal G_{3L}^A\cap\mathcal G_{3L}^B=\{0\}$.\footnote{%
-\leanid{MPSTensor.groundSpace\_inf\_eq\_bot\_of\_not\_bondDim\_eq\_and\_groundSpace\_eq\_of\_dim\_ge}.}
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge}.}
 
 The equal-size uniqueness branch is isolated as well. For injective tensors,
 equal length-$L$ image spaces force equality of the periodic MPV lines. A
 supplied distinct-MPV-line hypothesis therefore rules out the equal-size
-collapse.\footnote{\leanid{MPSTensor.not\_bondDim\_eq\_and\_groundSpace\_eq\_of\_mpvSubmodule\_ne}.}
+collapse.\footnote{\leanid{MPSTensor.not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne}.}
 The analytic source of distinct-MPV witnesses is formalized for irreducible
 trace-preserving blocks with normalized self-overlaps: if two blocks are not
 gauge-phase equivalent, then at arbitrarily large chain length their MPV states
 are not pointwise proportional.\footnote{%
-\leanid{MPSTensor.exists\_ge\_not\_forall\_mpv\_eq\_mul\_of\_not\_gaugePhaseEquiv\_of\_irreducible\_TP};
-\leanid{MPSTensor.exists\_ge\_not\_forall\_mpv\_eq\_mul\_of\_blocksNotGaugePhaseEquiv\_of\_irreducible\_TP}
+\leanid{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP};
+\leanid{MPSTensor.exists_ge_not_forall_mpv_eq_mul_of_blocksNotGaugePhaseEquiv_of_irreducible_TP}
 for the BNT-family form.}
 Combining the uniqueness argument with the finite-dimensional image-space step
 gives: if any chain length $N\ge\max\{2,L\}$ witnesses non-proportionality,
 then $\mathcal G_{3L}^A\cap\mathcal G_{3L}^B=\{0\}$.\footnote{%
-\leanid{MPSTensor.groundSpace\_inf\_eq\_bot\_of\_exists\_not\_forall\_mpv\_eq\_mul\_of\_dim\_ge};
-\leanid{MPSTensor.groundSpace\_inf\_eq\_bot\_of\_blocksNotGaugePhaseEquiv\_same\_dim\_of\_dim\_ge}
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge};
+\leanid{MPSTensor.groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}
 for the BNT-separation packaging.}
 Zero intersection of image spaces at a fixed length, together with injectivity
 of the boundary-to-chain maps at that length, implies homogeneous pair trace
-separation.\footnote{\leanid{MPSTensor.pairTraceSeparatingAt\_of\_groundSpace\_inf\_eq\_bot\_of\_isNBlkInjective};
+separation.\footnote{\leanid{MPSTensor.pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective};
 and the combined forms
-\leanid{MPSTensor.pairTraceSeparatingAt\_threeBlock\_of\_exists\_not\_forall\_mpv\_eq\_mul\_of\_dim\_ge},
-\leanid{MPSTensor.pairTraceSeparatingAt\_threeBlock\_of\_blocksNotGaugePhaseEquiv\_same\_dim\_of\_dim\_ge}.}
+\leanid{MPSTensor.pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge},
+\leanid{MPSTensor.pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}.}
 The two branches are combined for all ordered pairs of distinct blocks of a
 BNT family at the common length $3L$, and the result is fed into the
 selector and product-span construction.\footnote{%
-\leanid{MPSTensor.forall\_pairTraceSeparatingAt\_threeBlock\_of\_blocksNotGaugePhaseEquiv};
-\leanid{MPSTensor.exists\_forall\_pairTraceSeparatingAt\_threeBlock\_of\_blocksNotGaugePhaseEquiv}.}
+\leanid{MPSTensor.forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv};
+\leanid{MPSTensor.exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}.}
 
 The already-injective BNT conclusion should now be stated either from
 \leanid{IsNormalCanonicalFormBNT} together with the required injective-block

--- a/docs/paper-gaps/ft_one_copy_scope_restriction.tex
+++ b/docs/paper-gaps/ft_one_copy_scope_restriction.tex
@@ -116,7 +116,7 @@ future non-normal analogue stated with explicit separated-block hypotheses,
 would need a field allowing equal-modulus groups: rather than a global strict
 ordering on the full index set, the condition should be a strict ordering on
 the set of modulus classes, with each class admitting an arbitrary finite
-number of representative blocks. Relaxing \leanid{mu\_strict\_anti} to this
+number of representative blocks. Relaxing \leanid{mu_strict_anti} to this
 weaker form is the necessary type-level change. Without it, the
 general-multiplicity versions of
 Corollary~\texttt{II\_cor2} and of the gauge assembly step cannot be stated.
@@ -143,8 +143,8 @@ has already been supplied. Thus no current theorem is presented as deriving
 the source proportional comparison from the discarded coefficient hypotheses.
 
 The source normalization $\|\mu_1\| = 1$ is now recorded as the field
-\leanid{mu\_dom\_norm\_one} in \leanid{IsNormalCanonicalFormBNT},\footnote{%
-    \leanid{IsNormalCanonicalFormBNT.mu\_dom\_norm\_one},
+\leanid{mu_dom_norm_one} in \leanid{IsNormalCanonicalFormBNT},\footnote{%
+    \leanid{IsNormalCanonicalFormBNT.mu_dom_norm_one},
     \path{TNLean/MPS/BNT/Construction.lean} lines 192--198.} which
 brings the dominant-block normalization into alignment with the source
 convention. Under this normalization and the strict modulus ordering, every
@@ -157,12 +157,12 @@ normal-CF-BNT predicate have been audited against the one-copy-per-sector
 boundary.\footnote{The relevant Lean surfaces are
     \leanid{IsNormalCanonicalFormBNT},
     \leanid{IsNormalCanonicalFormBNT.ofSeparatedData},
-    \leanid{IsNormalCanonicalFormBNT.cross\_overlap\_tendsto\_zero},
+    \leanid{IsNormalCanonicalFormBNT.cross_overlap_tendsto_zero},
     \leanid{IsNormalCanonicalFormBNT.isBNT},
-    \leanid{isNormalCanonicalFormBNT\_commonRepresentativeBlocksAt},
-    \leanid{IsNormalCanonicalFormBNT.exists\_common\_blockTensor\_isInjective},
+    \leanid{isNormalCanonicalFormBNT_commonRepresentativeBlocksAt},
+    \leanid{IsNormalCanonicalFormBNT.exists_common_blockTensor_isInjective},
     and
-    \leanid{exists\_common\_blockTensor\_isInjective\_two\_of\_isNormalCanonicalFormBNT}.}
+    \leanid{exists_common_blockTensor_isInjective_two_of_isNormalCanonicalFormBNT}.}
 Each of these public surfaces either assumes or constructs an already chosen
 representative family, strictly ordered by weight modulus. They do not
 introduce a source-faithful canonical-form existence theorem and do not recover
@@ -185,7 +185,7 @@ formalization: the standalone Newton--Girard uniqueness lemma
 (\texttt{Lem:app\_simple}), the derivation of the blockwise power-sum
 identity from the BNT structure and the equal-MPV hypothesis, and the global
 gauge assembly with multiplicity identity factors. Supplying these components
-would also require relaxing the \leanid{mu\_strict\_anti} field from a global
+would also require relaxing the \leanid{mu_strict_anti} field from a global
 strict ordering to a class-level ordering.
 
 The corresponding tracked items are

--- a/docs/paper-gaps/mps_common_blocking_span_equality.tex
+++ b/docs/paper-gaps/mps_common_blocking_span_equality.tex
@@ -162,7 +162,7 @@ the main adapter names have prefix
 \texttt{MPSTensor.exists\_bnt\_sectorDecomp\_pair\_with\_overlapSpan\_of\_}
 and suffixes \texttt{block\_span\_eq} and \texttt{commonPhaseCover}; the
 block-permutation gauge-phase conclusion first gives span equality through
-\leanid{MPSTensor.mpv\_span\_eq\_of\_blockPermutationGaugePhaseConclusion}.}
+\leanid{MPSTensor.mpv_span_eq_of_blockPermutationGaugePhaseConclusion}.}
 These lemmas state precisely what comparison data are needed; they do not by
 themselves derive all of that data from an arbitrary equality of total MPV
 families.

--- a/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
@@ -619,7 +619,7 @@ blocked not-gauge-phase equivalence, zero-tail identities, and the common
 injective blocking length through the nested-to-flat reblocking map, and then
 feed the resulting families into the BNT sector-data comparison.\footnote{%
 The live target side is the sector-data theorem
-\leanid{MPSTensor.ft\_sector\_bnt\_equal\_sector\_data}; the now-available inputs are
+\leanid{MPSTensor.ft_sector_bnt_equal_sector_data}; the now-available inputs are
 the bounded and common injective-blocking theorems for normal-CF-BNT blocks and
 the already-injective direct-sum trace-separation theorems.}  The
 paper suppresses this bookkeeping in notation; Lean must make it explicit.

--- a/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex
@@ -53,10 +53,10 @@ comparison results. Their hypotheses include blockwise normalization, injective
 or irreducible block hypotheses, a common block index set and dimension
 function, and strict ordering of the weight moduli.\footnote{The corresponding
 formal declarations are
-\leanid{MPSTensor.per\_block\_sameMPV\_of\_\allowbreak canonical\_form},
-\leanid{MPSTensor.per\_block\_sameMPV\_of\_\allowbreak normal\_canonical\_form},
-\leanid{MPSTensor.fundamentalTheorem\_\allowbreak canonicalForm}, and
-\leanid{MPSTensor.fundamentalTheorem\_\allowbreak canonicalForm\_explicit}.}
+\leanid{MPSTensor.per_block_sameMPV_of_canonical_form},
+\leanid{MPSTensor.per_block_sameMPV_of_normal_canonical_form},
+\leanid{MPSTensor.fundamentalTheorem_canonicalForm}, and
+\leanid{MPSTensor.fundamentalTheorem_canonicalForm_explicit}.}
 
 These assumptions are useful local inputs for later MPS arguments, but they are
 not the hypothesis set of the PGVWC07 uniqueness theorem. In particular, the

--- a/docs/paper-gaps/policy.tex
+++ b/docs/paper-gaps/policy.tex
@@ -86,7 +86,7 @@ Formal identifiers should be written with \verb|\leanid| and should usually
 appear in footnotes. For example, the prose may say that the formal theorem is
 the same-dimensional gauge-phase component of a source lemma, and the footnote
 may identify the declaration.\footnote{Formal declaration:
-    \leanid{MPSTensor.gaugePhaseEquiv\_of\_overlap\_norm\_tendsto\_one\_of\_irreducible\_TP}
+    \leanid{MPSTensor.gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP}
     in \doclink{TNLean/MPS/FundamentalTheorem/Proportional}.}
 Do not put formal identifiers in displayed equations unless the mathematical
 object itself is a formal declaration.

--- a/docs/paper-gaps/power_sum_alternative_route.tex
+++ b/docs/paper-gaps/power_sum_alternative_route.tex
@@ -123,9 +123,9 @@ power sums over a common index type:
 The proof then applies the same-cardinality Newton--Girard theorem to recover
 the weight multiset. This route was previously present as checked Lean code
 through the corresponding copy-count, transported-positive-power-sum, and
-weight-multiset declarations.\footnote{\leanid{MPSTensor.SectorWeightData.copies\_eq\_of\_eventually\_coeff\_eq};
-\leanid{MPSTensor.SectorWeightData.eventually\_coeff\_eq\_implies\_all\_pos\_eq\_after\_copies};
-\leanid{MPSTensor.SectorWeightData.weight\_multiset\_eq\_of\_copies\_eq\_of\_coeff\_eq}.}
+weight-multiset declarations.\footnote{\leanid{MPSTensor.SectorWeightData.copies_eq_of_eventually_coeff_eq};
+\leanid{MPSTensor.SectorWeightData.eventually_coeff_eq_implies_all_pos_eq_after_copies};
+\leanid{MPSTensor.SectorWeightData.weight_multiset_eq_of_copies_eq_of_coeff_eq}.}
 Those declarations have been removed from the current source tree because the
 proportional Fundamental Theorem route no longer uses this same-cardinality
 detour. The calculation above records the removed argument for comparison

--- a/docs/paper-gaps/quantum_wielandt_deviation.tex
+++ b/docs/paper-gaps/quantum_wielandt_deviation.tex
@@ -82,7 +82,7 @@ The proof passes through the usual eventual full-rank formulation and a
 blocking argument, but the conclusion is the equality
 $S_n(A)=M_D(\mathbb C)$ for one fixed length $n$. It is not merely a statement
 about the increasing sum $S_0(A)+\cdots+S_n(A)$.\footnote{The general
-    theorem is \leanid{MPSTensor.iIndex\_le\_general\_of\_isPrimitivePaper}
+    theorem is \leanid{MPSTensor.iIndex_le_general_of_isPrimitivePaper}
     in \path{TNLean/Wielandt/Inequality/Bounds.lean:389--468}. The
     formal equivalence between the primitive condition used by Sanz--P\'erez-Garc\'ia--Wolf--Cirac
     and eventual full Kraus rank under normalization is in
@@ -103,17 +103,10 @@ under that assumption it proves
 These are the hypotheses in \cite[Theorem~1]{Sanz2010Quantum}. The older
 chosen-Kraus statements are still present, but only as corollaries obtained by
 taking $X=A_{i_0}$.\footnote{The relevant declarations are
-    \leanid{MPSTensor.wordSpan\_\allowbreak eq\_\allowbreak top\_\allowbreak of\_\allowbreak
-        isPrimitivePaper\_\allowbreak of\_\allowbreak mem\_\allowbreak wordSpan\_\allowbreak one\_\allowbreak
-        of\_\allowbreak isUnit} and
-    \leanid{MPSTensor.iIndex\_\allowbreak le\_\allowbreak of\_\allowbreak mem\_\allowbreak
-        wordSpan\_\allowbreak one\_\allowbreak of\_\allowbreak isUnit} for the invertible case, and
-    \leanid{MPSTensor.wordSpan\_\allowbreak eq\_\allowbreak top\_\allowbreak of\_\allowbreak
-        isPrimitivePaper\_\allowbreak of\_\allowbreak mem\_\allowbreak wordSpan\_\allowbreak one\_\allowbreak
-        of\_\allowbreak noninvertible\_\allowbreak eigenvector} and
-    \leanid{MPSTensor.iIndex\_\allowbreak le\_\allowbreak sq\_\allowbreak of\_\allowbreak
-        mem\_\allowbreak wordSpan\_\allowbreak one\_\allowbreak of\_\allowbreak noninvertible\_\allowbreak
-        eigenvector} for
+    \leanid{MPSTensor.wordSpan_eq_top_of_isPrimitivePaper_of_mem_wordSpan_one_of_isUnit} and
+    \leanid{MPSTensor.iIndex_le_of_mem_wordSpan_one_of_isUnit} for the invertible case, and
+    \leanid{MPSTensor.wordSpan_eq_top_of_isPrimitivePaper_of_mem_wordSpan_one_of_noninvertible_eigenvector} and
+    \leanid{MPSTensor.iIndex_le_sq_of_mem_wordSpan_one_of_noninvertible_eigenvector} for
     the non-invertible case, all in
     \path{TNLean/Wielandt/Inequality/Bounds.lean}. The shorter
     chosen-generator statements in the same file are corollaries.}
@@ -131,8 +124,8 @@ bound.
 The formal proof now uses this one-step-subspace version. It adjoins the
 chosen $X\in S_1(A)$ as a redundant generator and proves that the exact word
 spans and the Kraus rank are unchanged. The span equality is
-\leanid{MPSTensor.wordSpan\_oneStepAugment\_eq}, and the Kraus-rank equality is
-\leanid{MPSTensor.krausRank\_oneStepAugment}, both in
+\leanid{MPSTensor.wordSpan_oneStepAugment_eq}, and the Kraus-rank equality is
+\leanid{MPSTensor.krausRank_oneStepAugment}, both in
 \path{TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean}. This reduces the
 paper's hypothesis to the single-generator argument without changing the
 channel invariant being bounded.
@@ -145,7 +138,7 @@ stated for an arbitrary such $X$, not only for a distinguished Kraus matrix.
 \section{Primitive-to-normal theorem with a chosen positive fixed point}
 
 The theorem
-\leanid{MPSTensor.isNormal\_of\_isPrimitiveMPS\_with\_posDef}\footnote{%
+\leanid{MPSTensor.isNormal_of_isPrimitiveMPS_with_posDef}\footnote{%
     \path{TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean}.}
 proves normality from a chosen fixed point $\rho$ satisfying the local
 spectral-gap predicate \leanid{IsPrimitiveMPS} and the additional hypothesis
@@ -186,7 +179,7 @@ full quantum Wielandt theorem, but the theorem in
 \path{TNLean/Wielandt/Inequality/Bounds.lean} proves the stated bound for
 $i(A)$, where $i(A)$ is defined using the spaces $S_n(A)$ themselves.
 \footnote{The cumulative-span theorem is
-    \leanid{MPSTensor.cumulativeSpan\_eq\_top} in
+    \leanid{MPSTensor.cumulativeSpan_eq_top} in
     \path{TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean:164--197}; the
     theorem for the spaces $S_n(A)$ is the general theorem cited above.
     The blueprint makes this distinction in

--- a/docs/paper-gaps/quantum_wielandt_deviation_v1.tex
+++ b/docs/paper-gaps/quantum_wielandt_deviation_v1.tex
@@ -82,7 +82,7 @@ The proof passes through the usual eventual full-rank formulation and a
 blocking argument, but the conclusion is the equality
 $S_n(A)=M_D(\mathbb C)$ for one fixed length $n$. It is not merely a statement
 about the increasing sum $S_0(A)+\cdots+S_n(A)$.\footnote{The general
-    theorem is \leanid{MPSTensor.iIndex\_le\_general\_of\_isPrimitivePaper}
+    theorem is \leanid{MPSTensor.iIndex_le_general_of_isPrimitivePaper}
     in \path{TNLean/Wielandt/Inequality/Bounds.lean:389--468}. The
     formal equivalence between the primitive condition used by Sanz--P\'erez-Garc\'ia--Wolf--Cirac
     and eventual full Kraus rank under normalization is in
@@ -102,12 +102,12 @@ non-invertible and has a nonzero eigenvalue; under that assumption it proves
 The paper's hypotheses are weaker: they allow the invertible or non-invertible
 matrix to be any element of $S_1(A)$, hence any linear combination of the Kraus
 matrices.\footnote{The formal invertible case is
-    \leanid{MPSTensor.wordSpan\_eq\_top\_of\_isPrimitivePaper\_of\_isUnit} and
-    \leanid{MPSTensor.iIndex\_le\_of\_isPrimitivePaper\_of\_isUnit} in
+    \leanid{MPSTensor.wordSpan_eq_top_of_isPrimitivePaper_of_isUnit} and
+    \leanid{MPSTensor.iIndex_le_of_isPrimitivePaper_of_isUnit} in
     \path{TNLean/Wielandt/Inequality/Bounds.lean:313--337}. The
     formal non-invertible case is
-    \leanid{MPSTensor.wordSpan\_eq\_top\_of\_isPrimitivePaper\_of\_noninvertible\_eigenvector}
-    and \leanid{MPSTensor.iIndex\_le\_sq\_of\_noninvertible\_eigenvector} in
+    \leanid{MPSTensor.wordSpan_eq_top_of_isPrimitivePaper_of_noninvertible_eigenvector}
+    and \leanid{MPSTensor.iIndex_le_sq_of_noninvertible_eigenvector} in
     \path{TNLean/Wielandt/Inequality/Bounds.lean:213--243}.}
 
 \section{The mathematical difference}
@@ -155,7 +155,7 @@ full quantum Wielandt theorem, but the theorem in
 \path{TNLean/Wielandt/Inequality/Bounds.lean} proves the stated bound for
 $i(A)$, where $i(A)$ is defined using the spaces $S_n(A)$ themselves.
 \footnote{The cumulative-span theorem is
-    \leanid{MPSTensor.cumulativeSpan\_eq\_top} in
+    \leanid{MPSTensor.cumulativeSpan_eq_top} in
     \path{TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean:164--197}; the
     theorem for the spaces $S_n(A)$ is the general theorem cited above.
     The blueprint makes this distinction in


### PR DESCRIPTION
## Motivation

Paper-gap notes use `\leanid{...}` to display Lean declaration names. Escaped underscores inside these arguments are fragile: once the macro is defined through `\detokenize`, writing `\_` inside the argument displays a visible backslash before the underscore.

Issue #2081 asks for the notes to use raw underscores in these identifiers. Current `main` still had `\leanid` defined as `\textsf{#1}`, so this PR includes the corresponding shared macro correction as well; otherwise raw underscores would not be legal in text mode.

## Description

- Change `docs/paper-gaps/command.tex` so `\leanid` typesets `\detokenize{#1}`.
- Replace escaped underscores in `\leanid{...}` arguments by raw underscores across the affected paper-gap notes.
- Remove `\allowbreak` commands that occurred inside `\leanid{...}` arguments, since `\detokenize` would print them literally.

Fixes #2081.

## Testing

- `rg -n '\\leanid\{[^}]*\\_' docs/paper-gaps || true`
- `rg -n '\\leanid\{[^}]*\\allowbreak' docs/paper-gaps || true`
- `git diff --check`
- Locally compiled every changed paper-gap note with `latexmk -pdf -halt-on-error -interaction=nonstopmode -outdir=/tmp/tnlean-paper-gaps-build` from `docs/paper-gaps` and `TEXINPUTS=.:`
- Checked generated PDFs with `pdftotext` and found no visible `\_` sequences

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX macro and identifier formatting; no Lean proofs or runtime behavior.
> 
> **Overview**
> Updates **paper-gap** LaTeX so Lean declaration names in `\leanid{...}` typeset correctly and read like real identifiers.
> 
> **`\leanid` macro** in `docs/paper-gaps/command.tex` now wraps arguments with `\textsf{\detokenize{#1}}`, so underscores can be written literally instead of as `\_` (which would show a backslash once detokenized).
> 
> Across the affected gap notes, **escaped underscores inside `\leanid{...}` are replaced with raw underscores**, and **`\allowbreak` inside those arguments is removed** so it is not printed literally. Mathematical content and theorem statements are unchanged; this is documentation/typesetting hygiene for issue #2081.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac71e9439bb76a67577794e33c3b821d6ed4474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->