### PR TITLE
doc(faithfulness): clarify two source-labeling items from the systematic audit

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -568,7 +568,15 @@ theorem ft_sector_bnt_equal_global_gaugePos
   exact ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, W.weight_eq, X, hXdef,
     hGauge⟩
 
-/-- Reformulation for the all-length `SameMPV₂` form. -/
+/-- Reformulation for the all-length `SameMPV₂` form (the CPSV16 Corollary II.2
+convention).
+
+The hypothesis is the source's all-length MPV equality, but the proof consumes only its
+positive-length restriction (`hEqual.toSameMPV₂Pos`): the empty-word (`N = 0`) component
+of `SameMPV₂` carries only the bond-dimension count, which the BNT construction already
+fixes, so it never enters the gauge-matching argument. The all-length form is kept in the
+signature to match the source statement; see
+`docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`. -/
 theorem ft_sector_bnt_equal_global_gauge
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
@@ -27,7 +27,8 @@ lemma twistedTensor_eq_rotatePhysical
     (A : MPSTensor d D) (U : G →* Matrix (Fin d) (Fin d) ℂ) (g : G) :
     twistedTensor A U g = rotatePhysical (U g) A := rfl
 
-/-- **Corollary 4.1 (arXiv:1708.00029, Section 4.2): physical symmetry → virtual `Z`-gauge.**
+/-- **Group-representation generalization of the Symmetries corollary
+(arXiv:1708.00029, §"Characterization of symmetries").**
 
 Let `A` be in irreducible form II and let `U : G →* Mat_d ℂ` be a representation of a
 group `G` on the physical leg, acting unitarily. If `A` is on-site symmetric under `U`
@@ -39,8 +40,19 @@ In paper notation, for each `g` there exist matrices `Z_g, Y_g` with `Z_g^{m_g} 
 `[A^i, Z_g] = 0`, and
 `Z_g · A^i = Y_g · (twistedTensor A U g)^i · Y_g⁻¹`.
 
-This generalises the single-`u` corollary obtained via
-`zGaugeEquiv_of_isIrreducibleForm_sameMPV_rotatePhysical` to a full group of symmetries.
+**Faithfulness note (generalization + restated conclusion).** The source corollary is
+stated for a *single* local unitary `u` and concludes with a **diagonal** unitary `Z`
+satisfying the explicit relation `∑_i u^{i',i} A^i = Z U A^{i'} U†` (eq:symm). This
+statement (i) *generalizes* the input to an arbitrary group representation `U : G →* …`
+(the single-`u` case is the cyclic-subgroup instance), and (ii) *restates the conclusion*
+in `Z`-gauge-equivalence form with `Z_g` only required periodic (`Z_g^{m_g}=1`) and
+commuting with `A^i`, not literally diagonal, and with the relation written via the gauge
+`Y_g` rather than verbatim eq:symm. It is therefore a faithful generalization, not the
+source corollary verbatim; the diagonal-`Z` normalization and the exact eq:symm form are
+recoverable in the irreducible-form basis but are not part of this statement.
+
+The single-`u` specialization is obtained via
+`zGaugeEquiv_of_isIrreducibleForm_sameMPV_rotatePhysical`.
 The projective-representation upgrade (joint factor system on the family `(Y_g)_{g∈G}`)
 is left to subsequent SPT classification work; see
 `MPS/Symmetry/VirtualRepresentation.lean` for the analogous injective construction.


### PR DESCRIPTION
Follow-up to the systematic faithfulness audit (#1565). The audit (multi-agent, adversarially verified) found the un-audited layers **largely faithful** — zero confirmed findings in Channel/Spectral/QPF, CanonicalForm/Structure/Irreducible, and foundational MPS; Wielandt main theorems faithful; all `axiom`s documented+intentional. Two minor labeling/docstring items remained; this PR fixes both (docstring-only, no proof/signature changes):

1. **`cor_4_1_physical_symmetry_zgauge`** — relabel from "Corollary 4.1" to a **group-representation generalization** of the source 'Symmetries' corollary, with a faithfulness note: the source takes a single `u` → **diagonal** `Z` with the explicit `eq:symm` relation, whereas the Lean generalizes the input to a group rep and restates the conclusion (`Z_g^{m_g}=1` commuting with `A^i`, in `Z`-gauge form).
2. **`ft_sector_bnt_equal_global_gauge`** — document that the all-length `SameMPV₂` hypothesis (the source convention) is consumed only via its positive-length restriction (N=0 = BNT-fixed bond dimension).

Refs #1565.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only updates to theorem docstrings; no logic, APIs, or proof scripts change.
> 
> **Overview**
> This PR is **documentation-only** (no proof or signature changes), closing two faithfulness-audit labeling gaps from #1565.
> 
> In **`Corollary41.lean`**, the docstring for `cor_4_1_physical_symmetry_zgauge` is reframed from a literal “Corollary 4.1” label to a **group-representation generalization** of the arXiv symmetries corollary, with an explicit **faithfulness note**: the paper uses a single local unitary `u` and a **diagonal** `Z` with the verbatim `eq:symm` relation, while Lean takes a group rep `U` and states **periodic** `Z_g` in `Z`-gauge form via `Y_g`. The single-`u` case is pointed to `zGaugeEquiv_of_isIrreducibleForm_sameMPV_rotatePhysical`.
> 
> In **`Fundamental.lean`**, the docstring for `ft_sector_bnt_equal_global_gauge` now records that the **all-length** `SameMPV₂` hypothesis (CPSV16 Corollary II.2 convention) is proved only via **`hEqual.toSameMPV₂Pos`**, because the `N = 0` tail is bond-dimension data already fixed by BNT and does not enter gauge matching, with a pointer to `docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e7a94701fe920c57d3531c928878640e4830abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->