### PR TITLE
feat(MPS/ParentHamiltonian): isolate boundary product comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -777,6 +777,26 @@ theorem chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_c
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
     (A := A) (L₀ := L₀) (N := N) hInj hL₀ η Ywrap Ymirror hWrap hMirror hCompare'
 
+/-- Right-products with all one-site tensors determine the compared
+wrapped-boundary witnesses.
+
+This is the final algebraic reduction of the closure-property comparison from
+arXiv:2011.12127, Section IV.C, lines 2078--2090.  After the
+boundary-closing argument establishes `Y⁺_τ⁺ A^j = Y⁻_τ⁻ A^j` for every letter
+`j`, block-injectivity gives `span {A^w : |w| = L₀} = M_D(ℂ)`, so
+`Y⁺_τ⁺ = Y⁻_τ⁻`. -/
+theorem wrapped_mirror_witness_agree_of_right_products
+    {A : MPSTensor d D} {L₀ N : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    (Ywrap Ymirror : (Fin N → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (η : Fin d) (μ : Fin (N - (L₀ + 1)) → Fin d)
+    (hProd : ∀ j : Fin d,
+      Ywrap (wrappedMiddleBackground L₀ N η μ) * A j =
+        Ymirror (mirrorMiddleBackground L₀ N η μ) * A j) :
+    Ywrap (wrappedMiddleBackground L₀ N η μ) =
+      Ymirror (mirrorMiddleBackground L₀ N η μ) := by
+  exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
+
 /-- The two wrapped-boundary witnesses from a chain ground state agree when
 their complements are reindexed to a common middle word `μ`.
 
@@ -803,10 +823,11 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
         τ ⟨k.val + 1, by omega⟩)) = A j * Ymirror τ)
     (η : Fin d) (μ : Fin (N - (L₀ + 1)) → Fin d) :
     Ywrap (wrappedMiddleBackground L₀ N η μ) = Ymirror (mirrorMiddleBackground L₀ N η μ) := by
-  -- Both witnesses arise from the same chain ground state ψ restricted to the
-  -- two wrapped cyclic windows.  The chain ground space condition at the
-  -- intervening positions forces the two restrictions to induce the same
-  -- preimage under the injective groundSpaceMap.
+  refine wrapped_mirror_witness_agree_of_right_products (A := A) hInj hL₀
+    Ywrap Ymirror η μ ?_
+  intro j
+  -- It remains to prove the right-product identity by closing the boundary through
+  -- the intervening cyclic window constraints.
   sorry
 
 /-- Range reduction for normal tensors.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1316,11 +1316,40 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     finishes.
 \end{proof}
 
+\begin{lemma}[Right products determine the compared boundary condition]
+    \label{lem:wrapped_mirror_right_products_determine}
+    \lean{MPSTensor.wrapped_mirror_witness_agree_of_right_products}
+    \leanok
+    \uses{lem:one_sided_boundary_witness_unique}
+    Let $A$ be $L_0$-block-injective with $L_0>0$.  Fix two boundary-condition
+    families $Y^+$ and $Y^-$ and the two reindexed backgrounds
+    $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$.  If, for every physical letter
+    $j$,
+    \[
+        Y^+_{\tau^+_\eta(\mu)} A^j
+        =
+        Y^-_{\tau^-_\eta(\mu)} A^j,
+    \]
+    then
+    \[
+        Y^+_{\tau^+_\eta(\mu)}
+        =
+        Y^-_{\tau^-_\eta(\mu)}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply Lemma~\ref{lem:one_sided_boundary_witness_unique} to the two boundary
+    matrices $Y^+_{\tau^+_\eta(\mu)}$ and $Y^-_{\tau^-_\eta(\mu)}$.
+\end{proof}
+
 \begin{theorem}[Wrapped-boundary witnesses agree on a common middle word]
     \label{thm:wrapped_mirror_witness_agree_chain_ground_space}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace}
     \leanok
-    \uses{thm:reduced_wrapped_boundary_compatibilities}
+    \uses{thm:reduced_wrapped_boundary_compatibilities,
+        lem:wrapped_mirror_right_products_determine}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let $N\ge2$
     and $L_0<L\le N$, and let
     $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
@@ -1375,10 +1404,15 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         A^j Y^{-}_{\tau^{-}_{\eta}(\mu)}.
     \]
-    The missing argument is to use the remaining cyclic window constraints for
-    the same periodic-chain vector to pass from these two identities to
-    $Y^{+}_{\tau^{+}_{\eta}(\mu)}
-      =Y^{-}_{\tau^{-}_{\eta}(\mu)}$.
+    By Lemma~\ref{lem:wrapped_mirror_right_products_determine}, it is enough to
+    prove the right-product identities
+    \[
+        Y^{+}_{\tau^{+}_{\eta}(\mu)} A^j
+        =
+        Y^{-}_{\tau^{-}_{\eta}(\mu)} A^j
+    \]
+    for every $j$.  The missing argument is to obtain these identities from the
+    remaining cyclic window constraints for the same periodic-chain vector.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%


### PR DESCRIPTION
### Motivation

- Advances formalization of the parent Hamiltonian closure property for normal MPS (arXiv:2011.12127, Section IV.C), tracked in #1475.
- The proof that the chain ground space lies in the MPV subspace requires showing that two reindexed boundary witnesses agree. This PR extracts the algebraic core of that comparison as a standalone lemma, narrowing the remaining gap to a single cyclic-window identity.

### Description

- **`TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`**: adds `MPSTensor.wrapped_mirror_witness_agree_of_right_products`, proving that if the reindexed wrapped and mirror boundary witnesses have the same right-product with every one-site tensor, then block injectivity (`right_witness_unique_of_isNBlkInjective`) forces the witnesses to coincide. Rewires `wrapped_mirror_witness_agree_of_chainGroundSpace` to apply this lemma, reducing its remaining `sorry` to the single statement that the right-product identities follow from the cyclic window constraints.
- **`blueprint/src/chapter/ch14_parent_hamiltonian.tex`**: records the new intermediate result as Lemma `wrapped_mirror_right_products_determine` and updates the blueprint proof of the wrapped-mirror agreement theorem accordingly.
- One `sorry` remains in `wrapped_mirror_witness_agree_of_chainGroundSpace`; its discharge is the subject of #1475.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `lake exe lint_style TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- Direct axiom check: `MPSTensor.wrapped_mirror_witness_agree_of_right_products` depends only on `propext`, `Classical.choice`, and `Quot.sound`.

---
Addresses #1475

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure refactor in formalized MPS theory with no runtime, auth, or data-path changes; one `sorry` remains in the chain-ground-state theorem.
> 
> **Overview**
> This PR **isolates the algebraic step** in the parent-Hamiltonian closure comparison (arXiv:2011.12127, Sec. IV.C): when the reindexed wrapped and mirror boundary witnesses have the **same right-product with every one-site tensor** `A^j`, **block injectivity** forces the two witness matrices to agree.
> 
> In **`UniqueGroundState.lean`**, it adds **`wrapped_mirror_witness_agree_of_right_products`** (one line via `right_witness_unique_of_isNBlkInjective`) and **rewires** **`wrapped_mirror_witness_agree_of_chainGroundSpace`** to call it. The remaining **`sorry`** is only to derive those right-product identities from the **cyclic window constraints** on the chain ground state—not to re-prove witness equality from injectivity.
> 
> The **blueprint** records the same split as Lemma `wrapped_mirror_right_products_determine` and updates the wrapped-mirror agreement theorem so the open step is explicitly “right products from cyclic constraints.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0576eebb4d2be5ba369447047c96862fe43e7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->