### PR TITLE
refactor(MPS/CanonicalForm): hide cyclic-sector internals

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -80,7 +80,7 @@ private theorem cyclic_projection_nonzero_of_sum_one
 
 /-- Each cyclic projection lies in the multiplicative domain of the one-step
 adjoint transfer map. -/
-theorem cyclic_projection_mem_multiplicativeDomain
+private theorem cyclic_projection_mem_multiplicativeDomain
     {d D m : ℕ} [NeZero D] [NeZero m]
     {A : MPSTensor d D}
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -140,7 +140,7 @@ theorem cyclic_projection_mem_multiplicativeDomain
 
 /-- The adjoint transfer map is multiplicative on the left of a cyclic
 projection. -/
-theorem cyclic_projection_mul_left
+private theorem cyclic_projection_mul_left
     {d D m : ℕ} [NeZero D] [NeZero m]
     {A : MPSTensor d D}
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -161,7 +161,7 @@ theorem cyclic_projection_mul_left
 
 /-- The adjoint transfer map is multiplicative on the right of a cyclic
 projection. -/
-theorem cyclic_projection_mul_right
+private theorem cyclic_projection_mul_right
     {d D m : ℕ} [NeZero D] [NeZero m]
     {A : MPSTensor d D}
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -210,7 +210,8 @@ corner irreducibility theorem for `((transferMap A†)^m)` on each projection
 `P k`. In particular, this theorem isolates the orbit-sum / `hProjStep` part of
 the non-periodic proof chain from the subsequent compression-transport
 step. -/
-theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_cornerIrreducible
+private theorem
+    primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_cornerIrreducible
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)


### PR DESCRIPTION
### Motivation

- The SectorComparison single-source audit for the canonical-form reduction identified four projection-multiplicativity and orbit-lift lemmas in `CyclicSectorDecomposition` as internal to the period-removal proof. The module documentation already noted this boundary; this PR makes it explicit in Lean by marking those lemmas `private`.
- Continues the deduplication work in #2194 (consolidating per-tensor and after-blocking reduction declarations).

### Description

- `TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean`: four lemmas are made `private`:
  - `cyclic_projection_mem_multiplicativeDomain`
  - `cyclic_projection_mul_left`
  - `cyclic_projection_mul_right`
  - `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_cornerIrreducible`
- The public period-removal theorem `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking` and the top-level existence theorem `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` remain unchanged in statement and visibility.
- No proof or statement bodies are modified — visibility only.
- No blueprint entries change; the hidden lemmas had no blueprint entries. Chapter 11b continues to point at the unconditional period-removal theorem.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean`
- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorConstruction.lean`
- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean`
- `lake build TNLean` succeeds; existing `sorry` warnings in unrelated PEPS and periodic-overlap files are unchanged.

---
Progress toward #2194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visibility-only refactor in one Lean file; public theorems and mathematical content are unchanged, with no cross-module references to the hidden lemmas.
> 
> **Overview**
> In `CyclicSectorDecomposition.lean`, four lemmas that support the period-removal / orbit-lift argument are marked **`private`**, so they are no longer part of the module's public Lean API. The affected names are `cyclic_projection_mem_multiplicativeDomain`, `cyclic_projection_mul_left`, `cyclic_projection_mul_right`, and `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking_of_cornerIrreducible` (the last is only reformatted across lines).
> 
> **No proof or statement bodies change**—only visibility. Downstream code should keep using the unconditional theorem `primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking` and the existence result `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`, which stay public and unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2623910644e5a07b0278040bfaa62a39a330684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
