### PR TITLE
doc(mpdo): purification-RFP blueprint def is the weaker CF-free notion

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -252,10 +252,13 @@ legs cyclically and taking the resulting trace.
     \leanok
     \uses{def:lpdo, def:purifying_mps_tensor, def:is_rfp}
     An MPO tensor $M$ has a \emph{purification RFP} if it admits an LPDO
-    witness whose purifying MPS tensor is a pure-state renormalization
-    fixed point.
-    This is \cite[definition of purification RFP, lines~756--759]
-    {Cirac2016MPDO_arXiv}.
+    witness whose purifying MPS tensor is a renormalization fixed point in the
+    transfer-map idempotence sense of Definition~\ref{def:is_rfp}.
+    This is weaker than the purification RFP of
+    \cite[lines~756--759]{Cirac2016MPDO_arXiv}, whose pure-state renormalization
+    fixed point is the canonical-form condition $AA = A$; the two notions
+    coincide only in canonical form. The strictness is witnessed by
+    Remark~\ref{rem:prfp_not_implies_zcl}.
 \end{definition}
 
 \begin{remark}[PRFP does not imply MPO ZCL]\label{rem:prfp_not_implies_zcl}


### PR DESCRIPTION
Clarifies that `def:is_prfp` describes the Lean `MPOTensor.IsPRFP` (canonical-form-free transfer-map idempotence), which is **strictly weaker** than the source purification RFP (canonical-form $AA=A$). The prose previously claimed identity with the source definition. The Lean def exists and is honestly weaker, so its statement-level `\leanok` stays; the source-identity claim is removed and the strictness is pointed at `rem:prfp_not_implies_zcl`.

The single verified blueprint fix from the vacuous-proof audit (#2385); the other flagged entries were over-flagged (honest conditionals/definitions, valid `\leanok`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification in the blueprint TeX; no runtime or proof logic changes in the diff.
> 
> **Overview**
> **Definition `def:is_prfp`** in `ch02b_mpdo.tex` is updated so the blueprint matches Lean **`MPOTensor.IsPRFP`**: the purifying MPS tensor must be an RFP in the **transfer-map idempotence** sense (`Definition~\ref{def:is_rfp}`), not the paper’s **pure-state** purification RFP with canonical form **$AA=A$**.
> 
> The prose no longer claims equivalence with Cirac et al.; it states the Lean notion is **strictly weaker** than the source definition (they agree only in canonical form) and points to **`rem:prfp_not_implies_zcl`** for a witness. **`\leanok`** on the definition is unchanged because the formalization was already the weaker predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 704fdba574792e002cdb62ada94b10ae34295364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->