### PR TITLE
doc(SectorBNT): record unit-witness scope restriction

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -244,7 +244,12 @@ The theorem therefore separates the two mathematical ingredients:
 * the still-open proportional coefficient comparison must construct the
   copy-weight matching.  Once it is available, the global gauge is the
   equal-MPV corollary's direct-sum algebra from Appendix MPV proof,
-  lines 1189--1192. -/
+  lines 1189--1192.
+
+**Scope restriction (per-sector unit weights):** This theorem assumes a
+unit-modulus copy in every sector on both sides. CPSV16 Section II.C, line 246
+gives only one global unit-weight witness. See
+`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
 theorem ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -300,7 +305,12 @@ the copy-weight matching and the direct-sum global gauge follows.
 The coefficient identity is the precise remaining CPSV16 Appendix MPV line
 1188 input; until it is derived from the proportional MPV hypothesis, this
 theorem is a conditional assembly statement rather than the unrestricted
-source theorem. -/
+source theorem.
+
+**Scope restriction (per-sector unit weights):** This theorem assumes a
+unit-modulus copy in every sector on both sides. CPSV16 Section II.C, line 246
+gives only one global unit-weight witness. See
+`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
 theorem ft_sector_bnt_proportional_global_gauge_of_coeff_identity
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -543,7 +553,12 @@ theorem ft_sector_bnt_equal_global_gaugePos
       (P := P) (Q := Q) β hDim τ ζ Xblock hζ_ne hConj hWeight
   exact ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, hWeight, X, hXdef, hGauge⟩
 
-/-- Reformulation for the all-length `SameMPV₂` form. -/
+/-- Reformulation for the all-length `SameMPV₂` form.
+
+**Scope restriction (per-sector unit weights):** This theorem assumes a
+unit-modulus copy in every sector on both sides. CPSV16 Section II.C, line 246
+gives only one global unit-weight witness. See
+`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
 theorem ft_sector_bnt_equal_global_gauge
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -640,7 +640,12 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
           Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ))
   simp only [Matrix.mul_assoc]
 
-/-- Reformulation for the all-length `SameMPV₂` form. -/
+/-- Reformulation for the all-length `SameMPV₂` form.
+
+**Scope restriction (per-sector unit weights):** This theorem assumes a
+unit-modulus copy in every sector on both sides. CPSV16 Section II.C, line 246
+gives only one global unit-weight witness. See
+`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
 theorem ft_sector_bnt_equal_mps_gaugeEquiv_literal
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -248,7 +248,12 @@ The theorem intentionally stops before the raw coefficient identity.  Under
 length-dependent proportionality scalar; it is not the equal-MPV coefficient
 identity proved by `coeff_identity_via_matched_mpv_phase`, and it is not
 contained in CPSV16 Appendix MPV proof, lines 1187–1192, without the equal-MPV
-specialization. -/
+specialization.
+
+**Scope restriction (per-sector unit weights):** This theorem assumes a
+unit-modulus copy in every sector on both sides. CPSV16 Section II.C, line 246
+gives only one global unit-weight witness. See
+`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
 theorem ft_sector_bnt_proportional_sector_match_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -128,7 +128,12 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     apply hNonDecay_swapped
     exact tendsto_mpvOverlap_zero_swap (P.basis j) (Q.basis k) hTend
 
-/-- Reformulation for the all-length `SameMPV₂` form. -/
+/-- Reformulation for the all-length `SameMPV₂` form.
+
+**Scope restriction (per-sector unit weights):** This theorem keeps the
+per-sector unit-weight hypothesis of the positive-length form. CPSV16
+Section II.C, line 246 gives only one global unit-weight witness. See
+`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
 theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -266,7 +271,12 @@ theorem bijective_match_of_sameMPVPos
   intro k
   simpa [β] using φ₀_spec k
 
-/-- Reformulation for the all-length `SameMPV₂` form. -/
+/-- Reformulation for the all-length `SameMPV₂` form.
+
+**Scope restriction (per-sector unit weights):** This theorem assumes a
+unit-modulus copy in every sector on both sides. CPSV16 Section II.C, line 246
+gives only one global unit-weight witness. See
+`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
 theorem bijective_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -876,8 +876,8 @@ modulus-one hypothesis as a single \emph{global} existential over the
 two-layer $(j, q)$ index of the BNT display, whereas the statement below
 assumes the corresponding witness in each sector. This is why the result is
 labelled as a full-basis form rather than as the unrestricted source theorem.
-The scope restriction is documented in
-\path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
+% Scope restriction documented in
+% docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 The bijective-matching theorem below applies the
 strong existential theorem twice (with $(P, Q)$ swapped) to derive the
 cardinality identity and the per-pair bijection and gauges on the full
@@ -963,8 +963,8 @@ Under these hypotheses every sector lies in the unit-modulus part, so the
 symmetric injective matchings give a bijection on the full BNT basis. The
 coefficient comparison is not folded into this matching step; it is recorded
 separately in the following subsection.
-This scope restriction is documented in
-\path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
+% Scope restriction documented in
+% docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 
 \begin{theorem}[Bijective matching by symmetry]
     \label{thm:sector_bnt_bijective_match_of_sameMPV}
@@ -1061,8 +1061,8 @@ matching covers the whole BNT basis.
     \[
         Q_k^i=\zeta_k X_k P_{\beta(k)}^i X_k^{-1}
     \]
-    This per-sector unit-weight scope restriction is documented in
-    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
+    % Scope restriction documented in
+    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
     Equivalently, for every length $N$ and word $\sigma$,
     \[
         V^{(N)}(Q_k)_\sigma
@@ -1329,8 +1329,8 @@ matching covers the whole BNT basis.
     \[
         X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
     \]
-    This per-sector unit-weight scope restriction is documented in
-    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
+    % Scope restriction documented in
+    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1368,8 +1368,8 @@ matching covers the whole BNT basis.
     \[
         X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
     \]
-    This per-sector unit-weight scope restriction is documented in
-    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
+    % Scope restriction documented in
+    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1428,8 +1428,8 @@ matching covers the whole BNT basis.
     for every physical index $i$. This is the explicit direct-sum gauge
     construction of
     \cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}.
-    The per-sector unit-weight scope restriction is documented in
-    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
+    % Scope restriction documented in
+    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1475,8 +1475,8 @@ matching covers the whole BNT basis.
     \cite[Corollary~II.2 and Appendix MPV proof, lines~1189--1192]
     {Cirac2017MPDO_AnnPhys}, under the same unit-modulus-copy normalization
     as Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
-    The per-sector unit-weight scope restriction is documented in
-    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
+    % Scope restriction documented in
+    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -876,6 +876,8 @@ modulus-one hypothesis as a single \emph{global} existential over the
 two-layer $(j, q)$ index of the BNT display, whereas the statement below
 assumes the corresponding witness in each sector. This is why the result is
 labelled as a full-basis form rather than as the unrestricted source theorem.
+The scope restriction is documented in
+\path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
 The bijective-matching theorem below applies the
 strong existential theorem twice (with $(P, Q)$ swapped) to derive the
 cardinality identity and the per-pair bijection and gauges on the full
@@ -961,6 +963,8 @@ Under these hypotheses every sector lies in the unit-modulus part, so the
 symmetric injective matchings give a bijection on the full BNT basis. The
 coefficient comparison is not folded into this matching step; it is recorded
 separately in the following subsection.
+This scope restriction is documented in
+\path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
 
 \begin{theorem}[Bijective matching by symmetry]
     \label{thm:sector_bnt_bijective_match_of_sameMPV}
@@ -1057,6 +1061,8 @@ matching covers the whole BNT basis.
     \[
         Q_k^i=\zeta_k X_k P_{\beta(k)}^i X_k^{-1}
     \]
+    This per-sector unit-weight scope restriction is documented in
+    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
     Equivalently, for every length $N$ and word $\sigma$,
     \[
         V^{(N)}(Q_k)_\sigma
@@ -1323,6 +1329,8 @@ matching covers the whole BNT basis.
     \[
         X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
     \]
+    This per-sector unit-weight scope restriction is documented in
+    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1360,6 +1368,8 @@ matching covers the whole BNT basis.
     \[
         X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
     \]
+    This per-sector unit-weight scope restriction is documented in
+    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1418,6 +1428,8 @@ matching covers the whole BNT basis.
     for every physical index $i$. This is the explicit direct-sum gauge
     construction of
     \cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}.
+    The per-sector unit-weight scope restriction is documented in
+    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1463,6 +1475,8 @@ matching covers the whole BNT basis.
     \cite[Corollary~II.2 and Appendix MPV proof, lines~1189--1192]
     {Cirac2017MPDO_AnnPhys}, under the same unit-modulus-copy normalization
     as Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
+    The per-sector unit-weight scope restriction is documented in
+    \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1061,8 +1061,6 @@ matching covers the whole BNT basis.
     \[
         Q_k^i=\zeta_k X_k P_{\beta(k)}^i X_k^{-1}
     \]
-    % Scope restriction documented in
-    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
     Equivalently, for every length $N$ and word $\sigma$,
     \[
         V^{(N)}(Q_k)_\sigma
@@ -1075,6 +1073,8 @@ matching covers the whole BNT basis.
     \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys} is the
     corresponding argument. The following coefficient-comparison step is
     separate.
+    % Scope restriction documented in
+    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 \end{theorem}
 
 \begin{proof}\leanok\uses{lem:sector_bnt_norm_phase_of_matched_mpv}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -14,6 +14,10 @@ equal-modulus comparison has one current reference.
 - `blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` records only how
   the Chapter 10 comparison is used in the equal-MPV Fundamental Theorem
   argument.
+- `cpsv16_global_vs_persector_unit_witness.tex` records the separate
+  scope restriction that the current full-basis matching theorems assume a
+  unit-modulus copy in every sector, while CPSV16 line 246 gives only one
+  global unit-weight witness.
 - GitHub issue #2150 tracks the remaining verification that the assembled
   multi-block theorem uses this equal-modulus comparison without a surviving
   strictly-decreasing-moduli restriction.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -6,7 +6,7 @@ source passage, state the mathematical input in paper notation, and then name
 the current formal boundary.
 
 For the present non-periodic MPS Fundamental Theorem work, the repeated-copy and
-equal-modulus comparison has one current reference.
+equal-modulus comparison has these current reference points.
 
 - `blueprint/src/chapter/ch10_bnt.tex` records the SectorBNT canonical-form
   surface, the repeated-copy sector coefficients, and the Newton--Girard
@@ -14,13 +14,16 @@ equal-modulus comparison has one current reference.
 - `blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` records only how
   the Chapter 10 comparison is used in the equal-MPV Fundamental Theorem
   argument.
-- `cpsv16_global_vs_persector_unit_witness.tex` records the separate
-  scope restriction that the current full-basis matching theorems assume a
-  unit-modulus copy in every sector, while CPSV16 line 246 gives only one
-  global unit-weight witness.
 - GitHub issue #2150 tracks the remaining verification that the assembled
   multi-block theorem uses this equal-modulus comparison without a surviving
   strictly-decreasing-moduli restriction.
+
+The separate global-versus-per-sector unit-witness restriction has one current
+paper-gap note.
+
+- `cpsv16_global_vs_persector_unit_witness.tex` records that the current
+  full-basis matching theorems assume a unit-modulus copy in every sector,
+  while CPSV16 line 246 gives only one global unit-weight witness.
 
 Older notes in this directory record why previous one-copy or projection-based
 formulations were insufficient. They should be read as historical comparisons

--- a/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
+++ b/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
@@ -1,0 +1,119 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{./command}
+
+\title{Global and Per-Sector Unit-Weight Witnesses in the CPSV16 BNT Argument}
+\author{}
+\date{2026-05-30}
+
+\begin{document}
+\maketitle
+
+\section{The source normalization}
+
+Cirac--Perez-Garcia--Schuch--Verstraete 2016 normalizes the raw coefficients in
+the basis-of-normal-tensors (BNT) expansion by a single global condition.  In
+the notation of the two-layer display
+\[
+  A^i =
+  \bigoplus_{j=1}^{g}\bigoplus_{q=1}^{r_j}
+  \mu_{j,q} X_{j,q} A_j^i X_{j,q}^{-1},
+\]
+the source assumes
+\[
+  |\mu_{j,q}| \le 1 \quad \text{for all } (j,q),
+  \qquad
+  |\mu_{j_\ast,q_\ast}| = 1 \quad \text{for some } (j_\ast,q_\ast).
+\]
+This is the normalization at CPSV16 Section II.C, line 246 of the local
+arXiv source.
+
+Thus the paper-level canonical form does not state that every BNT sector
+\(j\) contains a copy \(q\) of modulus one.  A sector may contain only strictly
+subunit copy weights, while some other sector carries the global unit witness.
+
+\section{The formal boundary}
+
+The formal predicate \leanid{MPSTensor.IsBNTCanonicalForm} records the source
+normalization faithfully: it has a bound on all copy weights and a single
+global unit-weight witness.  It does not contain the per-sector condition
+\[
+  \forall j,\ \exists q,\ |\mu_{j,q}| = 1.
+\]
+
+Several full-basis matching and global-gauge theorems currently assume this
+per-sector condition explicitly.  The condition is used to apply the Cesaro
+non-decay lemma sector by sector in the CPSV16 Appendix MPV line-1182 matching
+argument.  The affected formal argument includes the strong matching theorem,
+the bijective matching theorem, the proportional matched-sector theorem, and
+the equal-MPV global-gauge theorems in the SectorBNT formulation.
+
+Consequently these declarations are not the unrestricted CPSV16 theorem or
+corollary.  They are scope-restricted full-basis statements: after the
+per-sector unit-weight hypotheses are supplied, they prove the sector matching,
+coefficient comparison, copy-weight recovery, and direct-sum gauge
+construction without imposing any strict ordering of the copy-weight moduli.
+
+\section{Relation to the equal-modulus issue}
+
+This restriction is logically separate from the retired strict-moduli
+formulation.  The current SectorBNT coefficient comparison works with raw
+sector coefficients
+\[
+  c_N^{(j)} = \sum_q \mu_{j,q}^N
+\]
+and the copy weights are recovered from these coefficients by the finite
+power-sum argument.  Equal-modulus copies such as the two copies in
+\(C \oplus (-C)\), and unequal-modulus copies such as \(C \oplus (1/2)C\),
+are both represented by the raw two-layer SectorBNT formulation.
+
+The remaining extra hypothesis is not strictness of moduli.  It is the
+per-sector existence of a unit-modulus copy weight, which is stronger than the
+single global unit witness stated in CPSV16 line 246.
+
+\section{Elimination plan}
+
+There are two possible ways to remove the restriction.
+
+First, one may prove the CPSV16 matching step directly from the global witness.
+In that approach, the line-1182 argument must show that every sector relevant
+to the full-basis matching either receives a unit-modulus witness from the
+source normalization after the appropriate comparison, or is eliminated by the
+same non-decay contradiction used in the paper.
+
+Second, one may split the BNT basis into the unit-supporting part and the
+strictly subunit part, prove matching on the unit-supporting part, and then
+derive the remaining sectors by the coefficient identities.  This argument must
+still end with the same raw coefficient comparison and finite power-sum
+recovery used by the current SectorBNT theorems.
+
+Until one of these arguments is formalized, the per-sector statements should
+remain marked as scope-restricted versions of the BNT Fundamental Theorem
+argument.  They should not be cited as the unrestricted CPSV16 theorem or
+corollary.
+
+\section{Current declarations}
+
+The main declarations carrying the additional per-sector hypothesis are:
+\begin{itemize}
+  \item \leanid{MPSTensor.forall_k_exists_j_nondecaying_overlap_of_sameMPV},
+  \item \leanid{MPSTensor.bijective_match_of_sameMPV},
+  \item \leanid{MPSTensor.ft_sector_bnt_proportional_sector_match_witnesses},
+  \item \leanid{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching},
+  \item \leanid{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_coeff_identity},
+  \item \leanid{MPSTensor.ft_sector_bnt_equal_global_gauge},
+  \item \leanid{MPSTensor.ft_sector_bnt_equal_mps_gaugeEquiv_literal}.
+\end{itemize}
+
+The faithful structural normalization remains the global unit-weight field
+\path{MPSTensor.IsBNTCanonicalForm.weight_unit_exists} in
+\path{TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
+++ b/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
@@ -16,8 +16,11 @@
 \section{The source normalization}
 
 Cirac--Perez-Garcia--Schuch--Verstraete 2016 normalizes the raw coefficients in
-the basis-of-normal-tensors (BNT) expansion by a single global condition.  In
-the notation of the two-layer display
+the basis-of-normal-tensors (BNT) expansion by a single global condition.
+Section II.C, line 246 states the condition for the one-index canonical-form
+coefficients \(\mu_k\).  The BNT display at lines 287--289 then refines this
+index into a sector index and a copy index.  In the resulting two-layer
+notation
 \[
   A^i =
   \bigoplus_{j=1}^{g}\bigoplus_{q=1}^{r_j}
@@ -29,8 +32,7 @@ the source assumes
   \qquad
   |\mu_{j_\ast,q_\ast}| = 1 \quad \text{for some } (j_\ast,q_\ast).
 \]
-This is the normalization at CPSV16 Section II.C, line 246 of the local
-arXiv source.
+This is the same normalization, expressed after the two-layer BNT refinement.
 
 Thus the paper-level canonical form does not state that every BNT sector
 \(j\) contains a copy \(q\) of modulus one.  A sector may contain only strictly


### PR DESCRIPTION
### Motivation

- The SectorBNT equal-MPV path no longer relies on strict ordering of copy-weight moduli: the comparison is carried by raw sector coefficients and finite power-sum recovery.
- The remaining extra hypothesis in the full-basis matching and gauge theorems is distinct: the current statements assume a unit-modulus copy in every sector, while CPSV16 Section II.C line 246 gives only one global unit-weight witness.
- A single paper-gap note should be the reference point for this scope restriction, with the blueprint and Lean declarations pointing to it rather than restating the issue in several places.

### Description

- Add `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`, recording the CPSV16 source normalization, the current per-sector theorem hypotheses, and possible elimination plans.
- Add LaTeX comment pointers from the affected Chapter 10 matching and global-gauge entries in `blueprint/src/chapter/ch10_bnt.tex` to the new note.
- Add `**Scope restriction (per-sector unit weights):**` docstring markers to the seven affected SectorBNT declarations listed by the note.
- Separate the equal-modulus reference points from the unit-witness scope note in `docs/paper-gaps/README.md`.

### Testing

- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py`
- `cd docs/paper-gaps && texfot pdflatex -interaction=nonstopmode -halt-on-error cpsv16_global_vs_persector_unit_witness.tex`
- `cd blueprint && leanblueprint web` (completed with existing renderer and citation warnings)
- `cd blueprint && python3 ../scripts/blueprint_lean_sync.py` (existing unrelated missing declarations remain in Chapter 14)
- No local `lake env lean`: this fresh worktree has no `.lake` cache, and the Lean edits are docstrings only.

---
Refs #2150