### PR TITLE
doc(PEPS): state insertion algebra correspondence by formula

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1308,11 +1308,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.IsEdgeBlockedInsertionAlgebraIsomorphism}
     \leanok
     \uses{def:peps_edgeInsertedCoeff}
-    For two PEPS tensors $A$ and $B$ and an edge $e$, this property asserts
-    the existence of an algebra isomorphism $\Phi$ between the two matrix
-    algebras on the chosen bond such that
-    $C_A(e,\sigma,X)=C_B(e,\sigma,\Phi(X))$ for every physical configuration
-    $\sigma$ and every inserted matrix $X$.
+    For two PEPS tensors $A$ and $B$ and an edge $e$, this property is
+    \[
+        \exists \Phi_e:\MN{D_A(e)}
+            \simeq_{\mathrm{alg}}
+            \MN{D_B(e)},\qquad
+        \forall \sigma,\ \forall X\in\MN{D_A(e)},\quad
+        C_A(e,\sigma,X)=C_B(e,\sigma,\Phi_e(X)).
+    \]
 \end{definition}
 
 \begin{theorem}[Edge-blocked insertion algebra isomorphism]%
@@ -1327,19 +1330,16 @@ injective and normal PEPS, following Theorems~2 and~3 of
         thm:peps_sameState_edgeBlockedCoeff_eq, def:peps_edgeInsertedCoeff}
     Suppose the two edge-blocked three-site chains associated to $A$ and $B$ at
     the edge $e$ are injective, and suppose the two PEPS tensors define the same
-    state. Then there is an algebra isomorphism
+    state. Then
     \[
-        \Phi_e:\operatorname{Mat}_{D_A(e)}(\mathbb C)
+        \exists \Phi_e:\MN{D_A(e)}
             \simeq_{\mathrm{alg}}
-            \operatorname{Mat}_{D_B(e)}(\mathbb C)
-    \]
-    such that, for every physical configuration $\sigma$ and every matrix
-    $X\in\operatorname{Mat}_{D_A(e)}(\mathbb C)$,
-    \[
+            \MN{D_B(e)},\qquad
+        \forall \sigma,\ \forall X\in\MN{D_A(e)},\quad
         C_A(e,\sigma,X)=C_B(e,\sigma,\Phi_e(X)).
     \]
-    This is the edge-blocked form of the algebra isomorphism $X\mapsto Y$
-    constructed in \cite[Section~3]{Molnar2018NormalPEPS}:
+    This is the edge-blocked form of the algebra isomorphism $X\mapsto Y$ in
+    \cite[Section~3]{Molnar2018NormalPEPS}:
     \begin{center}
         \TNPEPSThreeSiteInsertionComparison
     \end{center}


### PR DESCRIPTION
### Motivation

The blueprint node for the edge-blocked insertion algebra isomorphism should expose the same mathematical object as Lemma `inj_isomorph` in MGRPG+18, Section 3: the correspondence $X\mapsto Y$ is an algebra isomorphism between the two bond matrix algebras and preserves all inserted coefficients.

### Description

This PR rewrites the definition and theorem statements in `blueprint/src/chapter/ch13a_peps_ft.tex` as

$$
\exists \Phi_e:\MN{D_A(e)}\simeq_{\mathrm{alg}}\MN{D_B(e)},\qquad
\forall\sigma,\ \forall X\in\MN{D_A(e)},\quad
C_A(e,\sigma,X)=C_B(e,\sigma,\Phi_e(X)).
$$

It replaces the older prose description and `\operatorname{Mat}` notation with $\MN{D}$, while keeping the TikZ comparison diagram attached to the theorem node.

No Lean source changes are made. The theorem proof remains the tracked open proof for #1367.

Refs #1367.

### Testing

- `git diff --check`
- `rg -n '\\[()]' blueprint/src/chapter/ch13a_peps_ft.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch13a_peps_ft.tex`
- `PYTHONPATH=blueprint/src/Packages python3 blueprint/src/Packages/tn_diagrams.py --check --check-peps-usage --smoke-render TNPEPSThreeSiteInsertionComparison`
- `cd blueprint && leanblueprint web`