### PR TITLE
doc(SectorBNT): record equal-modulus declaration path

### DIFF
--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -11,15 +11,19 @@ equal-modulus comparison has these current reference points.
 - `blueprint/src/chapter/ch10_bnt.tex` records the SectorBNT canonical-form
   surface, the repeated-copy sector coefficients, and the Newton--Girard
   power-sum recovery.
+- `cpsv16_global_vs_persector_unit_witness.tex` records the current Lean
+  declaration path for equal-modulus copy matching and the surviving
+  per-sector unit-witness restriction.
 - `blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` records only how
   the Chapter 10 comparison is used in the equal-MPV Fundamental Theorem
   argument.
-- GitHub issue #2150 tracks the remaining verification that the assembled
-  multi-block theorem uses this equal-modulus comparison without a surviving
-  strictly-decreasing-moduli restriction.
+- GitHub issue #2150 records the verification request.  The outcome now
+  recorded in the paper-gap note is that no strictly-decreasing-moduli
+  hypothesis survives in the SectorBNT declaration path; the remaining
+  non-source-faithful hypothesis is the per-sector unit witness.
 
-The separate global-versus-per-sector unit-witness restriction has one current
-paper-gap note.
+The global-versus-per-sector unit-witness restriction has one current paper-gap
+note.
 
 - `cpsv16_global_vs_persector_unit_witness.tex` records that the current
   full-basis matching theorems assume a unit-modulus copy in every sector,

--- a/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
+++ b/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
@@ -60,11 +60,16 @@ per-sector unit-weight hypotheses are supplied, they prove the sector matching,
 coefficient comparison, copy-weight recovery, and direct-sum gauge
 construction without imposing any strict ordering of the copy-weight moduli.
 
-\section{Relation to the equal-modulus issue}
+\section{Equal-modulus declaration path}
 
-This restriction is logically separate from the retired strict-moduli
-formulation.  The current SectorBNT coefficient comparison works with raw
-sector coefficients
+The current formal assembly is organized through
+\path{TNLean/MPS/FundamentalTheorem/SectorBNT/}.  There is no separate
+\path{TNLean/MPS/FundamentalTheorem/Multi/} assembly directory on the current
+main branch.
+
+The equal-modulus question is logically separate from the per-sector
+unit-witness restriction above.  The current SectorBNT coefficient comparison
+works with raw sector coefficients
 \[
   c_N^{(j)} = \sum_q \mu_{j,q}^N
 \]
@@ -72,6 +77,37 @@ and the copy weights are recovered from these coefficients by the finite
 power-sum argument.  Equal-modulus copies such as the two copies in
 \(C \oplus (-C)\), and unequal-modulus copies such as \(C \oplus (1/2)C\),
 are both represented by the raw two-layer SectorBNT formulation.
+
+The declaration path is as follows.
+\begin{itemize}
+  \item \leanid{MPSTensor.IsBNTCanonicalForm} records the raw copy weights
+        \(\mu_{j,q}\), their coefficient sums, the bound
+        \(|\mu_{j,q}| \le 1\), and the single global unit witness.  It imposes
+        neither a strict ordering of the moduli nor an equal-modulus layer.
+  \item Sectorwise non-decay is supplied, after a unit-modulus copy in the
+        given sector is available, by the declarations
+        \path{MPSTensor.CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus}
+        and \path{MPSTensor.IsBNTCanonicalForm.coeff_not_eventually_zero}.
+  \item Eventual equality of the sector coefficient sequences is converted into
+        equality of copy weights by
+        \leanid{MPSTensor.matched_sector_weight_multiset_eq} and
+        \leanid{MPSTensor.matched_sector_weight_equiv}, using the finite
+        power-sum recovery theorem
+        \path{Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card}.
+  \item \leanid{MPSTensor.SectorBNTCopyWeightMatching.of_coeff_identity}
+        packages this recovery into the copy-weight matching used by the
+        proportional global-gauge theorem.
+  \item In the equal-MPV path,
+        \path{MPSTensor.ft_sector_bnt_equal_sector_data} and
+        \path{MPSTensor.ft_sector_bnt_equal_global_gauge} invoke the same
+        coefficient-to-copy-weight step.  The coordinate-level statement is
+        \path{MPSTensor.ft_sector_bnt_equal_mps_gaugeEquiv_literal}.
+\end{itemize}
+
+Thus equal-modulus examples such as \(C \oplus (-C)\) are handled by the raw
+coefficient comparison and finite power-sum recovery after sector matching.  No
+theorem in this SectorBNT declaration path assumes a strict ordering of the
+copy-weight moduli.
 
 The remaining extra hypothesis is not strictness of moduli.  It is the
 per-sector existence of a unit-modulus copy weight, which is stronger than the

--- a/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
+++ b/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
@@ -86,22 +86,28 @@ The declaration path is as follows.
         neither a strict ordering of the moduli nor an equal-modulus layer.
   \item Sectorwise non-decay is supplied, after a unit-modulus copy in the
         given sector is available, by the declarations
-        \path{MPSTensor.CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus}
-        and \path{MPSTensor.IsBNTCanonicalForm.coeff_not_eventually_zero}.
+        \begin{center}
+        {\small\leanid{MPSTensor.CesaroNonDecay.sum_pow_not_tendsto_zero_of_unit_modulus}}\\
+        {\small\leanid{MPSTensor.IsBNTCanonicalForm.coeff_not_eventually_zero}}.
+        \end{center}
   \item Eventual equality of the sector coefficient sequences is converted into
         equality of copy weights by
         \leanid{MPSTensor.matched_sector_weight_multiset_eq} and
         \leanid{MPSTensor.matched_sector_weight_equiv}, using the finite
         power-sum recovery theorem
-        \path{Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card}.
+        \begin{center}
+        {\small\leanid{Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card}}.
+        \end{center}
   \item \leanid{MPSTensor.SectorBNTCopyWeightMatching.of_coeff_identity}
         packages this recovery into the copy-weight matching used by the
         proportional global-gauge theorem.
-  \item In the equal-MPV path,
-        \path{MPSTensor.ft_sector_bnt_equal_sector_data} and
-        \path{MPSTensor.ft_sector_bnt_equal_global_gauge} invoke the same
-        coefficient-to-copy-weight step.  The coordinate-level statement is
-        \path{MPSTensor.ft_sector_bnt_equal_mps_gaugeEquiv_literal}.
+  \item In the equal-MPV path, the declarations
+        \begin{center}
+        {\small\leanid{MPSTensor.ft_sector_bnt_equal_sector_data}}\\
+        {\small\leanid{MPSTensor.ft_sector_bnt_equal_global_gauge}}\\
+        {\small\leanid{MPSTensor.ft_sector_bnt_equal_mps_gaugeEquiv_literal}}
+        \end{center}
+        use the same coefficient-to-copy-weight step.
 \end{itemize}
 
 Thus equal-modulus examples such as \(C \oplus (-C)\) are handled by the raw


### PR DESCRIPTION
### Motivation

- Issue #2150 asks to trace the equal-modulus sector argument and record, for the per-sector unit-witness paper-gap note, the exact Lean declaration path that discharges equal-modulus copy matching in the SectorBNT layer.
- The paper-gap note (`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`) previously lacked a named declaration path, making it impossible to audit whether a strictly-decreasing-moduli hypothesis survives in this sub-argument.

### Description

- `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`: adds an **Equal-modulus declaration path** section citing formal work under `TNLean/MPS/FundamentalTheorem/SectorBNT/` (not the `Multi/` assembly layer). Names the following declarations: raw coefficient, sector non-decay (Cesaro), finite power-sum recovery, `SectorBNTCopyWeightMatching.of_coeff_identity`, and the equal-MPV global-gauge results. States that no strictly-decreasing-moduli hypothesis appears on this path; the surviving extra hypothesis is the per-sector unit witness. Source: CPSV16 arXiv:1606.00608, Section II.C line 246 and the BNT two-layer display at lines 287--289.
- `docs/paper-gaps/README.md`: designates the above note as the single reference point for equal-modulus copy matching; records issue #2150 as resolved for the strictly-decreasing-moduli question, with the per-sector unit witness called out as the remaining non-source-faithful gap.

### Testing

- `git diff --check` (no trailing whitespace)
- LaTeX build of the updated paper-gap note: `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error cpsv16_global_vs_persector_unit_witness.tex`
- No `.lean` files changed; Lean CI (`lean_action_ci.yml`) covers any downstream validation.

---
Addresses #2150

> [!NOTE]
> **Low Risk**
> Documentation-only updates to paper-gap notes and the index; no Lean or runtime behavior changes.
>
> **Overview**
> Documentation now treats **`cpsv16_global_vs_persector_unit_witness.tex`** as the single paper-gap reference for **equal-modulus copy matching** in the SectorBNT path, alongside the surviving **per-sector unit witness** gap.
>
> The note gains an **Equal-modulus declaration path** section: formal work lives under **`TNLean/MPS/FundamentalTheorem/SectorBNT/`** (no **`Multi/`** assembly), and it walks from **`IsBNTCanonicalForm`** through Cesaro non-decay, finite power-sum recovery, **`SectorBNTCopyWeightMatching.of_coeff_identity`**, and the equal-MPV global-gauge declarations—stating that **no strict ordering of copy-weight moduli** is assumed on this path.
>
> **`docs/paper-gaps/README.md`** is updated so issue **#2150** is recorded as resolved for the strictly-decreasing-moduli question, with the per-sector unit witness called out as what remains non-source-faithful.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81f996f683d55fbd68e776f540e356a2dbbb4af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to paper-gap notes; no Lean or runtime behavior changes.
> 
> **Overview**
> **Paper-gap documentation** now traces how **equal-modulus copy matching** is discharged in Lean and what gap remains versus CPSV16.
> 
> `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex` gains an **Equal-modulus declaration path** section: assembly is under `TNLean/MPS/FundamentalTheorem/SectorBNT/` (not `Multi/`), and the note lists the chain from `IsBNTCanonicalForm` through Cesaro non-decay, finite power-sum recovery, `SectorBNTCopyWeightMatching.of_coeff_identity`, and the equal-MPV global-gauge theorems. It states that **no strict ordering of copy-weight moduli** appears on that path; the **per-sector unit-modulus copy** hypothesis is the surviving extra assumption.
> 
> `docs/paper-gaps/README.md` points readers to that note for equal-modulus matching and records GitHub **#2150** as resolved for the strictly-decreasing-moduli question, with the per-sector unit witness still called out as non-source-faithful.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39600bd1ff40697acfc933e4b266d1f01fa965ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->