### PR TITLE
doc(parent): align boundary-closing prose with source

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -21,35 +21,26 @@ ground space is spanned by the MPV state
 
 ## Overview
 
-The proof combines the intersection property from `IntersectionProperty.lean`
-with the periodic boundary condition:
+The proof combines the intersection property with the periodic boundary
+condition:
 
 1. **Open chain**: By iterated application of the intersection property,
    any state satisfying all local ground-space conditions has the form
-   `ψ(σ) = tr(A^σ · X)` for some boundary matrix `X ∈ M_D(ℂ)`.
-   This yields a `D²`-dimensional space.
+   \(\psi(\sigma)=\operatorname{tr}(A^\sigma X)\) for some boundary
+   matrix \(X \in M_D(\mathbb C)\). This yields a \(D^2\)-dimensional space.
 
 2. **Periodic chain**: The boundary condition obtained when closing the
-   periodic chain constrains `X`. For injective `A`, the matrices `{A^i}` span
-   `M_D(ℂ)`, so the commutation condition forces `X ∝ I`, yielding a
-   one-dimensional ground space spanned by the MPV.
+   periodic chain constrains \(X\). For injective \(A\), the one-site matrices
+   span \(M_D(\mathbb C)\), so the commutation condition forces \(X\) to be
+   scalar, yielding a one-dimensional ground space spanned by the MPV.
 
 ## Main results
 
-* `MPSTensor.mpvSubmodule` — the subspace spanned by the MPV
-* `MPSTensor.mpv_mem_groundSpace` — the MPV lies in the ground space
-* `MPSTensor.chainGroundSpace` — the periodic-chain ground space as intersection
-  of cyclic window ground submodules
-* `MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective` — cyclic
-  normal-range constraints imply open-chain ground-space membership
-* `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes`
-  — once a boundary matrix commutes with all long-enough word products, its
-  boundary contraction lies in the MPV span
-* `MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility`
-  — common-middle compatibilities with one boundary family imply MPV-line membership
-* `MPSTensor.groundSpace_unique_periodic` — uniqueness on the periodic chain
-* `MPSTensor.parentHamiltonian_unique_gs_injective` — uniqueness for `2L₀` sites
-* `MPSTensor.parentHamiltonian_unique_gs_normal` — uniqueness for `L₀+1` sites
+The formal statements define the periodic-chain ground space, prove that the
+MPV lies in it, reduce cyclic constraints to an open-chain boundary matrix,
+and show that the boundary-closing comparison forces the boundary matrix to be
+scalar. The final statements record uniqueness for injective tensors and the
+range \(L_0+1\) uniqueness theorem for normal tensors.
 
 ## References
 
@@ -61,12 +52,12 @@ with the periodic boundary condition:
 
 ## Remaining mathematical ingredients
 
-The remaining boundary-closing ingredient is an auxiliary comparison used to
-formalize the closure property from arXiv:2011.12127, Section IV.C,
-lines 2078--2090.  It compares the two boundary matrices obtained from one
-periodic-chain ground state after their complementary sites are indexed in the
-same way.  This is the last separate comparison in the normal range-reduction
-argument.
+The remaining boundary-closing ingredient is the comparison needed after the
+two boundary identities \(A^\mu A^j X=Y^+_{\tau^+_\eta(\mu)}A^j\) and
+\(X A^j A^\mu=A^jY^-_{\tau^-_\eta(\mu)}\) have been extracted.  The missing
+identification is \(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\) for the
+same complementary-site word \(\mu\); see arXiv:2011.12127, Section IV.C,
+lines 2078--2090.
 
 The open-chain build-up follows the inverting-and-growing-back argument from
 arXiv:2011.12127, Section IV.C, lines 2049--2078.  The normal case also uses the
@@ -465,8 +456,8 @@ theorem chainGroundSpace_le_groundSpace_of_isNBlkInjective
 
 /-! ### Vanishing on all word products implies zero -/
 
-/-- If `X` has the property that `tr(evalWord A w * X) = 0` for all words of
-length `k` (with `k ≥ 1` and `A` injective), then `X = 0`. -/
+/-- If \(X\) has the property that \(\operatorname{tr}(A^w X)=0\) for all words
+of length \(k\), with \(k \ge 1\) and \(A\) injective, then \(X=0\). -/
 private theorem eq_zero_of_trace_evalWord_mul_eq_zero {A : MPSTensor d D}
     (hA : IsInjective A) {k : ℕ} (hk : 0 < k)
     {X : Matrix (Fin D) (Fin D) ℂ}
@@ -554,9 +545,9 @@ theorem chainGroundSpace_eq_mpvSubmodule {A : MPSTensor d D} [NeZero D]
 at the boundary for an open-chain boundary matrix.
 
 After the cyclic-to-open-chain step writes a periodic-chain vector as
-`ψ = groundSpaceMap A N X`, the two reduced cyclic windows used when closing
-the boundary expose the boundary matrix `X` on opposite sides of the same
-length-`N - (L₀ + 1)` complement word. This theorem gives the local algebraic
+\(\psi=\Gamma_N(X)\), the two reduced cyclic windows used when closing the
+boundary expose the boundary matrix \(X\) on opposite sides of the same
+length \(N-(L₀+1)\) complement word. This theorem gives the local algebraic
 output needed for the remaining boundary-closing comparison
 (arXiv:2011.12127, Section IV.C, lines 2078--2090). -/
 theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
@@ -612,9 +603,9 @@ theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
 periodic MPV line.
 
 After the reduced cyclic-window compatibilities at the boundary have been converted into a
-family of identities `X A^ω = A^ω X` for one word length `m ≥ L₀`, the existing
-block-stripping theorem makes `X` commute with the full matrix algebra.  Hence
-`X` is scalar and `groundSpaceMap A N X` is a scalar multiple of the MPV. -/
+family of identities \(XA^\omega=A^\omega X\) for one word length \(m \ge L₀\),
+the existing block-stripping theorem makes \(X\) commute with the full matrix
+algebra. Hence \(X\) is scalar and \(\Gamma_N(X)\) is a scalar multiple of the MPV. -/
 theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes
     {A : MPSTensor d D} {L₀ m N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hm : L₀ ≤ m)
@@ -639,11 +630,11 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes
   simp only [groundSpaceMap_apply, Pi.smul_apply, smul_eq_mul, mpv, coeff]
   rw [hX_eq, Algebra.mul_smul_comm, mul_one, Matrix.trace_smul, smul_eq_mul]
 
-/-- Boundary contraction lies in the MPV span when `X` commutes with words of
+/-- Boundary contraction lies in the MPV span when \(X\) commutes with words of
 some positive length.
 
-If `X` commutes with all words of any positive length `m`, then chunking gives
-commutation at the multiple `L₀ * m`, which is at least `L₀`.  The long-word
+If \(X\) commutes with all words of any positive length \(m\), then chunking gives
+commutation at the multiple \(L₀m\), which is at least \(L₀\). The long-word
 centrality theorem then applies exactly as in
 `groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes`. -/
 theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes
@@ -660,13 +651,16 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_comm
     (A := A) (L₀ := L₀) (m := L₀ * m) (N := N) hInj hL₀
     (Nat.le_mul_of_pos_right L₀ hm) hCommMul
 
-/-- Two-sided compatibilities with one boundary family put the boundary vector
-in the MPV line.
+/-- Two-sided compatibilities put the boundary vector in the MPV line.
 
-This combines the algebraic lemma for a common boundary family with the
-positive-length amplification above. Thus the only remaining mathematical gap is
-to compare the two boundary matrices obtained when closing the boundary after
-their complementary sites are indexed in the same way. -/
+If
+\[
+  A^\mu A^j X = Y_\mu A^j,
+  \qquad
+  X A^j A^\mu = A^jY_\mu
+\]
+for the same matrix \(Y_\mu\), then positive-length commutation gives
+\(\Gamma_N(X)\in \mathbb C\,\Omega_N(A)\). -/
 theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility
     {A : MPSTensor d D} {L₀ m N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -686,11 +680,10 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_c
 /-- Reindexed boundary-closing comparison puts the boundary vector in the MPV
 line.
 
-This combines the common-middle commutation argument with the two cyclic windows
-used when closing the boundary. The one-sided hypotheses are exactly the outputs of
-`chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`; the
-additional hypothesis says that, after both complements are filled by the same
-middle word `μ`, the two boundary matrices are equal. -/
+The inputs are \(A^\mu A^j X=Y^+_{\tau^+_\eta(\mu)}A^j\),
+\(X A^j A^\mu=A^jY^-_{\tau^-_\eta(\mu)}\), and
+\(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\) for the same word \(\mu\).
+These equations put \(\Gamma_N(X)\) in the MPV line. -/
 theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
     {A : MPSTensor d D} {L₀ N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (η : Fin d)
@@ -858,10 +851,17 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 
 /-- Range reduction for normal tensors.
 
-This is the missing hard direction of `chainGroundSpace_eq_mpvSubmodule_normal`:
-for a normal tensor with a positive `L₀`-block-injective presentation, the
-reduced periodic window constraints `L > L₀` already force a chain ground state
-to lie in the MPV line. -/
+For a normal tensor that becomes injective after blocking \(L₀>0\) sites, the
+periodic constraints of any range \(L>L₀\) give
+\[
+  \mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A).
+\]
+This is the formal closure-property step in arXiv:2011.12127
+(Cirac--Perez-Garcia--Schuch--Verstraete 2021).
+
+**Open gap:** The current proof still depends on the comparison
+\(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\), recorded in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -888,15 +888,22 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
     (A := A) (L₀ := L₀) (N := N) hInj hL₀ η Ywrap Ymirror hWrap hMirror hCompare
 
-/-- On a periodic chain, the normal parent-Hamiltonian ground space coincides
-with the span of the MPV with the reduced window `L > L₀` (instead of `2L₀`).
+/-- On a periodic chain, the normal parent-Hamiltonian ground space satisfies
+\[
+  \mathcal G_{N,L}(A)=\mathbb C\,\Omega_N(A)
+\]
+at every interaction range \(L>L₀\).
 
-The normality hypothesis enables the range reduction from `2L₀` to `L₀ + 1`
-via the structure theory of normal MPS (peripheral spectrum, canonical form).
-See [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
-Section IV.C, lines 2078--2090. -/
--- TODO(parent-hamiltonian): derive using the normal-form range reduction and
--- the cyclic-window definition of `chainGroundSpace`.
+This is the MPS part of the closure-property argument in
+[Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+Section IV.C, lines 2078--2090: after the intersection-property reduction,
+closing the boundary leaves only the MPV line.
+
+**Open gap:** The containment direction depends on the comparison
+\(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\), recorded in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+-- TODO(parent-hamiltonian): derive from the normal range-reduction theorem and
+-- the cyclic-window definition of the periodic-chain ground space.
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N) :
@@ -916,11 +923,12 @@ space is one-dimensional, spanned by the MPV.
 
 The proof uses the intersection property iteratively:
 1. From the intersection property, any state in the chain ground space has the form
-   `ψ(σ) = tr(A^σ · X)` for some `X ∈ M_D(ℂ)`.
-2. The boundary condition obtained when closing the periodic chain constrains `X`
-   to commute with all `A^i`.
-3. For injective `A`, the center of `span{A^i} = M_D(ℂ)` consists only of scalars,
-   so `X = c · I` and `ψ = c · mpv A`. -/
+   \(\psi(\sigma)=\operatorname{tr}(A^\sigma X)\) for some
+   \(X \in M_D(\mathbb C)\).
+2. The boundary condition obtained when closing the periodic chain constrains
+   \(X\) to commute with all \(A^i\).
+3. For injective \(A\), the center of the span \(M_D(\mathbb C)\) consists only
+   of scalars, so \(\psi\) is proportional to the MPV. -/
 theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjective A)
     {L N : ℕ} (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N) :
     HasUniqueGroundState (chainGroundSpace A L N) := by
@@ -942,10 +950,13 @@ If `A` is `L₀`-block-injective with `L₀ > 0`, the parent Hamiltonian with
 interaction range `2L₀` on a periodic chain of `N ≥ 2L₀` sites has a unique
 ground state.
 
-**Proof sketch**: First rewrite the chain ground space as the MPV submodule
-using `chainGroundSpace_eq_mpvSubmodule_normal`, applying normality obtained
-from block injectivity. Then use `mpv_ne_zero_of_isNBlkInjective` to show the
-MPV submodule is one-dimensional. -/
+**Proof sketch**: First identify the chain ground space with the MPV line,
+using normality obtained from block injectivity. Then use nonvanishing of the
+MPV to show that this line is one-dimensional.
+
+**Open gap:** This uses the normal range-reduction equality and hence the
+comparison \(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\); see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) :
@@ -957,14 +968,18 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
   have hmpv := mpv_ne_zero_of_isNBlkInjective hA hL₀ hN'
   simpa [mpvSubmodule] using finrank_span_singleton (K := ℂ) hmpv
 
-/-- **Optimal unique ground state for normal tensors on `L₀ + 1` sites**.
+/-- **Unique ground state for normal tensors at range \(L₀+1\).**
 
-If `A` is normal and `L₀`-block-injective with `L₀ > 0`, the interaction range
-can be reduced from `2L₀` to `L₀ + 1`. The chain ground space with window
-`L₀ + 1` on `N ≥ L₀ + 1` sites has a unique ground state.
+If \(A\) is normal and becomes injective after blocking \(L₀>0\) sites, the
+parent Hamiltonian with interaction range \(L₀+1\) has a unique ground state on
+every periodic chain with \(N \ge L₀+1\).
 
-The proof rewrites via `chainGroundSpace_eq_mpvSubmodule_normal`, then uses
-`mpv_ne_zero_of_isNBlkInjective` to show the MPV submodule is 1D. -/
+Equivalently, \(\dim \mathcal G_{N,L₀+1}(A)=1\). The proof identifies this
+ground space with the MPV line and uses nonvanishing of the MPV.
+
+**Open gap:** This depends on the normal range-reduction equality above and
+hence on \(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\); see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -11,9 +11,9 @@ import TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
 /-!
 # Wrapping window argument for periodic MPS chains
 
-This file proves that the boundary matrix `X` arising from the open-chain
-intersection property must commute with all generators `A_j` of an injective
-MPS tensor on a periodic chain.
+This file proves that the boundary matrix \(X\) arising from the open-chain
+intersection property commutes with all one-site matrices \(A_j\) of an
+injective MPS tensor on a periodic chain.
 
 ## Proof strategy
 
@@ -21,41 +21,36 @@ On a periodic chain of `N` sites with window size `L`, the last cyclic window
 wraps around from position `N-1` back to the first `L-1` sites. The proof
 proceeds as follows:
 
-1. **Cyclic config decomposition** (`cyclicCfg_last_eq`, `cyclicCfg_window_site`,
-   `cyclicCfg_complement_site`): At the wrapping position `N-1`, the cyclic
-   configuration decomposes into window sites `σ_w(0), σ_w(1), …, σ_w(L-1)`
-   (wrapping around) and complement sites from `τ`.
+1. At the wrapping position \(N-1\), the cyclic configuration separates into
+   the \(L\) sites of the boundary-crossing support and the complementary
+   sites labelled by \(\tau\).
 
-2. **Snoc factorization** (`evalWord_cyclicCfg_snoc`, `init_evalWord_split`):
-   The product `evalWord A (cyclicCfg ...)` factors as
-   `evalWord(tail) * evalWord(complement) * A(σ_w(0))`, enabling trace rotation.
+2. The corresponding word product factors as
+   \(A^{\mathrm{tail}}A^{\mathrm{comp}}A^{\sigma_0}\), so trace cyclicity
+   rotates the tensor at the periodic boundary.
 
-3. **Trace rotation** (`wrapping_window_matEq`): Using `tr(P * Q) = tr(Q * P)`,
-   we rotate the wrapping boundary to obtain a matrix equation
-   `X * evalWord(σ_tail) * evalWord(complement) = evalWord(σ_tail) * Y_τ`
-   for all window tails `σ_tail` and background configs `τ`.
+3. The rotation gives an identity of the form
+   \(X A^{\mathrm{tail}}A^{\mathrm{comp}}
+     = A^{\mathrm{tail}}Y_\tau\)
+   for every boundary tail and every assignment of the complementary sites.
 
-4. **Spanning extension** (`boundary_matrix_commutes`): Since
-   `wordSpan A (L-1) = ⊤` for injective `A`, the equation extends from
-   `evalWord(σ_tail)` to all matrices `M₁`, yielding `[X, M₁] * complement = 0`.
-   A second spanning argument (over complement words) gives `X * M₁ = M₁ * X`
-   for all `M₁`, hence `X * A_j = A_j * X`.
+4. Block injectivity extends the identity from word products to the full
+   matrix algebra. Applying the same spanning argument to the complementary
+   words gives \(XM=MX\) for every matrix \(M\), hence \(XA_j=A_jX\).
 
 ## Main results
 
-* `MPSTensor.commutes_words_of_two_sided_middle_compatibility`
-  — two-sided common-middle identities with one boundary family imply word commutation
-* `MPSTensor.commutes_words_mul_of_commutes_words`
-  — fixed-length word commutation amplifies to all multiple lengths
-* `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes`
-  — block injectivity turns long-word commutation into generator commutation
-* `MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul`
-  — padding short complement annihilation to a full block-injective word span
-* `MPSTensor.right_witness_unique_of_isNBlkInjective` and
-  `MPSTensor.left_witness_unique_of_isNBlkInjective`
-  — uniqueness of the one-sided boundary matrices from block injectivity
-* `MPSTensor.boundary_matrix_commutes` — if `groundSpaceMap A N X` lies in
-  every cyclic window's ground space, then `X` commutes with all `A_j`.
+The main formal statements show that the two identities
+\[
+  A^\mu A^j X = Y_\mu A^j,
+  \qquad
+  X A^j A^\mu = A^jY_\mu
+\]
+imply commutation with fixed-length word products; that fixed-length
+commutation propagates to long words; and that block injectivity then gives
+\(XA_j=A_jX\) for every one-site matrix. They also record the one-sided
+uniqueness consequences of block injectivity used in the boundary-closing
+comparison.
 
 ## References
 
@@ -74,19 +69,11 @@ the spanning step used in the wrapping-window argument:
 > algebra `M_D(ℂ)`.  Concretely: `span{A_w v} = ℂ^D` for all `v ≠ 0` implies
 > `span{A_w} = M_D(ℂ)`.
 
-In MPS notation after blocking: for an injective tensor `A`, the Kraus word
-products of length `L-1` span `M_D(ℂ)` (`wordSpan A (L-1) = ⊤`).
+In MPS notation after blocking: for an injective tensor \(A\), the Kraus word
+products of length \(L-1\) span \(M_D(\mathbb C)\).
 This spanning conclusion is what allows the proof to extend the word-compatibility
-identity from `evalWord` values to arbitrary matrices `M₁`, yielding the
-commutation condition `X M₁ = M₁ X` for all matrices `M₁`, hence
-`X A_j = A_j X` for each generator.
-
-The formal Lean declaration:
-
-> `Wielandt.SpanGrowth.VectorToMatrixSpan` provides the lemmas that turn
-> a vector-span hypothesis into a matrix-span conclusion.  In the wrapping-window
-> proof, this is applied after the injectivity hypothesis `IsInjective A` gives
-> `wordSpan A (L-1) = ⊤` via `wordSpan_eq_top_of_isInjective`.
+identity from word products to arbitrary matrices \(M\), yielding \(XM=MX\)
+for all matrices \(M\), hence \(XA_j=A_jX\) for each one-site matrix.
 -/
 
 open scoped Matrix BigOperators
@@ -539,18 +526,25 @@ theorem wrapping_window_mirror_compatibility_of_isNBlkInjective
     _ = Matrix.trace (evalWord A (List.ofFn σ_head) * (A j * Y τ)) := by
           simpa [Matrix.mul_assoc] using key'
 
-/-! ### Common-middle algebraic closure
+/-! ### Complement-word algebraic closure
 
 The two one-sided cyclic-window identities close the boundary matrix once they
-are available with a common middle word and the same boundary-matrix family. -/
+take the form
+\[
+  A^\mu A^j X = Y_\mu A^j,
+  \qquad
+  X A^j A^\mu = A^jY_\mu
+\]
+with the same word \(\mu\) on complementary sites and the same matrix
+\(Y_\mu\). -/
 
 /-- A background configuration whose cyclic-window complement is the prescribed
-middle word.
+word on the complementary sites.
 
 For the wrapped window at the last site, the complement occupies physical sites
 `L₀, ..., N - 2`.  This construction fills exactly those sites with `μ`; the
-remaining sites are dummy values and do not affect the complement word extracted by
-`wrapping_window_compatibility_of_isNBlkInjective`. -/
+remaining sites receive the letter `η` and do not affect the complement word
+extracted by the wrapped boundary identity. -/
 def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
   fun i =>
@@ -560,11 +554,11 @@ def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
       η
 
 /-- A background configuration whose mirror-window complement is the prescribed
-middle word.
+word on the complementary sites.
 
 For the opposite wrapped window, the complement occupies physical sites
 `1, ..., N - L₀ - 1`.  This construction fills exactly those sites with `μ`; all
-window sites receive the dummy value `η`. -/
+other sites receive the letter `η`. -/
 def mirrorMiddleBackground (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
   fun i =>
@@ -574,7 +568,7 @@ def mirrorMiddleBackground (L₀ N : ℕ) (η : Fin d)
       η
 
 /-- Extracting the wrapped complement from `wrappedMiddleBackground` returns the
-prescribed middle word. -/
+prescribed word on the complementary sites. -/
 theorem wrappedMiddleBackground_complement (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) :
     (fun k : Fin (N - (L₀ + 1)) =>
@@ -588,7 +582,7 @@ theorem wrappedMiddleBackground_complement (L₀ N : ℕ) (η : Fin d)
   · constructor <;> omega
 
 /-- Extracting the mirror complement from `mirrorMiddleBackground` returns the
-prescribed middle word. -/
+prescribed word on the complementary sites. -/
 theorem mirrorMiddleBackground_complement (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) :
     (fun k : Fin (N - (L₀ + 1)) =>
@@ -599,15 +593,20 @@ theorem mirrorMiddleBackground_complement (L₀ N : ℕ) (η : Fin d)
   · congr 1
   · constructor <;> omega
 
-/-- Reindexed cyclic-window boundary matrices give a common boundary family over
-a common middle word.
+/-- Reindexed cyclic-window identities give the two equations with one matrix
+\(Y_\mu\).
 
-The hypotheses `hWrap` and `hMirror` are the two one-sided identities produced by
-`chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective`.  The only
-extra input is the genuine boundary-closing comparison: after filling the two complements
-with the same middle word `μ`, the two boundary matrices agree. The
-conclusion yields the shared-boundary-family hypotheses needed by
-`commutes_words_of_two_sided_middle_compatibility`. -/
+The one-sided inputs have the form
+\[
+  A^\mu A^j X = Y^+_{\tau^+_\eta(\mu)}A^j,
+  \qquad
+  X A^j A^\mu = A^jY^-_{\tau^-_\eta(\mu)}.
+\]
+The boundary-closing comparison
+\[
+  Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}
+\]
+therefore gives the two identities with the same matrix \(Y_\mu\). -/
 theorem two_sided_middle_compatibility_of_wrapped_witness_comparison
     {A : MPSTensor d D} {L₀ N : ℕ} (η : Fin d)
     {X : Matrix (Fin D) (Fin D) ℂ}
@@ -635,9 +634,8 @@ theorem two_sided_middle_compatibility_of_wrapped_witness_comparison
     have hCmp := hCompare μ
     simpa [mirrorMiddleBackground_complement, hCmp.symm] using h
 
-/-- A pair of one-sided compatibilities with one boundary family around a common
-middle word forces `X` to commute with every word obtained by adjoining one
-physical letter on each side of that middle.
+/-- Two one-sided identities with the same matrix \(Y_\mu\) force \(X\) to commute
+with every word obtained by adjoining one physical letter on each side.
 
 This is the algebraic core of the remaining normal parent-Hamiltonian closure
 step: after the two cyclic windows used when closing the boundary have been
@@ -675,8 +673,8 @@ theorem commutes_words_of_two_sided_middle_compatibility
     _ = (A a * (evalWord A (List.ofFn μ) * A b)) * X := by
             simp [Matrix.mul_assoc]
 
-/-- If `X` commutes with all words of a fixed length `m`, then it commutes
-with all words whose length is any multiple of `m`.
+/-- If \(X\) commutes with all words of a fixed length \(m\), then it commutes
+with all words whose length is any multiple of \(m\).
 
 The proof chunks a list of length `q * m` into a length-`m` prefix and a shorter
 multiple-length suffix. This formalizes the amplification step that promotes
@@ -880,7 +878,7 @@ set_option maxHeartbeats 800000 in
 -- The double spanning argument over window tails and complements creates large
 -- `LinearMap.ext_on_range` goals, so we raise the heartbeat budget here as well.
 /-- If `groundSpaceMap A N X` lies in every cyclic window's ground space,
-then `X` commutes with all generators `A_j`.
+then \(X\) commutes with all generators \(A_j\).
 
 This is the key step in the periodic-chain uniqueness argument:
 the wrapping window constraint forces the boundary matrix into the center

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -925,14 +925,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     arithmetic.
 \end{proof}
 
-\begin{lemma}[One boundary-matrix family from compared boundary matrices]%
+\begin{lemma}[One matrix $Y_\mu$ from compared boundary matrices]%
     \label{lem:two_sided_middle_of_wrapped_witness_comparison}
     \lean{MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison}
     \leanok
     \uses{lem:wrapped_middle_backgrounds}
-    Fix a dummy physical letter $\eta$. Suppose the two one-sided boundary
-    matrix families $Y^+$ and $Y^-$ have been extracted from the cyclic
-    windows. If, for every middle word
+    Fix a physical letter $\eta$ used outside the complementary sites. Suppose
+    the two one-sided boundary matrix families $Y^+$ and $Y^-$ have been
+    extracted from the cyclic windows. If, for every word on the complementary sites
     $\mu$, these boundary matrices agree on the backgrounds built from $\eta$,
     \[
         Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)},
@@ -955,12 +955,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $Y_\mu$.
 \end{proof}
 
-\begin{lemma}[Common-middle commutation with one boundary family]%
+\begin{lemma}[Commutation from two one-sided equations]%
     \label{lem:common_middle_same_witness_commutation}
     \lean{MPSTensor.commutes_words_of_two_sided_middle_compatibility}
     \leanok
-    Suppose a single family of boundary matrices $Y_\mu$, indexed by middle
-    words $\mu$, satisfies the two one-sided identities
+    Suppose a single family of boundary matrices $Y_\mu$, indexed by words
+    $\mu$ on the complementary sites, satisfies the two one-sided identities
     \begin{equation}\label{eq:ph_common_middle_one_sided}
         A^\mu A^b X = Y_\mu A^b,
         \qquad
@@ -968,7 +968,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \end{equation}
     for every pair of physical letters $a,b$. Then $X$ commutes with every word
     product $A^a A^\mu A^b$ obtained by adjoining one letter on each side of the
-    common middle.
+    word $A^\mu$.
 \end{lemma}
 
 \begin{proof}
@@ -1306,44 +1306,50 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:ground_space_map_mpv_of_long_word_commutes} applies.
 \end{proof}
 
-\begin{theorem}[Boundary contraction in the MPV span from one middle boundary family]
+\begin{theorem}[Boundary contraction in the MPV span from two one-sided equations]
     \label{thm:ground_space_map_mpv_of_common_middle}
     \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}
     \leanok
     \uses{lem:common_middle_same_witness_commutation,
         thm:ground_space_map_mpv_of_positive_word_commutes}
-    Let $A$ be $L_0$-block-injective with $L_0>0$. If the common-middle
-    one-boundary-family identities of
-    Lemma~\ref{lem:common_middle_same_witness_commutation} hold for $X$, then
+    Let $A$ be $L_0$-block-injective with $L_0>0$. Suppose there are matrices
+    $Y_\mu$ such that
+    \[
+        A^\mu A^b X = Y_\mu A^b,
+        \qquad
+        X A^a A^\mu = A^a Y_\mu
+    \]
+    for every pair of physical letters $a,b$. Then
     $\Gamma_N(X)$ lies in the MPV line.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The common-middle identities give commutation with all words of length
-    $|\mu|+2$, a positive length. The positive-length containment theorem then
-    applies.
+    The identities in~(\ref{eq:ph_common_middle_one_sided}) give commutation
+    with all words of length $|\mu|+2$, a positive length. The positive-length
+    containment theorem then applies.
 \end{proof}
 
-\begin{theorem}[Boundary contraction in the MPV span from wrapped-witness comparison]
+\begin{theorem}[Boundary contraction in the MPV span from boundary comparison]
     \label{thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison}
     \leanok
     \uses{lem:two_sided_middle_of_wrapped_witness_comparison,
         thm:ground_space_map_mpv_of_common_middle}
-    Let $A$ be $L_0$-block-injective with $L_0>0$, and fix a dummy physical
-    letter $\eta$. If the two one-sided boundary matrix families satisfy
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and fix a physical letter
+    $\eta$ used outside the complementary sites. If the two one-sided boundary
+    matrix families satisfy
     \[
         Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}
     \]
-    for every middle word $\mu$, then $\Gamma_N(X)$ lies in the MPV line.
+    for every word $\mu$ on the complementary sites, then $\Gamma_N(X)$ lies in the MPV line.
 \end{theorem}
 
 \begin{proof}
     \leanok
     Lemma~\ref{lem:two_sided_middle_of_wrapped_witness_comparison} uses the
     comparison at the two $\eta$-backgrounds to turn the two boundary matrices
-    into a single common-middle boundary family. Then
+    into the same matrix $Y_\mu$. Then
     Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} applies.
 \end{proof}
 
@@ -1606,13 +1612,19 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \cite[lines~2078--2090]{Cirac2021Matrix}.
     Theorem~\ref{thm:reduced_wrapped_boundary_compatibilities}
     supplies the two one-sided identities for the boundary-crossing local
-    constraints and the open-chain boundary matrix $X$. The padded-annihilation
-    lemma states that exact
-    complement-span length mismatches are no longer the obstruction. The new
-    conditional reduction theorem shows that the proof would finish as soon as
-    the two actual boundary matrices are compared after indexing their
-    complementary sites in the same way. What is still missing is precisely that
-    comparison after closing the boundary.
+    constraints and the open-chain boundary matrix $X$:
+    \[
+        A^\mu A^j X = Y^+_{\tau^+_\eta(\mu)}A^j,
+        \qquad
+        X A^j A^\mu = A^jY^-_{\tau^-_\eta(\mu)}.
+    \]
+    The remaining point is to compare the two boundary matrices after the
+    complementary sites are indexed by the same word $\mu$:
+    \[
+        Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}.
+    \]
+    Once this equality is known, the conditional reduction theorem gives the
+    containment in the MPV line.
 \end{proof}
 
 \begin{theorem}[Chain ground space equals the MPV line in the normal case]%
@@ -1655,19 +1667,21 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{theorem}[Unique ground state for block-injective tensors]%
     \label{thm:unique_gs_injective}
     \lean{MPSTensor.parentHamiltonian_unique_gs_injective}
-    \notready
+    \leanok
     \uses{thm:chain_ground_space_eq_mpv_normal}
     If $A$ is $L_0$-block-injective with $L_0 > 0$ and $D \ge 1$, the parent Hamiltonian
-    with interaction range $2L_0$ has a unique ground state on the periodic chain.
+    with interaction range $2L_0$ has a unique ground state on every periodic chain
+    of $N \ge 2L_0$ sites.
 \end{theorem}
 
-\begin{theorem}[Optimal unique ground state for normal tensors]%
+\begin{theorem}[Unique ground state for normal tensors at range $L_0+1$]%
     \label{thm:unique_gs_normal}
     \lean{MPSTensor.parentHamiltonian_unique_gs_normal}
-    \notready
+    \leanok
     \uses{thm:unique_gs_injective}
     If $A$ is normal (hence $L_0$-block-injective for some $L_0 > 0$),
-    $D \ge 1$, and in normal form, the interaction range can be reduced to $L_0 + 1$.
+    $D \ge 1$, then the parent Hamiltonian with interaction range $L_0 + 1$
+    has a unique ground state on every periodic chain of $N \ge L_0+1$ sites.
 \end{theorem}
 
 \section{Commuting parent Hamiltonians}\label{sec:commuting_parent_ham}

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -75,17 +75,17 @@ In the formal statement this is the equality between the cyclic chain ground spa
 and the MPV, or periodic MPS vector, subspace. The hard inclusion into the MPV
 line is the remaining range-reduction lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:864--888 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:865 for
 \path{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
 and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:899--909 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:907 for
 \path{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal}. The formal hypotheses
 are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
 \path{0 < L0}, \path{2 <= N}, and \path{L0 < L <= N}.}
 
 The blueprint records the same range-reduction target in the theorem
 ``Normal-range reduction: containment in the MPV line'' in
-\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1584--1598, labelled
+\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1590--1628, labelled
 \path{thm:normal_range_reduction_containment}. Its proof sketch already
 separates the open-chain containment from the boundary-closing comparison,
 which is the same division made by the formal statements below.
@@ -119,9 +119,9 @@ constraints. This supplies the formal analog of the iterated open-boundary
 part of the source proof, without expressing the inverse for the region $B$
 through the older single-site intersection lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:387 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:378 for
 \path{MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:449 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:440 for
 \path{MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}.}
 
 \section{The remaining comparison}
@@ -144,36 +144,36 @@ window, equivalently the physical labels outside the open middle interval. The
 formal cyclic-window lemmas produce analogous complement-word products,
 written schematically as $C^+_{\tau}$ and $C^-_{\tau}$, but the two products are
 obtained with different orientations and indexings. The two formulas are both
-valid; what is missing is a comparison that puts the two outputs over the same
-word on the complementary sites and one common boundary family.
+valid; what is missing is a comparison that identifies the two boundary
+matrices after the complementary sites have been indexed by the same word.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:562 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:553 for
 \path{MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective},
-\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:415--458 for the wrapped
+\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:402 for the wrapped
 compatibility, and
-\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:463--540 for the mirror
+\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:450 for the mirror
 compatibility.}
 
-The algebraic endgame needs a stronger common-boundary-family statement. There
-should be a word $\mu$ on the complementary sites and a single family of
-matrices $Y_\mu$ such that, for every physical letter $j$,
+The algebraic endgame needs the two one-sided identities to use the same matrix.
+There should be a word $\mu$ on the complementary sites and matrices $Y_\mu$
+such that, for every physical letter $j$,
 \[
   A^\mu A_j X = Y_\mu A_j,
   \qquad
   X A_j A^\mu = A_j Y_\mu.
 \]
-Once these two identities use the same complementary-site word and the same
-boundary family, the formal algebraic lemma proves that $X$ commutes with all
+Once these two identities use the same complementary-site word $\mu$ and the
+same matrix $Y_\mu$, the formal algebraic lemma proves that $X$ commutes with all
 words of a fixed positive length; block injectivity then promotes this to
 commutation with the full matrix algebra, so $X$ is scalar.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:647--660 for
+\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:645 for
 \path{MPSTensor.commutes_words_of_two_sided_middle_compatibility}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:670 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:664 for
 \path{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}.}
 The remaining point is the comparison between the two boundary-crossing
 outputs: one must reindex their complementary words in the same way and identify
-the two boundary matrices as a single common boundary family.\footnote{For traceability,
+the two boundary matrices as the same matrix $Y_\mu$.\footnote{For traceability,
 this is the mathematical content recorded in
 \href{https://github.com/LionSR/TNLean/issues/2331}{issue \#2331}. The earlier
 \href{https://github.com/LionSR/TNLean/issues/1475}{issue \#1475} was the


### PR DESCRIPTION
## Summary

- rewrite the parent-Hamiltonian boundary-closing prose around the CPGSV21 closure property in formula-first language
- remove local proof-device wording such as dummy/middle/common-middle/wrapped-witness from the touched reader-facing passages
- replace the non-source-faithful “optimal” uniqueness phrasing with the CPGSV21 range-$L_0+1$ uniqueness statement
- keep #2331 as the remaining proof obligation for the boundary-closing comparison

## Verification

- `git diff --check`
- targeted `rg` scan for removed phrases in the touched files
- `lake build TNLean.MPS.ParentHamiltonian.WrappingWindow TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `leanblueprint web` exited 0 locally, with the existing plasTeX/bibliography warnings and a local Python-package warning that prevented `lean_decls` regeneration
- `python3 scripts/blueprint_lean_sync.py --root . --report /tmp/tnlean_parent_boundary_sync_report.json` reports no missing declarations in `ch14_parent_hamiltonian.tex`; remaining sync issues are pre-existing outside this PR

Refs #2331.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation only; no proof or API logic changes beyond narrative and blueprint `\leanok` labels.
> 
> **Overview**
> This PR **realigns reader-facing documentation** for the CPGSV21 parent-Hamiltonian boundary-closing story; it does **not** change the underlying Lean proof terms beyond doc comments.
> 
> The touched Lean files (`UniqueGroundState.lean`, `WrappingWindow.lean`) rewrite module overviews and theorem docstrings in **formula-first language**: open-chain states as \(\psi=\Gamma_N(X)\), the two one-sided identities \(A^\mu A^j X = Y^+_{\tau^+_\eta(\mu)}A^j\) and \(X A^j A^\mu = A^j Y^-_{\tau^-_\eta(\mu)}\), and the remaining step as **\(Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}\)** for the same complementary word \(\mu\). Wording like dummy/middle/common-middle/wrapped-witness is dropped in favor of **complementary-site words** and a **single matrix \(Y_\mu\)**.
> 
> **Blueprint** `ch14_parent_hamiltonian.tex` is updated in parallel (lemma/theorem titles and proof sketches). The normal-range reduction sketch now states the two one-sided equations and the missing witness equality explicitly. Uniqueness theorems are retitled to match CPGSV21 (**range \(L_0+1\)**, not “optimal”), with fuller periodic-chain hypotheses; `\notready` → `\leanok` on the two uniqueness entries reflects doc/sync alignment—the hard comparison still depends on the documented gap (e.g. `closure_property_right_product_transport` remains `sorry`).
> 
> **`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`** is refreshed with corrected line references and the same \(Y^+ = Y^-\) framing instead of “common boundary family.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4bbb87c6447efd2509f2b429ad6853d93dd2d16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->