### PR TITLE
blueprint(ch:bnt): note the permutation-rigidity lemmas as a standalone route

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -368,13 +368,12 @@ equal block counts, then remove that restriction.
     Theorem~\ref{thm:bnt_perm_same_card} yields the permutation conclusion.
 \end{proof}
 
-The two preceding results give a self-contained formulation of permutation
-rigidity that derives the block matching directly from the asymptotic
-orthonormality of the overlaps. The fundamental theorem in this development
-does not invoke them; it obtains the same matching through the exact sector
-track of Section~\ref{sec:sector_bnt_strong_match}, which matches blocks by a
-bijection between the sectors of the two canonical forms. They are kept here as
-an alternative route to the same conclusion.
+The two preceding results obtain the block matching from the asymptotic
+orthonormality of the overlaps. The same matching is obtained by the exact
+sector comparison of Section~\ref{sec:sector_bnt_strong_match}, which pairs the
+sectors of two canonical forms through a bijection fixed by their bond
+dimensions and gauge-phase equivalences. The proof of the Fundamental Theorem
+in Chapter~\ref{ch:ft_proof} proceeds through the sector comparison.
 
 The same overlap dichotomy also shows that the MPV states of distinct normal
 blocks are non-proportional at arbitrarily large lengths; this is an input to

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -368,6 +368,14 @@ equal block counts, then remove that restriction.
     Theorem~\ref{thm:bnt_perm_same_card} yields the permutation conclusion.
 \end{proof}
 
+The two preceding results give a self-contained formulation of permutation
+rigidity that derives the block matching directly from the asymptotic
+orthonormality of the overlaps. The fundamental theorem in this development
+does not invoke them; it obtains the same matching through the exact sector
+track of Section~\ref{sec:sector_bnt_strong_match}, which matches blocks by a
+bijection between the sectors of the two canonical forms. They are kept here as
+an alternative route to the same conclusion.
+
 The same overlap dichotomy also shows that the MPV states of distinct normal
 blocks are non-proportional at arbitrarily large lengths; this is an input to
 the exact sector matching later in the chapter.


### PR DESCRIPTION
## Summary

Resolves #2276. `thm:bnt_perm_same_card` and `lem:bnt_perm_simple` (Lean `MPSTensor.exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho` / `exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho`) are fully `\leanok` and source-faithful, but the Fundamental Theorem in this development routes block matching through the exact sector track (`sec:sector_bnt_strong_match`), so they are consumed by nothing.

Retiring proven, correct, source-faithful theorems would discard verified mathematics. Instead this adds a sentence after `lem:bnt_perm_simple` recording them as a self-contained alternative formulation of permutation rigidity, off the FT critical path.

## Verification

- The keep-vs-retire recommendation and the orphan/zero-consumer status were independently confirmed (no Lean or blueprint consumer; the module is in the root import graph, so it is live compiled mathematics).
- The cross-reference `sec:sector_bnt_strong_match` resolves; the sentence describes the sector bijection accurately (matched by bond dimension + gauge-phase equivalence, not by copy-weight).
- Clean two-pass blueprint rebuild; no `\lean`/`\leanok`/`\uses` change, so `checkdecls` is unaffected.

## Follow-up (not in this PR)

Optional: mirror the note in the `PermutationRigidityPrimitive.lean` module docstring so the kept-orphan status is auditable from the Lean side too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only blueprint clarification with no code or proof dependency changes.
> 
> **Overview**
> After **`lem:bnt_perm_simple`**, the blueprint adds a short bridge paragraph clarifying how **permutation rigidity** is obtained in two ways: **`thm:bnt_perm_same_card`** / **`lem:bnt_perm_simple`** via asymptotic overlap orthonormality, and **`sec:sector_bnt_strong_match`** via exact sector comparison (bond dimension + gauge-phase bijection). It states explicitly that the **Fundamental Theorem** proof in **`ch:ft_proof`** follows the **sector** track, so the overlap lemmas remain a documented **standalone** route rather than appearing unused.
> 
> No Lean, `\leanok`, or `\uses` changes—documentation and cross-references only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 476a1b1c7900aa4e29a73267f567bae2f3ad7f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->