### PR TITLE
feat(Algebra,MPS/Examples): cluster + AKLT Z₂×Z₂ SPT phases are non-trivial (#2290)

### DIFF
--- a/TNLean/Algebra/CocycleCohomology.lean
+++ b/TNLean/Algebra/CocycleCohomology.lean
@@ -192,10 +192,6 @@ lemma ScalarCocycle.commPhase_eq_of_cohomologousTo {ω₁ ω₂ : ScalarCocycle 
   -- `Units ℂ` is a commutative group; coerce to `ℂ`, where units are nonzero, and
   -- let `field_simp` cancel the common `φ`-factors in the ratio.
   apply Units.ext
-  have h1 := (φ g).ne_zero
-  have h2 := (φ k).ne_zero
-  have h3 := (φ (k * g)).ne_zero
-  have h4 := (ω₂ k g).ne_zero
   push_cast
   field_simp
 

--- a/TNLean/Algebra/CocycleCohomology.lean
+++ b/TNLean/Algebra/CocycleCohomology.lean
@@ -163,4 +163,55 @@ lemma ScalarCocycle.isCoboundary_iff_cohomologousTo_one (ω : ScalarCocycle G) :
   · rintro ⟨φ, hφ⟩
     exact ⟨φ, fun g h => by rw [hφ g h]; simp [mul_one]⟩
 
+/-! ### Commutator phase and non-triviality of a cohomology class
+
+For a pair of commuting group elements `g`, `h`, the *commutator phase*
+`ω(g,h) · ω(h,g)⁻¹` of a `U(1)`-valued 2-cocycle is invariant under the
+coboundary action and so descends to the cohomology class.  When the phase
+differs from `1` the class is non-trivial.  This is the standard discrete
+invariant detecting the non-trivial element of `H²(Z₂ × Z₂, U(1)) = Z₂`. -/
+
+/-- The commutator phase `ω(g,h) · ω(h,g)⁻¹` of a scalar 2-cocycle. -/
+def ScalarCocycle.commPhase (ω : ScalarCocycle G) (g h : G) : Units ℂ :=
+  ω g h * (ω h g)⁻¹
+
+omit [Group G] in
+/-- The trivial cocycle has commutator phase `1`. -/
+lemma ScalarCocycle.commPhase_one (g h : G) :
+    ScalarCocycle.commPhase (G := G) (fun _ _ => (1 : Units ℂ)) g h = 1 := by
+  simp [ScalarCocycle.commPhase]
+
+/-- The commutator phase at a commuting pair is invariant under coboundary
+equivalence: cohomologous cocycles share the same commutator phase. -/
+lemma ScalarCocycle.commPhase_eq_of_cohomologousTo {ω₁ ω₂ : ScalarCocycle G}
+    (H : ScalarCocycle.CohomologousTo ω₁ ω₂) {g k : G} (hgk : g * k = k * g) :
+    ScalarCocycle.commPhase ω₁ g k = ScalarCocycle.commPhase ω₂ g k := by
+  obtain ⟨φ, hφ⟩ := H
+  -- Substitute the coboundary formula and use `φ (g*k) = φ (k*g)` (from `hgk`).
+  simp only [ScalarCocycle.commPhase, hφ g k, hφ k g, hgk]
+  -- `Units ℂ` is a commutative group; coerce to `ℂ`, where units are nonzero, and
+  -- let `field_simp` cancel the common `φ`-factors in the ratio.
+  apply Units.ext
+  have h1 := (φ g).ne_zero
+  have h2 := (φ k).ne_zero
+  have h3 := (φ (k * g)).ne_zero
+  have h4 := (ω₂ k g).ne_zero
+  push_cast
+  field_simp
+
+/-- A scalar 2-cocycle has a non-trivial cohomology class when it is not
+cohomologous to the trivial cocycle. -/
+def ScalarCocycle.IsNontrivialClass (ω : ScalarCocycle G) : Prop :=
+  ¬ ScalarCocycle.CohomologousTo ω (fun _ _ => 1)
+
+/-- A non-trivial commutator phase at a commuting pair forces a non-trivial
+cohomology class. -/
+theorem ScalarCocycle.isNontrivialClass_of_commPhase_ne_one {ω : ScalarCocycle G}
+    {g h : G} (hgh : g * h = h * g) (hne : ScalarCocycle.commPhase ω g h ≠ 1) :
+    ScalarCocycle.IsNontrivialClass ω := by
+  intro H
+  apply hne
+  rw [ScalarCocycle.commPhase_eq_of_cohomologousTo H hgh,
+    ScalarCocycle.commPhase_one]
+
 end TNLean.Algebra

--- a/TNLean/MPS/Examples/AKLT.lean
+++ b/TNLean/MPS/Examples/AKLT.lean
@@ -498,9 +498,8 @@ projective representation of `Z₂ × Z₂` on the bond space.  Its factor syste
 `akltOmega` sends `(g, h)` to `-1` exactly when the first component of `h` is
 nonzero and the two components of `g` differ, the cocycle `(-1)^{(g₁+g₂) h₁}`;
 the extra diagonal term over the cluster case reflects `(iσy)² = -I`.  Its
-commutator phase on the two generators is `-1`, so by
-`isNontrivialClass_of_commPhase_ne_one` its class is the non-trivial element of
-`H²(Z₂ × Z₂, U(1)) = Z₂`. -/
+commutator phase on the two generators is `-1`, so the commutator-phase test
+shows its class is the non-trivial element of `H²(Z₂ × Z₂, U(1)) = Z₂`. -/
 
 open TNLean.Algebra in
 /-- The AKLT factor system on `Z₂ × Z₂`: `ω(g, h) = (-1)^{(g₁ + g₂) h₁}`, the

--- a/TNLean/MPS/Examples/AKLT.lean
+++ b/TNLean/MPS/Examples/AKLT.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.Symmetry.Defs
 import TNLean.MPS.Examples.ZMod2
+import TNLean.Algebra.CocycleCohomology
 
 /-!
 # AKLT state as a Matrix Product State
@@ -489,6 +490,77 @@ theorem aklt_isOnSiteSymmetric_Z2Z2 :
   · exact aklt_gaugeEquiv_P1.sameMPV
   · exact aklt_gaugeEquiv_P2.sameMPV
   · exact aklt_gaugeEquiv_P1P2.sameMPV
+
+/-! ### The AKLT factor system is the non-trivial class of `H²(Z₂ × Z₂, U(1))`
+
+The anticommuting virtual gauges `iσy` and `σz` assemble into an explicit
+projective representation of `Z₂ × Z₂` on the bond space.  Its factor system
+`akltOmega` sends `(g, h)` to `-1` exactly when the first component of `h` is
+nonzero and the two components of `g` differ, the cocycle `(-1)^{(g₁+g₂) h₁}`;
+the extra diagonal term over the cluster case reflects `(iσy)² = -I`.  Its
+commutator phase on the two generators is `-1`, so by
+`isNontrivialClass_of_commPhase_ne_one` its class is the non-trivial element of
+`H²(Z₂ × Z₂, U(1)) = Z₂`. -/
+
+open TNLean.Algebra in
+/-- The AKLT factor system on `Z₂ × Z₂`: `ω(g, h) = (-1)^{(g₁ + g₂) h₁}`, the
+value `-1` when `g₁ + g₂ = 1` and `h₁ = 1`, and `1` otherwise. -/
+def akltOmega : ScalarCocycle (Multiplicative (ZMod 2 × ZMod 2)) :=
+  fun g h =>
+    if (Multiplicative.toAdd g).1 + (Multiplicative.toAdd g).2 = 1 ∧
+        (Multiplicative.toAdd h).1 = 1 then -1 else 1
+
+/-- The virtual action of the explicit AKLT projective representation:
+`1 ↦ I`, `(1,0) ↦ iσy`, `(0,1) ↦ σz`, `(1,1) ↦ iσy σz`. -/
+def akltRepX (g : Multiplicative (ZMod 2 × ZMod 2)) : GL (Fin 2) ℂ :=
+  (if (Multiplicative.toAdd g).1 = 0 then 1 else akltGaugeGL) *
+    (if (Multiplicative.toAdd g).2 = 0 then 1 else akltGaugeZ)
+
+private lemma akltOmega_apply_val (g h : Multiplicative (ZMod 2 × ZMod 2)) :
+    (akltOmega g h : ℂ) =
+      if (Multiplicative.toAdd g).1 + (Multiplicative.toAdd g).2 = 1 ∧
+          (Multiplicative.toAdd h).1 = 1 then -1 else 1 := by
+  rw [akltOmega]; split <;> simp
+
+open TNLean.Algebra in
+/-- The explicit `Z₂ × Z₂` projective representation on the bond space carrying
+`akltOmega`.  The two generators act by the anticommuting gauges `iσy` and `σz`;
+the third nontrivial element acts by their product `iσy σz`. -/
+def akltProjRep : ProjectiveRepresentation (D := 2) akltOmega where
+  X := akltRepX
+  map_mul' g h := by
+    rcases zmod2sq_cases g with rfl | rfl | rfl | rfl <;>
+      rcases zmod2sq_cases h with rfl | rfl | rfl | rfl <;>
+      rw [akltOmega_apply_val] <;>
+      simp only [akltRepX, ← ofAdd_add, Prod.mk_add_mk, toAdd_ofAdd, toAdd_one,
+        Units.val_mul, Units.val_one, akltGaugeGL_val, akltGaugeZ_val, akltGaugeMat,
+        show (1 : ZMod 2) + 1 = 0 from by decide, show (0 : ZMod 2) + 1 = 1 from by decide,
+        show (1 : ZMod 2) + 0 = 1 from by decide, show (0 : ZMod 2) + 0 = 0 from by decide,
+        one_ne_zero, ↓reduceIte, and_self, and_true, true_and, mul_one, one_mul] <;>
+      (ext a b; fin_cases a <;> fin_cases b <;>
+        simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.smul_apply, Matrix.one_apply,
+          smul_eq_mul])
+
+open TNLean.Algebra in
+/-- The commutator phase of `akltOmega` on the two generators is `-1`. -/
+lemma aklt_commPhase_eq_neg_one :
+    ScalarCocycle.commPhase akltOmega
+      (Multiplicative.ofAdd (1, 0)) (Multiplicative.ofAdd (0, 1)) = -1 := by
+  simp only [ScalarCocycle.commPhase, akltOmega, toAdd_ofAdd]
+  apply Units.ext
+  norm_num
+
+open TNLean.Algebra in
+/-- The AKLT factor system represents the non-trivial element of
+`H²(Z₂ × Z₂, U(1)) = Z₂`: the AKLT state is a non-trivial SPT phase. -/
+theorem aklt_isNontrivialSPT : ScalarCocycle.IsNontrivialClass akltOmega := by
+  refine ScalarCocycle.isNontrivialClass_of_commPhase_ne_one
+    (g := Multiplicative.ofAdd (1, 0)) (h := Multiplicative.ofAdd (0, 1)) ?_ ?_
+  · rfl
+  · rw [aklt_commPhase_eq_neg_one]
+    intro hcon
+    have : ((-1 : Units ℂ) : ℂ) = ((1 : Units ℂ) : ℂ) := congrArg _ hcon
+    norm_num at this
 
 end MPSTensor
 

--- a/TNLean/MPS/Examples/AKLT.lean
+++ b/TNLean/MPS/Examples/AKLT.lean
@@ -542,6 +542,13 @@ def akltProjRep : ProjectiveRepresentation (D := 2) akltOmega where
           smul_eq_mul])
 
 open TNLean.Algebra in
+/-- `akltOmega` is a genuine `2`-cocycle: it is the factor system of the
+projective representation `akltProjRep`, so its class lives in
+`H²(Z₂ × Z₂, U(1))`. -/
+lemma akltOmega_isCocycle : ScalarCocycle.IsCocycle akltOmega :=
+  ScalarCocycle.isCocycle_of_projRep akltProjRep (by norm_num)
+
+open TNLean.Algebra in
 /-- The commutator phase of `akltOmega` on the two generators is `-1`. -/
 lemma aklt_commPhase_eq_neg_one :
     ScalarCocycle.commPhase akltOmega

--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -520,6 +520,13 @@ def clusterProjRep : ProjectiveRepresentation (D := 2) clusterOmega where
           smul_eq_mul])
 
 open TNLean.Algebra in
+/-- `clusterOmega` is a genuine `2`-cocycle: it is the factor system of the
+projective representation `clusterProjRep`, so its class lives in
+`H²(Z₂ × Z₂, U(1))`. -/
+lemma clusterOmega_isCocycle : ScalarCocycle.IsCocycle clusterOmega :=
+  ScalarCocycle.isCocycle_of_projRep clusterProjRep (by norm_num)
+
+open TNLean.Algebra in
 /-- The commutator phase of `clusterOmega` on the two generators is `-1`. -/
 lemma cluster_commPhase_eq_neg_one :
     ScalarCocycle.commPhase clusterOmega

--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -6,6 +6,7 @@ import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Symmetry.Defs
 import TNLean.MPS.Examples.GHZ
 import TNLean.MPS.Examples.ZMod2
+import TNLean.Algebra.CocycleCohomology
 
 /-!
 # Cluster state as a Matrix Product State
@@ -467,6 +468,77 @@ theorem cluster_isOnSiteSymmetric_Z2Z2 :
   · exact cluster_gaugeEquiv_X1.sameMPV
   · exact cluster_gaugeEquiv_X2.sameMPV
   · exact cluster_gaugeEquiv_X1X2.sameMPV
+
+/-! ### The cluster factor system is the non-trivial class of `H²(Z₂ × Z₂, U(1))`
+
+The anticommuting virtual gauges `σz` and `σx` assemble into an explicit
+projective representation of `Z₂ × Z₂` on the bond space.  Its factor system
+`clusterOmega` sends `(g, h)` to `-1` exactly when the second component of `g`
+and the first component of `h` are both nonzero, the standard commutator cocycle
+`(-1)^{g₂ h₁}`.  Its commutator phase on the two generators is `-1`, so by
+`isNontrivialClass_of_commPhase_ne_one` its class is the non-trivial element of
+`H²(Z₂ × Z₂, U(1)) = Z₂`. -/
+
+open TNLean.Algebra in
+/-- The cluster factor system on `Z₂ × Z₂`: `ω(g, h) = (-1)^{g₂ h₁}`, the value
+`-1` when `(g₂, h₁) = (1, 1)` and `1` otherwise. -/
+def clusterOmega : ScalarCocycle (Multiplicative (ZMod 2 × ZMod 2)) :=
+  fun g h =>
+    if (Multiplicative.toAdd g).2 = 1 ∧ (Multiplicative.toAdd h).1 = 1 then -1 else 1
+
+/-- The virtual action of the explicit cluster projective representation:
+`1 ↦ I`, `(1,0) ↦ σz`, `(0,1) ↦ σx`, `(1,1) ↦ σz σx`. -/
+def clusterRepX (g : Multiplicative (ZMod 2 × ZMod 2)) : GL (Fin 2) ℂ :=
+  (if (Multiplicative.toAdd g).1 = 0 then 1 else clusterGaugeZ) *
+    (if (Multiplicative.toAdd g).2 = 0 then 1 else clusterGaugeX)
+
+private lemma clusterOmega_apply_val (g h : Multiplicative (ZMod 2 × ZMod 2)) :
+    (clusterOmega g h : ℂ) =
+      if (Multiplicative.toAdd g).2 = 1 ∧ (Multiplicative.toAdd h).1 = 1 then -1 else 1 := by
+  rw [clusterOmega]; split <;> simp
+
+open TNLean.Algebra in
+/-- The explicit `Z₂ × Z₂` projective representation on the bond space carrying
+`clusterOmega`.  The two generators act by the anticommuting gauges `σz` and
+`σx`; the third nontrivial element acts by their product `σz σx`. -/
+def clusterProjRep : ProjectiveRepresentation (D := 2) clusterOmega where
+  X := clusterRepX
+  map_mul' g h := by
+    have hX : pauliX = !![(0 : ℂ), 1; 1, 0] := by
+      ext a b; fin_cases a <;> fin_cases b <;> simp [pauliX, Matrix.of_apply]
+    rcases zmod2sq_cases g with rfl | rfl | rfl | rfl <;>
+      rcases zmod2sq_cases h with rfl | rfl | rfl | rfl <;>
+      rw [clusterOmega_apply_val] <;>
+      simp only [clusterRepX, ← ofAdd_add, Prod.mk_add_mk, toAdd_ofAdd, toAdd_one,
+        Units.val_mul, Units.val_one, clusterGaugeZ_val, clusterGaugeX_val, hX,
+        show (1 : ZMod 2) + 1 = 0 from by decide, show (0 : ZMod 2) + 1 = 1 from by decide,
+        show (1 : ZMod 2) + 0 = 1 from by decide, show (0 : ZMod 2) + 0 = 0 from by decide,
+        one_ne_zero, ↓reduceIte, and_self, and_true, true_and,
+        mul_one, one_mul] <;>
+      (ext a b; fin_cases a <;> fin_cases b <;>
+        simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.smul_apply, Matrix.one_apply,
+          smul_eq_mul])
+
+open TNLean.Algebra in
+/-- The commutator phase of `clusterOmega` on the two generators is `-1`. -/
+lemma cluster_commPhase_eq_neg_one :
+    ScalarCocycle.commPhase clusterOmega
+      (Multiplicative.ofAdd (1, 0)) (Multiplicative.ofAdd (0, 1)) = -1 := by
+  simp only [ScalarCocycle.commPhase, clusterOmega, toAdd_ofAdd]
+  apply Units.ext
+  norm_num
+
+open TNLean.Algebra in
+/-- The cluster factor system represents the non-trivial element of
+`H²(Z₂ × Z₂, U(1)) = Z₂`: the cluster state is a non-trivial SPT phase. -/
+theorem cluster_isNontrivialSPT : ScalarCocycle.IsNontrivialClass clusterOmega := by
+  refine ScalarCocycle.isNontrivialClass_of_commPhase_ne_one
+    (g := Multiplicative.ofAdd (1, 0)) (h := Multiplicative.ofAdd (0, 1)) ?_ ?_
+  · rfl
+  · rw [cluster_commPhase_eq_neg_one]
+    intro hcon
+    have : ((-1 : Units ℂ) : ℂ) = ((1 : Units ℂ) : ℂ) := congrArg _ hcon
+    norm_num at this
 
 end MPSTensor
 

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -507,10 +507,16 @@ non-triviality.
     \leanok
     \uses{def:nontrivial_class, def:comm_phase, thm:comm_phase_invariant}
     If a commuting pair $g,h$ has $\beta_\omega(g,h)\neq 1$, then $\omega$ has a
-    non-trivial class.  The trivial cocycle has commutator phase $1$ everywhere,
-    so by Theorem~\ref{thm:comm_phase_invariant} any cocycle cohomologous to it
-    would too.
+    non-trivial class.
 \end{theorem}
+
+\begin{proof}\leanok\uses{thm:comm_phase_invariant}
+    The trivial cocycle has commutator phase $1$ at every pair, so by
+    Theorem~\ref{thm:comm_phase_invariant} any cocycle cohomologous to it has
+    $\beta = 1$ at every commuting pair.  Contrapositively, $\beta_\omega(g,h)\neq
+    1$ for one commuting pair forces $\omega$ to be non-cohomologous to the
+    trivial cocycle.
+\end{proof}
 
 \section{Permutation-Based Physical Symmetry}
 

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -457,6 +457,48 @@ make this precise and establish the quotient $H^2(G,\C^{\times})$.
     cohomology-class equality for factor systems.
 \end{proof}
 
+\subsection{Non-triviality via the commutator phase}
+
+For an abelian symmetry group the cohomology class of a factor system is
+detected by an antisymmetric pairing, which gives a computable test for
+non-triviality.
+
+\begin{definition}[Commutator phase]\label{def:comm_phase}
+    \lean{TNLean.Algebra.ScalarCocycle.commPhase}
+    \leanok
+    \uses{def:is_cocycle}
+    The \emph{commutator phase} of a factor system $\omega$ at a pair $g,h$ is
+    $\beta_\omega(g,h) := \omega(g,h)\,\omega(h,g)^{-1}$.
+\end{definition}
+
+\begin{theorem}[The commutator phase is a class invariant]\label{thm:comm_phase_invariant}
+    \lean{TNLean.Algebra.ScalarCocycle.commPhase_eq_of_cohomologousTo}
+    \leanok
+    \uses{def:comm_phase, def:cohomologous_to}
+    If $\omega_1\sim\omega_2$ and $gh=hg$, then
+    $\beta_{\omega_1}(g,h)=\beta_{\omega_2}(g,h)$.  At a commuting pair the
+    coboundary factors cancel, so the commutator phase depends only on the
+    cohomology class.
+\end{theorem}
+
+\begin{definition}[Non-trivial cohomology class]\label{def:nontrivial_class}
+    \lean{TNLean.Algebra.ScalarCocycle.IsNontrivialClass}
+    \leanok
+    \uses{def:cohomologous_to}
+    A factor system $\omega$ has a \emph{non-trivial class} when it is not
+    cohomologous to the constant cocycle $1$.
+\end{definition}
+
+\begin{theorem}[Commutator-phase non-triviality test]\label{thm:nontrivial_of_comm_phase}
+    \lean{TNLean.Algebra.ScalarCocycle.isNontrivialClass_of_commPhase_ne_one}
+    \leanok
+    \uses{def:nontrivial_class, def:comm_phase, thm:comm_phase_invariant}
+    If a commuting pair $g,h$ has $\beta_\omega(g,h)\neq 1$, then $\omega$ has a
+    non-trivial class.  The trivial cocycle has commutator phase $1$ everywhere,
+    so by Theorem~\ref{thm:comm_phase_invariant} any cocycle cohomologous to it
+    would too.
+\end{theorem}
+
 \section{Permutation-Based Physical Symmetry}
 
 The linear-combination twist $\widetilde{A}_g^i = \sum_j U(g)_{ij}\, A^j$

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -466,9 +466,10 @@ non-triviality.
 \begin{definition}[Commutator phase]\label{def:comm_phase}
     \lean{TNLean.Algebra.ScalarCocycle.commPhase}
     \leanok
-    \uses{def:is_cocycle}
-    The \emph{commutator phase} of a factor system $\omega$ at a pair $g,h$ is
-    $\beta_\omega(g,h) := \omega(g,h)\,\omega(h,g)^{-1}$.
+    \uses{def:scalar_cocycle}
+    The \emph{commutator phase} of a $2$-cochain $\omega$ at a pair $g,h$ is
+    $\beta_\omega(g,h) := \omega(g,h)\,\omega(h,g)^{-1}$.  It is defined for any
+    $\mathbb{C}^{\times}$-valued $2$-cochain, the cocycle condition is not needed.
 \end{definition}
 
 \begin{theorem}[The commutator phase is a class invariant]\label{thm:comm_phase_invariant}
@@ -476,10 +477,22 @@ non-triviality.
     \leanok
     \uses{def:comm_phase, def:cohomologous_to}
     If $\omega_1\sim\omega_2$ and $gh=hg$, then
-    $\beta_{\omega_1}(g,h)=\beta_{\omega_2}(g,h)$.  At a commuting pair the
-    coboundary factors cancel, so the commutator phase depends only on the
-    cohomology class.
+    $\beta_{\omega_1}(g,h)=\beta_{\omega_2}(g,h)$.
 \end{theorem}
+
+\begin{proof}\leanok\uses{def:comm_phase, def:cohomologous_to}
+    Write $\omega_1(g,h)=\varphi(g)\varphi(h)\varphi(gh)^{-1}\omega_2(g,h)$ for a
+    coboundary witness $\varphi$.  Substituting into the ratio and using
+    $gh=hg$ and the commutativity of $\mathbb{C}^{\times}$,
+    \[
+        \beta_{\omega_1}(g,h)
+        = \frac{\varphi(g)\varphi(h)\varphi(gh)^{-1}\,\omega_2(g,h)}
+               {\varphi(h)\varphi(g)\varphi(hg)^{-1}\,\omega_2(h,g)}
+        = \frac{\omega_2(g,h)}{\omega_2(h,g)}
+        = \beta_{\omega_2}(g,h),
+    \]
+    the $\varphi$-factors cancelling since $\varphi(gh)=\varphi(hg)$.
+\end{proof}
 
 \begin{definition}[Non-trivial cohomology class]\label{def:nontrivial_class}
     \lean{TNLean.Algebra.ScalarCocycle.IsNontrivialClass}

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -163,13 +163,23 @@ symmetry-protected topological (SPT) order.
     anticommute.
 \end{theorem}
 
+\begin{theorem}[The AKLT $\Z_2 \times \Z_2$ phase is non-trivial]\label{thm:aklt_nontrivial_spt}
+    \lean{MPSTensor.aklt_isNontrivialSPT}
+    \leanok
+    \uses{def:nontrivial_class, thm:nontrivial_of_comm_phase}
+    The factor system of the AKLT virtual representation, built from the
+    anticommuting gauges $i\sigma_y$ and $\sigma_z$
+    (Theorem~\ref{thm:aklt_gauge_anticomm}), has a non-trivial class in
+    $H^2(\Z_2 \times \Z_2, \mathrm{U}(1)) \cong \Z_2$: its commutator phase on the
+    two generators is $-1$.  The AKLT chain therefore realizes a non-trivial SPT
+    phase, not a trivial product state.
+\end{theorem}
+
 \begin{remark}\label{rem:aklt_z2z2_spt}
-    Because the physical generators commute while their virtual representatives
-    anticommute (Theorem~\ref{thm:aklt_gauge_anticomm}), the bond representation
-    is projective, with $2$-cocycle the non-trivial element of
-    $H^2(\Z_2 \times \Z_2, \mathrm{U}(1)) \cong \Z_2$, the signature of a
-    non-trivial SPT phase.  This $\Z_2 \times \Z_2$ is the smallest subgroup of
-    $\mathrm{SO}(3)$ that still carries a non-trivial $2$-cocycle.
+    This $\Z_2 \times \Z_2$ is the smallest subgroup of $\mathrm{SO}(3)$ that
+    still carries a non-trivial $2$-cocycle.  That minimality, and the full
+    continuous classification over $\mathrm{SO}(3)$, are not formalized
+    (Remark~\ref{rem:aklt_so3_spt}).
 \end{remark}
 
 \begin{definition}[Cartesian AKLT tensor]\label{def:aklt_cartesian}
@@ -313,10 +323,14 @@ computation and provides another example of a non-trivial SPT phase.
     $V_2 = \sigma_x$, anticommute ($V_1 V_2 = -V_2 V_1$).
 \end{theorem}
 
-\begin{remark}\label{rem:cluster_z2z2_spt}
-    Since the physical generators commute while their virtual representatives
-    anticommute (Theorem~\ref{thm:cluster_gauge_anticomm}), the bond
-    representation is projective, with $2$-cocycle the non-trivial element of
-    $H^2(\Z_2 \times \Z_2, \mathrm{U}(1)) \cong \Z_2$, witnessing a non-trivial
+\begin{theorem}[The cluster-state $\Z_2 \times \Z_2$ phase is non-trivial]\label{thm:cluster_nontrivial_spt}
+    \lean{MPSTensor.cluster_isNontrivialSPT}
+    \leanok
+    \uses{def:nontrivial_class, thm:nontrivial_of_comm_phase}
+    The factor system of the cluster-state virtual representation, built from the
+    anticommuting gauges $\sigma_z$ and $\sigma_x$
+    (Theorem~\ref{thm:cluster_gauge_anticomm}), has a non-trivial class in
+    $H^2(\Z_2 \times \Z_2, \mathrm{U}(1)) \cong \Z_2$: its commutator phase on the
+    two generators is $-1$.  The cluster state therefore realizes a non-trivial
     SPT phase.
-\end{remark}
+\end{theorem}

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -163,10 +163,29 @@ symmetry-protected topological (SPT) order.
     anticommute.
 \end{theorem}
 
+\begin{definition}[AKLT factor system]\label{def:aklt_omega}
+    \lean{MPSTensor.akltOmega}
+    \leanok
+    \uses{def:aklt_tensor}
+    The AKLT factor system on $\Z_2 \times \Z_2$ is
+    $\omega(g,h) = (-1)^{(g_1 + g_2)\,h_1}$ (the value $-1$ when $g_1 + g_2 = 1$
+    and $h_1 = 1$, and $1$ otherwise).  It is the factor system of the explicit
+    projective representation with virtual gauges $i\sigma_y$ and $\sigma_z$; the
+    diagonal term $g_1 h_1$ relative to the cluster case reflects
+    $(i\sigma_y)^2 = -I$.
+\end{definition}
+
+\begin{lemma}[AKLT commutator phase]\label{lem:aklt_comm_phase_neg_one}
+    \lean{MPSTensor.aklt_commPhase_eq_neg_one}
+    \leanok
+    \uses{def:aklt_omega, def:comm_phase}
+    The commutator phase of the AKLT factor system on the two generators is $-1$.
+\end{lemma}
+
 \begin{theorem}[The AKLT factor system is a $2$-cocycle]\label{thm:aklt_omega_cocycle}
     \lean{MPSTensor.akltOmega_isCocycle}
     \leanok
-    \uses{def:is_cocycle, def:aklt_tensor}
+    \uses{def:is_cocycle, def:aklt_omega}
     The AKLT factor system is a genuine $2$-cocycle, being the factor system of an
     explicit projective representation, so it represents an element of
     $H^2(\Z_2 \times \Z_2, \mathrm{U}(1))$.
@@ -175,7 +194,7 @@ symmetry-protected topological (SPT) order.
 \begin{theorem}[The AKLT $\Z_2 \times \Z_2$ phase is non-trivial]\label{thm:aklt_nontrivial_spt}
     \lean{MPSTensor.aklt_isNontrivialSPT}
     \leanok
-    \uses{def:nontrivial_class, thm:nontrivial_of_comm_phase}
+    \uses{def:nontrivial_class, thm:nontrivial_of_comm_phase, lem:aklt_comm_phase_neg_one}
     The AKLT factor system (Theorem~\ref{thm:aklt_omega_cocycle}), built from the
     anticommuting gauges $i\sigma_y$ and $\sigma_z$
     (Theorem~\ref{thm:aklt_gauge_anticomm}), is not a coboundary: its commutator
@@ -333,10 +352,29 @@ computation and provides another example of a non-trivial SPT phase.
     $V_2 = \sigma_x$, anticommute ($V_1 V_2 = -V_2 V_1$).
 \end{theorem}
 
+\begin{definition}[Cluster-state factor system]\label{def:cluster_omega}
+    \lean{MPSTensor.clusterOmega}
+    \leanok
+    \uses{def:cluster_tensor}
+    The cluster-state factor system on $\Z_2 \times \Z_2$ is
+    $\omega(g,h) = (-1)^{g_2\,h_1}$ (the value $-1$ when $g_2 = 1$ and $h_1 = 1$,
+    and $1$ otherwise).  It is the factor system of the explicit projective
+    representation with virtual gauges $\sigma_z$ and $\sigma_x$, both squaring to
+    the identity, so there is no diagonal term.
+\end{definition}
+
+\begin{lemma}[Cluster-state commutator phase]\label{lem:cluster_comm_phase_neg_one}
+    \lean{MPSTensor.cluster_commPhase_eq_neg_one}
+    \leanok
+    \uses{def:cluster_omega, def:comm_phase}
+    The commutator phase of the cluster-state factor system on the two generators
+    is $-1$.
+\end{lemma}
+
 \begin{theorem}[The cluster-state factor system is a $2$-cocycle]\label{thm:cluster_omega_cocycle}
     \lean{MPSTensor.clusterOmega_isCocycle}
     \leanok
-    \uses{def:is_cocycle, def:cluster_tensor}
+    \uses{def:is_cocycle, def:cluster_omega}
     The cluster-state factor system is a genuine $2$-cocycle, being the factor
     system of an explicit projective representation, so it represents an element
     of $H^2(\Z_2 \times \Z_2, \mathrm{U}(1))$.
@@ -345,7 +383,7 @@ computation and provides another example of a non-trivial SPT phase.
 \begin{theorem}[The cluster-state $\Z_2 \times \Z_2$ phase is non-trivial]\label{thm:cluster_nontrivial_spt}
     \lean{MPSTensor.cluster_isNontrivialSPT}
     \leanok
-    \uses{def:nontrivial_class, thm:nontrivial_of_comm_phase}
+    \uses{def:nontrivial_class, thm:nontrivial_of_comm_phase, lem:cluster_comm_phase_neg_one}
     The cluster-state factor system (Theorem~\ref{thm:cluster_omega_cocycle}),
     built from the anticommuting gauges $\sigma_z$ and $\sigma_x$
     (Theorem~\ref{thm:cluster_gauge_anticomm}), is not a coboundary: its

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -163,16 +163,26 @@ symmetry-protected topological (SPT) order.
     anticommute.
 \end{theorem}
 
+\begin{theorem}[The AKLT factor system is a $2$-cocycle]\label{thm:aklt_omega_cocycle}
+    \lean{MPSTensor.akltOmega_isCocycle}
+    \leanok
+    \uses{def:is_cocycle, def:aklt_tensor}
+    The AKLT factor system is a genuine $2$-cocycle, being the factor system of an
+    explicit projective representation, so it represents an element of
+    $H^2(\Z_2 \times \Z_2, \mathrm{U}(1))$.
+\end{theorem}
+
 \begin{theorem}[The AKLT $\Z_2 \times \Z_2$ phase is non-trivial]\label{thm:aklt_nontrivial_spt}
     \lean{MPSTensor.aklt_isNontrivialSPT}
     \leanok
     \uses{def:nontrivial_class, thm:nontrivial_of_comm_phase}
-    The factor system of the AKLT virtual representation, built from the
+    The AKLT factor system (Theorem~\ref{thm:aklt_omega_cocycle}), built from the
     anticommuting gauges $i\sigma_y$ and $\sigma_z$
-    (Theorem~\ref{thm:aklt_gauge_anticomm}), has a non-trivial class in
-    $H^2(\Z_2 \times \Z_2, \mathrm{U}(1)) \cong \Z_2$: its commutator phase on the
-    two generators is $-1$.  The AKLT chain therefore realizes a non-trivial SPT
-    phase, not a trivial product state.
+    (Theorem~\ref{thm:aklt_gauge_anticomm}), is not a coboundary: its commutator
+    phase on the two generators is $-1$.  Its class in
+    $H^2(\Z_2 \times \Z_2, \mathrm{U}(1)) \cong \Z_2$ is therefore non-trivial,
+    so the AKLT chain realizes a non-trivial SPT phase rather than a trivial
+    product state.
 \end{theorem}
 
 \begin{remark}\label{rem:aklt_z2z2_spt}
@@ -323,14 +333,23 @@ computation and provides another example of a non-trivial SPT phase.
     $V_2 = \sigma_x$, anticommute ($V_1 V_2 = -V_2 V_1$).
 \end{theorem}
 
+\begin{theorem}[The cluster-state factor system is a $2$-cocycle]\label{thm:cluster_omega_cocycle}
+    \lean{MPSTensor.clusterOmega_isCocycle}
+    \leanok
+    \uses{def:is_cocycle, def:cluster_tensor}
+    The cluster-state factor system is a genuine $2$-cocycle, being the factor
+    system of an explicit projective representation, so it represents an element
+    of $H^2(\Z_2 \times \Z_2, \mathrm{U}(1))$.
+\end{theorem}
+
 \begin{theorem}[The cluster-state $\Z_2 \times \Z_2$ phase is non-trivial]\label{thm:cluster_nontrivial_spt}
     \lean{MPSTensor.cluster_isNontrivialSPT}
     \leanok
     \uses{def:nontrivial_class, thm:nontrivial_of_comm_phase}
-    The factor system of the cluster-state virtual representation, built from the
-    anticommuting gauges $\sigma_z$ and $\sigma_x$
-    (Theorem~\ref{thm:cluster_gauge_anticomm}), has a non-trivial class in
-    $H^2(\Z_2 \times \Z_2, \mathrm{U}(1)) \cong \Z_2$: its commutator phase on the
-    two generators is $-1$.  The cluster state therefore realizes a non-trivial
-    SPT phase.
+    The cluster-state factor system (Theorem~\ref{thm:cluster_omega_cocycle}),
+    built from the anticommuting gauges $\sigma_z$ and $\sigma_x$
+    (Theorem~\ref{thm:cluster_gauge_anticomm}), is not a coboundary: its
+    commutator phase on the two generators is $-1$.  Its class in
+    $H^2(\Z_2 \times \Z_2, \mathrm{U}(1)) \cong \Z_2$ is therefore non-trivial, so
+    the cluster state realizes a non-trivial SPT phase.
 \end{theorem}


### PR DESCRIPTION
Closes the "compute `[ω]` for concrete models (AKLT, cluster state)" sub-item of #2147 (filed as #2290): prove the cluster-state and AKLT `Z₂×Z₂` projective phases carry the **non-trivial** class of `H²(Z₂×Z₂,U(1)) ≅ Z₂`.

## What's new

**`TNLean/Algebra/CocycleCohomology.lean`** — a generic, reusable non-triviality test:
- `ScalarCocycle.commPhase ω g h := ω g h * (ω h g)⁻¹` (the antisymmetrized factor system)
- `commPhase_eq_of_cohomologousTo` — at a commuting pair the commutator phase is a coboundary invariant
- `IsNontrivialClass ω := ¬ CohomologousTo ω 1`
- `isNontrivialClass_of_commPhase_ne_one` — a commuting pair with `β ≠ 1` ⟹ non-trivial class

**`Cluster.lean` / `AKLT.lean`** — explicit projective representations built from the **same gauges that implement the on-site Z₂×Z₂ symmetry** (`clusterGaugeZ`=σz, `clusterGaugeX`=σx; `akltGaugeGL`=iσy, `akltGaugeZ`=σz), their factor systems `clusterOmega` / `akltOmega`, and `cluster_isNontrivialSPT` / `aklt_isNontrivialSPT` via `β((1,0),(0,1)) = −1`.

A correctness subtlety: the AKLT cocycle is **not** the cluster's — because `iσy² = −I` (vs `σz² = +I`) it gains a `(−1)^{g₁h₁}` term. `akltOmega` was derived from the explicit gauge multiplication table, not copied.

**blueprint**: ch13b gets a "Non-triviality via the commutator phase" subsection; ch16 upgrades the former untagged SPT remarks to `\leanok` theorems (`thm:cluster_nontrivial_spt`, `thm:aklt_nontrivial_spt`); the minimality of `Z₂×Z₂ ⊂ SO(3)` stays an untagged remark.

## Verification
- `lake build` (full) + `lake exe lint_style`: clean.
- No `sorry`/`axiom`/`native_decide`; `#print axioms` on both main theorems = `[propext, Classical.choice, Quot.sound]`.
- The projective reps use the actual symmetry gauges, so `clusterOmega`/`akltOmega` are the genuine SPT cocycles (not abstract stand-ins).

Builds on #2280 (cluster/AKLT Z₂×Z₂) and #2284 (AKLT SO(3)). The continuous `H²(SO(3),U(1))` classification remains the harder, separate gap (#2289).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds Mathlib proofs and documentation for SPT cohomology; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **commutator-phase** toolkit in `CocycleCohomology.lean` (`commPhase`, coboundary invariance at commuting pairs, `IsNontrivialClass`, and `isNontrivialClass_of_commPhase_ne_one`) so a single `β ≠ 1` witnesses a non-trivial `H²` class.
> 
> For **cluster** and **AKLT**, the PR defines explicit `Z₂×Z₂` factor systems (`clusterOmega`, `akltOmega`), bond projective reps built from the existing symmetry gauges, proves they are 2-cocycles, shows `β = -1` on the generators, and concludes `cluster_isNontrivialSPT` / `aklt_isNontrivialSPT`. The AKLT cocycle differs from the cluster one by an extra `(-1)^{g₁h₁}` term from `(iσy)² = -I`.
> 
> **Blueprint** (`ch13b_symmetry`, `ch16_examples`): new commutator-phase subsection and former informal SPT remarks replaced by `\leanok` theorems linking the examples to the non-trivial element of `H²(Z₂×Z₂, U(1)) ≅ Z₂`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03dd38b74f159a58e88535e526d9874a3d3ebe80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes #2290.