### PR TITLE
doc(parent): align closure-property terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
@@ -79,4 +79,82 @@ theorem adjacent_cyclicRestrictₗ_witness_overlap
       (A := A) hN (cyclicForwardSite i 1) τ₂ ψ hY₂ b
   exact hFirst.symm.trans (by rw [hτ]; exact hLast)
 
+/-- A finite chain of adjacent matrix identities gives a single word-product
+identity. -/
+theorem boundary_witness_product_of_adjacent_overlaps
+    {A : MPSTensor d D} {n : ℕ}
+    (Y : Fin (n + 1) → Matrix (Fin D) (Fin D) ℂ)
+    (a b : Fin n → Fin d)
+    (hStep : ∀ r : Fin n,
+      Y (Fin.castSucc r) * A (a r) = A (b r) * Y (Fin.succ r)) :
+    Y 0 * evalWord A (List.ofFn a) =
+      evalWord A (List.ofFn b) * Y (Fin.last n) := by
+  induction n with
+  | zero =>
+      simp
+  | succ n ih =>
+      have h0 : Y 0 * A (a 0) = A (b 0) * Y 1 := by
+        simpa using hStep 0
+      let Ytail : Fin (n + 1) → Matrix (Fin D) (Fin D) ℂ := fun r => Y (Fin.succ r)
+      let atail : Fin n → Fin d := a ∘ Fin.succ
+      let btail : Fin n → Fin d := b ∘ Fin.succ
+      have hStepTail : ∀ r : Fin n,
+          Ytail (Fin.castSucc r) * A (atail r) = A (btail r) * Ytail (Fin.succ r) := by
+        intro r
+        have h := hStep (Fin.succ r)
+        simpa [Ytail, atail, btail] using h
+      have htail := ih Ytail atail btail hStepTail
+      rw [evalWord_ofFn_succ A a, evalWord_ofFn_succ A b]
+      calc
+        Y 0 * (A (a 0) * evalWord A (List.ofFn (a ∘ Fin.succ)))
+            = (Y 0 * A (a 0)) * evalWord A (List.ofFn (a ∘ Fin.succ)) := by
+                rw [Matrix.mul_assoc]
+        _ = (A (b 0) * Y 1) * evalWord A (List.ofFn (a ∘ Fin.succ)) := by
+                rw [h0]
+        _ = A (b 0) * (Ytail 0 * evalWord A (List.ofFn atail)) := by
+                simp [Ytail, atail, Matrix.mul_assoc]
+        _ = A (b 0) * (evalWord A (List.ofFn btail) * Ytail (Fin.last n)) := by
+                rw [htail]
+        _ = (A (b 0) * evalWord A (List.ofFn (b ∘ Fin.succ))) *
+              Y (Fin.last (n + 1)) := by
+                simp [Ytail, btail, Matrix.mul_assoc]
+
+/-- Iterating adjacent cyclic-window overlaps gives the corresponding
+word-product identity between the endpoint matrices. -/
+theorem adjacent_cyclicRestrictₗ_witness_product
+    {A : MPSTensor d D} {N L n : ℕ}
+    (hInj : IsNBlkInjective A L) (hN : 0 < N) (hLN : L + 1 ≤ N)
+    (i₀ : Fin N) (τ : Fin (n + 1) → Fin N → Fin d) (ψ : NSiteSpace d N)
+    (Y : Fin (n + 1) → Matrix (Fin D) (Fin D) ℂ)
+    (a b : Fin n → Fin d)
+    (hY : ∀ r : Fin (n + 1),
+      cyclicRestrictₗ hN (L + 1) (cyclicForwardSite i₀ r.val) (τ r) ψ =
+        groundSpaceMap A (L + 1) (Y r))
+    (hτ : ∀ r : Fin n,
+      (fun k => if (k.val + N - (cyclicForwardSite i₀ r.val).val) % N = 0
+        then a r else τ (Fin.castSucc r) k) =
+      (fun k => if (k.val + N - (cyclicForwardSite i₀ (r.val + 1)).val) % N = L
+        then b r else τ (Fin.succ r) k)) :
+    Y 0 * evalWord A (List.ofFn a) =
+      evalWord A (List.ofFn b) * Y (Fin.last n) := by
+  apply boundary_witness_product_of_adjacent_overlaps
+  intro r
+  have hY₁ := hY (Fin.castSucc r)
+  have hY₂ : cyclicRestrictₗ hN (L + 1)
+      (cyclicForwardSite (cyclicForwardSite i₀ r.val) 1) (τ (Fin.succ r)) ψ =
+        groundSpaceMap A (L + 1) (Y (Fin.succ r)) := by
+    simpa [cyclicForwardSite_forwardSite, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc]
+      using hY (Fin.succ r)
+  have hτr :
+      (fun k => if (k.val + N - (cyclicForwardSite i₀ r.val).val) % N = 0
+        then a r else τ (Fin.castSucc r) k) =
+      (fun k => if
+        (k.val + N - (cyclicForwardSite (cyclicForwardSite i₀ r.val) 1).val) % N = L
+        then b r else τ (Fin.succ r) k) := by
+    simpa [cyclicForwardSite_forwardSite, Nat.add_assoc]
+      using hτ r
+  exact adjacent_cyclicRestrictₗ_witness_overlap
+    (A := A) hInj hN hLN (cyclicForwardSite i₀ r.val)
+    (τ (Fin.castSucc r)) (τ (Fin.succ r)) ψ hY₁ hY₂ (a r) (b r) hτr
+
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
@@ -10,9 +10,9 @@ import TNLean.MPS.ParentHamiltonian.SuffixWindow
 /-!
 # Boundary overlaps for cyclic parent-Hamiltonian windows
 
-This file records the elementary boundary-matrix identities obtained by deleting
-one endpoint from a cyclic window.  The identities are used in the closing
-boundary comparison for normal parent-Hamiltonian uniqueness.
+This file records the elementary matrix identities obtained by deleting one
+endpoint from a cyclic window.  The identities are used in the closure-property
+comparison for normal parent-Hamiltonian uniqueness.
 -/
 
 open scoped Matrix BigOperators
@@ -21,9 +21,9 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- If a non-repeating cyclic `(L + 1)`-window is represented by the boundary
-matrix `Y`, then fixing its first site to `j` represents the shifted length-`L`
-window by the boundary matrix `Y * A j`. -/
+/-- If a non-repeating cyclic `(L + 1)`-window is represented by the matrix `Y`,
+then fixing its first site to `j` represents the shifted length-`L` window by the
+matrix `Y * A j`. -/
 theorem cyclicRestrictₗ_restrictFirst_groundSpaceMap {A : MPSTensor d D}
     {N L : ℕ} (hN : 0 < N) (hLN : L + 1 ≤ N)
     (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N)
@@ -36,9 +36,9 @@ theorem cyclicRestrictₗ_restrictFirst_groundSpaceMap {A : MPSTensor d D}
   rw [← cyclicRestrictₗ_restrictFirst hN hLN i τ ψ j, hY,
     restrictFirst_groundSpaceMap]
 
-/-- If a cyclic `(L + 1)`-window is represented by the boundary matrix `Y`, then
-fixing its last site to `j` represents the initial length-`L` window by the
-boundary matrix `A j * Y`. -/
+/-- If a cyclic `(L + 1)`-window is represented by the matrix `Y`, then fixing
+its last site to `j` represents the initial length-`L` window by the matrix
+`A j * Y`. -/
 theorem cyclicRestrictₗ_restrictLast_groundSpaceMap {A : MPSTensor d D}
     {N L : ℕ} (hN : 0 < N)
     (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N)
@@ -50,8 +50,8 @@ theorem cyclicRestrictₗ_restrictLast_groundSpaceMap {A : MPSTensor d D}
       groundSpaceMap A L (A j * Y) := by
   rw [← cyclicRestrictₗ_restrictLast hN i τ ψ j, hY, restrictLast_groundSpaceMap]
 
-/-- Adjacent cyclic windows have compatible boundary matrices on their common
-length-`L` overlap.
+/-- Adjacent cyclic windows have compatible matrices on their common length-`L`
+overlap.
 
 The hypothesis `hτ` says that, after the first window is restricted at its first
 site and the second window is restricted at its last site, the two outside

--- a/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
+++ b/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
 
 /-!
-# Right-extension for block-injective parent-Hamiltonian ground spaces
+# Growing back for block-injective parent-Hamiltonian ground spaces
 
 This file proves the open-chain grow-back step from
 [Cirac--Perez-Garcia--Schuch--Verstraete 2021, arXiv:2011.12127,
@@ -139,9 +139,9 @@ private theorem exists_right_factor_of_evalWord_compatibility_succ [NeZero D]
         exact ⟨X, hX⟩
       exists_right_factor_of_letter_compatibility hInj hL₀ hCompat1
 
-/-- If a family of boundary matrices satisfies the compatibility identity
-`Z j * A^σ = A j * Y_σ` for every length-`K` word `σ`, then all `Z j` share a
-common right factor. -/
+/-- Inverting step: if a family of boundary matrices satisfies the compatibility
+identity `Z j * A^σ = A j * Y_σ` for every length-`K` word `σ`, then all `Z j`
+share a common right factor. -/
 theorem exists_right_factor_of_evalWord_compatibility [NeZero D]
     {A : MPSTensor d D} {K L₀ : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -8,7 +8,7 @@ import TNLean.Algebra.TracePairing
 import TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan
 
 /-!
-# Intersection and closure properties of MPS ground spaces
+# Intersection property of MPS ground spaces
 
 For an injective MPS tensor `A`, we establish:
 
@@ -270,9 +270,9 @@ theorem groundSpace_finrank_eq {A : MPSTensor d D} (hA : IsInjective A)
 
 /-! ### The intersection property -/
 
-/-- **Intersection property** for injective MPS: a state on `L+1` sites that restricts
-to ground-space elements on both the left and right `L`-site windows is itself
-in `G_{L+1}(A)`.
+/-- Nontrivial direction of the intersection property for injective MPS: a state
+on `L+1` sites that restricts to ground-space elements on both the left and right
+`L`-site windows is itself in `G_{L+1}(A)`.
 
 This is the "inverting and growing back" step. The proof proceeds as follows:
 

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -843,7 +843,8 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
 
 /-- The two boundary-condition matrix families agree in the closure property,
 reduced to the \(Y A^j\) equation above.
-**Open gap:** Depends on the restriction equality above; see
+**Open gap:** Inherits the unproved boundary-closing word equation
+`closure_property_boundary_right_annihilation_of_chainGroundSpace`; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -721,9 +721,8 @@ lines 2078--2090. The matrices `YAt i τ` represent local restrictions, and the
 displayed equation is the algebraic form that remains before block injectivity
 strips the final length-`L₀` word.
 
-**Open gap:** Prove this by iterating adjacent cyclic-window overlaps around the
-closed boundary; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and
-#2405. -/
+**Open gap:** Prove the adjacent-overlap iteration around the boundary; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_right_annihilation_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -746,8 +745,7 @@ theorem closure_property_boundary_right_annihilation_of_chainGroundSpace
 /-- Matrix form of the closure property, arXiv:2011.12127, lines 2078--2090.
 It follows from the auxiliary annihilation equation and block injectivity.
 
-**Open gap:** Depends on
-`closure_property_boundary_right_annihilation_of_chainGroundSpace`; see
+**Open gap:** Inherits the unproved annihilation lemma above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -785,8 +783,7 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
 lines 2078--2090. It follows by restricting the displayed matrix equation at
 the first physical index.
 
-**Open gap:** Depends on
-`closure_property_boundary_right_annihilation_of_chainGroundSpace`; see
+**Open gap:** Inherits the unproved annihilation lemma above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -824,8 +821,7 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
 /-- Restriction form of the closure property of arXiv:2011.12127,
 lines 2078--2090, obtained from the first-letter family.
 
-**Open gap:** Depends on
-`closure_property_boundary_right_annihilation_of_chainGroundSpace`; see
+**Open gap:** Inherits the unproved annihilation lemma above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -848,7 +844,7 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
 /-- The two families of matrices obtained from the boundary-crossing local
 constraints agree in the closure property, reduced to the \(Y A^j\) equation above.
 **Open gap:** Depends on the restriction equality above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2368. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -900,9 +896,8 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 \(\mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A)\) for \(L>L₀\).  This is
 the closure-property step of arXiv:2011.12127.
 
-**Open gap:** The proof still depends on
-\(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\); see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Open gap:** Depends on the closure-property witness comparison; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -936,9 +931,8 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 for every \(L>L₀\), by the intersection property and closure property of
 arXiv:2011.12127, Section IV.C, lines 2078--2090.
 
-**Open gap:** The containment direction depends on
-\(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\); see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Open gap:** The containment direction depends on the closure property; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N) :
@@ -974,9 +968,8 @@ theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjec
 
 /-- Unique ground state for \(L₀\)-block-injective tensors at range \(2L₀\).
 
-**Open gap:** This uses the normal range-reduction equality and hence the
-comparison \(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\); see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Open gap:** This uses the normal range-reduction equality; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) :
@@ -993,9 +986,8 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
   \dim \mathcal G_{N,L₀+1}(A)=1.
 \]
 
-**Open gap:** This depends on the normal range-reduction equality above and
-hence on \(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\); see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Open gap:** This depends on the normal range-reduction equality above; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -744,7 +744,11 @@ theorem closure_property_boundary_right_annihilation_of_chainGroundSpace
   sorry
 
 /-- Matrix form of the closure property, arXiv:2011.12127, lines 2078--2090.
-It follows from the auxiliary annihilation equation and block injectivity. -/
+It follows from the auxiliary annihilation equation and block injectivity.
+
+**Open gap:** Depends on
+`closure_property_boundary_right_annihilation_of_chainGroundSpace`; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -779,7 +783,11 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
 
 /-- Auxiliary first-letter form of the closure property of arXiv:2011.12127,
 lines 2078--2090. It follows by restricting the displayed matrix equation at
-the first physical index. -/
+the first physical index.
+
+**Open gap:** Depends on
+`closure_property_boundary_right_annihilation_of_chainGroundSpace`; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -814,7 +822,11 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
   exact hLeft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) hProd).trans hRight.symm)
 
 /-- Restriction form of the closure property of arXiv:2011.12127,
-lines 2078--2090, obtained from the first-letter family. -/
+lines 2078--2090, obtained from the first-letter family.
+
+**Open gap:** Depends on
+`closure_property_boundary_right_annihilation_of_chainGroundSpace`; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -599,7 +599,7 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_co
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility
     (A := A) (L₀ := L₀) (m := N - (L₀ + 1)) (N := N) hInj hL₀ Y hLeft hRight
 
-/-- Periodic-chain containment from the closure property in arXiv:2011.12127,
+/-- Closure-property step for periodic chains in arXiv:2011.12127,
 Section IV.C, lines 2078--2090.
 
 The cyclic-to-open-chain reduction produces a boundary matrix \(X\). The two
@@ -716,7 +716,7 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
       (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
   exact hfixed j
 
-/-- Auxiliary annihilation equation for the closure property of arXiv:2011.12127,
+/-- Boundary-closing word equation for the closure property of arXiv:2011.12127,
 lines 2078--2090. The matrices `YAt i τ` represent local restrictions, and the
 displayed equation is the algebraic form that remains before block injectivity
 strips the final length-`L₀` word.
@@ -743,9 +743,9 @@ theorem closure_property_boundary_right_annihilation_of_chainGroundSpace
   sorry
 
 /-- Matrix form of the closure property, arXiv:2011.12127, lines 2078--2090.
-It follows from the auxiliary annihilation equation and block injectivity.
+It follows from the boundary-closing word equation and block injectivity.
 
-**Open gap:** Inherits the unproved annihilation lemma above; see
+**Open gap:** Inherits the unproved boundary-closing word equation above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -783,7 +783,7 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
 lines 2078--2090. It follows by restricting the displayed matrix equation at
 the first physical index.
 
-**Open gap:** Inherits the unproved annihilation lemma above; see
+**Open gap:** Inherits the unproved boundary-closing word equation above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -821,7 +821,7 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
 /-- Restriction form of the closure property of arXiv:2011.12127,
 lines 2078--2090, obtained from the first-letter family.
 
-**Open gap:** Inherits the unproved annihilation lemma above; see
+**Open gap:** Inherits the unproved boundary-closing word equation above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -841,8 +841,8 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
       closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
         (A := A) hInj hL₀ hM hψ hψX η μ j
 
-/-- The two families of matrices obtained from the boundary-crossing local
-constraints agree in the closure property, reduced to the \(Y A^j\) equation above.
+/-- The two boundary-condition matrix families agree in the closure property,
+reduced to the \(Y A^j\) equation above.
 **Open gap:** Depends on the restriction equality above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
@@ -892,11 +892,11 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
   exact closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     (A := A) hInj hL₀ (by omega : L₀ ≤ M) hψred hψX YAt hYAt η μ j
 
-/-- Normal-tensor containment from the closure property:
+/-- Closure-property containment step:
 \(\mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A)\) for \(L>L₀\).  This is
 the closure-property step of arXiv:2011.12127.
 
-**Open gap:** Depends on the closure-property witness comparison; see
+**Open gap:** Depends on the closure-property boundary-condition comparison; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -840,7 +840,6 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     hL₀ hM η μ fun j =>
       closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
         (A := A) hInj hL₀ hM hψ hψX η μ j
-
 /-- The two boundary-condition matrix families agree in the closure property,
 reduced to the \(Y A^j\) equation above.
 **Open gap:** Inherits the unproved boundary-closing word equation

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -681,7 +681,7 @@ theorem wrapped_mirror_witness_agree_of_right_products
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
 /-- The full boundary-closing restriction equality follows from equality after
-fixing each first physical index.  This is a formal step used to isolate the
+fixing each first physical index.  This isolates the
 closing-boundary comparison discussed in arXiv:2011.12127, Section IV.C,
 lines 2078--2090. -/
 theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
@@ -716,86 +716,33 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
       (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
   exact hfixed j
 
-/-- Restriction equality when closing the boundaries, from the closure property,
-arXiv:2011.12127, lines 2078--2090:
-\(\operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L₀+1}(\psi)=
-\operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L₀,L₀+1}(\psi)\).
+/-- Right-annihilation form of the boundary-closing comparison; see
+arXiv:2011.12127, lines 2078--2090.
 
-**Open gap:** This is the instance of the closure property obtained when
-closing the boundaries by the inverting-and-growing-back argument. Tracked in
-#2368; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
-theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
+**Open gap:** Prove this by iterating adjacent cyclic-window overlaps around the
+closed boundary; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and
+#2405. -/
+theorem closure_property_boundary_right_annihilation_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
     (hψ : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1))
     (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
     (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
-    cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
-        ⟨M, by omega⟩
-        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
-      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
-        ⟨M + 1 - L₀, by omega⟩
-        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j -
+          YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j) *
+        evalWord A (List.ofFn σ) = 0 := by
   sorry
 
-/-- First-letter form of the closing-boundary comparison discussed in
-arXiv:2011.12127, lines 2078--2090:
-\(\operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L₀}(\psi)=
-\operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L₀,L₀}(\psi)\).
-
-It is the first-site restriction of the equality obtained when closing the
-boundaries:
-\[
-\operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L₀}(\psi)
-=
-\left.
-\operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L₀+1}(\psi)
-\right|_{\sigma_1=j}
-=
-\left.
-\operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L₀,L₀+1}(\psi)
-\right|_{\sigma_1=j}
-=
-\operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L₀,L₀}(\psi).
-\]
-
-**Open gap:** Depends on the restriction equality for closing the boundaries;
-see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2368. -/
-theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
-    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
-    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
-    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
-    (hψ : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1))
-    (hψX : ψ = groundSpaceMap A (M + 1) X)
-    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (j : Fin d) :
-    cyclicRestrictₗ (show 0 < M + 1 by omega) L₀
-        (cyclicForwardSite ⟨M, by omega⟩ 1)
-        (fun k => if (k.val + (M + 1) - (⟨M, by omega⟩ : Fin (M + 1)).val) %
-              (M + 1) = 0 then j else wrappedMiddleBackground L₀ (M + 1) η μ k) ψ =
-      cyclicRestrictₗ (show 0 < M + 1 by omega) L₀
-        (cyclicForwardSite ⟨M + 1 - L₀, by omega⟩ 1)
-        (fun k => if (k.val + (M + 1) -
-              (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)).val) % (M + 1) = 0 then j
-            else mirrorMiddleBackground L₀ (M + 1) η μ k) ψ := by
-  rw [← cyclicRestrictₗ_restrictFirst
-      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
-      (⟨M, by omega⟩ : Fin (M + 1))
-      (wrappedMiddleBackground L₀ (M + 1) η μ) ψ j]
-  rw [← cyclicRestrictₗ_restrictFirst
-      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
-      (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
-      (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
-  exact congrArg (fun φ => restrictFirst φ j)
-    (closure_property_boundary_restriction_eq_of_chainGroundSpace
-      (A := A) hInj hL₀ hM hψ hψX η μ)
-
-/-- Boundary-matrix form of the closing-boundary comparison discussed in
-arXiv:2011.12127, lines 2078--2090:
-\(Y_M(\tau^+_\eta(\mu))A^j=Y_{M+1-L₀}(\tau^-_\eta(\mu))A^j\).
-**Open gap:** Depends on the restriction equality above for closing the
-boundaries; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2368. -/
+/-- Matrix equation used for closing the boundaries, arXiv:2011.12127,
+lines 2078--2090. It follows from right-annihilation and block-injectivity. -/
 theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -813,7 +760,43 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
         YAt ⟨M + 1 - L₀, by omega⟩
           (mirrorMiddleBackground L₀ (M + 1) η μ) * A j := by
   intro j
-  apply groundSpaceMap_injective_of_isNBlkInjective hInj
+  have hzero : ∀ σ : Fin L₀ → Fin d,
+      (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j -
+          YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j) *
+        evalWord A (List.ofFn σ) = 0 :=
+    closure_property_boundary_right_annihilation_of_chainGroundSpace
+      (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ j
+  have hsub :
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j -
+          YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j = 0 :=
+    eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
+      (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
+  exact sub_eq_zero.mp hsub
+
+/-- First-index equation used for the boundary-closing comparison of
+arXiv:2011.12127, lines 2078--2090. It follows by restricting the displayed
+matrix equation at the first physical index. -/
+theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψ : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1))
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (j : Fin d) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) L₀
+        (cyclicForwardSite ⟨M, by omega⟩ 1)
+        (fun k => if (k.val + (M + 1) - (⟨M, by omega⟩ : Fin (M + 1)).val) %
+              (M + 1) = 0 then j else wrappedMiddleBackground L₀ (M + 1) η μ k) ψ =
+      cyclicRestrictₗ (show 0 < M + 1 by omega) L₀
+        (cyclicForwardSite ⟨M + 1 - L₀, by omega⟩ 1)
+        (fun k => if (k.val + (M + 1) -
+              (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)).val) % (M + 1) = 0 then j
+            else mirrorMiddleBackground L₀ (M + 1) η μ k) ψ := by
+  obtain ⟨YAt, hYAt⟩ :=
+    chainGroundSpace_window_witnesses A (show 0 < M + 1 by omega)
+      (show L₀ + 1 ≤ M + 1 by omega) hψ
   have hLeft := cyclicRestrictₗ_restrictFirst_groundSpaceMap
     (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
     (⟨M, by omega⟩ : Fin (M + 1))
@@ -824,14 +807,32 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
     (mirrorMiddleBackground L₀ (M + 1) η μ) ψ
     (hYAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) η μ)) j
-  exact hLeft.symm.trans
-    ((closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
-      (A := A) hInj hL₀ hM hψ hψX η μ j).trans hRight)
+  have hProd := closure_property_boundary_tensor_products_eq_of_chainGroundSpace
+    (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ j
+  exact hLeft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) hProd).trans hRight.symm)
 
-/-- Boundary matrices from the two boundary-closing comparisons agree.
-This is the boundary-matrix consequence expected from the closing-boundary
-comparison discussed in arXiv:2011.12127, lines 2078--2090, reduced to the
-\(Y A^j\) equation above.
+/-- Boundary-closing restriction equation of arXiv:2011.12127, lines 2078--2090,
+obtained from the first-index family. -/
+theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψ : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1))
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        ⟨M, by omega⟩
+        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        ⟨M + 1 - L₀, by omega⟩
+        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+  exact closure_property_boundary_restriction_eq_of_fixed_boundary_letters
+    hL₀ hM η μ fun j =>
+      closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
+        (A := A) hInj hL₀ hM hψ hψX η μ j
+
+/-- The two matrix witnesses obtained when closing the boundaries agree,
+reduced to the \(Y A^j\) equation above.
 **Open gap:** Depends on the restriction equality above for closing the
 boundaries; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2368. -/

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -262,12 +262,12 @@ private theorem neZero_d_of_isNBlkInjective [NeZero D]
   rw [IsNBlkInjective, hempty, Submodule.span_empty] at hInj
   exact bot_ne_top hInj
 
-/-- Open-chain range reduction for block-injective tensors.
+/-- Open-chain intersection property for block-injective tensors.
 
 If all contiguous windows of size `L₀ + 1` lie in the corresponding MPS ground
 space, then the full open chain lies in `groundSpace A N`.  This is the
-chain-level iteration of `groundSpace_extend_right_of_isNBlkInjective`; it is the
-open-boundary half of the normal parent-Hamiltonian range reduction. -/
+chain-level iteration of the inverting and growing-back argument in
+arXiv:2011.12127, Section IV.C. -/
 theorem contiguous_mem_groundSpace_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hLN : L₀ + 1 ≤ N)
@@ -599,8 +599,8 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_co
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility
     (A := A) (L₀ := L₀) (m := N - (L₀ + 1)) (N := N) hInj hL₀ Y hLeft hRight
 
-/-- Periodic-chain containment from the boundary equality, from the closure
-property in arXiv:2011.12127, Section IV.C, lines 2078--2090.
+/-- Periodic-chain containment from the closure property in arXiv:2011.12127,
+Section IV.C, lines 2078--2090.
 
 The cyclic-to-open-chain reduction produces a boundary matrix \(X\). The two
 boundary-crossing local constraints give
@@ -716,8 +716,10 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
       (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
   exact hfixed j
 
-/-- Right-annihilation form of the boundary-closing comparison; see
-arXiv:2011.12127, lines 2078--2090.
+/-- Auxiliary annihilation equation for the closure property of arXiv:2011.12127,
+lines 2078--2090. The matrices `YAt i τ` represent local restrictions, and the
+displayed equation is the algebraic form that remains before block injectivity
+strips the final length-`L₀` word.
 
 **Open gap:** Prove this by iterating adjacent cyclic-window overlaps around the
 closed boundary; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and
@@ -741,8 +743,8 @@ theorem closure_property_boundary_right_annihilation_of_chainGroundSpace
         evalWord A (List.ofFn σ) = 0 := by
   sorry
 
-/-- Matrix equation used for closing the boundaries, arXiv:2011.12127,
-lines 2078--2090. It follows from right-annihilation and block-injectivity. -/
+/-- Matrix form of the closure property, arXiv:2011.12127, lines 2078--2090.
+It follows from the auxiliary annihilation equation and block injectivity. -/
 theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -775,9 +777,9 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
       (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
   exact sub_eq_zero.mp hsub
 
-/-- First-index equation used for the boundary-closing comparison of
-arXiv:2011.12127, lines 2078--2090. It follows by restricting the displayed
-matrix equation at the first physical index. -/
+/-- Auxiliary first-letter form of the closure property of arXiv:2011.12127,
+lines 2078--2090. It follows by restricting the displayed matrix equation at
+the first physical index. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -811,8 +813,8 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ j
   exact hLeft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) hProd).trans hRight.symm)
 
-/-- Boundary-closing restriction equation of arXiv:2011.12127, lines 2078--2090,
-obtained from the first-index family. -/
+/-- Restriction form of the closure property of arXiv:2011.12127,
+lines 2078--2090, obtained from the first-letter family. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -831,10 +833,9 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
       closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
         (A := A) hInj hL₀ hM hψ hψX η μ j
 
-/-- The two matrix witnesses obtained when closing the boundaries agree,
-reduced to the \(Y A^j\) equation above.
-**Open gap:** Depends on the restriction equality above for closing the
-boundaries; see
+/-- The two families of matrices obtained from the boundary-crossing local
+constraints agree in the closure property, reduced to the \(Y A^j\) equation above.
+**Open gap:** Depends on the restriction equality above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2368. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
@@ -883,11 +884,9 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
   exact closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     (A := A) hInj hL₀ (by omega : L₀ ≤ M) hψred hψX YAt hYAt η μ j
 
-/-- Range reduction for normal tensors:
-\[
-  \mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A)
-\]
-for \(L>L₀\).  This is the closure-property step of arXiv:2011.12127.
+/-- Normal-tensor containment from the closure property:
+\(\mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A)\) for \(L>L₀\).  This is
+the closure-property step of arXiv:2011.12127.
 
 **Open gap:** The proof still depends on
 \(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\); see

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -749,8 +749,8 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes
 /-- If left multiplication by `Z` annihilates every word product of length `k`,
 and words of some longer length `n` span the full matrix algebra, then `Z = 0`.
 
-This is the padding form needed in the normal boundary-closing argument: an
-annihilation relation obtained for a short complement word can be multiplied by
+This is the padding form needed in the normal boundary-closing argument: a
+zero-product relation obtained for a short complement word can be multiplied by
 all padding words up to any length whose exact word span is `⊤`. -/
 theorem eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top
     {A : MPSTensor d D} {k n : ℕ} {Z : Matrix (Fin D) (Fin D) ℂ}
@@ -793,7 +793,7 @@ theorem eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top
 `eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top`.
 
 If `A` is `L₀`-block-injective, then every positive multiple of `L₀` has full
-word span. Hence an annihilation relation at length `k` already forces `Z = 0`
+word span. Hence a zero-product relation at length `k` already forces `Z = 0`
 as soon as `k` is bounded by such a multiple. -/
 theorem eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
     {A : MPSTensor d D} {L₀ k q : ℕ} (hInj : IsNBlkInjective A L₀)

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -443,10 +443,9 @@ theorem wrapping_window_compatibility_of_isNBlkInjective
         (evalWord A (List.ofFn σ_tail) * (Y τ * A j)) := by
           simp [Matrix.mul_assoc]
 
-/-- The opposite cyclic position used when closing the boundary exposes the compatibility
-`X * A j * C_τ = A j * Y_τ` after block-injective stripping of the trailing
-`L₀`-site block. This is the missing second cyclic-window extraction needed
-for the block-injective periodic argument. -/
+/-- The opposite cyclic position used in the closure property exposes the
+compatibility `X * A j * C_τ = A j * Y_τ` after block-injective stripping of the
+trailing `L₀`-site block. -/
 theorem wrapping_window_mirror_compatibility_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -638,9 +637,9 @@ theorem two_sided_middle_compatibility_of_wrapped_witness_comparison
 with every word obtained by adjoining one physical letter on each side.
 
 This is the algebraic core of the remaining normal parent-Hamiltonian closure
-step: after the two cyclic windows used when closing the boundary have been
-compared so that their boundary matrices agree on a shared complement `μ`, the identities
-`A^μ A^b X = Y_μ A^b` and `X A^a A^μ = A^a Y_μ` imply
+property: after the two cyclic windows have been compared so that their matrices
+agree on a shared complement `μ`, the identities `A^μ A^b X = Y_μ A^b` and
+`X A^a A^μ = A^a Y_μ` imply
 `X A^a A^μ A^b = A^a A^μ A^b X`. -/
 theorem commutes_words_of_two_sided_middle_compatibility
     {A : MPSTensor d D} {m : ℕ} {X : Matrix (Fin D) (Fin D) ℂ}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1465,7 +1465,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} applies.
 \end{proof}
 
-\begin{theorem}[Periodic-chain containment from the closure property]
+\begin{theorem}[Closure-property step for periodic chains]
     \label{thm:conditional_normal_range_reduction_witness_comparison}
     \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison}
     \leanok
@@ -1718,7 +1718,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     The two restrictions are therefore equal.
 \end{proof}
 
-\begin{lemma}[Auxiliary annihilation equation for the closure property]
+\begin{lemma}[Boundary-closing word equation for the closure property]
     \label{lem:boundary_closing_right_annihilation_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_right_annihilation_of_chainGroundSpace}
     \leanok
@@ -1762,7 +1762,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^jA^\sigma,
     \]
-    which is the displayed annihilation equation.
+    which is the displayed boundary-closing word equation.
 \end{proof}
 
 \begin{lemma}[Matrix form of the closure property]
@@ -1817,7 +1817,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
 \end{proof}
 
-\begin{theorem}[Closure-property witness comparison]
+\begin{theorem}[Boundary conditions agree in the closure property]
     \label{thm:wrapped_mirror_witness_agree_chain_ground_space}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace}
     \leanok
@@ -1937,7 +1937,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     the reverse inclusion is Lemma~\ref{lem:mpv_mem_chain_ground_space}.
 \end{proof}
 
-\begin{theorem}[Normal-tensor containment from the closure property]
+\begin{theorem}[Closure-property step toward uniqueness of the ground state]
     \label{thm:normal_range_reduction_containment}
     \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction}
     \leanok
@@ -1965,8 +1965,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \qquad
         X A^j A^\mu = A^jY^-_{\tau^-_\eta(\mu)}.
     \]
-    The closure-property comparison of
-    \cite[lines~2078--2090]{Cirac2021Matrix} is the equality
+    The closing-boundary argument of
+    \cite[lines~2078--2090]{Cirac2021Matrix} supplies the equality
     \[
         Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}.
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -681,9 +681,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \[
         Y_1 A^a = A^b Y_2.
     \]
-    Consequently, for a finite chain of adjacent overlaps
+    Consequently, for a finite chain of adjacent overlaps indexed by
+    \(0\le r<n\),
     \[
-        Y_rA^{a_r}=A^{b_r}Y_{r+1}\qquad (0\le r<n),
+        Y_rA^{a_r}=A^{b_r}Y_{r+1},
     \]
     one has
     \[
@@ -1720,6 +1721,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{lemma}[Auxiliary annihilation equation for the closure property]
     \label{lem:boundary_closing_right_annihilation_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_right_annihilation_of_chainGroundSpace}
+    \leanok
     \uses{def:chain_ground_space, lem:cyclic_window_boundary_matrix_transport,
         lem:wrapped_middle_backgrounds}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let
@@ -1790,7 +1792,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \end{lemma}
 
 \begin{proof}
-    \leanok
+    \notready
     Fix $j$ and set
     \[
         Z_j=

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -576,7 +576,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \end{enumerate}
 \end{proof}
 
-\begin{theorem}[Intersection characterization]\label{thm:ground_space_iff}
+\begin{theorem}[Intersection property]\label{thm:ground_space_iff}
     \lean{MPSTensor.groundSpace_iff_left_right}
     \leanok
     \uses{lem:ground_space_in_left_ground, lem:ground_space_in_right_ground,
@@ -792,7 +792,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $L_0$-block injectivity, yields $Z_j A^u = A_j Y_u$.
 \end{proof}
 
-\begin{theorem}[Common right factor from word compatibility]%
+\begin{theorem}[Inverting step for word compatibility]%
     \label{thm:right_factor_word_compatibility}
     \lean{MPSTensor.exists_right_factor_of_evalWord_compatibility}
     \leanok
@@ -819,7 +819,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $K = 1$.
 \end{proof}
 
-\begin{theorem}[Open-chain right extension at the injectivity length]%
+\begin{theorem}[Growing-back step at the injectivity length]%
     \label{thm:ground_space_extend_right_block_injective}
     \lean{MPSTensor.groundSpace_extend_right_of_isNBlkInjective}
     \leanok
@@ -1464,7 +1464,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Theorem~\ref{thm:ground_space_map_mpv_of_common_middle} applies.
 \end{proof}
 
-\begin{theorem}[Periodic-chain containment from the boundary equality]
+\begin{theorem}[Periodic-chain containment from the closure property]
     \label{thm:conditional_normal_range_reduction_witness_comparison}
     \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison}
     \leanok
@@ -1520,7 +1520,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_right_products}
     \leanok
     \uses{lem:one_sided_boundary_witness_unique}
-    Let $A$ be $L_0$-block-injective with $L_0>0$.  Fix two matrix-witness
+    Let $A$ be $L_0$-block-injective with $L_0>0$.  Fix two matrix
     families $Y^+$ and $Y^-$ and the two reindexed backgrounds
     $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$.  If, for every physical letter
     $j$,
@@ -1575,7 +1575,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
 \end{proof}
 
-\begin{lemma}[Boundary equality from fixed first letters]
+\begin{lemma}[Auxiliary restriction equality for the closure property]
     \label{lem:boundary_restriction_from_fixed_letters}
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_fixed_boundary_letters}
     \leanok
@@ -1603,11 +1603,11 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     Apply Lemma~\ref{lem:first_letter_restrictions_determine} to the two
-    length-$(L_0+1)$ restrictions, using the displayed family of first-index
+    length-$(L_0+1)$ restrictions, using the displayed family of first-letter
     equalities.
 \end{proof}
 
-\begin{lemma}[Auxiliary restriction equation for closing the boundaries]
+\begin{lemma}[Restriction form of the closure property]
     \label{lem:closure_property_boundary_restriction_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_chainGroundSpace}
     \leanok
@@ -1633,13 +1633,13 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    For each first index $j$, the first-index assertion gives
+    For each first letter $j$, the first-letter assertion gives
     \[
         \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
         =
         \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi).
     \]
-    The definitions of the first-index backgrounds identify these two sides
+    The definitions of the first-letter backgrounds identify these two sides
     with the first-letter restrictions
     \[
     \begin{aligned}
@@ -1669,7 +1669,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     two length-$(L_0+1)$ restrictions.
 \end{proof}
 
-\begin{lemma}[Auxiliary first-index form of the closure equation]
+\begin{lemma}[Auxiliary first-letter form of the closure property]
     \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
     \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}
     \leanok
@@ -1683,14 +1683,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \qquad
         \psi=\Gamma_{M+1}(X).
     \]
-    The first-index boundary-closing assertion is
+    The auxiliary first-letter assertion used to close the boundary is
     \[
         \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
         =
         \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi).
     \]
-    This is the first-index equation used for the closing-boundary
-    comparison discussed in \cite[lines~2078--2090]{Cirac2021Matrix}.
+    This is a first-letter form of the closure-property comparison discussed
+    in \cite[lines~2078--2090]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}
@@ -1717,15 +1717,20 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     The two restrictions are therefore equal.
 \end{proof}
 
-\begin{lemma}[Right-annihilation equation for closing the boundary]
+\begin{lemma}[Auxiliary annihilation equation for the closure property]
     \label{lem:boundary_closing_right_annihilation_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_right_annihilation_of_chainGroundSpace}
     \uses{def:chain_ground_space, lem:cyclic_window_boundary_matrix_transport,
         lem:wrapped_middle_backgrounds}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let
     $\psi\in\mathcal G_{M+1,L_0+1}(A)$ have an open-chain representation
-    $\psi=\Gamma_{M+1}(X)$, and let $Y_i(\tau)$ be the cyclic-window witnesses
-    for $\psi$ on windows of length $L_0+1$. If $L_0\le M$, then for every
+    $\psi=\Gamma_{M+1}(X)$.  Let $Y_i(\tau)$ be matrices satisfying
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    If $L_0\le M$, then for every
     boundary letter $\eta$, complementary word $\mu$, physical letter $j$, and
     word $\sigma$ of length $L_0$,
     \[
@@ -1758,7 +1763,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     which is the displayed annihilation equation.
 \end{proof}
 
-\begin{lemma}[Auxiliary matrix equation for closing the boundaries]
+\begin{lemma}[Matrix form of the closure property]
     \label{lem:boundary_closing_boundary_tensor_products_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_tensor_products_eq_of_chainGroundSpace}
     \leanok
@@ -1766,8 +1771,13 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         lem:padded_complement_annihilation}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let
     $\psi\in\mathcal G_{M+1,L_0+1}(A)$ have an open-chain representation
-    $\psi=\Gamma_{M+1}(X)$, and let $Y_i(\tau)$ be the cyclic-window witnesses
-    for $\psi$ on windows of length $L_0+1$. If $L_0\le M$, then for every
+    $\psi=\Gamma_{M+1}(X)$.  Let $Y_i(\tau)$ be matrices satisfying
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    If $L_0\le M$, then for every
     letter $\eta$ used in the two boundary assignments, every word $\mu$ on
     the complementary sites, and every physical letter $j$,
     \[
@@ -1789,11 +1799,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j .
     \]
     Lemma~\ref{lem:boundary_closing_right_annihilation_chain_ground_space}
-    gives
+    gives, for every word $\sigma$ of length $L_0$,
     \[
-        Z_jA^\sigma=0
-        \qquad
-        \text{for every word }\sigma\text{ of length }L_0.
+        Z_jA^\sigma=0.
     \]
     Since $A$ is $L_0$-block-injective,
     \[
@@ -1807,7 +1815,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
 \end{proof}
 
-\begin{theorem}[Witnesses agree after closing the boundary]
+\begin{theorem}[Closure-property witness comparison]
     \label{thm:wrapped_mirror_witness_agree_chain_ground_space}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace}
     \leanok
@@ -1817,9 +1825,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let $N\ge2$
     and $L_0<L\le N$, and let
     $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
-    $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are the two
-    matrix-witness families extracted from the two boundary-crossing local
-    constraints used when closing the periodic boundary, and that they satisfy,
+    $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are two families of
+    matrices obtained from the two boundary-crossing local constraints used
+    in the closure property, and that they satisfy,
     for every physical letter $j$ and every background configuration $\tau$,
     \[
         A^{\tau_{L_0}\cdots\tau_{N-2}} A^j X
@@ -1846,7 +1854,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
             \eta,      & \text{otherwise}.
         \end{cases}
     \]
-    Then the two boundary matrices agree on these two backgrounds:
+    Then the two families agree on these two backgrounds:
     \[
         Y^{+}_{\tau^{+}_{\eta}(\mu)}
         =
@@ -1927,7 +1935,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     the reverse inclusion is Lemma~\ref{lem:mpv_mem_chain_ground_space}.
 \end{proof}
 
-\begin{theorem}[Periodic-chain containment for normal tensors]
+\begin{theorem}[Normal-tensor containment from the closure property]
     \label{thm:normal_range_reduction_containment}
     \lean{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction}
     \leanok

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -665,6 +665,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.cyclicRestrictₗ_restrictFirst_groundSpaceMap}
     \lean{MPSTensor.cyclicRestrictₗ_restrictLast_groundSpaceMap}
     \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_overlap}
+    \lean{MPSTensor.boundary_witness_product_of_adjacent_overlaps}
+    \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_product}
     \leanok
     \uses{rem:cyclic_window_operators, def:ground_space_parent, def:l_blk_injective}
     If a cyclic $(L+1)$-window is represented by a boundary matrix $Y$, then
@@ -679,6 +681,16 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \[
         Y_1 A^a = A^b Y_2.
     \]
+    Consequently, for a finite chain of adjacent overlaps
+    \[
+        Y_rA^{a_r}=A^{b_r}Y_{r+1}\qquad (0\le r<n),
+    \]
+    one has
+    \[
+        Y_0A^{a_0}\cdots A^{a_{n-1}}
+        =
+        A^{b_0}\cdots A^{b_{n-1}}Y_n .
+    \]
 \end{lemma}
 
 \begin{proof}
@@ -688,6 +700,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     For adjacent windows, equality of the completed outside assignments makes
     the two restricted states on the common overlap equal. Injectivity of the
     length-$L$ ground-space map then identifies their boundary matrices.
+    Iterating the displayed adjacent identity gives the word-product identity.
 \end{proof}
 
 \begin{lemma}[Iterated contiguous-window intersection]\label{lem:contiguous_mem_ground_space}
@@ -830,7 +843,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     coincide, so $\psi$ lies in $G_{K + L_0 + 1}(A)$.
 \end{proof}
 
-\begin{theorem}[Open-chain closure property]%
+\begin{theorem}[Open-chain iteration of the intersection property]%
     \label{thm:normal_open_chain_range_reduction}
     \lean{MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective}
     \leanok
@@ -1502,12 +1515,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     finishes.
 \end{proof}
 
-\begin{lemma}[Products with one-site tensors determine the boundary matrix]
+\begin{lemma}[Products with one-site tensors determine the witness]
     \label{lem:wrapped_mirror_right_products_determine}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_right_products}
     \leanok
     \uses{lem:one_sided_boundary_witness_unique}
-    Let $A$ be $L_0$-block-injective with $L_0>0$.  Fix two boundary-matrix
+    Let $A$ be $L_0$-block-injective with $L_0>0$.  Fix two matrix-witness
     families $Y^+$ and $Y^-$ and the two reindexed backgrounds
     $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$.  If, for every physical letter
     $j$,
@@ -1526,7 +1539,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    Apply Lemma~\ref{lem:one_sided_boundary_witness_unique} to the two boundary
+    Apply Lemma~\ref{lem:one_sided_boundary_witness_unique} to the two
     matrices $Y^+_{\tau^+_\eta(\mu)}$ and $Y^-_{\tau^-_\eta(\mu)}$.
 \end{proof}
 
@@ -1590,16 +1603,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     Apply Lemma~\ref{lem:first_letter_restrictions_determine} to the two
-    length-$(L_0+1)$ restrictions, using the displayed family of fixed-letter
+    length-$(L_0+1)$ restrictions, using the displayed family of first-index
     equalities.
 \end{proof}
 
-\begin{lemma}[Restriction equation when closing the boundaries]
+\begin{lemma}[Auxiliary restriction equation for closing the boundaries]
     \label{lem:closure_property_boundary_restriction_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_chainGroundSpace}
     \leanok
     \uses{def:chain_ground_space, rem:cyclic_window_operators,
-        lem:wrapped_middle_backgrounds, lem:boundary_restriction_from_fixed_letters}
+        lem:wrapped_middle_backgrounds, lem:boundary_restriction_from_fixed_letters,
+        lem:closure_property_fixed_boundary_letter_chain_ground_space}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
     $L_0\le M$, and let
     \[
@@ -1608,7 +1622,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \psi=\Gamma_{M+1}(X).
     \]
     For every boundary letter $\eta$ and complementary word $\mu$, the
-    formal comparison isolated from the closing-boundary argument of
+    equation used for the closing-boundary argument of
     \cite[lines~2078--2090]{Cirac2021Matrix} is
     \[
         \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
@@ -1619,58 +1633,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    By Lemma~\ref{lem:boundary_restriction_from_fixed_letters}, it is enough to
-    prove the fixed-letter family
+    For each first index $j$, the first-index assertion gives
     \[
-        \forall j,\qquad
-        \left.
-        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
-        \right|_{\sigma_1=j}
+        \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
         =
-        \left.
-        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi)
-        \right|_{\sigma_1=j}.
+        \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi).
     \]
-    The required algebraic input is the block-injectivity identity
-    \[
-        \operatorname{span}\{A^{j_1}\cdots A^{j_{L_0}} :
-        j_1,\ldots,j_{L_0}\}
-        =
-        M_D(\mathbb C).
-    \]
-    Thus the unproved boundary-closing implication is
-    \[
-        \psi\in\mathcal G_{M+1,L_0+1}(A),\quad
-        \psi=\Gamma_{M+1}(X),\quad
-        \operatorname{span}\{A^{j_1}\cdots A^{j_{L_0}} :
-        j_1,\ldots,j_{L_0}\}=M_D(\mathbb C)
-        \Longrightarrow
-        \forall j,\qquad
-        \left.
-        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
-        \right|_{\sigma_1=j}
-        =
-        \left.
-        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi)
-        \right|_{\sigma_1=j}.
-    \]
-\end{proof}
-
-\begin{lemma}[Closure-property restriction equation]
-    \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
-    \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}
-    \leanok
-    \uses{def:chain_ground_space, rem:cyclic_window_operators,
-        lem:wrapped_middle_backgrounds,
-        lem:closure_property_boundary_restriction_chain_ground_space}
-    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
-    $L_0\le M$, and let
-    \[
-        \psi\in\mathcal G_{M+1,L_0+1}(A),
-        \qquad
-        \psi=\Gamma_{M+1}(X).
-    \]
-    The restricted boundary backgrounds are characterized by
+    The definitions of the first-index backgrounds identify these two sides
+    with the first-letter restrictions
     \[
     \begin{aligned}
         \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
@@ -1685,49 +1655,115 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \right|_{\sigma_1=j}.
     \end{aligned}
     \]
-    The closure property gives the restriction equation
+    Hence, for every $j$,
+    \[
+        \left.
+        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
+        \right|_{\sigma_1=j}
+        =
+        \left.
+        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi)
+        \right|_{\sigma_1=j}.
+    \]
+    Lemma~\ref{lem:boundary_restriction_from_fixed_letters} then identifies the
+    two length-$(L_0+1)$ restrictions.
+\end{proof}
+
+\begin{lemma}[Auxiliary first-index form of the closure equation]
+    \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
+    \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}
+    \leanok
+    \uses{def:chain_ground_space, rem:cyclic_window_operators,
+        lem:chain_ground_space_window_witnesses,
+        lem:boundary_closing_boundary_tensor_products_chain_ground_space}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
+    $L_0\le M$, and let
+    \[
+        \psi\in\mathcal G_{M+1,L_0+1}(A),
+        \qquad
+        \psi=\Gamma_{M+1}(X).
+    \]
+    The first-index boundary-closing assertion is
     \[
         \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
         =
         \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi).
     \]
-    This is the fixed-letter form used to express the closing-boundary
+    This is the first-index equation used for the closing-boundary
     comparison discussed in \cite[lines~2078--2090]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}
     \notready
-    The restriction equation obtained when closing the boundaries is
+    Let $Y_i(\tau)$ be the window witnesses of
+    Lemma~\ref{lem:chain_ground_space_window_witnesses}.  By
+    Lemma~\ref{lem:boundary_closing_boundary_tensor_products_chain_ground_space},
     \[
-        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
+        Y_M(\tau^+_\eta(\mu))A^j
         =
-        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi).
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
     \]
-    Therefore
+    Fixing the first physical letter in the two length-$(L_0+1)$ windows gives
     \[
     \begin{aligned}
         \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
         &=
-        \left.
-        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
-        \right|_{\sigma_1=j} \\
+        \Gamma_{L_0}\!\left(Y_M(\tau^+_\eta(\mu))A^j\right),\\
+        \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi)
         &=
-        \left.
-        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi)
-        \right|_{\sigma_1=j} \\
-        &=
-        \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi).
+        \Gamma_{L_0}\!\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\right).
     \end{aligned}
     \]
+    The two restrictions are therefore equal.
 \end{proof}
 
-\begin{lemma}[Boundary-closing \(Y A^j\) equation]
+\begin{lemma}[Right-annihilation equation for closing the boundary]
+    \label{lem:boundary_closing_right_annihilation_chain_ground_space}
+    \lean{MPSTensor.closure_property_boundary_right_annihilation_of_chainGroundSpace}
+    \uses{def:chain_ground_space, lem:cyclic_window_boundary_matrix_transport,
+        lem:wrapped_middle_backgrounds}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let
+    $\psi\in\mathcal G_{M+1,L_0+1}(A)$ have an open-chain representation
+    $\psi=\Gamma_{M+1}(X)$, and let $Y_i(\tau)$ be the cyclic-window witnesses
+    for $\psi$ on windows of length $L_0+1$. If $L_0\le M$, then for every
+    boundary letter $\eta$, complementary word $\mu$, physical letter $j$, and
+    word $\sigma$ of length $L_0$,
+    \[
+    \left(
+        Y_M(\tau^{+}_{\eta}(\mu))A^j
+        -
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j
+    \right)A^\sigma=0 .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \notready
+    For two adjacent cyclic windows, Lemma~\ref{lem:cyclic_window_boundary_matrix_transport}
+    gives
+    \[
+        Y_i(\tau_i)A^{a_i}=A^{b_i}Y_{i+1}(\tau_{i+1})
+    \]
+    when the two endpoint-deleted outside assignments agree on the common
+    length-$L_0$ interval.  Choose the assignments $\tau_i$ so that the deleted
+    endpoints are the letters of $j\sigma$ and the remaining sites are
+    $\tau^+_\eta(\mu)$ at the wrapped end and $\tau^-_\eta(\mu)$ at the
+    opposite end.  Iterating the adjacent-window identity around the closing
+    boundary gives
+    \[
+        Y_M(\tau^{+}_{\eta}(\mu))A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^jA^\sigma,
+    \]
+    which is the displayed annihilation equation.
+\end{proof}
+
+\begin{lemma}[Auxiliary matrix equation for closing the boundaries]
     \label{lem:boundary_closing_boundary_tensor_products_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_tensor_products_eq_of_chainGroundSpace}
     \leanok
-    \uses{def:chain_ground_space, lem:chain_ground_space_window_witnesses,
-        lem:closure_property_fixed_boundary_letter_chain_ground_space,
-        lem:wrapped_middle_backgrounds}
+    \uses{lem:boundary_closing_right_annihilation_chain_ground_space,
+        lem:padded_complement_annihilation}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let
     $\psi\in\mathcal G_{M+1,L_0+1}(A)$ have an open-chain representation
     $\psi=\Gamma_{M+1}(X)$, and let $Y_i(\tau)$ be the cyclic-window witnesses
@@ -1739,54 +1775,31 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
     \]
-    This is the boundary-matrix form of the closing-boundary comparison
+    This is the matrix equation representing the closing-boundary comparison
     discussed in \cite[lines~2078--2090]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}
-    \notready
-    With the notation of \cite[lines~2049--2079]{Cirac2021Matrix},
+    \leanok
+    Fix $j$ and set
     \[
-    \begin{aligned}
-        \mathcal I
-        &:=
-        \mathcal G_{1,\ldots,L_0+1}
-        \cap
-        \mathcal G_{2,\ldots,L_0+2},\\
-        \psi\in\mathcal I
-        &\Longrightarrow
-        \psi\in\mathcal G_{1,\ldots,L_0+2}.
-    \end{aligned}
+        Z_j=
+        Y_M(\tau^{+}_{\eta}(\mu))A^j
+        -
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j .
     \]
-    Hence
+    Lemma~\ref{lem:boundary_closing_right_annihilation_chain_ground_space}
+    gives
     \[
-    \begin{aligned}
-        \mathcal I
-        &\subseteq
-        \mathcal G_{1,\ldots,L_0+2},\\
-        \mathcal G_{1,\ldots,L_0+2}
-        &\subseteq
-        \mathcal G_{1,\ldots,L_0+1}
-        \cap
-        \mathcal G_{2,\ldots,L_0+2}.
-    \end{aligned}
+        Z_jA^\sigma=0
+        \qquad
+        \text{for every word }\sigma\text{ of length }L_0.
     \]
-    Thus
+    Since $A$ is $L_0$-block-injective,
     \[
-        \mathcal G_{1,\ldots,L_0+1}
-        \cap
-        \mathcal G_{2,\ldots,L_0+2}
-        =
-        \mathcal G_{1,\ldots,L_0+2}.
+        \operatorname{span}\{A^\sigma:|\sigma|=L_0\}=M_D(\mathbb C).
     \]
-    By iteration, for $2\le k\le L_0$,
-    \[
-        \bigcap_{r=1}^{k}
-        \mathcal G_{r,\ldots,r+L_0}
-        =
-        \mathcal G_{1,\ldots,L_0+k}.
-    \]
-    The boundary-closing equation is
+    Applying Lemma~\ref{lem:padded_complement_annihilation} gives $Z_j=0$, hence
     \[
         Y_M(\tau^{+}_{\eta}(\mu))A^j
         =
@@ -1794,7 +1807,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
 \end{proof}
 
-\begin{theorem}[Boundary matrices agree after closing the boundary]
+\begin{theorem}[Witnesses agree after closing the boundary]
     \label{thm:wrapped_mirror_witness_agree_chain_ground_space}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace}
     \leanok
@@ -1805,7 +1818,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     and $L_0<L\le N$, and let
     $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
     $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are the two
-    boundary-matrix families extracted from the two boundary-crossing local
+    matrix-witness families extracted from the two boundary-crossing local
     constraints used when closing the periodic boundary, and that they satisfy,
     for every physical letter $j$ and every background configuration $\tau$,
     \[


### PR DESCRIPTION
This PR realigns the parent-Hamiltonian blueprint and Lean docstrings with the terminology used in the RMP review around the intersection and closure properties.

## Changes

- Replaces local labels such as “fixed-letter”, “boundary-matrix”, and “cyclic-window witnesses” with the source terminology: intersection property, closure property, inverting step, and growing-back step.
- Rewrites the boundary-closing prose in `ch14_parent_hamiltonian.tex` around the actual equations for the matrices \(Y_i(\tau)\), rather than naming Lean theorem labels in the mathematical text.
- Isolates the remaining closure-property annihilation equation as the explicit outstanding step toward #2405.
- Updates nearby Lean docstrings so the same mathematical terminology is visible from the declarations.

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/ExtendRight.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/blueprint_lean_sync.py --root .` (known unrelated warnings: `blockingData`, literal `...`)

Refs #2405.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and formal proof scaffolding only; the hard closure step remains an explicit `sorry` with no change to proved runtime or security paths.
> 
> **Overview**
> Aligns parent-Hamiltonian **Lean docstrings** and **blueprint ch14** with RMP-style wording: *intersection property*, *closure property*, *inverting step*, and *growing-back step*, instead of labels like “fixed-letter”, “boundary-matrix”, and “range reduction”.
> 
> **Lean:** Adds `boundary_witness_product_of_adjacent_overlaps` and `adjacent_cyclicRestrictₗ_witness_product` in `BoundaryOverlap.lean` (finite chains of adjacent cyclic overlaps → one word-product identity). In `UniqueGroundState.lean`, the closure-property chain is reordered: the main missing step is now the explicit **`closure_property_boundary_right_annihilation_of_chainGroundSpace`** (`sorry`, #2405); matrix equality, first-letter, and restriction forms are derived from that plus block injectivity. Downstream theorems keep **open gap** notes pointing at #2405.
> 
> **Blueprint:** `ch14_parent_hamiltonian.tex` is updated in parallel—theorem titles, the cyclic-window lemma (word-product corollary), and boundary-closing prose in terms of \(Y_i(\tau)\) and the annihilation equation rather than Lean theorem names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067d25c13ea66b0a18b263dcdcd95cbc1447dea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->