### PR TITLE
doc(PEPS): make one-vertex comparison proof formula-driven

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1739,9 +1739,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         C_{\widetilde B_v,\widetilde B_{v^c}}
             (b,X;\eta_v,\eta_{v^c},\sigma_v,\sigma_{v^c}).
     \]
-    These are exactly the hypotheses of the two-injective comparison for this
-    two-block decomposition. Hence there is $\lambda_v\in\mathbb C^\times$
-    such that
+    Then there is $\lambda_v\in\mathbb C^\times$ such that
     $A_v(\eta,\sigma)=\lambda_v\widetilde B_v(\eta,\sigma)$ for every local
     virtual configuration $\eta$ and physical index $\sigma$:
     \begin{center}
@@ -1751,12 +1749,42 @@ injective and normal PEPS, following Theorems~2 and~3 of
     equality in \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 \begin{proof}\leanok
-    Apply Theorem~\ref{thm:peps_twoInjectiveTensorInsertionComparison} to
-    $A_v,\widetilde B_v$ and $A_{v^c},\widetilde B_{v^c}$. It gives a scalar
-    $\lambda_v\neq 0$ such that
-    $A_v=\lambda_v\widetilde B_v$ and
-    $A_{v^c}=\lambda_v^{-1}\widetilde B_{v^c}$; keep the first equality.
+    With $A_1=A_v$, $A_2=A_{v^c}$, $B_1=\widetilde B_v$, and
+    $B_2=\widetilde B_{v^c}$, the post-absorption equality is precisely
+    \[
+        \forall b,X,\eta_v,\eta_{v^c},\sigma_v,\sigma_{v^c},\quad
+        C_{A_1,A_2}(b,X;\eta_v,\eta_{v^c},\sigma_v,\sigma_{v^c})
+        =
+        C_{B_1,B_2}(b,X;\eta_v,\eta_{v^c},\sigma_v,\sigma_{v^c}).
+    \]
+    Theorem~\ref{thm:peps_twoInjectiveTensorInsertionComparison} gives
+    \[
+        \exists\lambda_v\in\mathbb C^\times,\qquad
+        A_v=\lambda_v\widetilde B_v,\qquad
+        A_{v^c}=\lambda_v^{-1}\widetilde B_{v^c}.
+    \]
+    The desired local proportionality is the first equality.
 \end{proof}
+
+\begin{remark}[Normal-region form]
+    The normal-region application in \cite[Section~3]{Molnar2018NormalPEPS}
+    uses the same scalar comparison after comparing two injective regions
+    $R\subset S=R\cup\{v\}$. If the region comparisons give
+    $A_R=\lambda_R\widetilde B_R$ and
+    $A_S=\lambda_S\widetilde B_S$, then the source-paper diagram reads
+    \[
+        A_R A_v
+        =
+        A_S
+        =
+        \lambda_S\widetilde B_S
+        =
+        \lambda_S\widetilde B_R\widetilde B_v .
+    \]
+    Applying the left inverse supplied by injectivity of the block
+    $A_R=\lambda_R\widetilde B_R$ gives
+    $A_v=(\lambda_S/\lambda_R)\widetilde B_v$.
+\end{remark}
 
 \begin{theorem}[Fundamental Theorem for injective PEPS, conditional on
         bond-dimension equality]%


### PR DESCRIPTION
### Motivation

- The blueprint proof of `thm:peps_oneVertexComplementComparison` (arXiv:1804.04964, Section 3) relied on a short verbal appeal to the two-injective comparison rather than an explicit formula chain; a reviewer cannot verify the step without tracing through the paper.
- Making the variable substitution explicit and writing out the post-absorption equality and the scalar conclusion improves the blueprint's self-containedness ahead of formalization.
- Source: `Papers/1804.04964/paper_normal.tex`, lines 1037-1210 (`eq:inj_equal_edge`, paragraph after `inj_equal_tensors_2`) and lines 1519-1571 (normal-region version).

### Description

- Modified `blueprint/src/chapter/ch13a_peps_ft.tex`: rewrote the proof of `thm:peps_oneVertexComplementComparison` so the one-vertex step is formula-driven.
- Substitution made explicit: $A_1=A_v$, $A_2=A_{v^c}$, $B_1=\widetilde B_v$, $B_2=\widetilde B_{v^c}$.
- Post-absorption equality stated as $C_{A_1,A_2}(b,X)=C_{B_1,B_2}(b,X)$ for all $b$ and $X$, citing `thm:peps_twoInjectiveTensorInsertionComparison`.
- Two-block conclusion written as $A_v=\lambda_v\widetilde B_v$ and $A_{v^c}=\lambda_v^{-1}\widetilde B_{v^c}$.
- The normal-region calculation is now a separate remark: $A_R A_v=A_S=\lambda_S\widetilde B_S=\lambda_S\widetilde B_R\widetilde B_v$ with $A_R=\lambda_R\widetilde B_R$, giving $A_v=(\lambda_S/\lambda_R)\widetilde B_v$ via a left inverse.
- No Lean declarations or proofs are changed.

### Testing

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files blueprint/src/chapter/ch13a_peps_ft.tex`
- Line-length scan and `\(...\)` inline-math check for `blueprint/src/chapter/ch13a_peps_ft.tex`.
- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --smoke-render` from `blueprint/src`.
- `cd blueprint && leanblueprint web`

---
Addresses #1360