### PR TITLE
doc(parent): isolate boundary assignment product equation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -313,6 +313,46 @@ theorem boundary_closing_product_eq_of_compatible_backgrounds
     (by intro _ _ k; exact hρMinus k)
     (by intro j σ; exact htransport j σ)
 
+/-- Auxiliary boundary-assignment product equation needed at the closing
+boundary.
+
+For each pair \(j,\sigma\), this states the existence of boundary assignments
+\(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) with the same complementary
+word \(\mu\) as the two canonical assignments, and satisfying
+\[
+  Y_M(\rho^+_{j,\sigma}) A^j A^\sigma
+  =
+  Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
+\]
+
+**Open gap:** This is the remaining closure-property equation from
+arXiv:2011.12127, Section IV.C, lines 2078--2090.  It is documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked in #2405. -/
+theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
+    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
+      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
+          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+            evalWord A (List.ofFn σ) := by
+  sorry
+
 /-- Endpoint-word form of adjacent-window transport at the closing boundary.
 
 For the \(L_0-1\) adjacent windows from \(M+1-L_0\) to \(M\), the endpoint

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -3,15 +3,10 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Basic
-import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
-import TNLean.MPS.ParentHamiltonian.CyclicWindow
+import TNLean.MPS.ParentHamiltonian.BoundaryClosing
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
-import TNLean.MPS.ParentHamiltonian.WrappingWindow
-import TNLean.MPS.FundamentalTheorem.FiniteLength
-import TNLean.Algebra.TracePairing
-import TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan
 
 /-!
 # Unique ground state for injective MPS parent Hamiltonians
@@ -716,15 +711,16 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
       (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
   exact hfixed j
 
-/-- Boundary-closing word equation for the closure property, arXiv:2011.12127, lines 2078--2090.
-The two closing-boundary conditions agree after appending \(A^jA^\sigma\).
-**Open gap:** Prove the adjacent-overlap iteration around the boundary; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+/-- Boundary-closing word equation for the closure property, arXiv:2011.12127,
+Section IV.C, lines 2078--2090: the two closing-boundary conditions agree after appending
+\(A^jA^\sigma\).  **Open gap:** Relies on the auxiliary product equation in
+`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`; documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.  Elimination: prove it; #2405. -/
 theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
-    (hψ : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1))
+    (_hψ : ψ ∈ chainGroundSpace A (L₀ + 1) (M + 1))
     (hψX : ψ = groundSpaceMap A (M + 1) X)
     (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
       Matrix (Fin D) (Fin D) ℂ)
@@ -738,7 +734,11 @@ theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
         YAt ⟨M + 1 - L₀, by omega⟩
             (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
           evalWord A (List.ofFn σ) := by
-  sorry
+  obtain ⟨ρPlus, ρMinus, hρPlus, hρMinus, hProductEq⟩ :=
+    closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX YAt hYAt μ
+  exact boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments
+    (A := A) hInj hL₀ hM YAt hYAt η μ ρPlus ρMinus hρPlus hρMinus hProductEq
 
 /-- Matrix form of the closure property, arXiv:2011.12127, lines 2078--2090.
 It follows from the boundary-closing word equation and block injectivity.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1944,12 +1944,49 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     The two restrictions are therefore equal.
 \end{proof}
 
+\begin{lemma}[Auxiliary boundary-assignment product equation]
+    \label{lem:closure_property_auxiliary_boundary_product_chain_ground_space}
+    \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap}
+    \leanok
+    \uses{def:l_blk_injective, def:ground_space_map, rem:cyclic_window_operators}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let $\psi$ be a
+    state on the chain of length $M+1$ with open-chain representation
+    $\psi=\Gamma_{M+1}(X)$.  Let $Y_i(\tau)$ be matrices satisfying
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    If $L_0\le M$, then for every complementary word $\mu$ there are boundary
+    assignments $\rho^+_{j,\sigma}$ and $\rho^-_{j,\sigma}$, depending on the
+    physical letter $j$ and the word $\sigma$ of length $L_0$, such that, for
+    every complementary position $k$,
+    \[
+        \rho^+_{j,\sigma}(k+L_0)=\mu_k,
+        \qquad
+        \rho^-_{j,\sigma}(k+1)=\mu_k
+    \]
+    and, for every $j$ and $\sigma$,
+    \[
+        Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma
+    \]
+\end{lemma}
+
+\begin{proof}
+    \notready
+    This is the remaining boundary-closing equation in the closure-property
+    argument.  It is recorded separately so that the complementary-site
+    conditions and the desired product equation are visible before reducing to
+    the canonical boundary assignments.
+\end{proof}
+
 \begin{lemma}[Boundary-closing word equation for the closure property]
     \label{lem:boundary_closing_word_equation_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_closing_product_eq_of_chainGroundSpace}
     \leanok
-    \uses{def:chain_ground_space, lem:cyclic_window_boundary_matrix_transport,
-        lem:wrapped_middle_backgrounds}
+    \uses{def:chain_ground_space, def:ground_space_map, rem:cyclic_window_operators}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let
     $\psi\in\mathcal G_{M+1,L_0+1}(A)$ have an open-chain representation
     $\psi=\Gamma_{M+1}(X)$.  Let $Y_i(\tau)$ be matrices satisfying
@@ -1970,23 +2007,30 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    For two adjacent cyclic windows, Lemma~\ref{lem:cyclic_window_boundary_matrix_transport}
-    gives
+    \uses{lem:closure_property_auxiliary_boundary_product_chain_ground_space,
+        thm:boundary_closing_product_pointwise_compatible_boundary_assignments}
+    Lemma~\ref{lem:closure_property_auxiliary_boundary_product_chain_ground_space}
+    gives boundary assignments $\rho^+_{j,\sigma}$ and
+    $\rho^-_{j,\sigma}$ satisfying
     \[
-        Y_i(\tau_i)A^{a_i}=A^{b_i}Y_{i+1}(\tau_{i+1})
+        \rho^+_{j,\sigma}(k+L_0)=\mu_k,
+        \qquad
+        \rho^-_{j,\sigma}(k+1)=\mu_k
     \]
-    when the two endpoint-deleted outside assignments agree on the common
-    length-$L_0$ interval.  Choose the assignments $\tau_i$ so that the deleted
-    endpoints are the letters of $j\sigma$ and the remaining sites are
-    $\tau^+_\eta(\mu)$ at the wrapped end and $\tau^-_\eta(\mu)$ at the
-    opposite end.  Iterating the adjacent-window identity around the closing
-    boundary gives
+    and
+    \[
+        Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
+    \]
+    Theorem~\ref{thm:boundary_closing_product_pointwise_compatible_boundary_assignments}
+    replaces these auxiliary assignments by the canonical boundary assignments:
     \[
         Y_M(\tau^{+}_{\eta}(\mu))A^jA^\sigma
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^jA^\sigma,
     \]
-    which is the displayed boundary-closing word equation.
+    which is the desired boundary-closing word equation.
 \end{proof}
 
 \begin{lemma}[Matrix form of the closure property]


### PR DESCRIPTION
## Summary

This isolates the remaining boundary-closing obligation in equation form.

It introduces the auxiliary statement that, for every physical letter \(j\) and word \(\sigma\) of length \(L_0\), there should be boundary assignments \(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) satisfying
\[
  \rho^+_{j,\sigma}(k+L_0)=\mu_k,
  \qquad
  \rho^-_{j,\sigma}(k+1)=\mu_k,
\]
and
\[
  Y_M(\rho^+_{j,\sigma})A^jA^\sigma
  =
  Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
\]

The existing boundary-closing product theorem is then proved from this auxiliary equation using the pointwise compatible-assignment reduction added in #2414.

## Mathematical status

This does not close #2405. It preserves the single open boundary-closing obligation, but moves it to the exact auxiliary product equation. The blueprint proof sketch no longer says that the adjacent-window identity directly gives the canonical product equation; it first states the auxiliary equation and then applies the pointwise reduction.

## Verification

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`  
  Expected warning: `closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap` uses `sorry`.
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`  
  Expected warning: replayed dependency `BoundaryClosing.lean` contains the same `sorry`.
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean`
- `git diff --check`

Progresses #2405.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and proof-structure refactor only; the mathematical gap remains a single `sorry` in the new auxiliary theorem, with no change to runtime or security-sensitive code.
> 
> **Overview**
> **Isolates the remaining boundary-closing gap** as an explicit auxiliary product equation (`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap` in `BoundaryClosing.lean`), still marked `sorry` and tracked for #2405.
> 
> The canonical **boundary-closing product theorem** in `UniqueGroundState.lean` is no longer a bare `sorry`: it obtains pointwise auxiliary assignments from that auxiliary statement and finishes via `boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments` (#2414). Imports are trimmed so `UniqueGroundState` depends on `BoundaryClosing` instead of several overlapping modules.
> 
> The **blueprint** adds a matching auxiliary lemma and rewrites the boundary-closing word-equation proof sketch to state the auxiliary equation first, then reduce to canonical `τ⁺`/`τ⁻` assignments—instead of claiming adjacent-window transport alone yields the canonical product.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ab095d6c9360a56c1045f9eab2f19905b24eae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->