### PR TITLE
blueprint(ch:mps): add blocking and MPV-overlap tensor-network diagrams

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -43,6 +43,8 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPSLocal": "tensor label",
     "TNMPSWord": "tensor left right length",
     "TNMPV": "tensor left right length",
+    "TNBlocking": "tensor left right length",
+    "TNMPVOverlap": "left right length",
     "TNTransferMap": "tensor",
     "TNMPOCell": "tensor top bottom",
     "TNMPOChain": "tensor top_left bottom_left top_right bottom_right length",

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -616,6 +616,12 @@ boundary conditions (PBC).
         (A^{[L]})^{(i_1, \ldots, i_L)}
         =  A^{i_1} A^{i_2} \cdots A^{i_L}.
     \]
+    Blocking coarse-grains $L$ neighbouring sites into one tensor: the inner
+    virtual bonds are contracted, the $L$ physical legs merge into a single
+    composite index, and the two outer bonds remain as the bond of $A^{[L]}$.
+    \begin{center}
+        \TNBlocking{A}{i_1}{i_L}{L}
+    \end{center}
 \end{definition}
 
 \begin{lemma}[Blocked word evaluation]\label{lem:eval_word_block}
@@ -725,6 +731,12 @@ boundary conditions (PBC).
         \sum_{\sigma \in \{0,\ldots,d{-}1\}^N}
         V^{(N)}(A)_\sigma \overline{V^{(N)}(B)_\sigma}.
     \]
+    Diagrammatically, the overlap contracts the MPV ring of $A$ against the
+    conjugate ring of $B$ along their shared physical indices, both virtual
+    rings closed by the trace:
+    \begin{center}
+        \TNMPVOverlap{A}{B}{N}
+    \end{center}
     This is the bilinear overlap (without complex conjugation) used later. By
     Lemma~\ref{lem:overlap_eq_inner}, it is the complex conjugate of
     the Hilbert-space inner product from Definition~\ref{def:mpv_inner}.

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -39,6 +39,40 @@
   \end{tikzpicture}%
 }
 
+% Blocking: L neighbouring local tensors grouped (dashed box) into one
+% blocked tensor; physical legs poke out the top, the outer virtual legs
+% become the blocked bond.
+\newcommand{\TNBlocking}[4]{%
+  \begin{tikzpicture}[tn picture]
+    \TN@openMPSword{tn}{#2}{#3}{#4}
+    \draw[densely dashed, rounded corners]
+      ($(tnL.west)+(-0.30,0.22)$) rectangle ($(tnR.east)+(0.30,-0.34)$);
+  \end{tikzpicture}%
+}
+
+% MPV overlap: the top row carries copies of #1, the bottom row the conjugate
+% copies of #2; the shared physical indices are contracted between the rows and
+% both virtual rings are closed by the trace (the boxes above and below).
+\newcommand{\TNMPVOverlap}[3]{%
+  \begin{tikzpicture}[tn picture]
+    \TN@tensordot{ovuL}{(0,0.62)}
+    \TN@tensordot{ovuM}{(\TN@chainsep,0.62)}
+    \TN@tensordot{ovuR}{(\TN@chainright,0.62)}
+    \draw[tn leg] (-0.48,0.62) rectangle (4.68,1.06);
+    \node at (\TN@chainellipsisx,0.62) {$\cdots$};
+    \TN@tensordot{ovdL}{(0,-0.62)}
+    \TN@tensordot{ovdM}{(\TN@chainsep,-0.62)}
+    \TN@tensordot{ovdR}{(\TN@chainright,-0.62)}
+    \draw[tn leg] (-0.48,-0.62) rectangle (4.68,-1.06);
+    \node at (\TN@chainellipsisx,-0.62) {$\cdots$};
+    \draw[tn phys leg] (ovuL.south) -- (ovdL.north);
+    \draw[tn phys leg] (ovuM.south) -- (ovdM.north);
+    \draw[tn phys leg] (ovuR.south) -- (ovdR.north);
+    \node[anchor=east] at (-0.85,0.62) {$#1$};
+    \node[anchor=east] at (-0.85,-0.62) {$\overline{#2}$};
+  \end{tikzpicture}%
+}
+
 \newcommand{\TNTransferMap}[1]{%
   \begin{tikzpicture}[tn picture]
     \TN@tensordot{tnUp}{(0,0.44)}

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -1,7 +1,7 @@
 name: TNTikZDiagram
 {{ obj.tn_svg_html }}
 
-name: TNMPSLocal TNMPSWord TNMPV TNTransferMap TNMPOCell TNMPOChain
+name: TNMPSLocal TNMPSWord TNMPV TNBlocking TNMPVOverlap TNTransferMap TNMPOCell TNMPOChain
 {{ obj.tn_svg_html }}
 
 name: TNGaugeConjugation TNPhysicalRealization TNLinearTwist


### PR DESCRIPTION
## Summary

Adds two tensor-network diagrams to the MPV chapter (Chapter 2): one for the
blocked tensor and one for the MPV overlap. Part of the MPV-chapter clarity
pass. Both render in the PDF and the web build.

## Changes

- **`\TNBlocking`** (new public macro) — `L` neighbouring local tensors in a
  dashed grouping box forming the blocked tensor `A^{[L]}`: physical legs out
  the top, the two outer virtual legs as the blocked bond. Used in
  `def:blocked_tensor`.
- **`\TNMPVOverlap`** (new public macro) — the double-layer periodic overlap
  ring: copies of `A` on top, conjugate copies of `B` below, physical indices
  contracted between the layers, both virtual rings closed by the trace. Used
  in `def:mpv_overlap`.
- Wired through `macros/tn_print.tex` (definitions), `Packages/tn_diagrams.py`
  (web SVG registry, arity-matched), and `plastex_templates/TensorNetworkDiagrams.jinja2s`
  (SVG template binding).
- A one-line motivating sentence accompanies each diagram.

## Build

- PDF: 306-page build, no errors.
- Web: both macros render via the SVG path (no default-renderer fallback);
  `ch-mps.html` embeds 7 tensor-network SVGs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and TikZ/plasTeX wiring only; no Lean or runtime behavior changes.
> 
> **Overview**
> Adds **two tensor-network figures** to the MPV chapter (Ch. 2) and hooks them into the shared PDF/web diagram stack.
> 
> **`\TNBlocking`** illustrates the $L$-blocked tensor: an open MPS word of length $L$ inside a dashed box, with a short prose note on coarse-graining. It appears in `def:blocked_tensor`.
> 
> **`\TNMPVOverlap`** shows the double-layer periodic overlap (tensor $A$ on top, $\overline{B}$ below, physical legs contracted, virtual rings traced). It appears in `def:mpv_overlap`, with matching explanatory text.
> 
> Registrations in `tn_diagrams.py` and `TensorNetworkDiagrams.jinja2s` keep web SVG arity and templates aligned with `tn_print.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19e1133fd7d1de87b5d19efee9db092b25deac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->