### PR TITLE
doc(parent): state closure boundary step as product equation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -716,14 +716,11 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
       (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
   exact hfixed j
 
-/-- Boundary-closing word equation for the closure property of arXiv:2011.12127,
-lines 2078--2090. The matrices `YAt i τ` represent local restrictions, and the
-displayed equation is the algebraic form that remains before block injectivity
-strips the final length-`L₀` word.
-
+/-- Boundary-closing word equation for the closure property, arXiv:2011.12127, lines 2078--2090.
+The two closing-boundary conditions agree after appending \(A^jA^\sigma\).
 **Open gap:** Prove the adjacent-overlap iteration around the boundary; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
-theorem closure_property_boundary_right_annihilation_of_chainGroundSpace
+theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
@@ -736,10 +733,11 @@ theorem closure_property_boundary_right_annihilation_of_chainGroundSpace
         groundSpaceMap A (L₀ + 1) (YAt i τ))
     (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
     ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
-      (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j -
-          YAt ⟨M + 1 - L₀, by omega⟩
-            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j) *
-        evalWord A (List.ofFn σ) = 0 := by
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) =
+        YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) := by
   sorry
 
 /-- Matrix form of the closure property, arXiv:2011.12127, lines 2078--2090.
@@ -769,8 +767,10 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
           YAt ⟨M + 1 - L₀, by omega⟩
             (mirrorMiddleBackground L₀ (M + 1) η μ) * A j) *
         evalWord A (List.ofFn σ) = 0 :=
-    closure_property_boundary_right_annihilation_of_chainGroundSpace
-      (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ j
+    fun σ => by
+      have hprod := closure_property_boundary_closing_product_eq_of_chainGroundSpace
+        (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ j σ
+      simpa [sub_mul, sub_eq_zero] using hprod
   have hsub :
       YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j -
           YAt ⟨M + 1 - L₀, by omega⟩
@@ -842,8 +842,8 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
         (A := A) hInj hL₀ hM hψ hψX η μ j
 /-- The two boundary-condition matrix families agree in the closure property,
 reduced to the \(Y A^j\) equation above.
-**Open gap:** Inherits the unproved boundary-closing word equation
-`closure_property_boundary_right_annihilation_of_chainGroundSpace`; see
+
+**Open gap:** Inherits the unproved boundary-closing word equation; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1719,8 +1719,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \end{proof}
 
 \begin{lemma}[Boundary-closing word equation for the closure property]
-    \label{lem:boundary_closing_right_annihilation_chain_ground_space}
-    \lean{MPSTensor.closure_property_boundary_right_annihilation_of_chainGroundSpace}
+    \label{lem:boundary_closing_word_equation_chain_ground_space}
+    \lean{MPSTensor.closure_property_boundary_closing_product_eq_of_chainGroundSpace}
     \leanok
     \uses{def:chain_ground_space, lem:cyclic_window_boundary_matrix_transport,
         lem:wrapped_middle_backgrounds}
@@ -1736,11 +1736,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     boundary letter $\eta$, complementary word $\mu$, physical letter $j$, and
     word $\sigma$ of length $L_0$,
     \[
-    \left(
-        Y_M(\tau^{+}_{\eta}(\mu))A^j
-        -
-        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j
-    \right)A^\sigma=0 .
+        Y_M(\tau^{+}_{\eta}(\mu))A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^jA^\sigma .
     \]
 \end{lemma}
 
@@ -1769,7 +1767,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \label{lem:boundary_closing_boundary_tensor_products_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_tensor_products_eq_of_chainGroundSpace}
     \leanok
-    \uses{lem:boundary_closing_right_annihilation_chain_ground_space,
+    \uses{lem:boundary_closing_word_equation_chain_ground_space,
         lem:padded_complement_annihilation}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let
     $\psi\in\mathcal G_{M+1,L_0+1}(A)$ have an open-chain representation
@@ -1800,8 +1798,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         -
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j .
     \]
-    Lemma~\ref{lem:boundary_closing_right_annihilation_chain_ground_space}
-    gives, for every word $\sigma$ of length $L_0$,
+    Lemma~\ref{lem:boundary_closing_word_equation_chain_ground_space}
+    gives, after subtracting the two sides, for every word $\sigma$ of length $L_0$,
     \[
         Z_jA^\sigma=0.
     \]


### PR DESCRIPTION
## Summary

This PR rewrites the boundary-closing closure-property obligation from the auxiliary zero form

```tex
(Y_M(τ^+) A^j - Y_{M+1-L₀}(τ^-) A^j) A^σ = 0
```

to the source-facing product equation

```tex
Y_M(τ^+) A^j A^σ = Y_{M+1-L₀}(τ^-) A^j A^σ.
```

This matches the terminology of arXiv:2011.12127, Section IV.C, lines 2078--2090: the source discusses the intersection property, closure property, boundary conditions, inversion, and growing back. It does not use the phrase “right annihilation”. The downstream matrix lemma still subtracts the displayed equality to obtain the zero form needed for the block-injectivity argument.

Closes no proof obligation by itself; it keeps the existing boundary-closing adjacent-overlap iteration as the tracked open step for #2405.

## Checks

- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/blueprint_lean_sync.py --root .`
- `git diff --check`

`leanblueprint checkdecls` did not run in this fresh worktree because `blueprint/lean_decls` was not generated. The Python sync check did find the new Lean declaration; its remaining warnings are the pre-existing PEPS `blockingData` entry and the literal ellipsis in `ch04a_channel_representations.tex`.

## Proof status

The renamed theorem still contains the same `sorry` obligation: prove the adjacent-overlap iteration around the closing boundary. No new `sorry` is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and logically equivalent statement refactor only; no new proofs and the same open `sorry` obligation remains.
> 
> **Overview**
> Aligns the **boundary-closing closure-property** obligation with arXiv:2011.12127 (Section IV.C): the tracked open step is now a **product equality** \(Y_M(\tau^+) A^j A^\sigma = Y_{M+1-L_0}(\tau^-) A^j A^\sigma\) instead of the auxiliary **difference annihilation** \((Y_M A^j - Y_{M+1-L_0} A^j) A^\sigma = 0\).
> 
> In Lean, `closure_property_boundary_right_annihilation_of_chainGroundSpace` is renamed to **`closure_property_boundary_closing_product_eq_of_chainGroundSpace`** with the new conclusion; **`closure_property_boundary_tensor_products_eq_of_chainGroundSpace`** still needs the zero form for block injectivity and now obtains it by subtracting the product equality (`sub_mul` / `sub_eq_zero`). The blueprint lemma label, `\lean{}` link, displayed equation, and matrix-form proof wording are updated to match. The **`sorry`** (adjacent-overlap iteration at the closing boundary) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b85ff70362155b27ba825ab7ab0e34005dc51b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->