### PR TITLE
feat(MPS/ParentHamiltonian): add one-sided witness uniqueness

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -803,6 +803,95 @@ theorem eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
     (wordSpan_top_of_mul A ((wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj) q hq)
     hkq hzero
 
+/-- A right boundary witness is unique once its products with all one-site
+tensors are fixed.
+
+This is the one-sided uniqueness consequence of block injectivity used in
+boundary-closing arguments: a positive block-injective word span turns equality
+after multiplying by each generator into equality of the boundary matrices. -/
+theorem right_witness_unique_of_isNBlkInjective
+    {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {Y₁ Y₂ : Matrix (Fin D) (Fin D) ℂ}
+    (hY : ∀ j : Fin d, Y₁ * A j = Y₂ * A j) :
+    Y₁ = Y₂ := by
+  have hword : ∀ σ : Fin L₀ → Fin d,
+      Y₁ * evalWord A (List.ofFn σ) = Y₂ * evalWord A (List.ofFn σ) := by
+    intro σ
+    let w := List.ofFn σ
+    have hw : w ≠ [] := by
+      intro hnil
+      have hlen : L₀ = 0 := by
+        simpa [w, List.length_ofFn] using congrArg List.length hnil
+      omega
+    obtain ⟨j, rest, hw_eq⟩ := List.exists_cons_of_ne_nil hw
+    rw [show List.ofFn σ = j :: rest from hw_eq]
+    calc
+      Y₁ * evalWord A (j :: rest)
+          = (Y₁ * A j) * evalWord A rest := by
+              rw [evalWord, Matrix.mul_assoc]
+      _ = (Y₂ * A j) * evalWord A rest := by rw [hY j]
+      _ = Y₂ * evalWord A (j :: rest) := by
+              rw [evalWord, Matrix.mul_assoc]
+  have hmul : LinearMap.mulLeft ℂ Y₁ = LinearMap.mulLeft ℂ Y₂ := by
+    apply LinearMap.ext_on_range
+      (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
+    · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+    · intro σ
+      simpa [LinearMap.mulLeft_apply] using hword σ
+  have h1 : Y₁ * (1 : Matrix (Fin D) (Fin D) ℂ) =
+      Y₂ * (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    simpa [LinearMap.mulLeft_apply] using
+      congrArg (fun f : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ =>
+        f (1 : Matrix (Fin D) (Fin D) ℂ)) hmul
+  simpa using h1
+
+/-- A left boundary witness is unique once all one-site tensors have the same
+products with it. -/
+theorem left_witness_unique_of_isNBlkInjective
+    {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {Y₁ Y₂ : Matrix (Fin D) (Fin D) ℂ}
+    (hY : ∀ j : Fin d, A j * Y₁ = A j * Y₂) :
+    Y₁ = Y₂ := by
+  have hlist : ∀ w : List (Fin d), w ≠ [] →
+      evalWord A w * Y₁ = evalWord A w * Y₂ := by
+    intro w hw
+    induction w with
+    | nil => cases hw rfl
+    | cons j rest ih =>
+        cases rest with
+        | nil =>
+            simpa [evalWord] using hY j
+        | cons k rest =>
+            have htail : evalWord A (k :: rest) * Y₁ = evalWord A (k :: rest) * Y₂ :=
+              ih (by simp)
+            calc
+              evalWord A (j :: k :: rest) * Y₁
+                  = A j * (evalWord A (k :: rest) * Y₁) := by
+                      simp [evalWord, Matrix.mul_assoc]
+              _ = A j * (evalWord A (k :: rest) * Y₂) := by rw [htail]
+              _ = evalWord A (j :: k :: rest) * Y₂ := by
+                      simp [evalWord, Matrix.mul_assoc]
+  have hword : ∀ σ : Fin L₀ → Fin d,
+      evalWord A (List.ofFn σ) * Y₁ = evalWord A (List.ofFn σ) * Y₂ := by
+    intro σ
+    apply hlist
+    intro hnil
+    have hlen : L₀ = 0 := by
+      simpa [List.length_ofFn] using congrArg List.length hnil
+    omega
+  have hmul : LinearMap.mulRight ℂ Y₁ = LinearMap.mulRight ℂ Y₂ := by
+    apply LinearMap.ext_on_range
+      (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
+    · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+    · intro σ
+      simpa [LinearMap.mulRight_apply] using hword σ
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) * Y₁ =
+      (1 : Matrix (Fin D) (Fin D) ℂ) * Y₂ := by
+    simpa [LinearMap.mulRight_apply] using
+      congrArg (fun f : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ =>
+        f (1 : Matrix (Fin D) (Fin D) ℂ)) hmul
+  simpa using h1
+
 set_option maxHeartbeats 800000 in
 -- The double spanning argument over window tails and complements creates large
 -- `LinearMap.ext_on_range` goals, so we raise the heartbeat budget here as well.

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -51,6 +51,9 @@ proceeds as follows:
   — block injectivity turns long-word commutation into generator commutation
 * `MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul`
   — padding short complement annihilation to a full block-injective word span
+* `MPSTensor.right_witness_unique_of_isNBlkInjective` and
+  `MPSTensor.left_witness_unique_of_isNBlkInjective`
+  — one-sided boundary witness uniqueness from block injectivity
 * `MPSTensor.boundary_matrix_commutes` — if `groundSpaceMap A N X` lies in
   every cyclic window's ground space, then `X` commutes with all `A_j`.
 
@@ -814,36 +817,15 @@ theorem right_witness_unique_of_isNBlkInjective
     {Y₁ Y₂ : Matrix (Fin D) (Fin D) ℂ}
     (hY : ∀ j : Fin d, Y₁ * A j = Y₂ * A j) :
     Y₁ = Y₂ := by
-  have hword : ∀ σ : Fin L₀ → Fin d,
-      Y₁ * evalWord A (List.ofFn σ) = Y₂ * evalWord A (List.ofFn σ) := by
+  have hzero : ∀ σ : Fin 1 → Fin d, (Y₁ - Y₂) * evalWord A (List.ofFn σ) = 0 := by
     intro σ
-    let w := List.ofFn σ
-    have hw : w ≠ [] := by
-      intro hnil
-      have hlen : L₀ = 0 := by
-        simpa [w, List.length_ofFn] using congrArg List.length hnil
-      omega
-    obtain ⟨j, rest, hw_eq⟩ := List.exists_cons_of_ne_nil hw
-    rw [show List.ofFn σ = j :: rest from hw_eq]
-    calc
-      Y₁ * evalWord A (j :: rest)
-          = (Y₁ * A j) * evalWord A rest := by
-              rw [evalWord, Matrix.mul_assoc]
-      _ = (Y₂ * A j) * evalWord A rest := by rw [hY j]
-      _ = Y₂ * evalWord A (j :: rest) := by
-              rw [evalWord, Matrix.mul_assoc]
-  have hmul : LinearMap.mulLeft ℂ Y₁ = LinearMap.mulLeft ℂ Y₂ := by
-    apply LinearMap.ext_on_range
-      (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
-    · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
-    · intro σ
-      simpa [LinearMap.mulLeft_apply] using hword σ
-  have h1 : Y₁ * (1 : Matrix (Fin D) (Fin D) ℂ) =
-      Y₂ * (1 : Matrix (Fin D) (Fin D) ℂ) := by
-    simpa [LinearMap.mulLeft_apply] using
-      congrArg (fun f : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ =>
-        f (1 : Matrix (Fin D) (Fin D) ℂ)) hmul
-  simpa using h1
+    have heval : evalWord A (List.ofFn σ) = A (σ 0) := by
+      simp [evalWord]
+    rw [heval, sub_mul, hY (σ 0), sub_self]
+  have hsub : Y₁ - Y₂ = 0 :=
+    eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
+      (A := A) (L₀ := L₀) (k := 1) (q := 1) hInj (by omega) (by omega) hzero
+  exact sub_eq_zero.mp hsub
 
 /-- A left boundary witness is unique once all one-site tensors have the same
 products with it. -/

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -808,7 +808,7 @@ tensors are fixed.
 
 This is the one-sided uniqueness consequence of block injectivity used in
 boundary-closing arguments: a positive block-injective word span turns equality
-after multiplying by each generator into equality of the boundary matrices. -/
+after multiplying by each one-site tensor into equality of the boundary matrices. -/
 theorem right_witness_unique_of_isNBlkInjective
     {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {Y₁ Y₂ : Matrix (Fin D) (Fin D) ℂ}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1180,11 +1180,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    Equality after multiplying by every one-site tensor gives equality after
-    multiplying by every nonempty word.  Applying this to words of length $L_0$
-    and using that these words span $\MN{D}$ gives equality after multiplying by
-    the identity.  The left-handed statement is the same argument with
-    multiplication on the other side.
+    If $Y_1 A^j = Y_2 A^j$ for every physical index $j$, then induction on the
+    word gives
+    \[
+        Y_1 A^w = Y_2 A^w
+    \]
+    for every nonempty word $w$.  Since $A$ is $L_0$-block-injective, the
+    matrices $A^w$ with $|w|=L_0$ span $\MN{D}$.  Thus the left
+    multiplication maps $M\mapsto Y_1 M$ and $M\mapsto Y_2 M$ are equal on
+    $\MN{D}$, and evaluating on the identity gives $Y_1=Y_2$.  The other
+    one-sided statement is the same argument, with right multiplication in
+    place of left multiplication.
 \end{proof}
 
 \begin{lemma}[Generator commutation from long-word commutation]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1172,7 +1172,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.right_witness_unique_of_isNBlkInjective}
     \lean{MPSTensor.left_witness_unique_of_isNBlkInjective}
     \leanok
-    \uses{def:l_blk_injective}
+    \uses{def:l_blk_injective, lem:padded_complement_annihilation,
+        lem:wordspan_blk_inj}
     Let $A$ be $L_0$-block-injective with $L_0>0$.  If two boundary matrices
     have the same product with every one-site tensor on one fixed side, then the
     two boundary matrices are equal.
@@ -1180,17 +1181,19 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    If $Y_1 A^j = Y_2 A^j$ for every physical index $j$, then induction on the
-    word gives
+    If $Y_1 A^j = Y_2 A^j$ for every physical index $j$, then for every
+    nonempty word $w$, induction on the word gives
     \[
         Y_1 A^w = Y_2 A^w
     \]
-    for every nonempty word $w$.  Since $A$ is $L_0$-block-injective, the
-    matrices $A^w$ with $|w|=L_0$ span $\MN{D}$.  Thus the left
-    multiplication maps $M\mapsto Y_1 M$ and $M\mapsto Y_2 M$ are equal on
-    $\MN{D}$, and evaluating on the identity gives $Y_1=Y_2$.  The other
-    one-sided statement is the same argument, with right multiplication in
-    place of left multiplication.
+    Since $A$ is $L_0$-block-injective,
+    \[
+        \spn\{A^w : |w|=L_0\}=\MN{D}.
+    \]
+    Thus the left multiplication maps $M\mapsto Y_1 M$ and
+    $M\mapsto Y_2 M$ are equal on $\MN{D}$, and evaluating on the identity
+    gives $Y_1=Y_2$.  The other one-sided statement is the same argument, with
+    right multiplication in place of left multiplication.
 \end{proof}
 
 \begin{lemma}[Generator commutation from long-word commutation]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1167,6 +1167,26 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     of the full span and hence annihilates the identity.
 \end{proof}
 
+\begin{lemma}[One-sided boundary witnesses are unique]
+    \label{lem:one_sided_boundary_witness_unique}
+    \lean{MPSTensor.right_witness_unique_of_isNBlkInjective}
+    \lean{MPSTensor.left_witness_unique_of_isNBlkInjective}
+    \leanok
+    \uses{def:l_blk_injective}
+    Let $A$ be $L_0$-block-injective with $L_0>0$.  If two boundary matrices
+    have the same product with every one-site tensor on one fixed side, then the
+    two boundary matrices are equal.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Equality after multiplying by every one-site tensor gives equality after
+    multiplying by every nonempty word.  Applying this to words of length $L_0$
+    and using that these words span $\MN{D}$ gives equality after multiplying by
+    the identity.  The left-handed statement is the same argument with
+    multiplication on the other side.
+\end{proof}
+
 \begin{lemma}[Generator commutation from long-word commutation]
     \label{lem:boundary_matrix_commutes_long_words}
     \lean{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes}


### PR DESCRIPTION
### Motivation

- The parent-Hamiltonian normal-range argument (arXiv:2011.12127, Section IV.C, lines 2078–2090) requires that two boundary matrices agreeing on all one-site products are equal. This uniqueness property is needed for the boundary-closing comparison in `wrapped_mirror_witness_agree_of_chainGroundSpace` (see #1475).
- The result holds for $L_0$-block-injective MPS tensors: block injectivity at level $L_0$ ensures that length-$L_0$ words span the full matrix algebra, so one-site agreement extends to equality.

### Description

- Added two proved lemmas in `TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`:
  - `MPSTensor.right_witness_unique_of_isNBlkInjective`: for an $L_0$-block-injective MPS tensor $A$, if matrices $P$ and $Q$ satisfy $P \cdot A_i = Q \cdot A_i$ for every site index $i$, then $P = Q$.
  - `MPSTensor.left_witness_unique_of_isNBlkInjective`: the symmetric statement with products on the left.
  - Proofs lift the one-site equality to all nonempty words, apply it at length $L_0$, and conclude by $L_0$-block injectivity via `wordSpan`.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: added `\leanok` entry for `lem:one_sided_boundary_witness_unique`.
- Does not close `MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace`; the wrapped–mirror compatibility comparison (arXiv:2011.12127, Section IV.C, lines 2078–2090) remains open. Also contributes to tracking issue #190.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.WrappingWindow TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `lake exe lint_style TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check`
- `#print axioms` for both new lemmas: only `propext`, `Classical.choice`, and `Quot.sound`

---
Addresses #1475

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs and blueprint sync only; no runtime, auth, or API surface changes.
> 
> **Overview**
> Adds **one-sided boundary witness uniqueness** for \(L_0\)-block-injective MPS tensors: if two boundary matrices agree on products with every one-site tensor on the same side, they are equal.
> 
> In `WrappingWindow.lean`, **`right_witness_unique_of_isNBlkInjective`** and **`left_witness_unique_of_isNBlkInjective`** prove this by lifting one-site equality to all nonempty words (left case), then using **`wordSpan`** / **`eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul`** (right case uses the difference matrix annihilating length-1 words). The file header and blueprint **`lem:one_sided_boundary_witness_unique`** in `ch14_parent_hamiltonian.tex` are wired to these names.
> 
> This supports the parent-Hamiltonian normal-range / wrapped–mirror witness comparison (e.g. arXiv:2011.12127 §IV.C); it does **not** prove `wrapped_mirror_witness_agree_of_chainGroundSpace`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16287c6cca5abd4efb12e5aa588a5db94e3e8e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->