### PR TITLE
feat(periodic): realign the overlap dichotomy to arXiv:1708.00029 and prove it modulo three leaf lemmas (7→4 sorrys)

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -159,21 +159,21 @@ decays to zero.
 
 Source: arXiv:1708.00029, Appendix A, lines 917--950. There the different-period
 decay is obtained by blocking at `p = lcm(m_a, m_b)` and using that, by
-`lem:bdcf`, the blocks `P_u A^{(p)}` and `Q_v B^{(p)}` are non-repeated normal
+Lemma bdcf, the blocks `P_u A^{(p)}` and `Q_v B^{(p)}` are non-repeated normal
 tensors, so that applying the one-site translation operator to `Q_v B^{(p)}`
 versus `Q_{v+1} B^{(p)}` yields a contradiction unless the overlap vanishes.
 
-**Local fix (different-period decay via peripheral spectrum):** the Lean proof
-realizes the *same* obstruction through the peripheral-spectrum form rather than
-the paper's lcm-blocking + translation argument. If `D₁ = D₂` and
-`B i = ζ X (A i) X⁻¹`, then `𝓔_B(Y) = ζ ζ̄ · X 𝓔_A(X⁻¹ Y X⁻ᴴ) Xᴴ`; eigenvalue
-uniqueness for an irreducible CP map (Wolf, *Quantum Channels & Operations*,
-Thm 6.3) forces `|ζ| = 1`, so the peripheral spectra of `𝓔_A` and `𝓔_B` agree.
-An `m`-periodic tensor has peripheral spectrum `{e^{2πi r/m} : 0 ≤ r < m}`, so
-agreement forces `m_a = m_b`; hence different periods exclude gauge-phase
-equivalence, and `equal-or-orthogonal` (the irreducible trace-preserving overlap
-dichotomy) gives the decay. This is a mathematically equivalent substitute for
-the paper's step, documented in
+**Route substitution (different-period decay via peripheral spectrum):** the Lean
+proof realizes the *same* obstruction through the peripheral-spectrum form rather
+than the paper's lcm-blocking + translation argument. If `D₁ = D₂` and
+B i = ζ X (A i) X⁻¹, then
+𝓔_B(Y) = ζ ζ̄ · X 𝓔_A(X⁻¹ Y X⁻ᴴ) Xᴴ. Eigenvalue uniqueness for an irreducible CP
+map (Wolf, *Quantum Channels & Operations*, Thm 6.3) forces |ζ| = 1, so the
+peripheral spectra of 𝓔_A and 𝓔_B agree. An `m`-periodic tensor has peripheral
+spectrum {e^{2πi r/m} : 0 ≤ r < m}, so agreement forces `m_a = m_b`; hence
+different periods exclude gauge-phase equivalence, and equal-or-orthogonal (the
+irreducible trace-preserving overlap dichotomy) gives the decay. This is a
+mathematically equivalent substitute for the paper's step, documented in
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 theorem periodicOverlap_tendsto_zero_of_ne_period
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]

--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -158,19 +158,19 @@ private theorem period_eq_of_gaugePhaseEquiv_of_isPeriodic
 decays to zero.
 
 Source: arXiv:1708.00029, Appendix A, lines 917--950. There the different-period
-decay is obtained by blocking at `p = lcm(m_a, m_b)` and using that, by
-Lemma bdcf, the blocks `P_u A^{(p)}` and `Q_v B^{(p)}` are non-repeated normal
-tensors, so that applying the one-site translation operator to `Q_v B^{(p)}`
-versus `Q_{v+1} B^{(p)}` yields a contradiction unless the overlap vanishes.
+decay is obtained by blocking at p = lcm(m_a, m_b) and using that, by
+Lemma bdcf, the blocks P_u A^{(p)} and Q_v B^{(p)} are non-repeated normal
+tensors, so that applying the one-site translation operator to Q_v B^{(p)}
+versus Q_{v+1} B^{(p)} yields a contradiction unless the overlap vanishes.
 
 **Route substitution (different-period decay via peripheral spectrum):** the Lean
 proof realizes the *same* obstruction through the peripheral-spectrum form rather
-than the paper's lcm-blocking + translation argument. If `D₁ = D₂` and
+than the paper's lcm-blocking + translation argument. If D₁ = D₂ and
 B i = ζ X (A i) X⁻¹, then
 𝓔_B(Y) = ζ ζ̄ · X 𝓔_A(X⁻¹ Y X⁻ᴴ) Xᴴ. Eigenvalue uniqueness for an irreducible CP
 map (Wolf, *Quantum Channels & Operations*, Thm 6.3) forces |ζ| = 1, so the
 peripheral spectra of 𝓔_A and 𝓔_B agree. An `m`-periodic tensor has peripheral
-spectrum {e^{2πi r/m} : 0 ≤ r < m}, so agreement forces `m_a = m_b`; hence
+spectrum {e^{2πi r/m} : 0 ≤ r < m}, so agreement forces m_a = m_b; hence
 different periods exclude gauge-phase equivalence, and equal-or-orthogonal (the
 irreducible trace-preserving overlap dichotomy) gives the decay. This is a
 mathematically equivalent substitute for the paper's step, documented in

--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -157,15 +157,24 @@ private theorem period_eq_of_gaugePhaseEquiv_of_isPeriodic
 /-- If two periodic tensors have different periods `m_a ≠ m_b`, their overlap
 decays to zero.
 
-Source: arXiv:1708.00029, Appendix A, lines 917--950.
-The local proof uses the Perron--Frobenius spectral form of the same obstruction:
-if $D_1=D_2$ and $B_i=\zeta X A_iX^{-1}$, then
-$\E_B(Y)=\zeta\overline{\zeta}\,X\E_A(X^{-1}YX^{-*})X^*$. Wolf Theorem 6.3
-forces $|\zeta|=1$, so the peripheral spectra of $\E_A$ and $\E_B$ agree. Since
-an $m$-periodic tensor has peripheral spectrum
-$\{e^{2\pi i r/m}:0\le r<m\}$, the periods would be equal. Thus different periods
-exclude gauge-phase equivalence, and the irreducible trace-preserving overlap
-dichotomy gives the decay. -/
+Source: arXiv:1708.00029, Appendix A, lines 917--950. There the different-period
+decay is obtained by blocking at `p = lcm(m_a, m_b)` and using that, by
+`lem:bdcf`, the blocks `P_u A^{(p)}` and `Q_v B^{(p)}` are non-repeated normal
+tensors, so that applying the one-site translation operator to `Q_v B^{(p)}`
+versus `Q_{v+1} B^{(p)}` yields a contradiction unless the overlap vanishes.
+
+**Local fix (different-period decay via peripheral spectrum):** the Lean proof
+realizes the *same* obstruction through the peripheral-spectrum form rather than
+the paper's lcm-blocking + translation argument. If `D₁ = D₂` and
+`B i = ζ X (A i) X⁻¹`, then `𝓔_B(Y) = ζ ζ̄ · X 𝓔_A(X⁻¹ Y X⁻ᴴ) Xᴴ`; eigenvalue
+uniqueness for an irreducible CP map (Wolf, *Quantum Channels & Operations*,
+Thm 6.3) forces `|ζ| = 1`, so the peripheral spectra of `𝓔_A` and `𝓔_B` agree.
+An `m`-periodic tensor has peripheral spectrum `{e^{2πi r/m} : 0 ≤ r < m}`, so
+agreement forces `m_a = m_b`; hence different periods exclude gauge-phase
+equivalence, and `equal-or-orthogonal` (the irreducible trace-preserving overlap
+dichotomy) gives the decay. This is a mathematically equivalent substitute for
+the paper's step, documented in
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 theorem periodicOverlap_tendsto_zero_of_ne_period
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -163,7 +163,7 @@ Lemma bdcf, the blocks P_u A^{(p)} and Q_v B^{(p)} are non-repeated normal
 tensors, so that applying the one-site translation operator to Q_v B^{(p)}
 versus Q_{v+1} B^{(p)} yields a contradiction unless the overlap vanishes.
 
-**Route substitution (different-period decay via peripheral spectrum):** the Lean
+**Different-period decay via the peripheral spectrum:** the Lean
 proof realizes the *same* obstruction through the peripheral-spectrum form rather
 than the paper's lcm-blocking + translation argument. If D₁ = D₂ and
 B i = ζ X (A i) X⁻¹, then
@@ -174,7 +174,7 @@ spectrum {e^{2πi r/m} : 0 ≤ r < m}, so agreement forces m_a = m_b; hence
 different periods exclude gauge-phase equivalence, and equal-or-orthogonal (the
 irreducible trace-preserving overlap dichotomy) gives the decay. This is a
 mathematically equivalent substitute for the paper's step, documented in
-`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
+docs/paper-gaps/1708_periodic_overlap_route_alignment.tex. -/
 theorem periodicOverlap_tendsto_zero_of_ne_period
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -90,13 +90,13 @@ P_{ũ+l} A^{(m)} = e^{iλ} U_{ṽ+l} Q_{ṽ+l} B^{(m)} U_{ṽ+l}†
 1007), which is the
 one-step transport (u, v) → (u+1, v+1) stated here.
 
-**Formalization route (to be discharged).** Rather than translate the global
+**Corner transition tensors (remaining step).** Rather than translate the global
 equation, the cyclic-sector construction can expose one-site corner transition
 tensors — the compressions `P k · A i · P (k+1)` and `Q l · B i · Q (l+1)` — and
 identify their `m`-fold cyclic products with the supplied `blocksA k`/`blocksB l`,
 so that the match transports along these transitions. This is a formalization of
 the same step via the `IsCyclicSectorDecomp` relation 𝓔_A^{*}(P_{k+1}) = P_k; see
-`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
+docs/paper-gaps/1708_periodic_overlap_route_alignment.tex. -/
 private lemma sectorGaugePhaseEquiv_succ_of_cyclicTransport
     [NeZero D]
     (A B : MPSTensor d D)
@@ -357,7 +357,7 @@ proportionality theorem `tensor_proportional` in `MPS/Chain/TensorEquality.lean`
 The remaining mathematical input is the `m`-factor cyclic contraction *together
 with* the κ/θ/φ phase assembly that passes from `hBlockMatch` to a global
 `RepeatedBlocks` witness. See
-`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
+docs/paper-gaps/1708_periodic_overlap_route_alignment.tex. -/
 private lemma repeatedBlocks_of_blockedSectorGaugePhase
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -211,6 +211,26 @@ private lemma gaugePhaseEquiv_cast_indices {d gA gB : ℕ}
   subst hj
   exact hg
 
+/-- **Cyclic induction on `Fin m`.** A predicate that holds at `0` and is closed
+under `· + 1` holds at every index, because `+1` generates the cyclic group from
+`0`. Proved by induction on `i.val`: the predecessor of a nonzero `i` is
+`⟨i.val - 1, _⟩`, whose successor is `i`. -/
+private lemma fin_cyclic_induction {m : ℕ} [NeZero m] {P : Fin m → Prop}
+    (h0 : P 0) (hstep : ∀ i : Fin m, P i → P (i + 1)) (i : Fin m) : P i := by
+  induction hi : i.val generalizing i with
+  | zero => obtain rfl : i = 0 := Fin.ext (by simpa using hi); exact h0
+  | succ k ih =>
+    have hk : k < m := by have := i.isLt; omega
+    have e : (⟨k, hk⟩ : Fin m) + 1 = i := by
+      apply Fin.ext
+      have hone : (1 : Fin m).val = 1 := by
+        have : (1 : Fin m).val = 1 % m := Fin.val_one' m
+        rw [this]; exact Nat.mod_eq_of_lt (by omega)
+      rw [Fin.val_add, Fin.val_mk, hone, hi]
+      exact Nat.mod_eq_of_lt (by have := i.isLt; omega)
+    rw [← e]
+    exact hstep _ (ih ⟨k, hk⟩ rfl)
+
 /-- **Translation propagation** (`eq:blockedABprop`, arXiv:1708.00029 lines
 998--1008):
 Given one matching compressed sector pair at `(u₀, v₀)`, applying the
@@ -273,13 +293,39 @@ lemma sectorMatch_propagation
             (MPSTensor (blockPhysDim d m)) hdim)
             (blocksA (u₀ + l)))
           (blocksB (v₀ + l)) := by
-  -- PROOF STRUCTURE: iterate the one-step transport
-  -- `sectorMatch_succ_of_cyclicSectorDecomp` (which carries nondegeneracy forward)
-  -- around the cycle `l = 0, …, m-1` (the translation-operator family of
-  -- arXiv:1708.00029 lines 985--1002). This is a cyclic induction over `Fin m`
-  -- with `(u₀ + l, v₀ + l)` as the running pair; the remaining one-step obligation
+  -- Iterate the one-step transport `sectorMatch_succ_of_cyclicSectorDecomp` (which
+  -- carries nondegeneracy forward) around the cycle by cyclic induction over
+  -- `Fin m`, with `(u₀ + l, v₀ + l)` as the running pair (the translation-operator
+  -- family of arXiv:1708.00029 lines 985--1002). The remaining one-step obligation
   -- is `sectorGaugePhaseEquiv_succ_of_cyclicTransport`.
-  sorry
+  have key : ∀ l : Fin m, ∃ (hdim : dimA (u₀ + l) = dimB (v₀ + l)),
+      dimA (u₀ + l) ≠ 0 ∧
+      GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim) (blocksA (u₀ + l)))
+        (blocksB (v₀ + l)) := by
+    intro l
+    refine fin_cyclic_induction
+      (P := fun l => ∃ (hdim : dimA (u₀ + l) = dimB (v₀ + l)),
+        dimA (u₀ + l) ≠ 0 ∧
+        GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim) (blocksA (u₀ + l)))
+          (blocksB (v₀ + l))) ?_ ?_ l
+    · exact ⟨(add_zero u₀).symm ▸ (add_zero v₀).symm ▸ hdim₀,
+        (add_zero u₀).symm ▸ hNondeg,
+        gaugePhaseEquiv_cast_indices blocksA blocksB
+          (add_zero u₀).symm (add_zero v₀).symm hdim₀ hMatch⟩
+    · intro j hj
+      obtain ⟨hdimj, hnzj, hgj⟩ := hj
+      obtain ⟨hdim', hnz', hg'⟩ :=
+        sectorMatch_succ_of_cyclicSectorDecomp A B hA_lc hB_lc blocksA blocksB
+          hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic hdimj hnzj hgj
+      have eA : (u₀ + j) + 1 = u₀ + (j + 1) := by abel
+      have eB : (v₀ + j) + 1 = v₀ + (j + 1) := by abel
+      exact ⟨eA ▸ eB ▸ hdim', eA ▸ hnz',
+        gaugePhaseEquiv_cast_indices blocksA blocksB eA eB hdim' hg'⟩
+  intro l
+  obtain ⟨hdim, _, hg⟩ := key l
+  exact ⟨hdim, hg⟩
 
 /-- Full-cycle contraction step for periodic-overlap Case 3.
 

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -86,9 +86,9 @@ are again normal tensors (Lemma bdcf), Theorem 2.10 of Cirac--Perez-Garcia 2017
 (thm:cf) yields, at each offset, a phase λ_{ṽ+l} and a unitary
 U_{ṽ+l} = P_{ũ+l} U_{ṽ+l} Q_{ṽ+l} with
 P_{ũ+l} A^{(m)} = e^{iλ} U_{ṽ+l} Q_{ṽ+l} B^{(m)} U_{ṽ+l}†
-(eq:blockedABprop). Hence the offset `v - u = q` is constant (eq:vprop, line
+(eq:blockedABprop). Hence the offset v - u = q is constant (eq:vprop, line
 1007), which is the
-one-step transport `(u, v) → (u+1, v+1)` stated here.
+one-step transport (u, v) → (u+1, v+1) stated here.
 
 **Formalization route (to be discharged).** Rather than translate the global
 equation, the cyclic-sector construction can expose one-site corner transition
@@ -146,7 +146,7 @@ private lemma sectorGaugePhaseEquiv_succ_of_cyclicTransport
 This is the formal one-step version of the propagation step in arXiv:1708.00029,
 Appendix A (lines 985--1002). The cyclic projection relation 𝓔_A^{*}(P_{k+1}) = P_k,
 together with the compressed-sector realization, transports a gauge-phase
-equivalence between sector pair `(u, v)` to one between `(u + 1, v + 1)`. The
+equivalence between sector pair (u, v) to one between (u + 1, v + 1). The
 conclusion also propagates nondegeneracy so the step can be iterated around the
 cycle. -/
 private lemma sectorMatch_succ_of_cyclicSectorDecomp
@@ -355,7 +355,7 @@ The available chain inputs are `decompositionMap` / `exists_rightInverse` in
 `MPS/Chain/OneSidedInverse.lean` (realizing Ω_u) and the two-site
 proportionality theorem `tensor_proportional` in `MPS/Chain/TensorEquality.lean`.
 The remaining mathematical input is the `m`-factor cyclic contraction *together
-with* the `κ`/`θ`/`φ` phase assembly that passes from `hBlockMatch` to a global
+with* the κ/θ/φ phase assembly that passes from `hBlockMatch` to a global
 `RepeatedBlocks` witness. See
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 private lemma repeatedBlocks_of_blockedSectorGaugePhase
@@ -394,7 +394,7 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
     RepeatedBlocks A B := by
   -- Remaining obligation (arXiv:1708.00029 lines 1023--1117): an `m`-factor cyclic
   -- contraction theorem built from `decompositionMap` (the Ω_u inverses) that,
-  -- together with the `κ`/`θ`/`φ` phase assembly (lines 1078--1117), upgrades the
+  -- together with the κ/θ/φ phase assembly (lines 1078--1117), upgrades the
   -- per-sector blocked gauge data in `hBlockMatch` to one global phase and one
   -- global gauge. The available two-site theorem is `tensor_proportional`.
   sorry
@@ -462,7 +462,7 @@ lemma sectorTensor_proportional_of_blockedMatch
 
 /-- **Case 3: a matching sector implies gauge equivalence**. If two periodic tensors have
 the same period and a compressed sector match exists, then they are related by a gauge
-transformation with a unit-modulus phase: `A^i = e^{iξ} U B^i U†`.
+transformation with a unit-modulus phase: A^i = e^{iξ} U B^i U†.
 
 The hypotheses describe compressed sector decompositions: `blocksA`/`blocksB` are
 the cyclic-sector tensors on corner bond spaces, tied back to the
@@ -476,7 +476,7 @@ follows from `hNondegA`), from which translation propagation extends the
 match to all sectors.
 
 This is the sector-match case of the appendix proof, arXiv:1708.00029 lines
-961--1117 (conclusion `A^i = e^{iξ} U B^i U†` at lines 1110--1117). -/
+961--1117 (conclusion A^i = e^{iξ} U B^i U† at lines 1110--1117). -/
 theorem periodicOverlap_gaugeEquiv_of_sector_match
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]
@@ -514,7 +514,7 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
   --      offset form `(u, u + q)` with `q = v₀ - u₀`;
   --   2. `sectorBlocked_isNormal_of_isPeriodic` (PROVED): each sector is normal;
   --   3. `sectorTensor_proportional_of_blockedMatch`: contract the matched blocks
-  --      to a global gauge with the `κ`/`θ`/`φ` phase assembly (lines 1023--1117).
+  --      to a global gauge with the κ/θ/φ phase assembly (lines 1023--1117).
   -- The remaining obligations are now exactly the stage-1 sorry
   -- `sectorGaugePhaseEquiv_succ_of_cyclicTransport` and the stage-3 sorry
   -- `repeatedBlocks_of_blockedSectorGaugePhase`.

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -225,9 +225,10 @@ private lemma fin_cyclic_induction {m : ℕ} [NeZero m] {P : Fin m → Prop}
     have hk : k < m := by have := i.isLt; omega
     have e : (⟨k, hk⟩ : Fin m) + 1 = i := by
       apply Fin.ext
+      have hmod_one : 1 < m := by omega
       have hone : (1 : Fin m).val = 1 := by
         have : (1 : Fin m).val = 1 % m := Fin.val_one' m
-        rw [this]; exact Nat.mod_eq_of_lt (by omega)
+        rw [this]; exact Nat.mod_eq_of_lt hmod_one
       rw [Fin.val_add, Fin.val_mk, hone, hi]
       exact Nat.mod_eq_of_lt (by have := i.isLt; omega)
     rw [← e]
@@ -340,7 +341,7 @@ Appendix A lines 1023--1117:
 * For each sector `u`, Lemma bdcf normality gives a repetition length `N₀` after
   which the blocked product F_u (eq:Fu, lines 1026--1030) is injective, with a
   right inverse Ω_u (eq:Omegauprop, lines 1035--1040).
-* Concatenating and applying the `Ω_u` inverses contracts the repeated products to
+* Concatenating and applying the Ω_u inverses contracts the repeated products to
   per-site proportionality A_u^i = κ_v · e^{iη/m} · B_v^i (eq:resultprop/
   eq:thetaACprop, lines 1063--1076).
 * The phase bookkeeping is load-bearing: ∏_v κ_v = 1 (eq:prodkappaprop, line
@@ -351,7 +352,7 @@ Appendix A lines 1023--1117:
   (eq:result and lines 1110--1117), giving A^i = e^{iξ} U B^i U†.
 
 The available chain inputs are `decompositionMap` / `exists_rightInverse` in
-`MPS/Chain/OneSidedInverse.lean` (realizing `Ω_u`) and the two-site
+`MPS/Chain/OneSidedInverse.lean` (realizing Ω_u) and the two-site
 proportionality theorem `tensor_proportional` in `MPS/Chain/TensorEquality.lean`.
 The remaining mathematical input is the `m`-factor cyclic contraction *together
 with* the `κ`/`θ`/`φ` phase assembly that passes from `hBlockMatch` to a global
@@ -392,7 +393,7 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
     (hNormal : ∀ u, IsNormal (blocksA u)) :
     RepeatedBlocks A B := by
   -- Remaining obligation (arXiv:1708.00029 lines 1023--1117): an `m`-factor cyclic
-  -- contraction theorem built from `decompositionMap` (the `Ω_u` inverses) that,
+  -- contraction theorem built from `decompositionMap` (the Ω_u inverses) that,
   -- together with the `κ`/`θ`/`φ` phase assembly (lines 1078--1117), upgrades the
   -- per-sector blocked gauge data in `hBlockMatch` to one global phase and one
   -- global gauge. The available two-site theorem is `tensor_proportional`.

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -77,15 +77,17 @@ private lemma sectorDim_ne_zero_succ_of_cyclicSectorDecomp
 /-- One-step cyclic gauge-transport of a sector match.
 
 This is the one-step form of the propagation step in arXiv:1708.00029, Appendix A
-(lines 985--1002, equation `eq:blockedABprop`).
+(lines 985--1002, equation eq:blockedABprop).
 
-**Paper's argument.** Starting from the blocked sector-match equation `eq:Nm`
-(lines 978--984), the paper applies the translation operator `T^l`
-(`l = 1, …, m-1`) to *both sides*; since `P_{ũ+l} A^{(m)}` and `Q_{ṽ+l} B^{(m)}`
-are again normal tensors (`lem:bdcf`), Theorem 2.10 of `Ci15` (`thm:cf`) yields, at
-each offset, a phase `λ_{ṽ+l}` and a unitary `U_{ṽ+l} = P_{ũ+l} U_{ṽ+l} Q_{ṽ+l}`
-with `P_{ũ+l} A^{(m)} = e^{iλ} U_{ṽ+l} Q_{ṽ+l} B^{(m)} U_{ṽ+l}†` (`eq:blockedABprop`).
-Hence the offset `v - u = q` is constant (`eq:vprop`, line 1007), which is the
+**Paper's argument.** Starting from the blocked sector-match equation eq:Nm
+(lines 978--984), the paper applies the translation operator T^l
+(l = 1, …, m-1) to *both sides*; since P_{ũ+l} A^{(m)} and Q_{ṽ+l} B^{(m)}
+are again normal tensors (Lemma bdcf), Theorem 2.10 of Cirac--Perez-Garcia 2017
+(thm:cf) yields, at each offset, a phase λ_{ṽ+l} and a unitary
+U_{ṽ+l} = P_{ũ+l} U_{ṽ+l} Q_{ṽ+l} with
+P_{ũ+l} A^{(m)} = e^{iλ} U_{ṽ+l} Q_{ṽ+l} B^{(m)} U_{ṽ+l}†
+(eq:blockedABprop). Hence the offset `v - u = q` is constant (eq:vprop, line
+1007), which is the
 one-step transport `(u, v) → (u+1, v+1)` stated here.
 
 **Formalization route (to be discharged).** Rather than translate the global
@@ -93,7 +95,7 @@ equation, the cyclic-sector construction can expose one-site corner transition
 tensors — the compressions `P k · A i · P (k+1)` and `Q l · B i · Q (l+1)` — and
 identify their `m`-fold cyclic products with the supplied `blocksA k`/`blocksB l`,
 so that the match transports along these transitions. This is a formalization of
-the same step via the `IsCyclicSectorDecomp` shift `𝓔_A^{*}(P_{k+1}) = P_k`; see
+the same step via the `IsCyclicSectorDecomp` relation 𝓔_A^{*}(P_{k+1}) = P_k; see
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 private lemma sectorGaugePhaseEquiv_succ_of_cyclicTransport
     [NeZero D]
@@ -134,7 +136,7 @@ private lemma sectorGaugePhaseEquiv_succ_of_cyclicTransport
           (blocksA (u + 1)))
         (blocksB (v + 1)) := by
   -- Remaining obligation (arXiv:1708.00029 lines 985--1002): realize the
-  -- translation-operator + `thm:cf` step as one-site cyclic transition tensors,
+  -- translation-operator + thm:cf step as one-site cyclic transition tensors,
   -- identified with the compressed blocked sector tensors produced by
   -- `exists_compressedTensor_of_supported_projection`.
   sorry
@@ -142,7 +144,7 @@ private lemma sectorGaugePhaseEquiv_succ_of_cyclicTransport
 /-- One-step cyclic transport statement for sector matches.
 
 This is the formal one-step version of the propagation step in arXiv:1708.00029,
-Appendix A (lines 985--1002). The cyclic projection relation `𝓔_A^{*}(P_{k+1}) = P_k`,
+Appendix A (lines 985--1002). The cyclic projection relation 𝓔_A^{*}(P_{k+1}) = P_k,
 together with the compressed-sector realization, transports a gauge-phase
 equivalence between sector pair `(u, v)` to one between `(u + 1, v + 1)`. The
 conclusion also propagates nondegeneracy so the step can be iterated around the
@@ -231,14 +233,14 @@ private lemma fin_cyclic_induction {m : ℕ} [NeZero m] {P : Fin m → Prop}
     rw [← e]
     exact hstep _ (ih ⟨k, hk⟩ rfl)
 
-/-- **Translation propagation** (`eq:blockedABprop`, arXiv:1708.00029 lines
+/-- **Translation propagation** (eq:blockedABprop, arXiv:1708.00029 lines
 998--1008):
 Given one matching compressed sector pair at `(u₀, v₀)`, applying the
-translation operator `T^l` for `l = 1, …, m-1` yields matching for all
+translation operator T^l for l = 1, …, m-1 yields matching for all
 sector pairs `(u₀ + l, v₀ + l)`. Each offset `l` gets its own gauge
-(`eq:blockedABprop` produces a different unitary `U_{ṽ+l}` at each sector,
-not a single transported gauge); the offset `v − u = q` is constant
-(`eq:vprop`, line 1007).
+(eq:blockedABprop produces a different unitary U_{ṽ+l} at each sector, not a
+single transported gauge); the offset v − u = q is constant (eq:vprop, line
+1007).
 
 The `hA_cyclic`/`hB_cyclic` hypotheses (see `IsCyclicSectorDecomp`)
 tie the `Fin m` block indexing to the cyclic orbit structure of the
@@ -331,22 +333,22 @@ lemma sectorMatch_propagation
 
 At this point the sector transport has already been abstracted into
 `hBlockMatch`, so the remaining gap is no longer the per-step
-`eq:blockedABprop` staircase identification (lines 985--1002). What is still
+eq:blockedABprop staircase identification (lines 985--1002). What is still
 needed is the contraction argument around the whole cycle, arXiv:1708.00029,
 Appendix A lines 1023--1117:
 
-* For each sector `u`, `lem:bdcf` normality gives a repetition length `N₀` after
-  which the blocked product `F_u` (`eq:Fu`, lines 1026--1030) is injective, with a
-  right inverse `Ω_u` (`eq:Omegauprop`, lines 1035--1040).
+* For each sector `u`, Lemma bdcf normality gives a repetition length `N₀` after
+  which the blocked product F_u (eq:Fu, lines 1026--1030) is injective, with a
+  right inverse Ω_u (eq:Omegauprop, lines 1035--1040).
 * Concatenating and applying the `Ω_u` inverses contracts the repeated products to
-  per-site proportionality `A_u^i = κ_v · e^{iη/m} · B_v^i` (`eq:resultprop`/
-  `eq:thetaACprop`, lines 1063--1076).
-* The phase bookkeeping is load-bearing: `∏_v κ_v = 1` (`eq:prodkappaprop`, line
-  1079) and `|κ_v| = 1` from `‖Σ_i A_u^{i†} A_u^i‖ = 1` (lines 1082--1084), so
-  `κ_v = e^{iθ_v}` with `Σ_v θ_v = 0`; choosing `φ_v` with `θ_v = φ_v − φ_{v+1}`
+  per-site proportionality A_u^i = κ_v · e^{iη/m} · B_v^i (eq:resultprop/
+  eq:thetaACprop, lines 1063--1076).
+* The phase bookkeeping is load-bearing: ∏_v κ_v = 1 (eq:prodkappaprop, line
+  1079) and |κ_v| = 1 from ‖Σ_i A_u^{i†} A_u^i‖ = 1 (lines 1082--1084), so
+  κ_v = e^{iθ_v} with Σ_v θ_v = 0; choosing φ_v with θ_v = φ_v − φ_{v+1}
   (lines 1093--1102) telescopes the per-sector phases into a single global phase
-  `ξ = η/m` and a single global unitary `U = Σ_u e^{iφ_{u+q}} P_u U_{u+q} Q_{u+q}`
-  (`eq:result` and lines 1110--1117), giving `A^i = e^{iξ} U B^i U†`.
+  ξ = η/m and a single global unitary U = Σ_u e^{iφ_{u+q}} P_u U_{u+q} Q_{u+q}
+  (eq:result and lines 1110--1117), giving A^i = e^{iξ} U B^i U†.
 
 The available chain inputs are `decompositionMap` / `exists_rightInverse` in
 `MPS/Chain/OneSidedInverse.lean` (realizing `Ω_u`) and the two-site
@@ -396,10 +398,10 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
   -- global gauge. The available two-site theorem is `tensor_proportional`.
   sorry
 
-/-- **Per-site proportionality** (`eq:thetaACprop`, arXiv:1708.00029 lines
+/-- **Per-site proportionality** (eq:thetaACprop, arXiv:1708.00029 lines
 1073--1076):
 After injectivity contraction, the sector-restricted tensors satisfy
-`A_u^i = κ_v · e^{iη/m} · B_v^i` with `∏ κ_v = 1` and `|κ_v| = 1`.
+A_u^i = κ_v · e^{iη/m} · B_v^i with ∏ κ_v = 1 and |κ_v| = 1.
 
 The offset `q` accounts for the cyclic shift between sector labelings of
 `A` and `B`: propagation from a match at `(u₀, v₀)` yields pairs
@@ -507,7 +509,7 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
     RepeatedBlocks A B := by
   -- APPENDIX TWO-STAGE STRUCTURE (arXiv:1708.00029 lines 961--1117):
   --   1. `sectorMatch_propagation`: iterate the single match around the cycle
-  --      (translation operator + `thm:cf`, lines 985--1008), reindexed to the
+  --      (translation operator + thm:cf, lines 985--1008), reindexed to the
   --      offset form `(u, u + q)` with `q = v₀ - u₀`;
   --   2. `sectorBlocked_isNormal_of_isPeriodic` (PROVED): each sector is normal;
   --   3. `sectorTensor_proportional_of_blockedMatch`: contract the matched blocks

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -273,10 +273,12 @@ lemma sectorMatch_propagation
             (MPSTensor (blockPhysDim d m)) hdim)
             (blocksA (u₀ + l)))
           (blocksB (v₀ + l)) := by
-  -- PROOF STRUCTURE: iterate `sectorMatch_succ_of_cyclicSectorDecomp` around the
-  -- cycle `l = 0, …, m-1` (the translation-operator family of arXiv:1708.00029
-  -- lines 985--1002). Currently sorry-backed pending discharge of the one-step
-  -- transport `sectorGaugePhaseEquiv_succ_of_cyclicTransport`.
+  -- PROOF STRUCTURE: iterate the one-step transport
+  -- `sectorMatch_succ_of_cyclicSectorDecomp` (which carries nondegeneracy forward)
+  -- around the cycle `l = 0, …, m-1` (the translation-operator family of
+  -- arXiv:1708.00029 lines 985--1002). This is a cyclic induction over `Fin m`
+  -- with `(u₀ + l, v₀ + l)` as the running pair; the remaining one-step obligation
+  -- is `sectorGaugePhaseEquiv_succ_of_cyclicTransport`.
   sorry
 
 /-- Full-cycle contraction step for periodic-overlap Case 3.
@@ -457,18 +459,39 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
           (blocksA u₀))
         (blocksB v₀)) :
     RepeatedBlocks A B := by
-  -- PLANNED ROUTE (appendix two-stage structure, arXiv:1708.00029):
-  --   1. `sectorMatch_propagation`: iterate the single match `hSomeMatch` around
-  --      the cycle (translation operator + `thm:cf`, lines 985--1008);
+  -- APPENDIX TWO-STAGE STRUCTURE (arXiv:1708.00029 lines 961--1117):
+  --   1. `sectorMatch_propagation`: iterate the single match around the cycle
+  --      (translation operator + `thm:cf`, lines 985--1008), reindexed to the
+  --      offset form `(u, u + q)` with `q = v₀ - u₀`;
   --   2. `sectorBlocked_isNormal_of_isPeriodic` (PROVED): each sector is normal;
   --   3. `sectorTensor_proportional_of_blockedMatch`: contract the matched blocks
   --      to a global gauge with the `κ`/`θ`/`φ` phase assembly (lines 1023--1117).
-  -- This body is currently `sorry` and does NOT yet invoke those lemmas; wiring it
-  -- through stages 1–3 is the next step. The transitive obligations are the
-  -- Case-3 sorrys `sectorGaugePhaseEquiv_succ_of_cyclicTransport` (stage 1) and
-  -- `repeatedBlocks_of_blockedSectorGaugePhase` (stage 3). (The corner-bridge
-  -- input `compressedTensor_adjointTransferMap_cornerBridge` is already PROVED.)
-  sorry
+  -- The remaining obligations are now exactly the stage-1 sorry
+  -- `sectorGaugePhaseEquiv_succ_of_cyclicTransport` and the stage-3 sorry
+  -- `repeatedBlocks_of_blockedSectorGaugePhase`.
+  classical
+  obtain ⟨u₀, v₀, hdim₀, hMatch⟩ := hSomeMatch
+  have hA_lc := hA.leftCanonical
+  have hB_lc := hB.leftCanonical
+  -- Stage 1: propagate the single match to every offset `l` around the cycle.
+  have hprop := sectorMatch_propagation A B hA_lc hB_lc blocksA blocksB
+    hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic
+    hdim₀ (hNondegA u₀) hMatch
+  -- Stage 2: each sector of `A` is a normal tensor.
+  have hNormal : ∀ u, IsNormal (blocksA u) := fun u =>
+    sectorBlocked_isNormal_of_isPeriodic A hA blocksA hA_blocks_lc hA_mpv hA_cyclic u
+      (hNondegA u)
+  -- Stage 3: contract the (reindexed) per-sector matches into a global gauge.
+  refine sectorTensor_proportional_of_blockedMatch A B hA_lc hB_lc blocksA blocksB
+    hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic (v₀ - u₀) ?_ hNondegA hNormal
+  -- Reindex `hprop` from the `(u₀ + l, v₀ + l)` form to the `(u, u + (v₀ - u₀))` form
+  -- by taking `l = u - u₀`, so `u₀ + l = u` and `v₀ + l = u + (v₀ - u₀)`.
+  intro u
+  have key := hprop (u - u₀)
+  have eA : u₀ + (u - u₀) = u := by abel
+  have eB : v₀ + (u - u₀) = u + (v₀ - u₀) := by abel
+  rw [eA, eB] at key
+  exact key
 
 /-- When `D₁ ≠ D₂`, no `RepeatedBlocks` relation can hold (the types don't
 match), so the overlap must decay. This covers the `D₁ ≠ D₂` subcase of

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -511,7 +511,7 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
   -- APPENDIX TWO-STAGE STRUCTURE (arXiv:1708.00029 lines 961--1117):
   --   1. `sectorMatch_propagation`: iterate the single match around the cycle
   --      (translation operator + thm:cf, lines 985--1008), reindexed to the
-  --      offset form `(u, u + q)` with `q = v₀ - u₀`;
+  --      offset form (u, u + q) with q = v₀ - u₀;
   --   2. `sectorBlocked_isNormal_of_isPeriodic` (PROVED): each sector is normal;
   --   3. `sectorTensor_proportional_of_blockedMatch`: contract the matched blocks
   --      to a global gauge with the κ/θ/φ phase assembly (lines 1023--1117).
@@ -533,8 +533,8 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
   -- Stage 3: contract the (reindexed) per-sector matches into a global gauge.
   refine sectorTensor_proportional_of_blockedMatch A B hA_lc hB_lc blocksA blocksB
     hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic (v₀ - u₀) ?_ hNondegA hNormal
-  -- Reindex `hprop` from the `(u₀ + l, v₀ + l)` form to the `(u, u + (v₀ - u₀))` form
-  -- by taking `l = u - u₀`, so `u₀ + l = u` and `v₀ + l = u + (v₀ - u₀)`.
+  -- Reindex `hprop` from the (u₀ + l, v₀ + l) form to the (u, u + (v₀ - u₀)) form
+  -- by taking l = u - u₀, so u₀ + l = u and v₀ + l = u + (v₀ - u₀).
   intro u
   have key := hprop (u - u₀)
   have eA : u₀ + (u - u₀) = u := by abel

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -74,17 +74,27 @@ private lemma sectorDim_ne_zero_succ_of_cyclicSectorDecomp
     exact Nat.cast_eq_zero.mp hcast
   exact hNondeg hdim_zero
 
-/-- Missing cyclic gauge-transport statement.
+/-- One-step cyclic gauge-transport of a sector match.
 
-This is the precise interface still needed for Equation A.8 of arXiv:1708.00029. From
-`IsCyclicSectorDecomp` one knows the projection shift `E†(P (k+1)) = P k` and the
-blocked trace realization of each compressed sector. To prove this statement, the
-cyclic-sector construction must additionally expose
-one-site corner transition tensors, for example the compressions of
-`P k * A i * P (k+1)` and `Q l * B i * Q (l+1)`, together with an identification
-of their `m`-fold cyclic products with the supplied `blocksA k` and `blocksB l`.
-Then a gauge-phase equivalence at `(u, v)` transports along those one-site
-transition tensors to a gauge-phase equivalence at `(u + 1, v + 1)`. -/
+This is the one-step form of the propagation step in arXiv:1708.00029, Appendix A
+(lines 985--1002, equation `eq:blockedABprop`).
+
+**Paper's argument.** Starting from the blocked sector-match equation `eq:Nm`
+(lines 978--984), the paper applies the translation operator `T^l`
+(`l = 1, …, m-1`) to *both sides*; since `P_{ũ+l} A^{(m)}` and `Q_{ṽ+l} B^{(m)}`
+are again normal tensors (`lem:bdcf`), Theorem 2.10 of `Ci15` (`thm:cf`) yields, at
+each offset, a phase `λ_{ṽ+l}` and a unitary `U_{ṽ+l} = P_{ũ+l} U_{ṽ+l} Q_{ṽ+l}`
+with `P_{ũ+l} A^{(m)} = e^{iλ} U_{ṽ+l} Q_{ṽ+l} B^{(m)} U_{ṽ+l}†` (`eq:blockedABprop`).
+Hence the offset `v - u = q` is constant (`eq:vprop`, line 1007), which is the
+one-step transport `(u, v) → (u+1, v+1)` stated here.
+
+**Formalization route (to be discharged).** Rather than translate the global
+equation, the cyclic-sector construction can expose one-site corner transition
+tensors — the compressions `P k · A i · P (k+1)` and `Q l · B i · Q (l+1)` — and
+identify their `m`-fold cyclic products with the supplied `blocksA k`/`blocksB l`,
+so that the match transports along these transitions. This is a formalization of
+the same step via the `IsCyclicSectorDecomp` shift `𝓔_A^{*}(P_{k+1}) = P_k`; see
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 private lemma sectorGaugePhaseEquiv_succ_of_cyclicTransport
     [NeZero D]
     (A B : MPSTensor d D)
@@ -123,18 +133,20 @@ private lemma sectorGaugePhaseEquiv_succ_of_cyclicTransport
           (MPSTensor (blockPhysDim d m)) hdim')
           (blocksA (u + 1)))
         (blocksB (v + 1)) := by
-  -- Missing step: one-site cyclic transition tensors and their identification
-  -- with the compressed blocked sector tensors produced by
+  -- Remaining obligation (arXiv:1708.00029 lines 985--1002): realize the
+  -- translation-operator + `thm:cf` step as one-site cyclic transition tensors,
+  -- identified with the compressed blocked sector tensors produced by
   -- `exists_compressedTensor_of_supported_projection`.
   sorry
 
-/-- Missing one-step cyclic transport statement for sector matches.
+/-- One-step cyclic transport statement for sector matches.
 
-This is the formal one-step version of Equation A.8 in arXiv:1708.00029. The cyclic
-projection relation `E†(P (k+1)) = P k`, together with the compressed-sector
-realization, should transport a gauge-phase equivalence between sector pair
-`(u, v)` to one between `(u + 1, v + 1)`. The conclusion also propagates
-nondegeneracy so the step can be iterated around the cycle. -/
+This is the formal one-step version of the propagation step in arXiv:1708.00029,
+Appendix A (lines 985--1002). The cyclic projection relation `𝓔_A^{*}(P_{k+1}) = P_k`,
+together with the compressed-sector realization, transports a gauge-phase
+equivalence between sector pair `(u, v)` to one between `(u + 1, v + 1)`. The
+conclusion also propagates nondegeneracy so the step can be iterated around the
+cycle. -/
 private lemma sectorMatch_succ_of_cyclicSectorDecomp
     [NeZero D]
     (A B : MPSTensor d D)
@@ -199,12 +211,14 @@ private lemma gaugePhaseEquiv_cast_indices {d gA gB : ℕ}
   subst hj
   exact hg
 
-/-- **Translation propagation** (Equation A.8 / blockedABprop of arXiv:1708.00029):
+/-- **Translation propagation** (`eq:blockedABprop`, arXiv:1708.00029 lines
+998--1008):
 Given one matching compressed sector pair at `(u₀, v₀)`, applying the
 translation operator `T^l` for `l = 1, …, m-1` yields matching for all
 sector pairs `(u₀ + l, v₀ + l)`. Each offset `l` gets its own gauge
-(the paper's Equation blockedABprop produces a different unitary at each
-sector, not a single transported gauge).
+(`eq:blockedABprop` produces a different unitary `U_{ṽ+l}` at each sector,
+not a single transported gauge); the offset `v − u = q` is constant
+(`eq:vprop`, line 1007).
 
 The `hA_cyclic`/`hB_cyclic` hypotheses (see `IsCyclicSectorDecomp`)
 tie the `Fin m` block indexing to the cyclic orbit structure of the
@@ -259,28 +273,40 @@ lemma sectorMatch_propagation
             (MPSTensor (blockPhysDim d m)) hdim)
             (blocksA (u₀ + l)))
           (blocksB (v₀ + l)) := by
-  -- PROOF STRUCTURE: see lemma
-  -- `sectorMatch_succ_of_cyclicSectorDecomp` for the planned proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `sectorGaugePhaseEquiv_succ_of_cyclicTransport`.
+  -- PROOF STRUCTURE: iterate `sectorMatch_succ_of_cyclicSectorDecomp` around the
+  -- cycle `l = 0, …, m-1` (the translation-operator family of arXiv:1708.00029
+  -- lines 985--1002). Currently sorry-backed pending discharge of the one-step
+  -- transport `sectorGaugePhaseEquiv_succ_of_cyclicTransport`.
   sorry
 
-/-- Missing full-cycle contraction step for periodic-overlap Case 3.
+/-- Full-cycle contraction step for periodic-overlap Case 3.
 
 At this point the sector transport has already been abstracted into
-`hBlockMatch`, so the remaining gap is no longer the Equation A.8 staircase
-identification.  What is still needed from Eqs. A.14-A.18 of
-arXiv:1708.00029 is the contraction argument around the whole cycle:
-for each sector `u`, normality gives a repetition length after which
-`blocksA u` is injective, and one should use a right inverse from
-`decompositionMap` to contract the repeated blocked products and recover
-per-site proportionality with a single telescoped phase.
+`hBlockMatch`, so the remaining gap is no longer the per-step
+`eq:blockedABprop` staircase identification (lines 985--1002). What is still
+needed is the contraction argument around the whole cycle, arXiv:1708.00029,
+Appendix A lines 1023--1117:
+
+* For each sector `u`, `lem:bdcf` normality gives a repetition length `N₀` after
+  which the blocked product `F_u` (`eq:Fu`, lines 1026--1030) is injective, with a
+  right inverse `Ω_u` (`eq:Omegauprop`, lines 1035--1040).
+* Concatenating and applying the `Ω_u` inverses contracts the repeated products to
+  per-site proportionality `A_u^i = κ_v · e^{iη/m} · B_v^i` (`eq:resultprop`/
+  `eq:thetaACprop`, lines 1063--1076).
+* The phase bookkeeping is load-bearing: `∏_v κ_v = 1` (`eq:prodkappaprop`, line
+  1079) and `|κ_v| = 1` from `‖Σ_i A_u^{i†} A_u^i‖ = 1` (lines 1082--1084), so
+  `κ_v = e^{iθ_v}` with `Σ_v θ_v = 0`; choosing `φ_v` with `θ_v = φ_v − φ_{v+1}`
+  (lines 1093--1102) telescopes the per-sector phases into a single global phase
+  `ξ = η/m` and a single global unitary `U = Σ_u e^{iφ_{u+q}} P_u U_{u+q} Q_{u+q}`
+  (`eq:result` and lines 1110--1117), giving `A^i = e^{iξ} U B^i U†`.
 
 The available chain inputs are `decompositionMap` / `exists_rightInverse` in
-`MPS/Chain/OneSidedInverse.lean` and the two-site proportionality theorem
-`tensor_proportional` in `MPS/Chain/TensorEquality.lean`. The remaining mathematical
-input is the `m`-factor cyclic contraction theorem that passes from `hBlockMatch` to a
-global `RepeatedBlocks` witness. -/
+`MPS/Chain/OneSidedInverse.lean` (realizing `Ω_u`) and the two-site
+proportionality theorem `tensor_proportional` in `MPS/Chain/TensorEquality.lean`.
+The remaining mathematical input is the `m`-factor cyclic contraction *together
+with* the `κ`/`θ`/`φ` phase assembly that passes from `hBlockMatch` to a global
+`RepeatedBlocks` witness. See
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 private lemma repeatedBlocks_of_blockedSectorGaugePhase
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]
@@ -315,14 +341,15 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
     (hNondeg : ∀ u, dimA u ≠ 0)
     (hNormal : ∀ u, IsNormal (blocksA u)) :
     RepeatedBlocks A B := by
-  -- Missing ingredient: a reusable `m`-factor cyclic contraction theorem,
-  -- built from `decompositionMap`, that upgrades the per-sector blocked
-  -- gauge data in `hBlockMatch` to one global phase and one global gauge.
-  -- The available two-site theorem is `tensor_proportional`; the missing step is
-  -- the full-cycle contraction from Eqs. A.14-A.18 of arXiv:1708.00029.
+  -- Remaining obligation (arXiv:1708.00029 lines 1023--1117): an `m`-factor cyclic
+  -- contraction theorem built from `decompositionMap` (the `Ω_u` inverses) that,
+  -- together with the `κ`/`θ`/`φ` phase assembly (lines 1078--1117), upgrades the
+  -- per-sector blocked gauge data in `hBlockMatch` to one global phase and one
+  -- global gauge. The available two-site theorem is `tensor_proportional`.
   sorry
 
-/-- **Per-site proportionality** (Equation A.14 of arXiv:1708.00029):
+/-- **Per-site proportionality** (`eq:thetaACprop`, arXiv:1708.00029 lines
+1073--1076):
 After injectivity contraction, the sector-restricted tensors satisfy
 `A_u^i = κ_v · e^{iη/m} · B_v^i` with `∏ κ_v = 1` and `|κ_v| = 1`.
 
@@ -397,7 +424,8 @@ tensor. The `hSomeMatch` witness provides a single matching sector pair
 follows from `hNondegA`), from which translation propagation extends the
 match to all sectors.
 
-This is Equation (A.17)–(A.18) of arXiv:1708.00029. -/
+This is the sector-match case of the appendix proof, arXiv:1708.00029 lines
+961--1117 (conclusion `A^i = e^{iξ} U B^i U†` at lines 1110--1117). -/
 theorem periodicOverlap_gaugeEquiv_of_sector_match
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]
@@ -429,13 +457,17 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
           (blocksA u₀))
         (blocksB v₀)) :
     RepeatedBlocks A B := by
-  -- PROOF STRUCTURE: see lemmas `sectorMatch_propagation`,
-  -- `sectorBlocked_isNormal_of_isPeriodic`, and
-  -- `sectorTensor_proportional_of_blockedMatch` for the planned proof route.
-  -- Currently sorry-backed pending discharge of
-  -- `sectorGaugePhaseEquiv_succ_of_cyclicTransport`,
-  -- `compressedTensor_adjointTransferMap_cornerBridge`, and
-  -- `repeatedBlocks_of_blockedSectorGaugePhase`.
+  -- PLANNED ROUTE (appendix two-stage structure, arXiv:1708.00029):
+  --   1. `sectorMatch_propagation`: iterate the single match `hSomeMatch` around
+  --      the cycle (translation operator + `thm:cf`, lines 985--1008);
+  --   2. `sectorBlocked_isNormal_of_isPeriodic` (PROVED): each sector is normal;
+  --   3. `sectorTensor_proportional_of_blockedMatch`: contract the matched blocks
+  --      to a global gauge with the `κ`/`θ`/`φ` phase assembly (lines 1023--1117).
+  -- This body is currently `sorry` and does NOT yet invoke those lemmas; wiring it
+  -- through stages 1–3 is the next step. The transitive obligations are the
+  -- Case-3 sorrys `sectorGaugePhaseEquiv_succ_of_cyclicTransport` (stage 1) and
+  -- `repeatedBlocks_of_blockedSectorGaugePhase` (stage 3). (The corner-bridge
+  -- input `compressedTensor_adjointTransferMap_cornerBridge` is already PROVED.)
   sorry
 
 /-- When `D₁ ≠ D₂`, no `RepeatedBlocks` relation can hold (the types don't

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -41,7 +41,7 @@ forces `m_a = m_b`).
 This is the core technical result of the paper: all subsequent theorems
 (proportional FT, equal FT with Z-gauge, symmetry corollary) depend on it.
 
-Source: arXiv:1708.00029, Proposition `equal-or-orthogonal-generalized`
+Source: arXiv:1708.00029, Proposition equal-or-orthogonal-generalized
 (statement, lines 589--609; appendix proof, lines 903--1118). -/
 theorem periodicOverlapDichotomy
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
@@ -88,7 +88,7 @@ theorem periodicOverlapDichotomy
   · exact Or.inl (periodicOverlap_tendsto_zero_of_ne_period A B hA hB hm)
 
 /-- **Eventual linear independence** (independence half of the consequence of
-Proposition `equal-or-orthogonal-generalized`):
+Proposition equal-or-orthogonal-generalized):
 Given a family of periodic tensors `{A_j}` whose periods all divide a common
 period `p`, there exists `N₀` such that for all `N ≥ N₀` that are multiples
 of `p`, the vectors `{|V_N(A_j)⟩}` are linearly independent.
@@ -99,7 +99,7 @@ simultaneously (a zero vector would prevent `LinearIndependent` from holding).
 **Scope restriction (independence only, no spanning):** the paper's consequence
 (arXiv:1708.00029, lines 604--608) states *both* that the non-zero members of
 `{|V_N(A_j)⟩}` are linearly independent *and* that they span `|V_N(A)⟩` — the
-spanning half is what "justifies the name basis of periodic vectors" (line 610).
+spanning half is what "justifies the name basis of periodic vectors" (line 611).
 Only the independence half is stated here. In addition the paper derives it from
 `Lem1t` (the ε-almost-orthonormal ⇒ independent lemma, lines 511--519) applied to
 the self-overlap limit and the cross-overlap decay; here the basis condition is
@@ -127,7 +127,7 @@ theorem periodicBasis_eventuallyLinearlyIndependent
   -- linear independence.
   -- The only sorry-backed input on this route is the off-diagonal decay for
   -- distinct cyclic sectors, `not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces`
-  -- (SelfOverlap, the `lem:bdcf` spectral non-repetition step, lines 404--423).
+  -- (SelfOverlap, the Lemma bdcf spectral non-repetition step, lines 404--423).
   sorry
 
 end MPSTensor

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -39,7 +39,10 @@ they are related by a gauge transformation up to a unit-modulus phase (which
 forces `m_a = m_b`).
 
 This is the core technical result of the paper: all subsequent theorems
-(proportional FT, equal FT with Z-gauge, symmetry corollary) depend on it. -/
+(proportional FT, equal FT with Z-gauge, symmetry corollary) depend on it.
+
+Source: arXiv:1708.00029, Proposition `equal-or-orthogonal-generalized`
+(statement, lines 589--609; appendix proof, lines 903--1118). -/
 theorem periodicOverlapDichotomy
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -48,16 +51,24 @@ theorem periodicOverlapDichotomy
     Tendsto (fun N => mpvOverlap A B N) atTop (nhds 0)
       ∨ ∃ (hdim : D₁ = D₂),
           RepeatedBlocks (cast (congr_arg (MPSTensor d) hdim) A) B := by
-  -- PROOF STRUCTURE: see theorems
-  -- `periodicOverlap_tendsto_zero_of_no_sector_match` and
-  -- `periodicOverlap_gaugeEquiv_of_sector_match` for the same-period branches.
-  -- Currently sorry-backed pending discharge of
-  -- `exists_sector_match_of_gaugePhaseEquiv`,
-  -- `sectorGaugePhaseEquiv_succ_of_cyclicTransport`, and
-  -- `compressedTensor_adjointTransferMap_cornerBridge`.
+  -- PROOF STRUCTURE (appendix case split, arXiv:1708.00029 lines 915--1117):
+  --   * `m_a ≠ m_b`            → `periodicOverlap_tendsto_zero_of_ne_period`   (PROVED)
+  --   * `m_a = m_b`, `D₁ ≠ D₂` → `periodicOverlap_tendsto_zero_of_ne_dim`      (PROVED)
+  --   * same period/dim, no sector match
+  --                            → `periodicOverlap_tendsto_zero_of_no_sector_match` (PROVED)
+  --   * same period/dim, a sector match
+  --                            → `periodicOverlap_gaugeEquiv_of_sector_match`   (sorry)
+  -- The only sorry-backed branch is the sector-match case; it inherits the
+  -- Case-3 obligations `sectorGaugePhaseEquiv_succ_of_cyclicTransport` (the
+  -- translation-operator + `thm:cf` step, lines 985--1000) and
+  -- `repeatedBlocks_of_blockedSectorGaugePhase` (the `Ω`-inverse contraction and
+  -- `κ`/`θ`/`φ` phase assembly, lines 1023--1117). The remaining work here is to
+  -- produce the cyclic sector decompositions, perform the case split, and wire
+  -- the four branch theorems together.
   sorry
 
-/-- **Eventual linear independence** (Corollary of Proposition 3.3):
+/-- **Eventual linear independence** (independence half of the consequence of
+Proposition `equal-or-orthogonal-generalized`):
 Given a family of periodic tensors `{A_j}` whose periods all divide a common
 period `p`, there exists `N₀` such that for all `N ≥ N₀` that are multiples
 of `p`, the vectors `{|V_N(A_j)⟩}` are linearly independent.
@@ -65,7 +76,16 @@ of `p`, the vectors `{|V_N(A_j)⟩}` are linearly independent.
 The common-period restriction ensures all `mpvState (A k) N` are nonzero
 simultaneously (a zero vector would prevent `LinearIndependent` from holding).
 
-This is the "consequence" stated at the end of Proposition 3.3. -/
+**Scope restriction (independence only, no spanning):** the paper's consequence
+(arXiv:1708.00029, lines 604--608) states *both* that the non-zero members of
+`{|V_N(A_j)⟩}` are linearly independent *and* that they span `|V_N(A)⟩` — the
+spanning half is what "justifies the name basis of periodic vectors" (line 610).
+Only the independence half is stated here. In addition the paper derives it from
+`Lem1t` (the ε-almost-orthonormal ⇒ independent lemma, lines 511--519) applied to
+the self-overlap limit and the cross-overlap decay; here the basis condition is
+encoded directly as the pairwise non-repetition hypothesis `hNonrep`. The dropped
+spanning clause and the `Lem1t` route are recorded in
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 theorem periodicBasis_eventuallyLinearlyIndependent
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -78,13 +98,16 @@ theorem periodicBasis_eventuallyLinearlyIndependent
         ¬ RepeatedBlocks (cast (congr_arg (MPSTensor d) hdim) (A i)) (A j)) :
     ∃ N₀ : ℕ, ∀ N ≥ N₀,
       LinearIndependent ℂ (fun k => mpvState (A k) (p * N)) := by
-  -- PROOF STRUCTURE: see theorems
-  -- `periodicSelfOverlap_tendsto` and `periodicOverlapDichotomy` for the
-  -- Gram-matrix argument.
-  -- Currently sorry-backed pending discharge of
-  -- `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`,
-  -- `exists_sector_match_of_gaugePhaseEquiv`, and
-  -- `sectorGaugePhaseEquiv_succ_of_cyclicTransport`.
+  -- PROOF STRUCTURE (Lem1t-style Gram argument, arXiv:1708.00029 lines 511--519,
+  -- 604--608): for `N` a multiple of `p`, `periodicSelfOverlap_tendsto` gives
+  -- `⟨V_N(A_k)|V_N(A_k)⟩ → m_k` (the diagonal), and the off-diagonal entries
+  -- `⟨V_N(A_i)|V_N(A_j)⟩` (i ≠ j) decay to 0 by the dichotomy
+  -- `periodicOverlapDichotomy` together with the non-repetition hypothesis
+  -- `hNonrep`. An almost-orthonormal Gram matrix is invertible (`Lem1t`), giving
+  -- linear independence.
+  -- The only sorry-backed input on this route is the off-diagonal decay for
+  -- distinct cyclic sectors, `not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces`
+  -- (SelfOverlap, the `lem:bdcf` spectral non-repetition step, lines 404--423).
   sorry
 
 end MPSTensor

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -36,7 +36,7 @@ variable {d : ℕ}
 For two periodic tensors `A` and `B` with periods `m_a` and `m_b` in
 irreducible form II, either their overlap decays to zero, or `D_a = D_b` and
 they are related by a gauge transformation up to a unit-modulus phase (which
-forces `m_a = m_b`).
+forces m_a = m_b).
 
 This is the core technical result of the paper: all subsequent theorems
 (proportional FT, equal FT with Z-gauge, symmetry corollary) depend on it.
@@ -52,8 +52,8 @@ theorem periodicOverlapDichotomy
       ∨ ∃ (hdim : D₁ = D₂),
           RepeatedBlocks (cast (congr_arg (MPSTensor d) hdim) A) B := by
   -- APPENDIX CASE SPLIT (arXiv:1708.00029 lines 915--1117):
-  --   * `m_a ≠ m_b`            → `periodicOverlap_tendsto_zero_of_ne_period`
-  --   * `m_a = m_b`, `D₁ ≠ D₂` → `periodicOverlap_tendsto_zero_of_ne_dim`
+  --   * m_a ≠ m_b            → `periodicOverlap_tendsto_zero_of_ne_period`
+  --   * m_a = m_b, D₁ ≠ D₂ → `periodicOverlap_tendsto_zero_of_ne_dim`
   --   * same period/dim, no sector match
   --                            → `periodicOverlap_tendsto_zero_of_no_sector_match`
   --   * same period/dim, a sector match
@@ -120,8 +120,8 @@ theorem periodicBasis_eventuallyLinearlyIndependent
       LinearIndependent ℂ (fun k => mpvState (A k) (p * N)) := by
   -- PROOF STRUCTURE (Lem1t-style Gram argument, arXiv:1708.00029 lines 511--519,
   -- 604--608): for `N` a multiple of `p`, `periodicSelfOverlap_tendsto` gives
-  -- `⟨V_N(A_k)|V_N(A_k)⟩ → m_k` (the diagonal), and the off-diagonal entries
-  -- `⟨V_N(A_i)|V_N(A_j)⟩` (i ≠ j) decay to 0 by the dichotomy
+  -- ⟨V_N(A_k)|V_N(A_k)⟩ → m_k (the diagonal), and the off-diagonal entries
+  -- ⟨V_N(A_i)|V_N(A_j)⟩ (i ≠ j) decay to 0 by the dichotomy
   -- `periodicOverlapDichotomy` together with the non-repetition hypothesis
   -- `hNonrep`. An almost-orthonormal Gram matrix is invertible (Lem1t), giving
   -- linear independence.

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -91,20 +91,20 @@ theorem periodicOverlapDichotomy
 Proposition equal-or-orthogonal-generalized):
 Given a family of periodic tensors `{A_j}` whose periods all divide a common
 period `p`, there exists `N₀` such that for all `N ≥ N₀` that are multiples
-of `p`, the vectors `{|V_N(A_j)⟩}` are linearly independent.
+of `p`, the vectors {|V_N(A_j)⟩} are linearly independent.
 
 The common-period restriction ensures all `mpvState (A k) N` are nonzero
 simultaneously (a zero vector would prevent `LinearIndependent` from holding).
 
 **Scope restriction (independence only, no spanning):** the paper's consequence
 (arXiv:1708.00029, lines 604--608) states *both* that the non-zero members of
-`{|V_N(A_j)⟩}` are linearly independent *and* that they span `|V_N(A)⟩` — the
+{|V_N(A_j)⟩} are linearly independent *and* that they span |V_N(A)⟩ — the
 spanning half is what "justifies the name basis of periodic vectors" (line 611).
 Only the independence half is stated here. In addition the paper derives it from
-`Lem1t` (the ε-almost-orthonormal ⇒ independent lemma, lines 511--519) applied to
+Lem1t (the ε-almost-orthonormal ⇒ independent lemma, lines 511--519) applied to
 the self-overlap limit and the cross-overlap decay; here the basis condition is
 encoded directly as the pairwise non-repetition hypothesis `hNonrep`. The dropped
-spanning clause and the `Lem1t` route are recorded in
+spanning clause and the Lem1t route are recorded in
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 theorem periodicBasis_eventuallyLinearlyIndependent
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -123,7 +123,7 @@ theorem periodicBasis_eventuallyLinearlyIndependent
   -- `⟨V_N(A_k)|V_N(A_k)⟩ → m_k` (the diagonal), and the off-diagonal entries
   -- `⟨V_N(A_i)|V_N(A_j)⟩` (i ≠ j) decay to 0 by the dichotomy
   -- `periodicOverlapDichotomy` together with the non-repetition hypothesis
-  -- `hNonrep`. An almost-orthonormal Gram matrix is invertible (`Lem1t`), giving
+  -- `hNonrep`. An almost-orthonormal Gram matrix is invertible (Lem1t), giving
   -- linear independence.
   -- The only sorry-backed input on this route is the off-diagonal decay for
   -- distinct cyclic sectors, `not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces`

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -105,7 +105,7 @@ Lem1t (the ε-almost-orthonormal ⇒ independent lemma, lines 511--519) applied 
 the self-overlap limit and the cross-overlap decay; here the basis condition is
 encoded directly as the pairwise non-repetition hypothesis `hNonrep`. The dropped
 spanning clause and the Lem1t route are recorded in
-`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
+docs/paper-gaps/1708_periodic_overlap_route_alignment.tex. -/
 theorem periodicBasis_eventuallyLinearlyIndependent
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -51,21 +51,41 @@ theorem periodicOverlapDichotomy
     Tendsto (fun N => mpvOverlap A B N) atTop (nhds 0)
       ∨ ∃ (hdim : D₁ = D₂),
           RepeatedBlocks (cast (congr_arg (MPSTensor d) hdim) A) B := by
-  -- PROOF STRUCTURE (appendix case split, arXiv:1708.00029 lines 915--1117):
-  --   * `m_a ≠ m_b`            → `periodicOverlap_tendsto_zero_of_ne_period`   (PROVED)
-  --   * `m_a = m_b`, `D₁ ≠ D₂` → `periodicOverlap_tendsto_zero_of_ne_dim`      (PROVED)
+  -- APPENDIX CASE SPLIT (arXiv:1708.00029 lines 915--1117):
+  --   * `m_a ≠ m_b`            → `periodicOverlap_tendsto_zero_of_ne_period`
+  --   * `m_a = m_b`, `D₁ ≠ D₂` → `periodicOverlap_tendsto_zero_of_ne_dim`
   --   * same period/dim, no sector match
-  --                            → `periodicOverlap_tendsto_zero_of_no_sector_match` (PROVED)
+  --                            → `periodicOverlap_tendsto_zero_of_no_sector_match`
   --   * same period/dim, a sector match
-  --                            → `periodicOverlap_gaugeEquiv_of_sector_match`   (sorry)
-  -- The only sorry-backed branch is the sector-match case; it inherits the
-  -- Case-3 obligations `sectorGaugePhaseEquiv_succ_of_cyclicTransport` (the
-  -- translation-operator + `thm:cf` step, lines 985--1000) and
-  -- `repeatedBlocks_of_blockedSectorGaugePhase` (the `Ω`-inverse contraction and
-  -- `κ`/`θ`/`φ` phase assembly, lines 1023--1117). The remaining work here is to
-  -- produce the cyclic sector decompositions, perform the case split, and wire
-  -- the four branch theorems together.
-  sorry
+  --                            → `periodicOverlap_gaugeEquiv_of_sector_match`
+  -- Each branch theorem is proved; the sector-match branch is proved modulo the
+  -- two Case-3 leaves `sectorGaugePhaseEquiv_succ_of_cyclicTransport` and
+  -- `repeatedBlocks_of_blockedSectorGaugePhase`.
+  classical
+  by_cases hm : m_a = m_b
+  · subst hm
+    haveI : NeZero m_a := ⟨hA.period_pos.ne'⟩
+    by_cases hD : D₁ = D₂
+    · subst hD
+      obtain ⟨dimA, blocksA, hA_blocks_lc, hA_mpv, hA_cyclic, hNondegA⟩ :=
+        exists_cyclic_sector_decomp_after_blocking_of_isPeriodic A hA
+      obtain ⟨dimB, blocksB, hB_blocks_lc, hB_mpv, hB_cyclic, hNondegB⟩ :=
+        exists_cyclic_sector_decomp_after_blocking_of_isPeriodic B hB
+      by_cases hmatch : ∃ (u₀ v₀ : Fin m_a) (hdim : dimA u₀ = dimB v₀),
+          GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor (blockPhysDim d m_a)) hdim) (blocksA u₀))
+            (blocksB v₀)
+      · refine Or.inr ⟨rfl, ?_⟩
+        simpa using
+          periodicOverlap_gaugeEquiv_of_sector_match A B hA hB blocksA blocksB
+            hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic hNondegA hmatch
+      · refine Or.inl ?_
+        refine periodicOverlap_tendsto_zero_of_no_sector_match A B hA hB blocksA blocksB
+          hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic hNondegA hNondegB ?_
+        intro u v hdim _ hgpe
+        exact hmatch ⟨u, v, hdim, hgpe⟩
+    · exact Or.inl (periodicOverlap_tendsto_zero_of_ne_dim A B hA hB hD)
+  · exact Or.inl (periodicOverlap_tendsto_zero_of_ne_period A B hA hB hm)
 
 /-- **Eventual linear independence** (independence half of the consequence of
 Proposition `equal-or-orthogonal-generalized`):

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -533,56 +533,39 @@ theorem mpvOverlap_blockTensor_self_eq
   rw [← trace_mixedTransferMap_pow_eq_mpvOverlap (A := A) (B := A) (N * L)]
   simp [mixedTransferMap_self, transferMap_blockTensor, pow_mul, Nat.mul_comm]
 
-/-- Orthogonal-corner trace rigidity for compressed cyclic sectors.
+/-- Distinct compressed cyclic sectors cannot be gauge-phase equivalent.
 
-**Remaining BDCF converse.**  This lemma asserts that distinct compressed
-sectors from the same cyclic decomposition cannot be gauge-phase equivalent.
-The mathematical proof in arXiv:1708.00029 (Appendix A, lines 930–950) relies
-on the block-diagonal canonical form (BDCF) lemma: distinct cyclic sectors
-have linearly independent MPV families at sufficiently large system sizes.
-A gauge-phase equivalence would force those MPV families to be proportional
-(via `mpv_eq_pow_mul_of_gaugePhase`), contradicting eventual linear
-independence.
+This is the **non-repetition** half of `lem:bdcf` of arXiv:1708.00029
+(the proof is at lines 409--423): the blocks `C_u = P_u A^{(m)}` of a periodic
+block form a basis of *non-repeated* normal tensors. The hypotheses here repackage
+the `lem:bdcf` data: `P` are the orthogonal projectors of the off-diagonal
+decomposition (`hPproj`, `hPsum`), `hCyclic` is the adjoint-transfer shift
+`𝓔_A^{*}(P_{k+1}) = P_k`, `hComm` is the commutation of each `P_k` with the
+blocked letters, and `hTrace` realizes each compressed MPV as
+`tr(P_k · evalWord …)`. The orthogonality `P_u P_v = 0` (`u ≠ v`) is the
+off-diagonal support condition.
 
-The BDCF lemma in arXiv:1708.00029 establishes the forward implication:
-if two compressed cyclic sectors are not gauge-phase equivalent, then their
-MPV families are eventually linearly independent.  Proving the present lemma
-requires the converse — that orthogonal cyclic sectors are eventually
-linearly independent.  This converse has not yet been established, so the
-proof below remains a documented gap.
+**Paper's argument (lines 404--423, to be ported).** Since `A` is a periodic
+block, `𝓔_A` is irreducible with peripheral spectrum `{ω^r}_{r=0}^{m-1}`,
+`ω = e^{2πi/m}`. The blocked map `𝓔_A^m` then has `1` as its *only* modulus-one
+eigenvalue (with multiplicity `m`), and its fixed-point set is exactly
+`{P_u Λ_A P_u}_u` (with `Λ_A` the fixed point of `𝓔_A`), while the fixed points
+of the adjoint `𝓔_A^{*m}` are exactly `{P_u}_u`. Suppose, for `u ≠ v`, a
+gauge-phase equivalence `C_u^{i} = e^{iξ} U C_v^{i} U†` held, with `U = P_u U P_v`
+(`U U† = P_u`, `U† U = P_v`). Then
+`𝓔_A^m(U) = Σ_i C_u^i U C_v^{i†} = e^{iξ} U Σ_i C_v^i C_v^{i†} = e^{iξ} U`,
+using `𝓔_{C_v}(P_v) = P_v`. Thus `U` is a modulus-one eigenvector of `𝓔_A^m`;
+but the only such eigenvalue is `1` with the *diagonal* fixed points
+`{P_w Λ_A P_w}`, whereas `U = P_u U P_v` is off-diagonal for `u ≠ v` — a
+contradiction. Hence no such equivalence exists.
 
-**Proof sketch when the converse is available.**  Assume a gauge-phase
-equivalence `blocks v = ζ · X · (cast blocks u) · X⁻¹` with `ζ ≠ 0`.
-Then `mpv_eq_pow_mul_of_gaugePhase` gives
-`mpv(blocks v) σ = ζ ^ N · mpv(blocks u) σ` for every configuration
-`σ` of length `N`.  By `hTrace` this becomes
-
-  `trace (P v · W_σ) = ζ ^ N · trace (P u · W_σ)`
-
-for all blocked words `W_σ = evalWord (blockTensor A m) σ`.
-Because `P u` commutes with every blocked letter (`hComm`) and the blocked
-letter products are invariant under cyclic permutations, the single-site
-translation operator `T` (the adjoint transfer map `transferMap Aᴴ`)
-acts on the level of the trace functional by shifting the projection index:
-
-  `trace (P (k+1) · W_σ) = trace (T (P (k+1)) · W_σ) = trace (P k · W_σ)`.
-
-Iterating this shift through the finite cyclic group `Fin m`, the gauge-phase
-equivalence propagates to all shifts `P_{v+l}`, `P_{u+l}`, yielding
-proportionality of the MPV families attached to **every** shifted pair.
-Since `u ≠ v`, some pair of distinct projections would then have proportional
-MPV families, which contradicts eventual linear independence of the cyclic
-sector states (the missing BDCF converse).
-
-The cyclic-sector decomposition `IsCyclicSectorDecomp A blocks` supplies the
-compression ∗-algebra isomorphisms `φ k` and the intertwining condition, which
-provide the per-sector primitivity and irreducibility that make the BDCF
-converse true.  Once that converse is proved, the `sorry` below can be
-discharged by the procedure outlined above. -/
-  -- (Implementation: the forward BDCF direction follows from
-  --  `exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal` together with
-  --  `cross_overlap_tendsto_zero_of_separated_normal_bnt_data`; the missing converse
-  --  would be a lemma in `CanonicalForm/BlockDiagonalCommutant`.)
+**Realignment note.** Earlier drafts of this lemma planned to discharge it via a
+"BDCF converse" (orthogonal sectors are eventually linearly independent, then a
+gauge-phase equivalence would make two sector MPV families proportional). That is
+*not* the paper's argument; the faithful route is the spectral one above, which
+reuses the same peripheral-spectrum / fixed-point machinery already used in
+`Case1.lean` (`period_eq_of_gaugePhaseEquiv_of_isPeriodic`). See
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 private lemma not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     {dim : Fin m → ℕ}
@@ -605,8 +588,10 @@ private lemma not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
     ¬ GaugePhaseEquiv
       (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim) (blocks u))
       (blocks v) := by
-  -- Missing lemma: the BDCF converse — that orthogonal cyclic sectors are
-  -- eventually linearly independent (see mathematical discussion above).
+  -- Remaining obligation: port the `lem:bdcf` spectral non-repetition argument
+  -- (arXiv:1708.00029 lines 404--423) — `𝓔_A^m` has `1` as its only modulus-one
+  -- eigenvalue with diagonal fixed points `{P_w Λ_A P_w}`, so an off-diagonal
+  -- `U = P_u U P_v` (`u ≠ v`) cannot satisfy `𝓔_A^m(U) = e^{iξ} U`.
   sorry
 
 /-- Distinct compressed sectors of a cyclic sector decomposition are not gauge-phase

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -103,11 +103,13 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
 /-- A periodic tensor of period `m`, after blocking by `m`, admits a cyclic
 sector decomposition.
 
-Source: arXiv:1708.00029, Lemma bdcf, lines 404--423. The decomposition consists
-of `m` compressed normal-tensor blocks, the C_u = P_u A^{(m)} blocks, which are
-left-canonical, reproduce the blocked tensor's MPV family, carry the cyclic
-projector/orbit structure (`IsCyclicSectorDecomp`), and all have nonzero bond
-dimension. -/
+Source: arXiv:1708.00029, Lemma bdcf, lines 404--423. This theorem records the
+existence of the cyclic projectors and corner blocks C_u = P_u A^{(m)}: the
+blocks are left-canonical, reproduce the blocked tensor's MPV family, satisfy
+`IsCyclicSectorDecomp`, and have nonzero bond dimensions. The normality and
+non-repetition conclusions of Lemma bdcf are stated separately below, for
+example in `sectorBlocked_isNormal_of_isPeriodic` and
+`not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces`. -/
 theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A) :

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -575,7 +575,7 @@ gauge-phase equivalence would make two sector MPV families proportional). That i
 *not* the paper's argument; the faithful route is the spectral one above, which
 reuses the same peripheral-spectrum / fixed-point machinery already used in
 `period_eq_of_gaugePhaseEquiv_of_isPeriodic`. See
-`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
+docs/paper-gaps/1708_periodic_overlap_route_alignment.tex. -/
 private lemma not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     {dim : Fin m → ℕ}

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -101,10 +101,13 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
       (φ k Xᴴ).1 = ((φ k X).1)ᴴ)
 
 /-- A periodic tensor of period `m`, after blocking by `m`, admits a cyclic
-sector decomposition: a family of `m` compressed normal-tensor blocks (the
-C_u = P_u A^{(m)} blocks of Lemma bdcf, arXiv:1708.00029) that are left-canonical,
-reproduce the blocked tensor's MPV family, carry the cyclic projector/orbit
-structure (`IsCyclicSectorDecomp`), and all have nonzero bond dimension. -/
+sector decomposition.
+
+Source: arXiv:1708.00029, Lemma bdcf, lines 404--423. The decomposition consists
+of `m` compressed normal-tensor blocks, the C_u = P_u A^{(m)} blocks, which are
+left-canonical, reproduce the blocked tensor's MPV family, carry the cyclic
+projector/orbit structure (`IsCyclicSectorDecomp`), and all have nonzero bond
+dimension. -/
 theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A) :

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -552,7 +552,7 @@ the Lemma bdcf hypotheses: `P` are the orthogonal projectors of the off-diagonal
 decomposition (`hPproj`, `hPsum`), `hCyclic` is the adjoint-transfer shift
 𝓔_A^{*}(P_{k+1}) = P_k, `hComm` is the commutation of each P_k with the
 blocked letters, and `hTrace` realizes each compressed MPV as
-tr(P_k · evalWord …). The orthogonality P_u P_v = 0 (`u ≠ v`) is the
+tr(P_k · evalWord …). The orthogonality P_u P_v = 0 (u ≠ v) is the
 off-diagonal support condition.
 
 **Paper's argument (lines 404--423, to be ported).** Since `A` is a periodic
@@ -560,13 +560,13 @@ block, 𝓔_A is irreducible with peripheral spectrum {ω^r}_{r=0}^{m-1},
 ω = e^{2πi/m}. The blocked map 𝓔_A^m then has 1 as its *only* modulus-one
 eigenvalue (with multiplicity `m`), and its fixed-point set is exactly
 {P_u Λ_A P_u}_u (with Λ_A the fixed point of 𝓔_A), while the fixed points
-of the adjoint 𝓔_A^{*m} are exactly {P_u}_u. Suppose, for `u ≠ v`, a
+of the adjoint 𝓔_A^{*m} are exactly {P_u}_u. Suppose, for u ≠ v, a
 gauge-phase equivalence C_u^{i} = e^{iξ} U C_v^{i} U† held, with U = P_u U P_v
 (U U† = P_u, U† U = P_v). Then
 𝓔_A^m(U) = Σ_i C_u^i U C_v^{i†} = e^{iξ} U Σ_i C_v^i C_v^{i†} = e^{iξ} U,
 using 𝓔_{C_v}(P_v) = P_v. Thus U is a modulus-one eigenvector of 𝓔_A^m;
 but the only such eigenvalue is 1 with the *diagonal* fixed points
-{P_w Λ_A P_w}, whereas U = P_u U P_v is off-diagonal for `u ≠ v` — a
+{P_w Λ_A P_w}, whereas U = P_u U P_v is off-diagonal for u ≠ v — a
 contradiction. Hence no such equivalence exists.
 
 **Realignment note.** Earlier drafts of this lemma planned to discharge it via a
@@ -574,7 +574,7 @@ contradiction. Hence no such equivalence exists.
 gauge-phase equivalence would make two sector MPV families proportional). That is
 *not* the paper's argument; the faithful route is the spectral one above, which
 reuses the same peripheral-spectrum / fixed-point machinery already used in
-`Case1.lean` (`period_eq_of_gaugePhaseEquiv_of_isPeriodic`). See
+`period_eq_of_gaugePhaseEquiv_of_isPeriodic`. See
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 private lemma not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
@@ -601,7 +601,7 @@ private lemma not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
   -- Remaining obligation: port the Lemma bdcf spectral non-repetition argument
   -- (arXiv:1708.00029 lines 404--423): 𝓔_A^m has 1 as its only modulus-one
   -- eigenvalue with diagonal fixed points {P_w Λ_A P_w}, so an off-diagonal
-  -- U = P_u U P_v (`u ≠ v`) cannot satisfy 𝓔_A^m(U) = e^{iξ} U.
+  -- U = P_u U P_v (u ≠ v) cannot satisfy 𝓔_A^m(U) = e^{iξ} U.
   sorry
 
 /-- Distinct compressed sectors of a cyclic sector decomposition are not gauge-phase

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -100,7 +100,7 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
     (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
       (φ k Xᴴ).1 = ((φ k X).1)ᴴ)
 
-private theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
+theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A) :
     ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -546,9 +546,9 @@ theorem mpvOverlap_blockTensor_self_eq
 This is the **non-repetition** half of Lemma bdcf of arXiv:1708.00029
 (the proof is at lines 409--423): the blocks C_u = P_u A^{(m)} of a periodic
 block form a basis of *non-repeated* normal tensors. The hypotheses here repackage
-the Lemma bdcf data: `P` are the orthogonal projectors of the off-diagonal
+the Lemma bdcf hypotheses: `P` are the orthogonal projectors of the off-diagonal
 decomposition (`hPproj`, `hPsum`), `hCyclic` is the adjoint-transfer shift
-𝓔_A^{*}(P_{k+1}) = P_k, `hComm` is the commutation of each `P_k` with the
+𝓔_A^{*}(P_{k+1}) = P_k, `hComm` is the commutation of each P_k with the
 blocked letters, and `hTrace` realizes each compressed MPV as
 tr(P_k · evalWord …). The orthogonality P_u P_v = 0 (`u ≠ v`) is the
 off-diagonal support condition.

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -100,6 +100,11 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
     (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
       (φ k Xᴴ).1 = ((φ k X).1)ᴴ)
 
+/-- A periodic tensor of period `m`, after blocking by `m`, admits a cyclic
+sector decomposition: a family of `m` compressed normal-tensor blocks (the
+`C_u = P_u A^{(m)}` of `lem:bdcf`, arXiv:1708.00029) that are left-canonical,
+reproduce the blocked tensor's MPV family, carry the cyclic projector/orbit
+structure (`IsCyclicSectorDecomp`), and all have nonzero bond dimension. -/
 theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A) :

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -102,7 +102,7 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
 
 /-- A periodic tensor of period `m`, after blocking by `m`, admits a cyclic
 sector decomposition: a family of `m` compressed normal-tensor blocks (the
-`C_u = P_u A^{(m)}` of `lem:bdcf`, arXiv:1708.00029) that are left-canonical,
+C_u = P_u A^{(m)} blocks of Lemma bdcf, arXiv:1708.00029) that are left-canonical,
 reproduce the blocked tensor's MPV family, carry the cyclic projector/orbit
 structure (`IsCyclicSectorDecomp`), and all have nonzero bond dimension. -/
 theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
@@ -540,28 +540,28 @@ theorem mpvOverlap_blockTensor_self_eq
 
 /-- Distinct compressed cyclic sectors cannot be gauge-phase equivalent.
 
-This is the **non-repetition** half of `lem:bdcf` of arXiv:1708.00029
-(the proof is at lines 409--423): the blocks `C_u = P_u A^{(m)}` of a periodic
+This is the **non-repetition** half of Lemma bdcf of arXiv:1708.00029
+(the proof is at lines 409--423): the blocks C_u = P_u A^{(m)} of a periodic
 block form a basis of *non-repeated* normal tensors. The hypotheses here repackage
-the `lem:bdcf` data: `P` are the orthogonal projectors of the off-diagonal
+the Lemma bdcf data: `P` are the orthogonal projectors of the off-diagonal
 decomposition (`hPproj`, `hPsum`), `hCyclic` is the adjoint-transfer shift
-`𝓔_A^{*}(P_{k+1}) = P_k`, `hComm` is the commutation of each `P_k` with the
+𝓔_A^{*}(P_{k+1}) = P_k, `hComm` is the commutation of each `P_k` with the
 blocked letters, and `hTrace` realizes each compressed MPV as
-`tr(P_k · evalWord …)`. The orthogonality `P_u P_v = 0` (`u ≠ v`) is the
+tr(P_k · evalWord …). The orthogonality P_u P_v = 0 (`u ≠ v`) is the
 off-diagonal support condition.
 
 **Paper's argument (lines 404--423, to be ported).** Since `A` is a periodic
-block, `𝓔_A` is irreducible with peripheral spectrum `{ω^r}_{r=0}^{m-1}`,
-`ω = e^{2πi/m}`. The blocked map `𝓔_A^m` then has `1` as its *only* modulus-one
+block, 𝓔_A is irreducible with peripheral spectrum {ω^r}_{r=0}^{m-1},
+ω = e^{2πi/m}. The blocked map 𝓔_A^m then has 1 as its *only* modulus-one
 eigenvalue (with multiplicity `m`), and its fixed-point set is exactly
-`{P_u Λ_A P_u}_u` (with `Λ_A` the fixed point of `𝓔_A`), while the fixed points
-of the adjoint `𝓔_A^{*m}` are exactly `{P_u}_u`. Suppose, for `u ≠ v`, a
-gauge-phase equivalence `C_u^{i} = e^{iξ} U C_v^{i} U†` held, with `U = P_u U P_v`
-(`U U† = P_u`, `U† U = P_v`). Then
-`𝓔_A^m(U) = Σ_i C_u^i U C_v^{i†} = e^{iξ} U Σ_i C_v^i C_v^{i†} = e^{iξ} U`,
-using `𝓔_{C_v}(P_v) = P_v`. Thus `U` is a modulus-one eigenvector of `𝓔_A^m`;
-but the only such eigenvalue is `1` with the *diagonal* fixed points
-`{P_w Λ_A P_w}`, whereas `U = P_u U P_v` is off-diagonal for `u ≠ v` — a
+{P_u Λ_A P_u}_u (with Λ_A the fixed point of 𝓔_A), while the fixed points
+of the adjoint 𝓔_A^{*m} are exactly {P_u}_u. Suppose, for `u ≠ v`, a
+gauge-phase equivalence C_u^{i} = e^{iξ} U C_v^{i} U† held, with U = P_u U P_v
+(U U† = P_u, U† U = P_v). Then
+𝓔_A^m(U) = Σ_i C_u^i U C_v^{i†} = e^{iξ} U Σ_i C_v^i C_v^{i†} = e^{iξ} U,
+using 𝓔_{C_v}(P_v) = P_v. Thus U is a modulus-one eigenvector of 𝓔_A^m;
+but the only such eigenvalue is 1 with the *diagonal* fixed points
+{P_w Λ_A P_w}, whereas U = P_u U P_v is off-diagonal for `u ≠ v` — a
 contradiction. Hence no such equivalence exists.
 
 **Realignment note.** Earlier drafts of this lemma planned to discharge it via a
@@ -593,10 +593,10 @@ private lemma not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
     ¬ GaugePhaseEquiv
       (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim) (blocks u))
       (blocks v) := by
-  -- Remaining obligation: port the `lem:bdcf` spectral non-repetition argument
-  -- (arXiv:1708.00029 lines 404--423) — `𝓔_A^m` has `1` as its only modulus-one
-  -- eigenvalue with diagonal fixed points `{P_w Λ_A P_w}`, so an off-diagonal
-  -- `U = P_u U P_v` (`u ≠ v`) cannot satisfy `𝓔_A^m(U) = e^{iξ} U`.
+  -- Remaining obligation: port the Lemma bdcf spectral non-repetition argument
+  -- (arXiv:1708.00029 lines 404--423): 𝓔_A^m has 1 as its only modulus-one
+  -- eigenvalue with diagonal fixed points {P_w Λ_A P_w}, so an off-diagonal
+  -- U = P_u U P_v (`u ≠ v`) cannot satisfy 𝓔_A^m(U) = e^{iξ} U.
   sorry
 
 /-- Distinct compressed sectors of a cyclic sector decomposition are not gauge-phase

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -450,10 +450,13 @@ unconditional result.
     \notready
     \uses{def:cyclic_sector_decomp, def:periodic_tensor}
     If $A$ is periodic with period $m$, then the blocked tensor $A^{(m)}$
-    admits a cyclic sector decomposition. Equivalently, the corner tensors
-    $C_u=P_u A^{(m)}$ are left-canonical non-repeated normal tensors whose
-    projectors realize the cyclic adjoint-transfer relation of
-    Lemma~\emph{bdcf} in \cite[lines~404--423]{DeLasCuevas2017Irreducible}.
+    admits a cyclic sector decomposition. Thus there are projectors $P_u$ and
+    corner tensors $C_u=P_u A^{(m)}$ which reproduce the blocked matrix-product
+    vectors, are left-canonical, have nonzero bond dimensions, and realize the
+    cyclic adjoint-transfer relation of Lemma~\emph{bdcf} in
+    \cite[lines~404--423]{DeLasCuevas2017Irreducible}. The normality and
+    non-repetition conclusions of Lemma~\emph{bdcf} are recorded separately in
+    the component lemmas below.
 \end{theorem}
 
 \begin{proof}\notready

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -444,6 +444,24 @@ unconditional result.
     adjoint-transfer relation.
 \end{definition}
 
+\begin{theorem}[Cyclic sector decomposition of a periodic tensor]
+    \label{thm:cyclic_sector_decomp_after_blocking_periodic}
+    \lean{MPSTensor.exists_cyclic_sector_decomp_after_blocking_of_isPeriodic}
+    \notready
+    \uses{def:cyclic_sector_decomp, def:periodic_tensor}
+    If $A$ is periodic with period $m$, then the blocked tensor $A^{(m)}$
+    admits a cyclic sector decomposition. Equivalently, the corner tensors
+    $C_u=P_u A^{(m)}$ are left-canonical non-repeated normal tensors whose
+    projectors realize the cyclic adjoint-transfer relation of
+    Lemma~\emph{bdcf} in \cite[lines~404--423]{DeLasCuevas2017Irreducible}.
+\end{theorem}
+
+\begin{proof}\notready
+    This is the cyclic-sector existence part of Lemma~\emph{bdcf}, translated
+    into the inverse indexing convention of
+    Definition~\ref{def:cyclic_sector_decomp}.
+\end{proof}
+
 % The overlap component lemmas below are part of the source dichotomy proof.
 % The self-overlap and no-sector-match theorems are already formal statements;
 % the full periodic overlap dichotomy still requires assembling these pieces

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -447,7 +447,7 @@ unconditional result.
 \begin{theorem}[Cyclic sector decomposition of a periodic tensor]
     \label{thm:cyclic_sector_decomp_after_blocking_periodic}
     \lean{MPSTensor.exists_cyclic_sector_decomp_after_blocking_of_isPeriodic}
-    \notready
+    \leanok
     \uses{def:cyclic_sector_decomp, def:periodic_tensor}
     If $A$ is periodic with period $m$, then the blocked tensor $A^{(m)}$
     admits a cyclic sector decomposition. Thus there are projectors $P_u$ and
@@ -459,7 +459,7 @@ unconditional result.
     the component lemmas below.
 \end{theorem}
 
-\begin{proof}\notready
+\begin{proof}\leanok
     This is the cyclic-sector existence part of Lemma~\emph{bdcf}, translated
     into the inverse indexing convention of
     Definition~\ref{def:cyclic_sector_decomp}.

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -629,7 +629,7 @@ unconditional result.
 
 \begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}
     \lean{MPSTensor.sectorMatch_propagation}
-    \notready
+    \leanok
     \uses{def:periodic_tensor, def:cyclic_sector_decomp}
     Let $A$ and $B$ be left-canonical tensors with period $m$, and let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
@@ -677,7 +677,7 @@ unconditional result.
 \begin{theorem}[Sector match yields repeated-block equivalence]%
     \label{thm:periodic_overlap_gauge_equiv_sector_match}
     \lean{MPSTensor.periodicOverlap_gaugeEquiv_of_sector_match}
-    \notready
+    \leanok
     \uses{lem:sector_match_propagation, lem:sector_tensor_proportional_blocked_match,
         def:cyclic_sector_decomp}
     Let $A$ and $B$ be periodic tensors with the same period $m$. Let
@@ -700,7 +700,7 @@ unconditional result.
 
 \begin{theorem}[Periodic overlap dichotomy]\label{thm:periodic_overlap_dichotomy}
     \lean{MPSTensor.periodicOverlapDichotomy}
-    \notready
+    \leanok
     \uses{thm:periodic_overlap_zero_ne_period,
         thm:periodic_overlap_zero_no_sector_match,
         thm:periodic_overlap_zero_ne_dim,

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -10,18 +10,19 @@
 \title{Proof-Route Alignment for the Periodic Overlap Dichotomy
   (de las Cuevas--Cirac--Schuch--P\'erez-Garc\'ia)}
 \author{}
-\date{2026-06-05}
+\date{2026-06-04}
 
 \begin{document}
 \maketitle
 
 \section{Scope}
 
-This note records, in mathematical terms, where the \Lean{} development of the
-periodic overlap dichotomy in \leanid{TNLean/MPS/Periodic/Overlap/} chooses a
-proof route that differs from the appendix argument of
-\cite[Appendix~A]{DeLasCuevas2017Irreducible}, and where its statements restrict
-the source.\footnote{Paper-level umbrella:
+This note records, in mathematical terms, where the formal development of the
+periodic overlap dichotomy chooses a proof route that differs from the appendix
+argument of \cite[Appendix~A]{DeLasCuevas2017Irreducible}, and where its
+statements restrict the source.\footnote{Formal files:
+\leanid{TNLean/MPS/Periodic/Overlap/}. Local source:
+\leanid{Papers/1708.00029/main.tex}. Paper-level umbrella:
 \href{https://github.com/LionSR/TNLean/issues/619}{issue \#619}; proposition-level
 subtracking: \href{https://github.com/LionSR/TNLean/issues/81}{issue \#81}
 (self-overlap limit and non-matching decay,
@@ -29,39 +30,48 @@ subtracking: \href{https://github.com/LionSR/TNLean/issues/81}{issue \#81}
 propagation and gauge assembly,
 \href{https://github.com/LionSR/TNLean/issues/450}{issue \#450}).}
 
-The source proposition is \emph{equal-or-orthogonal-generalized}
-(\cite{DeLasCuevas2017Irreducible}, stated at lines 589--609, proved in
-Appendix~A at lines 903--1118). None of the deviations below is unfaithful in the
-smuggled-hypothesis sense: each \Lean{} statement is a faithful (or explicitly
+The source proposition is \emph{equal-or-orthogonal-generalized}.\footnote{Stated
+in \cite{DeLasCuevas2017Irreducible}, lines 589--609, and proved in Appendix~A,
+lines 903--1118.} None of the deviations below is unfaithful in the
+smuggled-hypothesis sense: each formal statement is a faithful (or explicitly
 restricted) version of the source, and the route substitutions are
-mathematically equivalent. The note exists so that a reader checking the \Lean{}
-files against the local source \leanid{Papers/1708.00029/main.tex} can locate the
-differences quickly.
+mathematically equivalent.
 
 \section{Different-period decay via the peripheral spectrum}
 
-\textbf{Source (lines 917--950).} For periods $m_a\neq m_b$, the paper blocks at
+\textbf{Source.}\footnote{\cite{DeLasCuevas2017Irreducible}, Appendix~A,
+lines 917--950.} For periods $m_a\neq m_b$, the paper blocks at
 $p=\operatorname{lcm}(m_a,m_b)$ and uses Lemma~\emph{bdcf}: the blocks
 $P_uA^{(p)}$ and $Q_vB^{(p)}$ are non-repeated normal tensors. Applying the
 one-site translation operator to $Q_vB^{(p)}$ versus $Q_{v+1}B^{(p)}$ yields a
 contradiction unless $\lim_N|\langle V_N(A)|V_N(B)\rangle|=0$.
 
-\textbf{\Lean{} route} (\leanid{Case1.lean},
-\leanid{periodicOverlap_tendsto_zero_of_ne_period}). The same obstruction is
-realized spectrally. If $D_a=D_b$ and $B^i=\zeta\,XA^iX^{-1}$, then
-$\mathcal E_B(Y)=\zeta\bar\zeta\,X\mathcal E_A(X^{-1}YX^{-\dagger})X^\dagger$;
-eigenvalue uniqueness for an irreducible completely positive map
+\textbf{\Lean{} route.}\footnote{Formal declaration:
+\leanid{periodicOverlap_tendsto_zero_of_ne_period} in \leanid{Case1.lean}.}
+The same obstruction is realized spectrally. Write
+\begin{align}
+    \mathcal E_A(Y) &= \sum_i A^iYA^{i\dagger}.
+\end{align}
+If $D_a=D_b$ and $B^i=\zeta\,XA^iX^{-1}$, then
+\begin{align}
+    \mathcal E_B(Y)
+        &= \zeta\bar\zeta\,
+           X\mathcal E_A(X^{-1}YX^{-\dagger})X^\dagger .
+    \tag{Case 1}
+\end{align}
+Eigenvalue uniqueness for an irreducible completely positive map
 (\cite{Wolf2012Quantum}, Theorem~6.3) forces $|\zeta|=1$, so $\mathcal E_A$ and
 $\mathcal E_B$ have equal peripheral spectra. An $m$-periodic tensor has
 peripheral spectrum $\{e^{2\pi i r/m}:0\le r<m\}$, so equality forces $m_a=m_b$.
 Thus different periods exclude gauge-phase equivalence, and
 \emph{equal-or-orthogonal} (the irreducible trace-preserving overlap dichotomy)
 gives the decay. This substitutes the paper's lcm-blocking + translation
-argument; it is complete and proved (no \leanid{sorry}).
+argument; it is complete and proved.
 
 \section{Sector non-repetition via the blocked fixed-point structure}
 
-\textbf{Source (Lemma \emph{bdcf}, lines 404--423).} For a periodic block,
+\textbf{Source.}\footnote{Lemma~\emph{bdcf} in
+\cite{DeLasCuevas2017Irreducible}, lines 404--423.} For a periodic block,
 $\mathcal E_A$ is irreducible with peripheral spectrum $\{\omega^r\}$,
 $\omega=e^{2\pi i/m}$. The blocked map $\mathcal E_A^m$ then has $1$ as its only
 modulus-one eigenvalue (multiplicity $m$), with fixed-point set exactly
@@ -69,74 +79,88 @@ $\{P_u\Lambda_AP_u\}_u$, while the adjoint $\mathcal E_A^{*m}$ has fixed points
 $\{P_u\}_u$. If, for $u\neq v$, a gauge-phase equivalence
 $C_u^{\mathbf i}=e^{i\xi}UC_v^{\mathbf i}U^\dagger$ held with $U=P_uUP_v$
 ($UU^\dagger=P_u$, $U^\dagger U=P_v$), then
-$\mathcal E_A^m(U)=\sum_{\mathbf i}C_u^{\mathbf i}UC_v^{\mathbf i\dagger}
-=e^{i\xi}U\sum_{\mathbf i}C_v^{\mathbf i}C_v^{\mathbf i\dagger}=e^{i\xi}U$,
+\begin{align}
+    \mathcal E_A^m(U)
+        &= \sum_{\mathbf i} C_u^{\mathbf i}UC_v^{\mathbf i\dagger} \\
+        &= e^{i\xi}U
+           \sum_{\mathbf i} C_v^{\mathbf i}C_v^{\mathbf i\dagger} \\
+        &= e^{i\xi}U
+        && (\text{using } \mathcal E_{C_v}(P_v)=P_v) .
+\end{align}
 so $U$ is a modulus-one eigenvector of $\mathcal E_A^m$. As the only such
 eigenvalue is $1$ with the diagonal fixed points $\{P_w\Lambda_AP_w\}$ and
 $U=P_uUP_v$ is off-diagonal for $u\neq v$, this is a contradiction.
 
-\textbf{\Lean{} status} (\leanid{SelfOverlap.lean},
-\leanid{not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces}, currently a
-\leanid{sorry}). The lemma statement is the faithful non-repetition fact:
+\textbf{\Lean{} status.}\footnote{Formal declaration:
+\leanid{not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces} in
+\leanid{SelfOverlap.lean}; the proof is still open.} The lemma statement is the
+faithful non-repetition fact:
 distinct cyclic sectors (orthogonal projectors $P_uP_v=0$) are not gauge-phase
 equivalent. An earlier draft proposed to discharge it by a ``BDCF converse''
 (orthogonal sectors are eventually linearly independent, so a gauge-phase
 equivalence would force two sector matrix-product-vector families to be
 proportional). That is \emph{not} the source argument. The faithful route is the
 spectral one above, which reuses the peripheral-spectrum / fixed-point machinery
-already invoked in \leanid{Case1.lean}
-(\leanid{period_eq_of_gaugePhaseEquiv_of_isPeriodic}). The docstrings have been
-realigned to the source argument; the remaining work is to port it.
+already invoked in the different-period proof.\footnote{Formal declaration:
+\leanid{period_eq_of_gaugePhaseEquiv_of_isPeriodic} in \leanid{Case1.lean}.}
+The docstrings have been realigned to the source argument; the remaining work is
+to port it.
 
 \section{Sector-match case: propagation and the phase assembly}
 
-\textbf{Source (lines 961--1117).} Given one matched pair, applying the
-translation operator $T^l$ to the blocked equation \emph{eq:Nm} (lines 978--984)
+\textbf{Source.}\footnote{\cite{DeLasCuevas2017Irreducible}, Appendix~A,
+lines 961--1117; the initial blocked equation \emph{eq:Nm} appears at
+lines 978--984.} Given one matched pair, applying the
+translation operator $T^l$ to the blocked equation \emph{eq:Nm}
 and invoking Theorem~2.10 of \cite{CiracPerezGarcia2017Matrix} produces, at each
 offset, a phase and a unitary $U_{\tilde v+l}=P_{\tilde u+l}U_{\tilde
-v+l}Q_{\tilde v+l}$ (\emph{eq:blockedABprop}, lines 998--1002), so the offset
-$v-u=q$ is constant (\emph{eq:vprop}, line 1007). Then each blocked product
-$F_u$ (\emph{eq:Fu}) becomes injective after $N_0$ repetitions, with a right
-inverse $\Omega_u$ (\emph{eq:Omegauprop}); contracting the concatenated products
+v+l}Q_{\tilde v+l}$, so the offset
+$v-u=q$ is constant. Then each blocked product
+$F_u$ becomes injective after $N_0$ repetitions, with a right
+inverse $\Omega_u$; contracting the concatenated products
 with the $\Omega_u$ recovers per-site proportionality $A_u^i=\kappa_v\,
-e^{i\eta/m}\,B_v^i$ (\emph{eq:resultprop}, \emph{eq:thetaACprop}). The phase
+e^{i\eta/m}\,B_v^i$. The phase
 bookkeeping is load-bearing: $\prod_v\kappa_v=1$ (\emph{eq:prodkappaprop}) and
 $|\kappa_v|=1$ from $\|\sum_iA_u^{i\dagger}A_u^i\|=1$, so $\kappa_v=e^{i\theta_v}$
 with $\sum_v\theta_v=0$; choosing $\phi_v$ with $\theta_v=\phi_v-\phi_{v+1}$
 telescopes the per-sector phases into a single global phase $\xi=\eta/m$ and a
 single global unitary $U=\sum_u e^{i\phi_{u+q}}P_uU_{u+q}Q_{u+q}$, giving
-$A^i=e^{i\xi}UB^iU^\dagger$ (lines 1110--1117).
+$A^i=e^{i\xi}UB^iU^\dagger$.
 
-\textbf{\Lean{} status} (\leanid{Case3.lean}). The statements track this
-two-stage structure: \leanid{sectorMatch_propagation} (the
-$T^l$ + Theorem~2.10 staircase) and \leanid{sectorTensor_proportional_of_blockedMatch}
-/ \leanid{repeatedBlocks_of_blockedSectorGaugePhase} (the $\Omega_u$ contraction
-and the $\kappa/\theta/\phi$ phase assembly). The top-level theorem
-\leanid{periodicOverlap_gaugeEquiv_of_sector_match} is a \leanid{sorry} and does
-\emph{not} yet invoke these assembly lemmas; wiring it through them is the next
-step. The docstrings have been realigned to cite the source equation labels and
-line ranges (replacing earlier published-version labels such as ``A.8'' and
+\textbf{\Lean{} status.}\footnote{Formal declarations:
+\leanid{sectorMatch_propagation},
+\leanid{sectorTensor_proportional_of_blockedMatch},
+\leanid{repeatedBlocks_of_blockedSectorGaugePhase}, and
+\leanid{periodicOverlap_gaugeEquiv_of_sector_match} in \leanid{Case3.lean}.}
+The statements track this two-stage structure: the $T^l$ + Theorem~2.10
+staircase, followed by the $\Omega_u$ contraction and the
+$\kappa/\theta/\phi$ phase assembly. The top-level theorem now invokes these
+assembly lemmas and is proved modulo the two remaining leaf obligations. The
+docstrings have been realigned to cite the source equation labels and line
+ranges (replacing earlier published-version labels such as ``A.8'' and
 ``A.14--A.18'' that do not occur in the local source), and the
 $\kappa/\theta/\phi$ phase assembly is now stated explicitly as load-bearing.
 
 \section{Scope restriction: independence without spanning}
 
-\textbf{Source (lines 604--608, 610).} As a consequence of the proposition and
-Lemma~\emph{Lem1t} (lines 511--519), for $N\ge N_0$ the non-zero members of
+\textbf{Source.}\footnote{\cite{DeLasCuevas2017Irreducible}, lines 604--608
+and Lemma~\emph{Lem1t}, lines 511--519. The phrase about the name
+``basis of periodic vectors'' appears at line 611.} As a consequence of the
+proposition and Lemma~\emph{Lem1t}, for $N\ge N_0$ the non-zero members of
 $\{|V_N(A_j)\rangle\}_{j\in J}$ are linearly independent \emph{and} span
 $|V_N(A)\rangle$; the spanning half is what ``justifies the name basis of
-periodic vectors'' (line 610).
+periodic vectors''.
 
-\textbf{\Lean{} statement} (\leanid{Dichotomy.lean},
-\leanid{periodicBasis_eventuallyLinearlyIndependent}). Only the independence
+\textbf{\Lean{} statement.}\footnote{Formal declaration:
+\leanid{periodicBasis_eventuallyLinearlyIndependent} in \leanid{Dichotomy.lean};
+blueprint label \texttt{thm:periodic\_basis\_eventually\_li}.} Only the independence
 half is stated; the spanning clause is dropped. The basis condition is encoded
 directly as the pairwise non-repetition hypothesis \leanid{hNonrep} together with
 a common-period divisibility \leanid{hDiv}, rather than derived from a basis of
 periodic tensors, and the \emph{Lem1t} almost-orthonormal-implies-independent
-lemma is not used. The blueprint entry \texttt{thm:periodic\_basis\_eventually\_li}
-is correspondingly \texttt{\textbackslash notready} and states only the
-independence half. Restoring the spanning clause and routing through \emph{Lem1t}
-is tracked under \href{https://github.com/LionSR/TNLean/issues/81}{issue \#81}.
+lemma is not used. Restoring the spanning clause and routing through
+\emph{Lem1t} is tracked under
+\href{https://github.com/LionSR/TNLean/issues/81}{issue \#81}.
 
 \begin{thebibliography}{9}
 \bibitem{DeLasCuevas2017Irreducible}

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -88,7 +88,7 @@ $C_u^{\mathbf i}=e^{i\xi}UC_v^{\mathbf i}U^\dagger$ held with $U=P_uUP_v$
         &= e^{i\xi}U
            \sum_{\mathbf i} C_v^{\mathbf i}C_v^{\mathbf i\dagger} \\
         &= e^{i\xi}U .
-        \tag{\mathcal E_{C_v}(P_v)=P_v}
+        \tag{$\mathcal E_{C_v}(P_v)=P_v$}
 \end{align}
 so $U$ is a modulus-one eigenvector of $\mathcal E_A^m$. As the only such
 eigenvalue is $1$ with the diagonal fixed points $\{P_w\Lambda_AP_w\}$ and

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -48,11 +48,14 @@ contradiction unless $\lim_N|\langle V_N(A)|V_N(B)\rangle|=0$.
 
 \textbf{\Lean{} route.}\footnote{Formal declaration:
 \leanid{periodicOverlap_tendsto_zero_of_ne_period} in \leanid{Case1.lean}.}
-The same obstruction is realized spectrally. Write
+The same obstruction is realized spectrally. For a tensor $A$, write
+$\mathcal E_A$ and $\mathcal E_A^*$ for the transfer map and its adjoint,
+defined by
 \begin{align}
-    \mathcal E_A(Y) &= \sum_i A^iYA^{i\dagger}.
+    \mathcal E_A(Y) &= \sum_i A^iYA^{i\dagger},&
+    \mathcal E_A^*(Y) &= \sum_i A^{i\dagger}YA^i .
 \end{align}
-If $D_a=D_b$ and $B^i=\zeta\,XA^iX^{-1}$, then
+If $D_a=D_b$ and $B^i=\zeta\,XA^iX^{-1}$, the comparison is
 \begin{align}
     \mathcal E_B(Y)
         &= \zeta\bar\zeta\,
@@ -84,8 +87,8 @@ $C_u^{\mathbf i}=e^{i\xi}UC_v^{\mathbf i}U^\dagger$ held with $U=P_uUP_v$
         &= \sum_{\mathbf i} C_u^{\mathbf i}UC_v^{\mathbf i\dagger} \\
         &= e^{i\xi}U
            \sum_{\mathbf i} C_v^{\mathbf i}C_v^{\mathbf i\dagger} \\
-        &= e^{i\xi}U
-        && (\text{using } \mathcal E_{C_v}(P_v)=P_v) .
+        &= e^{i\xi}U .
+        \tag{\mathcal E_{C_v}(P_v)=P_v}
 \end{align}
 so $U$ is a modulus-one eigenvector of $\mathcal E_A^m$. As the only such
 eigenvalue is $1$ with the diagonal fixed points $\{P_w\Lambda_AP_w\}$ and

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -1,0 +1,158 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Proof-Route Alignment for the Periodic Overlap Dichotomy
+  (de las Cuevas--Cirac--Schuch--P\'erez-Garc\'ia)}
+\author{}
+\date{2026-06-05}
+
+\begin{document}
+\maketitle
+
+\section{Scope}
+
+This note records, in mathematical terms, where the \Lean{} development of the
+periodic overlap dichotomy in \leanid{TNLean/MPS/Periodic/Overlap/} chooses a
+proof route that differs from the appendix argument of
+\cite[Appendix~A]{DeLasCuevas2017Irreducible}, and where its statements restrict
+the source.\footnote{Paper-level umbrella:
+\href{https://github.com/LionSR/TNLean/issues/619}{issue \#619}; proposition-level
+subtracking: \href{https://github.com/LionSR/TNLean/issues/81}{issue \#81}
+(self-overlap limit and non-matching decay,
+\href{https://github.com/LionSR/TNLean/issues/448}{issue \#448}; sector-match
+propagation and gauge assembly,
+\href{https://github.com/LionSR/TNLean/issues/450}{issue \#450}).}
+
+The source proposition is \emph{equal-or-orthogonal-generalized}
+(\cite{DeLasCuevas2017Irreducible}, stated at lines 589--609, proved in
+Appendix~A at lines 903--1118). None of the deviations below is unfaithful in the
+smuggled-hypothesis sense: each \Lean{} statement is a faithful (or explicitly
+restricted) version of the source, and the route substitutions are
+mathematically equivalent. The note exists so that a reader checking the \Lean{}
+files against the local source \leanid{Papers/1708.00029/main.tex} can locate the
+differences quickly.
+
+\section{Different-period decay via the peripheral spectrum}
+
+\textbf{Source (lines 917--950).} For periods $m_a\neq m_b$, the paper blocks at
+$p=\operatorname{lcm}(m_a,m_b)$ and uses Lemma~\emph{bdcf}: the blocks
+$P_uA^{(p)}$ and $Q_vB^{(p)}$ are non-repeated normal tensors. Applying the
+one-site translation operator to $Q_vB^{(p)}$ versus $Q_{v+1}B^{(p)}$ yields a
+contradiction unless $\lim_N|\langle V_N(A)|V_N(B)\rangle|=0$.
+
+\textbf{\Lean{} route} (\leanid{Case1.lean},
+\leanid{periodicOverlap_tendsto_zero_of_ne_period}). The same obstruction is
+realized spectrally. If $D_a=D_b$ and $B^i=\zeta\,XA^iX^{-1}$, then
+$\mathcal E_B(Y)=\zeta\bar\zeta\,X\mathcal E_A(X^{-1}YX^{-\dagger})X^\dagger$;
+eigenvalue uniqueness for an irreducible completely positive map
+(\cite{Wolf2012Quantum}, Theorem~6.3) forces $|\zeta|=1$, so $\mathcal E_A$ and
+$\mathcal E_B$ have equal peripheral spectra. An $m$-periodic tensor has
+peripheral spectrum $\{e^{2\pi i r/m}:0\le r<m\}$, so equality forces $m_a=m_b$.
+Thus different periods exclude gauge-phase equivalence, and
+\emph{equal-or-orthogonal} (the irreducible trace-preserving overlap dichotomy)
+gives the decay. This substitutes the paper's lcm-blocking + translation
+argument; it is complete and proved (no \leanid{sorry}).
+
+\section{Sector non-repetition via the blocked fixed-point structure}
+
+\textbf{Source (Lemma \emph{bdcf}, lines 404--423).} For a periodic block,
+$\mathcal E_A$ is irreducible with peripheral spectrum $\{\omega^r\}$,
+$\omega=e^{2\pi i/m}$. The blocked map $\mathcal E_A^m$ then has $1$ as its only
+modulus-one eigenvalue (multiplicity $m$), with fixed-point set exactly
+$\{P_u\Lambda_AP_u\}_u$, while the adjoint $\mathcal E_A^{*m}$ has fixed points
+$\{P_u\}_u$. If, for $u\neq v$, a gauge-phase equivalence
+$C_u^{\mathbf i}=e^{i\xi}UC_v^{\mathbf i}U^\dagger$ held with $U=P_uUP_v$
+($UU^\dagger=P_u$, $U^\dagger U=P_v$), then
+$\mathcal E_A^m(U)=\sum_{\mathbf i}C_u^{\mathbf i}UC_v^{\mathbf i\dagger}
+=e^{i\xi}U\sum_{\mathbf i}C_v^{\mathbf i}C_v^{\mathbf i\dagger}=e^{i\xi}U$,
+so $U$ is a modulus-one eigenvector of $\mathcal E_A^m$. As the only such
+eigenvalue is $1$ with the diagonal fixed points $\{P_w\Lambda_AP_w\}$ and
+$U=P_uUP_v$ is off-diagonal for $u\neq v$, this is a contradiction.
+
+\textbf{\Lean{} status} (\leanid{SelfOverlap.lean},
+\leanid{not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces}, currently a
+\leanid{sorry}). The lemma statement is the faithful non-repetition fact:
+distinct cyclic sectors (orthogonal projectors $P_uP_v=0$) are not gauge-phase
+equivalent. An earlier draft proposed to discharge it by a ``BDCF converse''
+(orthogonal sectors are eventually linearly independent, so a gauge-phase
+equivalence would force two sector matrix-product-vector families to be
+proportional). That is \emph{not} the source argument. The faithful route is the
+spectral one above, which reuses the peripheral-spectrum / fixed-point machinery
+already invoked in \leanid{Case1.lean}
+(\leanid{period_eq_of_gaugePhaseEquiv_of_isPeriodic}). The docstrings have been
+realigned to the source argument; the remaining work is to port it.
+
+\section{Sector-match case: propagation and the phase assembly}
+
+\textbf{Source (lines 961--1117).} Given one matched pair, applying the
+translation operator $T^l$ to the blocked equation \emph{eq:Nm} (lines 978--984)
+and invoking Theorem~2.10 of \cite{CiracPerezGarcia2017Matrix} produces, at each
+offset, a phase and a unitary $U_{\tilde v+l}=P_{\tilde u+l}U_{\tilde
+v+l}Q_{\tilde v+l}$ (\emph{eq:blockedABprop}, lines 998--1002), so the offset
+$v-u=q$ is constant (\emph{eq:vprop}, line 1007). Then each blocked product
+$F_u$ (\emph{eq:Fu}) becomes injective after $N_0$ repetitions, with a right
+inverse $\Omega_u$ (\emph{eq:Omegauprop}); contracting the concatenated products
+with the $\Omega_u$ recovers per-site proportionality $A_u^i=\kappa_v\,
+e^{i\eta/m}\,B_v^i$ (\emph{eq:resultprop}, \emph{eq:thetaACprop}). The phase
+bookkeeping is load-bearing: $\prod_v\kappa_v=1$ (\emph{eq:prodkappaprop}) and
+$|\kappa_v|=1$ from $\|\sum_iA_u^{i\dagger}A_u^i\|=1$, so $\kappa_v=e^{i\theta_v}$
+with $\sum_v\theta_v=0$; choosing $\phi_v$ with $\theta_v=\phi_v-\phi_{v+1}$
+telescopes the per-sector phases into a single global phase $\xi=\eta/m$ and a
+single global unitary $U=\sum_u e^{i\phi_{u+q}}P_uU_{u+q}Q_{u+q}$, giving
+$A^i=e^{i\xi}UB^iU^\dagger$ (lines 1110--1117).
+
+\textbf{\Lean{} status} (\leanid{Case3.lean}). The statements track this
+two-stage structure: \leanid{sectorMatch_propagation} (the
+$T^l$ + Theorem~2.10 staircase) and \leanid{sectorTensor_proportional_of_blockedMatch}
+/ \leanid{repeatedBlocks_of_blockedSectorGaugePhase} (the $\Omega_u$ contraction
+and the $\kappa/\theta/\phi$ phase assembly). The top-level theorem
+\leanid{periodicOverlap_gaugeEquiv_of_sector_match} is a \leanid{sorry} and does
+\emph{not} yet invoke these assembly lemmas; wiring it through them is the next
+step. The docstrings have been realigned to cite the source equation labels and
+line ranges (replacing earlier published-version labels such as ``A.8'' and
+``A.14--A.18'' that do not occur in the local source), and the
+$\kappa/\theta/\phi$ phase assembly is now stated explicitly as load-bearing.
+
+\section{Scope restriction: independence without spanning}
+
+\textbf{Source (lines 604--608, 610).} As a consequence of the proposition and
+Lemma~\emph{Lem1t} (lines 511--519), for $N\ge N_0$ the non-zero members of
+$\{|V_N(A_j)\rangle\}_{j\in J}$ are linearly independent \emph{and} span
+$|V_N(A)\rangle$; the spanning half is what ``justifies the name basis of
+periodic vectors'' (line 610).
+
+\textbf{\Lean{} statement} (\leanid{Dichotomy.lean},
+\leanid{periodicBasis_eventuallyLinearlyIndependent}). Only the independence
+half is stated; the spanning clause is dropped. The basis condition is encoded
+directly as the pairwise non-repetition hypothesis \leanid{hNonrep} together with
+a common-period divisibility \leanid{hDiv}, rather than derived from a basis of
+periodic tensors, and the \emph{Lem1t} almost-orthonormal-implies-independent
+lemma is not used. The blueprint entry \texttt{thm:periodic\_basis\_eventually\_li}
+is correspondingly \texttt{\textbackslash notready} and states only the
+independence half. Restoring the spanning clause and routing through \emph{Lem1t}
+is tracked under \href{https://github.com/LionSR/TNLean/issues/81}{issue \#81}.
+
+\begin{thebibliography}{9}
+\bibitem{DeLasCuevas2017Irreducible}
+G.~de las Cuevas, J.~I.~Cirac, N.~Schuch, and D.~P\'erez-Garc\'ia,
+\emph{Irreducible forms of matrix product states: Theory and applications},
+J.~Math.~Phys.\ \textbf{58}, 121901 (2017), arXiv:1708.00029.
+
+\bibitem{CiracPerezGarcia2017Matrix}
+J.~I.~Cirac, D.~P\'erez-Garc\'ia, N.~Schuch, and F.~Verstraete,
+\emph{Matrix product states and projected entangled pair states: Concepts,
+symmetries, theorems}, Ann.\ Phys.\ \textbf{378}, 100 (2017)
+(``Ci15'' in arXiv:1708.00029).
+
+\bibitem{Wolf2012Quantum}
+M.~M.~Wolf, \emph{Quantum Channels and Operations: Guided Tour}, unpublished
+lecture notes (2012).
+\end{thebibliography}
+
+\end{document}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -65,3 +65,17 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
 - `cpgsv21_block_diagonal_parent_ground_space.tex` records the degenerate
   parent-Hamiltonian block-diagonal boundary-condition theorem behind the
   periodic block decomposition and the BNT ground-space span.
+
+For the periodic (irreducible-form) MPS Fundamental Theorem of
+arXiv:1708.00029, the overlap-dichotomy development has one route-alignment
+note.
+
+- `1708_periodic_overlap_route_alignment.tex` records where the Lean
+  development of the periodic overlap dichotomy (`MPS/Periodic/Overlap/`)
+  substitutes a mathematically equivalent proof route for the Appendix-A
+  argument: the different-period decay via the peripheral spectrum (Case 1),
+  the sector non-repetition via the blocked fixed-point structure of
+  Lemma bdcf (SelfOverlap), and the sector-match propagation plus the
+  load-bearing κ/θ/φ phase assembly (Case 3). It also records the scope
+  restriction of `periodicBasis_eventuallyLinearlyIndependent` (independence
+  half only, no spanning clause).


### PR DESCRIPTION
## Motivation

The periodic overlap dichotomy should track arXiv:1708.00029, Appendix A, in the notation and proof structure of the local source. The earlier text cited published-version labels absent from `Papers/1708.00029/main.tex`, described proof routes that differ from the appendix without a paper-gap note, and left the Case-3 top-level theorem disconnected from its assembly lemmas.

## Description

This PR realigns `TNLean/MPS/Periodic/Overlap/` with Proposition equal-or-orthogonal-generalized and its Appendix-A proof.

- Case 1 records the peripheral-spectrum proof as a route substitution for the paper's lcm-blocking and translation argument.
- Self-overlap records the Lemma bdcf spectral fixed-point argument for non-repetition of cyclic sectors.
- Case 3 follows the two-stage appendix structure: propagate one matched sector around the cycle, then contract the sector data and assemble the phases into one global gauge.
- `periodicOverlapDichotomy` now composes the four branch theorems after constructing the cyclic sector decompositions of `A` and `B`.
- `periodicBasis_eventuallyLinearlyIndependent` is marked as the independence-only scope restriction; the spanning clause and Lem1t route remain future work.
- `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex` records the route substitutions and scope restriction with source line references in footnotes and displayed calculations.

The dichotomy is proved modulo the remaining leaf obligations `not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces`, `sectorGaugePhaseEquiv_succ_of_cyclicTransport`, and `repeatedBlocks_of_blockedSectorGaugePhase`. The broader overlap sorry count drops from 7 to 4 across this branch.

Refs #81, #450, #619.

## Testing

- `lake build TNLean.MPS.Periodic.Overlap.SelfOverlap TNLean.MPS.Periodic.Overlap.Dichotomy -q --log-level=info`
- `lake build TNLean.MPS.Periodic.Overlap.SelfOverlap -q --log-level=info`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large doc/proof refactor in core periodic FT infrastructure with remaining `sorry` on sector transport, cyclic contraction, and BDCF non-repetition; misalignment could block downstream periodic FT theorems until those leaves close.
> 
> **Overview**
> Realigns the periodic overlap dichotomy in `MPS/Periodic/Overlap/` with arXiv:1708.00029 Appendix A: docstrings cite local line ranges and equation labels, and a new paper-gap note documents where Lean uses equivalent proof routes (peripheral spectrum for different periods, Lemma bdcf spectral non-repetition vs an older “BDCF converse” plan).
> 
> **Proof structure.** `periodicOverlapDichotomy` is no longer a single `sorry`; it case-splits on period and bond dimension, builds cyclic sector decompositions via the newly public `exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`, and dispatches to the branch theorems. `sectorMatch_propagation` is proved by cyclic induction on `Fin m`, modulo one-step transport. `periodicOverlap_gaugeEquiv_of_sector_match` wires propagation, sector normality, and blocked contraction in the appendix’s two-stage shape instead of one monolithic sorry.
> 
> **Remaining gaps (4 sorrys in this tree).** `sectorGaugePhaseEquiv_succ_of_cyclicTransport`, `repeatedBlocks_of_blockedSectorGaugePhase`, `not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces`, and `periodicBasis_eventuallyLinearlyIndependent` (independence-only; spanning/Lem1t documented as out of scope).
> 
> Blueprint updates mark dichotomy, sector propagation, and sector-match gauge equivalence as `\leanok`; adds the cyclic sector existence theorem after blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d23dedd0b40f29afc22cb1f2e9503d22380c75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->