### PR TITLE
refactor(CanonicalForm): bundle common-sector properties

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -183,60 +183,6 @@ private theorem commonSectorBlock_structural (F : CommonBlockedCyclicSectorFamil
         (F.sectorBlocks k s) (F.extra k))).2 hExtra.2.2
     simpa [commonSectorBlock] using hcast
 
-/-- Derived common-alphabet sectors are trace-preserving. -/
-theorem commonSectorBlock_tp (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) (s : Fin (F.period k)) :
-    ∑ i : Fin (blockPhysDim d F.p),
-      (F.commonSectorBlock k s i)ᴴ * F.commonSectorBlock k s i = 1 :=
-  (commonSectorBlock_structural F k s).1
-
-/-- Derived common-alphabet sectors have primitive transfer maps. -/
-theorem commonSectorBlock_primitive (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) (s : Fin (F.period k)) :
-    _root_.IsPrimitive
-      (transferMap (d := blockPhysDim d F.p) (D := F.sectorDim k s)
-        (F.commonSectorBlock k s)) :=
-  (commonSectorBlock_structural F k s).2.1
-
-/-- Derived common-alphabet sectors are tensor-irreducible. -/
-theorem commonSectorBlock_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) (s : Fin (F.period k)) : IsIrreducibleTensor (F.commonSectorBlock k s) :=
-  (commonSectorBlock_structural F k s).2.2
-
-/-- Derived common-alphabet sectors have positive bond dimensions. -/
-theorem commonSectorBlock_dim_pos (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) (s : Fin (F.period k)) : 0 < F.sectorDim k s :=
-  F.sector_dim_pos k s
-
-/-- The derived flattened common-sector family is trace-preserving. -/
-theorem commonFlatBlocks_tp (F : CommonBlockedCyclicSectorFamily blocks)
-    (x : Fin (∑ k : Fin r, F.period k)) :
-    ∑ i : Fin (blockPhysDim d F.p),
-      (F.commonFlatBlocks x i)ᴴ * F.commonFlatBlocks x i = 1 := by
-  let y := F.flatKey x
-  simpa [commonFlatBlocks, commonFlatDim, y] using F.commonSectorBlock_tp y.1 y.2
-
-/-- The derived flattened common-sector family has primitive transfer maps. -/
-theorem commonFlatBlocks_primitive (F : CommonBlockedCyclicSectorFamily blocks)
-    (x : Fin (∑ k : Fin r, F.period k)) :
-    _root_.IsPrimitive
-      (transferMap (d := blockPhysDim d F.p) (D := F.commonFlatDim x)
-        (F.commonFlatBlocks x)) := by
-  let y := F.flatKey x
-  simpa [commonFlatBlocks, commonFlatDim, y] using F.commonSectorBlock_primitive y.1 y.2
-
-/-- The derived flattened common-sector family is tensor-irreducible. -/
-theorem commonFlatBlocks_irreducible (F : CommonBlockedCyclicSectorFamily blocks)
-    (x : Fin (∑ k : Fin r, F.period k)) : IsIrreducibleTensor (F.commonFlatBlocks x) := by
-  let y := F.flatKey x
-  simpa [commonFlatBlocks, commonFlatDim, y] using F.commonSectorBlock_irreducible y.1 y.2
-
-/-- The derived flattened common-sector family has positive bond dimensions. -/
-theorem commonFlatDim_pos (F : CommonBlockedCyclicSectorFamily blocks)
-    (x : Fin (∑ k : Fin r, F.period k)) : 0 < F.commonFlatDim x := by
-  let y := F.flatKey x
-  simpa [commonFlatDim, y] using F.commonSectorBlock_dim_pos y.1 y.2
-
 /-- The iterated blocked tensor `(B_k^{[m_k]})^{[e_k]}` agrees with the directly blocked
 tensor `B_k^{[p]}` after transport to the common blocked alphabet.
 
@@ -544,9 +490,9 @@ theorem derived_properties (F : CommonBlockedCyclicSectorFamily blocks)
         (transferMap (d := blockPhysDim d F.p) (D := F.sectorDim k s)
           (F.commonSectorBlock k s)) ∧
     IsIrreducibleTensor (F.commonSectorBlock k s) ∧
-    0 < F.sectorDim k s :=
-  ⟨F.commonSectorBlock_tp k s, F.commonSectorBlock_primitive k s,
-    F.commonSectorBlock_irreducible k s, F.commonSectorBlock_dim_pos k s⟩
+    0 < F.sectorDim k s := by
+  have h := commonSectorBlock_structural F k s
+  exact ⟨h.1, h.2.1, h.2.2, F.sector_dim_pos k s⟩
 
 /-- The direct $p$-blocked tensor $B_k^{[p]}$ has the same MPV family as its image in the
 common alphabet via `commonReindexedBlock`. This is the unconditional common-alphabet

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -227,21 +227,43 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
   · intro x
     exact familyB.commonFlatWeight_ne_zero μB hμB x
   · intro x
-    exact familyA.commonFlatBlocks_tp x
+    let y := familyA.flatKey x
+    simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocks,
+      CommonBlockedCyclicSectorFamily.commonFlatDim, y] using
+      (familyA.derived_properties y.1 y.2).1
   · intro x
-    exact familyB.commonFlatBlocks_tp x
+    let y := familyB.flatKey x
+    simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocks,
+      CommonBlockedCyclicSectorFamily.commonFlatDim, y] using
+      (familyB.derived_properties y.1 y.2).1
   · intro x
-    exact familyA.commonFlatBlocks_primitive x
+    let y := familyA.flatKey x
+    simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocks,
+      CommonBlockedCyclicSectorFamily.commonFlatDim, y] using
+      (familyA.derived_properties y.1 y.2).2.1
   · intro x
-    exact familyB.commonFlatBlocks_primitive x
+    let y := familyB.flatKey x
+    simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocks,
+      CommonBlockedCyclicSectorFamily.commonFlatDim, y] using
+      (familyB.derived_properties y.1 y.2).2.1
   · intro x
-    exact familyA.commonFlatBlocks_irreducible x
+    let y := familyA.flatKey x
+    simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocks,
+      CommonBlockedCyclicSectorFamily.commonFlatDim, y] using
+      (familyA.derived_properties y.1 y.2).2.2.1
   · intro x
-    exact familyB.commonFlatBlocks_irreducible x
+    let y := familyB.flatKey x
+    simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocks,
+      CommonBlockedCyclicSectorFamily.commonFlatDim, y] using
+      (familyB.derived_properties y.1 y.2).2.2.1
   · intro x
-    exact familyA.commonFlatDim_pos x
+    let y := familyA.flatKey x
+    simpa [CommonBlockedCyclicSectorFamily.commonFlatDim, y] using
+      (familyA.derived_properties y.1 y.2).2.2.2
   · intro x
-    exact familyB.commonFlatDim_pos x
+    let y := familyB.flatKey x
+    simpa [CommonBlockedCyclicSectorFamily.commonFlatDim, y] using
+      (familyB.derived_properties y.1 y.2).2.2.2
 
 /-!
 ### What remains for the full 1606.00608 Fundamental Theorem


### PR DESCRIPTION
### Motivation

- Continues the canonical-form single-source audit from #2194, which tracks deduplication of declarations common to the per-tensor and after-blocking reduction modules.
- The derived common-sector properties (trace-preserving, primitive, irreducible, positive-dimension) were exposed as separate one-line projection lemmas alongside the bundled theorem `MPSTensor.CommonBlockedCyclicSectorFamily.derived_properties`. This duplication creates divergence risk and is not required by any independent blueprint entry.

### Description

- `TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean`: removes the separate public projection lemmas for trace-preserving, primitive, irreducible, and positive-dimension properties on `commonSectorBlock`/`commonFlatBlocks`; `derived_properties` is now the single entry point, proved directly from `commonSectorBlock_structural` and `sector_dim_pos`.
- `TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean`: updates `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` to discharge the eight flat-sector obligations by decoding the flat index via `flatKey` and applying `derived_properties` on the underlying block/cyclic-sector index (with `simpa` on `commonFlatBlocks`/`commonFlatDim`).
- No statement or API changes; all removed lemmas were one-line projections with no independent blueprint entries.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean`
- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport TNLean`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean`

---
Progress toward #2194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in MPS canonical-form sector comparison; no API or runtime behavior change beyond consolidating Lean lemmas.
> 
> **Overview**
> This refactor **removes the separate public lemmas** for trace-preserving, primitive, irreducible, and positive-dimension facts on `commonSectorBlock` / `commonFlatBlocks`, so those properties are no longer duplicated as one-line projections.
> 
> **`derived_properties`** is now the single bundled entry point: its proof pulls directly from `commonSectorBlock_structural` and `sector_dim_pos` instead of chaining through the deleted wrappers.
> 
> In **`afterBlocking_commonLengthCommonSectorData_of_sameMPV₂`**, the eight flat-sector obligations are proved by decoding `x` with `flatKey` and reusing **`derived_properties`** on the underlying block/sector index (with `simpa` on `commonFlatBlocks` / `commonFlatDim`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f59259c4af622b6e172cffa4429681b7354a48b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->