### PR TITLE
feat(mpdo): state Definition 4.1 RFP via trace-preserving CP maps (IsRFP_via_TS)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -265,6 +265,7 @@ import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.RFP
+import TNLean.MPS.MPDO.RFPViaTS
 import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.AlgebraStructure

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -284,8 +284,8 @@ trace-preserving CP maps T and S on the physical indices). Idempotence coincides
 with Definition 4.1 only in the pure (MPS) case. For general MPDO, Definition 4.1
 is strictly stronger:
 it implies idempotence/ZCL (Theorem 4.9, i ⟹ ii, gives ZCL and SAL), but ZCL alone
-does not imply it (line 786). A source-faithful `IsRFP_via_TS` and the theorem
-deriving idempotence from it are future work (#826, #237). -/
+does not imply it (line 786). Definition 4.1 is stated as `MPOTensor.IsRFPViaTS`;
+the theorem deriving idempotence from it is future work (#826, #237). -/
 def IsRFP (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M
 

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -14,9 +14,9 @@ equal here.
 Note that `IsRFP` is the idempotence / zero-correlation-length condition, not the
 paper's renormalization-fixed-point Definition 4.1 (paper label RFPMixedTS, the
 existence of two trace-preserving CP maps), which is an a priori different notion
-for general MPDO; see the faithfulness note on `MPOTensor.IsRFP`. A source-faithful
-`IsRFP_via_TS` and the theorem deriving idempotence from it are future work
-(#826, #237).
+for general MPDO; see the faithfulness note on `MPOTensor.IsRFP`. Definition 4.1
+is stated as `MPOTensor.IsRFPViaTS`; the theorem deriving idempotence from it is
+future work (#826, #237).
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -50,7 +50,6 @@ the predicate.
 -/
 
 open scoped Matrix BigOperators
-open Matrix
 
 /-- A **trace-preserving completely positive map** in Kraus form
 `S(X) = ∑ᵢ Aᵢ X Aᵢ†` with `∑ᵢ Aᵢ† Aᵢ = I`; rectangular Kraus operators

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.Defs
+
+/-!
+# MPDO renormalization fixed point via trace-preserving CP maps (Definition 4.1)
+
+This file states the source-faithful renormalization-fixed-point notion for
+matrix product density operators, following
+arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete), Definition 4.1
+(paper label `RFPMixedTS`, line 657, figures `MPDO_XM`, `MPDO_XMM`,
+`MPDO_TandS`).
+
+A tensor `M` in canonical form generating MPDOs is a renormalization fixed point
+when there exist two trace-preserving completely positive maps `T` and `S` on the
+physical indices intertwining the one-site and two-site physical operators
+obtained by contracting an arbitrary virtual operator into the tensor ring:
+
+* `S[M₂(X)] = M₁(X)`  (paper label `eq:Smap`);
+* `T[M₁(X)] = M₂(X)`  (paper label `eq:Tmap`),
+
+for all virtual operators `X`. Here, with the physical legs left open,
+
+* `(M₁ X) i j = tr(M^{ij} X)` is the one-site physical operator (figure
+  `MPDO_XM`), and
+* `(M₂ X) (i₁,i₂) (j₁,j₂) = tr(M^{i₁j₁} M^{i₂j₂} X)` is the two-site physical
+  operator (figure `MPDO_XMM`).
+
+## Main definitions
+
+* `IsKrausCPTP`: a trace-preserving completely positive map in rectangular Kraus
+  form.
+* `MPOTensor.physClose1`, `MPOTensor.physClose2`: the one-site and two-site
+  physical operators as linear maps in the virtual operator `X`.
+* `MPOTensor.IsRFP_via_TS`: Definition 4.1, the tp-CP-map renormalization
+  fixed point.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Definition 4.1
+  (line 657)
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+/-- A **trace-preserving completely positive map** in Kraus form
+`S(X) = ∑ᵢ Aᵢ X Aᵢ†` with `∑ᵢ Aᵢ† Aᵢ = I`; rectangular Kraus operators
+`Aᵢ : β × α` allow different in/out dimensions. The Kraus form is automatically
+completely positive, and the resolution-of-identity condition is exactly trace
+preservation. arXiv:1606.00608 Definition 4.1 uses tp-CP maps on the physical
+indices. -/
+def IsKrausCPTP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) : Prop :=
+  ∃ (ι : Type) (_ : Fintype ι) (A : ι → Matrix β α ℂ),
+    (∀ X, S X = ∑ i, A i * X * (A i)ᴴ) ∧ (∑ i, (A i)ᴴ * A i = (1 : Matrix α α ℂ))
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-! ### The one-site physical operator -/
+
+/-- The **one-site physical operator** as a linear map in the virtual operator
+`X`: contract `X : D × D` into a single copy of the tensor with the physical legs
+open, giving `(physClose1 M X) i j = tr(M^{ij} X)` (figure `MPDO_XM` of
+arXiv:1606.00608). -/
+noncomputable def physClose1 (M : MPOTensor d D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ where
+  toFun X := Matrix.of fun i j => Matrix.trace (M i j * X)
+  map_add' X Y := by
+    ext i j
+    simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c X := by
+    ext i j
+    simp [Matrix.trace_smul]
+
+@[simp] lemma physClose1_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
+    (i j : Fin d) : physClose1 M X i j = Matrix.trace (M i j * X) := rfl
+
+/-! ### The two-site physical operator -/
+
+/-- The **two-site physical operator** as a linear map in the virtual operator
+`X`: contract `X : D × D` into two copies of the tensor with all four physical
+legs open, giving `(physClose2 M X) (i₁,i₂) (j₁,j₂) = tr(M^{i₁j₁} M^{i₂j₂} X)`
+(figure `MPDO_XMM` of arXiv:1606.00608). -/
+noncomputable def physClose2 (M : MPOTensor d D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ where
+  toFun X := Matrix.of fun i j => Matrix.trace (M i.1 j.1 * M i.2 j.2 * X)
+  map_add' X Y := by
+    ext i j
+    simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c X := by
+    ext i j
+    simp [Matrix.trace_smul]
+
+@[simp] lemma physClose2_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
+    (i j : Fin d × Fin d) :
+    physClose2 M X i j = Matrix.trace (M i.1 j.1 * M i.2 j.2 * X) := rfl
+
+/-! ### MPDO renormalization fixed point (Definition 4.1) -/
+
+/-- `IsRFP_via_TS M` is the source's MPDO **renormalization fixed point** of
+arXiv:1606.00608 Definition 4.1 (paper label `RFPMixedTS`, line 657): there exist
+two trace-preserving completely positive maps `S` and `T` on the physical indices
+intertwining the one-site and two-site physical operators, namely
+
+* `S[M₂(X)] = M₁(X)` for all `X`  (paper label `eq:Smap`), and
+* `T[M₁(X)] = M₂(X)` for all `X`  (paper label `eq:Tmap`).
+
+This is the source's tp-CP-map renormalization fixed point. It is *distinct* from
+`MPOTensor.IsRFP`, the transfer-map idempotence (zero-correlation-length)
+condition: Definition 4.1 is strictly stronger for general MPDO. The implication
+`IsRFP_via_TS M → IsRFP M` (Theorem 4.9, direction i ⟹ ii) is deferred future
+work (#2382, #826). -/
+def IsRFP_via_TS (M : MPOTensor d D) : Prop :=
+  ∃ (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ),
+    IsKrausCPTP S ∧ IsKrausCPTP T ∧
+    (∀ X, S (physClose2 M X) = physClose1 M X) ∧
+    (∀ X, T (physClose1 M X) = physClose2 M X)
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -13,10 +13,11 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete), Definition 4.1
 (paper label `RFPMixedTS`, line 657, figures `MPDO_XM`, `MPDO_XMM`,
 `MPDO_TandS`).
 
-A tensor `M` in canonical form generating MPDOs is a renormalization fixed point
-when there exist two trace-preserving completely positive maps `T` and `S` on the
-physical indices intertwining the one-site and two-site physical operators
-obtained by contracting an arbitrary virtual operator into the tensor ring:
+In the paper, a tensor `M` in canonical form generating MPDOs is a renormalization
+fixed point when there exist two trace-preserving completely positive maps `T` and
+`S` on the physical indices intertwining the one-site and two-site physical
+operators obtained by contracting an arbitrary virtual operator into the tensor
+ring:
 
 * `S[M₂(X)] = M₁(X)`  (paper label `eq:Smap`);
 * `T[M₁(X)] = M₂(X)`  (paper label `eq:Tmap`),
@@ -28,13 +29,18 @@ for all virtual operators `X`. Here, with the physical legs left open,
 * `(M₂ X) (i₁,i₂) (j₁,j₂) = tr(M^{i₁j₁} M^{i₂j₂} X)` is the two-site physical
   operator (figure `MPDO_XMM`).
 
+Following the codebase convention (as for `MPOTensor.IsRFP` and `MPOTensor.IsZCL`),
+`IsRFPViaTS` is stated on a bare `MPOTensor`; the source's standing hypotheses
+(canonical form, generating an MPDO) are carried at theorem level rather than in
+the predicate.
+
 ## Main definitions
 
 * `IsKrausCPTP`: a trace-preserving completely positive map in rectangular Kraus
   form.
 * `MPOTensor.physClose1`, `MPOTensor.physClose2`: the one-site and two-site
   physical operators as linear maps in the virtual operator `X`.
-* `MPOTensor.IsRFP_via_TS`: Definition 4.1, the tp-CP-map renormalization
+* `MPOTensor.IsRFPViaTS`: Definition 4.1, the tp-CP-map renormalization
   fixed point.
 
 ## References
@@ -102,7 +108,7 @@ noncomputable def physClose2 (M : MPOTensor d D) :
 
 /-! ### MPDO renormalization fixed point (Definition 4.1) -/
 
-/-- `IsRFP_via_TS M` is the source's MPDO **renormalization fixed point** of
+/-- `IsRFPViaTS M` is the source's MPDO **renormalization fixed point** of
 arXiv:1606.00608 Definition 4.1 (paper label `RFPMixedTS`, line 657): there exist
 two trace-preserving completely positive maps `S` and `T` on the physical indices
 intertwining the one-site and two-site physical operators, namely
@@ -113,9 +119,9 @@ intertwining the one-site and two-site physical operators, namely
 This is the source's tp-CP-map renormalization fixed point. It is *distinct* from
 `MPOTensor.IsRFP`, the transfer-map idempotence (zero-correlation-length)
 condition: Definition 4.1 is strictly stronger for general MPDO. The implication
-`IsRFP_via_TS M → IsRFP M` (Theorem 4.9, direction i ⟹ ii) is deferred future
+`IsRFPViaTS M → IsRFP M` (Theorem 4.9, direction i ⟹ ii) is deferred future
 work (#2382, #826). -/
-def IsRFP_via_TS (M : MPOTensor d D) : Prop :=
+def IsRFPViaTS (M : MPOTensor d D) : Prop :=
   ∃ (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
     (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ),
     IsKrausCPTP S ∧ IsKrausCPTP T ∧

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -60,7 +60,7 @@ preservation. arXiv:1606.00608 Definition 4.1 uses tp-CP maps on the physical
 indices. -/
 def IsKrausCPTP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
     (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) : Prop :=
-  ∃ (ι : Type) (_ : Fintype ι) (A : ι → Matrix β α ℂ),
+  ∃ (r : ℕ) (A : Fin r → Matrix β α ℂ),
     (∀ X, S X = ∑ i, A i * X * (A i)ᴴ) ∧ (∑ i, (A i)ᴴ * A i = (1 : Matrix α α ℂ))
 
 namespace MPOTensor

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -292,9 +292,25 @@ legs cyclically and taking the resulting trace.
     \]
 \end{definition}
 
-% This is the Lean predicate `MPOTensor.IsRFP`, not the paper's Definition 4.1
-% (`RFPMixedTS`), which is a distinct MPDO renormalization-fixed-point condition
-% tracked in issues #826 and #237.
+% The definition above is transfer-map idempotence, distinct from the paper's
+% Definition 4.1 (`RFPMixedTS`); the latter is stated below as def:is_rfp_via_ts.
+
+\begin{definition}[Renormalization fixed point via trace-preserving maps]
+    \label{def:is_rfp_via_ts}
+    \lean{MPOTensor.IsRFPViaTS}
+    \leanok
+    \uses{def:mpo_tensor}
+    An MPO tensor $M$ is a \emph{renormalization fixed point} if there exist two
+    trace-preserving completely positive maps $\mathcal{S}, \mathcal{T}$ on the
+    physical indices such that $\mathcal{S}[M_2(X)] = M_1(X)$ and
+    $\mathcal{T}[M_1(X)] = M_2(X)$ for every virtual operator $X$, where
+    $M_1(X)_{ij} = \tr(M^{ij} X)$ and
+    $M_2(X)_{(i_1 i_2)(j_1 j_2)} = \tr(M^{i_1 j_1} M^{i_2 j_2} X)$ are the one-
+    and two-site physical operators obtained by closing one or two tensors with
+    $X$. This condition is strictly stronger than transfer-map idempotence for
+    general mixed states, and coincides with it for pure states.
+    This is \cite[Definition~4.1, line~657]{Cirac2016MPDO_arXiv}.
+\end{definition}
 
 \begin{theorem}[Transfer-map idempotence iff MPO ZCL]\label{thm:is_rfp_iff_is_zcl}
     \lean{MPOTensor.isRFP_iff_isZCL}

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -295,11 +295,34 @@ legs cyclically and taking the resulting trace.
 % The definition above is transfer-map idempotence, distinct from the paper's
 % Definition 4.1 (`RFPMixedTS`); the latter is stated below as def:is_rfp_via_ts.
 
+\begin{definition}[Trace-preserving completely positive map]
+    \label{def:is_kraus_cptp}
+    \lean{IsKrausCPTP}
+    \leanok
+    A linear map $\mathcal{S}$ between matrix algebras is \emph{trace-preserving
+    completely positive} if it has a Kraus form
+    $\mathcal{S}(X) = \sum_{i} A_i X A_i^\dagger$ with $\sum_i A_i^\dagger A_i = I$.
+    The Kraus operators may be rectangular, so the input and output dimensions
+    need not agree.
+\end{definition}
+
+\begin{definition}[One- and two-site physical closure maps]
+    \label{def:phys_close}
+    \lean{MPOTensor.physClose1, MPOTensor.physClose2}
+    \leanok
+    \uses{def:mpo_tensor}
+    For an MPO tensor $M$, the one- and two-site physical operators obtained by
+    closing one or two tensors with a virtual operator $X$ are
+    $M_1(X)_{ij} = \tr(M^{ij} X)$ and
+    $M_2(X)_{(i_1 i_2)(j_1 j_2)} = \tr(M^{i_1 j_1} M^{i_2 j_2} X)$, both linear
+    in $X$.
+\end{definition}
+
 \begin{definition}[Renormalization fixed point via trace-preserving maps]
     \label{def:is_rfp_via_ts}
     \lean{MPOTensor.IsRFPViaTS}
     \leanok
-    \uses{def:mpo_tensor}
+    \uses{def:mpo_tensor, def:is_kraus_cptp, def:phys_close}
     An MPO tensor $M$ is a \emph{renormalization fixed point} if there exist two
     trace-preserving completely positive maps $\mathcal{S}, \mathcal{T}$ on the
     physical indices such that $\mathcal{S}[M_2(X)] = M_1(X)$ and


### PR DESCRIPTION
Part of #2382 / #2380 (relates #826). Formalizes arXiv:1606.00608 **Definition 4.1** (`RFPMixedTS`, line 657) — the source's MPDO renormalization-fixed-point notion — which was **not stated**: `MPOTensor.IsRFP` is transfer-map idempotence, a different (ZCL-equivalent) condition.

## Source (Definition 4.1, line 657; figures `MPDO_XM`/`MPDO_XMM`/`MPDO_TandS`)
`M` (in CF, generating MPDOs) is an RFP if there exist two trace-preserving completely positive maps `T, S` on the physical indices with `S[M₂(X)] = M₁(X)` (`eq:Smap`) and `T[M₁(X)] = M₂(X)` (`eq:Tmap`) for all virtual `X`, where `M₁(X)ᵢⱼ = tr(Mⁱʲ X)` (one-site) and `M₂(X)₍i₁i₂₎₍j₁j₂₎ = tr(Mⁱ¹ʲ¹ Mⁱ²ʲ² X)` (two-site).

## New file `TNLean/MPS/MPDO/RFPViaTS.lean`
- `IsKrausCPTP` — a trace-preserving CP map between matrix algebras of possibly **different dimension**, in rectangular Kraus form `S(X) = ∑ Aᵢ X Aᵢ†` with `∑ Aᵢ† Aᵢ = 1` (the existing `Channel` CP/TP API is endomorphism-only, so this fills the gap for `S`: two-site → one-site).
- `MPOTensor.physClose1` / `physClose2` — the closure maps as `LinearMap`s, with `@[simp]` apply lemmas.
- `MPOTensor.IsRFP_via_TS` — Definition 4.1.

## Scope & verification
- **Definition only.** The implication `IsRFP_via_TS M → IsRFP M` (Theorem 4.9 `i⇒ii` direction) is a deferred follow-up under #2382/#826.
- `lake build TNLean`: green, 8752 jobs. No `sorry`/`axiom` in the new file (`#print axioms` shows only `propext`/`Classical.choice`/`Quot.sound`).

Closes the "Definition 4.1 not stated" gap from the coverage audit (#2380).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Definition-only Lean and blueprint additions with doc cross-references; no changes to `IsRFP` semantics or proof obligations beyond deferred follow-up.
> 
> **Overview**
> Adds the paper’s **Definition 4.1** MPDO renormalization fixed point (trace-preserving CP maps `S`, `T` intertwining one- and two-site physical closures) as formal definitions, distinct from existing transfer-map idempotence `MPOTensor.IsRFP`.
> 
> New module `TNLean/MPS/MPDO/RFPViaTS.lean` introduces `IsKrausCPTP` (rectangular Kraus tp-CP maps), `physClose1` / `physClose2`, and `MPOTensor.IsRFPViaTS`. The root import and blueprint chapter `ch02b_mpdo.tex` are wired to these names; comments in `Defs.lean` and `RFP.lean` now point at `IsRFPViaTS` instead of listing Definition 4.1 as unstated future work.
> 
> **No new theorems:** `IsRFPViaTS M → IsRFP M` (Theorem 4.9) remains deferred (#2382 / #826).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8133f585cb9ef185efaf8e1ee4cb1cb53dec53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->