### PR TITLE
ci: track texra-ai/lean-env-action@v1 (drop SHA pin)

### DIFF
--- a/.github/workflows/_ci-auto-fix-shared.yml
+++ b/.github/workflows/_ci-auto-fix-shared.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Set up Lean toolchain and cache
         if: inputs.setup_lean && steps.loop_guard.outputs.skip != 'true'
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Get CI failure details
         if: steps.loop_guard.outputs.skip != 'true'

--- a/.github/workflows/_codex-auto-fix-shared.yml
+++ b/.github/workflows/_codex-auto-fix-shared.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Set up Lean toolchain and cache
         if: inputs.setup_lean && steps.loop_guard.outputs.skip != 'true'
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Get CI failure details
         if: steps.loop_guard.outputs.skip != 'true'

--- a/.github/workflows/auto-fix-codex.yml
+++ b/.github/workflows/auto-fix-codex.yml
@@ -286,7 +286,7 @@ jobs:
         if: |
           steps.guard.outputs.skip != 'true' &&
           steps.review_payload.outputs.skip != 'true'
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Prepare review prompt
         if: |

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -309,7 +309,7 @@ jobs:
         if: |
           steps.guard.outputs.skip != 'true' &&
           steps.review_payload.outputs.skip != 'true'
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Fix review comments with Claude
         if: |

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -33,10 +33,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install system dependencies
-        uses: texra-ai/lean-env-action/blueprint-system-deps@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/blueprint-system-deps@v1
 
       - name: Install leanblueprint
-        uses: texra-ai/lean-env-action/leanblueprint@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/leanblueprint@v1
 
       - name: Check tensor-network diagram macros
         run: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Set up Lean toolchain and cache
         if: steps.claude-switch.outputs.skip != 'true' && steps.bot-check.outputs.skip != 'true' && steps.provider-token.outputs.skip != 'true'
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
         with:
           use-github-cache: false
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,13 +58,13 @@ jobs:
           token: ${{ env.GH_TOKEN }}
 
       - name: Set up Lean toolchain and cache
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Install blueprint TeX stack
-        uses: texra-ai/lean-env-action/blueprint-system-deps@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/blueprint-system-deps@v1
 
       - name: Install leanblueprint
-        uses: texra-ai/lean-env-action/leanblueprint@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/leanblueprint@v1
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -72,13 +72,13 @@ jobs:
           git config --global user.name "chatgpt-codex-connector[bot]"
 
       - name: Set up Lean toolchain and cache
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Install blueprint TeX stack
-        uses: texra-ai/lean-env-action/blueprint-system-deps@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/blueprint-system-deps@v1
 
       - name: Install leanblueprint
-        uses: texra-ai/lean-env-action/leanblueprint@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/leanblueprint@v1
 
       - name: Compose codex mention prompt
         id: codex-prompt

--- a/.github/workflows/deepseek.yml
+++ b/.github/workflows/deepseek.yml
@@ -60,13 +60,13 @@ jobs:
           token: ${{ env.GH_TOKEN }}
 
       - name: Set up Lean toolchain and cache
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Install blueprint TeX stack
-        uses: texra-ai/lean-env-action/blueprint-system-deps@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/blueprint-system-deps@v1
 
       - name: Install leanblueprint
-        uses: texra-ai/lean-env-action/leanblueprint@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/leanblueprint@v1
 
       - name: Run DeepSeek Code
         id: deepseek

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -47,13 +47,13 @@ jobs:
           build: true
 
       - name: Install TeX and graphviz
-        uses: texra-ai/lean-env-action/blueprint-system-deps@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/blueprint-system-deps@v1
         with:
           cache-suffix: docgen-v1
           extra-packages: latexmk texlive-science texlive-xetex
 
       - name: Install leanblueprint
-        uses: texra-ai/lean-env-action/leanblueprint@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/leanblueprint@v1
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py

--- a/.github/workflows/lean-audit.yml
+++ b/.github/workflows/lean-audit.yml
@@ -35,15 +35,15 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Lean toolchain and cache
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Set up blueprint system dependencies
         if: ${{ github.event.inputs.audit_type == 'blueprint-check' }}
-        uses: texra-ai/lean-env-action/blueprint-system-deps@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/blueprint-system-deps@v1
 
       - name: Install leanblueprint
         if: ${{ github.event.inputs.audit_type == 'blueprint-check' }}
-        uses: texra-ai/lean-env-action/leanblueprint@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/leanblueprint@v1
 
       - name: Run Lean Audit
         uses: ./.github/actions/claude-code-with-provider

--- a/.github/workflows/lean-linter-warning-autofix.yml
+++ b/.github/workflows/lean-linter-warning-autofix.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Set up Lean toolchain and cache
         if: steps.write_mode.outputs.skip != 'true'
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Set up Python for warning summary
         if: always() && steps.write_mode.outputs.skip != 'true'

--- a/.github/workflows/lean-linter-warning-sweep.yml
+++ b/.github/workflows/lean-linter-warning-sweep.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Lean toolchain and cache
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Run Lean build and capture warnings
         run: |

--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -43,10 +43,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install blueprint system dependencies
-        uses: texra-ai/lean-env-action/blueprint-system-deps@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/blueprint-system-deps@v1
 
       - name: Install blueprint Python dependencies
-        uses: texra-ai/lean-env-action/leanblueprint@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action/leanblueprint@v1
 
       - name: Check tensor-network diagram macros
         run: |
@@ -110,7 +110,7 @@ jobs:
         id: lean-setup
         continue-on-error: true
         timeout-minutes: 6
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Generate lean_decls from blueprint .tex files
         if: steps.lean-setup.outcome == 'success'

--- a/.github/workflows/mathlib-scout.yml
+++ b/.github/workflows/mathlib-scout.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Set up Lean toolchain and cache
         if: steps.decide.outputs.should_scout == 'true'
-        uses: texra-ai/lean-env-action@6a03d2aa517a2ee67f71be460210310b3d48d70e
+        uses: texra-ai/lean-env-action@v1
 
       - name: Scout Mathlib
         if: steps.decide.outputs.should_scout == 'true'


### PR DESCRIPTION
Follow-up to #2329. Flip the `texra-ai/lean-env-action` references from the `1.0.0` commit SHA (`6a03d2a`) to the moving `@v1` tag, so the repo automatically picks up `v1.x` patches of the published action. `@v1` currently resolves to the same `1.0.0` commit, so behaviour is unchanged today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dropping immutable SHA pins in favor of a moving `@v1` tag lets future `v1.x` action releases change CI behavior without a repo PR; no app code changes.
> 
> **Overview**
> Replaces every pinned `texra-ai/lean-env-action` reference (commit `6a03d2a…`) with the **`@v1`** tag across CI workflows—main action, **`blueprint-system-deps`**, and **`leanblueprint`** composite paths unchanged, only the version pin.
> 
> Affected areas include **auto-fix** (Claude/Codex shared and review jobs), **mention bots** (`claude`, `codex`, `deepseek`), **Claude code review**, **blueprint** build/lint/docgen, **lean-audit**, **mathlib-scout**, and **linter-warning** sweep/autofix. **No step inputs or job logic** are modified.
> 
> **Today** `@v1` still points at the same **1.0.0** commit as the old SHA, so runner behavior should be identical until a new **`v1.x`** release moves the tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b076dec6aa3b54076e837ab592733b7063349518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->