### PR TITLE
feat(PEPS): connect singleton regions to edge middles

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -1,18 +1,20 @@
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.InjectiveRegion
+import TNLean.PEPS.SingletonRegion
 
 /-!
 # Middle physical indices for edge-blocked PEPS
 
 This file gives the middle tensor in the edge-centered three-site decomposition
-its own physical index.  For an edge \(e=(u,v)\), the middle physical
-configuration is the family of physical indices on \(V\setminus\{u,v\}\).
+its own physical index. For an edge $e=(u,v)$, the middle physical
+configuration is the family of physical indices on $V\setminus\{u,v\}$.
 
 ## References
 
 - [Molnár, Schuch, Verstraete, Cirac, *Fundamental Theorem for injective PEPS*,
   arXiv:1804.04964, Section 3, `eq:block_to_mps`](https://arxiv.org/abs/1804.04964)
 - `Papers/1804.04964/paper_normal.tex`, lines 981--1009.
+- `Papers/1804.04964/paper_normal.tex`, lines 1322--1404.
 -/
 
 namespace TNLean
@@ -30,8 +32,8 @@ private theorem edge_ne_of_middle_incident_for_physical (e : Edge G) {v : V}
   · exact hvne.1 (hleft.symm.trans (congrArg (fun f : Edge G => f.1.1) hie))
   · exact hvne.2 (hright.symm.trans (congrArg (fun f : Edge G => f.1.2) hie))
 
-/-- Physical configurations on the middle block \(V\setminus\{u,v\}\) in the
-edge-centered three-site decomposition at the edge \(e=(u,v)\).
+/-- Physical configurations on the middle block $V\setminus\{u,v\}$ in the
+edge-centered three-site decomposition at the edge $e=(u,v)$.
 
 Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
@@ -164,7 +166,7 @@ def EdgeMiddleTensorInjective (A : Tensor G d) (e : Edge G) : Prop :=
   LinearIndependent ℂ (edgeMiddleTensorFamily (G := G) A e)
 
 /-- Injectivity of the three-site chain obtained by blocking around a
-chosen edge \(e=(u,v)\).
+chosen edge $e=(u,v)$.
 
 The first and last assertions are the injectivity of the endpoint tensors. The
 middle assertion is the injectivity of the tensor obtained by blocking all
@@ -181,14 +183,14 @@ edge-blocked three-site chain.
 
 The source proof uses that contracting injective tensors over a finite region
 gives an injective blocked tensor. This proposition records the part of that
-claim needed for the middle region \(V\setminus\{u,v\}\) attached to an edge
-\(e=(u,v)\), without asserting the full contraction theorem.
+claim needed for the middle region $V\setminus\{u,v\}$ attached to an edge
+$e=(u,v)$, without asserting the full contraction theorem.
 
 Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
 structure EdgeMiddleRegionInjectivityComparison
     (κ : RegionInjectivityData V) (A : Tensor G d) : Prop where
-  /-- Region injectivity of \(V\setminus\{u,v\}\) gives injectivity of the
+  /-- Region injectivity of $V\setminus\{u,v\}$ gives injectivity of the
   corresponding edge-middle tensor family. -/
   middle_tensor_injective :
     ∀ e : Edge G, κ.IsInjective (edgeMiddleVertices e) →
@@ -285,7 +287,7 @@ edge-middle tensor family.
 This is the all-edge conditional form of the assertion following
 `eq:block_to_mps` in arXiv:1804.04964, Section 3. The remaining source-paper
 step is the contraction theorem showing that vertex injectivity gives
-injectivity of each finite middle region \(V\setminus\{u,v\}\).
+injectivity of each finite middle region $V\setminus\{u,v\}$.
 
 Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
 `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
@@ -297,6 +299,77 @@ theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all
     ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) A e :=
   hA.edgeBlockedThreeSiteInjective_all_of_middle
     (hComparison.edgeMiddleTensorInjective_all hMiddleRegions)
+
+/-- Singleton comparison and finite union closure give the edge-middle tensor
+for a chosen edge whose middle region is nonempty.
+
+This is a restricted consequence of the source argument: it handles the case
+where $V\setminus\{u,v\}$ is a nonempty finite union of singleton regions.
+The remaining comparison from region injectivity to the concrete edge-middle
+tensor is still assumed.
+
+**Scope restriction (nonempty middle):** This theorem assumes
+`(edgeMiddleVertices e).Nonempty`; see
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
+`lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009
+and 1322--1404. -/
+theorem EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_of_singletons
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hSingleton : SingletonRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hA : IsVertexInjective A) (e : Edge G)
+    (hMiddle : (edgeMiddleVertices e).Nonempty) :
+    EdgeMiddleTensorInjective (G := G) A e :=
+  hComparison.middle_tensor_injective e
+    (hUnion.finset_injective_of_singletons hSingleton hA hMiddle)
+
+/-- Singleton comparison and finite union closure give the edge-blocked
+three-site injectivity statement for an edge whose middle region is nonempty.
+
+**Scope restriction (nonempty middle):** This theorem assumes
+`(edgeMiddleVertices e).Nonempty`; see
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
+`lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009
+and 1322--1404. -/
+theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_of_singletons
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hSingleton : SingletonRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hA : IsVertexInjective A) (e : Edge G)
+    (hMiddle : (edgeMiddleVertices e).Nonempty) :
+    EdgeBlockedThreeSiteInjective (G := G) A e :=
+  hA.edgeBlockedThreeSiteInjective_of_middle e
+    (hComparison.edgeMiddleTensorInjective_of_singletons hUnion hSingleton hA e hMiddle)
+
+/-- Singleton comparison and finite union closure give edge-blocked three-site
+injectivity at every edge whose middle region is nonempty.
+
+This is the all-edge form of the preceding restricted consequence.
+
+**Scope restriction (nonempty middle):** This theorem assumes
+`∀ e : Edge G, (edgeMiddleVertices e).Nonempty`; see
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
+`lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009
+and 1322--1404. -/
+theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_of_singletons
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hSingleton : SingletonRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hA : IsVertexInjective A)
+    (hMiddle : ∀ e : Edge G, (edgeMiddleVertices e).Nonempty) :
+    ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) A e :=
+  fun e =>
+    hComparison.edgeBlockedThreeSiteInjective_of_singletons
+      hUnion hSingleton hA e (hMiddle e)
 
 /-- Vertex injectivity is preserved by the edge blocking to a three-site MPS.
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1193,6 +1193,55 @@ injective and normal PEPS, following Theorems~2 and~3 of
     middle-tensor theorem then gives three-site injectivity for every edge.
 \end{proof}
 
+\begin{theorem}[Edge-middle tensor from singleton regions, nonempty middle case]%
+    \label{thm:peps_edgeMiddleTensorInjective_of_singletons}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_of_singletons}
+    \leanok
+    \uses{thm:peps_finiteRegionInjectivityFromSingletons,
+        def:peps_edgeMiddleRegionInjectivityComparison}
+    Let $e=(u,v)$ and put $M_e=V\setminus\{u,v\}$. Assume $M_e\ne\varnothing$.
+    Assume also singleton comparison, union closure for $\kappa$, and the
+    comparison
+    $\kappa(M_e)\Longrightarrow\operatorname{inj}(T_{A,M_e})$. If $A$ is
+    vertex-injective, then the edge-middle tensor family $T_{A,M_e}$ is
+    injective.
+\end{theorem}
+\begin{proof}\leanok
+    The finite-region theorem applied to
+    $M_e=\bigcup_{w\in M_e}\{w\}$ gives $\kappa(M_e)$. The edge-middle
+    comparison sends this to $\operatorname{inj}(T_{A,M_e})$.
+\end{proof}
+
+\begin{theorem}[One edge-blocked chain from singleton regions, nonempty middle case]%
+    \label{thm:peps_edgeBlockedThreeSiteInjective_of_singletons}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_of_singletons}
+    \leanok
+    \uses{thm:peps_edgeMiddleTensorInjective_of_singletons,
+        thm:peps_edgeBlockedThreeSiteInjective_of_middle}
+    Let $e=(u,v)$ and put $M_e=V\setminus\{u,v\}$. Under the hypotheses of the
+    preceding theorem, vertex injectivity of $A$ gives injectivity of the
+    edge-blocked three-site chain at $e$.
+\end{theorem}
+\begin{proof}\leanok
+    The preceding theorem gives $\operatorname{inj}(T_{A,M_e})$. The endpoint
+    reduction combines this middle-tensor injectivity with vertex injectivity
+    at $u$ and $v$.
+\end{proof}
+
+\begin{theorem}[All edge-blocked chains from singleton regions, nonempty middle case]%
+    \label{thm:peps_edgeBlockedThreeSiteInjective_all_of_singletons}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_of_singletons}
+    \leanok
+    \uses{thm:peps_edgeBlockedThreeSiteInjective_of_singletons}
+    If $M_e=V\setminus\{u,v\}$ is nonempty for every edge $e=(u,v)$, then the
+    preceding one-edge statement applies at every edge. Thus vertex
+    injectivity of $A$ gives injectivity of every edge-blocked three-site
+    chain.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the one-edge statement separately to each edge $e$.
+\end{proof}
+
 \begin{theorem}[Edge blocking preserves injectivity]%
     \label{thm:peps_edgeBlockedThreeSiteInjective}
     \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -143,6 +143,16 @@ Theorem can be proved in the manner of the paper.
   \leanid{TNLean.PEPS.RegionInjectivityUnionClosure.finset_injective_of_singletons}:
   $R=\bigcup_{v\in R}\{v\}$ and $\kappa(\{v\})$ for every $v\in R$ imply
   $\kappa(R)$.
+  The corresponding nonempty-middle edge-middle tensor consequence is recorded
+  in \path{thm:peps_edgeMiddleTensorInjective_of_singletons}:
+  for $M_e=V\setminus\{u,v\}$, the assumptions
+  $M_e\ne\varnothing$ and
+  $M_e=\bigcup_{w\in M_e}\{w\}$ give $\kappa(M_e)$; the edge-middle
+  comparison then gives injectivity of the middle tensor.
+  The endpoint reduction then gives the one-edge three-site statement
+  \path{thm:peps_edgeBlockedThreeSiteInjective_of_singletons}, and
+  applying this to all edges satisfying $M_e\ne\varnothing$ gives
+  \path{thm:peps_edgeBlockedThreeSiteInjective_all_of_singletons}.
   Vertex injectivity supplies the two endpoint assertions by
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective}
   and, for all edges at once, by


### PR DESCRIPTION
### Motivation

- Continues formalization of the edge-blocked three-site injectivity step from arXiv:1804.04964, Section 3, after `eq:block_to_mps`, toward issue #1366.
- Combines the finite-region singleton theorem with the existing edge-middle comparison to obtain edge-blocked three-site injectivity when every middle region $M_e = V\setminus\{u,v\}$ is nonempty.
- Source passages: `Papers/1804.04964/paper_normal.tex`, lines 981--1009 (edge blocking around `eq:block_to_mps`) and lines 1322--1404 (Lemma `injective_union`).

### Description

- Added `TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_of_singletons`, proving injectivity of the edge-middle tensor family $T_{A,M_e}$ from singleton comparison, finite-union closure, and edge-middle comparison.
- Added `TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_of_singletons`, proving three-site injectivity at one edge from the middle-tensor statement and endpoint reduction.
- Added `TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_of_singletons`, applying the one-edge statement to every edge whose middle region is nonempty.
- Added matching split blueprint entries for the three Lean statements, with direct `\uses` dependencies rather than a bundled theorem tag.
- Updated `docs/paper-gaps/peps_injective_ft_section3_route.tex` to record the conditional singleton-route edge consequence.
- Converted touched `EdgeMiddlePhysical.lean` docstring math from `\(...\)` to `$...$`.

This is a scope-restricted step, not the full Section 3 theorem: it still assumes the edge-middle comparison, and it only covers edges for which $M_e\ne\varnothing$.

### Testing

- `lake exe cache get`
- `lake build TNLean.PEPS.EdgeMiddlePhysical`
- `git diff --check`
- `rg -n '\\[()]' blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex TNLean/PEPS/EdgeMiddlePhysical.lean`
- Line-length check on touched Lean and paper-gap files.
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/EdgeMiddlePhysical.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `PYTHONPATH=blueprint/src/Packages python3 blueprint/src/Packages/tn_diagrams.py --check --check-peps-usage --smoke-render TNPEPSEdgeBlockingReduction`
- `cd blueprint && leanblueprint web`
- `leanblueprint checkdecls` not run: no `blueprint/lean_decls` directory is present in this checkout.

---
Related to #1366

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only formalization and documentation with no runtime, auth, or data-path changes; scope is explicitly conditional and documented.
> 
> **Overview**
> This PR extends the Section 3 injective-PEPS route by **wiring singleton-region injectivity through finite union closure into edge-middle and three-site injectivity**, still under explicit hypotheses (edge-middle comparison, union closure, singleton comparison) and only when the middle region \(M_e = V\setminus\{u,v\}\) is **nonempty**.
> 
> In **`TNLean/PEPS/EdgeMiddlePhysical.lean`**, it imports **`SingletonRegion`**, adds three short theorems on **`EdgeMiddleRegionInjectivityComparison`**: middle-tensor injectivity at one edge, full edge-blocked three-site injectivity at one edge (via existing endpoint reduction), and the all-edge variant. Proofs delegate to **`finset_injective_of_singletons`** and existing **`edgeBlockedThreeSiteInjective_of_middle`** machinery. Docstrings note the **nonempty-middle scope** and point to the paper-gap route doc; touched math notation moves from `\(...\)` to `$...$`, and a reference to **`lem:injective_union`** (lines 1322–1404) is added.
> 
> **`blueprint/src/chapter/ch13a_peps_ft.tex`** gains three matching **`\leanok`** theorems with direct **`\uses`** links (no bundled tag). **`docs/paper-gaps/peps_injective_ft_section3_route.tex`** records this conditional singleton-route consequence in the remaining-obligations narrative.
> 
> This is **not** the full **`eq:block_to_mps`** theorem: the finite-region contraction / edge-middle comparison proof and edges with empty \(M_e\) remain out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7570e6c93b0b487bc46bd1b3bc9d1f43967874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->