### PR TITLE
feat(PEPS): state edge-blocked injectivity

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -298,5 +298,22 @@ theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all
   hA.edgeBlockedThreeSiteInjective_all_of_middle
     (hComparison.edgeMiddleTensorInjective_all hMiddleRegions)
 
+/-- Vertex injectivity is preserved by the edge blocking to a three-site MPS.
+
+For every edge $e=(u,v)$, the two endpoint tensor maps and the middle tensor
+obtained by blocking $V\setminus\{u,v\}$ form an injective three-site chain.
+
+Source: arXiv:1804.04964, Section 3, eq:block_to_mps,
+`Papers/1804.04964/paper_normal.tex`, lines 979--1009.
+
+**Proof status:** This declaration states the source assertion. The missing
+proof is the finite-region contraction theorem saying that contracting
+vertex-injective tensors over the middle region gives an injective blocked
+tensor; it is tracked by issue #1366. -/
+theorem IsVertexInjective.edgeBlockedThreeSiteInjective {A : Tensor G d}
+    (hA : IsVertexInjective A) (e : Edge G) :
+    EdgeBlockedThreeSiteInjective (G := G) A e := by
+  sorry
+
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1107,14 +1107,19 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Edge blocking preserves injectivity]%
     \label{thm:peps_edgeBlockedThreeSiteInjective}
-    \notready
+    \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective}
+    \leanok
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
         thm:peps_edgeBlockedThreeSiteInjective_all_of_region}
-    If $A$ is vertex-injective, then for every edge $e=(u,v)$, the two
-    endpoint tensors together with the tensor obtained by blocking all vertices
-    outside $u$ and $v$ form an injective three-site MPS. This is the
-    precise assertion after the diagram
-    $\textup{eq:block\_to\_mps}$ in
+    If $A$ is vertex-injective, then for every edge $e=(u,v)$,
+    \[
+        \operatorname{inj}(T_{A,u}),\qquad
+        \operatorname{inj}(T_{A,V\setminus\{u,v\}}),\qquad
+        \operatorname{inj}(T_{A,v}).
+    \]
+    Here $T_{A,u}$ and $T_{A,v}$ are the two endpoint tensor maps, and
+    $T_{A,V\setminus\{u,v\}}$ is the blocked middle tensor family. This is the
+    precise assertion after the edge-blocking diagram in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -154,8 +154,9 @@ Theorem can be proved in the manner of the paper.
   The missing mathematical step is still the
   contraction theorem used in the paper: contracting vertex-injective tensors
   over that finite middle region gives an injective blocked tensor. The full
-  transfer remains the not-yet-formalized theorem
-  \path{thm:peps_edgeBlockedThreeSiteInjective}.
+  transfer is now stated as
+  \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective}; its
+  proof remains open and is tracked by issue~\#1366.
 \item The two internal steps in Lemma \path{inj_isomorph} must be formalized for
   the edge-blocked three-site MPS. The local endpoint part of the
   virtual-to-physical realization $X\mapsto O_1,O_2$ is formalized by
@@ -223,8 +224,9 @@ It is meant to prevent the proof from drifting away from the source argument.
 \begin{itemize}
 \item \path{eq:block_to_mps} edge blocking:
   \path{edgeBlockedCoeff_eq_stateCoeff} is locally proved; the injectivity
-  bridge is \path{thm:peps_edgeBlockedThreeSiteInjective}, tracked by
-  issue~\#1366. The middle physical index of this three-site object is
+  bridge is stated as
+  \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective}, with
+  proof tracked by issue~\#1366. The middle physical index of this three-site object is
   formalized by \leanid{TNLean.PEPS.EdgeMiddlePhysicalConfig}. The named
   injectivity statement is \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective},
   and the endpoint assertions are proved from vertex injectivity, both for a


### PR DESCRIPTION
### Motivation

This records the source assertion after arXiv:1804.04964, eq:block_to_mps: if the PEPS tensor is vertex-injective, then the edge-blocked object obtained from an edge $e=(u,v)$ is an injective three-site MPS. Continues formalization of the PEPS fundamental theorem; see #1366.

### Description

- Adds `TNLean.PEPS.IsVertexInjective.edge_blocked_three_site_injective` as the source-level statement for edge-blocked injectivity (arXiv:1804.04964, eq:block_to_mps).
- Updates Chapter 13a from `\notready` to a formula-driven statement with `\leanok`.
- Updates the Section 3 route note (`docs/paper-gaps/peps_injective_ft_section3_route.tex`) to record that the theorem is stated and its proof remains open under #1366.
- The theorem body carries the tracked `sorry` for #1366. The missing mathematical input is the finite-region contraction theorem: contracting vertex-injective tensors over $V\setminus\{u,v\}$ gives an injective blocked middle tensor. No other new `sorry` is introduced.

### Testing

- `lake env lean TNLean/PEPS/EdgeMiddlePhysical.lean`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/PEPS/EdgeMiddlePhysical.lean blueprint/src/chapter/ch13a_peps_ft.tex`
- `lake exe lint_style --github`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `cd blueprint && leanblueprint web`

`cd blueprint && leanblueprint checkdecls` was not run to completion locally because this checkout has no generated `blueprint/lean_decls` file; the targeted blueprint/Lean sync check above passed.

---
Addresses #1366

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a new `sorry` theorem only; no changes to existing proofs or runtime behavior.
> 
> **Overview**
> This PR **states** the source-level PEPS claim from arXiv:1804.04964 (`eq:block_to_mps`): vertex injectivity implies an **injective edge-blocked three-site MPS** at every edge.
> 
> It adds `TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective` in `EdgeMiddlePhysical.lean` with a documented **`sorry`** (proof tracked in **#1366**). The missing step is still the finite-region contraction theorem linking vertex injectivity to injective middle blocking.
> 
> Blueprint Chapter 13a moves `thm:peps_edgeBlockedThreeSiteInjective` from `\notready` to the Lean link with `\leanok`, and spells out injectivity of the two endpoint maps and the blocked middle family. The Section 3 route note (`peps_injective_ft_section3_route.tex`) now records that this bridge is **formalized as a statement**, not only as a gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3411663a3dd7c34f88bd95ee6b3c21d07e42ec8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->