### PR TITLE
refactor(MPS/CanonicalForm): remove redundant cyclic-sector predicate theorem

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorConstruction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorConstruction.lean
@@ -41,17 +41,6 @@ def HasPrimitiveIrreducibleCyclicSectors {d D : ℕ} (A : MPSTensor d D) : Prop 
     (∀ k, IsIrreducibleTensor (blocks k)) ∧
     (∀ k, 0 < dim k)
 
-/-- Trace-preserving irreducible tensors have primitive irreducible cyclic sectors. -/
-theorem hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor
-    {d D : ℕ} [NeZero D]
-    (A : MPSTensor d D)
-    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hIrr : IsIrreducibleTensor A) :
-    HasPrimitiveIrreducibleCyclicSectors A := by
-  simpa [HasPrimitiveIrreducibleCyclicSectors] using
-    exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
-      (d := d) (D := D) A hTP hIrr
-
 /-- A finite family of nonzero-weight blocks with per-block primitive irreducible cyclic sectors
 admits a prescribed common physical blocking length, provided that the prescribed
 length is a positive multiple of every period-removal length.

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -95,12 +95,14 @@ theorem afterBlocking_perBlockCyclicData_of_sameMPV₂
     hBook, ?_, ?_⟩
   · intro k
     letI : NeZero (dimA k) := ⟨Nat.ne_of_gt (hDimA k)⟩
-    exact hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor
-      (blocksA k) (hTPA k) (hIrrA k)
+    simpa [HasPrimitiveIrreducibleCyclicSectors] using
+      exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
+        (d := d) (D := dimA k) (blocksA k) (hTPA k) (hIrrA k)
   · intro k
     letI : NeZero (dimB k) := ⟨Nat.ne_of_gt (hDimB k)⟩
-    exact hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor
-      (blocksB k) (hTPB k) (hIrrB k)
+    simpa [HasPrimitiveIrreducibleCyclicSectors] using
+      exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
+        (d := d) (D := dimB k) (blocksB k) (hTPB k) (hIrrB k)
 
 set_option maxHeartbeats 800000 in
 -- The next theorem has a large dependent existential conclusion, matching the

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -37,7 +37,7 @@ The source PGVWC07 theorem is recorded as a single headline statement
 (Theorem~\ref{thm:pgvwc07_ti_canonical_form}). The reduction that feeds the
 Fundamental Theorem does not pass through it: it goes through
 Theorem~\ref{thm:tp_gauge_arbitrary},
-Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr}, and the
+Theorem~\ref{thm:cyclic_sector_decomp_irr_tp_prim_irr}, and the
 after-blocking reductions of Chapter~\ref{ch:canonical_after_blocking}. The
 principal outputs of this chapter are
 Theorem~\ref{thm:pgvwc07_ti_canonical_form} (the PGVWC07 translation-invariant
@@ -1280,29 +1280,15 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
     preserves the nonzero-weight hypothesis of a weighted block decomposition.
 \end{lemma}
 
-\begin{lemma}[Primitive cyclic sectors of irreducible TP tensors]%
-    \label{thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
-    \lean{MPSTensor.hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor}\leanok
-    \uses{def:irreducible_tensor, def:tp_kraus, def:primitive_channel,
-        thm:cyclic_sector_decomp_irr_tp_prim_irr}
-    Let $A$ be a left-canonical irreducible MPS tensor with $D > 0$. Then there
-    exist a period $m \ge 1$ and left-canonical blocks $(C_k)_{k=1}^m$ with
-    primitive transfer maps, tensor-irreducible structure, and positive bond
-    dimensions such that $A^{[m]}$ generates the same MPV family as
-    $\bigoplus_{k=1}^m C_k$ (unit weights).
-\end{lemma}
-
 \begin{lemma}[Common reblocking of cyclic-sector families]%
     \label{thm:exists_common_blocked_cyclic_sector_family}
     \lean{MPSTensor.exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors}\leanok
-    \uses{thm:has_primitive_irreducible_cyclic_sectors_tp_irr,
-        def:blocked_tensor}
-    Given a finite family $(B_k)_{k=1}^r$ of left-canonical irreducible TP tensors
-    with positive bond dimensions and per-block period-removal lengths
-    $(m_k)_{k=1}^r$, there is a common blocking length $p$ such that each
-    $B_k^{[p]}$ admits a unit-weight direct-sum decomposition over a single common
-    blocked alphabet $d^{[p]}$ into left-canonical blocks with primitive transfer
-    maps, tensor irreducibility, and positive bond dimensions.
+    \uses{def:primitive_irreducible_cyclic_sectors, def:blocked_tensor}
+    Given a finite family $(B_k)_{k=1}^r$, each with primitive irreducible cyclic
+    sectors, there is a common blocking length $p$ such that each $B_k^{[p]}$
+    admits a unit-weight direct-sum decomposition over a single common blocked
+    alphabet $d^{[p]}$ into left-canonical blocks with primitive transfer maps,
+    tensor irreducibility, and positive bond dimensions.
 \end{lemma}
 
 \begin{lemma}[Nonzero unit weight of the common reblocked family]%

--- a/blueprint/src/chapter/ch11b_after_blocking.tex
+++ b/blueprint/src/chapter/ch11b_after_blocking.tex
@@ -200,7 +200,7 @@ exactly Theorem~\ref{thm:normal_tp_primitive_irred}.
     \lean{MPSTensor.afterBlocking_perBlockCyclicData_of_sameMPV₂}
     \leanok
     \uses{thm:tp_gauge_arbitrary, def:primitive_irreducible_cyclic_sectors,
-        thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
+        thm:cyclic_sector_decomp_irr_tp_prim_irr}
     If $A$ and $B$ generate the same MPV family, then after the zero-block split
     and the trace-preserving gauge there are weighted nonzero-block tensors
     $\bigoplus_j \mu^A_j A_j$ and $\bigoplus_k \mu^B_k B_k$ with, for every
@@ -227,7 +227,7 @@ exactly Theorem~\ref{thm:normal_tp_primitive_irred}.
 
 \begin{proof}\leanok
     \uses{thm:tp_gauge_arbitrary,
-        thm:has_primitive_irreducible_cyclic_sectors_tp_irr}
+        thm:cyclic_sector_decomp_irr_tp_prim_irr}
     Apply Theorem~\ref{thm:tp_gauge_arbitrary} separately to $A$ and $B$. Its
     positive-length conclusion gives, for $N\ge 1$,
     \[
@@ -240,7 +240,7 @@ exactly Theorem~\ref{thm:normal_tp_primitive_irred}.
         V^{(N)}\!(\textstyle\bigoplus_k \mu^B_k B_k)_\sigma.
     \]
     Chaining these through $V(A)=V(B)$ identifies the two nonzero parts. Finally
-    apply Theorem~\ref{thm:has_primitive_irreducible_cyclic_sectors_tp_irr} to
+    apply Theorem~\ref{thm:cyclic_sector_decomp_irr_tp_prim_irr} to
     every trace-preserving irreducible nonzero-weight block.
 \end{proof}
 


### PR DESCRIPTION
### Motivation
- The common-sector after-blocking route should cite the period-removal theorem directly when it needs primitive irreducible cyclic sectors of trace-preserving irreducible blocks.
- `MPSTensor.hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor` was only a rephrasing of `MPSTensor.exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` into the predicate `HasPrimitiveIrreducibleCyclicSectors`.
- Removing this redundant theorem keeps the period-removal theorem as the single public source for this step, continuing the #2194 audit of duplicate canonical-form declarations.

### Description
- `CommonBlockedCyclicSectorConstruction.lean`: removes the redundant theorem `hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor`.
- `CommonSectorData.lean`: derives `HasPrimitiveIrreducibleCyclicSectors` directly from `exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor` for the two block families.
- `ch08_canonical.tex`: removes the duplicate blueprint entry and states the common reblocking lemma with the predicate it actually assumes.
- `ch11b_after_blocking.tex`: retargets the per-block cyclic-sector proof references to `thm:cyclic_sector_decomp_irr_tp_prim_irr`.

### Testing
- `lake exe cache get`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData`
- `lake build TNLean`
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorConstruction.lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch11b_after_blocking.tex --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` (changed declarations are covered; existing missing parent-Hamiltonian/PEPS declarations outside this diff remain reported)

---
Progress toward #2194

> [!NOTE]
> **Low Risk**
> Proof and documentation realignment only; no change to definitions or downstream theorem statements beyond citation paths.
> 
> **Overview**
> This refactor drops the thin Lean wrapper `hasPrimitiveIrreducibleCyclicSectors_of_TP_of_isIrreducibleTensor` and keeps **`exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor`** as the single cited step for trace-preserving irreducible blocks.
> 
> In **`CommonSectorData`**, per-block **`HasPrimitiveIrreducibleCyclicSectors`** is now proved inline with `simpa` from that existence theorem for both block families. **`HasPrimitiveIrreducibleCyclicSectors`** and the common-blocked construction API are unchanged.
> 
> Blueprint updates remove the duplicate **`thm:has_primitive_irreducible_cyclic_sectors_tp_irr`**, point the reduction chain and after-blocking proofs at **`thm:cyclic_sector_decomp_irr_tp_prim_irr`**, and state the common reblocking lemma in terms of the predicate it already assumes rather than re-deriving TP/irreducibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf8eb6f8efc8e7baa33570b4f89f72919fdaef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>