### PR TITLE
feat(PEPS): state physical-to-virtual insertion recovery

### DIFF
--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -1,4 +1,4 @@
-import TNLean.PEPS.Blocking
+import TNLean.PEPS.EdgeMiddlePhysical
 
 /-!
 # Physical realization of edge virtual insertions
@@ -18,6 +18,8 @@ corresponding endpoint.
   coefficient.
 - `edgeInsertedCoeff_eq_sum_right_physicalRealization`: the right endpoint
   physical realization gives the inserted-edge coefficient.
+- `physical_to_virtual_insertion`: equal neighboring physical insertions in the
+  edge-blocked three-site chain come from one matrix on the shared virtual bond.
 - `edgeInsertedCoeff_endpointPhysicalRealization`: vertex injectivity gives
   endpoint physical realizations of the inserted-edge coefficient.
 -/
@@ -125,6 +127,45 @@ theorem edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq
       A hA e O₁ M).2 hO₁
   · exact (edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
       A hA e O₂ M).2 hO₂
+
+/-- Equal neighboring physical insertions recover a common virtual matrix on the
+shared edge.
+
+This is the edge-blocked PEPS form of the $O_1,O_2\mapsto W$ step in
+Lemma $\mathrm{inj\_isomorph}$. If inserting $O_1$ at the left endpoint and
+inserting $O_2$ at the right endpoint give the same three-block coefficient for
+every physical configuration, then there is a matrix $M$ on the shared bond such
+that $O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T})$ and
+$O_2\Phi_v=\Phi_vT_{v,e}(M)$.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, equations
+eq:resonate--eq:O->X, lines 355--486 of the local paper source.
+
+**Proof status:** This declaration states the source recovery step used by the
+insertion-algebra theorem. Its proof is tracked by issue #1370. -/
+theorem physical_to_virtual_insertion
+    (A : Tensor G d) (e : Edge G)
+    (hA : EdgeBlockedThreeSiteInjective (G := G) A e)
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hEq : ∀ σ : V → Fin d,
+      (∑ β : EdgeBoundaryConfig (G := G) A e,
+        O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2)) :
+    ∃ M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ,
+      (∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+        O₁ (localTensorMap A e.1.1 c) =
+          localTensorMap A e.1.1
+            (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose c)) ∧
+        ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+          O₂ (localTensorMap A e.1.2 c) =
+            localTensorMap A e.1.2
+              (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c) := by
+  sorry
 
 /-- The left-endpoint physical realization of a virtual matrix insertion
 reproduces the full inserted-edge coefficient.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1259,12 +1259,36 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{proof}
 
 \begin{theorem}[Equal neighboring physical actions recover a virtual insertion]%
-    \label{thm:peps_physicalToVirtualInsertion}
-    \notready
-    \uses{def:IsVertexInjective}
-    Conversely, if two physical operations on neighboring particles act in the
-    same way on the three-site state, then injectivity of the adjacent tensors
-    recovers a virtual operation on their shared bond:
+    \label{thm:peps_physical_to_virtual_insertion}
+    \lean{TNLean.PEPS.physical_to_virtual_insertion}
+    \leanok
+    \uses{def:peps_edgeBlockedThreeSiteInjective, def:peps_edgeBoundaryConfig,
+        def:peps_edgeLeftLocalConfig, def:peps_edgeRightLocalConfig,
+        def:peps_edgeOpenMiddleWeight, def:peps_localTensorMap,
+        def:peps_localIncidentMatrixOp}
+    Let $e=(u,v)$ and suppose the edge-blocked three-site chain at $e$ is
+    injective. Let $O_1,O_2$ be physical operators at the two endpoint tensors.
+    Suppose that, for every physical configuration $\sigma$,
+    \[
+        \sum_{\beta}
+        O_1(A_u(\beta_u))_{\sigma_u}\,
+        C_{\mathrm{mid}}(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        A_v(\beta_v)_{\sigma_v}
+        =
+        \sum_{\beta}
+        A_u(\beta_u)_{\sigma_u}\,
+        C_{\mathrm{mid}}(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        O_2(A_v(\beta_v))_{\sigma_v}.
+    \]
+    Then there exists a matrix
+    $M\in\operatorname{Mat}_{D(e)}(\mathbb C)$ such that
+    \[
+        O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T}),
+        \qquad
+        O_2\Phi_v=\Phi_vT_{v,e}(M).
+    \]
+    Thus the two equal neighboring physical insertions come from one virtual
+    operation on the shared bond:
     \begin{center}
         \TNPEPSPhysicalToVirtualInsertion
     \end{center}
@@ -1292,7 +1316,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         thm:peps_edgeBlockedThreeSiteInjective,
         thm:peps_virtualInsertionPhysicalRealization,
         thm:peps_edgeInsertedCoeff_endpointPhysicalRealization,
-        thm:peps_physicalToVirtualInsertion,
+        thm:peps_physical_to_virtual_insertion,
         thm:peps_sameState_edgeBlockedCoeff_eq, def:peps_edgeInsertedCoeff}
     Suppose the two edge-blocked three-site chains associated to $A$ and $B$ at
     the edge $e$ are injective, and suppose the two PEPS tensors define the same
@@ -1440,7 +1464,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     injective-chain argument. The physical-realization and physical-to-virtual
     steps in that argument are recorded separately as
     Theorems~\ref{thm:peps_virtualInsertionPhysicalRealization} and
-    \ref{thm:peps_physicalToVirtualInsertion}.
+    \ref{thm:peps_physical_to_virtual_insertion}.
     After Theorem~\ref{thm:peps_postAbsorptionEdgeInsertionEquality} supplies
     the factorized local gauge hypothesis, injectivity on the star neighborhood
     provides a left inverse that isolates the local edge gauges:

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -167,8 +167,9 @@ Theorem can be proved in the manner of the paper.
   independent inserted-edge index at the corresponding endpoint. On the left
   endpoint the formal statement uses the transpose of the inserted matrix,
   because the ordinary boundary supplies the right bond index. The converse
-  recovery $O_1,O_2\mapsto W$ remains open as
-  \path{thm:peps_physicalToVirtualInsertion}.
+  recovery $O_1,O_2\mapsto W$ is stated as
+  \leanid{TNLean.PEPS.physical_to_virtual_insertion}; its proof remains open and
+  is tracked by issue~\#1370.
   Its local endpoint recovery component is now formalized by
   \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}:
   once the compressed endpoint actions are known to realize the same bond
@@ -242,7 +243,8 @@ It is meant to prevent the proof from drifting away from the source argument.
   endpoint coefficient expansion. These are tracked by issues~\#1369
   and~\#1995.
 \item Lemma \path{inj_isomorph}, $O_1,O_2\mapsto W$:
-  \path{thm:peps_physicalToVirtualInsertion}, tracked by issue~\#1370.
+  \leanid{TNLean.PEPS.physical_to_virtual_insertion} states the source recovery
+  step; its proof remains open and is tracked by issue~\#1370.
   The endpoint projected-recovery component for a common bond matrix is
   formalized by
   \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}.


### PR DESCRIPTION
### Motivation

This records the converse $O_1,O_2\mapsto W$ step in arXiv:1804.04964, Section 3, Lemma inj_isomorph, for the edge-blocked three-site PEPS chain. The statement is kept at the level used by the paper: equality of the two neighboring physical insertions as three-block coefficient sums implies one matrix on the shared virtual bond.

Related: #1370.

### Description

- adds `TNLean.PEPS.physical_to_virtual_insertion` with the edge-blocked three-site injectivity hypothesis and the source coefficient equality
- concludes the two equations $O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T})$ and $O_2\Phi_v=\Phi_vT_{v,e}(M)$, formalized as equalities on the images of the two endpoint tensor maps
- updates Chapter 13a to replace the word-only `\notready` node by a formula-driven statement with the existing TikZ diagram
- records in the PEPS Section 3 route note that this theorem is stated and that the proof remains open under #1370

### Proof Status

The theorem body is the tracked `sorry` for #1370. No other new `sorry` is introduced.

### Testing

- `lake env lean TNLean/PEPS/InsertionRealization.lean`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/PEPS/InsertionRealization.lean blueprint/src/chapter/ch13a_peps_ft.tex`
- `lake exe lint_style --github`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `cd blueprint && leanblueprint web`

`cd blueprint && leanblueprint checkdecls` was not run to completion locally because this checkout has no generated `blueprint/lean_decls` file; the targeted blueprint/Lean sync check above passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a single deferred `sorry` for an already-tracked proof obligation; no changes to proved authentication, security, or runtime behavior.
> 
> **Overview**
> This PR **formalizes the converse** \(O_1,O_2\mapsto W\) step from arXiv:1804.04964 Section 3 (Lemma `inj_isomorph`) for the **edge-blocked three-site PEPS** chain: it adds `TNLean.PEPS.physical_to_virtual_insertion`, which assumes **edge-blocked three-site injectivity** and that left/right physical insertions yield the **same three-block coefficient sum** for every physical configuration \(\sigma\), and concludes a bond matrix \(M\) with the expected **endpoint tensor-map** identities (left uses \(M^{\mathsf T}\)).
> 
> The theorem body is a single tracked **`sorry`** (#1370); `InsertionRealization.lean` now imports **`EdgeMiddlePhysical`** instead of **`Blocking`**, and the module doc lists the new result.
> 
> **Blueprint and docs** replace the previous `\notready` placeholder with a formula-driven theorem (`thm:peps_physical_to_virtual_insertion`), wire it into the **edge-blocked insertion algebra isomorphism** and **local gauge** dependency lists, and update the Section 3 route note to say the step is **stated** with proof still open under #1370.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0075a0b872e7735dcf71013f4e27d91004ea31c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->