### PR TITLE
feat(MPS/FT): remove per-sector unit-modulus restriction from the equal-MPV Fundamental Theorem

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ExactMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ExactMatch.lean
@@ -1,0 +1,408 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.FundamentalTheorem.SectorBNT.DominantMatch
+import TNLean.MPS.SharedInfra.GaugePhase
+
+/-!
+# Exact block matching for BNT canonical forms
+
+This file proves the exact, coefficient-comparison version of the single-block
+matching statement.  Unlike `exists_block_match_of_sameMPVPos`, the proof does
+not use a per-sector unit-modulus hypothesis and never derives a coefficient
+limit.  The contradiction is exact eventual vanishing of the selected sector
+coefficient, contradicting `IsBNTCanonicalForm.coeff_not_eventually_zero`.
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- Re-index a sum over a finite family through a finite map by collecting the
+coefficients in the fibres of the map. -/
+private lemma sum_fiber_smul
+    {ι κ V : Type*} [Fintype ι] [Fintype κ] [DecidableEq κ]
+    [AddCommMonoid V] [Module ℂ V]
+    (φ : ι → κ) (a : ι → ℂ) (v : κ → V) :
+    (∑ i : ι, a i • v (φ i)) =
+      ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
+  classical
+  calc
+    (∑ i : ι, a i • v (φ i))
+        = ∑ i : ι, ∑ k : κ, (if φ i = k then a i else 0) • v k := by
+          refine Finset.sum_congr rfl ?_
+          intro i _
+          have hinner :
+              (∑ k : κ, (if φ i = k then a i else 0) • v k)
+                = a i • v (φ i) := by
+            simp [ite_smul, eq_comm]
+          exact hinner.symm
+    _ = ∑ k : κ, ∑ i : ι, (if φ i = k then a i else 0) • v k := by
+          rw [Finset.sum_comm]
+    _ = ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
+          refine Finset.sum_congr rfl ?_
+          intro k _
+          rw [Finset.sum_smul]
+
+/-- If the overlap of two irreducible normalized BNT blocks does not decay,
+then the left MPV state is an exact scalar multiple of the right MPV state at
+every length. -/
+private lemma exists_state_scalar_of_nondecaying_overlap
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    {j : Fin P.basisCount} {k : Fin Q.basisCount}
+    (hnd : ¬ Tendsto (fun N : ℕ =>
+      mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0)) :
+    ∃ α : ℕ → ℂ, ∀ N : ℕ,
+      mpvState (d := d) (P.basis j) N =
+        α N • mpvState (d := d) (Q.basis k) N := by
+  classical
+  haveI hjdim : NeZero (P.basisDim j) := ⟨(hP.basis_dim_pos j).ne'⟩
+  haveI hkdim : NeZero (Q.basisDim k) := ⟨(hQ.basis_dim_pos k).ne'⟩
+  have hDim : P.basisDim j = Q.basisDim k := by
+    by_contra hne
+    exact hnd <|
+      mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP
+        (P.basis j) (Q.basis k)
+        (hP.basis_irreducible j) (hQ.basis_irreducible k)
+        (hP.basis_left_canonical j) (hQ.basis_left_canonical k)
+        hne
+  have hGPE :
+      GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) hDim) (P.basis j)) (Q.basis k) := by
+    by_contra hNot
+    exact hnd <|
+      mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP
+        (hdim := hDim) (A := P.basis j) (B := Q.basis k)
+        (hA_irr := hP.basis_irreducible j)
+        (hB_irr := hQ.basis_irreducible k)
+        (hA_norm := hP.basis_left_canonical j)
+        (hB_norm := hQ.basis_left_canonical k)
+        (hNot := hNot)
+  obtain ⟨X, ζ, hζ, hConj⟩ := hGPE
+  refine ⟨fun N : ℕ => (ζ ^ N)⁻¹, ?_⟩
+  intro N
+  apply PiLp.ext
+  intro σ
+  have hQ_mpv :
+      mpv (Q.basis k) σ = ζ ^ N * mpv (P.basis j) σ := by
+    rw [mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congr_arg (MPSTensor d) hDim) (P.basis j))
+      (B := Q.basis k) X ζ hConj N σ,
+      mpv_cast_dim hDim (P.basis j) N σ]
+  have hζN : ζ ^ N ≠ 0 := pow_ne_zero N hζ
+  simp only [mpvState_apply]
+  calc
+    mpv (P.basis j) σ = (ζ ^ N)⁻¹ * (ζ ^ N * mpv (P.basis j) σ) := by
+      rw [inv_mul_cancel_left₀ hζN]
+    _ = (ζ ^ N)⁻¹ * mpv (Q.basis k) σ := by
+      rw [← hQ_mpv]
+
+/-- Eventual linear independence for the family consisting of the `P`-blocks
+whose indices lie in a finset `T`, together with all `Q`-blocks, assuming all
+`T`-to-`Q` overlaps decay. -/
+private lemma restricted_combined_family_eventually_li
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (T : Finset (Fin P.basisCount))
+    (hTQ : ∀ (j : Fin P.basisCount), j ∈ T → ∀ k : Fin Q.basisCount,
+      Tendsto (fun N : ℕ =>
+        mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0)) :
+    ∀ᶠ N in atTop,
+      LinearIndependent ℂ
+        (Sum.elim
+          (fun j : {j : Fin P.basisCount // j ∈ T} =>
+            mpvState (d := d) (P.basis j.1) N)
+          (fun k : Fin Q.basisCount =>
+            mpvState (d := d) (Q.basis k) N)) := by
+  classical
+  let C : (x : Sum {j : Fin P.basisCount // j ∈ T} (Fin Q.basisCount)) →
+      MPSTensor d
+        (Sum.elim (fun j : {j : Fin P.basisCount // j ∈ T} => P.basisDim j.1)
+          (fun k : Fin Q.basisCount => Q.basisDim k) x) :=
+    Sum.rec
+      (motive := fun x => MPSTensor d
+        (Sum.elim (fun j : {j : Fin P.basisCount // j ∈ T} => P.basisDim j.1)
+          (fun k : Fin Q.basisCount => Q.basisDim k) x))
+      (fun j => P.basis j.1) (fun k => Q.basis k)
+  have h_self : ∀ x,
+      Tendsto (fun N : ℕ => mpvOverlap (d := d) (C x) (C x) N) atTop
+        (𝓝 (1 : ℂ)) := by
+    intro x
+    cases x with
+    | inl j => simpa [C] using hP.basis_normalized_self_overlap j.1
+    | inr k => simpa [C] using hQ.basis_normalized_self_overlap k
+  have h_cross : ∀ x y, x ≠ y →
+      Tendsto (fun N : ℕ => mpvOverlap (d := d) (C x) (C y) N) atTop
+        (𝓝 (0 : ℂ)) := by
+    intro x y hxy
+    cases x with
+    | inl i =>
+        cases y with
+        | inl j =>
+            have hij : i.1 ≠ j.1 := by
+              intro hval
+              apply hxy
+              exact congrArg Sum.inl (Subtype.ext hval)
+            simpa [C] using hP.cross_overlap_basis_tendsto_zero hij
+        | inr k =>
+            simpa [C] using hTQ i.1 i.2 k
+    | inr k =>
+        cases y with
+        | inl i =>
+            simpa [C] using
+              (tendsto_mpvOverlap_zero_swap (d := d) (A := P.basis i.1)
+                (B := Q.basis k) (N := id) (hTQ i.1 i.2 k))
+        | inr l =>
+            have hkl : k ≠ l := by
+              intro hkl
+              apply hxy
+              simp [hkl]
+            simpa [C] using hQ.cross_overlap_basis_tendsto_zero hkl
+  have hLI :=
+    eventually_linearIndependent_of_finite_overlap_tendsto_orthonormal C h_self h_cross
+  refine hLI.mono ?_
+  intro N hN
+  have key :
+      (fun x : Sum {j : Fin P.basisCount // j ∈ T} (Fin Q.basisCount) =>
+        mpvState (d := d) (C x) N) =
+        Sum.elim
+          (fun j : {j : Fin P.basisCount // j ∈ T} =>
+            mpvState (d := d) (P.basis j.1) N)
+          (fun k : Fin Q.basisCount =>
+            mpvState (d := d) (Q.basis k) N) := by
+    funext x
+    cases x <;> rfl
+  rw [← key]
+  exact hN
+
+/-- Exact non-decaying-overlap extraction at a fixed `P`-sector.  The proof is
+by exact finite-dimensional coefficient comparison, not by a coefficient limit. -/
+private lemma exists_nondecaying_overlap_exact
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (j₀ : Fin P.basisCount)
+    (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
+    ∃ k₀ : Fin Q.basisCount,
+      ¬ Tendsto (fun N : ℕ =>
+        mpvOverlap (d := d) (P.basis j₀) (Q.basis k₀) N) atTop (𝓝 0) := by
+  classical
+  by_contra hNo
+  push Not at hNo
+  let T : Finset (Fin P.basisCount) :=
+    Finset.univ.filter fun j : Fin P.basisCount =>
+      ∀ k : Fin Q.basisCount,
+        Tendsto (fun N : ℕ =>
+          mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0)
+  have hj₀T : j₀ ∈ T := by
+    simp [T, hNo]
+  have hTQ : ∀ (j : Fin P.basisCount), j ∈ T → ∀ k : Fin Q.basisCount,
+      Tendsto (fun N : ℕ =>
+        mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0) := by
+    intro j hj k
+    simpa [T] using (Finset.mem_filter.mp hj).2 k
+  have hNotT_nondecay : ∀ j : Fin P.basisCount, j ∉ T →
+      ∃ k : Fin Q.basisCount,
+        ¬ Tendsto (fun N : ℕ =>
+          mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0) := by
+    intro j hjT
+    have hnot : ¬ (∀ k : Fin Q.basisCount,
+        Tendsto (fun N : ℕ =>
+          mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0)) := by
+      intro hall
+      exact hjT (by simp [T, hall])
+    push Not at hnot
+    exact hnot
+  have hScalar : ∀ c : {j : Fin P.basisCount // j ∉ T},
+      ∃ k : Fin Q.basisCount, ∃ α : ℕ → ℂ, ∀ N : ℕ,
+        mpvState (d := d) (P.basis c.1) N =
+          α N • mpvState (d := d) (Q.basis k) N := by
+    intro c
+    obtain ⟨k, hk⟩ := hNotT_nondecay c.1 c.2
+    obtain ⟨α, hα⟩ := exists_state_scalar_of_nondecaying_overlap hP hQ hk
+    exact ⟨k, α, hα⟩
+  choose kOf αOf hStateOf using hScalar
+  letI : Fintype {j : Fin P.basisCount // j ∈ T} := Subtype.fintype (fun j => j ∈ T)
+  letI : Fintype {j : Fin P.basisCount // j ∉ T} := Subtype.fintype (fun j => j ∉ T)
+  have hLI : ∀ᶠ N in atTop,
+      LinearIndependent ℂ
+        (Sum.elim
+          (fun j : {j : Fin P.basisCount // j ∈ T} =>
+            mpvState (d := d) (P.basis j.1) N)
+          (fun k : Fin Q.basisCount =>
+            mpvState (d := d) (Q.basis k) N)) :=
+    restricted_combined_family_eventually_li hP hQ T hTQ
+  have hCoeff_eventually_zero :
+      ∀ᶠ N : ℕ in atTop, P.coeff N j₀ = 0 := by
+    refine (hLI.and (Filter.eventually_atTop.mpr ⟨1, fun N hN => hN⟩)).mono ?_
+    intro N hN
+    rcases hN with ⟨hLIN, hNpos⟩
+    have hPstate :
+        mpvState (d := d) P.toTensor N =
+          ∑ j : Fin P.basisCount, P.coeff N j •
+            mpvState (d := d) (P.basis j) N := by
+      refine mpvState_eq_sum_of_decomp (d := d) P.toTensor P.basis
+        (N := N) (fun j => P.coeff N j) ?_
+      intro σ
+      simpa [smul_eq_mul] using P.mpv_toTensor_eq_sum_coeff (N := N) σ
+    have hQstate :
+        mpvState (d := d) Q.toTensor N =
+          ∑ k : Fin Q.basisCount, Q.coeff N k •
+            mpvState (d := d) (Q.basis k) N := by
+      refine mpvState_eq_sum_of_decomp (d := d) Q.toTensor Q.basis
+        (N := N) (fun k => Q.coeff N k) ?_
+      intro σ
+      simpa [smul_eq_mul] using Q.mpv_toTensor_eq_sum_coeff (N := N) σ
+    have hStateEq : mpvState (d := d) P.toTensor N = mpvState (d := d) Q.toTensor N := by
+      apply PiLp.ext
+      intro σ
+      simpa [mpvState_apply, mpv] using hEqual N hNpos σ
+    have hPQsum :
+        (∑ j : Fin P.basisCount, P.coeff N j •
+            mpvState (d := d) (P.basis j) N) =
+          ∑ k : Fin Q.basisCount, Q.coeff N k •
+            mpvState (d := d) (Q.basis k) N := by
+      calc
+        (∑ j : Fin P.basisCount, P.coeff N j •
+            mpvState (d := d) (P.basis j) N)
+            = mpvState (d := d) P.toTensor N := hPstate.symm
+        _ = mpvState (d := d) Q.toTensor N := hStateEq
+        _ = ∑ k : Fin Q.basisCount, Q.coeff N k •
+            mpvState (d := d) (Q.basis k) N := hQstate
+    let sumT : MPVSpace d N :=
+      ∑ t : {j : Fin P.basisCount // j ∈ T}, P.coeff N t.1 •
+        mpvState (d := d) (P.basis t.1) N
+    let sumC : MPVSpace d N :=
+      ∑ c : {j : Fin P.basisCount // j ∉ T}, P.coeff N c.1 •
+        mpvState (d := d) (P.basis c.1) N
+    let sumQ : MPVSpace d N :=
+      ∑ k : Fin Q.basisCount, Q.coeff N k •
+        mpvState (d := d) (Q.basis k) N
+    let agg : Fin Q.basisCount → ℂ := fun k =>
+      ∑ c : {j : Fin P.basisCount // j ∉ T},
+        if kOf c = k then P.coeff N c.1 * αOf c N else 0
+    let sumAgg : MPVSpace d N :=
+      ∑ k : Fin Q.basisCount, agg k • mpvState (d := d) (Q.basis k) N
+    have hSplitP : sumT + sumC = sumQ := by
+      have hsplit :=
+        Fintype.sum_subtype_add_sum_subtype
+          (p := fun j : Fin P.basisCount => j ∈ T)
+          (f := fun j : Fin P.basisCount =>
+            P.coeff N j • mpvState (d := d) (P.basis j) N)
+      change
+        (∑ t : {j : Fin P.basisCount // j ∈ T}, P.coeff N t.1 •
+            mpvState (d := d) (P.basis t.1) N) +
+          (∑ c : {j : Fin P.basisCount // j ∉ T}, P.coeff N c.1 •
+            mpvState (d := d) (P.basis c.1) N) =
+        ∑ k : Fin Q.basisCount, Q.coeff N k •
+          mpvState (d := d) (Q.basis k) N
+      exact hsplit.trans hPQsum
+    have hC_subst :
+        sumC = ∑ c : {j : Fin P.basisCount // j ∉ T},
+          (P.coeff N c.1 * αOf c N) •
+            mpvState (d := d) (Q.basis (kOf c)) N := by
+      refine Finset.sum_congr rfl ?_
+      intro c _
+      calc
+        P.coeff N c.1 • mpvState (d := d) (P.basis c.1) N
+            = P.coeff N c.1 •
+                (αOf c N • mpvState (d := d) (Q.basis (kOf c)) N) := by
+              rw [hStateOf c N]
+        _ = (P.coeff N c.1 * αOf c N) •
+                mpvState (d := d) (Q.basis (kOf c)) N := by
+              rw [smul_smul]
+    have hC_group :
+        (∑ c : {j : Fin P.basisCount // j ∉ T},
+          (P.coeff N c.1 * αOf c N) •
+            mpvState (d := d) (Q.basis (kOf c)) N) = sumAgg := by
+      simpa [sumAgg, agg] using
+        (sum_fiber_smul (φ := kOf)
+          (a := fun c : {j : Fin P.basisCount // j ∉ T} => P.coeff N c.1 * αOf c N)
+          (v := fun k : Fin Q.basisCount => mpvState (d := d) (Q.basis k) N))
+    have hMain : sumT + sumAgg = sumQ := by
+      calc
+        sumT + sumAgg = sumT + sumC := by
+          rw [← hC_group, ← hC_subst]
+        _ = sumQ := hSplitP
+    let coeff : Sum {j : Fin P.basisCount // j ∈ T} (Fin Q.basisCount) → ℂ :=
+      Sum.elim (fun t => P.coeff N t.1) (fun k => agg k - Q.coeff N k)
+    have hZeroCombined :
+        ∑ x : Sum {j : Fin P.basisCount // j ∈ T} (Fin Q.basisCount),
+          coeff x •
+            Sum.elim
+              (fun t : {j : Fin P.basisCount // j ∈ T} =>
+                mpvState (d := d) (P.basis t.1) N)
+              (fun k : Fin Q.basisCount =>
+                mpvState (d := d) (Q.basis k) N) x = 0 := by
+      have hQsub :
+          (∑ k : Fin Q.basisCount, (agg k - Q.coeff N k) •
+              mpvState (d := d) (Q.basis k) N)
+            = sumAgg - sumQ := by
+        simp [sumAgg, sumQ, sub_smul, Finset.sum_sub_distrib]
+      have hZero : sumT +
+          (∑ k : Fin Q.basisCount, (agg k - Q.coeff N k) •
+              mpvState (d := d) (Q.basis k) N) = 0 := by
+        calc
+          sumT +
+              (∑ k : Fin Q.basisCount, (agg k - Q.coeff N k) •
+                mpvState (d := d) (Q.basis k) N)
+              = sumT + (sumAgg - sumQ) := by rw [hQsub]
+          _ = (sumT + sumAgg) - sumQ := by abel
+          _ = 0 := sub_eq_zero.mpr hMain
+      simpa [coeff, sumT] using hZero
+    have hcoeff :=
+      Fintype.linearIndependent_iff.mp hLIN coeff hZeroCombined
+        (Sum.inl ⟨j₀, hj₀T⟩)
+    simpa [coeff] using hcoeff
+  exact (hP.coeff_not_eventually_zero j₀) hCoeff_eventually_zero
+
+/-- Exact single-block matching without a per-sector unit-modulus hypothesis.
+
+The proof first obtains a non-decaying overlap by an exact coefficient-comparison
+argument over the partition of `P`-sectors that decay against all `Q`-sectors.
+It then recovers dimension equality and gauge-phase equivalence by the same
+overlap-dichotomy contrapositives used in `exists_block_match_of_sameMPVPos`. -/
+theorem exists_block_match_exact
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (j₀ : Fin P.basisCount)
+    (hP_pos : 0 < P.basisCount) (hQ_pos : 0 < Q.basisCount)
+    (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
+    ∃ k₀ : Fin Q.basisCount,
+      ∃ h : P.basisDim j₀ = Q.basisDim k₀,
+        GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis j₀)) (Q.basis k₀) ∧
+        ¬ Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis j₀) (Q.basis k₀) N) atTop (𝓝 0) := by
+  classical
+  have _hP_pos_used : 0 < P.basisCount := hP_pos
+  have _hQ_pos_used : 0 < Q.basisCount := hQ_pos
+  obtain ⟨k₀, hk₀⟩ := exists_nondecaying_overlap_exact
+    (P := P) (Q := Q) hP hQ j₀ hEqual
+  haveI hj₀dim : NeZero (P.basisDim j₀) := ⟨(hP.basis_dim_pos j₀).ne'⟩
+  haveI hk₀dim : NeZero (Q.basisDim k₀) := ⟨(hQ.basis_dim_pos k₀).ne'⟩
+  have hDim : P.basisDim j₀ = Q.basisDim k₀ := by
+    by_contra hne
+    exact hk₀ <|
+      mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP
+        (P.basis j₀) (Q.basis k₀)
+        (hP.basis_irreducible j₀) (hQ.basis_irreducible k₀)
+        (hP.basis_left_canonical j₀) (hQ.basis_left_canonical k₀)
+        hne
+  have hGPE :
+      GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) hDim) (P.basis j₀)) (Q.basis k₀) := by
+    by_contra hNot
+    exact hk₀ <|
+      mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP
+        (hdim := hDim) (A := P.basis j₀) (B := Q.basis k₀)
+        (hA_irr := hP.basis_irreducible j₀)
+        (hB_irr := hQ.basis_irreducible k₀)
+        (hA_norm := hP.basis_left_canonical j₀)
+        (hB_norm := hQ.basis_left_canonical k₀)
+        (hNot := hNot)
+  exact ⟨k₀, hDim, hGPE, hk₀⟩
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ExactMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ExactMatch.lean
@@ -8,11 +8,12 @@ import TNLean.MPS.SharedInfra.GaugePhase
 /-!
 # Exact block matching for BNT canonical forms
 
-This file proves the exact, coefficient-comparison version of the single-block
-matching statement.  Unlike `exists_block_match_of_sameMPVPos`, the proof does
-not use a per-sector unit-modulus hypothesis and never derives a coefficient
-limit.  The contradiction is exact eventual vanishing of the selected sector
-coefficient, contradicting `IsBNTCanonicalForm.coeff_not_eventually_zero`.
+Two BNT canonical forms with the same positive-length MPV family have exact
+single-sector matches: for each sector of one decomposition, some sector of the
+other has the same bond dimension, is gauge-phase equivalent after the dimension
+cast, and has non-decaying overlap.  The argument uses fixed-length linear
+independence to force an exact coefficient contradiction, so no per-sector
+unit-modulus copy-weight hypothesis is needed.
 -/
 
 open scoped Matrix BigOperators
@@ -370,15 +371,12 @@ theorem exists_block_match_exact
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (j₀ : Fin P.basisCount)
-    (hP_pos : 0 < P.basisCount) (hQ_pos : 0 < Q.basisCount)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ k₀ : Fin Q.basisCount,
       ∃ h : P.basisDim j₀ = Q.basisDim k₀,
         GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis j₀)) (Q.basis k₀) ∧
         ¬ Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis j₀) (Q.basis k₀) N) atTop (𝓝 0) := by
   classical
-  have _hP_pos_used : 0 < P.basisCount := hP_pos
-  have _hQ_pos_used : 0 < Q.basisCount := hQ_pos
   obtain ⟨k₀, hk₀⟩ := exists_nondecaying_overlap_exact
     (P := P) (Q := Q) hP hQ j₀ hEqual
   haveI hj₀dim : NeZero (P.basisDim j₀) := ⟨(hP.basis_dim_pos j₀).ne'⟩

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -23,11 +23,9 @@ Paper anchors:
   comparison, recovering copy multiplicities and weights up to the matched
   phase.
 * CPSV21 Definition 4.2 lines 1846–1850 and the two-layer display at
-  lines 1864–1884: per-block BNT normalization on the basis tensors.
-  The per-block convention on copy coefficients
-  `∀ j, ∃ q, ‖μ_{j,q}‖ = 1` — implicit in CPSV16 Appendix MPV proof,
-  line 1182's projection argument — is taken as an explicit theorem-level
-  hypothesis here, not as a structural field of `IsBNTCanonicalForm`.
+  lines 1864–1884: per-block BNT normalization on the basis tensors.  The
+  equal-MPV route below uses the exact matcher and therefore does not require
+  per-sector unit-modulus copy-weight hypotheses.
 
 The theorem below exposes the sector-level witnesses needed before assembling
 the global CPSV16 gauge `⊕_j (𝟙_{r_j} ⊗ Y_j)`.  The proof path is:
@@ -373,8 +371,6 @@ copy permutations and weight identities. -/
 theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -389,7 +385,7 @@ theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
               Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
       Nonempty (SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ) := by
   classical
-  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPVPos hP hQ hUnitP hUnitQ hEqual
+  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPVPos hP hQ hEqual
   let hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k :=
     fun k => (hβMatchFull k).choose
   let hGPE : ∀ k : Fin Q.basisCount,
@@ -442,8 +438,6 @@ theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
 theorem ft_sector_bnt_equal_matched_copy_weight_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -458,7 +452,7 @@ theorem ft_sector_bnt_equal_matched_copy_weight_witnesses
               Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
       Nonempty (SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ) :=
   ft_sector_bnt_equal_matched_copy_weight_witnessesPos
-    (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
+    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
 /-- **BNT equal-MPV sector-witness theorem.**
 
@@ -470,8 +464,6 @@ gauge phase and permuting the copies. -/
 theorem ft_sector_bnt_equal_sector_dataPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount),
       (∀ k, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -483,7 +475,7 @@ theorem ft_sector_bnt_equal_sector_dataPos
   classical
   obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ⟨W⟩⟩ :=
     ft_sector_bnt_equal_matched_copy_weight_witnessesPos
-      (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual
+      (P := P) (Q := Q) hP hQ hEqual
   let hMatch : ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
       GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k) :=
     fun k => by
@@ -503,8 +495,6 @@ theorem ft_sector_bnt_equal_sector_dataPos
 theorem ft_sector_bnt_equal_sector_data
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount),
       (∀ k, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -514,7 +504,7 @@ theorem ft_sector_bnt_equal_sector_data
         ∀ k, ∃ τ : Fin (Q.copies k) ≃ Fin (P.copies (β k)),
           ∀ q : Fin (Q.copies k), Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ q) :=
   ft_sector_bnt_equal_sector_dataPos
-    (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
+    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
 /-- **Global gauge in matched flattened coordinates.**
 
@@ -538,8 +528,6 @@ Appendix MPV proof witness rather than an opaque existential. -/
 theorem ft_sector_bnt_equal_global_gaugePos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -571,7 +559,7 @@ theorem ft_sector_bnt_equal_global_gaugePos
   classical
   obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ⟨W⟩⟩ :=
     ft_sector_bnt_equal_matched_copy_weight_witnessesPos
-      (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual
+      (P := P) (Q := Q) hP hQ hEqual
   have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
     intro k hzero
     have hnorm := hζ_norm k
@@ -588,17 +576,10 @@ theorem ft_sector_bnt_equal_global_gaugePos
   exact ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, W.weight_eq, X, hXdef,
     hGauge⟩
 
-/-- Reformulation for the all-length `SameMPV₂` form.
-
-**Scope restriction (per-sector unit weights):** This theorem assumes a
-unit-modulus copy in every sector on both sides. CPSV16 Section II.C, line 246
-gives only one global unit-weight witness. See
-`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
+/-- Reformulation for the all-length `SameMPV₂` form. -/
 theorem ft_sector_bnt_equal_global_gauge
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -628,6 +609,6 @@ theorem ft_sector_bnt_equal_global_gauge
                 Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
                   (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :=
   ft_sector_bnt_equal_global_gaugePos
-    (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
+    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -96,8 +96,6 @@ matching, copy-weight comparison, and global-gauge construction used here. -/
 theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
       (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
@@ -128,7 +126,7 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos
                      (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ)) := by
   classical
   obtain ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, hWeight, X, _hXdef, hGauge⟩ :=
-    ft_sector_bnt_equal_global_gaugePos hP hQ hUnitP hUnitQ hEqual
+    ft_sector_bnt_equal_global_gaugePos hP hQ hEqual
   -- `P.totalDim = Q.totalDim` follows from `sectorFlatEquiv` plus matched dims
   have hTotal : P.totalDim = Q.totalDim :=
     SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
@@ -433,8 +431,6 @@ CPSV16 §II.C lines 354–361. -/
 theorem ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
       ∀ i : Fin d,
@@ -448,7 +444,7 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
               Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
   classical
   obtain ⟨β, hDim, _hCopies, τ, _ζ, _Xblock, _hTotal, X, _, _, _, hGauge⟩ :=
-    ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos hP hQ hUnitP hUnitQ hEqual
+    ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos hP hQ hEqual
   -- Total bond dimensions agree.
   have hTotal : P.totalDim = Q.totalDim :=
     SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
@@ -539,17 +535,10 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
           Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ))
   simp only [Matrix.mul_assoc]
 
-/-- Reformulation for the all-length `SameMPV₂` form.
-
-**Scope restriction (per-sector unit weights):** This theorem assumes a
-unit-modulus copy in every sector on both sides. CPSV16 Section II.C, line 246
-gives only one global unit-weight witness. See
-`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
+/-- Reformulation for the all-length `SameMPV₂` form. -/
 theorem ft_sector_bnt_equal_mps_gaugeEquiv_literal
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
       ∀ i : Fin d,
@@ -562,6 +551,6 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_literal
             (((Y)⁻¹ : GL (Fin Q.totalDim) ℂ) :
               Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) :=
   ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
-    (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
+    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -2,15 +2,16 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.FundamentalTheorem.SectorBNT.DominantMatch
+import TNLean.MPS.FundamentalTheorem.SectorBNT.ExactMatch
 
 /-!
 # Strong existential and bijective sector matching
 
 The strong existential matching theorem states the CPSV16 Appendix MPV proof,
 line 1182, matching conclusion directly on the original pair `(P, Q)` of BNT
-canonical forms. The theorem is a full-basis statement: it assumes explicitly
-that every sector of `Q` carries a unit-modulus copy weight.
+canonical forms.  In the equal-MPV case the matching is now obtained from the
+exact coefficient-comparison matcher, so no per-sector unit-modulus copy-weight
+hypotheses are required.
 
 The coefficient identity of CPSV16 Appendix MPV proof, lines 1187–1188
 (Corollary substitution) lives in the companion module
@@ -27,42 +28,29 @@ $|V^{(N)}(B_k)\rangle = e^{i\phi_k N} |V^{(N)}(A_{j_k})\rangle$, and the
 single-block fundamental theorem gives
 $B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$.
 
-The paper's "given $k$" is represented here by an explicit theorem-level
-hypothesis
-`hUnitQ : ∀ k, ∃ q, ‖Q.weight k q‖ = 1`. This is stronger than the
-structural field `IsBNTCanonicalForm.weight_unit_exists`, because CPSV16
-§II.C line 246 records only a global unit witness over the two-layer index.
-The stronger hypothesis is the condition assumed by the
-bijective matching and global-gauge theorems.
-
 ## Proof structure
 
 The result is a **single `∀ k, ∃ j` existential statement** on the
-original pair, with the per-sector unit-modulus hypothesis supplied as an
-argument. The proof uses the full combined family at once, through
-`exists_block_match_of_sameMPVPos` and the full-family combined linear
-independence lemma `combined_family_eventually_li`, rather than deleting
-sectors one by one.
+original pair. The equal-MPV proof applies `exists_block_match_exact` with
+`P` and `Q` swapped, then flips the cast direction and overlap order.
 
-The bijective matching (`bijective_match_of_sameMPVPos`) applies the
-forward existential twice — once with `(P, Q)` and once with `(Q, P)` —
-using per-sector unit-modulus hypotheses on both sides, to derive
-`P.basisCount = Q.basisCount` and the full bijection
-`β : Fin Q.basisCount ≃ Fin P.basisCount`.
+The bijective matching (`bijective_match_of_sameMPVPos`) now applies the
+exact block matcher in both directions — once with `(Q, P)` for a map
+`Fin Q.basisCount → Fin P.basisCount` and once with `(P, Q)` for the
+reverse map — to derive `P.basisCount = Q.basisCount` and the full bijection
+`β : Fin Q.basisCount ≃ Fin P.basisCount` without per-sector unit-modulus
+copy-weight hypotheses.
 
 ## Proof of the existential
 
-Given a sector `k` of `Q` with a unit-modulus weight, apply the
-existing `exists_block_match_of_sameMPVPos` (`SectorBNT/DominantMatch`)
-**with `P` and `Q` swapped**:
+Given a sector `k` of `Q`, apply the exact matcher
+`exists_block_match_exact` **with `P` and `Q` swapped**:
 
 * feed `hQ`, `hP` (in that order);
-* supply `hP_pos : 0 < P.basisCount` from `hP.weight_unit_exists`
-  (which exists globally on `P`);
-* supply the unit-modulus witness on `Q`'s `k` (the hypothesis of this
-  theorem); and
-* supply `SameMPV₂ Q.toTensor P.toTensor` via the trivial symmetric
-  flip of `hEqual` (pointwise `.symm`).
+* supply positivity of the sector counts (`k` gives `0 < Q.basisCount`, and
+  the global canonical-form unit witness on `P` gives `0 < P.basisCount`); and
+* supply `SameMPV₂ Q.toTensor P.toTensor` via the symmetric flip of `hEqual`
+  (pointwise `.symm`).
 
 The result is a `j₀ : Fin P.basisCount` with `Q.basisDim k = P.basisDim j₀`,
 a gauge-phase equivalence in the `Q → P` cast direction, and a
@@ -83,25 +71,19 @@ variable {d : ℕ}
 
 /-- **CPSV16 Appendix MPV proof, line 1182, Step 1 (full-basis form).**
 
-Assume that every sector `k` of `Q` has a copy weight of modulus one. Then
-for every sector `k` of `Q`, there exists a sector `j` of `P` of equal bond
+For every sector `k` of `Q`, there exists a sector `j` of `P` of equal bond
 dimension, gauge-phase equivalent to `Q.basis k` after the dimension cast, and
 with non-decaying cross-overlap.
 
-The proof iterates `exists_block_match_of_sameMPVPos` over every `Q`-sector
-with `(P, Q)` swapped, so it consumes the per-block unit-modulus
-witnesses on the *swapped* side, namely `hUnitQ : ∀ k, ∃ q, ‖μ_{k,q}‖ = 1`
-for $Q$.  The per-block unit-modulus convention is paper-implicit in
-CPSV16 Appendix MPV proof, line 1182's projection argument; it is taken here
-as an explicit theorem-level hypothesis (CPSV16 §II.C line 246 records only
-the global unit witness).
+The proof applies `exists_block_match_exact` to the swapped pair `(Q, P)` and
+then flips the gauge-phase equivalence and overlap order back to the displayed
+`(P, Q)` orientation.
 
 Paper anchor: CPSV16 Appendix MPV proof, line 1182 (arXiv:1606.00608), CPSV21
 Definition 4.2 lines 1846–1850, and the two-layer display at lines 1864–1884. -/
 theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∀ k : Fin Q.basisCount, ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
       GaugePhaseEquiv
@@ -119,8 +101,8 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
   have hQ_pos : 0 < Q.basisCount := Nat.lt_of_le_of_lt (Nat.zero_le _) k.isLt
   have hEqual_symm : SameMPV₂Pos Q.toTensor P.toTensor := hEqual.symm
   obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
-    exists_block_match_of_sameMPVPos
-      (P := Q) (Q := P) hQ hP k (hUnitQ k) hQ_pos hP_pos hEqual_symm
+    exists_block_match_exact
+      (P := Q) (Q := P) hQ hP k hQ_pos hP_pos hEqual_symm
   refine ⟨j, hsymDim.symm, ?_, ?_⟩
   · exact gaugePhaseEquiv_swap_cast hsymDim.symm
       (by simpa using hGE_swapped)
@@ -128,16 +110,10 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     apply hNonDecay_swapped
     exact tendsto_mpvOverlap_zero_swap (P.basis j) (Q.basis k) hTend
 
-/-- Reformulation for the all-length `SameMPV₂` form.
-
-**Scope restriction (per-sector unit weights):** This theorem keeps the
-per-sector unit-weight hypothesis of the positive-length form. CPSV16
-Section II.C, line 246 gives only one global unit-weight witness. See
-`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
+/-- Reformulation for the all-length `SameMPV₂` form. -/
 theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∀ k : Fin Q.basisCount, ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
       GaugePhaseEquiv
@@ -147,7 +123,7 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
           mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
         atTop (𝓝 0) :=
   forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
-    (P := P) (Q := Q) hP hQ hUnitQ hEqual.toSameMPV₂Pos
+    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
 /-! ### Bijective sector matching by symmetry -/
 
@@ -161,18 +137,14 @@ Fin P.basisCount`, carrying the matched bond-dimension equality,
 gauge-phase equivalence, and non-decaying overlap for every sector of `Q`.
 
 This is the Lean counterpart of the CPSV16 symmetry step "$g_A \geq g_B$
-and $g_B \geq g_A$".  The proof invokes
-`forall_k_exists_j_nondecaying_overlap_of_sameMPV` once with $(P,Q)$ and
-once with $(Q,P)$, hence it consumes per-block unit-modulus witnesses on
-both sides: `hUnitP : ∀ j, ∃ q, ‖μ_{j,q}^P‖ = 1` and `hUnitQ : ∀ k, ∃ q,
-‖μ_{k,q}^Q‖ = 1`.  These are paper-implicit in CPSV16 Appendix MPV proof,
-line 1182's projection argument and are taken as explicit theorem-level
-hypotheses here (CPSV16 §II.C line 246 records only the global unit witness). -/
+and $g_B \geq g_A$".  The proof invokes the exact block matcher once with $(Q,P)$ for the
+`Q → P` map and once with $(P,Q)$ for the `P → Q` map.  Since the exact
+matcher uses exact coefficient comparison rather than the dominant
+coefficient asymptotic argument, no per-sector unit-modulus copy-weight
+hypotheses are needed in the equal-MPV case. -/
 theorem bijective_match_of_sameMPVPos
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ β : Fin Q.basisCount ≃ Fin P.basisCount,
       ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -183,11 +155,49 @@ theorem bijective_match_of_sameMPVPos
             mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N)
           atTop (𝓝 0) := by
   classical
-  have hFwd :=
-    forall_k_exists_j_nondecaying_overlap_of_sameMPVPos hP hQ hUnitQ hEqual
+  have hP_pos : 0 < P.basisCount := by
+    obtain ⟨j₀, _, _⟩ := hP.weight_unit_exists
+    exact Nat.lt_of_le_of_lt (Nat.zero_le _) j₀.isLt
+  have hQ_pos : 0 < Q.basisCount := by
+    obtain ⟨k₀, _, _⟩ := hQ.weight_unit_exists
+    exact Nat.lt_of_le_of_lt (Nat.zero_le _) k₀.isLt
   have hEqual_symm : SameMPV₂Pos Q.toTensor P.toTensor := hEqual.symm
-  have hBwd :=
-    forall_k_exists_j_nondecaying_overlap_of_sameMPVPos hQ hP hUnitP hEqual_symm
+  have hFwd : ∀ k : Fin Q.basisCount,
+      ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
+        GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) h) (P.basis j))
+            (Q.basis k) ∧
+        ¬ Tendsto (fun N : ℕ =>
+            mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
+          atTop (𝓝 0) := by
+    intro k
+    obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
+      exists_block_match_exact
+        (P := Q) (Q := P) hQ hP k hQ_pos hP_pos hEqual_symm
+    refine ⟨j, hsymDim.symm, ?_, ?_⟩
+    · exact gaugePhaseEquiv_swap_cast hsymDim.symm
+        (by simpa using hGE_swapped)
+    · intro hTend
+      apply hNonDecay_swapped
+      exact tendsto_mpvOverlap_zero_swap (P.basis j) (Q.basis k) hTend
+  have hBwd : ∀ j : Fin P.basisCount,
+      ∃ (k : Fin Q.basisCount) (h : Q.basisDim k = P.basisDim j),
+        GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) h) (Q.basis k))
+            (P.basis j) ∧
+        ¬ Tendsto (fun N : ℕ =>
+            mpvOverlap (d := d) (Q.basis k) (P.basis j) N)
+          atTop (𝓝 0) := by
+    intro j
+    obtain ⟨k, hDim, hGE, hNonDecay⟩ :=
+      exists_block_match_exact
+        (P := P) (Q := Q) hP hQ j hP_pos hQ_pos hEqual
+    refine ⟨k, hDim.symm, ?_, ?_⟩
+    · exact gaugePhaseEquiv_swap_cast hDim.symm
+        (by simpa using hGE)
+    · intro hTend
+      apply hNonDecay
+      exact tendsto_mpvOverlap_zero_swap (Q.basis k) (P.basis j) hTend
   let φ₀ : Fin Q.basisCount → Fin P.basisCount := fun k => (hFwd k).choose
   have φ₀_spec : ∀ k : Fin Q.basisCount,
       ∃ h : P.basisDim (φ₀ k) = Q.basisDim k,
@@ -271,17 +281,10 @@ theorem bijective_match_of_sameMPVPos
   intro k
   simpa [β] using φ₀_spec k
 
-/-- Reformulation for the all-length `SameMPV₂` form.
-
-**Scope restriction (per-sector unit weights):** This theorem assumes a
-unit-modulus copy in every sector on both sides. CPSV16 Section II.C, line 246
-gives only one global unit-weight witness. See
-`docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex`. -/
+/-- Reformulation for the all-length `SameMPV₂` form. -/
 theorem bijective_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hUnitP : ∀ j : Fin P.basisCount, ∃ q : Fin (P.copies j), ‖P.weight j q‖ = 1)
-    (hUnitQ : ∀ k : Fin Q.basisCount, ∃ q : Fin (Q.copies k), ‖Q.weight k q‖ = 1)
     (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
     ∃ β : Fin Q.basisCount ≃ Fin P.basisCount,
       ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
@@ -292,7 +295,7 @@ theorem bijective_match_of_sameMPV
             mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N)
           atTop (𝓝 0) :=
   bijective_match_of_sameMPVPos
-    (P := P) (Q := Q) hP hQ hUnitP hUnitQ hEqual.toSameMPV₂Pos
+    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -47,8 +47,7 @@ Given a sector `k` of `Q`, apply the exact matcher
 `exists_block_match_exact` **with `P` and `Q` swapped**:
 
 * feed `hQ`, `hP` (in that order);
-* supply positivity of the sector counts (`k` gives `0 < Q.basisCount`, and
-  the global canonical-form unit witness on `P` gives `0 < P.basisCount`); and
+* supply the selected sector `k`; and
 * supply `SameMPV₂ Q.toTensor P.toTensor` via the symmetric flip of `hEqual`
   (pointwise `.symm`).
 
@@ -94,15 +93,10 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
         atTop (𝓝 0) := by
   classical
   intro k
-  -- `P.basisCount > 0`: the global unit witness on `P` supplies a sector index.
-  have hP_pos : 0 < P.basisCount := by
-    obtain ⟨j₀, _, _⟩ := hP.weight_unit_exists
-    exact Nat.lt_of_le_of_lt (Nat.zero_le _) j₀.isLt
-  have hQ_pos : 0 < Q.basisCount := Nat.lt_of_le_of_lt (Nat.zero_le _) k.isLt
   have hEqual_symm : SameMPV₂Pos Q.toTensor P.toTensor := hEqual.symm
   obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
     exists_block_match_exact
-      (P := Q) (Q := P) hQ hP k hQ_pos hP_pos hEqual_symm
+      (P := Q) (Q := P) hQ hP k hEqual_symm
   refine ⟨j, hsymDim.symm, ?_, ?_⟩
   · exact gaugePhaseEquiv_swap_cast hsymDim.symm
       (by simpa using hGE_swapped)
@@ -155,12 +149,6 @@ theorem bijective_match_of_sameMPVPos
             mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N)
           atTop (𝓝 0) := by
   classical
-  have hP_pos : 0 < P.basisCount := by
-    obtain ⟨j₀, _, _⟩ := hP.weight_unit_exists
-    exact Nat.lt_of_le_of_lt (Nat.zero_le _) j₀.isLt
-  have hQ_pos : 0 < Q.basisCount := by
-    obtain ⟨k₀, _, _⟩ := hQ.weight_unit_exists
-    exact Nat.lt_of_le_of_lt (Nat.zero_le _) k₀.isLt
   have hEqual_symm : SameMPV₂Pos Q.toTensor P.toTensor := hEqual.symm
   have hFwd : ∀ k : Fin Q.basisCount,
       ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
@@ -173,7 +161,7 @@ theorem bijective_match_of_sameMPVPos
     intro k
     obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
       exists_block_match_exact
-        (P := Q) (Q := P) hQ hP k hQ_pos hP_pos hEqual_symm
+        (P := Q) (Q := P) hQ hP k hEqual_symm
     refine ⟨j, hsymDim.symm, ?_, ?_⟩
     · exact gaugePhaseEquiv_swap_cast hsymDim.symm
         (by simpa using hGE_swapped)
@@ -191,7 +179,7 @@ theorem bijective_match_of_sameMPVPos
     intro j
     obtain ⟨k, hDim, hGE, hNonDecay⟩ :=
       exists_block_match_exact
-        (P := P) (Q := Q) hP hQ j hP_pos hQ_pos hEqual
+        (P := P) (Q := Q) hP hQ j hEqual
     refine ⟨k, hDim.symm, ?_, ?_⟩
     · exact gaugePhaseEquiv_swap_cast hDim.symm
         (by simpa using hGE)

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1204,77 +1204,132 @@ Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}.
     pointwise identity to $\zeta^{-1}$ on the left.
 \end{proof}
 
-\section{Strong existential matching under per-sector unit weights}
+\section{Strong existential matching by exact linear independence}
 \label{sec:sector_bnt_strong_match}
 
 This section lifts the weak existential matching $\exists j, \exists k$ to
 the strong existential $\forall k, \exists j$ on the original pair of BNT
-canonical forms, without recursion, partial sector dropping, or any
-combined-linear-independence obligation on a partial union. The result is
-a single $\forall k, \exists j$ statement on the original $(P, Q)$,
-under the explicit hypothesis that every $Q$-side sector carries a
-unit-modulus copy weight.
+canonical forms. The matching is established \emph{exactly}, at fixed
+sufficiently large length, with no per-sector unit-modulus hypothesis: the
+only normalization used is the global one of
+\cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv}, which is part of the BNT
+canonical-form predicate.
 
-The per-sector unit-weight hypothesis is the formal version used in the
-current full-basis theorem:
-\cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv} records the
-modulus-one hypothesis as a single \emph{global} existential over the
-two-layer $(j, q)$ index of the BNT display, whereas the statement below
-assumes the corresponding witness in each sector. This is why the result is
-labelled as a full-basis form rather than as the unrestricted source theorem.
-% Scope restriction documented in
-% docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
-The bijective-matching theorem below applies the
-strong existential theorem twice (with $(P, Q)$ swapped) to derive the
-cardinality identity and the per-pair bijection and gauges on the full
-basis, assuming the same per-sector unit-weight condition on both sides.
+The mechanism is the one of
+\cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}, read as an exact
+statement rather than an asymptotic projection. Fix a sector $k$ of $Q$ and
+suppose, for contradiction, that the cross-overlap of $Q_k$ with every basis
+sector $P_j$ tends to zero. Let $T$ be the set of $P$-sectors that decay
+against \emph{all} sectors of $Q$. Every sector $j \notin T$ has a
+non-decaying overlap with some $Q_k$, hence by the overlap dichotomy a
+gauge-phase equivalence, so its MPV vectors are a scalar multiple of those of
+a $Q$-sector at every length. The family
+$\{P_j : j\in T\}\cup\{Q_k\}_k$ then has all pairwise cross-overlaps decaying,
+so it is eventually linearly independent
+(Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}). Rewriting the
+common-MPV identity over this family expresses the relation entirely in an
+eventually linearly independent family, so at each fixed large length every
+coefficient vanishes \emph{exactly}; in particular the sector coefficient of
+each $j\in T$ is eventually zero. This contradicts
+Lemma~\ref{lem:sector_bnt_coeff_not_eventually_zero}, which holds for any
+nonzero-weight sector with no modulus assumption. Hence the supposed
+all-decaying sector cannot occur and the match exists.
+
+Because the contradiction is between exact vanishing at fixed length and exact
+non-vanishing of a finite sum of distinct geometric sequences, it never passes
+through a limit of a single sector coefficient; a sub-unit sector, whose
+coefficient does decay, is matched by the same argument. The bijective-matching
+theorem below applies the strong existential theorem twice (with $(P, Q)$
+swapped) to derive the cardinality identity and the per-pair bijection and
+gauges on the full basis.
+
+\begin{lemma}[Sector coefficient is not eventually zero]
+    \label{lem:sector_bnt_coeff_not_eventually_zero}
+    \lean{MPSTensor.IsBNTCanonicalForm.coeff_not_eventually_zero}
+    \leanok
+    \uses{def:sector_bnt_cf}
+    For a BNT canonical form $P$ and any sector $j$, the sector coefficient
+    $c_{P,j}^{(N)} = \sum_q \mu_{j,q}^N$ is not eventually zero in $N$. No
+    modulus assumption on the copy weights is used: the sum is a finite sum of
+    geometric sequences with distinct nonzero ratios, so if it vanished for all
+    large $N$ it would vanish at every exponent, including $N=0$, contradicting
+    the positivity of the copy count $r_j = P.\mathrm{copies}(j)$.
+\end{lemma}
+
+\begin{proof}\leanok
+    If $c_{P,j}^{(N)} = 0$ for all $N \ge M$, the signed-geometric
+    extrapolation (Theorem~\ref{thm:newton_girard} and the power-sum
+    machinery) forces $\sum_q \mu_{j,q}^k = 0$ for every $k$, in particular
+    $\sum_q 1 = r_j = 0$ at $k=0$, contradicting $r_j > 0$.
+\end{proof}
+
+\begin{theorem}[Exact single-sector matching]
+    \label{thm:sector_bnt_exact_block_match}
+    \lean{MPSTensor.exists_block_match_exact}
+    \leanok
+    \uses{def:sector_bnt_cf,
+        lem:sector_bnt_combined_family_eventually_li,
+        lem:sector_bnt_coeff_not_eventually_zero}
+    Let $P, Q$ be two BNT canonical forms with the same MPV family (at all
+    positive lengths). For every sector $j$ of $P$ there exist a sector $k$ of
+    $Q$ with matched bond dimension $\dim_P(j) = \dim_Q(k)$, a gauge-phase
+    equivalence after identifying the matched bond dimensions, and a
+    non-decaying cross-overlap. No per-sector unit-modulus hypothesis is
+    required.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:sector_bnt_combined_family_eventually_li,
+        lem:sector_bnt_coeff_not_eventually_zero}
+    This is the exact $T$-partition argument described above. Suppose $j$
+    decays against every sector of $Q$, and let $T$ be the set of $P$-sectors
+    with this property. Sectors outside $T$ contribute MPV vectors lying in the
+    span of the $Q$-family, so the common-MPV identity restricts to the
+    eventually linearly independent family
+    $\{P_{j'} : j'\in T\}\cup\{Q_k\}_k$
+    (Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}). Exact
+    coefficient extraction at each fixed large length forces the sector
+    coefficient of $j$ to be eventually zero, contradicting
+    Lemma~\ref{lem:sector_bnt_coeff_not_eventually_zero}. Hence a matched
+    sector $k$ exists; the gauge-phase equivalence is recovered from the
+    non-decaying overlap by the irreducible trace-preserving overlap
+    dichotomy.
+\end{proof}
 
 \begin{theorem}[Strong existential matching, full-basis form]
     \label{thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV}
     \lean{MPSTensor.forall_k_exists_j_nondecaying_overlap_of_sameMPV}
     \leanok
     \uses{def:sector_bnt_cf,
-        lem:sector_bnt_combined_family_eventually_li,
-        lem:sector_bnt_coeff_not_tendsto_zero_at_unit_block}
-    Let $P, Q$ be two BNT canonical forms with the same MPV family. Assume
-    that every sector $k$ of $Q$ has a unit-modulus copy weight:
-    \[
-        \forall k\in J(Q),\ \exists q,\ |\nu_{k,q}|=1 .
-    \]
-    Then for every sector $k$ of $Q$ there exist a sector $j$ of $P$ with
-    matched bond dimension $\dim_P(j) = \dim_Q(k)$, a gauge-phase equivalence
-    after identifying the matched bond dimensions, and a non-decaying
-    cross-overlap.
+        thm:sector_bnt_exact_block_match}
+    Let $P, Q$ be two BNT canonical forms with the same MPV family. Then for
+    every sector $k$ of $Q$ there exist a sector $j$ of $P$ with matched bond
+    dimension $\dim_P(j) = \dim_Q(k)$, a gauge-phase equivalence after
+    identifying the matched bond dimensions, and a non-decaying cross-overlap.
+    No per-sector unit-modulus hypothesis is required.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:sector_bnt_combined_family_eventually_li,
-        lem:sector_bnt_coeff_not_tendsto_zero_at_unit_block}
-    The contrapositive of
-    \cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}, combined with
-    linear independence on the full family
-    $\{P_j\}_j \cup \{Q_k\}_k$, is iterated externally over each sector
-    $k$. Each iteration is discharged by the full-basis weak existential
-    matching theorem with the roles of $P$ and $Q$ swapped: supply the
-    canonical-form hypotheses in reversed order, the basis non-emptiness
-    witness from the retained global unit-modulus witness, the per-sector
-    unit-modulus witness for the chosen $Q$-sector, and the
-    same-MPV hypothesis through its pointwise-symmetric flip. The
-    resulting conclusion is re-oriented by symmetry of gauge-phase
-    equivalence under the bond-dimension identification and symmetry of overlap
+    \uses{thm:sector_bnt_exact_block_match}
+    Apply Theorem~\ref{thm:sector_bnt_exact_block_match} with the roles of $P$
+    and $Q$ swapped and the same-MPV hypothesis flipped by symmetry. The
+    resulting conclusion is re-oriented by symmetry of gauge-phase equivalence
+    under the bond-dimension identification and symmetry of overlap
     convergence.
 \end{proof}
 
-\begin{remark}[Linear independence on the full family]
+\begin{remark}[Linear independence carries the matching]
     \label{rem:sector_bnt_strong_match_no_partial_li}
-    Theorem~\ref{thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV}
-    consumes \emph{only} the weak existential matching theorem, which
-    itself routes through the linear-independence step
-    (Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}) on the
-    \emph{full} family $\{P_j\}_j \sqcup \{Q_k\}_k$, the corollary
+    Theorem~\ref{thm:sector_bnt_exact_block_match} routes through the
+    linear-independence step
+    (Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}), the corollary
     input of \cite[Appendix MPV corollary, lines~1131--1133]
-    {Cirac2016MPDO_arXiv}, not
-    on any partial union.
+    {Cirac2016MPDO_arXiv}, applied to the family
+    $\{P_j : j\in T\}\sqcup\{Q_k\}_k$ on which the residual relation lives. The
+    contradiction is exact vanishing of a coefficient at fixed length versus
+    Lemma~\ref{lem:sector_bnt_coeff_not_eventually_zero}; no asymptotic
+    projection of a single sector coefficient is taken, so no per-sector
+    unit-modulus hypothesis enters.
 \end{remark}
 
 \subsection{Bijective matching by symmetry}
@@ -1286,31 +1341,23 @@ $g_a \ge g_b$ and $g_b \ge g_a$ together imply $g_a = g_b$.
 
 The strong existential matching theorem
 (Theorem~\ref{thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV})
-gives one direction of the full-basis matching when every $Q$-sector has a
-unit-modulus copy weight. Applying the same theorem once more with the roles of
-$P$ and $Q$ swapped, using the corresponding per-sector hypothesis on $P$ and
-the symmetric flip of the same-MPV hypothesis, gives the other
-direction. The two matchings, combined with the basis-distinctness clause of
-the canonical-form predicate
+gives one direction of the full-basis matching. Applying the same theorem once
+more with the roles of $P$ and $Q$ swapped, using the symmetric flip of the
+same-MPV hypothesis, gives the other direction. The two matchings, combined
+with the basis-distinctness clause of the canonical-form predicate
 \cite[\S~II.C, lines~264--279]{Cirac2016MPDO_arXiv}, force injectivity
 in both directions.
 
 \paragraph{Scope.}
-The literal source conclusion ``$g_a = g_b$ and a relabelling
-$B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$''
-(\cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}) is formalized
-below under the explicit per-sector unit-weight hypotheses
-\[
-    \forall j\in J(P),\ \exists q,\ |\mu_{j,q}|=1,
-    \qquad
-    \forall k\in J(Q),\ \exists q,\ |\nu_{k,q}|=1 .
-\]
-Under these hypotheses every sector lies in the unit-modulus part, so the
-symmetric injective matchings give a bijection on the full BNT basis. The
-coefficient comparison is not folded into this matching step; it is recorded
-separately in the following subsection.
-% Scope restriction documented in
-% docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
+The matching delivers the literal source conclusion ``$g_a = g_b$ and a
+relabelling $B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$''
+(\cite[Appendix MPV proof, line~1182]{Cirac2016MPDO_arXiv}) on the full BNT
+basis, using only the global normalization of
+\cite[\S~II.C, line~246]{Cirac2016MPDO_arXiv} carried by the canonical-form
+predicate. No per-sector unit-modulus hypothesis is imposed: the exact
+matching (Theorem~\ref{thm:sector_bnt_exact_block_match}) handles sub-unit
+sectors on the same footing. The coefficient comparison is not folded into this
+matching step; it is recorded separately in the following subsection.
 
 \begin{theorem}[Bijective matching by symmetry]
     \label{thm:sector_bnt_bijective_match_of_sameMPV}
@@ -1318,9 +1365,8 @@ separately in the following subsection.
     \leanok
     \uses{thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV,
         def:sector_bnt_cf}
-    Let $P, Q$ be two BNT canonical forms with the same MPV family. Assume
-    that every sector of $P$ and every sector of $Q$ has a unit-modulus copy
-    weight. Then there is a bijection
+    Let $P, Q$ be two BNT canonical forms with the same MPV family. Then there
+    is a bijection
     \[
         \beta : J(Q) \simeq J(P)
     \]
@@ -1363,11 +1409,10 @@ The matching theorem above gives the sector phases and gauges. The remaining
 coefficient comparison is the step at
 \cite[Appendix MPV proof, lines~1187--1188]{Cirac2016MPDO_arXiv}. In the
 equal-MPV setting, the full BNT basis and eventual linear independence give the
-comparison directly. In the proportional setting below, the same comparison
-is recorded as the explicit hypothesis needed before the copy weights can be
-assembled into the global gauge. The hypotheses in this subsection require a
-unit-modulus copy in every sector on both sides; under this normalization, the
-matching covers the whole BNT basis.
+comparison directly, with no per-sector unit-modulus hypothesis. In the
+proportional setting below, the same comparison is recorded as the explicit
+hypothesis needed before the copy weights can be assembled into the global
+gauge, and there the per-sector unit-modulus witnesses are still carried.
 
 \begin{lemma}[Unit phase from matched normalized BNT blocks]%
     \label{lem:sector_bnt_norm_phase_of_matched_mpv}
@@ -1735,8 +1780,7 @@ matching covers the whole BNT basis.
     \leanok
     \uses{def:sector_bnt_cf}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
-    MPV family. Assume that every sector of $P$ and every sector of $Q$ has at
-    least one copy weight of modulus $1$. Then there are a bijection
+    MPV family. Then there are a bijection
     $\beta:J(Q)\simeq J(P)$, bond-dimension equalities, unit-modulus phases
     $\zeta_k$, and block gauges $X_k$ such that
     \[
@@ -1747,8 +1791,6 @@ matching covers the whole BNT basis.
     \[
         \nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}.
     \]
-    % Scope restriction documented in
-    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1780,8 +1822,7 @@ matching covers the whole BNT basis.
     \leanok
     \uses{def:sector_bnt_cf}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
-    MPV family. Assume that every sector of $P$ and every sector of $Q$ has at
-    least one copy weight of modulus $1$. Then there exist:
+    MPV family. Then there exist:
     \begin{itemize}
         \item a bijection $\beta:J(Q)\simeq J(P)$,
         \item bond-dimension equalities
@@ -1839,8 +1880,7 @@ matching covers the whole BNT basis.
     \leanok
     \uses{def:sector_bnt_cf}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
-    MPV family. Assume that every sector of $P$ and every sector of $Q$ has at
-    least one copy weight of modulus $1$. Then the total bond dimensions agree;
+    MPV family. Then the total bond dimensions agree;
     write their common value as $D$. There is
     \[
         Y\in \GL_D(\C)
@@ -1853,12 +1893,9 @@ matching covers the whole BNT basis.
     \]
     where $P_{\mathrm{tot}}^i$ and $Q_{\mathrm{tot}}^i$ are both regarded as
     matrices in $\MN{D}$ using the total bond-dimension equality. This is the
-    normalized BNT form of
+    BNT form of
     \cite[Corollary~II.2 and Appendix MPV proof, lines~1189--1192]
-    {Cirac2016MPDO_arXiv}, under the same unit-modulus-copy normalization
-    as Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
-    % Scope restriction documented in
-    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
+    {Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1220,10 +1220,14 @@ The mechanism is the one of
 statement rather than an asymptotic projection. Fix a sector $k$ of $Q$ and
 suppose, for contradiction, that the cross-overlap of $Q_k$ with every basis
 sector $P_j$ tends to zero. Let $T$ be the set of $P$-sectors that decay
-against \emph{all} sectors of $Q$. Every sector $j \notin T$ has a
-non-decaying overlap with some $Q_k$, hence by the overlap dichotomy a
-gauge-phase equivalence, so its MPV vectors are a scalar multiple of those of
-a $Q$-sector at every length. The family
+against \emph{all} sectors of $Q$. For every sector $j \notin T$ the overlap
+dichotomy turns a non-decaying overlap with some $Q_{k(j)}$ into a gauge-phase
+equivalence, hence a scalar $\omega_j \in \C^\times$ with
+\[
+    V^{(N)}(P_j)_\sigma = \omega_j^{N}\, V^{(N)}(Q_{k(j)})_\sigma
+    \qquad \text{for every } N \text{ and } \sigma,
+\]
+so $V^{(N)}(P_j)$ lies in the span of $\{V^{(N)}(Q_k)\}_k$. The family
 $\{P_j : j\in T\}\cup\{Q_k\}_k$ then has all pairwise cross-overlaps decaying,
 so it is eventually linearly independent
 (Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}). Rewriting the
@@ -1236,8 +1240,8 @@ nonzero-weight sector with no modulus assumption. Hence the supposed
 all-decaying sector cannot occur and the match exists.
 
 Because the contradiction is between exact vanishing at fixed length and exact
-non-vanishing of a finite sum of distinct geometric sequences, it never passes
-through a limit of a single sector coefficient; a sub-unit sector, whose
+non-vanishing of a finite sum of nonzero-weight geometric sequences, it never
+passes through a limit of a single sector coefficient; a sub-unit sector, whose
 coefficient does decay, is matched by the same argument. The bijective-matching
 theorem below applies the strong existential theorem twice (with $(P, Q)$
 swapped) to derive the cardinality identity and the per-pair bijection and
@@ -1250,17 +1254,18 @@ gauges on the full basis.
     \uses{def:sector_bnt_cf}
     For a BNT canonical form $P$ and any sector $j$, the sector coefficient
     $c_{P,j}^{(N)} = \sum_q \mu_{j,q}^N$ is not eventually zero in $N$. No
-    modulus assumption on the copy weights is used: the sum is a finite sum of
-    geometric sequences with distinct nonzero ratios, so if it vanished for all
-    large $N$ it would vanish at every exponent, including $N=0$, contradicting
-    the positivity of the copy count $r_j = P.\mathrm{copies}(j)$.
+    modulus assumption on the copy weights is used; only that they are nonzero.
+    The signed-geometric extrapolation shows that if the power sum vanished for
+    all large $N$ it would vanish at every exponent, including $N=0$,
+    contradicting the positivity of the copy count $r_j = P.\mathrm{copies}(j)$
+    (repeated ratios are handled by the same extrapolation, so distinctness of
+    the weights is not needed).
 \end{lemma}
 
 \begin{proof}\leanok
-    If $c_{P,j}^{(N)} = 0$ for all $N \ge M$, the signed-geometric
-    extrapolation (Theorem~\ref{thm:newton_girard} and the power-sum
-    machinery) forces $\sum_q \mu_{j,q}^k = 0$ for every $k$, in particular
-    $\sum_q 1 = r_j = 0$ at $k=0$, contradicting $r_j > 0$.
+    If $c_{P,j}^{(N)} = 0$ for all $N \ge M$, the signed geometric-sequence
+    vanishing lemma forces $\sum_q \mu_{j,q}^k = 0$ for every exponent $k$, in
+    particular $\sum_q 1 = r_j = 0$ at $k=0$, contradicting $r_j > 0$.
 \end{proof}
 
 \begin{theorem}[Exact single-sector matching]
@@ -1363,7 +1368,7 @@ matching step; it is recorded separately in the following subsection.
     \label{thm:sector_bnt_bijective_match_of_sameMPV}
     \lean{MPSTensor.bijective_match_of_sameMPV}
     \leanok
-    \uses{thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV,
+    \uses{thm:sector_bnt_exact_block_match,
         def:sector_bnt_cf}
     Let $P, Q$ be two BNT canonical forms with the same MPV family. Then there
     is a bijection
@@ -1377,12 +1382,13 @@ matching step; it is recorded separately in the following subsection.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV}
-    Apply Theorem~\ref{thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV}
-    first with $(P, Q)$ and the original hypothesis to obtain a raw
-    matched-sector function via classical choice, and then again with
-    $(Q, P)$ and the symmetric flipped hypothesis to obtain the
-    symmetric raw function.
+    \uses{thm:sector_bnt_exact_block_match}
+    Apply the exact single-sector matching
+    (Theorem~\ref{thm:sector_bnt_exact_block_match}) at each sector of $P$, with
+    $(P, Q)$ and the original hypothesis, to obtain a raw matched-sector
+    function via classical choice; apply it again at each sector of $Q$, with
+    $(Q, P)$ and the symmetric flipped hypothesis, to obtain the symmetric raw
+    function.
 
     \emph{Forward injectivity.} Suppose $\varphi_0(k_1) = \varphi_0(k_2) = j$.
     The two matching witnesses give a common centre $P_j$ with two


### PR DESCRIPTION
## Summary

Closes the **per-sector unit-modulus gap** in the equal-MPV (CPSV16 Corollary II.2) Fundamental-Theorem chain. A deep read of the actual CPSV16 appendix proof (Papers/1606.00608) showed this was a **formalization artifact**, not paper mathematics: the paper's matching only needs each sector coefficient to be *not eventually zero* (true for any nonzero-weight sector), whereas the formalized matching used an *asymptotic projection* that needed a unit-modulus copy per sector (the #1678 trap for sub-unit sectors).

## New mathematics
`MPSTensor.exists_block_match_exact` (new `SectorBNT/ExactMatch.lean`): for BNT canonical forms P, Q with `SameMPV2Pos`, every P-sector matches a Q-sector (gauge-phase equivalence + non-decaying overlap) with **no per-sector unit-modulus hypothesis**. Proof is the exact T-partition argument:
- sectors outside T (those matching some Q-sector) contribute MPV vectors in the span of the Q-family;
- the residual relation lives in the eventually **linearly-independent** family {P_j : j in T} + {Q_k}, so at each fixed large N every coefficient vanishes **exactly**;
- this contradicts the **modulus-free** `coeff_not_eventually_zero` (already in the repo, previously unused).

This is exact vanishing vs. exact non-vanishing -- it never takes a limit of a single sector coefficient, so it structurally avoids the #1678 0=0 obstruction. `#print axioms` on the literal endpoint: `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).

## Refactor
Re-routes the equal-case bijection (`bijective_match_of_sameMPV{,Pos}`) through the exact matcher and **strips `hUnitP`/`hUnitQ`** from the equal-MPV endpoints: `ft_sector_bnt_equal_sector_data{,Pos}`, `..._global_gauge{,Pos}`, `..._mps_gaugeEquiv_literal{,Pos}`, `..._matched_copy_weight_witnesses{,Pos}`, and the supporting `forall_k_exists_j_...`. The **proportional route is untouched**.

## Blueprint (ch10)
Retitles the matching section, rewrites its narrative to the exact T-partition argument, drops the per-sector unit assumption from the equal-case statements, and adds anchors `thm:sector_bnt_exact_block_match` + `lem:sector_bnt_coeff_not_eventually_zero`. Proportional statements keep their unit hypotheses.

## Gates
- `lake build TNLean`: green (8745 jobs); only pre-existing PEPS/Periodic `sorry` warnings.
- `blueprint_lean_sync.py`: ch10 71/71 (100%); total 65 = baseline (no regression).
- XeLaTeX `print.tex`: 0 undefined refs, 0 errors; ch10 latexindent-clean.

## Significance
Removes the larger of the two gaps keeping the aperiodic FT source statements `\notready`. With the second gap (an unused `basis_injective` field) addressed next, **CPSV16 Corollary II.2 becomes closable as the literal source theorem** on the canonical-form/BNT surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hypotheses and proof spine of the equal-MPV Fundamental Theorem chain (core formalization), but strengthens results by removing assumptions; proportional paths are untouched.
> 
> **Overview**
> Adds **`SectorBNT/ExactMatch.lean`** with `exists_block_match_exact`: equal positive-length MPV on BNT canonical forms forces per-sector bond match, gauge-phase equivalence, and non-decaying overlap via a **fixed-length** \(T\)-partition and eventual linear independence—**no** `hUnitP` / `hUnitQ`.
> 
> **`StrongMatch`** now imports `ExactMatch` and routes `forall_k_exists_j_…` and `bijective_match_of_sameMPV{,Pos}` through that matcher (swap + symmetry lemmas unchanged in role).
> 
> Strips per-sector unit-modulus copy-weight hypotheses from the **equal-MPV** chain in **`Fundamental`**, **`FundamentalCoord`**, and related `ft_sector_bnt_equal_*` theorems; **proportional** theorems and their unit-weight assumptions are **unchanged**.
> 
> Blueprint **ch10** retitles/rewrites strong matching to the exact argument and drops per-sector unit assumptions from equal-case statements while documenting `coeff_not_eventually_zero` and the new exact block-match theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b41b54a178cd71e453651ef216359d6eaad4e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->