### PR TITLE
feat(PEPS): construct square normal blocking hypotheses

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -374,6 +374,7 @@ import TNLean.PEPS.SquareLatticeGraph
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalEdgeBlockingCoordinate
 import TNLean.PEPS.NormalEdgeBlockingTranslated
+import TNLean.PEPS.NormalSquarePEPSBlocking
 import TNLean.PEPS.NormalEdgeBlockingMargins
 import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.InsertionRealization

--- a/TNLean/PEPS/NormalSquarePEPSBlocking.lean
+++ b/TNLean/PEPS/NormalSquarePEPSBlocking.lean
@@ -1,0 +1,98 @@
+import TNLean.PEPS.NormalEdgeBlockingTranslated
+
+/-!
+# Square-lattice normal PEPS blocking hypotheses
+
+This file connects the square-lattice edge-blocking construction with the
+general normal PEPS blocking hypotheses.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, Theorem 3]
+-/
+
+namespace TNLean
+namespace PEPS
+
+universe edgeCoverUniverse
+
+/-- Oriented margin-and-cover hypotheses at every edge, together with one-site
+separation, assemble into the general normal PEPS blocking hypotheses.
+
+The edge-blocking part is the existing construction
+`normalSquareEdgeBlockingHypotheses_of_marginCovers`; the one-site separation
+hypothesis is carried unchanged.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
+and theorem labelled `normal`, lines 1576--1583. -/
+def normalSquarePEPSBlockingHypotheses_of_marginCovers
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareEdgeMarginCover.{edgeCoverUniverse} e)
+    (oneSite : NormalOneSiteSeparationHypotheses κ) :
+    NormalPEPSBlockingHypotheses κ (squareLatticeGraph width height) where
+  edgeBlocking := normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data
+  oneSiteSeparation := oneSite
+
+/-- In the square-lattice construction from margin-and-cover hypotheses, the
+edge-blocking hypotheses are exactly the edge-blocking construction from those
+hypotheses.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
+and theorem labelled `normal`, lines 1576--1583. -/
+theorem normalSquarePEPSBlockingHypotheses_edgeBlocking_of_marginCovers
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareEdgeMarginCover.{edgeCoverUniverse} e)
+    (oneSite : NormalOneSiteSeparationHypotheses κ) :
+    (normalSquarePEPSBlockingHypotheses_of_marginCovers h hUnion data oneSite).edgeBlocking =
+      normalSquareEdgeBlockingHypotheses_of_marginCovers h hUnion data :=
+  rfl
+
+/-- The edge datum recovered from the square-lattice construction assembled
+from margin-and-cover hypotheses is the datum supplied by the corresponding
+edge datum.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
+and theorem labelled `normal`, lines 1576--1583. -/
+theorem normalSquarePEPSBlockingHypotheses_blockingData_of_marginCovers
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareEdgeMarginCover.{edgeCoverUniverse} e)
+    (oneSite : NormalOneSiteSeparationHypotheses κ)
+    (e : Edge (squareLatticeGraph width height)) :
+    (normalSquarePEPSBlockingHypotheses_of_marginCovers
+      h hUnion data oneSite).edgeBlocking.blockingData e =
+      (data e).blockingDatum h hUnion := by
+  rfl
+
+/-- In the square-lattice construction from margin-and-cover hypotheses, the
+one-site separation hypothesis is the supplied one.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`,
+lines 1576--1583. -/
+theorem normalSquarePEPSBlockingHypotheses_oneSiteSeparation_of_marginCovers
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareEdgeMarginCover.{edgeCoverUniverse} e)
+    (oneSite : NormalOneSiteSeparationHypotheses κ) :
+    (normalSquarePEPSBlockingHypotheses_of_marginCovers
+      h hUnion data oneSite).oneSiteSeparation = oneSite :=
+  rfl
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3497,6 +3497,29 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \end{center}
 \end{definition}
 
+\begin{theorem}[Square-lattice normal blocking hypotheses from margin covers]%
+    \label{thm:peps_normalSquarePEPSBlockingHypotheses_of_marginCovers}
+    \lean{TNLean.PEPS.normalSquarePEPSBlockingHypotheses_of_marginCovers}
+    \lean{TNLean.PEPS.normalSquarePEPSBlockingHypotheses_edgeBlocking_of_marginCovers}
+    \lean{TNLean.PEPS.normalSquarePEPSBlockingHypotheses_blockingData_of_marginCovers}
+    \lean{TNLean.PEPS.%
+        normalSquarePEPSBlockingHypotheses_oneSiteSeparation_of_marginCovers}
+    \leanok
+    \uses{thm:peps_normalSquareTranslatedEdgeBlockingHypotheses_of_windows,
+        def:peps_normalPEPSBlockingHypotheses,
+        def:peps_normalOneSiteSeparationHypotheses}
+    Given rectangular injectivity hypotheses, finite union closure, oriented
+    margin-and-cover hypotheses at every edge, and one-site separation, the finite
+    square lattice satisfies the general normal blocking hypotheses.  The
+    edge-blocking hypotheses are exactly the margin-cover construction, the
+    one-edge datum at an edge is the datum supplied there, and the one-site
+    separation is exactly the supplied one-site separation.
+\end{theorem}
+\begin{proof}\leanok
+    Combine the edge-blocking hypotheses constructed from the margin-cover
+    hypotheses with the given one-site separation hypotheses.
+\end{proof}
+
 \begin{theorem}[Fundamental Theorem for normal PEPS]%
     \label{thm:fundamentalTheorem_normalPEPS}
     \notready


### PR DESCRIPTION
### Motivation
- Continues the normal PEPS fundamental theorem formalization (arXiv:1804.04964, Section 3, Theorem 3): assembles per-edge oriented blocking data from existing margin-cover constructions into the `NormalPEPSBlockingHypotheses` bundle required for the main argument. See #2004.
- Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475–1500; theorem labelled `normal`, lines 1576–1583.

### Description
- Adds `normalSquarePEPSBlockingHypotheses_of_marginCovers` to `TNLean/PEPS/NormalEdgeBlockingTranslated.lean`: a conditional construction of `NormalPEPSBlockingHypotheses` from per-edge oriented margin-and-cover data (via `normalSquareEdgeBlockingHypotheses_of_marginCovers`) together with a `NormalOneSiteSeparationHypotheses` instance.
- Adds three definitional recovery theorems (proofs by `rfl`) showing that the edge-blocking component equals the existing margin-cover construction, each per-edge datum equals the one supplied at that edge, and the one-site separation component is unchanged.
- Updates `blueprint/src/chapter/ch13a_peps_ft.tex` to record the construction before the general normal PEPS fundamental theorem (Chapter 13a).
- This is a conditional construction. It does not construct margin-cover hypotheses for boundary edges, prove the source-faithful local and rotated T-injectivity argument, or close #2004.

### Testing
- `lake build TNLean.PEPS.NormalEdgeBlockingTranslated`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/NormalEdgeBlockingTranslated.lean`

---
Progress toward #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Lean formalization glue (`rfl` assembly and blueprint sync) with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds **`normalSquarePEPSBlockingHypotheses_of_marginCovers`**, which packages existing per-edge margin-cover edge blocking with a supplied **`NormalOneSiteSeparationHypotheses`** instance into **`NormalPEPSBlockingHypotheses`** on the finite square lattice— the hypothesis bundle the general normal PEPS fundamental theorem expects.
> 
> Three **`rfl`** lemmas record that the assembled structure’s edge-blocking part, per-edge blocking datum, and one-site separation field match the inputs unchanged. A new **`TNLean/PEPS/NormalSquarePEPSBlocking.lean`** module is wired into the root import list, and Chapter 13a blueprint documents the construction immediately before the general normal fundamental theorem.
> 
> This is conditional assembly only; it does not prove margin covers on boundary edges or close the full square-lattice normal route (#2004).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba5384cfc0825538aac380b733e09d7476cfa3de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->