### PR TITLE
feat(canonical): off-diagonal decomposition of a periodic block (eq:Auprop), unblocking the Case-3 leaves

### DIFF
--- a/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
@@ -14,10 +14,14 @@ projections fixed by the adjoint transfer map.
 
 * `commutes_letters_of_adjoint_fixed_projection`
 * `exists_blockDecomp_of_adjoint_fixed_projections`
+* `offDiag_shift_of_adjoint_cyclic_shift`
+* `eq_sum_offDiag_of_adjoint_cyclic_shift`
+* `offDiag_shift_evalWord_of_adjoint_cyclic_shift`
 
 ## References
 
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix A]
+* [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1708.00029, eq:Aoffdiag/eq:Auprop]
 * [Wolf, *Quantum Channels & Operations*, Chapter 6]
 -/
 
@@ -88,5 +92,111 @@ theorem exists_blockDecomp_of_adjoint_fixed_projections
   exact exists_blockDecomp_of_commuting_projections A P hPproj hPsum hLeft hComm
 
 end FixedAdjointProjection
+
+section CyclicShiftOffDiagonal
+
+/-!
+## Off-diagonal grading from the adjoint cyclic shift
+
+For a family of orthogonal projections `P : Fin m → M_D(ℂ)` summing to `1` and
+shifted by the adjoint transfer map, `𝓔^*(P_{k+1}) = P_k`, the Kraus operators
+`A_i` carry index `k` to index `k+1`:
+`P_{k+1} · A_i = A_i · P_k`.  Summing over the orthogonal grading then gives the
+off-diagonal reconstruction `A_i = ∑_u P_{u+1} · A_i · P_u`.  This is the
+single-site off-diagonal decomposition of a periodic block in arXiv:1708.00029,
+eq:Aoffdiag/eq:Auprop: the compressed-to-global bridge that the cyclic transport
+step contracts.
+-/
+
+variable {m : ℕ}
+
+/-- **Single-site off-diagonal grading from the adjoint cyclic shift.**
+
+If the orthogonal projections `P` are shifted by the adjoint transfer map,
+`𝓔^*(P_{k+1}) = P_k`, then each Kraus operator carries index `k` to `k+1`:
+`P_{k+1} · A_i = A_i · P_k`.  This is the single-site analogue of the
+fixed-projection commutation `commutes_letters_of_adjoint_fixed_projection`;
+see arXiv:1708.00029, eq:Auprop. -/
+theorem offDiag_shift_of_adjoint_cyclic_shift [NeZero m]
+    (A : MPSTensor d D)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    {P : Fin m → MatrixAlg D}
+    (hPproj : ∀ k, IsOrthogonalProjection (P k))
+    (hShift : ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (k : Fin m) (i : Fin d) :
+    P (k + 1) * A i = A i * P k := by
+  let K : Fin d → MatrixAlg D := fun i => (A i)ᴴ
+  have hTPK : IsTPKraus (d := d) (D := D) A := by simpa [IsTPKraus] using hLeft
+  have hUnitalK : IsUnitalKraus (d := d) (D := D) K :=
+    KadisonSchwarz.isUnitalKraus_conjTranspose (d := d) (D := D) (K := A) hTPK
+  -- The adjoint transfer map agrees with the Kraus map of `K = Aᴴ`.
+  have hKshift : krausMap K (P (k + 1)) = P k := by
+    simpa [K, KadisonSchwarz.krausMap, MPSTensor.transferMap_apply] using hShift k
+  -- `P (k + 1)` is fixed by `Xᴴ * X = X`, and `𝓔^*(P (k + 1)) = P k` is itself a
+  -- projection, so the Kadison–Schwarz gap vanishes at `P (k + 1)`.
+  have hEq : krausMap K ((P (k + 1))ᴴ * P (k + 1)) =
+      (krausMap K (P (k + 1)))ᴴ * krausMap K (P (k + 1)) := by
+    calc
+      krausMap K ((P (k + 1))ᴴ * P (k + 1)) = krausMap K (P (k + 1)) := by
+        simp only [(hPproj (k + 1)).1.eq, (hPproj (k + 1)).2]
+      _ = P k := hKshift
+      _ = (P k)ᴴ * P k := by
+        simp only [(hPproj k).1.eq, (hPproj k).2]
+      _ = (krausMap K (P (k + 1)))ᴴ * krausMap K (P (k + 1)) := by
+        simp only [hKshift]
+  have hComm :=
+    KadisonSchwarz.kraus_commute_of_ks_equality (K := K) hUnitalK (P (k + 1)) hEq i
+  -- `kraus_commute_of_ks_equality` yields `P (k+1) * (Aᵢ)ᴴ ᴴ = (Aᵢ)ᴴ ᴴ * 𝓔^*(P (k+1))`.
+  simpa [K, hKshift] using hComm
+
+/-- **Off-diagonal reconstruction** `A_i = ∑_u P_{u+1} · A_i · P_u`.
+
+With the projections summing to `1` and shifted by the adjoint transfer map, the
+identity is graded into its single-site off-diagonal pieces.  See
+arXiv:1708.00029, eq:Aoffdiag. -/
+theorem eq_sum_offDiag_of_adjoint_cyclic_shift [NeZero m]
+    (A : MPSTensor d D)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    {P : Fin m → MatrixAlg D}
+    (hPproj : ∀ k, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hShift : ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (i : Fin d) :
+    A i = ∑ u : Fin m, P (u + 1) * A i * P u := by
+  have hShiftLetter := offDiag_shift_of_adjoint_cyclic_shift A hLeft hPproj hShift
+  calc
+    A i = A i * ∑ u : Fin m, P u := by rw [hPsum, Matrix.mul_one]
+    _ = ∑ u : Fin m, A i * P u := by rw [Finset.mul_sum]
+    -- Each summand carries index `u` to `u + 1` via the cyclic shift, and the
+    -- right projector is recovered by idempotence: `P_{u+1}·Aᵢ·P_u = Aᵢ·P_u`.
+    _ = ∑ u : Fin m, P (u + 1) * A i * P u := by
+        refine Finset.sum_congr rfl fun u _ => ?_
+        rw [hShiftLetter u i, Matrix.mul_assoc, (hPproj u).2]
+
+/-- **Telescoped off-diagonal shift across a word.**
+
+The single-site grading `offDiag_shift_of_adjoint_cyclic_shift` accumulates one
+step per letter: evaluating a word of length `ℓ` carries index `k` to
+`k + ℓ·1` in `Fin m`.  This is the form contracted by the cyclic-transport step
+of arXiv:1708.00029 (eq:Aoffdiag iterated across a block): for a length-`m`
+word `ℓ·1 = 0`, recovering the same-index blocked commutation
+`commutes_letters_of_adjoint_fixed_projection` for `blockTensor A m`. -/
+theorem offDiag_shift_evalWord_of_adjoint_cyclic_shift [NeZero m]
+    (A : MPSTensor d D)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    {P : Fin m → MatrixAlg D}
+    (hPproj : ∀ k, IsOrthogonalProjection (P k))
+    (hShift : ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (k : Fin m) (w : List (Fin d)) :
+    P (k + w.length • (1 : Fin m)) * evalWord A w = evalWord A w * P k := by
+  induction w generalizing k with
+  | nil => simp
+  | cons a w ih =>
+    have hShiftLetter := offDiag_shift_of_adjoint_cyclic_shift A hLeft hPproj hShift
+    rw [evalWord_cons, List.length_cons, add_smul, one_smul, ← add_assoc,
+      ← Matrix.mul_assoc, hShiftLetter (k + w.length • (1 : Fin m)) a,
+      Matrix.mul_assoc, ih, ← Matrix.mul_assoc]
+
+end CyclicShiftOffDiagonal
 
 end MPSTensor

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -100,6 +100,38 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
     (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
       (φ k Xᴴ).1 = ((φ k X).1)ᴴ)
 
+/-- The single-site off-diagonal grading carried by a cyclic sector decomposition:
+each unblocked Kraus operator carries the cyclic projection index `k` to `k + 1`,
+`P_{k+1} · A^i = A^i · P_k`.  This is the single-site shift of arXiv:1708.00029,
+eq:Auprop, obtained from the cyclic relation `𝓔^*(P_{k+1}) = P_k` stored in
+`IsCyclicSectorDecomp`. -/
+theorem IsCyclicSectorDecomp.offDiag_shift [NeZero D] [NeZero m]
+    {A : MPSTensor d D} (hP : IsPeriodic m A) {dim : Fin m → ℕ}
+    {blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)}
+    (hCyclic : IsCyclicSectorDecomp A blocks)
+    (k : Fin m) (i : Fin d) :
+    ∃ P : Fin m → Matrix (Fin D) (Fin D) ℂ,
+      (∀ l, IsOrthogonalProjection (P l)) ∧ (∑ l : Fin m, P l = 1) ∧
+        P (k + 1) * A i = A i * P k := by
+  obtain ⟨P, _φ, hPproj, hPsum, hShift, _⟩ := hCyclic
+  exact ⟨P, hPproj, hPsum,
+    offDiag_shift_of_adjoint_cyclic_shift A hP.leftCanonical hPproj hShift k i⟩
+
+/-- The off-diagonal reconstruction `A^i = ∑_u P_{u+1} · A^i · P_u` carried by a
+cyclic sector decomposition (arXiv:1708.00029, eq:Aoffdiag), graded by the cyclic
+projections stored in `IsCyclicSectorDecomp`. -/
+theorem IsCyclicSectorDecomp.eq_sum_offDiag [NeZero D] [NeZero m]
+    {A : MPSTensor d D} (hP : IsPeriodic m A) {dim : Fin m → ℕ}
+    {blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)}
+    (hCyclic : IsCyclicSectorDecomp A blocks)
+    (i : Fin d) :
+    ∃ P : Fin m → Matrix (Fin D) (Fin D) ℂ,
+      (∀ l, IsOrthogonalProjection (P l)) ∧ (∑ l : Fin m, P l = 1) ∧
+        A i = ∑ u : Fin m, P (u + 1) * A i * P u := by
+  obtain ⟨P, _φ, hPproj, hPsum, hShift, _⟩ := hCyclic
+  exact ⟨P, hPproj, hPsum,
+    eq_sum_offDiag_of_adjoint_cyclic_shift A hP.leftCanonical hPproj hPsum hShift i⟩
+
 /-- A periodic tensor of period `m`, after blocking by `m`, admits a cyclic
 sector decomposition.
 


### PR DESCRIPTION
## Summary

Adds the **single-site off-diagonal decomposition** of a periodic-block tensor (arXiv:1708.00029 eq:Aoffdiag / eq:Auprop) — the compressed↔global bridge the two open periodic-FT Case-3 leaves need. The design pass found this is **provable from existing Kadison–Schwarz multiplicative-domain machinery** (no new spectral-projection theory):

- **`offDiag_shift_of_adjoint_cyclic_shift`** (`CyclicSectors/FixedAdjoint.lean`): `P(k+1)·A i = A i·P k`, from the KS gap vanishing at `P(k+1)` (idempotence + `𝓔*(P(k+1))=P k` being a projection) via `kraus_commute_of_ks_equality`.
- **`eq_sum_offDiag_of_adjoint_cyclic_shift`**: `A i = ∑_u P(u+1)·A i·P u` (grading by `∑P=1` + the shift + idempotence).
- **`offDiag_shift_evalWord_of_adjoint_cyclic_shift`**: the telescoped form `P(k + |w|•1)·evalWord A w = evalWord A w·P k` — the object the cyclic-transport staircase contracts.
- **`IsCyclicSectorDecomp.offDiag_shift` / `.eq_sum_offDiag`** (`SelfOverlap.lean`): the same identities on the bundled structure.

## Faithfulness note

The literal "blocked-tensor +1 shift" `P(k+1)·(blockTensor A m) i = (blockTensor A m) i·P k` is **false** (the blocked adjoint map *fixes* each period-`m` projector, so a length-`m` block shifts the index by `m ≡ 0`, giving same-index commutation — already `commutes_letters_of_adjoint_fixed_projection`). It is **not** added; the honest object is the telescoping lemma above, which collapses to that same-index commutation for length-`m` words.

## Verification

`lake build` succeeds (whole tree + `MPS.Periodic.Overlap.Dichotomy` sentinel). `#print axioms` on all five new declarations reports only `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no custom axioms**.

This unblocks the two Case-3 leaves: `sectorGaugePhaseEquiv_succ_of_cyclicTransport` contracts the telescoped form; `repeatedBlocks_of_blockedSectorGaugePhase` uses the off-diagonal reconstruction.

Refs #81, #450, #619.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formal additions with no runtime or auth impact; proofs reuse existing Kadison–Schwarz infrastructure.
> 
> **Overview**
> Adds **single-site off-diagonal grading** for periodic MPS tensors when cyclic projections satisfy the adjoint shift `𝓔^*(P_{k+1}) = P_k` (arXiv:1708.00029 eq:Auprop / eq:Aoffdiag).
> 
> In `FixedAdjoint.lean`, a new `CyclicShiftOffDiagonal` section proves **`offDiag_shift_of_adjoint_cyclic_shift`** (`P_{k+1}·A_i = A_i·P_k`) via Kadison–Schwarz `kraus_commute_of_ks_equality` (same pattern as fixed-projection commutation), then **`eq_sum_offDiag_of_adjoint_cyclic_shift`** (`A_i = ∑_u P_{u+1}·A_i·P_u`) and **`offDiag_shift_evalWord_of_adjoint_cyclic_shift`** (telescoped shift along `evalWord`).
> 
> In `SelfOverlap.lean`, **`IsCyclicSectorDecomp.offDiag_shift`** and **`.eq_sum_offDiag`** expose the same identities from bundled cyclic sector data (using periodic left-canonicality).
> 
> This is the compressed↔global bridge intended for periodic overlap **Case 3** (cyclic transport / repeated blocks), not a blocked-letter `+1` shift (which would collapse mod `m`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b42e50e0bd2fd7d31e13e429f05f023b01e1b44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->