### PR TITLE
doc(blueprint): fix TP gauge data dependency edge

### DIFF
--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -339,6 +339,44 @@ and~\cite{Evans1978Spectral}.
         = (S^\dagger)^{-1} S^\dagger S S^{-1} = \Id$.
 \end{proof}
 
+\begin{theorem}[Square-root trace-preserving gauge from an adjoint fixed point]%
+    \label{thm:tp_gauge_from_adjoint_fixed}
+    \lean{MPSTensor.tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint}
+    \leanok
+    \uses{def:transfer_map}
+    Let $\sigma$ be positive definite and satisfy
+    $\sum_i (A^i)^\dagger \sigma A^i = \sigma$.
+    Define
+    \[
+        B^i = \sigma^{1/2} A^i \sigma^{-1/2}.
+    \]
+    Then $B$ is trace-preserving:
+    $\sum_i (B^i)^\dagger B^i = \Id$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Since $\sigma^{1/2}$ is self-adjoint and
+    $\sigma^{1/2}\sigma^{1/2}=\sigma$, each summand becomes
+    $(\sigma^{1/2})^{-1}\,(A^i)^\dagger\sigma A^i\,\sigma^{-1/2}$.
+    Summing over $i$ and using the fixed-point equation leaves
+    $(\sigma^{1/2})^{-1}\sigma\sigma^{-1/2}=\Id$.
+\end{proof}
+
+\begin{lemma}[Square-root trace-preserving gauge is a gauge equivalence]%
+    \label{lem:tp_gauge_equiv}
+    \lean{MPSTensor.gaugeEquiv_tpGauge}
+    \leanok
+    \uses{def:gauge_equiv}
+    If $\sigma$ is positive definite and
+    $B^i=\sigma^{1/2}A^i\sigma^{-1/2}$, then $A$ and $B$ are
+    gauge-equivalent.
+\end{lemma}
+
+\begin{proof}\leanok
+    The gauge matrix is $\sigma^{1/2}$, which is invertible because
+    $\sigma$ is positive definite.
+\end{proof}
+
 \begin{remark}\leanok
     The right-canonical gauge of Theorem~\ref{thm:right_canonical_gauge}
     and the left-canonical gauge of Theorem~\ref{thm:left_canonical_gauge}
@@ -534,7 +572,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
     \label{thm:tp_data_irreducible}
     \lean{MPSTensor.exists_tp_data_of_irreducible}
     \leanok
-    \uses{def:irreducible_tensor}
+    \uses{def:irreducible_tensor, def:gauge_equiv}
     Let $A$ be an irreducible MPS tensor with $D > 0$
     and some $A^i \neq 0$.
     Then there exist a positive real~$r$, a positive definite
@@ -550,16 +588,18 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:posDef_adjoint_eigenvector, thm:left_canonical_gauge}
+    \uses{thm:posDef_adjoint_eigenvector, thm:tp_gauge_from_adjoint_fixed,
+        lem:tp_gauge_equiv}
     By Theorem~\ref{thm:posDef_adjoint_eigenvector},
     obtain $\sigma$ positive definite and $r > 0$ with
     $\E_A^\dagger(\sigma) = r \sigma$.
     Set $c = r^{-1/2}$ and $A'^i = c A^i$.
     Then $\E_{A'}^\dagger(\sigma) = \sigma$.
-    By the TP gauge construction
-    (Theorem~\ref{thm:left_canonical_gauge}),
+    By the square-root trace-preserving gauge construction
+    (Theorem~\ref{thm:tp_gauge_from_adjoint_fixed}),
     $B^i = \sigma^{1/2} A'^i \sigma^{-1/2}$
     satisfies $\sum_i (B^i)^\dagger B^i = \Id$.
+    Lemma~\ref{lem:tp_gauge_equiv} gives the required gauge equivalence.
 \end{proof}
 
 \begin{theorem}[Unital-gauge existence for irreducible tensors]%


### PR DESCRIPTION
### Motivation

- The blueprint proof of `thm:tp_data_irreducible` incorrectly cited `thm:left_canonical_gauge` as a dependency; the Lean proof `exists_tp_data_of_irreducible` calls `tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint` and `gaugeEquiv_tpGauge` instead. This mismatch is one of the loose ends tracked in #2296.
- The blueprint lacked entries for the square-root trace-preserving gauge and its gauge-equivalence statement, leaving the dependency graph incomplete.

### Description

- `blueprint/src/chapter/ch05_qpf.tex`: adds two new blueprint entries:
  - Theorem `thm:tp_gauge_from_adjoint_fixed` with `\lean{MPSTensor.tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint}` tag — the trace-preserving gauge $B^i = \sigma^{1/2} A^i \sigma^{-1/2}$ constructed from the adjoint transfer fixed point.
  - Lemma `lem:tp_gauge_equiv` with `\lean{MPSTensor.gaugeEquiv_tpGauge}` tag — gauge equivalence of the square-root TP gauge.
- Redirects the `\uses` list of `thm:tp_data_irreducible` from `thm:left_canonical_gauge` to the two new entries above.
- Adds `def:gauge_equiv` to `thm:tp_data_irreducible`'s `\uses` list so the gauge-equivalence claim is reflected in the blueprint dependency graph.

### Testing

- `lake build` completed successfully (8746 jobs); pre-existing sorry warnings are unrelated to this change.
- Blueprint sync report shows no new unresolved references introduced by this PR; the two pre-existing sync issues are in unrelated chapters.

---
Addresses #2296

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX/blueprint sync in ch05_qpf.tex; no runtime or proof logic changes in this diff.
>
> **Overview**
> The blueprint chapter **`ch05_qpf.tex`** now documents the **square-root TP gauge** and its **gauge equivalence** as first-class results, and wires the **irreducible TP-data** proof to the Lean lemmas it actually uses.
>
> **New material:** Theorem `thm:tp_gauge_from_adjoint_fixed` (trace-preserving \(B^i=\sigma^{1/2}A^i\sigma^{-1/2}\) from an adjoint transfer fixed point) and Lemma `lem:tp_gauge_equiv` (`\lean{MPSTensor.gaugeEquiv_tpGauge}`), with short proofs and `\lean` tags.
>
> **Proof dependency fix:** The proof of **TP-gauge existence for irreducible tensors** (`thm:tp_data_irreducible`) no longer cites the general **left-canonical gauge** theorem (`thm:left_canonical_gauge`); it cites the new square-root TP gauge theorem and the gauge-equivalence lemma. The theorem's `\uses` list also adds **`def:gauge_equiv`** so the statement's gauge-equivalence claim is reflected in blueprint dependencies.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671df19d4e8c9d35941579cce11cbb4cd2e5bad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>