### PR TITLE
feat(PEPS): add translated-window consequence lemmas for edge-blocking hypotheses

### DIFF
--- a/TNLean/PEPS/NormalEdgeBlockingTranslated.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingTranslated.lean
@@ -839,6 +839,75 @@ def normalSquareTranslatedEdgeBlockingHypotheses_of_windows
   NormalEdgeBlockingHypotheses.ofBlockingData fun e =>
     (windows e).blockingDatum h hUnion
 
+/-- The edge datum recovered from the hypotheses assembled from translated
+windows is the datum supplied by the chosen translated window at that edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem normalSquareTranslatedEdgeBlockingHypotheses_blockingData_of_windows
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (windows :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareTranslatedEdgeWindow.{edgeCoverUniverse} e)
+    (e : Edge (squareLatticeGraph width height)) :
+    (normalSquareTranslatedEdgeBlockingHypotheses_of_windows h hUnion windows).blockingData e =
+      (windows e).blockingDatum h hUnion := by
+  rfl
+
+/-- The edge-blocking hypotheses assembled from translated windows give the
+three injective regions at every edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem normalSquareTranslatedEdgeBlockingHypotheses_injective_chain_of_windows
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (windows :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareTranslatedEdgeWindow.{edgeCoverUniverse} e)
+    (e : Edge (squareLatticeGraph width height)) :
+    κ.IsInjective ((normalSquareTranslatedEdgeBlockingHypotheses_of_windows
+        h hUnion windows).red e) ∧
+      κ.IsInjective ((normalSquareTranslatedEdgeBlockingHypotheses_of_windows
+        h hUnion windows).blue e) ∧
+      κ.IsInjective ((normalSquareTranslatedEdgeBlockingHypotheses_of_windows
+        h hUnion windows).complement e) :=
+  (normalSquareTranslatedEdgeBlockingHypotheses_of_windows
+    h hUnion windows).injective_chain_at_edge e
+
+/-- The edge-blocking hypotheses assembled from translated windows give
+endpoint membership, pairwise disjointness, and coverage at every edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem normalSquareTranslatedEdgeBlockingHypotheses_endpoint_disjoint_cover_of_windows
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (windows :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareTranslatedEdgeWindow.{edgeCoverUniverse} e)
+    (e : Edge (squareLatticeGraph width height)) :
+    e.1.1 ∈ (normalSquareTranslatedEdgeBlockingHypotheses_of_windows h hUnion windows).red e ∧
+      e.1.2 ∈ (normalSquareTranslatedEdgeBlockingHypotheses_of_windows
+        h hUnion windows).blue e ∧
+      Disjoint ((normalSquareTranslatedEdgeBlockingHypotheses_of_windows h hUnion windows).red e)
+        ((normalSquareTranslatedEdgeBlockingHypotheses_of_windows h hUnion windows).blue e) ∧
+      Disjoint ((normalSquareTranslatedEdgeBlockingHypotheses_of_windows h hUnion windows).red e)
+        ((normalSquareTranslatedEdgeBlockingHypotheses_of_windows
+          h hUnion windows).complement e) ∧
+      Disjoint ((normalSquareTranslatedEdgeBlockingHypotheses_of_windows
+          h hUnion windows).blue e)
+        ((normalSquareTranslatedEdgeBlockingHypotheses_of_windows
+          h hUnion windows).complement e) ∧
+      (normalSquareTranslatedEdgeBlockingHypotheses_of_windows h hUnion windows).red e ∪
+          (normalSquareTranslatedEdgeBlockingHypotheses_of_windows h hUnion windows).blue e ∪
+            (normalSquareTranslatedEdgeBlockingHypotheses_of_windows
+              h hUnion windows).complement e =
+        (Finset.univ : Finset (SquareLatticeVertex width height)) :=
+  let H := normalSquareTranslatedEdgeBlockingHypotheses_of_windows h hUnion windows
+  H.endpoint_disjoint_cover_at_edge e
+
 /-- A choice of oriented margin-and-cover data for every edge assembles into
 the normal edge-blocking hypotheses.
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3280,6 +3280,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{theorem}[Construction from translated edge windows]%
     \label{thm:peps_normalSquareTranslatedEdgeBlockingHypotheses_of_windows}
     \lean{TNLean.PEPS.normalSquareTranslatedEdgeBlockingHypotheses_of_windows}
+    \lean{TNLean.PEPS.normalSquareTranslatedEdgeBlockingHypotheses_blockingData_of_windows}
+    \lean{TNLean.PEPS.normalSquareTranslatedEdgeBlockingHypotheses_injective_chain_of_windows}
+    \lean{TNLean.PEPS.%
+        normalSquareTranslatedEdgeBlockingHypotheses_endpoint_disjoint_cover_of_windows}
     \lean{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_of_marginCovers}
     \lean{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_blockingData_of_marginCovers}
     \lean{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_injective_chain_of_marginCovers}
@@ -3294,16 +3298,17 @@ injective and normal PEPS, following Theorems~2 and~3 of
     hypotheses.  This is the conditional construction;
     constructing such windows for all edges of the $7\times7$ lattice remains
     separate; the current open rectangular translated-window criterion does not
-    by itself supply such a family.  Equivalently, it is enough to supply the oriented
-    margin-and-cover data at every edge.  The one-edge datum recovered from the
-    resulting hypotheses is the datum supplied by the corresponding
-    margin-and-cover input, and the resulting hypotheses give the three
-    injective regions at every edge, together with
+    by itself supply such a family.  The one-edge datum recovered from the
+    resulting hypotheses is the datum supplied by the corresponding translated
+    window, and the resulting hypotheses give the three injective regions at
+    every edge, together with
     $u_e\in R_e$, $v_e\in B_e$,
     $R_e\cap B_e=R_e\cap C_e=B_e\cap C_e=\varnothing$, and
-    $R_e\cup B_e\cup C_e=V$.  The current open rectangular $7\times7$
-    model does not admit such margin-and-cover data for every edge, because
-    the boundary edges above fail this interior criterion.
+    $R_e\cup B_e\cup C_e=V$.  Equivalently, it is enough to supply the oriented
+    margin-and-cover data at every edge; the same recovered-datum, injectivity,
+    and disjoint-cover statements hold for that formulation.  The current open
+    rectangular $7\times7$ model does not admit such margin-and-cover data for
+    every edge, because the boundary edges above fail this interior criterion.
 \end{theorem}
 \begin{proof}\leanok
     Apply the general construction for one-edge blocking data to the datum

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3305,8 +3305,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $u_e\in R_e$, $v_e\in B_e$,
     $R_e\cap B_e=R_e\cap C_e=B_e\cap C_e=\varnothing$, and
     $R_e\cup B_e\cup C_e=V$.  Equivalently, it is enough to supply the oriented
-    margin-and-cover data at every edge; the same recovered-datum, injectivity,
-    and disjoint-cover statements hold for that formulation.  The current open
+    margin-and-cover data at every edge; the resulting hypotheses recover the
+    corresponding datum, give the same three injectivity conclusions, and give
+    the same endpoint, disjointness, and covering conclusions.  The current open
     rectangular $7\times7$ model does not admit such margin-and-cover data for
     every edge, because the boundary edges above fail this interior criterion.
 \end{theorem}


### PR DESCRIPTION
### Motivation

- Continues the formalization of the PEPS Fundamental Theorem (arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475–1500); see #2004.
- The assembled `NormalEdgeBlockingHypotheses` already contained the translated-window consequences implicitly in the construction; naming them makes the mathematical derivation explicit and allows the blueprint to point to specific declarations.
- Separates the translated-window formulation from the later margin-and-cover formulation in the blueprint entry.

### Description

- **`TNLean/PEPS/NormalEdgeBlockingTranslated.lean`** (modified): Adds named lemmas following `normalSquareTranslatedEdgeBlockingHypotheses_of_windows` showing that the assembled `NormalEdgeBlockingHypotheses` (a) recover the chosen edge datum, (b) give injectivity of the red, blue, and complementary regions at every edge, and (c) satisfy endpoint membership, pairwise disjointness, and full coverage — by delegating to the generic `NormalEdgeBlockingHypotheses` API.
- **`blueprint/src/chapter/ch13a_peps_ft.tex`** (modified): Updates the blueprint entry for "Construction from translated edge windows" with `\lean` links to the new declarations; reorders the prose to state translated-window consequences first, with the margin-and-cover formulation as an equivalent.

### Testing

- `lake env lean TNLean/PEPS/NormalEdgeBlockingTranslated.lean`
- `lake build TNLean.PEPS.NormalEdgeBlockingTranslated`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/PEPS/NormalEdgeBlockingTranslated.lean blueprint/src/chapter/ch13a_peps_ft.tex --diff-base main --diff-head HEAD`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/PEPS/NormalEdgeBlockingTranslated.lean || true`
- `leanblueprint checkdecls` fails only on pre-existing missing declarations; the new PEPS declarations in this PR are not among the missing names.

---
Refs #2004

> [!NOTE]
> **Low Risk**
> Proof-only `rfl`/delegation lemmas and blueprint sync; no runtime, auth, or behavioral code changes.
>
> **Overview**
> Adds three **Lean** theorems after `normalSquareTranslatedEdgeBlockingHypotheses_of_windows`, stating that assembled `NormalEdgeBlockingHypotheses` recover each edge's translated-window blocking datum (`rfl`), inherit injectivity of red/blue/complement at every edge, and satisfy endpoint membership, disjointness, and full coverage—by delegating to the generic `NormalEdgeBlockingHypotheses` API.
>
> Updates the blueprint theorem **Construction from translated edge windows** with `\lean` links to those names and reorders the prose so translated-window consequences are stated first, with margin-and-cover as an equivalent formulation.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74373827c58c1d2bfa1b0666fdb0f181d5861193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only `rfl`/delegation lemmas and blueprint documentation; no runtime or security-sensitive code.
> 
> **Overview**
> Adds three **Lean** theorems after `normalSquareTranslatedEdgeBlockingHypotheses_of_windows`, making explicit that assembled `NormalEdgeBlockingHypotheses` recover each edge's translated-window blocking datum (`rfl`), inherit injectivity of red/blue/complement at every edge, and satisfy endpoint membership, disjointness, and full coverage—by delegating to `NormalEdgeBlockingHypotheses.injective_chain_at_edge` and `endpoint_disjoint_cover_at_edge`.
> 
> Updates the blueprint theorem *Construction from translated edge windows* with `\lean` links to those names and reorders the prose so translated-window consequences are stated first, with margin-and-cover as an equivalent formulation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 993211aff185a2d7c30d220c563386d379eaf321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->