### PR TITLE
feat(peps): close physical_to_virtual_insertion (#1370) via middle-block + endpoint inversion

### DIFF
--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -57,6 +57,75 @@ theorem EdgeBlockedThreeSiteInjective.endpoint_linearIndependent {A : Tensor G d
   ⟨linearIndependent_iff_injective_fintypeLinearCombination.2 hA.left_injective,
     linearIndependent_iff_injective_fintypeLinearCombination.2 hA.right_injective⟩
 
+/-! ### The middle-block left inverse
+
+The middle block of the edge-centered three-site chain is injective
+(`EdgeMiddleTensorInjective`), so the associated linear-combination map
+`edgeMiddleTensorMap` admits a left inverse. This is the middle-block analogue of
+the endpoint construction `localLeftInverseAt`: where `localLeftInverseAt`
+inverts a single vertex tensor from `LinearIndependent ℂ (A.component v)`, here
+`edgeMiddleLeftInverse` inverts the whole blocked middle tensor from
+`EdgeMiddleTensorInjective`. It is the "invert $B_2$" half of the
+$D_{23}^{-1}$ contraction-inverse in `eq:inj_O->X_argument`.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, `eq:inj_O->X_argument`,
+lines 377--457 of the local paper source. -/
+
+/-- The middle-block tensor map: the linear-combination map of the edge-middle
+tensor family over the residual boundary labels.
+
+This is the middle-block analogue of `localTensorMap`: it sends a coefficient
+family on the residual boundary labels to the corresponding middle physical
+vector. -/
+noncomputable abbrev edgeMiddleTensorMap (A : Tensor G d) (e : Edge G) :
+    (EdgeMiddleBoundaryLabel (G := G) A e → ℂ) →ₗ[ℂ]
+      (EdgeMiddlePhysicalConfig (G := G) (d := d) e → ℂ) :=
+  Fintype.linearCombination ℂ (edgeMiddleTensorFamily (G := G) A e)
+
+/-- Middle-block injectivity makes the middle tensor map injective. This is the
+middle-block analogue of `localTensorMap_injective_of_linearIndependent`. -/
+theorem edgeMiddleTensorMap_injective_of_injective {A : Tensor G d} {e : Edge G}
+    (hMid : EdgeMiddleTensorInjective (G := G) A e) :
+    Function.Injective (edgeMiddleTensorMap (G := G) A e) :=
+  hMid.fintypeLinearCombination_injective
+
+/-- Kernel form of `edgeMiddleTensorMap_injective_of_injective`. -/
+theorem edgeMiddleTensorMap_ker_eq_bot_of_injective {A : Tensor G d} {e : Edge G}
+    (hMid : EdgeMiddleTensorInjective (G := G) A e) :
+    LinearMap.ker (edgeMiddleTensorMap (G := G) A e) = ⊥ :=
+  LinearMap.ker_eq_bot.mpr <| edgeMiddleTensorMap_injective_of_injective hMid
+
+/-- A chosen left inverse of the middle tensor map under middle-block
+injectivity. This is the middle-block analogue of `localLeftInverseAt`, built the
+same way from `LinearMap.exists_leftInverse_of_injective`. It is the
+contraction-inverse of the blocked middle tensor used in the $O_1,O_2\mapsto W$
+step.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, `eq:inj_O->X_argument`,
+lines 377--457 of the local paper source. -/
+noncomputable def edgeMiddleLeftInverse (A : Tensor G d) {e : Edge G}
+    (hMid : EdgeMiddleTensorInjective (G := G) A e) :
+    (EdgeMiddlePhysicalConfig (G := G) (d := d) e → ℂ) →ₗ[ℂ]
+      (EdgeMiddleBoundaryLabel (G := G) A e → ℂ) :=
+  ((edgeMiddleTensorMap (G := G) A e).exists_leftInverse_of_injective
+    (edgeMiddleTensorMap_ker_eq_bot_of_injective hMid)).choose
+
+@[simp] theorem edgeMiddleLeftInverse_comp_edgeMiddleTensorMap (A : Tensor G d)
+    {e : Edge G} (hMid : EdgeMiddleTensorInjective (G := G) A e) :
+    (edgeMiddleLeftInverse (G := G) A hMid).comp (edgeMiddleTensorMap (G := G) A e) =
+      LinearMap.id :=
+  ((edgeMiddleTensorMap (G := G) A e).exists_leftInverse_of_injective
+    (edgeMiddleTensorMap_ker_eq_bot_of_injective hMid)).choose_spec
+
+@[simp] theorem edgeMiddleLeftInverse_apply_edgeMiddleTensorMap (A : Tensor G d)
+    {e : Edge G} (hMid : EdgeMiddleTensorInjective (G := G) A e)
+    (c : EdgeMiddleBoundaryLabel (G := G) A e → ℂ) :
+    edgeMiddleLeftInverse (G := G) A hMid (edgeMiddleTensorMap (G := G) A e c) = c := by
+  change ((edgeMiddleLeftInverse (G := G) A hMid).comp
+    (edgeMiddleTensorMap (G := G) A e)) c = c
+  rw [edgeMiddleLeftInverse_comp_edgeMiddleTensorMap]
+  rfl
+
 /-- A virtual matrix inserted on an edge is physically realizable on either
 neighboring endpoint tensor, provided the PEPS tensor is vertex-injective.
 
@@ -341,6 +410,153 @@ theorem edgePhysicalToVirtualInsertion_of_endpointInjective
     rw [hRight] at hrealize
     exact hrealize.symm
 
+/-! ### Decoupling the three physical legs and inverting the middle block
+
+The two endpoints `e.1.1`, `e.1.2` and the middle region `V \ {u, v}` are
+pairwise disjoint, so a global physical configuration factors as three
+independent legs. The merge map below reassembles them, and the
+specialization of the resonate hypothesis at a merged configuration, combined
+with the middle-block left inverse, removes the middle dependence. This is the
+"invert $B_2$" reduction of `eq:inj_O->X_argument`.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, `eq:resonate`--
+`eq:inj_O->X_argument`, lines 355--457 of the local paper source. -/
+
+open Classical in
+/-- Reassemble independent physical legs on the two endpoints and the middle
+region into a global physical configuration. -/
+noncomputable def edgeMergeConfig (e : Edge G)
+    (τl τr : Fin d) (τm : EdgeMiddlePhysicalConfig (G := G) (d := d) e) : V → Fin d :=
+  fun w => if w = e.1.1 then τl else if w = e.1.2 then τr
+    else if h : w ∈ edgeMiddleVertices e then τm ⟨w, h⟩ else τl
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem edgeMergeConfig_left (e : Edge G) (τl τr : Fin d)
+    (τm : EdgeMiddlePhysicalConfig (G := G) (d := d) e) :
+    edgeMergeConfig (G := G) (d := d) e τl τr τm e.1.1 = τl := by
+  simp [edgeMergeConfig]
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem edgeMergeConfig_right (e : Edge G) (τl τr : Fin d)
+    (τm : EdgeMiddlePhysicalConfig (G := G) (d := d) e) :
+    edgeMergeConfig (G := G) (d := d) e τl τr τm e.1.2 = τr := by
+  have h : e.1.2 ≠ e.1.1 := (edgeLeft_ne_edgeRight e).symm
+  simp [edgeMergeConfig, h]
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem edgeMergeConfig_middle (e : Edge G) (τl τr : Fin d)
+    (τm : EdgeMiddlePhysicalConfig (G := G) (d := d) e) :
+    edgeMiddlePhysicalConfigOf (G := G) (d := d) e
+        (edgeMergeConfig (G := G) (d := d) e τl τr τm) = τm := by
+  funext w
+  obtain ⟨w, hw⟩ := w
+  have h1 : w ≠ e.1.1 := ((mem_edgeMiddleVertices_iff e w).mp hw).1
+  have h2 : w ≠ e.1.2 := ((mem_edgeMiddleVertices_iff e w).mp hw).2
+  simp [edgeMiddlePhysicalConfigOf, edgeMergeConfig, h1, h2, hw]
+
+/-- At a merged physical configuration the open middle weight is the middle
+tensor family evaluated on the chosen middle physical leg. -/
+theorem edgeOpenMiddleWeight_merge (A : Tensor G d) (e : Edge G) (τl τr : Fin d)
+    (τm : EdgeMiddlePhysicalConfig (G := G) (d := d) e)
+    (ρl : ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e))
+    (ρr : ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e)) :
+    edgeOpenMiddleWeight (G := G) A e (edgeMergeConfig (G := G) (d := d) e τl τr τm) ρl ρr =
+      edgeMiddleTensorFamily (G := G) A e (ρl, ρr) τm := by
+  rw [edgeOpenMiddleWeight_eq_on, edgeMergeConfig_middle]
+  rfl
+
+/-- A sum over edge boundary configurations of a summand `f β` times the middle
+tensor family is the middle tensor map applied to the per-residual-label
+bond-index sum of `f`. This is the algebraic shape that the middle left inverse
+peels. -/
+theorem sum_edgeBoundary_eq_edgeMiddleTensorMap (A : Tensor G d) (e : Edge G)
+    (τm : EdgeMiddlePhysicalConfig (G := G) (d := d) e)
+    (f : EdgeBoundaryConfig (G := G) A e → ℂ) :
+    (∑ β : EdgeBoundaryConfig (G := G) A e,
+        f β *
+          edgeMiddleTensorFamily (G := G) A e (β.leftResidual, β.rightResidual) τm) =
+      edgeMiddleTensorMap (G := G) A e
+        (fun ρ => ∑ k : Fin (A.bondDim e),
+          f { edgeIndex := k, leftResidual := ρ.1, rightResidual := ρ.2 }) τm := by
+  classical
+  rw [edgeMiddleTensorMap, Fintype.linearCombination_apply, Finset.sum_apply]
+  simp only [Pi.smul_apply, smul_eq_mul, Finset.sum_mul]
+  rw [← Equiv.sum_comp (edgeBoundaryConfigEquivProd (G := G) A e).symm
+        (fun β => f β *
+          edgeMiddleTensorFamily (G := G) A e (β.leftResidual, β.rightResidual) τm)]
+  rw [Fintype.sum_prod_type, Finset.sum_comm]
+  exact Finset.sum_congr rfl fun ρ _ => Finset.sum_congr rfl fun k _ => rfl
+
+/-- The middle-inverted resonate identity.
+
+After inverting the middle block of the edge-blocked three-site chain, the
+equality of the two neighboring physical insertions (`hEq`) becomes, for each
+choice of endpoint physical legs `τl, τr` and residual boundary labels
+`ρl, ρr`, an equality of bond-contracted products of the two endpoint tensors.
+The shared bond index `k` is summed on both sides; the left side carries the
+left-endpoint physical operator `O₁`, the right side the right-endpoint operator
+`O₂`.
+
+This is the formal content of the first equality in `eq:inj_O->X_argument`: the
+$D_{23}^{-1}$ middle contraction-inverse strips the middle block off
+`eq:resonate`. The middle left inverse `edgeMiddleLeftInverse` is exactly the
+inverse applied here.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, `eq:resonate`--
+`eq:inj_O->X_argument`, lines 355--457 of the local paper source. -/
+theorem resonate_middle_inverted (A : Tensor G d) (e : Edge G)
+    (hMid : EdgeMiddleTensorInjective (G := G) A e)
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hEq : ∀ σ : V → Fin d,
+      (∑ β : EdgeBoundaryConfig (G := G) A e,
+        O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2))
+    (τl τr : Fin d)
+    (ρl : ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e))
+    (ρr : ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e)) :
+    (∑ k : Fin (A.bondDim e),
+      O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e
+        { edgeIndex := k, leftResidual := ρl, rightResidual := ρr })) τl *
+        A.component e.1.2 (edgeRightLocalConfig (G := G) A e
+          { edgeIndex := k, leftResidual := ρl, rightResidual := ρr }) τr) =
+      ∑ k : Fin (A.bondDim e),
+        A.component e.1.1 (edgeLeftLocalConfig (G := G) A e
+          { edgeIndex := k, leftResidual := ρl, rightResidual := ρr }) τl *
+          O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e
+            { edgeIndex := k, leftResidual := ρl, rightResidual := ρr })) τr := by
+  classical
+  set fL : EdgeBoundaryConfig (G := G) A e → ℂ := fun β =>
+    O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) τl *
+      A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) τr with hfL
+  set fR : EdgeBoundaryConfig (G := G) A e → ℂ := fun β =>
+    A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) τl *
+      O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) τr with hfR
+  have hmapEq :
+      edgeMiddleTensorMap (G := G) A e
+          (fun ρ => ∑ k,
+            fL { edgeIndex := k, leftResidual := ρ.1, rightResidual := ρ.2 }) =
+        edgeMiddleTensorMap (G := G) A e
+          (fun ρ => ∑ k,
+            fR { edgeIndex := k, leftResidual := ρ.1, rightResidual := ρ.2 }) := by
+    funext τm
+    rw [← sum_edgeBoundary_eq_edgeMiddleTensorMap,
+      ← sum_edgeBoundary_eq_edgeMiddleTensorMap]
+    have h := hEq (edgeMergeConfig (G := G) (d := d) e τl τr τm)
+    rw [edgeMergeConfig_left, edgeMergeConfig_right] at h
+    simp only [edgeOpenMiddleWeight_merge] at h
+    rw [hfL, hfR]
+    refine Eq.trans ?_ (h.trans ?_)
+    · exact Finset.sum_congr rfl fun β _ => by ring
+    · exact Finset.sum_congr rfl fun β _ => by ring
+  have hcoeff := edgeMiddleTensorMap_injective_of_injective hMid hmapEq
+  have := congrFun hcoeff (ρl, ρr)
+  simpa [hfL, hfR] using this
+
 /-- Equal neighboring physical insertions recover a common virtual matrix on the
 shared edge.
 
@@ -354,13 +570,30 @@ $O_2\Phi_v=\Phi_vT_{v,e}(M)$.
 Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, equations
 eq:resonate--eq:O->X, lines 355--486 of the local paper source.
 
-**Proof status:** This declaration states the source recovery step used by the
-insertion-algebra theorem. The current formal status is recorded in
+**Positive-bond hypothesis (faithfulness fix).** Without `hpos` the statement is
+false: a zero-dimensional edge incident to an endpoint empties the edge boundary
+configuration, so `hEq` holds vacuously while the recovery conclusion remains a
+genuine constraint that fails for a nontrivial right-endpoint operator. The
+checked counterexample is `PhysicalToVirtualInsertionStatement_false` in
+`TNLean/PEPS/PhysicalToVirtualCounterexample.lean`. The hypothesis `hpos` (every
+bond dimension positive) is the source's standing assumption that injective PEPS
+have nonzero virtual bond spaces; the same defect was corrected for the
+edge-blocked three-site injectivity (issue #1366).
+
+**Proof status:** open (`sorry`). The middle-block half of
+`eq:inj_O->X_argument` is now formalized: `edgeMiddleLeftInverse` is the
+contraction-inverse of the blocked middle tensor, and `resonate_middle_inverted`
+applies it to `hEq` to strip the middle block, leaving the bond-contracted
+endpoint identity. The remaining step is the endpoint inversion: inverting the
+right endpoint (resp. left endpoint) to read off `M` (resp. `V`) as a bond
+matrix and reconciling them by full three-site injectivity. The current formal
+status is recorded in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
 mathematical obligations". -/
 theorem physical_to_virtual_insertion
     (A : Tensor G d) (e : Edge G)
     (hA : EdgeBlockedThreeSiteInjective (G := G) A e)
+    (hpos : ∀ f : Edge G, 0 < A.bondDim f)
     (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
     (hEq : ∀ σ : V → Fin d,
       (∑ β : EdgeBoundaryConfig (G := G) A e,

--- a/TNLean/PEPS/InsertionRealization.lean
+++ b/TNLean/PEPS/InsertionRealization.lean
@@ -28,13 +28,12 @@ corresponding endpoint.
 
 ## Status
 
-The endpoint theorem
-`edgePhysicalToVirtualInsertion_of_projected_realization_eq` is a
-proof-complete consequence once the common matrix, projected realizations, and
-image preservation are supplied. The source-level theorem
-`physical_to_virtual_insertion` still records the remaining
-\(O_1,O_2 \mapsto W\) obligation: deriving those hypotheses from equality of
-the two endpoint physical actions on the edge-blocked three-site state.
+The source-level theorem `physical_to_virtual_insertion` is proved: equality of
+the two endpoint physical actions on the edge-blocked three-site state yields a
+common matrix on the shared bond realizing both. The middle block is removed by
+`resonate_middle_inverted`; the two endpoints are inverted by
+`resonate_invert_right_endpoint` and `resonate_invert_left_endpoint`; the two
+extracted matrices are reconciled by `resonate_endpoint_coeff_reconcile`.
 -/
 
 namespace TNLean
@@ -557,6 +556,282 @@ theorem resonate_middle_inverted (A : Tensor G d) (e : Edge G)
   have := congrFun hcoeff (ρl, ρr)
   simpa [hfL, hfR] using this
 
+/-! ### Endpoint inversion
+
+The bond-contracted endpoint identity of `resonate_middle_inverted` is the
+middle-stripped form of `eq:resonate`. Inverting one endpoint tensor reads the
+neighboring physical operator off as a one-edge matrix action on the other
+endpoint. This is the "invert $B_2$" / "invert $B_1$" step of
+`eq:inj_O->X_argument`. The two extracted coefficient families are matched by the
+left inverse, which is the injectivity argument forcing $V=W$ in the source.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, `eq:inj_O->X_argument`,
+lines 377--457 of the local paper source. -/
+
+/-- Inverting the right endpoint of the bond-contracted resonate identity writes
+the left physical operator as a one-edge matrix action on the left endpoint.
+
+Applying the right-endpoint left inverse to `resonate_middle_inverted` isolates,
+for every residual boundary configuration, the action of `O₁` on a left tensor
+vector as a bond-indexed combination of left tensor vectors with the same
+residual. The combining coefficient is the right-endpoint left inverse of the
+right physical action; it is read at the fixed residual `ρr` and so does not
+depend on the left residual. This is the "invert $B_2$" half of
+`eq:inj_O->X_argument`.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, `eq:inj_O->X_argument`,
+lines 377--457 of the local paper source. -/
+theorem resonate_invert_right_endpoint (A : Tensor G d) (e : Edge G)
+    (hMid : EdgeMiddleTensorInjective (G := G) A e)
+    (hv : LinearIndependent ℂ (A.component e.1.2))
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hEq : ∀ σ : V → Fin d,
+      (∑ β : EdgeBoundaryConfig (G := G) A e,
+        O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2))
+    (ρl : ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e))
+    (ρr : ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e))
+    (x : Fin (A.bondDim e)) :
+    O₁ (A.component e.1.1
+        ((localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e)).symm (x, ρl))) =
+      ∑ k : Fin (A.bondDim e),
+        (localLeftInverseAt A hv
+          (O₂ (A.component e.1.2
+            ((localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e)).symm (k, ρr))))
+          ((localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e)).symm (x, ρr))) •
+        A.component e.1.1
+          ((localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e)).symm (k, ρl)) := by
+  classical
+  set sL := localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e) with hsL
+  set sR := localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e) with hsR
+  set AL : Fin (A.bondDim e) → (Fin d → ℂ) := fun k => A.component e.1.1 (sL.symm (k, ρl))
+    with hAL
+  set AR : Fin (A.bondDim e) → (Fin d → ℂ) := fun k => A.component e.1.2 (sR.symm (k, ρr))
+    with hAR
+  have hcontract : ∀ τl τr : Fin d,
+      (∑ k : Fin (A.bondDim e), O₁ (AL k) τl * AR k τr) =
+        ∑ k : Fin (A.bondDim e), AL k τl * O₂ (AR k) τr := by
+    intro τl τr
+    have h := resonate_middle_inverted (G := G) A e hMid O₁ O₂ hEq τl τr ρl ρr
+    simpa [hAL, hAR] using h
+  set ΦR := localTensorMap A e.1.2
+  set ΨR := localLeftInverseAt A hv
+  funext τl
+  have hvec : (∑ k : Fin (A.bondDim e), (O₁ (AL k) τl) • AR k) =
+      ∑ k : Fin (A.bondDim e), (AL k τl) • O₂ (AR k) := by
+    funext τr
+    simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+    exact hcontract τl τr
+  have hARsingle : ∀ k, AR k =
+      ΦR ((Pi.single (sR.symm (k, ρr)) (1 : ℂ) : LocalVirtualConfig A e.1.2 → ℂ)) := by
+    intro k
+    rw [localTensorMap_apply_single]
+  have hLHS : (∑ k : Fin (A.bondDim e), (O₁ (AL k) τl) • AR k) =
+      ΦR (∑ k : Fin (A.bondDim e),
+        (O₁ (AL k) τl) • (Pi.single (sR.symm (k, ρr)) (1 : ℂ) :
+          LocalVirtualConfig A e.1.2 → ℂ)) := by
+    rw [map_sum]
+    refine Finset.sum_congr rfl ?_
+    intro k _
+    rw [map_smul, ← hARsingle k]
+  have hΨ : ΨR (∑ k : Fin (A.bondDim e), (O₁ (AL k) τl) • AR k) =
+      ΨR (∑ k : Fin (A.bondDim e), (AL k τl) • O₂ (AR k)) := by rw [hvec]
+  rw [hLHS, localLeftInverseAt_apply_localTensorMap, map_sum] at hΨ
+  simp only [map_smul] at hΨ
+  have hEval := congrFun hΨ (sR.symm (x, ρr))
+  simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul] at hEval
+  have hLHSeval : (∑ k : Fin (A.bondDim e),
+        O₁ (AL k) τl *
+          (Pi.single (sR.symm (k, ρr)) (1 : ℂ) : LocalVirtualConfig A e.1.2 → ℂ)
+            (sR.symm (x, ρr))) =
+      O₁ (AL x) τl := by
+    rw [Finset.sum_eq_single x]
+    · rw [Pi.single_eq_same, mul_one]
+    · intro k _ hk
+      have hne : sR.symm (x, ρr) ≠ sR.symm (k, ρr) := by
+        intro h
+        apply hk
+        have := congrArg Prod.fst (sR.symm.injective h)
+        simpa using this.symm
+      rw [Pi.single_eq_of_ne hne, mul_zero]
+    · intro hx; exact absurd (Finset.mem_univ x) hx
+  rw [hLHSeval] at hEval
+  rw [hEval, Finset.sum_apply]
+  refine Finset.sum_congr rfl ?_
+  intro k _
+  rw [Pi.smul_apply, smul_eq_mul, mul_comm]
+
+/-- Inverting the left endpoint of the bond-contracted resonate identity writes
+the right physical operator as a one-edge matrix action on the right endpoint.
+
+This is the mirror of `resonate_invert_right_endpoint`: applying the
+left-endpoint left inverse isolates the action of `O₂` on a right tensor vector
+as a bond-indexed combination of right tensor vectors with the same residual.
+This is the "invert $B_1$" half of `eq:inj_O->X_argument`.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, `eq:inj_O->X_argument`,
+lines 377--457 of the local paper source. -/
+theorem resonate_invert_left_endpoint (A : Tensor G d) (e : Edge G)
+    (hMid : EdgeMiddleTensorInjective (G := G) A e)
+    (hu : LinearIndependent ℂ (A.component e.1.1))
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hEq : ∀ σ : V → Fin d,
+      (∑ β : EdgeBoundaryConfig (G := G) A e,
+        O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2))
+    (ρl : ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e))
+    (ρr : ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e))
+    (x : Fin (A.bondDim e)) :
+    O₂ (A.component e.1.2
+        ((localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e)).symm (x, ρr))) =
+      ∑ k : Fin (A.bondDim e),
+        (localLeftInverseAt A hu
+          (O₁ (A.component e.1.1
+            ((localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e)).symm (k, ρl))))
+          ((localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e)).symm (x, ρl))) •
+        A.component e.1.2
+          ((localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e)).symm (k, ρr)) := by
+  classical
+  set sL := localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e) with hsL
+  set sR := localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e) with hsR
+  set AL : Fin (A.bondDim e) → (Fin d → ℂ) := fun k => A.component e.1.1 (sL.symm (k, ρl))
+    with hAL
+  set AR : Fin (A.bondDim e) → (Fin d → ℂ) := fun k => A.component e.1.2 (sR.symm (k, ρr))
+    with hAR
+  have hcontract : ∀ τl τr : Fin d,
+      (∑ k : Fin (A.bondDim e), O₁ (AL k) τl * AR k τr) =
+        ∑ k : Fin (A.bondDim e), AL k τl * O₂ (AR k) τr := by
+    intro τl τr
+    have h := resonate_middle_inverted (G := G) A e hMid O₁ O₂ hEq τl τr ρl ρr
+    simpa [hAL, hAR] using h
+  set ΦL := localTensorMap A e.1.1
+  set ΨL := localLeftInverseAt A hu
+  funext τr
+  have hvec : (∑ k : Fin (A.bondDim e), (AR k τr) • O₁ (AL k)) =
+      ∑ k : Fin (A.bondDim e), (O₂ (AR k) τr) • AL k := by
+    funext τl
+    simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+    have h := hcontract τl τr
+    calc (∑ k, AR k τr * O₁ (AL k) τl) = ∑ k, O₁ (AL k) τl * AR k τr := by
+          refine Finset.sum_congr rfl ?_; intro k _; rw [mul_comm]
+      _ = ∑ k, AL k τl * O₂ (AR k) τr := h
+      _ = ∑ k, O₂ (AR k) τr * AL k τl := by
+          refine Finset.sum_congr rfl ?_; intro k _; rw [mul_comm]
+  have hALsingle : ∀ k, AL k =
+      ΦL ((Pi.single (sL.symm (k, ρl)) (1 : ℂ) : LocalVirtualConfig A e.1.1 → ℂ)) := by
+    intro k
+    rw [localTensorMap_apply_single]
+  have hRHS : (∑ k : Fin (A.bondDim e), (O₂ (AR k) τr) • AL k) =
+      ΦL (∑ k : Fin (A.bondDim e),
+        (O₂ (AR k) τr) • (Pi.single (sL.symm (k, ρl)) (1 : ℂ) :
+          LocalVirtualConfig A e.1.1 → ℂ)) := by
+    rw [map_sum]
+    refine Finset.sum_congr rfl ?_
+    intro k _
+    rw [map_smul, ← hALsingle k]
+  have hΨ : ΨL (∑ k : Fin (A.bondDim e), (AR k τr) • O₁ (AL k)) =
+      ΨL (∑ k : Fin (A.bondDim e), (O₂ (AR k) τr) • AL k) := by rw [hvec]
+  rw [hRHS, localLeftInverseAt_apply_localTensorMap, map_sum] at hΨ
+  simp only [map_smul] at hΨ
+  have hEval := congrFun hΨ (sL.symm (x, ρl))
+  simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul] at hEval
+  have hRHSeval : (∑ k : Fin (A.bondDim e),
+        O₂ (AR k) τr *
+          (Pi.single (sL.symm (k, ρl)) (1 : ℂ) : LocalVirtualConfig A e.1.1 → ℂ)
+            (sL.symm (x, ρl))) =
+      O₂ (AR x) τr := by
+    rw [Finset.sum_eq_single x]
+    · rw [Pi.single_eq_same, mul_one]
+    · intro k _ hk
+      have hne : sL.symm (x, ρl) ≠ sL.symm (k, ρl) := by
+        intro h
+        apply hk
+        have := congrArg Prod.fst (sL.symm.injective h)
+        simpa using this.symm
+      rw [Pi.single_eq_of_ne hne, mul_zero]
+    · intro hx; exact absurd (Finset.mem_univ x) hx
+  rw [hRHSeval] at hEval
+  rw [← hEval, Finset.sum_apply]
+  refine Finset.sum_congr rfl ?_
+  intro k _
+  rw [Pi.smul_apply, smul_eq_mul, mul_comm]
+
+/-- The two endpoint-inverted coefficient families agree.
+
+The combining coefficient produced by inverting the right endpoint at a fixed
+reference residual equals the one produced by inverting the left endpoint at a
+fixed reference residual, with the two bond indices exchanged. This is the
+formal version of the source step $V=W$: full three-site injectivity forces the
+two one-edge matrices read off from the two inversions to coincide.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, `eq:inj_O->X_argument`,
+lines 377--457 of the local paper source. -/
+theorem resonate_endpoint_coeff_reconcile (A : Tensor G d) (e : Edge G)
+    (hMid : EdgeMiddleTensorInjective (G := G) A e)
+    (hu : LinearIndependent ℂ (A.component e.1.1))
+    (hv : LinearIndependent ℂ (A.component e.1.2))
+    (O₁ O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
+    (hEq : ∀ σ : V → Fin d,
+      (∑ β : EdgeBoundaryConfig (G := G) A e,
+        O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2))
+    (ρl : ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e))
+    (ρr : ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e))
+    (x k : Fin (A.bondDim e)) :
+    localLeftInverseAt A hu
+        (O₁ (A.component e.1.1
+          ((localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e)).symm (k, ρl))))
+        ((localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e)).symm (x, ρl)) =
+      localLeftInverseAt A hv
+        (O₂ (A.component e.1.2
+          ((localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e)).symm (x, ρr))))
+        ((localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e)).symm (k, ρr)) := by
+  classical
+  set sL := localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e) with hsL
+  set sR := localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e) with hsR
+  set ΨL := localLeftInverseAt A hu
+  have hL := resonate_invert_right_endpoint (G := G) A e hMid hv O₁ O₂ hEq ρl ρr k
+  have hΨ : ΨL (O₁ (A.component e.1.1 (sL.symm (k, ρl)))) =
+      ΨL (∑ j : Fin (A.bondDim e),
+        (localLeftInverseAt A hv (O₂ (A.component e.1.2 (sR.symm (j, ρr))))
+          (sR.symm (k, ρr))) • A.component e.1.1 (sL.symm (j, ρl))) := by
+    rw [hL]
+  rw [map_sum] at hΨ
+  simp only [map_smul] at hΨ
+  have hEval := congrFun hΨ (sL.symm (x, ρl))
+  simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul] at hEval
+  have hΨcomp : ∀ j, ΨL (A.component e.1.1 (sL.symm (j, ρl))) =
+      (Pi.single (sL.symm (j, ρl)) (1 : ℂ) : LocalVirtualConfig A e.1.1 → ℂ) := by
+    intro j
+    rw [← localTensorMap_apply_single]
+    exact localLeftInverseAt_apply_localTensorMap A hu _
+  simp only [hΨcomp] at hEval
+  rw [hEval, Finset.sum_eq_single x]
+  · rw [Pi.single_eq_same, mul_one]
+  · intro j _ hj
+    have hne : sL.symm (x, ρl) ≠ sL.symm (j, ρl) := by
+      intro h
+      apply hj
+      have := congrArg Prod.fst (sL.symm.injective h)
+      simpa using this.symm
+    rw [Pi.single_eq_of_ne hne, mul_zero]
+  · intro hx; exact absurd (Finset.mem_univ x) hx
+
 /-- Equal neighboring physical insertions recover a common virtual matrix on the
 shared edge.
 
@@ -580,16 +855,15 @@ bond dimension positive) is the source's standing assumption that injective PEPS
 have nonzero virtual bond spaces; the same defect was corrected for the
 edge-blocked three-site injectivity (issue #1366).
 
-**Proof status:** open (`sorry`). The middle-block half of
-`eq:inj_O->X_argument` is now formalized: `edgeMiddleLeftInverse` is the
-contraction-inverse of the blocked middle tensor, and `resonate_middle_inverted`
-applies it to `hEq` to strip the middle block, leaving the bond-contracted
-endpoint identity. The remaining step is the endpoint inversion: inverting the
-right endpoint (resp. left endpoint) to read off `M` (resp. `V`) as a bond
-matrix and reconciling them by full three-site injectivity. The current formal
-status is recorded in
-`docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
-mathematical obligations". -/
+**Proof.** `edgeMiddleLeftInverse` is the contraction-inverse of the blocked
+middle tensor, and `resonate_middle_inverted` applies it to `hEq` to strip the
+middle block, leaving the bond-contracted endpoint identity. Inverting the right
+endpoint (`resonate_invert_right_endpoint`) reads the common bond matrix `M` off
+the left physical action; inverting the left endpoint
+(`resonate_invert_left_endpoint`) reads the right physical action off as a bond
+matrix, and `resonate_endpoint_coeff_reconcile` forces the two to agree, which
+is the source step $V=W$. The positivity hypothesis supplies the reference
+residual configurations used to fix `M`. -/
 theorem physical_to_virtual_insertion
     (A : Tensor G d) (e : Edge G)
     (hA : EdgeBlockedThreeSiteInjective (G := G) A e)
@@ -613,7 +887,86 @@ theorem physical_to_virtual_insertion
           O₂ (localTensorMap A e.1.2 c) =
             localTensorMap A e.1.2
               (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M c) := by
-  sorry
+  classical
+  obtain ⟨hu, hv⟩ := hA.endpoint_linearIndependent
+  have hMid := hA.middle_injective
+  set sL := localVirtualConfigSplitAt (G := G) A (edgeLeftIncident (G := G) e) with hsL
+  set sR := localVirtualConfigSplitAt (G := G) A (edgeRightIncident (G := G) e) with hsR
+  -- Reference residual configurations, nonempty because every bond is positive.
+  set ρl0 : ResidualLocalConfig (G := G) A (edgeLeftIncident (G := G) e) :=
+    fun je => ⟨0, hpos je.1.1⟩ with hρl0
+  set ρr0 : ResidualLocalConfig (G := G) A (edgeRightIncident (G := G) e) :=
+    fun je => ⟨0, hpos je.1.1⟩ with hρr0
+  -- The common bond matrix, read off from the right-endpoint inversion.
+  set M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ :=
+    fun a b => localLeftInverseAt A hv
+      (O₂ (A.component e.1.2 (sR.symm (a, ρr0)))) (sR.symm (b, ρr0)) with hM
+  refine ⟨M, ?_, ?_⟩
+  · -- Left endpoint: O₁ realizes the matrix action of Mᵀ.
+    have hLbasis : ∀ η : LocalVirtualConfig A e.1.1,
+        O₁ (A.component e.1.1 η) =
+          localTensorMap A e.1.1
+            (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) M.transpose
+              (Pi.single η (1 : ℂ))) := by
+      intro η
+      have hηeq : η = sL.symm (((sL η).1, (sL η).2)) := by
+        rw [Prod.mk.eta, Equiv.symm_apply_apply]
+      rw [hηeq, localTensorMap_localIncidentMatrixOp_single (G := G) A
+        (edgeLeftIncident (G := G) e) _ (sL η).1 (sL η).2]
+      have hL := resonate_invert_right_endpoint (G := G) A e hMid hv O₁ O₂ hEq
+        (sL η).2 ρr0 (sL η).1
+      rw [hsL] at hL ⊢
+      rw [hL]
+      refine Finset.sum_congr rfl ?_
+      intro k _
+      rw [Matrix.transpose_apply, hM]
+    intro c
+    rw [← Finset.univ_sum_single c]
+    simp only [map_sum]
+    refine Finset.sum_congr rfl ?_
+    intro η _
+    have hsingle : (Pi.single η (c η) : LocalVirtualConfig A e.1.1 → ℂ) =
+        c η • (Pi.single η (1 : ℂ) : LocalVirtualConfig A e.1.1 → ℂ) := by
+      rw [← Pi.single_smul', smul_eq_mul, mul_one]
+    rw [hsingle]
+    simp only [map_smul]
+    congr 1
+    rw [localTensorMap_apply_single]
+    exact hLbasis η
+  · -- Right endpoint: O₂ realizes the matrix action of M.
+    have hRbasis : ∀ η : LocalVirtualConfig A e.1.2,
+        O₂ (A.component e.1.2 η) =
+          localTensorMap A e.1.2
+            (localIncidentMatrixOp A (edgeRightIncident (G := G) e) M
+              (Pi.single η (1 : ℂ))) := by
+      intro η
+      have hηeq : η = sR.symm (((sR η).1, (sR η).2)) := by
+        rw [Prod.mk.eta, Equiv.symm_apply_apply]
+      rw [hηeq, localTensorMap_localIncidentMatrixOp_single (G := G) A
+        (edgeRightIncident (G := G) e) _ (sR η).1 (sR η).2]
+      have hR := resonate_invert_left_endpoint (G := G) A e hMid hu O₁ O₂ hEq
+        ρl0 (sR η).2 (sR η).1
+      rw [hsR] at hR ⊢
+      rw [hR]
+      refine Finset.sum_congr rfl ?_
+      intro k _
+      rw [hM]
+      have hrec := resonate_endpoint_coeff_reconcile (G := G) A e hMid hu hv O₁ O₂ hEq
+        ρl0 ρr0 (sR η).1 k
+      rw [hrec]
+    intro c
+    rw [← Finset.univ_sum_single c]
+    simp only [map_sum]
+    refine Finset.sum_congr rfl ?_
+    intro η _
+    have hsingle : (Pi.single η (c η) : LocalVirtualConfig A e.1.2 → ℂ) =
+        c η • (Pi.single η (1 : ℂ) : LocalVirtualConfig A e.1.2 → ℂ) := by
+      rw [← Pi.single_smul', smul_eq_mul, mul_one]
+    rw [hsingle]
+    simp only [map_smul]
+    congr 1
+    rw [localTensorMap_apply_single]
+    exact hRbasis η
 
 /-- The left-endpoint physical realization of a virtual matrix insertion
 reproduces the full inserted-edge coefficient.

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1734,7 +1734,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
         def:peps_edgeOpenMiddleWeight, def:peps_localTensorMap,
         def:peps_localIncidentMatrixOp}
     Let $e=(u,v)$. Assume that the edge-blocked three-site chain at $e$ is
-    injective. Let $O_1,O_2$ be physical operators at the endpoint tensors, and
+    injective and that every virtual bond has positive dimension. Let $O_1,O_2$
+    be physical operators at the endpoint tensors, and
     write $\Phi_u,\Phi_v$ for the two local tensor maps. Suppose that, for every
     physical configuration $\sigma$,
     \[
@@ -1764,6 +1765,19 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \cite[Section~3]{Molnar2018NormalPEPS}, where the recovered matrix is
     denoted $W$.
 \end{theorem}
+\begin{proof}\leanok
+    Contracting the middle block out of the hypothesis leaves a bond-contracted
+    identity between the two endpoint tensors, holding for every residual
+    boundary configuration. Inverting the right endpoint of this identity writes
+    the action of $O_1$ on a left tensor vector as a bond-indexed combination of
+    left tensor vectors with the same residual; the combining coefficients are
+    read at a fixed reference right residual and define $M$. Inverting the left
+    endpoint writes the action of $O_2$ on a right tensor vector as a bond-indexed
+    combination of right tensor vectors. The left inverse identifies the two
+    coefficient families, which is the source step $V=W$, so the right-endpoint
+    combination is also governed by $M$. The reference residuals exist because
+    every virtual bond has positive dimension.
+\end{proof}
 
 \begin{definition}[Edge-blocked insertion algebra correspondence]%
     \label{def:peps_edgeBlockedInsertionAlgebraIsomorphism_property}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -254,24 +254,27 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   independent inserted-edge index at the corresponding endpoint. On the left
   endpoint the formal statement uses the transpose of the inserted matrix,
   because the ordinary boundary supplies the right bond index. The source
-  recovery $O_1,O_2\mapsto W$ is stated as
-  \leanid{TNLean.PEPS.physical_to_virtual_insertion}; its proof remains open and
-  is tracked by issue~\#1370.
-  Its local endpoint recovery component is now formalized by
+  recovery $O_1,O_2\mapsto W$ is proved as
+  \leanid{TNLean.PEPS.physical_to_virtual_insertion} (issue~\#1370). The
+  middle block is contracted out by
+  \leanid{TNLean.PEPS.resonate_middle_inverted}, leaving the bond-contracted
+  endpoint identity. Inverting the right endpoint
+  (\leanid{TNLean.PEPS.resonate_invert_right_endpoint}) reads the common matrix
+  $M$ off the action of $O_1$; inverting the left endpoint
+  (\leanid{TNLean.PEPS.resonate_invert_left_endpoint}) reads the action of $O_2$
+  off as a bond matrix, and
+  \leanid{TNLean.PEPS.resonate_endpoint_coeff_reconcile} forces the two to
+  agree, which is the source step $V=W$. The positivity hypothesis on the
+  virtual bond dimensions supplies the reference residual configurations used to
+  fix $M$.
+  Its local endpoint recovery component is also formalized by
   \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}:
   once the compressed endpoint actions are known to realize the same bond
   matrix, the local virtual pullbacks recover that matrix on the shared bond.
   The image-preserving conditional form
   \leanid{TNLean.PEPS.edgePhysicalToVirtualInsertion_of_projected_realization_eq}
-  has the endpoint conclusion of the source theorem: if those same projected
-  realizations hold and the two endpoint physical operators preserve the local
-  tensor images, then $O_1\Phi_u=\Phi_uT_{u,e}(M^{\mathsf T})$ and
-  $O_2\Phi_v=\Phi_vT_{v,e}(M)$. This conditional endpoint theorem is not a
-  replacement for
-  \leanid{TNLean.PEPS.physical_to_virtual_insertion}: the remaining paper step
-  is to obtain the common matrix, the two projected-realization identities, and
-  the image-preservation hypotheses from equality of the neighboring physical
-  actions on the edge-blocked three-site state.
+  records the endpoint conclusion under explicit projected-realization and
+  image-preservation hypotheses.
 \item Equality of PEPS states must be upgraded to equality of edge-inserted
   coefficients after the three-site reduction. This is the step that produces
   the matrix-algebra isomorphism on the chosen bond. The formally stated
@@ -373,19 +376,21 @@ It is meant to prevent the proof from drifting away from the source argument.
   endpoint coefficient expansion. These are tracked by issues~\#1369
   and~\#1995.
 \item Lemma \path{inj_isomorph}, $O_1,O_2\mapsto W$:
-  \leanid{TNLean.PEPS.physical_to_virtual_insertion} states the source recovery
-  step; its proof remains open and is tracked by issue~\#1370.
-  The endpoint projected-recovery component for a common bond matrix is
+  \leanid{TNLean.PEPS.physical_to_virtual_insertion} proves the source recovery
+  step (issue~\#1370). The middle block is contracted out by
+  \leanid{TNLean.PEPS.resonate_middle_inverted}; the two endpoints are inverted
+  by \leanid{TNLean.PEPS.resonate_invert_right_endpoint} and
+  \leanid{TNLean.PEPS.resonate_invert_left_endpoint}; the two extracted matrices
+  are reconciled by
+  \leanid{TNLean.PEPS.resonate_endpoint_coeff_reconcile}. The positivity
+  hypothesis on the virtual bond dimensions supplies the reference residual
+  configurations used to fix the recovered matrix.
+  The endpoint projected-recovery component for a common bond matrix is also
   formalized by
-  \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq}.
-  The conditional theorem
+  \leanid{TNLean.PEPS.edgeEndpointLocalVirtualOpOfPhysicalOp_eq_of_projected_realization_eq},
+  and the conditional theorem
   \leanid{TNLean.PEPS.edgePhysicalToVirtualInsertion_of_projected_realization_eq}
-  additionally removes the endpoint projectors under explicit
-  image-preservation hypotheses. The missing paper step is to obtain these
-  hypotheses, and the common bond matrix, from equality of the two neighboring
-  physical actions on the edge-blocked state. Thus the conditional endpoint
-  theorem is a component of issue~\#1370, not the closure of that source-level
-  obligation.
+  records the endpoint conclusion under explicit image-preservation hypotheses.
 \item Matrix-insertion algebra isomorphism:
   \leanid{TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism} states the
   edge-blocked matrix-algebra correspondence and its inserted-coefficient


### PR DESCRIPTION
## Summary

Verified proof infrastructure toward closing `physical_to_virtual_insertion` (#1370), stacked on the engine refactor #2396 (and depends on the `hpos` correction #2392, included here redundantly).

The "contraction-inverse" the paper's invert-B₂B₃ recovery needs is just the **left inverse of the already-proven-injective middle tensor family** — the same `LinearIndependent → left inverse` pattern (`LinearMap.exists_leftInverse_of_injective`) the per-vertex engine uses.

## What lands (all sorry-free, `#print axioms`-clean)

- `edgeMiddleTensorMap` + `edgeMiddleTensorMap_injective_of_injective` / `_ker_eq_bot_of_injective`.
- **`edgeMiddleLeftInverse`** (+ `_comp_`/`_apply_` simp lemmas) — the middle-block left inverse, built from `EdgeMiddleTensorInjective`, mirroring `localLeftInverseAt`.
- `edgeMergeConfig` (+ projections) — reassembles the three disjoint physical legs into a global config.
- `edgeOpenMiddleWeight_merge`, `sum_edgeBoundary_eq_edgeMiddleTensorMap`.
- **`resonate_middle_inverted`** — applies `edgeMiddleLeftInverse` to `hEq`, stripping the middle block (the middle half of `eq:inj_O->X_argument`).
- The `hpos` correction on `physical_to_virtual_insertion` (matching #2392).

## Remaining step (precisely scoped)

After `resonate_middle_inverted` the problem is the **endpoint inversion**: invert the complementary two-block (left+middle, then middle+right) against `O₂`/`O₁` to extract the bond matrix `M`/`V`, get `V = M` by full three-site injectivity, and match coefficients via `hA.right_injective`. This needs a *combined* two-block left inverse (compose `edgeMiddleLeftInverse` with the endpoint `localLeftInverse`), which is the next module. The image-preservation hypotheses of `edgePhysicalToVirtualInsertion_of_endpointInjective` cannot be assumed (they are part of the conclusion), so the faithful route is this complementary-block inversion.

## Verification

`lake build TNLean.PEPS.InsertionRealization` exit 0; the only `sorry` is the target `physical_to_virtual_insertion` (honest — `#print axioms` shows `sorryAx`); every new lemma is `[propext, Classical.choice, Quot.sound]`. Refs #1370.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proof in core PEPS injectivity route; statement change (`hpos`) affects downstream callers of `physical_to_virtual_insertion`.
> 
> **Overview**
> Closes the PEPS **physical-to-virtual insertion** step (`physical_to_virtual_insertion`, issue #1370) by replacing the previous `sorry` with a full Lean proof and aligning the blueprint and gap docs.
> 
> The proof chain adds **middle-block** machinery (`edgeMiddleTensorMap`, `edgeMiddleLeftInverse`) and **leg-merging** lemmas (`edgeMergeConfig`, `resonate_middle_inverted`) to strip the middle tensor from the resonate equality. **Endpoint inversion** (`resonate_invert_right_endpoint`, `resonate_invert_left_endpoint`) and **`resonate_endpoint_coeff_reconcile`** extract a common bond matrix \(M\) and match the two sides (\(V=W\)). The theorem now requires **`hpos`** (positive bond dimension on every edge) so vacuous zero-bond cases cannot satisfy `hEq` while failing recovery; documentation points to the counterexample module.
> 
> Blueprint Ch. 13a and `peps_injective_ft_section3_route.tex` are updated to state the result as proved and to cite the new lemma names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1480aefc606a7fb72bd29a9dbc2a25edabc0c1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->