### PR TITLE
doc(periodic): write period-mismatch proof with formulas

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -157,14 +157,15 @@ private theorem period_eq_of_gaugePhaseEquiv_of_isPeriodic
 /-- If two periodic tensors have different periods `m_a ≠ m_b`, their overlap
 decays to zero.
 
-*Proof*: split on whether `D₁ = D₂`. If not, use dimension mismatch
-(`periodicOverlap_tendsto_zero_of_ne_dim`). If `D₁ = D₂`, assume for
-contradiction that `GaugePhaseEquiv A B`; then
-`period_eq_of_gaugePhaseEquiv_of_isPeriodic` gives `m_a = m_b`, contradicting
-`hne`. So `¬ GaugePhaseEquiv`, and `mpvOverlap_tendsto_zero_of_irreducible_TP`
-gives the result.
-
-This is the first substantial argument in Appendix A of arXiv:1708.00029. -/
+Source: arXiv:1708.00029, Appendix A, lines 917--950.
+The local proof uses the Perron--Frobenius spectral form of the same obstruction:
+if $D_1=D_2$ and $B_i=\zeta X A_iX^{-1}$, then
+$\E_B(Y)=\zeta\overline{\zeta}\,X\E_A(X^{-1}YX^{-*})X^*$. Wolf Theorem 6.3
+forces $|\zeta|=1$, so the peripheral spectra of $\E_A$ and $\E_B$ agree. Since
+an $m$-periodic tensor has peripheral spectrum
+$\{e^{2\pi i r/m}:0\le r<m\}$, the periods would be equal. Thus different periods
+exclude gauge-phase equivalence, and the irreducible trace-preserving overlap
+dichotomy gives the decay. -/
 theorem periodicOverlap_tendsto_zero_of_ne_period
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -468,11 +468,22 @@ unconditional result.
     \uses{thm:periodic_overlap_zero_ne_dim}
     Split on whether the bond dimensions agree. If not, the claim follows
     from Theorem~\ref{thm:periodic_overlap_zero_ne_dim}. If $D_1 = D_2$,
-    suppose for contradiction that $A$ and $B$ are gauge-phase equivalent;
-    Perron--Frobenius eigenvalue uniqueness
-    \cite[Theorem~6.3]{Wolf2012Quantum} then forces
-    equal periods, contradicting the hypothesis. Hence the tensors are not
-    gauge-phase equivalent, and the overlap decays.
+    suppose for contradiction that $A$ and $B$ are gauge-phase equivalent,
+    so $B^i=\zeta X A^iX^{-1}$ with $X$ invertible and $\zeta\ne0$. Then
+    \[
+        \E_B(Y)
+        =
+        \zeta\overline{\zeta}\,
+        X\,\E_A(X^{-1}YX^{-*})\,X^* .
+    \]
+    Perron--Frobenius eigenvalue uniqueness \cite[Theorem~6.3]{Wolf2012Quantum}
+    applied to the positive fixed points gives $|\zeta|=1$, and therefore
+    $\sigma_{\mathrm{per}}(\E_A)=\sigma_{\mathrm{per}}(\E_B)$. For a periodic
+    tensor of period $m$, the peripheral spectrum is
+    $\{e^{2\pi i r/m}:0\le r<m\}$. Hence $m_A=m_B$, contradicting the
+    hypothesis. Thus $A\not\sim_{\mathrm{gp}}B$, and the irreducible
+    trace-preserving overlap dichotomy gives
+    $\lim_{N\to\infty}O_{A,B}(N)=0$.
 \end{proof}
 
 \begin{lemma}[Sector-block normality for periodic tensors]\label{lem:sector_blocked_normal_periodic}


### PR DESCRIPTION
### Motivation

- The blueprint proof for the different-period overlap theorem (arXiv:1708.00029, Proposition 3.3, lines 589–604) previously carried its argument in high-level prose rather than explicit equations, making the step from transfer-map conjugation to peripheral-spectrum contradiction invisible to readers.
- The Lean docstring for `periodicOverlap_tendsto_zero_of_ne_period` lacked a source citation and stated the proof sketch at too high a level to verify against the paper.
- Continues formalization of the periodic MPS overlap dichotomy; see #448.

### Description

- `TNLean/MPS/Periodic/Overlap/Case1.lean`: rewrites the docstring for `periodicOverlap_tendsto_zero_of_ne_period` to spell out the equal-bond-dimension branch via the transfer-map conjugation $\mathcal{E}_B(Y) = \zeta\bar{\zeta}\, X \mathcal{E}_A(X^{-1}YX^{-*})X^*$, Wolf Theorem 6.3 forcing $|\zeta| = 1$, equality of peripheral spectra $\{e^{2\pi i r/m}\}$, and the resulting contradiction when periods differ; adds source citation to arXiv:1708.00029, Appendix A, lines 917–950.
- `blueprint/src/chapter/ch11b_periodic_ft.tex`: rewrites the blueprint proof of the same theorem with explicit transfer-map and peripheral-spectrum equations in place of the previous high-level sketch; sources: arXiv:1708.00029, Proposition 3.3 statement, lines 589–604, and Appendix A, lines 917–950.
- No Lean proof steps changed; no new `sorry` introduced.

### Testing

- `lake env lean TNLean/MPS/Periodic/Overlap/Case1.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/MPS/Periodic/Overlap/Case1.lean blueprint/src/chapter/ch11b_periodic_ft.tex`
- `git diff --check`
- `cd blueprint && leanblueprint web` (completed with existing plasTeX bibliography/package warnings)
- Lean CI (`lean_action_ci.yml`) validates the full build.

---
Addresses #448

> [!NOTE]
> **Low Risk**
> Commentary and LaTeX proof exposition only; no Lean proof or runtime behavior changes.
>
> **Overview**
> Documentation only: the **different-period overlap decay** theorem (`periodicOverlap_tendsto_zero_of_ne_period`) is unchanged in Lean; only its docstring and the matching blueprint proof are rewritten.
>
> Both now spell out the **equal bond dimension** branch with explicit transfer-map conjugation \( \mathcal{E}_B(Y)=\zeta\overline{\zeta}\,X\mathcal{E}_A(X^{-1}YX^{-*})X^* \), **Wolf Theorem 6.3** forcing \(|\zeta|=1\), equality of **peripheral spectra** \(\{e^{2\pi i r/m}\}\), hence a contradiction if periods differ, then **non–gauge-phase equivalence** and the irreducible trace-preserving overlap dichotomy. The Lean docstring adds an **arXiv:1708.00029 Appendix A (lines 917–950)** citation in place of the old high-level proof sketch.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25e78598c5dd572d3fc87e5a6209b356f9a3573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>