### PR TITLE
doc(PEPS): keep physical-to-virtual recovery status current

### DIFF
--- a/TNLean/PEPS/InsertionAlgebra.lean
+++ b/TNLean/PEPS/InsertionAlgebra.lean
@@ -72,7 +72,12 @@ matrix insertions on the chosen bond of the first blocked chain correspond, by
 an algebra isomorphism, to matrix insertions on the chosen bond of the second
 blocked chain, and the corresponding inserted coefficients agree.
 
-**Proof status:** This declaration states the source theorem. The available
+**Proof status:** This declaration states the source theorem. The
+virtual-to-physical endpoint direction is formalized, and the conditional
+endpoint consequence of the physical-to-virtual direction is formalized under
+projected-realization and image-preservation hypotheses. The source-level
+\(O_1,O_2 \mapsto W\) recovery theorem, which derives those hypotheses from
+equality of the two endpoint physical actions, remains open. The available
 components and remaining implications are recorded in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
 mathematical obligations". -/
@@ -83,9 +88,10 @@ theorem isEdgeBlockedInsertionAlgebraIsomorphism
     (hAB : SameState A B) :
     IsEdgeBlockedInsertionAlgebraIsomorphism (G := G) A B e := by
   -- This is the algebra-isomorphism step in arXiv:1804.04964, Section 3,
-  -- Lemma inj_isomorph, lines 254--582. The proof combines the
-  -- virtual-to-physical realization with the physical-to-virtual recovery
-  -- $O_1,O_2 \mapsto W$, then uses injectivity to prove uniqueness,
+  -- Lemma inj_isomorph, lines 254--582. The proof first combines the
+  -- virtual-to-physical realization with the full physical-to-virtual recovery
+  -- $O_1,O_2 \mapsto W$; the conditional endpoint recovery theorem is only one
+  -- component of that step. It then uses injectivity to prove uniqueness,
   -- bijectivity, and multiplicativity of the resulting map $X \mapsto Y$.
   sorry
 

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -25,6 +25,16 @@ corresponding endpoint.
   edge-blocked three-site chain come from one matrix on the shared virtual bond.
 - `edgeInsertedCoeff_endpointPhysicalRealization`: vertex injectivity gives
   endpoint physical realizations of the inserted-edge coefficient.
+
+## Status
+
+The endpoint theorem
+`edgePhysicalToVirtualInsertion_of_projected_realization_eq` is a
+proof-complete consequence once the common matrix, projected realizations, and
+image preservation are supplied. The source-level theorem
+`physical_to_virtual_insertion` still records the remaining
+\(O_1,O_2 \mapsto W\) obligation: deriving those hypotheses from equality of
+the two endpoint physical actions on the edge-blocked three-site state.
 -/
 
 namespace TNLean
@@ -136,10 +146,11 @@ conclusion of physical-to-virtual insertion once the endpoint physical actions
 preserve the local tensor images.
 
 This records the local endpoint part of the \(O_1,O_2\mapsto W\) step in
-Lemma \(\mathrm{inj\_isomorph}\). It does not prove the three-site statement:
-the remaining source step is to derive the common projected realizations, and
-the required image preservation, from equality of the two endpoint physical
-actions on the edge-blocked state.
+Lemma \(\mathrm{inj\_isomorph}\). It is a conditional consequence of a common
+bond matrix and projected endpoint realizations. It does not prove the
+three-site source theorem: the remaining source step is to derive the common
+matrix, the projected realizations, and image preservation from equality of the
+two endpoint physical actions on the edge-blocked state.
 
 Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 363--486
 of the local paper source. -/

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -201,7 +201,7 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   ordinary edge-boundary data, the left and right physical operators supply the
   independent inserted-edge index at the corresponding endpoint. On the left
   endpoint the formal statement uses the transpose of the inserted matrix,
-  because the ordinary boundary supplies the right bond index. The converse
+  because the ordinary boundary supplies the right bond index. The source
   recovery $O_1,O_2\mapsto W$ is stated as
   \leanid{TNLean.PEPS.physical_to_virtual_insertion}; its proof remains open and
   is tracked by issue~\#1370.
@@ -214,7 +214,12 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   has the endpoint conclusion of the source theorem: if those same projected
   realizations hold and the two endpoint physical operators preserve the local
   tensor images, then $O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T})$ and
-  $O_2\Phi_v=\Phi_vT_{v,e}(M)$.
+  $O_2\Phi_v=\Phi_vT_{v,e}(M)$. This conditional endpoint theorem is not a
+  replacement for
+  \leanid{TNLean.PEPS.physical_to_virtual_insertion}: the remaining paper step
+  is to obtain the common matrix, the two projected-realization identities, and
+  the image-preservation hypotheses from equality of the neighboring physical
+  actions on the edge-blocked three-site state.
 \item Equality of PEPS states must be upgraded to equality of edge-inserted
   coefficients after the three-site reduction. This is the step that produces
   the matrix-algebra isomorphism on the chosen bond. The formally stated
@@ -302,7 +307,9 @@ It is meant to prevent the proof from drifting away from the source argument.
   additionally removes the endpoint projectors under explicit
   image-preservation hypotheses. The missing paper step is to obtain these
   hypotheses, and the common bond matrix, from equality of the two neighboring
-  physical actions on the edge-blocked state.
+  physical actions on the edge-blocked state. Thus the conditional endpoint
+  theorem is a component of issue~\#1370, not the closure of that source-level
+  obligation.
 \item Matrix-insertion algebra isomorphism:
   \leanid{TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism} states the
   edge-blocked matrix-algebra correspondence and its inserted-coefficient


### PR DESCRIPTION
## Summary

This is a source-faithfulness/status correction for the PEPS insertion-algebra route. PR #2227 added the proof-complete endpoint theorem `TNLean.PEPS.edgePhysicalToVirtualInsertion_of_projected_realization_eq`, but it did not prove the source-level theorem `TNLean.PEPS.physical_to_virtual_insertion`.

Changes:

- Reopened #1370, because the full `O_1,O_2 -> W` recovery theorem still has its tracked proof obligation.
- Updated `InsertionRealization.lean` to state that the endpoint theorem is a conditional consequence, not a replacement for the source theorem.
- Updated `InsertionAlgebra.lean` and the Section 3 paper-gap ledger so #1367 depends on the full recovery theorem, with the endpoint theorem recorded as one component.

No declarations, theorem statements, or proof terms are changed.

## Validation

- `lake build TNLean.PEPS.InsertionRealization`
- `lake build TNLean.PEPS.InsertionAlgebra`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/InsertionRealization.lean TNLean/PEPS/InsertionAlgebra.lean docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error peps_injective_ft_section3_route.tex`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `lake exe lint_style --github`
- `git diff --check`
- changed-line proof-integrity scan

Refs #1367. Refs #1370.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX ledger edits only; no formal statements or proofs are modified.
> 
> **Overview**
> Clarifies **proof-status documentation** for the PEPS Section 3 insertion route after the conditional endpoint theorem `edgePhysicalToVirtualInsertion_of_projected_realization_eq` was added elsewhere.
> 
> **`InsertionRealization.lean`** gains a **Status** section and tighter docstrings: the endpoint theorem is **proof-complete given hypotheses**; **`physical_to_virtual_insertion`** still carries the open **\(O_1,O_2 \mapsto W\)** step (derive common matrix, projected realizations, and image preservation from equal neighboring physical actions).
> 
> **`InsertionAlgebra.lean`** updates **`isEdgeBlockedInsertionAlgebraIsomorphism`** proof-status and the `sorry` comment so the **full** recovery theorem—not only the conditional endpoint piece—is what remains for the algebra-isomorphism proof.
> 
> **`peps_injective_ft_section3_route.tex`** aligns the gap ledger: the conditional endpoint result **does not replace** `physical_to_virtual_insertion`; it is a **component of issue #1370**, not closure of that obligation.
> 
> No Lean declarations, theorem statements, or proof terms change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6accffdfc5b82857c34516b94f6cd402a1253f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->