### PR TITLE
feat(peps): formalize scalar residual reduction

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -377,5 +377,6 @@ import TNLean.PEPS.NormalEdgeBlockingMargins
 import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.InsertionRealization
 import TNLean.PEPS.LocalGauge
+import TNLean.PEPS.TensorFactorScalar
 -- The PEPS fundamental theorem is an exploratory capstone with recorded
 -- paper-alignment gaps; it is deliberately not part of the default root.

--- a/TNLean/PEPS/TensorFactorScalar.lean
+++ b/TNLean/PEPS/TensorFactorScalar.lean
@@ -5,7 +5,7 @@ import Mathlib.Data.Matrix.Basic
 # Scalar reduction for three exposed PEPS legs
 
 This file formalizes the finite-dimensional tensor-factor step in
-arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`.
+arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2.
 
 After inverting the two injective tensors, the paper obtains one operator on
 three exposed virtual legs which simultaneously has the forms
@@ -25,7 +25,7 @@ variable [DecidableEq α] [DecidableEq β] [DecidableEq γ]
 /-- The form $I_\alpha\otimes Z$ on
 $\alpha\otimes\beta\otimes\gamma$.
 
-Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`;
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2;
 `Papers/1804.04964/paper_normal.tex`, lines 1194--1204. -/
 def threeLegLeftIdentityForm (Z : Matrix (β × γ) (β × γ) ℂ) :
     Matrix (α × β × γ) (α × β × γ) ℂ :=
@@ -35,7 +35,7 @@ def threeLegLeftIdentityForm (Z : Matrix (β × γ) (β × γ) ℂ) :
 /-- The form $U\otimes I_\gamma$ on
 $\alpha\otimes\beta\otimes\gamma$.
 
-Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`;
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2;
 `Papers/1804.04964/paper_normal.tex`, lines 1194--1204. -/
 def threeLegRightIdentityForm (U : Matrix (α × β) (α × β) ℂ) :
     Matrix (α × β × γ) (α × β × γ) ℂ :=
@@ -44,7 +44,7 @@ def threeLegRightIdentityForm (U : Matrix (α × β) (α × β) ℂ) :
 
 /-- The form with identity on the middle leg $\beta$.
 
-Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`;
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2;
 `Papers/1804.04964/paper_normal.tex`, lines 1194--1204. -/
 def threeLegMiddleIdentityForm (W : Matrix (α × γ) (α × γ) ℂ) :
     Matrix (α × β × γ) (α × β × γ) ℂ :=
@@ -54,7 +54,7 @@ def threeLegMiddleIdentityForm (W : Matrix (α × γ) (α × γ) ℂ) :
 /-- Three compatible two-leg residual forms are scalar.
 
 This is the algebraic scalar-reduction step in arXiv:1804.04964, Section 3,
-Lemma `inj_equal_tensors_2`.  In the notation of the paper, the equality
+Lemma inj_equal_tensors_2.  In the notation of the paper, the equality
 $$
   I\otimes Z = U\otimes I = W
 $$

--- a/TNLean/PEPS/TensorFactorScalar.lean
+++ b/TNLean/PEPS/TensorFactorScalar.lean
@@ -1,0 +1,178 @@
+import Mathlib.Data.Complex.Basic
+import Mathlib.Data.Matrix.Basic
+
+/-!
+# Scalar reduction for three exposed PEPS legs
+
+This file formalizes the finite-dimensional tensor-factor step in
+arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`.
+
+After inverting the two injective tensors, the paper obtains one operator on
+three exposed virtual legs which simultaneously has the forms
+$I\otimes Z$, $U\otimes I$, and a third form with the identity on the middle
+leg.  The intersection of these three tensor-product subspaces is the scalar
+line.
+-/
+
+open scoped Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {α β γ : Type*}
+variable [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+
+/-- The form $I_\alpha\otimes Z$ on
+$\alpha\otimes\beta\otimes\gamma$.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`;
+`Papers/1804.04964/paper_normal.tex`, lines 1194--1204. -/
+def threeLegLeftIdentityForm (Z : Matrix (β × γ) (β × γ) ℂ) :
+    Matrix (α × β × γ) (α × β × γ) ℂ :=
+  fun x y =>
+    if x.1 = y.1 then Z (x.2.1, x.2.2) (y.2.1, y.2.2) else 0
+
+/-- The form $U\otimes I_\gamma$ on
+$\alpha\otimes\beta\otimes\gamma$.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`;
+`Papers/1804.04964/paper_normal.tex`, lines 1194--1204. -/
+def threeLegRightIdentityForm (U : Matrix (α × β) (α × β) ℂ) :
+    Matrix (α × β × γ) (α × β × γ) ℂ :=
+  fun x y =>
+    if x.2.2 = y.2.2 then U (x.1, x.2.1) (y.1, y.2.1) else 0
+
+/-- The form with identity on the middle leg $\beta$.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`;
+`Papers/1804.04964/paper_normal.tex`, lines 1194--1204. -/
+def threeLegMiddleIdentityForm (W : Matrix (α × γ) (α × γ) ℂ) :
+    Matrix (α × β × γ) (α × β × γ) ℂ :=
+  fun x y =>
+    if x.2.1 = y.2.1 then W (x.1, x.2.2) (y.1, y.2.2) else 0
+
+/-- Three compatible two-leg residual forms are scalar.
+
+This is the algebraic scalar-reduction step in arXiv:1804.04964, Section 3,
+Lemma `inj_equal_tensors_2`.  In the notation of the paper, the equality
+$$
+  I\otimes Z = U\otimes I = W
+$$
+with the identity in the three complementary positions forces the residual
+operators $Z$, $U$, and $W$ to be scalar multiples of the identity.
+
+The nonempty hypotheses express the paper's standing convention that virtual
+Hilbert spaces are nonzero finite-dimensional spaces. -/
+theorem threeLeg_residual_forms_scalar [Nonempty α] [Nonempty β] [Nonempty γ]
+    (Z : Matrix (β × γ) (β × γ) ℂ)
+    (U : Matrix (α × β) (α × β) ℂ)
+    (W : Matrix (α × γ) (α × γ) ℂ)
+    (hZU : threeLegLeftIdentityForm (α := α) Z = threeLegRightIdentityForm U)
+    (hZW : threeLegLeftIdentityForm (α := α) Z = threeLegMiddleIdentityForm W) :
+    ∃ lam : ℂ, Z = lam • 1 ∧ U = lam • 1 ∧ W = lam • 1 := by
+  classical
+  let a₀ : α := Classical.choice ‹Nonempty α›
+  let b₀ : β := Classical.choice ‹Nonempty β›
+  let c₀ : γ := Classical.choice ‹Nonempty γ›
+  let lam : ℂ := Z (b₀, c₀) (b₀, c₀)
+  have hZscalar : Z = lam • 1 := by
+    ext p q
+    rcases p with ⟨b, c⟩
+    rcases q with ⟨b', c'⟩
+    by_cases hb : b = b'
+    · subst b'
+      by_cases hc : c = c'
+      · subst c'
+        have hZW₁ := congrFun (congrFun hZW (a₀, b, c)) (a₀, b, c)
+        have hZW₂ := congrFun (congrFun hZW (a₀, b₀, c)) (a₀, b₀, c)
+        have hZU₁ := congrFun (congrFun hZU (a₀, b₀, c)) (a₀, b₀, c)
+        have hZU₂ := congrFun (congrFun hZU (a₀, b₀, c₀)) (a₀, b₀, c₀)
+        have h₁ : Z (b, c) (b, c) = W (a₀, c) (a₀, c) := by
+          simpa [threeLegLeftIdentityForm, threeLegMiddleIdentityForm] using hZW₁
+        have h₂ : Z (b₀, c) (b₀, c) = W (a₀, c) (a₀, c) := by
+          simpa [threeLegLeftIdentityForm, threeLegMiddleIdentityForm] using hZW₂
+        have h₃ : Z (b₀, c) (b₀, c) = U (a₀, b₀) (a₀, b₀) := by
+          simpa [threeLegLeftIdentityForm, threeLegRightIdentityForm] using hZU₁
+        have h₄ : Z (b₀, c₀) (b₀, c₀) = U (a₀, b₀) (a₀, b₀) := by
+          simpa [threeLegLeftIdentityForm, threeLegRightIdentityForm] using hZU₂
+        calc
+          Z (b, c) (b, c) = W (a₀, c) (a₀, c) := h₁
+          _ = Z (b₀, c) (b₀, c) := h₂.symm
+          _ = U (a₀, b₀) (a₀, b₀) := h₃
+          _ = lam := h₄.symm
+          _ = (lam • 1 : Matrix (β × γ) (β × γ) ℂ) (b, c) (b, c) := by
+            simp [Matrix.smul_apply]
+      · have hZU₁ := congrFun (congrFun hZU (a₀, b, c)) (a₀, b, c')
+        have hzero : Z (b, c) (b, c') = 0 := by
+          simpa [threeLegLeftIdentityForm, threeLegRightIdentityForm, hc] using hZU₁
+        simpa [Matrix.smul_apply, Matrix.one_apply, hc] using hzero
+    · have hZW₁ := congrFun (congrFun hZW (a₀, b, c)) (a₀, b', c')
+      have hzero : Z (b, c) (b', c') = 0 := by
+        simpa [threeLegLeftIdentityForm, threeLegMiddleIdentityForm, hb] using hZW₁
+      simpa [Matrix.smul_apply, Matrix.one_apply, hb] using hzero
+  have hUscalar : U = lam • 1 := by
+    ext p q
+    rcases p with ⟨a, b⟩
+    rcases q with ⟨a', b'⟩
+    by_cases hpq : (a, b) = (a', b')
+    · cases hpq
+      have hZU₁ := congrFun (congrFun hZU (a, b, c₀)) (a, b, c₀)
+      have hZentry := congrFun (congrFun hZscalar (b, c₀)) (b, c₀)
+      calc
+        U (a, b) (a, b) = Z (b, c₀) (b, c₀) := by
+          simpa [threeLegLeftIdentityForm, threeLegRightIdentityForm] using hZU₁.symm
+        _ = (lam • 1 : Matrix (β × γ) (β × γ) ℂ) (b, c₀) (b, c₀) := hZentry
+        _ = (lam • 1 : Matrix (α × β) (α × β) ℂ) (a, b) (a, b) := by
+          simp [Matrix.smul_apply]
+    · by_cases ha : a = a'
+      · subst a'
+        have hb_ne : b ≠ b' := by
+          intro hb
+          exact hpq (by cases hb; rfl)
+        have hZU₁ := congrFun (congrFun hZU (a, b, c₀)) (a, b', c₀)
+        have hZentry := congrFun (congrFun hZscalar (b, c₀)) (b', c₀)
+        calc
+          U (a, b) (a, b') = Z (b, c₀) (b', c₀) := by
+            simpa [threeLegLeftIdentityForm, threeLegRightIdentityForm] using hZU₁.symm
+          _ = (lam • 1 : Matrix (β × γ) (β × γ) ℂ) (b, c₀) (b', c₀) := hZentry
+          _ = (lam • 1 : Matrix (α × β) (α × β) ℂ) (a, b) (a, b') := by
+            simp [Matrix.smul_apply, hb_ne]
+      · have hZU₁ := congrFun (congrFun hZU (a, b, c₀)) (a', b', c₀)
+        have hzero : U (a, b) (a', b') = 0 := by
+          simpa [threeLegLeftIdentityForm, threeLegRightIdentityForm, ha] using hZU₁.symm
+        simpa [Matrix.smul_apply, Matrix.one_apply, hpq] using hzero
+  have hWscalar : W = lam • 1 := by
+    ext p q
+    rcases p with ⟨a, c⟩
+    rcases q with ⟨a', c'⟩
+    by_cases hpq : (a, c) = (a', c')
+    · cases hpq
+      have hZW₁ := congrFun (congrFun hZW (a, b₀, c)) (a, b₀, c)
+      have hZentry := congrFun (congrFun hZscalar (b₀, c)) (b₀, c)
+      calc
+        W (a, c) (a, c) = Z (b₀, c) (b₀, c) := by
+          simpa [threeLegLeftIdentityForm, threeLegMiddleIdentityForm] using hZW₁.symm
+        _ = (lam • 1 : Matrix (β × γ) (β × γ) ℂ) (b₀, c) (b₀, c) := hZentry
+        _ = (lam • 1 : Matrix (α × γ) (α × γ) ℂ) (a, c) (a, c) := by
+          simp [Matrix.smul_apply]
+    · by_cases ha : a = a'
+      · subst a'
+        have hc_ne : c ≠ c' := by
+          intro hc
+          exact hpq (by cases hc; rfl)
+        have hZW₁ := congrFun (congrFun hZW (a, b₀, c)) (a, b₀, c')
+        have hZentry := congrFun (congrFun hZscalar (b₀, c)) (b₀, c')
+        calc
+          W (a, c) (a, c') = Z (b₀, c) (b₀, c') := by
+            simpa [threeLegLeftIdentityForm, threeLegMiddleIdentityForm] using hZW₁.symm
+          _ = (lam • 1 : Matrix (β × γ) (β × γ) ℂ) (b₀, c) (b₀, c') := hZentry
+          _ = (lam • 1 : Matrix (α × γ) (α × γ) ℂ) (a, c) (a, c') := by
+            simp [Matrix.smul_apply, hc_ne]
+      · have hZW₁ := congrFun (congrFun hZW (a, b₀, c)) (a', b₀, c')
+        have hzero : W (a, c) (a', c') = 0 := by
+          simpa [threeLegLeftIdentityForm, threeLegMiddleIdentityForm, ha] using hZW₁.symm
+        simpa [Matrix.smul_apply, Matrix.one_apply, hpq] using hzero
+  exact ⟨lam, hZscalar, hUscalar, hWscalar⟩
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1372,7 +1372,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     subspace with $I_\beta$ in the middle leg, then it is a scalar multiple of
     the identity. Thus the residual virtual operators are scalar multiples of
     the identity. This is the scalar step in the proof of
-    Lemma~$\mathrm{inj\_equal\_tensors\_2}$.
+    \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 \begin{proof}\leanok
     Compare matrix entries. Equality with

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1319,7 +1319,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $\alpha\otimes\beta\otimes\gamma$ by acting as the identity on the
     $\alpha$ leg and as $Z$ on the remaining two legs. This is the
     $I_\alpha\otimes Z$ form appearing after the first tensor is inverted in
-    Lemma~$\mathrm{inj\_equal\_tensors\_2}$.
+    \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{definition}
 
 \begin{definition}[Right-identity three-leg residual form]%
@@ -1329,7 +1329,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     For an endomorphism $U$ of $\alpha\otimes\beta$, define the induced
     endomorphism of $\alpha\otimes\beta\otimes\gamma$ by acting as $U$ on the
     first two legs and as the identity on the $\gamma$ leg. This is the
-    $U\otimes I_\gamma$ form in Lemma~$\mathrm{inj\_equal\_tensors\_2}$.
+    $U\otimes I_\gamma$ form in \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{definition}
 
 \begin{definition}[Middle-identity three-leg residual form]%
@@ -1339,7 +1339,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     For an endomorphism $W$ of $\alpha\otimes\gamma$, define the induced
     endomorphism of $\alpha\otimes\beta\otimes\gamma$ by acting as $W$ on the
     outer two legs and as the identity on the middle $\beta$ leg. This is the
-    third residual form in Lemma~$\mathrm{inj\_equal\_tensors\_2}$.
+    third residual form in \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{definition}
 
 \begin{theorem}[Scalar reduction of the residual two-tensor gauges]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1310,10 +1310,45 @@ injective and normal PEPS, following Theorems~2 and~3 of
     the paper.
 \end{remark}
 
+\begin{definition}[Left-identity three-leg residual form]%
+    \label{def:peps_threeLegLeftIdentityForm}
+    \lean{TNLean.PEPS.threeLegLeftIdentityForm}
+    \leanok
+    For three virtual leg spaces $\alpha,\beta,\gamma$ and an endomorphism
+    $Z$ of $\beta\otimes\gamma$, define the induced endomorphism of
+    $\alpha\otimes\beta\otimes\gamma$ by acting as the identity on the
+    $\alpha$ leg and as $Z$ on the remaining two legs. This is the
+    $I_\alpha\otimes Z$ form appearing after the first tensor is inverted in
+    Lemma~$\mathrm{inj\_equal\_tensors\_2}$.
+\end{definition}
+
+\begin{definition}[Right-identity three-leg residual form]%
+    \label{def:peps_threeLegRightIdentityForm}
+    \lean{TNLean.PEPS.threeLegRightIdentityForm}
+    \leanok
+    For an endomorphism $U$ of $\alpha\otimes\beta$, define the induced
+    endomorphism of $\alpha\otimes\beta\otimes\gamma$ by acting as $U$ on the
+    first two legs and as the identity on the $\gamma$ leg. This is the
+    $U\otimes I_\gamma$ form in Lemma~$\mathrm{inj\_equal\_tensors\_2}$.
+\end{definition}
+
+\begin{definition}[Middle-identity three-leg residual form]%
+    \label{def:peps_threeLegMiddleIdentityForm}
+    \lean{TNLean.PEPS.threeLegMiddleIdentityForm}
+    \leanok
+    For an endomorphism $W$ of $\alpha\otimes\gamma$, define the induced
+    endomorphism of $\alpha\otimes\beta\otimes\gamma$ by acting as $W$ on the
+    outer two legs and as the identity on the middle $\beta$ leg. This is the
+    third residual form in Lemma~$\mathrm{inj\_equal\_tensors\_2}$.
+\end{definition}
+
 \begin{theorem}[Scalar reduction of the residual two-tensor gauges]%
     \label{thm:peps_twoInjectiveGaugeScalarReduction}
     \lean{TNLean.PEPS.threeLeg_residual_forms_scalar}
     \leanok
+    \uses{def:peps_threeLegLeftIdentityForm,
+        def:peps_threeLegRightIdentityForm,
+        def:peps_threeLegMiddleIdentityForm}
     In the proof of the generalized two-injective-tensor comparison, applying
     the inverse of the second injective tensor leaves three possible virtual
     operators on the exposed legs of the first tensor:

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1312,8 +1312,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Scalar reduction of the residual two-tensor gauges]%
     \label{thm:peps_twoInjectiveGaugeScalarReduction}
-    \notready
-    \uses{def:IsVertexInjective}
+    \lean{TNLean.PEPS.threeLeg_residual_forms_scalar}
+    \leanok
     In the proof of the generalized two-injective-tensor comparison, applying
     the inverse of the second injective tensor leaves three possible virtual
     operators on the exposed legs of the first tensor:
@@ -1321,7 +1321,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
         \TNPEPSTwoInjectiveGaugeScalarReduction
     \end{center}
     Inverting the first injective tensor then shows that the corresponding
-    tensor decompositions
+    residual operator on the three exposed virtual legs has the three
+    decompositions
     \[
         \sum_i I\otimes Z_i^{(1)}\otimes Z_i^{(2)}
         =
@@ -1329,10 +1330,26 @@ injective and normal PEPS, following Theorems~2 and~3 of
         =
         \sum_i W_i^{(1)}\otimes I\otimes W_i^{(2)}
     \]
-    force the residual virtual operators to be scalar multiples of the
-    identity. This is the scalar step in the proof of
+    Equivalently, for nonzero virtual leg spaces $\alpha,\beta,\gamma$, if one
+    endomorphism of $\alpha\otimes\beta\otimes\gamma$ lies simultaneously in
+    the three subspaces $I_\alpha\otimes \operatorname{End}(\beta\otimes\gamma)$,
+    $\operatorname{End}(\alpha\otimes\beta)\otimes I_\gamma$, and the analogous
+    subspace with $I_\beta$ in the middle leg, then it is a scalar multiple of
+    the identity. Thus the residual virtual operators are scalar multiples of
+    the identity. This is the scalar step in the proof of
     Lemma~$\mathrm{inj\_equal\_tensors\_2}$.
 \end{theorem}
+\begin{proof}\leanok
+    Compare matrix entries. Equality with
+    $\operatorname{End}(\alpha\otimes\beta)\otimes I_\gamma$ forces all
+    $I_\alpha\otimes Z$ entries with different $\gamma$-indices to vanish.
+    Equality with the middle-identity form forces all entries with different
+    $\beta$-indices to vanish. The remaining diagonal entries are equal because
+    the two identities compare them first along the $\beta$-direction and then
+    along the $\gamma$-direction. Substituting the resulting scalar form of $Z$
+    back into the two displayed equalities gives the same scalar form for $U$
+    and $W$.
+\end{proof}
 
 \begin{theorem}[Generalized two-injective-tensor comparison]%
     \label{thm:peps_twoInjectiveTensorInsertionComparison}


### PR DESCRIPTION
## Summary

This PR closes #1362 by formalizing the scalar-reduction substep in arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`.

The source proof obtains one residual operator on three exposed virtual legs with the three forms

```text
I ⊗ Z,
U ⊗ I,
and a third form with the identity on the middle leg.
```

The new theorem `TNLean.PEPS.threeLeg_residual_forms_scalar` proves that such compatible forms are all scalar multiples of the identity. The proof is by matrix entries: two of the identities kill the off-diagonal entries in the two exposed directions, and the remaining diagonal entries are compared through the two identities.

The blueprint node `thm:peps_twoInjectiveGaugeScalarReduction` now points to the Lean theorem and keeps the PEPS TikZ diagram attached to the source-paper step.

Closes #1362.

## Local checks

- `lake env lean TNLean/PEPS/TensorFactorScalar.lean`
- `lake build TNLean.PEPS.TensorFactorScalar`
- `lake env lean TNLean.lean`
- `lake build TNLean`
- `git diff --check`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/TensorFactorScalar.lean`
- `leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/TensorFactorScalar.lean`

Notes: `lake build TNLean` still prints pre-existing warnings outside this PR. Full `checkdecls` still reports pre-existing missing PEPS capstone and chapter-14 declarations, but after rebuilding the root the new declaration is not among the missing entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained Mathlib matrix algebra in the exploratory PEPS layer; no runtime, security, or API surface beyond a new root import and blueprint sync.
> 
> **Overview**
> Adds **`TNLean/PEPS/TensorFactorScalar.lean`**, which formalizes the scalar step of arXiv:1804.04964 Section 3 (`inj_equal_tensors_2`): three matrix encodings of \(I\otimes Z\), \(U\otimes I\), and middle-leg identity on \(\alpha\otimes\beta\otimes\gamma\), plus **`threeLeg_residual_forms_scalar`**, proved by entrywise comparison when two of the three lifted forms agree.
> 
> Wires the module into the default library via **`import TNLean.PEPS.TensorFactorScalar`** in `TNLean.lean`.
> 
> Updates **`blueprint/src/chapter/ch13a_peps_ft.tex`**: new blueprint definitions for the three forms, **`thm:peps_twoInjectiveGaugeScalarReduction`** marked `\leanok` and linked to the Lean theorem (replacing `\notready`), with a short proof sketch aligned to the Lean argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb3b9c048107a9e5032936ca2e3122612ccf05a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->