### PR TITLE
refactor(SectorBNT): route equal gauge through copy-weight matching

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -392,28 +392,20 @@ theorem ft_sector_bnt_equal_sector_dataPos
   have hCoeff_eventual : ∀ k : Fin Q.basisCount,
       ∃ N₀, ∀ N > N₀, P.coeff N (β k) = (ζ k) ^ N * Q.coeff N k := fun k =>
     (hCoeff k).choose_spec.2
-  have hWeightData : ∀ k : Fin Q.basisCount,
-      ∃ (hCopies : P.copies (β k) = Q.copies k)
-        (τ : Fin (P.copies (β k)) ≃ Fin (Q.copies k)),
-        ∀ q : Fin (P.copies (β k)),
-          Q.weight k (τ q) = (ζ k)⁻¹ * P.weight (β k) q := by
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
+    intro k hzero
+    have hnorm := hζ_norm k
+    simp [hzero] at hnorm
+  let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
+    SectorBNTCopyWeightMatching.of_coeff_identity
+      (P := P) (Q := Q) β ζ hζ_ne hCoeff_eventual
+  have hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k := by
     intro k
-    obtain ⟨N₀, hCoeff_k⟩ := hCoeff_eventual k
-    have hζ_ne : ζ k ≠ 0 := by
-      intro hzero
-      have hnorm := hζ_norm k
-      simp [hzero] at hnorm
-    exact matched_sector_weight_equiv (P := P) (Q := Q)
-      (j₀ := β k) (k₀' := k) (ζ := ζ k) hζ_ne (N₀ := N₀) hCoeff_k
-  let hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k := fun k =>
-    (hWeightData k).choose
+    have hcard := Fintype.card_congr (W.copy_equiv k)
+    simpa using hcard.symm
   refine ⟨β, hMatch, hCopies, ζ, hζ_norm, ?_⟩
   intro k
-  obtain ⟨hC, τPQ, hτPQ⟩ := hWeightData k
-  refine ⟨τPQ.symm, ?_⟩
-  intro q
-  have hpoint := hτPQ (τPQ.symm q)
-  simpa using hpoint
+  exact ⟨W.copy_equiv k, W.weight_eq k⟩
 
 /-- Reformulation for the all-length `SameMPV₂` form. -/
 theorem ft_sector_bnt_equal_sector_data
@@ -529,29 +521,20 @@ theorem ft_sector_bnt_equal_global_gaugePos
     have hnorm := hζ_norm k
     simp [hzero] at hnorm
   have hCoeff := coeff_identity_via_matched_mpv_phasePos hP hEqual β ζ hMpv
-  have hWeightData : ∀ k : Fin Q.basisCount,
-      ∃ (hCopies : P.copies (β k) = Q.copies k)
-        (τPQ : Fin (P.copies (β k)) ≃ Fin (Q.copies k)),
-        ∀ q : Fin (P.copies (β k)),
-          Q.weight k (τPQ q) = (ζ k)⁻¹ * P.weight (β k) q := by
+  let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
+    SectorBNTCopyWeightMatching.of_coeff_identity
+      (P := P) (Q := Q) β ζ hζ_ne hCoeff
+  let hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k := by
     intro k
-    obtain ⟨N₀, hCoeff_k⟩ := hCoeff k
-    exact matched_sector_weight_equiv (P := P) (Q := Q)
-      (j₀ := β k) (k₀' := k) (ζ := ζ k) (hζ_ne k) (N₀ := N₀) hCoeff_k
-  let hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k := fun k =>
-    (hWeightData k).choose
+    have hcard := Fintype.card_congr (W.copy_equiv k)
+    simpa using hcard.symm
   let τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)) :=
-    fun k => (hWeightData k).choose_spec.choose.symm
-  have hWeight : ∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
-      Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ k q) := by
-    intro k q
-    have hpoint := (hWeightData k).choose_spec.choose_spec
-      ((hWeightData k).choose_spec.choose.symm q)
-    simpa [τ] using hpoint
+    W.copy_equiv
   obtain ⟨X, hXdef, hGauge⟩ :=
-    sector_bnt_global_gauge_of_matched_weights
-      (P := P) (Q := Q) β hDim τ ζ Xblock hζ_ne hConj hWeight
-  exact ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, hWeight, X, hXdef, hGauge⟩
+    sector_bnt_global_gauge_of_copy_weight_matching
+      (P := P) (Q := Q) β hDim ζ Xblock hζ_ne hConj W
+  exact ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, W.weight_eq, X, hXdef,
+    hGauge⟩
 
 /-- Reformulation for the all-length `SameMPV₂` form.
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1390,8 +1390,8 @@ matching covers the whole BNT basis.
     \uses{def:sector_bnt_cf,
         thm:sector_bnt_bijective_match_of_sameMPV,
         lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
-        lem:sector_bnt_matched_sector_weight_equiv,
-        thm:sector_bnt_global_gauge_of_matched_weights}
+        lem:sector_bnt_copy_weight_matching_of_coeff_identity,
+        thm:sector_bnt_global_gauge_of_copy_weight_matching}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
     MPV family. Assume that every sector of $P$ and every sector of $Q$ has at
     least one copy weight of modulus $1$. Then there exist:
@@ -1436,18 +1436,32 @@ matching covers the whole BNT basis.
     \uses{thm:sector_bnt_bijective_match_of_sameMPV,
         lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
         lem:sector_bnt_norm_phase_of_matched_mpv,
-        lem:sector_bnt_matched_sector_weight_equiv,
-        thm:sector_bnt_global_gauge_of_matched_weights}
+        lem:sector_bnt_copy_weight_matching_of_coeff_identity,
+        thm:sector_bnt_global_gauge_of_copy_weight_matching}
     The full-basis matching theorem gives $\beta$, the bond-dimension
     identifications, and the gauge-phase equivalences between $Q_k$ and
     $P_{\beta(k)}$. Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
     gives the eventual exact coefficient identities for the same phases
     $\zeta_k$, while Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv}
     gives $|\zeta_k|=1$.
-    The matched-sector weight-permutation theorem then gives the copy
-    permutations and the displayed pointwise weight identities. Finally
-    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights} assembles the
-    block conjugacies into the flattened direct-sum conjugation by
+    For each sector $k$,
+    Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity} applies to
+    \[
+        c_N^{(\beta(k))}(P)
+        =
+        \zeta_k^N c_N^{(k)}(Q),
+        \qquad
+        \sum_r \mu_{\beta(k),r}^{\,N}
+        =
+        \sum_q(\zeta_k\nu_{k,q})^N ,
+    \]
+    and gives a copy permutation $\tau_k$ satisfying
+    \[
+        \nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)} .
+    \]
+    Finally
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_copy_weight_matching} assembles
+    the block conjugacies into the flattened direct-sum conjugation by
     $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
 \end{proof}
 


### PR DESCRIPTION
### Motivation

- Establish `SectorBNTCopyWeightMatching.of_coeff_identity` as the canonical path for recovering copy permutations and copy-weight identities in the equal-MPV sector and global-gauge proofs.
- Remove duplicated matched-sector weight extraction from `ft_sector_bnt_equal_sector_dataPos` and `ft_sector_bnt_equal_global_gaugePos`.
- Keep Chapter 10's proof graph aligned with the Lean proof route: coefficient identities produce the copy-weight matching, then the direct-sum gauge assembly consumes it.

### Description

- `TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean`: routes the equal-MPV sector-data and global-gauge proofs through `SectorBNTCopyWeightMatching.of_coeff_identity`.
- `blueprint/src/chapter/ch10_bnt.tex`: updates the Chapter 10 proof dependencies and prose to name the copy-weight matching theorem as the intermediate step.
- No theorem statement changes and no new proof-integrity blockers.

### Testing

- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental TNLean.MPS.FundamentalTheorem.SectorBNT.FundamentalCoord`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean blueprint/src/chapter/ch10_bnt.tex` (warns that the changed positive-length helper theorems are not separate blueprint entries; the public all-length theorem remains the blueprint entry)
- `git diff --check`
- `rg -n "\\b(sorry|admit|axiom|native_decide|unsafeCast)\\b" TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean blueprint/src/chapter/ch10_bnt.tex`

`leanblueprint checkdecls` still fails on the repository's pre-existing missing PEPS/parent-Hamiltonian/BNT declarations.

Refs #1749.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure refactor only; public theorem statements and mathematical claims are unchanged, with no auth, security, or runtime behavior impact.
> 
> **Overview**
> **Equal-MPV sector proofs** in `Fundamental.lean` no longer inline `matched_sector_weight_equiv` to build per-sector copy permutations and weight identities. They now construct a single `SectorBNTCopyWeightMatching` via `of_coeff_identity` from eventual coefficient identities, derive copy counts from `copy_equiv`, and feed that object into `sector_bnt_global_gauge_of_copy_weight_matching` instead of `sector_bnt_global_gauge_of_matched_weights` with separate `τ` and `hWeight` hypotheses.
> 
> **Chapter 10 blueprint** (`ch10_bnt.tex`) updates the global-gauge theorem’s `\uses` list and proof narrative so the documented pipeline is: matched MPV phases → coefficient identities → **copy-weight matching** lemma → copy-weight-matching global gauge theorem. Theorem statements are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac829e70f8b107eeee4013e418aa767d83447e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->