### PR TITLE
doc(bnt): record MPV dependency for CPSV BNT

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -31,7 +31,7 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 \begin{definition}[Basis of normal tensors, coefficient form]\label{def:bnt_cpsv}
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors}
     \leanok
-    \uses{def:nt_cpsv}
+    \uses{def:nt_cpsv, def:mpv}
     % Source: Cirac2017MPDO_AnnPhys \S~II.C, lines 271--274.
     The coefficient form of a basis of normal tensors: each block $A_j$ is a
     CPSV normal tensor (Definition~\ref{def:nt_cpsv}), the MPV of $A$ is given at


### PR DESCRIPTION
### Motivation

- The `\uses` annotation on `def:bnt_cpsv` in `blueprint/src/chapter/ch10_bnt.tex` did not list `def:mpv`, leaving the blueprint dependency record incomplete for `MPSTensor.IsCPSVBasisOfNormalTensors` (arXiv:1606.00608, §II.C, lines 271–274; see #2273).
- Follows up on #2269 (*blueprint(ch:bnt): rewrite the Basis of Normal Tensors chapter to the house style*), which rewrote the definition prose; the `\uses` list was not updated to include the MPV definition.

### Description

- `blueprint/src/chapter/ch10_bnt.tex`: adds `def:mpv` to the `\uses` list of `def:bnt_cpsv`, so that the blueprint records the CPSV basis-of-normal-tensors definition as depending on both `def:nt_cpsv` (CPSV normality notion) and `def:mpv` (matrix product vector definition).

### Testing

- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch10_bnt.tex`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch10_bnt.tex`
- `git diff --check`
- `lake build TNLean`
- `leanblueprint web`
- `lake exe checkdecls blueprint/lean_decls`: no missing declarations in `ch10_bnt.tex`; repository-wide pre-existing warnings are unaffected.

---
Closes #2273

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint dependency fix with no code or proof logic changes.
>
> **Overview**
> Updates the blueprint dependency metadata on **`def:bnt_cpsv`** (`MPSTensor.IsCPSVBasisOfNormalTensors`) so `\uses` lists **`def:nt_cpsv`** and **`def:mpv`**, matching the definition prose (CPSV blocks plus MPV span/coefficient wording). No change to the mathematical statement or Lean proof content—only the missing **`def:mpv`** annotation for blueprint/Lean sync.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79baa6325871925d13066413b2cd8586db55bfe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->