### PR TITLE
feat(MPS/ParentHamiltonian): add cyclic boundary overlap helpers

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -177,6 +177,7 @@ import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
+import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.WrappingWindow

--- a/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BlockStrip
+import TNLean.MPS.ParentHamiltonian.CyclicWindow
+import TNLean.MPS.ParentHamiltonian.SuffixWindow
+
+/-!
+# Boundary overlaps for cyclic parent-Hamiltonian windows
+
+This file records the elementary boundary-matrix identities obtained by deleting
+one endpoint from a cyclic window.  The identities are used in the closing
+boundary comparison for normal parent-Hamiltonian uniqueness.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- If a non-repeating cyclic `(L + 1)`-window is represented by the boundary
+matrix `Y`, then fixing its first site to `j` represents the shifted length-`L`
+window by the boundary matrix `Y * A j`. -/
+theorem cyclicRestrictₗ_restrictFirst_groundSpaceMap {A : MPSTensor d D}
+    {N L : ℕ} (hN : 0 < N) (hLN : L + 1 ≤ N)
+    (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N)
+    {Y : Matrix (Fin D) (Fin D) ℂ}
+    (hY : cyclicRestrictₗ hN (L + 1) i τ ψ = groundSpaceMap A (L + 1) Y)
+    (j : Fin d) :
+    cyclicRestrictₗ hN L (cyclicForwardSite i 1)
+        (fun k => if (k.val + N - i.val) % N = 0 then j else τ k) ψ =
+      groundSpaceMap A L (Y * A j) := by
+  rw [← cyclicRestrictₗ_restrictFirst hN hLN i τ ψ j, hY,
+    restrictFirst_groundSpaceMap]
+
+/-- If a cyclic `(L + 1)`-window is represented by the boundary matrix `Y`, then
+fixing its last site to `j` represents the initial length-`L` window by the
+boundary matrix `A j * Y`. -/
+theorem cyclicRestrictₗ_restrictLast_groundSpaceMap {A : MPSTensor d D}
+    {N L : ℕ} (hN : 0 < N)
+    (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N)
+    {Y : Matrix (Fin D) (Fin D) ℂ}
+    (hY : cyclicRestrictₗ hN (L + 1) i τ ψ = groundSpaceMap A (L + 1) Y)
+    (j : Fin d) :
+    cyclicRestrictₗ hN L i
+        (fun k => if (k.val + N - i.val) % N = L then j else τ k) ψ =
+      groundSpaceMap A L (A j * Y) := by
+  rw [← cyclicRestrictₗ_restrictLast hN i τ ψ j, hY, restrictLast_groundSpaceMap]
+
+/-- Adjacent cyclic windows have compatible boundary matrices on their common
+length-`L` overlap.
+
+The hypothesis `hτ` says that, after the first window is restricted at its first
+site and the second window is restricted at its last site, the two outside
+configurations give the same restricted vector on the common overlap. -/
+theorem adjacent_cyclicRestrictₗ_witness_overlap
+    {A : MPSTensor d D} {N L : ℕ}
+    (hInj : IsNBlkInjective A L) (hN : 0 < N) (hLN : L + 1 ≤ N)
+    (i : Fin N) (τ₁ τ₂ : Fin N → Fin d) (ψ : NSiteSpace d N)
+    {Y₁ Y₂ : Matrix (Fin D) (Fin D) ℂ}
+    (hY₁ : cyclicRestrictₗ hN (L + 1) i τ₁ ψ = groundSpaceMap A (L + 1) Y₁)
+    (hY₂ : cyclicRestrictₗ hN (L + 1) (cyclicForwardSite i 1) τ₂ ψ =
+      groundSpaceMap A (L + 1) Y₂)
+    (a b : Fin d)
+    (hτ :
+      (fun k => if (k.val + N - i.val) % N = 0 then a else τ₁ k) =
+        (fun k => if (k.val + N - (cyclicForwardSite i 1).val) % N = L then b
+          else τ₂ k)) :
+    Y₁ * A a = A b * Y₂ := by
+  apply groundSpaceMap_injective_of_isNBlkInjective hInj
+  have hFirst :=
+    cyclicRestrictₗ_restrictFirst_groundSpaceMap
+      (A := A) hN hLN i τ₁ ψ hY₁ a
+  have hLast :=
+    cyclicRestrictₗ_restrictLast_groundSpaceMap
+      (A := A) hN (cyclicForwardSite i 1) τ₂ ψ hY₂ b
+  exact hFirst.symm.trans (by rw [hτ]; exact hLast)
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
@@ -74,6 +74,22 @@ produces the expected boundary matrix `A j * X`. -/
   rw [evalWord_ofFn_snoc]
   simp [Matrix.mul_assoc]
 
+/-- Restricting a ground-space vector of length `L + 1` by fixing the first site
+produces the expected boundary matrix `X * A i`. -/
+@[simp] theorem restrictFirst_groundSpaceMap (A : MPSTensor d D) {L : ℕ}
+    (i : Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
+    restrictFirst (groundSpaceMap A (L + 1) X) i = groundSpaceMap A L (X * A i) := by
+  ext σ
+  simp only [restrictFirst_apply, groundSpaceMap_apply, evalWord_ofFn_cons]
+  calc
+    Matrix.trace ((A i * evalWord A (List.ofFn σ)) * X)
+        = Matrix.trace (X * (A i * evalWord A (List.ofFn σ))) := by
+            rw [Matrix.trace_mul_comm]
+    _ = Matrix.trace ((X * A i) * evalWord A (List.ofFn σ)) := by
+          rw [Matrix.mul_assoc]
+    _ = Matrix.trace (evalWord A (List.ofFn σ) * (X * A i)) := by
+          rw [Matrix.trace_mul_comm]
+
 /-- If the length-`L` word span is all of `M_D`, then `groundSpaceMap A L` is
 injective. -/
 theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Basic
+import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
@@ -179,6 +180,27 @@ theorem mpv_mem_chainGroundSpace (A : MPSTensor d D) (L N : ℕ)
   intro i τ
   simpa [cyclicRestrictₗ_apply, cyclicCfg, replaceWindow] using
     mpv_window_mem_groundSpace A L N hLN i τ
+
+/-- Every constrained cyclic window of a chain-ground-space vector has a boundary
+matrix representation in the local MPS ground space. -/
+theorem chainGroundSpace_window_witnesses (A : MPSTensor d D)
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    {ψ : NSiteSpace d N} (hψ : ψ ∈ chainGroundSpace A L N) :
+    ∃ YAt : (i : Fin N) → (Fin N → Fin d) → Matrix (Fin D) (Fin D) ℂ,
+      ∀ (i : Fin N) (τ : Fin N → Fin d),
+        cyclicRestrictₗ hN L i τ ψ = groundSpaceMap A L (YAt i τ) := by
+  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
+  have hLocal : ∀ (i : Fin N) (τ : Fin N → Fin d),
+      ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+        cyclicRestrictₗ hN L i τ ψ = groundSpaceMap A L Y := by
+    intro i τ
+    have hmem := hψ i τ
+    rw [groundSpace, LinearMap.mem_range] at hmem
+    obtain ⟨Y, hY⟩ := hmem
+    exact ⟨Y, hY.symm⟩
+  choose YAt hYAt using hLocal
+  exact ⟨YAt, hYAt⟩
 
 /-- Peeling the last site of every cyclic window shows that a larger interaction
 range imposes at least the constraints of the preceding range. -/

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -585,6 +585,35 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     restriction maps.
 \end{remark}
 
+\begin{lemma}[Cyclic-window boundary-matrix transport]
+    \label{lem:cyclic_window_boundary_matrix_transport}
+    \lean{MPSTensor.cyclicRestrictₗ_restrictFirst_groundSpaceMap}
+    \lean{MPSTensor.cyclicRestrictₗ_restrictLast_groundSpaceMap}
+    \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_overlap}
+    \leanok
+    \uses{rem:cyclic_window_operators, def:ground_space_parent, def:l_blk_injective}
+    Suppose a cyclic $(L+1)$-window is represented by a boundary matrix $Y$.
+    Fixing its last site to the letter $b$ gives the initial length-$L$ window
+    represented by $A^bY$. In the non-repeating regime $L+1\le N$, fixing the
+    first site to the letter $a$ gives the shifted length-$L$ window represented
+    by $Y A^a$. Consequently, for two adjacent cyclic $(L+1)$-windows in this
+    regime, if the two completed outside assignments obtained after these
+    one-site restrictions are identical as assignments on the $N$-site chain,
+    then $L$-block injectivity gives
+    \[
+        Y_1 A^a = A^b Y_2.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The first two identities are the cyclic first- and last-site deletion
+    identities, followed by the corresponding ground-space restriction formulas.
+    For adjacent windows, equality of the completed outside assignments makes
+    the two restricted states on the common overlap equal. Injectivity of the
+    length-$L$ ground-space map then identifies their boundary matrices.
+\end{proof}
+
 \begin{lemma}[Iterated contiguous-window intersection]\label{lem:contiguous_mem_ground_space}
     \lean{MPSTensor.contiguous_mem_groundSpace}
     \leanok
@@ -623,18 +652,22 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{lemma}[Ground-space suffix restriction]\label{lem:ground_space_in_tail_ground}
     \lean{MPSTensor.restrictLast_groundSpaceMap,
+        MPSTensor.restrictFirst_groundSpaceMap,
         MPSTensor.tailRestrictₗ_groundSpaceMap,
         MPSTensor.groundSpace_inTailGround}
     \leanok
     \uses{def:in_tail_ground, def:ground_space_parent}
     If $\psi \in G_{K+L}(A)$, then every fixed-prefix suffix restriction of
-    $\psi$ lies in $G_L(A)$.
+    $\psi$ lies in $G_L(A)$. For a vector in $G_{L+1}(A)$, fixing either
+    endpoint gives the expected left or right multiplication of its boundary
+    matrix.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    Write $\psi(\rho) = \tr(A^\rho X)$ for a boundary matrix $X$. Fixing a
-    prefix $u$ gives
+    Write $\psi(\rho) = \tr(A^\rho X)$ for a boundary matrix $X$. Fixing the
+    final site gives the boundary matrix $A^jX$, while fixing the first site
+    gives $XA^i$ by cyclicity of the trace. Fixing a prefix $u$ gives
     \[
         \psi(u,\sigma) = \tr(A^u A^\sigma X) = \tr(A^\sigma X A^u),
     \]
@@ -1029,6 +1062,23 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     to that window lies in $G_L(A)$.
     When $N = 0$ or $L > N$, set $\mathcal{G}_{N,L}(A) := \top$ by convention.
 \end{definition}
+
+\begin{lemma}[Cyclic-window witnesses inside the chain ground space]
+    \label{lem:chain_ground_space_window_witnesses}
+    \lean{MPSTensor.chainGroundSpace_window_witnesses}
+    \leanok
+    \uses{def:chain_ground_space, def:ground_space_parent}
+    If $0<N$, $L\le N$, and $\psi\in\mathcal G_{N,L}(A)$, then for every
+    cyclic window and every outside assignment there is a boundary matrix $Y$
+    such that the corresponding restricted $L$-site state is $\Gamma_L(Y)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is the defining cyclic-window condition for membership in
+    $\mathcal G_{N,L}(A)$, together with the definition of the local ground
+    space as the range of $\Gamma_L$.
+\end{proof}
 
 \begin{lemma}[The MPV satisfies every cyclic window constraint]
     \label{lem:mpv_mem_chain_ground_space}


### PR DESCRIPTION
## Summary
- Add `restrictFirst_groundSpaceMap`, the first-site analogue of the existing last-site ground-space restriction formula.
- Add `TNLean.MPS.ParentHamiltonian.BoundaryOverlap` with cyclic first/last boundary-matrix transport lemmas and an adjacent cyclic-window overlap identity.
- Add `chainGroundSpace_window_witnesses` and record the new local tools in the blueprint.

This is a helper step toward the remaining boundary-closing comparison in #1475; it does not close `wrapped_mirror_witness_agree_of_chainGroundSpace`.

## Verification
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryOverlap`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `lake build TNLean`
- `lake exe lint_style TNLean/MPS/ParentHamiltonian/SuffixWindow.lean TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files TNLean.lean TNLean/MPS/ParentHamiltonian/SuffixWindow.lean TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- `PATH="/Users/siruilu/Library/Python/3.9/bin:$PATH" leanblueprint web`
- `git diff --check`

No new proof-integrity placeholder is added; the remaining `sorry` is the pre-existing open theorem in `UniqueGroundState.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib additions and blueprint documentation; no changes to auth, runtime, or the existing sorry in the uniqueness capstone.
> 
> **Overview**
> Adds **cyclic boundary-matrix transport** lemmas for parent-Hamiltonian uniqueness: first-site ground-space restriction (`restrictFirst_groundSpaceMap`), a new `BoundaryOverlap` module (first/last deletion on cyclic `(L+1)` windows and adjacent-window overlap `Y₁ A^a = A^b Y₂`), and `chainGroundSpace_window_witnesses` to package boundary matrices for every cyclic window of a chain ground state.
> 
> Wires `BoundaryOverlap` into the root import list and `UniqueGroundState`, and documents the lemmas in the blueprint (ch14). This is scaffolding toward the open `wrapped_mirror_witness_agree_of_chainGroundSpace` comparison; it does not close that `sorry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 551dd1674962de5f10b7d7c5eda180ff32a7859f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->