### PR TITLE
doc(blueprint): sync Erickson status notes to exact-route FT completion

### DIFF
--- a/blueprint/comments202605/STATUS_erickson_items_20260530.md
+++ b/blueprint/comments202605/STATUS_erickson_items_20260530.md
@@ -19,21 +19,25 @@ Superseded documents:
 |---|---|---|---|
 | 1 | The FT proof should be a per-block existence argument plus injectivity from BNT **minimality**, not a peel-induction needing **combined-family** linear independence. | **Resolved.** `bijective_match_of_sameMPV` routes forward/backward injectivity through `basis_distinct` (minimality), and `combined_family_eventually_li` is used only for coefficient isolation, not a shrinking-pair recursion. | `SectorBNT/StrongMatch.lean`, `SectorBNT/Api.lean` |
 | 2 | The one-copy surface (one weight per sector, strict modulus ordering) is weaker than the paper's multi-copy BNT sector with power-sum coefficients $c_N^{(j)}=\sum_q \mu_{j,q}^N$. | **Resolved.** The one-copy `IsCanonicalFormBNT` (with `mu_strict_anti`) is retired; the current `SectorDecomposition` carries the raw power-sum coefficient. Equal-modulus copies ($C\oplus(-C)$) and unequal ($C\oplus\tfrac12 C$) are both represented. | `SharedInfra/SectorDecomposition.lean`, `SectorBNT/Api.lean` (`coeff_eq_sum_weight_pow`) |
-| 3 | The dominant-block projection argument fails for non-dominant blocks (both sides decay to $0=0$); use combined-family linear independence + exact coefficient comparison instead. | **Resolved.** The projection route is abandoned. The blueprint states it explicitly: "No projection-limit argument for non-dominant sectors is used." Non-decay comes from the Cesàro lemma. | ch11 intro; `SectorBNT/CesaroNonDecay.lean` (`sum_pow_not_tendsto_zero_of_unit_modulus`) |
+| 3 | The dominant-block projection argument fails for non-dominant blocks (both sides decay to $0=0$); use combined-family linear independence + exact coefficient comparison instead. | **Resolved.** The projection route is abandoned. The blueprint states it explicitly: "No projection-limit argument for non-dominant sectors is used." Non-decay is supplied by `coeff_not_eventually_zero` (BNT linear independence; no modulus assumption), replacing the former Cesàro lemma. `SectorBNT/CesaroNonDecay.lean` was deleted in the exact-route cleanup (PR #2257). | ch11 intro; `SectorBNT/ExactMatch.lean` |
 | 4 | The ~530-line Plan-A workaround (dominant-adjusted scalar, `finOne` base cases, discrete-rate $\delta_N$ upgrade) was wasted effort; N=0 / zero-tail handling consumed disproportionate effort. | **Resolved.** Plan-A deleted (the `Full/` directory is empty). Residual N=0 / zero-tail bloat cleaned: `SameMPV₂Pos` threaded through the after-blocking chain and the dead zero-tail/common-flat sub-chain removed. | PRs #2153, #2159; commit `1e63d981c` |
-| 5 | Vandermonde non-decay of $\sum_q \mu_q^N$ needed a Lean realization. | **Resolved.** Provided by the Cesàro non-decay lemma for unit-modulus sums. | `SectorBNT/CesaroNonDecay.lean` |
+| 5 | Vandermonde non-decay of $\sum_q \mu_q^N$ needed a Lean realization. | **Resolved (differently).** The Cesàro non-decay lemma (`sum_pow_not_tendsto_zero_of_unit_modulus`) was written and used in the asymptotic route, but both that lemma and the asymptotic route were retired when the exact matcher was adopted. Non-decay is now supplied by `coeff_not_eventually_zero` with no modulus assumption; `SectorBNT/CesaroNonDecay.lean` was deleted in PR #2257. | `SectorBNT/Basic.lean` (`coeff_not_eventually_zero`) |
 | 6 | The matching/equal-MPV theorems carry a **per-sector** unit-modulus hypothesis stronger than CPSV16's single **global** witness (line 246). | **Documented.** Recorded as a scope restriction with an elimination plan; the affected declarations are listed. | `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex` (commit `4605b9381`) |
 | 7 | Lemma A.2's $X^\dagger X = c\,\Id$ rescaling is elided in the source ("$=\mathbf 1$"); the Lean should carry the $c\,\Id$ fixed-point conclusion and rescale at the end. | **Needs confirmation (minor).** The gauge-phase extraction lives in the irreducible/primitive fixed-point modules; confirm it carries the scalar-fixed-point conclusion rather than assuming $X^\dagger X=\Id$. Not a blueprint defect. | `MPS/Irreducible/`, `SectorBNT/Supplier.lean` |
-| 8 | The proportional ($c_N\neq1$) FT still needs the matched-coefficient identity $c_N^{(\beta(k))}(P)=\zeta_k^N c_N^{(k)}(Q)$ **derived**, not assumed. | **Open — active work.** The source theorems (Cor II.1, Cor II.2) are honestly `\notready`; the conditional theorems take the identity as a hypothesis. Tracked by **issue #1749**. | `SectorBNT/Fundamental.lean`, `SectorBNT/CoeffIdentity.lean` |
+| 8 | The proportional ($c_N\neq1$) FT still needs the matched-coefficient identity $c_N^{(\beta(k))}(P)=\zeta_k^N c_N^{(k)}(Q)$ **derived**, not assumed. | **Resolved (PR #2254).** `MPSTensor.fundamentalTheorem_proportional_canonicalForm` is proved with no per-sector unit-modulus hypothesis and no coefficient-limit / Cesàro route. The mechanism is the exact fixed-length matcher (`exists_block_match_exact_of_eventuallyProportional`): the proportionality scalar $c_N$ rescales only the aggregate $Q$-side coefficients, so the isolated $P$-coefficient is detected by `coeff_not_eventually_zero` without any per-sector modulus assumption. Blueprint `thm:cpgsv_multiblock_ft_source` (ch11) flipped to `\leanok`. | `SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_proportional_canonicalForm`) |
 
 ## Summary
 
 Erickson's substantive structural recommendations are **implemented**: the
 multi-copy sector decomposition (2), abandoning the non-dominant projection
-argument (3) in favour of combined-family linear independence and Cesàro
-non-decay (5), and the per-block-existence-plus-minimality matching structure
-(1). The N=0 / Plan-A waste (4) is cleaned. The per-sector-vs-global unit
-witness (6) is documented as a tracked scope restriction. The one remaining
-genuine gap is the proportional matched-coefficient identity (8), which is
-active work under issue #1749, with the source theorems honestly marked
-`\notready`.
+argument (3) in favour of combined-family linear independence and exact
+coefficient comparison via `coeff_not_eventually_zero` (5), and the
+per-block-existence-plus-minimality matching structure (1). The N=0 / Plan-A
+waste (4) is cleaned. The per-sector-vs-global unit witness (6) is now fully
+resolved: the exact matcher requires no per-sector unit-modulus hypothesis;
+see `cpsv16_global_vs_persector_unit_witness.tex` for the current declaration
+path. Item (8), the proportional matched-coefficient identity, is also
+resolved: `MPSTensor.fundamentalTheorem_proportional_canonicalForm` is proved
+without the per-sector or coefficient-limit assumptions (PR #2254). Both
+headline CPSV16 results (Theorem II.1 and Corollary II.2) are now `\leanok`
+in the blueprint.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -16,8 +16,8 @@ equal-modulus comparison has these current reference points.
   linear-independence matcher. It is now a closure record, not a live
   restriction.
 - `blueprint/src/chapter/ch11_fundamental_theorem_proof.tex` records only how
-  the Chapter 10 comparison is used in the equal-MPV Fundamental Theorem
-  argument.
+  the Chapter 10 comparison is used in the equal-MPV and proportional-MPV
+  Fundamental Theorem arguments.
 - GitHub issue #2150 records the verification request. The outcome now
   recorded in the paper-gap note is that neither a strictly-decreasing-moduli
   hypothesis nor a per-sector unit-witness hypothesis survives in the SectorBNT


### PR DESCRIPTION
## Summary

Main's `blueprint/comments202605/STATUS_erickson_items_20260530.md` was stale: it still cited the **deleted** `SectorBNT/CesaroNonDecay.lean` (`sum_pow_not_tendsto_zero_of_unit_modulus`) for items 3 and 5, and marked item 8 (proportional matched-coefficient identity) as "Open — active work." This syncs the note to the current state of `main`.

- **Items 3, 5:** non-decay is now supplied by `coeff_not_eventually_zero` (`SectorBNT/Basic.lean`, `ExactMatch.lean`), no modulus assumption. `CesaroNonDecay.lean` was deleted in the exact-route cleanup (#2257).
- **Item 8:** `MPSTensor.fundamentalTheorem_proportional_canonicalForm` (`SectorBNT/FundamentalCoord.lean`) is proved with no per-sector unit-modulus and no coefficient-limit hypothesis (#2254); blueprint `thm:cpgsv_multiblock_ft_source` is `\\leanok`.
- **paper-gaps/README:** ch11 now records the Chapter-10 comparison's use in **both** the equal-MPV and proportional-MPV FT arguments.

## Verification

Every path/lemma cited in the updated note was confirmed against current `main`: `CesaroNonDecay.lean` absent; `coeff_not_eventually_zero` in `Basic.lean`/`ExactMatch.lean`; `fundamentalTheorem_proportional_canonicalForm` present, no `sorry`; `thm:cpgsv_multiblock_ft_source` `\\leanok` and bound to that declaration.

Doc-only change. Supersedes #2263 (which was 177 commits behind `main`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only updates to status and README; no Lean or runtime behavior changes.
> 
> **Overview**
> Updates **documentation only** so Erickson review status and paper-gap pointers match the exact-route Fundamental Theorem work on `main`.
> 
> **`STATUS_erickson_items_20260530.md`** now says non-dominant sectors use **`coeff_not_eventually_zero`** / **`ExactMatch.lean`**, not the removed Cesàro path and **`SectorBNT/CesaroNonDecay.lean`** (PR #2257). Item **8** is **resolved** via **`MPSTensor.fundamentalTheorem_proportional_canonicalForm`** (PR #2254); the closing summary drops the “one remaining gap” framing and notes both headline CPSV16 blueprint results are **`\leanok`**, with item **(6)** described as fully resolved on the exact matcher path.
> 
> **`docs/paper-gaps/README.md`** clarifies that **ch11** documents Chapter 10’s role in **equal-MPV and proportional-MPV** FT arguments, not equal-MPV alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 567ff5ddb7eabdc57d639049ecb8f591250c36b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->