### PR TITLE
refactor(MPS/CanonicalForm): inline common-sector weight nonzero

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean
@@ -101,11 +101,6 @@ noncomputable def flatKey (F : CommonBlockedCyclicSectorFamily blocks)
     (x : Fin (∑ k : Fin r, F.period k)) : (k : Fin r) × Fin (F.period k) :=
   finSigmaFinEquiv.symm x
 
-/-- The flattened sectors produced by `CommonBlockedCyclicSectorFamily` carry unit weights. -/
-def flatWeight (F : CommonBlockedCyclicSectorFamily blocks) :
-    Fin (∑ k : Fin r, F.period k) → ℂ :=
-  fun _ => 1
-
 /-- The common-alphabet sector obtained by later reblocking one cyclic sector. -/
 noncomputable def commonSectorBlock (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :
@@ -149,12 +144,6 @@ blocking by the common length. -/
 noncomputable def commonFlatWeight (F : CommonBlockedCyclicSectorFamily blocks)
     (μ : Fin r → ℂ) : Fin (∑ k : Fin r, F.period k) → ℂ :=
   fun x => (μ (F.flatKey x).1) ^ F.p
-
-/-- Flattened sector weights remain nonzero after common blocking. -/
-theorem commonFlatWeight_ne_zero (F : CommonBlockedCyclicSectorFamily blocks)
-    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0)
-    (x : Fin (∑ k : Fin r, F.period k)) : F.commonFlatWeight μ x ≠ 0 :=
-  pow_ne_zero F.p (hμ (F.flatKey x).1)
 
 private theorem commonSectorBlock_structural (F : CommonBlockedCyclicSectorFamily blocks)
     (k : Fin r) (s : Fin (F.period k)) :

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -209,9 +209,9 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
     hFamilyA, hFamilyB, hAPosCanon, hBPosCanon, hBook, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
     ?_, ?_⟩
   · intro x
-    exact familyA.commonFlatWeight_ne_zero μA hμA x
+    exact pow_ne_zero familyA.p (hμA (familyA.flatKey x).1)
   · intro x
-    exact familyB.commonFlatWeight_ne_zero μB hμB x
+    exact pow_ne_zero familyB.p (hμB (familyB.flatKey x).1)
   · intro x
     let y := familyA.flatKey x
     simpa [CommonBlockedCyclicSectorFamily.commonFlatBlocks,

--- a/audits/2026-04-28_issue969_common_blocking.md
+++ b/audits/2026-04-28_issue969_common_blocking.md
@@ -39,8 +39,10 @@ or injectivity/Wielandt blocking length.
   - a flattened finite sector family at physical dimension `blockPhysDim d p`;
   - TP, primitive transfer maps, tensor irreducibility, positive dimensions;
   - the checked per-block iterated-blocking MPV compatibility condition.
-- `MPSTensor.CommonBlockedCyclicSectorFamily.flatWeight` and `.flatWeight_ne_zero`:
-  the flattened common-reblocked sectors carry nonzero unit weights.
+- The predecessor version recorded nonzero unit weights on the flattened
+  common-reblocked sectors. In the current API, the actual powered flattened
+  weights are `MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight`, and
+  nonvanishing is discharged directly from the original nonzero weights.
 - `MPSTensor.exists_commonBlockedCyclicSectorFamily_of_hasPrimitiveIrreducibleCyclicSectors`:
   constructs the one-sided common reblocked family by taking the LCM of the per-block
   periods and applying `tp_primitive_irreducible_extra_blocking` to each cyclic sector.

--- a/audits/2026-04-28_issue969_direct_common_blocking.md
+++ b/audits/2026-04-28_issue969_direct_common_blocking.md
@@ -62,7 +62,8 @@ New derived operations for an existing `F : MPSTensor.CommonBlockedCyclicSectorF
 
 New structural/nonvanishing facts:
 
-- `F.commonBlockWeight_ne_zero` and `F.commonFlatWeight_ne_zero`.
+- Nonvanishing of the common-block and flattened powered weights, discharged from
+  the original nonzero block weights by `pow_ne_zero`.
 - `F.commonSectorBlock_tp`, `F.commonSectorBlock_primitive`,
   `F.commonSectorBlock_irreducible`, `F.commonSectorBlock_dim_pos`.
 - `F.commonFlatBlocks_tp`, `F.commonFlatBlocks_primitive`,
@@ -116,8 +117,8 @@ exact nonzero-part data those theorems will eventually need. The new data provid
 - **Sector families:** `family.commonFlatBlocks` at physical dimension
   `blockPhysDim d family.p`.
 - **Weights:** `family.commonFlatWeight μ`, equal to `(μ k) ^ family.p` on every sector
-  coming from nonzero-weight block `k`; `family.commonFlatWeight_ne_zero` proves nonvanishing from
-  the original nonzero weights.
+  coming from nonzero-weight block `k`; nonvanishing is proved from the original
+  nonzero weights by `pow_ne_zero`.
 - **TP/primitive/irreducible/positive dimension:** the `commonFlatBlocks_*` theorems give
   all four structural properties needed before a later injectivity refinement.
 - **Exact relabeled nonzero decomposition:**

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1039,14 +1039,6 @@ the periodic extension of Chapter~\ref{ch:periodic_ft_apps}.
     tensor irreducibility, and positive bond dimensions.
 \end{lemma}
 
-\begin{lemma}[Nonzero unit weight of the common reblocked family]%
-    \label{thm:common_blocked_cyclic_sector_flat_weight_ne_zero}
-    \lean{MPSTensor.CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero}\leanok
-    \uses{thm:exists_common_blocked_cyclic_sector_family}
-    The unit weight on each sector of the common reblocked cyclic-sector family of
-    Lemma~\ref{thm:exists_common_blocked_cyclic_sector_family} is nonzero.
-\end{lemma}
-
 \begin{lemma}[Sector irreducibility for the adjoint blocked map]%
     \label{thm:sector_irred_unconditional}
     \lean{MPSTensor.isIrreducibleOnCorner_of_cyclic_decomp_mps}\leanok


### PR DESCRIPTION
### Motivation

Progress toward #2194. The common-sector after-blocking route still exposed a one-line public theorem for nonvanishing of the flattened common-sector weights. That fact is just `pow_ne_zero` applied to the original nonzero block weight, so it need not be a separate public Lean and blueprint node.

### Description

- Remove the unused unit-weight `CommonBlockedCyclicSectorFamily.flatWeight` definition.
- Remove `CommonBlockedCyclicSectorFamily.commonFlatWeight_ne_zero` and inline its proof at the two uses in `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂`.
- Remove the corresponding Chapter 8 blueprint lemma.

This keeps `CommonBlockedCyclicSectorFamily.commonFlatWeight` as the single source for the actual flattened weights, with nonvanishing derived locally where the later theorem needs it.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean blueprint/src/chapter/ch08_canonical.tex --diff-base origin/main`
- `python3 scripts/blueprint_bibtex.py`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `git diff --check`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/CanonicalForm/SectorComparison/CommonBlockedCyclicSectorFamily.lean TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean || true`

`leanblueprint checkdecls` was also run after `lake build TNLean`; it still fails only on the pre-existing project-wide PEPS and parent-Hamiltonian declaration backlog, and does not mention the removed common-sector theorem.

The full build reports pre-existing `sorry` warnings in PEPS and periodic-overlap files outside this change.

---
Addresses #2194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no behavioral or security-sensitive changes; callers still get the same nonvanishing facts via direct `pow_ne_zero` applications.
> 
> **Overview**
> This PR **removes thin API surface** around common-sector weights: the unused unit-weight helper `CommonBlockedCyclicSectorFamily.flatWeight`, the public theorem `commonFlatWeight_ne_zero`, and the matching Chapter 8 blueprint lemma.
> 
> **`commonFlatWeight`** stays the definition of flattened sector weights `(μ k)^p`. Where `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` needs nonvanishing, the proof now calls **`pow_ne_zero`** on the original nonzero block weights at the two flattened-index goals—same logic, no separate named lemma.
> 
> Audit notes for issue #969 are updated to say nonvanishing is proved inline from `pow_ne_zero` rather than via removed declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9e1353cd539c86a3e796bcdcdfa5c6f914af10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->