### PR TITLE
doc(periodic): add off-diagonal grading blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -444,6 +444,150 @@ unconditional result.
     adjoint-transfer relation.
 \end{definition}
 
+\begin{theorem}[Single-site cyclic grading]
+    \label{thm:offdiag_shift_adjoint_cyclic_shift}
+    \lean{MPSTensor.offDiag_shift_of_adjoint_cyclic_shift}
+    \leanok
+    \uses{def:transfer_map}
+    Let $A$ be left-canonical, and let $P_0,\ldots,P_{m-1}$ be orthogonal
+    projections on the bond space. If the adjoint transfer map satisfies
+    \[
+        \E_A^\dagger(P_{k+1})=P_k
+    \]
+    for all $k$, with indices taken modulo $m$, then for every physical
+    letter $i$,
+    \[
+        P_{k+1}A^i=A^iP_k.
+    \]
+    This is the single-site grading behind
+    \cite[eq.~Aoffdiag]{DeLasCuevas2017Irreducible}; the compressed blocks of
+    \cite[eq.~Auprop]{DeLasCuevas2017Irreducible} use the inverse cyclic
+    indexing convention of Definition~\ref{def:cyclic_sector_decomp}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Put $K_i=(A^i)^\dagger$ and let $\Phi_K$ be the Kraus map of the family
+    $K$. Since $A$ is left-canonical, $\Phi_K$ is unital. The projection
+    identities and the shift relation give
+    \[
+        \Phi_K(P_{k+1}^\dagger P_{k+1})
+        =
+        \Phi_K(P_{k+1})^\dagger\Phi_K(P_{k+1}),
+    \]
+    because both sides are equal to $P_k$. The equality case in the
+    Kadison--Schwarz inequality therefore gives
+    \[
+        P_{k+1}K_i^\dagger=K_i^\dagger\Phi_K(P_{k+1}).
+    \]
+    Substituting $K_i^\dagger=A^i$ and $\Phi_K(P_{k+1})=P_k$ gives
+    $P_{k+1}A^i=A^iP_k$.
+\end{proof}
+
+\begin{theorem}[Off-diagonal reconstruction]
+    \label{thm:eq_sum_offdiag_adjoint_cyclic_shift}
+    \lean{MPSTensor.eq_sum_offDiag_of_adjoint_cyclic_shift}
+    \leanok
+    \uses{thm:offdiag_shift_adjoint_cyclic_shift}
+    Under the hypotheses of Theorem~\ref{thm:offdiag_shift_adjoint_cyclic_shift},
+    assume in addition that
+    \[
+        \sum_{u=0}^{m-1} P_u=\Id .
+    \]
+    Then every physical letter decomposes as
+    \[
+        A^i=\sum_{u=0}^{m-1} P_{u+1}A^iP_u .
+    \]
+    This is \cite[eq.~Aoffdiag]{DeLasCuevas2017Irreducible}, written in the
+    same inverse cyclic indexing convention.
+\end{theorem}
+
+\begin{proof}\leanok
+    Insert $\sum_u P_u=\Id$ on the right of $A^i$, then use
+    Theorem~\ref{thm:offdiag_shift_adjoint_cyclic_shift} and
+    $P_u^2=P_u$ term by term.
+\end{proof}
+
+\begin{theorem}[Word cyclic grading]
+    \label{thm:offdiag_shift_eval_word_adjoint_cyclic_shift}
+    \lean{MPSTensor.offDiag_shift_evalWord_of_adjoint_cyclic_shift}
+    \leanok
+    \uses{thm:offdiag_shift_adjoint_cyclic_shift}
+    Under the hypotheses of Theorem~\ref{thm:offdiag_shift_adjoint_cyclic_shift},
+    a word $w=i_1\cdots i_\ell$ satisfies
+    \[
+        P_{k+\ell} A^w = A^w P_k .
+    \]
+    Thus the single-site grading accumulates one cyclic step for each letter of
+    the word.
+\end{theorem}
+
+\begin{proof}\leanok
+    Induct on the length of $w$, using
+    Theorem~\ref{thm:offdiag_shift_adjoint_cyclic_shift} for the first letter
+    and the induction hypothesis for the remaining word.
+\end{proof}
+
+\begin{theorem}[Cyclic-sector single-site grading]
+    \label{thm:cyclic_sector_offdiag_shift}
+    \lean{MPSTensor.IsCyclicSectorDecomp.offDiag_shift}
+    \leanok
+    \uses{def:periodic_tensor, def:cyclic_sector_decomp,
+        thm:offdiag_shift_adjoint_cyclic_shift}
+    If a periodic tensor admits a cyclic sector decomposition, then for every
+    $k$ and every physical letter $i$ there exists a family
+    $P_0,\ldots,P_{m-1}$ such that
+    \[
+        P_u^\dagger=P_u,\qquad P_u^2=P_u\quad(0\le u<m),
+        \qquad
+        \sum_{u=0}^{m-1}P_u=\Id
+    \]
+    and
+    \[
+        P_{k+1}A^i=A^iP_k .
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose the projection family contained in the cyclic sector decomposition.
+    It satisfies
+    \[
+        P_u^\dagger=P_u,\qquad P_u^2=P_u,\qquad
+        \sum_u P_u=\Id,\qquad \E_A^\dagger(P_{u+1})=P_u .
+    \]
+    Apply
+    Theorem~\ref{thm:offdiag_shift_adjoint_cyclic_shift}.
+\end{proof}
+
+\begin{theorem}[Cyclic-sector off-diagonal reconstruction]
+    \label{thm:cyclic_sector_eq_sum_offdiag}
+    \lean{MPSTensor.IsCyclicSectorDecomp.eq_sum_offDiag}
+    \leanok
+    \uses{def:periodic_tensor, def:cyclic_sector_decomp,
+        thm:eq_sum_offdiag_adjoint_cyclic_shift}
+    If a periodic tensor admits a cyclic sector decomposition, then for every
+    physical letter $i$ there exists a family $P_0,\ldots,P_{m-1}$ such that
+    \[
+        P_u^\dagger=P_u,\qquad P_u^2=P_u\quad(0\le u<m),
+        \qquad
+        \sum_{u=0}^{m-1}P_u=\Id
+    \]
+    and
+    \[
+        A^i=\sum_{u=0}^{m-1} P_{u+1}A^iP_u .
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose the projection family contained in the cyclic sector decomposition.
+    It satisfies
+    \[
+        P_u^\dagger=P_u,\qquad P_u^2=P_u,\qquad
+        \sum_u P_u=\Id,\qquad \E_A^\dagger(P_{u+1})=P_u .
+    \]
+    Apply
+    Theorem~\ref{thm:eq_sum_offdiag_adjoint_cyclic_shift}.
+\end{proof}
+
 \begin{theorem}[Cyclic sector decomposition of a periodic tensor]
     \label{thm:cyclic_sector_decomp_after_blocking_periodic}
     \lean{MPSTensor.exists_cyclic_sector_decomp_after_blocking_of_isPeriodic}


### PR DESCRIPTION
## Summary

This PR adds the missing Chapter 11b blueprint entries for the off-diagonal grading declarations corresponding to arXiv:1708.00029, eq:Auprop and eq:Aoffdiag.  The statements record:

- the single-site cyclic grading $P_{k+1}A^i=A^iP_k$ from the adjoint cyclic shift;
- the reconstruction $A^i=\sum_u P_{u+1}A^iP_u$;
- the word-level cyclic grading;
- the two cyclic-sector formulations carried by `IsCyclicSectorDecomp`.

Closes #2377.

## Verification

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `leanblueprint web`
- `lake build TNLean.MPS.CanonicalForm.CyclicSectors.FixedAdjoint -q --log-level=info`
- `lake build TNLean.MPS.Periodic.Overlap.SelfOverlap -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `leanblueprint checkdecls` was run after building `TNLean`; it still fails on pre-existing missing declarations in other chapters, but none of the five declarations added here appears in the missing-declaration list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX/blueprint sync; no runtime or proof logic changes in the diff.
> 
> **Overview**
> Adds **Chapter 11b blueprint material** immediately after the cyclic sector decomposition definition, documenting the off-diagonal grading chain that was already formalized in Lean.
> 
> The new block states that an adjoint cyclic shift \(\mathcal{E}_A^\dagger(P_{k+1})=P_k\) yields **single-site grading** \(P_{k+1}A^i=A^iP_k\) (Kadison–Schwarz on the Kraus adjoint map), then **off-diagonal reconstruction** \(A^i=\sum_u P_{u+1}A^iP_u\) when \(\sum_u P_u=\mathrm{Id}\), and **word-level grading** \(P_{k+\ell}A^w=A^wP_k\). Two further theorems repackage the same identities for tensors with an **`IsCyclicSectorDecomp`**, with `\leanok` links to `MPSTensor.offDiag_shift_of_adjoint_cyclic_shift`, `eq_sum_offDiag_of_adjoint_cyclic_shift`, `offDiag_shift_evalWord_of_adjoint_cyclic_shift`, and the `IsCyclicSectorDecomp` corollaries—aligned with De Las Cuevas et al. (eq. Aoffdiag / Auprop) and the inverse cyclic indexing noted in the definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c471cb89bb03ca0d2e423764d32d9d25718509b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->