### PR TITLE
feat(PEPS): state one-vertex complement comparison

### DIFF
--- a/TNLean/PEPS/TwoInjectiveComparison.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison.lean
@@ -9,9 +9,9 @@ This file records the source-facing finite-dimensional statement of the
 two-tensor comparison used in the proof of the injective PEPS Fundamental
 Theorem.
 
-The statement is Lemma `inj_equal_tensors_2` in
+The statement is Lemma inj_equal_tensors_2 in
 Molnár--Schuch--Verstraete--Cirac, arXiv:1804.04964, Section 3, lines
-1068--1203 of `Papers/1804.04964/paper_normal.tex`: if two pairs of
+1068--1203 of Papers/1804.04964/paper_normal.tex: if two pairs of
 injective tensors agree after inserting an arbitrary matrix on each shared
 virtual bond, then the corresponding tensors differ by reciprocal nonzero
 scalars.
@@ -29,8 +29,8 @@ variable {bondDim : Bond → Type*} [∀ b, Fintype (bondDim b)]
 
 /-- A configuration of the shared virtual bonds between two injective tensors.
 
-Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, displayed
-equation `eq:lem_inj_eq_ten_2`. The family `bondDim` indexes the virtual
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2, displayed
+equation eq:lem_inj_eq_ten_2. The family `bondDim` indexes the virtual
 spaces carried by the parallel shared bonds in that diagram. -/
 abbrev SharedBondConfig (bondDim : Bond → Type*) : Type _ :=
   (b : Bond) → bondDim b
@@ -38,14 +38,14 @@ abbrev SharedBondConfig (bondDim : Bond → Type*) : Type _ :=
 /-- A finite-dimensional tensor block with an external virtual boundary, a
 shared virtual boundary, and a physical index.
 
-Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, where each
-of `A_1,A_2,B_1,B_2` is an injective tensor. -/
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2, where each
+of A_1,A_2,B_1,B_2 is an injective tensor. -/
 abbrev TwoBlockTensor (bondDim : Bond → Type*) (External Physical : Type*) : Type _ :=
   External → SharedBondConfig bondDim → Physical → ℂ
 
 /-- Two shared-bond configurations agree away from the distinguished bond.
 
-Source: arXiv:1804.04964, Section 3, equation `eq:lem_inj_eq_ten_2`: inserting
+Source: arXiv:1804.04964, Section 3, equation eq:lem_inj_eq_ten_2: inserting
 a matrix `X` on one shared edge leaves all other shared virtual bonds
 contracted by the identity. -/
 def SameAwayFromBond (b : Bond)
@@ -59,7 +59,7 @@ The summation has two shared-bond configurations, one on each side of the
 inserted matrix. The factor `SameAwayFromBond b η θ` imposes identity
 contraction on every other shared bond.
 
-Source: arXiv:1804.04964, Section 3, equation `eq:lem_inj_eq_ten_2`. -/
+Source: arXiv:1804.04964, Section 3, equation eq:lem_inj_eq_ten_2. -/
 noncomputable def twoBlockInsertedCoeff
     {External₁ External₂ Physical₁ Physical₂ : Type*}
     (A₁ : TwoBlockTensor bondDim External₁ Physical₁)
@@ -78,7 +78,7 @@ noncomputable def twoBlockInsertedCoeff
 physical vectors indexed by all virtual boundary configurations.
 
 This is the abstract form of injectivity used in arXiv:1804.04964, Section 3,
-Lemma `inj_equal_tensors_2`. -/
+Lemma inj_equal_tensors_2. -/
 def IsTwoBlockInjective
     {External Physical : Type*}
     (A : TwoBlockTensor bondDim External Physical) : Prop :=
@@ -88,7 +88,7 @@ def IsTwoBlockInjective
 /-- Equality of all one-bond matrix insertions for two pairs of injective
 tensors.
 
-Source: arXiv:1804.04964, Section 3, equation `eq:lem_inj_eq_ten_2`: for every
+Source: arXiv:1804.04964, Section 3, equation eq:lem_inj_eq_ten_2: for every
 shared virtual bond and every matrix inserted on that bond, the two-tensor
 contractions for the `A`-pair and the `B`-pair coincide. -/
 def SameTwoBlockInsertions
@@ -103,8 +103,8 @@ def SameTwoBlockInsertions
 
 /-- Scalar proportionality of two tensor blocks with the same boundary spaces.
 
-Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, conclusion
-`A_1 = λ B_1` and `A_2 = λ^{-1} B_2`. -/
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2, conclusion
+A_1 = λ B_1 and A_2 = λ^{-1} B_2. -/
 def TwoBlockScalarProportional
     {External Physical : Type*}
     (A B : TwoBlockTensor bondDim External Physical) (c : ℂ) : Prop :=
@@ -112,9 +112,9 @@ def TwoBlockScalarProportional
     A η μ σ = c * B η μ σ
 
 /-- Reciprocal scalar proportionality of the two tensor pairs in
-Lemma `inj_equal_tensors_2`.
+Lemma inj_equal_tensors_2.
 
-Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`. -/
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2. -/
 def TwoBlockReciprocalScalarProportional
     {External₁ External₂ Physical₁ Physical₂ : Type*}
     (A₁ B₁ : TwoBlockTensor bondDim External₁ Physical₁)
@@ -128,8 +128,8 @@ def TwoBlockReciprocalScalarProportional
 
 /-- **Generalized two-injective-tensor comparison.**
 
-Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, lines
-1068--1203 of `Papers/1804.04964/paper_normal.tex`.
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2, lines
+1068--1203 of Papers/1804.04964/paper_normal.tex.
 
 This is the source comparison theorem in an abstract form with nonempty
 spectator external boundary spaces; the statement in the paper is recovered by
@@ -153,10 +153,48 @@ theorem two_injective_tensor_insertion_comparison
     (hB₁ : IsTwoBlockInjective B₁) (hB₂ : IsTwoBlockInjective B₂)
     (hinsert : SameTwoBlockInsertions A₁ B₁ A₂ B₂) :
     TwoBlockReciprocalScalarProportional A₁ B₁ A₂ B₂ := by
-  -- The remaining proof is Lemma `inj_equal_tensors_2` from
+  -- The remaining proof is Lemma inj_equal_tensors_2 from
   -- arXiv:1804.04964, Section 3, lines 1068--1203. It depends on the
   -- scalar-reduction substep tracked separately by issue #1362.
   sorry
+
+/-! ### One vertex against its complement -/
+
+/-- **One-vertex versus complement comparison.**
+
+Source: arXiv:1804.04964, Section 3, immediately after Lemma
+inj_equal_tensors_2, lines 1205--1210 of
+Papers/1804.04964/paper_normal.tex.
+
+After the edge gauges have been absorbed into the second PEPS tensor family,
+the source blocks one vertex against its complement. The post-absorption
+insertion equality arXiv:1804.04964, eq:inj_equal_edge, supplies equality of
+all one-bond insertions for this two-block pair. Applying Lemma
+inj_equal_tensors_2 then gives scalar proportionality of the selected vertex
+tensor with its modified counterpart.
+
+This theorem records precisely that final local use of the generalized
+two-injective comparison in an abstract form with nonempty spectator external
+boundary spaces: the selected vertex is the first block and its complement is
+the second block. -/
+theorem one_vertex_complement_comparison
+    {ExternalVertex ExternalComplement PhysicalVertex PhysicalComplement : Type*}
+    [Nonempty Bond] [Nonempty ExternalVertex] [Nonempty ExternalComplement]
+    (Avertex Bvertex : TwoBlockTensor bondDim ExternalVertex PhysicalVertex)
+    (Acomplement Bcomplement :
+      TwoBlockTensor bondDim ExternalComplement PhysicalComplement)
+    (hAvertex : IsTwoBlockInjective Avertex)
+    (hAcomplement : IsTwoBlockInjective Acomplement)
+    (hBvertex : IsTwoBlockInjective Bvertex)
+    (hBcomplement : IsTwoBlockInjective Bcomplement)
+    (hinsert :
+      SameTwoBlockInsertions Avertex Bvertex Acomplement Bcomplement) :
+    ∃ c : ℂ, c ≠ 0 ∧ TwoBlockScalarProportional Avertex Bvertex c := by
+  rcases two_injective_tensor_insertion_comparison
+      Avertex Bvertex Acomplement Bcomplement
+      hAvertex hAcomplement hBvertex hBcomplement hinsert with
+    ⟨c, hc_ne, hvertex, _hcomplement⟩
+  exact ⟨c, hc_ne, hvertex⟩
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1643,20 +1643,41 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[One-vertex versus complement comparison]%
     \label{thm:peps_oneVertexComplementComparison}
-    \notready
-    \uses{def:IsVertexInjective, thm:peps_postAbsorptionEdgeInsertionEquality,
+    \lean{TNLean.PEPS.one_vertex_complement_comparison}
+    \leanok
+    \uses{thm:peps_postAbsorptionEdgeInsertionEquality,
         thm:peps_twoInjectiveTensorInsertionComparison}
-    After the edge gauges have been absorbed into the second tensor family,
-    the paper blocks one vertex $v$ against its injective complement. Applying
-    the generalized two-injective-tensor comparison to two regions that differ
-    by exactly this vertex gives $A_v\propto \widetilde B_v$:
+    Let the shared bond type and the two external boundary spaces be nonempty.
+    After the edge gauges have been absorbed into the second tensor family
+    $\widetilde B$, block one vertex $v$ against its complement. Assume that
+    $A_v,A_{v^c},\widetilde B_v,\widetilde B_{v^c}$ are injective as two-block
+    tensors. The post-absorption insertion equality gives, for every shared
+    bond $b$, every matrix $X\in\operatorname{Mat}_{D_b}$, and all external and
+    physical indices,
+    \[
+        C_{A_v,A_{v^c}}(b,X;\eta_v,\eta_{v^c},\sigma_v,\sigma_{v^c})
+        =
+        C_{\widetilde B_v,\widetilde B_{v^c}}
+            (b,X;\eta_v,\eta_{v^c},\sigma_v,\sigma_{v^c}).
+    \]
+    These are exactly the hypotheses of the two-injective comparison for this
+    two-block decomposition. Hence there is $\lambda_v\in\mathbb C^\times$
+    such that
+    $A_v(\eta,\sigma)=\lambda_v\widetilde B_v(\eta,\sigma)$ for every local
+    virtual configuration $\eta$ and physical index $\sigma$:
     \begin{center}
         \TNPEPSOneVertexComplementComparison
     \end{center}
-    This is the final local comparison following the equation
-    $\textup{eq:inj\_equal\_edge}$ in
-    \cite[Section~3]{Molnar2018NormalPEPS}.
+    This is the final local comparison following the post-absorption insertion
+    equality in \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
+\begin{proof}\leanok
+    Apply Theorem~\ref{thm:peps_twoInjectiveTensorInsertionComparison} to
+    $A_v,\widetilde B_v$ and $A_{v^c},\widetilde B_{v^c}$. It gives a scalar
+    $\lambda_v\neq 0$ such that
+    $A_v=\lambda_v\widetilde B_v$ and
+    $A_{v^c}=\lambda_v^{-1}\widetilde B_{v^c}$; keep the first equality.
+\end{proof}
 
 \begin{theorem}[Fundamental Theorem for injective PEPS, conditional on
         bond-dimension equality]%

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -206,9 +206,11 @@ Theorem can be proved in the manner of the paper.
 \item The final two-tensor comparison must then be applied by blocking one
   vertex against its complement. The paper uses this to prove
   $A_i=\lambda_i\widetilde B_i$ at each vertex, and then incorporates the
-  scalars into the local gauges. In the blueprint this specialization is the
-  separate not-yet-formalized theorem
-  \path{thm:peps_oneVertexComplementComparison}.
+  scalars into the local gauges. This specialization is now represented by
+  \leanid{TNLean.PEPS.one_vertex_complement_comparison}. The formal statement
+  uses the abstract two-block notation with nonempty external boundary spaces;
+  the source comparison is obtained from the one-vertex and complement blocks
+  after \path{eq:inj_equal_edge}.
 \end{enumerate}
 
 \section{Source-to-formalization ledger}
@@ -262,9 +264,12 @@ It is meant to prevent the proof from drifting away from the source argument.
   one-point external-boundary specialization; the proof is tracked by
   issue~\#1361.
 \item One vertex versus its complement:
-  \path{thm:peps_oneVertexComplementComparison}, tracked by issue~\#1360.
+  \leanid{TNLean.PEPS.one_vertex_complement_comparison} records the
+  application of the generalized two-block comparison to a selected vertex and
+  its complement, under the abstract nonempty external-boundary formulation.
+  The source proof is tracked by issue~\#1360.
 \item Final gauge equivalence and uniqueness:
-  \path{thm:fundamentalTheorem_PEPS_of_bondDim} and the uniqueness endpoint,
+  \path{thm:fundamentalTheorem_PEPS_of_bondDim} and the uniqueness theorem,
   tracked by issues~\#780 and~\#842.
 \end{itemize}
 


### PR DESCRIPTION
### Motivation

- Formalizes the final one-vertex versus complement comparison in the injective PEPS Fundamental Theorem (arXiv:1804.04964, Section 3, lines 1207–1210), continuing issue #1360.
- After edge gauges are absorbed into the second tensor family, blocking one selected vertex against its injective complement yields $A_v = \lambda_v \widetilde{B}_v$ for each vertex $v$ via the generalized two-injective comparison (`lem:inj_equal_tensors_2`).
- The source situation is recovered from the abstract two-block formulation by taking the first block to be the selected vertex and the second block to be its complement.

### Description

- `TNLean/PEPS/TwoInjectiveComparison.lean`: adds `one_vertex_complement_comparison`, a corollary of `two_injective_tensor_insertion_comparison` specializing to the one-vertex versus complement case with nonempty external boundary spaces.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds `\lean{TNLean.PEPS.one_vertex_complement_comparison}` and `\leanok` to the `thm:peps_oneVertexComplementComparison` blueprint entry, with a formula-based proof sketch derived from the two-injective comparison.
- `docs/paper-gaps/peps_injective_ft_section3_route.tex`: updates the Section 3 paper-gap ledger to cite the new formal statement in place of the previously unformalized blueprint item.
- No new `sorry` is introduced; the underlying `two_injective_tensor_insertion_comparison` remains tracked by issue #1361.

### Testing

- `lake env lean TNLean/PEPS/TwoInjectiveComparison.lean`
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/PEPS/TwoInjectiveComparison.lean blueprint/src/chapter/ch13a_peps_ft.tex`
- `lake exe lint_style --github`
- `leanblueprint web` (blueprint label validation)

---
Addresses #1360

> [!NOTE]
> **Low Risk**
> Thin corollary and documentation only; the underlying comparison proof remains open on issue #1361 with no new `sorry` introduced.
>
> **Overview**
> Adds **`TNLean.PEPS.one_vertex_complement_comparison`**, the one-vertex vs. complement step after post-absorption edge insertion: under shared two-block insertions and injectivity, it concludes a **nonzero scalar** \(c\) with **`TwoBlockScalarProportional`** for the vertex pair only. The proof is a **`rcases`** on the existing (still **`sorry`**) **`two_injective_tensor_insertion_comparison`**—no new proof obligation in Lean.
>
> The PEPS blueprint theorem **`thm:peps_oneVertexComplementComparison`** is marked **`leanok`**, linked to that Lean name, and given an explicit insertion-equality / proportionality write-up plus a short proof via the generalized two-injective comparison. The Section 3 **paper-gap** route doc and ledger now cite **`one_vertex_complement_comparison`** instead of a not-yet-formalized blueprint-only item.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7deb4d9d5c864e1abbf1c4fe536f35782274766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin Lean corollary and documentation only; the parent comparison proof remains open on issue #1361 with no additional sorry introduced.
> 
> **Overview**
> Adds **`TNLean.PEPS.one_vertex_complement_comparison`**, formalizing the injective PEPS step where one vertex is blocked against its complement: under **`SameTwoBlockInsertions`** and two-block injectivity, it concludes a **nonzero** scalar **`c`** with **`TwoBlockScalarProportional`** for the vertex tensors only. The proof is a short **`rcases`** on the existing **`two_injective_tensor_insertion_comparison`** (still **`sorry`** on #1361)—**no new proof obligation**.
> 
> The blueprint entry **`thm:peps_oneVertexComplementComparison`** is linked to that Lean name, marked **`leanok`**, and given an explicit insertion-equality statement plus a proof sketch via the generalized two-injective comparison. **`docs/paper-gaps/peps_injective_ft_section3_route.tex`** now cites the Lean theorem in the Section 3 ledger instead of a blueprint-only placeholder. Minor doc-comment edits in **`TwoInjectiveComparison.lean`** drop some backticks around paper references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c568aefe52d98bc102439e85c4fb09385791cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->