### PR TITLE
refactor(PEPS): separate union contraction maps

### DIFF
--- a/TNLean/PEPS/InjectiveRegionContraction.lean
+++ b/TNLean/PEPS/InjectiveRegionContraction.lean
@@ -26,7 +26,7 @@ $\mathcal C_{\{0,1,2\}}(X)=0 \Rightarrow \mathcal C_{\{2\}}(X)=0
 namespace TNLean
 namespace PEPS
 
-/-- The contraction-chain data used in the proof that $A\cup B$ is injective.
+/-- The three contraction maps used in the proof that $A\cup B$ is injective.
 
 Here `K` is the boundary space for the outside region
 $P_3=(A\cup B)^c$. The three maps are the contractions
@@ -35,7 +35,7 @@ $\mathcal C_{\{1,2\}}$ which occur in the source proof.
 
 Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union, lines
 1324--1404 of `Papers/1804.04964/paper_normal.tex`. -/
-structure InjectiveUnionContractionChain
+structure InjectiveUnionContractionMaps
     (K E012 E2 E12 : Type*) [AddCommGroup K] [Module ℂ K]
     [AddCommGroup E012] [Module ℂ E012] [AddCommGroup E2] [Module ℂ E2]
     [AddCommGroup E12] [Module ℂ E12] where
@@ -45,6 +45,20 @@ structure InjectiveUnionContractionChain
   contraction2 : K →ₗ[ℂ] E2
   /-- The contraction $\mathcal C_{\{1,2\}}$ after reinserting the overlap piece. -/
   contraction12 : K →ₗ[ℂ] E12
+
+/-- The contraction-chain data used in the proof that $A\cup B$ is injective.
+
+This extends `InjectiveUnionContractionMaps` by the three implications obtained
+from the left inverses for the two injective regions and from reinserting the
+overlap tensor.
+
+Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union, lines
+1324--1404 of `Papers/1804.04964/paper_normal.tex`. -/
+structure InjectiveUnionContractionChain
+    (K E012 E2 E12 : Type*) [AddCommGroup K] [Module ℂ K]
+    [AddCommGroup E012] [Module ℂ E012] [AddCommGroup E2] [Module ℂ E2]
+    [AddCommGroup E12] [Module ℂ E12] extends
+    InjectiveUnionContractionMaps K E012 E2 E12 where
   /-- The inverse for $A=P_0\cup P_1$ sends
   $\mathcal C_{\{0,1,2\}}(X)=0$ to $\mathcal C_{\{2\}}(X)=0$. -/
   left_inverse_A_zero : ∀ X : K, contraction012 X = 0 → contraction2 X = 0

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2392,17 +2392,27 @@ injective and normal PEPS, following Theorems~2 and~3 of
     intersection, together with the reconstruction of $A\cup B$.
 \end{proof}
 
+\begin{definition}[Contraction maps for the union injectivity proof]%
+    \label{def:peps_injectiveUnionContractionMaps}
+    \lean{TNLean.PEPS.InjectiveUnionContractionMaps}
+    \leanok
+    Let $K$, $E_{012}$, $E_2$, and $E_{12}$ be complex vector spaces. A
+    contraction-map family for the proof of
+    \cite[Section~3]{Molnar2018NormalPEPS} consists of three linear maps
+    $\mathcal C_{\{0,1,2\}}:K\to E_{012}$,
+    $\mathcal C_{\{2\}}:K\to E_2$, and
+    $\mathcal C_{\{1,2\}}:K\to E_{12}$.
+\end{definition}
+
 \begin{definition}[Contraction chain for the union injectivity proof]%
     \label{def:peps_injectiveUnionContractionChain}
     \lean{TNLean.PEPS.InjectiveUnionContractionChain}
     \leanok
-    Let $K$, $E_{012}$, $E_2$, and $E_{12}$ be complex vector spaces. A
-    contraction chain for the proof of \cite[Section~3]{Molnar2018NormalPEPS}
-    consists of three linear maps
-    $\mathcal C_{\{0,1,2\}}:K\to E_{012}$,
-    $\mathcal C_{\{2\}}:K\to E_2$, and
-    $\mathcal C_{\{1,2\}}:K\to E_{12}$, together with the three implications
-    used in Lemma~\ref{lem:peps_injectiveRegion_union_contractionChain}.
+    \uses{def:peps_injectiveUnionContractionMaps}
+    A contraction chain consists of the three contraction maps of
+    Definition~\ref{def:peps_injectiveUnionContractionMaps}, together with the
+    three implications used in
+    Lemma~\ref{lem:peps_injectiveRegion_union_contractionChain}.
 \end{definition}
 
 \begin{lemma}[Kernel criterion for the union contraction chain]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -296,8 +296,13 @@ The following part of the formalization is already present.
           \(A\setminus B\), \(A\cap B\), \(B\setminus A\), and
           \((A\cup B)^c\), including the reconstruction, disjointness, and
           selected-complement identities used by the two inverse applications.
+    \item The three contraction maps for Lemma \path{injective_union} are
+          separated as
+          \leanid{TNLean.PEPS.InjectiveUnionContractionMaps}.
     \item The abstract contraction-chain criterion for Lemma
-          \path{injective_union} is formalized: if the three implications
+          \path{injective_union} is formalized by
+          \leanid{TNLean.PEPS.InjectiveUnionContractionChain}: if the three
+          implications
           \[
               \mathcal C_{\{0,1,2\}}(X)=0
               \Longrightarrow \mathcal C_{\{2\}}(X)=0


### PR DESCRIPTION
### Motivation
- Advances the formalization of Lemma `injective_union` from MGRPG+18 (arXiv:1804.04964, Section 3; `Papers/1804.04964/paper_normal.tex`, lines 1324–1404), tracked in #1374.
- The source proof distinguishes constructing the three contraction maps $\mathcal{C}_{\{0,1,2\}}$, $\mathcal{C}_{\{2\}}$, $\mathcal{C}_{\{1,2\}}$ from the implication chain proving the kernel criterion; the previous single structure bundled both.

### Description
- `TNLean/PEPS/InjectiveRegionContraction.lean`: introduces `TNLean.PEPS.InjectiveUnionContractionMaps` for the three linear contraction maps; makes `TNLean.PEPS.InjectiveUnionContractionChain` extend that structure with the three zero-propagation implications.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds separate blueprint definitions for the map family and the full chain, with `\uses` linking them.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: records `InjectiveUnionContractionMaps` before the abstract chain criterion.
- Does not construct the maps from blocked PEPS tensors or close #1374; the remaining step is to construct these maps from the PEPS tensors and prove the three implications using left inverses for `A` and `B`.

### Testing
- `lake env lean TNLean/PEPS/InjectiveRegionContraction.lean`
- `lake build TNLean.PEPS.InjectiveRegionContraction`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/PEPS/InjectiveRegionContraction.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_normal_ft_section3_route.tex --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .` — no new oversized file introduced
- `git diff --check`; diff scan for new `sorry`/`admit`/`axiom`/`native_decide`/`unsafeCast` — none introduced
- Pre-existing long `\lean{...}` lines in Chapter 13a are outside this diff; no new overlong line was introduced.

---
Refs #1374

> [!NOTE]
> **Low Risk**
> Documentation and type-structure refactor only; no changes to proof scripts, security, or runtime behavior beyond clearer separation of abstract data.
> 
> **Overview**
> This PR refactors the PEPS **union injectivity** formalization toward issue #1374 by splitting what was one bundled structure into **maps** vs **chain**.
> 
> **Lean:** Introduces `TNLean.PEPS.InjectiveUnionContractionMaps` for the three linear contractions \(\mathcal C_{\{0,1,2\}}\), \(\mathcal C_{\{2\}}\), and \(\mathcal C_{\{1,2\}}\). `InjectiveUnionContractionChain` now **extends** that structure and only adds the three zero-propagation implications; existing kernel/injectivity theorems are unchanged in behavior.
> 
> **Docs:** Chapter 13a gains separate blueprint definitions for the map family and the full chain (with `\uses` linking them). The PEPS normal-route paper-gap note records `InjectiveUnionContractionMaps` separately before the abstract chain criterion.
> 
> This does **not** construct the maps from PEPS tensors or close the union lemma—that remains future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0faf8670b9b7a68157d847beaa6ea3658acb4a7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>