### PR TITLE
cleanup(Lean): remove zero-consumer orphan declarations

### DIFF
--- a/TNLean/MPS/Core/RepeatedWord.lean
+++ b/TNLean/MPS/Core/RepeatedWord.lean
@@ -27,15 +27,6 @@ lemma evalWord_replicate (A : MPSTensor d D) (i : Fin d) (L : ℕ) :
   | zero => simp
   | succ n ih => rw [List.replicate_succ, evalWord, ih, pow_succ']
 
-/-- Evaluating the concatenation of `L` copies of a word gives a matrix power. -/
-lemma evalWord_flatten_replicate (A : MPSTensor d D) (w : List (Fin d)) (L : ℕ) :
-    evalWord A ((List.replicate L w).flatten) = (evalWord A w) ^ L := by
-  induction L with
-  | zero => simp [List.replicate]
-  | succ n ih =>
-      simp only [List.replicate_succ, List.flatten_cons]
-      rw [evalWord_append, ih, pow_succ']
-
 /-- The MPV of a constant configuration is the trace of a matrix power. -/
 lemma mpv_const_eq_trace_pow (A : MPSTensor d D) (i : Fin d) (L : ℕ) :
     mpv A (fun _ : Fin L => i) = Matrix.trace ((A i) ^ L) := by

--- a/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
+++ b/TNLean/PiAlgebra/FundamentalTheoremComplete.lean
@@ -22,7 +22,6 @@ It also handles the single-block case where `SameMPV₂` directly gives `SameMPV
 * `fundamentalTheorem_multiBlock_decomposition` — auxiliary lemma exposing block permutation
 * `sameMPV₂_single_block` — for `r = 1`, SameMPV₂ gives per-block SameMPV (no PF needed)
 * `fundamentalTheorem_singleBlock_fromMPV₂` — single-block FT from SameMPV₂
-* `fundamentalTheorem_multiBlock_fromSameMPV₂` — from SameMPV₂ and separation data
 * `perBlock_sameMPV_iff_gaugeEquiv` — auxiliary lemma for SameMPV ↔ GaugeEquiv under injectivity
 
 ## References
@@ -129,64 +128,6 @@ theorem fundamentalTheorem_singleBlock_fromMPV₂
 
 end SingleBlockSeparation
 
-/-! ### From `SameMPV₂` to gauges once the block identities are known
-
-The implication used here is
-`SameMPV₂ (⊕_k μ_k A_k) (⊕_k μ_k B_k)` together with
-`∀ k, SameMPV (A k) (B k)`.  The second hypothesis supplies the block
-identities; the conclusions are `∀ k, GaugeEquiv (A k) (B k)`,
-`GaugeEquiv (⊕_k μ_k A_k) (⊕_k μ_k B_k)`, and the product-algebra
-decomposition.
-
-The per-block equality `∀ k, SameMPV (A k) (B k)` is an explicit hypothesis
-here; for `r = 1` it follows from `sameMPV₂_single_block`. -/
-section MultiBlockGaugeEquiv
-
-variable {r : ℕ} {dim : Fin r → ℕ}
-
-/-- Consequences of `SameMPV₂` once the per-block MPV equalities are known.
-
-From `∀ k, SameMPV (A k) (B k)`, injectivity of the `A_k`, and the recorded
-global equality `SameMPV₂ (⊕_k μ_k A_k) (⊕_k μ_k B_k)`, obtain the gauges on
-each block, the gauge for the weighted direct sums, and the product-algebra
-permutation/conjugation decomposition. -/
-lemma fundamentalTheorem_multiBlock_fromSameMPV₂
-    [∀ k, NeZero (dim k)]
-    (μ : Fin r → ℂ)
-    (A B : (k : Fin r) → MPSTensor d (dim k))
-    (hA : ∀ k, IsInjective (A k))
-    (hSame₂ : SameMPV₂ (toTensorFromBlocks μ A) (toTensorFromBlocks μ B))
-    (hSep : ∀ k, SameMPV (A k) (B k)) :
-    (∀ k, GaugeEquiv (A k) (B k)) ∧
-    GaugeEquiv (toTensorFromBlocks μ A) (toTensorFromBlocks μ B) ∧
-    (∃ (σ : Fin r ≃ Fin r) (hDeq : ∀ i, dim (σ i) = dim i)
-       (X : ∀ i, GL (Fin (dim i)) ℂ),
-     ∀ (i : Fin r) (M : Matrix (Fin (dim i)) (Fin (dim i)) ℂ),
-       (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDeq i)))
-         (componentMap (piAlgEquiv A B hA hSep).toRingEquiv σ i M) =
-         (X i : Matrix (Fin (dim i)) (Fin (dim i)) ℂ) * M *
-           ((X i)⁻¹ : GL (Fin (dim i)) ℂ)) := by
-  let _ := hSame₂
-  let hFull := fundamentalTheorem_multiBlock_full μ A B hA hSep
-  exact ⟨hFull.1, hFull.2, piAlgEquiv_decomposition A B hA hSep⟩
-
-/-- Explicit matrices `X_k` from `SameMPV₂` plus the block equalities.
-
-The conclusion is `B_k^i = X_k A_k^i X_k⁻¹` for every block and physical index. -/
-lemma fundamentalTheorem_multiBlock_explicit_fromSameMPV₂
-    (μ : Fin r → ℂ)
-    (A B : (k : Fin r) → MPSTensor d (dim k))
-    (hA : ∀ k, IsInjective (A k))
-    (hSame₂ : SameMPV₂ (toTensorFromBlocks μ A) (toTensorFromBlocks μ B))
-    (hSep : ∀ k, SameMPV (A k) (B k)) :
-    ∃ (X : ∀ k, GL (Fin (dim k)) ℂ),
-    ∀ k i, B k i = (X k : Matrix _ _ ℂ) * A k i *
-      (((X k)⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) := by
-  let _ := hSame₂
-  exact fundamentalTheorem_multiBlock_explicit A B hA hSep
-
-end MultiBlockGaugeEquiv
-
 /-! ### Equivalence: per-block SameMPV ↔ per-block GaugeEquiv (under injectivity) -/
 section Equivalence
 
@@ -204,13 +145,6 @@ lemma perBlock_sameMPV_iff_gaugeEquiv
     (∀ k, SameMPV (A k) (B k)) ↔ (∀ k, GaugeEquiv (A k) (B k)) :=
   ⟨fun hSame k => fundamentalTheorem_singleBlock (hA k) (hSame k),
    fun hGauge k => (hGauge k).sameMPV⟩
-
-/-- Global `SameMPV` follows from per-block `SameMPV` for block-diagonal tensors. -/
-lemma global_sameMPV_of_perBlock
-    (μ : Fin r → ℂ) (A B : (k : Fin r) → MPSTensor d (dim k))
-    (hSame : ∀ k, SameMPV (A k) (B k)) :
-    SameMPV (toTensorFromBlocks μ A) (toTensorFromBlocks μ B) :=
-  sameMPV_toTensorFromBlocks_of_blockSameMPV μ A B hSame
 
 end Equivalence
 


### PR DESCRIPTION
## Summary

Removes zero-consumer orphan Lean declarations surfaced by the post-strict-removal dead-code audit. No mathematical content lost; build green (8745 jobs).

Each deleted declaration was verified to have **zero Lean proof consumers** and **no blueprint `\lean{}` anchor**:

- `MPSTensor.evalWord_flatten_replicate` (`MPS/Core/RepeatedWord.lean`) — its blueprint block was removed in #2232; nothing else used it. The sibling `evalWord_replicate` / `mpv_const_eq_trace_pow` (which are used) stay.
- `MPSTensor.fundamentalTheorem_multiBlock_fromSameMPV₂`, `...explicit_fromSameMPV₂`, `global_sameMPV_of_perBlock` (`PiAlgebra/FundamentalTheoremComplete.lean`) — orphan `SameMPV₂` wrappers; the now-empty section and its module-doc bullet are removed with them.

**Kept** (still live or blueprint-anchored): `fundamentalTheorem_multiBlock_full` / `_explicit` / `_decomposition`, `sameMPV₂_single_block`, `fundamentalTheorem_singleBlock_fromMPV₂`, `perBlock_sameMPV_iff_gaugeEquiv`.

## Verification
- `lake build TNLean`: 8745 jobs green.
- No blueprint reference to any deleted declaration.

## Scope note
Additional removable Lean code identified by the audit is deliberately **not** in this PR:
- Tier 2 (`isIrreducibleTensor_allZero_dim_le_one` + helper; `bilateral_commonPeriod_blocking_tp_primitive_normal` + `StructuralData.lean`) is coupled to ch11b blueprint blocks and will be folded into the ch11b→ch08 merge PR.
- ~10 ch11/SectorDecomposition/PhaseCover zero-consumer decls are tangled with the pending ch11 reorganization and will be revisited after it lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of unreferenced lemmas and doc bullets; no changes to still-used theorems or runtime behavior.
> 
> **Overview**
> Removes **four unused Lean lemmas** and tightens module docs after a dead-code audit. No proof or API surface that other files depend on is changed.
> 
> In **`RepeatedWord.lean`**, deletes `evalWord_flatten_replicate` (flattened replicate words → matrix power). **`evalWord_replicate`** and **`mpv_const_eq_trace_pow`** stay.
> 
> In **`FundamentalTheoremComplete.lean`**, drops the whole **`MultiBlockGaugeEquiv`** section: `fundamentalTheorem_multiBlock_fromSameMPV₂`, `fundamentalTheorem_multiBlock_explicit_fromSameMPV₂`, and **`global_sameMPV_of_perBlock`**. The doc list no longer advertises the `SameMPV₂`→multi-block gauge entry point. **Kept** results (`fundamentalTheorem_multiBlock_full` / `_explicit` / `_decomposition`, single-block `SameMPV₂` lemmas, `perBlock_sameMPV_iff_gaugeEquiv`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db61f83b0cd4d58f861cb21fda6d8458bc2681fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->