### PR TITLE
feat(PEPS): expose normal blocking consequences

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -680,6 +680,49 @@ structure NormalPEPSBlockingHypotheses (G : SimpleGraph V) where
   /-- Every site admits one-site-different injective comparison regions. -/
   oneSiteSeparation : NormalOneSiteSeparationHypotheses ι
 
+namespace NormalPEPSBlockingHypotheses
+
+variable {ι} {G : SimpleGraph V}
+
+/-- The normal PEPS blocking hypotheses supply the three injective regions
+around every edge.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem injective_chain_at_edge (h : NormalPEPSBlockingHypotheses ι G) (e : Edge G) :
+    ι.IsInjective (h.edgeBlocking.red e) ∧
+      ι.IsInjective (h.edgeBlocking.blue e) ∧
+      ι.IsInjective (h.edgeBlocking.complement e) :=
+  h.edgeBlocking.injective_chain_at_edge e
+
+/-- The normal PEPS blocking hypotheses supply endpoint membership,
+pairwise disjointness, and coverage for the three regions around every edge.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem endpoint_disjoint_cover_at_edge
+    (h : NormalPEPSBlockingHypotheses ι G) (e : Edge G) :
+    e.1.1 ∈ h.edgeBlocking.red e ∧ e.1.2 ∈ h.edgeBlocking.blue e ∧
+      Disjoint (h.edgeBlocking.red e) (h.edgeBlocking.blue e) ∧
+      Disjoint (h.edgeBlocking.red e) (h.edgeBlocking.complement e) ∧
+      Disjoint (h.edgeBlocking.blue e) (h.edgeBlocking.complement e) ∧
+      h.edgeBlocking.red e ∪ h.edgeBlocking.blue e ∪
+          h.edgeBlocking.complement e = Finset.univ :=
+  h.edgeBlocking.endpoint_disjoint_cover_at_edge e
+
+/-- The one-site part of the normal PEPS blocking hypotheses says that the
+region containing a site is obtained from the comparison region by adding
+that site.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem mem_withSite_iff (h : NormalPEPSBlockingHypotheses ι G) (v w : V) :
+    w ∈ h.oneSiteSeparation.withSite v ↔
+      w = v ∨ w ∈ h.oneSiteSeparation.withoutSite v :=
+  h.oneSiteSeparation.mem_withSite_iff v w
+
+end NormalPEPSBlockingHypotheses
+
 end GeneralBlocking
 
 /-- Rectangular injectivity hypotheses for the square-lattice normal PEPS

--- a/TNLean/PEPS/NormalSquarePEPSBlocking.lean
+++ b/TNLean/PEPS/NormalSquarePEPSBlocking.lean
@@ -95,7 +95,7 @@ theorem normalSquarePEPSBlockingHypotheses_oneSiteSeparation_of_marginCovers
   rfl
 
 /-- The square-lattice hypotheses assembled from margin-and-cover assumptions
-supplies the three injective regions around every edge.
+supply the three injective regions around every edge.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
 and theorem labelled `normal`, lines 1576--1583. -/
@@ -116,7 +116,7 @@ theorem normalSquarePEPSBlockingHypotheses_injective_chain_of_marginCovers
     h hUnion data oneSite).injective_chain_at_edge e
 
 /-- The square-lattice hypotheses assembled from margin-and-cover assumptions
-supplies endpoint membership, pairwise disjointness, and coverage around
+supply endpoint membership, pairwise disjointness, and coverage around
 every edge.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
@@ -141,7 +141,7 @@ theorem normalSquarePEPSBlockingHypotheses_endpoint_disjoint_cover_of_marginCove
     h hUnion data oneSite).endpoint_disjoint_cover_at_edge e
 
 /-- The square-lattice hypotheses assembled from margin-and-cover assumptions
-inherits the supplied one-site comparison regions.
+inherit the supplied one-site comparison regions.
 
 Source: arXiv:1804.04964, Section 3, theorem labelled `normal`,
 lines 1576--1583. -/

--- a/TNLean/PEPS/NormalSquarePEPSBlocking.lean
+++ b/TNLean/PEPS/NormalSquarePEPSBlocking.lean
@@ -94,5 +94,71 @@ theorem normalSquarePEPSBlockingHypotheses_oneSiteSeparation_of_marginCovers
       h hUnion data oneSite).oneSiteSeparation = oneSite :=
   rfl
 
+/-- The square-lattice hypotheses assembled from margin-and-cover assumptions
+supplies the three injective regions around every edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
+and theorem labelled `normal`, lines 1576--1583. -/
+theorem normalSquarePEPSBlockingHypotheses_injective_chain_of_marginCovers
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareEdgeMarginCover.{edgeCoverUniverse} e)
+    (oneSite : NormalOneSiteSeparationHypotheses κ)
+    (e : Edge (squareLatticeGraph width height)) :
+    let H := normalSquarePEPSBlockingHypotheses_of_marginCovers h hUnion data oneSite
+    κ.IsInjective (H.edgeBlocking.red e) ∧
+      κ.IsInjective (H.edgeBlocking.blue e) ∧
+      κ.IsInjective (H.edgeBlocking.complement e) :=
+  (normalSquarePEPSBlockingHypotheses_of_marginCovers
+    h hUnion data oneSite).injective_chain_at_edge e
+
+/-- The square-lattice hypotheses assembled from margin-and-cover assumptions
+supplies endpoint membership, pairwise disjointness, and coverage around
+every edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
+and theorem labelled `normal`, lines 1576--1583. -/
+theorem normalSquarePEPSBlockingHypotheses_endpoint_disjoint_cover_of_marginCovers
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareEdgeMarginCover.{edgeCoverUniverse} e)
+    (oneSite : NormalOneSiteSeparationHypotheses κ)
+    (e : Edge (squareLatticeGraph width height)) :
+    let H := normalSquarePEPSBlockingHypotheses_of_marginCovers h hUnion data oneSite
+    e.1.1 ∈ H.edgeBlocking.red e ∧ e.1.2 ∈ H.edgeBlocking.blue e ∧
+      Disjoint (H.edgeBlocking.red e) (H.edgeBlocking.blue e) ∧
+      Disjoint (H.edgeBlocking.red e) (H.edgeBlocking.complement e) ∧
+      Disjoint (H.edgeBlocking.blue e) (H.edgeBlocking.complement e) ∧
+      H.edgeBlocking.red e ∪ H.edgeBlocking.blue e ∪
+          H.edgeBlocking.complement e = Finset.univ :=
+  (normalSquarePEPSBlockingHypotheses_of_marginCovers
+    h hUnion data oneSite).endpoint_disjoint_cover_at_edge e
+
+/-- The square-lattice hypotheses assembled from margin-and-cover assumptions
+inherits the supplied one-site comparison regions.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`,
+lines 1576--1583. -/
+theorem normalSquarePEPSBlockingHypotheses_mem_withSite_iff_of_marginCovers
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareEdgeMarginCover.{edgeCoverUniverse} e)
+    (oneSite : NormalOneSiteSeparationHypotheses κ)
+    (v w : SquareLatticeVertex width height) :
+    let H := normalSquarePEPSBlockingHypotheses_of_marginCovers h hUnion data oneSite
+    w ∈ H.oneSiteSeparation.withSite v ↔
+      w = v ∨ w ∈ H.oneSiteSeparation.withoutSite v :=
+  (normalSquarePEPSBlockingHypotheses_of_marginCovers
+    h hUnion data oneSite).mem_withSite_iff v w
+
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3505,8 +3505,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The general normal theorem assumes both the edge-centred blockings into
     three injective regions and the one-site comparison regions with injective
     complements.  These two assumptions are collected as the normal PEPS
-    blocking hypotheses, which also expose the corresponding edge and one-site
-    consequences without restating the separate edge and one-site assumptions.
+    blocking hypotheses; the same hypotheses give the corresponding edge and
+    one-site consequences without restating the separate edge and one-site
+    assumptions.
     \begin{center}
         \TNPEPSNormalBlockingHypotheses
     \end{center}
@@ -3536,8 +3537,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     one-edge datum at an edge is the datum supplied there, and the one-site
     separation is exactly the supplied one-site separation.  Hence these hypotheses
     give the three injective regions, the endpoint-disjoint-cover facts at
-    each edge, and the one-site membership formula through the general normal
-    blocking structure.
+    each edge, and the one-site membership formula as consequences of the same
+    normal blocking hypotheses.
 \end{theorem}
 \begin{proof}\leanok
     Combine the edge-blocking hypotheses constructed from the margin-cover

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3495,13 +3495,18 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{definition}[Normal PEPS blocking hypotheses]%
     \label{def:peps_normalPEPSBlockingHypotheses}
     \lean{TNLean.PEPS.NormalPEPSBlockingHypotheses}
+    \lean{TNLean.PEPS.NormalPEPSBlockingHypotheses.injective_chain_at_edge}
+    \lean{TNLean.PEPS.%
+        NormalPEPSBlockingHypotheses.endpoint_disjoint_cover_at_edge}
+    \lean{TNLean.PEPS.NormalPEPSBlockingHypotheses.mem_withSite_iff}
     \leanok
     \uses{def:peps_normalEdgeBlockingHypotheses,
         def:peps_normalOneSiteSeparationHypotheses}
     The general normal theorem assumes both the edge-centred blockings into
     three injective regions and the one-site comparison regions with injective
     complements.  These two assumptions are collected as the normal PEPS
-    blocking hypotheses.
+    blocking hypotheses, which also expose the corresponding edge and one-site
+    consequences without restating the separate edge and one-site assumptions.
     \begin{center}
         \TNPEPSNormalBlockingHypotheses
     \end{center}
@@ -3514,6 +3519,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.normalSquarePEPSBlockingHypotheses_blockingData_of_marginCovers}
     \lean{TNLean.PEPS.%
         normalSquarePEPSBlockingHypotheses_oneSiteSeparation_of_marginCovers}
+    \lean{TNLean.PEPS.%
+        normalSquarePEPSBlockingHypotheses_injective_chain_of_marginCovers}
+    \lean{TNLean.PEPS.%
+        normalSquarePEPSBlockingHypotheses_endpoint_disjoint_cover_of_marginCovers}
+    \lean{TNLean.PEPS.%
+        normalSquarePEPSBlockingHypotheses_mem_withSite_iff_of_marginCovers}
     \leanok
     \uses{thm:peps_normalSquareTranslatedEdgeBlockingHypotheses_of_windows,
         def:peps_normalPEPSBlockingHypotheses,
@@ -3523,7 +3534,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     square lattice satisfies the general normal blocking hypotheses.  The
     edge-blocking hypotheses are exactly the margin-cover construction, the
     one-edge datum at an edge is the datum supplied there, and the one-site
-    separation is exactly the supplied one-site separation.
+    separation is exactly the supplied one-site separation.  Hence these hypotheses
+    give the three injective regions, the endpoint-disjoint-cover facts at
+    each edge, and the one-site membership formula through the general normal
+    blocking structure.
 \end{theorem}
 \begin{proof}\leanok
     Combine the edge-blocking hypotheses constructed from the margin-cover

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -324,10 +324,10 @@ The following part of the formalization is already present.
     \item The one-edge, translated-window, and margin-cover hypotheses
           for normal edge blocking are present, together with their endpoint,
           disjointness, coverage, and injective-chain consequences.
-    \item The general normal PEPS blocking structure
-          \leanid{TNLean.PEPS.NormalPEPSBlockingHypotheses} now exposes its
+    \item The general normal PEPS blocking hypotheses
+          \leanid{TNLean.PEPS.NormalPEPSBlockingHypotheses} now provide their
           edge and one-site consequences directly, so downstream square-lattice
-          arguments can use this structure rather than restating the
+          arguments can use these hypotheses rather than restating the
           edge-blocking and one-site hypotheses separately.
 \end{itemize}
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -324,6 +324,11 @@ The following part of the formalization is already present.
     \item The one-edge, translated-window, and margin-cover hypotheses
           for normal edge blocking are present, together with their endpoint,
           disjointness, coverage, and injective-chain consequences.
+    \item The general normal PEPS blocking structure
+          \leanid{TNLean.PEPS.NormalPEPSBlockingHypotheses} now exposes its
+          edge and one-site consequences directly, so downstream square-lattice
+          arguments can use this structure rather than restating the
+          edge-blocking and one-site hypotheses separately.
 \end{itemize}
 
 The remaining obligations are the following.


### PR DESCRIPTION
### Motivation

- Centralizes the consequences of `NormalPEPSBlockingHypotheses` so downstream work can cite the combined normal blocking API rather than restating separate edge-blocking and one-site hypotheses independently.
- Continues the formalization of MGRPG+18 (arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475–1500; and the theorem labelled `normal`, lines 1576–1583); documented in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
- Addresses a source-of-truth gap in the normal PEPS route; see #2004.

### Description

- `TNLean/PEPS/NormalBlocking.lean`: adds thin forwarding lemmas on `NormalPEPSBlockingHypotheses` exposing (i) the three injective regions around each edge, (ii) endpoint membership, disjointness, and coverage facts per edge, and (iii) the one-site membership formula for the comparison regions.
- `TNLean/PEPS/NormalSquarePEPSBlocking.lean`: the square-lattice construction `normalSquarePEPSBlockingHypotheses_of_marginCovers` now recovers these same consequences through the general normal blocking structure instead of restating edge-blocking and one-site hypotheses separately.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: blueprint entries updated to reflect the combined normal blocking API.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: gap note updated to reflect remaining open obligations (tensor-level union theorem, source-faithful local and rotated T-injectivity, every-edge finite geometry).
- Does not close #2004: the tensor-level union theorem, source-faithful T-injectivity argument, and every-edge finite geometry remain open.

### Testing

- `lake build TNLean.PEPS.NormalSquarePEPSBlocking`
- `lake env lean TNLean/PEPS/NormalBlocking.lean`
- `lake env lean TNLean/PEPS/NormalSquarePEPSBlocking.lean`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/PEPS/NormalBlocking.lean TNLean/PEPS/NormalSquarePEPSBlocking.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_normal_ft_section3_route.tex --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- Changed-line proof-integrity scan: no new `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in changed files.
- Full build reports only pre-existing `sorry` warnings in unrelated files.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #2004

> [!NOTE]
> **Low Risk**
> Documentation and thin `rfl`-style lemma forwarding only; no auth, runtime, or substantive proof changes.
> 
> **Overview**
> Exposes **edge** and **one-site** consequences on `NormalPEPSBlockingHypotheses` (three-region injectivity, endpoint/disjoint/cover at each edge, `mem_withSite_iff`) as thin forwards to the existing edge-blocking and one-site structures, and adds matching square-lattice theorems off `normalSquarePEPSBlockingHypotheses_of_marginCovers`.
> 
> Blueprint (`ch13a_peps_ft.tex`) and the Section 3 route gap doc are updated so downstream work can cite the combined normal blocking API instead of restating separate hypotheses. No change to proof obligations for the open normal PEPS route items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00dd1eafa2db6eee3366e71edfea1a706fdf8c46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin lemma forwarding and documentation only; no new proofs, axioms, or runtime behavior.
> 
> **Overview**
> Adds a **combined normal blocking API**: `NormalPEPSBlockingHypotheses` now exposes edge injectivity/disjoint-cover facts and the one-site `mem_withSite_iff` as thin forwards to the existing `edgeBlocking` and `oneSiteSeparation` fields, and `normalSquarePEPSBlockingHypotheses_of_marginCovers` gets matching square-lattice theorems that call those forwards.
> 
> Blueprint (`ch13a_peps_ft.tex`) and the Section 3 route gap doc are updated so downstream formalization can cite `NormalPEPSBlockingHypotheses` directly instead of restating separate edge-blocking and one-site hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 493784966c82c48184b824a07fc9e162535fe83b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->