### PR TITLE
refactor(parent): isolate closure-property transport

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -61,59 +61,18 @@ with the periodic boundary condition:
 
 ## External inputs
 
-### Closure property in arXiv:2011.12127, Section IV.C
+The declaration `closure_property_right_product_transport_of_chainGroundSpace`
+is the remaining boundary-closing statement from arXiv:2011.12127, Section IV.C,
+lines 2078--2090.  It compares the two cyclic-window witnesses obtained from
+one periodic-chain ground state after the two complements are indexed by the same
+middle word.  This is the remaining hard input for
+`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
 
-The theorem `wrapped_mirror_witness_agree_of_chainGroundSpace` isolates the
-remaining boundary-matrix comparison used to formalize the **closure property**
-from Cirac--Perez-Garcia--Schuch--Verstraete (2021), Section IV.C:
-
-> **Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.C,
-> lines 2078--2090.** After proving the intersection property by inverting
-> tensors and growing them back, the source says that a similar argument applies
-> when closing the boundaries.  This boundary-closing statement is the closure
-> property.
-
-In the present formal reduction, for an `L₀`-block-injective tensor `A` on a
-periodic chain of `N` sites with window size `L > L₀`, a chain ground state
-`ψ = groundSpaceMap A N X` induces two boundary-matrix families from two cyclic
-windows used when closing the boundary. The formal proof has isolated the
-remaining comparison as the assertion that these boundary matrices agree after
-their complements are indexed by the same middle word `μ`, giving the comparison
-identity needed for the range-reduction argument.
-
-The formal Lean declaration:
-
-> `wrapped_mirror_witness_agree_of_chainGroundSpace` is the **unproven gap**
-> for this closure-property comparison.  It is the remaining hard step in the proof of
-> `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.  Once supplied,
-> it yields the normal-range reduction
-> `chainGroundSpace A L N = mpvSubmodule A N` for `L > L₀` (instead of `2L₀`).
-
-The supplementary files providing the open-chain build-up to this closure property are:
-
-* `TNLean.MPS.ParentHamiltonian.ExtendRight` — the right-extension (grow-back) step
-  that extracts a common right factor from universal word compatibility
-  (arXiv:2011.12127, Section IV.C, lines 2049--2078).
-* `TNLean.MPS.ParentHamiltonian.SuffixWindow` — suffix-window restrictions and
-  the existence of left-tail compatibility families.
-
-### Quantum Wielandt cumulative-to-word-span
-
-This file imports `TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which supplies:
-
-> **Wielandt cumulative-to-word-span connection.**  The Wielandt chain
-> (`WielandtBound.lean`) proves that under normality, the cumulative span
-> `S_n(A)` reaches the full matrix algebra for some `n ≤ D²`.
-> `CumulativeToWordSpan` converts this cumulative conclusion to a word-span
-> theorem: `∃ n, wordSpan A n = ⊤`.  This is used in the unique-ground-state
-> argument to deduce that sufficiently long word products of the Kraus operators
-> span `M_D(ℂ)`, which forces the boundary matrix to be a scalar.
-
-The formal Lean declaration:
-
-> `Wielandt.SpanGrowth.CumulativeToWordSpan` supplies the connection from
-> `cumulativeSpan_eq_top` to `wordSpan_eq_top`, the concrete word-span conclusion
-> consumed by the parent-Hamiltonian ground-space uniqueness argument.
+The open-chain build-up comes from `ExtendRight` and `SuffixWindow`
+(arXiv:2011.12127, Section IV.C, lines 2049--2078).  The normal case also uses
+`TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which converts the cumulative
+Wielandt span conclusion into the fixed-length word-span theorem used to make
+the open-chain boundary matrix scalar.
 -/
 
 open scoped Matrix BigOperators
@@ -819,18 +778,37 @@ theorem wrapped_mirror_witness_agree_of_right_products
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
-/-- The boundary matrices extracted from the cyclic closing windows agree after
-their complements are reindexed to a common middle word $\mu$.
+/-- Closure-property right-product transport for the two cyclic closing windows.
 
-This theorem states the formal comparison still needed for arXiv:2011.12127,
-Section IV.C, lines 2078--2090, and for normal-range reduction of the chain
-ground space into the MPS span.
+This is the remaining boundary-closing statement from arXiv:2011.12127,
+Section IV.C, lines 2078--2090: the two witnesses extracted from one
+periodic-chain ground state have the same right products after the two
+complements are indexed by the same middle word. -/
+theorem closure_property_right_product_transport_of_chainGroundSpace
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψ : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1))
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
+    ∀ j : Fin d,
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j =
+        YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j := by
+  intro j
+  sorry
 
-The proof already reduces to the $L_0 + 1$ chain condition, extracts the
-cyclic-window witnesses, and identifies the abstract witnesses with
-\(Y_M\) and \(Y_{M+1-L_0}\). The remaining goal is
-\(Y_M(\tau^+_\eta(\mu))A^j = Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\)
-for every physical letter \(j\). -/
+/-- The boundary matrices from the two cyclic closing windows agree after their
+complements are reindexed to a common middle word.
+
+This comparison is the closure-property step from arXiv:2011.12127,
+Section IV.C, lines 2078--2090.  It now reduces to the named right-product
+transport theorem above. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -875,9 +853,8 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     left_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
       (fun a => (hMirror a τm).symm.trans (hMirrorAt a τm))
   rw [hYwrap_eq, hYmirror_eq]
-  -- Remaining goal: \(Y_M(\tau^+_\eta(\mu))A^j =
-  --   Y_{M+1-L₀}(\tau^-_\eta(\mu))A^j\), transporting from \(M+1-L₀\) to \(M\).
-  sorry
+  exact closure_property_right_product_transport_of_chainGroundSpace
+    (A := A) hInj hL₀ (by omega : L₀ ≤ M) hψred hψX YAt hYAt η μ j
 
 /-- Range reduction for normal tensors.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1405,12 +1405,69 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     matrices $Y^+_{\tau^+_\eta(\mu)}$ and $Y^-_{\tau^-_\eta(\mu)}$.
 \end{proof}
 
+\begin{lemma}[Right-product transport for the two closing windows]
+    \label{lem:closure_property_right_product_transport_chain_ground_space}
+    \lean{MPSTensor.closure_property_right_product_transport_of_chainGroundSpace}
+    \leanok
+    \uses{def:chain_ground_space, lem:chain_ground_space_window_witnesses,
+        lem:wrapped_middle_backgrounds, lem:cyclic_window_boundary_matrix_transport}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let
+    $\psi\in\mathcal G_{M+1,L_0+1}(A)$ have an open-chain representation
+    $\psi=\Gamma_{M+1}(X)$, and let $Y_i(\tau)$ be the cyclic-window witnesses
+    for $\psi$ on windows of length $L_0+1$. If $L_0\le M$, then for every
+    dummy letter $\eta$, every middle word $\mu$ of length $M-L_0$, and every
+    physical letter $j$,
+    \[
+        Y_M(\tau^{+}_{\eta}(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
+    \]
+    This is the right-product boundary-transport statement in
+    \cite[lines~2078--2090]{Cirac2021Matrix}.
+\end{lemma}
+
+\begin{proof}
+    \notready
+    For consecutive cyclic windows, Lemma~\ref{lem:cyclic_window_boundary_matrix_transport}
+    gives the adjacent overlap identity
+    \[
+        Y_i(\tau)A^a=A^bY_{i+1}(\tau')
+    \]
+    whenever the two completed assignments
+    \[
+        \widehat{\tau}^{a}_{i,0}(k)
+        =
+        \begin{cases}
+            a,       & k=i,\\
+            \tau(k), & k\neq i,
+        \end{cases}
+        \qquad
+        \widehat{\tau'}^{b}_{i+1,L_0}(k)
+        =
+        \begin{cases}
+            b,        & k\equiv i+L_0+1 \pmod {M+1},\\
+            \tau'(k), & k\not\equiv i+L_0+1 \pmod {M+1},
+        \end{cases}
+    \]
+    agree. For each fixed final letter $j$, the closure-property step constructs
+    a chain of such equal completed assignments from the last-site background
+    $\tau^+_\eta(\mu)$ to the opposite background $\tau^-_\eta(\mu)$, with the
+    same endpoint letter $j$. Since all $Y_i(\tau)$ come from the same
+    periodic-chain vector $\psi$, the adjacent identities compose to
+    \[
+        Y_M(\tau^{+}_{\eta}(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
+    \]
+\end{proof}
+
 \begin{theorem}[Boundary matrices agree after closing the boundary]
     \label{thm:wrapped_mirror_witness_agree_chain_ground_space}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace}
     \leanok
     \uses{thm:reduced_wrapped_boundary_compatibilities,
-        lem:wrapped_mirror_right_products_determine}
+        lem:wrapped_mirror_right_products_determine,
+        lem:closure_property_right_product_transport_chain_ground_space}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let $N\ge2$
     and $L_0<L\le N$, and let
     $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
@@ -1488,61 +1545,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu)).
     \]
-    The remaining boundary-closing statement is therefore, for every physical
-    letter $j$,
-    \[
-        Y_M(\tau^{+}_{\eta}(\mu))A^j
-        =
-        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
-    \]
-    For consecutive cyclic windows, Lemma~\ref{lem:cyclic_window_boundary_matrix_transport}
-    gives the adjacent overlap identity
-    \[
-        Y_i(\tau)A^a=A^bY_{i+1}(\tau')
-    \]
-    whenever the two completed assignments
-    \[
-        \widehat{\tau}^{a}_{i,0}(k)
-        =
-        \begin{cases}
-            a,       & k=i,\\
-            \tau(k), & k\neq i,
-        \end{cases}
-        \qquad
-        \widehat{\tau'}^{b}_{i+1,L_0}(k)
-        =
-        \begin{cases}
-            b,        & k\equiv i+L_0+1 \pmod N,\\
-            \tau'(k), & k\not\equiv i+L_0+1 \pmod N,
-        \end{cases}
-    \]
-    agree, that is, as functions on the $N$-site chain:
-    \[
-        \widehat{\tau}^{a}_{i,0}
-        =
-        \widehat{\tau'}^{b}_{i+1,L_0}.
-    \]
-    The available adjacent identities therefore have the form
-    \[
-        Y_{i_r}(\tau_r)A^{a_r}
-        =
-        A^{b_r}Y_{i_{r+1}}(\tau_{r+1})
-        \qquad(0\le r<q),
-    \]
-    only at pairs whose completed assignments are equal.  They do not by
-    themselves give a telescope from
-    $\tau^{-}_{\eta}(\mu)$ to $\tau^{+}_{\eta}(\mu)$ with the same letter $j$
-    attached on the right throughout; the two endpoint backgrounds need not
-    agree away from a single adjacent overlap.  What remains is a separate
-    cyclic boundary-transport argument.  It must use the local identities for
-    genuinely equal completions, together with the fact that all witnesses come
-    from the same periodic-chain state, to obtain, for each fixed final letter
-    $j$,
-    \[
-        Y_M(\tau^{+}_{\eta}(\mu))A^j
-        =
-        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
-    \]
+    Lemma~\ref{lem:closure_property_right_product_transport_chain_ground_space}
+    gives these right-product identities for every physical letter $j$.
+    Lemma~\ref{lem:wrapped_mirror_right_products_determine} then gives the
+    desired equality of boundary matrices.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the injective case]%


### PR DESCRIPTION
## Summary

- introduce `MPSTensor.closure_property_right_product_transport_of_chainGroundSpace` as the named closure-property right-product transport statement from CPGSV21, Section IV.C, lines 2078--2090
- make `wrapped_mirror_witness_agree_of_chainGroundSpace` reduce to this named statement instead of ending with an anonymous final proof gap
- keep the blueprint theorem tag on `MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace`, whose conclusion matches the stated theorem; the proof remains marked `\notready`

This narrows issue #2331 but does not close it: the remaining proof is precisely the new closure-property transport theorem.

## Verification

- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info` (expected warning: the new transport theorem uses `sorry`)
- direct `#check` for `MPSTensor.closure_property_right_product_transport_of_chainGroundSpace` and `MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace`
- `cd blueprint && leanblueprint web` (usual local plasTeX and bibliography warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor and documentation only; proof obligations move to a single explicit `sorry` without changing downstream theorem statements or runtime behavior.
> 
> **Overview**
> This PR **names and isolates** the remaining CPGSV21 Section IV.C boundary-closing step (lines 2078–2090) instead of leaving it as an anonymous final gap in `wrapped_mirror_witness_agree_of_chainGroundSpace`.
> 
> It adds **`MPSTensor.closure_property_right_product_transport_of_chainGroundSpace`**, stating that the two cyclic-window witnesses from one periodic chain ground state have matching right products with every physical letter after reindexing to the same middle word. That theorem is still **`sorry`** in Lean; it is the explicit hard input for normal-range reduction.
> 
> **`wrapped_mirror_witness_agree_of_chainGroundState`** is rewired to finish by calling the new transport theorem (after the existing witness-identification steps), so the closure comparison is no longer a bare `sorry` at the end of that proof.
> 
> The blueprint gains matching lemma **`lem:closure_property_right_product_transport_chain_ground_space`** (`\notready`), and the wrapped-mirror theorem proof is shortened to cite it plus the existing right-product uniqueness lemma. Module docstrings in **External inputs** are tightened to point at the new name.
> 
> The mathematical obligation is unchanged; the refactor only clarifies where the open proof lives (issue #2331 is narrowed, not closed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c63e22f7c033094d06a07ec354ab79940774d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->