### PR TITLE
doc(MPS/ParentHamiltonian): align closure and martingale prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -62,24 +62,23 @@ with the periodic boundary condition:
 
 ### Closure property in arXiv:2011.12127, Section IV.C
 
-The theorem `wrapped_mirror_witness_agree_of_chainGroundSpace` states the
-remaining **closure-property comparison** from
-Cirac--Perez-Garcia--Schuch--Verstraete (2021), Section IV.C:
+The theorem `wrapped_mirror_witness_agree_of_chainGroundSpace` isolates the
+remaining boundary-matrix comparison used to formalize the **closure property**
+from Cirac--Perez-Garcia--Schuch--Verstraete (2021), Section IV.C:
 
 > **Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.C,
-> lines 2078--2090.** On a periodic chain, the two
-> wrapped-boundary witnesses extracted from a chain ground state (one from the
-> left-cyclic window, one from the right-cyclic window) must agree when their
-> complements are reindexed to a common middle word.  The source describes this
-> as the boundary-closing analogue of the preceding intersection argument.
+> lines 2078--2090.** After proving the intersection property by inverting
+> tensors and growing them back, the source says that a similar argument applies
+> when closing the boundaries.  This boundary-closing statement is the closure
+> property.
 
-In MPS notation after blocking: for an `L₀`-block-injective tensor `A` on a
+In the present formal reduction, for an `L₀`-block-injective tensor `A` on a
 periodic chain of `N` sites with window size `L > L₀`, a chain ground state
-`ψ = groundSpaceMap A N X` induces two families of boundary matrices
-`Y_wrap, Y_mirror` satisfying universal word compatibility relations. The
-closure property states that these two families must agree on every common
-middle word `μ`, yielding the key comparison identity needed to close the
-range-reduction argument.
+`ψ = groundSpaceMap A N X` induces two boundary-matrix families from two cyclic
+windows crossing the periodic boundary.  The closure property is represented by
+the assertion that these boundary matrices agree after their complements are
+indexed by the same middle word `μ`, giving the comparison identity needed for
+the range-reduction argument.
 
 The formal Lean declaration:
 
@@ -797,17 +796,17 @@ theorem wrapped_mirror_witness_agree_of_right_products
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
-/-- The two wrapped-boundary witnesses from a chain ground state agree when
-their complements are reindexed to a common middle word `μ`.
+/-- The two boundary matrices extracted from the two boundary-crossing cyclic
+windows agree when their complements are reindexed to a common middle word `μ`.
 
 This theorem states the closure-property comparison from arXiv:2011.12127,
 Section IV.C, lines 2078--2090, and is the remaining gap needed to close
 `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
 
 The expected proof is the boundary-closing analogue of the preceding
-intersection argument: the two witnesses come from the same periodic-chain
-state, and the missing step is to compare their reindexed boundary witnesses
-through the remaining cyclic window constraints. -/
+intersection argument: the two boundary matrices come from the same
+periodic-chain state, and the missing step is to compare them through the
+remaining cyclic window constraints. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2791,12 +2791,13 @@ Lucia~\cite{Kastoryano2018Martingale}.
     least one site under periodic boundary conditions),
     the martingale condition of Theorem~\ref{thm:martingale_criterion} holds with
     constants $c_{ij}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
-    The source obtains this uniformity by the martingale method, using the
-    finite-chain-state estimates to control the constants.  In the present
-    formulation, the only quantitative estimate still isolated as a separate
-    theorem is the overlapping-window Friedrichs-angle bound in
-    Theorem~\ref{thm:friedrichs_gap_bound}; the preceding lemmas turn this
-    estimate into the martingale inequality and then into the spectral gap.
+    Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}
+    obtain this uniformity by the martingale method, invoking finite-chain-state
+    estimates to control the constants.  For the explicit cyclic-window
+    constants displayed here, the remaining quantitative step is the
+    overlapping-window Friedrichs-angle bound in
+    Theorem~\ref{thm:friedrichs_gap_bound}; the preceding lemmas reduce the
+    martingale inequality and the spectral gap to that estimate.
     (When $L = 1$ the interaction terms have disjoint supports, so there are no
     overlapping pairs and the spectral gap follows directly without the
     martingale argument.)
@@ -2849,9 +2850,13 @@ Lucia~\cite{Kastoryano2018Martingale}.
     content of the martingale condition \eqref{eq:4:martingale-2}: it gives a
     lower bound on the nonzero angles between the overlapping local ground
     spaces, with constants depending on $A$ and $L$ but independent of~$N$.
-    The cited finite-chain-state estimates give such constants for MPS parent
-    Hamiltonians, as in
-    \cite{Fannes1992Finitely, Nachtergaele1996Spectral}.
+    At this point it remains to compare this explicit cyclic-window bound with
+    the principal-angle estimates cited in
+    \cite{Fannes1992Finitely, Nachtergaele1996Spectral}.  The comparison is
+    documented in \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex} and
+    tracked in issue~\#952: either the cited estimates supply exactly this
+    bound under the cyclic-window convention, or the displayed theorem is a
+    stronger replacement estimate.
 \end{proof}
 
 \begin{theorem}[Explicit Friedrichs-angle gap bound]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1344,7 +1344,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     matrices $Y^+_{\tau^+_\eta(\mu)}$ and $Y^-_{\tau^-_\eta(\mu)}$.
 \end{proof}
 
-\begin{theorem}[Wrapped-boundary witnesses agree on a common middle word]
+\begin{theorem}[Boundary conditions agree after closing the boundary]
     \label{thm:wrapped_mirror_witness_agree_chain_ground_space}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace}
     \leanok
@@ -1353,8 +1353,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let $N\ge2$
     and $L_0<L\le N$, and let
     $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
-    $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are one-sided
-    wrapped-boundary witness families satisfying, for every physical letter $j$
+    $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are the two
+    boundary-matrix families extracted from the two cyclic windows crossing the
+    periodic boundary, and that they satisfy, for every physical letter $j$
     and every background configuration $\tau$,
     \[
         A^{\tau_{L_0}\cdots\tau_{N-2}} A^j X
@@ -1381,20 +1382,20 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
             \eta,      & \text{otherwise}.
         \end{cases}
     \]
-    Then the two witnesses agree on these two backgrounds:
+    Then the two boundary conditions agree on these two backgrounds:
     \[
         Y^{+}_{\tau^{+}_{\eta}(\mu)}
         =
         Y^{-}_{\tau^{-}_{\eta}(\mu)}.
     \]
-    This is the closure-property comparison used in
-    \cite[lines~2078--2090]{Cirac2021Matrix}.
+    This is the boundary-closing comparison corresponding to the closure
+    property in \cite[lines~2078--2090]{Cirac2021Matrix}.
 \end{theorem}
 
 \begin{proof}
     \notready
-    The reduced wrapped-boundary compatibilities give, for every physical letter
-    $j$,
+    The reduced boundary-crossing window compatibilities give, for every
+    physical letter $j$,
     \[
         A^{\mu} A^j X
         =
@@ -1411,8 +1412,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y^{-}_{\tau^{-}_{\eta}(\mu)} A^j
     \]
-    for every $j$.  The missing argument is to obtain these identities from the
-    remaining cyclic window constraints for the same periodic-chain vector.
+    for every $j$.  The missing argument is the closing-boundary step: obtain
+    these identities from the remaining cyclic window constraints for the same
+    periodic-chain vector.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%
@@ -2789,10 +2791,12 @@ Lucia~\cite{Kastoryano2018Martingale}.
     least one site under periodic boundary conditions),
     the martingale condition of Theorem~\ref{thm:martingale_criterion} holds with
     constants $c_{ij}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
-    \emph{Note:} The proof below fully establishes the martingale constants
-    only for $L = 2$; for $L > 2$ the existence of suitable constants is
-    asserted without complete proof (see the remark at the end of the proof).
-    Only the $L = 2$ case is used in the spectral-gap theorem below.
+    The source obtains this uniformity by the martingale method, using the
+    finite-chain-state estimates to control the constants.  In the present
+    formulation, the only quantitative estimate still isolated as a separate
+    theorem is the overlapping-window Friedrichs-angle bound in
+    Theorem~\ref{thm:friedrichs_gap_bound}; the preceding lemmas turn this
+    estimate into the martingale inequality and then into the spectral gap.
     (When $L = 1$ the interaction terms have disjoint supports, so there are no
     overlapping pairs and the spectral gap follows directly without the
     martingale argument.)
@@ -2840,35 +2844,14 @@ Lucia~\cite{Kastoryano2018Martingale}.
     (matching the Friedrichs bound exactly).
     Since $\alpha < 1$ (the Friedrichs angle is strictly positive),
     it remains to show $\gamma > 0$, i.e.\ $\alpha < \tfrac{1}{2(L-1)}$.
-    In the blocked picture used in the spectral-gap theorem below,
-    $L = 2$ and each site
-    overlaps with at most $2$ neighbours, so the condition reduces to
-    $\alpha < \tfrac{1}{2}$. For $L = 2$ with an injective tensor,
-    the two projectors $h_i$ and $h_{i+1}$ act on a finite-dimensional
-    space, and the intersection property
-    (Theorem~\ref{thm:ground_space_intersection}) guarantees that
-    $\ker(h_i) \cap \ker(h_{i+1})$ is exactly $G_{[i,i+2]}(A)$;
-    hence $\|P_i P_{i+1}\| < 1$ (the Friedrichs cosine is strictly
-    less than~1). On a finite-dimensional space with two projectors,
-    the Friedrichs cosine satisfies the quantitative bound
-    $\alpha \le 1 - c_{\min}$ where $c_{\min} > 0$ depends on the
-    minimal principal angle between the two kernels. The bound
-    $\alpha < \tfrac{1}{2}$ then follows from the
-    Nachtergaele finite-size criterion~\cite{Nachtergaele1996Spectral},
-    which establishes that the overlap $\|P_i P_{i+1}\|$ for injective
-    MPS is bounded away from $1$ by a constant depending only on the
-    tensor~$A$.
-    For general $L > 2$, the uniform constants $c_{ij} = \tfrac{1}{2(L-1)}$
-    make the condition $\alpha < \tfrac{1}{2(L-1)}$ increasingly restrictive
-    as $L$ grows. A more refined choice of separation-dependent constants
-    $c_{ij} = c_{d_N(i,j)}$ that weight small-separation (large-overlap) pairs
-    more heavily can exploit the exponential decay of the Friedrichs cosine
-    $\alpha_s$ in $s$ to satisfy the row-sum constraint.
-    However, this refinement is not needed for the main result: the
-    spectral-gap argument below is applied only with $L = 2$ in the
-    blocked picture.
-    In all cases, the constants depend only on $A$ and are independent
-    of~$N$~\cite{Fannes1992Finitely, Kastoryano2018Martingale}.
+    Thus the remaining positivity of $\gamma$ is the overlapping-window estimate
+    stated in Theorem~\ref{thm:friedrichs_gap_bound}.  This is the quantitative
+    content of the martingale condition \eqref{eq:4:martingale-2}: it gives a
+    lower bound on the nonzero angles between the overlapping local ground
+    spaces, with constants depending on $A$ and $L$ but independent of~$N$.
+    The cited finite-chain-state estimates give such constants for MPS parent
+    Hamiltonians, as in
+    \cite{Fannes1992Finitely, Nachtergaele1996Spectral}.
 \end{proof}
 
 \begin{theorem}[Explicit Friedrichs-angle gap bound]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2847,8 +2847,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     it remains to show $\gamma > 0$, i.e.\ $\alpha < \tfrac{1}{2(L-1)}$.
     Thus the remaining positivity of $\gamma$ is the overlapping-window estimate
     stated in Theorem~\ref{thm:friedrichs_gap_bound}.  This is the quantitative
-    content of the martingale condition \eqref{eq:4:martingale-2}: it gives a
-    lower bound on the nonzero angles between the overlapping local ground
+    content of the martingale condition of
+    Theorem~\ref{thm:martingale_criterion}: it gives a lower bound on the
+    nonzero angles between the overlapping local ground
     spaces, with constants depending on $A$ and $L$ but independent of~$N$.
     At this point it remains to compare this explicit cyclic-window bound with
     the principal-angle estimates cited in

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2852,8 +2852,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     spaces, with constants depending on $A$ and $L$ but independent of~$N$.
     At this point it remains to compare this explicit cyclic-window bound with
     the principal-angle estimates cited in
-    \cite{Fannes1992Finitely, Nachtergaele1996Spectral}.  The comparison is
-    documented in \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex} and
+    \cite{Fannes1992Finitely, Nachtergaele1996Spectral,
+    Kastoryano2018Martingale}.  The comparison is documented in
+    \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex} and
     tracked in issue~\#952: either the cited estimates supply exactly this
     bound under the cyclic-window convention, or the displayed theorem is a
     stronger replacement estimate.


### PR DESCRIPTION
### Motivation
- The closure-property narrative in `UniqueGroundState.lean` and `ch14_parent_hamiltonian.tex` used non-source language ("wrapped-boundary witnesses") where the source (Cirac et al. 2021, §IV.C, lines 2078–2090) speaks of boundary matrices from two boundary-crossing cyclic windows and closing the boundary; see #1475.
- The martingale sketch in the blueprint incorrectly stated that the all-`L` uniformity argument was only established for `L = 2`; the remaining quantitative input is the overlapping-window Friedrichs-angle bound, tracked in #952.

### Description
- `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`: module notes and docstrings rephrased to boundary-condition language matching arXiv:2011.12127 §IV.C; no proof logic changed (the `sorry` in `wrapped_mirror_witness_agree_of_chainGroundSpace` remains).
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: closure-property theorem title updated to *Boundary conditions agree after closing the boundary*; stale `L = 2`–only martingale claim removed; proof sketch now names the overlapping-window Friedrichs-angle bound (`thm:friedrichs_gap_bound`) as the remaining quantitative input.

### Testing
- `lake exe cache get` then `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `lake exe lint_style TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- Pre-existing Chapter 13a and 4a blueprint sync issues (`TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData`) are unrelated to these changes.

---
Addresses #1475
Addresses #952

> [!NOTE]
> **Low Risk**
> Comment and blueprint edits only; no executable Lean or proof logic changes.
> 
> **Overview**
> This PR **realigns documentation** for the parent-Hamiltonian uniqueness and spectral-gap narrative; it does **not** change Lean proofs (the `wrapped_mirror_witness_agree_of_chainGroundSpace` gap still ends in `sorry`).
> 
> **Closure property:** Lean module notes and blueprint text now describe Cirac et al. Section IV.C in terms of **boundary matrices** from two **boundary-crossing cyclic windows** and **closing the boundary**, instead of "wrapped-boundary witnesses." The theorem title becomes *Boundary conditions agree after closing the boundary*; wording tracks the source's post–intersection-property boundary-closing step (lines 2078–2090).
> 
> **Martingale / spectral gap:** Blueprint **removes** the claim that martingale constants are only fully proved for **`L = 2`**. The martingale lemma now states that uniformity comes from the martingale method and that the **remaining quantitative input** is the overlapping-window **Friedrichs-angle bound** (`thm:friedrichs_gap_bound`), with a shorter proof sketch pointing there instead of a long `L = 2`–only Nachtergaele discussion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f4e8012b7e6de6112f364e7a4b97c0333de011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint edits only; no proof logic, APIs, or runtime behavior changes.
> 
> **Overview**
> **Documentation-only** realignment for parent-Hamiltonian closure and martingale narratives; **no Lean proof or executable logic changes** (the `sorry` in `wrapped_mirror_witness_agree_of_chainGroundSpace` is unchanged).
> 
> **Closure property (#1475):** Module notes and docstrings in `UniqueGroundState.lean`, plus blueprint Ch.14, now describe Cirac et al. §IV.C in terms of **boundary matrices** from two **boundary-crossing cyclic windows** and **closing the boundary**, instead of “wrapped-boundary witnesses.” The blueprint theorem is retitled *Boundary conditions agree after closing the boundary*; proof sketches use “boundary-closing” / “closing-boundary” language.
> 
> **Martingale / spectral gap (#952):** The blueprint **drops** the claim that martingale constants are only fully proved for **`L = 2`**. The martingale lemma now states that uniformity comes from the martingale method and that the **remaining quantitative input** is the overlapping-window **Friedrichs-angle bound** (`thm:friedrichs_gap_bound`), with a shorter positivity sketch pointing there and cross-references to `docs/paper-gaps/cpgsv21_martingale_overlap.tex` and issue #952.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81132c4460eeb34e2994f38f5097135d417e6989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->