### PR TITLE
refactor(MPS/CanonicalForm): remove duplicate blocking wrapper

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.MPS.Irreducible.FormII
-import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
 import TNLean.MPS.Tactic.Basic
@@ -31,7 +30,6 @@ and Cirac:
 * Pérez-García, Verstraete, Wolf, and Cirac, proof of Theorem Th:TIcanonical,
   lines 765-770 and 827-832: the full-rank fixed-point gauge and the final
   dual fixed-point diagonalization.
-* arXiv:1606.00608, lines 227-231: blocking removes peripheral periodicity.
 
 We also keep a couple of formulations for already-normalized primitive / injective block families,
 but those are **not** obtained from arbitrary input in this file.
@@ -203,30 +201,7 @@ theorem exists_CFII_data_of_TP_of_isIrreducibleTensor
 
 
 /-!
-## (4) Periodicity removal by blocking
-
-This is the Appendix-A periodicity-removal step for TP irreducible blocks, routed through the
-adjoint-transfer formulation.
--/
-
-/-- **Periodicity removal by blocking for irreducible trace-preserving blocks.**
-
-If `A` is trace-preserving and irreducible (tensor sense), then some physical blocking makes the
-transfer map primitive. -/
-theorem exists_blockTensor_isPrimitive
-    [NeZero D]
-    (A : MPSTensor d D)
-    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hIrr : IsIrreducibleTensor (d := d) (D := D) A) :
-    ∃ p : ℕ, 0 < p ∧
-      _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d p) (D := D) (blockTensor (d := d) (D := D) A p)) := by
-  have hDpos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
-  simpa using
-    (exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor (A := A) hTP hIrr hDpos)
-
-/-!
-## (5) Normality from primitive complementary-gap hypotheses
+## (4) Normality from primitive complementary-gap hypotheses
 
 For overlap and canonical-form hypotheses involving primitive transfer maps, we use the results from
 `PeripheralToTransferMapGap.lean` directly.

--- a/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.MPS.Core.Blocking
-import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
+import TNLean.MPS.Core.BlockingTransfer
 import TNLean.MPS.CanonicalForm.Existence
 import TNLean.PiAlgebra.CanonicalFormSep
 

--- a/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/Main.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.MPS.Core.Blocking
+import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.MPS.CanonicalForm.Existence
 import TNLean.PiAlgebra.CanonicalFormSep
 


### PR DESCRIPTION
## Summary

- removes the unused `exists_blockTensor_isPrimitive` wrapper from `CanonicalForm/Existence`
- leaves the blueprint-anchored periodicity-removal theorem `exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor` as the single formal statement
- drops the now-unneeded `BlockingViaAdjoint` import from `Existence.lean`

Part of the single-source audit in #2194.

## Verification

- `lake env lean TNLean/MPS/CanonicalForm/Existence.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/Main.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and import-surface cleanup only; the substantive blocking theorem is unchanged elsewhere in the library.
> 
> **Overview**
> Removes the thin **`exists_blockTensor_isPrimitive`** wrapper and its “periodicity removal by blocking” section from **`CanonicalForm/Existence.lean`**, along with the **`BlockingViaAdjoint`** import that existed only to support that re-export. Periodic blocking for TP irreducible tensors stays on the canonical theorem **`exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor`** in **`BlockingViaAdjoint`**, which downstream code (e.g. channel peripheral lemmas, blocking infrastructure) already calls directly.
> 
> Doc edits drop the Appendix-A blocking bullet from the existence file overview and renumber the following section. **`NormalReduction/Main.lean`** adds **`TNLean.MPS.Core.BlockingTransfer`** so blocking/transfer lemmas remain available on that import path after **`Existence`** stops pulling adjoint blocking in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d08ae65915f19d781b9342a8ef42cc574cc771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->