### PR TITLE
feat(PEPS): state insertion algebra isomorphism

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -376,6 +376,7 @@ import TNLean.PEPS.NormalEdgeBlockingTranslated
 import TNLean.PEPS.NormalEdgeBlockingMargins
 import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.InsertionRealization
+import TNLean.PEPS.InsertionAlgebra
 import TNLean.PEPS.LocalGauge
 import TNLean.PEPS.TensorFactorScalar
 import TNLean.PEPS.EdgeGaugeExtraction

--- a/TNLean/PEPS/InsertionAlgebra.lean
+++ b/TNLean/PEPS/InsertionAlgebra.lean
@@ -1,0 +1,72 @@
+import TNLean.PEPS.EdgeMiddlePhysical
+import TNLean.PEPS.IdentityInsertion
+import TNLean.PEPS.InsertionRealization
+import Mathlib.Algebra.Algebra.Equiv
+
+/-!
+# Edge-blocked insertion algebra for PEPS
+
+This file records the matrix-algebra correspondence obtained from applying the
+three-site injective-chain argument to a PEPS blocked around one edge.
+
+The statement follows the proof of Lemma inj_isomorph in
+Molnar--Schuch--Verstraete--Cirac, arXiv:1804.04964, Section 3, lines
+254--582 of Papers/1804.04964/paper_normal.tex: physical realization of
+virtual insertions and the converse physical-to-virtual recovery produce an
+algebra isomorphism between the matrix algebras on the chosen bond.
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- The algebra-isomorphism property obtained by comparing matrix insertions on an
+edge-blocked PEPS pair.
+
+The existentially quantified algebra equivalence is the map $X \mapsto Y$
+between the full matrix algebras on the chosen virtual bond. The coefficient
+identity says that inserting $X$ in the first blocked PEPS has the same
+coefficient as inserting the corresponding matrix in the second blocked PEPS.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, especially lines
+279--282 and 571--582 of Papers/1804.04964/paper_normal.tex. -/
+def IsEdgeBlockedInsertionAlgebraIsomorphism (A B : Tensor G d) (e : Edge G) : Prop :=
+  ∃ Φ :
+    Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ ≃ₐ[ℂ]
+      Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ,
+    ∀ (σ : V → Fin d) (X : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+      edgeInsertedCoeff (G := G) A e σ X =
+        edgeInsertedCoeff (G := G) B e σ (Φ X)
+
+/-- **Edge-blocked insertion algebra isomorphism.**
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 254--582 of
+Papers/1804.04964/paper_normal.tex.
+
+After blocking a PEPS around an edge $e=(u,v)$, suppose both resulting
+three-site chains are injective and the original PEPS states agree. Then
+matrix insertions on the chosen bond of the first blocked chain correspond, by
+an algebra isomorphism, to matrix insertions on the chosen bond of the second
+blocked chain, and the corresponding inserted coefficients agree.
+
+**Proof status:** This declaration states the source theorem. The proof uses the
+already formalized virtual-to-physical realization at the two vertices, the
+physical-to-virtual recovery step tracked by issue #1370, and the
+uniqueness/bijection argument in Lemma inj_isomorph. Tracked by issue #1367. -/
+theorem isEdgeBlockedInsertionAlgebraIsomorphism
+    (A B : Tensor G d) (e : Edge G)
+    (hA : EdgeBlockedThreeSiteInjective (G := G) A e)
+    (hB : EdgeBlockedThreeSiteInjective (G := G) B e)
+    (hAB : SameState A B) :
+    IsEdgeBlockedInsertionAlgebraIsomorphism (G := G) A B e := by
+  -- This is the algebra-isomorphism step in arXiv:1804.04964, Section 3,
+  -- Lemma inj_isomorph, lines 254--582. The proof combines the
+  -- virtual-to-physical realization with the physical-to-virtual recovery
+  -- $O_1,O_2 \mapsto W$, then uses injectivity to prove uniqueness,
+  -- bijectivity, and multiplicativity of the resulting map $X \mapsto Y$.
+  sorry
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1272,20 +1272,43 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
+\begin{definition}[Edge-blocked insertion algebra correspondence]%
+    \label{def:peps_edgeBlockedInsertionAlgebraIsomorphism_property}
+    \lean{TNLean.PEPS.IsEdgeBlockedInsertionAlgebraIsomorphism}
+    \leanok
+    \uses{def:peps_edgeInsertedCoeff}
+    For two PEPS tensors $A$ and $B$ and an edge $e$, this property asserts
+    the existence of an algebra isomorphism $\Phi$ between the two matrix
+    algebras on the chosen bond such that
+    $C_A(e,\sigma,X)=C_B(e,\sigma,\Phi(X))$ for every physical configuration
+    $\sigma$ and every inserted matrix $X$.
+\end{definition}
+
 \begin{theorem}[Edge-blocked insertion algebra isomorphism]%
     \label{thm:peps_edgeBlockedInsertionAlgebraIsomorphism}
-    \notready
-    \uses{thm:peps_edgeBlockedThreeSiteInjective,
+    \lean{TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism}
+    \leanok
+    \uses{def:peps_edgeBlockedInsertionAlgebraIsomorphism_property,
+        thm:peps_edgeBlockedThreeSiteInjective,
         thm:peps_virtualInsertionPhysicalRealization,
         thm:peps_edgeInsertedCoeff_endpointPhysicalRealization,
         thm:peps_physicalToVirtualInsertion,
         thm:peps_sameState_edgeBlockedCoeff_eq, def:peps_edgeInsertedCoeff}
-    Applying the three-site injective-chain theorem to the edge-blocked MPS
-    gives an algebra isomorphism between matrix insertions on the chosen edge in
-    the two PEPS tensors. Equivalently, for every matrix $X$ inserted on that
-    edge for the first tensor family, there is a uniquely determined matrix
-    $Y$ inserted on the corresponding edge for the second tensor family that
-    gives the same edge-blocked state:
+    Suppose the two edge-blocked three-site chains associated to $A$ and $B$ at
+    the edge $e$ are injective, and suppose the two PEPS tensors define the same
+    state. Then there is an algebra isomorphism
+    \[
+        \Phi_e:\operatorname{Mat}_{D_A(e)}(\mathbb C)
+            \simeq_{\mathrm{alg}}
+            \operatorname{Mat}_{D_B(e)}(\mathbb C)
+    \]
+    such that, for every physical configuration $\sigma$ and every matrix
+    $X\in\operatorname{Mat}_{D_A(e)}(\mathbb C)$,
+    \[
+        C_A(e,\sigma,X)=C_B(e,\sigma,\Phi_e(X)).
+    \]
+    This is the edge-blocked form of the algebra isomorphism $X\mapsto Y$
+    constructed in \cite[Section~3]{Molnar2018NormalPEPS}:
     \begin{center}
         \TNPEPSThreeSiteInsertionComparison
     \end{center}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -175,9 +175,10 @@ Theorem can be proved in the manner of the paper.
   matrix, the local virtual pullbacks recover that matrix on the shared bond.
 \item Equality of PEPS states must be upgraded to equality of edge-inserted
   coefficients after the three-site reduction. This is the step that produces
-  the matrix-algebra isomorphism on the chosen bond. In the blueprint this is
-  the not-yet-formalized theorem
-  \path{thm:peps_edgeBlockedInsertionAlgebraIsomorphism}.
+  the matrix-algebra isomorphism on the chosen bond. The formally stated
+  theorem is
+  \leanid{TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism}; its proof remains
+  open and is tracked by issue~\#1367.
 \item The algebra isomorphism must be converted into an invertible edge gauge,
   using the same finite-dimensional matrix-algebra argument as the
   one-dimensional injective theorem. In the blueprint this is the
@@ -246,8 +247,9 @@ It is meant to prevent the proof from drifting away from the source argument.
   formalized by
   \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}.
 \item Matrix-insertion algebra isomorphism:
-  \path{thm:peps_edgeBlockedInsertionAlgebraIsomorphism}, tracked by
-  issue~\#1367.
+  \leanid{TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism} states the
+  edge-blocked matrix-algebra correspondence and its inserted-coefficient
+  equality. Its proof is tracked by issue~\#1367.
 \item Edge gauge from the algebra isomorphism:
   \path{thm:peps_edgeGaugeFromInsertionAlgebraIsomorphism}, tracked by
   issue~\#1368.


### PR DESCRIPTION
### Motivation

This follows arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, especially the construction at lines 563--582 of `Papers/1804.04964/paper_normal.tex`: for every insertion matrix $X$ on the blocked $A$ chain, there is a uniquely determined insertion matrix $Y$ on the blocked $B$ chain, and the map $X\mapsto Y$ is an algebra isomorphism.

### Description

- add `TNLean.PEPS.IsEdgeBlockedInsertionAlgebraIsomorphism`, the matrix-insertion correspondence property for an edge-blocked PEPS pair
- state `TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism` as the Section 3 algebra-isomorphism theorem, with the proof tracked by #1367/#1370
- update the PEPS blueprint and Section 3 paper-gap ledger with the formula for the algebra isomorphism and inserted-coefficient equality

The formal statement uses the edge-blocked PEPS hypotheses directly: both edge-blocked three-site chains are injective, and the two PEPS tensors define the same state. The conclusion is the existence of an algebra equivalence $\Phi_e$ such that $C_A(e,\sigma,X)=C_B(e,\sigma,\Phi_e(X))$ for all physical configurations $\sigma$ and inserted matrices $X$.

This PR intentionally states the theorem and leaves its proof as the tracked `sorry` for issue #1367. The proof depends on the physical-to-virtual recovery step tracked by #1370. No other new `sorry` is introduced.

Addresses #1367.

### Testing

- `lake env lean TNLean/PEPS/InsertionAlgebra.lean`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/PEPS/InsertionAlgebra.lean blueprint/src/chapter/ch13a_peps_ft.tex`
- `lake exe lint_style --github`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds declarations and documentation only; behavior is unchanged aside from one tracked sorry in new PEPS formalization.
> 
> **Overview**
> This PR **states the edge-blocked matrix-algebra isomorphism** from Molnar et al. Section 3 (`inj_isomorph`): a new Lean module defines `IsEdgeBlockedInsertionAlgebraIsomorphism` (a ℂ-algebra equivalence `Φ` on bond matrix algebras with matching `edgeInsertedCoeff`) and `isEdgeBlockedInsertionAlgebraIsomorphism` under injective edge-blocked three-site chains and `SameState`, with proof left as **`sorry`** (issue **#1367**).
> 
> The module is exported via `TNLean.lean`. The **blueprint** gains a linked definition and a full theorem for `thm:peps_edgeBlockedInsertionAlgebraIsomorphism` (replacing `\notready`). The **Section 3 route** doc now points at `TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism` instead of an informal-only blueprint path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1963542af6a3f2129c7a023f19ce81cc6b56b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->