### PR TITLE
doc(PEPS): record edge-blocking proof sketch

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1340,6 +1340,30 @@ injective and normal PEPS, following Theorems~2 and~3 of
     precise assertion after the edge-blocking diagram in
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
+\begin{proof}
+    The endpoint assertions are
+    $\operatorname{inj}(T_{A,u})$ and $\operatorname{inj}(T_{A,v})$, which follow
+    from vertex injectivity. The middle assertion is the remaining blocking
+    step: for every coefficient family $c_{\rho}$ on the residual boundary,
+    \[
+        \Bigl(\forall \tau,\;
+            \sum_{\rho} c_{\rho}\,T_{A,V\setminus\{u,v\}}^{\rho}(\tau)=0\Bigr)
+        \Longrightarrow
+        \forall \rho,\; c_{\rho}=0.
+    \]
+    Let $R=V\setminus\{u,v\}$. For $S\subseteq R$, write
+    \[
+        K(S) \Longleftrightarrow
+        \forall \tau,\;
+            \sum_{\rho} c_{\rho}\,T_{A,S}^{\rho}(\tau)=0.
+    \]
+    If $j\in S$, contraction with the local left inverse at $j$ gives
+    \[
+        K(S)\Longrightarrow K(S\setminus\{j\}).
+    \]
+    Hence $K(R)\Longrightarrow K(\varnothing)$. Since $T_{A,\varnothing}$ is
+    the empty contraction, $K(\varnothing)$ is $\forall \rho,\;c_{\rho}=0$.
+\end{proof}
 
 \begin{theorem}[Local virtual insertion realized physically on either endpoint]%
     \label{thm:peps_virtualInsertionPhysicalRealization}


### PR DESCRIPTION
### Motivation

- Chapter 13a states the edge-blocked injectivity theorem `thm:peps_edgeBlockedThreeSiteInjective`.
- The corresponding Lean declaration, `TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective`, exists, but its proof is still the staged finite-region blocking endpoint tracked in #1366.
- MGRPG+18, Section 3 around `eq:block_to_mps` (`Papers/1804.04964/paper_normal.tex`, lines 979--1009) asserts that the middle block obtained from $V\setminus\{u,v\}$ is injective. The blueprint should display the corresponding kernel implication rather than relying on prose alone.

### Description

- Keeps the theorem block `\leanok`, since the Lean statement exists and matches the blueprint.
- Adds an unmarked proof sketch spelling out the remaining middle-block implication
  $$
    (\forall \tau,\ \sum_\rho c_\rho T_{A,V\setminus\{u,v\}}^\rho(\tau)=0)
    \Longrightarrow (\forall \rho,\ c_\rho=0).
  $$
- Records that the endpoint injectivity assertions follow from vertex injectivity, while the middle assertion is the blocking inversion step.
- No Lean source changes.

### Testing

- `git diff --check`
- `rg -n '\\(|\\)' blueprint/src/chapter/ch13a_peps_ft.tex || true`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files blueprint/src/chapter/ch13a_peps_ft.tex --diff-base origin/main`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch13a_peps_ft.tex`
- `PATH=/tmp/tnlean-blueprint-venv/bin:$PATH leanblueprint web`

Addresses #1366

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the blueprint TeX; no runtime, auth, or Lean proof changes.
> 
> **Overview**
> Adds an **unmarked proof sketch** to `thm:peps_edgeBlockedThreeSiteInjective` in `ch13a_peps_ft.tex` so the blueprint states the **middle-block kernel implication** from MGRPG+18 Section 3, not only the three injectivity conclusions in prose.
> 
> The sketch splits **endpoint** injectivity (`T_{A,u}`, `T_{A,v}`) from **vertex injectivity**, and for the middle family `T_{A,V\setminus\{u,v\}}` introduces coefficient kernels `K(S)` and shows `K(R) \Rightarrow K(\emptyset)` by repeatedly contracting with a **local left inverse** at a vertex in `S`, ending with triviality of the empty contraction.
> 
> The theorem stays `\leanok` (Lean statement unchanged); there are **no Lean source edits**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d645cc12e1f009567175d9f04a5b7f5e482d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->