### PR TITLE
doc(canonical): record PGVWC07 periodic decomposition gap

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1613,6 +1613,6 @@ through its own period agrees with the directly $p$-blocked block.
     state-vector decomposition. Here we use only the blocked cyclic-sector
     consequence, Theorem~\ref{thm:cyclic_sector_decomp_after_blocking}; the
     explicit decomposition of the state vector into $p$-periodic summands lies
-    outside this chapter. This scope boundary is recorded in
-    \path{docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex}.
+    outside this chapter.
+    % Scope boundary documented in docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex.
 \end{remark}

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1605,12 +1605,14 @@ through its own period agrees with the directly $p$-blocked block.
 \section{Scope of the canonical-form reduction}\label{sec:open_directions}
 
 \begin{remark}[Scope relative to \cite{PerezGarcia2007Matrix}, Section~III]%
-    \label{subsec:pgvwc06_out_of_scope}
+    \label{subsec:pgvwc07_out_of_scope}
     The reduction follows~\cite{Cirac2017MPDO_AnnPhys}
     and~\cite{Cirac2021Matrix}, using site-independent tensors, transfer-map
-    primitivity, and CPM fixed-point normalization. The period-removal step
-    of~\cite[Theorem~Th:periodic]{PerezGarcia2007Matrix} is
-    Theorem~\ref{thm:cyclic_sector_decomp_after_blocking}; the explicit
-    decomposition of the state vector into $p$-periodic summands lies outside
-    this chapter.
+    primitivity, and CPM fixed-point normalization. The periodic decomposition
+    theorem of~\cite[Theorem~5]{PerezGarcia2007Matrix} contains an explicit
+    state-vector decomposition. Here we use only the blocked cyclic-sector
+    consequence, Theorem~\ref{thm:cyclic_sector_decomp_after_blocking}; the
+    explicit decomposition of the state vector into $p$-periodic summands lies
+    outside this chapter. This scope boundary is recorded in
+    \path{docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex}.
 \end{remark}

--- a/docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex
+++ b/docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex
@@ -1,0 +1,77 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Scope of the Formal Period-Removal Step Relative to PGVWC07 Periodic
+Decomposition}
+\author{}
+\date{2026-06-04}
+
+\begin{document}
+\maketitle
+
+\section{Source theorem}
+
+P\'erez-Garc\'ia, Verstraete, Wolf, and Cirac prove the periodic decomposition
+theorem for translation-invariant MPS with periodic boundary conditions
+\cite[Theorem~5, lines~849--858]{PerezGarcia2007MPSReps}.
+The theorem starts with a TI state \(\psi \in (\mathbb C^d)^{\otimes N}\)
+whose canonical TI MPS representation has a single block with \(D\times D\)
+matrices \(A_i\).  Let
+\[
+  \mathcal E(X)=\sum_i A_i X A_i^\dagger .
+\]
+If \(\mathcal E\) has \(p\) eigenvalues of modulus \(1\), then:
+\begin{enumerate}
+  \item if \(p\) divides \(N\), the state \(\psi\) is a superposition of
+    \(p\) \(p\)-periodic states, each with an MPS representation of bond
+    dimension \(D\);
+  \item if \(p\) does not divide \(N\), then \(\psi=0\).
+\end{enumerate}
+The proof uses the peripheral spectral structure of the CP map from
+Fannes--Nachtergaele--Werner: there are orthogonal projectors \(P_k\) cyclically
+permuted by the matrices \(A_i\), and inserting
+\(\sum_k P_k\) into the trace splits \(\psi\) into the claimed
+\(p\)-periodic summands
+\cite[lines~860--880]{PerezGarcia2007MPSReps}.
+
+\section{Formal boundary}
+
+Chapter~8 formalizes only the period-removal-by-blocking consequence needed for
+the canonical-form reduction: after blocking by a common multiple of the periods,
+the relevant cyclic sectors have primitive transfer maps.
+
+This formal theorem is not the explicit PGVWC07 state-vector decomposition.  It
+does not produce \(p\) separate \(p\)-periodic MPS summands for the original
+unblocked ring, nor does it state the dichotomy between \(p\mid N\) and
+\(\psi=0\).  It supplies the primitive blocked sectors used by the later
+canonical-form development.
+
+\section{Required formalization}
+
+A source-faithful formalization of PGVWC07 Theorem~5 should state the one-block
+TI canonical hypothesis, the peripheral spectrum condition for \(\mathcal E\),
+and the two conclusions above.  The construction should exhibit the
+\(p\)-periodic summands obtained from the cyclic projectors \(P_k\), including
+their bond dimension \(D\), and should prove the vanishing statement when
+\(p\nmid N\).
+
+Until that theorem exists, Chapter~8 should cite the blocking theorem only as a
+period-removal input for primitive sectors, not as a formalization of the
+explicit periodic decomposition of the state vector.
+
+\section{Tracked consequence}
+
+The scope remark at the end of Chapter~8 records this boundary.  It is a
+documented scope restriction, not a source-error claim.  The open issue is
+\href{https://github.com/LionSR/TNLean/issues/2278}{issue \#2278}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation

- The closing scope remark in `blueprint/src/chapter/ch08_canonical.tex` was
  labelled `subsec:pgvwc06_out_of_scope` but cites PerezGarcia2007Matrix
  (PGVWC07); the label is inconsistent with the `pgvwc07` prefix used throughout
  Chapter 8 (e.g. `thm:pgvwc07_ti_canonical_form`).
- PGVWC07 Theorem 5 (the explicit periodic decomposition of a one-block TI
  canonical MPS into p-periodic summands) had no paper-gap note recording its
  deferral, leaving the scope boundary undocumented; see #2278.
- The existing Chapter 8 formalization covers only the period-removal-by-blocking
  consequence needed for primitive transfer maps, not the full state-vector
  summand decomposition or the divisibility dichotomy (\(p \mid N\) vs.
  \(\psi = 0\)).

### Description

- `blueprint/src/chapter/ch08_canonical.tex`: renamed label
  `subsec:pgvwc06_out_of_scope` to `subsec:pgvwc07_out_of_scope`; updated the
  scope remark to cite PGVWC07 Theorem 5 and reference the new paper-gap note.
- `docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex` (new file):
  records that PGVWC07 Theorem 5 (lines 849–858) states the periodic
  decomposition — the state is a superposition of p p-periodic states when
  \(p \mid N\), and zero otherwise — and that lines 860–880 construct the
  summands using cyclic projectors. Documents that only
  `thm:cyclic_sector_decomp_after_blocking` is currently in scope, and lists
  what a faithful formalization would require.
- No Lean declarations added or modified; no sorrys introduced.

### Testing

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root .` (reports only pre-existing
  PEPS declaration and literal placeholder warnings)
- `cd blueprint && leanblueprint web` (completed with the usual plasTeX and
  bibliography warnings)
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Closes #2278

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint and paper-gap documentation only; no Lean or runtime behavior changes.
> 
> **Overview**
> **Documentation-only** change: no Lean code is added or modified.
> 
> The closing **scope remark** in `ch08_canonical.tex` is aligned with PGVWC07 naming and citations. The label `subsec:pgvwc06_out_of_scope` becomes `subsec:pgvwc07_out_of_scope`, and the text now states that **PGVWC07 Theorem 5** gives an explicit **state-vector** periodic decomposition, while Chapter 8 only formalizes the **blocked cyclic-sector** input (`thm:cyclic_sector_decomp_after_blocking`), not the full \(p\)-periodic summand split or the \(p \mid N\) vs. \(\psi = 0\) dichotomy.
> 
> A new paper-gap note, `docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex`, records that boundary, what a faithful formalization of Theorem 5 would require, and links to issue **#2278** (closed by this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98b932ed40520ef841c2297ce3d630ccba90c66d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->