### PR TITLE
doc(PEPS): align normal route conclusion

### DIFF
--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -495,10 +495,15 @@ layer to named proof nodes.\footnote{Chapter~13a calls the public TikZ commands
 
 The normal PEPS route is separated from the injective PEPS route in the
 blueprint and in the GitHub issue tree. The formal proof still remains open:
-the next genuine mathematical step is to introduce blocked-region injectivity
-and prove Lemma \path{injective_union}. Once that lemma and the normal
-edge-blocking hypotheses are formalized, the downstream proof should reuse the
-injective edge-insertion route rather than duplicate it.
+the region-injectivity vocabulary, the four-region decomposition, and the
+abstract contraction-chain criterion are present, but the tensor-level proof of
+Lemma \path{injective_union} is not. The next genuine mathematical steps are
+that tensor-level union lemma, the source-faithful local and rotated
+$T$-injectivity argument, and the every-edge finite-geometry construction.
+After these normal blocking hypotheses are proved, the downstream proof should
+reuse the injective edge-insertion route rather than duplicate it. The
+translationally invariant gauge absorption and the scalar condition remain the
+final steps of the normal theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

The PEPS normal route note now separates completed infrastructure from remaining obligations in its main status section. Its conclusion still used the old summary, saying that the next mathematical step was to introduce blocked-region injectivity, although that vocabulary and the associated finite-region geometry are already present.

### Description

This PR updates only the conclusion of `docs/paper-gaps/peps_normal_ft_section3_route.tex` so it agrees with the status section. The conclusion now says that the region-injectivity vocabulary, four-region decomposition, and abstract contraction-chain criterion are present, while the tensor-level union lemma, source-faithful local and rotated `T`-injectivity argument, and every-edge finite geometry remain open.

No Lean or blueprint statements are changed.

### Testing

- `git diff --check`
- Line-length scan for `docs/paper-gaps/peps_normal_ft_section3_route.tex`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files docs/paper-gaps/peps_normal_ft_section3_route.tex`

---
Addresses #2004
Addresses #1373