### PR TITLE
doc(PEPS): centralize injective route status

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -504,10 +504,10 @@ obtained by blocking $V\setminus\{u,v\}$ form an injective three-site chain.
 Source: arXiv:1804.04964, Section 3, eq:block_to_mps,
 `Papers/1804.04964/paper_normal.tex`, lines 979--1009.
 
-**Proof status:** This declaration states the source assertion. The missing
-proof is the finite-region contraction theorem saying that contracting
-vertex-injective tensors over the middle region gives an injective blocked
-tensor; it is tracked by issue #1366. -/
+**Proof status:** This declaration states the source assertion. The current
+formal reductions and the remaining finite-region contraction theorem are
+recorded in `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section
+"Remaining mathematical obligations". -/
 theorem IsVertexInjective.edgeBlockedThreeSiteInjective {A : Tensor G d}
     (hA : IsVertexInjective A) (e : Edge G) :
     EdgeBlockedThreeSiteInjective (G := G) A e := by

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -5,9 +5,9 @@ import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 -- The contraction algebra is proved. The remaining converse ingredients are
--- separated by mathematical role: edge-centred gauge extraction (#780), the
--- bond-dimension equality from `SameState` and vertex injectivity (#874), and
--- uniqueness modulo balanced edge scalars (#842). The hypothesis
+-- separated by mathematical role in
+-- `docs/paper-gaps/peps_injective_ft_section3_route.tex` and
+-- `docs/paper-gaps/peps_gauge_edge_scalars.tex`. The hypothesis
 -- `IsVertexInjective` is the linear-independence formulation from `PEPS.Defs`,
 -- which gives the local left inverses used below.
 
@@ -17,8 +17,8 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 **Root-only.** This module is currently not imported downstream — it
 records the full statement of the PEPS Fundamental Theorem
 (arXiv:1804.04964 §3, Theorem 2), with the forward bond-dimension
-obligation and converse gaps documented explicitly.  See issue #1512 for
-the root-only audit.
+obligation and converse gaps documented in the paper-gap notes cited below.
+The separate root-only audit is tracked by issue #1512.
 
 This file develops the Fundamental Theorem for injective PEPS on simple graphs
 (arXiv:1804.04964, Theorem 2, Section 3):
@@ -570,9 +570,10 @@ This theorem records the global-gauge conclusion needed by the injective PEPS
 Fundamental Theorem under the already separated bond-dimension equality
 hypothesis.
 
-**Proof status:** The statement is still open. It depends on the edge-blocked
-three-site injective MPS comparison and the passage from the source insertion
-identity to the factorized local gauge formula; see issue #780. -/
+**Proof status:** The statement is still open. The edge-blocked route and the
+remaining insertion-to-gauge obligations are recorded in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
+mathematical obligations". -/
 theorem gaugeConsistency (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B)
     (hAB : SameState A B)
@@ -589,7 +590,8 @@ theorem gaugeConsistency (A B : Tensor G d)
   -- The key remaining consistency step is: for each edge e = (u,v), the gauges
   -- extracted from u and v must agree as inverse-transposes, with the
   -- orientation convention in `edgeGaugeAt`.
-  -- Proof obligation tracked by #780.
+  -- The current status is recorded in
+  -- `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
   sorry
 
 /-! ### Main theorem -/
@@ -602,9 +604,9 @@ states and vertex injectivity imply the gauge formula
 `B_v = gaugeVertex A X v` for one invertible matrix `X_e` on each edge.
 
 **Proof status:** This theorem is proved from the conditional global-gauge
-statement `gaugeConsistency`. The source theorem does not assume matching bond
-dimensions separately; removing `hDim` requires the boundary-insertion argument
-tracked by issue #874. -/
+statement above. The remaining difference from the source theorem is recorded
+in `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
+mathematical obligations". -/
 theorem fundamentalTheorem_PEPS_of_bondDim (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B)
     (hAB : SameState A B) (hDim : A.bondDim = B.bondDim) :
@@ -620,9 +622,9 @@ and have the same state coefficients, then there are invertible edge matrices
 endpoint action of the matrices `X_e` on the incident virtual legs.
 
 **Proof status:** The theorem is stated with the source's hypothesis set. The
-remaining formal proof obligations are the bond-dimension equality from
-`SameState` and vertex injectivity (#874), and the edge-centred gauge extraction
-recorded in `gaugeConsistency` (#780). -/
+remaining bond-dimension and edge-centred gauge obligations are recorded in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
+mathematical obligations". -/
 theorem fundamentalTheorem_PEPS (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B)
     (hAB : SameState A B) :
@@ -631,7 +633,8 @@ theorem fundamentalTheorem_PEPS (A B : Tensor G d)
   -- insertions. Linear independence at each vertex (`IsVertexInjective`) gives
   -- the right local data, while the global comparison still requires a
   -- boundary-insertion / blocking lemma.
-  -- Proof obligation tracked by #874.
+  -- The current status is recorded in
+  -- `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
   have hDim : A.bondDim = B.bondDim := by
     sorry
   -- With matching bond dimensions, `gaugeConsistency` supplies the global gauges.
@@ -939,7 +942,7 @@ see `docs/paper-gaps/peps_gauge_edge_scalars.tex`.
 **Proof status:** The proof has been reduced to equality of products of
 incident edge-gauge entries at each vertex. The remaining step extracts the
 local scalar ratios and reconciles them into one vertex-balanced edge-scalar
-family; see issue #842. -/
+family; see `docs/paper-gaps/peps_gauge_edge_scalars.tex`. -/
 theorem gauge_unique_mod_edge_scalars (A B : Tensor G d)
     (hA : IsVertexInjective A)
     (hDim : A.bondDim = B.bondDim)
@@ -975,7 +978,8 @@ theorem gauge_unique_mod_edge_scalars (A B : Tensor G d)
   -- `IsVertexBalanced c`. This is the local scalar-ratio argument of
   -- arXiv:1804.04964 Section 3; it is independent of the virtual-insertion and
   -- blocking lemmas used for local gauge existence.
-  -- Proof obligation tracked by #842.
+  -- The current status is recorded in
+  -- `docs/paper-gaps/peps_gauge_edge_scalars.tex`.
   sorry
 
 end PEPS

--- a/TNLean/PEPS/InsertionAlgebra.lean
+++ b/TNLean/PEPS/InsertionAlgebra.lean
@@ -72,10 +72,10 @@ matrix insertions on the chosen bond of the first blocked chain correspond, by
 an algebra isomorphism, to matrix insertions on the chosen bond of the second
 blocked chain, and the corresponding inserted coefficients agree.
 
-**Proof status:** This declaration states the source theorem. The proof uses the
-already formalized virtual-to-physical realization at the two vertices, the
-physical-to-virtual recovery step tracked by issue #1370, and the
-uniqueness/bijection argument in Lemma inj_isomorph. Tracked by issue #1367. -/
+**Proof status:** This declaration states the source theorem. The available
+components and remaining implications are recorded in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
+mathematical obligations". -/
 theorem isEdgeBlockedInsertionAlgebraIsomorphism
     (A B : Tensor G d) (e : Edge G)
     (hA : EdgeBlockedThreeSiteInjective (G := G) A e)

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -142,7 +142,9 @@ Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, equations
 eq:resonate--eq:O->X, lines 355--486 of the local paper source.
 
 **Proof status:** This declaration states the source recovery step used by the
-insertion-algebra theorem. Its proof is tracked by issue #1370. -/
+insertion-algebra theorem. The current formal status is recorded in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
+mathematical obligations". -/
 theorem physical_to_virtual_insertion
     (A : Tensor G d) (e : Edge G)
     (hA : EdgeBlockedThreeSiteInjective (G := G) A e)

--- a/TNLean/PEPS/TwoInjectiveComparison.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison.lean
@@ -140,10 +140,9 @@ coefficient for the `A`-pair and the `B`-pair, then there is a nonzero scalar
 `λ` such that `A₁ = λ B₁` and `A₂ = λ⁻¹ B₂`.
 
 **Proof status:** This is the main comparison theorem recorded in this file.
-The proof follows the paper's argument: use injectivity to apply the inverse of
-one tensor, reduce the residual virtual operators by the scalar-reduction step
-recorded in the blueprint as `thm:peps_twoInjectiveGaugeScalarReduction`, and
-then apply the same argument to the other tensor. Tracked by issue #1361. -/
+The scalar-reduction substep and the remaining comparison argument are recorded
+in `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
+mathematical obligations". -/
 theorem two_injective_tensor_insertion_comparison
     {External₁ External₂ Physical₁ Physical₂ : Type*}
     [Nonempty Bond] [Nonempty External₁] [Nonempty External₂]
@@ -155,7 +154,8 @@ theorem two_injective_tensor_insertion_comparison
     TwoBlockReciprocalScalarProportional A₁ B₁ A₂ B₂ := by
   -- The remaining proof is Lemma inj_equal_tensors_2 from
   -- arXiv:1804.04964, Section 3, lines 1068--1203. It depends on the
-  -- scalar-reduction substep tracked separately by issue #1362.
+  -- scalar-reduction substep recorded in
+  -- `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
   sorry
 
 /-! ### One vertex against its complement -/

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -107,7 +107,9 @@ reindex the finite inserted-boundary sum along the diagonal.
 \section{Remaining mathematical obligations}
 
 The following statements are still needed before the injective PEPS Fundamental
-Theorem can be proved in the manner of the paper.
+Theorem can be proved in the manner of the paper.\footnote{This list and the
+ledger below are the status record referenced by the Section~3 docstrings and
+blueprint comments.}
 
 \begin{enumerate}
 \item Vertex injectivity must be shown to pass to the edge-blocked three-site
@@ -143,7 +145,8 @@ Theorem can be proved in the manner of the paper.
   applying this to all edges satisfying $M_e\ne\varnothing$ gives
   \path{thm:peps_edgeBlockedThreeSiteInjective_all_of_singletons}.
   The graph-cardinality variant
-  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.edgeBlockedThreeSiteInjective_all_two_lt_card}
+  \leanid{TNLean.PEPS.EdgeMiddleRegionInjectivityComparison.%
+edgeBlockedThreeSiteInjective_all_two_lt_card}
   packages the common case $2<|V|$: since $|M_e|=|V|-2>0$ for every edge,
   the nonempty-middle hypothesis is automatic.
   Vertex injectivity supplies the two endpoint assertions by
@@ -247,6 +250,11 @@ Theorem can be proved in the manner of the paper.
   uses the abstract two-block notation with nonempty external boundary spaces;
   the source comparison is obtained from the one-vertex and complement blocks
   after \path{eq:inj_equal_edge}.
+\item The boundary-insertion argument must remove the separate
+  bond-dimension-identification hypothesis in
+  \leanid{TNLean.PEPS.fundamentalTheorem_PEPS_of_bondDim}. This is the
+  remaining difference between that conditional theorem and the source theorem;
+  it is tracked by issue~\#874.
 \end{enumerate}
 
 \section{Source-to-formalization ledger}
@@ -309,7 +317,7 @@ It is meant to prevent the proof from drifting away from the source argument.
   The source proof is tracked by issue~\#1360.
 \item Final gauge equivalence and uniqueness:
   \path{thm:fundamentalTheorem_PEPS_of_bondDim} and the uniqueness theorem,
-  tracked by issues~\#780 and~\#842.
+  tracked by issues~\#780, \#842, and the boundary-insertion issue~\#874.
 \end{itemize}
 
 \section{Blueprint diagrams}


### PR DESCRIPTION
### Motivation

- Docstrings and comments in `TNLean/PEPS/*.lean` were each enumerating GitHub issues to record open proof obligations, scattering status across multiple files and making the authoritative source unclear.
- `docs/paper-gaps/peps_injective_ft_section3_route.tex` was missing the boundary-insertion step as a recorded obligation; this step is required to remove the `hDim : A.bondDim = B.bondDim` hypothesis from `fundamentalTheorem_PEPS_of_bondDim` (arXiv:1804.04964 §3; see #874).
- Centralizing status in the paper-gap note reduces duplication and provides a single authoritative source for the remaining Section 3 proof obligations.

### Description

- `docs/paper-gaps/peps_injective_ft_section3_route.tex`: declared the *Remaining mathematical obligations* section as the authoritative status ledger for the injective PEPS Section 3 route; added the missing boundary-insertion obligation needed to drop the bond-dimension hypothesis.
- `TNLean/PEPS/EdgeMiddlePhysical.lean`, `InsertionRealization.lean`, `InsertionAlgebra.lean`, `TwoInjectiveComparison.lean`, `FundamentalTheorem.lean`: replaced inline issue-enumeration comments in docstrings with pointers to `peps_injective_ft_section3_route.tex` and `peps_gauge_edge_scalars.tex`.
- No proof bodies changed; all existing `sorry` obligations remain tracked as before.

### Testing

- `lake env lean TNLean/PEPS/EdgeMiddlePhysical.lean`
- `lake env lean TNLean/PEPS/InsertionRealization.lean`
- `lake env lean TNLean/PEPS/InsertionAlgebra.lean`
- `lake env lean TNLean/PEPS/TwoInjectiveComparison.lean`
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`
- `git diff --check`

---
Refs #1366, #1370, #1367, #1361, #1360, #874, #780, #842

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment updates only; no changes to proofs, APIs, or runtime behavior.
> 
> **Overview**
> This PR **centralizes** where open Section 3 PEPS proof work is documented. **Lean docstrings and comments** in `TNLean/PEPS/*` no longer scatter GitHub issue numbers; they point to **`docs/paper-gaps/peps_injective_ft_section3_route.tex`** (“Remaining mathematical obligations”) and **`peps_gauge_edge_scalars.tex`** for gauge uniqueness. **`FundamentalTheorem.lean`**’s module header is aligned the same way.
> 
> The **paper-gap note** is updated to be the **authoritative status ledger** (footnote), and it now **records** the missing **boundary-insertion** step needed to drop **`hDim : A.bondDim = B.bondDim`** from the conditional fundamental theorem (#874). The source-to-formalization ledger mentions that obligation alongside #780 and #842.
> 
> **No proof bodies change**; existing `sorry`s and tracked issues remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f47a789ed4d8d31de39b7e67d68bf2103e151e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->