### PR TITLE
ci(blueprint): build PDF before Pages deploy

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -64,6 +64,8 @@ jobs:
           set -o pipefail
           tmp_output_file="$(mktemp)"
 
+          leanblueprint pdf
+
           set +o pipefail
           leanblueprint web 2>&1 | tee "$tmp_output_file"
           cmd_status=${PIPESTATUS[0]}

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -71,7 +71,12 @@ echo "==> Updating blueprint..."
 rm -rf "$WORK_DIR/site/blueprint"
 mkdir -p "$WORK_DIR/site/blueprint"
 cp -r "$REPO_ROOT/blueprint/web/"* "$WORK_DIR/site/blueprint/"
-cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf" 2>/dev/null || true
+if [ ! -f "$REPO_ROOT/blueprint/print/print.pdf" ]; then
+  echo "::error::Blueprint PDF not found at blueprint/print/print.pdf"
+  echo "Run 'cd blueprint && leanblueprint pdf' before deploying."
+  exit 1
+fi
+cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf"
 
 # Update homepage (remove all homepage files first, then copy fresh)
 echo "==> Updating homepage..."


### PR DESCRIPTION
## Summary

This PR makes the public blueprint PDF part of the Pages deployment path rather than an optional stale artifact:

- runs `leanblueprint pdf` before `leanblueprint web` in the automatic blueprint Pages workflow;
- makes `scripts/deploy-to-gh-pages.sh` fail if `blueprint/print/print.pdf` is missing;
- keeps the existing `/blueprint/` HTML deployment and homepage deployment unchanged.

## Rationale

The site publishes `/blueprint.pdf` from `blueprint/print/print.pdf`. The workflow built only the web version, while the deploy script silently skipped the PDF when that file was absent. That allowed the HTML blueprint and public PDF to diverge. This change makes the generated blueprint sources the single source for both outputs.

## Checks

- `git diff --check`
- `bash -n scripts/deploy-to-gh-pages.sh scripts/deploy-blueprint.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and deploy-script changes only; no application logic, auth, or data handling.
> 
> **Overview**
> The blueprint **Pages** pipeline now runs **`leanblueprint pdf`** in the GitHub Actions workflow **before** **`leanblueprint web`**, so **`blueprint/print/print.pdf`** is produced in CI alongside the HTML output.
> 
> **`scripts/deploy-to-gh-pages.sh`** no longer treats the public **`/blueprint.pdf`** copy as optional: it **errors** if **`blueprint/print/print.pdf`** is missing and always copies that file to the site root when deploying (HTML blueprint and homepage steps are unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 726a93329f204a415465a99d9e87cf8b8bf25cff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->