### PR TITLE
doc(parent): align closure-property terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -19,8 +19,9 @@ For an injective MPS tensor `A`, we establish:
    `G_L(A)` on both the left `L`-site window (fixing the last index) and the right
    `L`-site window (fixing the first index).
 
-3. **Intersection property** (the "invert-and-regrow" step): conversely, a state on `L+1`
-   sites whose left and right restrictions both lie in `G_L(A)` is itself in `G_{L+1}(A)`.
+3. **Intersection property** (the "inverting and growing back" step): conversely, a state
+   on `L+1` sites whose left and right restrictions both lie in `G_L(A)` is itself in
+   `G_{L+1}(A)`.
 
 The intersection property is the key ingredient for proving uniqueness of the ground state
 of the parent Hamiltonian (see `UniqueGroundState.lean`).
@@ -264,7 +265,7 @@ theorem groundSpace_finrank_eq {A : MPSTensor d D} (hA : IsInjective A)
 to ground-space elements on both the left and right `L`-site windows is itself
 in `G_{L+1}(A)`.
 
-This is the "invert-and-regrow" step. The proof proceeds as follows:
+This is the "inverting and growing back" step. The proof proceeds as follows:
 
 1. From `InRightGround`: for each `i`, ∃ unique `Y_i` with `ψ(i, σ) = tr(A^σ · Y_i)`.
 2. From `InLeftGround`: for each `j`, ∃ unique `Z_j` with `ψ(σ, j) = tr(A^σ · Z_j)`.

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -29,8 +29,8 @@ with the periodic boundary condition:
    `ψ(σ) = tr(A^σ · X)` for some boundary matrix `X ∈ M_D(ℂ)`.
    This yields a `D²`-dimensional space.
 
-2. **Periodic chain**: The wrapping window condition (connecting the last and
-   first sites) constrains `X`. For injective `A`, the matrices `{A^i}` span
+2. **Periodic chain**: The boundary condition obtained when closing the
+   periodic chain constrains `X`. For injective `A`, the matrices `{A^i}` span
    `M_D(ℂ)`, so the commutation condition forces `X ∝ I`, yielding a
    one-dimensional ground space spanned by the MPV.
 
@@ -46,10 +46,10 @@ with the periodic boundary condition:
   — once a boundary matrix commutes with all long-enough word products, its
   boundary contraction lies in the MPV span
 * `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility`
-  — same-witness common-middle compatibilities imply MPV-line membership
+  — common-middle compatibilities with one boundary family imply MPV-line membership
 * `MPSTensor.groundSpace_unique_periodic` — uniqueness on the periodic chain
 * `MPSTensor.parentHamiltonian_unique_gs_injective` — uniqueness for `2L₀` sites
-* `MPSTensor.parentHamiltonian_unique_gs_normal` — optimal uniqueness for `L₀+1` sites
+* `MPSTensor.parentHamiltonian_unique_gs_normal` — uniqueness for `L₀+1` sites
 
 ## References
 
@@ -76,10 +76,10 @@ from Cirac--Perez-Garcia--Schuch--Verstraete (2021), Section IV.C:
 In the present formal reduction, for an `L₀`-block-injective tensor `A` on a
 periodic chain of `N` sites with window size `L > L₀`, a chain ground state
 `ψ = groundSpaceMap A N X` induces two boundary-matrix families from two cyclic
-windows crossing the periodic boundary.  The closure property is represented by
-the assertion that these boundary matrices agree after their complements are
-indexed by the same middle word `μ`, giving the comparison identity needed for
-the range-reduction argument.
+windows used when closing the boundary. The formal proof has isolated the
+remaining comparison as the assertion that these boundary matrices agree after
+their complements are indexed by the same middle word `μ`, giving the comparison
+identity needed for the range-reduction argument.
 
 The formal Lean declaration:
 
@@ -486,7 +486,7 @@ block-injective tensors.
 This combines cyclic window monotonicity (peeling longer cyclic windows down to
 `L₀ + 1`), the non-wrapping cyclic/contiguous identification, and the
 open-chain range-reduction argument for block-injective tensors. It stops at
-open-chain membership; the wrapped-boundary scalarity step remains separate. -/
+open-chain membership; the boundary-closing scalarity step remains separate. -/
 theorem chainGroundSpace_le_groundSpace_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -591,15 +591,15 @@ theorem chainGroundSpace_eq_mpvSubmodule {A : MPSTensor d D} [NeZero D]
     obtain ⟨c, rfl⟩ := hψ
     exact Submodule.smul_mem _ c (mpv_mem_chainGroundSpace A L N hN0 hLN)
 
-/-- Reduced cyclic constraints give the two wrapped-boundary compatibility
-families for an open-chain boundary matrix.
+/-- Reduced cyclic constraints give the two cyclic-window compatibility families
+at the boundary for an open-chain boundary matrix.
 
 After the cyclic-to-open-chain step writes a periodic-chain vector as
-`ψ = groundSpaceMap A N X`, the two reduced wrapped windows expose the boundary
-matrix `X` on opposite sides of the same length-`N - (L₀ + 1)` complement word.
-This theorem gives exactly the local algebraic output needed for the final
-common-middle/long-word commutation step of the normal parent-Hamiltonian
-argument. -/
+`ψ = groundSpaceMap A N X`, the two reduced cyclic windows used when closing
+the boundary expose the boundary matrix `X` on opposite sides of the same
+length-`N - (L₀ + 1)` complement word. This theorem gives the local algebraic
+output needed for the remaining boundary-closing comparison
+(arXiv:2011.12127, Section IV.C, lines 2078--2090). -/
 theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -652,7 +652,7 @@ theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
 /-- Long-word commutation is enough to place an open-chain boundary vector in the
 periodic MPV line.
 
-After the reduced wrapped-boundary compatibilities have been converted into a
+After the reduced cyclic-window compatibilities at the boundary have been converted into a
 family of identities `X A^ω = A^ω X` for one word length `m ≥ L₀`, the existing
 block-stripping theorem makes `X` commute with the full matrix algebra.  Hence
 `X` is scalar and `groundSpaceMap A N X` is a scalar multiple of the MPV. -/
@@ -701,13 +701,13 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_comm
     (A := A) (L₀ := L₀) (m := L₀ * m) (N := N) hInj hL₀
     (Nat.le_mul_of_pos_right L₀ hm) hCommMul
 
-/-- Same-witness two-sided middle compatibilities put the boundary vector in the
-MPV line.
+/-- Two-sided middle compatibilities with one boundary family put the boundary
+vector in the MPV line.
 
 This combines the common-middle algebraic lemma in `WrappingWindow` with the
-positive-length amplification above.  Thus the only remaining mathematical gap is
-to compare the two wrapped-window witnesses so that the hypotheses below hold for
-the actual common middle word. -/
+positive-length amplification above. Thus the only remaining mathematical gap is
+to compare the two boundary matrices obtained when closing the boundary so that
+the hypotheses below hold for the actual common middle word. -/
 theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility
     {A : MPSTensor d D} {L₀ m N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -724,14 +724,14 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_c
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes
     (A := A) (L₀ := L₀) (m := m + 2) (N := N) hInj hL₀ (by omega) hComm
 
-/-- Reindexed wrapped-window witness comparison puts the boundary vector in the
-MPV line.
+/-- Reindexed boundary-closing comparison puts the boundary vector in the MPV
+line.
 
-This combines the common-middle commutation argument with the actual wrapped and
-mirror windows.  The one-sided hypotheses are exactly the outputs of
+This combines the common-middle commutation argument with the two cyclic windows
+used when closing the boundary. The one-sided hypotheses are exactly the outputs of
 `chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`; the
 additional hypothesis says that, after both complements are filled by the same
-middle word `μ`, the two witnesses are equal. -/
+middle word `μ`, the two boundary matrices are equal. -/
 theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
     {A : MPSTensor d D} {L₀ N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (η : Fin d)
@@ -753,14 +753,15 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_co
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility
     (A := A) (L₀ := L₀) (m := N - (L₀ + 1)) (N := N) hInj hL₀ Y hLeft hRight
 
-/-- Conditional range-reduction theorem from the actual wrapped-window witness comparison.
+/-- Conditional range-reduction theorem from the actual boundary-closing comparison.
 
 This theorem isolates the remaining comparison needed for the normal-case range
 reduction.  The cyclic-to-open-chain reduction produces a boundary matrix `X`,
 and `chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`
-produces the two one-sided wrapped-window witness families.  If those actual
-witnesses agree after reindexing their complements to the same middle word, the
-chain state lies in the MPV line. -/
+produces the two one-sided boundary-matrix families from the cyclic windows used
+when closing the boundary. If those actual boundary matrices agree after
+reindexing their complements to the same middle word, the chain state lies in
+the MPV line. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -798,8 +799,8 @@ theorem chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_c
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
     (A := A) (L₀ := L₀) (N := N) hInj hL₀ η Ywrap Ymirror hWrap hMirror hCompare'
 
-/-- Right-products with all one-site tensors determine the compared
-wrapped-boundary witnesses.
+/-- Right-products with all one-site tensors determine the compared boundary
+conditions.
 
 This is the final algebraic reduction of the closure-property comparison from
 arXiv:2011.12127, Section IV.C, lines 2078--2090.  After the
@@ -818,11 +819,13 @@ theorem wrapped_mirror_witness_agree_of_right_products
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
-/-- The two boundary matrices extracted from the two boundary-crossing cyclic
-windows agree when their complements are reindexed to a common middle word `μ`.
+/-- The two boundary matrices extracted from the cyclic windows used in closing
+the boundary agree when their complements are reindexed to a common middle word
+`μ`.
 
-This theorem states the closure-property comparison from arXiv:2011.12127,
-Section IV.C, lines 2078--2090, and is the remaining gap needed to close
+This theorem states the formal comparison still needed to realize the closure
+property of arXiv:2011.12127, Section IV.C, lines 2078--2090, and is the
+remaining gap needed to close
 `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
 
 The expected proof is the boundary-closing analogue of the preceding
@@ -843,7 +846,8 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
       X * A j * evalWord A (List.ofFn (fun k : Fin (N - (L₀ + 1)) =>
         τ ⟨k.val + 1, by omega⟩)) = A j * Ymirror τ)
     (η : Fin d) (μ : Fin (N - (L₀ + 1)) → Fin d) :
-    Ywrap (wrappedMiddleBackground L₀ N η μ) = Ymirror (mirrorMiddleBackground L₀ N η μ) := by
+    Ywrap (wrappedMiddleBackground L₀ N η μ) =
+      Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   refine wrapped_mirror_witness_agree_of_right_products (A := A) hInj hL₀
     Ywrap Ymirror η μ ?_
   intro j
@@ -912,8 +916,8 @@ space is one-dimensional, spanned by the MPV.
 The proof uses the intersection property iteratively:
 1. From the intersection property, any state in the chain ground space has the form
    `ψ(σ) = tr(A^σ · X)` for some `X ∈ M_D(ℂ)`.
-2. The wrapping window condition (window crossing the periodic boundary) constrains
-   `X` to commute with all `A^i`.
+2. The boundary condition obtained when closing the periodic chain constrains `X`
+   to commute with all `A^i`.
 3. For injective `A`, the center of `span{A^i} = M_D(ℂ)` consists only of scalars,
    so `X = c · I` and `ψ = c · mpv A`. -/
 theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjective A)

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -44,7 +44,7 @@ proceeds as follows:
 ## Main results
 
 * `MPSTensor.commutes_words_of_two_sided_middle_compatibility`
-  — same-witness two-sided common-middle identities imply word commutation
+  — two-sided common-middle identities with one boundary family imply word commutation
 * `MPSTensor.commutes_words_mul_of_commutes_words`
   — fixed-length word commutation amplifies to all multiple lengths
 * `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`
@@ -53,7 +53,7 @@ proceeds as follows:
   — padding short complement annihilation to a full block-injective word span
 * `MPSTensor.right_witness_unique_of_isNBlkInjective` and
   `MPSTensor.left_witness_unique_of_isNBlkInjective`
-  — one-sided boundary witness uniqueness from block injectivity
+  — uniqueness of the one-sided boundary matrices from block injectivity
 * `MPSTensor.boundary_matrix_commutes` — if `groundSpaceMap A N X` lies in
   every cyclic window's ground space, then `X` commutes with all `A_j`.
 
@@ -408,9 +408,10 @@ private theorem wrapping_window_matEq {A : MPSTensor d D} [NeZero D]
       Matrix.mul_assoc (A (σ₁ 0))] at key
   exact key
 
-/-- Block injectivity strips the wrapped tail block and yields the one-sided
-compatibility `C_τ * A j * X = Y_τ * A j`. The complementary mirror comparison
-is the remaining local step needed for the two-sided wrapped-window relation. -/
+/-- Block injectivity strips the cyclic-window tail block at the boundary and
+yields the one-sided compatibility `C_τ * A j * X = Y_τ * A j`. The
+complementary opposite cyclic-window comparison is the remaining local step
+needed for the two-sided relation. -/
 theorem wrapping_window_compatibility_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -455,9 +456,9 @@ theorem wrapping_window_compatibility_of_isNBlkInjective
         (evalWord A (List.ofFn σ_tail) * (Y τ * A j)) := by
           simp [Matrix.mul_assoc]
 
-/-- The opposite wrapped position `N - L₀` exposes the mirror compatibility
+/-- The opposite cyclic position used when closing the boundary exposes the compatibility
 `X * A j * C_τ = A j * Y_τ` after block-injective stripping of the trailing
-`L₀`-site block.  This is the missing second wrapped-window extraction needed
+`L₀`-site block. This is the missing second cyclic-window extraction needed
 for the block-injective periodic argument. -/
 theorem wrapping_window_mirror_compatibility_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -540,10 +541,10 @@ theorem wrapping_window_mirror_compatibility_of_isNBlkInjective
 
 /-! ### Common-middle algebraic closure
 
-The two one-sided wrapped-boundary identities close the boundary matrix once they
-are available with a common middle word and the same boundary witness. -/
+The two one-sided cyclic-window identities close the boundary matrix once they
+are available with a common middle word and the same boundary-matrix family. -/
 
-/-- A background configuration whose wrapped-window complement is the prescribed
+/-- A background configuration whose cyclic-window complement is the prescribed
 middle word.
 
 For the wrapped window at the last site, the complement occupies physical sites
@@ -598,13 +599,14 @@ theorem mirrorMiddleBackground_complement (L₀ N : ℕ) (η : Fin d)
   · congr 1
   · constructor <;> omega
 
-/-- Reindexed wrapped and mirror witnesses give a same-witness common-middle pair.
+/-- Reindexed cyclic-window boundary matrices give a common boundary family over
+a common middle word.
 
 The hypotheses `hWrap` and `hMirror` are the two one-sided identities produced by
 `chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`.  The only
-extra input is the genuine witness comparison: after filling the two complements
-with the same middle word `μ`, the wrapped and mirror witnesses agree.  The
-conclusion yields the exact same-witness hypotheses needed by
+extra input is the genuine boundary-closing comparison: after filling the two complements
+with the same middle word `μ`, the two boundary matrices agree. The
+conclusion yields the shared-boundary-family hypotheses needed by
 `commutes_words_of_two_sided_middle_compatibility`. -/
 theorem two_sided_middle_compatibility_of_wrapped_witness_comparison
     {A : MPSTensor d D} {L₀ N : ℕ} (η : Fin d)
@@ -633,13 +635,13 @@ theorem two_sided_middle_compatibility_of_wrapped_witness_comparison
     have hCmp := hCompare μ
     simpa [mirrorMiddleBackground_complement, hCmp.symm] using h
 
-/-- A same-witness pair of one-sided compatibilities around a common middle word
-forces `X` to commute with every word obtained by adjoining one physical letter on
-each side of that middle.
+/-- A pair of one-sided compatibilities with one boundary family around a common
+middle word forces `X` to commute with every word obtained by adjoining one
+physical letter on each side of that middle.
 
 This is the algebraic core of the remaining normal parent-Hamiltonian closure
-step: after the wrapped and mirror windows have been compared so that their
-boundary witnesses agree on a shared complement `μ`, the identities
+step: after the two cyclic windows used when closing the boundary have been
+compared so that their boundary matrices agree on a shared complement `μ`, the identities
 `A^μ A^b X = Y_μ A^b` and `X A^a A^μ = A^a Y_μ` imply
 `X A^a A^μ A^b = A^a A^μ A^b X`. -/
 theorem commutes_words_of_two_sided_middle_compatibility
@@ -750,7 +752,7 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes
 /-- If left multiplication by `Z` annihilates every word product of length `k`,
 and words of some longer length `n` span the full matrix algebra, then `Z = 0`.
 
-This is the padding form needed in the normal wrapped-boundary closure: an
+This is the padding form needed in the normal boundary-closing argument: an
 annihilation relation obtained for a short complement word can be multiplied by
 all padding words up to any length whose exact word span is `⊤`. -/
 theorem eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -502,7 +502,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    The ``invert-and-regrow'' argument compares the left and right
+    The ``inverting and growing back'' argument compares the left and right
     restrictions on their common $(L-1)$-site overlap and then reconstructs the
     full $(L+1)$-site word from a single boundary matrix:
     \begin{center}
@@ -776,7 +776,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Definition~\ref{def:tail_restrict_parent} and the contiguous-window transport above
     identify every fixed-prefix suffix with one of the assumed length-$L_0+1$
     windows. Theorem~\ref{thm:ground_space_extend_right_block_injective} then
-    regrows the rightmost site.
+    grows back the rightmost site.
 \end{proof}
 
 \begin{lemma}[Cyclic-window range antitonicity]%
@@ -820,51 +820,54 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:normal_open_chain_range_reduction} applies.
 \end{proof}
 
-\begin{lemma}[Wrapped-window one-sided compatibility]%
+\begin{lemma}[Last cyclic-window one-sided compatibility at the boundary]%
     \label{lem:wrapped_window_one_sided_compatibility}
     \lean{MPSTensor.wrapping_window_compatibility_of_isNBlkInjective}
     \leanok
     \uses{def:l_blk_injective, rem:cyclic_window_operators}
     Assume $A$ is $L_0$-block injective with $L_0>0$ and $M \ge L_0$.
-    If the reduced wrapped window at the last site has boundary matrices
-    $Y_\tau$, then for every physical letter $j$ one has
+    If the reduced cyclic window used in closing the boundary at the last site has
+    boundary matrices $Y_\tau$, then for every physical letter $j$ one has
     \[
         C^+_\tau A^j X = Y_\tau A^j,
     \]
-    where $C^+_\tau$ is the complementary word seen by that wrapped window.
+    where $C^+_\tau$ is the complementary word seen by that cyclic
+    window.
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{lem:ground_space_map_injective_blk}
-    The trace identity for the wrapped window is tested against all words of
+    The trace identity for this cyclic window is tested against all words of
     length $L_0$. Injectivity of $\Gamma_{L_0}$, which follows from
     $L_0$-block injectivity, strips the test word and gives the displayed matrix
     identity.
 \end{proof}
 
-\begin{lemma}[Mirror wrapped-window one-sided compatibility]%
+\begin{lemma}[Opposite cyclic-window one-sided compatibility at the boundary]%
     \label{lem:mirror_wrapped_window_one_sided_compatibility}
     \lean{MPSTensor.wrapping_window_mirror_compatibility_of_isNBlkInjective}
     \leanok
     \uses{def:l_blk_injective, rem:cyclic_window_operators}
     Assume $A$ is $L_0$-block injective with $L_0>0$ and $M \ge L_0$.
-    If the opposite reduced wrapped window has boundary matrices $Y_\tau$, then
+    If the opposite reduced cyclic window used in closing the boundary has boundary
+    matrices $Y_\tau$, then
     \[
         X A^j C^-_\tau = A^j Y_\tau
     \]
     for every physical letter $j$, where $C^-_\tau$ is the complementary word
-    seen from the opposite boundary-crossing position.
+    seen from the opposite cyclic position.
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{lem:ground_space_map_injective_blk}
-    Factor the cyclic word at the opposite wrapped position, rotate the trace,
-    and use injectivity of $\Gamma_{L_0}$ to remove the length-$L_0$ test word.
+    Factor the cyclic word at the opposite cyclic position, rotate
+    the trace, and use injectivity of $\Gamma_{L_0}$ to remove the
+    length-$L_0$ test word.
 \end{proof}
 
-\begin{theorem}[Reduced wrapped-boundary compatibilities]%
+\begin{theorem}[Reduced cyclic-window compatibilities at the boundary]%
     \label{thm:reduced_wrapped_boundary_compatibilities}
     \lean{MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective}
     \leanok
@@ -883,7 +886,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         X A^j C^-_\tau = A^j Y^-_\tau,
     \]
     where $C^+_\tau$ and $C^-_\tau$ are the complementary words exposed by the
-    two opposite wrapped windows of reduced length $L_0+1$.
+    two opposite cyclic windows used in closing the boundary, both of reduced length
+    $L_0+1$.
 \end{theorem}
 
 \begin{proof}
@@ -892,12 +896,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         lem:wrapped_window_one_sided_compatibility,
         lem:mirror_wrapped_window_one_sided_compatibility}
     First use Lemma~\ref{lem:cyclic_window_range_antitonicity} to reduce the
-    cyclic constraints from range $L$ to range $L_0+1$. Then apply the wrapped
-    window and mirror wrapped window compatibility lemmas at the two
-    boundary-crossing positions to obtain the displayed one-sided identities.
+    cyclic constraints from range $L$ to range $L_0+1$. Then apply the two
+    cyclic-window compatibility lemmas at the two boundary positions to obtain
+    the displayed one-sided identities.
 \end{proof}
 
-\begin{lemma}[Middle-word backgrounds for the two wrapped complements]%
+\begin{lemma}[Middle-word backgrounds for the two cyclic-window complements]%
     \label{lem:wrapped_middle_backgrounds}
     \lean{MPSTensor.wrappedMiddleBackground,
         MPSTensor.mirrorMiddleBackground,
@@ -906,28 +910,31 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{rem:cyclic_window_operators}
     Fix a dummy physical letter $\eta$ and a middle word $\mu$ of length
-    $N-(L_0+1)$.  Write $\tau^+_\eta(\mu)$ for the last-site wrapped background
-    and $\tau^-_\eta(\mu)$ for the opposite wrapped background. Their exposed
+    $N-(L_0+1)$.  Write $\tau^+_\eta(\mu)$ for the last-site cyclic-window
+    background and $\tau^-_\eta(\mu)$ for the opposite cyclic-window
+    background. Their exposed
     complements are both exactly $\mu$.
 \end{lemma}
 
 \begin{proof}
     \leanok
     With the same dummy letter $\eta$ on the remaining sites, fill the physical
-    sites $L_0,\ldots,N-2$ with $\mu$ for the last-site wrapped window, and fill
-    the sites $1,\ldots,N-L_0-1$ with $\mu$ for the opposite wrapped window.
+    sites $L_0,\ldots,N-2$ with $\mu$ for the last-site cyclic
+    window, and fill the sites $1,\ldots,N-L_0-1$ with $\mu$ for the opposite
+    cyclic window.
     The two complement-extraction identities are then immediate from the index
     arithmetic.
 \end{proof}
 
-\begin{lemma}[Same-witness identities from compared wrapped witnesses]%
+\begin{lemma}[One boundary-matrix family from compared boundary matrices]%
     \label{lem:two_sided_middle_of_wrapped_witness_comparison}
     \lean{MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison}
     \leanok
     \uses{lem:wrapped_middle_backgrounds}
-    Fix a dummy physical letter $\eta$. Suppose the wrapped and mirror one-sided
-    witnesses $Y^+$ and $Y^-$ have been extracted. If, for every middle word
-    $\mu$, the witnesses agree on the backgrounds built from $\eta$,
+    Fix a dummy physical letter $\eta$. Suppose the two one-sided boundary
+    matrix families $Y^+$ and $Y^-$ have been extracted from the cyclic
+    windows. If, for every middle word
+    $\mu$, these boundary matrices agree on the backgrounds built from $\eta$,
     \[
         Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)},
     \]
@@ -942,13 +949,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    Define $Y_\mu$ to be the wrapped witness evaluated on the background
+    Define $Y_\mu$ to be the first boundary matrix evaluated on the background
     $\tau^+_\eta(\mu)$. Lemma~\ref{lem:wrapped_middle_backgrounds} rewrites the
-    wrapped complement as $\mu$, while the assumed comparison at
-    $\tau^-_\eta(\mu)$ rewrites the mirror witness to the same $Y_\mu$.
+    first cyclic-window complement as $\mu$, while the assumed comparison at
+    $\tau^-_\eta(\mu)$ rewrites the opposite boundary matrix to the same
+    $Y_\mu$.
 \end{proof}
 
-\begin{lemma}[Same-witness common-middle commutation]%
+\begin{lemma}[Common-middle commutation with one boundary family]%
     \label{lem:common_middle_same_witness_commutation}
     \lean{MPSTensor.commutes_words_of_two_sided_middle_compatibility}
     \leanok
@@ -1299,14 +1307,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:ground_space_map_mpv_of_long_word_commutes} applies.
 \end{proof}
 
-\begin{theorem}[Boundary contraction in the MPV span from a common-middle witness]
+\begin{theorem}[Boundary contraction in the MPV span from one middle boundary family]
     \label{thm:ground_space_map_mpv_of_common_middle}
     \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}
     \leanok
     \uses{lem:common_middle_same_witness_commutation,
         thm:ground_space_map_mpv_of_positive_word_commutes}
     Let $A$ be $L_0$-block-injective with $L_0>0$. If the common-middle
-    same-witness identities of
+    one-boundary-family identities of
     Lemma~\ref{lem:common_middle_same_witness_commutation} hold for $X$, then
     $\Gamma_N(X)$ lies in the MPV line.
 \end{theorem}
@@ -1325,7 +1333,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{lem:two_sided_middle_of_wrapped_witness_comparison,
         thm:ground_space_map_mpv_of_common_middle}
     Let $A$ be $L_0$-block-injective with $L_0>0$, and fix a dummy physical
-    letter $\eta$. If the wrapped and mirror one-sided witnesses satisfy
+    letter $\eta$. If the two one-sided boundary matrix families satisfy
     \[
         Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}
     \]
@@ -1335,8 +1343,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     Lemma~\ref{lem:two_sided_middle_of_wrapped_witness_comparison} uses the
-    comparison at the two $\eta$-backgrounds to turn the wrapped witnesses into a
-    single same-witness common-middle family. Then
+    comparison at the two $\eta$-backgrounds to turn the two boundary matrices
+    into a single common-middle boundary family. Then
     Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} applies.
 \end{proof}
 
@@ -1350,7 +1358,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D \ge 1$. Assume
     $N \ge 2$ and $L_0 < L \le N$. Suppose that, for every dummy letter $\eta$
     and every boundary matrix obtained from an $N$-site chain ground state, the
-    wrapped and mirror witnesses supplied by
+    two boundary-matrix families supplied by
     Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities} agree at
     $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ for every middle word $\mu$. Then
     the range-$L$ chain ground space is contained in the MPV line.
@@ -1362,20 +1370,20 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         thm:reduced_wrapped_boundary_compatibilities,
         thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     The cyclic-to-open-chain reduction writes any chain ground state as
-    $\Gamma_N(X)$. The reduced wrapped-boundary compatibility theorem supplies
-    the two one-sided witness families for this $X$. The comparison hypothesis,
-    applied to a dummy letter $\eta$, says that these witnesses agree at
+    $\Gamma_N(X)$. The reduced cyclic-window compatibility theorem supplies
+    the two one-sided boundary-matrix families for this $X$. The comparison hypothesis,
+    applied to a dummy letter $\eta$, says that these boundary matrices agree at
     $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ for every middle word $\mu$.
     Theorem~\ref{thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     finishes.
 \end{proof}
 
-\begin{lemma}[Right products determine the compared boundary condition]
+\begin{lemma}[Right products determine the compared boundary matrix]
     \label{lem:wrapped_mirror_right_products_determine}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_right_products}
     \leanok
     \uses{lem:one_sided_boundary_witness_unique}
-    Let $A$ be $L_0$-block-injective with $L_0>0$.  Fix two boundary-condition
+    Let $A$ be $L_0$-block-injective with $L_0>0$.  Fix two boundary-matrix
     families $Y^+$ and $Y^-$ and the two reindexed backgrounds
     $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$.  If, for every physical letter
     $j$,
@@ -1398,7 +1406,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     matrices $Y^+_{\tau^+_\eta(\mu)}$ and $Y^-_{\tau^-_\eta(\mu)}$.
 \end{proof}
 
-\begin{theorem}[Boundary conditions agree after closing the boundary]
+\begin{theorem}[Boundary matrices agree after closing the boundary]
     \label{thm:wrapped_mirror_witness_agree_chain_ground_space}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace}
     \leanok
@@ -1408,7 +1416,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     and $L_0<L\le N$, and let
     $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
     $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are the two
-    boundary-matrix families extracted from the two cyclic windows crossing the
+    boundary-matrix families extracted from the two cyclic windows used in closing the
     periodic boundary, and that they satisfy, for every physical letter $j$
     and every background configuration $\tau$,
     \[
@@ -1436,7 +1444,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
             \eta,      & \text{otherwise}.
         \end{cases}
     \]
-    Then the two boundary conditions agree on these two backgrounds:
+    Then the two boundary matrices agree on these two backgrounds:
     \[
         Y^{+}_{\tau^{+}_{\eta}(\mu)}
         =
@@ -1448,7 +1456,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    The reduced boundary-crossing window compatibilities give, for every
+    The reduced cyclic-window compatibilities at the boundary give, for every
     physical letter $j$,
     \[
         A^{\mu} A^j X
@@ -1516,16 +1524,16 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{thm:reduced_wrapped_boundary_compatibilities,
         thm:conditional_normal_range_reduction_witness_comparison,
         lem:padded_complement_annihilation}
-    The closure property needed here is the witness comparison from
+    The closure property still needs the boundary-matrix comparison corresponding to
     \cite[lines~2078--2090]{Cirac2021Matrix}.
     Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
-    supplies the two one-sided wrapped-boundary identities for the open-chain
+    supplies the two one-sided cyclic-window identities for the open-chain
     boundary matrix $X$. The padded-annihilation lemma states that exact
     complement-span length mismatches are no longer the obstruction. The new
     conditional reduction theorem shows that the proof would finish as soon as
-    those actual wrapped-window witnesses are compared after reindexing their
+    the two actual boundary matrices are compared after reindexing their
     complements to a common middle word. What is still missing is precisely that
-    comparison of the witnesses themselves.
+    comparison after closing the boundary.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the normal case]%
@@ -2204,7 +2212,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Lemma~\ref{lem:local_term_es_kernel_restrictions} translates the two local
     kernel assumptions into the left and right $L$-site ground conditions.  The
     open-chain intersection property, Theorem~\ref{thm:ground_space_intersection},
-    then regrows the shared $(L-1)$-site overlap to the $(L+1)$-site ground space.
+    then grows back the shared $(L-1)$-site overlap to the $(L+1)$-site ground space.
     The converse uses the forward restriction lemmas for ground-space vectors and
     the same kernel--restriction characterization.
 \end{proof}
@@ -3726,7 +3734,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     selector existence from BNT separation, nor the wrapping/open-chain boundary
     representation. It is the formal composition matching the block-injective
     ground-space route of \cite[lines~2120--2128]{Cirac2021Matrix}, where the
-    regrowing argument is restricted to block-diagonal boundary conditions.
+    growing-back argument is restricted to block-diagonal boundary conditions.
 \end{lemma}
 
 \begin{proof}

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -21,8 +21,9 @@ Section~IV.C of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
 \cite{Cirac2021Matrix}.\footnote{For traceability, this note corresponds to
 \href{https://github.com/LionSR/TNLean/issues/1042}{issue \#1042}. The principal
 formal obligation is recorded in
-\href{https://github.com/LionSR/TNLean/issues/588}{issue \#588}; the wrapped-boundary
-comparison is recorded in \href{https://github.com/LionSR/TNLean/issues/961}{issue \#961};
+\href{https://github.com/LionSR/TNLean/issues/588}{issue \#588}; the
+boundary-closing comparison is recorded in
+\href{https://github.com/LionSR/TNLean/issues/1475}{issue \#1475};
 and the parent-Hamiltonian consequences are recorded in
 \href{https://github.com/LionSR/TNLean/issues/460}{issue \#460}.}
 
@@ -74,16 +75,16 @@ In the formal statement this is the equality between the cyclic chain ground spa
 and the MPV, or periodic MPS vector, subspace. The hard inclusion into the MPV
 line is the remaining range-reduction lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:817--841 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:864--888 for
 \path{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
 and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:852--865 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:899--909 for
 \path{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal}. The formal hypotheses
 are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
 \path{0 < L0}, \path{2 <= N}, and \path{L0 < L <= N}.}
 
 The blueprint records the same range-reduction target in
-\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1314--1356, under the
+\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1506--1535, under the
 label \texttt{thm:normal\_range\_reduction\_containment}. Its proof sketch
 already separates the open-chain containment from the cyclic boundary comparison,
 which is the same division made by the formal statements below.
@@ -95,11 +96,11 @@ tensor that is already injective at one site. Its proof decomposes the identity 
 $A_j$ and then iterates this single-letter intersection property through
 contiguous windows.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean}:253--256 for
+\path{TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean}:281--284 for
 \path{MPSTensor.groundSpace_intersection},
-\path{TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean}:313--330 for the
+\path{TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean}:341--364 for the
 use of \path{decompositionMap hA 1}, and
-\path{TNLean/MPS/ParentHamiltonian/CyclicWindow.lean}:153--155 for the contiguous
+\path{TNLean/MPS/ParentHamiltonian/CyclicWindow.lean}:153--163 for the contiguous
 iteration using that theorem.}
 For a normal tensor with injectivity length $L_0$, the available inverse is the
 inverse for words of length $L_0$, not a one-site inverse. This is not a
@@ -117,41 +118,42 @@ constraints. This supplies the formal analog of the iterated open-boundary
 part of the source proof, without expressing the inverse for the region $B$
 through the older single-site intersection lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:347--353 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:428--481 for
 \path{MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:409--424 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:490--505 for
 \path{MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}.}
 
 \section{The remaining comparison}
 
 After the open-chain step, a periodic-chain ground state can be written with an
-open-chain boundary matrix $X$. The point left to prove is that the wrapped
+open-chain boundary matrix $X$. The point left to prove is that the cyclic
 length-$L_0+1$ constraints force $X$ to be scalar, and hence that the state is
-in the MPV line. The formal proof has extracted the two one-sided wrapped
-compatibilities. In schematic notation, the wrapped window gives
+in the MPV line. The formal proof has extracted the two one-sided
+cyclic-window compatibilities at the boundary. In schematic notation, the
+last-site cyclic window used in closing the boundary gives
 \[
   C^+_{\tau} A_j X = Y^+_{\tau} A_j,
 \]
-while the mirror wrapped window gives
+while the opposite cyclic window used in closing the boundary gives
 \[
   X A_j C^-_{\tau} = A_j Y^-_{\tau}.
 \]
-Here $\tau$ denotes the complementary boundary word exposed by a wrapped
+Here $\tau$ denotes the complementary boundary word exposed by such a cyclic
 window, equivalently the physical labels outside the open middle interval. The
-formal wrapped and mirrored lemmas produce analogous complement-word products,
+formal cyclic-window lemmas produce analogous complement-word products,
 written schematically as $C^+_{\tau}$ and $C^-_{\tau}$, but the two products are
 obtained with different orientations and indexings. The two formulas are both
 valid; what is missing is a comparison that puts the two outputs over one common
-middle word and one common witness family.
+middle word and one common boundary family.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:522--534 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:603--650 for
 \path{MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective},
-\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:386--397 for the wrapped
+\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:415--458 for the wrapped
 compatibility, and
-\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:434--445 for the mirror
+\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:463--540 for the mirror
 compatibility.}
 
-The algebraic endgame needs a stronger same-witness statement. There should be
+The algebraic endgame needs a stronger common-boundary-family statement. There should be
 a common middle word $\mu$ and a single family of matrices $Y_\mu$ such that, for
 every physical letter $j$,
 \[
@@ -159,34 +161,35 @@ every physical letter $j$,
   \qquad
   X A_j A^\mu = A_j Y_\mu.
 \]
-Once these two identities have the same middle word and the same witness, the
+Once these two identities have the same middle word and the same boundary family, the
 formal algebraic lemma proves that $X$ commutes with all words of a fixed positive
 length; block injectivity then promotes this to commutation with the full matrix
 algebra, so $X$ is scalar.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:527--535 for
+\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:647--660 for
 \path{MPSTensor.commutes_words_of_two_sided_middle_compatibility}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:629--643 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:711--725 for
 \path{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}.}
-The remaining point is the comparison between the two wrapped-window outputs:
+The remaining point is the comparison between the two cyclic-window outputs:
 one must reindex their complementary words to a common middle word and identify
-the two witnesses as a single same-witness family.\footnote{For traceability,
+the two boundary matrices as a single common boundary family.\footnote{For traceability,
 this is the mathematical content recorded in
-\href{https://github.com/LionSR/TNLean/issues/961}{issue \#961}.}
+\href{https://github.com/LionSR/TNLean/issues/1475}{issue \#1475}.}
 
 \section{Conclusion}
 
 The comparison is provisional. It identifies a difference between the compressed
 source paragraph and the available formal lemmas; it is not a source-error claim.
-The cited Cirac--Perez-Garcia--Schuch--Verstraete 2021 argument is not refuted. The source compresses two mathematical
-steps which the formal proof must keep separate: the $B$-region invert-and-grow
-open-chain range reduction, and the boundary-closing comparison of the witnesses
-arising from the wrapped windows.
+The cited Cirac--Perez-Garcia--Schuch--Verstraete 2021 argument is not
+refuted. The source compresses two mathematical steps which the formal proof
+must keep separate: the $B$-region inverting and growing-back open-chain range
+reduction, and the boundary-closing comparison of the boundary matrices arising
+from the cyclic windows used in closing the boundary.
 
 The open-chain part has been proved under the intended block-injective
 hypotheses, though not by reusing the older single-site intersection theorem.
-The last mathematical point is the same-witness comparison at the periodic
-boundary. If that comparison is proved, the difference is only expository. If it
+The last mathematical point is the comparison of the two boundary matrices at
+the periodic boundary. If that comparison is proved, the difference is only expository. If it
 reveals an additional mathematical obstruction, the conclusion should be revised
 accordingly.
 


### PR DESCRIPTION
## Summary

This PR aligns the parent-Hamiltonian closure-property prose with the terminology in Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:2011.12127, Section IV.C.

The source says the intersection-property argument proceeds by inverting tensors and growing them back, and that a similar argument applies when closing the boundaries; this patch avoids presenting formal-local names such as wrapped-window witness comparisons as source terminology. It uses cyclic-window language for the formal objects and boundary-closing/closure-property language for the source comparison.

It also updates the normal-range paper-gap note to point the remaining boundary-matrix comparison to #1475 instead of the now-stale #961 reference.

## Notes

- No Lean declarations, blueprint labels, or `\lean{...}` tags were renamed.
- This does not close #1475. The theorem `MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace` remains the proof gap.

## Checks

- `git diff --check`
- `lake build TNLean.MPS.ParentHamiltonian.IntersectionProperty TNLean.MPS.ParentHamiltonian.WrappingWindow TNLean.MPS.ParentHamiltonian.UniqueGroundState`
  - passes with the known `UniqueGroundState.lean` sorry warning for #1475
- `python3 scripts/blueprint_lean_sync.py --root .`
  - reports only the known unrelated PEPS `blockingData` reference and literal `...` tag
- `leanblueprint web`
  - completes with the repository's usual plasTeX and missing-bibliography warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint text only; no logic, labels, or theorem renames, so merge risk is limited to reviewer confusion if terminology drifts from formal names.
> 
> **Overview**
> This PR **rewords documentation only** (Lean module headers/docstrings, blueprint chapter 14, and the normal-range paper-gap note). It does **not** rename Lean declarations, blueprint `\lean{...}` tags, or change proofs.
> 
> The edits align prose with Cirac–Pérez-García–Schuch–Verstraete (arXiv:2011.12127) Section IV.C: **“inverting tensors and growing them back”** for the intersection step, and **boundary-closing / closure-property** language for the periodic comparison. Formal-local phrasing such as “wrapped-window witness” is reframed as **cyclic-window** objects and **boundary-matrix** families at the boundary.
> 
> The paper-gap note now tracks the remaining comparison to **issue #1475** (replacing #961) and updates cited line ranges in `UniqueGroundState.lean`; `wrapped_mirror_witness_agree_of_chainGroundSpace` remains the open `sorry` gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd2d9371cda34540f5afb0f6dd4b498767620c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->