### PR TITLE
feat(PEPS): state post-absorption edge insertion equality

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -3,37 +3,12 @@ import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
--- The contraction algebra is proved. The forward PEPS theorem is stated with
--- the remaining bond-dimension obligation separated below, and the converse
--- still depends on the mathematical hypotheses listed below.
---
--- Provability note: `IsVertexInjective` in `PEPS.Defs` is the
--- linear-independence formulation `∀ v, LinearIndependent ℂ (A.component v)`
--- (see issue #633 for the switch away from function-level injectivity, which
--- is strictly weaker). Linear independence gives each vertex tensor a left
--- inverse on its image and is the correct hypothesis for the repaired
--- uniqueness statement `gauge_unique_mod_edge_scalars`.
---
--- The unproved converse ingredients split into three groups:
--- * `gaugeConsistency` requires the edge-centred reduction from
---   arXiv:1804.04964, Section 3: after choosing an edge `e = (u,v)`,
---   blocking all vertices other than `u` and `v` gives a three-site injective
---   MPS; Lemma `inj_isomorph` assigns an edge gauge, and the gauges obtained
---   from all edges are absorbed into the second tensor family before the
---   equation labelled `eq:inj_equal_edge`. The local left inverse is in
---   `PEPS/VirtualInsertion`, the edge-blocked contraction is in `PEPS/Blocking`,
---   and `BlockedMiddleGaugeFormula` isolates the remaining implication from
---   `SameState` to the explicit local gauge formula.  Tracked by #780.
--- * The `hDim` step inside `fundamentalTheorem_PEPS` is factored out as the
---   conditional theorem `fundamentalTheorem_PEPS_of_bondDim`, so that the
---   bond-dimension equality is orthogonal to `gaugeConsistency`. Its derivation
---   from `SameState` plus vertex injectivity still requires a boundary-insertion
---   / blocking lemma.  Tracked by #874 (`PEPS: bond-dimension equality from
---   SameState and vertex injectivity`).
--- * `gauge_unique_mod_edge_scalars` is the repaired uniqueness statement. Its
---   proof still requires local tensor-factor uniqueness for the balanced
---   edge-scalar quotient.  Tracked by #842 (`Discharge sorry in
---   gauge_unique_mod_edge_scalars`).
+-- The contraction algebra is proved. The remaining converse ingredients are
+-- separated by mathematical role: edge-centred gauge extraction (#780), the
+-- bond-dimension equality from `SameState` and vertex injectivity (#874), and
+-- uniqueness modulo balanced edge scalars (#842). The hypothesis
+-- `IsVertexInjective` is the linear-independence formulation from `PEPS.Defs`,
+-- which gives the local left inverses used below.
 
 /-!
 # Fundamental Theorem for injective PEPS
@@ -569,6 +544,20 @@ theorem localGauge_exists (A B : Tensor G d)
   localGauge_exists_of_factorizedLocalGauge A B hA hDim v hFactorized
 
 /-! ### Gauge consistency across edges -/
+
+/-- Post-absorption edge insertion equality from arXiv:1804.04964, Section 3,
+lines 1037--1065. Assuming the separately tracked bond-dimension equality
+`hDim` (#874), the edge gauges obtained from the three-site comparison can be
+absorbed into `B` so that every edge insertion in `A` agrees with the transported
+edge insertion in the absorbed tensor family. The remaining proof is #1364. -/
+theorem post_absorption_edge_insertion_equality (A B : Tensor G d)
+    (hA : IsVertexInjective A) (hB : IsVertexInjective B) (hAB : SameState A B)
+    (hDim : A.bondDim = B.bondDim) :
+    ∃ Z, ∀ e X σ,
+      edgeInsertedCoeff (G := G) A e σ X =
+        edgeInsertedCoeff (G := G) (absorbEdgeGauges B Z) e σ
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hDim e)) X) := by
+  sorry
 
 /-- Edge gauges obtained from the three-site reductions give one global gauge
 family.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1298,12 +1298,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{thm:matrixAlgEquiv_inner_of_fin}
     Suppose the edge insertion correspondence is a $\C$-algebra isomorphism
     between the two full matrix algebras on the chosen bond. Then the two bond
-    dimensions on that edge are equal. If $h_e:D_A(e)=D_B(e)$ is this equality,
-    then the isomorphism is realized by conjugation with an invertible edge
-    matrix $Z_e$ after the canonical index identification:
-    $Y=Z_e\,(\operatorname{reindex}_{h_e} X)\,Z_e^{-1}$.
+    dimensions on that edge are equal. If $h_e:D_A(e)=D_B(e)$ is this
+    equality, and if
+    $\phi_{h_e}:\MN{D_A(e)}\to\MN{D_B(e)}$ is the induced algebra
+    isomorphism, then the insertion correspondence is
+    $Y=Z_e\,\phi_{h_e}(X)\,Z_e^{-1}$ for an invertible edge matrix $Z_e$.
     \begin{center}
-        \TNGaugeConjugation{Z_e}{\operatorname{reindex}_{h_e}(X)}{Z_e^{-1}}
+        \TNGaugeConjugation{Z_e}{\phi_{h_e}(X)}{Z_e^{-1}}
     \end{center}
     This is the finite-dimensional matrix-algebra step in
     \cite[Section~3]{Molnar2018NormalPEPS}.
@@ -1381,18 +1382,28 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Post-absorption edge insertion equality]%
     \label{thm:peps_postAbsorptionEdgeInsertionEquality}
-    \notready
+    \lean{TNLean.PEPS.post_absorption_edge_insertion_equality}
+    \leanok
     \uses{thm:peps_edge_gauge_absorption, def:peps_edgeInsertedCoeff}
-    After the edge gauges have been absorbed into the second tensor family, for
-    every edge and every matrix $X$, inserting $X$ on that edge in the first
-    PEPS gives the same state as inserting $X$ on the same edge in the
-    modified second PEPS:
+    Let $A$ and $B$ be vertex-injective PEPS with the same state, and assume
+    the bond-dimension equality $h:D_A=D_B$.  After the edge gauges have been
+    absorbed into the second tensor family, there are gauges $Z_e$ and an
+    absorbed tensor family $\widetilde B=B^Z$ with $D_{\widetilde B}=D_B$.
+    Writing $C_T(e,X;\sigma)$ for the edge-inserted
+    coefficient of a tensor family $T$, and writing
+    $\phi_{h_e}:\MN{D_A(e)}\to\MN{D_{\widetilde B}(e)}$ for the algebra
+    isomorphism induced by $h_e:D_A(e)=D_{\widetilde B}(e)$, for every edge
+    $e$, every $X\in\MN{D_A(e)}$, and every physical configuration $\sigma$,
+    \[
+        C_A(e,X;\sigma)
+        =
+        C_{\widetilde B}(e,\phi_{h_e}(X);\sigma),
+    \]
+    Diagrammatically, this is the equality
     \begin{center}
         \TNPEPSEdgeInsertionEquality
     \end{center}
-    This is the blueprint form of the displayed equation
-    $\textup{eq:inj\_equal\_edge}$ in
-    \cite[Section~3]{Molnar2018NormalPEPS}.
+    from \cite[Section~3, lines 1037--1065]{Molnar2018NormalPEPS}.
 \end{theorem}
 
 \begin{theorem}[Local gauge extraction]%


### PR DESCRIPTION
### Motivation

- Continues the PEPS fundamental theorem formalization from arXiv:1804.04964, Section 3, lines 1037--1065, later used at lines 1207--1210.
- The paper asserts that after the edge gauges are absorbed into the second tensor family, every edge insertion gives the same coefficient on the first family and on the absorbed second family.
- This is the formula-level endpoint tracked by #1364, with the bond-dimension equality kept as the separate #874 hypothesis.

### Description

- Adds `TNLean.PEPS.post_absorption_edge_insertion_equality` to `TNLean/PEPS/FundamentalTheorem.lean`.
- Hypotheses: vertex injectivity of `A` and `B`, `SameState A B`, and the separately tracked bond-dimension equality `hDim : A.bondDim = B.bondDim` (#874).
- Conclusion: there are edge gauges `Z_e` such that, after absorbing them into `B`,
  `edgeInsertedCoeff A e σ X = edgeInsertedCoeff (absorbEdgeGauges B Z) e σ (Matrix.reindexAlgEquiv ... X)` for every edge, inserted matrix, and physical configuration.
- Updates the PEPS blueprint statement with the matching hypotheses and the formula $C_A(e,X;\sigma)=C_{\widetilde B}(e,\phi_{h_e}(X);\sigma)$, keeping the TikZ diagram.
- Replaces the adjacent blueprint use of `\operatorname{reindex}` by the same algebra-isomorphism notation $\phi_{h_e}$.

### Testing

- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`
- `lake exe lint_style --github`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/PEPS/FundamentalTheorem.lean blueprint/src/chapter/ch13a_peps_ft.tex`
- `git diff --check`
- line-length scan on touched files
- `cd blueprint && leanblueprint web`
- `lake build`

Addresses #1364

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a sorry theorem in a root-only PEPS module; no proved logic or runtime behavior changes.
> 
> **Overview**
> Adds **`TNLean.PEPS.post_absorption_edge_insertion_equality`** in `FundamentalTheorem.lean`: under vertex injectivity, **`SameState`**, and bond-dimension equality **`hDim`** (#874), there exist edge gauges **`Z`** such that **`edgeInsertedCoeff`** on **`A`** matches **`edgeInsertedCoeff`** on **`absorbEdgeGauges B Z`** after reindexing the inserted matrix via **`hDim`**. The proof is left as **`sorry`** (#1364).
> 
> The module header is tightened to point at the three remaining converse tracks (#780, #874, #842) without repeating the old long note.
> 
> The PEPS blueprint **`ch13a_peps_ft.tex`** is aligned: the post-absorption theorem is marked **`\leanok`** with the same hypotheses and the coefficient identity **`C_A(e,X;\sigma)=C_{\widetilde B}(e,\phi_{h_e}(X);\sigma)`**; the adjacent edge-gauge-from-isomorphism theorem uses **`φ_{h_e}`** instead of **`reindex`** notation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92985cdd1fcbb0ab2b13b712059d28c5461c16f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->