### PR TITLE
doc(parent): quantify block proof step

### DIFF
--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -218,14 +218,18 @@ Thus the desired periodic-chain proof has the mathematical form
   \psi=\sum_{j=1}^b\Gamma_j(X_j),
   \notag\\
   &\hphantom{\Longrightarrow}
-  \Gamma_j(X_j)\in\mathcal K_{N,L}(A_j)
-  \qquad (1\le j\le b),
+  \forall\,1\le j\le b,\quad
+  \Gamma_j(X_j)\in\mathcal K_{N,L}(A_j),
   \notag\\
+  \forall\,1\le j\le b,\quad
   \Gamma_j(X_j)\in\mathcal K_{N,L}(A_j)
   &\Longrightarrow
-  \exists (c_j)_{j=1}^b,\quad
+  \exists (c_j)_{j=1}^b,
+  \notag\\
+  &\hphantom{\Longrightarrow}
+  \forall\,1\le j\le b,\quad
   \Gamma_j(X_j)=c_j V_j
-  \qquad (1\le j\le b).
+  .
 \end{align}
 Consequently,
 \begin{align}


### PR DESCRIPTION
## Summary
- make the blockwise uniqueness step in the block-diagonal parent-Hamiltonian note explicitly quantified
- replace the remaining free block index in the proof-path display by `\forall\,1\le j\le b`

This addresses the unresolved post-merge review thread on #2345 about quantifying the blockwise uniqueness step.

## Verification
- `git diff --check`
- `rg -n "leanid|texttt|thm:|parentHamiltonianGroundSpace|bntSpan|declaration|v2''|v2'" docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex || true`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv21_block_diagonal_parent_ground_space.tex && ! grep -n "Overfull \\hbox" cpgsv21_block_diagonal_parent_ground_space.log` from `docs/paper-gaps`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX presentation changes only; no Lean, runtime, or security impact.
> 
> **Overview**
> The block-diagonal parent ground-space note now states the periodic-chain proof obligations with **explicit universal quantification** over blocks (`\forall\,1\le j\le b`) instead of parenthetical `(1\le j\le b)` side conditions.
> 
> The displayed implication chain is reformatted so membership in `\mathcal K_{N,L}(A_j)`, existence of `(c_j)`, and `\Gamma_j(X_j)=c_j V_j` are each labeled as holding for every block index, including a separate line for `\exists (c_j)_{j=1}^b` before the uniqueness conclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172b835293809e0c6498867b0cb7f38eeb56a90e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->