### PR TITLE
style(blueprint): normalize spacing and source-citation references

### DIFF
--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -240,7 +240,7 @@ boundary conditions (PBC).
     nonzero scalar $c_N \in \C$ such that
     $\ket{V^{(N)}(A)} = c_N \ket{V^{(N)}(B)}$.
     This is the projective reading of the proportionality hypothesis in
-    \cite[Theorem~II.1]{Cirac2016MPDO_arXiv}.
+    \cite[Theorem~2.10]{Cirac2016MPDO_arXiv}.
     % Maintainer note: projective reading documented in
     % docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex.
 \end{definition}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -815,8 +815,8 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{proof}
     \leanok
     \uses{def:block_diagonal_tensor, def:injective, thm:propblockinj_abstract}
-    This is the equal-MPV blockwise equality of \cite[Appendix~A]{Cirac2016MPDO_arXiv}, using the
-    finite criterion from Theorem~\ref{thm:propblockinj_abstract}.
+    This is Lemma~L of \cite[Appendix~A]{Cirac2016MPDO_arXiv}, using the finite
+    criterion from Theorem~\ref{thm:propblockinj_abstract}.
     Expanding the hypothesis over a word of length~$L+1$ beginning with the
     fixed site and folding each block contribution into a trace pairing
     against the corresponding first-site insertion tensor yields, upon taking the

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -896,7 +896,7 @@ retract.
 \begin{proof}\leanok
     Apply the definition at blocked size $n = 1$.
     If $E_1 = S_1 \circ T_1$ and $T_1 \circ S_1 = \operatorname{id}$, then
-    $$E_1^2 = S_1 T_1 S_1 T_1 = S_1 (T_1 S_1) T_1 = S_1 T_1 = E_1$$.
+    $$E_1^2 = S_1 T_1 S_1 T_1 = S_1 (T_1 S_1) T_1 = S_1 T_1 = E_1.$$
     Since $E_1$ is the original transfer map, this is exactly the MPDO RFP
     condition.
 \end{proof}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -143,9 +143,9 @@ legs cyclically and taking the resulting trace.
     \[
         \E_M \circ \E_M = \E_M.
     \]
-    This is the mixed-state analogue of the renormalization fixed-point
+    This is the mixed-state analog of the renormalization fixed-point
     condition for MPS tensors; see \cite[definition of MPDO zero correlation
-        length, lines~736--741]{Cirac2017MPDO_AnnPhys} and
+        length, lines~736--741]{Cirac2016MPDO_arXiv} and
     \cite[Section~II.E.2, lines~937--939]{Cirac2021Matrix}.
 \end{definition}
 
@@ -176,7 +176,7 @@ legs cyclically and taking the resulting trace.
     \[
         \rho^{(N)}(M) \ge 0
     \]
-    This is the global positivity condition of \cite[Section~4.1]{Cirac2017MPDO_AnnPhys}.
+    This is the global positivity condition of \cite[Section~4]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{definition}[LPDO]\label{def:lpdo}
@@ -191,12 +191,12 @@ legs cyclically and taking the resulting trace.
     for all physical indices $i,j$,
     \[
         M^{ij}
-        = \Bigl(\sum_{k=0}^{d_K-1} A^{(i,k)} \otimes \overline{A^{(j,k)}}\Bigr)_{e,e}
+        = \left(\sum_{k=0}^{d_K-1} A^{(i,k)} \otimes \overline{A^{(j,k)}}\right)_{e,e}
     \]
     where $\otimes$ denotes the Kronecker product, $\overline{(\cdot)}$
     denotes entrywise complex conjugation, and $(\cdot)_{e,e}$ denotes
     reindexing along $e$ back to $\{0, \ldots, D - 1\}$.
-    See \cite[Section~4.3]{Cirac2017MPDO_AnnPhys}.
+    See \cite[Section~4.3]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[LPDOs are MPDOs]\label{thm:lpdo_is_mpdo}
@@ -215,7 +215,7 @@ legs cyclically and taking the resulting trace.
     bond-space identification $e$:
     \[
         M^{\sigma_1 \tau_1} \cdots M^{\sigma_N \tau_N}
-        = \bigl(\sum_{\kappa} P_\kappa \otimes \overline{Q_\kappa}\bigr)
+        = (\sum_{\kappa} P_\kappa \otimes \overline{Q_\kappa})
         \big|_{e},
     \]
     where $P_\kappa = A^{(\sigma_1,\kappa_1)} \cdots A^{(\sigma_N,\kappa_N)}$
@@ -224,8 +224,8 @@ legs cyclically and taking the resulting trace.
     we apply $\tr(X \otimes Y) = \tr(X)\tr(Y)$ to obtain
     \[
         \rho^{(N)}(M)_{\sigma,\tau}
-        = \sum_\kappa \tr(P_\kappa)\,\overline{\tr(Q_\kappa)}
-        = \sum_\kappa \psi_\kappa(\sigma)\,\overline{\psi_\kappa(\tau)},
+        = \sum_\kappa \tr(P_\kappa) \overline{\tr(Q_\kappa)}
+        = \sum_\kappa \psi_\kappa(\sigma) \overline{\psi_\kappa(\tau)},
     \]
     where $\psi_\kappa(\sigma) = \tr(P_\kappa)$.
     Hence $\rho^{(N)}(M) = \sum_\kappa \ketbra{\psi_\kappa}{\psi_\kappa} \ge 0$.
@@ -255,7 +255,7 @@ legs cyclically and taking the resulting trace.
     witness whose purifying MPS tensor is a pure-state renormalization
     fixed point.
     This is \cite[definition of purification RFP, lines~756--759]
-    {Cirac2017MPDO_AnnPhys}.
+    {Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{remark}[PRFP does not imply MPO ZCL]\label{rem:prfp_not_implies_zcl}
@@ -395,7 +395,7 @@ legs cyclically and taking the resulting trace.
 
 \section{Simple local structure from SAL and ZCL}
 
-For the simple MPDO case in Appendix~C.2 of \cite{Cirac2017MPDO_AnnPhys},
+For the simple MPDO case in Appendix~C.2 of \cite{Cirac2016MPDO_arXiv},
 the strong-area-law hypothesis is used locally through the equality case of
 strong subadditivity for a normalized three-site reduced state.
 
@@ -409,7 +409,7 @@ strong subadditivity for a normalized three-site reduced state.
     equality in strong subadditivity. Concretely, after a unitary change of
     basis on $B$, one has a finite direct-sum decomposition
     \[
-        B = \bigoplus_k \bigl(b_1^{(k)} \otimes b_2^{(k)}\bigr)
+        B = \bigoplus_k (b_1^{(k)} \otimes b_2^{(k)})
     \]
     such that
     \[
@@ -522,8 +522,8 @@ strong subadditivity for a normalized three-site reduced state.
     sector-reduced states on the neighboring bond spaces:
     \[
         \eta_{k,h}
-        := \tr_C\bigl(\rho_{b_2 C}^{(k)}\bigr)
-        \otimes \tr_A\bigl(\rho_{A b_1}^{(h)}\bigr).
+        := \tr_C(\rho_{b_2 C}^{(k)})
+        \otimes \tr_A(\rho_{A b_1}^{(h)}).
     \]
     Positive semidefiniteness of each $\eta_{k,h}$ follows from the fact
     that partial traces preserve positivity and that positive
@@ -569,7 +569,7 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    The trace of a positive semidefinite neighboring operator is nonnegative in
+    The trace of a positive semidefinite neighboring operator is non-negative in
     the complex order. Taking real parts gives the stated entrywise
     nonnegativity.
 \end{proof}
@@ -587,7 +587,7 @@ strong subadditivity for a normalized three-site reduced state.
     constant trace powers to such a factorization.
 
     This conditional implication is not a globally provable theorem. As a
-    universal statement over primitive nonnegative matrices it is false; a
+    universal statement over primitive non-negative matrices it is false; a
     concrete $3 \times 3$ counterexample appears in the archive. The
     corrected criterion proved here adds positive semidefiniteness and trace
     normalization, which provide the diagonalizability needed to turn the
@@ -630,7 +630,7 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{def:matrix_trace_rankone_predicates, thm:matrix_hermitian_trace_square_eigenvalues}
     The spectral theorem diagonalizes the positive semidefinite matrix with
-    nonnegative real eigenvalues. The trace gives that their sum is $1$, while
+    non-negative real eigenvalues. The trace gives that their sum is $1$, while
     the second trace moment gives that the sum of their squares is also $1$.
     Hence exactly one eigenvalue is equal to $1$ and all others vanish, so the
     diagonal form is rank one. Unitary conjugation preserves the existence of an
@@ -645,7 +645,7 @@ strong subadditivity for a normalized three-site reduced state.
     Let $T$ be a finite real square matrix. Assume that $T$ is primitive,
     that $\tr(T) = 1$, and that every positive power of $T$ has the same trace
     as $T$. If one further supplies the Perron--Frobenius hypothesis that
-    this particular primitive nonnegative matrix with constant trace powers is
+    this particular primitive non-negative matrix with constant trace powers is
     rank one, then
     \[
         T = a b^\top
@@ -711,7 +711,7 @@ strong subadditivity for a normalized three-site reduced state.
     positive scalar.
     This is the flattened form of the decomposition
     $\bigoplus_\alpha \mu_\alpha \otimes M_\alpha$
-    from \cite[Section~4.4]{Cirac2017MPDO_AnnPhys}.
+    from \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{remark}[Finite witnesses for block-injective canonical form]%
@@ -767,7 +767,7 @@ strong subadditivity for a normalized three-site reduced state.
     blocking length makes the entrywise family linearly independent.
 
     The block-injectivity proposition in
-    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} gives a concrete sufficient
+    \cite[lines~340--345]{Cirac2016MPDO_arXiv} gives a concrete sufficient
     criterion for the spanning condition: after a common blocking length each
     block is block-injective, and after a further finite blocking length one
     can form linear combinations of word evaluations which equal the identity
@@ -783,7 +783,7 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{rem:word_tuple_span_top}
     If a block family admits the finite-length data described in
     the block-injectivity proposition of
-    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys}, then it is in
+    \cite[lines~340--345]{Cirac2016MPDO_arXiv}, then it is in
     block-injective canonical form.
 \end{theorem}
 
@@ -793,7 +793,7 @@ strong subadditivity for a normalized three-site reduced state.
     This is the direct implication from the finite-length data to the
     finite-length trace-separation statement. What remains open in the full
     block-injectivity proposition of
-    \cite[lines~340--345]{Cirac2017MPDO_AnnPhys} is the derivation of this
+    \cite[lines~340--345]{Cirac2016MPDO_arXiv} is the derivation of this
     finite witness from separated canonical-form / BNT data.
 \end{proof}
 
@@ -815,7 +815,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{proof}
     \leanok
     \uses{def:block_diagonal_tensor, def:injective, thm:propblockinj_abstract}
-    This is Lemma~L from \cite[Appendix~A]{Cirac2017MPDO_AnnPhys}, using the
+    This is the equal-MPV blockwise equality of \cite[Appendix~A]{Cirac2016MPDO_arXiv}, using the
     finite criterion from Theorem~\ref{thm:propblockinj_abstract}.
     Expanding the hypothesis over a word of length~$L+1$ beginning with the
     fixed site and folding each block contribution into a trace pairing
@@ -850,7 +850,7 @@ strong subadditivity for a normalized three-site reduced state.
 
 \section{Fusion isometries}
 
-Following \cite[Section~4.5]{Cirac2017MPDO_AnnPhys}, the next definitions describe
+Following \cite[Section~4.5]{Cirac2016MPDO_arXiv}, the next definitions describe
 the transfer-map content of the fusion-isometry picture.
 For each blocked size $n \ge 1$, the doubled-index blocked tensor of an MPO
 has a blocked transfer map $E_n$ acting on bond-space matrices, and the
@@ -889,14 +889,14 @@ retract.
     \lean{MPOTensor.FusionIsometryData.isRFP, MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
-    A one-site fusion-isometry datum implies the MPDO RFP condition.  Hence the
+    A one-site fusion-isometry datum implies the MPDO RFP condition. Hence the
     fusion-isometry formulation, which supplies such data at every positive
     blocked size, implies the same condition.
 \end{theorem}
 \begin{proof}\leanok
     Apply the definition at blocked size $n = 1$.
     If $E_1 = S_1 \circ T_1$ and $T_1 \circ S_1 = \operatorname{id}$, then
-    $$E_1^2 = S_1 T_1 S_1 T_1 = S_1 (T_1 S_1) T_1 = S_1 T_1 = E_1.$$
+    $$E_1^2 = S_1 T_1 S_1 T_1 = S_1 (T_1 S_1) T_1 = S_1 T_1 = E_1$$.
     Since $E_1$ is the original transfer map, this is exactly the MPDO RFP
     condition.
 \end{proof}
@@ -983,7 +983,7 @@ retract.
     positive blocking size coincides with the fixed-point algebra of the adjoint
     blocked transfer map. This is a nontrivial algebraic condition, but it is still
     weaker than the full coefficient formulation of
-    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}; that formulation also
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; that formulation also
     includes the coefficient family $c_{\alpha,\beta,\gamma}^{(L)}$.
 \end{definition}
 
@@ -1039,7 +1039,7 @@ retract.
 \end{proof}
 
 This does not give the full converse direction of
-\cite[Theorem~IV.13]{Cirac2017MPDO_AnnPhys}: the compatibility condition above
+\cite[Theorem~4.14]{Cirac2016MPDO_arXiv}: the compatibility condition above
 only sees stabilized adjoint fixed-point algebras, not the coefficient/BNT data.
 In particular, Theorem~IV.13(ii) also requires the special diagonal matrices
 $\chi_{\alpha,\beta,\gamma}$. The coefficient data attached to the algebra tower are:
@@ -1158,7 +1158,7 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
         = E_1^{\dagger}E_n^{\dagger}X
         = E_1^{\dagger}(\lambda^n X)
         = \lambda^n E_1^{\dagger}X
-        = \lambda^{n+1}X .
+        = \lambda^{n+1}X.
     \]
 \end{proof}
 
@@ -1212,16 +1212,16 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
 \begin{remark}[Why algebra data do not imply fusion data]%
     \label{rem:mpdo_algebra_to_fusion_gap}
     \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion, thm:newton_girard}
-    Write $E=E_1$ for the one-site transfer map.  The present algebra predicate
+    Write $E=E_1$ for the one-site transfer map. The present algebra predicate
     gives, for every $n>0$,
     \[
-        \operatorname{Fix}\bigl((E^n)^\dagger\bigr)
+        \operatorname{Fix}((E^n)^\dagger)
         = \operatorname{Fix}(E^\dagger).
     \]
     Hence a vector $X$ with $E^\dagger X=\lambda X$ and $\lambda^n=1$ lies in
     $\operatorname{Fix}(E^\dagger)$, so $(\lambda-1)X=0$ and $\lambda=1$ by
-    Theorem~\ref{thm:mpdo_algebra_root_of_unity_eigenvalue}.  It does not imply
-    $E^2=E$.  For instance, if $\Pi_{\mathrm{diag}}$ is the projection onto
+    Theorem~\ref{thm:mpdo_algebra_root_of_unity_eigenvalue}. It does not imply
+    $E^2=E$. For instance, if $\Pi_{\mathrm{diag}}$ is the projection onto
     diagonal matrices and $0<\varepsilon<1$, set
     \[
         E(X)
@@ -1232,57 +1232,57 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \[
         E^n(X)
         = \Pi_{\mathrm{diag}}(X)
-          + \varepsilon^n\bigl(X-\Pi_{\mathrm{diag}}(X)\bigr),
+        + \varepsilon^n(X-\Pi_{\mathrm{diag}}(X)),
         \qquad
         E^2-E
         = (\varepsilon^2-\varepsilon)
-          (\mathrm{id}-\Pi_{\mathrm{diag}}).
+        (\mathrm{id}-\Pi_{\mathrm{diag}}).
     \]
     The fixed-point algebra is diagonal for every $n>0$, but $E^2\ne E$.
 
     The missing source step is the coefficient argument in
-    \cite[Appendix~C.4]{Cirac2017MPDO_AnnPhys}.  One needs the same-length
+    \cite[Appendix~C.4]{Cirac2016MPDO_arXiv}. One needs the same-length
     product law
     \[
         O_L(M_\alpha)O_L(M_\beta)
         =
         \sum_\gamma
-          \tr(\chi_{\alpha,\beta,\gamma}^{\,L})
-          O_L(M_\gamma)
+        \tr(\chi_{\alpha,\beta,\gamma}^{\,L})
+        O_L(M_\gamma)
     \]
     and the length-one idempotent trace identity
     \[
         m_\gamma
         =
         \sum_{\alpha,\beta}
-          \tr(\chi_{\alpha,\beta,\gamma})
-          m_\alpha m_\beta.
+        \tr(\chi_{\alpha,\beta,\gamma})
+        m_\alpha m_\beta.
     \]
-    The proof of \cite[Theorem~IV.13]{Cirac2017MPDO_AnnPhys} uses these
+    The proof of \cite[Theorem~4.14]{Cirac2016MPDO_arXiv} uses these
     identities, positivity, and the simple-matrix lemma
-    \cite[lines~1155--1163]{Cirac2017MPDO_AnnPhys} to give
+    \cite[lines~1155--1163]{Cirac2016MPDO_arXiv} to give
     \[
         \{\nu_{\gamma,k}\}_k
         =
         \{\mu_{\alpha,k_1}\mu_{\beta,k_2}
-          \chi_{\alpha,\beta,\gamma,k_3}\}_{\alpha,\beta,k_1,k_2,k_3},
+        \chi_{\alpha,\beta,\gamma,k_3}\}_{\alpha,\beta,k_1,k_2,k_3},
         \qquad
         \tr(\nu_\gamma)=m_\gamma.
     \]
-    The reconstruction maps in \cite[lines~2065--2085]{Cirac2017MPDO_AnnPhys}
+    The reconstruction maps in \cite[lines~2065--2085]{Cirac2016MPDO_arXiv}
     then use
     \[
-        \widetilde R_2\Bigl(\bigoplus_\gamma X_\gamma\Bigr)
-          = \bigoplus_\gamma \frac{\nu_\gamma}{m_\gamma}\otimes X_\gamma,
+        \widetilde R_2\left(\bigoplus_\gamma X_\gamma\right)
+        = \bigoplus_\gamma \frac{\nu_\gamma}{m_\gamma}\otimes X_\gamma,
         \qquad
-        \widetilde R_1\Bigl(\bigoplus_\gamma X_\gamma\Bigr)
-          = \bigoplus_\gamma \frac{\mu_\gamma}{m_\gamma}\otimes X_\gamma .
+        \widetilde R_1\left(\bigoplus_\gamma X_\gamma\right)
+        = \bigoplus_\gamma \frac{\mu_\gamma}{m_\gamma}\otimes X_\gamma.
     \]
     Thus $\tr(\nu_\gamma)=m_\gamma$ and the defining equality
     $m_\gamma=\tr(\mu_\gamma)$ normalize the factors
     $\nu_\gamma/m_\gamma$ and $\mu_\gamma/m_\gamma$, respectively, in
     $T=\widetilde R_2\widetilde T R_1$ and
-    $S=\widetilde R_1\widetilde S R_2$.  The scalar
+    $S=\widetilde R_1\widetilde S R_2$. The scalar
     Newton--Girard power-sum identity needed to obtain the trace-power form is
     already available as
     Theorem~\ref{thm:newton_girard}; what remains is the MPDO construction of
@@ -1292,7 +1292,7 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
 \subsection{Diagonal \texorpdfstring{$\chi$}{chi}-matrices and the trace-power formula}
 
 The following statements isolate the form of
-\cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}: the structure coefficients
+\cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}: the structure coefficients
 of the length-$L$ operator algebra are trace-powers of positive diagonal
 matrices $\chi_{\alpha,\beta,\gamma}$. They state the coefficient identity and
 the elementary trace-power identity for diagonal matrices.
@@ -1304,7 +1304,7 @@ the elementary trace-power identity for diagonal matrices.
     A family of diagonal complex matrices $\chi_{\alpha,\beta,\gamma}$ indexed
     by ordered triples drawn from a common index type, each of a specified
     size. This is the matrix $\chi_{\alpha,\beta,\gamma}$ of
-    \cite[Theorem~IV.13(ii)]{Cirac2017MPDO_AnnPhys}.
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[Trace of $\chi^L$ equals the sum of $L$-th powers of entries]%
@@ -1315,7 +1315,7 @@ the elementary trace-power identity for diagonal matrices.
     For every triple $(\alpha, \beta, \gamma)$, if $\chi_{\alpha,\beta,\gamma}$
     has size $r_{\alpha,\beta,\gamma}$, then for every $L \ge 0$,
     \[
-        \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr)
+        \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})
         = \sum_{k=1}^{r_{\alpha,\beta,\gamma}}
         \chi_{\alpha,\beta,\gamma,k}^{L},
     \]
@@ -1336,14 +1336,14 @@ the elementary trace-power identity for diagonal matrices.
     pair $(c, \chi)$ is said to be in \emph{trace-power form} when
     \[
         c^{(L)}_{\alpha,\beta,\gamma}
-        = \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr)
+        = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})
         = \sum_{k=1}^{r_{\alpha,\beta,\gamma}}
         \chi_{\alpha,\beta,\gamma,k}^{L}
     \]
     for every $L \ge 0$ and every triple $(\alpha, \beta, \gamma)$, where
     $r_{\alpha,\beta,\gamma}$ is the size of $\chi_{\alpha,\beta,\gamma}$. This
-    is the formal analogue of the target identity of
-    \cite[Theorem~IV.13~(ii)]{Cirac2017MPDO_AnnPhys}; the existential
+    is the formal analog of the target identity of
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; the existential
     version---``there exists $\chi$ for which $(c,\chi)$ has trace-power
     form''---is obtained by quantifying over $\chi$.
 \end{definition}
@@ -1357,16 +1357,16 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     The same-length coefficient system
     $c^{(L)}_{\alpha,\beta,\gamma}$ from Theorem~IV.13(ii), indexed by
-    fixed BNT labels $\alpha,\beta,\gamma$.  The coefficient is attached to
+    fixed BNT labels $\alpha,\beta,\gamma$. The coefficient is attached to
     the length-$L$ product
     $O_L(M_\alpha)O_L(M_\beta)$, not to the blocked-basis multiplication
     $\mathcal A_n\times\mathcal A_n\to\mathcal A_{2n}$.
     When a diagonal $\chi$-family has already been constructed, it also
     canonically determines the coefficient family
     $c^{(L)}_{\alpha,\beta,\gamma}
-    = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})
-    = \sum_r\chi_{\alpha,\beta,\gamma,r}^{\,L}$, as in
-    \cite[Appendix~C.4]{Cirac2017MPDO_AnnPhys}.
+        = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})
+        = \sum_r\chi_{\alpha,\beta,\gamma,r}^{\,L}$, as in
+    \cite[Appendix~C.4]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{definition}[BNT-label operator family]%
@@ -1458,7 +1458,7 @@ the elementary trace-power identity for diagonal matrices.
     The BNT-label assignment consists, for every positive blocked length $n$,
     of a source label map $\sigma_n$ from the chosen basis of
     $\mathcal A_n$ and a target label map $\tau_n$ from the chosen basis of
-    $\mathcal A_{2n}$ to the fixed BNT labels.  It also gives the combined
+    $\mathcal A_{2n}$ to the fixed BNT labels. It also gives the combined
     label map $\sigma_n \sqcup \tau_n$ on the disjoint union of these two
     blocked bases.
 \end{definition}
@@ -1509,7 +1509,7 @@ the elementary trace-power identity for diagonal matrices.
     compatible when, for every positive length $L$,
     \[
         c^{(L)}_{\alpha,\beta,\gamma}
-        = \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{L}\bigr).
+        = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L}).
     \]
     The same matrix $\chi_{\alpha,\beta,\gamma}$ is used for all positive
     $L$.
@@ -1517,7 +1517,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[BNT-label coefficient as a positive-length trace power]%
     \label{thm:mpdo_bnt_label_chi_eq_trace_matrix_pow}
-\lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.eq_trace_matrix_pow}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.eq_trace_matrix_pow}
     \leanok
     \uses{def:mpdo_bnt_label_positive_length_chi_trace_power_form,
         thm:mpdo_trace_matrix_pow}
@@ -1532,7 +1532,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[Canonical BNT coefficients from a $\chi$-family]%
     \label{thm:mpdo_bnt_label_of_chi_positive_length_trace_power}
-\lean{MPOTensor.BNTLabelCoefficientFamily.ofChi_hasPositiveLengthChiTracePowerForm}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.ofChi_hasPositiveLengthChiTracePowerForm}
     \leanok
     \uses{def:mpdo_bnt_label_coefficient_family,
         def:mpdo_bnt_label_positive_length_chi_trace_power_form}
@@ -1555,7 +1555,7 @@ the elementary trace-power identity for diagonal matrices.
     A positive BNT-label $\chi$ witness consists of a length-independent
     diagonal $\chi_{\alpha,\beta,\gamma}$-family, positivity of every
     diagonal entry, and the positive-length trace-power identity for the
-    BNT-label coefficients.  This is the coefficient statement of
+    BNT-label coefficients. This is the coefficient statement of
     Theorem~IV.13(ii); constructing the witness from an MPDO tensor and
     comparing it to blocked bases remain separate obligations.
     If the coefficient family is chosen canonically from the same
@@ -1571,7 +1571,7 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_chi_eq_trace_matrix_pow}
     A positive BNT-label $\chi$ witness gives, for every $L>0$, the formula
     $c^{(L)}_{\alpha,\beta,\gamma}
-    =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$.
+        =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace reformulation of the positive-length trace-power identity
@@ -1590,8 +1590,7 @@ the elementary trace-power identity for diagonal matrices.
     \[
         O_L(M_\alpha)O_L(M_\beta)
         = \sum_\gamma
-        \operatorname{tr}\bigl(
-        \chi_{\alpha,\beta,\gamma}^{\,L}
+        \operatorname{tr}\bigl(    \chi_{\alpha,\beta,\gamma}^{\,L}
         \bigr) O_L(M_\gamma).
     \]
 \end{theorem}
@@ -1602,7 +1601,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[Same-length BNT product for canonical chi coefficients]%
     \label{thm:mpdo_bnt_label_same_length_product_eq_sum_of_chi_trace_pow}
-\lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum_ofChi_trace_pow}
+    \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum_ofChi_trace_pow}
     \leanok
     \uses{thm:mpdo_bnt_label_same_length_product_eq_sum,
         def:mpdo_bnt_label_coefficient_family}
@@ -1612,8 +1611,7 @@ the elementary trace-power identity for diagonal matrices.
     \[
         O_L(M_\alpha)O_L(M_\beta)
         = \sum_\gamma
-        \operatorname{tr}\bigl(
-        \chi_{\alpha,\beta,\gamma}^{\,L}
+        \operatorname{tr}\bigl(    \chi_{\alpha,\beta,\gamma}^{\,L}
         \bigr) O_L(M_\gamma).
     \]
 \end{theorem}
@@ -1635,7 +1633,7 @@ the elementary trace-power identity for diagonal matrices.
         m_\gamma =
         \sum_{\alpha,\beta}
         \operatorname{tr}(\chi_{\alpha,\beta,\gamma})
-        m_\alpha m_\beta .
+        m_\alpha m_\beta.
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -1645,7 +1643,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{theorem}[BNT idempotent coefficients for canonical chi coefficients]%
     \label{thm:mpdo_bnt_label_idempotent_eq_sum_of_chi_trace}
-\lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum_ofChi_trace}
+    \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum_ofChi_trace}
     \leanok
     \uses{thm:mpdo_bnt_label_idempotent_coefficient_eq_sum,
         def:mpdo_bnt_label_coefficient_family}
@@ -1656,7 +1654,7 @@ the elementary trace-power identity for diagonal matrices.
         m_\gamma =
         \sum_{\alpha,\beta}
         \operatorname{tr}(\chi_{\alpha,\beta,\gamma})
-        m_\alpha m_\beta .
+        m_\alpha m_\beta.
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -1683,8 +1681,7 @@ the elementary trace-power identity for diagonal matrices.
     \[
         c^{(n)}_{i,j,k}
         = \operatorname{tr}
-        \bigl(
-        \chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}^{\,n}
+        \bigl(    \chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}^{\,n}
         \bigr).
     \]
 \end{theorem}
@@ -1705,8 +1702,8 @@ the elementary trace-power identity for diagonal matrices.
     A dependent diagonal matrix family indexed by the blocked multiplication
     triples $(n,i,j,k)$, where $i$ and $j$ label basis elements of
     $\mathcal{A}_n$ and $k$ labels a basis element of $\mathcal{A}_{2n}$.
-    This is a blocked-basis analogue of the uniform BNT-label family in
-    \cite[Theorem~IV.13(ii)]{Cirac2017MPDO_AnnPhys}; the remaining uniformity
+    This is a blocked-basis analog of the uniform BNT-label family in
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; the remaining uniformity
     gap is recorded in
     \path{docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex}.
 \end{definition}
@@ -1769,9 +1766,9 @@ the elementary trace-power identity for diagonal matrices.
     A positive blocked $\chi$ trace-power witness consists of a blocked
     $\chi$ family, positivity of all its diagonal entries, and the
     positive-length trace-power identity for the blocked multiplication
-    coefficients. This is the blocked-basis analogue of the positive
+    coefficients. This is the blocked-basis analog of the positive
     diagonal matrices in
-    \cite[Theorem~IV.13(ii)]{Cirac2017MPDO_AnnPhys}; the uniform BNT-label gap
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; the uniform BNT-label gap
     is recorded in
     \path{docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex}.
 \end{definition}
@@ -1793,7 +1790,7 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_blocked_basis_coefficient_eq}
     Suppose that the chosen blocked-basis coefficients are compared with a
     fixed BNT-label coefficient system, and that this BNT-label system has a
-    positive length-independent $\chi$-witness.  Then the chosen blocked
+    positive length-independent $\chi$-witness. Then the chosen blocked
     bases carry a positive blocked $\chi$ trace-power witness.
     The construction is obtained by pulling back the BNT-label
     $\chi_{\alpha,\beta,\gamma}$-matrices along the source and target label
@@ -1804,7 +1801,7 @@ the elementary trace-power identity for diagonal matrices.
 \end{theorem}
 \begin{proof}\leanok
     Reindex the positive BNT-label $\chi$-family along the blocked-basis
-    label map.  Positivity is preserved by reindexing, and the trace-power
+    label map. Positivity is preserved by reindexing, and the trace-power
     identity follows by substituting the blocked-basis comparison into the
     BNT-label trace-power formula.
 \end{proof}
@@ -1838,7 +1835,7 @@ the elementary trace-power identity for diagonal matrices.
     system, the same-length BNT operator family and product identity, the trace
     scalars and idempotent condition, the positive length-independent
     $\chi$-witness, and the comparison with the chosen blocked bases.
-    They also determine the pulled-back blocked-basis $\chi$-family.  These
+    They also determine the pulled-back blocked-basis $\chi$-family. These
     data are the source-side hypotheses from which the blocked-basis
     consequences below are derived.
     In the source-side special case where the coefficient family is
@@ -1859,8 +1856,8 @@ the elementary trace-power identity for diagonal matrices.
     BNT-label theorem data give the same-length product equation
     \[
         O_L(M_\alpha)O_L(M_\beta)
-          = \sum_\gamma
-              c^{(L)}_{\alpha,\beta,\gamma} O_L(M_\gamma)
+        = \sum_\gamma
+        c^{(L)}_{\alpha,\beta,\gamma} O_L(M_\gamma)
     \]
     for every positive length $L$.
 \end{theorem}
@@ -1877,8 +1874,8 @@ the elementary trace-power identity for diagonal matrices.
     BNT-label theorem data give the idempotent scalar equation
     \[
         m_\gamma =
-          \sum_{\alpha,\beta}
-            c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta .
+        \sum_{\alpha,\beta}
+        c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta.
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -1896,7 +1893,7 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_data_coeff_eq_trace_pow}
     BNT-label theorem data give the comparison between the blocked-basis
     coefficients and the BNT-label coefficients through the source and target
-    label maps.  Since the positive-length coefficients agree with the
+    label maps. Since the positive-length coefficients agree with the
     canonical coefficient family determined by the same $\chi$-matrices, the
     comparison can also be written with those canonical coefficients.
 \end{theorem}
@@ -1914,8 +1911,8 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_positive_bnt_label_chi_eq_trace_matrix_pow}
     BNT-label theorem data give the coefficient identity
     $c^{(L)}_{\alpha,\beta,\gamma}
-      = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$
-    for every positive length $L$.  Equivalently, at every positive length, the
+        = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$
+    for every positive length $L$. Equivalently, at every positive length, the
     coefficient family agrees with the canonical coefficient family determined
     by the same $\chi$-matrices.
 \end{theorem}
@@ -2091,7 +2088,7 @@ the elementary trace-power identity for diagonal matrices.
     An existential BNT-label theorem witness consists of the finite BNT-label
     type, the same-length operator spaces, their algebraic structure, and the
     corresponding BNT-label theorem data, including the pulled-back
-    blocked-basis $\chi$-family.  The construction of such a witness from an
+    blocked-basis $\chi$-family. The construction of such a witness from an
     MPDO tensor is the outstanding step toward Theorem~IV.13(ii).
     The proposition-level form is the nonemptiness of this witness type.
     In the source-side special case where the coefficients are canonically
@@ -2116,12 +2113,12 @@ the elementary trace-power identity for diagonal matrices.
     A proposition-level BNT-label theorem witness contains the source-side
     same-length product law, the idempotent scalar law, the positive-length
     trace-power law, and positivity of the diagonal
-    $\chi_{\alpha,\beta,\gamma}$-entries.  After unpacking the witness, the
+    $\chi_{\alpha,\beta,\gamma}$-entries. After unpacking the witness, the
     same-length product and idempotent equations can first be written with the
     BNT-label coefficients $c^{(L)}_{\alpha,\beta,\gamma}$, and then with
     the coefficients expressed as
     $\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})$ and
-    $\operatorname{tr}(\chi_{\alpha,\beta,\gamma})$, respectively.  At
+    $\operatorname{tr}(\chi_{\alpha,\beta,\gamma})$, respectively. At
     every positive length, the BNT-label coefficient family also agrees with
     the canonical coefficient family determined by these $\chi$-matrices.
     Consequently, the product and idempotent predicates may be stated directly
@@ -2142,8 +2139,8 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_data_coeff_eq_trace_pow}
     An existential BNT-label theorem witness gives the formula
     $c_{\alpha,\beta,\gamma}^{(L)}
-      = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})$
-    for every positive length $L$.  Equivalently, at positive lengths, its
+        = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})$
+    for every positive length $L$. Equivalently, at positive lengths, its
     coefficient family agrees with the canonical coefficient family determined
     by the same $\chi$-matrices.
 \end{theorem}
@@ -2173,7 +2170,7 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum}
     An existential BNT-label theorem witness gives the product identity
     $O_L(M_\alpha)O_L(M_\beta)
-      = \sum_\gamma c_{\alpha,\beta,\gamma}^{(L)} O_L(M_\gamma)$
+        = \sum_\gamma c_{\alpha,\beta,\gamma}^{(L)} O_L(M_\gamma)$
     for every positive length $L$.
 \end{theorem}
 \begin{proof}\leanok
@@ -2189,7 +2186,7 @@ the elementary trace-power identity for diagonal matrices.
     An existential BNT-label theorem witness gives the idempotent scalar
     identity
     $m_\gamma =
-      \sum_{\alpha,\beta} c_{\alpha,\beta,\gamma}^{(1)}m_\alpha m_\beta$.
+        \sum_{\alpha,\beta} c_{\alpha,\beta,\gamma}^{(1)}m_\alpha m_\beta$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -2208,9 +2205,9 @@ the elementary trace-power identity for diagonal matrices.
         thm:mpdo_bnt_label_theorem_data_blocked_coeff_eq}
     An existential BNT-label theorem witness gives the comparison between the
     blocked-basis coefficients and the BNT-label coefficients through the
-    source and target label maps.  The same comparison is also available with
+    source and target label maps. The same comparison is also available with
     the canonical coefficient family determined by the witness's
-    $\chi$-matrices.  The proposition-level nonempty form of the witness
+    $\chi$-matrices. The proposition-level nonempty form of the witness
     gives the same comparisons after choosing a witness.
 \end{theorem}
 \begin{proof}\leanok
@@ -2226,7 +2223,7 @@ the elementary trace-power identity for diagonal matrices.
     An existential BNT-label theorem witness gives, for every positive length
     $L$, the identity
     $O_L(M_\alpha)O_L(M_\beta)
-      = \sum_\gamma
+        = \sum_\gamma
         \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L}) O_L(M_\gamma)$.
 \end{theorem}
 \begin{proof}\leanok
@@ -2242,7 +2239,7 @@ the elementary trace-power identity for diagonal matrices.
     An existential BNT-label theorem witness gives the idempotent scalar
     identity
     $m_\gamma =
-      \sum_{\alpha,\beta}
+        \sum_{\alpha,\beta}
         \operatorname{tr}(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta$.
 \end{theorem}
 \begin{proof}\leanok
@@ -2278,9 +2275,9 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
     An existential BNT-label theorem witness gives a positive blocked-basis
-    $\chi$ trace-power witness for the chosen algebra-structure data.  The
+    $\chi$ trace-power witness for the chosen algebra-structure data. The
     blocked-basis $\chi$-family is the pullback of the BNT-label
-    $\chi$-family along the source and target comparison maps.  The
+    $\chi$-family along the source and target comparison maps. The
     proposition-level nonempty form of the witness gives the corresponding
     existential blocked-basis trace-power family, both in coefficient form and
     in matrix-trace form.
@@ -2392,7 +2389,7 @@ the elementary trace-power identity for diagonal matrices.
     if every finite-chain operator admits the equivalent positive-operator
     presentation $\rho^{(N)} = c \prod_i B_{i,i+1}$ with $c > 0$ and
     commuting nearest-neighbor factors. The projector-limit convention in
-    \cite{Cirac2017MPDO_AnnPhys}
+    \cite{Cirac2016MPDO_arXiv}
     identifies this with the exponential Gibbs form.
 \end{definition}
 
@@ -2417,7 +2414,7 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mpdo_is_gsnnch, def:mpo_is_zcl}
     This is the conjunction of the GSNNCH condition with MPO zero correlation
     length, matching item~(iii) of the simple-MPDO equivalence in
-    \cite{Cirac2017MPDO_AnnPhys}.
+    \cite{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[GSNNCH--ZCL iff commuting form with ZCL]
@@ -2490,9 +2487,9 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_has_commuting_form}
     The $\eta$-local structure itself determines a commuting-form witness for every
-    chain length $N \ge 2$.  In particular, the translated nearest-neighbor
+    chain length $N \ge 2$. In particular, the translated nearest-neighbor
     bonds commute and the MPDO at length $N$ is a positive scalar multiple of
-    their product, as in \cite[Proposition~C.6]{Cirac2017MPDO_AnnPhys}.
+    their product, as in \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2561,7 +2558,7 @@ the elementary trace-power identity for diagonal matrices.
     The remaining entropy-side step is the construction of a single
     $\eta$-local product form from $\mathrm{SAL}(K)$. The local $\eta_{k,h}$
     are already supplied by
-    Definition~\ref{def:mpdo_eta_of_hayashi_markov}.  What remains is the
+    Definition~\ref{def:mpdo_eta_of_hayashi_markov}. What remains is the
     tensor-coordinate assembly
     \[
         B=\sum_{k,h}
@@ -2574,7 +2571,7 @@ the elementary trace-power identity for diagonal matrices.
     \[
         \sigma^{(N)}(K)=c_N\prod_{n=1}^{N}B_{n,n+1},
         \qquad c_N>0,\qquad
-        [B_{i,i+1},B_{j,j+1}]=0 .
+        [B_{i,i+1},B_{j,j+1}]=0.
     \]
     These equations are exactly the $\eta$-local product hypothesis; after that,
     Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
@@ -2808,7 +2805,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{proof}\leanok
     The $\eta$-local structure supplies the commuting nearest-neighbor product
-    form.  The remaining two implications are
+    form. The remaining two implications are
     \[
         \operatorname{ZCL}(K) \Longrightarrow
         \operatorname{RFP}(K) \Longrightarrow

--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -2,7 +2,7 @@
 
 An injective MPS tensor that generates the same matrix-product vectors as a
 second tensor of equal bond dimension is conjugate to
-it~\cite[Section~III.B]{Cirac2021Matrix}: there is an invertible~$X$ with
+it~\cite[Corollary~IV.5]{Cirac2021Matrix}: there is an invertible~$X$ with
 $B^i = X A^i X^{-1}$ for every physical index~$i$. The argument is purely
 algebraic. Equality of the matrix-product vectors gives $\tr(A^w)=\tr(B^w)$ for
 every word~$w$; the length-two and length-three traces produce a linear map~$T$

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -170,7 +170,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     if whenever $P$ is an orthogonal projection satisfying
     $E(P \MN{D} P) \subseteq P \MN{D} P$,
     then $P = 0$ or $P = \Id$.
-    This is \cite[Theorem~6.2, condition~(1)]{Wolf2012Quantum}.
+    This is \cite[Theorem~6.2(1)]{Wolf2012Quantum}.
     The definition applies to any linear map; complete positivity
     is not required.
 \end{definition}
@@ -659,7 +659,7 @@ both unital and trace-preserving.
 The following results replace the trace-preservation hypothesis by the existence
 of a positive definite fixed point for the \emph{adjoint} Kraus map,
 matching the weighted-trace argument in
-\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
+\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{lemma}[Peripheral closure via adjoint fixed point]%
     \label{lem:peripheral_closed_powers_irred_fp}
@@ -732,7 +732,7 @@ matching the weighted-trace argument in
     $E^*(\Id) = \Id$, which is a positive definite fixed
     point of the adjoint.
     The adjoint-fixed-point formulation matches the
-    argument in \cite[Appendix~A]{Cirac2017MPDO_AnnPhys},
+    argument in \cite[Appendix~A]{Cirac2016MPDO_arXiv},
     which uses a faithful invariant state rather than
     bi-canonicality.
 \end{remark}

--- a/blueprint/src/chapter/ch04a_channel_representations.tex
+++ b/blueprint/src/chapter/ch04a_channel_representations.tex
@@ -1416,10 +1416,10 @@ This section states the existence theorems from
     \[
         \widehat{T'} =
         \begin{pmatrix}
-            1   & 0          & 0          & 0   \\
-            0   & x/\sqrt{3} & 0          & 0   \\
-            0   & 0          & x/\sqrt{3} & 0   \\
-            2/3 & 0          & 0          & 1/3
+            1   &0          &0          &0\\
+            0   &x/\sqrt{3} &0          &0\\
+            0   &0          &x/\sqrt{3} &0\\
+            2/3 &0          &0          &1/3
         \end{pmatrix}.
     \]
     Trace preservation supplies the first row of the displayed matrix.
@@ -1433,10 +1433,10 @@ This section states the existence theorems from
     \[
         \widehat{T'} =
         \begin{pmatrix}
-            1 & 0 & 0 & 0 \\
-            0 & 0 & 0 & 0 \\
-            0 & 0 & 0 & 0 \\
-            1 & 0 & 0 & 0
+            1 &0 &0 &0\\
+            0 &0 &0 &0\\
+            0 &0 &0 &0\\
+            1 &0 &0 &0
         \end{pmatrix},
     \]
     equivalently, every input state is mapped to $(1+\sigma_{3})/2$.
@@ -1463,7 +1463,7 @@ This section states the existence theorems from
 \label{sec:channel_determinant}
 %% =========================================================
 
-%% Source: \cite[Section~6.1.1, Theorem~6.1(2)]{Wolf2012Quantum}.
+%% Source: \cite[Section~6.1, Theorem~6.1(2)]{Wolf2012Quantum}.
 
 \begin{definition}[Channel determinant]\label{def:channel_det}
     \lean{channelDet}\leanok
@@ -1471,7 +1471,7 @@ This section states the existence theorems from
     \emph{channel determinant} $\det T$ is the determinant of the
     matrix of $T$ with respect to the standard matrix-unit basis
     of $\MN{D}$.
-    This is the quantity studied in \cite[Section~6.1.1]{Wolf2012Quantum}.
+    This is the quantity studied in \cite[Section~6.1]{Wolf2012Quantum}.
 \end{definition}
 
 \begin{remark}[Channel determinant as an operator determinant]

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -321,7 +321,7 @@ introduces a new axiom.
     \uses{def:entropy_von_neumann_entropy}
     For any PSD Hermitian matrix $\rho$ with $\tr(\rho) = 1$ on an
     arbitrary finite index set, $S(\rho) \ge 0$. This is the
-    analogue of Theorem~\ref{thm:entropy_nonneg} for arbitrary finite
+    analog of Theorem~\ref{thm:entropy_nonneg} for arbitrary finite
     index sets: it does
     not require the index set to be $\Fin{D}$, so it applies to
     bipartite density matrices on
@@ -345,7 +345,7 @@ introduces a new axiom.
     For any tripartite density matrix $\rho_{ABC}$ on
     $A \otimes B \otimes C$,
     \[
-        I(A{:}B)_{\tr_C \rho_{ABC}} \;\le\; I(A{:}BC)_{\rho_{ABC}},
+        I(A{:}B)_{\tr_C \rho_{ABC}} \le  I(A{:}BC)_{\rho_{ABC}},
     \]
     where the left-hand side is the bipartite mutual information of
     the reduced state $\rho_{AB} = \tr_C(\rho_{ABC})$ and the
@@ -373,7 +373,7 @@ introduces a new axiom.
     $\mathbb{C}^{d_A} \otimes \mathbb{C}^{d_B}$ with $d_A, d_B \ge 1$
     whose single-system reduced states are obtained by partial trace,
     \[
-        I(A{:}B) \;\le\; \log d_A + \log d_B.
+        I(A{:}B) \le  \log d_A + \log d_B.
     \]
 \end{theorem}
 

--- a/blueprint/src/chapter/ch04c_entropy_corollaries.tex
+++ b/blueprint/src/chapter/ch04c_entropy_corollaries.tex
@@ -7,14 +7,14 @@
 \section{Trivial-factor corollaries}
 
 The partial traces and von~Neumann entropy are introduced in
-Chapter~\ref{ch:entropy}.  This supplement collects elementary
+Chapter~\ref{ch:entropy}. This supplement collects elementary
 trace-preservation identities and the dimension-1 entropy bound that
-follow directly from those definitions.  They are listed as separate
+follow directly from those definitions. They are listed as separate
 results because each proof requires only unfolding definitions and
 re-indexing finite sums.
 
 %% The A-, C-, and AC-partial-trace identities are stated as a
-%% complete set of standard results.  The AC variant is the one
+%% complete set of standard results. The AC variant is the one
 %% consumed downstream (subadditivity from SSA with trivial middle
 %% B in StrongSubadditivity.lean).
 

--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -65,7 +65,7 @@ and~\cite{Evans1978Spectral}.
     for every matrix $M$. Given any vector $w$, choose $M$ with
     $M v = w$. Then $\rho w = 0$ for every $w$, so $\rho = 0$,
     contradicting $\rho \neq 0$.
-    In~\cite[Theorem~6.3, item~2]{Wolf2012Quantum},
+    In~\cite[Theorem~6.3(2)]{Wolf2012Quantum},
     the same conclusion is reached via the
     growth condition $(\Id + \E_A)^{D-1}(\rho) > 0$
     of~\cite[Theorem~6.2, condition~(2)]{Wolf2012Quantum};
@@ -100,7 +100,7 @@ and~\cite{Evans1978Spectral}.
     contradicting our assumption.
     Hence $\rho$ must be positive definite.
     This is the support-projection direction
-    of~\cite[Theorem~6.2, condition~(1)]{Wolf2012Quantum}.
+    of~\cite[Theorem~6.2(1)]{Wolf2012Quantum}.
 \end{proof}
 
 \begin{theorem}[Orthogonal trace condition]\label{thm:orthogonal_trace_cond}
@@ -119,7 +119,7 @@ and~\cite{Evans1978Spectral}.
 \begin{proof}
     \leanok
     The growth theorem for irreducible CP maps
-    (\cite[Theorem~6.2, item~2]{Wolf2012Quantum}) gives
+    (\cite[Theorem~6.2(2)]{Wolf2012Quantum}) gives
     $(\Id + E)^{D-1}(A) > 0$ (positive definite).
     Since $B \ge 0$ is nonzero,
     $\tr(B \cdot (\Id + E)^{D-1}(A)) > 0$.
@@ -132,7 +132,7 @@ and~\cite{Evans1978Spectral}.
     ($\tr(B A) = 0$).
     Hence at least one $k \in \{1, \ldots, D-1\}$ contributes
     a strictly positive term.
-    This is~\cite[Theorem~6.2, item~4]{Wolf2012Quantum}:
+    This is~\cite[Theorem~6.2(4)]{Wolf2012Quantum}:
     item~(2) (growth condition) implies item~(4)
     by a binomial expansion and PSD positivity argument.
 \end{proof}
@@ -187,7 +187,7 @@ and~\cite{Evans1978Spectral}.
 \begin{proof}\leanok
     The irreducible positive-definiteness theorem
     (Theorem~\ref{thm:psd_fp_pd_irred}) upgrades every nonzero positive
-    semidefinite fixed point to a positive definite one.  The same minimal
+    semidefinite fixed point to a positive definite one. The same minimal
     eigenvalue argument used in Theorem~\ref{thm:psd_fp_unique} then applies.
 \end{proof}
 
@@ -290,7 +290,7 @@ and~\cite{Evans1978Spectral}.
 
 \begin{proof}\leanok
     Existence is the channel fixed-point theorem
-    (Theorem~\ref{thm:psd_fp_exists}).  Irreducibility upgrades the fixed point
+    (Theorem~\ref{thm:psd_fp_exists}). Irreducibility upgrades the fixed point
     to positive definite, and Theorem~\ref{thm:psd_fp_unique_irred} gives
     uniqueness up to scalar multiple.
 \end{proof}
@@ -484,7 +484,7 @@ tensor, and uses it to construct a TP-gauge normalization.
 The PSD-eigenvector step corresponds to~\cite[Theorem~6.5]{Wolf2012Quantum}
 (general positive maps) and~\cite{Evans1978Spectral}; the upgrade to positive
 definiteness uses the irreducible-map theory of~\cite[Theorem~6.3]{Wolf2012Quantum}.
-The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
+The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{theorem}[PSD eigenvector for positive maps]%
     \label{thm:pf_eigenvector_existence}
@@ -535,8 +535,8 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
     This combines the general PF existence
     (\cite[Theorem~6.5]{Wolf2012Quantum}) with the
     irreducible upgrade to positive definiteness
-    (\cite[Theorem~6.3, item~2]{Wolf2012Quantum});
-    the application to the adjoint transfer map follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
+    (\cite[Theorem~6.3(2)]{Wolf2012Quantum});
+    the application to the adjoint transfer map follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -583,7 +583,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
     is trace-preserving:
     $\sum_i (B^i)^\dagger B^i = \Id$.
 
-    This is the ``spectral rescaling $+$ TP gauge'' step of~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
+    This is the ``spectral rescaling $+$ TP gauge'' step of~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     The similarity is generally non-unitary.
 \end{theorem}
 
@@ -618,17 +618,17 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
     $\sum_i B^i(B^i)^\dagger = \Id$.
 
     This is the Perron--Frobenius unital-gauge orientation used in
-    \cite[Theorem~Th:TIcanonical, lines~765--770]{PerezGarcia2007Matrix},
+    \cite[Theorem~4, lines~765--770]{PerezGarcia2007Matrix},
     stated for one irreducible nonzero block.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:posDef_adjoint_eigenvector, thm:unital_gauge_of_pd_fixed_point}
     Apply Theorem~\ref{thm:posDef_adjoint_eigenvector} to the
-    conjugate-transposed Kraus family.  Irreducibility transfers to that
+    conjugate-transposed Kraus family. Irreducibility transfers to that
     family, and the nonzero Kraus hypothesis is preserved by taking adjoints.
     Translating the resulting adjoint eigenvector equation back gives
-    $\E_A(\rho)=r\rho$ with $\rho$ positive definite and $r>0$.  The unital
+    $\E_A(\rho)=r\rho$ with $\rho$ positive definite and $r>0$. The unital
     gauge theorem then gives the displayed unital representative, and the
     same square-root similarity gives gauge equivalence to $r^{-1/2}A$.
 \end{proof}
@@ -647,7 +647,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
         \sum_{k=0}^{D-1} \frac{t^k}{k!} E^k(A)
     \]
     is positive definite.
-    This is the finite-sum core of~\cite[Theorem~6.2, item~(3)]{Wolf2012Quantum}.
+    This is the finite-sum core of~\cite[Theorem~6.2(3)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
@@ -675,7 +675,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
         \exp(tE)(A) = \sum_{k=0}^{\infty} \frac{t^k}{k!} E^k(A)
     \]
     is positive definite.
-    This is~\cite[Theorem~6.2, item~(3)]{Wolf2012Quantum}.
+    This is~\cite[Theorem~6.2(3)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
@@ -745,7 +745,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}.
     Let $E$ be an irreducible completely positive map on $\MN{D}$.
     Suppose $\rho > 0$ and $E(\rho) = r \rho$ with $r > 0$.
     Then the spectral radius of $E$ is $r$.
-    This is~\cite[Theorem~6.3, item~(4)]{Wolf2012Quantum}.
+    This is~\cite[Theorem~6.3(4)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -353,7 +353,7 @@ maps.
     We follow the convention that $\mc{A}_R(E)$ controls right multiplication
     and $\mc{A}_L(E)$ controls left multiplication.
     These are the two one-sided multiplicative domains from
-    \cite[Eqs.~(5.11)--(5.12)]{Wolf2012Quantum}.
+    \cite[Equations~(5.11)--(5.12)]{Wolf2012Quantum}.
 \end{definition}
 
 \begin{definition}[Full multiplicative domain]\label{def:full_multiplicative_domain}

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1129,7 +1129,7 @@ algebras over an algebraically closed field.
     \leanok
     \uses{thm:adjointFixedPointsStarSubalgebra}
     The subalgebra is finite-dimensional (as a subalgebra of~$\MN{D}$),
-    hence Artinian. By~\cite[Theorem~6.14]{Wolf2012Quantum}, it suffices to show
+    hence Artinian. It suffices to show
     the Jacobson radical~$J$ vanishes. If $x \in J$, then $x^*x \in J$
     (left-ideal closure). The radical of an Artinian ring is nilpotent,
     so $x^*x$ is nilpotent. A self-adjoint nilpotent matrix satisfies

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1129,8 +1129,9 @@ algebras over an algebraically closed field.
     \leanok
     \uses{thm:adjointFixedPointsStarSubalgebra}
     The subalgebra is finite-dimensional (as a subalgebra of~$\MN{D}$),
-    hence Artinian. It suffices to show
-    the Jacobson radical~$J$ vanishes. If $x \in J$, then $x^*x \in J$
+    hence Artinian. Following~\cite[Theorem~6.14]{Wolf2012Quantum}, it
+    suffices to show the Jacobson radical~$J$ vanishes. If $x \in J$, then
+    $x^*x \in J$
     (left-ideal closure). The radical of an Artinian ring is nilpotent,
     so $x^*x$ is nilpotent. A self-adjoint nilpotent matrix satisfies
     $\lVert x^*x\rVert^{2^k} = \lVert (x^*x)^{2^k}\rVert = 0$,

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -108,7 +108,7 @@ The results follow~\cite{Sanz2010Quantum}.
 
 \begin{proof}\leanok\uses{def:word_span}
     The zero-length products consist only of the identity, so
-    $S_0(A)=\spn_{\C}\{\Id\}$ has dimension~$1$.  Since
+    $S_0(A)=\spn_{\C}\{\Id\}$ has dimension~$1$. Since
     $\dim \MN{D}=D^2 \ge 4$, this span cannot be all of $\MN{D}$.
 \end{proof}
 
@@ -122,7 +122,7 @@ The results follow~\cite{Sanz2010Quantum}.
 
 \begin{proof}\leanok\uses{lem:wordspan_blk_inj, lem:wordspan_zero_ne_top}
     By Lemma~\ref{lem:wordspan_blk_inj}, $0$-block injectivity gives
-    $S_0(A)=\MN{D}$.  Lemma~\ref{lem:wordspan_zero_ne_top} excludes
+    $S_0(A)=\MN{D}$. Lemma~\ref{lem:wordspan_zero_ne_top} excludes
     $D \ge 2$, hence the nonzero bond dimension must be~$1$.
 \end{proof}
 
@@ -135,7 +135,7 @@ The results follow~\cite{Sanz2010Quantum}.
         \spn_{\C}\{R C S : R, S \in \MN{D}\}=\MN{D}.
     \]
     This is the matrix-factorization input used in~%
-    \cite[Lemma~\texttt{lem1}]{PerezGarcia2007Matrix}.
+    \cite[Lemma~3]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1453,7 +1453,7 @@ transfer-map gap. It is connected to normality through the following results.
     If $A$ is a primitive MPS tensor with PSD fixed point $\rho$
     and $\rho$ is positive definite, then $A$ is an irreducible tensor.
     This is part of~\cite[Proposition~3]{Sanz2010Quantum}
-    (see also \cite[Section~2.3]{Cirac2017MPDO_AnnPhys}).
+    (see also \cite[Section~2.3]{Cirac2016MPDO_arXiv}).
 \end{lemma}
 
 \begin{proof}
@@ -1813,7 +1813,7 @@ span.
     it works directly with irreducible TP-normalized blocks whose blocked transfer maps
     are primitive and, once the corresponding weighted block data are available,
     places them in normal canonical form in the sense of~%
-    \cite{Cirac2017MPDO_AnnPhys}. There are analogous cumulative-span lemmas for
+    \cite{Cirac2016MPDO_arXiv}. There are analogous cumulative-span lemmas for
     blocked irreducible tensors and eigenvector-spreading arguments, but they are
     auxiliary here and we do not list them separately.
 \end{remark}
@@ -1842,10 +1842,10 @@ span.
     If $D=1$, trace preservation gives a nonzero one-site Kraus matrix, and
     every nonzero scalar matrix spans $\MN{1}$; hence $A$ is one-site
     injective, so Lemma~\ref{lem:one_block_injective_of_injective} gives the
-    positive witness $L=1$.  Suppose now that $D\geq 2$.  The normality theorem
+    positive witness $L=1$. Suppose now that $D\geq 2$. The normality theorem
     (Theorem~\ref{thm:normal_tp_primitive_irred}) gives a block-injectivity
-    witness $L$.  If $L=0$, Corollary~\ref{cor:blk_inj_zero_dim_one} would
-    force $D=1$, a contradiction.  Thus $L>0$, and the blocked-chain
+    witness $L$. If $L=0$, Corollary~\ref{cor:blk_inj_zero_dim_one} would
+    force $D=1$, a contradiction. Thus $L>0$, and the blocked-chain
     equivalence identifies this $L$-block injectivity with one-site injectivity
     of the blocked tensor $A^{[L]}$.
 \end{proof}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -5,7 +5,7 @@ of matrix product states. Here an arbitrary translation-invariant MPS tensor is
 reduced to a weighted family of primitive blocks; Chapter~\ref{ch:bnt} constructs
 the basis of normal tensors carried by those blocks and compares their
 coefficients, and Chapter~\ref{ch:ft_proof} proves the theorem itself. The
-reduction follows~\cite{PerezGarcia2007Matrix}, \cite{Cirac2017MPDO_AnnPhys},
+reduction follows~\cite{PerezGarcia2007Matrix}, \cite{Cirac2016MPDO_arXiv},
 \cite{Cirac2021Matrix}, and~\cite[Chapter~6]{Wolf2012Quantum}. Its goal is to expose the primitive blocks
 inside the tensor. The transfer operator of an arbitrary tensor can be reducible
 and can have a period greater than one; the reduction splits it along its
@@ -15,7 +15,7 @@ fixed gauge, and the sections below carry out the reduction.
 
 Two normalizations appear. The unital orientation
 $\sum_i A_k^i(A_k^i)^\dagger=\Id$ is used in
-\cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}; the trace-preserving
+\cite[Theorem~4]{PerezGarcia2007Matrix}; the trace-preserving
 (left-canonical) orientation $\sum_i (A_k^i)^\dagger A_k^i=\Id$ is used in the
 TP-gauge and after-blocking reductions below. They exchange under the
 conjugate-transposed Kraus family $K_i:=(A^i)^\dagger$, whose transfer map is the
@@ -25,7 +25,7 @@ Frobenius adjoint of $\E_A$.
     \label{thm:pgvwc07_ti_canonical_form}
     \lean{MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty}
     \leanok
-    % Source: PerezGarcia2007Matrix, Theorem Th:TIcanonical.
+    % Source: PerezGarcia2007Matrix, Theorem 4.
     % Block decomposition, three block conditions, and bond-dimension bound.
     % Proof order to preserve: spectral-radius normalization and full-rank
     % fixed-point gauge; invariant support projection from a singular positive
@@ -57,13 +57,13 @@ Frobenius adjoint of $\E_A$.
     The total bond dimension of the decomposition is at most $D$.
 
     This is the positive-length form of
-    \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}, with the global
+    \cite[Theorem~4]{PerezGarcia2007Matrix}, with the global
     spectral-radius normalization step made explicit.
 \end{theorem}
 
 \begin{remark}[Source proof order]\label{rem:pgvwc07_ti_canonical_source_order}
     The proof follows
-    \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix} in order: normalize the
+    \cite[Theorem~4]{PerezGarcia2007Matrix} in order: normalize the
     spectral radius and use a full-rank positive fixed point to obtain the unital
     gauge; derive the invariant support projection from a singular positive fixed
     point by the positivity contradiction; split the finite-ring trace into the
@@ -87,7 +87,7 @@ Frobenius adjoint of $\E_A$.
     % removal; def:4:normal-tensor-mps and eq:II_CF1; BNT
     % definition/characterization; two-layer BNT/copy display.
     The blocked canonical-form reduction of
-    \cite[Section~II.C]{Cirac2017MPDO_AnnPhys} and
+    \cite[Section~2.3]{Cirac2016MPDO_arXiv} and
     \cite[Section~IV.A]{Cirac2021Matrix} states that an arbitrary
     translation-invariant MPS tensor becomes, after blocking by some period
     $p\ge 1$, the direct sum of an all-zero summand and a weighted family of
@@ -103,7 +103,7 @@ Frobenius adjoint of $\E_A$.
 \section{Normal tensors and canonical forms}\label{sec:cpsv_canonical_defs}
 
 This section records the CPSV definitions of \emph{normal tensor} and
-\emph{canonical form} from~\cite{Cirac2017MPDO_AnnPhys}. The basis of normal
+\emph{canonical form} from~\cite{Cirac2016MPDO_arXiv}. The basis of normal
 tensors is stated in Chapter~\ref{ch:bnt}. Write
 \[
     \sigma_\partial(\E) = \{\lambda \in \sigma(\E) : |\lambda| = r(\E)\}
@@ -121,7 +121,7 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     \leanok
     A tensor $A$ of physical dimension $d$ and bond dimension $D$ is a
     \emph{normal tensor} if, after the spectral-radius normalization
-    of~\cite{Cirac2017MPDO_AnnPhys}, (i)~$A$ admits no nontrivial invariant
+    of~\cite{Cirac2016MPDO_arXiv}, (i)~$A$ admits no nontrivial invariant
     orthogonal projection and (ii)~the associated CPM
     $\E_A(X) = \sum_i A^i X (A^i)^\dagger$ has peripheral spectrum
     $\sigma_\partial(\E_A)=\{1\}$.
@@ -139,7 +139,7 @@ decomposition
     A^i \cong \bigoplus_{k=1}^r \mu_k A_k^i
 \]
 with weights normalized by $|\mu_k| \le 1$ and with at least one $|\mu_k|=1$;
-see \cite[Section~II.C]{Cirac2017MPDO_AnnPhys}. In the statements below the
+see \cite[Section~2.3]{Cirac2016MPDO_arXiv}. In the statements below the
 structural part is supplied by the stronger normal canonical form of
 Definition~\ref{def:is_normal_canonical_form}, and the global weight
 normalization is invoked as a separate source hypothesis where needed.
@@ -226,8 +226,8 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     \[
         B^i =
         \begin{pmatrix}
-            A_1^i & *     \\
-            0     & A_2^i
+            A_1^i &*\\
+            0     &A_2^i
         \end{pmatrix}
     \]
     for the conjugated letters in this split basis. Since
@@ -293,7 +293,7 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     \lean{MPSTensor.lowerZero_of_posSemidef_fixedPoint}
     \leanok
     \uses{def:transfer_map}
-    % Source: the support-projection step in the proof of Th:TIcanonical
+    % Source: the support-projection step in the proof of Theorem 4
     % (PerezGarcia2007Matrix): the support of a singular positive fixed point is
     % invariant, A_i P_R = P_R A_i P_R, by positivity.
     Let $\rho \ge 0$ be a fixed point of $\E_A$, and let $P$ be its support
@@ -320,7 +320,7 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     \leanok
     \uses{def:transfer_map, def:same_mpv2}
     % Source: the invariant-support projection and finite-ring trace split in
-    % the proof of Th:TIcanonical (PerezGarcia2007Matrix).
+    % the proof of Theorem 4 (PerezGarcia2007Matrix).
     If $\E_A$ has a nonzero PSD fixed point $\rho$ that is not positive definite,
     then there exist MPS tensors $A_1, A_2$ of smaller bond dimensions with
     $\mc{V}(A) = \mc{V}(A_1 \oplus A_2)$.
@@ -352,7 +352,7 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     admits a two-block MPV-equivalent decomposition with both block dimensions
     strictly smaller than $D$. This is the fixed-point shift and further
     decomposition step in
-    \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.
+    \cite[Theorem~4]{PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -408,7 +408,7 @@ irreducible unital blocks and the algebra-spanning input used later.
     \uses{def:transfer_map, def:irreducible_tensor}
     If $A$ is irreducible and unital, $\E_A(\Id)=\Id$, and $\E_A(X)=X$, then $X$
     is a scalar multiple of $\Id$. This is the final fixed-point assertion in the
-    proof of \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.
+    proof of \cite[Theorem~4]{PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -432,7 +432,7 @@ irreducible unital blocks and the algebra-spanning input used later.
     If $r=1$, then the unscaled gauge $B^i := \rho^{-1/2}A^i\rho^{1/2}$ is unital
     and generates the same MPV family as $A$. This is the spectral-radius
     normalization and full-rank fixed-point gauge of
-    \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.
+    \cite[Theorem~4]{PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -546,7 +546,7 @@ below.
     no unital condition is assumed here.
     Condition~(5) is a primitivity hypothesis:
     for a primitive channel
-    (\cite[Theorem~6.7, item~3]{Wolf2012Quantum}),
+    (\cite[Theorem~6.7(3)]{Wolf2012Quantum}),
     $T^n(\rho) \to \rho_\infty$ for every initial state,
     which forces the self-overlap to converge to~$1$.
     See also~\cite[Theorem~6.8]{Wolf2012Quantum}
@@ -558,7 +558,7 @@ below.
 % rem:pgvwc07_vs_local_cf (deleted): Definition~\ref{def:is_canonical_form} is a
 % local/conditional predicate assuming injectivity and the self-overlap limit;
 % it is not the source canonical-form existence or uniqueness theorem of
-% \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.
+% \cite[Theorem~4]{PerezGarcia2007Matrix}.
 
 \begin{remark}[Normalization convention]\label{rem:tp_vs_unital}
     \cite[Theorem~4]{PerezGarcia2007Matrix} uses the unital gauge
@@ -582,7 +582,7 @@ below.
         \item all $\mu_k \neq 0$,
         \item all bond dimensions are positive.
     \end{enumerate}
-    Here ``normal'' is the spectral sense of~\cite{Cirac2017MPDO_AnnPhys}, which
+    Here ``normal'' is the spectral sense of~\cite{Cirac2016MPDO_arXiv}, which
     by~\cite[Proposition~3]{Sanz2010Quantum} is equivalent to the eventual
     block-injectivity formulation of Definition~\ref{def:normal}.
 \end{definition}
@@ -665,7 +665,7 @@ primitivity by blocking to period one.
 % peripheral-spectrum primitivity is known, the overlap-convergence hypothesis is
 % redundant, derived from the transfer-map gap of Chapter~\ref{ch:spectral}; these
 % are statements about blocks already in normal form, not the arbitrary-input
-% existence theorem of \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.
+% existence theorem of \cite[Theorem~4]{PerezGarcia2007Matrix}.
 
 \begin{theorem}[Blocking yields a peripheral-spectrum primitive transfer map]\label{thm:blocking_primitivity}
     \lean{MPSTensor.exists_blockTensor_isPrimitive_of_TP_of_isIrreducibleTensor}
@@ -695,7 +695,7 @@ primitivity by blocking to period one.
 
 \begin{remark}\label{rem:blocking_primitivity_appendixA}
     Theorem~\ref{thm:blocking_primitivity} is the periodicity-removal-by-blocking
-    step of~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys} for an irreducible block
+    step of~\cite[Appendix~A]{Cirac2016MPDO_arXiv} for an irreducible block
     already in TP gauge.
 \end{remark}
 
@@ -724,7 +724,7 @@ canonical form is Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
         \item $A$ and $B$ generate the same MPV family.
     \end{enumerate}
     This is the left-canonical normalization step (Canonical Form~II)
-    of~\cite[Appendix~A]{Cirac2017MPDO_AnnPhys}. The unitary conjugation is a
+    of~\cite[Appendix~A]{Cirac2016MPDO_arXiv}. The unitary conjugation is a
     second step inside TP gauge, performed only after TP normalization.
 \end{theorem}
 
@@ -750,7 +750,7 @@ canonical form is Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
     \]
     and $A$, $B$ generate the same MPV family. This is the dual-map fixed-point
     and unitary-diagonalization step of
-    \cite[Theorem~Th:TIcanonical]{PerezGarcia2007Matrix}.
+    \cite[Theorem~4]{PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -804,7 +804,7 @@ canonical form is Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
     Theorem~\ref{thm:exists_normal_canonical_form} assumes all six block
     hypotheses in advance and produces the normal canonical form by reordering.
     It is not the arbitrary-input existence theorem
-    of~\cite[Section~II.C]{Cirac2017MPDO_AnnPhys}; that primitive-block reduction,
+    of~\cite[Section~2.3]{Cirac2016MPDO_arXiv}; that primitive-block reduction,
     including the zero-tail count, is
     Theorem~\ref{thm:tp_primitive_blockdecomp} in
     Section~\ref{sec:reduction_to_normal_form}.
@@ -1017,7 +1017,7 @@ block.
 In the proof of~\cite{Cirac2017MPDO_AnnPhys} the required step is
 periodicity removal by blocking: after blocking each irreducible TP block by the
 least common multiple of its peripheral periods, the result has no nontrivial
-$p$-periodic vectors~\cite[Section~2.3]{Cirac2017MPDO_AnnPhys}. The cyclic-sector
+$p$-periodic vectors~\cite[Section~2.3]{Cirac2016MPDO_arXiv}. The cyclic-sector
 decomposition comes from the peripheral spectrum of the adjoint transfer
 map~\cite[Theorem~6.6]{Wolf2012Quantum}.
 
@@ -1050,7 +1050,7 @@ map~\cite[Theorem~6.6]{Wolf2012Quantum}.
               $\varphi_k(X^\dagger)=\varphi_k(X)^\dagger$.
     \end{enumerate}
     This is the cyclic-sector part of the period-removal step
-    of~\cite[Section~2.3]{Cirac2017MPDO_AnnPhys}; the projections $P_k$ come
+    of~\cite[Section~2.3]{Cirac2016MPDO_arXiv}; the projections $P_k$ come
     from the peripheral spectrum of the adjoint transfer map
     (\cite[Theorem~6.6]{Wolf2012Quantum}).
 \end{theorem}
@@ -1407,7 +1407,7 @@ basis-of-normal-tensors construction of Chapter~\ref{ch:bnt}.
 Blocking by a length~$p$ commutes with weighted direct sums up to the $p$th power
 of each weight: for nonzero weights $(\mu_k)$ and blocks $(B_k)$,
 \[
-    \Bigl(\textstyle\bigoplus_k \mu_k B_k\Bigr)^{[p]}
+    \left(\textstyle\bigoplus_k \mu_k B_k\right)^{[p]}
     \sim \textstyle\bigoplus_k \mu_k^{\,p}\, B_k^{[p]},
 \]
 where $\sim$ is equality of MPV families. When two block families are reblocked to

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -21,7 +21,7 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     (Definition~\ref{def:normal}); at each system size~$N$ the MPV of
     $A_{\mathrm{tot}}$ lies in the span of the block MPVs
     $\{\ket{V^{(N)}(A_j)}\}_{j=1}^g$; and for sufficiently large~$N$ those block
-    MPVs are linearly independent. This is \cite[Definition~4.2]{Cirac2021Matrix}.
+    MPVs are linearly independent. This is \cite[Definition~IV.2]{Cirac2021Matrix}.
     In the canonical-form characterization of
     \cite[Section~2.3]{Cirac2016MPDO_arXiv}, a BNT is a minimal family of
     representatives for $\widetilde A_k^i = e^{i\phi_k} X_k A_j^i X_k^{-1}$ among
@@ -508,7 +508,7 @@ multiset with multiplicity.
 % Source: Cirac2016MPDO_arXiv \S~II lines 287--301; Cirac2021Matrix
 % Definition~4.2, Proposition~4.3, lines 1864--1884.
 This section introduces the BNT canonical-form predicate of
-\cite[\S~II]{Cirac2016MPDO_arXiv}, defined on a sector decomposition with raw
+\cite[Section~2]{Cirac2016MPDO_arXiv}, defined on a sector decomposition with raw
 sector weights $\mu_{j,q}$ and coefficients $c_N^{(j)} = \sum_q \mu_{j,q}^{\,N}$;
 no equal-modulus factorization is assumed.
 
@@ -611,7 +611,7 @@ single family.
     converges to $1$; the basis MPV family is eventually linearly
     independent; distinct same-dimension basis blocks are not gauge-phase
     equivalent after identifying equal bond dimensions; and the
-    \cite[\S~II.C]{Cirac2016MPDO_arXiv} canonical-form normalization holds,
+    \cite[Section~2.3]{Cirac2016MPDO_arXiv} canonical-form normalization holds,
     \[
         \forall (j,q),\ |\mu_{j,q}| \le 1,
         \qquad
@@ -626,8 +626,8 @@ single family.
     \]
     % Source: Cirac2016MPDO_arXiv \S~II.C lines 271--301; Cirac2021Matrix
     % Definition~4.2, Proposition~4.3, lines 1864--1884.
-    matching \cite[\S~II.C]{Cirac2016MPDO_arXiv} and
-    \cite[Definition~4.2]{Cirac2021Matrix}.
+    matching \cite[Section~2.3]{Cirac2016MPDO_arXiv} and
+    \cite[Definition~IV.2]{Cirac2021Matrix}.
     The canonical-form normalization admits every example of the source paper
     (in particular $C \oplus D$, $C \oplus (-C)$,
     $C \oplus (1/2) C$, and $C \oplus (-C) \oplus (1/2) C$) and is
@@ -649,7 +649,7 @@ and the combined-family linear independence.
     \]
     % Source: two-layer BNT and coefficient-expansion displays,
     % Cirac2016MPDO_arXiv lines 287--301; Cirac2021Matrix lines 1864--1884.
-    This is \cite[\S~II.C]{Cirac2016MPDO_arXiv}.
+    This is \cite[Section~2.3]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -706,7 +706,7 @@ and the combined-family linear independence.
     \leanok
     \uses{def:sector_bnt_cf}
     Under the BNT canonical form, the
-    \cite[\S~II.C]{Cirac2016MPDO_arXiv} unit-modulus existential provides
+    \cite[Section~2.3]{Cirac2016MPDO_arXiv} unit-modulus existential provides
     indices $(j_*, q_*)$ with $|\mu_{j_*, q_*}| = 1$.
 \end{lemma}
 
@@ -837,7 +837,7 @@ overlap-decay theorem excludes unless the dimensions agree.
     \label{lem:prepared_collapsed_bnt_sector_decomp_total_dim}
     \lean{MPSTensor.collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr}
     \leanok
-    % Source: canonical-form eq:II_CF1 and prop:char-BNT (Cirac2017MPDO_AnnPhys),
+    % Source: canonical-form eq:II_CF1 and prop:char-BNT (Cirac2016MPDO_arXiv),
     % with the equalMPS dimension conclusion (Cirac2016MPDO_arXiv).
     For prepared trace-preserving primitive irreducible blocks of positive bond
     dimension with all copy weights nonzero, the phase-class quotient preserves
@@ -887,10 +887,10 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     The after-blocking reduction supplies the TP-normalized primitive irreducible
     injective blocks and the positive-length MPV identity. The normalized-weight
     hypotheses are the choice that
-    \cite[Section~II.C]{Cirac2017MPDO_AnnPhys} makes;
+    \cite[Section~2.3]{Cirac2016MPDO_arXiv} makes;
     Theorem~\ref{thm:paperbnt_supplier_prepared} then produces the sector
     decomposition, following the BNT selection of
-    \cite[Appendix~A]{Cirac2017MPDO_AnnPhys}. At length zero the MPV coefficient
+    \cite[Appendix~A]{Cirac2016MPDO_arXiv}. At length zero the MPV coefficient
     is the bond dimension, so equal total bond dimensions supply the missing
     length-zero coefficient. The remaining rescaling step is recorded in
     Remark~\ref{rem:arbitrary_input_reduction_gap}.
@@ -1055,7 +1055,7 @@ projection.
     $P$-sectors with this property. For $j' \notin T$ the overlap dichotomy
     turns a non-decaying overlap with some $Q_{k(j')}$ into a gauge-phase
     equivalence, hence a scalar $\omega_{j'} \in \C^\times$ with $V^{(N)}(P_{j'})
-    = \omega_{j'}^{N} V^{(N)}(Q_{k(j')})$, so $V^{(N)}(P_{j'})$ lies in the span
+        = \omega_{j'}^{N} V^{(N)}(Q_{k(j')})$, so $V^{(N)}(P_{j'})$ lies in the span
     of $\{V^{(N)}(Q_k)\}_k$. The family $\{P_{j'} : j'\in T\}\cup\{Q_k\}_k$ then
     has all pairwise cross-overlaps decaying, hence is eventually linearly
     independent (Lemma~\ref{lem:sector_bnt_combined_family_eventually_li}).
@@ -1063,7 +1063,7 @@ projection.
     \[
         \sum_{j'\in T} c_N^{(j')}\, V^{(N)}(P_{j'})
         = \sum_{k}\Bigl(c_N^{(k)} - \sum_{j'\notin T,\, k(j')=k}
-            c_N^{(j')}\omega_{j'}^{N}\Bigr) V^{(N)}(Q_k),
+        c_N^{(j')}\omega_{j'}^{N}\Bigr) V^{(N)}(Q_k),
     \]
     exact coefficient extraction forces $c_N^{(j)} = 0$ at each fixed large $N$,
     contradicting Lemma~\ref{lem:sector_bnt_coeff_not_eventually_zero}. Hence a

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -86,7 +86,7 @@ step uses a per-sector unit-modulus hypothesis.
         \zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma.
     \]
     This is \cite[Appendix MPV theorem statement, lines~1167--1170, and proof
-    line~1182]{Cirac2016MPDO_arXiv}.
+        line~1182]{Cirac2016MPDO_arXiv}.
     % Per-sector unit-modulus restriction eliminated by the exact matcher;
     % closure recorded in
     % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
@@ -554,7 +554,7 @@ In the equal-MPV case all ingredients are unconditional.
     with bases of normal tensors $(P_j)_{j=1}^{g_a}$ and $(Q_k)_{k=1}^{g_b}$. If
     the total tensors $P_{\mathrm{tot}}$, $Q_{\mathrm{tot}}$ generate eventually
     nonzero proportional MPV families --- for all sufficiently large $N$ there is
-    a nonzero scalar $c_N$ with $V^{(N)}(P_{\mathrm{tot}})=c_N\,
+    a nonzero scalar $c_N$ with $V^{(N)}(P_{\mathrm{tot}})=c_N
         V^{(N)}(Q_{\mathrm{tot}})$ --- then $g_a=g_b$. After relabelling the basis of
     normal tensors of $P$ by a bijection $\beta:J(Q)\simeq J(P)$, there are
     scalars $\zeta_k \in \C$ with $|\zeta_k|=1$ and invertible matrices $Y_k$
@@ -578,8 +578,8 @@ In the equal-MPV case all ingredients are unconditional.
     no per-sector unit-modulus hypothesis.
 \end{proof}
 
-This is \cite[Theorem~II.1]{Cirac2017MPDO_AnnPhys}; see also
-\cite[Theorem~4.5 and Corollary~IV.5]{Cirac2021Matrix}. The statement is given on
+This is \cite[Theorem~2.10]{Cirac2016MPDO_arXiv}; see also
+\cite[Theorem~IV.4 and Corollary~IV.5]{Cirac2021Matrix}. The statement is given on
 the BNT canonical-form surface (Definition~\ref{def:sector_bnt_cf}), which is the
 paper's ``$A$ and $B$ in canonical form'' with chosen bases of normal tensors;
 the reduction of an \emph{arbitrary} proportional-MPV pair to a common primitive
@@ -608,9 +608,9 @@ Chapter~\ref{ch:canonical}.
         X\,P_{\mathrm{tot}}^i\,X^{-1}.
     \]
 
-    This is \cite[Corollary~II.2]{Cirac2017MPDO_AnnPhys} on the BNT
+    This is \cite[Corollary~2.11]{Cirac2016MPDO_arXiv} on the BNT
     canonical-form surface; the canonical form of
-    \cite[\S~II.C]{Cirac2016MPDO_arXiv}, a direct sum of normal tensors with
+    \cite[Section~2.3]{Cirac2016MPDO_arXiv}, a direct sum of normal tensors with
     scalar weights, is a BNT canonical form. The reduction of an \emph{arbitrary}
     pair of same-MPV tensors to a common BNT canonical form is
     Chapter~\ref{ch:canonical}.

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -870,9 +870,9 @@ unconditional result.
     (Theorem~\ref{thm:periodic_ft}) as an explicit hypothesis on the
     pair $(d, D)$, expressed by the hypothesis
     \lean{MPSTensor.PeriodicEqualCaseFT}\,$d\,D$.
-    If $A$ is on-site symmetric under~$U$ - that is, the twisted tensor
+    If $A$ is on-site symmetric under~$U$ --- that is, the twisted tensor
     $\widetilde{A}_g$ has the same MPV family as~$A$ for every $g \in G$
-    - then for each $g \in G$ there exists a positive period $m_g$ and
+    --- then for each $g \in G$ there exists a positive period $m_g$ and
     a $\Z_{m_g}$-gauge equivalence between~$A$ and~$\widetilde{A}_g$.
 
     Concretely there are matrices $Z_g$ and~$Y_g$, with $Z_g^{m_g} = \Id$
@@ -1274,8 +1274,8 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
     The cardinality comparison $d \le d^{p}$ holds whenever $p \ge 1$, so
     \cite[Theorem~2.1(4)]{Wolf2012Quantum} supplies an isometry
     $V \in M_{d^p \times d}(\C)$ with $V^{\dagger} V = \Id$ and
-    $(A^{[p]})^{\alpha} = \sum_{j} V_{\alpha,j}\, B^{j}$. Expanding
-    $\mathrm{coeff}\,(A^{[p]})\,(\mathrm{ofFn} \tau)$ by linearity of matrix
+    $(A^{[p]})^{\alpha} = \sum_{j} V_{\alpha,j}\, B^{j}$. Expanding the
+    coefficient of $A^{[p]}$ at the word~$\tau$ by linearity of matrix
     multiplication and of the trace, the contributions reorganise into the
     $V$-weighted sum over length-$N$ words of $B$ required by
     Definition~\ref{def:p_refinable}, exhibiting $V$ as the isometry $W$ in the

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -1,7 +1,7 @@
 %% =========================================================
-%% Chapter: Periodic MPS — irreducible form and the periodic
+%% Chapter: Periodic MPS - irreducible form and the periodic
 %% Fundamental Theorem. Source: \cite[Sections~3--4]{DeLasCuevas2017Irreducible}.
-%% (de las Cuevas--Schuch--Pérez-García--Cirac).
+%% (de las Cuevas--Schuch--P\'erez-Garc\'ia--Cirac).
 %% =========================================================
 
 \chapter{Periodic MPS: irreducible form and the periodic Fundamental Theorem}%
@@ -75,7 +75,7 @@ The following compatibility theorems are proved in the present chapter.
 \begin{proof}\leanok
     \uses{lem:unitary_kraus_mixing}
     This is the unitary freedom of Kraus representations from
-    \cite[Theorem~2.18]{Wolf2012Quantum}.
+    \cite[Theorem~2.1(4)]{Wolf2012Quantum}.
 \end{proof}
 
 \begin{theorem}[Left-canonical preserved by physical rotation]%
@@ -213,7 +213,7 @@ The following compatibility theorems are proved in the present chapter.
     \uses{def:z_gauge_entry}
     If $\nu\neq 0$, then
     \[
-        z(\mu,\nu)\,\nu=\mu.
+        z(\mu,\nu) \nu=\mu.
     \]
 \end{lemma}
 
@@ -224,7 +224,7 @@ The following compatibility theorems are proved in the present chapter.
     For matched weight families $(\mu_i)_i$ and $(\nu_i)_i$ on a finite
     index type, define the diagonal matrix
     \[
-        Z := \diag\!\bigl(z(\mu_i,\nu_i)\bigr)_i.
+        Z := \diag\!(z(\mu_i,\nu_i))_i.
     \]
 \end{definition}
 
@@ -369,7 +369,7 @@ unconditional result.
 % The source-level equal-case theorem remains not ready as a single theorem:
 % the present Lean statements still assume the periodic-overlap and
 % coefficient-power hypotheses which the paper derives from equality of the
-% MPV family.  The Z-gauge/root-of-unity construction is already formalized.
+% MPV family. The Z-gauge/root-of-unity construction is already formalized.
 \begin{theorem}[Periodic Fundamental Theorem]\notready
     \label{thm:periodic_ft}
     \lean{MPSTensor.zgauge_construction, MPSTensor.equalCase_zgauge_of_power_sums,
@@ -436,10 +436,10 @@ unconditional result.
     (multiplicative and adjoint-preserving) intertwining the compressed adjoint
     transfer map with the sector adjoint transfer map on the corner of~$P_k$.
     This is the inverse cyclic indexing of the off-diagonal convention in
-    \cite[Appendix~A]{DeLasCuevas2017Irreducible}.  There the same adjoint
+    \cite[Appendix~A]{DeLasCuevas2017Irreducible}. There the same adjoint
     transfer map is written $E^*$, and the source projectors satisfy
     $E^*(P_u)=P_{u+1}$ together with
-    $A^i=\sum_u P_u A^i P_{u+1}$.  Here $P_k$ corresponds to the source
+    $A^i=\sum_u P_u A^i P_{u+1}$. Here $P_k$ corresponds to the source
     sector $u=-k \pmod m$, which turns the source shift into the displayed
     adjoint-transfer relation.
 \end{definition}
@@ -473,8 +473,8 @@ unconditional result.
     \[
         \E_B(Y)
         =
-        \zeta\overline{\zeta}\,
-        X\,\E_A(X^{-1}YX^{-*})\,X^* .
+        \zeta\overline{\zeta}
+        X\,\E_A(X^{-1}YX^{-*})\,X^*.
     \]
     With $\E_A(\rho_A)=\rho_A$, put
     $\sigma=X\rho_A X^*$. Then
@@ -529,7 +529,7 @@ unconditional result.
     whenever $d_u=e_v$, the corresponding sector tensors are not gauge-phase
     equivalent after identifying their virtual spaces:
     \[
-        d_u=e_v\quad\Longrightarrow\quad A_u\not\sim_{\mathrm{gp}}B_v .
+        d_u=e_v\quad\Longrightarrow\quad A_u\not\sim_{\mathrm{gp}}B_v.
     \]
     Then $\lim_{N\to\infty}O_{AB}(N)=0$.
 \end{theorem}
@@ -540,12 +540,12 @@ unconditional result.
         thm:overlap_decay_rect_irr_tp}
     Write
     $\bar A\sim\bigoplus_{u\in\mathbb Z_m}A_u$ and
-    $\bar B\sim\bigoplus_{v\in\mathbb Z_m}B_v$.  For every $N$,
+    $\bar B\sim\bigoplus_{v\in\mathbb Z_m}B_v$. For every $N$,
     \[
         O_{\bar A\bar B}(N)
         =
         \sum_{u\in\mathbb Z_m}\sum_{v\in\mathbb Z_m}
-            O_{A_uB_v}(N).
+        O_{A_uB_v}(N).
     \]
     For each sector pair $(u,v)$,
     \[
@@ -564,8 +564,8 @@ unconditional result.
         \lim_{N\to\infty} O_{\bar A\bar B}(N)
         =
         \sum_{u\in\mathbb Z_m}\sum_{v\in\mathbb Z_m}
-            \lim_{N\to\infty} O_{A_uB_v}(N)
-        =0 .
+        \lim_{N\to\infty} O_{A_uB_v}(N)
+        =0.
     \]
 
     If $A\sim_{\mathrm{gp}} B$, then $\bar A\sim_{\mathrm{gp}}\bar B$, so for
@@ -583,7 +583,7 @@ unconditional result.
     \]
     Since
     $\lim_{N\to\infty}O_{\bar A\bar A}(N)
-    =\lim_{N\to\infty}O_{\bar B\bar B}(N)=m>0$,
+        =\lim_{N\to\infty}O_{\bar B\bar B}(N)=m>0$,
     \[
         1
         =
@@ -592,7 +592,7 @@ unconditional result.
         =
         \lim_{N\to\infty}|\zeta|^{2N},
     \]
-    hence $|\zeta|=1$.  Therefore
+    hence $|\zeta|=1$. Therefore
     \[
         \lim_{N\to\infty}|O_{\bar A\bar B}(N)|
         =
@@ -697,16 +697,16 @@ unconditional result.
         thm:periodic_overlap_gauge_equiv_sector_match}
     If $m_A\ne m_B$, then
     $\lim_{N\to\infty}O_{AB}(N)=0$ by
-    Theorem~\ref{thm:periodic_overlap_zero_ne_period}.  Assume $m_A=m_B=m$.
+    Theorem~\ref{thm:periodic_overlap_zero_ne_period}. Assume $m_A=m_B=m$.
     If $D_A\ne D_B$, then
     $\lim_{N\to\infty}O_{AB}(N)=0$ by
-    Theorem~\ref{thm:periodic_overlap_zero_ne_dim}.  Assume $D_A=D_B$.
+    Theorem~\ref{thm:periodic_overlap_zero_ne_dim}. Assume $D_A=D_B$.
 
     Choose period-blocked sector decompositions
     \[
         \bar A\sim\bigoplus_{u\in\mathbb Z_m}A_u,
         \qquad
-        \bar B\sim\bigoplus_{v\in\mathbb Z_m}B_v .
+        \bar B\sim\bigoplus_{v\in\mathbb Z_m}B_v.
     \]
     If no pair $(u,v)$ satisfies
     \[
@@ -746,7 +746,7 @@ unconditional result.
 
     \begin{enumerate}
         \item \emph{Blocking approach} (Section~\ref{sec:ft_equal_proportional_cases},
-              following \cite{Cirac2017MPDO_AnnPhys}):
+              following \cite{Cirac2016MPDO_arXiv}):
               for a common multiple $p$ of the periods,
               \[
                   A^{[p]}\sim\bigoplus_a C_a,
@@ -848,7 +848,7 @@ unconditional result.
     There is also a proportional periodic Fundamental Theorem
     (Theorem~3.4, ``proportional case'', in \cite{DeLasCuevas2017Irreducible}).
     The former formulation of this theorem assumed externally supplied
-    coefficient arrays with nonzero limits as hypotheses.  That is not the
+    coefficient arrays with nonzero limits as hypotheses. That is not the
     hypothesis set of the source theorem.
     A faithful statement must instead derive the nondecaying cross-overlap
     witnesses from the proportional MPV hypothesis and the periodic BNT
@@ -870,9 +870,9 @@ unconditional result.
     (Theorem~\ref{thm:periodic_ft}) as an explicit hypothesis on the
     pair $(d, D)$, expressed by the hypothesis
     \lean{MPSTensor.PeriodicEqualCaseFT}\,$d\,D$.
-    If $A$ is on-site symmetric under~$U$ — that is, the twisted tensor
+    If $A$ is on-site symmetric under~$U$ - that is, the twisted tensor
     $\widetilde{A}_g$ has the same MPV family as~$A$ for every $g \in G$
-    — then for each $g \in G$ there exists a positive period $m_g$ and
+    - then for each $g \in G$ there exists a positive period $m_g$ and
     a $\Z_{m_g}$-gauge equivalence between~$A$ and~$\widetilde{A}_g$.
 
     Concretely there are matrices $Z_g$ and~$Y_g$, with $Z_g^{m_g} = \Id$
@@ -902,7 +902,7 @@ unconditional result.
     \uses{def:twisted_tensor, def:on_site_symmetric}
     Let $A$ be an MPS tensor with physical dimension $d$ and bond dimension $D$,
     and assume it is on-site symmetric under a group action
-    $U : G \to \GL_d(\C)$.  The tensor $A$ satisfies the
+    $U : G \to \GL_d(\C)$. The tensor $A$ satisfies the
     \emph{periodic projective-rigidity hypothesis} if one may choose a
     family of virtual gauges $Y : G \to \GL_D(\C)$ and a scalar
     $2$-cochain $u : G \times G \to \C^{\times}$ such that
@@ -937,7 +937,7 @@ unconditional result.
     $\omega : G \times G \to \C^{\times}$ and virtual gauges
     $X : G \to \GL_D(\C)$ satisfying
     \[
-        X(g)\, X(h) \;=\; \omega(g, h)\, X(g h),
+        X(g)\, X(h) =  \omega(g, h)\, X(g h),
     \]
     while for each $g$ the matrix $X(g^{-1})$ still realises the
     $\Z_{m_g}$-intertwining from
@@ -951,10 +951,10 @@ unconditional result.
     Unpack the rigidity hypothesis to extract the family
     $(Y, u)$ together with the intertwiners from
     \cite[Corollary~4.1]{DeLasCuevas2017Irreducible}. Set
-    $X(g) := Y(g^{-1})$ and $\omega(g, h) := u(h^{-1}, g^{-1})$.  The
+    $X(g) := Y(g^{-1})$ and $\omega(g, h) := u(h^{-1}, g^{-1})$. The
     projective multiplication law $X(g)\, X(h) = \omega(g, h)\, X(gh)$
     is then exactly the $(h^{-1}, g^{-1})$-instance of the factor-system
-    identity, using $(gh)^{-1} = h^{-1} g^{-1}$.  The intertwining
+    identity, using $(gh)^{-1} = h^{-1} g^{-1}$. The intertwining
     relation between $A$ and $\widetilde{A}_g$ transports unchanged.
 \end{proof}
 
@@ -980,11 +980,11 @@ unconditional result.
         \omega(g, h k)\, \omega(h, k)\, X(g (h k)).
     \]
     Since $(g h) k = g (h k)$, both sides are scalar multiples of the
-    same matrix $X((g h) k)$.  The matrix lies in $\GL_D(\C)$ and is
+    same matrix $X((g h) k)$. The matrix lies in $\GL_D(\C)$ and is
     therefore invertible, but the scalar cancellation leading from an
     equality of scalar multiples of a matrix to equality of the scalar
     coefficients additionally requires $D > 0$ so that the underlying
-    index set is inhabited.  Cancelling then yields
+    index set is inhabited. Cancelling then yields
     $\omega(g, h)\, \omega(g h, k) = \omega(g, h k)\, \omega(h, k)$
     in $\C^{\times}$, hence in $\mathrm{Units}(\C)$.
 \end{proof}
@@ -994,7 +994,7 @@ unconditional result.
     \uses{thm:cor_4_1_projective_rep_cocycle}
     The cohomology class of $\omega$ in $H^{2}(G, U(1))$ classifies the
     SPT phase of the symmetric MPS (cf.~Chen--Gu--Wen and
-    P\'erez-Garc\'ia et al.).  This classification statement is not
+    P\'erez-Garc\'ia et al.). This classification statement is not
     established here; only the underlying 2-cocycle identity of
     Theorem~\ref{thm:cor_4_1_projective_rep_cocycle} is available.
 \end{remark}
@@ -1016,7 +1016,7 @@ unconditional result.
 
 The next theorem characterises when the matrix-product-vector family of a
 periodic tensor admits a finer description in terms of a smaller-period
-tensor whose blocks have been merged.  This was the original motivation
+tensor whose blocks have been merged. This was the original motivation
 for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
 
 \begin{definition}[$p$-divisible CP map]
@@ -1041,9 +1041,9 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     of MPV coefficients:
     \[
         V^{(N)}(A^{[p]})_\tau
-        \;=\;
+        =
         \sum_{\sigma \in \{0,\ldots,d-1\}^N}
-        \Big(\prod_{k} W_{\tau(k),\,\sigma(k)}\Big)\,
+        \left(\prod_{k} W_{\tau(k), \sigma(k)}\right)
         V^{(N)}(B)_\sigma
     \]
     for every $N \in \N$ and every
@@ -1272,10 +1272,10 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
     families of the same completely positive map: the blocked family $A^{[p]}$
     with $d^{p}$ operators and the original family $B$ with $d$ operators.
     The cardinality comparison $d \le d^{p}$ holds whenever $p \ge 1$, so
-    \cite[Theorem~2.18]{Wolf2012Quantum} supplies an isometry
+    \cite[Theorem~2.1(4)]{Wolf2012Quantum} supplies an isometry
     $V \in M_{d^p \times d}(\C)$ with $V^{\dagger} V = \Id$ and
     $(A^{[p]})^{\alpha} = \sum_{j} V_{\alpha,j}\, B^{j}$. Expanding
-    $\mathrm{coeff}\,(A^{[p]})\,(\mathrm{ofFn}\,\tau)$ by linearity of matrix
+    $\mathrm{coeff}\,(A^{[p]})\,(\mathrm{ofFn} \tau)$ by linearity of matrix
     multiplication and of the trace, the contributions reorganise into the
     $V$-weighted sum over length-$N$ words of $B$ required by
     Definition~\ref{def:p_refinable}, exhibiting $V$ as the isometry $W$ in the
@@ -1289,5 +1289,5 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
     \cite{DeLasCuevas2017Irreducible}: refinability along arbitrarily
     large $p$ is equivalent to infinite divisibility of the transfer
     map, which selects out continuum limits of translationally invariant
-    MPS.  The further consequences are explored elsewhere.
+    MPS. The further consequences are explored elsewhere.
 \end{remark}

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -1829,7 +1829,7 @@ The four equivalent reducibility conditions of
     Induction on elements of the subalgebra shows
     $(1-P)A P = 0$ for every generator. Since the generated algebra is
     all of $M_d(\C)$, every matrix satisfies $(1-P)AP = 0$, forcing
-    $P = 0$ or $P = \Id$ - a contradiction.
+    $P = 0$ or $P = \Id$ --- a contradiction.
 \end{proof}
 
 \begin{theorem}[Hermitian span with trivial commutant forbids triangular form]%

--- a/blueprint/src/chapter/ch12_semigroup.tex
+++ b/blueprint/src/chapter/ch12_semigroup.tex
@@ -158,7 +158,7 @@ and proves the GKSL theorem.
     \uses{thm:hasDerivAt_expSemigroupCLM_ch12, thm:expSemigroup_toCLM_ch12}
     For every $X \in \MN{D}$ and every $t \in \R$,
     \[
-        \frac{d}{dt}\bigl(e^{tL}(X)\bigr) = e^{tL}(L(X)).
+        \frac{d}{dt}(e^{tL}(X)) = e^{tL}(L(X)).
     \]
 \end{theorem}
 
@@ -235,7 +235,7 @@ and proves the GKSL theorem.
         e^{tL'} - e^{tL}
         = \int_0^t e^{(t-s)L} \Delta\,e^{sL'}\,ds.
     \]
-    This is \cite[Lem.~7.1]{Wolf2012Quantum}.
+    This is \cite[Lemma~7.1]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
@@ -368,7 +368,7 @@ and proves the GKSL theorem.
     \uses{def:exp_semigroup_ch12}
     By induction on $n$. The base case is continuity of the matrix
     exponential. For the inductive step, the parametric integral
-    $t\mapsto \int_0^t e^{(t-s)L}\,\Delta\,\widetilde{T}^{(n)}_s\,ds$
+    $t\mapsto \int_0^t e^{(t-s)L} \Delta\,\widetilde{T}^{(n)}_s\,ds$
     is continuous by the continuous-parameter primitive theorem;
     the pasting lemma extends this to all of $\mathbb{R}$ since
     $\widetilde{T}^{(n+1)}_t = 0$ for $t \le 0$.
@@ -392,7 +392,7 @@ and proves the GKSL theorem.
         thm:dysonTerm_continuous_ch12}
     Induction on $N$. The base case is the semigroup supremum bound.
     The inductive step uses the telescoping remainder identity
-    $R_{N+1}(s) = \int_0^s e^{(s-u)L}\,\Delta\,R_N(u)\,du$
+    $R_{N+1}(s) = \int_0^s e^{(s-u)L} \Delta\,R_N(u)\,du$
     (derived from the Duhamel formula), bounds the integrand
     pointwise, and integrates to recover the factorial.
 \end{proof}
@@ -587,7 +587,7 @@ which shows that such generators have the standard Lindblad form.
         L(\rho)
         = i[\rho, H]
         + \tfrac{1}{2}\sum_{j}
-        \bigl([L_j,\,\rho L_j^\dagger]
+        \bigl([L_j, \rho L_j^\dagger]
         + [L_j\rho,\,L_j^\dagger]\bigr),
     \]
     where $[A,B] = AB - BA$.
@@ -747,7 +747,7 @@ which shows that such generators have the standard Lindblad form.
     If two Lindblad forms $F, F'$ induce the same generator and
     both have traceless Kraus operators, then their CP parts agree:
     $\phi = \phi'$.
-    This is part of \cite[Proposition~7.4, item~2]{Wolf2012Quantum}.
+    This is part of \cite[Proposition~7.4(2)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -763,7 +763,7 @@ which shows that such generators have the standard Lindblad form.
     both have traceless Kraus operators, then their drift matrices
     differ by an imaginary scalar: $\kappa' = \kappa + i\lambda\,\Id$
     for some $\lambda \in \R$.
-    This is part of \cite[Proposition~7.4, item~2]{Wolf2012Quantum}.
+    This is part of \cite[Proposition~7.4(2)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -936,8 +936,7 @@ which shows that such generators have the standard Lindblad form.
     \[
         L(\rho)
         = i[\rho, H]
-        + \tfrac{1}{2}\sum_{k,l} C_{lk}\bigl(
-        [F_k, \rho F_l^\dagger] + [F_k\rho, F_l^\dagger]
+        + \tfrac{1}{2}\sum_{k,l} C_{lk}\bigl(    [F_k, \rho F_l^\dagger] + [F_k\rho, F_l^\dagger]
         \bigr).
     \]
     In Wolf's formula one takes $\{F_k\}$ to be a basis of traceless matrices;
@@ -957,7 +956,7 @@ which shows that such generators have the standard Lindblad form.
     Forward: diagonalize $C = B^\dagger B$ and set
     $L_j = \sum_k B_{jk} F_k$.
     Reverse: keep the same Hamiltonian and family $F_k = L_k$, and take
-    $C = \,\Id$.
+    $C = \Id$.
 \end{proof}
 
 %% ---------------------------------------------------------
@@ -1067,12 +1066,12 @@ which shows that such generators have the standard Lindblad form.
     \label{thm:fixedPoint_eq_trace_smul_irreducible_channel_ch12}
     \lean{fixedPoint_eq_trace_smul_of_irreducible_channel}\leanok
     If $E$ is an irreducible channel with faithful fixed density $\sigma$, then every
-    nonzero fixed point $V$ of $E$ satisfies $V = \tr(V)\,\sigma$.
+    nonzero fixed point $V$ of $E$ satisfies $V = \tr(V) \sigma$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Subtract the trace multiple $\tr(V)\,\sigma$ and apply the vanishing theorem for
+    Subtract the trace multiple $\tr(V) \sigma$ and apply the vanishing theorem for
     trace-zero fixed points of an irreducible channel.
 \end{proof}
 
@@ -1159,7 +1158,7 @@ which shows that such generators have the standard Lindblad form.
 \end{proof}
 
 \begin{remark}[Semigroup irreducible/primitive equivalence]\leanok
-    The semigroup analogue of the irreducible/primitive equivalence
+    The semigroup analog of the irreducible/primitive equivalence
     starts from one irreducible time slice, constructs a primitive
     smaller time step, and lifts the conclusion to the full semigroup
     (Theorems~\ref{thm:irreducible_semigroup_implies_primitive}
@@ -1190,7 +1189,7 @@ which shows that such generators have the standard Lindblad form.
     \label{thm:fixedPoint_eq_trace_smul_at_irreducible_time_ch12}
     \lean{fixedPoint_eq_trace_smul_at_irreducible_time}\leanok
     If $T_{t_0}$ is irreducible with faithful fixed density $\sigma$, then every fixed point
-    $V$ of $T_{t_0}$ satisfies $V = \tr(V)\,\sigma$.
+    $V$ of $T_{t_0}$ satisfies $V = \tr(V) \sigma$.
 \end{theorem}
 
 \begin{proof}
@@ -1305,7 +1304,7 @@ which shows that such generators have the standard Lindblad form.
     \lean{fixedPoint_eq_trace_smul_of_primitive_slice}\leanok
     If $T_u$ is primitive and $\sigma$ is the common fixed density, then
     every fixed point of any positive-time slice $T_s$ has the form
-    $\tau = \tr(\tau)\,\sigma$.
+    $\tau = \tr(\tau) \sigma$.
 \end{theorem}
 
 \begin{theorem}[Existence of a primitive reduced time step]
@@ -1365,7 +1364,7 @@ which shows that such generators have the standard Lindblad form.
     For a quantum dynamical semigroup $T_t = e^{tL}$:
     \[
         (\exists\, t_0 > 0,\ T_{t_0}\ \text{irreducible})
-        \;\iff\;
+        \iff
         (\forall\, t > 0,\ T_t\ \text{primitive and irreducible}).
     \]
     This is \cite[Proposition~7.5]{Wolf2012Quantum}.
@@ -1473,7 +1472,7 @@ which shows that such generators have the standard Lindblad form.
     then for any $A$:
     \[
         L^*(A) = 0
-        \;\implies\;
+        \implies
         [A,H] = [A,L_j] = [A,L_j^\dagger] = 0\ \forall j.
     \]
     That is, $\ker(L^*) \subseteq \{H, L_j, L_j^\dagger\}'$.
@@ -1581,7 +1580,7 @@ The four equivalent reducibility conditions of
     \label{thm:generator_preserves_compression_from_semigroup_ch12}
     \lean{generatorPreservesCompression_of_semigroupPreservesCompression}\leanok
     \uses{def:generator_preserves_compression_ch12, def:has_invariant_compression}
-    If the semigroup preserves $P M_d(\C) P$ for all nonnegative times, then the generator
+    If the semigroup preserves $P M_d(\C) P$ for all non-negative times, then the generator
     preserves the same compression.
 \end{theorem}
 
@@ -1627,7 +1626,7 @@ The four equivalent reducibility conditions of
         def:has_rank_deficient_kernel_element}
     A rank-deficient density matrix is a fixed point of $e^{tL}$ for all
     $t \ge 0$ if and only if it lies in $\ker L$.
-    This is \cite[Proposition~7.6, (1)$\leftrightarrow$(2)]{Wolf2012Quantum}.
+    This is \cite[Proposition~7.6, (1)$\Leftrightarrow$(2)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1643,7 +1642,7 @@ The four equivalent reducibility conditions of
         def:has_invariant_compression, def:is_gksl_generator}
     If $L$ is a GKSL generator and there exists a rank-deficient fixed
     density matrix, then the semigroup preserves a nontrivial compression.
-    This is \cite[Proposition~7.6, (1)$\to$(3)]{Wolf2012Quantum}.
+    This is \cite[Proposition~7.6, (1)$\Rightarrow$(3)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1697,7 +1696,7 @@ The four equivalent reducibility conditions of
     For a GKSL generator $L$, the semigroup preserves a nontrivial
     compression if and only if the Lindblad data can be chosen
     block-upper-triangular.
-    This is \cite[Proposition~7.6, (3)$\leftrightarrow$(4)]{Wolf2012Quantum}.
+    This is \cite[Proposition~7.6, (3)$\Leftrightarrow$(4)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1716,7 +1715,7 @@ The four equivalent reducibility conditions of
     with respect to some nontrivial projector $P$,
     then there exists a density matrix $\rho_0$ with nontrivial kernel
     satisfying $L(\rho_0) = 0$.
-    This is \cite[Proposition~7.6, (4)$\to$(2)]{Wolf2012Quantum}.
+    This is \cite[Proposition~7.6, (4)$\Rightarrow$(2)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
@@ -1808,7 +1807,7 @@ The four equivalent reducibility conditions of
     From $L = \varphi - \kappa(\cdot) - (\cdot)\kappa^\dagger$ and
     $(1-P)L(P) = 0$: the $(1-P)\varphi(P)$ term vanishes because each
     $(1-P)L_j P = 0$, and the $(1-P)(P\kappa^\dagger)$ term vanishes
-    because $(1-P)P = 0$.  What remains is $(1-P)\kappa P = 0$.
+    because $(1-P)P = 0$. What remains is $(1-P)\kappa P = 0$.
 \end{proof}
 
 \begin{theorem}[Full algebra generation forbids block-upper-triangular form]%
@@ -1828,9 +1827,9 @@ The four equivalent reducibility conditions of
     By Theorem~\ref{thm:kappa_block_generator_compression},
     $(1-P)\kappa P = 0$.
     Induction on elements of the subalgebra shows
-    $(1-P)A P = 0$ for every generator.  Since the generated algebra is
+    $(1-P)A P = 0$ for every generator. Since the generated algebra is
     all of $M_d(\C)$, every matrix satisfies $(1-P)AP = 0$, forcing
-    $P = 0$ or $P = \Id$ — a contradiction.
+    $P = 0$ or $P = \Id$ - a contradiction.
 \end{proof}
 
 \begin{theorem}[Hermitian span with trivial commutant forbids triangular form]%
@@ -1845,9 +1844,9 @@ The four equivalent reducibility conditions of
 \end{theorem}
 \begin{proof}\leanok
     Assume for contradiction that a block-upper-triangular decomposition
-    exists with nontrivial projection $P$.  The block vanishing
+    exists with nontrivial projection $P$. The block vanishing
     $(1-P)L_j P = 0$ and Hermitian closure give $P L_j (1-P) = 0$ as
-    well, so $[P, L_j] = 0$ for all $j$.  But then $P$ lies in the
+    well, so $[P, L_j] = 0$ for all $j$. But then $P$ lies in the
     commutant of the Lindblad span, contradicting triviality.
 \end{proof}
 
@@ -1892,7 +1891,7 @@ The four equivalent reducibility conditions of
         thm:not_isReducibleQDS_of_no_blockUpperTriangular_ch12}
     If the algebra generated by $\{L_j\}$ and $\kappa$ is the entire
     matrix algebra $M_d(\C)$, then the QDS is not reducible.
-    This is \cite[Corollary~7.2, condition~1]{Wolf2012Quantum}.
+    This is \cite[Corollary~7.2(1)]{Wolf2012Quantum}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:full_algebra_gen_no_block_ut,
@@ -1911,7 +1910,7 @@ The four equivalent reducibility conditions of
         thm:not_isReducibleQDS_of_no_blockUpperTriangular_ch12}
     If the Lindblad span is Hermitian-closed and its commutant is trivial,
     then the QDS is not reducible.
-    This is \cite[Corollary~7.2, condition~2]{Wolf2012Quantum}.
+    This is \cite[Corollary~7.2(2)]{Wolf2012Quantum}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:herm_span_trivial_commutant_no_block_ut,
@@ -1928,7 +1927,7 @@ The four equivalent reducibility conditions of
         thm:large_kossakowski_rank_no_block_ut_ch12,
         thm:not_isReducibleQDS_of_no_blockUpperTriangular_ch12}
     If $\rank(C) > d^2 - d$, then the QDS is not reducible.
-    This is \cite[Corollary~7.2, condition~3]{Wolf2012Quantum}.
+    This is \cite[Corollary~7.2(3)]{Wolf2012Quantum}.
 \end{theorem}
 \begin{proof}\leanok
     The rank hypothesis rules out block-upper-triangular Lindblad data by

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -367,10 +367,10 @@ shows that this agreement forces the local tensors to be proportional.
     all $Y \in \MN{D}$ (on the external bond), and all physical indices $i,j$,
     \begin{align}
         \tr(A_1^{i}\, X\, A_2^{j})
-         & = \tr(B_1^{i}\, X\, B_2^{j})
-        \label{eq:internal_bond}        \\
+         &= \tr(B_1^{i}\, X\, B_2^{j})
+        \label{eq:internal_bond}\\
         \tr(A_2^{j}\, Y\, A_1^{i})
-         & = \tr(B_2^{j}\, Y\, B_1^{i})
+         &= \tr(B_2^{j}\, Y\, B_1^{i})
         \label{eq:external_bond}
     \end{align}
     Diagrammatically, inserting $X$ on the bond between the two sites
@@ -400,7 +400,7 @@ shows that this agreement forces the local tensors to be proportional.
     \leanok
     \uses{def:decomposition_map, lem:center_scalar}
     By cyclicity and non-degeneracy of the trace pairing,
-    the conditions in Eqs.~(\ref{eq:internal_bond}) and~(\ref{eq:external_bond})
+    the conditions in Eqs. (\ref{eq:internal_bond}) and (\ref{eq:external_bond})
     give, for all physical indices $i,j$,
     \[
         \begin{aligned}
@@ -1153,7 +1153,7 @@ The first lemmas in this section are elementary facts about block-diagonal tenso
 they assemble already-known block gauges, and they record the easy consequences
 of applying the injective single-block theorem to each block separately. They do
 not derive the block matching appearing in
-\cite[Theorem~II.1]{Cirac2017MPDO_AnnPhys}. In the source proof, that matching
+\cite[Theorem~2.10]{Cirac2016MPDO_arXiv}. In the source proof, that matching
 is obtained from BNT overlap, independence, and coefficient comparison; the
 corresponding global gauge assembly is
 Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
@@ -1243,7 +1243,7 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
     See Definition~\ref{def:block_diagonal_tensor} for the formalized
     block-diagonal tensor construction. The results in this subsection assume
     that the block correspondence has already been fixed; they do not prove
-    \cite[Theorem~II.1]{Cirac2017MPDO_AnnPhys}. They are therefore retained
+    \cite[Theorem~2.10]{Cirac2016MPDO_arXiv}. They are therefore retained
     here as same-index assembly corollaries, not among the BNT preparation
     steps used in the source proof or in the after-blocking canonical-form
     reduction.
@@ -1270,7 +1270,7 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
     This is a block-sum reformulation of the per-block injective single-block FT:
     the block pairing $(A_k, B_k)$ is assumed already given and the blocks already
     matched. It is not the multi-block Fundamental Theorem of
-    \cite[Theorem~II.1, lines~349--352]{Cirac2017MPDO_AnnPhys}, which derives the
+    \cite[Theorem~2.10, lines~349--352]{Cirac2016MPDO_arXiv}, which derives the
     block matching and permutation from only the global same-MPV hypothesis.
 \end{remark}
 
@@ -1520,7 +1520,7 @@ sector counts and bond dimensions before matching.
     matched copy multiplicities agree, and the copy weights agree up to a
     unit-modulus phase $\zeta$ and a copy-index reindexing.
     This is the sector-data form of the equal-case theorem
-    \cite[Corollary~II.2, lines 354--361 and appendix 1172--1192]{Cirac2017MPDO_AnnPhys};
+    \cite[Corollary~2.11, lines 354--361 and appendix 1172--1192]{Cirac2016MPDO_arXiv};
     the corresponding global gauge corollary is recorded in
     Chapter~\ref{ch:ft_proof}.
     % Maintainer note (Lean): the global-gauge companion is

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -400,7 +400,7 @@ shows that this agreement forces the local tensors to be proportional.
     \leanok
     \uses{def:decomposition_map, lem:center_scalar}
     By cyclicity and non-degeneracy of the trace pairing,
-    the conditions in Eqs. (\ref{eq:internal_bond}) and (\ref{eq:external_bond})
+    the conditions in Equations~(\ref{eq:internal_bond}) and~(\ref{eq:external_bond})
     give, for all physical indices $i,j$,
     \[
         \begin{aligned}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -141,12 +141,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     If $M_{ie}$ is the oriented endpoint matrix attached to an incident edge
     $ie$ at $v$, then
     $\widetilde B_v(\eta,\sigma)=
-    \sum_{\eta'}(\prod_{ie}M_{ie}(\eta(ie),\eta'(ie)))B_v(\eta',\sigma)$.
+        \sum_{\eta'}(\prod_{ie}M_{ie}(\eta(ie),\eta'(ie)))B_v(\eta',\sigma)$.
 \end{theorem}
 \begin{proof}\leanok
     Expanding $\widetilde B=B^X$ at a vertex gives
     $\widetilde B_v(\eta,\sigma)=(B^X)_v(\eta,\sigma)=
-    \sum_{\eta'}(\prod_{ie}M_{ie}(\eta(ie),\eta'(ie)))B_v(\eta',\sigma)$.
+        \sum_{\eta'}(\prod_{ie}M_{ie}(\eta(ie),\eta'(ie)))B_v(\eta',\sigma)$.
 \end{proof}
 
 \begin{definition}[Gauge equivalence for PEPS]%
@@ -195,7 +195,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     A PEPS tensor $A$ is \emph{vertex-injective} if, at every vertex $v$, the
     family of physical vectors
     \[
-        \bigl(A_v(\eta, \cdot) \in \C^d\bigr)_{\eta}
+        (A_v(\eta, \cdot) \in \C^d)_{\eta}
     \]
     indexed by virtual configurations $\eta$ on the edges incident to $v$ is
     linearly independent in $\C^d$. Equivalently, extending $A_v$ by linearity
@@ -234,7 +234,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     For an endomorphism $T$ of the coefficient space on local virtual
     configurations at $v$, define the local physical operator
     \[
-        O_T = \Phi_v \circ T \circ \Psi_v .
+        O_T = \Phi_v \circ T \circ \Psi_v.
     \]
 \end{definition}
 
@@ -246,7 +246,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     For every coefficient function $c$ on the local virtual configurations at
     $v$,
     \[
-        O_T\bigl(\Phi_v(c)\bigr) = \Phi_v(Tc).
+        O_T(\Phi_v(c)) = \Phi_v(Tc).
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -276,7 +276,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The local projector is the physical realization of the identity virtual
     operator:
     \[
-        P_v = \Phi_v \circ \Psi_v .
+        P_v = \Phi_v \circ \Psi_v.
     \]
 \end{definition}
 
@@ -288,7 +288,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     For a physical operator $O$ on the local physical space at $v$, define
     its virtual pullback by
     \[
-        \Psi_v \circ O \circ \Phi_v .
+        \Psi_v \circ O \circ \Phi_v.
     \]
     This is the local injectivity step used in the physical-to-virtual
     direction of the insertion-algebra argument in
@@ -352,7 +352,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         T_O = T_{O'}
         \quad\Longleftrightarrow\quad
         P_v O \Phi_v(c)=P_v O'\Phi_v(c)
-        \quad\text{for all }c .
+        \quad\text{for all }c.
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -388,7 +388,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     operator $O$. Then
     \[
         \Phi_v\circ T_O\circ\Psi_v
-        = P_v\circ O\circ P_v .
+        = P_v\circ O\circ P_v.
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -408,7 +408,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{theorem}
 \begin{proof}\leanok
     The physical realization of the virtual pullback of $O$ is
-    $P_v O P_v$.  By hypothesis this is the physical realization of $T$.
+    $P_v O P_v$. By hypothesis this is the physical realization of $T$.
     Injectivity of the canonical physical realization gives equality of the
     virtual operations.
 \end{proof}
@@ -538,7 +538,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     For any edge $e = (u,v)$ and any function $f$ on the vertex set with values
     in a commutative monoid $M$,
     \[
-        \prod_{x \in V} f(x) = f(u) \Bigl(\prod_{x \in V \setminus \{u,v\}} f(x)\Bigr) f(v).
+        \prod_{x \in V} f(x) = f(u) \left(\prod_{x \in V \setminus \{u,v\}} f(x)\right) f(v).
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -935,8 +935,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
         A_v(\omega|_v,\sigma_v)
         =
         \sum_{\beta}
-        A_u(\beta_u,\sigma_u)\,
-        C_{A,M_e}(\beta,\sigma|_{M_e})\,
+        A_u(\beta_u,\sigma_u)
+        C_{A,M_e}(\beta,\sigma|_{M_e})
         A_v(\beta_v,\sigma_v).
     \]
     Under the equivalence, $\omega|_u=\beta_u$ and $\omega|_v=\beta_v$; the
@@ -960,9 +960,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
         C_A(e,\Id;\sigma)
         =
         \sum_{a,b,\lambda,\rho}
-        \delta_{a,b}\,
-        A_u(a,\lambda;\sigma_u)\,
-        C^{\mathrm{open}}_{A,M_e}(\lambda,\rho;\sigma|_{M_e})\,
+        \delta_{a,b}
+        A_u(a,\lambda;\sigma_u)
+        C^{\mathrm{open}}_{A,M_e}(\lambda,\rho;\sigma|_{M_e})
         A_v(b,\rho;\sigma_v).
     \]
     Here $a,b$ are the two copies of the distinguished bond index, while
@@ -970,7 +970,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The factor $\delta_{a,b}$
     leaves only the diagonal $a=b$, and the open-middle reindexing gives
     $C^{\mathrm{open}}_{A,M_e}(\lambda,\rho;\sigma|_{M_e})
-    =C_{A,M_e}(a,\lambda,\rho;\sigma|_{M_e})$. Hence
+        =C_{A,M_e}(a,\lambda,\rho;\sigma|_{M_e})$. Hence
     $C_A(e,\Id;\sigma)=C_A(e;\sigma)=\operatorname{Coeff}_A(\sigma)$.
 \end{proof}
 
@@ -1103,7 +1103,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     For each $v$, the preceding theorem gives
     $A\text{ vertex-injective}\Longrightarrow
-    \operatorname{inj}(T_{A,\{v\}})$. The comparison hypothesis gives
+        \operatorname{inj}(T_{A,\{v\}})$. The comparison hypothesis gives
     $\operatorname{inj}(T_{A,\{v\}})\Longrightarrow\kappa(\{v\})$. Their
     composition is the claimed implication.
 \end{proof}
@@ -1402,16 +1402,14 @@ injective and normal PEPS, following Theorems~2 and~3 of
     endpoint configurations. It assigns to every finitely supported coefficient
     family $c=(c_{\rho})_{\rho}$ a finite kernel descent datum $K_c(S)$ such that
     \[
-        \left(
-            \forall\tau,\;
-            \sum_{\rho}c_{\rho}\,
-                T_{A,M_e}^{\rho}(\tau)=0
-        \right)
+        \left(\forall\tau,
+        \sum_{\rho}c_{\rho}
+        T_{A,M_e}^{\rho}(\tau)=0\right)
         \Longrightarrow K_c(M_e),
     \]
     and
     \[
-        K_c(\varnothing)\Longrightarrow \forall\rho,\;c_{\rho}=0.
+        K_c(\varnothing)\Longrightarrow \forall\rho, c_{\rho}=0.
     \]
 \end{definition}
 
@@ -1431,13 +1429,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Let $c=(c_{\rho})_{\rho}$ be a finite linear relation among the middle
     tensor vectors:
     \[
-        \forall\tau,\;
-        \sum_{\rho}c_{\rho}\,
-            T_{A,M_e}^{\rho}(\tau)=0.
+        \forall\tau,
+        \sum_{\rho}c_{\rho}
+        T_{A,M_e}^{\rho}(\tau)=0.
     \]
     The initial part of the descent datum gives $K_c(M_e)$. The finite descent
     lemma gives $K_c(M_e)\Longrightarrow K_c(\varnothing)$, and the terminal
-    part gives $\forall\rho,\;c_{\rho}=0$. Thus every finite relation is
+    part gives $\forall\rho, c_{\rho}=0$. Thus every finite relation is
     trivial, which is $\operatorname{inj}(T_{A,M_e})$. Vertex injectivity at
     $u$ and $v$ gives $\operatorname{inj}(T_{A,u})$ and
     $\operatorname{inj}(T_{A,v})$; the edge-blocked three-site injectivity at
@@ -1470,17 +1468,17 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Theorem~\ref{thm:peps_edgeMiddleTensorInjective_of_kernelDescent}: for each
     finite relation
     \[
-        \forall \tau,\;
+        \forall \tau,
         \sum_{\rho} c_{\rho}\,T_{A,M_e}^{\rho}(\tau)=0,
     \]
     the associated conditions $K_c(S)$ satisfy $K_c(M_e)$,
     $j\in S\Longrightarrow K_c(S)\Longrightarrow K_c(S\setminus\{j\})$, and
-    $K_c(\varnothing)\Longrightarrow \forall\rho,\;c_{\rho}=0$. The descent
+    $K_c(\varnothing)\Longrightarrow \forall\rho, c_{\rho}=0$. The descent
     implication is the local contraction identity: for $j\in S$, vertex
     injectivity at $j$ gives a left inverse $L_j$, and applying $L_j$ to the
     relation contracts away that tensor,
     \[
-        j\in S,\;K_c(S)\quad\stackrel{L_j}{\Longrightarrow}\quad
+        j\in S, K_c(S)\quad\stackrel{L_j}{\Longrightarrow}\quad
         K_c(S\setminus\{j\}).
     \]
     The kernel descent theorem gives $\operatorname{inj}(T_{A,M_e})$. The same
@@ -1563,10 +1561,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     The endpoint equivalences give
     $P_uO_1P_u=\Phi_uT_{u,e}(M^{\mathsf T})\Psi_u
-    \iff \Psi_uO_1\Phi_u=T_{u,e}(M^{\mathsf T})$
+        \iff \Psi_uO_1\Phi_u=T_{u,e}(M^{\mathsf T})$
     and
     $P_vO_2P_v=\Phi_vT_{v,e}(M)\Psi_v
-    \iff \Psi_vO_2\Phi_v=T_{v,e}(M)$.
+        \iff \Psi_vO_2\Phi_v=T_{v,e}(M)$.
     The two hypotheses are the left sides of these equivalences.
 \end{proof}
 
@@ -1668,13 +1666,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     physical configuration $\sigma$,
     \[
         \sum_{\beta}
-        O_1(A_u(\beta_u))_{\sigma_u}\,
-        C_{\mathrm{mid}}(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        O_1(A_u(\beta_u))_{\sigma_u}
+        C_{\mathrm{mid}}(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})
         A_v(\beta_v)_{\sigma_v}
         =
         \sum_{\beta}
-        A_u(\beta_u)_{\sigma_u}\,
-        C_{\mathrm{mid}}(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        A_u(\beta_u)_{\sigma_u}
+        C_{\mathrm{mid}}(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})
         O_2(A_v(\beta_v))_{\sigma_v}.
     \]
     Then
@@ -1702,8 +1700,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     For two PEPS tensors $A$ and $B$ and an edge $e$, this property is
     \[
         \exists \Phi_e:\MN{D_A(e)}
-            \simeq_{\mathrm{alg}}
-            \MN{D_B(e)},\qquad
+        \simeq_{\mathrm{alg}}
+        \MN{D_B(e)},\qquad
         \forall \sigma,\ \forall X\in\MN{D_A(e)},\quad
         C_A(e,\sigma,X)=C_B(e,\sigma,\Phi_e(X)).
     \]
@@ -1724,8 +1722,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     state. Then
     \[
         \exists \Phi_e:\MN{D_A(e)}
-            \simeq_{\mathrm{alg}}
-            \MN{D_B(e)},\qquad
+        \simeq_{\mathrm{alg}}
+        \MN{D_B(e)},\qquad
         \forall \sigma,\ \forall X\in\MN{D_A(e)},\quad
         C_A(e,\sigma,X)=C_B(e,\sigma,\Phi_e(X)).
     \]
@@ -1914,7 +1912,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Given edge gauges $X_e$, set $\widetilde B=B^X$. Then
     $D_{\widetilde B}=D_B$ and, for every vertex $v$,
     $\widetilde B_v(\eta,\sigma)=
-    \sum_{\eta'}(\prod_{ie}M_{ie}(\eta(ie),\eta'(ie)))B_v(\eta',\sigma)$,
+        \sum_{\eta'}(\prod_{ie}M_{ie}(\eta(ie),\eta'(ie)))B_v(\eta',\sigma)$,
     where $M_{ie}=X_e$ or $M_{ie}=(X_e^{-1})^t$ according to the orientation of
     the endpoint $ie$.
     \begin{center}
@@ -1928,7 +1926,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     gives $D_{\widetilde B}=D_B$, and
     Theorem~\ref{thm:peps_absorbEdgeGauges_component} gives
     $\widetilde B_v(\eta,\sigma)=
-    \sum_{\eta'}(\prod_{ie}M_{ie}(\eta(ie),\eta'(ie)))B_v(\eta',\sigma)$.
+        \sum_{\eta'}(\prod_{ie}M_{ie}(\eta(ie),\eta'(ie)))B_v(\eta',\sigma)$.
 \end{proof}
 
 \begin{definition}[Post-absorption inserted-edge comparison]%
@@ -1940,7 +1938,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     when $h:D_A=D_{\widetilde B}$ and the following equality holds. For each
     edge $e$, write
     $\phi_{h_e}:\MN{D_A(e)}
-    \to\MN{D_{\widetilde B}(e)}$ for the matrix-algebra
+        \to\MN{D_{\widetilde B}(e)}$ for the matrix-algebra
     transport induced by $h_e:D_A(e)=D_{\widetilde B}(e)$. Then, for every
     matrix $X\in\MN{D_A(e)}$ and every physical configuration
     $\sigma$,
@@ -2116,7 +2114,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \[
         \delta_{aa'} Z_{bc,b'c'}
         =
-        U_{ab,a'b'}\delta_{cc'} .
+        U_{ab,a'b'}\delta_{cc'}.
     \]
     If $c\neq c'$, the right hand side is zero; choosing $a=a'$ gives
     $Z_{bc,b'c'}=0$. Hence $Z$ is diagonal in the $\gamma$-index. Similarly,
@@ -2177,7 +2175,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \[
         \lambda =
         \frac{B_2(\eta_2^0,\nu^0,\sigma_2^0)}
-             {A_2(\eta_2^0,\nu^0,\sigma_2^0)} .
+        {A_2(\eta_2^0,\nu^0,\sigma_2^0)}.
     \]
     For every $(\eta_1,\mu,\sigma_1)$, the product identity with
     $(\eta_2^0,\nu^0,\sigma_2^0)$ fixed gives
@@ -2254,7 +2252,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $\lambda\in\C^\times$ such that
     \[
         A_1=\lambda B_1,\qquad
-        A_2=\lambda^{-1}B_2 .
+        A_2=\lambda^{-1}B_2.
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -2293,7 +2291,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \]
     Assume
     $C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)
-    =C_{B_1,B_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for every
+        =C_{B_1,B_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)$ for every
     $b,X,\eta_1,\eta_2,\sigma_1,\sigma_2$:
     \begin{center}
         \TNPEPSTwoInjectiveTensorInsertionComparison
@@ -2335,7 +2333,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         =
         U\otimes I_\gamma
         =
-        W_{\alpha\gamma}\otimes I_\beta .
+        W_{\alpha\gamma}\otimes I_\beta.
     \]
     Write $Z=\sum_i Z_i^{(1)}\otimes Z_i^{(2)}$,
     $U=\sum_i U_i^{(1)}\otimes U_i^{(2)}$, and
@@ -2361,8 +2359,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
         \sum_\mu
         B_1(\eta_1,\mu,\sigma_1)
         \bigl(A_2(\eta_2,\mu,\sigma_2)
-            -\lambda^{-1}B_2(\eta_2,\mu,\sigma_2)\bigr)
-        =0 .
+        -\lambda^{-1}B_2(\eta_2,\mu,\sigma_2)\bigr)
+        =0.
     \]
     Injectivity of $B_1$ gives
     $A_2(\eta_2,\mu,\sigma_2)=\lambda^{-1}B_2(\eta_2,\mu,\sigma_2)$.
@@ -2385,7 +2383,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         C_{A_v,A_{v^c}}(b,X;\eta_v,\eta_{v^c},\sigma_v,\sigma_{v^c})
         =
         C_{\widetilde B_v,\widetilde B_{v^c}}
-            (b,X;\eta_v,\eta_{v^c},\sigma_v,\sigma_{v^c}).
+        (b,X;\eta_v,\eta_{v^c},\sigma_v,\sigma_{v^c}).
     \]
     Then
     \[
@@ -2429,7 +2427,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         =
         \lambda_S\widetilde B_S
         =
-        \lambda_S\widetilde B_R\widetilde B_v .
+        \lambda_S\widetilde B_R\widetilde B_v.
     \]
     Applying the left inverse supplied by injectivity of the block
     $A_R=\lambda_R\widetilde B_R$ gives
@@ -2659,26 +2657,26 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{lemma}
 \begin{proof}
     Put $P_0=A\setminus B$, $P_1=A\cap B$, $P_2=B\setminus A$, and
-    $P_3=(A\cup B)^c$.  Then $P_0\cup P_1=A$, $P_1\cup P_2=B$, and
-    $P_0\cup P_1\cup P_2=A\cup B$.  Let $\mathcal C_I$ denote contraction of
-    the blocked tensor over the region $\bigcup_{i\in I}P_i$.  To prove
+    $P_3=(A\cup B)^c$. Then $P_0\cup P_1=A$, $P_1\cup P_2=B$, and
+    $P_0\cup P_1\cup P_2=A\cup B$. Let $\mathcal C_I$ denote contraction of
+    the blocked tensor over the region $\bigcup_{i\in I}P_i$. To prove
     injectivity of $A\cup B$, take a boundary tensor $X$ on $P_3$ such that
-    $\mathcal C_{\{0,1,2\}}(X)=0$.  Since $P_0\cup P_1=A$ is injective, its
+    $\mathcal C_{\{0,1,2\}}(X)=0$. Since $P_0\cup P_1=A$ is injective, its
     left inverse gives
     \[
         \mathcal C_{\{0,1,2\}}(X)=0
         \quad\Longrightarrow\quad
-        \mathcal C_{\{2\}}(X)=0 .
+        \mathcal C_{\{2\}}(X)=0.
     \]
     The remaining two steps are
     \[
         \begin{aligned}
             \mathcal C_{\{2\}}(X)=0
-            &\quad\Longrightarrow\quad
-            \mathcal C_{\{1,2\}}(X)=0,\\
+             & \quad\Longrightarrow\quad
+            \mathcal C_{\{1,2\}}(X)=0,   \\
             \mathcal C_{\{1,2\}}(X)=0
-            &\quad\Longrightarrow\quad
-            X=0 .
+             & \quad\Longrightarrow\quad
+            X=0.
         \end{aligned}
     \]
     The first implication is obtained by contracting with the tensor on
@@ -2696,7 +2694,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     A region-injectivity hypothesis assigns to each finite vertex region the
     assertion that the tensor obtained by blocking that region is injective.
     This predicate is used for regions such as $R$, $S$, $T$, and their
-    complements in the normal PEPS proof.  The union-closure hypothesis records
+    complements in the normal PEPS proof. The union-closure hypothesis records
     the conclusion supplied by the source union-of-injective-regions lemma:
     the union of two injective regions is injective.
 \end{definition}
@@ -2710,7 +2708,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     finite union of injective finite regions is injective.
 \end{lemma}
 \begin{proof}\leanok
-    Induct on the nonempty finite indexing set.  The singleton case is the
+    Induct on the nonempty finite indexing set. The singleton case is the
     given injectivity hypothesis, and the induction step is one application of
     binary union closure.
 \end{proof}
@@ -2783,30 +2781,30 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.verticalSquareLatticeEdge_eq_upEdge}
     \leanok
     The finite $n\times m$ square lattice is represented by pairs of
-    coordinates.  The corresponding square-lattice graph has horizontal and
+    coordinates. The corresponding square-lattice graph has horizontal and
     vertical nearest-neighbor edges; the two elementary adjacency lemmas record
     the right-neighbor and upper-neighbor cases used for translated edge
     blockings, and the corresponding coordinate edges name those two
-    nearest-neighbor edges as elements of the edge set.  These named right and
+    nearest-neighbor edges as elements of the edge set. These named right and
     upward edges have the expected horizontal and vertical orientations.
     Every edge of this
-    graph is horizontal or vertical, but not both.  Since edges are represented
+    graph is horizontal or vertical, but not both. Since edges are represented
     by ordered endpoint pairs, a horizontal edge is oriented from left to right
     and is exactly the coordinate right edge from its left endpoint; similarly,
     a vertical edge is oriented from bottom to top and is exactly the
     coordinate upward edge from its lower endpoint.
     A coordinate rectangle is a product of a horizontal coordinate set and a
-    vertical coordinate set.  The $2\times3$ and
+    vertical coordinate set. The $2\times3$ and
     $3\times2$ coordinate-product predicates assert only that these two
     coordinate sets have cardinalities $2,3$ and $3,2$, respectively.
     Contiguous coordinate rectangles are products of contiguous coordinate
     intervals, and the contiguous $2\times3$ and $3\times2$ predicates name the
-    rectangular blocks used in the normal square-lattice theorem.  The
+    rectangular blocks used in the normal square-lattice theorem. The
     displayed region $R$ is the union of a $2\times3$ contiguous rectangle
     with the $3\times2$ contiguous rectangle occupying its upper two rows and
-    extending one column to the right.  The displayed region $S$ is the union
+    extending one column to the right. The displayed region $S$ is the union
     of two $2\times3$ contiguous rectangles shifted by one horizontal
-    coordinate, hence the full $3\times3$ square spanned by them.  The
+    coordinate, hence the full $3\times3$ square spanned by them. The
     displayed local-window model for $T$ is the complement, inside a local
     $5\times6$ coordinate window, of the vertical $2\times3$ edge block
     and the horizontal $3\times2$ edge block shown in the source picture.
@@ -2848,31 +2846,31 @@ injective and normal PEPS, following Theorems~2 and~3 of
     membership in a contiguous coordinate rectangle is the conjunction of the
     four bounding inequalities, and membership in $R$ is the disjunction of
     membership in the $2\times3$ lower-left piece or in the shifted
-    $3\times2$ upper piece.  Membership in $S$ is the disjunction of
+    $3\times2$ upper piece. Membership in $S$ is the disjunction of
     membership in the left $2\times3$ piece or in the horizontally shifted
-    $2\times3$ piece.  Membership in the local-window $T$ region is
+    $2\times3$ piece. Membership in the local-window $T$ region is
     membership in the local $5\times6$ window together with nonmembership in
-    the union of the two displayed edge blocks.  Bounded contiguous coordinate
+    the union of the two displayed edge blocks. Bounded contiguous coordinate
     rectangles of sizes $2\times3$ and $3\times2$ satisfy, respectively,
     the predicates for
     contiguous $2\times3$ and contiguous $3\times2$ square-lattice
-    rectangles.  The cardinality of a coordinate rectangle is the
+    rectangles. The cardinality of a coordinate rectangle is the
     product of the two coordinate cardinalities, and the full coordinate
     rectangle is the whole finite vertex set.
 \end{lemma}
 \begin{proof}\leanok
     The coordinate-rectangle statements follow from membership and cardinality
-    identities for Cartesian products of finite coordinate sets.  The
+    identities for Cartesian products of finite coordinate sets. The
     contiguous-rectangle statement then unfolds the two coordinate intervals.
     The membership statements for $R$, $S$, and the two edge blocks removed
     from $T$ additionally unfold membership in a union of two such
     rectangles, while membership in $T$ also unfolds the set difference from
-    the local $5\times6$ window.  The shape predicates follow by using the
+    the local $5\times6$ window. The shape predicates follow by using the
     displayed lower-left corners as witnesses.
 \end{proof}
 
 \begin{lemma}[The normal regions $R$ and $S$ are unions of contiguous
-    rectangles]%
+        rectangles]%
     \label{lem:peps_normalSquareRegionRS_rectangular_decomposition}
     \lean{TNLean.PEPS.normalSquareRegionR_rectangular_decomposition}
     \lean{TNLean.PEPS.normalSquareRegionS_rectangular_decomposition}
@@ -2920,7 +2918,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_squareLatticeCoordinateRegions,
         lem:peps_squareLatticeCoordinateRegion_identities}
     The two edge blocks removed from the displayed local $T$-region lie inside
-    the local $5\times6$ coordinate window.  They are disjoint from each other
+    the local $5\times6$ coordinate window. They are disjoint from each other
     and from this local $T$ region, and their union with it is exactly that
     local window.
 \end{lemma}
@@ -2940,12 +2938,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_squareLatticeCoordinateRegion_identities}
     The finite-lattice complementary block around the edge is disjoint from
     the two displayed edge blocks, and its union with them is the full finite
-    square lattice.  The local-window $T$ region is contained in this
+    square lattice. The local-window $T$ region is contained in this
     finite-lattice complementary block.
 \end{lemma}
 \begin{proof}\leanok
     This is the set-theoretic complement of the two displayed edge blocks in
-    the full finite square lattice.  The containment of the local-window
+    the full finite square lattice. The containment of the local-window
     $T$ region follows because its points also avoid the two removed edge
     blocks.
 \end{proof}
@@ -2962,7 +2960,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareEdgeComplementRegion}
     A rectangular cover of a square-lattice region is a nonempty finite family
     of regions whose union is exactly the given region, and each member is a
-    contiguous $2\times3$ or $3\times2$ rectangle.  The two cases used in the
+    contiguous $2\times3$ or $3\times2$ rectangle. The two cases used in the
     proof are the cover of the local displayed $T$-region and the cover of the
     finite-lattice complementary block $A_3$.
     \begin{center}
@@ -2989,29 +2987,29 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The present origin-based local-window model for the displayed $T$-region
     admits no nonempty finite cover by contained contiguous $2\times3$ and
     $3\times2$ rectangles whenever the ambient lattice contains the
-    $5\times6$ window.  The origin-based rotated local-window model used for
+    $5\times6$ window. The origin-based rotated local-window model used for
     vertical edges has the analogous obstruction whenever the ambient lattice
-    contains the $6\times5$ window.  The normalized $5\times6$ and
-    $6\times5$ cases are recorded as corollaries.  The present origin-based
+    contains the $6\times5$ window. The normalized $5\times6$ and
+    $6\times5$ cases are recorded as corollaries. The present origin-based
     horizontal edge-complement model has the analogous obstruction whenever
     the ambient lattice contains the $5\times7$ frame; the normalized
-    $5\times7$ case is again recorded as a corollary.  The present
+    $5\times7$ case is again recorded as a corollary. The present
     origin-based vertical edge-complement model has the corresponding
     obstruction whenever the ambient lattice contains the $7\times5$ frame;
     the normalized $7\times5$ case is recorded as a corollary.
 \end{lemma}
 % Maintainer note: this is a local-model obstruction, not a statement of the
-% source theorem.  It records that the current coordinate model is not yet the
+% source theorem. It records that the current coordinate model is not yet the
 % source cover needed for the $T$-injectivity sentence.
 \begin{proof}\leanok
     The lower-left point of the local window belongs to the present $T$
-    model.  Any contiguous $2\times3$ rectangle containing it also contains
+    model. Any contiguous $2\times3$ rectangle containing it also contains
     a point of the removed vertical edge block, while any contiguous
     $3\times2$ rectangle containing it also contains a point of the removed
-    horizontal edge block.  The rotated statement is the same coordinate
-    argument with the two shapes interchanged.  The horizontal
+    horizontal edge block. The rotated statement is the same coordinate
+    argument with the two shapes interchanged. The horizontal
     edge-complement statement uses the same lower-left point, and so does the
-    normalized vertical edge-complement statement.  These cases are all
+    normalized vertical edge-complement statement. These cases are all
     instances of the same point-forcing obstruction to an exact rectangular
     cover.
 \end{proof}
@@ -3040,13 +3038,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_squareLatticeCoordinateRegions,
         lem:peps_squareLatticeCoordinateRegion_identities}
     For the displayed regions $R$ and $S$ with the same lower-left corner,
-    $R$ is contained in $S$.  The difference $S\setminus R$ is exactly
+    $R$ is contained in $S$. The difference $S\setminus R$ is exactly
     the lower-right site of the $3\times3$ square: in coordinates, the site
     one obtains by shifting two steps horizontally and zero steps vertically
     from the lower-left corner.
 \end{lemma}
 \begin{proof}\leanok
-    Expand the two displayed unions.  The only point of the second
+    Expand the two displayed unions. The only point of the second
     $2\times3$ piece of $S$ which is not already in the union defining
     $R$ is its lower-right point.
 \end{proof}
@@ -3059,9 +3057,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_regionInjectivityData,
         def:peps_squareLatticeCoordinateRegions}
     In the square-lattice normal theorem, every $2\times 3$ and
-    $3\times 2$ rectangular region is assumed injective.  The corresponding
+    $3\times 2$ rectangular region is assumed injective. The corresponding
     abstract hypotheses specify which finite regions have these two shapes and
-    assert injectivity for all of them.  In the coordinate square-lattice
+    assert injectivity for all of them. In the coordinate square-lattice
     specialization, these two families are the contiguous coordinate
     $2\times 3$ and $3\times 2$ rectangles.
 \end{definition}
@@ -3112,7 +3110,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $x_0 + 5 \leq n$ and $y_0 + 5 \leq m$ hold in the finite $n\times m$
     square lattice, then the coordinate square-lattice rectangular injectivity
     hypotheses imply that the vertical $2\times3$ block and horizontal
-    $3\times2$ block removed from the window are injective.  If, in addition,
+    $3\times2$ block removed from the window are injective. If, in addition,
     region injectivity is closed under unions, then the union of these two
     removed edge blocks is injective.
 \end{lemma}
@@ -3121,7 +3119,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 % \cite[Theorem~3]{Molnar2018NormalPEPS}.
 \begin{proof}\leanok
     Apply the rectangular injectivity hypotheses to the already identified
-    contiguous rectangle shapes of the two edge blocks.  The final assertion is
+    contiguous rectangle shapes of the two edge blocks. The final assertion is
     one application of union closure to these two injective blocks.
 \end{proof}
 
@@ -3137,7 +3135,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_regionInjectivityUnionClosure_finite}
     If the displayed local $T$-region has a nonempty finite cover by
     contiguous $2\times3$ and $3\times2$ rectangles, then rectangular
-    injectivity and finite union closure imply that $T$ is injective.  The
+    injectivity and finite union closure imply that $T$ is injective. The
     rotated vertical local $T$-region has the same conditional injectivity
     criterion.
 \end{lemma}
@@ -3163,17 +3161,17 @@ injective and normal PEPS, following Theorems~2 and~3 of
     If the finite-lattice complementary block $A_3$ has a nonempty finite
     cover by contiguous $2\times3$ and $3\times2$ rectangles, then
     rectangular injectivity and finite union closure imply that $A_3$ is
-    injective.  The same criterion applies to every vertical edge-complementary
+    injective. The same criterion applies to every vertical edge-complementary
     block: a nonempty finite cover of that block by contiguous $2\times3$ and
     $3\times2$ rectangles implies injectivity of the vertical
-    edge-complementary block.  In the normalized horizontal-edge $5\times7$
+    edge-complementary block. In the normalized horizontal-edge $5\times7$
     frame, it is enough to give such a cover of the local $T$-region, since
     adjoining the two top-collar $3\times2$ rectangles gives a cover of $A_3$.
 \end{lemma}
 % Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
 \begin{proof}\leanok
     Apply rectangular injectivity to every rectangle in the cover, then apply
-    finite union closure to the nonempty family.  For the normalized
+    finite union closure to the nonempty family. For the normalized
     $5\times7$ edge complement, first extend the local $T$-cover by the
     two top-collar rectangles.
 \end{proof}
@@ -3188,7 +3186,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     In the normalized horizontal-edge $5\times7$ frame with lower-left corner
     $(0,0)$, any rectangular cover of the local $T$-region extends to a
     rectangular cover of the edge-complementary block $A_3$ by adjoining the
-    two top-collar contiguous $3\times2$ rectangles.  In the normalized
+    two top-collar contiguous $3\times2$ rectangles. In the normalized
     vertical-edge $7\times5$ frame with lower-left corner $(0,0)$, any
     rectangular cover of the rotated local $T$-region extends to a rectangular
     cover of the vertical edge-complementary block by adjoining the two
@@ -3196,7 +3194,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{lemma}
 \begin{proof}\leanok
     Index the new cover by the old cover indices together with two extra
-    indices for the collar rectangles.  For the horizontal block, the
+    indices for the collar rectangles. For the horizontal block, the
     decomposition is
     \[
         A_3 =
@@ -3231,11 +3229,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_squareLatticeRectangleInjectivity_rectangles}
     In the normalized horizontal-edge $5\times7$ frame, the finite-lattice
     complementary block $A_3$ is the local-window $T$-region together with
-    two top-collar contiguous $3\times2$ rectangles.  Consequently, if the
+    two top-collar contiguous $3\times2$ rectangles. Consequently, if the
     local $T$-region is injective, then rectangular injectivity and union
-    closure imply that $A_3$ is injective.  There is also a transposed
+    closure imply that $A_3$ is injective. There is also a transposed
     $7\times5$ horizontal-frame collar identity with two contiguous
-    $2\times3$ right-collar rectangles.  For the rotated vertical
+    $2\times3$ right-collar rectangles. For the rotated vertical
     edge-blocking regions, the corresponding complement is the rotated local
     $T$-region together with the same two right-collar rectangles; hence rotated
     $T$-injectivity, and hence a rectangular cover of rotated $T$, implies
@@ -3287,32 +3285,32 @@ injective and normal PEPS, following Theorems~2 and~3 of
     In the normalized $5\times7$ horizontal-edge frame, the red block is the
     vertical $2\times3$ block, the blue block is the horizontal $3\times2$
     block, and the complementary block is the finite-lattice edge complement
-    $A_3$.  The distinguished edge is a horizontal edge of the square-lattice
-    graph.  The left endpoint of the distinguished edge lies in the red block,
+    $A_3$. The distinguished edge is a horizontal edge of the square-lattice
+    graph. The left endpoint of the distinguished edge lies in the red block,
     the right endpoint lies in the blue block, the three regions are pairwise
     disjoint, and their union is the whole finite square lattice.
     If the local $T$-region is injective, rectangular injectivity and union
     closure give injectivity of all three blocks; in particular a rectangular
-    cover of $T$ suffices.  The normalized $7\times5$ vertical-edge frame
+    cover of $T$ suffices. The normalized $7\times5$ vertical-edge frame
     has the analogous red and blue rectangular blocks, a distinguished vertical
     edge, and the same set-theoretic blocking data; at this stage its
     complementary-block injectivity is either kept as an explicit hypothesis or
     obtained from
     rotated $T$-injectivity, and therefore from a rectangular cover of
-    rotated $T$, by the vertical collar lemma.  In both cases the named
+    rotated $T$, by the vertical collar lemma. In both cases the named
     blocking datum supplies the corresponding three injective regions for the
     edge-blocked chain.
 \end{lemma}
 % Maintainer note: horizontal and vertical complement injectivity are reduced
-% to local and rotated T-covers, respectively.  The translated every-edge
+% to local and rotated T-covers, respectively. The translated every-edge
 % construction remains a separate step.
 \begin{proof}\leanok
-    The endpoint memberships are coordinate checks.  Rectangular injectivity
-    gives the rectangular red and blue blocks.  For the horizontal edge, the
+    The endpoint memberships are coordinate checks. Rectangular injectivity
+    gives the rectangular red and blue blocks. For the horizontal edge, the
     collar lemma gives the complement, and the rectangular cover criterion
     removes the direct $T$-injectivity input when such a cover is supplied.
     For the vertical edge, complement injectivity is an explicit input or is
-    obtained from the rotated $T$-cover.  The disjointness and cover
+    obtained from the rotated $T$-cover. The disjointness and cover
     statements are finite-set complement identities.
 \end{proof}
 
@@ -3338,21 +3336,21 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareEdgeComplementRegion_injective_of_cover}
     For any coordinate origin whose horizontal blocking window lies in the
     finite square lattice, there is a distinguished horizontal edge with the
-    same relative position as in the normalized picture.  The translated red
+    same relative position as in the normalized picture. The translated red
     region is the $2\times3$ block, the translated blue region is the
     $3\times2$ block, and the complementary region is the finite-lattice
-    complement of their union.  If this complementary region is injective,
+    complement of their union. If this complementary region is injective,
     these three regions form the one-edge blocking datum; if it has a
     rectangular cover, rectangular injectivity and union closure supply that
-    complementary injectivity.  In both forms the datum supplies the three
-    injective regions used in the edge-blocked chain.  The distinguished edge
-    is the corresponding coordinate right edge.  At coordinate origin $0,0$,
+    complementary injectivity. In both forms the datum supplies the three
+    injective regions used in the edge-blocked chain. The distinguished edge
+    is the corresponding coordinate right edge. At coordinate origin $0,0$,
     the translated edge and the three translated regions specialize to the
     normalized horizontal picture.
 \end{lemma}
 \begin{proof}\leanok
     The endpoint memberships and horizontal orientation are coordinate
-    checks.  Rectangular injectivity gives the red and blue blocks.  The
+    checks. Rectangular injectivity gives the red and blue blocks. The
     complementary block is supplied either as an input or from a rectangular
     cover, and the disjointness and covering identities follow from the
     finite-set complement formulas.
@@ -3379,21 +3377,21 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareEdgeComplementRegion_injective_of_cover}
     For any coordinate origin whose vertical blocking window lies in the
     finite square lattice, there is a distinguished vertical edge with the same
-    relative position as in the normalized vertical picture.  The translated
+    relative position as in the normalized vertical picture. The translated
     red region is the $3\times2$ block, the translated blue region is the
     $2\times3$ block, and the complementary region is the finite-lattice
-    complement of their union.  If this complementary region is injective,
+    complement of their union. If this complementary region is injective,
     these three regions form the one-edge blocking datum; if it has a
     rectangular cover, rectangular injectivity and union closure supply that
-    complementary injectivity.  In both forms the datum supplies the three
-    injective regions used in the edge-blocked chain.  The distinguished edge
-    is the corresponding coordinate upward edge.  At coordinate origin $0,0$,
+    complementary injectivity. In both forms the datum supplies the three
+    injective regions used in the edge-blocked chain. The distinguished edge
+    is the corresponding coordinate upward edge. At coordinate origin $0,0$,
     the translated edge and the three translated regions specialize to the
     normalized vertical picture.
 \end{lemma}
 \begin{proof}\leanok
     The endpoint memberships and vertical orientation are coordinate checks.
-    Rectangular injectivity gives the red and blue blocks.  The complementary
+    Rectangular injectivity gives the red and blue blocks. The complementary
     block is supplied either as an input or from a rectangular cover, and the
     disjointness and covering identities follow from the finite-set complement
     formulas.
@@ -3452,22 +3450,22 @@ injective and normal PEPS, following Theorems~2 and~3 of
         lem:peps_normalSquareVerticalTranslatedEdge_blockingData}
     A translated edge window records that a chosen edge is one of the
     translated horizontal or vertical edge pictures, together with a
-    rectangular cover of the complementary block.  Such a window gives the
+    rectangular cover of the complementary block. Such a window gives the
     one-edge blocking datum for that edge, hence the three injective regions
-    used in the edge-blocked chain.  The coordinate right and upward edges
+    used in the edge-blocked chain. The coordinate right and upward edges
     obtain such windows directly from the corresponding translated picture.
     Equivalently, an actual coordinate right or upward edge obtains such a
     window when it has the necessary room around it for the translated
     $5\times7$ or $7\times5$ frame and the complementary cover is supplied.
     The same criterion applies to an arbitrary horizontal or vertical
     square-lattice edge after identifying it with its coordinate right or
-    upward representative.  The oriented margin-and-cover datum is the same
+    upward representative. The oriented margin-and-cover datum is the same
     criterion packaged as per-edge data in the rectangular coordinate model;
     it directly supplies the one-edge blocking datum, its three injective
     regions, and the identities
     $u_e\in R_e$, $v_e\in B_e$,
     $R_e\cap B_e=R_e\cap C_e=B_e\cap C_e=\varnothing$, and
-    $R_e\cup B_e\cup C_e=V$.  The boundary obstruction lemmas show that these
+    $R_e\cup B_e\cup C_e=V$. The boundary obstruction lemmas show that these
     translated-window and margin-cover criteria are interior criteria, not the
     final every-edge construction in the open square-lattice model.
     % Detailed source-comparison status:
@@ -3492,19 +3490,19 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Given rectangular injectivity hypotheses, finite union closure, and a
     translated edge window at every edge of the finite square lattice, the
     corresponding one-edge blockings determine the normal edge-blocking
-    hypotheses.  This is the conditional construction;
+    hypotheses. This is the conditional construction;
     constructing such windows for all edges of the $7\times7$ lattice remains
     separate; the current open rectangular translated-window criterion does not
-    by itself supply such a family.  The one-edge datum recovered from the
+    by itself supply such a family. The one-edge datum recovered from the
     resulting hypotheses is the datum supplied by the corresponding translated
     window, and the resulting hypotheses give the three injective regions at
     every edge, together with
     $u_e\in R_e$, $v_e\in B_e$,
     $R_e\cap B_e=R_e\cap C_e=B_e\cap C_e=\varnothing$, and
-    $R_e\cup B_e\cup C_e=V$.  Equivalently, it is enough to supply the oriented
+    $R_e\cup B_e\cup C_e=V$. Equivalently, it is enough to supply the oriented
     margin-and-cover data at every edge; the resulting hypotheses recover the
     corresponding datum, give the same three injectivity conclusions, and give
-    the same endpoint, disjointness, and covering conclusions.  The obstruction
+    the same endpoint, disjointness, and covering conclusions. The obstruction
     theorem records that this interior margin-cover criterion does not by
     itself supply data at every edge of the open $7\times7$ lattice.
     % Detailed source-comparison status:
@@ -3529,8 +3527,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{lemma}
 \begin{proof}\leanok
     Region $R$ is the union of one injective $2\times3$ rectangle and one
-    injective $3\times2$ rectangle.  Region $S$ is the union of two
-    injective $2\times3$ rectangles.  Apply union closure in each case.
+    injective $3\times2$ rectangle. Region $S$ is the union of two
+    injective $2\times3$ rectangles. Apply union closure in each case.
 \end{proof}
 
 \begin{definition}[Normal edge-blocking hypotheses]%
@@ -3541,10 +3539,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{def:peps_edge, def:peps_regionInjectivityData}
     Around one edge, the normal proof uses a blocking into three injective
     regions: a red region containing one endpoint, a blue region containing the
-    other endpoint, and an injective complementary region.  The three regions
-    are pairwise disjoint and cover the whole vertex set.  The edge-blocking
+    other endpoint, and an injective complementary region. The three regions
+    are pairwise disjoint and cover the whole vertex set. The edge-blocking
     hypotheses are precisely this one-edge datum at every edge; the red,
-    blue, and complementary regions are read off from it.  The local blocking
+    blue, and complementary regions are read off from it. The local blocking
     picture used in the proof of
     \cite[Theorem~3]{Molnar2018NormalPEPS}:
     \begin{center}
@@ -3567,9 +3565,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_normalEdgeBlockingHypotheses}
     A family of one-edge blocking data is precisely the normal edge-blocking
-    hypotheses.  If $H$ is assembled from the family $d_e$, then the one-edge
-    datum that $H$ associates with $e$ is $d_e$.  Write the endpoints of $e$
-    as $u_e<v_e$ in the canonical vertex ordering.  If the three regions are
+    hypotheses. If $H$ is assembled from the family $d_e$, then the one-edge
+    datum that $H$ associates with $e$ is $d_e$. Write the endpoints of $e$
+    as $u_e<v_e$ in the canonical vertex ordering. If the three regions are
     $R_e$, $B_e$, and $C_e$, then
     \[
         u_e \in R_e,\qquad v_e \in B_e,\qquad
@@ -3590,7 +3588,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{def:peps_regionInjectivityData, def:peps_regionComplement}
     For each site, the normal theorem assumes two injective regions with
-    injective complements that differ exactly at that site.  This is the
+    injective complements that differ exactly at that site. This is the
     one-site comparison used after the edge gauges have been obtained.
     Diagrammatically, in the square-lattice proof this is the comparison
     between the source regions $R$ and $S=R\cup\{v\}$:
@@ -3610,7 +3608,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \end{theorem}
 \begin{proof}\leanok
     If $w=v$, use the distinguished-site membership and nonmembership
-    assumptions.  If $w\neq v$, use the equality of the two regions away
+    assumptions. If $w\neq v$, use the equality of the two regions away
     from the distinguished site.
 \end{proof}
 
@@ -3628,10 +3626,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     The formal statement here is the corresponding abstract, scope-restricted
     hypothesis bundle: it records the rectangular injectivity assumptions, the
     size bound $n,m\geq 7$ with $|V|=nm$, and three finite regions
-    $R$, $S$, and $T$ whose injectivity is assumed directly.  It does
+    $R$, $S$, and $T$ whose injectivity is assumed directly. It does
     not by itself assert that these regions are the displayed square-lattice
     unions, nor that their translated variants give the edge-centred blocking
-    around every edge.  Conversely, for the coordinate square lattice with
+    around every edge. Conversely, for the coordinate square lattice with
     $n,m\geq7$, the rectangular hypotheses, union closure, and a rectangular
     cover of the displayed $T$-region yield this abstract $R,S,T$
     structure, with $R$ and $S$ obtained from their rectangular
@@ -3658,7 +3656,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     Under the square-lattice normality hypotheses of
     \cite[Theorem~3]{Molnar2018NormalPEPS}, the regions $R$, $S$, and
     $T$, together with their translated variants, give an edge-centred
-    blocking into red, blue, and complementary injective regions.  These are
+    blocking into red, blue, and complementary injective regions. These are
     the regions on which the three-site injective-chain insertion argument is
     applied:
     \begin{center}
@@ -3710,7 +3708,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         def:peps_normalOneSiteSeparationHypotheses}
     The general normal theorem assumes both the edge-centred blockings into
     three injective regions and the one-site comparison regions with injective
-    complements.  These two assumptions are collected as the normal PEPS
+    complements. These two assumptions are collected as the normal PEPS
     blocking hypotheses; the same hypotheses give the corresponding edge and
     one-site consequences without restating the separate edge and one-site
     assumptions.
@@ -3740,10 +3738,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
         def:peps_normalOneSiteSeparationHypotheses}
     Given rectangular injectivity hypotheses, finite union closure, oriented
     margin-and-cover hypotheses at every edge, and one-site separation, the finite
-    square lattice satisfies the general normal blocking hypotheses.  The
+    square lattice satisfies the general normal blocking hypotheses. The
     edge-blocking hypotheses are exactly the margin-cover construction, the
     one-edge datum at an edge is the datum supplied there, and the one-site
-    separation is exactly the supplied one-site separation.  Hence these hypotheses
+    separation is exactly the supplied one-site separation. Hence these hypotheses
     give the three injective regions, the endpoint-disjoint-cover facts at
     each edge, and the one-site membership formula as consequences of the same
     normal blocking hypotheses.
@@ -3856,7 +3854,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     For every vertex $v$,
     $\prod_{e\ni v}(cd)_{v,e}=
-    (\prod_{e\ni v}c_{v,e})(\prod_{e\ni v}d_{v,e})=1\cdot 1=1$.
+        (\prod_{e\ni v}c_{v,e})(\prod_{e\ni v}d_{v,e})=1\cdot 1=1$.
 \end{proof}
 
 \begin{theorem}[Inverse of balanced edge scalars]%
@@ -3871,7 +3869,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     For every vertex $v$,
     $\prod_{e\ni v}(c^{-1})_{v,e}=
-    (\prod_{e\ni v}c_{v,e})^{-1}=1^{-1}=1$.
+        (\prod_{e\ni v}c_{v,e})^{-1}=1^{-1}=1$.
 \end{proof}
 
 \begin{theorem}[Reflexivity of balanced edge-scalar equivalence]%

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -1,4 +1,3 @@
-
 %% =========================================================
 %% Chapter: Symmetries and String Order
 %% Develops the symmetry-theoretic consequences of the MPS Fundamental

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1,4 +1,3 @@
-
 \chapter{Parent Hamiltonians}\label{ch:parent_hamiltonian}
 
 This chapter introduces the local ground-space construction and the parent
@@ -575,7 +574,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.cyclicRestrictₗ_eq_contiguousRestrictₗ}
     \leanok
     On the periodic chain, a cyclic window starting at $i$ reads the sites
-    $i,i+1,\ldots,i+L-1$ modulo $N$.  Deleting the final site of a cyclic
+    $i,i+1,\ldots,i+L-1$ modulo $N$. Deleting the final site of a cyclic
     $(L+1)$-window reads the value at cyclic offset $L$ in the outside
     configuration and gives the $L$-window starting at the same site. Deleting
     the first site, in the non-repeating case $L+1\le N$, reads the value at
@@ -910,7 +909,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{rem:cyclic_window_operators}
     Fix a dummy physical letter $\eta$ and a middle word $\mu$ of length
-    $N-(L_0+1)$.  Write $\tau^+_\eta(\mu)$ for the last-site cyclic-window
+    $N-(L_0+1)$. Write $\tau^+_\eta(\mu)$ for the last-site cyclic-window
     background and $\tau^-_\eta(\mu)$ for the opposite cyclic-window
     background. Their exposed
     complements are both exactly $\mu$.
@@ -1224,7 +1223,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     The hypothesis $\spn\{A^u: |u|=L_0\}=\MN{D}$ implies the same spanning
-    statement at every positive multiple $qL_0$.  Each length-$qL_0$ word factors
+    statement at every positive multiple $qL_0$. Each length-$qL_0$ word factors
     as a length-$k$ prefix followed by padding, so $Z$ annihilates all generators
     of the full span and hence annihilates the identity.
 \end{proof}
@@ -1285,7 +1284,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     Theorem~\ref{thm:block_word_strip_central} makes $X$ commute with the whole
-    matrix algebra.  The center of $\MN{D}$ consists of scalar matrices, so
+    matrix algebra. The center of $\MN{D}$ consists of scalar matrices, so
     $X=c\Id$, and therefore $\Gamma_N(X)=cV^{(N)}(A)$.
 \end{proof}
 
@@ -2121,7 +2120,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
-    Apply the averaging formula above: $h_{i,\mathrm{ES}}$ is a nonnegative scalar
+    Apply the averaging formula above: $h_{i,\mathrm{ES}}$ is a non-negative scalar
     multiple of a finite sum of positive conjugates of $P_L^{\mathrm{ES}}(A)$, hence is
     itself positive. Summing over $i$ yields positivity of $H_{N,\mathrm{ES}}$.
 \end{proof}
@@ -2210,7 +2209,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{thm:ground_space_intersection, lem:local_term_es_kernel_restrictions,
         lem:mem_ground_space_es}
     Lemma~\ref{lem:local_term_es_kernel_restrictions} translates the two local
-    kernel assumptions into the left and right $L$-site ground conditions.  The
+    kernel assumptions into the left and right $L$-site ground conditions. The
     open-chain intersection property, Theorem~\ref{thm:ground_space_intersection},
     then grows back the shared $(L-1)$-site overlap to the $(L+1)$-site ground space.
     The converse uses the forward restriction lemmas for ground-space vectors and
@@ -2234,10 +2233,10 @@ Lucia~\cite{Kastoryano2018Martingale}.
         h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)
         = h_{j,\mathrm{ES}}(h_{i,\mathrm{ES}}v),
     \]
-    and their ordered cross term is nonnegative:
+    and their ordered cross term is non-negative:
     \[
         0\le \operatorname{Re}\langle h_{i,\mathrm{ES}}v,
-        h_{j,\mathrm{ES}}v\rangle .
+        h_{j,\mathrm{ES}}v\rangle.
     \]
 \end{lemma}
 
@@ -2250,7 +2249,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     not change the extracted $j$-window, and the $i$- and $j$-window replacements
     commute. Therefore the two embedded local operators commute. The preceding
     projection-geometry identity for commuting symmetric projections gives the
-    nonnegative ordered cross term.
+    non-negative ordered cross term.
 \end{proof}
 
 \begin{lemma}[Quadratic form to norm bound]\label{lem:quadratic_form_to_norm_bound}
@@ -2380,7 +2379,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Let $P_i$ be a finite family of symmetric projections and let $\gamma\le1$.
     Suppose an interaction predicate $i\sim j$ has at most $m$ off-diagonal
     neighbours in each row for some positive integer $m$. If noninteracting
-    ordered cross terms are nonnegative and, on each interacting pair,
+    ordered cross terms are non-negative and, on each interacting pair,
     \[
         \operatorname{Re}\langle P_i v,P_jv\rangle
         \ge -(1-\gamma)\frac{1}{m}\operatorname{Re}\langle P_i v,v\rangle,
@@ -2405,7 +2404,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         rem:projection_geometry_rowsum_identities}
     Let $P_i$ be a finite family of symmetric projections and let $\gamma\le1$.
     Suppose an interaction predicate has at most $m>0$ off-diagonal neighbours
-    in each row, noninteracting ordered cross terms are nonnegative, and
+    in each row, noninteracting ordered cross terms are non-negative, and
     interacting pairs satisfy the norm-compression estimate
     \[
         \|P_iP_jv\|\le (1-\gamma)\frac{1}{m}\|P_iv\|.
@@ -2482,7 +2481,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{lem:parent_hamiltonian_ordered_rowsum_quadratic,
         lem:parent_hamiltonian_es_quadratic_reduction}
     The fixed-chain row-sum reduction supplies the quadratic-form estimate with
-    $\gamma=1/(4L)$ for every admissible $N$.  The positivity and kernel
+    $\gamma=1/(4L)$ for every admissible $N$. The positivity and kernel
     identification of the transported Hamiltonian then allow
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} to convert this
     quadratic-form estimate into the norm lower bound on the orthogonal
@@ -2497,7 +2496,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     For a fixed chain length $N$, let $m$ be a positive integer and let
     $\gamma\le1$. Suppose an overlap predicate on local windows has at most $m$
     overlapping off-diagonal windows in each row. If non-overlapping local terms
-    have nonnegative ordered cross terms, overlapping local terms satisfy the
+    have non-negative ordered cross terms, overlapping local terms satisfy the
     finite-overlap Friedrichs estimate
     \[
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
@@ -2524,7 +2523,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         lem:transported_es_local_projections}
     For a fixed chain length $N$, let $m>0$ and $\gamma\le1$. Suppose an overlap
     predicate on local windows has at most $m$ overlapping off-diagonal windows in
-    each row, non-overlapping local terms have nonnegative ordered cross terms,
+    each row, non-overlapping local terms have non-negative ordered cross terms,
     and overlapping local terms satisfy
     \[
         \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
@@ -2572,7 +2571,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
-    Write $k=i+r\pmod N$ for a representative offset $r$.  Membership in
+    Write $k=i+r\pmod N$ for a representative offset $r$. Membership in
     $S_i$ gives an offset $r<L$, and conversely an offset below $L$ gives the
     corresponding point of the support.
 \end{proof}
@@ -2594,10 +2593,10 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{lem:cyclic_window_support_offsets, def:cyclic_windows_overlap,
         lem:transported_es_nonoverlap_positive}
     If $L\le N$ and the cyclic supports $S_i$ and $S_j$ do not meet, then the
-    transported local ES terms have nonnegative ordered cross term:
+    transported local ES terms have non-negative ordered cross term:
     \[
         0\le\operatorname{Re}\langle h_{i,\mathrm{ES}}v,
-        h_{j,\mathrm{ES}}v\rangle .
+        h_{j,\mathrm{ES}}v\rangle.
     \]
 \end{lemma}
 
@@ -2605,7 +2604,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     \uses{lem:cyclic_window_support_offsets, lem:transported_es_nonoverlap_positive}
     The support-offset characterization converts failure of $S_i\cap S_j\ne\varnothing$
-    into site-disjointness of the two cyclic windows.  The disjoint-window
+    into site-disjointness of the two cyclic windows. The disjoint-window
     positivity lemma then applies.
 \end{proof}
 
@@ -2624,7 +2623,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     \uses{def:cyclic_window_support, def:cyclic_windows_overlap}
     If $S_i$ and $S_j$ meet, choose offsets $a,b<L$ with
-    $i+a\equiv j+b\pmod N$.  Since $2L\le N$, the offset from $i$ to $j$ is
+    $i+a\equiv j+b\pmod N$. Since $2L\le N$, the offset from $i$ to $j$ is
     either the clockwise distance $a-b\in\{1,\ldots,L-1\}$ or the
     counterclockwise distance $b-a\in\{1,\ldots,L-1\}$; the zero distance is
     excluded by $j\ne i$. Thus every overlapping off-diagonal start lies among
@@ -2681,7 +2680,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     projection structure of each transported local term. If two cyclic supports
     do not meet, the corresponding windows are site-disjoint, so
     Lemma~\ref{lem:cyclic_window_nonoverlap_positive} gives the required
-    nonnegative ordered cross term. Apply
+    non-negative ordered cross term. Apply
     Lemma~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} with these
     facts and the displayed overlapping-window estimate.
 \end{proof}
@@ -2718,7 +2717,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     \uses{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
         rem:projection_geometry_rowsum_identities}
-    Fix $L>1$.  Suppose uniformly for every $N\ge2L$ and every overlapping
+    Fix $L>1$. Suppose uniformly for every $N\ge2L$ and every overlapping
     off-diagonal pair that
     \[
         \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
@@ -2734,7 +2733,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
         rem:projection_geometry_rowsum_identities}
     The norm-compression condition is converted to the ordered Friedrichs lower
-    bound by the projection-geometry Cauchy--Schwarz lemma.  The preceding
+    bound by the projection-geometry Cauchy--Schwarz lemma. The preceding
     overlapping-cyclic Friedrichs reduction then gives the norm lower bound.
 \end{proof}
 
@@ -2950,7 +2949,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Concretely, it asserts that if $N \ge 2L$ and
     $v \in (\mathcal G_{N,L}^{\mathrm{ES}}(A))^{\perp}$, then
     \[
-        \gamma_{L} \, \|v\| \le \|H_{N,L}^{\mathrm{ES}}(A) v\|.
+        \gamma_{L} \|v\| \le \|H_{N,L}^{\mathrm{ES}}(A) v\|.
     \]
 \end{theorem}
 
@@ -2961,7 +2960,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \ref{lem:transported_es_positive}, and~\ref{lem:transported_es_local_projections}.
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} reduces the present
     theorem to the remaining MPS-specific task: deriving the uniform
-    quadratic-form estimate.  Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}
+    quadratic-form estimate. Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}
     establishes the finite-sum algebra from ordered cross-term row bounds, and
     Lemmas~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
     and~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} state the
@@ -2989,7 +2988,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     for every $N \ge 2L$ and every vector
     $v \in (\mathcal G_{N,L}^{\mathrm{ES}}(A))^{\perp}$ one has
     \[
-        \gamma \, \|v\| \le \|H_{N,L}^{\mathrm{ES}}(A) v\|.
+        \gamma \|v\| \le \|H_{N,L}^{\mathrm{ES}}(A) v\|.
     \]
     By Lemma~\ref{lem:quadratic_form_to_norm_bound}, this implies the usual uniform lower
     bound on every nonzero eigenvalue of the parent Hamiltonian.
@@ -3041,9 +3040,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     finite-length spanning condition already stated in
     Remark~\ref{rem:word_tuple_span_top}: the simultaneous block-word evaluations
     \[
-        \omega \longmapsto \bigl(A_j^{\omega}\bigr)_j
+        \omega \longmapsto (A_j^{\omega})_j
     \]
-    span the whole product algebra $\prod_j \MN{D_j}$.  The remaining
+    span the whole product algebra $\prod_j \MN{D_j}$. The remaining
     mathematical step is to derive this condition for some positive length from
     the separated canonical-form/BNT hypotheses.  This is the block-injective
     span requirement in \cite[lines~2120--2128]{Cirac2021Matrix}: after blocking,
@@ -3171,7 +3170,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \notready
     If the simultaneous length-$m$ block-word tuples
     \[
-        \omega \longmapsto \bigl(A_j^{\omega}\bigr)_j
+        \omega \longmapsto (A_j^{\omega})_j
     \]
     span the full product algebra $\prod_j \MN{D_j}$ and every $\mu_j$ is nonzero, then the
     pulled-back length-$m$ word products of $\operatorname{Assemble}(\mu,A)$ span every
@@ -3184,9 +3183,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \uses{lem:block_projection_span_from_product_algebra_span,
         lem:route_b_block_diagonal_commutant_reduction}
     First embed the product algebra linearly as dependent block-diagonal matrices, scaling the
-    $j$-th block by $\mu_j^m$.  Since $\mu_j^m\neq0$, the product-algebra span contains the
+    $j$-th block by $\mu_j^m$. Since $\mu_j^m\neq0$, the product-algebra span contains the
     tuple with $(\mu_j^m)^{-1}I$ in one component and zero elsewhere; its scaled diagonal image is
-    exactly $P_j$.  The word-evaluation formula for the assembled tensor identifies these scaled
+    exactly $P_j$. The word-evaluation formula for the assembled tensor identifies these scaled
     diagonal matrices with the pulled-back assembled word products, and the commutant conclusion
     follows from Lemma~\ref{lem:route_b_block_diagonal_commutant_reduction}.
 \end{proof}
@@ -3198,7 +3197,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \leanok
     A length-$S$ partial selector for block $k$ on a finite target set $T$ is a
     tuple in the span of simultaneous length-$S$ block-word evaluations which is
-    $I$ on block $k$ and $0$ on every block in $T$.  The pairwise version asks for
+    $I$ on block $k$ and $0$ on every block in $T$. The pairwise version asks for
     such a partial selector for each ordered pair of distinct blocks, with
     $T=\{j\}$.
 \end{definition}
@@ -3218,10 +3217,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \lean{MPSTensor.PairAllWordsSpanTop}
     \leanok
     For two blocks $A$ and $B$, the length-$S$ pair word tuple is
-    $w \mapsto (A^w,B^w)$.  The pair product-span condition says that these
-    tuples span $\MN{D_A}\times\MN{D_B}$.  Equivalently, in the trace-dual
+    $w \mapsto (A^w,B^w)$. The pair product-span condition says that these
+    tuples span $\MN{D_A}\times\MN{D_B}$. Equivalently, in the trace-dual
     formulation, the only pair of test matrices $(\Delta_A,\Delta_B)$ whose
-    trace pairing with every length-$S$ tuple vanishes is $(0,0)$.  The
+    trace pairing with every length-$S$ tuple vanishes is $(0,0)$. The
     cumulative variant replaces one fixed length by all word lengths at most
     $S$, and the all-length variant allows every finite word.
 \end{definition}
@@ -3235,14 +3234,14 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     Let $A$ be $L$-block injective, and let $\Delta_A\neq 0$.
     Suppose that, for all words $u,v,t$ of length $L$,
     \[
-        \tr\!\bigl(\Delta_A A_v A_t A_u\bigr)
-        + \tr\!\bigl(\Delta_B B_v B_t B_u\bigr)=0 .
+        \tr\!(\Delta_A A_v A_t A_u)
+        + \tr\!(\Delta_B B_v B_t B_u)=0.
     \]
     Then for every $Z\in M_{D_A}(\mathbb C)$ there is a matrix
     $W\in M_{D_B}(\mathbb C)$ such that, for all words $t$ of
     length $L$,
     \[
-        \tr(ZA_t)+\tr(WB_t)=0 .
+        \tr(ZA_t)+\tr(WB_t)=0.
     \]
     This is the trace-dual algebraic step in the two-block case of the
     direct-sum lemma of \cite{PerezGarcia2007Matrix}.
@@ -3255,7 +3254,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     as
     \[
         \tr(A_u\Delta_A A_vA_t)
-        +\tr(B_u\Delta_B B_vB_t)=0 .
+        +\tr(B_u\Delta_B B_vB_t)=0.
     \]
     Taking the same linear combination of the matrices $B_u\Delta_BB_v$
     gives the required $W$, and linearity gives the general case.
@@ -3276,7 +3275,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     Lemma~\ref{lem:three_block_trace_reduction_nonzero_middle}, the length-$L$
     image spaces satisfy
     \[
-        \mathcal G_L^A \subseteq \mathcal G_L^B .
+        \mathcal G_L^A \subseteq \mathcal G_L^B.
     \]
     If the corresponding nonzero middle matrix exists on both sides, then
     $\mathcal G_L^A=\mathcal G_L^B$.
@@ -3285,13 +3284,13 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}\leanok
     \uses{lem:three_block_trace_reduction_nonzero_middle}
     Write a vector in $\mathcal G_L^A$ as
-    $t\mapsto \tr(A_tZ)$.  The preceding lemma supplies $W$ with
-    $\tr(ZA_t)+\tr(WB_t)=0$ for every word $t$.  Cyclicity of the
+    $t\mapsto \tr(A_tZ)$. The preceding lemma supplies $W$ with
+    $\tr(ZA_t)+\tr(WB_t)=0$ for every word $t$. Cyclicity of the
     trace gives
     \[
         \tr(A_tZ)=\tr(ZA_t)=-\tr(WB_t)=\tr(B_t(-W)),
     \]
-    so the vector lies in $\mathcal G_L^B$.  The equality statement follows
+    so the vector lies in $\mathcal G_L^B$. The equality statement follows
     by applying the same argument with the two blocks exchanged.
 \end{proof}
 
@@ -3326,16 +3325,16 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         thm:chain_ground_space_eq_mpv_blk}
     If $A$ and $B$ are length-$L$ block-injective, the map
     $Z\mapsto(t\mapsto\tr(A_tZ))$ has image dimension $D_A^2$, and
-    similarly for $B$.  Therefore an inclusion
+    similarly for $B$. Therefore an inclusion
     $\mathcal G_L^A\subseteq \mathcal G_L^B$, together with
     $D_B\le D_A$, forces $D_A=D_B$ and
-    $\mathcal G_L^A=\mathcal G_L^B$.  In particular, the three-block
+    $\mathcal G_L^A=\mathcal G_L^B$. In particular, the three-block
     trace relation from
     Lemma~\ref{lem:three_block_relation_ground_space_inclusion} gives this
-    equality whenever the source-paper size ordering is available.  If the
+    equality whenever the source-paper size ordering is available. If the
     inclusion comes from the strictly larger block, $D_B<D_A$, then the same
     dimension step already contradicts the existence of the three-block trace
-    relation.  More generally, if an external source input rules out the
+    relation. More generally, if an external source input rules out the
     simultaneous conclusion $D_A=D_B$ and
     $\mathcal G_L^A=\mathcal G_L^B$, then the three-block image spaces
     $\mathcal G_{3L}^A$ and $\mathcal G_{3L}^B$ have zero intersection.
@@ -3345,25 +3344,25 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     at a sufficiently long chain length, equivalently distinctness of the
     corresponding periodic MPV lines: equality of the local image spaces gives
     equality of the periodic-chain constraint spaces, and injective uniqueness
-    identifies those spaces with the two MPV lines.  For same-dimensional
+    identifies those spaces with the two MPV lines. For same-dimensional
     separated BNT blocks, the non-equivalence condition supplies such
     non-proportional MPV states at arbitrarily large chain lengths; the
-    direct-sum injectivity hypotheses remain explicit.  Zero intersection of
+    direct-sum injectivity hypotheses remain explicit. Zero intersection of
     the two three-block image spaces also gives homogeneous pair trace
     separation at that length once the boundary-to-chain maps at the
-    three-block length are injective.  Combining the equal-dimension and
+    three-block length are injective. Combining the equal-dimension and
     unequal-dimension branches over all ordered block pairs gives one common
     three-block trace-separation length, and hence the positive-length
-    product-word span required by the selector construction.  Since
+    product-word span required by the selector construction. Since
     canonical-form/BNT blocks are one-site injective, one may take $L=2$;
     injectivity at lengths $2$ and $6$ then follows by passing from a
-    fixed injective length to positive multiples.  This length-$6$ trace
+    fixed injective length to positive multiples. This length-$6$ trace
     separation is equivalently a full homogeneous pair span; concatenating
     one-letter words propagates fullness to all later homogeneous lengths, so
     the direct-sum witness also gives a uniform finite pair-span period window.
     Combining this window with the conditional period-window homogenization
     theorem gives the selector-format homogeneous word span without separately
-    assuming homogeneous identity pairs.  The same conclusion applies
+    assuming homogeneous identity pairs. The same conclusion applies
     to normal-CF-BNT data once one-site injectivity is supplied explicitly,
     since the normal-CF-BNT predicate carries the irreducibility and
     normalization hypotheses used in the direct-sum comparison.
@@ -3374,16 +3373,16 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     Block injectivity makes the boundary-to-chain map injective, so
     $\dim\mathcal G_L^A=D_A^2$ and $\dim\mathcal G_L^B=D_B^2$.
     Inclusion gives $D_A^2\le D_B^2$, while $D_B\le D_A$ gives the
-    reverse inequality.  Hence $D_A=D_B$, and equality of dimensions inside
-    the inclusion gives equality of the image spaces.  In the strict-size
-    branch this contradicts $D_B<D_A$.  For the conditional directness
+    reverse inequality. Hence $D_A=D_B$, and equality of dimensions inside
+    the inclusion gives equality of the image spaces. In the strict-size
+    branch this contradicts $D_B<D_A$. For the conditional directness
     statement, a vector in the intersection of the two three-block image spaces
-    has two boundary representations.  If the first boundary matrix is zero,
-    the vector is zero.  Otherwise the difference of the two coefficient
+    has two boundary representations. If the first boundary matrix is zero,
+    the vector is zero. Otherwise the difference of the two coefficient
     formulas is exactly the homogeneous three-block trace relation, so the
-    dimension step gives the forbidden collapse.  In the equal-size branch,
+    dimension step gives the forbidden collapse. In the equal-size branch,
     equal local image spaces impose the same cyclic local constraints on a
-    periodic chain.  The injective uniqueness theorem then identifies both
+    periodic chain. The injective uniqueness theorem then identifies both
     cyclic ground spaces with the spans of their MPV states, contradicting
     non-proportionality of those states.
 \end{proof}
@@ -3412,20 +3411,20 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \uses{def:pair_trace_separation_words}
     If no nonzero trace functional vanishes on all finite pair words, then
     there is a finite $S$ such that vanishing on every word of length at most
-    $S$ already forces the test pair to be zero.  For a finite family of ordered
+    $S$ already forces the test pair to be zero. For a finite family of ordered
     block pairs, these bounds can be replaced by one common bound.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    The trace condition is dual to the span of all finite pair words.  If that
+    The trace condition is dual to the span of all finite pair words. If that
     span is the whole product algebra, every vector lies in some cumulative
-    span.  Since the product algebra is finite-dimensional, the increasing
+    span. Since the product algebra is finite-dimensional, the increasing
     sequence of cumulative spans stabilizes; at the stabilization index it is
-    already the whole product algebra.  Applying the finite trace-duality
-    criterion gives the stated finite bound.  This proves the cumulative
+    already the whole product algebra. Applying the finite trace-duality
+    criterion gives the stated finite bound. This proves the cumulative
     finite-dimensional step; the remaining BNT step is to convert it to a
-    single homogeneous length.  Cumulative span-top alone is not identity
+    single homogeneous length. Cumulative span-top alone is not identity
     padding, because the length-zero word already contributes the identity.
 \end{proof}
 
@@ -3452,12 +3451,12 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \uses{def:pair_trace_separation_words}
     If one of the two blocks is injective, then the corresponding coordinate
     projection of the pair algebra generated by the simultaneous one-letter
-    pairs is the full matrix algebra.  Moreover, every finite pair word lies in
+    pairs is the full matrix algebra. Moreover, every finite pair word lies in
     this pair algebra, and the all-word linear span is the submodule generated
-    by the pair algebra.  If the pair algebra is the graph of an algebra
+    by the pair algebra. If the pair algebra is the graph of an algebra
     automorphism of the matrix algebra, Skolem--Noether turns this graph case
     into gauge-phase equivalence, so under non-gauge-equivalence the graph
-    branch is impossible.  For two blocks of unequal bond dimensions, the graph
+    branch is impossible. For two blocks of unequal bond dimensions, the graph
     branch is also impossible because it would identify matrix algebras with
     different finite dimensions over $\C$.
 \end{lemma}
@@ -3465,9 +3464,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \leanok
     Projecting the pair generators to one coordinate gives exactly the
-    one-block generator family.  Injectivity says that the linear span of this
+    one-block generator family. Injectivity says that the linear span of this
     family is the full matrix algebra, and the linear span is contained in the
-    unital algebra it generates.  The pair-word membership follows by induction
+    unital algebra it generates. The pair-word membership follows by induction
     on the word, using closure of the generated algebra under multiplication.
     Conversely, the all-word linear span is closed under componentwise
     multiplication, so it contains the algebra generated by the pair generators.
@@ -3506,9 +3505,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     Homogeneous identity-padding witnesses multiply by concatenation of words.
     Therefore, if one has a positive period and a full residue window of
     homogeneous pair spans, then the simultaneous identity pair lies in all
-    sufficiently large homogeneous pair spans.  Combined with all-length pair
+    sufficiently large homogeneous pair spans. Combined with all-length pair
     trace separation, this period-window input gives one homogeneous
-    pair trace-separation length.  This does not prove the direct-sum input of
+    pair trace-separation length. This does not prove the direct-sum input of
     \cite{PerezGarcia2007Matrix} by itself: fullness of spans up to a
     bounded length is weaker than the exact homogeneous input used here.
 \end{lemma}
@@ -3516,9 +3515,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \leanok
     The length-zero word gives the identity only at length zero, so it is not a
-    positive-length padding theorem.  The useful padding facts are homogeneous:
+    positive-length padding theorem. The useful padding facts are homogeneous:
     if the identity pair is in the span at lengths $m$ and $n$, componentwise
-    multiplication puts it in the span at length $m+n$.  A period witness and a
+    multiplication puts it in the span at length $m+n$. A period witness and a
     complete residue window therefore give homogeneous padding at every
     sufficiently large length, which is the input needed by the
     all-length-to-fixed-length implication.
@@ -3535,7 +3534,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \leanok
     \uses{def:pairwise_block_separating_words, def:pair_trace_separation_words}
     At a fixed length $S$, the pair trace-separation criterion is dual to full
-    pair product-span.  Therefore a pair trace-separation witness supplies a
+    pair product-span. Therefore a pair trace-separation witness supplies a
     word polynomial that is identity on the first block and zero on the second.
     A common witness for all ordered distinct pairs gives pairwise
     block-separating words at the same length.
@@ -3544,8 +3543,8 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \leanok
     If the pair span were proper, a nonzero linear functional would vanish on
-    it.  Nondegeneracy of the matrix trace pairing represents that functional
-    as $(\Delta_A,\Delta_B)$, contradicting pair trace separation.  Once the
+    it. Nondegeneracy of the matrix trace pairing represents that functional
+    as $(\Delta_A,\Delta_B)$, contradicting pair trace separation. Once the
     pair span is the whole product algebra, the tuple $(I,0)$ is in the span;
     using the same coefficients on the ambient block family gives the required
     partial selector.
@@ -3565,9 +3564,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \leanok
     \uses{def:pairwise_block_separating_words}
     If every ordered pair of distinct blocks admits a common-length pairwise
-    separator, then full block-selector words exist.  More precisely, multiplying
+    separator, then full block-selector words exist. More precisely, multiplying
     the pairwise separators for a fixed block $k$ against all other blocks gives a
-    selector of length $(r-1)S$ for $k$.  Hence common block injectivity plus
+    selector of length $(r-1)S$ for $k$. Hence common block injectivity plus
     pairwise separators implies the finite product-word span in the block-injectivity
     proposition in
     \cite[lines~340--345]{Cirac2016MPDO_arXiv} and the block-injective
@@ -3579,9 +3578,9 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     The empty word gives the identity tuple, selecting on the empty target set.
     The span of word tuples is closed under pointwise multiplication because the
     product of a length-$L$ word and a length-$S$ word is the concatenated
-    length-$(L+S)$ word.  Inducting over the finite set of blocks different from
+    length-$(L+S)$ word. Inducting over the finite set of blocks different from
     $k$ and multiplying the corresponding pairwise separators keeps the value $I$
-    on $k$ and introduces one additional zero block at each step.  Extracting
+    on $k$ and introduces one additional zero block at each step. Extracting
     coefficients from the final tuple-span membership gives the coefficient form
     of block-selector words.
 \end{proof}
@@ -3593,11 +3592,11 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         lem:pair_trace_separation_homogenization_with_padding,
         lem:block_selectors_from_pairwise_separators,
         lem:block_projection_span_from_product_word_span}
-    Let $(A_j)$ be a finite family of block-injective tensors.  Suppose there are
+    Let $(A_j)$ be a finite family of block-injective tensors. Suppose there are
     length-$S$ block-selector words: for each sector $k$, a linear combination of
     length-$S$ words evaluates to $I$ on $A_k$ and to $0$ on every other block.
     Then the simultaneous length-$(1+S)$ block-word evaluations span
-    $\prod_j \MN{D_j}$, with positive length.  In particular, a canonical form
+    $\prod_j \MN{D_j}$, with positive length. In particular, a canonical form
     with BNT separation supplies the required block injectivity, but the
     selector-word conclusion does not require the full canonical-form/BNT data.
     It is enough, by Lemma~\ref{lem:block_selectors_from_pairwise_separators}, to
@@ -3620,17 +3619,17 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         lem:block_selectors_from_pairwise_separators,
         lem:block_projection_span_from_product_word_span}
     Block injectivity writes each target sector matrix as a fixed-length linear
-    combination of word evaluations.  For a canonical-form/BNT family,
+    combination of word evaluations. For a canonical-form/BNT family,
     Definition~\ref{def:bnt} gives one-site injectivity of each block, hence
     $1$-block injectivity by Lemma~\ref{lem:one_block_injective_of_injective}.
     For a target tuple $(M_j)_j$, write $M_k$ as a
     one-letter linear combination in block $k$, multiply by the selector for $k$,
-    and sum over $k$.  The selector kills all off-target blocks, while it is the
+    and sum over $k$. The selector kills all off-target blocks, while it is the
     identity on block $k$, so the length-$(1+S)$ word tuples span the full
-    product algebra.  If one starts with pairwise separators instead, first use
+    product algebra. If one starts with pairwise separators instead, first use
     Lemma~\ref{lem:block_selectors_from_pairwise_separators} to multiply them into
     full selectors; if one starts from the pair trace-separation criterion, first
-    use Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}.  The
+    use Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}. The
     projection-span and commutant consequences then follow
     from Lemma~\ref{lem:block_projection_span_from_product_word_span}.
 \end{proof}
@@ -3643,20 +3642,20 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         lem:isup_chain_ground_space_block_le_assembled,
         thm:chain_ground_space_eq_mpv_blk, lem:center_scalar}
     Let $A$ be in canonical-form/BNT, and assume $1<L$, $N \ge L+1$, and
-    $0<m$.  Assume every virtual sector projection
+    $0<m$. Assume every virtual sector projection
     lies in the pulled-back span of the length-$m$ word products of the assembled
-    tensor.  If a boundary matrix for the assembled tensor commutes with all
+    tensor. If a boundary matrix for the assembled tensor commutes with all
     those length-$m$ words, then the vector obtained by applying the assembled
     ground-space map to that boundary matrix lies in
-    $\bigsqcup_j \mathcal G_{N,L}(A_j)$.  Consequently, if every assembled
+    $\bigsqcup_j \mathcal G_{N,L}(A_j)$. Consequently, if every assembled
     periodic-chain ground vector admits such a commuting boundary matrix
     representation (the result of the wrapping-window comparison), then
     \[
-        \mathcal G_{N,L}\bigl(\operatorname{Assemble}(\mu, A)\bigr)
+        \mathcal G_{N,L}(\operatorname{Assemble}(\mu, A))
         \subseteq \bigsqcup_j \mathcal G_{N,L}(A_j),
     \]
     and together with the already-proved forward inclusion this gives the
-    corresponding conditional equality.  Composing the reverse inclusion with
+    corresponding conditional equality. Composing the reverse inclusion with
     blockwise injective uniqueness gives the conditional containment of the
     assembled parent ground space in the BNT span; this lemma keeps the
     projection-span and boundary-representation hypotheses explicit.
@@ -3671,10 +3670,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     The commutant reduction makes the pulled-back boundary matrix block diagonal.
     Restricting the same word-commutation identities to a diagonal block and
     using the injectivity of that block shows, by the scalar-commutant lemma, that
-    each diagonal block is scalar.  Expanding the assembled ground-space map on a
+    each diagonal block is scalar. Expanding the assembled ground-space map on a
     block-diagonal boundary matrix gives a finite sum of scalar multiples of the
     block MPV states, and each block MPV lies in its own periodic chain ground
-    space.  The reverse-inclusion, equality, and BNT-span forms are then
+    space. The reverse-inclusion, equality, and BNT-span forms are then
     reformulations of this boundary-matrix calculation, combined with the forward
     inclusion and the blockwise uniqueness theorem.
 \end{proof}
@@ -3684,16 +3683,16 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \notready
     \uses{def:route_b_product_word_span}
     Let $A$ be in canonical-form/BNT, and assume $1<L$, $N \ge L+1$, and
-    $0<m$.  If the length-$m$ product-word tuples span $\prod_j \MN{D_j}$ and
+    $0<m$. If the length-$m$ product-word tuples span $\prod_j \MN{D_j}$ and
     every assembled periodic-chain ground vector comes with a boundary matrix
     representation commuting with all length-$m$ assembled words, then
     \[
-        \mathcal G_{N,L}\bigl(\operatorname{Assemble}(\mu, A)\bigr)
+        \mathcal G_{N,L}(\operatorname{Assemble}(\mu, A))
         \subseteq \bigsqcup_j \mathcal G_{N,L}(A_j).
     \]
     Combined with the forward inclusion, this gives the corresponding conditional
-    equality.  In the parent-ground-space formulation, the same hypotheses imply
-    containment in $\operatorname{BNTSpan}_{N}(A)$.  The product-word span and
+    equality. In the parent-ground-space formulation, the same hypotheses imply
+    containment in $\operatorname{BNTSpan}_{N}(A)$. The product-word span and
     boundary representation remain hypotheses here; they are not derived by this
     composition lemma.
 \end{lemma}
@@ -3704,10 +3703,10 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
         lem:conditional_boundary_matrix_block_split_projection_span}
     The product-word span witness gives the sector-projection span by
     Lemma~\ref{lem:block_projection_span_from_product_word_span}; the nonzero
-    weights required there are supplied by the canonical-form/BNT hypothesis.  The
+    weights required there are supplied by the canonical-form/BNT hypothesis. The
     conditional boundary-matrix block split from
     Lemma~\ref{lem:conditional_boundary_matrix_block_split_projection_span} then
-    gives the reverse inclusion.  The equality and BNT-span forms are the
+    gives the reverse inclusion. The equality and BNT-span forms are the
     corresponding projection-span results after this product-word-to-projection-span
     reduction, followed by the blockwise uniqueness argument already built into the
     projection-span theorem.
@@ -3719,17 +3718,17 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     \uses{def:bnt, rem:word_tuple_span_top,
         def:parent_hamiltonian_ground_space_bnt, def:bnt_span}
     Let $A$ be in canonical-form/BNT, assume $1 < L$ and $N \ge L + 1$, and suppose
-    length-$S$ block-selector words are given.  If every assembled periodic-chain
+    length-$S$ block-selector words are given. If every assembled periodic-chain
     ground vector has a boundary matrix representation commuting with all
     length-$(1 + S)$ assembled words, then
     \[
-        \mathcal G_{N,L}\bigl(\operatorname{Assemble}(\mu, A)\bigr)
+        \mathcal G_{N,L}(\operatorname{Assemble}(\mu, A))
         \subseteq \bigsqcup_j \mathcal G_{N,L}(A_j).
     \]
     Together with the forward inclusion, this gives the corresponding
-    conditional block-splitting equality.  In the parent-ground-space
+    conditional block-splitting equality. In the parent-ground-space
     formulation, the same hypotheses imply containment in
-    $\operatorname{BNTSpan}_{N}(A)$.  The selector-word hypothesis and the
+    $\operatorname{BNTSpan}_{N}(A)$. The selector-word hypothesis and the
     boundary representation remain explicit: this lemma does not derive
     selector existence from BNT separation, nor the wrapping/open-chain boundary
     representation. It is the formal composition matching the block-injective
@@ -3746,7 +3745,7 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
     product-word span condition at the positive length $1 + S$.
     Lemma~\ref{lem:route_b_block_split_from_product_word_span} then applies
     Route B with the boundary matrix commuting with the same
-    length-$(1 + S)$ assembled words.  The equality and BNT-span containment are
+    length-$(1 + S)$ assembled words. The equality and BNT-span containment are
     exactly the corresponding product-word-span consequences after this
     selector-to-product-span replacement.
 \end{proof}
@@ -3766,12 +3765,12 @@ Chapter~\ref{ch:bnt}~\cite{Fannes1992Finitely, PerezGarcia2007Matrix}.
 \begin{proof}
     \notready
     The remaining structural step is the periodic block decomposition of the
-    assembled chain ground space.  Lemma~\ref{lem:block_selectors_from_pairwise_separators}
+    assembled chain ground space. Lemma~\ref{lem:block_selectors_from_pairwise_separators}
     reduces finite selector words to pairwise block-separating word polynomials.
     Lemma~\ref{lem:route_b_block_split_from_bnt_selectors} then gives the conditional
     Route B composition once those selector words and the wrapping-window commuting
-    boundary matrix are available.  What remains open is to derive the needed
-    separation data and to supply the compatible boundary representation.  With the
+    boundary matrix are available. What remains open is to derive the needed
+    separation data and to supply the compatible boundary representation. With the
     block decomposition available,
     one applies the blockwise injective uniqueness theorem to each block separately
     and recovers the BNT span.

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -8,14 +8,14 @@ transfer map.
 
 When the MPS tensor generates a parent Hamiltonian
 (Chapter~\ref{ch:parent_hamiltonian}), the correlator quantifies spatial
-correlations in the ground state.  The exponential decay rate is set by the
+correlations in the ground state. The exponential decay rate is set by the
 spectral properties of the transfer map, i.e.\ by the modulus of its
 subleading eigenvalues.
 
 The spectral analysis of the transfer map and the mixed transfer operator,
 including the eigenvalue bound $\rho(F_{AB}) \le 1$, the strict
 transfer-operator gap $\rho(F_{AB}) < 1$ for non-equivalent blocks, and the resulting
-overlap decay, is developed in Chapter~\ref{ch:spectral}.  This chapter
+overlap decay, is developed in Chapter~\ref{ch:spectral}. This chapter
 focuses on the \emph{correlator} side: one-point and two-point expectations,
 their spectral decomposition, and quantitative bounds on decay rates.
 
@@ -71,7 +71,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
         C(X,Y;n) = \sum_{j=1}^{D^2-1} c_j\,\lambda_j^n,
     \]
     then the connected correlator equals the stated sum of exponentials.
-    The source~\cite[Sec.~2.3]{Cirac2021Matrix} states that the connected
+    The source~\cite[Section~II.B.3]{Cirac2021Matrix} states that the connected
     correlator is a sum of $D^2-1$ pure exponentials
     $C(X,Y;n) = \sum_{j\ge 2}^{D^2} c_{XY}(j)\lambda_j^n$,
     which always exists for a normal MPS via the transfer-map spectral decomposition.
@@ -81,7 +81,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
 \begin{proof}
     \leanok
     Given the expansion hypothesis, the equality is immediate.
-    The source~\cite[Sec.~2.3]{Cirac2021Matrix} derives this expansion
+    The source~\cite[Section~II.B.3]{Cirac2021Matrix} derives this expansion
     from the spectral decomposition of $\E_A^n$ restricted to the
     complement of the fixed-point eigenspace: the leading eigenvalue
     $\lambda_1=1$ contributes $\langle X_0\rangle\langle Y_0\rangle$,
@@ -101,7 +101,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
         |C(X,Y;n)| \le C_{XY}\,|\lambda_2|^n,
     \]
     then the connected correlator satisfies that exponential decay bound.
-    The source~\cite[Sec.~2.3]{Cirac2021Matrix} obtains this by combining
+    The source~\cite[Section~II.B.3]{Cirac2021Matrix} obtains this by combining
     the sum-of-exponentials expansion with the triangle inequality, and
     Sec.~4 provides the transfer-map gap condition $|\lambda_j|<1$ for the
     subleading eigenvalues.
@@ -112,7 +112,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
 \begin{proof}
     \leanok
     Given the bound hypothesis, the estimate is immediate.
-    The source~\cite[Sec.~2.3]{Cirac2021Matrix} obtains this bound
+    The source~\cite[Section~II.B.3]{Cirac2021Matrix} obtains this bound
     by applying the triangle inequality to the sum-of-exponentials
     expansion and using the transfer-map gap condition
     $|\lambda_j|\le|\lambda_2|<1$ for all subleading eigenvalues.
@@ -127,7 +127,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
     The hypothesis ``$|\lambda_2| < 1$'' in
     Theorem~\ref{thm:correlator_exponential_bound} is a transfer-map gap
     condition: all non-leading eigenvalues of $\E_A$ lie strictly inside the
-    unit disk.  It is distinct from the Hamiltonian spectral gap of
+    unit disk. It is distinct from the Hamiltonian spectral gap of
     Chapter~\ref{ch:parent_hamiltonian}.
     The complementary transfer-map gap $\rho(\E_A - P) < 1$ is established for
     primitive channels
@@ -172,7 +172,7 @@ their spectral decomposition, and quantitative bounds on decay rates.
 \section{Quantitative transfer-map gap bounds}
 
 The transfer-map gap theorems in Chapter~\ref{ch:channels} establish
-$\rho(\E_A - P) < 1$ for primitive channels qualitatively.  This section
+$\rho(\E_A - P) < 1$ for primitive channels qualitatively. This section
 gives the \emph{quantitative} refinements with explicit constants
 and rates for the single-tensor transfer map $\E_A$.
 
@@ -193,7 +193,7 @@ and rates for the single-tensor transfer map $\E_A$.
     $n \ge 0$ and $X \in \MN{D}$,
     \[
         \|\E_A^n(X) - P(X)\|
-        \;\le\; C\,(1-\delta)^n\,\|X\|.
+        \le  C\,(1-\delta)^n\,\|X\|.
     \]
     The transfer-map gap $\delta$ exists by primitivity
     (Theorem~\ref{thm:primitive_compl_lt_one}, the complementary transfer-map gap).
@@ -219,10 +219,10 @@ and rates for the single-tensor transfer map $\E_A$.
     traceless $X \in \MN{D}$ (i.e.\ $\tr(X) = 0$),
     \[
         \|\E_A^n(X)\|
-        \;\le\; C\,e^{-n/\xi}\,\|X\|.
+        \le  C\,e^{-n/\xi} \|X\|.
     \]
     Traceless matrices lie in $\ker P$, where $P$ is the fixed-point
-    projection.  Since $\E_A - P$ has spectral radius strictly less
+    projection. Since $\E_A - P$ has spectral radius strictly less
     than~$1$, the Gelfand formula gives exponential decay at rate
     $\xi = -1/\log\rho(\E_A - P)$.
 \end{theorem}
@@ -231,7 +231,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \leanok
     For traceless $X$ we have $P(X) = 0$, so $\E_A^n(X) = (\E_A - P)^n(X)$.
     The exponential convergence theorem gives a geometric bound
-    $C\,(1-\delta)^n\,\|X\|$.  Rewriting $(1-\delta)^n = e^{-n/\xi}$ with
+    $C\,(1-\delta)^n\,\|X\|$. Rewriting $(1-\delta)^n = e^{-n/\xi}$ with
     $\xi = -1/\log(1-\delta)$ yields the claimed estimate.
 \end{proof}
 
@@ -273,7 +273,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \uses{def:transfer_map}
     An MPS tensor $A$ is a \emph{renormalization fixed point} (RFP) when its
     transfer map is idempotent, $\E_A \circ \E_A = \E_A$.
-    See \cite[Definition~3.2]{Cirac2021Matrix}.
+    See \cite[Definition~3.2]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[Kraus-isometry criterion for RFP]\label{thm:kraus_isometry_implies_rfp}
@@ -288,7 +288,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \]
     for all $i_1,i_2 \in \{0,\ldots,d-1\}$.
     Then $A$ is a renormalization fixed point.
-    This is the backward direction of \cite[Theorem~3.1]{Cirac2021Matrix}.
+    This is the backward direction of \cite[Theorem~3.1]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     Expanding $\E_A^2$ gives a double Kraus sum indexed by pairs $(i_1,i_2)$.
@@ -305,7 +305,7 @@ and rates for the single-tensor transfer map $\E_A$.
     is idempotent. For a single tensor this coincides with the RFP condition
     (Definition~\ref{def:is_rfp}); in the full multi-block BNT setting, local
     orthogonality additionally requires that mixed transfer operators vanish.
-    See \cite[Definition~3.5]{Cirac2021Matrix}.
+    See \cite[Definition~3.5]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[RFP normal tensor is injective]\label{thm:rfp_nt_injective}
@@ -332,7 +332,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \]
     Then $A$ is injective.
     This is the left-canonical injectivity step in
-    \cite[Appendix~B]{Cirac2021Matrix}.
+    \cite[Appendix~B]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:rfp_nt_injective}
@@ -359,7 +359,7 @@ and rates for the single-tensor transfer map $\E_A$.
         \E_B(\Lambda) = \Lambda.
     \]
     This is the diagonal fixed-point reduction in
-    \cite[Appendix~B]{Cirac2021Matrix}.
+    \cite[Appendix~B]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:rfp_nt_structural_of_left_canonical, thm:injective_irreducible,
@@ -380,7 +380,7 @@ and rates for the single-tensor transfer map $\E_A$.
         thm:exponential_convergence_primitive}
     Let $A$ be an injective left-canonical RFP tensor with positive-definite
     fixed point $\rho$ of the transfer map $\E_A$. Then
-    $\E_A = P_\rho$, where $P_\rho(X) = \frac{\tr(X)}{\tr(\rho)}\,\rho$
+    $\E_A = P_\rho$, where $P_\rho(X) = \frac{\tr(X)}{\tr(\rho)} \rho$
     is the rank-one fixed-point projection.
 \end{theorem}
 \begin{proof}\leanok
@@ -437,7 +437,7 @@ and rates for the single-tensor transfer map $\E_A$.
     idempotent linear map $\E_\infty$ as $n\to\infty$.
     That is, there exists $\E_\infty$ with $\E_\infty^2 = \E_\infty$ such that
     $\E_{A_k}^{2^n}(\rho) \to \E_\infty(\rho)$ for all density matrices $\rho$.
-    This is \cite[Appendix~B]{Cirac2021Matrix}.
+    This is \cite[Appendix~B]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     Each block is injective and left-canonical, so its transfer map is a
@@ -478,7 +478,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \uses{def:is_locally_orthogonal, def:is_cid}
     An MPS tensor has \emph{zero correlation length} when it is both locally
     orthogonal and correlations are independent of distance.
-    See \cite[Definition~3.6]{Cirac2021Matrix}.
+    See \cite[Definition~3.6]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[CID implies RFP]\label{thm:isCID_implies_isRFP}
@@ -488,7 +488,7 @@ and rates for the single-tensor transfer map $\E_A$.
     If an MPS tensor admits a positive definite right fixed point of its
     transfer map and has correlations independent of distance, then
     its transfer map is idempotent.
-    This is the reverse direction of \cite[Theorem~3.8]{Cirac2021Matrix}.
+    This is the reverse direction of \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     Trace nondegeneracy and invertibility of the fixed point reduce
@@ -503,7 +503,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \uses{def:is_rfp, def:is_cid, def:is_locally_orthogonal}
     An MPS tensor has zero correlation length (i.e.\ is both locally
     orthogonal and CID) if and only if its transfer map is idempotent.
-    This is \cite[Theorem~3.8]{Cirac2021Matrix}.
+    This is \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     The forward direction extracts local orthogonality (which equals
@@ -519,7 +519,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \uses{def:is_canonical_form, def:is_rfp, def:is_zcl}
     For a tensor in canonical form, each block is a renormalization fixed point
     if and only if it has zero correlation length.
-    This is the RFP--ZCL part of \cite[Theorem~3.10]{Cirac2021Matrix}.
+    This is the RFP--ZCL part of \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:zcl_iff_idempotent_transfer}

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -1,9 +1,9 @@
 \chapter{Concrete Examples}\label{ch:examples}
 
 This chapter collects concrete MPS tensors from
-\cite[Section~III]{Cirac2021Matrix}.  Each example is specified by its
+\cite[Section~III]{Cirac2021Matrix}. Each example is specified by its
 physical dimension~$d$, bond dimension~$D$, and explicit matrix
-family~$\{A^i\}$.  Key structural properties (injectivity, RFP status,
+family~$\{A^i\}$. Key structural properties (injectivity, RFP status,
 symmetry) are stated for each tensor.
 
 %% ===================================================================
@@ -17,7 +17,7 @@ non-injective, renormalization-fixed-point MPS.
     \lean{MPSTensor.ghzTensor}
     \leanok
     \uses{def:mps_tensor}
-    Set $d = D = 2$.  The GHZ tensor is the family
+    Set $d = D = 2$. The GHZ tensor is the family
     $\{A^0, A^1\} \subset \MN{2}$ defined by
     \[
         A^0 = \ketbra{0}{0} = \diag(1,0),
@@ -80,7 +80,7 @@ non-injective, renormalization-fixed-point MPS.
     \leanok
     \uses{def:ghz_tensor, def:on_site_symmetric}
     Let $\Z_2 = \{1, \sigma_x\}$ act on $\C^2$ by the Pauli-$X$
-    matrix~$\sigma_x$.  The GHZ tensor is on-site symmetric under this
+    matrix~$\sigma_x$. The GHZ tensor is on-site symmetric under this
     action: for each $g \in \Z_2$, the twisted tensor $\widetilde A_g$
     defines the same MPV family as $A$, i.e.\ $\mc V(A)=\mc V(\widetilde
         A_g)$.
@@ -88,7 +88,7 @@ non-injective, renormalization-fixed-point MPS.
 
 \begin{proof}
     \leanok
-    The identity element is trivial.  For the generator
+    The identity element is trivial. For the generator
     $g = \sigma_x$, the twisted tensor satisfies
     $\widetilde A_g^i = A^{1-i}$, i.e.\ the two matrices are swapped.
     Conjugation by $\sigma_x$ implements the same swap, giving
@@ -156,21 +156,21 @@ symmetry-protected topological (SPT) order.
     \lean{MPSTensor.akltTensor}
     \leanok
     \uses{def:mps_tensor}
-    Set $d = 3$ (spin-1) and $D = 2$.  The AKLT tensor is the family
+    Set $d = 3$ (spin-1) and $D = 2$. The AKLT tensor is the family
     $\{A^0, A^1, A^2\} \subset \MN{2}$ defined via the Pauli matrices by
     \[
-        A^0 = \frac{1}{\sqrt{3}}\,\sigma_z,
+        A^0 = \frac{1}{\sqrt{3}} \sigma_z,
         \qquad
-        A^1 = \frac{\sqrt{2}}{\sqrt{3}}\,\ketbra{0}{1},
+        A^1 = \frac{\sqrt{2}}{\sqrt{3}} \ketbra{0}{1},
         \qquad
-        A^2 = -\frac{\sqrt{2}}{\sqrt{3}}\,\ketbra{1}{0},
+        A^2 = -\frac{\sqrt{2}}{\sqrt{3}} \ketbra{1}{0},
     \]
     where
     $\sigma_z = \ketbra{0}{0} - \ketbra{1}{1}$,
-    so equivalently $A^1 = \frac{1}{\sqrt{3}}\,\sigma_+$ and
-    $A^2 = -\frac{1}{\sqrt{3}}\,\sigma_-$ for
-    $\sigma_+ = \sqrt{2}\,\ketbra{0}{1}$ and
-    $\sigma_- = \sqrt{2}\,\ketbra{1}{0}$.
+    so equivalently $A^1 = \frac{1}{\sqrt{3}} \sigma_+$ and
+    $A^2 = -\frac{1}{\sqrt{3}} \sigma_-$ for
+    $\sigma_+ = \sqrt{2} \ketbra{0}{1}$ and
+    $\sigma_- = \sqrt{2} \ketbra{1}{0}$.
     Equivalently, the matrices are the Clebsch--Gordan coefficients
     coupling spin-$1$ and spin-$\tfrac12$ to spin-$\tfrac12$.
 \end{definition}
@@ -191,7 +191,7 @@ symmetry-protected topological (SPT) order.
     \uses{def:aklt_tensor, def:transfer_map}
     The transfer map of the AKLT tensor has a unique eigenvalue of
     maximal modulus (a simple spectral-radius eigenvalue); in
-    particular the AKLT tensor is normal.  Concretely, the
+    particular the AKLT tensor is normal. Concretely, the
     length-$2$ blocked tensor is injective.
 \end{theorem}
 
@@ -318,7 +318,7 @@ computation and provides another example of a non-trivial SPT phase.
     \lean{MPSTensor.clusterTensor}
     \leanok
     \uses{def:mps_tensor}
-    Set $d = D = 2$.  The cluster-state tensor is the family
+    Set $d = D = 2$. The cluster-state tensor is the family
     $\{A^0, A^1\} \subset \MN{2}$ defined by
     \[
         A^0 = \ketbra{+}{0}
@@ -360,12 +360,12 @@ computation and provides another example of a non-trivial SPT phase.
     \uses{def:cluster_tensor, def:injective}
     Although the cluster-state tensor is not injective at a single site, its
     length-$2$ blocking is injective: the four length-$2$ products span
-    $\MN{2}$.  In particular the cluster-state tensor is normal.
+    $\MN{2}$. In particular the cluster-state tensor is normal.
 \end{theorem}
 
 \begin{remark}\label{rem:cluster_injective_blocked}
     Although the cluster-state tensor is not injective at length~$1$,
-    the length-$2$ blocked tensor is injective.  Using
+    the length-$2$ blocked tensor is injective. Using
     $\braket{0}{\pm} = \tfrac{1}{\sqrt{2}}$,
     $\braket{1}{+} = \tfrac{1}{\sqrt{2}}$, and
     $\braket{1}{-} = -\tfrac{1}{\sqrt{2}}$, the
@@ -386,7 +386,7 @@ computation and provides another example of a non-trivial SPT phase.
     \leanok
     \uses{def:cluster_tensor, def:on_site_symmetric}
     The length-$2$ blocked cluster-state tensor is on-site symmetric
-    under $\Z_2 \times \Z_2$.  The two generators act on the
+    under $\Z_2 \times \Z_2$. The two generators act on the
     $4$-dimensional blocked physical space $(\C^2)^{\otimes 2}$ by
     $\sigma_x \otimes I$ and $I \otimes \sigma_x$,
     which commute and each square to the identity, defining a linear

--- a/blueprint/src/chapter/ch17_operator_convexity.tex
+++ b/blueprint/src/chapter/ch17_operator_convexity.tex
@@ -247,7 +247,7 @@ are not developed elsewhere in this document.
     \[
         T(\log A) \le \log(TA).
     \]
-    This is \cite[Theorem~5.12]{Wolf2012Quantum} for~$f=\log$.
+    This is \cite[Theorem~5.13]{Wolf2012Quantum} for~$f=\log$.
     Requires unitality ($T(\Id)=\Id$), not merely subunitality.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch17_operator_convexity.tex
+++ b/blueprint/src/chapter/ch17_operator_convexity.tex
@@ -223,7 +223,8 @@ are not developed elsewhere in this document.
     \[
         (TA)^p \le T(A^p).
     \]
-    This is \cite[Theorem~5.12]{Wolf2012Quantum} for convex~$f(x)=x^p$.
+    This is \cite[Theorem~5.11]{Wolf2012Quantum} for the subunital
+    operator-convex case $f(x)=x^p$.
 \end{theorem}
 
 \begin{theorem}[Map form of Jensen for convex real powers]\label{thm:rpow_convex_jensen}

--- a/blueprint/src/chapter/ch17_operator_convexity.tex
+++ b/blueprint/src/chapter/ch17_operator_convexity.tex
@@ -3,7 +3,7 @@
 This chapter collects the operator convexity/concavity results, trace
 inequalities, the operator Jensen inequality for positive maps, and the
 Lieb concavity theorem. These are standard results in matrix analysis
-(\cite[Chapter~V]{Bhatia1997Matrix}; \cite[Theorem~5.1]{Wolf2012Quantum};
+(\cite[Chapter~V]{Bhatia1997Matrix}; \cite[Theorems~5.12 and~5.13]{Wolf2012Quantum};
 Hansen--Pedersen's Jensen inequality~\cite{HansenPedersen1982Jensen};
 and Lieb's concavity theorem~\cite{Lieb1973Convex}). They are
 provided here as cited inputs, since the corresponding matrix-analysis proofs for
@@ -198,7 +198,7 @@ are not developed elsewhere in this document.
     \[
         T(A^p) \le (TA)^p.
     \]
-    This is \cite[Theorem~5.1]{Wolf2012Quantum} for concave~$f(x)=x^p$.
+    This is \cite[Theorem~5.13]{Wolf2012Quantum} for concave~$f(x)=x^p$.
 \end{theorem}
 
 \begin{theorem}[Map form of Jensen for concave real powers]\label{thm:rpow_concave_jensen}
@@ -223,7 +223,7 @@ are not developed elsewhere in this document.
     \[
         (TA)^p \le T(A^p).
     \]
-    This is \cite[Theorem~5.1]{Wolf2012Quantum} for convex~$f(x)=x^p$.
+    This is \cite[Theorem~5.12]{Wolf2012Quantum} for convex~$f(x)=x^p$.
 \end{theorem}
 
 \begin{theorem}[Map form of Jensen for convex real powers]\label{thm:rpow_convex_jensen}
@@ -247,7 +247,7 @@ are not developed elsewhere in this document.
     \[
         T(\log A) \le \log(TA).
     \]
-    This is \cite[Theorem~5.1]{Wolf2012Quantum} for~$f=\log$.
+    This is \cite[Theorem~5.12]{Wolf2012Quantum} for~$f=\log$.
     Requires unitality ($T(\Id)=\Id$), not merely subunitality.
 \end{theorem}
 

--- a/docs/blueprint_style_guide.md
+++ b/docs/blueprint_style_guide.md
@@ -178,4 +178,13 @@ leanblueprint all     # pdf + web + checkdecls
 - **Chapter 2**: Overlap and inner product differ by conjugation. Lean: `mpvOverlap A B N = star (mpvInner A B N)`. The overlap sums $V_\sigma \overline{W_\sigma}$; the inner product sums $\overline{V_\sigma} W_\sigma$.
 - **Chapter 4**: KS inequality is for UNITAL maps, not TP. HS contraction requires BOTH.
 - **Chapter 4**: `kraus_commute_of_ks_equality` proves $X K_i^\dagger = K_i^\dagger E(X)$, not Kraus commutation with a unitary.
-- **Chapter 4**: Wolf citations: Equation (5.2) for KS; Proposition 6.1 spectral radius; Proposition 6.2 trivial Jordan; Theorem 6.6 irreducibility; Proposition 6.8 Hermitian FP; Theorem 6.11 primitive; Theorem 6.13 Cesàro.
+- **Chapter 4**: Wolf citations (verified against the PDF, 2026-06): Equation (5.2) = Kadison–Schwarz; Proposition 6.1 = spectral radius; Theorem 6.2(1) = irreducibility definition; Theorem 6.7 = primitive maps; Proposition 6.8 = positive (Hermitian) fixed points; Theorem 6.11 = stationary states (Brouwer); Theorem 6.12 = fixed-point $*$-algebra; Theorem 6.13 = fixed points and Kraus commutant.
+
+## Citing external sources (verified conventions)
+
+External theorem/equation numbers were cross-checked against the **PDF-converted text** (never the LaTeX source, which can be inaccurate). Wolf per-chapter PDFs live in `Notes/WolfNotePDF/`; paper sources are the arXiv PDFs.
+
+- **Wolf** (`Wolf2012Quantum`): sub-parts use a **parenthetical** form with no word — `Theorem~6.2(1)`, `Corollary~7.2(3)`, `Theorem~2.1(4)`, `Lemma~6.3(b)` — matching Wolf's bare `1. 2. 3.` enumeration. Spell out environment words (`Lemma~`, `Equations~`; never `Lem.`/`Eqs.`). Implications: `Proposition~7.6, (1)$\Rightarrow$(3)` / `$\Leftrightarrow$`.
+- **MPDO paper** is cited on the **arXiv preprint** key `Cirac2016MPDO_arXiv` with **Arabic** numbers (Theorem 2.10 = proportional FT, Corollary 2.11 = equal FT, Theorem 4.14(ii) = MPDO structure, Section 2.3 = canonical forms). The published-Annals key `Cirac2017MPDO_AnnPhys` (Roman II.1/IV.13) is **not** used in citations — its numbering is not locally verifiable.
+- **CPGSV21** (`Cirac2021Matrix`, RMP) uses **Roman** numbering exclusively (Theorem IV.4 = proportional FT, Corollary IV.5 = equal FT, Theorem IV.16 = ground-space generation, Definition IV.2 = basis of normal tensors, Section II.B.3 = correlations). It has a single appendix (A); do not cite an "Appendix B" to it.
+- **PGVWC07** (`PerezGarcia2007Matrix`): Theorem 4 = TI canonical form, Theorem 5 = periodic decomposition, Lemma 3 = matrix-span lemma. Cite resolved numbers, never internal `\label`s (`Th:TIcanonical`, etc.).


### PR DESCRIPTION
## Summary

A local **formatting + citation-normalization** pass across the blueprint chapters, rebased onto current `main`.

- **Whitespace** — collapse double spaces after sentence periods to single spaces; tighten display-math spacing (drop redundant `\;` / `\,`).
- **Citations** — normalize source references to the project's documented conventions (e.g. `Sec.~2.3` → `Section~II.B.3`) and re-point several definition/appendix citations to the verifiable arXiv key `Cirac2016MPDO_arXiv`.
- **Trailing newlines** — removed from the touched chapter files (intentional).

**24 files, +600/−599.** No `\lean`/`\leanok`/`\uses` tags changed, no equation/theorem labels touched — purely cosmetic + bibliographic.

## How it was built (rebase, not stale snapshot)

The local edits were made on a base ~57 commits behind `main`, so they were applied as a **3-way delta** onto current `main`:

- **16 files merged cleanly.**
- **9 files / 17 regions conflicted** with newer editorial work already on `main` (FT-nickname fixes, citation-convention conversion, expanded prose, and formalization-status updates). Per the author's instruction, every conflicting region was **deferred to main's current text** — so this PR never reverts main's work. `ch01` ended up identical to main and dropped out.

## Reviewer note

The citation **re-pointings** (notably `ch15`: `Cirac2021Matrix` → `Cirac2016MPDO_arXiv` on several `Definition`/`Appendix~B` references) are the author's bibliographic calls and are worth a domain check that the target key/label actually contains the cited result. No undefined keys are introduced — all 6 keys used are already defined and in active use across the blueprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits with no formalization tags changed; citation repointings should be spot-checked against the arXiv source numbering the author documented.
> 
> **Overview**
> Blueprint LaTeX chapters get a **cosmetic and bibliographic** pass across ~24 files: no `\lean` tags, labels, or math content change in substance.
> 
> **Citations** are retargeted to the project’s verifiable **arXiv** key `Cirac2016MPDO_arXiv` (replacing many `Cirac2017MPDO_AnnPhys` pointers) with **renumbered** in-text references (e.g. Theorem~II.1 → Theorem~2.10, Section~IV.13 → Theorem~4.14, `\S~II.C` → Section~2.3). **Wolf2012Quantum** and **PerezGarcia2007Matrix** cites are tightened to parenthetical forms like `Theorem~6.2(1)` and `Theorem~4`. A few **Cirac2021Matrix** anchors shift (e.g. single-block FT to Corollary~IV.5).
> 
> **Typography**: American **analog**, **non-negative**; sentence spacing after periods; lighter display-math (`\bigl`/`\Bigr` → `(` `)`, matrix alignment tweaks); minor punctuation in proofs.
> 
> **Trailing newlines** removed on touched chapter files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e00117baa85db6dd5badc2a4386699317f30f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Source-numbering check

For the `ch15_correlations.tex` repointings, I checked the local arXiv source
`Papers/1606.00608/MPDO-22-12-17-2.tex`: the cited RFP, mixed RFP/ZCL/SAL,
simple MPDO theorem, and Appendix B material occur under the arXiv paper's
Section III and Appendix B labels (`defRFP`, `RFPMixedTS`, `DefinitionZCL`,
`def:area-law`, `thm:main-simple`, and `AppendixMixed`). The PR is therefore
using the arXiv numbering intentionally for those references.
