### PR TITLE
docs(blueprint): relocate sector-decomposition definitions into the BNT chapter

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -512,6 +512,131 @@ factorization is assumed.
 % `SectorDecomposition`. The blueprint prose uses standard mathematical
 % notation; the `\lean{...}` tag below carries the link.
 
+\subsection{Sector decompositions and phase matching}
+\label{sec:bnt_sector_decompositions}
+
+The sector-decomposition data type, the gauge-phase matching predicates, and the
+MPV phase-class apparatus are collected here because they are used both by the
+BNT canonical-form predicate below and by the equal-MPV comparison results in
+Chapter~\ref{ch:ft_proof}.
+
+\begin{definition}[Sector weights and sector decomposition]%
+    \label{def:sector_weight_data}
+    \lean{MPSTensor.SectorWeightData, MPSTensor.SectorDecomposition}
+    \leanok
+    A sector-weight tuple over $g$ basis blocks consists of multiplicities
+    $r_j > 0$, nonzero weights $\mu_{j,q}$ for
+    $q \in \{1,\ldots,r_j\}$, and the sector coefficients
+    \[
+        c_{S,j}^{(N)}
+        :=
+        \sum_{q=1}^{r_j} \mu_{j,q}^N.
+    \]
+    A \emph{sector decomposition} consists of the basis blocks
+    $(A_j)_{j=1}^g$ together with these multiplicities and weights.
+\end{definition}
+
+\begin{definition}[Sector basis matching]%
+    \label{def:sector_basis_matching}
+    \lean{MPSTensor.SectorBasisMatching}
+    \leanok
+    \uses{def:sector_weight_data, def:gauge_phase_equiv}
+    A \emph{sector basis matching} between two sector decompositions $P$ and $Q$
+    consists of
+    \begin{enumerate}
+        \item a basis permutation
+              $\pi : \{1,\ldots,g_P\} \simeq \{1,\ldots,g_Q\}$,
+        \item per-block multiplicity equalities $r_j^P = r_{\pi(j)}^Q$,
+        \item per-block bond-dimension equalities $D_j^P = D_{\pi(j)}^Q$, and
+        \item per-block gauge-phase equivalences $P_j \simeq_{\mathrm{gp}} Q_{\pi(j)}$
+              after identifying the two matrix algebras by the bond-dimension equality.
+    \end{enumerate}
+    The hypotheses of
+    Lemma~\ref{lem:gauge_phase_matched_basis_sector_weights} are exactly these
+    listed components.
+\end{definition}
+
+\begin{definition}[Sector basis pre-matching]%
+    \label{def:sector_basis_pre_matching}
+    \lean{MPSTensor.SectorBasisPreMatching}
+    \leanok
+    \uses{def:sector_weight_data, def:gauge_phase_equiv}
+    A \emph{sector basis pre-matching} between sector decompositions $P$
+    and $Q$ consists of a permutation of their basis blocks, equality of the
+    paired bond dimensions, and gauge-phase equivalence of each corresponding
+    pair. It does not include the copy-count equality; that equality is recovered
+    from total MPV equality and BNT linear independence in
+    Lemma~\ref{lem:sector_basis_pre_matching_to_matching}.
+\end{definition}
+
+\begin{definition}[Single-family overlap-orthogonality hypotheses for sector bases]%
+    \label{def:sector_basis_overlap_ortho_hyps}
+    \lean{MPSTensor.SectorBasisOverlapOrthoHypotheses}
+    \leanok
+    \uses{def:sector_weight_data, def:mpv_overlap}
+    For one sector decomposition $P$, this condition states positive basis
+    dimensions, trace-preserving normalization of all basis blocks,
+    self-overlap limits equal to~$1$, and off-overlap limits equal to~$0$.
+\end{definition}
+
+\begin{definition}[Primitive overlap-span hypotheses for sector bases]%
+    \label{def:sector_basis_overlap_span_hyps}
+    \lean{MPSTensor.SectorBasisOverlapSpanHypotheses}
+    \leanok
+    \uses{def:sector_weight_data, def:mpv_overlap, def:mpv_state,
+        def:sector_basis_overlap_ortho_hyps}
+    For sector decompositions $P$ and $Q$, this condition states the
+    primitive overlap-rigidity hypotheses for their basis blocks: nonzero
+    bond dimensions, injectivity, trace-preserving normalization,
+    self-overlap limits equal to~$1$, off-overlap limits equal to~$0$, and
+    equality of the finite-length spans of the basis MPV states for every
+    system size.
+\end{definition}
+
+\begin{definition}[MPV phase equivalence for nonzero-weight blocks]
+    \label{def:mpv_block_phase_equiv}
+    \lean{MPSTensor.MPVBlockPhaseEquiv}
+    \leanok
+    \uses{def:mpv}
+    Two blocks $A$ and $B$ are MPV-phase equivalent if there is a nonzero
+    scalar $\zeta$ such that, for every system size~$N$ and every physical word,
+    \[
+        V^{(N)}(B)_\sigma
+        =
+        \zeta^N V^{(N)}(A)_\sigma.
+    \]
+    The two bond dimensions are allowed to differ.
+\end{definition}
+
+\begin{definition}[Common MPV phase cover]
+    \label{def:mpv_common_phase_cover}
+    \lean{MPSTensor.MPVCommonPhaseCover}
+    \leanok
+    \uses{def:mpv_block_phase_equiv}
+    For two finite nonzero-weight block families, a common MPV phase cover consists of a third
+    finite family of blocks, a map from each nonzero-weight block family onto that common
+    family, and MPV-phase equivalences between each block and its common
+    representative. Both maps are required to be surjective, so the common family
+    contains no unused representative.
+\end{definition}
+
+\begin{definition}[MPV phase classes]%
+    \label{def:mpv_phase_class_data}
+    \lean{MPSTensor.MPVPhaseEquiv, MPSTensor.MPVPhaseClassData, MPSTensor.mpvPhaseClassData}
+    \leanok
+    For a finite family of blocks, put $j \sim k$ when there is a nonzero
+    scalar factor $\zeta$ such that
+    \[
+        \ket{V^{(N)}(B_k)}
+        =
+        \zeta^N\ket{V^{(N)}(B_j)}
+    \]
+    for every length~$N$. The associated tuple enumerates the finite quotient,
+    chooses one representative per class, records the scalar relating the
+    representative to each member, and proves that distinct representatives are
+    not MPV-phase equivalent.
+\end{definition}
+
 \begin{definition}[BNT canonical form]%
     \label{def:sector_bnt_cf}
     \lean{MPSTensor.IsBNTCanonicalForm}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -297,21 +297,8 @@ $m_\alpha=\tr(\mu_\alpha)$ and $n_\beta=\tr(\nu_\beta)$. There
 $\mu_\alpha$ and $\nu_\beta$ are diagonal positive matrices; only their traces
 enter as the scalar coefficients compared here.
 
-\begin{definition}[Sector weights and sector decomposition]%
-    \label{def:sector_weight_data}
-    \lean{MPSTensor.SectorWeightData, MPSTensor.SectorDecomposition}
-    \leanok
-    A sector-weight tuple over $g$ basis blocks consists of multiplicities
-    $r_j > 0$, nonzero weights $\mu_{j,q}$ for
-    $q \in \{1,\ldots,r_j\}$, and the sector coefficients
-    \[
-        c_{S,j}^{(N)}
-        :=
-        \sum_{q=1}^{r_j} \mu_{j,q}^N.
-    \]
-    A \emph{sector decomposition} consists of the basis blocks
-    $(A_j)_{j=1}^g$ together with these multiplicities and weights.
-\end{definition}
+The base sector-weight and sector-decomposition data types are recorded once,
+in Chapter~\ref{ch:bnt} (Definition~\ref{def:sector_weight_data}).
 
 \begin{lemma}[Sector decomposition formula]%
     \label{lem:paper_decomp_formula}
@@ -456,62 +443,13 @@ enter as the scalar coefficients compared here.
     follows from Lemma~\ref{lem:phase_match_sector_weights}.
 \end{proof}
 
-\begin{definition}[Sector basis matching]%
-    \label{def:sector_basis_matching}
-    \lean{MPSTensor.SectorBasisMatching}
-    \leanok
-    \uses{def:sector_weight_data, def:gauge_phase_equiv}
-    A \emph{sector basis matching} between two sector decompositions $P$ and $Q$
-    consists of
-    \begin{enumerate}
-        \item a basis permutation
-              $\pi : \{1,\ldots,g_P\} \simeq \{1,\ldots,g_Q\}$,
-        \item per-block multiplicity equalities $r_j^P = r_{\pi(j)}^Q$,
-        \item per-block bond-dimension equalities $D_j^P = D_{\pi(j)}^Q$, and
-        \item per-block gauge-phase equivalences $P_j \simeq_{\mathrm{gp}} Q_{\pi(j)}$
-              after identifying the two matrix algebras by the bond-dimension equality.
-    \end{enumerate}
-    The hypotheses of
-    Lemma~\ref{lem:gauge_phase_matched_basis_sector_weights} are exactly these
-    listed components.
-\end{definition}
-
-\begin{definition}[Sector basis pre-matching]%
-    \label{def:sector_basis_pre_matching}
-    \lean{MPSTensor.SectorBasisPreMatching}
-    \leanok
-    \uses{def:sector_weight_data, def:gauge_phase_equiv}
-    A \emph{sector basis pre-matching} between sector decompositions $P$
-    and $Q$ consists of a permutation of their basis blocks, equality of the
-    paired bond dimensions, and gauge-phase equivalence of each corresponding
-    pair. It does not include the copy-count equality; that equality is recovered
-    from total MPV equality and BNT linear independence in
-    Lemma~\ref{lem:sector_basis_pre_matching_to_matching}.
-\end{definition}
-
-\begin{definition}[Single-family overlap-orthogonality hypotheses for sector bases]%
-    \label{def:sector_basis_overlap_ortho_hyps}
-    \lean{MPSTensor.SectorBasisOverlapOrthoHypotheses}
-    \leanok
-    \uses{def:sector_weight_data, def:mpv_overlap}
-    For one sector decomposition $P$, this condition states positive basis
-    dimensions, trace-preserving normalization of all basis blocks,
-    self-overlap limits equal to~$1$, and off-overlap limits equal to~$0$.
-\end{definition}
-
-\begin{definition}[Primitive overlap-span hypotheses for sector bases]%
-    \label{def:sector_basis_overlap_span_hyps}
-    \lean{MPSTensor.SectorBasisOverlapSpanHypotheses}
-    \leanok
-    \uses{def:sector_weight_data, def:mpv_overlap, def:mpv_state,
-        def:sector_basis_overlap_ortho_hyps}
-    For sector decompositions $P$ and $Q$, this condition states the
-    primitive overlap-rigidity hypotheses for their basis blocks: nonzero
-    bond dimensions, injectivity, trace-preserving normalization,
-    self-overlap limits equal to~$1$, off-overlap limits equal to~$0$, and
-    equality of the finite-length spans of the basis MPV states for every
-    system size.
-\end{definition}
+The sector-basis matching predicates used by the comparison results below are
+recorded in Chapter~\ref{ch:bnt}: Definition~\ref{def:sector_basis_matching}
+(sector basis matching), Definition~\ref{def:sector_basis_pre_matching}
+(sector basis pre-matching), Definition~\ref{def:sector_basis_overlap_ortho_hyps}
+(single-family overlap-orthogonality hypotheses), and
+Definition~\ref{def:sector_basis_overlap_span_hyps} (primitive overlap-span
+hypotheses).
 
 \begin{lemma}[Single-family overlap hypotheses plus span give overlap-span hypotheses]%
     \label{lem:sector_basis_overlap_ortho_to_span}
@@ -625,32 +563,9 @@ enter as the scalar coefficients compared here.
     for the sector bases.
 \end{proof}
 
-\begin{definition}[MPV phase equivalence for nonzero-weight blocks]
-    \label{def:mpv_block_phase_equiv}
-    \lean{MPSTensor.MPVBlockPhaseEquiv}
-    \leanok
-    \uses{def:mpv}
-    Two blocks $A$ and $B$ are MPV-phase equivalent if there is a nonzero
-    scalar $\zeta$ such that, for every system size~$N$ and every physical word,
-    \[
-        V^{(N)}(B)_\sigma
-        =
-        \zeta^N V^{(N)}(A)_\sigma.
-    \]
-    The two bond dimensions are allowed to differ.
-\end{definition}
-
-\begin{definition}[Common MPV phase cover]
-    \label{def:mpv_common_phase_cover}
-    \lean{MPSTensor.MPVCommonPhaseCover}
-    \leanok
-    \uses{def:mpv_block_phase_equiv}
-    For two finite nonzero-weight block families, a common MPV phase cover consists of a third
-    finite family of blocks, a map from each nonzero-weight block family onto that common
-    family, and MPV-phase equivalences between each block and its common
-    representative. Both maps are required to be surjective, so the common family
-    contains no unused representative.
-\end{definition}
+The MPV phase-equivalence and common-phase-cover predicates are recorded in
+Chapter~\ref{ch:bnt} (Definition~\ref{def:mpv_block_phase_equiv} and
+Definition~\ref{def:mpv_common_phase_cover}).
 
 \begin{lemma}[Common MPV phase cover gives nonzero-block span equality]%
     \label{lem:nonzero_block_span_eq_of_common_phase_cover}
@@ -1070,22 +985,8 @@ Chapter~\ref{ch:algebraic_ft}.
     sector decomposition.
 \end{proof}
 
-\begin{definition}[MPV phase classes]%
-    \label{def:mpv_phase_class_data}
-    \lean{MPSTensor.MPVPhaseEquiv, MPSTensor.MPVPhaseClassData, MPSTensor.mpvPhaseClassData}
-    \leanok
-    For a finite family of blocks, put $j \sim k$ when there is a nonzero
-    scalar factor $\zeta$ such that
-    \[
-        \ket{V^{(N)}(B_k)}
-        =
-        \zeta^N\ket{V^{(N)}(B_j)}
-    \]
-    for every length~$N$. The associated tuple enumerates the finite quotient,
-    chooses one representative per class, records the scalar relating the
-    representative to each member, and proves that distinct representatives are
-    not MPV-phase equivalent.
-\end{definition}
+The MPV phase-class data type is recorded in Chapter~\ref{ch:bnt}
+(Definition~\ref{def:mpv_phase_class_data}).
 
 \begin{theorem}[Phase-class BNT sector construction]%
     \label{thm:bnt_sector_decomp_tp_prim_irr_collapsed}


### PR DESCRIPTION
## Relocate sector-decomposition definitions into the BNT chapter

Fixes the worst ordering edge in the Ch 9–13 arc (audit O1): the base sector type `def:sector_weight_data` (`SectorDecomposition`/`SectorWeightData`) was **defined in Ch 13** (the FT proof, last chapter) yet `\uses`'d in Ch 9 and Ch 11 — a reader meets the entire SectorBNT API two chapters before the structure it is built on.

This moves the **definition blocks only** (verbatim, all `\lean`/`\label`/`\leanok`/`\uses` tags preserved) from `ch11_fundamental_theorem_proof.tex` into a new `\subsection{Sector decompositions and phase matching}` at the head of the BNT-canonical-form section of `ch10_bnt.tex`, before their first use:
- `def:sector_weight_data` (priority — the base type)
- `def:sector_basis_matching`, `def:sector_basis_pre_matching`, `def:sector_basis_overlap_ortho_hyps`, `def:sector_basis_overlap_span_hyps`
- `def:mpv_block_phase_equiv`, `def:mpv_common_phase_cover`, `def:mpv_phase_class_data`

The FT comparison **theorems/lemmas stay in Ch 13** (they consume these definitions); one-line forward pointers are left at the move sites. After the move, all Ch 13 → these-defs and Ch 9 → these-defs edges point **backward** (Ch 11 precedes Ch 13), and each moved label is defined exactly once.

**Pure blueprint relocation — no Lean file changed.** Internal dependency order preserved (ortho before span; block-phase before common-cover). `latexmk -lualatex` exits 0 with **0 undefined references**; `checkdecls` baseline unchanged.

Part of the Ch 9–13 structural consolidation (roadmap: `audits/2026-05-30_blueprint-ch9-13-structural-consolidation.md`). The PGVWC07 §9.13 quarantine (Stage 4) is handled separately on `codex/pgvwc07-recordings-single-source`, so it is intentionally excluded here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX reorganization with labels preserved; no runtime or proof code changes.
> 
> **Overview**
> **Relocates** eight sector-decomposition and MPV phase-matching **definition environments** from the Fundamental Theorem proof chapter (`ch11_fundamental_theorem_proof.tex`) into the BNT chapter (`ch10_bnt.tex`), in a new subsection *Sector decompositions and phase matching* placed **before** `def:sector_bnt_cf` and the rest of the sector-BNT API.
> 
> The moved labels are `def:sector_weight_data`, the sector-basis matching/pre-matching/overlap hypotheses, and `def:mpv_block_phase_equiv`, `def:mpv_common_phase_cover`, `def:mpv_phase_class_data`. Wording and Lean/`\uses` tags are unchanged; **no Lean sources** are touched.
> 
> In Ch. 13, the former definition blocks are replaced with **short cross-references** to Ch. 11 so lemmas and theorems there still cite the same labels. **Intent:** readers and `\uses` edges see base sector types and matching predicates where BNT canonical form is introduced, instead of two chapters after first use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eef000c4970ecc1d000eb99c1ed84ee9d9b5837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->