### PR TITLE
refactor(MPS/CanonicalForm): remove duplicate reindexed-block wrapper

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -237,13 +237,13 @@ theorem commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
   let y := F.flatKey x
   simpa [commonFlatDim, y] using F.commonSectorBlock_dim_pos y.1 y.2
 
-/-- Iterated blocking of a nonzero-weight block is the relabeled common block.
+/-- The iterated blocked tensor `(B_k^{[m_k]})^{[e_k]}` agrees with the directly blocked
+tensor `B_k^{[p]}` after transport to the common blocked alphabet.
 
-This is an internal flattening/comparison lemma: it identifies the MPV
-family of the iterated block `(B_k^{[m_k]})^{[e_k]}` with that of the
-reindexed direct block of length `p = m_k e_k`.  The reindexing uses
-the canonical identification of blocked physical words. -/
-theorem nestedBlock_sameMPV₂_commonReindexedBlock
+By definition, `commonReindexedBlock k` is the direct `p`-blocked tensor of
+block `k`, transported to the common physical alphabet `blockPhysDim d p` by the canonical
+reindexing. -/
+theorem reindexed_sameMPV₂
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     SameMPV₂
       (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
@@ -268,7 +268,7 @@ theorem commonReindexedBlock_sameMPV₂_commonSectorTensor
         mpv (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
           (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
             (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k))) σ :=
-      ((F.nestedBlock_sameMPV₂_commonReindexedBlock k) N σ).symm
+      ((F.reindexed_sameMPV₂ k) N σ).symm
     _ = mpv (F.commonSectorTensor k) σ := by
       simpa [commonSectorTensor, commonSectorBlock] using F.nested_same k N σ
 
@@ -585,19 +585,6 @@ theorem derived_properties (F : CommonBlockedCyclicSectorFamily blocks)
     0 < F.sectorDim k s :=
   ⟨F.commonSectorBlock_tp k s, F.commonSectorBlock_primitive k s,
     F.commonSectorBlock_irreducible k s, F.commonSectorBlock_dim_pos k s⟩
-
-/-- The iterated blocked tensor `(B_k^{[m_k]})^{[e_k]}` agrees with the directly blocked
-tensor `B_k^{[p]}` (under the canonical alphabet identification) in the sense of
-generating the same MPV family.  By definition, `commonReindexedBlock k` is the direct
-$p$-blocked tensor of block $k$, transported to the common alphabet $d^{[p]}$ via the
-canonical reindexing. -/
-theorem reindexed_sameMPV₂ (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
-    SameMPV₂
-      (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
-        (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
-          (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k)))
-      (F.commonReindexedBlock k) :=
-  F.nestedBlock_sameMPV₂_commonReindexedBlock k
 
 /-- The direct $p$-blocked tensor $B_k^{[p]}$ has the same MPV family as its image in the
 common alphabet via `commonReindexedBlock`. This is the unconditional form of

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -240,8 +240,8 @@ theorem commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
 /-- The iterated blocked tensor `(B_k^{[m_k]})^{[e_k]}` agrees with the directly blocked
 tensor `B_k^{[p]}` after transport to the common blocked alphabet.
 
-By definition, `commonReindexedBlock k` is the direct `p`-blocked tensor of
-block `k`, transported to the common physical alphabet `blockPhysDim d p` by the canonical
+By definition, `commonReindexedBlock k` is the direct $p$-blocked tensor of
+block $k$, transported to the common physical alphabet $d^{[p]}$ by the canonical
 reindexing. -/
 theorem reindexed_sameMPV₂
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :


### PR DESCRIPTION
## Summary

This PR continues the canonical-form single-source audit from #2194. It removes the duplicate theorem `CommonBlockedCyclicSectorFamily.nestedBlock_sameMPV₂_commonReindexedBlock` and keeps `CommonBlockedCyclicSectorFamily.reindexed_sameMPV₂` as the single statement of the iterated-block/common-alphabet comparison.

The proof that compares a relabeled block with its common-sector tensor now calls `reindexed_sameMPV₂` directly. The blueprint-backed declaration name is unchanged, so the existing label `thm:common_blocked_cyclic_sector_reindexed_samempv` still points to the maintained theorem.

## Verification

- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorFamily`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean`
- `git diff --check`

The full build has only the repository-existing `sorry` warnings in PEPS and periodic-overlap files.

Closes part of #2194.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-preserving rename and doc consolidation in one MPS canonical-form Lean file; no API or runtime behavior change.
> 
> **Overview**
> **`reindexed_sameMPV₂`** is now the single Lean theorem for iterated vs. common-alphabet blocking: the former duplicate **`nestedBlock_sameMPV₂_commonReindexedBlock`** is removed, its docstring is merged into **`reindexed_sameMPV₂`**, and the proof lives at the earlier site (no thin wrapper later in the file).
> 
> **`commonReindexedBlock_sameMPV₂_commonSectorTensor`** now cites **`reindexed_sameMPV₂`** instead of the deleted name. The blueprint-facing name **`reindexed_sameMPV₂`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deb9f6d38b82dfbc9f8c572a1a2731251c8bde54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->