### PR TITLE
feat(PEPS): state two-injective comparison

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -379,5 +379,6 @@ import TNLean.PEPS.InsertionRealization
 import TNLean.PEPS.LocalGauge
 import TNLean.PEPS.TensorFactorScalar
 import TNLean.PEPS.EdgeGaugeExtraction
+import TNLean.PEPS.TwoInjectiveComparison
 -- The PEPS fundamental theorem is an exploratory capstone with recorded
 -- paper-alignment gaps; it is deliberately not part of the default root.

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -1,6 +1,5 @@
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.LocalGauge
-import TNLean.PEPS.TwoInjectiveComparison
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -1,5 +1,6 @@
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.LocalGauge
+import TNLean.PEPS.TwoInjectiveComparison
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 

--- a/TNLean/PEPS/TwoInjectiveComparison.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison.lean
@@ -131,20 +131,22 @@ def TwoBlockReciprocalScalarProportional
 Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, lines
 1068--1203 of `Papers/1804.04964/paper_normal.tex`.
 
-If `A₁,A₂,B₁,B₂` are injective tensors joined by a finite nonempty family of
-shared virtual bonds, and inserting an arbitrary matrix on any shared bond
-gives the same two-tensor coefficient for the `A`-pair and the `B`-pair, then
-there is a nonzero scalar `λ` such that `A₁ = λ B₁` and
-`A₂ = λ⁻¹ B₂`.
+This is the source comparison theorem in an abstract form with nonempty
+spectator external boundary spaces; the statement in the paper is recovered by
+taking these spaces to be one-point spaces. If `A₁,A₂,B₁,B₂` are injective
+tensors joined by a finite nonempty family of shared virtual bonds, and
+inserting an arbitrary matrix on any shared bond gives the same two-tensor
+coefficient for the `A`-pair and the `B`-pair, then there is a nonzero scalar
+`λ` such that `A₁ = λ B₁` and `A₂ = λ⁻¹ B₂`.
 
-**Proof status:** This is the main theorem of the cited source. The proof
-follows the paper's argument: use injectivity to apply the inverse of one
-tensor, reduce the residual virtual operators by the scalar-reduction step
+**Proof status:** This is the main comparison theorem recorded in this file.
+The proof follows the paper's argument: use injectivity to apply the inverse of
+one tensor, reduce the residual virtual operators by the scalar-reduction step
 recorded in the blueprint as `thm:peps_twoInjectiveGaugeScalarReduction`, and
 then apply the same argument to the other tensor. Tracked by issue #1361. -/
-theorem twoInjectiveTensorInsertionComparison
+theorem two_injective_tensor_insertion_comparison
     {External₁ External₂ Physical₁ Physical₂ : Type*}
-    [Nonempty Bond]
+    [Nonempty Bond] [Nonempty External₁] [Nonempty External₂]
     (A₁ B₁ : TwoBlockTensor bondDim External₁ Physical₁)
     (A₂ B₂ : TwoBlockTensor bondDim External₂ Physical₂)
     (hA₁ : IsTwoBlockInjective A₁) (hA₂ : IsTwoBlockInjective A₂)

--- a/TNLean/PEPS/TwoInjectiveComparison.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison.lean
@@ -1,0 +1,160 @@
+import Mathlib.Data.Complex.Basic
+import Mathlib.Data.Matrix.Basic
+import Mathlib.LinearAlgebra.LinearIndependent.Basic
+
+/-!
+# Two-injective-tensor comparison for PEPS
+
+This file records the source-facing finite-dimensional statement of the
+two-tensor comparison used in the proof of the injective PEPS Fundamental
+Theorem.
+
+The statement is Lemma `inj_equal_tensors_2` in
+Molnár--Schuch--Verstraete--Cirac, arXiv:1804.04964, Section 3, lines
+1068--1203 of `Papers/1804.04964/paper_normal.tex`: if two pairs of
+injective tensors agree after inserting an arbitrary matrix on each shared
+virtual bond, then the corresponding tensors differ by reciprocal nonzero
+scalars.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {Bond : Type*} [Fintype Bond]
+variable {bondDim : Bond → Type*} [∀ b, Fintype (bondDim b)]
+
+/-! ### Abstract two-block tensors -/
+
+/-- A configuration of the shared virtual bonds between two injective tensors.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, displayed
+equation `eq:lem_inj_eq_ten_2`. The family `bondDim` indexes the virtual
+spaces carried by the parallel shared bonds in that diagram. -/
+abbrev SharedBondConfig (bondDim : Bond → Type*) : Type _ :=
+  (b : Bond) → bondDim b
+
+/-- A finite-dimensional tensor block with an external virtual boundary, a
+shared virtual boundary, and a physical index.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, where each
+of `A_1,A_2,B_1,B_2` is an injective tensor. -/
+abbrev TwoBlockTensor (bondDim : Bond → Type*) (External Physical : Type*) : Type _ :=
+  External → SharedBondConfig bondDim → Physical → ℂ
+
+/-- Two shared-bond configurations agree away from the distinguished bond.
+
+Source: arXiv:1804.04964, Section 3, equation `eq:lem_inj_eq_ten_2`: inserting
+a matrix `X` on one shared edge leaves all other shared virtual bonds
+contracted by the identity. -/
+def SameAwayFromBond (b : Bond)
+    (η θ : SharedBondConfig bondDim) : Prop :=
+  ∀ c : Bond, c ≠ b → η c = θ c
+
+/-- The two-tensor coefficient obtained by inserting a matrix on one shared
+virtual bond.
+
+The summation has two shared-bond configurations, one on each side of the
+inserted matrix. The factor `SameAwayFromBond b η θ` imposes identity
+contraction on every other shared bond.
+
+Source: arXiv:1804.04964, Section 3, equation `eq:lem_inj_eq_ten_2`. -/
+noncomputable def twoBlockInsertedCoeff
+    {External₁ External₂ Physical₁ Physical₂ : Type*}
+    (A₁ : TwoBlockTensor bondDim External₁ Physical₁)
+    (A₂ : TwoBlockTensor bondDim External₂ Physical₂)
+    (b : Bond) (X : Matrix (bondDim b) (bondDim b) ℂ)
+    (η₁ : External₁) (η₂ : External₂)
+    (σ₁ : Physical₁) (σ₂ : Physical₂) : ℂ := by
+  classical
+  exact
+    ∑ μ : SharedBondConfig bondDim,
+      ∑ ν : SharedBondConfig bondDim,
+        (if SameAwayFromBond b μ ν then X (μ b) (ν b) else 0) *
+          A₁ η₁ μ σ₁ * A₂ η₂ ν σ₂
+
+/-- Injectivity of a two-block tensor, expressed as linear independence of the
+physical vectors indexed by all virtual boundary configurations.
+
+This is the abstract form of injectivity used in arXiv:1804.04964, Section 3,
+Lemma `inj_equal_tensors_2`. -/
+def IsTwoBlockInjective
+    {External Physical : Type*}
+    (A : TwoBlockTensor bondDim External Physical) : Prop :=
+  LinearIndependent ℂ
+    (fun η : External × SharedBondConfig bondDim => fun σ : Physical => A η.1 η.2 σ)
+
+/-- Equality of all one-bond matrix insertions for two pairs of injective
+tensors.
+
+Source: arXiv:1804.04964, Section 3, equation `eq:lem_inj_eq_ten_2`: for every
+shared virtual bond and every matrix inserted on that bond, the two-tensor
+contractions for the `A`-pair and the `B`-pair coincide. -/
+def SameTwoBlockInsertions
+    {External₁ External₂ Physical₁ Physical₂ : Type*}
+    (A₁ B₁ : TwoBlockTensor bondDim External₁ Physical₁)
+    (A₂ B₂ : TwoBlockTensor bondDim External₂ Physical₂) : Prop :=
+  ∀ (b : Bond) (X : Matrix (bondDim b) (bondDim b) ℂ)
+    (η₁ : External₁) (η₂ : External₂)
+    (σ₁ : Physical₁) (σ₂ : Physical₂),
+      twoBlockInsertedCoeff A₁ A₂ b X η₁ η₂ σ₁ σ₂ =
+        twoBlockInsertedCoeff B₁ B₂ b X η₁ η₂ σ₁ σ₂
+
+/-- Scalar proportionality of two tensor blocks with the same boundary spaces.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, conclusion
+`A_1 = λ B_1` and `A_2 = λ^{-1} B_2`. -/
+def TwoBlockScalarProportional
+    {External Physical : Type*}
+    (A B : TwoBlockTensor bondDim External Physical) (c : ℂ) : Prop :=
+  ∀ (η : External) (μ : SharedBondConfig bondDim) (σ : Physical),
+    A η μ σ = c * B η μ σ
+
+/-- Reciprocal scalar proportionality of the two tensor pairs in
+Lemma `inj_equal_tensors_2`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`. -/
+def TwoBlockReciprocalScalarProportional
+    {External₁ External₂ Physical₁ Physical₂ : Type*}
+    (A₁ B₁ : TwoBlockTensor bondDim External₁ Physical₁)
+    (A₂ B₂ : TwoBlockTensor bondDim External₂ Physical₂) : Prop :=
+  ∃ c : ℂ,
+    c ≠ 0 ∧
+      TwoBlockScalarProportional A₁ B₁ c ∧
+        TwoBlockScalarProportional A₂ B₂ c⁻¹
+
+/-! ### Source theorem endpoint -/
+
+/-- **Generalized two-injective-tensor comparison.**
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, lines
+1068--1203 of `Papers/1804.04964/paper_normal.tex`.
+
+If `A₁,A₂,B₁,B₂` are injective tensors joined by a finite nonempty family of
+shared virtual bonds, and inserting an arbitrary matrix on any shared bond
+gives the same two-tensor coefficient for the `A`-pair and the `B`-pair, then
+there is a nonzero scalar `λ` such that `A₁ = λ B₁` and
+`A₂ = λ⁻¹ B₂`.
+
+**Proof status:** This is the source theorem endpoint. The proof follows the
+paper's argument: use injectivity to apply the inverse of one tensor, reduce
+the residual virtual operators by the scalar-reduction step recorded in the
+blueprint as `thm:peps_twoInjectiveGaugeScalarReduction`, and then apply the
+same argument to the other tensor. Tracked by issue #1361. -/
+theorem twoInjectiveTensorInsertionComparison
+    {External₁ External₂ Physical₁ Physical₂ : Type*}
+    [Nonempty Bond]
+    (A₁ B₁ : TwoBlockTensor bondDim External₁ Physical₁)
+    (A₂ B₂ : TwoBlockTensor bondDim External₂ Physical₂)
+    (hA₁ : IsTwoBlockInjective A₁) (hA₂ : IsTwoBlockInjective A₂)
+    (hB₁ : IsTwoBlockInjective B₁) (hB₂ : IsTwoBlockInjective B₂)
+    (hinsert : SameTwoBlockInsertions A₁ B₁ A₂ B₂) :
+    TwoBlockReciprocalScalarProportional A₁ B₁ A₂ B₂ := by
+  -- The remaining proof is Lemma `inj_equal_tensors_2` from
+  -- arXiv:1804.04964, Section 3, lines 1068--1203. It depends on the
+  -- scalar-reduction substep tracked separately by issue #1362.
+  sorry
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TwoInjectiveComparison.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison.lean
@@ -124,7 +124,7 @@ def TwoBlockReciprocalScalarProportional
       TwoBlockScalarProportional A₁ B₁ c ∧
         TwoBlockScalarProportional A₂ B₂ c⁻¹
 
-/-! ### Source theorem endpoint -/
+/-! ### Main comparison theorem -/
 
 /-- **Generalized two-injective-tensor comparison.**
 
@@ -137,11 +137,11 @@ gives the same two-tensor coefficient for the `A`-pair and the `B`-pair, then
 there is a nonzero scalar `λ` such that `A₁ = λ B₁` and
 `A₂ = λ⁻¹ B₂`.
 
-**Proof status:** This is the source theorem endpoint. The proof follows the
-paper's argument: use injectivity to apply the inverse of one tensor, reduce
-the residual virtual operators by the scalar-reduction step recorded in the
-blueprint as `thm:peps_twoInjectiveGaugeScalarReduction`, and then apply the
-same argument to the other tensor. Tracked by issue #1361. -/
+**Proof status:** This is the main theorem of the cited source. The proof
+follows the paper's argument: use injectivity to apply the inverse of one
+tensor, reduce the residual virtual operators by the scalar-reduction step
+recorded in the blueprint as `thm:peps_twoInjectiveGaugeScalarReduction`, and
+then apply the same argument to the other tensor. Tracked by issue #1361. -/
 theorem twoInjectiveTensorInsertionComparison
     {External₁ External₂ Physical₁ Physical₂ : Type*}
     [Nonempty Bond]

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1553,12 +1553,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{theorem}[Generalized two-injective-tensor comparison]%
     \label{thm:peps_twoInjectiveTensorInsertionComparison}
     \lean{TNLean.PEPS.twoInjectiveTensorInsertionComparison}
+    \lean{TNLean.PEPS.SameAwayFromBond, TNLean.PEPS.twoBlockInsertedCoeff}
+    \lean{TNLean.PEPS.IsTwoBlockInjective, TNLean.PEPS.SameTwoBlockInsertions}
+    \lean{TNLean.PEPS.TwoBlockScalarProportional}
+    \lean{TNLean.PEPS.TwoBlockReciprocalScalarProportional}
     \notready
-    \uses{def:IsVertexInjective, thm:peps_twoInjectiveGaugeScalarReduction}
-    Let $A_1,A_2,B_1,B_2$ be injective tensors with the same virtual boundary
-    spaces. Suppose that inserting an arbitrary matrix $X$ on any shared
-    virtual bond gives the same two-tensor state for the $A$-pair and the
-    $B$-pair:
+    \uses{thm:peps_twoInjectiveGaugeScalarReduction}
+    Let $A_1,A_2,B_1,B_2$ be injective tensors with the same shared virtual
+    bonds. For a shared bond $b$ and a matrix $X\in\operatorname{Mat}_{D_b}$,
+    write $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for the
+    two-tensor coefficient with $X$ inserted on $b$ and the identity inserted
+    on every other shared bond. Assume
+    $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)
+    =C_{B_1,B_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for every
+    $b,X,\eta_1,\eta_2,\sigma_1,\sigma_2$:
     \begin{center}
         \TNPEPSTwoInjectiveTensorInsertionComparison
     \end{center}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1552,6 +1552,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Generalized two-injective-tensor comparison]%
     \label{thm:peps_twoInjectiveTensorInsertionComparison}
+    \lean{TNLean.PEPS.twoInjectiveTensorInsertionComparison}
     \notready
     \uses{def:IsVertexInjective, thm:peps_twoInjectiveGaugeScalarReduction}
     Let $A_1,A_2,B_1,B_2$ be injective tensors with the same virtual boundary

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1575,15 +1575,17 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Generalized two-injective-tensor comparison]%
     \label{thm:peps_twoInjectiveTensorInsertionComparison}
-    \lean{TNLean.PEPS.twoInjectiveTensorInsertionComparison}
+    \lean{TNLean.PEPS.two_injective_tensor_insertion_comparison}
     \lean{TNLean.PEPS.SameAwayFromBond, TNLean.PEPS.twoBlockInsertedCoeff}
     \lean{TNLean.PEPS.IsTwoBlockInjective, TNLean.PEPS.SameTwoBlockInsertions}
     \lean{TNLean.PEPS.TwoBlockScalarProportional}
     \lean{TNLean.PEPS.TwoBlockReciprocalScalarProportional}
+    \leanok
     \uses{thm:peps_twoInjectiveGaugeScalarReduction}
     Let $A_1,A_2,B_1,B_2$ be injective tensors with the same shared virtual
-    bonds, and assume that there is at least one shared virtual bond. For a
-    shared bond $b$ and a matrix $X\in\operatorname{Mat}_{D_b}$, write
+    bonds and nonempty external boundary spaces, and assume that there is at
+    least one shared virtual bond. For a shared bond $b$ and a matrix
+    $X\in\operatorname{Mat}_{D_b}$, write
     $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for the two-tensor
     coefficient with $X$ inserted on $b$ and the identity inserted on every
     other shared bond. Assume

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1539,15 +1539,38 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 \begin{proof}\leanok
-    Compare matrix entries. Equality with
-    $\operatorname{End}(\alpha\otimes\beta)\otimes I_\gamma$ forces all
-    $I_\alpha\otimes Z$ entries with different $\gamma$-indices to vanish.
-    Equality with the middle-identity form forces all entries with different
-    $\beta$-indices to vanish. The remaining diagonal entries are equal because
-    the two identities compare them first along the $\beta$-direction and then
-    along the $\gamma$-direction. Substituting the resulting scalar form of $Z$
-    back into the two displayed equalities gives the same scalar form for $U$
-    and $W$.
+    Write the common operator as $T$. The equality
+    $T=I_\alpha\otimes Z=U\otimes I_\gamma$ gives, for all indices,
+    \[
+        \delta_{aa'} Z_{bc,b'c'}
+        =
+        U_{ab,a'b'}\delta_{cc'} .
+    \]
+    If $c\neq c'$, the right hand side is zero; choosing $a=a'$ gives
+    $Z_{bc,b'c'}=0$. Hence $Z$ is diagonal in the $\gamma$-index. Similarly,
+    the equality $T=I_\alpha\otimes Z=W_{\alpha\gamma}\otimes I_\beta$ gives
+    \[
+        \delta_{aa'} Z_{bc,b'c'}
+        =
+        W_{ac,a'c'}\delta_{bb'} ,
+    \]
+    so $Z_{bc,b'c'}=0$ whenever $b\neq b'$. Thus $Z_{bc,b'c'}=0$ unless
+    $b=b'$ and $c=c'$.
+
+    It remains to compare the surviving diagonal entries. From
+    $\delta_{aa'}Z_{bc,bc}=U_{ab,a'b}$, the value
+    $Z_{bc,bc}$ is independent of $c$. From the middle-identity equality it is
+    also independent of $b$. Therefore $Z=\lambda I_{\beta\otimes\gamma}$.
+    Substitution into
+    \[
+        I_\alpha\otimes Z
+        =
+        U\otimes I_\gamma
+        =
+        W_{\alpha\gamma}\otimes I_\beta
+    \]
+    gives $U=\lambda I_{\alpha\otimes\beta}$ and
+    $W_{\alpha\gamma}=\lambda I_{\alpha\otimes\gamma}$.
 \end{proof}
 
 \begin{theorem}[Generalized two-injective-tensor comparison]%
@@ -1575,6 +1598,33 @@ injective and normal PEPS, following Theorems~2 and~3 of
     form of the two-injective tensor comparison in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
+\begin{proof}
+    The proof is the argument of Lemma~$\mathrm{inj\_equal\_tensors\_2}$ in
+    \cite[Section~3]{Molnar2018NormalPEPS}. Applying the inverse of $A_2$ to
+    the three insertion equalities obtained by freeing each shared bond gives
+    \[
+        A_1
+        =
+        B_1\cdot Z
+        =
+        B_1\cdot U
+        =
+        B_1\cdot W,
+    \]
+    where $Z$, $U$, and $W$ act on the complementary pairs of exposed virtual
+    legs. Applying the inverse of $B_1$ gives the residual equality
+    \[
+        \sum_i I\otimes Z_i^{(1)}\otimes Z_i^{(2)}
+        =
+        \sum_i U_i^{(1)}\otimes U_i^{(2)}\otimes I
+        =
+        \sum_i W_i^{(1)}\otimes I\otimes W_i^{(2)}.
+    \]
+    The scalar-reduction theorem above gives $Z=\lambda I$, hence
+    $A_1=\lambda B_1$. Substituting this identity into the original insertion
+    equality with $X=I$ gives $A_2=\lambda^{-1}B_2$. Since $A_1$ and $B_1$ are
+    injective tensors, $\lambda\neq 0$.
+\end{proof}
 
 \begin{theorem}[One-vertex versus complement comparison]%
     \label{thm:peps_oneVertexComplementComparison}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1580,13 +1580,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.IsTwoBlockInjective, TNLean.PEPS.SameTwoBlockInsertions}
     \lean{TNLean.PEPS.TwoBlockScalarProportional}
     \lean{TNLean.PEPS.TwoBlockReciprocalScalarProportional}
-    \notready
     \uses{thm:peps_twoInjectiveGaugeScalarReduction}
     Let $A_1,A_2,B_1,B_2$ be injective tensors with the same shared virtual
-    bonds. For a shared bond $b$ and a matrix $X\in\operatorname{Mat}_{D_b}$,
-    write $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for the
-    two-tensor coefficient with $X$ inserted on $b$ and the identity inserted
-    on every other shared bond. Assume
+    bonds, and assume that there is at least one shared virtual bond. For a
+    shared bond $b$ and a matrix $X\in\operatorname{Mat}_{D_b}$, write
+    $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for the two-tensor
+    coefficient with $X$ inserted on $b$ and the identity inserted on every
+    other shared bond. Assume
     $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)
     =C_{B_1,B_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for every
     $b,X,\eta_1,\eta_2,\sigma_1,\sigma_2$:
@@ -1599,9 +1599,22 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 \begin{proof}
-    The proof is the argument of Lemma~$\mathrm{inj\_equal\_tensors\_2}$ in
+    The proof is the argument of the comparison lemma in
     \cite[Section~3]{Molnar2018NormalPEPS}. Applying the inverse of $A_2$ to
     the three insertion equalities obtained by freeing each shared bond gives
+    virtual operators $Z,U,W$ satisfying, for every external index $\eta$,
+    shared-boundary index $\mu$, and physical index $\sigma$ of the first
+    block,
+    \[
+        A_1(\eta,\mu,\sigma)
+        =
+        \sum_\nu B_1(\eta,\nu,\sigma) Z_{\nu,\mu}
+        =
+        \sum_\nu B_1(\eta,\nu,\sigma) U_{\nu,\mu}
+        =
+        \sum_\nu B_1(\eta,\nu,\sigma) W_{\nu,\mu}.
+    \]
+    In tensor notation this is
     \[
         A_1
         =

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -198,9 +198,11 @@ Theorem can be proved in the manner of the paper.
   $A_1=\lambda B_1$ and $A_2=\lambda^{-1}B_2$. In the blueprint this is
   split into the scalar-reduction substep
   \path{thm:peps_twoInjectiveGaugeScalarReduction} and the formally stated
-  theorem endpoint
-  \leanid{TNLean.PEPS.twoInjectiveTensorInsertionComparison}. Its proof remains
-  open and is tracked by issue~\#1361.
+  comparison theorem
+  \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison}. The formal
+  statement is an abstract version with nonempty spectator external boundary
+  spaces; the source lemma is recovered by taking these spaces to be one-point
+  spaces. Its proof remains open and is tracked by issue~\#1361.
 \item The final two-tensor comparison must then be applied by blocking one
   vertex against its complement. The paper uses this to prove
   $A_i=\lambda_i\widetilde B_i$ at each vertex, and then incorporates the
@@ -254,9 +256,11 @@ It is meant to prevent the proof from drifting away from the source argument.
 \item Lemma \path{inj_equal_tensors_2}, scalar step:
   \path{thm:peps_twoInjectiveGaugeScalarReduction}, tracked by issue~\#1362.
 \item Lemma \path{inj_equal_tensors_2}, comparison:
-  \leanid{TNLean.PEPS.twoInjectiveTensorInsertionComparison} states the
-  abstract two-block insertion comparison with reciprocal scalar
-  proportionality. Its proof is tracked by issue~\#1361.
+  \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison} states the
+  abstract two-block insertion comparison with nonempty external boundary
+  spaces and reciprocal scalar proportionality. The source lemma is the
+  one-point external-boundary specialization; the proof is tracked by
+  issue~\#1361.
 \item One vertex versus its complement:
   \path{thm:peps_oneVertexComplementComparison}, tracked by issue~\#1360.
 \item Final gauge equivalence and uniqueness:

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -197,9 +197,10 @@ Theorem can be proved in the manner of the paper.
   all virtual-bond insertions for two pairs of injective tensors forces
   $A_1=\lambda B_1$ and $A_2=\lambda^{-1}B_2$. In the blueprint this is
   split into the scalar-reduction substep
-  \path{thm:peps_twoInjectiveGaugeScalarReduction} and the not-yet-formalized
-  theorem
-  \path{thm:peps_twoInjectiveTensorInsertionComparison}.
+  \path{thm:peps_twoInjectiveGaugeScalarReduction} and the formally stated
+  theorem endpoint
+  \leanid{TNLean.PEPS.twoInjectiveTensorInsertionComparison}. Its proof remains
+  open and is tracked by issue~\#1361.
 \item The final two-tensor comparison must then be applied by blocking one
   vertex against its complement. The paper uses this to prove
   $A_i=\lambda_i\widetilde B_i$ at each vertex, and then incorporates the
@@ -253,8 +254,9 @@ It is meant to prevent the proof from drifting away from the source argument.
 \item Lemma \path{inj_equal_tensors_2}, scalar step:
   \path{thm:peps_twoInjectiveGaugeScalarReduction}, tracked by issue~\#1362.
 \item Lemma \path{inj_equal_tensors_2}, comparison:
-  \path{thm:peps_twoInjectiveTensorInsertionComparison}, tracked by
-  issue~\#1361.
+  \leanid{TNLean.PEPS.twoInjectiveTensorInsertionComparison} states the
+  abstract two-block insertion comparison with reciprocal scalar
+  proportionality. Its proof is tracked by issue~\#1361.
 \item One vertex versus its complement:
   \path{thm:peps_oneVertexComplementComparison}, tracked by issue~\#1360.
 \item Final gauge equivalence and uniqueness:


### PR DESCRIPTION
### Motivation

- Formalizes the generalized two-injective-tensor comparison in arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, tracked by #1361.
- The paper proves that if two injective tensors agree after inserting an arbitrary matrix on every shared virtual bond, the two tensors are proportional with reciprocal scalar factors: $A_1 = \lambda B_1$, $A_2 = \lambda^{-1} B_2$.
- Connects the Lean declaration to the PEPS blueprint entry `thm:peps_twoInjectiveTensorInsertionComparison` and records the open proof obligation in the Section 3 paper-gap ledger.

### Description

- Adds `TNLean/PEPS/TwoInjectiveComparison.lean` (160 lines) with shared-bond configurations, `twoBlockInsertedCoeff`, injectivity and insertion-equality predicates, and reciprocal scalar proportionality definitions.
- States the main theorem `twoInjectiveTensorInsertionComparison` with one `sorry`; this `sorry` is the proof obligation of #1361. No new untracked `sorry` is introduced outside this theorem.
- Source: `Papers/1804.04964/paper_normal.tex`, lines 1068–1203, Lemma `inj_equal_tensors_2`.
- Wires the module into `TNLean.lean` and `TNLean/PEPS/FundamentalTheorem.lean`.
- Updates `blueprint/src/chapter/ch13a_peps_ft.tex` with Lean links, a more explicit scalar-reduction proof sketch using displayed indexed equations, and a proof sketch for the generalized two-injective comparison.
- Updates `docs/paper-gaps/peps_injective_ft_section3_route.tex` to record the Lean theorem as stated with proof still open.

### Testing

- `lake env lean TNLean/PEPS/TwoInjectiveComparison.lean`
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`
- `lake env lean TNLean.lean`
- `lake exe lint_style --github`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/PEPS/TwoInjectiveComparison.lean TNLean/PEPS/FundamentalTheorem.lean blueprint/src/chapter/ch13a_peps_ft.tex`
- `cd blueprint && leanblueprint web` (succeeds with pre-existing plasTeX/bibliography warnings)

---
Addresses #1361

> [!NOTE]
> **Low Risk**
> Adds definitions and one documented sorry for a formalization milestone; no changes to proved PEPS logic or production paths.
> 
> **Overview**
> Adds **`TNLean/PEPS/TwoInjectiveComparison.lean`**, which formalizes the abstract two-block setup for arXiv:1804.04964 Lemma `inj_equal_tensors_2`: shared-bond configs, **`twoBlockInsertedCoeff`**, injectivity and insertion-equality predicates, and reciprocal scalar proportionality. The main endpoint **`twoInjectiveTensorInsertionComparison`** is stated with a single **`sorry`** (issue #1361); supporting defs are proved-free scaffolding.
> 
> Wires the module into **`TNLean.lean`** and **`TNLean/PEPS/FundamentalTheorem.lean`**. Updates the PEPS blueprint (**`ch13a_peps_ft.tex`**) with Lean links, a more explicit scalar-reduction proof, and a proof sketch for the generalized two-injective comparison; **`docs/paper-gaps/peps_injective_ft_section3_route.tex`** now records the Lean endpoint as stated with proof still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c223088b77bc949ee194998303e3fe4610250e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds definitions and one documented sorry on the exploratory PEPS path; no changes to existing proved logic or runtime behavior.
> 
> **Overview**
> Adds **`TNLean/PEPS/TwoInjectiveComparison.lean`**, formalizing arXiv:1804.04964 Lemma `inj_equal_tensors_2` in an abstract two-block setting: shared-bond configs, **`twoBlockInsertedCoeff`**, injectivity and insertion-equality predicates, and reciprocal scalar proportionality. The endpoint **`two_injective_tensor_insertion_comparison`** is stated with a single **`sorry`** (issue #1361); supporting definitions are proof-free scaffolding.
> 
> The module is imported from **`TNLean.lean`**. The PEPS blueprint (**`ch13a_peps_ft.tex`**) links the theorem to Lean, expands the scalar-reduction proof with displayed index equations, and adds a prose proof sketch for the generalized two-injective comparison (still depending on the scalar step). **`docs/paper-gaps/peps_injective_ft_section3_route.tex`** records the Lean statement as in place with proof still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3146d344a3bde7b61da0c0a71b136ca7e33bbd15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->