### PR TITLE
feat(PEPS): record endpoint recovery with image preservation

### DIFF
--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -159,19 +159,18 @@ theorem edgePhysicalToVirtualInsertion_of_projected_realization_eq
     (hO₂_image : ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
       localProjector A hA e.1.2 (O₂ (localTensorMap A e.1.2 c)) =
         O₂ (localTensorMap A e.1.2 c)) :
-    ∃ M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ,
-      (∀ c : LocalVirtualConfig A e.1.1 → ℂ,
-        O₁ (localTensorMap A e.1.1 c) =
-          localTensorMap A e.1.1
-            (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose c)) ∧
-        ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
-          O₂ (localTensorMap A e.1.2 c) =
-            localTensorMap A e.1.2
-              (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c) := by
+    (∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+      O₁ (localTensorMap A e.1.1 c) =
+        localTensorMap A e.1.1
+          (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose c)) ∧
+      ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+        O₂ (localTensorMap A e.1.2 c) =
+          localTensorMap A e.1.2
+            (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c) := by
   obtain ⟨hLeft, hRight⟩ :=
     edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq
       A hA e O₁ O₂ M hO₁ hO₂
-  refine ⟨M, ?_, ?_⟩
+  constructor
   · intro c
     have hrealize :=
       localVirtualOpOfPhysicalOp_realizes_of_projector A hA e.1.1 O₁ hO₁_image c

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -18,6 +18,9 @@ corresponding endpoint.
   coefficient.
 - `edgeInsertedCoeff_eq_sum_right_physicalRealization`: the right endpoint
   physical realization gives the inserted-edge coefficient.
+- `edgePhysicalToVirtualInsertion_of_projected_realization_eq`: projected
+  endpoint realizations and image preservation imply the endpoint conclusion
+  of physical-to-virtual insertion.
 - `physical_to_virtual_insertion`: equal neighboring physical insertions in the
   edge-blocked three-site chain come from one matrix on the shared virtual bond.
 - `edgeInsertedCoeff_endpointPhysicalRealization`: vertex injectivity gives
@@ -127,6 +130,58 @@ theorem edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq
       A hA e O₁ M).2 hO₁
   · exact (edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
       A hA e O₂ M).2 hO₂
+
+/-- Projected endpoint realizations of a common bond matrix give the endpoint
+conclusion of physical-to-virtual insertion once the endpoint physical actions
+preserve the local tensor images.
+
+This records the local endpoint part of the \(O_1,O_2\mapsto W\) step in
+Lemma \(\mathrm{inj\_isomorph}\). It does not prove the three-site statement:
+the remaining source step is to derive the common projected realizations, and
+the required image preservation, from equality of the two endpoint physical
+actions on the edge-blocked state.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 363--486
+of the local paper source. -/
+theorem edgePhysicalToVirtualInsertion_of_projected_realization_eq
+    (A : Tensor G d) (hA : IsVertexInjective A) (e : Edge G)
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (hO₁ : (localProjector A hA e.1.1).comp (O₁.comp (localProjector A hA e.1.1)) =
+      physRealizeLocalOp A hA e.1.1
+        (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose))
+    (hO₂ : (localProjector A hA e.1.2).comp (O₂.comp (localProjector A hA e.1.2)) =
+      physRealizeLocalOp A hA e.1.2
+        (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M))
+    (hO₁_image : ∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+      localProjector A hA e.1.1 (O₁ (localTensorMap A e.1.1 c)) =
+        O₁ (localTensorMap A e.1.1 c))
+    (hO₂_image : ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+      localProjector A hA e.1.2 (O₂ (localTensorMap A e.1.2 c)) =
+        O₂ (localTensorMap A e.1.2 c)) :
+    ∃ M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ,
+      (∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+        O₁ (localTensorMap A e.1.1 c) =
+          localTensorMap A e.1.1
+            (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose c)) ∧
+        ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+          O₂ (localTensorMap A e.1.2 c) =
+            localTensorMap A e.1.2
+              (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c) := by
+  obtain ⟨hLeft, hRight⟩ :=
+    edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq
+      A hA e O₁ O₂ M hO₁ hO₂
+  refine ⟨M, ?_, ?_⟩
+  · intro c
+    have hrealize :=
+      localVirtualOpOfPhysicalOp_realizes_of_projector A hA e.1.1 O₁ hO₁_image c
+    rw [hLeft] at hrealize
+    exact hrealize.symm
+  · intro c
+    have hrealize :=
+      localVirtualOpOfPhysicalOp_realizes_of_projector A hA e.1.2 O₂ hO₂_image c
+    rw [hRight] at hrealize
+    exact hrealize.symm
 
 /-- Equal neighboring physical insertions recover a common virtual matrix on the
 shared edge.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1582,7 +1582,6 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $O_1$ maps the image of $\Phi_u$ into itself and $O_2$ maps the image of
     $\Phi_v$ into itself. Then
     \[
-        \exists M,\qquad
         O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T}),
         \qquad
         O_2\Phi_v=\Phi_vT_{v,e}(M).

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1570,6 +1570,31 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The two hypotheses are the left sides of these equivalences.
 \end{proof}
 
+\begin{theorem}[Endpoint physical-to-virtual recovery under image preservation]%
+    \label{thm:peps_edgePhysicalToVirtualInsertion_of_projected_realization_eq}
+    \lean{TNLean.PEPS.edgePhysicalToVirtualInsertion_of_projected_realization_eq}
+    \leanok
+    \uses{thm:peps_edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq,
+        thm:peps_localVirtualOpOfPhysicalOp_realizes_of_projector}
+    Let $e=(u,v)$. Suppose that
+    $P_uO_1P_u=\Phi_uT_{u,e}(M^{\mathsf T})\Psi_u$ and
+    $P_vO_2P_v=\Phi_vT_{v,e}(M)\Psi_v$. Suppose also that
+    $O_1$ maps the image of $\Phi_u$ into itself and $O_2$ maps the image of
+    $\Phi_v$ into itself. Then
+    \[
+        \exists M,\qquad
+        O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T}),
+        \qquad
+        O_2\Phi_v=\Phi_vT_{v,e}(M).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    The preceding endpoint theorem identifies the two virtual pullbacks with
+    the one-edge actions of $M^{\mathsf T}$ and $M$. The pullback
+    specification gives the projected physical actions, and the
+    image-preservation hypotheses remove the endpoint projectors.
+\end{proof}
+
 \begin{theorem}[Right-endpoint physical realization of the inserted coefficient]%
     \label{thm:peps_edgeInsertedCoeff_rightPhysicalRealization}
     \lean{TNLean.PEPS.edgeInsertedCoeff_eq_sum_right_physicalRealization}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -209,6 +209,12 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}:
   once the compressed endpoint actions are known to realize the same bond
   matrix, the local virtual pullbacks recover that matrix on the shared bond.
+  The image-preserving conditional form
+  \leanid{TNLean.PEPS.edgePhysicalToVirtualInsertion_of_projected_realization_eq}
+  has the endpoint conclusion of the source theorem: if those same projected
+  realizations hold and the two endpoint physical operators preserve the local
+  tensor images, then $O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T})$ and
+  $O_2\Phi_v=\Phi_vT_{v,e}(M)$.
 \item Equality of PEPS states must be upgraded to equality of edge-inserted
   coefficients after the three-site reduction. This is the step that produces
   the matrix-algebra isomorphism on the chosen bond. The formally stated
@@ -291,6 +297,12 @@ It is meant to prevent the proof from drifting away from the source argument.
   The endpoint projected-recovery component for a common bond matrix is
   formalized by
   \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}.
+  The conditional theorem
+  \leanid{TNLean.PEPS.edgePhysicalToVirtualInsertion_of_projected_realization_eq}
+  additionally removes the endpoint projectors under explicit
+  image-preservation hypotheses. The missing paper step is to obtain these
+  hypotheses, and the common bond matrix, from equality of the two neighboring
+  physical actions on the edge-blocked state.
 \item Matrix-insertion algebra isomorphism:
   \leanid{TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism} states the
   edge-blocked matrix-algebra correspondence and its inserted-coefficient


### PR DESCRIPTION
## Summary
- Add `TNLean.PEPS.edgePhysicalToVirtualInsertion_of_projected_realization_eq`.
- The theorem turns projected endpoint realizations of a common bond matrix, plus explicit image-preservation hypotheses for the two endpoint physical maps, into the endpoint conclusion shape of `physical_to_virtual_insertion`.
- Record the result in Chapter 13a and in the Section 3 paper-gap route note without claiming the full three-site recovery theorem.

## Mathematical Scope
This is a conditional endpoint consequence for the `O_1,O_2 -> W` step of Lemma `inj_isomorph` in MGRPG+18, Section 3. It does not close #1370: the remaining source-paper step is still to derive the common projected realizations and image preservation from equality of the neighboring physical actions on the edge-blocked three-site state.

Refs #1370.

## Checks
- `lake env lean TNLean/PEPS/InsertionRealization.lean`
- `lake build TNLean.PEPS.InsertionRealization`
- `lake build TNLean`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/InsertionRealization.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check origin/main`
- `python3 blueprint/src/Packages/tn_diagrams.py --check --check-peps-usage --smoke-render TNPEPSPhysicalToVirtualInsertion`
- `python3 scripts/blueprint_bibtex.py`
- `PATH="/Users/siruilu/Library/Python/3.9/bin:$PATH" leanblueprint web`

`leanblueprint checkdecls` still reports repository-wide pre-existing missing declarations in unrelated PEPS and parent-Hamiltonian blueprint entries; the new declaration appears in `blueprint/lean_decls` and the rendered PEPS page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean formalization and blueprint/paper-gap documentation only; no runtime, auth, or data-path changes. The open proof obligation for #1370 is explicitly unchanged.
> 
> **Overview**
> Adds **`TNLean.PEPS.edgePhysicalToVirtualInsertion_of_projected_realization_eq`**, a **conditional** endpoint step for Lemma `inj_isomorph` ($O_1,O_2 \mapsto W$): given projected realizations of a common bond matrix $M$ at both endpoints **and** hypotheses that $O_1,O_2$ preserve the local tensor images, it proves the **unprojected** identities $O_1\Phi_u=\Phi_u T_{u,e}(M^{\mathsf T})$ and $O_2\Phi_v=\Phi_v T_{v,e}(M)$. The proof chains the existing endpoint virtual-pullback theorem with `localVirtualOpOfPhysicalOp_realizes_of_projector`.
> 
> The result is wired into **Chapter 13a** (new blueprint theorem) and **`docs/paper-gaps/peps_injective_ft_section3_route.tex`**, which now distinguishes this step from the still-open **`physical_to_virtual_insertion`** (#1370): deriving the projected realizations, $M$, and image preservation from equality on the edge-blocked three-site state is **not** claimed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b257dbdc6f0f47b19e88dd7053a4b9f5aaa4c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->