### PR TITLE
ci(actions): bump default Claude Opus model to 4.8

### DIFF
--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -224,7 +224,7 @@ runs:
 
           model_opus="$INPUT_CLAUDE_OPUS_MODEL"
           if [ -z "$model_opus" ]; then
-            model_opus="${CLAUDE_OPUS_MODEL:-claude-opus-4-7}"
+            model_opus="${CLAUDE_OPUS_MODEL:-claude-opus-4-8}"
           fi
 
           model_sonnet="$INPUT_CLAUDE_SONNET_MODEL"

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -716,7 +716,7 @@ label name, update `.github/workflows/auto-fix.yml` and the
 
 ### Model
 
-Anthropic Claude workflows use `claude-opus-4-7`, configured via `--model` in
+Anthropic Claude workflows use `claude-opus-4-8`, configured via `--model` in
 the `claude_args` parameter of the relevant workflow file. DeepSeek mention and
 review runs use the same wrapper in `deepseek` provider mode and select
 `deepseek-v4-pro[1m]` by default unless the repository variables override it.


### PR DESCRIPTION
### Motivation

- The composite action `claude-code-with-provider` used `claude-opus-4-7` as the hardcoded fallback default for the Opus model. Bumping the fallback to `claude-opus-4-8` ensures workflows that do not supply an explicit `claude-opus-model` input or `CLAUDE_OPUS_MODEL` repository variable use the latest available Opus release.

### Description

- `.github/actions/claude-code-with-provider/action.yml`: updates the hardcoded fallback string from `claude-opus-4-7` to `claude-opus-4-8` in the provider-resolution script. Workflows that explicitly set `claude-opus-model` input or the `CLAUDE_OPUS_MODEL` repository variable are unaffected.
- `docs/ci-automation.md`: aligns the **Model** section to document `claude-opus-4-8` as the current default. Sonnet defaults and DeepSeek paths are unchanged.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build. No Lean files are modified; no proof-level testing required.

---

<!-- No linked issue identified for this automated model-bump. -->

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Default-only model string change with existing overrides via inputs and repo variables; no auth or application logic changes.
>
> **Overview**
> Updates the **default Anthropic Opus model** for CI automation from `claude-opus-4-7` to **`claude-opus-4-8`** when workflows use `.github/actions/claude-code-with-provider` without an explicit `claude-opus-model` input or `CLAUDE_OPUS_MODEL` repo variable.
>
> The fallback is set in the composite action's provider-resolution script; **`docs/ci-automation.md`** is aligned so the "Model" section documents the new default. Sonnet defaults and DeepSeek paths are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ae56b569259657ff17f0d8bf9dddfa13ccc80f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->