### PR TITLE
feat(parent): add pointwise boundary assignment reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -203,67 +203,6 @@ theorem mirrorMiddleBackground_first_products_eq_of_complement_eq
     (cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
 
-/-- Complement reduction for the boundary-closing product equation.
-
-Suppose two auxiliary outside assignments have the same complementary words as
-\(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\), respectively.  If the desired
-product equation has already been proved for those two assignments, then it also
-holds for the canonical boundary assignments:
-\[
-  Y_M(\tau^+_\eta(\mu)) A^j A^\sigma
-  =
-  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma .
-\]
-
-This isolates the remaining closure-property task as an adjacent-window product
-identity between compatible outside assignments. -/
-theorem boundary_closing_product_eq_of_compatible_backgrounds
-    {A : MPSTensor d D} {L₀ M : ℕ}
-    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
-    {ψ : NSiteSpace d (M + 1)}
-    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
-      Matrix (Fin D) (Fin D) ℂ)
-    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
-      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
-        groundSpaceMap A (L₀ + 1) (YAt i τ))
-    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
-    (ρPlus ρMinus : Fin (M + 1) → Fin d)
-    (hρPlus : ∀ k : Fin (M + 1 - (L₀ + 1)),
-      ρPlus ⟨k.val + L₀, by omega⟩ = μ k)
-    (hρMinus : ∀ k : Fin (M + 1 - (L₀ + 1)),
-      ρMinus ⟨k.val + 1, by omega⟩ = μ k)
-    (htransport : ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
-      YAt ⟨M, by omega⟩ ρPlus * A j * evalWord A (List.ofFn σ) =
-        YAt ⟨M + 1 - L₀, by omega⟩ ρMinus * A j * evalWord A (List.ofFn σ)) :
-    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
-      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
-          evalWord A (List.ofFn σ) =
-        YAt ⟨M + 1 - L₀, by omega⟩
-            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
-          evalWord A (List.ofFn σ) := by
-  intro j σ
-  have hwrap := wrappedMiddleBackground_first_products_eq_of_complement_eq
-    (A := A) hInj hL₀ hM η μ ρPlus hρPlus
-    (hYAt ⟨M, by omega⟩ ρPlus)
-    (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ)) j
-  have hmirror := mirrorMiddleBackground_first_products_eq_of_complement_eq
-    (A := A) hInj hL₀ hM η μ ρMinus hρMinus
-    (hYAt ⟨M + 1 - L₀, by omega⟩ ρMinus)
-    (hYAt ⟨M + 1 - L₀, by omega⟩
-      (mirrorMiddleBackground L₀ (M + 1) η μ)) j
-  calc
-    YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
-          evalWord A (List.ofFn σ)
-        = YAt ⟨M, by omega⟩ ρPlus * A j * evalWord A (List.ofFn σ) := by
-            rw [← hwrap]
-    _ = YAt ⟨M + 1 - L₀, by omega⟩ ρMinus * A j *
-          evalWord A (List.ofFn σ) :=
-            htransport j σ
-    _ = YAt ⟨M + 1 - L₀, by omega⟩
-            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
-          evalWord A (List.ofFn σ) := by
-            rw [hmirror]
-
 /-- Pointwise complement reduction for the boundary-closing product equation.
 
 The auxiliary boundary assignments may depend on the fixed physical letter and
@@ -328,6 +267,51 @@ theorem boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments
             (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
           evalWord A (List.ofFn σ) := by
             rw [hmirror]
+
+/-- Complement reduction for the boundary-closing product equation.
+
+Suppose two auxiliary outside assignments have the same complementary words as
+\(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\), respectively.  If the desired
+product equation has already been proved for those two assignments, then it also
+holds for the canonical boundary assignments:
+\[
+  Y_M(\tau^+_\eta(\mu)) A^j A^\sigma
+  =
+  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma .
+\]
+
+This isolates the remaining closure-property task as an adjacent-window product
+identity between compatible outside assignments. -/
+theorem boundary_closing_product_eq_of_compatible_backgrounds
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (ρPlus ρMinus : Fin (M + 1) → Fin d)
+    (hρPlus : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρPlus ⟨k.val + L₀, by omega⟩ = μ k)
+    (hρMinus : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρMinus ⟨k.val + 1, by omega⟩ = μ k)
+    (htransport : ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      YAt ⟨M, by omega⟩ ρPlus * A j * evalWord A (List.ofFn σ) =
+        YAt ⟨M + 1 - L₀, by omega⟩ ρMinus * A j * evalWord A (List.ofFn σ)) :
+    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) =
+        YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) := by
+  exact boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments
+    (A := A) hInj hL₀ hM YAt hYAt η μ
+    (fun _ _ => ρPlus) (fun _ _ => ρMinus)
+    (by intro _ _ k; exact hρPlus k)
+    (by intro _ _ k; exact hρMinus k)
+    (by intro j σ; exact htransport j σ)
 
 /-- Endpoint-word form of adjacent-window transport at the closing boundary.
 

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -264,6 +264,71 @@ theorem boundary_closing_product_eq_of_compatible_backgrounds
           evalWord A (List.ofFn σ) := by
             rw [hmirror]
 
+/-- Pointwise complement reduction for the boundary-closing product equation.
+
+The auxiliary boundary assignments may depend on the fixed physical letter and
+the length-\(L_0\) word. If, for each pair \(j,\sigma\), the assignments
+\(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) carry the same complementary
+word as \(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\), respectively, then a
+product equation for those auxiliary assignments gives the corresponding
+canonical boundary-assignment equation:
+\[
+  Y_M(\tau^+_\eta(\mu)) A^j A^\sigma
+  =
+  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma .
+\] -/
+theorem boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (ρPlus ρMinus :
+      (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d)
+    (hρPlus : ∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+        (k : Fin (M + 1 - (L₀ + 1))),
+      ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k)
+    (hρMinus : ∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+        (k : Fin (M + 1 - (L₀ + 1))),
+      ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k)
+    (hProductEq : ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
+        YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+          evalWord A (List.ofFn σ)) :
+    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) =
+        YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) := by
+  intro j σ
+  have hwrap := wrappedMiddleBackground_first_products_eq_of_complement_eq
+    (A := A) hInj hL₀ hM η μ (ρPlus j σ) (hρPlus j σ)
+    (hYAt ⟨M, by omega⟩ (ρPlus j σ))
+    (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ)) j
+  have hmirror := mirrorMiddleBackground_first_products_eq_of_complement_eq
+    (A := A) hInj hL₀ hM η μ (ρMinus j σ) (hρMinus j σ)
+    (hYAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ))
+    (hYAt ⟨M + 1 - L₀, by omega⟩
+      (mirrorMiddleBackground L₀ (M + 1) η μ)) j
+  calc
+    YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ)
+        = YAt ⟨M, by omega⟩ (ρPlus j σ) * A j *
+          evalWord A (List.ofFn σ) := by
+            rw [← hwrap]
+    _ = YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+          evalWord A (List.ofFn σ) :=
+            hProductEq j σ
+    _ = YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) := by
+            rw [hmirror]
+
 /-- Endpoint-word form of adjacent-window transport at the closing boundary.
 
 For the \(L_0-1\) adjacent windows from \(M+1-L_0\) to \(M\), the endpoint

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1149,6 +1149,59 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     displayed product equation.
 \end{proof}
 
+\begin{theorem}[Pointwise reduction to compatible boundary assignments]
+    \label{thm:boundary_closing_product_pointwise_compatible_boundary_assignments}
+    \lean{MPSTensor.boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments}
+    \leanok
+    \uses{lem:boundary_assignment_first_letter_products}
+    Let $A$ be $L_0$-block-injective, with $L_0>0$, and let $L_0\le M$.
+    Let $\psi$ be a state on the chain of length $M+1$, and let the matrices
+    $Y_i(\tau)$ represent its length-$(L_0+1)$ cyclic restrictions:
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    Fix a boundary letter $\eta$ and a complementary word $\mu$. Suppose that,
+    for each physical letter $j$ and word $\sigma$ of length $L_0$, boundary
+    assignments $\rho^+_{j,\sigma}$ and $\rho^-_{j,\sigma}$ satisfy, for every
+    complementary position $k$,
+    \[
+        \rho^+_{j,\sigma}(k+L_0)=\mu_k,
+        \qquad
+        \rho^-_{j,\sigma}(k+1)=\mu_k .
+    \]
+    If, for every $j$ and $\sigma$,
+    \[
+        Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma ,
+    \]
+    then, for every $j$ and $\sigma$,
+    \[
+        Y_M(\tau^+_\eta(\mu))A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma .
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Fix $j$ and $\sigma$. Lemma~\ref{lem:boundary_assignment_first_letter_products}
+    gives
+    \[
+        Y_M(\rho^+_{j,\sigma})A^j
+        =
+        Y_M(\tau^+_\eta(\mu))A^j,
+        \qquad
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^j
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j.
+    \]
+    Multiply the two identities on the right by $A^\sigma$ and use the assumed
+    product equation for the chosen pair $j,\sigma$.
+\end{proof}
+
 \begin{lemma}[Endpoint words at the closing boundary]
     \label{lem:boundary_closing_endpoint_word_products}
     \lean{MPSTensor.boundary_closing_endpoint_word_products_common_background}


### PR DESCRIPTION
Progresses #2405 and #190. This does not close the remaining boundary-closing comparison in `UniqueGroundState.lean`.

This PR adds the pointwise reduction from compatible boundary assignments to the canonical boundary assignments. For each fixed physical letter `j` and length-`L₀` word `σ`, auxiliary assignments `ρ⁺_{j,σ}` and `ρ⁻_{j,σ}` may be chosen separately. If they have the same complementary word `μ` as `τ⁺_η(μ)` and `τ⁻_η(μ)`, respectively, and satisfy

```tex
Y_M(ρ⁺_{j,σ}) A^j A^σ = Y_{M+1-L_0}(ρ⁻_{j,σ}) A^j A^σ,
```

then the same product equation holds for the canonical boundary assignments:

```tex
Y_M(τ⁺_η(μ)) A^j A^σ = Y_{M+1-L_0}(τ⁻_η(μ)) A^j A^σ.
```

The blueprint entry states the result by these equations and avoids presenting local declaration names as mathematical prose.

Checks run:
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` fails only on pre-existing references outside this patch: `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and a literal `...` tag.
- `leanblueprint checkdecls` is not usable in this local plasTeX environment because the LeanBlueprint macros were not loaded and no `lean_decls` file was generated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in parent-Hamiltonian boundary closing with no runtime, auth, or data-path changes.
> 
> **Overview**
> Introduces a **pointwise** boundary-closing reduction: auxiliary assignments \(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) may vary with physical letter \(j\) and length-\(L_0\) word \(\sigma\). When each pair shares the same complementary word \(\mu\) as the canonical \(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\), and satisfies the product equation for that pair, the conclusion holds for the canonical wrapped/mirror boundary assignments.
> 
> The new Lean theorem `boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments` holds the former inline `calc` proof. `boundary_closing_product_eq_of_compatible_backgrounds` is reduced to a one-line `exact` by viewing global \(\rho^+\), \(\rho^-\) as constant-in-\((j,\sigma)\) instances.
> 
> The blueprint gains a matching theorem (`thm:boundary_closing_product_pointwise_compatible_boundary_assignments`) linked to the new Lean decl, placed before the existing compatible-backgrounds lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa8ac92673da34dcb7e170478d45cac01efe39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->