### PR TITLE
refactor(PEPS): centralize edge-blocking facts

### DIFF
--- a/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingCoordinate.lean
@@ -131,10 +131,9 @@ theorem normalSquareHorizontalEdge_blockingData
       normalSquareHorizontalEdgeRed ∪ normalSquareHorizontalEdgeBlue ∪
           normalSquareHorizontalEdgeComplement =
         (Finset.univ : Finset (SquareLatticeVertex 5 7)) := by
-  let d := normalSquareHorizontalEdge_blockingDatum h hUnion hT
-  exact ⟨d.left_mem_red, d.right_mem_blue, d.red_injective, d.blue_injective,
-    d.complement_injective, d.red_disjoint_blue, d.red_disjoint_complement,
-    d.blue_disjoint_complement, d.cover_univ⟩
+  simpa [normalSquareHorizontalEdge_blockingDatum, normalSquareHorizontalEdgeRed,
+    normalSquareHorizontalEdgeBlue, normalSquareHorizontalEdgeComplement] using
+    (normalSquareHorizontalEdge_blockingDatum h hUnion hT).endpoint_injective_disjoint_cover
 
 /-- The normalized horizontal edge has red/blue/complement blocking data once
 the local $T$-region has a rectangular cover.
@@ -313,10 +312,9 @@ theorem normalSquareVerticalEdge_blockingData
       normalSquareVerticalEdgeRed ∪ normalSquareVerticalEdgeBlue ∪
           normalSquareVerticalEdgeComplement =
         (Finset.univ : Finset (SquareLatticeVertex 7 5)) := by
-  let d := normalSquareVerticalEdge_blockingDatum h hComplement
-  exact ⟨d.left_mem_red, d.right_mem_blue, d.red_injective, d.blue_injective,
-    d.complement_injective, d.red_disjoint_blue, d.red_disjoint_complement,
-    d.blue_disjoint_complement, d.cover_univ⟩
+  simpa [normalSquareVerticalEdge_blockingDatum, normalSquareVerticalEdgeRed,
+    normalSquareVerticalEdgeBlue, normalSquareVerticalEdgeComplement] using
+    (normalSquareVerticalEdge_blockingDatum h hComplement).endpoint_injective_disjoint_cover
 
 /-- The normalized vertical edge has red/blue/complement blocking data once the
 rotated local $T$-region is injective.

--- a/TNLean/PEPS/NormalEdgeBlockingData.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingData.lean
@@ -77,6 +77,21 @@ theorem endpoint_disjoint_cover {G : SimpleGraph V} {e : Edge G}
   ⟨d.left_mem_red, d.right_mem_blue, d.red_disjoint_blue,
     d.red_disjoint_complement, d.blue_disjoint_complement, d.cover_univ⟩
 
+/-- For one edge, the red, blue, and complementary regions contain the
+corresponding endpoints, are injective, are pairwise disjoint, and cover the
+vertex set.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem endpoint_injective_disjoint_cover {G : SimpleGraph V} {e : Edge G}
+    (d : NormalEdgeBlockingData ι G e) :
+    e.1.1 ∈ d.red ∧ e.1.2 ∈ d.blue ∧
+      ι.IsInjective d.red ∧ ι.IsInjective d.blue ∧ ι.IsInjective d.complement ∧
+      Disjoint d.red d.blue ∧ Disjoint d.red d.complement ∧
+      Disjoint d.blue d.complement ∧ d.red ∪ d.blue ∪ d.complement = Finset.univ :=
+  ⟨d.left_mem_red, d.right_mem_blue, d.red_injective, d.blue_injective,
+    d.complement_injective, d.red_disjoint_blue, d.red_disjoint_complement,
+    d.blue_disjoint_complement, d.cover_univ⟩
+
 end NormalEdgeBlockingData
 
 /-- Edge-centred blocking into three injective regions.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3376,6 +3376,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \label{thm:peps_normalEdgeBlockingHypotheses_injectiveChain}
     \lean{TNLean.PEPS.NormalEdgeBlockingData.injective_chain}
     \lean{TNLean.PEPS.NormalEdgeBlockingData.endpoint_disjoint_cover}
+    \lean{TNLean.PEPS.NormalEdgeBlockingData.endpoint_injective_disjoint_cover}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.ofBlockingData}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.ofBlockingData_blockingData}


### PR DESCRIPTION
## Summary

This PR centralizes the complete one-edge blocking fact package on `NormalEdgeBlockingData`.  The new theorem `NormalEdgeBlockingData.endpoint_injective_disjoint_cover` records, in one place, the endpoint memberships, injectivity of the red/blue/complement regions, pairwise disjointness, and coverage of the vertex set.

The normalized horizontal and vertical coordinate edge-blocking tuple theorems now delegate to this single theorem instead of repackaging the same fields by hand.  The Chapter 13a blueprint records the new theorem at the normal edge-blocking consequences node.

This is a single-source-of-truth cleanup in support of #2004.  It does not close the remaining source-faithful finite-geometry and T-injectivity obligations.

## Source

MGRPG+18, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500.

## Validation

- `lake build TNLean.PEPS.NormalEdgeBlockingCoordinate`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/PEPS/NormalEdgeBlockingData.lean TNLean/PEPS/NormalEdgeBlockingCoordinate.lean blueprint/src/chapter/ch13a_peps_ft.tex --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- diff scan for new `sorry`/`admit`/`axiom`/`native_decide`/`unsafeCast`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor and blueprint sync only; no new axioms or behavior change beyond a single shared lemma for existing tuple theorems.
> 
> **Overview**
> Adds **`NormalEdgeBlockingData.endpoint_injective_disjoint_cover`**, which states in one theorem that the red/blue/complement regions contain the edge endpoints, are **injective**, are **pairwise disjoint**, and **union to the full vertex set**.
> 
> **`normalSquareHorizontalEdge_blockingData`** and **`normalSquareVerticalEdge_blockingData`** no longer reassemble those nine conclusions from the blocking datum by hand; they **`simpa`** through the new theorem on **`endpoint_injective_disjoint_cover`**.
> 
> The Chapter 13a blueprint links the new Lean name at the normal edge-blocking consequences node. No change to the mathematical obligations or proof strength beyond deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74be7d39a97e6783b4df5030041e69b9731e52aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->