### PR TITLE
feat(PEPS): formalize union contraction chain

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -364,6 +364,7 @@ import TNLean.Channel.Determinant
 -- PEPS (exploratory)
 import TNLean.PEPS.Defs
 import TNLean.PEPS.InjectiveRegion
+import TNLean.PEPS.InjectiveRegionContraction
 import TNLean.PEPS.VirtualInsertion
 import TNLean.PEPS.SingletonRegion
 import TNLean.PEPS.Blocking

--- a/TNLean/PEPS/InjectiveRegionContraction.lean
+++ b/TNLean/PEPS/InjectiveRegionContraction.lean
@@ -1,0 +1,88 @@
+import Mathlib.Algebra.Module.Submodule.Ker
+import Mathlib.Data.Complex.Basic
+
+/-!
+# Contraction chain for the union of injective PEPS regions
+
+This file records the linear-algebra kernel argument in the proof that the
+union of two injective PEPS regions is injective.
+
+For two regions $A$ and $B$, write the four parts as
+$P_0=A\setminus B$, $P_1=A\cap B$, $P_2=B\setminus A$, and
+$P_3=(A\cup B)^c$. The source proof starts with a boundary tensor $X$ on
+$P_3$ satisfying $\mathcal C_{\{0,1,2\}}(X)=0$. Injectivity of
+$A=P_0\cup P_1$, contraction with the tensor over $P_1$, and injectivity of
+$B=P_1\cup P_2$ give the chain
+$\mathcal C_{\{0,1,2\}}(X)=0 \Rightarrow \mathcal C_{\{2\}}(X)=0
+\Rightarrow \mathcal C_{\{1,2\}}(X)=0 \Rightarrow X=0$.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, Lemma lem:injective_union](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+/-- The contraction-chain data used in the proof that $A\cup B$ is injective.
+
+Here `K` is the boundary space for the outside region
+$P_3=(A\cup B)^c$. The three maps are the contractions
+$\mathcal C_{\{0,1,2\}}$, $\mathcal C_{\{2\}}$, and
+$\mathcal C_{\{1,2\}}$ which occur in the source proof.
+
+Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union, lines
+1324--1404 of `Papers/1804.04964/paper_normal.tex`. -/
+structure InjectiveUnionContractionChain
+    (K E012 E2 E12 : Type*) [AddCommGroup K] [Module ℂ K]
+    [AddCommGroup E012] [Module ℂ E012] [AddCommGroup E2] [Module ℂ E2]
+    [AddCommGroup E12] [Module ℂ E12] where
+  /-- The contraction $\mathcal C_{\{0,1,2\}}$ over the three inside pieces. -/
+  contraction012 : K →ₗ[ℂ] E012
+  /-- The contraction $\mathcal C_{\{2\}}$ remaining after the inverse for $A$. -/
+  contraction2 : K →ₗ[ℂ] E2
+  /-- The contraction $\mathcal C_{\{1,2\}}$ after reinserting the overlap piece. -/
+  contraction12 : K →ₗ[ℂ] E12
+  /-- The inverse for $A=P_0\cup P_1$ sends
+  $\mathcal C_{\{0,1,2\}}(X)=0$ to $\mathcal C_{\{2\}}(X)=0$. -/
+  left_inverse_A_zero : ∀ X : K, contraction012 X = 0 → contraction2 X = 0
+  /-- Contracting with the tensor over $P_1=A\cap B$ sends
+  $\mathcal C_{\{2\}}(X)=0$ to $\mathcal C_{\{1,2\}}(X)=0$. -/
+  insert_overlap_zero : ∀ X : K, contraction2 X = 0 → contraction12 X = 0
+  /-- The inverse for $B=P_1\cup P_2$ sends
+  $\mathcal C_{\{1,2\}}(X)=0$ to $X=0$. -/
+  left_inverse_B_zero : ∀ X : K, contraction12 X = 0 → X = 0
+
+namespace InjectiveUnionContractionChain
+
+variable {K E012 E2 E12 : Type*} [AddCommGroup K] [Module ℂ K]
+variable [AddCommGroup E012] [Module ℂ E012] [AddCommGroup E2] [Module ℂ E2]
+variable [AddCommGroup E12] [Module ℂ E12]
+
+/-- The contraction chain gives a zero kernel for
+$\mathcal C_{\{0,1,2\}}$.
+
+Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union, lines
+1324--1404. The proof is exactly the displayed implication chain
+$\mathcal C_{\{0,1,2\}}(X)=0 \Rightarrow \mathcal C_{\{2\}}(X)=0
+\Rightarrow \mathcal C_{\{1,2\}}(X)=0 \Rightarrow X=0$. -/
+theorem union_contraction_ker_eq_bot
+    (c : InjectiveUnionContractionChain K E012 E2 E12) :
+    LinearMap.ker c.contraction012 = ⊥ := by
+  rw [LinearMap.ker_eq_bot']
+  intro X hX
+  exact c.left_inverse_B_zero X
+    (c.insert_overlap_zero X (c.left_inverse_A_zero X hX))
+
+/-- Equivalently, the contraction $\mathcal C_{\{0,1,2\}}$ is injective. -/
+theorem union_contraction_injective
+    (c : InjectiveUnionContractionChain K E012 E2 E12) :
+    Function.Injective c.contraction012 :=
+  LinearMap.ker_eq_bot.mp c.union_contraction_ker_eq_bot
+
+end InjectiveUnionContractionChain
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2267,11 +2267,59 @@ injective and normal PEPS, following Theorems~2 and~3 of
     intersection, together with the reconstruction of $A\cup B$.
 \end{proof}
 
+\begin{definition}[Contraction chain for the union injectivity proof]%
+    \label{def:peps_injectiveUnionContractionChain}
+    \lean{TNLean.PEPS.InjectiveUnionContractionChain}
+    \leanok
+    Let $K$, $E_{012}$, $E_2$, and $E_{12}$ be complex vector spaces. A
+    contraction chain for the proof of \cite[Section~3]{Molnar2018NormalPEPS}
+    consists of three linear maps
+    $\mathcal C_{\{0,1,2\}}:K\to E_{012}$,
+    $\mathcal C_{\{2\}}:K\to E_2$, and
+    $\mathcal C_{\{1,2\}}:K\to E_{12}$, together with the three implications
+    used in Lemma~\ref{lem:peps_injectiveRegion_union_contractionChain}.
+\end{definition}
+
+\begin{lemma}[Kernel criterion for the union contraction chain]%
+    \label{lem:peps_injectiveRegion_union_contractionChain}
+    \lean{TNLean.PEPS.InjectiveUnionContractionChain.union_contraction_ker_eq_bot}
+    \lean{TNLean.PEPS.InjectiveUnionContractionChain.union_contraction_injective}
+    \leanok
+    \uses{def:peps_injectiveUnionContractionChain}
+    Let $P_0=A\setminus B$, $P_1=A\cap B$, $P_2=B\setminus A$, and
+    $P_3=(A\cup B)^c$. Let $K$ be the boundary vector space attached to
+    $P_3$, and let
+    $\mathcal C_{\{0,1,2\}}:K\to E_{012}$,
+    $\mathcal C_{\{2\}}:K\to E_2$, and
+    $\mathcal C_{\{1,2\}}:K\to E_{12}$ be the three contraction maps in the
+    proof of \cite[Section~3]{Molnar2018NormalPEPS}. If
+    \[
+        \mathcal C_{\{0,1,2\}}(X)=0
+        \Longrightarrow \mathcal C_{\{2\}}(X)=0,\qquad
+        \mathcal C_{\{2\}}(X)=0
+        \Longrightarrow \mathcal C_{\{1,2\}}(X)=0,
+    \]
+    and
+    $\mathcal C_{\{1,2\}}(X)=0\Longrightarrow X=0$, then
+    $\ker \mathcal C_{\{0,1,2\}}=\{0\}$.
+\end{lemma}
+\begin{proof}\leanok
+    For $X\in K$ with $\mathcal C_{\{0,1,2\}}(X)=0$, apply the three
+    implications in sequence:
+    \[
+        \mathcal C_{\{0,1,2\}}(X)=0
+        \Longrightarrow \mathcal C_{\{2\}}(X)=0
+        \Longrightarrow \mathcal C_{\{1,2\}}(X)=0
+        \Longrightarrow X=0.
+    \]
+\end{proof}
+
 \begin{lemma}[Union of injective regions]%
     \label{lem:peps_injectiveRegion_union}
     \notready
     \uses{def:IsVertexInjective, lem:peps_regionUnionDecomposition_identities,
-        lem:peps_regionUnionDecomposition_disjoint}
+        lem:peps_regionUnionDecomposition_disjoint,
+        lem:peps_injectiveRegion_union_contractionChain}
     Let $V$ be a finite vertex set. Write $\operatorname{inj}(R)$ for the
     assertion that the PEPS tensor blocked to the region $R\subseteq V$ is
     injective. For two possibly overlapping regions $A,B\subseteq V$,


### PR DESCRIPTION
Advances #1374.

## Mathematical Content

This PR isolates the linear-algebra step in MGRPG+18, Section 3, Lemma `injective_union` (`Papers/1804.04964/paper_normal.tex`, lines 1324--1404).

For the four regions $P_0=A\setminus B$, $P_1=A\cap B$, $P_2=B\setminus A$, and $P_3=(A\cup B)^c$, it adds `TNLean.PEPS.InjectiveUnionContractionChain` with contraction maps

$$
\mathcal C_{\{0,1,2\}},\qquad \mathcal C_{\{2\}},\qquad \mathcal C_{\{1,2\}}.
$$

The formal theorem proves that the source proof's implication chain

$$
\mathcal C_{\{0,1,2\}}(X)=0
\Longrightarrow \mathcal C_{\{2\}}(X)=0
\Longrightarrow \mathcal C_{\{1,2\}}(X)=0
\Longrightarrow X=0
$$

gives $\ker \mathcal C_{\{0,1,2\}}=\{0\}$, equivalently injectivity of $\mathcal C_{\{0,1,2\}}$.

The blueprint now has a separate definition node for the contraction-chain data and a `\leanok` lemma for the kernel criterion. The not-ready source theorem `lem:peps_injectiveRegion_union` depends on this criterion. The construction of the PEPS contraction maps from blocked tensors remains open.

## Validation

- `lake build TNLean.PEPS.InjectiveRegionContraction`
- `lake build TNLean`
- `leanblueprint web`
- `git diff --check`
- `leanblueprint checkdecls` was attempted. It still fails on pre-existing missing declarations in Chapter 13a and other chapters; the declarations added here are not in that missing-declaration output.