### PR TITLE
doc(parent): record example Hamiltonian source scope

### DIFF
--- a/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
+++ b/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
@@ -1,0 +1,157 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Example Parent Hamiltonians in Cirac--Perez-Garcia--Schuch--Verstraete 2021}
+\author{}
+\date{2026-06-04}
+
+\begin{document}
+\maketitle
+
+\section{Purpose}
+
+This note records the source scope for the example-level parent-Hamiltonian
+targets in \href{https://github.com/LionSR/TNLean/issues/2315}{issue \#2315}.
+The issue concerns the GHZ, cluster, and AKLT tensors already present in the
+formal development.  Its mathematical aim is natural: connect these tensors to
+their parent Hamiltonians and to the corresponding ground-space statements.
+The point of this note is only to separate what is stated in the local review
+source from standard example formulas which need an additional citation or an
+explicit derivation.
+
+\section{Statements present in the review}
+
+The review gives the GHZ MPS tensor by
+\[
+  A^i_{\alpha\beta}=\delta_{i=\alpha=\beta},
+\]
+and writes the corresponding state as
+\[
+  |\mathrm{GHZ}\rangle=\sum_{i=0}^{d-1}|i,i,\ldots,i\rangle
+\]
+\cite[lines~2341--2345]{Cirac2021Matrix}.  Earlier, in the discussion of
+symmetry breaking, it identifies the ferromagnetic Ising Hamiltonian
+\[
+  H=-\sum_i Z_iZ_{i+1}
+\]
+as the paradigmatic model whose symmetric ground state is the superposition of
+all spins up and all spins down, and writes the same MPS tensor as
+$A^\uparrow=|0\rangle\langle 0|$ and
+$A^\downarrow=|1\rangle\langle 1|$
+\cite[lines~1194--1196]{Cirac2021Matrix}.  In the stability discussion it also
+says that the parent Hamiltonian of a GHZ state is a ferromagnetic Ising
+Hamiltonian with a two-fold degenerate ground space
+\cite[line~2205]{Cirac2021Matrix}.  The two-dimensional GHZ PEPS tensor is
+recorded separately in the examples appendix
+\cite[lines~2417--2421]{Cirac2021Matrix}.
+
+For the one-dimensional cluster state, the review gives the MPS tensor
+\[
+  A^0=|0\rangle\langle +|,\qquad A^1=|1\rangle\langle -|,
+\]
+and explains its controlled-$Z$ preparation from $|+\rangle^{\otimes N}$
+\cite[lines~2364--2369]{Cirac2021Matrix}.  The two-dimensional cluster PEPS is
+also displayed in the examples appendix
+\cite[lines~2424--2429]{Cirac2021Matrix}.  In the local review source, however,
+the one-dimensional stabilizer Hamiltonian
+\[
+  -\sum_i X_{i-1}Z_iX_{i+1}
+\]
+is not stated in the one-dimensional cluster example passage.  The general
+parent-Hamiltonian theorem for normal MPS does imply a unique ground state for a
+suitable parent Hamiltonian once the normal-tensor hypotheses and the
+range-reduction theorem have been formalized
+\cite[lines~2087--2090]{Cirac2021Matrix}; it is not, by itself, the explicit
+cluster stabilizer formula.
+
+For the one-dimensional AKLT state, the review constructs the tensor from
+spin-$\tfrac12$ singlets and projection onto the joint spin-$1$ subspace, and
+then gives the matrices in two bases
+\cite[lines~2372--2393]{Cirac2021Matrix}.  In the parent-Hamiltonian section it
+states that the AKLT model has injectivity length $L_0=2$, while a two-site
+parent Hamiltonian is already sufficient for a unique ground state; the cited
+check is
+\[
+  \mathcal G_{1,2}\cap\mathcal G_{2,3}=\mathcal G_{1,2,3}
+\]
+\cite[line~2095]{Cirac2021Matrix}.  In the SPT discussion it also records the
+dangling spin-$\tfrac12$ edge modes: for open boundary conditions the parent
+Hamiltonian has at least the square of the virtual irrep dimension as ground
+state degeneracy, and for AKLT this gives a four-dimensional ground space with
+only one spin-$0$ state
+\cite[lines~1169--1174]{Cirac2021Matrix}.  The standard description of the
+AKLT Hamiltonian as a sum of spin-$2$ projectors is not displayed in these local
+review passages; it should be cited to the AKLT source or derived from the
+spin-addition calculation before it is made a source-faithful target here.
+
+\section{Current formal boundary}
+
+The formal example files already contain the tensors and their elementary
+structure.  The GHZ tensor is defined as
+$A^0=|0\rangle\langle 0|$ and $A^1=|1\rangle\langle 1|$, and the file proves
+that it is an RFP, is not injective, and has the expected $\mathbb Z_2$
+symmetry.\footnote{See \path{TNLean/MPS/Examples/GHZ.lean}:54--86 and the
+module summary at \path{TNLean/MPS/Examples/GHZ.lean}:21--29.}
+The cluster file defines the reflected one-dimensional convention
+$A^0=|+\rangle\langle 0|$ and $A^1=|-\rangle\langle 1|$, proves
+non-injectivity at one site, and proves two-block injectivity.\footnote{See
+\path{TNLean/MPS/Examples/Cluster.lean}:62--78 and
+\path{TNLean/MPS/Examples/Cluster.lean}:200--215.}
+The AKLT file defines the spin-$1$ tensor and proves two-block injectivity, hence
+normality.\footnote{See \path{TNLean/MPS/Examples/AKLT.lean}:49--58 and
+\path{TNLean/MPS/Examples/AKLT.lean}:222--237.}
+
+The general parent-Hamiltonian API is also present.  The local interaction is the
+orthogonal projector onto $\mathcal G_L(A)^\perp$, and the finite-chain parent
+Hamiltonian is the sum of translated local terms.\footnote{See
+\path{TNLean/MPS/ParentHamiltonian/Defs.lean}:66--75 and
+\path{TNLean/MPS/ParentHamiltonian/Defs.lean}:23--27.}
+The theorem that the parent Hamiltonian annihilates the MPS vector is already
+available.\footnote{See
+\path{TNLean/MPS/ParentHamiltonian/Basic.lean}:118--128.}
+The normal-MPS range-reduction theorem still depends on the wrapped-boundary
+comparison in
+\texttt{wrapped\_mirror\_witness\_agree\_of\_chainGroundSpace}, which is the
+remaining formal gap for the general unique-ground-state statement.\footnote{See
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:821--852 and
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:854--870.}
+
+\section{Source-faithful order of work}
+
+A source-faithful implementation of issue \#2315 should proceed in the following
+order.
+
+\begin{enumerate}
+  \item For GHZ, first state the Ising parent-Hamiltonian comparison using the
+        review terminology: the ferromagnetic Ising Hamiltonian and its
+        two-dimensional ground space.  This is directly supported by the local
+        review source.
+  \item For cluster, first connect the existing normality proof to the general
+        parent-Hamiltonian construction.  The explicit one-dimensional stabilizer
+        Hamiltonian should be added only after citing a source for that formula,
+        or after deriving it from the controlled-$Z$ construction and proving the
+        local-term equality in Lean.
+  \item For AKLT, first use the source's stated two-site criterion
+        $\mathcal G_{1,2}\cap\mathcal G_{2,3}=\mathcal G_{1,2,3}$ and the
+        already formalized two-block injectivity.  The spin-$2$ projector
+        formula should be introduced only with an AKLT citation or a derivation
+        from the spin-$\tfrac12\otimes\tfrac12$ construction.  The open-boundary
+        fourfold degeneracy should be treated separately from the periodic
+        unique-ground-state statement.
+\end{enumerate}
+
+Thus the issue should not be read as one monolithic formalization target.  The
+review-stated parent-Hamiltonian consequences, the explicit stabilizer or
+spin-projector formulas, and the open-boundary edge-mode ground spaces are
+distinct mathematical statements with distinct source obligations.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
+++ b/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
@@ -71,7 +71,7 @@ also displayed in the examples appendix
 \cite[lines~2424--2429]{Cirac2021Matrix}.  In the local review source, however,
 the one-dimensional stabilizer Hamiltonian
 \[
-  -\sum_i X_{i-1}Z_iX_{i+1}
+  -\sum_i Z_{i-1}X_iZ_{i+1}
 \]
 is not stated in the one-dimensional cluster example passage.  The older MPS
 review says instead that cluster states are unique ground states of the
@@ -80,9 +80,9 @@ three-body interactions
   \sum_i \sigma^z_i\sigma^x_{i+1}\sigma^z_{i+2},
 \]
 with an explicit two-matrix MPS representation
-\cite[local TeX lines~374--387]{PerezGarcia2007MPSReps}.  Thus the issue's
-$XZX$ formula should be treated as a convention or local-basis variant of this
-$ZXZ$ statement unless the equivalence is proved in the formalization.  The
+\cite[local TeX lines~374--387]{PerezGarcia2007MPSReps}.  Thus the issue should
+use the $ZXZ$ convention for the controlled-$Z$ cluster state unless a
+local-basis variant is explicitly introduced and proved equivalent.  The
 general parent-Hamiltonian theorem for normal MPS does imply a unique ground
 state for a suitable parent Hamiltonian once the normal-tensor hypotheses and
 the range-reduction theorem have been formalized
@@ -144,10 +144,10 @@ Hamiltonian is the sum of translated local terms.\footnote{See
 The theorem that the parent Hamiltonian annihilates the MPS vector is already
 available.\footnote{See
 \path{TNLean/MPS/ParentHamiltonian/Basic.lean}:118--128.}
-The normal-MPS range-reduction theorem still depends on the wrapped-boundary
-comparison in
-\texttt{wrapped\_mirror\_witness\_agree\_of\_chainGroundSpace}, which is the
-remaining formal gap for the general unique-ground-state statement.\footnote{See
+The normal-MPS range-reduction theorem still depends on the boundary-closing
+comparison, which is the remaining formal gap for the general unique-ground-state
+statement.\footnote{Formal declaration:
+\leanid{wrapped_mirror_witness_agree_of_chainGroundSpace}. See
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:821--852 and
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:854--870.}
 
@@ -163,7 +163,7 @@ order.
         taken from the local uncle-Hamiltonian source.
   \item For cluster, first connect the existing normality proof to the general
         parent-Hamiltonian construction, or prove the three-body $ZXZ$
-        interaction stated in the older MPS review.  The $XZX$ convention should
+        interaction stated in the older MPS review.  Any other convention should
         be stated only after recording the local-basis or index-shift equivalence.
   \item For AKLT, first use the source's stated two-site criterion
         $\mathcal G_{1,2}\cap\mathcal G_{2,3}=\mathcal G_{1,2,3}$ and the
@@ -174,10 +174,13 @@ order.
         separately from the periodic unique-ground-state statement.
 \end{enumerate}
 
-Thus the issue should not be read as one monolithic formalization target.  The
-review-stated parent-Hamiltonian consequences, the explicit stabilizer or
-spin-projector formulas, and the open-boundary edge-mode ground spaces are
-distinct mathematical statements with distinct source obligations.
+\section{Verdict}
+
+This is a scope restriction.  Issue \#2315 is source-faithful only when split
+into separate targets: the review-stated parent-Hamiltonian consequences, the
+explicit stabilizer or spin-projector formulas, and the open-boundary edge-mode
+ground spaces are distinct mathematical statements with distinct source
+obligations.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
+++ b/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
@@ -50,6 +50,16 @@ Hamiltonian with a two-fold degenerate ground space
 \cite[line~2205]{Cirac2021Matrix}.  The two-dimensional GHZ PEPS tensor is
 recorded separately in the examples appendix
 \cite[lines~2417--2421]{Cirac2021Matrix}.
+Another local source writes the two-site parent interaction explicitly as the
+projector complement of
+\[
+  \operatorname{span}\{|00\rangle,|11\rangle\},
+\]
+namely, up to an additive constant,
+\[
+  \tfrac12 I-\big(|00\rangle\langle 00|+|11\rangle\langle 11|\big).
+\]
+\footnote{See \path{Papers/1210.6613/UncleHMPS.tex}:432--455.}
 
 For the one-dimensional cluster state, the review gives the MPS tensor
 \[
@@ -63,10 +73,19 @@ the one-dimensional stabilizer Hamiltonian
 \[
   -\sum_i X_{i-1}Z_iX_{i+1}
 \]
-is not stated in the one-dimensional cluster example passage.  The general
-parent-Hamiltonian theorem for normal MPS does imply a unique ground state for a
-suitable parent Hamiltonian once the normal-tensor hypotheses and the
-range-reduction theorem have been formalized
+is not stated in the one-dimensional cluster example passage.  The older MPS
+review says instead that cluster states are unique ground states of the
+three-body interactions
+\[
+  \sum_i \sigma^z_i\sigma^x_{i+1}\sigma^z_{i+2},
+\]
+with an explicit two-matrix MPS representation
+\cite[local TeX lines~374--387]{PerezGarcia2007MPSReps}.  Thus the issue's
+$XZX$ formula should be treated as a convention or local-basis variant of this
+$ZXZ$ statement unless the equivalence is proved in the formalization.  The
+general parent-Hamiltonian theorem for normal MPS does imply a unique ground
+state for a suitable parent Hamiltonian once the normal-tensor hypotheses and
+the range-reduction theorem have been formalized
 \cite[lines~2087--2090]{Cirac2021Matrix}; it is not, by itself, the explicit
 cluster stabilizer formula.
 
@@ -89,6 +108,16 @@ only one spin-$0$ state
 AKLT Hamiltonian as a sum of spin-$2$ projectors is not displayed in these local
 review passages; it should be cited to the AKLT source or derived from the
 spin-addition calculation before it is made a source-faithful target here.
+What is displayed in the local sources is the polynomial spin Hamiltonian
+\[
+  H=\sum_i \vec S_i\cdot\vec S_{i+1}
+      +\frac13\big(\vec S_i\cdot\vec S_{i+1}\big)^2,
+\]
+together with the unnormalised matrices
+$\{\sigma^z,\sqrt2\sigma^+,-\sqrt2\sigma^-\}$
+\cite[local TeX lines~340--349]{PerezGarcia2007MPSReps}.  The same polynomial
+form, with an additive constant, appears in the local Schuch--P\'erez-Garc\'ia--Cirac
+source.\footnote{See \path{Papers/1010.3732/paper_v3.tex}:2126--2130.}
 
 \section{Current formal boundary}
 
@@ -130,20 +159,19 @@ order.
 \begin{enumerate}
   \item For GHZ, first state the Ising parent-Hamiltonian comparison using the
         review terminology: the ferromagnetic Ising Hamiltonian and its
-        two-dimensional ground space.  This is directly supported by the local
-        review source.
+        two-dimensional ground space.  The two-site projector description can be
+        taken from the local uncle-Hamiltonian source.
   \item For cluster, first connect the existing normality proof to the general
-        parent-Hamiltonian construction.  The explicit one-dimensional stabilizer
-        Hamiltonian should be added only after citing a source for that formula,
-        or after deriving it from the controlled-$Z$ construction and proving the
-        local-term equality in Lean.
+        parent-Hamiltonian construction, or prove the three-body $ZXZ$
+        interaction stated in the older MPS review.  The $XZX$ convention should
+        be stated only after recording the local-basis or index-shift equivalence.
   \item For AKLT, first use the source's stated two-site criterion
         $\mathcal G_{1,2}\cap\mathcal G_{2,3}=\mathcal G_{1,2,3}$ and the
-        already formalized two-block injectivity.  The spin-$2$ projector
-        formula should be introduced only with an AKLT citation or a derivation
-        from the spin-$\tfrac12\otimes\tfrac12$ construction.  The open-boundary
-        fourfold degeneracy should be treated separately from the periodic
-        unique-ground-state statement.
+        already formalized two-block injectivity.  The polynomial AKLT
+        Hamiltonian is locally sourced; the spin-$2$ projector wording should be
+        introduced only after citing or proving its equivalence with that
+        polynomial form.  The open-boundary fourfold degeneracy should be treated
+        separately from the periodic unique-ground-state statement.
 \end{enumerate}
 
 Thus the issue should not be read as one monolithic formalization target.  The


### PR DESCRIPTION
### Motivation

- Issue #2315 asks for GHZ, cluster, and AKLT example tensors to be connected to parent Hamiltonians and ground-space structure.
- The local RMP review directly states some facts, while the explicit Hamiltonian formulas needed for the examples come from other local sources or require an equivalence proof.
- Recording this distinction keeps the formalization source-faithful: review-stated facts, convention changes, and spin-representation equivalences are separate mathematical obligations.

### Description

- Add `docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex`.
- Record the RMP passages for the GHZ, cluster, and AKLT tensors and for the general parent-Hamiltonian theorem.
- Add local-source citations for the GHZ two-site projector, the older MPS-review cluster `ZXZ` interaction, and the polynomial AKLT spin Hamiltonian.
- Correct the cluster target to the controlled-`Z` stabilizer convention `ZXZ`, matching both the CZ preparation and the older MPS review.
- Mark the AKLT spin-2-projector wording as requiring either a direct citation or a proof of equivalence with the locally sourced polynomial Hamiltonian.
- Record the current formal boundary: the example tensors and normality proofs exist, while the general normal-MPS unique-ground-state theorem still depends on the boundary-closing comparison.
- Add the paper-gap policy verdict: this is a scope restriction.

### Testing

- `git diff --check`
- `rg -n -F '\\ket' docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex` (no matches)
- `rg -n "XZX|texttt|is the theorem|Theorem~\\texttt|\\texttt\{thm:" docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex` (no matches)
- `latexmk -pdf -interaction=nonstopmode -halt-on-error rmp_example_parent_hamiltonian_scope.tex` from `docs/paper-gaps`

---
Partially addresses #2315