### PR TITLE
doc(PEPS): point edge-window status to paper-gap note

### DIFF
--- a/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
@@ -64,10 +64,11 @@ abbrev normalSquareHorizontalEdgeComplement : Finset (SquareLatticeVertex 5 7) :
 /-- The normalized horizontal edge has the red/blue/complement blocking data
 used in the proof of the normal square-lattice theorem.
 
-This definition records the set-theoretic and injectivity data for the concrete
-horizontal-edge blocking as one `NormalEdgeBlockingData` value. The
-source-comparison status of the every-edge construction is recorded in
-`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+This definition records the set-theoretic and injectivity facts for the concrete
+horizontal-edge blocking as one `NormalEdgeBlockingData` value. The source
+comparison and every-edge elimination plan are recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 def normalSquareHorizontalEdge_blockingDatum
@@ -246,10 +247,11 @@ abbrev normalSquareVerticalEdgeComplement : Finset (SquareLatticeVertex 7 5) :=
 /-- The normalized vertical edge has the red/blue/complement blocking datum
 used in the proof of the normal square-lattice theorem.
 
-This definition records the set-theoretic data for the vertical-edge blocking.
+This definition records the set-theoretic facts for the vertical-edge blocking.
 Injectivity of the complementary block is kept as an explicit hypothesis here.
-The source-comparison status of that finite-geometry input is recorded in
-`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+The source comparison and finite-geometry elimination plan are recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 def normalSquareVerticalEdge_blockingDatum
@@ -392,9 +394,10 @@ def normalSquareVerticalEdge_blockingDatum_of_verticalTCover
 /-- The normalized vertical edge supplies the three injective regions used in
 the edge-blocked three-site chain.
 
-The complementary-block injectivity remains an explicit input here; the
-source-comparison status is recorded in
-`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+The complementary-block injectivity remains an explicit input here. The source
+comparison and finite-geometry elimination plan are recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 theorem normalSquareVerticalEdge_injective_chain

--- a/TNLean/PEPS/NormalEdgeBlockingTranslated.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingTranslated.lean
@@ -433,8 +433,9 @@ universe edgeCoverUniverse
 edge-blocking windows.
 
 The constructors deliberately record the rectangular cover of the complementary
-region. The source-comparison status of the every-edge window construction is
-recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+region. The source comparison and every-edge window elimination plan are
+recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section
+"Remaining mathematical obligations".
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 inductive NormalSquareTranslatedEdgeWindow {width height : ℕ}
@@ -737,8 +738,9 @@ normal edge-blocking window.
 This records the per-edge finite-geometry input in the current rectangular
 coordinate model: an edge must be horizontal or vertical, have the corresponding
 named margins, and have a rectangular cover for its complementary block. The
-source-comparison status of the every-edge construction is recorded in
-`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+source comparison and every-edge window elimination plan are recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
 inductive NormalSquareEdgeMarginCover {width height : ℕ}


### PR DESCRIPTION
### Motivation

The normal PEPS edge-window coordinate files still had several local status remarks for the every-edge finite-geometry construction. The authoritative list of remaining mathematical obligations is now `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining mathematical obligations".

The local docstrings should say what each declaration records and point to that section for the source comparison and elimination plan, rather than carrying a separate status ledger.

### Description

- Updates `NormalEdgeBlockingCoordinate.lean` docstrings for the normalized horizontal and vertical edge blocking data, and for the vertical injective-chain statement.
- Updates `NormalEdgeBlockingTranslated.lean` docstrings for translated edge windows and per-edge margin/cover data.
- Keeps the mathematical restriction visible: complementary-block injectivity and every-edge window construction remain finite-geometry inputs.
- No Lean declarations, theorem statements, or proofs are changed.
- Related trackers: #1373 and #2004
- Paper: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500
- Paper-gap note: `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining mathematical obligations"

### Testing

- `lake env lean TNLean/PEPS/NormalEdgeBlockingCoordinate.lean`
- `lake env lean TNLean/PEPS/NormalEdgeBlockingTranslated.lean`
- `git diff --check`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/NormalEdgeBlockingCoordinate.lean TNLean/PEPS/NormalEdgeBlockingTranslated.lean`

---
Related to #1373
Related to #2004