### PR TITLE
doc(mpdo): stop IsRFP and BiCFDerivation docstrings overstating the source

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -32,8 +32,8 @@ sufficient conditions for deriving that field.
    isolates the individual blocks (identity on one block, zero on the others),
    then concatenating the two families yields the preceding span condition.
    This is a self-contained *sufficient condition* for the block-separation step
-   of `propblockinj` (Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-   lines 340--345), which the paper itself obtains by citing David2006; the route
+   (Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, lines 340--345),
+   which the paper itself obtains by citing David2006; the route
    here is an alternative, not a formalization of the paper's argument, and the
    underlying block-separation theorem is still the missing ingredient (see the
    summary below and `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`).

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -31,8 +31,12 @@ sufficient conditions for deriving that field.
    block-injective at some common length and a second finite family of words
    isolates the individual blocks (identity on one block, zero on the others),
    then concatenating the two families yields the preceding span condition.
-   This captures the finite-length block-separation content of
-   Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, lines 340--345.
+   This is a self-contained *sufficient condition* for the block-separation step
+   of `propblockinj` (Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+   lines 340--345), which the paper itself obtains by citing David2006; the route
+   here is an alternative, not a formalization of the paper's argument, and the
+   underlying block-separation theorem is still the missing ingredient (see the
+   summary below and `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`).
 
 4. A **pairwise-to-global selector reduction**: if every ordered pair of
    distinct blocks admits a finite word polynomial that is the identity on the

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -281,9 +281,10 @@ theorem IsLPDO.isMPDO {M : MPOTensor d D} (h : IsLPDO M) : IsMPDO M := by
 This is *not* the paper's MPDO renormalization-fixed-point Definition 4.1
 (`RFPMixedTS`, arXiv:1606.00608 line 657: existence of two trace-preserving CP
 maps `T, S` on the physical indices). Idempotence coincides with Definition 4.1
-only in the pure (MPS) case; for general MPDO the equivalence with Definition 4.1
-is the content of Theorem 4.9 / Theorem IV.13, not a definition. A source-faithful
-`IsRFP_via_TS` and the bridge theorem are future work (#826, #237). -/
+only in the pure (MPS) case. For general MPDO, Definition 4.1 is strictly stronger:
+it implies idempotence/ZCL (Theorem 4.9, i ⟹ ii, gives ZCL and SAL), but ZCL alone
+does not imply it (line 786). A source-faithful `IsRFP_via_TS` and the bridge
+theorem are future work (#826, #237). -/
 def IsRFP (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M
 

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -275,8 +275,15 @@ theorem IsLPDO.isMPDO {M : MPOTensor d D} (h : IsLPDO M) : IsMPDO M := by
 
 /-! ### MPDO renormalization fixed points -/
 
-/-- An MPO tensor is an **MPDO renormalization fixed point** when its transfer
-map is idempotent: `E_M ∘ E_M = E_M`. See arXiv:1606.00608, Definition 4.1. -/
+/-- `IsRFP M` is the MPO transfer-map **idempotence** condition `E_M ∘ E_M = E_M`
+(definitionally `IsZCL M`, the zero-correlation-length characterization).
+
+This is *not* the paper's MPDO renormalization-fixed-point Definition 4.1
+(`RFPMixedTS`, arXiv:1606.00608 line 657: existence of two trace-preserving CP
+maps `T, S` on the physical indices). Idempotence coincides with Definition 4.1
+only in the pure (MPS) case; for general MPDO the equivalence with Definition 4.1
+is the content of Theorem 4.9 / Theorem IV.13, not a definition. A source-faithful
+`IsRFP_via_TS` and the bridge theorem are future work (#826, #237). -/
 def IsRFP (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M
 

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -283,8 +283,8 @@ This is *not* the paper's MPDO renormalization-fixed-point Definition 4.1
 maps `T, S` on the physical indices). Idempotence coincides with Definition 4.1
 only in the pure (MPS) case. For general MPDO, Definition 4.1 is strictly stronger:
 it implies idempotence/ZCL (Theorem 4.9, i ⟹ ii, gives ZCL and SAL), but ZCL alone
-does not imply it (line 786). A source-faithful `IsRFP_via_TS` and the bridge
-theorem are future work (#826, #237). -/
+does not imply it (line 786). A source-faithful `IsRFP_via_TS` and the theorem
+deriving idempotence from it are future work (#826, #237). -/
 def IsRFP (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M
 

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -279,9 +279,10 @@ theorem IsLPDO.isMPDO {M : MPOTensor d D} (h : IsLPDO M) : IsMPDO M := by
 (definitionally `IsZCL M`, the zero-correlation-length characterization).
 
 This is *not* the paper's MPDO renormalization-fixed-point Definition 4.1
-(`RFPMixedTS`, arXiv:1606.00608 line 657: existence of two trace-preserving CP
-maps `T, S` on the physical indices). Idempotence coincides with Definition 4.1
-only in the pure (MPS) case. For general MPDO, Definition 4.1 is strictly stronger:
+(paper label RFPMixedTS, arXiv:1606.00608 line 657: existence of two
+trace-preserving CP maps T and S on the physical indices). Idempotence coincides
+with Definition 4.1 only in the pure (MPS) case. For general MPDO, Definition 4.1
+is strictly stronger:
 it implies idempotence/ZCL (Theorem 4.9, i ⟹ ii, gives ZCL and SAL), but ZCL alone
 does not imply it (line 786). A source-faithful `IsRFP_via_TS` and the theorem
 deriving idempotence from it are future work (#826, #237). -/

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -15,7 +15,8 @@ Note that `IsRFP` is the idempotence / zero-correlation-length condition, not th
 paper's renormalization-fixed-point Definition 4.1 (`RFPMixedTS`, the existence of
 two trace-preserving CP maps), which is an a priori different notion for general
 MPDO; see the faithfulness note on `MPOTensor.IsRFP`. A source-faithful
-`IsRFP_via_TS` and the bridge theorem are future work (#826, #237).
+`IsRFP_via_TS` and the theorem deriving idempotence from it are future work
+(#826, #237).
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -12,9 +12,9 @@ and MPO zero correlation length (`MPOTensor.IsZCL`); the two are definitionally
 equal here.
 
 Note that `IsRFP` is the idempotence / zero-correlation-length condition, not the
-paper's renormalization-fixed-point Definition 4.1 (`RFPMixedTS`, the existence of
-two trace-preserving CP maps), which is an a priori different notion for general
-MPDO; see the faithfulness note on `MPOTensor.IsRFP`. A source-faithful
+paper's renormalization-fixed-point Definition 4.1 (paper label RFPMixedTS, the
+existence of two trace-preserving CP maps), which is an a priori different notion
+for general MPDO; see the faithfulness note on `MPOTensor.IsRFP`. A source-faithful
 `IsRFP_via_TS` and the theorem deriving idempotence from it are future work
 (#826, #237).
 
@@ -27,7 +27,8 @@ MPDO; see the faithfulness note on `MPOTensor.IsRFP`. A source-faithful
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Definition 4.2 (ZCL, line 735) and Definition 4.1 (`RFPMixedTS`, line 657)
+  Definition 4.2 (ZCL, line 735) and Definition 4.1 (paper label RFPMixedTS,
+  line 657)
 -/
 
 open scoped Matrix

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -5,11 +5,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.MPDO.ZCL
 
 /-!
-# General MPDO renormalization fixed point
+# MPDO transfer-map idempotence and zero correlation length
 
-This file states relations between the MPO transfer-map idempotence condition
-(`MPOTensor.IsRFP`) and MPO zero correlation length (`MPOTensor.IsZCL`),
-following arXiv:1606.00608, Definition 4.1.
+This file relates the MPO transfer-map idempotence condition (`MPOTensor.IsRFP`)
+and MPO zero correlation length (`MPOTensor.IsZCL`); the two are definitionally
+equal here.
+
+Note that `IsRFP` is the idempotence / zero-correlation-length condition, not the
+paper's renormalization-fixed-point Definition 4.1 (`RFPMixedTS`, the existence of
+two trace-preserving CP maps), which is an a priori different notion for general
+MPDO; see the faithfulness note on `MPOTensor.IsRFP`. A source-faithful
+`IsRFP_via_TS` and the bridge theorem are future work (#826, #237).
 
 ## Main results
 
@@ -19,7 +25,8 @@ following arXiv:1606.00608, Definition 4.1.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.1
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.2 (ZCL, line 735) and Definition 4.1 (`RFPMixedTS`, line 657)
 -/
 
 open scoped Matrix

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -889,12 +889,12 @@ retract.
     map $E_n$.
 \end{definition}
 
-\begin{theorem}[Fusion-isometry data imply the MPDO RFP condition]%
+\begin{theorem}[Fusion-isometry data imply transfer-map idempotence]%
     \label{thm:mpdo_rfp_of_fusion}
     \lean{MPOTensor.FusionIsometryData.isRFP, MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
-    A one-site fusion-isometry datum implies the MPDO RFP condition. Hence the
+    A one-site fusion-isometry datum implies transfer-map idempotence. Hence the
     fusion-isometry formulation, which supplies such data at every positive
     blocked size, implies the same condition.
 \end{theorem}
@@ -902,8 +902,8 @@ retract.
     Apply the definition at blocked size $n = 1$.
     If $E_1 = S_1 \circ T_1$ and $T_1 \circ S_1 = \operatorname{id}$, then
     $$E_1^2 = S_1 T_1 S_1 T_1 = S_1 (T_1 S_1) T_1 = S_1 T_1 = E_1.$$
-    Since $E_1$ is the original transfer map, this is exactly the MPDO RFP
-    condition.
+    Since $E_1$ is the original transfer map, this is exactly transfer-map
+    idempotence.
 \end{proof}
 
 \begin{theorem}[One-site fusion retract criterion]%
@@ -920,12 +920,12 @@ retract.
     it factors through its range, giving the required one-site datum.
 \end{proof}
 
-\begin{theorem}[Transfer-map fusion criterion for MPDO RFP]%
+\begin{theorem}[Transfer-map fusion criterion for idempotence]%
     \label{thm:mpdo_rfp_via_fusion_iff}
     \lean{MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
-    The fusion-isometry formulation is equivalent to the MPDO RFP condition.
+    The fusion-isometry formulation is equivalent to transfer-map idempotence.
 \end{theorem}
 \begin{proof}\leanok\uses{thm:mpdo_rfp_of_fusion}
     The forward implication is Theorem~\ref{thm:mpdo_rfp_of_fusion}.
@@ -2699,7 +2699,7 @@ the elementary trace-power identity for diagonal matrices.
 \end{theorem}
 
 \begin{proof}\leanok
-    Zero correlation length is the MPDO RFP condition.
+    Zero correlation length is transfer-map idempotence.
     Applying the converse direction of
     Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to that RFP witness yields
     fusion-isometry data at every positive blocked size; evaluating it at size $2$
@@ -2726,7 +2726,7 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:simple_mpdo_blocked_rfp_data, def:mpdo_rfp_via_fusion}
     Given the blocked-RFP data for an MPO tensor $K$, one obtains the
-    transfer-map fusion formulation of MPDO RFP.
+    transfer-map fusion formulation of idempotence.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -2747,7 +2747,7 @@ the elementary trace-power identity for diagonal matrices.
         lem:simple_mpdo_blocked_rfp_data_rfp_via_fusion}
     Given the blocked-RFP data for an MPO tensor $K$, one obtains the
     GSNNCH-with-ZCL case, the blocked fusion-isometry witness at size $2$, and
-    the transfer-map fusion formulation of MPDO RFP.
+    the transfer-map fusion formulation of idempotence.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2784,7 +2784,7 @@ the elementary trace-power identity for diagonal matrices.
         def:mpdo_rfp_via_fusion}
     If the $\eta$-local structure has been constructed for an MPO tensor $K$,
     then zero correlation length gives the transfer-map fusion formulation of
-    MPDO RFP.
+    idempotence.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -2808,7 +2808,7 @@ the elementary trace-power identity for diagonal matrices.
     If the $\eta$-local structure has been constructed for an
     MPO tensor $K$, then zero correlation length gives the GSNNCH-with-ZCL
     case, the blocked fusion-isometry witness at size $2$, and the
-    transfer-map fusion formulation of MPDO RFP.
+    transfer-map fusion formulation of idempotence.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2837,7 +2837,7 @@ the elementary trace-power identity for diagonal matrices.
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$. Then
     $K$ is GSNNCH with ZCL, admits a blocked fusion-isometry witness at size
-    $2$, and satisfies the transfer-map fusion formulation of MPDO RFP. The
+    $2$, and satisfies the transfer-map fusion formulation of idempotence. The
     PSD-corrected form uses $T\ge0$ together with
     $\operatorname{tr}(T^m)=1$ for all $m>0$ in place of the conditional
     matrix rank-one hypothesis.
@@ -2860,7 +2860,7 @@ the elementary trace-power identity for diagonal matrices.
     From the commuting-form property and zero correlation length one
     simultaneously recovers the GSNNCH-with-ZCL criterion, the
     blocked fusion-isometry witness at size $2$, and the transfer-map fusion
-    formulation of MPDO RFP.
+    formulation of idempotence.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2869,7 +2869,7 @@ the elementary trace-power identity for diagonal matrices.
     The blocked witness is Theorem~\ref{thm:structural_implies_rfp_blocked}. The
     full transfer-map fusion formulation follows by applying the converse direction
     of Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to zero correlation length, which
-    is the MPDO RFP condition.
+    is transfer-map idempotence.
 \end{proof}
 
 \begin{remark}[SAL--ZCL implication for the GSNNCH--ZCL criterion]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -282,23 +282,25 @@ legs cyclically and taking the resulting trace.
 
 \section{Pure-state recovery inside the MPO formalism}
 
-\begin{definition}[MPDO renormalization fixed point]\label{def:is_rfp_mpdo}
+\begin{definition}[MPO transfer-map idempotence]\label{def:is_rfp_mpdo}
     \lean{MPOTensor.IsRFP}
     \leanok
     \uses{def:mpo_transfer_map}
-    An MPO tensor $M$ is an \emph{MPDO renormalization fixed point} if its
-    transfer map is idempotent:
+    An MPO tensor $M$ has \emph{transfer-map idempotence} if
     \[
         \E_M \circ \E_M = \E_M.
     \]
 \end{definition}
 
-\begin{theorem}[MPDO RFP iff MPO ZCL]\label{thm:is_rfp_iff_is_zcl}
+% This is the Lean predicate `MPOTensor.IsRFP`, not the paper's Definition 4.1
+% (`RFPMixedTS`), which is a distinct MPDO renormalization-fixed-point condition
+% tracked in issues #826 and #237.
+
+\begin{theorem}[Transfer-map idempotence iff MPO ZCL]\label{thm:is_rfp_iff_is_zcl}
     \lean{MPOTensor.isRFP_iff_isZCL}
     \leanok
     \uses{def:is_rfp_mpdo, def:mpo_is_zcl}
-    MPDO renormalization fixed points are exactly MPO tensors with zero
-    correlation length.
+    MPO transfer-map idempotence is exactly zero correlation length.
 \end{theorem}
 
 \begin{proof}
@@ -307,19 +309,20 @@ legs cyclically and taking the resulting trace.
     identical.
 \end{proof}
 
-\begin{theorem}[MPDO RFP iff doubled-index MPS RFP]\label{thm:is_rfp_iff_to_mps_rfp}
+\begin{theorem}[Transfer-map idempotence iff doubled-index MPS RFP]
+    \label{thm:is_rfp_iff_to_mps_rfp}
     \lean{MPOTensor.isRFP_iff_toMPSTensor_isRFP}
     \leanok
     \uses{def:is_rfp_mpdo, def:mpo_to_mps, def:is_rfp, def:mpo_is_zcl,
         thm:mpo_is_zcl_iff_to_mps_rfp}
-    The MPDO RFP condition is equivalent to the pure-state RFP condition for
-    the doubled-index MPS tensor.
+    MPO transfer-map idempotence is equivalent to the pure-state RFP condition
+    for the doubled-index MPS tensor.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:mpo_is_zcl_iff_to_mps_rfp}
-    Unfold the MPDO RFP condition to its definitional equivalent, MPO ZCL,
+    Unfold transfer-map idempotence to its definitional equivalent, MPO ZCL,
     then apply Theorem~\ref{thm:mpo_is_zcl_iff_to_mps_rfp}.
 \end{proof}
 
@@ -356,15 +359,17 @@ legs cyclically and taking the resulting trace.
     is the defining formula for $\E_A$.
 \end{proof}
 
-\begin{theorem}[Pure-state recovery of the RFP condition]%
+\begin{theorem}[Pure-state recovery of transfer-map idempotence]%
     \label{thm:to_mpo_rfp_iff_rfp}
     \lean{MPSTensor.toMPOTensor_isRFP_iff_isRFP}
     \leanok
     \uses{def:is_rfp_mpdo, def:is_rfp, thm:to_mpo_transfer_map}
-    For an MPS tensor $A$, its diagonal MPO embedding is MPDO-RFP if and only
-    if $A$ is an RFP:
+    For an MPS tensor $A$, the diagonal MPO embedding has idempotent transfer
+    map if and only if $A$ is an RFP:
     \[
-        A^{\mathrm{MPO}} \text{ is MPDO-RFP} \iff A \text{ is RFP}.
+        \E_{A^{\mathrm{MPO}}}\circ\E_{A^{\mathrm{MPO}}}
+        = \E_{A^{\mathrm{MPO}}}
+        \iff A \text{ is RFP}.
     \]
 \end{theorem}
 
@@ -381,8 +386,8 @@ legs cyclically and taking the resulting trace.
     \lean{MPSTensor.toMPOTensor_isRFP_iff_isZCL}
     \leanok
     \uses{thm:to_mpo_rfp_iff_rfp, thm:zcl_iff_idempotent_transfer}
-    For an MPS tensor $A$, the diagonal MPO embedding is MPDO-RFP if and only
-    if $A$ has zero correlation length.
+    For an MPS tensor $A$, the diagonal MPO embedding has idempotent transfer
+    map if and only if $A$ has zero correlation length.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

Two MPDO docstrings overstated their correspondence to arXiv:1606.00608. Both are corrected to be honest about what is and isn't a formalization of the paper's argument.

### 1. `MPOTensor.IsRFP` is idempotence/ZCL, not Definition 4.1
`IsRFP M := transferMap M ∘ₗ transferMap M = transferMap M` (definitionally `IsZCL M`, `isRFP_iff_isZCL := Iff.rfl`) was documented as "arXiv:1606.00608, **Definition 4.1**". Definition 4.1 (`RFPMixedTS`, line 657) is a *different* notion — existence of two trace-preserving CP maps `T, S` on the physical indices. Idempotence coincides with it only in the pure (MPS) case; for **general MPDO, Definition 4.1 is strictly stronger** — it implies ZCL (Theorem 4.9, `i⟹ii`, gives ZCL+SAL) but ZCL alone does not imply it (line 786). Corrected in `Defs.lean` and `RFP.lean`, pointing to the planned source-faithful `IsRFP_via_TS` (#826, #237).

### 2. `BiCFDerivation/Core` does not formalize the paper's block-separation argument
Item (3)'s docstring claimed it "captures the finite-length block-separation content of arXiv:1606.00608, lines 340–345". But the paper obtains `propblockinj` (line 342) by **citing David2006**; the Burnside–Jacobson/selector-data route here is a self-contained *alternative sufficient condition*, not a formalization of the paper's argument — as the file's own summary already admits. Relabelled honestly, pointing to `docs/paper-gaps/cpgsv17_bicf_block_separation.tex` (#1043).

## Scope & verification

- **Doc-only**, 3 files (`Defs.lean`, `RFP.lean`, `BiCFDerivation/Core.lean`): no signatures, proofs, or tags changed.
- `lake build` of `Defs`, `RFP`, `BiCFDerivation.Core`: green.
- These are the honest-citation prerequisites for the source-faithful `IsRFP_via_TS` / block-separation work tracked by #826, #587, #237.

Refs #826, #587, #237, #1043.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint text only; no executable Lean or proof changes.
> 
> **Overview**
> Documentation-only alignment so MPDO and biCF docstrings no longer claim a tighter match to arXiv:1606.00608 than the Lean predicates provide.
> 
> **`MPOTensor.IsRFP`** is documented as **transfer-map idempotence** (`E_M ∘ E_M = E_M`, definitionally `IsZCL`), explicitly **not** the paper’s Definition 4.1 (`RFPMixedTS`, trace-preserving CP maps `T` and `S`). The notes state that for general MPDO, Definition 4.1 is **strictly stronger** than ZCL/idempotence, cite Theorem 4.9 and line 786, and point to planned source-faithful `IsRFP_via_TS` (#826, #237). Matching updates appear in `Defs.lean`, `RFP.lean`, and the blueprint chapter (definitions/theorems retitled to “transfer-map idempotence,” with a LaTeX comment on the Lean/paper gap).
> 
> **`BiCFDerivation/Core`** item (3) no longer says it “captures” the paper’s block-separation argument at lines 340–345; it is described as a **self-contained sufficient condition** on an **alternative** route (the paper uses David2006), with the block-separation theorem still an open ingredient and a pointer to `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
> 
> No definitions, proofs, or Lean tags change—only comments and blueprint prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31eb6967e513f40c3c766ace375fc5a252c0eb83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->