### PR TITLE
doc(PEPS): make two-injective comparison proof formula-driven

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1636,11 +1636,18 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{thm:peps_twoInjectiveGaugeScalarReduction}
     Let $A_1,A_2,B_1,B_2$ be injective tensors with the same shared virtual
     bonds and nonempty external boundary spaces, and assume that there is at
-    least one shared virtual bond. For a shared bond $b$ and a matrix
-    $X\in\operatorname{Mat}_{D_b}$, write
-    $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for the two-tensor
-    coefficient with $X$ inserted on $b$ and the identity inserted on every
-    other shared bond. Assume
+    least one shared virtual bond. For the set $\mathcal B$ of shared bonds, a
+    bond $b\in\mathcal B$, and $X\in\operatorname{Mat}_{D_b}$, set
+    \[
+        C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)
+        =
+        \sum_{\substack{\mu,\nu\\
+                \mu|_{\mathcal B\setminus\{b\}}
+                =\nu|_{\mathcal B\setminus\{b\}}}}
+        X_{\mu_b,\nu_b}
+        A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2).
+    \]
+    Assume
     $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)
     =C_{B_1,B_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for every
     $b,X,\eta_1,\eta_2,\sigma_1,\sigma_2$:
@@ -1653,33 +1660,38 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 \begin{proof}
-    The proof is the argument of the comparison lemma in
-    \cite[Section~3]{Molnar2018NormalPEPS}. Applying the inverse of $A_2$ to
-    the three insertion equalities obtained by freeing each shared bond gives
-    virtual operators $Z,U,W$ satisfying, for every external index $\eta$,
-    shared-boundary index $\mu$, and physical index $\sigma$ of the first
-    block,
+    The proof is the comparison lemma of
+    \cite[Section~3]{Molnar2018NormalPEPS}. After grouping the relevant
+    virtual spaces, reduce to three nonzero virtual legs
+    $\alpha,\beta,\gamma$. Applying the inverse of $A_2$ to the insertion
+    equalities obtained by freeing, respectively, the
+    $(\beta,\gamma)$, $(\alpha,\beta)$, and $(\alpha,\gamma)$ legs gives
+    endomorphisms $Z$, $U$, and $W$ such that, for every external index
+    $\eta$, shared-boundary index $\mu$, and physical index $\sigma$ of the
+    first block,
     \[
         A_1(\eta,\mu,\sigma)
         =
-        \sum_\nu B_1(\eta,\nu,\sigma) Z_{\nu,\mu}
+        \sum_\nu B_1(\eta,\nu,\sigma)
+            (I_\alpha\otimes Z)_{\nu,\mu}
         =
-        \sum_\nu B_1(\eta,\nu,\sigma) U_{\nu,\mu}
+        \sum_\nu B_1(\eta,\nu,\sigma)
+            (U\otimes I_\gamma)_{\nu,\mu}
         =
-        \sum_\nu B_1(\eta,\nu,\sigma) W_{\nu,\mu}.
+        \sum_\nu B_1(\eta,\nu,\sigma)
+            (W_{\alpha\gamma}\otimes I_\beta)_{\nu,\mu}.
     \]
-    In tensor notation this is
+    Injectivity of $B_1$ gives the residual equality
     \[
-        A_1
+        I_\alpha\otimes Z
         =
-        B_1\cdot Z
+        U\otimes I_\gamma
         =
-        B_1\cdot U
-        =
-        B_1\cdot W,
+        W_{\alpha\gamma}\otimes I_\beta .
     \]
-    where $Z$, $U$, and $W$ act on the complementary pairs of exposed virtual
-    legs. Applying the inverse of $B_1$ gives the residual equality
+    Write $Z=\sum_i Z_i^{(1)}\otimes Z_i^{(2)}$,
+    $U=\sum_i U_i^{(1)}\otimes U_i^{(2)}$, and
+    $W=\sum_i W_i^{(1)}\otimes W_i^{(2)}$. The previous display is exactly
     \[
         \sum_i I\otimes Z_i^{(1)}\otimes Z_i^{(2)}
         =
@@ -1687,10 +1699,25 @@ injective and normal PEPS, following Theorems~2 and~3 of
         =
         \sum_i W_i^{(1)}\otimes I\otimes W_i^{(2)}.
     \]
-    The scalar-reduction theorem above gives $Z=\lambda I$, hence
-    $A_1=\lambda B_1$. Substituting this identity into the original insertion
-    equality with $X=I$ gives $A_2=\lambda^{-1}B_2$. Since $A_1$ and $B_1$ are
-    injective tensors, $\lambda\neq 0$.
+    Theorem~\ref{thm:peps_twoInjectiveGaugeScalarReduction} gives
+    $Z=\lambda I_{\beta\otimes\gamma}$,
+    $U=\lambda I_{\alpha\otimes\beta}$, and
+    $W_{\alpha\gamma}=\lambda I_{\alpha\otimes\gamma}$. Hence
+    $A_1(\eta,\mu,\sigma)=\lambda B_1(\eta,\mu,\sigma)$.
+    If $\lambda=0$, then $A_1=0$, contradicting injectivity of $A_1$; hence
+    $\lambda\neq0$.
+
+    Put $X=I_{D_b}$ in the insertion identity. Since
+    $A_1=\lambda B_1$, for every boundary and physical index one has
+    \[
+        \sum_\mu
+        B_1(\eta_1,\mu,\sigma_1)
+        \bigl(A_2(\eta_2,\mu,\sigma_2)
+            -\lambda^{-1}B_2(\eta_2,\mu,\sigma_2)\bigr)
+        =0 .
+    \]
+    Injectivity of $B_1$ gives
+    $A_2(\eta_2,\mu,\sigma_2)=\lambda^{-1}B_2(\eta_2,\mu,\sigma_2)$.
 \end{proof}
 
 \begin{theorem}[One-vertex versus complement comparison]%


### PR DESCRIPTION
### Motivation
- The blueprint entry for the generalized two-injective-tensor comparison (Chapter 13a, `thm:peps_twoInjectiveTensorInsertionComparison`) used verbal description where the argument is inherently formula-driven.
- The proof sketch for arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2` (local source: `Papers/1804.04964/paper_normal.tex`, lines 1068--1205) requires explicit residual-operator forms and a scalar-reduction step; these are clearer as displayed equations than as prose.
- Aligns the blueprint with the source-faithful terminology and formula-first statement convention in `docs/prose_style.md`.

### Description
- Modified `blueprint/src/chapter/ch13a_peps_ft.tex`: rewrote the proof sketch for `thm:peps_twoInjectiveTensorInsertionComparison`.
- The insertion coefficient $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ is now defined explicitly as the indexed contraction with $X$ on the selected shared bond $b$.
- The three residual operator forms $I_\alpha \otimes Z$, $U \otimes I_\gamma$, and $W_{\alpha\gamma} \otimes I_\beta$ are derived explicitly.
- The scalar-reduction theorem (`thm:peps_twoInjectiveGaugeScalarReduction`) is applied to obtain $A_1 = \lambda B_1$; the identity insertion $X = I_{D_b}$ then gives $A_2 = \lambda^{-1} B_2$.
- The existing TikZ diagram for the insertion statement is unchanged.
- No Lean declarations or proofs are modified.

### Testing
- `git diff --check` on `blueprint/src/chapter/ch13a_peps_ft.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files blueprint/src/chapter/ch13a_peps_ft.tex`
- Line-length scan for `blueprint/src/chapter/ch13a_peps_ft.tex`
- `cd blueprint && leanblueprint web`

---
Addresses #1361