### PR TITLE
doc(blueprint): distinguish transfer and Hamiltonian gaps

### DIFF
--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -769,7 +769,8 @@ matching the weighted-trace argument in
     only element is $1$.
 \end{proof}
 
-\begin{theorem}[Primitive maps have a spectral gap on the complement]\label{thm:primitive_compl_lt_one}
+\begin{theorem}[Complementary transfer-map gap for primitive maps]%
+    \label{thm:primitive_compl_lt_one}
     \lean{compl_eigenvalue_norm_lt_one_of_primitive}
     \leanok
     \uses{def:primitive_channel, def:fixed_point_proj, def:trace_preserving}

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1,12 +1,18 @@
-\chapter{Spectral Gap and Block Separation}\label{ch:spectral}
+\chapter{Transfer-Operator Gaps and Block Separation}\label{ch:spectral}
 
 This chapter proves that the MPV overlaps between distinct
 (non-gauge-phase-equivalent) MPS blocks decay to zero as system
 size grows. It also proves the corresponding self-overlap convergence
-to~$1$ under the complementary spectral-gap hypothesis that encodes
+to~$1$ under the complementary transfer-map gap hypothesis that encodes
 primitivity in the cases of interest. The argument is based on a
 spectral analysis of the \emph{mixed transfer operator},
 following~\cite{PerezGarcia2007Matrix}.
+
+This chapter concerns gaps in the spectrum of transfer operators:
+$\rho(F_{AB}) < 1$ for mixed transfer operators, and
+$\rho(\E_A - P) < 1$ after removing the fixed-point projection. The
+unqualified phrase \emph{spectral gap} is reserved for the energy gap of a
+many-body Hamiltonian in Chapter~\ref{ch:parent_hamiltonian}.
 
 The algebraic mixed-transfer identities in the first two sections do
 not use normalization. Starting with the spectral-radius estimates,
@@ -197,7 +203,7 @@ mixed transfer power.
 
 \section{Frobenius norm estimates}
 
-The spectral-gap proofs use the Frobenius (Hilbert--Schmidt) norm
+The transfer-operator gap proofs use the Frobenius (Hilbert--Schmidt) norm
 as the natural norm for the finite-dimensional matrix algebra.
 We write $\|{\cdot}\|_F$ for this norm; it coincides with, and we use it
 interchangeably with, the Hilbert--Schmidt norm $\|{\cdot}\|_{\mathrm{HS}}$ on finite-dimensional spaces.
@@ -244,7 +250,7 @@ Euclidean space.
     Expand both sides as sums over entries and use $|z|^2 = \bar{z}z$.
 \end{proof}
 
-\section{Eigenvalue bound and spectral gap}
+\section{Eigenvalue bound and transfer-operator gap}
 
 The eigenvalue bound comes from a uniform Frobenius-norm estimate
 obtained directly from the trace-preserving normalization
@@ -426,12 +432,12 @@ a block embedding of a mixed-transfer eigenvector.
     the family \emph{trace-preserving} ($\sum_i (\tilde{A}^i)^\dagger \tilde{A}^i = \Id$).
     Both conventions appear in practice:
     the unital version via direct matrix square-root inversion
-    (used in the spectral-gap proof above), and the trace-preserving
+    (used in the transfer-operator gap proof above), and the trace-preserving
     version (used in the canonical-form reduction of
     Chapter~\ref{ch:canonical}).
 \end{remark}
 
-\begin{theorem}[Strict spectral gap]\label{thm:spectral_gap}
+\begin{theorem}[Strict transfer-operator gap]\label{thm:spectral_gap}
     \lean{MPSTensor.spectralRadius_mixedTransfer_lt_one}
     \leanok
     \uses{def:gauge_phase_equiv, def:injective, def:mixed_transfer}
@@ -448,7 +454,7 @@ a block embedding of a mixed-transfer eigenvector.
     equivalence, contradicting the hypothesis.
 \end{proof}
 
-\section{Spectral gap --- rectangular case}
+\section{Transfer-operator gap --- rectangular case}
 
 \begin{theorem}[Rectangular intertwining forces equal bond dimension]%
     \label{thm:rectangular_intertwining_dim_eq}
@@ -475,7 +481,7 @@ a block embedding of a mixed-transfer eigenvector.
     Applying the same argument to $X^\dagger$ gives $D_1 \le D_2$.
 \end{proof}
 
-\begin{theorem}[Rectangular spectral gap]\label{thm:spectral_gap_rect}
+\begin{theorem}[Rectangular transfer-operator gap]\label{thm:spectral_gap_rect}
     \lean{MPSTensor.mixedTransferSpectralRadius₂_lt_one_of_dim_ne}
     \leanok
     \uses{def:mixed_transfer_rect, def:injective}
@@ -511,7 +517,7 @@ a block embedding of a mixed-transfer eigenvector.
 \end{theorem}
 
 \begin{proof}\leanok\uses{thm:spectral_gap_rect, thm:overlap_trace_rect}
-    The spectral gap $\rho(F_{AB}^{\mathrm{rect}}) < 1$
+    The transfer-operator gap $\rho(F_{AB}^{\mathrm{rect}}) < 1$
     (Theorem~\ref{thm:spectral_gap_rect}) implies
     $(F_{AB}^{\mathrm{rect}})^N \to 0$, so the operator
     trace converges to~$0$.
@@ -533,7 +539,7 @@ a block embedding of a mixed-transfer eigenvector.
 \begin{proof}
     \leanok
     \uses{thm:spectral_gap}
-    The spectral gap $\rho(F_{AB}) < 1$
+    The transfer-operator gap $\rho(F_{AB}) < 1$
     (Theorem~\ref{thm:spectral_gap})
     implies $\|F_{AB}^n\|_{\mathrm{op}} \to 0$
     by the Gelfand formula,
@@ -588,9 +594,9 @@ canonical-form separation arguments.
     Theorem~\ref{thm:qpf}.
 \end{remark}
 
-\section{Spectral gap under irreducible-TP hypotheses}
+\section{Transfer-operator gap under irreducible-TP hypotheses}
 
-The preceding spectral-gap results require \emph{injectivity} of both
+The preceding transfer-operator gap results require \emph{injectivity} of both
 tensors. The following variants weaken this to \emph{irreducibility}
 combined with trace-preserving normalization
 ($\sum_i (A^i)^\dagger A^i = \Id$), following Cirac et
@@ -641,7 +647,7 @@ the Perron--Frobenius fixed point.
     upgrades the intertwining to gauge-phase equivalence.
 \end{proof}
 
-\begin{theorem}[Strict spectral gap (irreducible-TP)]%
+\begin{theorem}[Strict transfer-operator gap (irreducible-TP)]%
     \label{thm:spectral_gap_irr_tp}
     \lean{MPSTensor.spectralRadius_mixedTransfer_lt_one_of_irreducible_TP}
     \leanok
@@ -688,13 +694,13 @@ the Perron--Frobenius fixed point.
 \end{theorem}
 
 \begin{proof}\leanok\uses{thm:spectral_gap_irr_tp, thm:overlap_trace}
-    Combine the spectral gap
+    Combine the transfer-operator gap
     (Theorem~\ref{thm:spectral_gap_irr_tp})
     with the overlap--trace identity
     (Theorem~\ref{thm:overlap_trace}).
 \end{proof}
 
-\begin{theorem}[Rectangular spectral gap (irreducible-TP)]%
+\begin{theorem}[Rectangular transfer-operator gap (irreducible-TP)]%
     \label{thm:spectral_gap_rect_irr_tp}
     \lean{MPSTensor.mixedTransferSpectralRadius₂_lt_one_of_dim_ne_of_irreducible_TP}
     \leanok
@@ -1597,15 +1603,18 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
     $X = c \cdot U$ and the eigenspace is one-dimensional.
 \end{proof}
 
-\section{Primitive overlap convergence (spectral-gap form)}
+\section{Primitive overlap convergence (complementary transfer-map gap form)}
 
 The theorems in this section are stated directly in terms of the
 complementary map $E - P$. This is the analytic form needed for the later
-overlap argument, corresponding to the primitive-case specialization of~\cite[Theorem~6.7]{Wolf2012Quantum} where $T_\phi$ is a rank-one projection.
+overlap argument, corresponding to the primitive-case specialization
+of~\cite[Theorem~6.7]{Wolf2012Quantum} where $T_\phi$ is a rank-one
+projection.
 For primitive normalized transfer maps, Chapter~\ref{ch:channels} supplies
-this spectral-gap input under explicit hypotheses.
+this complementary transfer-map input under explicit hypotheses.
 
-\begin{theorem}[Complementary spectral gap implies trace convergence to $1$]\label{thm:trace_pow_one}
+\begin{theorem}[Complementary transfer-map gap implies trace convergence to $1$]%
+    \label{thm:trace_pow_one}
     \lean{MPSTensor.linearMap_trace_pow_tendsto_one_of_spectralRadius_compl_lt_one}
     \leanok
     \uses{def:fixed_point_proj, def:trace_preserving}
@@ -1630,7 +1639,8 @@ this spectral-gap input under explicit hypotheses.
     we have $\Tr(P) = \frac{\tr(\rho)}{\tr(\rho)} = 1$.
 \end{proof}
 
-\begin{theorem}[Self-overlap convergence from a complementary spectral gap]\label{thm:primitive_overlap}
+\begin{theorem}[Self-overlap convergence from a complementary transfer-map gap]%
+    \label{thm:primitive_overlap}
     \lean{MPSTensor.mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one}
     \leanok
     \uses{def:transfer_map, def:fixed_point_proj, def:mpv_overlap}

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1323,7 +1323,7 @@ used to produce rank-one elements.
 
 \begin{proof}\leanok\uses{thm:primitive_overlap}
     Immediate from the self-overlap convergence under a
-    complementary spectral gap
+    complementary transfer-map gap
     (Theorem~\ref{thm:primitive_overlap}).
 \end{proof}
 
@@ -1368,9 +1368,9 @@ spectral radius $< 1$.
 
 The primitivity condition of Definition~\ref{def:primitive_mps}
 combines TP normalization, a nonzero PSD fixed point, and a complementary
-spectral gap. It is connected to normality through the following results.
+transfer-map gap. It is connected to normality through the following results.
 
-\begin{theorem}[Fixed-point uniqueness from spectral gap]%
+\begin{theorem}[Fixed-point uniqueness from a complementary transfer-map gap]%
     \label{thm:fixedpoint_unique_spectral}
     \lean{MPSTensor.IsPrimitiveMPS.fixedPoint_unique}
     \leanok
@@ -1385,7 +1385,7 @@ spectral gap. It is connected to normality through the following results.
     Set $\sigma' = \sigma - \frac{\tr(\sigma)}{\tr(\rho)} \rho$.
     Then $\tr(\sigma') = 0$ and $(\E_A - P_\rho)(\sigma') = \sigma'$.
     If $\sigma' \neq 0$, then $1$ is an eigenvalue of $\E_A - P_\rho$,
-    contradicting the spectral gap
+    contradicting the complementary transfer-map gap
     $\rho_{\mathrm{spec}}(\E_A - P_\rho) < 1$.
 \end{proof}
 
@@ -1400,21 +1400,21 @@ spectral gap. It is connected to normality through the following results.
 
 \begin{proof}\leanok
     The spectral radius of $\E_A - P_\rho$ is strictly less
-    than $1$ by the spectral-gap hypothesis.
+    than $1$ by the complementary transfer-map gap hypothesis.
     Apply the general result that powers of an operator
     with spectral radius $< 1$ tend to zero.
 \end{proof}
 
-\begin{remark}[Primitivity: spectral gap vs.\ positive definiteness]%
+\begin{remark}[Primitivity: transfer-map gap vs.\ positive definiteness]%
     \label{rem:prim_definition_mismatch}\leanok
     The primitivity condition used in Section~\ref{subsec:prim_to_normal}
     has three parts: TP normalization $\sum_i (A^i)^\dagger A^i = \Id$,
-    a nonzero PSD fixed point $\rho$, and the spectral gap
+    a nonzero PSD fixed point $\rho$, and the complementary transfer-map gap
     $\rho_{\mathrm{spec}}(\E_A - P_\rho) < 1$.
     The notion of ``primitive'' in
     \cite[Proposition~3]{Sanz2010Quantum} additionally requires
     $\rho$ to be positive definite (full rank).
-    Without positive definiteness, the spectral-gap condition alone
+    Without positive definiteness, the transfer-map gap condition alone
     does \emph{not} imply irreducibility or normality.
     A counterexample is $D = 2$, $\rho = \diag(1,0)$.
 
@@ -1590,8 +1590,8 @@ For Burnside-style arguments it is more natural to work with invariant
 
 The results in this subsection remove the aperiodicity assumption
 from the normality conclusions.
-They connect the spectral-gap primitivity of
-Definition~\ref{def:primitive_mps} directly to normality
+They connect primitivity in Definition~\ref{def:primitive_mps},
+formulated via a complementary transfer-map gap, directly to normality
 (eventually full Kraus rank),
 using the convergence of the transfer-map iterates to the
 projection onto the fixed-point subspace.
@@ -1639,7 +1639,7 @@ projection onto the fixed-point subspace.
     \uses{thm:irreducible_map_from_primitive, thm:prim_overlap_one}
     Combine Theorem~\ref{thm:irreducible_map_from_primitive}
     (irreducibility) with the peripheral-spectrum primitivity from
-    the spectral-gap hypothesis
+    the transfer-map gap hypothesis
     (Theorem~\ref{thm:prim_overlap_one}).
 \end{proof}
 
@@ -1653,9 +1653,10 @@ projection onto the fixed-point subspace.
     (has eventually full Kraus rank).
     No aperiodicity assumption is needed.
 
-    This is the key connection between the spectral-gap primitivity of
-    Definition~\ref{def:primitive_mps} and normality; it removes the need for
-    the aperiodicity-based argument.
+    This is the key connection between primitivity in
+    Definition~\ref{def:primitive_mps}, formulated via a complementary
+    transfer-map gap, and normality; it removes the need for the
+    aperiodicity-based argument.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -488,8 +488,8 @@ periods makes the resulting transfer map primitive, removing periodicity.
     spectral hypotheses on the per-block transfer map $\E_{A_k}$: a
     positive-definite primitive fixed point, or the peripheral-spectrum
     condition $\sigma_\partial(\E_{A_k}) = \{1\}$. In both cases the
-    overlap clause $O_{A_k A_k}(N) \to 1$ follows from the spectral-gap
-    criterion of Chapter~\ref{ch:spectral}. Both statements assume the
+    overlap clause $O_{A_k A_k}(N) \to 1$ follows from the complementary
+    transfer-map gap criterion of Chapter~\ref{ch:spectral}. Both statements assume the
     blocks are already in the required normal form; they are not the
     arbitrary-input canonical-form existence theorem of
     \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.
@@ -499,10 +499,10 @@ periods makes the resulting transfer map primitive, removing periodicity.
     The remark above shows that the overlap convergence hypothesis in the
     canonical form conditions is redundant once peripheral-spectrum
     primitivity is known.
-    The argument factors through the spectral-gap formulation of
+    The argument factors through the complementary transfer-map gap formulation of
     Chapter~\ref{ch:spectral}: peripheral-spectrum primitivity is first
-    converted to that spectral-gap condition, and the overlap limit is then
-    deduced from it.
+    converted to that complementary transfer-map gap condition, and the
+    overlap limit is then deduced from it.
     In~\cite{Cirac2021Matrix}, primitivity is obtained from
     irreducibility plus periodicity removal by blocking to period one.
     Theorem~\ref{thm:blocking_primitivity} is precisely this
@@ -594,8 +594,8 @@ periods makes the resulting transfer map primitive, removing periodicity.
 \begin{proof}\leanok
     \uses{def:is_normal_canonical_form}
     Peripheral-spectrum primitivity is one of the hypotheses. Together with
-    irreducibility and TP normalization, it yields the spectral-gap
-    primitive theorem needed for overlap convergence, so the self-overlap
+    irreducibility and TP normalization, it yields the complementary
+    transfer-map gap theorem needed for overlap convergence, so the self-overlap
     condition follows from the other hypotheses rather than appearing as
     a separate assumption.
 \end{proof}
@@ -962,8 +962,8 @@ is the normality of a TP-primitive irreducible block.
 
 \begin{proof}\leanok
     \uses{thm:normal_from_primitive_posdef, thm:psd_fp_pd_irred}
-    Peripheral primitivity and irreducibility yield the spectral-gap
-    condition. The PSD fixed point is positive definite by
+    Peripheral primitivity and irreducibility yield the complementary
+    transfer-map gap condition. The PSD fixed point is positive definite by
     Theorem~\ref{thm:psd_fp_pd_irred}.
     Apply Theorem~\ref{thm:normal_from_primitive_posdef}.
 \end{proof}

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -328,7 +328,7 @@ We use this notation throughout the block-separation argument.
     which forces the self-overlap to converge to~$1$.
     See also~\cite[Theorem~6.8]{Wolf2012Quantum}
     for the completely-positive characterisation
-    and Chapter~\ref{ch:spectral} for the spectral-gap
+    and Chapter~\ref{ch:spectral} for the transfer-operator gap
     proof.
 \end{definition}
 

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -13,8 +13,8 @@ spectral properties of the transfer map, i.e.\ by the modulus of its
 subleading eigenvalues.
 
 The spectral analysis of the transfer map and the mixed transfer operator,
-including the eigenvalue bound $\rho(F_{AB}) \le 1$, the strict spectral
-gap $\rho(F_{AB}) < 1$ for non-equivalent blocks, and the resulting
+including the eigenvalue bound $\rho(F_{AB}) \le 1$, the strict
+transfer-operator gap $\rho(F_{AB}) < 1$ for non-equivalent blocks, and the resulting
 overlap decay, is developed in Chapter~\ref{ch:spectral}.  This chapter
 focuses on the \emph{correlator} side: one-point and two-point expectations,
 their spectral decomposition, and quantitative bounds on decay rates.
@@ -103,7 +103,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
     then the connected correlator satisfies that exponential decay bound.
     The source~\cite[Sec.~2.3]{Cirac2021Matrix} obtains this by combining
     the sum-of-exponentials expansion with the triangle inequality, and
-    Sec.~4 provides the spectral gap condition $|\lambda_j|<1$ for the
+    Sec.~4 provides the transfer-map gap condition $|\lambda_j|<1$ for the
     subleading eigenvalues.
     % Extracting $C_{XY}$ and $\lambda_2$ from the transfer-map spectrum
     % is tracked in Issue~\#1447.
@@ -114,26 +114,29 @@ their spectral decomposition, and quantitative bounds on decay rates.
     Given the bound hypothesis, the estimate is immediate.
     The source~\cite[Sec.~2.3]{Cirac2021Matrix} obtains this bound
     by applying the triangle inequality to the sum-of-exponentials
-    expansion and using the spectral gap condition
+    expansion and using the transfer-map gap condition
     $|\lambda_j|\le|\lambda_2|<1$ for all subleading eigenvalues.
     % Deriving the bound from the eigendecomposition of $\E_A$
     % is tracked in Issue~\#1447.
 \end{proof}
 
-\begin{remark}[Spectral hypothesis and the spectral gap]%
+\begin{remark}[Transfer-map spectral hypothesis]%
     \label{rem:spectral_hypothesis}
     \uses{thm:correlator_exponential_bound, thm:primitive_compl_lt_one,
         thm:spectral_gap_irr_tp, thm:spectral_gap_wielandt}
     The hypothesis ``$|\lambda_2| < 1$'' in
-    Theorem~\ref{thm:correlator_exponential_bound} is the source-paper
-    \emph{spectral gap} condition for the transfer map $\E_A$.
-    The complementary spectral gap $\rho(\E_A - P) < 1$ is established for
+    Theorem~\ref{thm:correlator_exponential_bound} is a transfer-map gap
+    condition: all non-leading eigenvalues of $\E_A$ lie strictly inside the
+    unit disk.  It is distinct from the Hamiltonian spectral gap of
+    Chapter~\ref{ch:parent_hamiltonian}.
+    The complementary transfer-map gap $\rho(\E_A - P) < 1$ is established for
     primitive channels
-    (Theorem~\ref{thm:primitive_compl_lt_one}, Chapter~\ref{ch:channels}),
-    for irreducible trace-preserving tensors
-    (Theorem~\ref{thm:spectral_gap_irr_tp}),
-    and quantitatively for injective tensors
-    (Theorem~\ref{thm:spectral_gap_wielandt}).
+    (Theorem~\ref{thm:primitive_compl_lt_one}, Chapter~\ref{ch:channels}).
+    The mixed-transfer gap needed for block separation is supplied for
+    irreducible trace-preserving tensors
+    (Theorem~\ref{thm:spectral_gap_irr_tp}), and quantitative single-tensor
+    transfer-map bounds for injective tensors are recorded in
+    Theorem~\ref{thm:spectral_gap_wielandt}.
     Thus the analytical input needed to make
     Theorems~\ref{thm:correlator_sum_exponentials}
     and~\ref{thm:correlator_exponential_bound} unconditional is already
@@ -166,9 +169,9 @@ their spectral decomposition, and quantitative bounds on decay rates.
     $\xi = -1/\log|\lambda_2| > 0$.
 \end{proof}
 
-\section{Quantitative spectral gap bounds}
+\section{Quantitative transfer-map gap bounds}
 
-The spectral gap theorems in Chapter~\ref{ch:channels} establish
+The transfer-map gap theorems in Chapter~\ref{ch:channels} establish
 $\rho(\E_A - P) < 1$ for primitive channels qualitatively.  This section
 gives the \emph{quantitative} refinements with explicit constants
 and rates for the single-tensor transfer map $\E_A$.
@@ -192,15 +195,16 @@ and rates for the single-tensor transfer map $\E_A$.
         \|\E_A^n(X) - P(X)\|
         \;\le\; C\,(1-\delta)^n\,\|X\|.
     \]
-    The spectral gap $\delta$ exists by primitivity
-    (Theorem~\ref{thm:primitive_compl_lt_one}, the complementary spectral gap).
+    The transfer-map gap $\delta$ exists by primitivity
+    (Theorem~\ref{thm:primitive_compl_lt_one}, the complementary transfer-map gap).
 \end{theorem}
 
 \begin{proof}
     \leanok
     Injectivity implies primitivity of the transfer map.
     The complementary spectral radius $\rho(\E_A - P) < 1$ then follows from
-    the primitive spectral gap theorem.  The Gelfand formula yields a
+    the primitive transfer-map gap theorem for the complementary map.
+    The Gelfand formula yields a
     geometric bound $\|\,(\E_A - P)^n\| \le C\,(1-\delta)^n$ for suitable
     constants, giving the claimed estimate.
 \end{proof}
@@ -231,7 +235,7 @@ and rates for the single-tensor transfer map $\E_A$.
     $\xi = -1/\log(1-\delta)$ yields the claimed estimate.
 \end{proof}
 
-\begin{theorem}[Spectral gap from injectivity]%
+\begin{theorem}[Transfer-map gap from injectivity]%
     \label{thm:spectral_gap_wielandt}
     \lean{MPSTensor.spectral_gap_of_injective}
     \leanok
@@ -243,7 +247,7 @@ and rates for the single-tensor transfer map $\E_A$.
 \begin{proof}
     \leanok
     Injectivity implies eventual full Kraus rank. This yields primitivity,
-    hence a spectral gap for the complementary map. Since the transfer map has
+    hence a complementary transfer-map gap. Since the transfer map has
     only finitely many eigenvalues, one may choose a uniform
     $\delta > 0$ separating $1$ from the remaining spectrum.
 \end{proof}


### PR DESCRIPTION
### Motivation

Issue #2152 points out that the blueprint used “spectral gap” both for transfer-operator spectral-radius bounds and for the Hamiltonian energy gap. In quantum many-body terminology the unqualified phrase should refer to the Hamiltonian gap.

### Description

- Reserve the unqualified phrase “spectral gap” for the parent-Hamiltonian chapter.
- Rename transfer-operator prose in Chapters 4, 6, 7, 8, 9, and 15 to “transfer-operator gap”, “transfer-map gap”, or “complementary transfer-map gap” as appropriate.
- Keep existing labels and Lean declaration names unchanged; declaration renames can be a separate mechanical follow-up.

### Testing

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch04_channels.tex blueprint/src/chapter/ch06_spectral.tex blueprint/src/chapter/ch07_wielandt.tex blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch09_block_perm.tex blueprint/src/chapter/ch15_correlations.tex`
- `cd blueprint && leanblueprint web` (succeeds; existing bibliography/renderer warnings remain)

Closes #2152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX terminology and chapter titles only; no Lean or proof logic changes.
> 
> **Overview**
> This PR is **documentation-only** in the blueprint LaTeX: it disambiguates **transfer-operator / transfer-map** spectral-radius language from the **Hamiltonian energy gap**, without changing theorem labels or Lean names.
> 
> **Chapter 6** is retitled to *Transfer-Operator Gaps and Block Separation* and now states explicitly that unqualified **spectral gap** means the parent-Hamiltonian gap (`ch:parent_hamiltonian`). Prose and section titles that referred to mixed-transfer or complementary-map bounds are renamed to **transfer-operator gap**, **transfer-map gap**, or **complementary transfer-map gap** (including `$\rho(F_{AB})<1$` and `$\rho(\mathcal{E}_A-P)<1$`).
> 
> The same wording is applied in **Chapters 4, 7, 8, 9, and 15** (channels primitive theorem, Wielandt primitivity, canonical-form overlap remarks, block-permutation references, and correlator remarks). **Chapter 15** also clarifies which analytic inputs come from primitive channels vs mixed-transfer / injective quantitative bounds.
> 
> A trivial newline fix at EOF in `ch04_channels.tex` is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122a8964505f805658c3b00b87e1277260c540c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->