### PR TITLE
ci(blueprint): install PDF TeX tools

### DIFF
--- a/.github/actions/setup-blueprint-system-deps/action.yml
+++ b/.github/actions/setup-blueprint-system-deps/action.yml
@@ -57,11 +57,13 @@ runs:
           chktex
           dvisvgm
           graphviz
+          latexmk
           libgraphviz-dev
           texlive-extra-utils
           texlive-fonts-recommended
           texlive-latex-extra
           texlive-pictures
+          texlive-xetex
         )
 
         if [ -n "$EXTRA_PACKAGES" ]; then


### PR DESCRIPTION
## Summary

This PR completes the Pages PDF deployment fix by adding the TeX tools needed by `leanblueprint pdf` in CI:

- adds `latexmk`, which `leanblueprint pdf` invokes;
- adds `texlive-xetex`, because `blueprint/src/latexmkrc` runs `xelatex`.

## Rationale

PR #2186 made the Pages workflow build the blueprint PDF before deploying. The first main-branch run reached that command and failed because the CI image did not contain `latexmk`. These packages make the automatic Pages path match the documented local command `cd blueprint && leanblueprint pdf`.

## Checks

- `git diff --check`
- parsed `.github/actions/setup-blueprint-system-deps/action.yml` as YAML

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds apt packages to a composite CI action; no application, auth, or runtime logic changes.
> 
> **Overview**
> Extends the **Setup Blueprint System Dependencies** GitHub Action so CI installs **`latexmk`** and **`texlive-xetex`** alongside the existing TeX/Graphviz stack.
> 
> That aligns automated **`leanblueprint pdf`** / Pages PDF builds with local workflow: **`latexmk`** is what the blueprint PDF step invokes, and **`blueprint/src/latexmkrc`** drives **`xelatex`** via **`$pdflatex`**, which needs the XeTeX package set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c60cad5108e842d731059a2bc1b52bef042452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->