### PR TITLE
refactor(MPS/CanonicalForm): remove nonpositive injective-block wrapper

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -30,8 +30,8 @@ shows that blocking keeps normality.
 
 * `isNormal_of_tp_primitive_irreducible` — TP, primitive transfer map, and
   tensor irreducibility imply normality.
-* `exists_blockTensor_isInjective_of_tp_primitive_irreducible` — the same
-  hypotheses give an extra blocking whose blocked tensor is one-site injective.
+* `exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible` — the same
+  hypotheses give a positive blocking whose blocked tensor is one-site injective.
 * `isNormal_blockTensor_of_isNormal` — blocking preserves normality.
 * `IsNormalCanonicalFormBNT.exists_common_blockTensor_isInjective` — a finite
   normal-canonical BNT family admits one positive blocking length at which all
@@ -110,21 +110,6 @@ theorem isNormal_of_tp_primitive_irreducible [NeZero D]
   -- Step 4: IsNormal from the primitive complementary gap and a faithful fixed point.
   exact isNormal_of_isPrimitiveMPS_with_posDef hPrimMPS hPD
 
-/-- **TP + primitive + irreducible → injective after blocking**.
-
-Normality is eventual block injectivity.  Combining
-`isNormal_of_tp_primitive_irreducible` with the equivalence between `N`-block
-injectivity and one-site injectivity of `blockTensor A N` gives a blocking length
-whose blocked tensor is injective. -/
-theorem exists_blockTensor_isInjective_of_tp_primitive_irreducible [NeZero D]
-    (A : MPSTensor d D)
-    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A))
-    (hIrr : IsIrreducibleTensor A) :
-    ∃ L : ℕ, IsInjective (blockTensor A L) := by
-  obtain ⟨L, hL⟩ := isNormal_of_tp_primitive_irreducible A hTP hPrim hIrr
-  exact ⟨L, (isNBlkInjective_iff_blockTensor_isInjective A L).1 hL⟩
-
 /-- A trace-preserving scalar tensor has a nonzero Kraus matrix. -/
 private theorem exists_nonzero_kraus_of_tp [NeZero D]
     (A : MPSTensor d D)
@@ -196,14 +181,12 @@ theorem exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible [NeZero D
         (isNBlkInjective_one_of_isInjective hInj)⟩
   · have hD_pos : 0 < D := NeZero.pos D
     have hD_ge : 2 ≤ D := by omega
-    obtain ⟨L, hL⟩ :=
-      exists_blockTensor_isInjective_of_tp_primitive_irreducible A hTP hPrim hIrr
-    refine ⟨L, ?_, hL⟩
+    obtain ⟨L, hL⟩ := isNormal_of_tp_primitive_irreducible A hTP hPrim hIrr
+    refine ⟨L, ?_, (isNBlkInjective_iff_blockTensor_isInjective A L).1 hL⟩
     by_contra hL_nonpos
     have hL_zero : L = 0 := Nat.eq_zero_of_not_pos hL_nonpos
     subst L
-    have hInj0 : IsNBlkInjective A 0 :=
-      (isNBlkInjective_iff_blockTensor_isInjective A 0).2 hL
+    have hInj0 : IsNBlkInjective A 0 := hL
     have hD_one := bondDim_eq_one_of_isNBlkInjective_zero A hInj0
     omega
 

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1821,22 +1821,31 @@ span.
 
 \begin{theorem}[TP-primitive irreducible tensor is injective after blocking]%
     \label{thm:tp_primitive_irred_block_injective}
-    \lean{MPSTensor.exists_blockTensor_isInjective_of_tp_primitive_irreducible,
-        MPSTensor.exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible}
+    \lean{MPSTensor.exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible}
     \leanok
     \uses{thm:normal_tp_primitive_irred,
-        lem:isNBlkInjective_iff_blockTensor_isInjective}
-    Let $A$ be a left-canonical MPS tensor with $D > 0$,
-    irreducible transfer map, and peripheral spectrum $\{1\}$.
-    Then some blocking $A^{[L]}$ is one-site injective.
+        lem:isNBlkInjective_iff_blockTensor_isInjective,
+        lem:one_block_injective_of_injective,
+        cor:blk_inj_zero_dim_one}
+    Let $A$ be a left-canonical MPS tensor with $D > 0$, irreducible tensor,
+    and primitive transfer map.
+    Then some positive blocking $A^{[L]}$ is one-site injective.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:normal_tp_primitive_irred,
-        lem:isNBlkInjective_iff_blockTensor_isInjective}
-    The normality theorem (Theorem~\ref{thm:normal_tp_primitive_irred}) gives
-    eventual block injectivity, and the blocked-chain equivalence identifies this
-    with one-site injectivity of the corresponding blocked tensor.
+        lem:isNBlkInjective_iff_blockTensor_isInjective,
+        lem:one_block_injective_of_injective,
+        cor:blk_inj_zero_dim_one}
+    If $D=1$, trace preservation gives a nonzero one-site Kraus matrix, and
+    every nonzero scalar matrix spans $\MN{1}$; hence $A$ is one-site
+    injective, so Lemma~\ref{lem:one_block_injective_of_injective} gives the
+    positive witness $L=1$.  Suppose now that $D\geq 2$.  The normality theorem
+    (Theorem~\ref{thm:normal_tp_primitive_irred}) gives a block-injectivity
+    witness $L$.  If $L=0$, Corollary~\ref{cor:blk_inj_zero_dim_one} would
+    force $D=1$, a contradiction.  Thus $L>0$, and the blocked-chain
+    equivalence identifies this $L$-block injectivity with one-site injectivity
+    of the blocked tensor $A^{[L]}$.
 \end{proof}
 
 \begin{remark}


### PR DESCRIPTION
### Motivation
- The TP-primitive irreducible blocking step should have a single public statement: a positive blocking length `0 < L` for which `blockTensor A L` is injective.
- The former nonpositive existence theorem allowed `L = 0` at the level of its statement. That is not a useful mathematical formulation for the canonical-form argument, even though the positive theorem can rule out the zero case when the bond dimension is at least two.
- This continues the canonical-form single-source-of-truth cleanup tracked in #2194, in the setting of arXiv:1606.00608, Appendix A.

### Description
- `TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean`: removes `MPSTensor.exists_blockTensor_isInjective_of_tp_primitive_irreducible` and proves `MPSTensor.exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible` directly from normality.
- In bond dimension one, the positive theorem keeps the explicit witness `L = 1`.
- In bond dimension at least two, the positive theorem obtains the normality witness `L`, excludes `L = 0`, and then converts `IsNBlkInjective A L` to injectivity of `blockTensor A L`.
- `blueprint/src/chapter/ch07_wielandt.tex`: retargets theorem `thm:tp_primitive_irred_block_injective` to the positive public declaration and states the positive blocking conclusion explicitly.

### Testing
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean blueprint/src/chapter/ch07_wielandt.tex --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` (the changed declaration is present; existing missing declarations outside this diff are still reported)

---
Progress toward #2194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of theorem statements and proofs in canonical-form/Wielandt documentation with no auth, security, or runtime behavior changes.
> 
> **Overview**
> This PR **removes** the intermediate Lean theorem `exists_blockTensor_isInjective_of_tp_primitive_irreducible`, which only promised some `L` with injective `blockTensor A L` and could still use `L = 0`.
> 
> **`exists_pos_blockTensor_isInjective_of_tp_primitive_irreducible`** is now the sole public blocking result: it is proved **directly** from `isNormal_of_tp_primitive_irreducible` instead of going through the deleted wrapper. For `D = 1` it still witnesses `L = 1`; for `D ≥ 2` it takes the normality witness, rules out `L = 0` via `bondDim_eq_one_of_isNBlkInjective_zero`, then converts `IsNBlkInjective` to `IsInjective (blockTensor A L)`.
> 
> Module docs and **blueprint** theorem `thm:tp_primitive_irred_block_injective` are updated to cite only the positive theorem and to spell out the `D = 1` / `D ≥ 2` proof (including `cor:blk_inj_zero_dim_one`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 974ec4c68eb8b23bfd1c26e1889cfbf7cf0df03d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->