### PR TITLE
feat(PEPS): add singleton blocked-region injectivity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -365,6 +365,7 @@ import TNLean.Channel.Determinant
 import TNLean.PEPS.Defs
 import TNLean.PEPS.InjectiveRegion
 import TNLean.PEPS.VirtualInsertion
+import TNLean.PEPS.SingletonRegion
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.EdgeMiddlePhysical
 import TNLean.PEPS.NormalEdgeBlockingData

--- a/TNLean/PEPS/SingletonRegion.lean
+++ b/TNLean/PEPS/SingletonRegion.lean
@@ -82,8 +82,9 @@ injectivity.
 
 For a one-vertex region, the blocked tensor is the original local tensor. The
 source proof in arXiv:1804.04964, Section 3, uses this as the base case before
-applying closure of injectivity under contractions. This proposition records
-that base case for the abstract region-injectivity predicate.
+applying closure of injectivity under contractions. This proposition records,
+for every vertex $v$, the implication
+$A\text{ vertex-injective}\Longrightarrow\kappa(\{v\})$.
 
 Source: arXiv:1804.04964, Section 3;
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/

--- a/TNLean/PEPS/SingletonRegion.lean
+++ b/TNLean/PEPS/SingletonRegion.lean
@@ -12,7 +12,7 @@ original local tensor at that vertex.
 
 - [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
   entangled pair states generating the same state*, arXiv:1804.04964,
-  Section 3, `eq:block_to_mps`](https://arxiv.org/abs/1804.04964)
+  Section 3](https://arxiv.org/abs/1804.04964)
 - `Papers/1804.04964/paper_normal.tex`, lines 981--1009.
 -/
 
@@ -27,7 +27,7 @@ variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 For a one-vertex region, the blocked physical space is the original physical
 space at that vertex.
 
-Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+Source: arXiv:1804.04964, Section 3;
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
 abbrev SingletonRegionPhysicalConfig (_v : V) : Type :=
   Fin d
@@ -37,20 +37,23 @@ abbrev SingletonRegionPhysicalConfig (_v : V) : Type :=
 For a one-vertex block, no contraction occurs: the blocked tensor is the
 original local tensor at $v$.
 
-Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+Source: arXiv:1804.04964, Section 3;
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
 def singletonRegionTensorFamily (A : Tensor G d) (v : V) :
     LocalVirtualConfig A v → SingletonRegionPhysicalConfig (d := d) v → ℂ :=
   A.component v
 
-/-- Injectivity of the singleton blocked-region tensor. -/
+/-- Injectivity of the singleton blocked-region tensor.
+
+Source: arXiv:1804.04964, Section 3;
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
 def SingletonRegionTensorInjective (A : Tensor G d) (v : V) : Prop :=
   LinearIndependent ℂ (singletonRegionTensorFamily (G := G) A v)
 
 omit [Fintype V] in
 /-- Vertex injectivity is exactly injectivity of every singleton blocked tensor.
 
-Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+Source: arXiv:1804.04964, Section 3;
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
 theorem IsVertexInjective.singletonRegionTensorInjective {A : Tensor G d}
     (hA : IsVertexInjective A) (v : V) :
@@ -60,12 +63,12 @@ theorem IsVertexInjective.singletonRegionTensorInjective {A : Tensor G d}
 /-- Compatibility between the concrete singleton blocked tensor and an abstract
 region-injectivity predicate.
 
-The abstract predicate $\kappa.\mathrm{IsInjective}$ is used for finite blocked
+The abstract injectivity predicate $\kappa$ is used for finite blocked
 regions in the normal PEPS proof. This comparison records the one-vertex base
 case: if the concrete singleton blocked tensor is injective, then the
 corresponding singleton region is injective for $\kappa$.
 
-Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+Source: arXiv:1804.04964, Section 3;
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
 structure SingletonRegionInjectivityComparison
     (κ : RegionInjectivityData V) (A : Tensor G d) : Prop where
@@ -78,11 +81,11 @@ structure SingletonRegionInjectivityComparison
 injectivity.
 
 For a one-vertex region, the blocked tensor is the original local tensor. The
-source proof after `eq:block_to_mps` uses this as the base case before applying
-closure of injectivity under contractions. This proposition records that base
-case for the abstract region-injectivity predicate.
+source proof in arXiv:1804.04964, Section 3, uses this as the base case before
+applying closure of injectivity under contractions. This proposition records
+that base case for the abstract region-injectivity predicate.
 
-Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+Source: arXiv:1804.04964, Section 3;
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
 structure SingletonRegionInjectivityFromVertexInjectivity
     (κ : RegionInjectivityData V) (A : Tensor G d) : Prop where
@@ -96,7 +99,7 @@ omit [Fintype V] in
 /-- The concrete singleton-tensor comparison supplies the singleton base case
 of the source contraction step.
 
-Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+Source: arXiv:1804.04964, Section 3;
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
 theorem ofSingletonComparison
     {κ : RegionInjectivityData V} {A : Tensor G d}

--- a/TNLean/PEPS/SingletonRegion.lean
+++ b/TNLean/PEPS/SingletonRegion.lean
@@ -1,0 +1,112 @@
+import TNLean.PEPS.InjectiveRegion
+import TNLean.PEPS.VirtualInsertion
+
+/-!
+# Singleton blocked regions for PEPS
+
+This file records the one-vertex base case of the PEPS blocking argument. For
+a singleton region, blocking performs no contraction: the blocked tensor is the
+original local tensor at that vertex.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, `eq:block_to_mps`](https://arxiv.org/abs/1804.04964)
+- `Papers/1804.04964/paper_normal.tex`, lines 981--1009.
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- Physical configurations of the singleton blocked region $\{v\}$.
+
+For a one-vertex region, the blocked physical space is the original physical
+space at that vertex.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+abbrev SingletonRegionPhysicalConfig (_v : V) : Type :=
+  Fin d
+
+/-- The tensor family obtained by blocking the singleton region $\{v\}$.
+
+For a one-vertex block, no contraction occurs: the blocked tensor is the
+original local tensor at $v$.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+def singletonRegionTensorFamily (A : Tensor G d) (v : V) :
+    LocalVirtualConfig A v → SingletonRegionPhysicalConfig (d := d) v → ℂ :=
+  A.component v
+
+/-- Injectivity of the singleton blocked-region tensor. -/
+def SingletonRegionTensorInjective (A : Tensor G d) (v : V) : Prop :=
+  LinearIndependent ℂ (singletonRegionTensorFamily (G := G) A v)
+
+omit [Fintype V] in
+/-- Vertex injectivity is exactly injectivity of every singleton blocked tensor.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+theorem IsVertexInjective.singletonRegionTensorInjective {A : Tensor G d}
+    (hA : IsVertexInjective A) (v : V) :
+    SingletonRegionTensorInjective (G := G) A v := by
+  simpa [SingletonRegionTensorInjective, singletonRegionTensorFamily] using hA v
+
+/-- Compatibility between the concrete singleton blocked tensor and an abstract
+region-injectivity predicate.
+
+The abstract predicate $\kappa.\mathrm{IsInjective}$ is used for finite blocked
+regions in the normal PEPS proof. This comparison records the one-vertex base
+case: if the concrete singleton blocked tensor is injective, then the
+corresponding singleton region is injective for $\kappa$.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+structure SingletonRegionInjectivityComparison
+    (κ : RegionInjectivityData V) (A : Tensor G d) : Prop where
+  /-- Injectivity of the concrete singleton tensor gives injectivity of the
+  singleton region in the abstract predicate. -/
+  singleton_region_injective :
+    ∀ v : V, SingletonRegionTensorInjective (G := G) A v → κ.IsInjective {v}
+
+/-- Compatibility between vertex injectivity and singleton blocked-region
+injectivity.
+
+For a one-vertex region, the blocked tensor is the original local tensor. The
+source proof after `eq:block_to_mps` uses this as the base case before applying
+closure of injectivity under contractions. This proposition records that base
+case for the abstract region-injectivity predicate.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+structure SingletonRegionInjectivityFromVertexInjectivity
+    (κ : RegionInjectivityData V) (A : Tensor G d) : Prop where
+  /-- Vertex injectivity gives injectivity of the singleton blocked region
+  $\{v\}$. -/
+  singleton_injective : IsVertexInjective A → ∀ v : V, κ.IsInjective {v}
+
+namespace SingletonRegionInjectivityFromVertexInjectivity
+
+omit [Fintype V] in
+/-- The concrete singleton-tensor comparison supplies the singleton base case
+of the source contraction step.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+theorem ofSingletonComparison
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hComparison :
+      SingletonRegionInjectivityComparison (G := G) (d := d) κ A) :
+    SingletonRegionInjectivityFromVertexInjectivity (G := G) (d := d) κ A where
+  singleton_injective hA v :=
+    hComparison.singleton_region_injective v (hA.singletonRegionTensorInjective v)
+
+end SingletonRegionInjectivityFromVertexInjectivity
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -980,11 +980,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{definition}[Singleton blocked region]%
     \label{def:peps_singletonRegionTensor}
-    \lean{TNLean.PEPS.SingletonRegionPhysicalConfig}
-    \lean{TNLean.PEPS.singletonRegionTensorFamily}
-    \lean{TNLean.PEPS.SingletonRegionTensorInjective}
-    \lean{TNLean.PEPS.SingletonRegionInjectivityComparison}
-    \lean{TNLean.PEPS.SingletonRegionInjectivityFromVertexInjectivity}
+    \lean{TNLean.PEPS.SingletonRegionPhysicalConfig,
+        TNLean.PEPS.singletonRegionTensorFamily,
+        TNLean.PEPS.SingletonRegionTensorInjective,
+        TNLean.PEPS.SingletonRegionInjectivityComparison}
     \leanok
     \uses{def:IsVertexInjective, def:peps_regionInjectivityData}
     For a singleton block $\{v\}$, the blocked physical index is the original
@@ -1002,20 +1001,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{theorem}[Vertex injectivity gives singleton-block injectivity]%
     \label{thm:peps_singletonRegionTensorInjective}
     \lean{TNLean.PEPS.IsVertexInjective.singletonRegionTensorInjective}
-    \lean{TNLean.PEPS.SingletonRegionInjectivityFromVertexInjectivity.ofSingletonComparison}
     \leanok
     \uses{def:IsVertexInjective, def:peps_singletonRegionTensor}
     If $A$ is vertex-injective, then every singleton blocked tensor is
-    injective:
+    injective. For every vertex $v$,
     \[
-        \forall v,\qquad \operatorname{inj}(T_{A,\{v\}}).
-    \]
-    Consequently, any comparison
-    $\operatorname{inj}(T_{A,\{v\}})\Rightarrow\kappa(\{v\})$ supplies the
-    singleton base case
-    \[
-        A\text{ vertex-injective}\Longrightarrow
-        \forall v,\qquad \kappa(\{v\}).
+        \operatorname{inj}(T_{A,\{v\}}).
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -1026,14 +1017,33 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Thus $\operatorname{inj}(A_v)$ is exactly
     $\operatorname{inj}(T_{A,\{v\}})$. Vertex injectivity gives
     $\forall v,\operatorname{inj}(A_v)$, and therefore
-    $\forall v,\operatorname{inj}(T_{A,\{v\}})$. If
-    $\operatorname{inj}(T_{A,\{v\}})\Rightarrow\kappa(\{v\})$, then, for each
-    $v$,
+    $\forall v,\operatorname{inj}(T_{A,\{v\}})$. For a fixed $v$, this is the
+    displayed assertion.
+\end{proof}
+
+\begin{theorem}[Singleton comparison gives the region base case]%
+    \label{thm:peps_singletonRegionInjectivityFromVertexInjectivity}
+    \lean{TNLean.PEPS.SingletonRegionInjectivityFromVertexInjectivity,
+        TNLean.PEPS.SingletonRegionInjectivityFromVertexInjectivity.ofSingletonComparison}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_singletonRegionTensor,
+        thm:peps_singletonRegionTensorInjective}
+    Assume that a region-injectivity predicate $\kappa$ satisfies, for every
+    vertex $v$,
     \[
-        A\text{ vertex-injective}
-        \Longrightarrow \operatorname{inj}(T_{A,\{v\}})
-        \Longrightarrow \kappa(\{v\}).
+        \operatorname{inj}(T_{A,\{v\}})\Longrightarrow\kappa(\{v\}).
     \]
+    Then, for every vertex $v$,
+    \[
+        A\text{ vertex-injective}\Longrightarrow\kappa(\{v\}).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    For each $v$, the preceding theorem gives
+    $A\text{ vertex-injective}\Longrightarrow
+    \operatorname{inj}(T_{A,\{v\}})$. The comparison hypothesis gives
+    $\operatorname{inj}(T_{A,\{v\}})\Longrightarrow\kappa(\{v\})$. Their
+    composition is the claimed implication.
 \end{proof}
 
 \begin{definition}[Region injectivity supplies the edge-middle tensor]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -985,7 +985,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         TNLean.PEPS.SingletonRegionTensorInjective,
         TNLean.PEPS.SingletonRegionInjectivityComparison}
     \leanok
-    \uses{def:IsVertexInjective, def:peps_regionInjectivityData}
+    \uses{def:peps_regionInjectivityData}
     For a singleton block $\{v\}$, the blocked physical index is the original
     physical index and the blocked tensor is
     \[

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -978,6 +978,64 @@ injective and normal PEPS, following Theorems~2 and~3 of
     the right endpoint tensor map are all injective.
 \end{definition}
 
+\begin{definition}[Singleton blocked region]%
+    \label{def:peps_singletonRegionTensor}
+    \lean{TNLean.PEPS.SingletonRegionPhysicalConfig}
+    \lean{TNLean.PEPS.singletonRegionTensorFamily}
+    \lean{TNLean.PEPS.SingletonRegionTensorInjective}
+    \lean{TNLean.PEPS.SingletonRegionInjectivityComparison}
+    \lean{TNLean.PEPS.SingletonRegionInjectivityFromVertexInjectivity}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_regionInjectivityData}
+    For a singleton block $\{v\}$, the blocked physical index is the original
+    physical index and the blocked tensor is
+    \[
+        T_{A,\{v\}}(\eta,\sigma)=A_v(\eta,\sigma).
+    \]
+    Its injectivity is $\operatorname{inj}(T_{A,\{v\}})$. The comparison with a
+    region-injectivity predicate $\kappa$ records the implication
+    \[
+        \operatorname{inj}(T_{A,\{v\}})\Longrightarrow\kappa(\{v\}).
+    \]
+\end{definition}
+
+\begin{theorem}[Vertex injectivity gives singleton-block injectivity]%
+    \label{thm:peps_singletonRegionTensorInjective}
+    \lean{TNLean.PEPS.IsVertexInjective.singletonRegionTensorInjective}
+    \lean{TNLean.PEPS.SingletonRegionInjectivityFromVertexInjectivity.ofSingletonComparison}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_singletonRegionTensor}
+    If $A$ is vertex-injective, then every singleton blocked tensor is
+    injective:
+    \[
+        \forall v,\qquad \operatorname{inj}(T_{A,\{v\}}).
+    \]
+    Consequently, any comparison
+    $\operatorname{inj}(T_{A,\{v\}})\Rightarrow\kappa(\{v\})$ supplies the
+    singleton base case
+    \[
+        A\text{ vertex-injective}\Longrightarrow
+        \forall v,\qquad \kappa(\{v\}).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    For $R=\{v\}$, the contraction defining $T_{A,R}$ has one factor. Hence
+    \[
+        T_{A,\{v\}}(\eta,\sigma)=A_v(\eta,\sigma).
+    \]
+    Thus $\operatorname{inj}(A_v)$ is exactly
+    $\operatorname{inj}(T_{A,\{v\}})$. Vertex injectivity gives
+    $\forall v,\operatorname{inj}(A_v)$, and therefore
+    $\forall v,\operatorname{inj}(T_{A,\{v\}})$. If
+    $\operatorname{inj}(T_{A,\{v\}})\Rightarrow\kappa(\{v\})$, then, for each
+    $v$,
+    \[
+        A\text{ vertex-injective}
+        \Longrightarrow \operatorname{inj}(T_{A,\{v\}})
+        \Longrightarrow \kappa(\{v\}).
+    \]
+\end{proof}
+
 \begin{definition}[Region injectivity supplies the edge-middle tensor]%
     \label{def:peps_edgeMiddleRegionInjectivityComparison}
     \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -129,6 +129,15 @@ Theorem can be proved in the manner of the paper.
   have the middle-indexed forms \leanid{TNLean.PEPS.edgeMiddleWeightOn} and
   \leanid{TNLean.PEPS.edgeOpenMiddleWeightOn}. In the blueprint the
   injectivity statement is \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective}.
+  The singleton base case is now formalized by
+  \leanid{TNLean.PEPS.singletonRegionTensorFamily} and
+  \leanid{TNLean.PEPS.IsVertexInjective.singletonRegionTensorInjective}: for a
+  one-vertex block $\{v\}$,
+  $T_{A,\{v\}}(\eta,\sigma)=A_v(\eta,\sigma)$, hence vertex injectivity gives
+  $\operatorname{inj}(T_{A,\{v\}})$. The bridge to the abstract
+  region-injectivity predicate is recorded by
+  \leanid{TNLean.PEPS.SingletonRegionInjectivityComparison} and
+  \leanid{TNLean.PEPS.SingletonRegionInjectivityFromVertexInjectivity.ofSingletonComparison}.
   Vertex injectivity supplies the two endpoint assertions by
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective}
   and, for all edges at once, by


### PR DESCRIPTION
### Motivation

- The PEPS fundamental theorem in arXiv:1804.04964, Section 3, reduces an edge-blocked argument to injectivity of blocked-region tensors.
- For a singleton region $\{v\}$ there is no contraction, so $T_{A,\{v\}}(\eta,\sigma)=A_v(\eta,\sigma)$, and vertex injectivity of $A$ gives injectivity of the singleton blocked tensor.
- This PR records only that singleton base case for issue #1366; the finite-region contraction step remains open.

Source reread: MGRPG+18, Section 3; local source `Papers/1804.04964/paper_normal.tex`, lines 981--1009.

### Description

- Add `TNLean/PEPS/SingletonRegion.lean`, defining the singleton blocked tensor as `A.component v` and proving `IsVertexInjective.singletonRegionTensorInjective`.
- Add comparison structures connecting $\operatorname{inj}(T_{A,\{v\}})$ and vertex injectivity to the abstract finite-region predicate $\kappa(\{v\})$.
- Update Chapter 13a with formula-level blueprint entries, splitting the direct singleton injectivity statement from the comparison-hypothesis statement.
- Update the PEPS Section 3 paper-gap note to mark the singleton base case as formalized.

### Testing

- `lake exe cache get`
- `lake build TNLean`
- `lake build TNLean.PEPS.SingletonRegion`
- `git diff --check`
- `rg -n '\\[()]' blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex TNLean/PEPS/SingletonRegion.lean`
- `awk 'length($0) > 100 { print FILENAME ":" FNR ":" length($0) ":" $0 }' TNLean/PEPS/SingletonRegion.lean TNLean.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean.lean TNLean/PEPS/SingletonRegion.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `PYTHONPATH=blueprint/src/Packages python3 blueprint/src/Packages/tn_diagrams.py --check --check-peps-usage --smoke-render TNPEPSEdgeBlockingReduction`
- `cd blueprint && leanblueprint web` passes with the existing plasTeX and bibliography warnings.

`cd blueprint && leanblueprint checkdecls` could not run in this fresh worktree because the repository has no `blueprint/lean_decls` file; the command exits before checking Lean declarations.

---
Addresses #1366