### PR TITLE
doc(blueprint): make periodic overlap sketches formula-driven

### DIFF
--- a/.github/prompts/blueprint-prose-review-prompt.md
+++ b/.github/prompts/blueprint-prose-review-prompt.md
@@ -1,9 +1,13 @@
 Review this PR for TWO categories ONLY:
   (A) blueprint ↔ Lean **mathematical equivalence and status accuracy**;
-  (B) prose quality — banned AI/software language AND no Lean jargon.
+  (B) prose quality — banned AI/software language, no Lean jargon, and
+      formula-driven proof sketches.
 
 Authoritative source for category B: `docs/prose_style.md`. Read it once
-before reviewing; do not paraphrase the tables here.
+before reviewing; do not paraphrase the tables here. In particular, enforce
+the rule that equations carry mathematical proof sketches: overlap arguments
+should display the limiting identities, and tensor-network arguments should
+display the contraction equalities or kernel implications.
 
 All other concerns (proof integrity, Mathlib style, performance, etc.)
 belong to the main `Claude Code Review (Lean)` workflow — do NOT comment
@@ -98,7 +102,7 @@ matches — the blueprint clearly *is* ready and the tag is stale.
   Lean proof actually invokes. Do not list everything the statement
   mentions; do not omit lemmas the proof uses.
 
-## Category B — 🟡 Prose quality and no-Lean-jargon
+## Category B — 🟡 Prose quality, formulas, and no-Lean-jargon
 
 **Read `docs/prose_style.md` before reviewing.** It is the single
 authoritative source for:
@@ -110,6 +114,12 @@ Apply judgment for context-sensitive entries (the doc lists which).
 Scope: blueprint `.tex` and Lean docstrings/comments/`section`
 `/`namespace` names. Out of scope: `docs/`, workflow YAML, `Papers/`,
 `Notes/`.
+
+For blueprint proof sketches, also check that the proof is carried by formulas
+when the mathematics depends on a concrete identity. Flag phrases such as
+"the overlap does not decay", "injectivity removes the boundary tensor", or
+"the sector overlaps give a contradiction" when the changed text does not
+write the corresponding limit, equality, kernel, or contraction identity.
 
 For each finding, cite the exact phrase, link to the line, and propose
 a concrete replacement from the table (or "drop").

--- a/.github/prompts/blueprint-prose-review-system-prompt.md
+++ b/.github/prompts/blueprint-prose-review-system-prompt.md
@@ -9,9 +9,11 @@ theory. You are a focused reviewer with TWO concerns:
    - Flag missing `\leanok` on now-formalized results and stale `\lean{...}` tags
      after renames.
 
-2. prose quality per docs/prose_style.md (no Lean jargon, no banned software-engineering
-   language).
+2. prose quality per docs/prose_style.md (no Lean jargon, no banned
+   software-engineering language, and formula-driven proof sketches).
+   - For mathematical arguments in blueprint prose, especially overlap and
+     tensor-network arguments, flag word-only sketches that should instead show
+     the relevant limits, equalities, kernels, or contraction identities.
 
 Do NOT comment on proof integrity, Mathlib style, performance, modularity, or other
 concerns covered by the main `Claude Code Review (Lean)` workflow.
-

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -507,10 +507,9 @@ unconditional result.
             O_{A_u,B_v}(N).
     \]
     The no-matching hypothesis is
-    $A_u \not\sim_{\mathrm{gp}} B_v$ for all $u,v\in\mathbb Z_m$. By the
-    normal-tensor overlap dichotomy,
-    $\lim_{N\to\infty} O_{A_u,B_v}(N)=0$ for every $u,v$.
-    Hence
+    $\forall u,v\in\mathbb Z_m,\ A_u \not\sim_{\mathrm{gp}} B_v$. The
+    normal-tensor overlap dichotomy gives
+    $\lim_{N\to\infty} O_{A_u,B_v}(N)=0$ for every $u,v$, and therefore
     \[
         \lim_{N\to\infty} O_{\bar A,\bar B}(N)
         =
@@ -519,11 +518,11 @@ unconditional result.
         =0 .
     \]
 
-    Suppose, to the contrary, that $A\sim_{\mathrm{gp}} B$. Blocking preserves
-    gauge-phase equivalence, so $\bar A\sim_{\mathrm{gp}}\bar B$. Thus, for
-    some invertible $X$ and some $\zeta\ne0$,
+    If $A\sim_{\mathrm{gp}} B$, then blocking gives
+    $\bar A\sim_{\mathrm{gp}}\bar B$, so for some invertible $X$ and
+    some $\zeta\ne0$,
     $V_N(\bar B)=\zeta^N X V_N(\bar A)X^{-1}$.
-    Gauge cancellation in the trace pairing gives
+    The trace pairing cancels the conjugating matrices:
     \[
         O_{\bar A,\bar B}(N)
         =
@@ -533,13 +532,28 @@ unconditional result.
         =
         |\zeta|^{2N} O_{\bar A,\bar A}(N).
     \]
-    Since $O_{\bar A,\bar A}(N)\to m$ and
-    $O_{\bar B,\bar B}(N)\to m$ with $m>0$, the second identity forces
-    $|\zeta|=1$. Therefore
-    $|O_{\bar A,\bar B}(N)|=O_{\bar A,\bar A}(N)\to m\ne0$, contradicting
-    $\lim_N O_{\bar A,\bar B}(N)=0$. Hence
+    With $O_{\bar A,\bar A}(N)\to m$ and $O_{\bar B,\bar B}(N)\to m>0$,
+    the second identity gives
+    \[
+        1
+        =
+        \lim_{N\to\infty}
+        \frac{O_{\bar B,\bar B}(N)}{O_{\bar A,\bar A}(N)}
+        =
+        \lim_{N\to\infty} |\zeta|^{2N},
+    \]
+    hence $|\zeta|=1$. The first identity then gives
+    \[
+        \lim_{N\to\infty}|O_{\bar A,\bar B}(N)|
+        =
+        \lim_{N\to\infty}|\zeta|^N |O_{\bar A,\bar A}(N)|
+        =
+        m\ne0,
+    \]
+    while the sector sum above gives
+    $\lim_{N\to\infty}O_{\bar A,\bar B}(N)=0$. Thus
     $A\not\sim_{\mathrm{gp}}B$, and the irreducible trace-preserving overlap
-    dichotomy gives $O_{A,B}(N)\to0$.
+    dichotomy gives $\lim_{N\to\infty}O_{A,B}(N)=0$.
 \end{proof}
 
 \begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}
@@ -649,11 +663,25 @@ unconditional result.
     By Theorem~\ref{thm:periodic_overlap_dichotomy}, either the overlap
     $\braket{V^{(N)}(A)}{V^{(N)}(B)}$ tends to $0$ or the bond dimensions agree
     and $A$ and $B$ are equivalent up to repeated blocks. In the decay case,
-    equality of the MPV families identifies the cross-overlap with the
-    self-overlap of $A$ for every $N$. But
-    Theorem~\ref{thm:periodic_self_overlap_tendsto} gives
-    $\braket{V^{(m_a N)}(A)}{V^{(m_a N)}(A)} \to m_a$ along multiples of the
-    period $m_a$, contradiction.
+    equality of the MPV families gives, for every $N$,
+    \[
+        \braket{V^{(N)}(A)}{V^{(N)}(B)}
+        =
+        \braket{V^{(N)}(A)}{V^{(N)}(A)}.
+    \]
+    Along multiples of the period $m_a$ this would imply
+    \[
+        0
+        =
+        \lim_{N\to\infty}
+        \braket{V^{(m_aN)}(A)}{V^{(m_aN)}(B)}
+        =
+        \lim_{N\to\infty}
+        \braket{V^{(m_aN)}(A)}{V^{(m_aN)}(A)}
+        =
+        m_a,
+    \]
+    contradicting $m_a>0$.
 \end{proof}
 
 \begin{theorem}[Peripheral proportional case from phase rescaling]


### PR DESCRIPTION
Refs #1685.

## Summary
- rewrite the periodic no-sector-match proof sketch so the contradiction is expressed through sector-sum limits and gauge-phase overlap identities
- rewrite the nearby periodic proportional decay contradiction as an explicit overlap limit chain
- teach the blueprint/prose review prompts to flag word-only overlap and tensor-network proof sketches

## Local checks
- `git diff --check`
- `(cd blueprint && leanblueprint web)` (passes with existing plasTeX/bibliography warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint prose/review-prompt changes only; no Lean or runtime behavior.
> 
> **Overview**
> Strengthens **blueprint/prose review** so category B also requires **formula-driven proof sketches** (overlap limits, contraction equalities, kernels), with explicit examples of word-only phrases to flag—aligned with `docs/prose_style.md`.
> 
> In **`ch11b_periodic_ft.tex`**, two periodic overlap proof sketches are rewritten so contradictions are carried by **displayed limits and identities** (sector-sum decay, gauge-phase overlap relations, and an explicit \(0 = m_a\) chain from equal MPV families) instead of prose-only conclusions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba98102bdc644ebc9eba40e768b0be8ed1875d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->