### PR TITLE
doc(BNT): make coefficient comparison formulas explicit

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1112,11 +1112,25 @@ matching covers the whole BNT basis.
 
 \begin{proof}\leanok
     \uses{lem:eventual_coeff_eq_of_eventual_li}
-    Expand the equality of the total MPVs in the $P$-basis and the $Q$-basis.
-    Substitute the displayed phase relation for every $Q_k$, and reindex the
-    resulting $Q$-sum by $\beta$. The BNT linear independence of the $P$-basis,
-    through Lemma~\ref{lem:eventual_coeff_eq_of_eventual_li}, forces equality
-    of the corresponding coefficients for all sufficiently large lengths.
+    For all sufficiently large $N$, expand the equality of total MPVs as
+    \[
+        \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
+        =
+        \sum_{k\in J(Q)} c_N^{(k)}(Q)\ket{V^{(N)}(Q_k)} .
+    \]
+    The phase relation gives
+    $\ket{V^{(N)}(Q_k)}=\zeta_k^N\ket{V^{(N)}(P_{\beta(k)})}$, hence
+    \[
+        \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
+        =
+        \sum_{j\in J(P)}
+        \zeta_{\beta^{-1}(j)}^N
+        c_N^{(\beta^{-1}(j))}(Q)\ket{V^{(N)}(P_j)} .
+    \]
+    Lemma~\ref{lem:eventual_coeff_eq_of_eventual_li} applied to the
+    $P$-basis gives
+    $c_N^{(\beta(k))}(P)=\zeta_k^Nc_N^{(k)}(Q)$ for all sufficiently
+    large $N$.
 \end{proof}
 
 \begin{lemma}[Full-basis coefficient identity from global gauges]%
@@ -1144,11 +1158,14 @@ matching covers the whole BNT basis.
 \begin{proof}\leanok
     \uses{lem:sector_bnt_norm_phase_of_matched_mpv,
         lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
-    Choose the scalar-power MPV identity associated to each gauge-phase
-    equivalence. Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv} gives
-    unit modulus for each scalar. Applying
-    Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase} to these
-    phases gives the eventual coefficient identities.
+    For each matched sector, the gauge-phase equivalence gives
+    $V^{(N)}(Q_k)_\sigma=\zeta_k^NV^{(N)}(P_{\beta(k)})_\sigma$.
+    Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv} gives
+    $|\zeta_k|=1$. Applying
+    Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase} to the
+    same phases gives
+    $c_N^{(\beta(k))}(P)=\zeta_k^Nc_N^{(k)}(Q)$ for all sufficiently
+    large $N$.
 \end{proof}
 
 \begin{definition}[Copy-weight matching for matched BNT sectors]%
@@ -1190,10 +1207,19 @@ matching covers the whole BNT basis.
 \end{lemma}
 
 \begin{proof}\leanok
-    Apply Lemma~\ref{lem:sector_bnt_matched_sector_weight_equiv} in each
-    matched sector.  The resulting copy permutations and pointwise weight
-    identities satisfy exactly the conditions of
-    Definition~\ref{def:sector_bnt_copy_weight_matching}.
+    For all sufficiently large $N$, the coefficient identity in sector $k$ is
+    \[
+        \sum_q \mu_{\beta(k),q}^{\,N}
+        =
+        \zeta_k^N\sum_p\nu_{k,p}^{\,N}
+        =
+        \sum_p(\zeta_k\nu_{k,p})^{N}.
+    \]
+    Lemma~\ref{lem:sector_bnt_matched_sector_weight_equiv} applies the finite
+    power-sum comparison sector by sector, producing a copy permutation
+    $\tau_k$ with
+    $\mu_{\beta(k),\tau_k(q)}=\zeta_k\nu_{k,q}$. Since $\zeta_k\ne0$, this is
+    equivalent to $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$.
 \end{proof}
 
 \begin{theorem}[Global gauge from matched sectors and copy weights]%
@@ -1228,12 +1254,19 @@ matching covers the whole BNT basis.
 \end{theorem}
 
 \begin{proof}\leanok
-    Multiply the displayed sector identity by the matching copy weight
-    identity. The phase $\zeta_k$ cancels against $\zeta_k^{-1}$, giving a
-    conjugation identity for every flattened weighted block. Applying
-    Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} to the flattened
-    family assembles these block conjugacies into the displayed direct-sum
-    gauge.
+    For each matched copy,
+    \[
+        \nu_{k,q}Q_k^i
+        =
+        \bigl(\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}\bigr)
+        \bigl(\zeta_kX_kP_{\beta(k)}^iX_k^{-1}\bigr)
+        =
+        \mu_{\beta(k),\tau_k(q)}X_kP_{\beta(k)}^iX_k^{-1}.
+    \]
+    Thus every flattened weighted block is conjugated by its sector gauge
+    $X_k$. Lemma~\ref{lem:tensor_from_blocks_globalGauge_conj} assembles these
+    block conjugacies into the direct-sum gauge
+    $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
 \end{proof}
 
 \begin{theorem}[Global gauge from a copy-weight matching]%
@@ -1258,8 +1291,10 @@ matching covers the whole BNT basis.
 \end{theorem}
 
 \begin{proof}\leanok
-    The copy-weight matching supplies the copy permutations and the weight
-    identities. Apply
+    The copy-weight matching supplies
+    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$. Together with
+    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$, these are exactly the two
+    displayed hypotheses of
     Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
 \end{proof}
 
@@ -1285,9 +1320,13 @@ matching covers the whole BNT basis.
 \end{theorem}
 
 \begin{proof}\leanok
-    Apply the proportional sector-matching theorem. The unit-modulus phases
-    are nonzero, so the global-gauge theorem applies to any
-    copy-weight matching for the resulting phases.
+    The proportional sector-matching theorem supplies $\beta$, $X_k$, and
+    unit phases $\zeta_k$ satisfying
+    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$. Since $|\zeta_k|=1$, each
+    $\zeta_k$ is nonzero. A copy-weight matching gives
+    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$, so
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_copy_weight_matching} gives the
+    direct-sum gauge.
 \end{proof}
 
 \begin{theorem}[Conditional proportional global gauge from coefficient identities]%
@@ -1318,12 +1357,14 @@ matching covers the whole BNT basis.
 \end{theorem}
 
 \begin{proof}\leanok
-    Apply Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
-    to obtain the matched sectors, phases, block gauges, and the conditional
-    global gauge for any copy-weight matching. The unit-modulus phases are
-    nonzero. Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity}
-    turns the coefficient identities into such a copy-weight matching, and the
-    conditional global-gauge conclusion applies.
+    The sector-matching theorem gives $\beta$, $X_k$, and $|\zeta_k|=1$ with
+    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$. Since $\zeta_k\ne0$, the
+    coefficient identities
+    $c_N^{(\beta(k))}(P)=\zeta_k^Nc_N^{(k)}(Q)$ produce
+    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$ by
+    Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity}.
+    Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
+    then applies to this copy-weight matching.
 \end{proof}
 
 \begin{theorem}[Full-basis global gauge in matched coordinates]%

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1112,13 +1112,13 @@ matching covers the whole BNT basis.
 
 \begin{proof}\leanok
     \uses{lem:eventual_coeff_eq_of_eventual_li}
-    For all sufficiently large $N$, expand the equality of total MPVs as
+    For every $N$, expand the equality of total MPVs as
     \[
         \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
         =
         \sum_{k\in J(Q)} c_N^{(k)}(Q)\ket{V^{(N)}(Q_k)} .
     \]
-    The phase relation gives
+    For every $N$, the phase relation gives
     $\ket{V^{(N)}(Q_k)}=\zeta_k^N\ket{V^{(N)}(P_{\beta(k)})}$, hence
     \[
         \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
@@ -1209,11 +1209,11 @@ matching covers the whole BNT basis.
 \begin{proof}\leanok
     For all sufficiently large $N$, the coefficient identity in sector $k$ is
     \[
-        \sum_q \mu_{\beta(k),q}^{\,N}
+        \sum_r \mu_{\beta(k),r}^{\,N}
         =
-        \zeta_k^N\sum_p\nu_{k,p}^{\,N}
+        \zeta_k^N\sum_q\nu_{k,q}^{\,N}
         =
-        \sum_p(\zeta_k\nu_{k,p})^{N}.
+        \sum_q(\zeta_k\nu_{k,q})^{N}.
     \]
     Lemma~\ref{lem:sector_bnt_matched_sector_weight_equiv} applies the finite
     power-sum comparison sector by sector, producing a copy permutation


### PR DESCRIPTION
### Motivation

- Blueprint proof sketches in Chapter 10 (`ch10_bnt.tex`) for the BNT coefficient-comparison and global-gauge assembly carry their argument through prose alone, without displaying the formulas being used. Exposing the formulas makes the argument independently checkable without following references.
- Source: CPGSV16 (arXiv:1606.00608), Appendix MPV proof, lines 1187–1192 of the local source. Continues the formalization work tracked in #1749.

### Description

- File modified: `blueprint/src/chapter/ch10_bnt.tex` only; no Lean files changed.
- Expands the equality of total MPVs in the matched $P$-basis and records the reindexed coefficient identity $c_N^{(\beta(k))}(P) = \zeta_k^N c_N^{(k)}(Q)$.
- Writes the sector power-sum comparison: $\sum_q \mu_{\beta(k),q}^N = \zeta_k^N \sum_p \nu_{k,p}^N = \sum_p (\zeta_k \nu_{k,p})^N$.
- Writes the cancellation giving the flattened block conjugacy: $\nu_{k,q} Q_k^i = \mu_{\beta(k),\tau_k(q)} X_k P_{\beta(k)}^i X_k^{-1}$.
- Short formulas are kept inline with `$...$`; blueprint statements, labels, and `\leanok` tags are unchanged.

### Testing

- `git diff --check` — passes.
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch10_bnt.tex` — passes.
- `cd blueprint && leanblueprint web` — passes (existing renderer and bibliography warnings unaffected).
- Lean CI (`lean_action_ci.yml`) will validate the build; no `.lean` files changed.

---
Addresses #1749

> [!NOTE]
> **Low Risk**
> Documentation-only edits to LaTeX proof text in the blueprint; no Lean or runtime behavior changes.
>
> **Overview**
> Blueprint-only update in **Chapter 10** (`ch10_bnt.tex`): several `\begin{proof}` blocks in the full-basis coefficient comparison and global-gauge chain are rewritten so the argument is carried by **displayed formulas** instead of high-level prose ("apply lemma X", "substitute", "assemble").
>
> The **matched-phase coefficient lemma** now expands equal total MPVs in the $P$-basis, reindexes using $\ket{V^{(N)}(Q_k)}=\zeta_k^N\ket{V^{(N)}(P_{\beta(k)})}$, and cites eventual linear independence for $c_N^{(\beta(k))}(P)=\zeta_k^N c_N^{(k)}(Q)$. The **global-gauge-from-gauges** proof spells out the per-sector MPV phase relation before invoking the matched-phase lemma. **Copy-weight matching** is derived from the sector power-sum identity $\sum_q \mu_{\beta(k),q}^{N}=\zeta_k^N\sum_p\nu_{k,p}^{N}=\sum_p(\zeta_k\nu_{k,p})^{N}$ and the matched-sector weight equivalence. **Global gauge assembly** shows the $\zeta_k$ cancellation on each copy, $\nu_{k,q}Q_k^i=\mu_{\beta(k),\tau_k(q)}X_kP_{\beta(k)}^iX_k^{-1}$, before the direct-sum conjugation lemma. Short **wrapper proofs** for proportional and coefficient-identity theorems now state the exact hypotheses ($|\zeta_k|=1$, copy-weight identities) passed to the cited theorems.
>
> Statements, labels, and Lean tags are unchanged; this is documentation alignment with CPGSV16 Appendix MPV lines 1187–1192 (issue #1749).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9e22b078f1e682095931f497eac308b57347dc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX proof text in the blueprint; no Lean or runtime behavior changes.
> 
> **Overview**
> Blueprint **Chapter 10** (`ch10_bnt.tex`) rewrites several `\begin{proof}` blocks in the full-basis coefficient comparison and global-gauge chain so the argument is carried by **displayed formulas** instead of high-level prose (“apply lemma X”, “substitute”, “assemble”).
> 
> The **matched-phase coefficient lemma** now expands equal total MPVs in the $P$-basis, reindexes using $\ket{V^{(N)}(Q_k)}=\zeta_k^N\ket{V^{(N)}(P_{\beta(k)})}$, and cites eventual linear independence for $c_N^{(\beta(k))}(P)=\zeta_k^N c_N^{(k)}(Q)$. The **global-gauge-from-gauges** proof spells out the per-sector MPV phase relation before invoking the matched-phase lemma. **Copy-weight matching** is derived from the sector power-sum identity $\sum_r \mu_{\beta(k),r}^{N}=\zeta_k^N\sum_q\nu_{k,q}^{N}=\sum_q(\zeta_k\nu_{k,q})^{N}$ and matched-sector weight equivalence. **Global gauge assembly** shows the $\zeta_k$ cancellation on each copy, $\nu_{k,q}Q_k^i=\mu_{\beta(k),\tau_k(q)}X_kP_{\beta(k)}^iX_k^{-1}$, before the direct-sum conjugation lemma. Short **wrapper proofs** for proportional and coefficient-identity theorems now state the exact hypotheses ($|\zeta_k|=1$, copy-weight identities) passed to the cited theorems.
> 
> Statements, labels, and Lean tags are unchanged; this aligns documentation with CPGSV16 Appendix MPV lines 1187–1192 (#1749).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ad3a51e1cb779b03488812c282b55578cde63c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->