### PR TITLE
doc(periodic): make sector-match prose formula-driven

### DIFF
--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -587,7 +587,7 @@ unconditional result.
 \begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}
     \lean{MPSTensor.sectorMatch_propagation}
     \notready
-    \uses{def:periodic_tensor}
+    \uses{def:periodic_tensor, def:cyclic_sector_decomp}
     Let $A$ and $B$ be left-canonical tensors with period $m$, and let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
     cyclic sector decompositions whose sectors are left-canonical. Suppose
@@ -603,7 +603,7 @@ unconditional result.
     \label{lem:sector_tensor_proportional_blocked_match}
     \lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
     \notready
-    \uses{lem:sector_match_propagation}
+    \uses{lem:sector_match_propagation, def:cyclic_sector_decomp}
     Let $A$ and $B$ be left-canonical tensors with period $m$, and let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
     cyclic sector decompositions whose sectors are left-canonical. Assume
@@ -611,23 +611,32 @@ unconditional result.
     assume that for every $u$ there are $d_u=e_{u+q}$, $\zeta_u\ne0$, and
     $X_u\in\GL_{d_u}(\C)$ such that
     $B_{u+q}^\alpha=\zeta_u X_u A_u^\alpha X_u^{-1}$ for every blocked
-    physical index $\alpha$. In the source notation this means that, for every
-    physical block $(i_1,\ldots,i_m)$,
+    physical index $\alpha$. The source obtains a phase-only product identity
+    after absorbing these sector gauges into the $B$-sectors: with $Q_v$ the
+    cyclic sector projectors of $B$, it writes
+    \[
+        \widetilde B_v^i
+        =
+        U_v Q_v B^i Q_{v+1} U_{v+1}^{\dagger}.
+    \]
+    The contraction input is then, for every physical block $(i_1,\ldots,i_m)$,
     \[
         A_u^{i_1}A_{u+1}^{i_2}\cdots A_{u+m-1}^{i_m}
         =
         e^{i\lambda_{u+q}}
-        B_{u+q}^{i_1}B_{u+q+1}^{i_2}\cdots B_{u+q+m-1}^{i_m}.
+        \widetilde B_{u+q}^{i_1}\widetilde B_{u+q+1}^{i_2}
+        \cdots\widetilde B_{u+q+m-1}^{i_m}.
     \]
     Then there are a phase $\xi$ and an invertible matrix $U$ such that
-    $A^i=e^{i\xi}UB^iU^{-1}$ after the cyclic sector relabeling.
+    $A^i=e^{i\xi}UB^iU^{-1}$ for every physical index $i$.
 \end{lemma}
 
 \begin{theorem}[Sector match yields repeated-block equivalence]%
     \label{thm:periodic_overlap_gauge_equiv_sector_match}
     \lean{MPSTensor.periodicOverlap_gaugeEquiv_of_sector_match}
     \notready
-    \uses{lem:sector_match_propagation, lem:sector_tensor_proportional_blocked_match}
+    \uses{lem:sector_match_propagation, lem:sector_tensor_proportional_blocked_match,
+        def:cyclic_sector_decomp}
     Let $A$ and $B$ be periodic tensors with the same period $m$. Let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
     cyclic sector decompositions whose sectors are left-canonical, and assume

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -561,7 +561,10 @@ unconditional result.
     \]
 
     If $A\sim_{\mathrm{gp}} B$, then $\bar A\sim_{\mathrm{gp}}\bar B$, so for
-    some $X\in\GL_D(\C)$ and $\zeta\ne0$ the trace pairing gives
+    some $X\in\GL_D(\C)$ and $\zeta\ne0$,
+    $(\bar B)^\alpha=\zeta X(\bar A)^\alpha X^{-1}$. Thus, for every
+    configuration $\sigma$ of length $N$,
+    $V^{(N)}(\bar B)_\sigma=\zeta^N V^{(N)}(\bar A)_\sigma$. Hence
     \[
         O_{\bar A\bar B}(N)
         =
@@ -585,13 +588,14 @@ unconditional result.
     \lean{MPSTensor.sectorMatch_propagation}
     \notready
     \uses{def:periodic_tensor}
-    Suppose that one blocked sector pair satisfies
-    $P_u A^{[m]}=e^{i\lambda_v}U_v Q_v B^{[m]}U_v^\dagger$. Then for every
-    $l\in\mathbb Z_m$ there are $\lambda_{v+l}$ and $U_{v+l}$ with
+    Let $A$ and $B$ be left-canonical tensors with period $m$, and let
+    $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
+    cyclic sector decompositions whose sectors are left-canonical. Suppose
+    $d_{u_0}=e_{v_0}$, $d_{u_0}\ne0$, and, after identifying the virtual spaces,
+    $A_{u_0}\sim_{\mathrm{gp}}B_{v_0}$. Then for every $l\in\mathbb Z_m$ there
+    is an equality $d_{u_0+l}=e_{v_0+l}$ and, after this identification,
     \[
-        P_{u+l} A^{[m]}
-        =
-        e^{i\lambda_{v+l}}U_{v+l} Q_{v+l} B^{[m]}U_{v+l}^\dagger .
+        A_{u_0+l}\sim_{\mathrm{gp}}B_{v_0+l}.
     \]
 \end{lemma}
 
@@ -600,8 +604,15 @@ unconditional result.
     \lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
     \notready
     \uses{lem:sector_match_propagation}
-    Assume $v=u+q$ in $\mathbb Z_m$ and, for every $u$ and every physical block
-    $(i_1,\ldots,i_m)$,
+    Let $A$ and $B$ be left-canonical tensors with period $m$, and let
+    $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
+    cyclic sector decompositions whose sectors are left-canonical. Assume
+    $d_u\ne0$ and $A_u$ is normal for every $u$. Fix $q\in\mathbb Z_m$ and
+    assume that for every $u$ there are $d_u=e_{u+q}$, $\zeta_u\ne0$, and
+    $X_u\in\GL_{d_u}(\C)$ such that
+    $B_{u+q}^\alpha=\zeta_u X_u A_u^\alpha X_u^{-1}$ for every blocked
+    physical index $\alpha$. In the source notation this means that, for every
+    physical block $(i_1,\ldots,i_m)$,
     \[
         A_u^{i_1}A_{u+1}^{i_2}\cdots A_{u+m-1}^{i_m}
         =
@@ -617,9 +628,13 @@ unconditional result.
     \lean{MPSTensor.periodicOverlap_gaugeEquiv_of_sector_match}
     \notready
     \uses{lem:sector_match_propagation, lem:sector_tensor_proportional_blocked_match}
-    For periodic tensors of the same period, the existence of one pair
-    $(u,v)$ with $P_u A^{[m]}=e^{i\lambda_v}U_v Q_v B^{[m]}U_v^\dagger$
-    implies repeated-block equivalence.
+    Let $A$ and $B$ be periodic tensors with the same period $m$. Let
+    $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
+    cyclic sector decompositions whose sectors are left-canonical, and assume
+    every sector $A_u$ has nonzero virtual dimension. If there are sectors
+    $u_0,v_0$ with $d_{u_0}=e_{v_0}$ and
+    $A_{u_0}\sim_{\mathrm{gp}}B_{v_0}$ after identifying their virtual spaces,
+    then $A$ and $B$ are equivalent up to repeated blocks.
 \end{theorem}
 
 \begin{theorem}[Different bond dimensions imply asymptotic orthogonality]%

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -548,12 +548,10 @@ unconditional result.
         \sum_{u\in\mathbb Z_m}\sum_{v\in\mathbb Z_m}
             O_{A_uB_v}(N).
     \]
-    For a sector pair $(u,v)$, if $d_u=e_v$, the no-matching hypothesis gives
-    $A_u \not\sim_{\mathrm{gp}} B_v$ after identifying the virtual spaces, and
-    the normal-tensor overlap dichotomy gives
-    $\lim_{N\to\infty} O_{A_uB_v}(N)=0$. If $d_u\ne e_v$, the rectangular
-    overlap dichotomy gives the same limit. Thus every summand tends to zero,
-    and therefore
+    For every sector pair $(u,v)$ the overlap dichotomy gives
+    $\lim_{N\to\infty} O_{A_uB_v}(N)=0$: if $d_u=e_v$, this follows from
+    $A_u \not\sim_{\mathrm{gp}} B_v$, while if $d_u\ne e_v$ it follows from
+    the rectangular dichotomy. Hence
     \[
         \lim_{N\to\infty} O_{\bar A\bar B}(N)
         =
@@ -562,11 +560,8 @@ unconditional result.
         =0 .
     \]
 
-    If $A\sim_{\mathrm{gp}} B$, then blocking gives
-    $\bar A\sim_{\mathrm{gp}}\bar B$, so for some invertible $X$ and
-    some $\zeta\ne0$,
-    $V_N(\bar B)=\zeta^N X V_N(\bar A)X^{-1}$.
-    The trace pairing cancels the conjugating matrices:
+    If $A\sim_{\mathrm{gp}} B$, then $\bar A\sim_{\mathrm{gp}}\bar B$, so for
+    some $X\in\GL_D(\C)$ and $\zeta\ne0$ the trace pairing gives
     \[
         O_{\bar A\bar B}(N)
         =
@@ -576,26 +571,12 @@ unconditional result.
         =
         |\zeta|^{2N} O_{\bar A\bar A}(N).
     \]
-    With $O_{\bar A\bar A}(N)\to m$ and $O_{\bar B\bar B}(N)\to m>0$,
-    the second identity gives
-    \[
-        1
-        =
-        \lim_{N\to\infty}
-        \frac{O_{\bar B\bar B}(N)}{O_{\bar A\bar A}(N)}
-        =
-        \lim_{N\to\infty} |\zeta|^{2N},
-    \]
-    hence $|\zeta|=1$. The first identity then gives
-    \[
-        \lim_{N\to\infty}|O_{\bar A\bar B}(N)|
-        =
-        \lim_{N\to\infty}|\zeta|^N |O_{\bar A\bar A}(N)|
-        =
-        m\ne0,
-    \]
-    while the sector sum above gives
-    $\lim_{N\to\infty}O_{\bar A\bar B}(N)=0$. Thus
+    With $O_{\bar A\bar A}(N)\to m$ and $O_{\bar B\bar B}(N)\to m>0$, the
+    second identity gives
+    $1=\lim_{N\to\infty}O_{\bar B\bar B}(N)/O_{\bar A\bar A}(N)
+    =\lim_{N\to\infty}|\zeta|^{2N}$, hence $|\zeta|=1$. The first identity
+    gives $\lim_{N\to\infty}|O_{\bar A\bar B}(N)|=m\ne0$, whereas the sector
+    sum gives $\lim_{N\to\infty}O_{\bar A\bar B}(N)=0$. Thus
     $A\not\sim_{\mathrm{gp}}B$, and the irreducible trace-preserving overlap
     dichotomy gives $\lim_{N\to\infty}O_{AB}(N)=0$.
 \end{proof}
@@ -604,8 +585,14 @@ unconditional result.
     \lean{MPSTensor.sectorMatch_propagation}
     \notready
     \uses{def:periodic_tensor}
-    A single gauge-phase match between blocked sectors propagates to all
-    cyclic translates of that sector pair.
+    Suppose that one blocked sector pair satisfies
+    $P_u A^{[m]}=e^{i\lambda_v}U_v Q_v B^{[m]}U_v^\dagger$. Then for every
+    $l\in\mathbb Z_m$ there are $\lambda_{v+l}$ and $U_{v+l}$ with
+    \[
+        P_{u+l} A^{[m]}
+        =
+        e^{i\lambda_{v+l}}U_{v+l} Q_{v+l} B^{[m]}U_{v+l}^\dagger .
+    \]
 \end{lemma}
 
 \begin{lemma}[Per-site proportionality from blocked sector match]%
@@ -613,8 +600,16 @@ unconditional result.
     \lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
     \notready
     \uses{lem:sector_match_propagation}
-    If all aligned blocked sectors match up to gauge and phase, then the
-    original tensors are related by repeated-block proportionality.
+    Assume $v=u+q$ in $\mathbb Z_m$ and, for every $u$ and every physical block
+    $(i_1,\ldots,i_m)$,
+    \[
+        A_u^{i_1}A_{u+1}^{i_2}\cdots A_{u+m-1}^{i_m}
+        =
+        e^{i\lambda_{u+q}}
+        B_{u+q}^{i_1}B_{u+q+1}^{i_2}\cdots B_{u+q+m-1}^{i_m}.
+    \]
+    Then there are a phase $\xi$ and an invertible matrix $U$ such that
+    $A^i=e^{i\xi}UB^iU^{-1}$ after the cyclic sector relabeling.
 \end{lemma}
 
 \begin{theorem}[Sector match yields repeated-block equivalence]%
@@ -622,8 +617,9 @@ unconditional result.
     \lean{MPSTensor.periodicOverlap_gaugeEquiv_of_sector_match}
     \notready
     \uses{lem:sector_match_propagation, lem:sector_tensor_proportional_blocked_match}
-    For periodic tensors of the same period, existence of one matching
-    sector pair implies repeated-block equivalence.
+    For periodic tensors of the same period, the existence of one pair
+    $(u,v)$ with $P_u A^{[m]}=e^{i\lambda_v}U_v Q_v B^{[m]}U_v^\dagger$
+    implies repeated-block equivalence.
 \end{theorem}
 
 \begin{theorem}[Different bond dimensions imply asymptotic orthogonality]%


### PR DESCRIPTION
### Motivation

The periodic sector-match portion of the blueprint should be readable as mathematics rather than a verbal summary. This PR continues the formula-driven rewrite tracked in #448, aligned with arXiv:1708.00029, Appendix A, lines 952-1021 in `Papers/1708.00029/main.tex`.

### Description

This is a blueprint-only change in `blueprint/src/chapter/ch11b_periodic_ft.tex`.

The no-sector-match proof now records the sector-pair limits $\lim_N O_{A_uB_v}(N)=0$ and derives the blocked gauge-phase contradiction through explicit overlap identities. In particular it restores the coefficient relation $V^{(N)}(\bar B)_\sigma=\zeta^N V^{(N)}(\bar A)_\sigma$ before taking limits.

The sector-match propagation and blocked-sector proportionality entries now state the current cyclic-sector hypotheses explicitly: left-canonical sector decompositions, dimension equalities, nonzero sector dimensions, normality where required, and gauge-phase equivalence in the form $B_{u+q}^\alpha=\zeta_u X_u A_u^\alpha X_u^{-1}$.

No Lean declarations or proofs are changed.

### Testing

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files blueprint/src/chapter/ch11b_periodic_ft.tex`
- line-length and `$...$` delimiter scan on `blueprint/src/chapter/ch11b_periodic_ft.tex`
- `cd blueprint && leanblueprint web` (passes with the repository's existing plasTeX and bibliography warnings)

No Lean build was run because no `.lean` files changed.

Addresses #448

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the LaTeX blueprint; no Lean, runtime, or security impact.
> 
> **Overview**
> **Blueprint-only** updates in `ch11b_periodic_ft.tex` make the periodic sector-match overlap material **formula-driven** instead of high-level prose, aligned with the De las Cuevas et al. appendix.
> 
> The **no-sector-match** proof now states sector-pair limits $\lim_N O_{A_uB_v}(N)=0$ via the overlap dichotomy (matching vs rectangular cases), and walks the blocked **gauge-phase contradiction** through explicit identities—including $V^{(N)}(\bar B)_\sigma=\zeta^N V^{(N)}(\bar A)_\sigma$—before taking limits.
> 
> **Sector-match propagation**, **blocked-sector proportionality**, and **sector match ⇒ repeated-block equivalence** now spell out **cyclic sector decomposition** hypotheses (left-canonical sectors, dimensions, normality, gauge relations $B_{u+q}^\alpha=\zeta_u X_u A_u^\alpha X_u^{-1}$, projector-based $\widetilde B_v$, and block contraction inputs) rather than short verbal summaries. `\uses{def:cyclic_sector_decomp}` is added where relevant.
> 
> No Lean files or proofs are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a2b6fcdc054cb3ea5d8284a8bdcb5b39b18ddc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->