### PR TITLE
feat(canonical): derive period removal from QPF

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -351,13 +351,13 @@ theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking
     A hTP hγprim hperiph blocks P φ hPproj hPsum hcyclic hIntertwine hMul hStar hNondeg
     hCornerIrr
 
-/-- Internal QPF package for source-level period removal.
+/-- QPF derivation for period removal.
 
-For an irreducible trace-preserving tensor, the positive adjoint fixed point,
-the primitive peripheral root, and the map-level irreducibility used by
-`exists_cyclic_sector_decomp_after_blocking` are derived from the stated
-source hypotheses.  The public theorem below discards the auxiliary root data;
-the primitive-sector theorem reuses it to avoid repeating the same QPF setup. -/
+For an irreducible trace-preserving tensor, there are a positive period `m`, a
+primitive `m`th root `γ`, and a cyclic-sector decomposition of `A^[m]`.  The
+positive adjoint fixed point and the map-level irreducibility are consequences
+of quantum Perron--Frobenius theory, so the only hypotheses are
+trace-preservation and tensor irreducibility. -/
 private theorem exists_cyclic_sector_decomp_with_peripheral_data_of_TP_of_irreducible
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)
@@ -412,16 +412,17 @@ private theorem exists_cyclic_sector_decomp_with_peripheral_data_of_TP_of_irredu
   exact ⟨m, hne, hm_pos, γ, hγ_prim, hperiph_range, dim, blocks, P, φ, hTP_blocks, hSame,
     hPproj, hPsum, hcyclic, hComm, hTrace, hIntertwine, hMul, hStar, hNondeg⟩
 
-/-- **Source-level period removal by blocking.**
+/-- **Period removal by blocking.**
 
 For an irreducible trace-preserving tensor `A`, the cyclic-sector decomposition
-after period-removing blocking follows from the source-level hypotheses alone:
+after period-removing blocking follows from trace-preservation and tensor
+irreducibility alone:
 the positive adjoint fixed point, primitive peripheral root, and map-level
-irreducibility are derived internally by quantum Perron--Frobenius theory.
+irreducibility are consequences of quantum Perron--Frobenius theory.
 
-This is the formal period-removal statement used in the blueprint theorem
-`thm:cyclic_sector_decomp_after_blocking`; it corresponds to
-arXiv:1606.00608, lines 227--231. -/
+This is the period-removal statement used in the blueprint theorem
+`thm:cyclic_sector_decomp_after_blocking`; it corresponds to arXiv:1606.00608,
+lines 227--231. -/
 theorem exists_cyclic_sector_decomp_after_blocking_of_TP_of_isIrreducibleTensor
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -351,6 +351,118 @@ theorem primitive_and_irreducible_sectorBlocks_of_cyclic_decomp_after_blocking
     A hTP hγprim hperiph blocks P φ hPproj hPsum hcyclic hIntertwine hMul hStar hNondeg
     hCornerIrr
 
+/-- Internal QPF package for source-level period removal.
+
+For an irreducible trace-preserving tensor, the positive adjoint fixed point,
+the primitive peripheral root, and the map-level irreducibility used by
+`exists_cyclic_sector_decomp_after_blocking` are derived from the stated
+source hypotheses.  The public theorem below discards the auxiliary root data;
+the primitive-sector theorem reuses it to avoid repeating the same QPF setup. -/
+private theorem exists_cyclic_sector_decomp_with_peripheral_data_of_TP_of_irreducible
+    {d D : ℕ} [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A) :
+    ∃ (m : ℕ) (_ : NeZero m) (_ : 0 < m) (γ : ℂ),
+      IsPrimitiveRoot γ m ∧
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+        Set.range (fun j : Fin m => γ ^ (j : ℕ)) ∧
+      ∃ (dim : Fin m → ℕ)
+        (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+        (P : Fin m → MatrixAlg D)
+        (φ : (k : Fin m) →
+          Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
+        (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
+        SameMPV₂ (blockTensor A m)
+          (toTensorFromBlocks (d := blockPhysDim d m) (μ := fun _ : Fin m => (1 : ℂ))
+            blocks) ∧
+        (∀ k, IsOrthogonalProjection (P k)) ∧
+        (∑ k : Fin m, P k = 1) ∧
+        (∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) ∧
+        (∀ k (i : Fin (blockPhysDim d m)),
+          P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
+        (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+          mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace) ∧
+        (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
+              (fun i => (blocks k i)ᴴ) X)).1 =
+            transferMap (d := blockPhysDim d m) (D := D)
+              (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1)) ∧
+        (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+        (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          (φ k Xᴴ).1 = ((φ k X).1)ᴴ) ∧
+        (∀ k, dim k ≠ 0) := by
+  obtain ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
+    conjTranspose_kraus_setup A hTP hIrr
+  obtain ⟨m, γ, hm_pos, hγ_prim, hperiph_set⟩ :=
+    PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure _ h_unitalK ρ hρ_pd h_adjfix hIrrK
+  have hperiph_range :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+        Set.range (fun j : Fin m => γ ^ (j : ℕ)) := by
+    rw [hperiph_set]
+    ext x
+    simp [Set.mem_range, eq_comm]
+  let hne : NeZero m := ⟨Nat.ne_of_gt hm_pos⟩
+  haveI : NeZero m := hne
+  obtain ⟨dim, blocks, P, φ, hTP_blocks, hSame, hPproj, hPsum, hcyclic, hComm,
+      hTrace, hIntertwine, hMul, hStar, hNondeg⟩ :=
+    exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim
+      hperiph_range
+  exact ⟨m, hne, hm_pos, γ, hγ_prim, hperiph_range, dim, blocks, P, φ, hTP_blocks, hSame,
+    hPproj, hPsum, hcyclic, hComm, hTrace, hIntertwine, hMul, hStar, hNondeg⟩
+
+/-- **Source-level period removal by blocking.**
+
+For an irreducible trace-preserving tensor `A`, the cyclic-sector decomposition
+after period-removing blocking follows from the source-level hypotheses alone:
+the positive adjoint fixed point, primitive peripheral root, and map-level
+irreducibility are derived internally by quantum Perron--Frobenius theory.
+
+This is the formal period-removal statement used in the blueprint theorem
+`thm:cyclic_sector_decomp_after_blocking`; it corresponds to
+arXiv:1606.00608, lines 227--231. -/
+theorem exists_cyclic_sector_decomp_after_blocking_of_TP_of_isIrreducibleTensor
+    {d D : ℕ} [NeZero D]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A) :
+    ∃ (m : ℕ) (_ : NeZero m) (_ : 0 < m)
+      (dim : Fin m → ℕ)
+      (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+      (P : Fin m → MatrixAlg D)
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
+      (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
+      SameMPV₂ (blockTensor A m)
+        (toTensorFromBlocks (d := blockPhysDim d m) (μ := fun _ : Fin m => (1 : ℂ))
+          blocks) ∧
+      (∀ k, IsOrthogonalProjection (P k)) ∧
+      (∑ k : Fin m, P k = 1) ∧
+      (∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) ∧
+      (∀ k (i : Fin (blockPhysDim d m)),
+        P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
+      (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+        mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := blockPhysDim d m) (D := D)
+            (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1)) ∧
+      (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ) ∧
+      (∀ k, dim k ≠ 0) := by
+  obtain ⟨m, hne, hm_pos, _γ, _hγ_prim, _hperiph, hdecomp⟩ :=
+    exists_cyclic_sector_decomp_with_peripheral_data_of_TP_of_irreducible
+      A hTP hIrr
+  haveI : NeZero m := hne
+  obtain ⟨dim, blocks, P, φ, hTP_blocks, hSame, hPproj, hPsum, hcyclic, hComm,
+    hTrace, hIntertwine, hMul, hStar, hNondeg⟩ := hdecomp
+  exact ⟨m, hne, hm_pos, dim, blocks, P, φ, hTP_blocks, hSame, hPproj, hPsum, hcyclic,
+    hComm, hTrace, hIntertwine, hMul, hStar, hNondeg⟩
+
 /-- **Period removal with primitive, irreducible sectors.**
 
 For an irreducible TP tensor `A`, after blocking by the least common
@@ -376,22 +488,13 @@ theorem exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducible
         (transferMap (d := blockPhysDim d m) (D := dim k) (blocks k))) ∧
       (∀ k, IsIrreducibleTensor (blocks k)) ∧
       (∀ k, 0 < dim k) := by
-  -- Use shared setup to get conjugate Kraus data and the cyclic peripheral structure.
-  obtain ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
-    conjTranspose_kraus_setup A hTP hIrr
-  obtain ⟨m, γ, hm_pos, hγ_prim, hperiph_set⟩ :=
-    PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure _ h_unitalK ρ hρ_pd h_adjfix hIrrK
-  have hperiph_range :
-      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
-        Set.range (fun j : Fin m => γ ^ (j : ℕ)) := by
-    rw [hperiph_set]
-    ext x
-    simp [Set.mem_range, eq_comm]
-  haveI : NeZero m := ⟨Nat.ne_of_gt hm_pos⟩
+  obtain ⟨m, hne, hm_pos, _γ, hγ_prim, hperiph_range, hdecomp⟩ :=
+    exists_cyclic_sector_decomp_with_peripheral_data_of_TP_of_irreducible
+      A hTP hIrr
+  haveI : NeZero m := hne
   obtain ⟨dim, blocks, P, φ, hTP_blocks, hSame, hPproj, hPsum, hcyclic, _hComm,
       _hTrace, hIntertwine, hMul, hStar, hNondeg⟩ :=
-    exists_cyclic_sector_decomp_after_blocking A hTP hIrr ρ hρ_pd h_adjfix hIrrK hγ_prim
-      hperiph_range
+    hdecomp
   have hPrimIrr : ∀ u : Fin m,
       _root_.IsPrimitive (transferMap (d := blockPhysDim d m) (D := dim u) (blocks u)) ∧
         IsIrreducibleTensor (blocks u) :=

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1084,10 +1084,11 @@ map~\cite[Theorem~6.6]{Wolf2012Quantum}.
 
 \begin{theorem}[Period removal by blocking]%
     \label{thm:cyclic_sector_decomp_after_blocking}
-    \notready
-    \uses{def:blocked_tensor}
-    Let $A$ be a left-canonical irreducible tensor of period $m$. Then $A^{[m]}$
-    admits:
+    \lean{MPSTensor.exists_cyclic_sector_decomp_after_blocking_of_TP_of_isIrreducibleTensor}
+    \leanok
+    \uses{def:blocked_tensor, thm:peripheral_cyclic_structure}
+    Let $A$ be a left-canonical irreducible tensor. Then there is a
+    period-removing length $m\ge 1$ such that $A^{[m]}$ admits:
     \begin{enumerate}
         \item left-canonical sector tensors $(C_k)_{k=1}^m$,
         \item orthogonal projections $(P_k)_{k=1}^m$ summing to $\Id$ with
@@ -1104,13 +1105,7 @@ map~\cite[Theorem~6.6]{Wolf2012Quantum}.
     the adjoint transfer map (\cite[Theorem~6.6]{Wolf2012Quantum}).
 \end{theorem}
 
-% Formal status: the checked period-removal bridge currently exposes the
-% positive-definite adjoint fixed point, the primitive root parametrizing the
-% peripheral eigenvalues, and map-level irreducibility as explicit inputs. These
-% data are consequences of the source-level hypotheses through the quantum
-% Perron--Frobenius theorem, and are packaged in the primitive-sector theorem
-% below.
-\begin{proof}
+\begin{proof}\leanok
     The cyclic decomposition of the adjoint transfer map gives projections
     $(P_k)$ with $\E_{A^\dagger}(P_{k+1}) = P_k$. Iterating the cyclic relation
     $m$ times gives $(\E_{A^\dagger})^m(P_k) = P_k$, and the blocked-transfer

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1090,19 +1090,30 @@ map~\cite[Theorem~6.6]{Wolf2012Quantum}.
     Let $A$ be a left-canonical irreducible tensor. Then there is a
     period-removing length $m\ge 1$ such that $A^{[m]}$ admits:
     \begin{enumerate}
-        \item left-canonical sector tensors $(C_k)_{k=1}^m$,
+        \item left-canonical sector tensors $(C_k)_{k=1}^m$ of nonzero bond
+              dimension,
+        \item a unit-weight direct-sum MPV decomposition
+              $A^{[m]} \sim \bigoplus_{k=1}^m C_k$,
         \item orthogonal projections $(P_k)_{k=1}^m$ summing to $\Id$ with
               $\E_{A^\dagger}(P_{k+1}) = P_k$,
+        \item commutation relations
+              $P_k A^{[m]}_i = A^{[m]}_i P_k$ for every blocked letter $i$,
+        \item the sector trace formula
+              $f_{C_k}(\sigma)=
+              \tr(P_k A^{[m]}_{\sigma_1}\cdots A^{[m]}_{\sigma_N})$,
         \item linear isomorphisms onto the compression corners
               $\varphi_k : \MN{\dim C_k} \xrightarrow{\sim} P_k \MN{D} P_k$,
-        \item a direct-sum MPV decomposition
-              $A^{[m]} \sim \bigoplus_{k=1}^m C_k$.
+        \item transfer-intertwining identities
+              $\varphi_k(\E_{C_k^\dagger}(X)) =
+              \E_{(P_kA^{[m]})^\dagger}(\varphi_k(X))$,
+        \item multiplicativity and adjoint compatibility
+              $\varphi_k(XY)=\varphi_k(X)\varphi_k(Y)$ and
+              $\varphi_k(X^\dagger)=\varphi_k(X)^\dagger$.
     \end{enumerate}
-    This is the period-removal step
-    of~\cite[Section~2.3]{Cirac2017MPDO_AnnPhys}: after blocking by $m$, the
-    result admits a unit-weight decomposition with no nontrivial $p$-periodic
-    vectors, the cyclic projections $P_k$ coming from the peripheral spectrum of
-    the adjoint transfer map (\cite[Theorem~6.6]{Wolf2012Quantum}).
+    This is the cyclic-sector part of the period-removal step
+    of~\cite[Section~2.3]{Cirac2017MPDO_AnnPhys}; the projections $P_k$ come
+    from the peripheral spectrum of the adjoint transfer map
+    (\cite[Theorem~6.6]{Wolf2012Quantum}).
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -150,16 +150,18 @@ paper notation both tensors are simply regarded as tensors over words of the
 common blocked length. In the formal theorem, this coordinate identification is
 now derived from the grouped-block cast construction.
 
-The period-removal bridge currently exposes the analytic data used to construct
+The period-removal bridge formerly exposed the analytic data used to construct
 cyclic sectors: a positive-definite fixed point of the adjoint transfer map, the
 primitive root parametrizing the peripheral eigenvalues, and irreducibility of
-the associated completely positive map. The sources do not state these as
-additional hypotheses of the period-removal step; they follow from
-trace-preservation, tensor irreducibility, and the quantum
-Perron--Frobenius theorem. Until this derivation is packaged into the
-source-level period-removal statement, the blueprint records that statement as
-not yet source-faithfully complete and uses the explicit-data theorem only in
-the derived primitive-sector construction.
+the associated completely positive map. These data are now packaged in the
+source-level Lean theorem
+\leanid{MPSTensor.exists\_cyclic\_sector\_decomp\_after\_blocking\_of\_TP\_of\_isIrreducibleTensor},
+which derives them from trace-preservation and tensor irreducibility by the
+quantum Perron--Frobenius theorem. Thus the blueprint period-removal theorem
+records the cyclic-sector decomposition itself as source-faithful. The
+remaining gaps in this note concern the later injectivity refinement, BNT-cover
+comparison, zero-tail bookkeeping, and coordinate transports for the final
+common-sector families.
 
 The zero-tail condition has a similar origin. The source definition of matrix
 product vectors is for positive lengths, and zero blocks are invisible there.
@@ -190,9 +192,11 @@ paper-level inputs and formal coordinate transports made visible.
 This note records a proof gap in the present Lean development rather than a
 source error. The cited papers compress the canonical-form reduction, blocking,
 BNT matching, and injectivity refinements in the usual paper notation. The Lean
-development should keep the theorem conditional until the injectivity
-refinement, the BNT-cover comparison for the produced sectors, and the zero-tail
-and weight transports have been proved for the same final common-sector data.
+development should keep the full blocked-normal-form comparison boundary
+conditional until the injectivity refinement, the BNT-cover comparison for the
+produced sectors, and the zero-tail and weight transports have been proved for
+the same final common-sector data. The analytic period-removal input itself no
+longer needs to be listed among the open source-faithfulness gaps.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
+++ b/docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex
@@ -153,7 +153,7 @@ now derived from the grouped-block cast construction.
 The period-removal bridge formerly exposed the analytic data used to construct
 cyclic sectors: a positive-definite fixed point of the adjoint transfer map, the
 primitive root parametrizing the peripheral eigenvalues, and irreducibility of
-the associated completely positive map. These data are now packaged in the
+the associated completely positive map. These quantities are now derived in the
 source-level Lean theorem
 \leanid{MPSTensor.exists\_cyclic\_sector\_decomp\_after\_blocking\_of\_TP\_of\_isIrreducibleTensor},
 which derives them from trace-preservation and tensor irreducibility by the


### PR DESCRIPTION
## Summary

- prove `MPSTensor.exists_cyclic_sector_decomp_after_blocking_of_TP_of_isIrreducibleTensor`, deriving the adjoint fixed point, the peripheral primitive root, and map-level irreducibility from trace preservation and tensor irreducibility
- reuse the same QPF derivation in the primitive-sector theorem
- restore blueprint `thm:cyclic_sector_decomp_after_blocking` to `\leanok` and update the paper-gap note so the remaining gap is only the later blocked-normal-form comparison boundary

Closes #2238.
Closes #2240.

## Checks

- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorDecomposition`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py` (reports only the existing `ch14_parent_hamiltonian.tex` sync issues)
- `git diff --check`
- `leanblueprint web`
- `leanblueprint pdf`
- `leanblueprint checkdecls` could not be completed locally because `blueprint/lean_decls` is absent in this worktree; the checker executable built and then reported the missing declaration list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the canonical-form period-removal proof chain in Lean and blueprint linkage; changes are mostly packaging and documentation, but errors here would affect downstream blocking and sector comparison arguments.
> 
> **Overview**
> Derives **period removal by blocking** from trace preservation and tensor irreducibility alone, instead of treating the adjoint fixed point, peripheral primitive root, and map irreducibility as separate hypotheses.
> 
> In Lean, a private QPF-packaging lemma (`exists_cyclic_sector_decomp_with_peripheral_data_of_TP_of_irreducible`) centralizes the Kraus/adjoint setup and peripheral cyclic structure; the new theorem `exists_cyclic_sector_decomp_after_blocking_of_TP_of_isIrreducibleTensor` exposes the cyclic-sector decomposition with only TP + irreducibility, and the primitive-sector existence theorem reuses that helper instead of duplicating the analytic chain.
> 
> Blueprint **`thm:cyclic_sector_decomp_after_blocking`** is restored to `\leanok`, wired to the new declaration, and the statement is expanded (nonzero sectors, direct-sum MPV, projections, commutation, trace and intertwining identities). The conditional after-blocking paper-gap note is updated so analytic period-removal is closed in Lean; open work is framed as later injectivity, BNT-cover, zero-tail, and coordinate transport for the full comparison boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d464cb369d58494aa3bb0d2184126d0cb9c7c66a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->