### PR TITLE
feat(MPS/FT): relax IsBNTCanonicalForm to paper-faithful BNT (drop basis_injective)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -17,7 +17,7 @@ This module introduces the canonical-form predicate
 The structure is the minimal CPSV16/CPSV21 BNT canonical-form data on top of
 a `SectorDecomposition`.  It records:
 
-* **per-block normality** (injective, irreducible, left-canonical) and
+* **per-block irreducibility**, **left-canonicality**, and
   **self-overlap → 1** (non-periodic / after-blocking surface);
 * **eventual linear independence** of basis MPV states (`HasBNTSectorData`);
 * **block distinctness** in the cast-compatible gauge-phase shape, ruling out
@@ -110,9 +110,6 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   inference on `Fin (P.basisDim j)`; cf. CPSV21 lines 1815–1830 where the
   primitive transfer map lives on a positive-dimension block). -/
   basis_dim_pos : ∀ j : Fin P.basisCount, 0 < P.basisDim j
-  /-- **Per-block injectivity.**  Each basis block `P.basis j` is an
-  injective MPS tensor (CPSV21 lines 1815–1830). -/
-  basis_injective : ∀ j : Fin P.basisCount, IsInjective (P.basis j)
   /-- **Per-block irreducibility.**  Each basis block has irreducible
   transfer map after blocking (CPSV16 lines 233–234; CPSV21 lines
   1815–1830). -/

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -6,43 +6,22 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.FundamentalTheorem.SectorBNT.EqualModulus
 
 /-!
-# Executable examples for `IsBNTCanonicalForm`
+# Concrete BNT canonical forms
 
-This file collects concrete `SectorDecomposition` constructions and
-instantiates `IsBNTCanonicalForm` on each.  All three
-core examples have a single BNT basis sector (`basisCount = 1`):
+These examples present one-sector BNT canonical forms built from a normal block
+`C`.  The assumptions on `C` are the standard mathematical ones for such a
+block: positive bond dimension, irreducibility, left canonicity, normalized
+self-overlap, and eventual non-vanishing of the associated vector state.
 
-* **Example 1** — single sector, single copy: `weight = (1,)`.
-* **Example 2** — `C ⊕ (-C)`: single sector, two copies with raw weights
-  `(1, -1)`; the coefficient is `1 + (-1)^N`, which is *not* a scalar
-  power.  This shows why `IsBNTCanonicalForm` records raw copy weights rather
-  than replacing a sector coefficient by one scalar power.
-* **Example 3** — `C ⊕ e^{iθ}C`: single sector, two copies with raw
-  weights `(1, e^{iθ})`; the coefficient is `1 + e^{iNθ}`, illustrating
-  equal-modulus grouping with a non-trivial phase.
-* **Example 5** — `C ⊕ (1/2)C` (`halvedDecomp`): single sector, two
-  copies with raw weights `(1, 1/2)`.  Demonstrates that unequal-modulus
-  copies are admissible by the CPSV16 §II.C line-246 normalization
-  (`weight_norm_le_one` holds because both `1` and `1/2` have modulus
-  `≤ 1`; `weight_unit_exists` is witnessed by the first copy).
+* A single normal block `C`, with coefficient `1`.
+* The sign-flip GHZ pair `C ⊕ (-C)`, with length-`N` coefficient
+  `1 + (-1)^N`.
+* The phase pair `C ⊕ e^{iθ}C`, with coefficient `1 + e^{iNθ}`.
+* The unequal-modulus pair `C ⊕ (1/2)C`, with coefficient `1 + (1/2)^N`.
 
-Each example additionally exposes a named lemma `<example>_weight_unit_per_block`
-witnessing the per-block unit-modulus convention `∀ j, ∃ q, ‖μ_{j,q}‖ = 1`,
-which fundamental-theorem theorems consume as an explicit hypothesis
-(paper-implicit in CPSV16 Appendix MPV proof, line 1182's projection argument).
-
-A fourth example exercises the **optional** equal-modulus layer
-`HasEqualModulusWeightLayer` on top of `signFlipDecomp`, demonstrating
-that the equal-modulus subclass is non-empty.  The `halvedDecomp`
-construction below admits `IsBNTCanonicalForm` but does not admit
-`HasEqualModulusWeightLayer`: its two copies have unequal moduli, ruling out
-a single per-sector spectral level.
-
-Each example takes the per-block irreducibility, left-canonical,
-self-overlap, and eventual linear-independence data of `C` as hypotheses;
-this avoids reproving the underlying analytic facts here and keeps the file's
-focus on instantiating the new structure.  The former injectivity hypothesis is
-retained as an unused input for API continuity.
+The sign-flip and phase pairs have weights of equal modulus.  The final pair
+has one unit weight and one smaller weight, so it remains a BNT canonical form
+without satisfying the equal-modulus condition.
 -/
 
 open scoped Matrix BigOperators
@@ -70,7 +49,7 @@ variable {d D : ℕ}
 /-- **Example 1**: a single BNT sector with a single copy and weight `1`. -/
 noncomputable example
     (C : MPSTensor d D) (hDpos : 0 < D)
-    (_hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
@@ -138,7 +117,7 @@ raw weights `(1, -1)`.  The sector coefficient is `1 + (-1)^N`, which is
 must retain the raw copy weights in its coefficient. -/
 noncomputable example
     (C : MPSTensor d D) (hDpos : 0 < D)
-    (_hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
@@ -209,7 +188,7 @@ illustrating equal-modulus grouping in the CPSV16 two-layer BNT
 decomposition. -/
 noncomputable example
     (C : MPSTensor d D) (θ : ℝ) (hDpos : 0 < D)
-    (_hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
@@ -346,7 +325,7 @@ equals `1`.  See also
 for the original counter-example. -/
 noncomputable example
     (C : MPSTensor d D) (hDpos : 0 < D)
-    (_hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -38,11 +38,11 @@ construction below admits `IsBNTCanonicalForm` but does not admit
 `HasEqualModulusWeightLayer`: its two copies have unequal moduli, ruling out
 a single per-sector spectral level.
 
-Each example takes the per-block normality data (injectivity,
-irreducibility, left-canonical, self-overlap, eventual linear
-independence) of `C` as hypotheses; this avoids reproving the underlying
-analytic facts here and keeps the file's focus on instantiating the new
-structure.
+Each example takes the per-block irreducibility, left-canonical,
+self-overlap, and eventual linear-independence data of `C` as hypotheses;
+this avoids reproving the underlying analytic facts here and keeps the file's
+focus on instantiating the new structure.  The former injectivity hypothesis is
+retained as an unused input for API continuity.
 -/
 
 open scoped Matrix BigOperators
@@ -70,13 +70,12 @@ variable {d D : ℕ}
 /-- **Example 1**: a single BNT sector with a single copy and weight `1`. -/
 noncomputable example
     (C : MPSTensor d D) (hDpos : 0 < D)
-    (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (_hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
     IsBNTCanonicalForm (singletonDecomp C) where
   basis_dim_pos := fun _ => hDpos
-  basis_injective := fun _ => hCInj
   basis_irreducible := fun _ => hCIrr
   basis_left_canonical := fun _ => hCLeft
   basis_normalized_self_overlap := fun _ => hCSelf
@@ -139,13 +138,12 @@ raw weights `(1, -1)`.  The sector coefficient is `1 + (-1)^N`, which is
 must retain the raw copy weights in its coefficient. -/
 noncomputable example
     (C : MPSTensor d D) (hDpos : 0 < D)
-    (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (_hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
     IsBNTCanonicalForm (signFlipDecomp C) where
   basis_dim_pos := fun _ => hDpos
-  basis_injective := fun _ => hCInj
   basis_irreducible := fun _ => hCIrr
   basis_left_canonical := fun _ => hCLeft
   basis_normalized_self_overlap := fun _ => hCSelf
@@ -211,13 +209,12 @@ illustrating equal-modulus grouping in the CPSV16 two-layer BNT
 decomposition. -/
 noncomputable example
     (C : MPSTensor d D) (θ : ℝ) (hDpos : 0 < D)
-    (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (_hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
     IsBNTCanonicalForm (phaseDecomp C θ) where
   basis_dim_pos := fun _ => hDpos
-  basis_injective := fun _ => hCInj
   basis_irreducible := fun _ => hCIrr
   basis_left_canonical := fun _ => hCLeft
   basis_normalized_self_overlap := fun _ => hCSelf
@@ -349,13 +346,12 @@ equals `1`.  See also
 for the original counter-example. -/
 noncomputable example
     (C : MPSTensor d D) (hDpos : 0 < D)
-    (hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
+    (_hCInj : IsInjective C) (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
     (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
     (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
     IsBNTCanonicalForm (halvedDecomp C) where
   basis_dim_pos := fun _ => hDpos
-  basis_injective := fun _ => hCInj
   basis_irreducible := fun _ => hCIrr
   basis_left_canonical := fun _ => hCLeft
   basis_normalized_self_overlap := fun _ => hCSelf

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -11,9 +11,9 @@ import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 /-!
 # Prepared-block SectorBNT constructor
 
-Given a finite family of **already prepared** TP / primitive / irreducible /
-injective blocks with nonzero weights satisfying the CPSV16 §II.C line-246
-normalization (`|μ_k| ≤ 1` and at least one `|μ_k| = 1`), this file produces a
+Given a finite family of **already prepared** TP / primitive / irreducible
+blocks with nonzero weights satisfying the CPSV16 §II.C line-246 normalization
+(`|μ_k| ≤ 1` and at least one `|μ_k| = 1`), this file produces a
 `SectorDecomposition` `P` together with a proof that
 
 * `P.toTensor` has the same MPV at every length as the original
@@ -256,8 +256,8 @@ theorem collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr
 /--
 **Prepared-block SectorBNT constructor.**
 
-Given a finite family of TP, primitive, irreducible, injective blocks with
-nonzero weights satisfying the SectorBNT normalization conditions, produce a
+Given a finite family of TP, primitive, irreducible blocks with nonzero weights
+satisfying the SectorBNT normalization conditions, produce a
 `SectorDecomposition P` and a proof that `IsBNTCanonicalForm P` and the
 assembled tensor agrees with the original direct sum.
 
@@ -265,7 +265,7 @@ Paper anchor: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 271-279 and
 1135-1148 for prop:char-BNT, and lines 283-301 for the two-layer BNT/copy
 expansion.
 -/
-theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks
+theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -273,7 +273,6 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks
     (hTP : ∀ k, IsLeftCanonical (blocks k))
     (hPrim : ∀ k, _root_.IsPrimitive (transferMap (blocks k)))
     (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
-    (hInj : ∀ k, IsInjective (blocks k))
     (hμne : ∀ k, μ k ≠ 0)
     (hμLe : ∀ k, ‖μ k‖ ≤ 1)
     (hμUnit : ∃ k, ‖μ k‖ = 1) :
@@ -317,8 +316,6 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks
     -- `P.basisDim j` is definitionally `dim (classes.repr j)`.
     change 0 < dim (classes.repr j)
     exact hDim (classes.repr j)
-  have h_inj : ∀ j : Fin P.basisCount, IsInjective (P.basis j) := by
-    intro j; change IsInjective (blocks (classes.repr j)); exact hInj (classes.repr j)
   have h_irr : ∀ j : Fin P.basisCount, IsIrreducibleTensor (P.basis j) := by
     intro j; change IsIrreducibleTensor (blocks (classes.repr j)); exact hIrr (classes.repr j)
   have h_lc : ∀ j : Fin P.basisCount, IsLeftCanonical (P.basis j) := by
@@ -365,7 +362,6 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks
   refine ⟨P, hSame, ?_⟩
   exact
     { basis_dim_pos := h_dim_pos
-      basis_injective := h_inj
       basis_irreducible := h_irr
       basis_left_canonical := h_lc
       basis_normalized_self_overlap := h_self_overlap
@@ -388,7 +384,7 @@ remaining ingredient is the CPSV16 §II.C line 246 normalization
 which the source paper makes an explicit user choice ("we can always choose
 this normalization, which we will assume").  A separate normalization layer
 or hypothesis passes those facts to the prepared-block supplier
-`exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks` to obtain
+`exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks` to obtain
 the full `IsBNTCanonicalForm` conclusion.
 
 Paper anchor: Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608,
@@ -418,7 +414,7 @@ The CPSV16 §II.C line 246 weight normalization is **not** delivered
 here, since the source paper makes this an explicit user assumption.  A
 separate normalization hypothesis is composed with the prepared
 blocks here to feed the `IsBNTCanonicalForm` constructor
-`exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks`.
+`exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks`.
 
 Construction steps:
 
@@ -597,7 +593,7 @@ theorem exists_prepared_BNT_blocks_afterBlocking_pos
 
 Composing the prepared-block supplier `exists_prepared_BNT_blocks_afterBlocking_pos`
 with the prepared-block BNT constructor
-`exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks` closes the
+`exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks` closes the
 arbitrary-input path on the SectorBNT construction, with one explicit user assumption.
 
 The CPSV16 paper makes the weight normalization (absolute value of every weight
@@ -656,9 +652,9 @@ theorem exists_isBNTCanonicalForm_afterBlocking_pos
   refine ⟨p, hp, r, dim, μ, blocks, hDim, hTP, hPrim, hIrr, hInj, hμne, hSamePos, ?_⟩
   intro hμLe hμUnit
   obtain ⟨P, hSame, hBNT⟩ :=
-    exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks
+    exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
       (d := blockPhysDim d p) (r := r) (dim := dim)
-      μ blocks hDim hTP hPrim hIrr hInj hμne hμLe hμUnit
+      μ blocks hDim hTP hPrim hIrr hμne hμLe hμUnit
   refine ⟨P, ?_, hBNT⟩
   -- Chain the positive-length MPV identity with the prepared-block agreement.
   -- `hSamePos`: `mpv (blockTensor A p) σ = mpv (toTensorFromBlocks μ blocks) σ` for `N > 0`.

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.Core.CPPrimitive
 import TNLean.PiAlgebra.CanonicalFormSepAux
-import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.Irreducible.FormII
 import TNLean.Spectral.QuantitativeGap
 

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -25,7 +25,6 @@ that are renormalization fixed points, following arXiv:1606.00608 Section 3.4
 * `rfp_nt_cfii_diagonal_fixedPoint`: Appendix B / CFII reduction step — after unitary
   conjugation, a left-canonical normal RFP tensor has a diagonal positive-definite fixed point
 * `rfp_cf_structural`: each canonical-form block is injective
-* `rfp_bnt_structural`: each BNT basis block of a `SectorDecomposition` is injective
 
 ## Proof strategy
 
@@ -256,16 +255,5 @@ theorem rfp_cf_structural {r : ℕ} {dim : Fin r → ℕ}
     (hCF : IsCanonicalForm μ A) :
     ∀ k, IsInjective (A k) :=
   hCF.block_injective
-
-/-- Every BNT basis block is injective.
-
-Given a sector decomposition `P` in BNT canonical form (CPSV16 §III, `thm:charact-MPS`,
-arXiv:1606.00608 lines 543–555; basis-block properties at lines 271–301 and 317–344),
-every basis block `P.basis j` is an injective MPS tensor.  The result is a direct projection
-of `IsBNTCanonicalForm.basis_injective`. -/
-theorem rfp_bnt_structural (P : SectorDecomposition d)
-    (hP : IsBNTCanonicalForm P) :
-    ∀ j, IsInjective (P.basis j) :=
-  hP.basis_injective
 
 end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -743,12 +743,18 @@ preparation of suitable blocks from the normalized-weight BNT construction.
 
 \begin{proof}\leanok
     The phase-class quotient groups gauge-phase-equivalent blocks into sectors
-    with unit-modulus per-copy scalars. The TP, primitive, and irreducible
-    hypotheses are those under which the phase-class construction applies; they
-    give the eventual linear-independence condition through the cross-overlap
-    decay of distinct phase classes, with no injectivity required. The resulting
-    sector decomposition inherits the span and multiplicity conditions, and the
-    bounded-weight and global-unit hypotheses give the weight-norm conditions.
+    with unit-modulus per-copy scalars. Under the TP, primitive, and irreducible
+    hypotheses the phase-class construction applies, and for distinct
+    representatives $B_j$, $B_{j'}$ ($j \neq j'$) the cross-overlap decays,
+    \[
+        \lim_{N\to\infty} O_{B_j B_{j'}}(N) = 0,
+        \qquad
+        \lim_{N\to\infty} O_{B_j B_j}(N) = 1,
+    \]
+    which gives the eventual linear-independence condition with no injectivity
+    required. The resulting sector decomposition inherits the span and
+    multiplicity conditions, and the bounded-weight and global-unit hypotheses
+    give the weight-norm conditions.
 \end{proof}
 
 \begin{lemma}[Total dimension of a dimension-preserving phase-class quotient]%

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -632,7 +632,7 @@ Chapter~\ref{ch:ft_proof}.
     records the minimal BNT hypotheses of
     \cite{Cirac2016MPDO_arXiv,Cirac2021Matrix} without any equal-modulus
     or strict-ordering condition on the raw sector weights. It asserts that
-    each basis block has positive bond dimension, is injective, irreducible,
+    each basis block has positive bond dimension, is irreducible,
     and left-canonical; the normalized self-overlap of every basis block
     converges to $1$; the basis MPV family is eventually linearly
     independent; distinct same-dimension basis blocks are not gauge-phase
@@ -720,7 +720,7 @@ preparation of suitable blocks from the normalized-weight BNT construction.
 
 \begin{theorem}[BNT from normal blocks with normalized weights]%
     \label{thm:paperbnt_supplier_prepared}
-    \lean{MPSTensor.exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks}
+    \lean{MPSTensor.exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks}
     \leanok
     Let $r \in \N$, and for each $k = 1,\ldots,r$ let $D_k \in \N$,
     $\mu_k \in \C$, and let $B_k$ be an MPS tensor of physical dimension $d$ and
@@ -730,7 +730,6 @@ preparation of suitable blocks from the normalized-weight BNT construction.
         \item \textbf{TP normalization:} $\sum_i (B_k^i)^\dagger B_k^i = \Id$,
         \item \textbf{primitivity:} $\E_{B_k}$ is primitive for each $k$,
         \item \textbf{irreducibility:} each $B_k$ is irreducible,
-        \item \textbf{injectivity:} each $B_k$ is injective,
         \item \textbf{nonzero weights:} $\mu_k \neq 0$ for all $k$,
         \item \textbf{bounded weights:} $|\mu_k| \le 1$ for all $k$,
         \item \textbf{global unit witness:} $|\mu_k| = 1$ for some $k$.
@@ -745,8 +744,9 @@ preparation of suitable blocks from the normalized-weight BNT construction.
 \begin{proof}\leanok
     The phase-class quotient groups gauge-phase-equivalent blocks into sectors
     with unit-modulus per-copy scalars. The TP, primitive, and irreducible
-    hypotheses are those under which the phase-class construction applies, while
-    injectivity gives the eventual linear-independence condition. The resulting
+    hypotheses are those under which the phase-class construction applies; they
+    give the eventual linear-independence condition through the cross-overlap
+    decay of distinct phase classes, with no injectivity required. The resulting
     sector decomposition inherits the span and multiplicity conditions, and the
     bounded-weight and global-unit hypotheses give the weight-norm conditions.
 \end{proof}

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -425,24 +425,6 @@ and rates for the single-tensor transfer map $\E_A$.
     \texttt{IsCanonicalForm}.
 \end{proof}
 
-\begin{theorem}[BNT basis blocks are injective]\label{thm:rfp_bnt_structural}
-    \lean{MPSTensor.rfp_bnt_structural}
-    \leanok
-    \uses{def:bnt, def:injective}
-    Let $P$ be a sector decomposition in BNT canonical form.
-    Then every basis block $P_j$ is injective as an MPS tensor.
-    This is the basis-block injectivity part of
-    \cite[Section~III]{Cirac2016MPDO_arXiv}
-    (\texttt{thm:charact-MPS}, lines 543--555;
-    basis-block normality established at lines 271--301 and 317--344).
-\end{theorem}
-\begin{proof}\leanok
-    \uses{thm:rfp_cf_structural}
-    Direct projection of the \texttt{basis\_injective} field of
-    \texttt{IsBNTCanonicalForm}.  The result holds for arbitrary copy
-    multiplicities, since the statement concerns only BNT basis blocks and
-    not copy weights.
-\end{proof}
 
 \begin{theorem}[RG flow convergence for canonical-form tensors]%
     \label{thm:rg_flow_converges_of_cf}


### PR DESCRIPTION
## Summary

**Gap 2 of the FT-assembly arc** (stacked on #2251). Relaxes `IsBNTCanonicalForm` to CPSV16's *actual* basis-of-normal-tensors by dropping the `basis_injective` field.

## Why this is faithful (and the field was wrong)
In CPSV16 (Papers/1606.00608) a **basis of normal tensors** is built from **normal** tensors -- primitive, with a single peripheral eigenvalue (lines 233-234, 271-274). **One-site injectivity is a separate notion** ("block-injective canonical form"), reached only after Wielandt blocking (lines 317-344). So requiring `basis_injective` inside `IsBNTCanonicalForm` was **stronger than the paper's BNT**, conflating BNT with biCF.

A read-only audit (and the green build) confirm **no aperiodic FT endpoint, and none of the derived fields** (`bnt_data`, `basis_normalized_self_overlap`, `basis_distinct`) uses injectivity -- the whole endpoint dependency graph already runs on the **primitive + irreducible + TP** route. The field's only reader was the zero-consumer `rfp_bnt_structural`.

## Changes
- **Drop** `basis_injective` from `IsBNTCanonicalForm` (`SectorBNT/Basic.lean`).
- **Rename + weaken the supplier**: `exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks` -> `..._of_tp_primitive_irr_blocks`, dropping its now-dead `hInj`. A BNT canonical form is now built **directly from primitive+irreducible+TP nonzero blocks** -- exactly what `unconditional_commonPrimitiveIrreducibleBlocks` produces -- with **no injectivity**. This is the clean entry point the assembly needs.
- Fix the four `Examples.lean` constructors.
- **Delete** the now-unprovable orphan `rfp_bnt_structural` (`RFP/StructuralForm.lean`) + its ch15 anchor.
- **Blueprint**: `ch10` `def:sector_bnt_cf` drops the injectivity clause; `thm:paperbnt_supplier_prepared` retargets to the renamed decl and drops the injectivity hypothesis/prose; `ch15` removes `thm:rfp_bnt_structural`.

## Gates
- `lake build TNLean`: green (8745 jobs); only pre-existing PEPS/Periodic `sorry` warnings.
- `#print axioms ft_sector_bnt_equal_mps_gaugeEquiv_literal`: `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
- `blueprint_lean_sync.py`: ch10 71/71, ch15 25/25 (100%); total 65 = baseline.
- XeLaTeX: 0 undefined refs, 0 errors; ch10/ch15 latexindent-clean.

## Significance
With Gap 1 (#2251) and this PR, **both gaps that kept the aperiodic FT source statements `\notready` are closed**. The next PR assembles CPSV16 **Corollary II.2** (equal case) as the literal source theorem on the canonical-form/BNT surface.

> Note: stacked on #2251; base will retarget to `main` once that merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a core FT predicate and the main BNT construction API; downstream proofs must not have depended on `basis_injective` (PR claims they do not).
> 
> **Overview**
> **Relaxes** `IsBNTCanonicalForm` to match CPSV16’s basis-of-normal-tensors by **dropping** the `basis_injective` field from `SectorBNT/Basic.lean` and updating the module docs accordingly.
> 
> The prepared-block supplier is **renamed and weakened**: `exists_isBNTCanonicalForm_of_tp_primitive_irr_injective_blocks` → `exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks`, with the injectivity hypothesis and `basis_injective` proof branch removed. The four `Examples.lean` constructors no longer assume `IsInjective C`. The orphan **`rfp_bnt_structural`** theorem and its `SectorBNT` import are **removed** from `RFP/StructuralForm.lean`; blueprint **ch10** (`def:sector_bnt_cf`, `thm:paperbnt_supplier_prepared`) and **ch15** are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06743c8b8e29661857f1b56a44b4e432b610146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->