### PR TITLE
feat(PEPS): compose blocked-middle local gauge formula

### DIFF
--- a/TNLean/PEPS/LocalGauge.lean
+++ b/TNLean/PEPS/LocalGauge.lean
@@ -270,5 +270,29 @@ theorem localGauge_exists_of_factorizedLocalGauge (A B : Tensor G d)
           intro η' _
           rw [hXv η η']
 
+/-- The blocked-middle local gauge formula gives the local gauge relation at a
+vertex.
+
+This is the direct algebraic consequence of the edge-centred three-site
+reduction: once the reduction supplies the product-kernel formula at the vertex,
+the canonical pullback through the local left inverse gives the same local gauge
+formula.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and the discussion after
+`eq:TN_5_particle_eq`, lines 981--1044 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem localGauge_exists_of_blockedMiddleGaugeFormula (A B : Tensor G d)
+    (hA : IsVertexInjective A) (hDim : A.bondDim = B.bondDim) (v : V)
+    (hBlocked : BlockedMiddleGaugeFormula A B hA hDim v) :
+    ∃ (Xv : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ),
+      ∀ (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
+        B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
+          ∑ η' : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1),
+            (∏ ie : IncidentEdge G v,
+              (↑(Xv ie.1) : Matrix _ _ ℂ) (η ie) (η' ie)) *
+              A.component v η' σ :=
+  localGauge_exists_of_factorizedLocalGauge A B hA hDim v
+    (hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula A B hA hDim v hBlocked)
+
 end PEPS
 end TNLean

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -86,6 +86,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNPEPSEdgeGaugeOrientation": "",
     "TNPEPSGaugeVertexAction": "",
     "TNPEPSGaugeCancellation": "",
+    "TNPEPSBlockedMiddleLocalGaugeFormula": "",
     "TNPEPSLocalGaugeExtraction": "",
     "TNPEPSGlobalConsistency": "",
 }

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1552,7 +1552,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.localGauge_exists_of_blockedMiddleGaugeFormula}
     \leanok
     \uses{def:peps_blockedMiddleGaugeFormula,
-        thm:peps_hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula}
+        thm:peps_hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula,
+        thm:localGauge_exists}
     Suppose that the edge-centred three-site reduction supplies invertible
     matrices $X_e$ on the incident edges of $v$ such that, for all local virtual
     configurations $\eta$ and physical indices $\sigma$,
@@ -1566,9 +1567,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \begin{center}
         \TNPEPSBlockedMiddleLocalGaugeFormula
     \end{center}
-    The open part is still the derivation of the blocked-middle formula from
-    equality of PEPS states; this theorem only records the resulting local
-    algebra.
+    % Open: derive the blocked-middle formula from SameState
+    % by the edge-centred three-site reduction.
 \end{theorem}
 \begin{proof}\leanok
     Apply the previous theorem to obtain the factorized local gauge datum, then

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1547,6 +1547,34 @@ injective and normal PEPS, following Theorems~2 and~3 of
     coefficient kernel, so both parts of the factorized local gauge datum follow.
 \end{proof}
 
+\begin{theorem}[Blocked-middle formula gives a local gauge formula]%
+    \label{thm:peps_localGauge_exists_of_blockedMiddleGaugeFormula}
+    \lean{TNLean.PEPS.localGauge_exists_of_blockedMiddleGaugeFormula}
+    \leanok
+    \uses{def:peps_blockedMiddleGaugeFormula,
+        thm:peps_hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula}
+    Suppose that the edge-centred three-site reduction supplies invertible
+    matrices $X_e$ on the incident edges of $v$ such that, for all local virtual
+    configurations $\eta$ and physical indices $\sigma$,
+    \[
+        B_v(\eta,\sigma)
+        =
+        \sum_{\eta'}
+        \left(\prod_{e\ni v} X_e(\eta_e,\eta'_e)\right)A_v(\eta',\sigma).
+    \]
+    Then the same family $X_e$ is a local gauge at $v$:
+    \begin{center}
+        \TNPEPSBlockedMiddleLocalGaugeFormula
+    \end{center}
+    The open part is still the derivation of the blocked-middle formula from
+    equality of PEPS states; this theorem only records the resulting local
+    algebra.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the previous theorem to obtain the factorized local gauge datum, then
+    use the local left inverse to read off the same product-kernel formula.
+\end{proof}
+
 \begin{theorem}[Absorbing edge gauges into the second PEPS]%
     \label{thm:peps_edge_gauge_absorption}
     \lean{TNLean.PEPS.edge_gauge_absorption}
@@ -1622,6 +1650,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{theorem}[Local gauge extraction]%
     \label{thm:localGauge_exists}
     \lean{TNLean.PEPS.localGauge_exists}
+    \lean{TNLean.PEPS.localGauge_exists_of_factorizedLocalGauge}
     \leanok
     \uses{def:peps_hasFactorizedLocalGauge}
     Under the factorized local gauge hypothesis, the local gauge formula follows.

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -998,6 +998,29 @@
   \end{tikzpicture}%
 }
 
+\newcommand{\TNPEPSBlockedMiddleLocalGaugeFormula}{%
+  \begin{tikzpicture}[tn picture]
+    \TN@tensordot{bmA}{(0,0)}
+    \TN@tensordot{bmB}{(2.55,0)}
+    \draw[tn leg] (bmA) -- ++(40:0.55);
+    \draw[tn leg] (bmA) -- ++(100:0.55);
+    \draw[tn leg] (bmA) -- ++(160:0.55);
+    \draw[tn leg] (bmA) -- ++(220:0.55);
+    \draw[tn leg] (bmA) -- ++(300:0.55);
+    \draw[tn leg] (bmB) -- ++(40:0.55);
+    \draw[tn leg] (bmB) -- ++(100:0.55);
+    \draw[tn leg] (bmB) -- ++(160:0.55);
+    \draw[tn leg] (bmB) -- ++(220:0.55);
+    \draw[tn leg] (bmB) -- ++(300:0.55);
+    \draw[tn phys leg] (bmA.north) -- ++(0,0.62);
+    \draw[tn phys leg] (bmB.north) -- ++(0,0.62);
+    \node at ($(bmA)+(0,-0.62)$) {$A_v$};
+    \node at ($(bmB)+(0,-0.62)$) {$B_v$};
+    \node at (1.28,0.25) {$\prod_{e\ni v}X_e$};
+    \draw[->,tn leg] (0.62,0) -- (1.93,0);
+  \end{tikzpicture}%
+}
+
 \newcommand{\TNPEPSLocalGaugeExtraction}{%
   \begin{tikzpicture}[tn picture]
     \TN@tensordot{tnLv}{(0,0)}

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -22,7 +22,10 @@ name: TNLocalEqualityStep TNPeriodicGauge TNGroundSpaceMap
 name: TNPEPSEdgeGaugeOrientation TNPEPSGaugeVertexAction
 {{ obj.tn_svg_html }}
 
-name: TNPEPSGaugeCancellation TNPEPSLocalGaugeExtraction TNPEPSGlobalConsistency
+name: TNPEPSGaugeCancellation TNPEPSBlockedMiddleLocalGaugeFormula
+{{ obj.tn_svg_html }}
+
+name: TNPEPSLocalGaugeExtraction TNPEPSGlobalConsistency
 {{ obj.tn_svg_html }}
 
 name: TNPEPSEdgeBlockingReduction TNPEPSEdgeInsertedCoeff


### PR DESCRIPTION
### Motivation

- arXiv:1804.04964 §3 reduces a PEPS gauge comparison to a three-site MPS comparison via the edge-centred blocking step; the source equations around `eq:block_to_mps` and `eq:TN_5_particle_eq` produce the local product-kernel formula
  $$B_v(\eta,\sigma)=\sum_{\eta'}\left(\prod_{e\ni v}X_e(\eta_e,\eta'_e)\right)A_v(\eta',\sigma).$$
- Once this formula is available, the local gauge formula follows by composing the existing conversion to `HasFactorizedLocalGauge` with local gauge extraction.
- Provides the final algebraic step in the chain `localGauge_exists → gaugeConsistency → fundamentalTheorem_PEPS`; the implication from `SameState` to `BlockedMiddleGaugeFormula` (the three-site MPS reduction itself) is not yet proved.

### Description

- `TNLean/PEPS/LocalGauge.lean` (+24 lines): new theorem `localGauge_exists_of_blockedMiddleGaugeFormula` composing `hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula` with `localGauge_exists_of_factorizedLocalGauge` to derive the explicit local gauge formula from the product-kernel hypothesis.
- `blueprint/src/chapter/ch13a_peps_ft.tex` (+29 lines): new formula-driven theorem node for this step, with `\lean{TNLean.PEPS.localGauge_exists_of_blockedMiddleGaugeFormula}` link; cross-links local gauge extraction to `localGauge_exists_of_factorizedLocalGauge`.
- `blueprint/src/macros/tn_print.tex` (+23 lines): new TikZ macro `\TNPEPSBlockedMiddleLocalGaugeFormula` for the blocked-middle local gauge diagram.
- `blueprint/src/Packages/tn_diagrams.py`, `blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s`: register the new diagram for blueprint web rendering.

### Testing

- `lake exe cache get`
- `lake build TNLean.PEPS.LocalGauge`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base main --changed-files TNLean/PEPS/LocalGauge.lean blueprint/src/chapter/ch13a_peps_ft.tex blueprint/src/macros/tn_print.tex blueprint/src/Packages/tn_diagrams.py blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s`
- `python3 blueprint/src/Packages/tn_diagrams.py --check`
- `cd blueprint && leanblueprint web`

---
Addresses #820

> [!NOTE]
> **Low Risk**
> Small additive Lean composition and blueprint/diagram sync; no auth, runtime, or changes to the still-open SameState → blocked-middle derivation.
>
> **Overview**
> Adds the algebraic composition step for PEPS local gauge extraction (issue #820): once the edge-centred three-site reduction supplies `BlockedMiddleGaugeFormula`, the new Lean theorem `localGauge_exists_of_blockedMiddleGaugeFormula` chains `hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula` with `localGauge_exists_of_factorizedLocalGauge` to obtain the explicit product-kernel local gauge formula. **No proof** is added from `SameState` to the blocked-middle formula.
>
> The blueprint gains a dedicated theorem node (with `\lean` link), a TikZ diagram `\TNPEPSBlockedMiddleLocalGaugeFormula`, and plastex/HTML registration for that diagram. **Local gauge extraction** is cross-linked to `localGauge_exists_of_factorizedLocalGauge`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c90c3df501671a24d37a39532aa5b56a2d72770c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean composition and blueprint/diagram wiring only; no runtime, auth, or changes to the still-open SameState → blocked-middle derivation.
> 
> **Overview**
> Adds the **algebraic bridge** in the PEPS local-gauge chain: assuming the edge-centred three-site reduction already yields **`BlockedMiddleGaugeFormula`** (product-kernel reconstruction of `B_v` from `A_v`), the new Lean theorem **`localGauge_exists_of_blockedMiddleGaugeFormula`** composes existing results to obtain the explicit **local gauge formula** at a vertex. **No new proof** is added from **`SameState`** to the blocked-middle hypothesis.
> 
> The blueprint gains a theorem node with `\lean` link, a TikZ diagram **`\TNPEPSBlockedMiddleLocalGaugeFormula`**, and plastex/HTML registration so the diagram renders on the web. **Local gauge extraction** is cross-linked to **`localGauge_exists_of_factorizedLocalGauge`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd7d74eac0dbb3a6da98b51b6324a198d31b9a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->