### PR TITLE
doc(PEPS): make physical-to-virtual statement formula-driven

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1271,9 +1271,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
         def:peps_edgeLeftLocalConfig, def:peps_edgeRightLocalConfig,
         def:peps_edgeOpenMiddleWeight, def:peps_localTensorMap,
         def:peps_localIncidentMatrixOp}
-    Let $e=(u,v)$ and suppose the edge-blocked three-site chain at $e$ is
-    injective. Let $O_1,O_2$ be physical operators at the two endpoint tensors.
-    Suppose that, for every physical configuration $\sigma$,
+    Let $e=(u,v)$. Assume that the edge-blocked three-site chain at $e$ is
+    injective. Let $O_1,O_2$ be physical operators at the endpoint tensors, and
+    write $\Phi_u,\Phi_v$ for the two local tensor maps. Suppose that, for every
+    physical configuration $\sigma$,
     \[
         \sum_{\beta}
         O_1(A_u(\beta_u))_{\sigma_u}\,
@@ -1285,20 +1286,21 @@ injective and normal PEPS, following Theorems~2 and~3 of
         C_{\mathrm{mid}}(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
         O_2(A_v(\beta_v))_{\sigma_v}.
     \]
-    Then there exists a matrix
-    $M\in\operatorname{Mat}_{D(e)}(\mathbb C)$ such that
+    Then
     \[
+        \exists M\in\MN{D(e)},\qquad
         O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T}),
         \qquad
         O_2\Phi_v=\Phi_vT_{v,e}(M).
     \]
-    Thus the two equal neighboring physical insertions come from one virtual
-    operation on the shared bond:
+    The same implication is represented diagrammatically by the
+    $O_1,O_2\mapsto W$ step:
     \begin{center}
         \TNPEPSPhysicalToVirtualInsertion
     \end{center}
-    This is the $O_1,O_2\mapsto W$ step in the insertion-algebra argument of
-    \cite[Section~3]{Molnar2018NormalPEPS}.
+    This is the converse part of the insertion-algebra lemma in
+    \cite[Section~3]{Molnar2018NormalPEPS}, where the recovered matrix is
+    denoted $W$.
 \end{theorem}
 
 \begin{definition}[Edge-blocked insertion algebra correspondence]%


### PR DESCRIPTION
### Motivation

The blueprint statement for `thm:peps_physical_to_virtual_insertion` should present the source-paper conclusion as equations. In MGRPG+18, Section 3, Lemma `inj_isomorph`, the converse $O_1,O_2\mapsto W$ step produces one virtual matrix on the shared bond.

### Description

This PR rewrites the theorem conclusion in `blueprint/src/chapter/ch13a_peps_ft.tex` as

$$
\exists M\in\MN{D(e)},\qquad
O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T}),\qquad
O_2\Phi_v=\Phi_vT_{v,e}(M).
$$

It also names $\Phi_u,\Phi_v$ in the statement, uses the project notation $\MN{D(e)}$, and keeps the TikZ diagram attached to this theorem node.

No Lean source changes are made. The theorem proof remains the tracked open proof for #1370.

Refs #1370.

### Testing

- `git diff --check`
- `rg -n '\\[()]' blueprint/src/chapter/ch13a_peps_ft.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch13a_peps_ft.tex`
- `PYTHONPATH=blueprint/src/Packages python3 blueprint/src/Packages/tn_diagrams.py --check --check-peps-usage --smoke-render TNPEPSPhysicalToVirtualInsertion`
- `cd blueprint && leanblueprint web`