### PR TITLE
refactor: remove dead equal-MPV gauge-equivalence duplicate statements (keep the literal FT headline)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -13,7 +13,7 @@ the main-text statement is at lines 354–361, the appendix restatement is at
 lines 1172–1179, the copy-weight comparison is at line 1188, and the
 global-gauge construction is at lines 1189–1192 of the Appendix MPV proof.
 
-The bundled-witness theorem `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses`
+The bundled-witness theorem `ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos`
 exposes, for any two BNT sector decompositions $P$ and $Q$ satisfying
 `IsBNTCanonicalForm` and generating the same MPV family:
 
@@ -137,117 +137,16 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos
   intro i
   exact hGauge i
 
-/-- Reformulation for the all-length `SameMPV₂` form. -/
-theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnesses
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
-      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
-      (_hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k)
-      (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
-      (ζ : Fin Q.basisCount → ℂ)
-      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ)
-      (_hTotal : P.totalDim = Q.totalDim)
-      (X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ),
-      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
-      (∀ (k : Fin Q.basisCount) (i : Fin d),
-        Q.basis k i =
-          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
-            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
-            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
-              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
-      (∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
-        Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ k q)) ∧
-      (∀ i : Fin d,
-        Q.toTensor i =
-          (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-                      (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
-            toTensorFromBlocks (d := d)
-              (μ := matched_p_weight (P := P) (Q := Q) β τ)
-              (matched_p_basis (P := P) (Q := Q) β hDim) i *
-            (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
-              Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-                     (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ)) :=
-  ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos
-    (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
-
-/-- **BNT equal-MPV corollary: gauge equivalence and bond-dimension equality.**
-
-If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
-same MPV family, their total bond dimensions agree and there exists a matrix $X$
-realizing the direct-sum global gauge of CPSV16 Appendix MPV proof,
-lines 1189–1192 in
-$Q$'s flattened sector coordinates.
-
-This is the CPSV16 equal-MPV corollary, labelled II_cor2, in gauge-equivalence
-form for two BNT canonical forms with the same expectation values; the witness
-bundle is provided by `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses`.
-
-CPSV16 §II.C lines 354–361. -/
-theorem ft_sector_bnt_equal_mps_gaugeEquivPos
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
-    (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
-    ∃ (_hTotal : P.totalDim = Q.totalDim),
-      ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
-        (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
-        (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
-        (X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ),
-        ∀ i : Fin d,
-          Q.toTensor i =
-            (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-                        (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
-              toTensorFromBlocks (d := d)
-                (μ := matched_p_weight (P := P) (Q := Q) β τ)
-                (matched_p_basis (P := P) (Q := Q) β hDim) i *
-              (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
-                Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-                       (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
-  classical
-  obtain ⟨β, hDim, _hCopies, τ, _ζ, _Xblock, _hTotal, X, _, _, _, hGauge⟩ :=
-    ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos hP hQ hUnitP hUnitQ hEqual
-  exact ⟨SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ,
-    β, hDim, τ, X, hGauge⟩
-
-/-- Reformulation for the all-length `SameMPV₂` form. -/
-theorem ft_sector_bnt_equal_mps_gaugeEquiv
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ (_hTotal : P.totalDim = Q.totalDim),
-      ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
-        (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
-        (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
-        (X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ),
-        ∀ i : Fin d,
-          Q.toTensor i =
-            (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-                        (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
-              toTensorFromBlocks (d := d)
-                (μ := matched_p_weight (P := P) (Q := Q) β τ)
-                (matched_p_basis (P := P) (Q := Q) β hDim) i *
-              (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
-                Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-                       (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :=
-  ft_sector_bnt_equal_mps_gaugeEquivPos
-    (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
-
 /-! ## Coordinate identification between matched and literal blocks
 
 The matched-coordinate `toTensorFromBlocks` and the literal `P.toTensor`
 differ only by a $\Sigma$-level permutation of flattened sector indices
 along `sectorFlatSigmaEquiv`; equivalently a permutation of
 `Fin Q.totalDim` (after the bond-dimension equality) by
-`sectorFlatDimEquiv`.  This lets us upgrade
-`ft_sector_bnt_equal_mps_gaugeEquiv` from the matched-coordinate form to the
-equal-MPV corollary form (CPSV16 §II.C lines 354–361). -/
+`sectorFlatDimEquiv`.  This lets us upgrade the matched-coordinate gauge
+equation of `ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos` into the literal
+form `ft_sector_bnt_equal_mps_gaugeEquiv_literalPos`, the equal-MPV corollary
+form (CPSV16 §II.C lines 354–361). -/
 
 /-- Cast of an `MPSTensor` along a bond-dimension equality, evaluated at one
 physical site and two bond indices, equals the underlying tensor evaluated at
@@ -525,7 +424,7 @@ at every physical site $i$, where the inner factor is the bond-dim cast of the
 literal $P$-tensor along the total-dimension equality.
 
 This reformulates the matched-coordinate gauge equation
-`ft_sector_bnt_equal_mps_gaugeEquiv` (CPSV16 Appendix MPV proof,
+`ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos` (CPSV16 Appendix MPV proof,
 lines 1189–1192) into the equal-MPV corollary labelled II_cor2 in CPSV16
 §II.C lines 354–361 by composing the matched-coordinate global gauge with the
 sector permutation.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -209,7 +209,7 @@ Paper anchor: CPSV16 §II.C lines 349–352 (theorem `thm1`), Appendix MPV
 theorem statement lines 1167–1170, and Appendix MPV proof line 1182 (matching
 proof); CPSV21 lines 1891–1894 (proportional-MPV theorem-level target).
 This is the proportional analogue
-of `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses` (`SectorBNT/FundamentalCoord.lean`)
+of `ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos` (`SectorBNT/FundamentalCoord.lean`)
 in the matching layer. The source proportional theorem stops at sector
 matching; the weight comparison and global gauge in CPSV16 Appendix MPV proof,
 lines 1187–1192, belong to the equal-MPV corollary unless an additional


### PR DESCRIPTION
## Summary

Collapses the `*Pos` / non-`Pos` **duplicate-statement ladder** in `MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean`. The file restated the equal-MPV Fundamental Theorem several times; three of those statements are dead intermediate duplicates — **0 real call-sites** anywhere in `TNLean/`, **not** referenced by any `\lean{}`/`\ref`/`\uses` in the blueprint, and **not** on the live proof chain of the headline.

Continuation of the canonical-form → BNT → FT duplicate-removal arc (#2189, #2191, #2193).

## Removed (0-consumer, not blueprint-anchored)
| Theorem | Why dead |
|---|---|
| `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses` | only docstring mentions; no call-site |
| `ft_sector_bnt_equal_mps_gaugeEquivPos` | only consumed by `_gaugeEquiv` (also removed) |
| `ft_sector_bnt_equal_mps_gaugeEquiv` | only docstring mentions; no call-site |

## Kept (live)
The blueprint-anchored headline `MPSTensor.ft_sector_bnt_equal_mps_gaugeEquiv_literal` (`\lean{}` at `ch10_bnt.tex:1617`) and its real proof chain `_literal → _literalPos → _witnessesPos → ft_sector_bnt_equal_global_gaugePos`. After removal, the only consumer of `_witnessesPos` is the live `_literalPos` — correct and expected. `Supplier.lean` `*Pos` statements untouched (live on the FT path).

Four docstrings (module header, the "coordinate identification" section note, the `_literal` docstring, and one note in `ProportionalMatch.lean`) were reworded to point at the surviving chain — no math/citation content lost.

## Verification
- `lake build`: **8746 jobs, green** (= baseline, unchanged).
- Blueprint: `lualatex` ×2, rc 0, **0 undefined references**.
- checkdecls: 64 issues, **all pre-existing ch14 baseline**; 0 new, none from the removed decls.

🤖 Generated with TeXRA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dead-declaration removal only; the blueprint-anchored literal FT theorem and its proof chain are unchanged.
> 
> **Overview**
> **`FundamentalCoord.lean`** drops three unused equal-MPV gauge-equivalence theorems (`ft_sector_bnt_equal_mps_gaugeEquiv_witnesses`, `ft_sector_bnt_equal_mps_gaugeEquivPos`, `ft_sector_bnt_equal_mps_gaugeEquiv`) that only wrapped `SameMPV₂` / thinner existential statements around the surviving `*Pos` / literal API. No proof terms on the live path change: **`ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos` → `ft_sector_bnt_equal_mps_gaugeEquiv_literalPos` → `ft_sector_bnt_equal_mps_gaugeEquiv_literal`** remains.
> 
> Module and section docstrings (and one cross-reference in **`ProportionalMatch.lean`**) now name **`ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos`** and the literal headline instead of the removed names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47564d77ca3fec488c550e93ee53625edd2f6c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->