### PR TITLE
feat(PEPS): expose translated edge cover data

### DIFF
--- a/TNLean/PEPS/NormalEdgeBlockingTranslated.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingTranslated.lean
@@ -489,6 +489,28 @@ theorem injective_chain
       κ.IsInjective ((w.blockingDatum h hUnion).complement) :=
   (w.blockingDatum h hUnion).injective_chain
 
+/-- A translated edge window supplies endpoint membership, pairwise
+disjointness, and coverage by its three blocking regions.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem endpoint_disjoint_cover
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    {e : Edge (squareLatticeGraph width height)}
+    (w : NormalSquareTranslatedEdgeWindow e)
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) :
+    e.1.1 ∈ (w.blockingDatum h hUnion).red ∧
+      e.1.2 ∈ (w.blockingDatum h hUnion).blue ∧
+      Disjoint ((w.blockingDatum h hUnion).red) ((w.blockingDatum h hUnion).blue) ∧
+      Disjoint ((w.blockingDatum h hUnion).red)
+        ((w.blockingDatum h hUnion).complement) ∧
+      Disjoint ((w.blockingDatum h hUnion).blue)
+        ((w.blockingDatum h hUnion).complement) ∧
+      (w.blockingDatum h hUnion).red ∪ (w.blockingDatum h hUnion).blue ∪
+          (w.blockingDatum h hUnion).complement =
+        (Finset.univ : Finset (SquareLatticeVertex width height)) :=
+  (w.blockingDatum h hUnion).endpoint_disjoint_cover
+
 end NormalSquareTranslatedEdgeWindow
 
 /-- A translated horizontal window around a coordinate right edge.
@@ -774,6 +796,28 @@ theorem injective_chain
       κ.IsInjective ((d.blockingDatum h hUnion).complement) :=
   (d.blockingDatum h hUnion).injective_chain
 
+/-- Oriented margin-and-cover data supply endpoint membership, pairwise
+disjointness, and coverage by the three blocking regions.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem endpoint_disjoint_cover
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    {e : Edge (squareLatticeGraph width height)}
+    (d : NormalSquareEdgeMarginCover e)
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) :
+    e.1.1 ∈ (d.blockingDatum h hUnion).red ∧
+      e.1.2 ∈ (d.blockingDatum h hUnion).blue ∧
+      Disjoint ((d.blockingDatum h hUnion).red) ((d.blockingDatum h hUnion).blue) ∧
+      Disjoint ((d.blockingDatum h hUnion).red)
+        ((d.blockingDatum h hUnion).complement) ∧
+      Disjoint ((d.blockingDatum h hUnion).blue)
+        ((d.blockingDatum h hUnion).complement) ∧
+      (d.blockingDatum h hUnion).red ∪ (d.blockingDatum h hUnion).blue ∪
+          (d.blockingDatum h hUnion).complement =
+        (Finset.univ : Finset (SquareLatticeVertex width height)) :=
+  (d.blockingDatum h hUnion).endpoint_disjoint_cover
+
 end NormalSquareEdgeMarginCover
 
 /-- A choice of translated edge window for every edge assembles into the normal
@@ -849,6 +893,33 @@ theorem normalSquareEdgeBlockingHypotheses_injective_chain_of_marginCovers
       κ.IsInjective ((normalSquareEdgeBlockingHypotheses_of_marginCovers
         h hUnion data).complement e) :=
   (normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).injective_chain_at_edge e
+
+/-- The edge-blocking hypotheses assembled from oriented margin-and-cover data
+give endpoint membership, pairwise disjointness, and coverage at every edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem normalSquareEdgeBlockingHypotheses_endpoint_disjoint_cover_of_marginCovers
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareEdgeMarginCover.{edgeCoverUniverse} e)
+    (e : Edge (squareLatticeGraph width height)) :
+    e.1.1 ∈ (normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).red e ∧
+      e.1.2 ∈ (normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).blue e ∧
+      Disjoint ((normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).red e)
+        ((normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).blue e) ∧
+      Disjoint ((normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).red e)
+        ((normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).complement e) ∧
+      Disjoint ((normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).blue e)
+        ((normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).complement e) ∧
+      (normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).red e ∪
+          (normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).blue e ∪
+            (normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data).complement e =
+        (Finset.univ : Finset (SquareLatticeVertex width height)) :=
+  let H := normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data
+  H.endpoint_disjoint_cover_at_edge e
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3196,6 +3196,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.NormalSquareTranslatedEdgeWindow}
     \lean{TNLean.PEPS.NormalSquareTranslatedEdgeWindow.blockingDatum}
     \lean{TNLean.PEPS.NormalSquareTranslatedEdgeWindow.injective_chain}
+    \lean{TNLean.PEPS.NormalSquareTranslatedEdgeWindow.endpoint_disjoint_cover}
     \lean{TNLean.PEPS.normalSquareTranslatedEdgeWindow_rightEdge_margins}
     \lean{TNLean.PEPS.normalSquareTranslatedEdgeWindow_upEdge_margins}
     \lean{TNLean.PEPS.not_leftBoundaryRightEdge_window}
@@ -3226,6 +3227,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.NormalSquareEdgeMarginCover.window}
     \lean{TNLean.PEPS.NormalSquareEdgeMarginCover.blockingDatum}
     \lean{TNLean.PEPS.NormalSquareEdgeMarginCover.injective_chain}
+    \lean{TNLean.PEPS.NormalSquareEdgeMarginCover.endpoint_disjoint_cover}
     \lean{TNLean.PEPS.normalSquareEdgeMarginCover_rightEdge_bounds}
     \lean{TNLean.PEPS.normalSquareEdgeMarginCover_upEdge_bounds}
     \lean{TNLean.PEPS.not_leftBoundaryRightEdge_marginCover}
@@ -3253,8 +3255,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     square-lattice edge after identifying it with its coordinate right or
     upward representative.  The oriented margin-and-cover datum is the
     corresponding per-edge form of this remaining finite-geometry input; it
-    directly supplies the one-edge blocking datum and its three injective
-    regions.  The horizontal and vertical margin predicates name the coordinate
+    directly supplies the one-edge blocking datum, its three injective
+    regions, and the identities
+    $u_e\in R_e$, $v_e\in B_e$,
+    $R_e\cap B_e=R_e\cap C_e=B_e\cap C_e=\varnothing$, and
+    $R_e\cup B_e\cup C_e=V$.  The horizontal and vertical margin predicates
+    name the coordinate
     inequalities needed to place these two translated frames, and there are
     corresponding coordinate and oriented-edge window constructors that take
     these predicates directly.  On coordinate right and upward edges,
@@ -3277,6 +3283,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_of_marginCovers}
     \lean{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_blockingData_of_marginCovers}
     \lean{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_injective_chain_of_marginCovers}
+    \lean{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_endpoint_disjoint_cover_of_marginCovers}
     \lean{TNLean.PEPS.not_forall_normalSquareEdgeMarginCover_seven}
     \leanok
     \uses{def:peps_normalSquareTranslatedEdgeWindow,
@@ -3291,7 +3298,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     margin-and-cover data at every edge.  The one-edge datum recovered from the
     resulting hypotheses is the datum supplied by the corresponding
     margin-and-cover input, and the resulting hypotheses give the three
-    injective regions at every edge.  The current open rectangular $7\times7$
+    injective regions at every edge, together with
+    $u_e\in R_e$, $v_e\in B_e$,
+    $R_e\cap B_e=R_e\cap C_e=B_e\cap C_e=\varnothing$, and
+    $R_e\cup B_e\cup C_e=V$.  The current open rectangular $7\times7$
     model does not admit such margin-and-cover data for every edge, because
     the boundary edges above fail this interior criterion.
 \end{theorem}


### PR DESCRIPTION
### Motivation

- Addresses formalization obligation 3 from #2004: define the per-edge translated variants of the red ($R_e$), blue ($B_e$), and complementary ($C_e$) blocks, and prove endpoint containment, pairwise disjointness, and full vertex coverage.
- Follows arXiv:1804.04964, Section 3, proof of Theorem 3, `Papers/1804.04964/paper_normal.tex` lines 1475–1500: the three injective blocks around each edge satisfy $u_e \in R_e$, $v_e \in B_e$, pairwise disjointness, and $R_e \cup B_e \cup C_e = V$.

### Description

- `TNLean/PEPS/NormalEdgeBlockingTranslated.lean`: adds `endpoint_disjoint_cover` projections on `NormalSquareTranslatedEdgeWindow` and `NormalSquareEdgeMarginCover`, recording endpoint membership, pairwise disjointness, and full-vertex coverage for translated edge windows.
- Adds `normalSquareEdgeBlockingHypotheses_endpoint_disjoint_cover_of_marginCovers`, which assembles edge-blocking hypotheses from per-edge margin-cover instances; each delegation reduces to `NormalEdgeBlockingData` / `NormalEdgeBlockingHypotheses`.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: updates Chapter 13a tags and equations linking the new declarations for the normal square-lattice edge-blocking route.
- Scoped step toward #2004 (obligation 3); the finite window around every edge and the full issue remain open.

### Testing

- `lake env lean TNLean/PEPS/NormalEdgeBlockingTranslated.lean`
- `lake build TNLean.PEPS.NormalEdgeBlockingTranslated`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/PEPS/NormalEdgeBlockingTranslated.lean` returned no matches.
- `leanblueprint checkdecls` pre-existing failures on PEPS and parent-Hamiltonian declarations do not include the three new declarations.
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
Addresses #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin forwarding lemmas and blueprint tag updates on the formal normal edge-blocking route; no auth, runtime, or behavioral application changes.
> 
> **Overview**
> Exposes **endpoint membership**, **pairwise disjointness**, and **full-vertex coverage** for translated PEPS edge windows and oriented margin-cover data, mirroring the existing `injective_chain` wrappers.
> 
> Lean adds `endpoint_disjoint_cover` on `NormalSquareTranslatedEdgeWindow` and `NormalSquareEdgeMarginCover`, plus `normalSquareEdgeBlockingHypotheses_endpoint_disjoint_cover_of_marginCovers` for hypotheses built from per-edge margin covers (each delegates to `NormalEdgeBlockingData` / `NormalEdgeBlockingHypotheses`).
> 
> The Chapter 13a blueprint links the new declarations and states that margin-cover and window-based constructions supply \(u_e\in R_e\), \(v_e\in B_e\), disjointness, and \(R_e\cup B_e\cup C_e=V\) at every edge—not only the three injective regions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db87c9d58cfc7f73c4cde649ff848253ba149dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->