### PR TITLE
refactor(MPS/CanonicalForm): hide internal grouping predicate

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -331,7 +331,8 @@ and do not correspond to independent results of CPSV.
 
 /-- The canonical identification from the common blocked alphabet to one iterated blocked alphabet
 agrees with the map obtained by grouping a direct blocked word into consecutive blocks. -/
-def groupedBlockCastAgrees (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) : Prop :=
+private def groupedBlockCastAgrees
+    (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) : Prop :=
   ∀ i : Fin (blockPhysDim d F.p),
     Fin.cast ((F.blockPhysDim_nested_eq k).symm) i =
       directToIteratedBlockIndex d (F.period k) (F.extra k)
@@ -341,7 +342,7 @@ def groupedBlockCastAgrees (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin
 order-preserving cast from the common blocked alphabet gives the corresponding direct
 blocked index.  This isolates the remaining point as a comparison between the `Fin.cast`
 identification and the canonical direct/iterated blocking equivalence. -/
-theorem groupedBlockCastAgrees_iff_iteratedBlockIndex_cast
+private theorem groupedBlockCastAgrees_iff_iteratedBlockIndex_cast
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     F.groupedBlockCastAgrees k ↔
       ∀ i : Fin (blockPhysDim d F.p),
@@ -401,7 +402,7 @@ theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
 
 /-- The global grouping-cast hypothesis applied to a specific family reduces to the
 core Fintype-level assertion. -/
-theorem groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
+private theorem groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
     {d : ℕ} (h_flatten : ∀ {m n p : ℕ} (_ : p = m * n)
       (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
       (i : Fin (blockPhysDim d p)),
@@ -438,7 +439,7 @@ theorem groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
 /-- The blocked-word comparison follows if the canonical identification from the common
 alphabet to an iterated alphabet agrees with the grouping map that reads a direct word in
 consecutive blocks of length $m_k$ (the period of block $k$). -/
-theorem wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees
+private theorem wordOfBlock_eq_iteratedBlockIndex_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hCast : F.groupedBlockCastAgrees k) :
     ∀ i : Fin (blockPhysDim d F.p),
@@ -469,7 +470,7 @@ one original block gives the corresponding block obtained through iterated block
 
 The hypothesis compares the word read from the common block alphabet with the word
 read after first viewing the same index as an iterated block and then flattening it. -/
-theorem blockTensor_eq_commonReindexedBlock_of_word_eq
+private theorem blockTensor_eq_commonReindexedBlock_of_word_eq
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hWord : ∀ i : Fin (blockPhysDim d F.p),
       wordOfBlock d F.p i =
@@ -484,7 +485,7 @@ theorem blockTensor_eq_commonReindexedBlock_of_word_eq
 /-- Direct blocking of one original block is the relabeled common block when the
 canonical identification with the iterated alphabet agrees with consecutive grouping of the
 direct word. -/
-theorem blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees
+private theorem blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hCast : F.groupedBlockCastAgrees k) :
     blockTensor (d := d) (D := dim k) (blocks k) F.p = F.commonReindexedBlock k :=
@@ -493,7 +494,7 @@ theorem blockTensor_eq_commonReindexedBlock_of_groupedBlockCastAgrees
 
 /-- Direct and iterated common blocking of one original block have the same MPV family
 when the canonical identification with the iterated alphabet agrees with consecutive grouping. -/
-theorem blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees
+private theorem blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r)
     (hCast : F.groupedBlockCastAgrees k) :
     SameMPV₂
@@ -532,21 +533,6 @@ theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise
         (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock) σ :=
           (mpv_toTensorFromBlocks_eq_sum (fun k : Fin r => (μ k) ^ F.p)
             F.commonReindexedBlock σ).symm
-
-/-- Agreement between the canonical identifications and the consecutive grouping maps assembles
-the weighted direct sum obtained by direct blocking with the one obtained through iterated
-blocking. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees
-    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
-    (hCast : ∀ k : Fin r, F.groupedBlockCastAgrees k) :
-    SameMPV₂
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p)
-        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock) :=
-  F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise μ
-    (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k (hCast k))
 
 /-- If the canonical blocked nonzero part agrees with the explicitly reindexed
 blocks, then the weighted nonzero part agrees with the derived common-sector family.
@@ -587,9 +573,8 @@ theorem derived_properties (F : CommonBlockedCyclicSectorFamily blocks)
     F.commonSectorBlock_irreducible k s, F.commonSectorBlock_dim_pos k s⟩
 
 /-- The direct $p$-blocked tensor $B_k^{[p]}$ has the same MPV family as its image in the
-common alphabet via `commonReindexedBlock`. This is the unconditional form of
-`blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees`, used as a building
-block in `blocked_word_comparison` and `reindexed_nonzero_part`. -/
+common alphabet via `commonReindexedBlock`. This is the unconditional common-alphabet
+comparison used by `blocked_word_comparison` and `reindexed_nonzero_part`. -/
 theorem blockTensor_sameMPV₂_commonReindexedBlock
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     SameMPV₂

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -586,7 +586,7 @@ map returns the direct block tensor at length `m*n`.
 
 This lemma avoids the `Fin.cast` / `Fintype.equivFin` identification and instead uses the
 explicit bijection `directToIteratedBlockIndex`. It gives a direct connection between iterated
-and direct blocking without needing `groupedBlockCastAgrees`. -/
+and direct blocking without an additional coordinate-grouping hypothesis. -/
 theorem reindexPhysical_directToIteratedBlockIndex_blockTensor {D : ℕ}
     (A : MPSTensor d D) (m n : ℕ) :
     reindexPhysical (directToIteratedBlockIndex d m n)
@@ -675,7 +675,7 @@ theorem sameMPV₂_toTensorFromBlocks_flattenedIteratedBlockPower
 
 /-- Iterated blocking expressed with the block-grouping bijection equals direct blocking.
 This is the tensor-level version of the blocked-word identity that underlies
-`groupedBlockCastAgrees`. -/
+the common-sector coordinate comparison. -/
 theorem sameMPV₂_reindexPhysical_directToIteratedBlockIndex_blockTensor
     {D : ℕ} (A : MPSTensor d D) (m n : ℕ) :
     SameMPV₂
@@ -707,13 +707,12 @@ The proof is purely combinatorial.  With the explicit `finFunctionFinEquiv` enco
 coordinate comparison reduces to the base-`d` digit identity relating a length-`m*n`
 word to a length-`n` word over length-`m` blocks.
 
-### Relationship with `flattenWordOfBlock_cast_eq`
+### Relationship with the common-sector word identity
 
-The theorem `flattenWordOfBlock_cast_eq` in `CyclicSectorDecomposition.lean` encodes the same
-combinatorial identity as a list equality.  The lemma
-`groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq` shows that this list-level
-assertion implies the coordinate-level one required by `groupedBlockCastAgrees`, and the
-sector-comparison theorem uses it to remove the former blocking-coordinate hypothesis.
+The common-sector comparison uses the same combinatorial fact as a list equality: flattening
+a word of length `n` over length-`m` blocks gives the direct word of length `m*n`.  That
+list-level assertion supplies the coordinate comparison needed for the common-alphabet
+blocked tensor theorem.
 -/
 
 /-- Casting the physical dimension of both tensors preserves rectangular MPV equality. -/

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1388,19 +1388,9 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
     $p$-blocked tensors.
 \end{lemma}
 
-\begin{definition}[Coordinate-grouping predicate]%
-    \label{def:common_blocked_cyclic_sector_grouped_block_cast}
-    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.groupedBlockCastAgrees}\leanok
-    \uses{thm:exists_common_blocked_cyclic_sector_family}
-    The canonical identification of the common-alphabet sectors with the iterated
-    alphabet $(d^{[m_k]})^{e_k}$ agrees with grouping any direct word of length
-    $p = m_k e_k$ into $e_k$ consecutive words of length $m_k$.
-\end{definition}
-
 \begin{lemma}[Digit-level flattening identification]%
     \label{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
     \lean{MPSTensor.CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq}\leanok
-    \uses{def:common_blocked_cyclic_sector_grouped_block_cast}
     For $p = mn$, the canonical word-flattening identification sends a $p$-letter
     word to the concatenation of $n$ consecutive $m$-letter words: the two
     encodings of a word of length $p$ over $d^{[p]}$ and over $(d^{[m]})^{n}$ are


### PR DESCRIPTION
## Summary

This PR continues the SectorComparison single-source audit from #2194.

It makes the coordinate-grouping predicate for common blocked cyclic sectors, and the conditional lemmas that mention it, private to `CommonBlockedCyclicSectorFamily.lean`. The public theorem surface now starts at the unconditional common-alphabet comparison
`MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock`, together with the blockwise weighted assembly lemma used by the after-blocking common-sector route.

The blueprint is updated accordingly: the internal coordinate-grouping predicate is no longer presented as an independent mathematical node in Chapter 8. The digit-level flattening lemma remains public, and the direct blocking/common-alphabet theorem remains the single exposed statement used downstream.

Refs #2194.

## Validation

- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorFamily`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport`
- `lake build`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean TNLean/MPS/Core/BlockingInfrastructure.lean blueprint/src/chapter/ch08_canonical.tex`
- `PATH="/private/tmp/tnlean-blueprint-venv-check/bin:$PATH" leanblueprint web` from `blueprint/`

`leanblueprint checkdecls` still fails on the existing generated declaration list because of pre-existing parent-Hamiltonian and PEPS blueprint references; it does not report a new Chapter 8 missing declaration from this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API and documentation cleanup only; public theorems and proof obligations are unchanged, with no remaining references to the removed public symbol.
> 
> **Overview**
> This PR **narrows the public API** for common blocked cyclic-sector comparison: the coordinate-grouping predicate `groupedBlockCastAgrees` and the lemmas that take it as a hypothesis are now **`private`** in `CommonBlockedCyclicSectorFamily.lean`, and the redundant weighted assembly theorem `sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_groupedBlockCastAgrees` is **removed** (callers use the blockwise lemma plus unconditional per-block `blockTensor_sameMPV₂_commonReindexedBlock`).
> 
> Downstream-facing statements stay **unconditional** at the surface: `blockTensor_sameMPV₂_commonReindexedBlock` still proves direct vs. common-alphabet MPV equality via the internal flattening lemma `flattenWordOfBlock_cast_eq`. Docstrings in `BlockingInfrastructure.lean` are updated to describe the combinatorial word identity instead of naming the hidden predicate.
> 
> **Blueprint (Ch. 8):** the definition `def:common_blocked_cyclic_sector_grouped_block_cast` is dropped; the digit-level flattening and direct-blocking lemmas remain the exposed mathematical nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7934bd9eba85e0facf967022338ea31a22b538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->