### PR TITLE
blueprint(macros): compact the MPV-overlap diagram and fix ellipsis overlap

### DIFF
--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -55,21 +55,21 @@
 % both virtual rings are closed by the trace (the boxes above and below).
 \newcommand{\TNMPVOverlap}[3]{%
   \begin{tikzpicture}[tn picture]
-    \TN@tensordot{ovuL}{(0,0.62)}
-    \TN@tensordot{ovuM}{(\TN@chainsep,0.62)}
-    \TN@tensordot{ovuR}{(\TN@chainright,0.62)}
-    \draw[tn leg] (-0.48,0.62) rectangle (4.68,1.06);
-    \node at (\TN@chainellipsisx,0.62) {$\cdots$};
-    \TN@tensordot{ovdL}{(0,-0.62)}
-    \TN@tensordot{ovdM}{(\TN@chainsep,-0.62)}
-    \TN@tensordot{ovdR}{(\TN@chainright,-0.62)}
-    \draw[tn leg] (-0.48,-0.62) rectangle (4.68,-1.06);
-    \node at (\TN@chainellipsisx,-0.62) {$\cdots$};
+    \TN@tensordot{ovuL}{(0,0.42)}
+    \TN@tensordot{ovuM}{(\TN@chainsep,0.42)}
+    \TN@tensordot{ovuR}{(\TN@chainright,0.42)}
+    \draw[tn leg] (-0.48,0.42) rectangle (4.68,0.74);
+    \TN@tensordot{ovdL}{(0,-0.42)}
+    \TN@tensordot{ovdM}{(\TN@chainsep,-0.42)}
+    \TN@tensordot{ovdR}{(\TN@chainright,-0.42)}
+    \draw[tn leg] (-0.48,-0.42) rectangle (4.68,-0.74);
     \draw[tn phys leg] (ovuL.south) -- (ovdL.north);
     \draw[tn phys leg] (ovuM.south) -- (ovdM.north);
     \draw[tn phys leg] (ovuR.south) -- (ovdR.north);
-    \node[anchor=east] at (-0.85,0.62) {$#1$};
-    \node[anchor=east] at (-0.85,-0.62) {$\overline{#2}$};
+    % single centred ellipsis in the omitted-site column (no line crosses it)
+    \node at (\TN@chainellipsisx,0) {$\cdots$};
+    \node[anchor=east] at (-0.85,0.42) {$#1$};
+    \node[anchor=east] at (-0.85,-0.42) {$\overline{#2}$};
   \end{tikzpicture}%
 }
 


### PR DESCRIPTION
## Summary

Adjusts the `\TNMPVOverlap` (MPV overlap) tensor-network diagram per review feedback:

- **More compact vertically:** the two trace rings move from `y = ±0.62` to
  `y = ±0.42` and the trace-box height shrinks from `0.44` to `0.32` (≈30%
  shorter overall).
- **Ellipsis no longer overlaps a line:** the two per-ring `\cdots` (which sat
  on the trace-box edges) are replaced by a single centred `\cdots` in the
  omitted-site column, where no box edge or physical leg crosses it.

Verified by rendering the standalone macro (renders cleanly; rings compact, `⋯`
clear of all lines). Used in ch02 `def:mpv_overlap`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX/TikZ layout only for one public diagram macro; no runtime, API, or proof content changes.
> 
> **Overview**
> Tightens the **`\TNMPVOverlap`** MPV-overlap TikZ figure in `tn_print.tex`: the upper and lower trace rings move from **y = ±0.62** to **±0.42**, and the trace rectangles shrink vertically (about **30%** shorter overall).
> 
> **Ellipsis layout:** the two **`\cdots`** nodes that sat on each ring’s trace box are removed; one **`\cdots`** is drawn at the chain’s omitted-site column (**`\TN@chainellipsisx`**, **y = 0**) so it does not sit on a box edge or physical leg. Row labels (**`#1`**, **`overline{#2}`**) follow the new vertical positions.
> 
> Used unchanged in ch02 **`def:mpv_overlap`** via **`\TNMPVOverlap{A}{B}{N}`**—diagram-only, no logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb41cfc7469d8e2fa0b874355e67aab4d54be845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->