### PR TITLE
feat(MPS/MPDO): formalize algebra eigenvalue obstruction

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -523,6 +523,62 @@ theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply
         simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
       rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, ih, hX]
 
+/-- Eigenvector version of the blocked adjoint calculation.
+
+If `X` is an eigenvector of the unblocked adjoint transfer map with eigenvalue
+`λ`, then it is an eigenvector of the adjoint blocked transfer map at size `n`
+with eigenvalue `λ^n`.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
+lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. This is the
+spectral fixed-point calculation underlying the obstruction to deriving the
+fusion formulation from the present support-algebra predicate alone. -/
+theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector
+    {M : MPOTensor d D} (n : ℕ) {lam : ℂ} {X : Mat}
+    (hX : (transferMap M).adjoint X = lam • X) :
+    (blockedTransferMap M n).adjoint X = lam ^ n • X := by
+  induction n with
+  | zero =>
+      simp [blockedTransferMap_eq_pow, Module.End.one_eq_id]
+  | succ k ih =>
+      have hPow : blockedTransferMap M (k + 1) =
+          blockedTransferMap M k ∘ₗ transferMap M := by
+        simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
+      rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, ih]
+      rw [map_smul, hX, smul_smul, pow_succ]
+
+/-- The current algebra-structure predicate rules out finite-order adjoint
+eigenvalues different from $1$.
+
+More explicitly, let `E` be the one-site transfer map. If
+`IsRFP_MPDO_via_algebra M` holds, `X ≠ 0`,
+`E† X = λ X`, and `λ^n = 1` for some `n > 0`, then `λ = 1`. This is exactly the
+finite-order consequence of the fixed-point equality
+$\operatorname{Fix}((E^n)^\dagger)=\operatorname{Fix}(E^\dagger)$. It is not
+the fusion-side idempotence statement $E^2=E$; the latter is the paper's
+coefficient-comparison argument in Appendix C.4.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
+lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra
+    {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
+    {n : ℕ} (hn : 0 < n) {lam : ℂ} {X : Mat} (hX_ne : X ≠ 0)
+    (hX : (transferMap M).adjoint X = lam • X) (hlam : lam ^ n = 1) :
+    lam = 1 := by
+  have hBlocked : (blockedTransferMap M n).adjoint X = X := by
+    rw [adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector
+      (M := M) n hX, hlam, one_smul]
+  have hFix : (transferMap M).adjoint X = X :=
+    adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra hAlg hn hBlocked
+  have hLamX : lam • X = X := by
+    rw [← hX]
+    exact hFix
+  have hSub : (lam - 1) • X = 0 := by
+    rw [sub_smul, hLamX, one_smul, sub_self]
+  rcases smul_eq_zero.mp hSub with hLam_sub | hX_zero
+  · exact sub_eq_zero.mp hLam_sub
+  · exact (hX_ne hX_zero).elim
+
 /-- Under the current algebra-structure predicate, the adjoint fixed points of
 every positive blocked transfer map coincide with the adjoint fixed points of
 the unblocked transfer map.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1143,6 +1143,42 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     $E_0 = \mathrm{id}$. This step does not require the algebra-structure data.
 \end{proof}
 
+\begin{lemma}[Blocked powers of adjoint eigenvectors]%
+    \label{lem:mpdo_adjoint_blocked_eigenvector}
+    \lean{MPOTensor.adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector}
+    \leanok
+    If $E=E_1$ and $E^\dagger X=\lambda X$, then
+    $E_n^\dagger X=\lambda^n X$ for every $n$.
+\end{lemma}
+\begin{proof}\leanok
+    The case $n=0$ is $E_0=\mathrm{id}$. For the induction step,
+    $E_{n+1}=E_n\circ E_1$, hence
+    \[
+        E_{n+1}^{\dagger}X
+        = E_1^{\dagger}E_n^{\dagger}X
+        = E_1^{\dagger}(\lambda^n X)
+        = \lambda^n E_1^{\dagger}X
+        = \lambda^{n+1}X .
+    \]
+\end{proof}
+
+\begin{theorem}[Finite-order adjoint eigenvalues for algebra towers]%
+    \label{thm:mpdo_algebra_root_of_unity_eigenvalue}
+    \lean{MPOTensor.adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra}
+    \leanok
+    \uses{def:mpdo_rfp_via_algebra, thm:mpdo_adjoint_fix_descent,
+        lem:mpdo_adjoint_blocked_eigenvector}
+    Assume the algebra-structure formulation holds. If $X\ne 0$,
+    $E_1^\dagger X=\lambda X$, and $\lambda^n=1$ for some $n>0$, then
+    $\lambda=1$.
+\end{theorem}
+\begin{proof}\leanok
+    By Lemma~\ref{lem:mpdo_adjoint_blocked_eigenvector},
+    $E_n^\dagger X=\lambda^n X=X$. The descent theorem gives
+    $E_1^\dagger X=X$. Thus $\lambda X=X$, so $(\lambda-1)X=0$. Since
+    $X\ne0$, one obtains $\lambda=1$.
+\end{proof}
+
 \begin{theorem}[Adjoint fixed-point equality for algebra towers]%
     \label{thm:mpdo_adjoint_fix_equality_from_algebra}
     \lean{MPOTensor.adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra}
@@ -1183,8 +1219,8 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
         = \operatorname{Fix}(E^\dagger).
     \]
     Hence a vector $X$ with $E^\dagger X=\lambda X$ and $\lambda^n=1$ lies in
-    $\operatorname{Fix}(E^\dagger)$, so $(\lambda-1)X=0$.  Thus the predicate
-    excludes root-of-unity peripheral eigenvalues.  It does not imply
+    $\operatorname{Fix}(E^\dagger)$, so $(\lambda-1)X=0$ and $\lambda=1$ by
+    Theorem~\ref{thm:mpdo_algebra_root_of_unity_eigenvalue}.  It does not imply
     $E^2=E$.  For instance, if $\Pi_{\mathrm{diag}}$ is the projection onto
     diagonal matrices and $0<\varepsilon<1$, set
     \[


### PR DESCRIPTION
### Motivation

- PR #810 proved the forward direction (`isRFP_MPDO_via_fusion → isRFP_MPDO_via_algebra`); the converse direction (tracked in #826) requires showing that `IsRFP_MPDO_via_algebra` forces only trivial roots of unity on the adjoint spectrum of the one-site transfer map, corresponding to CPGSV17 Theorem IV.13(ii) (arXiv:1606.00608).
- The finite-order spectral obstruction must be formalized as a self-contained step before the full converse can be assembled via the Appendix C.4 coefficient-comparison argument.

### Description

In `TNLean/MPS/MPDO/AlgebraStructure.lean`, two theorems are added:

- `adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector`: if $E^\dagger X = \lambda X$ then $E_n^\dagger X = \lambda^n X$, proved by induction on blocking length.
- `adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra`: under `IsRFP_MPDO_via_algebra`, a nonzero adjoint eigenvector satisfying $\lambda^n = 1$ for some $n > 0$ forces $\lambda = 1$.

In `blueprint/src/chapter/ch02b_mpdo.tex`:

- Matching Lemma and Theorem entries added for the two results above.
- Remark `rem:mpdo_algebra_to_fusion_gap` updated to cite the proved root-of-unity exclusion in place of an informal argument, and points to the remaining Appendix C.4 coefficient-comparison step (positivity and BNT trace-power identities needed to construct one-site maps $T$ and $S$).

The full algebra-to-fusion converse (CPGSV17 Theorem IV.13(ii)) is not yet claimed.

### Testing

- `lake build TNLean.MPS.MPDO.AlgebraStructure -q --log-level=info`
- `lake build TNLean -q --log-level=info` (passes; existing warnings in unrelated PEPS / periodic overlap / normal-reduction files)
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --warn-missing-blueprint --changed-files TNLean/MPS/MPDO/AlgebraStructure.lean --diff-base origin/main --diff-head HEAD` (changed declarations covered; pre-existing global blueprint mismatches remain)
- `rg -n "sorry|axiom" TNLean/MPS/MPDO/AlgebraStructure.lean` (clean)
- `leanblueprint checkdecls` still fails on pre-existing parent-Hamiltonian and PEPS declarations; the two new declarations are not in that failing list.

---
Addresses #826

> [!NOTE]
> **Low Risk**
> Pure formalization and blueprint sync in MPDO algebra structure; no runtime, auth, or API surface changes.
>
> **Overview**
> Adds Lean proofs and blueprint text for the **finite-order spectral obstruction** of the MPDO algebra-structure predicate: adjoint eigenvectors of the one-site transfer map propagate to blocked maps with eigenvalue **λⁿ**, and under `IsRFP_MPDO_via_algebra`, nonzero eigenvectors with **λⁿ = 1** force **λ = 1**.
>
> In `AlgebraStructure.lean`, new theorems `adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector` and `adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra` chain induction on blocking length with the existing adjoint fixed-point descent lemma. The blueprint gains matching Lemma/Theorem entries and Remark `rem:mpdo_algebra_to_fusion_gap` now cites the proved root-of-unity exclusion instead of an informal argument.
>
> This sharpens what the current algebra tower implies (no nontrivial roots of unity on the adjoint spectrum) without claiming the full algebra-to-fusion converse, which still needs Appendix C.4 coefficient data.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c746aeb7c65d9f2a00262c5df6e76f0dfe66290c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>