### PR TITLE
doc(canonical): remove blueprint label from period-removal prose

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean
@@ -420,9 +420,8 @@ irreducibility alone:
 the positive adjoint fixed point, primitive peripheral root, and map-level
 irreducibility are consequences of quantum Perron--Frobenius theory.
 
-This is the period-removal statement used in the blueprint theorem
-`thm:cyclic_sector_decomp_after_blocking`; it corresponds to arXiv:1606.00608,
-lines 227--231. -/
+The statement records the period-removal decomposition for irreducible
+trace-preserving MPS tensors described in arXiv:1606.00608, lines 227--231. -/
 theorem exists_cyclic_sector_decomp_after_blocking_of_TP_of_isIrreducibleTensor
     {d D : ℕ} [NeZero D]
     (A : MPSTensor d D)


### PR DESCRIPTION
### Motivation

- The cyclic-sector docstring should identify the mathematical statement it records, rather than presenting an internal blueprint label as the theorem.
- The result is the period-removal decomposition for irreducible trace-preserving MPS tensors, cited to arXiv:1606.00608, lines 227--231.

### Description

- Rephrased the docstring to describe the period-removal decomposition directly.
- Kept the arXiv:1606.00608 line citation unchanged.
- No theorem statement, proof term, or mathematical dependency is changed.

### Testing

- `git diff --check`
- `rg -n "This is the period-removal statement used in the blueprint theorem|is the theorem|thm:cyclic_sector_decomp_after_blocking" TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean` (no matches)
- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorDecomposition.lean` did not reach the edited file in the fresh worktree because no `TNLean` oleans had been built there; CI should perform the project build.

---
Addresses #1399