### PR TITLE
refactor(parent): isolate closing-boundaries restriction equation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -174,6 +174,7 @@ import TNLean.MPS.Core.Correlations
 import TNLean.MPS.ParentHamiltonian.GroundSpace
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.Basic
+import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.SuffixWindow

--- a/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
+++ b/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
@@ -83,9 +83,14 @@ private theorem allZero_contradiction [NeZero D]
 /-- For a tensor that is injective after blocking, the MPS vector is nonzero on
 chains of sufficient length.
 
-Assuming `mpv = 0` (all trace products of length `N` vanish), factor through
-`wordSpan A L₀ = M_D` to force all length-(`N − L₀`) products to zero, then
-`allZero_contradiction` gives the contradiction. -/
+If the length-\(N\) MPS vector vanished, then
+\(\operatorname{tr}(A^w)=0\) for every word \(w\) of length \(N\). The
+block-injectivity span identity
+\[
+  \operatorname{span}\{A^u : |u|=L_0\}=M_D(\mathbb C)
+\]
+forces every suffix product of length \(N-L_0\) to vanish. Strong induction on
+the word length then gives a contradiction. -/
 theorem mpv_ne_zero_of_isNBlkInjective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :

--- a/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
+++ b/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
@@ -19,12 +19,16 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- If all products of some positive length `k` are zero and `A` is `L₀`-block-injective
-with `L₀ > 0`, we reach a contradiction.
+/-- If all products of some positive length \(k\) are zero and \(A\) is
+\(L_0\)-block-injective with \(L_0>0\), we reach a contradiction.
 
-**Descent argument**: if `k ≤ L₀`, factor every length-`L₀` word through a zero
-length-`k` prefix; if `k > L₀`, use `wordSpan A L₀ = M_D` with `M = 1` to show
-all length-(`k − L₀`) products are zero, then recurse. -/
+**Descent argument:** if \(k\le L_0\), factor every length-\(L_0\) word through
+a zero length-\(k\) prefix. If \(k>L_0\), use the span equality
+\[
+  \operatorname{span}\{A^w : |w|=L_0\}=M_D(\mathbb C)
+\]
+with the identity matrix to show that every product of length \(k-L_0\) is zero,
+then recurse. -/
 private theorem allZero_contradiction [NeZero D]
     {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {k : ℕ} (hk : 0 < k)

--- a/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
+++ b/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
@@ -13,8 +13,6 @@ This file records the descent argument showing that a block-injective tensor has
 a nonzero periodic MPS vector on chains longer than the injectivity length.
 -/
 
-open scoped Matrix BigOperators
-
 namespace MPSTensor
 
 variable {d D : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
+++ b/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.Basic
+import TNLean.Algebra.TracePairing
+import TNLean.Wielandt.SpanGrowth.CumulativeSpan
+
+/-!
+# Nonvanishing of block-injective MPS vectors
+
+This file records the descent argument showing that a block-injective tensor has
+a nonzero periodic MPS vector on chains longer than the injectivity length.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- If all products of some positive length `k` are zero and `A` is `L₀`-block-injective
+with `L₀ > 0`, we reach a contradiction.
+
+**Descent argument**: if `k ≤ L₀`, factor every length-`L₀` word through a zero
+length-`k` prefix; if `k > L₀`, use `wordSpan A L₀ = M_D` with `M = 1` to show
+all length-(`k − L₀`) products are zero, then recurse. -/
+private theorem allZero_contradiction [NeZero D]
+    {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {k : ℕ} (hk : 0 < k)
+    (hzero : ∀ w : List (Fin d), w.length = k → evalWord A w = 0) : False := by
+  have hws : wordSpan A L₀ = ⊤ := (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+  -- Strong induction on k.
+  suffices ∀ k, 0 < k → (∀ w : List (Fin d), w.length = k → evalWord A w = 0) → False from
+    this k hk hzero
+  intro k
+  induction k using Nat.strongRecOn with
+  | ind k ih =>
+    intro hk_pos hk_zero
+    by_cases hkL : k ≤ L₀
+    · -- Case k ≤ L₀: factor every length-L₀ word as (take k) ++ (drop k).
+      have hws_bot : wordSpan A L₀ = ⊥ := by
+        rw [eq_bot_iff, wordSpan]
+        apply Submodule.span_le.mpr
+        rintro _ ⟨σ, rfl⟩
+        rw [SetLike.mem_coe, Submodule.mem_bot]
+        have hsplit := List.take_append_drop k (List.ofFn σ)
+        have htake_len : (List.take k (List.ofFn σ)).length = k := by
+          rw [List.length_take]; simp; omega
+        calc evalWord A (List.ofFn σ)
+            = evalWord A (List.take k (List.ofFn σ) ++
+                List.drop k (List.ofFn σ)) := by rw [hsplit]
+          _ = evalWord A (List.take k (List.ofFn σ)) *
+                evalWord A (List.drop k (List.ofFn σ)) := evalWord_append ..
+          _ = 0 * evalWord A (List.drop k (List.ofFn σ)) := by
+                rw [hk_zero _ htake_len]
+          _ = 0 := zero_mul _
+      exact absurd (hws ▸ hws_bot) top_ne_bot
+    · -- Case k > L₀: use span = M_D and M = 1 to descend to k - L₀.
+      push Not at hkL
+      have hkL₀_pos : 0 < k - L₀ := by omega
+      apply ih (k - L₀) (by omega) hkL₀_pos
+      intro w₂ hw₂
+      -- For each σ₁ of length L₀: evalWord A (ofFn σ₁) * evalWord A w₂ = 0.
+      have hmul_zero : ∀ σ₁ : Fin L₀ → Fin d,
+          evalWord A (List.ofFn σ₁) * evalWord A w₂ = 0 := by
+        intro σ₁
+        have hlen : (List.ofFn σ₁ ++ w₂).length = k := by simp [hw₂]; omega
+        have := hk_zero _ hlen
+        rwa [evalWord_append] at this
+      -- The map M ↦ M * evalWord A w₂ vanishes on wordSpan A L₀ = ⊤.
+      have hright : LinearMap.mulRight ℂ (evalWord A w₂) = 0 := by
+        apply LinearMap.ext_on_range
+          (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
+          (hv := by rwa [← wordSpan])
+        intro σ₁
+        simp [LinearMap.mulRight_apply, hmul_zero σ₁]
+      -- Taking M = 1: evalWord A w₂ = 0.
+      have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) * evalWord A w₂ = 0 :=
+        show LinearMap.mulRight ℂ (evalWord A w₂) 1 = 0 by rw [hright]; simp
+      simpa using h1
+
+/-- For a tensor that is injective after blocking, the MPS vector is nonzero on
+chains of sufficient length.
+
+Assuming `mpv = 0` (all trace products of length `N` vanish), factor through
+`wordSpan A L₀ = M_D` to force all length-(`N − L₀`) products to zero, then
+`allZero_contradiction` gives the contradiction. -/
+theorem mpv_ne_zero_of_isNBlkInjective {A : MPSTensor d D} [NeZero D]
+    {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {N : ℕ} (hN : L₀ + 1 ≤ N) :
+    (mpv A : NSiteSpace d N) ≠ 0 := by
+  have hws : wordSpan A L₀ = ⊤ := (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+  intro hzero
+  -- mpv = 0 means tr(evalWord A (List.ofFn σ)) = 0 for all σ : Fin N → Fin d.
+  have htr_zero : ∀ σ : Fin N → Fin d,
+      Matrix.trace (evalWord A (List.ofFn σ)) = 0 := by
+    intro σ; simpa [mpv, coeff] using congrFun hzero σ
+  -- All products of length (N - L₀) are zero by trace nondegeneracy.
+  have hprod_zero : ∀ w₂ : List (Fin d), w₂.length = N - L₀ →
+      evalWord A w₂ = 0 := by
+    intro w₂ hw₂
+    -- Show ∀ M, tr(evalWord A w₂ * M) = 0 to get evalWord A w₂ = 0.
+    apply trace_mul_right_eq_zero
+    intro M
+    -- The functional P ↦ tr(P * evalWord A w₂) vanishes on wordSpan A L₀ = ⊤.
+    have hφ : (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
+        (LinearMap.mulRight ℂ (evalWord A w₂)) = 0 := by
+      apply LinearMap.ext_on_range
+        (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
+        (hv := by rwa [← wordSpan])
+      intro σ₁
+      simp only [LinearMap.comp_apply, LinearMap.mulRight_apply,
+        Matrix.traceLinearMap_apply]
+      -- tr(evalWord A (List.ofFn σ₁) * evalWord A w₂) = tr(evalWord A (σ₁ ++ w₂))
+      rw [← evalWord_append]
+      -- This is a trace of a length-N word product, hence 0.
+      have hlen : (List.ofFn σ₁ ++ w₂).length = N := by simp [hw₂]; omega
+      let σ' : Fin N → Fin d :=
+        fun i => (List.ofFn σ₁ ++ w₂).get ⟨i.val, hlen.symm ▸ i.isLt⟩
+      have hw_eq : List.ofFn σ' = List.ofFn σ₁ ++ w₂ := by
+        apply List.ext_get
+        · simp [hw₂]; omega
+        · intro i h1 h2; simp [σ']
+      rw [← hw_eq]
+      exact htr_zero σ'
+    -- From hφ: ∀ P, tr(P * evalWord A w₂) = 0. By trace commutativity:
+    calc Matrix.trace (evalWord A w₂ * M)
+        = Matrix.trace (M * evalWord A w₂) := Matrix.trace_mul_comm ..
+      _ = 0 := by
+          simpa [Matrix.traceLinearMap_apply] using congrArg (· M) hφ
+  exact allZero_contradiction hInj hL₀ (by omega : 0 < N - L₀) hprod_zero
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -6,6 +6,7 @@ import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.ExtendRight
+import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
 import TNLean.MPS.FundamentalTheorem.FiniteLength
@@ -236,120 +237,6 @@ theorem hasUniqueGroundState_iff_proportional {V : Type*} [AddCommGroup V] [Modu
     exact (finrank_eq_one_iff_of_nonzero' ψ₀ hψ₀).2 fun ψ => by
       obtain ⟨c, hc⟩ := hgen ψ
       exact ⟨c, hc.symm⟩
-
-/-! ### Nonvanishing after blocking -/
-
-/-- If all products of some positive length `k` are zero and `A` is `L₀`-block-injective
-with `L₀ > 0`, we reach a contradiction.
-
-**Descent argument**: if `k ≤ L₀`, factor every length-`L₀` word through a zero
-length-`k` prefix; if `k > L₀`, use `wordSpan A L₀ = M_D` with `M = 1` to show
-all length-(`k − L₀`) products are zero, then recurse. -/
-private theorem allZero_contradiction [NeZero D]
-    {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
-    {k : ℕ} (hk : 0 < k)
-    (hzero : ∀ w : List (Fin d), w.length = k → evalWord A w = 0) : False := by
-  have hws : wordSpan A L₀ = ⊤ := (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
-  -- Strong induction on k.
-  suffices ∀ k, 0 < k → (∀ w : List (Fin d), w.length = k → evalWord A w = 0) → False from
-    this k hk hzero
-  intro k
-  induction k using Nat.strongRecOn with
-  | ind k ih =>
-    intro hk_pos hk_zero
-    by_cases hkL : k ≤ L₀
-    · -- Case k ≤ L₀: factor every length-L₀ word as (take k) ++ (drop k).
-      have hws_bot : wordSpan A L₀ = ⊥ := by
-        rw [eq_bot_iff, wordSpan]
-        apply Submodule.span_le.mpr
-        rintro _ ⟨σ, rfl⟩
-        rw [SetLike.mem_coe, Submodule.mem_bot]
-        have hsplit := List.take_append_drop k (List.ofFn σ)
-        have htake_len : (List.take k (List.ofFn σ)).length = k := by
-          rw [List.length_take]; simp; omega
-        calc evalWord A (List.ofFn σ)
-            = evalWord A (List.take k (List.ofFn σ) ++
-                List.drop k (List.ofFn σ)) := by rw [hsplit]
-          _ = evalWord A (List.take k (List.ofFn σ)) *
-                evalWord A (List.drop k (List.ofFn σ)) := evalWord_append ..
-          _ = 0 * evalWord A (List.drop k (List.ofFn σ)) := by
-                rw [hk_zero _ htake_len]
-          _ = 0 := zero_mul _
-      exact absurd (hws ▸ hws_bot) top_ne_bot
-    · -- Case k > L₀: use span = M_D and M = 1 to descend to k - L₀.
-      push Not at hkL
-      have hkL₀_pos : 0 < k - L₀ := by omega
-      apply ih (k - L₀) (by omega) hkL₀_pos
-      intro w₂ hw₂
-      -- For each σ₁ of length L₀: evalWord A (ofFn σ₁) * evalWord A w₂ = 0.
-      have hmul_zero : ∀ σ₁ : Fin L₀ → Fin d,
-          evalWord A (List.ofFn σ₁) * evalWord A w₂ = 0 := by
-        intro σ₁
-        have hlen : (List.ofFn σ₁ ++ w₂).length = k := by simp [hw₂]; omega
-        have := hk_zero _ hlen
-        rwa [evalWord_append] at this
-      -- The map M ↦ M * evalWord A w₂ vanishes on wordSpan A L₀ = ⊤.
-      have hright : LinearMap.mulRight ℂ (evalWord A w₂) = 0 := by
-        apply LinearMap.ext_on_range
-          (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
-          (hv := by rwa [← wordSpan])
-        intro σ₁
-        simp [LinearMap.mulRight_apply, hmul_zero σ₁]
-      -- Taking M = 1: evalWord A w₂ = 0.
-      have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) * evalWord A w₂ = 0 :=
-        show LinearMap.mulRight ℂ (evalWord A w₂) 1 = 0 by rw [hright]; simp
-      simpa using h1
-
-/-- For a tensor that is injective after blocking, the MPS vector is nonzero on
-chains of sufficient length.
-
-Assuming `mpv = 0` (all trace products of length `N` vanish), factor through
-`wordSpan A L₀ = M_D` to force all length-(`N − L₀`) products to zero, then
-`allZero_contradiction` gives the contradiction. -/
-theorem mpv_ne_zero_of_isNBlkInjective {A : MPSTensor d D} [NeZero D]
-    {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
-    {N : ℕ} (hN : L₀ + 1 ≤ N) :
-    (mpv A : NSiteSpace d N) ≠ 0 := by
-  have hws : wordSpan A L₀ = ⊤ := (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
-  intro hzero
-  -- mpv = 0 means tr(evalWord A (List.ofFn σ)) = 0 for all σ : Fin N → Fin d.
-  have htr_zero : ∀ σ : Fin N → Fin d,
-      Matrix.trace (evalWord A (List.ofFn σ)) = 0 := by
-    intro σ; simpa [mpv, coeff] using congrFun hzero σ
-  -- All products of length (N - L₀) are zero by trace nondegeneracy.
-  have hprod_zero : ∀ w₂ : List (Fin d), w₂.length = N - L₀ →
-      evalWord A w₂ = 0 := by
-    intro w₂ hw₂
-    -- Show ∀ M, tr(evalWord A w₂ * M) = 0 to get evalWord A w₂ = 0.
-    apply trace_mul_right_eq_zero
-    intro M
-    -- The functional P ↦ tr(P * evalWord A w₂) vanishes on wordSpan A L₀ = ⊤.
-    have hφ : (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
-        (LinearMap.mulRight ℂ (evalWord A w₂)) = 0 := by
-      apply LinearMap.ext_on_range
-        (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
-        (hv := by rwa [← wordSpan])
-      intro σ₁
-      simp only [LinearMap.comp_apply, LinearMap.mulRight_apply,
-        Matrix.traceLinearMap_apply]
-      -- tr(evalWord A (List.ofFn σ₁) * evalWord A w₂) = tr(evalWord A (σ₁ ++ w₂))
-      rw [← evalWord_append]
-      -- This is a trace of a length-N word product, hence 0.
-      have hlen : (List.ofFn σ₁ ++ w₂).length = N := by simp [hw₂]; omega
-      let σ' : Fin N → Fin d :=
-        fun i => (List.ofFn σ₁ ++ w₂).get ⟨i.val, hlen.symm ▸ i.isLt⟩
-      have hw_eq : List.ofFn σ' = List.ofFn σ₁ ++ w₂ := by
-        apply List.ext_get
-        · simp [hw₂]; omega
-        · intro i h1 h2; simp [σ']
-      rw [← hw_eq]
-      exact htr_zero σ'
-    -- From hφ: ∀ P, tr(P * evalWord A w₂) = 0. By trace commutativity:
-    calc Matrix.trace (evalWord A w₂ * M)
-        = Matrix.trace (M * evalWord A w₂) := Matrix.trace_mul_comm ..
-      _ = 0 := by
-          simpa [Matrix.traceLinearMap_apply] using congrArg (· M) hφ
-  exact allZero_contradiction hInj hL₀ (by omega : 0 < N - L₀) hprod_zero
 
 /-- A positive block-injectivity length over nonzero virtual dimension forces the
 physical alphabet to be nonempty. -/

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -774,11 +774,48 @@ theorem wrapped_mirror_witness_agree_of_right_products
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
-/-- Closure-property restriction equation, arXiv:2011.12127, lines 2049--2090:
+/-- Restriction equality when closing the boundaries, from the closure property,
+arXiv:2011.12127, lines 2078--2090:
+\(\operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L₀+1}(\psi)=
+\operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L₀,L₀+1}(\psi)\).
+
+**Open gap:** This is the instance of the closure property obtained when
+closing the boundaries by the inverting-and-growing-back argument. Tracked in
+#2368; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψ : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1))
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        ⟨M, by omega⟩
+        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        ⟨M + 1 - L₀, by omega⟩
+        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+  sorry
+
+/-- Closure-property restriction equation, arXiv:2011.12127, lines 2078--2090:
 \(\operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L₀}(\psi)=
 \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L₀,L₀}(\psi)\).
-**Open gap:** Localized obligation for #2331; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+
+It is the first-site restriction of the equality obtained when closing the
+boundaries:
+\[
+\operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L₀}(\psi)
+=
+\left.
+\operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L₀+1}(\psi)
+\right|_{\sigma_1=j}
+=
+\left.
+\operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L₀,L₀+1}(\psi)
+\right|_{\sigma_1=j}
+=
+\operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L₀,L₀}(\psi).
+\] -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -795,12 +832,23 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
         (fun k => if (k.val + (M + 1) -
               (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)).val) % (M + 1) = 0 then j
             else mirrorMiddleBackground L₀ (M + 1) η μ k) ψ := by
-  sorry
+  rw [← cyclicRestrictₗ_restrictFirst
+      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M, by omega⟩ : Fin (M + 1))
+      (wrappedMiddleBackground L₀ (M + 1) η μ) ψ j]
+  rw [← cyclicRestrictₗ_restrictFirst
+      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+      (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
+  exact congrArg (fun φ => restrictFirst φ j)
+    (closure_property_boundary_restriction_eq_of_chainGroundSpace
+      (A := A) hInj hL₀ hM hψ hψX η μ)
 
 /-- Boundary-closing \(Y A^j\) equation from arXiv:2011.12127, lines 2078--2090:
 \(Y_M(\tau^+_\eta(\mu))A^j=Y_{M+1-L₀}(\tau^-_\eta(\mu))A^j\).
-**Open gap:** Depends on the restriction equation above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2331. -/
+**Open gap:** Depends on the restriction equality above for closing the
+boundaries; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2368. -/
 theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -836,8 +884,9 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
 /-- Boundary matrices from the two boundary-closing comparisons agree.
 This is arXiv:2011.12127, lines 2078--2090, reduced to the \(Y A^j\) equation
 above.
-**Open gap:** Depends on the restriction equation above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2331. -/
+**Open gap:** Depends on the restriction equality above for closing the
+boundaries; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2368. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -702,7 +702,10 @@ boundaries:
 \right|_{\sigma_1=j}
 =
 \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L₀,L₀}(\psi).
-\] -/
+\]
+
+**Open gap:** Depends on the restriction equality for closing the boundaries;
+see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2368. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1458,12 +1458,42 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     matrices $Y^+_{\tau^+_\eta(\mu)}$ and $Y^-_{\tau^-_\eta(\mu)}$.
 \end{proof}
 
+\begin{lemma}[Restriction equation when closing the boundaries]
+    \label{lem:closure_property_boundary_restriction_chain_ground_space}
+    \lean{MPSTensor.closure_property_boundary_restriction_eq_of_chainGroundSpace}
+    \leanok
+    \uses{def:chain_ground_space, rem:cyclic_window_operators,
+        lem:wrapped_middle_backgrounds}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
+    $L_0\le M$, and let
+    \[
+        \psi\in\mathcal G_{M+1,L_0+1}(A),
+        \qquad
+        \psi=\Gamma_{M+1}(X).
+    \]
+    For every boundary letter $\eta$ and complementary word $\mu$, the form of
+    the closure property obtained when closing the boundaries is
+    \[
+        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
+        =
+        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi).
+    \]
+    This is \cite[lines~2078--2090]{Cirac2021Matrix}.
+\end{lemma}
+
+\begin{proof}
+    \notready
+    This is the instance, when closing the boundaries, of the same inverting
+    and growing-back argument used for the open-chain intersection property.
+\end{proof}
+
 \begin{lemma}[Closure-property restriction equation]
     \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
     \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}
     \leanok
     \uses{def:chain_ground_space, rem:cyclic_window_operators,
-        lem:wrapped_middle_backgrounds}
+        lem:wrapped_middle_backgrounds,
+        lem:closure_property_boundary_restriction_chain_ground_space}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
     $L_0\le M$, and let
     \[
@@ -1496,8 +1526,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \end{lemma}
 
 \begin{proof}
-    \notready
-    The boundary-closing equality is
+    \leanok
+    The restriction equation obtained when closing the boundaries is
     \[
         \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
         =

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1461,7 +1461,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{lemma}[Restriction equation when closing the boundaries]
     \label{lem:closure_property_boundary_restriction_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_chainGroundSpace}
-    \notready
+    \leanok
     \uses{def:chain_ground_space, rem:cyclic_window_operators,
         lem:wrapped_middle_backgrounds}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
@@ -1489,8 +1489,16 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi).
     \]
-    It should be obtained when closing the boundaries by the same inverting and
-    growing-back argument used for the open-chain intersection property.
+    The required algebraic input is the block-injectivity identity
+    \[
+        \operatorname{span}\{A^{j_1}\cdots A^{j_{L_0}} :
+        j_1,\ldots,j_{L_0}\}
+        =
+        M_D(\mathbb C).
+    \]
+    Applying this identity to the boundary vector formed by closing the two
+    sides should identify the two boundary representations, hence the two
+    restrictions displayed above.
 \end{proof}
 
 \begin{lemma}[Closure-property restriction equation]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1526,7 +1526,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     The restriction equation obtained when closing the boundaries is
     \[
         \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1461,7 +1461,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{lemma}[Restriction equation when closing the boundaries]
     \label{lem:closure_property_boundary_restriction_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_chainGroundSpace}
-    \leanok
+    \notready
     \uses{def:chain_ground_space, rem:cyclic_window_operators,
         lem:wrapped_middle_backgrounds}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
@@ -1483,8 +1483,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    This is the instance, when closing the boundaries, of the same inverting
-    and growing-back argument used for the open-chain intersection property.
+    The missing step is the equality
+    \[
+        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
+        =
+        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi).
+    \]
+    It should be obtained when closing the boundaries by the same inverting and
+    growing-back argument used for the open-chain intersection property.
 \end{proof}
 
 \begin{lemma}[Closure-property restriction equation]
@@ -1522,7 +1528,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi).
     \]
-    This is \cite[lines~2049--2090]{Cirac2021Matrix}.
+    This is \cite[lines~2078--2090]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1483,11 +1483,13 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    The missing step is the equality
+    The missing step is the vanishing
     \[
-        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
-        =
-        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi).
+        \left(
+        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}
+        -
+        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}
+        \right)(\psi)=0.
     \]
     The required algebraic input is the block-injectivity identity
     \[
@@ -1496,9 +1498,19 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         M_D(\mathbb C).
     \]
-    Applying this identity to the boundary vector formed by closing the two
-    sides should identify the two boundary representations, hence the two
-    restrictions displayed above.
+    Thus the unproved boundary-closing implication is
+    \[
+        \psi\in\mathcal G_{M+1,L_0+1}(A),\quad
+        \psi=\Gamma_{M+1}(X),\quad
+        \operatorname{span}\{A^{j_1}\cdots A^{j_{L_0}} :
+        j_1,\ldots,j_{L_0}\}=M_D(\mathbb C)
+        \Longrightarrow
+        \left(
+        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}
+        -
+        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}
+        \right)(\psi)=0.
+    \]
 \end{proof}
 
 \begin{lemma}[Closure-property restriction equation]

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -75,10 +75,10 @@ In the formal statement this is the equality between the cyclic chain ground
 space and the subspace \(\mathbb C\,\Omega_N(A)\). The hard inclusion into
 \(\mathbb C\,\Omega_N(A)\) is the remaining range-reduction lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:868 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:836 for
 \path{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
 and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:910 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:872 for
 \path{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal}. The formal hypotheses
 are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
 \path{0 < L0}, \path{2 <= N}, and \path{L0 < L <= N}.}
@@ -119,9 +119,9 @@ constraints. This supplies the formal analog of the iterated open-boundary
 part of the source proof, without expressing the inverse for the region $B$
 through the older single-site intersection lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:379 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:266 for
 \path{MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:441 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:328 for
 \path{MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}.}
 
 \section{The remaining comparison}
@@ -173,8 +173,31 @@ commutation with the full matrix algebra, so $X$ is scalar.
 \path{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}.}
 The remaining point is the comparison between the two boundary-crossing
 outputs: one must reindex their complementary words in the same way and identify
-the two boundary matrices as the same matrix $Y_\mu$. Equivalently, when
-closing the boundaries, the closure property should identify the two restrictions
+the two boundary matrices as the same matrix $Y_\mu$. For an $N$-site vector
+$\psi$, write
+\[
+  \operatorname{Res}^{\tau}_{i,L}(\psi)(\sigma)
+  =
+  \psi\!\left(\operatorname{replaceWindow}_{L,i}(\sigma,\tau)\right),
+\]
+where the cyclic window of length $L$ beginning at $i$ is fixed to the word
+$\tau$, and $\sigma$ labels the remaining $N-L$ sites. With $N=M+1$, the two
+boundary-crossing words are
+\[
+  \tau^{+}_{\eta}(\mu)_i =
+  \begin{cases}
+    \mu_{i-L_0}, & L_0\le i<N-1,\\
+    \eta,        & \text{otherwise},
+  \end{cases}
+  \qquad
+  \tau^{-}_{\eta}(\mu)_i =
+  \begin{cases}
+    \mu_{i-1}, & 1\le i<N-L_0,\\
+    \eta,      & \text{otherwise}.
+  \end{cases}
+\]
+Equivalently, when closing the boundaries, the closure property should identify
+the two restrictions
 \[
   \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
   =

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -23,7 +23,7 @@ Section~IV.C of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
 formal obligation is recorded in
 \href{https://github.com/LionSR/TNLean/issues/588}{issue \#588}; the
 boundary-closing comparison is recorded in
-\href{https://github.com/LionSR/TNLean/issues/2331}{issue \#2331};
+\href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368};
 and the parent-Hamiltonian consequences are recorded in
 \href{https://github.com/LionSR/TNLean/issues/460}{issue \#460}.}
 
@@ -173,11 +173,16 @@ commutation with the full matrix algebra, so $X$ is scalar.
 \path{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}.}
 The remaining point is the comparison between the two boundary-crossing
 outputs: one must reindex their complementary words in the same way and identify
-the two boundary matrices as the same matrix $Y_\mu$.\footnote{For traceability,
-this is the mathematical content recorded in
-\href{https://github.com/LionSR/TNLean/issues/2331}{issue \#2331}. The earlier
-\href{https://github.com/LionSR/TNLean/issues/1475}{issue \#1475} was the
-predecessor before this comparison was isolated.}
+the two boundary matrices as the same matrix $Y_\mu$. Equivalently, when
+closing the boundaries, the closure property should identify the two restrictions
+\[
+  \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
+  =
+  \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi),
+\]
+before taking the first-site restriction $\sigma_1=j$.\footnote{For
+traceability, this is the mathematical content recorded in
+\href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368}.}
 
 \section{Conclusion}
 

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -169,7 +169,7 @@ commutation with the full matrix algebra, so $X$ is scalar.
 \footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:645 for
 \path{MPSTensor.commutes_words_of_two_sided_middle_compatibility}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:667 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:554 for
 \path{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}.}
 The remaining point is the comparison between the two boundary-crossing
 outputs: one must reindex their complementary words in the same way and identify

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -147,7 +147,7 @@ obtained with different orientations and indexings. The two formulas are both
 valid; what is missing is a comparison that identifies the two boundary
 matrices after the complementary sites have been indexed by the same word.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:554 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:441 for
 \path{MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective},
 \path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:402 for the wrapped
 compatibility, and


### PR DESCRIPTION
## Summary
- introduce the restriction equality obtained when closing the boundaries as the localized closure-property obligation
- prove the fixed-boundary-letter restriction equation by taking the first-site restriction of that displayed equality
- update the blueprint and paper-gap note so the remaining assertion is stated as an equation and traced to #2368

Refs #2368. This does not close the issue; it moves the remaining proof obligation to the source-level restriction equality.

## Checks
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info` (passes; one deliberate localized `sorry`)
- `lake build TNLean -q --log-level=info` (passes; existing/deliberate `sorry` warnings)
- `leanblueprint web` (passes with the repository’s usual renderer/bibliography warnings)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (chapter 14: 349/349; reports unrelated existing missing refs in ch13a/ch04a)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (fails only on existing ch13a `blockingData` and ch04a `...` refs)
- `leanblueprint checkdecls` (fails on existing missing declarations; the new parent-Hamiltonian declaration is not among them)
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly file moves and proof restructuring; one localized `sorry` replaces a larger sorry’d lemma without changing the overall formalization strategy.
> 
> **Overview**
> Refactors the parent-Hamiltonian **boundary-closing** step so the remaining proof obligation is a single **restriction equality** when closing boundaries, instead of burying it inside the fixed-letter restriction lemma.
> 
> **Lean:** `allZero_contradiction` and `mpv_ne_zero_of_isNBlkInjective` move to new `TNLean/MPS/ParentHamiltonian/Nonvanishing.lean` (wired through `TNLean.lean`). `closure_property_boundary_restriction_eq_of_chainGroundSpace` is introduced with a deliberate `sorry` (#2368). `closure_property_fixed_boundary_letter_eq_of_chainGroundSpace` is **proved** by peeling the first site via `cyclicRestrictₗ_restrictFirst` from that equality. Downstream closure lemmas now cite the boundary-restriction gap and issue **#2368** (replacing #2331).
> 
> **Docs:** Blueprint ch.14 adds lemma `lem:closure_property_boundary_restriction_chain_ground_space` and reframes the fixed-letter lemma as depending on it; `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` states the open comparison as the displayed \(\mathrm{Res}\) identity and updates formal line references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d34b71bd5214fb3ae265e913ae9e7390d9fd9c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->