### PR TITLE
feat(parent): add boundary complement equations

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -182,6 +182,7 @@ import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
+import TNLean.MPS.ParentHamiltonian.BoundaryClosing
 import TNLean.Axioms.Beigi
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
+import TNLean.MPS.ParentHamiltonian.WrappingWindow
+
+/-!
+# Boundary assignments for the closure property
+
+This file records elementary coordinate facts for the two boundary-crossing
+supports used in the closure property of the normal parent-Hamiltonian
+argument.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Equal cyclic restrictions give the same products after one fixed physical
+letter:
+\[
+  Y_1 A^j = Y_2 A^j .
+\]
+
+The conclusion is at length \(L\), where block injectivity makes \(\Gamma_L\)
+injective; no uniqueness is claimed for the longer $(L+1)$-site matrices
+themselves. -/
+theorem cyclicRestrictₗ_first_products_eq_of_restriction_eq
+    {A : MPSTensor d D} {N L : ℕ} (hInj : IsNBlkInjective A L)
+    (hN : 0 < N) (hLN : L + 1 ≤ N)
+    (i : Fin N) (τ₁ τ₂ : Fin N → Fin d) (ψ : NSiteSpace d N)
+    {Y₁ Y₂ : Matrix (Fin D) (Fin D) ℂ}
+    (hY₁ : cyclicRestrictₗ hN (L + 1) i τ₁ ψ = groundSpaceMap A (L + 1) Y₁)
+    (hY₂ : cyclicRestrictₗ hN (L + 1) i τ₂ ψ = groundSpaceMap A (L + 1) Y₂)
+    (heq : cyclicRestrictₗ hN (L + 1) i τ₁ ψ =
+      cyclicRestrictₗ hN (L + 1) i τ₂ ψ) :
+    ∀ j : Fin d, Y₁ * A j = Y₂ * A j := by
+  intro j
+  apply groundSpaceMap_injective_of_isNBlkInjective hInj
+  have hfirst :
+      restrictFirst (cyclicRestrictₗ hN (L + 1) i τ₁ ψ) j =
+        restrictFirst (cyclicRestrictₗ hN (L + 1) i τ₂ ψ) j := by
+    rw [heq]
+  rw [cyclicRestrictₗ_restrictFirst hN hLN i τ₁ ψ j,
+    cyclicRestrictₗ_restrictFirst hN hLN i τ₂ ψ j] at hfirst
+  have hleft :=
+    cyclicRestrictₗ_restrictFirst_groundSpaceMap
+      (A := A) hN hLN i τ₁ ψ hY₁ j
+  have hright :=
+    cyclicRestrictₗ_restrictFirst_groundSpaceMap
+      (A := A) hN hLN i τ₂ ψ hY₂ j
+  exact hleft.symm.trans (hfirst.trans hright)
+
+/-- For the boundary-crossing interval starting at the last site, any outside
+configuration with the same complementary word gives the same restriction as the
+boundary assignment \(\tau^+_\eta(\mu)\) used in the closure property. -/
+theorem cyclicRestrictₗ_wrappedMiddleBackground_eq_of_complement_eq
+    {L₀ M : ℕ} (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
+    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρ ⟨k.val + L₀, by omega⟩ = μ k) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M, by omega⟩ : Fin (M + 1)) ρ ψ =
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M, by omega⟩ : Fin (M + 1))
+        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ := by
+  apply cyclicRestrictₗ_congr_outside
+  intro k hkout
+  have hk_ne_last : k.val ≠ M := by
+    intro hkM
+    apply hkout
+    rw [hkM]
+    have hsum : M + (M + 1) - M = M + 1 := by omega
+    rw [hsum, Nat.mod_self]
+    omega
+  have hk_lt_last : k.val < M := by omega
+  have hoff : (k.val + (M + 1) - M) % (M + 1) = k.val + 1 := by
+    have hsum : k.val + (M + 1) - M = k.val + 1 := by omega
+    rw [hsum]
+    exact Nat.mod_eq_of_lt (by omega)
+  have hkL : L₀ ≤ k.val := by
+    by_contra hkL
+    push Not at hkL
+    apply hkout
+    rw [hoff]
+    omega
+  rw [wrappedMiddleBackground, dif_pos ⟨hkL, hk_lt_last⟩]
+  let r : Fin (M + 1 - (L₀ + 1)) := ⟨k.val - L₀, by omega⟩
+  have hrho := hρ r
+  have hsite : (⟨r.val + L₀, by omega⟩ : Fin (M + 1)) = k := by
+    ext
+    simp [r]
+    omega
+  rwa [hsite] at hrho
+
+/-- Matrix consequence at the last-site boundary-crossing support.  If an
+outside configuration has the same complementary word as
+\(\tau^+_\eta(\mu)\), then
+\[
+  Y_\rho A^j = Y_{\tau^+_\eta(\mu)} A^j .
+\] -/
+theorem wrappedMiddleBackground_first_products_eq_of_complement_eq
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
+    {Yρ Yτ : Matrix (Fin D) (Fin D) ℂ}
+    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρ ⟨k.val + L₀, by omega⟩ = μ k)
+    (hYρ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M, by omega⟩ : Fin (M + 1)) ρ ψ =
+      groundSpaceMap A (L₀ + 1) Yρ)
+    (hYτ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M, by omega⟩ : Fin (M + 1))
+        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+      groundSpaceMap A (L₀ + 1) Yτ) :
+    ∀ j : Fin d, Yρ * A j = Yτ * A j := by
+  exact cyclicRestrictₗ_first_products_eq_of_restriction_eq
+    (A := A) hInj (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+    (⟨M, by omega⟩ : Fin (M + 1)) ρ (wrappedMiddleBackground L₀ (M + 1) η μ) ψ
+    hYρ hYτ
+    (cyclicRestrictₗ_wrappedMiddleBackground_eq_of_complement_eq
+      hL₀ hM η μ ρ hρ)
+
+/-- For the opposite boundary-crossing interval, any outside configuration with
+the same complementary word gives the same restriction as the boundary
+assignment \(\tau^-_\eta(\mu)\) used in the closure property. -/
+theorem cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
+    {L₀ M : ℕ} (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
+    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρ ⟨k.val + 1, by omega⟩ = μ k) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) ρ ψ =
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+  apply cyclicRestrictₗ_congr_outside
+  intro k hkout
+  have hk_pos : 1 ≤ k.val := by
+    by_contra hkpos
+    push Not at hkpos
+    have hk0 : k.val = 0 := by omega
+    apply hkout
+    rw [hk0]
+    have hsum : 0 + (M + 1) - (M + 1 - L₀) = L₀ := by omega
+    rw [hsum, Nat.mod_eq_of_lt (by omega : L₀ < M + 1)]
+    omega
+  have hk_lt : k.val < M + 1 - L₀ := by
+    by_contra hklt
+    push Not at hklt
+    apply hkout
+    have hsum :
+        k.val + (M + 1) - (M + 1 - L₀) = k.val + L₀ := by
+      omega
+    rw [hsum]
+    have hsplit : k.val + L₀ = (M + 1) + (k.val + L₀ - (M + 1)) := by
+      omega
+    rw [hsplit, Nat.add_mod_left]
+    rw [Nat.mod_eq_of_lt (by omega : k.val + L₀ - (M + 1) < M + 1)]
+    omega
+  rw [mirrorMiddleBackground, dif_pos ⟨hk_pos, hk_lt⟩]
+  let r : Fin (M + 1 - (L₀ + 1)) := ⟨k.val - 1, by omega⟩
+  have hrho := hρ r
+  have hsite : (⟨r.val + 1, by omega⟩ : Fin (M + 1)) = k := by
+    ext
+    simp [r]
+    omega
+  rwa [hsite] at hrho
+
+/-- Matrix consequence at the opposite boundary-crossing support.  If an
+outside configuration has the same complementary word as
+\(\tau^-_\eta(\mu)\), then
+\[
+  Y_\rho A^j = Y_{\tau^-_\eta(\mu)} A^j .
+\] -/
+theorem mirrorMiddleBackground_first_products_eq_of_complement_eq
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
+    {Yρ Yτ : Matrix (Fin D) (Fin D) ℂ}
+    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρ ⟨k.val + 1, by omega⟩ = μ k)
+    (hYρ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) ρ ψ =
+      groundSpaceMap A (L₀ + 1) Yρ)
+    (hYτ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ =
+      groundSpaceMap A (L₀ + 1) Yτ) :
+    ∀ j : Fin d, Yρ * A j = Yτ * A j := by
+  exact cyclicRestrictₗ_first_products_eq_of_restriction_eq
+    (A := A) hInj (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+    (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) ρ
+    (mirrorMiddleBackground L₀ (M + 1) η μ) ψ hYρ hYτ
+    (cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
+      hL₀ hM η μ ρ hρ)
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -423,6 +423,35 @@ theorem cyclicRestrictₗ_congr_outside {N L : ℕ} (hN : 0 < N) (i : Fin N)
   · rw [dif_pos hwin, dif_pos hwin]
   · rw [dif_neg hwin, dif_neg hwin, hτ k hwin]
 
+/-- Filling the selected cyclic interval in the outside configuration does not
+change the corresponding cyclic restriction. -/
+theorem cyclicRestrictₗ_cyclicCfg_outside {N L : ℕ} (hN : 0 < N)
+    (i : Fin N) (ω : Fin L → Fin d) (τ : Fin N → Fin d)
+    (ψ : NSiteSpace d N) :
+    cyclicRestrictₗ hN L i (cyclicCfg hN L i ω τ) ψ =
+      cyclicRestrictₗ hN L i τ ψ := by
+  apply cyclicRestrictₗ_congr_outside
+  intro k hk
+  simp [cyclicCfg, hk]
+
+/-- Reading the assembled cyclic configuration along the selected interval
+recovers the inserted word. -/
+theorem cyclicCfg_cyclicForwardSite {N L : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (i : Fin N) (ω : Fin L → Fin d) (τ : Fin N → Fin d) :
+    (fun r : Fin L => cyclicCfg hN L i ω τ (cyclicForwardSite i r.val)) = ω := by
+  ext r
+  simp only [cyclicCfg]
+  have hrN : r.val < N := Nat.lt_of_lt_of_le r.isLt hLN
+  have hoff :
+      ((cyclicForwardSite i r.val).val + N - i.val) % N = r.val := by
+    simpa [cyclicForwardSite] using offset_mod_eq i.isLt hrN
+  have hidx :
+      (⟨((cyclicForwardSite i r.val).val + N - i.val) % N,
+        by rw [hoff]; exact r.isLt⟩ : Fin L) = r := by
+    ext
+    exact hoff
+  rw [dif_pos (by rw [hoff]; exact r.isLt), hidx]
+
 /-- Restricting the final site of a cyclic `(L + 1)`-window peels off the site with
 cyclic offset `L` and stores its value in the outside configuration. -/
 theorem cyclicRestrictₗ_restrictLast {N L : ℕ} (hN : 0 < N)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -629,6 +629,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.cyclicRestrictₗ}
     \lean{MPSTensor.cyclicRestrictₗ_apply}
     \lean{MPSTensor.cyclicRestrictₗ_congr_outside}
+    \lean{MPSTensor.cyclicRestrictₗ_cyclicCfg_outside}
+    \lean{MPSTensor.cyclicCfg_cyclicForwardSite}
     \lean{MPSTensor.eq_cyclic_site_of_offset_eq}
     \lean{MPSTensor.cyclicRestrictₗ_restrictLast}
     \lean{MPSTensor.cyclicRestrictₗ_restrictFirst}
@@ -653,12 +655,24 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \psi\!\left(\rho^{\mathrm{cyc}}_{i,L,\omega}\right),
     \]
     with all site labels read modulo $N$. If $L\le N$, this is the same
-    configuration as $\rho^{[i,i+L-1]\leftarrow\omega}$. The listed identities
-    say that deleting
-    the final site of an $(L+1)$-interval gives the $L$-interval beginning at
-    $i$; if $L+1\le N$, deleting the first site gives the $L$-interval beginning
-    at $i+1$; and the cyclic formula agrees with the contiguous formula when the
-    interval does not wrap around the ring.
+    configuration as $\rho^{[i,i+L-1]\leftarrow\omega}$. If two boundary
+    assignments agree whenever $\delta_i(k)\ge L$, their restrictions are equal.
+    In particular, filling the interval inside the outside configuration leaves the
+    restriction unchanged:
+    \[
+        \operatorname{Res}^{\rho^{\mathrm{cyc}}_{i,L,\omega}}_{i,L}\psi
+        =
+        \operatorname{Res}^{\rho}_{i,L}\psi.
+    \]
+    For every $r<L$, the inserted word is recovered:
+    \[
+        \rho^{\mathrm{cyc}}_{i,L,\omega}(i+r)=\omega(r).
+    \]
+    Here site labels are taken modulo $N$. The remaining listed identities say that
+    deleting the final site of an $(L+1)$-interval gives the $L$-interval
+    beginning at $i$; if $L+1\le N$, deleting the first site gives the
+    $L$-interval beginning at $i+1$; and the cyclic formula agrees with the
+    contiguous formula when the interval does not wrap around the ring.
 \end{remark}
 
 \begin{lemma}[One-site restrictions of cyclic-window boundary conditions]
@@ -1001,21 +1015,78 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         MPSTensor.mirrorMiddleBackground_complement}
     \leanok
     \uses{rem:cyclic_window_operators}
-    Fix a physical letter $\eta$ used outside the complementary sites and a word
-    $\mu$ of length $N-(L_0+1)$. Write $\tau^+_\eta(\mu)$ for the background
-    at the support crossing the last site and $\tau^-_\eta(\mu)$ for the
-    background at the opposite boundary-crossing support. Their exposed
-    complements are both exactly $\mu$.
+    On a chain of length $N=M+1$, with $L_0\le M$, fix a physical letter $\eta$
+    used outside the complementary sites and a word $\mu$ of length
+    $M+1-(L_0+1)$. Write $\tau^+_\eta(\mu)$ for the boundary assignment at the
+    support crossing the last site and $\tau^-_\eta(\mu)$ for the boundary
+    assignment at the opposite boundary-crossing support. Their exposed complements
+    are both exactly $\mu$.
 \end{lemma}
 
 \begin{proof}
     \leanok
     Put the same letter $\eta$ on the remaining sites. Fill the physical sites
-    $L_0,\ldots,N-2$ with $\mu$ for the support crossing the last site, and fill
-    the sites $1,\ldots,N-L_0-1$ with $\mu$ for the opposite boundary-crossing
+    $L_0,\ldots,M-1$ with $\mu$ for the support crossing the last site, and fill
+    the sites $1,\ldots,M-L_0$ with $\mu$ for the opposite boundary-crossing
     support.
     The two complement-extraction identities are then immediate from the index
-    arithmetic.
+    arithmetic. The same outside-site calculation gives, for any $\rho$ with
+    $\rho_{k+L_0}=\mu_k$,
+    \[
+        \operatorname{Res}^{\rho}_{M,L_0+1}\psi
+        =
+        \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}\psi,
+    \]
+    and, for any $\rho$ with $\rho_{k+1}=\mu_k$,
+    \[
+        \operatorname{Res}^{\rho}_{M+1-L_0,L_0+1}\psi
+        =
+        \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}\psi.
+    \]
+\end{proof}
+
+\begin{lemma}[Boundary equations from a common complement word]
+    \label{lem:boundary_assignment_first_letter_products}
+    \lean{MPSTensor.cyclicRestrictₗ_first_products_eq_of_restriction_eq,
+        MPSTensor.cyclicRestrictₗ_wrappedMiddleBackground_eq_of_complement_eq,
+        MPSTensor.cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq,
+        MPSTensor.wrappedMiddleBackground_first_products_eq_of_complement_eq,
+        MPSTensor.mirrorMiddleBackground_first_products_eq_of_complement_eq}
+    \leanok
+    \uses{rem:cyclic_window_operators, lem:wrapped_middle_backgrounds}
+    Let $A$ be $L_0$-block-injective, with $L_0>0$, and let $L_0\le M$.
+    Suppose two length-$(L_0+1)$ restrictions of a state $\psi$ at the same
+    cyclic support are represented by
+    \[
+        \operatorname{Res}^{\rho}_{i,L_0+1}\psi=\Gamma_{L_0+1}(Y_\rho),
+        \qquad
+        \operatorname{Res}^{\tau}_{i,L_0+1}\psi=\Gamma_{L_0+1}(Y_\tau).
+    \]
+    If these two restrictions are equal, then for every physical letter $j$,
+    \[
+        Y_\rho A^j = Y_\tau A^j .
+    \]
+    In particular, the last-site boundary-crossing assignment satisfies
+    \[
+        \rho_{k+L_0}=\mu_k
+        \Longrightarrow
+        Y_\rho A^j = Y_{\tau^+_\eta(\mu)}A^j,
+    \]
+    and the opposite boundary-crossing assignment satisfies
+    \[
+        \rho_{k+1}=\mu_k
+        \Longrightarrow
+        Y_\rho A^j = Y_{\tau^-_\eta(\mu)}A^j .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply the first-letter restriction to both equal length-$(L_0+1)$
+    restrictions. The two resulting length-$L_0$ vectors are represented by
+    $\Gamma_{L_0}(Y_\rho A^j)$ and $\Gamma_{L_0}(Y_\tau A^j)$, and block
+    injectivity makes $\Gamma_{L_0}$ injective. The two displayed special cases
+    follow from Lemma~\ref{lem:wrapped_middle_backgrounds}.
 \end{proof}
 
 \begin{lemma}[One matrix $Y_\mu$ from compared boundary matrices]%


### PR DESCRIPTION
## Summary

This PR adds a source-facing boundary-assignment helper layer toward #2405.

It proves:
- filling the selected cyclic interval in an outside configuration does not change the corresponding restriction;
- reading `cyclicCfg` along the selected cyclic support recovers the inserted word;
- if an outside configuration has the same complementary word as `tau^+_eta(mu)` or `tau^-_eta(mu)`, then it gives the same cyclic restriction at the corresponding boundary-crossing support;
- after fixing one physical letter, block injectivity turns that restriction equality into the equations
  `Y_rho A^j = Y_{tau^+_eta(mu)} A^j` and
  `Y_rho A^j = Y_{tau^-_eta(mu)} A^j`.

This is an auxiliary equation-level step for the boundary-closing transport argument. It does not close the remaining product equation in `closure_property_boundary_closing_product_eq_of_chainGroundSpace`.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing`
- `lake build TNLean`
- `lake exe lint_style TNLean.MPS.ParentHamiltonian.CyclicWindow TNLean.MPS.ParentHamiltonian.BoundaryClosing`
- `git diff --check`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` reports the existing non-parent missing refs `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and `...`; `ch14_parent_hamiltonian.tex` is 363/363.
- `cd blueprint && leanblueprint checkdecls` still reports pre-existing missing declarations outside this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean additions and blueprint documentation in the parent-Hamiltonian track; no runtime, auth, or data-path changes.
> 
> **Overview**
> Introduces **`TNLean.MPS.ParentHamiltonian.BoundaryClosing`** (wired into the root import) as equation-level scaffolding for the parent-Hamiltonian **closure / boundary-closing** argument (#2405).
> 
> **Cyclic window (`CyclicWindow.lean`):** two lemmas—filling the selected interval inside an outside config does not change `cyclicRestrictₗ`, and reading `cyclicCfg` along forward sites recovers the inserted word.
> 
> **Boundary closing (`BoundaryClosing.lean`):** when an outside configuration shares the complementary word with `wrappedMiddleBackground` or `mirrorMiddleBackground`, the corresponding cyclic restrictions agree; with **block injectivity**, equal length-`(L₀+1)` restrictions imply **`Y₁ A^j = Y₂ A^j`** for all physical letters `j`, including the wrapped/mirror boundary cases.
> 
> **Blueprint (`ch14_parent_hamiltonian.tex`):** documents the new cyclic identities, extends the wrapped-middle-background lemma with restriction-equality corollaries, and adds **Lemma (boundary equations from a common complement word)** linked to the new Lean declarations.
> 
> This does **not** prove the remaining **`closure_property_boundary_closing_product_eq_of_chainGroundState`** product equation in `UniqueGroundState`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40da0318b99556e35d3288ec8006857b52757155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->