### PR TITLE
feat(PEPS): recover endpoint virtual insertions

### DIFF
--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -94,6 +94,38 @@ theorem edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
   localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq A hA e.1.2 O₂
     (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M)
 
+/-- Projected endpoint physical realizations recover the corresponding virtual
+matrix insertion on both endpoints.
+
+This is the local endpoint part of the $O_1,O_2\mapsto W$ step in
+Lemma $\mathrm{inj\_isomorph}$: once the compressed physical actions are the
+canonical realizations of the same bond matrix, injectivity recovers the
+virtual insertion on the distinguished bond. The full three-site theorem still
+has to prove that such a common matrix is forced by equality of the two
+physical actions on the blocked state.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 363--486
+of the local paper source. -/
+theorem edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq
+    (A : Tensor G d) (hA : IsVertexInjective A) (e : Edge G)
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (hO₁ : (localProjector A hA e.1.1).comp (O₁.comp (localProjector A hA e.1.1)) =
+      physRealizeLocalOp A hA e.1.1
+        (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose))
+    (hO₂ : (localProjector A hA e.1.2).comp (O₂.comp (localProjector A hA e.1.2)) =
+      physRealizeLocalOp A hA e.1.2
+        (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M)) :
+    localVirtualOpOfPhysicalOp A hA e.1.1 O₁ =
+        localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose ∧
+      localVirtualOpOfPhysicalOp A hA e.1.2 O₂ =
+        localIncidentMatrixOp A (edgeRightIncident (G := G) e) M := by
+  constructor
+  · exact (edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
+      A hA e O₁ M).2 hO₁
+  · exact (edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
+      A hA e O₂ M).2 hO₂
+
 /-- The left-endpoint physical realization of a virtual matrix insertion
 reproduces the full inserted-edge coefficient.
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1175,6 +1175,31 @@ injective and normal PEPS, following Theorems~2 and~3 of
     incident edge of $e$.
 \end{proof}
 
+\begin{theorem}[Endpoint recovery of a common virtual insertion]%
+    \label{thm:peps_edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}
+    \lean{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}
+    \leanok
+    \uses{thm:peps_edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq,
+        thm:peps_edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq}
+    Let $e=(u,v)$. If
+    $P_uO_1P_u=\Phi_uT_{u,e}(M^{\mathsf T})\Psi_u$ and
+    $P_vO_2P_v=\Phi_vT_{v,e}(M)\Psi_v$, then
+    $\Psi_uO_1\Phi_u=T_{u,e}(M^{\mathsf T})$ and
+    $\Psi_vO_2\Phi_v=T_{v,e}(M)$.
+    Here $T_{w,e}(N)$ denotes the virtual operator on the legs incident to $w$
+    which acts by $N$ on the leg belonging to $e$ and by the identity on the
+    other incident legs.
+\end{theorem}
+\begin{proof}\leanok
+    The endpoint equivalences give
+    $P_uO_1P_u=\Phi_uT_{u,e}(M^{\mathsf T})\Psi_u
+    \iff \Psi_uO_1\Phi_u=T_{u,e}(M^{\mathsf T})$
+    and
+    $P_vO_2P_v=\Phi_vT_{v,e}(M)\Psi_v
+    \iff \Psi_vO_2\Phi_v=T_{v,e}(M)$.
+    The two hypotheses are the left sides of these equivalences.
+\end{proof}
+
 \begin{theorem}[Right-endpoint physical realization of the inserted coefficient]%
     \label{thm:peps_edgeInsertedCoeff_rightPhysicalRealization}
     \lean{TNLean.PEPS.edgeInsertedCoeff_eq_sum_right_physicalRealization}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -169,6 +169,10 @@ Theorem can be proved in the manner of the paper.
   because the ordinary boundary supplies the right bond index. The converse
   recovery $O_1,O_2\mapsto W$ remains open as
   \path{thm:peps_physicalToVirtualInsertion}.
+  Its local endpoint recovery component is now formalized by
+  \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}:
+  once the compressed endpoint actions are known to realize the same bond
+  matrix, the local virtual pullbacks recover that matrix on the shared bond.
 \item Equality of PEPS states must be upgraded to equality of edge-inserted
   coefficients after the three-site reduction. This is the step that produces
   the matrix-algebra isomorphism on the chosen bond. In the blueprint this is
@@ -233,6 +237,9 @@ It is meant to prevent the proof from drifting away from the source argument.
   and~\#1995.
 \item Lemma \path{inj_isomorph}, $O_1,O_2\mapsto W$:
   \path{thm:peps_physicalToVirtualInsertion}, tracked by issue~\#1370.
+  The endpoint projected-recovery component for a common bond matrix is
+  formalized by
+  \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}.
 \item Matrix-insertion algebra isomorphism:
   \path{thm:peps_edgeBlockedInsertionAlgebraIsomorphism}, tracked by
   issue~\#1367.


### PR DESCRIPTION
### Motivation
- Formalizes the local component of the converse physical-to-virtual step in Lemma `inj_isomorph` (arXiv:1804.04964, Section 3), one of the two internal ingredients of the insertion-algebra isomorphism.
- Source: `Papers/1804.04964/paper_normal.tex`, lines 355–486. From two neighboring physical operations $O_1, O_2$ acting identically on the three-site state, the proof inverts adjacent injective tensors to obtain virtual operations $W$ and $V$, then uses injectivity to identify them.
- Advances formalization of blueprint node `thm:peps_physicalToVirtualInsertion` (see #1370).

### Description
- `TNLean/PEPS/InsertionRealization.lean`: adds `edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq`. When the compressed endpoint physical actions already realize the same bond matrix $M$ (left endpoint with $M^{\mathsf{T}}$, right endpoint with $M$), the virtual pullbacks recover the corresponding one-edge insertions: $\Psi_u O_1 \Phi_u = T_{u,e}(M^{\mathsf{T}})$ and $\Psi_v O_2 \Phi_v = T_{v,e}(M)$. The proof applies the existing left/right projected recovery equivalences.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds the matching theorem entry with `\leanok` and `\lean{...}` tags.
- `docs/paper-gaps/peps_injective_ft_section3_route.tex`: records the local endpoint component of the $O_1, O_2 \mapsto W$ step as formalized.
- The full three-site statement `thm:peps_physicalToVirtualInsertion` remains open: the remaining step is to prove that equal physical actions on the blocked state force the existence of a common bond matrix $M$.

### Testing
- `lake build TNLean.PEPS.InsertionRealization`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/InsertionRealization.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `git diff --check origin/main..HEAD`
- `cd blueprint && leanblueprint web`
- Lean CI (`lean_action_ci.yml`) validates the full build.

---
Addresses #1370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a Lean theorem proved from existing equivalences plus blueprint/gap documentation only; no auth, I/O, or behavioral runtime changes.
> 
> **Overview**
> Adds the **local endpoint half** of the converse physical-to-virtual step in Lemma `inj_isomorph` (Section 3, arXiv:1804.04964): when both endpoints’ **projected** physical actions already realize the same bond matrix \(M\) (left with \(M^{\mathsf T}\), right with \(M\)), the virtual pullbacks are forced to be the corresponding one-edge insertions on that bond.
> 
> In **`TNLean/PEPS/InsertionRealization.lean`**, new theorem `edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq` is a short `constructor` proof applying the existing left/right **iff** projected-recovery lemmas. **`blueprint/src/chapter/ch13a_peps_ft.tex`** gets the matching `\lean` / `\leanok` theorem block. **`docs/paper-gaps/peps_injective_ft_section3_route.tex`** records this as done for the \(O_1,O_2 \mapsto W\) route while **`thm:peps_physicalToVirtualInsertion`** (proving a common \(M\) from equal three-site physical actions) stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57cb812860949e6db7b66840cdc25613c4cbde79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->