### PR TITLE
refactor(mpdo): conservative proof-golf simplifications in MPDO/RFP core

### DIFF
--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -421,7 +421,7 @@ theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
     (data : SimpleMPDOBlockedRFPData K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
       IsRFP_MPDO_via_fusion K := by
-  refine ⟨data.isGSNNCHWithZCL, structural_implies_rfp_blocked_of_data data,
+  exact ⟨data.isGSNNCHWithZCL, structural_implies_rfp_blocked_of_data data,
     data.isRFP_via_fusion⟩
 
 /-- Direct-argument form of Theorem 4.9 using only the hypotheses that enter the

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -62,9 +62,8 @@ def AgreesOutsideWindow (L : ℕ) {N : ℕ} (hLN : L ≤ N) (i : Fin N)
 acting as the given local matrix on the window and as the identity on the
 complement. -/
 noncomputable def embedLocalOperator (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
-    (B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) : ChainOperator d N := by
-  classical
-  exact Matrix.of fun σ τ =>
+    (B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) : ChainOperator d N :=
+  Matrix.of fun σ τ =>
     if AgreesOutsideWindow (d := d) L hLN i σ τ then
       B (MPSTensor.extractWindow L i σ) (MPSTensor.extractWindow L i τ)
     else 0
@@ -74,8 +73,7 @@ noncomputable def embedLocalOperator (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
     embedLocalOperator (d := d) L N hLN i B σ τ =
       if AgreesOutsideWindow (d := d) L hLN i σ τ then
         B (MPSTensor.extractWindow L i σ) (MPSTensor.extractWindow L i τ)
-      else 0 := by
-  classical
+      else 0 :=
   rfl
 
 /-- Chain-level commuting-form data for the simple-MPDO theorem.
@@ -113,8 +111,7 @@ noncomputable def bondAt (data : CommutingFormData d N) (i : Fin N) :
     data.bondAt i σ τ =
       if AgreesOutsideWindow (d := d) 2 data.hN i σ τ then
         data.bond (MPSTensor.extractWindow 2 i σ) (MPSTensor.extractWindow 2 i τ)
-      else 0 := by
-  classical
+      else 0 :=
   rfl
 
 theorem bondAt_comm (data : CommutingFormData d N) (i j : Fin N) :

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -186,14 +186,12 @@ theorem isGSNNCHAt (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N) :
 
 /-- The explicit `η`-local structure yields a GSNNCH witness on every finite
 chain. -/
-theorem isGSNNCH (data : EtaLocalStructureData M) : IsGSNNCH M := by
-  intro N hN
-  exact data.isGSNNCHAt N hN
+theorem isGSNNCH (data : EtaLocalStructureData M) : IsGSNNCH M :=
+  fun N hN => data.isGSNNCHAt N hN
 
 /-- The explicit `η`-local structure yields the global commuting-form property. -/
-theorem hasCommutingForm (data : EtaLocalStructureData M) : HasCommutingForm M := by
-  intro N hN
-  exact ⟨data.formAt N hN, data.formAt_realizes N hN⟩
+theorem hasCommutingForm (data : EtaLocalStructureData M) : HasCommutingForm M :=
+  fun N hN => ⟨data.formAt N hN, data.formAt_realizes N hN⟩
 
 /-- The explicit `η`-local structure, together with ZCL, gives the
 GSNNCH-with-ZCL case of the simple-MPDO equivalence.

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -112,7 +112,7 @@ theorem blockedTransferMap_idempotent (F : FusionIsometryData M n) :
   calc
     blockedTransferMap M n ∘ₗ blockedTransferMap M n
         = (F.S ∘ₗ F.T) ∘ₗ (F.S ∘ₗ F.T) := by rw [F.hST]
-    _ = F.S ∘ₗ (F.T ∘ₗ F.S) ∘ₗ F.T := by simp [LinearMap.comp_assoc]
+    _ = F.S ∘ₗ (F.T ∘ₗ F.S) ∘ₗ F.T := by simp only [LinearMap.comp_assoc]
     _ = F.S ∘ₗ LinearMap.id ∘ₗ F.T := by rw [F.hTS]
     _ = F.S ∘ₗ F.T := by
       simp only [LinearMap.id_comp]
@@ -135,8 +135,8 @@ noncomputable def ofBlockedTransferMapIdempotent
     apply Subtype.ext
     change blockedTransferMap M n (blockedTransferMap M n y) = blockedTransferMap M n y
     simpa only [LinearMap.comp_apply] using congrArg (fun f => f y) hE
-  hST := by
-    exact LinearMap.subtype_comp_codRestrict
+  hST :=
+    LinearMap.subtype_comp_codRestrict
       (blockedTransferMap M n)
       (blockedTransferMap M n).range
       (fun x => ⟨x, rfl⟩)

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -313,10 +313,8 @@ It is strictly weaker than the matrix-level positive semidefiniteness needed by
 stronger property for the sector trace matrix is the remaining MPDO-specific
 evidence. -/
 theorem traceMatrixRe_nonneg (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
-    0 ≤ data.traceMatrixRe k h := by
-  have htr : 0 ≤ Matrix.trace (data.eta k h) :=
-    (data.eta_pos k h).trace_nonneg
-  exact (Complex.le_def.mp htr).1
+    0 ≤ data.traceMatrixRe k h :=
+  (Complex.le_def.mp (data.eta_pos k h).trace_nonneg).1
 
 end ExplicitEtaOperators
 
@@ -367,8 +365,8 @@ theorem sal_zcl_implies_rank_one_T_of_posSemidef
     (hPSD : T.PosSemidef)
     (hTrace : Matrix.trace T = 1)
     (hZCL : Matrix.TracePowersConstant T) :
-    ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
-  exact sal_zcl_implies_rank_one_T T hPrimitive hTrace hZCL
+    ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 :=
+  sal_zcl_implies_rank_one_T T hPrimitive hTrace hZCL
     (Matrix.primitive_trace_powers_constant_implies_rank_one_of_posSemidef hPSD hTrace)
 
 end RankOneT

--- a/TNLean/MPS/RFP/Decorrelation.lean
+++ b/TNLean/MPS/RFP/Decorrelation.lean
@@ -234,13 +234,11 @@ theorem HasCommutingParentHam.mem_ground_iff {P_K : E →ₗ[ℂ] E}
   · intro hv
     constructor
     · have : h.P_AX (P_K v) = P_K v := by
-        change (h.P_AX ∘ₗ P_K) v = P_K v
-        rw [h.pAX_comp_pK]
-      rw [hv] at this; exact this
+        rw [← LinearMap.comp_apply, h.pAX_comp_pK]
+      rwa [hv] at this
     · have : h.P_XB (P_K v) = P_K v := by
-        change (h.P_XB ∘ₗ P_K) v = P_K v
-        rw [h.pXB_comp_pK]
-      rw [hv] at this; exact this
+        rw [← LinearMap.comp_apply, h.pXB_comp_pK]
+      rwa [hv] at this
   · rintro ⟨hAX, hXB⟩
     have : (h.P_AX ∘ₗ h.P_XB) v = v := by
       simp only [LinearMap.comp_apply]; rw [hXB, hAX]

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -167,10 +167,8 @@ private theorem exists_nonzero_of_leftCanonical [DecidableEq (Fin D)] [NeZero D]
   push Not at hA
   have hsum : ∑ i : Fin d, (A i)ᴴ * A i = 0 := by
     simp [hA]
-  have h1 : (1 : Mat) = 0 := by
-    rw [hLeft] at hsum
-    exact hsum
-  exact (one_ne_zero : (1 : Mat) ≠ 0) h1
+  rw [hLeft] at hsum
+  exact one_ne_zero hsum
 
 /-- Appendix B precursor without a separate nonzero side condition:
 for a left-canonical normal RFP tensor, the one-site Kraus span is already all of `M_D(ℂ)`. -/


### PR DESCRIPTION
## Summary

A code-simplifier pass over the MPDO/RFP core files. **Proof-body-only golf** — no statement, signature, docstring, `\lean`/`\leanok`/`\uses` tag, or behavior changes.

12 edits across 7 files:
- `rw […]; exact h` → `rwa […]`; `by exact <term>` → term-mode; `by intro …; exact …` → `fun …`
- drop redundant `classical` where a local `Classical.propDecidable` instance is already in scope (`CommutingForm`)
- inline a single-use `have`; `refine ⟨…⟩` (no holes) → `exact ⟨…⟩`; narrow an unrestricted `simp` to `simp only [...]`

Files: `BlockedRFPConstruction`, `CommutingForm`, `CommutingFormBridge`, `FusionIsometries`, `SimpleLocalStructure` (`MPS/MPDO/`), `Decorrelation`, `StructuralForm` (`MPS/RFP/`).

Several other core files (`Defs`, `VerticalCF`, `PureRecovery`, `AlgebraStructure`, …) were analyzed and left unchanged — already clean. (`AlgebraStructure` golf was dropped: it is heartbeat-sensitive and a `rw;exact`→`rwa` rewrite tripped a `whnf` timeout.)

## Verification

- `lake build` of all 7 touched modules: green, no warnings.
- Quality-only; no proofs weakened, no sorries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Edits are limited to proof bodies in already-built modules; no API, definitions, or proof obligations were weakened.
> 
> **Overview**
> This PR **shortens proof scripts** in seven MPDO/RFP Lean modules. There are **no changes** to theorem statements, definitions, or intended mathematics—only how proofs are written.
> 
> **Commuting form:** `embedLocalOperator` and related `@[simp]` lemmas drop redundant `by classical` / `rfl` wrappers because `Classical.propDecidable` is already a local instance in that file.
> 
> **Bridges and locals:** `isGSNNCH` and `hasCommutingForm` in `CommutingFormBridge` become direct term-mode proofs (`fun N hN => …`) instead of `by intro; exact`. Rank-one and trace-nonnegativity steps in `SimpleLocalStructure` inline small `have` blocks into single expressions.
> 
> **Fusion / blocked RFP / decorrelation / structural:** `simple_mpdo_rfp_chain_of_data` uses `exact ⟨…⟩` where `refine` had no goals left; fusion idempotence uses `simp only [LinearMap.comp_assoc]`; ground-space lemmas use `rwa` with `comp_apply` instead of manual `change`/`rw`; left-canonical nonzero existence collapses the `1 = 0` contradiction to `exact one_ne_zero hsum`.
> 
> Overall this is **maintainability and style** in the simple-MPDO and RFP proof core, aligned with the existing “proof golf only” scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b66fde15c215096958f9ac890330ef3b24b3d630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->