### PR TITLE
feat(PEPS): introduce kernel-descent datum for edge-middle injectivity

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.Blocking
+import TNLean.PEPS.FiniteKernelDescent
 import TNLean.PEPS.InjectiveRegion
 import TNLean.PEPS.SingletonRegion
 
@@ -165,6 +166,71 @@ Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
 def EdgeMiddleTensorInjective (A : Tensor G d) (e : Edge G) : Prop :=
   LinearIndependent ℂ (edgeMiddleTensorFamily (G := G) A e)
 
+/-- Boundary labels of the middle tensor in the edge-blocked three-site chain.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+abbrev EdgeMiddleBoundaryLabel (A : Tensor G d) (e : Edge G) : Type _ :=
+  ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e) ×
+    ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e)
+
+/-- Kernel-descent data for the edge-middle tensor.
+
+For a finitely supported coefficient family $c_{\rho}$, the source proof
+considers kernel conditions $K_c(S)$ for finite vertex sets $S$ in the middle
+region. The initial condition is the zero relation: for every middle physical
+index $\tau$,
+\[
+    \sum_{\rho} c_{\rho} T^{\rho}_{A,V\setminus\{u,v\}}(\tau)=0,
+\]
+which is $K_c(V\setminus\{u,v\})$. The deletion condition in
+the finite descent datum is $K_c(S)\Rightarrow K_c(S\setminus\{j\})$, obtained
+from the local left inverse at $j$. The terminal condition is
+$K_c(\varnothing)\Rightarrow c=0$.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+structure EdgeMiddleKernelDescentData (A : Tensor G d) (e : Edge G) where
+  /-- The finite kernel-descent datum attached to a coefficient family $c_{\rho}$.
+
+  Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+  `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+  kernelDescent :
+    (EdgeMiddleBoundaryLabel (G := G) A e →₀ ℂ) → FiniteRegionKernelDescent V
+  /-- A zero linear relation among the middle tensor vectors gives
+  $K_c(V\setminus\{u,v\})$.
+
+  Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+  `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+  initial_relation :
+    ∀ c : EdgeMiddleBoundaryLabel (G := G) A e →₀ ℂ,
+      Finsupp.linearCombination ℂ (edgeMiddleTensorFamily (G := G) A e) c = 0 →
+        (kernelDescent c).kernelCondition (edgeMiddleVertices e)
+  /-- The empty-region condition gives $c=0$.
+
+  Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+  `Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+  terminal_relation :
+    ∀ c : EdgeMiddleBoundaryLabel (G := G) A e →₀ ℂ,
+      (kernelDescent c).kernelCondition ∅ → c = 0
+
+namespace EdgeMiddleKernelDescentData
+
+/-- Kernel descent for the middle block gives injectivity of the edge-middle
+tensor family.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+theorem edgeMiddleTensorInjective {A : Tensor G d} {e : Edge G}
+    (hDescent : EdgeMiddleKernelDescentData (G := G) A e) :
+    EdgeMiddleTensorInjective (G := G) A e := by
+  rw [EdgeMiddleTensorInjective, linearIndependent_iff]
+  intro c hc
+  exact hDescent.terminal_relation c <|
+    (hDescent.kernelDescent c).descend_to_empty (hDescent.initial_relation c hc)
+
+end EdgeMiddleKernelDescentData
+
 /-- Injectivity of the three-site chain obtained by blocking around a
 chosen edge $e=(u,v)$.
 
@@ -245,6 +311,17 @@ theorem IsVertexInjective.edgeBlockedThreeSiteInjective_all_of_middle {A : Tenso
     (hMiddle : ∀ e : Edge G, EdgeMiddleTensorInjective (G := G) A e) :
     ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) A e :=
   fun e => hA.edgeBlockedThreeSiteInjective_of_middle e (hMiddle e)
+
+/-- Kernel descent for the middle block supplies the full edge-blocked
+three-site injectivity statement.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+theorem IsVertexInjective.edgeBlockedThreeSiteInjective_of_kernelDescent {A : Tensor G d}
+    (hA : IsVertexInjective A) (e : Edge G)
+    (hDescent : EdgeMiddleKernelDescentData (G := G) A e) :
+    EdgeBlockedThreeSiteInjective (G := G) A e :=
+  hA.edgeBlockedThreeSiteInjective_of_middle e hDescent.edgeMiddleTensorInjective
 
 /-- Region injectivity of the edge-middle block, together with the comparison to
 the edge-middle tensor family, gives the edge-blocked three-site injectivity

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1356,12 +1356,66 @@ injective and normal PEPS, following Theorems~2 and~3 of
     gives $K(S)\Longrightarrow K(\varnothing)$.
 \end{proof}
 
+\begin{definition}[Edge-middle kernel descent data]%
+    \label{def:peps_edgeMiddleKernelDescentData}
+    \lean{TNLean.PEPS.EdgeMiddleBoundaryLabel,
+        TNLean.PEPS.EdgeMiddleKernelDescentData}
+    \leanok
+    \uses{def:peps_edgeMiddleTensorFamily,
+        def:peps_finiteRegionKernelDescent}
+    Let $e=(u,v)$ and $M_e=V\setminus\{u,v\}$. An edge-middle kernel descent
+    datum is indexed by boundary labels $\rho$ consisting of the two residual
+    endpoint configurations. It assigns to every finitely supported coefficient
+    family $c=(c_{\rho})_{\rho}$ a finite kernel descent datum $K_c(S)$ such that
+    \[
+        \left(
+            \forall\tau,\;
+            \sum_{\rho}c_{\rho}\,
+                T_{A,M_e}^{\rho}(\tau)=0
+        \right)
+        \Longrightarrow K_c(M_e),
+    \]
+    and
+    \[
+        K_c(\varnothing)\Longrightarrow \forall\rho,\;c_{\rho}=0.
+    \]
+\end{definition}
+
+\begin{theorem}[Kernel descent gives edge-middle injectivity]%
+    \label{thm:peps_edgeMiddleTensorInjective_of_kernelDescent}
+    \lean{TNLean.PEPS.EdgeMiddleKernelDescentData.edgeMiddleTensorInjective,
+        TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_of_kernelDescent}
+    \leanok
+    \uses{def:peps_edgeMiddleKernelDescentData,
+        lem:peps_finiteRegionKernelDescent,
+        thm:peps_edgeBlockedThreeSiteInjective_of_middle}
+    Let $e=(u,v)$ and $M_e=V\setminus\{u,v\}$. If an edge-middle kernel descent
+    datum is given, then $T_{A,M_e}$ is injective. Consequently, if $A$ is
+    vertex-injective, the edge-blocked three-site chain at $e$ is injective.
+\end{theorem}
+\begin{proof}\leanok
+    Let $c=(c_{\rho})_{\rho}$ be a finite linear relation among the middle
+    tensor vectors:
+    \[
+        \forall\tau,\;
+        \sum_{\rho}c_{\rho}\,
+            T_{A,M_e}^{\rho}(\tau)=0.
+    \]
+    The initial part of the descent datum gives $K_c(M_e)$. The finite descent
+    lemma gives $K_c(M_e)\Longrightarrow K_c(\varnothing)$, and the terminal
+    part gives $\forall\rho,\;c_{\rho}=0$. Thus every finite relation is
+    trivial, which is $\operatorname{inj}(T_{A,M_e})$. Vertex injectivity at
+    $u$ and $v$ gives $\operatorname{inj}(T_{A,u})$ and
+    $\operatorname{inj}(T_{A,v})$; the edge-blocked three-site injectivity at
+    $e$ follows.
+\end{proof}
+
 \begin{theorem}[Edge blocking preserves injectivity]%
     \label{thm:peps_edgeBlockedThreeSiteInjective}
     \lean{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective}
     \leanok
     \uses{def:IsVertexInjective, def:peps_edgeBlockedThreeSiteInjective,
-        thm:peps_edgeBlockedThreeSiteInjective_all_of_region}
+        thm:peps_edgeMiddleTensorInjective_of_kernelDescent}
     For a tensor map or blocked tensor family $T$, write
     $\operatorname{inj}(T)$ for the assertion that $T$ is injective. If $A$
     is vertex-injective, then for every edge $e=(u,v)$,

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -175,6 +175,20 @@ Theorem can be proved in the manner of the paper.
   The all-edge conditional form
   is
   \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all}.
+  The finite induction on exposed middle vertices is separated as
+  \leanid{TNLean.PEPS.FiniteRegionKernelDescent}: for kernel conditions
+  $K_c(S)$ attached to a coefficient family $c=(c_\rho)_\rho$, the implications
+  $K_c(S)\Rightarrow K_c(S\setminus\{j\})$ imply
+  $K_c(M_e)\Rightarrow K_c(\varnothing)$. The edge-middle instance of this
+  coefficient argument is recorded by
+  \leanid{TNLean.PEPS.EdgeMiddleKernelDescentData}: the zero relation
+  $\sum_\rho c_\rho T_{A,M_e}^\rho(\tau)=0$ for every middle physical index
+  $\tau$ gives $K_c(M_e)$, and $K_c(\varnothing)$ gives $c_\rho=0$ for every
+  $\rho$. Consequently
+  \leanid{TNLean.PEPS.EdgeMiddleKernelDescentData.edgeMiddleTensorInjective}
+  proves $\operatorname{inj}(T_{A,M_e})$ from such a datum, and
+  \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_of_kernelDescent}
+  combines it with the endpoint injectivity assertions.
   The missing mathematical step is still the
   contraction theorem used in the paper: contracting vertex-injective tensors
   over that finite middle region gives an injective blocked tensor. The full


### PR DESCRIPTION
## Summary

This PR introduces the coefficient-level descent datum for the edge-middle tensor in the PEPS edge-blocking argument.

For an edge $e=(u,v)$ and $M_e=V\setminus\{u,v\}$, the new datum records the source-paper implication

$$
\left(\forall \tau,\; \sum_\rho c_\rho T_{A,M_e}^\rho(\tau)=0\right)\Rightarrow K_c(M_e),
\qquad
K_c(\varnothing)\Rightarrow \forall \rho,\; c_\rho=0,
$$

together with the one-vertex deletion descent $K_c(S)\Rightarrow K_c(S\setminus\{j\})$. The proved theorem then derives $\operatorname{inj}(T_{A,M_e})$ and combines it with endpoint injectivity to obtain the edge-blocked three-site injectivity statement under this descent datum.

Source reference: arXiv:1804.04964, Section 3 around `eq:block_to_mps`, especially `Papers/1804.04964/paper_normal.tex`, lines 981--1009.

This advances #1366 without claiming the remaining local-left-inverse calculation is complete.

## Local checks

- `lake env lean TNLean/PEPS/EdgeMiddlePhysical.lean`
- `lake build TNLean.PEPS.EdgeMiddlePhysical`
- direct `lake exe checkdecls` on the four new declarations
- `git diff --check`
- `cd blueprint && leanblueprint web`

The targeted Lean checks still report the pre-existing warning that `TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective` uses `sorry`. Whole-blueprint `leanblueprint checkdecls` still fails on pre-existing missing declarations outside this PR, so I used direct declaration checking for the new names.