### PR TITLE
feat(PEPS): package balanced edge-scalar quotient

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -779,6 +779,29 @@ theorem GaugeEquivModEdgeScalars.trans {A : Tensor G d}
           edgeGaugeAt A Z v ie := by
           rw [edgeScalarAt_mul]
 
+/-- Gauge equivalence modulo balanced edge scalars is an equivalence relation.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; the corrected quotient
+is the quotient of edge gauges by the vertex-balanced scalar action. -/
+theorem GaugeEquivModEdgeScalars.equivalence (A : Tensor G d) :
+    Equivalence (GaugeEquivModEdgeScalars (G := G) A) := by
+  refine ⟨?_, ?_, ?_⟩
+  · intro X
+    exact GaugeEquivModEdgeScalars.refl (G := G) A X
+  · intro X Y hXY
+    exact GaugeEquivModEdgeScalars.symm (G := G) hXY
+  · intro X Y Z hXY hYZ
+    exact GaugeEquivModEdgeScalars.trans (G := G) hXY hYZ
+
+/-- The quotient relation on gauge families modulo balanced edge scalars.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; this packages the
+corrected balanced edge-scalar quotient as a formal equivalence relation. -/
+def GaugeEquivModEdgeScalars.setoid (A : Tensor G d) :
+    Setoid ((e : Edge G) → GL (Fin (A.bondDim e)) ℂ) where
+  r := GaugeEquivModEdgeScalars (G := G) A
+  iseqv := GaugeEquivModEdgeScalars.equivalence (G := G) A
+
 /-- Balanced edge-scalar reweightings do not change the gauged tensor at a
 vertex. -/
 theorem GaugeEquivModEdgeScalars.gaugeVertex_eq
@@ -821,7 +844,9 @@ theorem GaugeEquivModEdgeScalars.applyGauge_eq
     {X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ}
     (hXY : GaugeEquivModEdgeScalars (G := G) A X Y) :
     applyGauge A X = applyGauge A Y := by
-  simp [applyGauge]
+  change Tensor.mk A.bondDim (fun v => gaugeVertex A X v) =
+    Tensor.mk A.bondDim (fun v => gaugeVertex A Y v)
+  congr
   funext v η σ
   exact GaugeEquivModEdgeScalars.gaugeVertex_eq (G := G) hXY v η σ
 

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -634,6 +634,32 @@ theorem edgeScalarAt_mul (c d : (e : Edge G) → Units ℂ)
   · simp [edgeScalarAt, h]
   · simp [edgeScalarAt, h, mul_comm]
 
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- Endpoint scalars invert pointwise under inversion of edge scalars.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; the corrected quotient
+uses nonzero edge scalars and the inverse endpoint action on the opposite end
+of each oriented edge. -/
+theorem edgeScalarAt_inv (c : (e : Edge G) → Units ℂ)
+    (v : V) (ie : IncidentEdge G v) :
+    edgeScalarAt (G := G) (fun e => (c e)⁻¹) v ie =
+      (edgeScalarAt (G := G) c v ie)⁻¹ := by
+  by_cases h : ie.1.1.1 = v
+  · simp [edgeScalarAt, h]
+  · simp [edgeScalarAt, h]
+
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- Endpoint scalar factors are nonzero.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; edge scalars are
+nonzero and the opposite endpoint uses their inverse. -/
+theorem edgeScalarAt_ne_zero (c : (e : Edge G) → Units ℂ)
+    (v : V) (ie : IncidentEdge G v) :
+    edgeScalarAt (G := G) c v ie ≠ 0 := by
+  by_cases h : ie.1.1.1 = v
+  · simp [edgeScalarAt, h]
+  · simp [edgeScalarAt, h]
+
 /-- Vertex-balanced edge scalars are closed under pointwise multiplication.
 
 Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; the corrected quotient
@@ -656,6 +682,25 @@ theorem IsVertexBalanced.mul {c d : (e : Edge G) → Units ℂ}
           ∏ ie : IncidentEdge G v, edgeScalarAt (G := G) d v ie := by
           rw [Finset.prod_mul_distrib]
     _ = 1 := by simp [hc v, hd v]
+
+/-- Vertex-balanced edge scalars are closed under pointwise inversion.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; the corrected quotient
+uses invertible edge scalars, and the inverse family again has oriented product
+`1` at every vertex. -/
+theorem IsVertexBalanced.inv {c : (e : Edge G) → Units ℂ}
+    (hc : IsVertexBalanced (G := G) c) :
+    IsVertexBalanced (G := G) (fun e => (c e)⁻¹) := by
+  intro v
+  calc
+    ∏ ie : IncidentEdge G v, edgeScalarAt (G := G) (fun e => (c e)⁻¹) v ie =
+        ∏ ie : IncidentEdge G v, (edgeScalarAt (G := G) c v ie)⁻¹ := by
+          refine Finset.prod_congr rfl ?_
+          intro ie _
+          simp [edgeScalarAt_inv]
+    _ = (∏ ie : IncidentEdge G v, edgeScalarAt (G := G) c v ie)⁻¹ := by
+          rw [Finset.prod_inv_distrib]
+    _ = 1 := by simp [hc v]
 
 /-- Two PEPS gauge families are equivalent modulo balanced edge scalars if,
 after inserting the corresponding endpoint scalars, they induce the same
@@ -680,6 +725,29 @@ theorem GaugeEquivModEdgeScalars.refl (A : Tensor G d)
     simp [edgeScalarAt]
   · intro v ie
     simp [edgeScalarAt]
+
+/-- Gauge equivalence modulo balanced edge scalars is symmetric.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; reversing a balanced
+edge-scalar reweighting uses the inverse edge-scalar family. -/
+theorem GaugeEquivModEdgeScalars.symm {A : Tensor G d}
+    {X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ}
+    (hXY : GaugeEquivModEdgeScalars (G := G) A X Y) :
+    GaugeEquivModEdgeScalars (G := G) A Y X := by
+  rcases hXY with ⟨c, hc, hXY⟩
+  refine ⟨fun e => (c e)⁻¹, IsVertexBalanced.inv (G := G) hc, ?_⟩
+  intro v ie
+  let s := edgeScalarAt (G := G) c v ie
+  have hs : s ≠ 0 := edgeScalarAt_ne_zero (G := G) c v ie
+  calc
+    edgeGaugeAt A Y v ie = s⁻¹ • (s • edgeGaugeAt A Y v ie) := by
+      rw [smul_smul, inv_mul_cancel₀ hs, one_smul]
+    _ = s⁻¹ • edgeGaugeAt A X v ie := by
+      rw [← hXY v ie]
+    _ =
+        edgeScalarAt (G := G) (fun e => (c e)⁻¹) v ie •
+          edgeGaugeAt A X v ie := by
+          rw [edgeScalarAt_inv]
 
 /-- Gauge equivalence modulo balanced edge scalars is transitive.
 

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -632,6 +632,19 @@ def GaugeEquivModEdgeScalars (A : Tensor G d)
         edgeGaugeAt A X v ie =
           edgeScalarAt (G := G) c v ie • edgeGaugeAt A Y v ie
 
+/-- Gauge equivalence modulo balanced edge scalars is reflexive.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; the identity edge-scalar
+family is vertex-balanced and leaves every oriented endpoint action unchanged. -/
+theorem GaugeEquivModEdgeScalars.refl (A : Tensor G d)
+    (X : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ) :
+    GaugeEquivModEdgeScalars (G := G) A X X := by
+  refine ⟨fun _ => 1, ?_, ?_⟩
+  · intro v
+    simp [edgeScalarAt]
+  · intro v ie
+    simp [edgeScalarAt]
+
 /-- Balanced edge-scalar reweightings do not change the gauged tensor at a
 vertex. -/
 theorem GaugeEquivModEdgeScalars.gaugeVertex_eq

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -632,7 +632,8 @@ theorem edgeScalarAt_mul (c d : (e : Edge G) → Units ℂ)
       edgeScalarAt (G := G) c v ie * edgeScalarAt (G := G) d v ie := by
   by_cases h : ie.1.1.1 = v
   · simp [edgeScalarAt, h]
-  · simp [edgeScalarAt, h, mul_comm]
+  · simpa [edgeScalarAt, h] using
+      (mul_comm (((d ie.1 : Units ℂ) : ℂ)⁻¹) (((c ie.1 : Units ℂ) : ℂ)⁻¹))
 
 omit [Fintype V] [DecidableRel G.Adj] in
 /-- Endpoint scalars invert pointwise under inversion of edge scalars.
@@ -737,8 +738,10 @@ theorem GaugeEquivModEdgeScalars.symm {A : Tensor G d}
   rcases hXY with ⟨c, hc, hXY⟩
   refine ⟨fun e => (c e)⁻¹, IsVertexBalanced.inv (G := G) hc, ?_⟩
   intro v ie
-  let s := edgeScalarAt (G := G) c v ie
-  have hs : s ≠ 0 := edgeScalarAt_ne_zero (G := G) c v ie
+  set s : ℂ := edgeScalarAt (G := G) c v ie with hs_def
+  have hs : s ≠ 0 := by
+    rw [hs_def]
+    exact edgeScalarAt_ne_zero (G := G) c v ie
   calc
     edgeGaugeAt A Y v ie = s⁻¹ • (s • edgeGaugeAt A Y v ie) := by
       rw [smul_smul, inv_mul_cancel₀ hs, one_smul]
@@ -747,7 +750,7 @@ theorem GaugeEquivModEdgeScalars.symm {A : Tensor G d}
     _ =
         edgeScalarAt (G := G) (fun e => (c e)⁻¹) v ie •
           edgeGaugeAt A X v ie := by
-          rw [edgeScalarAt_inv]
+          rw [edgeScalarAt_inv, ← hs_def]
 
 /-- Gauge equivalence modulo balanced edge scalars is transitive.
 

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -621,6 +621,42 @@ endpoint scalars is `1` at every vertex. -/
 def IsVertexBalanced (c : (e : Edge G) → Units ℂ) : Prop :=
   ∀ v : V, ∏ ie : IncidentEdge G v, edgeScalarAt (G := G) c v ie = 1
 
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- Endpoint scalars multiply pointwise under multiplication of edge scalars.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; endpoint factors are
+defined by the oriented edge scalar and its inverse. -/
+theorem edgeScalarAt_mul (c d : (e : Edge G) → Units ℂ)
+    (v : V) (ie : IncidentEdge G v) :
+    edgeScalarAt (G := G) (fun e => c e * d e) v ie =
+      edgeScalarAt (G := G) c v ie * edgeScalarAt (G := G) d v ie := by
+  by_cases h : ie.1.1.1 = v
+  · simp [edgeScalarAt, h]
+  · simp [edgeScalarAt, h, mul_comm]
+
+/-- Vertex-balanced edge scalars are closed under pointwise multiplication.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; the corrected quotient
+uses the multiplicative group of edge scalars whose oriented product is `1` at
+each vertex. -/
+theorem IsVertexBalanced.mul {c d : (e : Edge G) → Units ℂ}
+    (hc : IsVertexBalanced (G := G) c)
+    (hd : IsVertexBalanced (G := G) d) :
+    IsVertexBalanced (G := G) (fun e => c e * d e) := by
+  intro v
+  calc
+    ∏ ie : IncidentEdge G v, edgeScalarAt (G := G) (fun e => c e * d e) v ie =
+        ∏ ie : IncidentEdge G v,
+          edgeScalarAt (G := G) c v ie * edgeScalarAt (G := G) d v ie := by
+          refine Finset.prod_congr rfl ?_
+          intro ie _
+          simp [edgeScalarAt_mul]
+    _ =
+        (∏ ie : IncidentEdge G v, edgeScalarAt (G := G) c v ie) *
+          ∏ ie : IncidentEdge G v, edgeScalarAt (G := G) d v ie := by
+          rw [Finset.prod_mul_distrib]
+    _ = 1 := by simp [hc v, hd v]
+
 /-- Two PEPS gauge families are equivalent modulo balanced edge scalars if,
 after inserting the corresponding endpoint scalars, they induce the same
 oriented edge action on every incident half-edge. -/
@@ -644,6 +680,36 @@ theorem GaugeEquivModEdgeScalars.refl (A : Tensor G d)
     simp [edgeScalarAt]
   · intro v ie
     simp [edgeScalarAt]
+
+/-- Gauge equivalence modulo balanced edge scalars is transitive.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; composing two balanced
+edge-scalar reweightings multiplies their edge scalars, and the balancing
+condition is multiplicatively closed at every vertex. -/
+theorem GaugeEquivModEdgeScalars.trans {A : Tensor G d}
+    {X Y Z : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ}
+    (hXY : GaugeEquivModEdgeScalars (G := G) A X Y)
+    (hYZ : GaugeEquivModEdgeScalars (G := G) A Y Z) :
+    GaugeEquivModEdgeScalars (G := G) A X Z := by
+  rcases hXY with ⟨c, hc, hXY⟩
+  rcases hYZ with ⟨d, hd, hYZ⟩
+  refine ⟨fun e => c e * d e, IsVertexBalanced.mul (G := G) hc hd, ?_⟩
+  intro v ie
+  calc
+    edgeGaugeAt A X v ie =
+        edgeScalarAt (G := G) c v ie • edgeGaugeAt A Y v ie := hXY v ie
+    _ =
+        edgeScalarAt (G := G) c v ie •
+          (edgeScalarAt (G := G) d v ie • edgeGaugeAt A Z v ie) := by
+          rw [hYZ v ie]
+    _ =
+        (edgeScalarAt (G := G) c v ie * edgeScalarAt (G := G) d v ie) •
+          edgeGaugeAt A Z v ie := by
+          rw [smul_smul]
+    _ =
+        edgeScalarAt (G := G) (fun e => c e * d e) v ie •
+          edgeGaugeAt A Z v ie := by
+          rw [edgeScalarAt_mul]
 
 /-- Balanced edge-scalar reweightings do not change the gauged tensor at a
 vertex. -/

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -811,6 +811,32 @@ theorem GaugeEquivModEdgeScalars.gaugeVertex_eq
             rw [hc v, one_mul]
   rw [hprod]
 
+/-- Balanced edge-scalar equivalent gauges define the same gauged PEPS tensor.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; balanced endpoint
+scalars leave every local gauged tensor unchanged, hence the whole gauged
+tensor is unchanged. -/
+theorem GaugeEquivModEdgeScalars.applyGauge_eq
+    {A : Tensor G d}
+    {X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ}
+    (hXY : GaugeEquivModEdgeScalars (G := G) A X Y) :
+    applyGauge A X = applyGauge A Y := by
+  simp [applyGauge]
+  funext v η σ
+  exact GaugeEquivModEdgeScalars.gaugeVertex_eq (G := G) hXY v η σ
+
+/-- Balanced edge-scalar equivalent gauges give the same PEPS state.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; the balanced quotient
+acts trivially on every local gauged tensor, and hence on the contracted state. -/
+theorem GaugeEquivModEdgeScalars.applyGauge_sameState
+    {A : Tensor G d}
+    {X Y : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ}
+    (hXY : GaugeEquivModEdgeScalars (G := G) A X Y) :
+    SameState (applyGauge A X) (applyGauge A Y) := by
+  intro σ
+  rw [GaugeEquivModEdgeScalars.applyGauge_eq (G := G) hXY]
+
 /-! ### Uniqueness modulo balanced edge scalars -/
 
 /-- If the gauged vertex tensors produced by two gauge families agree pointwise

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2725,6 +2725,39 @@ injective and normal PEPS, following Theorems~2 and~3 of
     endpoint scalars is $1$ at every vertex.
 \end{definition}
 
+\begin{theorem}[Multiplication of oriented edge scalars]%
+    \label{thm:edgeScalarAt_mul}
+    \lean{TNLean.PEPS.edgeScalarAt_mul}
+    \leanok
+    \uses{def:GaugeEquivModEdgeScalars}
+    If two edge-scalar families are multiplied pointwise, then their endpoint
+    scalar on each oriented half-edge is the product of the two endpoint
+    scalars.
+    \begin{center}
+        \TNPEPSEdgeGaugeOrientation
+    \end{center}
+\end{theorem}
+
+\begin{proof}\leanok
+    At the lower endpoint this is ordinary multiplication of the edge scalars.
+    At the upper endpoint it is multiplication of their inverses, which agrees
+    because the scalars lie in a commutative field.
+\end{proof}
+
+\begin{theorem}[Product of balanced edge scalars]%
+    \label{thm:IsVertexBalanced_mul}
+    \lean{TNLean.PEPS.IsVertexBalanced.mul}
+    \leanok
+    \uses{def:GaugeEquivModEdgeScalars, thm:edgeScalarAt_mul}
+    The pointwise product of two vertex-balanced edge-scalar families is again
+    vertex-balanced.
+\end{theorem}
+
+\begin{proof}\leanok
+    At each vertex, multiply the two oriented endpoint products. Both products
+    are $1$, so the product family is also balanced.
+\end{proof}
+
 \begin{theorem}[Reflexivity of balanced edge-scalar equivalence]%
     \label{thm:GaugeEquivModEdgeScalars_refl}
     \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.refl}
@@ -2744,6 +2777,25 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Use the constant edge-scalar family $c_e=1$. Both endpoint actions are
     unchanged, and the product of the incident endpoint scalars at every vertex
     is $1$.
+\end{proof}
+
+\begin{theorem}[Transitivity of balanced edge-scalar equivalence]%
+    \label{thm:GaugeEquivModEdgeScalars_trans}
+    \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.trans}
+    \leanok
+    \uses{def:GaugeEquivModEdgeScalars, thm:IsVertexBalanced_mul}
+    If one gauge family differs from a second by balanced edge scalars, and the
+    second differs from a third by balanced edge scalars, then the first differs
+    from the third by the pointwise product of the two scalar families.
+    \begin{center}
+        \TNPEPSEdgeGaugeOrientation
+    \end{center}
+\end{theorem}
+
+\begin{proof}\leanok
+    Compose the two endpoint rescalings. The endpoint scalar is the product of
+    the two endpoint scalars, and the product family is balanced by
+    Theorem~\ref{thm:IsVertexBalanced_mul}.
 \end{proof}
 
 \begin{theorem}[Balanced edge scalars preserve the local gauge action]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2725,6 +2725,27 @@ injective and normal PEPS, following Theorems~2 and~3 of
     endpoint scalars is $1$ at every vertex.
 \end{definition}
 
+\begin{theorem}[Reflexivity of balanced edge-scalar equivalence]%
+    \label{thm:GaugeEquivModEdgeScalars_refl}
+    \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.refl}
+    \leanok
+    \uses{def:GaugeEquivModEdgeScalars}
+    Every edge-gauge family is equivalent to itself modulo balanced edge
+    scalars. The witnessing scalar family is identically $1$, whose oriented
+    product at every vertex is $1$.
+    Diagrammatically, the extra endpoint scalars on the oriented edge are
+    invisible factors multiplying the two endpoint actions:
+    \begin{center}
+        \TNPEPSEdgeGaugeOrientation
+    \end{center}
+\end{theorem}
+
+\begin{proof}\leanok
+    Use the constant edge-scalar family $c_e=1$. Both endpoint actions are
+    unchanged, and the product of the incident endpoint scalars at every vertex
+    is $1$.
+\end{proof}
+
 \begin{theorem}[Balanced edge scalars preserve the local gauge action]%
     \label{thm:GaugeEquivModEdgeScalars_gaugeVertex_eq}
     \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.gaugeVertex_eq}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2714,34 +2714,43 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Theorem~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
+\begin{definition}[Oriented endpoint scalar]%
+    \label{def:edgeScalarAt}
+    \lean{TNLean.PEPS.edgeScalarAt}
+    \leanok
+    \uses{def:edgeGaugeAt}
+    An edge-scalar family $c=(c_e)_{e\in E}$ determines the endpoint scalar
+    $c_{v,e}$ by $c_{v,e}=c_e$ at the lower endpoint of $e$ and
+    $c_{v,e}=c_e^{-1}$ at the upper endpoint.
+\end{definition}
+
 \begin{definition}[Vertex-balanced edge scalars]%
     \label{def:IsVertexBalanced}
     \lean{TNLean.PEPS.IsVertexBalanced}
     \leanok
-    \uses{def:edgeGaugeAt}
-    An edge-scalar family is vertex-balanced when the product of its oriented
-    endpoint scalars is $1$ at every vertex.
+    \uses{def:edgeScalarAt}
+    An edge-scalar family is vertex-balanced when
+    $\prod_{e\ni v} c_{v,e}=1$ for every vertex $v$.
 \end{definition}
 
 \begin{definition}[Gauge equivalence modulo balanced edge scalars]%
     \label{def:GaugeEquivModEdgeScalars}
     \lean{TNLean.PEPS.GaugeEquivModEdgeScalars}
     \leanok
-    \uses{def:edgeGaugeAt, def:IsVertexBalanced}
+    \uses{def:edgeGaugeAt, def:edgeScalarAt, def:IsVertexBalanced}
     Two gauge families are equivalent modulo balanced edge scalars if there is
     a nonzero scalar $c_e$ on each edge such that the corresponding endpoint
-    actions rescale the oriented edge gauges, and the oriented product of those
-    endpoint scalars is $1$ at every vertex.
+    actions satisfy $X_{v,e}=c_{v,e}Y_{v,e}$, and
+    $\prod_{e\ni v}c_{v,e}=1$ for every vertex $v$.
 \end{definition}
 
 \begin{theorem}[Multiplication of oriented edge scalars]%
     \label{thm:edgeScalarAt_mul}
     \lean{TNLean.PEPS.edgeScalarAt_mul}
     \leanok
-    \uses{def:GaugeEquivModEdgeScalars}
-    If two edge-scalar families are multiplied pointwise, then their endpoint
-    scalar on each oriented half-edge is the product of the two endpoint
-    scalars.
+    \uses{def:edgeScalarAt}
+    If two edge-scalar families are multiplied, then their endpoint scalars
+    satisfy $(cd)_{v,e}=c_{v,e}d_{v,e}$ on every oriented half-edge.
     \begin{center}
         \TNPEPSEdgeGaugeOrientation
     \end{center}
@@ -2749,31 +2758,31 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{proof}\leanok
     At the lower endpoint this is ordinary multiplication of the edge scalars.
-    At the upper endpoint it is multiplication of their inverses, which agrees
-    because the scalars lie in a commutative field.
+    At the upper endpoint, $(c_ed_e)^{-1}=c_e^{-1}d_e^{-1}$ because the
+    edge scalars lie in $\mathbb C^\times$.
 \end{proof}
 
 \begin{theorem}[Inversion of oriented edge scalars]%
     \label{thm:edgeScalarAt_inv}
     \lean{TNLean.PEPS.edgeScalarAt_inv}
     \leanok
-    \uses{def:GaugeEquivModEdgeScalars}
-    Inverting an edge-scalar family inverts the scalar appearing on every
-    oriented endpoint.
+    \uses{def:edgeScalarAt}
+    Inverting an edge-scalar family gives
+    $(c^{-1})_{v,e}=c_{v,e}^{-1}$ on every oriented endpoint.
 \end{theorem}
 
 \begin{proof}\leanok
-    Check the two endpoint cases. At the upper endpoint the definition already
-    uses the inverse scalar, so inverting the edge family removes that inverse.
+    At the lower endpoint, $(c^{-1})_{v,e}=c_e^{-1}=c_{v,e}^{-1}$.
+    At the upper endpoint,
+    $(c^{-1})_{v,e}=(c_e^{-1})^{-1}=c_{v,e}^{-1}$.
 \end{proof}
 
 \begin{theorem}[Nonzero oriented edge scalars]%
     \label{thm:edgeScalarAt_ne_zero}
     \lean{TNLean.PEPS.edgeScalarAt_ne_zero}
     \leanok
-    \uses{def:GaugeEquivModEdgeScalars}
-    Every oriented endpoint scalar attached to an edge-scalar family is
-    nonzero.
+    \uses{def:edgeScalarAt}
+    Every oriented endpoint scalar satisfies $c_{v,e}\ne 0$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2784,29 +2793,30 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \label{thm:IsVertexBalanced_mul}
     \lean{TNLean.PEPS.IsVertexBalanced.mul}
     \leanok
-    \uses{def:GaugeEquivModEdgeScalars, thm:edgeScalarAt_mul}
+    \uses{def:IsVertexBalanced, thm:edgeScalarAt_mul}
     The pointwise product of two vertex-balanced edge-scalar families is again
     vertex-balanced.
 \end{theorem}
 
 \begin{proof}\leanok
-    At each vertex, multiply the two oriented endpoint products. Both products
-    are $1$, so the product family is also balanced.
+    For every vertex $v$,
+    $\prod_{e\ni v}(cd)_{v,e}=
+    (\prod_{e\ni v}c_{v,e})(\prod_{e\ni v}d_{v,e})=1\cdot 1=1$.
 \end{proof}
 
 \begin{theorem}[Inverse of balanced edge scalars]%
     \label{thm:IsVertexBalanced_inv}
     \lean{TNLean.PEPS.IsVertexBalanced.inv}
     \leanok
-    \uses{def:GaugeEquivModEdgeScalars, thm:edgeScalarAt_inv}
+    \uses{def:IsVertexBalanced, thm:edgeScalarAt_inv}
     The pointwise inverse of a vertex-balanced edge-scalar family is again
     vertex-balanced.
 \end{theorem}
 
 \begin{proof}\leanok
-    At each vertex, the oriented product for the inverse family is the inverse
-    of the original oriented product. Since the original product is $1$, its
-    inverse is also $1$.
+    For every vertex $v$,
+    $\prod_{e\ni v}(c^{-1})_{v,e}=
+    (\prod_{e\ni v}c_{v,e})^{-1}=1^{-1}=1$.
 \end{proof}
 
 \begin{theorem}[Reflexivity of balanced edge-scalar equivalence]%
@@ -2815,19 +2825,15 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:GaugeEquivModEdgeScalars}
     Every edge-gauge family is equivalent to itself modulo balanced edge
-    scalars. The witnessing scalar family is identically $1$, whose oriented
-    product at every vertex is $1$.
-    Diagrammatically, the extra endpoint scalars on the oriented edge are
-    invisible factors multiplying the two endpoint actions:
+    scalars, witnessed by $c_e=1$ for every edge $e$.
     \begin{center}
         \TNPEPSEdgeGaugeOrientation
     \end{center}
 \end{theorem}
 
 \begin{proof}\leanok
-    Use the constant edge-scalar family $c_e=1$. Both endpoint actions are
-    unchanged, and the product of the incident endpoint scalars at every vertex
-    is $1$.
+    If $c_e=1$, then $c_{v,e}=1$, $X_{v,e}=c_{v,e}X_{v,e}$, and
+    $\prod_{e\ni v}c_{v,e}=1$.
 \end{proof}
 
 \begin{theorem}[Symmetry of balanced edge-scalar equivalence]%
@@ -2844,15 +2850,17 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{theorem}
 
 \begin{proof}\leanok
-    Use the inverse edge-scalar family. The endpoint scalar is nonzero, so the
-    endpoint equality may be multiplied by its inverse.
+    If $X_{v,e}=c_{v,e}Y_{v,e}$ with $c_{v,e}\ne 0$, then
+    $Y_{v,e}=c_{v,e}^{-1}X_{v,e}$. The inverse scalar family is balanced by
+    Theorem~\ref{thm:IsVertexBalanced_inv}.
 \end{proof}
 
 \begin{theorem}[Transitivity of balanced edge-scalar equivalence]%
     \label{thm:GaugeEquivModEdgeScalars_trans}
     \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.trans}
     \leanok
-    \uses{def:GaugeEquivModEdgeScalars, thm:IsVertexBalanced_mul}
+    \uses{def:GaugeEquivModEdgeScalars, thm:IsVertexBalanced_mul,
+        thm:edgeScalarAt_mul}
     If one gauge family differs from a second by balanced edge scalars, and the
     second differs from a third by balanced edge scalars, then the first differs
     from the third by the pointwise product of the two scalar families.
@@ -2862,10 +2870,36 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{theorem}
 
 \begin{proof}\leanok
-    Compose the two endpoint rescalings. The endpoint scalar is the product of
-    the two endpoint scalars, and the product family is balanced by
-    Theorem~\ref{thm:IsVertexBalanced_mul}.
+    From $X_{v,e}=c_{v,e}Y_{v,e}$ and $Y_{v,e}=d_{v,e}Z_{v,e}$ one obtains
+    $X_{v,e}=(c_{v,e}d_{v,e})Z_{v,e}$. The product scalar family is balanced
+    by Theorem~\ref{thm:IsVertexBalanced_mul}.
 \end{proof}
+
+\begin{theorem}[The balanced edge-scalar quotient is an equivalence relation]%
+    \label{thm:GaugeEquivModEdgeScalars_equivalence}
+    \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.equivalence}
+    \leanok
+    \uses{thm:GaugeEquivModEdgeScalars_refl,
+        thm:GaugeEquivModEdgeScalars_symm,
+        thm:GaugeEquivModEdgeScalars_trans}
+    Gauge equivalence modulo balanced edge scalars is reflexive, symmetric,
+    and transitive.
+\end{theorem}
+
+\begin{proof}\leanok
+    Reflexivity is witnessed by $1$, symmetry by $c^{-1}$, and transitivity
+    by $cd$.
+\end{proof}
+
+\begin{definition}[The balanced edge-scalar quotient relation]%
+    \label{def:GaugeEquivModEdgeScalars_setoid}
+    \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.setoid}
+    \leanok
+    \uses{def:GaugeEquivModEdgeScalars,
+        thm:GaugeEquivModEdgeScalars_equivalence}
+    The preceding equivalence relation is the quotient relation on edge-gauge
+    families modulo vertex-balanced edge scalars.
+\end{definition}
 
 \begin{theorem}[Balanced edge scalars preserve the local gauge action]%
     \label{thm:GaugeEquivModEdgeScalars_gaugeVertex_eq}
@@ -2877,10 +2911,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{theorem}
 
 \begin{proof}\leanok\uses{def:GaugeEquivModEdgeScalars, def:gaugeVertex}
-    In the defining sum for the gauged tensor, each incident edge contributes
-    its endpoint scalar factor in addition to the original gauge entry.
-    The product of these endpoint scalars is $1$ by the balancing condition,
-    so every summand is unchanged.
+    In each summand of the gauged tensor at $v$, the edge scalars contribute
+    the factor $\prod_{e\ni v}c_{v,e}=1$. Hence the summand, and therefore
+    the whole local tensor, is unchanged.
 \end{proof}
 
 \begin{theorem}[Balanced edge scalars preserve the gauged tensor]%
@@ -2896,9 +2929,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{theorem}
 
 \begin{proof}\leanok
-    Compare the gauged tensor component at each vertex, virtual index, and
-    physical index. The preceding vertex-level theorem gives each component
-    equality.
+    For every vertex $v$, virtual index $\eta$, and physical index $\sigma$,
+    $(A^X)_v(\eta,\sigma)=(A^Y)_v(\eta,\sigma)$ for the two gauged tensors by
+    Theorem~\ref{thm:GaugeEquivModEdgeScalars_gaugeVertex_eq}. Hence the
+    two gauged tensors are equal.
 \end{proof}
 
 \begin{theorem}[Balanced edge scalars preserve the gauged state]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2714,11 +2714,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Theorem~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
+\begin{definition}[Vertex-balanced edge scalars]%
+    \label{def:IsVertexBalanced}
+    \lean{TNLean.PEPS.IsVertexBalanced}
+    \leanok
+    \uses{def:edgeGaugeAt}
+    An edge-scalar family is vertex-balanced when the product of its oriented
+    endpoint scalars is $1$ at every vertex.
+\end{definition}
+
 \begin{definition}[Gauge equivalence modulo balanced edge scalars]%
     \label{def:GaugeEquivModEdgeScalars}
     \lean{TNLean.PEPS.GaugeEquivModEdgeScalars}
     \leanok
-    \uses{def:edgeGaugeAt}
+    \uses{def:edgeGaugeAt, def:IsVertexBalanced}
     Two gauge families are equivalent modulo balanced edge scalars if there is
     a nonzero scalar $c_e$ on each edge such that the corresponding endpoint
     actions rescale the oriented edge gauges, and the oriented product of those
@@ -2744,6 +2753,33 @@ injective and normal PEPS, following Theorems~2 and~3 of
     because the scalars lie in a commutative field.
 \end{proof}
 
+\begin{theorem}[Inversion of oriented edge scalars]%
+    \label{thm:edgeScalarAt_inv}
+    \lean{TNLean.PEPS.edgeScalarAt_inv}
+    \leanok
+    \uses{def:GaugeEquivModEdgeScalars}
+    Inverting an edge-scalar family inverts the scalar appearing on every
+    oriented endpoint.
+\end{theorem}
+
+\begin{proof}\leanok
+    Check the two endpoint cases. At the upper endpoint the definition already
+    uses the inverse scalar, so inverting the edge family removes that inverse.
+\end{proof}
+
+\begin{theorem}[Nonzero oriented edge scalars]%
+    \label{thm:edgeScalarAt_ne_zero}
+    \lean{TNLean.PEPS.edgeScalarAt_ne_zero}
+    \leanok
+    \uses{def:GaugeEquivModEdgeScalars}
+    Every oriented endpoint scalar attached to an edge-scalar family is
+    nonzero.
+\end{theorem}
+
+\begin{proof}\leanok
+    Edge scalars are units, and the inverse of a unit is again a unit.
+\end{proof}
+
 \begin{theorem}[Product of balanced edge scalars]%
     \label{thm:IsVertexBalanced_mul}
     \lean{TNLean.PEPS.IsVertexBalanced.mul}
@@ -2756,6 +2792,21 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     At each vertex, multiply the two oriented endpoint products. Both products
     are $1$, so the product family is also balanced.
+\end{proof}
+
+\begin{theorem}[Inverse of balanced edge scalars]%
+    \label{thm:IsVertexBalanced_inv}
+    \lean{TNLean.PEPS.IsVertexBalanced.inv}
+    \leanok
+    \uses{def:GaugeEquivModEdgeScalars, thm:edgeScalarAt_inv}
+    The pointwise inverse of a vertex-balanced edge-scalar family is again
+    vertex-balanced.
+\end{theorem}
+
+\begin{proof}\leanok
+    At each vertex, the oriented product for the inverse family is the inverse
+    of the original oriented product. Since the original product is $1$, its
+    inverse is also $1$.
 \end{proof}
 
 \begin{theorem}[Reflexivity of balanced edge-scalar equivalence]%
@@ -2777,6 +2828,24 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Use the constant edge-scalar family $c_e=1$. Both endpoint actions are
     unchanged, and the product of the incident endpoint scalars at every vertex
     is $1$.
+\end{proof}
+
+\begin{theorem}[Symmetry of balanced edge-scalar equivalence]%
+    \label{thm:GaugeEquivModEdgeScalars_symm}
+    \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.symm}
+    \leanok
+    \uses{def:GaugeEquivModEdgeScalars, thm:IsVertexBalanced_inv,
+        thm:edgeScalarAt_ne_zero}
+    If one gauge family differs from another by balanced edge scalars, then the
+    second differs from the first by the inverse balanced edge-scalar family.
+    \begin{center}
+        \TNPEPSEdgeGaugeOrientation
+    \end{center}
+\end{theorem}
+
+\begin{proof}\leanok
+    Use the inverse edge-scalar family. The endpoint scalar is nonzero, so the
+    endpoint equality may be multiplied by its inverse.
 \end{proof}
 
 \begin{theorem}[Transitivity of balanced edge-scalar equivalence]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2883,6 +2883,39 @@ injective and normal PEPS, following Theorems~2 and~3 of
     so every summand is unchanged.
 \end{proof}
 
+\begin{theorem}[Balanced edge scalars preserve the gauged tensor]%
+    \label{thm:GaugeEquivModEdgeScalars_applyGauge_eq}
+    \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.applyGauge_eq}
+    \leanok
+    \uses{thm:GaugeEquivModEdgeScalars_gaugeVertex_eq, def:applyGauge}
+    If two gauge families differ by a balanced edge-scalar reweighting, then
+    applying them to the same PEPS tensor produces the same gauged tensor.
+    \begin{center}
+        \TNPEPSGaugeVertexAction
+    \end{center}
+\end{theorem}
+
+\begin{proof}\leanok
+    Compare the gauged tensor component at each vertex, virtual index, and
+    physical index. The preceding vertex-level theorem gives each component
+    equality.
+\end{proof}
+
+\begin{theorem}[Balanced edge scalars preserve the gauged state]%
+    \label{thm:GaugeEquivModEdgeScalars_applyGauge_sameState}
+    \lean{TNLean.PEPS.GaugeEquivModEdgeScalars.applyGauge_sameState}
+    \leanok
+    \uses{thm:GaugeEquivModEdgeScalars_applyGauge_eq, def:peps_same_state}
+    If two gauge families differ by a balanced edge-scalar reweighting, then
+    the PEPS tensors obtained by applying those gauge families represent the
+    same state.
+\end{theorem}
+
+\begin{proof}\leanok
+    The two gauged tensors are equal, hence all of their state coefficients are
+    equal.
+\end{proof}
+
 \begin{theorem}[Gauge uniqueness modulo balanced edge scalars]%
     \label{thm:gauge_unique_mod_edge_scalars}
     \lean{TNLean.PEPS.gauge_unique_mod_edge_scalars}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2196,7 +2196,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     two top-collar contiguous $3\times2$ rectangles.  Consequently, if the
     local $T$-region is injective, then rectangular injectivity and union
     closure imply that $A_3$ is injective.  There is also a transposed
-    $7\times5$ horizontal-frame collar identity, now using two contiguous
+    $7\times5$ horizontal-frame collar identity with two contiguous
     $2\times3$ right-collar rectangles.  For the rotated vertical
     edge-blocking regions, the corresponding complement is the rotated local
     $T$-region together with the same two right-collar rectangles; hence rotated
@@ -2970,8 +2970,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Section~3]{Molnar2018NormalPEPS}. The middle-region blocked coefficient is
     constructed by the preceding definitions; the remaining local-gauge step is
     the comparison with the corresponding three-site injective chain.
-    The uniqueness statement has now
-    been repaired to a quotient by balanced edge scalars, but its proof still
-    requires the same blocking construction together with the corresponding
-    tensor-factor uniqueness statement at a single vertex.
+    The corrected uniqueness statement is a quotient by balanced edge scalars;
+    its proof still requires the same blocking construction together with the
+    corresponding tensor-factor uniqueness statement at a single vertex.
 \end{remark}

--- a/docs/paper-gaps/peps_gauge_edge_scalars.tex
+++ b/docs/paper-gaps/peps_gauge_edge_scalars.tex
@@ -72,11 +72,14 @@ vertex $v$ by the factors $c_{v,e}$ multiplies the gauged local tensor at $v$ by
 $\prod_{e\ni v} c_{v,e}$. If the scalar family is vertex-balanced, this product
 is $1$ at every vertex, so all local gauged tensors are unchanged. Thus local
 gauge uniqueness can at best be uniqueness modulo these balanced edge scalars.
-The formal statement uses this quotient as the corrected uniqueness statement.\footnote{The formal definitions are
+The formal statement uses this quotient as the corrected uniqueness statement;
+the quotient relation is now recorded as an equivalence relation on gauge
+families.\footnote{The formal definitions are
 \leanid{TNLean.PEPS.edgeScalarAt}, \leanid{TNLean.PEPS.IsVertexBalanced}, and
-\leanid{TNLean.PEPS.GaugeEquivModEdgeScalars} in
-\path{TNLean/PEPS/FundamentalTheorem.lean:603--625}. The corresponding
-blueprint entries are at \path{blueprint/src/chapter/ch13a_peps_ft.tex:375--423}.}
+\leanid{TNLean.PEPS.GaugeEquivModEdgeScalars}; the quotient relation is
+\leanid{TNLean.PEPS.GaugeEquivModEdgeScalars.setoid} in
+\path{TNLean/PEPS/FundamentalTheorem.lean}. The corresponding blueprint
+entries are in \path{blueprint/src/chapter/ch13a_peps_ft.tex}.}
 
 \section{The triangle witness}
 

--- a/docs/paper-gaps/peps_gauge_edge_scalars.tex
+++ b/docs/paper-gaps/peps_gauge_edge_scalars.tex
@@ -73,7 +73,7 @@ $\prod_{e\ni v} c_{v,e}$. If the scalar family is vertex-balanced, this product
 is $1$ at every vertex, so all local gauged tensors are unchanged. Thus local
 gauge uniqueness can at best be uniqueness modulo these balanced edge scalars.
 The formal statement uses this quotient as the corrected uniqueness statement;
-the quotient relation is now recorded as an equivalence relation on gauge
+the quotient relation is an equivalence relation on gauge
 families.\footnote{The formal definitions are
 \leanid{TNLean.PEPS.edgeScalarAt}, \leanid{TNLean.PEPS.IsVertexBalanced}, and
 \leanid{TNLean.PEPS.GaugeEquivModEdgeScalars}; the quotient relation is


### PR DESCRIPTION
### Motivation

This is preparatory work for #842. The proof of PEPS gauge uniqueness modulo balanced edge scalars still needs the tensor-factor scalar-ratio extraction step in `gauge_unique_mod_edge_scalars`; this PR does not claim that step. It proves the quotient laws for the graph-correct balanced edge-scalar relation.

The relevant source passage is `Papers/1804.04964/paper_normal.tex`, lines 1018-1045 and 1168-1212: the paper assigns edge gauges after blocking, absorbs them, and then uses a local proportionality argument before stating uniqueness up to scalar freedom. The corrected graph quotient is documented in `docs/paper-gaps/peps_gauge_edge_scalars.tex`.

### Description

- Proves the endpoint-scalar identities $(cd)_{v,e}=c_{v,e}d_{v,e}$, $(c^{-1})_{v,e}=c_{v,e}^{-1}$, and $c_{v,e}
e 0$.
- Proves that vertex-balanced edge-scalar families are closed under multiplication and inversion.
- Proves reflexivity, symmetry, and transitivity of `GaugeEquivModEdgeScalars`, and packages the resulting quotient relation.
- Proves that balanced edge-scalar equivalent gauge families give the same gauged tensor and hence the same PEPS state.
- Updates Chapter 13a with formula-driven statements and TikZ diagrams for the PEPS endpoint action.

### Testing

- `lake build TNLean.PEPS.FundamentalTheorem`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/PEPS/FundamentalTheorem.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_gauge_edge_scalars.tex`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check main..HEAD`
- `cd blueprint && leanblueprint web`

The targeted Lean build reports only the three pre-existing `sorry` warnings in `TNLean/PEPS/FundamentalTheorem.lean`.

Refs #842

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation; no runtime, auth, or API surface. Remaining `sorry` in uniqueness is unchanged in scope.
> 
> **Overview**
> This PR formalizes the **graph-correct balanced edge-scalar quotient** used for PEPS gauge uniqueness (prep for #842). It does **not** complete `gauge_unique_mod_edge_scalars`; that theorem still ends in `sorry` after the product-of-edge-gauge step.
> 
> In **`TNLean/PEPS/FundamentalTheorem.lean`**, it adds lemmas that oriented endpoint scalars multiply and invert compatibly with edge-scalar families, that **vertex-balanced** families are closed under product and inverse, and that **`GaugeEquivModEdgeScalars`** is an equivalence relation packaged as **`GaugeEquivModEdgeScalars.setoid`**. It also proves balanced equivalence preserves **`gaugeVertex`**, the full **`applyGauge`** tensor, and **`SameState`**.
> 
> **Blueprint** (`ch13a_peps_ft.tex`) and **`docs/paper-gaps/peps_gauge_edge_scalars.tex`** are expanded to match: explicit definitions for `edgeScalarAt` / `IsVertexBalanced`, the quotient laws, invariance theorems, and a note that the quotient is a formal equivalence relation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05da24d286cb8ac75afccd964590475f8b95ac15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->