### PR TITLE
doc(paper-gaps): move leanid subscripts outside detokenize

### DIFF
--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -152,7 +152,7 @@ now derived from the grouped-block cast construction.
 
 The zero-tail condition has a similar origin. The source definition of matrix
 product vectors is for positive lengths, and zero blocks are invisible there.
-The formal relation \leanid{SameMPV₂} also includes the empty word. A zero
+The formal relation \leanid{SameMPV}\textsubscript{2} also includes the empty word. A zero
 block of bond dimension $D_0$ contributes nothing at positive length but
 contributes $D_0$ at length zero. Hence the formal proof records a zero-tail
 dimension and must either identify the two zero tails or keep the length-zero

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -41,7 +41,7 @@ $c_N\ne 0$ cofinally,
     \label{eq:prop}
 \end{align}
 formalized as
-\leanid{EventuallyNonzeroProportionalMPV\textsubscript{2}}.
+\leanid{EventuallyNonzeroProportionalMPV}\textsubscript{2}.
 
 The surviving one-copy normal-canonical BNT formulation
 \leanid{IsNormalCanonicalFormBNT} carries a single weight $\mu_k$ per
@@ -87,7 +87,7 @@ combines it with the proportionality identity at
 The mathematical target is, for $k_0:\mathrm{Fin}\,r_B$ arbitrary:
 given the one-copy normal-canonical BNT hypotheses on both $\mu^A,A$ and
 $\mu^B,B$,
-\leanid{EventuallyNonzeroProportionalMPV\textsubscript{2}} between the
+\leanid{EventuallyNonzeroProportionalMPV}\textsubscript{2} between the
 assembled tensors, an index $k_0:\mathrm{Fin}\,r_B$ and the hypothesis
 $\forall j,\langle V^{(N)}(A_j),V^{(N)}(B_{k_0})\rangle\to 0$, derive
 $\bot$.

--- a/docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex
+++ b/docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex
@@ -32,7 +32,7 @@ The scalar multiple with coefficient $0$ gives no projective point.
 
 \section{Formal reading}
 
-The formal predicate \leanid{NonzeroProportionalMPV₂} requires, at each
+The formal predicate \leanid{NonzeroProportionalMPV}\textsubscript{2} requires, at each
 length $N$, a scalar $c_N \neq 0$ such that
 \begin{align}
     V^{(N)}(A) = c_N V^{(N)}(B).
@@ -79,7 +79,7 @@ asymptotic assumption to the block-selection argument.
 The nonzero condition does not change the intended conclusion of the source
 theorem. It records the conventional mathematical meaning of proportional
 nonzero vectors in the source argument. The weaker scalar-multiple predicate
-\leanid{ProportionalMPV₂}, where $c_N$ may vanish, remains available for
+\leanid{ProportionalMPV}\textsubscript{2}, where $c_N$ may vanish, remains available for
 older auxiliary lemmas, but it is not used as the paper-faithful hypothesis
 for the proportional Fundamental Theorem.
 
@@ -92,7 +92,7 @@ reading is later required,
 it should be formalized as a separate bridge theorem: prove from the source
 canonical-form hypotheses that the relevant MPV vectors do not vanish at the
 lengths used in the argument, then derive
-\leanid{NonzeroProportionalMPV₂} from the weak predicate before applying the
+\leanid{NonzeroProportionalMPV}\textsubscript{2} from the weak predicate before applying the
 block-selection proof.
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/mps_common_blocking_span_equality.tex
+++ b/docs/paper-gaps/mps_common_blocking_span_equality.tex
@@ -91,7 +91,7 @@ proportional and equal MPV fundamental theorems in the same form
 
 \section{The formal argument}
 
-The formal equality relation \leanid{SameMPV₂} compares matrix product
+The formal equality relation \leanid{SameMPV}\textsubscript{2} compares matrix product
 vector coefficients for all finite words, including the empty word.
 This convention is stronger than the positive-length family in the source
 definition. An all-zero block of bond dimension $D_0$ contributes nothing at

--- a/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
+++ b/docs/paper-gaps/nonperiodic_mps_bnt_comparison_inputs.tex
@@ -606,7 +606,7 @@ comparison.
 
 By contrast, zero-tail equality and common-sector relabeling are mostly formal
 bookkeeping. CPSV16 works at positive lengths and treats zero blocks as unused
-bond dimension. Lean's $N=0$ convention for \leanid{SameMPV₂} forces an
+bond dimension. Lean's $N=0$ convention for \leanid{SameMPV}\textsubscript{2} forces an
 explicit zero-tail identity, and the common-sector construction must also track
 casts between grouped and flat blocked words. These conventions are not extra
 paper hypotheses, but the final after-blocking theorem still has to transport

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -312,7 +312,7 @@ The earlier existence path now has the following formal pieces.
     \item
           \path|MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization_projective|
           turns the preceding scalar-factor identity into the existing
-          projective MPV relation \leanid{NonzeroProportionalMPV₂}.
+          projective MPV relation \leanid{NonzeroProportionalMPV}\textsubscript{2}.
           For positive lengths the proportionality scalar is \(s^N\), while at
           length zero the scalar is the ratio between the original bond
           dimension and the positive total dimension of the nonzero normalized


### PR DESCRIPTION
## Motivation

After #2085, `\leanid{...}` detokenizes its argument. Any LaTeX command or active Unicode subscript inside the argument can therefore render literally rather than as the intended identifier typography.

## Description

- Move `\textsubscript{2}` outside `\leanid{...}` in `cpsv16_nondominant_per_block_projection.tex`.
- Move all remaining Unicode `₂` suffixes outside `\leanid{...}` as `\textsubscript{2}`.
- Leave the mathematical text unchanged; this only changes how Lean identifier names are typeset.

Fixes #2086.

## Testing

- `rg -nP '\\leanid\{(?:[^{}]|\{[^{}]*\})*\\[a-zA-Z]+' docs/paper-gaps/ || true`
- `rg -nP '\\leanid\{[^}]*₂' docs/paper-gaps/ || true`
- `git diff --check`
- Locally compiled every changed paper-gap note with `latexmk -pdf -halt-on-error -interaction=nonstopmode -outdir=/tmp/tnlean-paper-gaps-subscript-build` from `docs/paper-gaps` and `TEXINPUTS=.:`
- Checked generated PDFs with `pdftotext` for literal TeX control-sequence fragments in identifier names

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX typography in paper-gap notes; no code or proof changes.
> 
> **Overview**
> After #2085, `\leanid{...}` detokenizes its argument, so LaTeX subscripts **inside** the macro were rendering as literal TeX instead of subscripted Lean names.
> 
> This PR **only changes typesetting** in six `docs/paper-gaps/` notes: identifiers like `SameMPV₂`, `NonzeroProportionalMPV₂`, and `EventuallyNonzeroProportionalMPV₂` are written as `\leanid{Name}\textsubscript{2}` (Unicode `₂` was moved outside the same way). **No mathematical or Lean content was altered.**
> 
> Affected notes include conditional after-blocking FT, CPSV16 nondominant projection / nonzero proportionality, common blocking span equality, nonperiodic BNT comparison inputs, and PGVWC07 TI canonical form scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce85584ac6b4f0d629954a89be475ccd72be66cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->