### PR TITLE
feat(PEPS): derive finite-region injectivity from singletons

### DIFF
--- a/TNLean/PEPS/SingletonRegion.lean
+++ b/TNLean/PEPS/SingletonRegion.lean
@@ -14,6 +14,7 @@ original local tensor at that vertex.
   entangled pair states generating the same state*, arXiv:1804.04964,
   Section 3](https://arxiv.org/abs/1804.04964)
 - `Papers/1804.04964/paper_normal.tex`, lines 981--1009.
+- `Papers/1804.04964/paper_normal.tex`, lines 1322--1404.
 -/
 
 namespace TNLean
@@ -111,6 +112,40 @@ theorem ofSingletonComparison
     hComparison.singleton_region_injective v (hA.singletonRegionTensorInjective v)
 
 end SingletonRegionInjectivityFromVertexInjectivity
+
+namespace RegionInjectivityUnionClosure
+
+omit [Fintype V] in
+/-- Vertex injectivity gives injectivity of every nonempty finite region once
+singleton regions are compatible with the abstract region predicate and
+injectivity is closed under finite unions.
+
+The formula behind the proof is $R = \bigcup_{v \in R} \{v\}$. Vertex
+injectivity gives $\kappa(\{v\})$ for every $v$, and finite iteration of the
+injective-union lemma gives $\kappa(R)$.
+
+Source: arXiv:1804.04964, Section 3;
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009 and 1322--1404. -/
+theorem finset_injective_of_singletons
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hComparison :
+      SingletonRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hA : IsVertexInjective A) {R : Finset V} (hR : R.Nonempty) :
+    κ.IsInjective R := by
+  classical
+  have hSingleton :
+      SingletonRegionInjectivityFromVertexInjectivity (G := G) (d := d) κ A :=
+    SingletonRegionInjectivityFromVertexInjectivity.ofSingletonComparison hComparison
+  have hPieces : ∀ v ∈ R, κ.IsInjective ({v} : Finset V) := by
+    intro v _hv
+    exact hSingleton.singleton_injective hA v
+  have hBlocked :
+      κ.IsInjective (R.biUnion fun v => ({v} : Finset V)) :=
+    hUnion.biUnion_injective hR (fun v => ({v} : Finset V)) hPieces
+  simpa using hBlocked
+
+end RegionInjectivityUnionClosure
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1046,6 +1046,26 @@ injective and normal PEPS, following Theorems~2 and~3 of
     composition is the claimed implication.
 \end{proof}
 
+\begin{theorem}[Finite regions from singleton regions and union closure]%
+    \label{thm:peps_finiteRegionInjectivityFromSingletons}
+    \lean{TNLean.PEPS.RegionInjectivityUnionClosure.finset_injective_of_singletons}
+    \leanok
+    \uses{thm:peps_singletonRegionInjectivityFromVertexInjectivity,
+        lem:peps_regionInjectivityUnionClosure_finite}
+    Assume that $\kappa$ satisfies singleton comparison and union closure:
+    $\operatorname{inj}(T_{A,\{v\}})\Longrightarrow\kappa(\{v\})$ for every
+    vertex $v$, and
+    $\kappa(R)\wedge\kappa(S)\Longrightarrow\kappa(R\cup S)$. If $A$ is
+    vertex-injective, then every nonempty finite region $R$ satisfies
+    $\kappa(R)$.
+\end{theorem}
+\begin{proof}\leanok
+    For $R\ne\varnothing$, write $R=\bigcup_{v\in R}\{v\}$. The preceding
+    theorem turns singleton comparison and vertex injectivity into
+    $\kappa(\{v\})$ for every $v\in R$. Applying the finite-union consequence
+    of union closure to these singleton regions gives $\kappa(R)$.
+\end{proof}
+
 \begin{definition}[Region injectivity supplies the edge-middle tensor]%
     \label{def:peps_edgeMiddleRegionInjectivityComparison}
     \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -138,6 +138,11 @@ Theorem can be proved in the manner of the paper.
   region-injectivity predicate is recorded by
   \leanid{TNLean.PEPS.SingletonRegionInjectivityComparison} and
   \leanid{TNLean.PEPS.SingletonRegionInjectivityFromVertexInjectivity.ofSingletonComparison}.
+  With the abstract union-closure lemma, this gives every nonempty finite
+  region by
+  \leanid{TNLean.PEPS.RegionInjectivityUnionClosure.finset_injective_of_singletons}:
+  $R=\bigcup_{v\in R}\{v\}$ and $\kappa(\{v\})$ for every $v\in R$ imply
+  $\kappa(R)$.
   Vertex injectivity supplies the two endpoint assertions by
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective}
   and, for all edges at once, by


### PR DESCRIPTION
### Motivation

- Advances the PEPS Section 3 formalization route toward `thm:peps_edgeBlockedThreeSiteInjective` (issue #1366).
- The finite decomposition $R = \bigcup_{v \in R} \{v\}$ is a required intermediate step: under singleton comparison and finite union closure for the region-injectivity predicate `κ`, vertex injectivity implies $\kappa(R)$ for every nonempty finite region $R$.
- Source: arXiv:1804.04964, lines 981--1009 for the edge-blocking passage around `eq:block_to_mps`, and lines 1322--1404 for Lemma `injective_union`.

### Description

- Modified `TNLean/PEPS/SingletonRegion.lean`: added `TNLean.PEPS.RegionInjectivityUnionClosure.finset_injective_of_singletons`.
- The theorem assumes the source-facing singleton comparison directly, derives the vertex-injective singleton base case internally, and then applies the finite union lemma to $R = \bigcup_{v \in R} \{v\}$.
- Added the corresponding formula-driven blueprint theorem in `blueprint/src/chapter/ch13a_peps_ft.tex`.
- Updated `docs/paper-gaps/peps_injective_ft_section3_route.tex` to record this finite-region consequence on the Section 3 route.
- This does not prove the full edge-blocked three-site injectivity theorem.

### Testing

- `lake build TNLean.PEPS.SingletonRegion`
- `git diff --check`
- Line-length check on touched files
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/SingletonRegion.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `PYTHONPATH=blueprint/src/Packages python3 blueprint/src/Packages/tn_diagrams.py --check --check-peps-usage --smoke-render TNPEPSEdgeBlockingReduction`
- `cd blueprint && leanblueprint web`
- `leanblueprint checkdecls` not runnable because there is no `blueprint/lean_decls` directory in this checkout.
- Full build validated by Lean CI (`lean_action_ci.yml`).

---
Related to #1366.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small formal lemma and synced blueprint/docs on an existing PEPS proof route; no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds the **finite-region injectivity** step on the PEPS Section 3 route: under **singleton comparison** (concrete singleton tensors imply `κ({v})`) and **union closure** on `κ`, **vertex injectivity implies `κ(R)` for every nonempty finite region `R`**.
> 
> The Lean proof is `TNLean.PEPS.RegionInjectivityUnionClosure.finset_injective_of_singletons`, which writes `R` as `⋃_{v∈R} {v}`, gets `κ({v})` from the existing singleton-from-vertex bridge, then applies `biUnion_injective`. The blueprint gains a matching theorem; the Section 3 paper-gap doc and module references now cite this result and the union lemma in the source paper (lines 1322–1404). This does **not** prove full edge-blocked three-site injectivity (#1366).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bcdd7c795788f066fb5c269811705aa30d47a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->