### PR TITLE
feat(parent): isolate fixed-letter boundary reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -147,6 +147,15 @@ noncomputable def restrictFirst {d L : ℕ} (ψ : NSiteSpace d (L + 1)) (i : Fin
     (i : Fin d) (σ : Fin L → Fin d) :
     restrictFirst ψ i σ = ψ (Fin.cons i σ) := rfl
 
+/-- A vector on `L + 1` sites is determined by all restrictions obtained by
+fixing its first physical index. -/
+theorem eq_of_forall_restrictFirst_eq {d L : ℕ} {ψ φ : NSiteSpace d (L + 1)}
+    (h : ∀ i : Fin d, restrictFirst ψ i = restrictFirst φ i) :
+    ψ = φ := by
+  ext σ
+  have hσ := congr_fun (h (σ 0)) (Fin.tail σ)
+  simpa [restrictFirst_apply, Fin.cons_self_tail σ] using hσ
+
 /-! ### Ground space membership via restrictions -/
 
 /-- A state on `L+1` sites has its left restriction in `G_L(A)`: for each value of the

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -680,6 +680,42 @@ theorem wrapped_mirror_witness_agree_of_right_products
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
+/-- The full boundary-closing restriction equality follows from equality after
+fixing each first physical index.  This is a formal step used to isolate the
+closing-boundary comparison discussed in arXiv:2011.12127, Section IV.C,
+lines 2078--2090. -/
+theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
+    {L₀ M : ℕ} (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hfixed : ∀ j : Fin d,
+      cyclicRestrictₗ (show 0 < M + 1 by omega) L₀
+          (cyclicForwardSite (⟨M, by omega⟩ : Fin (M + 1)) 1)
+          (fun k => if (k.val + (M + 1) - (⟨M, by omega⟩ : Fin (M + 1)).val) %
+                (M + 1) = 0 then j else wrappedMiddleBackground L₀ (M + 1) η μ k) ψ =
+        cyclicRestrictₗ (show 0 < M + 1 by omega) L₀
+          (cyclicForwardSite (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) 1)
+          (fun k => if (k.val + (M + 1) -
+                (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)).val) % (M + 1) = 0 then j
+              else mirrorMiddleBackground L₀ (M + 1) η μ k) ψ) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        ⟨M, by omega⟩
+        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        ⟨M + 1 - L₀, by omega⟩
+        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+  apply eq_of_forall_restrictFirst_eq
+  intro j
+  rw [cyclicRestrictₗ_restrictFirst
+      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M, by omega⟩ : Fin (M + 1))
+      (wrappedMiddleBackground L₀ (M + 1) η μ) ψ j]
+  rw [cyclicRestrictₗ_restrictFirst
+      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+      (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
+  exact hfixed j
+
 /-- Restriction equality when closing the boundaries, from the closure property,
 arXiv:2011.12127, lines 2078--2090:
 \(\operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L₀+1}(\psi)=
@@ -703,7 +739,8 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
         (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
   sorry
 
-/-- Closure-property restriction equation, arXiv:2011.12127, lines 2078--2090:
+/-- First-letter form of the closing-boundary comparison discussed in
+arXiv:2011.12127, lines 2078--2090:
 \(\operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L₀}(\psi)=
 \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L₀,L₀}(\psi)\).
 
@@ -753,7 +790,8 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     (closure_property_boundary_restriction_eq_of_chainGroundSpace
       (A := A) hInj hL₀ hM hψ hψX η μ)
 
-/-- Boundary-closing \(Y A^j\) equation from arXiv:2011.12127, lines 2078--2090:
+/-- Boundary-matrix form of the closing-boundary comparison discussed in
+arXiv:2011.12127, lines 2078--2090:
 \(Y_M(\tau^+_\eta(\mu))A^j=Y_{M+1-L₀}(\tau^-_\eta(\mu))A^j\).
 **Open gap:** Depends on the restriction equality above for closing the
 boundaries; see
@@ -791,8 +829,9 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
       (A := A) hInj hL₀ hM hψ hψX η μ j).trans hRight)
 
 /-- Boundary matrices from the two boundary-closing comparisons agree.
-This is arXiv:2011.12127, lines 2078--2090, reduced to the \(Y A^j\) equation
-above.
+This is the boundary-matrix consequence expected from the closing-boundary
+comparison discussed in arXiv:2011.12127, lines 2078--2090, reduced to the
+\(Y A^j\) equation above.
 **Open gap:** Depends on the restriction equality above for closing the
 boundaries; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2368. -/

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1530,12 +1530,76 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     matrices $Y^+_{\tau^+_\eta(\mu)}$ and $Y^-_{\tau^-_\eta(\mu)}$.
 \end{proof}
 
+\begin{lemma}[First-letter restrictions determine a vector]
+    \label{lem:first_letter_restrictions_determine}
+    \lean{MPSTensor.eq_of_forall_restrictFirst_eq}
+    \leanok
+    Let $R_j$ be restriction to first letter $j$:
+    \[
+        (R_j\phi)(\sigma_1,\ldots,\sigma_L)
+        =
+        \phi(j,\sigma_1,\ldots,\sigma_L).
+    \]
+    For $\phi,\psi\in(\mathbb C^d)^{\otimes(L+1)}$,
+    \[
+        \bigl(\forall j,\ R_j\phi=R_j\psi\bigr)
+        \Longrightarrow
+        \phi=\psi .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    At $(\sigma_0,\sigma_1,\ldots,\sigma_L)$ the required equality is
+    \[
+        \phi(\sigma_0,\sigma_1,\ldots,\sigma_L)
+        =
+        (R_{\sigma_0}\phi)(\sigma_1,\ldots,\sigma_L)
+        =
+        (R_{\sigma_0}\psi)(\sigma_1,\ldots,\sigma_L)
+        =
+        \psi(\sigma_0,\sigma_1,\ldots,\sigma_L).
+    \]
+\end{proof}
+
+\begin{lemma}[Boundary equality from fixed first letters]
+    \label{lem:boundary_restriction_from_fixed_letters}
+    \lean{MPSTensor.closure_property_boundary_restriction_eq_of_fixed_boundary_letters}
+    \leanok
+    \uses{lem:first_letter_restrictions_determine, rem:cyclic_window_operators}
+    Let $L_0>0$ and $L_0\le M$, and set
+    \[
+        B^+_{\eta,\mu}(\psi)
+        =
+        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi),
+        \qquad
+        B^-_{\eta,\mu}(\psi)
+        =
+        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi).
+    \]
+    With $R_j$ as in Lemma~\ref{lem:first_letter_restrictions_determine},
+    \[
+        \bigl(\forall j,\ R_jB^+_{\eta,\mu}(\psi)
+        =
+        R_jB^-_{\eta,\mu}(\psi)\bigr)
+        \Longrightarrow
+        B^+_{\eta,\mu}(\psi)=B^-_{\eta,\mu}(\psi).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply Lemma~\ref{lem:first_letter_restrictions_determine} to the two
+    length-$(L_0+1)$ restrictions, using the displayed family of fixed-letter
+    equalities.
+\end{proof}
+
 \begin{lemma}[Restriction equation when closing the boundaries]
     \label{lem:closure_property_boundary_restriction_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_chainGroundSpace}
     \leanok
     \uses{def:chain_ground_space, rem:cyclic_window_operators,
-        lem:wrapped_middle_backgrounds}
+        lem:wrapped_middle_backgrounds, lem:boundary_restriction_from_fixed_letters}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
     $L_0\le M$, and let
     \[
@@ -1544,8 +1608,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \psi=\Gamma_{M+1}(X).
     \]
     For every boundary letter $\eta$ and complementary word $\mu$, the
-    boundary-closing closure relation of
-    \cite[lines~2078--2090]{Cirac2021Matrix} takes the form
+    formal comparison isolated from the closing-boundary argument of
+    \cite[lines~2078--2090]{Cirac2021Matrix} is
     \[
         \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
         =
@@ -1555,13 +1619,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    The missing step is the vanishing
+    By Lemma~\ref{lem:boundary_restriction_from_fixed_letters}, it is enough to
+    prove the fixed-letter family
     \[
-        \left(
-        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}
-        -
-        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}
-        \right)(\psi)=0.
+        \forall j,\qquad
+        \left.
+        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
+        \right|_{\sigma_1=j}
+        =
+        \left.
+        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi)
+        \right|_{\sigma_1=j}.
     \]
     The required algebraic input is the block-injectivity identity
     \[
@@ -1577,11 +1645,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \operatorname{span}\{A^{j_1}\cdots A^{j_{L_0}} :
         j_1,\ldots,j_{L_0}\}=M_D(\mathbb C)
         \Longrightarrow
-        \left(
-        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}
-        -
-        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}
-        \right)(\psi)=0.
+        \forall j,\qquad
+        \left.
+        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
+        \right|_{\sigma_1=j}
+        =
+        \left.
+        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi)
+        \right|_{\sigma_1=j}.
     \]
 \end{proof}
 
@@ -1620,7 +1691,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi).
     \]
-    This is \cite[lines~2078--2090]{Cirac2021Matrix}.
+    This is the fixed-letter form used to express the closing-boundary
+    comparison discussed in \cite[lines~2078--2090]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}
@@ -1667,8 +1739,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
     \]
-    This is the closure-property comparison of
-    \cite[lines~2078--2090]{Cirac2021Matrix} in boundary-matrix notation.
+    This is the boundary-matrix form of the closing-boundary comparison
+    discussed in \cite[lines~2078--2090]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

- prove that a vector on \(L+1\) sites is determined by all first-letter restrictions
- prove the boundary reduction
  \[
  (\forall j,\ R_j B^+_{\eta,\mu}(\psi)=R_j B^-_{\eta,\mu}(\psi))\Longrightarrow B^+_{\eta,\mu}(\psi)=B^-_{\eta,\mu}(\psi)
  \]
- rewrite the corresponding blueprint entries equation-first and soften the source attribution so these are formal comparisons extracted from the closing-boundary argument, not new named source theorems

This does not resolve issue 2368. It reduces the remaining boundary-closing comparison to the fixed-letter/product comparison.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info` (passes with the existing `sorry` warning in `UniqueGroundState.lean`)
- `lake build TNLean.MPS.ParentHamiltonian.IntersectionProperty -q --log-level=info`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root .` (Chapter 14 remains 351/351; the reported missing refs are the pre-existing non-parent Chapter 4a/13a entries)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and blueprint documentation only; no runtime or security-sensitive code, and the main open proof obligation is unchanged.
> 
> **Overview**
> Adds a **first-letter uniqueness** lemma (`eq_of_forall_restrictFirst_eq`) and a **proved reduction** showing the full boundary-closing cyclic restriction equality follows once equality holds for every fixed first physical index (`closure_property_boundary_restriction_eq_of_fixed_boundary_letters`).
> 
> The **blueprint** (Chapter 14) gains matching lemmas and reframes the still-open boundary-closing step (#2368): the gap is now stated as proving the **fixed-letter family**, not the full restriction identity in one shot. Docstrings on downstream closure-property statements are softened so they read as **formal comparisons** extracted from the Cirac et al. closing-boundary argument, not as newly named source theorems.
> 
> The main chain-ground-space boundary restriction theorem remains **`sorry`**; this PR does not close #2368.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5986328a14bcb5236141455572ead115afc176c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->