### PR TITLE
doc(SectorBNT): use scalar modulus notation for BNT weights

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean
@@ -222,7 +222,7 @@ copy witness `hUnit : ∃ q, ‖P.weight j₀ q‖ = 1`, the power-sum coefficie
 The per-block unit-modulus hypothesis `hUnit` is taken as an explicit
 theorem-level argument rather than a structural field of
 `IsBNTCanonicalForm`: CPSV16 §II.C line 246 records only the *global*
-normalization $\exists j, \exists q, \|\mu_{j,q}\| = 1$, while CPSV21
+normalization $\exists j, \exists q, |\mu_{j,q}| = 1$, while CPSV21
 Section IV.A uses Definition 4.2 (lines 1846–1850) for the BNT basis and
 the display at lines 1864–1884 for the two-layer expansion.  It normalizes
 the spectral radius of the *basis* tensors, not the copy coefficients

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -132,11 +132,12 @@ and~\cite{Cirac2021Matrix}.
     if it satisfies Definition~\ref{def:is_normal_canonical_form}
     and, in addition:
     \begin{enumerate}
-        \item the moduli are strictly decreasing
-              (strengthened from non-increasing),
+        \item the weight moduli
+              $|\mu_1| > |\mu_2| > \cdots > |\mu_r|$ are strictly decreasing
+              (a one-representative restriction),
         \item distinct blocks of the same bond dimension are
               not gauge-phase equivalent,
-        \item the dominant block has unit modulus, $\|\mu_1\| = 1$
+        \item the dominant block has unit modulus, $|\mu_1| = 1$
               (\cite[paragraph after \texttt{eq:II\_CF1}]{Cirac2016MPDO_arXiv}).
     \end{enumerate}
     This is a scope-restricted one-copy-per-sector surface: it keeps one
@@ -145,7 +146,11 @@ and~\cite{Cirac2021Matrix}.
     route is recorded in
     \path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}.
     The strict ordering describes an already selected or grouped
-    representative family. It is not the source BNT expansion
+    representative family. Equal-modulus copies are not separated by this
+    surface; they appear as the individual weights $\mu_{j,q}$ in the
+    coefficient sum $c_N^{(j)} = \sum_q \mu_{j,q}^N$ used in the
+    sector-BNT surface below. This is not the source BNT
+    expansion
     \[
         A^i
         = \bigoplus_{j=1}^g \bigoplus_{q=1}^{r_j}
@@ -522,9 +527,9 @@ factorization is assumed.
     equivalent after identifying equal bond dimensions; and the
     \cite[\S II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization holds,
     \[
-        \forall (j,q),\ \lVert \mu_{j,q} \rVert \le 1,
+        \forall (j,q),\ |\mu_{j,q}| \le 1,
         \qquad
-        \exists\, (j_*, q_*) : \lVert \mu_{j_*, q_*} \rVert = 1.
+        \exists\, (j_*, q_*) : |\mu_{j_*, q_*}| = 1.
     \]
     The MPV expansion takes the raw two-layer form
     \[
@@ -569,17 +574,17 @@ factorization is assumed.
     \uses{lem:sector_bnt_coeff_eq_sum_weight_pow}
     Under the optional global modulus normalization
     \cite[\S II, lines~217--246]{Cirac2017MPDO_AnnPhys}, every raw weight satisfies
-    $\lVert \mu_{j,q} \rVert \le 1$, and the triangle inequality bounds
+    $|\mu_{j,q}| \le 1$, and the triangle inequality bounds
     the norm of the sector coefficient by the multiplicity:
     \[
-        \bigl\lVert c_N^{(j)} \bigr\rVert \le r_j.
+        \bigl| c_N^{(j)} \bigr| \le r_j.
     \]
 \end{lemma}
 
 \begin{proof}\leanok
     Apply the triangle inequality to the raw power sum from
     Lemma~\ref{lem:sector_bnt_coeff_eq_sum_weight_pow} and bound each term by
-    $1$ using $\lVert \mu_{j,q} \rVert \le 1$.
+    $1$ using $|\mu_{j,q}| \le 1$.
 \end{proof}
 
 \begin{lemma}[Cross-overlap decay between distinct basis blocks]%
@@ -642,7 +647,7 @@ factorization is assumed.
     \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization yields
     directly
     \[
-        \bigl\lVert c_N^{(j)} \bigr\rVert \le r_j
+        \bigl| c_N^{(j)} \bigr| \le r_j
     \]
     for every $N$ and basis index $j$, without an additional explicit
     modulus-bound hypothesis.
@@ -661,7 +666,7 @@ factorization is assumed.
     Under the BNT canonical form, the
     \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} unit-modulus existential
     provides indices $(j_*, q_*)$ with
-    $\lVert \mu_{j_*, q_*} \rVert = 1$.
+    $|\mu_{j_*, q_*}| = 1$.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -677,7 +682,7 @@ factorization is assumed.
     The single-sector two-copy decomposition with raw weights
     $(1, 1/2)$ demonstrates that the BNT canonical form admits
     unequal-modulus copies: the modulus bound holds because
-    $\lVert 1 \rVert \le 1$ and $\lVert 1/2 \rVert = 1/2 \le 1$, and the
+    $|1| \le 1$ and $|1/2| = 1/2 \le 1$, and the
     unit-modulus existential is witnessed by the first copy with
     weight $1$. This is the
     \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization in
@@ -732,7 +737,7 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     \uses{def:sector_bnt_cf, lem:sector_bnt_cesaro_nondecay}
     Let $P$ be a BNT canonical form and let $j_0$ be a sector index such
     that some copy of sector $j_0$ carries a unit-modulus weight, that is,
-    there exists $q$ with $\lVert \mu_{j_0, q}\rVert = 1$. Then the
+    there exists $q$ with $|\mu_{j_0, q}| = 1$. Then the
     sector-$j_0$ coefficient $c_N^{(j_0)} = \sum_q \mu_{j_0, q}^N$ does not
     tend to $0$ as $N \to \infty$.
 
@@ -748,7 +753,7 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
 \begin{proof}\leanok
     Apply Lemma~\ref{lem:sector_bnt_cesaro_nondecay} to the family
     $q \mapsto \mu_{j_0, q}$, using the modulus bound
-    $\lVert \mu_{j_0, q}\rVert \le 1$ from the canonical-form normalization
+    $|\mu_{j_0, q}| \le 1$ from the canonical-form normalization
     together with the per-sector unit-modulus hypothesis.
 \end{proof}
 

--- a/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
+++ b/docs/paper-gaps/cpsv16_bnt_rate_quantification.tex
@@ -20,8 +20,8 @@
 Fix a sector decomposition $P$ with basis blocks
 $\{P.\mathtt{basis}\,j\}_{j=0}^{g-1}$ and a spectral level
 $\lambda_j\in\mathbb C\setminus\{0\}$ with
-$\|\lambda_0\|>\|\lambda_1\|>\cdots>\|\lambda_{g-1}\|$ and
-$\|\lambda_0\|=1$. The bilinear cross-overlap between basis blocks
+$|\lambda_0|>|\lambda_1|>\cdots>|\lambda_{g-1}|$ and
+$|\lambda_0|=1$. The bilinear cross-overlap between basis blocks
 $j$ and $k$ at length $N$ is
 \begin{align}
     O_{j,k}(N) := 
@@ -37,7 +37,7 @@ written \leanid{mpvOverlap} in the formalization.\footnote{%
 For every ordered pair $j\ne k$ we are interested in a geometric
 bound
 \begin{align}
-    \|O_{j,k}(N)\| \le C_{j,k} \eta_{j,k}^N
+    |O_{j,k}(N)| \le C_{j,k} \eta_{j,k}^N
     \qquad(\forall N\in\mathbb N),
     \label{eq:rate}
 \end{align}
@@ -84,7 +84,7 @@ $j\ne k$,
 \begin{align}
     0\le C_{j,k},\quad 0\le\eta_{j,k}<1,
         \qquad
-    \eta_{j,k}\cdot\|\lambda_j/\lambda_k\|<1,
+    \eta_{j,k}\cdot|\lambda_j/\lambda_k|<1,
     \label{eq:hyp}
 \end{align}
 together with the geometric bound~\eqref{eq:rate} for all $N$.
@@ -113,14 +113,14 @@ $V^{(N)}(P.\mathtt{basis}\,k_0)$ on the right and renormalising by
 $\lambda_{k_0}^N$, that every $j\ne k_0$ contribute a term whose modulus
 is bounded by
 \begin{align}
-    \|O_{j,k_0}(N)\|\cdot\|\lambda_j/\lambda_{k_0}\|^N
-    \le C_{j,k_0}(\eta_{j,k_0}\cdot\|\lambda_j/\lambda_{k_0}\|)^N.
+    |O_{j,k_0}(N)|\cdot|\lambda_j/\lambda_{k_0}|^N
+    \le C_{j,k_0}(\eta_{j,k_0}\cdot|\lambda_j/\lambda_{k_0}|)^N.
     \label{eq:product}
 \end{align}
 The right-hand side of~\eqref{eq:product} converges to $0$ exactly when
 \eqref{eq:hyp} holds. The qualitative limit~\eqref{eq:qual} alone
 gives $\eta_{j,k_0}<1$ but not the comparison
-$\eta_{j,k_0}\cdot\|\lambda_j/\lambda_{k_0}\|<1$, which is the
+$\eta_{j,k_0}\cdot|\lambda_j/\lambda_{k_0}|<1$, which is the
 content of the new hypothesis.
 
 \section{Classification}
@@ -132,7 +132,7 @@ in principle derivable from the spectral gap of the mixed transfer
 operator that powers
 \leanid{mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP},
 but the compatibility inequality
-$\eta_{j,k}\cdot\|\lambda_j/\lambda_k\|<1$ is not implied by the
+$\eta_{j,k}\cdot|\lambda_j/\lambda_k|<1$ is not implied by the
 BNT structure and must be either imposed or established analytically.
 
 The analytic derivation from the transfer matrix spectral gap is the

--- a/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
+++ b/docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex
@@ -47,18 +47,18 @@ The surviving one-copy normal-canonical BNT formulation
 \leanid{IsNormalCanonicalFormBNT} carries a single weight $\mu_k$ per
 sector with strict ordering
 \begin{align}
-    \|\mu_1\|>\|\mu_2\|>\cdots>\|\mu_r\|
+    |\mu_1|>|\mu_2|>\cdots>|\mu_r|
     \tag{\leanid{mu_strict_anti}}
 \end{align}
 across the entire family.\footnote{%
     \leanid{MPSTensor.IsNormalCanonicalFormBNT.mu_strict_anti} in
     \doclink{TNLean/MPS/BNT/Construction}.}
-Together with the dominant normalization $\|\mu_1\|=1$, every
+Together with the dominant normalization $|\mu_1|=1$, every
 sub-dominant block has modulus strictly less than~$1$.
 \cite[Definition~4.2 and lines~1864--1884]{Cirac2021Matrix} states the
 corresponding source structure as a two-layer canonical form: spectral levels
-$\lambda_j$ with $\|\lambda_1\|>\cdots>\|\lambda_g\|$ factored from
-within-sector unit-modulus weights $\mu_{j,q}$ ($\|\mu_{j,q}\|=1$)
+$\lambda_j$ with $|\lambda_1|>\cdots>|\lambda_g|$ factored from
+within-sector unit-modulus weights $\mu_{j,q}$ ($|\mu_{j,q}|=1$)
 with sector multiplicities $r_j\ge 1$. The
 \leanid{IsNormalCanonicalFormBNT} formulation is the one-copy specialization
 $r_j=1$ of that structure; see
@@ -111,7 +111,7 @@ and $\mathrm{RHS}_N:=c_N\langle V^{(N)}(B_{\mathrm{tot}}),V^{(N)}(B_{k_0})\rangl
        &=c_N\sum_{k}(\mu^B_k)^N\langle V^{(N)}(B_k),V^{(N)}(B_{k_0})\rangle.
     \label{eq:LHSRHS}
 \end{align}
-With $\|\mu^A_j\|\le 1$, every $(\mu^A_j)^N$ is bounded; together with
+With $|\mu^A_j|\le 1$, every $(\mu^A_j)^N$ is bounded; together with
 \eqref{eq:Hk0} this forces $\mathrm{LHS}_N\to 0$. For $\mathrm{RHS}_N$,
 the current cross-overlap decay statement
 \leanid{MPSTensor.IsBNTCanonicalForm.cross_overlap_basis_tendsto_zero}
@@ -120,15 +120,15 @@ while the diagonal block has a nonzero limiting coefficient, so
 $\mathrm{RHS}_N=c_N(\mu^B_{k_0})^N(\ell+o(1))$.
 In the dominant block, the proportionality identity and the BNT normalizations
 give the dominant-adjusted scalar limit
-$\bigl\|c_N(\mu^B_0/\mu^A_0)^N\bigr\|\to 1$.  Therefore
+$\bigl|c_N(\mu^B_0/\mu^A_0)^N\bigr|\to 1$.  Therefore
 \begin{align}
-    \bigl\|c_N(\mu^B_{k_0})^N\bigr\|
+    \bigl|c_N(\mu^B_{k_0})^N\bigr|
     &\sim
-    \|\mu^A_0\|^N
-    \bigl\|\mu^B_{k_0}/\mu^B_0\bigr\|^N.
+    |\mu^A_0|^N
+    \bigl|\mu^B_{k_0}/\mu^B_0\bigr|^N.
     \label{eq:decay}
 \end{align}
-Under $\|\mu^A_0\|=1$ and \leanid{mu_strict_anti}, the second factor
+Under $|\mu^A_0|=1$ and \leanid{mu_strict_anti}, the second factor
 in~\eqref{eq:decay} decays geometrically whenever $k_0\ne 0$, so
 $\mathrm{RHS}_N\to 0$ together with $\mathrm{LHS}_N$. No contradiction
 is available from the per-block projection. The dominant case

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -43,7 +43,7 @@ which are stronger than the source display:
   \item \textbf{Strict spectral ordering.}
         The predicate requires the existence of spectral-level coefficients
         $\lambda_j \in \mathbb{C}$ (one per BNT sector $j$) with
-        $\|\lambda_0\| > \|\lambda_1\| > \cdots > \|\lambda_{g-1}\|$
+        $|\lambda_0| > |\lambda_1| > \cdots > |\lambda_{g-1}|$
         (formerly recorded as a strict-antitone condition on the chosen
         spectral levels).
         No such ordering is present in \eqref{eq:bnt-general}.
@@ -59,7 +59,7 @@ which are stronger than the source display:
         (lines 543--555), which is a strict sub-class of the general BNT.
 
   \item \textbf{Dominant normalization.}
-        The dominant spectral level satisfies $\|\lambda_0\| = 1$.
+        The dominant spectral level satisfies $|\lambda_0| = 1$.
         This mirrors the \leanid{IsNormalCanonicalFormBNT.mu_dom_norm_one}
         convention in \doclink{TNLean/MPS/BNT/Construction}; it is not
         imposed by \eqref{eq:bnt-general}.

--- a/docs/paper-gaps/ft_one_copy_scope_restriction.tex
+++ b/docs/paper-gaps/ft_one_copy_scope_restriction.tex
@@ -142,13 +142,13 @@ boundary uses the explicit conclusion
 has already been supplied. Thus no current theorem is presented as deriving
 the source proportional comparison from the discarded coefficient hypotheses.
 
-The source normalization $\|\mu_1\| = 1$ is now recorded as the field
+The source normalization $|\mu_1| = 1$ is now recorded as the field
 \leanid{mu_dom_norm_one} in \leanid{IsNormalCanonicalFormBNT},\footnote{%
     \leanid{IsNormalCanonicalFormBNT.mu_dom_norm_one},
     \path{TNLean/MPS/BNT/Construction.lean} lines 192--198.} which
 brings the dominant-block normalization into alignment with the source
 convention. Under this normalization and the strict modulus ordering, every
-sub-dominant block has $\|\mu_j\| < 1$.
+sub-dominant block has $|\mu_j| < 1$.
 
 \section{Downstream audit status}
 


### PR DESCRIPTION
### Motivation

- CPSV16 (arXiv:1606.00608, Section II.C, line 246) writes BNT scalar weights with single-bar modulus notation, $|\mu_k| \le 1$, with at least one weight of modulus one.
- Chapter 10 and several CPSV16 paper-gap notes used double-bar notation for scalar weights, scalar spectral levels, scalar sector coefficients, or scalar overlaps, which made the prose less faithful to the source convention.
- The normal-canonical BNT paragraph also needed to state clearly that its strict ordering is a one-representative restriction, not the general equal-modulus sector argument.

### Description

- Replaces double-bar notation by scalar modulus notation for BNT weights and sector coefficients in `blueprint/src/chapter/ch10_bnt.tex`.
- Clarifies that the strict-order normal-canonical BNT paragraph concerns weights whose moduli satisfy $|\mu_1| > |\mu_2| > \cdots > |\mu_r|$; equal-modulus copies remain visible as the individual weights $\mu_{j,q}$ in the coefficient sum $c_N^{(j)} = \sum_q \mu_{j,q}^N$ on the sector-BNT surface.
- Applies the same scalar-modulus convention in the related CPSV16 paper-gap notes: `cpsv16_nondominant_per_block_projection.tex`, `ft_one_copy_scope_restriction.tex`, `cpsv16_two_layer_sector_refinement.tex`, and `cpsv16_bnt_rate_quantification.tex`.
- Aligns the paper-anchor sentence in `TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean`. The formal Lean hypotheses remain unchanged.

This PR addresses the notation and exposition subtasks of #2150. The equal-modulus verification across the assembled multi-block theorem remains open there.

### Testing

- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Api`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch10_bnt.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean blueprint/src/chapter/ch10_bnt.tex docs/paper-gaps/cpsv16_nondominant_per_block_projection.tex docs/paper-gaps/ft_one_copy_scope_restriction.tex docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex docs/paper-gaps/cpsv16_bnt_rate_quantification.tex --diff-base main --diff-head HEAD`
- `python3 scripts/blueprint_bibtex.py`
- `leanblueprint web`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`

Refs #2150.