### PR TITLE
refactor(MPS/CanonicalForm): remove unused projective PGVWC07 dichotomy

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -39,7 +39,6 @@ The imported modules provide the original public declarations:
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_mpv`
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`
-* `MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
 * `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean
@@ -314,11 +314,10 @@ theorem exists_pgvwc07_normalized_exact_form_after_rescaling_of_exists_ne_zero_m
 canonical-form statement.
 
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-742--763 and proof lines 765--766.  This is the exact positive-length analogue
-of `exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`:
-either every positive-length MPV coefficient vanishes, or, after a positive
-global rescaling of the original tensor, the normalized PGVWC07 block tensor
-has exactly the same positive-length MPV coefficients.
+742--763 and proof lines 765--766.  Either every positive-length MPV coefficient
+vanishes, or, after a positive global rescaling of the original tensor, the
+normalized PGVWC07 block tensor has exactly the same positive-length MPV
+coefficients.
 
 This theorem keeps the zero positive-length branch explicit.  The following
 theorem combines the two branches as the arbitrary-input positive-length
@@ -429,49 +428,5 @@ theorem exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty
         hν_le, hν_unit, hdim_pos, hMPV, hbond⟩
     exact ⟨scale, r, dim, ν, blocks, hscale_pos, hdual, hscalar, hν_pos,
       hν_le, fun _ => hν_unit, hdim_pos, hMPV, hbond⟩
-
-/-- Arbitrary-input zero/nonzero dichotomy for the projective PGVWC07
-canonical-form statement.
-
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-742--763 and proof lines 765--766.  This is a scope-separating formulation of
-the nonzero positive-length theorem above: either all positive-length MPV
-coefficients vanish, or the tensor has a nonempty normalized projective
-PGVWC07 block form.
-
-**Scope restriction:** This is the projective branch statement, not the primary
-exact positive-length theorem.  It records the zero positive-length branch
-explicitly; the length-zero convention is recorded in
-`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
-theorem exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero
-    (A : MPSTensor d D) :
-    (∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d, mpv A σ = 0) ∨
-    ∃ (r : ℕ) (dim : Fin r → ℕ)
-      (ν : Fin r → ℂ)
-      (blocks : (k : Fin r) → MPSTensor d (dim k)),
-      0 < r ∧
-      (∀ k,
-        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          Λ.PosDef ∧
-          Λ.IsDiag ∧
-          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
-          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
-      (∀ k,
-        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          transferMap (d := d) (D := dim k) (blocks k) X = X →
-            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
-      (∀ k, ∃ a : ℝ, 0 < a ∧ ν k = (a : ℂ)) ∧
-      (∀ k, ‖ν k‖ ≤ 1) ∧
-      (∃ k, ‖ν k‖ = 1) ∧
-      (∀ k, 0 < dim k) ∧
-      NonzeroProportionalMPV₂ A (toTensorFromBlocks (d := d) (μ := ν) blocks) ∧
-      ∑ k : Fin r, dim k ≤ D := by
-  classical
-  by_cases hA : ∃ (N : ℕ), 0 < N ∧ ∃ σ : Fin N → Fin d, mpv A σ ≠ 0
-  · exact Or.inr (exists_pgvwc07_normalized_projective_form_of_exists_ne_zero_mpv A hA)
-  · refine Or.inl ?_
-    intro N hN σ
-    by_contra hσ
-    exact hA ⟨N, hN, σ, hσ⟩
 
 end MPSTensor

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -381,13 +381,6 @@ The earlier existence path now has the following formal pieces.
           lengths the zero block contributes zero; at length zero the equality
           is the dimension identity \(D_0+\sum_kD_k=D\).
 
-    \item
-          \path|MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero|
-          records the arbitrary-input zero/nonzero dichotomy for this
-          projective formulation.  Either all positive-length MPV coefficients
-          of the original tensor vanish, or the preceding nonempty normalized
-          projective PGVWC07 form exists.
-
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an


### PR DESCRIPTION
## Summary

This PR continues the canonical-form single-source cleanup for #2194.

It removes the unused theorem
`MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero`.
The exact rescaled zero/nonzero theorem remains the active arbitrary-input statement:
`MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`, and the final allow-empty theorem continues to consume that exact statement.

The module summary and the PGVWC07 paper-gap note are updated so they no longer list the retired projective dichotomy as part of the current formal path.

## Verification

- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/WeightNormalization.lean`
- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction.lean`
- `rg -n "exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero" TNLean blueprint/src docs/paper-gaps`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion of an unreferenced theorem and documentation-only edits; no change to the primary exact canonical-form theorems or their proof chain.
> 
> **Overview**
> This PR **removes** the unused Lean theorem `MPSTensor.exists_pgvwc07_normalized_projective_form_or_forall_pos_mpv_eq_zero` and its ~45-line proof from `WeightNormalization.lean`, as part of the canonical-form single-source cleanup (#2194).
> 
> The **exact** arbitrary-input dichotomy `exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero` stays the active statement; `exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` still builds on it. Docs are aligned: the module import list in `NormalReduction.lean` drops the retired name, the doc on the exact dichotomy no longer compares itself to the removed projective theorem, and `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex` no longer lists the projective zero/nonzero dichotomy on the formal path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c13e7cbbffbe37cad9dfcb97fdf96768a20b532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->