### PR TITLE
feat(PEPS): add cardinal form of edge-middle injectivity

### DIFF
--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -171,6 +171,20 @@ theorem edgeMiddleVertices_card (e : Edge G) :
     card_erase_erase_univ (V := V) e.1.1 e.1.2 (edgeLeft_ne_edgeRight e)
 
 omit [DecidableRel G.Adj] in
+/-- If the ambient graph has more than two vertices, every edge has a nonempty
+middle region.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
+`Papers/1804.04964/paper_normal.tex`, lines 981--1009: the edge-blocking
+picture has a nonempty complementary middle block. -/
+theorem edgeMiddleVertices_nonempty_of_two_lt_card (e : Edge G)
+    (hcard : 2 < Fintype.card V) :
+    (edgeMiddleVertices e).Nonempty :=
+  Finset.card_pos.mp <| by
+    rw [edgeMiddleVertices_card]
+    exact Nat.sub_pos_of_lt hcard
+
+omit [DecidableRel G.Adj] in
 /-- Products over the vertex set factor through the three-region partition at
 any edge: the distinguished endpoints appear separately from the middle-region
 product. -/

--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -412,7 +412,7 @@ nonempty-region singleton theorem applies at every edge.
 Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
 `lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009
 and 1322--1404. -/
-theorem EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all_card_gt_two
+theorem EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all_two_lt_card
     {κ : RegionInjectivityData V} {A : Tensor G d}
     (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
     (hUnion : RegionInjectivityUnionClosure κ)
@@ -479,7 +479,7 @@ nonempty-middle theorem applies uniformly.
 Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
 `lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009
 and 1322--1404. -/
-theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_card_gt_two
+theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_two_lt_card
     {κ : RegionInjectivityData V} {A : Tensor G d}
     (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
     (hUnion : RegionInjectivityUnionClosure κ)

--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -403,6 +403,27 @@ theorem EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_of_singl
   hComparison.middle_tensor_injective e
     (hUnion.finset_injective_of_singletons hSingleton hA hMiddle)
 
+/-- Singleton comparison and finite union closure give every edge-middle tensor
+when the ambient graph has more than two vertices.
+
+For $2<|V|$, each middle region $V\setminus\{u,v\}$ is nonempty, so the
+nonempty-region singleton theorem applies at every edge.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
+`lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009
+and 1322--1404. -/
+theorem EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all_card_gt_two
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hSingleton : SingletonRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hA : IsVertexInjective A)
+    (hcard : 2 < Fintype.card V) :
+    ∀ e : Edge G, EdgeMiddleTensorInjective (G := G) A e :=
+  fun e =>
+    hComparison.edgeMiddleTensorInjective_of_singletons hUnion hSingleton hA e
+      (edgeMiddleVertices_nonempty_of_two_lt_card e hcard)
+
 /-- Singleton comparison and finite union closure give the edge-blocked
 three-site injectivity statement for an edge whose middle region is nonempty.
 
@@ -447,6 +468,28 @@ theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_
   fun e =>
     hComparison.edgeBlockedThreeSiteInjective_of_singletons
       hUnion hSingleton hA e (hMiddle e)
+
+/-- Singleton comparison and finite union closure give every edge-blocked
+three-site injectivity statement when the ambient graph has more than two
+vertices.
+
+For $2<|V|$, each edge has a nonempty middle region, and the preceding
+nonempty-middle theorem applies uniformly.
+
+Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
+`lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009
+and 1322--1404. -/
+theorem EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_card_gt_two
+    {κ : RegionInjectivityData V} {A : Tensor G d}
+    (hComparison : EdgeMiddleRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hSingleton : SingletonRegionInjectivityComparison (G := G) (d := d) κ A)
+    (hA : IsVertexInjective A)
+    (hcard : 2 < Fintype.card V) :
+    ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) A e :=
+  fun e =>
+    hComparison.edgeBlockedThreeSiteInjective_of_singletons
+      hUnion hSingleton hA e (edgeMiddleVertices_nonempty_of_two_lt_card e hcard)
 
 /-- Vertex injectivity is preserved by the edge blocking to a three-site MPS.
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1340,10 +1340,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_card_gt_two}
     \leanok
     \uses{thm:peps_edgeMiddleVertices_nonempty_of_two_lt_card,
-        thm:peps_edgeBlockedThreeSiteInjective_all_of_singletons}
-    If $2<|V|$, the nonempty-middle hypothesis holds for every edge
-    $e=(u,v)$. Thus singleton comparison, union closure, and vertex
-    injectivity give $\operatorname{inj}(T_{A,V\setminus\{u,v\}})$ and hence
+        thm:peps_edgeBlockedThreeSiteInjective_all_of_singletons,
+        def:peps_edgeMiddleRegionInjectivityComparison}
+    Assume singleton comparison, union closure for $\kappa$, the comparison
+    $\kappa(M_e)\Longrightarrow\operatorname{inj}(T_{A,M_e})$, and vertex
+    injectivity of $A$. If $2<|V|$, then
+    $V\setminus\{u,v\}\ne\varnothing$ for every edge $e=(u,v)$, and these
+    hypotheses give $\operatorname{inj}(T_{A,V\setminus\{u,v\}})$ and
     edge-blocked three-site injectivity at every edge.
 \end{theorem}
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1335,9 +1335,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{proof}
 
 \begin{theorem}[All edge-blocked chains from singleton regions, cardinal form]%
-    \label{thm:peps_edgeBlockedThreeSiteInjective_all_card_gt_two}
-    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all_card_gt_two}
-    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_card_gt_two}
+    \label{thm:peps_edgeBlockedThreeSiteInjective_all_two_lt_card}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all_two_lt_card}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_two_lt_card}
     \leanok
     \uses{thm:peps_edgeMiddleVertices_nonempty_of_two_lt_card,
         thm:peps_edgeBlockedThreeSiteInjective_all_of_singletons,

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -517,6 +517,19 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Every vertex is either $u$, $v$, or different from both.
 \end{proof}
 
+\begin{theorem}[Nonempty middle region from a cardinal bound]%
+    \label{thm:peps_edgeMiddleVertices_nonempty_of_two_lt_card}
+    \lean{TNLean.PEPS.edgeMiddleVertices_nonempty_of_two_lt_card}
+    \leanok
+    \uses{def:peps_edgeMiddleVertices}
+    If $2<|V|$, then for every edge $e=(u,v)$ the middle region
+    $V\setminus\{u,v\}$ is nonempty.
+\end{theorem}
+\begin{proof}\leanok
+    The middle region has cardinality $|V|-2$. Hence
+    $2<|V|$ gives $|V|-2>0$.
+\end{proof}
+
 \begin{theorem}[Product splitting at an edge]%
     \label{thm:peps_prod_univ_splitAtEdge}
     \lean{TNLean.PEPS.prod_univ_splitAtEdge}
@@ -1319,6 +1332,24 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{theorem}
 \begin{proof}\leanok
     Apply the one-edge statement separately to each edge $e$.
+\end{proof}
+
+\begin{theorem}[All edge-blocked chains from singleton regions, cardinal form]%
+    \label{thm:peps_edgeBlockedThreeSiteInjective_all_card_gt_two}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all_card_gt_two}
+    \lean{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_card_gt_two}
+    \leanok
+    \uses{thm:peps_edgeMiddleVertices_nonempty_of_two_lt_card,
+        thm:peps_edgeBlockedThreeSiteInjective_all_of_singletons}
+    If $2<|V|$, the nonempty-middle hypothesis holds for every edge
+    $e=(u,v)$. Thus singleton comparison, union closure, and vertex
+    injectivity give $\operatorname{inj}(T_{A,V\setminus\{u,v\}})$ and hence
+    edge-blocked three-site injectivity at every edge.
+\end{theorem}
+\begin{proof}\leanok
+    For each $e=(u,v)$, Theorem~\ref{thm:peps_edgeMiddleVertices_nonempty_of_two_lt_card}
+    gives $V\setminus\{u,v\}\ne\varnothing$. Apply the preceding all-edge
+    singleton theorem.
 \end{proof}
 
 \begin{definition}[Finite kernel descent datum]%

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -97,10 +97,10 @@ reindexing needed for the identity-insertion specialization. The current Lean
 layer includes the corresponding middle-tensor reindexing theorem
 \leanid{TNLean.PEPS.edgeMiddleWeight_eq_edgeOpenMiddleWeight}. The diagonal
 summand has also been isolated in
-\leanid{TNLean.PEPS.edgeInsertedCoeff_identity_diagonal_summand}. The
-pointwise off-diagonal vanishing is recorded as
-\leanid{TNLean.PEPS.edgeInsertedCoeff_identity_offDiagonal_summand}; what
-remains is to use
+\leanid{TNLean.PEPS.edgeInsertedCoeff_identity_diagonal_summand}, and
+\leanid{TNLean.PEPS.edgeInsertedCoeff_identity_offDiagonal_summand} records the
+pointwise off-diagonal vanishing. The full identity-insertion specialization is
+\leanid{TNLean.PEPS.edgeInsertedCoeff_identity}; its proof uses
 \leanid{TNLean.PEPS.edgeBoundaryConfigEquivDiagonalInsertedBoundaryConfig} to
 reindex the finite inserted-boundary sum along the diagonal.
 
@@ -110,17 +110,6 @@ The following statements are still needed before the injective PEPS Fundamental
 Theorem can be proved in the manner of the paper.
 
 \begin{enumerate}
-\item The identity matrix coefficient must be used to collapse the two inserted
-  bond indices to the diagonal. The diagonal summand theorem
-  \path{thm:peps_edgeInsertedCoeff_identity_diagonal_summand} and the
-  off-diagonal summand theorem
-  \path{thm:peps_edgeInsertedCoeff_identity_offDiagonal_summand} reduce this to
-  the diagonal equivalence
-  \path{def:peps_edgeBoundaryConfigEquivDiagonalInsertedBoundaryConfig} and the
-  finite diagonal reindexing theorem
-  \path{thm:peps_edgeInsertedCoeff_identity}, identifying the matrix-insertion
-  formalism with the ordinary three-block contraction when no nontrivial matrix
-  is inserted.
 \item Vertex injectivity must be shown to pass to the edge-blocked three-site
   object. This is the formal version of the paper's assertion that the
   regrouped MPS is injective. The middle physical index for this regrouped
@@ -154,7 +143,7 @@ Theorem can be proved in the manner of the paper.
   applying this to all edges satisfying $M_e\ne\varnothing$ gives
   \path{thm:peps_edgeBlockedThreeSiteInjective_all_of_singletons}.
   The graph-cardinality variant
-  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_card_gt_two}
+  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_two_lt_card}
   packages the common case $2<|V|$: since $|M_e|=|V|-2>0$ for every edge,
   the nonempty-middle hypothesis is automatic.
   Vertex injectivity supplies the two endpoint assertions by

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -120,7 +120,7 @@ Theorem can be proved in the manner of the paper.
   finite diagonal reindexing theorem
   \path{thm:peps_edgeInsertedCoeff_identity}, identifying the matrix-insertion
   formalism with the ordinary three-block contraction when no nontrivial matrix
-  is inserted. This remaining finite-sum step is tracked by issue~\#1372.
+  is inserted.
 \item Vertex injectivity must be shown to pass to the edge-blocked three-site
   object. This is the formal version of the paper's assertion that the
   regrouped MPS is injective. The middle physical index for this regrouped
@@ -153,6 +153,10 @@ Theorem can be proved in the manner of the paper.
   \path{thm:peps_edgeBlockedThreeSiteInjective_of_singletons}, and
   applying this to all edges satisfying $M_e\ne\varnothing$ gives
   \path{thm:peps_edgeBlockedThreeSiteInjective_all_of_singletons}.
+  The graph-cardinality variant
+  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_card_gt_two}
+  packages the common case $2<|V|$: since $|M_e|=|V|-2>0$ for every edge,
+  the nonempty-middle hypothesis is automatic.
   Vertex injectivity supplies the two endpoint assertions by
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective}
   and, for all edges at once, by
@@ -276,8 +280,8 @@ It is meant to prevent the proof from drifting away from the source argument.
   conditional bridge from middle-region injectivity is
   \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all}.
 \item Identity insertion on the chosen bond:
-  \path{thm:peps_edgeInsertedCoeff_identity} is reduced to finite diagonal
-  reindexing, tracked by issue~\#1372.
+  \path{thm:peps_edgeInsertedCoeff_identity} is formalized by finite diagonal
+  reindexing.
 \item Lemma \path{inj_isomorph}, $X\mapsto O_1,O_2$:
   \path{thm:peps_virtualInsertionPhysicalRealization} formalizes the endpoint
   realization, and


### PR DESCRIPTION
### Motivation
- The PEPS edge-blocking route (arXiv:1804.04964, Section 3, `eq:block_to_mps`) requires
  the middle region $M_e = V \setminus \{u, v\}$ to be non-empty for every edge $e = (u, v)$.
  In the finite-graph case with $|V| > 2$ this holds automatically, but callers previously
  had to supply a per-edge non-emptiness hypothesis for every edge.
- Continues formalization of the PEPS edge-blocking route; see #1366.

### Description
- `TNLean/PEPS/Blocking.lean`: adds `edgeMiddleVertices_nonempty_of_two_lt_card`, which
  derives $M_e \ne \varnothing$ from the cardinality bound $2 < |V|$.
- `TNLean/PEPS/EdgeMiddlePhysical.lean`: adds
  `EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all_two_lt_card` and
  `EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_two_lt_card`,
  packaging the cardinality step into the all-edge injectivity API.
- `blueprint/src/chapter/ch13a_peps_ft.tex` and
  `docs/paper-gaps/peps_injective_ft_section3_route.tex`: updated blueprint entry and
  paper-gap note for the new results.
  Source: arXiv:1804.04964, Section 3, lines 981--1009 of `Papers/1804.04964/paper_normal.tex`;
  union-closure input from `lem:injective_union`, lines 1322--1404.
- The proof of `IsVertexInjective.edgeBlockedThreeSiteInjective` (the source-paper
  finite-region contraction theorem, the main goal of #1366) is not part of this PR.

### Testing
- `lake build TNLean.PEPS.EdgeMiddlePhysical` passes.
- `git diff --check` passes.
- `leanblueprint checkdecls` does not report the new declarations as missing (pre-existing
  missing-declaration failures are unrelated to this PR).
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
Addresses #1366