### PR TITLE
feat(parent): add closing endpoint word transport

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -264,4 +264,62 @@ theorem boundary_closing_product_eq_of_compatible_backgrounds
           evalWord A (List.ofFn σ) := by
             rw [hmirror]
 
+/-- Endpoint-word form of adjacent-window transport at the closing boundary.
+
+For the \(L_0-1\) adjacent windows from \(M+1-L_0\) to \(M\), the endpoint
+letters are indexed by
+\[
+  M+1-L_0+r,
+  \qquad
+  M+1-L_0+r+L_0+1 \equiv r+1 \pmod {M+1}.
+\]
+Thus the iterated transport identity is
+\[
+  Y_0(\rho)\,
+  A^{\rho_{M+1-L_0}\cdots \rho_{M-1}}
+  =
+  A^{\rho_1\cdots\rho_{L_0-1}}\,Y_{L_0-1}(\rho).
+\]
+For \(L_0=1\) both products are empty. -/
+theorem boundary_closing_endpoint_word_products_common_background
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} (ρ : Fin (M + 1) → Fin d)
+    (Y : Fin ((L₀ - 1) + 1) → Matrix (Fin D) (Fin D) ℂ)
+    (hY : ∀ r : Fin ((L₀ - 1) + 1),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (cyclicForwardSite (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) r.val) ρ ψ =
+        groundSpaceMap A (L₀ + 1) (Y r)) :
+    Y 0 * evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+        ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) =
+      evalWord A (List.ofFn (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩)) *
+        Y (Fin.last (L₀ - 1)) := by
+  refine adjacent_cyclicRestrictₗ_witness_product_common_background_named
+    (A := A) hInj (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+    (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) ρ ψ Y
+    (fun r : Fin (L₀ - 1) => ρ ⟨M + 1 - L₀ + r.val, by omega⟩)
+    (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩) hY ?_ ?_
+  · ext r
+    have hsite :
+        cyclicForwardSite (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) r.val =
+          ⟨M + 1 - L₀ + r.val, by omega⟩ := by
+      ext
+      simp only [cyclicForwardSite, Fin.val_mk]
+      rw [Nat.mod_eq_of_lt (by omega)]
+    rw [hsite]
+  · ext r
+    have hsite :
+        cyclicForwardSite
+            (cyclicForwardSite (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) r.val)
+            (L₀ + 1) =
+          ⟨r.val + 1, by omega⟩ := by
+      ext
+      simp only [cyclicForwardSite, Fin.val_mk]
+      have hsum : ((M + 1 - L₀ + r.val) % (M + 1)) + (L₀ + 1) =
+          M + 1 + (r.val + 1) := by
+        rw [Nat.mod_eq_of_lt (by omega)]
+        omega
+      rw [hsum, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
+    rw [hsite]
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1149,6 +1149,45 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     displayed product equation.
 \end{proof}
 
+\begin{lemma}[Endpoint words at the closing boundary]
+    \label{lem:boundary_closing_endpoint_word_products}
+    \lean{MPSTensor.boundary_closing_endpoint_word_products_common_background}
+    \leanok
+    \uses{lem:cyclic_window_boundary_matrix_transport}
+    Let \(A\) be \(L_0\)-block-injective with \(L_0>0\), and let \(L_0\le M\).
+    Let \(\psi\) be a state on the chain of length \(M+1\). Suppose that
+    matrices \(Y_r(\rho)\), for \(0\le r\le L_0-1\), represent the
+    length-\((L_0+1)\) cyclic restrictions beginning at the sites
+    \(M+1-L_0+r\):
+    \[
+        \operatorname{Res}^{\rho}_{M+1-L_0+r,L_0+1}\psi
+        =
+        \Gamma_{L_0+1}(Y_r(\rho)).
+    \]
+    Then
+    \[
+        Y_0(\rho)
+        A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}
+        =
+        A^{\rho_1}\cdots A^{\rho_{L_0-1}}
+        Y_{L_0-1}(\rho).
+    \]
+    For \(L_0=1\), both products are empty.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Use Lemma~\ref{lem:cyclic_window_boundary_matrix_transport} for the
+    \(L_0-1\) adjacent restrictions starting at \(i_0=M+1-L_0\). For
+    \(0\le r<L_0-1\), the two endpoint words are determined by
+    \[
+        i_0+r=M+1-L_0+r,\qquad
+        i_0+r+L_0+1\equiv r+1 \pmod {M+1},
+    \]
+    Substituting these two words in the iterated transport identity gives the
+    displayed product equation.
+\end{proof}
+
 \begin{lemma}[One matrix $Y_\mu$ from compared boundary matrices]%
     \label{lem:two_sided_middle_of_wrapped_witness_comparison}
     \lean{MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison}


### PR DESCRIPTION
Progresses #2405.

This adds the no-sorry closing-boundary endpoint-word identity obtained by iterating the adjacent-window transport from the support beginning at \(M+1-L_0\) to the support beginning at \(M\):

\[
  Y_{M+1-L_0}(\rho)\,
  A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}
  =
  A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho).
\]

The index calculation used in both the Lean proof and the blueprint is

\[
  i_0=M+1-L_0,\qquad
  i_0+r=M+1-L_0+r,
\]
\[
  i_0+r+L_0+1 \equiv r+1 \pmod {M+1},
  \qquad 0\le r<L_0-1.
\]

This does not close #2405; it records one of the endpoint-word equations needed for the remaining boundary-closing comparison.

Verification:
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` reports the parent chapter at `367 / 367`; it still fails on the pre-existing non-parent references `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and `...`.

Local note: `leanblueprint checkdecls` could not run to completion here because this machine's LeanBlueprint/plasTeX setup does not generate `blueprint/lean_decls`; the source-level sync check above resolves the new declaration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization in MPS parent-Hamiltonian theory and blueprint text; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> Adds a **closing-boundary endpoint-word identity** for parent-Hamiltonian boundary closing: iterating adjacent cyclic-window transport from site \(M+1-L_0\) through \(M\) yields
> \[
> Y_0(\rho)\,A^{\rho_{M+1-L_0}\cdots\rho_{M-1}}
> =
> A^{\rho_1\cdots\rho_{L_0-1}}\,Y_{L_0-1}(\rho)
> \]
> under \(L_0\)-block injectivity and matrix witnesses for each shifted \((L_0+1)\)-window.
> 
> In Lean, **`boundary_closing_endpoint_word_products_common_background`** in `BoundaryClosing.lean` applies `adjacent_cyclicRestrictₗ_witness_product_common_background_named` and proves the two endpoint word maps match \(M+1-L_0+r\) and \(r+1 \pmod{M+1}\) via `cyclicForwardSite` arithmetic.
> 
> The blueprint gains **`lem:boundary_closing_endpoint_word_products`** (`\leanok`), linked to that declaration and citing cyclic window boundary matrix transport—one formal step toward the remaining boundary-closing comparison (#2405).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae50422a901a71cd2ea909bc6ea25b0af208449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->