### PR TITLE
doc(MPS/ParentHamiltonian): sync chapter 14 proof status

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -37,7 +37,8 @@ words of length `L₀`.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, Section~4.3, lines 2049--2094
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+  Section IV.C, lines 2049--2094
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
+++ b/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
@@ -9,7 +9,8 @@ import TNLean.MPS.ParentHamiltonian.SuffixWindow
 # Right-extension for block-injective parent-Hamiltonian ground spaces
 
 This file proves the open-chain grow-back step from
-[Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section~4.3, lines 2049--2094].
+[Cirac--Perez-Garcia--Schuch--Verstraete 2021, arXiv:2011.12127,
+Section IV.C, lines 2049--2094].
 Starting from the compatibility family extracted by
 `MPSTensor.exists_left_tail_compatibility`, we show that block injectivity forces
 all boundary matrices `Z j` to share a common right factor. This yields the
@@ -25,7 +26,8 @@ open-chain extension theorem `groundSpace_extend_right_of_isNBlkInjective`.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, Section~4.3, lines 2049--2078
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+  Section IV.C, lines 2049--2078
 -/
 
 open scoped Matrix

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -36,7 +36,7 @@ of the parent Hamiltonian (see `UniqueGroundState.lean`).
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
-  Section~4.3 (see in particular lines 1976--2000 for the parent Hamiltonian
+  Section IV.C (see in particular lines 1976--2000 for the parent Hamiltonian
   definition, lines 2013--2078 for the intersection property)
 * [MPGSC18] arXiv:1804.04964, Section 3 (one-sided inverse)
 * [FNW92] Sections 3–4

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -9,11 +9,11 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 /-!
 # Martingale-method spectral-gap framework for parent Hamiltonians
 
-**Root-only.** This module is currently not imported downstream — it
-formalizes the martingale-method infrastructure for the MPS
-parent-Hamiltonian spectral gap. The Friedrichs-angle estimate needed
-to close `parentHamiltonian_gapped` is the remaining analytic step; the
-root module is kept out of downstream imports until that estimate is proved.
+This module collects the proof-complete martingale-method infrastructure for the
+MPS parent-Hamiltonian spectral gap and is imported by the project root.  The
+Friedrichs-angle estimate needed to close `parentHamiltonian_gapped` is the
+remaining analytic step, so `Martingale.Gap` stays separate until that estimate
+is proved.
 
 This file collects the three proof-complete infrastructure submodules:
 

--- a/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
@@ -14,8 +14,8 @@ This file provides a small reusable collection for transporting the parent-Hamil
 open-chain restriction maps (`contiguousRestrictₗ`, `tailRestrictₗ`,
 `restrictFirst`) across arithmetic-equal indexings of the total length. It is
 aimed at the periodic-chain normal-form range-reduction argument
-(see [Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section~4.3,
-lines 2049--2094]), where intermediate induction steps naturally produce
+(see [Cirac--Perez-Garcia--Schuch--Verstraete 2021, arXiv:2011.12127,
+Section IV.C, lines 2049--2094]), where intermediate induction steps naturally produce
 states indexed by `K + 1 + L₀` that have to be viewed as states indexed by
 `K + (L₀ + 1)`, or states indexed by `N - (L₀ + 1) + (L₀ + 1)` that have to be
 viewed as states indexed by `N`.
@@ -44,7 +44,8 @@ equal cannot be compared directly. The canonical solution is to reindex via
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, Section~4.3, lines 2049--2094
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+  Section IV.C, lines 2049--2094
 -/
 
 open scoped Matrix

--- a/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
@@ -13,7 +13,8 @@ import Mathlib.Data.Fin.Tuple.Basic
 This file introduces restriction maps obtained by fixing a prefix and reading the
 last `L` sites of a state on `K + L` sites. It states the resulting matrix
 identities needed for the open-chain range-reduction argument in
-[Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section~4.3, lines 2049--2094].
+[Cirac--Perez-Garcia--Schuch--Verstraete 2021, arXiv:2011.12127,
+Section IV.C, lines 2049--2094].
 
 ## Main results
 
@@ -27,7 +28,8 @@ identities needed for the open-chain range-reduction argument in
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, Section~4.3, lines 2049--2078
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+  Section IV.C, lines 2049--2078
 -/
 
 open scoped Matrix

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -53,37 +53,38 @@ with the periodic boundary condition:
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
-  Section~4.3, lines 1976--2094 (parent Hamiltonian definition and uniqueness
+  Section IV.C, lines 1976--2094 (parent Hamiltonian definition and uniqueness
   argument)
 * [FNW92] Sections 3–4
 * [PGVWC07] arXiv:quant-ph/0608197, Sections 5–6
 
 ## External inputs
 
-### CPGSV closure property (§IV.C of arXiv:2011.12127)
+### Closure property in arXiv:2011.12127, Section IV.C
 
-The theorem `wrapped_mirror_witness_agree_of_chainGroundSpace` is the formalization of the
-**closure-property comparison** from Cirac–Pérez-García–Schuch–Verstraete (2021), §IV.C:
+The theorem `wrapped_mirror_witness_agree_of_chainGroundSpace` states the
+remaining **closure-property comparison** from
+Cirac--Perez-Garcia--Schuch--Verstraete (2021), Section IV.C:
 
-> **CPGSV21, Section IV.C (lines 2049–2078).**  On a periodic chain, the two
+> **Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.C,
+> lines 2078--2090.** On a periodic chain, the two
 > wrapped-boundary witnesses extracted from a chain ground state (one from the
 > left-cyclic window, one from the right-cyclic window) must agree when their
-> complements are reindexed to a common middle word.  This agreement follows
-> because the two cyclic restrictions differ only by a cyclic shift, and the
-> boundary matrix is simultaneously constrained by all interior windows.
+> complements are reindexed to a common middle word.  The source describes this
+> as the boundary-closing analogue of the preceding intersection argument.
 
 In MPS notation after blocking: for an `L₀`-block-injective tensor `A` on a
 periodic chain of `N` sites with window size `L > L₀`, a chain ground state
 `ψ = groundSpaceMap A N X` induces two families of boundary matrices
-`Y_wrap, Y_mirror` satisfying universal word compatibility relations.  The CPGSV
-closure property states that these two families must agree on every common middle
-word `μ`, yielding the key comparison identity needed to close the range-reduction
-argument.
+`Y_wrap, Y_mirror` satisfying universal word compatibility relations. The
+closure property states that these two families must agree on every common
+middle word `μ`, yielding the key comparison identity needed to close the
+range-reduction argument.
 
 The formal Lean declaration:
 
 > `wrapped_mirror_witness_agree_of_chainGroundSpace` is the **unproven gap**
-> at line 786 of this file.  It is the remaining hard step in the proof of
+> for this closure-property comparison.  It is the remaining hard step in the proof of
 > `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.  Once supplied,
 > it yields the normal-range reduction
 > `chainGroundSpace A L N = mpvSubmodule A N` for `L > L₀` (instead of `2L₀`).
@@ -92,7 +93,7 @@ The supplementary files providing the open-chain build-up to this closure proper
 
 * `TNLean.MPS.ParentHamiltonian.ExtendRight` — the right-extension (grow-back) step
   that extracts a common right factor from universal word compatibility
-  (CPGSV21, lines 2049–2078).
+  (arXiv:2011.12127, Section IV.C, lines 2049--2078).
 * `TNLean.MPS.ParentHamiltonian.SuffixWindow` — suffix-window restrictions and
   the existence of left-tail compatibility families.
 
@@ -779,14 +780,14 @@ theorem chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_c
 /-- The two wrapped-boundary witnesses from a chain ground state agree when
 their complements are reindexed to a common middle word `μ`.
 
-This is the closure-property comparison from CPGSV21, §IV.C, and the remaining
-gap needed to close `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
+This theorem states the closure-property comparison from arXiv:2011.12127,
+Section IV.C, lines 2078--2090, and is the remaining gap needed to close
+`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
 
-The proof uses the full periodic structure: the chain ground space condition at
-ALL `N` cyclic positions forces the two cyclic restrictions at the wrapping
-boundaries to induce the same witness, because the corresponding cyclic
-configurations differ only by a cyclic shift and the boundary matrix `X` is
-constrained by the interior windows. -/
+The expected proof is the boundary-closing analogue of the preceding
+intersection argument: the two witnesses come from the same periodic-chain
+state, and the missing step is to compare their reindexed boundary witnesses
+through the remaining cyclic window constraints. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -846,7 +847,7 @@ with the span of the MPV with the reduced window `L > L₀` (instead of `2L₀`)
 The normality hypothesis enables the range reduction from `2L₀` to `L₀ + 1`
 via the structure theory of normal MPS (peripheral spectrum, canonical form).
 See [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
-Section~4.3, lines 2049--2094. -/
+Section IV.C, lines 2078--2090. -/
 -- TODO(parent-hamiltonian): derive using the normal-form range reduction and
 -- the cyclic-window definition of `chainGroundSpace`.
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -56,7 +56,8 @@ proceeds as follows:
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127, Section~4.3, lines 1976--2094
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+  Section IV.C, lines 1976--2094
 * [FNW92] Sections 3–4
 
 ## External input — Quantum Wielandt vector-to-matrix span

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1287,6 +1287,71 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     finishes.
 \end{proof}
 
+\begin{theorem}[Wrapped-boundary witnesses agree on a common middle word]
+    \label{thm:wrapped_mirror_witness_agree_chain_ground_space}
+    \lean{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace}
+    \leanok
+    \uses{thm:reduced_wrapped_boundary_compatibilities}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let $N\ge2$
+    and $L_0<L\le N$, and let
+    $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
+    $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are one-sided
+    wrapped-boundary witness families satisfying, for every physical letter $j$
+    and every background configuration $\tau$,
+    \[
+        A^{\tau_{L_0}\cdots\tau_{N-2}} A^j X
+        =
+        Y^{+}_{\tau} A^j,
+        \qquad
+        X A^j A^{\tau_1\cdots\tau_{N-L_0-1}}
+        =
+        A^j Y^{-}_{\tau}.
+    \]
+    For every physical letter
+    $\eta\in\{0,\ldots,d-1\}$ and every middle word $\mu$ of length
+    $N-(L_0+1)$, define two background configurations by
+    \[
+        \tau^{+}_{\eta}(\mu)_i =
+        \begin{cases}
+            \mu_{i-L_0}, & L_0\le i<N-1,\\
+            \eta,        & \text{otherwise},
+        \end{cases}
+        \qquad
+        \tau^{-}_{\eta}(\mu)_i =
+        \begin{cases}
+            \mu_{i-1}, & 1\le i<N-L_0,\\
+            \eta,      & \text{otherwise}.
+        \end{cases}
+    \]
+    Then the two witnesses agree on these two backgrounds:
+    \[
+        Y^{+}_{\tau^{+}_{\eta}(\mu)}
+        =
+        Y^{-}_{\tau^{-}_{\eta}(\mu)}.
+    \]
+    This is the closure-property comparison used in
+    \cite[lines~2078--2090]{Cirac2021Matrix}.
+\end{theorem}
+
+\begin{proof}
+    \notready
+    The reduced wrapped-boundary compatibilities give, for every physical letter
+    $j$,
+    \[
+        A^{\mu} A^j X
+        =
+        Y^{+}_{\tau^{+}_{\eta}(\mu)} A^j,
+        \qquad
+        X A^j A^{\mu}
+        =
+        A^j Y^{-}_{\tau^{-}_{\eta}(\mu)}.
+    \]
+    The missing argument is to use the remaining cyclic window constraints for
+    the same periodic-chain vector to pass from these two identities to
+    $Y^{+}_{\tau^{+}_{\eta}(\mu)}
+      =Y^{-}_{\tau^{-}_{\eta}(\mu)}$.
+\end{proof}
+
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%
     \label{thm:chain_ground_space_eq_mpv_blk}
     \lean{MPSTensor.chainGroundSpace_eq_mpvSubmodule}
@@ -1318,6 +1383,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{def:chain_ground_space, def:mpv_submodule, def:normal,
         def:l_blk_injective, thm:cyclic_normal_open_chain_range_reduction,
         thm:reduced_wrapped_boundary_compatibilities,
+        thm:wrapped_mirror_witness_agree_chain_ground_space,
         thm:conditional_normal_range_reduction_witness_comparison}
     If $A$ is normal, $D \ge 1$, and $L_0$-block-injective for some
     $L_0>0$, with $N \ge 2$ and $L_0 < L \le N$, then
@@ -1331,8 +1397,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{thm:reduced_wrapped_boundary_compatibilities,
         thm:conditional_normal_range_reduction_witness_comparison,
         lem:padded_complement_annihilation}
-    The closure property needed here is the one from
-    \cite[Section~4.3, lines 2049--2094]{Cirac2021Matrix}. Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
+    The closure property needed here is the witness comparison from
+    \cite[lines~2078--2090]{Cirac2021Matrix}.
+    Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
     supplies the two one-sided wrapped-boundary identities for the open-chain
     boundary matrix $X$. The padded-annihilation lemma states that exact
     complement-span length mismatches are no longer the obstruction. The new
@@ -2830,8 +2897,7 @@ the basis of normal tensors (BNT) from
 Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{definition}[Assembled parent ground space]\label{def:parent_hamiltonian_ground_space_bnt}
-    \lean{MPSTensor.parentHamiltonianGroundSpace}
-    \leanok
+    \notready
     \uses{def:chain_ground_space}
     For a family of blocks $A = (A_{j})_{j=1}^{r}$ and weights $\mu$, write
     $\operatorname{ParentGround}_{N,L}(A)$ for the periodic chain ground space of the
@@ -2840,15 +2906,13 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Definition by assembled chain ground space]
     \label{lem:parent_hamiltonian_ground_space_eq}
-    \lean{MPSTensor.parentHamiltonianGroundSpace_eq}
-    \leanok
+    \notready
     \uses{def:parent_hamiltonian_ground_space_bnt}
     By definition, this subspace is exactly the chain ground space of the assembled tensor.
 \end{lemma}
 
 \begin{definition}[Span of BNT block states]\label{def:bnt_span}
-    \lean{MPSTensor.bntSpan}
-    \leanok
+    \notready
     The BNT span is the linear span of the periodic MPV states of the individual blocks:
     \[
         \operatorname{BNTSpan}_{N}(A) := \spn\{V^{(N)}(A_{j}) : j = 1,\ldots,r\}.
@@ -2868,21 +2932,20 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     span the whole product algebra $\prod_j \MN{D_j}$.  The remaining
     mathematical step is to derive this condition for some positive length from
     the separated canonical-form/BNT hypotheses.  This is the block-injective
-    span requirement in \cite[Section~4.3, lines 2049--2094]{Cirac2021Matrix}: after blocking,
+    span requirement in \cite[lines~2120--2128]{Cirac2021Matrix}: after blocking,
     the parent ground space is generated by the basis of normal tensors, with
     the improved bound coming from block-diagonal boundary conditions.
 \end{definition}
 
 \begin{lemma}[Each BNT MPV lies in the assembled parent ground space]\label{lem:bnt_mpv_mem_ground_space}
-    \lean{MPSTensor.bnt_mem_groundSpace}
-    \leanok
+    \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, lem:mpv_mem_chain_ground_space}
     If $1 < L$ and $N \ge L + 1$, then for each block $A_{j}$ of a canonical-form/BNT
     decomposition, the corresponding MPV state lies in the assembled parent ground space.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     One first applies Lemma~\ref{lem:mpv_mem_chain_ground_space} to the individual block.
     The proof then inserts the resulting boundary matrix into the $j$-th diagonal block of the
     assembled tensor, with the compensating scalar factor coming from the nonzero weight $\mu_{j}$.
@@ -2890,8 +2953,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Periodic block lift]
     \label{lem:chain_ground_space_block_le_assembled}
-    \lean{MPSTensor.chainGroundSpace_block_le_toTensorFromBlocks}
-    \leanok
+    \notready
     \uses{def:chain_ground_space}
     For each block index $j$ with $\mu_{j} \neq 0$, the chain ground space of the block
     $A_{j}$ embeds into the chain ground space of the assembled tensor:
@@ -2902,7 +2964,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     The cyclic-window definition of the chain ground space reduces the inclusion to
     the local block-embedding statement that each ground vector of $A_{j}$ on the
     window of length $L$ lifts to the assembled tensor by inserting the block-diagonal
@@ -2911,8 +2973,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Periodic block decomposition: forward inclusion]
     \label{lem:isup_chain_ground_space_block_le_assembled}
-    \lean{MPSTensor.iSup_chainGroundSpace_block_le_toTensorFromBlocks}
-    \leanok
+    \notready
     \uses{def:chain_ground_space, lem:chain_ground_space_block_le_assembled}
     Assume $\mu_{j} \neq 0$ for every block index $j$. The supremum of the blockwise
     periodic-chain ground spaces is contained in the assembled tensor's periodic-chain
@@ -2925,14 +2986,13 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     Aggregate the block lift over all block indices.
 \end{proof}
 
 \begin{lemma}[Forward inclusion for assembled parent ground spaces]
     \label{lem:isup_chain_ground_space_block_le_parent_ground_space}
-    \lean{MPSTensor.iSup_chainGroundSpace_block_le_parentHamiltonianGroundSpace}
-    \leanok
+    \notready
     \uses{def:parent_hamiltonian_ground_space_bnt,
         lem:isup_chain_ground_space_block_le_assembled}
     For a canonical-form/BNT family, the supremum of the blockwise periodic-chain
@@ -2944,7 +3004,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     The canonical-form/BNT hypothesis supplies $\mu_{j} \neq 0$ for every $j$, and the
     assembled parent ground space is the chain ground space of the assembled tensor by
     definition.
@@ -2952,10 +3012,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Block-diagonal commutant reduction from span extension]
     \label{lem:route_b_block_diagonal_commutant_reduction}
-    \lean{Matrix.isBlockDiagonal'_of_commutes_span_blockProjection}
-    \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_wordSpan}
-    \lean{MPSTensor.offBlock_zero_of_commutes_reindexed_wordSpan}
-    \leanok
+    \notready
     \uses{def:block_projection, def:block_diagonal_matrix}
     Suppose the virtual sector projections $P_j$ of a dependent direct-sum bond space
     lie in the span of a family of matrices. Any boundary matrix commuting with that
@@ -2966,7 +3023,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     \uses{lem:block_diagonal_of_commutes_block_projection,
         lem:block_diagonal_iff_off_block_zero}
     Commutation is linear in the matrix from the spanning family, so it extends from
@@ -2978,8 +3035,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Block projections from product-algebra span]
     \label{lem:block_projection_span_from_product_algebra_span}
-    \lean{Matrix.blockProjection_mem_span_blockDiagonal'_of_pi_span_eq_top}
-    \leanok
+    \notready
     Let $T_a = (T_a(i))_i$ be a family of tuples spanning the full product algebra
     $\prod_i \MN{n_i}$, and let $c_i\neq0$ be nonzero scalars. Then, for every
     sector $k$, the sector projection $P_k$ lies in the span of the scaled
@@ -2990,7 +3046,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     Apply the linear map $(M_i)_i \mapsto \bigoplus_i c_i M_i$ to the full-span
     product-algebra element with $(c_k)^{-1} I$ in the $k$-th component and zero in
     every other component. Its image is exactly $P_k$.
@@ -2998,11 +3054,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Projection span from product-word span]
     \label{lem:block_projection_span_from_product_word_span}
-    \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
-    \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_wordTupleSpanTop}
-    \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
-    \lean{MPSTensor.offBlock_zero_of_commutes_reindexed_toTensorFromBlocks_of_wordTuple_span_eq_top}
-    \leanok
+    \notready
     If the simultaneous length-$m$ block-word tuples
     \[
         \omega \longmapsto \bigl(A_j^{\omega}\bigr)_j
@@ -3014,7 +3066,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     \uses{lem:block_projection_span_from_product_algebra_span,
         lem:route_b_block_diagonal_commutant_reduction}
     First embed the product algebra linearly as dependent block-diagonal matrices, scaling the
@@ -3155,20 +3207,6 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge}
     \lean{MPSTensor.forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}
     \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}
-    \lean{MPSTensor.forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock}
-    \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_threeBlock}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_threeBlock}
-    \lean{MPSTensor.forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.exists_forall_pairSpanTop_period_window_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_directSum_pairSpanTop_period_windows}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.exists_forall_pairTraceSeparatingAt_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.exists_wordTupleSpanTop_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.hasBiCF_of_isCanonicalFormBNT_of_directSum_injectiveBlocks}
-    \lean{MPSTensor.hasBiCF_of_isNormalCanonicalFormBNT_of_directSum_injectiveBlocks}
     \leanok
     \uses{lem:three_block_relation_ground_space_inclusion,
         thm:chain_ground_space_eq_mpv_blk}
@@ -3418,7 +3456,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     selector of length $(r-1)S$ for $k$.  Hence common block injectivity plus
     pairwise separators implies the finite product-word span in the block-injectivity
     proposition in
-    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} and the block-injective
+    \cite[lines~340--345]{Cirac2016MPDO_arXiv} and the block-injective
     canonical-form trace-separation condition.
 \end{lemma}
 
@@ -3436,29 +3474,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Product-word span from block-injective selector words]
     \label{lem:product_word_span_from_bnt_selectors}
-    \lean{MPSTensor.wordTupleSpanTop_of_hasInjectiveBlocks_of_blockSelectorWords}
-    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_blockSelectorWords}
-    \lean{MPSTensor.wordTupleSpanTop_of_hasInjectiveBlocks_of_pairBlockSeparatingWords}
-    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
-    \lean{MPSTensor.wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingAt}
-    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
-    \lean{MPSTensor.wordTupleSpanTop_of_hasInjectiveBlocks_of_pairTraceSeparatingUpTo_of_identity_padding}
-    \lean{MPSTensor.wordTupleSpanTop_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_hasInjectiveBlocks_of_pairBlockSeparatingWords}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairBlockSeparatingWords}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_hasInjectiveBlocks_of_pairTraceSeparatingAt}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingAt}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_pairTraceSeparatingUpTo_of_identity_padding}
-    \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_identity_period_windows}
-    \lean{MPSTensor.exists_wordTupleSpanTop_of_isCanonicalFormBNT_of_pairSpanTop_period_windows}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_identity_period_windows}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_hasInjectiveBlocks_of_blockSelectorWords}
-    \lean{MPSTensor.exists_pos_productWordSpan_of_isCanonicalFormBNT_of_blockSelectorWords}
-    \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_selectorWords}
-    \lean{MPSTensor.blockProjection_mem_span_reindexed_toTensorFromBlocks_of_bntSelectorWords}
-    \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_selectorWords}
-    \lean{MPSTensor.isBlockDiagonal'_of_commutes_reindexed_toTensorFromBlocks_of_bntSelectorWords}
-    \leanok
+    \notready
     \uses{def:bnt, lem:pair_trace_separation_to_pairwise_selectors,
         lem:pair_trace_separation_homogenization_with_padding,
         lem:block_selectors_from_pairwise_separators,
@@ -3484,7 +3500,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     \uses{lem:one_block_injective_of_injective,
         lem:pair_trace_separation_to_pairwise_selectors,
         lem:block_selectors_from_pairwise_separators,
@@ -3507,11 +3523,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Conditional boundary-matrix block split from projection span]
     \label{lem:conditional_boundary_matrix_block_split_projection_span}
-    \lean{MPSTensor.groundSpaceMap_toTensorFromBlocks_mem_iSup_chainGroundSpace_of_reindexed_projectionSpan}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_reindexed_projectionSpan}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_reindexed_projectionSpan}
-    \lean{MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_reindexed_projectionSpan}
-    \leanok
+    \notready
     \uses{lem:route_b_block_diagonal_commutant_reduction,
         lem:eval_word_block_diagonal_tensor, lem:mpv_mem_chain_ground_space,
         lem:isup_chain_ground_space_block_le_assembled,
@@ -3537,7 +3549,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     \uses{lem:route_b_block_diagonal_commutant_reduction,
         lem:eval_word_block_diagonal_tensor, lem:mpv_mem_chain_ground_space,
         lem:isup_chain_ground_space_block_le_assembled,
@@ -3555,10 +3567,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Conditional Route B block split from product-word span]
     \label{lem:route_b_block_split_from_product_word_span}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_wordTupleSpanTop}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_wordTupleSpanTop}
-    \lean{MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_wordTupleSpanTop}
-    \leanok
+    \notready
     \uses{def:route_b_product_word_span}
     Let $A$ be in canonical-form/BNT, and assume $1<L$, $N \ge L+1$, and
     $0<m$.  If the length-$m$ product-word tuples span $\prod_j \MN{D_j}$ and
@@ -3576,7 +3585,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     \uses{lem:block_projection_span_from_product_word_span,
         lem:conditional_boundary_matrix_block_split_projection_span}
     The product-word span witness gives the sector-projection span by
@@ -3592,10 +3601,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{lemma}[Conditional Route B block split from BNT selector words]
     \label{lem:route_b_block_split_from_bnt_selectors}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_bntSelectorWords}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_bntSelectorWords}
-    \lean{MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_bntSelectorWords}
-    \leanok
+    \notready
     \uses{def:bnt, rem:word_tuple_span_top,
         def:parent_hamiltonian_ground_space_bnt, def:bnt_span}
     Let $A$ be in canonical-form/BNT, assume $1 < L$ and $N \ge L + 1$, and suppose
@@ -3613,12 +3619,12 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     boundary representation remain explicit: this lemma does not derive
     selector existence from BNT separation, nor the wrapping/open-chain boundary
     representation. It is the formal composition matching the block-injective
-    ground-space route of \cite[Section~4.3, lines 2049--2094]{Cirac2021Matrix}, where the
+    ground-space route of \cite[lines~2120--2128]{Cirac2021Matrix}, where the
     regrowing argument is restricted to block-diagonal boundary conditions.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     \uses{lem:product_word_span_from_bnt_selectors,
         lem:route_b_block_split_from_product_word_span}
     Lemma~\ref{lem:product_word_span_from_bnt_selectors} turns the
@@ -3633,7 +3639,6 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{theorem}[Containment in the BNT span by block decomposition]
     \label{thm:parent_ground_space_le_bnt_span}
-    \lean{MPSTensor.parentHamiltonianGroundSpace_le_bntSpan_of_block_decomposition}
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, def:bnt_span,
         thm:chain_ground_space_eq_mpv_blk,
@@ -3660,7 +3665,6 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 
 \begin{theorem}[Ground space equals span of BNT]\label{thm:gs_eq_bnt_span}
     \notready
-    \lean{MPSTensor.parentHamiltonian_gs_eq_bnt_span}
     \uses{thm:parent_ground_space_le_bnt_span, lem:bnt_mpv_mem_ground_space,
         def:parent_hamiltonian_ground_space_bnt, def:bnt_span}
     If $1 < L$ and $N \ge L + 1$, then for a canonical-form/BNT family the assembled


### PR DESCRIPTION
### Motivation

- Chapter 14 of the blueprint advertises several parent-Hamiltonian results (degenerate/BNT ground-space route, Route B lemmas) via `\lean{...}` and `\leanok` tags that no longer correspond to declarations present on `main`, making the formalization appear more complete than it is.
- The lemma `MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace` — the boundary-closing witness comparison (arXiv:2011.12127, §IV.C, lines 2078–2090) — is the remaining gap on the normal-case route; it needs an explicit `\notready` blueprint entry so the gap is tracked rather than hidden (see #1475).
- Source shorthands ("Section 4.3") in comments and blueprint prose are untraceable without local PDF access; concrete `arXiv:2011.12127` section and line references are required.

### Description

- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`:
  - Mark degenerate/BNT ground-space route and Route B entries `\notready`; strip `\lean{...}` tags for declarations no longer on `main`.
  - Add explicit `\notready` blueprint entry for `MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace` (arXiv:2011.12127, §IV.C, lines 2078–2090), wired into the normal-range reduction proof outline.
  - Replace "Section 4.3" source shorthands with concrete `arXiv:2011.12127, §IV.C` line references throughout.
  - Weaken prose around the wrapped-boundary witness comparison to state only what is currently justified: the remaining step is the boundary-closing analogue of the preceding intersection argument.
- `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`: update module comment to record the open `sorry` at `wrapped_mirror_witness_agree_of_chainGroundSpace` as the boundary-closing witness comparison step, not as a proved result.
- `TNLean/MPS/ParentHamiltonian/Martingale.lean`: clarify root-module comment to distinguish proof-complete infrastructure from the still-separate Friedrichs-angle gap module (`Martingale.Gap`).
- `TNLean/MPS/ParentHamiltonian/{BlockStrip,ExtendRight,IntersectionProperty,RestrictTransport,SuffixWindow,WrappingWindow}.lean`: update source citations to concrete `arXiv:2011.12127, §IV.C` line references.
- No new `sorry` introduced; the existing `sorry` at `wrapped_mirror_witness_agree_of_chainGroundSpace` is now explicitly documented rather than silently present.
- Relates to #870, #905, #952, #460, #190.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState TNLean.MPS.ParentHamiltonian.Martingale` succeeds with the known `sorry` warning at `wrapped_mirror_witness_agree_of_chainGroundSpace`.
- `lake exe lint_style` passes on all eight modified `.lean` files.
- `python3 scripts/blueprint_lean_sync.py`: Chapter 14 reports no missing Lean declarations; remaining global findings are unrelated to this PR.
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files ...` passes.
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main` passes.
- `git diff --check` passes.
- Lean CI (`lean_action_ci.yml`) validates the full build.

---
Addresses #1475

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint tagging only; no Mathlib API or proof-logic changes beyond comments and TeX sync.
> 
> **Overview**
> This PR **aligns Chapter 14 of the blueprint and Parent Hamiltonian module docs with what is actually proved**, instead of marking results complete when the Lean declarations are missing or still `sorry`.
> 
> In **`ch14_parent_hamiltonian.tex`**, the degenerate/BNT ground-space route and many Route B lemmas are switched to **`\notready`** and **`\lean{...}` tags are removed** where there is no matching declaration on `main`. A new **`\notready`** theorem documents **`MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace`** (arXiv:2011.12127, §IV.C, lines 2078–2090) and wires it into the normal-range reduction outline. Vague **“Section 4.3”** references are replaced by **concrete arXiv section/line citations**; prose around the wrapped-boundary witness comparison is toned down to what is currently justified.
> 
> **Lean changes are comment/citation only** across `BlockStrip`, `ExtendRight`, `IntersectionProperty`, `RestrictTransport`, `SuffixWindow`, `WrappingWindow`, **`UniqueGroundState`** (explicit open gap at `wrapped_mirror_witness_agree_of_chainGroundState`), and **`Martingale`** (root import vs still-separate `Martingale.Gap`). **No new `sorry`**; the existing one at `wrapped_mirror_witness_agree_of_chainGroundSpace` is documented explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a534c0d7b6c032a73ef77515b6fa24d057a46aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->