### PR TITLE
doc(blueprint): move BNT material to its chapter

### DIFF
--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1028,26 +1028,25 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     Lemma~\ref{lem:blocking_transfer}.
 \end{proof}
 
-\begin{corollary}[Uniform injective blocking for normal BNT families]%
+\begin{corollary}[Uniform injective blocking for separated normal-canonical families]%
     \label{cor:uniform_injective_blocking_normal_bnt}
     \lean{MPSTensor.IsNormalCanonicalFormBNT.exists_common_blockTensor_isInjective,
         MPSTensor.exists_common_blockTensor_isInjective_two_of_isNormalCanonicalFormBNT}
     \leanok
     \uses{thm:normal_tp_primitive_irred,
         thm:bounded_injective_blocking_normal_left_canonical}
-    Let $(A_x)_{x \in X}$ be a finite normal-canonical BNT family whose
+    Let $(A_x)_{x \in X}$ be a finite separated normal-canonical family whose
     blocks have positive virtual bond dimension. Then there is a positive
     integer $L$ such that every blocked tensor $A_x^{[L]}$ is one-site
     injective. The same conclusion holds simultaneously for two finite
-    normal-canonical BNT families whose blocks have positive virtual bond
+    separated normal-canonical families whose blocks have positive virtual bond
     dimension.
 
     This is a common-blocking theorem for the scope-restricted
     one-copy-per-sector surface of Definition~\ref{def:normal_cf_bnt}. It
-    assumes that the normal-CF-BNT representative families have already been
-    selected and strictly ordered; it does not reconstruct the full CPSV16 BNT
-    sector decomposition with repeated copies inside one sector. The restriction
-    is recorded in
+    assumes that the representative families have already been selected and
+    strictly ordered; it does not reconstruct the full CPSV sector decomposition
+    with repeated copies inside one sector. The restriction is recorded in
     \path{docs/paper-gaps/ft_one_copy_scope_restriction.tex}.
 \end{corollary}
 

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -126,20 +126,19 @@ primitive blocks).
     Remark~\ref{rem:arbitrary_input_reduction_gap}.
 \end{remark}
 
-\section{Normal tensors, canonical forms, and bases of normal tensors}\label{sec:cpsv_canonical_defs}
+\section{Normal tensors and canonical forms}\label{sec:cpsv_canonical_defs}
 
-This section records the CPSV definitions of \emph{normal tensor},
-\emph{canonical form}, and \emph{basis of normal tensors}
-from~\cite{Cirac2017MPDO_AnnPhys}. Write
+This section records the CPSV definitions of \emph{normal tensor} and
+\emph{canonical form} from~\cite{Cirac2017MPDO_AnnPhys}. The basis of normal
+tensors is stated in Chapter~\ref{ch:bnt}. Write
 \[
     \sigma_\partial(\E) = \{\lambda \in \sigma(\E) : |\lambda| = r(\E)\}
 \]
 for the peripheral spectrum of a transfer map $\E$, where $r(\E)$ is its
 spectral radius. The stronger predicates used later
-(Definition~\ref{def:is_normal_canonical_form} and the canonical-form BNT
-predicate of Chapter~\ref{ch:bnt}) add left-canonical normalization, strict
-modulus ordering, and one copy per sector; these are subcases of the CPSV
-definitions, treated by the bases of normal tensors of Chapter~\ref{ch:bnt}.
+(Definition~\ref{def:is_normal_canonical_form} and the canonical-form predicate
+of Chapter~\ref{ch:bnt}) add left-canonical normalization, strict modulus
+ordering, and one copy per sector.
 
 \begin{definition}[CPSV normal tensor (NT)]\label{def:nt_cpsv}
     \lean{MPSTensor.IsNormalTensor}
@@ -168,24 +167,6 @@ see \cite[Section~II.C]{Cirac2017MPDO_AnnPhys}. In the statements below the
 structural part is supplied by the stronger normal canonical form of
 Definition~\ref{def:is_normal_canonical_form}, and the global weight
 normalization is invoked as a separate source hypothesis where needed.
-
-\begin{definition}[CPSV basis of normal tensors (BNT)]\label{def:bnt_cpsv}
-    \lean{MPSTensor.IsCPSVBasisOfNormalTensors}
-    \leanok
-    A finite family $\{A_j\}_{j=1}^g$ of normal tensors, with bond dimension
-    allowed to depend on $j$, is a \emph{basis of normal tensors} for $A$ if:
-    \begin{enumerate}
-        \item each $A_j$ is normal in the sense of Definition~\ref{def:nt_cpsv};
-        \item for every system length $N$ there exist coefficients
-              $c_j^{(N)} \in \C$ with
-              \[
-                  \ket{V^{(N)}(A)}
-                  = \sum_{j=1}^{g} c_j^{(N)} \ket{V^{(N)}(A_j)};
-              \]
-        \item there exists $N_0$ such that for all $N > N_0$ the family
-              $\{\ket{V^{(N)}(A_j)}\}_{j=1}^{g}$ is linearly independent.
-    \end{enumerate}
-\end{definition}
 
 \begin{remark}[Relation to the strong predicates]
     A tensor $A$ which is both irreducible
@@ -529,7 +510,7 @@ the transfer map primitive, removing periodicity.
     Definition~\ref{def:is_normal_canonical_form} additionally assume pairwise
     distinct moduli and one copy per sector. This is the distinct-modulus,
     one-copy subcase: equal-modulus sectors are first grouped by the common value
-    of $|\mu_k|$, and repeated copies are then treated by the phase-class BNT
+    of $|\mu_k|$, and repeated copies are then treated by the phase-class
     sector construction of Chapter~\ref{ch:bnt}
     (Definition~\ref{def:mpv_phase_class_data}) and the collapsed sector theorem
     of Chapter~\ref{ch:ft_proof}
@@ -883,15 +864,15 @@ a TP-primitive irreducible block.
     Theorem~\ref{thm:normal_from_primitive_posdef} applies.
 \end{proof}
 
-\subsection{Basis of Normal Tensors}
+\subsection{Single-copy sector decompositions}
 
 This subsection records the single-copy case and the elementary regrouping by
-common weight modulus. It is not the general equal-modulus comparison: that is
-the SectorBNT material of Chapter~\ref{ch:bnt} and its use in the equal-MPV
-theorem of Chapter~\ref{ch:ft_proof}, as discussed in the remark after
-Definition~\ref{def:is_normal_canonical_form}. Equal-modulus and repeated-copy
-sectors do occur: for $A = C \oplus (-C)$ the length-$N$ MPV coefficients are
-$(1 + (-1)^N)\,V^{(N)}(C)_\sigma$, which is not a single scalar power.
+common weight modulus. Equal-modulus and repeated-copy sectors are treated by
+the basis-of-normal-tensors material of Chapter~\ref{ch:bnt} and its use in the
+equal-MPV theorem of Chapter~\ref{ch:ft_proof}, as discussed in the remark after
+Definition~\ref{def:is_normal_canonical_form}. Such sectors occur already for
+$A = C \oplus (-C)$, whose length-$N$ MPV coefficients are
+$(1 + (-1)^N)\,V^{(N)}(C)_\sigma$, not a single scalar power.
 
 \begin{definition}[Single-copy sector decomposition]
     \label{def:trivial_sector_decomp}
@@ -926,10 +907,10 @@ $(1 + (-1)^N)\,V^{(N)}(C)_\sigma$, which is not a single scalar power.
 The sorted distinct-modulus sector statement and the regrouping of blocks by
 common weight modulus are the subcase discussed in the remark after
 Definition~\ref{def:is_normal_canonical_form}; they are subsumed by the
-phase-class BNT sector construction of Chapter~\ref{ch:ft_proof} and the
+phase-class sector construction of Chapter~\ref{ch:ft_proof} and the
 development of Chapter~\ref{ch:bnt}, and are not recorded separately here.
 
-\section{Scope and BNT input reductions}\label{sec:open_directions}
+\section{Scope of the canonical-form reduction}\label{sec:open_directions}
 
 \begin{remark}[Canonical-form reduction before the equal-case comparison]%
     \label{rem:canonical_construction_gaps}
@@ -955,239 +936,6 @@ development of Chapter~\ref{ch:bnt}, and are not recorded separately here.
     Theorem~\ref{thm:cyclic_sector_decomp_after_blocking}; the explicit
     decomposition of the state vector into $p$-periodic summands lies outside
     this chapter.
-\end{remark}
-
-\subsection{Building a BNT from normal blocks with normalized weights}%
-\label{subsec:paperbnt_supplier}
-
-The BNT predicate of~\cite{Cirac2017MPDO_AnnPhys}
-(Definition~\ref{def:bnt_cpsv}) is strengthened in Chapter~\ref{ch:bnt} by
-multiplicity, span, and weight-norm conditions. The results below separate the
-after-blocking preparation of suitable blocks from the normalized-weight BNT
-construction.
-
-\begin{lemma}[Common injective blocking for primitive irreducible families]%
-    \label{thm:common_injective_blocking_tp_primitive_irreducible_family}
-    \lean{MPSTensor.exists_common_injective_blocking_of_tp_primitive_irr_family}
-    \leanok
-    \uses{thm:tp_primitive_irred_block_injective,
-        thm:tp_primitive_irreducible_extra_blocking}
-    Let $(B_k)_{k=1}^r$ be a finite family of positive-bond-dimension MPS tensors,
-    each trace-preserving, primitive, and tensor-irreducible. Then there is a
-    single $L\ge 1$ such that each $B_k^{[L]}$ is one-site injective, and this
-    blocking preserves trace preservation, primitivity, and irreducibility for
-    every block.
-\end{lemma}
-
-\begin{proof}\leanok
-    For each block,
-    Theorem~\ref{thm:tp_primitive_irred_block_injective} gives a positive length
-    at which it becomes one-site injective; the product of these lengths is a
-    common length. Injectivity persists under positive further blocking, and
-    Theorem~\ref{thm:tp_primitive_irreducible_extra_blocking} preserves the other
-    hypotheses.
-\end{proof}
-
-\begin{theorem}[Prepared BNT blocks after blocking]%
-    \label{thm:prepared_bnt_blocks_after_blocking}
-    \lean{MPSTensor.exists_prepared_BNT_blocks_afterBlocking_pos}
-    \leanok
-    \uses{thm:unconditional_common_primitive_irreducible_blocks,
-        thm:common_injective_blocking_tp_primitive_irreducible_family}
-    Let $A$ be an MPS tensor. Then there is a blocking length $p\ge 1$, nonzero
-    weights $\mu_k$, and blocks $B_k$ over the $p$-blocked alphabet such that:
-    \begin{enumerate}
-        \item each block has positive bond dimension;
-        \item each block is trace-preserving, primitive, tensor-irreducible, and
-              one-site injective;
-        \item $A^{[p]}$ and $\bigoplus_k \mu_k B_k$ generate the same MPV family
-              at every positive length.
-    \end{enumerate}
-    No weight-modulus normalization is asserted at this stage.
-\end{theorem}
-
-\begin{proof}\leanok
-    Apply the common primitive irreducible block decomposition to $(A,A)$,
-    giving a positive blocking length and a nonzero weighted family of
-    trace-preserving primitive irreducible blocks with the positive-length MPV
-    identity. Lemma~\ref{thm:common_injective_blocking_tp_primitive_irreducible_family}
-    supplies one common further blocking making every block one-site injective
-    while preserving the other hypotheses; finally identify the iterated blocked
-    alphabet with the direct one.
-\end{proof}
-
-\begin{theorem}[BNT from normal blocks with normalized weights]%
-    \label{thm:paperbnt_supplier_prepared}
-    \lean{MPSTensor.exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks}
-    \leanok
-    Let $r \in \N$, and for each $k = 1,\ldots,r$ let $D_k \in \N$,
-    $\mu_k \in \C$, and let $B_k$ be an MPS tensor of physical dimension $d$ and
-    bond dimension $D_k$. Assume:
-    \begin{enumerate}
-        \item \textbf{positive bond dimensions:} $D_k > 0$ for all $k$,
-        \item \textbf{TP normalization:} $\sum_i (B_k^i)^\dagger B_k^i = \Id$,
-        \item \textbf{primitivity:} $\E_{B_k}$ is primitive for each $k$,
-        \item \textbf{irreducibility:} each $B_k$ is irreducible,
-        \item \textbf{injectivity:} each $B_k$ is injective,
-        \item \textbf{nonzero weights:} $\mu_k \neq 0$ for all $k$,
-        \item \textbf{bounded weights:} $|\mu_k| \le 1$ for all $k$,
-        \item \textbf{global unit witness:} $|\mu_k| = 1$ for some $k$.
-    \end{enumerate}
-    Then there exists a sector decomposition $P$ such that $P$ and
-    $\bigoplus_{k=1}^{r} \mu_k B_k$ generate the same MPV family at every length,
-    and $P$ satisfies the BNT conditions of Definition~\ref{def:bnt_cpsv}
-    together with the multiplicity, span, and weight-bound conditions of
-    Chapter~\ref{ch:bnt}.
-\end{theorem}
-
-\begin{proof}\leanok
-    The phase-class quotient groups gauge-phase-equivalent blocks into sectors
-    with unit-modulus per-copy scalars. The TP, primitive, and irreducible
-    hypotheses are those under which the phase-class construction applies, while
-    injectivity gives the eventual linear-independence condition. The resulting
-    sector decomposition inherits the span and multiplicity conditions, and the
-    bounded-weight and global-unit hypotheses give the weight-norm conditions.
-\end{proof}
-
-\begin{lemma}[Total dimension of a dimension-preserving phase-class quotient]%
-    \label{lem:collapsed_bnt_sector_decomp_total_dim}
-    \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim}
-    \leanok
-    In the phase-class quotient of the prepared-block BNT supplier, suppose every
-    original copy weight is nonzero and every block in a phase class has the bond
-    dimension of its representative. Then the total bond dimension of the
-    collapsed sector decomposition equals the sum of the bond dimensions of the
-    original prepared blocks.
-\end{lemma}
-
-\begin{proof}\leanok
-    Sum the representative bond dimensions over the copies in each phase class.
-    The same-dimension hypothesis replaces each representative dimension by the
-    enumerated original block dimension, and the phase-class regrouping identity
-    recovers the original direct-sum dimension.
-\end{proof}
-
-\begin{lemma}[Prepared phase-equivalent blocks have the same bond dimension]%
-    \label{lem:prepared_phase_equiv_dim_eq}
-    \lean{MPSTensor.dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr}
-    \leanok
-    % Source: Lemma equalMPS (Cirac2016MPDO_arXiv), dimension conclusion.
-    Let $X$ and $Y$ be trace-preserving, primitive, irreducible MPS blocks of
-    positive bond dimension. If their MPV families differ by a nonzero scalar
-    power, then their bond dimensions are equal.
-\end{lemma}
-
-\begin{proof}\leanok\uses{thm:overlap_decay_rect_irr_tp}
-    Self-overlap normalization forces the scalar relating the two MPV families to
-    have unit modulus, so the rectangular overlap has norm tending to $1$. If the
-    bond dimensions differed, the rectangular overlap-decay theorem would force
-    that overlap to tend to $0$.
-\end{proof}
-
-\begin{lemma}[Prepared phase classes preserve bond dimension]%
-    \label{lem:prepared_phase_class_dim_eq}
-    \lean{MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr}
-    \leanok
-    % Source: prop:char-BNT (Cirac2017MPDO_AnnPhys), with appendix restatement
-    % and the same-CF BNT uniqueness note.
-    In a prepared family of positive-bond-dimension trace-preserving primitive
-    irreducible blocks, every block in an MPV phase class has the bond dimension
-    of its representative.
-\end{lemma}
-
-\begin{proof}\leanok\uses{lem:prepared_phase_equiv_dim_eq}
-    Apply Lemma~\ref{lem:prepared_phase_equiv_dim_eq} to each representative and
-    each member of its phase class.
-\end{proof}
-
-\begin{lemma}[Prepared collapsed BNT total dimension]%
-    \label{lem:prepared_collapsed_bnt_sector_decomp_total_dim}
-    \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr}
-    \leanok
-    % Source: canonical-form eq:II_CF1 (Cirac2017MPDO_AnnPhys) and the
-    % phase-class quotient prop:char-BNT with its appendix restatement.
-    For prepared trace-preserving primitive irreducible blocks of positive bond
-    dimension with all copy weights nonzero, the phase-class quotient preserves
-    the total bond dimension: the collapsed sector decomposition has total bond
-    dimension equal to the sum of the original block dimensions.
-\end{lemma}
-
-\begin{proof}\leanok\uses{lem:collapsed_bnt_sector_decomp_total_dim,
-        lem:prepared_phase_class_dim_eq}
-    Lemma~\ref{lem:prepared_phase_class_dim_eq} supplies the same-dimension
-    hypothesis in Lemma~\ref{lem:collapsed_bnt_sector_decomp_total_dim}.
-\end{proof}
-
-\begin{theorem}[Conditional BNT form after blocking for an arbitrary tensor]%
-    \label{thm:paperbnt_supplier_after_blocking}
-    \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos}
-    \leanok
-    \uses{thm:prepared_bnt_blocks_after_blocking,
-        thm:paperbnt_supplier_prepared}
-    Let $A$ be an MPS tensor. Then there exists a blocking length $p \ge 1$,
-    nonzero weights $\mu_k$, and blocks $B_k$ over the blocked alphabet, such
-    that:
-    \begin{enumerate}
-        \item every block has positive bond dimension;
-        \item every block is TP-normalized, primitive, irreducible, and
-              injective;
-        \item $A^{[p]}$ and $\bigoplus_k \mu_k B_k$ generate the same MPV family
-              at every positive length.
-    \end{enumerate}
-    Moreover, under $|\mu_k| \le 1$ for every $k$ and $|\mu_k|=1$ for at least
-    one $k$, there exists a sector decomposition $P$ over the blocked alphabet in
-    the strengthened BNT canonical form of Chapter~\ref{ch:bnt} such that
-    $A^{[p]}$ and $P$ generate the same MPV family at every positive length.
-\end{theorem}
-
-\begin{proof}\leanok
-    The after-blocking reduction supplies the TP-normalized primitive irreducible
-    injective blocks and the positive-length MPV identity. The normalized-weight
-    hypotheses are the choice that
-    \cite[Section~II.C]{Cirac2017MPDO_AnnPhys} makes;
-    Theorem~\ref{thm:paperbnt_supplier_prepared} then produces the sector
-    decomposition, following the BNT selection of
-    \cite[Appendix~A]{Cirac2017MPDO_AnnPhys}. The missing rescaling step is
-    recorded in Remark~\ref{rem:arbitrary_input_reduction_gap}.
-\end{proof}
-
-\begin{theorem}[Conditional BNT form after blocking, completed at length zero]%
-    \label{thm:paperbnt_supplier_after_blocking_total_dim}
-    \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_of_totalDim}
-    \leanok
-    \uses{thm:paperbnt_supplier_after_blocking,
-        def:same_mpv2,
-        def:same_mpv2_pos,
-        lem:samempv2pos_to_samempv2_of_bonddim_eq}
-    In the setting of Theorem~\ref{thm:paperbnt_supplier_after_blocking}, the same
-    prepared blocks may be chosen so that the positive-length MPV identity
-    upgrades to all lengths whenever the total bond dimension of $P$ equals the
-    bond dimension of the blocked input tensor.
-\end{theorem}
-
-\begin{proof}\leanok
-    The positive-length statement is
-    Theorem~\ref{thm:paperbnt_supplier_after_blocking}. At length zero the MPV
-    coefficient is the bond dimension, so equality of the two total bond
-    dimensions supplies the missing length-zero coefficient, and the
-    positive-length identity gives all remaining lengths.
-\end{proof}
-
-\begin{remark}[Arbitrary-input reduction]%
-    \label{rem:arbitrary_input_reduction_gap}
-    Theorem~\ref{thm:paperbnt_supplier_after_blocking} gives the arbitrary-input
-    reduction, conditional on the two weight-normalization hypotheses displayed
-    there. The preparatory part,
-    Theorem~\ref{thm:prepared_bnt_blocks_after_blocking}, produces the
-    TP-normalized primitive irreducible injective blocks and the positive-length
-    MPV identity but not the weight normalization. Since the all-zero summand
-    contributes only at length zero, the nonzero primitive blocks identify the
-    MPV family for $N\ge 1$. The proof that the prepared weights can always be
-    rescaled to satisfy $|\mu_k|\le 1$ with a unit-modulus witness is the one
-    remaining step, recorded in
-    \texttt{docs/paper-gaps/cpsv16\_cf\_normalization\_and\_proportional\_comparison.tex};
-    the length-zero trace identity and the fully unblocked canonical form remain
-    part of the reduction in Chapter~\ref{ch:canonical_after_blocking}.
 \end{remark}
 
 \subsection{Auxiliary lemmas}%

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -15,6 +15,27 @@ and~\cite{Cirac2021Matrix}.
 
 \section{Basis of normal tensors}
 
+\begin{definition}[CPSV basis of normal tensors]\label{def:bnt_cpsv}
+    \lean{MPSTensor.IsCPSVBasisOfNormalTensors}
+    \leanok
+    A finite family $\{A_j\}_{j=1}^g$ of normal tensors, with bond dimension
+    allowed to depend on $j$, is a \emph{basis of normal tensors} for $A$ if:
+    \begin{enumerate}
+        \item each $A_j$ is normal in the sense of Definition~\ref{def:nt_cpsv};
+        \item for every system length $N$ there exist coefficients
+              $c_j^{(N)} \in \C$ with
+              \[
+                  \ket{V^{(N)}(A)}
+                  = \sum_{j=1}^{g} c_j^{(N)} \ket{V^{(N)}(A_j)};
+              \]
+        \item there exists $N_0$ such that for all $N > N_0$ the family
+              $\{\ket{V^{(N)}(A_j)}\}_{j=1}^{g}$ is linearly independent.
+    \end{enumerate}
+    This is the basis-of-normal-tensors definition in
+    \cite[\S~II.C, lines~271--274]{Cirac2017MPDO_AnnPhys} and
+    \cite[Definition~4.2]{Cirac2021Matrix}.
+\end{definition}
+
 \begin{definition}[Basis of Normal Tensors (BNT)]\label{def:bnt}
     \lean{MPSTensor.IsBNT}
     \leanok
@@ -672,6 +693,241 @@ Chapter~\ref{ch:ft_proof}.
     $C \oplus (1/2) C$, and $C \oplus (-C) \oplus (1/2) C$) and is
     not derivable from the per-block normality hypotheses alone.
 \end{definition}
+
+\subsection{Prepared-block construction of BNT canonical forms}%
+\label{subsec:paperbnt_supplier}
+
+The CPSV basis-of-normal-tensors predicate in Definition~\ref{def:bnt_cpsv}
+is strengthened by the sector-decomposition predicate of
+Definition~\ref{def:sector_bnt_cf}, which records multiplicities, span, and
+weight-norm conditions. The results below separate the after-blocking
+preparation of suitable blocks from the normalized-weight BNT construction.
+
+\begin{lemma}[Common injective blocking for primitive irreducible families]%
+    \label{thm:common_injective_blocking_tp_primitive_irreducible_family}
+    \lean{MPSTensor.exists_common_injective_blocking_of_tp_primitive_irr_family}
+    \leanok
+    \uses{thm:tp_primitive_irred_block_injective,
+        thm:tp_primitive_irreducible_extra_blocking}
+    Let $(B_k)_{k=1}^r$ be a finite family of positive-bond-dimension MPS tensors,
+    each trace-preserving, primitive, and tensor-irreducible. Then there is a
+    single $L\ge 1$ such that each $B_k^{[L]}$ is one-site injective, and this
+    blocking preserves trace preservation, primitivity, and irreducibility for
+    every block.
+\end{lemma}
+
+\begin{proof}\leanok
+    For each block,
+    Theorem~\ref{thm:tp_primitive_irred_block_injective} gives a positive length
+    at which it becomes one-site injective; the product of these lengths is a
+    common length. Injectivity persists under positive further blocking, and
+    Theorem~\ref{thm:tp_primitive_irreducible_extra_blocking} preserves the other
+    hypotheses.
+\end{proof}
+
+\begin{theorem}[Prepared BNT blocks after blocking]%
+    \label{thm:prepared_bnt_blocks_after_blocking}
+    \lean{MPSTensor.exists_prepared_BNT_blocks_afterBlocking_pos}
+    \leanok
+    \uses{thm:unconditional_common_primitive_irreducible_blocks,
+        thm:common_injective_blocking_tp_primitive_irreducible_family}
+    Let $A$ be an MPS tensor. Then there is a blocking length $p\ge 1$, nonzero
+    weights $\mu_k$, and blocks $B_k$ over the $p$-blocked alphabet such that:
+    \begin{enumerate}
+        \item each block has positive bond dimension;
+        \item each block is trace-preserving, primitive, tensor-irreducible, and
+              one-site injective;
+        \item $A^{[p]}$ and $\bigoplus_k \mu_k B_k$ generate the same MPV family
+              at every positive length.
+    \end{enumerate}
+    No weight-modulus normalization is asserted at this stage.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the common primitive irreducible block decomposition to $(A,A)$,
+    giving a positive blocking length and a nonzero weighted family of
+    trace-preserving primitive irreducible blocks with the positive-length MPV
+    identity. Lemma~\ref{thm:common_injective_blocking_tp_primitive_irreducible_family}
+    supplies one common further blocking making every block one-site injective
+    while preserving the other hypotheses; finally identify the iterated blocked
+    alphabet with the direct one.
+\end{proof}
+
+\begin{theorem}[BNT from normal blocks with normalized weights]%
+    \label{thm:paperbnt_supplier_prepared}
+    \lean{MPSTensor.exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks}
+    \leanok
+    Let $r \in \N$, and for each $k = 1,\ldots,r$ let $D_k \in \N$,
+    $\mu_k \in \C$, and let $B_k$ be an MPS tensor of physical dimension $d$ and
+    bond dimension $D_k$. Assume:
+    \begin{enumerate}
+        \item \textbf{positive bond dimensions:} $D_k > 0$ for all $k$,
+        \item \textbf{TP normalization:} $\sum_i (B_k^i)^\dagger B_k^i = \Id$,
+        \item \textbf{primitivity:} $\E_{B_k}$ is primitive for each $k$,
+        \item \textbf{irreducibility:} each $B_k$ is irreducible,
+        \item \textbf{injectivity:} each $B_k$ is injective,
+        \item \textbf{nonzero weights:} $\mu_k \neq 0$ for all $k$,
+        \item \textbf{bounded weights:} $|\mu_k| \le 1$ for all $k$,
+        \item \textbf{global unit witness:} $|\mu_k| = 1$ for some $k$.
+    \end{enumerate}
+    Then there exists a sector decomposition $P$ such that $P$ and
+    $\bigoplus_{k=1}^{r} \mu_k B_k$ generate the same MPV family at every length,
+    and $P$ satisfies the BNT conditions of Definition~\ref{def:bnt_cpsv}
+    together with the multiplicity, span, and weight-bound conditions of
+    Definition~\ref{def:sector_bnt_cf}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The phase-class quotient groups gauge-phase-equivalent blocks into sectors
+    with unit-modulus per-copy scalars. The TP, primitive, and irreducible
+    hypotheses are those under which the phase-class construction applies, while
+    injectivity gives the eventual linear-independence condition. The resulting
+    sector decomposition inherits the span and multiplicity conditions, and the
+    bounded-weight and global-unit hypotheses give the weight-norm conditions.
+\end{proof}
+
+\begin{lemma}[Total dimension of a dimension-preserving phase-class quotient]%
+    \label{lem:collapsed_bnt_sector_decomp_total_dim}
+    \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim}
+    \leanok
+    In the phase-class quotient of the prepared-block BNT supplier, suppose every
+    original copy weight is nonzero and every block in a phase class has the bond
+    dimension of its representative. Then the total bond dimension of the
+    collapsed sector decomposition equals the sum of the bond dimensions of the
+    original prepared blocks.
+\end{lemma}
+
+\begin{proof}\leanok
+    Sum the representative bond dimensions over the copies in each phase class.
+    The same-dimension hypothesis replaces each representative dimension by the
+    enumerated original block dimension, and the phase-class regrouping identity
+    recovers the original direct-sum dimension.
+\end{proof}
+
+\begin{lemma}[Prepared phase-equivalent blocks have the same bond dimension]%
+    \label{lem:prepared_phase_equiv_dim_eq}
+    \lean{MPSTensor.dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr}
+    \leanok
+    % Source: Lemma equalMPS (Cirac2016MPDO_arXiv), dimension conclusion.
+    Let $X$ and $Y$ be trace-preserving, primitive, irreducible MPS blocks of
+    positive bond dimension. If their MPV families differ by a nonzero scalar
+    power, then their bond dimensions are equal.
+\end{lemma}
+
+\begin{proof}\leanok\uses{thm:overlap_decay_rect_irr_tp}
+    Self-overlap normalization forces the scalar relating the two MPV families to
+    have unit modulus, so the rectangular overlap has norm tending to $1$. If the
+    bond dimensions differed, the rectangular overlap-decay theorem would force
+    that overlap to tend to $0$.
+\end{proof}
+
+\begin{lemma}[Prepared phase classes preserve bond dimension]%
+    \label{lem:prepared_phase_class_dim_eq}
+    \lean{MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr}
+    \leanok
+    % Source: prop:char-BNT (Cirac2017MPDO_AnnPhys), with appendix restatement
+    % and the same-CF BNT uniqueness note.
+    In a prepared family of positive-bond-dimension trace-preserving primitive
+    irreducible blocks, every block in an MPV phase class has the bond dimension
+    of its representative.
+\end{lemma}
+
+\begin{proof}\leanok\uses{lem:prepared_phase_equiv_dim_eq}
+    Apply Lemma~\ref{lem:prepared_phase_equiv_dim_eq} to each representative and
+    each member of its phase class.
+\end{proof}
+
+\begin{lemma}[Prepared collapsed BNT total dimension]%
+    \label{lem:prepared_collapsed_bnt_sector_decomp_total_dim}
+    \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr}
+    \leanok
+    % Source: canonical-form eq:II_CF1 (Cirac2017MPDO_AnnPhys) and the
+    % phase-class quotient prop:char-BNT with its appendix restatement.
+    For prepared trace-preserving primitive irreducible blocks of positive bond
+    dimension with all copy weights nonzero, the phase-class quotient preserves
+    the total bond dimension: the collapsed sector decomposition has total bond
+    dimension equal to the sum of the original block dimensions.
+\end{lemma}
+
+\begin{proof}\leanok\uses{lem:collapsed_bnt_sector_decomp_total_dim,
+        lem:prepared_phase_class_dim_eq}
+    Lemma~\ref{lem:prepared_phase_class_dim_eq} supplies the same-dimension
+    hypothesis in Lemma~\ref{lem:collapsed_bnt_sector_decomp_total_dim}.
+\end{proof}
+
+\begin{theorem}[Conditional BNT form after blocking for an arbitrary tensor]%
+    \label{thm:paperbnt_supplier_after_blocking}
+    \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos}
+    \leanok
+    \uses{thm:prepared_bnt_blocks_after_blocking,
+        thm:paperbnt_supplier_prepared}
+    Let $A$ be an MPS tensor. Then there exists a blocking length $p \ge 1$,
+    nonzero weights $\mu_k$, and blocks $B_k$ over the blocked alphabet, such
+    that:
+    \begin{enumerate}
+        \item every block has positive bond dimension;
+        \item every block is TP-normalized, primitive, irreducible, and
+              injective;
+        \item $A^{[p]}$ and $\bigoplus_k \mu_k B_k$ generate the same MPV family
+              at every positive length.
+    \end{enumerate}
+    Moreover, under $|\mu_k| \le 1$ for every $k$ and $|\mu_k|=1$ for at least
+    one $k$, there exists a sector decomposition $P$ over the blocked alphabet in
+    the strengthened BNT canonical form of Definition~\ref{def:sector_bnt_cf}
+    such that
+    $A^{[p]}$ and $P$ generate the same MPV family at every positive length.
+\end{theorem}
+
+\begin{proof}\leanok
+    The after-blocking reduction supplies the TP-normalized primitive irreducible
+    injective blocks and the positive-length MPV identity. The normalized-weight
+    hypotheses are the choice that
+    \cite[Section~II.C]{Cirac2017MPDO_AnnPhys} makes;
+    Theorem~\ref{thm:paperbnt_supplier_prepared} then produces the sector
+    decomposition, following the BNT selection of
+    \cite[Appendix~A]{Cirac2017MPDO_AnnPhys}. The missing rescaling step is
+    recorded in Remark~\ref{rem:arbitrary_input_reduction_gap}.
+\end{proof}
+
+\begin{theorem}[Conditional BNT form after blocking, completed at length zero]%
+    \label{thm:paperbnt_supplier_after_blocking_total_dim}
+    \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_of_totalDim}
+    \leanok
+    \uses{thm:paperbnt_supplier_after_blocking,
+        def:same_mpv2,
+        def:same_mpv2_pos,
+        lem:samempv2pos_to_samempv2_of_bonddim_eq}
+    In the setting of Theorem~\ref{thm:paperbnt_supplier_after_blocking}, the same
+    prepared blocks may be chosen so that the positive-length MPV identity
+    upgrades to all lengths whenever the total bond dimension of $P$ equals the
+    bond dimension of the blocked input tensor.
+\end{theorem}
+
+\begin{proof}\leanok
+    The positive-length statement is
+    Theorem~\ref{thm:paperbnt_supplier_after_blocking}. At length zero the MPV
+    coefficient is the bond dimension, so equality of the two total bond
+    dimensions supplies the missing length-zero coefficient, and the
+    positive-length identity gives all remaining lengths.
+\end{proof}
+
+\begin{remark}[Arbitrary-input reduction]%
+    \label{rem:arbitrary_input_reduction_gap}
+    Theorem~\ref{thm:paperbnt_supplier_after_blocking} gives the arbitrary-input
+    reduction, conditional on the two weight-normalization hypotheses displayed
+    there. The preparatory part,
+    Theorem~\ref{thm:prepared_bnt_blocks_after_blocking}, produces the
+    TP-normalized primitive irreducible injective blocks and the positive-length
+    MPV identity but not the weight normalization. Since the all-zero summand
+    contributes only at length zero, the nonzero primitive blocks identify the
+    MPV family for $N\ge 1$. The proof that the prepared weights can always be
+    rescaled to satisfy $|\mu_k|\le 1$ with a unit-modulus witness is the one
+    remaining step, recorded in
+    \texttt{docs/paper-gaps/cpsv16\_cf\_normalization\_and\_proportional\_comparison.tex};
+    the length-zero trace identity and the fully unblocked canonical form remain
+    part of the reduction in Chapter~\ref{ch:canonical_after_blocking}.
+\end{remark}
+
 
 \begin{lemma}[Raw two-layer sector coefficient identity]%
     \label{lem:sector_bnt_coeff_eq_sum_weight_pow}


### PR DESCRIPTION
### Motivation

- Blueprint chapters 7–8 (Wielandt and canonical forms) introduced the CPSV basis-of-normal-tensors (BNT) definitions and supplier arguments before Chapter 10 (the dedicated BNT chapter), creating a confusing presentation order. Issue #2207 tracked this structural problem.

### Description

- Moved the CPSV basis-of-normal-tensors definition (`def:bnt_cpsv`) from `blueprint/src/chapter/ch08_canonical.tex` to `blueprint/src/chapter/ch10_bnt.tex`.
- Moved the full prepared-block BNT supplier block (common injective blocking, prepared blocks after blocking, normalized-weight BNT construction, phase-class dimension lemmas, length-zero completion) into the BNT canonical-form section in `ch10_bnt.tex`.
- Retitled and narrowed subsections in `ch08_canonical.tex`: the former "Basis of Normal Tensors" subsection becomes "single-copy sector decompositions"; cross-references to phase-class / equal-modulus work now point to Chapter BNT.
- Updated `ch07_wielandt.tex`: renamed one corollary's family label from "normal-canonical BNT" to "separated normal-canonical".
- Existing `\ref{...}` labels for all moved theorems are unchanged, preserving cross-references from other chapters.

### Testing

- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files blueprint/src/chapter/ch07_wielandt.tex blueprint/src/chapter/ch08_canonical.tex blueprint/src/chapter/ch10_bnt.tex --diff-base origin/main`
- `leanblueprint web` succeeded.
- `lake build TNLean` succeeded.
- `git diff --check` clean.
- `leanblueprint checkdecls` run: remaining failures are pre-existing missing declarations in PEPS and parent-Hamiltonian blueprint entries, not in the moved BNT declarations.

---
Fixes #2207

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX moves and cross-reference edits; Lean labels on moved statements are preserved and validation was run on the touched chapters.
>
> **Overview**
> This PR **reorganizes the blueprint** so BNT-specific definitions and proofs live in Chapter 10 (`ch10_bnt.tex`) instead of being developed in the canonical-form chapter.
>
> **Chapter 10** now opens with the CPSV **basis of normal tensors** (`def:bnt_cpsv`) and adds the full **prepared-block BNT supplier** block (common injective blocking, prepared blocks after blocking, normalized-weight BNT construction, phase-class dimension lemmas, and the arbitrary-input / length-zero completion remarks). Supplier theorems now cite **`def:sector_bnt_cf`** for the strengthened sector predicate.
>
> **Chapter 8** drops that material: the CPSV section is retitled to *normal tensors and canonical forms*, points readers to Chapter BNT for BNT, renames the old "Basis of Normal Tensors" subsection to **single-copy sector decompositions**, and narrows the scope section title. Cross-references to phase-class / equal-modulus work now say **Chapter BNT** rather than duplicating BNT here.
>
> **Chapter 7** only updates wording in one corollary: **"normal-canonical BNT" → "separated normal-canonical"** families and slightly cleaner CPSV scope text—no mathematical relocation.
>
> Existing `\ref{...}` labels for moved theorems are unchanged, so other chapters can still cite `thm:paperbnt_supplier_after_blocking` etc.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34d86e9042cf6e99e6309b1df0828d467c0cfbb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>