### PR TITLE
doc(blueprint): require formula-driven proof sketches

### DIFF
--- a/docs/blueprint_style_guide.md
+++ b/docs/blueprint_style_guide.md
@@ -30,6 +30,12 @@ The blueprint links the mathematics to its Lean formalization. A reader should b
     mathematical prose. The explicit proof-status markers in
     [`prose_style.md`](prose_style.md) are for Lean docstrings and comments, not
     blueprint-visible paragraphs.
+11. **Proofs are carried by formulas.** For mathematical proof sketches,
+    especially tensor-network and overlap arguments, state the main equations
+    explicitly instead of replacing them by verbal paraphrase. Short equations
+    should usually be inline with `$...$`; use displayed equations only when the
+    expression is long or when several implications must be compared. Avoid
+    long paragraphs whose only mathematical content is described in words.
 
 ## Proof Sketches Must Match Lean
 This is the most important rule. Every proof in the blueprint must faithfully describe what the Lean proof does:
@@ -46,6 +52,13 @@ This is the most important rule. Every proof in the blueprint must faithfully de
   blueprint prose.
   If the auxiliary route is no longer used by the checked proof, delete the entry
   rather than keeping an unmotivated theorem-like statement in the blueprint.
+- **Write tensor-network proofs with equations.** When a tensor-network proof
+  applies injectivity, inserts a boundary tensor, or compares two contractions,
+  introduce notation such as $P_i$, $\mathcal C_I$, or $X$ and write the
+  implication being used. A sketch like "apply injectivity twice" is not enough
+  when the paper proof distinguishes regions, boundaries, or inserted matrices.
+  Display the sequence of equalities or kernel implications that carries the
+  argument.
 
 ## Notation Consistency
 Notation must be **internally consistent** across the entire blueprint and **close to what the Lean code expresses**:
@@ -117,6 +130,12 @@ lengths, and atomic drawing commands. Chapter-facing diagrams are defined in
 move they depict. The web renderer in `blueprint/src/Packages/tn_diagrams.py`
 uses the same public commands and treats both TeX files as part of the diagram
 source.
+
+PEPS blueprint statements should keep the relevant tensor-network diagram
+attached to the theorem, lemma, or definition whose content it depicts. If the
+source paper proves a step by a diagrammatic equality or a blocked-region
+picture, the blueprint entry should contain the corresponding TikZ diagram and
+the proof sketch should name the regions or inserted tensors appearing in it.
 
 ## Lean Blueprint Macros
 - `\lean{Namespace.DeclName}` — links to Lean declaration

--- a/docs/prose_style.md
+++ b/docs/prose_style.md
@@ -150,6 +150,16 @@ use unexplained shorthand such as "zero tail", "norm-class data", or
 "blockwise construction". Write, for example, "the remaining direct summand is
 the all-zero block" and display the corresponding direct-sum decomposition.
 
+For proof sketches, equations should carry the argument. Replace purely verbal
+phrases such as "the overlap does not decay" or "injectivity removes the
+boundary tensor" by the corresponding limit, kernel, equality, or contraction
+identity. In tensor-network arguments, name the regions and inserted tensors and
+write the implications between contractions explicitly, for example
+\[
+    \mathcal C_{\{0,1,2\}}(X)=0
+    \Rightarrow \mathcal C_{\{2\}}(X)=0 \Rightarrow X=0.
+\]
+
 When the Lean statement is stronger, weaker, or differently organized than the
 paper source, separate the two assertions:
 


### PR DESCRIPTION
Refs #1252.

This records the blueprint review standard requested in the PEPS work: mathematical proof sketches should be carried by explicit formulas, not verbal paraphrase. It also records that PEPS blueprint nodes should keep the relevant TikZ tensor-network diagram attached to the statement being discussed.

Changes:
- add a core blueprint rule requiring formula-driven proof sketches and `$...$` for short inline equations;
- add a proof-sketch review rule for tensor-network contractions, injectivity steps, and inserted tensors;
- add a PEPS diagram rule requiring the corresponding TikZ picture when the source proof is diagrammatic.

Local check:
- `git diff --check`

No Lean or blueprint render was run: this PR changes only Markdown style guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to style guides; no runtime, formalization, or blueprint content changes.
> 
> **Overview**
> Documents the PEPS/blueprint review standard from issue #1252: **proof sketches must be formula-driven**, not verbal paraphrase.
> 
> **`docs/blueprint_style_guide.md`** adds general principle **#11** (inline `$...$` vs displays; avoid word-only math paragraphs), a **tensor-network proof** bullet under “Proof Sketches Must Match Lean” (name $P_i$, $\mathcal C_I$, $X$; show equality/kernel chains instead of “apply injectivity twice”), and a **PEPS diagram** rule: keep the relevant TikZ on the theorem/lemma/def and reference regions/inserted tensors in the sketch when the source proof is diagrammatic.
> 
> **`docs/prose_style.md`** extends “Source-faithful terminology and formulas” with the same expectation for proof sketches, including an example displayed implication chain for contraction arguments.
> 
> No Lean, blueprint `.tex`, or render pipeline changes—Markdown guidance only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c578efa354900738ad3b1625fc8d0d2eb9ee46bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->