### PR TITLE
feat(peps): per-edge gauge family from the insertion isomorphism (toward gaugeConsistency)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -386,6 +386,7 @@ import TNLean.PEPS.InsertionAlgebra
 import TNLean.PEPS.LocalGauge
 import TNLean.PEPS.TensorFactorScalar
 import TNLean.PEPS.EdgeGaugeExtraction
+import TNLean.PEPS.EdgeGaugeFamily
 import TNLean.PEPS.TwoInjectiveComparison
 -- The PEPS fundamental theorem is an exploratory capstone with recorded
 -- paper-alignment gaps; it is deliberately not part of the default root.

--- a/TNLean/PEPS/EdgeGaugeFamily.lean
+++ b/TNLean/PEPS/EdgeGaugeFamily.lean
@@ -7,7 +7,7 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 /-!
 # Per-edge gauge family for injective PEPS
 
-This file assembles the per-edge content of the injective PEPS Fundamental
+This file records the per-edge content of the injective PEPS Fundamental
 Theorem (arXiv:1804.04964, Section 3) into one global gauge family.
 
 For each edge `e`, blocking a vertex-injective PEPS around `e` gives a three-site
@@ -16,12 +16,12 @@ injective chain. Comparing two PEPS that generate the same state then yields, vi
 between the two bond matrix algebras whose inserted edge coefficients agree.
 Skolem--Noether (`edgeGaugeFromInsertionAlgebraIsomorphism`) realizes each `Φ_e`
 as conjugation by an invertible bond matrix. Transporting these matrices back to
-the first tensor's bonds across the bond-dimension equality assembles a single
+the first tensor's bonds across the bond-dimension equality gives a single
 gauge family `X` and records, edgewise, both the inserted-coefficient identity
 and the conjugation form of `Φ_e`.
 
 This is the construction consumed by `gaugeConsistency` in
-`TNLean/PEPS/FundamentalTheorem.lean`; the remaining cross-edge assembly into the
+`TNLean/PEPS/FundamentalTheorem.lean`; the remaining cross-edge passage to the
 per-vertex gauge formula is recorded there and in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
 -/
@@ -63,13 +63,13 @@ an algebra isomorphism `Φ_e` between the bond matrix algebras whose inserted
 coefficients match. The finite-dimensional algebra step
 `edgeGaugeFromInsertionAlgebraIsomorphism` (Skolem--Noether) realizes each `Φ_e`
 as conjugation by an invertible bond matrix on the `B`-side. Transporting those
-matrices back to the `A`-side bonds across `hDim` assembles a single global gauge
+matrices back to the `A`-side bonds across `hDim` gives a single global gauge
 family `X`, and records, edgewise, both the inserted-coefficient identity and
 that `Φ_e` is conjugation by `X_e`.
 
-This packages the per-edge content of the source proof up to the point where the
+This records the per-edge content of the source proof up to the point where the
 edge gauges are produced. The remaining work in `gaugeConsistency` is the
-cross-edge assembly into the per-vertex formula `B_v = gaugeVertex A X v`, which
+cross-edge passage to the per-vertex formula `B_v = gaugeVertex A X v`, which
 the source obtains from the post-absorption insertion identity
 (`eq:inj_equal_edge`) and the one-vertex-versus-complement comparison; both of
 those steps are tracked separately (see

--- a/TNLean/PEPS/EdgeGaugeFamily.lean
+++ b/TNLean/PEPS/EdgeGaugeFamily.lean
@@ -20,9 +20,9 @@ the first tensor's bonds across the bond-dimension equality gives a single
 gauge family `X` and records, edgewise, both the inserted-coefficient identity
 and the conjugation form of `Φ_e`.
 
-This is the construction consumed by `gaugeConsistency` in
-`TNLean/PEPS/FundamentalTheorem.lean`; the remaining cross-edge passage to the
-per-vertex gauge formula is recorded there and in
+This is the construction used in the gauge-consistency theorem; the remaining
+cross-edge passage to the per-vertex gauge formula is recorded in
+the fundamental-theorem module and in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
 -/
 
@@ -63,13 +63,13 @@ an algebra isomorphism `Φ_e` between the bond matrix algebras whose inserted
 coefficients match. The finite-dimensional algebra step
 `edgeGaugeFromInsertionAlgebraIsomorphism` (Skolem--Noether) realizes each `Φ_e`
 as conjugation by an invertible bond matrix on the `B`-side. Transporting those
-matrices back to the `A`-side bonds across `hDim` gives a single global gauge
-family `X`, and records, edgewise, both the inserted-coefficient identity and
+matrices back to the \(A\)-side bonds across the bond-dimension equality gives
+a single global gauge family, and records, edgewise, both the inserted-coefficient identity and
 that `Φ_e` is conjugation by `X_e`.
 
 This records the per-edge content of the source proof up to the point where the
-edge gauges are produced. The remaining work in `gaugeConsistency` is the
-cross-edge passage to the per-vertex formula `B_v = gaugeVertex A X v`, which
+edge gauges are produced. The remaining work in gauge consistency is the
+cross-edge passage to the per-vertex formula \(B_v = X\cdot A_v\), which
 the source obtains from the post-absorption insertion identity
 (`eq:inj_equal_edge`) and the one-vertex-versus-complement comparison; both of
 those steps are tracked separately (see
@@ -127,6 +127,8 @@ theorem exists_edgeGaugeFamily (A B : Tensor G d)
           (↑(Z e)⁻¹ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) := by
     rw [← map_inv, glReindex_coe]
   rw [hXcoe, hXinvcoe]
+  have hProofEq : congr_fun hDim e = hEdge e := Subsingleton.elim _ _
+  rw [hProofEq]
   -- `reindexAlgEquiv (finCongr h)` is a ring hom; push it through products, and
   -- the inner `finCongr (hEdge e).symm` round-trips against the outer reindex.
   simp only [map_mul,

--- a/TNLean/PEPS/EdgeGaugeFamily.lean
+++ b/TNLean/PEPS/EdgeGaugeFamily.lean
@@ -106,14 +106,16 @@ theorem exists_edgeGaugeFamily (A B : Tensor G d)
     fun e =>
       isEdgeBlockedInsertionAlgebraIsomorphism A B e (hAblk e) (hBblk e) hAB hpos hposB
   choose Φ hΦcoeff using fun e => (hiso e)
-  -- Skolem--Noether: each `Φ e` is conjugation by an invertible `B`-side matrix.
+  -- Skolem--Noether: each edge algebra equivalence is conjugation by an
+  -- invertible matrix on the second tensor's bond.
   choose hEdge Z hZ using
     fun e => edgeGaugeFromInsertionAlgebraIsomorphism A B e (Φ e)
-  -- Transport each `Z e` back to the `A`-side bond.
+  -- Transport each edge gauge back to the first tensor's bond.
   refine ⟨fun e => glReindex (hEdge e).symm (Z e), fun e => ⟨Φ e, hΦcoeff e, ?_⟩⟩
   intro M
   rw [hZ e]
-  -- Both sides reindex `M` from the `A`-bond to the `B`-bond, conjugated by `Z e`.
+  -- Both sides reindex the inserted matrix from the first bond to the second
+  -- bond, conjugated by the edge gauge.
   have hXcoe :
       (↑(glReindex (hEdge e).symm (Z e)) :
           Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
@@ -129,10 +131,10 @@ theorem exists_edgeGaugeFamily (A B : Tensor G d)
   rw [hXcoe, hXinvcoe]
   have hProofEq : congr_fun hDim e = hEdge e := Subsingleton.elim _ _
   rw [hProofEq]
-  -- `reindexAlgEquiv (finCongr h)` is a ring hom; push it through products, and
-  -- the inner `finCongr (hEdge e).symm` round-trips against the outer reindex.
+  -- The reindexing equivalence is multiplicative; push it through products, and
+  -- the inverse-index transport cancels against the outer reindex.
   simp only [map_mul,
-    reindexAlgEquiv_finCongr_symm_round (congr_fun hDim e) (hEdge e)]
+    reindexAlgEquiv_finCongr_symm_round (hEdge e) (hEdge e)]
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/EdgeGaugeFamily.lean
+++ b/TNLean/PEPS/EdgeGaugeFamily.lean
@@ -1,0 +1,136 @@
+import TNLean.PEPS.Blocking
+import TNLean.PEPS.InsertionAlgebra
+import TNLean.PEPS.EdgeGaugeExtraction
+import TNLean.PEPS.EdgeMiddlePhysical
+import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+
+/-!
+# Per-edge gauge family for injective PEPS
+
+This file assembles the per-edge content of the injective PEPS Fundamental
+Theorem (arXiv:1804.04964, Section 3) into one global gauge family.
+
+For each edge `e`, blocking a vertex-injective PEPS around `e` gives a three-site
+injective chain. Comparing two PEPS that generate the same state then yields, via
+`isEdgeBlockedInsertionAlgebraIsomorphism` (#1367), an algebra isomorphism `Φ_e`
+between the two bond matrix algebras whose inserted edge coefficients agree.
+Skolem--Noether (`edgeGaugeFromInsertionAlgebraIsomorphism`) realizes each `Φ_e`
+as conjugation by an invertible bond matrix. Transporting these matrices back to
+the first tensor's bonds across the bond-dimension equality assembles a single
+gauge family `X` and records, edgewise, both the inserted-coefficient identity
+and the conjugation form of `Φ_e`.
+
+This is the construction consumed by `gaugeConsistency` in
+`TNLean/PEPS/FundamentalTheorem.lean`; the remaining cross-edge assembly into the
+per-vertex gauge formula is recorded there and in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- Transport an invertible matrix across an equality of finite index sizes. -/
+noncomputable def glReindex {m n : ℕ} (h : m = n) :
+    GL (Fin m) ℂ ≃* GL (Fin n) ℂ :=
+  Units.mapEquiv (Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)).toRingEquiv.toMulEquiv
+
+/-- The matrix of a transported invertible matrix is the reindexed matrix. -/
+theorem glReindex_coe {m n : ℕ} (h : m = n) (Z : GL (Fin m) ℂ) :
+    (↑(glReindex h Z) : Matrix (Fin n) (Fin n) ℂ) =
+      Matrix.reindexAlgEquiv ℂ ℂ (finCongr h) (↑Z : Matrix (Fin m) (Fin m) ℂ) :=
+  rfl
+
+/-- Reindexing back and forth across an index-size equality is the identity. -/
+theorem reindexAlgEquiv_finCongr_symm_round {m n : ℕ} (h h' : m = n)
+    (N : Matrix (Fin n) (Fin n) ℂ) :
+    Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
+        (Matrix.reindexAlgEquiv ℂ ℂ (finCongr h'.symm) N) = N := by
+  subst h
+  simp
+
+/-- **Per-edge gauge family from the edge-blocked insertion algebra
+isomorphisms.**
+
+For each edge `e`, blocking `A` and `B` around `e` gives three-site injective
+chains (`IsVertexInjective.edgeBlockedThreeSiteInjective`, using the positive
+bond dimensions), and `isEdgeBlockedInsertionAlgebraIsomorphism` (#1367) supplies
+an algebra isomorphism `Φ_e` between the bond matrix algebras whose inserted
+coefficients match. The finite-dimensional algebra step
+`edgeGaugeFromInsertionAlgebraIsomorphism` (Skolem--Noether) realizes each `Φ_e`
+as conjugation by an invertible bond matrix on the `B`-side. Transporting those
+matrices back to the `A`-side bonds across `hDim` assembles a single global gauge
+family `X`, and records, edgewise, both the inserted-coefficient identity and
+that `Φ_e` is conjugation by `X_e`.
+
+This packages the per-edge content of the source proof up to the point where the
+edge gauges are produced. The remaining work in `gaugeConsistency` is the
+cross-edge assembly into the per-vertex formula `B_v = gaugeVertex A X v`, which
+the source obtains from the post-absorption insertion identity
+(`eq:inj_equal_edge`) and the one-vertex-versus-complement comparison; both of
+those steps are tracked separately (see
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`).
+
+Source: arXiv:1804.04964, Section 3, lines 560--586. -/
+theorem exists_edgeGaugeFamily (A B : Tensor G d)
+    (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hAB : SameState A B)
+    (hDim : A.bondDim = B.bondDim)
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e) :
+    ∃ X : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ,
+      ∀ e : Edge G,
+        ∃ Φ :
+          Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ ≃ₐ[ℂ]
+            Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ,
+          (∀ (σ : V → Fin d)
+              (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+            edgeInsertedCoeff (G := G) A e σ M =
+              edgeInsertedCoeff (G := G) B e σ (Φ M)) ∧
+          ∀ M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ,
+            Φ M =
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hDim e))
+                ((↑(X e) : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) * M *
+                  (↑(X e)⁻¹ : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)) := by
+  classical
+  have hposB : ∀ e : Edge G, 0 < B.bondDim e := by
+    intro e; rw [← congr_fun hDim e]; exact hpos e
+  have hAblk : ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) A e :=
+    fun e => hA.edgeBlockedThreeSiteInjective hpos e
+  have hBblk : ∀ e : Edge G, EdgeBlockedThreeSiteInjective (G := G) B e :=
+    fun e => hB.edgeBlockedThreeSiteInjective hposB e
+  have hiso : ∀ e : Edge G, IsEdgeBlockedInsertionAlgebraIsomorphism (G := G) A B e :=
+    fun e =>
+      isEdgeBlockedInsertionAlgebraIsomorphism A B e (hAblk e) (hBblk e) hAB hpos hposB
+  choose Φ hΦcoeff using fun e => (hiso e)
+  -- Skolem--Noether: each `Φ e` is conjugation by an invertible `B`-side matrix.
+  choose hEdge Z hZ using
+    fun e => edgeGaugeFromInsertionAlgebraIsomorphism A B e (Φ e)
+  -- Transport each `Z e` back to the `A`-side bond.
+  refine ⟨fun e => glReindex (hEdge e).symm (Z e), fun e => ⟨Φ e, hΦcoeff e, ?_⟩⟩
+  intro M
+  rw [hZ e]
+  -- Both sides reindex `M` from the `A`-bond to the `B`-bond, conjugated by `Z e`.
+  have hXcoe :
+      (↑(glReindex (hEdge e).symm (Z e)) :
+          Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hEdge e).symm)
+          (↑(Z e) : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) :=
+    glReindex_coe (hEdge e).symm (Z e)
+  have hXinvcoe :
+      (↑(glReindex (hEdge e).symm (Z e))⁻¹ :
+          Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hEdge e).symm)
+          (↑(Z e)⁻¹ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) := by
+    rw [← map_inv, glReindex_coe]
+  rw [hXcoe, hXinvcoe]
+  -- `reindexAlgEquiv (finCongr h)` is a ring hom; push it through products, and
+  -- the inner `finCongr (hEdge e).symm` round-trips against the outer reindex.
+  simp only [map_mul,
+    reindexAlgEquiv_finCongr_symm_round (congr_fun hDim e) (hEdge e)]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -548,9 +548,10 @@ theorem localGauge_exists (A B : Tensor G d)
 
 /-- Post-absorption edge insertion equality from arXiv:1804.04964, Section 3,
 lines 1037--1065. Assuming the separately tracked bond-dimension equality
-`hDim` (#874), the edge gauges obtained from the three-site comparison can be
-absorbed into `B` so that every edge insertion in `A` agrees with the transported
-edge insertion in the absorbed tensor family. The remaining proof is #1364. -/
+(\#874), the edge gauges obtained from the three-site comparison can be absorbed
+into the second tensor family so that every edge insertion in \(A\) agrees with
+the transported edge insertion in the absorbed tensor family. The remaining
+proof is #1364. -/
 theorem post_absorption_edge_insertion_equality (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B) (hAB : SameState A B)
     (hDim : A.bondDim = B.bondDim) :
@@ -610,7 +611,7 @@ and have the same state coefficients, then there are invertible edge matrices
 `X_e` such that, at every vertex, `B_v` is obtained from `A_v` by the oriented
 endpoint action of the matrices `X_e` on the incident virtual legs.
 
-**Positive-bond hypothesis (faithfulness fix).** Without `hposA`/`hposB` the
+**Positive-bond hypothesis (faithfulness fix).** Without the positivity conditions the
 theorem is false: a zero-dimensional edge makes the virtual configuration empty,
 so both state coefficients vanish and `SameState` holds vacuously without
 relating the two tensors, while the gauge-equivalence conclusion stays a genuine
@@ -639,7 +640,7 @@ theorem fundamentalTheorem_PEPS (A B : Tensor G d)
   -- `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
   have hDim : A.bondDim = B.bondDim := by
     sorry
-  -- With matching bond dimensions, `gaugeConsistency` supplies the global gauges.
+  -- With matching bond dimensions, gauge consistency supplies the global gauges.
   exact fundamentalTheorem_PEPS_of_bondDim A B hA hB hAB hDim hposA
 
 /-! ### Balanced edge scalars -/

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -597,7 +597,7 @@ theorem gaugeConsistency (A B : Tensor G d)
   --      two-injective comparison `inj_equal_tensors_2`
   --      (`one_vertex_complement_comparison`, which depends on
   --      `two_injective_tensor_insertion_comparison`, still `sorry`, #1361) to
-  --      get `A_v = λ_v · B̃_v`, absorbing `λ_v` into the edge gauges.
+  --      get `A_v = λ_v · B'_v`, absorbing `λ_v` into the edge gauges.
   -- The per-vertex output is `BlockedMiddleGaugeFormula A B hA hDim v`, which
   -- `localGauge_exists_of_blockedMiddleGaugeFormula` converts to the local gauge
   -- relation; the orientation flip to `edgeGaugeAt`/`gaugeVertex` is the last

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -577,21 +577,34 @@ mathematical obligations". -/
 theorem gaugeConsistency (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B)
     (hAB : SameState A B)
-    (hDim : A.bondDim = B.bondDim) :
+    (hDim : A.bondDim = B.bondDim)
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e) :
     ∃ (X : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ),
       ∀ (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
         B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
           gaugeVertex A X v η σ := by
-  -- Derive `BlockedMiddleGaugeFormula A B hA hDim v` from `SameState` at each
-  -- vertex by comparing the edge-blocked coefficient from `PEPS/Blocking` with
-  -- the three-site MPS reduction, then use
-  -- `hasFactorizedLocalGauge_of_blockedMiddleGaugeFormula` to obtain the local
-  -- gauges.
-  -- The key remaining consistency step is: for each edge e = (u,v), the gauges
-  -- extracted from u and v must agree as inverse-transposes, with the
-  -- orientation convention in `edgeGaugeAt`.
-  -- The current status is recorded in
-  -- `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+  -- The global gauge family `X` is already available, sorry-free, from
+  -- `exists_edgeGaugeFamily A B hA hB hAB hDim hpos`: each edge `e` yields the
+  -- algebra isomorphism `Φ_e` (#1367) realized as conjugation by `X_e`
+  -- (Skolem--Noether, `edgeGaugeFromInsertionAlgebraIsomorphism`).
+  --
+  -- The remaining content is the cross-edge assembly into the per-vertex formula
+  -- `B_v = gaugeVertex A X v`. In the source this is obtained by:
+  --   1. absorbing the edge gauges `X_e` into `B` and proving the post-absorption
+  --      insertion identity `eq:inj_equal_edge`
+  --      (`post_absorption_edge_insertion_equality`, still `sorry`, #1364), and
+  --   2. blocking one vertex against its complement and applying the generalized
+  --      two-injective comparison `inj_equal_tensors_2`
+  --      (`one_vertex_complement_comparison`, which depends on
+  --      `two_injective_tensor_insertion_comparison`, still `sorry`, #1361) to
+  --      get `A_v = λ_v · B̃_v`, absorbing `λ_v` into the edge gauges.
+  -- The per-vertex output is `BlockedMiddleGaugeFormula A B hA hDim v`, which
+  -- `localGauge_exists_of_blockedMiddleGaugeFormula` converts to the local gauge
+  -- relation; the orientation flip to `edgeGaugeAt`/`gaugeVertex` is the last
+  -- bookkeeping step.
+  -- Both load-bearing dependencies (#1364, #1361) are open `sorry`s; the status
+  -- is recorded in `docs/paper-gaps/peps_injective_ft_section3_route.tex`,
+  -- Section "Remaining mathematical obligations".
   sorry
 
 /-! ### Main theorem -/
@@ -609,9 +622,10 @@ in `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
 mathematical obligations". -/
 theorem fundamentalTheorem_PEPS_of_bondDim (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B)
-    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim) :
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e) :
     GaugeEquiv A B := by
-  rcases gaugeConsistency A B hA hB hAB hDim with ⟨X, hX⟩
+  rcases gaugeConsistency A B hA hB hAB hDim hpos with ⟨X, hX⟩
   exact ⟨hDim, X, hX⟩
 
 /-- **Fundamental Theorem for injective PEPS** (arXiv:1804.04964, Theorem 2).
@@ -621,13 +635,25 @@ and have the same state coefficients, then there are invertible edge matrices
 `X_e` such that, at every vertex, `B_v` is obtained from `A_v` by the oriented
 endpoint action of the matrices `X_e` on the incident virtual legs.
 
+**Positive-bond hypothesis (faithfulness fix).** Without `hposA`/`hposB` the
+theorem is false: a zero-dimensional edge makes the virtual configuration empty,
+so both state coefficients vanish and `SameState` holds vacuously without
+relating the two tensors, while the gauge-equivalence conclusion stays a genuine
+constraint that fails. The hypotheses (every bond dimension positive) are the
+source's standing assumption that injective PEPS have nonzero virtual bond
+spaces; the same defect was corrected for the edge-blocked three-site
+injectivity (#1366) and the physical-to-virtual recovery (#1370), and is
+recorded in `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
+
 **Proof status:** The theorem is stated with the source's hypothesis set. The
 remaining bond-dimension and edge-centred gauge obligations are recorded in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
 mathematical obligations". -/
 theorem fundamentalTheorem_PEPS (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B)
-    (hAB : SameState A B) :
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) :
     GaugeEquiv A B := by
   -- Bond-dimension equality should follow from the full family of boundary
   -- insertions. Linear independence at each vertex (`IsVertexInjective`) gives
@@ -638,7 +664,7 @@ theorem fundamentalTheorem_PEPS (A B : Tensor G d)
   have hDim : A.bondDim = B.bondDim := by
     sorry
   -- With matching bond dimensions, `gaugeConsistency` supplies the global gauges.
-  exact fundamentalTheorem_PEPS_of_bondDim A B hA hB hAB hDim
+  exact fundamentalTheorem_PEPS_of_bondDim A B hA hB hAB hDim hposA
 
 /-! ### Balanced edge scalars -/
 

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -558,22 +558,12 @@ theorem post_absorption_edge_insertion_equality (A B : Tensor G d)
   sorry
 
 /-- Edge gauges obtained from the three-site reductions give one global gauge
-family.
+family. Source: arXiv:1804.04964, Section 3, from `eq:TN_5_particle_eq` through
+`eq:inj_equal_edge`.
 
-Source: arXiv:1804.04964, Section 3, after the equation labelled
-`eq:TN_5_particle_eq`: for each edge, block all other vertices into the middle
-site of a three-site injective MPS and apply Lemma `inj_isomorph`. After the
-resulting edge gauges are absorbed into `B`, the source proves the insertion
-identity labelled `eq:inj_equal_edge`.
-
-This theorem records the global-gauge conclusion needed by the injective PEPS
-Fundamental Theorem under the already separated bond-dimension equality
-hypothesis.
-
-**Proof status:** The statement is still open. The edge-blocked route and the
-remaining insertion-to-gauge obligations are recorded in
-`docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
-mathematical obligations". -/
+**Proof status:** The edge-blocked route and remaining insertion-to-gauge
+obligations are recorded in
+`docs/paper-gaps/peps_injective_ft_section3_route.tex`. -/
 theorem gaugeConsistency (A B : Tensor G d)
     (hA : IsVertexInjective A) (hB : IsVertexInjective B)
     (hAB : SameState A B)
@@ -583,28 +573,10 @@ theorem gaugeConsistency (A B : Tensor G d)
       ∀ (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
         B.component v (fun ie => Fin.cast (congr_fun hDim ie.1) (η ie)) σ =
           gaugeVertex A X v η σ := by
-  -- The global gauge family `X` is already available, sorry-free, from
-  -- `exists_edgeGaugeFamily A B hA hB hAB hDim hpos`: each edge `e` yields the
-  -- algebra isomorphism `Φ_e` (#1367) realized as conjugation by `X_e`
-  -- (Skolem--Noether, `edgeGaugeFromInsertionAlgebraIsomorphism`).
-  --
-  -- The remaining content is the cross-edge assembly into the per-vertex formula
-  -- `B_v = gaugeVertex A X v`. In the source this is obtained by:
-  --   1. absorbing the edge gauges `X_e` into `B` and proving the post-absorption
-  --      insertion identity `eq:inj_equal_edge`
-  --      (`post_absorption_edge_insertion_equality`, still `sorry`, #1364), and
-  --   2. blocking one vertex against its complement and applying the generalized
-  --      two-injective comparison `inj_equal_tensors_2`
-  --      (`one_vertex_complement_comparison`, which depends on
-  --      `two_injective_tensor_insertion_comparison`, still `sorry`, #1361) to
-  --      get `A_v = λ_v · B'_v`, absorbing `λ_v` into the edge gauges.
-  -- The per-vertex output is `BlockedMiddleGaugeFormula A B hA hDim v`, which
-  -- `localGauge_exists_of_blockedMiddleGaugeFormula` converts to the local gauge
-  -- relation; the orientation flip to `edgeGaugeAt`/`gaugeVertex` is the last
-  -- bookkeeping step.
-  -- Both load-bearing dependencies (#1364, #1361) are open `sorry`s; the status
-  -- is recorded in `docs/paper-gaps/peps_injective_ft_section3_route.tex`,
-  -- Section "Remaining mathematical obligations".
+  -- `exists_edgeGaugeFamily` supplies the per-edge gauges. It remains to prove
+  -- post-absorption insertion equality (#1364) and the one-vertex complement
+  -- comparison through the two-injective theorem (#1361), then convert the
+  -- resulting `BlockedMiddleGaugeFormula` to the local gauge relation.
   sorry
 
 /-! ### Main theorem -/

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -586,7 +586,10 @@ equality** (arXiv:1804.04964, Theorem 2).
 
 If the bond spaces of `A` and `B` are already identified, equality of their PEPS
 states and vertex injectivity imply the gauge formula
-`B_v = gaugeVertex A X v` for one invertible matrix `X_e` on each edge.
+`B_v = gaugeVertex A X v` for one invertible matrix `X_e` on each edge, under
+the explicit assumption that every virtual bond of `A` has positive dimension.
+Via the bond-dimension equality this is also the corresponding positivity
+assumption for `B`.
 
 **Proof status:** This theorem is proved from the conditional global-gauge
 statement above. The remaining difference from the source theorem is recorded

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -645,8 +645,9 @@ spaces; the same defect was corrected for the edge-blocked three-site
 injectivity (#1366) and the physical-to-virtual recovery (#1370), and is
 recorded in `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
 
-**Proof status:** The theorem is stated with the source's hypothesis set. The
-remaining bond-dimension and edge-centred gauge obligations are recorded in
+**Proof status:** The conclusion is the source gauge-equivalence conclusion, with
+positive bond dimension made explicit to exclude the zero-bond vacuous-state
+case above. The remaining bond-dimension and edge-centred gauge obligations are recorded in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`, Section "Remaining
 mathematical obligations". -/
 theorem fundamentalTheorem_PEPS (A B : Tensor G d)

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2003,6 +2003,41 @@ injective and normal PEPS, following Theorems~2 and~3 of
     algebras determined by the two edge bond spaces.
 \end{proof}
 
+\begin{theorem}[Per-edge gauge family from insertion algebra isomorphisms]%
+    \label{thm:peps_exists_edgeGaugeFamily}
+    \lean{TNLean.PEPS.exists_edgeGaugeFamily}
+    \leanok
+    \uses{thm:peps_edgeBlockedThreeSiteInjective,
+        thm:peps_edgeBlockedInsertionAlgebraIsomorphism,
+        thm:peps_edgeGaugeFromInsertionAlgebraIsomorphism}
+    Let $A$ and $B$ be vertex-injective PEPS tensors with the same PEPS state.
+    Suppose the corresponding virtual bond dimensions are equal and every
+    virtual bond of $A$ has positive dimension. Then there is a family
+    $X_e\in\GL(D_A(e))$ such that, for every edge $e$, there is a
+    $\C$-algebra isomorphism
+    \[
+        \Phi_e:\MN{D_A(e)}\longrightarrow\MN{D_B(e)}
+    \]
+    satisfying, for every physical configuration $\sigma$ and matrix $M$,
+    \[
+        C_A(e,\sigma,M)=C_B(e,\sigma,\Phi_e(M)),
+    \]
+    and, writing $\phi_{h_e}:\MN{D_A(e)}\to\MN{D_B(e)}$ for the algebra
+    isomorphism induced by the dimension equality on $e$,
+    \[
+        \Phi_e(M)=\phi_{h_e}\!\left(X_eMX_e^{-1}\right).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Vertex injectivity and positivity give edge-blocked three-site injectivity
+    for $A$ and $B$ at each edge. Theorem~\ref{thm:peps_edgeBlockedInsertionAlgebraIsomorphism}
+    gives the algebra isomorphism $\Phi_e$ preserving inserted coefficients.
+    Theorem~\ref{thm:peps_edgeGaugeFromInsertionAlgebraIsomorphism} realizes
+    $\Phi_e$ by conjugation, and the bond-dimension equality transports the
+    conjugating matrix to the $A$-side bond.
+\end{proof}
+
 \begin{definition}[Factorized local gauge datum]%
     \label{def:peps_hasFactorizedLocalGauge}
     \lean{TNLean.PEPS.HasFactorizedLocalGauge}
@@ -2217,8 +2252,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \label{thm:gaugeConsistency}
     \lean{TNLean.PEPS.gaugeConsistency}
     \notready
-    \uses{thm:peps_postAbsorptionEdgeInsertionEquality,
+    \uses{thm:peps_exists_edgeGaugeFamily,
+        thm:peps_postAbsorptionEdgeInsertionEquality,
         thm:localGauge_exists, def:gaugeVertex}
+    Suppose $A$ and $B$ are vertex-injective PEPS tensors with the same PEPS
+    state, that the corresponding virtual bond dimensions are equal, and that
+    every virtual bond of $A$ has positive dimension.
     Choose an edge $e=(u,v)$ and block all other vertices into one middle
     tensor. The three resulting tensors form an injective chain, so the
     one-dimensional injective comparison assigns an invertible matrix to the
@@ -2655,25 +2694,30 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \uses{thm:gaugeConsistency, thm:peps_oneVertexComplementComparison,
         def:GaugeEquivPEPS, def:IsVertexInjective}
     Suppose that the corresponding virtual edge spaces of $A$ and $B$ are
-    already identified. If $A$ and $B$ are vertex-injective and give the same
-    PEPS state, then there are invertible matrices $X_e$, one for each edge,
-    such that at every vertex the tensor $B_v$ is obtained from $A_v$ by the
-    oriented endpoint action of the incident matrices.
+    already identified, and every virtual bond of $A$ has positive dimension.
+    If $A$ and $B$ are vertex-injective and give the same PEPS state, then
+    there are invertible matrices $X_e$, one for each edge, such that at every
+    vertex the tensor $B_v$ is obtained from $A_v$ by the oriented endpoint
+    action of the incident matrices.
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for injective PEPS]%
     \label{thm:fundamentalTheorem_PEPS}
     \lean{TNLean.PEPS.fundamentalTheorem_PEPS}
     \notready
+    % Scope restriction: this is the positive-bond variant of Theorem 2 in
+    % \cite{Molnar2018NormalPEPS}. The elimination plan for the positivity
+    % hypotheses is recorded in
+    % \path{docs/paper-gaps/peps_injective_ft_section3_route.tex}.
     \uses{thm:fundamentalTheorem_PEPS_of_bondDim, def:GaugeEquivPEPS,
         def:IsVertexInjective}
     Let $A$ and $B$ be vertex-injective PEPS tensors on a finite simple
-    graph. If they give the same PEPS state, then their corresponding virtual
-    edge spaces have the same dimensions and, after identifying these spaces,
-    there are invertible matrices $X_e$, one for each edge, such that $B_v$ is
-    obtained from $A_v$ by the oriented endpoint action of the matrices incident
-    to $v$. This is Theorem~2 of
-    \cite{Molnar2018NormalPEPS}.
+    graph, and suppose every virtual bond of $A$ and $B$ has positive
+    dimension. If they give the same PEPS state, then their corresponding
+    virtual edge spaces have the same dimensions and, after identifying these
+    spaces, there are invertible matrices $X_e$, one for each edge, such that
+    $B_v$ is obtained from $A_v$ by the oriented endpoint action of the matrices
+    incident to $v$.
 \end{theorem}
 
 \section{Normal PEPS}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2251,7 +2251,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{theorem}[Gauge consistency]%
     \label{thm:gaugeConsistency}
     \lean{TNLean.PEPS.gaugeConsistency}
-    \notready
+    \leanok
     \uses{thm:peps_exists_edgeGaugeFamily,
         thm:peps_postAbsorptionEdgeInsertionEquality,
         thm:localGauge_exists, def:gaugeVertex}
@@ -2690,7 +2690,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         bond-dimension equality]%
     \label{thm:fundamentalTheorem_PEPS_of_bondDim}
     \lean{TNLean.PEPS.fundamentalTheorem_PEPS_of_bondDim}
-    \notready
+    \leanok
     \uses{thm:gaugeConsistency, thm:peps_oneVertexComplementComparison,
         def:GaugeEquivPEPS, def:IsVertexInjective}
     Suppose that the corresponding virtual edge spaces of $A$ and $B$ are
@@ -2704,7 +2704,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{theorem}[Fundamental Theorem for injective PEPS]%
     \label{thm:fundamentalTheorem_PEPS}
     \lean{TNLean.PEPS.fundamentalTheorem_PEPS}
-    \notready
+    \leanok
     % Scope restriction: this is the positive-bond variant of Theorem 2 in
     % \cite{Molnar2018NormalPEPS}. The elimination plan for the positivity
     % hypotheses is recorded in


### PR DESCRIPTION
Stacked on #2400. Builds `exists_edgeGaugeFamily` (sorry-free, `#print axioms`-clean): from the proved #1367 per-edge isomorphism + Skolem-Noether `edgeGaugeFromInsertionAlgebraIsomorphism`, assembles the global edge-gauge family `X : (e:Edge G)→GL(Fin(A.bondDim e))ℂ` with the per-edge conjugation + inserted-coefficient identity. Also applies the #2394 positivity correction to `gaugeConsistency`/`fundamentalTheorem_PEPS` on this branch. `gaugeConsistency` stays `sorry`: its cross-edge assembly into the per-vertex formula depends on #1364 (post-absorption) and #1361 (the Z/U/W two-injective comparison), both open. Refs #1364, #1361.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hypotheses and the formal capstone route for injective PEPS gauge equivalence; the new lemma is proved but `gaugeConsistency` and bond-dimension derivation remain sorry, so callers must match the new positivity assumptions.
> 
> **Overview**
> Adds **`TNLean.PEPS.EdgeGaugeFamily`** with a complete proof of **`exists_edgeGaugeFamily`**: from per-edge insertion-algebra isomorphisms (#1367) and Skolem–Noether **`edgeGaugeFromInsertionAlgebraIsomorphism`**, it builds a global edge gauge family on \(A\)’s bonds with matching inserted coefficients and conjugation formulas for each \(\Phi_e\), using **`glReindex`** to transport \(B\)-side gauges across bond-dimension equality.
> 
> **`gaugeConsistency`**, **`fundamentalTheorem_PEPS_of_bondDim`**, and **`fundamentalTheorem_PEPS`** now require **positive bond dimension** on \(A\) (and both tensors in the main theorem) so **`SameState`** is not vacuous when a bond has dimension zero; **`gaugeConsistency`** remains **`sorry`**, with comments that **`exists_edgeGaugeFamily`** covers the per-edge step and cross-edge assembly still needs #1364 and #1361. The blueprint chapter documents the new theorem and updates gauge/FT statements and proof-status tags accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b843d06592b7020db7b77469a997912d94251e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->