### PR TITLE
refactor(MPS/CanonicalForm): remove unused flat-weight lemmas

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -106,11 +106,6 @@ def flatWeight (F : CommonBlockedCyclicSectorFamily blocks) :
     Fin (∑ k : Fin r, F.period k) → ℂ :=
   fun _ => 1
 
-/-- The unit weights of the flattened common-alphabet sectors are nonzero. -/
-theorem flatWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
-    (x : Fin (∑ k : Fin r, F.period k)) : F.flatWeight x ≠ 0 := by
-  simp [flatWeight]
-
 /-- The common-alphabet sector obtained by later reblocking one cyclic sector. -/
 noncomputable def commonSectorBlock (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -133,12 +133,6 @@ theorem toTensor_eq_toTensorFromBlocks_flat (P : SectorDecomposition d) :
     P.toTensor = toTensorFromBlocks (d := d) (μ := P.flatWeight) P.flatBasis :=
   rfl
 
-/-- Every flattened sector weight is nonzero. -/
-theorem flatWeight_ne_zero (P : SectorDecomposition d) (s : Fin P.totalCopies) :
-    P.flatWeight s ≠ 0 := by
-  simpa [SectorDecomposition.flatWeight] using
-    P.weight_ne_zero (P.flatIndexEquiv.symm s).1 (P.flatIndexEquiv.symm s).2
-
 /--
 Intermediate expansion: first sum over the basis index `j`, then over its copies `q`.
 -/


### PR DESCRIPTION
## Summary

- removes two unused `flatWeight_ne_zero` wrapper theorems from flattened sector constructions
- leaves the actual nonzero data in the underlying `weight_ne_zero` hypotheses and the used common-flat-weight theorem

Part of the single-source audit in #2194.

## Verification

- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean`
- `lake env lean TNLean/MPS/SharedInfra/SectorDecomposition.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only deletions of unreferenced lemmas; no API or runtime behavior change.
> 
> **Overview**
> Removes two unused **`flatWeight_ne_zero`** lemmas from flattened MPS sector infrastructure: one on **`CommonBlockedCyclicSectorFamily`** (constant unit **`flatWeight`**) and one on **`SectorDecomposition`** (wrapper around **`weight_ne_zero`** via **`flatIndexEquiv`**).
> 
> **`flatWeight`** definitions and downstream MPV/tensor assembly are unchanged. Nonzero flattened weights still come from **`SectorWeightData.weight_ne_zero`** / **`SectorDecomposition.weight_ne_zero`** and from **`commonFlatWeight_ne_zero`** where blocking uses nontrivial **`μ`**. Part of the single-source audit in #2194.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8253e3bfdf68400a2a5633cf6d42c9ac3682b427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->