### PR TITLE
doc(blueprint): align channel and Wielandt graph notes

### DIFF
--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -278,13 +278,14 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 
 \begin{proof}
     \leanok
-    \uses{thm:density_compact, thm:density_convex,
-        thm:density_nonempty, thm:channel_preserves_density,
-        thm:cesaro_telescope}
+    \uses{thm:density_compact, thm:density_nonempty,
+        thm:channel_preserves_density, thm:cesaro_telescope}
     Start with any $\rho_0 \in \mc{D}_D$
     (Theorem~\ref{thm:density_nonempty}).
     Each Ces\`aro mean $\sigma_N$ lies in $\mc{D}_D$
-    (by convexity and channel preservation).
+    by applying channel preservation to every iterate, adding positive
+    semidefinite matrices, rescaling by the positive average factor, and using
+    trace linearity.
     By compactness (Theorem~\ref{thm:density_compact}),
     extract a convergent subsequence
     $\sigma_{N_k} \to \rho$.

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -520,9 +520,11 @@ The results follow~\cite{Sanz2010Quantum}.
     The full-rank index bound $\iota(A) \le (D^2 - d + 1) \cdot D^2$
     (\cite[Theorem~1, case~(1)]{Sanz2010Quantum}) is proved in
     Theorem~\ref{thm:wielandt_general} below.
-    The sharp blocking-length estimates for injectivity ($D^4$)
-    and bi-canonical form ($3D^5$) from~\cite{Sanz2010Quantum}
-    are not proved here.
+    The left-canonical normal blocked-injectivity estimate $D^4$ is proved
+    below in
+    Theorem~\ref{thm:bounded_injective_blocking_normal_left_canonical}.
+    The sharper bi-canonical blocking estimate $3D^5$ from
+    \cite{Sanz2010Quantum} is not proved here.
 \end{remark}
 
 \begin{definition}[One-step augmentation]\label{def:one_step_augment}


### PR DESCRIPTION
### Motivation
- Two blueprint dependency-graph and prose mismatches in the channel and Wielandt chapters diverge from the actual Lean call graph; correcting them is part of the graph-hygiene audit in #2296.
- The `\uses{thm:density_convex}` edge on `thm:cesaro_fixedpoint` is spurious: `IsChannel.exists_posSemidef_fixedPoint` establishes Cesàro mean membership via PSD sums and trace linearity, never calling `densityMatrices_isConvex`.
- The blocking-length remark in the Wielandt chapter incorrectly states that both the $D^4$ and $3D^5$ estimates are absent; the $D^4$ left-canonical bound is proved in the same chapter.

### Description
- `blueprint/src/chapter/ch04_channels.tex`: removed `thm:density_convex` from the `\uses` list of `thm:cesaro_fixedpoint`. The proof that each Cesàro mean lies in $\mathcal{D}_D$ follows from channel preservation on iterates, positive semidefiniteness of finite sums, and trace linearity — not from convexity of $\mathcal{D}_D$.
- `blueprint/src/chapter/ch07_wielandt.tex`: updated the explicit blocking-length remark (ch07, lines 517–526) to record that the left-canonical normal $D^4$ blocked-injectivity bound is proved as `thm:bounded_injective_blocking_normal_left_canonical`; only the sharper bi-canonical $3D^5$ estimate from Sanz et al. remains absent.
- Remaining items from #2296 (`thm:tp_data_irreducible`, `thm:transfer_operator_gap_rect`, `thm:peripheral_cyclic_group`, `thm:fitting_decomp`) are left for separate focused PRs.

### Testing
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch04_channels.tex blueprint/src/chapter/ch07_wielandt.tex`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --diff-base origin/main --changed-files blueprint/src/chapter/ch04_channels.tex blueprint/src/chapter/ch07_wielandt.tex`
- `leanblueprint web`
- `git diff --check`

---
Addresses #2296

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits to proof dependencies and remarks; no runtime or formal proof code changes.
> 
> **Overview**
> Aligns two blueprint spots with the formalized Lean proofs and the chapter's actual coverage.
> 
> For **`thm:cesaro_fixedpoint`**, the proof's `\uses` list drops **`thm:density_convex`**; the text now explains Cesàro means stay in \(\mathcal{D}_D\) via channel preservation on iterates, PSD sums, positive averaging, and trace linearity—the route used by **`IsChannel.exists_posSemidef_fixedPoint`**.
> 
> In the Wielandt **explicit blocking-length** remark, the prose now states the left-canonical normal **\(D^4\)** blocked-injectivity bound is proved later as **`thm:bounded_injective_blocking_normal_left_canonical`**, and only the sharper bi-canonical **\(3D^5\)** estimate from Sanz et al. remains absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70bd3c06e01c3e9d572c0125646f543d0a904e41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->