### PR TITLE
feat(PEPS): prove two-block product cancellation

### DIFF
--- a/TNLean/PEPS/TwoInjectiveComparison.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison.lean
@@ -124,6 +124,90 @@ def TwoBlockReciprocalScalarProportional
       TwoBlockScalarProportional A₁ B₁ c ∧
         TwoBlockScalarProportional A₂ B₂ c⁻¹
 
+/-! ### Product cancellation after coefficient separation -/
+
+omit [Fintype Bond] [(b : Bond) → Fintype (bondDim b)] in
+/-- Reciprocal scalar proportionality from separated pointwise products.
+
+This is the final finite-dimensional cancellation step in the two-injective
+comparison once the insertion equalities have been converted into pointwise
+equalities of tensor products. It is the rank-one cancellation part of
+arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2, lines 1068--1203 of
+Papers/1804.04964/paper_normal.tex.
+
+Proof status: the remaining open theorem `two_injective_tensor_insertion_comparison`
+must still derive the hypothesis of this lemma from equality of all one-bond
+insertions, using injective inverses and `threeLeg_residual_forms_scalar`.
+-/
+theorem twoBlockReciprocalScalarProportional_of_pointwise_mul_eq
+    {External₁ External₂ Physical₁ Physical₂ : Type*}
+    [Nonempty (SharedBondConfig bondDim)] [Nonempty External₁] [Nonempty External₂]
+    (A₁ B₁ : TwoBlockTensor bondDim External₁ Physical₁)
+    (A₂ B₂ : TwoBlockTensor bondDim External₂ Physical₂)
+    (hA₁ : IsTwoBlockInjective A₁) (hA₂ : IsTwoBlockInjective A₂)
+    (hmul : ∀ (η₁ : External₁) (η₂ : External₂)
+      (μ ν : SharedBondConfig bondDim) (σ₁ : Physical₁) (σ₂ : Physical₂),
+        A₁ η₁ μ σ₁ * A₂ η₂ ν σ₂ = B₁ η₁ μ σ₁ * B₂ η₂ ν σ₂) :
+    TwoBlockReciprocalScalarProportional A₁ B₁ A₂ B₂ := by
+  classical
+  let η₁₀ : External₁ := Classical.choice ‹Nonempty External₁›
+  let η₂₀ : External₂ := Classical.choice ‹Nonempty External₂›
+  let μ₀ : SharedBondConfig bondDim := Classical.choice ‹Nonempty (SharedBondConfig bondDim)›
+  let ν₀ : SharedBondConfig bondDim := μ₀
+  have hA₁_vec_ne : (fun σ₁ : Physical₁ => A₁ η₁₀ μ₀ σ₁) ≠ 0 :=
+    hA₁.ne_zero (η₁₀, μ₀)
+  obtain ⟨σ₁₀, hA₁_ne⟩ :=
+    Function.ne_iff.mp hA₁_vec_ne
+  have hA₂_vec_ne : (fun σ₂ : Physical₂ => A₂ η₂₀ ν₀ σ₂) ≠ 0 :=
+    hA₂.ne_zero (η₂₀, ν₀)
+  obtain ⟨σ₂₀, hA₂_ne⟩ :=
+    Function.ne_iff.mp hA₂_vec_ne
+  have hprod₀ :
+      B₁ η₁₀ μ₀ σ₁₀ * B₂ η₂₀ ν₀ σ₂₀ ≠ 0 := by
+    rw [← hmul η₁₀ η₂₀ μ₀ ν₀ σ₁₀ σ₂₀]
+    exact mul_ne_zero hA₁_ne hA₂_ne
+  have hB₁_ne : B₁ η₁₀ μ₀ σ₁₀ ≠ 0 :=
+    (mul_ne_zero_iff.mp hprod₀).1
+  have hB₂_ne : B₂ η₂₀ ν₀ σ₂₀ ≠ 0 :=
+    (mul_ne_zero_iff.mp hprod₀).2
+  let c : ℂ := B₂ η₂₀ ν₀ σ₂₀ / A₂ η₂₀ ν₀ σ₂₀
+  have hc_ne : c ≠ 0 := div_ne_zero hB₂_ne hA₂_ne
+  have hA₁_scalar : TwoBlockScalarProportional A₁ B₁ c := by
+    intro η₁ μ σ₁
+    have h := hmul η₁ η₂₀ μ ν₀ σ₁ σ₂₀
+    have hB₂_eq : B₂ η₂₀ ν₀ σ₂₀ = A₂ η₂₀ ν₀ σ₂₀ * c := by
+      change B₂ η₂₀ ν₀ σ₂₀ =
+        A₂ η₂₀ ν₀ σ₂₀ * (B₂ η₂₀ ν₀ σ₂₀ / A₂ η₂₀ ν₀ σ₂₀)
+      exact (mul_div_cancel₀ (B₂ η₂₀ ν₀ σ₂₀) hA₂_ne).symm
+    change A₁ η₁ μ σ₁ = c * B₁ η₁ μ σ₁
+    rw [mul_comm c (B₁ η₁ μ σ₁)]
+    rw [← mul_right_inj' hA₂_ne]
+    calc
+      A₂ η₂₀ ν₀ σ₂₀ * A₁ η₁ μ σ₁ =
+          A₁ η₁ μ σ₁ * A₂ η₂₀ ν₀ σ₂₀ := by
+        simp [mul_comm]
+      _ = B₁ η₁ μ σ₁ * B₂ η₂₀ ν₀ σ₂₀ := h
+      _ = A₂ η₂₀ ν₀ σ₂₀ * (B₁ η₁ μ σ₁ * c) := by
+        rw [hB₂_eq]
+        simp [mul_left_comm]
+  have hA₂_scalar : TwoBlockScalarProportional A₂ B₂ c⁻¹ := by
+    intro η₂ ν σ₂
+    have h := hmul η₁₀ η₂ μ₀ ν σ₁₀ σ₂
+    have hA₁₀ : A₁ η₁₀ μ₀ σ₁₀ = c * B₁ η₁₀ μ₀ σ₁₀ :=
+      hA₁_scalar η₁₀ μ₀ σ₁₀
+    change A₂ η₂ ν σ₂ = c⁻¹ * B₂ η₂ ν σ₂
+    rw [hA₁₀] at h
+    rw [← mul_left_inj' (mul_ne_zero hc_ne hB₁_ne)]
+    calc
+      A₂ η₂ ν σ₂ * (c * B₁ η₁₀ μ₀ σ₁₀) =
+          (c * B₁ η₁₀ μ₀ σ₁₀) * A₂ η₂ ν σ₂ := by
+        simp [mul_comm]
+      _ =
+          B₁ η₁₀ μ₀ σ₁₀ * B₂ η₂ ν σ₂ := h
+      _ = (c⁻¹ * B₂ η₂ ν σ₂) * (c * B₁ η₁₀ μ₀ σ₁₀) := by
+        simp [hc_ne, mul_comm, mul_left_comm]
+  exact ⟨c, hc_ne, hA₁_scalar, hA₂_scalar⟩
+
 /-! ### Main comparison theorem -/
 
 /-- **Generalized two-injective-tensor comparison.**

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2113,6 +2113,62 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $W_{\alpha\gamma}=\lambda I_{\alpha\otimes\gamma}$.
 \end{proof}
 
+\begin{theorem}[Pointwise product cancellation for two injective blocks]%
+    \label{thm:peps_twoBlockPointwiseProductCancellation}
+    \lean{TNLean.PEPS.twoBlockReciprocalScalarProportional_of_pointwise_mul_eq}
+    \leanok
+    Let $A_1,A_2,B_1,B_2$ be tensors with matching external,
+    shared-boundary, and physical index sets. Assume that the two external
+    boundary spaces and the shared-boundary configuration space are nonempty,
+    and that $A_1$ and $A_2$ are injective. Suppose that, for every pair of
+    external indices, every pair of shared-boundary configurations, and every
+    pair of physical indices,
+    \[
+        A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2)
+        =
+        B_1(\eta_1,\mu,\sigma_1)B_2(\eta_2,\nu,\sigma_2).
+    \]
+    Then there exists $\lambda\in\C^\times$ such that
+    \[
+        A_1=\lambda B_1,\qquad
+        A_2=\lambda^{-1}B_2.
+    \]
+\end{theorem}
+% This theorem is the rank-one cancellation step once
+% \cite[Section~3]{Molnar2018NormalPEPS} has been reduced to pointwise product
+% equality of separated coefficients.
+\begin{proof}\leanok
+    Choose external and shared-boundary indices, and use injectivity of
+    $A_1$ and $A_2$ to choose physical indices for which the two chosen
+    coefficients are nonzero. The product equality then shows that the
+    corresponding coefficients of $B_1$ and $B_2$ are also nonzero. Define
+    \[
+        \lambda =
+        \frac{B_2(\eta_2^0,\nu^0,\sigma_2^0)}
+             {A_2(\eta_2^0,\nu^0,\sigma_2^0)} .
+    \]
+    For every $(\eta_1,\mu,\sigma_1)$, the product identity with
+    $(\eta_2^0,\nu^0,\sigma_2^0)$ fixed gives
+    \[
+        A_1(\eta_1,\mu,\sigma_1)
+        A_2(\eta_2^0,\nu^0,\sigma_2^0)
+        =
+        B_1(\eta_1,\mu,\sigma_1)
+        B_2(\eta_2^0,\nu^0,\sigma_2^0).
+    \]
+    Dividing by $A_2(\eta_2^0,\nu^0,\sigma_2^0)\ne0$ gives
+    $A_1=\lambda B_1$. Fixing $(\eta_1^0,\mu^0,\sigma_1^0)$ and substituting
+    $A_1=\lambda B_1$ into the product identity gives
+    \[
+        \lambda\, B_1(\eta_1^0,\mu^0,\sigma_1^0)
+        A_2(\eta_2,\nu,\sigma_2)
+        =
+        B_1(\eta_1^0,\mu^0,\sigma_1^0) B_2(\eta_2,\nu,\sigma_2).
+    \]
+    Dividing by $B_1(\eta_1^0,\mu^0,\sigma_1^0)\ne0$ gives
+    $A_2=\lambda^{-1}B_2$.
+\end{proof}
+
 \begin{theorem}[Generalized two-injective-tensor comparison]%
     \label{thm:peps_twoInjectiveTensorInsertionComparison}
     \lean{TNLean.PEPS.two_injective_tensor_insertion_comparison}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -252,7 +252,18 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison}. The formal
   statement is an abstract version with nonempty spectator external boundary
   spaces; the source lemma is recovered by taking these spaces to be one-point
-  spaces. Its proof remains open and is tracked by issue~\#1361.
+  spaces. The rank-one cancellation after coefficientwise product equality is
+  now formalized by
+  \leanid{TNLean.PEPS.twoBlockReciprocalScalarProportional_of_pointwise_mul_eq}:
+  if
+  $A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2)
+  =B_1(\eta_1,\mu,\sigma_1)B_2(\eta_2,\nu,\sigma_2)$ for all indices, then
+  injectivity of $A_1$ and $A_2$ gives the reciprocal scalar
+  proportionality. The remaining proof of
+  \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison} is to derive
+  this coefficientwise product equality from equality of all one-bond
+  insertions, using the injective inverse maps and the scalar-reduction
+  theorem. This remaining implication is tracked by issue~\#1361.
 \item The final two-tensor comparison must then be applied by blocking one
   vertex against its complement. The paper uses this to prove
   $A_i=\lambda_i\widetilde B_i$ at each vertex, and then incorporates the


### PR DESCRIPTION
## Summary

This PR records a proof-complete finite-dimensional cancellation step for the PEPS two-injective comparison in arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`.

It proves that once the comparison has been reduced to coefficientwise product identities
\[
A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2)
=
B_1(\eta_1,\mu,\sigma_1)B_2(\eta_2,\nu,\sigma_2),
\]
injectivity of `A₁` and `A₂` gives a nonzero scalar `λ` with
\[
A_1=\lambda B_1,\qquad A_2=\lambda^{-1}B_2.
\]

The full theorem `two_injective_tensor_insertion_comparison` remains open: the remaining mathematical work is to derive the coefficientwise product identity from equality of all one-bond insertions, using the injective inverse maps and the scalar-reduction theorem.

Refs #1361.

## Changes

- Adds `TNLean.PEPS.twoBlockReciprocalScalarProportional_of_pointwise_mul_eq`.
- Adds the corresponding Chapter 13a blueprint theorem with `\leanok`.
- Updates the PEPS Section 3 paper-gap note so the completed cancellation result and the remaining implication are recorded in one place.

## Verification

- `lake env lean TNLean/PEPS/TwoInjectiveComparison.lean`
- `lake build TNLean.PEPS.TwoInjectiveComparison`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/PEPS/TwoInjectiveComparison.lean blueprint/src/chapter/ch13a_peps_ft.tex docs/paper-gaps/peps_injective_ft_section3_route.tex`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `leanblueprint web`
- `leanblueprint pdf`

`leanblueprint checkdecls` was also run after generating `blueprint/lean_decls`; it fails on many pre-existing missing blueprint declarations outside this PR. The new declaration in this PR is not among the missing names, and `blueprint_lean_sync.py` confirms that no changed Lean declaration lacks blueprint coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a self-contained formal proof and blueprint sync in the PEPS comparison file; the main comparison theorem stays `sorry` and there is no runtime or security impact.
> 
> **Overview**
> This PR **completes one finite-dimensional step** in the PEPS two-injective comparison (Molnár et al., Section 3): once all coefficientwise product identities hold, injectivity of `A₁` and `A₂` forces reciprocal scalar proportionality `A₁ = λ B₁`, `A₂ = λ⁻¹ B₂`.
> 
> It adds the Lean theorem `twoBlockReciprocalScalarProportional_of_pointwise_mul_eq` in `TwoInjectiveComparison.lean`, the matching Chapter 13a blueprint entry (`thm:peps_twoBlockPointwiseProductCancellation`, `\leanok`), and updates `peps_injective_ft_section3_route.tex` so the **done** cancellation lemma is distinguished from the **still open** main theorem `two_injective_tensor_insertion_comparison` (deriving pointwise products from equality of all one-bond insertions, issue #1361).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea14a3be26094f196f6bde0550b50afe12c4ab38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->