### PR TITLE
feat(PEPS): expose normal edge blocking geometry

### DIFF
--- a/TNLean/PEPS/NormalEdgeBlockingData.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingData.lean
@@ -65,6 +65,18 @@ theorem injective_chain {G : SimpleGraph V} {e : Edge G}
     ι.IsInjective d.red ∧ ι.IsInjective d.blue ∧ ι.IsInjective d.complement :=
   ⟨d.red_injective, d.blue_injective, d.complement_injective⟩
 
+/-- The one-edge blocking datum records endpoint membership, pairwise
+disjointness, and coverage by the three regions.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem endpoint_disjoint_cover {G : SimpleGraph V} {e : Edge G}
+    (d : NormalEdgeBlockingData ι G e) :
+    e.1.1 ∈ d.red ∧ e.1.2 ∈ d.blue ∧ Disjoint d.red d.blue ∧
+      Disjoint d.red d.complement ∧ Disjoint d.blue d.complement ∧
+      d.red ∪ d.blue ∪ d.complement = Finset.univ :=
+  ⟨d.left_mem_red, d.right_mem_blue, d.red_disjoint_blue,
+    d.red_disjoint_complement, d.blue_disjoint_complement, d.cover_univ⟩
+
 end NormalEdgeBlockingData
 
 /-- Edge-centred blocking into three injective regions.
@@ -142,12 +154,33 @@ def ofBlockingData (data : ∀ e : Edge G, NormalEdgeBlockingData ι G e) :
   blue_disjoint_complement e := (data e).blue_disjoint_complement
   cover_univ e := (data e).cover_univ
 
+/-- Recovering the one-edge datum from hypotheses assembled from one-edge data
+returns the datum supplied at that edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+@[simp] theorem ofBlockingData_blockingData
+    (data : ∀ e : Edge G, NormalEdgeBlockingData ι G e) (e : Edge G) :
+    (ofBlockingData data).blockingData e = data e :=
+  rfl
+
 /-- The edge-centred blocking supplies a three-region injective chain at every
 edge. -/
 theorem injective_chain_at_edge (h : NormalEdgeBlockingHypotheses ι G) (e : Edge G) :
     ι.IsInjective (h.red e) ∧ ι.IsInjective (h.blue e) ∧
       ι.IsInjective (h.complement e) :=
   (h.blockingData e).injective_chain
+
+/-- At every edge, the edge-centred blocking records endpoint membership,
+pairwise disjointness, and coverage by the three regions.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem endpoint_disjoint_cover_at_edge
+    (h : NormalEdgeBlockingHypotheses ι G) (e : Edge G) :
+    e.1.1 ∈ h.red e ∧ e.1.2 ∈ h.blue e ∧ Disjoint (h.red e) (h.blue e) ∧
+      Disjoint (h.red e) (h.complement e) ∧
+      Disjoint (h.blue e) (h.complement e) ∧
+      h.red e ∪ h.blue e ∪ h.complement e = Finset.univ :=
+  (h.blockingData e).endpoint_disjoint_cover
 
 end NormalEdgeBlockingHypotheses
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3166,21 +3166,32 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{theorem}[Injectivity supplied by normal edge blocking]%
     \label{thm:peps_normalEdgeBlockingHypotheses_injectiveChain}
     \lean{TNLean.PEPS.NormalEdgeBlockingData.injective_chain}
+    \lean{TNLean.PEPS.NormalEdgeBlockingData.endpoint_disjoint_cover}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.ofBlockingData}
+    \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.ofBlockingData_blockingData}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.injective_chain_at_edge}
+    \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.endpoint_disjoint_cover_at_edge}
     \leanok
     \uses{def:peps_normalEdgeBlockingHypotheses}
     A family of one-edge blocking data determines the normal edge-blocking
-    hypotheses.  Conversely, for every edge, the normal edge-blocking
-    hypotheses supply the corresponding one-edge datum and hence three
-    injective regions: the red region, the blue region, and the complementary
-    region.
+    hypotheses.  If $H$ is assembled from the family $d_e$, then the one-edge
+    datum that $H$ associates with $e$ is $d_e$.  Conversely, for every edge,
+    the normal edge-blocking hypotheses supply the corresponding one-edge
+    datum.  Write the endpoints of $e$ as $u_e<v_e$ in the canonical vertex
+    ordering.  If the three regions are $R_e$, $B_e$, and $C_e$, then
+    \[
+        u_e \in R_e,\qquad v_e \in B_e,\qquad
+        R_e\cap B_e=R_e\cap C_e=B_e\cap C_e=\varnothing,\qquad
+        R_e\cup B_e\cup C_e=V,
+    \]
+    and the underlying PEPS tensor is injective on $R_e$, $B_e$, and $C_e$.
 \end{theorem}
 \begin{proof}\leanok
-    The construction maps each field of the one-edge datum to the corresponding
-    field of the uniform hypotheses.  The injectivity statement is exactly the
-    injectivity part of those hypotheses.
+    The construction sends each assumption in the one-edge datum to the
+    matching assumption in the uniform hypotheses.  The displayed endpoint,
+    disjointness, coverage, and injectivity statements are exactly the
+    corresponding assumptions of the one-edge datum.
 \end{proof}
 
 \begin{definition}[Normal one-site separation hypotheses]%


### PR DESCRIPTION
### Motivation

- Issue #2004 is assembling the normal PEPS square-lattice blocking route from MGRPG+18, Section 3.
- In the proof of Theorem 3, an edge is surrounded by three injective regions: the red region, the blue region, and the complement.
- Downstream arguments need the endpoint membership, pairwise disjointness, covering identity, and injectivity hypotheses as one named geometric package.

### Description

- Adds `NormalEdgeBlockingData.endpoint_disjoint_cover`. For an edge $e$ with ordered endpoints $u_e<v_e$ and regions $R_e,B_e,C_e$, it packages
  $$
    u_e\in R_e,\qquad v_e\in B_e,\qquad
    R_e\cap B_e=R_e\cap C_e=B_e\cap C_e=\varnothing,\qquad
    R_e\cup B_e\cup C_e=V.
  $$
- Adds the round-trip lemma `NormalEdgeBlockingHypotheses.ofBlockingData_blockingData`, stating that when $H$ is assembled from the family $d_e$, the one-edge datum that $H$ associates with $e$ is $d_e$.
- Adds `NormalEdgeBlockingHypotheses.endpoint_disjoint_cover_at_edge`, the uniform version for every edge.
- Updates the Chapter 13a blueprint theorem to state these formulas explicitly, to avoid the undefined notation $e_-,e_+$, to record the endpoint order $u_e<v_e$, and to phrase injectivity as a property of the underlying PEPS tensor on $R_e$, $B_e$, and $C_e$.

### Testing

- `lake build TNLean.PEPS.NormalEdgeBlockingData`
- `lake build TNLean.PEPS.NormalEdgeBlockingTranslated`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/PEPS/NormalEdgeBlockingData.lean blueprint/src/chapter/ch13a_peps_ft.tex --diff-base origin/main`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch13a_peps_ft.tex`
- `PATH=/tmp/tnlean-blueprint-venv/bin:$PATH leanblueprint web`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- touched-file line-length and proof-integrity scans

---
Addresses #2004