### PR TITLE
blueprint: drop periodic/non-periodic/aperiodic Fundamental Theorem nicknames

### DIFF
--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1010,7 +1010,7 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     tensor $A^{[L]}$ is one-site injective.
 
     This is the blocked-injectivity form of the quantum Wielandt input used in
-    the non-periodic Fundamental Theorem chain. It corresponds to the statement
+    the Fundamental Theorem for translation-invariant tensors. It corresponds to the statement
     in \cite[Section~II, line~332]{Cirac2016MPDO_arXiv} that every normal tensor
     becomes injective after at most $D^4$ blockings, using the index estimate of~%
     \cite[Theorem~1]{Sanz2010Quantum}. The Lean statement includes the

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1014,7 +1014,7 @@ block.
 \subsection{Period removal by cyclic sectors}%
 \label{sec:cyclic_sectors}
 
-In the non-periodic proof of~\cite{Cirac2017MPDO_AnnPhys} the required step is
+In the proof of~\cite{Cirac2017MPDO_AnnPhys} the required step is
 periodicity removal by blocking: after blocking each irreducible TP block by the
 least common multiple of its peripheral periods, the result has no nontrivial
 $p$-periodic vectors~\cite[Section~2.3]{Cirac2017MPDO_AnnPhys}. The cyclic-sector

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -17,7 +17,7 @@ is $N_0$ such that the stated relation holds for every $N>N_0$. The comparison i
 made at a fixed such $N$, where BNT linear independence detects a vanishing
 coefficient even when $|\mu|<1$ lets it decay.
 
-% NOTE: The aperiodic Fundamental Theorem proof is formalised on the BNT
+% NOTE: The Fundamental Theorem proof is formalised on the BNT
 % canonical-form statements of Chapter~\ref{ch:bnt}. The Lean targets are
 % MPSTensor.ft_sector_bnt_equal_global_gauge and
 % MPSTensor.ft_sector_bnt_equal_mps_gaugeEquiv_literal in

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -401,7 +401,7 @@ unconditional result.
     \begin{center}
         \TNPeriodicGauge{m_j}{Z_j}{m_j}
     \end{center}
-    rather than by an ordinary aperiodic gauge alone: the operator $Z_j$
+    rather than by an ordinary gauge alone: the operator $Z_j$
     sits on the closing virtual bond and satisfies $Z_j^{m_j}=\Id$.
     Equivalently, setting $Y = \bigoplus_j Y_j \otimes \Id_{r_j}$
     and $Z = \bigoplus_j Z_j \otimes \Id_{r_j}$, one has
@@ -753,7 +753,7 @@ unconditional result.
                   \qquad
                   B^{[p]}\sim\bigoplus_b D_b,
               \]
-              with all $C_a,D_b$ normal.  The aperiodic theorem gives, after a
+              with all $C_a,D_b$ normal.  The Fundamental Theorem gives, after a
               permutation of the normal summands,
               \[
                   D_{\pi(a)}^\alpha
@@ -787,7 +787,7 @@ unconditional result.
 
     Chapters~\ref{ch:canonical} and~\ref{ch:ft_proof} follow only the
     blocking argument: remove periodicity by blocking, then apply the
-    aperiodic theory.  The periodic extension treats periodic blocks directly.
+    Fundamental Theorem.  The periodic extension treats periodic blocks directly.
 \end{remark}
 
 \begin{theorem}[Peripheral proportional case from exact MPV equality]


### PR DESCRIPTION
## Summary

"periodic"/"non-periodic"/"aperiodic Fundamental Theorem" name a result by which paper's setup it came from (a provenance label), not by mathematics. This replaces the remaining theorem-nickname uses with the setup or the theorem itself:

- **ch07** — "the non-periodic Fundamental Theorem chain" → "the Fundamental Theorem for translation-invariant tensors".
- **ch08** — "In the non-periodic proof of [CPSV16]" → "In the proof of [CPSV16]".
- **ch11** (a `% NOTE` comment) — "The aperiodic Fundamental Theorem proof" → "The Fundamental Theorem proof".
- **ch11b** — "The aperiodic theorem gives" → "The Fundamental Theorem gives"; "apply the aperiodic theory" → "apply the Fundamental Theorem"; "an ordinary aperiodic gauge" → "an ordinary gauge".

(ch01/ch05 were already done in #2286; ch13b in #2287.)

## Preserved

The mathematical term **"aperiodicity"/"aperiodic" for the condition** (trivial peripheral spectrum, period one) stays everywhere — ch07's span/normality theorems (26 uses), ch02's `thm:irred_tensor_aperiodic_normal` label, etc. So do the **setup descriptors** ("translation-invariant", "periodically repeated", "periodic blocks", the "periodic"/"blocking approach" method headers) and the `thm:periodic_ft` label.

## Build

Clean two-pass rebuild; zero undefined/multiply-defined references.

## Note

ch07/ch08/ch11/ch11b are also touched by an in-progress citation-normalization pass; the overlaps are mostly on adjacent lines (one same-line overlap at ch08:1017) and resolve trivially.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX wording in the blueprint; no code or formal proof changes.
> 
> **Overview**
> Blueprint prose no longer uses **periodic / non-periodic / aperiodic Fundamental Theorem** as provenance nicknames; wording now names the setup or the theorem directly.
> 
> In **ch07**, the Wielandt blocked-injectivity remark now ties that input to **the Fundamental Theorem for translation-invariant tensors** instead of “the non-periodic Fundamental Theorem chain.” **ch08** drops “non-periodic” from the Cirac et al. proof lead-in. **ch11** updates a `% NOTE` to say **the Fundamental Theorem proof** (not “aperiodic”). **ch11b** rephrases the blocking-vs-periodic comparison so the blocking route applies **the Fundamental Theorem** / **Fundamental Theorem** (not “aperiodic theorem” or “aperiodic theory”) and describes periodic gauge freedom without “aperiodic gauge.”
> 
> Mathematical **aperiodicity** (trivial peripheral spectrum, labels like `thm:irred_tensor_aperiodic_normal`) and setup terms (translation-invariant, periodic blocks, `thm:periodic_ft`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d0f5eca9fff956bdcd02c4f433aa09712a8d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->