### PR TITLE
feat(parent): add boundary product complement reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -203,4 +203,65 @@ theorem mirrorMiddleBackground_first_products_eq_of_complement_eq
     (cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
 
+/-- Complement reduction for the boundary-closing product equation.
+
+Suppose two auxiliary outside assignments have the same complementary words as
+\(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\), respectively.  If the desired
+product equation has already been proved for those two assignments, then it also
+holds for the canonical boundary assignments:
+\[
+  Y_M(\tau^+_\eta(\mu)) A^j A^\sigma
+  =
+  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma .
+\]
+
+This isolates the remaining closure-property task as an adjacent-window product
+identity between compatible outside assignments. -/
+theorem boundary_closing_product_eq_of_compatible_backgrounds
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (ρPlus ρMinus : Fin (M + 1) → Fin d)
+    (hρPlus : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρPlus ⟨k.val + L₀, by omega⟩ = μ k)
+    (hρMinus : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρMinus ⟨k.val + 1, by omega⟩ = μ k)
+    (htransport : ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      YAt ⟨M, by omega⟩ ρPlus * A j * evalWord A (List.ofFn σ) =
+        YAt ⟨M + 1 - L₀, by omega⟩ ρMinus * A j * evalWord A (List.ofFn σ)) :
+    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) =
+        YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) := by
+  intro j σ
+  have hwrap := wrappedMiddleBackground_first_products_eq_of_complement_eq
+    (A := A) hInj hL₀ hM η μ ρPlus hρPlus
+    (hYAt ⟨M, by omega⟩ ρPlus)
+    (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ)) j
+  have hmirror := mirrorMiddleBackground_first_products_eq_of_complement_eq
+    (A := A) hInj hL₀ hM η μ ρMinus hρMinus
+    (hYAt ⟨M + 1 - L₀, by omega⟩ ρMinus)
+    (hYAt ⟨M + 1 - L₀, by omega⟩
+      (mirrorMiddleBackground L₀ (M + 1) η μ)) j
+  calc
+    YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ)
+        = YAt ⟨M, by omega⟩ ρPlus * A j * evalWord A (List.ofFn σ) := by
+            rw [← hwrap]
+    _ = YAt ⟨M + 1 - L₀, by omega⟩ ρMinus * A j *
+          evalWord A (List.ofFn σ) :=
+            htransport j σ
+    _ = YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) := by
+            rw [hmirror]
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1089,6 +1089,55 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     follow from Lemma~\ref{lem:wrapped_middle_backgrounds}.
 \end{proof}
 
+\begin{lemma}[Reduction to compatible boundary assignments]
+    \label{lem:boundary_closing_product_compatible_backgrounds}
+    \lean{MPSTensor.boundary_closing_product_eq_of_compatible_backgrounds}
+    \leanok
+    \uses{lem:boundary_assignment_first_letter_products}
+    Let $A$ be $L_0$-block-injective, with $L_0>0$, and let $L_0\le M$.
+    Let $\psi$ be a state on the chain of length $M+1$, and let the matrices
+    $Y_i(\tau)$ represent its length-$(L_0+1)$ cyclic restrictions:
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    Fix a boundary letter $\eta$ and a complementary word $\mu$. Let $\rho^+$
+    and $\rho^-$ be two boundary assignments satisfying
+    \[
+        \rho^+_{k+L_0}=\mu_k,
+        \qquad
+        \rho^-_{k+1}=\mu_k .
+    \]
+    If the adjacent-window comparison gives, for every physical letter $j$ and
+    every word $\sigma$ of length $L_0$,
+    \[
+        Y_M(\rho^+)A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\rho^-)A^jA^\sigma ,
+    \]
+    then the same product equation holds for the canonical boundary assignments:
+    \[
+        Y_M(\tau^+_\eta(\mu))A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    By Lemma~\ref{lem:boundary_assignment_first_letter_products},
+    \[
+        Y_M(\rho^+)A^j = Y_M(\tau^+_\eta(\mu))A^j,
+        \qquad
+        Y_{M+1-L_0}(\rho^-)A^j
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j.
+    \]
+    Multiplying on the right by $A^\sigma$ and applying the hypothesis gives the
+    displayed product equation.
+\end{proof}
+
 \begin{lemma}[One matrix $Y_\mu$ from compared boundary matrices]%
     \label{lem:two_sided_middle_of_wrapped_witness_comparison}
     \lean{MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison}


### PR DESCRIPTION
## Summary

- add a no-sorry reduction from compatible boundary assignments to the canonical \(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\) product equation
- record the corresponding blueprint lemma in source-facing equation form

## Relation to #2405

This does not close #2405. It isolates the remaining closure-property step as the adjacent-window comparison

```tex
Y_M(\rho^+)A^jA^\sigma
  =
Y_{M+1-L_0}(\rho^-)A^jA^\sigma,
```

for boundary assignments with the same complementary word. The new lemma then converts that equation to the canonical boundary assignments

```tex
Y_M(\tau^+_\eta(\mu))A^jA^\sigma
  =
Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma.
```

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` reports `ch14_parent_hamiltonian.tex 365/365`; it still fails globally on the pre-existing non-parent entries `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and `...` in `ch04a_channel_representations.tex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal documentation in parent-Hamiltonian boundary closing; no runtime, auth, or API surface—only new proved lemmas and blueprint sync.
> 
> **Overview**
> Adds **`boundary_closing_product_eq_of_compatible_backgrounds`**, a no-sorry Lean reduction for the parent-Hamiltonian **boundary-closing product** \(Y_M(\tau^+_\eta(\mu)) A^j A^\sigma = Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma\).
> 
> Given **compatible** outside assignments \(\rho^+\), \(\rho^-\) with the same complementary word \(\mu\), the theorem assumes the **adjacent-window** product identity for those backgrounds and derives the same equation for the **canonical** wrapped/mirror backgrounds. The proof is a short **`calc`**: existing **first-letter / complement** lemmas identify canonical sides with \(\rho^+\) and \(\rho^-\) up to \(A^j\), then **`htransport`** carries the full \(A^j A^\sigma\) products across windows.
> 
> The blueprint gains **Lemma “Reduction to compatible boundary assignments”** (`lem:boundary_closing_product_compatible_backgrounds`), linked to the Lean name and citing **`lem:boundary_assignment_first_letter_products`**. This **does not finish** the closure property—it reframes the open step as proving the product equation for arbitrary compatible \(\rho^+\), \(\rho^-\) rather than only \(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a215c0691e57a2c10a7ca0d13902977a6748e37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->