### PR TITLE
doc(canonical): normalize MPDO period-removal citation

### DIFF
--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -1020,10 +1020,10 @@ block.
 \subsection{Period removal by cyclic sectors}%
 \label{sec:cyclic_sectors}
 
-In the proof of~\cite{Cirac2017MPDO_AnnPhys} the required step is
-periodicity removal by blocking: after blocking each irreducible TP block by the
-least common multiple of its peripheral periods, the result has no nontrivial
-$p$-periodic vectors~\cite[Section~2.3]{Cirac2016MPDO_arXiv}. The cyclic-sector
+The step needed below is the period-removing blocking described
+in~\cite[Section~2.3]{Cirac2016MPDO_arXiv}: after blocking each irreducible TP
+block by the least common multiple of its peripheral periods, the result has no
+nontrivial $p$-periodic vectors. The cyclic-sector
 decomposition comes from the peripheral spectrum of the adjoint transfer
 map~\cite[Theorem~6.6]{Wolf2012Quantum}.
 


### PR DESCRIPTION
## Summary
- replace the remaining bare `Cirac2017MPDO_AnnPhys` citation in the canonical chapter period-removal prose with the locally verifiable arXiv citation
- cite `Cirac2016MPDO_arXiv`, Section 2.3, for the period-removing blocking step

Closes #2327.

## Checks
- `git diff --check`
- `rg -n -F 'Cirac2017MPDO_AnnPhys' blueprint/src docs/blueprint_style_guide.md`
- `cd blueprint && leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only citation normalization in LaTeX; no code or proof logic changes.
> 
> **Overview**
> In **`ch08_canonical.tex`**, the opening prose of **§Period removal by cyclic sectors** is retargeted so the period-removing blocking step cites **`Cirac2016MPDO_arXiv`, Section 2.3** instead of the published **`Cirac2017MPDO_AnnPhys`** reference, matching the rest of the canonical chapter’s MPDO sourcing.
> 
> The edit is **wording and citation only**: it reframes the paragraph around “the step needed below” and the arXiv section anchor; **theorem labels, Lean hooks, and mathematical claims are unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ef1408c8b7c5b9a7f64138df0eaca96ec275964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->