### PR TITLE
refactor(MPS/CanonicalForm): use direct positive blocking transport

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -10,7 +10,7 @@ open scoped Matrix BigOperators ComplexOrder MatrixOrder
 open Filter
 
 /-!
-# Common-sector data for the after-blocking reduction
+# Common-sector witnesses for the after-blocking reduction
 
 This file collects the common-sector continuation of the structural
 canonical-form reduction following arXiv:1606.00608. Starting from the
@@ -21,8 +21,8 @@ to compare the resulting sector families.
 
 ## Main statements
 
-* `afterBlocking_perBlockCyclicData_of_sameMPV₂` — per-block cyclic-sector
-  data together with the positive-length nonzero-sector identities.
+* `afterBlocking_perBlockCyclicData_of_sameMPV₂` — per-block weights, blocks,
+  cyclic-sector decompositions, and positive-length nonzero-sector identities.
 * `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` — a two-sided
   common blocking length with common-sector families.
 
@@ -108,7 +108,7 @@ theorem afterBlocking_perBlockCyclicData_of_sameMPV₂
 
 set_option maxHeartbeats 800000 in
 -- The next theorem has a large dependent existential conclusion, matching the
--- CPSV data used by the later sector comparison.
+-- CPSV witnesses used by the later sector comparison.
 
 /-- **Two-sided common-length relabeled cyclic-sector theorem.**
 
@@ -251,14 +251,14 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
 ### What remains for the full 1606.00608 Fundamental Theorem
 
 The complete fundamental theorem should take two tensors `A, B` with `SameMPV₂ A B`
-and pass from the blocked reduction data to the CPSV basis-of-normal-tensors
+and pass from the blocked reduction witnesses to the CPSV basis-of-normal-tensors
 sector comparison. The one-sided phase-class BNT construction is available as
 `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`; the remaining overlap/span
-data are supplied at the two-sided comparison layer.
+hypotheses are supplied at the two-sided comparison layer.
 The sector matching extraction is available from primitive overlap-rigidity
 hypotheses through `SectorBasisOverlapSpanHypotheses.exists_sectorBasisMatching`.
 
-The comparison data match the CPSV boundary: blocked-word relabeling,
+The comparison hypotheses match the CPSV boundary: blocked-word relabeling,
 finite-length nonzero-block span comparison, and BNT sector
 matching.
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -15,15 +15,14 @@ open Filter
 This file collects the common-sector continuation of the structural
 canonical-form reduction following arXiv:1606.00608. Starting from the
 all-zero leftover block and TP-gauge decomposition, it records the per-block
-cyclic-sector data, chooses common blocking lengths, and states the relabeled
-common-sector data needed to compare the resulting sector families.  The
-`zeroTail` variables below name the total bond dimension of the all-zero blocks,
-corresponding to the CPSV allowance `∑ k, D_k ≤ D`.
+weights, blocks, and positive-length agreements of the nonzero part, chooses
+common blocking lengths, and states the relabeled common-sector families needed
+to compare the resulting sector families.
 
 ## Main statements
 
-* `afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂` — per-block
-  cyclic-sector data together with the zero-tail identity.
+* `afterBlocking_perBlockCyclicData_of_sameMPV₂` — per-block cyclic-sector
+  data together with the positive-length nonzero-sector identities.
 * `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` — a two-sided
   common blocking length with common-sector families.
 
@@ -43,27 +42,29 @@ variable {d D : ℕ}
 
 section FundamentalTheoremAfterBlocking
 
-/-- **Per-block cyclic-sector decomposition with a zero-tail identity.**
+/-- **Per-block cyclic-sector decomposition after the zero-block split.**
 
 This is the faithful predecessor to the common nonzero-sector statement. From
 `SameMPV₂ A B`, it first separates the all-zero leftover block and then applies
 the TP gauge to obtain irreducible nonzero-weight blocks on both sides. It then
 removes the period of each block separately, producing primitive irreducible cyclic sectors for
-every nonzero-weight block. The nonzero parts agree at every positive length; the length-zero
-coefficient is recovered separately, at the end, from equality of the bond dimensions.
+every nonzero-weight block. The tensor on each side agrees with its nonzero part
+at every positive length, and the two nonzero parts agree at every positive length.
+The length-zero coefficient is recovered separately, at the end, from equality of
+the bond dimensions.
 
 The theorem intentionally keeps the per-block period-removal lengths inside
 `HasPrimitiveIrreducibleCyclicSectors`. It does not conflate those lengths with a
 later common-refinement or Wielandt/injectivity blocking length; assembling the
 per-block cyclic sectors at one physical blocking level is the next formal
 statement in the reduction chain. -/
-theorem afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂
+theorem afterBlocking_perBlockCyclicData_of_sameMPV₂
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hSame : SameMPV₂ A B) :
-    ∃ (zeroTailA : ℕ) (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
+    ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
       (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
-    ∃ (zeroTailB : ℕ) (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
+    ∃ (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
       (blocksB : (k : Fin rB) → MPSTensor d (dimB k)),
       (∀ k, IsIrreducibleTensor (blocksA k)) ∧
       (∀ k, IsIrreducibleTensor (blocksB k)) ∧
@@ -73,12 +74,8 @@ theorem afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂
       (∀ k, μB k ≠ 0) ∧
       (∀ k, 0 < dimA k) ∧
       (∀ k, 0 < dimB k) ∧
-      (∀ (N : ℕ) (σ : Fin N → Fin d),
-        mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
-          mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ) ∧
-      (∀ (N : ℕ) (σ : Fin N → Fin d),
-        mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
-          mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) ∧
+      SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μA) blocksA) ∧
+      SameMPV₂Pos B (toTensorFromBlocks (d := d) (μ := μB) blocksB) ∧
       SameMPV₂Pos
         (toTensorFromBlocks (d := d) (μ := μA) blocksA)
         (toTensorFromBlocks (d := d) (μ := μB) blocksB) ∧
@@ -93,9 +90,12 @@ theorem afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂
   have hBook :=
     nonzeroBlock_sameMPV₂Pos_of_sameMPV₂
       A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hMPVA hMPVB
-  refine ⟨zeroTailA, rA, dimA, μA, blocksA,
-    zeroTailB, rB, dimB, μB, blocksB,
-    hIrrA, hIrrB, hTPA, hTPB, hμA, hμB, hDimA, hDimB, hMPVA, hMPVB,
+  have hAPos := sameMPV₂Pos_of_zeroTail_eq A
+    (toTensorFromBlocks (d := d) (μ := μA) blocksA) hMPVA
+  have hBPos := sameMPV₂Pos_of_zeroTail_eq B
+    (toTensorFromBlocks (d := d) (μ := μB) blocksB) hMPVB
+  refine ⟨rA, dimA, μA, blocksA, rB, dimB, μB, blocksB,
+    hIrrA, hIrrB, hTPA, hTPB, hμA, hμB, hDimA, hDimB, hAPos, hBPos,
     hBook, ?_, ?_⟩
   · intro k
     letI : NeZero (dimA k) := ⟨Nat.ne_of_gt (hDimA k)⟩
@@ -178,11 +178,11 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
       (∀ x, IsIrreducibleTensor (familyB.commonFlatBlocks x)) ∧
       (∀ x, 0 < familyA.commonFlatDim x) ∧
       (∀ x, 0 < familyB.commonFlatDim x) := by
-  obtain ⟨zeroTailA, rA, dimA, μA, blocksA,
-      zeroTailB, rB, dimB, μB, blocksB,
+  obtain ⟨rA, dimA, μA, blocksA,
+      rB, dimB, μB, blocksB,
       _hIrrA, _hIrrB, _hTPA, _hTPB, hμA, hμB, _hDimA, _hDimB,
-      hMPVA, hMPVB, _hPos, hCycA, hCycB⟩ :=
-    afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂ A B hSame
+      hAPos, hBPos, hPos, hCycA, hCycB⟩ :=
+    afterBlocking_perBlockCyclicData_of_sameMPV₂ A B hSame
   let periodA : Fin rA → ℕ := fun k => (hCycA k).choose
   let periodB : Fin rB → ℕ := fun k => (hCycB k).choose
   have periodA_pos : ∀ k, 0 < periodA k := fun k => (hCycA k).choose_spec.1
@@ -211,17 +211,15 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
   obtain ⟨⟨familyB, hFamilyB⟩⟩ :=
     exists_commonBlockedCyclicSectorFamily_of_commonMultiple
       blocksB hCycB p hp hDvdB
-  have hZA := zeroTail_toTensorFromBlocks_blockPower
-    (d := d) (D := D₁) (r := rA) (z := zeroTailA) (p := p) (dim := dimA)
-    A μA blocksA hp hMPVA
-  have hZB := zeroTail_toTensorFromBlocks_blockPower
-    (d := d) (D := D₂) (r := rB) (z := zeroTailB) (p := p) (dim := dimB)
-    B μB blocksB hp hMPVB
-  have hAPosCanon := sameMPV₂Pos_of_zeroTail_eq _ _ hZA
-  have hBPosCanon := sameMPV₂Pos_of_zeroTail_eq _ _ hZB
+  have hAPosCanon :=
+    sameMPV₂Pos_blockTensor_toTensorFromBlocks
+      (d := d) A μA blocksA hAPos p hp
+  have hBPosCanon :=
+    sameMPV₂Pos_blockTensor_toTensorFromBlocks
+      (d := d) B μB blocksB hBPos p hp
   have hBook :=
-    nonzeroBlock_blockPower_sameMPV₂Pos_of_sameMPV₂
-      A B hSame zeroTailA zeroTailB μA blocksA μB blocksB hp hMPVA hMPVB
+    sameMPV₂Pos_toTensorFromBlocks_blockPower
+      (d := d) μA blocksA μB blocksB hPos p hp
   refine ⟨p, hp, rA, dimA, μA, blocksA,
     rB, dimB, μB, blocksB, familyA, familyB,
     hFamilyA, hFamilyB, hAPosCanon, hBPosCanon, hBook, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,

--- a/TNLean/MPS/CanonicalForm/SectorComparison/NonzeroBlockComparison.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NonzeroBlockComparison.lean
@@ -69,58 +69,6 @@ theorem nonzeroBlock_sameMPV₂Pos_of_sameMPV₂
     _ = mpv B σ := hSame N σ
     _ = mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ := hBσ
 
-/-- **Reblocked nonzero-block equality at positive length.**
-
-If two tensors have the same MPVs and each is expressed as an all-zero leftover block plus a
-weighted nonzero block tensor, then every positive common reblocking raises the
-nonzero weights to powers and preserves positive-length equality of the nonzero parts.
-The all-zero leftover block contributes only at length zero, so its coefficient is
-recovered separately, at the end, from equality of the bond dimensions. -/
-theorem nonzeroBlock_blockPower_sameMPV₂Pos_of_sameMPV₂
-    {d D₁ D₂ rA rB p : ℕ}
-    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B)
-    (zeroTailA zeroTailB : ℕ)
-    (μA : Fin rA → ℂ) (blocksA : (k : Fin rA) → MPSTensor d (dimA k))
-    (μB : Fin rB → ℂ) (blocksB : (k : Fin rB) → MPSTensor d (dimB k))
-    (hp : 0 < p)
-    (hA : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d zeroTailA) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μA) blocksA) σ)
-    (hB : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv B σ = mpv (zeroMPSTensor d zeroTailB) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μB) blocksB) σ) :
-    SameMPV₂Pos
-      (toTensorFromBlocks (d := blockPhysDim d p)
-        (fun k => (μA k) ^ p)
-        (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p))
-      (toTensorFromBlocks (d := blockPhysDim d p)
-        (fun k => (μB k) ^ p)
-        (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) := by
-  have hAblock :=
-    zeroTail_toTensorFromBlocks_blockPower
-      (d := d) (D := D₁) (r := rA) (z := zeroTailA) (p := p) (dim := dimA)
-      A μA blocksA hp hA
-  have hBblock :=
-    zeroTail_toTensorFromBlocks_blockPower
-      (d := d) (D := D₂) (r := rB) (z := zeroTailB) (p := p) (dim := dimB)
-      B μB blocksB hp hB
-  have hAB : SameMPV₂ (blockTensor (d := d) (D := D₁) A p)
-      (blockTensor (d := d) (D := D₂) B p) :=
-    sameMPV₂_blockTensor A B hSame p
-  exact
-    nonzeroBlock_sameMPV₂Pos_of_sameMPV₂
-      (d := blockPhysDim d p)
-      (blockTensor (d := d) (D := D₁) A p)
-      (blockTensor (d := d) (D := D₂) B p)
-      hAB zeroTailA zeroTailB
-      (fun k => (μA k) ^ p)
-      (fun k => blockTensor (d := d) (D := dimA k) (blocksA k) p)
-      (fun k => (μB k) ^ p)
-      (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)
-      hAblock hBblock
-
 /-- **Recover full nonzero-block `SameMPV₂` once all-zero leftover blocks agree.**
 
 This combines the positive-length theorem with the single additional

--- a/TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean
@@ -70,7 +70,7 @@ The current library already settles the common-period blocking arithmetic and
 now has a one-sided phase-class BNT construction for TP primitive irreducible
 nonzero-weight blocks, one-sided overlap data, and zero-tail sector comparison
 from finite-length span or BNT comparison hypotheses. The theorem
-`afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂`
+`afterBlocking_perBlockCyclicData_of_sameMPV₂`
 follows the CPSV order: first separate the all-zero leftover block and
 TP-gauge the irreducible nonzero-weight blocks, then remove each block's period by
 cyclic sectors.

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -235,6 +235,36 @@ theorem sameMPV₂Pos_blockTensor
     _ = mpv (blockTensor (d := d) (D := D₂) B p) σ :=
           (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) B p σ).symm
 
+/-- Positive-length equality with a weighted nonzero-block tensor is preserved by
+positive physical blocking, with each weight transported to the corresponding power. -/
+theorem sameMPV₂Pos_blockTensor_toTensorFromBlocks
+    {D r : ℕ} {dim : Fin r → ℕ}
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hSame : SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μ) blocks))
+    (p : ℕ) (hp : 0 < p) :
+    SameMPV₂Pos
+      (blockTensor (d := d) (D := D) A p)
+      (toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k => (μ k) ^ p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) := by
+  have hBlock : SameMPV₂Pos
+      (blockTensor (d := d) (D := D) A p)
+      (blockTensor (d := d) (D := ∑ k : Fin r, dim k)
+        (toTensorFromBlocks (d := d) (μ := μ) blocks) p) :=
+    sameMPV₂Pos_blockTensor
+      (d := d) A (toTensorFromBlocks (d := d) (μ := μ) blocks) hSame p hp
+  have hCanon := sameMPV₂_blockTensor_toTensorFromBlocks
+    (d := d) (dim := dim) μ blocks p
+  mpv_ext
+  calc
+    mpv (blockTensor (d := d) (D := D) A p) σ =
+        mpv (blockTensor (d := d) (D := ∑ k : Fin r, dim k)
+          (toTensorFromBlocks (d := d) (μ := μ) blocks) p) σ := hBlock N hN σ
+    _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k => (μ k) ^ p)
+        (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) σ := hCanon N σ
+
 /-- Positive-length equality of weighted nonzero-block tensors is preserved after
 positive common blocking, with each weight transported to the corresponding power. -/
 theorem sameMPV₂Pos_toTensorFromBlocks_blockPower

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1432,6 +1432,42 @@ Chapter~\ref{ch:periodic_ft_apps}.
     where $\sim$ denotes generation of the same MPV family at every length.
 \end{lemma}
 
+\begin{lemma}[Positive-length equality survives blocking]%
+    \label{thm:same_mpv2_pos_block_tensor}
+    \lean{MPSTensor.sameMPV₂Pos_blockTensor}\leanok
+    \uses{def:blocked_tensor, def:same_mpv2_pos}
+    If two tensors have the same MPV coefficients at every positive length, then
+    their blocked tensors have the same MPV coefficients at every positive length
+    after any positive blocking length.
+\end{lemma}
+
+\begin{lemma}[Positive-length blocking of a weighted block sum]%
+    \label{thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks}
+    \lean{MPSTensor.sameMPV₂Pos_blockTensor_toTensorFromBlocks}\leanok
+    \uses{def:blocked_tensor, def:block_diagonal_tensor, def:same_mpv2_pos,
+        thm:same_mpv2_pos_block_tensor, thm:block_tensor_to_tensor_from_blocks}
+    Suppose $A$ and a weighted block sum
+    $\bigoplus_k \mu_k B_k$ have the same MPV coefficients at every positive
+    length.  Then after any positive blocking length $p$, the blocked tensor
+    $A^{[p]}$ and the weighted block sum
+    $\bigoplus_k \mu_k^{\,p} B_k^{[p]}$ have the same MPV coefficients at every
+    positive length.
+\end{lemma}
+
+\begin{lemma}[Positive-length equality of powered block sums]%
+    \label{thm:same_mpv2_pos_to_tensor_from_blocks_block_power}
+    \lean{MPSTensor.sameMPV₂Pos_toTensorFromBlocks_blockPower}\leanok
+    \uses{def:blocked_tensor, def:block_diagonal_tensor, def:same_mpv2_pos,
+        thm:same_mpv2_pos_block_tensor, thm:block_tensor_to_tensor_from_blocks}
+    Suppose two weighted block sums
+    $\bigoplus_j \mu^A_j A_j$ and $\bigoplus_k \mu^B_k B_k$
+    have the same MPV coefficients at every positive length.  Then after any
+    positive common blocking length $p$, the powered block sums
+    $\bigoplus_j (\mu^A_j)^p A_j^{[p]}$ and
+    $\bigoplus_k (\mu^B_k)^p B_k^{[p]}$ have the same MPV coefficients at every
+    positive length.
+\end{lemma}
+
 \begin{lemma}[Nonzero weights survive blocking]%
     \label{lem:block_weights_ne_zero}
     \lean{MPSTensor.blockWeights_ne_zero}\leanok

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -343,6 +343,36 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     Theorem~\ref{thm:block_tensor_to_tensor_from_blocks}.
 \end{proof}
 
+\begin{lemma}[One-sided zero-tail cancellation at positive length]%
+    \label{thm:same_mpv2_pos_of_zero_tail_eq}
+    \lean{MPSTensor.sameMPV₂Pos_of_zeroTail_eq}
+    \leanok
+    \uses{def:same_mpv2_pos, def:zero_mps_tensor}
+    Suppose a tensor $A$ is written as an all-zero leftover block plus a
+    nonzero part $A_{\mathrm{nz}}$:
+    \[
+        V^{(N)}(A)_\sigma
+        =
+        V^{(N)}(\mathbf{0}_{d,z})_\sigma
+        +
+        V^{(N)}(A_{\mathrm{nz}})_\sigma.
+    \]
+    Then for every $N\ge 1$ and every configuration $\sigma$,
+    \[
+        V^{(N)}(A)_\sigma = V^{(N)}(A_{\mathrm{nz}})_\sigma.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:zero_mps_tensor}
+    For $N\ge 1$, one has
+    \[
+        V^{(N)}(\mathbf{0}_{d,z})_\sigma = 0.
+    \]
+    Substituting this identity in the displayed zero-tail decomposition gives the
+    positive-length equality.
+\end{proof}
+
 \begin{theorem}[Positive-length equality of nonzero block tensors]%
     \label{thm:nonzero_block_zero_tail_identity}
     \lean{MPSTensor.nonzeroBlock_sameMPV₂Pos_of_sameMPV₂}
@@ -405,7 +435,7 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     \lean{MPSTensor.afterBlocking_perBlockCyclicData_of_sameMPV₂}
     \leanok
     \uses{thm:tp_gauge_arbitrary, thm:nonzero_block_zero_tail_identity,
-        def:primitive_irreducible_cyclic_sectors,
+        thm:same_mpv2_pos_of_zero_tail_eq, def:primitive_irreducible_cyclic_sectors,
         thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
     If two tensors $A$ and $B$ generate the same MPV family, then after the
     zero-block split and the trace-preserving gauge there are weighted
@@ -437,13 +467,22 @@ a single tensor $\mathbf{0}_{d,D_0}$.
 
 \begin{proof}\leanok
     \uses{thm:tp_gauge_arbitrary, thm:nonzero_block_zero_tail_identity,
+        thm:same_mpv2_pos_of_zero_tail_eq,
         thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
     Apply the arbitrary-tensor TP-gauge theorem separately to $A$ and $B$. The
-    zero-block summands vanish at positive length, so each tensor agrees with its
-    nonzero part there, and the positive-length equality theorem compares the two
-    nonzero parts. Finally apply
-    Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr} to every
-    trace-preserving irreducible nonzero-weight block.
+    one-sided zero-tail cancellation theorem gives, for every $N\ge 1$,
+    \[
+        V^{(N)}(A)_\sigma
+        =
+        V^{(N)}\!(\textstyle\bigoplus_j \mu^A_j A_j)_\sigma,
+        \qquad
+        V^{(N)}(B)_\sigma
+        =
+        V^{(N)}\!(\textstyle\bigoplus_k \mu^B_k B_k)_\sigma.
+    \]
+    The positive-length equality theorem compares the two nonzero parts. Finally
+    apply Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr} to
+    every trace-preserving irreducible nonzero-weight block.
 \end{proof}
 
 \begin{theorem}[Common blocking length for cyclic sectors]%
@@ -488,11 +527,19 @@ a single tensor $\mathbf{0}_{d,D_0}$.
         thm:common_blocked_cyclic_sector_derived_properties}
     Start from the per-block cyclic-sector theorem. Let $p_A$ and $p_B$ be the
     least common multiples of the period-removal lengths on the two sides, and
-    use $p=\operatorname{lcm}(p_A,p_B)$. The prescribed-common-multiple theorem constructs both
-    one-sided sector families at this same length. The positive-length blocking
-    lemmas transport the one-sided tensor/nonzero-part equalities and the
-    two-sided nonzero-part equality to the common blocked alphabet; the sector
-    conclusions are the common-alphabet MPV equalities.
+    use $p=\operatorname{lcm}(p_A,p_B)$. The prescribed-common-multiple theorem
+    constructs both one-sided sector families at this same length. The
+    positive-length blocking lemmas transport the one-sided tensor/nonzero-part
+    equalities to the common blocked alphabet; for instance, for every $N\ge 1$,
+    \[
+        V^{(N)}\!(A^{[p]})_\sigma
+        =
+        V^{(N)}\!\bigl(\textstyle\bigoplus_j
+        (\mu^A_j)^p (A_j)^{[p]}\bigr)_\sigma.
+    \]
+    The same argument applies on the $B$ side, and the two-sided positive-length
+    blocking lemma gives the equality of the two powered nonzero parts. The
+    sector conclusions are the common-alphabet MPV equalities.
 \end{proof}
 
 \begin{theorem}[Length-zero identity under compatible blocking]%

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -376,36 +376,6 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     decompositions can be compared directly through the common MPV family.
 \end{proof}
 
-\begin{theorem}[Positive-length equality of blocked nonzero parts]%
-    \label{thm:nonzero_block_block_power_zero_tail_identity}
-    \lean{MPSTensor.nonzeroBlock_blockPower_sameMPV₂Pos_of_sameMPV₂}
-    \leanok
-    \uses{thm:nonzero_block_zero_tail_identity,
-        thm:zero_tail_to_tensor_from_blocks_block_power, def:same_mpv2_pos}
-    In the setting of Theorem~\ref{thm:nonzero_block_zero_tail_identity}, let
-    \[
-        A_{\mathrm{nz}}=\textstyle\bigoplus_j \mu^A_j A_j,
-        \qquad
-        B_{\mathrm{nz}}=\textstyle\bigoplus_k \mu^B_k B_k.
-    \]
-    After any positive common blocking length $p$, the powered nonzero parts
-    satisfy, for every $N\ge 1$ and every blocked configuration $\sigma$,
-    \[
-        V^{(N)}\!\bigl(\textstyle\bigoplus_j
-        (\mu^A_j)^p (A_j)^{[p]}\bigr)_\sigma
-        =
-        V^{(N)}\!\bigl(\textstyle\bigoplus_k
-        (\mu^B_k)^p (B_k)^{[p]}\bigr)_\sigma.
-    \]
-\end{theorem}
-
-\begin{proof}\leanok
-    Use Theorem~\ref{thm:zero_tail_to_tensor_from_blocks_block_power} on both
-    zero-tail decompositions, block the original MPV equality, and apply
-    Theorem~\ref{thm:nonzero_block_zero_tail_identity} at the blocked physical
-    dimension.
-\end{proof}
-
 \begin{theorem}[Equal zero tails give full nonzero-part MPV equality]%
     \label{thm:nonzero_block_same_mpv_zero_tail_eq}
     \lean{MPSTensor.nonzeroBlock_sameMPV₂_of_sameMPV₂_of_zeroTail_eq}
@@ -430,30 +400,28 @@ a single tensor $\mathbf{0}_{d,D_0}$.
 \end{proof}
 
 
-\begin{theorem}[Cyclic sectors after the zero-tail split]%
+\begin{theorem}[Cyclic sectors after the zero-block split]%
     \label{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
-    \lean{MPSTensor.afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂}
+    \lean{MPSTensor.afterBlocking_perBlockCyclicData_of_sameMPV₂}
     \leanok
     \uses{thm:tp_gauge_arbitrary, thm:nonzero_block_zero_tail_identity,
         def:primitive_irreducible_cyclic_sectors,
         thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
     If two tensors $A$ and $B$ generate the same MPV family, then after the
-    zero-tail split and the trace-preserving gauge there are decompositions
+    zero-block split and the trace-preserving gauge there are weighted
+    nonzero-block tensors $\bigoplus_j \mu^A_j A_j$ and
+    $\bigoplus_k \mu^B_k B_k$.  For every $N\ge 1$ and every configuration
+    $\sigma$,
     \[
         V^{(N)}(A)_\sigma
         =
-        V^{(N)}(\mathbf{0}_{d,z_A})_\sigma
-        +
         V^{(N)}\!(\textstyle\bigoplus_j \mu^A_j A_j)_\sigma,
-    \]
-    \[
+        \qquad
         V^{(N)}(B)_\sigma
         =
-        V^{(N)}(\mathbf{0}_{d,z_B})_\sigma
-        +
-        V^{(N)}\!(\textstyle\bigoplus_k \mu^B_k B_k)_\sigma.
+        V^{(N)}\!(\textstyle\bigoplus_k \mu^B_k B_k)_\sigma,
     \]
-    The nonzero parts agree for every $N\ge 1$:
+    and the two nonzero parts agree:
     \[
         V^{(N)}\!(\textstyle\bigoplus_j \mu^A_j A_j)_\sigma
         =
@@ -471,8 +439,9 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     \uses{thm:tp_gauge_arbitrary, thm:nonzero_block_zero_tail_identity,
         thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
     Apply the arbitrary-tensor TP-gauge theorem separately to $A$ and $B$. The
-    positive-length equality theorem compares the two resulting nonzero parts.
-    Finally apply
+    zero-block summands vanish at positive length, so each tensor agrees with its
+    nonzero part there, and the positive-length equality theorem compares the two
+    nonzero parts. Finally apply
     Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr} to every
     trace-preserving irreducible nonzero-weight block.
 \end{proof}
@@ -483,8 +452,8 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     \leanok
     \uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
         thm:exists_common_blocked_cyclic_sector_family_common_multiple,
-        thm:zero_tail_to_tensor_from_blocks_block_power,
-        thm:nonzero_block_block_power_zero_tail_identity,
+        thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks,
+        thm:same_mpv2_pos_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_reindexed_samempv,
         thm:common_blocked_cyclic_sector_derived_properties}
     If two tensors generate the same MPV family, then the cyclic-sector
@@ -513,17 +482,17 @@ a single tensor $\mathbf{0}_{d,D_0}$.
 \begin{proof}\leanok
     \uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
         thm:exists_common_blocked_cyclic_sector_family_common_multiple,
-        thm:zero_tail_to_tensor_from_blocks_block_power,
-        thm:nonzero_block_block_power_zero_tail_identity,
+        thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks,
+        thm:same_mpv2_pos_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_reindexed_samempv,
         thm:common_blocked_cyclic_sector_derived_properties}
     Start from the per-block cyclic-sector theorem. Let $p_A$ and $p_B$ be the
     least common multiples of the period-removal lengths on the two sides, and
     use $p=\operatorname{lcm}(p_A,p_B)$. The prescribed-common-multiple theorem constructs both
-    one-sided sector families at this same length. Blocking each one-sided
-    decomposition and removing the all-zero leftover block at positive length
-    gives the displayed positive-length equalities, and the sector conclusions
-    are the common-alphabet MPV equalities.
+    one-sided sector families at this same length. The positive-length blocking
+    lemmas transport the one-sided tensor/nonzero-part equalities and the
+    two-sided nonzero-part equality to the common blocked alphabet; the sector
+    conclusions are the common-alphabet MPV equalities.
 \end{proof}
 
 \begin{theorem}[Length-zero identity under compatible blocking]%


### PR DESCRIPTION
### Motivation

Issue #2157 identified one remaining place where the after-blocking chain still carried zero-tail decomposition equations even though the later argument only needed positive-length MPV equalities. The mathematical point is that positive-length MPV equality is itself preserved under positive physical blocking.

### Description

- Add `MPSTensor.sameMPV₂Pos_blockTensor_toTensorFromBlocks`: if `A` agrees at positive length with a weighted nonzero-block tensor, then `blockTensor A p` agrees at positive length with the powered weighted block tensor for every `0 < p`.
- Rename `afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂` to `afterBlocking_perBlockCyclicData_of_sameMPV₂` and replace the exported zero-tail dimensions and decomposition equations by three `SameMPV₂Pos` conclusions: `A` with its nonzero part, `B` with its nonzero part, and the two nonzero parts with each other.
- Rewrite `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` to transport those positive-length identities directly to the common blocking length.
- Remove the now-unused corollary `nonzeroBlock_blockPower_sameMPV₂Pos_of_sameMPV₂`; its content is exactly the direct composition now used at the call site.
- Keep `zeroTail_toTensorFromBlocks_blockPower`, since it remains used by length-zero zero-block transport in `TPPrimitiveReduction` and `CommonSectorTransport`.
- Update the blueprint entries in chapters 8 and 11b to record the positive-length blocking lemmas and the revised proof route.

### Testing

- `lake build`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files ...`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`

`lake exe checkdecls blueprint/lean_decls` was also run after regenerating `blueprint/lean_decls`; it fails only on pre-existing missing blueprint declarations outside this change.

Closes #2157.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the formal proof spine for CPSV after-blocking sector comparison (renamed theorem, new lemma, deleted corollary); risk is proof/regression in Lean and blueprint sync, not runtime or security.
> 
> **Overview**
> This refactor streamlines the **after-blocking** canonical-form chain so later steps carry **`SameMPV₂Pos`** (positive-length MPV agreement) instead of full zero-tail decomposition equations.
> 
> **`TNLean/MPS/Core/BlockingInfrastructure.lean`** adds **`sameMPV₂Pos_blockTensor_toTensorFromBlocks`**: if a tensor matches a weighted nonzero block sum at every positive length, then after blocking by `p > 0`, **`blockTensor A p`** matches the powered weighted block tensor with weights **`μ_k^p`**.
> 
> **`afterBlocking_perBlockCyclicDataWithZeroTail_of_sameMPV₂`** is renamed to **`afterBlocking_perBlockCyclicData_of_sameMPV₂`**. The existential no longer exports zero-tail dimensions or per-length zero-tail MPV splits; it states three **`SameMPV₂Pos`** facts (each side vs its nonzero part, and the two nonzero parts vs each other), built via **`sameMPV₂Pos_of_zeroTail_eq`** after the existing TP-gauge construction.
> 
> **`afterBlocking_commonLengthCommonSectorData_of_sameMPV₂`** now lifts those identities to the common blocking length using **`sameMPV₂Pos_blockTensor_toTensorFromBlocks`** and **`sameMPV₂Pos_toTensorFromBlocks_blockPower`** instead of **`zeroTail_toTensorFromBlocks_blockPower`** plus **`nonzeroBlock_blockPower_sameMPV₂Pos_of_sameMPV₂`**.
> 
> The corollary **`nonzeroBlock_blockPower_sameMPV₂Pos_of_sameMPV₂`** is removed from **`NonzeroBlockComparison.lean`** as redundant. Blueprint chapters **8** and **11b** document the new positive-length blocking lemmas and the revised proof route; **`StructuralData.lean`** references the renamed theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a03688c5404f290dcff2203928934495fef26ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->