### PR TITLE
feat(PEPS): formalize finite kernel descent

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -365,6 +365,7 @@ import TNLean.Channel.Determinant
 import TNLean.PEPS.Defs
 import TNLean.PEPS.InjectiveRegion
 import TNLean.PEPS.InjectiveRegionContraction
+import TNLean.PEPS.FiniteKernelDescent
 import TNLean.PEPS.VirtualInsertion
 import TNLean.PEPS.SingletonRegion
 import TNLean.PEPS.Blocking

--- a/TNLean/PEPS/FiniteKernelDescent.lean
+++ b/TNLean/PEPS/FiniteKernelDescent.lean
@@ -1,0 +1,83 @@
+import Mathlib.Data.Finset.Basic
+
+/-!
+# Finite kernel descent for PEPS blocking arguments
+
+This file records the finite induction used in the proof that blocking a
+finite region of vertex-injective PEPS tensors preserves injectivity. In the
+source proof, after the edge blocking around $e=(u,v)$, the middle block is
+handled by repeatedly applying local left inverses inside
+$V\setminus\{u,v\}$.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, `eq:block_to_mps`](https://arxiv.org/abs/1804.04964)
+- `Papers/1804.04964/paper_normal.tex`, lines 979--1009.
+-/
+
+namespace TNLean
+namespace PEPS
+
+/-- A finite family of kernel conditions stable under deleting one vertex.
+
+In the edge-blocking proof, `kernelCondition S` is the assertion $K(S)$ that a
+family of boundary coefficients, with the virtual indices exposed at that
+stage, gives zero after the tensors in $S$ are contracted. The deletion
+implication is the step $K(S)\Rightarrow K(S\setminus\{j\})$ obtained from the
+local left inverse at $j$.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 979--1009. -/
+structure FiniteRegionKernelDescent (V : Type*) [DecidableEq V] where
+  /-- The kernel condition attached to a finite vertex set. -/
+  kernelCondition : Finset V → Prop
+  /-- The local deletion step $K(S)\Rightarrow K(S\setminus\{j\})$. -/
+  erase_vertex :
+    ∀ {S : Finset V} {j : V}, j ∈ S → kernelCondition S → kernelCondition (S.erase j)
+
+namespace FiniteRegionKernelDescent
+
+variable {V : Type*}
+
+/-- Iterating the one-vertex deletion implication gives $K(S)\Rightarrow
+K(\varnothing)$.
+
+This is the finite-induction part of the middle-block injectivity proof after
+`eq:block_to_mps`: once every local left inverse gives
+$K(S)\Rightarrow K(S\setminus\{j\})$, the kernel condition descends from the
+whole blocked region to the empty contraction.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 979--1009. -/
+lemma descend_to_empty [DecidableEq V] (c : FiniteRegionKernelDescent V) {S : Finset V} :
+    c.kernelCondition S → c.kernelCondition ∅ := by
+  induction S using Finset.induction with
+  | empty =>
+      intro h
+      exact h
+  | insert j S hj ih =>
+      intro h
+      have hErase : c.kernelCondition S := by
+        simpa [Finset.erase_insert, hj] using
+          c.erase_vertex (S := insert j S) (j := j) (by simp) h
+      exact ih hErase
+
+/-- A terminal consequence of $K(\varnothing)$ holds already at any finite
+region satisfying $K(S)$.
+
+In the PEPS blocking proof, the terminal consequence is that every boundary
+coefficient is zero after the empty contraction has been reached.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 979--1009. -/
+lemma descend [DecidableEq V] (c : FiniteRegionKernelDescent V) {S : Finset V} {Q : Prop}
+    (hEmpty : c.kernelCondition ∅ → Q) :
+    c.kernelCondition S → Q :=
+  fun hS => hEmpty (c.descend_to_empty hS)
+
+end FiniteRegionKernelDescent
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1321,6 +1321,41 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Apply the one-edge statement separately to each edge $e$.
 \end{proof}
 
+\begin{definition}[Finite kernel descent datum]%
+    \label{def:peps_finiteRegionKernelDescent}
+    \lean{TNLean.PEPS.FiniteRegionKernelDescent}
+    \leanok
+    Let $V$ be a vertex type with decidable equality. A finite kernel descent
+    datum is a predicate $K$ on finite subsets $S\subseteq V$ together with
+    implications
+    \[
+        j\in S \quad\Longrightarrow\quad K(S)\Longrightarrow K(S\setminus\{j\}).
+    \]
+    In the edge-blocking proof, $K(S)$ is the assertion that the boundary
+    coefficients $c_{\rho}$, with the virtual indices exposed at that stage,
+    give zero after the tensors in $S$ have been contracted.
+\end{definition}
+
+\begin{lemma}[Finite descent of kernel conditions]%
+    \label{lem:peps_finiteRegionKernelDescent}
+    \lean{TNLean.PEPS.FiniteRegionKernelDescent.descend_to_empty}
+    \lean{TNLean.PEPS.FiniteRegionKernelDescent.descend}
+    \leanok
+    \uses{def:peps_finiteRegionKernelDescent}
+    For a finite kernel descent datum and any finite $R\subseteq V$,
+    \[
+        K(R)\Longrightarrow K(\varnothing).
+    \]
+    More generally, if $K(\varnothing)\Longrightarrow Q$, then
+    $K(R)\Longrightarrow Q$.
+\end{lemma}
+\begin{proof}\leanok
+    Induct on the finite set $R$. If $R=\varnothing$, there is nothing to
+    prove. Otherwise write $R=S\cup\{j\}$ with $j\notin S$. The deletion
+    implication gives $K(R)\Longrightarrow K(S)$, and the induction hypothesis
+    gives $K(S)\Longrightarrow K(\varnothing)$.
+\end{proof}
+
 \begin{theorem}[Edge blocking preserves injectivity]%
     \label{thm:peps_edgeBlockedThreeSiteInjective}
     \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective}
@@ -1341,6 +1376,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 \begin{proof}
+    \uses{lem:peps_finiteRegionKernelDescent}
     The endpoint assertions are
     $\operatorname{inj}(T_{A,u})$ and $\operatorname{inj}(T_{A,v})$, which follow
     from vertex injectivity. The middle assertion is the remaining blocking
@@ -1361,8 +1397,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \[
         K(S)\Longrightarrow K(S\setminus\{j\}).
     \]
-    Hence $K(R)\Longrightarrow K(\varnothing)$. Since $T_{A,\varnothing}$ is
-    the empty contraction, $K(\varnothing)$ is $\forall \rho,\;c_{\rho}=0$.
+    The finite descent lemma gives $K(R)\Longrightarrow K(\varnothing)$.
+    Since $T_{A,\varnothing}$ is the empty contraction, $K(\varnothing)$ is
+    $\forall \rho,\;c_{\rho}=0$.
 \end{proof}
 
 \begin{theorem}[Local virtual insertion realized physically on either endpoint]%


### PR DESCRIPTION
### Motivation
- The edge-blocking proof in arXiv:1804.04964, Section 3, around `eq:block_to_mps` (`Papers/1804.04964/paper_normal.tex`, lines 979--1009) uses a finite induction on a set $R$ of interior vertices to descend from the kernel condition $K(R)$ to $K(\varnothing)$.
- Isolating this induction as an independent lemma keeps the proof of `thm:peps_edgeBlockedThreeSiteInjective` modular and makes the still-open instantiation step (local left inverses and boundary-index bookkeeping for $T_{A,V\setminus\{u,v\}}$) explicit.
- Addresses part of the formalization target for #1366.

### Description
- Adds `TNLean/PEPS/FiniteKernelDescent.lean` introducing the module `TNLean.PEPS.FiniteRegionKernelDescent`.
- The predicate `kernelCondition S` encodes the middle-block kernel condition $K(S)$ for a finite set $S$ of vertices.
- The one-step implication `erase_vertex` states that for $j \in S$, the condition $K(S)$ implies $K(S \setminus \{j\})$.
- The lemma `descend_to_empty` proves $K(R) \Rightarrow K(\varnothing)$ by finite induction on $R$.
- The lemma `descend` derives $K(R) \Rightarrow Q$ from the terminal assumption $K(\varnothing) \Rightarrow Q$.
- Registers the new module in `TNLean.lean`.
- Updates `blueprint/src/chapter/ch13a_peps_ft.tex` to record the descent lemma with `\leanok` and cites it inside the proof sketch for `thm:peps_edgeBlockedThreeSiteInjective` in place of an inline induction on $R$.
- Does not supply the tensor-level instantiation of `erase_vertex`; that step remains open.

### Testing
- `lake env lean TNLean/PEPS/FiniteKernelDescent.lean`
- `lake build TNLean.PEPS.FiniteKernelDescent`
- `lake build TNLean`
- `leanblueprint web`
- `git diff --check`
- Direct `lake exe checkdecls` on the three new declarations passed.

---
Addresses #1366