### PR TITLE
refactor(MPS/CanonicalForm): remove unused PGVWC07 weight lemma

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -99,20 +99,6 @@ structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
   original bond dimension. -/
   bondDim_le : ∑ k : Fin r, dim k ≤ D
 
-/-- Positive PGVWC07 witness weights are nonzero.
-
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-751--752, writes the canonical-form weights as positive real numbers.  In the
-positive-length witness, nonvanishing is therefore a consequence of the
-positive-real weight field. -/
-theorem PGVWC07PositiveLengthWitness.weight_ne_zero
-    {A : MPSTensor d D} (W : PGVWC07PositiveLengthWitness (d := d) (D := D) A) :
-    ∀ k, W.weights k ≠ 0 := by
-  intro k
-  obtain ⟨a, ha_pos, hweight⟩ := W.weight_pos k
-  rw [hweight]
-  exact_mod_cast (ne_of_gt ha_pos)
-
 private noncomputable def gaugeMulVecLinearEquiv {D : ℕ} (X : GL (Fin D) ℂ) :
     (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) where
   toFun v := (X : Matrix (Fin D) (Fin D) ℂ) *ᵥ v

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -291,13 +291,12 @@ The earlier existence path now has the following formal pieces.
           fields contain the nonzero unital blocks, positive real weights,
           diagonal positive-definite dual fixed points, scalar fixed-point
           conclusions, positive block dimensions, positive-length MPV equality,
-          and the total bond-dimension bound.  The companion theorem
-          \path|MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero| derives
-          nonvanishing of the weights from their positive-real form, so that
-          nonvanishing is not an additional field of the witness.  This is not
-          a new proof route; it is an equivalent formulation of the proved
-          positive-length theorem, intended to prevent later arguments from
-          repeating the long existential conclusion.
+          and the total bond-dimension bound.  Nonvanishing of the weights is
+          a direct consequence of their positive-real form, so nonvanishing is
+          not an additional field of the witness.  This is not a new proof
+          route; it is an equivalent formulation of the proved positive-length
+          theorem, intended to prevent later arguments from repeating the long
+          existential conclusion.
 
     \item
           \path|MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization|


### PR DESCRIPTION
## Summary

This PR continues the canonical-form single-source cleanup for #2194.

It removes the unused theorem
`MPSTensor.PGVWC07PositiveLengthWitness.weight_ne_zero`.  The statement only repackaged the existing `weight_pos` field of `PGVWC07PositiveLengthWitness`: every weight is already recorded as a positive real number embedded in `ℂ`, so nonvanishing follows directly when needed.

The PGVWC07 paper-gap note is updated so it describes the mathematical content of the witness without naming the retired theorem.

## Verification

- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `rg -n "PGVWC07PositiveLengthWitness\\.weight_ne_zero|positive_length_witness_weight_ne_zero" TNLean blueprint/src docs/paper-gaps`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and removal of an unused lemma with no change to `PGVWC07PositiveLengthWitness` fields or proof obligations.
> 
> **Overview**
> Removes the standalone theorem **`PGVWC07PositiveLengthWitness.weight_ne_zero`** from `TPGauge.lean`. That lemma only restated **`weight_pos`**: each weight is already a positive real embedded in `ℂ`, so nonvanishing is immediate when needed and did not need its own export.
> 
> The PGVWC07 scope note in **`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`** is reworded so it explains that nonvanishing follows from positive-real weights **without** citing the retired theorem name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0cb6b2d15b6625e49baca84091f595f77b7268d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->