### PR TITLE
doc(blueprint): remove stale Fitting edges

### DIFF
--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -364,16 +364,11 @@ The results follow~\cite{Sanz2010Quantum}.
 
 \begin{proof}
     \leanok
-    \uses{thm:fitting_decomp}
-    A matrix with nonzero trace has a nonzero eigenvalue
-    (since trace = sum of eigenvalues counted with multiplicity).
-    The Fitting decomposition
-    (Theorem~\ref{thm:fitting_decomp})
-    ensures that the corresponding generalized eigenspace is nontrivial.
-    On that generalized eigenspace, $M - \mu \Id$ is nilpotent,
-    so its kernel is nontrivial.
-    Any nonzero vector in $\ker(M - \mu \Id)$ is therefore a
-    genuine eigenvector with eigenvalue~$\mu$.
+    The trace is the sum of the roots of the characteristic polynomial, counted
+    with multiplicity, so a nonzero trace gives a nonzero root $\mu$. This root
+    is a spectral value of the matrix, hence an eigenvalue of the associated
+    linear map on $\C^D$. Choosing a nonzero vector in the corresponding
+    eigenspace gives $M\varphi=\mu\varphi$.
 \end{proof}
 
 \begin{theorem}[Eigenvalue extraction]\label{thm:eigenvalue_extraction}
@@ -709,7 +704,7 @@ The results follow~\cite{Sanz2010Quantum}.
     \label{lem:rank_one_noninvertible_eigenvector}
     \lean{MPSTensor.vecMulVec_eigenvector_exact_wordSpan}
     \leanok
-    \uses{def:word_span, def:normal, thm:fitting_decomp}
+    \uses{def:word_span, def:normal}
     Let $A$ be a normal MPS tensor with bond dimension $D \ge 1$.
     Suppose that a Kraus operator $A^{i_0}$ is non-invertible and that
     there exists a vector $\varphi \in \C^D$ and a nonzero scalar $\mu$
@@ -722,14 +717,14 @@ The results follow~\cite{Sanz2010Quantum}.
 
 \begin{proof}
     \leanok
-    \uses{thm:fitting_decomp}
-    Decompose $A^{i_0}$ into its nilpotent and nonzero generalized
-    eigenspaces. On the nonzero part, multiplication by $A^{i_0}$ is
-    injective, so the rectangular spans grow strictly until they fill
-    the whole range. The nilpotent index contributes the remaining
-    length. Since the eigenvalue on $\varphi$ is nonzero, eigenvector
-    padding moves the resulting cumulative membership to the exact
-    length $D^2 - D + 1$.
+    Let $r$ be the nilpotent index of left multiplication by $A^{i_0}$.
+    Normality forces strict growth of the rectangular spans below $r$, and the
+    strict-growth lemma identifies the span at $r$ with the relevant range.
+    The eigenvector hypothesis then puts each rank-one matrix
+    $\ketbra{\varphi}{\psi}$ in the word span at the nilpotent-index level.
+    The sharp length estimate gives the bound $r+n_0\le D^2-D+1$, and the
+    nonzero eigenvalue of $\varphi$ pads the membership to the exact length
+    $D^2-D+1$.
 \end{proof}
 
 \begin{theorem}[Wielandt case (3), one-step non-invertible element]%

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -750,10 +750,9 @@ The results follow~\cite{Sanz2010Quantum}.
     \]
     implies
     \[
+        \ketbra{\varphi}{\psi}\in S_k(A)
+        \implies
         \ketbra{\varphi}{\psi}\in S_{k+1}(A)
-        \qquad
-        \text{whenever }
-        \ketbra{\varphi}{\psi}\in S_k(A),
     \]
     because left multiplication by $A^{i_0}$ maps $S_k(A)$ into
     $S_{k+1}(A)$.  Iterating from $k=r+n_0$ and using

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -718,14 +718,13 @@ The results follow~\cite{Sanz2010Quantum}.
 \begin{proof}
     \leanok
     Let $r$ be the nilpotent index of left multiplication by $A^{i_0}$.
-    Write $R_n(P,A)=P S_n(A)$ for the corresponding rectangular span.
     The dimension-growth argument gives a level $n_0$ for which
     \[
-        R_{n_0}((A^{i_0})^r,A)
+        (A^{i_0})^r S_{n_0}(A)
         =
-        \operatorname{range}\bigl(L_{(A^{i_0})^r}\bigr),
+        \bigl\{(A^{i_0})^r M : M\in \MN{D}\bigr\}.
     \]
-    where $L_P(M)=PM$. Since $\mu\neq 0$, the eigenvector relation gives
+    Since $\mu\neq 0$, the eigenvector relation gives
     $\varphi\in\operatorname{range}((A^{i_0})^r)$; hence, for every
     $\psi\in\C^D$,
     \[
@@ -749,7 +748,15 @@ The results follow~\cite{Sanz2010Quantum}.
         =
         \mu^{-1}A^{i_0}\ketbra{\varphi}{\psi}
     \]
-    raises the span length by one. Iterating this equality and using
+    implies
+    \[
+        \ketbra{\varphi}{\psi}\in S_{k+1}(A)
+        \qquad
+        \text{whenever }
+        \ketbra{\varphi}{\psi}\in S_k(A),
+    \]
+    because left multiplication by $A^{i_0}$ maps $S_k(A)$ into
+    $S_{k+1}(A)$.  Iterating from $k=r+n_0$ and using
     $r+n_0\le D^2-D+1$ gives
     \[
         \ketbra{\varphi}{\psi}\in S_{D^2-D+1}(A).

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -718,13 +718,28 @@ The results follow~\cite{Sanz2010Quantum}.
 \begin{proof}
     \leanok
     Let $r$ be the nilpotent index of left multiplication by $A^{i_0}$.
-    Normality forces strict growth of the rectangular spans below $r$, and the
-    strict-growth lemma identifies the span at $r$ with the relevant range.
-    The eigenvector hypothesis then puts each rank-one matrix
-    $\ketbra{\varphi}{\psi}$ in the word span at the nilpotent-index level.
-    The sharp length estimate gives the bound $r+n_0\le D^2-D+1$, and the
-    nonzero eigenvalue of $\varphi$ pads the membership to the exact length
-    $D^2-D+1$.
+    Write $R_n(P,A)=P S_n(A)$ for the corresponding rectangular span.
+    The dimension-growth argument gives a level $n_0$ for which
+    \[
+        R_{n_0}((A^{i_0})^r,A)
+        =
+        \operatorname{range}\bigl(L_{(A^{i_0})^r}\bigr),
+    \]
+    where $L_P(M)=PM$. Since $\mu\neq 0$, the eigenvector relation gives
+    $\varphi\in\operatorname{range}((A^{i_0})^r)$; hence, for every
+    $\psi\in\C^D$,
+    \[
+        \ketbra{\varphi}{\psi}\in S_{r+n_0}(A).
+    \]
+    The nilpotent-index estimate gives
+    \[
+        r+n_0\le D^2-D+1.
+    \]
+    Finally, the same nonzero eigenvalue extends this membership to the exact
+    word length, so
+    \[
+        \ketbra{\varphi}{\psi}\in S_{D^2-D+1}(A).
+    \]
 \end{proof}
 
 \begin{theorem}[Wielandt case (3), one-step non-invertible element]%

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -364,11 +364,9 @@ The results follow~\cite{Sanz2010Quantum}.
 
 \begin{proof}
     \leanok
-    The trace is the sum of the roots of the characteristic polynomial, counted
-    with multiplicity, so a nonzero trace gives a nonzero root $\mu$. This root
-    is a spectral value of the matrix, hence an eigenvalue of the associated
-    linear map on $\C^D$. Choosing a nonzero vector in the corresponding
-    eigenspace gives $M\varphi=\mu\varphi$.
+    The trace is the sum of the eigenvalues of $M$, counted with multiplicity,
+    so a nonzero trace gives a nonzero eigenvalue $\mu$.  Choosing a nonzero
+    vector $\varphi\in\ker(M-\mu\Id)$ gives $M\varphi=\mu\varphi$.
 \end{proof}
 
 \begin{theorem}[Eigenvalue extraction]\label{thm:eigenvalue_extraction}
@@ -724,9 +722,15 @@ The results follow~\cite{Sanz2010Quantum}.
         =
         \bigl\{(A^{i_0})^r M : M\in \MN{D}\bigr\}.
     \]
-    Since $\mu\neq 0$, the eigenvector relation gives
-    $\varphi\in\operatorname{range}((A^{i_0})^r)$; hence, for every
-    $\psi\in\C^D$,
+    Since $A^{i_0}\varphi=\mu\varphi$ and $\mu\neq 0$, iterating gives
+    $(A^{i_0})^r\varphi=\mu^r\varphi$, hence
+    \[
+        \varphi
+        =
+        \mu^{-r}(A^{i_0})^r\varphi
+        \in \operatorname{range}((A^{i_0})^r).
+    \]
+    Hence, for every $\psi\in\C^D$,
     \[
         \ketbra{\varphi}{\psi}\in S_{r+n_0}(A).
     \]

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -735,8 +735,22 @@ The results follow~\cite{Sanz2010Quantum}.
     \[
         r+n_0\le D^2-D+1.
     \]
-    Finally, the same nonzero eigenvalue extends this membership to the exact
-    word length, so
+    Since
+    \[
+        A^{i_0}\ketbra{\varphi}{\psi}
+        =
+        \ketbra{A^{i_0}\varphi}{\psi}
+        =
+        \mu\ketbra{\varphi}{\psi}
+    \]
+    and $\mu\neq 0$, the equality
+    \[
+        \ketbra{\varphi}{\psi}
+        =
+        \mu^{-1}A^{i_0}\ketbra{\varphi}{\psi}
+    \]
+    raises the span length by one. Iterating this equality and using
+    $r+n_0\le D^2-D+1$ gives
     \[
         \ketbra{\varphi}{\psi}\in S_{D^2-D+1}(A).
     \]


### PR DESCRIPTION
### Motivation

- Two Wielandt chapter blueprint entries — `thm:eigenvector_from_trace` and
  `lem:rank_one_noninvertible_eigenvector` — carry stale `\uses{thm:fitting_decomp}`
  dependency edges, but neither corresponding Lean proof calls the bundled
  `Wielandt.fittingDecomposition` record (see issue #2296, "ch07 `thm:fitting_decomp`" item).

### Description

- `blueprint/src/chapter/ch07_wielandt.tex`: removes `\uses{thm:fitting_decomp}` from
  `thm:eigenvector_from_trace` and `lem:rank_one_noninvertible_eigenvector`.
- Proof narrative for `thm:eigenvector_from_trace` rewritten to follow the
  characteristic-polynomial route: nonzero trace implies a nonzero eigenvalue,
  which yields an eigenvector.
- Proof narrative for `lem:rank_one_noninvertible_eigenvector` rewritten around
  the nilpotent index of left multiplication, strict rectangular-span growth under
  normality, and eigenvector padding to the stated word-span length.
- The standalone Fitting decomposition section (`thm:fitting_decomp`) is unchanged;
  only the two dependent entries are decoupled from it.

### Testing

- `git diff --check`: passes.
- `python3 scripts/blueprint_lean_sync.py --root .`: reports only the known unrelated
  PEPS `blockingData` reference and literal `...` tag.
- `leanblueprint web`: completes with the repository's usual plasTeX and
  missing-bibliography warnings.

---
Addresses #2296

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint/LaTeX edits with no runtime or Lean proof changes in this diff.
> 
> **Overview**
> **Blueprint dependency cleanup** in `ch07_wielandt.tex`: `thm:eigenvector_from_trace` and `lem:rank_one_noninvertible_eigenvector` no longer declare `\uses{thm:fitting_decomp}`, aligning the dependency graph with Lean proofs that do not use `Wielandt.fittingDecomposition`.
> 
> **Proof text updates** replace Fitting-based narratives. For nonzero trace, the proof now uses trace as the sum of eigenvalues to get a nonzero eigenvalue and a vector in `ker(M - μ Id)`. For rank-one extraction from a non-invertible Kraus eigenvector, the proof is rebuilt around the nilpotent index of left multiplication by `A^{i_0}`, dimension growth to reach `(A^{i_0})^r`’s range, membership of `|φ⟩⟨ψ|` in `S_{r+n_0}(A)`, and stepping down to `S_{D^2-D+1}(A)` via left multiplication by `A^{i_0}`.
> 
> The standalone Fitting decomposition section (`thm:fitting_decomp`) is **unchanged**; only these two entries are decoupled from it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8857f0eee458a7d49a47167b891a3cb95fe5b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->