### PR TITLE
doc(PEPS): centralize normal blocking status

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -867,24 +867,13 @@ large enough for the edge-blocking proof, and the specific \(R\), \(S\), and
 that the displayed regions are unions of smaller injective rectangles is left
 to the tensor-level region-injectivity theorem.
 
-**Scope restriction (R/S/T injectivity):** The injectivity assertions for
-\(R\), \(S\), and \(T\) are assumed directly, whereas arXiv:1804.04964,
-Section 3, derives them from the \(2\times 3\) and \(3\times 2\) rectangular
-injectivity assumptions using the union-of-injective-regions lemma. The
-coordinate regions \(R\), \(S\), and \(T\) are now recorded separately, and
-\(R\) and \(S\) have conditional injectivity lemmas assuming union closure, but
-the local-window \(T\) region still has no source-faithful injectivity
-derivation. In particular, the complementary region used as the third block in
-Theorem 3 is a finite-lattice complement around an edge, and this abstract
-structure still assumes its three region fields directly. The translated
-horizontal and vertical edge pictures and their conditional per-edge
-margin-and-cover construction are formalized separately, but this structure is
-not yet derived from that coordinate layer. Documented in
-`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Remaining mathematical
-obligations 1--5. Elimination: derive these assertions from rectangular
-injectivity after the tensor-level union theorem and the finite-lattice
-complement construction are formalized, then construct the translated edge
-blockings for every edge.
+**Scope restriction (R/S/T injectivity):** This structure assumes injectivity
+of \(R\), \(S\), and \(T\) directly, whereas arXiv:1804.04964, Section 3
+derives those assertions from rectangular injectivity and the
+union-of-injective-regions argument. The authoritative source comparison and
+elimination plan are
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section
+"Remaining mathematical obligations".
 
 Source: arXiv:1804.04964, Section 3, Theorem 3 and its proof, lines
 1407--1504 of `Papers/1804.04964/paper_normal.tex`. -/

--- a/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
@@ -65,10 +65,9 @@ abbrev normalSquareHorizontalEdgeComplement : Finset (SquareLatticeVertex 5 7) :
 used in the proof of the normal square-lattice theorem.
 
 This definition records the set-theoretic and injectivity data for the concrete
-horizontal-edge blocking as one `NormalEdgeBlockingData` value. The remaining
-step toward
-`NormalEdgeBlockingHypotheses` is to translate this coordinate picture around
-every horizontal and vertical edge of the finite square lattice.
+horizontal-edge blocking as one `NormalEdgeBlockingData` value. The
+source-comparison status of the every-edge construction is recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 def normalSquareHorizontalEdge_blockingDatum
@@ -248,10 +247,9 @@ abbrev normalSquareVerticalEdgeComplement : Finset (SquareLatticeVertex 7 5) :=
 used in the proof of the normal square-lattice theorem.
 
 This definition records the set-theoretic data for the vertical-edge blocking.
-Injectivity of the complementary block is kept as an explicit hypothesis here;
-deriving it from the source rectangular hypotheses is the remaining
-finite-geometry step before this can be promoted to an every-edge
-`NormalEdgeBlockingHypotheses` construction.
+Injectivity of the complementary block is kept as an explicit hypothesis here.
+The source-comparison status of that finite-geometry input is recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 def normalSquareVerticalEdge_blockingDatum
@@ -394,9 +392,9 @@ def normalSquareVerticalEdge_blockingDatum_of_verticalTCover
 /-- The normalized vertical edge supplies the three injective regions used in
 the edge-blocked three-site chain.
 
-The complementary-block injectivity remains an explicit input here; discharging
-that input from the rectangular hypotheses is the remaining source-geometry
-step.
+The complementary-block injectivity remains an explicit input here; the
+source-comparison status is recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 theorem normalSquareVerticalEdge_injective_chain

--- a/TNLean/PEPS/NormalEdgeBlockingTranslated.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingTranslated.lean
@@ -433,8 +433,8 @@ universe edgeCoverUniverse
 edge-blocking windows.
 
 The constructors deliberately record the rectangular cover of the complementary
-region. The remaining finite-geometry step in the source proof is to provide
-such a window for every edge of the \(7\times7\) square-lattice PEPS.
+region. The source-comparison status of the every-edge window construction is
+recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 inductive NormalSquareTranslatedEdgeWindow {width height : ℕ}
@@ -734,10 +734,11 @@ def verticalSquareLatticeEdgeWindow_of_margins
 /-- Per-edge data sufficient to realize a square-lattice edge by a translated
 normal edge-blocking window.
 
-This records the remaining finite-geometry input in the current open
-rectangular coordinate model: an edge must be horizontal or vertical, have the
-corresponding named margins, and have a rectangular cover for its complementary
-block.
+This records the per-edge finite-geometry input in the current rectangular
+coordinate model: an edge must be horizontal or vertical, have the corresponding
+named margins, and have a rectangular cover for its complementary block. The
+source-comparison status of the every-edge construction is recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 inductive NormalSquareEdgeMarginCover {width height : ℕ}
@@ -912,7 +913,7 @@ theorem normalSquareTranslatedEdgeBlockingHypotheses_endpoint_disjoint_cover_of_
 the normal edge-blocking hypotheses.
 
 This is the same conditional construction as
-`normalSquareTranslatedEdgeBlockingHypotheses_of_windows`, with the remaining
+`normalSquareTranslatedEdgeBlockingHypotheses_of_windows`, with the per-edge
 finite-geometry input expressed directly on each square-lattice edge.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3254,7 +3254,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The same criterion applies to an arbitrary horizontal or vertical
     square-lattice edge after identifying it with its coordinate right or
     upward representative.  The oriented margin-and-cover datum is the
-    corresponding per-edge form of this remaining finite-geometry input; it
+    corresponding per-edge datum in the rectangular coordinate model; it
     directly supplies the one-edge blocking datum, its three injective
     regions, and the identities
     $u_e\in R_e$, $v_e\in B_e$,
@@ -3273,8 +3273,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     horizontal edges without enough left or right margin, nor to vertical edges
     without enough bottom or top margin; the corresponding $7\times7$
     examples are recorded explicitly, including a single four-sided boundary
-    obstruction.  This records the remaining boundary geometry in the formal
-    route; it is not a contradiction of the source theorem.
+    obstruction.
+    % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \end{definition}
 
 \begin{theorem}[Construction from translated edge windows]%
@@ -3437,6 +3437,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     decompositions and $T$ obtained from the supplied cover.  Under the
     present exact-cover criterion this converse is vacuous at the origin:
     the no-cover lemma for the displayed $T$-region rules out such a cover.
+    % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
     The source regions are:
     \begin{center}
         \TNPEPSNormalRegionsRS

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -278,7 +278,10 @@ diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
 \section{Remaining mathematical obligations}
 
 The normal PEPS theorem cannot be obtained by citing the injective theorem
-alone. The following additional obligations remain.
+alone. The list below is the authoritative record of the remaining
+mathematical obligations for the square-lattice normal blocking route. Lean
+docstrings and blueprint entries should point here rather than repeat this
+status in full.
 
 \begin{enumerate}
     \item Define a formal notion of injectivity for a blocked region, not only for


### PR DESCRIPTION
### Motivation
- Duplicate obligation lists in PEPS Lean docstrings and the Chapter 13a blueprint (`ch13a_peps_ft.tex`) made the remaining square-lattice normal blocking tasks hard to maintain; a single authoritative record eliminates drift between those copies.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex` already documents obligations 1–5 (R/S/T injectivity derivation and edge-blocking coordination) from arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407–1504; centralizing there avoids re-stating the same status in multiple files.
- Continues documentation clean-up following #2003; see #2004 for the mathematical obligations this note tracks.

### Description
- `TNLean/PEPS/NormalBlocking.lean`: shortened scope notes for assumed R/S/T injectivity to compact pointers toward `docs/paper-gaps/peps_normal_ft_section3_route.tex`; no Lean APIs or proofs changed.
- `TNLean/PEPS/NormalEdgeBlockingCoordinate.lean`: same treatment for per-edge translated window and margin/cover obligation notes.
- `TNLean/PEPS/NormalEdgeBlockingTranslated.lean`: same treatment.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: trimmed duplicated obligation narrative (margin-cover wording, "not a contradiction" passage); added comments linking to the paper-gap file. Mathematical statements and formal interfaces are unchanged.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: updated as the single authoritative status record for obligations 1–5 (arXiv:1804.04964, Section 3, Theorem 3).

### Testing
- `lake exe cache get`
- `lake build TNLean.PEPS.NormalBlocking TNLean.PEPS.NormalEdgeBlockingCoordinate TNLean.PEPS.NormalEdgeBlockingTranslated`
- `leanblueprint web` (passes with pre-existing bibliography and renderer warnings)
- `python3 ../scripts/blueprint_lean_sync.py` (exits 0; pre-existing Chapter 14 missing declarations reported)
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`

---
Addresses #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation edits only; no Lean APIs, proofs, or blueprint mathematical statements changed.
> 
> **Overview**
> This PR **deduplicates** status text about the square-lattice normal PEPS blocking route (arXiv:1804.04964, Section 3). Lean docstrings in `NormalBlocking`, `NormalEdgeBlockingCoordinate`, and `NormalEdgeBlockingTranslated` no longer spell out long “remaining step” narratives for assumed **R/S/T** injectivity, per-edge translated windows, and margin/cover inputs; they now **point** to `docs/paper-gaps/peps_normal_ft_section3_route.tex`, section **Remaining mathematical obligations**.
> 
> The Chapter 13a blueprint (`ch13a_peps_ft.tex`) drops parallel obligation prose and adds **comments** with the same pointer. The paper-gap doc is updated to state that list is the **single authoritative** record and that Lean/blueprint should reference it instead of repeating it.
> 
> **No** formal definitions, theorems, or proofs change—only documentation and cross-references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3baac02ba610c73f007f610412a8a453cdd0d06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->