### PR TITLE
refactor(MPS/CanonicalForm): centralize CPSV canonical form

### DIFF
--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Overlap.Basic
-import TNLean.MPS.SharedInfra.BlockAssembly
 import TNLean.Channel.Peripheral.Spectrum
 
 /-!
@@ -19,16 +18,17 @@ operators: Renormalization fixed points and boundary theories"):
 * basis of normal tensors (BNT), `MPSTensor.IsCPSVBasisOfNormalTensors`.
 
 The canonical-form (CF) decomposition of arXiv:1606.00608 eq. `II_CF1` plus the
-normalization paragraph (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`) is
-carried by the strong downstream predicate
-`MPSTensor.IsCanonicalFormSepAux.IsNormalCanonicalForm`; the previously vestigial
-weak duplicate `IsCPSVCanonicalForm` (zero consumers) has been removed.
+normalization paragraph (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`) is not
+introduced here as a separate predicate.  The later normal canonical form
+predicate `MPSTensor.IsCanonicalFormSepAux.IsNormalCanonicalForm` records the
+strengthened form used in the Fundamental Theorem: normal blocks together with
+left-canonical normalization, strict nonzero weights, primitive transfer maps,
+and positive block dimensions.
 
-The existing TNLean canonical-form layer (`TNLean.PiAlgebra.CanonicalFormSepAux`,
-`TNLean.MPS.BNT.Construction`) ships several *strengthenings* of these definitions
-(adding left-canonical normalization, strict modulus ordering, one-copy-per-sector,
-etc.) that are convenient for downstream FT proofs but drift from the paper text.
-The predicates here are the CPSV formulations.
+The existing canonical-form layer (`TNLean.PiAlgebra.CanonicalFormSepAux`,
+`TNLean.MPS.BNT.Construction`) contains several strengthenings of these definitions
+(left-canonical normalization, strict modulus ordering, and one copy per sector).
+The predicates in this file are the CPSV formulations.
 
 ## Paper anchors
 
@@ -61,8 +61,7 @@ One direct connection is provided:
 * `MPSTensor.IsNormalTensor.of_irreducible_and_primitive` —
   combine an `IsIrreducibleTensor` proof with a primitive-transfer-map proof.
 
-A further connection is intentionally **not** provided here, in keeping with the
-"clean layer, no `sorry`" quality bar:
+A further connection is intentionally not provided here:
 
 * A BNT connection `IsCPSVBasisOfNormalTensors.of_isBNT` would require the implication
   `MPSTensor.IsNormal → IsNormalTensor` per block, i.e. from algebraic eventual

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -23,7 +23,9 @@ introduced here as a separate predicate.  The later normal canonical form
 predicate `MPSTensor.IsCanonicalFormSepAux.IsNormalCanonicalForm` records the
 strengthened form used in the Fundamental Theorem: normal blocks together with
 left-canonical normalization, strict nonzero weights, primitive transfer maps,
-and positive block dimensions.
+and positive block dimensions.  The global CPSV normalization
+`‖μ k‖ ≤ 1` with a unit-modulus witness remains a separate source hypothesis
+when it is needed.
 
 The existing canonical-form layer (`TNLean.PiAlgebra.CanonicalFormSepAux`,
 `TNLean.MPS.BNT.Construction`) contains several strengthenings of these definitions

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -9,15 +9,20 @@ import TNLean.MPS.SharedInfra.BlockAssembly
 import TNLean.Channel.Peripheral.Spectrum
 
 /-!
-# Normal tensor, canonical form, and basis of normal tensors (CPSV16)
+# Normal tensor and basis of normal tensors (CPSV16)
 
-This module records the definitions of the three central notions
+This module records the definitions of two of the central notions
 from arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete, "Matrix product density
 operators: Renormalization fixed points and boundary theories"):
 
-* normal tensor (NT), `MPSTensor.IsNormalTensor`,
-* canonical form (CF), `MPSTensor.IsCPSVCanonicalForm`, and
+* normal tensor (NT), `MPSTensor.IsNormalTensor`, and
 * basis of normal tensors (BNT), `MPSTensor.IsCPSVBasisOfNormalTensors`.
+
+The canonical-form (CF) decomposition of arXiv:1606.00608 eq. `II_CF1` plus the
+normalization paragraph (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`) is
+carried by the strong downstream predicate
+`MPSTensor.IsCanonicalFormSepAux.IsNormalCanonicalForm`; the previously vestigial
+weak duplicate `IsCPSVCanonicalForm` (zero consumers) has been removed.
 
 The existing TNLean canonical-form layer (`TNLean.PiAlgebra.CanonicalFormSepAux`,
 `TNLean.MPS.BNT.Construction`) ships several *strengthenings* of these definitions
@@ -30,9 +35,6 @@ The predicates here are the CPSV formulations.
 * `MPSTensor.IsNormalTensor`: `Papers/1606.00608/MPDO-22-12-17-2.tex:233-235`
   (Definition: NT is no nontrivial invariant projector + unique modulus-1
   eigenvalue of the associated CPM equal to its spectral radius equal to one).
-* `MPSTensor.IsCPSVCanonicalForm`: `Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`
-  (Definition: CF is `A^i = ⊕_k μ_k A_k^i` with each `A_k` normal; combined with
-  the normalization paragraph at line 246: `|μ_k| ≤ 1` and at least one `|μ_k| = 1`).
 * `MPSTensor.IsCPSVBasisOfNormalTensors`: `Papers/1606.00608/MPDO-22-12-17-2.tex:271-274`
   (Definition: BNT `{A_j}` of `A` is `A_j` all normal, MPV family of `A`
   spanned by MPV families of the `A_j` at every length, and eventually linearly
@@ -59,13 +61,9 @@ One direct connection is provided:
 * `MPSTensor.IsNormalTensor.of_irreducible_and_primitive` —
   combine an `IsIrreducibleTensor` proof with a primitive-transfer-map proof.
 
-Two further connections are intentionally **not** provided here, in keeping with the
+A further connection is intentionally **not** provided here, in keeping with the
 "clean layer, no `sorry`" quality bar:
 
-* A CF connection `IsCPSVCanonicalForm.of_isNormalCanonicalForm` would need to import
-  `TNLean.PiAlgebra.CanonicalFormSepAux` which transitively imports
-  `TNLean.MPS.FundamentalTheorem.*`; we keep `Definitions.lean` in a clean pre-FT
-  layer. Such a connection belongs in a separate downstream file.
 * A BNT connection `IsCPSVBasisOfNormalTensors.of_isBNT` would require the implication
   `MPSTensor.IsNormal → IsNormalTensor` per block, i.e. from algebraic eventual
   block injectivity to the CPSV16 (no-invariant-proj + primitive-transfer)
@@ -117,70 +115,6 @@ theorem IsNormalTensor.of_irreducible_and_primitive
     IsNormalTensor A :=
   { no_invariant_proj := hIrr
     primitive_transfer := hPrim }
-
-/-! ## Canonical form (CF) -/
-
-/--
-`MPSTensor.CPSVCanonicalFormData A` is the data of a canonical-form
-decomposition of `A` from arXiv:1606.00608 eq. `II_CF1` plus the normalization paragraph
-immediately following (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`):
-
-* a number `r` of blocks,
-* per-block bond dimensions `dim k`,
-* per-block weights `weights k : ℂ`,
-* per-block tensors `blocks k : MPSTensor d (dim k)`, each normal,
-* an MPV-equality witness `A^i = ⊕_k weights k • blocks k^i` at every positive
-  length (encoded as `SameMPV₂Pos A (toTensorFromBlocks weights blocks)`),
-* the bond-dimension identity `D = ∑_k D_k`, which is the length-zero content of
-  the decomposition,
-* modulus normalization `‖weights k‖ ≤ 1` for all `k`, and at least one `‖weights k‖ = 1`.
-
-Full all-length MPV equality is recovered from the positive-length witness and the
-bond-dimension identity through `SameMPV₂Pos.toSameMPV₂_of_bondDim_eq`.
-
-This is **data** (a `Type`); the propositional version is `IsCPSVCanonicalForm` below.
--/
-structure CPSVCanonicalFormData (A : MPSTensor d D) where
-  /-- Number of blocks `r` in the direct-sum decomposition `A^i = ⊕_{k=1}^r μ_k A_k^i`. -/
-  r : ℕ
-  /-- Bond dimensions of the blocks `dim k = D_k`. -/
-  dim : Fin r → ℕ
-  /-- Block weights `μ k` of the decomposition. -/
-  weights : Fin r → ℂ
-  /-- Per-block MPS tensors `A_k`. -/
-  blocks : (k : Fin r) → MPSTensor d (dim k)
-  /-- `A` and the direct sum `⊕_k μ_k A_k` have the same MPV family at every positive
-  length. -/
-  sameMPV : SameMPV₂Pos A (toTensorFromBlocks (d := d) weights blocks)
-  /-- The bond dimension of `A` equals the total bond dimension `∑_k D_k` of the blocks.
-  This is the length-zero content of the decomposition, from which full MPV equality is
-  recovered through `SameMPV₂Pos.toSameMPV₂_of_bondDim_eq`. -/
-  bondDim_eq : D = ∑ k : Fin r, dim k
-  /-- Each block `A_k` is a CPSV16 normal tensor. -/
-  blocks_normal : ∀ k, IsNormalTensor (blocks k)
-  /-- Modulus normalization (`MPDO-22-12-17-2.tex:246`): every weight has modulus at most one. -/
-  weight_norm_le_one : ∀ k, ‖weights k‖ ≤ 1
-  /-- Modulus normalization (`MPDO-22-12-17-2.tex:246`): at least one weight has unit modulus. -/
-  weight_unit_exists : ∃ k, ‖weights k‖ = 1
-
-/--
-`MPSTensor.IsCPSVCanonicalForm A` is the propositional **canonical form**
-predicate from arXiv:1606.00608
-(`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`): `A` admits a normal-block
-direct-sum decomposition with weights normalized to `|μ_k| ≤ 1` and at least one
-`|μ_k| = 1`.
-
-This is `Nonempty (CPSVCanonicalFormData A)` — i.e. existence of a CPSV canonical-form
-decomposition witness.
--/
-def IsCPSVCanonicalForm (A : MPSTensor d D) : Prop :=
-  Nonempty (CPSVCanonicalFormData A)
-
-/-- Promote a CPSV canonical-form data witness to the propositional predicate. -/
-theorem IsCPSVCanonicalForm.of_data
-    {A : MPSTensor d D} (h : CPSVCanonicalFormData A) :
-    IsCPSVCanonicalForm A :=
-  ⟨h⟩
 
 /-! ## Basis of normal tensors (BNT) -/
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -147,22 +147,13 @@ tensors of Chapter~\ref{ch:bnt}.
     normality. Absence of nontrivial invariant projections is essential.
 \end{remark}
 
-\begin{definition}[CPSV canonical form (CF)]\label{def:cf_cpsv}
-    \lean{MPSTensor.IsCPSVCanonicalForm}
-    \leanok
-    A tensor $A$ is in \emph{canonical form} if there is a finite family
-    of normal tensors $A_k$ of physical dimension $d$ and bond dimension $D_k$,
-    and weights $\mu_k \in \C$ for $k = 1,\ldots,r$, such that, for each
-    physical index $i$,
-    \[
-        A^i \cong \bigoplus_{k=1}^r \mu_k\, A_k^i,
-    \]
-    in the sense that $A$ and the weighted direct sum
-    $\bigoplus_{k=1}^r \mu_k A_k$ generate the same MPV family at every positive
-    length, the bond dimensions satisfy $D = \sum_{k=1}^r D_k$, and the weights
-    satisfy the normalization $|\mu_k| \le 1$ for all $k$ and $|\mu_k| = 1$ for at
-    least one $k$.
-\end{definition}
+The CPSV \emph{canonical form} (CF) of a tensor $A$ --- a normal-block
+direct-sum decomposition $A^i \cong \bigoplus_{k=1}^r \mu_k A_k^i$ with weights
+normalized to $|\mu_k| \le 1$ and at least one $|\mu_k| = 1$ --- is the source
+definition of \cite[Section~II.C]{Cirac2017MPDO_AnnPhys}. In TNLean this role is
+played by the strong downstream predicate
+\texttt{MPSTensor.IsCanonicalFormSepAux.IsNormalCanonicalForm}, so no separate
+weak CF predicate is recorded here.
 
 \begin{definition}[CPSV basis of normal tensors (BNT)]\label{def:bnt_cpsv}
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors}
@@ -476,7 +467,8 @@ particular Theorem~\ref{thm:irreducible_action_cumulative_span}.
 \section{Canonical form from primitivity}\label{sec:canonical_from_primitivity}
 
 The self-overlap convergence $O_{A_k A_k}(N) \to 1$ for each block is not part of
-Definition~\ref{def:cf_cpsv}; it is a derived consequence of block normality,
+the CPSV canonical-form definition of \cite[Section~II.C]{Cirac2017MPDO_AnnPhys};
+it is a derived consequence of block normality,
 obtained from the transfer-map gap criterion of Chapter~\ref{ch:spectral}
 (Remark~\ref{rem:primitivity_reduces_assumptions}).
 The CPSV result of this section is Theorem~\ref{thm:blocking_primitivity}:
@@ -485,8 +477,8 @@ periods makes the resulting transfer map primitive, removing periodicity.
 
 \begin{remark}[Two ways to obtain the canonical-form predicate from normal blocks]
     Given a family of injective, left-canonical, strictly-ordered
-    nonzero-weight blocks $(\mu_k, A_k)$, the canonical-form conditions of
-    Definition~\ref{def:cf_cpsv} can be established from either of two
+    nonzero-weight blocks $(\mu_k, A_k)$, the CPSV canonical-form conditions of
+    \cite[Section~II.C]{Cirac2017MPDO_AnnPhys} can be established from either of two
     spectral hypotheses on the per-block transfer map $\E_{A_k}$: a
     positive-definite primitive fixed point, or the peripheral-spectrum
     condition $\sigma_\partial(\E_{A_k}) = \{1\}$. In both cases the

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -147,13 +147,16 @@ tensors of Chapter~\ref{ch:bnt}.
     normality. Absence of nontrivial invariant projections is essential.
 \end{remark}
 
-The CPSV \emph{canonical form} (CF) of a tensor $A$ --- a normal-block
-direct-sum decomposition $A^i \cong \bigoplus_{k=1}^r \mu_k A_k^i$ with weights
-normalized to $|\mu_k| \le 1$ and at least one $|\mu_k| = 1$ --- is the source
-definition of \cite[Section~II.C]{Cirac2017MPDO_AnnPhys}. In TNLean this role is
-played by the strong downstream predicate
-\texttt{MPSTensor.IsCanonicalFormSepAux.IsNormalCanonicalForm}, so no separate
-weak CF predicate is recorded here.
+The CPSV \emph{canonical form} (CF) of a tensor $A$ is the normal-block
+decomposition
+\[
+    A^i \cong \bigoplus_{k=1}^r \mu_k A_k^i
+\]
+with weights normalized by $|\mu_k| \le 1$ and with at least one
+$|\mu_k|=1$; see \cite[Section~II.C]{Cirac2017MPDO_AnnPhys}.  In the
+formal statements below, this condition is used through the stronger normal
+canonical form of Definition~\ref{def:is_normal_canonical_form}, so it is not
+listed as a second definition here.
 
 \begin{definition}[CPSV basis of normal tensors (BNT)]\label{def:bnt_cpsv}
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors}
@@ -180,7 +183,7 @@ weak CF predicate is recorded here.
     stronger predicates of Definition~\ref{def:is_normal_canonical_form} and
     of Chapter~\ref{ch:bnt} require either the fundamental-theorem step or
     the algebraic-to-spectral normality equivalence; these appear in
-    downstream chapters.
+    later chapters.
 \end{remark}
 
 \section{Transfer map normalization}\label{sec:transfer_map_normalization}
@@ -814,7 +817,7 @@ Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
 
 Blocking by an integer~$p$ carries MPV equalities, weights, transfer maps,
 and identifications of the blocked physical alphabet. The consequence needed
-downstream is the existence of a common blocking period under which every
+later is the existence of a common blocking period under which every
 transfer map in a finite family becomes primitive.
 
 \begin{theorem}[Common blocking period for a block family]%

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -983,39 +983,13 @@ repeated-copy sectors do occur: for instance, $A = C \oplus (-C)$ has one normal
 tensor $C$ with weights $1$ and $-1$, and its length-$N$ MPV coefficients are
 $(1 + (-1)^N)\,V^{(N)}(C)_\sigma$, which is not a single scalar power.
 
-\begin{theorem}[Sorting by strictly decreasing weight norms]
-    \label{thm:bnt_sorted_reindexing}
-    Let $(\mu_k)_{k=1}^r$ be nonzero complex weights whose moduli are pairwise
-    distinct. Then there exists a permutation $\sigma$ of $\{1,\ldots,r\}$ such that
-    \[
-        |\mu_{\sigma(1)}| > |\mu_{\sigma(2)}| > \cdots > |\mu_{\sigma(r)}| > 0.
-    \]
-\end{theorem}
-
-\begin{theorem}[Sorted decomposition preserves the represented MPS family]
-    \label{thm:bnt_sorted_blockdecomp}
-    \uses{thm:bnt_sorted_reindexing}
-    Under the same hypothesis, with $\sigma$ as above and
-    $\tilde\mu_k := \mu_{\sigma(k)}$, $\tilde B_k := B_{\sigma(k)}$,
-    \[
-        \mc{V}\!(\textstyle\bigoplus_k \mu_k B_k)
-        =  \mc{V}\!(\textstyle\bigoplus_k \tilde\mu_k \tilde B_k),
-        \qquad |\tilde\mu_1| > \cdots > |\tilde\mu_r|.
-    \]
-\end{theorem}
-
-\begin{theorem}[Normal canonical form after sorting]
-    \label{thm:bnt_sorted_ncf}
-    \uses{def:is_normal_canonical_form, thm:bnt_sorted_blockdecomp}
-    Suppose $(\mu_k, B_k)_{k=1}^r$ satisfies $\mu_k \neq 0$, $|\mu_k|$ pairwise
-    distinct, and each $B_k$ is irreducible, left-canonical
-    ($\sum_i (B_k^i)^\dagger B_k^i = \Id$), with primitive transfer map and
-    $\dim B_k > 0$. Then after sorting by strictly decreasing
-    $|\mu_{\sigma(k)}|$, the resulting family $(\tilde\mu_k, \tilde B_k)$
-    satisfies the normal canonical form conditions of
-    Definition~\ref{def:is_normal_canonical_form}. This is the distinct-modulus,
-    one-copy-per-sector subcase.
-\end{theorem}
+The distinct-modulus, one-copy-per-sector subcase (sorting blocks by strictly
+decreasing weight modulus and matching the normal canonical form one sector at a
+time) is subsumed by the general phase-class BNT sector construction of
+Chapter~\ref{ch:ft_proof}
+(Definition~\ref{def:mpv_phase_class_data},
+Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}), so it is no longer
+recorded as separate sorting theorems here.
 
 \begin{definition}[Single-copy sector decomposition]
     \label{def:trivial_sector_decomp}
@@ -1049,43 +1023,12 @@ $(1 + (-1)^N)\,V^{(N)}(C)_\sigma$, which is not a single scalar power.
     block-sum expression for $\bigoplus_k \mu_k B_k$.
 \end{proof}
 
-\begin{theorem}[Single-copy sector decomposition for the sorted distinct-modulus case]
-    \label{thm:bnt_trivial_sector}
-    \notready
-    \uses{def:trivial_sector_decomp, lem:trivial_sector_decomp_same_mpv}
-    If $\mu_k \neq 0$ for all $k$ and $|\mu_1| > \cdots > |\mu_r|$, then the
-    single-copy sector decomposition associated to $(\mu,B)$ represents the same
-    family as $\bigoplus_k \mu_k B_k$ for every $N \ge 1$ and has exactly one
-    copy per sector. This is the distinct-modulus, one-copy-per-sector subcase.
-\end{theorem}
-
-To remove the artificial distinct-modulus assumption, group blocks by common
-weight modulus. The next two definitions record this grouping; it is the
-mechanism that handles equal-modulus sectors in Chapter~\ref{ch:bnt}.
-
-\begin{definition}[Partition by common weight modulus]
-    \label{def:norm_class_grouping_data}
-    Let $(\mu_k)_{k=1}^r$ be a finite family of complex weights. A
-    \emph{partition by common weight modulus} consists of: a number of classes $s \le r$;
-    representative values $\lambda_1 > \cdots > \lambda_s > 0$;
-    multiplicities $(m_j)_{j=1}^s$ with $\sum_j m_j = r$; for each $j$ an
-    enumeration $\iota_j : \{1,\ldots,m_j\} \hookrightarrow \{1,\ldots,r\}$ of
-    the indices $k$ with $|\mu_k| = \lambda_j$; and the regrouping identity
-    \[
-        \sum_{k=1}^{r} f(k) =  \sum_{j=1}^{s} \sum_{q=1}^{m_j} f(\iota_j(q)),
-    \]
-    for every function $f$.
-\end{definition}
-
-\begin{definition}[Common-modulus enumeration in decreasing order]
-    \label{def:norm_class_grouping}
-    \uses{def:norm_class_grouping_data}
-    For any finite family $(\mu_k)_{k=1}^r$ of complex weights, sorting
-    the distinct moduli $\{|\mu_k| : 1 \le k \le r,\ \mu_k \neq 0\}$ in
-    strictly decreasing order yields a common-modulus partition (in the
-    sense of Definition~\ref{def:norm_class_grouping_data}) with
-    representative values $\lambda_1 > \cdots > \lambda_s$.
-\end{definition}
+The sorted distinct-modulus sector statement and the regrouping of blocks by
+common weight modulus (which handles equal-modulus sectors) are subsumed by the
+phase-class BNT sector construction of Chapter~\ref{ch:ft_proof}
+(Definition~\ref{def:mpv_phase_class_data},
+Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}) and the
+basis-of-normal-tensors development of Chapter~\ref{ch:bnt}.
 
 \section{Scope and BNT input reductions}\label{sec:open_directions}
 
@@ -1100,9 +1043,10 @@ mechanism that handles equal-modulus sectors in Chapter~\ref{ch:bnt}.
     The invariant-subspace decomposition, TP gauges, and one-block period-removal
     statements are recorded above. Chapter~\ref{ch:canonical_after_blocking}
     contains the common-blocking construction, the zero-tail identities, and the
-    common-sector decompositions over one blocked physical alphabet. The
-    distinct-modulus case is covered by the sorted normal-canonical-form theorem
-    (Theorem~\ref{thm:bnt_sorted_ncf}); equal-modulus families require the
+    common-sector decompositions over one blocked physical alphabet. Both the
+    distinct-modulus and the equal-modulus cases are covered by the phase-class
+    BNT sector construction of Chapter~\ref{ch:ft_proof}
+    (Theorem~\ref{thm:bnt_sector_decomp_tp_prim_irr_collapsed}) together with the
     basis-of-normal-tensors and multiplicity comparison developed in
     Chapter~\ref{ch:bnt}.
 \end{remark}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -154,9 +154,10 @@ decomposition
 \]
 with weights normalized by $|\mu_k| \le 1$ and with at least one
 $|\mu_k|=1$; see \cite[Section~II.C]{Cirac2017MPDO_AnnPhys}.  In the
-formal statements below, this condition is used through the stronger normal
-canonical form of Definition~\ref{def:is_normal_canonical_form}, so it is not
-listed as a second definition here.
+statements below, the structural part is supplied by the stronger normal
+canonical form of Definition~\ref{def:is_normal_canonical_form}.  The global
+weight normalization is a separate source hypothesis whenever it is needed, so
+the CPSV canonical form is not listed as a second definition here.
 
 \begin{definition}[CPSV basis of normal tensors (BNT)]\label{def:bnt_cpsv}
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors}


### PR DESCRIPTION
## Motivation
The CPSV canonical-form material should have one mathematical home. The weak `IsCPSVCanonicalForm` predicate duplicated the normal-canonical formulation used by the formal argument, and several unformalized distinct-modulus blueprint entries repeated a special case already covered by the phase-class BNT construction.

## Description
- remove the unused `CPSVCanonicalFormData`, `IsCPSVCanonicalForm`, and `IsCPSVCanonicalForm.of_data` declarations
- keep the CPSV normal tensor and BNT predicates in `TNLean/MPS/CanonicalForm/Definitions.lean`
- replace the Chapter 8 CF blueprint entry by a mathematical paragraph pointing to the stronger normal-canonical condition used below
- remove the untagged distinct-modulus one-copy blueprint statements and common-modulus grouping entries, replacing them by references to the phase-class BNT sector construction
- drop the now-unused `SharedInfra.BlockAssembly` import from the CPSV definitions file

## Testing
- `lake env lean TNLean/MPS/CanonicalForm/Definitions.lean`
- `git diff --check origin/main...HEAD`
- `rg -n "IsCPSVCanonicalForm|CPSVCanonicalFormData|def:cf_cpsv|bnt_sorted_reindexing|bnt_sorted_blockdecomp|bnt_sorted_ncf|bnt_trivial_sector|norm_class_grouping" TNLean docs blueprint/src --glob '!blueprint/src/web/**' --glob '!blueprint/web/**'` (no matches)
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --diff-head HEAD --changed-files TNLean/MPS/CanonicalForm/Definitions.lean blueprint/src/chapter/ch08_canonical.tex`
- `cd blueprint && leanblueprint web` (passes with existing renderer/path warnings)

Refs #1565, #1685, #1857.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and definition cleanup with no remaining references to removed symbols; NT and BNT predicates are unchanged.
> 
> **Overview**
> This PR **removes the weak CPSV canonical-form layer** so canonical form has a single formal home. In `TNLean/MPS/CanonicalForm/Definitions.lean` it deletes `CPSVCanonicalFormData`, `IsCPSVCanonicalForm`, and `IsCPSVCanonicalForm.of_data`, drops the unused `SharedInfra.BlockAssembly` import, and rewrites the module doc to say CPSV CF is described narratively while **`IsNormalCanonicalForm`** (and separate weight-normalization hypotheses) carry the structural predicate used downstream.
> 
> **Chapter 8 blueprint** (`ch08_canonical.tex`) replaces the formal `\label{def:cf_cpsv}` definition with a short CPSV CF paragraph tied to the stronger normal canonical form; it **removes** several unformalized distinct-modulus sorting/grouping theorems and points those cases to the **phase-class BNT sector construction** in the FT proof chapter instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b13f9691a471bbadf261df8c13474626948ecdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->