### PR TITLE
refactor(Spectral): align transfer-map gap terminology

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -133,16 +133,16 @@ import TNLean.Channel.Peripheral.GroupStructure
 import TNLean.Channel.Peripheral.CyclicGroup
 import TNLean.Channel.Semigroup.RelaxationConditions
 
--- Layer 2c: Spectral theory (QPF + spectral gap)
+-- Layer 2c: Spectral theory (QPF + transfer-operator gaps)
 import TNLean.QPF.PosDef
 import TNLean.QPF.Uniqueness
 import TNLean.QPF.Assembly
 import TNLean.QPF.Primitive
 import TNLean.Spectral.MixedTransfer
 import TNLean.Spectral.MPVOverlapTrace
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 import TNLean.Spectral.MPVOverlapDecay
-import TNLean.Spectral.SpectralGapRect
+import TNLean.Spectral.TransferOperatorGapRect
 import TNLean.Spectral.PrimitiveOverlap
 import TNLean.Spectral.CrossCorrelation
 import TNLean.Spectral.QuantitativeGap
@@ -211,7 +211,7 @@ import TNLean.MPS.BNT.Separation
 import TNLean.MPS.BNT.PermutationRigidityPrimitive
 import TNLean.MPS.BNT.Construction
 import TNLean.MPS.Structure.PrimitivityBridge
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.MPS.FundamentalTheorem.Multi
 import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
 import TNLean.MPS.FundamentalTheorem.SectorDecomposition

--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -8,7 +8,7 @@ import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Irreducible.Similarity
 import TNLean.Channel.Irreducible.TraceAdjoint
 import TNLean.MPS.Core.TPGauge
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 
 /-!
 # Irreducible spectral-radius identity (Wolf Theorem 6.3(4))
@@ -28,7 +28,7 @@ for irreducible completely positive maps on `M_D(ℂ)`.
 
 The proof uses a TP-gauge reduction. Starting from a positive-definite right
  eigenvector, we build a positive-definite adjoint eigenvector, rescale and gauge
- the Kraus family to a trace-preserving one, use the existing spectral-gap bound
+ the Kraus family to a trace-preserving one, use the existing transfer-operator gap bound
  to obtain spectral radius `1` in the gauged setting, and then undo the scalar
  rescaling and similarity.
 

--- a/TNLean/Channel/Peripheral/IrreducibleChannel.lean
+++ b/TNLean/Channel/Peripheral/IrreducibleChannel.lean
@@ -8,7 +8,7 @@ import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import TNLean.Channel.KrausRepresentation
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 
 /-!
 # Channel-level formulations for peripheral spectrum and primitivity
@@ -25,7 +25,7 @@ peripheral-spectrum theory from Wolf Chapter 6.
 * `peripheral_isRootOfUnity_of_irreducible_channel`:
   peripheral eigenvalues of an irreducible channel are roots of unity
 * `compl_eigenvalue_norm_lt_one_of_primitive_of_irreducible_channel`:
-  primitive irreducible channels have a strict complementary spectral gap
+  primitive irreducible channels have a strict complementary transfer-map gap
 
 The proofs reduce general channels to Kraus transfer maps and then reuse the
 existing MPS blocking / periodicity-removal formalization.
@@ -181,7 +181,7 @@ theorem peripheral_isRootOfUnity_of_irreducible_channel [NeZero D]
 /-- Channel-level formulation for `compl_eigenvalue_norm_lt_one_of_primitive`.
 
 For an irreducible channel, the auxiliary hypotheses needed by the general
-spectral-gap lemma are automatic: channel eigenvalues have norm at most `1`,
+complementary-gap lemma are automatic: channel eigenvalues have norm at most `1`,
 and trace-zero fixed points vanish by irreducibility. -/
 theorem compl_eigenvalue_norm_lt_one_of_primitive_of_irreducible_channel
     [NeZero D]

--- a/TNLean/Channel/Peripheral/Spectrum.lean
+++ b/TNLean/Channel/Peripheral/Spectrum.lean
@@ -31,8 +31,8 @@ the eigenvalues on the unit circle.
 * `isRootOfUnity_of_finite_powers` — pigeonhole for roots of unity
 * `peripheral_isRootOfUnity_of_pow_eigenvalue` — powers-are-eigenvalues ⟹ root of unity
 * `isPrimitive_iff_period_one` — primitive ↔ period = 1
-* `isPrimitive_of_compl_eigenvalues_lt_one` — spectral gap → primitive
-* `compl_eigenvalue_norm_lt_one_of_primitive` — primitive → spectral gap
+* `isPrimitive_of_compl_eigenvalues_lt_one` — complementary transfer-map gap → primitive
+* `compl_eigenvalue_norm_lt_one_of_primitive` — primitive → complementary transfer-map gap
 
 ## References
 
@@ -237,12 +237,12 @@ theorem isPrimitive_iff_period_one
 
 end ChannelPeriod
 
-/-! ## Part 5: Spectral gap ↔ primitivity -/
+/-! ## Part 5: Complementary transfer-map gap ↔ primitivity -/
 
-section SpectralGap
+section ComplementaryTransferMapGap
 
-/-- **Spectral gap → primitive**: if all eigenvalues of `E - P` have norm < 1,
-then 1 is the only peripheral eigenvalue of E.
+/-- **Complementary transfer-map gap → primitive**: if all eigenvalues of `E - P`
+have norm < 1, then 1 is the only peripheral eigenvalue of E.
 
 Key idea: for `μ ≠ 1`, trace preservation forces eigenvectors to have trace 0,
 so they lie in ker(P), making μ an eigenvalue of `E - P`. -/
@@ -282,8 +282,9 @@ theorem isPrimitive_of_compl_eigenvalues_lt_one
   have := hcompl μ (hasEigenvalue_of_eigenvector_eq _ μ X hNX hX_ne)
   linarith [hμ_norm.symm ▸ this]
 
-/-- **Primitive → spectral gap (eigenvalue level)**: if E is primitive, TP, and
-all eigenvalues of E have norm ≤ 1, then eigenvalues of `E - P` have norm < 1. -/
+/-- **Primitive → complementary transfer-map gap (eigenvalue level)**: if E is
+primitive, TP, and all eigenvalues of E have norm ≤ 1, then eigenvalues of
+`E - P` have norm < 1. -/
 theorem compl_eigenvalue_norm_lt_one_of_primitive
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (_hfix : E ρ = ρ) (_hne : ρ ≠ 0)
@@ -335,14 +336,14 @@ theorem compl_eigenvalue_norm_lt_one_of_primitive
       exact this
     exact (mul_eq_zero.mp h1).resolve_right htrX
 
-end SpectralGap
+end ComplementaryTransferMapGap
 
 /-! ## Part 6: Connection to MPS primitivity
 
 The peripheral spectrum framework connects to MPS theory via:
 
 1. Transfer map `E_A(X) = ∑ᵢ Aᵢ X Aᵢ†` is trace-preserving when `∑ᵢ Aᵢ† Aᵢ = I`.
-2. By `Spectral/SpectralGap.lean`, eigenvalues satisfy `‖μ‖ ≤ 1`.
+2. By `Spectral/TransferOperatorGap.lean`, eigenvalues satisfy `‖μ‖ ≤ 1`.
 3. `IsPrimitiveMPS` requires `spectralRadius(E - P) < 1`, which by
    `compl_eigenvalue_norm_lt_one_of_primitive` is equivalent to `IsPrimitive E`.
 4. For irreducible CPTP maps, multiplicative domain theory

--- a/TNLean/Channel/Primitive.lean
+++ b/TNLean/Channel/Primitive.lean
@@ -17,8 +17,9 @@ We formalize the **rank-one projection** onto a fixed point and the algebraic de
   E^n = P + (E-P)^n \qquad (n \ge 1)
 \]
 where `P` is the fixed-point projection. This decomposition is the algebraic core
-of Wolf Theorem 6.7 item 3 → item 1: the spectral gap `‖E - P‖ < 1` ensures
-`(E - P)^n → 0`, so `E^n → P`, giving convergence to the unique fixed state.
+of Wolf Theorem 6.7 item 3 → item 1: a complementary transfer-map gap for
+`E - P` ensures `(E - P)^n → 0`, so `E^n → P`, giving convergence to the
+unique fixed state.
 
 ## Main definitions
 
@@ -32,7 +33,7 @@ of Wolf Theorem 6.7 item 3 → item 1: the spectral gap `‖E - P‖ < 1` ensure
 
 ## Notation
 
-Within `section SpectralGapDecomposition`, we use local notation:
+Within `section ComplementaryDecomposition`, we use local notation:
 * `P` for `fixedPointProj ρ htr`
 * `N` for `E - P` (the complementary part)
 
@@ -104,7 +105,7 @@ theorem fixedPointProj_comp_E (hTP : IsTracePreservingMap E) :
 
 end TracePreservingInteraction
 
-section SpectralGapDecomposition
+section ComplementaryDecomposition
 
 variable (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
 variable {ρ : Matrix (Fin D) (Fin D) ℂ} (htr : trace ρ ≠ 0)
@@ -141,7 +142,8 @@ theorem compl_pow_succ_mul_fixedPointProj (hρ : E ρ = ρ) (n : ℕ) :
 /-- For `P := fixedPointProj ρ` and `N := E - P`, we have `E^(n+1) = P + N^(n+1)`.
 
 This is the algebraic core of primitive convergence: the dynamics splits into the fixed-point
-part `P` and a complementary part `N` that decays under a spectral gap hypothesis. -/
+part `P` and a complementary part `N` that decays under a complementary transfer-map
+gap hypothesis. -/
 theorem pow_succ_eq_fixedPointProj_add_compl_pow
     (hTP : IsTracePreservingMap E) (hρ : E ρ = ρ) (n : ℕ) :
     E ^ (n + 1) = P + N ^ (n + 1) := by
@@ -167,4 +169,4 @@ theorem pow_eq_fixedPointProj_add_compl_pow
       simpa using
         pow_succ_eq_fixedPointProj_add_compl_pow (E := E) (ρ := ρ) (htr := htr) hTP hρ n
 
-end SpectralGapDecomposition
+end ComplementaryDecomposition

--- a/TNLean/Channel/Schwarz/Basic.lean
+++ b/TNLean/Channel/Schwarz/Basic.lean
@@ -6,7 +6,7 @@ import TNLean.Channel.Basic
 This file provides a small self-contained interface for Kraus maps on matrices
 `Matrix n n ℂ`, parametrised by an arbitrary finite Kraus index type `ι`.
 
-The main purpose is to support the spectral-gap proof for the mixed transfer
+The main purpose is to support the transfer-operator gap proof for the mixed transfer
 operator, where we need a *weighted* Kadison–Schwarz equality:
 
 * `kadison_schwarz` : KS inequality for unital Kraus maps

--- a/TNLean/Channel/Semigroup/Primitivity/Basic.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Basic.lean
@@ -13,7 +13,7 @@ import TNLean.Channel.Peripheral.ClosureFixedPoint
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.Primitive
 import TNLean.MPS.Irreducible.Adjoint
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.NumberTheory.Real.Irrational
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -148,7 +148,7 @@ PARTIALLY FORMALIZED in `TNLean.Channel.Peripheral.CyclicDecomposition`.
 * `IsPrimitive` — `TNLean.Channel.Peripheral.Spectrum`
 * `isPrimitive_of_compl_eigenvalues_lt_one` / `compl_eigenvalue_norm_lt_one_of_primitive`
 
-Other items: PARTIALLY via spectral gap formalization in `TNLean.Spectral.*`.
+Other items: PARTIALLY via transfer-operator gap formalization in `TNLean.Spectral.*`.
 
 ### Wolf Theorem 6.8 (CP primitive maps, Kraus span characterizations)
 

--- a/TNLean/MPS/BNT/Construction.lean
+++ b/TNLean/MPS/BNT/Construction.lean
@@ -1,6 +1,6 @@
 import TNLean.PiAlgebra.CanonicalFormSep
-import TNLean.Spectral.SpectralGapRect
-import TNLean.Spectral.SpectralGapNT
+import TNLean.Spectral.TransferOperatorGapRect
+import TNLean.Spectral.TransferOperatorGapNT
 import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.MPS.BNT.Separation
 import TNLean.MPS.BNT.Basic

--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -1,6 +1,6 @@
 import TNLean.MPS.BNT.Basic
 import TNLean.MPS.FundamentalTheorem.Proportional
-import TNLean.Spectral.SpectralGapRect
+import TNLean.Spectral.TransferOperatorGapRect
 import TNLean.MPS.Overlap.Basic
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.Overlap.CastDecay

--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -6,7 +6,7 @@ import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
 import TNLean.MPS.Tactic.Basic
 
@@ -123,8 +123,8 @@ completely positive maps (Wolf Chapter 6), formalized in
 > transformation `A_i ↦ ρ^{1/2} A_i ρ^{-1/2}` that makes the
 > tensor left-canonical.
 
-The spectral-gap connection to peripheral primitivity is supplied by
-`TNLean.MPS.Overlap.PeripheralToSpectralGap` (Wolf Proposition 6.8).
+The complementary transfer-map gap connection to peripheral primitivity is supplied by
+`TNLean.MPS.Overlap.PeripheralToTransferMapGap` (Wolf Proposition 6.8).
 -/
 
 namespace MPSTensor
@@ -244,8 +244,8 @@ theorem exists_blockTensor_leftCanonical_isPrimitive
     exists_blockTensor_isPrimitive (A := A) hTP hIrr
   refine ⟨p, hp, leftCanonical_blockTensor (d := d) (D := D) (A := A) (L := p) hTP, hPrim⟩
 
-/-- **Reduction theorem:** spectral-gap primitivity with a positive-definite fixed point implies
-normality. -/
+/-- **Reduction theorem:** complementary transfer-map gap primitivity with a
+positive-definite fixed point implies normality. -/
 theorem isNormal_of_isPrimitiveMPS
     [NeZero D]
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
@@ -256,10 +256,10 @@ theorem isNormal_of_isPrimitiveMPS
 
 
 /-!
-## (5) Normality from primitive spectral-gap hypotheses
+## (5) Normality from primitive complementary-gap hypotheses
 
 For overlap and canonical-form hypotheses involving primitive transfer maps, we use the results from
-`PeripheralToSpectralGap.lean` directly.
+`PeripheralToTransferMapGap.lean` directly.
 -/
 
 /-!

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.MPS.SharedInfra.SectorDecomposition
 import TNLean.MPS.Structure.PrimitivityBridge
-import TNLean.Spectral.SpectralGapNT
+import TNLean.Spectral.TransferOperatorGapNT
 
 open scoped Matrix BigOperators
 open Filter

--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -21,8 +21,8 @@ The core chain is the channel Perron–Frobenius route with all hypotheses kept
 separate: trace preservation fixes the normalization convention, peripheral
 primitivity says that the peripheral spectrum of the transfer map is `{1}`,
 tensor irreducibility rules out nontrivial invariant projections, and these
-inputs produce a positive definite Perron fixed point.  The primitive spectral
-gap together with this faithful fixed point gives eventual full Kraus rank,
+inputs produce a positive definite Perron fixed point.  The primitive complementary
+transfer-map gap together with this faithful fixed point gives eventual full Kraus rank,
 which is the normality condition used here. A separate word-span argument then
 shows that blocking keeps normality.
 
@@ -92,7 +92,7 @@ is `1`.  The conclusion is obtained by the following implications:
   including a Perron fixed point for the transfer map.
 * Irreducibility upgrades the nonzero positive semidefinite Perron fixed point
   in that datum to a positive definite, faithful fixed point.
-* The primitive spectral gap together with the faithful fixed point gives
+* The primitive complementary transfer-map gap together with the faithful fixed point gives
   eventual full Kraus rank, equivalently `IsNormal A`. -/
 theorem isNormal_of_tp_primitive_irreducible [NeZero D]
     (A : MPSTensor d D)
@@ -109,7 +109,7 @@ theorem isNormal_of_tp_primitive_irreducible [NeZero D]
   -- Step 3: Upgrade PSD → PosDef using tensor irreducibility.
   have hPD : ρ.PosDef :=
     posDef_of_isIrreducibleTensor_of_isPrimitiveMPS hPrimMPS hIrr
-  -- Step 4: IsNormal from the primitive spectral gap and a faithful fixed point.
+  -- Step 4: IsNormal from the primitive complementary gap and a faithful fixed point.
   exact isNormal_of_isPrimitiveMPS_with_posDef hPrimMPS hPD
 
 /-- **TP + primitive + irreducible → injective after blocking**.

--- a/TNLean/MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/PrimitiveBlocks.lean
@@ -48,7 +48,8 @@ with the PSD fixed point `ρ` of the original transfer map:
 2. `ρ` is also fixed by `transferMap (blockTensor A P)` (since `transferMap (blockTensor A P) = E^P`
    and `E ρ = ρ` implies `E^P ρ = ρ`)
 3. Uniqueness of PSD fixed points of `E^P`: if `E^P σ = σ`, set `σ' = σ - c•ρ`.
-   From the spectral gap of `IsPrimitiveMPS A ρ`, `E^n → Pρ` exponentially.
+   From the complementary transfer-map gap of `IsPrimitiveMPS A ρ`,
+   `E^n → Pρ` exponentially.
    Since `E^{Pk} σ' = Pρ σ' + N^{Pk} σ' = N^{Pk} σ'` (as `Pρ σ' = 0`)
    and `N^{Pk} σ' = σ'` (from `E^P σ' = σ'`), but `N^n → 0`, we get `σ' = 0`.
 4. Apply `isIrreducibleMap_of_channel_posDef_fixedPoint_unique` →
@@ -64,9 +65,10 @@ If `A` is TP, has a primitive transfer map, and is an irreducible tensor, then
 
 The key insight: the PosDef fixed point `ρ` of the original transfer map is also
 a PosDef fixed point of the blocked transfer map `E^P`. Uniqueness of PSD fixed
-points for `E^P` follows from the spectral gap of `IsPrimitiveMPS A ρ`: if
+points for `E^P` follows from the complementary transfer-map gap of
+`IsPrimitiveMPS A ρ`: if
 `E^P σ = σ` then `N^{Pk} σ' = σ'` (where `σ' = σ - c•ρ`, `N = E - Pρ`), but
-`N^n → 0` from the spectral gap, so `σ' = 0`. -/
+`N^n → 0` from the complementary gap, so `σ' = 0`. -/
 theorem isIrreducibleTensor_blockTensor_of_tp_primitive_irr [NeZero D]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.CanonicalForm.CommonPeriodCyclicSectors
 import TNLean.MPS.CanonicalForm.SectorComparison.ZeroTailTransport
 import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Core.BlockingTransfer
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.MPS.SharedInfra.KrausAdjointSetup
 import TNLean.Channel.Peripheral.CyclicDecomposition
 import TNLean.Channel.Peripheral.GroupStructure

--- a/TNLean/MPS/Core/Correlations.lean
+++ b/TNLean/MPS/Core/Correlations.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Core.Transfer
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 import TNLean.Spectral.TraceExpansion
 import TNLean.QPF.Assembly
 
@@ -22,7 +22,7 @@ The spectral statements `connectedCorrelator_eq_sum` and
 as an explicit hypothesis; the source (arXiv:2011.12127 [CPGSV21])
 states the connected-correlation formulas in Sec. 2.3
 ("Correlations, Entanglement, and the Transfer Matrix") and derives
-the spectral-gap hypotheses in Sec. 4 ("Formal results").
+the transfer-matrix gap hypotheses in Sec. 4 ("Formal results").
 The definitions here are used by the zero-correlation-length results.
 -/
 
@@ -109,7 +109,7 @@ The source CPGSV21, Sec. 2.3, notes that `|λ₂| < 1` defines the
 correlation length `ξ = −1/log|λ₂|`.  The exponential decay bound
 follows by applying the triangle inequality to the sum-of-exponentials
 expansion and using `|λⱼ| ≤ |λ₂| < 1` for all subleading eigenvalues
-(the spectral gap proved in Sec. 4).
+(the transfer-matrix gap proved in Sec. 4).
 -/
 theorem connectedCorrelator_bound
     (A : MPSTensor d D)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -6,7 +6,7 @@ import TNLean.MPS.CanonicalForm.PhaseClassSectorData
 import TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport
 import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 
 /-!
 # Prepared-block SectorBNT constructor
@@ -80,7 +80,7 @@ Proof sketch (scout memo §2.4):
    `mpvOverlap Y Y N = (ζ · conj ζ)^N · mpvOverlap X X N`.
 3. Both self-overlaps tend to `1` by
    `overlap_tendsto_one_of_peripheralPrimitive_of_irreducible`
-   (`Overlap/PeripheralToSpectralGap.lean`).
+   (`Overlap/PeripheralToTransferMapGap.lean`).
 4. `norm_eq_one_of_selfOverlap_scale` (`SharedInfra/GaugePhase.lean`)
    concludes `‖ζ‖ = 1`.
 -/

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -94,7 +94,7 @@ eigenvalues of `(transferMap M).adjoint`, because any such eigenvalue would
 produce a blocked adjoint fixed point at some positive `n` that is not fixed
 by the unblocked adjoint. It does *not* exclude unit-modulus eigenvalues of
 irrational phase, and a fortiori it is not enough to force `transferMap M`
-itself to be idempotent. Ergodic channels with a strict spectral gap on the
+itself to be idempotent. Ergodic channels with a strict complementary gap on the
 `1`-complement therefore satisfy `IsRFP_MPDO_via_algebra M` without being
 MPDO RFPs: on `M_D(ℂ)`, with `0 < ε < 1`, consider
 `E(X) = ε · X + (1 - ε) · Π_diag(X)`, where `Π_diag` is the projection that

--- a/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/BurnsideJacobson.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/PairHomogenization/BurnsideJacobson.lean
@@ -82,7 +82,7 @@ blocks are not gauge-phase equivalent — to the existence of a homogeneous leng
 
 **Spectral approach:** non-gauge-equivalence forces the spectral radius of the
 mixed transfer map below one, so the matrix-product-vector overlap decays to
-zero.  This is the non-decaying overlap argument from the spectral-gap
+zero.  This is the non-decaying overlap argument from the transfer-operator gap
 development.
 
 **Algebraic approach (this section):** non-gauge-equivalence implies all-length

--- a/TNLean/MPS/Overlap/CastDecay.lean
+++ b/TNLean/MPS/Overlap/CastDecay.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Overlap.CastLemmas
 import TNLean.Spectral.MPVOverlapDecay
-import TNLean.Spectral.SpectralGapNT
+import TNLean.Spectral.TransferOperatorGapNT
 
 /-!
 # Cast-aware overlap-decay lemmas

--- a/TNLean/MPS/Overlap/PeripheralToTransferMapGap.lean
+++ b/TNLean/MPS/Overlap/PeripheralToTransferMapGap.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.Channel.Peripheral.Spectrum
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 import TNLean.QPF.Assembly
 import TNLean.MPS.Irreducible.FormII
 import TNLean.Channel.FixedPoint.Cesaro
@@ -12,16 +12,17 @@ import TNLean.MPS.Core.CPPrimitive
 import Mathlib.Analysis.Normed.Algebra.GelfandFormula
 
 /-!
-# Peripheral primitivity → spectral gap primitivity (transfer map)
+# Peripheral primitivity → complementary transfer-map gap primitivity
 
 This file connects the **peripheral-spectrum** notion of primitivity for quantum channels
-(`peripheralEigenvalues E = {1}`) to the **spectral-gap** notion used in the MPS
-proof chain (`MPSTensor.IsPrimitiveMPS` / `MPSTensor.HasPrimitiveFixedPoint`).
+(`peripheralEigenvalues E = {1}`) to the **complementary transfer-map gap** notion
+used in the MPS proof chain (`MPSTensor.IsPrimitiveMPS` /
+`MPSTensor.HasPrimitiveFixedPoint`).
 
 Concretely, for the transfer map of an injective normalized tensor `A`, we prove:
 
 * trace-zero fixed points are trivial (`X = 0`),
-* peripheral primitivity implies a spectral gap for the complementary map `E - P`,
+* peripheral primitivity implies a complementary transfer-map gap for `E - P`,
 * hence `MPSTensor.HasPrimitiveFixedPoint A` and the overlap convergence
   `mpvOverlap → 1`.
 
@@ -46,7 +47,7 @@ The formal Lean declaration:
 > `TNLean.Channel.FixedPoint.Cesaro` supplies the PSD decomposition used in
 > `transferMap_hermitian_fixedPoint_eq_zero_of_trace_eq_zero` (line 93).
 > This is the Wolf Proposition 6.8 formalization consumed by the
-> peripheral-to-spectral-gap connection.
+  > peripheral-to-complementary-gap connection.
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
@@ -199,7 +200,7 @@ private theorem transferMap_fixedPoint_eq_zero_of_trace_eq_zero_of_hermitian_zer
 with trace zero must be the zero matrix.
 
 This is the key “uniqueness on the trace-zero subspace” hypothesis needed to turn
-peripheral primitivity into a spectral gap for `E - P`. -/
+peripheral primitivity into a complementary transfer-map gap for `E - P`. -/
 theorem transferMap_fixedPoint_eq_zero_of_trace_eq_zero
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)
@@ -280,7 +281,7 @@ theorem transferMap_fixedPoint_eq_zero_of_trace_eq_zero_of_irreducible
         (A := A) hIrrMap hNorm Y hYherm hYfix htrY)
     X hXfix htrX
 
-/-! ## Step 2: peripheral primitive ⇒ spectral gap for the complement -/
+/-! ## Step 2: peripheral primitive ⇒ complementary transfer-map gap -/
 
 private theorem spectralRadius_compl_lt_one_of_peripheralPrimitive_aux
     {d D : ℕ} [NeZero D]
@@ -350,8 +351,8 @@ private theorem spectralRadius_compl_lt_one_of_peripheralPrimitive_aux
     exact (NNReal.coe_lt_one).1 this
   exact ⟨htrρ, by simpa only [map_sub, E] using hgap⟩
 
-/-- **Step 2:** peripheral primitivity of the transfer map implies a spectral gap for the
-complementary map `E - P` (where `P` projects onto the unique fixed point). -/
+/-- **Step 2:** peripheral primitivity of the transfer map implies a complementary
+transfer-map gap for `E - P` (where `P` projects onto the unique fixed point). -/
 theorem spectralRadius_compl_lt_one_of_peripheralPrimitive
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)
@@ -392,7 +393,7 @@ theorem spectralRadius_compl_lt_one_of_peripheralPrimitive
 /-! ## Step 3: express as MPS primitivity + overlap -/
 
 /-- Peripheral primitivity of the transfer map implies
-`MPSTensor.HasPrimitiveFixedPoint` (spectral-gap primitivity). -/
+`MPSTensor.HasPrimitiveFixedPoint` (complementary transfer-map gap primitivity). -/
 theorem hasPrimitiveFixedPoint_of_peripheralPrimitive
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)
@@ -407,7 +408,7 @@ theorem hasPrimitiveFixedPoint_of_peripheralPrimitive
   refine ⟨ρ, ?_⟩
   refine ⟨hNorm, hρ_ne, hρ_psd, hρ_fix, ?_⟩
   -- `fixedPointProj` ignores the trace-nonzero proof argument, so `hgap` matches the
-  -- `IsPrimitiveMPS` field `spectral_gap` definitionally.
+  -- `IsPrimitiveMPS` field `complementary_transfer_map_gap` definitionally.
   simpa only [map_sub] using hgap
 
 /-- As a corollary, peripheral primitivity implies the self-overlap converges to 1. -/

--- a/TNLean/MPS/Overlap/PeripheralToTransferMapGap.lean
+++ b/TNLean/MPS/Overlap/PeripheralToTransferMapGap.lean
@@ -47,7 +47,7 @@ The formal Lean declaration:
 > `TNLean.Channel.FixedPoint.Cesaro` supplies the PSD decomposition used in
 > `transferMap_hermitian_fixedPoint_eq_zero_of_trace_eq_zero` (line 93).
 > This is the Wolf Proposition 6.8 formalization consumed by the
-  > peripheral-to-complementary-gap connection.
+> peripheral-to-complementary-gap connection.
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -14,7 +14,7 @@ import TNLean.MPS.Periodic.SectorIrreducibility
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.SharedInfra.KrausAdjointSetup
 import TNLean.MPS.SharedInfra.BlockAssembly
-import TNLean.Spectral.SpectralGapNT
+import TNLean.Spectral.TransferOperatorGapNT
 import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull
 

--- a/TNLean/MPS/RFP/Convergence.lean
+++ b/TNLean/MPS/RFP/Convergence.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Core.Transfer
 import TNLean.PiAlgebra.CanonicalFormSepAux
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 import TNLean.Spectral.QuantitativeGap
 import TNLean.MPS.RFP.Defs
 
@@ -12,7 +12,7 @@ import TNLean.MPS.RFP.Defs
 # RG flow convergence for canonical-form MPS tensors
 
 This file proves the convergence result for the renormalization-group (RG) flow
-applied to MPS tensors in canonical form. The proof follows the spectral-gap
+applied to MPS tensors in canonical form. The proof follows the transfer-map gap
 argument from arXiv:1606.00608, Appendix B, lines 1211--1244; see also the
 transfer-matrix and RGFP discussion in arXiv:2011.12127, lines 433--442 and
 870--892.
@@ -27,7 +27,7 @@ converges to an idempotent (the RFP).
 
 * `rg_flow_converges_of_cf`: the sequence of blocked transfer maps converges
   pointwise to an idempotent for any canonical-form tensor. The proof uses the
-  exponential spectral-gap bound to squeeze the difference
+  exponential transfer-map gap bound to squeeze the difference
   `E^n X - P X` to zero, then composes with the subsequence `2^n → ∞`.
 
 ## References
@@ -59,7 +59,7 @@ transfer map.
 The convergence is entry-wise on the `D² × D²` transfer matrix space:
 `∀ ρ, (E^{2^n}) ρ → E_∞ ρ` where `E_∞ ∘ E_∞ = E_∞`.
 
-The proof uses the spectral gap: for each block `k`, injectivity implies
+The proof uses the transfer-map gap: for each block `k`, injectivity implies
 primitivity of the transfer map, giving `E^n = P + N^n` where `P` is the
 fixed-point projection (idempotent) and `N = E - P` has spectral radius `< 1`.
 The exponential bound `‖E^n X - P X‖ ≤ C(1-δ)^n ‖X‖` from

--- a/TNLean/MPS/SharedInfra/GaugePhase.lean
+++ b/TNLean/MPS/SharedInfra/GaugePhase.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Defs
 import TNLean.MPS.Overlap.Basic
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.Spectral.MPVOverlapDecay
-import TNLean.Spectral.SpectralGapNT
+import TNLean.Spectral.TransferOperatorGapNT
 import TNLean.Topology.TendstoHelpers
 
 import Mathlib.Data.Real.Sqrt

--- a/TNLean/MPS/Structure/PrimitivityBridge.lean
+++ b/TNLean/MPS/Structure/PrimitivityBridge.lean
@@ -5,18 +5,19 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Spectral.PrimitiveOverlap
 
 /-!
-# Spectral-gap primitivity and MPV overlap convergence
+# Complementary transfer-map gap primitivity and MPV overlap convergence
 
-This module connects the **spectral-gap definition of primitivity** to the overlap and
-canonical-form hypotheses used elsewhere in the library.
+This module connects the **complementary transfer-map gap** formulation of
+primitivity to the overlap and canonical-form hypotheses used elsewhere in the
+library.
 
 ## Main definitions
 
-* `IsPrimitiveMPS`: an MPS tensor is primitive if its transfer map has a spectral gap —
-  the spectral radius of `E - P` (where `P` is the fixed-point projection) is strictly
-  less than 1.
+* `IsPrimitiveMPS`: an MPS tensor is primitive if the complement of its
+  transfer-map fixed-point projection has spectral radius strictly less than 1.
 * `HasPrimitiveFixedPoint`: the existential formulation `∃ ρ, IsPrimitiveMPS A ρ`.
-  This is the MPS-specific spectral-gap predicate used in later arguments.
+  This is the MPS-specific complementary transfer-map gap predicate used in later
+  arguments.
 
 ## Main results
 
@@ -36,8 +37,8 @@ This file supplies one corner of the codebase's primitivity vocabulary:
 * `MPSTensor.IsPrimitivePaper` in
   `TNLean/Wielandt/Primitivity/Definitions.lean` is the uniform
   spreading definition.
-* `HasPrimitiveFixedPoint` here is the existential spectral-gap formulation used by the MPS
-  proof chain.
+* `HasPrimitiveFixedPoint` here is the existential complementary transfer-map
+  gap formulation used by the MPS proof chain.
 
 The connection between `IsPrimitiveMPS` / `HasPrimitiveFixedPoint` and the standard algebraic
 notions is deferred to peripheral spectrum theory.
@@ -50,9 +51,8 @@ namespace MPSTensor
 
 /-! ## Part 1: IsPrimitiveMPS -/
 
-/-- An MPS tensor is **primitive** (with witness `ρ`) if its transfer map has a spectral gap:
-the spectral radius of `E - P` (where `P` is the fixed-point projection onto a PSD
-fixed point `ρ`) is strictly less than 1.
+/-- An MPS tensor is **primitive** (with witness `ρ`) if the complement of its
+transfer-map fixed-point projection has spectral radius strictly less than `1`.
 
 The fixed point `ρ` is a parameter rather than an existentially quantified field, so that
 subsequent lemmas can directly access it without choice. For the existential formulation,
@@ -73,8 +73,9 @@ structure IsPrimitiveMPS {d D : ℕ} [NeZero D]
   fixedPoint_psd : ρ.PosSemidef
   /-- The transfer map fixes this point: `E(ρ) = ρ`. -/
   fixedPoint_is_fixed : transferMap (d := d) (D := D) A ρ = ρ
-  /-- Spectral gap: the complement of the fixed-point projection has spectral radius < 1. -/
-  spectral_gap :
+  /-- Complementary transfer-map gap: the complement of the fixed-point projection has
+  spectral radius `< 1`. -/
+  complementary_transfer_map_gap :
       spectralRadius ℂ
         ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
           ((transferMap (d := d) (D := D) A) -
@@ -89,12 +90,29 @@ structure IsPrimitiveMPS {d D : ℕ} [NeZero D]
 /-- An MPS tensor **has a primitive fixed point** if there exists a PSD fixed point `ρ`
 with `IsPrimitiveMPS A ρ`.
 
-Equivalently, this is the existential formulation `∃ ρ, IsPrimitiveMPS A ρ`. It is the
-MPS-specific spectral-gap formulation, distinct from the generic peripheral-spectrum predicate
-`_root_.IsPrimitive`, the transfer-map formulation `MPSTensor.IsPeripherallyPrimitive`, and the
-spreading predicate `MPSTensor.IsPrimitivePaper`. -/
+Equivalently, this is the existential formulation `∃ ρ, IsPrimitiveMPS A ρ`.
+It is the MPS-specific complementary transfer-map gap formulation, distinct from
+the generic peripheral-spectrum predicate `_root_.IsPrimitive`, the transfer-map
+formulation `MPSTensor.IsPeripherallyPrimitive`, and the spreading predicate
+`MPSTensor.IsPrimitivePaper`. -/
 def HasPrimitiveFixedPoint {d D : ℕ} [NeZero D] (A : MPSTensor d D) : Prop :=
   ∃ ρ : Matrix (Fin D) (Fin D) ℂ, IsPrimitiveMPS A ρ
+
+/-- Deprecated name for `IsPrimitiveMPS.complementary_transfer_map_gap`. -/
+@[deprecated IsPrimitiveMPS.complementary_transfer_map_gap (since := "2026-05-30")]
+theorem IsPrimitiveMPS.spectral_gap {d D : ℕ} [NeZero D]
+    {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ} (h : IsPrimitiveMPS A ρ) :
+    spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          ((transferMap (d := d) (D := D) A) -
+            fixedPointProj (D := D) ρ
+              (by
+                intro htrace
+                exact
+                  h.fixedPoint_ne_zero
+                    ((Matrix.PosSemidef.trace_eq_zero_iff h.fixedPoint_psd).1 htrace)))) <
+      1 :=
+  h.complementary_transfer_map_gap
 
 /-! ## Part 2: Derive overlap → 1 from primitivity -/
 
@@ -108,7 +126,7 @@ theorem IsPrimitiveMPS.overlap_tendsto_one {d D : ℕ} [NeZero D]
     Tendsto (fun N ↦ mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ)) :=
   mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one A
     hP.norm ρ hP.fixedPoint_is_fixed hP.fixedPoint_ne_zero hP.fixedPoint_psd
-    hP.spectral_gap
+    hP.complementary_transfer_map_gap
 
 /-- Existential version: if `A` has a primitive fixed point, its self-overlap converges to 1. -/
 theorem HasPrimitiveFixedPoint.overlap_tendsto_one {d D : ℕ} [NeZero D]

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -12,7 +12,7 @@ import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Irreducible.Similarity
 import TNLean.Channel.Irreducible.TraceAdjoint
 import TNLean.Channel.KrausRepresentation
-import TNLean.Spectral.SpectralGapNT
+import TNLean.Spectral.TransferOperatorGapNT
 
 /-!
 # String order: trace-preserving gauge reduction and auxiliary proofs

--- a/TNLean/MPS/Symmetry/StringOrderDefs.lean
+++ b/TNLean/MPS/Symmetry/StringOrderDefs.lean
@@ -6,7 +6,7 @@ import TNLean.MPS.Symmetry.Defs
 import TNLean.MPS.Core.Transfer
 import TNLean.Channel.KrausFreedom
 import TNLean.Channel.KrausRepresentation
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 import Mathlib.Analysis.Matrix.Order
 
 /-!

--- a/TNLean/PiAlgebra/CanonicalFormSep.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSep.lean
@@ -480,7 +480,7 @@ theorem sameMPV_of_charpoly_eq_all_words
 
 /-- Block separation for all blocks: a direct consequence of the core lemma.
 Under canonical form hypotheses, the summed identity implies per-block SameMPV.
-Requires injectivity of all blocks (used in the core lemma for the spectral gap
+Requires injectivity of all blocks (used in the core lemma for the transfer-operator gap
 argument). -/
 lemma block_separation_all_words
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -5,15 +5,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.Core.RepeatedWord
 import TNLean.PiAlgebra.FundamentalTheoremComplete
 import TNLean.Algebra.MatrixAux
-import TNLean.Spectral.SpectralGap
-import TNLean.Spectral.SpectralGapNT
+import TNLean.Spectral.TransferOperatorGap
+import TNLean.Spectral.TransferOperatorGapNT
 import TNLean.Spectral.MPVOverlapDecay
 import TNLean.Spectral.PrimitiveOverlap
 import TNLean.QPF.Assembly
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.MPS.Irreducible.FormII
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.Channel.Peripheral.Spectrum
 import Mathlib.Analysis.Complex.Basic
 
@@ -160,8 +160,8 @@ structure HasOrderedNonzeroWeights {r : ℕ} (μ : Fin r → ℂ) : Prop where
 /-- Strict weight ordering together with nonvanishing coefficients.
 
 This is the strengthened weight-ordering condition used in the block-separation
-proofs: `StrictAnti` on moduli guarantees a spectral gap between the dominant
-block and all others, which drives the geometric convergence. At the BNT level,
+proofs: `StrictAnti` on moduli guarantees a gap between the dominant block
+and all others, which drives the geometric convergence. At the BNT level,
 the grouping step ensures this holds. -/
 structure HasStrictOrderedNonzeroWeights {r : ℕ} (μ : Fin r → ℂ) : Prop where
   /-- Strict ordering of the block weights by modulus. -/
@@ -534,7 +534,7 @@ lemma leftCanonical_mpvOverlap_self_bound
       _ = (D : ℝ) * ∑ σ : Fin N → Fin d, (Matrix.trace ((M σ)ᴴ * M σ)).re := by
             simp [Finset.mul_sum]
       _ = (D : ℝ) * (Matrix.trace (∑ σ : Fin N → Fin d, (M σ)ᴴ * M σ)).re := by
-            -- Move `re` and `trace` outside the finite sum (as in `SpectralGap.sum_frobSq_words`).
+            -- Move `re` and `trace` outside the finite sum (as in `sum_frobSq_words`).
             congr 1
             rw [← Complex.re_sum, ← Matrix.trace_sum]
       _ = (D : ℝ) * (Matrix.trace (1 : Matrix (Fin D) (Fin D) ℂ)).re := by

--- a/TNLean/Spectral/CrossCorrelation.lean
+++ b/TNLean/Spectral/CrossCorrelation.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 
 /-!
 # Cross-correlation decay and block separation
@@ -23,7 +23,7 @@ cross-correlations between distinct blocks decay exponentially.
 * [CPGSV21] Cirac, Pérez-García, Schuch, Verstraete,
   *Matrix Product States and Projected Entangled Pair States*,
   Rev. Mod. Phys. 93 (2021), arXiv:2011.12127.
-  Sec. 2.3 (correlations and transfer matrix), Sec. 4 (spectral gap).
+  Sec. 2.3 (correlations and transfer matrix), Sec. 4 (transfer-matrix gap).
   Source: `Papers/2011.12127/`
 * [PGWSVC08] Pérez-García, Wolf, Sanz, Verstraete, Cirac,
   *String order and symmetries in quantum spin lattices*,
@@ -57,7 +57,7 @@ theorem cross_correlation_tendsto_zero
     Filter.Tendsto
       (fun N => Matrix.trace (((mixedTransferMap A B) ^ N) X))
       Filter.atTop (nhds 0) := by
-  -- Compose: F^N(X) → 0 (by spectral gap) and trace is continuous.
+  -- Compose: F^N(X) → 0 (by the transfer-operator gap) and trace is continuous.
   have h := mixedTransfer_pow_tendsto_zero A B hA hB hA_norm hB_norm hAB X
   have h_cont : Continuous (Matrix.traceLinearMap (Fin D) ℂ ℂ) :=
     LinearMap.continuous_of_finiteDimensional _

--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -12,7 +12,7 @@ Frobenius-norm identities for rectangular matrices. Everything here works for
 `Matrix (Fin m) (Fin n) ℂ`; the square case is obtained by setting `m = n`.
 
 The Frobenius (Hilbert--Schmidt) norm gives the rectangular Cauchy--Schwarz
-estimates used in the MPS spectral-gap argument of PerezGarcia2007. Wolf
+estimates used in the MPS transfer-operator gap argument of PerezGarcia2007. Wolf
 Chapter 6 proves the analogous eigenvalue bound for positive maps by the
 operator norm and Russo--Dye theorem (Proposition 6.1); in finite dimension
 both norms give the same spectral radius.

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -11,7 +11,7 @@ import Mathlib.Data.Matrix.Block
 import Mathlib.Analysis.Matrix.Normed
 
 /-!
-# Gauge construction for spectral-gap rigidity
+# Gauge construction for transfer-operator gap rigidity
 
 For tensors $A$ and $B$, a mixed-transfer eigenvector with $|\lambda|=1$
 can be transported through left-canonical gauges.  After embedding the
@@ -19,7 +19,7 @@ transported matrix into a block Kraus map, equality in the weighted
 Kadison--Schwarz inequality gives intertwining relations between the
 gauged Kraus operators.  This is the common argument in Wolf Theorem 6.6
 (peripheral spectrum of irreducible Schwarz maps) and PerezGarcia2007
-Lemma 5 (spectral gap for distinct MPS blocks).
+Lemma 5 (strict mixed-transfer-operator gap for distinct MPS blocks).
 -/
 
 open scoped Matrix Matrix.Norms.Operator MatrixOrder ComplexOrder BigOperators
@@ -666,8 +666,8 @@ theorem gaugePhaseEquiv_of_gauged_intertwining [NeZero D]
     simp only [A', gaugeTensor, Ymat, Yinv, Matrix.mul_assoc]
   simpa [Ygl] using this
 
-/-- Generic rectangular dimension comparison: the two intertwining relations force equality of dimensions
-once both gauged tensor families are injective. -/
+/-- Generic rectangular dimension comparison: the two intertwining relations force equality of
+dimensions once both gauged tensor families are injective. -/
 theorem dim_eq_of_gauged_intertwining [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (X : Matrix (Fin D₁) (Fin D₂) ℂ) (μ : ℂ)

--- a/TNLean/Spectral/MPVOverlapDecay.lean
+++ b/TNLean/Spectral/MPVOverlapDecay.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Spectral.MPVOverlapTrace
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 
 import Mathlib.Topology.Algebra.Star
 import Mathlib.Analysis.Matrix.Normed
@@ -21,7 +21,7 @@ open Matrix Filter
 This file proves a literature-standard decay statement for the *MPV overlap*
 `mpvOverlap A B N` in the **square bond dimension** case
 (cf. PerezGarcia2007 Lemma 5; Wolf Theorem 6.6 for the underlying
-spectral-gap theory).
+transfer-operator gap theory).
 
 If `A` and `B` are injective, satisfy the trace-preserving normalization
 `∑ i, (A i)ᴴ * A i = 1` and `∑ i, (B i)ᴴ * B i = 1`, and are **not** gauge-phase
@@ -33,7 +33,8 @@ equivalent, then the MPV overlaps decay to `0` as `N → ∞`.
    operator trace of `((mixedTransferMap A B)^N)`.
 2. Expand `LinearMap.trace` as a finite double sum over matrix units
    `Matrix.single p q 1` using `linearMap_trace_eq_sum_apply_single`.
-3. For each fixed `(p,q)`, apply the spectral-gap lemma `mixedTransfer_pow_tendsto_zero`
+3. For each fixed `(p,q)`, apply the transfer-operator gap lemma
+   `mixedTransfer_pow_tendsto_zero`
    to get `((mixedTransferMap A B)^N) (Matrix.single p q 1) → 0`.
 4. Extract the `(p,q)` entry using the continuous linear functional
    `Matrix.entryLinearMap ℂ ℂ p q`.
@@ -69,7 +70,7 @@ theorem mpvOverlap_tendsto_zero
   have hterm : ∀ p q : Fin D,
       Filter.Tendsto (fun N => term p q N) Filter.atTop (nhds 0) := by
     intro p q
-    -- Matrix-level convergence from the spectral gap.
+    -- Matrix-level convergence from the transfer-operator gap.
     have hmat :
         Filter.Tendsto
           (fun N => ((mixedTransferMap A B) ^ N) (Matrix.single p q (1 : ℂ)))

--- a/TNLean/Spectral/PrimitiveOverlap.lean
+++ b/TNLean/Spectral/PrimitiveOverlap.lean
@@ -3,26 +3,26 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Primitive
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 import TNLean.Spectral.MPVOverlapTrace
 
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Normed.Operator.CompleteCodomain
 
 /-!
-# Primitive overlap limit (spectral-gap formulation)
+# Primitive overlap limit (complementary transfer-map gap formulation)
 
 This module derives the **primitive/aperiodic overlap normalization**
 
 `mpvOverlap A A N → 1`
 
-from a spectral-gap hypothesis on the transfer map
+from a complementary transfer-map gap hypothesis
 (cf. Wolf Theorem 6.7: a primitive TP map has trivial peripheral spectrum,
 so its powers converge to the rank-one projection onto the stationary state).
 
 More precisely, if a trace-preserving map `E` has a (nonzero) fixed point `ρ`, and the
-spectral radius of the complementary map `N := E - fixedPointProj ρ` is strictly less than `1`,
-then `LinearMap.trace (E^n) → 1`.
+spectral radius of the complementary map `N := E - fixedPointProj ρ` is strictly
+less than `1`, then `LinearMap.trace (E^n) → 1`.
 
 For MPS tensors, the identity
 
@@ -33,9 +33,9 @@ then yields `mpvOverlap A A N → 1`.
 This matches the **primitive branch** of the Fundamental Theorem proofs
 (Cirac--Pérez-García--Schuch--Verstraete, Rev. Mod. Phys. 93 (2021)).
 
-We intentionally phrase primitivity as a **spectral-gap hypothesis**. Connecting this to Wolf's
-characterizations (irreducible + aperiodic, peripheral spectrum roots of unity, etc.) is a
-separate, future module.
+We intentionally phrase primitivity as a **complementary transfer-map gap**
+hypothesis. Connecting this to Wolf's characterizations (irreducible +
+aperiodic, peripheral spectrum roots of unity, etc.) is a separate module.
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
@@ -74,13 +74,13 @@ lemma tendsto_trace_pow_of_tendsto_zero
       atTop (nhds (0 : ℂ))
   simpa [traceCLM, Function.comp_apply, hzero] using h
 
-/-- **Trace convergence from a spectral gap.**
+/-- **Trace convergence from a complementary transfer-map gap.**
 
 Let `P` be the rank-one projection onto a fixed point `ρ` and `N := E - P`.
 If `spectralRadius(N) < 1`, then `trace(E^n) → 1`.
 
 This is the analytic core used to replace the current hypothesis
-`mpvOverlap A A N → 1` by a genuine primitive/spectral-gap condition.
+`mpvOverlap A A N → 1` by a genuine complementary transfer-map gap condition.
 -/
 theorem linearMap_trace_pow_tendsto_one_of_spectralRadius_compl_lt_one
     [NeZero D]
@@ -149,10 +149,11 @@ section MPV
 
 variable {d D : ℕ} [NeZero D]
 
-/-- **Primitive overlap limit** (spectral-gap formulation).
+/-- **Primitive overlap limit** (complementary transfer-map gap formulation).
 
-If the transfer map of a normalized tensor `A` has a fixed point `ρ` and a spectral gap on the
-complement of the fixed-point projection, then the MPV self-overlap converges to `1`.
+If the transfer map of a normalized tensor `A` has a fixed point `ρ` and the
+complement of the fixed-point projection has spectral radius less than `1`,
+then the MPV self-overlap converges to `1`.
 -/
 theorem mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one
     (A : MPSTensor d D)
@@ -172,7 +173,7 @@ theorem mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one
   -- First derive `trace((transferMap A)^N) → 1`.
   have hTP : IsTracePreservingMap (transferMap (d := d) (D := D) A) := by
     intro X
-    -- same proof as `MPSTensor.trace_transferMap` in `SpectralGap.lean`
+    -- same proof as `MPSTensor.trace_transferMap` in `TransferOperatorGap.lean`
     rw [transferMap_apply, Matrix.trace_sum]
     conv_lhs => arg 2; ext i; rw [Matrix.trace_mul_cycle]
     rw [← Matrix.trace_sum, ← Finset.sum_mul, hNorm, one_mul]

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -2,26 +2,26 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Wielandt.Primitivity.EasyDirections
 import TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducibleAux
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 
 /-!
-# Quantitative spectral gap bounds for MPS transfer operators
+# Quantitative transfer-map gap bounds for MPS transfer operators
 
-This file provides **explicit quantitative bounds** on the spectral gap of
+This file provides **explicit quantitative bounds** on transfer-map gaps for
 MPS transfer operators, strengthening the existing qualitative result
 `spectralRadius_mixedTransfer_lt_one` (which only proves `ρ < 1` without
 a lower bound on `1 - ρ`).
 
 ## Building blocks (already formalized elsewhere)
 
-* `pow_tendsto_zero_of_spectralRadius_lt_one` in `Spectral/SpectralGap.lean` —
+* `pow_tendsto_zero_of_spectralRadius_lt_one` in `Spectral/TransferOperatorGap.lean` —
   exponential convergence to zero when spectral radius < 1
 * `compl_eigenvalue_norm_lt_one_of_primitive` in `Peripheral/Spectrum.lean` —
-  primitive channels have spectral gap
+  primitive channels have a complementary transfer-map gap
 * `cumulativeSpan_eq_top` in `Wielandt/WielandtBound.lean` — the D² Wielandt bound
 
 ## Main results
@@ -29,7 +29,7 @@ a lower bound on `1 - ρ`).
 * `exponential_convergence_of_primitive` — for an injective primitive TP channel,
   `‖E^n(X) - P(X)‖ ≤ C · (1-δ)^n · ‖X‖` (convergence to fixed-point projection)
 * `correlation_length_bound` — exponential decay of traceless iterates
-* `spectral_gap_of_injective` — explicit spectral gap `δ > 0` with
+* `transfer_map_gap_of_injective` — explicit transfer-map gap `δ > 0` with
   all non-unit eigenvalues satisfying `|μ| ≤ 1 - δ`
 
 ## Strengthening relative to the literature
@@ -209,7 +209,7 @@ theorem hasEventuallyFullKrausRank_of_injective (A : MPSTensor d D)
     (hA : IsInjective A) : HasEventuallyFullKrausRank A :=
   ⟨1, by rw [wordSpan_one_eq_span_range, hA]⟩
 
-/-! ## Convergence rate from spectral gap -/
+/-! ## Convergence rate from a complementary transfer-map gap -/
 
 /-- **Exponential convergence of injective primitive channels.**
 
@@ -219,7 +219,7 @@ For an injective primitive TP channel `E` with fixed point projection `P`, the i
   `‖E^n(X) - P(X)‖ ≤ C · (1-δ)^n · ‖X‖`
 
 where `P(X) = tr(X) · ρ_∞ / tr(ρ_∞)` is the projection onto the fixed state,
-`δ > 0` is the spectral gap, and `C` depends on the Jordan structure.
+`δ > 0` is the transfer-map gap, and `C` depends on the Jordan structure.
 
 The extra injectivity hypothesis is what supplies the needed uniqueness of
 trace-zero fixed points, so that the complementary map `E - P` has spectral
@@ -310,10 +310,11 @@ theorem exponential_convergence_of_primitive [NeZero D]
 
 For an injective TP-normalized MPS tensor, traceless matrices decay
 exponentially under the transfer map iteration. The rate is determined by
-the spectral gap, which exists because injectivity implies primitivity.
+the complementary transfer-map gap, which exists because injectivity implies
+primitivity.
 
 This uses `pow_tendsto_zero_of_spectralRadius_lt_one` from
-`Spectral/SpectralGap.lean` directly — traceless matrices lie in
+`Spectral/TransferOperatorGap.lean` directly — traceless matrices lie in
 `ker(P) = range(E - P)`, where `E - P` has spectral radius < 1. -/
 theorem correlation_length_bound [NeZero D]
     (A : MPSTensor d D)
@@ -403,7 +404,7 @@ theorem correlation_length_bound [NeZero D]
 
 /-! ## Explicit gap from injectivity -/
 
-/-- **Spectral gap from injectivity** (existential version).
+/-- **Transfer-map gap from injectivity** (existential version).
 
 For an injective TP-normalized MPS tensor, all eigenvalues of the transfer
 map other than 1 have modulus strictly less than 1, with a uniform gap.
@@ -411,10 +412,10 @@ map other than 1 have modulus strictly less than 1, with a uniform gap.
 The existential bound `∃ δ > 0` follows from: injectivity implies
 `HasEventuallyFullKrausRank` (at index 1), which implies primitivity
 (via `IsPrimitivePaper → IsPeripherallyPrimitive`), primitivity implies
-spectral gap (by `compl_eigenvalue_norm_lt_one_of_primitive`), and in
-finite dimensions the maximum over finitely many eigenvalues gives a
+the complementary transfer-map gap (by `compl_eigenvalue_norm_lt_one_of_primitive`),
+and in finite dimensions the maximum over finitely many eigenvalues gives a
 uniform bound. -/
-theorem spectral_gap_of_injective [NeZero D]
+theorem transfer_map_gap_of_injective [NeZero D]
     (A : MPSTensor d D)
     (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hA : IsInjective A) :
@@ -433,8 +434,19 @@ theorem spectral_gap_of_injective [NeZero D]
     intro μ hμ
     exact eigenvalue_norm_le_one A A hNorm hNorm μ (hE_eq ▸ hμ)
   -- Step 3: non-1 eigenvalues have ‖μ‖ < 1, then extract uniform gap
-  exact uniform_spectral_gap_of_finite_lt_one (Module.End.finite_hasEigenvalue E)
+  exact uniform_eigenvalue_gap_of_finite_lt_one (Module.End.finite_hasEigenvalue E)
     fun μ hμ hne => lt_of_le_of_ne (hbound μ hμ)
       fun h => hne (hPrim.unique_peripheral μ hμ h)
+
+/-- Deprecated name for `transfer_map_gap_of_injective`. -/
+@[deprecated transfer_map_gap_of_injective (since := "2026-05-30")]
+theorem spectral_gap_of_injective [NeZero D]
+    (A : MPSTensor d D)
+    (hNorm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hA : IsInjective A) :
+    ∃ (δ : ℝ), 0 < δ ∧
+      ∀ (μ : ℂ), Module.End.HasEigenvalue (transferMap (d := d) (D := D) A) μ →
+        μ ≠ 1 → ‖μ‖ ≤ 1 - δ :=
+  transfer_map_gap_of_injective A hNorm hA
 
 end MPSTensor

--- a/TNLean/Spectral/TransferOperatorGap.lean
+++ b/TNLean/Spectral/TransferOperatorGap.lean
@@ -16,7 +16,7 @@ import Mathlib.LinearAlgebra.Eigenspace.Basic
 import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 
 /-!
-# Spectral gap for the mixed transfer operator
+# Transfer-operator gap for the mixed transfer operator
 
 The key analytic ingredient: if a linear operator on a finite-dimensional
 space has spectral radius strictly less than 1, then its iterates converge
@@ -27,7 +27,8 @@ to zero. This is the mechanism by which the mixed transfer operator
 
 * `eigenvalue_norm_le_one`: every eigenvalue of `F_{AB}` has modulus ≤ 1
 * `spectralRadius_mixedTransfer_le_one`: `ρ(F_{AB}) ≤ 1` for normalized tensors
-* `spectralRadius_mixedTransfer_lt_one`: strict spectral gap for non-equivalent blocks
+* `spectralRadius_mixedTransfer_lt_one`: strict transfer-operator gap for
+  non-equivalent blocks
 * `mixedTransfer_pow_tendsto_zero`: `F_{AB}^n → 0` for distinct blocks
 
 ## References
@@ -35,7 +36,7 @@ to zero. This is the mechanism by which the mixed transfer operator
 * CPGSV21: Cirac, Pérez-García, Schuch, Verstraete,
   *Matrix Product States and Projected Entangled Pair States*,
   Rev. Mod. Phys. 93 (2021), arXiv:2011.12127.
-  Sec. 2.3 (correlations and transfer matrix), Sec. 4 (spectral gap and
+  Sec. 2.3 (correlations and transfer matrix), Sec. 4 (transfer-operator gap and
   mixed transfer operator `F_{jk}`).
 * [Wolf2012Quantum] Wolf, *Quantum Channels & Operations: Guided Tour*,
   Proposition 6.1, Theorem 6.6, Section 6.2.
@@ -466,7 +467,7 @@ theorem modulus_one_eigenvalue_implies_gauge
   -- Step 3: Apply the core algebraic lemma
   exact eigenvector_gives_gauge A B X μ hA hB hA_norm hB_norm hFX hμ_eq hX_ne
 
-/-- **Spectral gap for distinct blocks**: `ρ(F_{AB}) < 1` when `A ≇ B`. -/
+/-- **Transfer-operator gap for distinct blocks**: `ρ(F_{AB}) < 1` when `A ≇ B`. -/
 theorem spectralRadius_mixedTransfer_lt_one
     (A B : MPSTensor d D)
     (hA : IsInjective A) (hB : IsInjective B)
@@ -527,14 +528,14 @@ end SpectralConvergence
 
 end MPSTensor
 
-/-! ## Uniform spectral gap from finite eigenvalue set -/
+/-! ## Uniform eigenvalue gap from a finite eigenvalue set -/
 
-/-- **Uniform spectral gap from finitely many eigenvalues with modulus < 1.**
+/-- **Uniform eigenvalue gap from finitely many eigenvalues with modulus < 1.**
 
 If an endomorphism has finitely many eigenvalues, and every eigenvalue `μ ≠ 1` satisfies
 `‖μ‖ < 1`, then there exists a uniform gap `δ > 0` such that `‖μ‖ ≤ 1 - δ` for all
 non-unit eigenvalues. This is a general finite-dimensional argument via `Finset.max'`. -/
-theorem uniform_spectral_gap_of_finite_lt_one
+theorem uniform_eigenvalue_gap_of_finite_lt_one
     {K V : Type*} [NormedField K] [AddCommGroup V] [Module K V]
     {E : V →ₗ[K] V}
     (hfin : Set.Finite {μ : K | Module.End.HasEigenvalue E μ})
@@ -562,3 +563,13 @@ theorem uniform_spectral_gap_of_finite_lt_one
     linarith [Finset.le_max' norms ‖μ‖ hμ_norm_mem]
   · -- Empty: no non-1 eigenvalues, δ = 1 works vacuously
     exact ⟨1, one_pos, fun μ hμ hne => absurd ⟨μ, hμ, hne⟩ hS⟩
+
+/-- Deprecated name for `uniform_eigenvalue_gap_of_finite_lt_one`. -/
+@[deprecated uniform_eigenvalue_gap_of_finite_lt_one (since := "2026-05-30")]
+theorem uniform_spectral_gap_of_finite_lt_one
+    {K V : Type*} [NormedField K] [AddCommGroup V] [Module K V]
+    {E : V →ₗ[K] V}
+    (hfin : Set.Finite {μ : K | Module.End.HasEigenvalue E μ})
+    (hlt : ∀ μ, Module.End.HasEigenvalue E μ → μ ≠ 1 → ‖μ‖ < 1) :
+    ∃ δ > 0, ∀ μ, Module.End.HasEigenvalue E μ → μ ≠ 1 → ‖μ‖ ≤ 1 - δ :=
+  uniform_eigenvalue_gap_of_finite_lt_one hfin hlt

--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -2,13 +2,13 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Spectral.SpectralGapRect
+import TNLean.Spectral.TransferOperatorGapRect
 import TNLean.Spectral.GaugeConstruction
 import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.MPS.Irreducible.FormII
 
 /-!
-# Spectral gap for normal tensor (irreducible + TP) blocks
+# Transfer-operator gap for normal tensor (irreducible + TP) blocks
 
 This file proves the overlap dichotomy for irreducible trace-preserving / left-canonical
 blocks without assuming injectivity. The argument combines the Cauchy--Schwarz
@@ -20,10 +20,10 @@ The key new rigidity statement is
 left-canonical tensors have mixed-transfer spectral radius at least `1`, then they are
 already gauge-phase equivalent (cf. Wolf Theorem 6.6 adapted to MPS transfer maps).
 
-The same-dimension rigidity step is now fully formalized. The downstream strict-gap and
-overlap-decay consequences for equal bond dimension are routed through the existing
-spectral-radius infrastructure, and the rectangular different-dimension analogue is
-formalized below as well.
+The same-dimension rigidity step is now fully formalized. The downstream
+transfer-operator gap and overlap-decay consequences for equal bond dimension
+are routed through the existing spectral-radius infrastructure, and the
+rectangular different-dimension analogue is formalized below as well.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators NNReal ENNReal Matrix.Norms.Operator
@@ -225,8 +225,8 @@ theorem modulus_one_eigenvalue_implies_gauge_of_irreducible_TP
     A B X μ hA_irr hB_irr hA_left hB_left hFX hμ_eq hX_ne
 
 /--
-**Strict mixed-transfer spectral gap** for distinct irreducible left-canonical blocks of the
-same bond dimension.
+**Strict mixed-transfer-operator gap** for distinct irreducible left-canonical blocks
+of the same bond dimension.
 -/
 theorem spectralRadius_mixedTransfer_lt_one_of_irreducible_TP
     (A B : MPSTensor d D)
@@ -607,8 +607,8 @@ set_option synthInstance.maxHeartbeats 200000 in
 -- The rectangular spectral-radius extraction uses the same CLM instance search and needs
 -- the same small local heartbeat bump.
 /--
-**Rectangular strict spectral gap** for irreducible left-canonical blocks of different bond
-sizes.
+**Rectangular strict transfer-operator gap** for irreducible left-canonical blocks
+of different bond sizes.
 
 The intended proof follows the same Cauchy--Schwarz rigidity mechanism as
 `modulus_one_eigenvalue_implies_gauge_of_irreducible_TP`, but in the rectangular setting:

--- a/TNLean/Spectral/TransferOperatorGapRect.lean
+++ b/TNLean/Spectral/TransferOperatorGapRect.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Spectral.SpectralGap
+import TNLean.Spectral.TransferOperatorGap
 import TNLean.Spectral.MPVOverlapDecay
 import TNLean.QPF.Assembly
 import TNLean.Channel.FixedPoint.CanonicalGauge
@@ -12,21 +12,22 @@ import Mathlib.Analysis.Normed.Algebra.GelfandFormula
 import Mathlib.LinearAlgebra.Eigenspace.Basic
 
 /-!
-# Rectangular spectral gap for the mixed transfer operator
+# Rectangular transfer-operator gap for the mixed transfer operator
 
 When two MPS tensors `A : MPSTensor d D₁` and `B : MPSTensor d D₂` have **different bond
 dimensions** `D₁ ≠ D₂`, the spectral radius of the rectangular mixed transfer operator
 `mixedTransferMap₂ A B` is strictly less than 1 (assuming both tensors are injective and
 normalized).
 
-This is the "dimension-mismatch" spectral gap (cf. Wolf Theorem 6.6 adapted to
-MPS transfer maps with rectangular bond dimensions): if the bond dimensions differ, then
-the overlap `∑ σ, mpv A σ * conj(mpv B σ)` decays to zero exponentially.
+This is the dimension-mismatch transfer-operator gap (cf. Wolf Theorem 6.6
+adapted to MPS transfer maps with rectangular bond dimensions): if the bond
+dimensions differ, then the overlap
+`∑ σ, mpv A σ * conj(mpv B σ)` decays to zero exponentially.
 
 ## Main results
 
-* `mixedTransferSpectralRadius₂_lt_one_of_dim_ne`: strict spectral gap for dimension-mismatched
-  normalized injective tensors
+* `mixedTransferSpectralRadius₂_lt_one_of_dim_ne`: strict transfer-operator gap
+  for dimension-mismatched normalized injective tensors
 * `mpvOverlap_tendsto_zero_of_dim_ne`: the MPV overlap tends to zero when `D₁ ≠ D₂`
 
 ## Proof outline
@@ -235,7 +236,7 @@ section DimensionEquality
 /-- Core algebraic lemma: if there is an eigenvector of `mixedTransferMap₂ A B` with eigenvalue
 of modulus 1, then `D₁ = D₂`.
 
-This is the rectangular analogue of `eigenvector_gives_gauge` from `SpectralGap.lean`,
+This is the rectangular analogue of `eigenvector_gives_gauge` from `TransferOperatorGap.lean`,
 but instead of constructing a gauge equivalence, we derive equality of dimensions. -/
 private theorem dim_eq_of_modulus_one_eigenvector [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -311,8 +312,8 @@ section MainTheorem
 set_option synthInstance.maxHeartbeats 400000 in
 -- Instance search for the rectangular continuous endomorphism space needs a local
 -- heartbeat bump during the spectral-radius extraction.
-/-- **Dimension-mismatch spectral gap**: the spectral radius of the rectangular mixed transfer
-operator is strictly less than 1 when the bond dimensions differ. -/
+/-- **Dimension-mismatch transfer-operator gap**: the spectral radius of the rectangular
+mixed transfer operator is strictly less than 1 when the bond dimensions differ. -/
 theorem mixedTransferSpectralRadius₂_lt_one_of_dim_ne
     {d D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/Wielandt/Primitivity/Definitions.lean
+++ b/TNLean/Wielandt/Primitivity/Definitions.lean
@@ -38,8 +38,8 @@ There are four distinct primitivity predicates in the codebase:
   `peripheralEigenvalues E = {1}`.
 * `MPSTensor.HasPrimitiveFixedPoint A` in
   `TNLean/MPS/Structure/PrimitivityBridge.lean`: the existential statement
-  `∃ ρ, IsPrimitiveMPS A ρ`, encoding the spectral-gap formulation used in the MPS
-  proof route.
+  `∃ ρ, IsPrimitiveMPS A ρ`, encoding the complementary transfer-map gap
+  formulation used in the MPS proof route.
 * `IsPrimitivePaper A` in this file: the uniform spreading condition from
   Proposition 3(a).
 * `IsPeripherallyPrimitive A` in this file: the transfer-map formulation of
@@ -163,8 +163,8 @@ This is the transfer-map formulation of the canonical predicate
 For orientation, the codebase distinguishes four related notions:
 
 * `_root_.IsPrimitive E`: generic peripheral-spectrum primitivity for any linear map `E`;
-* `MPSTensor.HasPrimitiveFixedPoint A`: existential statement around the spectral-gap
-  predicate `IsPrimitiveMPS`;
+* `MPSTensor.HasPrimitiveFixedPoint A`: existential statement around the
+  complementary transfer-map gap predicate `IsPrimitiveMPS`;
 * `IsPrimitivePaper A`: the paper-faithful uniform spreading condition;
 * `IsPeripherallyPrimitive A`: this thin transfer-map formulation.
 
@@ -198,8 +198,8 @@ quantum Perron–Frobenius theorem) and aperiodicity giving uniqueness of the
 peripheral eigenvalue.
 
 **Relationship to `IsPrimitiveMPS` / `HasPrimitiveFixedPoint`**: this is
-strictly stronger than the spectral-gap statement because the fixed point is
-required to be positive *definite* (not merely positive semidefinite). For
+strictly stronger than the complementary transfer-map gap statement because the
+fixed point is required to be positive *definite* (not merely positive semidefinite). For
 irreducible channels, the PSD fixed point is automatically PosDef, so the two
 notions coincide in that case.
 

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
@@ -6,7 +6,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Wielandt.Primitivity.Definitions
 import TNLean.Wielandt.Primitivity.Normal
 import TNLean.MPS.CanonicalForm.Reduction
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import Mathlib.Analysis.InnerProductSpace.Positive
 import Mathlib.Analysis.Matrix.Spectrum

--- a/TNLean/Wielandt/Primitivity/Normal.lean
+++ b/TNLean/Wielandt/Primitivity/Normal.lean
@@ -15,7 +15,7 @@ Wielandt development and recalls the normality side of the chain from
 `WielandtBound.lean`.
 
 It does **not** prove `HasPrimitiveFixedPoint → IsNormal`. The currently formalized route
-from spectral-gap primitivity to normality with an additional positive-definite
+from complementary transfer-map gap primitivity to normality with an additional positive-definite
 fixed point hypothesis is assembled in
 `TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank`.
 
@@ -74,7 +74,7 @@ theorem transferMap_pow_apply_eq_sum (A : MPSTensor d D) (n : ℕ)
 
 /-- **Every word length has a nonzero word product under primitivity.**
 
-Given `IsPrimitiveMPS A ρ` (transfer map has a spectral gap with PSD
+Given `IsPrimitiveMPS A ρ` (transfer map has a complementary gap with PSD
 fixed point `ρ`), for every `n : ℕ` there exists a word `σ : Fin n → Fin d`
 such that `evalWord A (List.ofFn σ) ≠ 0`.
 
@@ -158,7 +158,7 @@ in this file. The currently formalized route in
 `IsPrimitiveMPS A ρ` under the additional hypothesis that `ρ` is positive
 definite.
 
-What remains here is the gap from bare spectral-gap primitivity to eventual
+What remains here is the gap from bare complementary transfer-map gap primitivity to eventual
 full matrix spanning. Conceptually this should follow from irreducibility plus a
 Burnside- or peripheral-spectrum argument, but that formalization is kept out
 of this lightweight statement file.

--- a/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
+++ b/TNLean/Wielandt/Primitivity/PrimitiveBridge.lean
@@ -5,17 +5,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 import TNLean.MPS.Core.Transfer
 import TNLean.Wielandt.Primitivity.Definitions
-import TNLean.MPS.Overlap.PeripheralToSpectralGap
+import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.MPS.Irreducible.FormII
 import TNLean.Wielandt.Primitivity.ToNormal
 import TNLean.Channel.Primitive
 import TNLean.Channel.Irreducible.FromSpectral
 
 /-!
-# Connecting results for primitive MPS and spectral-gap conditions
+# Connecting results for primitive MPS and complementary transfer-map gaps
 
 This module collects the connection between the transfer-map
-condition `IsStronglyIrreduciblePaper` and the spectral-gap predicate
+condition `IsStronglyIrreduciblePaper` and the complementary-gap predicate
 `IsPrimitiveMPS`.  These results are used by the Proposition 3(c)→(b) proof in
 `TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank` and by downstream
 normality/canonical-form reductions.
@@ -23,10 +23,10 @@ normality/canonical-form reductions.
 ## Main results
 
 * `isPrimitiveMPS_of_isStronglyIrreduciblePaper` — strong irreducibility gives
-  spectral-gap primitivity for a positive-definite fixed point.
-* `IsPrimitiveMPS.isPeripherallyPrimitive` — spectral-gap primitivity implies
+  complementary transfer-map gap primitivity for a positive-definite fixed point.
+* `IsPrimitiveMPS.isPeripherallyPrimitive` — complementary transfer-map gap primitivity implies
   paper peripheral primitivity.
-* `isIrreducibleMap_of_isPrimitiveMPS_of_posDef` — primitive spectral-gap data
+* `isIrreducibleMap_of_isPrimitiveMPS_of_posDef` — primitive complementary-gap data
   with a positive-definite fixed point gives irreducibility of the transfer map.
 * `isStronglyIrreduciblePaper_of_isPrimitiveMPS_of_posDef` — the previous two
   implications stated as paper strong irreducibility.
@@ -46,14 +46,14 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ## Strong irreducibility and primitive spectral-gap data -/
+/-! ## Strong irreducibility and primitive complementary-gap data -/
 
-/-- **Primitivity implication**: strong irreducibility implies the spectral-gap
+/-- **Primitivity implication**: strong irreducibility implies the complementary-gap
 predicate `IsPrimitiveMPS A ρ` for some positive-definite `ρ`.
 
 This is the structural step in Proposition 3(c)→(b): it connects the paper's
 spectral characterization (peripheral eigenvalues = {1}, irreducibility, and a
-positive-definite fixed point) to the operational spectral-gap hypothesis used
+positive-definite fixed point) to the operational complementary transfer-map gap used
 by the transfer-map convergence theory.
 
 The proof chains:
@@ -78,7 +78,7 @@ theorem isPrimitiveMPS_of_isStronglyIrreduciblePaper [NeZero D]
       hPrimMPS.fixedPoint_psd hPrimMPS.fixedPoint_ne_zero hPrimMPS.fixedPoint_is_fixed
   exact ⟨ρ', hPrimMPS, hρ'PD⟩
 
-/-- A primitive MPS tensor in the spectral-gap sense is peripherally primitive in
+/-- A primitive MPS tensor in the complementary-gap sense is peripherally primitive in
 the transfer-map sense.
 
 This is the easy spectral implication: if the complementary map `E - P_ρ` has
@@ -108,7 +108,7 @@ theorem IsPrimitiveMPS.isPeripherallyPrimitive [NeZero D]
       exact @le_iSup₂ ENNReal ℂ (· ∈ spectrum ℂ _) _
         (fun z _ => (‖z‖₊ : ENNReal)) ν hν_mem
     have hν_lt : (‖ν‖₊ : ENNReal) < 1 :=
-      lt_of_le_of_lt hν_le hP.spectral_gap
+      lt_of_le_of_lt hν_le hP.complementary_transfer_map_gap
     have : ((‖ν‖₊ : ℝ) < 1) := by
       simpa using hν_lt
     simpa using this
@@ -119,7 +119,7 @@ theorem IsPrimitiveMPS.isPeripherallyPrimitive [NeZero D]
 /-- A primitive MPS tensor with a positive-definite fixed point has an
 irreducible transfer map.
 
-The spectral gap gives uniqueness of the fixed-point space via
+The complementary transfer-map gap gives uniqueness of the fixed-point space via
 `IsPrimitiveMPS.fixedPoint_unique`; combined with `ρ.PosDef`, Wolf's fixed-point
 criterion for irreducibility applies directly. -/
 theorem isIrreducibleMap_of_isPrimitiveMPS_of_posDef [NeZero D]
@@ -137,7 +137,7 @@ theorem isIrreducibleMap_of_isPrimitiveMPS_of_posDef [NeZero D]
   exact isIrreducibleMap_of_channel_posDef_fixedPoint_unique E hP.transferMap_isChannel ρ
     hρ_pd (by simpa [E] using hP.fixedPoint_is_fixed) huniq
 
-/-- Primitive spectral-gap data plus a positive-definite fixed point imply
+/-- Primitive complementary-gap data plus a positive-definite fixed point imply
 paper strong irreducibility. -/
 theorem isStronglyIrreduciblePaper_of_isPrimitiveMPS_of_posDef [NeZero D]
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}

--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -197,7 +197,7 @@ This is the "nondegeneracy → full span" direction.
 **Lemma B** (`norm_tracePairBilin_le`): operator-norm bound on the bilinear form:
 `‖Q_F(B)‖ ≤ D² · ‖Bᴴ‖ · ‖Φ(F)‖ · ‖B‖`,
 where `Φ = Module.End.toContinuousLinearMap` and `‖·‖` is the `l∞`-operator norm
-(the scoped norm in the `MPSTensor` namespace via `SpectralGap.lean`).
+(the scoped norm in the `MPSTensor` namespace via `TransferOperatorGap.lean`).
 This bounds the error term `Q_{(E − P_ρ)^n}(B)` uniformly. -/
 
 section UniformPositivity
@@ -325,7 +325,7 @@ private theorem wordSpan_eq_top_of_tracePairBilin_re_pos
 /-! #### Lemma B: operator-norm bound on the bilinear form
 
 The norm on `Matrix (Fin D) (Fin D) ℂ` in the `MPSTensor` namespace is the
-`l∞`-operator norm (scoped instance from `SpectralGap.lean`), under which
+`l∞`-operator norm (scoped instance from `TransferOperatorGap.lean`), under which
 matrix multiplication is submultiplicative (`norm_mul_le`).  We prove entry
 bounds and single-matrix norm bounds directly for this norm. -/
 

--- a/TNLean/Wielandt/Primitivity/ToNormal.lean
+++ b/TNLean/Wielandt/Primitivity/ToNormal.lean
@@ -13,14 +13,14 @@ import TNLean.Spectral.MixedTransfer
 /-!
 # Preparatory lemmas for the current `IsPrimitiveMPS → IsNormal` route
 
-This file collects spectral-gap consequences of `IsPrimitiveMPS` together with
+This file collects complementary transfer-map gap consequences of `IsPrimitiveMPS` together with
 basic transfer-map compatibility lemmas. It stops short of proving any
 `IsNormal` theorem; the actual primitive-to-normal implication lives in
 `Primitivity/StronglyIrreducibleToFullRank.lean`.
 
 ## Main results
 
-### Spectral-gap consequences
+### Complementary transfer-map gap consequences
 
 * `IsPrimitiveMPS.trace_ne_zero`: `tr(ρ) ≠ 0`
 * `IsPrimitiveMPS.fixedPoint_unique`: any fixed point of `E` is proportional to
@@ -40,8 +40,8 @@ basic transfer-map compatibility lemmas. It stops short of proving any
 
 ## Important note on definitions
 
-Our `IsPrimitiveMPS` hypothesis consists of a spectral gap around a nonzero PSD
-fixed point. This is weaker than the paper's primitive condition in
+Our `IsPrimitiveMPS` hypothesis consists of a complementary transfer-map gap
+around a nonzero PSD fixed point. This is weaker than the paper's primitive condition in
 arXiv:0909.5347, Proposition 3, which additionally forces the fixed point to be
 positive definite.
 
@@ -63,7 +63,7 @@ namespace MPSTensor
 
 variable {d D : ℕ} [NeZero D]
 
-/-! ## Part 1: Spectral-gap consequences -/
+/-! ## Part 1: Complementary transfer-map gap consequences -/
 
 /-- The trace of the PSD fixed point is nonzero. -/
 theorem IsPrimitiveMPS.trace_ne_zero
@@ -74,7 +74,7 @@ theorem IsPrimitiveMPS.trace_ne_zero
   exact hP.fixedPoint_ne_zero
     ((Matrix.PosSemidef.trace_eq_zero_iff hP.fixedPoint_psd).1 h)
 
-/-- **Any fixed point of E is proportional to ρ** (from spectral gap).
+/-- **Any fixed point of E is proportional to ρ** (from the complementary transfer-map gap).
 
 If `E(σ) = σ`, then `σ = (tr(σ)/tr(ρ)) • ρ`.
 
@@ -83,7 +83,7 @@ If `E(σ) = σ`, then `σ = (tr(σ)/tr(ρ)) • ρ`.
 `E − P_ρ`, contradicting `spectralRadius(E − P_ρ) < 1`.
 
 Paper: arXiv:0909.5347, Proposition 3 (uniqueness of fixed point from
-spectral gap). -/
+the complementary transfer-map gap). -/
 theorem IsPrimitiveMPS.fixedPoint_unique
     {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ)
@@ -115,7 +115,7 @@ theorem IsPrimitiveMPS.fixedPoint_unique
   have hEig : Module.End.HasEigenvalue Ê 1 := by
     rw [Module.End.hasEigenvalue_iff]
     exact fun h_bot => hσ'_ne ((Submodule.eq_bot_iff _).mp h_bot σ' h_mem)
-  -- Ê has eigenvalue 1, so spectralRadius ≥ 1, contradicting the spectral gap
+  -- Ê has eigenvalue 1, so spectralRadius ≥ 1, contradicting the complementary gap
   have h1_in_spec : (1 : ℂ) ∈ spectrum ℂ
       ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) Ê) := by
     rw [AlgEquiv.spectrum_eq]; exact hEig.mem_spectrum
@@ -125,7 +125,7 @@ theorem IsPrimitiveMPS.fixedPoint_unique
     rw [h1]
     exact @le_iSup₂ ENNReal ℂ (· ∈ spectrum ℂ _) _
       (fun k _ => (‖k‖₊ : ENNReal)) 1 h1_in_spec
-  exact absurd (lt_of_le_of_lt h1_le hP.spectral_gap) (lt_irrefl _)
+  exact absurd (lt_of_le_of_lt h1_le hP.complementary_transfer_map_gap) (lt_irrefl _)
 
 /-- **(E − P_ρ)^n → 0** as continuous linear maps.
 
@@ -138,7 +138,7 @@ theorem IsPrimitiveMPS.complement_pow_tendsto_zero
     let Ê := Φ (transferMap (d := d) (D := D) A -
       fixedPointProj (D := D) ρ hP.trace_ne_zero)
     Tendsto (fun n => Ê ^ n) atTop (nhds 0) :=
-  pow_tendsto_zero_of_spectralRadius_lt_one _ hP.spectral_gap
+  pow_tendsto_zero_of_spectralRadius_lt_one _ hP.complementary_transfer_map_gap
 
 /-! ## Part 2: Transfer map structure -/
 
@@ -210,7 +210,7 @@ What it does provide is the preparatory material reused by the later implication
 
 The key conceptual mismatch remains that our `IsPrimitiveMPS` hypothesis does
 not force `ρ.PosDef`; the standard rank-deficient `2 × 2` example still applies.
-So the paper's primitive condition is stronger than the bare spectral-gap data
+So the paper's primitive condition is stronger than the bare complementary-gap data
 formalized here.
 
 For the actual `IsPrimitiveMPS + PosDef → IsNormal` implication, see

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -437,7 +437,7 @@ a block embedding of a mixed-transfer eigenvector.
     Chapter~\ref{ch:canonical}).
 \end{remark}
 
-\begin{theorem}[Strict transfer-operator gap]\label{thm:spectral_gap}
+\begin{theorem}[Strict transfer-operator gap]\label{thm:transfer_operator_gap}
     \lean{MPSTensor.spectralRadius_mixedTransfer_lt_one}
     \leanok
     \uses{def:gauge_phase_equiv, def:injective, def:mixed_transfer}
@@ -481,7 +481,7 @@ a block embedding of a mixed-transfer eigenvector.
     Applying the same argument to $X^\dagger$ gives $D_1 \le D_2$.
 \end{proof}
 
-\begin{theorem}[Rectangular transfer-operator gap]\label{thm:spectral_gap_rect}
+\begin{theorem}[Rectangular transfer-operator gap]\label{thm:transfer_operator_gap_rect}
     \lean{MPSTensor.mixedTransferSpectralRadius₂_lt_one_of_dim_ne}
     \leanok
     \uses{def:mixed_transfer_rect, def:injective}
@@ -516,9 +516,9 @@ a block embedding of a mixed-transfer eigenvector.
     normalized, then $O_{AB}(N) \to 0$ as $N \to \infty$.
 \end{theorem}
 
-\begin{proof}\leanok\uses{thm:spectral_gap_rect, thm:overlap_trace_rect}
+\begin{proof}\leanok\uses{thm:transfer_operator_gap_rect, thm:overlap_trace_rect}
     The transfer-operator gap $\rho(F_{AB}^{\mathrm{rect}}) < 1$
-    (Theorem~\ref{thm:spectral_gap_rect}) implies
+    (Theorem~\ref{thm:transfer_operator_gap_rect}) implies
     $(F_{AB}^{\mathrm{rect}})^N \to 0$, so the operator
     trace converges to~$0$.
     By Theorem~\ref{thm:overlap_trace_rect},
@@ -538,9 +538,9 @@ a block embedding of a mixed-transfer eigenvector.
 
 \begin{proof}
     \leanok
-    \uses{thm:spectral_gap}
+    \uses{thm:transfer_operator_gap}
     The transfer-operator gap $\rho(F_{AB}) < 1$
-    (Theorem~\ref{thm:spectral_gap})
+    (Theorem~\ref{thm:transfer_operator_gap})
     implies $\|F_{AB}^n\|_{\mathrm{op}} \to 0$
     by the Gelfand formula,
     so $F_{AB}^n(X) \to 0$ for every~$X$.
@@ -648,7 +648,7 @@ the Perron--Frobenius fixed point.
 \end{proof}
 
 \begin{theorem}[Strict transfer-operator gap (irreducible-TP)]%
-    \label{thm:spectral_gap_irr_tp}
+    \label{thm:transfer_operator_gap_irr_tp}
     \lean{MPSTensor.spectralRadius_mixedTransfer_lt_one_of_irreducible_TP}
     \leanok
     \uses{def:gauge_phase_equiv, def:irreducible_tensor,
@@ -673,11 +673,11 @@ the Perron--Frobenius fixed point.
     \uses{def:mixed_transfer, def:gauge_phase_equiv,
         def:irreducible_tensor}
     Under the hypotheses of
-    Theorem~\ref{thm:spectral_gap_irr_tp},
+    Theorem~\ref{thm:transfer_operator_gap_irr_tp},
     $F_{AB}^n(X) \to 0$ for every $X \in \MN{D}$.
 \end{theorem}
 
-\begin{proof}\leanok\uses{thm:spectral_gap_irr_tp}
+\begin{proof}\leanok\uses{thm:transfer_operator_gap_irr_tp}
     By the Gelfand formula,
     $\rho(F_{AB}) < 1$ implies $\|F_{AB}^n\|_{\mathrm{op}} \to 0$.
 \end{proof}
@@ -693,15 +693,15 @@ the Perron--Frobenius fixed point.
     Then $O_{AB}(N) \to 0$ as $N \to \infty$.
 \end{theorem}
 
-\begin{proof}\leanok\uses{thm:spectral_gap_irr_tp, thm:overlap_trace}
+\begin{proof}\leanok\uses{thm:transfer_operator_gap_irr_tp, thm:overlap_trace}
     Combine the transfer-operator gap
-    (Theorem~\ref{thm:spectral_gap_irr_tp})
+    (Theorem~\ref{thm:transfer_operator_gap_irr_tp})
     with the overlap--trace identity
     (Theorem~\ref{thm:overlap_trace}).
 \end{proof}
 
 \begin{theorem}[Rectangular transfer-operator gap (irreducible-TP)]%
-    \label{thm:spectral_gap_rect_irr_tp}
+    \label{thm:transfer_operator_gap_rect_irr_tp}
     \lean{MPSTensor.mixedTransferSpectralRadius₂_lt_one_of_dim_ne_of_irreducible_TP}
     \leanok
     \uses{def:mixed_transfer_rect, def:irreducible_tensor}
@@ -733,10 +733,10 @@ the Perron--Frobenius fixed point.
     $O_{AB}(N) \to 0$ as $N \to \infty$.
 \end{theorem}
 
-\begin{proof}\leanok\uses{thm:spectral_gap_rect_irr_tp,
+\begin{proof}\leanok\uses{thm:transfer_operator_gap_rect_irr_tp,
         thm:overlap_trace_rect}
     Combine
-    Theorem~\ref{thm:spectral_gap_rect_irr_tp} with
+    Theorem~\ref{thm:transfer_operator_gap_rect_irr_tp} with
     Theorem~\ref{thm:overlap_trace_rect}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -123,7 +123,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
 \begin{remark}[Transfer-map spectral hypothesis]%
     \label{rem:spectral_hypothesis}
     \uses{thm:correlator_exponential_bound, thm:primitive_compl_lt_one,
-        thm:spectral_gap_irr_tp, thm:spectral_gap_wielandt}
+        thm:transfer_operator_gap_irr_tp, thm:transfer_map_gap_wielandt}
     The hypothesis ``$|\lambda_2| < 1$'' in
     Theorem~\ref{thm:correlator_exponential_bound} is a transfer-map gap
     condition: all non-leading eigenvalues of $\E_A$ lie strictly inside the
@@ -134,9 +134,9 @@ their spectral decomposition, and quantitative bounds on decay rates.
     (Theorem~\ref{thm:primitive_compl_lt_one}, Chapter~\ref{ch:channels}).
     The mixed-transfer gap needed for block separation is supplied for
     irreducible trace-preserving tensors
-    (Theorem~\ref{thm:spectral_gap_irr_tp}), and quantitative single-tensor
+    (Theorem~\ref{thm:transfer_operator_gap_irr_tp}), and quantitative single-tensor
     transfer-map bounds for injective tensors are recorded in
-    Theorem~\ref{thm:spectral_gap_wielandt}.
+    Theorem~\ref{thm:transfer_map_gap_wielandt}.
     Thus the analytical input needed to make
     Theorems~\ref{thm:correlator_sum_exponentials}
     and~\ref{thm:correlator_exponential_bound} unconditional is already
@@ -236,10 +236,10 @@ and rates for the single-tensor transfer map $\E_A$.
 \end{proof}
 
 \begin{theorem}[Transfer-map gap from injectivity]%
-    \label{thm:spectral_gap_wielandt}
-    \lean{MPSTensor.spectral_gap_of_injective}
+    \label{thm:transfer_map_gap_wielandt}
+    \lean{MPSTensor.transfer_map_gap_of_injective}
     \leanok
-    \uses{thm:spectral_gap}
+    \uses{thm:transfer_operator_gap}
     For an injective trace-preserving MPS tensor, there exists
     $\delta > 0$ such that every eigenvalue $\mu \neq 1$ of the
     transfer map satisfies $|\mu| \le 1 - \delta$.

--- a/docs/paper-gaps/quantum_wielandt_deviation.tex
+++ b/docs/paper-gaps/quantum_wielandt_deviation.tex
@@ -141,7 +141,7 @@ The theorem
 \leanid{MPSTensor.isNormal_of_isPrimitiveMPS_with_posDef}\footnote{%
     \path{TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean}.}
 proves normality from a chosen fixed point $\rho$ satisfying the local
-spectral-gap predicate \leanid{IsPrimitiveMPS} and the additional hypothesis
+complementary transfer-map gap predicate \leanid{IsPrimitiveMPS} and the additional hypothesis
 $\rho>0$.
 
 This is the formal argument for Proposition~3(c)$\Rightarrow$(b) of


### PR DESCRIPTION
### Motivation

- Blueprint terminology introduced in #2166 distinguishes transfer-operator gap ($\rho(F_{AB}) < 1$), transfer-map gap ($\rho(\mathcal{E}_A - P) < 1$), and complementary transfer-map gap from the Hamiltonian spectral gap (Chapter 14). Lean declaration names were left unchanged by that PR; this PR closes the resulting inconsistency (noted in #2152).
- Declaration names (`spectral_gap_of_injective`, `IsPrimitiveMPS.spectral_gap`, `SpectralGap*.lean` modules) used "spectral gap" in the transfer-operator sense, conflicting with the blueprint labels `thm:spectral_gap_wielandt`, `thm:spectral_gap`, and `thm:spectral_gap_irr_tp` in `blueprint/src/chapter/ch06_spectral.tex`.

### Description

- Renamed module files:
  - `Spectral/SpectralGap.lean` → `Spectral/TransferOperatorGap.lean`
  - `Spectral/SpectralGapRect.lean` → `Spectral/TransferOperatorGapRect.lean`
  - `Spectral/SpectralGapNT.lean` → `Spectral/TransferOperatorGapNT.lean`
  - `MPS/Overlap/PeripheralToSpectralGap.lean` → `MPS/Overlap/PeripheralToTransferMapGap.lean`
- Renamed declarations with `@[deprecated … (since := "2026-05-30")]` aliases preserving backward compatibility:
  - `IsPrimitiveMPS.spectral_gap` → `IsPrimitiveMPS.complementary_transfer_map_gap`
  - `spectral_gap_of_injective` → `transfer_map_gap_of_injective`
  - `uniform_spectral_gap_of_finite_lt_one` → `uniform_eigenvalue_gap_of_finite_lt_one`
- Updated imports across `Channel/`, `MPS/`, `Wielandt/`, and root `TNLean.lean`.
- Updated blueprint `\lean{...}` tags in `ch06_spectral.tex` and `ch15_correlations.tex`.
- Updated `docs/paper-gaps/quantum_wielandt_deviation.tex` to use new theorem names.
- Hamiltonian spectral-gap declarations (`FrustrationFree.spectralGap_of_martingale`, `parentHamiltonian_gapped`, and related items in `MPS/ParentHamiltonian/`) are intentionally untouched.

### Testing

- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main`
- `git diff --cached --check`
- Proof-integrity diff scan for new `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast` (none introduced).
- `leanblueprint checkdecls` run after build; pre-existing failures on PEPS, parent-Hamiltonian, and BNT declarations are unrelated to this PR.

---
Closes #2169

> [!NOTE]
> **Low Risk**
> Mechanical rename plus deprecated aliases; no proof or Hamiltonian-gap logic changes, so risk is mainly import-path churn for downstream consumers.
>
> **Overview**
> This PR standardizes **transfer-operator / transfer-map gap** wording for MPS and channel results that are **not** Hamiltonian spectral gaps. The main `TNLean.Spectral.SpectralGap*` modules and `MPS.Overlap.PeripheralToSpectralGap` are renamed to `TransferOperatorGap`, `TransferOperatorGapRect`, `TransferOperatorGapNT`, and `PeripheralToTransferMapGap`, with matching import and docstring updates across channel, MPS, Wielandt, and root `TNLean.lean`.
>
> The primitive MPS witness field **`IsPrimitiveMPS.spectral_gap`** becomes **`complementary_transfer_map_gap`**; related theorems and uniform-gap helpers are renamed (e.g. **`spectral_gap_of_injective`** → **`transfer_map_gap_of_injective`**, **`uniform_spectral_gap_of_finite_lt_one`** → **`uniform_eigenvalue_gap_of_finite_lt_one`**). **`@[deprecated … (since := "2026-05-30")]`** aliases keep old Lean names working.
>
> Blueprint labels in `ch06_spectral.tex` and `ch15_correlations.tex` and the Wielandt deviation note are updated to the new theorem/label names; Hamiltonian gap material is explicitly out of scope.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eefc0cac2e0ef82d607aed12239f7c592fe9454d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical renames and doc/blueprint tag updates with deprecated aliases; no Mathlib proof or Hamiltonian-gap logic changes.
> 
> **Overview**
> This PR aligns Lean and blueprint wording with the transfer-map / transfer-operator gap vocabulary from blueprint #2166, so **“spectral gap”** is reserved for Hamiltonian material and not used for mixed-transfer or `E − P` bounds.
> 
> **Lean:** `TNLean.Spectral.SpectralGap*` and `MPS.Overlap.PeripheralToSpectralGap` are renamed to **`TransferOperatorGap`**, **`TransferOperatorGapRect`**, **`TransferOperatorGapNT`**, and **`PeripheralToTransferMapGap`**, with imports updated across `Channel/`, `MPS/`, `Wielandt/`, and root **`TNLean.lean`**. **`IsPrimitiveMPS.spectral_gap`** becomes **`complementary_transfer_map_gap`**; **`spectral_gap_of_injective`** → **`transfer_map_gap_of_injective`**; **`uniform_spectral_gap_of_finite_lt_one`** → **`uniform_eigenvalue_gap_of_finite_lt_one`**. Docstrings and section names (e.g. **`ComplementaryTransferMapGap`**, **`ComplementaryDecomposition`**) follow the same terminology. **`@[deprecated … (since := "2026-05-30")]`** aliases keep old names; proofs are unchanged.
> 
> **Docs:** Blueprint `\label`/`\lean` tags in **`ch06_spectral.tex`** and **`ch15_correlations.tex`** and **`quantum_wielandt_deviation.tex`** use the new theorem names. Parent-Hamiltonian spectral-gap code is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe49010184d8a431331f9065d9d0dd371fa52061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->