### PR TITLE
feat(parent): name adjacent endpoint transport

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
@@ -224,4 +224,33 @@ theorem adjacent_cyclicRestrictₗ_witness_product_common_background
   exact adjacent_cyclicRestrictₗ_witness_overlap_common_background
     (A := A) hInj hN hLN (cyclicForwardSite i₀ r.val) ρ ψ hY₁ hY₂
 
+/-- Iterated adjacent cyclic-window transport with explicitly named endpoint
+words.
+
+If the forward endpoint word is \(a\) and the opposite endpoint word is \(b\),
+then the adjacent-window equations give
+\[
+  Y_0 A^a = A^b Y_n .
+\] -/
+theorem adjacent_cyclicRestrictₗ_witness_product_common_background_named
+    {A : MPSTensor d D} {N L n : ℕ}
+    (hInj : IsNBlkInjective A L) (hN : 0 < N) (hLN : L + 1 ≤ N)
+    (i₀ : Fin N) (ρ : Fin N → Fin d) (ψ : NSiteSpace d N)
+    (Y : Fin (n + 1) → Matrix (Fin D) (Fin D) ℂ)
+    (a b : Fin n → Fin d)
+    (hY : ∀ r : Fin (n + 1),
+      cyclicRestrictₗ hN (L + 1) (cyclicForwardSite i₀ r.val) ρ ψ =
+        groundSpaceMap A (L + 1) (Y r))
+    (ha : (fun r : Fin n => ρ (cyclicForwardSite i₀ r.val)) = a)
+    (hb : (fun r : Fin n =>
+        ρ (cyclicForwardSite (cyclicForwardSite i₀ r.val) (L + 1))) = b) :
+    Y 0 * evalWord A (List.ofFn a) =
+      evalWord A (List.ofFn b) * Y (Fin.last n) := by
+  have htransport :=
+    adjacent_cyclicRestrictₗ_witness_product_common_background
+      (A := A) hInj hN hLN i₀ ρ ψ Y hY
+  have hb' : (fun r : Fin n => ρ (cyclicForwardSite i₀ (r.val + (L + 1)))) = b := by
+    simpa [cyclicForwardSite_forwardSite] using hb
+  simpa [ha, hb'] using htransport
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -684,6 +684,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.boundary_witness_product_of_adjacent_overlaps}
     \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_product}
     \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_product_common_background}
+    \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_product_common_background_named}
     \leanok
     \uses{rem:cyclic_window_operators, def:ground_space_parent, def:l_blk_injective}
     If a cyclic $(L+1)$-window is represented by a boundary matrix $Y$, then
@@ -708,6 +709,16 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         Y_0A^{a_0}\cdots A^{a_{n-1}}
         =
         A^{b_0}\cdots A^{b_{n-1}}Y_n .
+    \]
+    In particular, if the two endpoint words are named by the equations
+    \[
+        a_r=\rho(i_0+r),\qquad
+        b_r=\rho(i_0+r+L+1),
+    \]
+    with site labels read modulo $N$, then the same transport identity is
+    written as
+    \[
+        Y_0A^a=A^bY_n .
     \]
 \end{lemma}
 


### PR DESCRIPTION
## Summary

This PR adds a no-`sorry` adjacent-window transport wrapper for the parent-Hamiltonian closure-property proof. It records the iterated adjacent-overlap equation after the two endpoint words have been identified explicitly:

```tex
Y_0 A^a = A^b Y_n,
\qquad
 a_r=\rho(i_0+r),\quad b_r=\rho(i_0+r+L+1),
```
with site labels read modulo `N`.

This is auxiliary progress toward the reopened #2405 boundary-closing product obligation. It does not claim to prove the final equation

```tex
Y_M(\tau^+_\eta(\mu)) A^j A^\sigma
  =
Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma .
```

## Blueprint

The parent-Hamiltonian blueprint entry for adjacent cyclic-window transport now includes the new named-endpoint form. The prose uses word-product equations and the source distinction between the open-chain intersection property and the periodic closure step.

## Tests

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryOverlap -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryOverlap TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean`

Notes: `python3 scripts/blueprint_lean_sync.py --root . --ci` reports `ch14_parent_hamiltonian.tex 366/366`; its nonzero exit is from the pre-existing unrelated references `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and `...` in `ch04a_channel_representations.tex`. `leanblueprint checkdecls` needs a full root `TNLean.olean`; locally only the affected modules were built.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, proof-only addition that delegates to an existing theorem; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **named-endpoint** variant of iterated adjacent cyclic-window boundary transport for parent-Hamiltonian closure work.
> 
> In `BoundaryOverlap.lean`, **`adjacent_cyclicRestrictₗ_witness_product_common_background_named`** takes explicit endpoint words `a`, `b` and equalities tying them to `ρ` along the cyclic walk (`a_r = ρ(i₀+r)`, `b_r = ρ(i₀+r+L+1)` modulo `N`). It proves **`Y₀ A^a = A^b Yₙ`** by reusing **`adjacent_cyclicRestrictₗ_witness_product_common_background`** and rewriting with **`cyclicForwardSite_forwardSite`**.
> 
> The blueprint lemma on cyclic-window boundary matrix transport now cites this theorem and states the same identity in word-product notation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c7a1a401ae6a23e1c0b8b2fe97c66ff983bbeaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->