### PR TITLE
feat(examples): prove GHZ periodic chain space

### DIFF
--- a/TNLean/MPS/Examples/GHZParentHamiltonian.lean
+++ b/TNLean/MPS/Examples/GHZParentHamiltonian.lean
@@ -10,7 +10,8 @@ import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 /-!
 # GHZ parent-Hamiltonian local ground space
 
-This file records the two-site ground-space calculation for the GHZ tensor.
+This file records the two-site ground-space calculation for the GHZ tensor and
+the periodic nearest-neighbour chain ground-space equation.
 
 ## References
 
@@ -27,7 +28,9 @@ namespace MPSTensor
 def twoSiteKet (a b : Fin 2) : NSiteSpace 2 2 :=
   Pi.single (fun k : Fin 2 => if k = 0 then a else b) 1
 
-/-- The computational basis vector \(\ket{a}^{\otimes N}\). -/
+/-- The computational basis vector \(\ket{a}^{\otimes N}\).
+This is the constant product vector in the two-fold GHZ degeneracy,
+arXiv:2011.12127, line 2205. -/
 def constantKet (a : Fin 2) (N : ℕ) : NSiteSpace 2 N :=
   Pi.single (fun _ : Fin N => a) 1
 

--- a/TNLean/MPS/Examples/GHZParentHamiltonian.lean
+++ b/TNLean/MPS/Examples/GHZParentHamiltonian.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.Examples.GHZ
 import TNLean.MPS.ParentHamiltonian.GroundSpace
+import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 
 /-!
 # GHZ parent-Hamiltonian local ground space
@@ -25,6 +26,10 @@ namespace MPSTensor
 \((\mathbb C^2)^{\otimes 2}\). -/
 def twoSiteKet (a b : Fin 2) : NSiteSpace 2 2 :=
   Pi.single (fun k : Fin 2 => if k = 0 then a else b) 1
+
+/-- The computational basis vector \(\ket{a}^{\otimes N}\). -/
+def constantKet (a : Fin 2) (N : ℕ) : NSiteSpace 2 N :=
+  Pi.single (fun _ : Fin N => a) 1
 
 private theorem ghz_groundSpaceMap_two
     (X : Matrix (Fin 2) (Fin 2) ℂ) :
@@ -103,5 +108,267 @@ theorem ghz_groundSpace_two_eq_span :
     · refine ⟨Matrix.diagonal (Pi.single (1 : Fin 2) 1), ?_⟩
       rw [ghz_groundSpaceMap_two]
       simp [twoSiteKet]
+
+private lemma twoSiteKet_same_apply_mixed (c : Fin 2) {a b : Fin 2} (hab : a ≠ b) :
+    twoSiteKet c c (fun k : Fin 2 => if k = 0 then a else b) = 0 := by
+  have hne :
+      (fun k : Fin 2 => if k = 0 then c else c) ≠
+        (fun k : Fin 2 => if k = 0 then a else b) := by
+    intro h
+    have h0 := congrFun h 0
+    have h1 := congrFun h 1
+    apply hab
+    exact h0.symm.trans h1
+  rw [twoSiteKet, Pi.single_eq_of_ne hne.symm]
+
+private lemma mem_ghz_two_span_apply_mixed {v : NSiteSpace 2 2}
+    (hv : v ∈ Submodule.span ℂ
+      ({twoSiteKet 0 0, twoSiteKet 1 1} : Set (NSiteSpace 2 2)))
+    {a b : Fin 2} (hab : a ≠ b) :
+    v (fun k : Fin 2 => if k = 0 then a else b) = 0 := by
+  induction hv using Submodule.span_induction with
+  | mem x hx =>
+      rw [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+      rcases hx with rfl | rfl
+      · exact twoSiteKet_same_apply_mixed 0 hab
+      · exact twoSiteKet_same_apply_mixed 1 hab
+  | zero => simp
+  | add _ _ _ _ h₁ h₂ => rw [Pi.add_apply, h₁, h₂, add_zero]
+  | smul c _ _ h => rw [Pi.smul_apply, h, smul_zero]
+
+private lemma mem_ghz_two_span_of_apply_mixed_eq_zero {v : NSiteSpace 2 2}
+    (hzero : ∀ {a b : Fin 2}, a ≠ b →
+      v (fun k : Fin 2 => if k = 0 then a else b) = 0) :
+    v ∈ Submodule.span ℂ
+      ({twoSiteKet 0 0, twoSiteKet 1 1} : Set (NSiteSpace 2 2)) := by
+  have hdecomp :
+      v = v (fun _ : Fin 2 => (0 : Fin 2)) • twoSiteKet 0 0 +
+        v (fun _ : Fin 2 => (1 : Fin 2)) • twoSiteKet 1 1 := by
+    suffices hcalc : ∀ a₀ a₁ : Fin 2,
+        v (fun k : Fin 2 => if k = 0 then a₀ else a₁) =
+          (v (fun _ : Fin 2 => (0 : Fin 2)) • twoSiteKet 0 0 +
+            v (fun _ : Fin 2 => (1 : Fin 2)) • twoSiteKet 1 1)
+              (fun k : Fin 2 => if k = 0 then a₀ else a₁) by
+      ext σ
+      let a₀ : Fin 2 := σ 0
+      let a₁ : Fin 2 := σ 1
+      have hσ : σ = fun k : Fin 2 => if k = 0 then a₀ else a₁ := by
+        ext k
+        fin_cases k <;> simp [a₀, a₁]
+      rw [hσ]
+      exact hcalc a₀ a₁
+    intro a₀ a₁
+    fin_cases a₀ <;> fin_cases a₁
+    · have hne :
+          (fun _ : Fin 2 => (0 : Fin 2)) ≠ (fun _ : Fin 2 => (1 : Fin 2)) := by
+        decide
+      simp [twoSiteKet, hne]
+    · have hmix : (0 : Fin 2) ≠ (1 : Fin 2) := by decide
+      have hne0 :
+          (fun k : Fin 2 => if k = 0 then (0 : Fin 2) else (1 : Fin 2)) ≠
+            (fun _ : Fin 2 => (0 : Fin 2)) := by
+        decide
+      have hne1 :
+          (fun k : Fin 2 => if k = 0 then (0 : Fin 2) else (1 : Fin 2)) ≠
+            (fun _ : Fin 2 => (1 : Fin 2)) := by
+        decide
+      simp [twoSiteKet, hzero hmix, hne0, hne1]
+    · have hmix : (1 : Fin 2) ≠ (0 : Fin 2) := by decide
+      have hne0 :
+          (fun k : Fin 2 => if k = 0 then (1 : Fin 2) else (0 : Fin 2)) ≠
+            (fun _ : Fin 2 => (0 : Fin 2)) := by
+        decide
+      have hne1 :
+          (fun k : Fin 2 => if k = 0 then (1 : Fin 2) else (0 : Fin 2)) ≠
+            (fun _ : Fin 2 => (1 : Fin 2)) := by
+        decide
+      simp [twoSiteKet, hzero hmix, hne0, hne1]
+    · have hne :
+          (fun _ : Fin 2 => (1 : Fin 2)) ≠ (fun _ : Fin 2 => (0 : Fin 2)) := by
+        decide
+      simp [twoSiteKet, hne]
+  rw [hdecomp]
+  exact Submodule.add_mem _
+    (Submodule.smul_mem _ _ (Submodule.subset_span (by simp)))
+    (Submodule.smul_mem _ _ (Submodule.subset_span (by simp)))
+
+private lemma extractWindow_two_eq {N : ℕ} (i : Fin N)
+    (σ : Fin N → Fin 2) :
+    extractWindow 2 i σ =
+      fun k : Fin 2 => if k = 0 then σ i else σ (cyclicForwardSite i 1) := by
+  ext k
+  fin_cases k <;> simp [extractWindow, cyclicForwardSite, Nat.mod_eq_of_lt]
+
+private lemma cyclicCfg_extractWindow_eq {N : ℕ} (hN : 2 ≤ N) (i : Fin N)
+    (σ : Fin N → Fin 2) :
+    cyclicCfg (by omega : 0 < N) 2 i (extractWindow 2 i σ) σ = σ := by
+  ext k
+  simp only [cyclicCfg]
+  by_cases hk : (k.val + N - i.val) % N < 2
+  · rw [dif_pos hk]
+    have hsite :
+        k =
+          ⟨(i.val + (k.val + N - i.val) % N) % N,
+            Nat.mod_lt _ (by omega : 0 < N)⟩ :=
+      eq_cyclic_site_of_offset_eq (N := N) (by omega : 0 < N)
+        (i := i) (k := k) (r := (k.val + N - i.val) % N) rfl
+    exact congrArg Fin.val (by simpa [extractWindow] using congrArg σ hsite.symm)
+  · rw [dif_neg hk]
+
+private lemma ghz_chainGroundSpace_apply_eq_zero_of_adjacent_ne {N : ℕ} (hN : 2 ≤ N)
+    {ψ : NSiteSpace 2 N} (hψ : ψ ∈ chainGroundSpace ghzTensor 2 N)
+    {σ : Fin N → Fin 2} {i : Fin N}
+    (hne : σ i ≠ σ (cyclicForwardSite i 1)) :
+    ψ σ = 0 := by
+  have hNpos : 0 < N := by omega
+  rw [chainGroundSpace, dif_pos ⟨hNpos, hN⟩] at hψ
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
+  have hv := hψ i σ
+  rw [ghz_groundSpace_two_eq_span] at hv
+  have hzero := mem_ghz_two_span_apply_mixed hv hne
+  have hwindow := extractWindow_two_eq i σ
+  rw [← hwindow] at hzero
+  have hcfg := cyclicCfg_extractWindow_eq hN i σ
+  simpa [cyclicRestrictₗ_apply, hcfg] using hzero
+
+private lemma exists_adjacent_ne_of_not_constant {N : ℕ} (hN : 2 ≤ N)
+    (σ : Fin N → Fin 2)
+    (hzero : σ ≠ fun _ : Fin N => (0 : Fin 2))
+    (hone : σ ≠ fun _ : Fin N => (1 : Fin 2)) :
+    ∃ i : Fin N, σ i ≠ σ (cyclicForwardSite i 1) := by
+  by_contra hnone
+  have hadj : ∀ i : Fin N, σ i = σ (cyclicForwardSite i 1) := by
+    intro i
+    by_contra hne
+    exact hnone ⟨i, hne⟩
+  let i₀ : Fin N := ⟨0, by omega⟩
+  have hconst : ∀ n : ℕ, (hn : n < N) → σ ⟨n, hn⟩ = σ i₀ := by
+    intro n
+    induction n with
+    | zero =>
+        intro hn
+        rfl
+    | succ n ih =>
+        intro hn
+        have hnlt : n < N := by omega
+        have hforward :
+            cyclicForwardSite ⟨n, hnlt⟩ 1 = ⟨n + 1, hn⟩ := by
+          ext
+          simp [cyclicForwardSite, Nat.mod_eq_of_lt (by omega : n + 1 < N)]
+        calc
+          σ ⟨n + 1, hn⟩ = σ (cyclicForwardSite ⟨n, hnlt⟩ 1) := by rw [hforward]
+          _ = σ ⟨n, hnlt⟩ := (hadj ⟨n, hnlt⟩).symm
+          _ = σ i₀ := ih hnlt
+  by_cases hbase : σ i₀ = 0
+  · apply hzero
+    ext k
+    exact congrArg Fin.val ((hconst k.val k.isLt).trans hbase)
+  · apply hone
+    have hbase' : σ i₀ = 1 := by
+      apply Fin.ext
+      have hne : (σ i₀).val ≠ 0 := by
+        intro hval
+        exact hbase (Fin.ext hval)
+      omega
+    ext k
+    exact congrArg Fin.val ((hconst k.val k.isLt).trans hbase')
+
+/-- Each vector \(\ket{a}^{\otimes N}\) satisfies all GHZ two-site cyclic
+constraints. -/
+theorem constantKet_mem_ghz_chainGroundSpace {N : ℕ} (hN : 2 ≤ N) (a : Fin 2) :
+    constantKet a N ∈ chainGroundSpace ghzTensor 2 N := by
+  have hNpos : 0 < N := by omega
+  rw [chainGroundSpace, dif_pos ⟨hNpos, hN⟩]
+  simp only [Submodule.mem_iInf, Submodule.mem_comap]
+  intro i τ
+  rw [ghz_groundSpace_two_eq_span]
+  apply mem_ghz_two_span_of_apply_mixed_eq_zero
+  intro b c hbc
+  rw [cyclicRestrictₗ_apply, constantKet]
+  have hstart :
+      cyclicCfg hNpos 2 i (fun k : Fin 2 => if k = 0 then b else c) τ i = b := by
+    simp [cyclicCfg]
+  have hnext :
+      cyclicCfg hNpos 2 i (fun k : Fin 2 => if k = 0 then b else c) τ
+        (cyclicForwardSite i 1) = c := by
+    have hoff : ((cyclicForwardSite i 1).val + N - i.val) % N = 1 := by
+      simp [cyclicForwardSite, offset_mod_eq i.isLt (by omega : 1 < N)]
+    simp [cyclicCfg, hoff]
+  have hne :
+      cyclicCfg hNpos 2 i (fun k : Fin 2 => if k = 0 then b else c) τ ≠
+        (fun _ : Fin N => a) := by
+    intro hcfg
+    have hb : b = a := by
+      simpa [hstart] using congrFun hcfg i
+    have hc : c = a := by
+      simpa [hnext] using congrFun hcfg (cyclicForwardSite i 1)
+    exact hbc (hb.trans hc.symm)
+  rw [Pi.single_eq_of_ne hne]
+
+/-- The periodic nearest-neighbour GHZ constraints have exactly the two constant
+configuration vectors as their common kernel:
+\[
+  \mathcal G_{N,2}(A_{\mathrm{GHZ}})
+  =
+  \operatorname{span}_{\mathbb C}
+    \{\ket{0}^{\otimes N},\ket{1}^{\otimes N}\}.
+\]
+This is the cyclic-window form of the two-fold degeneracy in
+arXiv:2011.12127, line 2205. -/
+theorem ghz_chainGroundSpace_two_eq_constant_span {N : ℕ} (hN : 2 ≤ N) :
+    chainGroundSpace ghzTensor 2 N =
+      Submodule.span ℂ
+        ({constantKet 0 N, constantKet 1 N} : Set (NSiteSpace 2 N)) := by
+  apply le_antisymm
+  · intro ψ hψ
+    let zeroCfg : Fin N → Fin 2 := fun _ => 0
+    let oneCfg : Fin N → Fin 2 := fun _ => 1
+    have hdecomp :
+        ψ = ψ zeroCfg • constantKet 0 N + ψ oneCfg • constantKet 1 N := by
+      ext σ
+      by_cases hσzero : σ = zeroCfg
+      · rw [hσzero]
+        have hzero_ne_one : zeroCfg ≠ oneCfg := by
+          intro h
+          have hval := congrFun h ⟨0, by omega⟩
+          simp [zeroCfg, oneCfg] at hval
+        have hket0 : constantKet 0 N zeroCfg = 1 := by
+          simp [constantKet, zeroCfg]
+        have hket1 : constantKet 1 N zeroCfg = 0 := by
+          rw [constantKet, Pi.single_eq_of_ne hzero_ne_one]
+        rw [Pi.add_apply, Pi.smul_apply, Pi.smul_apply, hket0, hket1]
+        simp
+      · by_cases hσone : σ = oneCfg
+        · rw [hσone]
+          have hone_ne_zero : oneCfg ≠ zeroCfg := by
+            intro h
+            have hval := congrFun h ⟨0, by omega⟩
+            simp [zeroCfg, oneCfg] at hval
+          have hket0 : constantKet 0 N oneCfg = 0 := by
+            rw [constantKet, Pi.single_eq_of_ne hone_ne_zero]
+          have hket1 : constantKet 1 N oneCfg = 1 := by
+            simp [constantKet, oneCfg]
+          rw [Pi.add_apply, Pi.smul_apply, Pi.smul_apply, hket0, hket1]
+          simp
+        · obtain ⟨i, hi⟩ :=
+            exists_adjacent_ne_of_not_constant hN σ hσzero hσone
+          have hψσ :=
+            ghz_chainGroundSpace_apply_eq_zero_of_adjacent_ne hN hψ hi
+          have hket0 : constantKet 0 N σ = 0 := by
+            rw [constantKet, Pi.single_eq_of_ne hσzero]
+          have hket1 : constantKet 1 N σ = 0 := by
+            rw [constantKet, Pi.single_eq_of_ne hσone]
+          rw [hψσ, Pi.add_apply, Pi.smul_apply, Pi.smul_apply, hket0, hket1]
+          simp
+    rw [hdecomp]
+    exact Submodule.add_mem _
+      (Submodule.smul_mem _ _ (Submodule.subset_span (by simp)))
+      (Submodule.smul_mem _ _ (Submodule.subset_span (by simp)))
+  · apply Submodule.span_le.mpr
+    intro ψ hψ
+    rw [Set.mem_insert_iff, Set.mem_singleton_iff] at hψ
+    rcases hψ with rfl | rfl
+    · exact constantKet_mem_ghz_chainGroundSpace hN 0
+    · exact constantKet_mem_ghz_chainGroundSpace hN 1
 
 end MPSTensor

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -47,13 +47,14 @@ non-injective, renormalization-fixed-point MPS.
 \begin{definition}[Constant product vector]\label{def:constant_ket}
     \lean{MPSTensor.constantKet}
     \leanok
-    For $a\in\{0,1\}$ and $N\ge0$, the vector
+    For $a\in\{0,1\}$ and $N\ge0$,
     \[
-        \ket{a}^{\otimes N}\in(\{0,1\}^{N}\to\C)
-    \]
-    is the indicator of the constant configuration
-    \[
-        (\sigma_1,\ldots,\sigma_N)=(a,\ldots,a).
+        \ket{a}^{\otimes N}(\sigma_1,\ldots,\sigma_N)
+        =
+        \begin{cases}
+            1, & (\sigma_1,\ldots,\sigma_N)=(a,\ldots,a),\\
+            0, & \text{otherwise}.
+        \end{cases}
     \]
 \end{definition}
 
@@ -576,15 +577,18 @@ for the ground eigenspace.
 \begin{proof}
     \leanok
     \uses{thm:ghz_ground_space_two}
-    Every cyclic nearest-neighbour restriction of $\ket{a}^{\otimes N}$ is the
-    two-site vector $\ket{aa}$.  Since
+    For each cyclic nearest-neighbour window,
     \[
+        \left.\ket{a}^{\otimes N}\right|_{[i,i+1]}
+        =
+        \ket{aa},
+        \qquad
         \ket{aa}\in
         \spn_{\C}\{\ket{00},\ket{11}\}
         =
         \mathcal G_2(A_{\mathrm{GHZ}}),
     \]
-    all cyclic two-site constraints are satisfied.
+    so $\ket{a}^{\otimes N}\in\mathcal G_{N,2}(A_{\mathrm{GHZ}})$.
 \end{proof}
 
 \begin{theorem}[GHZ periodic nearest-neighbour ground space]
@@ -611,9 +615,11 @@ for the ground eigenspace.
     \leanok
     \uses{thm:ghz_ground_space_two,
         thm:constant_ket_mem_ghz_chain_ground_space}
-    Let $\psi\in\mathcal G_{N,2}(A_{\mathrm{GHZ}})$.  Every cyclic two-site
-    restriction belongs to
+    Let $\psi\in\mathcal G_{N,2}(A_{\mathrm{GHZ}})$.  For every cyclic
+    nearest-neighbour window,
     \[
+        \left.\psi\right|_{[i,i+1]}
+        \in
         \mathcal G_2(A_{\mathrm{GHZ}})
         =
         \spn_{\C}\{\ket{00},\ket{11}\}.
@@ -624,8 +630,13 @@ for the ground eigenspace.
         \quad\Longrightarrow\quad
         \psi(\sigma)=0.
     \]
-    If a binary cyclic word is neither $(0,\ldots,0)$ nor $(1,\ldots,1)$, then
-    some nearest-neighbour pair is mixed.  Therefore
+    A nonconstant binary cyclic word has a mixed edge,
+    \[
+        \sigma\notin\{(0,\ldots,0),(1,\ldots,1)\}
+        \quad\Longrightarrow\quad
+        \exists i,\ \sigma_i\ne\sigma_{i+1}.
+    \]
+    Therefore
     \[
         \psi
         =
@@ -633,9 +644,14 @@ for the ground eigenspace.
         +
         \psi(1,\ldots,1)\ket{1}^{\otimes N}.
     \]
-    Conversely, the two constant product vectors have only the two local
-    words $00$ and $11$ on every cyclic nearest-neighbour window, so each local
-    restriction lies in $\mathcal G_2(A_{\mathrm{GHZ}})$.
+    Conversely, for $a\in\{0,1\}$ and every cyclic nearest-neighbour window,
+    \[
+        \left.\ket{a}^{\otimes N}\right|_{[i,i+1]}
+        =
+        \ket{aa}
+        \in
+        \mathcal G_2(A_{\mathrm{GHZ}}).
+    \]
 \end{proof}
 
 \begin{remark}[GHZ parent interaction]\label{rem:ghz_parent_interaction}
@@ -661,8 +677,13 @@ for the ground eigenspace.
         =
         \spn\{\ket{0}^{\otimes N},\ket{1}^{\otimes N}\},
     \]
-    where the cyclic-window equality is
-    Theorem~\ref{thm:ghz_chain_ground_space_two}.
+    using the cyclic-window equality
+    \[
+        \mathcal G_{N,2}(A_{\mathrm{GHZ}})
+        =
+        \spn\{\ket{0}^{\otimes N},\ket{1}^{\otimes N}\}
+    \]
+    from Theorem~\ref{thm:ghz_chain_ground_space_two}.
     This is the ferromagnetic Ising parent Hamiltonian
     \cite[lines~1194--1196 and line~2205]{Cirac2021Matrix};
     see also \cite[Section~3]{FernandezGonzalez2015Uncle} for the displayed

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -577,13 +577,23 @@ for the ground eigenspace.
 \begin{proof}
     \leanok
     \uses{thm:ghz_ground_space_two}
-    For each cyclic nearest-neighbour window,
+    For a cyclic nearest-neighbour window and outside assignment $\tau$, set
     \[
-        \left.\ket{a}^{\otimes N}\right|_{[i,i+1]}
+        R_{i,\tau}
+        :=
+        \left.\ket{a}^{\otimes N}\right|_{[i,i+1],\tau}.
+    \]
+    For $b,c\in\{0,1\}$ with $b\ne c$, the completed configuration is not
+    constant, hence
+    \[
+        R_{i,\tau}(b,c)=0.
+    \]
+    Therefore
+    \[
+        R_{i,\tau}
+        \in
+        \{v:v(0,1)=v(1,0)=0\}
         =
-        \ket{aa},
-        \qquad
-        \ket{aa}\in
         \spn_{\C}\{\ket{00},\ket{11}\}
         =
         \mathcal G_2(A_{\mathrm{GHZ}}),

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -654,14 +654,13 @@ for the ground eigenspace.
         +
         \psi(1,\ldots,1)\ket{1}^{\otimes N}.
     \]
-    Conversely, for $a\in\{0,1\}$ and every cyclic nearest-neighbour window,
+    Conversely, Theorem~\ref{thm:constant_ket_mem_ghz_chain_ground_space} gives
     \[
-        \left.\ket{a}^{\otimes N}\right|_{[i,i+1]}
-        =
-        \ket{aa}
+        \ket{0}^{\otimes N},\ \ket{1}^{\otimes N}
         \in
-        \mathcal G_2(A_{\mathrm{GHZ}}).
+        \mathcal G_{N,2}(A_{\mathrm{GHZ}}),
     \]
+    and hence their span lies in $\mathcal G_{N,2}(A_{\mathrm{GHZ}})$.
 \end{proof}
 
 \begin{remark}[GHZ parent interaction]\label{rem:ghz_parent_interaction}

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -561,6 +561,32 @@ for the ground eigenspace.
     $\spn_{\C}\{\ket{00},\ket{11}\}$.
 \end{proof}
 
+\begin{theorem}[Constant GHZ product vectors satisfy the cyclic constraints]
+    \label{thm:constant_ket_mem_ghz_chain_ground_space}
+    \lean{MPSTensor.constantKet_mem_ghz_chainGroundSpace}
+    \leanok
+    \uses{def:ghz_tensor, def:chain_ground_space, def:constant_ket,
+        thm:ghz_ground_space_two}
+    For $N\ge2$ and $a\in\{0,1\}$,
+    \[
+        \ket{a}^{\otimes N}\in\mathcal G_{N,2}(A_{\mathrm{GHZ}}).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ghz_ground_space_two}
+    Every cyclic nearest-neighbour restriction of $\ket{a}^{\otimes N}$ is the
+    two-site vector $\ket{aa}$.  Since
+    \[
+        \ket{aa}\in
+        \spn_{\C}\{\ket{00},\ket{11}\}
+        =
+        \mathcal G_2(A_{\mathrm{GHZ}}),
+    \]
+    all cyclic two-site constraints are satisfied.
+\end{proof}
+
 \begin{theorem}[GHZ periodic nearest-neighbour ground space]
     \label{thm:ghz_chain_ground_space_two}
     \lean{MPSTensor.ghz_chainGroundSpace_two_eq_constant_span}
@@ -583,7 +609,8 @@ for the ground eigenspace.
 
 \begin{proof}
     \leanok
-    \uses{thm:ghz_ground_space_two}
+    \uses{thm:ghz_ground_space_two,
+        thm:constant_ket_mem_ghz_chain_ground_space}
     Let $\psi\in\mathcal G_{N,2}(A_{\mathrm{GHZ}})$.  Every cyclic two-site
     restriction belongs to
     \[

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -44,6 +44,19 @@ non-injective, renormalization-fixed-point MPS.
     \]
 \end{definition}
 
+\begin{definition}[Constant product vector]\label{def:constant_ket}
+    \lean{MPSTensor.constantKet}
+    \leanok
+    For $a\in\{0,1\}$ and $N\ge0$, the vector
+    \[
+        \ket{a}^{\otimes N}\in(\{0,1\}^{N}\to\C)
+    \]
+    is the indicator of the constant configuration
+    \[
+        (\sigma_1,\ldots,\sigma_N)=(a,\ldots,a).
+    \]
+\end{definition}
+
 \begin{theorem}[GHZ transfer map is idempotent]\label{thm:ghz_transfer_idempotent}
     \lean{MPSTensor.ghz_transferMap_idempotent}
     \leanok
@@ -548,6 +561,56 @@ for the ground eigenspace.
     $\spn_{\C}\{\ket{00},\ket{11}\}$.
 \end{proof}
 
+\begin{theorem}[GHZ periodic nearest-neighbour ground space]
+    \label{thm:ghz_chain_ground_space_two}
+    \lean{MPSTensor.ghz_chainGroundSpace_two_eq_constant_span}
+    \leanok
+    \uses{def:ghz_tensor, def:chain_ground_space, def:constant_ket,
+        thm:ghz_ground_space_two}
+    For $N\ge2$, the common nearest-neighbour cyclic ground space of the GHZ
+    tensor satisfies
+    \[
+        \mathcal G_{N,2}(A_{\mathrm{GHZ}})
+        =
+        \spn_{\C}\{
+            \ket{0}^{\otimes N},
+            \ket{1}^{\otimes N}
+        \}.
+    \]
+    This is the cyclic-window form of the two-fold degeneracy in
+    \cite[line~2205]{Cirac2021Matrix}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ghz_ground_space_two}
+    Let $\psi\in\mathcal G_{N,2}(A_{\mathrm{GHZ}})$.  Every cyclic two-site
+    restriction belongs to
+    \[
+        \mathcal G_2(A_{\mathrm{GHZ}})
+        =
+        \spn_{\C}\{\ket{00},\ket{11}\}.
+    \]
+    Hence a mixed nearest-neighbour word has zero coefficient:
+    \[
+        \sigma_i\ne\sigma_{i+1}
+        \quad\Longrightarrow\quad
+        \psi(\sigma)=0.
+    \]
+    If a binary cyclic word is neither $(0,\ldots,0)$ nor $(1,\ldots,1)$, then
+    some nearest-neighbour pair is mixed.  Therefore
+    \[
+        \psi
+        =
+        \psi(0,\ldots,0)\ket{0}^{\otimes N}
+        +
+        \psi(1,\ldots,1)\ket{1}^{\otimes N}.
+    \]
+    Conversely, the two constant product vectors have only the two local
+    words $00$ and $11$ on every cyclic nearest-neighbour window, so each local
+    restriction lies in $\mathcal G_2(A_{\mathrm{GHZ}})$.
+\end{proof}
+
 \begin{remark}[GHZ parent interaction]\label{rem:ghz_parent_interaction}
     For the GHZ tensor of Definition~\ref{def:ghz_tensor},
     \[
@@ -569,8 +632,10 @@ for the ground eigenspace.
         \qquad
         \ker H_{\mathrm{GHZ},N}
         =
-        \spn\{\ket{0}^{\otimes N},\ket{1}^{\otimes N}\}.
+        \spn\{\ket{0}^{\otimes N},\ket{1}^{\otimes N}\},
     \]
+    where the cyclic-window equality is
+    Theorem~\ref{thm:ghz_chain_ground_space_two}.
     This is the ferromagnetic Ising parent Hamiltonian
     \cite[lines~1194--1196 and line~2205]{Cirac2021Matrix};
     see also \cite[Section~3]{FernandezGonzalez2015Uncle} for the displayed

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -626,13 +626,19 @@ for the ground eigenspace.
     \uses{thm:ghz_ground_space_two,
         thm:constant_ket_mem_ghz_chain_ground_space}
     Let $\psi\in\mathcal G_{N,2}(A_{\mathrm{GHZ}})$.  For every cyclic
-    nearest-neighbour window,
+    nearest-neighbour window and outside assignment $\tau$,
     \[
-        \left.\psi\right|_{[i,i+1]}
+        \left.\psi\right|_{[i,i+1],\tau}
         \in
         \mathcal G_2(A_{\mathrm{GHZ}})
         =
         \spn_{\C}\{\ket{00},\ket{11}\}.
+    \]
+    Taking the outside assignment from the word $\sigma$ gives
+    \[
+        \left.\psi\right|_{[i,i+1],\sigma}(\sigma_i,\sigma_{i+1})
+        =
+        \psi(\sigma).
     \]
     Hence a mixed nearest-neighbour word has zero coefficient:
     \[


### PR DESCRIPTION
## Summary

This proves the cyclic nearest-neighbour GHZ ground-space equation

\[
  \mathcal G_{N,2}(A_{\mathrm{GHZ}})
  =
  \operatorname{span}_{\mathbb C}
  \{\ket{0}^{\otimes N},\ket{1}^{\otimes N}\}
  \qquad (N\ge 2).
\]

The proof uses the already formalized two-site equation

\[
  \mathcal G_2(A_{\mathrm{GHZ}})
  =
  \operatorname{span}_{\mathbb C}\{\ket{00},\ket{11}\},
\]

then shows that any nonconstant binary cyclic word has an adjacent mixed pair, so a vector satisfying all two-site constraints is determined by its coefficients on the two constant words. Conversely, the two constant product vectors have only the local words \(00\) and \(11\) on every cyclic nearest-neighbour window.

Blueprint ch16 now records the constant product vectors and the cyclic-window GHZ theorem separately from the parent-interaction remark.

Advances #2315 and #2320. It does not close #2315, since the cluster and AKLT parent-Hamiltonian examples remain.

## Verification

- `lake build TNLean.MPS.Examples.GHZParentHamiltonian -q --log-level=info`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check origin/main...HEAD`
- `leanblueprint web`

`leanblueprint checkdecls`/the sync script still report pre-existing unrelated missing declarations in other chapters; the new GHZ declarations are not among the missing names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and blueprint documentation; no runtime, auth, or infrastructure changes.
> 
> **Overview**
> Formalizes the **periodic nearest-neighbour GHZ chain ground space** for \(N \ge 2\): \(\mathcal G_{N,2}(A_{\mathrm{GHZ}})\) equals the span of \(\ket{0}^{\otimes N}\) and \(\ket{1}^{\otimes N}\). Adds **`constantKet`**, imports **`UniqueGroundState`** for `chainGroundSpace`, and proves membership of constant product states plus the main span equality by lifting the existing two-site \(\mathcal G_2 = \mathrm{span}\{\ket{00},\ket{11}\}\) result through cyclic windows (mixed edges vanish; nonconstant configs have an adjacent mismatch).
> 
> **Blueprint ch16** gains the constant-product definition, two new theorems with proofs, and ties the GHZ parent-interaction remark to the new cyclic-window theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a86a3caedc0e7ad6c1228c2ed8f7d2e678fc1ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->