### PR TITLE
feat(MPS/ParentHamiltonian): add cyclic restrict-first transport

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -430,6 +430,80 @@ theorem cyclicRestrictₗ_restrictLast {N L : ℕ} (hN : 0 < N)
     · rw [dif_neg (by omega : ¬((k.val + N - i.val) % N < L + 1))]
       simp [hlast]
 
+/-- Restricting the first site of a non-repeating cyclic `(L + 1)`-window peels
+off the site with cyclic offset `0`, stores its value in the outside
+configuration, and moves the window start one site forward. -/
+theorem cyclicRestrictₗ_restrictFirst {N L : ℕ} (hN : 0 < N) (hLN : L + 1 ≤ N)
+    (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N) (j : Fin d) :
+    restrictFirst (cyclicRestrictₗ hN (L + 1) i τ ψ) j =
+      cyclicRestrictₗ hN L (cyclicForwardSite i 1)
+        (fun k => if (k.val + N - i.val) % N = 0 then j else τ k) ψ := by
+  ext σ
+  simp only [restrictFirst_apply, cyclicRestrictₗ_apply]
+  congr 1
+  ext k
+  simp only [cyclicCfg]
+  by_cases hzero : (k.val + N - i.val) % N = 0
+  · have hk : k = i := by
+      have hk' := eq_cyclic_site_of_offset_eq (N := N) hN (i := i) (k := k) hzero
+      simpa [Nat.mod_eq_of_lt i.isLt] using hk'
+    subst k
+    have hshift_eq : (i.val + N - (cyclicForwardSite i 1).val) % N = N - 1 := by
+      by_cases hi : i.val + 1 < N
+      · have hval : (cyclicForwardSite i 1).val = i.val + 1 := by
+          simp [cyclicForwardSite, Nat.mod_eq_of_lt hi]
+        rw [hval]
+        have hsub : i.val + N - (i.val + 1) = N - 1 := by omega
+        rw [hsub]
+        exact Nat.mod_eq_of_lt (by omega)
+      · have hiN : i.val + 1 = N := by omega
+        have hval : (cyclicForwardSite i 1).val = 0 := by
+          simp [cyclicForwardSite, hiN]
+        rw [hval]
+        have hsub : i.val + N - 0 = (N - 1) + N := by omega
+        rw [hsub, Nat.add_mod_right]
+        exact Nat.mod_eq_of_lt (by omega)
+    have hshift : ¬((i.val + N - (cyclicForwardSite i 1).val) % N < L) := by
+      rw [hshift_eq]
+      omega
+    rw [dif_pos (by omega : (i.val + N - i.val) % N < L + 1), dif_neg hshift]
+    simp
+  · let r := (k.val + N - i.val) % N
+    have hrpos : 0 < r := Nat.pos_of_ne_zero hzero
+    have hrN : r < N := Nat.mod_lt _ hN
+    have hk_site : k = cyclicForwardSite i r := by
+      have hsite :=
+        eq_cyclic_site_of_offset_eq (N := N) hN (i := i) (k := k) (r := r) rfl
+      simpa [cyclicForwardSite, r] using hsite
+    have hshift_site : k = cyclicForwardSite (cyclicForwardSite i 1) (r - 1) := by
+      rw [hk_site, cyclicForwardSite_forwardSite]
+      congr 1
+      omega
+    have hshift_eq : (k.val + N - (cyclicForwardSite i 1).val) % N = r - 1 := by
+      rw [hshift_site]
+      change (((cyclicForwardSite i 1).val + (r - 1)) % N + N -
+          (cyclicForwardSite i 1).val) % N = r - 1
+      exact offset_mod_eq (cyclicForwardSite i 1).isLt (by omega : r - 1 < N)
+    by_cases hsmall : (k.val + N - i.val) % N < L + 1
+    · have hshiftSmall : (k.val + N - (cyclicForwardSite i 1).val) % N < L := by
+        rw [hshift_eq]
+        omega
+      rw [dif_pos hsmall, dif_pos hshiftSmall]
+      have hidx :
+          (⟨(k.val + N - i.val) % N, hsmall⟩ : Fin (L + 1)) =
+            Fin.succ
+              (⟨(k.val + N - (cyclicForwardSite i 1).val) % N, hshiftSmall⟩ :
+                Fin L) := by
+        ext
+        simp [hshift_eq, r]
+        omega
+      rw [hidx, Fin.cons_succ]
+    · have hshiftLarge : ¬((k.val + N - (cyclicForwardSite i 1).val) % N < L) := by
+        rw [hshift_eq]
+        omega
+      rw [dif_neg hsmall, dif_neg hshiftLarge]
+      simp [hzero]
+
 /-- For a non-wrapping window (`i + L ≤ N`), the cyclic config agrees with
 the contiguous config. -/
 theorem cyclicCfg_eq_contiguousCfg {N : ℕ} (hN : 0 < N) {L : ℕ} (hLN : L ≤ N)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -570,15 +570,19 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.cyclicRestrictₗ_apply}
     \lean{MPSTensor.eq_cyclic_site_of_offset_eq}
     \lean{MPSTensor.cyclicRestrictₗ_restrictLast}
+    \lean{MPSTensor.cyclicRestrictₗ_restrictFirst}
     \lean{MPSTensor.cyclicCfg_eq_contiguousCfg}
     \lean{MPSTensor.cyclicRestrictₗ_eq_contiguousRestrictₗ}
     \leanok
     On the periodic chain, a cyclic window starting at $i$ reads the sites
     $i,i+1,\ldots,i+L-1$ modulo $N$.  Deleting the final site of a cyclic
     $(L+1)$-window reads the value at cyclic offset $L$ in the outside
-    configuration and gives the $L$-window starting at the same site.  When this
-    window does not wrap around the ring, the cyclic construction agrees with the
-    contiguous one, and so do the two restriction maps.
+    configuration and gives the $L$-window starting at the same site. Deleting
+    the first site, in the non-repeating case $L+1\le N$, reads the value at
+    cyclic offset $0$ in the outside configuration and gives the $L$-window
+    starting one site later. When this window does not wrap around the ring, the
+    cyclic construction agrees with the contiguous one, and so do the two
+    restriction maps.
 \end{remark}
 
 \begin{lemma}[Iterated contiguous-window intersection]\label{lem:contiguous_mem_ground_space}


### PR DESCRIPTION
### Motivation

- The parent-Hamiltonian uniqueness proof requires a cyclic-window transport identity for first-site deletion, symmetrical to the existing last-site deletion result. Without it, the boundary-closing step toward `wrapped_mirror_witness_agree_of_chainGroundSpace` cannot proceed.
- Contributes toward discharging the `sorry` at `UniqueGroundState.lean:810` (see #1475, which follows arXiv:2011.12127, Section IV.C).

### Description

- `TNLean/MPS/ParentHamiltonian/CyclicWindow.lean` (+74 lines): adds `MPSTensor.cyclicRestrictₗ_restrictFirst`. For an MPS tensor `A` with parameters `(N, L)` satisfying `L + 1 ≤ N`, peeling the first site of a cyclic window of length `L + 1` starting at site `i` yields the cyclic restriction of length `L` starting at `cyclicForwardSite i 1`, with cyclic offset `0` recorded in the boundary configuration. This is the first-site analogue of `cyclicRestrictₗ_restrictLast`.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex` (+7, −3 lines): updates the Chapter 14 cyclic-window operators remark to document first-site deletion and links the new lemma.
- Known existing `sorry`: `UniqueGroundState.lean:810` (present before this change; unrelated to this PR).

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `lake exe lint_style TNLean/MPS/ParentHamiltonian/CyclicWindow.lean`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/CyclicWindow.lean blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- Lean CI (`lean_action_ci.yml`) validates the full build on merge.

---
Addresses #1475

> [!NOTE]
> **Low Risk**
> Proof-only additions to CyclicWindow.lean and blueprint sync; no production code paths or security-sensitive logic.
>
> **Overview**
> Adds **`cyclicRestrictₗ_restrictFirst`**, the cyclic-window companion to the existing **`cyclicRestrictₗ_restrictLast`** transport lemma: peeling the first site of a length-`(L+1)` window records cyclic offset `0` in the outside config and restricts to the length-`L` window starting at **`cyclicForwardSite i 1`**, under **`L + 1 ≤ N`** so the window does not wrap twice.
>
> The Lean proof is a large pointwise case split on **`cyclicCfg`** (offset zero vs positive, with **`Fin.cons_succ`** indexing). Chapter 14's cyclic-window remark is updated to document first-site deletion and links the new theorem in the blueprint.
>
> No runtime or API behavior changes—formal proof tooling only, aimed at later boundary-closing transport (e.g. #1475).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb5b5c3e54c08312d27766baf133c402d056315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>