### PR TITLE
refactor(peps): parametrize the realization engine by per-vertex injectivity (#1370)

### DIFF
--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -131,7 +131,7 @@ This is the per-endpoint form of
 only `LinearIndependent ℂ (A.component e.1.1)`, the fact that
 `EdgeBlockedThreeSiteInjective` already supplies via
 `EdgeBlockedThreeSiteInjective.endpoint_linearIndependent`. -/
-theorem edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eqAt
+theorem edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq_at
     (A : Tensor G d) (e : Edge G)
     (hu : LinearIndependent ℂ (A.component e.1.1))
     (O₁ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
@@ -152,7 +152,7 @@ This is the per-endpoint form of
 requires only `LinearIndependent ℂ (A.component e.1.2)`, the fact that
 `EdgeBlockedThreeSiteInjective` already supplies via
 `EdgeBlockedThreeSiteInjective.endpoint_linearIndependent`. -/
-theorem edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eqAt
+theorem edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq_at
     (A : Tensor G d) (e : Edge G)
     (hv : LinearIndependent ℂ (A.component e.1.2))
     (O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
@@ -262,7 +262,7 @@ three-site injectivity hypothesis of `physical_to_virtual_insertion`.
 
 Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 363--486
 of the local paper source. -/
-theorem edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eqAt
+theorem edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq_at
     (A : Tensor G d) (e : Edge G)
     (hu : LinearIndependent ℂ (A.component e.1.1))
     (hv : LinearIndependent ℂ (A.component e.1.2))
@@ -279,9 +279,9 @@ theorem edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eqAt
       localVirtualOpOfPhysicalOpAt A hv O₂ =
         localIncidentMatrixOp A (edgeRightIncident (G := G) e) M := by
   constructor
-  · exact (edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eqAt
+  · exact (edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq_at
       A e hu O₁ M).2 hO₁
-  · exact (edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eqAt
+  · exact (edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq_at
       A e hv O₂ M).2 hO₂
 
 /-- Projected endpoint realizations of a common bond matrix give the endpoint
@@ -300,7 +300,7 @@ actions on the edge-blocked state.
 
 Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 363--486
 of the local paper source. -/
-theorem edgePhysicalToVirtualInsertion_of_endpointInjective
+theorem edgePhysicalToVirtualInsertion_of_endpoint_injective
     (A : Tensor G d) (e : Edge G)
     (hu : LinearIndependent ℂ (A.component e.1.1))
     (hv : LinearIndependent ℂ (A.component e.1.2))
@@ -327,7 +327,7 @@ theorem edgePhysicalToVirtualInsertion_of_endpointInjective
           localTensorMap A e.1.2
             (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c) := by
   obtain ⟨hLeft, hRight⟩ :=
-    edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eqAt
+    edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq_at
       A e hu hv O₁ O₂ M hO₁ hO₂
   constructor
   · intro c

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -293,8 +293,8 @@ This is the endpoint-injective form of
 endpoint linear-independence facts (the pair supplied by
 `EdgeBlockedThreeSiteInjective.endpoint_linearIndependent`) instead of the global
 `IsVertexInjective` hypothesis. The conclusion is exactly the per-`M` body of the
-existential in `physical_to_virtual_insertion`, so wiring that source theorem
-through this lemma reduces it to supplying the common matrix, the projected
+existential in `physical_to_virtual_insertion`, so using this lemma to apply that
+source theorem reduces it to supplying the common matrix, the projected
 realizations, and image preservation from equality of the two endpoint physical
 actions on the edge-blocked state.
 

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -43,6 +43,20 @@ namespace PEPS
 variable {V : Type*} [Fintype V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 
+/-- The edge-blocked three-site injectivity hypothesis already carries linear
+independence of the tensor families at the two endpoints of the chosen edge.
+
+The endpoint fields `left_injective`/`right_injective` are injectivity of the
+local tensor maps `localTensorMap A e.1.1`/`localTensorMap A e.1.2`, which equal
+the `Fintype.linearCombination` of the endpoint component families. Injectivity
+of that linear combination is exactly linear independence of the family. -/
+theorem EdgeBlockedThreeSiteInjective.endpoint_linearIndependent {A : Tensor G d}
+    {e : Edge G} (hA : EdgeBlockedThreeSiteInjective (G := G) A e) :
+    LinearIndependent ℂ (A.component e.1.1) ∧
+      LinearIndependent ℂ (A.component e.1.2) :=
+  ⟨linearIndependent_iff_injective_fintypeLinearCombination.2 hA.left_injective,
+    linearIndependent_iff_injective_fintypeLinearCombination.2 hA.right_injective⟩
+
 /-- A virtual matrix inserted on an edge is physically realizable on either
 neighboring endpoint tensor, provided the PEPS tensor is vertex-injective.
 
@@ -107,6 +121,48 @@ theorem edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
         physRealizeLocalOp A hA e.1.2
           (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M) :=
   localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq A hA e.1.2 O₂
+    (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M)
+
+/-- Projected recovery at the left endpoint of an edge, under linear
+independence of the tensor family at that single endpoint.
+
+This is the per-endpoint form of
+`edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq`: it requires
+only `LinearIndependent ℂ (A.component e.1.1)`, the fact that
+`EdgeBlockedThreeSiteInjective` already supplies via
+`EdgeBlockedThreeSiteInjective.endpoint_linearIndependent`. -/
+theorem edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eqAt
+    (A : Tensor G d) (e : Edge G)
+    (hu : LinearIndependent ℂ (A.component e.1.1))
+    (O₁ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    localVirtualOpOfPhysicalOpAt A hu O₁ =
+        localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose ↔
+      (localProjectorAt A hu).comp (O₁.comp (localProjectorAt A hu)) =
+        physRealizeLocalOpAt A hu
+          (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose) :=
+  localVirtualOpOfPhysicalOpAt_eq_iff_projected_realization_eq A hu O₁
+    (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose)
+
+/-- Projected recovery at the right endpoint of an edge, under linear
+independence of the tensor family at that single endpoint.
+
+This is the per-endpoint form of
+`edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq`: it
+requires only `LinearIndependent ℂ (A.component e.1.2)`, the fact that
+`EdgeBlockedThreeSiteInjective` already supplies via
+`EdgeBlockedThreeSiteInjective.endpoint_linearIndependent`. -/
+theorem edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eqAt
+    (A : Tensor G d) (e : Edge G)
+    (hv : LinearIndependent ℂ (A.component e.1.2))
+    (O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    localVirtualOpOfPhysicalOpAt A hv O₂ =
+        localIncidentMatrixOp A (edgeRightIncident (G := G) e) M ↔
+      (localProjectorAt A hv).comp (O₂.comp (localProjectorAt A hv)) =
+        physRealizeLocalOpAt A hv
+          (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M) :=
+  localVirtualOpOfPhysicalOpAt_eq_iff_projected_realization_eq A hv O₂
     (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M)
 
 /-- Projected endpoint physical realizations recover the corresponding virtual
@@ -190,6 +246,98 @@ theorem edgePhysicalToVirtualInsertion_of_projected_realization_eq
   · intro c
     have hrealize :=
       localVirtualOpOfPhysicalOp_realizes_of_projector A hA e.1.2 O₂ hO₂_image c
+    rw [hRight] at hrealize
+    exact hrealize.symm
+
+/-- Projected endpoint physical realizations recover the corresponding virtual
+matrix insertion on both endpoints, under linear independence at the two
+endpoints only.
+
+This is the endpoint-injective form of
+`edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq`: it takes
+the two endpoint linear-independence facts (the pair supplied by
+`EdgeBlockedThreeSiteInjective.endpoint_linearIndependent`) instead of the global
+`IsVertexInjective` hypothesis, so it applies directly under the edge-blocked
+three-site injectivity hypothesis of `physical_to_virtual_insertion`.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 363--486
+of the local paper source. -/
+theorem edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eqAt
+    (A : Tensor G d) (e : Edge G)
+    (hu : LinearIndependent ℂ (A.component e.1.1))
+    (hv : LinearIndependent ℂ (A.component e.1.2))
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (hO₁ : (localProjectorAt A hu).comp (O₁.comp (localProjectorAt A hu)) =
+      physRealizeLocalOpAt A hu
+        (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose))
+    (hO₂ : (localProjectorAt A hv).comp (O₂.comp (localProjectorAt A hv)) =
+      physRealizeLocalOpAt A hv
+        (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M)) :
+    localVirtualOpOfPhysicalOpAt A hu O₁ =
+        localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose ∧
+      localVirtualOpOfPhysicalOpAt A hv O₂ =
+        localIncidentMatrixOp A (edgeRightIncident (G := G) e) M := by
+  constructor
+  · exact (edgeLeftLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eqAt
+      A e hu O₁ M).2 hO₁
+  · exact (edgeRightLocalVirtualOpOfPhysicalOp_eq_iff_projected_realization_eqAt
+      A e hv O₂ M).2 hO₂
+
+/-- Projected endpoint realizations of a common bond matrix give the endpoint
+conclusion of physical-to-virtual insertion, under linear independence at the
+two endpoints only.
+
+This is the endpoint-injective form of
+`edgePhysicalToVirtualInsertion_of_projected_realization_eq`: it takes the two
+endpoint linear-independence facts (the pair supplied by
+`EdgeBlockedThreeSiteInjective.endpoint_linearIndependent`) instead of the global
+`IsVertexInjective` hypothesis. The conclusion is exactly the per-`M` body of the
+existential in `physical_to_virtual_insertion`, so wiring that source theorem
+through this lemma reduces it to supplying the common matrix, the projected
+realizations, and image preservation from equality of the two endpoint physical
+actions on the edge-blocked state.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 363--486
+of the local paper source. -/
+theorem edgePhysicalToVirtualInsertion_of_endpointInjective
+    (A : Tensor G d) (e : Edge G)
+    (hu : LinearIndependent ℂ (A.component e.1.1))
+    (hv : LinearIndependent ℂ (A.component e.1.2))
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (hO₁ : (localProjectorAt A hu).comp (O₁.comp (localProjectorAt A hu)) =
+      physRealizeLocalOpAt A hu
+        (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose))
+    (hO₂ : (localProjectorAt A hv).comp (O₂.comp (localProjectorAt A hv)) =
+      physRealizeLocalOpAt A hv
+        (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M))
+    (hO₁_image : ∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+      localProjectorAt A hu (O₁ (localTensorMap A e.1.1 c)) =
+        O₁ (localTensorMap A e.1.1 c))
+    (hO₂_image : ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+      localProjectorAt A hv (O₂ (localTensorMap A e.1.2 c)) =
+        O₂ (localTensorMap A e.1.2 c)) :
+    (∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+      O₁ (localTensorMap A e.1.1 c) =
+        localTensorMap A e.1.1
+          (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose c)) ∧
+      ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+        O₂ (localTensorMap A e.1.2 c) =
+          localTensorMap A e.1.2
+            (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c) := by
+  obtain ⟨hLeft, hRight⟩ :=
+    edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eqAt
+      A e hu hv O₁ O₂ M hO₁ hO₂
+  constructor
+  · intro c
+    have hrealize :=
+      localVirtualOpOfPhysicalOpAt_realizes_of_projector A hu O₁ hO₁_image c
+    rw [hLeft] at hrealize
+    exact hrealize.symm
+  · intro c
+    have hrealize :=
+      localVirtualOpOfPhysicalOpAt_realizes_of_projector A hv O₂ hO₂_image c
     rw [hRight] at hrealize
     exact hrealize.symm
 

--- a/TNLean/PEPS/LocalGauge.lean
+++ b/TNLean/PEPS/LocalGauge.lean
@@ -118,7 +118,7 @@ theorem localGaugeMap_apply_single (A B : Tensor G d)
       localProjector A hA v (B.component v (castLocalVirtualConfig A B hDim v η)) := by
   rw [localGaugeMap, LinearMap.comp_apply, LinearMap.comp_apply,
     localTensorMap_castLocalCoeffMap_single]
-  simp [localProjector, physRealizeLocalOp]
+  simp [localProjector, localProjectorAt, physRealizeLocalOpAt, localLeftInverse]
 
 /-- Sharper local hypothesis for PEPS gauge extraction.
 

--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -484,6 +484,8 @@ noncomputable def localVirtualOpOfPhysicalOp (A : Tensor G d)
     localProjector A hA v (A.component v η) = A.component v η :=
   localProjectorAt_apply_component A (hA v) η
 
+/-- The projection onto the image of the single-site tensor family is
+idempotent. -/
 theorem localProjectorAt_idempotent (A : Tensor G d) {v : V}
     (hv : LinearIndependent ℂ (A.component v)) :
     (localProjectorAt A hv).comp (localProjectorAt A hv) =

--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -120,36 +120,67 @@ abbrev localTensorMap (A : Tensor G d) (v : V) :
     localTensorMap A v (Pi.single η (1 : ℂ)) = A.component v η := by
   simp [localTensorMap, Fintype.linearCombination_apply_single]
 
+/-- Linear independence of the vertex tensor family makes the local tensor map
+at that vertex injective. This is the per-vertex form: it depends only on the
+single vertex `v`, not on the global `IsVertexInjective` hypothesis. -/
+theorem localTensorMap_injective_of_linearIndependent {A : Tensor G d} {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) :
+    Function.Injective (localTensorMap A v) :=
+  hv.fintypeLinearCombination_injective
+
+/-- Kernel form of `localTensorMap_injective_of_linearIndependent`. -/
+theorem localTensorMap_ker_eq_bot_of_linearIndependent {A : Tensor G d} {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) :
+    LinearMap.ker (localTensorMap A v) = ⊥ :=
+  LinearMap.ker_eq_bot.mpr <| localTensorMap_injective_of_linearIndependent hv
+
 /-- Vertex injectivity makes the local tensor map injective. -/
 theorem IsVertexInjective.localTensorMap_injective {A : Tensor G d}
     (hA : IsVertexInjective A) (v : V) :
     Function.Injective (localTensorMap A v) :=
-  (hA v).fintypeLinearCombination_injective
+  localTensorMap_injective_of_linearIndependent (hA v)
 
 /-- Kernel form of `IsVertexInjective.localTensorMap_injective`. -/
 theorem IsVertexInjective.localTensorMap_ker_eq_bot {A : Tensor G d}
     (hA : IsVertexInjective A) (v : V) :
     LinearMap.ker (localTensorMap A v) = ⊥ :=
-  LinearMap.ker_eq_bot.mpr <| hA.localTensorMap_injective v
+  localTensorMap_ker_eq_bot_of_linearIndependent (hA v)
+
+/-- A chosen left inverse of the local tensor map under per-vertex linear
+independence of the tensor family at `v`. -/
+noncomputable def localLeftInverseAt (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) :
+    (Fin d → ℂ) →ₗ[ℂ] (LocalVirtualConfig A v → ℂ) :=
+  ((localTensorMap A v).exists_leftInverse_of_injective
+    (localTensorMap_ker_eq_bot_of_linearIndependent hv)).choose
+
+@[simp] theorem localLeftInverseAt_comp_localTensorMap (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) :
+    (localLeftInverseAt A hv).comp (localTensorMap A v) = LinearMap.id :=
+  ((localTensorMap A v).exists_leftInverse_of_injective
+    (localTensorMap_ker_eq_bot_of_linearIndependent hv)).choose_spec
+
+@[simp] theorem localLeftInverseAt_apply_localTensorMap (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) (c : LocalVirtualConfig A v → ℂ) :
+    localLeftInverseAt A hv (localTensorMap A v c) = c := by
+  change ((localLeftInverseAt A hv).comp (localTensorMap A v)) c = c
+  rw [localLeftInverseAt_comp_localTensorMap]
+  rfl
 
 /-- A chosen left inverse of the local tensor map under vertex injectivity. -/
 noncomputable def localLeftInverse (A : Tensor G d) (hA : IsVertexInjective A)
     (v : V) : (Fin d → ℂ) →ₗ[ℂ] (LocalVirtualConfig A v → ℂ) :=
-  ((localTensorMap A v).exists_leftInverse_of_injective
-    (hA.localTensorMap_ker_eq_bot v)).choose
+  localLeftInverseAt A (hA v)
 
 @[simp] theorem localLeftInverse_comp_localTensorMap (A : Tensor G d)
     (hA : IsVertexInjective A) (v : V) :
     (localLeftInverse A hA v).comp (localTensorMap A v) = LinearMap.id :=
-  ((localTensorMap A v).exists_leftInverse_of_injective
-    (hA.localTensorMap_ker_eq_bot v)).choose_spec
+  localLeftInverseAt_comp_localTensorMap A (hA v)
 
 @[simp] theorem localLeftInverse_apply_localTensorMap (A : Tensor G d)
     (hA : IsVertexInjective A) (v : V) (c : LocalVirtualConfig A v → ℂ) :
-    localLeftInverse A hA v (localTensorMap A v c) = c := by
-  change ((localLeftInverse A hA v).comp (localTensorMap A v)) c = c
-  rw [localLeftInverse_comp_localTensorMap]
-  rfl
+    localLeftInverse A hA v (localTensorMap A v c) = c :=
+  localLeftInverseAt_apply_localTensorMap A (hA v) c
 
 /-- Endomorphisms of the local virtual coefficient space at a vertex. -/
 abbrev LocalVirtualOp (A : Tensor G d) (v : V) : Type _ :=
@@ -296,6 +327,25 @@ theorem localTensorMap_localIncidentMatrixOp_single (A : Tensor G d) {v : V}
   rw [localIncidentMatrixOp_single]
   simp [map_sum]
 
+/-- Physical realization of a local virtual endomorphism, under per-vertex
+linear independence of the tensor family at `v`.
+
+Since the local tensor map is injective, a virtual operator on the coefficient
+space extends to a physical linear map after choosing a left inverse. -/
+noncomputable def physRealizeLocalOpAt (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) (T : LocalVirtualOp A v) :
+    (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ) :=
+  (localTensorMap A v).comp <| T.comp (localLeftInverseAt A hv)
+
+/-- The physical realization agrees with the virtual operator on the image of
+`localTensorMap`. -/
+theorem physRealizeLocalOpAt_spec (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) (T : LocalVirtualOp A v)
+    (c : LocalVirtualConfig A v → ℂ) :
+    physRealizeLocalOpAt A hv T (localTensorMap A v c) =
+      localTensorMap A v (T c) := by
+  simp [physRealizeLocalOpAt]
+
 /-- Physical realization of a local virtual endomorphism.
 
 Since the local tensor map is injective, a virtual operator on the coefficient
@@ -303,15 +353,28 @@ space extends to a physical linear map after choosing a left inverse. -/
 noncomputable def physRealizeLocalOp (A : Tensor G d) (hA : IsVertexInjective A)
     (v : V) (T : LocalVirtualOp A v) :
     (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ) :=
-  (localTensorMap A v).comp <| T.comp (localLeftInverse A hA v)
+  physRealizeLocalOpAt A (hA v) T
 
 /-- The physical realization agrees with the virtual operator on the image of
 `localTensorMap`. -/
 theorem physRealizeLocalOp_spec (A : Tensor G d) (hA : IsVertexInjective A)
     (v : V) (T : LocalVirtualOp A v) (c : LocalVirtualConfig A v → ℂ) :
     physRealizeLocalOp A hA v T (localTensorMap A v c) =
-      localTensorMap A v (T c) := by
-  simp [physRealizeLocalOp]
+      localTensorMap A v (T c) :=
+  physRealizeLocalOpAt_spec A (hA v) T c
+
+/-- A matrix acting on one incident virtual edge is realized by a physical
+operator on the vertex tensor, under per-vertex linear independence of the
+tensor family at `v`. -/
+theorem localIncidentMatrixOp_physicalRealizationAt (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) (ie : IncidentEdge G v)
+    (M : Matrix (Fin (A.bondDim ie.1)) (Fin (A.bondDim ie.1)) ℂ) :
+    ∃ O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ),
+      ∀ c : LocalVirtualConfig A v → ℂ,
+        O (localTensorMap A v c) =
+          localTensorMap A v (localIncidentMatrixOp A ie M c) :=
+  ⟨physRealizeLocalOpAt A hv (localIncidentMatrixOp A ie M),
+    fun c => physRealizeLocalOpAt_spec A hv (localIncidentMatrixOp A ie M) c⟩
 
 /-- A matrix acting on one incident virtual edge is realized by a physical
 operator on the vertex tensor, under vertex injectivity. -/
@@ -322,21 +385,27 @@ theorem localIncidentMatrixOp_physicalRealization (A : Tensor G d)
       ∀ c : LocalVirtualConfig A v → ℂ,
         O (localTensorMap A v c) =
           localTensorMap A v (localIncidentMatrixOp A ie M c) :=
-  ⟨physRealizeLocalOp A hA v (localIncidentMatrixOp A ie M),
-    fun c => physRealizeLocalOp_spec A hA v (localIncidentMatrixOp A ie M) c⟩
+  localIncidentMatrixOp_physicalRealizationAt A (hA v) ie M
+
+/-- Realization is compatible with composition of virtual operators. -/
+theorem physRealizeLocalOpAt_comp (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) (S T : LocalVirtualOp A v) :
+    physRealizeLocalOpAt A hv (S.comp T) =
+      (physRealizeLocalOpAt A hv S).comp (physRealizeLocalOpAt A hv T) := by
+  ext x
+  simp [physRealizeLocalOpAt, LinearMap.comp_assoc]
 
 /-- Realization is compatible with composition of virtual operators. -/
 theorem physRealizeLocalOp_comp (A : Tensor G d) (hA : IsVertexInjective A)
     (v : V) (S T : LocalVirtualOp A v) :
     physRealizeLocalOp A hA v (S.comp T) =
-      (physRealizeLocalOp A hA v S).comp (physRealizeLocalOp A hA v T) := by
-  ext x
-  simp [physRealizeLocalOp, LinearMap.comp_assoc]
+      (physRealizeLocalOp A hA v S).comp (physRealizeLocalOp A hA v T) :=
+  physRealizeLocalOpAt_comp A (hA v) S T
 
 /-- Virtual operators are determined by their physical realizations. -/
-theorem physRealizeLocalOp_injective (A : Tensor G d) (hA : IsVertexInjective A)
-    (v : V) :
-    Function.Injective (physRealizeLocalOp A hA v) := by
+theorem physRealizeLocalOpAt_injective (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) :
+    Function.Injective (physRealizeLocalOpAt A hv) := by
   intro S T hST
   apply LinearMap.ext
   intro c
@@ -345,15 +414,41 @@ theorem physRealizeLocalOp_injective (A : Tensor G d) (hA : IsVertexInjective A)
   have hApply := congrArg (fun F : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ) =>
     F (localTensorMap A v c)) hST
   have hVirtual : localTensorMap A v (S c) = localTensorMap A v (T c) := by
-    simpa [physRealizeLocalOp_spec] using hApply
+    simpa [physRealizeLocalOpAt_spec] using hApply
   exact congrArg (fun f : LocalVirtualConfig A v → ℂ => f η)
-    (hA.localTensorMap_injective v hVirtual)
+    (localTensorMap_injective_of_linearIndependent hv hVirtual)
+
+/-- Virtual operators are determined by their physical realizations. -/
+theorem physRealizeLocalOp_injective (A : Tensor G d) (hA : IsVertexInjective A)
+    (v : V) :
+    Function.Injective (physRealizeLocalOp A hA v) :=
+  physRealizeLocalOpAt_injective A (hA v)
+
+/-- The virtual identity realizes a projection onto the image of the local
+tensor map, under per-vertex linear independence of the tensor family at `v`. -/
+noncomputable def localProjectorAt (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) :
+    (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ) :=
+  physRealizeLocalOpAt A hv LinearMap.id
 
 /-- The virtual identity realizes a projection onto the image of the local
  tensor map. -/
 noncomputable def localProjector (A : Tensor G d) (hA : IsVertexInjective A)
     (v : V) : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ) :=
-  physRealizeLocalOp A hA v LinearMap.id
+  localProjectorAt A (hA v)
+
+/-- Pull a local physical operator back to the virtual coefficient space,
+under per-vertex linear independence of the tensor family at `v`.
+
+This is the local injectivity step used in the \(O_1,O_2 \mapsto W\) part of
+arXiv:1804.04964, Section 3: the chosen left inverse identifies the action of a
+physical operator on the image of the local tensor map with a virtual operation
+on local boundary coefficients. -/
+noncomputable def localVirtualOpOfPhysicalOpAt (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v))
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) :
+    LocalVirtualOp A v :=
+  (localLeftInverseAt A hv).comp (O.comp (localTensorMap A v))
 
 /-- Pull a local physical operator back to the virtual coefficient space.
 
@@ -365,26 +460,51 @@ noncomputable def localVirtualOpOfPhysicalOp (A : Tensor G d)
     (hA : IsVertexInjective A) (v : V)
     (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) :
     LocalVirtualOp A v :=
-  (localLeftInverse A hA v).comp (O.comp (localTensorMap A v))
+  localVirtualOpOfPhysicalOpAt A (hA v) O
+
+@[simp] theorem localProjectorAt_apply_localTensorMap (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) (c : LocalVirtualConfig A v → ℂ) :
+    localProjectorAt A hv (localTensorMap A v c) = localTensorMap A v c := by
+  simpa [localProjectorAt] using
+    (physRealizeLocalOpAt_spec A hv LinearMap.id c)
 
 @[simp] theorem localProjector_apply_localTensorMap (A : Tensor G d)
     (hA : IsVertexInjective A) (v : V) (c : LocalVirtualConfig A v → ℂ) :
-    localProjector A hA v (localTensorMap A v c) = localTensorMap A v c := by
-  simpa [localProjector] using
-    (physRealizeLocalOp_spec A hA v LinearMap.id c)
+    localProjector A hA v (localTensorMap A v c) = localTensorMap A v c :=
+  localProjectorAt_apply_localTensorMap A (hA v) c
+
+@[simp] theorem localProjectorAt_apply_component (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) (η : LocalVirtualConfig A v) :
+    localProjectorAt A hv (A.component v η) = A.component v η := by
+  simpa [localTensorMap_apply_single] using
+    (localProjectorAt_apply_localTensorMap A hv (Pi.single η (1 : ℂ)))
 
 @[simp] theorem localProjector_apply_component (A : Tensor G d)
     (hA : IsVertexInjective A) (v : V) (η : LocalVirtualConfig A v) :
-    localProjector A hA v (A.component v η) = A.component v η := by
-  simpa [localTensorMap_apply_single] using
-    (localProjector_apply_localTensorMap A hA v (Pi.single η (1 : ℂ)))
+    localProjector A hA v (A.component v η) = A.component v η :=
+  localProjectorAt_apply_component A (hA v) η
+
+theorem localProjectorAt_idempotent (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) :
+    (localProjectorAt A hv).comp (localProjectorAt A hv) =
+      localProjectorAt A hv := by
+  simpa [localProjectorAt] using
+    (physRealizeLocalOpAt_comp A hv LinearMap.id LinearMap.id).symm
 
 theorem localProjector_idempotent (A : Tensor G d) (hA : IsVertexInjective A)
     (v : V) :
     (localProjector A hA v).comp (localProjector A hA v) =
-      localProjector A hA v := by
-  simpa [localProjector] using
-    (physRealizeLocalOp_comp A hA v LinearMap.id LinearMap.id).symm
+      localProjector A hA v :=
+  localProjectorAt_idempotent A (hA v)
+
+/-- The virtual pullback realizes the projected physical action on the image of
+the local tensor map. -/
+theorem localVirtualOpOfPhysicalOpAt_spec (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v))
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (c : LocalVirtualConfig A v → ℂ) :
+    localTensorMap A v (localVirtualOpOfPhysicalOpAt A hv O c) =
+      localProjectorAt A hv (O (localTensorMap A v c)) := by
+  simp [localVirtualOpOfPhysicalOpAt, localProjectorAt, physRealizeLocalOpAt]
 
 /-- The virtual pullback realizes the projected physical action on the image of
 the local tensor map. -/
@@ -392,8 +512,20 @@ theorem localVirtualOpOfPhysicalOp_spec (A : Tensor G d) (hA : IsVertexInjective
     (v : V) (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
     (c : LocalVirtualConfig A v → ℂ) :
     localTensorMap A v (localVirtualOpOfPhysicalOp A hA v O c) =
-      localProjector A hA v (O (localTensorMap A v c)) := by
-  simp [localVirtualOpOfPhysicalOp, localProjector, physRealizeLocalOp]
+      localProjector A hA v (O (localTensorMap A v c)) :=
+  localVirtualOpOfPhysicalOpAt_spec A (hA v) O c
+
+/-- If a local physical operator preserves the image of the local tensor map,
+then its virtual pullback gives exactly the same action on that image. -/
+theorem localVirtualOpOfPhysicalOpAt_realizes_of_projector (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v))
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hO : ∀ c : LocalVirtualConfig A v → ℂ,
+      localProjectorAt A hv (O (localTensorMap A v c)) = O (localTensorMap A v c))
+    (c : LocalVirtualConfig A v → ℂ) :
+    localTensorMap A v (localVirtualOpOfPhysicalOpAt A hv O c) =
+      O (localTensorMap A v c) := by
+  rw [localVirtualOpOfPhysicalOpAt_spec, hO]
 
 /-- If a local physical operator preserves the image of the local tensor map,
 then its virtual pullback gives exactly the same action on that image. -/
@@ -404,8 +536,27 @@ theorem localVirtualOpOfPhysicalOp_realizes_of_projector (A : Tensor G d)
       localProjector A hA v (O (localTensorMap A v c)) = O (localTensorMap A v c))
     (c : LocalVirtualConfig A v → ℂ) :
     localTensorMap A v (localVirtualOpOfPhysicalOp A hA v O c) =
-      O (localTensorMap A v c) := by
-  rw [localVirtualOpOfPhysicalOp_spec, hO]
+      O (localTensorMap A v c) :=
+  localVirtualOpOfPhysicalOpAt_realizes_of_projector A (hA v) O hO c
+
+/-- A virtual operator is recovered by pulling back any physical operator that
+realizes it on the image of the local tensor map. -/
+theorem localVirtualOpOfPhysicalOpAt_eq_of_realizes (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v))
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (T : LocalVirtualOp A v)
+    (hO : ∀ c : LocalVirtualConfig A v → ℂ,
+      O (localTensorMap A v c) = localTensorMap A v (T c)) :
+    localVirtualOpOfPhysicalOpAt A hv O = T := by
+  apply LinearMap.ext
+  intro c
+  apply localTensorMap_injective_of_linearIndependent hv
+  calc
+    localTensorMap A v (localVirtualOpOfPhysicalOpAt A hv O c) =
+        localProjectorAt A hv (O (localTensorMap A v c)) := by
+      rw [localVirtualOpOfPhysicalOpAt_spec]
+    _ = localTensorMap A v (T c) := by
+      rw [hO c]
+      simp
 
 /-- A virtual operator is recovered by pulling back any physical operator that
 realizes it on the image of the local tensor map. -/
@@ -414,17 +565,23 @@ theorem localVirtualOpOfPhysicalOp_eq_of_realizes (A : Tensor G d)
     (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (T : LocalVirtualOp A v)
     (hO : ∀ c : LocalVirtualConfig A v → ℂ,
       O (localTensorMap A v c) = localTensorMap A v (T c)) :
-    localVirtualOpOfPhysicalOp A hA v O = T := by
+    localVirtualOpOfPhysicalOp A hA v O = T :=
+  localVirtualOpOfPhysicalOpAt_eq_of_realizes A (hA v) O T hO
+
+/-- Two physical endpoint operations have the same virtual pullback if their
+projected actions agree on the image of the local tensor map. -/
+theorem localVirtualOpOfPhysicalOpAt_eq_of_projected_action_eq (A : Tensor G d)
+    {v : V} (hv : LinearIndependent ℂ (A.component v))
+    (O O' : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hOO' : ∀ c : LocalVirtualConfig A v → ℂ,
+      localProjectorAt A hv (O (localTensorMap A v c)) =
+        localProjectorAt A hv (O' (localTensorMap A v c))) :
+    localVirtualOpOfPhysicalOpAt A hv O =
+      localVirtualOpOfPhysicalOpAt A hv O' := by
   apply LinearMap.ext
   intro c
-  apply hA.localTensorMap_injective v
-  calc
-    localTensorMap A v (localVirtualOpOfPhysicalOp A hA v O c) =
-        localProjector A hA v (O (localTensorMap A v c)) := by
-      rw [localVirtualOpOfPhysicalOp_spec]
-    _ = localTensorMap A v (T c) := by
-      rw [hO c]
-      simp
+  apply localTensorMap_injective_of_linearIndependent hv
+  rw [localVirtualOpOfPhysicalOpAt_spec, localVirtualOpOfPhysicalOpAt_spec, hOO']
 
 /-- Two physical endpoint operations have the same virtual pullback if their
 projected actions agree on the image of the local tensor map. -/
@@ -435,11 +592,24 @@ theorem localVirtualOpOfPhysicalOp_eq_of_projected_action_eq (A : Tensor G d)
       localProjector A hA v (O (localTensorMap A v c)) =
         localProjector A hA v (O' (localTensorMap A v c))) :
     localVirtualOpOfPhysicalOp A hA v O =
-      localVirtualOpOfPhysicalOp A hA v O' := by
-  apply LinearMap.ext
-  intro c
-  apply hA.localTensorMap_injective v
-  rw [localVirtualOpOfPhysicalOp_spec, localVirtualOpOfPhysicalOp_spec, hOO']
+      localVirtualOpOfPhysicalOp A hA v O' :=
+  localVirtualOpOfPhysicalOpAt_eq_of_projected_action_eq A (hA v) O O' hOO'
+
+/-- Equality of virtual pullbacks is equivalent to equality of the projected
+physical actions on the image of the local tensor map. -/
+theorem localVirtualOpOfPhysicalOpAt_eq_iff_projected_action_eq (A : Tensor G d)
+    {v : V} (hv : LinearIndependent ℂ (A.component v))
+    (O O' : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) :
+    localVirtualOpOfPhysicalOpAt A hv O =
+        localVirtualOpOfPhysicalOpAt A hv O' ↔
+      ∀ c : LocalVirtualConfig A v → ℂ,
+        localProjectorAt A hv (O (localTensorMap A v c)) =
+          localProjectorAt A hv (O' (localTensorMap A v c)) := by
+  constructor
+  · intro h c
+    rw [← localVirtualOpOfPhysicalOpAt_spec A hv O c,
+      ← localVirtualOpOfPhysicalOpAt_spec A hv O' c, h]
+  · exact localVirtualOpOfPhysicalOpAt_eq_of_projected_action_eq A hv O O'
 
 /-- Equality of virtual pullbacks is equivalent to equality of the projected
 physical actions on the image of the local tensor map. -/
@@ -450,21 +620,36 @@ theorem localVirtualOpOfPhysicalOp_eq_iff_projected_action_eq (A : Tensor G d)
         localVirtualOpOfPhysicalOp A hA v O' ↔
       ∀ c : LocalVirtualConfig A v → ℂ,
         localProjector A hA v (O (localTensorMap A v c)) =
-          localProjector A hA v (O' (localTensorMap A v c)) := by
-  constructor
-  · intro h c
-    rw [← localVirtualOpOfPhysicalOp_spec A hA v O c,
-      ← localVirtualOpOfPhysicalOp_spec A hA v O' c, h]
-  · exact localVirtualOpOfPhysicalOp_eq_of_projected_action_eq A hA v O O'
+          localProjector A hA v (O' (localTensorMap A v c)) :=
+  localVirtualOpOfPhysicalOpAt_eq_iff_projected_action_eq A (hA v) O O'
+
+/-- Pulling back the canonical physical realization of a virtual operation
+recovers the original virtual operation. -/
+theorem localVirtualOpOfPhysicalOpAt_physRealizeLocalOpAt (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v)) (T : LocalVirtualOp A v) :
+    localVirtualOpOfPhysicalOpAt A hv (physRealizeLocalOpAt A hv T) = T :=
+  localVirtualOpOfPhysicalOpAt_eq_of_realizes A hv
+    (physRealizeLocalOpAt A hv T) T
+    (physRealizeLocalOpAt_spec A hv T)
 
 /-- Pulling back the canonical physical realization of a virtual operation
 recovers the original virtual operation. -/
 theorem localVirtualOpOfPhysicalOp_physRealizeLocalOp (A : Tensor G d)
     (hA : IsVertexInjective A) (v : V) (T : LocalVirtualOp A v) :
     localVirtualOpOfPhysicalOp A hA v (physRealizeLocalOp A hA v T) = T :=
-  localVirtualOpOfPhysicalOp_eq_of_realizes A hA v
-    (physRealizeLocalOp A hA v T) T
-    (physRealizeLocalOp_spec A hA v T)
+  localVirtualOpOfPhysicalOpAt_physRealizeLocalOpAt A (hA v) T
+
+/-- The physical realization of the virtual pullback of \(O\) is
+\(P \circ O \circ P\), where \(P\) is the local projector onto the image of the
+local tensor map. -/
+theorem physRealizeLocalOpAt_localVirtualOpOfPhysicalOpAt (A : Tensor G d) {v : V}
+    (hv : LinearIndependent ℂ (A.component v))
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) :
+    physRealizeLocalOpAt A hv (localVirtualOpOfPhysicalOpAt A hv O) =
+      (localProjectorAt A hv).comp (O.comp (localProjectorAt A hv)) := by
+  ext x
+  simp [physRealizeLocalOpAt, localVirtualOpOfPhysicalOpAt, localProjectorAt,
+    LinearMap.comp_assoc]
 
 /-- The physical realization of the virtual pullback of \(O\) is
 \(P \circ O \circ P\), where \(P\) is the local projector onto the image of the
@@ -473,10 +658,20 @@ theorem physRealizeLocalOp_localVirtualOpOfPhysicalOp (A : Tensor G d)
     (hA : IsVertexInjective A) (v : V)
     (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) :
     physRealizeLocalOp A hA v (localVirtualOpOfPhysicalOp A hA v O) =
-      (localProjector A hA v).comp (O.comp (localProjector A hA v)) := by
-  ext x
-  simp [physRealizeLocalOp, localVirtualOpOfPhysicalOp, localProjector,
-    LinearMap.comp_assoc]
+      (localProjector A hA v).comp (O.comp (localProjector A hA v)) :=
+  physRealizeLocalOpAt_localVirtualOpOfPhysicalOpAt A (hA v) O
+
+/-- If the projected physical action of \(O\) is the canonical physical
+realization of a virtual operation \(T\), then pulling back \(O\) recovers
+\(T\). -/
+theorem localVirtualOpOfPhysicalOpAt_eq_of_projected_realization_eq
+    (A : Tensor G d) {v : V} (hv : LinearIndependent ℂ (A.component v))
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (T : LocalVirtualOp A v)
+    (hO : (localProjectorAt A hv).comp (O.comp (localProjectorAt A hv)) =
+      physRealizeLocalOpAt A hv T) :
+    localVirtualOpOfPhysicalOpAt A hv O = T := by
+  apply physRealizeLocalOpAt_injective A hv
+  rw [physRealizeLocalOpAt_localVirtualOpOfPhysicalOpAt, hO]
 
 /-- If the projected physical action of \(O\) is the canonical physical
 realization of a virtual operation \(T\), then pulling back \(O\) recovers
@@ -486,9 +681,21 @@ theorem localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq
     (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (T : LocalVirtualOp A v)
     (hO : (localProjector A hA v).comp (O.comp (localProjector A hA v)) =
       physRealizeLocalOp A hA v T) :
-    localVirtualOpOfPhysicalOp A hA v O = T := by
-  apply physRealizeLocalOp_injective A hA v
-  rw [physRealizeLocalOp_localVirtualOpOfPhysicalOp, hO]
+    localVirtualOpOfPhysicalOp A hA v O = T :=
+  localVirtualOpOfPhysicalOpAt_eq_of_projected_realization_eq A (hA v) O T hO
+
+/-- The compressed physical action of \(O\) is the canonical physical
+realization of \(T\) exactly when the virtual pullback of \(O\) is \(T\). -/
+theorem localVirtualOpOfPhysicalOpAt_eq_iff_projected_realization_eq
+    (A : Tensor G d) {v : V} (hv : LinearIndependent ℂ (A.component v))
+    (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (T : LocalVirtualOp A v) :
+    localVirtualOpOfPhysicalOpAt A hv O = T ↔
+      (localProjectorAt A hv).comp (O.comp (localProjectorAt A hv)) =
+        physRealizeLocalOpAt A hv T := by
+  constructor
+  · intro h
+    rw [← h, physRealizeLocalOpAt_localVirtualOpOfPhysicalOpAt]
+  · exact localVirtualOpOfPhysicalOpAt_eq_of_projected_realization_eq A hv O T
 
 /-- The compressed physical action of \(O\) is the canonical physical
 realization of \(T\) exactly when the virtual pullback of \(O\) is \(T\). -/
@@ -497,11 +704,8 @@ theorem localVirtualOpOfPhysicalOp_eq_iff_projected_realization_eq
     (O : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ)) (T : LocalVirtualOp A v) :
     localVirtualOpOfPhysicalOp A hA v O = T ↔
       (localProjector A hA v).comp (O.comp (localProjector A hA v)) =
-        physRealizeLocalOp A hA v T := by
-  constructor
-  · intro h
-    rw [← h, physRealizeLocalOp_localVirtualOpOfPhysicalOp]
-  · exact localVirtualOpOfPhysicalOp_eq_of_projected_realization_eq A hA v O T
+        physRealizeLocalOp A hA v T :=
+  localVirtualOpOfPhysicalOpAt_eq_iff_projected_realization_eq A (hA v) O T
 
 end PEPS
 end TNLean


### PR DESCRIPTION
## Summary

Concrete proof-infrastructure progress toward `physical_to_virtual_insertion` (#1370). Its first obstruction was a **hypothesis-strength mismatch**: the local-realization engine (`localLeftInverse`, `physRealizeLocalOp`, `localProjector`, `localVirtualOpOfPhysicalOp`) and its conditional helpers were parametrized by the *global* `IsVertexInjective A`, but `physical_to_virtual_insertion` only offers `EdgeBlockedThreeSiteInjective A e` (endpoints + middle block), which does not entail global vertex injectivity.

## What lands (non-breaking)

- **`VirtualInsertion.lean`**: added per-vertex `...At` variants of the whole engine taking `(hv : LinearIndependent ℂ (A.component v))`, and redefined every existing global function as a thin delegate `f A hA v := fAt A (hA v)`. All pre-existing signatures are unchanged, so downstream compiles untouched.
- **`InsertionRealization.lean`** (pure additions): `EdgeBlockedThreeSiteInjective.endpoint_linearIndependent` (the bridge, axiom-clean), the per-vertex `...At` eq-iff helpers, and `edgePhysicalToVirtualInsertion_of_endpointInjective` — the endpoint-injective consumer variant taking the two endpoint linear-independence facts instead of global `IsVertexInjective`.
- **`LocalGauge.lean`**: one `simp` argument-list adjustment (no signature change).

## Verification

`lake build TNLean.PEPS.{InsertionRealization, InsertionAlgebra, LocalGauge, EdgeMiddlePhysical}` → **exit 0** (1760 jobs); only the two pre-existing `sorry` warnings remain (no new ones). `endpoint_linearIndependent` is `#print axioms`-clean. **Confirmed applicable**: an `example` shows `edgePhysicalToVirtualInsertion_of_endpointInjective` typechecks directly against `physical_to_virtual_insertion`'s hypothesis `hA : EdgeBlockedThreeSiteInjective A e` via `hA.endpoint_linearIndependent.1/.2`.

The statement and `sorry` of `physical_to_virtual_insertion` are unchanged. The remaining obstruction for that proof is the right+middle contraction-inverse that extracts the common matrix `M` from `hEq` (the invert-B₂B₃ step); this PR removes the engine-parametrization wall in front of it. Refs #1370.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-library refactor with delegating wrappers and no API breaks; main risk is accidental lemma duplication or simp regressions in PEPS files.
> 
> **Overview**
> The PEPS local realization machinery is refactored so injectivity is assumed **per vertex** (`LinearIndependent` on `A.component v`) instead of only via global `IsVertexInjective`. In **`VirtualInsertion.lean`**, new `…At` definitions (`localLeftInverseAt`, `physRealizeLocalOpAt`, `localProjectorAt`, `localVirtualOpOfPhysicalOpAt`, etc.) carry the full lemma suite; existing global names are thin wrappers `f A hA v := fAt A (hA v)` with **unchanged signatures**.
> 
> **`InsertionRealization.lean`** adds `EdgeBlockedThreeSiteInjective.endpoint_linearIndependent` (endpoint injectivity ⇒ linear independence), per-endpoint projected-recovery lemmas, and **`edgePhysicalToVirtualInsertion_of_endpoint_injective`**, which matches the existential conclusion of `physical_to_virtual_insertion` under only the two endpoint independence facts from edge-blocked three-site injectivity—not full vertex injectivity. **`LocalGauge.lean`** updates one `simp` list for the expanded projector definitions.
> 
> `physical_to_virtual_insertion` remains `sorry`; this PR removes the hypothesis-strength gap between `EdgeBlockedThreeSiteInjective` and the old global-injectivity engine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c297f1b512fef60749cab3c6ab3ca16a7bd6a050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->