### PR TITLE
feat(parent): reduce boundary comparison to window witnesses

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -828,13 +828,10 @@ property of arXiv:2011.12127, Section IV.C, lines 2078--2090, and is the
 remaining gap needed to close
 `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
 
-The proof reduces to the `L₀ + 1` chain condition, extracts the cyclic-window
-witnesses of the periodic-chain state, reconstructs the wrapped and mirror
-compatibilities from those witnesses, and identifies the abstract witnesses
-`Ywrap` and `Ymirror` with the concrete cyclic-window witnesses by uniqueness.
-The remaining step is the finite boundary telescope: after these identifications,
-one must compare the right products of the two concrete witnesses through the
-adjacent cyclic-window overlap identities. -/
+The proof already reduces to the `L₀ + 1` chain condition, extracts the
+cyclic-window witnesses, reconstructs the wrapped and mirror compatibilities,
+and identifies `Ywrap` and `Ymirror` with the concrete witnesses. The remaining
+step is the finite boundary telescope through adjacent cyclic-window overlaps. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -879,9 +876,7 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     left_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
       (fun a => (hMirror a τm).symm.trans (hMirrorAt a τm))
   rw [hYwrap_eq, hYmirror_eq]
-  -- The residual goal is the right-product identity between the concrete
-  -- cyclic-window witnesses. It should follow by telescoping
-  -- `adjacent_cyclicRestrictₗ_witness_overlap` from `mirrorPos` to `wrapPos`.
+  -- Remaining goal: telescope adjacent cyclic-window overlaps from `mirrorPos` to `wrapPos`.
   sorry
 
 /-- Range reduction for normal tensors.

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -848,11 +848,55 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     (η : Fin d) (μ : Fin (N - (L₀ + 1)) → Fin d) :
     Ywrap (wrappedMiddleBackground L₀ N η μ) =
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
+  obtain ⟨M, rfl⟩ : ∃ M, N = M + 1 := ⟨N - 1, by omega⟩
   refine wrapped_mirror_witness_agree_of_right_products (A := A) hInj hL₀
     Ywrap Ymirror η μ ?_
   intro j
-  -- It remains to prove the right-product identity by closing the boundary through
-  -- the intervening cyclic window constraints.
+  have hNpos : 0 < M + 1 := by omega
+  have hL₀N : L₀ + 1 ≤ M + 1 := by omega
+  have hψred : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1) :=
+    chainGroundSpace_le_chainGroundSpace_of_le (A := A) hNpos
+      (by omega : L₀ + 1 ≤ L) hLN hψ
+  obtain ⟨YAt, hYAt⟩ := chainGroundSpace_window_witnesses A hNpos hL₀N hψred
+  let wrapPos : Fin (M + 1) := ⟨M, by omega⟩
+  let mirrorPos : Fin (M + 1) := ⟨M + 1 - L₀, by omega⟩
+  have hWrapAt := wrapping_window_compatibility_of_isNBlkInjective
+    (A := A) hInj hL₀ (by omega : L₀ ≤ M) (YAt wrapPos)
+      (fun τ σ_w => by
+        have h := congr_fun (hYAt wrapPos τ) σ_w
+        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX] using h)
+  have hMirrorAt := wrapping_window_mirror_compatibility_of_isNBlkInjective
+    (A := A) hInj hL₀ (by omega : L₀ ≤ M) (YAt mirrorPos)
+      (fun τ σ_w => by
+        have h := congr_fun (hYAt mirrorPos τ) σ_w
+        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX] using h)
+  have hYwrap_eq :
+      Ywrap (wrappedMiddleBackground L₀ (M + 1) η μ) =
+        YAt wrapPos (wrappedMiddleBackground L₀ (M + 1) η μ) := by
+    apply right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
+    intro a
+    calc
+      Ywrap (wrappedMiddleBackground L₀ (M + 1) η μ) * A a
+          = evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+              wrappedMiddleBackground L₀ (M + 1) η μ ⟨k.val + L₀, by omega⟩)) *
+              A a * X := (hWrap a (wrappedMiddleBackground L₀ (M + 1) η μ)).symm
+      _ = YAt wrapPos (wrappedMiddleBackground L₀ (M + 1) η μ) * A a :=
+          hWrapAt a (wrappedMiddleBackground L₀ (M + 1) η μ)
+  have hYmirror_eq :
+      Ymirror (mirrorMiddleBackground L₀ (M + 1) η μ) =
+        YAt mirrorPos (mirrorMiddleBackground L₀ (M + 1) η μ) := by
+    apply left_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
+    intro a
+    calc
+      A a * Ymirror (mirrorMiddleBackground L₀ (M + 1) η μ)
+          = X * A a * evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+              mirrorMiddleBackground L₀ (M + 1) η μ ⟨k.val + 1, by omega⟩)) :=
+          (hMirror a (mirrorMiddleBackground L₀ (M + 1) η μ)).symm
+      _ = A a * YAt mirrorPos (mirrorMiddleBackground L₀ (M + 1) η μ) :=
+          hMirrorAt a (mirrorMiddleBackground L₀ (M + 1) η μ)
+  rw [hYwrap_eq, hYmirror_eq]
+  -- It remains to telescope the adjacent cyclic-window overlap identities from
+  -- the mirror boundary-crossing window to the wrapped boundary-crossing window.
   sorry
 
 /-- Range reduction for normal tensors.

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -819,19 +819,18 @@ theorem wrapped_mirror_witness_agree_of_right_products
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
-/-- The two boundary matrices extracted from the cyclic windows used in closing
-the boundary agree when their complements are reindexed to a common middle word
-`μ`.
+/-- The boundary matrices extracted from the cyclic closing windows agree after
+their complements are reindexed to a common middle word `μ`.
 
-This theorem states the formal comparison still needed to realize the closure
-property of arXiv:2011.12127, Section IV.C, lines 2078--2090, and is the
-remaining gap needed to close
+This theorem states the formal comparison still needed for arXiv:2011.12127,
+Section IV.C, lines 2078--2090, and closes the remaining gap for
 `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
 
 The proof already reduces to the `L₀ + 1` chain condition, extracts the
-cyclic-window witnesses, and identifies `Ywrap` and `Ymirror` with concrete
-witnesses. The remaining goal is `YAt wrapPos τp * A j = YAt mirrorPos τm * A j`
-for every letter `j`, obtained by transporting witnesses from `mirrorPos` to `wrapPos`. -/
+cyclic-window witnesses, and identifies the abstract witnesses with
+\(Y_M\) and \(Y_{M+1-L_0}\). The remaining goal is
+\(Y_M(\tau^+_\eta(\mu))A^j = Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\)
+for every physical letter \(j\). -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -876,7 +875,8 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     left_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
       (fun a => (hMirror a τm).symm.trans (hMirrorAt a τm))
   rw [hYwrap_eq, hYmirror_eq]
-  -- Remaining goal: telescope adjacent cyclic-window overlaps from `mirrorPos` to `wrapPos`.
+  -- Remaining goal: \(Y_M(\tau^+_\eta(\mu))A^j =
+  --   Y_{M+1-L₀}(\tau^-_\eta(\mu))A^j\), transporting from \(M+1-L₀\) to \(M\).
   sorry
 
 /-- Range reduction for normal tensors.

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -820,13 +820,13 @@ theorem wrapped_mirror_witness_agree_of_right_products
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
 /-- The boundary matrices extracted from the cyclic closing windows agree after
-their complements are reindexed to a common middle word `μ`.
+their complements are reindexed to a common middle word $\mu$.
 
 This theorem states the formal comparison still needed for arXiv:2011.12127,
-Section IV.C, lines 2078--2090, and closes the remaining gap for
-`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
+Section IV.C, lines 2078--2090, and for normal-range reduction of the chain
+ground space into the MPS span.
 
-The proof already reduces to the `L₀ + 1` chain condition, extracts the
+The proof already reduces to the $L_0 + 1$ chain condition, extracts the
 cyclic-window witnesses, and identifies the abstract witnesses with
 \(Y_M\) and \(Y_{M+1-L_0}\). The remaining goal is
 \(Y_M(\tau^+_\eta(\mu))A^j = Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -828,10 +828,13 @@ property of arXiv:2011.12127, Section IV.C, lines 2078--2090, and is the
 remaining gap needed to close
 `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
 
-The expected proof is the boundary-closing analogue of the preceding
-intersection argument: the two boundary matrices come from the same
-periodic-chain state, and the missing step is to compare them through the
-remaining cyclic window constraints. -/
+The proof reduces to the `L₀ + 1` chain condition, extracts the cyclic-window
+witnesses of the periodic-chain state, reconstructs the wrapped and mirror
+compatibilities from those witnesses, and identifies the abstract witnesses
+`Ywrap` and `Ymirror` with the concrete cyclic-window witnesses by uniqueness.
+The remaining step is the finite boundary telescope: after these identifications,
+one must compare the right products of the two concrete witnesses through the
+adjacent cyclic-window overlap identities. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -875,7 +878,11 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
   have hYmirror_eq : Ymirror τm = YAt mirrorPos τm :=
     left_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
       (fun a => (hMirror a τm).symm.trans (hMirrorAt a τm))
-  rw [hYwrap_eq, hYmirror_eq]; sorry
+  rw [hYwrap_eq, hYmirror_eq]
+  -- The residual goal is the right-product identity between the concrete
+  -- cyclic-window witnesses. It should follow by telescoping
+  -- `adjacent_cyclicRestrictₗ_witness_overlap` from `mirrorPos` to `wrapPos`.
+  sorry
 
 /-- Range reduction for normal tensors.
 

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -829,9 +829,9 @@ remaining gap needed to close
 `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
 
 The proof already reduces to the `L₀ + 1` chain condition, extracts the
-cyclic-window witnesses, reconstructs the wrapped and mirror compatibilities,
-and identifies `Ywrap` and `Ymirror` with the concrete witnesses. The remaining
-step is the finite boundary telescope through adjacent cyclic-window overlaps. -/
+cyclic-window witnesses, and identifies `Ywrap` and `Ymirror` with concrete
+witnesses. The remaining goal is `YAt wrapPos τp * A j = YAt mirrorPos τm * A j`
+for every letter `j`, obtained by transporting witnesses from `mirrorPos` to `wrapPos`. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -869,17 +869,13 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
       (fun τ σ_w => by
         simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
           using congr_fun (hYAt mirrorPos τ) σ_w)
-  have hYwrap_eq : Ywrap τp = YAt wrapPos τp := by
-    apply right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
-    intro a
-    exact (hWrap a τp).symm.trans (hWrapAt a τp)
-  have hYmirror_eq : Ymirror τm = YAt mirrorPos τm := by
-    apply left_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
-    intro a
-    exact (hMirror a τm).symm.trans (hMirrorAt a τm)
-  rw [hYwrap_eq, hYmirror_eq]
-  -- It remains to telescope the adjacent cyclic-window overlap identities.
-  sorry
+  have hYwrap_eq : Ywrap τp = YAt wrapPos τp :=
+    right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
+      (fun a => (hWrap a τp).symm.trans (hWrapAt a τp))
+  have hYmirror_eq : Ymirror τm = YAt mirrorPos τm :=
+    left_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
+      (fun a => (hMirror a τm).symm.trans (hMirrorAt a τm))
+  rw [hYwrap_eq, hYmirror_eq]; sorry
 
 /-- Range reduction for normal tensors.
 

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -852,51 +852,33 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
   refine wrapped_mirror_witness_agree_of_right_products (A := A) hInj hL₀
     Ywrap Ymirror η μ ?_
   intro j
-  have hNpos : 0 < M + 1 := by omega
-  have hL₀N : L₀ + 1 ≤ M + 1 := by omega
   have hψred : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1) :=
-    chainGroundSpace_le_chainGroundSpace_of_le (A := A) hNpos
-      (by omega : L₀ + 1 ≤ L) hLN hψ
-  obtain ⟨YAt, hYAt⟩ := chainGroundSpace_window_witnesses A hNpos hL₀N hψred
+    chainGroundSpace_le_chainGroundSpace_of_le (A := A) (by omega) (by omega) hLN hψ
+  obtain ⟨YAt, hYAt⟩ := chainGroundSpace_window_witnesses A (by omega) (by omega) hψred
   let wrapPos : Fin (M + 1) := ⟨M, by omega⟩
   let mirrorPos : Fin (M + 1) := ⟨M + 1 - L₀, by omega⟩
+  let τp := wrappedMiddleBackground L₀ (M + 1) η μ
+  let τm := mirrorMiddleBackground L₀ (M + 1) η μ
   have hWrapAt := wrapping_window_compatibility_of_isNBlkInjective
     (A := A) hInj hL₀ (by omega : L₀ ≤ M) (YAt wrapPos)
       (fun τ σ_w => by
-        have h := congr_fun (hYAt wrapPos τ) σ_w
-        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX] using h)
+        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
+          using congr_fun (hYAt wrapPos τ) σ_w)
   have hMirrorAt := wrapping_window_mirror_compatibility_of_isNBlkInjective
     (A := A) hInj hL₀ (by omega : L₀ ≤ M) (YAt mirrorPos)
       (fun τ σ_w => by
-        have h := congr_fun (hYAt mirrorPos τ) σ_w
-        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX] using h)
-  have hYwrap_eq :
-      Ywrap (wrappedMiddleBackground L₀ (M + 1) η μ) =
-        YAt wrapPos (wrappedMiddleBackground L₀ (M + 1) η μ) := by
+        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
+          using congr_fun (hYAt mirrorPos τ) σ_w)
+  have hYwrap_eq : Ywrap τp = YAt wrapPos τp := by
     apply right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
     intro a
-    calc
-      Ywrap (wrappedMiddleBackground L₀ (M + 1) η μ) * A a
-          = evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
-              wrappedMiddleBackground L₀ (M + 1) η μ ⟨k.val + L₀, by omega⟩)) *
-              A a * X := (hWrap a (wrappedMiddleBackground L₀ (M + 1) η μ)).symm
-      _ = YAt wrapPos (wrappedMiddleBackground L₀ (M + 1) η μ) * A a :=
-          hWrapAt a (wrappedMiddleBackground L₀ (M + 1) η μ)
-  have hYmirror_eq :
-      Ymirror (mirrorMiddleBackground L₀ (M + 1) η μ) =
-        YAt mirrorPos (mirrorMiddleBackground L₀ (M + 1) η μ) := by
+    exact (hWrap a τp).symm.trans (hWrapAt a τp)
+  have hYmirror_eq : Ymirror τm = YAt mirrorPos τm := by
     apply left_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
     intro a
-    calc
-      A a * Ymirror (mirrorMiddleBackground L₀ (M + 1) η μ)
-          = X * A a * evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
-              mirrorMiddleBackground L₀ (M + 1) η μ ⟨k.val + 1, by omega⟩)) :=
-          (hMirror a (mirrorMiddleBackground L₀ (M + 1) η μ)).symm
-      _ = A a * YAt mirrorPos (mirrorMiddleBackground L₀ (M + 1) η μ) :=
-          hMirrorAt a (mirrorMiddleBackground L₀ (M + 1) η μ)
+    exact (hMirror a τm).symm.trans (hMirrorAt a τm)
   rw [hYwrap_eq, hYmirror_eq]
-  -- It remains to telescope the adjacent cyclic-window overlap identities from
-  -- the mirror boundary-crossing window to the wrapped boundary-crossing window.
+  -- It remains to telescope the adjacent cyclic-window overlap identities.
   sorry
 
 /-- Range reduction for normal tensors.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1474,7 +1474,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y^{-}_{\tau^{-}_{\eta}(\mu)} A^j
     \]
-    for every $j$.  Let $Y_i(\tau)$ denote the cyclic-window witness supplied by
+    for every $j$.  Write $N=M+1$, so the wrapped boundary window starts at
+    $M$ and the mirror boundary window starts at $M+1-L_0$.  Let $Y_i(\tau)$
+    denote the cyclic-window witness supplied by
     Lemma~\ref{lem:chain_ground_space_window_witnesses} at the window beginning at
     $i$.  The first step identifies the two abstract boundary-condition families
     with the two boundary-crossing witnesses:

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1515,13 +1515,11 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
             \tau'(k), & k\not\equiv i+L_0+1 \pmod N,
         \end{cases}
     \]
-    agree, that is,
+    agree, that is, as functions on the $N$-site chain:
     \[
         \widehat{\tau}^{a}_{i,0}
         =
-        \widehat{\tau'}^{b}_{i+1,L_0}
-        \qquad
-        \text{as functions on the }N\text{-site chain}.
+        \widehat{\tau'}^{b}_{i+1,L_0}.
     \]
     The available adjacent identities therefore have the form
     \[

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1474,9 +1474,11 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y^{-}_{\tau^{-}_{\eta}(\mu)} A^j
     \]
-    for every $j$.  The missing argument is the closing-boundary step: obtain
-    these identities from the remaining cyclic window constraints for the same
-    periodic-chain vector.
+    for every $j$.  First identify the two abstract boundary-condition families
+    with the witnesses extracted from the corresponding boundary-crossing cyclic
+    windows.  The missing argument is the closing-boundary step for these
+    witnesses: telescope the adjacent cyclic-window overlap identities from the
+    mirror boundary to the wrapped boundary.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1515,25 +1515,30 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
             \tau'(k), & k\not\equiv i+L_0+1 \pmod N,
         \end{cases}
     \]
-    agree as assignments on the periodic chain.  Thus the remaining unproved
-    step is to construct backgrounds
+    agree, that is,
     \[
-        \tau_0=\tau^{-}_{\eta}(\mu),\quad
-        \tau_{L_0-1}=\tau^{+}_{\eta}(\mu),\quad
-        i_r=M+1-L_0+r\qquad(0\le r\le L_0-1),
+        \widehat{\tau}^{a}_{i,0}
+        =
+        \widehat{\tau'}^{b}_{i+1,L_0}
+        \qquad
+        \text{as functions on the }N\text{-site chain}.
     \]
-    for which these completed-assignment equalities hold at every adjacent pair
-    $(i_r,i_{r+1})$.  The available adjacent identities have the form
+    The available adjacent identities therefore have the form
     \[
         Y_{i_r}(\tau_r)A^{a_r}
         =
         A^{b_r}Y_{i_{r+1}}(\tau_{r+1})
-        \qquad(0\le r<L_0-1).
+        \qquad(0\le r<q),
     \]
-    Thus the missing closing step is the bookkeeping of the intermediate
-    letters $a_r,b_r$ and the accompanying left boundary factors $A^{b_r}$:
-    the chain must transport the attached boundary letters from the mirror
-    window to the wrapped window and yield, for the fixed final letter $j$,
+    only at pairs whose completed assignments are equal.  They do not by
+    themselves give a telescope from
+    $\tau^{-}_{\eta}(\mu)$ to $\tau^{+}_{\eta}(\mu)$ with the same letter $j$
+    attached on the right throughout; the two endpoint backgrounds need not
+    agree away from a single adjacent overlap.  What remains is a separate
+    cyclic boundary-transport argument.  It must use the local identities for
+    genuinely equal completions, together with the fact that all witnesses come
+    from the same periodic-chain state, to obtain, for each fixed final letter
+    $j$,
     \[
         Y_M(\tau^{+}_{\eta}(\mu))A^j
         =

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1474,11 +1474,34 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y^{-}_{\tau^{-}_{\eta}(\mu)} A^j
     \]
-    for every $j$.  First identify the two abstract boundary-condition families
-    with the witnesses extracted from the corresponding boundary-crossing cyclic
-    windows.  The missing argument is the closing-boundary step for these
-    witnesses: telescope the adjacent cyclic-window overlap identities from the
-    mirror boundary to the wrapped boundary.
+    for every $j$.  Let $Y_i(\tau)$ denote the cyclic-window witness supplied by
+    Lemma~\ref{lem:chain_ground_space_window_witnesses} at the window beginning at
+    $i$.  The first step identifies the two abstract boundary-condition families
+    with the two boundary-crossing witnesses:
+    \[
+        Y^{+}_{\tau^{+}_{\eta}(\mu)}
+        =
+        Y_M(\tau^{+}_{\eta}(\mu)),
+        \qquad
+        Y^{-}_{\tau^{-}_{\eta}(\mu)}
+        =
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu)).
+    \]
+    The remaining boundary-closing statement is therefore
+    \[
+        Y_M(\tau^{+}_{\eta}(\mu))
+        =
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu)).
+    \]
+    For consecutive cyclic windows, Lemma~\ref{lem:cyclic_window_boundary_matrix_transport}
+    gives the adjacent overlap identity
+    \[
+        Y_i(\tau)A^a=A^bY_{i+1}(\tau')
+    \]
+    whenever the two one-site restrictions have the same completed outside
+    assignment.  The unproved closing step is to choose the intermediate outside
+    assignments across the boundary and chain these adjacent identities from the
+    mirror window to the wrapped window.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1487,11 +1487,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu)).
     \]
-    The remaining boundary-closing statement is therefore
+    The remaining boundary-closing statement is therefore, for every physical
+    letter $j$,
     \[
-        Y_M(\tau^{+}_{\eta}(\mu))
+        Y_M(\tau^{+}_{\eta}(\mu))A^j
         =
-        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu)).
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
     \]
     For consecutive cyclic windows, Lemma~\ref{lem:cyclic_window_boundary_matrix_transport}
     gives the adjacent overlap identity
@@ -1500,8 +1501,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
     whenever the two one-site restrictions have the same completed outside
     assignment.  The unproved closing step is to choose the intermediate outside
-    assignments across the boundary and chain these adjacent identities from the
-    mirror window to the wrapped window.
+    assignments across the boundary and chain these adjacent identities, with the
+    final right boundary letter kept fixed, from the mirror window to the wrapped
+    window.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1499,11 +1499,39 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \[
         Y_i(\tau)A^a=A^bY_{i+1}(\tau')
     \]
-    whenever the two one-site restrictions have the same completed outside
-    assignment.  The unproved closing step is to choose the intermediate outside
-    assignments across the boundary and chain these adjacent identities, with the
-    final right boundary letter kept fixed, from the mirror window to the wrapped
-    window.
+    whenever the two completed assignments
+    \[
+        \widehat{\tau}^{a}_{i,0}(k)
+        =
+        \begin{cases}
+            a,       & k=i,\\
+            \tau(k), & k\neq i,
+        \end{cases}
+        \qquad
+        \widehat{\tau'}^{b}_{i+1,L_0}(k)
+        =
+        \begin{cases}
+            b,        & k\equiv i+L_0+1 \pmod N,\\
+            \tau'(k), & k\not\equiv i+L_0+1 \pmod N,
+        \end{cases}
+    \]
+    agree as assignments on the periodic chain.  Thus the remaining unproved
+    step is to construct backgrounds
+    \[
+        \tau_0=\tau^{-}_{\eta}(\mu),\quad
+        \tau_{L_0-1}=\tau^{+}_{\eta}(\mu),\quad
+        i_r=M+1-L_0+r\qquad(0\le r\le L_0-1),
+    \]
+    for which these completed-assignment equalities hold at every adjacent pair
+    $(i_r,i_{r+1})$ and imply, with the final right letter $j$ fixed,
+    \[
+        Y_{i_{r+1}}(\tau_{r+1})A^j
+        =
+        Y_{i_r}(\tau_r)A^j
+        \qquad(0\le r<L_0-1).
+    \]
+    Chaining these $L_0-1$ identities gives the displayed boundary-closing
+    right-product identity.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1523,15 +1523,22 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         i_r=M+1-L_0+r\qquad(0\le r\le L_0-1),
     \]
     for which these completed-assignment equalities hold at every adjacent pair
-    $(i_r,i_{r+1})$ and imply, with the final right letter $j$ fixed,
+    $(i_r,i_{r+1})$.  The available adjacent identities have the form
     \[
-        Y_{i_{r+1}}(\tau_{r+1})A^j
+        Y_{i_r}(\tau_r)A^{a_r}
         =
-        Y_{i_r}(\tau_r)A^j
+        A^{b_r}Y_{i_{r+1}}(\tau_{r+1})
         \qquad(0\le r<L_0-1).
     \]
-    Chaining these $L_0-1$ identities gives the displayed boundary-closing
-    right-product identity.
+    Thus the missing closing step is the bookkeeping of the intermediate
+    letters $a_r,b_r$ and the accompanying left boundary factors $A^{b_r}$:
+    the chain must transport the attached boundary letters from the mirror
+    window to the wrapped window and yield, for the fixed final letter $j$,
+    \[
+        Y_M(\tau^{+}_{\eta}(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
+    \]
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%


### PR DESCRIPTION
### Motivation

- Issue #1475 asks for the boundary-closing comparison in `wrapped_mirror_witness_agree_of_chainGroundSpace`.
- The current sorry was phrased as a right-product identity for arbitrary boundary-condition families `Ywrap` and `Ymirror`.
- The first source-faithful step is to show that these arbitrary families agree with the witnesses actually extracted from the two boundary-crossing cyclic windows of the same chain ground state.

### Description

- In `wrapped_mirror_witness_agree_of_chainGroundSpace`, reduce the chain ground-space hypothesis to range `L₀ + 1` and extract cyclic-window witnesses with `chainGroundSpace_window_witnesses`.
- Reconstruct the wrapped and mirror one-sided compatibilities for those extracted witnesses.
- Use `right_witness_unique_of_isNBlkInjective` and `left_witness_unique_of_isNBlkInjective` to identify `Ywrap` and `Ymirror` with the extracted witnesses at the two boundary-crossing backgrounds.
- Leave the original single sorry in place, now narrowed to the canonical telescope: prove the right-product identity for the extracted witnesses by telescoping adjacent cyclic-window overlap identities from the mirror boundary to the wrapped boundary.
- Update the Chapter 14 proof sketch to state this sharper remaining boundary-closing step.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryOverlap`
- `lake build TNLean.MPS.ParentHamiltonian.WrappingWindow`
- `lake env lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean` (passes with the pre-existing `wrapped_mirror_witness_agree_of_chainGroundSpace` sorry warning)
- `git diff --check`
- `rg -n "formal proof|is the theorem|Theorem~\\texttt|\\texttt\{thm:|\\texttt" blueprint/src/chapter/ch14_parent_hamiltonian.tex TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean` (no matches)
- Attempted `leanblueprint checkdecls`; this fresh worktree lacks the generated `blueprint/lean_decls` declaration list, so the command did not start the declaration check.

---
Refs #1475

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a critical unproven step in normal parent-Hamiltonian ground-space reduction; logic is partial (still `sorry`) but documentation and proof structure are clearer.
> 
> **Overview**
> This PR advances the **boundary-closing comparison** in `wrapped_mirror_witness_agree_of_chainGroundSpace` (the closure-property gap for normal-range reduction, arXiv:2011.12127 §IV.C) without closing it.
> 
> In **`UniqueGroundState.lean`**, the proof now sets `N = M + 1`, reduces `ψ` to `chainGroundSpace` at range `L₀ + 1`, pulls cyclic-window witnesses via `chainGroundSpace_window_witnesses`, and uses injectivity uniqueness to equate the abstract `Ywrap` / `Ymirror` families with the witnesses at the wrapped site `M` and mirror site `M+1-L₀`. The **single `sorry` remains**, reframed as proving `Y_M(τ⁺_η(μ)) A^j = Y_{M+1-L₀}(τ⁻_η(μ)) A^j` for all letters `j`—cyclic transport between the two boundary windows, not a bare comparison of arbitrary families.
> 
> **Chapter 14** (`ch14_parent_hamiltonian.tex`) is updated to match: identify `Y⁺`/`Y⁻` with `Y_M` and `Y_{M+1-L₀}`, cite adjacent overlap identities from cyclic-window transport, and state explicitly that those local identities do **not** telescope endpoint backgrounds with a fixed `j` on the right; a separate cyclic boundary-transport argument is still required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a55f00e71125eae9b29263bc845b0392721cd592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->