### PR TITLE
doc(blueprint): cite rectangular eigenvalue bound

### DIFF
--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -296,6 +296,23 @@ a block embedding of a mixed-transfer eigenvector.
     and does not appeal to Perron--Frobenius theory.
 \end{proof}
 
+\begin{theorem}[Rectangular eigenvalue bound]\label{thm:eigenvalue_bound_rect}
+    \lean{MPSTensor.eigenvalue_norm_le_one₂}
+    \leanok
+    \uses{def:mixed_transfer_rect}
+    Let $A$ and $B$ be normalized MPS tensors of bond dimensions
+    $D_1 \ge 1$ and $D_2 \ge 1$.  Every eigenvalue $\mu$ of
+    $F_{AB}^{\mathrm{rect}}$ satisfies $|\mu| \le 1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The word-expansion and Frobenius-norm estimate used in
+    Theorem~\ref{thm:eigenvalue_bound} apply equally to rectangular matrices:
+    if $F_{AB}^{\mathrm{rect}}(X)=\mu X$ and $X\neq 0$, then
+    $|\mu|^n\|X\|_{\mathrm{HS}}\le D_1\|X\|_{\mathrm{HS}}$
+    for every $n$.  Hence $|\mu|\le 1$.
+\end{proof}
+
 \begin{lemma}[Spectral radius bound]\label{thm:spectral_radius_le_one}
     \lean{MPSTensor.spectralRadius_mixedTransfer_le_one}
     \leanok
@@ -499,10 +516,10 @@ a block embedding of a mixed-transfer eigenvector.
 
 \begin{proof}
     \leanok
-    \uses{thm:eigenvalue_bound, thm:gauged_intertwining_core,
+    \uses{thm:eigenvalue_bound_rect, thm:gauged_intertwining_core,
         thm:rectangular_intertwining_dim_eq}
     The same word-expansion argument as in
-    Theorem~\ref{thm:eigenvalue_bound} gives $|\mu| \le 1$
+    Theorem~\ref{thm:eigenvalue_bound_rect} gives $|\mu| \le 1$
     for every eigenvalue of $F_{AB}^{\mathrm{rect}}$.
     If $\rho_{\spec}(F_{AB}^{\mathrm{rect}}) = 1$, choose a
     modulus-one eigenvector $X \in M_{D_1 \times D_2}(\C) \setminus \{0\}$.


### PR DESCRIPTION
### Motivation
- The blueprint proof of `thm:transfer_operator_gap_rect` cited the square eigenvalue bound (`thm:eigenvalue_bound`) via `\uses`, but the Lean proof in `TransferOperatorGapRect.lean:227` calls the rectangular eigenvalue bound — the `\uses` edge was mismatched (issue #2296, third bullet).
- A dedicated blueprint entry for the rectangular eigenvalue bound was missing: every eigenvalue of the rectangular mixed transfer map has modulus at most one, proved via the same word-expansion / Hilbert–Schmidt argument as the square case.

### Description
- `blueprint/src/chapter/ch06_spectral.tex`: adds new blueprint entry `thm:eigenvalue_bound_rect` with `\lean{MPSTensor.eigenvalue_norm_le_one₂}` and `\leanok`, recording the rectangular eigenvalue bound.
- Redirects the `\uses` edge in `thm:transfer_operator_gap_rect` from `thm:eigenvalue_bound` to `thm:eigenvalue_bound_rect`, aligning the blueprint dependency graph with the actual Lean call graph.
- No Lean source changes; the statement of the gap theorem is unchanged.

### Testing
- `python3 scripts/blueprint_lean_sync.py` (reports only pre-existing unrelated missing refs in `ch13a_peps_ft.tex` and `ch04a_channel_representations.tex`)
- `lake exe cache get`
- `lake build TNLean.Spectral.TransferOperatorGapRect`
- `lake env lean --stdin` with checks for `MPSTensor.eigenvalue_norm_le_one₂` and `MPSTensor.mixedTransferSpectralRadius₂_lt_one_of_dim_ne`

---
Addresses #2296

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX/blueprint edits with no runtime or proof-code changes in this diff.
> 
> **Overview**
> The blueprint chapter on spectral transfer operators now records a **dedicated rectangular eigenvalue bound** (`thm:eigenvalue_bound_rect`, Lean `MPSTensor.eigenvalue_norm_le_one₂`): every eigenvalue of the rectangular mixed transfer map has modulus at most 1, via the same word-expansion / Hilbert–Schmidt argument as the square case.
> 
> The proof of **rectangular transfer-operator gap** (`thm:transfer_operator_gap_rect`) is updated to cite that rectangular bound instead of the square `thm:eigenvalue_bound`; the gap theorem's statement is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08f3b3c05ee353e002a79a6c9562bae2a857077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX/blueprint-only edits; no runtime or Lean proof code in this diff.
> 
> **Overview**
> Adds a **blueprint theorem** `thm:eigenvalue_bound_rect` for the rectangular mixed transfer operator: every eigenvalue has \(|\mu|\le 1\), linked to Lean `MPSTensor.eigenvalue_norm_le_one₂`, with a short proof reusing the square-case word-expansion / Hilbert–Schmidt argument.
> 
> Updates **`thm:transfer_operator_gap_rect`** so its `\uses` dependency and proof text cite `thm:eigenvalue_bound_rect` instead of the square `thm:eigenvalue_bound`, matching the Lean proof graph (issue #2296). **No Lean or theorem statements change** beyond documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6538354694dde665d1af949347a24cddd01bd13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->