### PR TITLE
refactor(MPS/CanonicalForm): remove relabeling hypothesis layer

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -534,30 +534,6 @@ theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise
           (mpv_toTensorFromBlocks_eq_sum (fun k : Fin r => (μ k) ^ F.p)
             F.commonReindexedBlock σ).symm
 
-/-- If the canonical blocked nonzero part agrees with the explicitly reindexed
-blocks, then the weighted nonzero part agrees with the derived common-sector family.
-
-The hypothesis isolates the remaining equality after relabeling blocked physical
-words by `iteratedBlockIndex`; the canonical blocked tensor uses the ambient blocked
-alphabet directly. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed
-    (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
-    (hRelabel : SameMPV₂
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p)
-        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)) :
-    SameMPV₂
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p)
-        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := F.commonFlatWeight μ) F.commonFlatBlocks) := by
-  intro N σ
-  exact (hRelabel N σ).trans
-    (F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ)
-
 /-- Each sector tensor in the common reblocked cyclic-sector family is trace-preserving,
 has primitive transfer map, is tensor-irreducible, and has positive bond dimension. -/
 theorem derived_properties (F : CommonBlockedCyclicSectorFamily blocks)
@@ -611,24 +587,9 @@ theorem reindexed_nonzero_part (F : CommonBlockedCyclicSectorFamily blocks) (μ 
       (toTensorFromBlocks (d := blockPhysDim d F.p)
         (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) := by
   intro N σ
-  have hCommon : ∀ k, mpv (blockTensor (d := d) (D := dim k) (blocks k) F.p) σ =
-      mpv (F.commonReindexedBlock k) σ :=
-    fun k => F.blockTensor_sameMPV₂_commonReindexedBlock k N σ
-  calc mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-            (μ := fun k => (μ k) ^ F.p)
-            (fun k => blockTensor (blocks k) F.p)) σ
-      = ∑ k : Fin r,
-          ((μ k) ^ F.p) ^ N • mpv (blockTensor (blocks k) F.p) σ :=
-        mpv_toTensorFromBlocks_eq_sum _ _ σ
-    _ = ∑ k : Fin r,
-          ((μ k) ^ F.p) ^ N • mpv (F.commonReindexedBlock k) σ :=
-        Finset.sum_congr rfl fun k _ => by rw [hCommon k]
-    _ = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-              (μ := fun k => (μ k) ^ F.p) (F.commonReindexedBlock)) σ :=
-        (mpv_toTensorFromBlocks_eq_sum _ _ σ).symm
-    _ = mpv (toTensorFromBlocks (d := blockPhysDim d F.p)
-              (μ := F.commonFlatWeight μ) (F.commonFlatBlocks)) σ :=
-        F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ
+  exact (F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise μ
+      (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock k) N σ).trans
+    (F.sameMPV₂_weightedCommonReindexedBlock_commonFlat μ N σ)
 
 end CommonBlockedCyclicSectorFamily
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -13,16 +13,13 @@ namespace MPSTensor
 /-!
 # Common-sector transport after canonical-form blocking
 
-This module contains the common-sector reindexing hypotheses used after the
-structural canonical-form reduction has produced common cyclic-sector families.
+This module contains the common-sector transport theorem used after the structural
+canonical-form reduction has produced common cyclic-sector families.
 
 ## Main statements
 
-* `CommonSectorRelabelingHypothesis` encodes the remaining blocked-word
-  comparison hypothesis used by the conditional common-sector theorem.
-* `afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`
-  and `unconditional_commonPrimitiveIrreducibleBlocks` turn the structural
-  common-sector families into common primitive irreducible block decompositions.
+* `unconditional_commonPrimitiveIrreducibleBlocks` turns the structural common-sector
+  families into common primitive irreducible block decompositions.
 
 ## References
 
@@ -34,46 +31,28 @@ structural canonical-form reduction has produced common cyclic-sector families.
 matrix product states, canonical form, common sectors
 -/
 
-/-- The one-sided blocked-word relabeling hypothesis for cyclic-sector families.
-
-It says that, for every common cyclic-sector family, the canonically blocked
-weighted nonzero tensor agrees as an MPV family with the same blocks read through
-the explicit relabeling of blocked physical words. This is the hypothesis isolated
-by the current blocked-word coordinate problem. -/
-abbrev CommonSectorRelabelingHypothesis (d : ℕ) : Prop :=
-  ∀ {r : ℕ} {dim : Fin r → ℕ}
-    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
-    (F : CommonBlockedCyclicSectorFamily blocks),
-    SameMPV₂
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p)
-        (fun k => blockTensor (d := d) (D := dim k) (blocks k) F.p))
-      (toTensorFromBlocks (d := blockPhysDim d F.p)
-        (μ := fun k : Fin r => (μ k) ^ F.p) F.commonReindexedBlock)
-
 set_option maxHeartbeats 800000 in
 -- The conclusion records both decompositions and all their structural hypotheses together.
-/-- **Common primitive irreducible block decompositions after blocked-word reindexing.**
+/-- **Unconditional common primitive irreducible block decompositions.**
 
-Assume the one-sided equality which identifies, for every common cyclic-sector
-family, the canonically blocked weighted nonzero part with the same family written
-using the reindexing of blocked physical words.  Then two tensors with the same
-MPV family have one common positive blocking length whose nonzero parts are
-weighted families of trace-preserving, primitive, tensor-irreducible blocks with
-positive bond dimensions and nonzero weights.  At every positive length each
-blocked tensor equals its nonzero part, and the two nonzero parts equal each
-other.  The all-zero leftover block contributes only at length zero, so it is
-omitted; the length-zero coefficient is restored once, at the end, from equality
-of the bond dimensions.
+Two tensors with the same MPV family have one common positive blocking length
+whose nonzero parts are weighted families of trace-preserving, primitive,
+tensor-irreducible blocks with positive bond dimensions and nonzero weights. At
+every positive length each blocked tensor equals its nonzero part, and the two
+nonzero parts equal each other. The all-zero leftover block contributes only at
+length zero, so it is omitted; the length-zero coefficient is restored once, at
+the end, from equality of the bond dimensions.
 
-The displayed reindexing equality is the remaining one-sided blocked-word
-theorem; this result isolates the mathematical hypotheses used before the later
-injectivity and BNT comparison. -/
-theorem afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
+The proof uses the family-level common-alphabet nonzero-part identity directly,
+rather than passing through a separate relabeling hypothesis.
+
+Source: arXiv:1606.00608, Appendix A and Section II.C, where the nonnormal
+canonical-form reduction is blocked to primitive sector families before the
+multi-block comparison. -/
+theorem unconditional_commonPrimitiveIrreducibleBlocks
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B)
-    (hReindexed : CommonSectorRelabelingHypothesis d) :
+    (hSame : SameMPV₂ A B) :
     ∃ p : ℕ, 0 < p ∧
     ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
       (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)),
@@ -104,10 +83,8 @@ theorem afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
       _hReindexedA, _hReindexedB, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB,
       hIrrA, hIrrB, hDimA, hDimB⟩ :=
     afterBlocking_commonLengthCommonSectorData_of_sameMPV₂ A B hSame
-  have hWordA := hReindexed μA₀ blocksA₀ familyA
-  have hWordB := hReindexed μB₀ blocksB₀ familyB
-  have hFlatA_raw := familyA.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μA₀ hWordA
-  have hFlatB_raw := familyB.sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed μB₀ hWordB
+  have hFlatA_raw := familyA.reindexed_nonzero_part μA₀
+  have hFlatB_raw := familyB.reindexed_nonzero_part μB₀
   let flatBlocksA : (x : Fin (∑ k : Fin rA₀, familyA.period k)) →
       MPSTensor (blockPhysDim d p) (familyA.commonFlatDim x) :=
     fun x => cast (congr_arg (fun q => MPSTensor (blockPhysDim d q)
@@ -188,46 +165,5 @@ theorem afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
     flatBlocksB,
     hAPos, hBPos, hNonzeroPos,
     hμA, hμB, hTPA', hTPB', hPrimA', hPrimB', hIrrA', hIrrB', hDimA, hDimB⟩
-
-/-- **Unconditional common primitive irreducible block decompositions.**
-
-The proof obtains the required relabeling assertion directly from the family-level
-comparison between direct blocking and the common alphabet, then assembles the
-blockwise equalities over the weighted direct sum.
--/
-theorem unconditional_commonPrimitiveIrreducibleBlocks
-    {d D₁ D₂ : ℕ}
-    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :
-    ∃ p : ℕ, 0 < p ∧
-    ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
-      (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)),
-    ∃ (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
-      (blocksB : (x : Fin rB) → MPSTensor (blockPhysDim d p) (dimB x)),
-      SameMPV₂Pos (blockTensor (d := d) (D := D₁) A p)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA) ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D₂) B p)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
-      SameMPV₂Pos
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μA) blocksA)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μB) blocksB) ∧
-      (∀ x, μA x ≠ 0) ∧
-      (∀ x, μB x ≠ 0) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksA x i)ᴴ * blocksA x i = 1) ∧
-      (∀ x, ∑ i : Fin (blockPhysDim d p), (blocksB x i)ᴴ * blocksB x i = 1) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d p) (D := dimA x) (blocksA x))) ∧
-      (∀ x, _root_.IsPrimitive
-        (transferMap (d := blockPhysDim d p) (D := dimB x) (blocksB x))) ∧
-      (∀ x, IsIrreducibleTensor (blocksA x)) ∧
-      (∀ x, IsIrreducibleTensor (blocksB x)) ∧
-      (∀ x, 0 < dimA x) ∧
-      (∀ x, 0 < dimB x) := by
-  have h_relabel : CommonSectorRelabelingHypothesis d :=
-    fun μ blocks F =>
-      F.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise μ
-        (fun k => F.blockTensor_sameMPV₂_commonReindexedBlock k)
-  exact afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts
-    A B hSame h_relabel
 
 end MPSTensor

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1380,9 +1380,11 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
     \label{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
     \lean{MPSTensor.CommonBlockedCyclicSectorFamily.reindexed_nonzero_part}\leanok
     \uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
-        thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
-    The nonzero-part decomposition of $\bigoplus_k \mu_k B_k$ carries over under
-    the common-alphabet identification of
+        thm:common_blocked_cyclic_sector_block_tensor_common_reindexed,
+        thm:common_blocked_cyclic_sector_weighted_common_reindexed}
+    The powered nonzero-part decomposition
+    $\bigoplus_k \mu_k^p B_k^{[p]}$ carries over under the common-alphabet
+    identification of
     Lemma~\ref{thm:common_blocked_cyclic_sector_reindexed_samempv}: the
     common-alphabet sectors have the same nonzero-part decomposition as the direct
     $p$-blocked tensors.

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -301,70 +301,13 @@ exactly Theorem~\ref{thm:normal_tp_primitive_irred}.
     equality of the two powered nonzero parts.
 \end{proof}
 
-\begin{theorem}[Primitive block decompositions at a common length]%
-    \label{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-    \lean{MPSTensor.afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts}
-    \leanok
-    \uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-        thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
-        def:same_mpv2_pos}
-    Assume the nonzero part can be identified with the common blocked alphabet.
-    Then two tensors with the same MPV family admit one $p>0$ and nonzero
-    weighted block families such that, for every $N\ge 1$,
-    \[
-        V^{(N)}\!(A^{[p]})_\sigma
-        =
-        V^{(N)}\!(\textstyle\bigoplus_x \mu^A_x A_x)_\sigma,
-        \qquad
-        V^{(N)}\!(B^{[p]})_\sigma
-        =
-        V^{(N)}\!(\textstyle\bigoplus_y \mu^B_y B_y)_\sigma,
-    \]
-    and the two nonzero parts agree at every positive length,
-    \[
-        V^{(N)}\!(\textstyle\bigoplus_x \mu^A_x A_x)_\sigma
-        =
-        V^{(N)}\!(\textstyle\bigoplus_y \mu^B_y B_y)_\sigma.
-    \]
-    The all-zero leftover is restored by the separate zero-tail cancellation
-    theorem. All blocks are trace-preserving, primitive, tensor-irreducible, and
-    of positive bond dimension, and all weights are nonzero.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:ft_after_blocking_common_length_common_sector_theorem,
-        thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
-    Apply
-    Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} to
-    choose the common blocking length and the two common cyclic-sector families.
-    The assumed word identification converts the blocked nonzero part into the
-    weighted common-sector family on each side, and since the zero-tail term
-    vanishes at positive length, this gives the displayed identities. The
-    structural properties and nonzero weights come from the common-sector
-    families.
-\end{proof}
-
-\begin{definition}[Blocked-word identification for common sectors]%
-    \label{def:common_sector_relabeling_hypothesis}
-    \lean{MPSTensor.CommonSectorRelabelingHypothesis}
-    \leanok
-    This is the one-sided assertion that the canonically blocked weighted
-    nonzero part agrees, as an MPV family, with the same common cyclic-sector
-    family after identifying blocked physical words. It is the coordinate
-    equality between direct blocking and iterated blocking.
-\end{definition}
-
-The unconditional theorem below obtains this assertion directly from the
-blockwise common-alphabet comparison already proved for common cyclic-sector
-families.
-
 \begin{theorem}[Unconditional common primitive block decompositions]%
     \label{thm:unconditional_common_primitive_irreducible_blocks}
     \lean{MPSTensor.unconditional_commonPrimitiveIrreducibleBlocks}
     \leanok
-    \uses{thm:common_blocked_cyclic_sector_block_tensor_common_reindexed,
-        thm:common_blocked_cyclic_sector_weighted_common_reindexed,
-        thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
+    \uses{thm:ft_after_blocking_common_length_common_sector_theorem,
+        thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
+        def:same_mpv2_pos}
     Let $A$ and $B$ have the same MPV family. Then there is a positive blocking
     length at which both blocked tensors have the same positive-length MPV
     family as weighted direct sums of trace-preserving, primitive,
@@ -375,36 +318,27 @@ families.
 
 \begin{proof}
     \leanok
-    \uses{thm:common_blocked_cyclic_sector_block_tensor_common_reindexed,
-        thm:common_blocked_cyclic_sector_weighted_common_reindexed,
-        thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-    Write $\widetilde B_k$ for the image of $B_k^{[p]}$ in the common blocked
-    alphabet.
-    For each common cyclic-sector family, the canonical identification between
-    direct $p$-blocking and the transported common alphabet gives, for every
-    length $N$ and blocked word $\sigma$,
-    \[
-        V^{(N)}(B_k^{[p]})_\sigma
-        =
-        V^{(N)}(\widetilde B_k)_\sigma .
-    \]
-    The weighted direct sums therefore satisfy
+    \uses{thm:ft_after_blocking_common_length_common_sector_theorem,
+        thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
+    Apply
+    Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} to
+    choose the common blocking length and the two common cyclic-sector families.
+    For either one of these families, write $G_k$ for its cyclic-sector blocks,
+    and write $(\nu_x,C_x)$ for the weights and blocks of the flattened
+    common-sector family from
+    Lemma~\ref{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}. The
+    common-alphabet nonzero-part identity gives, for every length $N$ and
+    blocked word $\sigma$,
     \[
         V^{(N)}\!
-        \bigl(\textstyle\bigoplus_k \mu_k^p B_k^{[p]}\bigr)_\sigma
-        =
-        \sum_k (\mu_k^p)^N V^{(N)}(B_k^{[p]})_\sigma
-        =
-        \sum_k (\mu_k^p)^N V^{(N)}(\widetilde B_k)_\sigma
+        \bigl(\textstyle\bigoplus_k \mu_k^p G_k^{[p]}\bigr)_\sigma
         =
         V^{(N)}\!
-        \bigl(\textstyle\bigoplus_k \mu_k^p \widetilde B_k\bigr)_\sigma .
+        \bigl(\textstyle\bigoplus_x \nu_x C_x\bigr)_\sigma ,
     \]
-    This is the relabeling hypothesis of
-    Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}. Then
-    Theorem~\ref{thm:after_blocking_common_primitive_irreducible_blocks_reindexed}
-    yields a positive length $p$ and weighted primitive block families such that,
-    for every $N\ge 1$ and blocked word $\sigma$,
+    Applying this on the two sides of the comparison yields a positive length
+    $p$ and weighted primitive block families such that, for every $N\ge 1$ and
+    blocked word $\sigma$,
     \[
         V^{(N)}\!(A^{[p]})_\sigma
         =
@@ -414,7 +348,9 @@ families.
         =
         V^{(N)}\!(\textstyle\bigoplus_y \mu^B_y B_y)_\sigma,
     \]
-    with the two weighted nonzero parts equal at every positive length.
+    with the two weighted nonzero parts equal at every positive length. The
+    structural properties and the nonvanishing of the weights come from the
+    common-sector families.
 \end{proof}
 
 \section{Primitive-block decomposition of an arbitrary tensor}%

--- a/docs/paper-gaps/common_sector_relabeling_hypothesis.tex
+++ b/docs/paper-gaps/common_sector_relabeling_hypothesis.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{Common Sector Relabeling as an Explicit Hypothesis}
+\title{Common Sector Relabeling as an Unconditional Identity}
 \author{}
 \date{2026-05-10}
 
@@ -47,21 +47,21 @@ The paper therefore treats the equality as transparent and does not name it.
 \section{Status}
 
 No deviation from the source paper is present. The relabeling assertion is the
-identity between two descriptions of the same blocked-word coordinates, and the
-formalization proves it unconditionally before using it in the sector-comparison
-theorems.\footnote{%
-    The family-level proof is
-    \leanid{CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock};
-    the unconditional common-sector theorem assembles these blockwise identities
-    directly into the stated relabeling hypothesis. The declarations are in
+identity between two descriptions of the same blocked-word coordinates. The
+formalization uses the unconditional nonzero-part identity for a common
+cyclic-sector family directly, without introducing a separate hypothesis.\footnote{%
+    The family-level statement is
+    \leanid{CommonBlockedCyclicSectorFamily.reindexed_nonzero_part}; the
+    common primitive-block theorem applies it directly on both sides. The
+    declarations are in
     \doclink{TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean}
     and
     \doclink{TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean}.}
 
 \section{Verdict}
 
-The hypothesis is therefore a named form of the paper's implicit blocked-index
-identification, not an additional mathematical assumption.
+The relabeling identity is therefore a formal expression of the paper's implicit
+blocked-index identification, not an additional mathematical assumption.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This PR continues the SectorComparison single-source audit from #2194.

It removes the remaining named `CommonSectorRelabelingHypothesis` layer and the conditional common primitive-block theorem. The public theorem `MPSTensor.unconditional_commonPrimitiveIrreducibleBlocks` now applies `CommonBlockedCyclicSectorFamily.reindexed_nonzero_part` directly on the two common cyclic-sector families produced by the structural theorem.

The family-level nonzero-part theorem now also reuses the weighted assembly lemma instead of repeating its weighted-sum calculation. The blueprint removes the conditional theorem and hypothesis node, and the paper-gap note now records the relabeling as an unconditional identity rather than an explicit hypothesis.

Refs #2194.

## Verification

- `lake exe cache get`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonBlockedCyclicSectorFamily`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport`
- `lake build`
- `git diff --check`
- `rg -n "CommonSectorRelabelingHypothesis|afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts|sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed|def:common_sector_relabeling_hypothesis|after_blocking_common_primitive_irreducible_blocks_reindexed" TNLean blueprint/src docs/paper-gaps || true`
- `rg -n "\\b(sorry|axiom|native_decide|unsafeCast|admit)\\b" TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean || true`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch11b_after_blocking.tex docs/paper-gaps/common_sector_relabeling_hypothesis.tex`
- `python3 scripts/blueprint_bibtex.py`
- `leanblueprint web` in a Python 3.13 virtual environment installed from `.github/requirements/blueprint-python.txt`

Note: the repository-wide generated declaration-list check still reports pre-existing missing blueprint declarations in unrelated parent-Hamiltonian and PEPS chapters. The changed-declaration sync check for this PR is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure refactor in formalized MPS sector comparison and documentation; the main theorem’s statement is unchanged and no auth, security, or runtime paths are touched.
> 
> **Overview**
> This PR **removes the intermediate relabeling-hypothesis layer** in SectorComparison and wires the public result directly to the family-level nonzero-part identity.
> 
> In Lean, **`CommonSectorRelabelingHypothesis`**, **`afterBlocking_commonPrimitiveIrreducibleBlocks_of_reindexedNonzeroParts`**, and **`sameMPV₂_weightedCanonicalBlock_commonFlat_of_reindexed`** are deleted. **`unconditional_commonPrimitiveIrreducibleBlocks`** no longer takes a global relabeling assumption; it calls **`reindexed_nonzero_part`** on each common cyclic-sector family from the structural theorem. **`reindexed_nonzero_part`** is shortened to chain **`sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise`** with the existing weighted flattening lemma instead of duplicating the weighted-sum proof.
> 
> The blueprint drops the conditional primitive-block theorem and the relabeling definition; the unconditional theorem’s proof and **`reindexed_nonzero_part`**’s uses are updated accordingly. The paper-gap note is retitled to treat blocked-index relabeling as an **unconditional identity**, not a named hypothesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0988694a5ec415119217891f712c4d4a77d4018b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->