### PR TITLE
doc(mpdo): realign general-case citations to arXiv:1606.00608 source labels

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -15,7 +15,7 @@ import TNLean.MPS.MPDO.FusionIsometries
 # Algebra-structure witnesses for MPDO renormalization fixed points
 
 This file replaces the earlier construction for the algebra-structure side of
-arXiv:1606.00608, Section 4.5.
+arXiv:1606.00608, the General case subsection (line 928).
 
 The paper's full statement uses coefficient systems
 $c_{\alpha,\beta,\gamma}^{(L)} =
@@ -72,7 +72,8 @@ The present `CompatibleWith` relation identifies the support algebras with the
 adjoint fixed-point algebras of the blocked transfer maps. It does **not** yet
 construct the specific `DiagonalChiFamily` attached to an RFP MPDO tensor, nor
 prove the converse algebra-to-fusion implication. Those steps still require the
-BNT / coefficient-comparison layer from Appendix C.3--C.4.
+BNT / coefficient-comparison layer from the appendix proofs of Proposition
+`Prop:IV.12` (lines 1830--1922) and Theorem `thm:IV.13` (lines 1925--2088).
 
 ### Why the converse algebra-to-fusion implication is blocked
 
@@ -104,14 +105,18 @@ blocking size, yet `E ∘ E ≠ E`.
 
 Closing the converse algebra-to-fusion implication therefore requires
 strengthening the predicate to the paper's full coefficient formulation -- the
-positive diagonal matrices `χ_{α,β,γ}` from Appendix C.3 and the coefficient
-identity `c^{(L)}_{α,β,γ} = tr(χ_{α,β,γ}^L)` from Appendix C.4. The scalar
+positive diagonal matrices `χ_{α,β,γ}` from the appendix proof of Proposition
+`Prop:IV.12` (lines 1830--1922) and the coefficient identity
+`c^{(L)}_{α,β,γ} = tr(χ_{α,β,γ}^L)` from the appendix proof of Theorem
+`thm:IV.13` (lines 1925--2088). The scalar
 Newton--Girard power-sum identity needed for the latter step is already
 available in this formalization.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.5 and Appendix C.3--C.4
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, the General case
+  subsection (line 928) and the appendix proofs of Proposition `Prop:IV.12`
+  (lines 1830--1922) and Theorem `thm:IV.13` (lines 1925--2088)
 * [Wolf12] Wolf, *Quantum Channels & Operations*, Theorem 6.12
 -/
 
@@ -148,7 +153,8 @@ support algebra. The fields `m_apply` and `iota_apply` require that these maps
 are realized by the ambient matrix product and ambient inclusion.
 
 This structure contains only this realization data. It does **not** yet include
-the full Section 4.5 coherence / coefficient / BNT layer from the paper. -/
+the full coherence / coefficient / BNT layer from the General case subsection
+(line 928) of the paper. -/
 structure AlgebraStructureData (d D : ℕ) where
   /-- Support algebra at blocked size `n`. -/
   A : ℕ → StarSubalgebra ℂ (Matrix (Fin D) (Fin D) ℂ)
@@ -272,7 +278,16 @@ def IsRFP_MPDO_via_algebra (M : MPOTensor d D) : Prop :=
   ∃ data : AlgebraStructureData d D, data.CompatibleWith M
 
 /-- A trace-preserving MPO with a positive-definite fixed point admits a
-stationary algebra tower as soon as it is an RFP. -/
+stationary algebra tower as soon as it is an RFP.
+
+Source: arXiv:1606.00608, Theorem `thm:IV.13` (line 972).
+
+**Scope restriction:** The trace-preserving hypothesis `h_tp`, the
+positive-definite hypothesis `hρ`, and the fixed-point hypothesis `hρ_fix` are
+added relative to `thm:IV.13` (which assumes only that `M` is in CF and
+generates MPDO) in order to invoke Wolf Theorem 6.12. This is therefore a
+scope-restricted variant, not the literal source theorem. See
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
 theorem isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
     {M : MPOTensor d D} (hRFP : IsRFP M) (h_tp : Kraus.IsTP M.toMPSTensor)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ) :
@@ -282,7 +297,16 @@ theorem isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
      (M := M) (h_tp := h_tp) hρ hρ_fix hRFP⟩
 
 /-- Under the same side hypotheses, the transfer-map fusion formulation implies
-this algebra formulation. -/
+this algebra formulation.
+
+Source: arXiv:1606.00608, Theorem `thm:IV.13` (line 972).
+
+**Scope restriction:** The trace-preserving hypothesis `h_tp`, the
+positive-definite hypothesis `hρ`, and the fixed-point hypothesis `hρ_fix` are
+added relative to `thm:IV.13` (which assumes only that `M` is in CF and
+generates MPDO) in order to invoke Wolf Theorem 6.12. This is therefore a
+scope-restricted variant, not the literal source theorem. See
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
 theorem isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed
     {M : MPOTensor d D} (hFusion : IsRFP_MPDO_via_fusion M)
     (h_tp : Kraus.IsTP M.toMPSTensor) {ρ : Mat} (hρ : ρ.PosDef)
@@ -508,8 +532,9 @@ If `X` is an eigenvector of the unblocked adjoint transfer map with eigenvalue
 `λ`, then it is an eigenvector of the adjoint blocked transfer map at size `n`
 with eigenvalue `λ^n`.
 
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. This is the
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and the appendix
+proof of Theorem `thm:IV.13`, lines 2046--2085 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. This is the
 spectral fixed-point calculation underlying the obstruction to deriving the
 fusion formulation from the present support-algebra predicate alone. -/
 theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector
@@ -535,10 +560,11 @@ More explicitly, let `E` be the one-site transfer map. If
 finite-order consequence of the fixed-point equality
 $\operatorname{Fix}((E^n)^\dagger)=\operatorname{Fix}(E^\dagger)$. It is not
 the fusion-side idempotence statement $E^2=E$; the latter is the paper's
-coefficient-comparison argument in Appendix C.4.
+coefficient-comparison argument in the appendix proof of Theorem `thm:IV.13`.
 
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and the appendix
+proof of Theorem `thm:IV.13`, lines 2046--2085 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     {n : ℕ} (hn : 0 < n) {lam : ℂ} {X : Mat} (hX_ne : X ≠ 0)
@@ -562,11 +588,13 @@ theorem adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra
 every positive blocked transfer map coincide with the adjoint fixed points of
 the unblocked transfer map.
 
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 2015--2067. This equality is only the fixed-point consequence of the
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and the appendix
+proof of Theorem `thm:IV.13`, lines 2015--2067. This equality is only the
+fixed-point consequence of the
 present algebra-tower predicate. It is not the converse
 from the algebra formulation to the fusion formulation; the latter requires
-the positive trace-power coefficient comparison used in Appendix C.4. -/
+the positive trace-power coefficient comparison used in the appendix proof of
+Theorem `thm:IV.13`. -/
 theorem adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     {n : ℕ} (hn : 0 < n) {X : Mat} :
@@ -583,8 +611,9 @@ Applying the fixed-point equality above to the stationary tower constructed
 from the faithful fixed point yields compatibility with the MPO tensor.  It is
 still only a consequence of the present algebra-tower predicate, not the source
 converse from Theorem IV.13(ii) to the fusion-isometry formulation.
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 2015--2067 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and the appendix
+proof of Theorem `thm:IV.13`, lines 2015--2067 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem stationaryOfFaithfulFixedPoint_compatible_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     (h_tp : Kraus.IsTP M.toMPSTensor)

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -16,7 +16,8 @@ The declarations here state the coefficient, product, trace-scalar, chi, and
 blocked-basis comparison predicates.  The theorem-data layer built from these
 predicates and the corresponding existential witness are recorded in separate
 files.  These files do not yet construct the source objects from an MPDO tensor;
-that construction remains part of the Appendix C.3--C.4 comparison work.
+that construction remains part of the comparison work in the appendix proofs of
+Proposition `Prop:IV.12` and Theorem `thm:IV.13`.
 
 The source comparison and remaining construction plan for these coefficient
 objects are recorded in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`,
@@ -25,7 +26,7 @@ Section "BNT-label coefficient objects and remaining elimination plan".
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Theorem IV.13(ii) and Appendix C.3--C.4
+  Theorem IV.13(ii) and the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`
 -/
 
 open scoped BigOperators ComplexOrder
@@ -53,12 +54,13 @@ The same-length product formula is recorded separately by
 Comparison with chosen blocked-basis coefficients is deliberately separated.
 The predicate
 `BNTBlockedBasisCoefficientComparison` records that comparison once the
-Appendix C.3 label maps have been supplied; constructing those maps from an
+label maps from the appendix proof of Proposition `Prop:IV.12` have been
+supplied; constructing those maps from an
 MPDO tensor remains part of the gap recorded in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`, Section "BNT-label
 coefficient objects and remaining elimination plan".
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.4, lines 1925--1942 of
+the appendix proof of Theorem `thm:IV.13`, lines 1925--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure BNTLabelCoefficientFamily (Λ : Type*) where
   /-- The coefficient \(c_{\alpha,\beta,\gamma}^{(L)}\).
@@ -74,14 +76,14 @@ variable {Λ : Type*} (c : BNTLabelCoefficientFamily Λ)
 /-- The BNT-label coefficient family canonically determined by a diagonal
 \(\chi_{\alpha,\beta,\gamma}\)-family.
 
-This is the source-side specialization used after Appendix C.4 constructs the
-positive diagonal matrices:
+This is the source-side specialization used after the appendix proof of Theorem
+`thm:IV.13` constructs the positive diagonal matrices:
 \[
   c^{(L)}_{\alpha,\beta,\gamma}
     = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L}).
 \]
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 noncomputable def ofChi (χ : DiagonalChiFamily Λ) : BNTLabelCoefficientFamily Λ where
   coeff L α β γ := χ.tracePowerCoeff α β γ L
@@ -90,7 +92,7 @@ noncomputable def ofChi (χ : DiagonalChiFamily Λ) : BNTLabelCoefficientFamily 
 a \(\chi\)-family.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem ofChi_coeff (χ : DiagonalChiFamily Λ) (L : ℕ) (α β γ : Λ) :
     (ofChi χ).coeff L α β γ = χ.tracePowerCoeff α β γ L :=
@@ -104,7 +106,7 @@ same-length product formula; the canonical coefficient family is indexed by
 all natural lengths, and this equality follows from the definition and the
 diagonal trace identity.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem ofChi_coeff_eq_trace_matrix_pow
     (χ : DiagonalChiFamily Λ) (L : ℕ) (α β γ : Λ) :
@@ -122,7 +124,7 @@ predicate `HasChiTracePowerForm`, this predicate has exactly the positive-length
 quantifier used for Theorem IV.13(ii).
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def HasPositiveLengthChiTracePowerForm (χ : DiagonalChiFamily Λ) : Prop :=
   ∀ L : ℕ, 0 < L → ∀ α β γ : Λ,
@@ -131,7 +133,7 @@ def HasPositiveLengthChiTracePowerForm (χ : DiagonalChiFamily Λ) : Prop :=
 /-- Trace reformulation of positive-length BNT-label trace-power form.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem HasPositiveLengthChiTracePowerForm.eq_trace_matrix_pow
     {χ : DiagonalChiFamily Λ} (h : c.HasPositiveLengthChiTracePowerForm χ)
@@ -143,7 +145,7 @@ theorem HasPositiveLengthChiTracePowerForm.eq_trace_matrix_pow
 positive-length trace-power form with respect to that same \(\chi\)-family.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem ofChi_hasPositiveLengthChiTracePowerForm (χ : DiagonalChiFamily Λ) :
     (ofChi χ).HasPositiveLengthChiTracePowerForm χ := by
@@ -259,23 +261,24 @@ end BNTLabelTraceScalarFamily
 
 For each positive blocked length `n`, the source map reads a chosen basis label
 of \(\mathcal A_n\) as a BNT label, while the target map reads a chosen basis
-label of \(\mathcal A_{2n}\) as a BNT label.  This is the source-side
-Appendix C.3 input needed before one can compare the blocked-basis
+label of \(\mathcal A_{2n}\) as a BNT label.  This is the source-side input
+from the appendix proof of Proposition `Prop:IV.12` needed before one can
+compare the blocked-basis
 coefficients with the BNT-label coefficient system.
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure BNTBlockedBasisLabelAssignment (data : AlgebraStructureData d D)
     (Λ : Type*) where
   /-- BNT label attached to a chosen basis element of \(\mathcal A_n\).
 
-  Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+  Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
   `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
   sourceLabel :
     ∀ n : ℕ, 0 < n → AlgebraStructureData.BlockedIndex data n → Λ
   /-- BNT label attached to a chosen basis element of \(\mathcal A_{2n}\).
 
-  Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+  Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
   `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
   targetLabel :
     ∀ n : ℕ, 0 < n → AlgebraStructureData.BlockedIndex data (2 * n) → Λ
@@ -288,7 +291,7 @@ variable {data : AlgebraStructureData d D} {Λ : Type*}
 /-- The single label map on the disjoint union of source- and target-length
 blocked-basis labels.
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def blockedLabel (n : ℕ) (hn : 0 < n) :
     AlgebraStructureData.BlockedIndex data n ⊕
@@ -323,24 +326,26 @@ The restriction is documented in
 coefficient objects and remaining elimination plan".
 
 This structure records the comparison statement only.  Constructing the label
-maps from the Appendix C.3 decomposition and relating this blocked product to
+maps from the decomposition in the appendix proof of Proposition `Prop:IV.12`
+and relating this blocked product to
 the same-length BNT operator product remain separate obligations.
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.3, lines 1830--1922 of
+the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure BNTBlockedBasisCoefficientComparison
     (data : AlgebraStructureData d D) {Λ : Type*}
     (c : BNTLabelCoefficientFamily Λ) where
-  /-- The Appendix C.3 BNT-label assignment for the chosen blocked bases.
+  /-- The BNT-label assignment from the appendix proof of Proposition `Prop:IV.12`
+  for the chosen blocked bases.
 
-  Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+  Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
   `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
   labelAssignment : BNTBlockedBasisLabelAssignment data Λ
   /-- The blocked-basis coefficient is pulled back from the source-length
   BNT-label coefficient.
 
   Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-  Appendix C.3, lines 1830--1922 of
+  the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
   `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
   coeff_eq : ∀ (n : ℕ) (hn : 0 < n)
     (i j : AlgebraStructureData.BlockedIndex data n)
@@ -357,7 +362,7 @@ variable {data : AlgebraStructureData d D} {Λ : Type*} {c : BNTLabelCoefficient
 /-- The source BNT label attached to a chosen basis element of
 \(\mathcal A_n\).
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def sourceLabel (n : ℕ) (hn : 0 < n)
     (i : AlgebraStructureData.BlockedIndex data n) : Λ :=
@@ -366,7 +371,7 @@ def sourceLabel (n : ℕ) (hn : 0 < n)
 /-- The target BNT label attached to a chosen basis element of
 \(\mathcal A_{2n}\).
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def targetLabel (n : ℕ) (hn : 0 < n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) : Λ :=
@@ -392,18 +397,20 @@ the BNT-label coefficient system.
 
 This is not yet a proof of Theorem IV.13(ii) from an MPDO tensor: it is the
 paper-faithful coefficient statement to be constructed.  The construction of
-this witness from the Appendix C.3--C.4 data remains the main obligation
+this witness from the data in the appendix proofs of Proposition `Prop:IV.12`
+and Theorem `thm:IV.13` remains the main obligation
 described in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`, Section
 "BNT-label coefficient objects and remaining elimination plan"; the
 blocked-basis comparison predicate is recorded separately below.
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and the appendix
+proof of Theorem `thm:IV.13`,
 lines 1925--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure PositiveBNTLabelChiTracePowerForm
     {Λ : Type*} (c : BNTLabelCoefficientFamily Λ) where
   /-- The length-independent BNT-label chi family.
 
   Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-  Appendix C.4, lines 1925--1942 of
+  the appendix proof of Theorem `thm:IV.13`, lines 1925--1942 of
   `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
   chi : DiagonalChiFamily Λ
   /-- Positivity of every diagonal entry.
@@ -425,11 +432,12 @@ variable {Λ : Type*} {c : BNTLabelCoefficientFamily Λ}
 \(\chi\)-family by taking the coefficient family to be
 \(\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})\).
 
-This records the coefficient part of the Appendix C.4 construction: once the
+This records the coefficient part of the construction in the appendix proof of
+Theorem `thm:IV.13`: once the
 positive diagonal matrices \(\chi_{\alpha,\beta,\gamma}\) have been produced,
 the corresponding coefficient system is their trace-power family.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def ofChi (χ : DiagonalChiFamily Λ) (hχ : χ.PosEntries) :
     PositiveBNTLabelChiTracePowerForm (BNTLabelCoefficientFamily.ofChi χ) where
@@ -477,7 +485,7 @@ coefficients.
 
 This is the coefficient-level form of arXiv:1606.00608,
 Theorem IV.13(ii), eq:algebra, lines 972--985, after choosing the canonical
-coefficient family described in Appendix C.4, lines 2015--2037 of
+coefficient family described in the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem HasSameLengthProductForm.eq_sum_ofChi_trace_pow [Fintype Λ]
     [∀ L : ℕ, AddCommMonoid (O L)] [∀ L : ℕ, Module ℂ (O L)]
@@ -524,7 +532,8 @@ associated to a \(\chi\)-family, written directly with length-one traces.
 
 This is the coefficient-level form of arXiv:1606.00608,
 Theorem IV.13(ii), idempotent equation, lines 981--985, after choosing the
-canonical coefficient family described in Appendix C.4, lines 2015--2037 of
+canonical coefficient family described in the appendix proof of Theorem `thm:IV.13`,
+lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem HasIdempotentCoefficientForm.eq_sum_ofChi_trace [Fintype Λ]
     {χ : DiagonalChiFamily Λ}
@@ -550,7 +559,8 @@ variable {data : AlgebraStructureData d D} {Λ : Type*} {c : BNTLabelCoefficient
 /-- The label map on the disjoint union of source and target blocked basis
 indices at a positive blocked length.
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922, and Theorem
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`,
+lines 1830--1922, and Theorem
 IV.13(ii), lines 972--985 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def blockedLabel (cmp : BNTBlockedBasisCoefficientComparison data c)
@@ -582,7 +592,7 @@ This is the canonical-coefficient version of the blocked-basis comparison
 corollary.  It does not construct the comparison maps or the \(\chi\)-family
 from an MPDO tensor.
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq_ofChi_trace_pow
     {χ : DiagonalChiFamily Λ}
@@ -617,7 +627,7 @@ def pulledBlockedChiFamily
 the BNT-label chi family composed with the source and target comparison maps.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem pulledBlockedChiFamily_toDiagonal_of_pos
     (cmp : BNTBlockedBasisCoefficientComparison data c)
@@ -632,7 +642,7 @@ pulled-back blocked chi family is the corresponding BNT-label trace-power
 coefficient.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem pulledBlockedChi_tracePowerCoeff_of_pos
     (cmp : BNTBlockedBasisCoefficientComparison data c)
@@ -652,7 +662,7 @@ theorem pulledBlockedChi_tracePowerCoeff_of_pos
 is the corresponding BNT-label chi-matrix size.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem pulledBlockedChi_dim_of_pos
     (cmp : BNTBlockedBasisCoefficientComparison data c)
@@ -672,7 +682,7 @@ pulled-back blocked chi matrix is the trace of the `L`-th power of the
 corresponding BNT-label chi matrix.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem pulledBlockedChi_trace_matrix_pow_of_pos
     (cmp : BNTBlockedBasisCoefficientComparison data c)
@@ -695,7 +705,7 @@ BNT-label chi witness to the trace-power formula for the pulled-back
 blocked-basis chi matrix.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq_pulledBlockedChi_trace_pow
     (cmp : BNTBlockedBasisCoefficientComparison data c)
@@ -716,7 +726,8 @@ coefficient family or comparison maps from an MPDO tensor; it only transports an
 already given uniform BNT-label witness along an already given comparison.  The
 unused zero-length component of the blocked chi family is filled by empty
 diagonal matrices.
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.3--C.4,
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and the appendix
+proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`,
 lines 1830--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def toPositiveBlockedStructureChiTracePowerForm
     (cmp : BNTBlockedBasisCoefficientComparison data c)

--- a/TNLean/MPS/MPDO/BNTTheoremData.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremData.lean
@@ -14,13 +14,13 @@ operator, trace-scalar, chi, and blocked-basis comparison primitives are kept in
 the coefficient file; the existential witness is recorded separately.
 
 The declarations here do not yet construct the source objects from an MPDO
-tensor.  They collect the objects and consequences that the Appendix C.3--C.4
-argument must provide.
+tensor.  They collect the objects and consequences that the appendix proofs of
+Proposition `Prop:IV.12` and Theorem `thm:IV.13` must provide.
 
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Theorem IV.13(ii) and Appendix C.3--C.4
+  Theorem IV.13(ii) and the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`
 -/
 
 open scoped BigOperators ComplexOrder
@@ -30,13 +30,14 @@ namespace MPOTensor
 /-- The BNT-label data asserted by the source theorem, together with its
 blocked-basis comparison.
 
-This record gathers the objects that the remaining Appendix C.3--C.4
-construction must produce from an MPDO tensor: the fixed BNT-label coefficient
+This record gathers the objects that the remaining construction in the appendix
+proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`
+must produce from an MPDO tensor: the fixed BNT-label coefficient
 system, the same-length BNT operator family and product law, the trace scalars
 and idempotent condition, the positive length-independent chi witness, and the
 comparison with the chosen blocked bases.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure BNTLabelTheoremData (data : AlgebraStructureData d D)
     (Λ : Type*) (O : ℕ → Type*) [Fintype Λ]
@@ -70,13 +71,13 @@ structure BNTLabelTheoremData (data : AlgebraStructureData d D)
   /-- The positive length-independent BNT-label chi witness.
 
   Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-  Appendix C.4, lines 1925--1942 of
+  the appendix proof of Theorem `thm:IV.13`, lines 1925--1942 of
   `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
   positiveChi : PositiveBNTLabelChiTracePowerForm coeffs
   /-- Comparison of the chosen blocked-basis coefficients with the BNT labels.
 
   Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-  Appendix C.3, lines 1830--1922 of
+  the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
   `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
   blockedComparison : BNTBlockedBasisCoefficientComparison data coeffs
 
@@ -90,7 +91,8 @@ variable {data : AlgebraStructureData d D} {Λ : Type*} {O : ℕ → Type*}
 family is canonically determined by the same diagonal
 \(\chi_{\alpha,\beta,\gamma}\)-family.
 
-This is the form closest to the Appendix C.4 construction: after the positive
+This is the form closest to the construction in the appendix proof of Theorem
+`thm:IV.13`: after the positive
 diagonal matrices \(\chi_{\alpha,\beta,\gamma}\) have been produced, the
 coefficient system is fixed to
 \[
@@ -100,7 +102,7 @@ coefficient system is fixed to
 The remaining inputs are precisely the product law, idempotent law, and
 blocked-basis comparison for that canonical coefficient family.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 noncomputable def ofChi (χ : DiagonalChiFamily Λ) (hχ : χ.PosEntries)
     (operators : BNTLabelOperatorFamily Λ O)
@@ -153,9 +155,10 @@ theorem positive_chi_trace_power :
     H.coeffs.HasPositiveLengthChiTracePowerForm H.positiveChi.chi :=
   H.positiveChi.tracePower
 
-/-- The Appendix C.3 BNT-label assignment carried by theorem data.
+/-- The BNT-label assignment from the appendix proof of Proposition `Prop:IV.12`
+carried by theorem data.
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def labelAssignment : BNTBlockedBasisLabelAssignment data Λ :=
   H.blockedComparison.labelAssignment
@@ -163,7 +166,7 @@ def labelAssignment : BNTBlockedBasisLabelAssignment data Λ :=
 /-- The source BNT label attached by theorem data to a chosen basis element of
 \(\mathcal A_n\).
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def sourceLabel (n : ℕ) (hn : 0 < n)
     (i : AlgebraStructureData.BlockedIndex data n) : Λ :=
@@ -172,7 +175,7 @@ def sourceLabel (n : ℕ) (hn : 0 < n)
 /-- The target BNT label attached by theorem data to a chosen basis element of
 \(\mathcal A_{2n}\).
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def targetLabel (n : ℕ) (hn : 0 < n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) : Λ :=
@@ -197,7 +200,7 @@ physical positive-length coefficients, and the formal coefficient family is
 not constrained at length zero by Theorem IV.13(ii).
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem coeff_eq_ofChi_coeff (L : ℕ) (hL : 0 < L) (α β γ : Λ) :
     H.coeffs.coeff L α β γ =
@@ -209,7 +212,7 @@ the canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem same_length_product_form_ofChi :
     H.operators.HasSameLengthProductForm
@@ -226,7 +229,7 @@ canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem same_length_product_eq_sum_ofChi
     (L : ℕ) (hL : 0 < L) (α β : Λ) :
@@ -242,7 +245,7 @@ canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), idempotent, lines 981--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem idempotent_coefficient_form_ofChi :
     H.traceScalars.HasIdempotentCoefficientForm
@@ -261,7 +264,7 @@ canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), idempotent, lines 981--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem idempotent_eq_sum_ofChi (γ : Λ) :
     H.traceScalars.traceScalar γ =
@@ -306,7 +309,7 @@ theorem idempotent_eq_sum (γ : Λ) :
 /-- The blocked-basis/BNT-label coefficient comparison carried by theorem data.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.3, lines 1830--1922 of
+the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq
     (n : ℕ) (hn : 0 < n)
@@ -324,7 +327,7 @@ the canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def blockedComparison_ofChi :
     BNTBlockedBasisCoefficientComparison data
@@ -341,7 +344,7 @@ with the canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq_ofChi
     (n : ℕ) (hn : 0 < n)
@@ -382,7 +385,7 @@ theorem idempotent_eq_sum_chi_trace (γ : Λ) :
 traces of powers of the pulled-back BNT-label chi matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq_trace_pow
     (n : ℕ) (hn : 0 < n)
@@ -399,7 +402,7 @@ theorem blocked_coeff_eq_trace_pow
 and the blocked-basis comparison.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def toPositiveBlockedStructureChiTracePowerForm :
     AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm data :=
@@ -409,7 +412,7 @@ def toPositiveBlockedStructureChiTracePowerForm :
 BNT-label chi family in theorem data along the blocked-basis comparison maps.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def positiveBlockedChi : AlgebraStructureData.BlockedStructureChiFamily data :=
   H.toPositiveBlockedStructureChiTracePowerForm.chi
@@ -419,7 +422,7 @@ BNT-label theorem data is exactly the BNT-label chi family composed with the
 source and target comparison maps.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_toDiagonal_of_pos
     (n : ℕ) (hn : 0 < n) :
@@ -432,7 +435,7 @@ blocked-basis chi family obtained from BNT-label theorem data is the
 corresponding BNT-label trace-power coefficient.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_tracePowerCoeff_of_pos
     (n : ℕ) (hn : 0 < n)
@@ -449,7 +452,7 @@ theorem positiveBlockedChi_tracePowerCoeff_of_pos
 from BNT-label theorem data is the corresponding BNT-label chi-matrix size.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_dim_of_pos
     (n : ℕ) (hn : 0 < n)
@@ -465,7 +468,7 @@ blocked-basis chi matrix obtained from BNT-label theorem data is the trace of
 the `L`-th power of the corresponding BNT-label chi matrix.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_trace_matrix_pow_of_pos
     (n : ℕ) (hn : 0 < n)
@@ -483,7 +486,7 @@ theorem positiveBlockedChi_trace_matrix_pow_of_pos
 data satisfies the blocked trace-power predicate.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_tracePower :
     data.HasBlockedStructureChiTracePowerForm H.positiveBlockedChi :=
@@ -493,7 +496,7 @@ theorem positiveBlockedChi_tracePower :
 data has positive diagonal entries.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_posEntries :
     H.positiveBlockedChi.PosEntries :=
@@ -503,7 +506,7 @@ theorem positiveBlockedChi_posEntries :
 data are positive.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_entry_pos
     (n : ℕ) (i j : AlgebraStructureData.BlockedIndex data n)
@@ -516,7 +519,7 @@ theorem positiveBlockedChi_entry_pos
 traces of powers of the pulled-back blocked-basis chi matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq_positiveBlockedChi_trace_pow
     (n : ℕ) (hn : 0 < n)

--- a/TNLean/MPS/MPDO/BNTTheoremWitness.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremWitness.lean
@@ -15,12 +15,13 @@ primitives.
 
 The declarations here do not yet construct the source objects from an MPDO
 tensor.  They record the existence statement and witness consequences that the
-Appendix C.3--C.4 argument must provide.
+appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13` must
+provide.
 
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Theorem IV.13(ii) and Appendix C.3--C.4
+  Theorem IV.13(ii) and the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`
 -/
 
 open scoped BigOperators ComplexOrder
@@ -37,7 +38,7 @@ This proposition-level witness uses universe-zero labels and operator spaces;
 the intended MPDO-derived finite-dimensional objects live in that universe.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure BNTLabelTheoremWitness (data : AlgebraStructureData d D) where
   /-- The finite type of BNT labels.
@@ -79,7 +80,7 @@ structure BNTLabelTheoremWitness (data : AlgebraStructureData d D) where
   /-- The BNT-label theorem data for these choices.
 
   Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-  Appendix C.3--C.4, lines 1830--1942 of
+  the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
   `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
   theoremData : @BNTLabelTheoremData d D data Label OperatorSpace
     labelFintype operatorAddCommMonoid operatorModule operatorMul
@@ -91,10 +92,11 @@ BNT labels, same-length operators, trace scalars, length-independent positive
 \(\chi_{\alpha,\beta,\gamma}\)-matrices, and the corresponding product,
 idempotent, and blocked-basis comparison data.  It is only the target
 existence predicate; constructing such a witness from an MPDO tensor remains
-the Appendix C.3--C.4 obligation.
+the obligation of the appendix proofs of Proposition `Prop:IV.12` and Theorem
+`thm:IV.13`.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def HasBNTLabelTheoremWitness (data : AlgebraStructureData d D) : Prop :=
   Nonempty (BNTLabelTheoremWitness data)
@@ -107,7 +109,7 @@ blocked-basis \(\chi\)-witness by pulling back the BNT-label
 maps.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positive_blocked_chi_witness {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -128,7 +130,7 @@ blocked \(\chi\)-family is obtained from the uniform BNT-label
 length-dependent family.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_blocked_chi_trace_power_form {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -144,7 +146,7 @@ This is the trace-form version of the preceding blocked-basis trace-power
 existence statement.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_blocked_coeff_eq_trace_pow {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -175,11 +177,12 @@ supplied as the witness, while the coefficient family is fixed to
   c^{(L)}_{\alpha,\beta,\gamma}
     = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L}).
 \]
-Constructing the inputs from an MPDO tensor remains the Appendix C.3--C.4
-obligation; this definition only makes the source-side coefficient choice
+Constructing the inputs from an MPDO tensor remains the obligation of the
+appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`;
+this definition only makes the source-side coefficient choice
 single-source once those inputs have been produced.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 noncomputable def ofChi (data : AlgebraStructureData d D)
     (Λ : Type) (O : ℕ → Type) [Fintype Λ]
@@ -209,7 +212,7 @@ noncomputable def ofChi (data : AlgebraStructureData d D)
 statement for Theorem IV.13(ii).
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem hasBNTLabelTheoremWitness {data : AlgebraStructureData d D}
     (W : BNTLabelTheoremWitness data) : HasBNTLabelTheoremWitness data :=
@@ -221,7 +224,7 @@ law, and blocked-basis comparison have been supplied for the canonical
 coefficient family.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem ofChi_hasBNTLabelTheoremWitness (data : AlgebraStructureData d D)
     (Λ : Type) (O : ℕ → Type) [Fintype Λ]
@@ -260,7 +263,7 @@ algebraic structures on the label type and operator spaces supplied by the
 witness.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def toTheoremData :
     @BNTLabelTheoremData d D data W.Label W.OperatorSpace
@@ -321,9 +324,10 @@ theorem positive_chi_trace_power :
     W.coeffs.HasPositiveLengthChiTracePowerForm W.positiveChi.chi :=
   W.toTheoremData.positive_chi_trace_power
 
-/-- The Appendix C.3 BNT-label assignment carried by an existential witness.
+/-- The BNT-label assignment from the appendix proof of Proposition `Prop:IV.12`
+carried by an existential witness.
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def labelAssignment : BNTBlockedBasisLabelAssignment data W.Label :=
   W.toTheoremData.labelAssignment
@@ -331,7 +335,7 @@ def labelAssignment : BNTBlockedBasisLabelAssignment data W.Label :=
 /-- The source BNT label attached by an existential witness to a chosen basis
 element of \(\mathcal A_n\).
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def sourceLabel (n : ℕ) (hn : 0 < n)
     (i : AlgebraStructureData.BlockedIndex data n) : W.Label :=
@@ -340,7 +344,7 @@ def sourceLabel (n : ℕ) (hn : 0 < n)
 /-- The target BNT label attached by an existential witness to a chosen basis
 element of \(\mathcal A_{2n}\).
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1830--1922 of
+Source: arXiv:1606.00608, the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def targetLabel (n : ℕ) (hn : 0 < n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) : W.Label :=
@@ -365,7 +369,7 @@ physical positive-length coefficients, and the formal coefficient family is
 not constrained at length zero by Theorem IV.13(ii).
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem coeff_eq_ofChi_coeff (L : ℕ) (hL : 0 < L) (α β γ : W.Label) :
     W.coeffs.coeff L α β γ =
@@ -377,7 +381,7 @@ written using the canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem same_length_product_form_ofChi :
     W.operators.HasSameLengthProductForm
@@ -389,7 +393,7 @@ with the canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem same_length_product_eq_sum_ofChi
     (L : ℕ) (hL : 0 < L) (α β : W.Label) :
@@ -404,7 +408,7 @@ using the canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), idempotent, lines 981--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem idempotent_coefficient_form_ofChi :
     W.traceScalars.HasIdempotentCoefficientForm
@@ -416,7 +420,7 @@ with the canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), idempotent, lines 981--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem idempotent_eq_sum_ofChi (γ : W.Label) :
     W.traceScalars.traceScalar γ =
@@ -459,7 +463,7 @@ theorem idempotent_eq_sum (γ : W.Label) :
 existential witness.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.3, lines 1830--1922 of
+the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq
     (n : ℕ) (hn : 0 < n)
@@ -477,7 +481,7 @@ written using the canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def blockedComparison_ofChi :
     BNTBlockedBasisCoefficientComparison data
@@ -489,7 +493,7 @@ witness, written with the canonical coefficient family determined by the same
 \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), eq:algebra, lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq_ofChi
     (n : ℕ) (hn : 0 < n)
@@ -530,7 +534,7 @@ theorem idempotent_eq_sum_chi_trace (γ : W.Label) :
 traces of powers of the BNT-label chi matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq_trace_pow
     (n : ℕ) (hn : 0 < n)
@@ -547,7 +551,7 @@ theorem blocked_coeff_eq_trace_pow
 trace-power witness for the chosen algebra-structure data.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def toPositiveBlockedStructureChiTracePowerForm :
     AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm data :=
@@ -558,7 +562,7 @@ BNT-label chi family in an existential witness along the blocked-basis
 comparison maps.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def positiveBlockedChi : AlgebraStructureData.BlockedStructureChiFamily data :=
   W.toPositiveBlockedStructureChiTracePowerForm.chi
@@ -568,7 +572,7 @@ existential BNT-label theorem witness is exactly the BNT-label chi family
 composed with the source and target comparison maps.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_toDiagonal_of_pos
     (n : ℕ) (hn : 0 < n) :
@@ -581,7 +585,7 @@ blocked-basis chi family obtained from an existential BNT-label theorem witness
 is the corresponding BNT-label trace-power coefficient.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_tracePowerCoeff_of_pos
     (n : ℕ) (hn : 0 < n)
@@ -598,7 +602,7 @@ from an existential BNT-label theorem witness is the corresponding BNT-label
 chi-matrix size.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_dim_of_pos
     (n : ℕ) (hn : 0 < n)
@@ -614,7 +618,7 @@ blocked-basis chi matrix obtained from an existential BNT-label theorem witness
 is the trace of the `L`-th power of the corresponding BNT-label chi matrix.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_trace_matrix_pow_of_pos
     (n : ℕ) (hn : 0 < n)
@@ -631,7 +635,7 @@ theorem positiveBlockedChi_trace_matrix_pow_of_pos
 BNT-label theorem witness satisfies the blocked trace-power predicate.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_tracePower :
     data.HasBlockedStructureChiTracePowerForm W.positiveBlockedChi :=
@@ -641,7 +645,7 @@ theorem positiveBlockedChi_tracePower :
 BNT-label theorem witness has positive diagonal entries.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_posEntries :
     W.positiveBlockedChi.PosEntries :=
@@ -651,7 +655,7 @@ theorem positiveBlockedChi_posEntries :
 BNT-label theorem witness are positive.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_entry_pos
     (n : ℕ) (i j : AlgebraStructureData.BlockedIndex data n)
@@ -665,7 +669,7 @@ coefficients are traces of powers of the pulled-back blocked-basis chi
 matrices.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem blocked_coeff_eq_positiveBlockedChi_trace_pow
     (n : ℕ) (hn : 0 < n)

--- a/TNLean/MPS/MPDO/BNTTheoremWitnessConsequences.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremWitnessConsequences.lean
@@ -14,12 +14,12 @@ the source equations, the positive \(\chi\)-coefficient form, and the
 blocked-basis comparison consequences.
 
 The declarations here do not construct the witness from an MPDO tensor; that
-remains the Appendix C.3--C.4 obligation.
+remains the obligation of the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`.
 
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Theorem IV.13(ii) and Appendix C.3--C.4
+  Theorem IV.13(ii) and the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`
 -/
 
 open scoped BigOperators ComplexOrder
@@ -36,7 +36,7 @@ the diagonal \(\chi_{\alpha,\beta,\gamma}\)-entries.
 This only unpacks the existential witness; it does not construct that witness
 from an MPDO tensor.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_source_predicates {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -57,7 +57,7 @@ This statement deliberately keeps the positive-length hypothesis.  Theorem
 IV.13(ii) does not constrain the artificial length-zero value of the formal
 coefficient family.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_positive_length_coeff_eq_ofChi {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -77,7 +77,7 @@ family determined by its \(\chi_{\alpha,\beta,\gamma}\)-matrices.
 This only rephrases the positive-length coefficient identity carried by the
 witness; it does not construct the witness from an MPDO tensor.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_source_ofChi_predicates {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -96,7 +96,7 @@ written with the canonical coefficient family determined by its
 This only rephrases the positive-length coefficient identity carried by the
 witness; it does not construct the witness from an MPDO tensor.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.4, lines 2015--2037 of
+the appendix proof of Theorem `thm:IV.13`, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_source_ofChi_equations {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -123,9 +123,10 @@ blocked-basis \(\chi\)-family is the pullback of the BNT-label
 \(\chi_{\alpha,\beta,\gamma}\)-family along the blocked-basis comparison maps.
 
 This only unpacks the existential witness; constructing such a witness from an
-MPDO tensor remains the Appendix C.3--C.4 obligation.
+MPDO tensor remains the obligation of the appendix proofs of Proposition `Prop:IV.12`
+and Theorem `thm:IV.13`.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_blocked_chi_pullback {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -149,9 +150,10 @@ blocked-basis multiplication coefficients and the BNT-label coefficients:
   c^{(n)}_{\sigma_n(i),\sigma_n(j),\tau_n(k)}.
 \]
 It only unpacks the existential witness; constructing such a witness from an
-MPDO tensor remains the Appendix C.3--C.4 obligation.
+MPDO tensor remains the obligation of the appendix proofs of Proposition `Prop:IV.12`
+and Theorem `thm:IV.13`.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3, lines 1830--1922 of
+the appendix proof of Proposition `Prop:IV.12`, lines 1830--1922 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_blocked_coefficient_comparison {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -177,7 +179,7 @@ This only rephrases the positive-length coefficient identity carried by the
 witness; constructing such a witness from an MPDO tensor remains the Appendix
 C.3--C.4 obligation.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_blocked_coefficient_comparison_ofChi {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -209,9 +211,10 @@ for positive \(L\), together with the idempotent equation
     \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta.
 \]
 It only unpacks the existential witness; constructing such a witness from an
-MPDO tensor remains the Appendix C.3--C.4 obligation.
+MPDO tensor remains the obligation of the appendix proofs of Proposition `Prop:IV.12`
+and Theorem `thm:IV.13`.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_source_coefficient_equations {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
@@ -248,9 +251,10 @@ for positive \(L\), together with the length-one idempotent equation
       \operatorname{tr}(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta.
 \]
 It only unpacks the existential witness; constructing such a witness from an
-MPDO tensor remains the Appendix C.3--C.4 obligation.
+MPDO tensor remains the obligation of the appendix proofs of Proposition `Prop:IV.12`
+and Theorem `thm:IV.13`.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
-Appendix C.3--C.4, lines 1830--1942 of
+the appendix proofs of Proposition `Prop:IV.12` and Theorem `thm:IV.13`, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem exists_source_chi_trace_equations {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -11,7 +11,8 @@ import TNLean.MPS.MPDO.RFP
 # Fusion-isometry formulations of the MPDO renormalization fixed point
 
 This file gives the **fusion-isometry** side of the equivalence stated in
-arXiv:1606.00608 Section 4.5 (Cirac–Pérez-García–Schuch–Verstraete). In the notation
+arXiv:1606.00608, the General case subsection (line 928)
+(Cirac–Pérez-García–Schuch–Verstraete). In the notation
 of the paper, a fusion isometry at blocked size `n` is a pair of linear maps
 `T`, `S` between the physical space of `n` blocked sites and the corresponding
 support algebra of the tensor, with `T ∘ S = id` on the support algebra and
@@ -43,7 +44,9 @@ transfer-map-level fusion formulation.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.5 and Appendix C.4
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, the General case
+  subsection (line 928) and the appendix proof of Theorem `thm:IV.13`
+  (lines 1925--2088)
   (Cirac–Pérez-García–Schuch–Verstraete, Ann. Phys. 378, 100–149).
 -/
 
@@ -154,9 +157,10 @@ The forward direction is the retract calculation
 \(E_1^2 = S_1T_1S_1T_1 = S_1T_1\).  The reverse direction factors the
 idempotent transfer map through its range.
 
-Source: arXiv:1606.00608, Theorem IV.13(i), and Appendix C.4, lines
-2065--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`, where the converse
-algebra-to-fusion proof constructs the one-step maps \(T\) and \(S\). -/
+Source: arXiv:1606.00608, Theorem IV.13(i), and the appendix proof of Theorem
+`thm:IV.13`, lines 2065--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`, where
+the converse algebra-to-fusion proof constructs the one-step maps \(T\) and
+\(S\). -/
 theorem fusionIsometryData_one_iff_isRFP (M : MPOTensor d D) :
     Nonempty (FusionIsometryData M 1) ↔ IsRFP M := by
   constructor
@@ -217,8 +221,8 @@ theorem isRFP_MPDO_via_fusion_iff_isRFP (M : MPOTensor d D) :
 one-site fusion retract.
 
 Thus, in the present transfer-map formulation, an algebra-to-fusion proof may
-be reduced to constructing the one-step retract appearing in Appendix C.4 of
-arXiv:1606.00608. -/
+be reduced to constructing the one-step retract appearing in the appendix proof
+of Theorem `thm:IV.13` (lines 1925--2088) of arXiv:1606.00608. -/
 theorem isRFP_MPDO_via_fusion_iff_fusionIsometryData_one (M : MPOTensor d D) :
     IsRFP_MPDO_via_fusion M ↔ Nonempty (FusionIsometryData M 1) := by
   rw [isRFP_MPDO_via_fusion_iff_isRFP, fusionIsometryData_one_iff_isRFP]

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -39,7 +39,7 @@ surrogate for the paper's vertical canonical form.
   canonical-form (biCF) field of `HorizontalCFData`.
 
 The full passage from horizontal to vertical canonical form
-(Proposition IV.12 / Proposition 4.13 of arXiv:1606.00608) is still outside
+(Proposition IV.12, `Prop:IV.12` line 945, of arXiv:1606.00608) is still outside
 this file: its blueprint entry `thm:vertical_cf_of_horizontal_cf` is marked
 `\notready`, and the corresponding Lean statement will be introduced together
 with its proof rather than as an empty placeholder.
@@ -317,8 +317,8 @@ theorem blockwise_insert_eq_of_mpv_agree
     (smul_eq_zero.mp hk).resolve_left hμne
   exact sub_eq_zero.mp hdiff
 
--- The implication `verticalCF_of_horizontalCF` (Proposition IV.12 / Proposition 4.13
--- of arXiv:1606.00608) — every MPDO in horizontal canonical form is in vertical
+-- The implication `verticalCF_of_horizontalCF` (Proposition IV.12, `Prop:IV.12`
+-- line 945, of arXiv:1606.00608) — every MPDO in horizontal canonical form is in vertical
 -- canonical form — is tracked by the blueprint entry
 -- `thm:vertical_cf_of_horizontal_cf` (currently `\notready`) and will be added
 -- as a theorem together with its proof once the horizontal-to-vertical


### PR DESCRIPTION
## Summary

Companion to #2349. A faithfulness audit of the general-case MPDO files (issue #826 area) found the same **citation drift**: docstrings cite journal-version labels — *Section 4.5*, *Appendix C.3*, *Appendix C.4* — absent from the local source `Papers/1606.00608/MPDO-22-12-17-2.tex` (arXiv:1606.00608).

This PR replaces each with the actual local structure:

| Fictional | Local source (verified) |
|---|---|
| Section 4.5 | the General case subsection (L928) |
| Appendix C.3 | the appendix proof of Proposition `Prop:IV.12` (L1830–1922) |
| Appendix C.4 | the appendix proof of Theorem `thm:IV.13` (L1925–2088) |
| Proposition 4.13 (stray) | Proposition `Prop:IV.12` (L945) |

Real labels (`Theorem IV.13`, `Proposition IV.12`, `thm:IV.13`, `Prop:IV.12`) and all correct line ranges (e.g. 2046–2085 for the T,S construction) are preserved.

## Faithfulness markers

Adds `**Scope restriction:**` notes to the two algebra-side forward bridges (`isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed`, `isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed`), whose `IsTP` / `PosDef`-fixed-point side hypotheses are **absent from `thm:IV.13`** (which assumes only "M in CF generating MPDO") and are added only to invoke Wolf Theorem 6.12. References `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.

## Scope & verification

- **Doc-only**: no signatures, proofs, or `\lean{}`/`\leanok` tags changed; comment blocks verified balanced; wrapped 8 lines to stay within the 100-char limit.
- Files: `AlgebraStructure`, `FusionIsometries`, `VerticalCF`, `BNTCoefficients`, `BNTTheoremData`, `BNTTheoremWitness`, `BNTTheoremWitnessConsequences` (`TNLean/MPS/MPDO/`).
- `lake build` of all touched modules: green, no warnings.

Refs #826, #237, #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and docstring edits only; no executable Lean or proof logic changes.
> 
> **Overview**
> Realigns MPDO general-case **docstrings and module comments** to the local arXiv:1606.00608 TeX (`Papers/1606.00608/MPDO-22-12-17-2.tex`), replacing journal-style pointers that do not exist in that file.
> 
> **Citation mapping:** *Section 4.5* → the General case subsection (line 928); *Appendix C.3* → appendix proof of Proposition `Prop:IV.12` (1830–1922); *Appendix C.4* → appendix proof of Theorem `thm:IV.13` (1925–2088); stray *Proposition 4.13* → `Prop:IV.12` (line 945). Existing labels (`Theorem IV.13`, line ranges) are kept where already correct.
> 
> **Faithfulness:** Adds **`Scope restriction:`** notes on `isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed` and `isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed`, stating that trace-preserving / positive-definite fixed-point hypotheses are extra relative to `thm:IV.13` (for Wolf 6.12), with a pointer to `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
> 
> Touches seven files under `TNLean/MPS/MPDO/` (`AlgebraStructure`, `FusionIsometries`, `VerticalCF`, `BNTCoefficients`, `BNTTheoremData`, `BNTTheoremWitness`, `BNTTheoremWitnessConsequences`). **No Lean definitions, proofs, or blueprint tags change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6168735fa554472b909f0eb9bda1fafb0da9f67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->