### PR TITLE
doc(BNT): give abstract BNT one Lean reference

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -16,7 +16,7 @@ and~\cite{Cirac2021Matrix}.
 \section{Basis of normal tensors}
 
 \begin{definition}[Basis of Normal Tensors (BNT)]\label{def:bnt}
-    \lean{MPSTensor.IsBNTCanonicalForm}
+    \lean{MPSTensor.IsBNT}
     \leanok
     \uses{def:normal, def:mpv}
     A \emph{basis of normal tensors} (BNT) for a


### PR DESCRIPTION
### Motivation

- Blueprint chapter 10 (`ch10_bnt.tex`) had two `def`-level entries both pointing to `MPSTensor.IsBNTCanonicalForm` via `\lean{...}`: the abstract Basis of Normal Tensors notion (`def:bnt`) and the stronger sector-decomposition canonical-form predicate (`def:sector_bnt_cf`).
- The abstract BNT entry (`def:bnt`) should point to `MPSTensor.IsBNT`, leaving `MPSTensor.IsBNTCanonicalForm` linked only at `def:sector_bnt_cf`.

### Description

- `blueprint/src/chapter/ch10_bnt.tex`: retargets the `\lean{...}` tag in the abstract BNT definition entry (`def:bnt`) from `MPSTensor.IsBNTCanonicalForm` to `MPSTensor.IsBNT`.
- No Lean source files changed.

### Testing

- `git diff --check` — no whitespace errors.
- `cd blueprint && leanblueprint web` — completed (existing unrelated citation and renderer warnings unchanged).
- `cd blueprint && python3 ../scripts/blueprint_lean_sync.py` — Chapter 10 remains 49/49; pre-existing Chapter 14 missing declarations unchanged.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---

> [!NOTE]
> **Low Risk**
> Single-line `\lean` tag change in blueprint TeX with no Lean or runtime behavior changes.
>
> **Overview**
> The abstract **Basis of Normal Tensors** definition (`def:bnt` in `ch10_bnt.tex`) now points its blueprint `\lean{...}` tag at **`MPSTensor.IsBNT`** instead of **`MPSTensor.IsBNTCanonicalForm`**, so the abstract BNT notion and the sector-decomposition canonical-form predicate are not both wired to the same Lean name.
>
> **`MPSTensor.IsBNTCanonicalForm`** remains linked only at **`def:sector_bnt_cf`** and the lemmas that depend on that definition. No Lean sources change—this is documentation / blueprint–Lean alignment only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83be01a13292cc7a8ddca100de5fc4a4eccd2c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>