### PR TITLE
doc(PEPS): display union injectivity as a formula

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1111,7 +1111,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
         thm:peps_edgeBlockedThreeSiteInjective_all_of_region}
-    If $A$ is vertex-injective, then for every edge $e=(u,v)$,
+    For a tensor map or blocked tensor family $T$, write
+    $\operatorname{inj}(T)$ for the assertion that $T$ is injective. If $A$
+    is vertex-injective, then for every edge $e=(u,v)$,
     \[
         \operatorname{inj}(T_{A,u}),\qquad
         \operatorname{inj}(T_{A,V\setminus\{u,v\}}),\qquad
@@ -1955,7 +1957,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \notready
     \uses{def:IsVertexInjective, lem:peps_regionUnionDecomposition_identities,
         lem:peps_regionUnionDecomposition_disjoint}
-    If two regions of a PEPS are injective, then their union is injective.
+    Let $V$ be a finite vertex set. Write $\operatorname{inj}(R)$ for the
+    assertion that the PEPS tensor blocked to the region $R\subseteq V$ is
+    injective. For two possibly overlapping regions $A,B\subseteq V$,
+    \[
+        \operatorname{inj}(A)\wedge\operatorname{inj}(B)
+        \Longrightarrow
+        \operatorname{inj}(A\cup B).
+    \]
     The proof in \cite[Section~3]{Molnar2018NormalPEPS} blocks the network into
     four parts $A\setminus B$, $A\cap B$, $B\setminus A$, and
     $(A\cup B)^c$, and applies the two available left inverses in sequence:


### PR DESCRIPTION
### Motivation

The PEPS union-of-injective-regions lemma is the source-paper step used to pass from rectangular injectivity assumptions to larger normal regions. Its blueprint statement should display the mathematical implication rather than describe it only in prose.

### Description

This PR updates `blueprint/src/chapter/ch13a_peps_ft.tex` so that:

- the earlier edge-blocking display introduces $\operatorname{inj}(T)$ for injectivity of a tensor map or blocked tensor family $T$;
- `lem:peps_injectiveRegion_union` introduces $V$ and writes $\operatorname{inj}(R)$ for the assertion that the PEPS tensor blocked to $R\subseteq V$ is injective;
- with this notation, the union lemma states

$$
\operatorname{inj}(A)\wedge\operatorname{inj}(B)
\Longrightarrow
\operatorname{inj}(A\cup B),
$$

for two possibly overlapping regions $A,B\subseteq V$.

The existing TikZ diagram `TNPEPSInjectiveRegionUnion` remains attached to the lemma node. No Lean source changes are made, and the lemma remains marked `\notready` until #1374 is formalized.

Source reread before editing: MGRPG+18, Section 3, Lemma `injective_union`, local lines 1324--1402 of `Papers/1804.04964/paper_normal.tex`.

Refs #1374.

### Testing

- `git diff --check`
- `rg -n '\\[()]' blueprint/src/chapter/ch13a_peps_ft.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch13a_peps_ft.tex`
- `PYTHONPATH=blueprint/src/Packages python3 blueprint/src/Packages/tn_diagrams.py --check --check-peps-usage --smoke-render TNPEPSInjectiveRegionUnion`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX in the blueprint; no Lean or runtime behavior changes.
> 
> **Overview**
> Blueprint-only edits in `ch13a_peps_ft.tex` align two PEPS injectivity statements with explicit mathematical notation instead of prose-only wording.
> 
> **`thm:peps_edgeBlockedThreeSiteInjective`** introduces $\operatorname{inj}(T)$ for injectivity of a tensor map or blocked family, then states vertex injectivity of $A$ implies $\operatorname{inj}(T_{A,u})$, $\operatorname{inj}(T_{A,V\setminus\{u,v\}})$, and $\operatorname{inj}(T_{A,v})$ at every edge, with short labels for the endpoint maps and middle family.
> 
> **`lem:peps_injectiveRegion_union`** defines $\operatorname{inj}(R)$ for blocked-region injectivity on $R\subseteq V$ and displays the union step as $\operatorname{inj}(A)\wedge\operatorname{inj}(B)\Longrightarrow\operatorname{inj}(A\cup B)$. The four-region proof narrative and `TNPEPSInjectiveRegionUnion` diagram are unchanged; the lemma stays `\notready` with no Lean changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f7175b2bb54101302f15cf3f23c068674a97f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->