### PR TITLE
feat(MPS/MPDO): add PSD blocked RFP constructors

### DIFF
--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -211,6 +211,9 @@ def ofSALZCLAndCommutingForm
 PSD-corrected rank-one criterion for `T`, a commuting-form hypothesis, and MPO
 ZCL.
 
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 and Proposition 3to4,
+lines 1489--1505 and 1569--1593.
+
 **Local fix (PSD rank-one criterion):** this is the blocked-RFP version of
 `SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef`; the correction is recorded
 in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -46,9 +46,11 @@ once the remaining local-to-global implication has been formalized.
 * `MPOTensor.SimpleMPDOBlockedRFPData`
 * `MPOTensor.SimpleMPDOBlockedRFPData.ofEtaLocalStructure`
 * `MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure`
+* `MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructureOfPosSemidef`
 * `MPOTensor.structural_implies_rfp_blocked`
 * `MPOTensor.simple_mpdo_rfp_chain_of_etaLocalStructure`
 * `MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure`
+* `MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef`
 * `MPOTensor.simple_mpdo_rfp_chain`
 
 ## References
@@ -130,6 +132,42 @@ def ofSALZCL
   hTraceConst := hTraceConst
   rankOne := sal_zcl_implies_rank_one_T T hPrimitive hTrace hTraceConst hPF
 
+/-- Construct the local simple-MPDO structure from the Lemma C.3 hypotheses and
+the PSD-corrected Lemma C.4 rank-one criterion.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 and the corollary after
+it, lines 1489--1505.
+
+**Local fix (PSD rank-one criterion):** the source's primitive
+nonnegative-matrix inference at lines 1490--1498 is not valid as stated. This
+constructor uses the positive-semidefinite sufficient condition documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+def ofSALZCLOfPosSemidef
+    {dA dB dC n : ℕ}
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hPSD : T.PosSemidef)
+    (hTrace : Matrix.trace T = 1)
+    (hTraceConst : Matrix.TracePowersConstant T) :
+    SimpleMPDOLocalStructureData where
+  dA := dA
+  dB := dB
+  dC := dC
+  rhoABC := rhoABC
+  hRhoDM := hRhoDM
+  hSSA := hSSA
+  eta := sal_implies_eta_structure rhoABC hRhoDM hSSA
+  Tdim := n
+  T := T
+  hPrimitive := hPrimitive
+  hTrace := hTrace
+  hTraceConst := hTraceConst
+  rankOne :=
+    sal_zcl_implies_rank_one_T_of_posSemidef T hPrimitive hPSD hTrace hTraceConst
+
 end SimpleMPDOLocalStructureData
 
 /-- Auxiliary structure for the simple-MPDO blocked-RFP argument.
@@ -166,6 +204,30 @@ def ofSALZCLAndCommutingForm
     SimpleMPDOBlockedRFPData K where
   localData := SimpleMPDOLocalStructureData.ofSALZCL
     rhoABC hRhoDM hSSA T hPrimitive hTrace hTraceConst hPF
+  commutingForm := hCommuting
+  zcl := hZCL
+
+/-- Construct this structure from the local SAL--ZCL hypotheses, the
+PSD-corrected rank-one criterion for `T`, a commuting-form hypothesis, and MPO
+ZCL.
+
+**Local fix (PSD rank-one criterion):** this is the blocked-RFP version of
+`SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef`; the correction is recorded
+in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+def ofSALZCLAndCommutingFormOfPosSemidef
+    {dA dB dC n : ℕ}
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hPSD : T.PosSemidef)
+    (hTrace : Matrix.trace T = 1)
+    (hTraceConst : Matrix.TracePowersConstant T)
+    (hCommuting : HasCommutingForm K) (hZCL : IsZCL K) :
+    SimpleMPDOBlockedRFPData K where
+  localData := SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef
+    rhoABC hRhoDM hSSA T hPrimitive hPSD hTrace hTraceConst
   commutingForm := hCommuting
   zcl := hZCL
 
@@ -215,6 +277,38 @@ def ofSALZCLAndEtaLocalStructure
   ofEtaLocalStructure
     (SimpleMPDOLocalStructureData.ofSALZCL
       rhoABC hRhoDM hSSA T hPrimitive hTrace hTraceConst hPF)
+    hEta hZCL
+
+/-- Construct the blocked-RFP data from the local SAL--ZCL hypotheses, the
+PSD-corrected rank-one criterion for `T`, and the assembled `η`-local
+structure.
+
+References: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
+lines 1501--1505, and Proposition 3to4, lines 1571--1593.
+
+**Scope restriction:** this constructor still assumes `EtaLocalStructureData K`;
+it does not construct the translated bond operators from SAL. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`; that
+construction is tracked by issue #823.
+
+**Local fix (PSD rank-one criterion):** it uses the positive-semidefinite
+replacement for the matrix step in Lemma C.4, documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+def ofSALZCLAndEtaLocalStructureOfPosSemidef
+    {dA dB dC n : ℕ}
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hPSD : T.PosSemidef)
+    (hTrace : Matrix.trace T = 1)
+    (hTraceConst : Matrix.TracePowersConstant T)
+    (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    SimpleMPDOBlockedRFPData K :=
+  ofEtaLocalStructure
+    (SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef
+      rhoABC hRhoDM hSSA T hPrimitive hPSD hTrace hTraceConst)
     hEta hZCL
 
 /-- Commuting-form data together with MPO ZCL yield the GSNNCH-with-ZCL case of
@@ -323,5 +417,37 @@ theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure {K : MPOTensor d 
   simple_mpdo_rfp_chain_of_data
     (SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure
       rhoABC hRhoDM hSSA T hPrimitive hTrace hTraceConst hPF hEta hZCL)
+
+/-- The simple-MPDO RFP chain from local SAL--ZCL hypotheses, the
+PSD-corrected rank-one criterion for `T`, and the assembled eta-local
+nearest-neighbor product.
+
+References: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
+lines 1501--1505, and Proposition 3to4, lines 1571--1593.
+
+**Scope restriction:** this theorem assumes the assembled eta-local structure
+instead of deriving it from SAL. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`; the missing
+construction is tracked by issue #823.
+
+**Local fix (PSD rank-one criterion):** it uses the positive-semidefinite
+replacement for the matrix step in Lemma C.4, documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef
+    {K : MPOTensor d D} {dA dB dC n : ℕ}
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hPSD : T.PosSemidef)
+    (hTrace : Matrix.trace T = 1)
+    (hTraceConst : Matrix.TracePowersConstant T)
+    (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
+      IsRFP_MPDO_via_fusion K :=
+  simple_mpdo_rfp_chain_of_data
+    (SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructureOfPosSemidef
+      rhoABC hRhoDM hSSA T hPrimitive hPSD hTrace hTraceConst hEta hZCL)
 
 end MPOTensor

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2599,10 +2599,16 @@ the elementary trace-power identity for diagonal matrices.
 \begin{theorem}[Local simple-MPDO structure from SAL--ZCL hypotheses]
     \label{thm:simple_mpdo_local_structure_data_of_sal_zcl}
     \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCL}
+    \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef}
     \leanok
     \uses{def:simple_mpdo_local_structure_data, thm:sal_implies_eta_structure,
-        thm:sal_zcl_implies_rank_one_t}
-    The hypotheses of Lemmas C.3--C.4 determine the local simple-MPDO structure.
+        thm:sal_zcl_implies_rank_one_t, thm:psd_trace_powers_rank_one_t}
+    The hypotheses of Lemmas C.3--C.4 determine the local simple-MPDO
+    structure. There are two forms. The conditional form assumes the
+    rank-one implication for $T$. The corrected form assumes instead that
+    $T\ge 0$ as a matrix, with $\operatorname{tr}(T)=1$ and
+    $\operatorname{tr}(T^m)=1$ for every $m>0$, and then applies
+    Theorem~\ref{thm:psd_trace_powers_rank_one_t}.
 \end{theorem}
 
 \begin{definition}[Simple-MPDO blocked-RFP structure]
@@ -2619,11 +2625,15 @@ the elementary trace-power identity for diagonal matrices.
 \begin{theorem}[Blocked-RFP structure from SAL--ZCL and commuting form]
     \label{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_commuting_form}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndCommutingForm}
+    \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndCommutingFormOfPosSemidef}
     \leanok
     \uses{def:simple_mpdo_blocked_rfp_data,
         thm:simple_mpdo_local_structure_data_of_sal_zcl}
     The SAL--ZCL hypotheses together with a commuting-form witness determine
-    the simple-MPDO blocked-RFP structure.
+    the simple-MPDO blocked-RFP structure. In the PSD-corrected form, the
+    matrix input is $T\ge0$, $\operatorname{tr}(T)=1$, and
+    $\operatorname{tr}(T^m)=1$ for all $m>0$, rather than an abstract
+    Perron--Frobenius rank-one assumption for $T$.
 \end{theorem}
 
 \begin{theorem}[Blocked-RFP structure from $\eta$-local structure]
@@ -2647,6 +2657,7 @@ the elementary trace-power identity for diagonal matrices.
 \begin{theorem}[Blocked-RFP structure from SAL--ZCL and $\eta$-local structure]
     \label{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure}
+    \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructureOfPosSemidef}
     \leanok
     \uses{thm:simple_mpdo_local_structure_data_of_sal_zcl,
         thm:simple_mpdo_blocked_rfp_data_of_eta_local_structure}
@@ -2659,6 +2670,9 @@ the elementary trace-power identity for diagonal matrices.
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$ for all $i,j$.
     Then these data determine the simple-MPDO blocked-RFP structure for $K$.
+    In the PSD-corrected form, the conditional rank-one criterion is replaced
+    by $T\ge0$, $\operatorname{tr}(T)=1$, and
+    $\operatorname{tr}(T^m)=1$ for all $m>0$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2741,6 +2755,7 @@ the elementary trace-power identity for diagonal matrices.
 \begin{theorem}[Simple-MPDO RFP chain from SAL--ZCL and $\eta$-local structure]
     \label{thm:simple_mpdo_rfp_chain_of_sal_zcl_and_eta_local_structure}
     \lean{MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure}
+    \lean{MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef}
     \leanok
     \uses{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure,
         thm:simple_mpdo_rfp_chain_of_data}
@@ -2749,7 +2764,10 @@ the elementary trace-power identity for diagonal matrices.
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$. Then
     $K$ is GSNNCH with ZCL, admits a blocked fusion-isometry witness at size
-    $2$, and satisfies the transfer-map fusion formulation of MPDO RFP.
+    $2$, and satisfies the transfer-map fusion formulation of MPDO RFP. The
+    PSD-corrected form uses $T\ge0$ together with
+    $\operatorname{tr}(T^m)=1$ for all $m>0$ in place of the conditional
+    matrix rank-one hypothesis.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
### Motivation

- Lemma C.4 of CPGSV17a (arXiv:1606.00608, Appendix C.2, `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 1489–1505) and its corollary provide a route to rank-one factorisation of the auxiliary matrix $T$ from positive semidefiniteness plus trace constraints, distinct from the Perron–Frobenius route currently assumed in the conditional constructors.
- Proposition 3to4 of the same appendix (lines 1569–1593) constructs the blocked-RFP structure from SAL and ZCL via this PSD route.
- The paper-gap note `docs/paper-gaps/cpgsv17_pf_rank_one.tex` documents the divergence between the two routes; adding PSD-corrected constructors brings the formalization in line with the paper's proof strategy. Progress toward #823.

### Description

- `TNLean/MPS/MPDO/BlockedRFPConstruction.lean`: added four PSD-corrected entry points alongside the existing conditional SAL–ZCL blocked-RFP constructors:
  - `ofSALZCLOfPosSemidef` — local simple-MPDO structure from SAL, ZCL, and `T.PosSemidef`
  - `ofSALZCLAndCommutingFormOfPosSemidef` — blocked-RFP from SAL, ZCL, commuting form, and `T.PosSemidef`
  - `ofSALZCLAndEtaLocalStructureOfPosSemidef` — blocked-RFP from SAL, ZCL, `EtaLocalStructureData`, and `T.PosSemidef`
  - `simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef` — direct RFP-chain theorem for the SAL–ZCL plus η-local-structure route with PSD hypothesis
  - All new constructors derive rank-one for $T$ from `sal_zcl_implies_rank_one_T_of_posSemidef`; the assembled `EtaLocalStructureData K` hypothesis remains assumed, not constructed from SAL (the residual gap tracked by #823).
- `blueprint/src/chapter/ch02b_mpdo.tex`: added `\lean` tags and updated prose so both the Perron–Frobenius conditional form and the PSD-corrected form are visible for local structure, blocked-RFP construction, and the SAL–ZCL + η-local RFP chain.

### Testing

- `lake env lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean`
- `lake build TNLean.MPS.MPDO.BlockedRFPConstruction`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/MPDO/BlockedRFPConstruction.lean blueprint/src/chapter/ch02b_mpdo.tex --diff-base main --diff-head HEAD`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- Proof-integrity scan on the changed Lean file.
- `leanblueprint checkdecls` run; pre-existing failures on PEPS and parent-Hamiltonian declarations remain; the new MPDO declarations from this PR are not in the missing list.

---
Refs #823

> [!NOTE]
> **Low Risk**
> Additive Lean constructors and blueprint sync only; existing conditional APIs are unchanged and the new paths delegate to an already-proved PSD rank-one theorem.
> 
> **Overview**
> Adds **PSD-corrected** parallel entry points alongside the existing conditional SAL–ZCL blocked-RFP API in `BlockedRFPConstruction.lean`. New constructors and theorems (`ofSALZCLOfPosSemidef`, `ofSALZCLAndCommutingFormOfPosSemidef`, `ofSALZCLAndEtaLocalStructureOfPosSemidef`, and `simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef`) build the same local/blocked structures and RFP chain, but derive rank-one for the auxiliary matrix **T** from **`T.PosSemidef`** plus trace constraints via `sal_zcl_implies_rank_one_T_of_posSemidef`, instead of assuming `PrimitiveTracePowersConstantImpliesRankOne`.
> 
> Docstrings record the **Lemma C.4 paper-gap fix** (`docs/paper-gaps/cpgsv17_pf_rank_one.tex`) and unchanged scope: **`EtaLocalStructureData` is still assumed** (issue #823).
> 
> The MPDO blueprint (`ch02b_mpdo.tex`) gains matching `\lean` tags and prose so reviewers see **both** the conditional Perron–Frobenius form and the PSD-corrected form for local structure, blocked-RFP packaging, and the SAL–ZCL + η-local RFP chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f296d810523b6ea60b8981b7209b0c95a18c87d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean constructors and blueprint sync only; existing conditional APIs are unchanged and new paths delegate to an already-proved PSD rank-one theorem.
> 
> **Overview**
> Adds **parallel PSD-corrected entry points** next to the existing conditional SAL–ZCL blocked-RFP API in `BlockedRFPConstruction.lean`, without changing the old constructors.
> 
> New pieces build the same local / blocked structures and the **simple-MPDO RFP chain**, but obtain rank-one for the auxiliary matrix **T** from **`T.PosSemidef`** plus trace constraints via `sal_zcl_implies_rank_one_T_of_posSemidef`, instead of assuming `PrimitiveTracePowersConstantImpliesRankOne`. Covered names include `ofSALZCLOfPosSemidef`, `ofSALZCLAndCommutingFormOfPosSemidef`, `ofSALZCLAndEtaLocalStructureOfPosSemidef`, and `simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef`.
> 
> Docstrings point at the **Lemma C.4 paper-gap fix** (`docs/paper-gaps/cpgsv17_pf_rank_one.tex`). **`EtaLocalStructureData` is still assumed**, not built from SAL (issue #823).
> 
> `ch02b_mpdo.tex` gets matching `\lean` tags and prose so reviewers see **both** the Perron–Frobenius conditional route and the PSD-corrected route for local structure, blocked-RFP packaging, and the SAL–ZCL + η-local RFP chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d20f3f1af32b36ceace879e05c8f05ab689787f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->