### PR TITLE
doc(PEPS): point T-cover status to paper-gap note

### DIFF
--- a/TNLean/PEPS/NormalEdgeComplementCover.lean
+++ b/TNLean/PEPS/NormalEdgeComplementCover.lean
@@ -255,12 +255,11 @@ theorem normalSquareEdgeComplementRegion_eq_T_union_topCollar :
 cover of the normalized horizontal-edge \(5\times7\) complementary block by
 adding the two top-collar \(3\times2\) rectangles.
 
-**Scope restriction (T-cover):** This construction is conditional on a
-rectangular cover of the displayed local \(T\)-region. Under the present
-exact-cover criterion, the origin local \(T\)-region has no such cover for
-\(5 \leq\) `width` and \(6 \leq\) `height`, hence also for this \(5\times7\)
-frame. The source-faithful finite PEPS geometry is recorded as an open
-obligation in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+**Scope restriction (T-cover):** This construction remains conditional on a
+rectangular cover of the displayed local \(T\)-region. The source comparison,
+the exact-cover obstruction, and the elimination plan are recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
 
 This is the rectangular-cover form of the top-collar decomposition of the
 edge-complementary block. It separates this finite-lattice collar step from
@@ -710,14 +709,10 @@ displayed \(T\)-region supply the abstract square-lattice blocking-region
 structure.
 
 **Scope restriction (T-cover):** This conditional result assumes a
-rectangular cover of the displayed \(T\)-region at the origin. Under the
-present exact-cover criterion, no such cover exists:
-`not_normalSquareRegionT_rectangleCover_at_origin` rules it out for
-\(5 \leq\) `width` and \(6 \leq\) `height`, and hence a fortiori under the
-`7 ≤ width` and `7 ≤ height` bounds assumed here. The conditional theorem is
-therefore currently vacuous at the origin in the current coordinate model. A
-source-faithful cover construction tied to the finite PEPS geometry is recorded
-as an open obligation in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+rectangular cover of the displayed \(T\)-region at the origin. The source
+comparison, the exact-cover obstruction, and the elimination plan are recorded
+in `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1500
 of `Papers/1804.04964/paper_normal.tex`. -/

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2951,8 +2951,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     rotated vertical local $T$-region has the same conditional injectivity
     criterion.
 \end{lemma}
-% Maintainer note: this is still conditional; the concrete source cover is not
-% yet constructed.
+% Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok
     Apply rectangular injectivity to every rectangle in the cover, then apply
     finite union closure to the nonempty family.
@@ -2976,8 +2975,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     enough to give such a cover of the local $T$-region, since adjoining the
     two top-collar $3\times2$ rectangles gives a cover of $A_3$.
 \end{lemma}
-% Maintainer note: the concrete cover required by
-% \cite[Theorem~3]{Molnar2018NormalPEPS} remains to be constructed.
+% Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok
     Apply rectangular injectivity to every rectangle in the cover, then apply
     finite union closure to the nonempty family.  For the normalized
@@ -3035,8 +3033,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         \TNPEPSNormalEdgeComplementTopCollar
     \end{center}
 \end{lemma}
-% Maintainer note: this still leaves local/rotated T-injectivity and the
-% translated every-edge construction open.
+% Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok
     The two set identities follow by expanding the coordinate inequalities.
     The injectivity statements apply union closure first to the local
@@ -3434,9 +3431,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $n,m\geq7$, the rectangular hypotheses, union closure, and a rectangular
     cover of the displayed $T$-region yield this abstract $R,S,T$
     structure, with $R$ and $S$ obtained from their rectangular
-    decompositions and $T$ obtained from the supplied cover.  Under the
-    present exact-cover criterion this converse is vacuous at the origin:
-    the no-cover lemma for the displayed $T$-region rules out such a cover.
+    decompositions and $T$ obtained from the supplied cover.
     % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
     The source regions are:
     \begin{center}


### PR DESCRIPTION
### Motivation

- The scope-restriction prose for the local $T$-cover obstruction in the square-lattice PEPS route was duplicated inline in both `TNLean/PEPS/NormalEdgeComplementCover.lean` and `blueprint/src/chapter/ch13a_peps_ft.tex`, creating a maintenance burden when the elimination plan evolves.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex` (Section "Remaining mathematical obligations") is the designated single source of truth for the source comparison, the exact-cover obstruction, and the elimination plan for this gap; the inline copies should point there instead.
- The mathematical source is arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1504 of `Papers/1804.04964/paper_normal.tex`.

### Description

- `TNLean/PEPS/NormalEdgeComplementCover.lean`: shortened the **Scope restriction (T-cover)** docstrings on `normalSquareEdgeComplementRectangleCoverOfT` and `normalSquareBlockingRegions_of_TCover`; inline details about `not_normalSquareRegionT_rectangleCover_at_origin` and the vacuous origin case are removed, replaced by a pointer to `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining mathematical obligations".
- `blueprint/src/chapter/ch13a_peps_ft.tex`: replaced several maintainer notes on $T$-cover, edge-complement, and collar lemmas with the same paper-gap pointer; the `peps_normalSquareBlockingRegions` definition remark now defers the exact-cover obstruction detail to the paper-gap note.
- No Lean declarations, theorem statements, or proofs are changed.

### Testing

- `lake env lean TNLean/PEPS/NormalEdgeComplementCover.lean`
- `git diff --check`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/NormalEdgeComplementCover.lean`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`

---
Related to #2004