### PR TITLE
refactor(SectorBNT): share equal copy-weight witnesses

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -358,6 +358,108 @@ theorem ft_sector_bnt_proportional_global_gauge_of_coeff_identity
       (P := P) (Q := Q) β ζ hζ_ne hCoeff
   exact ⟨W, hGlobal W⟩
 
+/-- **Equal-MPV matched copy-weight witnesses.**
+
+From full-basis BNT matching and coefficient comparison one obtains a sector
+bijection β, bond-dimension equalities, unit phases ζ k, block gauges X k, and
+a copy-weight matching for the same phases.
+
+The matched coefficient identities give the sectorwise power-sum comparison
+\[
+  \sum_q \mu_{\beta(k),q}^N = \sum_q (\zeta_k \nu_{k,q})^N
+\]
+for all sufficiently large \(N\).  Finite power-sum comparison then gives the
+copy permutations and weight identities. -/
+theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
+    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
+      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+      (ζ : Fin Q.basisCount → ℂ)
+      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
+      (∀ (k : Fin Q.basisCount) (i : Fin d),
+        Q.basis k i =
+          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
+      Nonempty (SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ) := by
+  classical
+  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPVPos hP hQ hUnitP hUnitQ hEqual
+  let hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k :=
+    fun k => (hβMatchFull k).choose
+  let hGPE : ∀ k : Fin Q.basisCount,
+      GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) (Q.basis k) :=
+    fun k => (hβMatchFull k).choose_spec.1
+  let Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ :=
+    fun k => (hGPE k).choose
+  let ζ : Fin Q.basisCount → ℂ := fun k => (hGPE k).choose_spec.choose
+  have hConj : ∀ (k : Fin Q.basisCount) (i : Fin d),
+      Q.basis k i =
+        ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+          (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+          (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+            Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ)) := by
+    intro k i
+    exact (hGPE k).choose_spec.choose_spec.2 i
+  have hMpv : ∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ := by
+    intro k N σ
+    rw [mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k)))
+      (B := Q.basis k) (Xblock k) (ζ k) (hConj k) N σ,
+      mpv_cast_dim (hDim k) (P.basis (β k)) N σ]
+  have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := by
+    intro k
+    have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) (P.basis (β k)) (P.basis (β k)) N‖)
+        atTop (𝓝 (1 : ℝ)) := by
+      have h1 := (hP.basis_normalized_self_overlap (β k)).norm
+      simpa using h1
+    have hBB : Tendsto (fun N => ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k) N‖)
+        atTop (𝓝 (1 : ℝ)) := by
+      have h1 := (hQ.basis_normalized_self_overlap k).norm
+      simpa using h1
+    have hScale :=
+      mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis (β k)) (B := Q.basis k)
+        (ζ := ζ k) (hMpv k)
+    exact norm_eq_one_of_selfOverlap_scale (ζ := ζ k) hAA hBB hScale
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
+    intro k hzero
+    have hnorm := hζ_norm k
+    simp [hzero] at hnorm
+  have hCoeff := coeff_identity_via_matched_mpv_phasePos hP hEqual β ζ hMpv
+  let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
+    SectorBNTCopyWeightMatching.of_coeff_identity
+      (P := P) (Q := Q) β ζ hζ_ne hCoeff
+  exact ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ⟨W⟩⟩
+
+/-- Reformulation for the all-length `SameMPV₂` form. -/
+theorem ft_sector_bnt_equal_matched_copy_weight_witnesses
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
+    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
+      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
+      (ζ : Fin Q.basisCount → ℂ)
+      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
+      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
+      (∀ (k : Fin Q.basisCount) (i : Fin d),
+        Q.basis k i =
+          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
+            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
+            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
+              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
+      Nonempty (SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ) :=
+  ft_sector_bnt_equal_matched_copy_weight_witnessesPos
+    (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
+
 /-- **BNT equal-MPV sector-witness theorem.**
 
 If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
@@ -379,26 +481,16 @@ theorem ft_sector_bnt_equal_sector_dataPos
         ∀ k, ∃ τ : Fin (Q.copies k) ≃ Fin (P.copies (β k)),
           ∀ q : Fin (Q.copies k), Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ q) := by
   classical
-  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPVPos hP hQ hUnitP hUnitQ hEqual
+  obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ⟨W⟩⟩ :=
+    ft_sector_bnt_equal_matched_copy_weight_witnessesPos
+      (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual
   let hMatch : ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
       GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k) :=
     fun k => by
-      obtain ⟨h, hGPE, _hNondecay⟩ := hβMatchFull k
-      exact ⟨h, hGPE⟩
-  have hCoeff := coeff_identity_via_global_gaugePos hP hQ hEqual β hMatch
-  let ζ : Fin Q.basisCount → ℂ := fun k => (hCoeff k).choose
-  have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := fun k =>
-    (hCoeff k).choose_spec.1
-  have hCoeff_eventual : ∀ k : Fin Q.basisCount,
-      ∃ N₀, ∀ N > N₀, P.coeff N (β k) = (ζ k) ^ N * Q.coeff N k := fun k =>
-    (hCoeff k).choose_spec.2
-  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
-    intro k hzero
-    have hnorm := hζ_norm k
-    simp [hzero] at hnorm
-  let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
-    SectorBNTCopyWeightMatching.of_coeff_identity
-      (P := P) (Q := Q) β ζ hζ_ne hCoeff_eventual
+      refine ⟨hDim k, Xblock k, ζ k, ?_, hConj k⟩
+      intro hzero
+      have hnorm := hζ_norm k
+      simp [hzero] at hnorm
   have hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k := by
     intro k
     have hcard := Fintype.card_congr (W.copy_equiv k)
@@ -477,53 +569,13 @@ theorem ft_sector_bnt_equal_global_gaugePos
                 Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
                   (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
   classical
-  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPVPos hP hQ hUnitP hUnitQ hEqual
-  let hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k :=
-    fun k => (hβMatchFull k).choose
-  let hGPE : ∀ k : Fin Q.basisCount,
-      GaugePhaseEquiv
-        (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) (Q.basis k) :=
-    fun k => (hβMatchFull k).choose_spec.1
-  let Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ :=
-    fun k => (hGPE k).choose
-  let ζ : Fin Q.basisCount → ℂ := fun k => (hGPE k).choose_spec.choose
-  have hConj : ∀ (k : Fin Q.basisCount) (i : Fin d),
-      Q.basis k i =
-        ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
-          (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
-          (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
-            Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ)) := by
-    intro k i
-    exact (hGPE k).choose_spec.choose_spec.2 i
-  have hMpv : ∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
-      mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ := by
-    intro k N σ
-    rw [mpv_eq_pow_mul_of_gaugePhase
-      (A := cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k)))
-      (B := Q.basis k) (Xblock k) (ζ k) (hConj k) N σ,
-      mpv_cast_dim (hDim k) (P.basis (β k)) N σ]
-  have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := by
-    intro k
-    have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) (P.basis (β k)) (P.basis (β k)) N‖)
-        atTop (𝓝 (1 : ℝ)) := by
-      have h1 := (hP.basis_normalized_self_overlap (β k)).norm
-      simpa using h1
-    have hBB : Tendsto (fun N => ‖mpvOverlap (d := d) (Q.basis k) (Q.basis k) N‖)
-        atTop (𝓝 (1 : ℝ)) := by
-      have h1 := (hQ.basis_normalized_self_overlap k).norm
-      simpa using h1
-    have hScale :=
-      mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis (β k)) (B := Q.basis k)
-        (ζ := ζ k) (hMpv k)
-    exact norm_eq_one_of_selfOverlap_scale (ζ := ζ k) hAA hBB hScale
+  obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ⟨W⟩⟩ :=
+    ft_sector_bnt_equal_matched_copy_weight_witnessesPos
+      (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual
   have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
     intro k hzero
     have hnorm := hζ_norm k
     simp [hzero] at hnorm
-  have hCoeff := coeff_identity_via_matched_mpv_phasePos hP hEqual β ζ hMpv
-  let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
-    SectorBNTCopyWeightMatching.of_coeff_identity
-      (P := P) (Q := Q) β ζ hζ_ne hCoeff
   let hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k := by
     intro k
     have hcard := Fintype.card_congr (W.copy_equiv k)

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1383,15 +1383,56 @@ matching covers the whole BNT basis.
     then applies to this copy-weight matching.
 \end{proof}
 
+\begin{lemma}[Equal-MPV matched copy-weight witnesses]%
+    \label{lem:sector_bnt_equal_matched_copy_weight_witnesses}
+    \lean{MPSTensor.ft_sector_bnt_equal_matched_copy_weight_witnesses}
+    \leanok
+    \uses{def:sector_bnt_cf}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
+    MPV family. Assume that every sector of $P$ and every sector of $Q$ has at
+    least one copy weight of modulus $1$. Then there are a bijection
+    $\beta:J(Q)\simeq J(P)$, bond-dimension equalities, unit-modulus phases
+    $\zeta_k$, and block gauges $X_k$ such that
+    \[
+        Q_k^i=\zeta_k X_kP_{\beta(k)}^iX_k^{-1}.
+    \]
+    For the same phases there is a copy-weight matching: after a permutation
+    of the copies inside each matched sector,
+    \[
+        \nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}.
+    \]
+    % Scope restriction documented in
+    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:sector_bnt_bijective_match_of_sameMPV,
+        lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
+        lem:sector_bnt_copy_weight_matching_of_coeff_identity}
+    The full-basis matching theorem gives the bijection and block gauges. The
+    self-overlap comparison
+    \[
+        \langle V_N(Q_k),V_N(Q_k)\rangle
+        =
+        |\zeta_k|^{2N}
+        \langle V_N(P_{\beta(k)}),V_N(P_{\beta(k)})\rangle
+    \]
+    together with the BNT normalization limits on both sides forces
+    $|\zeta_k|=1$. The matched MPV phase identities also give the eventual
+    coefficient identities
+    \[
+        c_N^{(\beta(k))}(P)=\zeta_k^N c_N^{(k)}(Q).
+    \]
+    Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity} applies
+    the finite power-sum comparison in each sector and gives the copy-weight
+    identities.
+\end{proof}
+
 \begin{theorem}[Full-basis global gauge in matched coordinates]%
     \label{thm:sector_bnt_equal_global_gauge}
     \lean{MPSTensor.ft_sector_bnt_equal_global_gauge}
     \leanok
-    \uses{def:sector_bnt_cf,
-        thm:sector_bnt_bijective_match_of_sameMPV,
-        lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
-        lem:sector_bnt_copy_weight_matching_of_coeff_identity,
-        thm:sector_bnt_global_gauge_of_copy_weight_matching}
+    \uses{def:sector_bnt_cf}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
     MPV family. Assume that every sector of $P$ and every sector of $Q$ has at
     least one copy weight of modulus $1$. Then there exist:
@@ -1433,33 +1474,14 @@ matching covers the whole BNT basis.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:sector_bnt_bijective_match_of_sameMPV,
-        lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
-        lem:sector_bnt_norm_phase_of_matched_mpv,
-        lem:sector_bnt_copy_weight_matching_of_coeff_identity,
+    \uses{lem:sector_bnt_equal_matched_copy_weight_witnesses,
         thm:sector_bnt_global_gauge_of_copy_weight_matching}
-    The full-basis matching theorem gives $\beta$, the bond-dimension
-    identifications, and the gauge-phase equivalences between $Q_k$ and
-    $P_{\beta(k)}$. Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
-    gives the eventual exact coefficient identities for the same phases
-    $\zeta_k$, while Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv}
-    gives $|\zeta_k|=1$.
-    For each sector $k$,
-    Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity} applies to
-    \[
-        c_N^{(\beta(k))}(P)
-        =
-        \zeta_k^N c_N^{(k)}(Q),
-        \qquad
-        \sum_r \mu_{\beta(k),r}^{\,N}
-        =
-        \sum_q(\zeta_k\nu_{k,q})^N ,
-    \]
-    and gives a copy permutation $\tau_k$ satisfying
+    Lemma~\ref{lem:sector_bnt_equal_matched_copy_weight_witnesses} gives
+    $\beta$, the bond-dimension identifications, the phases $\zeta_k$, the
+    block gauges $X_k$, and copy permutations $\tau_k$ satisfying
     \[
         \nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)} .
     \]
-    Finally
     Theorem~\ref{thm:sector_bnt_global_gauge_of_copy_weight_matching} assembles
     the block conjugacies into the flattened direct-sum conjugation by
     $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.


### PR DESCRIPTION
### Motivation

The equal-MPV BNT sector-data theorem and the matched-coordinate global-gauge theorem both reconstructed the same sector bijection, phases, block gauges, and copy-weight matching. The copy-weight matching should have one formal origin: the finite power-sum comparison implemented by `SectorBNTCopyWeightMatching.of_coeff_identity`.

### Description

This PR adds `MPSTensor.ft_sector_bnt_equal_matched_copy_weight_witnesses`, which records the common equal-MPV witnesses: the sector bijection, bond-dimension equalities, unit phases, block gauges, and nonempty copy-weight matching structure.

It then routes both `ft_sector_bnt_equal_sector_data` and `ft_sector_bnt_equal_global_gauge` through that common theorem, so the copy permutations and weight identities are extracted in one place. Chapter 10 now tags the common witness theorem at the existing full-basis global-gauge node.

Addresses #1749.

### Testing

- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental TNLean.MPS.FundamentalTheorem.SectorBNT.FundamentalCoord`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean blueprint/src/chapter/ch10_bnt.tex`
- `git diff --check`
- `rg -n "\\b(sorry|admit|axiom|native_decide|unsafeCast)\\b" TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean blueprint/src/chapter/ch10_bnt.tex`
- `cd blueprint && leanblueprint checkdecls` fails only on pre-existing missing PEPS and parent-Hamiltonian declarations; the blueprint sync check reports no missing changed declaration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure refactor only; no change to theorem statements beyond reusing a shared proof path, with blueprint sync to the new Lean name.
> 
> **Overview**
> **Deduplicates** the equal-MPV BNT pipeline so sector bijection, unit phases, block gauges, and copy-weight matching are proved once instead of twice.
> 
> Adds `MPSTensor.ft_sector_bnt_equal_matched_copy_weight_witnesses` (and the `SameMPV₂Pos` variant), which packages full-basis matching, `‖ζ_k‖ = 1`, block conjugation, and a `SectorBNTCopyWeightMatching` built via `of_coeff_identity`. **`ft_sector_bnt_equal_sector_data`** and **`ft_sector_bnt_equal_global_gauge`** now obtain those witnesses from this theorem and only extract their respective conclusions (gauge-phase sector data vs. flattened global gauge).
> 
> Chapter 10 gains lemma `sector_bnt_equal_matched_copy_weight_witnesses` and the full-basis global-gauge proof is shortened to cite that lemma plus the existing copy-weight global-gauge assembly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346615e4e2b599192d4ee680ae045ab00130599f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->