### PR TITLE
refactor: remove three duplicate reduction theorems on the canonical-form → FT path

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -48,64 +48,6 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 
-/-!
-## Derivation from MPS hypotheses
-
-For an irreducible TP tensor, all channel-level hypotheses needed by
-`exists_cyclic_sector_decomp_after_blocking` can be derived automatically:
-
-1. `IsIrreducibleTensor A` → `IsIrreducibleMap (transferMap (fun i => (A i)ᴴ))`
-2. TP + irreducible → ∃ ρ.PosDef fixed by `transferMap A` = `Kraus.adjointMap K`
-3. `peripheral_eigenvalues_cyclic_structure` → `(m, γ, IsPrimitiveRoot γ m, periph = {γ^k})`
-4. Feed all into `exists_cyclic_sector_decomp_after_blocking`
--/
-
-section CyclicSectorFromMPS
-
-open KadisonSchwarz
-
-/-- **Period removal for an irreducible TP tensor (1606.00608, §2.3).**
-
-For an irreducible TP tensor `A` with `0 < D`, there exists a period `m > 0`
-such that after blocking by `m`, the blocked tensor admits a unit-weight
-decomposition into `m` left-canonical (TP) blocks via cyclic spectral
-projections.  This is the period-removal step needed before the
-normal/BNT comparison in the non-periodic route of arXiv:1606.00608.
-
-The proof derives all intermediate channel-level hypotheses
-(`ρ.PosDef`, `Kraus.adjointMap` fixed point, `IsIrreducibleMap`,
-peripheral spectrum structure) from `conjTranspose_kraus_setup` and
-passes them to `exists_cyclic_sector_decomp_after_blocking`. -/
-theorem exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
-    {d D : ℕ} [NeZero D]
-    (A : MPSTensor d D)
-    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hIrr : IsIrreducibleTensor A) :
-    ∃ (m : ℕ) (_ : 0 < m)
-      (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
-      (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
-      SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) := by
-  -- Use shared setup to get conjugate Kraus family and PosDef fixed point.
-  obtain ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
-    conjTranspose_kraus_setup A hTP hIrr
-  -- Extract cyclic peripheral structure via
-  -- `peripheral_eigenvalues_cyclic_structure` from `GroupStructure.lean`.
-  obtain ⟨m, γ, hm_pos, hγ_prim, hperiph_set⟩ :=
-    PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure _ h_unitalK ρ hρ_pd h_adjfix hIrrK
-  -- Convert set representation to range form.
-  have hperiph_range :
-      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
-        Set.range (fun j : Fin m => γ ^ (j : ℕ)) := by
-    rw [hperiph_set]; ext x; simp [Set.mem_range, eq_comm]
-  -- Apply exists_cyclic_sector_decomp_after_blocking.
-  haveI : NeZero m := ⟨Nat.ne_of_gt hm_pos⟩
-  obtain ⟨dim, blocks, _, _, hTP_blocks, hSame, _, _, _, _, _, _, _⟩ :=
-    exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim
-      hperiph_range
-  exact ⟨m, hm_pos, dim, blocks, hTP_blocks, hSame⟩
-
-end CyclicSectorFromMPS
-
 section SectorOrbitLift
 
 /-!
@@ -417,8 +359,8 @@ positive bond dimensions.
 
 This encodes the unconditional sector-orbit lift into the single
 result consumed by the downstream common-blocking construction.  It is
-the period-removal counterpart of `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`
-strengthened with primitivity and irreducibility. -/
+the period-removal step of arXiv:1606.00608, §2.3, strengthened with
+primitivity and irreducibility of the sector blocks. -/
 theorem exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
@@ -32,19 +32,11 @@ The "zero tail" in the produced decomposition is the total bond dimension of
 the separated all-zero leftover blocks.  It is the dimension gap allowed by
 `∑ k, D_k ≤ D`, where the remaining summands are zero blocks.
 
-It also includes two immediate consequences when extra hypotheses are already
-available: the sorted normal-canonical-form criterion for blocked primitive
-families and the trivial-blocking shortcut for tensors that already come with a
-primitive block decomposition.
-
 ## Main statements
 
 * `exists_tp_primitive_blockDecomp_after_blocking` — arbitrary tensors admit a
   positive-length blocked decomposition into TP-primitive blocks, together with
   the separate zero-block bond-dimension count.
-* `isNormalCanonicalForm_of_tp_primitive_irr_sorted` — a blocked TP-primitive
-  family with irreducible blocks and non-increasing weights is already in
-  normal canonical form.
 
 ## References
 
@@ -175,47 +167,5 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
         A μ₀ blocks₀ hPos₀ P hP
   -- (f) Length-zero bond-dimension count.
   · exact hDimId₀.symm
-
-/-!
-## Conditional normal canonical form
-
-If the blocked weights are ordered by non-increasing norm, and the blocked
-blocks are irreducible, then the data can be shown to satisfy
-`IsNormalCanonicalForm`.  Equal weight moduli are allowed; requiring pairwise
-distinct norms is only a restricted separated-representative branch.
-
-This is a conditional theorem: the extra hypotheses are genuine conditions
-that the reduction does not produce automatically (see gap documentation above).
--/
-
-/-- **Conditional normal canonical form after blocking.**
-
-If the blocked data additionally satisfy tensor irreducibility for each block,
-and the weight moduli are already sorted in non-increasing order, then the data
-forms an `IsNormalCanonicalForm` directly.  Equal moduli are allowed here, as in
-the canonical form of arXiv:1606.00608; strict separation belongs only to the
-restricted strict-representative branch.
-
-For the unsorted case, use `exists_normalCanonicalForm_of_primitive_blockDecomp`
-which handles both sorting and blocking internally. -/
-theorem isNormalCanonicalForm_of_tp_primitive_irr_sorted
-    {d' : ℕ}
-    {r : ℕ} {dim : Fin r → ℕ}
-    {μ : Fin r → ℂ}
-    (blocks : (k : Fin r) → MPSTensor d' (dim k))
-    (hTP : ∀ k, ∑ i : Fin d', (blocks k i)ᴴ * blocks k i = 1)
-    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d') (D := dim k) (blocks k)))
-    (hDim : ∀ k, 0 < dim k)
-    (hμne : ∀ k, μ k ≠ 0)
-    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
-    (hAnti : Antitone (fun k : Fin r => ‖μ k‖)) :
-    IsNormalCanonicalForm (d := d') μ blocks :=
-  IsNormalCanonicalForm.ofSeparatedData
-    (HasIrreducibleBlocks.ofForall hIrr)
-    (IsLeftCanonicalBlockFamily.ofForall hTP)
-    (HasPrimitiveBlocks.ofForall hPrim)
-    { mu_antitone := hAnti
-      mu_ne_zero := hμne }
-    hDim
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
@@ -45,9 +45,6 @@ primitive block decomposition.
 * `isNormalCanonicalForm_of_tp_primitive_irr_sorted` — a blocked TP-primitive
   family with irreducible blocks and non-increasing weights is already in
   normal canonical form.
-* `exists_normalCanonicalForm_of_primitive_input` — primitive block data with
-  distinct weight norms yields a normal canonical form without nontrivial
-  blocking.
 
 ## References
 
@@ -220,44 +217,5 @@ theorem isNormalCanonicalForm_of_tp_primitive_irr_sorted
     { mu_antitone := hAnti
       mu_ne_zero := hμne }
     hDim
-
-/-!
-## Reduction shortcut for pre-primitive blocks
-
-When the tensor already has primitive blocks with distinct weight norms
-(e.g., from an external construction or a tensor that is already aperiodic),
-the blocking step is trivial (p = 1) and the full `IsNormalCanonicalForm`
-follows directly via `exists_normalCanonicalForm_of_primitive_blockDecomp`.
--/
-
-/-- **Reduction shortcut for pre-primitive blocks.**
-
-If an arbitrary tensor `A` already admits a primitive block decomposition with
-pairwise distinct weight norms, then the normal canonical form exists after
-trivial blocking (p = 1). -/
-theorem exists_normalCanonicalForm_of_primitive_input
-    (A : MPSTensor d D)
-    {r₁ : ℕ} {dim₁ : Fin r₁ → ℕ}
-    (μ₁ : Fin r₁ → ℂ)
-    (blocks₁ : (k : Fin r₁) → MPSTensor d (dim₁ k))
-    (hSame₁ : SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ₁) blocks₁))
-    (hIrr₁ : ∀ k, IsIrreducibleTensor (blocks₁ k))
-    (hTP₁ : ∀ k, ∑ i : Fin d, (blocks₁ k i)ᴴ * blocks₁ k i = 1)
-    (hPrim₁ : ∀ k,
-      _root_.IsPrimitive (transferMap (d := d) (D := dim₁ k) (blocks₁ k)))
-    (hDistinct : ∀ j k, j ≠ k → ‖μ₁ j‖ ≠ ‖μ₁ k‖)
-    (hμne₁ : ∀ k, μ₁ k ≠ 0)
-    (hDim₁ : ∀ k, 0 < dim₁ k) :
-    ∃ p : ℕ, 0 < p ∧
-      ∃ r : ℕ,
-      ∃ dim : Fin r → ℕ,
-      ∃ μ : Fin r → ℂ,
-      ∃ blocks : (k : Fin r) → MPSTensor (blockPhysDim d p) (dim k),
-        SameMPV₂
-          (blockTensor (d := d) (D := D) A p)
-          (toTensorFromBlocks (d := blockPhysDim d p) (μ := μ) blocks) ∧
-        IsNormalCanonicalForm (d := blockPhysDim d p) μ blocks :=
-  exists_normalCanonicalForm_of_primitive_blockDecomp
-    A μ₁ blocks₁ hSame₁ hIrr₁ hTP₁ hPrim₁ hDistinct hμne₁ hDim₁
 
 end MPSTensor

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -819,8 +819,8 @@ map~\cite[Theorem~6.6]{Wolf2012Quantum}.
 % as explicit hypotheses, whereas the blueprint statement above quantifies
 % only over the period. The hypotheses are derivable from the period-m
 % hypothesis and left-canonical irreducibility via the upstream Wielandt and
-% quantum Perron-Frobenius statements; the form used later is the next
-% theorem, thm:cyclic_sector_decomp_irr_tp, which carries the \leanok.
+% quantum Perron-Frobenius statements; the consumed form is the next
+% theorem, thm:cyclic_sector_decomp_irr_tp_prim_irr, which carries the \leanok.
 \begin{proof}
     The cyclic decomposition of the adjoint transfer map gives projections
     $(P_k)$ with $\E_{A^\dagger}(P_{k+1}) = P_k$. Iterating the cyclic relation
@@ -828,27 +828,6 @@ map~\cite[Theorem~6.6]{Wolf2012Quantum}.
     identity $\E_{(A^{[m]})^\dagger} = (\E_{A^\dagger})^m$ identifies these with
     the adjoint transfer map of $A^{[m]}$. Apply the block decomposition from
     adjoint-fixed projections.
-\end{proof}
-
-\begin{theorem}[Period removal for irreducible TP tensors]%
-    \label{thm:cyclic_sector_decomp_irr_tp}
-    \lean{MPSTensor.exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor}
-    \leanok
-    \uses{def:blocked_tensor, def:irreducible_tensor}
-    Let $A$ be a left-canonical irreducible tensor. Then there exist $m \ge 1$ and
-    left-canonical blocks $(C_k)_{k=1}^m$ such that $A^{[m]}$ admits a unit-weight
-    decomposition into the $C_k$. This is the period-removal step
-    of~\cite[Section~2.3]{Cirac2017MPDO_AnnPhys}.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:cyclic_sector_decomp_after_blocking}
-    Left-canonicality makes $K_i := (A^i)^\dagger$ unital, irreducibility passes
-    to the adjoint map, and the quantum Perron--Frobenius theorem provides a
-    positive-definite fixed point. The cyclic peripheral-spectrum theorem gives a
-    period $m$ and the cyclic projections and compression equivalences, and
-    Theorem~\ref{thm:cyclic_sector_decomp_after_blocking} produces the
-    decomposition.
 \end{proof}
 
 \begin{theorem}[Period removal with primitive irreducible sectors]%
@@ -869,9 +848,12 @@ map~\cite[Theorem~6.6]{Wolf2012Quantum}.
 \begin{proof}\leanok
     \uses{thm:peripheral_cyclic_structure,
         thm:cyclic_sector_decomp_after_blocking, thm:blocked_sector_unconditional}
-    Repeat the cyclic-sector construction of
-    Theorem~\ref{thm:cyclic_sector_decomp_irr_tp}, keep the projections and
-    compression equivalences, and apply
+    Left-canonicality makes $K_i := (A^i)^\dagger$ unital, irreducibility passes
+    to the adjoint map, and the quantum Perron--Frobenius theorem provides a
+    positive-definite fixed point; the cyclic peripheral-spectrum theorem and
+    Theorem~\ref{thm:cyclic_sector_decomp_after_blocking} then produce the
+    cyclic-sector decomposition. Keep the projections and compression
+    equivalences, and apply
     Theorem~\ref{thm:blocked_sector_unconditional} to the sector blocks.
 \end{proof}
 

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -186,33 +186,6 @@ an equality of MPV families.
     The hypotheses are exactly the constructor for normal canonical form.
 \end{proof}
 
-\begin{theorem}[Normal canonical form from an already primitive block decomposition]%
-    \label{thm:ncf_from_primitive_input}
-    \lean{MPSTensor.exists_normalCanonicalForm_of_primitive_input}
-    \leanok
-    \uses{def:is_normal_canonical_form}
-    Suppose $A$ admits a block decomposition into irreducible left-canonical
-    primitive blocks with pairwise distinct weight norms, nonzero weights, and
-    positive bond dimensions. Then there exist $p>0$, weights $(\nu_k)$, and
-    blocks $(B_k)$ satisfying Definition~\ref{def:is_normal_canonical_form} such
-    that, for every blocked $N$ and $\sigma$,
-    \[
-        V^{(N)}\!(A^{[p]})_\sigma
-        =
-        V^{(N)}\!(\textstyle\bigoplus_k \nu_k B_k)_\sigma.
-    \]
-    This is the after-blocking form of
-    Theorem~\ref{thm:exists_normal_canonical_form}; the distinct-modulus
-    hypothesis is the subcase discussed in the remark after
-    Definition~\ref{def:is_normal_canonical_form}.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:exists_normal_canonical_form}
-    Apply Theorem~\ref{thm:exists_normal_canonical_form} to the given primitive
-    block decomposition.
-\end{proof}
-
 \begin{theorem}[Common blocking period for two primitive normal tensors]%
     \label{thm:common_period_two_tensors}
     \lean{MPSTensor.bilateral_commonPeriod_blocking_tp_primitive_normal}

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -170,22 +170,6 @@ an equality of MPV families.
     irreducibility from Theorem~\ref{thm:blocked_irreducible_tp_primitive}.
 \end{proof}
 
-\begin{theorem}[Sorted TP primitive irreducible family forms a normal canonical form]%
-    \label{thm:ncf_sorted_tp_primitive_irred}
-    \lean{MPSTensor.isNormalCanonicalForm_of_tp_primitive_irr_sorted}
-    \leanok
-    \uses{def:is_normal_canonical_form}
-    Let $(\mu_k,A_k)_{k=1}^r$ have $|\mu_1| \ge \cdots \ge |\mu_r|$ and
-    $\mu_k \ne 0$ for every $k$. If every block is left-canonical, primitive,
-    irreducible, and of positive bond dimension, then $(\mu_k,A_k)_{k=1}^r$
-    satisfies the six conditions of Definition~\ref{def:is_normal_canonical_form}.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:is_normal_canonical_form}
-    The hypotheses are exactly the constructor for normal canonical form.
-\end{proof}
-
 \begin{theorem}[Common blocking period for two primitive normal tensors]%
     \label{thm:common_period_two_tensors}
     \lean{MPSTensor.bilateral_commonPeriod_blocking_tp_primitive_normal}


### PR DESCRIPTION
## Summary

Removes three **0-consumer duplicate reduction theorems** along the canonical-form → BNT → Fundamental-Theorem path. Each is a redundant restatement/weakening of a live headline theorem that the equal-MPV Fundamental Theorem actually consumes. Pure dead-code removal: `lake build` job count is unchanged (8746), confirming nothing downstream depended on them.

Continuation of the Ch9/Ch12 reduction-narrative cleanup merged in #2191.

## Removed (Lean decl + blueprint block)

| Removed | Verdict | Live replacement (kept) |
|---|---|---|
| `exists_normalCanonicalForm_of_primitive_input` (`thm:ncf_from_primitive_input`) | pass-through wrapper forwarding args verbatim | `exists_normalCanonicalForm_of_primitive_blockDecomp` (`thm:exists_normal_canonical_form`, 2 consumers) |
| `isNormalCanonicalForm_of_tp_primitive_irr_sorted` (`thm:ncf_sorted_tp_primitive_irred`) | restates the six conditions of the NCF definition | `IsNormalCanonicalForm.ofSeparatedData` / `def:is_normal_canonical_form` |
| `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` (`thm:cyclic_sector_decomp_irr_tp`) | strict weakening lacking the sector primitivity/irreducibility/positive-bond-dim consumed downstream | `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` (`thm:cyclic_sector_decomp_irr_tp_prim_irr`, 1 consumer, on the live FT path) |

Two ch08 prose refs to the removed period-removal label were repointed to the live `_prim_irr` sibling; one Lean docstring updated.

## Live path kept untouched
`exists_tp_gauge_blockwise` (1 consumer), `exists_normalCanonicalForm_of_primitive_blockDecomp` (headline), `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`, `exists_tp_primitive_blockDecomp_after_blocking`.

## Verification
- `lake build`: **8746 jobs, green** (= baseline, unchanged).
- Blueprint: `lualatex` ×2, rc 0, **0 undefined references**.
- checkdecls: 64 issues, **all pre-existing ch14 parent-Hamiltonian baseline**; 0 new, none from the removed decls.

🤖 Generated with TeXRA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of unreferenced theorems and documentation; the consumed APIs (`exists_primitive_irreducible_cyclic_sector_decomp`, `exists_tp_primitive_blockDecomp_after_blocking`, etc.) are unchanged.
> 
> **Overview**
> This PR **removes three unused Lean theorems** and their matching blueprint entries on the canonical-form → fundamental-theorem path—dead code only, with no change to the live reduction chain.
> 
> **Period removal:** Drops `exists_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` and blueprint `thm:cyclic_sector_decomp_irr_tp` (unit-weight cyclic decomposition only). The proof narrative now goes straight to **`exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`** (`thm:cyclic_sector_decomp_irr_tp_prim_irr`), which adds primitive, irreducible sector blocks—the form downstream actually uses.
> 
> **TP-primitive reduction:** Deletes `isNormalCanonicalForm_of_tp_primitive_irr_sorted` and `exists_normalCanonicalForm_of_primitive_input` plus their ch11b blueprint blocks. Those were restatements or thin wrappers; **`exists_normalCanonicalForm_of_primitive_blockDecomp`** and **`IsNormalCanonicalForm.ofSeparatedData`** remain.
> 
> **Docs:** ch08 drops the intermediate theorem/proof, folds the Perron–Frobenius/cyclic setup into the `_prim_irr` proof, and updates cross-references; **`CyclicSectorDecomposition.lean`** and **`TPPrimitiveReduction.lean`** module comments are trimmed accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f938722ca8aa1c59c6d64e654d9a0ae02afaa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->