### PR TITLE
fix(MPS/CanonicalForm): restate primitive reduction in SameMPV₂Pos form

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean
@@ -60,11 +60,11 @@ The full proof chain is:
 
 The after-blocking primitive block decomposition provides:
 - A blocking period `p > 0`
-- A trivial all-zero block of dimension `zeroTailDim`, representing the CPSV
-  allowance `∑ k, D_k ≤ D` where zero blocks may occur
 - A family of TP sector blocks
-- The MPV relationship: `blockTensor A p` is `SameMPV₂`-equivalent to
-  `zeroMPSTensor + toTensorFromBlocks μ sectors` for some weights `μ`
+- The positive-length MPV relationship: `blockTensor A p` is `SameMPV₂Pos`-equivalent to
+  `toTensorFromBlocks μ sectors` for some weights `μ`
+- A separate zero-block bond-dimension count, representing the CPSV allowance
+  `∑ k, D_k ≤ D` where zero blocks may occur
 
 The current library already settles the common-period blocking arithmetic and
 now has a one-sided phase-class BNT construction for TP primitive irreducible
@@ -211,17 +211,19 @@ theorem afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂
         (toTensorFromBlocks (d := blockPhysDim d pA) (μ := μA) blocksA) ∧
       SameMPV₂Pos (blockTensor (d := d) (D := D₂) B pB)
         (toTensorFromBlocks (d := blockPhysDim d pB) (μ := μB) blocksB) := by
-  obtain ⟨zeroTailA, pA, hpA, rA, dimA, μA, blocksA, hTPA, hPrimA, hDimA, hμA, hMPVA⟩ :=
+  obtain ⟨_zeroTailA, pA, hpA, rA, dimA, μA, blocksA,
+      hTPA, hPrimA, hDimA, hμA, hMPVA, _hBondA⟩ :=
     exists_tp_primitive_blockDecomp_after_blocking A
-  obtain ⟨zeroTailB, pB, hpB, rB, dimB, μB, blocksB, hTPB, hPrimB, hDimB, hμB, hMPVB⟩ :=
+  obtain ⟨_zeroTailB, pB, hpB, rB, dimB, μB, blocksB,
+      hTPB, hPrimB, hDimB, hμB, hMPVB, _hBondB⟩ :=
     exists_tp_primitive_blockDecomp_after_blocking B
   refine ⟨pA, hpA, rA, dimA, μA, blocksA,
     pB, hpB, rB, dimB, μB, blocksB,
     ?_, ?_, hTPA, hTPB, hPrimA, hPrimB, hμA, hμB, hDimA, hDimB, ?_, ?_⟩
   · exact sameMPV₂_blockTensor A B hSame pA
   · exact sameMPV₂_blockTensor A B hSame pB
-  · exact sameMPV₂Pos_of_zeroTail_eq _ _ hMPVA
-  · exact sameMPV₂Pos_of_zeroTail_eq _ _ hMPVB
+  · exact hMPVA
+  · exact hMPVB
 
 
 end FundamentalTheoremAfterBlocking

--- a/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
@@ -41,7 +41,8 @@ primitive block decomposition.
 ## Main statements
 
 * `exists_tp_primitive_blockDecomp_after_blocking` — arbitrary tensors admit a
-  blocked decomposition into a zero tail and TP-primitive blocks.
+  positive-length blocked decomposition into TP-primitive blocks, together with
+  the separate zero-block bond-dimension count.
 * `isNormalCanonicalForm_of_tp_primitive_irr_sorted` — a blocked TP-primitive
   family with irreducible blocks and non-increasing weights is already in
   normal canonical form.
@@ -115,21 +116,14 @@ a decomposition:
   - positive bond dimension;
   - nonzero weight `μ k`.
 
-The MPV relationship holds:
+The MPV relationship holds at every positive blocked length:
 ```
-  mpv (blockTensor A p) σ = mpv (zeroMPSTensor (blockPhysDim d p) zeroTailDim) σ
-    + mpv (toTensorFromBlocks μ blocks) σ
+  mpv (blockTensor A p) σ = mpv (toTensorFromBlocks μ blocks) σ
 ```
 
-In particular, for system sizes `N > 0`, the trivial block vanishes and
-`blockTensor A p` has the same MPVs as `toTensorFromBlocks μ blocks`.
-
-**Note on the length-zero term**: this statement keeps the explicit zero block
-to match the cited Section 2.3 decomposition, even though only the positive-length
-comparison carries mathematical content and the empty-word coefficient is just
-the bond-dimension count `zeroTailDim + ∑ dim = D ^ p`. The downstream consumer
-converts to the positive-length form at once. The reason the all-length shape is
-kept here, and the positive-length replacement, are described in
+The zero block appears only through the length-zero bond-dimension identity
+`zeroTailDim + ∑ dim = D`. This separates the source's positive-length
+comparison from the empty-word dimension count, as described in
 `docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`.
 
 **Note on the original blocks**: The pre-blocking blocks (from step 2) ARE
@@ -149,14 +143,16 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
       (∀ k, 0 < dim k) ∧
       -- (d) Nonzero weights
       (∀ k, μ k ≠ 0) ∧
-      -- (e) MPV relationship
-      (∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-        mpv (blockTensor (d := d) (D := D) A p) σ =
-          mpv (zeroMPSTensor (blockPhysDim d p) zeroTailDim) σ +
-            mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μ) blocks) σ) := by
+      -- (e) Positive-length MPV relationship
+      SameMPV₂Pos
+        (blockTensor (d := d) (D := D) A p)
+        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μ) blocks) ∧
+      -- (f) Length-zero bond-dimension count
+      zeroTailDim + ∑ k : Fin r, dim k = D := by
   classical
   -- Step A: Get TP-gauged irreducible blocks from an arbitrary tensor.
-  obtain ⟨zeroTailDim, r₀, dim₀, μ₀, blocks₀, hIrr₀, hTP₀, hμNe₀, hDim₀, hMPV₀⟩ :=
+  obtain ⟨zeroTailDim, r₀, dim₀, μ₀, blocks₀,
+      hIrr₀, hTP₀, hμNe₀, hDim₀, hMPV₀⟩ :=
     exists_tp_gauge_from_arbitrary_with_zeroTail (d := d) (D := D) A
   -- Step B: Find a common blocking period making all transfer maps primitive.
   obtain ⟨P, hP, hPrim⟩ :=
@@ -166,7 +162,7 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
     fun k => blockTensor (d := d) (D := dim₀ k) (blocks₀ k) P with blocks₁_def
   set μ₁ : Fin r₀ → ℂ := fun k => (μ₀ k) ^ P with μ₁_def
   -- Step D: Verify all properties.
-  refine ⟨zeroTailDim, P, hP, r₀, dim₀, μ₁, blocks₁, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨zeroTailDim, P, hP, r₀, dim₀, μ₁, blocks₁, ?_, ?_, ?_, ?_, ?_, ?_⟩
   -- (a) TP under blocking.
   · intro k
     exact leftCanonical_blockTensor (d := d) (D := dim₀ k) (A := blocks₀ k) (L := P) (hTP₀ k)
@@ -176,11 +172,17 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
   · exact hDim₀
   -- (d) Nonzero weights: `(μ₀ k)^P` remains nonzero since `μ₀ k ≠ 0`.
   · exact blockWeights_ne_zero μ₀ hμNe₀ P
-  -- (e) MPV relationship.
-  · simpa [μ₁_def, blocks₁_def] using
-      zeroTail_toTensorFromBlocks_blockPower
-        (d := d) (D := D) (r := r₀) (z := zeroTailDim) (p := P) (dim := dim₀)
-        A μ₀ blocks₀ hP hMPV₀
+  -- (e) Positive-length MPV relationship.
+  · have hPos₀ : SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μ₀) blocks₀) :=
+      sameMPV₂Pos_of_zeroTail_eq A
+        (toTensorFromBlocks (d := d) (μ := μ₀) blocks₀) hMPV₀
+    simpa [μ₁_def, blocks₁_def] using
+      sameMPV₂Pos_blockTensor_toTensorFromBlocks
+        (d := d) (D := D) (r := r₀) (dim := dim₀)
+        A μ₀ blocks₀ hPos₀ P hP
+  -- (f) Length-zero bond-dimension count.
+  · exact zeroTail_bondDim_eq_of_mpv_decomp A
+      (toTensorFromBlocks (d := d) (μ := μ₀) blocks₀) hMPV₀
 
 /-!
 ## Conditional normal canonical form

--- a/TNLean/MPS/CanonicalForm/SectorComparison/ZeroTailTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/ZeroTailTransport.lean
@@ -66,13 +66,15 @@ theorem sameMPV₂Pos_of_zeroTail_eq
     _ = mpv live σ := by
       rw [hZero, zero_add]
 
-/-- The length-zero coefficient of a zero-tail decomposition is the bond-dimension identity. -/
+/-- The length-zero coefficient of a zero-tail decomposition is the bond-dimension identity.
+
+At the empty word, the MPV coefficient is the trace of the identity on the
+corresponding bond space. -/
 theorem zeroTail_bondDim_eq_of_mpv_decomp
     {d D L z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
     (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),
       mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ) :
     z + L = D := by
-  classical
   let σ0 : Fin 0 → Fin d := Fin.elim0
   have hCoeff : (D : ℂ) = (z + L : ℕ) := by
     calc

--- a/TNLean/MPS/CanonicalForm/SectorComparison/ZeroTailTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/ZeroTailTransport.lean
@@ -51,41 +51,6 @@ theorem zeroTail_mpv_decomp_blockTensor
   congr 1
   exact (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) nonzeroPart p σ).symm
 
-/-- Reblocking a zero-tail plus weighted nonzero-block decomposition transports every
-nonzero-block weight to the corresponding blocking power. -/
-theorem zeroTail_toTensorFromBlocks_blockPower
-    {d D r z p : ℕ} {dim : Fin r → ℕ}
-    (A : MPSTensor d D)
-    (μ : Fin r → ℂ)
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (hp : 0 < p)
-    (hMPV : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ = mpv (zeroMPSTensor d z) σ +
-        mpv (toTensorFromBlocks (d := d) (μ := μ) blocks) σ) :
-    ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d p)),
-      mpv (blockTensor (d := d) (D := D) A p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (fun k => (μ k) ^ p)
-            (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) σ := by
-  intro N σ
-  have hBlock :=
-    zeroTail_mpv_decomp_blockTensor
-      (d := d) (D := D) (L := ∑ k : Fin r, dim k) (z := z) (p := p)
-      A (toTensorFromBlocks (d := d) (μ := μ) blocks) hp hMPV N σ
-  have hNonzeroPart := sameMPV₂_blockTensor_toTensorFromBlocks
-    (d := d) (dim := dim) μ blocks p
-  calc
-    mpv (blockTensor (d := d) (D := D) A p) σ =
-        mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
-          mpv (blockTensor (d := d) (D := ∑ k : Fin r, dim k)
-            (toTensorFromBlocks (d := d) (μ := μ) blocks) p) σ := hBlock
-    _ = mpv (zeroMPSTensor (blockPhysDim d p) z) σ +
-          mpv (toTensorFromBlocks (d := blockPhysDim d p)
-            (fun k => (μ k) ^ p)
-            (fun k => blockTensor (d := d) (D := dim k) (blocks k) p)) σ := by
-          rw [hNonzeroPart N σ]
-
 /-- At positive lengths, a zero-tail decomposition reduces to the nonzero part. -/
 theorem sameMPV₂Pos_of_zeroTail_eq
     {d D L z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
@@ -100,6 +65,22 @@ theorem sameMPV₂Pos_of_zeroTail_eq
     mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ := hZeroTail N σ
     _ = mpv live σ := by
       rw [hZero, zero_add]
+
+/-- The length-zero coefficient of a zero-tail decomposition is the bond-dimension identity. -/
+theorem zeroTail_bondDim_eq_of_mpv_decomp
+    {d D L z : ℕ} (A : MPSTensor d D) (live : MPSTensor d L)
+    (hZeroTail : ∀ (N : ℕ) (σ : Fin N → Fin d),
+      mpv A σ = mpv (zeroMPSTensor d z) σ + mpv live σ) :
+    z + L = D := by
+  classical
+  let σ0 : Fin 0 → Fin d := Fin.elim0
+  have hCoeff : (D : ℂ) = (z + L : ℕ) := by
+    calc
+      (D : ℂ) = mpv A σ0 := (mpv_zero_length A σ0).symm
+      _ = mpv (zeroMPSTensor d z) σ0 + mpv live σ0 := hZeroTail 0 σ0
+      _ = (z : ℂ) + (L : ℂ) := by simp
+      _ = (z + L : ℕ) := by simp
+  exact_mod_cast hCoeff.symm
 
 /-- Remove matching zero tails from two MPV identities.
 

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -273,9 +273,9 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     \label{rem:ft_after_blocking_structural}
     Applying Theorem~\ref{thm:tp_primitive_blockdecomp} to each of two
     same-MPV tensors $A$ and $B$ produces, after a positive blocking length,
-    a zero-tail tensor plus a left-canonical primitive nonzero block
-    decomposition for each side. This is a preliminary step in the chain
-    leading to
+    a left-canonical primitive nonzero block decomposition for each side,
+    together with the separate zero-block bond-dimension count. This is a
+    preliminary step in the chain leading to
     Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem},
     where the two sides are matched.
 \end{remark}
@@ -311,38 +311,6 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     unchanged by the reblocking convention.
 \end{proof}
 
-\begin{theorem}[Zero-tail weighted block decomposition after blocking]%
-    \label{thm:zero_tail_to_tensor_from_blocks_block_power}
-    \lean{MPSTensor.zeroTail_toTensorFromBlocks_blockPower}
-    \leanok
-    \uses{thm:zero_tail_decomp_block_tensor, thm:block_tensor_to_tensor_from_blocks,
-        def:block_diagonal_tensor}
-    Suppose that, for every length $N$ and every configuration $\sigma$,
-    \[
-        V^{(N)}(A)_\sigma
-        =
-        V^{(N)}(\mathbf{0}_{d,z})_\sigma
-        +
-        V^{(N)}\!(\textstyle\bigoplus_{k=1}^r \mu_k B_k)_\sigma.
-    \]
-    For every $p>0$, the blocked tensor satisfies, for every blocked
-    configuration $\tau$ of length $N$,
-    \[
-        V^{(N)}\!(A^{[p]})_\tau
-        =
-        V^{(N)}\!(\mathbf{0}_{d^{[p]},z})_\tau
-        +
-        V^{(N)}\!\bigl(\textstyle\bigoplus_{k=1}^r
-        \mu_k^{\,p} B_k^{[p]}\bigr)_\tau.
-    \]
-\end{theorem}
-
-\begin{proof}\leanok
-    Apply Theorem~\ref{thm:zero_tail_decomp_block_tensor} to the assembled
-    weighted nonzero tensor and rewrite the blocked assembled tensor using
-    Theorem~\ref{thm:block_tensor_to_tensor_from_blocks}.
-\end{proof}
-
 \begin{lemma}[One-sided zero-tail cancellation at positive length]%
     \label{thm:same_mpv2_pos_of_zero_tail_eq}
     \lean{MPSTensor.sameMPV₂Pos_of_zeroTail_eq}
@@ -371,6 +339,31 @@ a single tensor $\mathbf{0}_{d,D_0}$.
     \]
     Substituting this identity in the displayed zero-tail decomposition gives the
     positive-length equality.
+\end{proof}
+
+\begin{lemma}[Length-zero zero-tail bond-dimension identity]%
+    \label{thm:zero_tail_bond_dim_eq_of_mpv_decomp}
+    \lean{MPSTensor.zeroTail_bondDim_eq_of_mpv_decomp}
+    \leanok
+    \uses{def:zero_mps_tensor}
+    Suppose a tensor $A$ of bond dimension $D$ is written, for every length
+    $N$ and configuration $\sigma$, as
+    \[
+        V^{(N)}(A)_\sigma
+        =
+        V^{(N)}(\mathbf{0}_{d,z})_\sigma
+        +
+        V^{(N)}(L)_\sigma,
+    \]
+    where $L$ has bond dimension $D_L$. Then
+    \[
+        z + D_L = D.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Evaluate the identity at the empty word. The MPV coefficient at length zero
+    is the trace of the identity on the corresponding bond space.
 \end{proof}
 
 \begin{theorem}[Positive-length equality of nonzero block tensors]%
@@ -637,15 +630,19 @@ blocking.
     \label{thm:tp_primitive_blockdecomp}
     \lean{MPSTensor.exists_tp_primitive_blockDecomp_after_blocking}
     \leanok
-    \uses{def:blocked_tensor, def:zero_mps_tensor}
+    \uses{def:blocked_tensor, def:same_mpv2_pos}
     For any MPS tensor $A$, there exist $p\ge 1$, a zero-tail bond dimension
     $D_0$, nonzero weights $(\mu_k)_{k=1}^r$, and blocks $(B_k)_{k=1}^r$ such
-    that, for every blocked configuration $\sigma$ of length $N$,
+    that, for every blocked configuration $\sigma$ of positive length $N$,
     \[
         V^{(N)}\!(A^{[p]})_\sigma
-        = V^{(N)}\!(\mathbf{0}_{d^{[p]},D_0})_\sigma
-        + V^{(N)}\!\bigl(\textstyle\bigoplus_{k=1}^{r}
+        = V^{(N)}\!\bigl(\textstyle\bigoplus_{k=1}^{r}
         \mu_k B_k\bigr)_\sigma.
+    \]
+    The zero-block contribution is recorded separately by the length-zero
+    identity
+    \[
+        D_0 + \sum_{k=1}^{r} D_k = D.
     \]
     Each block is left-canonical and primitive,
     \[
@@ -658,14 +655,18 @@ blocking.
 
 \begin{proof}\leanok
     \uses{thm:tp_gauge_arbitrary, thm:common_blocking_period,
-        lem:block_weights_ne_zero, thm:zero_tail_to_tensor_from_blocks_block_power}
+        lem:block_weights_ne_zero, thm:same_mpv2_pos_of_zero_tail_eq,
+        thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks,
+        thm:zero_tail_bond_dim_eq_of_mpv_decomp}
     Apply Theorem~\ref{thm:tp_gauge_arbitrary} to get the trivial block
     and left-canonical nontrivial blocks.
     Apply Theorem~\ref{thm:common_blocking_period} to find a common
     blocking period $p$ making all transfer maps primitive. Lemma~\ref{lem:block_weights_ne_zero}
-    keeps the blocked weights nonzero, and
-    Theorem~\ref{thm:zero_tail_to_tensor_from_blocks_block_power} transports the
-    zero-tail/nonzero MPV identity through the blocking step.
+    keeps the blocked weights nonzero. Theorem~\ref{thm:same_mpv2_pos_of_zero_tail_eq}
+    removes the all-zero summand at positive length, and
+    Theorem~\ref{thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks} transports the
+    resulting positive-length equality through the blocking step. The
+    length-zero identity is Theorem~\ref{thm:zero_tail_bond_dim_eq_of_mpv_decomp}.
 \end{proof}
 
 \begin{theorem}[Two tensors after one-sided primitive reductions]%

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -662,11 +662,11 @@ blocking.
     and left-canonical nontrivial blocks.
     Apply Theorem~\ref{thm:common_blocking_period} to find a common
     blocking period $p$ making all transfer maps primitive. Lemma~\ref{lem:block_weights_ne_zero}
-    keeps the blocked weights nonzero. Theorem~\ref{thm:same_mpv2_pos_of_zero_tail_eq}
+    keeps the blocked weights nonzero. Lemma~\ref{thm:same_mpv2_pos_of_zero_tail_eq}
     removes the all-zero summand at positive length, and
-    Theorem~\ref{thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks} transports the
+    Lemma~\ref{thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks} transports the
     resulting positive-length equality through the blocking step. The
-    length-zero identity is Theorem~\ref{thm:zero_tail_bond_dim_eq_of_mpv_decomp}.
+    length-zero identity is Lemma~\ref{thm:zero_tail_bond_dim_eq_of_mpv_decomp}.
 \end{proof}
 
 \begin{theorem}[Two tensors after one-sided primitive reductions]%

--- a/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
@@ -47,8 +47,7 @@ block and a weighted family of normal blocks,
 where $\mathbf 0_{z}$ is the zero tensor on a bond space of dimension~$z$,
 the $B_k$ are normal (primitive, trace-preserving, irreducible) blocks of
 bond dimension $D_k$, the weights satisfy $\mu_k\neq 0$, and
-$z+\sum_k D_k = D$ is the bond dimension of $A^{[p]}$ in the formal blocking
-convention.
+$z+\sum_k D_k = D$ is the bond dimension of $A^{[p]}$.
 
 \section{The point at issue}
 

--- a/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
@@ -47,7 +47,8 @@ block and a weighted family of normal blocks,
 where $\mathbf 0_{z}$ is the zero tensor on a bond space of dimension~$z$,
 the $B_k$ are normal (primitive, trace-preserving, irreducible) blocks of
 bond dimension $D_k$, the weights satisfy $\mu_k\neq 0$, and
-$z+\sum_k D_k = D^{\,p}$ is the bond dimension of $A^{[p]}$.
+$z+\sum_k D_k = D$ is the bond dimension of $A^{[p]}$ in the formal blocking
+convention.
 
 \section{The point at issue}
 
@@ -71,7 +72,7 @@ bond space,
 Hence the \emph{entire} content of the length-zero instance
 of~\eqref{eq:all-length} is the dimension count
 \begin{align}
-  z + \sum_k D_k = D^{\,p},\label{eq:dim}
+  z + \sum_k D_k = D,\label{eq:dim}
 \end{align}
 which is already part of~\eqref{eq:zero-block}. Every length $N\ge 1$ carries
 the genuine mathematical content: the weighted normal-block comparison
@@ -117,49 +118,26 @@ This is the source-faithful shape: the nonzero normal blocks are compared at
 positive length, and the zero block appears only as the scalar~$z$
 in~\eqref{eq:dim}.
 
-\section{The remaining formal boundary}
+\section{Formal status}
 
-One theorem still states the reduction in the all-length form
-of~\eqref{eq:all-length}: the single-tensor after-blocking decomposition
-that produces~\eqref{eq:zero-block} with its explicit zero block.\footnote{%
-  \leanid{exists_tp_primitive_blockDecomp_after_blocking}, blueprint
-  \path{thm:tp_primitive_blockdecomp} in
-  \path{blueprint/src/chapter/ch11b_after_blocking.tex}; its support lemma is
-  \leanid{zeroTail_toTensorFromBlocks_blockPower}.}
-It is kept in that form for two reasons. First, the explicit zero block is the
-literal content of \cite[Section~2.3]{Cirac2016MPDO_arXiv} and is named as the
-``zero-tail term'' in the surrounding blueprint exposition, so the displayed
-statement should still exhibit it. Second, its only consumer already converts
-to the positive-length form~\eqref{eq:pos} at the correct boundary, so no
-downstream lemma carries the empty-word instance any further.
-
-The source-faithful simplification, if pursued, is to replace the all-length
-clause of that theorem by the positive-length comparison~\eqref{eq:pos}
-against the blocked normal blocks, using the elementary fact that blocking
-preserves a positive-length identity,\footnote{%
-  The missing one-line lemma is
-  \(\leanid{SameMPV₂Pos}\,A\,B \Rightarrow
-  \leanid{SameMPV₂Pos}\,(A^{[p]})\,(B^{[p]})\) for $p\ge 1$, from
-  $N\ge 1\wedge p\ge 1 \Rightarrow Np\ge 1$. With it, clause~(e) of the
-  theorem becomes a \leanid{SameMPV₂Pos} statement and the support lemma
-  \leanid{zeroTail_toTensorFromBlocks_blockPower} is no longer needed.}
-together with the dimension identity~\eqref{eq:dim}. This change is deferred
-because it edits the zero-tail exposition in two blueprint chapters; it is a
-prose and statement reshaping, not new mathematics.
+\leanid{exists_tp_primitive_blockDecomp_after_blocking}, blueprint
+\path{thm:tp_primitive_blockdecomp} in
+\path{blueprint/src/chapter/ch11b_after_blocking.tex}, now uses the
+source-faithful shape: its MPV clause is the positive-length comparison
+in~\eqref{eq:pos}, and the empty-word contribution is the separate identity
+\(z+\sum_k D_k=D\).  The former support lemma
+\leanid{zeroTail_toTensorFromBlocks_blockPower} has therefore been removed.
 
 \section{Conclusion}
 
 The blocked canonical form~\eqref{eq:zero-block} is correct, and the dimension
-count~\eqref{eq:dim} is part of it. The defect is one of formal shape: stating
-the reduction as the all-length matrix-product-vector
-identity~\eqref{eq:all-length} fuses a trivial empty-word dimension count with
-the substantive positive-length comparison and forces the two through the whole
-after-blocking chain together, against the article, which keeps the zero block
-only as a bond-dimension term. The faithful statement is the positive-length
-comparison~\eqref{eq:pos} with the length-zero coefficient restored once
-from~\eqref{eq:dim}. The development now uses this shape everywhere except the
-single headline decomposition theorem, where the explicit zero block is kept to
-match the cited exposition.
+count~\eqref{eq:dim} is part of it. The former formal defect was one of shape:
+stating the reduction as the all-length matrix-product-vector
+identity~\eqref{eq:all-length} fused a trivial empty-word dimension count with
+the substantive positive-length comparison. The faithful statement is the
+positive-length comparison~\eqref{eq:pos} with the length-zero coefficient
+restored once from~\eqref{eq:dim}. The development now uses this shape in the
+after-blocking primitive decomposition and its downstream consumers.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation
- `exists_tp_primitive_blockDecomp_after_blocking` stated the decomposition using an all-length `SameMPV₂` form with an explicit zero-block coefficient, deviating from arXiv:1606.00608 §2.3, which presents the decomposition as a direct `SameMPV₂Pos` comparison on positive-length MPVs with a separate bond-dimension identity.
- The bond-dimension identity `zeroTailDim + ∑ k, dim k = D ^ p` is a dimension count, not substantive decomposition content; conflating it with the MPV comparison obscures the mathematical structure.
- `zeroTail_toTensorFromBlocks_blockPower` existed solely to support the all-length form; restating the theorem makes it dead code. See #2170 and `docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`.

### Description
- **`TPPrimitiveReduction.lean`**: Restates `exists_tp_primitive_blockDecomp_after_blocking` with conclusion `SameMPV₂Pos (blockTensor A p) (toTensorFromBlocks μ blocks)` and separate identity `zeroTailDim + ∑ k, dim k = D ^ p`, replacing the all-length zero-direct-sum form.
- **`ZeroTailTransport.lean`**: Removes the now-dead lemma `zeroTail_toTensorFromBlocks_blockPower`.
- **`StructuralData.lean`**: Updates `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂` to pass through the `SameMPV₂Pos` fields directly from the restated theorem.
- **`ch11b_after_blocking.tex`**: Blueprint entry `thm:tp_primitive_blockdecomp` updated to reflect the `SameMPV₂Pos` conclusion.
- **`docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`**: Paper-gap note updated to reflect the source-faithful split (positive-length comparison vs. length-zero bond count).

### Testing
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.ZeroTailTransport TNLean.MPS.CanonicalForm.SectorComparison.TPPrimitiveReduction TNLean.MPS.CanonicalForm.SectorComparison.StructuralData`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/StructuralData.lean TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean TNLean/MPS/CanonicalForm/SectorComparison/ZeroTailTransport.lean blueprint/src/chapter/ch11b_after_blocking.tex docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`
- `leanblueprint checkdecls`: pre-existing failures on PEPS, parent-Hamiltonian, and BNT declarations are unrelated to this PR.

---
Closes #2170

> [!NOTE]
> **Low Risk**
> Formal and documentation reshaping of existing MPS canonical-form lemmas; no auth, runtime, or external API surface.
>
> **Overview**
> Restates the after-blocking primitive decomposition so **positive-length** MPV comparison uses `SameMPV₂Pos` against the weighted block sum, while the all-zero tail is recorded only by **`zeroTailDim + ∑ dim = D`**.
>
> **Lean:** `exists_tp_primitive_blockDecomp_after_blocking` drops the all-length MPV identity in favor of those two clauses; proof uses `sameMPV₂Pos_of_zeroTail_eq`, `sameMPV₂Pos_blockTensor_toTensorFromBlocks`, and new `zeroTail_bondDim_eq_of_mpv_decomp`. Removes `zeroTail_toTensorFromBlocks_blockPower`. `afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂` passes through the decomposition's `SameMPV₂Pos` fields directly.
>
> **Docs:** Blueprint chapter `ch11b_after_blocking` and `cpsv16_zero_tail_length_zero_decomposition.tex` align with the source-faithful split (positive-length comparison vs length-zero bond count).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e821ca443ed3441d6929d0d519fb308c2271f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal and documentation reshaping of existing canonical-form lemmas; no runtime, auth, or external APIs.
> 
> **Overview**
> Restates the after-blocking **primitive block decomposition** so substantive content is a **positive-length** `SameMPV₂Pos` match between `blockTensor A p` and the weighted block sum, while the all-zero tail is recorded only by **`zeroTailDim + ∑ dim = D`**.
> 
> **Lean:** `exists_tp_primitive_blockDecomp_after_blocking` drops the all-length MPV identity; proof chains `sameMPV₂Pos_of_zeroTail_eq`, `sameMPV₂Pos_blockTensor_toTensorFromBlocks`, and new **`zeroTail_bondDim_eq_of_mpv_decomp`**. Removes dead **`zeroTail_toTensorFromBlocks_blockPower`**. **`afterBlocking_tpPrimitiveBlockDecompositions_of_sameMPV₂`** forwards the decomposition’s `SameMPV₂Pos` fields directly.
> 
> **Docs:** Blueprint `ch11b_after_blocking` and `cpsv16_zero_tail_length_zero_decomposition.tex` align with CPSV §2.3 (positive-length comparison vs length-zero bond count).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75f964729558aa29890e27a1b19cb04bfa32a45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->