### PR TITLE
feat(MPS/FT): close CPSV16 Corollary II.2 (equal-case Fundamental Theorem)

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -553,4 +553,29 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_literal
   ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
     (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
+/-- **Fundamental Theorem of MPS, equal case (CPSV16 Corollary II.2).**
+
+Two BNT canonical forms generating the same MPV family at every length are
+globally conjugate: their total bond dimensions agree, and a single invertible
+gauge `Y` carries one total tensor to the other.  This is the literal
+equal-case source statement on the basis-of-normal-tensors canonical-form
+surface — no per-sector unit-modulus restriction and no one-site injectivity
+assumption (arXiv:1606.00608, Corollary II.2; Appendix MPV proof,
+lines 1189–1192). -/
+theorem fundamentalTheorem_equal_canonicalForm
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
+      ∀ i : Fin d,
+        Q.toTensor i =
+          (Y : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+            cast (by rw [hTotal] :
+                Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+                Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
+              (P.toTensor i) *
+            (((Y)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+              Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) :=
+  ft_sector_bnt_equal_mps_gaugeEquiv_literal hP hQ hEqual
+
 end MPSTensor

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -87,28 +87,34 @@ then combined in Theorem~\ref{thm:sector_bnt_equal_global_gauge}. The same-index
 direct-sum corollaries of Chapter~\ref{ch:algebraic_ft} are useful algebraic
 consequences, but they are not the BNT block-matching theorem itself.
 
-\begin{theorem}[Equal canonical-form representations are globally conjugate]%
+\begin{theorem}[Equal BNT canonical forms are globally conjugate]%
     \label{thm:cpgsv_equal_case_source}
     \lean{MPSTensor.fundamentalTheorem_equal_canonicalForm}
     \leanok
     \uses{def:sector_bnt_cf, thm:sector_bnt_equal_mps_gaugeEquiv_literal}
-    Let $A$ and $B$ be canonical-form representations generating the same MPV
-    family for every system size~$N$. Then the matrix dimensions of $A^i$ and
-    $B^i$ coincide, and there is one invertible matrix $X$ such that, for every
-    physical index~$i$,
+    Let $P$ and $Q$ be BNT canonical forms (Definition~\ref{def:sector_bnt_cf})
+    whose total tensors $P_{\mathrm{tot}}$, $Q_{\mathrm{tot}}$ generate the same
+    MPV family for every system size~$N$. Then their total bond dimensions
+    coincide; writing the common value as~$D$, there is one invertible matrix
+    $X \in \GL_D(\C)$ such that, for every physical index~$i$,
     \[
-        A^i
+        Q_{\mathrm{tot}}^i
         =
-        X\,B^i\,X^{-1}.
+        X\,P_{\mathrm{tot}}^i\,X^{-1}.
     \]
     Thus the equal case removes the blockwise phase freedom of the proportional
     theorem and gives a single global conjugacy.
 
-    Here a \emph{canonical-form representation} is rendered as a BNT canonical
-    form (Definition~\ref{def:sector_bnt_cf}): the canonical form of
+    This is the equal-case corollary
+    \cite[Corollary~II.2]{Cirac2017MPDO_AnnPhys} on the
+    basis-of-normal-tensors surface: the canonical form of
     \cite[\S~II.C]{Cirac2016MPDO_arXiv} is a direct sum of normal tensors with
-    scalar weights, which is exactly a BNT canonical form, and $A^i$, $B^i$ are
-    the associated total tensors.
+    scalar weights, which is exactly a BNT canonical form, so the hypothesis is
+    the paper's ``$A$ and $B$ in canonical form'' and $P_{\mathrm{tot}}$,
+    $Q_{\mathrm{tot}}$ are the represented tensors. The statement is on
+    canonical-form tensors directly; the reduction of an \emph{arbitrary} pair
+    of same-MPV tensors to a common BNT canonical form is the after-blocking
+    common-sector decomposition of Chapter~\ref{ch:canonical}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -9,12 +9,15 @@ comparison, copy-weight recovery, and block-diagonal gauge construction in
 Chapter~\ref{ch:bnt}.
 
 Section~\ref{sec:ft_source_theorems} states the two source statements: the
-multi-block proportional theorem and its equal-case corollary. They remain
-marked as not ready, because they are obtained only once the canonical-form
+multi-block proportional theorem and its equal-case corollary. The equal-case
+corollary (Theorem~\ref{thm:cpgsv_equal_case_source}) is proved here on the
+basis-of-normal-tensors canonical-form surface, by combining the canonical-form
 reduction, the BNT representative comparison, the repeated-copy coefficient
-comparison, and the global gauge conclusion have been combined from the source
-hypotheses. Section~\ref{sec:ft_equal_mpv_comparisons} records where the BNT
-comparison of Chapter~\ref{ch:bnt} enters that combination.
+comparison, and the global gauge conclusion. The multi-block proportional
+theorem (Theorem~\ref{thm:cpgsv_multiblock_ft_source}) remains marked as not
+ready: it additionally requires deriving the matched-sector coefficient identity
+from the proportional-MPV hypothesis. Section~\ref{sec:ft_equal_mpv_comparisons}
+records where the BNT comparison of Chapter~\ref{ch:bnt} enters.
 
 The comparison is made at fixed sufficiently large system size. A sector
 coefficient with $|\mu|<1$ may decay with~$N$, but BNT linear independence at a
@@ -84,12 +87,11 @@ then combined in Theorem~\ref{thm:sector_bnt_equal_global_gauge}. The same-index
 direct-sum corollaries of Chapter~\ref{ch:algebraic_ft} are useful algebraic
 consequences, but they are not the BNT block-matching theorem itself.
 
-% The equal-case source corollary remains not ready until the unrestricted
-% source theorem has been proved from the common blocked surface, the
-% paper-faithful BNT coefficient comparison, and the global gauge construction.
 \begin{theorem}[Equal canonical-form representations are globally conjugate]%
     \label{thm:cpgsv_equal_case_source}
-    \notready
+    \lean{MPSTensor.fundamentalTheorem_equal_canonicalForm}
+    \leanok
+    \uses{def:sector_bnt_cf, thm:sector_bnt_equal_mps_gaugeEquiv_literal}
     Let $A$ and $B$ be canonical-form representations generating the same MPV
     family for every system size~$N$. Then the matrix dimensions of $A^i$ and
     $B^i$ coincide, and there is one invertible matrix $X$ such that, for every
@@ -101,14 +103,30 @@ consequences, but they are not the BNT block-matching theorem itself.
     \]
     Thus the equal case removes the blockwise phase freedom of the proportional
     theorem and gives a single global conjugacy.
+
+    Here a \emph{canonical-form representation} is rendered as a BNT canonical
+    form (Definition~\ref{def:sector_bnt_cf}): the canonical form of
+    \cite[\S~II.C]{Cirac2016MPDO_arXiv} is a direct sum of normal tensors with
+    scalar weights, which is exactly a BNT canonical form, and $A^i$, $B^i$ are
+    the associated total tensors.
 \end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:sector_bnt_equal_mps_gaugeEquiv_literal}
+    This is Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}. The BNT
+    coefficient comparison of Chapter~\ref{ch:bnt} provides the basis
+    relabelling, the per-block gauge-phase equivalences, the copy-weight
+    multiset matching, and the assembled block-diagonal global gauge. The exact
+    linear-independence matching needs no per-sector unit-modulus hypothesis,
+    and the basis-of-normal-tensors surface needs no one-site injectivity, so
+    the conjugacy holds for every equal-MPV pair of BNT canonical forms.
+\end{proof}
 
 This is the equal-case corollary of
 \cite[Corollary~II.2]{Cirac2017MPDO_AnnPhys}; see also
 \cite[Corollary~IV.5]{Cirac2021Matrix}. The coefficient identities for the
 paired sectors are supplied by the BNT comparison of Chapter~\ref{ch:bnt}; the
-weight recovery uses Newton--Girard. The resulting global conjugacy is recorded
-in Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}.
+weight recovery uses Newton--Girard.
 
 \section{The equal-MPV comparison}%
 \label{sec:ft_equal_mpv_comparisons}


### PR DESCRIPTION
## Summary

**The capstone of the FT-assembly arc** (stacked on #2252 → #2251): closes **CPSV16 Corollary II.2**, the equal-case Fundamental Theorem of MPS.

Adds the named headline theorem
```lean
theorem fundamentalTheorem_equal_canonicalForm
    {P Q : SectorDecomposition d}
    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
    ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
      ∀ i, Q.toTensor i = Y * cast … (P.toTensor i) * Y⁻¹
```
Two BNT canonical forms generating the same MPV family at every length are **globally conjugate** (equal total bond dimension + a single invertible gauge). It is proved directly from the now-unrestricted endpoint `ft_sector_bnt_equal_mps_gaugeEquiv_literal` — with **no per-sector unit-modulus hypothesis** (closed in #2251) and **no one-site injectivity** (closed in #2252).

## Blueprint
Flips `ch11` `thm:cpgsv_equal_case_source` from `\notready` to `\leanok`, anchored to the new theorem, with a proof block and a faithfulness note: a *canonical-form representation* is rendered as a **BNT canonical form** — CPSV16 §II.C's canonical form is a direct sum of normal tensors with scalar weights (arXiv:1606.00608 lines 237–243), which is exactly a BNT canonical form. The chapter intro is updated to reflect the split status.

The **multi-block proportional theorem** (Thm II.1, `thm:cpgsv_multiblock_ft_source`) intentionally **stays `\notready`**: it additionally needs the matched-sector coefficient identity derived from the proportional-MPV hypothesis (an independent, still-open task on the proportional route).

## Why this is honest, not overclaimed
The theorem is stated on the BNT canonical-form surface — exactly CPSV16's hypothesis "A, B in canonical form" — and the appendix FT proof runs on normal tensors at single site (no blocking), so there is no hidden deblocking or injectivity debt. The earlier "deblocking gap" was an artifact of an unused injectivity field, removed in #2252.

## Gates
- `lake build TNLean`: green (8745 jobs).
- `#print axioms fundamentalTheorem_equal_canonicalForm`: `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
- `blueprint_lean_sync.py`: ch11 1/1 (100%); total 65 = baseline.
- XeLaTeX: 0 undefined refs, 0 errors; ch11 latexindent-clean; no dangling refs.

## Arc recap (3 stacked PRs)
1. **#2251** — exact matcher removes the per-sector unit-modulus restriction (equal case).
2. **#2252** — relax `IsBNTCanonicalForm` to the paper's actual (non-injective) BNT.
3. **this** — assemble & close Corollary II.2.

> Stacked; base retargets to `main` as the lower PRs merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API and documentation sync; no changes to authentication, I/O, or the underlying gauge proof beyond a thin theorem alias.
> 
> **Overview**
> **Closes the equal-case Fundamental Theorem (CPSV16 Corollary II.2)** on the BNT canonical-form surface by exposing a named Lean headline `MPSTensor.fundamentalTheorem_equal_canonicalForm`: two `IsBNTCanonicalForm` sector decompositions with `SameMPV₂` total tensors get equal `totalDim` and a single global gauge conjugating every site tensor. The proof is a direct delegate to the existing literal global-gauge endpoint `ft_sector_bnt_equal_mps_gaugeEquiv_literal` (no new proof obligations).
> 
> The blueprint chapter on FT source theorems is updated so **Theorem `cpgsv_equal_case_source` is `\leanok`** with `\lean{MPSTensor.fundamentalTheorem_equal_canonicalForm}`, a `\leanok` proof block, and notation aligned to BNT totals \(P_{\mathrm{tot}}, Q_{\mathrm{tot}}\). The chapter intro now states the equal corollary is proved here while the **multi-block proportional theorem stays `\notready`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d609a1cf694c4c983a38170258a72139ffe2f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->