### PR TITLE
blueprint(ch:canonical): replace the stage arrow-chain with the central idea

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -6,17 +6,11 @@ reduced to a weighted family of primitive blocks; Chapter~\ref{ch:bnt} construct
 the basis of normal tensors carried by those blocks and compares their
 coefficients, and Chapter~\ref{ch:ft_proof} proves the theorem itself. The
 reduction follows~\cite{PerezGarcia2007Matrix}, \cite{Cirac2017MPDO_AnnPhys},
-\cite{Cirac2021Matrix}, and~\cite[Chapter~6]{Wolf2012Quantum}, and proceeds in
-stages,
-\[
-    \text{invariant-subspace split}
-    \to \text{irreducible block decomposition}
-    \to \text{zero-block separation}
-    \to \text{TP gauge}
-    \to \text{period removal}
-    \to \text{common blocking}
-    \to \text{primitive blocks}.
-\]
+\cite{Cirac2021Matrix}, and~\cite[Chapter~6]{Wolf2012Quantum}. Its goal is to expose the primitive core
+of the tensor: a transfer operator is primitive exactly when it is both
+irreducible and aperiodic, so the reduction strips an arbitrary tensor of
+reducibility and of periodicity, leaving its primitive blocks in a fixed gauge.
+The sections below carry out the reduction.
 
 Two normalizations appear. The unital orientation
 $\sum_i A_k^i(A_k^i)^\dagger=\Id$ is used in

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -6,11 +6,12 @@ reduced to a weighted family of primitive blocks; Chapter~\ref{ch:bnt} construct
 the basis of normal tensors carried by those blocks and compares their
 coefficients, and Chapter~\ref{ch:ft_proof} proves the theorem itself. The
 reduction follows~\cite{PerezGarcia2007Matrix}, \cite{Cirac2017MPDO_AnnPhys},
-\cite{Cirac2021Matrix}, and~\cite[Chapter~6]{Wolf2012Quantum}. Its goal is to expose the primitive core
-of the tensor: a transfer operator is primitive exactly when it is both
-irreducible and aperiodic, so the reduction strips an arbitrary tensor of
-reducibility and of periodicity, leaving its primitive blocks in a fixed gauge.
-The sections below carry out the reduction.
+\cite{Cirac2021Matrix}, and~\cite[Chapter~6]{Wolf2012Quantum}. Its goal is to expose the primitive blocks
+inside the tensor. The transfer operator of an arbitrary tensor can be reducible
+and can have a period greater than one; the reduction splits it along its
+invariant subspaces and brings the period of each block down to one, so that each
+block is primitive, with peripheral spectrum $\{1\}$. The blocks are returned in a
+fixed gauge, and the sections below carry out the reduction.
 
 Two normalizations appear. The unital orientation
 $\sum_i A_k^i(A_k^i)^\dagger=\Id$ is used in


### PR DESCRIPTION
## Summary

The Canonical Form Reduction chapter opened with a displayed arrow-chain enumerating its seven reduction stages:

```latex
\[ \text{invariant-subspace split} \to \text{irreducible block decomposition}
   \to \dots \to \text{primitive blocks}. \]
```

That reads as a process diagram, not mathematics. This replaces it with the idea that organizes the whole reduction: a transfer operator is primitive **exactly when it is both irreducible and aperiodic**, so the reduction strips an arbitrary tensor of reducibility and of periodicity, leaving its primitive blocks in a fixed gauge. The individual stages are carried by the section order, not re-listed.

## Why

Per the prose standard, a blueprint/lecture-note opening should state what the chapter achieves and the central idea, not convey the proof spine as a `\text{step}→\text{step}→…` display or a mechanical step enumeration. The new sentence is idea-first (primitivity = irreducible + aperiodic) and defers the stages to the sections.

## Build

Clean two-pass rebuild: zero undefined/multiply-defined references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only change to a LaTeX chapter introduction; no code, build logic, or formal proofs affected.
> 
> **Overview**
> The **Canonical Form Reduction** chapter introduction no longer uses a displayed `\to` chain of seven reduction stage names. It now states the chapter’s goal (expose **primitive blocks**), explains that a generic transfer operator may be **reducible** or **periodic**, and that the reduction splits along invariant subspaces and forces period one so each block is **primitive** with peripheral spectrum \(\{1\}\), in a **fixed gauge**, with the detailed steps left to the following sections.
> 
> A citation line is folded into the same opening paragraph (including **Wolf2012Quantum**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c39d7c5b024644e3e9fafd1c91b299021e0ae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->