### PR TITLE
refactor(MPS/MPDO,PEPS): remove unused leaf lemmas

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -393,17 +393,6 @@ recovers the original matrix. -/
   exact reconstructFromBlockedCoefficients_of_mem
     (data := data) (n := n) (X := X) ((hCompat n hn X).2 hX)
 
-/-- Any coefficient family reconstructed inside a compatible algebra tower is fixed by the
-adjoint blocked transfer map. -/
-theorem adjoint_blockedTransferMap_reconstructFromBlockedCoefficients_eq
-    (data : AlgebraStructureData d D) {M : MPOTensor d D}
-    (hCompat : data.CompatibleWith M) {n : ℕ} (hn : 0 < n)
-    (a : BlockedCoefficients data n) :
-    (blockedTransferMap M n).adjoint
-        (((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat)) =
-      (((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat)) :=
-  (hCompat n hn _).1 (data.reconstructFromBlockedCoefficients n a).property
-
 /-- The coefficient family of the blocked product of two chosen basis elements. -/
 noncomputable def blockedStructureCoefficients
     (data : AlgebraStructureData d D) (n : ℕ)
@@ -445,16 +434,6 @@ noncomputable def blockedInclusionCoefficients
         (data.blockedInclusionCoefficients n i) =
       data.iota n (data.blockedBasis n i) := by
   simp [blockedInclusionCoefficients]
-
-/-- Ambient-matrix form of the blocked inclusion reconstruction formula. -/
-theorem coe_iota_eq_sum_blockedInclusionCoefficients
-    (data : AlgebraStructureData d D) (n : ℕ) (i : BlockedIndex data n) :
-    ((data.iota n (data.blockedBasis n i) : data.A (n + 1)) : Mat) =
-      ∑ k, data.blockedInclusionCoefficients n i k •
-        ((data.blockedBasis (n + 1) k : data.A (n + 1)) : Mat) := by
-  simpa [reconstructFromBlockedInclusionCoefficients] using
-    coe_reconstructFromBlockedCoefficients_apply
-      (data := data) (n := n + 1) (a := data.blockedInclusionCoefficients n i)
 
 end AlgebraStructureData
 

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -223,12 +223,6 @@ theorem isRFP_MPDO_via_fusion_iff_fusionIsometryData_one (M : MPOTensor d D) :
     IsRFP_MPDO_via_fusion M ↔ Nonempty (FusionIsometryData M 1) := by
   rw [isRFP_MPDO_via_fusion_iff_isRFP, fusionIsometryData_one_iff_isRFP]
 
-/-- The transfer-map-level fusion formulation agrees with the pure-state RFP
-condition for the doubled-index MPS tensor. -/
-theorem isRFP_MPDO_via_fusion_iff_toMPSTensor_isRFP (M : MPOTensor d D) :
-    IsRFP_MPDO_via_fusion M ↔ MPSTensor.IsRFP M.toMPSTensor := by
-  rw [isRFP_MPDO_via_fusion_iff_isRFP, isRFP_iff_toMPSTensor_isRFP]
-
 end MPOTensor
 
 namespace MPSTensor

--- a/TNLean/MPS/MPDO/PRFP.lean
+++ b/TNLean/MPS/MPDO/PRFP.lean
@@ -57,14 +57,6 @@ def purifyingMPSTensor {dK D' : ℕ}
     purifyingMPSTensor A ik = A ik.divNat ik.modNat :=
   rfl
 
-/-- The LPDO condition expressed in terms of `IsLPDOWitness`. -/
-theorem isLPDO_iff_exists_witness (M : MPOTensor d D) :
-    IsLPDO M ↔
-      ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ)
-        (e : Fin D ≃ Fin D' × Fin D'),
-        IsLPDOWitness M A e :=
-  Iff.rfl
-
 /-- An MPO tensor has a **purification RFP** when it is an LPDO with a
 purifying family `A` whose purifying MPS tensor is a pure-state renormalization
 fixed point: `IsLPDO M` and `MPSTensor.IsRFP (purifyingMPSTensor A)`.

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -99,11 +99,6 @@ noncomputable def verticalTransferMap (M : MPOTensor d D) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
   MPSTensor.transferMap (diagonalTensor M)
 
-lemma verticalTransferMap_apply (M : MPOTensor d D)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    verticalTransferMap M X = ∑ i : Fin d, M i i * X * (M i i)ᴴ := by
-  simp [verticalTransferMap, diagonalTensor, MPSTensor.transferMap_apply]
-
 /-- Lightweight horizontal canonical-form data for a family of blocks.
 
 This is the fragment of the full canonical-form data needed for the MPDO

--- a/TNLean/PEPS/Blocking.lean
+++ b/TNLean/PEPS/Blocking.lean
@@ -92,30 +92,6 @@ omit [DecidableRel G.Adj] in
     simp [edgeMiddleVertices])
 
 omit [DecidableRel G.Adj] in
-theorem edgeLeftVertices_disjoint_edgeMiddleVertices (e : Edge G) :
-    Disjoint (edgeLeftVertices e) (edgeMiddleVertices e) := by
-  refine Finset.disjoint_left.mpr ?_
-  intro v hvLeft hvMiddle
-  exact (mem_edgeMiddleVertices_iff e v).mp hvMiddle |>.1 <| (mem_edgeLeftVertices e v).mp hvLeft
-
-omit [DecidableRel G.Adj] in
-theorem edgeRightVertices_disjoint_edgeMiddleVertices (e : Edge G) :
-    Disjoint (edgeRightVertices e) (edgeMiddleVertices e) := by
-  refine Finset.disjoint_left.mpr ?_
-  intro v hvRight hvMiddle
-  exact (mem_edgeMiddleVertices_iff e v).mp hvMiddle |>.2 <|
-    (mem_edgeRightVertices e v).mp hvRight
-
-omit [Fintype V] [DecidableRel G.Adj] in
-theorem edgeLeftVertices_disjoint_edgeRightVertices (e : Edge G) :
-    Disjoint (edgeLeftVertices e) (edgeRightVertices e) := by
-  refine Finset.disjoint_left.mpr ?_
-  intro v hvLeft hvRight
-  have hv₁ : v = e.1.1 := (mem_edgeLeftVertices e v).mp hvLeft
-  have hv₂ : v = e.1.2 := (mem_edgeRightVertices e v).mp hvRight
-  exact edgeLeft_ne_edgeRight e <| hv₁.symm.trans hv₂
-
-omit [DecidableRel G.Adj] in
 theorem edgeVertices_union (e : Edge G) :
     edgeLeftVertices e ∪ edgeMiddleVertices e ∪ edgeRightVertices e = Finset.univ := by
   ext v


### PR DESCRIPTION
### Motivation

- Eight auxiliary lemmas across `TNLean/MPS/MPDO/` and `TNLean/PEPS/Blocking.lean` had no remaining call sites and no blueprint references.
- Their mathematical content is already available from nearby definitions, reconstruction formulae, or membership lemmas. Removing the wrappers leaves the underlying statements as the single reference points.
- This supports #823, #826, #1373, and #2004 by keeping the MPDO/RFP and PEPS interfaces smaller while the paper-faithful statements are being aligned.

### Description

Removed declarations, all with no remaining references in `TNLean`, `blueprint/src`, `docs`, or `README.md`:

- `AlgebraStructureData.adjoint_blockedTransferMap_reconstructFromBlockedCoefficients_eq` in `AlgebraStructure.lean`
- `AlgebraStructureData.coe_iota_eq_sum_blockedInclusionCoefficients` in `AlgebraStructure.lean`
- `MPOTensor.isLPDO_iff_exists_witness` in `PRFP.lean`
- `MPOTensor.isRFP_MPDO_via_fusion_iff_toMPSTensor_isRFP` in `FusionIsometries.lean`
- `MPOTensor.verticalTransferMap_apply` in `VerticalCF.lean`
- `PEPS.edgeLeftVertices_disjoint_edgeMiddleVertices` in `PEPS/Blocking.lean`
- `PEPS.edgeRightVertices_disjoint_edgeMiddleVertices` in `PEPS/Blocking.lean`
- `PEPS.edgeLeftVertices_disjoint_edgeRightVertices` in `PEPS/Blocking.lean`

The PEPS partition facts `mem_edgeLeftVertices`, `mem_edgeMiddleVertices`, and `edgeVertices_union` are retained. No definitions are changed.

### Testing

- `rg -n "adjoint_blockedTransferMap_reconstructFromBlockedCoefficients_eq|coe_iota_eq_sum_blockedInclusionCoefficients|isLPDO_iff_exists_witness|isRFP_MPDO_via_fusion_iff_toMPSTensor_isRFP|verticalTransferMap_apply|edgeLeftVertices_disjoint_edgeMiddleVertices|edgeRightVertices_disjoint_edgeMiddleVertices|edgeLeftVertices_disjoint_edgeRightVertices" TNLean blueprint/src docs README.md -S`
- `git diff --check`
- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake env lean TNLean/MPS/MPDO/PRFP.lean`
- `lake env lean TNLean/MPS/MPDO/FusionIsometries.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake env lean TNLean/PEPS/Blocking.lean`
- `lake build TNLean`

---
Supports #823, #826, #1373, and #2004.