### PR TITLE
feat(MPS/MPDO): assemble eta-local RFP consequence

### DIFF
--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -73,8 +73,9 @@ subadditivity, the resulting local `η`-structure, and a primitive real matrix
 condition.
 
 The structure is intentionally independent of a particular MPO tensor. The missing
-preceding theorem is the map from a concrete simple MPDO satisfying SAL/ZCL to
-such a structure and then onward to `HasCommutingForm`. -/
+preceding theorem is the map from a concrete simple MPDO to this structure and
+then onward to `HasCommutingForm`: SAL supplies the local `η`-structure, while
+ZCL supplies trace-power constancy and the rank-one factorization of `T`. -/
 structure SimpleMPDOLocalStructureData where
   /-- Dimensions of the three contiguous local regions. -/
   dA : ℕ
@@ -183,19 +184,22 @@ def ofEtaLocalStructure
   commutingForm := hEta.hasCommutingForm
   zcl := hZCL
 
-/-- Construct the blocked-RFP data from the local SAL--ZCL package and the
+/-- Construct the blocked-RFP data from the local SAL--ZCL hypotheses and the
 assembled `η`-local structure.
 
-Source: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
-lines 1501--1505, and Proposition 3to4, lines 1571--1593. The local package
-records the Lemmas C.3--C.4 consequences, while the eta-local structure records
-the already assembled positive nearest-neighbor product
+References: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
+lines 1501--1505, and Proposition 3to4, lines 1571--1593. This declaration is
+the post-assembly step: the local hypotheses record the Lemmas C.3--C.4
+consequences, while the eta-local structure records the already assembled
+positive nearest-neighbor product
 `σ^{(N)}(K) ∝ ∏ n, B_{n,n+1}` with commuting bonds.
 
 **Scope restriction:** this constructor still assumes `EtaLocalStructureData K`;
-it does not construct the translated bond operators from SAL/ZCL. Documented in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`; the remaining
-construction is tracked by issue #823. -/
+it does not construct the translated bond operators from SAL. It also assumes
+the conditional primitive trace-power rank-one input `hPF`. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` and
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the remaining constructions are
+tracked by issue #823. -/
 def ofSALZCLAndEtaLocalStructure
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -289,18 +293,20 @@ theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
       IsRFP_MPDO_via_fusion K :=
   simple_mpdo_rfp_chain hEta.hasCommutingForm hZCL
 
-/-- The simple-MPDO RFP chain from local SAL--ZCL data once the eta-local
+/-- The simple-MPDO RFP chain from local SAL--ZCL hypotheses once the eta-local
 nearest-neighbor product has been assembled.
 
-Source: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
-lines 1501--1505, and Proposition 3to4, lines 1571--1593.
+References: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
+lines 1501--1505, and Proposition 3to4, lines 1571--1593. This declaration is
+the post-assembly step combining those outputs.
 
 **Scope restriction:** this theorem assumes the assembled eta-local structure
-instead of deriving it from SAL/ZCL. It records the final assembly step after
-the nearest-neighbor bonds $B_{n,n+1}$ and their commutation have been
-constructed. Documented in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`; the
-source-faithful construction is tracked by issue #823. -/
+instead of deriving it from SAL, and it assumes the conditional primitive
+trace-power rank-one input `hPF`. It records the final assembly step after the
+nearest-neighbor bonds $B_{n,n+1}$ and their commutation have been constructed.
+Documented in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`
+and `docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the source-faithful
+constructions are tracked by issue #823. -/
 theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure {K : MPOTensor d D}
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -45,8 +45,10 @@ once the remaining local-to-global implication has been formalized.
 * `MPOTensor.SimpleMPDOLocalStructureData`
 * `MPOTensor.SimpleMPDOBlockedRFPData`
 * `MPOTensor.SimpleMPDOBlockedRFPData.ofEtaLocalStructure`
+* `MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure`
 * `MPOTensor.structural_implies_rfp_blocked`
 * `MPOTensor.simple_mpdo_rfp_chain_of_etaLocalStructure`
+* `MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure`
 * `MPOTensor.simple_mpdo_rfp_chain`
 
 ## References
@@ -181,6 +183,36 @@ def ofEtaLocalStructure
   commutingForm := hEta.hasCommutingForm
   zcl := hZCL
 
+/-- Construct the blocked-RFP data from the local SAL--ZCL package and the
+assembled `η`-local structure.
+
+Source: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
+lines 1501--1505, and Proposition 3to4, lines 1571--1593. The local package
+records the Lemmas C.3--C.4 consequences, while the eta-local structure records
+the already assembled positive nearest-neighbor product
+`σ^{(N)}(K) ∝ ∏ n, B_{n,n+1}` with commuting bonds.
+
+**Scope restriction:** this constructor still assumes `EtaLocalStructureData K`;
+it does not construct the translated bond operators from SAL/ZCL. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`; the remaining
+construction is tracked by issue #823. -/
+def ofSALZCLAndEtaLocalStructure
+    {dA dB dC n : ℕ}
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hTrace : Matrix.trace T = 1)
+    (hTraceConst : Matrix.TracePowersConstant T)
+    (hPF : Matrix.PrimitiveTracePowersConstantImpliesRankOne T)
+    (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    SimpleMPDOBlockedRFPData K :=
+  ofEtaLocalStructure
+    (SimpleMPDOLocalStructureData.ofSALZCL
+      rhoABC hRhoDM hSSA T hPrimitive hTrace hTraceConst hPF)
+    hEta hZCL
+
 /-- Commuting-form data together with MPO ZCL yield the GSNNCH-with-ZCL case of
 Theorem 4.9. -/
 theorem isGSNNCHWithZCL (data : SimpleMPDOBlockedRFPData K) : IsGSNNCHWithZCL K :=
@@ -256,5 +288,34 @@ theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
       IsRFP_MPDO_via_fusion K :=
   simple_mpdo_rfp_chain hEta.hasCommutingForm hZCL
+
+/-- The simple-MPDO RFP chain from local SAL--ZCL data once the eta-local
+nearest-neighbor product has been assembled.
+
+Source: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
+lines 1501--1505, and Proposition 3to4, lines 1571--1593.
+
+**Scope restriction:** this theorem assumes the assembled eta-local structure
+instead of deriving it from SAL/ZCL. It records the final assembly step after
+the nearest-neighbor bonds $B_{n,n+1}$ and their commutation have been
+constructed. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`; the
+source-faithful construction is tracked by issue #823. -/
+theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure {K : MPOTensor d D}
+    {dA dB dC n : ℕ}
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hTrace : Matrix.trace T = 1)
+    (hTraceConst : Matrix.TracePowersConstant T)
+    (hPF : Matrix.PrimitiveTracePowersConstantImpliesRankOne T)
+    (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
+      IsRFP_MPDO_via_fusion K :=
+  simple_mpdo_rfp_chain_of_data
+    (SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure
+      rhoABC hRhoDM hSSA T hPrimitive hTrace hTraceConst hPF hEta hZCL)
 
 end MPOTensor

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2554,6 +2554,28 @@ the elementary trace-power identity for diagonal matrices.
     unchanged.
 \end{proof}
 
+\begin{theorem}[Blocked-RFP structure from SAL--ZCL and $\eta$-local structure]
+    \label{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure}
+    \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure}
+    \leanok
+    \uses{thm:simple_mpdo_local_structure_data_of_sal_zcl,
+        thm:simple_mpdo_blocked_rfp_data_of_eta_local_structure}
+    Suppose the local hypotheses of Lemmas~C.3--C.4 give
+    $\rho_{ABC}$, $I(A:C|B)_{\rho}=0$, a primitive matrix $T$ with
+    $\operatorname{tr}(T)=1$ and $\operatorname{tr}(T^m)$ independent of $m$,
+    and the rank-one conclusion for $T$. Suppose also that the assembled
+    $\eta$-local data give
+    $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
+    $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$ for all $i,j$.
+    Then these data determine the simple-MPDO blocked-RFP structure for $K$.
+\end{theorem}
+
+\begin{proof}\leanok
+    First form the local structure from the SAL--ZCL local hypotheses. The
+    $\eta$-local product formula supplies the commuting-form component, and ZCL
+    supplies the remaining component of the blocked-RFP structure.
+\end{proof}
+
 \begin{theorem}[Zero correlation length gives a blocked fusion-isometry witness]
     \label{thm:structural_implies_rfp_blocked}
     \lean{MPOTensor.structural_implies_rfp_blocked}
@@ -2622,6 +2644,26 @@ the elementary trace-power identity for diagonal matrices.
     this with zero correlation length gives the GSNNCH-with-ZCL case; zero
     correlation length also gives the blocked fusion-isometry witness and the
     transfer-map fusion formulation.
+\end{proof}
+
+\begin{theorem}[Simple-MPDO RFP chain from SAL--ZCL and $\eta$-local structure]
+    \label{thm:simple_mpdo_rfp_chain_of_sal_zcl_and_eta_local_structure}
+    \lean{MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure}
+    \leanok
+    \uses{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure,
+        thm:simple_mpdo_rfp_chain_of_data}
+    Assume the local SAL--ZCL package of Lemmas~C.3--C.4 and the assembled
+    $\eta$-local product form
+    $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
+    $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$. Then
+    $K$ is GSNNCH with ZCL, admits a blocked fusion-isometry witness at size
+    $2$, and satisfies the transfer-map fusion formulation of MPDO RFP.
+\end{theorem}
+
+\begin{proof}\leanok
+    Package the local SAL--ZCL data and the $\eta$-local product form into the
+    blocked-RFP structure, then apply
+    Theorem~\ref{thm:simple_mpdo_rfp_chain_of_data}.
 \end{proof}
 
 \begin{theorem}[Simple-MPDO RFP chain from commuting form and ZCL]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2479,17 +2479,28 @@ the elementary trace-power identity for diagonal matrices.
 \end{proof}
 
 \begin{remark}[Entropy-side construction]
-    The entropy-side theorem still to be supplied constructs the local data needed for
-    Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure} from the SAL
-    and ZCL hypotheses. The sector-reduced neighboring operators $\eta_{k,h}$
-    are already provided by Definition~\ref{def:mpdo_eta_of_hayashi_markov}.
-    What remains is to identify this sector family with the inverse-map
-    construction in the original simple-MPDO tensor coordinates and assemble it
-    into a single translation-invariant positive two-site bond realizing all
-    finite chains. Once this construction is available,
-    Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure} yields the
-    commuting-form conclusion and hence the GSNNCH branch of the simple-MPDO
-    equivalence.
+    The remaining entropy-side step is the construction of a single
+    $\eta$-local product form from $\mathrm{SAL}(K)$. The local $\eta_{k,h}$
+    are already supplied by
+    Definition~\ref{def:mpdo_eta_of_hayashi_markov}.  What remains is the
+    tensor-coordinate assembly
+    \[
+        B=\sum_{k,h}
+        \operatorname{Id}_{H_L^{(k)}}\otimes
+        \eta_{k,h}\otimes
+        \operatorname{Id}_{H_R^{(h)}},
+        \qquad B\ge 0,
+    \]
+    and, for every $N\ge 2$,
+    \[
+        \sigma^{(N)}(K)=c_N\prod_{n=1}^{N}B_{n,n+1},
+        \qquad c_N>0,\qquad
+        [B_{i,i+1},B_{j,j+1}]=0 .
+    \]
+    These equations are exactly the $\eta$-local product hypothesis; after that,
+    Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
+    gives the commuting-form conclusion. Zero correlation length enters only in
+    the subsequent RFP and GSNNCH--ZCL conclusions.
 \end{remark}
 
 \section{Blocked-RFP construction for simple MPDOs}
@@ -2502,7 +2513,8 @@ the elementary trace-power identity for diagonal matrices.
     This structure records the local Appendix~C.2 ingredients: a normalized
     three-site reduced state with equality in strong subadditivity, the
     resulting local $\eta$-structure, and the rank-one conclusion for the
-    auxiliary primitive matrix $T$.
+    auxiliary primitive matrix $T$, supplied here through the conditional
+    rank-one criterion of Theorem~\ref{thm:sal_zcl_implies_rank_one_t}.
 \end{definition}
 
 \begin{theorem}[Local simple-MPDO structure from SAL--ZCL hypotheses]
@@ -2542,16 +2554,15 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:simple_mpdo_local_structure_data,
         def:simple_mpdo_blocked_rfp_data,
         def:mpdo_eta_local_structure_data}
-    Once the $\eta$-local structure has been assembled, it
-    supplies the commuting-form property required by the blocked-RFP structure. Together with
-    the local Appendix~C.2 ingredients and zero correlation length, this gives the
-    explicit hypotheses used by the simple-MPDO construction theorem.
+    Given the local Appendix~C.2 data, ZCL, and an $\eta$-local product
+    $\sigma^{(N)}(K)=c_N\prod_n B_{n,n+1}$ with $c_N>0$,
+    $B_{n,n+1}\ge0$, and $[B_{i,i+1},B_{j,j+1}]=0$, one obtains the
+    simple-MPDO blocked-RFP structure for $K$.
 \end{theorem}
 
 \begin{proof}\leanok
-    Use the commuting-form property carried by the $\eta$-local structure and
-    keep the local Appendix~C.2 ingredients and zero-correlation-length hypothesis
-    unchanged.
+    The $\eta$-local product gives the commuting-form property for $K$; the local
+    Appendix~C.2 hypotheses and ZCL fill the other two fields.
 \end{proof}
 
 \begin{theorem}[Blocked-RFP structure from SAL--ZCL and $\eta$-local structure]
@@ -2563,7 +2574,8 @@ the elementary trace-power identity for diagonal matrices.
     Suppose the local hypotheses of Lemmas~C.3--C.4 give
     $\rho_{ABC}$, $I(A:C|B)_{\rho}=0$, a primitive matrix $T$ with
     $\operatorname{tr}(T)=1$ and $\operatorname{tr}(T^m)$ independent of $m$,
-    and the rank-one conclusion for $T$. Suppose also that the assembled
+    together with the conditional rank-one criterion for $T$. Suppose also
+    that $K$ has zero correlation length and that the assembled
     $\eta$-local data give
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$ for all $i,j$.
@@ -2571,9 +2583,10 @@ the elementary trace-power identity for diagonal matrices.
 \end{theorem}
 
 \begin{proof}\leanok
-    First form the local structure from the SAL--ZCL local hypotheses. The
-    $\eta$-local product formula supplies the commuting-form component, and ZCL
-    supplies the remaining component of the blocked-RFP structure.
+    First form the local structure from the SAL--ZCL local hypotheses and the
+    conditional rank-one criterion for $T$. The $\eta$-local product formula
+    supplies the commuting-form component, and ZCL supplies the remaining
+    component of the blocked-RFP structure.
 \end{proof}
 
 \begin{theorem}[Zero correlation length gives a blocked fusion-isometry witness]
@@ -2652,8 +2665,8 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure,
         thm:simple_mpdo_rfp_chain_of_data}
-    Assume the local SAL--ZCL package of Lemmas~C.3--C.4 and the assembled
-    $\eta$-local product form
+    Assume the local SAL--ZCL hypotheses of Lemmas~C.3--C.4 and the assembled
+    $\eta$-local product form, with the conditional rank-one criterion for $T$,
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$. Then
     $K$ is GSNNCH with ZCL, admits a blocked fusion-isometry witness at size
@@ -2661,7 +2674,7 @@ the elementary trace-power identity for diagonal matrices.
 \end{theorem}
 
 \begin{proof}\leanok
-    Package the local SAL--ZCL data and the $\eta$-local product form into the
+    Combine the local SAL--ZCL hypotheses and the $\eta$-local product form into the
     blocked-RFP structure, then apply
     Theorem~\ref{thm:simple_mpdo_rfp_chain_of_data}.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{The SAL--ZCL to Eta-Local Structure Step in
+\title{The SAL to Eta-Local Structure Step in
 Cirac--Perez-Garcia--Schuch--Verstraete 2017 Appendix C.2}
 \author{}
 \date{2026-05-27}
@@ -51,35 +51,31 @@ $B$-operators follows from their sector-local action.
 
 \section{Current formalization}
 
-The formal development currently has a structure
-\[
-  \texttt{MPOTensor.EtaLocalStructureData}\;K
-\]
-which records the assembled positive translation-invariant two-site bond and
-its realization of the finite-chain MPO. From this structure, the development
-proves the commuting-form property and the GSNNCH--ZCL consequences.
+The formal development currently records this as an eta-local structure for
+$K$.\footnote{The formal structure is
+\leanid{MPOTensor.EtaLocalStructureData}.} It contains the assembled positive
+translation-invariant two-site bond and its realization of the finite-chain
+MPO. From this structure, the development proves the commuting-form property
+and the GSNNCH--ZCL consequences.
 
-The declarations
-\[
-\begin{aligned}
-  &\texttt{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure},\\
-  &\texttt{MPOTensor.simple\_mpdo\_rfp\_chain\_of\_sal\_zcl\_and\_etaLocalStructure}
-\end{aligned}
-\]
-are scope-restricted assembly statements. They assume the eta-local structure
-instead of deriving it from the SAL--ZCL local coordinates. Thus they formalize
-the final packaging step after the $B_{n,n+1}$ have been constructed, not the
-source theorem that constructs those bonds from SAL.
+The two scope-restricted declarations are assembly
+statements.\footnote{These declarations are
+\leanid{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure} and
+\leanid{MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure}.}
+They assume the eta-local structure instead of deriving it from the SAL local
+coordinates. They also carry the ZCL hypothesis needed for the subsequent RFP
+consequences. Thus they formalize the final assembly step after the
+$B_{n,n+1}$ have been constructed, not the source theorem that constructs those
+bonds from SAL.
 
 \section{Missing step}
 
-The missing source-faithful theorem must construct
-\[
-  \texttt{MPOTensor.EtaLocalStructureData}\;K
-\]
-from the Appendix C.2 local data attached to a simple MPDO satisfying SAL and
-ZCL. Concretely, it must identify the local $\eta_{k,h}$ family with the
-original tensor coordinates, define the translation-invariant bond
+The missing source-faithful theorem must construct the formal eta-local
+structure \leanid{MPOTensor.EtaLocalStructureData} from the Appendix C.2 local
+data attached to a simple MPDO satisfying SAL. It must not add ZCL as a
+hypothesis for this construction. Concretely, it must identify the local
+$\eta_{k,h}$ family with the original tensor coordinates, define the
+translation-invariant bond
 $B_{n,n+1}$ above, prove $B_{n,n+1}\geq 0$, prove the commutation relations,
 and prove the finite-chain realization
 \[
@@ -87,10 +83,20 @@ and prove the finite-chain realization
 \]
 for positive scalars $c_N$.
 
+ZCL enters only after this commuting product form has been obtained, in the
+later step that derives the GSNNCH--ZCL and RFP conclusions.
+
 This is tracked by
 \href{https://github.com/LionSR/TNLean/issues/823}{issue \#823}. Until that
 construction exists, the scope-restricted assembly statements must not be
 presented as the full formalization of Proposition~C.6.
+
+\section{Classification}
+
+This note records an open gap for the SAL-to-bond construction of
+\leanid{MPOTensor.EtaLocalStructureData}. The two assembly declarations above
+are scope restrictions: they formalize only the post-assembly step after the
+nearest-neighbor bonds have already been constructed.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -1,0 +1,98 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The SAL--ZCL to Eta-Local Structure Step in
+Cirac--Perez-Garcia--Schuch--Verstraete 2017 Appendix C.2}
+\author{}
+\date{2026-05-27}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+Appendix C.2 of Cirac--P\'erez-Garcia--Schuch--Verstraete proves that a simple
+MPDO satisfying the strong area law has the commuting nearest-neighbor product
+form
+\[
+  \sigma^{(N)}({\cal K})\propto \prod_{n=1}^N B_{n,n+1},
+\]
+where $B_{n,n+1}\geq 0$ and the translated two-site operators commute
+\cite[Appendix~C.2, Proposition~C.6]{Cirac2016MPDO_arXiv}. In the local
+source file this is Proposition \texttt{3to4},
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1571--1593}.
+
+The proof uses the sector decomposition obtained earlier in Appendix C.2:
+\[
+  \tilde\sigma
+  =
+  \bigoplus_{k_1,\ldots,k_N}
+  \bigotimes_{n=1}^N \eta_{k_n,k_{n+1}},
+\]
+with $\eta_{k_n,k_{n+1}}\geq 0$ acting between the right subspace of site $n$
+and the left subspace of site $n+1$. It then defines
+\[
+  B_{n,n+1}
+  =
+  \sum_{k_n,k_{n+1}}
+  \operatorname{Id}_{H_{L,n}^{(k_n)}}\otimes
+  \eta_{k_n,k_{n+1}}\otimes
+  \operatorname{Id}_{H_{R,n+1}^{(k_{n+1})}},
+\]
+regarded as the identity away from sites $n,n+1$. With this definition,
+$\tilde\sigma=\prod_n B_{n,n+1}$ and the commutation of the translated
+$B$-operators follows from their sector-local action.
+
+\section{Current formalization}
+
+The formal development currently has a structure
+\[
+  \texttt{MPOTensor.EtaLocalStructureData}\;K
+\]
+which records the assembled positive translation-invariant two-site bond and
+its realization of the finite-chain MPO. From this structure, the development
+proves the commuting-form property and the GSNNCH--ZCL consequences.
+
+The declarations
+\[
+\begin{aligned}
+  &\texttt{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure},\\
+  &\texttt{MPOTensor.simple\_mpdo\_rfp\_chain\_of\_sal\_zcl\_and\_etaLocalStructure}
+\end{aligned}
+\]
+are scope-restricted assembly statements. They assume the eta-local structure
+instead of deriving it from the SAL--ZCL local coordinates. Thus they formalize
+the final packaging step after the $B_{n,n+1}$ have been constructed, not the
+source theorem that constructs those bonds from SAL.
+
+\section{Missing step}
+
+The missing source-faithful theorem must construct
+\[
+  \texttt{MPOTensor.EtaLocalStructureData}\;K
+\]
+from the Appendix C.2 local data attached to a simple MPDO satisfying SAL and
+ZCL. Concretely, it must identify the local $\eta_{k,h}$ family with the
+original tensor coordinates, define the translation-invariant bond
+$B_{n,n+1}$ above, prove $B_{n,n+1}\geq 0$, prove the commutation relations,
+and prove the finite-chain realization
+\[
+  \sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}
+\]
+for positive scalars $c_N$.
+
+This is tracked by
+\href{https://github.com/LionSR/TNLean/issues/823}{issue \#823}. Until that
+construction exists, the scope-restricted assembly statements must not be
+presented as the full formalization of Proposition~C.6.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation
- Advances issue #823: the local-to-global bridge from SAL and ZCL hypotheses to a blocked MPDO RFP result requires an intermediate step once the eta-local nearest-neighbor product form has been assembled.
- Records the post-assembly consequence explicitly in `SimpleMPDOBlockedRFPData`, so the transfer-map fusion RFP formulation is available without conflating it with the yet-unproved derivation of the eta-local form from SAL and ZCL alone.
- Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4`, lines 1571--1593; proves that SAL yields $\sigma^{(N)}(K) \propto \prod_{n=1}^N B_{n,n+1}$ with positive commuting nearest-neighbor bonds; the Lean theorem assumes that assembled product form explicitly, and the paper-gap note records the missing construction.

### Description
- `TNLean/MPS/MPDO/BlockedRFPConstruction.lean`: adds constructor `SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure` from local SAL--ZCL hypotheses plus an eta-local product form, and adds theorem `simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure` giving GSNNCH with ZCL, a blocked fusion-isometry witness at size 2, and the transfer-map fusion RFP formulation; docstrings note the scope limit and point to issue #823.
- `blueprint/src/chapter/ch02b_mpdo.tex`: sharpens the entropy-side remark with explicit $B$ and $\sigma^{(N)}(K) = c_N \prod B_{n,n+1}$ hypotheses; adds theorem and proof blocks for blocked-RFP data and the SAL/ZCL + eta-local RFP chain, aligned with the new Lean names.
- `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`: documents that the missing source-faithful step is constructing `EtaLocalStructureData` from SAL and ZCL (bond assembly, positivity, commutation, finite-chain realization).

### Testing
- `lake build TNLean.MPS.MPDO.BlockedRFPConstruction`
- `rg -n "sorry|axiom" TNLean/MPS/MPDO/BlockedRFPConstruction.lean || true`
- `leanblueprint web`

---
Addresses #823

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean additions are thin wrappers over existing blocked-RFP machinery with explicit scope limits; risk is mainly misreading them as completing the SAL→η-local proof tracked in #823.
> 
> **Overview**
> Adds the **post-assembly** simple-MPDO blocked-RFP layer: once local SAL–ZCL data (Lemmas C.3–C.4) and an assembled **η-local** product form are assumed, the PR wires them into `SimpleMPDOBlockedRFPData` and the **RFP consequence chain** (GSNNCH with ZCL, blocked fusion isometry at size 2, transfer-map fusion RFP).
> 
> In **`BlockedRFPConstruction.lean`**, new **`ofSALZCLAndEtaLocalStructure`** and **`simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure`** compose existing local-structure and η-local constructors; docstrings state they **do not** build `EtaLocalStructureData` from SAL alone and still take conditional **`hPF`**, pointing to issue **#823**.
> 
> The **blueprint** (`ch02b_mpdo.tex`) spells out the bond sum \(B\) and \(\sigma^{(N)}(K)=c_N\prod B_{n,n+1}\) hypotheses, adds matching theorem/proof blocks, and clarifies that ZCL is for later RFP steps—not for constructing η-local from SAL.
> 
> New **`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`** records the open **SAL → η-local bond** gap (Proposition C.6 / `3to4`) so the new declarations are not mistaken for a full source-faithful proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d176361637410937b6254af907e1238b04e3d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->