### PR TITLE
doc(peps): trace Section-3 FT proof routes to the Cirac source

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -184,20 +184,27 @@ abbrev EdgeMiddleBoundaryLabel (A : Tensor G d) (e : Edge G) : Type _ :=
 
 /-- Kernel-descent data for the edge-middle tensor.
 
-For a finitely supported coefficient family $c_{\rho}$, the source proof
-considers kernel conditions $K_c(S)$ for finite vertex sets $S$ in the middle
-region. The initial condition is the zero relation: for every middle physical
-index $\tau$,
+This packages the formalization route to middle-block injectivity: a
+contraction of injective tensors is injective (arXiv:1804.04964, Section 3,
+`Papers/1804.04964/paper_normal.tex`, lines 205--250). The source proves that
+fact in one step from the one-sided inverse; the kernel conditions $K_c(S)$
+below are the finite-induction device used to formalize it, not a separate
+construction in the source.
+
+For a finitely supported coefficient family $c_{\rho}$, the kernel condition
+$K_c(S)$ for a finite vertex set $S$ in the middle region records the zero
+relation reached after contracting the tensors in $S$. The initial condition
+is, for every middle physical index $\tau$,
 \[
     \sum_{\rho} c_{\rho} T^{\rho}_{A,V\setminus\{u,v\}}(\tau)=0,
 \]
-which is $K_c(V\setminus\{u,v\})$. The deletion condition in
-the finite descent datum is $K_c(S)\Rightarrow K_c(S\setminus\{j\})$, obtained
-from the local left inverse at $j$. The terminal condition is
-$K_c(\varnothing)\Rightarrow c=0$.
+which is $K_c(V\setminus\{u,v\})$. The deletion condition
+$K_c(S)\Rightarrow K_c(S\setminus\{j\})$ applies the one-sided inverse at $j$.
+The terminal condition is $K_c(\varnothing)\Rightarrow c=0$.
 
-Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
-`Papers/1804.04964/paper_normal.tex`, lines 981--1009. -/
+Source: a contraction of injective tensors is injective, arXiv:1804.04964,
+Section 3, `Papers/1804.04964/paper_normal.tex`, lines 205--250; the middle
+block is that of `eq:block_to_mps`, lines 981--1009. -/
 structure EdgeMiddleKernelDescentData (A : Tensor G d) (e : Edge G) where
   /-- The finite kernel-descent datum attached to a coefficient family $c_{\rho}$.
 
@@ -502,12 +509,19 @@ For every edge $e=(u,v)$, the two endpoint tensor maps and the middle tensor
 obtained by blocking $V\setminus\{u,v\}$ form an injective three-site chain.
 
 Source: arXiv:1804.04964, Section 3, eq:block_to_mps,
-`Papers/1804.04964/paper_normal.tex`, lines 979--1009.
+`Papers/1804.04964/paper_normal.tex`, lines 979--1009. The middle-tensor
+injectivity is the source fact that a contraction of injective tensors is
+injective, with inverse the contraction of the inverses up to the bond
+dimension (lines 205--250); the two endpoint injectivities come directly from
+vertex injectivity.
 
-**Proof status:** This declaration states the source assertion. The current
-formal reductions and the remaining finite-region contraction theorem are
-recorded in `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section
-"Remaining mathematical obligations". -/
+**Proof status:** This declaration states the source assertion. The endpoint
+maps are injective from vertex injectivity; the open step is the middle-block
+contraction fact (lines 205--250). The current formal reductions route that
+fact through the finite kernel descent rather than the source's one-step
+inverse-of-a-contraction identity, and are recorded in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
+mathematical obligations"; tracked by issue #1366. -/
 theorem IsVertexInjective.edgeBlockedThreeSiteInjective {A : Tensor G d}
     (hA : IsVertexInjective A) (e : Edge G) :
     EdgeBlockedThreeSiteInjective (G := G) A e := by

--- a/TNLean/PEPS/EdgeMiddlePhysical.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical.lean
@@ -184,8 +184,8 @@ abbrev EdgeMiddleBoundaryLabel (A : Tensor G d) (e : Edge G) : Type _ :=
 
 /-- Kernel-descent data for the edge-middle tensor.
 
-This packages the formalization route to middle-block injectivity: a
-contraction of injective tensors is injective (arXiv:1804.04964, Section 3,
+This structure records the approach to middle-block injectivity: a contraction
+of injective tensors is injective (arXiv:1804.04964, Section 3,
 `Papers/1804.04964/paper_normal.tex`, lines 205--250). The source proves that
 fact in one step from the one-sided inverse; the kernel conditions $K_c(S)$
 below are the finite-induction device used to formalize it, not a separate

--- a/TNLean/PEPS/FiniteKernelDescent.lean
+++ b/TNLean/PEPS/FiniteKernelDescent.lean
@@ -12,7 +12,7 @@ one-sided inverse, and the inverse of a contraction of two injective tensors
 is the contraction of their inverses, up to the connecting bond dimension
 (arXiv:1804.04964, Section 3; the inverse-of-a-contraction identity in
 `Papers/1804.04964/paper_normal.tex`, lines 205--250). The finite induction
-packaged here is the formalization route towards that fact, not a separate
+described here is the approach towards that fact, not a separate
 step in the source: deleting one vertex of the region at a time, each step
 uses a one-sided inverse, until the empty contraction is reached. The region
 contracted is the middle block $V\setminus\{u,v\}$ of the edge blocking

--- a/TNLean/PEPS/FiniteKernelDescent.lean
+++ b/TNLean/PEPS/FiniteKernelDescent.lean
@@ -3,18 +3,28 @@ import Mathlib.Data.Finset.Basic
 /-!
 # Finite kernel descent for PEPS blocking arguments
 
-This file records the finite induction used in the proof that blocking a
-finite region of vertex-injective PEPS tensors preserves injectivity. In the
-source proof, after the edge blocking around $e=(u,v)$, the middle block is
-handled by repeatedly applying local left inverses inside
-$V\setminus\{u,v\}$.
+This file records a finite induction used to formalize the fact that
+contracting a finite region of vertex-injective PEPS tensors yields an
+injective tensor.
+
+The source establishes that fact in one step. An injective tensor admits a
+one-sided inverse, and the inverse of a contraction of two injective tensors
+is the contraction of their inverses, up to the connecting bond dimension
+(arXiv:1804.04964, Section 3; the inverse-of-a-contraction identity in
+`Papers/1804.04964/paper_normal.tex`, lines 205--250). The finite induction
+packaged here is the formalization route towards that fact, not a separate
+step in the source: deleting one vertex of the region at a time, each step
+uses a one-sided inverse, until the empty contraction is reached. The region
+contracted is the middle block $V\setminus\{u,v\}$ of the edge blocking
+`eq:block_to_mps`.
 
 ## References
 
 - [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
   entangled pair states generating the same state*, arXiv:1804.04964,
   Section 3, `eq:block_to_mps`](https://arxiv.org/abs/1804.04964)
-- `Papers/1804.04964/paper_normal.tex`, lines 979--1009.
+- `Papers/1804.04964/paper_normal.tex`, lines 205--250 (a contraction of
+  injective tensors is injective) and 981--1009 (`eq:block_to_mps`).
 -/
 
 namespace TNLean
@@ -26,10 +36,11 @@ In the edge-blocking proof, `kernelCondition S` is the assertion $K(S)$ that a
 family of boundary coefficients, with the virtual indices exposed at that
 stage, gives zero after the tensors in $S$ are contracted. The deletion
 implication is the step $K(S)\Rightarrow K(S\setminus\{j\})$ obtained from the
-local left inverse at $j$.
+one-sided inverse at $j$.
 
-Source: arXiv:1804.04964, Section 3, `eq:block_to_mps`,
-`Papers/1804.04964/paper_normal.tex`, lines 979--1009. -/
+Source: the one-sided inverse of an injective tensor, arXiv:1804.04964,
+Section 3, `Papers/1804.04964/paper_normal.tex`, lines 205--250; applied to the
+middle block of `eq:block_to_mps`, lines 981--1009. -/
 structure FiniteRegionKernelDescent (V : Type*) [DecidableEq V] where
   /-- The kernel condition attached to a finite vertex set. -/
   kernelCondition : Finset V → Prop

--- a/TNLean/PEPS/TwoInjectiveComparison.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison.lean
@@ -135,16 +135,17 @@ $A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2)
 = B_1(\eta_1,\mu,\sigma_1)B_2(\eta_2,\nu,\sigma_2)$ for all indices
 independently.
 
-Scope note: that separated equality is stronger than the source hypothesis of
-Lemma inj_equal_tensors_2, which assumes equality of one-bond insertions only.
-It follows from the conclusion $A_1=\lambda B_1$, $A_2=\lambda^{-1}B_2$, so this
-lemma lies on the source path only in the single-shared-bond case, where a
-matrix-unit insertion extracts the separated product directly
+**Scope restriction (separated product):** that separated equality is stronger
+than the source hypothesis of Lemma inj_equal_tensors_2, which assumes equality
+of one-bond insertions only. It follows from the conclusion
+$A_1=\lambda B_1$, $A_2=\lambda^{-1}B_2$, so this lemma lies on the source path
+only in the single-shared-bond case, where a matrix-unit insertion extracts the
+separated product directly
 (`two_injective_tensor_insertion_comparison_singletonBond`). In the
 many-shared-bond case the source does not separate the product; it follows the
-$Z,U,W$ gauge-consistency route via `threeLeg_residual_forms_scalar`
-(arXiv:1804.04964, Section 3, lines 1157--1204 of
-`Papers/1804.04964/paper_normal.tex`).
+$Z,U,W$ gauge-consistency route via `threeLeg_residual_forms_scalar`. Documented
+in `docs/paper-gaps/peps_injective_ft_section3_route.tex` (arXiv:1804.04964,
+Section 3, lines 1157--1204 of `Papers/1804.04964/paper_normal.tex`).
 -/
 theorem twoBlockReciprocalScalarProportional_of_pointwise_mul_eq
     {External₁ External₂ Physical₁ Physical₂ : Type*}

--- a/TNLean/PEPS/TwoInjectiveComparison.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison.lean
@@ -129,15 +129,22 @@ def TwoBlockReciprocalScalarProportional
 omit [Fintype Bond] [(b : Bond) → Fintype (bondDim b)] in
 /-- Reciprocal scalar proportionality from separated pointwise products.
 
-This is the final finite-dimensional cancellation step in the two-injective
-comparison once the insertion equalities have been converted into pointwise
-equalities of tensor products. It is the rank-one cancellation part of
-arXiv:1804.04964, Section 3, Lemma inj_equal_tensors_2, lines 1068--1203 of
-Papers/1804.04964/paper_normal.tex.
+This auxiliary cancellation closes the comparison once the two pairs of blocks
+satisfy the separated equality
+$A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2)
+= B_1(\eta_1,\mu,\sigma_1)B_2(\eta_2,\nu,\sigma_2)$ for all indices
+independently.
 
-Proof status: the remaining open theorem `two_injective_tensor_insertion_comparison`
-must still derive the hypothesis of this lemma from equality of all one-bond
-insertions, using injective inverses and `threeLeg_residual_forms_scalar`.
+Scope note: that separated equality is stronger than the source hypothesis of
+Lemma inj_equal_tensors_2, which assumes equality of one-bond insertions only.
+It follows from the conclusion $A_1=\lambda B_1$, $A_2=\lambda^{-1}B_2$, so this
+lemma lies on the source path only in the single-shared-bond case, where a
+matrix-unit insertion extracts the separated product directly
+(`two_injective_tensor_insertion_comparison_singletonBond`). In the
+many-shared-bond case the source does not separate the product; it follows the
+$Z,U,W$ gauge-consistency route via `threeLeg_residual_forms_scalar`
+(arXiv:1804.04964, Section 3, lines 1157--1204 of
+`Papers/1804.04964/paper_normal.tex`).
 -/
 theorem twoBlockReciprocalScalarProportional_of_pointwise_mul_eq
     {External₁ External₂ Physical₁ Physical₂ : Type*}
@@ -314,10 +321,17 @@ inserting an arbitrary matrix on any shared bond gives the same two-tensor
 coefficient for the `A`-pair and the `B`-pair, then there is a nonzero scalar
 `λ` such that `A₁ = λ B₁` and `A₂ = λ⁻¹ B₂`.
 
-**Proof status:** This is the main comparison theorem recorded in this file.
-The scalar-reduction substep and the remaining comparison argument are recorded
-in `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
-mathematical obligations". -/
+**Proof status:** open (`sorry`). The source route, which this proof should
+follow, groups the shared bonds into three nonzero legs, inverts `A₂`, and
+reads off the gauges $Z$, $U$, $W$ on the three leg pairs; their identity-form
+compatibility forces each to be a scalar by `threeLeg_residual_forms_scalar`
+(already proved), giving $A_1=\lambda B_1$ and $A_2=\lambda^{-1}B_2$
+(arXiv:1804.04964, Section 3, lines 1157--1204). The single-shared-bond case is
+closed by `two_injective_tensor_insertion_comparison_singletonBond`. The
+remaining work, the inversion and leg-regrouping that produce $Z$, $U$, $W$ from
+the one-bond insertions, is recorded in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
+mathematical obligations"; tracked by issue #1361. -/
 theorem two_injective_tensor_insertion_comparison
     {External₁ External₂ Physical₁ Physical₂ : Type*}
     [Nonempty Bond] [Nonempty External₁] [Nonempty External₂]
@@ -327,10 +341,11 @@ theorem two_injective_tensor_insertion_comparison
     (hB₁ : IsTwoBlockInjective B₁) (hB₂ : IsTwoBlockInjective B₂)
     (hinsert : SameTwoBlockInsertions A₁ B₁ A₂ B₂) :
     TwoBlockReciprocalScalarProportional A₁ B₁ A₂ B₂ := by
-  -- The remaining proof is Lemma inj_equal_tensors_2 from
-  -- arXiv:1804.04964, Section 3, lines 1068--1203. It depends on the
-  -- scalar-reduction substep recorded in
-  -- `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+  -- Source route (arXiv:1804.04964, Section 3, lines 1157--1204): invert `A₂`
+  -- and free the three leg pairs to obtain the gauges `Z`, `U`, `W`, then apply
+  -- `threeLeg_residual_forms_scalar` to force each to be a scalar. The
+  -- single-bond case is `two_injective_tensor_insertion_comparison_singletonBond`.
+  -- Status recorded in `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
   sorry
 
 /-! ### One vertex against its complement -/

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -187,7 +187,12 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   combines it with the endpoint injectivity assertions.
   The missing mathematical step is still the
   contraction theorem used in the paper: contracting vertex-injective tensors
-  over that finite middle region gives an injective blocked tensor. The full
+  over that finite middle region gives an injective blocked tensor. The source
+  proves this in one step from the one-sided inverse, where the inverse of a
+  contraction of injective tensors is the contraction of the inverses up to the
+  connecting bond dimension (\path{Papers/1804.04964/paper_normal.tex}, lines
+  205--250). The kernel descent recorded above is the finite-induction route
+  towards that one-step fact, not a separate argument in the source. The full
   transfer is now stated as
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective}; its
   proof remains open and is tracked by issue~\#1366.
@@ -265,12 +270,18 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   inserting the matrix unit $E_{\mu,\nu}$ extracts the single product
   $A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2)$, and the pointwise
   product cancellation theorem then gives reciprocal scalar proportionality.
-  The remaining proof of
-  \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison} is to derive
-  this coefficientwise product equality from equality of all one-bond
-  insertions in the many-bond case, using the injective inverse maps and the
-  scalar-reduction theorem. This remaining implication is tracked by
-  issue~\#1361.
+  The coefficientwise product separation above is on the source path only in the
+  single-shared-bond case
+  (\leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison_singletonBond}),
+  where a matrix-unit insertion extracts the product directly. In the many-bond
+  case the source does not separate the product: it inverts $A_2$, reads off the
+  gauges $Z,U,W$ on three leg pairs, and uses their identity-form compatibility
+  to force each gauge to be a scalar
+  (\leanid{TNLean.PEPS.threeLeg_residual_forms_scalar}, already proved;
+  \path{Papers/1804.04964/paper_normal.tex}, lines 1157--1204). The remaining
+  proof of \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison} is the
+  inversion and leg-regrouping that produce $Z,U,W$ from the one-bond
+  insertions. This is tracked by issue~\#1361.
 \item The final two-tensor comparison must then be applied by blocking one
   vertex against its complement. The paper uses this to prove
   $A_i=\lambda_i\widetilde B_i$ at each vertex, and then incorporates the


### PR DESCRIPTION
## Summary

A faithfulness pass over the injective-PEPS Section-3 Fundamental Theorem
(arXiv:1804.04964, `Papers/1804.04964/paper_normal.tex`). The proof route
carries intermediate scaffolding whose correspondence to the source argument
was hard to check; this realigns the docstrings and the paper-gap note so each
open step points at the paper passage it actually formalizes. No statement or
proof changes.

## Findings addressed

- **Middle-block injectivity (`#1366`).** The source proves "a contraction of
  injective tensors is injective" in one step from the one-sided inverse: the
  inverse of a contraction is the contraction of the inverses, up to the bond
  dimension (`paper_normal.tex` lines 205–250, displayed at line 222). The Lean
  `FiniteRegionKernelDescent` / `EdgeMiddleKernelDescentData` apparatus is the
  finite-induction *route* towards that one-step fact, not a separate source
  argument. The docstrings previously framed the per-vertex deletion as the
  source's own argument and cited only the `eq:block_to_mps` blocking lines
  (981–1009). They now state the route honestly and cite 205–250.

- **Two-injective comparison (`#1361`).** The faithful route is the source's
  `Z, U, W` gauge-consistency argument via the already-proved
  `threeLeg_residual_forms_scalar` (`paper_normal.tex` lines 1157–1204). The
  proof comment on `two_injective_tensor_insertion_comparison` and the scope
  note on `twoBlockReciprocalScalarProportional_of_pointwise_mul_eq` now state
  that the separated-product shortcut is on the source path **only** in the
  single-shared-bond case (`…_singletonBond`, via matrix-unit insertion). In the
  many-bond case the source does not separate the product.

- `docs/paper-gaps/peps_injective_ft_section3_route.tex` updated to match both.

## Verification

- Docstring/comment/tex only. Balanced block-comment delimiters; **sorry count
  unchanged** (1 each in `EdgeMiddlePhysical.lean`, `TwoInjectiveComparison.lean`;
  0 in `FiniteKernelDescent.lean`).
- All three edited Lean files compiled with `lake env lean` (exit 0, only the
  pre-existing `sorry` warnings).

## Scope

This is documentation realignment of an open research frontier — it does not
close any `sorry`. The named source routes (paper 205–250 for middle injectivity;
paper 1157–1204 via `threeLeg_residual_forms_scalar` for the two-injective
comparison) are the next implementation steps, tracked by #1366 and #1361.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and TeX documentation only; no executable proof or API changes.
> 
> **Overview**
> **Documentation-only** realignment of PEPS Section 3 (arXiv:1804.04964) docstrings and `docs/paper-gaps/peps_injective_ft_section3_route.tex`. No theorem statements, proofs, or `sorry` count changes.
> 
> **Middle-block injectivity (#1366):** Comments on `EdgeMiddleKernelDescentData`, `FiniteKernelDescent`, and `IsVertexInjective.edgeBlockedThreeSiteInjective` now state that the paper proves “contraction of injective tensors is injective” **in one step** from the one-sided inverse (`paper_normal.tex` 205–250), while `FiniteRegionKernelDescent` / kernel descent is the **formal induction route** toward that fact—not a separate source argument.
> 
> **Two-injective comparison (#1361):** `two_injective_tensor_insertion_comparison` and `twoBlockReciprocalScalarProportional_of_pointwise_mul_eq` now document the faithful many-bond path via **Z, U, W** and `threeLeg_residual_forms_scalar` (1157–1204), and that **separated pointwise product** reasoning is on the source path **only** for the single-shared-bond case (`…_singletonBond`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dbb1a3c6166019649b124ba236fa873b2757775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->