### PR TITLE
refactor(MPS): remove dead RFP and BNT leaf lemmas

### DIFF
--- a/TNLean/MPS/Chain/OneSidedInverse.lean
+++ b/TNLean/MPS/Chain/OneSidedInverse.lean
@@ -73,9 +73,4 @@ theorem decompositionMap_sum {A : MPSTensor d D} (hA : IsInjective A)
   have := decompositionMap_spec hA X
   rwa [Fintype.linearCombination_apply] at this
 
-/-- The decomposition map is a right inverse of the linear combination map. -/
-theorem decompositionMap_rightInverse {A : MPSTensor d D} (hA : IsInjective A) :
-    Function.RightInverse (decompositionMap hA) (Fintype.linearCombination ℂ A) :=
-  decompositionMap_spec hA
-
 end MPSTensor

--- a/TNLean/MPS/Chain/VirtualInsertion.lean
+++ b/TNLean/MPS/Chain/VirtualInsertion.lean
@@ -41,28 +41,6 @@ theorem physRealizeLeft_spec (A : MPSTensor d D) (hA : IsInjective A)
     X * A i = ∑ j, (physRealizeLeft A hA X) i j • A j :=
   (decompositionMap_sum (A := A) hA (X * A i)).symm
 
-/-- `physRealize` is linear in the inserted matrix. -/
-theorem physRealize_linear (A : MPSTensor d D) (hA : IsInjective A) :
-    ∀ (c : ℂ) (X Y : Matrix (Fin D) (Fin D) ℂ),
-      physRealize A hA (c • X + Y) = c • physRealize A hA X + physRealize A hA Y := by
-  intro c X Y
-  ext i j
-  simp [physRealize, mul_add]
-
-/-- Identity insertion does nothing. -/
-theorem physRealize_one (A : MPSTensor d D) (hA : IsInjective A)
-    (hLin : LinearIndependent ℂ A) :
-    physRealize A hA 1 = 1 := by
-  ext i j
-  let c : Fin d → ℂ := fun k => physRealize A hA 1 i k
-  have hc : Fintype.linearCombination ℂ A c = A i := by
-    simpa [c, Fintype.linearCombination_apply] using (physRealize_spec A hA 1 i).symm
-  have hsingle : Fintype.linearCombination ℂ A (Pi.single i (1 : ℂ)) = A i := by
-    simp [Fintype.linearCombination_apply_single]
-  have hc' : c = Pi.single i (1 : ℂ) :=
-    hLin.fintypeLinearCombination_injective (hc.trans hsingle.symm)
-  simpa [c, Matrix.one_apply, Pi.single_apply, eq_comm] using congrArg (fun f => f j) hc'
-
 /-- `physRealize` preserves multiplication. -/
 theorem physRealize_mul (A : MPSTensor d D) (hA : IsInjective A)
     (X Y : Matrix (Fin D) (Fin D) ℂ) :
@@ -93,24 +71,6 @@ theorem physRealize_mul (A : MPSTensor d D) (hA : IsInjective A)
           simp [physRealize]
     _ = (physRealize A hA X * physRealize A hA Y) i k := by
           simp [Matrix.mul_apply]
-
-/-- Nonzero insertion gives nonzero physical operation. -/
-theorem physRealize_injective (A : MPSTensor d D) (hA : IsInjective A)
-    (X : Matrix (Fin D) (Fin D) ℂ) (hX : X ≠ 0) :
-    physRealize A hA X ≠ 0 := by
-  intro hZero
-  have hAll : ∀ i : Fin d, A i * X = 0 := by
-    intro i
-    rw [physRealize_spec A hA X i, hZero]
-    simp
-  obtain ⟨c, hc⟩ := hA.exists_decomposition (1 : Matrix (Fin D) (Fin D) ℂ)
-  have hX0 : X = 0 := by
-    calc
-      X = (1 : Matrix (Fin D) (Fin D) ℂ) * X := by simp
-      _ = (∑ i, c i • A i) * X := by simp [hc]
-      _ = ∑ i, c i • (A i * X) := by simp [Finset.sum_mul]
-      _ = 0 := by simp [hAll]
-  exact hX hX0
 
 /-- Three-site coefficient with a virtual insertion `X` between the first and
 second local tensors. -/

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -332,16 +332,6 @@ theorem replicatedWeights_pow_ne_zero
   intro x
   exact pow_ne_zero (p x.1) (hμ x.1)
 
-/-- A nonzero sector phase can be multiplied into a transported block weight
-without making the sector weight vanish. -/
-theorem replicatedWeights_pow_mul_phase_ne_zero
-    {m : Fin r → ℕ}
-    (μ : Fin r → ℂ) (θ : (Σ k : Fin r, Fin (m k)) → ℂ)
-    (hμ : ∀ k, μ k ≠ 0) (hθ : ∀ x, θ x ≠ 0) (p : Fin r → ℕ) :
-    ∀ x : Σ k : Fin r, Fin (m k), (μ x.1) ^ (p x.1) * θ x ≠ 0 := by
-  intro x
-  exact mul_ne_zero (replicatedWeights_pow_ne_zero μ hμ p x) (hθ x)
-
 end WeightTransport
 
 /-!
@@ -425,13 +415,6 @@ noncomputable def directToIteratedBlockIndex (d m n : ℕ)
     (List.ofFn fun j : Fin n =>
       blockIndexOfList d m (blockWordChunk d m n i j) (length_blockWordChunk d m n i j))
     (by simp)
-
-/-- Encoding the decoded word of a block gives back the original blocked index. -/
-theorem blockIndexOfList_wordOfBlock (d L : ℕ) (i : Fin (blockPhysDim d L)) :
-    blockIndexOfList d L (wordOfBlock d L i) (length_wordOfBlock d L i) = i := by
-  classical
-  unfold blockIndexOfList wordOfBlock decodeBlock
-  simp [blockPhysDim]
 
 /-- Decoding blocked physical indices as words is injective. -/
 theorem wordOfBlock_injective (d L : ℕ) : Function.Injective (wordOfBlock d L) := by
@@ -634,18 +617,6 @@ noncomputable def flattenedIteratedBlockTensor
     MPSTensor (blockPhysDim d (p * L)) D :=
   reindexPhysical (directToIteratedBlockIndex d p L)
     (blockTensor (d := blockPhysDim d p) (D := D) A L)
-
-/-- Evaluating a flattened iterated block is evaluating the iterated block on the grouped
-physical configuration. -/
-theorem mpv_flattenedIteratedBlockTensor
-    {d p D L N : ℕ} (A : MPSTensor (blockPhysDim d p) D)
-    (σ : Fin N → Fin (blockPhysDim d (p * L))) :
-    mpv (flattenedIteratedBlockTensor (d := d) (p := p) (D := D) A L) σ =
-      mpv (blockTensor (d := blockPhysDim d p) (D := D) A L)
-        (fun n => directToIteratedBlockIndex d p L (σ n)) := by
-  simpa [flattenedIteratedBlockTensor] using
-    (mpv_reindexPhysical (directToIteratedBlockIndex d p L)
-      (blockTensor (d := blockPhysDim d p) (D := D) A L) σ)
 
 /-- Flattened iterated blocking of an already `p`-blocked tensor agrees with direct blocking by
 `p * L` of the original tensor. -/

--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -285,12 +285,4 @@ theorem fundamentalTheorem_singleBlock_finiteLength [NeZero D]
     GaugeEquiv A B :=
   fundamentalTheorem_singleBlock hA (sameMPV_of_sameMPVFrom_of_injective hA hFrom)
 
-/-- For injective tensors, finite-length MPV agreement (from any threshold) is
-equivalent to gauge equivalence. -/
-theorem sameMPVFrom_iff_gaugeEquiv_of_injective [NeZero D]
-    {A B : MPSTensor d D} (hA : IsInjective A) {N₀ : ℕ} :
-    SameMPVFrom N₀ A B ↔ GaugeEquiv A B :=
-  ⟨fundamentalTheorem_singleBlock_finiteLength hA,
-   fun hGE => (GaugeEquiv.sameMPV hGE).sameMPVFrom _⟩
-
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/DominantMatch.lean
@@ -149,17 +149,6 @@ theorem exists_nondecaying_overlap_pair_of_sameMPVPos
   exists_nondecaying_overlap_pair_of_eventuallyProportional
     (P := P) (Q := Q) hP hQ hQ_pos hEqual.toEventuallyNonzeroProportionalMPV₂
 
-theorem exists_nondecaying_overlap_pair_of_sameMPV
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hQ_pos : 0 < Q.basisCount)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ j : Fin P.basisCount, ∃ k : Fin Q.basisCount,
-      ¬ Tendsto (fun N => mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
-          atTop (𝓝 0) :=
-  exists_nondecaying_overlap_pair_of_sameMPVPos
-    (P := P) (Q := Q) hP hQ hQ_pos hEqual.toSameMPV₂Pos
-
 /-! ### Lemma 3: block matching at a user-supplied index `j₀`
 
 The main result of Phase 4b-ii: under `SameMPV₂` plus a unit-modulus

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/EqualModulus.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/EqualModulus.lean
@@ -84,59 +84,6 @@ structure HasEqualModulusWeightLayer (P : SectorDecomposition d) where
 
 namespace HasEqualModulusWeightLayer
 
-variable {P : SectorDecomposition d}
-
-/-- **Phase weights are nonzero** (immediate from `phase_weight_norm_one`). -/
-lemma phase_weight_ne_zero (h : HasEqualModulusWeightLayer P)
-    (j : Fin P.basisCount) (q : Fin (P.copies j)) :
-    h.phase_weight j q ≠ 0 := by
-  intro hzero
-  have hnorm := h.phase_weight_norm_one j q
-  rw [hzero, norm_zero] at hnorm
-  exact one_ne_zero hnorm.symm
-
-/-- **All spectral-level moduli are bounded by `1`**, combining the
-dominant normalization with `Antitone`. -/
-lemma spectral_level_norm_le_one (h : HasEqualModulusWeightLayer P)
-    (j : Fin P.basisCount) : ‖h.spectral_level j‖ ≤ 1 := by
-  have hpos : 0 < P.basisCount := Nat.lt_of_le_of_lt (Nat.zero_le _) j.isLt
-  have hdom : ‖h.spectral_level ⟨0, hpos⟩‖ = 1 :=
-    h.spectral_level_dom_norm_one hpos
-  have hle : (⟨0, hpos⟩ : Fin P.basisCount) ≤ j :=
-    Fin.mk_le_of_le_val (Nat.zero_le _)
-  have hanti : ‖h.spectral_level j‖ ≤ ‖h.spectral_level ⟨0, hpos⟩‖ :=
-    h.spectral_level_antitone hle
-  rw [hdom] at hanti
-  exact hanti
-
-/-- **Sector coefficient identity** for the equal-modulus layer.
-
-When the equal-modulus factorization is available, the BNT sector
-coefficient `P.coeff N j = ∑_q (μ_{j,q})^N` factors as
-`(λ_j)^N · ∑_q (ν_{j,q})^N`. -/
-lemma coeff_eq_pow_unit_sum (h : HasEqualModulusWeightLayer P)
-    (N : ℕ) (j : Fin P.basisCount) :
-    P.coeff N j =
-      (h.spectral_level j) ^ N *
-        ∑ q : Fin (P.copies j), (h.phase_weight j q) ^ N := by
-  classical
-  unfold SectorDecomposition.coeff SectorWeightData.coeff
-  calc
-    ∑ q : Fin (P.copies j), (P.weight j q) ^ N
-        = ∑ q : Fin (P.copies j),
-            (h.spectral_level j * h.phase_weight j q) ^ N := by
-          refine Finset.sum_congr rfl ?_
-          intro q _
-          rw [h.weight_factor j q]
-    _ = ∑ q : Fin (P.copies j),
-          (h.spectral_level j) ^ N * (h.phase_weight j q) ^ N := by
-          refine Finset.sum_congr rfl ?_
-          intro q _
-          rw [mul_pow]
-    _ = (h.spectral_level j) ^ N *
-          ∑ q : Fin (P.copies j), (h.phase_weight j q) ^ N := by
-          rw [← Finset.mul_sum]
-
 end HasEqualModulusWeightLayer
 
 end MPSTensor

--- a/TNLean/MPS/RFP/Decorrelation.lean
+++ b/TNLean/MPS/RFP/Decorrelation.lean
@@ -144,16 +144,6 @@ theorem frustration_free_ham_eq
   simp only [comp_sub, sub_comp, comp_id, id_comp]
   abel
 
-/-- Complement-product cancellation identity:
-`P ∘ (id − Q ∘ P) ∘ Q = 0` for commuting idempotents.
-This is `comp_complement_comm_zero` with swapped roles. -/
-theorem comp_complement_comm_zero_swap
-    {P Q : E →ₗ[ℂ] E}
-    (hP : P ∘ₗ P = P) (hQ : Q ∘ₗ Q = Q)
-    (hcomm : P ∘ₗ Q = Q ∘ₗ P) :
-    P ∘ₗ (id - Q ∘ₗ P) ∘ₗ Q = 0 :=
-  comp_complement_comm_zero hQ hP hcomm.symm
-
 end LinearMap
 
 end CommutingIdempotentAlgebra
@@ -256,18 +246,6 @@ theorem HasCommutingParentHam.mem_ground_iff {P_K : E →ₗ[ℂ] E}
       simp only [LinearMap.comp_apply]; rw [hXB, hAX]
     rwa [h.hK] at this
 
-/-- Ground-space vectors are fixed by `P_AX`. -/
-theorem HasCommutingParentHam.pAX_of_ground {P_K : E →ₗ[ℂ] E}
-    (h : HasCommutingParentHam P_K)
-    {v : E} (hv : P_K v = v) : h.P_AX v = v :=
-  ((h.mem_ground_iff v).mp hv).1
-
-/-- Ground-space vectors are fixed by `P_XB`. -/
-theorem HasCommutingParentHam.pXB_of_ground {P_K : E →ₗ[ℂ] E}
-    (h : HasCommutingParentHam P_K)
-    {v : E} (hv : P_K v = v) : h.P_XB v = v :=
-  ((h.mem_ground_iff v).mp hv).2
-
 end Decorrelation
 
 end HasCommutingParentHamProperties
@@ -346,28 +324,6 @@ theorem IsDecorrelated.singleton {P_K O_A O_B : E →ₗ[ℂ] E}
   intro O_A' hA O_B' hB
   rw [Set.mem_singleton_iff.mp hA, Set.mem_singleton_iff.mp hB]
   exact h
-
-/-- Decorrelation is preserved under unions of A-observable sets. -/
-theorem IsDecorrelated.union_obsA {P_K : E →ₗ[ℂ] E}
-    {ObsA₁ ObsA₂ ObsB : Set (E →ₗ[ℂ] E)}
-    (h₁ : IsDecorrelated P_K ObsA₁ ObsB)
-    (h₂ : IsDecorrelated P_K ObsA₂ ObsB) :
-    IsDecorrelated P_K (ObsA₁ ∪ ObsA₂) ObsB := by
-  intro O_A hOA O_B hOB
-  rcases hOA with h | h
-  · exact h₁ O_A h O_B hOB
-  · exact h₂ O_A h O_B hOB
-
-/-- Decorrelation is preserved under unions of B-observable sets. -/
-theorem IsDecorrelated.union_obsB {P_K : E →ₗ[ℂ] E}
-    {ObsA ObsB₁ ObsB₂ : Set (E →ₗ[ℂ] E)}
-    (h₁ : IsDecorrelated P_K ObsA ObsB₁)
-    (h₂ : IsDecorrelated P_K ObsA ObsB₂) :
-    IsDecorrelated P_K ObsA (ObsB₁ ∪ ObsB₂) := by
-  intro O_A hOA O_B hOB
-  rcases hOB with h | h
-  · exact h₁ O_A hOA O_B h
-  · exact h₂ O_A hOA O_B h
 
 end Decorrelation
 

--- a/TNLean/MPS/RFP/Defs.lean
+++ b/TNLean/MPS/RFP/Defs.lean
@@ -146,13 +146,4 @@ theorem isRFP_iff_kraus_isometry (A : MPSTensor d D) :
     rintro ⟨V, hV, hprod⟩
     exact isRFP_of_kraus_isometry A V hV hprod
 
-/-- Equivalent formulation of `isRFP_iff_kraus_isometry` using the shorter historical name. -/
-theorem isRFP_iff_kraus (A : MPSTensor d D) :
-    IsRFP A ↔
-      ∃ V : Matrix (Fin d × Fin d) (Fin d) ℂ,
-        V.conjTranspose * V = 1 ∧
-        ∀ i₁ i₂ : Fin d,
-          A i₁ * A i₂ = ∑ j : Fin d, V (i₁, i₂) j • A j :=
-  isRFP_iff_kraus_isometry A
-
 end MPSTensor

--- a/TNLean/MPS/SharedInfra/Scaling.lean
+++ b/TNLean/MPS/SharedInfra/Scaling.lean
@@ -63,72 +63,11 @@ theorem mpv_smul (c : ℂ) (A : MPSTensor d D) {N : ℕ} (σ : Fin N → Fin d) 
   rw [evalWord_smul]
   simp [List.length_ofFn, Matrix.trace_smul]
 
-/-- Nonzero scalar rescaling preserves injectivity. -/
-theorem isInjective_smul (c : ℂ) (hc : c ≠ 0) (A : MPSTensor d D) (hA : IsInjective A) :
-    IsInjective (fun i => c • A i) := by
-  unfold IsInjective at hA ⊢
-  have hrange : Set.range (fun i => c • A i) = (c • ·) '' Set.range A := by
-    ext M
-    simp only [Set.mem_range, Set.mem_image]
-    constructor
-    · rintro ⟨i, rfl⟩
-      exact ⟨A i, ⟨i, rfl⟩, rfl⟩
-    · rintro ⟨N, ⟨i, rfl⟩, rfl⟩
-      exact ⟨i, rfl⟩
-  rw [hrange]
-  rw [show (c • · : Matrix (Fin D) (Fin D) ℂ → Matrix (Fin D) (Fin D) ℂ) =
-      (c • LinearMap.id : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) from by
-    ext M
-    simp]
-  rw [Submodule.span_image, hA, Submodule.map_smul _ _ c hc, Submodule.map_id]
-
 /-- The phase `μ / ‖μ‖` of a nonzero scalar has unit norm. -/
 theorem phase_norm_one {μ : ℂ} (hμ : μ ≠ 0) :
     ‖μ / ↑‖μ‖‖ = 1 := by
   rw [norm_div, Complex.norm_real, norm_norm]
   exact div_self (norm_ne_zero_iff.mpr hμ)
-
-/-- Split `μ • M` into a modulus part and a phase part. -/
-theorem smul_eq_norm_smul_phase (μ : ℂ) (hμ : μ ≠ 0) (M : Matrix (Fin D) (Fin D) ℂ) :
-    μ • M = (↑‖μ‖ : ℂ) • ((μ / ↑‖μ‖) • M) := by
-  rw [smul_smul]
-  congr 1
-  rw [mul_comm, div_mul_cancel₀]
-  exact_mod_cast norm_ne_zero_iff.mpr hμ
-
-/-- Scaling by the modulus `‖μ‖` scales the transfer map by `‖μ‖²`. -/
-theorem transferMap_norm_smul (μ : ℂ) {D' : ℕ} (A : MPSTensor d D')
-    (X : Matrix (Fin D') (Fin D') ℂ) :
-    transferMap (fun i => (↑‖μ‖ : ℂ) • A i) X =
-      (↑(‖μ‖ ^ 2) : ℂ) • transferMap A X := by
-  rw [transferMap_smul]
-  congr 1
-  rw [Complex.conj_ofReal, ← Complex.ofReal_mul, sq]
-
-/-- Phase scaling preserves left-canonical normalization. -/
-theorem leftCanonical_phase_smul {D' : ℕ} (μ : ℂ) (hμ : μ ≠ 0)
-    (A : MPSTensor d D') (hA : ∑ i : Fin d, (A i)ᴴ * (A i) = 1) :
-    ∑ i : Fin d, ((μ / ↑‖μ‖) • A i)ᴴ * ((μ / ↑‖μ‖) • A i) = 1 := by
-  have hn := phase_norm_one (μ := μ) hμ
-  exact leftCanonical_smul_of_norm_one _ hn A hA
-
-/-- MPV under block normalization: every block weight may be split into its
-modulus and a unit-modulus phase by absorbing the modulus into the block tensor.
-With $\eta_k := \mu_k / \|\mu_k\|$ and $B_k := \|\mu_k\| \cdot A_k$, the
-block-diagonal tensors $\bigoplus_k \mu_k A_k$ and $\bigoplus_k \eta_k B_k$
-generate the same MPV family.  See arXiv:2011.12127 Section IV.A. -/
-theorem mpv_toTensorFromBlocks_normalize {r : ℕ} {dim : Fin r → ℕ}
-    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0)
-    (A : (k : Fin r) → MPSTensor d (dim k))
-    {N : ℕ} (σ : Fin N → Fin d) :
-    mpv (toTensorFromBlocks μ A) σ =
-      mpv (toTensorFromBlocks (fun k => μ k / ↑‖μ k‖)
-        (fun k i => (↑‖μ k‖ : ℂ) • A k i)) σ := by
-  rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
-  refine Finset.sum_congr rfl fun k _ => ?_
-  have hne : (↑‖μ k‖ : ℂ) ≠ 0 := by exact_mod_cast norm_ne_zero_iff.mpr (hμ k)
-  rw [mpv_smul, smul_eq_mul, smul_eq_mul, ← mul_assoc, ← mul_pow,
-    div_mul_cancel₀ (μ k) hne]
 
 /-- Multiplying every block weight by the same scalar multiplies length-`N`
 MPV coefficients by `c ^ N`. -/

--- a/blueprint/comments20260407/ch13_lean_audit.md
+++ b/blueprint/comments20260407/ch13_lean_audit.md
@@ -107,7 +107,7 @@ Legend:
 | `MPSTensor.IsInjective.exists_rightInverse` | Match | Blueprint matches the Lean theorem: injectivity gives a linear right inverse of the linear-combination map. |
 | `MPSTensor.decompositionMap` | Match | Correctly describes a chosen right inverse. |
 | `MPSTensor.IsInjective.exists_decomposition` | Match | Correct. |
-| `MPSTensor.physRealize` | Match | Definition matches. The blueprint also mentions linearity; in Lean that is a separate theorem `physRealize_linear`, not part of this definition. |
+| `MPSTensor.physRealize` | Match | Definition matches. The blueprint also mentions linearity; that is a separate statement, not part of this definition. |
 | `MPSTensor.physRealize_spec` | Match | Correct. |
 | `MPSTensor.physRealize_mul` | Mismatch | Blueprint weakens Lean by adding an unnecessary basis hypothesis. Lean proves multiplicativity for every injective tensor. |
 | `MPSTensor.chainCombinedTensor_isInjective` | Mismatch | Blueprint states injectivity of a blocked product tensor; Lean proves injectivity of the repackaged combined tensor `chainCombinedTensor`. |


### PR DESCRIPTION
### Motivation

- Removes unreferenced leaf lemmas across the `MPS/RFP`, `SectorBNT`, `SharedInfra`, `Chain`, and `Core` stacks. None of the deleted declarations have call sites in `TNLean/`, `blueprint/src/`, or `docs/`, and none carry `simp`, `deprecated`, or automation-hook attributes.
- Keeps the active API surface small ahead of the remaining coefficient-comparison and RFP bridge work (Phases 6–7 of #1685).
- Part of the paper-faithful CPSV16 BNT clean-slate plan; see #1685 and #1749.

### Description

Deleted declarations with zero word-boundary references (verified by reference scan and `lake build TNLean`):

- `SharedInfra/Scaling.lean`: `isInjective_smul`, `smul_eq_norm_smul_phase`, `transferMap_norm_smul`, `leftCanonical_phase_smul`, `mpv_toTensorFromBlocks_normalize`
- `FundamentalTheorem/SectorBNT/EqualModulus.lean`: `phase_weight_ne_zero`, `spectral_level_norm_le_one`, `coeff_eq_pow_unit_sum`, and the `HasEqualModulusWeightLayer` helper block (structure definition retained)
- `FundamentalTheorem/SectorBNT/DominantMatch.lean`: `exists_nondecaying_overlap_pair_of_sameMPV` (superseded by the `SameMPV₂Pos` path)
- `Core/BlockingInfrastructure.lean`: `mpv_flattenedIteratedBlockTensor`, `blockIndexOfList_wordOfBlock`, `replicatedWeights_pow_mul_phase_ne_zero`
- `FundamentalTheorem/FiniteLength.lean`: `sameMPVFrom_iff_gaugeEquiv_of_injective` (finite-length MPV ↔ gauge-equivalence wrapper)
- `RFP/Defs.lean`: `isRFP_iff_kraus` (historical alias; `isRFP_iff_kraus_isometry` retained)
- `RFP/Decorrelation.lean`: `comp_complement_comm_zero_swap`, `HasCommutingParentHam.pAX_of_ground`, `HasCommutingParentHam.pXB_of_ground`, `IsDecorrelated.union_obsA`, `IsDecorrelated.union_obsB`
- `Chain/VirtualInsertion.lean`: `physRealize_linear`, `physRealize_one`, `physRealize_injective`
- `Chain/OneSidedInverse.lean`: `decompositionMap_rightInverse`

Retained (not dead): `thermodynamic_limit_nonvanishing` (live `\leanid` reference in `docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex`); `coeff_tendsto_zero_of_all_weights_subnorm` (referenced in `blueprint/src/web.paux`); `Chain/Defs.lean` abbreviations (intended public API).

No mathematical content is changed; no `sorry` is introduced.

### Testing

- `git diff --check origin/main...HEAD`
- Word-boundary reference scan for all removed declaration names across `TNLean/`, `blueprint/src/`, `docs/`, and `README.md`
- `lake env lean` on each edited Lean file
- `lake build TNLean` (pre-existing `sorry` warnings in PEPS and periodic overlap files unaffected)

---
Addresses #1685, #1749, #237, #236, #823

> [!NOTE]
> **Low Risk**
> Pure deletions of unused lemmas with no logic or `simp` attribute changes; risk is limited to accidental removal of something external callers depended on (PR claims reference scans passed).
>
> **Overview**
> This PR **deletes unused leaf lemmas** across the MPS stack—no behavior or public API surface that callers still rely on should change.
>
> **Chain / blocking:** Drops convenience results around `decompositionMap`, `physRealize` (linearity, identity, injectivity), blocking index round-trips (`blockIndexOfList_wordOfBlock`, `mpv_flattenedIteratedBlockTensor`), and a replicated-weight×phase nonvanishing lemma.
>
> **Fundamental theorem / BNT:** Removes `sameMPVFrom_iff_gaugeEquiv_of_injective` (finite-length MPV ↔ gauge equiv wrapper) and `exists_nondecaying_overlap_pair_of_sameMPV` (superseded by the `SameMPV₂Pos` path). Strips the entire `HasEqualModulusWeightLayer` helper block in `EqualModulus.lean`, leaving only the structure definition.
>
> **RFP / scaling:** Cuts historical `isRFP_iff_kraus` alias, decorrelation union/swap/ground lemmas, and scaling helpers (injectivity/phase/transfer under rescaling, block MPV normalization).
>
> The active development paths keep the core definitions and the lemmas still wired into proofs (e.g. `decompositionMap_sum`, `physRealize_mul`, `fundamentalTheorem_singleBlock_finiteLength`, `exists_nondecaying_overlap_pair_of_sameMPVPos`).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf48c3c999df2f060ae9ea0a8cab11372999936c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletions with no logic changes; risk is limited to undocumented external callers of removed theorem names.
> 
> **Overview**
> This PR **removes unused leaf lemmas** across the MPS stack—definitions and core proof paths stay intact; only declarations with no in-repo callers are deleted.
> 
> **Chain / virtual insertion:** Drops `decompositionMap_rightInverse` and convenience results on `physRealize` (linearity, identity insertion, injectivity from nonzero `X`). **`physRealize_mul`**, specs, and `virtualInsertCoeff` remain.
> 
> **Blocking / fundamental theorem:** Removes blocking helpers (`blockIndexOfList_wordOfBlock`, `mpv_flattenedIteratedBlockTensor`, replicated-weight×phase nonvanishing) and the `sameMPVFrom_iff_gaugeEquiv_of_injective` biconditional wrapper; **`fundamentalTheorem_singleBlock_finiteLength`** and the main blocking API stay.
> 
> **Sector BNT:** Deletes `exists_nondecaying_overlap_pair_of_sameMPV` (the **`SameMPV₂Pos`** variant remains) and the entire `HasEqualModulusWeightLayer` helper namespace in `EqualModulus.lean`, leaving only the structure definition.
> 
> **RFP / scaling / decorrelation:** Cuts the `isRFP_iff_kraus` alias, several decorrelation union/swap/ground lemmas, and scaling helpers (injectivity/phase/transfer under rescaling, block MPV normalization). **`isRFP_iff_kraus_isometry`** and remaining scaling lemmas used in proofs are kept.
> 
> **Docs:** `ch13_lean_audit.md` notes that linearity for `physRealize` is a separate statement, not bundled in the definition tag.
> 
> No proof logic or `sorry` status is intended to change—this is API surface cleanup ahead of later BNT/RFP work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb915accaccb97a99ce8c6780c6eaa79e0ff7d42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->