### PR TITLE
refactor(sector-bnt): name per-sector unit-weight hypothesis

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -84,6 +84,22 @@ namespace MPSTensor
 variable {d : ℕ}
 
 /--
+**Per-sector unit-weight hypothesis.**
+
+Every BNT basis sector contains at least one copy whose raw scalar weight has
+modulus one.  This is the theorem-level strengthening of the global
+normalization field `IsBNTCanonicalForm.weight_unit_exists` used in the current
+full-basis matching and global-gauge statements.
+
+CPSV16 Section II.C, line 246 gives a global unit-modulus witness among the
+two-layer weights.  CPSV16 Appendix MPV proof, line 1182 uses non-decay sector
+by sector, so the SectorBNT full-basis theorems keep this stronger condition as
+an explicit hypothesis rather than as a field of `IsBNTCanonicalForm`.
+-/
+abbrev SectorDecomposition.HasPerSectorUnitWeight (P : SectorDecomposition d) : Prop :=
+  ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1
+
+/--
 **BNT canonical form (core predicate `IsBNTCanonicalForm`).**
 
 Given `P : SectorDecomposition d`, this captures the minimal CPSV16/CPSV21

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -253,8 +253,8 @@ gives only one global unit-weight witness. See
 theorem ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -314,8 +314,8 @@ gives only one global unit-weight witness. See
 theorem ft_sector_bnt_proportional_global_gauge_of_coeff_identity
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -373,8 +373,8 @@ copy permutations and weight identities. -/
 theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -442,8 +442,8 @@ theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
 theorem ft_sector_bnt_equal_matched_copy_weight_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -470,8 +470,8 @@ gauge phase and permuting the copies. -/
 theorem ft_sector_bnt_equal_sector_dataPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount),
       (∀ k, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -503,8 +503,8 @@ theorem ft_sector_bnt_equal_sector_dataPos
 theorem ft_sector_bnt_equal_sector_data
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount),
       (∀ k, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -538,8 +538,8 @@ Appendix MPV proof witness rather than an opaque existential. -/
 theorem ft_sector_bnt_equal_global_gaugePos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -597,8 +597,8 @@ gives only one global unit-weight witness. See
 theorem ft_sector_bnt_equal_global_gauge
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -96,8 +96,8 @@ matching, copy-weight comparison, and global-gauge construction used here. -/
 theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -433,8 +433,8 @@ CPSV16 §II.C lines 354–361. -/
 theorem ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
       ∀ i : Fin d,
@@ -548,8 +548,8 @@ gives only one global unit-weight witness. See
 theorem ft_sector_bnt_equal_mps_gaugeEquiv_literal
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
       ∀ i : Fin d,

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -43,7 +43,7 @@ line 1182 (matching). -/
 theorem forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
     ∀ k : Fin Q.basisCount,
       ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
@@ -83,8 +83,8 @@ Paper anchor: CPSV16 Appendix MPV proof, line 1182, the symmetry step
 theorem bijective_match_of_eventuallyProportional
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
     ∃ β : Fin Q.basisCount ≃ Fin P.basisCount,
       ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -219,8 +219,8 @@ gives only one global unit-weight witness. See
 theorem ft_sector_bnt_proportional_sector_match_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -101,7 +101,7 @@ Definition 4.2 lines 1846–1850, and the two-layer display at lines 1864–1884
 theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∀ k : Fin Q.basisCount, ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
       GaugePhaseEquiv
@@ -137,7 +137,7 @@ Section II.C, line 246 gives only one global unit-weight witness. See
 theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∀ k : Fin Q.basisCount, ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
       GaugePhaseEquiv
@@ -171,8 +171,8 @@ hypotheses here (CPSV16 §II.C line 246 records only the global unit witness). -
 theorem bijective_match_of_sameMPVPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ β : Fin Q.basisCount ≃ Fin P.basisCount,
       ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -280,8 +280,8 @@ gives only one global unit-weight witness. See
 theorem bijective_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
+    (hUnitP : P.HasPerSectorUnitWeight)
+    (hUnitQ : Q.HasPerSectorUnitWeight)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ β : Fin Q.basisCount ≃ Fin P.basisCount,
       ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -686,6 +686,24 @@ Chapter~\ref{ch:ft_proof}.
     not derivable from the per-block normality hypotheses alone.
 \end{definition}
 
+\begin{definition}[Per-sector unit-weight hypothesis]%
+    \label{def:sector_bnt_per_sector_unit_weight}
+    \lean{MPSTensor.SectorDecomposition.HasPerSectorUnitWeight}
+    \leanok
+    \uses{def:sector_weight_data}
+    For a sector decomposition $P$, this condition says that every BNT basis
+    sector contains at least one copy with unit-modulus raw weight:
+    \[
+        \forall j\in J(P),\ \exists q\in\{1,\ldots,r_j\},
+        \qquad |\mu_{j,q}|=1 .
+    \]
+    It is stronger than the global line-246 normalization in
+    Definition~\ref{def:sector_bnt_cf}, which supplies only one unit-modulus
+    weight among all pairs $(j,q)$. The full-basis matching theorems below
+    take this as an explicit theorem-level hypothesis, because their non-decay
+    argument is applied separately in each sector.
+\end{definition}
+
 \subsection{Prepared-block construction of BNT canonical forms}%
 \label{subsec:paperbnt_supplier}
 
@@ -1242,8 +1260,9 @@ a single $\forall k, \exists j$ statement on the original $(P, Q)$,
 under the explicit hypothesis that every $Q$-side sector carries a
 unit-modulus copy weight.
 
-The per-sector unit-weight hypothesis is the formal version used in the
-current full-basis theorem:
+The per-sector unit-weight hypothesis
+(Definition~\ref{def:sector_bnt_per_sector_unit_weight}) is the formal version
+used in the current full-basis theorem:
 \cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv} records the
 modulus-one hypothesis as a single \emph{global} existential over the
 two-layer $(j, q)$ index of the BNT display, whereas the statement below


### PR DESCRIPTION
## Summary

- Add `SectorDecomposition.HasPerSectorUnitWeight` for the per-sector unit-copy condition used in the SectorBNT full-basis matching and global-gauge statements.
- Use the named predicate in `StrongMatch`, `ProportionalMatch`, `Fundamental`, and `FundamentalCoord` theorem signatures.
- Add the corresponding Chapter 10 blueprint definition.

This is a single-source-of-truth cleanup for the existing stronger theorem-level hypothesis; it does not change the mathematical content of the proofs.

Refs #1685, #1749.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.FundamentalCoord`
- `lake build`
- `git diff --check`
- `cd blueprint && leanblueprint web` (local plasTeX package warnings; render completed)
- `cd blueprint && leanblueprint pdf` (completed; existing overfull-box warnings)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && python3 scripts/blueprint_lean_sync.py --root . --ci` (reports existing off-scope missing declarations; the new SectorBNT declaration is present)
- `lake exe checkdecls blueprint/lean_decls` (fails on existing off-scope missing declarations; the new SectorBNT declaration is not among them)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and API refactor only; theorem statements are definitionally the same hypotheses with no changes to `IsBNTCanonicalForm` or proof scripts.
> 
> **Overview**
> Introduces **`SectorDecomposition.HasPerSectorUnitWeight`** as the named form of the existing theorem-level condition that every BNT sector has a unit-modulus copy weight (stronger than the global line-246 witness in `IsBNTCanonicalForm`).
> 
> **SectorBNT** matching and global-gauge theorems in `StrongMatch`, `ProportionalMatch`, `Fundamental`, and `FundamentalCoord` now take `hUnitP : P.HasPerSectorUnitWeight` and `hUnitQ : Q.HasPerSectorUnitWeight` instead of repeating the same `∀ j, ∃ q, ‖…‖ = 1` quantifiers.
> 
> Chapter 10 blueprint adds **Definition** `def:sector_bnt_per_sector_unit_weight` linked to the Lean abbrev and clarifies that full-basis theorems use this hypothesis explicitly.
> 
> No change to proof bodies or to what `IsBNTCanonicalForm` requires—only a single source of truth for the per-sector unit-weight hypothesis and aligned docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3351b64ddc2df12546059ded4846da9c30a8461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->