### PR TITLE
doc(bnt): restore dimension blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -831,12 +831,15 @@ to the same BNT representative have equal bond dimension. Indeed, suppose
 trace-preserving primitive irreducible NTs $X$ and $Y$ of positive bond dimension
 have MPV families related by
 $\ket{V^{(N)}(Y)}=\zeta^N\ket{V^{(N)}(X)}$ with $\zeta\neq0$. The normalized
-self-overlaps give
+self-overlaps give $|O_{XX}(N)|\to 1$. The phase relation gives the
+cross-overlap identity
 \[
-    |\zeta|=1,
+    O_{YX}(N)=\zeta^N O_{XX}(N),
     \qquad
-    |O_{YX}(N)|\to 1.
+    |O_{YX}(N)|=|\zeta|^N |O_{XX}(N)|.
 \]
+Since the same normalization forces $|\zeta|=1$, this gives
+$|O_{YX}(N)|\to 1$.
 If their bond dimensions differed, the rectangular overlap-decay theorem would
 give
 \[
@@ -886,12 +889,15 @@ a contradiction.
 \begin{proof}\leanok
     Choose $\zeta\neq0$ with
     $\ket{V^{(N)}(Y)}=\zeta^N\ket{V^{(N)}(X)}$ for every length~$N$. The
-    normalized self-overlaps give
+    normalized self-overlaps give $|O_{XX}(N)|\to 1$, and the phase relation
+    gives
     \[
-        |\zeta|=1,
+        O_{YX}(N)=\zeta^N O_{XX}(N),
         \qquad
-        |O_{YX}(N)|\to 1.
+        |O_{YX}(N)|=|\zeta|^N |O_{XX}(N)|.
     \]
+    Since the same normalization forces $|\zeta|=1$, this gives
+    $|O_{YX}(N)|\to 1$.
     If the two bond dimensions differed, the rectangular overlap-decay theorem
     would force
     \[

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -826,12 +826,63 @@ form by quotienting gauge-phase-equivalent blocks into sectors.
     give the weight-norm conditions.
 \end{proof}
 
-The phase-class quotient preserves total bond dimension because
-phase-equivalent prepared blocks have equal bond dimension: if two
-trace-preserving primitive irreducible blocks of positive bond dimension have
-MPV families differing by a nonzero scalar power, the scalar has unit modulus,
-so the rectangular overlap has norm tending to $1$, which the rectangular
+The BNT construction preserves total bond dimension because CF summands assigned
+to the same BNT representative have equal bond dimension: if two
+trace-preserving primitive irreducible NTs of positive bond dimension have MPV
+families differing by a nonzero scalar power, the scalar has unit modulus, so
+the rectangular overlap has norm tending to $1$, which the rectangular
 overlap-decay theorem excludes unless the dimensions agree.
+
+\begin{lemma}[Total dimension after grouping by BNT representatives]%
+    \label{lem:collapsed_bnt_sector_decomp_total_dim}
+    \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim}
+    \leanok
+    \uses{def:mpv_phase_class_data}
+    Suppose CF summands are grouped by BNT representative, every original copy
+    weight is nonzero, and every summand assigned to a representative has that
+    representative's bond dimension. Then the total bond dimension of the
+    resulting BNT sector decomposition is the sum of the original block
+    dimensions.
+\end{lemma}
+
+\begin{proof}\leanok
+    The collapsed decomposition counts one representative dimension for each
+    assigned copy. By the same-dimension hypothesis, this is the corresponding
+    original CF summand dimension, and regrouping by representatives recovers
+    the original direct-sum dimension.
+\end{proof}
+
+\begin{lemma}[Prepared phase-equivalent NTs have the same bond dimension]%
+    \label{lem:prepared_phase_equiv_dim_eq}
+    \lean{MPSTensor.dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr}
+    \leanok
+    \uses{def:mpv_block_phase_equiv, thm:overlap_decay_rect_irr_tp}
+    Let $X$ and $Y$ be trace-preserving, primitive, irreducible NTs of positive
+    bond dimension. If their MPV families differ by a nonzero scalar power, then
+    $X$ and $Y$ have the same bond dimension.
+\end{lemma}
+
+\begin{proof}\leanok
+    The self-overlap normalization shows that the scalar relating the MPV
+    families has unit modulus. Hence the rectangular overlap between the two
+    NTs has norm tending to $1$. If the two bond dimensions differed, the
+    rectangular overlap-decay theorem would force that overlap to tend to $0$.
+\end{proof}
+
+\begin{lemma}[Prepared BNT representative classes preserve bond dimension]%
+    \label{lem:prepared_phase_class_dim_eq}
+    \lean{MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr}
+    \leanok
+    \uses{def:mpv_phase_class_data, lem:prepared_phase_equiv_dim_eq}
+    In a prepared family of positive-bond-dimension trace-preserving primitive
+    irreducible NTs, every CF summand assigned to a BNT representative has that
+    representative's bond dimension.
+\end{lemma}
+
+\begin{proof}\leanok
+    Apply Lemma~\ref{lem:prepared_phase_equiv_dim_eq} to each representative and
+    each assigned summand.
+\end{proof}
 
 \begin{lemma}[Prepared collapsed BNT total dimension]%
     \label{lem:prepared_collapsed_bnt_sector_decomp_total_dim}
@@ -839,17 +890,19 @@ overlap-decay theorem excludes unless the dimensions agree.
     \leanok
     % Source: canonical-form eq:II_CF1 and prop:char-BNT (Cirac2017MPDO_AnnPhys),
     % with the equalMPS dimension conclusion (Cirac2016MPDO_arXiv).
-    For prepared trace-preserving primitive irreducible blocks of positive bond
-    dimension with all copy weights nonzero, the phase-class quotient preserves
-    the total bond dimension: the collapsed sector decomposition has total bond
-    dimension equal to the sum of the original block dimensions.
+    For prepared trace-preserving primitive irreducible NTs of positive bond
+    dimension with all copy weights nonzero, grouping CF summands by BNT
+    representative preserves the total bond dimension: the collapsed sector
+    decomposition has total bond dimension equal to the sum of the original block
+    dimensions.
 \end{lemma}
 
-\begin{proof}\leanok\uses{thm:overlap_decay_rect_irr_tp}
-    Every block in a phase class shares the bond dimension of its representative,
-    by the equal-dimension fact above. Summing representative bond dimensions
-    over the copies in each phase class and using the regrouping identity
-    recovers the original direct-sum dimension.
+\begin{proof}\leanok\uses{lem:collapsed_bnt_sector_decomp_total_dim,
+        lem:prepared_phase_class_dim_eq}
+    Every assigned summand shares the bond dimension of its representative, by
+    the equal-dimension fact above. Summing representative bond dimensions over
+    the assigned copies and using the regrouping identity recovers the original
+    direct-sum dimension.
 \end{proof}
 
 Combining the after-blocking preparation with the normalized-weight construction

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -827,11 +827,22 @@ form by quotienting gauge-phase-equivalent blocks into sectors.
 \end{proof}
 
 The BNT construction preserves total bond dimension because CF summands assigned
-to the same BNT representative have equal bond dimension: if two
-trace-preserving primitive irreducible NTs of positive bond dimension have MPV
-families differing by a nonzero scalar power, the scalar has unit modulus, so
-the rectangular overlap has norm tending to $1$, which the rectangular
-overlap-decay theorem excludes unless the dimensions agree.
+to the same BNT representative have equal bond dimension. Indeed, suppose
+trace-preserving primitive irreducible NTs $X$ and $Y$ of positive bond dimension
+have MPV families related by
+$\ket{V^{(N)}(Y)}=\zeta^N\ket{V^{(N)}(X)}$ with $\zeta\neq0$. The normalized
+self-overlaps give
+\[
+    |\zeta|=1,
+    \qquad
+    |O_{YX}(N)|\to 1.
+\]
+If their bond dimensions differed, the rectangular overlap-decay theorem would
+give
+\[
+    O_{YX}(N)\to 0,
+\]
+a contradiction.
 
 \begin{lemma}[Total dimension after grouping by BNT representatives]%
     \label{lem:collapsed_bnt_sector_decomp_total_dim}
@@ -847,9 +858,19 @@ overlap-decay theorem excludes unless the dimensions agree.
 
 \begin{proof}\leanok
     The collapsed decomposition counts one representative dimension for each
-    assigned copy. By the same-dimension hypothesis, this is the corresponding
-    original CF summand dimension, and regrouping by representatives recovers
-    the original direct-sum dimension.
+    assigned copy. Let $e(j,q)$ denote the original CF summand assigned to the
+    $q$th copy of representative $P_j$. Since $(j,q)\mapsto e(j,q)$ reindexes
+    the original summands and each assigned summand has the representative's bond
+    dimension,
+    \[
+        \sum_{j=1}^{g}\sum_{q=1}^{r_j}\dim(P_j)
+        =
+        \sum_{j=1}^{g}\sum_{q=1}^{r_j}D_{e(j,q)}
+        =
+        \sum_{k=1}^{r}D_k.
+    \]
+    This is the equality between the collapsed total dimension and the original
+    direct-sum dimension.
 \end{proof}
 
 \begin{lemma}[Prepared phase-equivalent NTs have the same bond dimension]%
@@ -863,10 +884,20 @@ overlap-decay theorem excludes unless the dimensions agree.
 \end{lemma}
 
 \begin{proof}\leanok
-    The self-overlap normalization shows that the scalar relating the MPV
-    families has unit modulus. Hence the rectangular overlap between the two
-    NTs has norm tending to $1$. If the two bond dimensions differed, the
-    rectangular overlap-decay theorem would force that overlap to tend to $0$.
+    Choose $\zeta\neq0$ with
+    $\ket{V^{(N)}(Y)}=\zeta^N\ket{V^{(N)}(X)}$ for every length~$N$. The
+    normalized self-overlaps give
+    \[
+        |\zeta|=1,
+        \qquad
+        |O_{YX}(N)|\to 1.
+    \]
+    If the two bond dimensions differed, the rectangular overlap-decay theorem
+    would force
+    \[
+        O_{YX}(N)\to 0,
+    \]
+    contradicting the preceding limit.
 \end{proof}
 
 \begin{lemma}[Prepared BNT representative classes preserve bond dimension]%
@@ -900,8 +931,9 @@ overlap-decay theorem excludes unless the dimensions agree.
 \begin{proof}\leanok\uses{lem:collapsed_bnt_sector_decomp_total_dim,
         lem:prepared_phase_class_dim_eq}
     Every assigned summand shares the bond dimension of its representative, by
-    the equal-dimension fact above. Summing representative bond dimensions over
-    the assigned copies and using the regrouping identity recovers the original
+    the equal-dimension fact above. The displayed regrouping identity in
+    Lemma~\ref{lem:collapsed_bnt_sector_decomp_total_dim} then identifies the
+    collapsed sum over pairs $(j,q)$ with $\sum_{k=1}^{r}D_k$, the original
     direct-sum dimension.
 \end{proof}
 


### PR DESCRIPTION
### Motivation

- Follow-up from #2269 (*blueprint(ch:bnt): rewrite the Basis of Normal Tensors chapter to the house style*), which folded three distinct lemmas into a single `\lean{...}` tag under `lem:prepared_collapsed_bnt_sector_decomp_total_dim`; the bundled entry listed declarations whose statements were not described by the umbrella lemma, breaking blueprint completeness criterion A.1 (see #2274).
- Restores reader-facing blueprint statements for three BNT dimension results in `blueprint/src/chapter/ch10_bnt.tex`, sourced from arXiv:1606.00608, §II.C.

### Description

- Modified `blueprint/src/chapter/ch10_bnt.tex`: restored three individual `\begin{lemma}...\leanok` entries, each with its own `\lean{...}` tag:
  - `MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim` — total bond dimension after grouping CF summands by BNT representatives equals the sum of block dimensions.
  - `MPSTensor.dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr` — two TP primitive irreducible blocks that are MPV-phase equivalent have equal bond dimensions.
  - `MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr` — every NT in an MPV phase class has the bond dimension of its BNT representative.
- Rewrote surrounding prose to use CF summands, NTs, and BNT representatives vocabulary from arXiv:1606.00608.
- Updated the proof of `lem:prepared_collapsed_bnt_sector_decomp_total_dim` to cite the restored entries via `\uses` rather than inlining the argument.

### Testing

- `git diff --check` — passes.
- `python3 scripts/blueprint_lean_sync.py --root .` — reports only the known unrelated PEPS `blockingData` reference and literal `...` tag.
- `leanblueprint web` — completes with the repository's usual plasTeX and missing-bibliography warnings.
- `leanblueprint checkdecls` not run locally (no generated `blueprint/lean_decls` file in the worktree); the sync script verifies referenced Lean declarations. Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
Closes #2274

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the blueprint TeX; no Lean or runtime code is modified.
> 
> **Overview**
> **Restores three standalone blueprint lemmas** in `ch10_bnt.tex` that were previously folded into `lem:prepared_collapsed_bnt_sector_decomp_total_dim`, each with its own `\lean{...}` tag: total dimension after grouping by BNT representatives (`collapsedBntSectorDecomp_totalDim_eq_sum_dim`), equal bond dimension for MPV phase-equivalent prepared NTs (`dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr`), and the same dimension on every CF summand in a BNT representative class (`mpvPhaseClassData_dim_eq_of_tp_primitive_irr`).
> 
> **Reframes the surrounding prose** from "phase-class quotient" language to **CF summands, NTs, and BNT representatives**, and **rewires** `lem:prepared_collapsed_bnt_sector_decomp_total_dim` so its proof cites the new lemmas via `\uses` instead of inlining the overlap argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8951adc7559e11ce208a10d9ae162cbcff043349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TeX-only blueprint documentation; no Lean or runtime behavior changes.
> 
> **Overview**
> **Restores three standalone blueprint lemmas** in `ch10_bnt.tex` that had been merged into `lem:prepared_collapsed_bnt_sector_decomp_total_dim`, so each Lean declaration again has its own `\lean{...}` / `\leanok` entry: total dimension after grouping CF summands by BNT representatives (`collapsedBntSectorDecomp_totalDim_eq_sum_dim`), equal bond dimension for MPV phase-equivalent prepared NTs (`dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr`), and representative bond dimension on every summand in a class (`mpvPhaseClassData_dim_eq_of_tp_primitive_irr`).
> 
> **Reframes the narrative** from “phase-class quotient” wording to **CF summands, NTs, and BNT representatives** (per arXiv:1606.00608 §II.C), keeps the overlap/decay argument in prose before the lemmas, and **shortens** `lem:prepared_collapsed_bnt_sector_decomp_total_dim` so its proof cites the restored lemmas via `\uses` instead of inlining the dimension argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b17b262b712add29d7f819cef14319a8b47d0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->