### PR TITLE
feat(MPS/Examples): GHZ virtual Z₂ symmetry and symmetry-breaking order parameter

### DIFF
--- a/TNLean/MPS/Examples/GHZ.lean
+++ b/TNLean/MPS/Examples/GHZ.lean
@@ -174,7 +174,7 @@ private lemma pauliZ_sq : pauliZ * pauliZ = 1 := by
     simp [pauliZ, Matrix.mul_apply, Fin.sum_univ_two]
 
 /-- Each GHZ matrix commutes with `σz`: both `A⁰` and `A¹` are diagonal.  (Kept
-`private`: `pauliZ` is an internal abbreviation, not part of the public API.) -/
+`private`, as `σz` here is only an internal abbreviation.) -/
 private lemma ghz_pauliZ_commutes (i : Fin 2) :
     pauliZ * ghzTensor i = ghzTensor i * pauliZ := by
   fin_cases i <;> ext a b <;> fin_cases a <;> fin_cases b <;>

--- a/TNLean/MPS/Examples/GHZ.lean
+++ b/TNLean/MPS/Examples/GHZ.lean
@@ -158,54 +158,57 @@ theorem ghz_isOnSiteSymmetric_Z2 :
 
 /-! ### Virtual Z₂ symmetry and the symmetry-breaking order parameter
 
-The GHZ tensor is the standard example of a symmetry-broken phase. Both of its
-matrices are diagonal, so they commute with the diagonal operator σz acting on
-the bond (virtual) space. This virtual Z₂ symmetry is the hallmark of a
-$G$-injective tensor whose blocks are permuted trivially: the on-site physical
-symmetry lifts to a commuting action on the bond indices. The same operator σz
-is a nonidentity fixed point of the transfer map, the transfer-matrix signature
-of long-range ferromagnetic order. -/
+The GHZ tensor is the standard example of a symmetry-broken phase.  The on-site
+physical symmetry $\sigma_x$ swaps its two one-dimensional injective blocks
+$A^0 \leftrightarrow A^1$ (see `ghz_twisted_generator_eq`).  Dually, since both
+matrices are diagonal they commute with the diagonal operator $\sigma_z$ on the
+bond (virtual) space, a virtual Z₂ symmetry that acts on each block by a phase.
+This virtual symmetry, together with $\sigma_z$ being a fixed point of the
+transfer map, are the transfer-matrix fingerprints of long-range order. -/
 
-/-- Each GHZ matrix commutes with σz. Both $A^0$ and $A^1$ are diagonal, so they
-commute with the diagonal Pauli Z matrix. -/
-lemma ghz_pauliZ_commutes (i : Fin 2) :
-    (!![(1 : ℂ), 0; 0, -1]) * ghzTensor i = ghzTensor i * (!![(1 : ℂ), 0; 0, -1]) := by
+/-- The Pauli Z matrix `σz = diag(1, -1)` on the bond space. -/
+private def pauliZ : Matrix (Fin 2) (Fin 2) ℂ := !![(1 : ℂ), 0; 0, -1]
+
+private lemma pauliZ_sq : pauliZ * pauliZ = 1 := by
+  ext i j; fin_cases i <;> fin_cases j <;>
+    simp [pauliZ, Matrix.mul_apply, Fin.sum_univ_two]
+
+/-- Each GHZ matrix commutes with `σz`: both `A⁰` and `A¹` are diagonal. -/
+lemma ghz_pauliZ_commutes (i : Fin 2) : pauliZ * ghzTensor i = ghzTensor i * pauliZ := by
   fin_cases i <;> ext a b <;> fin_cases a <;> fin_cases b <;>
-    simp [ghzTensor, Matrix.mul_apply, Matrix.diagonal, Pi.single_apply]
+    simp [pauliZ, ghzTensor, Matrix.mul_apply, Matrix.diagonal, Pi.single_apply]
 
-/-- The virtual Z₂ representation on the bond space, sending the generator to σz.
-The identity element acts as the identity matrix, the generator acts as
-$\sigma_z = \mathrm{diag}(1, -1)$. -/
+/-- The virtual Z₂ representation on the bond space: the identity acts as `1` and
+the generator as `σz = diag(1, -1)`. -/
 noncomputable def ghzVirtualZ2Action :
     Multiplicative (ZMod 2) →* Matrix (Fin 2) (Fin 2) ℂ where
-  toFun g := if Multiplicative.toAdd g = 0 then 1 else !![(1 : ℂ), 0; 0, -1]
+  toFun g := if Multiplicative.toAdd g = 0 then 1 else pauliZ
   map_one' := by simp [toAdd_one]
   map_mul' a b := by
-    have hsq : (!![(1 : ℂ), 0; 0, -1]) * (!![(1 : ℂ), 0; 0, -1]) = 1 := by
-      ext i j; fin_cases i <;> fin_cases j <;>
-        simp [Matrix.mul_apply, Fin.sum_univ_two]
     rcases zmod2_cases a with rfl | rfl <;> rcases zmod2_cases b with rfl | rfl <;>
-      simp [toAdd_ofAdd, zmod2_one_add_one, hsq]
+      simp [toAdd_ofAdd, zmod2_one_add_one, pauliZ_sq]
 
-/-- The virtual Z₂ symmetry of the GHZ tensor: σz commutes with every GHZ matrix.
-This dual symmetry on the bond space is the $G$-injectivity hallmark of a
-symmetry-broken GHZ state. -/
+/-- The virtual Z₂ symmetry of the GHZ tensor: `σz` commutes with every GHZ
+matrix.  A non-scalar matrix commuting with all `Aⁱ` is the hallmark of a
+non-injective (Z₂-injective) tensor: the on-site `σx` swaps the two injective
+blocks, while `σz` acts on each block by a phase. -/
 theorem ghz_virtual_Z2_symmetric (i : Fin 2) :
     Commute (ghzVirtualZ2Action (Multiplicative.ofAdd 1)) (ghzTensor i) := by
-  have hgen : ghzVirtualZ2Action (Multiplicative.ofAdd 1) = !![(1 : ℂ), 0; 0, -1] := by
+  have hgen : ghzVirtualZ2Action (Multiplicative.ofAdd 1) = pauliZ := by
     simp [ghzVirtualZ2Action]
   rw [Commute, SemiconjBy, hgen]
   exact ghz_pauliZ_commutes i
 
-/-- The order parameter σz is a fixed point of the GHZ transfer map with eigenvalue 1.
-For an injective (gapped) tensor only multiples of the identity survive the
-transfer map, so the persistence of the nontrivial diagonal operator σz signals
-the long-range ferromagnetic order of the symmetry-broken phase. -/
-theorem ghz_orderParam_fixed :
-    transferMap ghzTensor (!![(1 : ℂ), 0; 0, -1]) = !![(1 : ℂ), 0; 0, -1] := by
+/-- The order parameter `σz` is a fixed point of the GHZ transfer map (eigenvalue
+one).  A primitive (injective) tensor has a one-dimensional transfer-map
+fixed-point space, spanned by a positive matrix that equals the identity only in
+a normalized gauge; the GHZ transfer map fixes the additional non-scalar operator
+`σz`, the extra non-decaying mode responsible for its long-range ferromagnetic
+order. -/
+theorem ghz_orderParam_fixed : transferMap ghzTensor pauliZ = pauliZ := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [transferMap_apply, ghzTensor, Fin.sum_univ_two, Matrix.diagonal, Pi.single_apply,
-      Matrix.mul_apply, Matrix.conjTranspose_apply]
+    simp [pauliZ, transferMap_apply, ghzTensor, Fin.sum_univ_two, Matrix.diagonal,
+      Pi.single_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
 
 end MPSTensor

--- a/TNLean/MPS/Examples/GHZ.lean
+++ b/TNLean/MPS/Examples/GHZ.lean
@@ -173,8 +173,10 @@ private lemma pauliZ_sq : pauliZ * pauliZ = 1 := by
   ext i j; fin_cases i <;> fin_cases j <;>
     simp [pauliZ, Matrix.mul_apply, Fin.sum_univ_two]
 
-/-- Each GHZ matrix commutes with `σz`: both `A⁰` and `A¹` are diagonal. -/
-lemma ghz_pauliZ_commutes (i : Fin 2) : pauliZ * ghzTensor i = ghzTensor i * pauliZ := by
+/-- Each GHZ matrix commutes with `σz`: both `A⁰` and `A¹` are diagonal.  (Kept
+`private`: `pauliZ` is an internal abbreviation, not part of the public API.) -/
+private lemma ghz_pauliZ_commutes (i : Fin 2) :
+    pauliZ * ghzTensor i = ghzTensor i * pauliZ := by
   fin_cases i <;> ext a b <;> fin_cases a <;> fin_cases b <;>
     simp [pauliZ, ghzTensor, Matrix.mul_apply, Matrix.diagonal, Pi.single_apply]
 
@@ -205,10 +207,11 @@ fixed-point space, spanned by a positive matrix that equals the identity only in
 a normalized gauge; the GHZ transfer map fixes the additional non-scalar operator
 `σz`, the extra non-decaying mode responsible for its long-range ferromagnetic
 order. -/
-theorem ghz_orderParam_fixed : transferMap ghzTensor pauliZ = pauliZ := by
+theorem ghz_orderParam_fixed :
+    transferMap ghzTensor (!![(1 : ℂ), 0; 0, -1]) = !![(1 : ℂ), 0; 0, -1] := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [pauliZ, transferMap_apply, ghzTensor, Fin.sum_univ_two, Matrix.diagonal,
+    simp [transferMap_apply, ghzTensor, Fin.sum_univ_two, Matrix.diagonal,
       Pi.single_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
 
 end MPSTensor

--- a/TNLean/MPS/Examples/GHZ.lean
+++ b/TNLean/MPS/Examples/GHZ.lean
@@ -23,6 +23,10 @@ proves its key properties.
 * `ghz_isRFP` : the GHZ tensor is a renormalization fixed point
 * `ghz_not_isInjective` : the GHZ tensor is not injective
 * `ghz_isOnSiteSymmetric_Z2` : the GHZ tensor is on-site symmetric under Z₂
+* `ghz_virtual_Z2_symmetric` : the virtual Z₂ symmetry, with σz commuting with every
+  GHZ matrix
+* `ghz_orderParam_fixed` : the order parameter σz is a fixed point of the transfer map,
+  the signature of long-range ferromagnetic order
 
 ## References
 
@@ -151,5 +155,57 @@ theorem ghz_isOnSiteSymmetric_Z2 :
   rcases zmod2_cases g with rfl | rfl
   · rw [twistedTensor_one]; exact fun _ _ => rfl
   · exact ghz_gaugeEquiv_twisted.sameMPV
+
+/-! ### Virtual Z₂ symmetry and the symmetry-breaking order parameter
+
+The GHZ tensor is the standard example of a symmetry-broken phase. Both of its
+matrices are diagonal, so they commute with the diagonal operator σz acting on
+the bond (virtual) space. This virtual Z₂ symmetry is the hallmark of a
+$G$-injective tensor whose blocks are permuted trivially: the on-site physical
+symmetry lifts to a commuting action on the bond indices. The same operator σz
+is a nonidentity fixed point of the transfer map, the transfer-matrix signature
+of long-range ferromagnetic order. -/
+
+/-- Each GHZ matrix commutes with σz. Both $A^0$ and $A^1$ are diagonal, so they
+commute with the diagonal Pauli Z matrix. -/
+lemma ghz_pauliZ_commutes (i : Fin 2) :
+    (!![(1 : ℂ), 0; 0, -1]) * ghzTensor i = ghzTensor i * (!![(1 : ℂ), 0; 0, -1]) := by
+  fin_cases i <;> ext a b <;> fin_cases a <;> fin_cases b <;>
+    simp [ghzTensor, Matrix.mul_apply, Matrix.diagonal, Pi.single_apply]
+
+/-- The virtual Z₂ representation on the bond space, sending the generator to σz.
+The identity element acts as the identity matrix, the generator acts as
+$\sigma_z = \mathrm{diag}(1, -1)$. -/
+noncomputable def ghzVirtualZ2Action :
+    Multiplicative (ZMod 2) →* Matrix (Fin 2) (Fin 2) ℂ where
+  toFun g := if Multiplicative.toAdd g = 0 then 1 else !![(1 : ℂ), 0; 0, -1]
+  map_one' := by simp [toAdd_one]
+  map_mul' a b := by
+    have hsq : (!![(1 : ℂ), 0; 0, -1]) * (!![(1 : ℂ), 0; 0, -1]) = 1 := by
+      ext i j; fin_cases i <;> fin_cases j <;>
+        simp [Matrix.mul_apply, Fin.sum_univ_two]
+    rcases zmod2_cases a with rfl | rfl <;> rcases zmod2_cases b with rfl | rfl <;>
+      simp [toAdd_ofAdd, zmod2_one_add_one, hsq]
+
+/-- The virtual Z₂ symmetry of the GHZ tensor: σz commutes with every GHZ matrix.
+This dual symmetry on the bond space is the $G$-injectivity hallmark of a
+symmetry-broken GHZ state. -/
+theorem ghz_virtual_Z2_symmetric (i : Fin 2) :
+    Commute (ghzVirtualZ2Action (Multiplicative.ofAdd 1)) (ghzTensor i) := by
+  have hgen : ghzVirtualZ2Action (Multiplicative.ofAdd 1) = !![(1 : ℂ), 0; 0, -1] := by
+    simp [ghzVirtualZ2Action]
+  rw [Commute, SemiconjBy, hgen]
+  exact ghz_pauliZ_commutes i
+
+/-- The order parameter σz is a fixed point of the GHZ transfer map with eigenvalue 1.
+For an injective (gapped) tensor only multiples of the identity survive the
+transfer map, so the persistence of the nontrivial diagonal operator σz signals
+the long-range ferromagnetic order of the symmetry-broken phase. -/
+theorem ghz_orderParam_fixed :
+    transferMap ghzTensor (!![(1 : ℂ), 0; 0, -1]) = !![(1 : ℂ), 0; 0, -1] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [transferMap_apply, ghzTensor, Fin.sum_univ_two, Matrix.diagonal, Pi.single_apply,
+      Matrix.mul_apply, Matrix.conjTranspose_apply]
 
 end MPSTensor

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -95,6 +95,29 @@ non-injective, renormalization-fixed-point MPS.
     gauge equivalence and hence the same MPV family.
 \end{proof}
 
+\begin{theorem}[Virtual $\Z_2$ symmetry of the GHZ tensor]\label{thm:ghz_virtual_z2}
+    \lean{MPSTensor.ghz_virtual_Z2_symmetric}
+    \leanok
+    \uses{def:ghz_tensor}
+    The matrix $\sigma_z$ commutes with every GHZ matrix $A^i$.  Thus, unlike the
+    on-site symmetry of Theorem~\ref{thm:ghz_z2_symmetric}, the GHZ tensor admits
+    a \emph{virtual} $\Z_2$ symmetry: a non-scalar matrix commuting with all
+    $A^i$, the hallmark of a non-injective ($\Z_2$-injective) tensor whose
+    physical symmetry permutes degenerate injective blocks.
+\end{theorem}
+
+\begin{theorem}[GHZ order parameter is a transfer-map fixed point]\label{thm:ghz_order_param}
+    \lean{MPSTensor.ghz_orderParam_fixed}
+    \leanok
+    \uses{def:ghz_tensor, def:transfer_map}
+    The order-parameter operator $\sigma_z$ is a fixed point of the GHZ transfer
+    map, $\E_A(\sigma_z) = \sigma_z$.  An eigenvalue-one fixed point other than
+    the identity is the transfer-matrix signature of long-range order: it is the
+    non-decaying mode that gives the GHZ state its ferromagnetic two-point
+    correlations, in contrast to an injective tensor where only the identity
+    survives.
+\end{theorem}
+
 %% ===================================================================
 \section{The AKLT state}\label{sec:aklt}
 %% ===================================================================

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -127,11 +127,7 @@ non-injective, renormalization-fixed-point MPS.
     \leanok
     \uses{def:ghz_tensor, def:transfer_map}
     The order-parameter operator $\sigma_z$ is a fixed point of the GHZ transfer
-    map, $\E_A(\sigma_z) = \sigma_z$.  A primitive (injective) tensor has a
-    one-dimensional transfer-map fixed-point space, spanned by a positive matrix
-    that equals the identity only in a normalized gauge; here the transfer map
-    fixes the additional non-scalar operator $\sigma_z$, the extra non-decaying
-    mode behind the GHZ state's long-range ferromagnetic correlations.
+    map, $\E_A(\sigma_z) = \sigma_z$.
 \end{theorem}
 
 \begin{proof}
@@ -139,6 +135,14 @@ non-injective, renormalization-fixed-point MPS.
     Since $\E_A(X) = \sum_i A^i X (A^i)^{\dagger}$ and both $A^i$ are diagonal,
     the claim is the entrywise computation $\E_A(\sigma_z) = \sigma_z$.
 \end{proof}
+
+\begin{remark}
+    A primitive (injective) tensor has a one-dimensional transfer-map
+    fixed-point space, spanned by a positive matrix that equals the identity only
+    in a normalized gauge.  That the GHZ transfer map fixes the additional
+    non-scalar operator $\sigma_z$ is the transfer-matrix signature of the extra
+    non-decaying mode behind its long-range ferromagnetic correlations.
+\end{remark}
 
 %% ===================================================================
 \section{The AKLT state}\label{sec:aklt}

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -95,15 +95,25 @@ non-injective, renormalization-fixed-point MPS.
     gauge equivalence and hence the same MPV family.
 \end{proof}
 
+\begin{definition}[Virtual $\Z_2$ representation of the GHZ tensor]\label{def:ghz_virtual_z2_action}
+    \lean{MPSTensor.ghzVirtualZ2Action}
+    \leanok
+    \uses{def:ghz_tensor}
+    The virtual $\Z_2$ representation on the bond space is the homomorphism
+    $\Z_2 \to \MN{2}$ sending the identity to $I$ and the generator to
+    $\sigma_z = \diag(1, -1)$.
+\end{definition}
+
 \begin{theorem}[Virtual $\Z_2$ symmetry of the GHZ tensor]\label{thm:ghz_virtual_z2}
     \lean{MPSTensor.ghz_virtual_Z2_symmetric}
     \leanok
-    \uses{def:ghz_tensor}
-    The matrix $\sigma_z$ commutes with every GHZ matrix $A^i$.  Thus, unlike the
-    on-site symmetry of Theorem~\ref{thm:ghz_z2_symmetric}, the GHZ tensor admits
-    a \emph{virtual} $\Z_2$ symmetry: a non-scalar matrix commuting with all
-    $A^i$, the hallmark of a non-injective ($\Z_2$-injective) tensor whose
-    physical symmetry permutes degenerate injective blocks.
+    \uses{def:ghz_tensor, def:ghz_virtual_z2_action}
+    The matrix $\sigma_z$ commutes with every GHZ matrix $A^i$.  A non-scalar
+    matrix commuting with all $A^i$ is the hallmark of a non-injective
+    ($\Z_2$-injective) tensor: the on-site symmetry of
+    Theorem~\ref{thm:ghz_z2_symmetric} swaps the two one-dimensional injective
+    blocks $A^0 \leftrightarrow A^1$, while $\sigma_z$ acts on each block by a
+    phase.
 \end{theorem}
 
 \begin{theorem}[GHZ order parameter is a transfer-map fixed point]\label{thm:ghz_order_param}
@@ -111,11 +121,11 @@ non-injective, renormalization-fixed-point MPS.
     \leanok
     \uses{def:ghz_tensor, def:transfer_map}
     The order-parameter operator $\sigma_z$ is a fixed point of the GHZ transfer
-    map, $\E_A(\sigma_z) = \sigma_z$.  An eigenvalue-one fixed point other than
-    the identity is the transfer-matrix signature of long-range order: it is the
-    non-decaying mode that gives the GHZ state its ferromagnetic two-point
-    correlations, in contrast to an injective tensor where only the identity
-    survives.
+    map, $\E_A(\sigma_z) = \sigma_z$.  A primitive (injective) tensor has a
+    one-dimensional transfer-map fixed-point space, spanned by a positive matrix
+    that equals the identity only in a normalized gauge; here the transfer map
+    fixes the additional non-scalar operator $\sigma_z$, the extra non-decaying
+    mode behind the GHZ state's long-range ferromagnetic correlations.
 \end{theorem}
 
 %% ===================================================================

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -116,6 +116,12 @@ non-injective, renormalization-fixed-point MPS.
     phase.
 \end{theorem}
 
+\begin{proof}
+    \leanok
+    Both $A^0$ and $A^1$ are diagonal, so each commutes with the diagonal
+    matrix $\sigma_z$.
+\end{proof}
+
 \begin{theorem}[GHZ order parameter is a transfer-map fixed point]\label{thm:ghz_order_param}
     \lean{MPSTensor.ghz_orderParam_fixed}
     \leanok
@@ -127,6 +133,12 @@ non-injective, renormalization-fixed-point MPS.
     fixes the additional non-scalar operator $\sigma_z$, the extra non-decaying
     mode behind the GHZ state's long-range ferromagnetic correlations.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    Since $\E_A(X) = \sum_i A^i X (A^i)^{\dagger}$ and both $A^i$ are diagonal,
+    the claim is the entrywise computation $\E_A(\sigma_z) = \sigma_z$.
+\end{proof}
 
 %% ===================================================================
 \section{The AKLT state}\label{sec:aklt}


### PR DESCRIPTION
## Summary

Adds the symmetry-broken / Z₂-injective picture of the GHZ state (RMP [arXiv:2011.12127](https://arxiv.org/abs/2011.12127) §III), complementing its already-formalized on-site Z₂ symmetry. Extends `TNLean/MPS/Examples/GHZ.lean` (additive only).

- **`ghzVirtualZ2Action`** + **`ghz_virtual_Z2_symmetric`** — `σz` commutes with every GHZ matrix `Aⁱ`. A non-scalar matrix commuting with all `Aⁱ` is the *virtual* symmetry hallmark of a Z₂-injective (non-injective) tensor whose physical symmetry permutes degenerate injective blocks.
- **`ghz_orderParam_fixed`** — `transferMap ghzTensor σz = σz`. The order-parameter operator is an eigenvalue-1 fixed point of the transfer map: the transfer-matrix signature of long-range (ferromagnetic) order, in contrast to an injective tensor where only the identity survives.

Blueprint `ch16`: new entries `thm:ghz_virtual_z2`, `thm:ghz_order_param` (`\lean`/`\leanok`).

## Verification
- `lake build TNLean.MPS.Examples.GHZ` + `lake exe lint_style`: clean.
- No `sorry`/`axiom`/`native_decide`; no >100-char lines.

Part of the concrete-examples track (#903). Complements the SPT-symmetry examples (cluster, AKLT) already merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs and blueprint text on an example module; no changes to core MPS APIs, auth, or runtime behavior.
> 
> **Overview**
> Extends the GHZ MPS example with the **symmetry-broken / Z₂-injective** story alongside the existing on-site **σₓ** symmetry: a bond-space **virtual Z₂** action **`ghzVirtualZ2Action`** (generator **σz**) and **`ghz_virtual_Z2_symmetric`**, showing **σz** commutes with every **`ghzTensor`** matrix.
> 
> Adds **`ghz_orderParam_fixed`**, proving **σz** is an eigenvalue-1 fixed point of **`transferMap ghzTensor`**, framed as the transfer-matrix signature of long-range ferromagnetic order. Supporting private lemmas (**`pauliZ`**, commutation, squaring) and module doc updates mirror new blueprint **`ch16`** entries (`def:ghz_virtual_z2_action`, `thm:ghz_virtual_z2`, `thm:ghz_order_param` plus a remark).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1571430859c2581a60f52aa929ad4e8b80fdc09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->