### PR TITLE
feat(PEPS): add vertical edge-complement rectangular cover

### DIFF
--- a/TNLean/PEPS/NormalEdgeComplementCover.lean
+++ b/TNLean/PEPS/NormalEdgeComplementCover.lean
@@ -525,6 +525,67 @@ theorem normalSquareVerticalEdgeComplement_eq_verticalT_union_rightCollar :
     mem_normalSquareVerticalRegionT, mem_normalSquareVerticalRegionTHole,
     mem_squareLatticeContiguousRectangle]
   omega
+
+/-- A rectangular cover of the rotated local \(T\)-region extends to a
+rectangular cover of the normalized vertical-edge complementary block by adding
+the two right-collar \(2\times3\) rectangles.
+
+**Scope restriction (T-cover):** This construction remains conditional on a
+rectangular cover of the rotated local \(T\)-region. The source comparison, the
+exact-cover obstruction, and the elimination plan are recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
+
+This is the rotated counterpart of
+`normalSquareEdgeComplementRectangleCoverOfT`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500
+of `Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def normalSquareVerticalEdgeComplementRectangleCoverOfVerticalT
+    (cover : NormalSquareVerticalRegionTRectangleCover (width := 7) (height := 5) 0 0) :
+    NormalSquareVerticalEdgeComplementRectangleCover (width := 7) (height := 5) 0 0 where
+  Index := Sum {i // i ∈ cover.regions} (Fin 2)
+  regions := Finset.univ
+  nonempty := Finset.univ_nonempty
+  region
+    | Sum.inl i => cover.region i.1
+    | Sum.inr 0 => squareLatticeContiguousRectangle 5 0 2 3
+    | Sum.inr 1 => squareLatticeContiguousRectangle 5 2 2 3
+  rectangular := by
+    intro i _
+    rcases i with i | j
+    · exact cover.rectangular i.1 i.2
+    · fin_cases j
+      · exact Or.inl ⟨5, 0, by omega, by omega, rfl⟩
+      · exact Or.inl ⟨5, 2, by omega, by omega, rfl⟩
+  cover := by
+    rw [normalSquareVerticalEdgeComplement_eq_verticalT_union_rightCollar]
+    ext v
+    have hT :
+        (∃ a ∈ cover.regions, v ∈ cover.region a) ↔
+          v ∈ (normalSquareVerticalRegionT (width := 7) (height := 5) 0 0) := by
+      constructor
+      · intro hv
+        rw [← cover.cover]
+        exact Finset.mem_biUnion.mpr hv
+      · intro hv
+        have hvCover : v ∈ cover.regions.biUnion cover.region := by
+          rw [cover.cover]
+          exact hv
+        exact Finset.mem_biUnion.mp hvCover
+    simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, Finset.mem_union]
+    constructor
+    · rintro ⟨i | j, hv⟩
+      · exact Or.inl (Or.inl (hT.mp ⟨i.1, i.2, hv⟩))
+      · fin_cases j
+        · exact Or.inl (Or.inr hv)
+        · exact Or.inr hv
+    · rintro ((hvT | hvRightLower) | hvRightUpper)
+      · rcases hT.mpr hvT with ⟨i, hi, hvi⟩
+        exact ⟨Sum.inl ⟨i, hi⟩, hvi⟩
+      · exact ⟨Sum.inr 0, hvRightLower⟩
+      · exact ⟨Sum.inr 1, hvRightUpper⟩
+
 namespace NormalSquareLatticeRectangleInjectivityHypotheses
 
 variable {width height : ℕ}
@@ -606,6 +667,22 @@ theorem edgeComplement_injective
     (cover : NormalSquareEdgeComplementRectangleCover (width := width) (height := height)
       xStart yStart) :
     κ.IsInjective (normalSquareEdgeComplementRegion xStart yStart) :=
+  h.injective_of_rectangleCover hUnion cover
+
+/-- The vertical finite-lattice edge-complementary block is injective once it
+is covered by source-paper \(2\times3\) and \(3\times2\) rectangles.
+
+This is the rotated counterpart of `edgeComplement_injective`.
+
+Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union and proof of
+Theorem 3, lines 1322--1500 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem verticalEdgeComplement_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart : ℕ}
+    (cover : NormalSquareVerticalEdgeComplementRectangleCover
+      (width := width) (height := height) xStart yStart) :
+    κ.IsInjective (normalSquareVerticalEdgeComplementRegion xStart yStart) :=
   h.injective_of_rectangleCover hUnion cover
 
 /-- In the normalized horizontal-edge \(5\times7\) frame, a rectangular cover
@@ -700,7 +777,8 @@ theorem verticalComp_inj_of_cover
       (width := 7) (height := 5) 0 0) :
     κ.IsInjective
       (normalSquareVerticalEdgeComplementRegion (width := 7) (height := 5) 0 0) :=
-  h.verticalComp_injective hUnion (h.verticalT_inj_of_cover hUnion cover)
+  h.verticalEdgeComplement_injective hUnion
+    (normalSquareVerticalEdgeComplementRectangleCoverOfVerticalT cover)
 
 end NormalSquareLatticeRectangleInjectivityHypotheses
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2971,6 +2971,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \label{lem:peps_normalSquareEdgeComplementRegion_injective_of_cover}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.edgeComplement_injective}
     \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.%
+        verticalEdgeComplement_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.%
         edgeComplement_injective_of_T_cover}
     \leanok
     \uses{def:peps_normalSquareRectangleCover,
@@ -2984,6 +2986,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     injective.  In the normalized horizontal-edge $5\times7$ frame, it is
     enough to give such a cover of the local $T$-region, since adjoining the
     two top-collar $3\times2$ rectangles gives a cover of $A_3$.
+    The vertical counterpart uses the same cover criterion for the rotated
+    complementary block.
 \end{lemma}
 % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok
@@ -2996,18 +3000,22 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{lemma}[A cover of $T$ extends to a cover of the edge complement]%
     \label{lem:peps_normalSquareEdgeComplementRegion_coverOfT}
     \lean{TNLean.PEPS.normalSquareEdgeComplementRectangleCoverOfT}
+    \lean{TNLean.PEPS.normalSquareVerticalEdgeComplementRectangleCoverOfVerticalT}
     \leanok
     \uses{def:peps_normalSquareRectangleCover,
         lem:peps_normalSquareEdgeComplementRegion_topCollar}
     In the normalized horizontal-edge $5\times7$ frame, any rectangular cover
     of the local $T$-region extends to a rectangular cover of the
     edge-complementary block $A_3$ by adjoining the two top-collar
-    contiguous $3\times2$ rectangles.
+    contiguous $3\times2$ rectangles.  In the normalized vertical-edge
+    $7\times5$ frame, any rectangular cover of the rotated local $T$-region
+    extends to a rectangular cover of the vertical edge-complementary block by
+    adjoining the two right-collar contiguous $2\times3$ rectangles.
 \end{lemma}
 \begin{proof}\leanok
     Index the new cover by the old cover indices together with two extra
-    indices for the top-collar rectangles.  The set equality is exactly the
-    top-collar decomposition of the edge-complementary block.
+    indices for the collar rectangles.  The set equality is exactly the
+    collar decomposition of the corresponding edge-complementary block.
 \end{proof}
 
 \begin{lemma}[The normalized edge complements have collars]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2983,11 +2983,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     If the finite-lattice complementary block $A_3$ has a nonempty finite
     cover by contiguous $2\times3$ and $3\times2$ rectangles, then
     rectangular injectivity and finite union closure imply that $A_3$ is
-    injective.  In the normalized horizontal-edge $5\times7$ frame, it is
-    enough to give such a cover of the local $T$-region, since adjoining the
-    two top-collar $3\times2$ rectangles gives a cover of $A_3$.
-    The vertical counterpart uses the same cover criterion for the rotated
-    complementary block.
+    injective.  The same criterion applies to every vertical edge-complementary
+    block: a nonempty finite cover of that block by contiguous $2\times3$ and
+    $3\times2$ rectangles implies injectivity of the vertical
+    edge-complementary block.  In the normalized horizontal-edge $5\times7$
+    frame, it is enough to give such a cover of the local $T$-region, since
+    adjoining the two top-collar $3\times2$ rectangles gives a cover of $A_3$.
 \end{lemma}
 % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok
@@ -3004,18 +3005,30 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_normalSquareRectangleCover,
         lem:peps_normalSquareEdgeComplementRegion_topCollar}
-    In the normalized horizontal-edge $5\times7$ frame, any rectangular cover
-    of the local $T$-region extends to a rectangular cover of the
-    edge-complementary block $A_3$ by adjoining the two top-collar
-    contiguous $3\times2$ rectangles.  In the normalized vertical-edge
-    $7\times5$ frame, any rectangular cover of the rotated local $T$-region
-    extends to a rectangular cover of the vertical edge-complementary block by
-    adjoining the two right-collar contiguous $2\times3$ rectangles.
+    In the normalized horizontal-edge $5\times7$ frame with lower-left corner
+    $(0,0)$, any rectangular cover of the local $T$-region extends to a
+    rectangular cover of the edge-complementary block $A_3$ by adjoining the
+    two top-collar contiguous $3\times2$ rectangles.  In the normalized
+    vertical-edge $7\times5$ frame with lower-left corner $(0,0)$, any
+    rectangular cover of the rotated local $T$-region extends to a rectangular
+    cover of the vertical edge-complementary block by adjoining the two
+    right-collar contiguous $2\times3$ rectangles.
 \end{lemma}
 \begin{proof}\leanok
     Index the new cover by the old cover indices together with two extra
-    indices for the collar rectangles.  The set equality is exactly the
-    collar decomposition of the corresponding edge-complementary block.
+    indices for the collar rectangles.  For the horizontal block, the
+    decomposition is
+    \[
+        A_3 =
+        T \cup (\{0,1,2\}\times\{5,6\})
+        \cup (\{2,3,4\}\times\{5,6\}).
+    \]
+    For the vertical block, the decomposition is
+    \[
+        A_3^{\mathrm v} =
+        T^{\mathrm v} \cup (\{5,6\}\times\{0,1,2\})
+        \cup (\{5,6\}\times\{2,3,4\}).
+    \]
 \end{proof}
 
 \begin{lemma}[The normalized edge complements have collars]%


### PR DESCRIPTION
### Motivation

- The normal PEPS square-lattice route (arXiv:1804.04964, Section 3, proof of Theorem 3,
  lines 1430–1500 of `Papers/1804.04964/paper_normal.tex`) requires, for each edge,
  a rectangular cover of the edge-complementary block.
- The horizontal edge direction already has a construction that adjoins top-collar
  $3\times2$ rectangles to a cover of the local $T$-region. The vertical direction
  lacks the corresponding construction.
- This gap blocks the conditional $A_3$ path for vertical edges.

### Description

- `TNLean/PEPS/NormalEdgeComplementCover.lean`: adds a constructor that, given a
  rectangular cover of the rotated local $T$-region in the normalized $7\times5$
  vertical-edge frame, adjoins the two right-collar contiguous $2\times3$ rectangles
  to produce a rectangular cover of the vertical edge-complementary block.
- Exposes a general injectivity criterion for the vertical edge-complementary block
  from such a cover.
- Updates `verticalComp_inj_of_cover` to delegate through the new cover object,
  matching the structure of the horizontal path.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: records the new declarations with
  `\lean{}` tags and states that the vertical $7\times5$ frame uses right-collar
  $2\times3$ rectangles analogously to the top-collar $3\times2$ rectangles of the
  horizontal $5\times7$ frame.
- This construction is conditional on a rectangular cover of the local $T$-region;
  it does not construct that cover and does not resolve the corresponding open
  obligation in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.

### Testing

- `lake exe cache get`
- `lake build TNLean.PEPS.NormalEdgeComplementCover`
- `lake build TNLean.PEPS.NormalEdgeBlockingCoordinate`
- `lake build TNLean.PEPS.NormalEdgeBlockingTranslated`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/PEPS/NormalEdgeComplementCover.lean blueprint/src/chapter/ch13a_peps_ft.tex --diff-base origin/main` (passed)
- `python3 scripts/check_oversized_lean_files.py --root .` (passed)
- `git diff --check` (clean)
- Diff scan for new `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast` (none introduced)
- `cd blueprint && leanblueprint web` (passed)
- `leanblueprint checkdecls` could not run (no `blueprint/lean_decls` file in fresh worktree); changed-declaration blueprint sync check passed.

---
Addresses #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in PEPS geometry; no runtime, security, or data-path changes, and behavior stays conditional on an assumed T-region rectangular cover.
> 
> **Overview**
> Adds the **vertical** analogue of the horizontal “T-cover + collar rectangles → edge-complement cover” step in the normal PEPS square-lattice route.
> 
> In `NormalEdgeComplementCover.lean`, a new constructor takes a rectangular cover of the rotated local **T**-region in the normalized **7×5** frame and adjoins the two **right-collar** contiguous **2×3** pieces to obtain a rectangular cover of the vertical edge-complementary block, using the set identity **T ∪ right collar**. A matching **`verticalEdgeComplement_injective`** lemma states injectivity from any such cover (parallel to the horizontal **A₃** criterion). **`verticalComp_inj_of_cover`** is rewired to build that cover and call the new lemma, aligning the vertical path with **`edgeComplement_injective_of_T_cover`**.
> 
> The blueprint chapter records the new Lean names and states that vertical edge complements follow the same cover→injectivity logic, with **7×5** right-collar **2×3** rectangles playing the role of **5×7** top-collar **3×2** pieces. Construction remains **conditional** on supplying a rectangular **T**-cover; it does not prove that cover exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19950d64462bc3faa81ea7d04b567f0989a5c093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->