### PR TITLE
doc(PEPS): mark edge-blocked injectivity not ready

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1324,7 +1324,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{theorem}[Edge blocking preserves injectivity]%
     \label{thm:peps_edgeBlockedThreeSiteInjective}
     \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective}
-    \leanok
+    \notready
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
         thm:peps_edgeBlockedThreeSiteInjective_all_of_region}
     For a tensor map or blocked tensor family $T$, write


### PR DESCRIPTION
### Motivation

- The blueprint entry `thm:peps_edgeBlockedThreeSiteInjective` in Chapter 13a was marked `\leanok`, but the corresponding Lean declaration `TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective` still contains `sorry`.
- A `\leanok` tag on an unproven declaration misrepresents the formalization status and should be corrected to `\notready` until the proof obligation is discharged.
- The remaining mathematical obligation is to prove injectivity of the blocked middle tensor $T_{A,V\setminus\{u,v\}}$ from vertex injectivity, following arXiv:1804.04964, Section 3, around `eq:block_to_mps`.

### Description

- Modified `blueprint/src/chapter/ch13a_peps_ft.tex`: changed the readiness tag of `thm:peps_edgeBlockedThreeSiteInjective` from `\leanok` to `\notready`.
- No Lean source files were changed.
- The proof sketch — injectivity of the three factors $T_{A,u}$, $T_{A,V\setminus\{u,v\}}$, $T_{A,v}$ when the PEPS is vertex-injective — remains attached to arXiv:1804.04964, Section 3. The unfilled step is the inversion argument establishing injectivity of $T_{A,V\setminus\{u,v\}}$ from vertex injectivity via finite-region blocking.

### Testing

- `leanblueprint web` completed with the repository's pre-existing plasTeX/bibliography warnings.
- `git diff --check` passed.
- No Lean build was run because this PR changes only a blueprint readiness tag. Lean CI (`lean_action_ci.yml`) validates any `.lean` changes automatically.

---
Addresses #1366