### PR TITLE
feat(PEPS): add all-edge reductions for edge-blocked three-site injectivity

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -263,6 +263,21 @@ theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective
   hA.edgeBlockedThreeSiteInjective_of_middle e
     (hComparison.middle_tensor_injective e hMiddleRegion)
 
+/-- If every edge-middle region is injective after blocking, then every
+edge-middle tensor family is injective.
+
+This is the all-edge form of the finite-region comparison isolated from the
+assertion following `eq:block_to_mps`.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+theorem EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hMiddleRegions : ∀ e : Edge G, κ.IsInjective (edgeMiddleVertices e)) :
+    ∀ e : Edge G, EdgeMiddleTensorInjective (G := G) A e :=
+  fun e => hComparison.middle_tensor_injective e (hMiddleRegions e)
+
 /-- All edge-blocked three-site chains are injective once every edge-middle
 region is injective and region injectivity has been compared with the
 edge-middle tensor family.
@@ -280,8 +295,8 @@ theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all
     (hA : IsVertexInjective A)
     (hMiddleRegions : ∀ e : Edge G, κ.IsInjective (edgeMiddleVertices e)) :
     ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) A e :=
-  hA.edgeBlockedThreeSiteInjective_all_of_middle fun e =>
-    hComparison.middle_tensor_injective e (hMiddleRegions e)
+  hA.edgeBlockedThreeSiteInjective_all_of_middle
+    (hComparison.edgeMiddleTensorInjective_all hMiddleRegions)
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -205,6 +205,18 @@ theorem IsVertexInjective.edgeBlockedEndpointTensorMaps_injective {A : Tensor G 
       Function.Injective (localTensorMap A e.1.2) :=
   ⟨hA.localTensorMap_injective e.1.1, hA.localTensorMap_injective e.1.2⟩
 
+/-- Vertex injectivity supplies the two endpoint injectivity assertions for
+the edge-blocked three-site chain at every edge.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+theorem IsVertexInjective.edgeBlockedEndpointTensorMaps_injective_all {A : Tensor G d}
+    (hA : IsVertexInjective A) :
+    ∀ e : Edge G,
+      Function.Injective (localTensorMap A e.1.1) ∧
+        Function.Injective (localTensorMap A e.1.2) :=
+  fun e => hA.edgeBlockedEndpointTensorMaps_injective e
+
 /-- Once the middle block is injective, vertex injectivity gives the full
 edge-blocked three-site injectivity statement.
 
@@ -216,6 +228,21 @@ theorem IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle {A : Tensor G 
     (hMiddle : EdgeMiddleTensorInjective (G := G) A e) :
     EdgeBlockedThreeSiteInjective (G := G) A e :=
   ⟨hA.localTensorMap_injective e.1.1, hMiddle, hA.localTensorMap_injective e.1.2⟩
+
+/-- If every edge-middle tensor is injective, then vertex injectivity gives an
+injective edge-blocked three-site chain at every edge.
+
+This is the middle-tensor version of the assertion following `eq:block_to_mps`.
+The separate comparison theorem below supplies the middle-tensor hypotheses
+from finite-region injectivity.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+theorem IsVertexInjective.edgeBlockedThreeSiteInjective_all_of_middle {A : Tensor G d}
+    (hA : IsVertexInjective A)
+    (hMiddle : ∀ e : Edge G, EdgeMiddleTensorInjective (G := G) A e) :
+    ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) A e :=
+  fun e => hA.edgeBlockedThreeSiteInjective_of_middle e (hMiddle e)
 
 /-- Region injectivity of the edge-middle block, together with the comparison to
 the edge-middle tensor family, gives the edge-blocked three-site injectivity
@@ -253,7 +280,8 @@ theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all
     (hA : IsVertexInjective A)
     (hMiddleRegions : ∀ e : Edge G, κ.IsInjective (edgeMiddleVertices e)) :
     ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) A e :=
-  fun e => hComparison.edgeBlockedThreeSiteInjective hA e (hMiddleRegions e)
+  hA.edgeBlockedThreeSiteInjective_all_of_middle fun e =>
+    hComparison.middle_tensor_injective e (hMiddleRegions e)
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -236,5 +236,24 @@ theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective
   hA.edgeBlockedThreeSiteInjective_of_middle e
     (hComparison.middle_tensor_injective e hMiddleRegion)
 
+/-- All edge-blocked three-site chains are injective once every edge-middle
+region is injective and region injectivity has been compared with the
+edge-middle tensor family.
+
+This is the all-edge conditional form of the assertion following
+`eq:block_to_mps` in arXiv:1804.04964, Section 3. The remaining source-paper
+step is the contraction theorem showing that vertex injectivity gives
+injectivity of each finite middle region \(V\setminus\{u,v\}\).
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hA : IsVertexInjective A)
+    (hMiddleRegions : ∀ e : Edge G, κ.IsInjective (edgeMiddleVertices e)) :
+    ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) A e :=
+  fun e => hComparison.edgeBlockedThreeSiteInjective hA e (hMiddleRegions e)
+
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -965,6 +965,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Apply vertex injectivity at the two endpoints of the chosen edge.
 \end{proof}
 
+\begin{theorem}[Endpoint injectivity at all edges]%
+    \label{thm:peps_edgeBlockedEndpointTensorMaps_injective_all}
+    \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective_all}
+    \leanok
+    \uses{def:IsVertexInjective,
+        thm:peps_edgeBlockedEndpointTensorMaps_injective}
+    If the original PEPS tensor is vertex-injective, then the two endpoint
+    tensor maps in the edge-blocked three-site chain are injective at every
+    edge.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the one-edge endpoint theorem to each edge.
+\end{proof}
+
 \begin{theorem}[Reducing edge-blocked injectivity to the middle block]%
     \label{thm:peps_edgeBlockedThreeSiteInjective_of_middle}
     \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle}
@@ -978,6 +992,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     The endpoint assertions are supplied by vertex injectivity. The middle
     assertion is the assumed injectivity of the blocked middle tensor.
+\end{proof}
+
+\begin{theorem}[All edge-blocked chains from middle-tensor injectivity]%
+    \label{thm:peps_edgeBlockedThreeSiteInjective_all_of_middle}
+    \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_all_of_middle}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
+        def:peps_edgeMiddleTensorFamily,
+        thm:peps_edgeBlockedThreeSiteInjective_of_middle}
+    If every edge-middle tensor is injective, then a vertex-injective PEPS
+    tensor gives an injective edge-blocked three-site chain at every edge.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the one-edge reduction to each edge.
 \end{proof}
 
 \begin{theorem}[Region injectivity gives edge-blocked injectivity]%
@@ -1004,7 +1032,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
         def:peps_edgeMiddleRegionInjectivityComparison,
-        thm:peps_edgeBlockedThreeSiteInjective_of_region}
+        thm:peps_edgeBlockedThreeSiteInjective_all_of_middle}
     Suppose every edge-middle region \(V\setminus\{u,v\}\) is injective after
     blocking, and suppose finite-region injectivity has been identified with
     injectivity of the corresponding edge-middle tensor family. Then a

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -976,7 +976,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     edge.
 \end{theorem}
 \begin{proof}\leanok
-    Apply the one-edge endpoint theorem to each edge.
+    For each edge $e$, Theorem~\ref{thm:peps_edgeBlockedEndpointTensorMaps_injective}
+    gives injectivity of the two endpoint tensor maps at $e$.
 \end{proof}
 
 \begin{theorem}[Reducing edge-blocked injectivity to the middle block]%
@@ -1005,7 +1006,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     tensor gives an injective edge-blocked three-site chain at every edge.
 \end{theorem}
 \begin{proof}\leanok
-    Apply the one-edge reduction to each edge.
+    For each edge $e$, the one-edge reduction turns injectivity of the
+    edge-middle tensor family at $e$ into injectivity of the corresponding
+    three-site chain.
 \end{proof}
 
 \begin{theorem}[Region injectivity gives edge-blocked injectivity]%
@@ -1026,21 +1029,41 @@ injective and normal PEPS, following Theorems~2 and~3 of
     combines this with vertex injectivity at the two endpoints.
 \end{proof}
 
+\begin{theorem}[Middle tensors from all middle regions]%
+    \label{thm:peps_edgeMiddleTensorInjective_all_of_region}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all}
+    \leanok
+    \uses{def:peps_edgeMiddleRegionInjectivityComparison,
+        def:peps_edgeMiddleTensorFamily}
+    Suppose every edge-middle region $V\setminus\{u,v\}$ is injective after
+    blocking, and suppose finite-region injectivity has been identified with
+    injectivity of the corresponding edge-middle tensor family. Then every
+    edge-middle tensor family is injective.
+\end{theorem}
+\begin{proof}\leanok
+    For each edge $e=(u,v)$, the hypotheses give
+    injectivity of the middle region $V\setminus\{u,v\}$ after blocking; the
+    comparison sends this to injectivity of the corresponding middle tensor
+    family.
+\end{proof}
+
 \begin{theorem}[All edge-blocked chains from middle-region injectivity]%
     \label{thm:peps_edgeBlockedThreeSiteInjective_all_of_region}
     \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all}
     \leanok
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
         def:peps_edgeMiddleRegionInjectivityComparison,
-        thm:peps_edgeBlockedThreeSiteInjective_all_of_middle}
-    Suppose every edge-middle region \(V\setminus\{u,v\}\) is injective after
+        thm:peps_edgeBlockedThreeSiteInjective_all_of_middle,
+        thm:peps_edgeMiddleTensorInjective_all_of_region}
+    Suppose every edge-middle region $V\setminus\{u,v\}$ is injective after
     blocking, and suppose finite-region injectivity has been identified with
     injectivity of the corresponding edge-middle tensor family. Then a
     vertex-injective PEPS tensor gives an injective edge-blocked three-site
     chain at every edge.
 \end{theorem}
 \begin{proof}\leanok
-    Apply the one-edge conditional theorem to each edge.
+    The comparison gives middle-tensor injectivity for every edge. The all-edge
+    middle-tensor theorem then gives three-site injectivity for every edge.
 \end{proof}
 
 \begin{theorem}[Edge blocking preserves injectivity]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -998,11 +998,28 @@ injective and normal PEPS, following Theorems~2 and~3 of
     combines this with vertex injectivity at the two endpoints.
 \end{proof}
 
+\begin{theorem}[All edge-blocked chains from middle-region injectivity]%
+    \label{thm:peps_edgeBlockedThreeSiteInjective_all_of_region}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
+        def:peps_edgeMiddleRegionInjectivityComparison,
+        thm:peps_edgeBlockedThreeSiteInjective_of_region}
+    Suppose every edge-middle region \(V\setminus\{u,v\}\) is injective after
+    blocking, and suppose finite-region injectivity has been identified with
+    injectivity of the corresponding edge-middle tensor family. Then a
+    vertex-injective PEPS tensor gives an injective edge-blocked three-site
+    chain at every edge.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the one-edge conditional theorem to each edge.
+\end{proof}
+
 \begin{theorem}[Edge blocking preserves injectivity]%
     \label{thm:peps_edgeBlockedThreeSiteInjective}
     \notready
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
-        thm:peps_edgeBlockedThreeSiteInjective_of_region}
+        thm:peps_edgeBlockedThreeSiteInjective_all_of_region}
     If $A$ is vertex-injective, then for every edge $e=(u,v)$, the two
     endpoint tensors together with the tensor obtained by blocking all vertices
     outside $u$ and $v$ form an injective three-site MPS. This is the

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -142,10 +142,13 @@ Theorem can be proved in the manner of the paper.
   comparison
   \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison}
   records the conditional passage from finite-region injectivity of
-  \(V\setminus\{u,v\}\) to the edge-middle tensor family. Its theorem
+  $V\setminus\{u,v\}$ to the edge-middle tensor family. Its theorem
   \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective}
   then combines this comparison with vertex injectivity to obtain the
-  edge-blocked three-site assertion at one edge. The all-edge conditional form
+  edge-blocked three-site assertion at one edge. The all-edge middle-tensor
+  comparison is
+  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all}.
+  The all-edge conditional form
   is
   \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all}.
   The missing mathematical step is still the
@@ -214,7 +217,9 @@ It is meant to prevent the proof from drifting away from the source argument.
   formalized by \leanid{TNLean.PEPS.EdgeMiddlePhysicalConfig}. The named
   injectivity statement is \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective},
   and the endpoint assertions are proved from vertex injectivity, both for a
-  single chosen edge and uniformly over all edges. The all-edge
+  single chosen edge and uniformly over all edges. The comparison from
+  edge-middle region injectivity to edge-middle tensor injectivity is also
+  available uniformly over all edges. The all-edge
   conditional bridge from middle-region injectivity is
   \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all}.
 \item Identity insertion on the chosen bond:

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -131,9 +131,14 @@ Theorem can be proved in the manner of the paper.
   injectivity statement is \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective}.
   Vertex injectivity supplies the two endpoint assertions by
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective}
+  and, for all edges at once, by
+  \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective_all},
   and
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle}
-  reduces the remaining work to the middle-block injectivity statement. The
+  reduces the remaining work to the middle-block injectivity statement. Its
+  all-edge form is
+  \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_all_of_middle}.
+  The
   comparison
   \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison}
   records the conditional passage from finite-region injectivity of
@@ -208,7 +213,8 @@ It is meant to prevent the proof from drifting away from the source argument.
   issue~\#1366. The middle physical index of this three-site object is
   formalized by \leanid{TNLean.PEPS.EdgeMiddlePhysicalConfig}. The named
   injectivity statement is \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective},
-  and the endpoint assertions are proved from vertex injectivity. The all-edge
+  and the endpoint assertions are proved from vertex injectivity, both for a
+  single chosen edge and uniformly over all edges. The all-edge
   conditional bridge from middle-region injectivity is
   \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all}.
 \item Identity insertion on the chosen bond:

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -140,7 +140,10 @@ Theorem can be proved in the manner of the paper.
   \(V\setminus\{u,v\}\) to the edge-middle tensor family. Its theorem
   \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective}
   then combines this comparison with vertex injectivity to obtain the
-  edge-blocked three-site assertion. The missing mathematical step is still the
+  edge-blocked three-site assertion at one edge. The all-edge conditional form
+  is
+  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all}.
+  The missing mathematical step is still the
   contraction theorem used in the paper: contracting vertex-injective tensors
   over that finite middle region gives an injective blocked tensor. The full
   transfer remains the not-yet-formalized theorem
@@ -205,7 +208,9 @@ It is meant to prevent the proof from drifting away from the source argument.
   issue~\#1366. The middle physical index of this three-site object is
   formalized by \leanid{TNLean.PEPS.EdgeMiddlePhysicalConfig}. The named
   injectivity statement is \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective},
-  and the endpoint assertions are proved from vertex injectivity.
+  and the endpoint assertions are proved from vertex injectivity. The all-edge
+  conditional bridge from middle-region injectivity is
+  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all}.
 \item Identity insertion on the chosen bond:
   \path{thm:peps_edgeInsertedCoeff_identity} is reduced to finite diagonal
   reindexing, tracked by issue~\#1372.


### PR DESCRIPTION
### Motivation
- Issue #1366 asks for the formalization of arXiv:1804.04964, Section 3: when a PEPS is vertex-injective and one blocks all vertices except the endpoints of a chosen edge, the resulting three-site MPS is injective.
- This PR extends the single-edge conditional reductions to all edges, providing ∀-edge variants needed before the three-site injective-chain theorem can be applied uniformly across the lattice.
- Source: MGRPG+18 (arXiv:1804.04964), Section 3, `eq:block_to_mps`; local source: `Papers/1804.04964/paper_normal.tex`, lines 981--1009.

### Description
- `TNLean/PEPS/EdgeMiddlePhysical.lean`: adds ∀-edge variants for (i) endpoint injectivity at every edge, (ii) three-site injectivity from middle-tensor injectivity at every edge, (iii) middle-tensor injectivity from region injectivity at every edge, and (iv) an all-edge region comparison.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: records matching blueprint theorems and proofs; `thm:peps_edgeBlockedThreeSiteInjective` now cites the all-edge conditional proof path.
- `docs/paper-gaps/peps_injective_ft_section3_route.tex`: updated ledger lists the new Lean names and clarifies that the full contraction theorem (vertex injectivity alone implies injectivity of every finite middle region) remains open.
- These results are conditional: the full theorem that vertex injectivity makes every finite middle region injective is not yet proved.

### Testing
- `lake env lean TNLean/PEPS/EdgeMiddlePhysical.lean`
- `lake build TNLean.PEPS.EdgeMiddlePhysical`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/EdgeMiddlePhysical.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `(cd blueprint && leanblueprint web)` passes (pre-existing plasTeX/bibliography warnings only).
- `lake exe checkdecls blueprint/lean_decls`: new declarations are not among the pre-existing missing ones.

---
Addresses #1366

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only formalization and documentation; no runtime, auth, or data paths—remaining risk is mathematical (unproved contraction), not deployment.
> 
> **Overview**
> This PR **lifts single-edge conditional injectivity lemmas to ∀-edge forms** in `EdgeMiddlePhysical.lean`, so the Section 3 `eq:block_to_mps` route can be stated uniformly over the lattice before the full contraction theorem exists.
> 
> New Lean results are thin wrappers: endpoint injectivity everywhere (`edgeBlockedEndpointTensorMaps_injective_all`), three-site injectivity from middle-tensor injectivity at every edge (`edgeBlockedThreeSiteInjective_all_of_middle`), middle tensors from region injectivity everywhere (`edgeMiddleTensorInjective_all`), and the combined all-edge region bridge (`edgeBlockedThreeSiteInjective_all`). **Blueprint** (`ch13a_peps_ft.tex`) adds matching theorems; the still-open `thm:peps_edgeBlockedThreeSiteInjective` now depends on the all-edge conditional path. **Paper-gap docs** list the new names and note the contraction step (vertex injectivity ⇒ injective middle regions) remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5690e159e3cefdd8d3a9ffedf0e76e1b7165ce01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->