### PR TITLE
doc(blueprint): use dollar inline math

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1277,16 +1277,16 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelCoefficientFamily.ofChi_coeff_eq_trace_matrix_pow}
     \leanok
     The same-length coefficient system
-    \(c^{(L)}_{\alpha,\beta,\gamma}\) from Theorem~IV.13(ii), indexed by
-    fixed BNT labels \(\alpha,\beta,\gamma\).  The coefficient is attached to
-    the length-\(L\) product
-    \(O_L(M_\alpha)O_L(M_\beta)\), not to the blocked-basis multiplication
-    \(\mathcal A_n\times\mathcal A_n\to\mathcal A_{2n}\).
-    When a diagonal \(\chi\)-family has already been constructed, it also
+    $c^{(L)}_{\alpha,\beta,\gamma}$ from Theorem~IV.13(ii), indexed by
+    fixed BNT labels $\alpha,\beta,\gamma$.  The coefficient is attached to
+    the length-$L$ product
+    $O_L(M_\alpha)O_L(M_\beta)$, not to the blocked-basis multiplication
+    $\mathcal A_n\times\mathcal A_n\to\mathcal A_{2n}$.
+    When a diagonal $\chi$-family has already been constructed, it also
     canonically determines the coefficient family
-    \(c^{(L)}_{\alpha,\beta,\gamma}
+    $c^{(L)}_{\alpha,\beta,\gamma}
     = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})
-    = \sum_r\chi_{\alpha,\beta,\gamma,r}^{\,L}\), as in
+    = \sum_r\chi_{\alpha,\beta,\gamma,r}^{\,L}$, as in
     \cite[Appendix~C.4]{Cirac2017MPDO_AnnPhys}.
 \end{definition}
 
@@ -1294,9 +1294,9 @@ the elementary trace-power identity for diagonal matrices.
     \label{def:mpdo_bnt_label_operator_family}
     \lean{MPOTensor.BNTLabelOperatorFamily}
     \leanok
-    A BNT-label operator family records, for each chain length \(L\), the
-    operators \(O_L(M_\alpha)\) indexed by the fixed BNT labels \(\alpha\).
-    The ambient algebra at length \(L\) is left abstract here; the later
+    A BNT-label operator family records, for each chain length $L$, the
+    operators $O_L(M_\alpha)$ indexed by the fixed BNT labels $\alpha$.
+    The ambient algebra at length $L$ is left abstract here; the later
     comparison step must relate it to the chosen blocked support algebras.
 \end{definition}
 
@@ -1307,7 +1307,7 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_operator_family,
         def:mpdo_bnt_label_coefficient_family}
     A BNT-label operator family and a BNT-label coefficient system have
-    same-length product form when, for every positive length \(L\),
+    same-length product form when, for every positive length $L$,
     \[
         O_L(M_\alpha)O_L(M_\beta)
         = \sum_\gamma
@@ -1315,7 +1315,7 @@ the elementary trace-power identity for diagonal matrices.
     \]
     This is the product identity appearing in Theorem~IV.13(ii), stated
     independently of the blocked-basis multiplication
-    \(\mathcal A_n\times\mathcal A_n\to\mathcal A_{2n}\).
+    $\mathcal A_n\times\mathcal A_n\to\mathcal A_{2n}$.
 \end{definition}
 
 \begin{theorem}[Same-length BNT product expansion]%
@@ -1323,9 +1323,9 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum}
     \leanok
     \uses{def:mpdo_bnt_label_same_length_product_form}
-    Under same-length BNT product form, the product of two length-\(L\)
+    Under same-length BNT product form, the product of two length-$L$
     BNT-label operators is the corresponding finite linear combination of
-    length-\(L\) BNT-label operators.
+    length-$L$ BNT-label operators.
 \end{theorem}
 \begin{proof}\leanok
     This is exactly the defining equality of same-length product form.
@@ -1336,8 +1336,8 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelTraceScalarFamily}
     \leanok
     A BNT-label trace-scalar family records the scalars
-    \(m_\alpha=\operatorname{tr}(\mu_\alpha)\) indexed by the fixed BNT labels
-    \(\alpha\), as in the idempotent condition of Theorem~IV.13(ii).
+    $m_\alpha=\operatorname{tr}(\mu_\alpha)$ indexed by the fixed BNT labels
+    $\alpha$, as in the idempotent condition of Theorem~IV.13(ii).
 \end{definition}
 
 \begin{definition}[BNT idempotent coefficient form]%
@@ -1347,7 +1347,7 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_trace_scalar_family,
         def:mpdo_bnt_label_coefficient_family}
     A BNT-label trace-scalar family and a BNT-label coefficient system have
-    idempotent coefficient form when, for every BNT label \(\gamma\),
+    idempotent coefficient form when, for every BNT label $\gamma$,
     \[
         m_\gamma =
         \sum_{\alpha,\beta}
@@ -1362,9 +1362,9 @@ the elementary trace-power identity for diagonal matrices.
     \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum}
     \leanok
     \uses{def:mpdo_bnt_label_idempotent_coefficient_form}
-    Under BNT idempotent coefficient form, each \(m_\gamma\) is the
-    corresponding finite linear combination of products \(m_\alpha m_\beta\)
-    with the length-one coefficients \(c^{(1)}_{\alpha,\beta,\gamma}\).
+    Under BNT idempotent coefficient form, each $m_\gamma$ is the
+    corresponding finite linear combination of products $m_\alpha m_\beta$
+    with the length-one coefficients $c^{(1)}_{\alpha,\beta,\gamma}$.
 \end{theorem}
 \begin{proof}\leanok
     This is exactly the defining equality of BNT idempotent coefficient form.
@@ -1426,14 +1426,14 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_coefficient_family,
         def:mpdo_diagonal_chi_family}
-    A BNT-label coefficient system and a diagonal \(\chi\)-family are
-    compatible when, for every positive length \(L\),
+    A BNT-label coefficient system and a diagonal $\chi$-family are
+    compatible when, for every positive length $L$,
     \[
         c^{(L)}_{\alpha,\beta,\gamma}
         = \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr).
     \]
-    The same matrix \(\chi_{\alpha,\beta,\gamma}\) is used for all positive
-    \(L\).
+    The same matrix $\chi_{\alpha,\beta,\gamma}$ is used for all positive
+    $L$.
 \end{definition}
 
 \begin{theorem}[BNT-label coefficient as a positive-length trace power]%
@@ -1442,30 +1442,30 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_positive_length_chi_trace_power_form,
         thm:mpdo_trace_matrix_pow}
-    Under positive-length BNT-label trace-power form, for every \(L>0\),
-    \(c^{(L)}_{\alpha,\beta,\gamma}\) is the trace of
-    \(\chi_{\alpha,\beta,\gamma}^{L}\).
+    Under positive-length BNT-label trace-power form, for every $L>0$,
+    $c^{(L)}_{\alpha,\beta,\gamma}$ is the trace of
+    $\chi_{\alpha,\beta,\gamma}^{L}$.
 \end{theorem}
 \begin{proof}\leanok
     Combine the defining positive-length trace-power identity with the trace
     formula for powers of a diagonal matrix.
 \end{proof}
 
-\begin{theorem}[Canonical BNT coefficients from a \(\chi\)-family]%
+\begin{theorem}[Canonical BNT coefficients from a $\chi$-family]%
     \label{thm:mpdo_bnt_label_of_chi_positive_length_trace_power}
 \lean{MPOTensor.BNTLabelCoefficientFamily.ofChi_hasPositiveLengthChiTracePowerForm}
     \leanok
     \uses{def:mpdo_bnt_label_coefficient_family,
         def:mpdo_bnt_label_positive_length_chi_trace_power_form}
     The coefficient family canonically determined by a diagonal
-    \(\chi\)-family satisfies the positive-length trace-power condition with
-    respect to the same \(\chi\)-family.
+    $\chi$-family satisfies the positive-length trace-power condition with
+    respect to the same $\chi$-family.
 \end{theorem}
 \begin{proof}\leanok
     This is immediate from the definition of the canonical coefficient family.
 \end{proof}
 
-\begin{definition}[Positive BNT-label \(\chi\) trace-power witness]%
+\begin{definition}[Positive BNT-label $\chi$ trace-power witness]%
     \label{def:mpdo_positive_bnt_label_chi_trace_power_form}
     \lean{MPOTensor.PositiveBNTLabelChiTracePowerForm}
     \lean{MPOTensor.PositiveBNTLabelChiTracePowerForm.ofChi}
@@ -1473,14 +1473,14 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_positive_length_chi_trace_power_form,
         def:mpdo_diagonal_chi_family,
         thm:mpdo_bnt_label_of_chi_positive_length_trace_power}
-    A positive BNT-label \(\chi\) witness consists of a length-independent
-    diagonal \(\chi_{\alpha,\beta,\gamma}\)-family, positivity of every
+    A positive BNT-label $\chi$ witness consists of a length-independent
+    diagonal $\chi_{\alpha,\beta,\gamma}$-family, positivity of every
     diagonal entry, and the positive-length trace-power identity for the
     BNT-label coefficients.  This is the coefficient statement of
     Theorem~IV.13(ii); constructing the witness from an MPDO tensor and
     comparing it to blocked bases remain separate obligations.
     If the coefficient family is chosen canonically from the same
-    \(\chi\)-family, positivity of the diagonal entries alone gives such a
+    $\chi$-family, positivity of the diagonal entries alone gives such a
     witness.
 \end{definition}
 
@@ -1490,9 +1490,9 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_positive_bnt_label_chi_trace_power_form,
         thm:mpdo_bnt_label_chi_eq_trace_matrix_pow}
-    A positive BNT-label \(\chi\) witness gives, for every \(L>0\), the formula
-    \(c^{(L)}_{\alpha,\beta,\gamma}
-    =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})\).
+    A positive BNT-label $\chi$ witness gives, for every $L>0$, the formula
+    $c^{(L)}_{\alpha,\beta,\gamma}
+    =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace reformulation of the positive-length trace-power identity
@@ -1506,8 +1506,8 @@ the elementary trace-power identity for diagonal matrices.
     \uses{thm:mpdo_bnt_label_same_length_product_eq_sum,
         thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
     If the same-length BNT product identity holds and the BNT-label
-    coefficients come from a positive length-independent \(\chi\)-witness, then
-    for every \(L>0\),
+    coefficients come from a positive length-independent $\chi$-witness, then
+    for every $L>0$,
     \[
         O_L(M_\alpha)O_L(M_\beta)
         = \sum_\gamma
@@ -1528,8 +1528,8 @@ the elementary trace-power identity for diagonal matrices.
     \uses{thm:mpdo_bnt_label_same_length_product_eq_sum,
         def:mpdo_bnt_label_coefficient_family}
     If the same-length BNT product identity holds with the coefficient family
-    canonically determined by a diagonal \(\chi\)-family, then for every
-    \(L>0\),
+    canonically determined by a diagonal $\chi$-family, then for every
+    $L>0$,
     \[
         O_L(M_\alpha)O_L(M_\beta)
         = \sum_\gamma
@@ -1551,7 +1551,7 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
     If the BNT trace scalars satisfy the idempotent coefficient condition and
     the BNT-label coefficients come from a positive length-independent
-    \(\chi\)-witness, then
+    $\chi$-witness, then
     \[
         m_\gamma =
         \sum_{\alpha,\beta}
@@ -1572,7 +1572,7 @@ the elementary trace-power identity for diagonal matrices.
         def:mpdo_bnt_label_coefficient_family}
     If the BNT trace scalars satisfy the idempotent coefficient condition with
     the coefficient family canonically determined by a diagonal
-    \(\chi\)-family, then
+    $\chi$-family, then
     \[
         m_\gamma =
         \sum_{\alpha,\beta}
@@ -1598,9 +1598,9 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
     If the chosen blocked-basis coefficients are compared with the fixed
     BNT-label coefficient system, and that BNT-label system has a positive
-    length-independent \(\chi\)-witness, then each positive-length blocked
+    length-independent $\chi$-witness, then each positive-length blocked
     coefficient is the trace power of the corresponding BNT-label
-    \(\chi\)-matrix:
+    $\chi$-matrix:
     \[
         c^{(n)}_{i,j,k}
         = \operatorname{tr}
@@ -1614,7 +1614,7 @@ the elementary trace-power identity for diagonal matrices.
     corresponding BNT-label coefficient, and then apply the BNT-label
     trace-power formula.
     In the special case where the compared BNT-label coefficient family is
-    already the canonical family determined by \(\chi\), the same conclusion
+    already the canonical family determined by $\chi$, the same conclusion
     follows directly from the canonical trace formula.
 \end{proof}
 
@@ -1697,7 +1697,7 @@ the elementary trace-power identity for diagonal matrices.
     \path{docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex}.
 \end{definition}
 
-\begin{theorem}[BNT witnesses give blocked \(\chi\) witnesses]%
+\begin{theorem}[BNT witnesses give blocked $\chi$ witnesses]%
     \label{thm:mpdo_bnt_blocked_basis_to_positive_blocked_chi_trace_power_form}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.blockedLabel}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.pulledBlockedChiFamily}
@@ -1714,17 +1714,17 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_blocked_basis_coefficient_eq}
     Suppose that the chosen blocked-basis coefficients are compared with a
     fixed BNT-label coefficient system, and that this BNT-label system has a
-    positive length-independent \(\chi\)-witness.  Then the chosen blocked
-    bases carry a positive blocked \(\chi\) trace-power witness.
+    positive length-independent $\chi$-witness.  Then the chosen blocked
+    bases carry a positive blocked $\chi$ trace-power witness.
     The construction is obtained by pulling back the BNT-label
-    \(\chi_{\alpha,\beta,\gamma}\)-matrices along the source and target label
+    $\chi_{\alpha,\beta,\gamma}$-matrices along the source and target label
     maps.
     % Formalization note: the zero-length component of the blocked chi family is
     % filled by empty diagonal matrices; it plays no role in the positive-length
     % trace-power statement.
 \end{theorem}
 \begin{proof}\leanok
-    Reindex the positive BNT-label \(\chi\)-family along the blocked-basis
+    Reindex the positive BNT-label $\chi$-family along the blocked-basis
     label map.  Positivity is preserved by reindexing, and the trace-power
     identity follows by substituting the blocked-basis comparison into the
     BNT-label trace-power formula.
@@ -1758,16 +1758,16 @@ the elementary trace-power identity for diagonal matrices.
     The BNT-label theorem data consist of the fixed BNT-label coefficient
     system, the same-length BNT operator family and product identity, the trace
     scalars and idempotent condition, the positive length-independent
-    \(\chi\)-witness, and the comparison with the chosen blocked bases.
-    They also determine the pulled-back blocked-basis \(\chi\)-family.  These
+    $\chi$-witness, and the comparison with the chosen blocked bases.
+    They also determine the pulled-back blocked-basis $\chi$-family.  These
     data are the source-side hypotheses from which the blocked-basis
     consequences below are derived.
     In the source-side special case where the coefficient family is
-    canonically determined by the same \(\chi\)-family, theorem data are built
-    from that \(\chi\)-family, its positivity, and the product, idempotent, and
+    canonically determined by the same $\chi$-family, theorem data are built
+    from that $\chi$-family, its positivity, and the product, idempotent, and
     blocked-comparison statements for the resulting canonical coefficients.
     The same product and idempotent predicates may also be rephrased using the
-    canonical coefficient family determined by the \(\chi\)-matrices carried by
+    canonical coefficient family determined by the $\chi$-matrices carried by
     the data, with the corresponding displayed equations.
 \end{definition}
 
@@ -1818,7 +1818,7 @@ the elementary trace-power identity for diagonal matrices.
     BNT-label theorem data give the comparison between the blocked-basis
     coefficients and the BNT-label coefficients through the source and target
     label maps.  Since the positive-length coefficients agree with the
-    canonical coefficient family determined by the same \(\chi\)-matrices, the
+    canonical coefficient family determined by the same $\chi$-matrices, the
     comparison can also be written with those canonical coefficients.
 \end{theorem}
 \begin{proof}\leanok
@@ -1838,7 +1838,7 @@ the elementary trace-power identity for diagonal matrices.
       = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$
     for every positive length $L$.  Equivalently, at every positive length, the
     coefficient family agrees with the canonical coefficient family determined
-    by the same \(\chi\)-matrices.
+    by the same $\chi$-matrices.
 \end{theorem}
 \begin{proof}\leanok
     This is the positive-length $\chi$-trace identity belonging to the
@@ -1852,11 +1852,11 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_theorem_data,
         def:mpdo_positive_bnt_label_chi_trace_power_form}
     BNT-label theorem data give positivity of every diagonal entry of
-    \(\chi_{\alpha,\beta,\gamma}\).
+    $\chi_{\alpha,\beta,\gamma}$.
 \end{theorem}
 \begin{proof}\leanok
     This is the positivity condition carried by the positive BNT-label
-    \(\chi\)-witness in the theorem data.
+    $\chi$-witness in the theorem data.
 \end{proof}
 
 \begin{theorem}[BNT theorem data give the chi-trace product law]%
@@ -1867,11 +1867,11 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_same_length_product_eq_sum_chi_trace_pow}
     BNT-label theorem data give the same-length product expansion with
     coefficients written as traces of powers of the length-independent
-    \(\chi_{\alpha,\beta,\gamma}\)-matrices.
+    $\chi_{\alpha,\beta,\gamma}$-matrices.
 \end{theorem}
 \begin{proof}\leanok
     Apply the chi-trace product law to the product identity and the positive
-    BNT-label \(\chi\)-witness belonging to the theorem data.
+    BNT-label $\chi$-witness belonging to the theorem data.
 \end{proof}
 
 \begin{theorem}[BNT theorem data give the chi-trace idempotent law]%
@@ -1882,11 +1882,11 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_idempotent_eq_sum_chi_trace}
     BNT-label theorem data give the idempotent scalar identity with the
     length-one coefficients written as traces of the corresponding
-    \(\chi\)-matrices.
+    $\chi$-matrices.
 \end{theorem}
 \begin{proof}\leanok
     Apply the chi-trace idempotent law to the idempotent condition and the
-    positive BNT-label \(\chi\)-witness belonging to the theorem data.
+    positive BNT-label $\chi$-witness belonging to the theorem data.
 \end{proof}
 
 \begin{theorem}[BNT theorem data give blocked coefficient trace powers]%
@@ -1897,15 +1897,15 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_blocked_basis_coefficient_eq_trace_pow}
     BNT-label theorem data give the blocked-basis coefficient trace-power
     formula obtained by pulling the BNT-label
-    \(\chi_{\alpha,\beta,\gamma}\)-matrices back along the blocked-basis
+    $\chi_{\alpha,\beta,\gamma}$-matrices back along the blocked-basis
     comparison maps.
 \end{theorem}
 \begin{proof}\leanok
     Apply the blocked-basis coefficient trace-power theorem to the comparison
-    and the positive BNT-label \(\chi\)-witness belonging to the theorem data.
+    and the positive BNT-label $\chi$-witness belonging to the theorem data.
 \end{proof}
 
-\begin{theorem}[BNT theorem data give a positive blocked \(\chi\) witness]%
+\begin{theorem}[BNT theorem data give a positive blocked $\chi$ witness]%
     \label{thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
     \lean{MPOTensor.BNTLabelTheoremData.toPositiveBlockedStructureChiTracePowerForm}
     \lean{MPOTensor.BNTLabelTheoremData.positiveBlockedChi_toDiagonal_of_pos}
@@ -1915,13 +1915,13 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_blocked_basis_to_positive_blocked_chi_trace_power_form}
-    BNT-label theorem data give a positive blocked-basis \(\chi\) trace-power
-    witness by pulling the length-independent BNT-label \(\chi\)-family back
+    BNT-label theorem data give a positive blocked-basis $\chi$ trace-power
+    witness by pulling the length-independent BNT-label $\chi$-family back
     along the blocked-basis comparison maps.
 \end{theorem}
 \begin{proof}\leanok
     Apply the BNT-to-blocked witness construction to the comparison and the
-    positive BNT-label \(\chi\)-witness belonging to the theorem data.
+    positive BNT-label $\chi$-witness belonging to the theorem data.
 \end{proof}
 
 \begin{theorem}[BNT theorem data give blocked trace-power form]%
@@ -1930,12 +1930,12 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
-    The pulled-back blocked-basis \(\chi\)-family obtained from BNT-label
+    The pulled-back blocked-basis $\chi$-family obtained from BNT-label
     theorem data satisfies the blocked trace-power predicate.
 \end{theorem}
 \begin{proof}\leanok
     This is the trace-power part of the positive blocked-basis
-    \(\chi\)-witness obtained from the theorem data.
+    $\chi$-witness obtained from the theorem data.
 \end{proof}
 
 \begin{theorem}[BNT theorem data give positive blocked chi families]%
@@ -1944,12 +1944,12 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
-    The pulled-back blocked-basis \(\chi\)-family obtained from BNT-label
+    The pulled-back blocked-basis $\chi$-family obtained from BNT-label
     theorem data has positive diagonal entries.
 \end{theorem}
 \begin{proof}\leanok
     This is the positivity part of the positive blocked-basis
-    \(\chi\)-witness obtained from the theorem data.
+    $\chi$-witness obtained from the theorem data.
 \end{proof}
 
 \begin{theorem}[BNT theorem data give positive pulled-back blocked entries]%
@@ -1958,12 +1958,12 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
-    The pulled-back blocked-basis \(\chi\)-entries obtained from BNT-label
+    The pulled-back blocked-basis $\chi$-entries obtained from BNT-label
     theorem data are positive.
 \end{theorem}
 \begin{proof}\leanok
     This is the positivity part of the positive blocked-basis
-    \(\chi\)-witness obtained from the theorem data.
+    $\chi$-witness obtained from the theorem data.
 \end{proof}
 
 \begin{theorem}[BNT theorem data give pulled-back blocked trace powers]%
@@ -1974,12 +1974,12 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form,
         thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
     The positive-length blocked-basis coefficients are traces of powers of the
-    pulled-back blocked-basis \(\chi\)-matrices obtained from BNT-label
+    pulled-back blocked-basis $\chi$-matrices obtained from BNT-label
     theorem data.
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace-power identity of the positive blocked-basis
-    \(\chi\)-witness obtained from the theorem data.
+    $\chi$-witness obtained from the theorem data.
 \end{proof}
 
 \begin{definition}[Existential BNT-label theorem witness]%
@@ -2012,16 +2012,16 @@ the elementary trace-power identity for diagonal matrices.
     An existential BNT-label theorem witness consists of the finite BNT-label
     type, the same-length operator spaces, their algebraic structure, and the
     corresponding BNT-label theorem data, including the pulled-back
-    blocked-basis \(\chi\)-family.  The construction of such a witness from an
+    blocked-basis $\chi$-family.  The construction of such a witness from an
     MPDO tensor is the outstanding step toward Theorem~IV.13(ii).
     The proposition-level form is the nonemptiness of this witness type.
     In the source-side special case where the coefficients are canonically
-    determined by a \(\chi\)-family, the witness is obtained from
-    that same \(\chi\)-family together with the remaining product, idempotent,
+    determined by a $\chi$-family, the witness is obtained from
+    that same $\chi$-family together with the remaining product, idempotent,
     and blocked-comparison statements.
     For any such witness, the product and idempotent predicates can be
     rephrased with the canonical coefficient family determined by its
-    \(\chi\)-matrices, with the corresponding displayed equations.
+    $\chi$-matrices, with the corresponding displayed equations.
 \end{definition}
 
 \begin{theorem}[BNT theorem witnesses give source equations]%
@@ -2037,14 +2037,14 @@ the elementary trace-power identity for diagonal matrices.
     A proposition-level BNT-label theorem witness contains the source-side
     same-length product law, the idempotent scalar law, the positive-length
     trace-power law, and positivity of the diagonal
-    \(\chi_{\alpha,\beta,\gamma}\)-entries.  After unpacking the witness, the
+    $\chi_{\alpha,\beta,\gamma}$-entries.  After unpacking the witness, the
     same-length product and idempotent equations can first be written with the
-    BNT-label coefficients \(c^{(L)}_{\alpha,\beta,\gamma}\), and then with
+    BNT-label coefficients $c^{(L)}_{\alpha,\beta,\gamma}$, and then with
     the coefficients expressed as
-    \(\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})\) and
-    \(\operatorname{tr}(\chi_{\alpha,\beta,\gamma})\), respectively.  At
+    $\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})$ and
+    $\operatorname{tr}(\chi_{\alpha,\beta,\gamma})$, respectively.  At
     every positive length, the BNT-label coefficient family also agrees with
-    the canonical coefficient family determined by these \(\chi\)-matrices.
+    the canonical coefficient family determined by these $\chi$-matrices.
     Consequently, the product and idempotent predicates may be stated directly
     using that canonical coefficient family, and the same displayed source
     equations hold with those canonical coefficients.
@@ -2066,7 +2066,7 @@ the elementary trace-power identity for diagonal matrices.
       = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})$
     for every positive length $L$.  Equivalently, at positive lengths, its
     coefficient family agrees with the canonical coefficient family determined
-    by the same \(\chi\)-matrices.
+    by the same $\chi$-matrices.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -2079,11 +2079,11 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_theorem_witness,
         def:mpdo_positive_bnt_label_chi_trace_power_form}
     An existential BNT-label theorem witness gives positivity of every
-    diagonal entry of \(\chi_{\alpha,\beta,\gamma}\).
+    diagonal entry of $\chi_{\alpha,\beta,\gamma}$.
 \end{theorem}
 \begin{proof}\leanok
     This follows from the positivity condition in the positive BNT-label
-    \(\chi\)-witness.
+    $\chi$-witness.
 \end{proof}
 
 \begin{theorem}[BNT theorem witnesses give the same-length product law]%
@@ -2131,7 +2131,7 @@ the elementary trace-power identity for diagonal matrices.
     blocked-basis coefficients and the BNT-label coefficients through the
     source and target label maps.  The same comparison is also available with
     the canonical coefficient family determined by the witness's
-    \(\chi\)-matrices.  The proposition-level nonempty form of the witness
+    $\chi$-matrices.  The proposition-level nonempty form of the witness
     gives the same comparisons after choosing a witness.
 \end{theorem}
 \begin{proof}\leanok
@@ -2178,13 +2178,13 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_data_blocked_coeff_eq_trace_pow}
     An existential BNT-label theorem witness gives the blocked-basis
     coefficient trace-power formula obtained by pulling the BNT-label
-    \(\chi\)-matrices back along the blocked-basis comparison maps.
+    $\chi$-matrices back along the blocked-basis comparison maps.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
 \end{proof}
 
-\begin{theorem}[BNT theorem witnesses give positive blocked \(\chi\) witnesses]%
+\begin{theorem}[BNT theorem witnesses give positive blocked $\chi$ witnesses]%
     \label{thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form}
     \lean{MPOTensor.BNTLabelTheoremWitness.toPositiveBlockedStructureChiTracePowerForm}
     \lean{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_toDiagonal_of_pos}
@@ -2199,9 +2199,9 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
     An existential BNT-label theorem witness gives a positive blocked-basis
-    \(\chi\) trace-power witness for the chosen algebra-structure data.  The
-    blocked-basis \(\chi\)-family is the pullback of the BNT-label
-    \(\chi\)-family along the source and target comparison maps.  The
+    $\chi$ trace-power witness for the chosen algebra-structure data.  The
+    blocked-basis $\chi$-family is the pullback of the BNT-label
+    $\chi$-family along the source and target comparison maps.  The
     proposition-level nonempty form of the witness gives the corresponding
     existential blocked-basis trace-power family, both in coefficient form and
     in matrix-trace form.
@@ -2216,12 +2216,12 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form}
-    The pulled-back blocked-basis \(\chi\)-family obtained from an existential
+    The pulled-back blocked-basis $\chi$-family obtained from an existential
     BNT-label theorem witness satisfies the blocked trace-power predicate.
 \end{theorem}
 \begin{proof}\leanok
     This is the trace-power part of the positive blocked-basis
-    \(\chi\)-witness obtained from the existential witness.
+    $\chi$-witness obtained from the existential witness.
 \end{proof}
 
 \begin{theorem}[BNT theorem witnesses give positive blocked chi families]%
@@ -2230,12 +2230,12 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form}
-    The pulled-back blocked-basis \(\chi\)-family obtained from an existential
+    The pulled-back blocked-basis $\chi$-family obtained from an existential
     BNT-label theorem witness has positive diagonal entries.
 \end{theorem}
 \begin{proof}\leanok
     This is the positivity part of the positive blocked-basis
-    \(\chi\)-witness obtained from the existential witness.
+    $\chi$-witness obtained from the existential witness.
 \end{proof}
 
 \begin{theorem}[BNT theorem witnesses give positive pulled-back blocked entries]%
@@ -2244,12 +2244,12 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form}
-    The pulled-back blocked-basis \(\chi\)-entries obtained from an
+    The pulled-back blocked-basis $\chi$-entries obtained from an
     existential BNT-label theorem witness are positive.
 \end{theorem}
 \begin{proof}\leanok
     This is the positivity part of the positive blocked-basis
-    \(\chi\)-witness obtained from the existential witness.
+    $\chi$-witness obtained from the existential witness.
 \end{proof}
 
 \begin{theorem}[BNT theorem witnesses give pulled-back blocked trace powers]%
@@ -2260,12 +2260,12 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form,
         thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
     The positive-length blocked-basis coefficients are traces of powers of the
-    pulled-back blocked-basis \(\chi\)-matrices obtained from an existential
+    pulled-back blocked-basis $\chi$-matrices obtained from an existential
     BNT-label theorem witness.
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace-power identity of the positive blocked-basis
-    \(\chi\)-witness obtained from the existential witness.
+    $\chi$-witness obtained from the existential witness.
 \end{proof}
 
 \begin{theorem}[Positive blocked $\chi$ witness gives trace powers]%
@@ -2276,7 +2276,7 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_blocked_structure_chi_eq_trace_matrix_pow}
     A positive blocked $\chi$ trace-power witness gives, for every positive
     blocked size $n$, the formula
-    \(c^{(n)}_{i,j,k}=\operatorname{tr}(\chi_{n,i,j,k}^{\,n})\).
+    $c^{(n)}_{i,j,k}=\operatorname{tr}(\chi_{n,i,j,k}^{\,n})$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace reformulation of the trace-power identity from the witness.

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -230,7 +230,7 @@ later MPDO arguments.
     \leanok
     \uses{def:von_neumann_entropy}
     This formulation has the same value
-    \(S(\rho) = -\sum_i \lambda_i \log \lambda_i\) as in
+    $S(\rho) = -\sum_i \lambda_i \log \lambda_i$ as in
     Definition~\ref{def:von_neumann_entropy}.
 \end{definition}
 
@@ -278,7 +278,7 @@ later MPDO arguments.
     \leanok
     \uses{def:entropy_von_neumann_entropy}
     This formulation has the same value
-    \(I(A{:}B) = S(\rho_A) + S(\rho_B) - S(\rho_{AB})\)
+    $I(A{:}B) = S(\rho_A) + S(\rho_B) - S(\rho_{AB})$
     as in Definition~\ref{def:mutual_information}.
 \end{definition}
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -727,7 +727,7 @@ statement is Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
     \lean{MPSTensor.mpv_toTensorFromBlocks_weight_mul_left}
     \leanok
     Multiplying every block weight in a block-diagonal MPS tensor by the same
-    scalar \(c\) multiplies every length-\(N\) MPV coefficient by \(c^N\).
+    scalar $c$ multiplies every length-$N$ MPV coefficient by $c^N$.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1693,10 +1693,10 @@ structure for completeness.
     \leanok
     \uses{thm:zero_block_separation,
         thm:pgvwc07_blockwise_unital_dual_package}
-    Let \(A\) be an arbitrary translation-invariant MPS tensor.  Then there is
-    a zero block of bond dimension \(D_0\), a finite family of nonzero blocks
-    \(C_k\), and positive real weights \(\mu_k\), such that for every chain
-    length \(N\) and every word \(\sigma \in \{0,\ldots,d-1\}^N\),
+    Let $A$ be an arbitrary translation-invariant MPS tensor.  Then there is
+    a zero block of bond dimension $D_0$, a finite family of nonzero blocks
+    $C_k$, and positive real weights $\mu_k$, such that for every chain
+    length $N$ and every word $\sigma \in \{0,\ldots,d-1\}^N$,
     \[
         \operatorname{MPV}_A
         =
@@ -1717,7 +1717,7 @@ structure for completeness.
 \begin{proof}\leanok
     \uses{thm:zero_block_separation,
         thm:pgvwc07_blockwise_unital_dual_package}
-    First apply the zero-block separation theorem to \(A\), retaining the
+    First apply the zero-block separation theorem to $A$, retaining the
     all-zero summands as a single zero block and extracting the nonzero
     irreducible summands.  Then apply the blockwise PGVWC07 unital and
     dual-diagonal theorem to this nonzero family.  Chaining the two MPV
@@ -1736,17 +1736,17 @@ structure for completeness.
         D_0+\sum_k D_k = D .
     \]
     In particular, the total bond dimension of the nonzero blocks is at most
-    the original bond dimension \(D\).
+    the original bond dimension $D$.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package,
         lem:mpv_zero_length}
     Evaluate the MPV identity of
     Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_package} on the
-    empty word.  The length-zero coefficient of a bond-\(D\) tensor is \(D\);
-    the zero block contributes \(D_0\), and the direct sum of the nonzero
-    blocks contributes \(\sum_k D_k\).  This gives the displayed identity, and
-    the inequality follows because \(D_0\geq 0\).
+    empty word.  The length-zero coefficient of a bond-$D$ tensor is $D$;
+    the zero block contributes $D_0$, and the direct sum of the nonzero
+    blocks contributes $\sum_k D_k$.  This gives the displayed identity, and
+    the inequality follows because $D_0\geq 0$.
 \end{proof}
 
 \begin{theorem}[Positive-length PGVWC07 unital dual-diagonal form]%
@@ -1754,8 +1754,8 @@ structure for completeness.
     \lean{MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound}
     \leanok
     \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
-    For any MPS tensor \(A\) of bond dimension \(D\), there are nonzero blocks
-    \(C_k\) and positive real weights \(\mu_k\) such that each block is in the
+    For any MPS tensor $A$ of bond dimension $D$, there are nonzero blocks
+    $C_k$ and positive real weights $\mu_k$ such that each block is in the
     unital orientation,
     \[
         \sum_i C_k^i(C_k^i)^\dagger=\Id,
@@ -1766,36 +1766,36 @@ structure for completeness.
         \sum_i (C_k^i)^\dagger\Lambda_k C_k^i=\Lambda_k .
     \]
     Moreover, for
-    every chain length \(N>0\) and word
-    \(\sigma\in\{0,\ldots,d-1\}^N\),
+    every chain length $N>0$ and word
+    $\sigma\in\{0,\ldots,d-1\}^N$,
     \[
         \operatorname{MPV}_A(\sigma)
         =
         \operatorname{MPV}_{\bigoplus_k \mu_k C_k}(\sigma),
     \]
-    and the nonzero block dimensions satisfy \(\sum_k D_k\leq D\).
+    and the nonzero block dimensions satisfy $\sum_k D_k\leq D$.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}
     Apply Theorem~\ref{thm:pgvwc07_arbitrary_zero_tail_unital_dual_bond_dim_bound}.
     The all-zero summand contributes zero to every positive-length coefficient,
-    so it may be omitted from the displayed MPV identity for \(N>0\).  The
-    bound \(\sum_k D_k\leq D\) is one of the conclusions of that theorem.
+    so it may be omitted from the displayed MPV identity for $N>0$.  The
+    bound $\sum_k D_k\leq D$ is one of the conclusions of that theorem.
 \end{proof}
 
 \begin{definition}[Positive-length PGVWC07 canonical-form witness]%
     \label{def:pgvwc07_positive_length_witness}
     \lean{MPSTensor.PGVWC07PositiveLengthWitness}
     \leanok
-    A positive-length PGVWC07 canonical-form witness for an MPS tensor \(A\)
+    A positive-length PGVWC07 canonical-form witness for an MPS tensor $A$
     consists of a finite family of nonzero unital blocks, positive real
     weights, diagonal positive-definite dual fixed points, scalar fixed-point
     conclusions, positive block dimensions, positive-length MPV equality with
-    \(A\), and the total bond-dimension bound \(\sum_k D_k\leq D\).
+    $A$, and the total bond-dimension bound $\sum_k D_k\leq D$.
 
     This definition records the exact-MPV, nonempty-ring part of the PGVWC07
     construction.  It still does not include the source theorem's upper
-    normalization \(1\geq\lambda_k\), which depends on the global
+    normalization $1\geq\lambda_k$, which depends on the global
     spectral-radius normalization convention of
     \cite[Theorem~Th:TIcanonical, lines~765--766]{PerezGarcia2007Matrix}.
 \end{definition}
@@ -1807,10 +1807,10 @@ structure for completeness.
     \uses{def:pgvwc07_positive_length_witness}
     Let a positive-length PGVWC07 canonical-form witness have at least one
     nonzero block.  Then its positive real weights may be divided by their
-    largest value so that the new weights \(\nu_k\) are positive,
-    \(|\nu_k|\leq 1\) for all \(k\), and \(|\nu_{k_0}|=1\) for at least one
-    block \(k_0\).  If the original weights are \(\mu_k=s\nu_k\) with
-    \(s>0\), then for every chain length \(N>0\),
+    largest value so that the new weights $\nu_k$ are positive,
+    $|\nu_k|\leq 1$ for all $k$, and $|\nu_{k_0}|=1$ for at least one
+    block $k_0$.  If the original weights are $\mu_k=s\nu_k$ with
+    $s>0$, then for every chain length $N>0$,
     \[
         \operatorname{MPV}_A(\sigma)
         =
@@ -1824,9 +1824,9 @@ structure for completeness.
 \begin{proof}\leanok
     \uses{def:pgvwc07_positive_length_witness,
         lem:mpv_to_tensor_from_blocks_weight_mul_left}
-    Choose the largest positive real weight \(s\).  Dividing every weight by
-    \(s\) gives positive weights bounded above by \(1\), and a block attaining
-    the maximum has normalized weight \(1\).  The MPV identity follows from
+    Choose the largest positive real weight $s$.  Dividing every weight by
+    $s$ gives positive weights bounded above by $1$, and a block attaining
+    the maximum has normalized weight $1$.  The MPV identity follows from
     Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left}.
 \end{proof}
 
@@ -1913,17 +1913,17 @@ structure for completeness.
     \uses{thm:pgvwc07_positive_length_witness,
         lem:pgvwc07_positive_length_witness_nonempty_of_nonzero_mpv,
         thm:pgvwc07_positive_length_witness_weight_normalization}
-    Suppose that some positive-length MPV coefficient of an MPS tensor \(A\) is
-    nonzero.  Then there is a positive scalar \(s\) and a nonempty finite family
-    of PGVWC07 blocks \(C_k\) with positive normalized weights \(\nu_k\)
-    satisfying \(|\nu_k|\leq 1\) for all \(k\) and
-    \(|\nu_{k_0}|=1\) for some block \(k_0\).  Each block is in the unital
+    Suppose that some positive-length MPV coefficient of an MPS tensor $A$ is
+    nonzero.  Then there is a positive scalar $s$ and a nonempty finite family
+    of PGVWC07 blocks $C_k$ with positive normalized weights $\nu_k$
+    satisfying $|\nu_k|\leq 1$ for all $k$ and
+    $|\nu_{k_0}|=1$ for some block $k_0$.  Each block is in the unital
     orientation, has only scalar fixed points for its transfer map, and has a
     diagonal positive-definite fixed point for the dual transfer map.  Each
     block has positive bond dimension.  Moreover the globally rescaled tensor
-    \(s^{-1}A\) and the normalized weighted block tensor have the same
+    $s^{-1}A$ and the normalized weighted block tensor have the same
     positive-length MPV coefficients, and the block dimensions satisfy
-    \(\sum_k D_k\leq D\).
+    $\sum_k D_k\leq D$.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:pgvwc07_positive_length_witness,
@@ -1932,9 +1932,9 @@ structure for completeness.
         lem:mpv_smul}
     Start from the positive-length witness and use the nonzero coefficient to
     make the block family nonempty.  Divide the positive weights by their
-    maximum.  The exact coefficient identity for \(A\) contains the global
-    factor \(s^N\) at length \(N\); applying the scalar rescaling \(s^{-1}\) to
-    every matrix of \(A\) contributes the factor \(s^{-N}\), so the two factors
+    maximum.  The exact coefficient identity for $A$ contains the global
+    factor $s^N$ at length $N$; applying the scalar rescaling $s^{-1}$ to
+    every matrix of $A$ contributes the factor $s^{-N}$, so the two factors
     cancel at every positive length.
 \end{proof}
 
@@ -1943,8 +1943,8 @@ structure for completeness.
     \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero}
     \leanok
     \uses{thm:pgvwc07_nonzero_normalized_exact_rescaled_form}
-    For every MPS tensor \(A\), either every positive-length MPV coefficient of
-    \(A\) is zero, or the exact rescaled normalized PGVWC07 form of
+    For every MPS tensor $A$, either every positive-length MPV coefficient of
+    $A$ is zero, or the exact rescaled normalized PGVWC07 form of
     Theorem~\ref{thm:pgvwc07_nonzero_normalized_exact_rescaled_form} exists.
 \end{theorem}
 \begin{proof}\leanok
@@ -1960,7 +1960,7 @@ structure for completeness.
     \leanok
     \uses{def:pgvwc07_positive_length_witness,
         thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
-    For every MPS tensor \(A\), the conclusions of
+    For every MPS tensor $A$, the conclusions of
     Theorem~\ref{thm:pgvwc07_arbitrary_positive_length_unital_dual_bond_dim_bound}
     give a positive-length PGVWC07 canonical-form witness.
 \end{theorem}

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -187,11 +187,11 @@ The following compatibility theorems are proved in the present chapter.
 
 \subsection{The \texorpdfstring{$Z$}{Z}-gauge degree of freedom}
 
-\begin{definition}[Entrywise periodic \(Z\)-gauge ratio]\label{def:z_gauge_entry}
+\begin{definition}[Entrywise periodic $Z$-gauge ratio]\label{def:z_gauge_entry}
     \lean{MPSTensor.zGaugeEntry}
     \leanok
     Given complex weights $\mu,\nu$, define the entrywise
-    \(Z\)-gauge ratio by
+    $Z$-gauge ratio by
     \[
         z(\mu,\nu) := \mu/\nu.
     \]
@@ -217,7 +217,7 @@ The following compatibility theorems are proved in the present chapter.
     \]
 \end{lemma}
 
-\begin{definition}[Diagonal periodic \(Z\)-gauge matrix]\label{def:z_gauge_diagonal}
+\begin{definition}[Diagonal periodic $Z$-gauge matrix]\label{def:z_gauge_diagonal}
     \lean{MPSTensor.zGaugeDiagonal}
     \leanok
     \uses{def:z_gauge_entry}
@@ -228,7 +228,7 @@ The following compatibility theorems are proved in the present chapter.
     \]
 \end{definition}
 
-\begin{lemma}[Diagonal \(Z\)-gauge has finite order under matched powers]%
+\begin{lemma}[Diagonal $Z$-gauge has finite order under matched powers]%
     \label{lem:z_gauge_diagonal_pow}
     \lean{MPSTensor.zGaugeDiagonal_pow_eq_one}
     \leanok
@@ -239,7 +239,7 @@ The following compatibility theorems are proved in the present chapter.
     \]
 \end{lemma}
 
-\begin{lemma}[Diagonal \(Z\)-gauge transports diagonal weights]\label{lem:z_gauge_diagonal_mul}
+\begin{lemma}[Diagonal $Z$-gauge transports diagonal weights]\label{lem:z_gauge_diagonal_mul}
     \lean{MPSTensor.zGaugeDiagonal_mul_diagonal}
     \leanok
     \uses{def:z_gauge_diagonal, lem:z_gauge_entry_mul}
@@ -437,10 +437,10 @@ unconditional result.
     transfer map with the sector adjoint transfer map on the corner of~$P_k$.
     This is the inverse cyclic indexing of the off-diagonal convention in
     \cite[Appendix~A]{DeLasCuevas2017Irreducible}.  There the same adjoint
-    transfer map is written \(E^*\), and the source projectors satisfy
-    \(E^*(P_u)=P_{u+1}\) together with
-    \(A^i=\sum_u P_u A^i P_{u+1}\).  Here \(P_k\) corresponds to the source
-    sector \(u=-k \pmod m\), which turns the source shift into the displayed
+    transfer map is written $E^*$, and the source projectors satisfy
+    $E^*(P_u)=P_{u+1}$ together with
+    $A^i=\sum_u P_u A^i P_{u+1}$.  Here $P_k$ corresponds to the source
+    sector $u=-k \pmod m$, which turns the source shift into the displayed
     adjoint-transfer relation.
 \end{definition}
 
@@ -497,35 +497,49 @@ unconditional result.
         thm:overlap_decay_irr_tp,
         thm:overlap_decay_rect_irr_tp}
     Write the period-blocked tensors as
-    \[
-        \bar A \sim \bigoplus_{u\in\mathbb Z_m} A_u,\qquad
-        \bar B \sim \bigoplus_{v\in\mathbb Z_m} B_v ,
-    \]
-    with unit sector weights. For every length $N$,
+    $\bar A \sim \bigoplus_{u\in\mathbb Z_m} A_u$ and
+    $\bar B \sim \bigoplus_{v\in\mathbb Z_m} B_v$, with unit sector weights.
+    For every length $N$,
     \[
         O_{\bar A,\bar B}(N)
         =
         \sum_{u\in\mathbb Z_m}\sum_{v\in\mathbb Z_m}
             O_{A_u,B_v}(N).
     \]
-    If no pair $(u,v)$ is gauge-phase equivalent, then for every $u,v$
-    the normal-tensor dichotomy gives $O_{A_u,B_v}(N)\to0$.
-    Hence the finite double sum gives $O_{\bar A,\bar B}(N)\to 0$.
+    The no-matching hypothesis is
+    $A_u \not\sim_{\mathrm{gp}} B_v$ for all $u,v\in\mathbb Z_m$. By the
+    normal-tensor overlap dichotomy,
+    $\lim_{N\to\infty} O_{A_u,B_v}(N)=0$ for every $u,v$.
+    Hence
+    \[
+        \lim_{N\to\infty} O_{\bar A,\bar B}(N)
+        =
+        \sum_{u\in\mathbb Z_m}\sum_{v\in\mathbb Z_m}
+            \lim_{N\to\infty} O_{A_u,B_v}(N)
+        =0 .
+    \]
 
-    This decay is incompatible with a hypothetical global gauge-phase
-    equivalence. If $A$ and $B$ were gauge-phase equivalent, then
-    $\bar A$ and $\bar B$ would be gauge-phase equivalent. Thus
-    $V_N(\bar B)=\zeta^N X V_N(\bar A)X^{-1}$ at the virtual level, and
+    Suppose, to the contrary, that $A\sim_{\mathrm{gp}} B$. Blocking preserves
+    gauge-phase equivalence, so $\bar A\sim_{\mathrm{gp}}\bar B$. Thus, for
+    some invertible $X$ and some $\zeta\ne0$,
+    $V_N(\bar B)=\zeta^N X V_N(\bar A)X^{-1}$.
+    Gauge cancellation in the trace pairing gives
     \[
         O_{\bar A,\bar B}(N)
         =
-        \overline{\zeta}^{\,N} O_{\bar A,\bar A}(N).
+        \overline{\zeta}^{\,N} O_{\bar A,\bar A}(N),
+        \qquad
+        O_{\bar B,\bar B}(N)
+        =
+        |\zeta|^{2N} O_{\bar A,\bar A}(N).
     \]
-    The periodic self-overlap limits $O_{\bar A,\bar A}(N)\to m$ and
-    $O_{\bar B,\bar B}(N)\to m$ imply $|\zeta|=1$, and the displayed
-    identity cannot tend to zero. This contradiction proves that $A$ and
-    $B$ are not gauge-phase equivalent. The irreducible trace-preserving
-    overlap dichotomy then yields $O_{A,B}(N)\to0$.
+    Since $O_{\bar A,\bar A}(N)\to m$ and
+    $O_{\bar B,\bar B}(N)\to m$ with $m>0$, the second identity forces
+    $|\zeta|=1$. Therefore
+    $|O_{\bar A,\bar B}(N)|=O_{\bar A,\bar A}(N)\to m\ne0$, contradicting
+    $\lim_N O_{\bar A,\bar B}(N)=0$. Hence
+    $A\not\sim_{\mathrm{gp}}B$, and the irreducible trace-preserving overlap
+    dichotomy gives $O_{A,B}(N)\to0$.
 \end{proof}
 
 \begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -245,14 +245,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp}
     \leanok
     \uses{def:peps_localTensorMap, def:peps_localLeftInverse}
-    For a physical operator \(O\) on the local physical space at \(v\), define
+    For a physical operator $O$ on the local physical space at $v$, define
     its virtual pullback by
     \[
         \Psi_v \circ O \circ \Phi_v .
     \]
     This is the local injectivity step used in the
-    \(O_1,O_2\mapsto W\) direction of
-    Lemma~\(\mathrm{inj\_isomorph}\) in
+    $O_1,O_2\mapsto W$ direction of
+    Lemma~$\mathrm{inj\_isomorph}$ in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{definition}
 
@@ -263,13 +263,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_localVirtualOpOfPhysicalOp,
         def:peps_physRealizeLocalOp,
         def:peps_localProjector}
-    For every coefficient function \(c\), applying the local tensor map after
-    the virtual pullback gives the projection of \(O(\Phi_v(c))\) onto the
-    image of \(\Phi_v\).
+    For every coefficient function $c$, applying the local tensor map after
+    the virtual pullback gives the projection of $O(\Phi_v(c))$ onto the
+    image of $\Phi_v$.
 \end{theorem}
 \begin{proof}\leanok
     Expand the definitions. The chosen left inverse gives
-    \(\Psi_v\Phi_v=\Id\), and the remaining map is the local projector.
+    $\Psi_v\Phi_v=\Id$, and the remaining map is the local projector.
 \end{proof}
 
 \begin{theorem}[Virtual pullback for image-preserving physical actions]%
@@ -277,9 +277,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.localVirtualOpOfPhysicalOp_realizes_of_projector}
     \leanok
     \uses{thm:peps_localVirtualOpOfPhysicalOp_spec}
-    If \(O\) sends every vector in the image of \(\Phi_v\) back into that image,
-    then its virtual pullback realizes exactly the action of \(O\) on
-    \(\Phi_v(c)\).
+    If $O$ sends every vector in the image of $\Phi_v$ back into that image,
+    then its virtual pullback realizes exactly the action of $O$ on
+    $\Phi_v(c)$.
 \end{theorem}
 \begin{proof}\leanok
     Use the preceding theorem and the image-preservation hypothesis.
@@ -291,8 +291,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:IsVertexInjective,
         thm:peps_localVirtualOpOfPhysicalOp_spec}
-    If a physical operator \(O\) realizes a virtual operation \(T\) on every
-    vector in the image of \(\Phi_v\), then pulling back \(O\) recovers \(T\).
+    If a physical operator $O$ realizes a virtual operation $T$ on every
+    vector in the image of $\Phi_v$, then pulling back $O$ recovers $T$.
 \end{theorem}
 \begin{proof}\leanok
     After applying the local tensor map, both virtual operations have the same
@@ -344,9 +344,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_physRealizeLocalOp,
         def:peps_localVirtualOpOfPhysicalOp,
         def:peps_localProjector}
-    Let \(P_v=\Phi_v\circ\Psi_v\) be the local projector, and let
-    \(T_O=\Psi_v\circ O\circ\Phi_v\) be the virtual pullback of a physical
-    operator \(O\). Then
+    Let $P_v=\Phi_v\circ\Psi_v$ be the local projector, and let
+    $T_O=\Psi_v\circ O\circ\Phi_v$ be the virtual pullback of a physical
+    operator $O$. Then
     \[
         \Phi_v\circ T_O\circ\Psi_v
         = P_v\circ O\circ P_v .
@@ -363,13 +363,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{thm:peps_physRealizeLocalOp_injective,
         thm:peps_physRealizeLocalOp_localVirtualOpOfPhysicalOp}
-    Suppose that the compressed physical action \(P_v O P_v\) agrees with the
-    canonical physical realization of a virtual operation \(T\). Then the
-    virtual pullback of \(O\) is \(T\).
+    Suppose that the compressed physical action $P_v O P_v$ agrees with the
+    canonical physical realization of a virtual operation $T$. Then the
+    virtual pullback of $O$ is $T$.
 \end{theorem}
 \begin{proof}\leanok
-    The physical realization of the virtual pullback of \(O\) is
-    \(P_v O P_v\).  By hypothesis this is the physical realization of \(T\).
+    The physical realization of the virtual pullback of $O$ is
+    $P_v O P_v$.  By hypothesis this is the physical realization of $T$.
     Injectivity of the canonical physical realization gives equality of the
     virtual operations.
 \end{proof}
@@ -380,9 +380,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{thm:peps_physRealizeLocalOp_localVirtualOpOfPhysicalOp,
         thm:peps_localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}
-    The compressed physical action \(P_v O P_v\) is the canonical physical
-    realization of a virtual operation \(T\) if and only if the virtual
-    pullback of \(O\) is \(T\).
+    The compressed physical action $P_v O P_v$ is the canonical physical
+    realization of a virtual operation $T$ if and only if the virtual
+    pullback of $O$ is $T$.
 \end{theorem}
 \begin{proof}\leanok
     One implication follows by realizing both virtual operations physically and
@@ -681,8 +681,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.edgeMiddlePhysicalConfigOf}
     \leanok
     \uses{def:peps_edgeMiddleVertices}
-    For an edge \(e=(u,v)\), the middle physical configurations are the
-    physical indices on the vertices in \(V\setminus\{u,v\}\). A global
+    For an edge $e=(u,v)$, the middle physical configurations are the
+    physical indices on the vertices in $V\setminus\{u,v\}$. A global
     physical configuration restricts to such a middle configuration.
 \end{definition}
 
@@ -711,7 +711,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     middle physical configuration.
 \end{theorem}
 \begin{proof}\leanok
-    Rewrite the product over \(V\setminus\{u,v\}\) as the product over the
+    Rewrite the product over $V\setminus\{u,v\}$ as the product over the
     corresponding finite set of middle vertices.
 \end{proof}
 
@@ -947,7 +947,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         def:peps_edgeMiddleTensorFamily}
     A comparison from finite-region injectivity to the edge-middle tensor
     records the following assertion: if the middle vertex region
-    \(V\setminus\{u,v\}\) is injective after blocking, then the middle tensor
+    $V\setminus\{u,v\}$ is injective after blocking, then the middle tensor
     in the edge-blocked three-site chain is injective. This isolates the
     finite-region contraction claim in
     \cite[Section~3]{Molnar2018NormalPEPS}.
@@ -987,11 +987,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
         def:peps_edgeMiddleRegionInjectivityComparison,
         thm:peps_edgeBlockedThreeSiteInjective_of_middle}
-    Suppose the middle region \(V\setminus\{u,v\}\) is injective after
+    Suppose the middle region $V\setminus\{u,v\}$ is injective after
     blocking, and suppose this region-injectivity assertion has been identified
     with injectivity of the corresponding edge-middle tensor family. Then a
     vertex-injective PEPS tensor gives an injective edge-blocked three-site
-    chain at the edge \(e=(u,v)\).
+    chain at the edge $e=(u,v)$.
 \end{theorem}
 \begin{proof}\leanok
     The comparison gives injectivity of the middle tensor. The previous reduction
@@ -1003,11 +1003,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \notready
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
         thm:peps_edgeBlockedThreeSiteInjective_of_region}
-    If \(A\) is vertex-injective, then for every edge \(e=(u,v)\), the two
+    If $A$ is vertex-injective, then for every edge $e=(u,v)$, the two
     endpoint tensors together with the tensor obtained by blocking all vertices
-    outside \(u\) and \(v\) form an injective three-site MPS. This is the
+    outside $u$ and $v$ form an injective three-site MPS. This is the
     precise assertion after the diagram
-    \(\textup{eq:block\_to\_mps}\) in
+    $\textup{eq:block\_to\_mps}$ in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
@@ -1017,9 +1017,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:IsVertexInjective, def:peps_localIncidentMatrixOp,
         thm:peps_localIncidentMatrixOp_physicalRealization}
-    Let \(A\) be vertex-injective and let \(e=(u,v)\) be an edge. For every
-    matrix \(M\) on the bond space of \(e\), the one-leg virtual action induced
-    by \(M\) on the local tensor at \(u\), and likewise at \(v\), is realized by
+    Let $A$ be vertex-injective and let $e=(u,v)$ be an edge. For every
+    matrix $M$ on the bond space of $e$, the one-leg virtual action induced
+    by $M$ on the local tensor at $u$, and likewise at $v$, is realized by
     a physical operator on that endpoint's physical space.
     \begin{center}
         \TNPEPSInsertionPhysicalRealization
@@ -1041,14 +1041,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{thm:peps_localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq,
         def:peps_localIncidentMatrixOp}
-    Let \(e=(u,v)\). A physical operator at the left endpoint pulls back to
-    the one-edge virtual action of \(M^{\mathsf T}\) if and only if its
+    Let $e=(u,v)$. A physical operator at the left endpoint pulls back to
+    the one-edge virtual action of $M^{\mathsf T}$ if and only if its
     compressed physical action is the canonical realization of that
     one-edge virtual action.
 \end{theorem}
 \begin{proof}\leanok
     This is the projected local recovery equivalence applied to the left
-    incident edge of \(e\), with the transpose convention used by the
+    incident edge of $e$, with the transpose convention used by the
     left-endpoint coefficient identity.
 \end{proof}
 
@@ -1058,13 +1058,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{thm:peps_localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq,
         def:peps_localIncidentMatrixOp}
-    Let \(e=(u,v)\). A physical operator at the right endpoint pulls back to
-    the one-edge virtual action of \(M\) if and only if its compressed physical
+    Let $e=(u,v)$. A physical operator at the right endpoint pulls back to
+    the one-edge virtual action of $M$ if and only if its compressed physical
     action is the canonical realization of that one-edge virtual action.
 \end{theorem}
 \begin{proof}\leanok
     This is the projected local recovery equivalence applied to the right
-    incident edge of \(e\).
+    incident edge of $e$.
 \end{proof}
 
 \begin{theorem}[Right-endpoint physical realization of the inserted coefficient]%
@@ -1137,8 +1137,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \begin{center}
         \TNPEPSPhysicalToVirtualInsertion
     \end{center}
-    This is the \(O_1,O_2\mapsto W\) step in the proof of
-    Lemma~\(\mathrm{inj\_isomorph}\).
+    This is the $O_1,O_2\mapsto W$ step in the proof of
+    Lemma~$\mathrm{inj\_isomorph}$.
 \end{theorem}
 
 \begin{theorem}[Edge-blocked insertion algebra isomorphism]%
@@ -1151,9 +1151,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
         thm:peps_sameState_edgeBlockedCoeff_eq, def:peps_edgeInsertedCoeff}
     Applying the three-site injective-chain theorem to the edge-blocked MPS
     gives an algebra isomorphism between matrix insertions on the chosen edge in
-    the two PEPS tensors. Equivalently, for every matrix \(X\) inserted on that
+    the two PEPS tensors. Equivalently, for every matrix $X$ inserted on that
     edge for the first tensor family, there is a uniquely determined matrix
-    \(Y\) inserted on the corresponding edge for the second tensor family that
+    $Y$ inserted on the corresponding edge for the second tensor family that
     gives the same edge-blocked state:
     \begin{center}
         \TNPEPSThreeSiteInsertionComparison
@@ -1167,10 +1167,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The insertion correspondence obtained from the three-site injective-chain
     theorem is an isomorphism between full matrix algebras on the chosen bond.
     Hence the two bond dimensions on that edge are equal, and the isomorphism is
-    realized by conjugation with an invertible edge matrix \(Z_e\):
-    \(Y=Z_e X Z_e^{-1}\). The matrix \(Z_e\) is unique up to multiplication by
+    realized by conjugation with an invertible edge matrix $Z_e$:
+    $Y=Z_e X Z_e^{-1}$. The matrix $Z_e$ is unique up to multiplication by
     a nonzero scalar. This is the finite-dimensional matrix-algebra step used in
-    \cite[Section~3]{Molnar2018NormalPEPS} after Lemma~\(\mathrm{inj\_isomorph}\).
+    \cite[Section~3]{Molnar2018NormalPEPS} after Lemma~$\mathrm{inj\_isomorph}$.
 \end{theorem}
 
 \begin{definition}[Factorized local gauge datum]%
@@ -1218,8 +1218,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{thm:peps_edgeGaugeFromInsertionAlgebraIsomorphism, def:gaugeVertex}
     The edge gauges obtained by applying the three-site injective-chain theorem
     at each edge can be absorbed into the tensors of the second family. At a
-    vertex \(v\), each incident edge contributes the appropriate oriented gauge
-    or inverse gauge, producing the modified tensor \(\widetilde B_v\):
+    vertex $v$, each incident edge contributes the appropriate oriented gauge
+    or inverse gauge, producing the modified tensor $\widetilde B_v$:
     \begin{center}
         \TNPEPSEdgeGaugeAbsorption
     \end{center}
@@ -1232,14 +1232,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \notready
     \uses{thm:peps_edgeGaugeAbsorption, def:peps_edgeInsertedCoeff}
     After the edge gauges have been absorbed into the second tensor family, for
-    every edge and every matrix \(X\), inserting \(X\) on that edge in the first
-    PEPS gives the same state as inserting \(X\) on the same edge in the
+    every edge and every matrix $X$, inserting $X$ on that edge in the first
+    PEPS gives the same state as inserting $X$ on the same edge in the
     modified second PEPS:
     \begin{center}
         \TNPEPSEdgeInsertionEquality
     \end{center}
     This is the blueprint form of the displayed equation
-    \(\textup{eq:inj\_equal\_edge}\) in
+    $\textup{eq:inj\_equal\_edge}$ in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
@@ -1296,13 +1296,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     cancellation diagram is the converse contracted identity: inserting
     opposite endpoint actions on an internal edge leaves the PEPS coefficient
     unchanged. The edge-gauge absorption diagram records the formation of
-    \(\widetilde B\) before the post-absorption insertion equality. The
+    $\widetilde B$ before the post-absorption insertion equality. The
     local-extraction diagram summarizes the comparison of
     one-site-enlarged injective regions with injective complements, after the
     edge gauges have been absorbed into $\tilde{B}$. The global-consistency
     diagram summarizes repeating the edge blocking over all edges, so the two
     endpoint actions on a shared edge are one edge gauge. The
-    two-injective-tensor diagram records Lemma~\(\mathrm{inj\_equal\_tensors\_2}\)
+    two-injective-tensor diagram records Lemma~$\mathrm{inj\_equal\_tensors\_2}$
     from the paper, and the final one-vertex-complement diagram records its
     application to one vertex and its complement. These pictures use the
     blueprint tensor-dot convention, but each one is attached to the same
@@ -1331,23 +1331,23 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \]
     force the residual virtual operators to be scalar multiples of the
     identity. This is the scalar step in the proof of
-    Lemma~\(\mathrm{inj\_equal\_tensors\_2}\).
+    Lemma~$\mathrm{inj\_equal\_tensors\_2}$.
 \end{theorem}
 
 \begin{theorem}[Generalized two-injective-tensor comparison]%
     \label{thm:peps_twoInjectiveTensorInsertionComparison}
     \notready
     \uses{def:IsVertexInjective, thm:peps_twoInjectiveGaugeScalarReduction}
-    Let \(A_1,A_2,B_1,B_2\) be injective tensors with the same virtual boundary
-    spaces. Suppose that inserting an arbitrary matrix \(X\) on any shared
-    virtual bond gives the same two-tensor state for the \(A\)-pair and the
-    \(B\)-pair:
+    Let $A_1,A_2,B_1,B_2$ be injective tensors with the same virtual boundary
+    spaces. Suppose that inserting an arbitrary matrix $X$ on any shared
+    virtual bond gives the same two-tensor state for the $A$-pair and the
+    $B$-pair:
     \begin{center}
         \TNPEPSTwoInjectiveTensorInsertionComparison
     \end{center}
-    Then there is a nonzero scalar \(\lambda\) such that
-    \(A_1=\lambda B_1\) and \(A_2=\lambda^{-1}B_2\). This is the blueprint
-    form of Lemma~\(\mathrm{inj\_equal\_tensors\_2}\) in
+    Then there is a nonzero scalar $\lambda$ such that
+    $A_1=\lambda B_1$ and $A_2=\lambda^{-1}B_2$. This is the blueprint
+    form of Lemma~$\mathrm{inj\_equal\_tensors\_2}$ in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
@@ -1357,14 +1357,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:IsVertexInjective, thm:peps_postAbsorptionEdgeInsertionEquality,
         thm:peps_twoInjectiveTensorInsertionComparison}
     After the edge gauges have been absorbed into the second tensor family,
-    the paper blocks one vertex \(v\) against its injective complement. Applying
+    the paper blocks one vertex $v$ against its injective complement. Applying
     the generalized two-injective-tensor comparison to two regions that differ
-    by exactly this vertex gives \(A_v\propto \widetilde B_v\):
+    by exactly this vertex gives $A_v\propto \widetilde B_v$:
     \begin{center}
         \TNPEPSOneVertexComplementComparison
     \end{center}
     This is the final local comparison following the equation
-    \(\textup{eq:inj\_equal\_edge}\) in
+    $\textup{eq:inj\_equal\_edge}$ in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
@@ -1511,8 +1511,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_regionUnionDecomposition_disjoint}
     If two regions of a PEPS are injective, then their union is injective.
     The proof in \cite[Section~3]{Molnar2018NormalPEPS} blocks the network into
-    four parts \(A\setminus B\), \(A\cap B\), \(B\setminus A\), and
-    \((A\cup B)^c\), and applies the two available left inverses in sequence:
+    four parts $A\setminus B$, $A\cap B$, $B\setminus A$, and
+    $(A\cup B)^c$, and applies the two available left inverses in sequence:
     \begin{center}
         \TNTikZDiagram{TNPEPSInjectiveRegionUnion}{%
             \begin{tikzpicture}[tn picture]
@@ -1544,7 +1544,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     A region-injectivity hypothesis assigns to each finite vertex region the
     assertion that the tensor obtained by blocking that region is injective.
-    This predicate is used for regions such as \(R\), \(S\), \(T\), and their
+    This predicate is used for regions such as $R$, $S$, $T$, and their
     complements in the normal PEPS proof.  The union-closure hypothesis records
     the conclusion supplied by the source union-of-injective-regions lemma:
     the union of two injective regions is injective.
@@ -1650,16 +1650,16 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Contiguous coordinate rectangles are products of contiguous coordinate
     intervals, and the contiguous $2\times3$ and $3\times2$ predicates name the
     rectangular blocks used in the normal square-lattice theorem.  The
-    displayed region \(R\) is the union of a \(2\times3\) contiguous rectangle
-    with the \(3\times2\) contiguous rectangle occupying its upper two rows and
-    extending one column to the right.  The displayed region \(S\) is the union
-    of two \(2\times3\) contiguous rectangles shifted by one horizontal
-    coordinate, hence the full \(3\times3\) square spanned by them.  The
-    displayed local-window model for \(T\) is the complement, inside a local
-    \(5\times6\) coordinate window, of the vertical \(2\times3\) edge block
-    and the horizontal \(3\times2\) edge block shown in the source picture.
+    displayed region $R$ is the union of a $2\times3$ contiguous rectangle
+    with the $3\times2$ contiguous rectangle occupying its upper two rows and
+    extending one column to the right.  The displayed region $S$ is the union
+    of two $2\times3$ contiguous rectangles shifted by one horizontal
+    coordinate, hence the full $3\times3$ square spanned by them.  The
+    displayed local-window model for $T$ is the complement, inside a local
+    $5\times6$ coordinate window, of the vertical $2\times3$ edge block
+    and the horizontal $3\times2$ edge block shown in the source picture.
     The finite-lattice complementary block is the whole finite square lattice
-    with those two edge blocks removed; this is the block denoted \(A_3\) in
+    with those two edge blocks removed; this is the block denoted $A_3$ in
     the proof of \cite[Theorem~3]{Molnar2018NormalPEPS}.
     % Maintainer note: injectivity of this finite-lattice complementary block
     % is not yet proved; this definition only names the region.
@@ -1686,16 +1686,16 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Membership in a coordinate rectangle is coordinatewise membership, the
     contiguous coordinate interval has the expected coordinate inequalities,
     membership in a contiguous coordinate rectangle is the conjunction of the
-    four bounding inequalities, and membership in \(R\) is the disjunction of
-    membership in the \(2\times3\) lower-left piece or in the shifted
-    \(3\times2\) upper piece.  Membership in \(S\) is the disjunction of
-    membership in the left \(2\times3\) piece or in the horizontally shifted
-    \(2\times3\) piece.  Membership in the local-window \(T\) region is
-    membership in the local \(5\times6\) window together with nonmembership in
+    four bounding inequalities, and membership in $R$ is the disjunction of
+    membership in the $2\times3$ lower-left piece or in the shifted
+    $3\times2$ upper piece.  Membership in $S$ is the disjunction of
+    membership in the left $2\times3$ piece or in the horizontally shifted
+    $2\times3$ piece.  Membership in the local-window $T$ region is
+    membership in the local $5\times6$ window together with nonmembership in
     the union of the two displayed edge blocks.  Bounded contiguous coordinate
-    rectangles of sizes \(2\times3\) and \(3\times2\) satisfy, respectively,
+    rectangles of sizes $2\times3$ and $3\times2$ satisfy, respectively,
     the predicates for
-    contiguous \(2\times3\) and contiguous \(3\times2\) square-lattice
+    contiguous $2\times3$ and contiguous $3\times2$ square-lattice
     rectangles.  The cardinality of a coordinate rectangle is the
     product of the two coordinate cardinalities, and the full coordinate
     rectangle is the whole finite vertex set.
@@ -1704,14 +1704,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The coordinate-rectangle statements follow from membership and cardinality
     identities for Cartesian products of finite coordinate sets.  The
     contiguous-rectangle statement then unfolds the two coordinate intervals.
-    The membership statements for \(R\), \(S\), and the two edge blocks removed
-    from \(T\) additionally unfold membership in a union of two such
-    rectangles, while membership in \(T\) also unfolds the set difference from
-    the local \(5\times6\) window.  The shape predicates follow by using the
+    The membership statements for $R$, $S$, and the two edge blocks removed
+    from $T$ additionally unfold membership in a union of two such
+    rectangles, while membership in $T$ also unfolds the set difference from
+    the local $5\times6$ window.  The shape predicates follow by using the
     displayed lower-left corners as witnesses.
 \end{proof}
 
-\begin{lemma}[The normal regions \(R\) and \(S\) are unions of contiguous
+\begin{lemma}[The normal regions $R$ and $S$ are unions of contiguous
     rectangles]%
     \label{lem:peps_normalSquareRegionRS_rectangular_decomposition}
     \lean{TNLean.PEPS.normalSquareRegionR_rectangular_decomposition}
@@ -1719,18 +1719,18 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_squareLatticeCoordinateRegions,
         lem:peps_squareLatticeCoordinateRegion_identities}
-    If the displayed \(3\times3\) window containing \(R\) and \(S\) lies in
-    the finite square lattice, then \(R\) is the union of a contiguous
-    \(2\times3\) rectangle and a contiguous \(3\times2\) rectangle, while
-    \(S\) is the union of two contiguous \(2\times3\) rectangles.
+    If the displayed $3\times3$ window containing $R$ and $S$ lies in
+    the finite square lattice, then $R$ is the union of a contiguous
+    $2\times3$ rectangle and a contiguous $3\times2$ rectangle, while
+    $S$ is the union of two contiguous $2\times3$ rectangles.
 \end{lemma}
 \begin{proof}\leanok
-    This is the defining description of \(R\) and \(S\), together with the
+    This is the defining description of $R$ and $S$, together with the
     coordinate bounds which make the displayed rectangles contiguous
-    \(2\times3\) and \(3\times2\) rectangles.
+    $2\times3$ and $3\times2$ rectangles.
 \end{proof}
 
-\begin{lemma}[The edge blocks removed from \(T\) are contiguous rectangles]%
+\begin{lemma}[The edge blocks removed from $T$ are contiguous rectangles]%
     \label{lem:peps_normalSquareRegionTHole_rectangular_decomposition}
     \lean{TNLean.PEPS.normalSquareRegionTVerticalBlock_rectangular}
     \lean{TNLean.PEPS.normalSquareRegionTHorizontalBlock_rectangular}
@@ -1738,9 +1738,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_squareLatticeCoordinateRegions,
         lem:peps_squareLatticeCoordinateRegion_identities}
-    If the two edge blocks cut out of the displayed \(T\)-region lie in the
+    If the two edge blocks cut out of the displayed $T$-region lie in the
     finite square lattice, then they are respectively a contiguous
-    \(2\times3\) rectangle and a contiguous \(3\times2\) rectangle.
+    $2\times3$ rectangle and a contiguous $3\times2$ rectangle.
 \end{lemma}
 \begin{proof}\leanok
     This is the defining description of the two removed edge blocks, together
@@ -1780,13 +1780,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_squareLatticeCoordinateRegion_identities}
     The finite-lattice complementary block around the edge is disjoint from
     the two displayed edge blocks, and its union with them is the full finite
-    square lattice.  The local-window \(T\) region is contained in this
+    square lattice.  The local-window $T$ region is contained in this
     finite-lattice complementary block.
 \end{lemma}
 \begin{proof}\leanok
     This is the set-theoretic complement of the two displayed edge blocks in
     the full finite square lattice.  The containment of the local-window
-    \(T\) region follows because its points also avoid the two removed edge
+    $T$ region follows because its points also avoid the two removed edge
     blocks.
 \end{proof}
 
@@ -1802,14 +1802,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareEdgeComplementRegion}
     A rectangular cover of a square-lattice region is a nonempty finite family
     of regions whose union is exactly the given region, and each member of the
-    family is a contiguous \(2\times3\) or \(3\times2\) rectangle.  The two
-    cases used in the proof are the cover of the local displayed \(T\)-region
-    and the cover of the finite-lattice complementary block \(A_3\).
+    family is a contiguous $2\times3$ or $3\times2$ rectangle.  The two
+    cases used in the proof are the cover of the local displayed $T$-region
+    and the cover of the finite-lattice complementary block $A_3$.
 \end{definition}
 % Maintainer note: this definition records sufficient coordinate criteria.
 % The concrete local T cover remains to be constructed.
 
-\begin{lemma}[The present local \(T\)-window and \(A_3\) cover obstructions]%
+\begin{lemma}[The present local $T$-window and $A_3$ cover obstructions]%
     \label{lem:peps_normalSquareRegionT_no_five_by_six_cover}
     \lean{TNLean.PEPS.not_squareLatticeRectangleCover_of_forced_points}
     \lean{TNLean.PEPS.not_normalSquareRegionT_rectangleCover_at_origin}
@@ -1823,28 +1823,28 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_normalSquareRectangleCover,
         lem:peps_normalSquareRegionT_window_complement}
-    The present origin-based local-window model for the displayed \(T\)-region
-    admits no nonempty finite cover by contained contiguous \(2\times3\) and
-    \(3\times2\) rectangles whenever the ambient lattice contains the
-    \(5\times6\) window.  The origin-based rotated local-window model used for
+    The present origin-based local-window model for the displayed $T$-region
+    admits no nonempty finite cover by contained contiguous $2\times3$ and
+    $3\times2$ rectangles whenever the ambient lattice contains the
+    $5\times6$ window.  The origin-based rotated local-window model used for
     vertical edges has the analogous obstruction whenever the ambient lattice
-    contains the \(6\times5\) window.  The normalized \(5\times6\) and
-    \(6\times5\) cases are recorded as corollaries.  The present origin-based
+    contains the $6\times5$ window.  The normalized $5\times6$ and
+    $6\times5$ cases are recorded as corollaries.  The present origin-based
     horizontal edge-complement model has the analogous obstruction whenever
-    the ambient lattice contains the \(5\times7\) frame; the normalized
-    \(5\times7\) case is again recorded as a corollary.  The present
+    the ambient lattice contains the $5\times7$ frame; the normalized
+    $5\times7$ case is again recorded as a corollary.  The present
     origin-based vertical edge-complement model has the corresponding
-    obstruction whenever the ambient lattice contains the \(7\times5\) frame;
-    the normalized \(7\times5\) case is recorded as a corollary.
+    obstruction whenever the ambient lattice contains the $7\times5$ frame;
+    the normalized $7\times5$ case is recorded as a corollary.
 \end{lemma}
 % Maintainer note: this is a local-model obstruction, not a statement of the
 % source theorem.  It records that the current coordinate model is not yet the
-% source cover needed for the \(T\)-injectivity sentence.
+% source cover needed for the $T$-injectivity sentence.
 \begin{proof}\leanok
-    The lower-left point of the local window belongs to the present \(T\)
-    model.  Any contiguous \(2\times3\) rectangle containing it also contains
+    The lower-left point of the local window belongs to the present $T$
+    model.  Any contiguous $2\times3$ rectangle containing it also contains
     a point of the removed vertical edge block, while any contiguous
-    \(3\times2\) rectangle containing it also contains a point of the removed
+    $3\times2$ rectangle containing it also contains a point of the removed
     horizontal edge block.  The rotated statement is the same coordinate
     argument with the two shapes interchanged.  The horizontal
     edge-complement statement uses the same lower-left point, and so does the
@@ -1861,7 +1861,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_regionInjectivityUnionClosure_finite}
     If a square-lattice region has a nonempty finite cover by contiguous
-    \(2\times3\) and \(3\times2\) rectangles, then rectangular injectivity and
+    $2\times3$ and $3\times2$ rectangles, then rectangular injectivity and
     finite union closure imply that the region is injective.
 \end{lemma}
 \begin{proof}\leanok
@@ -1869,23 +1869,23 @@ injective and normal PEPS, following Theorems~2 and~3 of
     finite union closure to the nonempty family.
 \end{proof}
 
-\begin{lemma}[The normal regions \(R\) and \(S\) differ in one site]%
+\begin{lemma}[The normal regions $R$ and $S$ differ in one site]%
     \label{lem:peps_normalSquareRegionR_regionS_difference}
     \lean{TNLean.PEPS.normalSquareRegionR_subset_regionS}
     \lean{TNLean.PEPS.mem_normalSquareRegionS_sdiff_regionR}
     \leanok
     \uses{def:peps_squareLatticeCoordinateRegions,
         lem:peps_squareLatticeCoordinateRegion_identities}
-    For the displayed regions \(R\) and \(S\) with the same lower-left corner,
-    \(R\) is contained in \(S\).  The difference \(S\setminus R\) is exactly
-    the lower-right site of the \(3\times3\) square: in coordinates, the site
+    For the displayed regions $R$ and $S$ with the same lower-left corner,
+    $R$ is contained in $S$.  The difference $S\setminus R$ is exactly
+    the lower-right site of the $3\times3$ square: in coordinates, the site
     one obtains by shifting two steps horizontally and zero steps vertically
     from the lower-left corner.
 \end{lemma}
 \begin{proof}\leanok
     Expand the two displayed unions.  The only point of the second
-    \(2\times3\) piece of \(S\) which is not already in the union defining
-    \(R\) is its lower-right point.
+    $2\times3$ piece of $S$ which is not already in the union defining
+    $R$ is its lower-right point.
 \end{proof}
 
 \begin{definition}[Normal rectangular injectivity hypotheses]%
@@ -1895,12 +1895,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_regionInjectivityData,
         def:peps_squareLatticeCoordinateRegions}
-    In the square-lattice normal theorem, every \(2\times 3\) and
-    \(3\times 2\) rectangular region is assumed injective.  The corresponding
+    In the square-lattice normal theorem, every $2\times 3$ and
+    $3\times 2$ rectangular region is assumed injective.  The corresponding
     abstract hypotheses specify which finite regions have these two shapes and
     assert injectivity for all of them.  In the coordinate square-lattice
     specialization, these two families are the contiguous coordinate
-    \(2\times 3\) and \(3\times 2\) rectangles.
+    $2\times 3$ and $3\times 2$ rectangles.
 \end{definition}
 
 \begin{lemma}[Coordinate rectangular injectivity gives abstract rectangular
@@ -1911,8 +1911,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_normalRectangleInjectivityHypotheses}
     The coordinate square-lattice rectangular injectivity hypotheses determine
     abstract rectangular injectivity hypotheses, with the two abstract
-    rectangular families taken to be the contiguous coordinate \(2\times 3\)
-    and \(3\times 2\) rectangles.
+    rectangular families taken to be the contiguous coordinate $2\times 3$
+    and $3\times 2$ rectangles.
 \end{lemma}
 \begin{proof}\leanok
     This is the direct specialization of the abstract rectangular families to
@@ -1927,15 +1927,15 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_squareLatticeCoordinateRegion_identities}
     Under the coordinate square-lattice rectangular injectivity hypotheses,
-    every bounded contiguous \(2\times3\) rectangle and every bounded
-    contiguous \(3\times2\) rectangle is injective.
+    every bounded contiguous $2\times3$ rectangle and every bounded
+    contiguous $3\times2$ rectangle is injective.
 \end{lemma}
 \begin{proof}\leanok
     This is the defining rectangular injectivity hypothesis applied to the
     coordinate witnesses for the two rectangle shapes.
 \end{proof}
 
-\begin{lemma}[Rectangular injectivity gives injective \(T\)-edge blocks]%
+\begin{lemma}[Rectangular injectivity gives injective $T$-edge blocks]%
     \label{lem:peps_normalSquareRegionT_edgeBlocks_injective}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.tVerticalBlock_injective}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.tHorizontalBlock_injective}
@@ -1962,7 +1962,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     one application of union closure to these two injective blocks.
 \end{proof}
 
-\begin{lemma}[Injectivity from a rectangular cover of the local \(T\)-region]%
+\begin{lemma}[Injectivity from a rectangular cover of the local $T$-region]%
     \label{lem:peps_normalSquareRegionT_injective_of_cover}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionT_injective_of_cover}
     \lean{TNLean.PEPS.NormalSquareVerticalRegionTRectangleCover}
@@ -1972,10 +1972,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
         def:peps_normalRectangleInjectivityHypotheses,
         lem:peps_normalSquareRectangleCover_injective,
         lem:peps_regionInjectivityUnionClosure_finite}
-    If the displayed local \(T\)-region has a nonempty finite cover by
-    contiguous \(2\times3\) and \(3\times2\) rectangles, then rectangular
-    injectivity and finite union closure imply that \(T\) is injective.  The
-    rotated vertical local \(T\)-region has the same conditional injectivity
+    If the displayed local $T$-region has a nonempty finite cover by
+    contiguous $2\times3$ and $3\times2$ rectangles, then rectangular
+    injectivity and finite union closure imply that $T$ is injective.  The
+    rotated vertical local $T$-region has the same conditional injectivity
     criterion.
 \end{lemma}
 % Maintainer note: this is still conditional; the concrete source cover is not
@@ -1996,32 +1996,32 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareRectangleCover_injective,
         lem:peps_regionInjectivityUnionClosure_finite,
         lem:peps_normalSquareEdgeComplementRegion_coverOfT}
-    If the finite-lattice complementary block \(A_3\) has a nonempty finite
-    cover by contiguous \(2\times3\) and \(3\times2\) rectangles, then
-    rectangular injectivity and finite union closure imply that \(A_3\) is
-    injective.  In the normalized horizontal-edge \(5\times7\) frame, it is
-    enough to give such a cover of the local \(T\)-region, since adjoining the
-    two top-collar \(3\times2\) rectangles gives a cover of \(A_3\).
+    If the finite-lattice complementary block $A_3$ has a nonempty finite
+    cover by contiguous $2\times3$ and $3\times2$ rectangles, then
+    rectangular injectivity and finite union closure imply that $A_3$ is
+    injective.  In the normalized horizontal-edge $5\times7$ frame, it is
+    enough to give such a cover of the local $T$-region, since adjoining the
+    two top-collar $3\times2$ rectangles gives a cover of $A_3$.
 \end{lemma}
 % Maintainer note: the concrete cover required by
 % \cite[Theorem~3]{Molnar2018NormalPEPS} remains to be constructed.
 \begin{proof}\leanok
     Apply rectangular injectivity to every rectangle in the cover, then apply
     finite union closure to the nonempty family.  For the normalized
-    \(5\times7\) edge complement, first extend the local \(T\)-cover by the
+    $5\times7$ edge complement, first extend the local $T$-cover by the
     two top-collar rectangles.
 \end{proof}
 
-\begin{lemma}[A cover of \(T\) extends to a cover of the edge complement]%
+\begin{lemma}[A cover of $T$ extends to a cover of the edge complement]%
     \label{lem:peps_normalSquareEdgeComplementRegion_coverOfT}
     \lean{TNLean.PEPS.normalSquareEdgeComplementRectangleCoverOfT}
     \leanok
     \uses{def:peps_normalSquareRectangleCover,
         lem:peps_normalSquareEdgeComplementRegion_topCollar}
-    In the normalized horizontal-edge \(5\times7\) frame, any rectangular cover
-    of the local \(T\)-region extends to a rectangular cover of the
-    edge-complementary block \(A_3\) by adjoining the two top-collar
-    contiguous \(3\times2\) rectangles.
+    In the normalized horizontal-edge $5\times7$ frame, any rectangular cover
+    of the local $T$-region extends to a rectangular cover of the
+    edge-complementary block $A_3$ by adjoining the two top-collar
+    contiguous $3\times2$ rectangles.
 \end{lemma}
 \begin{proof}\leanok
     Index the new cover by the old cover indices together with two extra
@@ -2047,16 +2047,16 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareRegionT_window_complement,
         def:peps_regionInjectivityData,
         lem:peps_squareLatticeRectangleInjectivity_rectangles}
-    In the normalized horizontal-edge \(5\times7\) frame, the finite-lattice
-    complementary block \(A_3\) is the local-window \(T\)-region together with
-    two top-collar contiguous \(3\times2\) rectangles.  Consequently, if the
-    local \(T\)-region is injective, then rectangular injectivity and union
-    closure imply that \(A_3\) is injective.  There is also a transposed
-    \(7\times5\) horizontal-frame collar identity, now using two contiguous
-    \(2\times3\) right-collar rectangles.  For the rotated vertical
+    In the normalized horizontal-edge $5\times7$ frame, the finite-lattice
+    complementary block $A_3$ is the local-window $T$-region together with
+    two top-collar contiguous $3\times2$ rectangles.  Consequently, if the
+    local $T$-region is injective, then rectangular injectivity and union
+    closure imply that $A_3$ is injective.  There is also a transposed
+    $7\times5$ horizontal-frame collar identity, now using two contiguous
+    $2\times3$ right-collar rectangles.  For the rotated vertical
     edge-blocking regions, the corresponding complement is the rotated local
-    \(T\)-region together with the same two right-collar rectangles; hence rotated
-    \(T\)-injectivity, and hence a rectangular cover of rotated \(T\), implies
+    $T$-region together with the same two right-collar rectangles; hence rotated
+    $T$-injectivity, and hence a rectangular cover of rotated $T$, implies
     injectivity of the vertical complementary block.
 \end{lemma}
 % Maintainer note: this still leaves local/rotated T-injectivity and the
@@ -2064,7 +2064,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     The two set identities follow by expanding the coordinate inequalities.
     The injectivity statements apply union closure first to the local
-    \(T\)-region and the first collar rectangle, and then to the second collar
+    $T$-region and the first collar rectangle, and then to the second collar
     rectangle.
 \end{proof}
 
@@ -2097,22 +2097,22 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareEdgeComplementRegion,
         lem:peps_normalSquareRegionT_edgeBlocks_injective,
         lem:peps_normalSquareEdgeComplementRegion_topCollar}
-    In the normalized \(5\times7\) horizontal-edge frame, the red block is the
-    vertical \(2\times3\) block, the blue block is the horizontal \(3\times2\)
+    In the normalized $5\times7$ horizontal-edge frame, the red block is the
+    vertical $2\times3$ block, the blue block is the horizontal $3\times2$
     block, and the complementary block is the finite-lattice edge complement
-    \(A_3\).  The distinguished edge is a horizontal edge of the square-lattice
+    $A_3$.  The distinguished edge is a horizontal edge of the square-lattice
     graph.  The left endpoint of the distinguished edge lies in the red block,
     the right endpoint lies in the blue block, the three regions are pairwise
     disjoint, and their union is the whole finite square lattice.
-    If the local \(T\)-region is injective, rectangular injectivity and union
+    If the local $T$-region is injective, rectangular injectivity and union
     closure give injectivity of all three blocks; in particular a rectangular
-    cover of \(T\) suffices.  The normalized \(7\times5\) vertical-edge frame
+    cover of $T$ suffices.  The normalized $7\times5$ vertical-edge frame
     has the analogous red and blue rectangular blocks, a distinguished vertical
     edge, and the same set-theoretic blocking data; at this stage its
     complementary-block injectivity is either kept as an explicit hypothesis or
     obtained from
-    rotated \(T\)-injectivity, and therefore from a rectangular cover of
-    rotated \(T\), by the vertical collar lemma.  In both cases the named
+    rotated $T$-injectivity, and therefore from a rectangular cover of
+    rotated $T$, by the vertical collar lemma.  In both cases the named
     blocking datum supplies the corresponding three injective regions for the
     edge-blocked chain.
 \end{lemma}
@@ -2123,9 +2123,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The endpoint memberships are coordinate checks.  Rectangular injectivity
     gives the rectangular red and blue blocks.  For the horizontal edge, the
     collar lemma gives the complement, and the rectangular cover criterion
-    removes the direct \(T\)-injectivity input when such a cover is supplied.
+    removes the direct $T$-injectivity input when such a cover is supplied.
     For the vertical edge, complement injectivity is an explicit input or is
-    obtained from the rotated \(T\)-cover.  The disjointness and cover
+    obtained from the rotated $T$-cover.  The disjointness and cover
     statements are finite-set complement identities.
 \end{proof}
 
@@ -2152,14 +2152,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     For any coordinate origin whose horizontal blocking window lies in the
     finite square lattice, there is a distinguished horizontal edge with the
     same relative position as in the normalized picture.  The translated red
-    region is the \(2\times3\) block, the translated blue region is the
-    \(3\times2\) block, and the complementary region is the finite-lattice
+    region is the $2\times3$ block, the translated blue region is the
+    $3\times2$ block, and the complementary region is the finite-lattice
     complement of their union.  If this complementary region is injective,
     these three regions form the one-edge blocking datum; if it has a
     rectangular cover, rectangular injectivity and union closure supply that
     complementary injectivity.  In both forms the datum supplies the three
     injective regions used in the edge-blocked chain.  The distinguished edge
-    is the corresponding coordinate right edge.  At coordinate origin \(0,0\),
+    is the corresponding coordinate right edge.  At coordinate origin $0,0$,
     the translated edge and the three translated regions specialize to the
     normalized horizontal picture.
 \end{lemma}
@@ -2193,14 +2193,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     For any coordinate origin whose vertical blocking window lies in the
     finite square lattice, there is a distinguished vertical edge with the same
     relative position as in the normalized vertical picture.  The translated
-    red region is the \(3\times2\) block, the translated blue region is the
-    \(2\times3\) block, and the complementary region is the finite-lattice
+    red region is the $3\times2$ block, the translated blue region is the
+    $2\times3$ block, and the complementary region is the finite-lattice
     complement of their union.  If this complementary region is injective,
     these three regions form the one-edge blocking datum; if it has a
     rectangular cover, rectangular injectivity and union closure supply that
     complementary injectivity.  In both forms the datum supplies the three
     injective regions used in the edge-blocked chain.  The distinguished edge
-    is the corresponding coordinate upward edge.  At coordinate origin \(0,0\),
+    is the corresponding coordinate upward edge.  At coordinate origin $0,0$,
     the translated edge and the three translated regions specialize to the
     normalized vertical picture.
 \end{lemma}
@@ -2269,7 +2269,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     obtain such windows directly from the corresponding translated picture.
     Equivalently, an actual coordinate right or upward edge obtains such a
     window when it has the necessary room around it for the translated
-    \(5\times7\) or \(7\times5\) frame and the complementary cover is supplied.
+    $5\times7$ or $7\times5$ frame and the complementary cover is supplied.
     The same criterion applies to an arbitrary horizontal or vertical
     square-lattice edge after identifying it with its coordinate right or
     upward representative.  The oriented margin-and-cover datum is the
@@ -2280,13 +2280,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     corresponding coordinate and oriented-edge window constructors that take
     these predicates directly.  On coordinate right and upward edges,
     translated windows force the corresponding margin predicates.  The current
-    open \(7\times7\) model therefore does not admit translated windows for
+    open $7\times7$ model therefore does not admit translated windows for
     every edge; explicit boundary examples are recorded on all four sides.  The
     margin-cover datum stores these named predicates, so such data force the
     corresponding horizontal and vertical margin inequalities.  In the present
     open rectangular coordinate model, this margin criterion does not apply to
     horizontal edges without enough left or right margin, nor to vertical edges
-    without enough bottom or top margin; the corresponding \(7\times7\)
+    without enough bottom or top margin; the corresponding $7\times7$
     examples are recorded explicitly, including a single four-sided boundary
     obstruction.  This records the remaining boundary geometry in the formal
     route; it is not a contradiction of the source theorem.
@@ -2306,13 +2306,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     translated edge window at every edge of the finite square lattice, the
     corresponding one-edge blockings determine the normal edge-blocking
     hypotheses.  This is the conditional construction;
-    constructing such windows for all edges of the \(7\times7\) lattice remains
+    constructing such windows for all edges of the $7\times7$ lattice remains
     separate; the current open rectangular translated-window criterion does not
     by itself supply such a family.  Equivalently, it is enough to supply the oriented
     margin-and-cover data at every edge.  The one-edge datum recovered from the
     resulting hypotheses is the datum supplied by the corresponding
     margin-and-cover input, and the resulting hypotheses give the three
-    injective regions at every edge.  The current open rectangular \(7\times7\)
+    injective regions at every edge.  The current open rectangular $7\times7$
     model does not admit such margin-and-cover data for every edge, because
     the boundary edges above fail this interior criterion.
 \end{theorem}
@@ -2321,7 +2321,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     supplied by the chosen translated window at each edge.
 \end{proof}
 
-\begin{lemma}[Conditional injectivity of the normal \(R\) and \(S\) regions]%
+\begin{lemma}[Conditional injectivity of the normal $R$ and $S$ regions]%
     \label{lem:peps_normalSquareRegionRS_injective_of_unionClosure}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionR_injective_of_union}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.regionS_injective_of_union}
@@ -2331,12 +2331,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareRegionRS_rectangular_decomposition}
     If region injectivity is closed under unions, then the coordinate
     square-lattice rectangular injectivity hypotheses imply that the displayed
-    regions \(R\) and \(S\) are injective.
+    regions $R$ and $S$ are injective.
 \end{lemma}
 \begin{proof}\leanok
-    Region \(R\) is the union of one injective \(2\times3\) rectangle and one
-    injective \(3\times2\) rectangle.  Region \(S\) is the union of two
-    injective \(2\times3\) rectangles.  Apply union closure in each case.
+    Region $R$ is the union of one injective $2\times3$ rectangle and one
+    injective $3\times2$ rectangle.  Region $S$ is the union of two
+    injective $2\times3$ rectangles.  Apply union closure in each case.
 \end{proof}
 
 \begin{definition}[Normal edge-blocking hypotheses]%
@@ -2387,13 +2387,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.NormalOneSiteSeparationHypotheses.mem_withSite_iff}
     \leanok
     \uses{def:peps_normalOneSiteSeparationHypotheses}
-    For the two regions associated to a site \(v\), a vertex \(w\) belongs to
-    the region containing \(v\) if and only if either \(w=v\), or \(w\)
-    belongs to the comparison region omitting \(v\).
+    For the two regions associated to a site $v$, a vertex $w$ belongs to
+    the region containing $v$ if and only if either $w=v$, or $w$
+    belongs to the comparison region omitting $v$.
 \end{theorem}
 \begin{proof}\leanok
-    If \(w=v\), use the distinguished-site membership and nonmembership
-    assumptions.  If \(w\neq v\), use the equality of the two regions away
+    If $w=v$, use the distinguished-site membership and nonmembership
+    assumptions.  If $w\neq v$, use the equality of the two regions away
     from the distinguished site.
 \end{proof}
 
@@ -2407,20 +2407,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareRegionRS_injective_of_unionClosure,
         lem:peps_normalSquareRegionT_injective_of_cover}
     In the translationally invariant square-lattice proof, the source paper
-    assumes that every \(2\times 3\) and \(3\times 2\) region is injective.
+    assumes that every $2\times 3$ and $3\times 2$ region is injective.
     The formal statement here is the corresponding abstract, scope-restricted
     hypothesis bundle: it records the rectangular injectivity assumptions, the
-    size bound \(n,m\geq 7\) with \(|V|=nm\), and three finite regions
-    \(R\), \(S\), and \(T\) whose injectivity is assumed directly.  It does
+    size bound $n,m\geq 7$ with $|V|=nm$, and three finite regions
+    $R$, $S$, and $T$ whose injectivity is assumed directly.  It does
     not by itself assert that these regions are the displayed square-lattice
     unions, nor that their translated variants give the edge-centred blocking
     around every edge.  Conversely, for the coordinate square lattice with
-    \(n,m\geq7\), the rectangular hypotheses, union closure, and a rectangular
-    cover of the displayed \(T\)-region yield this abstract \(R,S,T\)
-    structure, with \(R\) and \(S\) obtained from their rectangular
-    decompositions and \(T\) obtained from the supplied cover.  Under the
+    $n,m\geq7$, the rectangular hypotheses, union closure, and a rectangular
+    cover of the displayed $T$-region yield this abstract $R,S,T$
+    structure, with $R$ and $S$ obtained from their rectangular
+    decompositions and $T$ obtained from the supplied cover.  Under the
     present exact-cover criterion this converse is vacuous at the origin:
-    the no-cover lemma for the displayed \(T\)-region rules out such a cover.
+    the no-cover lemma for the displayed $T$-region rules out such a cover.
     The source regions are:
     \begin{center}
         \TNTikZDiagram{TNPEPSNormalRegionsRS}{%
@@ -2460,8 +2460,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
         thm:peps_normalEdgeBlockingHypotheses_injectiveChain,
         thm:peps_edgeBlockedInsertionAlgebraIsomorphism}
     Under the square-lattice normality hypotheses of
-    \cite[Theorem~3]{Molnar2018NormalPEPS}, the regions \(R\), \(S\), and
-    \(T\), together with their translated variants, give an edge-centred
+    \cite[Theorem~3]{Molnar2018NormalPEPS}, the regions $R$, $S$, and
+    $T$, together with their translated variants, give an edge-centred
     blocking into red, blue, and complementary injective regions.  These are
     the regions on which the three-site injective-chain insertion argument is
     applied:
@@ -2492,8 +2492,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
         thm:peps_edgeGaugeAbsorption}
     In the translationally invariant normal square-lattice case, the edge
     gauges obtained after blocking are represented by one horizontal matrix
-    \(X\) and one vertical matrix \(Y\), unique up to scalar. Absorbing these
-    matrices into \(B\) gives a tensor \(\widetilde B\), equivalently the final
+    $X$ and one vertical matrix $Y$, unique up to scalar. Absorbing these
+    matrices into $B$ gives a tensor $\widetilde B$, equivalently the final
     local gauge formula of \cite[Theorem~3]{Molnar2018NormalPEPS}:
     \begin{center}
         \TNTikZDiagram{TNPEPSTINormalGaugeAbsorption}{%
@@ -2533,12 +2533,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{thm:peps_tiNormalGaugeAbsorption,
         thm:peps_oneVertexComplementComparison,
         def:GaugeEquivPEPS}
-    Let \(A\) and \(B\) be translationally invariant normal square-lattice PEPS
-    tensors such that every \(2\times 3\) and \(3\times 2\) region is
-    injective. If they generate the same state on an \(n\times m\) region with
-    \(n,m\geq 7\), then they are related by horizontal and vertical gauges
-    \(X,Y\), up to a scalar \(\lambda\) satisfying
-    \(\lambda^{nm}=1\). This is
+    Let $A$ and $B$ be translationally invariant normal square-lattice PEPS
+    tensors such that every $2\times 3$ and $3\times 2$ region is
+    injective. If they generate the same state on an $n\times m$ region with
+    $n,m\geq 7$, then they are related by horizontal and vertical gauges
+    $X,Y$, up to a scalar $\lambda$ satisfying
+    $\lambda^{nm}=1$. This is
     \cite[Theorem~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -132,7 +132,7 @@ onto $G_L(A)^\perp$ in the $L$-site Euclidean space.
     \leanok
     \uses{def:nsite_space_parent, def:ground_space_parent}
     Via the canonical identification between coefficient functions and the
-    Euclidean space \(\ell^{2}(\{0,\ldots,d{-}1\}^{L})\), one transports the local
+    Euclidean space $\ell^{2}(\{0,\ldots,d{-}1\}^{L})$, one transports the local
     ground space to a Hilbert-space subspace
     \[
         G_{L}^{\mathrm{ES}}(A) \subseteq \ell^{2}(\{0,\ldots,d{-}1\}^{L}).
@@ -1368,7 +1368,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{thm:chain_ground_space_eq_mpv_blk, lem:mpv_eq_ground_space_map_one,
         thm:ground_space_map_injective}
     By Theorem~\ref{thm:chain_ground_space_eq_mpv_blk}, the ground space is the line
-    \(\spn\bigl\{V^{(N)}(A)\bigr\}\). It remains to show that the MPV is nonzero. If
+    $\spn\bigl\{V^{(N)}(A)\bigr\}$. It remains to show that the MPV is nonzero. If
     $V^{(N)}(A)=0$, then Lemma~\ref{lem:mpv_eq_ground_space_map_one} gives
     \[
         \Gamma_{N}(\Id) = \Gamma_{N}(0).
@@ -3064,15 +3064,15 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.exists_left_trace_test_of_three_block_trace_relation_right}
     \leanok
     \uses{def:l_blk_injective, lem:block_injective_two_sided_word_span}
-    Let \(A\) be \(L\)-block injective, and let \(\Delta_A\neq 0\).
-    Suppose that, for all words \(u,v,t\) of length \(L\),
+    Let $A$ be $L$-block injective, and let $\Delta_A\neq 0$.
+    Suppose that, for all words $u,v,t$ of length $L$,
     \[
         \tr\!\bigl(\Delta_A A_v A_t A_u\bigr)
         + \tr\!\bigl(\Delta_B B_v B_t B_u\bigr)=0 .
     \]
-    Then for every \(Z\in M_{D_A}(\mathbb C)\) there is a matrix
-    \(W\in M_{D_B}(\mathbb C)\) such that, for all words \(t\) of
-    length \(L\),
+    Then for every $Z\in M_{D_A}(\mathbb C)$ there is a matrix
+    $W\in M_{D_B}(\mathbb C)$ such that, for all words $t$ of
+    length $L$,
     \[
         \tr(ZA_t)+\tr(WB_t)=0 .
     \]
@@ -3081,16 +3081,16 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}\leanok\uses{lem:block_injective_two_sided_word_span}
-    Since \(\Delta_A\neq0\), Lemma~\ref{lem:block_injective_two_sided_word_span}
-    writes \(Z\) as a linear combination of matrices \(A_u\Delta_A A_v\).
+    Since $\Delta_A\neq0$, Lemma~\ref{lem:block_injective_two_sided_word_span}
+    writes $Z$ as a linear combination of matrices $A_u\Delta_A A_v$.
     For one such term, cyclicity of the trace rewrites the three-block relation
     as
     \[
         \tr(A_u\Delta_A A_vA_t)
         +\tr(B_u\Delta_B B_vB_t)=0 .
     \]
-    Taking the same linear combination of the matrices \(B_u\Delta_BB_v\)
-    gives the required \(W\), and linearity gives the general case.
+    Taking the same linear combination of the matrices $B_u\Delta_BB_v$
+    gives the required $W$, and linearity gives the general case.
 \end{proof}
 
 \begin{lemma}[Finite-chain image inclusion from a three-block relation]
@@ -3105,25 +3105,25 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \leanok
     \uses{lem:three_block_trace_reduction_nonzero_middle}
     Under the hypotheses of
-    Lemma~\ref{lem:three_block_trace_reduction_nonzero_middle}, the length-\(L\)
+    Lemma~\ref{lem:three_block_trace_reduction_nonzero_middle}, the length-$L$
     image spaces satisfy
     \[
         \mathcal G_L^A \subseteq \mathcal G_L^B .
     \]
     If the corresponding nonzero middle matrix exists on both sides, then
-    \(\mathcal G_L^A=\mathcal G_L^B\).
+    $\mathcal G_L^A=\mathcal G_L^B$.
 \end{lemma}
 
 \begin{proof}\leanok
     \uses{lem:three_block_trace_reduction_nonzero_middle}
-    Write a vector in \(\mathcal G_L^A\) as
-    \(t\mapsto \tr(A_tZ)\).  The preceding lemma supplies \(W\) with
-    \(\tr(ZA_t)+\tr(WB_t)=0\) for every word \(t\).  Cyclicity of the
+    Write a vector in $\mathcal G_L^A$ as
+    $t\mapsto \tr(A_tZ)$.  The preceding lemma supplies $W$ with
+    $\tr(ZA_t)+\tr(WB_t)=0$ for every word $t$.  Cyclicity of the
     trace gives
     \[
         \tr(A_tZ)=\tr(ZA_t)=-\tr(WB_t)=\tr(B_t(-W)),
     \]
-    so the vector lies in \(\mathcal G_L^B\).  The equality statement follows
+    so the vector lies in $\mathcal G_L^B$.  The equality statement follows
     by applying the same argument with the two blocks exchanged.
 \end{proof}
 
@@ -3170,23 +3170,23 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}
-    If \(A\) and \(B\) are length-\(L\) block-injective, the map
-    \(Z\mapsto(t\mapsto\tr(A_tZ))\) has image dimension \(D_A^2\), and
-    similarly for \(B\).  Therefore an inclusion
-    \(\mathcal G_L^A\subseteq \mathcal G_L^B\), together with
-    \(D_B\le D_A\), forces \(D_A=D_B\) and
-    \(\mathcal G_L^A=\mathcal G_L^B\).  In particular, the three-block
+    If $A$ and $B$ are length-$L$ block-injective, the map
+    $Z\mapsto(t\mapsto\tr(A_tZ))$ has image dimension $D_A^2$, and
+    similarly for $B$.  Therefore an inclusion
+    $\mathcal G_L^A\subseteq \mathcal G_L^B$, together with
+    $D_B\le D_A$, forces $D_A=D_B$ and
+    $\mathcal G_L^A=\mathcal G_L^B$.  In particular, the three-block
     trace relation from
     Lemma~\ref{lem:three_block_relation_ground_space_inclusion} gives this
     equality whenever the source-paper size ordering is available.  If the
-    inclusion comes from the strictly larger block, \(D_B<D_A\), then the same
+    inclusion comes from the strictly larger block, $D_B<D_A$, then the same
     dimension step already contradicts the existence of the three-block trace
     relation.  More generally, if an external source input rules out the
-    simultaneous conclusion \(D_A=D_B\) and
-    \(\mathcal G_L^A=\mathcal G_L^B\), then the three-block image spaces
-    \(\mathcal G_{3L}^A\) and \(\mathcal G_{3L}^B\) have zero intersection.
+    simultaneous conclusion $D_A=D_B$ and
+    $\mathcal G_L^A=\mathcal G_L^B$, then the three-block image spaces
+    $\mathcal G_{3L}^A$ and $\mathcal G_{3L}^B$ have zero intersection.
     With injectivity at the three-block length, the strict-size branch itself
-    already gives homogeneous pair trace separation at length \(3L\).
+    already gives homogeneous pair trace separation at length $3L$.
     One such source input is non-proportionality of the periodic MPV states
     at a sufficiently long chain length, equivalently distinctness of the
     corresponding periodic MPV lines: equality of the local image spaces gives
@@ -3201,9 +3201,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     unequal-dimension branches over all ordered block pairs gives one common
     three-block trace-separation length, and hence the positive-length
     product-word span required by the selector construction.  Since
-    canonical-form/BNT blocks are one-site injective, one may take \(L=2\);
-    injectivity at lengths \(2\) and \(6\) then follows by passing from a
-    fixed injective length to positive multiples.  This length-\(6\) trace
+    canonical-form/BNT blocks are one-site injective, one may take $L=2$;
+    injectivity at lengths $2$ and $6$ then follows by passing from a
+    fixed injective length to positive multiples.  This length-$6$ trace
     separation is equivalently a full homogeneous pair span; concatenating
     one-letter words propagates fullness to all later homogeneous lengths, so
     the direct-sum witness also gives a uniform finite pair-span period window.
@@ -3218,11 +3218,11 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}\leanok
     \uses{lem:three_block_relation_ground_space_inclusion}
     Block injectivity makes the boundary-to-chain map injective, so
-    \(\dim\mathcal G_L^A=D_A^2\) and \(\dim\mathcal G_L^B=D_B^2\).
-    Inclusion gives \(D_A^2\le D_B^2\), while \(D_B\le D_A\) gives the
-    reverse inequality.  Hence \(D_A=D_B\), and equality of dimensions inside
+    $\dim\mathcal G_L^A=D_A^2$ and $\dim\mathcal G_L^B=D_B^2$.
+    Inclusion gives $D_A^2\le D_B^2$, while $D_B\le D_A$ gives the
+    reverse inequality.  Hence $D_A=D_B$, and equality of dimensions inside
     the inclusion gives equality of the image spaces.  In the strict-size
-    branch this contradicts \(D_B<D_A\).  For the conditional directness
+    branch this contradicts $D_B<D_A$.  For the conditional directness
     statement, a vector in the intersection of the two three-block image spaces
     has two boundary representations.  If the first boundary matrix is zero,
     the vector is zero.  Otherwise the difference of the two coefficient
@@ -3305,7 +3305,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     into gauge-phase equivalence, so under non-gauge-equivalence the graph
     branch is impossible.  For two blocks of unequal bond dimensions, the graph
     branch is also impossible because it would identify matrix algebras with
-    different finite dimensions over \(\C\).
+    different finite dimensions over $\C$.
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

This PR standardizes inline mathematics in the blueprint sources by replacing inline `\\( ... \\)` forms with `$...$` in the chapter `.tex` files. It also rewrites the periodic no-sector-match overlap proof so that the contradiction is carried by the displayed overlap identities, rather than by prose alone.

This follows the blueprint review convention that short inline mathematics should use `$...$`, while keeping the longer overlap identities displayed.

## Local checks

- `rg -n "\\\\\\\\\\(|\\\\\\\\\\)" blueprint/src --glob '*.tex'`
- `git diff --check -- blueprint/src`
- `leanblueprint web`

No specific open issue matched this local blueprint-style review instruction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and LaTeX style only, plus a localized proof exposition change with no runtime or build-system impact beyond blueprint rendering.
> 
> **Overview**
> Blueprint chapter sources now use **`$...$`** for short inline math instead of **`\(...\)`**, applied consistently across MPDO/BNT (`ch02b_mpdo`), entropy (`ch04b_entropy`), canonical/PGVWC07 (`ch08_canonical`), periodic FT and **$Z$**-gauge (`ch11b_periodic_ft`), PEPS normal/injective (`ch13a_peps_ft`), and parent Hamiltonian (`ch14_parent_hamiltonian`). Displayed equations are largely unchanged.
> 
> The only non-cosmetic edit is in **`ch11b_periodic_ft.tex`**: the proof of **no sector match implies asymptotic orthogonality** is rewritten so the argument goes through explicit sector sums, limits, gauge-phase identities (**$|\zeta|=1$**), and a contradiction with **$\lim_N O_{\bar A,\bar B}(N)=0$**, instead of a shorter prose-only contradiction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be27d48cab1b9faecddbf8da233485054abc884e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->