### PR TITLE
doc(blueprint/MPDO): spell out RFP normalizing maps

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1233,10 +1233,20 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
         \qquad
         \tr(\nu_\gamma)=m_\gamma.
     \]
-    Only then do the maps
+    The reconstruction maps in \cite[lines~2065--2085]{Cirac2017MPDO_AnnPhys}
+    then use
+    \[
+        \widetilde R_2\Bigl(\bigoplus_\gamma X_\gamma\Bigr)
+          = \bigoplus_\gamma \frac{\nu_\gamma}{m_\gamma}\otimes X_\gamma,
+        \qquad
+        \widetilde R_1\Bigl(\bigoplus_\gamma X_\gamma\Bigr)
+          = \bigoplus_\gamma \frac{\mu_\gamma}{m_\gamma}\otimes X_\gamma .
+    \]
+    Thus $\tr(\nu_\gamma)=m_\gamma$ and the defining equality
+    $m_\gamma=\tr(\mu_\gamma)$ normalize the factors
+    $\nu_\gamma/m_\gamma$ and $\mu_\gamma/m_\gamma$, respectively, in
     $T=\widetilde R_2\widetilde T R_1$ and
-    $S=\widetilde R_1\widetilde S R_2$ have the normalizing factors used in
-    \cite[lines~2065--2085]{Cirac2017MPDO_AnnPhys}.  The scalar
+    $S=\widetilde R_1\widetilde S R_2$.  The scalar
     Newton--Girard power-sum identity needed to obtain the trace-power form is
     already available as
     Theorem~\ref{thm:newton_girard}; what remains is the MPDO construction of

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -169,13 +169,20 @@ Summing this identity gives
           c^{(1)}_{\alpha,\beta,\gamma}
       = m_\gamma .
 \]
-Only after this trace equality is obtained do the maps
+Only after this trace equality is obtained do the normalizing maps in
+\cite[lines~2065--2085]{Cirac2017MPDO_AnnPhys} have the form
 \[
-    T=\widetilde R_2\widetilde T R_1,
+    \widetilde R_2\Bigl(\bigoplus_\gamma X_\gamma\Bigr)
+      = \bigoplus_\gamma \frac{\nu_\gamma}{m_\gamma}\otimes X_\gamma,
     \qquad
-    S=\widetilde R_1\widetilde S R_2
+    \widetilde R_1\Bigl(\bigoplus_\gamma X_\gamma\Bigr)
+      = \bigoplus_\gamma \frac{\mu_\gamma}{m_\gamma}\otimes X_\gamma .
 \]
-have the normalizing factors required in lines~2065--2085.
+These are the maps used in
+$T=\widetilde R_2\widetilde T R_1$ and
+$S=\widetilde R_1\widetilde S R_2$.  The first denominator is normalized by
+$\tr(\nu_\gamma)=m_\gamma$, proved above; the second by the defining equality
+$m_\gamma=\tr(\mu_\gamma)$ for the original block coefficient.
 
 The present algebra predicate
 \leanid{MPOTensor.IsRFP_MPDO_via_algebra} does not include these BNT-label


### PR DESCRIPTION
### Motivation

- The Appendix C.4 normalizing-map step in arXiv:1606.00608 was still described mainly by a line-range reference.
- The source formulas are
  $\widetilde R_2(\bigoplus_\gamma X_\gamma)=\bigoplus_\gamma (\nu_\gamma/m_\gamma)\otimes X_\gamma$ and
  $\widetilde R_1(\bigoplus_\gamma X_\gamma)=\bigoplus_\gamma (\mu_\gamma/m_\gamma)\otimes X_\gamma$.
- The text now records both normalizations: $\tr(\nu_\gamma)=m_\gamma$ for the $\nu_\gamma/m_\gamma$ factor and $m_\gamma=\tr(\mu_\gamma)$ for the $\mu_\gamma/m_\gamma$ factor.

### Description

- `blueprint/src/chapter/ch02b_mpdo.tex`: replaces the line-range-only normalizing-map sentence with the explicit formulas for $\widetilde R_2$ and $\widetilde R_1$ and the two trace normalizations.
- `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`: adds the same formulas and normalization explanation to the blocked-chi uniformity note.
- No Lean files changed. This PR is only the formula-level clarification of the Appendix C.4 normalizing step; issue #826 remains open.

### Source

- `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1956 and 2065--2085.

### Testing

- `git diff --check` passed.
- Line-length check on the touched files passed.
- No parenthesized TeX math delimiters occur in the touched files.
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files blueprint/src/chapter/ch02b_mpdo.tex docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex --diff-base origin/main` passed.
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv17_blocked_chi_uniformity.tex` from `docs/paper-gaps` passed with existing long-identifier box warnings.
- `leanblueprint web` and `leanblueprint pdf` passed with existing renderer, bibliography, citation, reference, and overfull warnings.

References #826.