### PR TITLE
fix(mps/periodic): extract nondecaying sector overlap

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Periodic.Overlap.Case1
+import TNLean.MPS.SharedInfra.BlockAssembly
 
 /-!
 # Periodic overlap dichotomy: Case 2
@@ -268,18 +269,6 @@ private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicD
   classical
   by_contra hNone
   push Not at hNone
-  have hDecompA : ∀ N (σ : Fin N → Fin (blockPhysDim d m)),
-      mpv (blockTensor (d := d) (D := D) A m) σ =
-        ∑ u : Fin m, mpv (blocksA u) σ := by
-    intro N σ
-    exact mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
-      (blockTensor (d := d) (D := D) A m) blocksA hA_mpv σ
-  have hDecompB : ∀ N (σ : Fin N → Fin (blockPhysDim d m)),
-      mpv (blockTensor (d := d) (D := D) B m) σ =
-        ∑ v : Fin m, mpv (blocksB v) σ := by
-    intro N σ
-    exact mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
-      (blockTensor (d := d) (D := D) B m) blocksB hB_mpv σ
   have hOverlap_eq : ∀ N,
       mpvOverlap (d := blockPhysDim d m)
           (blockTensor (d := d) (D := D) A m)
@@ -287,39 +276,10 @@ private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicD
         ∑ u : Fin m, ∑ v : Fin m,
           mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := by
     intro N
-    calc
-      mpvOverlap (d := blockPhysDim d m)
-          (blockTensor (d := d) (D := D) A m)
-          (blockTensor (d := d) (D := D) B m) N
-        = ∑ σ : Cfg (blockPhysDim d m) N,
-          mpv (blockTensor (d := d) (D := D) A m) σ *
-            star (mpv (blockTensor (d := d) (D := D) B m) σ) := rfl
-      _ = ∑ σ : Cfg (blockPhysDim d m) N,
-            (∑ u : Fin m, mpv (blocksA u) σ) *
-              star (∑ v : Fin m, mpv (blocksB v) σ) := by
-              refine Finset.sum_congr rfl ?_
-              intro σ _
-              rw [hDecompA N σ, hDecompB N σ]
-      _ = ∑ σ : Cfg (blockPhysDim d m) N,
-            ∑ u : Fin m, ∑ v : Fin m,
-              mpv (blocksA u) σ * star (mpv (blocksB v) σ) := by
-              refine Finset.sum_congr rfl ?_
-              intro σ _
-              rw [star_sum, Finset.sum_mul]
-              refine Finset.sum_congr rfl ?_
-              intro u _
-              rw [Finset.mul_sum]
-      _ = ∑ u : Fin m, ∑ σ : Cfg (blockPhysDim d m) N,
-            ∑ v : Fin m, mpv (blocksA u) σ * star (mpv (blocksB v) σ) := by
-              rw [Finset.sum_comm]
-      _ = ∑ u : Fin m, ∑ v : Fin m, ∑ σ : Cfg (blockPhysDim d m) N,
-            mpv (blocksA u) σ * star (mpv (blocksB v) σ) := by
-              refine Finset.sum_congr rfl ?_
-              intro u _
-              rw [Finset.sum_comm]
-      _ = ∑ u : Fin m, ∑ v : Fin m,
-            mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := by
-              simp [mpvOverlap]
+    exact mpvOverlap_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
+      (blockTensor (d := d) (D := D) A m)
+      (blockTensor (d := d) (D := D) B m)
+      blocksA blocksB hA_mpv hB_mpv N
   have hInnerZero : ∀ u : Fin m,
       Tendsto
         (fun N => ∑ v : Fin m,

--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -116,20 +116,6 @@ private theorem gaugePhaseEquiv_blockTensor
             ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
           simp [hGauge, blockTensor]
 
-/-- The self-overlap of a blocked tensor at length `N` is the self-overlap of the
-original tensor at length `N * L`. This is the trace form of the blocking
-identity used in arXiv:1708.00029, Appendix A, lines 908-914. -/
-private theorem mpvOverlap_blockTensor_self_eq
-    [NeZero D] (A : MPSTensor d D) (L N : ℕ) :
-    mpvOverlap (d := blockPhysDim d L) (blockTensor (d := d) (D := D) A L)
-        (blockTensor (d := d) (D := D) A L) N =
-      mpvOverlap (d := d) A A (N * L) := by
-  rw [← trace_mixedTransferMap_pow_eq_mpvOverlap
-      (A := blockTensor (d := d) (D := D) A L)
-      (B := blockTensor (d := d) (D := D) A L) N]
-  rw [← trace_mixedTransferMap_pow_eq_mpvOverlap (A := A) (B := A) (N * L)]
-  simp [mixedTransferMap_self, transferMap_blockTensor, pow_mul, Nat.mul_comm]
-
 /-- A periodic tensor has nonzero blocked self-overlap limit after blocking by
 its period; the limit is the period itself. This restates
 `periodicSelfOverlap_tendsto` for the blocked tensor. -/
@@ -188,7 +174,7 @@ private theorem mpvOverlap_eq_star_pow_mul_self_of_gaugePhase
 periodic tensors gives a mixed blocked overlap which does not tend to zero.
 
 The proof uses the nonzero blocked self-overlap limits from Appendix A,
-lines 908-914 of arXiv:1708.00029, to show that the gauge phase has unit
+lines 908-914 of arXiv:1708.00029, to show that the gauge factor has unit
 modulus. -/
 private theorem gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic
     [NeZero D] (A B : MPSTensor d D) {m : ℕ} [NeZero m]
@@ -220,42 +206,12 @@ private theorem gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic
         (ζ * starRingEnd ℂ ζ) ^ N *
           mpvOverlap (d := blockPhysDim d m) Ablk Ablk N :=
     mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := Ablk) (B := Bblk) (ζ := ζ) hmpv
-  have hA_self_ne : ∀ᶠ N in atTop,
-      ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖ ≠ 0 :=
-    hA_self.norm.eventually_ne (by
-      exact_mod_cast (NeZero.ne m : m ≠ 0))
-  have hRatio : Tendsto
-      (fun N => ‖mpvOverlap (d := blockPhysDim d m) Bblk Bblk N‖ /
-        ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖)
-      atTop (nhds (1 : ℝ)) := by
-    have hm_ne : ‖(m : ℂ)‖ ≠ 0 := by
-      exact_mod_cast (NeZero.ne m : m ≠ 0)
-    simpa [div_self hm_ne] using hB_self.norm.div hA_self.norm hm_ne
-  have hRatioEq : ∀ᶠ N in atTop,
-      ‖mpvOverlap (d := blockPhysDim d m) Bblk Bblk N‖ /
-          ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖ =
-        (‖ζ‖ ^ 2) ^ N := by
-    filter_upwards [hA_self_ne] with N hN
-    rw [hSelfScale N, norm_mul, norm_pow,
-      show ‖ζ * starRingEnd ℂ ζ‖ = ‖ζ‖ ^ 2 by
-        rw [norm_mul, RCLike.norm_conj, sq]]
-    rw [← pow_mul, Nat.mul_comm, pow_mul]
-    exact mul_div_cancel_of_imp (fun h => absurd h hN)
-  have hPow : Tendsto (fun N => (‖ζ‖ ^ 2) ^ N) atTop (nhds (1 : ℝ)) :=
-    hRatio.congr' hRatioEq
+  have hm_norm_ne : ‖(m : ℂ)‖ ≠ 0 := by
+    exact_mod_cast (NeZero.ne m : m ≠ 0)
   have hζnorm : ‖ζ‖ = 1 := by
-    have h1 : ‖ζ‖ ^ 2 = 1 := by
-      by_contra hne
-      rcases lt_or_gt_of_ne hne with hlt | hgt
-      · exact (hPow.ne_nhds one_ne_zero)
-          (tendsto_pow_atTop_nhds_zero_of_lt_one (by positivity) hlt)
-      · have hlt2 : ∀ᶠ n in atTop, (‖ζ‖ ^ 2) ^ n < 2 :=
-          hPow.eventually (Iio_mem_nhds (by norm_num : (1 : ℝ) < 2))
-        rcases ((Filter.tendsto_atTop.1
-            (tendsto_pow_atTop_atTop_of_one_lt hgt) 2).and hlt2).exists
-          with ⟨n, hn1, hn2⟩
-        exact not_lt_of_ge hn1 hn2
-    nlinarith [norm_nonneg ζ]
+    exact norm_eq_one_of_selfOverlap_scale_at_nonzero_limit
+      (A := Ablk) (B := Bblk) (ζ := ζ) hm_norm_ne
+      hA_self.norm hB_self.norm hSelfScale
   have hCrossNormEq : ∀ N,
       ‖mpvOverlap (d := blockPhysDim d m) Ablk Bblk N‖ =
         ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖ := by
@@ -282,11 +238,11 @@ If two blocked tensors are globally gauge-phase equivalent and both are decompos
 into cyclic compressed sectors, then some sector of the `A` decomposition has a
 non-decaying overlap with some sector of the `B` decomposition.
 
-This is the analytic core of the same-period case in arXiv:1708.00029,
-Appendix A, lines 952-960. The proof expands the total blocked overlap using
-`hA_mpv` and `hB_mpv` as a finite double sum of sector overlaps. Global
-gauge-phase equivalence keeps the total blocked overlap from tending to zero,
-so not every mixed sector overlap can tend to zero. -/
+This is the contrapositive extraction behind the same-period case in
+arXiv:1708.00029, Appendix A, lines 952-960. The proof expands the total
+blocked overlap, using the two block decompositions, as a finite double sum of
+sector overlaps. Global gauge-phase equivalence keeps the total blocked overlap
+from tending to zero, so not every mixed sector overlap can tend to zero. -/
 private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicDecomp
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]
@@ -296,22 +252,12 @@ private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicD
       (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
     (blocksB :
       (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
-    (_hA_blocks_lc :
-      ∀ k, ∑ i : Fin (blockPhysDim d m),
-        (blocksA k i)ᴴ * blocksA k i = 1)
-    (_hB_blocks_lc :
-      ∀ k, ∑ i : Fin (blockPhysDim d m),
-        (blocksB k i)ᴴ * blocksB k i = 1)
     (hA_mpv :
       SameMPV₂ (blockTensor A m)
         (toTensorFromBlocks (μ := fun _ => 1) blocksA))
     (hB_mpv :
       SameMPV₂ (blockTensor B m)
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
-    (_hA_cyclic : IsCyclicSectorDecomp A blocksA)
-    (_hB_cyclic : IsCyclicSectorDecomp B blocksB)
-    (_hNondegA : ∀ u, dimA u ≠ 0)
-    (_hNondegB : ∀ v, dimB v ≠ 0)
     (hGPE_block :
       GaugePhaseEquiv (blockTensor (d := d) (D := D) A m)
         (blockTensor (d := d) (D := D) B m)) :
@@ -327,24 +273,14 @@ private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicD
       mpv (blockTensor (d := d) (D := D) A m) σ =
         ∑ u : Fin m, mpv (blocksA u) σ := by
     intro N σ
-    calc
-      mpv (blockTensor (d := d) (D := D) A m) σ =
-          mpv (toTensorFromBlocks (d := blockPhysDim d m)
-            (μ := fun _ : Fin m => (1 : ℂ)) blocksA) σ := hA_mpv N σ
-      _ = ∑ u : Fin m, ((1 : ℂ) ^ N) • mpv (blocksA u) σ := by
-            rw [mpv_toTensorFromBlocks_eq_sum]
-      _ = ∑ u : Fin m, mpv (blocksA u) σ := by simp
+    exact mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
+      (blockTensor (d := d) (D := D) A m) blocksA hA_mpv σ
   have hDecompB : ∀ N (σ : Fin N → Fin (blockPhysDim d m)),
       mpv (blockTensor (d := d) (D := D) B m) σ =
         ∑ v : Fin m, mpv (blocksB v) σ := by
     intro N σ
-    calc
-      mpv (blockTensor (d := d) (D := D) B m) σ =
-          mpv (toTensorFromBlocks (d := blockPhysDim d m)
-            (μ := fun _ : Fin m => (1 : ℂ)) blocksB) σ := hB_mpv N σ
-      _ = ∑ v : Fin m, ((1 : ℂ) ^ N) • mpv (blocksB v) σ := by
-            rw [mpv_toTensorFromBlocks_eq_sum]
-      _ = ∑ v : Fin m, mpv (blocksB v) σ := by simp
+    exact mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
+      (blockTensor (d := d) (D := D) B m) blocksB hB_mpv σ
   have hOverlap_eq : ∀ N,
       mpvOverlap (d := blockPhysDim d m)
           (blockTensor (d := d) (D := D) A m)
@@ -456,8 +392,7 @@ private lemma exists_sector_match_of_blockedGaugePhaseEquiv_cyclicDecomp
         (blocksB v) := by
   obtain ⟨u, v, hNondecay⟩ :=
     exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicDecomp
-      A B hA hB blocksA blocksB hA_blocks_lc hB_blocks_lc
-      hA_mpv hB_mpv hA_cyclic hB_cyclic hNondegA hNondegB hGPE_block
+      A B hA hB blocksA blocksB hA_mpv hB_mpv hGPE_block
   haveI : NeZero (dimA u) := ⟨hNondegA u⟩
   haveI : NeZero (dimB v) := ⟨hNondegB v⟩
   have hA_irr : IsIrreducibleTensor (blocksA u) :=
@@ -487,8 +422,8 @@ This is the structural step used by the no-sector-match case: the cyclic
 sector decomposition is unique up to relabeling, and a global gauge-phase
 equivalence carries a nonzero sector of `A` to a sector of `B`. The hypothesis
 `hNondegA` supplies the nonzero-sector condition for the returned `A` sector, while
-`hNondegB` provides the typeclass needed to apply the mixed-sector overlap
-dichotomy. Both come from the periodic sector decomposition constructed by
+`hNondegB` gives positive bond dimension for the corresponding `B` sector.
+Both come from the periodic sector decomposition constructed by
 `exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`. -/
 lemma exists_sector_match_of_gaugePhaseEquiv
     [NeZero D] (A B : MPSTensor d D)

--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -116,18 +116,177 @@ private theorem gaugePhaseEquiv_blockTensor
             ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
           simp [hGauge, blockTensor]
 
-/-- Missing mixed-overlap statement after blocking.
+/-- The self-overlap of a blocked tensor at length `N` is the self-overlap of the
+original tensor at length `N * L`. This is the trace form of the blocking
+identity used in arXiv:1708.00029, Appendix A, lines 908-914. -/
+private theorem mpvOverlap_blockTensor_self_eq
+    [NeZero D] (A : MPSTensor d D) (L N : ℕ) :
+    mpvOverlap (d := blockPhysDim d L) (blockTensor (d := d) (D := D) A L)
+        (blockTensor (d := d) (D := D) A L) N =
+      mpvOverlap (d := d) A A (N * L) := by
+  rw [← trace_mixedTransferMap_pow_eq_mpvOverlap
+      (A := blockTensor (d := d) (D := D) A L)
+      (B := blockTensor (d := d) (D := D) A L) N]
+  rw [← trace_mixedTransferMap_pow_eq_mpvOverlap (A := A) (B := A) (N * L)]
+  simp [mixedTransferMap_self, transferMap_blockTensor, pow_mul, Nat.mul_comm]
+
+/-- A periodic tensor has nonzero blocked self-overlap limit after blocking by
+its period; the limit is the period itself. This restates
+`periodicSelfOverlap_tendsto` for the blocked tensor. -/
+private theorem blockTensor_selfOverlap_tendsto_of_isPeriodic
+    [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
+    (hP : IsPeriodic m A) :
+    Tendsto
+      (fun N => mpvOverlap (d := blockPhysDim d m)
+        (blockTensor (d := d) (D := D) A m)
+        (blockTensor (d := d) (D := D) A m) N)
+      atTop (nhds (m : ℂ)) := by
+  have hSelf : Tendsto (fun N => mpvOverlap A A (m * N)) atTop (nhds (m : ℂ)) :=
+    periodicSelfOverlap_tendsto A hP
+  refine hSelf.congr' ?_
+  filter_upwards with N
+  rw [mpvOverlap_blockTensor_self_eq]
+  simp [Nat.mul_comm]
+
+/-- Under a gauge-phase relation `B = ζ X A X⁻¹`, the mixed overlap with `A`
+equals `(conj ζ)^N` times the self-overlap of `A` at length `N`. -/
+private theorem mpvOverlap_eq_star_pow_mul_self_of_gaugePhase
+    (A B : MPSTensor d D)
+    (X : GL (Fin D) ℂ) (ζ : ℂ)
+    (hX :
+      ∀ i : Fin d,
+        B i =
+          ζ • ((X : Matrix (Fin D) (Fin D) ℂ) * A i *
+            ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)))
+    (N : ℕ) :
+    mpvOverlap (d := d) A B N =
+      (star ζ) ^ N * mpvOverlap (d := d) A A N := by
+  classical
+  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ :=
+    mpv_eq_pow_mul_of_gaugePhase A B X ζ hX
+  calc
+    mpvOverlap (d := d) A B N =
+        ∑ σ : Cfg d N, mpv A σ * star (ζ ^ N * mpv A σ) := by
+          simp only [mpvOverlap]
+          refine Finset.sum_congr rfl ?_
+          intro σ _
+          rw [hmpv N σ]
+    _ = ∑ σ : Cfg d N,
+        (star ζ) ^ N * (mpv A σ * star (mpv A σ)) := by
+          refine Finset.sum_congr rfl ?_
+          intro σ _
+          have hstar :
+              star (ζ ^ N * mpv A σ) = star (mpv A σ) * (star ζ) ^ N := by
+            rw [StarMul.star_mul, star_pow]
+          rw [hstar]
+          ring
+    _ = (star ζ) ^ N * mpvOverlap (d := d) A A N := by
+          rw [← Finset.mul_sum]
+          rfl
+
+/-- A gauge-phase equivalence between the period-blocked tensors of two
+periodic tensors gives a mixed blocked overlap which does not tend to zero.
+
+The proof uses the nonzero blocked self-overlap limits from Appendix A,
+lines 908-914 of arXiv:1708.00029, to show that the gauge phase has unit
+modulus. -/
+private theorem gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic
+    [NeZero D] (A B : MPSTensor d D) {m : ℕ} [NeZero m]
+    (hA : IsPeriodic m A) (hB : IsPeriodic m B)
+    (hGPE_block :
+      GaugePhaseEquiv (blockTensor (d := d) (D := D) A m)
+        (blockTensor (d := d) (D := D) B m)) :
+    ¬ Tendsto
+      (fun N => mpvOverlap (d := blockPhysDim d m)
+        (blockTensor (d := d) (D := D) A m)
+        (blockTensor (d := d) (D := D) B m) N)
+      atTop (nhds (0 : ℂ)) := by
+  classical
+  intro hZero
+  obtain ⟨X, ζ, _hζ, hX⟩ := hGPE_block
+  let Ablk := blockTensor (d := d) (D := D) A m
+  let Bblk := blockTensor (d := d) (D := D) B m
+  have hA_self : Tendsto (fun N => mpvOverlap (d := blockPhysDim d m) Ablk Ablk N)
+      atTop (nhds (m : ℂ)) := by
+    simpa [Ablk] using blockTensor_selfOverlap_tendsto_of_isPeriodic A hA
+  have hB_self : Tendsto (fun N => mpvOverlap (d := blockPhysDim d m) Bblk Bblk N)
+      atTop (nhds (m : ℂ)) := by
+    simpa [Bblk] using blockTensor_selfOverlap_tendsto_of_isPeriodic B hB
+  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+      mpv Bblk σ = ζ ^ N * mpv Ablk σ :=
+    mpv_eq_pow_mul_of_gaugePhase Ablk Bblk X ζ hX
+  have hSelfScale : ∀ N : ℕ,
+      mpvOverlap (d := blockPhysDim d m) Bblk Bblk N =
+        (ζ * starRingEnd ℂ ζ) ^ N *
+          mpvOverlap (d := blockPhysDim d m) Ablk Ablk N :=
+    mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := Ablk) (B := Bblk) (ζ := ζ) hmpv
+  have hA_self_ne : ∀ᶠ N in atTop,
+      ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖ ≠ 0 :=
+    hA_self.norm.eventually_ne (by
+      exact_mod_cast (NeZero.ne m : m ≠ 0))
+  have hRatio : Tendsto
+      (fun N => ‖mpvOverlap (d := blockPhysDim d m) Bblk Bblk N‖ /
+        ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖)
+      atTop (nhds (1 : ℝ)) := by
+    have hm_ne : ‖(m : ℂ)‖ ≠ 0 := by
+      exact_mod_cast (NeZero.ne m : m ≠ 0)
+    simpa [div_self hm_ne] using hB_self.norm.div hA_self.norm hm_ne
+  have hRatioEq : ∀ᶠ N in atTop,
+      ‖mpvOverlap (d := blockPhysDim d m) Bblk Bblk N‖ /
+          ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖ =
+        (‖ζ‖ ^ 2) ^ N := by
+    filter_upwards [hA_self_ne] with N hN
+    rw [hSelfScale N, norm_mul, norm_pow,
+      show ‖ζ * starRingEnd ℂ ζ‖ = ‖ζ‖ ^ 2 by
+        rw [norm_mul, RCLike.norm_conj, sq]]
+    rw [← pow_mul, Nat.mul_comm, pow_mul]
+    exact mul_div_cancel_of_imp (fun h => absurd h hN)
+  have hPow : Tendsto (fun N => (‖ζ‖ ^ 2) ^ N) atTop (nhds (1 : ℝ)) :=
+    hRatio.congr' hRatioEq
+  have hζnorm : ‖ζ‖ = 1 := by
+    have h1 : ‖ζ‖ ^ 2 = 1 := by
+      by_contra hne
+      rcases lt_or_gt_of_ne hne with hlt | hgt
+      · exact (hPow.ne_nhds one_ne_zero)
+          (tendsto_pow_atTop_nhds_zero_of_lt_one (by positivity) hlt)
+      · have hlt2 : ∀ᶠ n in atTop, (‖ζ‖ ^ 2) ^ n < 2 :=
+          hPow.eventually (Iio_mem_nhds (by norm_num : (1 : ℝ) < 2))
+        rcases ((Filter.tendsto_atTop.1
+            (tendsto_pow_atTop_atTop_of_one_lt hgt) 2).and hlt2).exists
+          with ⟨n, hn1, hn2⟩
+        exact not_lt_of_ge hn1 hn2
+    nlinarith [norm_nonneg ζ]
+  have hCrossNormEq : ∀ N,
+      ‖mpvOverlap (d := blockPhysDim d m) Ablk Bblk N‖ =
+        ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖ := by
+    intro N
+    rw [mpvOverlap_eq_star_pow_mul_self_of_gaugePhase Ablk Bblk X ζ hX N]
+    simp [norm_pow, hζnorm]
+  have hCrossNormZero : Tendsto
+      (fun N => ‖mpvOverlap (d := blockPhysDim d m) Ablk Bblk N‖)
+      atTop (nhds (0 : ℝ)) := by
+    simpa using hZero.norm
+  have hA_self_norm_zero : Tendsto
+      (fun N => ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖)
+      atTop (nhds (0 : ℝ)) :=
+    hCrossNormZero.congr hCrossNormEq
+  have hLimit : (0 : ℝ) = ‖(m : ℂ)‖ :=
+    tendsto_nhds_unique hA_self_norm_zero hA_self.norm
+  have hm_pos : 0 < ‖(m : ℂ)‖ := by
+    exact norm_pos_iff.mpr (by exact_mod_cast (NeZero.ne m : m ≠ 0))
+  exact (ne_of_gt hm_pos) hLimit.symm
+
+/-- Mixed-overlap extraction after blocking.
 
 If two blocked tensors are globally gauge-phase equivalent and both are decomposed
 into cyclic compressed sectors, then some sector of the `A` decomposition has a
 non-decaying overlap with some sector of the `B` decomposition.
 
-This is the analytic core of the Wedderburn uniqueness step needed below.  The
-intended proof expands the total blocked overlap using `hA_mpv` and `hB_mpv` as a
-finite double sum of sector overlaps.  Global gauge-phase equivalence keeps the
-total blocked overlap nonzero asymptotically (after the usual unit-modulus
-normalization of the global phase), so not every mixed sector overlap can tend
-to zero. -/
+This is the analytic core of the same-period case in arXiv:1708.00029,
+Appendix A, lines 952-960. The proof expands the total blocked overlap using
+`hA_mpv` and `hB_mpv` as a finite double sum of sector overlaps. Global
+gauge-phase equivalence keeps the total blocked overlap from tending to zero,
+so not every mixed sector overlap can tend to zero. -/
 private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicDecomp
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]
@@ -137,10 +296,10 @@ private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicD
       (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
     (blocksB :
       (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
-    (hA_blocks_lc :
+    (_hA_blocks_lc :
       ∀ k, ∑ i : Fin (blockPhysDim d m),
         (blocksA k i)ᴴ * blocksA k i = 1)
-    (hB_blocks_lc :
+    (_hB_blocks_lc :
       ∀ k, ∑ i : Fin (blockPhysDim d m),
         (blocksB k i)ᴴ * blocksB k i = 1)
     (hA_mpv :
@@ -149,10 +308,10 @@ private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicD
     (hB_mpv :
       SameMPV₂ (blockTensor B m)
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
-    (hA_cyclic : IsCyclicSectorDecomp A blocksA)
-    (hB_cyclic : IsCyclicSectorDecomp B blocksB)
-    (hNondegA : ∀ u, dimA u ≠ 0)
-    (hNondegB : ∀ v, dimB v ≠ 0)
+    (_hA_cyclic : IsCyclicSectorDecomp A blocksA)
+    (_hB_cyclic : IsCyclicSectorDecomp B blocksB)
+    (_hNondegA : ∀ u, dimA u ≠ 0)
+    (_hNondegB : ∀ v, dimB v ≠ 0)
     (hGPE_block :
       GaugePhaseEquiv (blockTensor (d := d) (D := D) A m)
         (blockTensor (d := d) (D := D) B m)) :
@@ -161,9 +320,98 @@ private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicD
         (fun N => mpvOverlap (d := blockPhysDim d m)
           (blocksA u) (blocksB v) N)
         atTop (nhds (0 : ℂ)) := by
-  sorry
+  classical
+  by_contra hNone
+  push Not at hNone
+  have hDecompA : ∀ N (σ : Fin N → Fin (blockPhysDim d m)),
+      mpv (blockTensor (d := d) (D := D) A m) σ =
+        ∑ u : Fin m, mpv (blocksA u) σ := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D) A m) σ =
+          mpv (toTensorFromBlocks (d := blockPhysDim d m)
+            (μ := fun _ : Fin m => (1 : ℂ)) blocksA) σ := hA_mpv N σ
+      _ = ∑ u : Fin m, ((1 : ℂ) ^ N) • mpv (blocksA u) σ := by
+            rw [mpv_toTensorFromBlocks_eq_sum]
+      _ = ∑ u : Fin m, mpv (blocksA u) σ := by simp
+  have hDecompB : ∀ N (σ : Fin N → Fin (blockPhysDim d m)),
+      mpv (blockTensor (d := d) (D := D) B m) σ =
+        ∑ v : Fin m, mpv (blocksB v) σ := by
+    intro N σ
+    calc
+      mpv (blockTensor (d := d) (D := D) B m) σ =
+          mpv (toTensorFromBlocks (d := blockPhysDim d m)
+            (μ := fun _ : Fin m => (1 : ℂ)) blocksB) σ := hB_mpv N σ
+      _ = ∑ v : Fin m, ((1 : ℂ) ^ N) • mpv (blocksB v) σ := by
+            rw [mpv_toTensorFromBlocks_eq_sum]
+      _ = ∑ v : Fin m, mpv (blocksB v) σ := by simp
+  have hOverlap_eq : ∀ N,
+      mpvOverlap (d := blockPhysDim d m)
+          (blockTensor (d := d) (D := D) A m)
+          (blockTensor (d := d) (D := D) B m) N =
+        ∑ u : Fin m, ∑ v : Fin m,
+          mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := by
+    intro N
+    calc
+      mpvOverlap (d := blockPhysDim d m)
+          (blockTensor (d := d) (D := D) A m)
+          (blockTensor (d := d) (D := D) B m) N
+        = ∑ σ : Cfg (blockPhysDim d m) N,
+          mpv (blockTensor (d := d) (D := D) A m) σ *
+            star (mpv (blockTensor (d := d) (D := D) B m) σ) := rfl
+      _ = ∑ σ : Cfg (blockPhysDim d m) N,
+            (∑ u : Fin m, mpv (blocksA u) σ) *
+              star (∑ v : Fin m, mpv (blocksB v) σ) := by
+              refine Finset.sum_congr rfl ?_
+              intro σ _
+              rw [hDecompA N σ, hDecompB N σ]
+      _ = ∑ σ : Cfg (blockPhysDim d m) N,
+            ∑ u : Fin m, ∑ v : Fin m,
+              mpv (blocksA u) σ * star (mpv (blocksB v) σ) := by
+              refine Finset.sum_congr rfl ?_
+              intro σ _
+              rw [star_sum, Finset.sum_mul]
+              refine Finset.sum_congr rfl ?_
+              intro u _
+              rw [Finset.mul_sum]
+      _ = ∑ u : Fin m, ∑ σ : Cfg (blockPhysDim d m) N,
+            ∑ v : Fin m, mpv (blocksA u) σ * star (mpv (blocksB v) σ) := by
+              rw [Finset.sum_comm]
+      _ = ∑ u : Fin m, ∑ v : Fin m, ∑ σ : Cfg (blockPhysDim d m) N,
+            mpv (blocksA u) σ * star (mpv (blocksB v) σ) := by
+              refine Finset.sum_congr rfl ?_
+              intro u _
+              rw [Finset.sum_comm]
+      _ = ∑ u : Fin m, ∑ v : Fin m,
+            mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := by
+              simp [mpvOverlap]
+  have hInnerZero : ∀ u : Fin m,
+      Tendsto
+        (fun N => ∑ v : Fin m,
+          mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N)
+        atTop (nhds (0 : ℂ)) := by
+    intro u
+    have := tendsto_finset_sum (s := Finset.univ) fun v _ => hNone u v
+    simpa using this
+  have hSumZero :
+      Tendsto
+        (fun N => ∑ u : Fin m, ∑ v : Fin m,
+          mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N)
+        atTop (nhds (0 : ℂ)) := by
+    have := tendsto_finset_sum (s := Finset.univ) fun u _ => hInnerZero u
+    simpa using this
+  have hGlobalZero :
+      Tendsto
+        (fun N => mpvOverlap (d := blockPhysDim d m)
+          (blockTensor (d := d) (D := D) A m)
+          (blockTensor (d := d) (D := D) B m) N)
+        atTop (nhds (0 : ℂ)) :=
+    hSumZero.congr fun N => (hOverlap_eq N).symm
+  exact
+    (gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic
+      A B hA hB hGPE_block) hGlobalZero
 
-/-- Missing compressed-sector uniqueness statement after blocking.
+/-- Compressed-sector uniqueness statement after blocking.
 
 Once global gauge-phase equivalence has been transported to the blocked
 tensors, the cyclic sector decompositions of the two blocked tensors should be
@@ -239,11 +487,9 @@ This is the structural step used by the no-sector-match case: the cyclic
 sector decomposition is unique up to relabeling, and a global gauge-phase
 equivalence carries a nonzero sector of `A` to a sector of `B`. The hypothesis
 `hNondegA` supplies the nonzero-sector condition for the returned `A` sector, while
-`hNondegB` provides the typeclass needed to apply the mixed-sector overlap dichotomy.
-Both come from the periodic sector decomposition constructed by
-`exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`. The missing
-mathematical input is the compressed-sector form of this uniqueness theorem,
-isolated here as the only missing ingredient. -/
+`hNondegB` provides the typeclass needed to apply the mixed-sector overlap
+dichotomy. Both come from the periodic sector decomposition constructed by
+`exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`. -/
 lemma exists_sector_match_of_gaugePhaseEquiv
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]

--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -167,8 +167,7 @@ private theorem mpvOverlap_eq_star_pow_mul_self_of_gaugePhase
           rw [hstar]
           ring
     _ = (star ζ) ^ N * mpvOverlap (d := d) A A N := by
-          rw [← Finset.mul_sum]
-          rfl
+          simp [mpvOverlap, Finset.mul_sum]
 
 /-- A gauge-phase equivalence between the period-blocked tensors of two
 periodic tensors gives a mixed blocked overlap which does not tend to zero.

--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Periodic.Overlap.Case1
 import TNLean.MPS.SharedInfra.BlockAssembly
+import TNLean.MPS.SharedInfra.GaugePhase
 
 /-!
 # Periodic overlap dichotomy: Case 2
@@ -135,41 +136,6 @@ private theorem blockTensor_selfOverlap_tendsto_of_isPeriodic
   rw [mpvOverlap_blockTensor_self_eq]
   simp [Nat.mul_comm]
 
-/-- Under a gauge-phase relation `B = ζ X A X⁻¹`, the mixed overlap with `A`
-equals `(conj ζ)^N` times the self-overlap of `A` at length `N`. -/
-private theorem mpvOverlap_eq_star_pow_mul_self_of_gaugePhase
-    (A B : MPSTensor d D)
-    (X : GL (Fin D) ℂ) (ζ : ℂ)
-    (hX :
-      ∀ i : Fin d,
-        B i =
-          ζ • ((X : Matrix (Fin D) (Fin D) ℂ) * A i *
-            ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)))
-    (N : ℕ) :
-    mpvOverlap (d := d) A B N =
-      (star ζ) ^ N * mpvOverlap (d := d) A A N := by
-  classical
-  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ :=
-    mpv_eq_pow_mul_of_gaugePhase A B X ζ hX
-  calc
-    mpvOverlap (d := d) A B N =
-        ∑ σ : Cfg d N, mpv A σ * star (ζ ^ N * mpv A σ) := by
-          simp only [mpvOverlap]
-          refine Finset.sum_congr rfl ?_
-          intro σ _
-          rw [hmpv N σ]
-    _ = ∑ σ : Cfg d N,
-        (star ζ) ^ N * (mpv A σ * star (mpv A σ)) := by
-          refine Finset.sum_congr rfl ?_
-          intro σ _
-          have hstar :
-              star (ζ ^ N * mpv A σ) = star (mpv A σ) * (star ζ) ^ N := by
-            rw [StarMul.star_mul, star_pow]
-          rw [hstar]
-          ring
-    _ = (star ζ) ^ N * mpvOverlap (d := d) A A N := by
-          simp [mpvOverlap, Finset.mul_sum]
-
 /-- A gauge-phase equivalence between the period-blocked tensors of two
 periodic tensors gives a mixed blocked overlap which does not tend to zero.
 
@@ -207,7 +173,7 @@ private theorem gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic
           mpvOverlap (d := blockPhysDim d m) Ablk Ablk N :=
     mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := Ablk) (B := Bblk) (ζ := ζ) hmpv
   have hm_norm_ne : ‖(m : ℂ)‖ ≠ 0 := by
-    exact_mod_cast (NeZero.ne m : m ≠ 0)
+    simpa using (Nat.cast_ne_zero.mpr (NeZero.ne m) : (m : ℂ) ≠ 0)
   have hζnorm : ‖ζ‖ = 1 := by
     exact norm_eq_one_of_selfOverlap_scale_at_nonzero_limit
       (A := Ablk) (B := Bblk) (ζ := ζ) hm_norm_ne
@@ -216,7 +182,8 @@ private theorem gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic
       ‖mpvOverlap (d := blockPhysDim d m) Ablk Bblk N‖ =
         ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖ := by
     intro N
-    rw [mpvOverlap_eq_star_pow_mul_self_of_gaugePhase Ablk Bblk X ζ hX N]
+    rw [mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul (A := Ablk) (B := Bblk)
+      (ζ := ζ) hmpv N]
     simp [norm_pow, hζnorm]
   have hCrossNormZero : Tendsto
       (fun N => ‖mpvOverlap (d := blockPhysDim d m) Ablk Bblk N‖)
@@ -228,8 +195,8 @@ private theorem gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic
     hCrossNormZero.congr hCrossNormEq
   have hLimit : (0 : ℝ) = ‖(m : ℂ)‖ :=
     tendsto_nhds_unique hA_self_norm_zero hA_self.norm
-  have hm_pos : 0 < ‖(m : ℂ)‖ := by
-    exact norm_pos_iff.mpr (by exact_mod_cast (NeZero.ne m : m ≠ 0))
+  have hm_pos : 0 < ‖(m : ℂ)‖ :=
+    (norm_nonneg _).lt_of_ne (Ne.symm hm_norm_ne)
   exact (ne_of_gt hm_pos) hLimit.symm
 
 /-- Mixed-overlap extraction after blocking.

--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -268,7 +268,7 @@ private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicD
         atTop (nhds (0 : ℂ)) := by
   classical
   by_contra hNone
-  push Not at hNone
+  simp only [not_exists, not_not] at hNone
   have hOverlap_eq : ∀ N,
       mpvOverlap (d := blockPhysDim d m)
           (blockTensor (d := d) (D := D) A m)

--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -379,11 +379,10 @@ gauge-phase equivalent.
 
 This is the structural step used by the no-sector-match case: the cyclic
 sector decomposition is unique up to relabeling, and a global gauge-phase
-equivalence carries a nonzero sector of `A` to a sector of `B`. The hypothesis
-`hNondegA` supplies the nonzero-sector condition for the returned `A` sector, while
-`hNondegB` gives positive bond dimension for the corresponding `B` sector.
-Both come from the periodic sector decomposition constructed by
-`exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`. -/
+equivalence carries a nonzero sector of `A` to a sector of `B`. The
+nondegeneracy assumptions ensure that the returned `A` sector has nonzero
+virtual dimension and that the corresponding `B` sector has positive bond
+dimension. Both assumptions come from the periodic sector decomposition. -/
 lemma exists_sector_match_of_gaugePhaseEquiv
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]
@@ -470,20 +469,18 @@ If two periodic tensors have the same period `m` but no compressed sector
 pair matches (up to dimension cast and gauge-phase equivalence), their
 overlap decays to zero.
 
-The `hNoMatch` hypothesis quantifies over nondegenerate dimension
-equalities: for each sector pair `(u, v)` with `dimA u ≠ 0` and any
-proof that `dimA u = dimB v`, the compressed blocks are not gauge-phase
-equivalent. The nondegeneracy guard `dimA u ≠ 0` is essential: when
-`dimA u = 0`, `GaugePhaseEquiv` may hold vacuously for
-`MPSTensor _ 0`, and without this guard `hNoMatch` would be
-unsatisfiable whenever a zero-dimensional sector pair exists. With
-this guard and the separate nondegeneracy hypotheses
-`hNondegA : ∀ u, dimA u ≠ 0` and `hNondegB : ∀ v, dimB v ≠ 0`
-coming from the periodic sector decompositions, `hNoMatch` is exactly
-the negation of `hSomeMatch` in `periodicOverlap_gaugeEquiv_of_sector_match`,
-making the two conditions complementary for the dichotomy proof.  The
-`hNondegB` hypothesis is also needed by the mixed-sector overlap dichotomy
-used to extract a sector match from global gauge-phase equivalence.
+The no-match condition quantifies over nondegenerate dimension equalities:
+for each sector pair `(u, v)` with `dimA u ≠ 0` and any proof that
+`dimA u = dimB v`, the compressed blocks are not gauge-phase equivalent.
+The nondegeneracy guard `dimA u ≠ 0` is essential: when `dimA u = 0`,
+gauge-phase equivalence may hold vacuously for `MPSTensor _ 0`, and without
+this guard the no-match condition would be unsatisfiable whenever a
+zero-dimensional sector pair exists. With this guard and the separate
+assumption that every sector in both decompositions has nonzero virtual
+dimension, the no-match and sector-match conditions are complementary for
+the dichotomy proof. Positive virtual dimension on the `B` sectors is also
+needed by the mixed-sector overlap dichotomy used to extract a sector match
+from global gauge-phase equivalence.
 
 This is the "first case" of the same-period argument in Appendix A:
 block by `m`, decompose into normal sectors, and observe that all

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -13,6 +13,7 @@ import TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData
 import TNLean.MPS.Periodic.SectorIrreducibility
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.SharedInfra.KrausAdjointSetup
+import TNLean.MPS.SharedInfra.BlockAssembly
 import TNLean.Spectral.SpectralGapNT
 import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull
@@ -754,12 +755,6 @@ private theorem blockTensor_selfOverlap_tendsto_of_cyclicSectorDecomp
         (blockTensor (d := d) (D := D) A m) k)
       atTop (nhds (m : ℂ)) := by
   classical
-  have hDecomp : ∀ N (σ : Fin N → Fin (blockPhysDim d m)),
-      mpv (blockTensor (d := d) (D := D) A m) σ =
-        ∑ u : Fin m, mpv (blocks u) σ := by
-    intro N σ
-    exact mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
-      (blockTensor (d := d) (D := D) A m) blocks hBlocks_mpv σ
   have hOverlap_eq : ∀ N,
       mpvOverlap (d := blockPhysDim d m)
           (blockTensor (d := d) (D := D) A m)
@@ -767,39 +762,10 @@ private theorem blockTensor_selfOverlap_tendsto_of_cyclicSectorDecomp
         ∑ u : Fin m, ∑ v : Fin m,
           mpvOverlap (d := blockPhysDim d m) (blocks u) (blocks v) N := by
     intro N
-    calc
-      mpvOverlap (d := blockPhysDim d m)
-          (blockTensor (d := d) (D := D) A m)
-          (blockTensor (d := d) (D := D) A m) N
-        = ∑ σ : Cfg (blockPhysDim d m) N,
-          mpv (blockTensor (d := d) (D := D) A m) σ *
-            star (mpv (blockTensor (d := d) (D := D) A m) σ) := rfl
-      _ = ∑ σ : Cfg (blockPhysDim d m) N,
-            (∑ u : Fin m, mpv (blocks u) σ) *
-              star (∑ v : Fin m, mpv (blocks v) σ) := by
-              refine Finset.sum_congr rfl ?_
-              intro σ _
-              rw [hDecomp N σ]
-      _ = ∑ σ : Cfg (blockPhysDim d m) N,
-            ∑ u : Fin m, ∑ v : Fin m,
-              mpv (blocks u) σ * star (mpv (blocks v) σ) := by
-              refine Finset.sum_congr rfl ?_
-              intro σ _
-              rw [star_sum, Finset.sum_mul]
-              refine Finset.sum_congr rfl ?_
-              intro u _
-              rw [Finset.mul_sum]
-      _ = ∑ u : Fin m, ∑ σ : Cfg (blockPhysDim d m) N,
-            ∑ v : Fin m, mpv (blocks u) σ * star (mpv (blocks v) σ) := by
-              rw [Finset.sum_comm]
-      _ = ∑ u : Fin m, ∑ v : Fin m, ∑ σ : Cfg (blockPhysDim d m) N,
-            mpv (blocks u) σ * star (mpv (blocks v) σ) := by
-              refine Finset.sum_congr rfl ?_
-              intro u _
-              rw [Finset.sum_comm]
-      _ = ∑ u : Fin m, ∑ v : Fin m,
-            mpvOverlap (d := blockPhysDim d m) (blocks u) (blocks v) N := by
-              simp [mpvOverlap]
+    exact mpvOverlap_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
+      (blockTensor (d := d) (D := D) A m)
+      (blockTensor (d := d) (D := D) A m)
+      blocks blocks hBlocks_mpv hBlocks_mpv N
   have hInner : ∀ u : Fin m,
       Tendsto
         (fun N => ∑ v : Fin m,

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -519,7 +519,9 @@ lemma primitive_and_irreducible_sectorBlocks_of_cyclicDecomp
 
 /-! ## Self-overlap (first paragraph of Appendix A) -/
 
-private theorem mpvOverlap_blockTensor_self_eq
+/-- The self-overlap of a blocked tensor at length `N` is the self-overlap of
+the original tensor at length `N * L`. -/
+theorem mpvOverlap_blockTensor_self_eq
     [NeZero D] (A : MPSTensor d D) (L N : ℕ) :
     mpvOverlap (d := blockPhysDim d L) (blockTensor (d := d) (D := D) A L)
         (blockTensor (d := d) (D := D) A L) N =
@@ -756,13 +758,8 @@ private theorem blockTensor_selfOverlap_tendsto_of_cyclicSectorDecomp
       mpv (blockTensor (d := d) (D := D) A m) σ =
         ∑ u : Fin m, mpv (blocks u) σ := by
     intro N σ
-    calc
-      mpv (blockTensor (d := d) (D := D) A m) σ =
-          mpv (toTensorFromBlocks (d := blockPhysDim d m)
-            (μ := fun _ : Fin m => (1 : ℂ)) blocks) σ := hBlocks_mpv N σ
-      _ = ∑ u : Fin m, ((1 : ℂ) ^ N) • mpv (blocks u) σ := by
-            rw [mpv_toTensorFromBlocks_eq_sum]
-      _ = ∑ u : Fin m, mpv (blocks u) σ := by simp
+    exact mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
+      (blockTensor (d := d) (D := D) A m) blocks hBlocks_mpv σ
   have hOverlap_eq : ∀ N,
       mpvOverlap (d := blockPhysDim d m)
           (blockTensor (d := d) (D := D) A m)

--- a/TNLean/MPS/SharedInfra/BlockAssembly.lean
+++ b/TNLean/MPS/SharedInfra/BlockAssembly.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Core.MultiBlock
+import TNLean.MPS.Overlap.Basic
 
 /-!
 # Shared direct-sum tensor infrastructure for MPS tensors
@@ -84,5 +85,60 @@ theorem mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
     _ = ∑ k : Fin r, ((1 : ℂ) ^ N) • mpv (blocks k) σ := by
       rw [mpv_toTensorFromBlocks_eq_sum]
     _ = ∑ k : Fin r, mpv (blocks k) σ := by simp
+
+/-- The overlap of two tensors with unit-weight block diagonal MPV
+decompositions is the finite double sum of the overlaps of their blocks. -/
+theorem mpvOverlap_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
+    {D₁ D₂ r : ℕ} {dimA dimB : Fin r → ℕ}
+    (T₁ : MPSTensor d D₁) (T₂ : MPSTensor d D₂)
+    (blocksA : (k : Fin r) → MPSTensor d (dimA k))
+    (blocksB : (k : Fin r) → MPSTensor d (dimB k))
+    (hSameA :
+      SameMPV₂ T₁
+        (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocksA))
+    (hSameB :
+      SameMPV₂ T₂
+        (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocksB))
+    (N : ℕ) :
+    mpvOverlap (d := d) T₁ T₂ N =
+      ∑ u : Fin r, ∑ v : Fin r, mpvOverlap (d := d) (blocksA u) (blocksB v) N := by
+  classical
+  have hDecompA : ∀ σ : Fin N → Fin d, mpv T₁ σ =
+      ∑ u : Fin r, mpv (blocksA u) σ := by
+    intro σ
+    exact mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one T₁ blocksA hSameA σ
+  have hDecompB : ∀ σ : Fin N → Fin d, mpv T₂ σ =
+      ∑ v : Fin r, mpv (blocksB v) σ := by
+    intro σ
+    exact mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one T₂ blocksB hSameB σ
+  calc
+    mpvOverlap (d := d) T₁ T₂ N =
+        ∑ σ : Cfg d N, mpv T₁ σ * star (mpv T₂ σ) := rfl
+    _ = ∑ σ : Cfg d N,
+          (∑ u : Fin r, mpv (blocksA u) σ) *
+            star (∑ v : Fin r, mpv (blocksB v) σ) := by
+            refine Finset.sum_congr rfl ?_
+            intro σ _
+            rw [hDecompA σ, hDecompB σ]
+    _ = ∑ σ : Cfg d N,
+          ∑ u : Fin r, ∑ v : Fin r,
+            mpv (blocksA u) σ * star (mpv (blocksB v) σ) := by
+            refine Finset.sum_congr rfl ?_
+            intro σ _
+            rw [star_sum, Finset.sum_mul]
+            refine Finset.sum_congr rfl ?_
+            intro u _
+            rw [Finset.mul_sum]
+    _ = ∑ u : Fin r, ∑ σ : Cfg d N,
+          ∑ v : Fin r, mpv (blocksA u) σ * star (mpv (blocksB v) σ) := by
+            rw [Finset.sum_comm]
+    _ = ∑ u : Fin r, ∑ v : Fin r, ∑ σ : Cfg d N,
+          mpv (blocksA u) σ * star (mpv (blocksB v) σ) := by
+            refine Finset.sum_congr rfl ?_
+            intro u _
+            rw [Finset.sum_comm]
+    _ = ∑ u : Fin r, ∑ v : Fin r,
+          mpvOverlap (d := d) (blocksA u) (blocksB v) N := by
+            simp [mpvOverlap]
 
 end MPSTensor

--- a/TNLean/MPS/SharedInfra/BlockAssembly.lean
+++ b/TNLean/MPS/SharedInfra/BlockAssembly.lean
@@ -68,4 +68,21 @@ theorem mpv_toTensorFromBlocks_eq_sum
   rw [Matrix.trace_blockDiagonal']
   exact Finset.sum_congr rfl fun k _ => by simp [Matrix.trace_smul, hwlen]
 
+/-- If a tensor has the same MPV family as a unit-weight block diagonal
+assembly, then each MPV coefficient is the sum of the block coefficients. -/
+theorem mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one
+    {D r : ℕ} {dim : Fin r → ℕ}
+    (T : MPSTensor d D) (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hSame :
+      SameMPV₂ T (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks))
+    {N : ℕ} (σ : Fin N → Fin d) :
+    mpv T σ = ∑ k : Fin r, mpv (blocks k) σ := by
+  calc
+    mpv T σ =
+        mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks) σ :=
+      hSame N σ
+    _ = ∑ k : Fin r, ((1 : ℂ) ^ N) • mpv (blocks k) σ := by
+      rw [mpv_toTensorFromBlocks_eq_sum]
+    _ = ∑ k : Fin r, mpv (blocks k) σ := by simp
+
 end MPSTensor

--- a/TNLean/MPS/SharedInfra/GaugePhase.lean
+++ b/TNLean/MPS/SharedInfra/GaugePhase.lean
@@ -85,6 +85,36 @@ theorem mpvOverlap_self_scale_of_mpv_eq_pow_mul
       fun x => by ring]
   rw [← Finset.mul_sum, mul_pow]
 
+/-- If all matrix-product amplitudes of `B` are obtained from those of `A` by the
+length-dependent phase `ζ ^ N`, then the mixed overlap with `A` is
+`(conj ζ) ^ N` times the self-overlap of `A`. -/
+theorem mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ) :
+    ∀ N : ℕ,
+      mpvOverlap (d := d) A B N =
+        (star ζ) ^ N * mpvOverlap (d := d) A A N := by
+  intro N
+  classical
+  calc
+    mpvOverlap (d := d) A B N =
+        ∑ σ : Cfg d N, mpv A σ * star (ζ ^ N * mpv A σ) := by
+          simp only [mpvOverlap]
+          refine Finset.sum_congr rfl ?_
+          intro σ _
+          rw [hmpv N σ]
+    _ = ∑ σ : Cfg d N,
+        (star ζ) ^ N * (mpv A σ * star (mpv A σ)) := by
+          refine Finset.sum_congr rfl ?_
+          intro σ _
+          have hstar :
+              star (ζ ^ N * mpv A σ) = star (mpv A σ) * (star ζ) ^ N := by
+            rw [StarMul.star_mul, star_pow]
+          rw [hstar]
+          ring
+    _ = (star ζ) ^ N * mpvOverlap (d := d) A A N := by
+          simp [mpvOverlap, Finset.mul_sum]
+
 /-- If two self-overlaps have the same nonzero norm limit, and one scales from
 the other by powers of `ζ * conj ζ`, then `ζ` has unit norm. -/
 theorem norm_eq_one_of_selfOverlap_scale_at_nonzero_limit

--- a/TNLean/MPS/SharedInfra/GaugePhase.lean
+++ b/TNLean/MPS/SharedInfra/GaugePhase.lean
@@ -85,22 +85,22 @@ theorem mpvOverlap_self_scale_of_mpv_eq_pow_mul
       fun x => by ring]
   rw [← Finset.mul_sum, mul_pow]
 
-/-- If two self-overlaps both have norm limit `1`, and one scales from the other by powers of
-`ζ * conj ζ`, then `ζ` has unit norm. -/
-theorem norm_eq_one_of_selfOverlap_scale
+/-- If two self-overlaps have the same nonzero norm limit, and one scales from
+the other by powers of `ζ * conj ζ`, then `ζ` has unit norm. -/
+theorem norm_eq_one_of_selfOverlap_scale_at_nonzero_limit
     {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
-    (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1))
-    (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds 1))
+    {r : ℝ} (hr : r ≠ 0)
+    (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds r))
+    (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds r))
     (hSelf : ∀ N : ℕ,
       mpvOverlap (d := d) B B N =
         (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
     ‖ζ‖ = 1 := by
   have hAA_ne : ∀ᶠ N in Filter.atTop, ‖mpvOverlap (d := d) A A N‖ ≠ 0 :=
-    hAA.eventually_ne one_ne_zero
+    hAA.eventually_ne hr
   have hRatio : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖ /
       ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1) := by
-    rw [show (1 : ℝ) = 1 / 1 from (one_div_one).symm]
-    exact hBB.div hAA one_ne_zero
+    simpa [div_self hr] using hBB.div hAA hr
   have hRatioEq : ∀ᶠ N in Filter.atTop,
       ‖mpvOverlap (d := d) B B N‖ / ‖mpvOverlap (d := d) A A N‖ = (‖ζ‖ ^ 2) ^ N := by
     filter_upwards [hAA_ne] with N hN
@@ -121,6 +121,18 @@ theorem norm_eq_one_of_selfOverlap_scale
         with ⟨n, hn1, hn2⟩
       exact not_lt_of_ge hn1 hn2
   nlinarith [norm_nonneg ζ]
+
+/-- If two self-overlaps both have norm limit `1`, and one scales from the other by powers of
+`ζ * conj ζ`, then `ζ` has unit norm. -/
+theorem norm_eq_one_of_selfOverlap_scale
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1))
+    (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds 1))
+    (hSelf : ∀ N : ℕ,
+      mpvOverlap (d := d) B B N =
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
+    ‖ζ‖ = 1 :=
+  norm_eq_one_of_selfOverlap_scale_at_nonzero_limit one_ne_zero hAA hBB hSelf
 
 /-- The gauge phase `ζ` in a gauge-phase equivalence between two TP-normalized irreducible
 primitive blocks has unit norm. -/

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -491,6 +491,38 @@ unconditional result.
     If two periodic tensors with the same period admit no gauge-phase
     matching sector pair after blocking, then their overlap tends to zero.
 \end{theorem}
+\begin{proof}\leanok
+    \uses{lem:sector_blocked_normal_periodic}
+    Write the period-blocked tensors as
+    \[
+        \bar A \sim \bigoplus_{u\in\mathbb Z_m} A_u,\qquad
+        \bar B \sim \bigoplus_{v\in\mathbb Z_m} B_v ,
+    \]
+    with unit sector weights. For every length \(N\),
+    \[
+        O_{\bar A,\bar B}(N)
+        =
+        \sum_{u\in\mathbb Z_m}\sum_{v\in\mathbb Z_m}
+            O_{A_u,B_v}(N).
+    \]
+    If no pair \((u,v)\) is gauge-phase equivalent, then for every \(u,v\)
+    the normal-tensor dichotomy gives \(O_{A_u,B_v}(N)\to0\).
+    Hence the finite double sum gives \(O_{\bar A,\bar B}(N)\to 0\).
+
+    Conversely, if \(A\) and \(B\) were gauge-phase equivalent, then
+    \(\bar A\) and \(\bar B\) would be gauge-phase equivalent. Thus
+    \(V_N(\bar B)=\zeta^N X V_N(\bar A)X^{-1}\) at the virtual level, and
+    \[
+        O_{\bar A,\bar B}(N)
+        =
+        \overline{\zeta}^{\,N} O_{\bar A,\bar A}(N).
+    \]
+    The periodic self-overlap limits \(O_{\bar A,\bar A}(N)\to m\) and
+    \(O_{\bar B,\bar B}(N)\to m\) imply \(|\zeta|=1\), and the displayed
+    identity cannot tend to zero. This contradiction proves that \(A\) and
+    \(B\) are not gauge-phase equivalent. The irreducible trace-preserving
+    overlap dichotomy then yields \(O_{A,B}(N)\to0\).
+\end{proof}
 
 \begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}
     \lean{MPSTensor.sectorMatch_propagation}

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -512,7 +512,8 @@ unconditional result.
     the normal-tensor dichotomy gives \(O_{A_u,B_v}(N)\to0\).
     Hence the finite double sum gives \(O_{\bar A,\bar B}(N)\to 0\).
 
-    Conversely, if \(A\) and \(B\) were gauge-phase equivalent, then
+    This decay is incompatible with a hypothetical global gauge-phase
+    equivalence. If \(A\) and \(B\) were gauge-phase equivalent, then
     \(\bar A\) and \(\bar B\) would be gauge-phase equivalent. Thus
     \(V_N(\bar B)=\zeta^N X V_N(\bar A)X^{-1}\) at the virtual level, and
     \[

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -491,7 +491,7 @@ unconditional result.
     If two periodic tensors with the same period admit no gauge-phase
     matching sector pair after blocking, then their overlap tends to zero.
 \end{theorem}
-\begin{proof}\leanok
+\begin{proof}
     \uses{lem:sector_blocked_normal_periodic,
         thm:periodic_self_overlap_tendsto,
         thm:overlap_decay_irr_tp,

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -492,7 +492,10 @@ unconditional result.
     matching sector pair after blocking, then their overlap tends to zero.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{lem:sector_blocked_normal_periodic}
+    \uses{lem:sector_blocked_normal_periodic,
+        thm:periodic_self_overlap_tendsto,
+        thm:overlap_decay_irr_tp,
+        thm:overlap_decay_rect_irr_tp}
     Write the period-blocked tensors as
     \[
         \bar A \sim \bigoplus_{u\in\mathbb Z_m} A_u,\qquad

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -501,31 +501,31 @@ unconditional result.
         \bar A \sim \bigoplus_{u\in\mathbb Z_m} A_u,\qquad
         \bar B \sim \bigoplus_{v\in\mathbb Z_m} B_v ,
     \]
-    with unit sector weights. For every length \(N\),
+    with unit sector weights. For every length $N$,
     \[
         O_{\bar A,\bar B}(N)
         =
         \sum_{u\in\mathbb Z_m}\sum_{v\in\mathbb Z_m}
             O_{A_u,B_v}(N).
     \]
-    If no pair \((u,v)\) is gauge-phase equivalent, then for every \(u,v\)
-    the normal-tensor dichotomy gives \(O_{A_u,B_v}(N)\to0\).
-    Hence the finite double sum gives \(O_{\bar A,\bar B}(N)\to 0\).
+    If no pair $(u,v)$ is gauge-phase equivalent, then for every $u,v$
+    the normal-tensor dichotomy gives $O_{A_u,B_v}(N)\to0$.
+    Hence the finite double sum gives $O_{\bar A,\bar B}(N)\to 0$.
 
     This decay is incompatible with a hypothetical global gauge-phase
-    equivalence. If \(A\) and \(B\) were gauge-phase equivalent, then
-    \(\bar A\) and \(\bar B\) would be gauge-phase equivalent. Thus
-    \(V_N(\bar B)=\zeta^N X V_N(\bar A)X^{-1}\) at the virtual level, and
+    equivalence. If $A$ and $B$ were gauge-phase equivalent, then
+    $\bar A$ and $\bar B$ would be gauge-phase equivalent. Thus
+    $V_N(\bar B)=\zeta^N X V_N(\bar A)X^{-1}$ at the virtual level, and
     \[
         O_{\bar A,\bar B}(N)
         =
         \overline{\zeta}^{\,N} O_{\bar A,\bar A}(N).
     \]
-    The periodic self-overlap limits \(O_{\bar A,\bar A}(N)\to m\) and
-    \(O_{\bar B,\bar B}(N)\to m\) imply \(|\zeta|=1\), and the displayed
-    identity cannot tend to zero. This contradiction proves that \(A\) and
-    \(B\) are not gauge-phase equivalent. The irreducible trace-preserving
-    overlap dichotomy then yields \(O_{A,B}(N)\to0\).
+    The periodic self-overlap limits $O_{\bar A,\bar A}(N)\to m$ and
+    $O_{\bar B,\bar B}(N)\to m$ imply $|\zeta|=1$, and the displayed
+    identity cannot tend to zero. This contradiction proves that $A$ and
+    $B$ are not gauge-phase equivalent. The irreducible trace-preserving
+    overlap dichotomy then yields $O_{A,B}(N)\to0$.
 \end{proof}
 
 \begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}


### PR DESCRIPTION
## Summary

This closes the finite-sum extraction hole in periodic-overlap Case 2.

The proof follows arXiv:1708.00029, Appendix A, lines 952-960: after blocking by the common period, the global blocked overlap is expanded as a finite double sum over cyclic sector overlaps. If every sector-pair overlap tended to zero, the finite sum would tend to zero. This contradicts global blocked gauge-phase equivalence, since the periodic self-overlap limits force the gauge phase to have unit modulus and hence the global mixed blocked overlap cannot decay.

## Local validation

- `lake env lean TNLean/MPS/Periodic/Overlap/Case2.lean`
- `rg -n "sorry|axiom" TNLean/MPS/Periodic/Overlap/Case2.lean || true`
- `git diff --check`

Closes #872

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof completion and lemma refactors in periodic overlap theory; no runtime, security, or data-path changes.
> 
> **Overview**
> **Closes the periodic overlap Case 2 “finite double sum” gap** by proving `exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicDecomp` (replacing `sorry`): if every blocked sector-pair overlap went to zero, the blocked global overlap would too, contradicting gauge-phase equivalence with **nonzero** periodic blocked self-overlap limits.
> 
> Supporting work **factors block-diagonal overlap algebra** into `BlockAssembly` (`mpv_eq_sum` / `mpvOverlap_eq_sum` for unit-weight `toTensorFromBlocks`) and **extends gauge-phase lemmas** (`mpvOverlap_eq_star_pow_mul_self`, `norm_eq_one_of_selfOverlap_scale_at_nonzero_limit`) used to show blocked mixed overlap cannot decay when tensors are gauge-phase equivalent. `SelfOverlap` reuses the shared sum lemma and **exports** `mpvOverlap_blockTensor_self_eq`. The blueprint **adds a proof** for no sector match ⇒ overlap → 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342bc618451c98db9f00ccaa2d94480663d51f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->