### PR TITLE
doc(parent): align closure-property prose with source

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -715,12 +715,12 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_co
 /-- Conditional range-reduction theorem from the actual boundary-closing comparison.
 
 This theorem isolates the remaining comparison needed for the normal-case range
-reduction.  The cyclic-to-open-chain reduction produces a boundary matrix `X`,
-and `chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`
-produces the two one-sided boundary-matrix families from the cyclic windows used
-when closing the boundary. If those actual boundary matrices agree after
-reindexing their complements to the same middle word, the chain state lies in
-the MPV line. -/
+reduction.  The cyclic-to-open-chain reduction produces a boundary matrix, and
+the reduced boundary-compatibility theorem produces the two one-sided
+boundary-matrix families from the boundary-crossing local constraints used when
+closing the boundary. If those actual boundary matrices agree after their
+complementary sites are indexed in the same way, the chain state lies in the MPV
+line. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -59,20 +59,20 @@ with the periodic boundary condition:
 * [FNW92] Sections 3–4
 * [PGVWC07] arXiv:quant-ph/0608197, Sections 5–6
 
-## External inputs
+## Remaining mathematical ingredients
 
-The declaration `closure_property_right_product_transport_of_chainGroundSpace`
-is the remaining boundary-closing statement from arXiv:2011.12127, Section IV.C,
-lines 2078--2090.  It compares the two cyclic-window witnesses obtained from
-one periodic-chain ground state after the two complements are indexed by the same
-middle word.  This is the remaining hard input for
-`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`.
+The remaining boundary-closing ingredient is an auxiliary comparison used to
+formalize the closure property from arXiv:2011.12127, Section IV.C,
+lines 2078--2090.  It compares the two boundary matrices obtained from one
+periodic-chain ground state after their complementary sites are indexed in the
+same way.  This is the last separate comparison in the normal range-reduction
+argument.
 
-The open-chain build-up comes from `ExtendRight` and `SuffixWindow`
-(arXiv:2011.12127, Section IV.C, lines 2049--2078).  The normal case also uses
-`TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which converts the cumulative
-Wielandt span conclusion into the fixed-length word-span theorem used to make
-the open-chain boundary matrix scalar.
+The open-chain build-up follows the inverting-and-growing-back argument from
+arXiv:2011.12127, Section IV.C, lines 2049--2078.  The normal case also uses the
+Wielandt span-growth theorem to pass from a cumulative span conclusion to the
+fixed-length word-span theorem used to make the open-chain boundary matrix
+scalar.
 -/
 
 open scoped Matrix BigOperators
@@ -660,13 +660,13 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_comm
     (A := A) (L₀ := L₀) (m := L₀ * m) (N := N) hInj hL₀
     (Nat.le_mul_of_pos_right L₀ hm) hCommMul
 
-/-- Two-sided middle compatibilities with one boundary family put the boundary
-vector in the MPV line.
+/-- Two-sided compatibilities with one boundary family put the boundary vector
+in the MPV line.
 
-This combines the common-middle algebraic lemma in `WrappingWindow` with the
+This combines the algebraic lemma for a common boundary family with the
 positive-length amplification above. Thus the only remaining mathematical gap is
-to compare the two boundary matrices obtained when closing the boundary so that
-the hypotheses below hold for the actual common middle word. -/
+to compare the two boundary matrices obtained when closing the boundary after
+their complementary sites are indexed in the same way. -/
 theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility
     {A : MPSTensor d D} {L₀ m N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -778,12 +778,12 @@ theorem wrapped_mirror_witness_agree_of_right_products
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
-/-- Closure-property right-product transport for the two cyclic closing windows.
+/-- Right products in the auxiliary comparison for closing the boundary.
 
 This is the remaining boundary-closing statement from arXiv:2011.12127,
 Section IV.C, lines 2078--2090: the two witnesses extracted from one
 periodic-chain ground state have the same right products after the two
-complements are indexed by the same middle word. -/
+complements are indexed in the same way. -/
 theorem closure_property_right_product_transport_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -803,12 +803,12 @@ theorem closure_property_right_product_transport_of_chainGroundSpace
   intro j
   sorry
 
-/-- The boundary matrices from the two cyclic closing windows agree after their
-complements are reindexed to a common middle word.
+/-- The boundary matrices from the two boundary-closing comparisons agree after
+their complementary sites are indexed in the same way.
 
-This comparison is the closure-property step from arXiv:2011.12127,
-Section IV.C, lines 2078--2090.  It now reduces to the named right-product
-transport theorem above. -/
+This comparison is part of closing the boundary in arXiv:2011.12127,
+Section IV.C, lines 2078--2090.  It now reduces to the right-product form of
+the auxiliary comparison above. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -900,7 +900,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     the displayed one-sided identities~(\ref{eq:ph_reduced_wrapped_compat}).
 \end{proof}
 
-\begin{lemma}[Middle-word backgrounds for the two cyclic-window complements]%
+\begin{lemma}[Complementary-site backgrounds for the two boundary supports]%
     \label{lem:wrapped_middle_backgrounds}
     \lean{MPSTensor.wrappedMiddleBackground,
         MPSTensor.mirrorMiddleBackground,
@@ -908,19 +908,19 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         MPSTensor.mirrorMiddleBackground_complement}
     \leanok
     \uses{rem:cyclic_window_operators}
-    Fix a dummy physical letter $\eta$ and a middle word $\mu$ of length
-    $N-(L_0+1)$. Write $\tau^+_\eta(\mu)$ for the last-site cyclic-window
-    background and $\tau^-_\eta(\mu)$ for the opposite cyclic-window
-    background. Their exposed
+    Fix a physical letter $\eta$ used outside the complementary sites and a word
+    $\mu$ of length $N-(L_0+1)$. Write $\tau^+_\eta(\mu)$ for the background
+    at the support crossing the last site and $\tau^-_\eta(\mu)$ for the
+    background at the opposite boundary-crossing support. Their exposed
     complements are both exactly $\mu$.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    With the same dummy letter $\eta$ on the remaining sites, fill the physical
-    sites $L_0,\ldots,N-2$ with $\mu$ for the last-site cyclic
-    window, and fill the sites $1,\ldots,N-L_0-1$ with $\mu$ for the opposite
-    cyclic window.
+    Put the same letter $\eta$ on the remaining sites. Fill the physical sites
+    $L_0,\ldots,N-2$ with $\mu$ for the support crossing the last site, and fill
+    the sites $1,\ldots,N-L_0-1$ with $\mu$ for the opposite boundary-crossing
+    support.
     The two complement-extraction identities are then immediate from the index
     arithmetic.
 \end{proof}
@@ -1355,12 +1355,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         thm:reduced_wrapped_boundary_compatibilities,
         thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D \ge 1$. Assume
-    $N \ge 2$ and $L_0 < L \le N$. Suppose that, for every dummy letter $\eta$
-    and every boundary matrix obtained from an $N$-site chain ground state, the
-    two boundary-matrix families supplied by
+    $N \ge 2$ and $L_0 < L \le N$. Suppose that, for every physical letter
+    $\eta$ used in the two boundary assignments and every boundary matrix
+    obtained from an $N$-site chain ground state, the two boundary-matrix
+    families supplied by
     Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities} agree at
-    $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ for every middle word $\mu$. Then
-    the range-$L$ chain ground space is contained in the MPV line.
+    $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ for every word $\mu$ on the
+    complementary sites. Then the range-$L$ chain ground space is contained in
+    the MPV line.
 \end{theorem}
 
 \begin{proof}
@@ -1370,9 +1372,11 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     The cyclic-to-open-chain reduction writes any chain ground state as
     $\Gamma_N(X)$. The reduced cyclic-window compatibility theorem supplies
-    the two one-sided boundary-matrix families for this $X$. The comparison hypothesis,
-    applied to a dummy letter $\eta$, says that these boundary matrices agree at
-    $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ for every middle word $\mu$.
+    the two one-sided boundary-matrix families for this $X$. The comparison
+    hypothesis, applied to a physical letter $\eta$ used in the two boundary
+    assignments, says that these boundary matrices agree at
+    $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ for every word $\mu$ on the
+    complementary sites.
     Theorem~\ref{thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     finishes.
 \end{proof}
@@ -1405,8 +1409,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     matrices $Y^+_{\tau^+_\eta(\mu)}$ and $Y^-_{\tau^-_\eta(\mu)}$.
 \end{proof}
 
-\begin{lemma}[Right-product transport for the two closing windows]
-    \label{lem:closure_property_right_product_transport_chain_ground_space}
+\begin{lemma}[Right-product comparison for closing the boundary]
+    \label{lem:boundary_closing_right_products_chain_ground_space}
     \lean{MPSTensor.closure_property_right_product_transport_of_chainGroundSpace}
     \leanok
     \uses{def:chain_ground_space, lem:chain_ground_space_window_witnesses,
@@ -1415,14 +1419,15 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $\psi\in\mathcal G_{M+1,L_0+1}(A)$ have an open-chain representation
     $\psi=\Gamma_{M+1}(X)$, and let $Y_i(\tau)$ be the cyclic-window witnesses
     for $\psi$ on windows of length $L_0+1$. If $L_0\le M$, then for every
-    dummy letter $\eta$, every middle word $\mu$ of length $M-L_0$, and every
-    physical letter $j$,
+    letter $\eta$ used in the two boundary assignments, every word $\mu$ on
+    the complementary sites, and every physical letter $j$,
     \[
         Y_M(\tau^{+}_{\eta}(\mu))A^j
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
     \]
-    This is the right-product boundary-transport statement in
+    This auxiliary equality is one of the formal comparisons needed when
+    closing the boundary in
     \cite[lines~2078--2090]{Cirac2021Matrix}.
 \end{lemma}
 
@@ -1449,11 +1454,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
             \tau'(k), & k\not\equiv i+L_0+1 \pmod {M+1},
         \end{cases}
     \]
-    agree. For each fixed final letter $j$, the closure-property step constructs
-    a chain of such equal completed assignments from the last-site background
-    $\tau^+_\eta(\mu)$ to the opposite background $\tau^-_\eta(\mu)$, with the
-    same endpoint letter $j$. Since all $Y_i(\tau)$ come from the same
-    periodic-chain vector $\psi$, the adjacent identities compose to
+    agree. For each fixed final letter $j$, the boundary-closing argument
+    follows a chain of such equal completed assignments from the last-site
+    background $\tau^+_\eta(\mu)$ to the opposite background
+    $\tau^-_\eta(\mu)$, with the same endpoint letter $j$. Since all
+    $Y_i(\tau)$ come from the same periodic-chain vector $\psi$, the adjacent
+    identities compose to
     \[
         Y_M(\tau^{+}_{\eta}(\mu))A^j
         =
@@ -1467,14 +1473,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{thm:reduced_wrapped_boundary_compatibilities,
         lem:wrapped_mirror_right_products_determine,
-        lem:closure_property_right_product_transport_chain_ground_space}
+        lem:boundary_closing_right_products_chain_ground_space}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let $N\ge2$
     and $L_0<L\le N$, and let
     $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
     $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are the two
-    boundary-matrix families extracted from the two cyclic windows used in closing the
-    periodic boundary, and that they satisfy, for every physical letter $j$
-    and every background configuration $\tau$,
+    boundary-matrix families extracted from the two boundary-crossing local
+    constraints used when closing the periodic boundary, and that they satisfy,
+    for every physical letter $j$ and every background configuration $\tau$,
     \[
         A^{\tau_{L_0}\cdots\tau_{N-2}} A^j X
         =
@@ -1485,8 +1491,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         A^j Y^{-}_{\tau}.
     \]
     For every physical letter
-    $\eta\in\{0,\ldots,d-1\}$ and every middle word $\mu$ of length
-    $N-(L_0+1)$, define two background configurations by
+    $\eta\in\{0,\ldots,d-1\}$ and every word $\mu$ on the complementary sites,
+    define two background configurations by
     \[
         \tau^{+}_{\eta}(\mu)_i =
         \begin{cases}
@@ -1545,7 +1551,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu)).
     \]
-    Lemma~\ref{lem:closure_property_right_product_transport_chain_ground_space}
+    Lemma~\ref{lem:boundary_closing_right_products_chain_ground_space}
     gives these right-product identities for every physical letter $j$.
     Lemma~\ref{lem:wrapped_mirror_right_products_determine} then gives the
     desired equality of boundary matrices.
@@ -1599,12 +1605,13 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     The closure property still needs the boundary-matrix comparison corresponding to
     \cite[lines~2078--2090]{Cirac2021Matrix}.
     Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
-    supplies the two one-sided cyclic-window identities for the open-chain
-    boundary matrix $X$. The padded-annihilation lemma states that exact
+    supplies the two one-sided identities for the boundary-crossing local
+    constraints and the open-chain boundary matrix $X$. The padded-annihilation
+    lemma states that exact
     complement-span length mismatches are no longer the obstruction. The new
     conditional reduction theorem shows that the proof would finish as soon as
-    the two actual boundary matrices are compared after reindexing their
-    complements to a common middle word. What is still missing is precisely that
+    the two actual boundary matrices are compared after indexing their
+    complementary sites in the same way. What is still missing is precisely that
     comparison after closing the boundary.
 \end{proof}
 

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -83,10 +83,12 @@ and
 are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
 \path{0 < L0}, \path{2 <= N}, and \path{L0 < L <= N}.}
 
-The blueprint records the same range-reduction target in
-\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1506--1535. Its proof
-sketch already separates the open-chain containment from the boundary-closing
-comparison, which is the same division made by the formal statements below.
+The blueprint records the same range-reduction target in the theorem
+``Normal-range reduction: containment in the MPV line'' in
+\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1584--1598, labelled
+\path{thm:normal_range_reduction_containment}. Its proof sketch already
+separates the open-chain containment from the boundary-closing comparison,
+which is the same division made by the formal statements below.
 
 
 The first mismatch is that the available intersection theorem is not a literal
@@ -142,8 +144,8 @@ window, equivalently the physical labels outside the open middle interval. The
 formal cyclic-window lemmas produce analogous complement-word products,
 written schematically as $C^+_{\tau}$ and $C^-_{\tau}$, but the two products are
 obtained with different orientations and indexings. The two formulas are both
-valid; what is missing is a comparison that puts the two outputs over one common
-middle word and one common boundary family.
+valid; what is missing is a comparison that puts the two outputs over the same
+word on the complementary sites and one common boundary family.
 \footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:603--650 for
 \path{MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective},
@@ -160,10 +162,10 @@ matrices $Y_\mu$ such that, for every physical letter $j$,
   \qquad
   X A_j A^\mu = A_j Y_\mu.
 \]
-Once these two identities have the same middle word and the same boundary family, the
-formal algebraic lemma proves that $X$ commutes with all words of a fixed positive
-length; block injectivity then promotes this to commutation with the full matrix
-algebra, so $X$ is scalar.
+Once these two identities use the same complementary-site word and the same
+boundary family, the formal algebraic lemma proves that $X$ commutes with all
+words of a fixed positive length; block injectivity then promotes this to
+commutation with the full matrix algebra, so $X$ is scalar.
 \footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:647--660 for
 \path{MPSTensor.commutes_words_of_two_sided_middle_compatibility}, and
@@ -179,13 +181,14 @@ predecessor before this comparison was isolated.}
 
 \section{Conclusion}
 
-The comparison is provisional. It identifies a difference between the compressed
-source paragraph and the available formal lemmas; it is not a source-error claim.
-The cited Cirac--Perez-Garcia--Schuch--Verstraete 2021 argument is not
-refuted. The source compresses two mathematical steps which the formal proof
-must keep separate: the $B$-region inverting and growing-back open-chain range
-reduction, and the boundary-closing comparison of the boundary matrices arising
-from the cyclic windows used in closing the boundary.
+The classification is an open gap. It identifies a difference between the
+compressed source paragraph and the available formal lemmas; it is not a
+source-error claim. The cited Cirac--Perez-Garcia--Schuch--Verstraete 2021
+argument is not refuted. The source compresses two mathematical steps which the
+formal proof must keep separate: the $B$-region inverting and growing-back
+open-chain range reduction, and the boundary-closing comparison of the boundary
+matrices arising from the two boundary-crossing supports used in closing the
+boundary.
 
 The open-chain part has been proved under the intended block-injective
 hypotheses, though not by reusing the older single-site intersection theorem.

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -23,7 +23,7 @@ Section~IV.C of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
 formal obligation is recorded in
 \href{https://github.com/LionSR/TNLean/issues/588}{issue \#588}; the
 boundary-closing comparison is recorded in
-\href{https://github.com/LionSR/TNLean/issues/1475}{issue \#1475};
+\href{https://github.com/LionSR/TNLean/issues/2331}{issue \#2331};
 and the parent-Hamiltonian consequences are recorded in
 \href{https://github.com/LionSR/TNLean/issues/460}{issue \#460}.}
 
@@ -84,10 +84,9 @@ are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
 \path{0 < L0}, \path{2 <= N}, and \path{L0 < L <= N}.}
 
 The blueprint records the same range-reduction target in
-\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1506--1535, under the
-label \texttt{thm:normal\_range\_reduction\_containment}. Its proof sketch
-already separates the open-chain containment from the cyclic boundary comparison,
-which is the same division made by the formal statements below.
+\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1506--1535. Its proof
+sketch already separates the open-chain containment from the boundary-closing
+comparison, which is the same division made by the formal statements below.
 
 
 The first mismatch is that the available intersection theorem is not a literal
@@ -153,9 +152,9 @@ compatibility, and
 \path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:463--540 for the mirror
 compatibility.}
 
-The algebraic endgame needs a stronger common-boundary-family statement. There should be
-a common middle word $\mu$ and a single family of matrices $Y_\mu$ such that, for
-every physical letter $j$,
+The algebraic endgame needs a stronger common-boundary-family statement. There
+should be a word $\mu$ on the complementary sites and a single family of
+matrices $Y_\mu$ such that, for every physical letter $j$,
 \[
   A^\mu A_j X = Y_\mu A_j,
   \qquad
@@ -170,11 +169,13 @@ algebra, so $X$ is scalar.
 \path{MPSTensor.commutes_words_of_two_sided_middle_compatibility}, and
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:711--725 for
 \path{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}.}
-The remaining point is the comparison between the two cyclic-window outputs:
-one must reindex their complementary words to a common middle word and identify
+The remaining point is the comparison between the two boundary-crossing
+outputs: one must reindex their complementary words in the same way and identify
 the two boundary matrices as a single common boundary family.\footnote{For traceability,
 this is the mathematical content recorded in
-\href{https://github.com/LionSR/TNLean/issues/1475}{issue \#1475}.}
+\href{https://github.com/LionSR/TNLean/issues/2331}{issue \#2331}. The earlier
+\href{https://github.com/LionSR/TNLean/issues/1475}{issue \#1475} was the
+predecessor before this comparison was isolated.}
 
 \section{Conclusion}
 

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -119,9 +119,9 @@ constraints. This supplies the formal analog of the iterated open-boundary
 part of the source proof, without expressing the inverse for the region $B$
 through the older single-site intersection lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:428--481 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:387 for
 \path{MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:490--505 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:449 for
 \path{MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}.}
 
 \section{The remaining comparison}
@@ -147,7 +147,7 @@ obtained with different orientations and indexings. The two formulas are both
 valid; what is missing is a comparison that puts the two outputs over the same
 word on the complementary sites and one common boundary family.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:603--650 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:562 for
 \path{MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective},
 \path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:415--458 for the wrapped
 compatibility, and
@@ -169,7 +169,7 @@ commutation with the full matrix algebra, so $X$ is scalar.
 \footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:647--660 for
 \path{MPSTensor.commutes_words_of_two_sided_middle_compatibility}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:711--725 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:670 for
 \path{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}.}
 The remaining point is the comparison between the two boundary-crossing
 outputs: one must reindex their complementary words in the same way and identify


### PR DESCRIPTION
## Summary

- describe the remaining boundary-closing equality as an auxiliary comparison used to formalize the CPGSV closure property, not as source terminology
- rename the Chapter 14 blueprint lemma label/title away from right-product transport and remove nearby dummy-letter/common-middle-word prose
- update the normal range-reduction paper-gap note to point the live boundary-closing comparison to #2331, with #1475 recorded only as its predecessor

## Source

CPGSV21, Section IV.C, lines 2049--2090: inverting and growing back; applying a similar argument when closing the boundaries; intersection property and closure property.

## Checks

- git diff --check
- lake exe cache get
- lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState
- cd blueprint && leanblueprint web

The Lean target build still reports the known remaining sorry in MPSTensor.closure_property_right_product_transport_of_chainGroundSpace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation only; no proof or API changes beyond cross-reference label updates in the blueprint.
> 
> **Overview**
> This PR **realigns documentation** for the parent-Hamiltonian normal range-reduction story so prose matches CPGSV21 Section IV.C without implying extra source terminology.
> 
> In **`UniqueGroundState.lean`**, the module header and docstrings on the boundary-closing chain now describe the remaining step as an **auxiliary comparison** (same complementary-site indexing), and refer to **boundary-crossing** constraints and **boundary-matrix families** instead of “cyclic windows,” “dummy letter,” or “common middle word.” **No Lean proofs or theorem names change**; the known `sorry` in `closure_property_right_product_transport_of_chainGroundSpace` is unchanged.
> 
> **Chapter 14 blueprint** (`ch14_parent_hamiltonian.tex`) gets matching edits: lemma title/label `lem:boundary_closing_right_products_chain_ground_space` (replacing closure-property “transport” wording), “complementary-site backgrounds” instead of middle-word cyclic complements, and **physical letter η** / **words on complementary sites** in the conditional reduction and witness-agreement statements.
> 
> The **normal range-reduction gap note** points the live boundary-closing obligation to **#2331**, records **#1475** as predecessor, updates blueprint/Lean line references, and reframes the conclusion as an **open gap** with boundary-crossing supports (not “provisional” / cyclic-window transport language).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04add7897d79837124aa402fd9aa605980513428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->