### PR TITLE
feat(parent): add cyclic boundary overlap transport

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
@@ -79,6 +79,48 @@ theorem adjacent_cyclicRestrictₗ_witness_overlap
       (A := A) hN (cyclicForwardSite i 1) τ₂ ψ hY₂ b
   exact hFirst.symm.trans (by rw [hτ]; exact hLast)
 
+/-- Adjacent cyclic windows with the same outside configuration have compatible
+boundary matrices. -/
+theorem adjacent_cyclicRestrictₗ_witness_overlap_common_background
+    {A : MPSTensor d D} {N L : ℕ}
+    (hInj : IsNBlkInjective A L) (hN : 0 < N) (hLN : L + 1 ≤ N)
+    (i : Fin N) (ρ : Fin N → Fin d) (ψ : NSiteSpace d N)
+    {Y₁ Y₂ : Matrix (Fin D) (Fin D) ℂ}
+    (hY₁ : cyclicRestrictₗ hN (L + 1) i ρ ψ = groundSpaceMap A (L + 1) Y₁)
+    (hY₂ : cyclicRestrictₗ hN (L + 1) (cyclicForwardSite i 1) ρ ψ =
+      groundSpaceMap A (L + 1) Y₂) :
+    Y₁ * A (ρ i) = A (ρ (cyclicForwardSite i (L + 1))) * Y₂ := by
+  refine adjacent_cyclicRestrictₗ_witness_overlap
+    (A := A) hInj hN hLN i ρ ρ ψ hY₁ hY₂
+    (ρ i) (ρ (cyclicForwardSite i (L + 1))) ?_
+  ext k
+  have hleft :
+      (if (k.val + N - i.val) % N = 0 then ρ i else ρ k) = ρ k := by
+    by_cases hzero : (k.val + N - i.val) % N = 0
+    · rw [if_pos hzero]
+      have hk : k = i := by
+        have hk' := eq_cyclic_site_of_offset_eq (N := N) hN (i := i) (k := k) hzero
+        simpa [Nat.mod_eq_of_lt i.isLt] using hk'
+      rw [hk]
+    · rw [if_neg hzero]
+  have hright :
+      (if (k.val + N - (cyclicForwardSite i 1).val) % N = L then
+          ρ (cyclicForwardSite i (L + 1)) else ρ k) = ρ k := by
+    by_cases hlast : (k.val + N - (cyclicForwardSite i 1).val) % N = L
+    · rw [if_pos hlast]
+      have hkStep : k = cyclicForwardSite (cyclicForwardSite i 1) L := by
+        have hk' := eq_cyclic_site_of_offset_eq (N := N) hN
+          (i := cyclicForwardSite i 1) (k := k) (r := L) hlast
+        simpa [cyclicForwardSite] using hk'
+      have hk : k = cyclicForwardSite i (L + 1) := by
+        calc
+          k = cyclicForwardSite (cyclicForwardSite i 1) L := hkStep
+          _ = cyclicForwardSite i (1 + L) := by rw [cyclicForwardSite_forwardSite]
+          _ = cyclicForwardSite i (L + 1) := by congr 1; omega
+      rw [hk]
+    · rw [if_neg hlast]
+  rw [hleft, hright]
+
 /-- A finite chain of adjacent matrix identities gives a single word-product
 identity. -/
 theorem boundary_witness_product_of_adjacent_overlaps
@@ -156,5 +198,30 @@ theorem adjacent_cyclicRestrictₗ_witness_product
   exact adjacent_cyclicRestrictₗ_witness_overlap
     (A := A) hInj hN hLN (cyclicForwardSite i₀ r.val)
     (τ (Fin.castSucc r)) (τ (Fin.succ r)) ψ hY₁ hY₂ (a r) (b r) hτr
+
+/-- Iterating adjacent cyclic-window overlaps with a common outside
+configuration gives the corresponding word-product identity. -/
+theorem adjacent_cyclicRestrictₗ_witness_product_common_background
+    {A : MPSTensor d D} {N L n : ℕ}
+    (hInj : IsNBlkInjective A L) (hN : 0 < N) (hLN : L + 1 ≤ N)
+    (i₀ : Fin N) (ρ : Fin N → Fin d) (ψ : NSiteSpace d N)
+    (Y : Fin (n + 1) → Matrix (Fin D) (Fin D) ℂ)
+    (hY : ∀ r : Fin (n + 1),
+      cyclicRestrictₗ hN (L + 1) (cyclicForwardSite i₀ r.val) ρ ψ =
+        groundSpaceMap A (L + 1) (Y r)) :
+    Y 0 * evalWord A (List.ofFn (fun r : Fin n => ρ (cyclicForwardSite i₀ r.val))) =
+      evalWord A (List.ofFn (fun r : Fin n =>
+        ρ (cyclicForwardSite (cyclicForwardSite i₀ r.val) (L + 1)))) *
+        Y (Fin.last n) := by
+  apply boundary_witness_product_of_adjacent_overlaps
+  intro r
+  have hY₁ := hY (Fin.castSucc r)
+  have hY₂ : cyclicRestrictₗ hN (L + 1)
+      (cyclicForwardSite (cyclicForwardSite i₀ r.val) 1) ρ ψ =
+        groundSpaceMap A (L + 1) (Y (Fin.succ r)) := by
+    simpa [cyclicForwardSite_forwardSite, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc]
+      using hY (Fin.succ r)
+  exact adjacent_cyclicRestrictₗ_witness_overlap_common_background
+    (A := A) hInj hN hLN (cyclicForwardSite i₀ r.val) ρ ψ hY₁ hY₂
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -408,6 +408,21 @@ theorem cyclicRestrictₗ_apply {N : ℕ} (hN : 0 < N) (L : ℕ)
     (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N) (σ : Fin L → Fin d) :
     cyclicRestrictₗ hN L i τ ψ σ = ψ (cyclicCfg hN L i σ τ) := rfl
 
+/-- A cyclic restriction depends on the outside configuration only away from
+the selected cyclic window. -/
+theorem cyclicRestrictₗ_congr_outside {N L : ℕ} (hN : 0 < N) (i : Fin N)
+    {τ₁ τ₂ : Fin N → Fin d} (ψ : NSiteSpace d N)
+    (hτ : ∀ k : Fin N, ¬((k.val + N - i.val) % N < L) → τ₁ k = τ₂ k) :
+    cyclicRestrictₗ hN L i τ₁ ψ = cyclicRestrictₗ hN L i τ₂ ψ := by
+  ext σ
+  simp only [cyclicRestrictₗ_apply]
+  congr 1
+  ext k
+  simp only [cyclicCfg]
+  by_cases hwin : (k.val + N - i.val) % N < L
+  · rw [dif_pos hwin, dif_pos hwin]
+  · rw [dif_neg hwin, dif_neg hwin, hτ k hwin]
+
 /-- Restricting the final site of a cyclic `(L + 1)`-window peels off the site with
 cyclic offset `L` and stores its value in the outside configuration. -/
 theorem cyclicRestrictₗ_restrictLast {N L : ℕ} (hN : 0 < N)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -628,6 +628,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.cyclicCfg}
     \lean{MPSTensor.cyclicRestrictₗ}
     \lean{MPSTensor.cyclicRestrictₗ_apply}
+    \lean{MPSTensor.cyclicRestrictₗ_congr_outside}
     \lean{MPSTensor.eq_cyclic_site_of_offset_eq}
     \lean{MPSTensor.cyclicRestrictₗ_restrictLast}
     \lean{MPSTensor.cyclicRestrictₗ_restrictFirst}
@@ -665,8 +666,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.cyclicRestrictₗ_restrictFirst_groundSpaceMap}
     \lean{MPSTensor.cyclicRestrictₗ_restrictLast_groundSpaceMap}
     \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_overlap}
+    \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_overlap_common_background}
     \lean{MPSTensor.boundary_witness_product_of_adjacent_overlaps}
     \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_product}
+    \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_product_common_background}
     \leanok
     \uses{rem:cyclic_window_operators, def:ground_space_parent, def:l_blk_injective}
     If a cyclic $(L+1)$-window is represented by a boundary matrix $Y$, then


### PR DESCRIPTION
## Summary

- Add `cyclicRestrictₗ_congr_outside`, recording that a cyclic restriction only depends on the complementary-site values of the outside configuration.
- Package the adjacent-window boundary-matrix equation when the two cyclic supports are evaluated against one common outside configuration.
- Add the corresponding iterated product identity for a chain of adjacent cyclic supports.

This advances #2405 by isolating the elementary boundary-matrix transport used in the closure-property comparison. It does not claim to close the remaining boundary-closing equality in `closure_property_boundary_closing_product_eq_of_chainGroundSpace`.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryOverlap`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState` (only the pre-existing parent-Hamiltonian `sorry` warning)
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `lake exe lint_style TNLean.MPS.ParentHamiltonian.CyclicWindow TNLean.MPS.ParentHamiltonian.BoundaryOverlap`
- `lake build TNLean -q --log-level=info` (only pre-existing `sorry` warnings and existing tactic suggestions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style Lean additions and blueprint `\lean{}` tags; no runtime, auth, or data-path changes. Remaining closure proofs still rely on separate `sorry`/`notready` steps elsewhere.
> 
> **Overview**
> This PR extends the parent-Hamiltonian cyclic-window toolkit used in closure-property boundary comparisons.
> 
> **`cyclicRestrictₗ_congr_outside`** states that changing the outside configuration only on sites outside the cyclic window does not change the restriction. That lemma is wired into the blueprint remark on cyclic interval operators.
> 
> **Boundary overlap (common background):** When two adjacent `(L+1)` cyclic windows are evaluated against the same full outside configuration `ρ`, the PR proves the single-site matrix identity `Y₁ * A(ρ i) = A(ρ(i+L+1)) * Y₂` via the existing general overlap theorem, using cyclic offset arithmetic. **`adjacent_cyclicRestrictₗ_witness_product_common_background`** chains those steps into the endpoint word-product identity without per-step `τ` hypotheses.
> 
> The blueprint lemma on cyclic-window boundary matrix transport now cites these Lean names alongside the existing adjacent-overlap and product lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cddd7a687cb0d599132af86cc8ebab2e97b53caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->