### PR TITLE
feat(PEPS): name post-absorption insertion equality

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.Blocking
+import TNLean.PEPS.InsertionAlgebra
 import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
@@ -553,10 +554,7 @@ edge insertion in the absorbed tensor family. The remaining proof is #1364. -/
 theorem post_absorption_edge_insertion_equality (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B) (hAB : SameState A B)
     (hDim : A.bondDim = B.bondDim) :
-    ∃ Z, ∀ e X σ,
-      edgeInsertedCoeff (G := G) A e σ X =
-        edgeInsertedCoeff (G := G) (absorbEdgeGauges B Z) e σ
-          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hDim e)) X) := by
+    ∃ Z, PostAbsorptionEdgeInsertionEquality A (absorbEdgeGauges B Z) := by
   sorry
 
 /-- Edge gauges obtained from the three-site reductions give one global gauge

--- a/TNLean/PEPS/InsertionAlgebra.lean
+++ b/TNLean/PEPS/InsertionAlgebra.lean
@@ -2,6 +2,7 @@ import TNLean.PEPS.EdgeMiddlePhysical
 import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.InsertionRealization
 import Mathlib.Algebra.Algebra.Equiv
+import Mathlib.LinearAlgebra.Matrix.Reindex
 
 /-!
 # Edge-blocked insertion algebra for PEPS
@@ -39,6 +40,26 @@ def IsEdgeBlockedInsertionAlgebraIsomorphism (A B : Tensor G d) (e : Edge G) : P
     ∀ (σ : V → Fin d) (X : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
       edgeInsertedCoeff (G := G) A e σ X =
         edgeInsertedCoeff (G := G) B e σ (Φ X)
+
+/-! ### Post-absorption inserted-edge comparison -/
+
+/-- Post-absorption equality of all inserted-edge coefficients.
+
+Source: arXiv:1804.04964, Section 3, `eq:inj_equal_edge`
+(`Papers/1804.04964/paper_normal.tex:1037-1065`). After absorbing the edge
+gauges into the modified second tensor family $\widetilde B$, for every edge
+and every inserted matrix, the first PEPS and $\widetilde B$ give the same
+edge-inserted coefficient. -/
+structure PostAbsorptionEdgeInsertionEquality (A Btilde : Tensor G d) : Prop where
+  /-- The absorbed tensor family has the same bond dimensions as the first PEPS. -/
+  bondDim_eq : A.bondDim = Btilde.bondDim
+  /-- The same inserted virtual matrix gives equal edge-inserted coefficients. -/
+  edgeInsertedCoeff_eq :
+    ∀ (e : Edge G) (σ : V → Fin d)
+      (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+      edgeInsertedCoeff (G := G) A e σ M =
+        edgeInsertedCoeff (G := G) Btilde e σ
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun bondDim_eq e)) M)
 
 /-- **Edge-blocked insertion algebra isomorphism.**
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1432,20 +1432,40 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \sum_{\eta'}(\prod_{ie}M_{ie}(\eta(ie),\eta'(ie)))B_v(\eta',\sigma)$.
 \end{proof}
 
+\begin{definition}[Post-absorption inserted-edge comparison]%
+    \label{def:peps_postAbsorptionEdgeInsertionEquality}
+    \lean{TNLean.PEPS.PostAbsorptionEdgeInsertionEquality}
+    \leanok
+    \uses{def:peps_edgeInsertedCoeff}
+    For tensor families $A,\widetilde B$, the post-absorption comparison holds
+    when $h:D_A=D_{\widetilde B}$ and the following equality holds. For each
+    edge $e$, write
+    $\phi_{h_e}:\MN{D_A(e)}
+    \to\MN{D_{\widetilde B}(e)}$ for the matrix-algebra
+    transport induced by $h_e:D_A(e)=D_{\widetilde B}(e)$. Then, for every
+    matrix $X\in\MN{D_A(e)}$ and every physical configuration
+    $\sigma$,
+    \[
+        C_A(e,X;\sigma)
+        =
+        C_{\widetilde B}(e,\phi_{h_e}(X);\sigma).
+    \]
+\end{definition}
+
 \begin{theorem}[Post-absorption edge insertion equality]%
     \label{thm:peps_postAbsorptionEdgeInsertionEquality}
     \lean{TNLean.PEPS.post_absorption_edge_insertion_equality}
     \leanok
-    \uses{thm:peps_edge_gauge_absorption, def:peps_edgeInsertedCoeff}
+    \uses{thm:peps_edge_gauge_absorption,
+        def:peps_postAbsorptionEdgeInsertionEquality}
     Let $A$ and $B$ be vertex-injective PEPS with the same state, and assume
-    the bond-dimension equality $h:D_A=D_B$.  After the edge gauges have been
-    absorbed into the second tensor family, there are gauges $Z_e$ and an
-    absorbed tensor family $\widetilde B=B^Z$ with $D_{\widetilde B}=D_B$.
-    Writing $C_T(e,X;\sigma)$ for the edge-inserted
-    coefficient of a tensor family $T$, and writing
-    $\phi_{h_e}:\MN{D_A(e)}\to\MN{D_{\widetilde B}(e)}$ for the algebra
-    isomorphism induced by $h_e:D_A(e)=D_{\widetilde B}(e)$, for every edge
-    $e$, every $X\in\MN{D_A(e)}$, and every physical configuration $\sigma$,
+    the bond-dimension equality $h:D_A=D_B$. After the edge gauges have been
+    absorbed into the second tensor family, there are gauges $Z_e$ and
+    $\widetilde B=B^Z$ such that $D_{\widetilde B}=D_A$ and, for every edge
+    $e$, write $\phi_{h_e}:\MN{D_A(e)}\to\MN{D_{\widetilde B}(e)}$ for the
+    matrix-algebra transport induced by the corresponding equality
+    $h_e:D_A(e)=D_{\widetilde B}(e)$. Then, for every matrix
+    $X\in\MN{D_A(e)}$ and every physical configuration $\sigma$,
     \[
         C_A(e,X;\sigma)
         =

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -193,7 +193,9 @@ Theorem can be proved in the manner of the paper.
   family and the modified second tensor family. In the blueprint the absorption
   step is the not-yet-formalized theorem
   \path{thm:peps_edgeGaugeAbsorption}, and the post-absorption insertion
-  equality is the not-yet-formalized theorem
+  equality target is now named formally by
+  \leanid{TNLean.PEPS.PostAbsorptionEdgeInsertionEquality}.  Constructing that
+  predicate from the absorbed edge gauges remains the not-yet-formalized theorem
   \path{thm:peps_postAbsorptionEdgeInsertionEquality}.
 \item The generalized two-injective-tensor comparison from
   \path{lem:inj_equal_tensors_2} must be formalized. It says that equality of


### PR DESCRIPTION
### Motivation

The post-absorption equality `eq:inj_equal_edge` in arXiv:1804.04964, Section 3 is the formal target of issue #1364. After the edge gauges have been absorbed into the second tensor family $\widetilde B$, the capstone theorem should refer to a named mathematical predicate rather than restating the inserted-edge coefficient equality inline.

Source: `Papers/1804.04964/paper_normal.tex`, lines 1037-1065.

### Description

- Added `TNLean.PEPS.PostAbsorptionEdgeInsertionEquality` in `TNLean/PEPS/InsertionAlgebra.lean`.
- The predicate records $D_A=D_{\widetilde B}$ and $C_A(e,X;\sigma)=C_{\widetilde B}(e,\phi_{h_e}(X);\sigma)$ for every edge $e$, matrix $X$, and physical configuration $\sigma$.
- Updated `post_absorption_edge_insertion_equality` to return this predicate for `absorbEdgeGauges B Z`.
- Updated Chapter 13a and the Section 3 paper-gap route note to use the named comparison.

### Local Validation

- `lake build TNLean.PEPS.InsertionAlgebra TNLean.PEPS.FundamentalTheorem`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/FundamentalTheorem.lean TNLean/PEPS/InsertionAlgebra.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`, touched-file line-length scan, and inline-math delimiter scan
- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --smoke-render`
- `cd blueprint && leanblueprint web`
- `lake exe checkdecls blueprint/lean_decls` was also run after regenerating `blueprint/lean_decls`; it still reports the repository's known root-excluded declaration set, including PEPS capstone names.

The blueprint review patches were rechecked with blueprint sync, `git diff --check`, inline-math delimiter scan, and `leanblueprint web`. The docstring patches were also checked with targeted Lean.

Refs #1364