### PR TITLE
doc(canonical): record PGVWC07 final convention

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -38,33 +38,32 @@ Note: the Appendix-A CFII story is genuinely two-step:
 first a generally non-unitary TP similarity from the adjoint Perron--Frobenius eigenvector,
 then a unitary diagonalization **within** that TP gauge.
 
-What is **not** yet proved here:
+The reductions below are composed with finite-family weight normalization to
+obtain the arbitrary-input positive-length PGVWC07 canonical form.  After a
+positive global rescaling, the conclusion gives positive weights, unital blocks,
+diagonal full-rank dual fixed points, scalar transfer-map fixed points, and the
+bond-dimension bound.  If every positive-length MPV coefficient vanishes, the
+nonzero-block family is empty.  The remaining all-zero direct summand $A_0$
+separately records the length-zero dimension identity $D = D_0 + \sum_k D_k$.
 
-* Thread the TP-gauge and periodicity theorems through the irreducible block decomposition while
-  handling possible zero blocks exactly under `SameMPV₂` (which remembers the `N = 0` sector).
-* Resolve the post-blocking cyclic-sector bookkeeping and normalize the surviving nonzero weights
-  so that the block family is ordered non-increasingly by modulus.
-* Pass these hypotheses to the block-injective / `IsCanonicalForm` predicates needed for the
-  fundamental-theorem results.
+The later Fundamental-Theorem reductions--TP gauge, period removal, common
+blocking, and normal/BNT predicates--are subsequent consequences of the
+canonical-form outputs, not missing conclusions of PGVWC07 Theorem
+Th:TIcanonical.
 
-Accordingly, this file gives reduction lemmas and explicit conditional statements,
-**not** a complete canonical-form existence theorem for arbitrary input tensors.
-Relative to Pérez-García, Verstraete, Wolf, and Cirac, Theorem
-Th:TIcanonical, lines 742–763, the missing source-level conclusion is the
-single theorem that starts from an arbitrary translation-invariant
-representation and simultaneously constructs positive weights, unital blocks,
-diagonal full-rank dual fixed points, uniqueness of the identity fixed point for
-each block transfer map, and the stated bond-dimension bound. The audit
-boundary is recorded in
-`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
+Maintainer note: the blueprint cites
+`MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` in
+`TNLean.MPS.CanonicalForm.NormalReduction.WeightNormalization`; the zero-tail
+dimension identity is recorded by
+`MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
+in `TNLean.MPS.CanonicalForm.NormalReduction.TPGauge`.  The audit boundary is
+recorded in `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
 For Pérez-García, Verstraete, Wolf, and Cirac, the faithful proof order is the
 one in `Papers/quant-ph_0608197/MPSarchive.tex`: lines 765–770 for
 spectral-radius normalization and the full-rank fixed-point gauge, lines
 771–815 for deriving the invariant support from a singular positive fixed point
 and then splitting the trace, lines 816–826 for iteration and non-scalar
 fixed-point splitting, and lines 827–832 for dual fixed-point diagonalization.
-In this file the remaining problem is the source-level composition over the
-whole recursive decomposition, starting from an arbitrary representation.
 
 ## External input — Quantum Wielandt strong irreducibility ⇒ full Kraus rank
 
@@ -323,7 +322,7 @@ theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
     with nonzeroSet_def
   set zeroSet : Finset (Fin r₀) := Finset.univ.filter (fun k => ¬ isNonzero k)
     with zeroSet_def
-  -- The zero tail dimension is the sum of bond dimensions of zero blocks.
+  -- The all-zero summand dimension is the sum of bond dimensions of zero blocks.
   set zeroTailDim : ℕ := zeroSet.sum dim₀ with zeroTailDim_def
   -- Reindex nonzero blocks via a bijection with `Fin nonzeroSet.card`.
   set nonzeroEquiv : nonzeroSet ≃ Fin nonzeroSet.card := nonzeroSet.equivFin
@@ -334,7 +333,7 @@ theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
   set newBlocks : (k : Fin r) → MPSTensor d (dim k) :=
     fun j => blocks₀ (nonzeroEquiv.symm j).1 with newBlocks_def
   -- The MPV of `A` decomposes into the nonzero-block direct sum plus the
-  -- length-zero zero-tail contribution.
+  -- length-zero all-zero summand contribution.
   have key : ∀ (N : ℕ) (σ : Fin N → Fin d),
       mpv A σ =
         mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ +

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -241,7 +241,7 @@ The earlier existence path now has the following formal pieces.
           applies the preceding single-block theorem to a prepared family of
           nonzero irreducible summands with unit weights.  It constructs the
           positive spectral-radius weights, unital block representatives,
-          scalar fixed-point endpoints, and diagonal positive-definite dual
+          scalar transfer-map fixed points, and diagonal positive-definite dual
           fixed points block by block, while preserving the weighted MPV
           family.  This closes the blockwise assembly step after the
           irreducible summands have already been obtained.  It is still not
@@ -256,7 +256,7 @@ The earlier existence path now has the following formal pieces.
           PGVWC07 theorem.  Starting from an arbitrary tensor, it retains the
           all-zero summands as one zero block and puts the nonzero part into
           the unital orientation, with positive spectral-radius weights,
-          scalar fixed-point endpoints, and diagonal positive-definite dual
+          scalar transfer-map fixed points, and diagonal positive-definite dual
           fixed points.  This removes the prepared-family hypothesis from the
           blockwise statement while still keeping the zero-block contribution
           explicit in the finite-ring MPV identity.  It is still not the full
@@ -289,8 +289,8 @@ The earlier existence path now has the following formal pieces.
           \path|MPSTensor.exists_pgvwc07_positiveLengthWitness| record the
           preceding positive-length theorem as a single package of data.  The
           fields contain the nonzero unital blocks, positive real weights,
-          diagonal positive-definite dual fixed points, scalar fixed-point
-          conclusions, positive block dimensions, positive-length MPV equality,
+          diagonal positive-definite dual fixed points, scalar transfer-map
+          fixed-point conclusions, positive block dimensions, positive-length MPV equality,
           and the total bond-dimension bound.  Nonvanishing of the weights is
           a direct consequence of their positive-real form, so nonvanishing is
           not an additional field of the witness.  This is not a new proof
@@ -333,7 +333,7 @@ The earlier existence path now has the following formal pieces.
           nonemptiness lemma and the projective weight-normalization theorem.
           Under the explicit nonzero positive-length MPV hypothesis, it gives
           nonempty normalized PGVWC07 block data with \(|\nu_k|\leq 1\),
-          equality for one block, unital blocks, scalar fixed-point endpoints,
+          equality for one block, unital blocks, scalar transfer-map fixed points,
           diagonal positive-definite dual fixed points, the nonzero projective
           MPV relation, and the bound \(\sum_k D_k\leq D\).
 
@@ -372,14 +372,13 @@ The earlier existence path now has the following formal pieces.
           nonempty ring, and \(\sum_k D_k\leq D\).
 
     \item
-          \path|MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail|
-          records the complementary explicit zero-block convention.  It keeps
-          the zero block from the arbitrary-input decomposition, normalizes the
-          positive nonzero-block weights by their maximum when the nonzero
-          family is nonempty, and proves exact MPV equality at every finite
-          length after the same positive global rescaling.  For positive
-          lengths the zero block contributes zero; at length zero the equality
-          is the dimension identity \(D_0+\sum_kD_k=D\).
+          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound|
+          records the complementary explicit all-zero direct-summand convention before the
+          final finite-family weight normalization.  It keeps the all-zero summand
+          dimension from the arbitrary-input decomposition, proves
+          positive-length agreement with the weighted nonzero blocks, and
+          records the length-zero dimension identity
+          \(D_0+\sum_kD_k=D\), together with the bond-dimension bound.
 
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
@@ -438,38 +437,29 @@ form directly from an arbitrary translation-invariant MPS representation.
 
 \section{Current conclusion}
 
-A faithful formalization of PGVWC07
-Theorem~\texttt{Th:TIcanonical} should start with an arbitrary
-translation-invariant MPS representation and construct the block
-decomposition, the positive weights, the unital block gauge, the diagonal
-full-rank fixed points, and the uniqueness of the identity fixed point,
-while preserving the stated bond-dimension bound. The conditional primitive,
-peripheral-primitive, and normal-canonical-form reductions can then be used
-only after the source argument has produced the corresponding hypotheses or
-after a later theorem has explicitly assumed them.
+The formalization now has a theorem cited for PGVWC07
+Theorem~\texttt{Th:TIcanonical}, in the positive-length convention used by the
+blueprint:
+\path|MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty|.
+It starts from an arbitrary translation-invariant MPS representation.  After a
+positive global rescaling, it constructs a finite family of positive weights,
+unital blocks, diagonal full-rank dual fixed points, scalar transfer-map fixed
+points, and the bond-dimension bound.  The nonzero-block family is allowed to
+be empty exactly in the case where every positive-length MPV coefficient
+vanishes.
 
-This is a composition gap, not a mathematical obstruction.  The formal proof
-has to compose the source steps in order: Perron--Frobenius fixed-point existence
-and spectral-radius normalization; support projection from a singular positive
-fixed point; finite-ring trace splitting over the support and orthogonal
-support; dimension-decreasing iteration, including the split forced by a
-non-scalar fixed point; and, finally, the dual-map fixed point and unitary
-diagonalization.  None of these steps may be replaced by a theorem that starts
-from an already prepared primitive or trace-preserving block family, because
-those hypotheses are not present in Theorem~\texttt{Th:TIcanonical}.
+The explicit zero-block/length-zero bookkeeping is recorded earlier by
+\path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound|.
+It keeps the all-zero summand dimension, gives positive-length agreement with the
+weighted nonzero blocks, and proves \(D_0+\sum_kD_k=D\), together with the
+bond-dimension bound.  This is the companion length-zero convention before the
+final finite-family weight normalization, while the blueprint cites the
+positive-length theorem as the primary statement.
 
-At the present stage, the block construction, nonempty-ring exact-MPV witness,
-finite-family weight normalization, and projective interpretation of the global
-scalar factor are available.  These pieces have been composed into the
-arbitrary-input exact positive-length theorem, allowing the nonzero-block
-family to be empty exactly in the branch where every positive-length
-coefficient vanishes.  This is the statement promoted in the blueprint as the
-formal positive-length version of Theorem~\texttt{Th:TIcanonical}.  The
-explicit zero-block/length-zero formulation is also available: after the same
-positive global rescaling, the zero block and the normalized weighted nonzero
-blocks reproduce the MPV coefficients at every finite length, with
-\(D_0+\sum_kD_k=D\).  It is kept as the companion bookkeeping convention rather
-than as the primary existence theorem.
+The remaining conditional primitive, peripheral-primitive, and
+normal-canonical-form reductions are later consequences used only after their
+extra hypotheses have been established.  They are not alternate citations for
+Theorem~\texttt{Th:TIcanonical}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- Update the `Existence.lean` overview and the PGVWC07 paper-gap conclusion so they agree with the current blueprint citation: `thm:pgvwc07_ti_canonical_form` is represented by `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`.
- Record the zero-block theorem as the length-zero companion convention, not as an unresolved source theorem.
- Keep primitive, peripheral-primitive, and normal-canonical-form reductions as later conditional consequences rather than alternate citations for PGVWC07 `Th:TIcanonical`.

Closes #1857.

## Checks

- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --changed-files TNLean/MPS/CanonicalForm/Existence.lean docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex --diff-base origin/main`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error pgvwc07_ti_canonical_form_scope.tex`

Lean build was not run locally for this documentation-only change; the fresh worktree would have fetched dependencies, so CI is the build check here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX-only updates; no Lean proofs or runtime behavior change.
> 
> **Overview**
> This PR **realigns documentation** with the current blueprint: PGVWC07 `Th:TIcanonical` is described as **proved** via `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`, not as an open composition gap.
> 
> In **`Existence.lean`**, the module overview **drops** the long “what is not yet proved” list and **adds** maintainer pointers to `WeightNormalization` and `TPGauge`, plus wording that Fundamental-Theorem steps are **downstream** of canonical-form outputs. Inline comments **rename** “zero tail” to **all-zero summand** where the zero-block dimension is discussed.
> 
> In **`pgvwc07_ti_canonical_form_scope.tex`**, the proof-path audit **standardizes** “scalar fixed-point” to **scalar transfer-map fixed points**, **replaces** the audit entry for `exists_pgvwc07_normalized_exact_form_after_rescaling_with_zeroTail` with **`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`** as the length-zero companion, and **rewrites** “Current conclusion” from a missing-theorem / composition-gap narrative to the **positive-length primary theorem** plus the **bond-dimension / \(D_0+\sum D_k=D\)** bookkeeping theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ee626cf6eae00adca89d409a6a837fdb22f4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->