### PR TITLE
doc(blueprint): move common-sector labels to after-blocking chapter

### DIFF
--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -725,93 +725,9 @@ Definition~\ref{def:mpv_common_phase_cover}).
     so the conclusion follows directly from that lemma.
 \end{proof}
 
-\begin{definition}[Blocked-word identification for common sectors]%
-    \label{def:common_sector_relabeling_hypothesis}
-    \lean{MPSTensor.CommonSectorRelabelingHypothesis}
-    \leanok
-    This is the one-sided assertion that the canonically blocked weighted
-    nonzero part agrees, as an MPV family, with the same common cyclic-sector
-    family after identifying blocked physical words. It is the coordinate
-    equality between direct blocking and iterated blocking.
-\end{definition}
-
-The coordinate-grouping theorem below proves this assertion for the canonical
-word grouping.
-
-\begin{definition}[Global coordinate-grouping hypothesis for common sectors]%
-    \label{def:common_grouped_block_cast_hypothesis}
-    \lean{MPSTensor.CommonGroupedBlockCastHypothesis}
-    \leanok
-    \uses{def:common_blocked_cyclic_sector_grouped_block_cast}
-    This is the corresponding global assertion at the level of blocked words:
-    every common blocked cyclic-sector family satisfies the coordinate-grouping
-    condition for each original nonzero block. Equivalently, the canonical
-    identification with each iterated blocked alphabet agrees with grouping the
-    direct blocked word into consecutive words of the period-removal length.
-\end{definition}
-
-The next lemma proves this assertion from the concrete word-grouping
-construction.
-
-\begin{lemma}[Canonical coordinate grouping]%
-    \label{lem:common_grouped_block_cast_of_flatten_word}
-    \lean{MPSTensor.CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq}
-    \leanok
-    \uses{def:common_grouped_block_cast_hypothesis,
-        thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
-    The canonical coordinate grouping holds for every common blocked
-    cyclic-sector family. The proof identifies each grouped block with the
-    corresponding direct blocked word.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
-    Apply the grouped-block comparison to each original nonzero block.
-\end{proof}
-
-\begin{lemma}[Coordinate grouping gives the word identification]%
-    \label{lem:common_grouped_block_cast_to_relabeling}
-    \lean{MPSTensor.CommonGroupedBlockCastHypothesis.toRelabelingHypothesis}
-    \leanok
-    \uses{def:common_grouped_block_cast_hypothesis,
-        def:common_sector_relabeling_hypothesis,
-        thm:common_blocked_cyclic_sector_blocked_word_comparison}
-    If the global coordinate-grouping hypothesis holds, then the blocked-word
-    identification used by the common-sector structural theorem holds. The
-    proof is the weighted finite-sum comparison for direct and iterated blocking
-    applied to each common cyclic-sector family.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    \uses{thm:common_blocked_cyclic_sector_blocked_word_comparison}
-    Apply the coordinate-grouping comparison to each one-sided family and sum over
-    the original nonzero blocks with the corresponding powers of the weights.
-\end{proof}
-
-\begin{theorem}[Unconditional common primitive block decompositions]%
-    \label{thm:unconditional_common_primitive_irreducible_blocks}
-    \lean{MPSTensor.unconditional_commonPrimitiveIrreducibleBlocks}
-    \leanok
-    \uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-    Let $A$ and $B$ have the same MPV family. Then there is a positive blocking
-    length at which both blocked tensors have the same positive-length MPV
-    family as weighted direct sums of trace-preserving, primitive,
-    tensor-irreducible blocks with positive bond dimensions and nonzero weights.
-    The two weighted nonzero-sector families have the same positive-length MPV
-    family.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast,
-        lem:common_grouped_block_cast_to_relabeling,
-        thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-    The direct digit computation gives the global coordinate-grouping hypothesis.
-    This implies the blocked-word identification for common sectors. Applying the
-    common primitive decomposition theorem with this identification gives the
-    unconditional decomposition.
-\end{proof}
+The blocked-word identification and the resulting unconditional common
+primitive block decomposition are part of the after-blocking reduction;
+see Theorem~\ref{thm:unconditional_common_primitive_irreducible_blocks}.
 
 \begin{remark}[Equal-case comparison after canonical reduction]
     The source proof starts after both tensors have been put in canonical form

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -379,13 +379,21 @@ construction.
     \uses{def:common_grouped_block_cast_hypothesis,
         thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
     The canonical coordinate grouping holds for every common blocked
-    cyclic-sector family. The proof identifies each grouped block with the
-    corresponding direct blocked word.
+    cyclic-sector family.
 \end{lemma}
 
 \begin{proof}\leanok
     \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
-    Apply the grouped-block comparison to each original nonzero block.
+    For each original nonzero block $k$, write $m_k$ for its period-removal
+    length and $e_k$ for the later blocking length, so $p=m_k e_k$. The
+    digit-level identity gives, for every blocked coordinate $i$,
+    \[
+        \operatorname{flatten}_{m_k}\!
+        \bigl(\operatorname{word}_{(d^{[m_k]})^{[e_k]}}(i)\bigr)
+        =
+        \operatorname{word}_{d^{[p]}}(i).
+    \]
+    This is precisely the required coordinate grouping for the $k$th block.
 \end{proof}
 
 \begin{lemma}[Coordinate grouping gives the word identification]%
@@ -396,16 +404,32 @@ construction.
         def:common_sector_relabeling_hypothesis,
         thm:common_blocked_cyclic_sector_blocked_word_comparison}
     If the global coordinate-grouping hypothesis holds, then the blocked-word
-    identification used by the common-sector structural theorem holds. The
-    proof is the weighted finite-sum comparison for direct and iterated blocking
-    applied to each common cyclic-sector family.
+    identification used by the common-sector structural theorem holds.
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{thm:common_blocked_cyclic_sector_blocked_word_comparison}
-    Apply the coordinate-grouping comparison to each one-sided family and sum over
-    the original nonzero blocks with the corresponding powers of the weights.
+    Let $\widetilde B_k$ denote the $p$-blocked tensor of the $k$th original
+    nonzero block after transport to the common blocked alphabet. For every
+    length $N$ and every blocked word $\sigma$, the blockwise comparison gives
+    \[
+        V^{(N)}(B_k^{[p]})_\sigma
+        =
+        V^{(N)}(\widetilde B_k)_\sigma.
+    \]
+    Therefore the weighted sums agree:
+    \[
+        V^{(N)}\!
+        \bigl(\textstyle\bigoplus_k \mu_k^p B_k^{[p]}\bigr)_\sigma
+        =
+        \sum_k (\mu_k^p)^N V^{(N)}(B_k^{[p]})_\sigma
+        =
+        \sum_k (\mu_k^p)^N V^{(N)}(\widetilde B_k)_\sigma
+        =
+        V^{(N)}\!
+        \bigl(\textstyle\bigoplus_k \mu_k^p \widetilde B_k\bigr)_\sigma.
+    \]
 \end{proof}
 
 \begin{theorem}[Unconditional common primitive block decompositions]%
@@ -426,10 +450,30 @@ construction.
     \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast,
         lem:common_grouped_block_cast_to_relabeling,
         thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-    The direct digit computation gives the global coordinate-grouping hypothesis.
-    This implies the blocked-word identification for common sectors. Applying the
-    common primitive decomposition theorem with this identification gives the
-    unconditional decomposition.
+    For $p=mn$, the canonical digit grouping satisfies
+    \[
+        \operatorname{flatten}_{m}
+        \bigl(\operatorname{word}_{(d^{[m]})^{[n]}}(i)\bigr)
+        =
+        \operatorname{word}_{d^{[p]}}(i)
+    \]
+    for every blocked coordinate $i$. Hence the global coordinate-grouping
+    hypothesis holds, and
+    Lemma~\ref{lem:common_grouped_block_cast_to_relabeling} gives the
+    blocked-word identification for common sectors. Then
+    Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+    yields a positive length $p$ and weighted primitive block families such that,
+    for every $N\ge 1$ and blocked word $\sigma$,
+    \[
+        V^{(N)}\!(A^{[p]})_\sigma
+        =
+        V^{(N)}\!(\textstyle\bigoplus_x \mu^A_x A_x)_\sigma,
+        \qquad
+        V^{(N)}\!(B^{[p]})_\sigma
+        =
+        V^{(N)}\!(\textstyle\bigoplus_y \mu^B_y B_y)_\sigma,
+    \]
+    with the two weighted nonzero parts equal at every positive length.
 \end{proof}
 
 \section{Primitive-block decomposition of an arbitrary tensor}%

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -385,8 +385,8 @@ construction.
 \begin{proof}\leanok
     \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
     For each original nonzero block $k$, write $m_k$ for its period-removal
-    length and $e_k$ for the later blocking length, so $p=m_k e_k$. The
-    digit-level identity gives, for every blocked coordinate $i$,
+    length and $e_k$ for the later blocking length, so $p=m_k e_k$. For every
+    blocked coordinate $i$, the digit-level identity gives
     \[
         \operatorname{flatten}_{m_k}\!
         \bigl(\operatorname{word}_{(d^{[m_k]})^{[e_k]}}(i)\bigr)
@@ -447,18 +447,18 @@ construction.
 
 \begin{proof}
     \leanok
-    \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast,
+    \uses{lem:common_grouped_block_cast_of_flatten_word,
         lem:common_grouped_block_cast_to_relabeling,
         thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-    For $p=mn$, the canonical digit grouping satisfies
+    For $p=mn$ and every blocked coordinate $i$, the canonical digit grouping
+    satisfies
     \[
         \operatorname{flatten}_{m}
         \bigl(\operatorname{word}_{(d^{[m]})^{[n]}}(i)\bigr)
         =
-        \operatorname{word}_{d^{[p]}}(i)
+        \operatorname{word}_{d^{[p]}}(i).
     \]
-    for every blocked coordinate $i$. Hence the global coordinate-grouping
-    hypothesis holds, and
+    Hence the global coordinate-grouping hypothesis holds, and
     Lemma~\ref{lem:common_grouped_block_cast_to_relabeling} gives the
     blocked-word identification for common sectors. Then
     Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -344,6 +344,94 @@ exactly Theorem~\ref{thm:normal_tp_primitive_irred}.
     families.
 \end{proof}
 
+\begin{definition}[Blocked-word identification for common sectors]%
+    \label{def:common_sector_relabeling_hypothesis}
+    \lean{MPSTensor.CommonSectorRelabelingHypothesis}
+    \leanok
+    This is the one-sided assertion that the canonically blocked weighted
+    nonzero part agrees, as an MPV family, with the same common cyclic-sector
+    family after identifying blocked physical words. It is the coordinate
+    equality between direct blocking and iterated blocking.
+\end{definition}
+
+The coordinate-grouping theorem below proves this assertion for the canonical
+word grouping.
+
+\begin{definition}[Global coordinate-grouping hypothesis for common sectors]%
+    \label{def:common_grouped_block_cast_hypothesis}
+    \lean{MPSTensor.CommonGroupedBlockCastHypothesis}
+    \leanok
+    \uses{def:common_blocked_cyclic_sector_grouped_block_cast}
+    This is the corresponding global assertion at the level of blocked words:
+    every common blocked cyclic-sector family satisfies the coordinate-grouping
+    condition for each original nonzero block. Equivalently, the canonical
+    identification with each iterated blocked alphabet agrees with grouping the
+    direct blocked word into consecutive words of the period-removal length.
+\end{definition}
+
+The next lemma proves this assertion from the concrete word-grouping
+construction.
+
+\begin{lemma}[Canonical coordinate grouping]%
+    \label{lem:common_grouped_block_cast_of_flatten_word}
+    \lean{MPSTensor.CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq}
+    \leanok
+    \uses{def:common_grouped_block_cast_hypothesis,
+        thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+    The canonical coordinate grouping holds for every common blocked
+    cyclic-sector family. The proof identifies each grouped block with the
+    corresponding direct blocked word.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+    Apply the grouped-block comparison to each original nonzero block.
+\end{proof}
+
+\begin{lemma}[Coordinate grouping gives the word identification]%
+    \label{lem:common_grouped_block_cast_to_relabeling}
+    \lean{MPSTensor.CommonGroupedBlockCastHypothesis.toRelabelingHypothesis}
+    \leanok
+    \uses{def:common_grouped_block_cast_hypothesis,
+        def:common_sector_relabeling_hypothesis,
+        thm:common_blocked_cyclic_sector_blocked_word_comparison}
+    If the global coordinate-grouping hypothesis holds, then the blocked-word
+    identification used by the common-sector structural theorem holds. The
+    proof is the weighted finite-sum comparison for direct and iterated blocking
+    applied to each common cyclic-sector family.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:common_blocked_cyclic_sector_blocked_word_comparison}
+    Apply the coordinate-grouping comparison to each one-sided family and sum over
+    the original nonzero blocks with the corresponding powers of the weights.
+\end{proof}
+
+\begin{theorem}[Unconditional common primitive block decompositions]%
+    \label{thm:unconditional_common_primitive_irreducible_blocks}
+    \lean{MPSTensor.unconditional_commonPrimitiveIrreducibleBlocks}
+    \leanok
+    \uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+    Let $A$ and $B$ have the same MPV family. Then there is a positive blocking
+    length at which both blocked tensors have the same positive-length MPV
+    family as weighted direct sums of trace-preserving, primitive,
+    tensor-irreducible blocks with positive bond dimensions and nonzero weights.
+    The two weighted nonzero-sector families have the same positive-length MPV
+    family.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast,
+        lem:common_grouped_block_cast_to_relabeling,
+        thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+    The direct digit computation gives the global coordinate-grouping hypothesis.
+    This implies the blocked-word identification for common sectors. Applying the
+    common primitive decomposition theorem with this identification gives the
+    unconditional decomposition.
+\end{proof}
+
 \section{Primitive-block decomposition of an arbitrary tensor}%
 \label{sec:ch11b_primitive_block_reduction}
 


### PR DESCRIPTION
## Summary

This is a narrow blueprint organization step for #2194.

It moves the blocked-word identification labels and the unconditional common primitive-block decomposition theorem out of the later FT proof chapter and into `ch11b_after_blocking.tex`, where the after-blocking canonical-form reduction is recorded. The FT proof chapter now refers back to that theorem instead of restating the reduction locally.

No Lean declarations or theorem statements changed.

## Source

- arXiv:1606.00608, Section 2.3 and Appendix A
- `blueprint/src/chapter/ch11b_after_blocking.tex`
- `blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`

## Verification

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch11b_after_blocking.tex blueprint/src/chapter/ch11_fundamental_theorem_proof.tex`
- `cd blueprint && PATH="/Users/siruilu/Library/Python/3.9/bin:$PATH" leanblueprint web`
- `lake exe cache get`
- `lake build TNLean`
- `cd blueprint && PATH="/Users/siruilu/Library/Python/3.9/bin:$PATH" leanblueprint checkdecls` (fails only on the existing repository-wide missing-declaration baseline; the moved common-sector labels are not in the missing list)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX reorganization with unchanged Lean declarations; no runtime, auth, or data-path impact.
> 
> **Overview**
> This PR **relocates** the common-sector blocked-word identification material (definitions, coordinate-grouping lemmas, and **Theorem** `unconditional_common_primitive_irreducible_blocks`) from the Fundamental Theorem proof chapter into **`ch11b_after_blocking.tex`**, immediately after the reindexed common primitive-block theorem, so the narrative stays with the after-blocking canonical reduction.
> 
> The FT proof chapter **drops** that local restatement and instead **points** readers to `Theorem~\ref{thm:unconditional_common_primitive_irreducible_blocks}` in the after-blocking chapter. **Lean labels and theorem statements are unchanged**; several moved proofs are **expanded** with explicit digit-grouping and weighted MPV sum arguments.
> 
> No executable or formal proof code is modified—only blueprint LaTeX organization and exposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111bec4fcfd2bb99533e498845273334312e910f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->