### PR TITLE
doc(readme): sync project name and examples row

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ import.  The main source tree is organized as follows.
 | `TNLean/MPS/Irreducible` | Fixed-point projections, Form II reductions, scalar fixed points, adjoint irreducibility, and periodic-blocking infrastructure for irreducible blocks. |
 | `TNLean/MPS/ParentHamiltonian` | Parent Hamiltonians, local projectors, ground spaces, intersection and wrapping-window arguments, commuting cases, and martingale estimates. |
 | `TNLean/MPS/MPDO`, `TNLean/MPS/RFP` | MPDO/LPDO foundations, canonical-form and zero-correlation-length predicates, pure RFP structures, and structural bridges. |
+| `TNLean/MPS/Examples` | Example tensors and state families, including AKLT, even-parity, GHZ, and $\mathbb{Z}/2$ examples. |
 | `TNLean/Wielandt` | Quantum Wielandt span growth, rank-one constructions, rectangular span, primitivity equivalences, and paper-facing endpoints. |
 | `TNLean/PEPS` | PEPS definitions, virtual insertions, identity-edge insertions, blocking, local gauge transformations, and the injective PEPS theorem frontier. |
 | `TNLean/PiAlgebra` | Algebraic Fundamental-Theorem variants and block-separation statements. |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,7 +1,7 @@
-# Contributing to MPSLean
+# Contributing to TNLean
 
 This document codifies the conventions for pull requests, issues, code review,
-Lean style, and CI automation used in the MPSLean project.
+Lean style, and CI automation used in the TNLean project.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Closes #2130.
- `docs/CONTRIBUTING.md` still used the old project name `MPSLean` in its title and opening sentence.
- `TNLean.lean` imports the MPS examples modules, but the root README module table did not list `TNLean/MPS/Examples`.

### Description
- Renames the stale `MPSLean` references in `docs/CONTRIBUTING.md` to `TNLean`.
- Adds a `TNLean/MPS/Examples` row to the README module table, listing the AKLT, even-parity, GHZ, and $\mathbb{Z}/2$ examples.

### Testing
- `git diff --check` passes.
- `rg -n "MPSLean|TNLean/MPS/Examples|TNLean.MPS.Examples" docs/CONTRIBUTING.md README.md TNLean.lean` confirms the stale name is gone and the README row matches the imported examples.