### PR TITLE
feat(examples): prove GHZ two-site parent space

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -281,6 +281,7 @@ import TNLean.MPS.Examples.AKLTRotation
 import TNLean.MPS.Examples.Cluster
 import TNLean.MPS.Examples.EvenParity
 import TNLean.MPS.Examples.GHZ
+import TNLean.MPS.Examples.GHZParentHamiltonian
 import TNLean.MPS.Examples.ZMod2
 
 -- Layer 5b: Renormalization fixed points (RFP) — pure-state scaffolding

--- a/TNLean/MPS/Examples/GHZParentHamiltonian.lean
+++ b/TNLean/MPS/Examples/GHZParentHamiltonian.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Examples.GHZ
+import TNLean.MPS.ParentHamiltonian.GroundSpace
+
+/-!
+# GHZ parent-Hamiltonian local ground space
+
+This file records the two-site ground-space calculation for the GHZ tensor.
+
+## References
+
+* Fernández-González--Wolf--Sanz--Pérez-García 2012, arXiv:1210.6613,
+  Section 3, lines 432--455.
+* Cirac--Pérez-García--Schuch--Verstraete 2021, arXiv:2011.12127,
+  lines 1194--1196 and line 2205.
+-/
+
+namespace MPSTensor
+
+/-- The computational two-site vector \(\ket{ab}\) for the physical space
+\((\mathbb C^2)^{\otimes 2}\). -/
+def twoSiteKet (a b : Fin 2) : NSiteSpace 2 2 :=
+  Pi.single (fun k : Fin 2 => if k = 0 then a else b) 1
+
+private theorem ghz_groundSpaceMap_two
+    (X : Matrix (Fin 2) (Fin 2) ℂ) :
+    groundSpaceMap ghzTensor 2 X =
+      X 0 0 • twoSiteKet 0 0 + X 1 1 • twoSiteKet 1 1 := by
+  ext σ
+  let a₀ : Fin 2 := σ 0
+  let a₁ : Fin 2 := σ 1
+  have hσ : σ = fun k : Fin 2 => if k = 0 then a₀ else a₁ := by
+    ext k
+    fin_cases k <;> simp [a₀, a₁]
+  suffices hcalc : ∀ a b : Fin 2,
+      groundSpaceMap ghzTensor 2 X (fun k : Fin 2 => if k = 0 then a else b) =
+        (X 0 0 • twoSiteKet 0 0 + X 1 1 • twoSiteKet 1 1)
+          (fun k : Fin 2 => if k = 0 then a else b) by
+    rw [hσ]
+    exact hcalc a₀ a₁
+  intro a b
+  fin_cases a <;> fin_cases b
+  · have hne :
+        (fun _ : Fin 2 => (0 : Fin 2)) ≠ (fun _ : Fin 2 => (1 : Fin 2)) := by
+      decide
+    simp [groundSpaceMap_apply, twoSiteKet, ghzTensor, evalWord, Matrix.trace,
+      Matrix.mul_apply, Matrix.diagonal_apply, Pi.single_apply, hne]
+  · have hne0 :
+        (fun k : Fin 2 => if k = 0 then (0 : Fin 2) else (1 : Fin 2)) ≠
+          (fun _ : Fin 2 => (0 : Fin 2)) := by
+      decide
+    have hne1 :
+        (fun k : Fin 2 => if k = 0 then (0 : Fin 2) else (1 : Fin 2)) ≠
+          (fun _ : Fin 2 => (1 : Fin 2)) := by
+      decide
+    simp [groundSpaceMap_apply, twoSiteKet, ghzTensor, evalWord, Matrix.trace,
+      Matrix.mul_apply, Matrix.diagonal_apply, Pi.single_apply, hne0, hne1]
+  · have hne0 :
+        (fun k : Fin 2 => if k = 0 then (1 : Fin 2) else (0 : Fin 2)) ≠
+          (fun _ : Fin 2 => (0 : Fin 2)) := by
+      decide
+    have hne1 :
+        (fun k : Fin 2 => if k = 0 then (1 : Fin 2) else (0 : Fin 2)) ≠
+          (fun _ : Fin 2 => (1 : Fin 2)) := by
+      decide
+    simp [groundSpaceMap_apply, twoSiteKet, ghzTensor, evalWord, Matrix.trace,
+      Matrix.mul_apply, Matrix.diagonal_apply, Pi.single_apply, hne0, hne1]
+  · have hne :
+        (fun _ : Fin 2 => (1 : Fin 2)) ≠ (fun _ : Fin 2 => (0 : Fin 2)) := by
+      decide
+    simp [groundSpaceMap_apply, twoSiteKet, ghzTensor, evalWord, Matrix.trace,
+      Matrix.mul_apply, Matrix.diagonal_apply, Pi.single_apply, hne]
+
+/-- The local parent-space equation for the GHZ tensor is
+\[
+  \mathcal G_2(A_{\mathrm{GHZ}})
+  =
+  \operatorname{span}_{\mathbb C}\{\ket{00},\ket{11}\}.
+\]
+This is arXiv:1210.6613, lines 449--455. -/
+theorem ghz_groundSpace_two_eq_span :
+    groundSpace ghzTensor 2 =
+      Submodule.span ℂ
+        ({twoSiteKet 0 0, twoSiteKet 1 1} : Set (NSiteSpace 2 2)) := by
+  apply le_antisymm
+  · rintro ψ ⟨X, rfl⟩
+    rw [ghz_groundSpaceMap_two]
+    exact Submodule.add_mem _
+      (Submodule.smul_mem _ _ (Submodule.subset_span (by simp)))
+      (Submodule.smul_mem _ _ (Submodule.subset_span (by simp)))
+  · apply Submodule.span_le.mpr
+    intro ψ hψ
+    rw [groundSpace]
+    rw [Set.mem_insert_iff, Set.mem_singleton_iff] at hψ
+    rcases hψ with rfl | rfl
+    · refine ⟨Matrix.diagonal (Pi.single (0 : Fin 2) 1), ?_⟩
+      rw [ghz_groundSpaceMap_two]
+      simp [twoSiteKet]
+    · refine ⟨Matrix.diagonal (Pi.single (1 : Fin 2) 1), ?_⟩
+      rw [ghz_groundSpaceMap_two]
+      simp [twoSiteKet]
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -167,7 +167,7 @@ versus Q_{v+1} B^{(p)} yields a contradiction unless the overlap vanishes.
 proof realizes the *same* obstruction through the peripheral-spectrum form rather
 than the paper's lcm-blocking + translation argument. If D₁ = D₂ and
 B i = ζ X (A i) X⁻¹, then
-𝓔_B(Y) = ζ ζ̄ · X 𝓔_A(X⁻¹ Y X⁻ᴴ) Xᴴ. Eigenvalue uniqueness for an irreducible CP
+𝓔_B(Y) = ζ · (conj ζ) · X 𝓔_A(X⁻¹ Y X⁻ᴴ) Xᴴ. Eigenvalue uniqueness for an irreducible CP
 map (Wolf, *Quantum Channels & Operations*, Thm 6.3) forces |ζ| = 1, so the
 peripheral spectra of 𝓔_A and 𝓔_B agree. An `m`-periodic tensor has peripheral
 spectrum {e^{2πi r/m} : 0 ≤ r < m}, so agreement forces m_a = m_b; hence

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -81,11 +81,11 @@ This is the one-step form of the propagation step in arXiv:1708.00029, Appendix 
 
 **Paper's argument.** Starting from the blocked sector-match equation eq:Nm
 (lines 978--984), the paper applies the translation operator T^l
-(l = 1, …, m-1) to *both sides*; since P_{ũ+l} A^{(m)} and Q_{ṽ+l} B^{(m)}
+(l = 1, …, m-1) to *both sides*; since P_{u'+l} A^{(m)} and Q_{v'+l} B^{(m)}
 are again normal tensors (Lemma bdcf), Theorem 2.10 of Cirac--Perez-Garcia 2017
-(thm:cf) yields, at each offset, a phase λ_{ṽ+l} and a unitary
-U_{ṽ+l} = P_{ũ+l} U_{ṽ+l} Q_{ṽ+l} with
-P_{ũ+l} A^{(m)} = e^{iλ} U_{ṽ+l} Q_{ṽ+l} B^{(m)} U_{ṽ+l}†
+(thm:cf) yields, at each offset, a phase λ_{v'+l} and a unitary
+U_{v'+l} = P_{u'+l} U_{v'+l} Q_{v'+l} with
+P_{u'+l} A^{(m)} = e^{iλ} U_{v'+l} Q_{v'+l} B^{(m)} U_{v'+l}†
 (eq:blockedABprop). Hence the offset v - u = q is constant (eq:vprop, line
 1007), which is the
 one-step transport (u, v) → (u+1, v+1) stated here.
@@ -239,7 +239,7 @@ private lemma fin_cyclic_induction {m : ℕ} [NeZero m] {P : Fin m → Prop}
 Given one matching compressed sector pair at `(u₀, v₀)`, applying the
 translation operator T^l for l = 1, …, m-1 yields matching for all
 sector pairs `(u₀ + l, v₀ + l)`. Each offset `l` gets its own gauge
-(eq:blockedABprop produces a different unitary U_{ṽ+l} at each sector, not a
+(eq:blockedABprop produces a different unitary U_{v'+l} at each sector, not a
 single transported gauge); the offset v − u = q is constant (eq:vprop, line
 1007).
 

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -31,6 +31,19 @@ non-injective, renormalization-fixed-point MPS.
     \]
 \end{definition}
 
+\begin{definition}[Two-site computational vector]\label{def:two_site_ket}
+    \lean{MPSTensor.twoSiteKet}
+    \leanok
+    For $a,b\in\{0,1\}$, the vector
+    \[
+        \ket{ab}\in(\{0,1\}^{2}\to\C)
+    \]
+    is the indicator of the configuration
+    \[
+        (\sigma_1,\sigma_2)=(a,b).
+    \]
+\end{definition}
+
 \begin{theorem}[GHZ transfer map is idempotent]\label{thm:ghz_transfer_idempotent}
     \lean{MPSTensor.ghz_transferMap_idempotent}
     \leanok
@@ -496,6 +509,44 @@ We write
     \operatorname{GS}(H)=\ker(H-E_0(H)I)
 \]
 for the ground eigenspace.
+
+\begin{theorem}[GHZ two-site parent space]\label{thm:ghz_ground_space_two}
+    \lean{MPSTensor.ghz_groundSpace_two_eq_span}
+    \leanok
+    \uses{def:ghz_tensor, def:ground_space_parent, def:two_site_ket}
+    For the GHZ tensor $A$ of Definition~\ref{def:ghz_tensor},
+    \[
+        \mathcal G_2(A)
+        =
+        \spn_{\C}\{\ket{00},\ket{11}\}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:ghz_tensor, def:ground_space_map, def:ground_space_parent,
+        def:two_site_ket}
+    By definition,
+    \[
+        \Gamma_2(X)(\sigma_1,\sigma_2)
+        =
+        \tr(A^{\sigma_1}A^{\sigma_2}X).
+    \]
+    For the GHZ matrices
+    $A^0=\diag(1,0)$ and $A^1=\diag(0,1)$,
+    whenever $\sigma_1\ne\sigma_2$,
+    \[
+        A^{\sigma_1}A^{\sigma_2}=0.
+    \]
+    Hence
+    \[
+        \Gamma_2(X)
+        =
+        X_{00}\ket{00}+X_{11}\ket{11},
+    \]
+    and the image of~$\Gamma_2$ is
+    $\spn_{\C}\{\ket{00},\ket{11}\}$.
+\end{proof}
 
 \begin{remark}[GHZ parent interaction]\label{rem:ghz_parent_interaction}
     For the GHZ tensor of Definition~\ref{def:ghz_tensor},


### PR DESCRIPTION
## Summary
- adds `MPSTensor.ghz_groundSpace_two_eq_span`, proving
  `G_2(A_GHZ) = span{|00>, |11>}` for the GHZ tensor
- records the theorem as a separate `\leanok` entry in the examples blueprint
- keeps the full periodic GHZ parent-Hamiltonian kernel statement as prose only, since that is a later formalization step

Addresses part of #2315.

## Source
- arXiv:1210.6613, Section 3, lines 432--455
- arXiv:2011.12127, lines 1194--1196 and line 2205

## Verification
- `lake exe cache get`
- `lake build TNLean.MPS.Examples.GHZParentHamiltonian -q --log-level=info`
- `lake build TNLean -q --log-level=info` (existing PEPS/periodic sorry warnings only)
- `printf 'MPSTensor.ghz_groundSpace_two_eq_span\n' | lake exe checkdecls /dev/stdin`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (fails only on pre-existing unrelated missing refs in ch13a/ch04a)
- `cd blueprint && leanblueprint web` (usual plasTeX and bibliography warnings)
- `rg -n "sorry|axiom|admit|unsafe" TNLean/MPS/Examples/GHZParentHamiltonian.lean || true`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New example theorem and blueprint entries only; no auth, runtime, or core library behavior changes beyond a root import.
> 
> **Overview**
> Adds a **Lean proof** that the GHZ tensor’s two-site parent ground space is \(\mathrm{span}\{\ket{00},\ket{11}\}\): new `MPSTensor.twoSiteKet`, a case split showing \(\Gamma_2(X) = X_{00}\ket{00} + X_{11}\ket{11}\), and `ghz_groundSpace_two_eq_span`. The module is wired into `TNLean.lean` and the examples blueprint (`def:two_site_ket`, `thm:ghz_ground_space_two`).
> 
> **Doc-only:** periodic overlap comments in `Case1.lean` / `Case3.lean` use clearer phase notation (\(\zeta \cdot \overline{\zeta}\)) and \(u', v'\) instead of \(\tilde u, \tilde v\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e5395f9bad9156af3f56f191f1bfedca51eacc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->