### PR TITLE
doc(PEPS): spell out union injectivity chain

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2307,13 +2307,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
         \quad\Longrightarrow\quad
         \mathcal C_{\{2\}}(X)=0 .
     \]
-    Reinsert the tensor on $P_1$.  Since $P_1\cup P_2=B$ is injective, the
-    left inverse for $B$ gives
+    The remaining two steps are
     \[
-        \mathcal C_{\{1,2\}}(X)=0
-        \quad\Longrightarrow\quad
-        X=0 .
+        \begin{aligned}
+            \mathcal C_{\{2\}}(X)=0
+            &\quad\Longrightarrow\quad
+            \mathcal C_{\{1,2\}}(X)=0,\\
+            \mathcal C_{\{1,2\}}(X)=0
+            &\quad\Longrightarrow\quad
+            X=0 .
+        \end{aligned}
     \]
+    The first implication is obtained by contracting with the tensor on
+    $P_1$, and the second is the left inverse for the injective region
+    $P_1\cup P_2=B$.
     Thus $\ker \mathcal C_{\{0,1,2\}}=\{0\}$, and therefore
     $P_0\cup P_1\cup P_2=A\cup B$ is injective.
 \end{proof}


### PR DESCRIPTION
### Motivation

- Issue #1374 tracks the tensor-level union-of-injective-regions lemma from MGRPG+18, Section 3.
- The source proof at `Papers/1804.04964/paper_normal.tex`, lines 1324--1404, uses the four-region decomposition and two successive inverse applications.
- The blueprint already has the TikZ diagrams; this PR makes the displayed proof sketch match the source proof more explicitly.

### Description

- Replaces the remaining prose-only `reinsert` step in `lem:peps_injectiveRegion_union` with the contraction chain
  $$
    \mathcal C_{\{2\}}(X)=0
    \Longrightarrow \mathcal C_{\{1,2\}}(X)=0
    \Longrightarrow X=0.
  $$
- Keeps the lemma `\notready`; this is a blueprint proof-sketch improvement, not the Lean formalization of #1374.
- No Lean source changes.

### Testing

- `git diff --check`
- `rg -n '\\(|\\)' blueprint/src/chapter/ch13a_peps_ft.tex || true`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files blueprint/src/chapter/ch13a_peps_ft.tex --diff-base origin/main`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch13a_peps_ft.tex`
- `PATH=/tmp/tnlean-blueprint-venv/bin:$PATH leanblueprint web`

---
Progress on #1374.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Documentation-only edit to a `\notready` blueprint proof sketch; no runtime, auth, or Lean formalization impact.
>
> **Overview**
> The PR tightens the **blueprint proof sketch** for `lem:peps_injectiveRegion_union` in `ch13a_peps_ft.tex` so it matches the MGRPG+18 four-region argument more explicitly.
>
> After the first step \(\mathcal C_{\{0,1,2\}}(X)=0 \Rightarrow \mathcal C_{\{2\}}(X)=0\) from injectivity of \(A\), the old prose about reinserting \(P_1\) and applying \(B\)'s left inverse is replaced by a displayed **two-step contraction chain** (\(\mathcal C_{\{2\}} \Rightarrow \mathcal C_{\{1,2\}} \Rightarrow X=0\)), with short notes that the first step contracts with the tensor on \(P_1\) and the second uses injectivity of \(P_1 \cup P_2 = B\).
>
> The lemma stays **`\notready`**; there are **no Lean** changes—documentation only for the union-of-injective-regions track (#1374).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ea97021f9981bdf31cd2bf805430cead795617a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- /CURSOR_SUMMARY -->
