### PR TITLE
doc(mpdo): correct mis-numbered arXiv:1606.00608 Appendix C references

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -104,7 +104,7 @@ blocking size, yet `E ∘ E ≠ E`.
 
 Closing the converse algebra-to-fusion implication therefore requires
 strengthening the predicate to the paper's full coefficient formulation -- the
-positive diagonal matrices `χ_{α,β,γ}` from Appendix C.3 and the coefficient
+positive diagonal matrices `χ_{α,β,γ}` from Appendix C.4 and the coefficient
 identity `c^{(L)}_{α,β,γ} = tr(χ_{α,β,γ}^L)` from Appendix C.4. The scalar
 Newton--Girard power-sum identity needed for the latter step is already
 available in this formalization.
@@ -282,7 +282,12 @@ theorem isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
      (M := M) (h_tp := h_tp) hρ hρ_fix hRFP⟩
 
 /-- Under the same side hypotheses, the transfer-map fusion formulation implies
-this algebra formulation. -/
+this algebra formulation.
+
+**Scope restriction:** the side hypotheses `h_tp`/`hρ`/`hρ_fix` (trace
+preservation and a positive-definite fixed point, used to invoke Wolf Theorem
+6.12) are absent from Theorem IV.13, which assumes only that `M` is in canonical
+form generating an MPDO; see `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
 theorem isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed
     {M : MPOTensor d D} (hFusion : IsRFP_MPDO_via_fusion M)
     (h_tp : Kraus.IsTP M.toMPSTensor) {ρ : Mat} (hρ : ρ.PosDef)

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -91,7 +91,7 @@ structure SimpleMPDOLocalStructureData where
   hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1
   /-- Equality in strong subadditivity for `rhoABC`. -/
   hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian
-  /-- The local `η`-structure extracted in Lemma C.4. -/
+  /-- The quantum-Markov decomposition (`EtaStructure`) from Lemma C.2. -/
   eta : Nonempty (EtaStructure rhoABC)
   /-- The auxiliary real matrix `T` from Lemma C.5. -/
   Tdim : ℕ

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -77,9 +77,10 @@ condition.
 
 The structure is intentionally independent of a particular MPO tensor. The missing
 preceding theorem is the map from a concrete simple MPDO to this structure and
-then onward to `HasCommutingForm`: Lemma C.4 supplies the local `η`-structure
-and primitivity of `T`, while ZCL and Lemma C.5 supply trace-power constancy and
-the rank-one factorization of `T`. -/
+then onward to `HasCommutingForm`: Lemma C.2 supplies the local `η`-structure
+(the Markov decomposition), Lemma C.4 supplies the trace matrix `T` and its
+primitivity, while ZCL and Lemma C.5 supply trace-power constancy and the
+rank-one factorization of `T`. -/
 structure SimpleMPDOLocalStructureData where
   /-- Dimensions of the three contiguous local regions. -/
   dA : ℕ
@@ -93,7 +94,7 @@ structure SimpleMPDOLocalStructureData where
   hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian
   /-- The quantum-Markov decomposition (`EtaStructure`) from Lemma C.2. -/
   eta : Nonempty (EtaStructure rhoABC)
-  /-- The auxiliary real matrix `T` from Lemma C.5. -/
+  /-- The auxiliary trace matrix `T` from Lemma C.4. -/
   Tdim : ℕ
   T : Matrix (Fin Tdim) (Fin Tdim) ℝ
   /-- Primitivity of `T`, supplied by Lemma C.4. -/

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -17,12 +17,12 @@ At the present repository state, the local entropy side and the commuting-form
 side live in separate modules:
 
 * `SimpleLocalStructure.lean` isolates the local SAL/SSA and rank-one-`T`
-  consequences of Lemmas C.3--C.4.
+  consequences of Lemmas C.2 and C.5.
 * `CommutingFormBridge.lean` isolates the `η`-local structure that carries the
-  commuting-form witness of arXiv:1606.00608, Appendix C.2, Proposition C.6,
+  commuting-form witness of arXiv:1606.00608, Appendix C.2, Proposition C.8,
   after the sector-local neighboring operators have been assembled.
 * `CommutingForm.lean` states the GSNNCH / commuting-form target side of
-  arXiv:1606.00608, Appendix C.2, Proposition C.6 and Theorem 4.9(iii).
+  arXiv:1606.00608, Appendix C.2, Proposition C.8 and Theorem 4.9(iii).
 
 What is still missing is the preceding theorem turning the local simple-MPDO data
 into the global commuting-form property. Because of that gap, the present file
@@ -56,7 +56,7 @@ once the remaining local-to-global implication has been formalized.
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Appendix C.2, Proposition C.5 and Theorem 4.9
+  Appendix C.2, Corollary C.6 and Theorem 4.9
 -/
 
 open scoped Matrix ComplexOrder
@@ -65,7 +65,7 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- The local simple-MPDO structure isolated by Appendix C.2, Lemmas C.3--C.4.
+/-- The local simple-MPDO structure isolated by Appendix C.2, Lemmas C.2 and C.5.
 
 This structure contains exactly the information proved in `SimpleLocalStructure.lean`:
 
@@ -83,7 +83,7 @@ structure SimpleMPDOLocalStructureData where
   dA : ℕ
   dB : ℕ
   dC : ℕ
-  /-- The normalized three-site reduced state entering Lemma C.3. -/
+  /-- The normalized three-site reduced state entering Lemma C.2. -/
   rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ
   /-- Density-matrix normalization for the local state. -/
   hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1
@@ -91,7 +91,7 @@ structure SimpleMPDOLocalStructureData where
   hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian
   /-- The local `η`-structure extracted from SSA equality. -/
   eta : Nonempty (EtaStructure rhoABC)
-  /-- The auxiliary real matrix `T` from Lemma C.4. -/
+  /-- The auxiliary real matrix `T` from Lemma C.5. -/
   Tdim : ℕ
   T : Matrix (Fin Tdim) (Fin Tdim) ℝ
   /-- Primitivity of `T`. -/
@@ -105,7 +105,7 @@ structure SimpleMPDOLocalStructureData where
 
 namespace SimpleMPDOLocalStructureData
 
-/-- Construct the local simple-MPDO structure from the Lemma C.3/C.4 hypotheses
+/-- Construct the local simple-MPDO structure from the Lemma C.2 / Lemma C.5 hypotheses
 already available in `SimpleLocalStructure.lean`. -/
 def ofSALZCL
     {dA dB dC n : ℕ}
@@ -132,10 +132,10 @@ def ofSALZCL
   hTraceConst := hTraceConst
   rankOne := sal_zcl_implies_rank_one_T T hPrimitive hTrace hTraceConst hPF
 
-/-- Construct the local simple-MPDO structure from the Lemma C.3 hypotheses and
-the PSD-corrected Lemma C.4 rank-one criterion.
+/-- Construct the local simple-MPDO structure from the Lemma C.2 hypotheses and
+the PSD-corrected Lemma C.5 rank-one criterion.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 and the corollary after
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5 and the corollary after
 it, lines 1489--1505.
 
 **Local fix (PSD rank-one criterion):** the source's primitive
@@ -211,7 +211,7 @@ def ofSALZCLAndCommutingForm
 PSD-corrected rank-one criterion for `T`, a commuting-form hypothesis, and MPO
 ZCL.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 and Proposition 3to4,
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5 and Proposition 3to4,
 lines 1489--1505 and 1569--1593.
 
 **Local fix (PSD rank-one criterion):** this is the blocked-RFP version of
@@ -254,7 +254,7 @@ assembled `η`-local structure.
 
 References: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
 lines 1501--1505, and Proposition 3to4, lines 1571--1593. This declaration is
-the post-assembly step: the local hypotheses record the Lemmas C.3--C.4
+the post-assembly step: the local hypotheses record the Lemmas C.2 and C.5
 consequences, while the eta-local structure records the already assembled
 positive nearest-neighbor product
 `σ^{(N)}(K) ∝ ∏ n, B_{n,n+1}` with commuting bonds.
@@ -295,7 +295,7 @@ it does not construct the translated bond operators from SAL. Documented in
 construction is tracked by issue #823.
 
 **Local fix (PSD rank-one criterion):** it uses the positive-semidefinite
-replacement for the matrix step in Lemma C.4, documented in
+replacement for the matrix step in Lemma C.5, documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
 def ofSALZCLAndEtaLocalStructureOfPosSemidef
     {dA dB dC n : ℕ}
@@ -469,7 +469,7 @@ instead of deriving it from SAL. Documented in
 construction is tracked by issue #823.
 
 **Local fix (PSD rank-one criterion):** it uses the positive-semidefinite
-replacement for the matrix step in Lemma C.4, documented in
+replacement for the matrix step in Lemma C.5, documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
 theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef
     {K : MPOTensor d D} {dA dB dC n : ℕ}

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -108,7 +108,14 @@ structure SimpleMPDOLocalStructureData where
 namespace SimpleMPDOLocalStructureData
 
 /-- Construct the local simple-MPDO structure from the Lemma C.2, C.4, and C.5
-hypotheses already available in `SimpleLocalStructure.lean`. -/
+hypotheses already available in `SimpleLocalStructure.lean`.
+
+**Unfaithful:** This constructor currently relies on
+`sal_zcl_implies_rank_one_T`, whose `hPF` hypothesis is not supplied by
+arXiv:1606.00608, Lemma C.5, lines 1484--1502. Documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. Elimination: use
+`ofSALZCLOfPosSemidef` and `sal_zcl_implies_rank_one_T_of_posSemidef`; tracked
+in issue #1041. -/
 def ofSALZCL
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -191,7 +198,13 @@ namespace SimpleMPDOBlockedRFPData
 variable {K : MPOTensor d D}
 
 /-- Construct this structure directly from the local lemmas of
-`SimpleLocalStructure.lean`, the commuting-form hypothesis, and MPO ZCL. -/
+`SimpleLocalStructure.lean`, the commuting-form hypothesis, and MPO ZCL.
+
+**Unfaithful:** This constructor uses `SimpleMPDOLocalStructureData.ofSALZCL`,
+and hence relies on the conditional `hPF` shortcut absent from arXiv:1606.00608,
+Lemma C.5, lines 1484--1502. Documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. Elimination: use
+`ofSALZCLAndCommutingFormOfPosSemidef`; tracked in issue #1041. -/
 def ofSALZCLAndCommutingForm
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -266,7 +279,13 @@ it does not construct the translated bond operators from SAL. It also assumes
 the conditional primitive trace-power rank-one input `hPF`. Documented in
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` and
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the remaining constructions are
-tracked by issue #823. -/
+tracked by issue #823.
+
+**Unfaithful:** The local-data field is constructed through
+`SimpleMPDOLocalStructureData.ofSALZCL`, whose `hPF` shortcut is absent from
+arXiv:1606.00608, Lemma C.5, lines 1484--1502. Documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. Elimination: use
+`ofSALZCLAndEtaLocalStructureOfPosSemidef`; tracked in issue #1041. -/
 def ofSALZCLAndEtaLocalStructure
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -440,7 +459,15 @@ trace-power rank-one input `hPF`. It records the final assembly step after the
 nearest-neighbor bonds $B_{n,n+1}$ and their commutation have been constructed.
 Documented in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`
 and `docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the source-faithful
-constructions are tracked by issue #823. -/
+constructions are tracked by issue #823.
+
+**Unfaithful:** The proof uses the non-PSD constructor
+`SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure`, which relies on the
+conditional `hPF` shortcut absent from arXiv:1606.00608, Lemma C.5,
+lines 1484--1502. Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+Elimination: use the PSD-corrected theorem
+`simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef`; tracked
+in issue #1041. -/
 theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure {K : MPOTensor d D}
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -65,7 +65,8 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- The local simple-MPDO structure isolated by Appendix C.2, Lemmas C.2 and C.5.
+/-- The local simple-MPDO structure isolated by Appendix C.2, Lemmas C.2, C.4,
+and C.5.
 
 This structure contains exactly the information proved in `SimpleLocalStructure.lean`:
 
@@ -76,8 +77,9 @@ condition.
 
 The structure is intentionally independent of a particular MPO tensor. The missing
 preceding theorem is the map from a concrete simple MPDO to this structure and
-then onward to `HasCommutingForm`: SAL supplies the local `η`-structure, while
-ZCL supplies trace-power constancy and the rank-one factorization of `T`. -/
+then onward to `HasCommutingForm`: Lemma C.4 supplies the local `η`-structure
+and primitivity of `T`, while ZCL and Lemma C.5 supply trace-power constancy and
+the rank-one factorization of `T`. -/
 structure SimpleMPDOLocalStructureData where
   /-- Dimensions of the three contiguous local regions. -/
   dA : ℕ
@@ -89,12 +91,12 @@ structure SimpleMPDOLocalStructureData where
   hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1
   /-- Equality in strong subadditivity for `rhoABC`. -/
   hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian
-  /-- The local `η`-structure extracted from SSA equality. -/
+  /-- The local `η`-structure extracted in Lemma C.4. -/
   eta : Nonempty (EtaStructure rhoABC)
   /-- The auxiliary real matrix `T` from Lemma C.5. -/
   Tdim : ℕ
   T : Matrix (Fin Tdim) (Fin Tdim) ℝ
-  /-- Primitivity of `T`. -/
+  /-- Primitivity of `T`, supplied by Lemma C.4. -/
   hPrimitive : Matrix.IsPrimitive T
   /-- Trace normalization of `T`. -/
   hTrace : Matrix.trace T = 1
@@ -105,8 +107,8 @@ structure SimpleMPDOLocalStructureData where
 
 namespace SimpleMPDOLocalStructureData
 
-/-- Construct the local simple-MPDO structure from the Lemma C.2 / Lemma C.5 hypotheses
-already available in `SimpleLocalStructure.lean`. -/
+/-- Construct the local simple-MPDO structure from the Lemma C.2, C.4, and C.5
+hypotheses already available in `SimpleLocalStructure.lean`. -/
 def ofSALZCL
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -132,11 +134,11 @@ def ofSALZCL
   hTraceConst := hTraceConst
   rankOne := sal_zcl_implies_rank_one_T T hPrimitive hTrace hTraceConst hPF
 
-/-- Construct the local simple-MPDO structure from the Lemma C.2 hypotheses and
-the PSD-corrected Lemma C.5 rank-one criterion.
+/-- Construct the local simple-MPDO structure from the Lemma C.2 and C.4
+hypotheses and the PSD-corrected Lemma C.5 rank-one criterion.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.5 and the corollary after
-it, lines 1489--1505.
+Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4 and C.5 and the corollary
+after them, lines 1406--1505.
 
 **Local fix (PSD rank-one criterion):** the source's primitive
 nonnegative-matrix inference at lines 1490--1498 is not valid as stated. This
@@ -211,8 +213,8 @@ def ofSALZCLAndCommutingForm
 PSD-corrected rank-one criterion for `T`, a commuting-form hypothesis, and MPO
 ZCL.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.5 and Proposition 3to4,
-lines 1489--1505 and 1569--1593.
+Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4 and C.5 and Proposition 3to4,
+lines 1406--1505 and 1569--1593.
 
 **Local fix (PSD rank-one criterion):** this is the blocked-RFP version of
 `SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef`; the correction is recorded

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -17,7 +17,7 @@ At the present repository state, the local entropy side and the commuting-form
 side live in separate modules:
 
 * `SimpleLocalStructure.lean` isolates the local SAL/SSA and rank-one-`T`
-  consequences of Lemmas C.2 and C.5.
+  consequences of Lemmas C.2, C.4, and C.5.
 * `CommutingFormBridge.lean` isolates the `η`-local structure that carries the
   commuting-form witness of arXiv:1606.00608, Appendix C.2, Proposition C.8,
   after the sector-local neighboring operators have been assembled.
@@ -270,8 +270,8 @@ assembled `η`-local structure.
 
 References: arXiv:1606.00608, Appendix C.2, Corollary to Proposition 3.3,
 lines 1501--1505, and Proposition 3to4, lines 1571--1593. This declaration is
-the post-assembly step: the local hypotheses record the Lemmas C.2 and C.5
-consequences, while the eta-local structure records the already assembled
+the post-assembly step: the local hypotheses record the Lemmas C.2, C.4, and
+C.5 consequences, while the eta-local structure records the already assembled
 positive nearest-neighbor product
 `σ^{(N)}(K) ∝ ∏ n, B_{n,n+1}` with commuting bonds.
 

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -27,8 +27,8 @@ and realize the MPO on every finite length.
 
 This is the strongest unconditional forward step currently available.
 The intended future Proposition C.8 proof should construct
-`EtaLocalStructureData M` from the SAL and ZCL hypotheses, using the
-sector-reduced `η_{k,h}` operators and the inverse-map layer; the existing
+`EtaLocalStructureData M` from the SAL hypotheses, using the sector-reduced
+`η_{k,h}` operators and the inverse-map layer; the existing
 theorem `hasCommutingForm_of_etaLocalStructure` will then discharge the global
 commuting-form target.
 

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -26,7 +26,7 @@ positive two-site bond whose translated copies commute on all periodic chains
 and realize the MPO on every finite length.
 
 This is the strongest unconditional forward step currently available.
-The intended future Proposition C.6 proof should construct
+The intended future Proposition C.8 proof should construct
 `EtaLocalStructureData M` from the SAL and ZCL hypotheses, using the
 sector-reduced `η_{k,h}` operators and the inverse-map layer; the existing
 theorem `hasCommutingForm_of_etaLocalStructure` will then discharge the global
@@ -41,7 +41,7 @@ commuting-form target.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Appendix C.2, Proposition C.6
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Appendix C.2, Proposition C.8
 -/
 
 open scoped ComplexOrder
@@ -162,7 +162,7 @@ theorem exists_positive_scalar_mpo_eq_product
   data.formAt_realizes N hN
 
 /-- At a fixed chain length, the `η`-local structure gives precisely the
-positive commuting nearest-neighbor product form appearing in Proposition C.6
+positive commuting nearest-neighbor product form appearing in Proposition C.8
 of arXiv:1606.00608.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -29,7 +29,7 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 - `MPOTensor.EtaStructure`: the quantum-Markov decomposition on the middle
   subsystem supplied by equality in strong subadditivity.
 - `MPOTensor.sal_implies_eta_structure`: the Lean form of the entropy step in
-  Lemma C.3. We formalize the strong-area-law input locally as equality in
+  Lemma C.2. We formalize the strong-area-law input locally as equality in
   strong subadditivity for a normalized three-site reduced state.
 - `MPOTensor.etaOperators`: the dependent type of explicit neighboring operator
   families over a fixed Hayashi decomposition.
@@ -44,14 +44,14 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   Kronecker product of the sector-indexed neighboring reduced states.
 - `MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg`: positivity of each
   neighboring operator gives entrywise nonnegativity of the real trace matrix.
-- `MPOTensor.sal_zcl_implies_rank_one_T`: the conditional Lemma C.4 consequence,
+- `MPOTensor.sal_zcl_implies_rank_one_T`: the conditional Lemma C.5 consequence,
   proved relative to the Perron–Frobenius rank-one input.
 - `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`: the same consequence
   with the Perron–Frobenius input derived from positive semidefiniteness of `T`.
 
 ## Implementation note
 
-In the paper, Lemma C.3 continues from equality in strong subadditivity to the
+In the paper, Lemma C.2 continues from equality in strong subadditivity to the
 explicit operators `η_{k,h}` by applying local inverse maps coming from the
 injectivity of the simple tensor. The present file now contains that
 inverse-map layer for an injective simple MPO tensor, given by
@@ -70,7 +70,7 @@ matrix `T_{k,h} = 1`. The remaining connection to the Appendix C.2 proof is
 the identification of this sector-reduced family with the inverse-map
 construction in the original simple-MPDO tensor coordinates.
 
-Lemma C.4 is further isolated to the finite-dimensional Perron–Frobenius step:
+Lemma C.5 is further isolated to the finite-dimensional Perron–Frobenius step:
 for a primitive nonnegative matrix `T`, constant traces of positive powers are
 *claimed* (in the paper) to force `T` to have rank one. The universally
 quantified form of that claim is false — see
@@ -83,7 +83,7 @@ semidefiniteness of the concrete trace matrix, together with trace
 normalization and constant trace powers, supplies the missing diagonalizability
 and forces a rank-one factorization. The theorem
 `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef` connects this corrected
-criterion to the Lemma C.4 structure. What remains on
+criterion to the Lemma C.5 structure. What remains on
 the MPDO side is to prove that the sector trace matrix `T` extracted from the
 η-operators is itself positive semidefinite or Hermitian; positivity of the
 individual η-operators alone only gives entrywise nonnegativity of the trace
@@ -91,7 +91,7 @@ matrix.
 
 ## References
 
-- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Appendix C.2, Lemmas C.3–C.4
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Appendix C.2, Lemmas C.2 and C.5
 - Hayashi, *Quantum Information: An Introduction*, Springer 2006, Theorem 5.24
 - Ruskai, JMP 43, 4358 (2002)
 - Hayden, Jozsa, Petz, Winter, Commun. Math. Phys. 246, 359–374 (2004)
@@ -187,7 +187,7 @@ abbrev EtaStructure
       (Fin dA × Fin dB × Fin dC) ℂ) : Type :=
   Entropy.QuantumMarkovDecomposition ρ_ABC
 
-/-- **Lemma C.3, local entropy form**: strong area law implies the local
+/-- **Lemma C.2, local entropy form**: strong area law implies the local
 `η`-structure.
 
 We formalize the SAL input at the exact local point where the paper invokes it:
@@ -246,7 +246,7 @@ noncomputable def traceMatrix (data : ExplicitEtaOperators hη) :
 /-- The real-part trace matrix attached to an explicit `η_{k,h}` family.
 
 This is the direct real-valued input to the Perron–Frobenius matrix `T` used
-later in Appendix C.2, Lemma C.4. -/
+later in Appendix C.2, Lemma C.5. -/
 noncomputable def traceMatrixRe (data : ExplicitEtaOperators hη) :
     Matrix (Fin hη.m) (Fin hη.m) ℝ :=
   fun k h => (Matrix.trace (data.eta k h)).re
@@ -281,7 +281,7 @@ noncomputable def ofHayashiMarkov (hη : EtaStructure ρ_ABC) :
 /-- The trace of each extracted `η_{k,h}` equals the product of the sector
 traces, which are both `1` by normalization of the Hayashi density matrices.
 This specializes to `T_{k,h} = 1` for the partial-trace-based extraction and
-feeds the rank-one Perron–Frobenius step of Lemma C.4 with a concrete
+feeds the rank-one Perron–Frobenius step of Lemma C.5 with a concrete
 rank-one trace matrix (the all-ones matrix). -/
 @[simp] theorem traceMatrix_ofHayashiMarkov
     (hη : EtaStructure ρ_ABC) (k h : Fin hη.m) :
@@ -325,12 +325,21 @@ section RankOneT
 
 variable {n : ℕ}
 
-/-- **Lemma C.4, conditional matrix form**: once the matrix `T` attached to the
+/-- **Lemma C.5, conditional matrix form**: once the matrix `T` attached to the
 local `η`-structure is known to be primitive and to have constant trace on all
 positive powers, the remaining Perron–Frobenius input forces `T` to be rank one.
 
 The normalization `a ⬝ᵥ b = 1` is then immediate from `trace T = 1` and the
-identity `trace (vecMulVec a b) = a ⬝ᵥ b`. -/
+identity `trace (vecMulVec a b) = a ⬝ᵥ b`.
+
+**Unfaithful:** relies on `hPF : PrimitiveTracePowersConstantImpliesRankOne T`,
+which restates the conclusion and is false in general (counterexample in
+`TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`); the source Lemma
+C.5 (`SALZCL`, lines 1484--1502) instead derives the factorization from
+Perron--Frobenius fixed-point theory. Documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. Elimination: discharge via the
+PSD-corrected variant `sal_zcl_implies_rank_one_T_of_posSemidef` once the MPDO
+call site supplies positivity of `T`. -/
 theorem sal_zcl_implies_rank_one_T
     (T : Matrix (Fin n) (Fin n) ℝ)
     (hPrimitive : Matrix.IsPrimitive T)
@@ -343,7 +352,7 @@ theorem sal_zcl_implies_rank_one_T
   rw [← Matrix.trace_vecMulVec, ← hT]
   exact hTrace
 
-/-- **Lemma C.4, PSD-corrected matrix form**: if the auxiliary trace matrix `T`
+/-- **Lemma C.5, PSD-corrected matrix form**: if the auxiliary trace matrix `T`
 is positive semidefinite, then the corrected finite-dimensional theorem
 `Matrix.PosSemidef.trace_powers_constant_implies_rank_one` supplies the
 conditional Perron--Frobenius input used by `MPOTensor.sal_zcl_implies_rank_one_T`.

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -51,10 +51,10 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 
 ## Implementation note
 
-In the paper, Lemma C.2 continues from equality in strong subadditivity to the
-explicit operators `η_{k,h}` by applying local inverse maps coming from the
-injectivity of the simple tensor. The present file now contains that
-inverse-map layer for an injective simple MPO tensor, given by
+In the paper, Lemma C.2 supplies the Markov direct-sum decomposition. Lemma C.4
+then constructs the explicit operators `η_{k,h}` by applying local inverse maps
+coming from the injectivity of the simple tensor. The present file now contains
+that inverse-map layer for an injective simple MPO tensor, given by
 `MPOTensor.inverseTensor`, `MPOTensor.physRealize`, and
 `MPOTensor.physRealizeLeft`.
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -91,7 +91,8 @@ matrix.
 
 ## References
 
-- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Appendix C.2, Lemmas C.2 and C.5
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Lemmas C.2, C.4, and C.5
 - Hayashi, *Quantum Information: An Introduction*, Springer 2006, Theorem 5.24
 - Ruskai, JMP 43, 4358 (2002)
 - Hayden, Jozsa, Petz, Winter, Commun. Math. Phys. 246, 359–374 (2004)

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -19,7 +19,7 @@ networks, following arXiv:1606.00608, lines 736–741.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.2
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.3
 -/
 
 open scoped Matrix

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2663,10 +2663,9 @@ the elementary trace-power identity for diagonal matrices.
         thm:simple_mpdo_blocked_rfp_data_of_eta_local_structure}
     Suppose Lemma~C.2 gives the Markov decomposition, Lemma~C.4 gives the
     local $\eta$-structure and a primitive matrix $T$ with
-    $\operatorname{tr}(T)=1$ and $\operatorname{tr}(T^m)$ independent of $m$,
-    and Lemma~C.5 supplies the conditional rank-one criterion for $T$.
-    Suppose also that $K$ has zero correlation length and that the assembled
-    $\eta$-local structure gives
+    $\operatorname{tr}(T)=1$, and ZCL together with Lemma~C.5 gives
+    $\operatorname{tr}(T^m)$ independent of $m$ and the conditional rank-one
+    criterion for $T$. Suppose also that the assembled $\eta$-local structure gives
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$ for all $i,j$.
     Then these hypotheses determine the simple-MPDO blocked-RFP structure for $K$.

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2603,7 +2603,7 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:simple_mpdo_local_structure_data, thm:sal_implies_eta_structure,
         thm:sal_zcl_implies_rank_one_t, thm:psd_trace_powers_rank_one_t}
-    The hypotheses of Lemmas~C.2 and~C.5 determine the local simple-MPDO
+    The hypotheses of Lemmas~C.2, C.4, and~C.5 determine the local simple-MPDO
     structure. There are two forms. The conditional form assumes the
     rank-one implication for $T$. The corrected form assumes instead that
     $T\ge 0$ as a matrix, with $\operatorname{tr}(T)=1$ and
@@ -2828,7 +2828,7 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure,
         thm:simple_mpdo_rfp_chain_of_data}
-    Assume the local SAL--ZCL hypotheses of Lemmas~C.2 and~C.5 and the assembled
+    Assume the local SAL--ZCL hypotheses of Lemmas~C.2, C.4, and~C.5 and the assembled
     $\eta$-local product form, with the conditional rank-one criterion for $T$,
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$. Then
@@ -2875,7 +2875,7 @@ the elementary trace-power identity for diagonal matrices.
         def:simple_mpdo_blocked_rfp_data, thm:simple_mpdo_rfp_chain}
     The implication from SAL and ZCL alone to the conclusion of Appendix~C.2
     requires a derivation of the commuting-form property from the local
-    simple-MPDO structure of Lemmas~C.2 and~C.5. Once that derivation is available,
+    simple-MPDO structure of Lemmas~C.2, C.4, and~C.5. Once that derivation is available,
     Theorem~\ref{thm:simple_mpdo_rfp_chain} gives the GSNNCH--ZCL branch and
     the blocked fusion-isometry witness.
 \end{remark}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -2661,25 +2661,26 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{thm:simple_mpdo_local_structure_data_of_sal_zcl,
         thm:simple_mpdo_blocked_rfp_data_of_eta_local_structure}
-    Suppose the local hypotheses of Lemmas~C.2 and~C.5 give
-    $\rho_{ABC}$, $I(A:C|B)_{\rho}=0$, a primitive matrix $T$ with
+    Suppose Lemma~C.2 gives the Markov decomposition, Lemma~C.4 gives the
+    local $\eta$-structure and a primitive matrix $T$ with
     $\operatorname{tr}(T)=1$ and $\operatorname{tr}(T^m)$ independent of $m$,
-    together with the conditional rank-one criterion for $T$. Suppose also
-    that $K$ has zero correlation length and that the assembled
-    $\eta$-local data give
+    and Lemma~C.5 supplies the conditional rank-one criterion for $T$.
+    Suppose also that $K$ has zero correlation length and that the assembled
+    $\eta$-local structure gives
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$ for all $i,j$.
-    Then these data determine the simple-MPDO blocked-RFP structure for $K$.
+    Then these hypotheses determine the simple-MPDO blocked-RFP structure for $K$.
     In the PSD-corrected form, the conditional rank-one criterion is replaced
     by $T\ge0$, $\operatorname{tr}(T)=1$, and
     $\operatorname{tr}(T^m)=1$ for all $m>0$.
 \end{theorem}
 
 \begin{proof}\leanok
-    First form the local structure from the SAL--ZCL local hypotheses and the
-    conditional rank-one criterion for $T$. The $\eta$-local product formula
-    supplies the commuting-form component, and ZCL supplies the remaining
-    component of the blocked-RFP structure.
+    First form the local structure from the Lemma~C.2 Markov decomposition,
+    the Lemma~C.4 local $\eta$-structure and primitivity statement, and the
+    Lemma~C.5 conditional rank-one criterion for $T$. The $\eta$-local product
+    formula supplies the commuting-form component, and ZCL supplies the
+    remaining component of the blocked-RFP structure.
 \end{proof}
 
 \begin{theorem}[Zero correlation length gives a blocked fusion-isometry witness]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -581,7 +581,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{Matrix.PrimitiveTracePowersConstantImpliesRankOne}
     \leanok
     The auxiliary predicates state three matrix-theoretic ingredients used in
-    the rank-one step of Appendix~C.2, Lemma~C.4: constant traces of all
+    the rank-one step of Appendix~C.2, Lemma~C.5: constant traces of all
     positive powers, existence of a rank-one factorization $T = a b^\top$, and
     the conditional Perron--Frobenius implication from primitivity together with
     constant trace powers to such a factorization.
@@ -623,7 +623,7 @@ strong subadditivity for a normalized three-site reduced state.
     normalized by $\tr(T)=1$, and has constant traces on all positive powers,
     then $T$ has a rank-one factorization. Consequently, under the same
     positive-semidefinite and trace-normalization hypotheses, the conditional
-    rank-one criterion used in Lemma~C.4 follows.
+    rank-one criterion used in Lemma~C.5 follows.
 \end{theorem}
 
 \begin{proof}
@@ -684,7 +684,7 @@ strong subadditivity for a normalized three-site reduced state.
         thm:matrix_psd_trace_power_rank_one}
     The positive-semidefinite matrix criterion diagonalizes $T$, uses the first
     two trace moments to show that exactly one eigenvalue is nonzero, and hence
-    supplies the auxiliary rank-one criterion. The conditional Lemma~C.4
+    supplies the auxiliary rank-one criterion. The conditional Lemma~C.5
     statement then gives the factorization and trace normalization.
 \end{proof}
 
@@ -2603,7 +2603,7 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:simple_mpdo_local_structure_data, thm:sal_implies_eta_structure,
         thm:sal_zcl_implies_rank_one_t, thm:psd_trace_powers_rank_one_t}
-    The hypotheses of Lemmas C.3--C.4 determine the local simple-MPDO
+    The hypotheses of Lemmas~C.2 and~C.5 determine the local simple-MPDO
     structure. There are two forms. The conditional form assumes the
     rank-one implication for $T$. The corrected form assumes instead that
     $T\ge 0$ as a matrix, with $\operatorname{tr}(T)=1$ and
@@ -2661,7 +2661,7 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{thm:simple_mpdo_local_structure_data_of_sal_zcl,
         thm:simple_mpdo_blocked_rfp_data_of_eta_local_structure}
-    Suppose the local hypotheses of Lemmas~C.3--C.4 give
+    Suppose the local hypotheses of Lemmas~C.2 and~C.5 give
     $\rho_{ABC}$, $I(A:C|B)_{\rho}=0$, a primitive matrix $T$ with
     $\operatorname{tr}(T)=1$ and $\operatorname{tr}(T^m)$ independent of $m$,
     together with the conditional rank-one criterion for $T$. Suppose also
@@ -2827,7 +2827,7 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure,
         thm:simple_mpdo_rfp_chain_of_data}
-    Assume the local SAL--ZCL hypotheses of Lemmas~C.3--C.4 and the assembled
+    Assume the local SAL--ZCL hypotheses of Lemmas~C.2 and~C.5 and the assembled
     $\eta$-local product form, with the conditional rank-one criterion for $T$,
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$. Then
@@ -2874,7 +2874,7 @@ the elementary trace-power identity for diagonal matrices.
         def:simple_mpdo_blocked_rfp_data, thm:simple_mpdo_rfp_chain}
     The implication from SAL and ZCL alone to the conclusion of Appendix~C.2
     requires a derivation of the commuting-form property from the local
-    simple-MPDO structure of Lemmas~C.3--C.4. Once that derivation is available,
+    simple-MPDO structure of Lemmas~C.2 and~C.5. Once that derivation is available,
     Theorem~\ref{thm:simple_mpdo_rfp_chain} gives the GSNNCH--ZCL branch and
     the blocked fusion-isometry witness.
 \end{remark}


### PR DESCRIPTION
## Summary

`Papers/1606.00608/MPDO-22-12-17-2.tex` is `elsarticle`. Its **Appendix C** theorem-environments render (displayed numbers) as `Lsigma3` = **Lemma C.2**, `propSN` = Lemma C.4, `SALZCL` = **Lemma C.5**, `CorollarytoProp` = **Corollary C.6**, `3to4` = **Proposition C.8**; ZCL is the **Section 4.3** subsection. The MPDO docstrings/blueprint mixed these correct numbers with a few mis-numbered theorem-environment references. This corrects only the genuinely-wrong ones.

| Wrong | Correct | Referent |
|---|---|---|
| Lemma C.3 | Lemma C.2 | `Lsigma3` (SAL→Markov) |
| Lemma C.4 | Lemma C.5 | `SALZCL` (rank-one T) |
| Proposition C.5 | Corollary C.6 | `CorollarytoProp` |
| Proposition C.6 | Proposition C.8 | `3to4` (commuting form) |
| ZCL Section 4.2 | Section 4.3 | Zero correlation length |

The corrections are **corroborated by the blueprint's own already-correct usage** — `\cite[Proposition~C.8]{...}` for `3to4` (ch02b line 2494) and `\cite[Section~4.3]{...}` (line 199) — which only hold if the shared `thm` counter advances through the `DefQk` definition, fixing the whole chain.

**Kept untouched** (already correct): "Appendix C.2/C.3/C.4", "Theorem 4.9", "Theorem IV.13", "Proposition IV.12", "Section 4.5", "Proposition C.8", and all line ranges. (The `IV.13`-vs-`4.14` display choice is a separate editorial question left as-is.)

## Faithfulness markers

- `**Unfaithful:**` on `sal_zcl_implies_rank_one_T`: `hPF` restates the conclusion and is false in general; source Lemma C.5 uses Perron–Frobenius (`docs/paper-gaps/cpgsv17_pf_rank_one.tex`).
- `**Scope restriction:**` on the algebra forward bridge: `IsTP`/`PosDef`-fixed-point side hypotheses absent from Theorem IV.13 (`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`).

## Scope & verification

- **Doc-only**, 6 files: no signatures, proofs, or `\lean{}`/`\leanok`/`\uses{}` changed.
- `lake build` of all touched modules: green, no warnings.
- History: supersedes the closed #2349/#2350, which were based on a wrong premise (that the C.x/4.x numbers were fictional — they are real elsarticle displayed numbers).

Refs #823, #826, #232, #237.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint text only; no executable Lean or proof logic changed.
> 
> **Overview**
> Aligns **arXiv:1606.00608** citations in MPDO Lean docstrings and the blueprint with the paper’s displayed numbering: **Lemma C.2** (SAL→Markov), **Lemma C.5** (rank-one **T**), **Corollary C.6**, **Proposition C.8** (commuting form), and **Section 4.3** for ZCL. Narrative is updated so **C.2** is the Markov step, **C.4** the **η** / trace-matrix layer, and **C.5** the Perron–Frobenius rank-one step.
> 
> Adds **`**Unfaithful:**`** notes where constructors still use the conditional **`hPF`** shortcut (vs. Lemma C.5) and a **`**Scope restriction:**`** on the algebra fusion bridge (Wolf **6.12** side hypotheses vs. Theorem IV.13), with pointers to existing gap docs and issues.
> 
> **No** Lean signatures, proofs, or blueprint `\lean{}` links are changed—documentation and cross-references only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dddb23b4ffacb9edb28efe47706f3fe190599bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->