### PR TITLE
refactor(MPS/CanonicalForm): hide relabeling helpers

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -205,7 +205,7 @@ theorem reindexed_sameMPV₂
       (blockTensor (d := d) (D := dim k) (blocks k) (F.period k * F.extra k)))).2 h
 
 /-- A relabeled nonzero-weight block is represented by its common-alphabet cyclic sectors. -/
-theorem commonReindexedBlock_sameMPV₂_commonSectorTensor
+private theorem commonReindexedBlock_sameMPV₂_commonSectorTensor
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     SameMPV₂ (F.commonReindexedBlock k) (F.commonSectorTensor k) := by
   intro N σ
@@ -219,7 +219,7 @@ theorem commonReindexedBlock_sameMPV₂_commonSectorTensor
       simpa [commonSectorTensor, commonSectorBlock] using F.nested_same k N σ
 
 /-- Weighted nonzero blocks with explicit relabelings flatten to the common-sector family. -/
-theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
+private theorem sameMPV₂_weightedCommonReindexedBlock_commonFlat
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ) :
     SameMPV₂
       (toTensorFromBlocks (d := blockPhysDim d F.p)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -111,13 +111,9 @@ set_option maxHeartbeats 800000 in
 Starting from `SameMPV₂ A B`, this theorem chooses one positive physical blocking
 length for both sides.  At that common length it gives, for each side, the
 positive-length equality between the blocked tensor and its weighted nonzero part,
-the positive-length equality of the two nonzero parts, and the relabeled
-cyclic-sector families produced by `CommonBlockedCyclicSectorFamily`.
-
-The last two `SameMPV₂` conclusions are deliberately stated for the relabeled
-blocked sector blocks.  They isolate the remaining equality under the chosen word
-reindexing needed to replace the canonical blocked nonzero blocks by the derived
-primitive irreducible common-sector blocks. -/
+the positive-length equality of the two nonzero parts, the relabeled
+cyclic-sector families produced by `CommonBlockedCyclicSectorFamily`, and the
+structural hypotheses for their flattened sector blocks. -/
 theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -148,16 +144,6 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
         (toTensorFromBlocks (d := blockPhysDim d p)
           (fun k => (μB k) ^ p)
           (fun k => blockTensor (d := d) (D := dimB k) (blocksB k) p)) ∧
-      SameMPV₂
-        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
-          (μ := fun k : Fin rA => (μA k) ^ familyA.p) familyA.commonReindexedBlock)
-        (toTensorFromBlocks (d := blockPhysDim d familyA.p)
-          (μ := familyA.commonFlatWeight μA) familyA.commonFlatBlocks) ∧
-      SameMPV₂
-        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
-          (μ := fun k : Fin rB => (μB k) ^ familyB.p) familyB.commonReindexedBlock)
-        (toTensorFromBlocks (d := blockPhysDim d familyB.p)
-          (μ := familyB.commonFlatWeight μB) familyB.commonFlatBlocks) ∧
       (∀ x, familyA.commonFlatWeight μA x ≠ 0) ∧
       (∀ x, familyB.commonFlatWeight μB x ≠ 0) ∧
       (∀ x, ∑ i : Fin (blockPhysDim d familyA.p),
@@ -219,9 +205,7 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
   refine ⟨p, hp, rA, dimA, μA, blocksA,
     rB, dimB, μB, blocksB, familyA, familyB,
     hFamilyA, hFamilyB, hAPosCanon, hBPosCanon, hBook, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
-    ?_, ?_, ?_, ?_⟩
-  · exact familyA.sameMPV₂_weightedCommonReindexedBlock_commonFlat μA
-  · exact familyB.sameMPV₂_weightedCommonReindexedBlock_commonFlat μB
+    ?_, ?_⟩
   · intro x
     exact familyA.commonFlatWeight_ne_zero μA hμA x
   · intro x

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -80,8 +80,7 @@ theorem unconditional_commonPrimitiveIrreducibleBlocks
   obtain ⟨p, hp, rA₀, dimA₀, μA₀, blocksA₀,
       rB₀, dimB₀, μB₀, blocksB₀, familyA, familyB,
       hFamilyA, hFamilyB, hAPosCanon, hBPosCanon, hPosCanon,
-      _hReindexedA, _hReindexedB, hμA, hμB, hTPA, hTPB, hPrimA, hPrimB,
-      hIrrA, hIrrB, hDimA, hDimB⟩ :=
+      hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
     afterBlocking_commonLengthCommonSectorData_of_sameMPV₂ A B hSame
   have hFlatA_raw := familyA.reindexed_nonzero_part μA₀
   have hFlatB_raw := familyB.reindexed_nonzero_part μB₀

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -252,7 +252,6 @@ exactly Theorem~\ref{thm:normal_tp_primitive_irred}.
         thm:exists_common_blocked_cyclic_sector_family_common_multiple,
         thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks,
         thm:same_mpv2_pos_to_tensor_from_blocks_block_power,
-        thm:common_blocked_cyclic_sector_reindexed_samempv,
         thm:common_blocked_cyclic_sector_derived_properties}
     If two tensors generate the same MPV family, then the cyclic-sector
     decompositions on the two sides can be expressed at one common positive
@@ -282,7 +281,6 @@ exactly Theorem~\ref{thm:normal_tp_primitive_irred}.
         thm:exists_common_blocked_cyclic_sector_family_common_multiple,
         thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks,
         thm:same_mpv2_pos_to_tensor_from_blocks_block_power,
-        thm:common_blocked_cyclic_sector_reindexed_samempv,
         thm:common_blocked_cyclic_sector_derived_properties}
     Start from
     Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}. With


### PR DESCRIPTION
### Motivation

- The SectorComparison single-source audit (#2194) identified that `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` was exporting two relabeled nonzero-part equalities that no downstream theorem consumes directly; `unconditional_commonPrimitiveIrreducibleBlocks` already obtains the needed comparison from `CommonBlockedCyclicSectorFamily.reindexed_nonzero_part`.
- The two weighted relabeling lemmas were used only inside `CommonBlockedCyclicSectorFamily.lean`, making them candidates for privatization to tighten the module API.
- Continues consolidation of the canonical-form reduction chain per arXiv:1606.00608, Appendix A; see #2194.

### Description

- `CommonSectorData.lean`: `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` no longer exports the two `SameMPV₂` equalities comparing weighted `commonReindexedBlock` sums to flattened `commonFlatBlocks`; the theorem docstring is updated to reflect the slimmer existential.
- `CommonBlockedCyclicSectorFamily.lean`: `commonReindexedBlock_sameMPV₂_commonSectorTensor` and `sameMPV₂_weightedCommonReindexedBlock_commonFlat` are made `private`, as they are only used inside `reindexed_nonzero_part`.
- `CommonSectorTransport.lean`: `obtain` pattern updated to match the reduced existential from `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂`.
- `blueprint/src/chapter/ch11b_after_blocking.tex`: `\uses{}` for the common-length theorem drops the unused `common_blocked_cyclic_sector_reindexed_samempv` dependency.

### Testing

- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport TNLean`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean`
- `git diff --check`
- Note: `leanblueprint checkdecls` did not run locally — no `blueprint/lean_decls` declaration list in this checkout. Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
Progress toward #2194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in SectorComparison: no runtime behavior; downstream transport still uses `reindexed_nonzero_part` directly.
> 
> **Overview**
> **SectorComparison API cleanup:** `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` no longer bundles the two per-side `SameMPV₂` identities comparing weighted `commonReindexedBlock` sums to flattened `commonFlatBlocks`. Callers that need that relabeling already get it from `CommonBlockedCyclicSectorFamily.reindexed_nonzero_part` (as in `unconditional_commonPrimitiveIrreducibleBlocks`).
> 
> The weighted relabeling lemmas `commonReindexedBlock_sameMPV₂_commonSectorTensor` and `sameMPV₂_weightedCommonReindexedBlock_commonFlat` stay in `CommonBlockedCyclicSectorFamily.lean` but are **`private`**, since they are only used inside `reindexed_nonzero_part`. The theorem docstring and `CommonSectorTransport`'s `obtain` are updated to match the slimmer existential. Chapter 11b blueprint **`\uses{}`** for the common-length theorem drops the unused `common_blocked_cyclic_sector_reindexed_samempv` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38886f74e25fc85c491862dd95a7fa7c07a0c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->