### PR TITLE
doc(parent): write block gap step by equations

### DIFF
--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -210,7 +210,7 @@ For the next display, abbreviate
   \qquad
   V_j=V^{(N)}(A_j).
 \end{align}
-Thus the desired periodic-chain proof has the mathematical form
+Thus the desired periodic-chain proof is the composition of the two implications
 \begin{align}
   \psi\in\mathcal K_{N,L}(\widetilde A)
   &\Longrightarrow
@@ -219,8 +219,11 @@ Thus the desired periodic-chain proof has the mathematical form
   \notag\\
   &\hphantom{\Longrightarrow}
   \forall\,1\le j\le b,\quad
-  \Gamma_j(X_j)\in\mathcal K_{N,L}(A_j),
-  \notag\\
+  \Gamma_j(X_j)\in\mathcal K_{N,L}(A_j)
+  ,
+\end{align}
+and, for every \(X_1,\ldots,X_b\),
+\begin{align}
   \forall\,1\le j\le b,\quad
   \Gamma_j(X_j)\in\mathcal K_{N,L}(A_j)
   &\Longrightarrow
@@ -231,7 +234,7 @@ Thus the desired periodic-chain proof has the mathematical form
   \Gamma_j(X_j)=c_j V_j
   .
 \end{align}
-Consequently,
+The composition gives
 \begin{align}
   \psi
   &=
@@ -243,9 +246,6 @@ Consequently,
   &\in
   \operatorname{span}\{V_j:j=1,\ldots,b\}.
 \end{align}
-The first implication is the periodic iteration of the block-diagonal
-intersection identity. The second implication is the one-block
-parent-Hamiltonian uniqueness theorem applied to each block.
 
 \section{Conclusion}
 


### PR DESCRIPTION
## Summary
- replace prose labels for the block-diagonal ground-space argument with the two displayed implications they denote
- keep the blockwise quantification explicit in the scalar conclusion

## Checks
- git diff --check
- latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv21_block_diagonal_parent_ground_space.tex
- checked for overfull hboxes in cpgsv21_block_diagonal_parent_ground_space.log

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits to a paper-gap note; no code, auth, or runtime behavior.
> 
> **Overview**
> The periodic-chain ground-space argument in `cpgsv21_block_diagonal_parent_ground_space.tex` is reframed as **two explicit displayed implications** instead of one long chain with prose labels.
> 
> The first display is membership in \(\mathcal K_{N,L}(\widetilde A)\) implying a block sum \(\psi=\sum_j \Gamma_j(X_j)\) with each \(\Gamma_j(X_j)\in\mathcal K_{N,L}(A_j)\). A **second** display, quantified over \(X_1,\ldots,X_b\), states blockwise ground membership implies scalar multiples \(\Gamma_j(X_j)=c_j V_j\). Wording shifts from “mathematical form” / “Consequently” to **composition** and “The composition gives” for the span conclusion; the closing sentences that named the block-diagonal identity and one-block uniqueness theorems are **removed** from that spot (the Conclusion section still mentions the gap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d1d2ca2ac30aae99c3c1a316cb538cc29e38dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->