### PR TITLE
style(parent): align early blueprint terminology

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -4,20 +4,21 @@ This chapter introduces the local ground-space construction and the parent
 interaction for translation-invariant periodic MPS.
 We follow the standard setup from
 \cite{Cirac2021Matrix, PerezGarcia2007Matrix}, with the $N$-site Hilbert space
-written in the computational basis as
+identified with functions on the computational basis,
 \[
     \{0,\ldots,d{-}1\}^N \to \C,
 \]
 rather than as an explicit tensor product.
 
-\begin{definition}[$N$-site coefficient space]\label{def:nsite_space_parent}
+\begin{definition}[$N$-site Hilbert space]\label{def:nsite_space_parent}
     \lean{MPSTensor.NSiteSpace}
     \leanok
-    For local dimension $d$ and chain length $N$, the ambient Hilbert space is
+    For local dimension $d$ and chain length $N$, the $N$-site Hilbert space is
     \[
         \mathcal H_{N}^{(d)} := \{0,\ldots,d{-}1\}^{N} \to \C.
     \]
-    This is the concrete model used throughout the chapter for periodic-chain states.
+    This is the computational-basis realization used throughout the chapter for
+    periodic-chain states.
 \end{definition}
 
 \section{\texorpdfstring{Local ground space $G_L(A)$}{Local ground space G\_L(A)}}\label{sec:ground_space_parent}
@@ -96,7 +97,7 @@ $A^{\sigma(0)}\cdots A^{\sigma(L-1)}$.
 \begin{lemma}[Ambient-space dimension]\label{lem:nsite_space_finrank}
     \lean{MPSTensor.nSiteSpace_finrank}
     \leanok
-    The coefficient-function model satisfies
+    The above Hilbert-space realization satisfies
     \[
         \dim\!(\{0,\ldots,d{-}1\}^L \to \C)=d^L.
     \]
@@ -132,31 +133,40 @@ The canonical parent interaction at range $L$ is
 The sources also allow any positive local interaction with this kernel; the
 orthogonal projector is the canonical representative used here.
 
-\begin{definition}[Euclidean transport of the local ground space]\label{def:ground_space_es}
+\begin{definition}[Hilbert-space copy of the local ground space]\label{def:ground_space_es}
     \lean{MPSTensor.groundSpaceES}
     \leanok
     \uses{def:nsite_space_parent, def:ground_space_parent}
-    Via the canonical identification between the computational-basis model and the
-    Euclidean space $\ell^{2}(\{0,\ldots,d{-}1\}^{L})$, one transports the local
-    ground space to a Hilbert-space subspace
+    Let
     \[
-        G_{L}^{\mathrm{ES}}(A) \subseteq \ell^{2}(\{0,\ldots,d{-}1\}^{L}).
+        \iota_L :
+        (\{0,\ldots,d{-}1\}^{L}\to\C)
+        \simeq \ell^{2}(\{0,\ldots,d{-}1\}^{L})
+    \]
+    be the canonical computational-basis identification. The Hilbert-space copy
+    of the local ground space is
+    \[
+        G_{L}^{\mathrm{ES}}(A):=\iota_L(G_L(A))
+        \subseteq \ell^{2}(\{0,\ldots,d{-}1\}^{L}).
     \]
 \end{definition}
 
-\begin{lemma}[Membership in the transported local ground space]\label{lem:mem_ground_space_es}
+\begin{lemma}[Membership in the Hilbert-space copy]\label{lem:mem_ground_space_es}
     \lean{MPSTensor.mem_groundSpaceES_iff}
     \leanok
     \uses{def:ground_space_es, def:ground_space_parent}
-    A Euclidean vector lies in $G_L^{\mathrm{ES}}(A)$ exactly when transporting it
-    back through the canonical coefficient-space equivalence gives an element of
-    the original local ground space $G_L(A)$.
+    For $v\in\ell^{2}(\{0,\ldots,d{-}1\}^{L})$,
+    \[
+        v\in G_L^{\mathrm{ES}}(A)
+        \Longleftrightarrow
+        \iota_L^{-1}v\in G_L(A).
+    \]
 \end{lemma}
 
 \begin{proof}
     \leanok
-    This is just the definition of $G_L^{\mathrm{ES}}(A)$ as the image of
-    $G_L(A)$ under the inverse of the canonical equivalence.
+    This is the defining equation
+    $G_L^{\mathrm{ES}}(A)=\iota_L(G_L(A))$.
 \end{proof}
 
 \begin{definition}[Canonical parent interaction]\label{def:parent_interaction}
@@ -172,7 +182,7 @@ orthogonal projector is the canonical representative used here.
     on the local $L$-site space.
 \end{definition}
 
-\begin{lemma}[Parent interaction kills ground-space elements]%
+\begin{lemma}[Parent interaction annihilates ground-space elements]%
     \label{lem:parent_interaction_apply_mem_ground_space}
     \lean{MPSTensor.parentInteraction_apply_mem_groundSpace}
     \leanok
@@ -186,38 +196,52 @@ orthogonal projector is the canonical representative used here.
     annihilates every element of $G_L(A)$.
 \end{proof}
 
-\begin{definition}[Periodic window extraction]\label{def:extract_window}
+\begin{definition}[Restriction to a cyclic interval]\label{def:extract_window}
     \lean{MPSTensor.extractWindow}
     \leanok
     \uses{def:nsite_space_parent}
-    For a configuration $\sigma \in \{0,\ldots,d{-}1\}^{N}$ on the periodic chain and a
-    starting site $i$, the extracted word
+    For $\sigma \in \{0,\ldots,d{-}1\}^{N}$ and a starting site $i$, write
     \[
-        \operatorname{extractWindow}_{L,i}(\sigma) \in \{0,\ldots,d{-}1\}^{L}
+        \sigma|_{[i,i+L-1]}
+        \in \{0,\ldots,d{-}1\}^{L}
     \]
-    reads the entries of $\sigma$ on the cyclic interval $i,i+1,\ldots,i+L-1$ modulo $N$.
+    for the word defined by
+    \[
+        \bigl(\sigma|_{[i,i+L-1]}\bigr)(r)
+        =\sigma(i+r \bmod N),
+        \qquad 0\le r<L.
+    \]
 \end{definition}
 
-\begin{definition}[Periodic window replacement]\label{def:replace_window}
+\begin{definition}[Prescribing a cyclic interval]\label{def:replace_window}
     \lean{MPSTensor.replaceWindow}
     \leanok
     \uses{def:extract_window}
-    If $L \le N$, the configuration
+    If $L \le N$ and $\tau\in\{0,\ldots,d{-}1\}^{L}$, write
     \[
-        \operatorname{replaceWindow}_{L,i}(\sigma,\tau)
+        \sigma^{[i,i+L-1]\leftarrow\tau}
     \]
-    is obtained from $\sigma$ by replacing the cyclic window starting at $i$ by the
-    length-$L$ word $\tau$.
+    for the configuration defined by
+    \[
+        \sigma^{[i,i+L-1]\leftarrow\tau}(k)
+        =
+        \begin{cases}
+            \tau(r),
+                & k\equiv i+r \pmod N\text{ for some }0\le r<L,\\
+            \sigma(k), & \text{otherwise}.
+        \end{cases}
+    \]
+    The index $r$ in the first case is unique because $L\le N$.
 \end{definition}
 
 \begin{lemma}[Extracting a replaced window]\label{lem:extract_window_replace_window}
     \lean{MPSTensor.extractWindow_replaceWindow}
     \leanok
     \uses{def:extract_window, def:replace_window}
-    If $L \le N$, then extracting the same cyclic window after replacement recovers the
-    inserted word:
+    If $L \le N$, then restricting to the same cyclic interval after prescribing
+    its values recovers the inserted word:
     \[
-        \operatorname{extractWindow}_{L,i}(\operatorname{replaceWindow}_{L,i}(\sigma,\tau)) = \tau.
+        \left(\sigma^{[i,i+L-1]\leftarrow\tau}\right)|_{[i,i+L-1]}=\tau.
     \]
 \end{lemma}
 
@@ -225,16 +249,16 @@ orthogonal projector is the canonical representative used here.
     \lean{MPSTensor.replaceWindow_extractWindow}
     \leanok
     \uses{def:extract_window, def:replace_window}
-    If $L \le N$, then replacing the cyclic window at $i$ in $\sigma$ by the values
-    extracted from that same $\sigma$ leaves $\sigma$ unchanged:
+    If $L \le N$, then prescribing on a cyclic interval the values already
+    carried by $\sigma$ leaves $\sigma$ unchanged:
     \[
-        \operatorname{replaceWindow}_{L,i}(\sigma,\operatorname{extractWindow}_{L,i}(\sigma)) = \sigma.
+        \sigma^{[i,i+L-1]\leftarrow\sigma|_{[i,i+L-1]}}=\sigma.
     \]
 \end{lemma}
 \begin{proof}\leanok
-    Case-split on whether the offset $(k - i + N) \bmod N$ lies in $[0,L)$: inside the
-    window the value comes from $\operatorname{extractWindow}$, which returns
-    $\sigma$ at the same position; outside the window both sides already agree with $\sigma$.
+    Case-split on whether the offset $(k - i + N) \bmod N$ lies in $[0,L)$:
+    inside the cyclic interval the prescribed value is the original value of
+    $\sigma$; outside the interval both sides already agree with $\sigma$.
 \end{proof}
 
 For a periodic chain of length $N$, the parent Hamiltonian is the sum of
@@ -243,11 +267,21 @@ translated copies of the local interaction.
 \begin{definition}[Translated local term]\label{def:local_term_parent}
     \lean{MPSTensor.localTerm}
     \leanok
-    \uses{def:parent_interaction}
-    For each site index $i \in \{0,\ldots,N{-}1\}$, the translated local term
-    $h_i$ embeds the parent interaction into the full $N$-site space at
-    position~$i$ (with periodic boundary conditions). Thus $h_i$ acts on the
-    cyclic interval $[i,i+L-1]$ and as the identity outside that interval.
+    \uses{def:parent_interaction, def:replace_window, def:extract_window}
+    For each site index $i \in \{0,\ldots,N{-}1\}$, the translated local term is
+    determined by
+    \[
+        (h_i\psi)(\sigma)
+        =
+        \begin{cases}
+        \left[
+            h_L(A)
+            \bigl(\tau\mapsto
+                \psi(\sigma^{[i,i+L-1]\leftarrow\tau})\bigr)
+        \right]\!\bigl(\sigma|_{[i,i+L-1]}\bigr), & L \le N,\\
+        0, & L > N.
+        \end{cases}
+    \]
 \end{definition}
 
 \begin{definition}[Parent Hamiltonian]\label{def:parent_hamiltonian}
@@ -282,7 +316,7 @@ translated copies of the local interaction.
 
 \begin{proof}
     \leanok
-    The witness is the product of $A$-matrices on the complement sites.
+    The boundary matrix is the product of $A$-matrices on the complement sites.
     Trace cyclicity rotates the full $N$-site product so that window
     indices come first, matching the ground-space map definition.
 \end{proof}
@@ -298,7 +332,7 @@ translated copies of the local interaction.
 \begin{proof}
     \leanok
     Combines MPV window membership with the fact that the parent
-    interaction kills ground-space elements.
+    interaction annihilates ground-space elements.
 \end{proof}
 
 \begin{lemma}[Parent Hamiltonian annihilates the MPV]\label{lem:parent_hamiltonian_annihilates}
@@ -341,7 +375,7 @@ chain.
 
 Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
-\begin{remark}[Word and restriction auxiliary formulas]
+\begin{remark}[Word and restriction identities]
     \lean{List.ofFn_snoc}
     \lean{MPSTensor.evalWord_ofFn_snoc}
     \lean{MPSTensor.evalWord_ofFn_cons}
@@ -352,8 +386,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     Appending a last letter to a word corresponds to right multiplication by the
     corresponding tensor letter, while prepending a first letter corresponds to left
-    multiplication. The restriction operators are the associated linear maps on
-    coefficient spaces, together with their pointwise formulas.
+    multiplication. The restriction maps are the associated linear maps on the
+    Hilbert spaces in the computational-basis realization, together with their
+    pointwise formulas.
 \end{remark}
 
 \begin{definition}[Left restriction]\label{def:restrict_last}
@@ -565,9 +600,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \subsection{Unique ground state}
 
-\subsubsection{Contiguous and cyclic window operators}
+\subsubsection{Contiguous and cyclic interval restrictions}
 
-\begin{remark}[Contiguous window operators]\label{rem:contiguous_window_operators}
+\begin{remark}[Contiguous interval restrictions]\label{rem:contiguous_window_operators}
     \lean{MPSTensor.contiguousCfg}
     \lean{MPSTensor.contiguousRestrictₗ}
     \lean{MPSTensor.contiguousRestrictₗ_apply}
@@ -576,16 +611,20 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.contiguousRestrictₗ_restrictFirst}
     \lean{MPSTensor.tailRestrictₗ_contiguousRestrictₗ}
     \leanok
-    For a non-wrapping interval $[s,s+M-1] \subseteq \{0,\ldots,N-1\}$, one can insert a
-    length-$M$ word into that interval and keep the complementary sites fixed. The
-    associated restriction map evaluates an $N$-site state on those configurations.
-    The auxiliary lemmas state the full-window case $s=0$, $M=N$, the
-    compatibility of this restriction with deleting the last or first site, and
-    the fact that fixing the first $K$ entries of a contiguous $(K+L)$-window
-    leaves the contiguous $L$-window beginning at $s+K$.
+    For a non-wrapping interval $[s,s+M-1] \subseteq \{0,\ldots,N-1\}$ and a
+    full configuration $\rho$ supplying the complementary values, the
+    restriction map is
+    \[
+        (\operatorname{Res}^{\rho}_{s,M}\psi)(\omega)
+        =
+        \psi\!\left(\rho^{[s,s+M-1]\leftarrow\omega}\right).
+    \]
+    The listed identities are the equations for $s=0$, $M=N$, for deleting the
+    first or last site, and for first fixing $K$ sites and then restricting to
+    $[s+K,s+K+L-1]$.
 \end{remark}
 
-\begin{remark}[Cyclic window operators]\label{rem:cyclic_window_operators}
+\begin{remark}[Cyclic interval restrictions]\label{rem:cyclic_window_operators}
     \lean{MPSTensor.cyclicCfg}
     \lean{MPSTensor.cyclicRestrictₗ}
     \lean{MPSTensor.cyclicRestrictₗ_apply}
@@ -595,15 +634,30 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.cyclicCfg_eq_contiguousCfg}
     \lean{MPSTensor.cyclicRestrictₗ_eq_contiguousRestrictₗ}
     \leanok
-    On the periodic chain, a cyclic window starting at $i$ reads the sites
-    $i,i+1,\ldots,i+L-1$ modulo $N$. Deleting the final site of a cyclic
-    $(L+1)$-window reads the value at cyclic offset $L$ in the outside
-    configuration and gives the $L$-window starting at the same site. Deleting
-    the first site, in the non-repeating case $L+1\le N$, reads the value at
-    cyclic offset $0$ in the outside configuration and gives the $L$-window
-    starting one site later. When this window does not wrap around the ring, the
-    cyclic construction agrees with the contiguous one, and so do the two
-    restriction maps.
+    On the periodic chain, for a full configuration $\rho$ supplying the
+    complementary values, put
+    \[
+        \delta_i(k) := (k+N-i)\bmod N,\qquad
+        \rho^{\mathrm{cyc}}_{i,L,\omega}(k)
+        :=
+        \begin{cases}
+        \omega(\delta_i(k)), & \delta_i(k)<L,\\
+        \rho(k), & \delta_i(k)\ge L.
+        \end{cases}
+    \]
+    The restriction to the cyclic interval beginning at $i$ is
+    \[
+        (\operatorname{Res}^{\rho}_{i,L}\psi)(\omega)
+        =
+        \psi\!\left(\rho^{\mathrm{cyc}}_{i,L,\omega}\right),
+    \]
+    with all site labels read modulo $N$. If $L\le N$, this is the same
+    configuration as $\rho^{[i,i+L-1]\leftarrow\omega}$. The listed identities
+    say that deleting
+    the final site of an $(L+1)$-interval gives the $L$-interval beginning at
+    $i$; if $L+1\le N$, deleting the first site gives the $L$-interval beginning
+    at $i+1$; and the cyclic formula agrees with the contiguous formula when the
+    interval does not wrap around the ring.
 \end{remark}
 
 \begin{lemma}[One-site restrictions of cyclic-window boundary conditions]
@@ -776,7 +830,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     coincide, so $\psi$ lies in $G_{K + L_0 + 1}(A)$.
 \end{proof}
 
-\begin{theorem}[Open-chain normal range reduction]%
+\begin{theorem}[Open-chain closure property]%
     \label{thm:normal_open_chain_range_reduction}
     \lean{MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective}
     \leanok
@@ -784,9 +838,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         rem:contiguous_window_operators}
     Let $A$ be $L_0$-block injective with $D \ge 1$ and $L_0 > 0$.
     If an $N$-site state satisfies the ground-space constraint on every
-    non-wrapping contiguous window of length $L_0+1$, for every choice $\tau$
-    of the complementary outside configuration, with $N \ge L_0+1$, then it
-    lies in $G_N(A)$.
+    non-wrapping contiguous interval of length $L_0+1$, for every fixed choice
+    of the complementary sites, with $N \ge L_0+1$, then it lies in $G_N(A)$.
 \end{theorem}
 
 \begin{proof}
@@ -795,9 +848,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         def:tail_restrict_parent, rem:contiguous_window_operators}
     Induct on the extra length beyond $L_0+1$. The induction hypothesis gives the
     long left-window ground condition after deleting the last site, while
-    Definition~\ref{def:tail_restrict_parent} and the contiguous-window transport above
-    identify every fixed-prefix suffix with one of the assumed length-$L_0+1$
-    windows. Theorem~\ref{thm:ground_space_extend_right_block_injective} then
+    Definition~\ref{def:tail_restrict_parent} and the contiguous-interval
+    restriction identities above identify every fixed-prefix suffix with one of
+    the assumed length-$L_0+1$ intervals.
+    Theorem~\ref{thm:ground_space_extend_right_block_injective} then
     grows back the rightmost site.
 \end{proof}
 
@@ -842,38 +896,37 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:normal_open_chain_range_reduction} applies.
 \end{proof}
 
-\begin{lemma}[Boundary-crossing compatibility at the final support]%
+\begin{lemma}[Boundary-crossing compatibility at the last site]%
     \label{lem:wrapped_window_one_sided_compatibility}
     \lean{MPSTensor.wrapping_window_compatibility_of_isNBlkInjective}
     \leanok
     \uses{def:l_blk_injective, rem:cyclic_window_operators}
     Assume $A$ is $L_0$-block injective with $L_0>0$ and $M \ge L_0$.
-    If the reduced cyclic window used in closing the boundary at the last site has
-    boundary matrices $Y_\tau$, then for every physical letter $j$ one has
+    If the reduced cyclic interval used in closing the boundary at the last site
+    has boundary matrices $Y_\tau$, then for every physical letter $j$ one has
     \begin{equation}\label{eq:ph_wrapped_window_compat}
         C^+_\tau A^j X = Y_\tau A^j,
     \end{equation}
-    where $C^+_\tau$ is the complementary word seen by that cyclic
-    window.
+    where $C^+_\tau$ is the complementary word seen by that cyclic interval.
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{lem:ground_space_map_injective_blk}
-    The trace identity for this cyclic window is tested against all words of
+    The trace identity for this cyclic interval is tested against all words of
     length $L_0$. Injectivity of $\Gamma_{L_0}$, which follows from
     $L_0$-block injectivity, strips the test word and gives the displayed matrix
     identity~(\ref{eq:ph_wrapped_window_compat}).
 \end{proof}
 
-\begin{lemma}[Boundary-crossing compatibility at the opposite support]%
+\begin{lemma}[Boundary-crossing compatibility at the opposite boundary position]%
     \label{lem:mirror_wrapped_window_one_sided_compatibility}
     \lean{MPSTensor.wrapping_window_mirror_compatibility_of_isNBlkInjective}
     \leanok
     \uses{def:l_blk_injective, rem:cyclic_window_operators}
     Assume $A$ is $L_0$-block injective with $L_0>0$ and $M \ge L_0$.
-    If the opposite reduced cyclic window used in closing the boundary has boundary
-    matrices $Y_\tau$, then
+    If the opposite reduced cyclic interval used in closing the boundary has
+    boundary matrices $Y_\tau$, then
     \[
         X A^j C^-_\tau = A^j Y_\tau
     \]
@@ -900,16 +953,16 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Let $A$ be $L_0$-block injective with $L_0>0$ and $D \ge 1$.
     Suppose $\psi \in \mathcal G_{N,L}(A)$, $N \ge 2$, $L_0 < L \le N$, and
     $\psi = \Gamma_N(X)$ for a boundary matrix $X$. Then there are two families
-    of boundary matrices $Y^+_\tau$ and $Y^-_\tau$, indexed by outside
-    configurations $\tau$, such that for every physical letter $j$,
+    of boundary matrices $Y^+_\tau$ and $Y^-_\tau$, indexed by fixed complement
+    values $\tau$, such that for every physical letter $j$,
     \begin{equation}\label{eq:ph_reduced_wrapped_compat}
         C^+_\tau A^j X = Y^+_\tau A^j,
         \qquad
         X A^j C^-_\tau = A^j Y^-_\tau,
     \end{equation}
     where $C^+_\tau$ and $C^-_\tau$ are the complementary words exposed by the
-    two opposite cyclic windows used in closing the boundary, both of reduced length
-    $L_0+1$.
+    two opposite cyclic intervals used in closing the boundary, both of reduced
+    length $L_0+1$.
 \end{theorem}
 
 \begin{proof}
@@ -919,7 +972,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         lem:mirror_wrapped_window_one_sided_compatibility}
     First use Lemma~\ref{lem:cyclic_window_range_antitonicity} to reduce the
     cyclic constraints from range $L$ to range $L_0+1$. Then apply the two
-    cyclic-window compatibility lemmas at the two boundary positions to obtain
+    cyclic-interval compatibility lemmas at the two boundary positions to obtain
     the displayed one-sided identities~(\ref{eq:ph_reduced_wrapped_compat}).
 \end{proof}
 


### PR DESCRIPTION
## Summary

This PR makes a narrow terminology pass over the early parent-Hamiltonian blueprint setup.  It replaces local formalization phrasing with mathematical language closer to the source discussion:

- the $N$-site space is described as the Hilbert space identified with functions on the computational basis;
- local ground-space Hilbert-space copies are described through the canonical identification with $\ell^2$;
- cyclic-window language is rewritten as restrictions to cyclic intervals and prescriptions of fixed values on those intervals;
- informal phrases such as “kills” and “witness” are replaced by “annihilates” and “boundary matrix”.

This is a prose-only cleanup related to the parent-Hamiltonian tracker #190. It does not change the open proof obligation #2368.

## Verification

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root .`
- `leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to blueprint LaTeX; no code, proofs, or formal definitions changed beyond wording.
> 
> **Overview**
> This PR is a **prose-only terminology pass** on the early parent-Hamiltonian blueprint in `ch14_parent_hamiltonian.tex`. It does not change Lean tags or proof obligations.
> 
> The **$N$-site ambient space** is reframed as a **Hilbert space** identified with functions on the computational basis (not a “coefficient-function model”). The **Euclidean transport** of the local ground space is rewritten using an explicit map **$\iota_L$** to $\ell^2$, with membership stated as $\iota_L^{-1}v \in G_L(A)$.
> 
> **Cyclic “window” language** is replaced by **restrictions to cyclic intervals** ($\sigma|_{[i,i+L-1]}$) and **prescribing values** on those intervals ($\sigma^{[i,i+L-1]\leftarrow\tau}$). The translated local term $h_i$ is given an explicit formula via those operations. **Contiguous/cyclic window operators** in remarks are spelled out as restriction maps $\operatorname{Res}^{\rho}_{s,M}$ (and the cyclic variant).
> 
> Wording is aligned with standard math: e.g. “kills” → **annihilates**, “witness” → **boundary matrix**, “range reduction” → **closure property**, and “window” → **interval** where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1925317a379636d6452bbd65b52b31c24f9e173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->