### PR TITLE
feat(PEPS/NormalEdgeBlockingCoordinate): add cover-based normal edge blocking data

### DIFF
--- a/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
@@ -139,9 +139,6 @@ theorem normalSquareHorizontalEdge_blockingData
 /-- The normalized horizontal edge has red/blue/complement blocking data once
 the local $T$-region has a rectangular cover.
 
-It states the individual membership, injectivity, disjointness, and covering
-conclusions obtained from the cover version of the horizontal blocking datum.
-
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500. -/
 theorem normalSquareHorizontalEdge_blockingData_of_TCover
     {κ : RegionInjectivityData (SquareLatticeVertex 5 7)}
@@ -324,9 +321,6 @@ theorem normalSquareVerticalEdge_blockingData
 /-- The normalized vertical edge has red/blue/complement blocking data once the
 rotated local $T$-region is injective.
 
-It states the individual membership, injectivity, disjointness, and covering
-conclusions obtained after applying the vertical collar identity.
-
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 theorem normalSquareVerticalEdge_blockingData_of_verticalT
     {κ : RegionInjectivityData (SquareLatticeVertex 7 5)}
@@ -348,9 +342,6 @@ theorem normalSquareVerticalEdge_blockingData_of_verticalT
 
 /-- The normalized vertical edge has red/blue/complement blocking data once the
 rotated local $T$-region has a rectangular cover.
-
-It states the individual membership, injectivity, disjointness, and covering
-conclusions obtained from the rectangular cover of the rotated $T$-region.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500. -/
 theorem normalSquareVerticalEdge_blockingData_of_verticalTCover

--- a/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
@@ -17,7 +17,7 @@ the normal square-lattice PEPS theorem.
 namespace TNLean
 namespace PEPS
 
-/-- The distinguished horizontal edge in the normalized \(5\times7\) frame.
+/-- The distinguished horizontal edge in the normalized $5\times7$ frame.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
 where the proof blocks the tensor network around a horizontal edge. -/
@@ -136,6 +136,31 @@ theorem normalSquareHorizontalEdge_blockingData
     d.complement_injective, d.red_disjoint_blue, d.red_disjoint_complement,
     d.blue_disjoint_complement, d.cover_univ⟩
 
+/-- The normalized horizontal edge has red/blue/complement blocking data once
+the local $T$-region has a rectangular cover.
+
+It states the individual membership, injectivity, disjointness, and covering
+conclusions obtained from the cover version of the horizontal blocking datum.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500. -/
+theorem normalSquareHorizontalEdge_blockingData_of_TCover
+    {κ : RegionInjectivityData (SquareLatticeVertex 5 7)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (cover : NormalSquareRegionTRectangleCover (width := 5) (height := 7) 0 0) :
+    normalSquareHorizontalEdge.1.1 ∈ normalSquareHorizontalEdgeRed ∧
+      normalSquareHorizontalEdge.1.2 ∈ normalSquareHorizontalEdgeBlue ∧
+      κ.IsInjective normalSquareHorizontalEdgeRed ∧
+      κ.IsInjective normalSquareHorizontalEdgeBlue ∧
+      κ.IsInjective normalSquareHorizontalEdgeComplement ∧
+      Disjoint normalSquareHorizontalEdgeRed normalSquareHorizontalEdgeBlue ∧
+      Disjoint normalSquareHorizontalEdgeRed normalSquareHorizontalEdgeComplement ∧
+      Disjoint normalSquareHorizontalEdgeBlue normalSquareHorizontalEdgeComplement ∧
+      normalSquareHorizontalEdgeRed ∪ normalSquareHorizontalEdgeBlue ∪
+          normalSquareHorizontalEdgeComplement =
+        (Finset.univ : Finset (SquareLatticeVertex 5 7)) :=
+  normalSquareHorizontalEdge_blockingData h hUnion (h.regionT_injective_of_cover hUnion cover)
+
 /-- The normalized horizontal edge supplies the three injective regions used in
 the edge-blocked three-site chain.
 
@@ -151,7 +176,7 @@ theorem normalSquareHorizontalEdge_injective_chain
   (normalSquareHorizontalEdge_blockingDatum h hUnion hT).injective_chain
 
 /-- The normalized horizontal edge has red/blue/complement blocking data once
-the local \(T\)-region has a rectangular cover.
+the local $T$-region has a rectangular cover.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500. -/
 def normalSquareHorizontalEdge_blockingDatum_of_TCover
@@ -164,7 +189,7 @@ def normalSquareHorizontalEdge_blockingDatum_of_TCover
     (h.regionT_injective_of_cover hUnion cover)
 
 /-- The normalized horizontal edge supplies the three injective regions once
-the local \(T\)-region has a rectangular cover.
+the local $T$-region has a rectangular cover.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500. -/
 theorem normalSquareHorizontalEdge_injective_chain_of_TCover
@@ -177,10 +202,10 @@ theorem normalSquareHorizontalEdge_injective_chain_of_TCover
       κ.IsInjective normalSquareHorizontalEdgeComplement :=
   (normalSquareHorizontalEdge_blockingDatum_of_TCover h hUnion cover).injective_chain
 
-/-- The distinguished vertical edge in the normalized \(7\times5\) frame.
+/-- The distinguished vertical edge in the normalized $7\times5$ frame.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
-where the proof says that vertical edges use the \(7\times5\) counterpart of
+where the proof says that vertical edges use the $7\times5$ counterpart of
 the horizontal-edge blocking. -/
 def normalSquareVerticalEdge : Edge (squareLatticeGraph 7 5) where
   val :=
@@ -296,8 +321,59 @@ theorem normalSquareVerticalEdge_blockingData
     d.complement_injective, d.red_disjoint_blue, d.red_disjoint_complement,
     d.blue_disjoint_complement, d.cover_univ⟩
 
+/-- The normalized vertical edge has red/blue/complement blocking data once the
+rotated local $T$-region is injective.
+
+It states the individual membership, injectivity, disjointness, and covering
+conclusions obtained after applying the vertical collar identity.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem normalSquareVerticalEdge_blockingData_of_verticalT
+    {κ : RegionInjectivityData (SquareLatticeVertex 7 5)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hT : κ.IsInjective (normalSquareVerticalRegionT (width := 7) (height := 5) 0 0)) :
+    normalSquareVerticalEdge.1.1 ∈ normalSquareVerticalEdgeRed ∧
+      normalSquareVerticalEdge.1.2 ∈ normalSquareVerticalEdgeBlue ∧
+      κ.IsInjective normalSquareVerticalEdgeRed ∧
+      κ.IsInjective normalSquareVerticalEdgeBlue ∧
+      κ.IsInjective normalSquareVerticalEdgeComplement ∧
+      Disjoint normalSquareVerticalEdgeRed normalSquareVerticalEdgeBlue ∧
+      Disjoint normalSquareVerticalEdgeRed normalSquareVerticalEdgeComplement ∧
+      Disjoint normalSquareVerticalEdgeBlue normalSquareVerticalEdgeComplement ∧
+      normalSquareVerticalEdgeRed ∪ normalSquareVerticalEdgeBlue ∪
+          normalSquareVerticalEdgeComplement =
+        (Finset.univ : Finset (SquareLatticeVertex 7 5)) :=
+  normalSquareVerticalEdge_blockingData h (h.verticalComp_injective hUnion hT)
+
+/-- The normalized vertical edge has red/blue/complement blocking data once the
+rotated local $T$-region has a rectangular cover.
+
+It states the individual membership, injectivity, disjointness, and covering
+conclusions obtained from the rectangular cover of the rotated $T$-region.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500. -/
+theorem normalSquareVerticalEdge_blockingData_of_verticalTCover
+    {κ : RegionInjectivityData (SquareLatticeVertex 7 5)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (cover : NormalSquareVerticalRegionTRectangleCover
+      (width := 7) (height := 5) 0 0) :
+    normalSquareVerticalEdge.1.1 ∈ normalSquareVerticalEdgeRed ∧
+      normalSquareVerticalEdge.1.2 ∈ normalSquareVerticalEdgeBlue ∧
+      κ.IsInjective normalSquareVerticalEdgeRed ∧
+      κ.IsInjective normalSquareVerticalEdgeBlue ∧
+      κ.IsInjective normalSquareVerticalEdgeComplement ∧
+      Disjoint normalSquareVerticalEdgeRed normalSquareVerticalEdgeBlue ∧
+      Disjoint normalSquareVerticalEdgeRed normalSquareVerticalEdgeComplement ∧
+      Disjoint normalSquareVerticalEdgeBlue normalSquareVerticalEdgeComplement ∧
+      normalSquareVerticalEdgeRed ∪ normalSquareVerticalEdgeBlue ∪
+          normalSquareVerticalEdgeComplement =
+        (Finset.univ : Finset (SquareLatticeVertex 7 5)) :=
+  normalSquareVerticalEdge_blockingData h (h.verticalComp_inj_of_cover hUnion cover)
+
 /-- The normalized vertical edge has red/blue/complement blocking data once
-the rotated local \(T\)-region is injective.
+the rotated local $T$-region is injective.
 
 This discharges the complementary-block input of
 `normalSquareVerticalEdge_blockingDatum` using the vertical collar identity.
@@ -312,7 +388,7 @@ def normalSquareVerticalEdge_blockingDatum_of_verticalT
   normalSquareVerticalEdge_blockingDatum h (h.verticalComp_injective hUnion hT)
 
 /-- The normalized vertical edge has red/blue/complement blocking data once the
-rotated local \(T\)-region has a rectangular cover.
+rotated local $T$-region has a rectangular cover.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500. -/
 def normalSquareVerticalEdge_blockingDatum_of_verticalTCover
@@ -342,7 +418,7 @@ theorem normalSquareVerticalEdge_injective_chain
   (normalSquareVerticalEdge_blockingDatum h hComplement).injective_chain
 
 /-- The normalized vertical edge supplies the three injective regions once the
-rotated local \(T\)-region is injective.
+rotated local $T$-region is injective.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 theorem normalSquareVerticalEdge_injective_chain_of_verticalT
@@ -356,7 +432,7 @@ theorem normalSquareVerticalEdge_injective_chain_of_verticalT
   (normalSquareVerticalEdge_blockingDatum_of_verticalT h hUnion hT).injective_chain
 
 /-- The normalized vertical edge supplies the three injective regions once the
-rotated local \(T\)-region has a rectangular cover.
+rotated local $T$-region has a rectangular cover.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500. -/
 theorem normalSquareVerticalEdge_injective_chain_of_verticalTCover

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2887,11 +2887,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     complementary-block injectivity is either kept as an explicit hypothesis or
     obtained from
     rotated $T$-injectivity, and therefore from a rectangular cover of
-    rotated $T$, by the vertical collar lemma.  The cover-based variants state
-    the same membership, injectivity, disjointness, and covering conclusions
-    directly from the cover hypotheses.  In both cases the named blocking datum
-    supplies the corresponding three injective regions for the edge-blocked
-    chain.
+    rotated $T$, by the vertical collar lemma.  In both cases the named
+    blocking datum supplies the corresponding three injective regions for the
+    edge-blocked chain.
 \end{lemma}
 % Maintainer note: horizontal and vertical complement injectivity are reduced
 % to local and rotated T-covers, respectively.  The translated every-edge

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2849,6 +2849,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.normalSquareHorizontalEdgeComplement}
     \lean{TNLean.PEPS.normalSquareHorizontalEdge_blockingDatum}
     \lean{TNLean.PEPS.normalSquareHorizontalEdge_blockingData}
+    \lean{TNLean.PEPS.normalSquareHorizontalEdge_blockingData_of_TCover}
     \lean{TNLean.PEPS.normalSquareHorizontalEdge_injective_chain}
     \lean{TNLean.PEPS.normalSquareHorizontalEdge_blockingDatum_of_TCover}
     \lean{TNLean.PEPS.normalSquareHorizontalEdge_injective_chain_of_TCover}
@@ -2859,6 +2860,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.normalSquareVerticalEdgeComplement}
     \lean{TNLean.PEPS.normalSquareVerticalEdge_blockingDatum}
     \lean{TNLean.PEPS.normalSquareVerticalEdge_blockingData}
+    \lean{TNLean.PEPS.normalSquareVerticalEdge_blockingData_of_verticalT}
+    \lean{TNLean.PEPS.normalSquareVerticalEdge_blockingData_of_verticalTCover}
     \lean{TNLean.PEPS.normalSquareVerticalEdge_blockingDatum_of_verticalT}
     \lean{TNLean.PEPS.normalSquareVerticalEdge_blockingDatum_of_verticalTCover}
     \lean{TNLean.PEPS.normalSquareVerticalEdge_injective_chain}
@@ -2884,9 +2887,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
     complementary-block injectivity is either kept as an explicit hypothesis or
     obtained from
     rotated $T$-injectivity, and therefore from a rectangular cover of
-    rotated $T$, by the vertical collar lemma.  In both cases the named
-    blocking datum supplies the corresponding three injective regions for the
-    edge-blocked chain.
+    rotated $T$, by the vertical collar lemma.  The cover-based variants state
+    the same membership, injectivity, disjointness, and covering conclusions
+    directly from the cover hypotheses.  In both cases the named blocking datum
+    supplies the corresponding three injective regions for the edge-blocked
+    chain.
 \end{lemma}
 % Maintainer note: horizontal and vertical complement injectivity are reduced
 % to local and rotated T-covers, respectively.  The translated every-edge


### PR DESCRIPTION
### Motivation
- Continues the square-lattice normal PEPS proof of MGRPG+18, Theorem 3, using `Papers/1804.04964/paper_normal.tex`, lines 1430--1500.
- The proof blocks the tensor network around an edge into red, blue, and complementary injective regions.  The rectangular-cover hypotheses should therefore give the membership, injectivity, disjointness, and covering assertions directly for the normalized horizontal and vertical edge blockings.
- This is a narrow step toward #2004; it does not complete the every-edge translation from `NormalSquareBlockingRegions` to `NormalEdgeBlockingHypotheses`.

### Description
- Adds `normalSquareHorizontalEdge_blockingData_of_TCover`, deriving the horizontal red/blue/complement data from a rectangular cover of the local $T$-region.
- Adds `normalSquareVerticalEdge_blockingData_of_verticalT`, deriving the vertical data from rotated $T$-injectivity via the vertical collar identity.
- Adds `normalSquareVerticalEdge_blockingData_of_verticalTCover`, deriving the same vertical data from a rectangular cover of the rotated $T$-region.
- Updates the PEPS blueprint entry for normalized horizontal and vertical edge blocking to link the three new statements.
- Converts the touched inline mathematical prose in `TNLean/PEPS/NormalEdgeBlockingCoordinate.lean` from `\(...\)` to `$...$`.

### Source Comparison
- Lines 1430--1448: the $T$-region is obtained from smaller injective rectangles.
- Lines 1475--1499: the network is blocked around an edge into red, blue, and complementary regions.
- Line 1498: vertical edges use the $7\times5$ counterpart.

### Testing
- `lake exe cache get`
- `lake build TNLean.PEPS.NormalEdgeBlockingCoordinate -q --log-level=info`
- `lake build TNLean -q --log-level=info` (passes; existing warnings in unrelated files remain)
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/PEPS/NormalEdgeBlockingCoordinate.lean blueprint/src/chapter/ch13a_peps_ft.tex --diff-base origin/main`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/PEPS/NormalEdgeBlockingCoordinate.lean` (no output)
- `leanblueprint checkdecls`: the three new declarations appear in the generated declaration list and are not in the missing-declaration output; pre-existing failures in the parent-Hamiltonian chapter and later PEPS FT placeholders remain.

References #2004.