### PR TITLE
doc(blueprint): fix CF/BNT/FT faithfulness prose

### DIFF
--- a/blueprint/comments202605/STATUS_erickson_items_20260530.md
+++ b/blueprint/comments202605/STATUS_erickson_items_20260530.md
@@ -1,0 +1,39 @@
+# Status of Erickson's CPSV16 FT/BNT comments (checked 2026-05-30)
+
+The three analysis documents in this directory date from 2026-05-13 and were
+written against the **one-copy `IsCanonicalFormBNT`** surface (with
+`mu_strict_anti` / `mu_dom_norm_one`) and the **non-dominant projection /
+Plan-A** roadmap. Both have since been **retired and replaced** by the
+multi-copy sector structure. Those documents are therefore **superseded as
+architecture descriptions**; they are kept as the record that prompted the
+overhaul. This note records the current resolution of each concern.
+
+Superseded documents:
+- `cpsv16_fundamental_theorem_analysis.md`
+- `cpsv16_ft_expanded_proof.tex`
+- `cpsv16_bnt_gap_recommendation_examples.tex`
+
+## Item-by-item resolution
+
+| # | Erickson's concern | Current status | Where |
+|---|---|---|---|
+| 1 | The FT proof should be a per-block existence argument plus injectivity from BNT **minimality**, not a peel-induction needing **combined-family** linear independence. | **Resolved.** `bijective_match_of_sameMPV` routes forward/backward injectivity through `basis_distinct` (minimality), and `combined_family_eventually_li` is used only for coefficient isolation, not a shrinking-pair recursion. | `SectorBNT/StrongMatch.lean`, `SectorBNT/Api.lean` |
+| 2 | The one-copy surface (one weight per sector, strict modulus ordering) is weaker than the paper's multi-copy BNT sector with power-sum coefficients $c_N^{(j)}=\sum_q \mu_{j,q}^N$. | **Resolved.** The one-copy `IsCanonicalFormBNT` (with `mu_strict_anti`) is retired; the current `SectorDecomposition` carries the raw power-sum coefficient. Equal-modulus copies ($C\oplus(-C)$) and unequal ($C\oplus\tfrac12 C$) are both represented. | `SharedInfra/SectorDecomposition.lean`, `SectorBNT/Api.lean` (`coeff_eq_sum_weight_pow`) |
+| 3 | The dominant-block projection argument fails for non-dominant blocks (both sides decay to $0=0$); use combined-family linear independence + exact coefficient comparison instead. | **Resolved.** The projection route is abandoned. The blueprint states it explicitly: "No projection-limit argument for non-dominant sectors is used." Non-decay comes from the Cesàro lemma. | ch11 intro; `SectorBNT/CesaroNonDecay.lean` (`sum_pow_not_tendsto_zero_of_unit_modulus`) |
+| 4 | The ~530-line Plan-A workaround (dominant-adjusted scalar, `finOne` base cases, discrete-rate $\delta_N$ upgrade) was wasted effort; N=0 / zero-tail handling consumed disproportionate effort. | **Resolved.** Plan-A deleted (the `Full/` directory is empty). Residual N=0 / zero-tail bloat cleaned: `SameMPV₂Pos` threaded through the after-blocking chain and the dead zero-tail/common-flat sub-chain removed. | PRs #2153, #2159; commit `1e63d981c` |
+| 5 | Vandermonde non-decay of $\sum_q \mu_q^N$ needed a Lean realization. | **Resolved.** Provided by the Cesàro non-decay lemma for unit-modulus sums. | `SectorBNT/CesaroNonDecay.lean` |
+| 6 | The matching/equal-MPV theorems carry a **per-sector** unit-modulus hypothesis stronger than CPSV16's single **global** witness (line 246). | **Documented.** Recorded as a scope restriction with an elimination plan; the affected declarations are listed. | `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex` (commit `4605b9381`) |
+| 7 | Lemma A.2's $X^\dagger X = c\,\Id$ rescaling is elided in the source ("$=\mathbf 1$"); the Lean should carry the $c\,\Id$ fixed-point conclusion and rescale at the end. | **Needs confirmation (minor).** The gauge-phase extraction lives in the irreducible/primitive fixed-point modules; confirm it carries the scalar-fixed-point conclusion rather than assuming $X^\dagger X=\Id$. Not a blueprint defect. | `MPS/Irreducible/`, `SectorBNT/Supplier.lean` |
+| 8 | The proportional ($c_N\neq1$) FT still needs the matched-coefficient identity $c_N^{(\beta(k))}(P)=\zeta_k^N c_N^{(k)}(Q)$ **derived**, not assumed. | **Open — active work.** The source theorems (Cor II.1, Cor II.2) are honestly `\notready`; the conditional theorems take the identity as a hypothesis. Tracked by **issue #1749**. | `SectorBNT/Fundamental.lean`, `SectorBNT/CoeffIdentity.lean` |
+
+## Summary
+
+Erickson's substantive structural recommendations are **implemented**: the
+multi-copy sector decomposition (2), abandoning the non-dominant projection
+argument (3) in favour of combined-family linear independence and Cesàro
+non-decay (5), and the per-block-existence-plus-minimality matching structure
+(1). The N=0 / Plan-A waste (4) is cleaned. The per-sector-vs-global unit
+witness (6) is documented as a tracked scope restriction. The one remaining
+genuine gap is the proportional matched-coefficient identity (8), which is
+active work under issue #1749, with the source theorems honestly marked
+`\notready`.

--- a/blueprint/comments202605/blueprint_cf_ft_audit_20260530.md
+++ b/blueprint/comments202605/blueprint_cf_ft_audit_20260530.md
@@ -1,0 +1,181 @@
+# Canonical-form / BNT / FT blueprint + Lean audit (2026-05-30)
+
+Cross-check of the canonical-form/BNT/fundamental-theorem blueprint cluster against
+its Lean backing, the CPSV16 source (arXiv:1606.00608v4), Erickson's
+`blueprint/comments202605/` analysis, and the `docs/` + `.github` prose/blueprint
+standards. Produced by an 8-agent read-only audit fleet.
+
+## Headline
+
+**No chapter needs a full rewrite.** Erickson's May-13 documents in
+`comments202605/` are **stale**: they describe the one-copy `IsCanonicalFormBNT`
+predicate (with `mu_strict_anti` / `mu_dom_norm_one`) and the broken non-dominant
+projection / Plan-A roadmap, all of which have since been **deleted** and replaced
+by the multi-copy sector structure (`SectorDecomposition` + `IsBNTCanonicalForm`
+carrying the global unit witness). Driving rewrites from those docs would re-introduce
+retired architecture.
+
+The current chapters are good-to-strong. The defects are surgical: 2 blockers,
+4 majors, 40 minors, plus a modest Lean N=0 cleanup localized to the current branch.
+
+Severity histogram (blueprint): 2 blocker, 4 major, 40 minor.
+
+---
+
+## Blockers (both in ch10_bnt)
+
+### B1 — `def:bnt` tags the wrong Lean declaration  (ch10-01)
+`def:bnt` (ch10:18–43) displays the abstract 3-clause Definition 4.2 BNT (each block
+normal; the MPV lies in the span of the block MPVs; the block MPVs are eventually
+linearly independent). That prose matches `MPSTensor.IsBNT` (`BNT/Basic.lean:75`).
+But the entry tags `\lean{MPSTensor.IsBNTCanonicalForm}` — the 10-field much stronger
+structure already (correctly) tagged by `def:sector_bnt_cf` (ch10:517). Statement
+`\leanok` is therefore invalid, and the abstract BNT definition is left unlinked.
+
+**Fix:** retarget `def:bnt` → `\lean{MPSTensor.IsBNT}`, keep the 3-clause prose. The
+downstream `lem:cf_bnt_is_bnt_split` and `lem:normal_cf_bnt_is_bnt` already conclude
+`IsBNT`, so their `\uses{def:bnt}` becomes correct. Leave `def:sector_bnt_cf` as the
+sole entry for `IsBNTCanonicalForm`. Re-run `leanblueprint checkdecls`.
+
+### B2 — per-sector vs global unit-modulus witness: faithfulness-rule violation  (ch10-02 / ch10-07; mirrored ch11 F3/F4)
+Four equal-MPV / matching theorems carry **per-sector** unit-modulus hypotheses
+`∀ j ∃ q ‖μ_{j,q}‖ = 1` (and `∀ k` for the Q side) — `StrongMatch.lean:132,270`,
+`FundamentalCoord.lean:644`:
+- `thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV` (884)
+- `thm:sector_bnt_bijective_match_of_sameMPV` (965)
+- `thm:sector_bnt_equal_global_gauge` (1376)
+- `thm:sector_bnt_equal_mps_gaugeEquiv_literal` (1442) — most exposed; calls itself
+  "the normalized BNT form of Corollary II.2".
+
+CPSV16 §II.C line 246 (and Cor II.2, line 1182) states only a **single global**
+existential `∃ (j*,q*) |μ_{j*,q*}| = 1`. The per-sector form is strictly stronger and
+absent from the source. Per the CLAUDE.md Faithfulness rule, these are scope-restricted
+theorems; bearing `\leanok` against the source labels without a paper-gap note is the
+"smuggled hypothesis" antipattern. The core structure `IsBNTCanonicalForm`
+(`Basic.lean:152-161`, `weight_unit_exists`) faithfully carries the **global** witness;
+ch08's BNT supplier also correctly carries only the global witness (confirmed clean).
+No existing note covers this gap (`ft_one_copy_scope_restriction.tex` is the r_j=1
+case; `cpsv16_two_layer_sector_refinement.tex` only remarks the factorization).
+
+**Fix:** write `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex` (global
+line-246 existential vs the per-sector Lean hypotheses; elimination plan: derive the
+per-sector witness from the global one inside the line-1182 matching argument, or
+split off all-strict-modulus sectors via the dominant-block argument). Add a complete
+`\path{}` sentence to the four entries above + the two proportional
+`..._global_gauge_of_...` theorems, modeled on ch07 `cor:uniform_injective_blocking`
+and ch10 `def:normal_cf_bnt` (144–148). Keep `\leanok` (Lean statements match the
+per-sector form); ensure none is presented as the unrestricted source theorem.
+
+---
+
+## Majors
+
+### M1 — ch08: false "only fixed point" claim  (C08-01)
+`thm:pgvwc07_ti_canonical_form` headline (ch08:63) writes "$\Id$ is the only fixed
+point of $\E_{A_k}$". False: every $c\,\Id$ is fixed by a unital map. Lean
+(`WeightNormalization.lean:389-391`) says the fixed-point space is spanned by $\Id$:
+`∀ X, transferMap (blocks k) X = X → ∃ c, X = c • 1`.
+**Fix:** "the only fixed points of $\E_{A_k}$ are scalar multiples of $\Id$"; display
+$\E_{A_k}(X) = X \Rightarrow X = c\,\Id$.
+
+### M2 — ch10: inconsistent bibliographic edition / line numbers  (ch10-03 / FT-08)
+The sector-BNT section (ch10:505+) pins ~41 line-range citations to
+`Cirac2017MPDO_AnnPhys` (Annals pagination), whose line numbers differ from
+arXiv:1606.00608v4 — the edition the Lean docstrings use (`Basic.lean:152` "CPSV16
+§II.C line 246"). A reviewer cannot verify line 246 / line 1182 against the cited
+edition. **Fix:** pin every line-range citation to `Cirac2016MPDO_arXiv`, verify each
+range (246, 264–279, 1080–1091, 1121–1132, 1167–1170, 1182, 1184–1192) resolves there,
+collapse the three keys to the two papers actually used.
+
+### M3 — ch11b: hidden hypothesis on a conditional theorem  (F-A-01)
+`thm:after_blocking_common_primitive_irreducible_blocks_reindexed` (ch11b:751–799)
+reduces a real Lean hypothesis (`CommonSectorRelabelingHypothesis`, a `SameMPV₂`
+between the directly-blocked weighted family and the reindexed common-sector family)
+to the vague phrase "can be identified with the common blocked alphabet". The
+hypothesis is dischargeable — `unconditional_commonPrimitiveIrreducibleBlocks`
+(`CommonSectorTransport.lean:536`) exists and is its own ch11 entry.
+**Fix:** display the assumed `SameMPV₂` equality, cross-reference the unconditional
+version; or retarget the entry's `\lean` to the unconditional theorem.
+
+### M4 — ch11b: untagged graph-orphan theorem  (F-A-02)
+`thm:zero_tail_common_flat_of_blocked_word_comparison` (ch11b:651–704) is a
+`\begin{theorem}` with full statement + proof but **no** `\lean`/`\leanok`/`\notready`
+— a dependency-graph orphan bundling "three equivalent hypothesis forms" (file-local
+lemmas) with a verbal proof and an em-dash narrative. Cited by `\uses` at 884, 919.
+**Fix:** attach `\lean{MPSTensor.zeroTail_commonFlat_of_blockwise}`
+(`CommonSectorTransport.lean:79`) + `\leanok` displaying the blockwise hypothesis; or
+demote to `\begin{remark}` and reroute the two `\uses` edges to the file-local lemmas.
+Remove the em-dash list; display the contraction identity in the proof.
+
+---
+
+## Minor themes (40 findings; representative)
+
+- **Formula-first proof sketches** (B-category): ch11 `thm:unit_modulus_phase_tp_prim_irred`
+  (F1) hand-waves "peripheral spectrum = {1}"; the Lean uses the self-overlap scaling
+  identity $O_{BB}(N) = |\zeta|^{2N} O_{AA}(N)$ with $O_{AA},O_{BB}\to 1 \Rightarrow |\zeta|=1$.
+  ch08 BNT supplier (C08-07) should display $\|\zeta_{j,q}\|=1$ and the sector-weight
+  identity. ch11b proofs F-A-03/04/05 should display the fixed-point uniqueness chain,
+  the $\phi_u$ algebra-iso properties, and the length-zero identity $D = D_0 + \sum_k D_k$.
+- **Prose / Lean-jargon leaks**: "SectorBNT" namespace in ch11 prose (F2 → "BNT"),
+  "the matched basis" ch10:400 (ch10-04 → "paired basis tensors"), "assembly" as a
+  prose noun ch10:788,1257 (ch10-05 → "construction"), "granular sector decomposition"
+  ch08 (C08-03 → "single-copy sector decomposition").
+- **Indexing drift**: ch08 CPSV definitions use 1-based $k=1,\ldots,r$ (C08-02); should
+  be 0-based / `Fin r`. Lambda/Lambda clash in the ch08 headline (C08-06).
+- **Status hygiene**: 7 untagged blueprint-only ch08 entries (C08-04) need
+  `\notready`-or-delete (several duplicate the ch10 SectorBNT grouping); undefined
+  symbol `P` in `thm:bnt_trivial_sector`. ch08 `thm:cyclic_sector_decomp_after_blocking`
+  tag-without-`\leanok` limbo (C08-05). ch11 `lem:ft_equal_same_structure` ambiguous
+  status (F4).
+- **Scope `\path{}` markers** missing on scope-restricted entries: ch09 block-separation
+  (ch09-01), ch11 equal-structure (F3) — both have governing paper-gap notes but cite
+  them only in LaTeX comments, not reader-facing `\path{}`.
+- **NeZero / positive-bond-dimension** hypotheses to surface: ch09-02, ch10-06, ch11 F7.
+- **Section preambles** missing in ch09 (ch09-03). **One-copy mis-advertisement** of
+  ch11's own multi-copy lemmas (F5). **Overlap-clause inconsistency** ch08 (C08-09).
+- **Positive confirmations** (no action): ch09 all `\leanok`/`\uses` accurate;
+  ch11 both source theorems correctly `\notready` (no smuggled source `\leanok`); FT-04
+  injectivity-from-`basis_distinct` clean; ch08 BNT supplier carries only the global
+  witness.
+
+---
+
+## Lean N=0 / degenerate-case cleanup (current branch)
+
+FT-05: most genuinely-wasted N=0 effort (the Plan-A projection workaround, the one-copy
+predicate) is **already deleted**. The retired `Full/` directory is empty. The
+zero-tail / length-zero ($D = D_0 + \sum_k D_k$) handling in ch11b is **source-faithful
+CPSV16 content** (all-zero irreducible blocks contribute only at N=0), **not** bloat.
+
+Remaining, localized to the current branch's modified files:
+- **F1** `SectorComparison/CommonSectorTransport.lean`
+  (`afterBlocking_commonPrimitiveIrreducibleBlocks`, ~456,490–537): the N=0 zero-tail
+  identity is threaded as an **unused** `_hZeroCanon`; only `SameMPV2Pos` is used; the
+  A/B blocks re-derive zero-vanishing twice (~9 lines each). Cleanup: drop the `Fin 0`
+  threading, recover N=0 via `toSameMPV2_of_bondDim_eq`, factor the duplicated A/B
+  blocks into one lemma (~90 lines saved).
+- **F2** `SectorComparison/CommonSectorData.lean` (85–87, 152–154; unused `_hZero` 261):
+  the `Fin 0` zero-tail conjunct is dropped unused by the consumer; pure N=0 bookkeeping
+  is just a dimension equation. Cleanup: drop the `Fin 0` conjunct, expose the nat dim
+  equation if needed.
+
+NOTE: this Lean N=0 pass was the thinnest agent result; a deeper pass over the active
+`SectorComparison/` files is warranted before committing the cleanup, since the branch
+is actively reworking exactly these files.
+
+---
+
+## Genuinely-open mathematics (not blueprint fixes; tracked separately)
+
+1. **Per-sector → global unit witness** (B2): eliminate the per-sector hypothesis by
+   deriving it from the global one (or the all-strict-modulus dominant-block split).
+2. **Proportional matched-coefficient identity** (FT-02): the proportional
+   ($c_N \ne 1$) FT still takes $c_N^{(\beta(k))}(P) = \zeta_k^N c_N^{(k)}(Q)$ as a
+   hypothesis rather than deriving it; this is the load-bearing remaining input,
+   tracked by issue #1749. The two CPSV16 source theorems (Cor II.1, Cor II.2) are
+   correctly `\notready`.
+
+These are real formalization work; the blueprint already flags them honestly via
+`\notready` / scope prose. The audit's blueprint fixes make the *documentation* of
+these gaps rubric-compliant; they do not close the gaps.

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -60,9 +60,13 @@ obtained from primitive blocks).
         \sum_i (A_k^i)^\dagger \Lambda_k A_k^i = \Lambda_k,
     \]
     where $\Lambda_k$ is diagonal, positive, and full-rank. Each block has
-    positive bond dimension. Moreover $\Id$ is the only fixed point of
-    $\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$, and the total bond dimension
-    of the decomposition is at most $D$.
+    positive bond dimension. Moreover the only fixed points of
+    $\E_{A_k}(X)=\sum_i A_k^iX(A_k^i)^\dagger$ are the scalar multiples of
+    $\Id$: for every $X$,
+    \[
+        \E_{A_k}(X)=X \;\Longrightarrow\; \exists\,c\in\C,\; X = c\,\Id.
+    \]
+    The total bond dimension of the decomposition is at most $D$.
 
     This is the positive-length form of
     \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}, with the global
@@ -76,7 +80,7 @@ obtained from primitive blocks).
     gauge; derive the invariant support projection from a singular positive fixed
     point by the positivity contradiction; split the finite-ring trace into the
     supported and orthogonal summands; iterate, using a non-scalar fixed point to
-    split further until the identity is the only fixed point of each block; and
+    split further until each block has only scalar fixed points; and
     finally repeat the fixed-point argument for the dual map and diagonalize the
     resulting full-rank positive fixed point by a unitary gauge. Later
     primitive-block results are used only after their hypotheses have been
@@ -1015,13 +1019,13 @@ $(1 + (-1)^N)\,V^{(N)}(C)_\sigma$, which is not a single scalar power.
     one-copy-per-sector subcase.
 \end{theorem}
 
-\begin{definition}[Granular sector decomposition]
+\begin{definition}[Single-copy sector decomposition]
     \label{def:trivial_sector_decomp}
     \lean{MPSTensor.trivialSectorDecomp}
     \leanok
     \uses{def:sector_weight_data}
     Given nonzero weights $(\mu_k)_{k=1}^r$ and blocks $(B_k)_{k=1}^r$, the
-    \emph{granular sector decomposition} has $r$ sectors, one basis block
+    \emph{single-copy sector decomposition} has $r$ sectors, one basis block
     $B_k$ per sector, multiplicity~$1$ in each sector, and sector weight
     $\mu_k$ on the $k$th sector. Equivalently, as a finite sum,
     \[
@@ -1030,12 +1034,12 @@ $(1 + (-1)^N)\,V^{(N)}(C)_\sigma$, which is not a single scalar power.
     \]
 \end{definition}
 
-\begin{lemma}[Granular sector decomposition preserves the represented family]
+\begin{lemma}[Single-copy sector decomposition preserves the represented family]
     \label{lem:trivial_sector_decomp_same_mpv}
     \lean{MPSTensor.sameMPV₂_trivialSectorDecomp}
     \leanok
     \uses{def:trivial_sector_decomp}
-    The granular sector decomposition associated to $(\mu_k,B_k)_k$ represents
+    The single-copy sector decomposition associated to $(\mu_k,B_k)_k$ represents
     the same MPS family as the original weighted block sum
     $\bigoplus_k \mu_k B_k$.
 \end{lemma}
@@ -1047,14 +1051,14 @@ $(1 + (-1)^N)\,V^{(N)}(C)_\sigma$, which is not a single scalar power.
     block-sum expression for $\bigoplus_k \mu_k B_k$.
 \end{proof}
 
-\begin{theorem}[Trivial sector decomposition for the sorted distinct-modulus case]
+\begin{theorem}[Single-copy sector decomposition for the sorted distinct-modulus case]
     \label{thm:bnt_trivial_sector}
+    \notready
     \uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv}
     If $\mu_k \neq 0$ for all $k$ and $|\mu_1| > \cdots > |\mu_r|$, then the
-    granular sector decomposition associated to $(\mu,B)$ satisfies
-    $V^{(N)}(P) = V^{(N)}(\bigoplus_k \mu_k B_k)$ for every
-    $N \ge 1$ and has exactly one copy per sector. This is the distinct-modulus,
-    one-copy-per-sector subcase.
+    single-copy sector decomposition associated to $(\mu,B)$ represents the same
+    family as $\bigoplus_k \mu_k B_k$ for every $N \ge 1$ and has exactly one
+    copy per sector. This is the distinct-modulus, one-copy-per-sector subcase.
 \end{theorem}
 
 To remove the artificial distinct-modulus assumption, group blocks by common

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -397,7 +397,7 @@ and~\cite{Cirac2021Matrix}.
 
 \begin{remark}[How the power-sum equality is used]
     The equal-MPV corollary in the source compares scalar power sums only after
-    the BNT representatives have already been matched. If the matched basis
+    the BNT representatives have already been matched. If the paired basis
     tensors satisfy $B_j=e^{i\phi_j}Y_jA_jY_j^{-1}$, then for every positive
     length $N$ the coefficient $\sum_q \mu_{j,q}^N$ of
     $\ket{V^{(N)}(A_j)}$ in the BNT expansion of $A$ equals the coefficient
@@ -502,7 +502,7 @@ and~\cite{Cirac2021Matrix}.
 \label{sec:sector_bnt_api}
 
 This section introduces the BNT canonical-form predicate following
-\cite[\S II, lines~287--301]{Cirac2017MPDO_AnnPhys} and
+\cite[\S II, lines~287--301]{Cirac2016MPDO_arXiv} and
 \cite[Definition~4.2, Proposition~4.3, and lines~1864--1884]{Cirac2021Matrix}.
 The predicate is
 defined on a sector decomposition with raw sector weights $\mu_{j,q}$ and
@@ -519,14 +519,14 @@ factorization is assumed.
     \uses{def:sector_weight_data}
     Given a sector decomposition $P$, the BNT canonical-form predicate
     records the minimal BNT hypotheses of
-    \cite{Cirac2017MPDO_AnnPhys,Cirac2021Matrix} without any equal-modulus
+    \cite{Cirac2016MPDO_arXiv,Cirac2021Matrix} without any equal-modulus
     or strict-ordering condition on the raw sector weights. It asserts that
     each basis block has positive bond dimension, is injective, irreducible,
     and left-canonical; the normalized self-overlap of every basis block
     converges to $1$; the basis MPV family is eventually linearly
     independent; distinct same-dimension basis blocks are not gauge-phase
     equivalent after identifying equal bond dimensions; and the
-    \cite[\S II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization holds,
+    \cite[\S II.C, line~246]{Cirac2016MPDO_arXiv} normalization holds,
     \[
         \forall (j,q),\ |\mu_{j,q}| \le 1,
         \qquad
@@ -539,7 +539,7 @@ factorization is assumed.
         \sum_{j=1}^{g} \left(\sum_{q=1}^{r_j} \mu_{j,q}^N\right)
         V^{(N)}(P_j)_\sigma,
     \]
-    matching \cite[\S~II.C, lines~271--301]{Cirac2017MPDO_AnnPhys}
+    matching \cite[\S~II.C, lines~271--301]{Cirac2016MPDO_arXiv}
     and \cite[Definition~4.2, Proposition~4.3, and lines~1864--1884]
     {Cirac2021Matrix}.
     The line-246 normalization admits every example of the source paper
@@ -560,7 +560,7 @@ factorization is assumed.
     \]
     This is
     \cite[two-layer BNT and coefficient-expansion displays,
-        lines~287--301]{Cirac2017MPDO_AnnPhys} and
+        lines~287--301]{Cirac2016MPDO_arXiv} and
     \cite[lines~1864--1884]{Cirac2021Matrix}.
 \end{lemma}
 
@@ -574,7 +574,7 @@ factorization is assumed.
     \leanok
     \uses{lem:sector_bnt_coeff_eq_sum_weight_pow}
     Under the optional global modulus normalization
-    \cite[\S II, lines~217--246]{Cirac2017MPDO_AnnPhys}, every raw weight satisfies
+    \cite[\S II, lines~217--246]{Cirac2016MPDO_arXiv}, every raw weight satisfies
     $|\mu_{j,q}| \le 1$, and the triangle inequality bounds
     the norm of the sector coefficient by the multiplicity:
     \[
@@ -597,10 +597,10 @@ factorization is assumed.
     $O_{P_j P_k}(N) \to 0$ as $N \to \infty$, where $P_j$ and $P_k$ are the
     basis blocks at indices $j$ and $k$. The argument follows the
     normal-tensor overlap dichotomy of
-    \cite[lines~1080--1091]{Cirac2017MPDO_AnnPhys}: differing bond dimensions
+    \cite[lines~1080--1091]{Cirac2016MPDO_arXiv}: differing bond dimensions
     force decay, and matching bond dimensions are ruled out by the
     gauge-phase distinctness clause of
-    \cite[lines~264--279]{Cirac2017MPDO_AnnPhys}.
+    \cite[lines~264--279]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -626,7 +626,7 @@ factorization is assumed.
         \bigl\{\ket{V^{(N)}(Q_k)}\bigr\}_{k=1}^{g_Q}
     \]
     is linearly independent for all sufficiently large $N$. This is the
-    corollary at \cite[lines~1121--1132]{Cirac2017MPDO_AnnPhys}, matching
+    corollary at \cite[lines~1121--1132]{Cirac2016MPDO_arXiv}, matching
     the BNT linear-independence input recorded at
     \cite[line~1850]{Cirac2021Matrix}.
 \end{lemma}
@@ -645,7 +645,7 @@ factorization is assumed.
     \leanok
     \uses{def:sector_bnt_cf, lem:sector_bnt_norm_coeff_le_copies}
     Under the BNT canonical form, the
-    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization yields
+    \cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv} normalization yields
     directly
     \[
         \bigl| c_N^{(j)} \bigr| \le r_j
@@ -665,7 +665,7 @@ factorization is assumed.
     \leanok
     \uses{def:sector_bnt_cf}
     Under the BNT canonical form, the
-    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} unit-modulus existential
+    \cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv} unit-modulus existential
     provides indices $(j_*, q_*)$ with
     $|\mu_{j_*, q_*}| = 1$.
 \end{lemma}
@@ -686,7 +686,7 @@ factorization is assumed.
     $|1| \le 1$ and $|1/2| = 1/2 \le 1$, and the
     unit-modulus existential is witnessed by the first copy with
     weight $1$. This is the
-    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} normalization in
+    \cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv} normalization in
     positive form, applied to the $C \oplus (1/2)C$ example.
 \end{example}
 
@@ -697,7 +697,7 @@ This section formalizes the analytic input that supplies, for any
 sector $j_0$ carrying a unit-modulus weight, the
 ``sector-$j_0$ coefficient does not asymptotically vanish''
 ingredient used in the matching step of
-\cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}.
+\cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}.
 The reduction is to a pure-analytic statement: a finite sum of $N$-th
 powers of complex numbers in the closed unit disk, with at least one
 unit-modulus summand, cannot tend to zero.
@@ -723,8 +723,8 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     sequence $N \mapsto \sum_{q=0}^{r-1} (\mu_q)^N$ does not tend to $0$
     as $N \to \infty$. This is the analytic content of the unit-block
     non-decay step at
-    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} and
-    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}.
+    \cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv} and
+    \cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -742,10 +742,10 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
     sector-$j_0$ coefficient $c_N^{(j_0)} = \sum_q \mu_{j_0, q}^N$ does not
     tend to $0$ as $N \to \infty$.
 
-    This reads the \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys}
+    This reads the \cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv}
     normalization sector by sector, together with the convergence use at
     \cite[Appendix ``Proofs of Section MPS'', line~1244]
-    {Cirac2017MPDO_AnnPhys}. The unit-modulus witness is supplied
+    {Cirac2016MPDO_arXiv}. The unit-modulus witness is supplied
     externally (as the hypothesis above) because the source statement is
     global (``at least one of them equals one'' over the two-layer index
     $(j, q)$) and does not pin the witness to a specific sector.
@@ -760,11 +760,11 @@ $c(N) \to 0 \Rightarrow |c(N)|^2 \to 0 \Rightarrow M_T \to 0$.
 
 \begin{remark}
     Used inside the matching theorem of
-    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys} this lemma
+    \cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv} this lemma
     supplies the non-decay step on $c_N^{(j_0)}$. The matching theorem takes
     the unit-modulus sector and witness as explicit parameters, mirroring
     the global character of the source normalization at
-    \cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys}.
+    \cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv}.
 \end{remark}
 
 \subsection{Matched-sector weight multiset equality}
@@ -780,13 +780,13 @@ recovery (Theorem~\ref{thm:power_sum_multiset}), and the
 \emph{matched-sector weight-permutation extractor} upgrading the multiset
 equality to an explicit per-copy indexing. Together they realise the
 $\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ recovery of
-\cite[Appendix MPV proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}. At the source level,
+\cite[Appendix MPV proof, lines~1184--1188]{Cirac2016MPDO_arXiv}. At the source level,
 the preceding block-selection argument supplies the matched normal sectors
-\cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}; the sector-coefficient identity
+\cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}; the sector-coefficient identity
 used here is the equal-MPV coefficient comparison of
-\cite[Appendix MPV proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}, followed by the
-global-gauge assembly in
-\cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}. The coefficient identity
+\cite[Appendix MPV proof, lines~1184--1188]{Cirac2016MPDO_arXiv}, followed by the
+global-gauge construction in
+\cite[Appendix MPV proof, lines~1189--1192]{Cirac2016MPDO_arXiv}. The coefficient identity
 is supplied, in the equal-MPV case, by
 Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase} below. In
 the proportional case it is kept as the remaining hypothesis of
@@ -806,7 +806,7 @@ Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}.
     \]
     Then the per-sector multiplicities agree, $r_{j_0}(P) = r_{\tilde k_0}(Q)$,
     and the rescaled per-copy weight multisets coincide.
-    This is \cite[Appendix MPV proof, lines~1184--1188]{Cirac2017MPDO_AnnPhys}
+    This is \cite[Appendix MPV proof, lines~1184--1188]{Cirac2016MPDO_arXiv}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$ and matching
     multiplicities $r_{a,j} = r_{b,j}$) read on a single matched sector.
 \end{lemma}
@@ -841,7 +841,7 @@ Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}.
         \nu_{\tilde k_0, \tau(q)} = \zeta^{-1} \cdot \mu_{j_0, q}.
     \]
     This is the per-copy realisation of
-    \cite[Appendix MPV proof, line~1188]{Cirac2017MPDO_AnnPhys}
+    \cite[Appendix MPV proof, line~1188]{Cirac2016MPDO_arXiv}
     ($\mu_{j,q} = \nu_{j,q} \cdot e^{i\varphi_j}$): the multiset equality
     from Lemma~\ref{lem:sector_bnt_matched_sector_weight_multiset_eq} is
     upgraded to a concrete indexing between the matched $P$- and
@@ -871,7 +871,7 @@ unit-modulus copy weight.
 
 The per-sector unit-weight hypothesis is the formal version used in the
 current full-basis theorem:
-\cite[\S~II.C, line~246]{Cirac2017MPDO_AnnPhys} records the
+\cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv} records the
 modulus-one hypothesis as a single \emph{global} existential over the
 two-layer $(j, q)$ index of the BNT display, whereas the statement below
 assumes the corresponding witness in each sector. This is why the result is
@@ -905,7 +905,7 @@ basis, assuming the same per-sector unit-weight condition on both sides.
     \uses{lem:sector_bnt_combined_family_eventually_li,
         lem:sector_bnt_coeff_not_tendsto_zero_at_unit_block}
     The contrapositive of
-    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}, combined with
+    \cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}, combined with
     linear independence on the full family
     $\{P_j\}_j \cup \{Q_k\}_k$, is iterated externally over each sector
     $k$. Each iteration is discharged by the full-basis weak existential
@@ -927,7 +927,7 @@ basis, assuming the same per-sector unit-weight condition on both sides.
     (Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}) on the
     \emph{full} family $\{P_j\}_j \sqcup \{Q_k\}_k$, the corollary
     input of \cite[Appendix MPV corollary, lines~1131--1133]
-    {Cirac2017MPDO_AnnPhys}, not
+    {Cirac2016MPDO_arXiv}, not
     on any partial union.
 \end{remark}
 
@@ -935,7 +935,7 @@ basis, assuming the same per-sector unit-weight condition on both sides.
 \label{subsec:sector_bnt_strong_match_bijective_symmetry}
 
 This subsection derives the symmetry argument of
-\cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}:
+\cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}:
 $g_a \ge g_b$ and $g_b \ge g_a$ together imply $g_a = g_b$.
 
 The strong existential matching theorem
@@ -946,13 +946,13 @@ $P$ and $Q$ swapped, using the corresponding per-sector hypothesis on $P$ and
 the symmetric flip of the same-MPV hypothesis, gives the other
 direction. The two matchings, combined with the basis-distinctness clause of
 the canonical-form predicate
-\cite[\S~II.C, lines~264--279]{Cirac2017MPDO_AnnPhys}, force injectivity
+\cite[\S~II.C, lines~264--279]{Cirac2016MPDO_arXiv}, force injectivity
 in both directions.
 
 \paragraph{Scope.}
 The literal source conclusion ``$g_a = g_b$ and a relabelling
 $B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$''
-(\cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys}) is formalized
+(\cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}) is formalized
 below under the explicit per-sector unit-weight hypotheses
 \[
     \forall j\in J(P),\ \exists q,\ |\mu_{j,q}|=1,
@@ -1001,7 +1001,7 @@ separately in the following subsection.
     dimension equality
     $\dim_Q(k_1) = \dim_Q(k_2)$. The basis-distinctness clause of the
     canonical-form predicate on $Q$
-    (\cite[\S~II.C, lines~264--279]{Cirac2017MPDO_AnnPhys}) then forces
+    (\cite[\S~II.C, lines~264--279]{Cirac2016MPDO_arXiv}) then forces
     $k_1 = k_2$. Backward injectivity is symmetric.
 
     \emph{Bijection.} The two injections give equality of the two finite
@@ -1015,7 +1015,7 @@ separately in the following subsection.
 
 The matching theorem above gives the sector phases and gauges. The remaining
 coefficient comparison is the step at
-\cite[Appendix MPV proof, lines~1187--1188]{Cirac2017MPDO_AnnPhys}. In the
+\cite[Appendix MPV proof, lines~1187--1188]{Cirac2016MPDO_arXiv}. In the
 equal-MPV setting, the full BNT basis and eventual linear independence give the
 comparison directly. In the proportional setting below, the same comparison
 is recorded as the explicit hypothesis needed before the copy weights can be
@@ -1069,8 +1069,8 @@ matching covers the whole BNT basis.
     \]
     This records the per-block phase conclusion of
     \cite[Appendix MPV theorem statement, lines~1167--1170]
-    {Cirac2017MPDO_AnnPhys}; the proof step at
-    \cite[Appendix MPV proof, line~1182]{Cirac2017MPDO_AnnPhys} is the
+    {Cirac2016MPDO_arXiv}; the proof step at
+    \cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv} is the
     corresponding argument. The following coefficient-comparison step is
     separate.
     % Scope restriction documented in
@@ -1118,7 +1118,7 @@ matching covers the whole BNT basis.
         \zeta_k^N\,c_N^{(k)}(Q).
     \]
     This is the coefficient-comparison step of
-    \cite[Appendix MPV proof, lines~1187--1188]{Cirac2017MPDO_AnnPhys} in full-basis
+    \cite[Appendix MPV proof, lines~1187--1188]{Cirac2016MPDO_arXiv} in full-basis
     form.
 \end{lemma}
 
@@ -1164,7 +1164,7 @@ matching covers the whole BNT basis.
         c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q).
     \]
     This is the full-basis equal-MPV coefficient comparison of
-    \cite[Appendix MPV proof, lines~1187--1188]{Cirac2017MPDO_AnnPhys}.
+    \cite[Appendix MPV proof, lines~1187--1188]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1192,7 +1192,7 @@ matching covers the whole BNT basis.
         \nu_{k,q}=\zeta_k^{-1}\,\mu_{\beta(k),\tau_k(q)}.
     \]
     This is the copy-level conclusion supplied by the equal-MPV coefficient comparison in
-    \cite[Appendix MPV proof, line~1188]{Cirac2017MPDO_AnnPhys}. For the
+    \cite[Appendix MPV proof, line~1188]{Cirac2016MPDO_arXiv}. For the
     proportional theorem it remains the separate coefficient-comparison input.
 \end{definition}
 
@@ -1215,7 +1215,7 @@ matching covers the whole BNT basis.
         \nu_{k,q}=\zeta_k^{-1}\,\mu_{\beta(k),\tau_k(q)}.
     \]
     This is, sector by sector, the content of the coefficient comparison in
-    \cite[Appendix MPV proof, line~1188]{Cirac2017MPDO_AnnPhys}.
+    \cite[Appendix MPV proof, line~1188]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1260,8 +1260,8 @@ matching covers the whole BNT basis.
         \qquad
         X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
     \]
-    This is the direct-sum gauge assembly of
-    \cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}, separated from
+    This is the direct-sum gauge construction of
+    \cite[Appendix MPV proof, lines~1189--1192]{Cirac2016MPDO_arXiv}, separated from
     the coefficient-comparison step that supplies the weight identities.
 \end{theorem}
 
@@ -1468,7 +1468,7 @@ matching covers the whole BNT basis.
     \]
     for every physical index $i$. This is the explicit direct-sum gauge
     construction of
-    \cite[Appendix MPV proof, lines~1189--1192]{Cirac2017MPDO_AnnPhys}.
+    \cite[Appendix MPV proof, lines~1189--1192]{Cirac2016MPDO_arXiv}.
     % Scope restriction documented in
     % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 \end{theorem}
@@ -1509,7 +1509,7 @@ matching covers the whole BNT basis.
     matrices in $\MN{D}$ using the total bond-dimension equality. This is the
     normalized BNT form of
     \cite[Corollary~II.2 and Appendix MPV proof, lines~1189--1192]
-    {Cirac2017MPDO_AnnPhys}, under the same unit-modulus-copy normalization
+    {Cirac2016MPDO_arXiv}, under the same unit-modulus-copy normalization
     as Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
     % Scope restriction documented in
     % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1020,9 +1020,19 @@ Chapter~\ref{ch:algebraic_ft}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:gauge_phase_equiv, def:irreducible_tensor}
-    Primitivity forces the peripheral spectrum to consist of $\{1\}$ alone,
-    so the gauge phase must have modulus one.
+    \uses{thm:gauge_phase_mpv_scaling}
+    The gauge-phase equivalence $B^i = \zeta\,X A^i X^{-1}$ scales every MPV
+    coefficient by $\zeta^N$,
+    \[
+        V^{(N)}(B)_\sigma = \zeta^N\,V^{(N)}(A)_\sigma,
+    \]
+    so the self-overlaps satisfy
+    \[
+        O_{BB}(N) = |\zeta|^{2N}\,O_{AA}(N).
+    \]
+    For primitive irreducible trace-preserving blocks the self-overlaps
+    converge in modulus, $\|O_{AA}(N)\|\to 1$ and $\|O_{BB}(N)\|\to 1$, so
+    $|\zeta|^{2N}\to 1$, which forces $|\zeta|=1$.
 \end{proof}
 
 \begin{theorem}[Existential BNT independence from overlap limits]%


### PR DESCRIPTION
### Motivation

- The CPSV16 BNT and FT blueprint prose should be a single source of truth for the current multi-copy `SectorBNT` route, not for the retired one-copy/strict-modulus roadmap.
- Erickson's May 2026 review notes identified several blueprint-status and prose issues around source faithfulness, BNT multiplicities, and the proportional theorem boundary.
- The remaining proportional matched-coefficient identity is still open and tracked by #1749; this PR makes the documentation state that boundary explicitly.

### Description

- Adds an audit note, `blueprint/comments202605/blueprint_cf_ft_audit_20260530.md`, summarizing which CF/BNT/FT blueprint concerns are documentation defects and which are genuine remaining mathematics.
- Adds `blueprint/comments202605/STATUS_erickson_items_20260530.md`, an item-by-item status ledger for the review comments.
- Updates Chapter 8 to correct the fixed-point statement, use the single-copy terminology, and mark the unsupported trivial-sector theorem as not ready.
- Updates Chapter 10 citations to the arXiv CPSV16 source key and adjusts BNT prose around paired bases, source lines, and gauge construction.
- Updates Chapter 11 to make the unit-phase argument formula-driven through self-overlap scaling.

### Testing

- `git diff --check origin/main...HEAD`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch10_bnt.tex blueprint/src/chapter/ch11_fundamental_theorem_proof.tex blueprint/comments202605/STATUS_erickson_items_20260530.md blueprint/comments202605/blueprint_cf_ft_audit_20260530.md`
- `cd blueprint && leanblueprint web` (passes with the repository's existing plasTeX renderer warnings for project-specific commands)

Addresses #1685.
Refs #1749, #1565.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX and markdown; no Lean or runtime behavior changes. Remaining math gaps stay explicitly `\notready` or in audit notes.
> 
> **Overview**
> Adds two **2026-05-30** maintainer notes under `blueprint/comments202605/`: an Erickson comment **status ledger** and a **CF/BNT/FT audit** that distinguish resolved architecture from remaining gaps (#1749, global vs per-sector unit witness).
> 
> **Chapter 8** corrects the PGVWC07 transfer-map fixed-point wording to *scalar multiples of* `\Id`, renames *granular* → **single-copy** sector decomposition, and marks `thm:bnt_trivial_sector` as `\notready` with a cleaner statement (no stray `P`).
> 
> **Chapter 10** retargets CPSV16 line citations to `Cirac2016MPDO_arXiv`, and tightens BNT prose (*paired basis*, *gauge construction* vs *assembly*).
> 
> **Chapter 11** replaces the hand-wavy unit-modulus gauge-phase proof with the **self-overlap scaling** argument (`O_{BB}(N)=|\zeta|^{2N}O_{AA}(N)` and limits → `|\zeta|=1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6b64518f91d76d46f2aeeab76774b3826bb999. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->