### PR TITLE
fix(periodic): add missing IsPeriodic hypothesis to the sector non-repetition leaf (was false as stated)

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -575,9 +575,19 @@ gauge-phase equivalence would make two sector MPV families proportional). That i
 *not* the paper's argument; the faithful route is the spectral one above, which
 reuses the same peripheral-spectrum / fixed-point machinery already used in
 `period_eq_of_gaugePhaseEquiv_of_isPeriodic`. See
-docs/paper-gaps/1708_periodic_overlap_route_alignment.tex. -/
+docs/paper-gaps/1708_periodic_overlap_route_alignment.tex.
+
+**Correctness — the `IsPeriodic m A` hypothesis is load-bearing.** The spectral
+argument requires `A` to be a periodic (irreducible) block: that is what gives
+𝓔_A the peripheral spectrum {ω^r} and makes each cyclic sector primitive. Without
+it the statement is FALSE — the bare cyclic-projection data (orthogonal `P_k`
+summing to `1`, the adjoint shift, blocked commutation, the trace formula) is
+consistent with a *reducible* `A` (e.g. `B ⊕ B` for an irreducible period-`m`
+block `B`) whose distinct sectors are gauge-phase equivalent. `hP` is supplied at
+the unique call site `sectorBlocks_not_gaugePhaseEquiv_of_ne`. -/
 private lemma not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
+    (hP : IsPeriodic m A)
     {dim : Fin m → ℕ}
     (blocks :
       (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
@@ -619,7 +629,7 @@ missing mathematical input is orthogonal-corner rigidity: distinct cyclic corner
 cannot be related by an invertible gauge and a nonzero scalar. -/
 private lemma sectorBlocks_not_gaugePhaseEquiv_of_ne
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
-    (_hP : IsPeriodic m A)
+    (hP : IsPeriodic m A)
     {dim : Fin m → ℕ}
     (blocks :
       (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
@@ -642,7 +652,7 @@ private lemma sectorBlocks_not_gaugePhaseEquiv_of_ne
   have hOrth : P u * P v = 0 := hPairwise huv
   exact
     not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
-      A blocks hPproj hPsum hCyclicP hComm hTrace hNondeg huv hdim hOrth
+      A hP blocks hPproj hPsum hCyclicP hComm hTrace hNondeg huv hdim hOrth
 
 /-- Sector-asymptotic step for the self-overlap proof.
 

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -109,6 +109,20 @@ already invoked in the different-period proof.\footnote{Formal declaration:
 The docstrings have been realigned to the source argument; the remaining work is
 to port it.
 
+\textbf{Signature correction (periodicity is load-bearing).} An adversarial
+proof-attempt found that the lemma was \emph{underspecified}: with only the bare
+cyclic-projection data (orthogonal $P_k$ summing to $1$, the adjoint shift
+$\mathcal E_A^{*}(P_{k+1})=P_k$, blocked-letter commutation, the trace formula,
+and orthogonality), the conclusion is \emph{false} --- a reducible $A=B\oplus B$
+(for an irreducible period-$m$ block $B$) admits the same cyclic-projection data
+yet has gauge-phase-equivalent distinct sectors. The spectral argument genuinely
+requires $A$ to be a periodic (irreducible) block: that is what makes $\mathcal
+E_A$ irreducible with the stated peripheral spectrum and the sectors primitive.
+The hypothesis \leanid{hP : IsPeriodic m A} was therefore added to the lemma
+signature (it is supplied at the unique call site
+\leanid{sectorBlocks_not_gaugePhaseEquiv_of_ne}). The \leanid{sorry} now sits on a
+\emph{true} statement; the remaining work is to port the spectral proof.
+
 \section{Sector-match case: propagation and the phase assembly}
 
 \textbf{Source.}\footnote{\cite{DeLasCuevas2017Irreducible}, Appendix~A,
@@ -143,6 +157,40 @@ docstrings have been realigned to cite the source equation labels and line
 ranges (replacing earlier published-version labels such as ``A.8'' and
 ``A.14--A.18'' that do not occur in the local source), and the
 $\kappa/\theta/\phi$ phase assembly is now stated explicitly as load-bearing.
+
+\textbf{Missing infrastructure (identified by adversarial proof-attempts).} The
+two open Case-3 leaves reduce to a common gap: \leanid{IsCyclicSectorDecomp}
+exposes only \emph{blocked-letter} data (the commutation $P_k\,(\bar A)_i=(\bar
+A)_i\,P_k$ and the adjoint shift $\mathcal E_A^{*}(P_{k+1})=P_k$), but the
+appendix argument needs \emph{single-site} structure that is currently absent
+from the repository (and from Mathlib):
+\begin{itemize}
+  \item \emph{Single-site off-diagonal decomposition} $A^i=\sum_u P_uA^iP_{u+1}$
+    (\emph{eq:Auprop}, line~1043). This is the bridge from the corner-compressed
+    sectors back to the global matrices $A^i$, required to even \emph{state} the
+    contraction in \leanid{repeatedBlocks_of_blockedSectorGaugePhase}. Adding it
+    (as a field of \leanid{IsCyclicSectorDecomp} or a derived lemma) is the key
+    enabling step.
+  \item \emph{Single-site sector-overlap translation invariance}: that
+    $\lVert\langle V_N(A_{u+1})|V_N(B_{v+1})\rangle\rVert$ and
+    $\lVert\langle V_N(A_u)|V_N(B_v)\rangle\rVert$ share an $N\to\infty$ limit,
+    obtained by applying the dual single-site shifts $\sum_iA_i^{\dagger}P_{u+1}A_i=P_u$
+    and $\sum_iB_i^{\dagger}Q_{v+1}B_i=Q_v$ inside the paired trace sum. This is the
+    one missing lemma for \leanid{sectorGaugePhaseEquiv_succ_of_cyclicTransport};
+    given it, that leaf closes via the proved
+    \leanid{gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP} and the
+    proved sector primitivity. There is no one-physical-site offset reblocking
+    equivalence on configurations in the repo (only the $m\cdot n$ regrouping).
+  \item \emph{Per-sector corner unitaries}: upgrading the compression LinearEquiv
+    $\varphi_u$ to a multiplicative $\ast$-isomorphism with a unitary intertwiner
+    $U_v=P_uU_vQ_v$ on $\mathrm{Fin}\,D$ (\emph{eq:Cvprop}); and the $m$-factor
+    cyclic $\Omega_u$-contraction with the $\eta$ bookkeeping (the two-site
+    \leanid{tensor_proportional} is its $m=2$ shadow) plus the $\kappa/\theta/\phi$
+    telescoping into the global unitary $U=\sum_u e^{i\phi_{u+q}}P_uU_{u+q}Q_{u+q}$.
+\end{itemize}
+These are the remaining obligations for \leanid{sectorGaugePhaseEquiv_succ_of_cyclicTransport}
+and \leanid{repeatedBlocks_of_blockedSectorGaugePhase}; each is a focused
+infrastructure development rather than a one-step discharge.
 
 \section{Scope restriction: independence without spanning}
 


### PR DESCRIPTION
## Summary

An adversarial proof-attempt (ultracode workflow, one worktree-isolated agent per remaining leaf) found that `not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces` (`MPS/Periodic/Overlap/SelfOverlap.lean`) was **underspecified — its conclusion is false as stated**.

The lemma carried only the bare cyclic-projection data (orthogonal `P_k` summing to `1`, the adjoint shift `𝓔_A^*(P_{k+1})=P_k`, blocked-letter commutation, the trace formula, and `P_u P_v = 0`) with **no periodicity/irreducibility hypothesis**. That data is consistent with a *reducible* `A = B ⊕ B` (for an irreducible period-`m` block `B`), whose distinct sectors **are** gauge-phase equivalent — so `¬ GaugePhaseEquiv` fails. The spectral non-repetition argument (`lem:bdcf`, arXiv:1708.00029 lines 404–423: `𝓔_A^m` has `1` as its only modulus-one eigenvalue with diagonal fixed points) genuinely requires `A` to be a periodic (irreducible) block — indeed the docstring already *assumed* it ("Since A is a periodic block…").

## Fix

Thread `hP : IsPeriodic m A` into the leaf. It is **already available at the unique call site** `sectorBlocks_not_gaugePhaseEquiv_of_ne`, where it was an unused `_hP`. The `sorry` now sits on a **true** statement (its faithful spectral proof remains future work). This is a signature correction — sorry count is unchanged.

Verified: `lake build TNLean.MPS.Periodic.Overlap.Dichotomy` succeeds; the only `sorry` warning in SelfOverlap is the (now correctly-hypothesized) target lemma.

## Also

Records in `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex` the precise missing infrastructure for the two open Case-3 leaves (also surfaced by the proof-attempts): the single-site off-diagonal decomposition `A^i = Σ_u P_u A^i P_{u+1}` (eq:Auprop) and single-site sector-overlap translation invariance — both absent from `IsCyclicSectorDecomp`, which exposes only blocked-letter data. Adding eq:Auprop is the key enabling step for both leaves.

Refs #81, #450, #619.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature and documentation correction for a still-unproved lemma; no runtime or security impact, and build behavior is unchanged aside from correct typing.
> 
> **Overview**
> Fixes an **underspecified** periodic overlap leaf: `not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces` was provably **false** from cyclic-projection data alone (e.g. reducible `A = B ⊕ B`), so the PR adds **`hP : IsPeriodic m A`** to match the intended spectral (Lemma bdcf) argument and threads it from the sole caller `sectorBlocks_not_gaugePhaseEquiv_of_ne` (previously unused `_hP`).
> 
> Docstrings in `SelfOverlap.lean` and `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex` now record why periodicity is load-bearing and list **missing Case-3 infrastructure** (single-site `A^i = Σ_u P_u A^i P_{u+1}`, sector-overlap translation invariance, corner unitaries / Ω contraction). The leaf remains a `sorry`; only the statement is corrected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f69ac58bb909f100e0c6d1cad7cd1efff84a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->