### PR TITLE
doc(PEPS): centralize edge-window status

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3250,28 +3250,17 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $5\times7$ or $7\times5$ frame and the complementary cover is supplied.
     The same criterion applies to an arbitrary horizontal or vertical
     square-lattice edge after identifying it with its coordinate right or
-    upward representative.  The oriented margin-and-cover datum is the
-    corresponding per-edge datum in the rectangular coordinate model; it
-    directly supplies the one-edge blocking datum, its three injective
+    upward representative.  The oriented margin-and-cover datum is the same
+    criterion packaged as per-edge data in the rectangular coordinate model;
+    it directly supplies the one-edge blocking datum, its three injective
     regions, and the identities
     $u_e\in R_e$, $v_e\in B_e$,
     $R_e\cap B_e=R_e\cap C_e=B_e\cap C_e=\varnothing$, and
-    $R_e\cup B_e\cup C_e=V$.  The horizontal and vertical margin predicates
-    name the coordinate
-    inequalities needed to place these two translated frames, and there are
-    corresponding coordinate and oriented-edge window constructors that take
-    these predicates directly.  On coordinate right and upward edges,
-    translated windows force the corresponding margin predicates.  The current
-    open $7\times7$ model therefore does not admit translated windows for
-    every edge; explicit boundary examples are recorded on all four sides.  The
-    margin-cover datum stores these named predicates, so such data force the
-    corresponding horizontal and vertical margin inequalities.  In the present
-    open rectangular coordinate model, this margin criterion does not apply to
-    horizontal edges without enough left or right margin, nor to vertical edges
-    without enough bottom or top margin; the corresponding $7\times7$
-    examples are recorded explicitly, including a single four-sided boundary
-    obstruction.
-    % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
+    $R_e\cup B_e\cup C_e=V$.  The boundary obstruction lemmas show that these
+    translated-window and margin-cover criteria are interior criteria, not the
+    final every-edge construction in the open square-lattice model.
+    % Detailed source-comparison status:
+    % docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \end{definition}
 
 \begin{theorem}[Construction from translated edge windows]%
@@ -3304,9 +3293,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $R_e\cup B_e\cup C_e=V$.  Equivalently, it is enough to supply the oriented
     margin-and-cover data at every edge; the resulting hypotheses recover the
     corresponding datum, give the same three injectivity conclusions, and give
-    the same endpoint, disjointness, and covering conclusions.  The current open
-    rectangular $7\times7$ model does not admit such margin-and-cover data for
-    every edge, because the boundary edges above fail this interior criterion.
+    the same endpoint, disjointness, and covering conclusions.  The obstruction
+    theorem records that this interior margin-cover criterion does not by
+    itself supply data at every edge of the open $7\times7$ lattice.
+    % Detailed source-comparison status:
+    % docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \end{theorem}
 \begin{proof}\leanok
     Apply the general construction for one-edge blocking data to the datum


### PR DESCRIPTION
## Summary

This blueprint-only PR trims repeated boundary-status prose from the translated edge-window part of Chapter 13a.

The mathematical statements and Lean links are unchanged.  The blueprint now records only the conditional translated-window and margin-cover constructions, while the detailed source comparison, boundary examples, and elimination plan remain centralized in `docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining mathematical obligations".

## Source

- arXiv:1804.04964, Section 3, proof of Theorem 3
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`
- Tracks part of #2004

## Checks

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch13a_peps_ft.tex`
- `cd blueprint && leanblueprint web`

`leanblueprint checkdecls` was also attempted in the fresh worktree.  The first invocation had no generated `blueprint/lean_decls`; after generating it, `lake exe checkdecls blueprint/lean_decls` could not run because the fresh worktree has no built `TNLean` module in `.lake/build/lib/lean`.  No Lean declarations or blueprint Lean tags changed in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to blueprint LaTeX; no Lean code or formal proof obligations change.
> 
> **Overview**
> **Chapter 13a** (normal PEPS / translated edge windows) drops repeated boundary and source-comparison prose from `def:peps_normalSquareTranslatedEdgeWindow` and `thm:peps_normalSquareTranslatedEdgeBlockingHypotheses_of_windows`.
> 
> The blueprint still states the **conditional** translated-window and margin-cover constructions and points to `docs/paper-gaps/peps_normal_ft_section3_route.tex` for boundary examples, obstructions, and remaining obligations. **Lean tags and mathematical claims are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b42174922149a3dcf8b1358a3e0aeeb97f105be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->