### PR TITLE
doc(blueprint): make BNT overlap sketches formula-driven

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -284,11 +284,19 @@ and~\cite{Cirac2021Matrix}.
 
 \begin{proof}\leanok\uses{lem:bnt_eventual_change_basis, thm:overlap_decay, thm:overlap_decay_rect}
     For large $N$, Lemma~\ref{lem:bnt_eventual_change_basis} gives an
-    invertible matrix $U_N$ relating the two MPV families. Fix $j$. If every
-    mixed overlap $O_{A_iB_j}(N)$ tended to $0$, then taking inner products of
-    the relation with the $A_i$ and using that the Gram matrix of the
-    $A$-family tends to the identity would force the $j$th column of $U_N$ to
-    vanish asymptotically, contradicting the self-overlap limit of $B_j$.
+    invertible matrix $U_N$ relating the two MPV families. Fix $j$ and write
+    $\ket{V^{(N)}(B_j)}=\sum_i u_{ij}^{(N)}\ket{V^{(N)}(A_i)}$. With
+    $G_A(N)=(O_{A_iA_\ell}(N))_{i,\ell}$ and
+    $b_j(N)=(O_{A_iB_j}(N))_i$, this gives
+    \[
+        G_A(N)\overline{u_j(N)}=b_j(N),
+        \qquad
+        O_{B_jB_j}(N)=u_j(N)^{\top}G_A(N)\overline{u_j(N)}.
+    \]
+    If all mixed overlaps $O_{A_iB_j}(N)$ tended to $0$, then
+    $b_j(N)\to0$; since $G_A(N)\to I$, one obtains
+    $\overline{u_j(N)}\to0$ and hence $u_j(N)\to0$. Thus
+    $O_{B_jB_j}(N)\to0$, contradicting $O_{B_jB_j}(N)\to1$.
     Thus each $B_j$ has a matched block $A_{f(j)}$ with non-decaying mixed
     overlap. Theorems~\ref{thm:overlap_decay_rect}
     and~\ref{thm:overlap_decay} then force equal bond dimension and
@@ -342,9 +350,17 @@ and~\cite{Cirac2021Matrix}.
 \end{theorem}
 
 \begin{proof}\leanok
-    If the two MPV states were proportional for all sufficiently large $N$,
-    the irreducible trace-preserving overlap decay theorem would force
-    gauge-phase equivalence. This contradicts the hypothesis.
+    Suppose that for all sufficiently large $N$ one had
+    $\ket{V^{(N)}(A)}=c_N\ket{V^{(N)}(B)}$. Then
+    \[
+        O_{AA}(N)=|c_N|^2O_{BB}(N),
+        \qquad
+        O_{AB}(N)=c_NO_{BB}(N).
+    \]
+    Since $O_{AA}(N)\to1$ and $O_{BB}(N)\to1$, the first identity gives
+    $|c_N|\to1$, and hence $|O_{AB}(N)|\to1$. The irreducible
+    trace-preserving overlap decay theorem gives $O_{AB}(N)\to0$ when
+    $A\not\sim_{\mathrm{gp}}B$, a contradiction.
 \end{proof}
 
 \section{Newton--Girard identities}
@@ -1049,13 +1065,20 @@ matching covers the whole BNT basis.
     separate.
 \end{theorem}
 
-\begin{proof}\leanok
+\begin{proof}\leanok\uses{lem:sector_bnt_norm_phase_of_matched_mpv}
     Apply the proportional sector-matching theorem to obtain the bijection and
     dimension-compatible gauge-phase equivalences. Choosing the gauges and
-    scalars gives the displayed block identities. The normalized self-overlap
-    limits of the matched BNT blocks force the chosen scalars to have modulus
-    $1$, and the MPV scalar-power identity follows from gauge-phase
-    equivalence.
+    scalars gives $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$, and therefore
+    \[
+        O_{Q_kQ_k}(N)
+        =
+        |\zeta_k|^{2N}O_{P_{\beta(k)}P_{\beta(k)}}(N).
+    \]
+    The normalized self-overlap limits give
+    $O_{Q_kQ_k}(N)\to1$ and $O_{P_{\beta(k)}P_{\beta(k)}}(N)\to1$, so
+    $|\zeta_k|^{2N}\to1$ and hence $|\zeta_k|=1$. The MPV scalar-power
+    identity follows from the same gauge equation:
+    $V^{(N)}(Q_k)_\sigma=\zeta_k^NV^{(N)}(P_{\beta(k)})_\sigma$.
 \end{proof}
 
 \begin{lemma}[Full-basis coefficient identity from matched phases]%
@@ -1353,16 +1376,17 @@ matching covers the whole BNT basis.
 \begin{proof}\leanok
     \uses{thm:sector_bnt_bijective_match_of_sameMPV,
         lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
+        lem:sector_bnt_norm_phase_of_matched_mpv,
         lem:sector_bnt_matched_sector_weight_equiv,
         thm:sector_bnt_global_gauge_of_matched_weights}
     The full-basis matching theorem gives $\beta$, the bond-dimension
     identifications, and the gauge-phase equivalences between $Q_k$ and
     $P_{\beta(k)}$. Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
     gives the eventual exact coefficient identities for the same phases
-    $\zeta_k$. The normalized self-overlap limits in the BNT hypotheses force
-    $|\zeta_k|=1$ for every matched sector. The matched-sector
-    weight-permutation theorem then gives the copy permutations and the
-    displayed pointwise weight identities. Finally
+    $\zeta_k$, while Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv}
+    gives $|\zeta_k|=1$.
+    The matched-sector weight-permutation theorem then gives the copy
+    permutations and the displayed pointwise weight identities. Finally
     Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights} assembles the
     block conjugacies into the flattened direct-sum conjugation by
     $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.


### PR DESCRIPTION
### Motivation

- The BNT chapter proof sketches in `blueprint/src/chapter/ch10_bnt.tex` carried contradiction steps as prose rather than displayed equations, making the mathematical argument harder to verify at a glance.
- Rewriting these sketches to be formula-driven is consistent with the source-faithful notation style and aligns with the formula-first conventions for BNT blueprint content.

### Description

Modified `blueprint/src/chapter/ch10_bnt.tex` to replace prose-carried contradiction arguments with displayed overlap equations in three places:

- **Equal-block-count permutation step**: spells out the Gram-matrix relation $G_A(N)u_j(N) = b_j(N)$ and the overlap expression $O_{B_jB_j}(N) = u_j(N)^* G_A(N) u_j(N)$ before arguing that vanishing mixed overlaps would force $O_{B_jB_j}(N) \to 0$.
- **Non-gauge-phase-equivalent irreducible blocks**: derives the proportional-state overlap identities $O_{AA}(N) = |c_N|^2 O_{BB}(N)$ and $O_{AB}(N) = c_N O_{BB}(N)$ before reaching the contradiction with overlap decay.
- **Matched-sector phases**: uses the phase identity $O_{Q_kQ_k}(N) = |\zeta_k|^{2N} O_{P_{\beta(k)}P_{\beta(k)}}(N)$ with self-overlap limits to conclude $|\zeta_k| = 1$; the full-basis global-gauge proof points to this step rather than restating the modulus argument.

No Lean statements or proofs are changed.

### Testing

- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch10_bnt.tex`
- `git diff --check origin/main..HEAD -- blueprint/src/chapter/ch10_bnt.tex`
- `cd blueprint && leanblueprint web` — blueprint web build completes locally with pre-existing bibliography and renderer warnings.
- Relies on Blueprint Lint CI (`lint-blueprint.yml`) to validate LaTeX labels and references.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> LaTeX blueprint documentation only; mathematical statements and Lean proofs are unchanged.
> 
> **Overview**
> **Documentation-only** updates in `blueprint/src/chapter/ch10_bnt.tex`: three BNT proof sketches now carry their contradiction steps as **displayed overlap identities** instead of prose-only arguments. No Lean code changes.
> 
> The **equal block-count permutation** proof spells out the Gram relation \(G_A(N)\overline{u_j(N)}=b_j(N)\) and \(O_{B_jB_j}(N)=u_j(N)^{\top}G_A(N)\overline{u_j(N)}\) before concluding that vanishing mixed overlaps would force \(O_{B_jB_j}\to 0\). The **non–gauge-phase-equivalent irreducible blocks** sketch derives \(O_{AA}=|c_N|^2 O_{BB}\) and \(O_{AB}=c_N O_{BB}\) from eventual proportionality before invoking overlap decay. The **matched-sector phase** proof uses \(O_{Q_kQ_k}=|\zeta_k|^{2N}O_{P_{\beta(k)}P_{\beta(k)}}\) with self-overlap limits to get \(|\zeta_k|=1\), cites `\uses{lem:sector_bnt_norm_phase_of_matched_mpv}` where appropriate, and the full-basis global-gauge proof **defers** the modulus step to that lemma instead of restating it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1190e334d287bca8648c6088873ac152722243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->