### PR TITLE
refactor(MPS/CanonicalForm): remove global grouping wrapper

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -14,16 +14,15 @@ namespace MPSTensor
 # Common-sector transport after canonical-form blocking
 
 This module contains the common-sector reindexing hypotheses used after the
-structural canonical-form reduction has produced common cyclic-sector data.
+structural canonical-form reduction has produced common cyclic-sector families.
 
 ## Main statements
 
-* `CommonSectorRelabelingHypothesis` and
-  `CommonGroupedBlockCastHypothesis` encode the remaining blocked-word
-  comparison data.
+* `CommonSectorRelabelingHypothesis` encodes the remaining blocked-word
+  comparison hypothesis used by the conditional common-sector theorem.
 * `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
   and `unconditional_commonPrimitiveIrreducibleBlocks` turn the structural
-  common-sector data into common primitive irreducible block decompositions.
+  common-sector families into common primitive irreducible block decompositions.
 
 ## References
 
@@ -35,7 +34,7 @@ structural canonical-form reduction has produced common cyclic-sector data.
 matrix product states, canonical form, common sectors
 -/
 
-/-- The one-sided blocked-word relabeling hypothesis for cyclic-sector data.
+/-- The one-sided blocked-word relabeling hypothesis for cyclic-sector families.
 
 It says that, for every common cyclic-sector family, the canonically blocked
 weighted nonzero tensor agrees as an MPV family with the same blocks read through
@@ -51,37 +50,6 @@ abbrev CommonSectorRelabelingHypothesis (d : ℕ) : Prop :=
         (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)
-
-/-- The global coordinate-grouping assertion for common cyclic-sector families.
-
-It requires every common blocked cyclic-sector family to satisfy the
-coordinate-grouping condition for each original block, so the canonical identification
-with the iterated blocked alphabet is the explicit grouping of direct blocked words. -/
-abbrev CommonGroupedBlockCastHypothesis (d : ℕ) : Prop :=
-  ∀ {r : ℕ} {dim : Fin r → ℕ}
-    (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (F : CommonBlockedCyclicSectorFamily blocks),
-    ∀ k : Fin r, F.groupedBlockCastAgrees k
-
-namespace CommonGroupedBlockCastHypothesis
-
-/-- The canonical coordinate grouping for common blocked cyclic-sector families. -/
-lemma of_flattenWordOfBlock_cast_eq (d : ℕ) : CommonGroupedBlockCastHypothesis d := by
-  intro r dim blocks F k
-  exact F.groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
-    (fun hp_eq h_card i =>
-      CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq hp_eq h_card i) k
-
-/-- The coordinate-grouping assertion implies the one-sided reindexing hypothesis
-used by the common-sector structural theorem. -/
-lemma toRelabelingHypothesis {d : ℕ}
-    (hCast : CommonGroupedBlockCastHypothesis d) :
-    CommonSectorRelabelingHypothesis d := by
-  intro r dim μ blocks F
-  exact F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees μ
-    (hCast blocks F)
-
-end CommonGroupedBlockCastHypothesis
 
 set_option maxHeartbeats 800000 in
 -- The conclusion records both decompositions and all their structural hypotheses together.
@@ -223,17 +191,9 @@ theorem afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
 
 /-- **Unconditional common primitive irreducible block decompositions.**
 
-The proved blocked-word flattening identity supplies the grouped-cast hypothesis needed to
-apply `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts` without any
-blocking-coordinate hypothesis.
-
-The proof chains:
-1. `flattenWordOfBlock_cast_eq` → `CommonGroupedBlockCastHypothesis d`
-   (via `groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq`)
-2. `CommonGroupedBlockCastHypothesis d` → `CommonSectorRelabelingHypothesis d`
-   (via `CommonGroupedBlockCastHypothesis.toRelabelingHypothesis`)
-3. `CommonSectorRelabelingHypothesis d` → the full common-block decomposition
-   (via `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`)
+The proof obtains the required relabeling assertion directly from the family-level
+comparison between direct blocking and the common alphabet, then assembles the
+blockwise equalities over the weighted direct sum.
 -/
 theorem unconditional_commonPrimitiveIrreducibleBlocks
     {d D₁ D₂ : ℕ}
@@ -263,10 +223,10 @@ theorem unconditional_commonPrimitiveIrreducibleBlocks
       (∀ x, IsIrreducibleTensor (blocksB x)) ∧
       (∀ x, 0 < dimA x) ∧
       (∀ x, 0 < dimB x) := by
-  have h_group : CommonGroupedBlockCastHypothesis d :=
-    CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq d
   have h_relabel : CommonSectorRelabelingHypothesis d :=
-    h_group.toRelabelingHypothesis
+    fun μ blocks F =>
+      F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise μ
+        (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock k)
   exact afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
     A B hSame h_relabel
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1379,7 +1379,8 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
 \begin{lemma}[Reindexed nonzero-part identity]%
     \label{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
     \lean{MPSTensor.CommonBlockedCyclicSectorFamily.reindexed_nonzero_part}\leanok
-    \uses{thm:common_blocked_cyclic_sector_reindexed_samempv}
+    \uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
+        thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
     The nonzero-part decomposition of $\bigoplus_k \mu_k B_k$ carries over under
     the common-alphabet identification of
     Lemma~\ref{thm:common_blocked_cyclic_sector_reindexed_samempv}: the
@@ -1406,11 +1407,39 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
     equal.
 \end{lemma}
 
+\begin{lemma}[Direct blocking in the common alphabet]%
+    \label{thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
+    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock}\leanok
+    \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+    For every original block $B_k$, direct blocking at the common length
+    $p=m_k e_k$ agrees, as an MPV family, with the same block transported to the
+    common blocked alphabet. Write $\widetilde B_k$ for this common-alphabet
+    image. Then
+    \[
+        V^{(N)}\!(B_k^{[p]})_\sigma
+        =
+        V^{(N)}\!(\widetilde B_k)_\sigma .
+    \]
+\end{lemma}
+
+\begin{lemma}[Weighted assembly in the common alphabet]%
+    \label{thm:common_blocked_cyclic_sector_weighted_common_reindexed}
+    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise}\leanok
+    \uses{thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
+    If each direct block $B_k^{[p]}$ agrees with its common-alphabet image
+    $\widetilde B_k$, then the weighted direct sums agree:
+    \[
+        V^{(N)}\!\bigl(\textstyle\bigoplus_k \mu_k^p B_k^{[p]}\bigr)_\sigma
+        =
+        V^{(N)}\!\bigl(\textstyle\bigoplus_k \mu_k^p \widetilde B_k\bigr)_\sigma .
+    \]
+\end{lemma}
+
 \begin{lemma}[Direct and iterated blocking comparison]%
     \label{thm:common_blocked_cyclic_sector_blocked_word_comparison}
     \lean{MPSTensor.CommonBlockedCyclicSectorFamily.blocked_word_comparison}\leanok
     \uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
-        def:common_blocked_cyclic_sector_grouped_block_cast}
+        thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
     Direct blocking at length $p = m_k e_k$ and iterated blocking
     $(B_k^{[m_k]})^{[e_k]}$ produce, after the canonical alphabet identification,
     the same weighted finite sum: for every $N \ge 0$ and every blocked word

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -354,89 +354,17 @@ exactly Theorem~\ref{thm:normal_tp_primitive_irred}.
     equality between direct blocking and iterated blocking.
 \end{definition}
 
-The coordinate-grouping theorem below proves this assertion for the canonical
-word grouping.
-
-\begin{definition}[Global coordinate-grouping hypothesis for common sectors]%
-    \label{def:common_grouped_block_cast_hypothesis}
-    \lean{MPSTensor.CommonGroupedBlockCastHypothesis}
-    \leanok
-    \uses{def:common_blocked_cyclic_sector_grouped_block_cast}
-    This is the corresponding global assertion at the level of blocked words:
-    every common blocked cyclic-sector family satisfies the coordinate-grouping
-    condition for each original nonzero block. Equivalently, the canonical
-    identification with each iterated blocked alphabet agrees with grouping the
-    direct blocked word into consecutive words of the period-removal length.
-\end{definition}
-
-The next lemma proves this assertion from the concrete word-grouping
-construction.
-
-\begin{lemma}[Canonical coordinate grouping]%
-    \label{lem:common_grouped_block_cast_of_flatten_word}
-    \lean{MPSTensor.CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq}
-    \leanok
-    \uses{def:common_grouped_block_cast_hypothesis,
-        thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
-    The canonical coordinate grouping holds for every common blocked
-    cyclic-sector family.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
-    For each original nonzero block $k$, write $m_k$ for its period-removal
-    length and $e_k$ for the later blocking length, so $p=m_k e_k$. For every
-    blocked coordinate $i$, the digit-level identity gives
-    \[
-        \operatorname{flatten}_{m_k}\!
-        \bigl(\operatorname{word}_{(d^{[m_k]})^{[e_k]}}(i)\bigr)
-        =
-        \operatorname{word}_{d^{[p]}}(i).
-    \]
-    This is precisely the required coordinate grouping for the $k$th block.
-\end{proof}
-
-\begin{lemma}[Coordinate grouping gives the word identification]%
-    \label{lem:common_grouped_block_cast_to_relabeling}
-    \lean{MPSTensor.CommonGroupedBlockCastHypothesis.toRelabelingHypothesis}
-    \leanok
-    \uses{def:common_grouped_block_cast_hypothesis,
-        def:common_sector_relabeling_hypothesis,
-        thm:common_blocked_cyclic_sector_blocked_word_comparison}
-    If the global coordinate-grouping hypothesis holds, then the blocked-word
-    identification used by the common-sector structural theorem holds.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    \uses{thm:common_blocked_cyclic_sector_blocked_word_comparison}
-    Let $\widetilde B_k$ denote the $p$-blocked tensor of the $k$th original
-    nonzero block after transport to the common blocked alphabet. For every
-    length $N$ and every blocked word $\sigma$, the blockwise comparison gives
-    \[
-        V^{(N)}(B_k^{[p]})_\sigma
-        =
-        V^{(N)}(\widetilde B_k)_\sigma.
-    \]
-    Therefore the weighted sums agree:
-    \[
-        V^{(N)}\!
-        \bigl(\textstyle\bigoplus_k \mu_k^p B_k^{[p]}\bigr)_\sigma
-        =
-        \sum_k (\mu_k^p)^N V^{(N)}(B_k^{[p]})_\sigma
-        =
-        \sum_k (\mu_k^p)^N V^{(N)}(\widetilde B_k)_\sigma
-        =
-        V^{(N)}\!
-        \bigl(\textstyle\bigoplus_k \mu_k^p \widetilde B_k\bigr)_\sigma.
-    \]
-\end{proof}
+The unconditional theorem below obtains this assertion directly from the
+blockwise common-alphabet comparison already proved for common cyclic-sector
+families.
 
 \begin{theorem}[Unconditional common primitive block decompositions]%
     \label{thm:unconditional_common_primitive_irreducible_blocks}
     \lean{MPSTensor.unconditional_commonPrimitiveIrreducibleBlocks}
     \leanok
-    \uses{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+    \uses{thm:common_blocked_cyclic_sector_block_tensor_common_reindexed,
+        thm:common_blocked_cyclic_sector_weighted_common_reindexed,
+        thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
     Let $A$ and $B$ have the same MPV family. Then there is a positive blocking
     length at which both blocked tensors have the same positive-length MPV
     family as weighted direct sums of trace-preserving, primitive,
@@ -447,20 +375,33 @@ construction.
 
 \begin{proof}
     \leanok
-    \uses{lem:common_grouped_block_cast_of_flatten_word,
-        lem:common_grouped_block_cast_to_relabeling,
+    \uses{thm:common_blocked_cyclic_sector_block_tensor_common_reindexed,
+        thm:common_blocked_cyclic_sector_weighted_common_reindexed,
         thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-    For $p=mn$ and every blocked coordinate $i$, the canonical digit grouping
-    satisfies
+    Write $\widetilde B_k$ for the image of $B_k^{[p]}$ in the common blocked
+    alphabet.
+    For each common cyclic-sector family, the canonical identification between
+    direct $p$-blocking and the transported common alphabet gives, for every
+    length $N$ and blocked word $\sigma$,
     \[
-        \operatorname{flatten}_{m}
-        \bigl(\operatorname{word}_{(d^{[m]})^{[n]}}(i)\bigr)
+        V^{(N)}(B_k^{[p]})_\sigma
         =
-        \operatorname{word}_{d^{[p]}}(i).
+        V^{(N)}(\widetilde B_k)_\sigma .
     \]
-    Hence the global coordinate-grouping hypothesis holds, and
-    Lemma~\ref{lem:common_grouped_block_cast_to_relabeling} gives the
-    blocked-word identification for common sectors. Then
+    The weighted direct sums therefore satisfy
+    \[
+        V^{(N)}\!
+        \bigl(\textstyle\bigoplus_k \mu_k^p B_k^{[p]}\bigr)_\sigma
+        =
+        \sum_k (\mu_k^p)^N V^{(N)}(B_k^{[p]})_\sigma
+        =
+        \sum_k (\mu_k^p)^N V^{(N)}(\widetilde B_k)_\sigma
+        =
+        V^{(N)}\!
+        \bigl(\textstyle\bigoplus_k \mu_k^p \widetilde B_k\bigr)_\sigma .
+    \]
+    This is the relabeling hypothesis of
+    Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}. Then
     Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
     yields a positive length $p$ and weighted primitive block families such that,
     for every $N\ge 1$ and blocked word $\sigma$,

--- a/docs/paper-gaps/common_sector_relabeling_hypothesis.tex
+++ b/docs/paper-gaps/common_sector_relabeling_hypothesis.tex
@@ -50,10 +50,12 @@ No deviation from the source paper is present. The relabeling assertion is the
 identity between two descriptions of the same blocked-word coordinates, and the
 formalization proves it unconditionally before using it in the sector-comparison
 theorems.\footnote{%
-    The proof is
-    \leanid{CommonGroupedBlockCastHypothesis.of_flattenWordOfBlock_cast_eq},
-    and \leanid{CommonGroupedBlockCastHypothesis.toRelabelingHypothesis} gives
-    the stated relabeling hypothesis. Both declarations are in
+    The family-level proof is
+    \leanid{CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock};
+    the unconditional common-sector theorem assembles these blockwise identities
+    directly into the stated relabeling hypothesis. The declarations are in
+    \doclink{TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean}
+    and
     \doclink{TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean}.}
 
 \section{Verdict}


### PR DESCRIPTION
## Summary
- removes the global `CommonGroupedBlockCastHypothesis` wrapper and its two namespace lemmas
- has `unconditional_commonPrimitiveIrreducibleBlocks` assemble the relabeling hypothesis directly from the family-level common-alphabet comparison
- updates the after-blocking blueprint and the common-sector relabeling paper-gap note to point to that single source

## Verification
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean`
- `git diff --check`

`lake exe checkdecls blueprint/lean_decls` was also run after generating `blueprint/lean_decls`; it reaches the known repository-wide parent-Hamiltonian and PEPS declaration gaps on `main`, not the removed common-sector names.

Progress for #2194.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure and documentation refactor only; the relabeling statement and downstream conditional theorem interface are unchanged, with no auth, security, or runtime impact.
> 
> **Overview**
> This refactor **removes the intermediate `CommonGroupedBlockCastHypothesis` layer** (global coordinate-grouping `Prop` plus `of_flattenWordOfBlock_cast_eq` and `toRelabelingHypothesis`) from `CommonSectorTransport.lean`. The conditional theorem still takes **`CommonSectorRelabelingHypothesis`**; only how the unconditional result obtains it changes.
> 
> **`unconditional_commonPrimitiveIrreducibleBlocks`** now builds that hypothesis **in one step** from family-level lemmas on `CommonBlockedCyclicSectorFamily`: per-block `blockTensor_sameMPV₂_commonReindexedBlock`, then `sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise`, instead of flattening → grouped cast → relabeling.
> 
> Blueprint (**ch08**, **ch11b_after_blocking**) and **`docs/paper-gaps/common_sector_relabeling_hypothesis.tex`** drop the grouped-cast definition/lemmas/proof chain and cite the blockwise common-alphabet comparison as the single source for the unconditional common-sector theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e285b7b406aabec7d39d88696c98d723553075a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->