### PR TITLE
feat(PEPS): prove one-bond two-block comparison

### DIFF
--- a/TNLean/PEPS/TwoInjectiveComparison.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison.lean
@@ -1,5 +1,5 @@
 import Mathlib.Data.Complex.Basic
-import Mathlib.Data.Matrix.Basic
+import Mathlib.Data.Matrix.Basis
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 
 /-!
@@ -207,6 +207,97 @@ theorem twoBlockReciprocalScalarProportional_of_pointwise_mul_eq
       _ = (c⁻¹ * B₂ η₂ ν σ₂) * (c * B₁ η₁₀ μ₀ σ₁₀) := by
         simp [hc_ne, mul_comm, mul_left_comm]
   exact ⟨c, hc_ne, hA₁_scalar, hA₂_scalar⟩
+
+/-! ### The one-shared-bond case -/
+
+/-- The usual elementary matrix with a single nonzero entry equal to `1` at
+position `(i, j)`. -/
+noncomputable def matrixUnit {ι κ : Type*} (i : ι) (j : κ) :
+    Matrix ι κ ℂ := by
+  classical
+  exact Matrix.single i j (1 : ℂ)
+
+/-- If there is only one shared bond, then a matrix insertion supported at one
+matrix entry extracts the corresponding pointwise product.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2. This is the
+one-shared-bond specialization, where no residual two-leg operators appear. -/
+theorem twoBlockInsertedCoeff_singletonBond_single
+    {External₁ External₂ Physical₁ Physical₂ : Type*}
+    [Subsingleton Bond] (b : Bond)
+    (A₁ : TwoBlockTensor bondDim External₁ Physical₁)
+    (A₂ : TwoBlockTensor bondDim External₂ Physical₂)
+    (η₁ : External₁) (η₂ : External₂)
+    (μ ν : SharedBondConfig bondDim) (σ₁ : Physical₁) (σ₂ : Physical₂) :
+    twoBlockInsertedCoeff A₁ A₂ b (matrixUnit (μ b) (ν b))
+        η₁ η₂ σ₁ σ₂ =
+      A₁ η₁ μ σ₁ * A₂ η₂ ν σ₂ := by
+  classical
+  unfold twoBlockInsertedCoeff
+  rw [Finset.sum_eq_single μ]
+  · rw [Finset.sum_eq_single ν]
+    · have hsame : SameAwayFromBond b μ ν := by
+        intro c hc
+        exact (hc (Subsingleton.elim c b)).elim
+      simp [matrixUnit, Matrix.single, hsame]
+    · intro ν' _ hν'
+      have hν'_ne : ν' b ≠ ν b := by
+        intro hb
+        apply hν'
+        funext c
+        have hc : c = b := Subsingleton.elim c b
+        rw [hc]
+        exact hb
+      have hν_ne' : ν b ≠ ν' b := hν'_ne.symm
+      simp [matrixUnit, Matrix.single, hν_ne']
+    · intro hν
+      simp at hν
+  · intro μ' _ hμ'
+    have hμ'_ne : μ' b ≠ μ b := by
+      intro hb
+      apply hμ'
+      funext c
+      have hc : c = b := Subsingleton.elim c b
+      rw [hc]
+      exact hb
+    have hμ_ne' : μ b ≠ μ' b := hμ'_ne.symm
+    apply Finset.sum_eq_zero
+    intro ν' _
+    simp [matrixUnit, Matrix.single, hμ_ne']
+  · intro hμ
+    simp at hμ
+
+/-- The generalized two-injective comparison in the case of a single shared
+virtual bond.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2. This proves
+the coefficient-separation subcase where the shared-boundary family has one
+bond, so equality of all matrix insertions gives pointwise product equality
+directly. The many-bond case still requires the residual-operator argument. -/
+theorem two_injective_tensor_insertion_comparison_singletonBond
+    {External₁ External₂ Physical₁ Physical₂ : Type*}
+    [Nonempty Bond] [Subsingleton Bond] [Nonempty External₁] [Nonempty External₂]
+    (A₁ B₁ : TwoBlockTensor bondDim External₁ Physical₁)
+    (A₂ B₂ : TwoBlockTensor bondDim External₂ Physical₂)
+    (hA₁ : IsTwoBlockInjective A₁) (hA₂ : IsTwoBlockInjective A₂)
+    (hinsert : SameTwoBlockInsertions A₁ B₁ A₂ B₂) :
+    TwoBlockReciprocalScalarProportional A₁ B₁ A₂ B₂ := by
+  classical
+  by_cases hcfg : Nonempty (SharedBondConfig bondDim)
+  · letI : Nonempty (SharedBondConfig bondDim) := hcfg
+    refine
+      twoBlockReciprocalScalarProportional_of_pointwise_mul_eq A₁ B₁ A₂ B₂ hA₁ hA₂ ?_
+    intro η₁ η₂ μ ν σ₁ σ₂
+    let b : Bond := Classical.choice ‹Nonempty Bond›
+    have hcoeff := hinsert b (matrixUnit (μ b) (ν b)) η₁ η₂ σ₁ σ₂
+    rw [twoBlockInsertedCoeff_singletonBond_single b A₁ A₂,
+      twoBlockInsertedCoeff_singletonBond_single b B₁ B₂] at hcoeff
+    exact hcoeff
+  · refine ⟨1, one_ne_zero, ?_, ?_⟩
+    · intro η μ σ
+      exact (hcfg ⟨μ⟩).elim
+    · intro η μ σ
+      exact (hcfg ⟨μ⟩).elim
 
 /-! ### Main comparison theorem -/
 

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2169,6 +2169,74 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $A_2=\lambda^{-1}B_2$.
 \end{proof}
 
+\begin{definition}[Matrix unit for coefficient extraction]%
+    \label{def:peps_matrixUnit}
+    \lean{TNLean.PEPS.matrixUnit}
+    \leanok
+    For indices $i$ and $j$, let $E_{ij}$ denote the matrix whose only
+    nonzero entry is the $(i,j)$ entry, where it is equal to $1$.
+\end{definition}
+
+\begin{theorem}[Coefficient extraction for one shared bond]%
+    \label{thm:peps_twoBlockInsertedCoeff_singletonBond}
+    \lean{TNLean.PEPS.twoBlockInsertedCoeff_singletonBond_single}
+    \leanok
+    \uses{def:peps_matrixUnit}
+    Suppose that the two blocks share a single virtual bond. Then inserting
+    the matrix unit $E_{\mu,\nu}$ in that bond extracts the corresponding
+    product of tensor coefficients:
+    \[
+        C_{A_1,A_2}(b,E_{\mu,\nu};\eta_1,\eta_2,\sigma_1,\sigma_2)
+        =
+        A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Since there is only one shared bond, the condition that the two shared
+    configurations agree away from the distinguished bond is vacuous, and
+    \[
+        C_{A_1,A_2}(b,E_{\mu,\nu};\eta_1,\eta_2,\sigma_1,\sigma_2)
+        =
+        \sum_{\mu',\nu'}
+        (E_{\mu,\nu})_{\mu'(b),\nu'(b)}
+        A_1(\eta_1,\mu',\sigma_1)A_2(\eta_2,\nu',\sigma_2).
+    \]
+    The entries of the matrix unit satisfy
+    \[
+        (E_{\mu,\nu})_{i,j}=\delta_{i,\mu(b)}\delta_{j,\nu(b)}.
+    \]
+    Thus the only nonzero summand is the one with
+    $(\mu',\nu')=(\mu,\nu)$.
+\end{proof}
+
+\begin{theorem}[One-bond two-injective comparison]%
+    \label{thm:peps_twoInjectiveTensorInsertionComparison_singletonBond}
+    \lean{TNLean.PEPS.two_injective_tensor_insertion_comparison_singletonBond}
+    \leanok
+    \uses{thm:peps_twoBlockInsertedCoeff_singletonBond,
+        thm:peps_twoBlockPointwiseProductCancellation}
+    Suppose that the two injective blocks have exactly one shared virtual
+    bond and nonempty external boundary spaces. If all matrix insertions on
+    that bond give equal two-block coefficients for the pairs
+    $(A_1,A_2)$ and $(B_1,B_2)$, then there exists
+    $\lambda\in\C^\times$ such that
+    \[
+        A_1=\lambda B_1,\qquad
+        A_2=\lambda^{-1}B_2 .
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Insert the matrix unit $E_{\mu,\nu}$ and use the coefficient-extraction
+    theorem to obtain the pointwise product equality
+    \[
+        A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2)
+        =
+        B_1(\eta_1,\mu,\sigma_1)B_2(\eta_2,\nu,\sigma_2)
+    \]
+    for all indices. The pointwise product cancellation theorem gives the
+    reciprocal scalar proportionality.
+\end{proof}
+
 \begin{theorem}[Generalized two-injective-tensor comparison]%
     \label{thm:peps_twoInjectiveTensorInsertionComparison}
     \lean{TNLean.PEPS.two_injective_tensor_insertion_comparison}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -259,11 +259,18 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   $A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2)
   =B_1(\eta_1,\mu,\sigma_1)B_2(\eta_2,\nu,\sigma_2)$ for all indices, then
   injectivity of $A_1$ and $A_2$ gives the reciprocal scalar
-  proportionality. The remaining proof of
+  proportionality. The one-shared-bond coefficient-separation case is now
+  formalized by
+  \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison_singletonBond}:
+  inserting the matrix unit $E_{\mu,\nu}$ extracts the single product
+  $A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2)$, and the pointwise
+  product cancellation theorem then gives reciprocal scalar proportionality.
+  The remaining proof of
   \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison} is to derive
   this coefficientwise product equality from equality of all one-bond
-  insertions, using the injective inverse maps and the scalar-reduction
-  theorem. This remaining implication is tracked by issue~\#1361.
+  insertions in the many-bond case, using the injective inverse maps and the
+  scalar-reduction theorem. This remaining implication is tracked by
+  issue~\#1361.
 \item The final two-tensor comparison must then be applied by blocking one
   vertex against its complement. The paper uses this to prove
   $A_i=\lambda_i\widetilde B_i$ at each vertex, and then incorporates the


### PR DESCRIPTION
### Motivation

- Formalizes the one-shared-virtual-bond specialization of the two-injective tensor comparison from arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`, advancing #1361.
- When two pairs of injective tensors agree after inserting a matrix unit $E_{\mu,\nu}$ on the sole shared virtual bond, that unit isolates the coefficient product $A_1(\eta_1, \mu, \sigma_1) A_2(\eta_2, \nu, \sigma_2)$; the existing pointwise product cancellation theorem then yields reciprocal scalar proportionality. The many-bond residual-operator argument remains open.

### Description

- `TNLean/PEPS/TwoInjectiveComparison.lean`: adds `TNLean.PEPS.matrixUnit`; proves `twoBlockInsertedCoeff_singletonBond_single` (inserting a matrix unit on the sole shared bond isolates the pointwise coefficient product); proves `two_injective_tensor_insertion_comparison_singletonBond` (reciprocal scalar proportionality for the one-bond case). `two_injective_tensor_insertion_comparison` (blueprint node `thm:peps_twoInjectiveTensorInsertionComparison`, the general many-bond theorem) remains `sorry`.
- `blueprint/src/chapter/ch13a_peps_ft.tex`: adds matching Chapter 13a blueprint entries for the three new declarations with `\lean{}` and `\leanok` tags.
- `docs/paper-gaps/peps_injective_ft_section3_route.tex`: updates the Section 3 paper-gap ledger to record that the many-bond coefficient-separation step is still outstanding.

### Testing

- `lake env lean TNLean/PEPS/TwoInjectiveComparison.lean`
- `lake build TNLean.PEPS.TwoInjectiveComparison`
- `lake build TNLean`
- Proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast` on changed lines.
- `lake exe checkdecls` on the three new declarations.
- `leanblueprint web` with no `ERROR:` lines.

---
Addresses #1361

> [!NOTE]
> **Low Risk**
> Adds completed Lean proofs and documentation only; no runtime, auth, or data-path changes, and the general many-bond theorem is unchanged (`sorry`).
>
> **Overview**
> This PR **closes the one-shared-virtual-bond case** of the two-injective tensor comparison (MGRPG+18 §3, `inj_equal_tensors_2`), advancing issue **#1361** without touching the still-`sorry` many-bond theorem.
>
> In **`TNLean/PEPS/TwoInjectiveComparison.lean`**, it adds **`matrixUnit`**, proves that inserting that unit on the sole bond makes **`twoBlockInsertedCoeff`** equal the pointwise product **`A₁(…) A₂(…)`**, and proves **`two_injective_tensor_insertion_comparison_singletonBond`** by feeding that equality into the existing reciprocal-scalar cancellation lemma. **`two_injective_tensor_insertion_comparison`** remains open for multiple bonds.
>
> **Blueprint** (`ch13a_peps_ft.tex`) and the **Section 3 paper-gap route** are updated to mirror the new Lean names and to record that the many-bond coefficient-separation step is still outstanding.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1496e89352373a638a34f31b8c579fa689f84084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds completed Lean proofs and documentation only; no runtime or security paths, and the general many-bond theorem remains `sorry`.
> 
> **Overview**
> This PR **formalizes the one-shared-virtual-bond case** of the two-injective tensor comparison (MGRPG+18 §3, `inj_equal_tensors_2`), advancing **#1361** without changing the still-`sorry` many-bond theorem.
> 
> In **`TNLean/PEPS/TwoInjectiveComparison.lean`**, it adds **`matrixUnit`**, proves that inserting that unit on the sole bond makes **`twoBlockInsertedCoeff`** equal the pointwise product **`A₁(…) A₂(…)`**, and proves **`two_injective_tensor_insertion_comparison_singletonBond`** by feeding that equality into the existing reciprocal-scalar cancellation lemma. The import switches to **`Mathlib.Data.Matrix.Basis`** for **`Matrix.single`**.
> 
> **Blueprint** (`ch13a_peps_ft.tex`) and the **Section 3 paper-gap route** are updated to mirror the new Lean names and to record that the many-bond coefficient-separation step remains outstanding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9786629317603c26de226b532a618c657ac0210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->