### PR TITLE
feat(PEPS): extract edge gauge from matrix algebra isomorphism

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -378,5 +378,6 @@ import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.InsertionRealization
 import TNLean.PEPS.LocalGauge
 import TNLean.PEPS.TensorFactorScalar
+import TNLean.PEPS.EdgeGaugeExtraction
 -- The PEPS fundamental theorem is an exploratory capstone with recorded
 -- paper-alignment gaps; it is deliberately not part of the default root.

--- a/TNLean/Algebra/SkolemNoether.lean
+++ b/TNLean/Algebra/SkolemNoether.lean
@@ -1,3 +1,4 @@
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.Defs
 
 import Mathlib.LinearAlgebra.GeneralLinearGroup.AlgEquiv
@@ -11,8 +12,12 @@ This file provides the "abstract algebra" ingredients for the Fundamental Theore
 * **Simplicity** (`linear_mul_endomorphism_bijective`): A nonzero multiplicative linear
   endomorphism of a matrix algebra is bijective, because the kernel is a two-sided ideal
   in a simple ring.
-* **Skolem–Noether** (`skolemNoether_matrix`): Every algebra automorphism of `Matrix n n ℂ`
-  is inner (conjugation by an invertible matrix).
+* `matrixAlgEquiv_fin_eq`: an algebra isomorphism between full matrix algebras
+  forces the same matrix size.
+* `matrixAlgEquiv_inner_of_fin`: after this size identification, such an
+  isomorphism is inner.
+* **Skolem–Noether** (`skolemNoether_matrix`): Every algebra automorphism of
+  `Matrix n n ℂ` is inner (conjugation by an invertible matrix).
 * **`linearMapToAlgHom`**: Promotes a multiplicative surjective linear map to an algebra
   homomorphism (proving `T 1 = 1`).
 -/
@@ -49,6 +54,22 @@ theorem linear_mul_endomorphism_bijective
       simpa [f] using (TwoSidedIdeal.ker_eq_bot (f := f)).1 hker
     exact ⟨hinj, LinearMap.surjective_of_injective hinj⟩
 
+/-- Full matrix algebras over `ℂ` can be algebra-isomorphic only when their
+matrix sizes agree.
+
+Source: arXiv:1804.04964, Section 3, lines 582--584:
+after the insertion correspondence is shown to be an algebra isomorphism
+between full matrix algebras, the paper concludes that the two bond dimensions
+are the same. -/
+theorem matrixAlgEquiv_fin_eq {D E : ℕ}
+    (φ : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ) :
+    D = E := by
+  have hfinrank : Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) =
+      Module.finrank ℂ (Matrix (Fin E) (Fin E) ℂ) :=
+    LinearEquiv.finrank_eq φ.toLinearEquiv
+  rw [Matrix.finrank_matrix_fin_eq_sq, Matrix.finrank_matrix_fin_eq_sq] at hfinrank
+  exact Nat.pow_left_injective (by norm_num) hfinrank
+
 /-- Skolem--Noether for matrices: every $\C$-algebra automorphism of $\MN{D}$ is inner.
 For any $f \in \Aut_{\C\text{-alg}}(\MN{D})$, there exists an invertible $X$ such that
 $f(M) = X M X^{-1}$ for all $M$. -/
@@ -58,7 +79,8 @@ theorem skolemNoether_matrix {n : Type*} [Fintype n] [DecidableEq n]
       f M = (X : Matrix n n ℂ) * M * ((X⁻¹ : GL n ℂ) : Matrix n n ℂ) := by
   classical
   let e : Matrix n n ℂ ≃ₐ[ℂ] Module.End ℂ (n → ℂ) := Matrix.toLinAlgEquiv'
-  let fEnd : Module.End ℂ (n → ℂ) ≃ₐ[ℂ] Module.End ℂ (n → ℂ) := e.symm.trans (f.trans e)
+  let fEnd : Module.End ℂ (n → ℂ) ≃ₐ[ℂ] Module.End ℂ (n → ℂ) :=
+    e.symm.trans (f.trans e)
   obtain ⟨T, hT⟩ := AlgEquiv.eq_linearEquivConjAlgEquiv (f := fEnd)
   let X : GL n ℂ :=
     (Matrix.GeneralLinearGroup.toLin (n := n) (R := ℂ)).symm
@@ -85,11 +107,45 @@ theorem skolemNoether_matrix {n : Type*} [Fintype n] [DecidableEq n]
   -- Compute both sides under `e`.
   calc e (f M)
       = fEnd (e M) := by simp [fEnd]
-    _ = (T : (n → ℂ) →ₗ[ℂ] n → ℂ) ∘ₗ e M ∘ₗ (T.symm : (n → ℂ) →ₗ[ℂ] n → ℂ) := by
+    _ = (T : (n → ℂ) →ₗ[ℂ] n → ℂ) ∘ₗ e M ∘ₗ
+          (T.symm : (n → ℂ) →ₗ[ℂ] n → ℂ) := by
         rw [congrArg (· (e M)) hT]; simp [LinearEquiv.conjAlgEquiv_apply]
     _ = e (X : Matrix n n ℂ) * e M * e ((X⁻¹ : GL n ℂ) : Matrix n n ℂ) := by
         rw [← hX_lin, ← hX_lin_inv]; simp [Module.End.mul_eq_comp, LinearMap.comp_assoc]
     _ = e ((X : Matrix n n ℂ) * M * ((X⁻¹ : GL n ℂ) : Matrix n n ℂ)) := by simp [mul_assoc]
+
+/-- An algebra isomorphism between full matrix algebras is conjugation by an
+invertible matrix after the matrix sizes are identified.
+
+Source: arXiv:1804.04964, Section 3, lines 582--586:
+after the insertion correspondence is shown to be an algebra isomorphism
+between full matrix algebras, the paper identifies the two matrix sizes and
+applies Skolem--Noether to obtain an invertible gauge matrix. -/
+theorem matrixAlgEquiv_inner_of_fin {D E : ℕ}
+    (φ : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ) :
+    ∃ h : D = E, ∃ X : GL (Fin E) ℂ,
+      ∀ M : Matrix (Fin D) (Fin D) ℂ,
+        φ M = (X : Matrix (Fin E) (Fin E) ℂ) *
+            Matrix.reindexAlgEquiv ℂ ℂ (finCongr h) M *
+            ((X⁻¹ : GL (Fin E) ℂ) : Matrix (Fin E) (Fin E) ℂ) := by
+  classical
+  have hDE : D = E := matrixAlgEquiv_fin_eq φ
+  let e : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ :=
+    Matrix.reindexAlgEquiv ℂ ℂ (finCongr hDE)
+  let f : Matrix (Fin E) (Fin E) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ :=
+    e.symm.trans φ
+  obtain ⟨X, hX⟩ := skolemNoether_matrix (f := f)
+  refine ⟨hDE, X, ?_⟩
+  intro M
+  calc φ M
+      = f (e M) := by
+          change φ (e.symm (e M)) = φ M
+          rw [AlgEquiv.symm_apply_apply]
+    _ = (X : Matrix (Fin E) (Fin E) ℂ) * e M *
+          ((X⁻¹ : GL (Fin E) ℂ) : Matrix (Fin E) (Fin E) ℂ) := hX (e M)
+    _ = (X : Matrix (Fin E) (Fin E) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr hDE) M *
+          ((X⁻¹ : GL (Fin E) ℂ) : Matrix (Fin E) (Fin E) ℂ) := by rfl
 
 /-- Promote a multiplicative surjective $\C$-linear map
 $T : \MN{D} \to \MN{D}$ to a $\C$-algebra homomorphism. The key step is

--- a/TNLean/PEPS/EdgeGaugeExtraction.lean
+++ b/TNLean/PEPS/EdgeGaugeExtraction.lean
@@ -1,0 +1,43 @@
+import TNLean.Algebra.SkolemNoether
+import TNLean.PEPS.Defs
+
+/-!
+# Edge gauge extraction from insertion algebra isomorphisms
+
+This file records the finite-dimensional algebra step in the injective PEPS
+Fundamental Theorem. Once the edge-blocked three-site argument gives an algebra
+isomorphism between the full matrix algebras of insertions on a chosen edge,
+Skolem--Noether turns that isomorphism into conjugation by an invertible edge
+matrix.
+-/
+
+open scoped Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- The edge matrix-algebra isomorphism determines the bond dimension on that
+edge and is realized as conjugation by an invertible edge matrix.
+
+Source: arXiv:1804.04964, Section 3, lines 560--586. After the three-site
+injective-chain argument constructs the algebra isomorphism $\varphi : X \mapsto Y$
+between edge insertions, the source proves that it is an isomorphism between
+full matrix algebras. It then concludes that the two matrix sizes agree and
+writes $Y = Z_e X Z_e^{-1}$ for an invertible edge matrix $Z_e$. -/
+theorem edgeGaugeFromInsertionAlgebraIsomorphism (A B : Tensor G d) (e : Edge G)
+    (φ : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ ≃ₐ[ℂ]
+      Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) :
+    ∃ hEdge : A.bondDim e = B.bondDim e,
+      ∃ Z : GL (Fin (B.bondDim e)) ℂ,
+        ∀ X : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ,
+          φ X = (Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) X *
+              ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+                Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) :=
+  MPSTensor.matrixAlgEquiv_inner_of_fin φ
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -185,6 +185,20 @@ normal-form reductions.
     finite-dimensionality.
 \end{proof}
 
+\begin{theorem}[Matrix-algebra isomorphisms preserve size]%
+    \label{thm:matrixAlgEquiv_fin_eq}
+    \lean{MPSTensor.matrixAlgEquiv_fin_eq}
+    \leanok
+    If the full matrix algebras $\MN{D}$ and $\MN{E}$ are isomorphic as
+    $\C$-algebras, then $D=E$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The isomorphism preserves complex vector-space dimension. Since
+    $\dim_{\C}\MN{D}=D^2$ and $\dim_{\C}\MN{E}=E^2$, it follows that
+    $D=E$.
+\end{proof}
+
 \begin{theorem}[Skolem--Noether]\label{thm:skolem_noether}
     \lean{MPSTensor.skolemNoether_matrix}
     \leanok
@@ -205,6 +219,24 @@ normal-form reductions.
     (this is a standard result in the theory of central
     simple algebras).
     Translating back to matrices gives the invertible~$X$.
+\end{proof}
+
+\begin{theorem}[Matrix-algebra isomorphisms are inner after identifying size]%
+    \label{thm:matrixAlgEquiv_inner_of_fin}
+    \lean{MPSTensor.matrixAlgEquiv_inner_of_fin}
+    \leanok
+    \uses{thm:matrixAlgEquiv_fin_eq, thm:skolem_noether}
+    If the full matrix algebras $\MN{D}$ and $\MN{E}$ are isomorphic as
+    $\C$-algebras, then $D=E$. If $h:D=E$ is this equality, then after the
+    canonical index identification along $h$ the isomorphism acts by
+    $\varphi(M)=X\,(\operatorname{reindex}_h M)\,X^{-1}$ for some invertible
+    matrix $X$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The vector-space dimension comparison gives $D=E$. Transporting along
+    this equality turns the isomorphism into an automorphism of a single full
+    matrix algebra, so Skolem--Noether gives the required conjugating matrix.
 \end{proof}
 
 \begin{lemma}[Unit preservation of multiplicative surjective maps]\label{lem:linear_map_to_alg}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -290,9 +290,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \[
         \Psi_v \circ O \circ \Phi_v .
     \]
-    This is the local injectivity step used in the
-    $O_1,O_2\mapsto W$ direction of
-    Lemma~$\mathrm{inj\_isomorph}$ in
+    This is the local injectivity step used in the physical-to-virtual
+    direction of the insertion-algebra argument in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{definition}
 
@@ -1133,8 +1132,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         \TNPEPSInsertionPhysicalRealization
     \end{center}
 
-    % This is the local endpoint part of the X -> O_1,O_2 step in
-    % Lemma inj_isomorph of Molnar2018NormalPEPS, Section 3.  The corresponding
+    % This is the local endpoint part of Molnar2018NormalPEPS, Section 3. The corresponding
     % coefficient identity is
     % thm:peps_edgeInsertedCoeff_endpointPhysicalRealization.
 \end{theorem}
@@ -1270,8 +1268,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \begin{center}
         \TNPEPSPhysicalToVirtualInsertion
     \end{center}
-    This is the $O_1,O_2\mapsto W$ step in the proof of
-    Lemma~$\mathrm{inj\_isomorph}$.
+    This is the $O_1,O_2\mapsto W$ step in the insertion-algebra argument of
+    \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
 \begin{theorem}[Edge-blocked insertion algebra isomorphism]%
@@ -1295,16 +1293,26 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Edge gauge from the insertion algebra isomorphism]%
     \label{thm:peps_edgeGaugeFromInsertionAlgebraIsomorphism}
-    \notready
-    \uses{thm:peps_edgeBlockedInsertionAlgebraIsomorphism, def:gaugeVertex}
-    The insertion correspondence obtained from the three-site injective-chain
-    theorem is an isomorphism between full matrix algebras on the chosen bond.
-    Hence the two bond dimensions on that edge are equal, and the isomorphism is
-    realized by conjugation with an invertible edge matrix $Z_e$:
-    $Y=Z_e X Z_e^{-1}$. The matrix $Z_e$ is unique up to multiplication by
-    a nonzero scalar. This is the finite-dimensional matrix-algebra step used in
-    \cite[Section~3]{Molnar2018NormalPEPS} after Lemma~$\mathrm{inj\_isomorph}$.
+    \lean{TNLean.PEPS.edgeGaugeFromInsertionAlgebraIsomorphism}
+    \leanok
+    \uses{thm:matrixAlgEquiv_inner_of_fin}
+    Suppose the edge insertion correspondence is a $\C$-algebra isomorphism
+    between the two full matrix algebras on the chosen bond. Then the two bond
+    dimensions on that edge are equal. If $h_e:D_A(e)=D_B(e)$ is this equality,
+    then the isomorphism is realized by conjugation with an invertible edge
+    matrix $Z_e$ after the canonical index identification:
+    $Y=Z_e\,(\operatorname{reindex}_{h_e} X)\,Z_e^{-1}$.
+    \begin{center}
+        \TNGaugeConjugation{Z_e}{\operatorname{reindex}_{h_e}(X)}{Z_e^{-1}}
+    \end{center}
+    This is the finite-dimensional matrix-algebra step in
+    \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
+
+\begin{proof}\leanok
+    Apply Theorem~\ref{thm:matrixAlgEquiv_inner_of_fin} to the full matrix
+    algebras determined by the two edge bond spaces.
+\end{proof}
 
 \begin{definition}[Factorized local gauge datum]%
     \label{def:peps_hasFactorizedLocalGauge}
@@ -1446,9 +1454,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     edge gauges have been absorbed into $\tilde{B}$. The global-consistency
     diagram summarizes repeating the edge blocking over all edges, so the two
     endpoint actions on a shared edge are one edge gauge. The
-    two-injective-tensor diagram records Lemma~$\mathrm{inj\_equal\_tensors\_2}$
-    from the paper, and the final one-vertex-complement diagram records its
-    application to one vertex and its complement. These pictures use the
+    two-injective-tensor diagram records the two-block comparison from
+    \cite[Section~3]{Molnar2018NormalPEPS}, and the final
+    one-vertex-complement diagram records its application to one vertex and its
+    complement. These pictures use the
     blueprint tensor-dot convention, but each one is attached to the same
     contraction, insertion, or blocking step as the corresponding argument in
     the paper.
@@ -1543,7 +1552,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \end{center}
     Then there is a nonzero scalar $\lambda$ such that
     $A_1=\lambda B_1$ and $A_2=\lambda^{-1}B_2$. This is the blueprint
-    form of Lemma~$\mathrm{inj\_equal\_tensors\_2}$ in
+    form of the two-injective tensor comparison in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 


### PR DESCRIPTION
### Motivation

- Formalizes the finite-dimensional matrix-algebra consequence in arXiv:1804.04964 Section 3 (Lemma `inj_isomorph`): source `Papers/1804.04964/paper_normal.tex`, lines 254–310, 560–586, and 1018–1045.
- Once the edge-blocked insertion correspondence is shown to be a $\mathbb{C}$-algebra isomorphism between full matrix algebras, the two edge bond dimensions coincide and the isomorphism takes the form $Y = Z_e X Z_e^{-1}$ for an invertible edge matrix $Z_e$.
- Addresses the acceptance criteria of #1368; scalar uniqueness of $Z_e$ is deferred to #842.

### Description

- Adds `MPSTensor.matrixAlgEquiv_fin_eq`: full matrix algebras over $\mathbb{C}$ are algebra-isomorphic only if their dimensions agree, proved via `finrank` and `nlinarith`.
- Adds `MPSTensor.matrixAlgEquiv_inner_of_fin`: once dimensions are identified, the isomorphism is inner by Skolem–Noether.
- Adds `TNLean.PEPS.edgeGaugeFromInsertionAlgebraIsomorphism` in `TNLean/PEPS/EdgeGaugeExtraction.lean` (new file): derives the bond-dimension equality and an invertible edge gauge from the insertion algebra isomorphism, corresponding to blueprint node `thm:peps_edgeGaugeFromInsertionAlgebraIsomorphism`.
- Updates `blueprint/src/chapter/ch03_single.tex` and `blueprint/src/chapter/ch13a_peps_ft.tex`: documents the two matrix-algebra theorems, marks the edge-gauge theorem `leanok`, and adds the gauge-conjugation diagram.
- Root import `TNLean.lean` extended with `TNLean.PEPS.EdgeGaugeExtraction`.

### Testing

- `lake build TNLean.Algebra.SkolemNoether TNLean.PEPS.EdgeGaugeExtraction`
- `lake env lean TNLean/PEPS/EdgeGaugeExtraction.lean`
- `lake env lean TNLean.lean`
- Blueprint sync script and oversized-file check passed; `cd blueprint && leanblueprint web` succeeded.
- Proof-integrity scan and 100-column check on changed Lean files passed.
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
Closes #1368

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style algebra and a one-line PEPS wrapper; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> This PR formalizes the **finite-dimensional matrix-algebra step** after an edge insertion correspondence is a \(\mathbb{C}\)-algebra isomorphism: matching bond dimensions and an invertible edge gauge via conjugation (Molnár et al., Section 3).
> 
> **Lean:** `MPSTensor.matrixAlgEquiv_fin_eq` shows isomorphic full matrix algebras over \(\mathbb{C}\) must have the same size (via `finrank` and \(D^2\)). `MPSTensor.matrixAlgEquiv_inner_of_fin` combines that with existing Skolem–Noether so the isomorphism is inner after `finCongr` reindexing. `TNLean.PEPS.edgeGaugeFromInsertionAlgebraIsomorphism` in new `EdgeGaugeExtraction.lean` instantiates this on `A.bondDim e` and `B.bondDim e`. `TNLean.lean` imports the new module; `SkolemNoether` gains `MatrixAux` and doc updates.
> 
> **Blueprint:** Chapter 3 documents the two matrix-algebra theorems; Chapter 13a marks `thm:peps_edgeGaugeFromInsertionAlgebraIsomorphism` as `\leanok`, adds a gauge-conjugation diagram and proof, and tightens wording around the insertion-algebra argument (replacing informal `inj_isomorph` labels).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9540474bcccd899a104d060b14441640b0622209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->