### PR TITLE
refactor(PEPS): expose combined normal blocking facts

### DIFF
--- a/TNLean/PEPS/NormalBlocking.lean
+++ b/TNLean/PEPS/NormalBlocking.lean
@@ -710,6 +710,25 @@ theorem endpoint_disjoint_cover_at_edge
           h.edgeBlocking.complement e = Finset.univ :=
   h.edgeBlocking.endpoint_disjoint_cover_at_edge e
 
+/-- The normal PEPS blocking hypotheses supply endpoint membership,
+injectivity, pairwise disjointness, and coverage for the three regions around
+every edge.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem endpoint_injective_disjoint_cover_at_edge
+    (h : NormalPEPSBlockingHypotheses ι G) (e : Edge G) :
+    e.1.1 ∈ h.edgeBlocking.red e ∧ e.1.2 ∈ h.edgeBlocking.blue e ∧
+      ι.IsInjective (h.edgeBlocking.red e) ∧
+      ι.IsInjective (h.edgeBlocking.blue e) ∧
+      ι.IsInjective (h.edgeBlocking.complement e) ∧
+      Disjoint (h.edgeBlocking.red e) (h.edgeBlocking.blue e) ∧
+      Disjoint (h.edgeBlocking.red e) (h.edgeBlocking.complement e) ∧
+      Disjoint (h.edgeBlocking.blue e) (h.edgeBlocking.complement e) ∧
+      h.edgeBlocking.red e ∪ h.edgeBlocking.blue e ∪
+          h.edgeBlocking.complement e = Finset.univ :=
+  h.edgeBlocking.endpoint_injective_disjoint_cover_at_edge e
+
 /-- The one-site part of the normal PEPS blocking hypotheses says that the
 region containing a site is obtained from the comparison region by adding
 that site.

--- a/TNLean/PEPS/NormalEdgeBlockingData.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingData.lean
@@ -205,6 +205,20 @@ theorem endpoint_disjoint_cover_at_edge
       h.red e ∪ h.blue e ∪ h.complement e = Finset.univ :=
   (h.blockingData e).endpoint_disjoint_cover
 
+/-- At every edge, the edge-centred blocking records endpoint membership,
+injectivity of the three regions, pairwise disjointness, and coverage.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem endpoint_injective_disjoint_cover_at_edge
+    (h : NormalEdgeBlockingHypotheses ι G) (e : Edge G) :
+    e.1.1 ∈ h.red e ∧ e.1.2 ∈ h.blue e ∧
+      ι.IsInjective (h.red e) ∧ ι.IsInjective (h.blue e) ∧
+      ι.IsInjective (h.complement e) ∧ Disjoint (h.red e) (h.blue e) ∧
+      Disjoint (h.red e) (h.complement e) ∧
+      Disjoint (h.blue e) (h.complement e) ∧
+      h.red e ∪ h.blue e ∪ h.complement e = Finset.univ :=
+  (h.blockingData e).endpoint_injective_disjoint_cover
+
 end NormalEdgeBlockingHypotheses
 
 end PEPS

--- a/TNLean/PEPS/NormalSquarePEPSBlocking.lean
+++ b/TNLean/PEPS/NormalSquarePEPSBlocking.lean
@@ -141,6 +141,35 @@ theorem normalSquarePEPSBlockingHypotheses_endpoint_disjoint_cover_of_marginCove
     h hUnion data oneSite).endpoint_disjoint_cover_at_edge e
 
 /-- The square-lattice hypotheses assembled from margin-and-cover assumptions
+supply endpoint membership, injectivity, pairwise disjointness, and coverage
+around every edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500,
+and theorem labelled `normal`, lines 1576--1583. -/
+theorem normalSquarePEPSBlockingHypotheses_endpoint_injective_disjoint_cover_of_marginCovers
+    {width height : ℕ} {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareEdgeMarginCover.{edgeCoverUniverse} e)
+    (oneSite : NormalOneSiteSeparationHypotheses κ)
+    (e : Edge (squareLatticeGraph width height)) :
+    let H := normalSquarePEPSBlockingHypotheses_of_marginCovers h hUnion data oneSite
+    e.1.1 ∈ H.edgeBlocking.red e ∧ e.1.2 ∈ H.edgeBlocking.blue e ∧
+      κ.IsInjective (H.edgeBlocking.red e) ∧
+      κ.IsInjective (H.edgeBlocking.blue e) ∧
+      κ.IsInjective (H.edgeBlocking.complement e) ∧
+      Disjoint (H.edgeBlocking.red e) (H.edgeBlocking.blue e) ∧
+      Disjoint (H.edgeBlocking.red e) (H.edgeBlocking.complement e) ∧
+      Disjoint (H.edgeBlocking.blue e) (H.edgeBlocking.complement e) ∧
+      H.edgeBlocking.red e ∪ H.edgeBlocking.blue e ∪
+          H.edgeBlocking.complement e =
+        (Finset.univ : Finset (SquareLatticeVertex width height)) :=
+  (normalSquarePEPSBlockingHypotheses_of_marginCovers
+    h hUnion data oneSite).endpoint_injective_disjoint_cover_at_edge e
+
+/-- The square-lattice hypotheses assembled from margin-and-cover assumptions
 inherit the supplied one-site comparison regions.
 
 Source: arXiv:1804.04964, Section 3, theorem labelled `normal`,

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3382,6 +3382,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.ofBlockingData_blockingData}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.injective_chain_at_edge}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.endpoint_disjoint_cover_at_edge}
+    \lean{TNLean.PEPS.%
+        NormalEdgeBlockingHypotheses.endpoint_injective_disjoint_cover_at_edge}
     \leanok
     \uses{def:peps_normalEdgeBlockingHypotheses}
     A family of one-edge blocking data is precisely the normal edge-blocking
@@ -3520,6 +3522,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.NormalPEPSBlockingHypotheses.injective_chain_at_edge}
     \lean{TNLean.PEPS.%
         NormalPEPSBlockingHypotheses.endpoint_disjoint_cover_at_edge}
+    \lean{TNLean.PEPS.%
+        NormalPEPSBlockingHypotheses.endpoint_injective_disjoint_cover_at_edge}
     \lean{TNLean.PEPS.NormalPEPSBlockingHypotheses.mem_withSite_iff}
     \leanok
     \uses{def:peps_normalEdgeBlockingHypotheses,
@@ -3546,6 +3550,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
         normalSquarePEPSBlockingHypotheses_injective_chain_of_marginCovers}
     \lean{TNLean.PEPS.%
         normalSquarePEPSBlockingHypotheses_endpoint_disjoint_cover_of_marginCovers}
+    \lean{TNLean.PEPS.%
+        normalSquarePEPSBlockingHypotheses_endpoint_injective_disjoint_cover_of_marginCovers}
     \lean{TNLean.PEPS.%
         normalSquarePEPSBlockingHypotheses_mem_withSite_iff_of_marginCovers}
     \leanok

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -437,11 +437,12 @@ The remaining obligations are the following.
           and vertical edges inherit these criteria from their coordinate
           representatives. The oriented margin-and-cover data structure records
           the remaining per-edge input in the open rectangular coordinate
-          model. One such datum directly supplies one-edge blocking data and
-          the corresponding injective-chain conclusion, and a family of such
-          data determines the normal edge-blocking hypotheses. The
-          resulting hypotheses recover the supplied datum and its three
-          injective regions at each edge. The horizontal and vertical margin
+          model. One such datum directly supplies one-edge blocking data
+          together with the corresponding endpoint, injectivity, disjointness,
+          and coverage conclusions, and a family of such data determines the
+          normal edge-blocking hypotheses. The resulting hypotheses recover the
+          supplied datum and the same combined edge-blocking conclusions at
+          each edge. The horizontal and vertical margin
           predicates are named, the coordinate right/up and oriented-edge
           window constructors accept those predicates directly, translated
           windows on coordinate right/up edges force those predicates, and the
@@ -458,7 +459,8 @@ The remaining obligations are the following.
           over all edges of the current open $7\times7$ graph is also
           formalized.
     \item A family of one-edge blocking data determining the uniform
-          every-edge hypotheses: blueprint
+          every-edge hypotheses, including the combined endpoint, injectivity,
+          disjointness, and coverage assertion: blueprint
           \path{thm:peps_normalEdgeBlockingHypotheses_injectiveChain}, issue
           \#2004.
     \item Edge blocking into red, blue, and complementary injective regions:


### PR DESCRIPTION
## Summary

This is a narrow single-source cleanup for #2004.

It forwards the one-edge combined endpoint/injectivity/disjointness/coverage assertion from `NormalEdgeBlockingData` to the every-edge normal blocking hypotheses, then exposes the same combined consequence for the general normal PEPS blocking hypotheses and the square-lattice margin-cover construction.

The change keeps the mathematical source of these facts at the one-edge datum while making the downstream normal-blocking statements available without restating endpoint, injectivity, disjointness, and coverage separately.

This does not close #2004: the tensor-level union theorem, source-faithful `T`-injectivity, and every-edge finite-geometry construction remain open.

## Source

- MGRPG+18, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500
- theorem labelled `normal`, lines 1576--1583
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`

## Checks

- `lake build TNLean.PEPS.NormalSquarePEPSBlocking`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/PEPS/NormalEdgeBlockingData.lean TNLean/PEPS/NormalBlocking.lean TNLean/PEPS/NormalSquarePEPSBlocking.lean blueprint/src/chapter/ch13a_peps_ft.tex --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/PEPS/NormalEdgeBlockingData.lean TNLean/PEPS/NormalBlocking.lean TNLean/PEPS/NormalSquarePEPSBlocking.lean`
- `leanblueprint web` in a temporary Python environment with `.github/requirements/blueprint-python.txt`
- `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error peps_normal_ft_section3_route.tex`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin forwarding lemmas and documentation only; no changes to definitions, proofs of core constructions, or security-sensitive code.
> 
> **Overview**
> Exposes a **single combined per-edge lemma**—endpoints in red/blue, injectivity of all three regions, pairwise disjointness, and full vertex coverage—at the every-edge normal blocking layers, without duplicating separate injectivity and disjoint-cover statements.
> 
> New Lean theorems forward `endpoint_injective_disjoint_cover` from `NormalEdgeBlockingData` through `NormalEdgeBlockingHypotheses`, `NormalPEPSBlockingHypotheses`, and the square-lattice `normalSquarePEPSBlockingHypotheses_of_marginCovers` path. Blueprint (`ch13a_peps_ft.tex`) and the Section 3 route doc are updated to cite these names and describe margin-cover data as supplying the combined conclusion directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c254e6006636f27c51120299af103c38bf60b79a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->