### PR TITLE
doc(periodic): add Gram sketch for periodic LI

### DIFF
--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -771,6 +771,48 @@ unconditional result.
     \]
 \end{theorem}
 
+\begin{proof}
+    \notready
+    \uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
+    Let
+    \[
+        G_N(j,k)
+        =
+        \left\langle
+            V^{(pN)}(A_j),V^{(pN)}(A_k)
+        \right\rangle
+    \]
+    be the Gram matrix of the periodic vectors.  The diagonal entries have
+    positive limits,
+    \[
+        G_N(j,j)\longrightarrow m_j>0,
+    \]
+    by Theorem~\ref{thm:periodic_self_overlap_tendsto}.  If $j\ne k$, the
+    second alternative in Theorem~\ref{thm:periodic_overlap_dichotomy} would
+    make $A_j$ and $A_k$ repeated blocks, that is, gauge equivalent up to a
+    unit-modulus scalar.  This contradicts the non-repetition hypothesis, and
+    hence
+    \[
+        G_N(j,k)\longrightarrow 0.
+    \]
+    Hence
+    \[
+        G_N\longrightarrow \diag(m_j)_{j\in J}.
+    \]
+    Since $m_j>0$ for every $j$, the limit matrix $\diag(m_j)_{j\in J}$ is
+    positive definite.  Hence $G_N$ is positive definite for all sufficiently
+    large $N$.  Thus
+    \[
+        \Phi_N(c)=0
+        \quad\Longrightarrow\quad
+        0=\langle \Phi_N(c),\Phi_N(c)\rangle
+        =c^{*}G_Nc
+        \quad\Longrightarrow\quad
+        c=0,
+    \]
+    and $\ker\Phi_N=\{0\}$.
+\end{proof}
+
 \begin{remark}[Comparison with the blocking approach]\notready
     \label{rem:periodic_vs_blocking_ft}
     Theorem~\ref{thm:periodic_ft} and the equal-MPV corollary


### PR DESCRIPTION
## Summary

- keep the statement-level `\leanok` for `thm:periodic_basis_eventually_li`
- add the Gram-matrix proof sketch: diagonal self-overlaps have positive limits, off-diagonal overlaps vanish, hence the Gram matrix is eventually nonsingular
- mark the proof block `\notready`, since the Lean proof still depends transitively on open periodic-overlap `sorry` gaps

Refs #2359. This PR does not close #2359; proof-level `\leanok` should wait until the transitive periodic-overlap gaps are removed.

## Verification

- `git diff --check`
- `leanblueprint web` (passes with the repository usual plasTeX/bibliography warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint-only documentation with no runtime or auth impact; proof remains explicitly not ready for formalization.
> 
> **Overview**
> Adds a **proof sketch** for `thm:periodic_basis_eventually_li` (eventual linear independence of periodic MPV vectors) in the periodic FT chapter. The argument builds the Gram matrix of overlaps at length \(pN\): diagonal entries tend to positive limits via `thm:periodic_self_overlap_tendsto`, off-diagonals vanish because non-repetition rules out the repeated-block branch of `thm:periodic_overlap_dichotomy`, so \(G_N\) is eventually positive definite and \(\ker\Phi_N=\{0\}\).
> 
> The new `\begin{proof}...\end{proof}` block is marked **`\notready`** (no proof-level `\leanok` yet), since Lean still depends on open periodic-overlap gaps referenced by those theorems. The theorem statement keeps its existing `\leanok` tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96350a8f75e04d91a032ab5df7a12a853c01e33d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->