### PR TITLE
doc(PEPS): update normal route obligations ledger

### DIFF
--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -285,8 +285,12 @@ rather than repeat this status in full.
 The following part of the formalization is already present.
 \begin{itemize}
     \item Region injectivity is represented by
-          \leanid{TNLean.PEPS.RegionInjectivityData}, with region complements
-          and the finite-region union-closure hypothesis.
+          \leanid{TNLean.PEPS.RegionInjectivityData}; the same infrastructure
+          contains the region-complement definitions
+          \leanid{TNLean.PEPS.regionComplement} and
+          \leanid{TNLean.PEPS.regionOutsideUnion}, and the finite-region
+          union-closure hypothesis
+          \leanid{TNLean.PEPS.RegionInjectivityUnionClosure}.
     \item The four-region decomposition for Lemma \path{injective_union} is
           formalized both by named regions and by the indexed family
           \(A\setminus B\), \(A\cap B\), \(B\setminus A\), and

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -278,50 +278,61 @@ diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
 \section{Remaining mathematical obligations}
 
 The normal PEPS theorem cannot be obtained by citing the injective theorem
-alone. The list below is the authoritative record of the remaining
-mathematical obligations for the square-lattice normal blocking route. Lean
-docstrings and blueprint entries should point here rather than repeat this
-status in full.
+alone. The lists below are the authoritative record for the square-lattice
+normal blocking route. Lean docstrings and blueprint entries should point here
+rather than repeat this status in full.
+
+The following part of the formalization is already present.
+\begin{itemize}
+    \item Region injectivity is represented by
+          \leanid{TNLean.PEPS.RegionInjectivityData}, with region complements
+          and the finite-region union-closure hypothesis.
+    \item The four-region decomposition for Lemma \path{injective_union} is
+          formalized both by named regions and by the indexed family
+          \(A\setminus B\), \(A\cap B\), \(B\setminus A\), and
+          \((A\cup B)^c\), including the reconstruction, disjointness, and
+          selected-complement identities used by the two inverse applications.
+    \item The abstract contraction-chain criterion for Lemma
+          \path{injective_union} is formalized: if the three implications
+          \[
+              \mathcal C_{\{0,1,2\}}(X)=0
+              \Longrightarrow \mathcal C_{\{2\}}(X)=0
+              \Longrightarrow \mathcal C_{\{1,2\}}(X)=0
+              \Longrightarrow X=0
+          \]
+          are supplied, then the union contraction has trivial kernel.
+    \item The square-lattice coordinate model, contiguous \(2\times3\) and
+          \(3\times2\) rectangles, and the coordinate rectangular-injectivity
+          hypotheses are present.
+    \item The source regions \(R\) and \(S\) are explicit finite coordinate
+          regions, their rectangular decompositions are formalized, and their
+          injectivity follows conditionally from rectangular injectivity and
+          union closure.
+    \item The displayed local \(T\)-region, the finite-lattice
+          edge-complement regions, their sufficient rectangular-cover criteria,
+          the no-cover diagnostics for the present origin-based local models,
+          and the normalized collar decompositions are formalized.
+    \item The one-edge, translated-window, and margin-cover hypotheses
+          for normal edge blocking are present, together with their endpoint,
+          disjointness, coverage, and injective-chain consequences.
+\end{itemize}
+
+The remaining obligations are the following.
 
 \begin{enumerate}
-    \item Define a formal notion of injectivity for a blocked region, not only for
-          a single vertex. The statement must be able to express the regions
-          $A\setminus B$, $A\cap B$, $B\setminus A$, $R$, $S$, $T$, and
-          complements of such regions.
-    \item Prove the union-of-injective-regions lemma. The proof must follow the
-          source proof by applying the left inverses for $A$ and $B$ in sequence.
-    \item Record the square-lattice normal hypotheses. The rectangular
-          injectivity part is expressed for contiguous coordinate
-          $2\times 3$ and $3\times 2$ rectangles; the remaining size data must
-          be tied to the displayed regions and their required complements.
-    \item Prove that the paper's regions $R$, $S$, and $T$ are injective
-          under those hypotheses. Regions $R$ and $S$ are explicit unions of
-          contiguous rectangles, with the displayed rectangular decompositions
-          and the expected one-site difference. Union closure therefore gives
-          their injectivity conditionally on the source union lemma. The local
-          model for $T$ is the complement of the two displayed edge blocks in
-          the source $5\times6$ window; those two blocks have the required
-          rectangular shapes and are injective under rectangular injectivity.
-          Rectangular-cover data give sufficient injectivity criteria for the
-          local $T$ region, the rotated vertical local $T$ region, and the
-          finite-lattice complementary block. The normalized horizontal
-          $5\times7$ and vertical $7\times5$ collar identities show how local
-          or rotated $T$ injectivity implies injectivity of the corresponding
-          edge-complementary block. The same exact-cover criterion has
-          point-forcing obstructions for the present origin-based local $T$
-          models and origin-based edge-complement models in the
-          $5\times6$, $6\times5$, $5\times7$, and $7\times5$ frames. Thus the
-          remaining coordinate work is to align the source local and rotated
-          $T$ covers with the finite PEPS geometry and translate these
-          decompositions around every edge.
-    \item Prove that the edge-centered red, blue, and complementary regions form a
-          three-site injective chain around every edge. The normalized and
-          translated one-edge data supply these chain hypotheses locally,
-          and translated edge windows determine the uniform hypotheses
-          once such a window is available for every edge. The remaining work is
-          the finite-geometry construction of those windows. This is the normal
-          analog of the injective edge-blocking bridge tracked by
-          \ghissue{1366}.
+    \item Prove the tensor-level union-of-injective-regions lemma. The proof
+          must follow the source proof by applying the left inverses for $A$
+          and $B$ in sequence.
+    \item Realign the source proof of injectivity for the local and rotated
+          \(T\)-regions with the finite PEPS geometry. The present exact-cover
+          criterion is a useful sufficient condition, but the recorded
+          point-forcing obstructions show that it is not the source argument
+          for the origin-based local models.
+    \item Prove the every-edge finite-geometry construction. The normalized and
+          translated one-edge data give the desired red, blue, and
+          complementary injective regions when the corresponding window or
+          margin-cover datum is supplied; the remaining task is to construct
+          source-faithful data for every edge, including boundary edges.
     \item Reuse the injective-chain insertion route after this blocking:
           \ghissue{1367}, \ghissue{1368}, \ghissue{1363}, \ghissue{1364},
           \ghissue{1361}, and \ghissue{1360}.


### PR DESCRIPTION
### Motivation

- The paper-gap note `docs/paper-gaps/peps_normal_ft_section3_route.tex` records the remaining obligations for the square-lattice normal blocking route (arXiv:1804.04964, Section 3). Its remaining-obligations section listed formal region-injectivity vocabulary as open, although the current development already contains the region injectivity, decomposition, rectangular-injectivity, and one-edge normal-blocking infrastructure.
- Aligning the note with current Lean development keeps the open-obligations list accurate and focused on genuinely missing results. Continues the normal blocking route formalization tracked in #1373 and the R/S/T injectivity obligations documented in #2004.

### Description

- Modified `docs/paper-gaps/peps_normal_ft_section3_route.tex` to separate completed infrastructure from genuinely remaining mathematical obligations.
- Added an "already present" subsection listing: region injectivity data, four-region union geometry, abstract contraction-chain criterion, square-lattice rectangles with conditional R/S injectivity, local T / edge-complement / no-cover / collar formalization, and one-edge translated blocking hypotheses.
- Shortened the remaining-obligations list to six items: the tensor-level union lemma, source-faithful local and rotated T-injectivity argument, every-edge finite-geometry construction with boundaries, injective-chain insertion route (reusing #1374), TI gauge absorption, and scalar conditions.
- No Lean or blueprint statements are changed. Also refs #1374, #1366, #1252.

### Testing

- `git diff --check`
- Line-length scan for `docs/paper-gaps/peps_normal_ft_section3_route.tex`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files docs/paper-gaps/peps_normal_ft_section3_route.tex`

---
Addresses #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to a LaTeX gap tracker; no code, proofs, or blueprint nodes are modified.
> 
> **Overview**
> The **Remaining mathematical obligations** section in `docs/paper-gaps/peps_normal_ft_section3_route.tex` is reorganized so the normal square-lattice blocking route ledger matches what is already in Lean versus what is still open.
> 
> A new **already present** bullet list documents formalized infrastructure (region injectivity data, four-region `injective_union` geometry, abstract contraction-chain criterion, coordinate rectangles and conditional **R**/**S** injectivity, local **T** / edge-complement / collar / no-cover material, and one-edge translated blocking hypotheses). The **remaining obligations** list is cut from seven broad items to six focused ones: prove the **tensor-level** union lemma, realign source-faithful local/rotated **T** injectivity (beyond the exact-cover sufficient route), build every-edge finite geometry including boundaries, then reuse the injective-chain insertion route, TI gauge absorption, and scalar conditions.
> 
> No Lean or blueprint statements change—only the paper-gap status narrative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa3edcfcd731b4653e422e3f563474ade0b7e131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->