### PR TITLE
refactor(MPS/CanonicalForm): hide common-sector helpers

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -328,7 +328,7 @@ private lemma Nat.div_pow_mod_pow_block (x d m j t : ℕ) (ht : t < m) :
 
 /-- Flattening the explicit length-`n` blocked decoding of a length-`m*n` index agrees with
 the direct length-`m*n` decoding. -/
-theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
+private theorem flattenWordOfBlock_cast_eq {d m n p : ℕ}
     (hp_eq : p = m * n) (h_card : blockPhysDim (blockPhysDim d m) n = blockPhysDim d p)
     (i : Fin (blockPhysDim d p)) :
     flattenBlockedWord d m
@@ -451,7 +451,7 @@ private theorem blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastA
   rfl
 
 /-- Blockwise MPV comparisons assemble over the weighted direct sum after common blocking. -/
-theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise
+private theorem sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise
     (F : CommonBlockedCyclicSectorFamily blocks) (μ : Fin r → ℂ)
     (hBlock : ∀ k : Fin r,
       SameMPV₂
@@ -496,7 +496,7 @@ theorem derived_properties (F : CommonBlockedCyclicSectorFamily blocks)
 
 /-- The direct $p$-blocked tensor $B_k^{[p]}$ has the same MPV family as its image in the
 common alphabet via `commonReindexedBlock`. This is the unconditional common-alphabet
-comparison used by `blocked_word_comparison` and `reindexed_nonzero_part`. -/
+comparison used by `reindexed_nonzero_part`. -/
 theorem blockTensor_sameMPV₂_commonReindexedBlock
     (F : CommonBlockedCyclicSectorFamily blocks) (k : Fin r) :
     SameMPV₂
@@ -505,20 +505,6 @@ theorem blockTensor_sameMPV₂_commonReindexedBlock
   F.blockTensor_sameMPV₂_commonReindexedBlock_of_groupedBlockCastAgrees k
     (groupedBlockCastAgrees_of_flattenWordOfBlock_cast_eq
       (fun hp_eq => flattenWordOfBlock_cast_eq hp_eq) F k)
-
-/-- Direct blocking at length `p = m_k * e_k` and iterated blocking
-`(B_k^{[m_k]})^{[e_k]}` produce the same MPV family after the canonical
-alphabet identification. -/
-theorem blocked_word_comparison (F : CommonBlockedCyclicSectorFamily blocks)
-    (k : Fin r) :
-    SameMPV₂
-      (blockTensor (d := d) (D := dim k) (blocks k) F.p)
-      (cast (congr_arg (fun d' => MPSTensor d' (dim k)) (F.blockPhysDim_nested_eq k))
-        (blockTensor (d := blockPhysDim d (F.period k)) (D := dim k)
-          (blockTensor (d := d) (D := dim k) (blocks k) (F.period k)) (F.extra k))) := by
-  intro N σ
-  exact (F.blockTensor_sameMPV₂_commonReindexedBlock k N σ).trans
-    (F.reindexed_sameMPV₂ k N σ).symm
 
 /-- The nonzero-part decomposition of a weighted block sum $\bigoplus_k \mu_k B_k$
 transports through the common-alphabet identification: the common-alphabet sectors

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1380,8 +1380,7 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
     \label{thm:common_blocked_cyclic_sector_reindexed_nonzero_part}
     \lean{MPSTensor.CommonBlockedCyclicSectorFamily.reindexed_nonzero_part}\leanok
     \uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
-        thm:common_blocked_cyclic_sector_block_tensor_common_reindexed,
-        thm:common_blocked_cyclic_sector_weighted_common_reindexed}
+        thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
     The powered nonzero-part decomposition
     $\bigoplus_k \mu_k^p B_k^{[p]}$ carries over under the common-alphabet
     identification of
@@ -1390,19 +1389,10 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
     $p$-blocked tensors.
 \end{lemma}
 
-\begin{lemma}[Digit-level flattening identification]%
-    \label{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
-    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.flattenWordOfBlock_cast_eq}\leanok
-    For $p = mn$, the canonical word-flattening identification sends a $p$-letter
-    word to the concatenation of $n$ consecutive $m$-letter words: the two
-    encodings of a word of length $p$ over $d^{[p]}$ and over $(d^{[m]})^{n}$ are
-    equal.
-\end{lemma}
-
 \begin{lemma}[Direct blocking in the common alphabet]%
     \label{thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
     \lean{MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock}\leanok
-    \uses{thm:common_blocked_cyclic_sector_flatten_word_of_block_cast}
+    \uses{thm:exists_common_blocked_cyclic_sector_family}
     For every original block $B_k$, direct blocking at the common length
     $p=m_k e_k$ agrees, as an MPV family, with the same block transported to the
     common blocked alphabet. Write $\widetilde B_k$ for this common-alphabet
@@ -1412,34 +1402,4 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
         =
         V^{(N)}\!(\widetilde B_k)_\sigma .
     \]
-\end{lemma}
-
-\begin{lemma}[Weighted assembly in the common alphabet]%
-    \label{thm:common_blocked_cyclic_sector_weighted_common_reindexed}
-    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise}\leanok
-    \uses{thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
-    If each direct block $B_k^{[p]}$ agrees with its common-alphabet image
-    $\widetilde B_k$, then the weighted direct sums agree:
-    \[
-        V^{(N)}\!\bigl(\textstyle\bigoplus_k \mu_k^p B_k^{[p]}\bigr)_\sigma
-        =
-        V^{(N)}\!\bigl(\textstyle\bigoplus_k \mu_k^p \widetilde B_k\bigr)_\sigma .
-    \]
-\end{lemma}
-
-\begin{lemma}[Direct and iterated blocking comparison]%
-    \label{thm:common_blocked_cyclic_sector_blocked_word_comparison}
-    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.blocked_word_comparison}\leanok
-    \uses{thm:common_blocked_cyclic_sector_reindexed_samempv,
-        thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
-    Direct blocking at length $p = m_k e_k$ and iterated blocking
-    $(B_k^{[m_k]})^{[e_k]}$ produce, after the canonical alphabet identification,
-    the same weighted finite sum: for every $N \ge 0$ and every blocked word
-    $\sigma$,
-    \[
-        V^{(N)}\!(B_k^{[p]})_\sigma
-        =  V^{(N)}\!((B_k^{[m_k]})^{[e_k]})_{\sigma'},
-    \]
-    where $\sigma'$ is the image of $\sigma$ under the coordinate-grouping
-    identification.
 \end{lemma}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1392,7 +1392,6 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
 \begin{lemma}[Direct blocking in the common alphabet]%
     \label{thm:common_blocked_cyclic_sector_block_tensor_common_reindexed}
     \lean{MPSTensor.CommonBlockedCyclicSectorFamily.blockTensor_sameMPV₂_commonReindexedBlock}\leanok
-    \uses{thm:exists_common_blocked_cyclic_sector_family}
     For every original block $B_k$, direct blocking at the common length
     $p=m_k e_k$ agrees, as an MPV family, with the same block transported to the
     common blocked alphabet. Write $\widetilde B_k$ for this common-alphabet


### PR DESCRIPTION
### Motivation

- Continues the consolidation of public declarations in `MPS/CanonicalForm/` toward #2194 (deduplication of canonical-form reduction declarations common to the per-tensor and after-blocking modules, deferred from #2191).
- The public interface of the common-sector transport module is narrowed to the single statement needed by downstream canonical-form arguments: two proof-internal auxiliary lemmas and one redundant public theorem are removed from the public API.

### Description

- **`TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean`**: marks `flattenWordOfBlock_cast_eq` (digit-level flattening identity comparing direct and iterated blocking alphabets) and `sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise` (conditional weighted-sum lemma used in the nonzero-part transport) as `private`. Removes unused public theorem `blocked_word_comparison`, which was the transitive combination of the surviving direct-block comparison with the iterated-block comparison.
- `MPSTensor.CommonBlockedCyclicSectorFamily.reindexed_nonzero_part` remains the sole public formalization of the powered nonzero-part decomposition in the common alphabet.
- **`blueprint/src/chapter/ch08_canonical.tex`** (Chapter 8): removes blueprint theorem nodes for the digit-level flattening identity, the weighted-sum transport lemma, and the direct-vs-iterated blocking comparison; `reindexed_nonzero_part` now cites only the reindexed MPV and direct common-alphabet block lemmas.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean`
- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean`
- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean`
- Blueprint synchronizer (`python3 scripts/blueprint_lean_sync.py`) passes on changed files.
- `lake build TNLean` succeeds; pre-existing `sorry` warnings in unrelated PEPS and periodic-overlap files are unchanged by this PR.

---
Progress toward #2194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-internal visibility and documentation-only blueprint edits; the exported `reindexed_nonzero_part` theorem is unchanged and downstream grep shows no references to removed symbols.
> 
> **Overview**
> This PR **narrows the public API** of `CommonBlockedCyclicSectorFamily` in the MPS canonical-form sector-comparison path (toward deduplication in #2194).
> 
> In **`CommonBlockedCyclicSectorFamily.lean`**, the digit-flattening lemma `flattenWordOfBlock_cast_eq` and the conditional weighted-sum transport `sameMPV₂_weightedCanonicalBlock_commonReindexedBlock_of_blockwise` are marked **`private`** (still used inside proofs). The public theorem **`blocked_word_comparison`** (direct vs iterated blocking at length \(p = m_k e_k\)) is **removed** as redundant with the surviving `blockTensor_sameMPV₂_commonReindexedBlock` and `reindexed_sameMPV₂` chain. **`reindexed_nonzero_part`** stays the main exported statement for the powered nonzero-part decomposition in the common alphabet; its doc now points only at `reindexed_nonzero_part` for the direct-block comparison.
> 
> **`ch08_canonical.tex`** drops the matching blueprint nodes (flattening identity, weighted assembly, direct/iterated blocking comparison) and trims `\uses` on `reindexed_nonzero_part` and the direct common-alphabet block lemma accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccce0be5fd16493e2ec5a96cbcf7487a6b33929f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

