### PR TITLE
feat(MPS/MPDO): expose eta-local RFP consequences

### DIFF
--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -324,7 +324,7 @@ theorem isRFP (data : SimpleMPDOBlockedRFPData K) : IsRFP K :=
   data.zcl
 
 /-- The structure implies the transfer-map fusion formulation of MPDO RFP. -/
-theorem isRFPViaFusion (data : SimpleMPDOBlockedRFPData K) : IsRFP_MPDO_via_fusion K :=
+theorem isRFP_via_fusion (data : SimpleMPDOBlockedRFPData K) : IsRFP_MPDO_via_fusion K :=
   isRFP_MPDO_via_fusion_of_isRFP (M := K) data.isRFP
 
 end SimpleMPDOBlockedRFPData
@@ -349,6 +349,41 @@ theorem structural_implies_rfp_blocked_of_data {K : MPOTensor d D}
     Nonempty (FusionIsometryData K 2) :=
   structural_implies_rfp_blocked (K := K) data.zcl
 
+namespace EtaLocalStructureData
+
+variable {K : MPOTensor d D}
+
+/-- An η-local structure, together with ZCL, gives the blocked
+fusion-isometry witness at size `2`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593,
+followed by the ZCL/RFP implication in Theorem 4.9. -/
+theorem fusion_isometry_data_two (_data : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    Nonempty (FusionIsometryData K 2) :=
+  structural_implies_rfp_blocked (K := K) hZCL
+
+/-- An η-local structure, together with ZCL, gives the transfer-map
+fusion formulation of MPDO RFP.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593,
+followed by the ZCL/RFP implication in Theorem 4.9. -/
+theorem isRFP_via_fusion (_data : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    IsRFP_MPDO_via_fusion K :=
+  isRFP_MPDO_via_fusion_of_isRFP (M := K) (show IsRFP K from hZCL)
+
+/-- The complete RFP chain carried by an η-local structure and ZCL.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
+the η-local nearest-neighbor product gives the commuting-form side; adding ZCL
+gives the GSNNCH--ZCL and RFP consequences of Theorem 4.9. -/
+theorem simple_mpdo_rfp_chain (data : EtaLocalStructureData K) (hZCL : IsZCL K) :
+    IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
+      IsRFP_MPDO_via_fusion K :=
+  ⟨data.isGSNNCHWithZCL hZCL, data.fusion_isometry_data_two hZCL,
+    data.isRFP_via_fusion hZCL⟩
+
+end EtaLocalStructureData
+
 /-- **Theorem 4.9 conclusion, hypothesis-parameterized form**.
 
 From the explicit simple-MPDO hypotheses one simultaneously recovers:
@@ -365,7 +400,7 @@ theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
       IsRFP_MPDO_via_fusion K := by
   refine ⟨data.isGSNNCHWithZCL, structural_implies_rfp_blocked_of_data data,
-    data.isRFPViaFusion⟩
+    data.isRFP_via_fusion⟩
 
 /-- Direct-argument form of Theorem 4.9 using only the hypotheses that enter the
 current theorem. -/
@@ -388,7 +423,7 @@ theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
     (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
       IsRFP_MPDO_via_fusion K :=
-  simple_mpdo_rfp_chain hEta.hasCommutingForm hZCL
+  hEta.simple_mpdo_rfp_chain hZCL
 
 /-- The simple-MPDO RFP chain from local SAL--ZCL hypotheses once the eta-local
 nearest-neighbor product has been assembled.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2715,12 +2715,31 @@ the elementary trace-power identity for diagonal matrices.
     blocked-RFP data.
 \end{proof}
 
+\begin{lemma}[Blocked-RFP data give the fusion formulation]
+    \label{lem:simple_mpdo_blocked_rfp_data_rfp_via_fusion}
+    \lean{MPOTensor.SimpleMPDOBlockedRFPData.isRFP_via_fusion}
+    \leanok
+    \uses{def:simple_mpdo_blocked_rfp_data, def:mpdo_rfp_via_fusion}
+    Given the blocked-RFP data for an MPO tensor $K$, one obtains the
+    transfer-map fusion formulation of MPDO RFP.
+\end{lemma}
+
+\begin{proof}\leanok
+    The implication used here is
+    \[
+        \operatorname{ZCL}(K)
+        \Longrightarrow \operatorname{RFP}(K)
+        \Longrightarrow \operatorname{RFP}_{\mathrm{fusion}}(K).
+    \]
+\end{proof}
+
 \begin{theorem}[Simple-MPDO RFP chain from blocked-RFP data]
     \label{thm:simple_mpdo_rfp_chain_of_data}
     \lean{MPOTensor.simple_mpdo_rfp_chain_of_data}
     \leanok
     \uses{def:simple_mpdo_blocked_rfp_data,
-        thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion}
+        thm:structural_implies_rfp_blocked,
+        lem:simple_mpdo_blocked_rfp_data_rfp_via_fusion}
     Given the blocked-RFP data for an MPO tensor $K$, one obtains the
     GSNNCH-with-ZCL case, the blocked fusion-isometry witness at size $2$, and
     the transfer-map fusion formulation of MPDO RFP.
@@ -2732,13 +2751,55 @@ the elementary trace-power identity for diagonal matrices.
     fusion-isometry witness and the transfer-map fusion formulation.
 \end{proof}
 
+\begin{lemma}[Size-$2$ fusion witness from $\eta$-local structure]
+    \label{lem:eta_local_structure_fusion_isometry_two}
+    \lean{MPOTensor.EtaLocalStructureData.fusion_isometry_data_two}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data, def:mpo_is_zcl,
+        thm:structural_implies_rfp_blocked}
+    If the $\eta$-local structure has been constructed for an MPO tensor $K$,
+    then zero correlation length gives the blocked fusion-isometry witness at
+    size $2$.
+\end{lemma}
+
+\begin{proof}\leanok
+    The implication used here is
+    \[
+        \operatorname{ZCL}(K)
+        \Longrightarrow \operatorname{RFP}(K)
+        \Longrightarrow \operatorname{FusionWitness}_{2}(K).
+    \]
+\end{proof}
+
+\begin{lemma}[Fusion formulation from $\eta$-local structure]
+    \label{lem:eta_local_structure_rfp_via_fusion}
+    \lean{MPOTensor.EtaLocalStructureData.isRFP_via_fusion}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data, def:mpo_is_zcl,
+        def:mpdo_rfp_via_fusion}
+    If the $\eta$-local structure has been constructed for an MPO tensor $K$,
+    then zero correlation length gives the transfer-map fusion formulation of
+    MPDO RFP.
+\end{lemma}
+
+\begin{proof}\leanok
+    This is the implication
+    \[
+        \operatorname{ZCL}(K)
+        \Longrightarrow \operatorname{RFP}(K)
+        \Longrightarrow \operatorname{RFP}_{\mathrm{fusion}}(K).
+    \]
+\end{proof}
+
 \begin{theorem}[Simple-MPDO RFP chain from $\eta$-local structure]
     \label{thm:simple_mpdo_rfp_chain_of_eta_local_structure}
+    \lean{MPOTensor.EtaLocalStructureData.simple_mpdo_rfp_chain}
     \lean{MPOTensor.simple_mpdo_rfp_chain_of_etaLocalStructure}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpo_is_zcl,
         thm:mpdo_eta_local_structure_is_gsnnch_zcl,
-        thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion}
+        lem:eta_local_structure_fusion_isometry_two,
+        lem:eta_local_structure_rfp_via_fusion}
     If the $\eta$-local structure has been constructed for an
     MPO tensor $K$, then zero correlation length gives the GSNNCH-with-ZCL
     case, the blocked fusion-isometry witness at size $2$, and the
@@ -2746,10 +2807,17 @@ the elementary trace-power identity for diagonal matrices.
 \end{theorem}
 
 \begin{proof}\leanok
-    The $\eta$-local structure supplies the commuting-form property. Combining
-    this with zero correlation length gives the GSNNCH-with-ZCL case; zero
-    correlation length also gives the blocked fusion-isometry witness and the
-    transfer-map fusion formulation.
+    The $\eta$-local structure supplies the commuting nearest-neighbor product
+    form.  The remaining two implications are
+    \[
+        \operatorname{ZCL}(K) \Longrightarrow
+        \operatorname{RFP}(K) \Longrightarrow
+        \operatorname{RFP}_{\mathrm{fusion}}(K)
+        \quad\text{and}\quad
+        \operatorname{ZCL}(K) \Longrightarrow
+        \operatorname{RFP}(K) \Longrightarrow
+        \operatorname{FusionWitness}_{2}(K).
+    \]
 \end{proof}
 
 \begin{theorem}[Simple-MPDO RFP chain from SAL--ZCL and $\eta$-local structure]

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -56,7 +56,9 @@ $K$.\footnote{The formal structure is
 \leanid{MPOTensor.EtaLocalStructureData}.} It contains the assembled positive
 translation-invariant two-site bond and its realization of the finite-chain
 MPO. From this structure, the development proves the commuting-form property
-and the GSNNCH--ZCL consequences.
+and the GSNNCH--ZCL consequences.  After ZCL is assumed, ZCL itself gives the
+size-$2$ fusion witness and the transfer-map fusion formulation of the MPDO
+RFP condition.
 
 The two scope-restricted declarations are assembly
 statements.\footnote{These declarations are


### PR DESCRIPTION
### Motivation

- The MPDO RFP consequences following an eta-local structure were previously routed through `HasCommutingForm` plus ZCL, with no single named source on `EtaLocalStructureData`.
- This PR names the immediate eta-local consequences used in the CPGSV17a comparison.
- Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593, together with the ZCL/RFP implication in Theorem 4.9.

### Description

- `TNLean/MPS/MPDO/BlockedRFPConstruction.lean` adds `MPOTensor.EtaLocalStructureData` consequences for the size-2 fusion-isometry witness `fusion_isometry_data_two`, the transfer-map fusion formulation `isRFP_via_fusion`, and the combined GSNNCH--ZCL/RFP chain.
- `MPOTensor.SimpleMPDOBlockedRFPData.isRFP_via_fusion` is the corresponding single source for the blocked-RFP-data fusion formulation.
- `simple_mpdo_rfp_chain_of_etaLocalStructure` now calls the eta-local chain directly.
- `blueprint/src/chapter/ch02b_mpdo.tex` gives the partial consequences their own blueprint lemmas and keeps the full theorem attached only to full-conjunction Lean declarations.
- `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` records that eta-local structure plus ZCL now supplies these RFP/fusion consequences.
- This is a narrow eta-local-to-RFP step; it does not close the broader SAL-to-eta-local construction in #823.

Refs #823.

### Testing

- `lake env lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean`
- `lake build TNLean.MPS.MPDO.BlockedRFPConstruction`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/MPDO/BlockedRFPConstruction.lean blueprint/src/chapter/ch02b_mpdo.tex docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- diff scan for newly added `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`
- `leanblueprint web`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` from `docs/paper-gaps/`

`leanblueprint checkdecls` was attempted. It first required regenerating the ignored `blueprint/lean_decls` file; after regeneration the project-wide sync report still contains pre-existing missing declarations in other blueprint chapters. The changed-file sync check above passes for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin Lean wrappers and doc/blueprint sync over existing ZCL→RFP implications; no change to core proof obligations or security-sensitive code.
> 
> **Overview**
> This PR **names and centralizes** the simple-MPDO RFP consequences that follow once **η-local structure** is in hand and **ZCL** is assumed, instead of routing them only through `HasCommutingForm` plus ZCL.
> 
> In **`BlockedRFPConstruction.lean`**, `SimpleMPDOBlockedRFPData.isRFPViaFusion` is renamed to **`isRFP_via_fusion`**. A new **`EtaLocalStructureData`** namespace adds **`fusion_isometry_data_two`**, **`isRFP_via_fusion`**, and **`simple_mpdo_rfp_chain`** (GSNNCH–ZCL, size-2 fusion witness, fusion RFP), each delegating to the existing ZCL→RFP blocked chain. **`simple_mpdo_rfp_chain_of_etaLocalStructure`** now calls **`hEta.simple_mpdo_rfp_chain`** directly.
> 
> The **blueprint** (`ch02b_mpdo.tex`) splits out lemmas for the blocked-RFP fusion step and the η-local size-2 / fusion-formulation steps, and wires the full η-local theorem through those partial Lean names. The **paper-gaps** note records that η-local structure plus ZCL now explicitly supplies the fusion/RFP consequences (still not closing SAL→η-local construction in #823).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d4863b16c422ec78ca11d0c25fc6a8cd7752ef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->