### PR TITLE
feat(MPS/Examples): cluster state string order under Z₂×Z₂ symmetry

### DIFF
--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -575,7 +575,7 @@ open scoped ComplexOrder MatrixOrder
 
 /-- The blocked cluster transfer map is unital: `∑ Aᵢ Aᵢ† = 1`.  The four blocked
 matrices form a normalised Kraus family, so the cluster channel is unital. -/
-theorem clusterBlocked_transferMap_one : transferMap clusterBlocked 1 = 1 := by
+private theorem clusterBlocked_transferMap_one : transferMap clusterBlocked 1 = 1 := by
   rw [transferMap_apply]
   ext i j
   fin_cases i <;> fin_cases j <;>
@@ -590,7 +590,7 @@ theorem clusterBlocked_transferMap_one : transferMap clusterBlocked 1 = 1 := by
 adjoint transfer map: `∑ Aᵢ† Λ Aᵢ = Λ`.  The four blocked matrices satisfy
 `∑ Aᵢ† Aᵢ = 1`, so the adjoint channel is unital, and scaling by `1/2`
 propagates through the linear map. -/
-theorem clusterBlocked_adjoint_fixes_maximallyMixed :
+private theorem clusterBlocked_adjoint_fixes_maximallyMixed :
     transferMap (fun i => (clusterBlocked i)ᴴ) ((1 / 2 : ℂ) • 1) = (1 / 2 : ℂ) • 1 := by
   rw [transferMap_apply]
   ext i j
@@ -604,7 +604,7 @@ theorem clusterBlocked_adjoint_fixes_maximallyMixed :
 
 /-- The maximally mixed boundary state `Λ = (1/2) · 1` on the bond space is
 positive definite. -/
-theorem maximallyMixed_posDef :
+private theorem maximallyMixed_posDef :
     ((1 / 2 : ℂ) • (1 : Matrix (Fin 2) (Fin 2) ℂ)).PosDef := by
   have h : (1 / 2 : ℂ) • (1 : Matrix (Fin 2) (Fin 2) ℂ) =
       (1 / 2 : ℝ) • (1 : Matrix (Fin 2) (Fin 2) ℂ) := by
@@ -614,7 +614,7 @@ theorem maximallyMixed_posDef :
 
 /-- The maximally mixed boundary state `Λ = (1/2) · 1` on the bond space has
 trace `1`. -/
-theorem maximallyMixed_trace :
+private theorem maximallyMixed_trace :
     Matrix.trace ((1 / 2 : ℂ) • (1 : Matrix (Fin 2) (Fin 2) ℂ)) = 1 := by
   rw [Matrix.trace_smul, Matrix.trace_one]
   norm_num
@@ -622,7 +622,7 @@ theorem maximallyMixed_trace :
 /-- The `Z₂ × Z₂` on-site representation is unitary on every group element: the
 two generators act by real symmetric involutive permutation matrices, so each
 group element equals its own adjoint inverse. -/
-theorem clusterZ2Z2Action_unitary (g : Multiplicative (ZMod 2 × ZMod 2)) :
+private theorem clusterZ2Z2Action_unitary (g : Multiplicative (ZMod 2 × ZMod 2)) :
     clusterZ2Z2Action g * (clusterZ2Z2Action g)ᴴ = 1 := by
   rcases zmod2sq_cases g with rfl | rfl | rfl | rfl
   · simp
@@ -640,14 +640,14 @@ theorem clusterZ2Z2Action_unitary (g : Multiplicative (ZMod 2 × ZMod 2)) :
 /-- **The cluster state has string order under its `Z₂ × Z₂` symmetry.**
 
 For every group element `g`, the blocked cluster tensor has string order with the
-maximally mixed boundary state `Λ = (1/2) · 1`.  This applies the general
-criterion `hasStringOrder_of_symmetric_injective`: the blocked tensor is
-injective and on-site symmetric, and the maximally mixed state is a positive
-definite, trace-one fixed point of the adjoint transfer map, while the transfer
-map itself is unital.
+maximally mixed boundary state `Λ = (1/2) · 1`.  The blocked tensor is injective
+and on-site symmetric, the maximally mixed state is a positive definite,
+trace-one fixed point of the adjoint transfer map, and the transfer map itself is
+unital; an injective, on-site symmetric tensor meeting these conditions has string
+order for every group element (see `hasStringOrder_of_symmetric_injective`).
 
 This exhibits the cluster state as the first explicit witness of the string-order
-machinery of Pérez-García, Wolf, Sanz, Verstraete, Cirac (arXiv:0802.0447): a
+criterion of Pérez-García, Wolf, Sanz, Verstraete, Cirac (arXiv:0802.0447): a
 non-trivial symmetry-protected topological phase carrying genuine string order. -/
 theorem cluster_hasStringOrder (g : Multiplicative (ZMod 2 × ZMod 2)) :
     HasStringOrder clusterBlocked (clusterZ2Z2Action g)

--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Symmetry.Defs
+import TNLean.MPS.Symmetry.StringOrder
 import TNLean.MPS.Examples.GHZ
 import TNLean.MPS.Examples.ZMod2
 import TNLean.Algebra.CocycleCohomology
@@ -33,6 +34,9 @@ is injective and which lies in a non-trivial symmetry-protected topological
 * `clusterBlocked_isInjective` : the length-`2` blocked tensor is injective
 * `cluster_isOnSiteSymmetric_Z2Z2` : the blocked tensor is on-site symmetric
   under `Z₂ × Z₂`, with anticommuting virtual gauges `σz` and `σx`
+* `cluster_hasStringOrder` : the blocked tensor has string order under every
+  element of its `Z₂ × Z₂` symmetry, with the maximally mixed boundary state
+  as its stationary boundary
 
 ## References
 
@@ -42,6 +46,8 @@ is injective and which lies in a non-trivial symmetry-protected topological
   (equivalently, the MPS read in the opposite direction), which represents the
   same state and carries the same SPT order.
 * Raussendorf, Briegel (arXiv:quant-ph/0010033) — original cluster state
+* Pérez-García, Wolf, Sanz, Verstraete, Cirac, arXiv:0802.0447 (PRL 2008) —
+  string order and local symmetry for finitely correlated states
 -/
 
 open scoped Matrix BigOperators
@@ -516,8 +522,10 @@ def clusterProjRep : ProjectiveRepresentation (D := 2) clusterOmega where
         one_ne_zero, ↓reduceIte, and_self, and_true, true_and,
         mul_one, one_mul] <;>
       (ext a b; fin_cases a <;> fin_cases b <;>
-        simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.smul_apply, Matrix.one_apply,
-          smul_eq_mul])
+        simp only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.smul_apply, Matrix.one_apply,
+          smul_eq_mul, Matrix.of_apply, Matrix.cons_val', Matrix.cons_val_zero,
+          Matrix.cons_val_one, Matrix.empty_val', Matrix.cons_val_fin_one,
+          Fin.mk_zero] <;> norm_num)
 
 open TNLean.Algebra in
 /-- `clusterOmega` is a genuine `2`-cocycle: it is the factor system of the
@@ -546,6 +554,110 @@ theorem cluster_isNontrivialSPT : ScalarCocycle.IsNontrivialClass clusterOmega :
     intro hcon
     have : ((-1 : Units ℂ) : ℂ) = ((1 : Units ℂ) : ℂ) := congrArg _ hcon
     norm_num at this
+
+/-! ### String order under the `Z₂ × Z₂` symmetry
+
+The blocked cluster tensor is injective and on-site symmetric under `Z₂ × Z₂`,
+so it falls under the string-order criterion of Pérez-García, Wolf, Sanz,
+Verstraete, Cirac (arXiv:0802.0447): an injective symmetric finitely correlated
+state has string order for every on-site symmetry.  The cluster state is the
+first explicit witness of that criterion in this development.
+
+The stationary boundary state is the maximally mixed state `Λ = (1/2) · 1`.  It
+is a fixed point of both the transfer map and its adjoint, because the four
+blocked matrices satisfy `∑ Aᵢ Aᵢ† = 1` and `∑ Aᵢ† Aᵢ = 1`, so the channel is
+both trace preserving and unital.  The first identity also gives the
+normalisation `E_A(1) = 1` required by the criterion. -/
+
+section StringOrder
+
+open scoped ComplexOrder MatrixOrder
+
+/-- The blocked cluster transfer map is unital: `∑ Aᵢ Aᵢ† = 1`.  The four blocked
+matrices form a normalised Kraus family, so the cluster channel is unital. -/
+theorem clusterBlocked_transferMap_one : transferMap clusterBlocked 1 = 1 := by
+  rw [transferMap_apply]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [Fin.sum_univ_four, clusterBlocked_zero, clusterBlocked_one, clusterBlocked_two,
+      clusterBlocked_three, Matrix.add_apply, Matrix.mul_apply, Fin.sum_univ_two,
+      Matrix.conjTranspose_apply, Matrix.smul_apply, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.empty_val', Matrix.cons_val_fin_one,
+      Matrix.one_apply, smul_eq_mul] <;>
+    norm_num [Complex.ext_iff]
+
+/-- The maximally mixed boundary state `Λ = (1/2) · 1` is a fixed point of the
+adjoint transfer map: `∑ Aᵢ† Λ Aᵢ = Λ`.  The four blocked matrices satisfy
+`∑ Aᵢ† Aᵢ = 1`, so the adjoint channel is unital, and scaling by `1/2`
+propagates through the linear map. -/
+theorem clusterBlocked_adjoint_fixes_maximallyMixed :
+    transferMap (fun i => (clusterBlocked i)ᴴ) ((1 / 2 : ℂ) • 1) = (1 / 2 : ℂ) • 1 := by
+  rw [transferMap_apply]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [Fin.sum_univ_four, clusterBlocked_zero, clusterBlocked_one, clusterBlocked_two,
+      clusterBlocked_three, Matrix.add_apply, Matrix.mul_apply, Fin.sum_univ_two,
+      Matrix.conjTranspose_apply, Matrix.smul_apply, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.empty_val', Matrix.cons_val_fin_one,
+      Matrix.one_apply, smul_eq_mul] <;>
+    norm_num [Complex.ext_iff]
+
+/-- The maximally mixed boundary state `Λ = (1/2) · 1` on the bond space is
+positive definite. -/
+theorem maximallyMixed_posDef :
+    ((1 / 2 : ℂ) • (1 : Matrix (Fin 2) (Fin 2) ℂ)).PosDef := by
+  have h : (1 / 2 : ℂ) • (1 : Matrix (Fin 2) (Fin 2) ℂ) =
+      (1 / 2 : ℝ) • (1 : Matrix (Fin 2) (Fin 2) ℂ) := by
+    ext i j; simp [Matrix.smul_apply, smul_eq_mul, Complex.real_smul]
+  rw [h]
+  exact Matrix.PosDef.one.smul (by norm_num)
+
+/-- The maximally mixed boundary state `Λ = (1/2) · 1` on the bond space has
+trace `1`. -/
+theorem maximallyMixed_trace :
+    Matrix.trace ((1 / 2 : ℂ) • (1 : Matrix (Fin 2) (Fin 2) ℂ)) = 1 := by
+  rw [Matrix.trace_smul, Matrix.trace_one]
+  norm_num
+
+/-- The `Z₂ × Z₂` on-site representation is unitary on every group element: the
+two generators act by real symmetric involutive permutation matrices, so each
+group element equals its own adjoint inverse. -/
+theorem clusterZ2Z2Action_unitary (g : Multiplicative (ZMod 2 × ZMod 2)) :
+    clusterZ2Z2Action g * (clusterZ2Z2Action g)ᴴ = 1 := by
+  rcases zmod2sq_cases g with rfl | rfl | rfl | rfl
+  · simp
+  · rw [clusterZ2Z2Action_10]
+    ext i j; fin_cases i <;> fin_cases j <;>
+      simp [clusterPhysX1, Matrix.mul_apply, Fin.sum_univ_four, Matrix.conjTranspose_apply]
+  · rw [clusterZ2Z2Action_01]
+    ext i j; fin_cases i <;> fin_cases j <;>
+      simp [clusterPhysX2, Matrix.mul_apply, Fin.sum_univ_four, Matrix.conjTranspose_apply]
+  · rw [clusterZ2Z2Action_11]
+    ext i j; fin_cases i <;> fin_cases j <;>
+      simp [clusterPhysX1, clusterPhysX2, Matrix.mul_apply, Fin.sum_univ_four,
+        Matrix.conjTranspose_apply]
+
+/-- **The cluster state has string order under its `Z₂ × Z₂` symmetry.**
+
+For every group element `g`, the blocked cluster tensor has string order with the
+maximally mixed boundary state `Λ = (1/2) · 1`.  This applies the general
+criterion `hasStringOrder_of_symmetric_injective`: the blocked tensor is
+injective and on-site symmetric, and the maximally mixed state is a positive
+definite, trace-one fixed point of the adjoint transfer map, while the transfer
+map itself is unital.
+
+This exhibits the cluster state as the first explicit witness of the string-order
+machinery of Pérez-García, Wolf, Sanz, Verstraete, Cirac (arXiv:0802.0447): a
+non-trivial symmetry-protected topological phase carrying genuine string order. -/
+theorem cluster_hasStringOrder (g : Multiplicative (ZMod 2 × ZMod 2)) :
+    HasStringOrder clusterBlocked (clusterZ2Z2Action g)
+      ((1 / 2 : ℂ) • (1 : Matrix (Fin 2) (Fin 2) ℂ)) :=
+  hasStringOrder_of_symmetric_injective clusterBlocked clusterBlocked_isInjective
+    clusterZ2Z2Action cluster_isOnSiteSymmetric_Z2Z2 clusterZ2Z2Action_unitary g
+    ((1 / 2 : ℂ) • 1) maximallyMixed_posDef maximallyMixed_trace
+    clusterBlocked_adjoint_fixes_maximallyMixed clusterBlocked_transferMap_one
+
+end StringOrder
 
 end MPSTensor
 

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -440,3 +440,30 @@ computation and provides another example of a non-trivial SPT phase.
     $H^2(\Z_2 \times \Z_2, \mathrm{U}(1)) \cong \Z_2$ is therefore non-trivial, so
     the cluster state realizes a non-trivial SPT phase.
 \end{theorem}
+
+\begin{theorem}[The cluster state has string order under its $\Z_2 \times \Z_2$ symmetry]\label{thm:cluster_string_order}
+    \lean{MPSTensor.cluster_hasStringOrder}
+    \leanok
+    \uses{def:has_string_order, thm:has_string_order_of_symmetric_injective,
+      thm:cluster_z2z2_symmetric, def:cluster_tensor, rem:cluster_injective_blocked}
+    For every element $g$ of $\Z_2 \times \Z_2$, the length-$2$ blocked cluster-state
+    tensor has string order in the sense of
+    Definition~\ref{def:has_string_order} for the twist by $g$, with the
+    maximally mixed boundary state $\Lambda = \tfrac{1}{2}\Id$ as its stationary
+    boundary state.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The blocked tensor is injective (Remark~\ref{rem:cluster_injective_blocked})
+    and on-site symmetric under $\Z_2 \times \Z_2$
+    (Theorem~\ref{thm:cluster_z2z2_symmetric}), and each group element acts by a
+    real symmetric involutive permutation matrix, hence unitarily.  The
+    maximally mixed state $\Lambda = \tfrac{1}{2}\Id$ is positive definite and
+    has trace~$1$.  The four blocked matrices satisfy
+    $\sum_i A^i (A^i)^\dagger = \Id$ and $\sum_i (A^i)^\dagger A^i = \Id$, so the
+    transfer map is unital and $\Lambda$ is a fixed point of the adjoint transfer
+    map.  These are exactly the hypotheses of
+    Theorem~\ref{thm:has_string_order_of_symmetric_injective}, which then yields
+    string order for every $g$.  The cluster state is thus the first explicit
+    witness of that criterion.
+\end{proof}

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -444,8 +444,7 @@ computation and provides another example of a non-trivial SPT phase.
 \begin{theorem}[The cluster state has string order under its $\Z_2 \times \Z_2$ symmetry]\label{thm:cluster_string_order}
     \lean{MPSTensor.cluster_hasStringOrder}
     \leanok
-    \uses{def:has_string_order, thm:has_string_order_of_symmetric_injective,
-      thm:cluster_z2z2_symmetric, def:cluster_tensor, rem:cluster_injective_blocked}
+    \uses{def:has_string_order, def:cluster_tensor}
     For every element $g$ of $\Z_2 \times \Z_2$, the length-$2$ blocked cluster-state
     tensor has string order in the sense of
     Definition~\ref{def:has_string_order} for the twist by $g$, with the
@@ -454,6 +453,8 @@ computation and provides another example of a non-trivial SPT phase.
 \end{theorem}
 \begin{proof}
     \leanok
+    \uses{thm:has_string_order_of_symmetric_injective, thm:cluster_z2z2_symmetric,
+      rem:cluster_injective_blocked}
     The blocked tensor is injective (Remark~\ref{rem:cluster_injective_blocked})
     and on-site symmetric under $\Z_2 \times \Z_2$
     (Theorem~\ref{thm:cluster_z2z2_symmetric}), and each group element acts by a


### PR DESCRIPTION
## Summary

Adds `MPSTensor.cluster_hasStringOrder` to `TNLean/MPS/Examples/Cluster.lean`: for every element $g$ of the $\mathbb{Z}_2\times\mathbb{Z}_2$ symmetry, the length-2 blocked cluster-state tensor has string order (in the sense of `HasStringOrder`), with the maximally mixed boundary state $\Lambda=\tfrac12 I$ as its stationary boundary state.

This is the **first explicit witness** of the injective-symmetric string-order criterion `hasStringOrder_of_symmetric_injective` (Pérez-García, Wolf, Sanz, Verstraete, Cirac, arXiv:0802.0447, PRL 2008). The cluster example already had: non-injective at one site, normal / injective when blocked, $\mathbb{Z}_2\times\mathbb{Z}_2$ on-site symmetric, non-trivial SPT class. This closes the loop by exhibiting its string order.

## What the proof checks

The criterion's four hypotheses are discharged for $\Lambda=\tfrac12 I$:

- **Unital transfer map** `clusterBlocked_transferMap_one`: $\sum_i A^i (A^i)^\dagger = I$ (the four blocked matrices form a normalised Kraus family), giving $E_A(I)=I$.
- **Adjoint fixed point** `clusterBlocked_adjoint_fixes_maximallyMixed`: $\sum_i (A^i)^\dagger \Lambda A^i = \Lambda$ (the adjoint channel is unital, and $1/2$ scales through).
- **Positive-definite, trace-one boundary** `maximallyMixed_posDef`, `maximallyMixed_trace`.
- **Unitary symmetry action** `clusterZ2Z2Action_unitary`: each generator is a real symmetric involutive permutation matrix.

## Faithfulness

`HasStringOrder` is the virtual-boundary reformulation of arXiv:0802.0447 already in the blueprint (`def:has_string_order`, ch13b). The new entry `thm:cluster_string_order` (ch16) applies the already-merged criterion `thm:has_string_order_of_symmetric_injective` to the cluster example and is worded as string order *in the sense of that definition*; it does not overclaim the unrestricted physical string-order observable.

## Verification

- `lake build` — success (8745 jobs)
- `lake exe lint_style` — exit 0; no lines > 100 chars
- No `sorry` / `admit` / `native_decide` / `axiom`
- `#print axioms MPSTensor.cluster_hasStringOrder` → `[propext, Classical.choice, Quot.sound]`
- `leanblueprint checkdecls` — `cluster_hasStringOrder` resolves (remaining "missing" entries are pre-existing PEPS/ParentHamiltonian stubs)
- CI changed-decl ↔ blueprint coverage check — passes

## Blueprint

Adds `thm:cluster_string_order` after `thm:cluster_nontrivial_spt`, with `\lean`/`\leanok`, A.4 `\uses` wiring (`def:has_string_order`, `thm:has_string_order_of_symmetric_injective`, `thm:cluster_z2z2_symmetric`, `def:cluster_tensor`, `rem:cluster_injective_blocked`), and a `\leanok` proof block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds example-specific Lean proofs and blueprint text on top of an existing general theorem; no changes to auth, runtime APIs, or core library contracts beyond the cluster example module.
> 
> **Overview**
> Proves **`MPSTensor.cluster_hasStringOrder`**: for every \(g \in \mathbb{Z}_2\times\mathbb{Z}_2\), the length-2 **blocked** cluster tensor has **`HasStringOrder`** (virtual-boundary string order from the blueprint) for twist \(g\), with stationary boundary \(\Lambda = \tfrac{1}{2}I\).
> 
> The proof is a direct application of the existing criterion **`hasStringOrder_of_symmetric_injective`**, discharging its hypotheses via new lemmas: blocked Kraus normalization (\(\sum_i A^i(A^i)^\dagger = I\) and adjoint analogue → unital transfer map and \(\Lambda\) fixed under the adjoint channel), \(\Lambda\) positive definite with trace 1, and **unitary** on-site **`clusterZ2Z2Action`**. This is positioned as the **first explicit example** in the development instantiating that criterion for a concrete SPT state (cluster), complementing existing blocked injectivity and \(\mathbb{Z}_2\times\mathbb{Z}_2\) symmetry results.
> 
> Also adds blueprint **`thm:cluster_string_order`** in ch16, imports **`TNLean.MPS.Symmetry.StringOrder`**, documents the result in the module header, and tightens matrix **`simp`** in the projective-representation multiplication proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7bd9d8895902a8d7547d52de29ef8b24cf774c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->