### PR TITLE
feat(MPS/Examples): formalize the on-site SO(3) symmetry of the AKLT MPS

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -276,6 +276,7 @@ import TNLean.MPS.MPDO.BlockedRFPConstruction
 
 -- MPS examples
 import TNLean.MPS.Examples.AKLT
+import TNLean.MPS.Examples.AKLTRotation
 import TNLean.MPS.Examples.Cluster
 import TNLean.MPS.Examples.EvenParity
 import TNLean.MPS.Examples.GHZ

--- a/TNLean/MPS/Examples/AKLTRotation.lean
+++ b/TNLean/MPS/Examples/AKLTRotation.lean
@@ -1,0 +1,676 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Symmetry.Defs
+import Mathlib.LinearAlgebra.UnitaryGroup
+
+/-!
+# On-site rotational symmetry of the AKLT state
+
+This module formalizes the on-site rotational symmetry of the AKLT matrix
+product state in its Cartesian (Pauli) form `A^i = σ^i`, `i ∈ {x, y, z}`
+(arXiv:2011.12127, around line 1159).
+
+The physical site carries the spin-`1` (defining) representation of the
+rotations, while the virtual/bond index transforms in the projective
+spin-`½` representation: for every `U ∈ SU(2)`, conjugation of the Pauli
+vector by `U` is a rotation `R(U)` of the three physical components, and the
+AKLT tensor twisted by `R(U)` is gauge equivalent to the original through the
+gauge `U⁻¹`.  This is the projective-representation content of the
+symmetry-protected topological phase, stated over the cover `SU(2)` so that no
+appeal to the (currently unformalized) surjectivity of `SU(2) → SO(3)` is
+needed.
+
+## Main definitions
+
+* `MPSTensor.pauli` : the three Pauli matrices indexed by `Fin 3`
+* `MPSTensor.pauliConjAd` : the rotation matrix `R(U)ᵢⱼ = ½ tr(σᵢ U σⱼ U⁻¹)`
+* `MPSTensor.spinHalfCover` : `R` packaged as a `MonoidHom` on `GL (Fin 2) ℂ`
+* `MPSTensor.akltCartesian` : the AKLT tensor `A^i = σ^i`
+
+## Main results
+
+* `MPSTensor.pauli_expansion` : every `2×2` matrix expands in `{1, σx, σy, σz}`
+* `MPSTensor.pauli_conj_eq` : the covariance `U σⱼ U⁻¹ = ∑ᵢ R(U)ᵢⱼ σᵢ`
+* `MPSTensor.aklt_isOnSiteSymmetric_spinHalfCover` : the AKLT tensor is on-site
+  symmetric under the `SU(2)`-parametrized rotations
+* `MPSTensor.transpose_mul_pauliConjAd` : the rotations `R(U)` are orthogonal,
+  `R(U)ᵀ R(U) = 1`
+
+## References
+
+* RMP review (arXiv:2011.12127) line 1159 (`A^i = σ^i`, on-site `SO(3)`)
+-/
+
+open scoped Matrix BigOperators
+open Matrix Finset
+
+noncomputable section
+
+namespace MPSTensor
+
+/-! ### The Pauli matrices -/
+
+/-- The three Pauli matrices `σx, σy, σz`, indexed by `Fin 3`. -/
+def pauli : Fin 3 → Matrix (Fin 2) (Fin 2) ℂ
+  | 0 => !![0, 1; 1, 0]
+  | 1 => !![0, -Complex.I; Complex.I, 0]
+  | 2 => !![1, 0; 0, -1]
+
+@[simp] lemma pauli_zero : pauli 0 = !![0, 1; 1, 0] := rfl
+@[simp] lemma pauli_one : pauli 1 = !![0, -Complex.I; Complex.I, 0] := rfl
+@[simp] lemma pauli_two : pauli 2 = !![1, 0; 0, -1] := rfl
+
+/-- Each Pauli matrix is traceless. -/
+@[simp] lemma trace_pauli (k : Fin 3) : (pauli k).trace = 0 := by
+  fin_cases k <;> simp [pauli, Matrix.trace, Fin.sum_univ_two]
+
+/-! ### Expansion in the Pauli basis
+
+Every `2×2` complex matrix is a linear combination of the identity and the
+three Pauli matrices, with coefficients read off by the trace pairing. -/
+
+/-- The Pauli basis expansion: `M = ½(tr M)·1 + ∑ₖ ½ tr(σₖ M)·σₖ`. -/
+lemma pauli_expansion (M : Matrix (Fin 2) (Fin 2) ℂ) :
+    M = (M.trace / 2) • (1 : Matrix (Fin 2) (Fin 2) ℂ) +
+      ∑ k : Fin 3, ((pauli k * M).trace / 2) • pauli k := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    refine Complex.ext ?_ ?_ <;>
+    simp [pauli, Matrix.trace, Fin.sum_univ_two, Fin.sum_univ_three, Matrix.mul_apply,
+      Matrix.add_apply, Matrix.smul_apply, smul_eq_mul, Complex.add_re, Complex.add_im] <;>
+    ring
+
+/-- The trace pairing of two Pauli matrices: `tr(σᵢ σⱼ) = 2 δᵢⱼ`. -/
+lemma pauli_mul_pauli_trace (i j : Fin 3) :
+    (pauli i * pauli j).trace = if i = j then 2 else 0 := by
+  fin_cases i <;> fin_cases j <;>
+    simp [pauli, Matrix.trace, Fin.sum_univ_two, Complex.ext_iff] <;> norm_num
+
+/-! ### The spin-`½` rotation `R(U)` -/
+
+/-- The rotation matrix `R(U)ᵢⱼ = ½ tr(σᵢ U σⱼ U⁻¹)` obtained by conjugating the
+Pauli vector by `U`.  It is the spin-`1` (adjoint) action that accompanies the
+virtual spin-`½` action of `U` on the AKLT bond index (arXiv:2011.12127,
+around line 1159). -/
+def pauliConjAd (U : GL (Fin 2) ℂ) : Matrix (Fin 3) (Fin 3) ℂ :=
+  fun i j => ((pauli i * (U : Matrix (Fin 2) (Fin 2) ℂ) * pauli j *
+    ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)).trace) / 2
+
+/-- Conjugating a single Pauli matrix is traceless: `tr(U σⱼ U⁻¹) = tr σⱼ = 0`. -/
+lemma trace_conj_pauli_zero (U : GL (Fin 2) ℂ) (j : Fin 3) :
+    ((U : Matrix (Fin 2) (Fin 2) ℂ) * pauli j *
+      ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)).trace = 0 := by
+  rw [Matrix.trace_mul_comm, ← Matrix.mul_assoc, ← Matrix.GeneralLinearGroup.coe_mul,
+    inv_mul_cancel, Matrix.GeneralLinearGroup.coe_one, Matrix.one_mul, trace_pauli]
+
+/-- Covariance of the Pauli vector under conjugation: `U σⱼ U⁻¹ = ∑ᵢ R(U)ᵢⱼ σᵢ`.
+The conjugate is traceless, so it carries no identity component and expands purely
+in the Pauli basis with the rotation coefficients `R(U)`. -/
+lemma pauli_conj_eq (U : GL (Fin 2) ℂ) (j : Fin 3) :
+    (U : Matrix (Fin 2) (Fin 2) ℂ) * pauli j *
+      ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) =
+      ∑ i, pauliConjAd U i j • pauli i := by
+  have hM := pauli_expansion ((U : Matrix (Fin 2) (Fin 2) ℂ) * pauli j *
+    ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ))
+  rw [trace_conj_pauli_zero] at hM
+  simp only [zero_div, zero_smul, zero_add] at hM
+  rw [hM]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  simp only [pauliConjAd, Matrix.mul_assoc]
+
+/-- The rotation by the identity is the identity matrix: `R(1) = 1`. -/
+lemma pauliConjAd_one : pauliConjAd 1 = (1 : Matrix (Fin 3) (Fin 3) ℂ) := by
+  ext i j
+  simp only [pauliConjAd, inv_one, Matrix.GeneralLinearGroup.coe_one, Matrix.mul_one,
+    Matrix.one_apply]
+  rw [pauli_mul_pauli_trace]
+  split <;> norm_num
+
+/-- Pull a finite Pauli expansion out of the conjugated trace. -/
+private lemma trace_conj_sum (U : GL (Fin 2) ℂ) (X : Matrix (Fin 2) (Fin 2) ℂ)
+    (c : Fin 3 → ℂ) :
+    (X * (∑ k, c k • pauli k) *
+      ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)).trace =
+      ∑ k, c k * (X * pauli k *
+        ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)).trace := by
+  rw [Matrix.mul_sum, Matrix.sum_mul, Matrix.trace_sum]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
+
+/-- The rotations compose: `R(U V) = R(U) R(V)`.  Conjugation by `U V` is
+conjugation by `V` followed by conjugation by `U`, and covariance turns the inner
+conjugation into a Pauli expansion whose coefficients are exactly the product. -/
+lemma pauliConjAd_mul (U V : GL (Fin 2) ℂ) :
+    pauliConjAd (U * V) = pauliConjAd U * pauliConjAd V := by
+  ext i j
+  rw [Matrix.mul_apply]
+  simp only [pauliConjAd]
+  rw [_root_.mul_inv_rev, Matrix.GeneralLinearGroup.coe_mul,
+    Matrix.GeneralLinearGroup.coe_mul]
+  rw [show pauli i * ((U : Matrix (Fin 2) (Fin 2) ℂ) * (V : Matrix (Fin 2) (Fin 2) ℂ)) *
+      pauli j * (((V⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) *
+        ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)) =
+      (pauli i * (U : Matrix (Fin 2) (Fin 2) ℂ)) *
+        ((V : Matrix (Fin 2) (Fin 2) ℂ) * pauli j *
+          ((V⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)) *
+        ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) by
+    simp only [Matrix.mul_assoc]]
+  rw [pauli_conj_eq, trace_conj_sum, Finset.sum_div]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  simp only [pauliConjAd, Matrix.mul_assoc]
+  ring
+
+/-- The spin-`½` cover `U ↦ R(U)`, packaged as a monoid homomorphism from
+`GL (Fin 2) ℂ` into the multiplicative monoid of `3×3` matrices. -/
+def spinHalfCover : GL (Fin 2) ℂ →* Matrix (Fin 3) (Fin 3) ℂ where
+  toFun := pauliConjAd
+  map_one' := pauliConjAd_one
+  map_mul' := pauliConjAd_mul
+
+@[simp] lemma spinHalfCover_apply (U : GL (Fin 2) ℂ) :
+    spinHalfCover U = pauliConjAd U := rfl
+
+/-! ### The AKLT tensor and its on-site symmetry -/
+
+/-- The AKLT tensor in Cartesian (Pauli) form `A^i = σ^i`, `i ∈ {x, y, z}`
+(arXiv:2011.12127, around line 1159). -/
+def akltCartesian : MPSTensor 3 2 := pauli
+
+@[simp] lemma akltCartesian_apply (i : Fin 3) : akltCartesian i = pauli i := rfl
+
+/-- Trace cyclicity exchanges `U` and `U⁻¹` while transposing the rotation:
+`R(U)ᵢⱼ = R(U⁻¹)ⱼᵢ`. -/
+lemma pauliConjAd_swap (U : GL (Fin 2) ℂ) (i j : Fin 3) :
+    pauliConjAd U i j = pauliConjAd U⁻¹ j i := by
+  simp only [pauliConjAd, inv_inv]
+  congr 1
+  rw [show pauli i * (U : Matrix (Fin 2) (Fin 2) ℂ) * pauli j *
+      ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) =
+      (pauli i * (U : Matrix (Fin 2) (Fin 2) ℂ)) *
+        (pauli j * ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)) by
+    simp only [Matrix.mul_assoc]]
+  rw [Matrix.trace_mul_comm]
+  simp only [Matrix.mul_assoc]
+
+/-- For every `U ∈ GL (Fin 2) ℂ` the AKLT tensor twisted on the physical index by
+the rotation `R(U)` is gauge equivalent to the original through the virtual gauge
+`U⁻¹`: this is the projective spin-`½` representation acting on the bond index
+(arXiv:2011.12127, around line 1159). -/
+theorem aklt_gaugeEquiv_spinHalfCover (U : GL (Fin 2) ℂ) :
+    GaugeEquiv akltCartesian (twistedTensor akltCartesian spinHalfCover U) := by
+  refine ⟨U⁻¹, fun i => ?_⟩
+  -- The gauge `X = U⁻¹` sends `B i = ↑U⁻¹ * pauli i * ↑(U⁻¹)⁻¹`.
+  simp only [twistedTensor, spinHalfCover_apply, akltCartesian_apply]
+  rw [pauli_conj_eq U⁻¹ i]
+  refine Finset.sum_congr rfl (fun j _ => ?_)
+  rw [pauliConjAd_swap U i j]
+
+/-- The AKLT tensor is on-site symmetric under the `SU(2)`-cover-parametrized
+rotations `R(U)`.  The physical site carries the spin-`1` representation `R(U)`
+while the virtual bond index transforms in the projective spin-`½`
+representation, with the gauge for `U` given by `U⁻¹`.  Stating the symmetry over
+the cover `SU(2) → SO(3)` avoids any appeal to the (currently unformalized)
+surjectivity of that cover (arXiv:2011.12127, around line 1159). -/
+theorem aklt_isOnSiteSymmetric_spinHalfCover :
+    IsOnSiteSymmetric akltCartesian spinHalfCover :=
+  fun U => (aklt_gaugeEquiv_spinHalfCover U).sameMPV
+
+/-- The columns of `R(U)` are orthonormal: `∑ₖ R(U)ₖᵢ R(U)ₖⱼ = δᵢⱼ`.  Cyclicity of
+the trace cancels the conjugating factors, reducing the bilinear pairing to
+`½ tr(σᵢ σⱼ) = δᵢⱼ`. -/
+lemma pauliConjAd_orthogonal (U : GL (Fin 2) ℂ) (i j : Fin 3) :
+    ∑ k, pauliConjAd U k i * pauliConjAd U k j = if i = j then 1 else 0 := by
+  have hUU : ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) *
+      (U : Matrix (Fin 2) (Fin 2) ℂ) = 1 := by
+    rw [← Matrix.GeneralLinearGroup.coe_mul, inv_mul_cancel,
+      Matrix.GeneralLinearGroup.coe_one]
+  have key : (((U : Matrix (Fin 2) (Fin 2) ℂ) * pauli i *
+        ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)) *
+      ((U : Matrix (Fin 2) (Fin 2) ℂ) * pauli j *
+        ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ))).trace =
+      (pauli i * pauli j).trace := by
+    rw [show ((U : Matrix (Fin 2) (Fin 2) ℂ) * pauli i *
+          ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)) *
+        ((U : Matrix (Fin 2) (Fin 2) ℂ) * pauli j *
+          ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)) =
+        (U : Matrix (Fin 2) (Fin 2) ℂ) * pauli i *
+          (((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) *
+            (U : Matrix (Fin 2) (Fin 2) ℂ)) * (pauli j *
+          ((U⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)) by
+      simp only [Matrix.mul_assoc]]
+    rw [hUU, Matrix.mul_one, ← Matrix.mul_assoc,
+      Matrix.trace_mul_comm, ← Matrix.mul_assoc, ← Matrix.mul_assoc, hUU, Matrix.one_mul]
+  rw [pauli_conj_eq, pauli_conj_eq] at key
+  rw [pauli_mul_pauli_trace] at key
+  rw [Matrix.sum_mul] at key
+  simp only [Matrix.mul_sum, Matrix.smul_mul, Matrix.mul_smul, Matrix.trace_sum,
+    Matrix.trace_smul, smul_eq_mul] at key
+  rw [Finset.sum_comm] at key
+  simp only [pauli_mul_pauli_trace, mul_ite, mul_zero,
+    Finset.sum_ite_eq', Finset.mem_univ, if_true] at key
+  -- key : ∑ x, pauliConjAd U x j * (pauliConjAd U x i * 2) = if i = j then 2 else 0
+  have hsum : (∑ k, pauliConjAd U k i * pauliConjAd U k j) * 2 =
+      ∑ x, pauliConjAd U x j * (pauliConjAd U x i * 2) := by
+    rw [Finset.sum_mul]
+    refine Finset.sum_congr rfl (fun k _ => ?_)
+    ring
+  refine mul_right_cancel₀ (b := (2 : ℂ)) (by norm_num) ?_
+  rw [hsum, key]
+  split <;> ring
+
+/-- The rotation matrices `R(U)` are orthogonal: `R(U)ᵀ R(U) = 1` for every
+`U ∈ GL (Fin 2) ℂ`.  This is the matrix form of `pauliConjAd_orthogonal`. -/
+lemma transpose_mul_pauliConjAd (U : GL (Fin 2) ℂ) :
+    (pauliConjAd U)ᵀ * pauliConjAd U = 1 := by
+  ext i j
+  rw [Matrix.mul_apply, Matrix.one_apply]
+  simp only [Matrix.transpose_apply]
+  rw [pauliConjAd_orthogonal]
+
+/-! ### Generators of `SU(2)` and `SO(3)`
+
+The surjectivity of the spin-`½` cover is proved through an explicit
+Euler-angle factorization.  Every rotation of three-space is a product of a
+rotation about the `z`-axis, a rotation about the `x`-axis, and a further
+rotation about the `z`-axis, and each of these one-parameter families is the
+image under the cover of a one-parameter family in `SU(2)`. -/
+
+/-- The diagonal `SU(2)` matrix `diag(e^{-iθ/2}, e^{iθ/2})` covering a rotation by
+`θ` about the `z`-axis. -/
+def su2Diag (θ : ℝ) : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![Complex.exp (-(θ / 2) * Complex.I), 0; 0, Complex.exp (θ / 2 * Complex.I)]
+
+/-- The `SU(2)` matrix covering a rotation by `β` about the `x`-axis. -/
+def su2Xrot (β : ℝ) : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![Real.cos (β / 2), -Complex.I * Real.sin (β / 2);
+    -Complex.I * Real.sin (β / 2), Real.cos (β / 2)]
+
+/-- The rotation by `θ` about the `z`-axis. -/
+def rotZ (θ : ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![Real.cos θ, -Real.sin θ, 0; Real.sin θ, Real.cos θ, 0; 0, 0, 1]
+
+/-- The rotation by `β` about the `x`-axis. -/
+def rotX (β : ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![1, 0, 0; 0, Real.cos β, -Real.sin β; 0, Real.sin β, Real.cos β]
+
+lemma su2Diag_mem_specialUnitaryGroup (θ : ℝ) :
+    su2Diag θ ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ := by
+  rw [Matrix.mem_specialUnitaryGroup_iff]
+  refine ⟨?_, ?_⟩
+  · rw [Matrix.mem_unitaryGroup_iff]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [su2Diag, Matrix.mul_apply, Fin.sum_univ_two, Matrix.star_apply,
+        Matrix.one_apply, Complex.star_def, Fin.mk_zero, Fin.mk_one, Matrix.cons_val_zero,
+        Matrix.cons_val_one, Matrix.of_apply, Matrix.cons_val', Matrix.empty_val',
+        Matrix.cons_val_fin_one, ← Complex.exp_conj, ← Complex.exp_add, map_zero, mul_zero,
+        zero_mul, add_zero, zero_add, Fin.isValue, Fin.reduceEq, if_true, if_false] <;>
+      first
+        | rfl
+        | (rw [← Complex.exp_zero]; congr 1
+           simp only [map_mul, Complex.conj_I, Complex.conj_ofReal, map_div₀,
+             map_neg, map_ofNat]
+           ring)
+  · rw [su2Diag, Matrix.det_fin_two_of, mul_zero, sub_zero, ← Complex.exp_add]
+    rw [show -(θ / 2) * Complex.I + θ / 2 * Complex.I = 0 by ring, Complex.exp_zero]
+
+lemma su2Xrot_mem_specialUnitaryGroup (β : ℝ) :
+    su2Xrot β ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ := by
+  have hp : ((Real.cos (β / 2) : ℂ)) ^ 2 + ((Real.sin (β / 2) : ℂ)) ^ 2 = 1 := by
+    rw [← Complex.ofReal_pow, ← Complex.ofReal_pow, ← Complex.ofReal_add,
+      Real.cos_sq_add_sin_sq, Complex.ofReal_one]
+  rw [Matrix.mem_specialUnitaryGroup_iff]
+  refine ⟨?_, ?_⟩
+  · rw [Matrix.mem_unitaryGroup_iff]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [su2Xrot, Matrix.mul_apply, Fin.sum_univ_two, Matrix.star_apply,
+        Matrix.one_apply, Fin.mk_zero, Fin.mk_one, Matrix.cons_val_zero, Matrix.cons_val_one,
+        Matrix.of_apply, Matrix.cons_val', Matrix.empty_val',
+        Matrix.cons_val_fin_one, Complex.star_def, map_neg, map_mul,
+        Complex.conj_I, Complex.conj_ofReal, Fin.isValue, Fin.reduceEq,
+        if_true, if_false] <;>
+      first
+        | linear_combination hp - (Real.sin (β / 2) : ℂ) ^ 2 * Complex.I_sq
+        | ring
+  · rw [su2Xrot, Matrix.det_fin_two_of]
+    linear_combination hp - (Real.sin (β / 2) : ℂ) ^ 2 * Complex.I_sq
+
+lemma rotZ_mem_specialOrthogonalGroup (θ : ℝ) :
+    rotZ θ ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ := by
+  rw [Matrix.mem_specialOrthogonalGroup_iff]
+  refine ⟨?_, ?_⟩
+  · rw [Matrix.mem_orthogonalGroup_iff]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [rotZ, Matrix.mul_apply, Fin.sum_univ_three, Matrix.transpose_apply] <;>
+      nlinarith [Real.sin_sq_add_cos_sq θ]
+  · rw [Matrix.det_fin_three]
+    simp only [rotZ, Matrix.of_apply, Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.head_cons, Matrix.head_fin_const, Matrix.cons_val_fin_one, Matrix.empty_val',
+      Matrix.cons_val_two, Matrix.tail_cons]
+    nlinarith [Real.sin_sq_add_cos_sq θ]
+
+lemma rotX_mem_specialOrthogonalGroup (β : ℝ) :
+    rotX β ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ := by
+  rw [Matrix.mem_specialOrthogonalGroup_iff]
+  refine ⟨?_, ?_⟩
+  · rw [Matrix.mem_orthogonalGroup_iff]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [rotX, Matrix.mul_apply, Fin.sum_univ_three, Matrix.transpose_apply] <;>
+      nlinarith [Real.sin_sq_add_cos_sq β]
+  · rw [Matrix.det_fin_three]
+    simp only [rotX, Matrix.of_apply, Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.head_cons, Matrix.head_fin_const, Matrix.cons_val_fin_one, Matrix.empty_val',
+      Matrix.cons_val_two, Matrix.tail_cons]
+    nlinarith [Real.sin_sq_add_cos_sq β]
+
+/-! ### Lifting `SU(2)` matrices into the general linear group -/
+
+/-- A special unitary matrix has nonzero determinant, hence lifts to the general
+linear group. -/
+def su2ToGL (A : Matrix (Fin 2) (Fin 2) ℂ)
+    (hA : A ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ) : GL (Fin 2) ℂ :=
+  Matrix.GeneralLinearGroup.mkOfDetNeZero A
+    (by rw [(Matrix.mem_specialUnitaryGroup_iff.mp hA).2]; exact one_ne_zero)
+
+@[simp] lemma su2ToGL_coe (A : Matrix (Fin 2) (Fin 2) ℂ)
+    (hA : A ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ) :
+    ((su2ToGL A hA : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) = A := by
+  simp [su2ToGL]
+
+/-- The matrix coercion of the inverse of a lifted special unitary matrix is the
+matrix inverse, which for unit determinant is the adjugate. -/
+lemma su2ToGL_inv_coe (A : Matrix (Fin 2) (Fin 2) ℂ)
+    (hA : A ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ) :
+    (((su2ToGL A hA)⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) = A.adjugate := by
+  rw [Matrix.GeneralLinearGroup.coe_inv, su2ToGL_coe, Matrix.inv_def,
+    (Matrix.mem_specialUnitaryGroup_iff.mp hA).2]
+  simp
+
+/-! ### The cover sends the chosen generators to the coordinate rotations -/
+
+/-- Conjugating the Pauli vector by the diagonal cover `su2Diag θ` realizes the
+rotation by `θ` about the `z`-axis. -/
+lemma R_su2Diag_eq_rotZ (θ : ℝ) :
+    pauliConjAd (su2ToGL (su2Diag θ) (su2Diag_mem_specialUnitaryGroup θ))
+      = (rotZ θ).map Complex.ofReal := by
+  have hexpP : Complex.exp ((θ : ℂ) / 2 * Complex.I)
+      = (Real.cos (θ / 2) : ℂ) + (Real.sin (θ / 2) : ℂ) * Complex.I := by
+    rw [show (θ : ℂ) / 2 = ((θ / 2 : ℝ) : ℂ) by push_cast; ring, Complex.exp_mul_I,
+      Complex.ofReal_cos, Complex.ofReal_sin]
+  have hexpN : Complex.exp (-((θ : ℂ) / 2 * Complex.I))
+      = (Real.cos (θ / 2) : ℂ) - (Real.sin (θ / 2) : ℂ) * Complex.I := by
+    have harg : -((θ : ℂ) / 2 * Complex.I) = ((-(θ / 2) : ℝ) : ℂ) * Complex.I := by
+      push_cast; ring
+    rw [harg, Complex.exp_mul_I, Complex.ofReal_cos, Complex.ofReal_sin, Complex.ofReal_neg,
+      Complex.cos_neg, Complex.sin_neg]
+    ring
+  have hcos : (Real.cos θ : ℂ)
+      = (Real.cos (θ / 2) : ℂ) ^ 2 - (Real.sin (θ / 2) : ℂ) ^ 2 := by
+    have h : Real.cos θ = Real.cos (θ / 2) ^ 2 - Real.sin (θ / 2) ^ 2 := by
+      rw [← Real.cos_two_mul' (θ / 2), show 2 * (θ / 2) = θ by ring]
+    rw [h]; push_cast; ring
+  have hsin : (Real.sin θ : ℂ) = 2 * (Real.sin (θ / 2) : ℂ) * (Real.cos (θ / 2) : ℂ) := by
+    have h : Real.sin θ = 2 * Real.sin (θ / 2) * Real.cos (θ / 2) := by
+      rw [← Real.sin_two_mul, show 2 * (θ / 2) = θ by ring]
+    rw [h]; push_cast; ring
+  have hpyth : (↑(Real.cos (θ * (1 / 2))) : ℂ) ^ 2
+      + (↑(Real.sin (θ * (1 / 2))) : ℂ) ^ 2 = 1 := by
+    rw [← Complex.ofReal_pow, ← Complex.ofReal_pow, ← Complex.ofReal_add,
+      Real.cos_sq_add_sin_sq, Complex.ofReal_one]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [pauliConjAd, su2ToGL_coe, su2ToGL_inv_coe, pauli, su2Diag, rotZ,
+      Matrix.adjugate_fin_two_of, Matrix.trace_fin_two, Matrix.mul_apply, Fin.sum_univ_two,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.of_apply,
+      Matrix.cons_val', Matrix.empty_val', Matrix.cons_val_fin_one, Matrix.head_fin_const,
+      Matrix.map_apply, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Fin.zero_eta,
+      Fin.mk_one, Fin.isValue, Complex.ofReal_zero, Complex.ofReal_one, Complex.ofReal_neg,
+      neg_mul, mul_neg, neg_zero, mul_zero, zero_mul, add_zero, zero_add, mul_one, one_mul,
+      hexpP, hexpN, hcos, hsin] <;>
+    (ring_nf; (try (simp only [Complex.I_sq, Complex.I_pow_four]; ring));
+      (try linear_combination hpyth))
+
+/-- Conjugating the Pauli vector by the cover `su2Xrot β` realizes the rotation by
+`β` about the `x`-axis. -/
+lemma R_su2Xrot_eq_rotX (β : ℝ) :
+    pauliConjAd (su2ToGL (su2Xrot β) (su2Xrot_mem_specialUnitaryGroup β))
+      = (rotX β).map Complex.ofReal := by
+  have hcos : (Real.cos β : ℂ)
+      = (Real.cos (β / 2) : ℂ) ^ 2 - (Real.sin (β / 2) : ℂ) ^ 2 := by
+    have h : Real.cos β = Real.cos (β / 2) ^ 2 - Real.sin (β / 2) ^ 2 := by
+      rw [← Real.cos_two_mul' (β / 2), show 2 * (β / 2) = β by ring]
+    rw [h]; push_cast; ring
+  have hsin : (Real.sin β : ℂ) = 2 * (Real.sin (β / 2) : ℂ) * (Real.cos (β / 2) : ℂ) := by
+    have h : Real.sin β = 2 * Real.sin (β / 2) * Real.cos (β / 2) := by
+      rw [← Real.sin_two_mul, show 2 * (β / 2) = β by ring]
+    rw [h]; push_cast; ring
+  have hpyth : (↑(Real.cos (β * (1 / 2))) : ℂ) ^ 2
+      + (↑(Real.sin (β * (1 / 2))) : ℂ) ^ 2 = 1 := by
+    rw [← Complex.ofReal_pow, ← Complex.ofReal_pow, ← Complex.ofReal_add,
+      Real.cos_sq_add_sin_sq, Complex.ofReal_one]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [pauliConjAd, su2ToGL_coe, su2ToGL_inv_coe, pauli, su2Xrot, rotX,
+      Matrix.adjugate_fin_two_of, Matrix.trace_fin_two, Matrix.mul_apply, Fin.sum_univ_two,
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.of_apply,
+      Matrix.cons_val', Matrix.empty_val', Matrix.cons_val_fin_one, Matrix.head_fin_const,
+      Matrix.map_apply, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Fin.zero_eta,
+      Fin.mk_one, Fin.isValue, Complex.ofReal_zero, Complex.ofReal_one, Complex.ofReal_neg,
+      neg_mul, mul_neg, neg_zero, mul_zero, zero_mul, add_zero, zero_add, mul_one, one_mul,
+      hcos, hsin] <;>
+    (ring_nf; (try (simp only [Complex.I_sq, Complex.I_pow_four]; ring));
+      (try linear_combination hpyth))
+
+
+/-! ### Surjectivity of the cover via the Euler-angle factorization -/
+
+/-- A point on the unit circle is the cosine-sine pair of an angle.  Existence of
+the angle comes from the argument of the corresponding unit complex number. -/
+lemma exists_cos_sin {c s : ℝ} (h : c ^ 2 + s ^ 2 = 1) :
+    ∃ θ : ℝ, Real.cos θ = c ∧ Real.sin θ = s := by
+  have hn : ‖(⟨c, s⟩ : ℂ)‖ = 1 := by
+    rw [Complex.norm_def, Complex.normSq_mk, show c * c + s * s = 1 by nlinarith [h]]; simp
+  have hz : (⟨c, s⟩ : ℂ) ≠ 0 := by
+    intro hc; rw [Complex.ext_iff] at hc
+    simp only [Complex.zero_re, Complex.zero_im] at hc; nlinarith [hc.1, hc.2]
+  exact ⟨Complex.arg (⟨c, s⟩ : ℂ), by rw [Complex.cos_arg hz, hn]; simp,
+    by rw [Complex.sin_arg, hn]; simp⟩
+
+set_option maxHeartbeats 1600000 in
+-- The Euler decomposition verifies all nine entries of a three-by-three rotation
+-- against the product of three coordinate rotations, each closed by a polynomial
+-- certificate over the orthonormality and cofactor relations; this exceeds the
+-- default elaboration budget.
+lemma so3_euler_decomp (M : Matrix (Fin 3) (Fin 3) ℝ)
+    (hM : M ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
+    ∃ α β γ : ℝ, M = rotZ α * rotX β * rotZ γ := by
+  rw [Matrix.mem_specialOrthogonalGroup_iff] at hM
+  obtain ⟨ho, hdet⟩ := hM
+  have hoM : M * Mᵀ = 1 := (Matrix.mem_orthogonalGroup_iff (Fin 3) ℝ).mp ho
+  have hoT : Mᵀ * M = 1 := (Matrix.mem_orthogonalGroup_iff' (Fin 3) ℝ).mp ho
+  have hadj : Mᵀ = M.adjugate := by
+    rw [show Mᵀ = M⁻¹ from (Matrix.inv_eq_right_inv hoM).symm, Matrix.inv_def, hdet]; simp
+  -- concrete row/column dot products and cofactors
+  have row : ∀ p q : Fin 3, M p 0 * M q 0 + M p 1 * M q 1 + M p 2 * M q 2 =
+      if p = q then 1 else 0 := by
+    intro p q
+    have := congrFun (congrFun hoM p) q
+    simpa only [Matrix.mul_apply, Fin.sum_univ_three, Matrix.transpose_apply,
+      Matrix.one_apply] using this
+  have col : ∀ p q : Fin 3, M 0 p * M 0 q + M 1 p * M 1 q + M 2 p * M 2 q =
+      if p = q then 1 else 0 := by
+    intro p q
+    have := congrFun (congrFun hoT p) q
+    simpa only [Matrix.mul_apply, Fin.sum_univ_three, Matrix.transpose_apply,
+      Matrix.one_apply] using this
+  have cof : ∀ p q : Fin 3, M q p = (M.adjugate) p q := by
+    intro p q
+    have := congrFun (congrFun hadj p) q; rwa [Matrix.transpose_apply] at this
+  -- the nine cofactor identities
+  have cof00 : M 0 0 = M 1 1 * M 2 2 - M 1 2 * M 2 1 := by
+    have := cof 0 0; simp only [Matrix.adjugate_fin_three, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_fin_one, Matrix.empty_val'] at this
+    linarith [this]
+  have cof01 : M 1 0 = -(M 0 1 * M 2 2) + M 0 2 * M 2 1 := by
+    have := cof 0 1; simp only [Matrix.adjugate_fin_three, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+      Matrix.empty_val'] at this
+    linarith [this]
+  have cof10 : M 0 1 = -(M 1 0 * M 2 2) + M 1 2 * M 2 0 := by
+    have := cof 1 0; simp only [Matrix.adjugate_fin_three, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+      Matrix.empty_val'] at this
+    linarith [this]
+  have cof11 : M 1 1 = M 0 0 * M 2 2 - M 0 2 * M 2 0 := by
+    have := cof 1 1; simp only [Matrix.adjugate_fin_three, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+      Matrix.empty_val'] at this
+    linarith [this]
+  -- norms of relevant rows/cols
+  have hr22 : M 2 0 * M 2 0 + M 2 1 * M 2 1 + M 2 2 * M 2 2 = 1 := by
+    have := row 2 2; rwa [if_pos rfl] at this
+  have hc22 : M 0 2 * M 0 2 + M 1 2 * M 1 2 + M 2 2 * M 2 2 = 1 := by
+    have := col 2 2; rwa [if_pos rfl] at this
+  have hbound : M 2 2 ^ 2 ≤ 1 := by
+    nlinarith [hr22, sq_nonneg (M 2 0), sq_nonneg (M 2 1)]
+  set sβ := Real.sqrt (1 - M 2 2 ^ 2) with hsβdef
+  have hsβsq : sβ ^ 2 = 1 - M 2 2 ^ 2 := by
+    rw [hsβdef, Real.sq_sqrt (by nlinarith [hbound])]
+  have hsβnn : 0 ≤ sβ := Real.sqrt_nonneg _
+  obtain ⟨β, hcosβ, hsinβ⟩ := exists_cos_sin (c := M 2 2) (s := sβ) (by nlinarith [hsβsq])
+  by_cases hs : sβ = 0
+  · -- gimbal lock: sin β = 0, so M 2 2 = ±1 and the off-axis entries vanish
+    have h22sq : M 2 2 ^ 2 = 1 := by
+      have : sβ ^ 2 = 0 := by rw [hs]; ring
+      rw [this] at hsβsq; linarith [hsβsq]
+    have hz20 : M 2 0 = 0 := by nlinarith [hr22, h22sq, sq_nonneg (M 2 0), sq_nonneg (M 2 1)]
+    have hz21 : M 2 1 = 0 := by nlinarith [hr22, h22sq, sq_nonneg (M 2 0), sq_nonneg (M 2 1)]
+    have hz02 : M 0 2 = 0 := by nlinarith [hc22, h22sq, sq_nonneg (M 0 2), sq_nonneg (M 1 2)]
+    have hz12 : M 1 2 = 0 := by nlinarith [hc22, h22sq, sq_nonneg (M 0 2), sq_nonneg (M 1 2)]
+    have hcol0 : M 0 0 ^ 2 + M 1 0 ^ 2 = 1 := by
+      have := col 0 0; rw [if_pos rfl] at this; nlinarith [this, hz20]
+    obtain ⟨α, hcosα, hsinα⟩ :=
+      exists_cos_sin (c := M 0 0) (s := M 1 0) (by nlinarith [hcol0])
+    refine ⟨α, β, 0, ?_⟩
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [rotZ, rotX, Matrix.mul_apply, Fin.sum_univ_three, Matrix.cons_val_zero,
+        Matrix.cons_val_one, Matrix.head_cons, Matrix.of_apply, Matrix.cons_val',
+        Matrix.empty_val', Matrix.cons_val_fin_one, Matrix.head_fin_const, Matrix.cons_val_two,
+        Matrix.tail_cons, Fin.zero_eta, Fin.mk_one, Fin.isValue, Fin.reduceFinMk,
+        hcosα, hsinα, hcosβ, hsinβ, Real.cos_zero, Real.sin_zero, hs,
+        hz02, hz12, hz20, hz21] <;>
+      first
+        | linear_combination cof10 + M 1 2 * hz20
+        | linear_combination cof11 - M 0 2 * hz20
+        | ring
+  · have hspos : 0 < sβ := lt_of_le_of_ne hsβnn (Ne.symm hs)
+    have hsβne : sβ ≠ 0 := hs
+    obtain ⟨α, hcosα, hsinα⟩ := exists_cos_sin (c := -M 1 2 / sβ) (s := M 0 2 / sβ) (by
+      rw [div_pow, div_pow, ← add_div, div_eq_one_iff_eq (pow_ne_zero 2 hsβne)]
+      nlinarith [hc22, hsβsq])
+    obtain ⟨γ, hcosγ, hsinγ⟩ := exists_cos_sin (c := M 2 1 / sβ) (s := M 2 0 / sβ) (by
+      rw [div_pow, div_pow, ← add_div, div_eq_one_iff_eq (pow_ne_zero 2 hsβne)]
+      nlinarith [hr22, hsβsq])
+    refine ⟨α, β, γ, ?_⟩
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [rotZ, rotX, Matrix.mul_apply, Fin.sum_univ_three, Matrix.cons_val_zero,
+        Matrix.cons_val_one, Matrix.head_cons, Matrix.of_apply, Matrix.cons_val',
+        Matrix.empty_val', Matrix.cons_val_fin_one, Matrix.head_fin_const, Matrix.cons_val_two,
+        Matrix.tail_cons, Fin.zero_eta, Fin.mk_one, Fin.isValue, Fin.reduceFinMk,
+        hcosα, hsinα, hcosβ, hsinβ, hcosγ, hsinγ] <;>
+      field_simp <;>
+      first
+        | nlinarith [hsβsq, hspos, hr22, hc22, mul_pos hspos hspos]
+        | linear_combination M 0 0 * hsβsq + cof00 + M 2 2 * cof11
+        | linear_combination M 0 1 * hsβsq + cof10 - M 2 2 * cof01
+        | linear_combination M 1 0 * hsβsq + cof01 - M 2 2 * cof10
+        | linear_combination M 1 1 * hsβsq + cof11 + M 2 2 * cof00
+
+/-! ### Lifting the cover through products -/
+
+/-- Lifting a product of special unitary matrices agrees with the product of the
+lifts in the general linear group. -/
+lemma su2ToGL_mul (A B : Matrix (Fin 2) (Fin 2) ℂ)
+    (hA : A ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ)
+    (hB : B ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ)
+    (hAB : A * B ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ) :
+    su2ToGL (A * B) hAB = su2ToGL A hA * su2ToGL B hB := by
+  apply Matrix.GeneralLinearGroup.ext
+  intro i j
+  simp [su2ToGL, Matrix.GeneralLinearGroup.mkOfDetNeZero]
+
+/-- The cover is multiplicative on lifted special unitary matrices. -/
+lemma pauliConjAd_su2ToGL_mul (A B : Matrix (Fin 2) (Fin 2) ℂ)
+    (hA : A ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ)
+    (hB : B ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ)
+    (hAB : A * B ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ) :
+    pauliConjAd (su2ToGL (A * B) hAB)
+      = pauliConjAd (su2ToGL A hA) * pauliConjAd (su2ToGL B hB) := by
+  rw [← spinHalfCover_apply, ← spinHalfCover_apply, ← spinHalfCover_apply,
+    su2ToGL_mul A B hA hB, map_mul]
+
+/-! ### The spin-½ cover is onto `SO(3)` -/
+
+/-- The spin-`½` cover is surjective onto `SO(3)`: every rotation of three-space
+is the adjoint action of some `SU(2)` matrix on the Pauli vector.  The witness is
+read off the Euler-angle factorization of the rotation. -/
+theorem spinHalfCover_surjective_onto_SO3 (M : Matrix (Fin 3) (Fin 3) ℝ)
+    (hM : M ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
+    ∃ U : Matrix (Fin 2) (Fin 2) ℂ, ∃ hU : U ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ,
+      pauliConjAd (su2ToGL U hU) = M.map Complex.ofReal := by
+  obtain ⟨α, β, γ, hαβγ⟩ := so3_euler_decomp M hM
+  have hd : ∀ θ, su2Diag θ ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ :=
+    su2Diag_mem_specialUnitaryGroup
+  have hx : ∀ b, su2Xrot b ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ :=
+    su2Xrot_mem_specialUnitaryGroup
+  have hU1 : su2Diag α * su2Xrot β ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ :=
+    Submonoid.mul_mem _ (hd α) (hx β)
+  have hU : su2Diag α * su2Xrot β * su2Diag γ ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ :=
+    Submonoid.mul_mem _ hU1 (hd γ)
+  refine ⟨su2Diag α * su2Xrot β * su2Diag γ, hU, ?_⟩
+  rw [pauliConjAd_su2ToGL_mul _ _ hU1 (hd γ), pauliConjAd_su2ToGL_mul _ _ (hd α) (hx β),
+    R_su2Diag_eq_rotZ, R_su2Xrot_eq_rotX, R_su2Diag_eq_rotZ, hαβγ,
+    show (Complex.ofReal : ℝ → ℂ) = ⇑Complex.ofRealHom from rfl, ← Matrix.map_mul,
+    ← Matrix.map_mul]
+
+/-! ### On-site `SO(3)` symmetry of the AKLT tensor -/
+
+/-- The spin-`1` (defining) representation of the rotation group on the physical
+index, embedded into the complex matrices. -/
+noncomputable def so3DefiningRep :
+    Matrix.specialOrthogonalGroup (Fin 3) ℝ →* Matrix (Fin 3) (Fin 3) ℂ where
+  toFun M := (M : Matrix (Fin 3) (Fin 3) ℝ).map Complex.ofReal
+  map_one' := by simp
+  map_mul' M N := by
+    have hof : (Complex.ofReal : ℝ → ℂ) = ⇑Complex.ofRealHom := rfl
+    simp only [Submonoid.coe_mul, hof, Matrix.map_mul]
+
+@[simp] lemma so3DefiningRep_apply (M : Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
+    so3DefiningRep M = (M : Matrix (Fin 3) (Fin 3) ℝ).map Complex.ofReal := rfl
+
+/-- The AKLT tensor is on-site symmetric under the full rotation group `SO(3)`
+acting through its spin-`1` representation on the physical index.  Surjectivity of
+the spin-`½` cover upgrades the `SU(2)`-cover symmetry to a literal `SO(3)`
+symmetry: every rotation is the conjugation action of some `SU(2)` matrix, whose
+virtual gauge then witnesses the same matrix product vector
+(arXiv:2011.12127, around line 1159). -/
+theorem aklt_isOnSiteSymmetric_SO3 : IsOnSiteSymmetric akltCartesian so3DefiningRep := by
+  intro M
+  obtain ⟨U, hU, hRU⟩ := spinHalfCover_surjective_onto_SO3 (M : Matrix (Fin 3) (Fin 3) ℝ) M.2
+  have key : twistedTensor akltCartesian so3DefiningRep M
+      = twistedTensor akltCartesian spinHalfCover (su2ToGL U hU) := by
+    unfold twistedTensor
+    simp only [so3DefiningRep_apply, spinHalfCover_apply, ← hRU]
+  rw [key]
+  exact (aklt_gaugeEquiv_spinHalfCover (su2ToGL U hU)).sameMPV
+
+end MPSTensor
+
+end

--- a/TNLean/MPS/Examples/AKLTRotation.lean
+++ b/TNLean/MPS/Examples/AKLTRotation.lean
@@ -18,9 +18,9 @@ spin-`½` representation: for every `U ∈ SU(2)`, conjugation of the Pauli
 vector by `U` is a rotation `R(U)` of the three physical components, and the
 AKLT tensor twisted by `R(U)` is gauge equivalent to the original through the
 gauge `U⁻¹`.  This is the projective-representation content of the
-symmetry-protected topological phase, stated over the cover `SU(2)` so that no
-appeal to the (currently unformalized) surjectivity of `SU(2) → SO(3)` is
-needed.
+symmetry-protected topological phase.  The symmetry is first stated over the
+cover `SU(2)`; the `SO(3)` version then follows from the surjectivity of the
+cover, both proved here.
 
 ## Main definitions
 
@@ -28,15 +28,20 @@ needed.
 * `MPSTensor.pauliConjAd` : the rotation matrix `R(U)ᵢⱼ = ½ tr(σᵢ U σⱼ U⁻¹)`
 * `MPSTensor.spinHalfCover` : `R` packaged as a `MonoidHom` on `GL (Fin 2) ℂ`
 * `MPSTensor.akltCartesian` : the AKLT tensor `A^i = σ^i`
+* `MPSTensor.so3DefiningRep` : the spin-`1` defining representation of `SO(3)`
 
 ## Main results
 
 * `MPSTensor.pauli_expansion` : every `2×2` matrix expands in `{1, σx, σy, σz}`
 * `MPSTensor.pauli_conj_eq` : the covariance `U σⱼ U⁻¹ = ∑ᵢ R(U)ᵢⱼ σᵢ`
-* `MPSTensor.aklt_isOnSiteSymmetric_spinHalfCover` : the AKLT tensor is on-site
-  symmetric under the `SU(2)`-parametrized rotations
 * `MPSTensor.transpose_mul_pauliConjAd` : the rotations `R(U)` are orthogonal,
   `R(U)ᵀ R(U) = 1`
+* `MPSTensor.aklt_isOnSiteSymmetric_spinHalfCover` : the AKLT tensor is on-site
+  symmetric under the `SU(2)`-parametrized rotations
+* `MPSTensor.spinHalfCover_surjective_onto_SO3` : every `SO(3)` rotation is a
+  Pauli conjugation by some `SU(2)` element
+* `MPSTensor.aklt_isOnSiteSymmetric_SO3` : the AKLT tensor is on-site symmetric
+  under the spin-`1` representation of `SO(3)`
 
 ## References
 
@@ -210,9 +215,10 @@ theorem aklt_gaugeEquiv_spinHalfCover (U : GL (Fin 2) ℂ) :
 /-- The AKLT tensor is on-site symmetric under the `SU(2)`-cover-parametrized
 rotations `R(U)`.  The physical site carries the spin-`1` representation `R(U)`
 while the virtual bond index transforms in the projective spin-`½`
-representation, with the gauge for `U` given by `U⁻¹`.  Stating the symmetry over
-the cover `SU(2) → SO(3)` avoids any appeal to the (currently unformalized)
-surjectivity of that cover (arXiv:2011.12127, around line 1159). -/
+representation, with the gauge for `U` given by `U⁻¹`.  This cover form is
+strictly stronger bookkeeping than the `SO(3)` statement
+`aklt_isOnSiteSymmetric_SO3`, which follows from it by the surjectivity of the
+cover `spinHalfCover_surjective_onto_SO3` (arXiv:2011.12127, around line 1159). -/
 theorem aklt_isOnSiteSymmetric_spinHalfCover :
     IsOnSiteSymmetric akltCartesian spinHalfCover :=
   fun U => (aklt_gaugeEquiv_spinHalfCover U).sameMPV

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -172,21 +172,48 @@ symmetry-protected topological (SPT) order.
     $\mathrm{SO}(3)$ that still carries a non-trivial $2$-cocycle.
 \end{remark}
 
-\begin{theorem}[$\mathrm{SO}(3)$ on-site symmetry of the AKLT tensor]\label{thm:aklt_so3_symmetric}
-    \notready
-    \uses{def:aklt_tensor, def:on_site_symmetric, thm:aklt_z2z2_symmetric}
-    The AKLT tensor is on-site symmetric under the spin-$1$
-    representation of $\mathrm{SO}(3)$ (the spin-$1$ representation
-    of $\mathrm{SU}(2)$ factors through $\mathrm{SO}(3)$), with the
-    virtual representation being the projective spin-$\tfrac12$
-    representation.  The projective phase is the non-trivial
-    element of $H^2(\mathrm{SO}(3),\mathrm{U}(1)) \cong \Z_2$,
-    witnessing a non-trivial SPT phase.  The full continuous
-    $\mathrm{SO}(3)$ symmetry is not formalized; the
-    $\Z_2 \times \Z_2$ subgroup of
-    Theorem~\ref{thm:aklt_z2z2_symmetric} carries the same projective
-    class and is the minimal protecting symmetry.
+\begin{definition}[Cartesian AKLT tensor]\label{def:aklt_cartesian}
+    \lean{MPSTensor.akltCartesian}
+    \leanok
+    \uses{def:mps_tensor}
+    The Cartesian presentation of the AKLT tensor has $d = 3$, $D = 2$, and
+    $A^x = \sigma_x$, $A^y = \sigma_y$, $A^z = \sigma_z$, the three Pauli
+    matrices.  This is the rotationally natural form used in
+    \cite{Cirac2021Matrix} (around line~1159); it is the AKLT state of
+    Definition~\ref{def:aklt_tensor} written in the Cartesian basis of the
+    spin-$1$ site.
+\end{definition}
+
+\begin{theorem}[The spin-$\tfrac12$ cover is surjective onto $\mathrm{SO}(3)$]\label{thm:su2_so3_surjective}
+    \lean{MPSTensor.spinHalfCover_surjective_onto_SO3}
+    \leanok
+    \uses{def:aklt_cartesian}
+    Every rotation $R \in \mathrm{SO}(3)$ is realized by conjugating the Pauli
+    vector by some $U \in \mathrm{SU}(2)$: there is $U \in \mathrm{SU}(2)$ with
+    $\bigl(\tfrac12 \tr(\sigma_i\, U \sigma_j U^{-1})\bigr)_{ij} = R$.
+    Equivalently, the adjoint double cover $\mathrm{SU}(2)\to\mathrm{SO}(3)$ is
+    surjective.  The proof factors $R$ by its $ZXZ$ Euler decomposition and hits
+    each coordinate rotation with an explicit $\mathrm{SU}(2)$ element.
 \end{theorem}
+
+\begin{theorem}[$\mathrm{SO}(3)$ on-site symmetry of the AKLT tensor]\label{thm:aklt_so3_symmetric}
+    \lean{MPSTensor.aklt_isOnSiteSymmetric_SO3}
+    \leanok
+    \uses{def:aklt_cartesian, def:on_site_symmetric, thm:su2_so3_surjective}
+    The Cartesian AKLT tensor is on-site symmetric under the spin-$1$ (defining)
+    representation of $\mathrm{SO}(3)$ on the physical index.
+\end{theorem}
+
+\begin{remark}\label{rem:aklt_so3_spt}
+    The bond index carries the projective spin-$\tfrac12$ representation: the
+    gauge for a rotation is either of its two $\mathrm{SU}(2)$ preimages, so the
+    assignment is a representation only up to sign and factors through the double
+    cover $\mathrm{SU}(2)\to\mathrm{SO}(3)$.  Its class is the non-trivial element
+    of $H^2(\mathrm{SO}(3),\mathrm{U}(1))\cong\Z_2$, witnessing the SPT phase.
+    This cohomological classification, which needs the continuous group
+    cohomology of $\mathrm{SO}(3)$, is not formalized; the obstruction is
+    recorded in \texttt{docs/paper-gaps/rmp\_aklt\_continuous\_rotation\_gap.tex}.
+\end{remark}
 
 %% ===================================================================
 \section{The cluster state}\label{sec:cluster}

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -179,21 +179,24 @@ symmetry-protected topological (SPT) order.
     The Cartesian presentation of the AKLT tensor has $d = 3$, $D = 2$, and
     $A^x = \sigma_x$, $A^y = \sigma_y$, $A^z = \sigma_z$, the three Pauli
     matrices.  This is the rotationally natural form used in
-    \cite{Cirac2021Matrix} (around line~1159); it is the AKLT state of
-    Definition~\ref{def:aklt_tensor} written in the Cartesian basis of the
-    spin-$1$ site.
+    \cite{Cirac2021Matrix} (around line~1159); it is the AKLT state in the
+    Cartesian basis of the spin-$1$ site, the counterpart of the
+    $|m\rangle$-basis form of Definition~\ref{def:aklt_tensor}.
 \end{definition}
 
 \begin{theorem}[The spin-$\tfrac12$ cover is surjective onto $\mathrm{SO}(3)$]\label{thm:su2_so3_surjective}
     \lean{MPSTensor.spinHalfCover_surjective_onto_SO3}
     \leanok
-    \uses{def:aklt_cartesian}
     Every rotation $R \in \mathrm{SO}(3)$ is realized by conjugating the Pauli
     vector by some $U \in \mathrm{SU}(2)$: there is $U \in \mathrm{SU}(2)$ with
     $\bigl(\tfrac12 \tr(\sigma_i\, U \sigma_j U^{-1})\bigr)_{ij} = R$.
     Equivalently, the adjoint double cover $\mathrm{SU}(2)\to\mathrm{SO}(3)$ is
-    surjective.  The proof factors $R$ by its $ZXZ$ Euler decomposition and hits
-    each coordinate rotation with an explicit $\mathrm{SU}(2)$ element.
+    surjective.  The proof factors $R = R_z(\alpha)\,R_x(\beta)\,R_z(\gamma)$ by
+    its $ZXZ$ Euler decomposition and maps each coordinate rotation to an explicit
+    $\mathrm{SU}(2)$ generator:
+    $\diag(e^{-i\theta/2}, e^{i\theta/2}) \mapsto R_z(\theta)$ and
+    $\bigl(\begin{smallmatrix}\cos\frac\beta2 & -i\sin\frac\beta2 \\
+    -i\sin\frac\beta2 & \cos\frac\beta2\end{smallmatrix}\bigr) \mapsto R_x(\beta)$.
 \end{theorem}
 
 \begin{theorem}[$\mathrm{SO}(3)$ on-site symmetry of the AKLT tensor]\label{thm:aklt_so3_symmetric}
@@ -210,9 +213,10 @@ symmetry-protected topological (SPT) order.
     assignment is a representation only up to sign and factors through the double
     cover $\mathrm{SU}(2)\to\mathrm{SO}(3)$.  Its class is the non-trivial element
     of $H^2(\mathrm{SO}(3),\mathrm{U}(1))\cong\Z_2$, witnessing the SPT phase.
-    This cohomological classification, which needs the continuous group
-    cohomology of $\mathrm{SO}(3)$, is not formalized; the obstruction is
-    recorded in \texttt{docs/paper-gaps/rmp\_aklt\_continuous\_rotation\_gap.tex}.
+    % Maintainer note: the cohomological classification above (the class in
+    % H^2(SO(3),U(1))) needs continuous group cohomology of SO(3) and is not
+    % formalized; the obstruction is recorded in
+    % docs/paper-gaps/rmp_aklt_continuous_rotation_gap.tex.
 \end{remark}
 
 %% ===================================================================

--- a/docs/paper-gaps/rmp_aklt_continuous_rotation_gap.tex
+++ b/docs/paper-gaps/rmp_aklt_continuous_rotation_gap.tex
@@ -6,8 +6,8 @@
 
 \input{command}
 
-\title{Scope Note: The AKLT On-Site Symmetry Is Formalized for the
-$\mathbb{Z}_2\times\mathbb{Z}_2$ Subgroup, Not the Full $\mathrm{SO}(3)$}
+\title{Scope Note: The AKLT On-Site $\mathrm{SO}(3)$ Symmetry Is Formalized;
+Its Cohomological Classification Is Not}
 \author{}
 \date{\today}
 
@@ -40,27 +40,23 @@ Two different statements must be separated: the on-site $\mathrm{SO}(3)$
 protects. They have very different formalization costs.
 
 \paragraph{The symmetry.}
-The symmetry statement says that for every rotation $R\in\mathrm{SO}(3)$ the
-twisted tensor is gauge equivalent to the original; for each $R$ this asks only
-for the \emph{existence} of a virtual gauge. Most of the required machinery is
-already available. The groups $\mathrm{SO}(3)$ and $\mathrm{SU}(2)$ exist as
-matrix groups, with their group structure, as
-$\mathrm{specialOrthogonalGroup}\,(\mathrm{Fin}\,3)\,\mathbb{R}$ and
-$\mathrm{specialUnitaryGroup}\,(\mathrm{Fin}\,2)\,\mathbb{C}$. The spin-$1$
-representation is not an extra construction at all: it is the defining action of
-$\mathrm{SO}(3)$ on the three physical states (followed by a fixed change of
-basis), so no exponentiation of angular-momentum generators is needed. The one
-genuinely missing input is the surjectivity of the double cover
-$\mathrm{SU}(2)\to\mathrm{SO}(3)$: that every rotation is realized by
-conjugating the Pauli vector $(\sigma_x,\sigma_y,\sigma_z)$ by an
-$\mathrm{SU}(2)$ element. As of this writing the library does not prove this (the
-Clifford spin group leaves cover-surjectivity onto the orthogonal group as an
-explicit open task, and the quaternion development has no rotation map), but it is
-a classical
-finite-dimensional computation, a single self-contained development rather than a
-research project. With that lemma in hand, the on-site $\mathrm{SO}(3)$ symmetry
-of the AKLT tensor is within reach of the existing on-site-symmetry predicate:
-for each $R$ one takes the gauge to be an $\mathrm{SU}(2)$ preimage of $R$.
+This statement is now formalized. For every rotation $R\in\mathrm{SO}(3)$ the
+Cartesian AKLT tensor $A^i=\sigma^i$ twisted by $R$ is gauge equivalent to the
+original, the gauge being an $\mathrm{SU}(2)$ preimage of $R$.\footnote{%
+\leanid{aklt\_isOnSiteSymmetric\_SO3} in \doclink{TNLean/MPS/Examples/AKLTRotation}.}
+The one substantive input is the surjectivity of the adjoint double cover
+$\mathrm{SU}(2)\to\mathrm{SO}(3)$, that every rotation is realized by conjugating
+the Pauli vector $(\sigma_x,\sigma_y,\sigma_z)$ by an $\mathrm{SU}(2)$ element.
+It is proved by an explicit $ZXZ$ Euler-angle construction: each coordinate
+rotation is the image of an explicit $\mathrm{SU}(2)$ generator, and an arbitrary
+rotation is factored into coordinate rotations.\footnote{%
+\leanid{spinHalfCover\_surjective\_onto\_SO3}.} The physical spin-$1$
+representation is just the defining action of $\mathrm{SO}(3)$ on the three
+Cartesian components, and the adjoint map $U\mapsto R(U)$ is a monoid
+homomorphism, so its image is automatically a subgroup; hitting the Euler
+generators therefore yields surjectivity with no appeal to Lie-group topology, to
+the Clifford spin group, or to a quaternion bridge (none of which the library
+provides).
 
 \paragraph{The classification.}
 The claim that the resulting projective phase is the order-two generator of
@@ -76,46 +72,34 @@ a substantial development on its own.
 
 \section{The formalized statement}
 
-The formalization proves the $\mathbb{Z}_2\times\mathbb{Z}_2$ case, which the
-review singles out as the smallest subgroup of $\mathrm{SO}(3)$ that still carries
-a non-trivial $2$-cocycle. Concretely, the two generators act on the spin-$1$
-physical index by two commuting involutions, the images of the
-$\pi$-rotations about two orthogonal axes, and each twisted tensor is gauge
-equivalent to the original. The virtual gauges are
-\[
-  G_1=\begin{pmatrix}0&1\\-1&0\end{pmatrix}=i\sigma_y,
-  \qquad
-  G_2=\sigma_z=\begin{pmatrix}1&0\\0&-1\end{pmatrix},
-\]
-and they anticommute, $G_1G_2=-G_2G_1$. The group commutator therefore acts on
-the bond space by $-I$, so the assignment of gauges to group elements is a
-projective representation with the non-trivial class in
-$H^2(\mathbb{Z}_2\times\mathbb{Z}_2,\mathrm{U}(1))\cong\mathbb{Z}_2$. This is the
-mathematical content of the symmetry-protected phase: the phase $-1$ cannot be
-removed by rephasing the gauges, so it distinguishes the AKLT chain from a
-trivial product state.\footnote{Formalized as \leanid{aklt\_isOnSiteSymmetric\_Z2Z2}
-in \doclink{TNLean/MPS/Examples/AKLT}.}
+The formalization establishes the full on-site $\mathrm{SO}(3)$ symmetry of the
+Cartesian AKLT tensor $A^i=\sigma^i$: the physical site carries the spin-$1$
+(defining) representation, and for each rotation the bond index is conjugated by
+a spin-$\tfrac12$ $\mathrm{SU}(2)$ preimage. The finite
+$\mathbb{Z}_2\times\mathbb{Z}_2$ subgroup, which the review singles out as the
+smallest subgroup of $\mathrm{SO}(3)$ carrying a non-trivial $2$-cocycle, is
+formalized separately on the $|m\rangle$-basis tensor with the explicit
+anticommuting gauges $i\sigma_y$ and
+$\sigma_z$.\footnote{\leanid{aklt\_isOnSiteSymmetric\_Z2Z2} in
+\doclink{TNLean/MPS/Examples/AKLT}.}
 
-The $\mathbb{Z}_2\times\mathbb{Z}_2$ statement is a genuine restriction of the
-$\mathrm{SO}(3)$ statement, not a derivation of it: it exhibits the same
-projective class on a finite subgroup, but it does not establish symmetry under
-the full continuous group.
+In both cases the bond representation is projective: rotations that commute have
+$\mathrm{SU}(2)$ preimages that need not commute, and that sign obstruction is the
+content of the symmetry-protected phase. For $\mathbb{Z}_2\times\mathbb{Z}_2$ the
+obstruction is the explicit anticommutator $i\sigma_y\,\sigma_z=-\sigma_z\,i\sigma_y$;
+for the full $\mathrm{SO}(3)$ it is the non-triviality of the double cover.
 
 \section{Conclusion}
 
-The AKLT example is formalized at the level of the finite
-$\mathbb{Z}_2\times\mathbb{Z}_2\subset\mathrm{SO}(3)$ symmetry, which captures the
-projective-representation obstruction that witnesses the phase. The full on-site
-$\mathrm{SO}(3)$ symmetry asserted by \cite{Cirac2021Matrix} is not yet
-formalized, but it is not blocked by any deep obstruction: it is a moderate
-development gated almost entirely on the surjectivity of
-$\mathrm{SU}(2)\to\mathrm{SO}(3)$, which would be a worthwhile addition to the
-library in its own right. The accompanying classification of the phase by
-$H^2(\mathrm{SO}(3),\mathrm{U}(1))\cong\mathbb{Z}_2$ is the genuinely large piece,
-requiring continuous group cohomology. The blueprint entry for the
-$\mathrm{SO}(3)$ statement is therefore kept without a formal tag until the
-symmetry is proved, while the $\mathbb{Z}_2\times\mathbb{Z}_2$ statement is tagged
-against the formal declaration.
+The on-site $\mathrm{SO}(3)$ symmetry asserted by \cite{Cirac2021Matrix},
+together with the surjectivity of the spin-$\tfrac12$ cover that it rests on, is
+now formalized. What remains unformalized is the \emph{cohomological
+classification} of the resulting projective phase as the order-two generator of
+$H^2(\mathrm{SO}(3),\mathrm{U}(1))\cong\mathbb{Z}_2$: this needs the continuous
+group cohomology of $\mathrm{SO}(3)$ (equivalently its Schur multiplier), which
+the library does not provide. The blueprint therefore tags the symmetry and the
+cover-surjectivity against their formal declarations, and records the
+cohomological classification as an untagged remark.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Resolves the `thm:aklt_so3_symmetric` gap in `blueprint/src/chapter/ch16_examples.tex` — the **full continuous on-site SO(3) symmetry of the AKLT state** (RMP [arXiv:2011.12127](https://arxiv.org/abs/2011.12127), line 1159), previously `\notready`.

This builds directly on the example infrastructure merged in #2280.

## What's formalized (`TNLean/MPS/Examples/AKLTRotation.lean`, no `sorry`/`axiom`)

- **`akltCartesian`** — the AKLT tensor in Cartesian form `Aⁱ = σⁱ`.
- **`spinHalfCover : GL(2,ℂ) →* M₃(ℂ)`**, `R(U)ᵢⱼ = ½ tr(σᵢ U σⱼ U⁻¹)`, constructed from the Pauli expansion of traceless 2×2 matrices; with its covariance `U σⱼ U⁻¹ = Σᵢ R(U)ᵢⱼ σᵢ`, multiplicativity, and orthogonality `R(U)ᵀ R(U) = 1`.
- **`spinHalfCover_surjective_onto_SO3`** — every `R ∈ SO(3)` is realized by SU(2) conjugation of the Pauli vector. Proved via the explicit **ZXZ Euler-angle decomposition** (`su2Diag`/`su2Xrot ↦ rotZ`/`rotX` image lemmas + `so3_euler_decomp`, with the gimbal-lock case). This avoids the routes Mathlib can't yet support (Cartan–Dieudonné via Clifford `SpinGroup`, `ℍ≅SU(2)`, `ConnectedSpace SO(3)`).
- **`aklt_isOnSiteSymmetric_SO3 : IsOnSiteSymmetric akltCartesian so3DefiningRep`** — the capstone: physical site in the spin-1 *defining* rep `so3DefiningRep`, bond in the projective spin-½ rep (gauge = an SU(2) preimage per rotation).

## Blueprint / docs

- `ch16`: add `def:aklt_cartesian` and `thm:su2_so3_surjective`; **upgrade `thm:aklt_so3_symmetric` from `\notready` to `\leanok`** (symmetry only). The H²(SO(3),U(1)) classification stays an **untagged remark** — faithful to what the `IsOnSiteSymmetric` type proves.
- `docs/paper-gaps/rmp_aklt_continuous_rotation_gap.tex` rewritten: the SO(3) symmetry and cover-surjectivity are now formalized; only the cohomological classification (continuous group cohomology of SO(3) / Schur multiplier — absent in Mathlib) remains a gap.

## Verification

- `lake build TNLean.MPS.Examples.AKLTRotation`, `lake exe lint_style`: clean.
- **No `sorry`/`axiom`/`native_decide`**; `#print axioms` on both main theorems = `[propext, Classical.choice, Quot.sound]`.
- One `set_option maxHeartbeats 1600000` on the nine-entry Euler-decomposition verification, with the required explanatory comment.

## Note
The faithfulness boundary is deliberate: the **symmetry** is now formal; the **cohomological classification** of the SPT phase is not (it needs continuous-group cohomology Mathlib lacks), and is fenced off in the remark + paper-gap note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a self-contained example proof module and documentation/blueprint tags; no changes to core channel, transfer, or auth paths—main risk is build time from the large Euler-angle proof (raised `maxHeartbeats` on one lemma).
> 
> **Overview**
> Adds **`TNLean/MPS/Examples/AKLTRotation.lean`** (~680 lines) and registers it in **`TNLean.lean`**, formalizing the AKLT MPS in Cartesian form **`akltCartesian`** (`A^i = σ^i`) and its **on-site SO(3)** symmetry via existing **`IsOnSiteSymmetric`** / **`twistedTensor`** machinery.
> 
> The new file builds the Pauli-adjoint map **`pauliConjAd`** / **`spinHalfCover`**, proves **SU(2)-cover gauge equivalence** and **`aklt_isOnSiteSymmetric_spinHalfCover`**, then **surjectivity onto SO(3)** through an explicit **ZXZ Euler-angle** route (**`so3_euler_decomp`**, generator matching lemmas, **`spinHalfCover_surjective_onto_SO3`**) and the capstone **`aklt_isOnSiteSymmetric_SO3`** with **`so3DefiningRep`**.
> 
> **Blueprint** (`ch16_examples.tex`): introduces **`def:aklt_cartesian`** and **`thm:su2_so3_surjective`**, upgrades **`thm:aklt_so3_symmetric`** from `\notready` to `\leanok`; **H²(SO(3), U(1))** SPT classification stays an **untagged remark**.
> 
> **`docs/paper-gaps/rmp_aklt_continuous_rotation_gap.tex`** is rewritten to state continuous **SO(3) symmetry and cover surjectivity are formalized**; **continuous cohomology / Schur-multiplier classification** remains the documented gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d902bd2423cf6351f88c7e6af58ab33aedc772a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->