### PR TITLE
doc(blueprint): align peripheral cyclic group edges

### DIFF
--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -336,6 +336,29 @@ maps.
     \end{align*}
 \end{proof}
 
+\begin{theorem}[Right multiplicative identity from KS equality]
+    \label{thm:right_multiplicative_identity}
+    \lean{KadisonSchwarz.multiplicative_domain_right}
+    \leanok
+    \uses{def:unital_kraus}
+    Let $E$ be a unital Kraus map.
+    If $E(X^\dagger X) = E(X)^\dagger E(X)$, then
+    $E(YX) = E(Y)E(X)$ for all $Y \in \MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kraus_commute}
+    From Theorem~\ref{thm:kraus_commute},
+    $X K_i^\dagger = K_i^\dagger E(X)$ for all~$i$. Then
+    \begin{align*}
+        E(YX)
+         & = \sum_i K_i Y X K_i^\dagger    \\
+         & = \sum_i K_i Y K_i^\dagger E(X) \\
+         & = E(Y)E(X).
+    \end{align*}
+\end{proof}
+
 \subsection{Full multiplicative-domain structure}
 
 \begin{definition}[Right and left multiplicative domains]\label{def:one_sided_multiplicative_domains}

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -1444,7 +1444,7 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
 
 \begin{theorem}[Peripheral eigenvalues form a cyclic group]%
     \label{thm:peripheral_cyclic_group}
-    \lean{MPSTensor.peripheralEigenvalues_eq_range_primitiveRoot}
+    \lean{PeripheralSpectrum.peripheral_eigenvalues_form_cyclic_group}
     \leanok
     \uses{thm:peripheral_cyclic_structure}
     Let $E$ be an irreducible unital trace-preserving Schwarz map on
@@ -1456,7 +1456,8 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
 
 \begin{proof}
     \leanok
-    \uses{thm:peripheral_cyclic_structure}
+    \uses{thm:peripheral_cyclic_structure,
+        thm:cyclic_decomposition_irreducible_schwarz}
     Apply Theorem~\ref{thm:peripheral_cyclic_structure} for the cyclic
     structure. Divisibility $m \mid D$ follows from the cyclic
     decomposition: $m$ mutually orthogonal projections summing to $\Id$
@@ -1468,19 +1469,25 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
     \label{thm:channel_period_divides_dim}
     \lean{PeripheralSpectrum.channel_period_divides_dim}
     \leanok
-    \uses{thm:peripheral_cyclic_group}
-    Let $E$ be as in Theorem~\ref{thm:peripheral_cyclic_group},
-    and let $\gamma$ be a primitive $m$-th root of unity generating
-    the peripheral eigenvalues.
+    \uses{thm:cyclic_decomposition_irreducible_schwarz}
+    Let $E$ be an irreducible unital trace-preserving Schwarz map on
+    $\MN{D}$ with a positive-definite adjoint fixed point. Let $\gamma$
+    be a primitive $m$-th root of unity such that the peripheral eigenvalues
+    are exactly $\{\gamma^k : k \in \Fin{m}\}$.
     Then $m \mid D$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:peripheral_cyclic_group}
-    Follows from the cyclic projection decomposition and
-    trace preservation, as in the final step of
-    Theorem~\ref{thm:peripheral_cyclic_group}.
+    \uses{thm:cyclic_decomposition_irreducible_schwarz}
+    The cyclic decomposition gives orthogonal projections
+    $P_0,\ldots,P_{m-1}$ with $\sum_k P_k=\Id$ and
+    $E(P_{k+1})=P_k$. Trace preservation gives
+    $\tr(P_{k+1})=\tr(P_k)$ for every $k$, hence
+    \[
+        D=\tr(\Id)=\sum_{k=0}^{m-1}\tr(P_k)=m\,\tr(P_0).
+    \]
+    Since the trace of an orthogonal projection is an integer, $m\mid D$.
 \end{proof}
 
 \subsection{Cyclic decomposition of irreducible Schwarz maps}
@@ -1536,42 +1543,76 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
     The rank of an orthogonal projection $P$ equals its trace: $n = \tr P$.
 \end{lemma}
 
+\begin{lemma}[Scalar fixed points for irreducible unital maps]
+    \label{lem:irreducible_unital_fixed_points_scalar}
+    \lean{MPSTensor.fixed_eq_scalar_of_irreducible_unital}
+    \leanok
+    \uses{thm:psd_fp_unique_irred}
+    If $E$ is irreducible and unital, then every fixed point of $E$ is a
+    scalar multiple of $\Id$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:psd_fp_unique_irred}
+    If $E(X)=X$, then the Hermitian matrices
+    \[
+        X+X^\dagger,
+        \qquad
+        i(X-X^\dagger)
+    \]
+    are also fixed by $E$. The positive-semidefinite fixed-point uniqueness
+    theorem gives $X+X^\dagger=a\Id$ and
+    $i(X-X^\dagger)=b\Id$, hence
+    \[
+        X=\frac{1}{2}(a-i b)\Id.
+    \]
+\end{proof}
+
 \begin{lemma}[Peripheral unitary eigenvector]
+    \label{lem:peripheral_unitary_eigenvector}
     \lean{MPSTensor.exists_peripheral_unitary_of_irreducible_schwarz}
     \leanok
-    \uses{thm:ks_peripheral}
+    \uses{thm:ks_equality_of_peripheral_eigenvector_of_fixedPoint,
+        thm:psd_fp_unique_irred}
     For an irreducible unital Schwarz map with faithful adjoint fixed point,
     each peripheral eigenvalue admits a unitary eigenvector.
 \end{lemma}
 
 \begin{lemma}[Powers on a peripheral-unitary orbit]
+    \label{lem:peripheral_unitary_powers}
     \lean{MPSTensor.map_powers_of_peripheral_unitary}
     \leanok
-    \uses{thm:ks_peripheral}
+    \uses{thm:ks_equality_of_peripheral_eigenvector_of_fixedPoint,
+        thm:right_multiplicative_identity}
     If $E(U)=\mu U$ with $|\mu|=1$ and $U$ unitary, then
     $E(U^n)=\mu^n U^n$ for all $n$.
 \end{lemma}
 
 \begin{lemma}[Normalized peripheral unitary]
+    \label{lem:normalized_peripheral_unitary}
     \lean{MPSTensor.exists_normalized_peripheral_unitary_of_irreducible_schwarz}
     \leanok
-    \uses{thm:ks_peripheral}
+    \uses{lem:peripheral_unitary_eigenvector, lem:peripheral_unitary_powers,
+        lem:irreducible_unital_fixed_points_scalar}
     Peripheral unitary eigenvectors can be normalized compatibly with
     the faithful fixed-point state.
 \end{lemma}
 
 \begin{lemma}[Cyclic projections from a peripheral unitary]
+    \label{lem:cyclic_projections_from_peripheral_unitary}
     \lean{exists_cyclic_projections_of_peripheral_unitary}
     \leanok
-    \uses{thm:channel_period_divides_dim}
     A primitive $m$-th peripheral root yields $m$ orthogonal projections
     summing to $\Id$ and cyclically permuted by the channel.
 \end{lemma}
 
 \begin{theorem}[Cyclic decomposition for irreducible Schwarz maps]
+    \label{thm:cyclic_decomposition_irreducible_schwarz}
     \lean{MPSTensor.exists_cyclic_decomposition_of_irreducible_schwarz}
     \leanok
-    \uses{thm:peripheral_cyclic_group}
+    \uses{lem:normalized_peripheral_unitary, lem:peripheral_unitary_powers,
+        lem:cyclic_projections_from_peripheral_unitary}
     Under irreducibility and faithful fixed point hypotheses, there is a
     full cyclic projection decomposition realizing the peripheral period.
 \end{theorem}
@@ -1616,19 +1657,14 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
     The inverse of a peripheral eigenvalue is peripheral.
 \end{lemma}
 
-\begin{theorem}[Peripheral cyclic group with period divisibility]
-    \lean{PeripheralSpectrum.peripheral_eigenvalues_form_cyclic_group}
-    \leanok
-    \uses{thm:peripheral_cyclic_group}
-    The peripheral eigenvalues form a finite cyclic group whose order
-    divides the dimension.
-\end{theorem}
-
 \begin{theorem}[Peripheral eigenvalue multiplicity one]
     \label{thm:peripheral_multiplicity_one}
     \lean{PeripheralSpectrum.peripheral_eigenvalue_multiplicity_one}
     \leanok
-    \uses{thm:peripheral_cyclic_group}
+    \uses{lem:peripheral_unitary_eigenvector,
+        thm:ks_equality_of_peripheral_eigenvector_of_fixedPoint,
+        thm:right_multiplicative_identity,
+        lem:irreducible_unital_fixed_points_scalar}
     Each peripheral eigenvalue has algebraic multiplicity one.
 \end{theorem}
 \begin{proof}\leanok


### PR DESCRIPTION
Addresses the remaining ch06 item of #2296.

This PR aligns the peripheral-spectrum blueprint entries with the Lean theorems that prove them:

- `thm:peripheral_cyclic_group` now points to `PeripheralSpectrum.peripheral_eigenvalues_form_cyclic_group`, the theorem whose conclusion includes `m ∣ D`.
- `thm:channel_period_divides_dim` is stated with the primitive generator hypothesis used by the Lean theorem, and its proof cites the cyclic decomposition route.
- The cyclic projection and cyclic decomposition entries now cite the peripheral unitary, its powers, and the Fourier projection construction rather than the cyclic-group theorem.
- `thm:peripheral_multiplicity_one` now cites the peripheral unitary, fixed-point KS equality, right multiplicative identity, and scalar fixed-point theorem used in the Lean proof.
- The duplicate period-divisibility cyclic-group entry was removed.

Verification:

- `git diff --check`
- `leanblueprint web`
- direct Lean `#check` for the changed `\lean{...}` declarations
- `python3 scripts/blueprint_lean_sync.py --root . --ci` still reports only the two pre-existing unrelated missing declarations in `ch13a_peps_ft.tex` and `ch04a_channel_representations.tex`.

Closes #2296.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint/LaTeX and `\lean` link updates; no runtime or proof-code changes in this diff.
> 
> **Overview**
> This PR **aligns the blueprint with Lean** for peripheral-spectrum and Kadison–Schwarz material in `ch05_schwarz.tex` and `ch06_spectral.tex`.
> 
> **`ch05`:** Adds **`thm:right_multiplicative_identity`** (right multiplicative domain from KS equality) with proof and `\lean{KadisonSchwarz.multiplicative_domain_right}`—the step Lean uses for peripheral product closure and multiplicity-one arguments.
> 
> **`ch06`:** Points **`thm:peripheral_cyclic_group`** at **`PeripheralSpectrum.peripheral_eigenvalues_form_cyclic_group`** and routes **`m ∣ D`** through **`thm:cyclic_decomposition_irreducible_schwarz`**. Restates **`thm:channel_period_divides_dim`** with the primitive-root hypothesis and a trace argument on cyclic projections. Adds **`lem:irreducible_unital_fixed_points_scalar`**, labels peripheral lemmas, and retargets `\uses` on the unitary / Fourier projection chain and **`thm:peripheral_multiplicity_one`** (KS equality, right multiplicative identity, scalar fixed points). **Removes** the duplicate period-divisibility cyclic-group theorem. Minor proof-environment fix in the Wolf example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2fa7322ee71deb892773eac63bdba4108b259f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->