### PR TITLE
doc(PEPS): centralize nonempty middle status

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -16,6 +16,14 @@ configuration is the family of physical indices on $V\setminus\{u,v\}$.
   arXiv:1804.04964, Section 3, `eq:block_to_mps`](https://arxiv.org/abs/1804.04964)
 - `Papers/1804.04964/paper_normal.tex`, lines 981--1009.
 - `Papers/1804.04964/paper_normal.tex`, lines 1322--1404.
+
+## Scope note
+
+The singleton-region consequences below still assume that the middle region
+$V\setminus\{u,v\}$ is nonempty. The source comparison and removal plan for
+this hypothesis are recorded in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
 -/
 
 namespace TNLean
@@ -386,8 +394,7 @@ The remaining comparison from region injectivity to the concrete edge-middle
 tensor is still assumed.
 
 **Scope restriction (nonempty middle):** This theorem assumes
-`(edgeMiddleVertices e).Nonempty`; see
-`docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+`(edgeMiddleVertices e).Nonempty`; see the module scope note.
 
 Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
 `lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009
@@ -428,8 +435,7 @@ theorem EdgeMiddleRegionInjectivityComparison.edgeMiddleTensorInjective_all_two_
 three-site injectivity statement for an edge whose middle region is nonempty.
 
 **Scope restriction (nonempty middle):** This theorem assumes
-`(edgeMiddleVertices e).Nonempty`; see
-`docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+`(edgeMiddleVertices e).Nonempty`; see the module scope note.
 
 Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
 `lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009
@@ -451,8 +457,7 @@ injectivity at every edge whose middle region is nonempty.
 This is the all-edge form of the preceding restricted consequence.
 
 **Scope restriction (nonempty middle):** This theorem assumes
-`∀ e : Edge G, (edgeMiddleVertices e).Nonempty`; see
-`docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+`∀ e : Edge G, (edgeMiddleVertices e).Nonempty`; see the module scope note.
 
 Source: arXiv:1804.04964, Section 3, `eq:block_to_mps` and Lemma
 `lem:injective_union`; `Papers/1804.04964/paper_normal.tex`, lines 981--1009


### PR DESCRIPTION
### Motivation

The nonempty-middle singleton consequences in `EdgeMiddlePhysical.lean` repeated the same paper-gap pointer in three theorem docstrings. The authoritative status for this scope restriction already lives in `docs/paper-gaps/peps_injective_ft_section3_route.tex`.

### Description

- Add a module-level scope note naming the paper-gap note and its "Remaining mathematical obligations" section.
- Shorten the three `**Scope restriction (nonempty middle):**` markers to point to that module note.
- Leave all declarations, theorem statements, and proofs unchanged.

### Testing

- `lake env lean TNLean/PEPS/EdgeMiddlePhysical.lean` (passes; reports the pre-existing `sorry` warning in this file)
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/EdgeMiddlePhysical.lean`
- `git diff --check`
- diff scan for new `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`

---
Addresses #1366

> [!NOTE]
> **Low Risk**
> Documentation-only edits to module and theorem docstrings; no logic, proofs, or APIs changed.
>
> **Overview**
> Adds a **module-level scope note** in `EdgeMiddlePhysical.lean` stating that singleton-region consequences still assume a nonempty middle region \(V\setminus\{u,v\}\), and points to `docs/paper-gaps/peps_injective_ft_section3_route.tex` ("Remaining mathematical obligations") for the comparison and removal plan.
>
> Three theorem docstrings (`edgeMiddleTensorInjective_of_singletons`, `edgeBlockedThreeSiteInjective_of_singletons`, `edgeBlockedThreeSiteInjective_all_of_singletons`) no longer repeat that paper-gap path; their **Scope restriction (nonempty middle)** lines now refer to the module note instead.
>
> **No** changes to Lean declarations, statements, or proofs.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7743d01fbd85a78849e09d4020823437ae86402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>