### PR TITLE
refactor(MPS/CanonicalForm): remove duplicate normal-block wrapper

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -32,8 +32,6 @@ shows that blocking keeps normality.
   tensor irreducibility imply normality.
 * `exists_blockTensor_isInjective_of_tp_primitive_irreducible` — the same
   hypotheses give an extra blocking whose blocked tensor is one-site injective.
-* `isNormal_live_block_of_primitive` — the same conclusion for a single
-  nonzero-weight block from the reduction data.
 * `isNormal_blockTensor_of_isNormal` — blocking preserves normality.
 * `IsNormalCanonicalFormBNT.exists_common_blockTensor_isInjective` — a finite
   normal-canonical BNT family admits one positive blocking length at which all
@@ -287,18 +285,6 @@ theorem exists_pos_blockTensor_isInjective_le_pow_four_of_isNormal_leftCanonical
     refine ⟨L, hLpos, hBound, ?_⟩
     exact (isNBlkInjective_iff_blockTensor_isInjective A L).1
       ((wordSpan_eq_top_iff_isNBlkInjective A L).mp hTop)
-
-/-- **Pre-blocking blocks are normal once primitive.**
-
-For the nonzero-weight blocks from the arbitrary-tensor TP-gauge reduction, if a
-block additionally has a primitive transfer map, then it is normal. -/
-theorem isNormal_live_block_of_primitive [NeZero D]
-    (A : MPSTensor d D)
-    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hIrr : IsIrreducibleTensor A)
-    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A)) :
-    IsNormal A :=
-  isNormal_of_tp_primitive_irreducible A hTP hPrim hIrr
 
 /-!
 ## IsNormal is preserved by blocking

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -108,21 +108,8 @@ an equality of MPV families.
     positive scaling factors are absorbed into the weights $\mu_k$.
 \end{proof}
 
-\begin{theorem}[Primitive nonzero blocks are normal]%
-    \label{thm:normal_live_block_primitive}
-    \lean{MPSTensor.isNormal_live_block_of_primitive}
-    \leanok
-    \uses{def:normal, def:irreducible_tensor}
-    Let $A$ be irreducible of positive bond dimension. If
-    $\sum_i (A^i)^\dagger A^i = \Id$ and $\sigma_\partial(\E_A)=\{1\}$, then $A$ is
-    normal. This is the nonzero-block instance of
-    Theorem~\ref{thm:normal_tp_primitive_irred}.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:normal_tp_primitive_irred}
-    Apply Theorem~\ref{thm:normal_tp_primitive_irred}.
-\end{proof}
+For a primitive nonzero block satisfying the same hypotheses, normality is
+exactly Theorem~\ref{thm:normal_tp_primitive_irred}.
 
 \begin{theorem}[Blocking preserves irreducibility for primitive irreducible blocks]%
     \label{thm:blocked_irreducible_tp_primitive}


### PR DESCRIPTION
## Summary

This is a narrow step in #2194. The after-blocking chapter had a separate Lean declaration `MPSTensor.isNormal_live_block_of_primitive`, but that declaration was only the one-line specialization of `MPSTensor.isNormal_of_tp_primitive_irreducible` with the same hypotheses in a different order.

This PR removes the duplicate wrapper and changes the after-blocking blueprint prose to cite the single maintained theorem directly.

## Verification

- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean`
- `lake build`
- `cd blueprint && PATH="/Users/siruilu/Library/Python/3.9/bin:$PATH" leanblueprint web`
- `cd blueprint && PATH="/Users/siruilu/Library/Python/3.9/bin:$PATH" leanblueprint checkdecls` still reports the existing missing-declaration blueprint baseline; the removed wrapper and label are absent from `blueprint/lean_decls` and from the source tree.

Part of #2194.
