### PR TITLE
doc(periodic): mark periodic vector independence leanok

### DIFF
--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -749,14 +749,24 @@ unconditional result.
     repeated-block equivalence between $A$ and $B$.
 \end{proof}
 
-\begin{theorem}[Eventual linear independence of a periodic basis]%
+\begin{theorem}[Eventual linear independence of periodic vectors]%
     \label{thm:periodic_basis_eventually_li}
     \lean{MPSTensor.periodicBasis_eventuallyLinearlyIndependent}
-    \notready
+    \leanok
     \uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
-    For a finite family of pairwise non-equivalent periodic tensors whose
-    periods divide a common integer $p$, there is $N_0$ such that for every
-    $N \ge N_0$ the vectors $\{\ket{V^{(pN)}(A_j)}\}_j$ are linearly independent.
+    For a finite family $\{A_j\}_{j\in J}$ of pairwise non-equivalent
+    periodic tensors whose periods divide a common integer $p$, there is
+    $N_0$ such that for every $N \ge N_0$, the map
+    \[
+        \Phi_N : \C^J \to (\C^d)^{\otimes pN},
+        \qquad
+        (c_j)_{j\in J}\mapsto
+        \sum_{j\in J}c_j\ket{V^{(pN)}(A_j)}
+    \]
+    satisfies
+    \[
+        \ker \Phi_N=\{0\}.
+    \]
 \end{theorem}
 
 \begin{remark}[Comparison with the blocking approach]\notready

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -754,7 +754,7 @@ unconditional result.
     \lean{MPSTensor.periodicBasis_eventuallyLinearlyIndependent}
     \leanok
     \uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
-    For a finite family $\{A_j\}_{j\in J}$ of pairwise non-equivalent
+    For a finite family $\{A_j\}_{j\in J}$ of pairwise non-repeated
     periodic tensors whose periods divide a common positive integer $p$,
     there is $N_0$ such that for every $N \ge N_0$, the map
     \[

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -755,8 +755,8 @@ unconditional result.
     \leanok
     \uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
     For a finite family $\{A_j\}_{j\in J}$ of pairwise non-equivalent
-    periodic tensors whose periods divide a common integer $p$, there is
-    $N_0$ such that for every $N \ge N_0$, the map
+    periodic tensors whose periods divide a common positive integer $p$,
+    there is $N_0$ such that for every $N \ge N_0$, the map
     \[
         \Phi_N : \C^J \to (\C^d)^{\otimes pN},
         \qquad

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -40,8 +40,8 @@ $p$-divisibility of the transfer map.
     \]
     where each block $A_j$ is an $m_j$-periodic tensor,
     each weight $\mu_j \neq 0$, and the blocks are pairwise
-    non-repeated (no two distinct $j, j'$ have $A_j$ gauge-equivalent
-    to $A_{j'}$).
+    non-repeated (no two distinct $j, j'$ are related by a gauge
+    transformation and a unit-modulus scalar).
     This is the standard form introduced in
     \cite[Section~II]{DeLasCuevas2017Irreducible}.
     It extends the normal canonical form
@@ -755,7 +755,9 @@ unconditional result.
     \leanok
     \uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
     For a finite family $\{A_j\}_{j\in J}$ of pairwise non-repeated
-    periodic tensors whose periods divide a common positive integer $p$,
+    periodic tensors, in the sense that no two are related by a gauge
+    transformation and a unit-modulus scalar, whose periods divide a common
+    positive integer $p$,
     there is $N_0$ such that for every $N \ge N_0$, the map
     \[
         \Phi_N : \C^J \to (\C^d)^{\otimes pN},


### PR DESCRIPTION
## Summary
- marks `periodicBasis_eventuallyLinearlyIndependent` as `\leanok` in the periodic FT blueprint
- retitles the entry so it asserts periodic-vector independence, not a completed basis theorem
- states the formalized content by the coefficient map equation `\ker \Phi_N = \{0\}` and leaves the spanning half unclaimed

Addresses #2359.

## Verification
- `lake build TNLean.MPS.Periodic.Overlap.Dichotomy -q --log-level=info` (existing sorry warnings in periodic overlap files)
- `lake build TNLean -q --log-level=info` (existing warnings)
- `printf 'MPSTensor.periodicBasis_eventuallyLinearlyIndependent\n' | lake exe checkdecls /dev/stdin`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (fails only on pre-existing unrelated missing refs in ch13a/ch04a)
- `cd blueprint && leanblueprint web` (usual plasTeX and bibliography warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint edits; no Lean or runtime behavior changes in the diff.
> 
> **Overview**
> Updates the periodic FT blueprint so **`periodicBasis_eventuallyLinearlyIndependent`** is marked **`\leanok`** and the surrounding text matches what Lean actually proves.
> 
> The theorem is retitled to **eventual linear independence of periodic vectors** (not a full “basis” theorem). The statement now uses pairwise **non-repeated** blocks (gauge plus unit-modulus scalar), introduces the coefficient map **`\Phi_N`**, and claims only **`\ker \Phi_N = \{0\}`** for large **`N`**—not spanning. **Irreducible form**’s “non-repeated” wording is aligned the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84312e4860abc3277b3f3235099535ab18d7f0b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->