### PR TITLE
fix(parent-hamiltonian): require positive normal range length

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -811,47 +811,34 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 /-- Range reduction for normal tensors.
 
 This is the missing hard direction of `chainGroundSpace_eq_mpvSubmodule_normal`:
-for a normal tensor with an `L₀`-block-injective presentation, the reduced
-periodic window constraints `L > L₀` already force a chain ground state to lie
-in the MPV line. -/
+for a normal tensor with a positive `L₀`-block-injective presentation, the
+reduced periodic window constraints `L > L₀` already force a chain ground state
+to lie in the MPV line. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
-    (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀)
+    (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N) :
     chainGroundSpace A L N ≤ mpvSubmodule A N := by
   have hNpos : 0 < N := by omega
-  by_cases hL₀pos : 0 < L₀
-  · intro ψ hψ
-    have hψGS : ψ ∈ groundSpace A N :=
-      chainGroundSpace_le_groundSpace_of_isNBlkInjective hInj hL₀pos hNpos hL hLN hψ
-    rw [groundSpace, LinearMap.mem_range] at hψGS
-    obtain ⟨X, hX⟩ := hψGS
-    haveI : NeZero d := neZero_d_of_isNBlkInjective hInj hL₀pos
-    let η : Fin d := ⟨0, Nat.pos_of_ne_zero (NeZero.ne d)⟩
-    obtain ⟨Ywrap, Ymirror, hWrap, hMirror⟩ :=
-      chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
-        (A := A) hInj hL₀pos hN hL hLN hψ hX.symm
-    have hCompare : ∀ μ : Fin (N - (L₀ + 1)) → Fin d,
-        Ywrap (wrappedMiddleBackground L₀ N η μ) =
-          Ymirror (mirrorMiddleBackground L₀ N η μ) := by
-      intro μ
-      exact wrapped_mirror_witness_agree_of_chainGroundSpace
-        (A := A) hInj hL₀pos hN hL hLN hψ hX.symm Ywrap Ymirror hWrap hMirror η μ
-    rw [← hX]
-    exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
-      (A := A) (L₀ := L₀) (N := N) hInj hL₀pos η Ywrap Ymirror hWrap hMirror hCompare
-  · -- L₀ = 0 case: range reduction is trivial because L₀+1 = 1,
-    -- but we still need the containment.  IsNBlkInjective A 0 is atypical;
-    -- we handle it by using the injective theorem with L=1.
-    have hL₀zero : L₀ = 0 := by omega
-    subst hL₀zero
-    -- When L₀ = 0, the window size is L₀+1 = 1.
-    -- chainGroundSpace A L N ≤ chainGroundSpace A 1 N (by antitone, since 1 ≤ L)
-    -- And chainGroundSpace A 1 N can be handled similarly:
-    -- For range 1, the cyclic windows are single sites, and the constraints
-    -- are handled by the existing machinery.
-    -- This is a degenerate case; we leave it as a sorry for now.
-    sorry
+  intro ψ hψ
+  have hψGS : ψ ∈ groundSpace A N :=
+    chainGroundSpace_le_groundSpace_of_isNBlkInjective hInj hL₀ hNpos hL hLN hψ
+  rw [groundSpace, LinearMap.mem_range] at hψGS
+  obtain ⟨X, hX⟩ := hψGS
+  haveI : NeZero d := neZero_d_of_isNBlkInjective hInj hL₀
+  let η : Fin d := ⟨0, Nat.pos_of_ne_zero (NeZero.ne d)⟩
+  obtain ⟨Ywrap, Ymirror, hWrap, hMirror⟩ :=
+    chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
+      (A := A) hInj hL₀ hN hL hLN hψ hX.symm
+  have hCompare : ∀ μ : Fin (N - (L₀ + 1)) → Fin d,
+      Ywrap (wrappedMiddleBackground L₀ N η μ) =
+        Ymirror (mirrorMiddleBackground L₀ N η μ) := by
+    intro μ
+    exact wrapped_mirror_witness_agree_of_chainGroundSpace
+      (A := A) hInj hL₀ hN hL hLN hψ hX.symm Ywrap Ymirror hWrap hMirror η μ
+  rw [← hX]
+  exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
+    (A := A) (L₀ := L₀) (N := N) hInj hL₀ η Ywrap Ymirror hWrap hMirror hCompare
 
 /-- On a periodic chain, the normal parent-Hamiltonian ground space coincides
 with the span of the MPV with the reduced window `L > L₀` (instead of `2L₀`).
@@ -863,12 +850,12 @@ Section~4.3, lines 2049--2094. -/
 -- TODO(parent-hamiltonian): derive using the normal-form range reduction and
 -- the cyclic-window definition of `chainGroundSpace`.
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
-    (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀)
+    (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N) :
     chainGroundSpace A L N = mpvSubmodule A N := by
   apply le_antisymm
   · exact chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
-      hA hInj hN hL hLN
+      hA hInj hL₀ hN hL hLN
   · intro ψ hψ
     rw [mpvSubmodule, Submodule.mem_span_singleton] at hψ
     obtain ⟨c, rfl⟩ := hψ
@@ -918,7 +905,7 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
   have hNormal : IsNormal A := ⟨L₀, hA⟩
   have hN' : L₀ + 1 ≤ N := by omega
   rw [HasUniqueGroundState,
-    chainGroundSpace_eq_mpvSubmodule_normal hNormal hA (by omega) (by omega) hN]
+    chainGroundSpace_eq_mpvSubmodule_normal hNormal hA hL₀ (by omega) (by omega) hN]
   have hmpv := mpv_ne_zero_of_isNBlkInjective hA hL₀ hN'
   simpa [mpvSubmodule] using finrank_span_singleton (K := ℂ) hmpv
 
@@ -935,7 +922,7 @@ theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {N : ℕ} (hN : L₀ + 1 ≤ N) :
     HasUniqueGroundState (chainGroundSpace A (L₀ + 1) N) := by
   rw [HasUniqueGroundState,
-    chainGroundSpace_eq_mpvSubmodule_normal hA hInj (by omega) (by omega) hN]
+    chainGroundSpace_eq_mpvSubmodule_normal hA hInj hL₀ (by omega) (by omega) hN]
   have hmpv := mpv_ne_zero_of_isNBlkInjective hInj hL₀ hN
   simpa [mpvSubmodule] using finrank_span_singleton (K := ℂ) hmpv
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1314,7 +1314,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{theorem}[Normal-range reduction: containment in the MPV line]
     \label{thm:normal_range_reduction_containment}
     \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction}
-    \notready
+    \leanok
     \uses{def:chain_ground_space, def:mpv_submodule, def:normal,
         def:l_blk_injective, thm:cyclic_normal_open_chain_range_reduction,
         thm:reduced_wrapped_boundary_compatibilities,
@@ -1345,7 +1345,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{theorem}[Chain ground space equals the MPV line in the normal case]%
     \label{thm:chain_ground_space_eq_mpv_normal}
     \lean{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal}
-    \notready
+    \leanok
     \uses{thm:normal_range_reduction_containment, lem:mpv_mem_chain_ground_space,
         def:normal, def:l_blk_injective}
     If $A$ is normal, $D \ge 1$, and $L_0$-block-injective for some

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1319,7 +1319,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         def:l_blk_injective, thm:cyclic_normal_open_chain_range_reduction,
         thm:reduced_wrapped_boundary_compatibilities,
         thm:conditional_normal_range_reduction_witness_comparison}
-    If $A$ is normal, $D \ge 1$, $L_0$-block-injective, with $N \ge 2$ and $L_0 < L \le N$, then
+    If $A$ is normal, $D \ge 1$, and $L_0$-block-injective for some
+    $L_0>0$, with $N \ge 2$ and $L_0 < L \le N$, then
     \[
         \mathcal G_{N,L}(A) \subseteq \spn\bigl\{V^{(N)}(A)\bigr\}.
     \]
@@ -1347,7 +1348,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \notready
     \uses{thm:normal_range_reduction_containment, lem:mpv_mem_chain_ground_space,
         def:normal, def:l_blk_injective}
-    If $A$ is normal, $D \ge 1$, $L_0$-block-injective, with $N \ge 2$ and $L_0 < L \le N$, then
+    If $A$ is normal, $D \ge 1$, and $L_0$-block-injective for some
+    $L_0>0$, with $N \ge 2$ and $L_0 < L \le N$, then
     \[
         \mathcal G_{N,L}(A) = \spn\bigl\{V^{(N)}(A)\bigr\}.
     \]

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -26,7 +26,7 @@ comparison is recorded in \href{https://github.com/LionSR/TNLean/issues/961}{iss
 and the parent-Hamiltonian consequences are recorded in
 \href{https://github.com/LionSR/TNLean/issues/460}{issue \#460}.}
 
-Let $A$ be a normal MPS tensor, and let $L_0$ be its injectivity length: after
+Let $A$ be a normal MPS tensor, and let $L_0>0$ be its injectivity length: after
 blocking $L_0$ consecutive sites, the resulting tensor is injective. The source
 first proves an intersection step for two overlapping local Hamiltonian terms of
 range $L_0+1$. These terms act on sites $1,\ldots,L_0+1$ and
@@ -61,9 +61,10 @@ boundary-closing sentence, and
 \section{The formal statement}
 
 The corresponding formal statement keeps the intended hypotheses. In
-mathematical terms, it assumes that $A$ is normal, that $A$ is injective after blocking
-$L_0$ sites, and that the periodic chain has length $N\ge 2$ with an interaction
-range $L$ satisfying $L_0<L\le N$. The desired conclusion is that the
+mathematical terms, it assumes that $A$ is normal, that $A$ is injective
+after blocking a positive number $L_0$ of sites, and that the periodic
+chain has length $N\ge 2$ with an interaction range $L$ satisfying
+$L_0<L\le N$. The desired conclusion is that the
 periodic-chain ground space is the line spanned by the periodic MPS vector
 $\Omega_N(A)$:
 \[
@@ -73,16 +74,16 @@ In the formal statement this is the equality between the cyclic chain ground spa
 and the MPV, or periodic MPS vector, subspace. The hard inclusion into the MPV
 line is the remaining range-reduction lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:651--660 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:817--841 for
 \path{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
 and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:670--680 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:852--865 for
 \path{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal}. The formal hypotheses
 are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
-\path{2 <= N} and \path{L0 < L <= N}.}
+\path{0 < L0}, \path{2 <= N}, and \path{L0 < L <= N}.}
 
 The blueprint records the same range-reduction target in
-\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1212--1240, under the
+\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1314--1356, under the
 label \texttt{thm:normal\_range\_reduction\_containment}. Its proof sketch
 already separates the open-chain containment from the cyclic boundary comparison,
 which is the same division made by the formal statements below.


### PR DESCRIPTION
## Summary

Closes #1808.

This PR removes the artificial `L₀ = 0` branch from the normal parent-Hamiltonian range-reduction statement.  The range-reduction theorem is now stated for a positive injectivity length `0 < L₀`, matching the surrounding normal parent-Hamiltonian arguments and the already-used positive-length span propagation lemmas.

Concretely, it:

- adds `0 < L₀` to `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` and `chainGroundSpace_eq_mpvSubmodule_normal`;
- deletes the degenerate zero-length proof branch and its `sorry`;
- updates the uniqueness-theorem calls to pass the existing positive-length hypotheses;
- updates the blueprint and the CPGSV21 range-reduction paper-gap note to record that the formal normal range-reduction target uses a positive injectivity length.

The remaining `sorry` in `wrapped_mirror_witness_agree_of_chainGroundSpace` is unchanged and belongs to the separate wrapped-boundary comparison gap tracked in #1475.

## Checks

- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `lake env lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py 2>&1 | tail -n 30` (reports existing baseline sync gaps in later `ch14_parent_hamiltonian.tex` entries)
- `leanblueprint web`
- `leanblueprint pdf`

Both Lean checks emit only the pre-existing warning for the wrapped-boundary `sorry`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hypothesis tightening and proof cleanup on formal statements and documentation; the remaining mathematical gap (`wrapped_mirror_witness_agree`) is unchanged.
> 
> **Overview**
> The normal parent-Hamiltonian **range-reduction** statements now require a **positive** block-injectivity length `0 < L₀`, in line with the rest of the parent-Hamiltonian development and CPGSV21’s injectivity-after-blocking setup.
> 
> In Lean, `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` and `chainGroundSpace_eq_mpvSubmodule_normal` take an explicit `hL₀ : 0 < L₀`; the old `by_cases` on `L₀ = 0` and its unproved branch are removed so the positive case is the only proof path. Uniqueness theorems pass through existing `hL₀` when calling the equality theorem. The blueprint marks the containment and normal equality theorems `\leanok` with updated hypotheses; the CPGSV21 range-reduction gap note records `0 < L₀` and refreshed Lean line references. The `sorry` in `wrapped_mirror_witness_agree_of_chainGroundSpace` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2444b69148fa4e70d8c679c5533ba5b53e7df44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->