### PR TITLE
fix(peps): physical_to_virtual_insertion is false without positive bonds (#1370)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -382,6 +382,7 @@ import TNLean.PEPS.NormalSquarePEPSBlocking
 import TNLean.PEPS.NormalEdgeBlockingMargins
 import TNLean.PEPS.IdentityInsertion
 import TNLean.PEPS.InsertionRealization
+import TNLean.PEPS.PhysicalToVirtualCounterexample
 import TNLean.PEPS.InsertionAlgebra
 import TNLean.PEPS.LocalGauge
 import TNLean.PEPS.TensorFactorScalar

--- a/TNLean/PEPS/EdgeMiddlePhysical/KernelDescent.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical/KernelDescent.lean
@@ -513,7 +513,7 @@ theorem exposedIndicator_edgeMiddleVertices
   intro f hf1 hf2
   -- both endpoints of f are outside midV, so both are in {e.1.1, e.1.2}; with f ≠ e impossible
   rw [mem_edgeMiddleVertices_iff, not_and_or, not_not, not_not] at hf1 hf2
-  -- hf1 : f.1.1.1 = e.1.1 ∨ f.1.1.1 = e.1.2 ; hf2 : f.1.1.2 = e.1.1 ∨ f.1.1.2 = e.1.2
+  -- hf1 : f.1.1.1 = e.1.1 ∨ f.1.1.1 = e.1.2; hf2 : f.1.1.2 = e.1.1 ∨ f.1.1.2 = e.1.2
   have d1 : f.1.1.1 = e.1.1 ∨ f.1.1.1 = e.1.2 := hf1
   have d2 : f.1.1.2 = e.1.1 ∨ f.1.1.2 = e.1.2 := hf2
   refine absurd (incidentBoth_eq_edge (G := G) e f.1 ?_ ?_) f.2

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -206,11 +206,12 @@ $O_2\Phi_v=\Phi_vT_{v,e}(M)$.
 Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, equations
 eq:resonate--eq:O->X, lines 355--486 of the local paper source.
 
-**Positive-bond hypothesis.** Without `hpos` the statement is
-false: a zero-dimensional edge incident to an endpoint empties the edge boundary
-configuration, so `hEq` holds vacuously while the recovery conclusion remains a
-genuine constraint that fails for a nontrivial right-endpoint operator. The
-checked counterexample is `physical_to_virtual_insertion_statement_false` in
+**Positive-bond hypothesis.** Without the positive-bond hypothesis, the statement
+is false: a zero-dimensional edge incident to an endpoint empties the edge
+boundary configuration, so the resonate sum identity holds vacuously while the
+recovery conclusion remains a genuine constraint that fails for a nontrivial
+right-endpoint operator. The checked counterexample is
+`physical_to_virtual_insertion_statement_false` in
 `TNLean/PEPS/PhysicalToVirtualCounterexample.lean`. The hypothesis `hpos` (every
 bond dimension positive) is the source's standing assumption that injective PEPS
 have nonzero virtual bond spaces; the same missing hypothesis was identified

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -206,13 +206,26 @@ $O_2\Phi_v=\Phi_vT_{v,e}(M)$.
 Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, equations
 eq:resonate--eq:O->X, lines 355--486 of the local paper source.
 
-**Proof status:** This declaration states the source recovery step used by the
-insertion-algebra theorem. The current formal status is recorded in
+**Positive-bond hypothesis (faithfulness fix).** Without `hpos` the statement is
+false: a zero-dimensional edge incident to an endpoint empties the edge boundary
+configuration, so `hEq` holds vacuously while the recovery conclusion remains a
+genuine constraint that fails for a nontrivial right-endpoint operator. The
+checked counterexample is `PhysicalToVirtualInsertionStatement_false` in
+`TNLean/PEPS/PhysicalToVirtualCounterexample.lean`. The hypothesis `hpos` (every
+bond dimension positive) is the source's standing assumption that injective PEPS
+have nonzero virtual bond spaces; the same defect was corrected for the
+edge-blocked three-site injectivity (issue #1366).
+
+**Proof status:** open (`sorry`). This declaration states the source recovery
+step used by the insertion-algebra theorem. With `hpos` the paper's
+invert-and-recover argument has a nontrivial bond to land the recovered matrix
+on; the remaining formal status is recorded in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
 mathematical obligations". -/
 theorem physical_to_virtual_insertion
     (A : Tensor G d) (e : Edge G)
     (hA : EdgeBlockedThreeSiteInjective (G := G) A e)
+    (hpos : ∀ f : Edge G, 0 < A.bondDim f)
     (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
     (hEq : ∀ σ : V → Fin d,
       (∑ β : EdgeBoundaryConfig (G := G) A e,

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -206,15 +206,15 @@ $O_2\Phi_v=\Phi_vT_{v,e}(M)$.
 Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, equations
 eq:resonate--eq:O->X, lines 355--486 of the local paper source.
 
-**Positive-bond hypothesis (faithfulness fix).** Without `hpos` the statement is
+**Positive-bond hypothesis.** Without `hpos` the statement is
 false: a zero-dimensional edge incident to an endpoint empties the edge boundary
 configuration, so `hEq` holds vacuously while the recovery conclusion remains a
 genuine constraint that fails for a nontrivial right-endpoint operator. The
 checked counterexample is `PhysicalToVirtualInsertionStatement_false` in
 `TNLean/PEPS/PhysicalToVirtualCounterexample.lean`. The hypothesis `hpos` (every
 bond dimension positive) is the source's standing assumption that injective PEPS
-have nonzero virtual bond spaces; the same defect was corrected for the
-edge-blocked three-site injectivity (issue #1366).
+have nonzero virtual bond spaces; the same missing hypothesis was identified
+for the edge-blocked three-site injectivity (issue #1366).
 
 **Proof status:** open (`sorry`). This declaration states the source recovery
 step used by the insertion-algebra theorem. With `hpos` the paper's

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -203,8 +203,9 @@ every physical configuration, then there is a matrix $M$ on the shared bond such
 that $O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T})$ and
 $O_2\Phi_v=\Phi_vT_{v,e}(M)$.
 
-Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, equations
-eq:resonate--eq:O->X, lines 355--486 of the local paper source.
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, local source
+`paper_normal.tex`, lines 254--255; the edge vector-space convention is on line
+250, and the calculation is equations eq:resonate--eq:O->X, lines 355--486.
 
 **Positive-bond hypothesis.** Without the positive-bond hypothesis, the statement
 is false: a zero-dimensional edge incident to an endpoint empties the edge
@@ -212,15 +213,17 @@ boundary configuration, so the resonate sum identity holds vacuously while the
 recovery conclusion remains a genuine constraint that fails for a nontrivial
 right-endpoint operator. The checked counterexample is
 `physical_to_virtual_insertion_statement_false` in
-`TNLean/PEPS/PhysicalToVirtualCounterexample.lean`. The hypothesis `hpos` (every
-bond dimension positive) is the source's standing assumption that injective PEPS
-have nonzero virtual bond spaces; the same missing hypothesis was identified
-for the edge-blocked three-site injectivity (issue #1366).
+`TNLean/PEPS/PhysicalToVirtualCounterexample.lean`. The source lemma is stated
+for injective three-site tensor networks with a vector space assigned to the
+edge (`paper_normal.tex`, lines 250 and 254--255). The positivity hypothesis is
+a local correction that makes this nonzero virtual edge space explicit in the
+formal statement; the same missing hypothesis was identified for the
+edge-blocked three-site injectivity (issue #1366).
 
 **Proof status:** open (`sorry`). This declaration states the source recovery
-step used by the insertion-algebra theorem. With `hpos` the paper's
-invert-and-recover argument has a nontrivial bond to land the recovered matrix
-on; the remaining formal status is recorded in
+step used by the insertion-algebra theorem. With the positivity hypothesis, the
+paper's invert-and-recover argument has a nontrivial bond to land the recovered
+matrix on; the remaining formal status is recorded in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
 mathematical obligations". -/
 theorem physical_to_virtual_insertion

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -210,7 +210,7 @@ eq:resonate--eq:O->X, lines 355--486 of the local paper source.
 false: a zero-dimensional edge incident to an endpoint empties the edge boundary
 configuration, so `hEq` holds vacuously while the recovery conclusion remains a
 genuine constraint that fails for a nontrivial right-endpoint operator. The
-checked counterexample is `PhysicalToVirtualInsertionStatement_false` in
+checked counterexample is `physical_to_virtual_insertion_statement_false` in
 `TNLean/PEPS/PhysicalToVirtualCounterexample.lean`. The hypothesis `hpos` (every
 bond dimension positive) is the source's standing assumption that injective PEPS
 have nonzero virtual bond spaces; the same missing hypothesis was identified

--- a/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
+++ b/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
@@ -29,14 +29,14 @@ namespace PhysicalToVirtualCounterexample
 
 open scoped BigOperators
 
-abbrev V3 := Fin 3
+abbrev v3 := Fin 3
 
-def adj3 (a b : V3) : Prop :=
+def adj3 (a b : v3) : Prop :=
   (a = 0 ∧ b = 1) ∨ (a = 1 ∧ b = 0) ∨ (a = 0 ∧ b = 2) ∨ (a = 2 ∧ b = 0)
 
 instance : DecidableRel adj3 := by unfold adj3; infer_instance
 
-def g3 : SimpleGraph V3 where
+def g3 : SimpleGraph v3 where
   Adj := adj3
   symm := by
     intro a b h
@@ -72,21 +72,21 @@ def a3 : Tensor g3 2 where
 theorem a3_bond_dim_e3 : a3.bondDim e3 = 1 := bd_e3
 theorem a3_bond_dim_f3 : a3.bondDim f3 = 0 := bd_f3
 
-theorem e3_left : e3.1.1 = (0 : V3) := rfl
-theorem e3_right : e3.1.2 = (1 : V3) := rfl
+theorem e3_left : e3.1.1 = (0 : v3) := rfl
+theorem e3_right : e3.1.2 = (1 : v3) := rfl
 
 /-- f3 as an incident edge of vertex 0. -/
-def f3incident : IncidentEdge g3 (0 : V3) := ⟨f3, Or.inl rfl⟩
+def f3incident : IncidentEdge g3 (0 : v3) := ⟨f3, Or.inl rfl⟩
 
 /-- Left endpoint local config is empty (incident edge f3 has bond 0). -/
-instance : IsEmpty (LocalVirtualConfig a3 (0 : V3)) := by
+instance : IsEmpty (LocalVirtualConfig a3 (0 : v3)) := by
   refine ⟨fun c => ?_⟩
   have h := c f3incident
   rw [show a3.bondDim f3incident.1 = 0 from a3_bond_dim_f3] at h
   exact h.elim0
 
 /-- f3 is an other-incident edge of vertex 0 relative to the distinguished edge. -/
-def f3other : OtherIncidentEdge (G := g3) (0 : V3) (edgeLeftIncident (G := g3) e3) :=
+def f3other : OtherIncidentEdge (G := g3) (0 : v3) (edgeLeftIncident (G := g3) e3) :=
   ⟨f3incident, by decide⟩
 
 /-- Left residual config is empty (it includes the f3-coordinate of bond 0). -/
@@ -101,17 +101,17 @@ instance : IsEmpty (EdgeMiddleBoundaryLabel (G := g3) a3 e3) :=
   Prod.isEmpty_left
 
 /-- The only incident edge of vertex 1 is the distinguished edge e3. -/
-theorem incident_one_eq (ie : IncidentEdge g3 (1 : V3)) : ie.1 = e3 := by
+theorem incident_one_eq (ie : IncidentEdge g3 (1 : v3)) : ie.1 = e3 := by
   revert ie; decide
 
 /-- Every incident-edge bond at vertex 1 has dimension 1. -/
-theorem bond_dim_incident_one (ie : IncidentEdge g3 (1 : V3)) :
+theorem bond_dim_incident_one (ie : IncidentEdge g3 (1 : v3)) :
     a3.bondDim ie.1 = 1 := by
   rw [incident_one_eq ie]; exact a3_bond_dim_e3
 
 /-- The right endpoint local config type has exactly one element. -/
 theorem right_config_unique :
-    ∀ a b : LocalVirtualConfig a3 (1 : V3), a = b := by
+    ∀ a b : LocalVirtualConfig a3 (1 : v3), a = b := by
   intro a b
   funext ie
   have h1 : a3.bondDim ie.1 = 1 := bond_dim_incident_one ie
@@ -119,14 +119,14 @@ theorem right_config_unique :
   apply Subsingleton.elim
 
 /-- `a3.component 1 η = ![1,0]` for every (the unique) config `η`. -/
-theorem a3_component_one (η : LocalVirtualConfig a3 (1 : V3)) :
-    a3.component (1 : V3) η = ![1, 0] := rfl
+theorem a3_component_one (η : LocalVirtualConfig a3 (1 : v3)) :
+    a3.component (1 : v3) η = ![1, 0] := rfl
 
 /-- The right endpoint local tensor map applied to `c` evaluated at index 0
 recovers `c` at the unique config. -/
-theorem local_tensor_map_one_apply_zero (c : LocalVirtualConfig a3 (1 : V3) → ℂ)
-    (η₀ : LocalVirtualConfig a3 (1 : V3)) :
-    localTensorMap a3 (1 : V3) c 0 = c η₀ := by
+theorem local_tensor_map_one_apply_zero (c : LocalVirtualConfig a3 (1 : v3) → ℂ)
+    (η₀ : LocalVirtualConfig a3 (1 : v3)) :
+    localTensorMap a3 (1 : v3) c 0 = c η₀ := by
   classical
   simp only [localTensorMap, Fintype.linearCombination_apply]
   rw [Finset.sum_apply]
@@ -138,7 +138,7 @@ theorem local_tensor_map_one_apply_zero (c : LocalVirtualConfig a3 (1 : V3) → 
   · intro h; exact absurd (Finset.mem_univ η₀) h
 
 /-- Right endpoint local tensor map is injective. -/
-theorem right_injective : Function.Injective (localTensorMap a3 (1 : V3)) := by
+theorem right_injective : Function.Injective (localTensorMap a3 (1 : v3)) := by
   intro c c' h
   funext η
   have h0 := congrFun h 0
@@ -146,7 +146,7 @@ theorem right_injective : Function.Injective (localTensorMap a3 (1 : V3)) := by
   exact h0
 
 /-- Left endpoint local tensor map is injective (its domain is empty). -/
-theorem left_injective : Function.Injective (localTensorMap a3 (0 : V3)) := by
+theorem left_injective : Function.Injective (localTensorMap a3 (0 : v3)) := by
   intro c c' _
   funext η
   exact (IsEmpty.false η).elim
@@ -159,11 +159,11 @@ theorem middle_injective : EdgeMiddleTensorInjective (G := g3) a3 e3 :=
 theorem a3_edge_blocked_three_site_injective :
     EdgeBlockedThreeSiteInjective (G := g3) a3 e3 :=
   { left_injective := by
-      have : e3.1.1 = (0 : V3) := e3_left
+      have : e3.1.1 = (0 : v3) := e3_left
       rw [this]; exact left_injective
     middle_injective := middle_injective
     right_injective := by
-      have : e3.1.2 = (1 : V3) := e3_right
+      have : e3.1.2 = (1 : v3) := e3_right
       rw [this]; exact right_injective }
 
 /-- The ordinary edge-boundary configuration type is empty (its left residual
@@ -184,8 +184,8 @@ theorem o2bad_apply_e0 : o2bad (![1, 0] : Fin 2 → ℂ) = ![0, 1] := by
 
 /-- Everything in the image of the right endpoint local tensor map has a zero in
 coordinate 1 (the image lies in the span of `![1,0]`). -/
-theorem local_tensor_map_one_apply_one (w : LocalVirtualConfig a3 (1 : V3) → ℂ) :
-    localTensorMap a3 (1 : V3) w 1 = 0 := by
+theorem local_tensor_map_one_apply_one (w : LocalVirtualConfig a3 (1 : v3) → ℂ) :
+    localTensorMap a3 (1 : v3) w 1 = 0 := by
   classical
   simp only [localTensorMap, Fintype.linearCombination_apply]
   rw [Finset.sum_apply]
@@ -195,15 +195,15 @@ theorem local_tensor_map_one_apply_one (w : LocalVirtualConfig a3 (1 : V3) → �
 
 /-- The right endpoint local config type is inhabited (assign 0 to every
 incident-edge bond, each of which has dimension 1). -/
-instance : Inhabited (LocalVirtualConfig a3 (1 : V3)) :=
+instance : Inhabited (LocalVirtualConfig a3 (1 : v3)) :=
   ⟨fun ie => ⟨0, by rw [bond_dim_incident_one ie]; exact Nat.one_pos⟩⟩
 
 /-- The unique right-endpoint config. -/
-def η₀ : LocalVirtualConfig a3 (1 : V3) := default
+def η₀ : LocalVirtualConfig a3 (1 : v3) := default
 
 /-- The right endpoint local tensor map sends the single basis vector to `![1,0]`. -/
 theorem local_tensor_map_one_single :
-    localTensorMap a3 (1 : V3) (Pi.single η₀ (1 : ℂ)) = ![1, 0] := by
+    localTensorMap a3 (1 : v3) (Pi.single η₀ (1 : ℂ)) = ![1, 0] := by
   rw [localTensorMap_apply_single]
   exact a3_component_one η₀
 
@@ -212,7 +212,7 @@ theorem local_tensor_map_one_single :
 /-- The type of the original `physical_to_virtual_insertion` statement, generic
 over the graph, vertex set, and physical dimension. This is the universe-0
 specialization of the signature of `TNLean.PEPS.physical_to_virtual_insertion`. -/
-def PhysicalToVirtualInsertionStatement : Prop :=
+def physicalToVirtualInsertionStatement : Prop :=
   ∀ {V : Type} [Fintype V] [LinearOrder V] {G : SimpleGraph V} [DecidableRel G.Adj]
     {d : ℕ} (A : Tensor G d) (e : Edge G)
     (_ : EdgeBlockedThreeSiteInjective (G := G) A e)
@@ -241,10 +241,10 @@ no proof of its signature can exist, because our explicit witness
 `(g3, a3, e3, id, o2bad)` satisfies all of its hypotheses yet refutes its
 conclusion. -/
 theorem physical_to_virtual_insertion_statement_false :
-    ¬ PhysicalToVirtualInsertionStatement := by
+    ¬ physicalToVirtualInsertionStatement := by
   intro hThm
   -- Build the resonate hypothesis at our witness (both sides empty sums).
-  have hEq : ∀ σ : V3 → Fin 2,
+  have hEq : ∀ σ : v3 → Fin 2,
       (∑ β : EdgeBoundaryConfig (G := g3) a3 e3,
         (LinearMap.id : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ))
             (a3.component e3.1.1 (edgeLeftLocalConfig (G := g3) a3 e3 β)) (σ e3.1.1) *
@@ -258,9 +258,9 @@ theorem physical_to_virtual_insertion_statement_false :
     rw [Finset.univ_eq_empty, Finset.sum_empty, Finset.sum_empty]
   obtain ⟨M, _, hRight⟩ :=
     hThm a3 e3 a3_edge_blocked_three_site_injective LinearMap.id o2bad hEq
-  have hRight' : ∀ c : LocalVirtualConfig a3 (1 : V3) → ℂ,
-      o2bad (localTensorMap a3 (1 : V3) c) =
-        localTensorMap a3 (1 : V3)
+  have hRight' : ∀ c : LocalVirtualConfig a3 (1 : v3) → ℂ,
+      o2bad (localTensorMap a3 (1 : v3) c) =
+        localTensorMap a3 (1 : v3)
           (localIncidentMatrixOp a3 (edgeRightIncident (G := g3) e3) M c) := hRight
   have hr := hRight' (Pi.single η₀ (1 : ℂ))
   rw [local_tensor_map_one_single] at hr

--- a/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
+++ b/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
@@ -12,7 +12,7 @@ right-endpoint operator.
 
 The explicit witness is the graph on three vertices with the distinguished edge
 of bond dimension one and a second edge of bond dimension zero at the left
-endpoint. `PhysicalToVirtualInsertionStatement_false` refutes the universe-0
+endpoint. `physical_to_virtual_insertion_statement_false` refutes the universe-0
 specialization of the hypothesis-free statement;
 `physical_to_virtual_insertion` itself carries the restored hypothesis that
 every bond dimension is positive.
@@ -36,7 +36,7 @@ def adj3 (a b : V3) : Prop :=
 
 instance : DecidableRel adj3 := by unfold adj3; infer_instance
 
-def G3 : SimpleGraph V3 where
+def g3 : SimpleGraph V3 where
   Adj := adj3
   symm := by
     intro a b h
@@ -44,24 +44,24 @@ def G3 : SimpleGraph V3 where
     fin_cases a <;> fin_cases b <;> simp_all
   loopless := ⟨by intro a; unfold adj3; fin_cases a <;> simp⟩
 
-instance : DecidableRel G3.Adj := by
+instance : DecidableRel g3.Adj := by
   change DecidableRel adj3
   infer_instance
 
-def e3 : Edge G3 := ⟨(0, 1), by constructor <;> decide⟩
-def f3 : Edge G3 := ⟨(0, 2), by constructor <;> decide⟩
+def e3 : Edge g3 := ⟨(0, 1), by constructor <;> decide⟩
+def f3 : Edge g3 := ⟨(0, 2), by constructor <;> decide⟩
 
 theorem f3_ne_e3 : f3 ≠ e3 := by decide
 
 /-- bond dimension: 1 on e (distinguished), 0 on f (the extra zero bond at u). -/
-def bd : Edge G3 → ℕ := fun g => if g = e3 then 1 else 0
+def bd : Edge g3 → ℕ := fun g => if g = e3 then 1 else 0
 
 theorem bd_e3 : bd e3 = 1 := by simp [bd]
 theorem bd_f3 : bd f3 = 0 := by simp [bd, f3_ne_e3]
 
 /-- The tensor: d = 2. Right endpoint (vertex 1) outputs e_0 = ![1,0] on its
 single config; other vertices output 0 (their config spaces are empty anyway). -/
-def A3 : Tensor G3 2 where
+def a3 : Tensor g3 2 where
   bondDim := bd
   component v :=
     match v with
@@ -69,95 +69,95 @@ def A3 : Tensor G3 2 where
     | 1 => fun _ => ![1, 0]
     | 2 => fun _ _ => 0
 
-theorem A3_bondDim_e3 : A3.bondDim e3 = 1 := bd_e3
-theorem A3_bondDim_f3 : A3.bondDim f3 = 0 := bd_f3
+theorem a3_bond_dim_e3 : a3.bondDim e3 = 1 := bd_e3
+theorem a3_bond_dim_f3 : a3.bondDim f3 = 0 := bd_f3
 
 theorem e3_left : e3.1.1 = (0 : V3) := rfl
 theorem e3_right : e3.1.2 = (1 : V3) := rfl
 
 /-- f3 as an incident edge of vertex 0. -/
-def f3incident : IncidentEdge G3 (0 : V3) := ⟨f3, Or.inl rfl⟩
+def f3incident : IncidentEdge g3 (0 : V3) := ⟨f3, Or.inl rfl⟩
 
 /-- Left endpoint local config is empty (incident edge f3 has bond 0). -/
-instance : IsEmpty (LocalVirtualConfig A3 (0 : V3)) := by
+instance : IsEmpty (LocalVirtualConfig a3 (0 : V3)) := by
   refine ⟨fun c => ?_⟩
   have h := c f3incident
-  rw [show A3.bondDim f3incident.1 = 0 from A3_bondDim_f3] at h
+  rw [show a3.bondDim f3incident.1 = 0 from a3_bond_dim_f3] at h
   exact h.elim0
 
 /-- f3 is an other-incident edge of vertex 0 relative to the distinguished edge. -/
-def f3other : OtherIncidentEdge (G := G3) (0 : V3) (edgeLeftIncident (G := G3) e3) :=
+def f3other : OtherIncidentEdge (G := g3) (0 : V3) (edgeLeftIncident (G := g3) e3) :=
   ⟨f3incident, by decide⟩
 
 /-- Left residual config is empty (it includes the f3-coordinate of bond 0). -/
-instance : IsEmpty (ResidualLocalConfig A3 (edgeLeftIncident (G := G3) e3)) := by
+instance : IsEmpty (ResidualLocalConfig a3 (edgeLeftIncident (G := g3) e3)) := by
   refine ⟨fun c => ?_⟩
   have h := c f3other
-  rw [show A3.bondDim f3other.1.1 = 0 from A3_bondDim_f3] at h
+  rw [show a3.bondDim f3other.1.1 = 0 from a3_bond_dim_f3] at h
   exact h.elim0
 
 /-- Hence the edge-middle boundary label is empty. -/
-instance : IsEmpty (EdgeMiddleBoundaryLabel (G := G3) A3 e3) :=
+instance : IsEmpty (EdgeMiddleBoundaryLabel (G := g3) a3 e3) :=
   Prod.isEmpty_left
 
 /-- The only incident edge of vertex 1 is the distinguished edge e3. -/
-theorem incident_one_eq (ie : IncidentEdge G3 (1 : V3)) : ie.1 = e3 := by
+theorem incident_one_eq (ie : IncidentEdge g3 (1 : V3)) : ie.1 = e3 := by
   revert ie; decide
 
 /-- Every incident-edge bond at vertex 1 has dimension 1. -/
-theorem bondDim_incident_one (ie : IncidentEdge G3 (1 : V3)) :
-    A3.bondDim ie.1 = 1 := by
-  rw [incident_one_eq ie]; exact A3_bondDim_e3
+theorem bond_dim_incident_one (ie : IncidentEdge g3 (1 : V3)) :
+    a3.bondDim ie.1 = 1 := by
+  rw [incident_one_eq ie]; exact a3_bond_dim_e3
 
 /-- The right endpoint local config type has exactly one element. -/
-theorem rightConfig_unique :
-    ∀ a b : LocalVirtualConfig A3 (1 : V3), a = b := by
+theorem right_config_unique :
+    ∀ a b : LocalVirtualConfig a3 (1 : V3), a = b := by
   intro a b
   funext ie
-  have h1 : A3.bondDim ie.1 = 1 := bondDim_incident_one ie
-  haveI : Subsingleton (Fin (A3.bondDim ie.1)) := by rw [h1]; infer_instance
+  have h1 : a3.bondDim ie.1 = 1 := bond_dim_incident_one ie
+  haveI : Subsingleton (Fin (a3.bondDim ie.1)) := by rw [h1]; infer_instance
   apply Subsingleton.elim
 
-/-- `A3.component 1 η = ![1,0]` for every (the unique) config `η`. -/
-theorem A3_component_one (η : LocalVirtualConfig A3 (1 : V3)) :
-    A3.component (1 : V3) η = ![1, 0] := rfl
+/-- `a3.component 1 η = ![1,0]` for every (the unique) config `η`. -/
+theorem a3_component_one (η : LocalVirtualConfig a3 (1 : V3)) :
+    a3.component (1 : V3) η = ![1, 0] := rfl
 
 /-- The right endpoint local tensor map applied to `c` evaluated at index 0
 recovers `c` at the unique config. -/
-theorem localTensorMap_one_apply_zero (c : LocalVirtualConfig A3 (1 : V3) → ℂ)
-    (η₀ : LocalVirtualConfig A3 (1 : V3)) :
-    localTensorMap A3 (1 : V3) c 0 = c η₀ := by
+theorem local_tensor_map_one_apply_zero (c : LocalVirtualConfig a3 (1 : V3) → ℂ)
+    (η₀ : LocalVirtualConfig a3 (1 : V3)) :
+    localTensorMap a3 (1 : V3) c 0 = c η₀ := by
   classical
   simp only [localTensorMap, Fintype.linearCombination_apply]
   rw [Finset.sum_apply]
   rw [Finset.sum_eq_single η₀]
-  · simp [A3_component_one]
+  · simp [a3_component_one]
   · intro b _ hb
-    rw [rightConfig_unique b η₀] at hb
+    rw [right_config_unique b η₀] at hb
     exact absurd rfl hb
   · intro h; exact absurd (Finset.mem_univ η₀) h
 
 /-- Right endpoint local tensor map is injective. -/
-theorem right_injective : Function.Injective (localTensorMap A3 (1 : V3)) := by
+theorem right_injective : Function.Injective (localTensorMap a3 (1 : V3)) := by
   intro c c' h
   funext η
   have h0 := congrFun h 0
-  rw [localTensorMap_one_apply_zero c η, localTensorMap_one_apply_zero c' η] at h0
+  rw [local_tensor_map_one_apply_zero c η, local_tensor_map_one_apply_zero c' η] at h0
   exact h0
 
 /-- Left endpoint local tensor map is injective (its domain is empty). -/
-theorem left_injective : Function.Injective (localTensorMap A3 (0 : V3)) := by
+theorem left_injective : Function.Injective (localTensorMap a3 (0 : V3)) := by
   intro c c' _
   funext η
   exact (IsEmpty.false η).elim
 
 /-- Middle tensor family is linearly independent (its index type is empty). -/
-theorem middle_injective : EdgeMiddleTensorInjective (G := G3) A3 e3 :=
+theorem middle_injective : EdgeMiddleTensorInjective (G := g3) a3 e3 :=
   linearIndependent_empty_type
 
 /-- The blocked three-site object is injective. -/
-theorem A3_edgeBlockedThreeSiteInjective :
-    EdgeBlockedThreeSiteInjective (G := G3) A3 e3 :=
+theorem a3_edge_blocked_three_site_injective :
+    EdgeBlockedThreeSiteInjective (G := g3) a3 e3 :=
   { left_injective := by
       have : e3.1.1 = (0 : V3) := e3_left
       rw [this]; exact left_injective
@@ -168,44 +168,44 @@ theorem A3_edgeBlockedThreeSiteInjective :
 
 /-- The ordinary edge-boundary configuration type is empty (its left residual
 field ranges over an empty type). -/
-instance : IsEmpty (EdgeBoundaryConfig (G := G3) A3 e3) := by
+instance : IsEmpty (EdgeBoundaryConfig (G := g3) a3 e3) := by
   refine ⟨fun β => ?_⟩
   exact (IsEmpty.false β.leftResidual).elim
 
 /-- The "bad" right physical operator: coordinate swap on `Fin 2 → ℂ`. It sends
 `![1,0]` to `![0,1]`, which is not a scalar multiple of `![1,0]`. -/
-def O2bad : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ) where
+def o2bad : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ) where
   toFun x := ![x 1, x 0]
   map_add' x y := by funext i; fin_cases i <;> simp
   map_smul' c x := by funext i; fin_cases i <;> simp
 
-theorem O2bad_apply_e0 : O2bad (![1, 0] : Fin 2 → ℂ) = ![0, 1] := by
-  funext i; fin_cases i <;> simp [O2bad]
+theorem o2bad_apply_e0 : o2bad (![1, 0] : Fin 2 → ℂ) = ![0, 1] := by
+  funext i; fin_cases i <;> simp [o2bad]
 
 /-- Everything in the image of the right endpoint local tensor map has a zero in
 coordinate 1 (the image lies in the span of `![1,0]`). -/
-theorem localTensorMap_one_apply_one (w : LocalVirtualConfig A3 (1 : V3) → ℂ) :
-    localTensorMap A3 (1 : V3) w 1 = 0 := by
+theorem local_tensor_map_one_apply_one (w : LocalVirtualConfig a3 (1 : V3) → ℂ) :
+    localTensorMap a3 (1 : V3) w 1 = 0 := by
   classical
   simp only [localTensorMap, Fintype.linearCombination_apply]
   rw [Finset.sum_apply]
   refine Finset.sum_eq_zero ?_
   intro η _
-  simp [A3_component_one]
+  simp [a3_component_one]
 
 /-- The right endpoint local config type is inhabited (assign 0 to every
 incident-edge bond, each of which has dimension 1). -/
-instance : Inhabited (LocalVirtualConfig A3 (1 : V3)) :=
-  ⟨fun ie => ⟨0, by rw [bondDim_incident_one ie]; exact Nat.one_pos⟩⟩
+instance : Inhabited (LocalVirtualConfig a3 (1 : V3)) :=
+  ⟨fun ie => ⟨0, by rw [bond_dim_incident_one ie]; exact Nat.one_pos⟩⟩
 
 /-- The unique right-endpoint config. -/
-def η₀ : LocalVirtualConfig A3 (1 : V3) := default
+def η₀ : LocalVirtualConfig a3 (1 : V3) := default
 
 /-- The right endpoint local tensor map sends the single basis vector to `![1,0]`. -/
-theorem localTensorMap_one_single :
-    localTensorMap A3 (1 : V3) (Pi.single η₀ (1 : ℂ)) = ![1, 0] := by
+theorem local_tensor_map_one_single :
+    localTensorMap a3 (1 : V3) (Pi.single η₀ (1 : ℂ)) = ![1, 0] := by
   rw [localTensorMap_apply_single]
-  exact A3_component_one η₀
+  exact a3_component_one η₀
 
 /-! ### The scope refutation -/
 
@@ -238,35 +238,35 @@ def PhysicalToVirtualInsertionStatement : Prop :=
 
 /-- The original `physical_to_virtual_insertion` statement is FALSE as written:
 no proof of its signature can exist, because our explicit witness
-`(G3, A3, e3, id, O2bad)` satisfies all of its hypotheses yet refutes its
+`(g3, a3, e3, id, o2bad)` satisfies all of its hypotheses yet refutes its
 conclusion. -/
-theorem PhysicalToVirtualInsertionStatement_false :
+theorem physical_to_virtual_insertion_statement_false :
     ¬ PhysicalToVirtualInsertionStatement := by
   intro hThm
   -- Build the resonate hypothesis at our witness (both sides empty sums).
   have hEq : ∀ σ : V3 → Fin 2,
-      (∑ β : EdgeBoundaryConfig (G := G3) A3 e3,
+      (∑ β : EdgeBoundaryConfig (G := g3) a3 e3,
         (LinearMap.id : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ))
-            (A3.component e3.1.1 (edgeLeftLocalConfig (G := G3) A3 e3 β)) (σ e3.1.1) *
-          edgeOpenMiddleWeight (G := G3) A3 e3 σ β.leftResidual β.rightResidual *
-          A3.component e3.1.2 (edgeRightLocalConfig (G := G3) A3 e3 β) (σ e3.1.2)) =
-        ∑ β : EdgeBoundaryConfig (G := G3) A3 e3,
-          A3.component e3.1.1 (edgeLeftLocalConfig (G := G3) A3 e3 β) (σ e3.1.1) *
-            edgeOpenMiddleWeight (G := G3) A3 e3 σ β.leftResidual β.rightResidual *
-            O2bad (A3.component e3.1.2 (edgeRightLocalConfig (G := G3) A3 e3 β)) (σ e3.1.2) := by
+            (a3.component e3.1.1 (edgeLeftLocalConfig (G := g3) a3 e3 β)) (σ e3.1.1) *
+          edgeOpenMiddleWeight (G := g3) a3 e3 σ β.leftResidual β.rightResidual *
+          a3.component e3.1.2 (edgeRightLocalConfig (G := g3) a3 e3 β) (σ e3.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := g3) a3 e3,
+          a3.component e3.1.1 (edgeLeftLocalConfig (G := g3) a3 e3 β) (σ e3.1.1) *
+            edgeOpenMiddleWeight (G := g3) a3 e3 σ β.leftResidual β.rightResidual *
+            o2bad (a3.component e3.1.2 (edgeRightLocalConfig (G := g3) a3 e3 β)) (σ e3.1.2) := by
     intro σ
     rw [Finset.univ_eq_empty, Finset.sum_empty, Finset.sum_empty]
   obtain ⟨M, _, hRight⟩ :=
-    hThm A3 e3 A3_edgeBlockedThreeSiteInjective LinearMap.id O2bad hEq
-  have hRight' : ∀ c : LocalVirtualConfig A3 (1 : V3) → ℂ,
-      O2bad (localTensorMap A3 (1 : V3) c) =
-        localTensorMap A3 (1 : V3)
-          (localIncidentMatrixOp A3 (edgeRightIncident (G := G3) e3) M c) := hRight
+    hThm a3 e3 a3_edge_blocked_three_site_injective LinearMap.id o2bad hEq
+  have hRight' : ∀ c : LocalVirtualConfig a3 (1 : V3) → ℂ,
+      o2bad (localTensorMap a3 (1 : V3) c) =
+        localTensorMap a3 (1 : V3)
+          (localIncidentMatrixOp a3 (edgeRightIncident (G := g3) e3) M c) := hRight
   have hr := hRight' (Pi.single η₀ (1 : ℂ))
-  rw [localTensorMap_one_single] at hr
+  rw [local_tensor_map_one_single] at hr
   have h1 := congrFun hr 1
-  rw [O2bad_apply_e0] at h1
-  rw [localTensorMap_one_apply_one] at h1
+  rw [o2bad_apply_e0] at h1
+  rw [local_tensor_map_one_apply_one] at h1
   simp at h1
 
 end PhysicalToVirtualCounterexample

--- a/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
+++ b/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
@@ -19,8 +19,8 @@ every bond dimension is positive.
 
 Source: the positive-bond assumption is the standing assumption of
 arXiv:1804.04964 that injective PEPS have nonzero-dimensional virtual bond
-spaces. The same defect was found and corrected for the edge-blocked three-site
-injectivity (issue #1366).
+spaces. The same missing hypothesis was identified for the edge-blocked
+three-site injectivity (issue #1366).
 -/
 
 namespace TNLean

--- a/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
+++ b/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
@@ -1,0 +1,332 @@
+import TNLean.PEPS.InsertionRealization
+
+/-!
+# The unrestricted physical-to-virtual recovery is false without positive bonds
+
+This file is a checked counterexample. The statement of
+`physical_to_virtual_insertion` is false once the positive-bond hypothesis is
+dropped: a zero-dimensional edge incident to an endpoint empties the edge
+boundary configuration, so the resonate hypothesis holds vacuously while the
+recovery conclusion remains a genuine constraint that fails for a nontrivial
+right-endpoint operator.
+
+The explicit witness is the graph on three vertices with the distinguished edge
+of bond dimension one and a second edge of bond dimension zero at the left
+endpoint. `PhysicalToVirtualInsertionStatement_false` refutes a verbatim copy of
+the hypothesis-free statement; `physical_to_virtual_insertion` itself carries the
+restored hypothesis that every bond dimension is positive.
+
+Source: the positive-bond assumption is the standing assumption of
+arXiv:1804.04964 that injective PEPS have nonzero-dimensional virtual bond
+spaces. The same defect was found and corrected for the edge-blocked three-site
+injectivity (issue #1366).
+-/
+
+namespace TNLean
+namespace PEPS
+namespace PhysicalToVirtualCounterexample
+
+open scoped BigOperators
+
+abbrev V3 := Fin 3
+
+def adj3 (a b : V3) : Prop :=
+  (a = 0 ∧ b = 1) ∨ (a = 1 ∧ b = 0) ∨ (a = 0 ∧ b = 2) ∨ (a = 2 ∧ b = 0)
+
+instance : DecidableRel adj3 := by unfold adj3; infer_instance
+
+def G3 : SimpleGraph V3 where
+  Adj := adj3
+  symm := by
+    intro a b h
+    unfold adj3 at *
+    fin_cases a <;> fin_cases b <;> simp_all
+  loopless := ⟨by intro a; unfold adj3; fin_cases a <;> simp⟩
+
+instance : DecidableRel G3.Adj := by
+  change DecidableRel adj3
+  infer_instance
+
+def e3 : Edge G3 := ⟨(0, 1), by constructor <;> decide⟩
+def f3 : Edge G3 := ⟨(0, 2), by constructor <;> decide⟩
+
+theorem f3_ne_e3 : f3 ≠ e3 := by decide
+
+/-- bond dimension: 1 on e (distinguished), 0 on f (the extra zero bond at u). -/
+def bd : Edge G3 → ℕ := fun g => if g = e3 then 1 else 0
+
+theorem bd_e3 : bd e3 = 1 := by simp [bd]
+theorem bd_f3 : bd f3 = 0 := by simp [bd, f3_ne_e3]
+
+/-- The tensor: d = 2. Right endpoint (vertex 1) outputs e_0 = ![1,0] on its
+single config; other vertices output 0 (their config spaces are empty anyway). -/
+def A3 : Tensor G3 2 where
+  bondDim := bd
+  component v :=
+    match v with
+    | 0 => fun _ _ => 0
+    | 1 => fun _ => ![1, 0]
+    | 2 => fun _ _ => 0
+
+theorem A3_bondDim_e3 : A3.bondDim e3 = 1 := bd_e3
+theorem A3_bondDim_f3 : A3.bondDim f3 = 0 := bd_f3
+
+theorem e3_left : e3.1.1 = (0 : V3) := rfl
+theorem e3_right : e3.1.2 = (1 : V3) := rfl
+
+/-- f3 as an incident edge of vertex 0. -/
+def f3incident : IncidentEdge G3 (0 : V3) := ⟨f3, Or.inl rfl⟩
+
+/-- Left endpoint local config is empty (incident edge f3 has bond 0). -/
+instance : IsEmpty (LocalVirtualConfig A3 (0 : V3)) := by
+  refine ⟨fun c => ?_⟩
+  have h := c f3incident
+  rw [show A3.bondDim f3incident.1 = 0 from A3_bondDim_f3] at h
+  exact h.elim0
+
+/-- f3 is an other-incident edge of vertex 0 relative to the distinguished edge. -/
+def f3other : OtherIncidentEdge (G := G3) (0 : V3) (edgeLeftIncident (G := G3) e3) :=
+  ⟨f3incident, by decide⟩
+
+/-- Left residual config is empty (it includes the f3-coordinate of bond 0). -/
+instance : IsEmpty (ResidualLocalConfig A3 (edgeLeftIncident (G := G3) e3)) := by
+  refine ⟨fun c => ?_⟩
+  have h := c f3other
+  rw [show A3.bondDim f3other.1.1 = 0 from A3_bondDim_f3] at h
+  exact h.elim0
+
+/-- Hence the edge-middle boundary label is empty. -/
+instance : IsEmpty (EdgeMiddleBoundaryLabel (G := G3) A3 e3) :=
+  Prod.isEmpty_left
+
+/-- The only incident edge of vertex 1 is the distinguished edge e3. -/
+theorem incident_one_eq (ie : IncidentEdge G3 (1 : V3)) : ie.1 = e3 := by
+  revert ie; decide
+
+/-- Every incident-edge bond at vertex 1 has dimension 1. -/
+theorem bondDim_incident_one (ie : IncidentEdge G3 (1 : V3)) :
+    A3.bondDim ie.1 = 1 := by
+  rw [incident_one_eq ie]; exact A3_bondDim_e3
+
+/-- The right endpoint local config type has exactly one element. -/
+theorem rightConfig_unique :
+    ∀ a b : LocalVirtualConfig A3 (1 : V3), a = b := by
+  intro a b
+  funext ie
+  have h1 : A3.bondDim ie.1 = 1 := bondDim_incident_one ie
+  haveI : Subsingleton (Fin (A3.bondDim ie.1)) := by rw [h1]; infer_instance
+  apply Subsingleton.elim
+
+/-- `A3.component 1 η = ![1,0]` for every (the unique) config `η`. -/
+theorem A3_component_one (η : LocalVirtualConfig A3 (1 : V3)) :
+    A3.component (1 : V3) η = ![1, 0] := rfl
+
+/-- The right endpoint local tensor map applied to `c` evaluated at index 0
+recovers `c` at the unique config. -/
+theorem localTensorMap_one_apply_zero (c : LocalVirtualConfig A3 (1 : V3) → ℂ)
+    (η₀ : LocalVirtualConfig A3 (1 : V3)) :
+    localTensorMap A3 (1 : V3) c 0 = c η₀ := by
+  classical
+  simp only [localTensorMap, Fintype.linearCombination_apply]
+  rw [Finset.sum_apply]
+  rw [Finset.sum_eq_single η₀]
+  · simp [A3_component_one]
+  · intro b _ hb
+    rw [rightConfig_unique b η₀] at hb
+    exact absurd rfl hb
+  · intro h; exact absurd (Finset.mem_univ η₀) h
+
+/-- Right endpoint local tensor map is injective. -/
+theorem right_injective : Function.Injective (localTensorMap A3 (1 : V3)) := by
+  intro c c' h
+  funext η
+  have h0 := congrFun h 0
+  rw [localTensorMap_one_apply_zero c η, localTensorMap_one_apply_zero c' η] at h0
+  exact h0
+
+/-- Left endpoint local tensor map is injective (its domain is empty). -/
+theorem left_injective : Function.Injective (localTensorMap A3 (0 : V3)) := by
+  intro c c' _
+  funext η
+  exact (IsEmpty.false η).elim
+
+/-- Middle tensor family is linearly independent (its index type is empty). -/
+theorem middle_injective : EdgeMiddleTensorInjective (G := G3) A3 e3 :=
+  linearIndependent_empty_type
+
+/-- The blocked three-site object is injective. -/
+theorem A3_edgeBlockedThreeSiteInjective :
+    EdgeBlockedThreeSiteInjective (G := G3) A3 e3 :=
+  { left_injective := by
+      have : e3.1.1 = (0 : V3) := e3_left
+      rw [this]; exact left_injective
+    middle_injective := middle_injective
+    right_injective := by
+      have : e3.1.2 = (1 : V3) := e3_right
+      rw [this]; exact right_injective }
+
+/-- The ordinary edge-boundary configuration type is empty (its left residual
+field ranges over an empty type). -/
+instance : IsEmpty (EdgeBoundaryConfig (G := G3) A3 e3) := by
+  refine ⟨fun β => ?_⟩
+  exact (IsEmpty.false β.leftResidual).elim
+
+/-- The "bad" right physical operator: coordinate swap on `Fin 2 → ℂ`. It sends
+`![1,0]` to `![0,1]`, which is not a scalar multiple of `![1,0]`. -/
+def O2bad : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ) where
+  toFun x := ![x 1, x 0]
+  map_add' x y := by funext i; fin_cases i <;> simp
+  map_smul' c x := by funext i; fin_cases i <;> simp
+
+theorem O2bad_apply_e0 : O2bad (![1, 0] : Fin 2 → ℂ) = ![0, 1] := by
+  funext i; fin_cases i <;> simp [O2bad]
+
+/-- Everything in the image of the right endpoint local tensor map has a zero in
+coordinate 1 (the image lies in the span of `![1,0]`). -/
+theorem localTensorMap_one_apply_one (w : LocalVirtualConfig A3 (1 : V3) → ℂ) :
+    localTensorMap A3 (1 : V3) w 1 = 0 := by
+  classical
+  simp only [localTensorMap, Fintype.linearCombination_apply]
+  rw [Finset.sum_apply]
+  refine Finset.sum_eq_zero ?_
+  intro η _
+  simp [A3_component_one]
+
+/-- The right endpoint local config type is inhabited (assign 0 to every
+incident-edge bond, each of which has dimension 1). -/
+instance : Inhabited (LocalVirtualConfig A3 (1 : V3)) :=
+  ⟨fun ie => ⟨0, by rw [bondDim_incident_one ie]; exact Nat.one_pos⟩⟩
+
+/-- The unique right-endpoint config. -/
+def η₀ : LocalVirtualConfig A3 (1 : V3) := default
+
+/-- The right endpoint local tensor map sends the single basis vector to `![1,0]`. -/
+theorem localTensorMap_one_single :
+    localTensorMap A3 (1 : V3) (Pi.single η₀ (1 : ℂ)) = ![1, 0] := by
+  rw [localTensorMap_apply_single]
+  exact A3_component_one η₀
+
+/-! ### The scope refutation -/
+
+/-- `physical_to_virtual_insertion` is FALSE as stated, i.e. without a
+positive-bond (or nonempty-boundary / vertex-injectivity) hypothesis: there is a
+tensor `A3`, a distinguished edge `e3`, physical operators `O₁ = id`,
+`O₂ = O2bad`, with `EdgeBlockedThreeSiteInjective A3 e3` and the resonate
+equation `hEq` holding, yet NO matrix `M` on the shared bond realizes the
+endpoint conclusion. -/
+theorem physical_to_virtual_insertion_false :
+    ¬ ∀ (A : Tensor G3 2) (e : Edge G3)
+        (_ : EdgeBlockedThreeSiteInjective (G := G3) A e)
+        (O₁ O₂ : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ))
+        (_ : ∀ σ : V3 → Fin 2,
+          (∑ β : EdgeBoundaryConfig (G := G3) A e,
+            O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G3) A e β)) (σ e.1.1) *
+              edgeOpenMiddleWeight (G := G3) A e σ β.leftResidual β.rightResidual *
+              A.component e.1.2 (edgeRightLocalConfig (G := G3) A e β) (σ e.1.2)) =
+            ∑ β : EdgeBoundaryConfig (G := G3) A e,
+              A.component e.1.1 (edgeLeftLocalConfig (G := G3) A e β) (σ e.1.1) *
+                edgeOpenMiddleWeight (G := G3) A e σ β.leftResidual β.rightResidual *
+                O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G3) A e β)) (σ e.1.2)),
+      ∃ M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ,
+        (∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+          O₁ (localTensorMap A e.1.1 c) =
+            localTensorMap A e.1.1
+              (localIncidentMatrixOp A (edgeLeftIncident (G := G3) e) M.transpose c)) ∧
+          ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+            O₂ (localTensorMap A e.1.2 c) =
+              localTensorMap A e.1.2
+                (localIncidentMatrixOp A (edgeRightIncident (G := G3) e) M c) := by
+  intro h
+  -- Apply the universally-quantified statement to our witness.
+  have hEq : ∀ σ : V3 → Fin 2,
+      (∑ β : EdgeBoundaryConfig (G := G3) A3 e3,
+        (LinearMap.id : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ))
+            (A3.component e3.1.1 (edgeLeftLocalConfig (G := G3) A3 e3 β)) (σ e3.1.1) *
+          edgeOpenMiddleWeight (G := G3) A3 e3 σ β.leftResidual β.rightResidual *
+          A3.component e3.1.2 (edgeRightLocalConfig (G := G3) A3 e3 β) (σ e3.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := G3) A3 e3,
+          A3.component e3.1.1 (edgeLeftLocalConfig (G := G3) A3 e3 β) (σ e3.1.1) *
+            edgeOpenMiddleWeight (G := G3) A3 e3 σ β.leftResidual β.rightResidual *
+            O2bad (A3.component e3.1.2 (edgeRightLocalConfig (G := G3) A3 e3 β)) (σ e3.1.2) := by
+    intro σ
+    -- both sums are over an empty index type
+    rw [Finset.univ_eq_empty, Finset.sum_empty, Finset.sum_empty]
+  obtain ⟨M, _, hRight⟩ :=
+    h A3 e3 A3_edgeBlockedThreeSiteInjective LinearMap.id O2bad hEq
+  -- specialize the right conclusion at the single basis config; e3.1.2 = 1 definitionally
+  have hRight' : ∀ c : LocalVirtualConfig A3 (1 : V3) → ℂ,
+      O2bad (localTensorMap A3 (1 : V3) c) =
+        localTensorMap A3 (1 : V3)
+          (localIncidentMatrixOp A3 (edgeRightIncident (G := G3) e3) M c) := hRight
+  have hr := hRight' (Pi.single η₀ (1 : ℂ))
+  rw [localTensorMap_one_single] at hr
+  -- evaluate both sides at coordinate 1
+  have h1 := congrFun hr 1
+  rw [O2bad_apply_e0] at h1
+  rw [localTensorMap_one_apply_one] at h1
+  -- now h1 : (![0,1] : Fin 2 → ℂ) 1 = 0, i.e. 1 = 0
+  simp at h1
+
+/-- The type of the original `physical_to_virtual_insertion` statement, generic
+over the graph, vertex set, and physical dimension. This is a verbatim copy of
+the signature of `TNLean.PEPS.physical_to_virtual_insertion`. -/
+def PhysicalToVirtualInsertionStatement : Prop :=
+  ∀ {V : Type} [Fintype V] [LinearOrder V] {G : SimpleGraph V} [DecidableRel G.Adj]
+    {d : ℕ} (A : Tensor G d) (e : Edge G)
+    (_ : EdgeBlockedThreeSiteInjective (G := G) A e)
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (_ : ∀ σ : V → Fin d,
+      (∑ β : EdgeBoundaryConfig (G := G) A e,
+        O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2)),
+    ∃ M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ,
+      (∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+        O₁ (localTensorMap A e.1.1 c) =
+          localTensorMap A e.1.1
+            (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose c)) ∧
+        ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+          O₂ (localTensorMap A e.1.2 c) =
+            localTensorMap A e.1.2
+              (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c)
+
+/-- The original `physical_to_virtual_insertion` statement is FALSE as written:
+no proof of its signature can exist, because our explicit witness
+`(G3, A3, e3, id, O2bad)` satisfies all of its hypotheses yet refutes its
+conclusion. -/
+theorem PhysicalToVirtualInsertionStatement_false :
+    ¬ PhysicalToVirtualInsertionStatement := by
+  intro hThm
+  -- Build the resonate hypothesis at our witness (both sides empty sums).
+  have hEq : ∀ σ : V3 → Fin 2,
+      (∑ β : EdgeBoundaryConfig (G := G3) A3 e3,
+        (LinearMap.id : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ))
+            (A3.component e3.1.1 (edgeLeftLocalConfig (G := G3) A3 e3 β)) (σ e3.1.1) *
+          edgeOpenMiddleWeight (G := G3) A3 e3 σ β.leftResidual β.rightResidual *
+          A3.component e3.1.2 (edgeRightLocalConfig (G := G3) A3 e3 β) (σ e3.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := G3) A3 e3,
+          A3.component e3.1.1 (edgeLeftLocalConfig (G := G3) A3 e3 β) (σ e3.1.1) *
+            edgeOpenMiddleWeight (G := G3) A3 e3 σ β.leftResidual β.rightResidual *
+            O2bad (A3.component e3.1.2 (edgeRightLocalConfig (G := G3) A3 e3 β)) (σ e3.1.2) := by
+    intro σ
+    rw [Finset.univ_eq_empty, Finset.sum_empty, Finset.sum_empty]
+  obtain ⟨M, _, hRight⟩ :=
+    hThm A3 e3 A3_edgeBlockedThreeSiteInjective LinearMap.id O2bad hEq
+  have hRight' : ∀ c : LocalVirtualConfig A3 (1 : V3) → ℂ,
+      O2bad (localTensorMap A3 (1 : V3) c) =
+        localTensorMap A3 (1 : V3)
+          (localIncidentMatrixOp A3 (edgeRightIncident (G := G3) e3) M c) := hRight
+  have hr := hRight' (Pi.single η₀ (1 : ℂ))
+  rw [localTensorMap_one_single] at hr
+  have h1 := congrFun hr 1
+  rw [O2bad_apply_e0] at h1
+  rw [localTensorMap_one_apply_one] at h1
+  simp at h1
+
+end PhysicalToVirtualCounterexample
+end PEPS
+end TNLean

--- a/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
+++ b/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
@@ -17,10 +17,12 @@ instance of the hypothesis-free statement;
 `physical_to_virtual_insertion` itself carries the restored hypothesis that
 every bond dimension is positive.
 
-Source: the positive-bond assumption is the standing assumption of
-arXiv:1804.04964 that injective PEPS have nonzero-dimensional virtual bond
-spaces. The same missing hypothesis was identified for the edge-blocked
-three-site injectivity (issue #1366).
+Source: arXiv:1804.04964, local source `paper_normal.tex`, lines 250 and
+254--255: the recovery lemma is stated for injective three-site tensor networks
+with a vector space assigned to the edge. The positivity hypothesis makes this
+nonzero virtual edge space explicit in the formal statement. The same missing
+hypothesis was identified for the edge-blocked three-site injectivity
+(issue #1366).
 -/
 
 namespace TNLean
@@ -211,7 +213,8 @@ theorem local_tensor_map_one_single :
 
 /-- The type of the original `physical_to_virtual_insertion` statement, generic
 over the graph, vertex set, and physical dimension. This is a concrete finite
-vertex-set instance of the signature of `TNLean.PEPS.physical_to_virtual_insertion`. -/
+vertex-set instance of the signature of
+`TNLean.PEPS.physical_to_virtual_insertion`. -/
 def physicalToVirtualInsertionStatement : Prop :=
   ∀ {V : Type} [Fintype V] [LinearOrder V] {G : SimpleGraph V} [DecidableRel G.Adj]
     {d : ℕ} (A : Tensor G d) (e : Edge G)

--- a/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
+++ b/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
@@ -12,8 +12,8 @@ right-endpoint operator.
 
 The explicit witness is the graph on three vertices with the distinguished edge
 of bond dimension one and a second edge of bond dimension zero at the left
-endpoint. `physical_to_virtual_insertion_statement_false` refutes the universe-0
-specialization of the hypothesis-free statement;
+endpoint. `physical_to_virtual_insertion_statement_false` refutes a concrete
+instance of the hypothesis-free statement;
 `physical_to_virtual_insertion` itself carries the restored hypothesis that
 every bond dimension is positive.
 
@@ -210,8 +210,8 @@ theorem local_tensor_map_one_single :
 /-! ### The scope refutation -/
 
 /-- The type of the original `physical_to_virtual_insertion` statement, generic
-over the graph, vertex set, and physical dimension. This is the universe-0
-specialization of the signature of `TNLean.PEPS.physical_to_virtual_insertion`. -/
+over the graph, vertex set, and physical dimension. This is a concrete finite
+vertex-set instance of the signature of `TNLean.PEPS.physical_to_virtual_insertion`. -/
 def physicalToVirtualInsertionStatement : Prop :=
   ∀ {V : Type} [Fintype V] [LinearOrder V] {G : SimpleGraph V} [DecidableRel G.Adj]
     {d : ℕ} (A : Tensor G d) (e : Edge G)

--- a/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
+++ b/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
@@ -29,14 +29,14 @@ namespace PhysicalToVirtualCounterexample
 
 open scoped BigOperators
 
-abbrev v3 := Fin 3
+abbrev V3 := Fin 3
 
-def adj3 (a b : v3) : Prop :=
+def adj3 (a b : V3) : Prop :=
   (a = 0 ∧ b = 1) ∨ (a = 1 ∧ b = 0) ∨ (a = 0 ∧ b = 2) ∨ (a = 2 ∧ b = 0)
 
 instance : DecidableRel adj3 := by unfold adj3; infer_instance
 
-def g3 : SimpleGraph v3 where
+def g3 : SimpleGraph V3 where
   Adj := adj3
   symm := by
     intro a b h
@@ -72,21 +72,21 @@ def a3 : Tensor g3 2 where
 theorem a3_bond_dim_e3 : a3.bondDim e3 = 1 := bd_e3
 theorem a3_bond_dim_f3 : a3.bondDim f3 = 0 := bd_f3
 
-theorem e3_left : e3.1.1 = (0 : v3) := rfl
-theorem e3_right : e3.1.2 = (1 : v3) := rfl
+theorem e3_left : e3.1.1 = (0 : V3) := rfl
+theorem e3_right : e3.1.2 = (1 : V3) := rfl
 
 /-- f3 as an incident edge of vertex 0. -/
-def f3incident : IncidentEdge g3 (0 : v3) := ⟨f3, Or.inl rfl⟩
+def f3incident : IncidentEdge g3 (0 : V3) := ⟨f3, Or.inl rfl⟩
 
 /-- Left endpoint local config is empty (incident edge f3 has bond 0). -/
-instance : IsEmpty (LocalVirtualConfig a3 (0 : v3)) := by
+instance : IsEmpty (LocalVirtualConfig a3 (0 : V3)) := by
   refine ⟨fun c => ?_⟩
   have h := c f3incident
   rw [show a3.bondDim f3incident.1 = 0 from a3_bond_dim_f3] at h
   exact h.elim0
 
 /-- f3 is an other-incident edge of vertex 0 relative to the distinguished edge. -/
-def f3other : OtherIncidentEdge (G := g3) (0 : v3) (edgeLeftIncident (G := g3) e3) :=
+def f3other : OtherIncidentEdge (G := g3) (0 : V3) (edgeLeftIncident (G := g3) e3) :=
   ⟨f3incident, by decide⟩
 
 /-- Left residual config is empty (it includes the f3-coordinate of bond 0). -/
@@ -101,17 +101,17 @@ instance : IsEmpty (EdgeMiddleBoundaryLabel (G := g3) a3 e3) :=
   Prod.isEmpty_left
 
 /-- The only incident edge of vertex 1 is the distinguished edge e3. -/
-theorem incident_one_eq (ie : IncidentEdge g3 (1 : v3)) : ie.1 = e3 := by
+theorem incident_one_eq (ie : IncidentEdge g3 (1 : V3)) : ie.1 = e3 := by
   revert ie; decide
 
 /-- Every incident-edge bond at vertex 1 has dimension 1. -/
-theorem bond_dim_incident_one (ie : IncidentEdge g3 (1 : v3)) :
+theorem bond_dim_incident_one (ie : IncidentEdge g3 (1 : V3)) :
     a3.bondDim ie.1 = 1 := by
   rw [incident_one_eq ie]; exact a3_bond_dim_e3
 
 /-- The right endpoint local config type has exactly one element. -/
 theorem right_config_unique :
-    ∀ a b : LocalVirtualConfig a3 (1 : v3), a = b := by
+    ∀ a b : LocalVirtualConfig a3 (1 : V3), a = b := by
   intro a b
   funext ie
   have h1 : a3.bondDim ie.1 = 1 := bond_dim_incident_one ie
@@ -119,14 +119,14 @@ theorem right_config_unique :
   apply Subsingleton.elim
 
 /-- `a3.component 1 η = ![1,0]` for every (the unique) config `η`. -/
-theorem a3_component_one (η : LocalVirtualConfig a3 (1 : v3)) :
-    a3.component (1 : v3) η = ![1, 0] := rfl
+theorem a3_component_one (η : LocalVirtualConfig a3 (1 : V3)) :
+    a3.component (1 : V3) η = ![1, 0] := rfl
 
 /-- The right endpoint local tensor map applied to `c` evaluated at index 0
 recovers `c` at the unique config. -/
-theorem local_tensor_map_one_apply_zero (c : LocalVirtualConfig a3 (1 : v3) → ℂ)
-    (η₀ : LocalVirtualConfig a3 (1 : v3)) :
-    localTensorMap a3 (1 : v3) c 0 = c η₀ := by
+theorem local_tensor_map_one_apply_zero (c : LocalVirtualConfig a3 (1 : V3) → ℂ)
+    (η₀ : LocalVirtualConfig a3 (1 : V3)) :
+    localTensorMap a3 (1 : V3) c 0 = c η₀ := by
   classical
   simp only [localTensorMap, Fintype.linearCombination_apply]
   rw [Finset.sum_apply]
@@ -138,7 +138,7 @@ theorem local_tensor_map_one_apply_zero (c : LocalVirtualConfig a3 (1 : v3) → 
   · intro h; exact absurd (Finset.mem_univ η₀) h
 
 /-- Right endpoint local tensor map is injective. -/
-theorem right_injective : Function.Injective (localTensorMap a3 (1 : v3)) := by
+theorem right_injective : Function.Injective (localTensorMap a3 (1 : V3)) := by
   intro c c' h
   funext η
   have h0 := congrFun h 0
@@ -146,7 +146,7 @@ theorem right_injective : Function.Injective (localTensorMap a3 (1 : v3)) := by
   exact h0
 
 /-- Left endpoint local tensor map is injective (its domain is empty). -/
-theorem left_injective : Function.Injective (localTensorMap a3 (0 : v3)) := by
+theorem left_injective : Function.Injective (localTensorMap a3 (0 : V3)) := by
   intro c c' _
   funext η
   exact (IsEmpty.false η).elim
@@ -159,11 +159,11 @@ theorem middle_injective : EdgeMiddleTensorInjective (G := g3) a3 e3 :=
 theorem a3_edge_blocked_three_site_injective :
     EdgeBlockedThreeSiteInjective (G := g3) a3 e3 :=
   { left_injective := by
-      have : e3.1.1 = (0 : v3) := e3_left
+      have : e3.1.1 = (0 : V3) := e3_left
       rw [this]; exact left_injective
     middle_injective := middle_injective
     right_injective := by
-      have : e3.1.2 = (1 : v3) := e3_right
+      have : e3.1.2 = (1 : V3) := e3_right
       rw [this]; exact right_injective }
 
 /-- The ordinary edge-boundary configuration type is empty (its left residual
@@ -184,8 +184,8 @@ theorem o2bad_apply_e0 : o2bad (![1, 0] : Fin 2 → ℂ) = ![0, 1] := by
 
 /-- Everything in the image of the right endpoint local tensor map has a zero in
 coordinate 1 (the image lies in the span of `![1,0]`). -/
-theorem local_tensor_map_one_apply_one (w : LocalVirtualConfig a3 (1 : v3) → ℂ) :
-    localTensorMap a3 (1 : v3) w 1 = 0 := by
+theorem local_tensor_map_one_apply_one (w : LocalVirtualConfig a3 (1 : V3) → ℂ) :
+    localTensorMap a3 (1 : V3) w 1 = 0 := by
   classical
   simp only [localTensorMap, Fintype.linearCombination_apply]
   rw [Finset.sum_apply]
@@ -195,15 +195,15 @@ theorem local_tensor_map_one_apply_one (w : LocalVirtualConfig a3 (1 : v3) → �
 
 /-- The right endpoint local config type is inhabited (assign 0 to every
 incident-edge bond, each of which has dimension 1). -/
-instance : Inhabited (LocalVirtualConfig a3 (1 : v3)) :=
+instance : Inhabited (LocalVirtualConfig a3 (1 : V3)) :=
   ⟨fun ie => ⟨0, by rw [bond_dim_incident_one ie]; exact Nat.one_pos⟩⟩
 
 /-- The unique right-endpoint config. -/
-def η₀ : LocalVirtualConfig a3 (1 : v3) := default
+def η₀ : LocalVirtualConfig a3 (1 : V3) := default
 
 /-- The right endpoint local tensor map sends the single basis vector to `![1,0]`. -/
 theorem local_tensor_map_one_single :
-    localTensorMap a3 (1 : v3) (Pi.single η₀ (1 : ℂ)) = ![1, 0] := by
+    localTensorMap a3 (1 : V3) (Pi.single η₀ (1 : ℂ)) = ![1, 0] := by
   rw [localTensorMap_apply_single]
   exact a3_component_one η₀
 
@@ -244,7 +244,7 @@ theorem physical_to_virtual_insertion_statement_false :
     ¬ physicalToVirtualInsertionStatement := by
   intro hThm
   -- Build the resonate hypothesis at our witness (both sides empty sums).
-  have hEq : ∀ σ : v3 → Fin 2,
+  have hEq : ∀ σ : V3 → Fin 2,
       (∑ β : EdgeBoundaryConfig (G := g3) a3 e3,
         (LinearMap.id : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ))
             (a3.component e3.1.1 (edgeLeftLocalConfig (G := g3) a3 e3 β)) (σ e3.1.1) *
@@ -258,9 +258,9 @@ theorem physical_to_virtual_insertion_statement_false :
     rw [Finset.univ_eq_empty, Finset.sum_empty, Finset.sum_empty]
   obtain ⟨M, _, hRight⟩ :=
     hThm a3 e3 a3_edge_blocked_three_site_injective LinearMap.id o2bad hEq
-  have hRight' : ∀ c : LocalVirtualConfig a3 (1 : v3) → ℂ,
-      o2bad (localTensorMap a3 (1 : v3) c) =
-        localTensorMap a3 (1 : v3)
+  have hRight' : ∀ c : LocalVirtualConfig a3 (1 : V3) → ℂ,
+      o2bad (localTensorMap a3 (1 : V3) c) =
+        localTensorMap a3 (1 : V3)
           (localIncidentMatrixOp a3 (edgeRightIncident (G := g3) e3) M c) := hRight
   have hr := hRight' (Pi.single η₀ (1 : ℂ))
   rw [local_tensor_map_one_single] at hr

--- a/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
+++ b/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
@@ -12,9 +12,10 @@ right-endpoint operator.
 
 The explicit witness is the graph on three vertices with the distinguished edge
 of bond dimension one and a second edge of bond dimension zero at the left
-endpoint. `PhysicalToVirtualInsertionStatement_false` refutes a verbatim copy of
-the hypothesis-free statement; `physical_to_virtual_insertion` itself carries the
-restored hypothesis that every bond dimension is positive.
+endpoint. `PhysicalToVirtualInsertionStatement_false` refutes the universe-0
+specialization of the hypothesis-free statement;
+`physical_to_virtual_insertion` itself carries the restored hypothesis that
+every bond dimension is positive.
 
 Source: the positive-bond assumption is the standing assumption of
 arXiv:1804.04964 that injective PEPS have nonzero-dimensional virtual bond
@@ -208,68 +209,9 @@ theorem localTensorMap_one_single :
 
 /-! ### The scope refutation -/
 
-/-- `physical_to_virtual_insertion` is FALSE as stated, i.e. without a
-positive-bond (or nonempty-boundary / vertex-injectivity) hypothesis: there is a
-tensor `A3`, a distinguished edge `e3`, physical operators `O₁ = id`,
-`O₂ = O2bad`, with `EdgeBlockedThreeSiteInjective A3 e3` and the resonate
-equation `hEq` holding, yet NO matrix `M` on the shared bond realizes the
-endpoint conclusion. -/
-theorem physical_to_virtual_insertion_false :
-    ¬ ∀ (A : Tensor G3 2) (e : Edge G3)
-        (_ : EdgeBlockedThreeSiteInjective (G := G3) A e)
-        (O₁ O₂ : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ))
-        (_ : ∀ σ : V3 → Fin 2,
-          (∑ β : EdgeBoundaryConfig (G := G3) A e,
-            O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G3) A e β)) (σ e.1.1) *
-              edgeOpenMiddleWeight (G := G3) A e σ β.leftResidual β.rightResidual *
-              A.component e.1.2 (edgeRightLocalConfig (G := G3) A e β) (σ e.1.2)) =
-            ∑ β : EdgeBoundaryConfig (G := G3) A e,
-              A.component e.1.1 (edgeLeftLocalConfig (G := G3) A e β) (σ e.1.1) *
-                edgeOpenMiddleWeight (G := G3) A e σ β.leftResidual β.rightResidual *
-                O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G3) A e β)) (σ e.1.2)),
-      ∃ M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ,
-        (∀ c : LocalVirtualConfig A e.1.1 → ℂ,
-          O₁ (localTensorMap A e.1.1 c) =
-            localTensorMap A e.1.1
-              (localIncidentMatrixOp A (edgeLeftIncident (G := G3) e) M.transpose c)) ∧
-          ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
-            O₂ (localTensorMap A e.1.2 c) =
-              localTensorMap A e.1.2
-                (localIncidentMatrixOp A (edgeRightIncident (G := G3) e) M c) := by
-  intro h
-  -- Apply the universally-quantified statement to our witness.
-  have hEq : ∀ σ : V3 → Fin 2,
-      (∑ β : EdgeBoundaryConfig (G := G3) A3 e3,
-        (LinearMap.id : (Fin 2 → ℂ) →ₗ[ℂ] (Fin 2 → ℂ))
-            (A3.component e3.1.1 (edgeLeftLocalConfig (G := G3) A3 e3 β)) (σ e3.1.1) *
-          edgeOpenMiddleWeight (G := G3) A3 e3 σ β.leftResidual β.rightResidual *
-          A3.component e3.1.2 (edgeRightLocalConfig (G := G3) A3 e3 β) (σ e3.1.2)) =
-        ∑ β : EdgeBoundaryConfig (G := G3) A3 e3,
-          A3.component e3.1.1 (edgeLeftLocalConfig (G := G3) A3 e3 β) (σ e3.1.1) *
-            edgeOpenMiddleWeight (G := G3) A3 e3 σ β.leftResidual β.rightResidual *
-            O2bad (A3.component e3.1.2 (edgeRightLocalConfig (G := G3) A3 e3 β)) (σ e3.1.2) := by
-    intro σ
-    -- both sums are over an empty index type
-    rw [Finset.univ_eq_empty, Finset.sum_empty, Finset.sum_empty]
-  obtain ⟨M, _, hRight⟩ :=
-    h A3 e3 A3_edgeBlockedThreeSiteInjective LinearMap.id O2bad hEq
-  -- specialize the right conclusion at the single basis config; e3.1.2 = 1 definitionally
-  have hRight' : ∀ c : LocalVirtualConfig A3 (1 : V3) → ℂ,
-      O2bad (localTensorMap A3 (1 : V3) c) =
-        localTensorMap A3 (1 : V3)
-          (localIncidentMatrixOp A3 (edgeRightIncident (G := G3) e3) M c) := hRight
-  have hr := hRight' (Pi.single η₀ (1 : ℂ))
-  rw [localTensorMap_one_single] at hr
-  -- evaluate both sides at coordinate 1
-  have h1 := congrFun hr 1
-  rw [O2bad_apply_e0] at h1
-  rw [localTensorMap_one_apply_one] at h1
-  -- now h1 : (![0,1] : Fin 2 → ℂ) 1 = 0, i.e. 1 = 0
-  simp at h1
-
 /-- The type of the original `physical_to_virtual_insertion` statement, generic
-over the graph, vertex set, and physical dimension. This is a verbatim copy of
-the signature of `TNLean.PEPS.physical_to_virtual_insertion`. -/
+over the graph, vertex set, and physical dimension. This is the universe-0
+specialization of the signature of `TNLean.PEPS.physical_to_virtual_insertion`. -/
 def PhysicalToVirtualInsertionStatement : Prop :=
   ∀ {V : Type} [Fintype V] [LinearOrder V] {G : SimpleGraph V} [DecidableRel G.Adj]
     {d : ℕ} (A : Tensor G d) (e : Edge G)

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1733,10 +1733,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
         def:peps_edgeLeftLocalConfig, def:peps_edgeRightLocalConfig,
         def:peps_edgeOpenMiddleWeight, def:peps_localTensorMap,
         def:peps_localIncidentMatrixOp}
-    Let $e=(u,v)$. Assume that the edge-blocked three-site chain at $e$ is
-    injective. Let $O_1,O_2$ be physical operators at the endpoint tensors, and
-    write $\Phi_u,\Phi_v$ for the two local tensor maps. Suppose that, for every
-    physical configuration $\sigma$,
+    Let $e=(u,v)$. Assume that every virtual bond has positive dimension and
+    that the edge-blocked three-site chain at $e$ is injective. Let $O_1,O_2$
+    be physical operators at the endpoint tensors, and write $\Phi_u,\Phi_v$
+    for the two local tensor maps. Suppose that, for every physical
+    configuration $\sigma$,
     \[
         \sum_{\beta}
         O_1(A_u(\beta_u))_{\sigma_u}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -262,7 +262,7 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   resonate hypothesis holds vacuously while the recovery conclusion stays a
   genuine constraint that fails for a nontrivial right-endpoint operator. The
   checked counterexample is
-  \leanid{TNLean.PEPS.PhysicalToVirtualCounterexample.PhysicalToVirtualInsertionStatement_false},
+  \leanid{TNLean.PEPS.PhysicalToVirtualCounterexample.physical_to_virtual_insertion_statement_false},
   and the hypothesis $\forall f,\ 0<\dim(f)$ has been restored on
   \leanid{TNLean.PEPS.physical_to_virtual_insertion}. The remaining proof needs,
   in addition, the local realization engine to be parametrized by endpoint

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -264,7 +264,13 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   checked counterexample is
   \leanid{TNLean.PEPS.PhysicalToVirtualCounterexample.physical_to_virtual_insertion_statement_false},
   and the hypothesis $\forall f,\ 0<\dim(f)$ has been restored on
-  \leanid{TNLean.PEPS.physical_to_virtual_insertion}. The remaining proof needs,
+  \leanid{TNLean.PEPS.physical_to_virtual_insertion}. This is a local
+  correction: the source recovery lemma is stated for injective three-site
+  tensor networks with a vector space assigned to the edge
+  \path{Papers/1804.04964/paper_normal.tex:250,254--255}, while the formal
+  statement also admits the degenerate case $\dim(f)=0$. Requiring
+  $0<\dim(f)$ makes the source's nonzero virtual edge space explicit. The
+  remaining proof needs,
   in addition, the local realization engine to be parametrized by endpoint
   injectivity (available from
   \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective}) rather than global vertex

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -256,7 +256,20 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   because the ordinary boundary supplies the right bond index. The source
   recovery $O_1,O_2\mapsto W$ is stated as
   \leanid{TNLean.PEPS.physical_to_virtual_insertion}; its proof remains open and
-  is tracked by issue~\#1370.
+  is tracked by issue~\#1370. As for the middle-block injectivity, this
+  statement is false without a positive-bond hypothesis: a zero-dimensional edge
+  incident to an endpoint empties the edge boundary configuration, so the
+  resonate hypothesis holds vacuously while the recovery conclusion stays a
+  genuine constraint that fails for a nontrivial right-endpoint operator. The
+  checked counterexample is
+  \leanid{TNLean.PEPS.PhysicalToVirtualCounterexample.PhysicalToVirtualInsertionStatement_false},
+  and the hypothesis $\forall f,\ 0<\dim(f)$ has been restored on
+  \leanid{TNLean.PEPS.physical_to_virtual_insertion}. The remaining proof needs,
+  in addition, the local realization engine to be parametrized by endpoint
+  injectivity (available from
+  \leanid{TNLean.PEPS.EdgeBlockedThreeSiteInjective}) rather than global vertex
+  injectivity, and a one-sided inverse for the right-endpoint-plus-middle
+  contraction that extracts the recovered matrix.
   Its local endpoint recovery component is now formalized by
   \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}:
   once the compressed endpoint actions are known to realize the same bond


### PR DESCRIPTION
## Summary

The second PEPS recovery step, `physical_to_virtual_insertion` (the O₁,O₂→W direction of Lemma `inj_isomorph`), is **false as written** — the same dropped-positivity defect found and fixed for `edgeBlockedThreeSiteInjective` (#1366, #2370), now one layer up.

## The defect (proved)

A zero-dimensional edge **incident to an endpoint** empties `EdgeBoundaryConfig`, so the resonate hypothesis `hEq` becomes `0 = 0` for any `O₁,O₂`, while the recovery conclusion (`∃ M, …`) stays a genuine constraint that fails for a nontrivial right-endpoint operator. Witness: the 3-vertex graph with distinguished edge `e=(0,1)` of bond dim 1 and a second edge `(0,2)` of bond dim 0; `O₁=id`, `O₂=` coordinate swap. `EdgeBlockedThreeSiteInjective` and `hEq` both hold (left endpoint vacuous, right genuine), but no `M` works.

## What lands

- **Checked counterexample** `TNLean/PEPS/PhysicalToVirtualCounterexample.lean`: `PhysicalToVirtualInsertionStatement_false` refutes a **verbatim copy** of the hypothesis-free signature. `#print axioms` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.
- **Faithful restatement**: `∀ f, 0 < A.bondDim f` restored on `physical_to_virtual_insertion`. No non-sorry callers, so zero propagation.
- Paper-gap note updated.

## Verification

`lake env lean` on both files: exit 0; `InsertionRealization.lean` keeps only its target `sorry`, the counterexample is sorry-free and axiom-clean.

The theorem keeps its `sorry` (corrected statement). The remaining proof additionally needs the realization engine parametrized by endpoint injectivity (the engine currently demands global `IsVertexInjective`, which `EdgeBlockedThreeSiteInjective` does not supply) plus a right+middle contraction-inverse to extract `M`. Refs #1370.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and statement correction on an exploratory PEPS track; the main theorem remains `sorry` and the PR reports no downstream caller updates.
> 
> **Overview**
> Proves **`physical_to_virtual_insertion`** was **false without positive bond dimensions** (same degeneracy pattern as edge-blocked three-site injectivity in #1366), then **restores** `∀ f, 0 < A.bondDim f` on the open `sorry` theorem.
> 
> Adds **`TNLean/PEPS/PhysicalToVirtualCounterexample.lean`**: a 3-vertex PEPS with a zero bond at the left endpoint so `EdgeBoundaryConfig` is empty (resonate sums vacuous) but a coordinate-swap `O₂` still cannot be realized as virtual insertion on the right; **`physical_to_virtual_insertion_statement_false`** refutes the old signature. Wires the module in **`TNLean.lean`**, expands docstrings in **`InsertionRealization.lean`**, and aligns the **blueprint** theorem and **`docs/paper-gaps/peps_injective_ft_section3_route.tex`** with the positivity hypothesis and counterexample reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb7284ebf3e1da096dd76d775b050f2a2cfe9e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->