### PR TITLE
doc(blueprint): centralize BNT dimension hypotheses

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -50,9 +50,9 @@ obtained from primitive blocks).
     blocks $A_k$, possibly empty, such that the globally rescaled tensor
     $s^{-1}A$ has the same MPV coefficients on every positive-length ring as
     \[
-        \bigoplus_k \lambda_k A_k^i.
+        \bigoplus_k \mu_k A_k^i.
     \]
-    The weights are positive and satisfy $1\geq |\lambda_k|$; if the family is
+    The weights are positive and satisfy $1\geq |\mu_k|$; if the family is
     nonempty, then some weight has norm $1$. For each block,
     \[
         \sum_i A_k^i(A_k^i)^\dagger = \Id,
@@ -475,12 +475,10 @@ particular Theorem~\ref{thm:irreducible_action_cumulative_span}.
 
 \section{Canonical form from primitivity}\label{sec:canonical_from_primitivity}
 
-% MAINTAINER: Definition~\ref{def:cf_cpsv} as stated does not list overlap
-% convergence O_{A_k A_k}(N) -> 1 as a separate clause; the prose below and the
-% next remark treat overlap convergence as part of the canonical-form
-% conditions. Reconcile the two presentations (cf. def:is_canonical_form).
-The canonical-form conditions used here include the self-overlap convergence
-$O_{A_k A_k}(N) \to 1$ for each block (cf.\ Definition~\ref{def:cf_cpsv}).
+The self-overlap convergence $O_{A_k A_k}(N) \to 1$ for each block is not part of
+Definition~\ref{def:cf_cpsv}; it is a derived consequence of block normality,
+obtained from the transfer-map gap criterion of Chapter~\ref{ch:spectral}
+(Remark~\ref{rem:primitivity_reduces_assumptions}).
 The CPSV result of this section is Theorem~\ref{thm:blocking_primitivity}:
 blocking an irreducible TP block by the least common multiple of its peripheral
 periods makes the resulting transfer map primitive, removing periodicity.
@@ -1827,7 +1825,7 @@ Chapter~\ref{ch:canonical_after_blocking}.
 
     This definition records the exact-MPV, nonempty-ring part of the PGVWC07
     construction. It does not include the source theorem's upper normalization
-    $1\geq\lambda_k$, which depends on the global spectral-radius normalization
+    $1\geq\mu_k$, which depends on the global spectral-radius normalization
     convention of \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.
 \end{definition}
 

--- a/blueprint/src/chapter/ch09_block_perm.tex
+++ b/blueprint/src/chapter/ch09_block_perm.tex
@@ -5,12 +5,12 @@
 % docs/paper-gaps/pgvwc07_ti_uniqueness_scope.tex; the same-structure
 % lemmas below are not the PGVWC07 uniqueness theorem
 % (\cite[Theorem~thm-uniq, lines~1002--1015]{PerezGarcia2007Matrix}).
-This chapter records three reduction outputs: the algebra-automorphism
-decomposition Theorem~\ref{thm:pi_auto_decomp}; the per-block linear-extension
-product automorphism Theorem~\ref{thm:pi_linear_ext}; and the strict-weight
-block separation Lemmas~\ref{lem:block_sep} and~\ref{lem:block_sep_normal},
-together with the canonical-form gauge comparison
-Lemma~\ref{lem:ft_canonical}.
+This chapter records two reduction outputs: the algebra-automorphism
+decomposition Theorem~\ref{thm:pi_auto_decomp}; and the strict-weight block
+separation Lemmas~\ref{lem:block_sep} and~\ref{lem:block_sep_normal}, together
+with the canonical-form gauge comparison Lemma~\ref{lem:ft_canonical}.  The
+per-block linear-extension construction is stated once in
+Chapter~\ref{ch:algebraic_ft}, Section~\ref{sec:pi_algebra}.
 
 \section{Block permutation algebra}
 
@@ -147,59 +147,6 @@ Lemma~\ref{lem:ft_canonical}.
 
     This is a standard result in the theory of semisimple algebras;
     see~\cite[Section~IV.A]{Cirac2021Matrix} for the MPS context.
-\end{proof}
-
-\section{Product algebra linear extension}
-
-\begin{definition}[Per-block linear extension]\label{def:per_block_linear_ext}
-    \lean{MPSTensor.perBlockLinearExtension}
-    \leanok
-    \uses{def:injective, def:same_mpv}
-    Given injective tensors $A_k, B_k$ of bond dimension~$D_k$
-    with the same MPV for each block~$k$,
-    the \emph{per-block linear extension} $T_k$ is the unique
-    linear map $\MN{D_k} \to \MN{D_k}$ satisfying
-    $T_k(A_k^i) = B_k^i$ for all~$i$.
-    It exists (and is unique) because $\{A_k^i\}$ spans
-    $\MN{D_k}$ by injectivity.
-\end{definition}
-
-\begin{definition}[Product algebra automorphism]\label{def:pi_alg_equiv}
-    \lean{MPSTensor.piAlgEquiv}
-    \leanok
-    \uses{def:per_block_linear_ext}
-    The \emph{product algebra automorphism} is the componentwise map
-    $T : \prod_k \MN{D_k} \to \prod_k \MN{D_k}$ defined by
-    $T(M)_k := T_k(M_k)$.
-    Theorem~\ref{thm:pi_linear_ext} shows that each $T_k$ is a
-    $\C$-algebra homomorphism and that this map is a
-    $\C$-algebra automorphism.
-\end{definition}
-
-\begin{theorem}[Per-block linear extensions define a product algebra automorphism]\label{thm:pi_linear_ext}
-    \lean{MPSTensor.piAlgEquiv_decomposition}
-    \leanok
-    \uses{def:injective, def:per_block_linear_ext}
-    Let $A_k$ and $B_k$ be injective tensors of bond dimension
-    $D_k$ for $k = 1, \ldots, r$, and suppose the per-block
-    same-MPV condition holds.
-    Then the per-block linear extensions $T_k : A_k^i \mapsto B_k^i$
-    define an algebra automorphism of $\prod_k \MN{D_k}$,
-    which decomposes as a permutation $\pi$ with
-    $D_{\pi(k)} = D_k$ and per-block conjugation matrices $X_k$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:linear_ext, thm:linear_ext_mul, lem:linear_map_to_alg,
-        thm:pi_auto_decomp}
-    Each $T_k$ exists uniquely and is multiplicative by
-    Theorems~\ref{thm:linear_ext} and~\ref{thm:linear_ext_mul}.
-    Promotion to algebra homomorphisms
-    (Lemma~\ref{lem:linear_map_to_alg}) and componentwise composition give an
-    algebra automorphism of $\prod_k \MN{D_k}$.
-    Theorem~\ref{thm:pi_auto_decomp} then decomposes this automorphism as a
-    block permutation together with per-block inner automorphisms.
 \end{proof}
 
 \section{Burnside and invariant projections}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -280,8 +280,8 @@ and~\cite{Cirac2021Matrix}.
     \lean{MPSTensor.exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho}
     \leanok
     \uses{def:injective, def:mpv_overlap, def:gauge_phase_equiv}
-    Let $(A_j)_{j=1}^g$ and $(B_j)_{j=1}^g$ be injective families satisfying
-    trace-preserving normalization, with self-overlaps tending to~$1$ and
+    Let $(A_j)_{j=1}^g$ and $(B_j)_{j=1}^g$ be injective families of positive
+    bond dimension satisfying trace-preserving normalization, with self-overlaps tending to~$1$ and
     off-diagonal overlaps tending to~$0$ within each family. If the spans of
     the MPV states agree for every system size $N$, then there is a permutation
     $\pi$ of $\{1, \ldots, g\}$ such that $A_j$ and $B_{\pi(j)}$ have the
@@ -316,7 +316,7 @@ and~\cite{Cirac2021Matrix}.
     \leanok
     \uses{def:injective, def:mpv, def:mpv_overlap, def:gauge_phase_equiv}
     Let $(A_j)_{j=1}^{g_A}$ and $(B_k)_{k=1}^{g_B}$ be two
-    families of injective tensors satisfying the TP normalization
+    families of injective tensors of positive bond dimension satisfying the TP normalization
     $\sum_i (A_j^i)^\dagger A_j^i = \Id$ and
     $\sum_i (B_k^i)^\dagger B_k^i = \Id$, whose self-overlaps
     converge to~$1$ and whose cross-overlaps within each

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -841,6 +841,7 @@ per-block $\mc{V}(A_k) = \mc{V}(B_k)$, one seeks per-block gauge
 equivalence $B_k^i = X_k\, A_k^i\, X_k^{-1}$ for each~$k$
 independently, and a global block-permutation plus inner-automorphism
 decomposition.
+Throughout this section, assume $D_k \ge 1$ for every block~$k$.
 
 \subsection{Per-block linear extension}
 


### PR DESCRIPTION
## Motivation
The CPGSV16/BNT blueprint route should state the mathematical hypotheses that the formal statements actually use, while keeping each tagged construction in one blueprint location.

## Description
- use the BNT weight symbol `μ_k` consistently in Chapter 8 canonical-form prose
- replace the stale overlap-clause maintainer note by the mathematical statement that self-overlap convergence is derived from block normality and the transfer-map gap criterion
- make Chapter 13 the single blueprint owner for the per-block linear-extension and product-algebra automorphism construction
- state the positive block-dimension hypothesis once in the Chapter 13 product-algebra section
- state the positive bond-dimension hypotheses in the Chapter 10 BNT permutation-rigidity statements

## Testing
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --diff-head HEAD --changed-files blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch09_block_perm.tex blueprint/src/chapter/ch10_bnt.tex blueprint/src/chapter/ch13_algebraic_ft.tex`
- duplicate-tag check for `MPSTensor.perBlockLinearExtension`, `MPSTensor.piAlgEquiv`, and `MPSTensor.piAlgEquiv_decomposition`
- `cd blueprint && leanblueprint web` (passes with existing renderer/path warnings)

Refs #1565, #1685, #1753, #1857.