### PR TITLE
doc(parent): record boundary-crossing equations

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -313,6 +313,51 @@ theorem boundary_closing_product_eq_of_compatible_backgrounds
     (by intro _ _ k; exact hρMinus k)
     (by intro j σ; exact htransport j σ)
 
+/-- The two one-sided equations obtained from the boundary-crossing cyclic
+windows.
+
+Assume \(\psi=\Gamma_{M+1}(X)\), and suppose \(Y_i(\tau)\) represents the
+length-\((L_0+1)\) cyclic restriction of \(\psi\) beginning at \(i\).  Then the
+two boundary-crossing positions give, for every physical letter \(j\) and
+boundary condition \(\tau\),
+\[
+  A^{\tau_{L_0}\cdots\tau_{M-1}} A^j X = Y_M(\tau) A^j,
+  \qquad
+  X A^j A^{\tau_1\cdots\tau_{M-L_0}} = A^j Y_{M+1-L_0}(\tau).
+\]
+
+This is the one-sided part of the closure-property argument in
+arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
+theorem closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ)) :
+    (∀ (j : Fin d) (τ : Fin (M + 1) → Fin d),
+      evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+        τ ⟨k.val + L₀, by omega⟩)) * A j * X =
+          YAt ⟨M, by omega⟩ τ * A j) ∧
+    (∀ (j : Fin d) (τ : Fin (M + 1) → Fin d),
+      X * A j * evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+        τ ⟨k.val + 1, by omega⟩)) =
+          A j * YAt ⟨M + 1 - L₀, by omega⟩ τ) := by
+  constructor
+  · exact wrapping_window_compatibility_of_isNBlkInjective
+      (A := A) hInj hL₀ hM (YAt ⟨M, by omega⟩)
+      (fun τ σ_w => by
+        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
+          using congr_fun (hYAt ⟨M, by omega⟩ τ) σ_w)
+  · exact wrapping_window_mirror_compatibility_of_isNBlkInjective
+      (A := A) hInj hL₀ hM (YAt ⟨M + 1 - L₀, by omega⟩)
+      (fun τ σ_w => by
+        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
+          using congr_fun (hYAt ⟨M + 1 - L₀, by omega⟩ τ) σ_w)
+
 /-- Auxiliary boundary-assignment product equation needed at the closing
 boundary.
 

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -872,16 +872,9 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
   let mirrorPos : Fin (M + 1) := ⟨M + 1 - L₀, by omega⟩
   let τp := wrappedMiddleBackground L₀ (M + 1) η μ
   let τm := mirrorMiddleBackground L₀ (M + 1) η μ
-  have hWrapAt := wrapping_window_compatibility_of_isNBlkInjective
-    (A := A) hInj hL₀ (by omega : L₀ ≤ M) (YAt wrapPos)
-      (fun τ σ_w => by
-        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
-          using congr_fun (hYAt wrapPos τ) σ_w)
-  have hMirrorAt := wrapping_window_mirror_compatibility_of_isNBlkInjective
-    (A := A) hInj hL₀ (by omega : L₀ ≤ M) (YAt mirrorPos)
-      (fun τ σ_w => by
-        simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
-          using congr_fun (hYAt mirrorPos τ) σ_w)
+  obtain ⟨hWrapAt, hMirrorAt⟩ :=
+    closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
+      (A := A) hInj hL₀ (by omega : L₀ ≤ M) hψX YAt hYAt
   have hYwrap_eq : Ywrap τp = YAt wrapPos τp :=
     right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
       (fun a => (hWrap a τp).symm.trans (hWrapAt a τp))

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1018,6 +1018,42 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     the displayed one-sided identities~(\ref{eq:ph_reduced_wrapped_compat}).
 \end{proof}
 
+\begin{lemma}[Boundary-crossing equations for $\Gamma_{M+1}(X)$]%
+    \label{lem:closure_property_boundary_crossing_equations_ground_space_map}
+    \lean{MPSTensor.closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap}
+    \leanok
+    \uses{def:ground_space_map, rem:cyclic_window_operators,
+        lem:wrapped_window_one_sided_compatibility,
+        lem:mirror_wrapped_window_one_sided_compatibility}
+    Let $A$ be $L_0$-block injective with $L_0>0$, $D\ge1$, and $L_0\le M$.
+    Suppose $\psi=\Gamma_{M+1}(X)$, and suppose matrices $Y_i(\tau)$ represent
+    the length-$(L_0+1)$ cyclic restrictions
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    Then, for every physical letter $j$ and boundary condition $\tau$,
+    \begin{equation}\label{eq:ph_closure_boundary_crossing_gamma_equations}
+        A^{\tau_{L_0}}\cdots A^{\tau_{M-1}} A^j X
+        =
+        Y_M(\tau)A^j,
+        \qquad
+        X A^j A^{\tau_1}\cdots A^{\tau_{M-L_0}}
+        =
+        A^jY_{M+1-L_0}(\tau).
+    \end{equation}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Substitute $\psi=\Gamma_{M+1}(X)$ in the two cyclic restrictions at the
+    last site and at the opposite boundary-crossing support. Lemmas
+    \ref{lem:wrapped_window_one_sided_compatibility} and
+    \ref{lem:mirror_wrapped_window_one_sided_compatibility} then give the two
+    equations in~(\ref{eq:ph_closure_boundary_crossing_gamma_equations}).
+\end{proof}
+
 \begin{lemma}[Common complement word for the two boundary supports]%
     \label{lem:wrapped_middle_backgrounds}
     \lean{MPSTensor.wrappedMiddleBackground,
@@ -1976,10 +2012,25 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
+    \uses{lem:closure_property_boundary_crossing_equations_ground_space_map}
     This is the remaining boundary-closing equation in the closure-property
-    argument.  It is recorded separately so that the complementary-site
-    conditions and the desired product equation are visible before reducing to
-    the canonical boundary assignments.
+    argument.  The two one-sided equations
+    \[
+        A^{\rho^+_{j,\sigma,L_0}}\cdots
+        A^{\rho^+_{j,\sigma,M-1}} A^j X
+        =
+        Y_M(\rho^+_{j,\sigma})A^j,
+        \qquad
+        X A^j A^{\rho^-_{j,\sigma,1}}\cdots
+        A^{\rho^-_{j,\sigma,M-L_0}}
+        =
+        A^jY_{M+1-L_0}(\rho^-_{j,\sigma})
+    \]
+    come from
+    Lemma~\ref{lem:closure_property_boundary_crossing_equations_ground_space_map}.
+    What remains is to choose the two boundary conditions so that their
+    complementary sites equal $\mu$ and their products after multiplication by
+    $A^jA^\sigma$ agree.
 \end{proof}
 
 \begin{lemma}[Boundary-closing word equation for the closure property]


### PR DESCRIPTION
## Summary

This records the two one-sided boundary-crossing equations obtained from an open-chain representation
\[
  \psi=\Gamma_{M+1}(X)
\]
and cyclic restriction matrices
\[
  \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)=\Gamma_{L_0+1}(Y_i(\tau)).
\]
For every physical letter \(j\) and boundary condition \(\tau\), the formalized statement gives
\[
  A^{\tau_{L_0}}\cdots A^{\tau_{M-1}} A^j X = Y_M(\tau)A^j,
  \qquad
  X A^j A^{\tau_1}\cdots A^{\tau_{M-L_0}} = A^jY_{M+1-L_0}(\tau).
\]

The downstream boundary-condition comparison now invokes this theorem instead of repeating the two cyclic-window arguments. The blueprint entry states these equations directly and points the remaining auxiliary product equation at them.

## Open gap

This does not prove the remaining #2405 product equation. The remaining obligation is still to choose \(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) with complementary sites equal to \(\mu\) and prove
\[
  Y_M(\rho^+_{j,\sigma})A^jA^\sigma
  =
  Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma.
\]

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and documentation only; no change to proof obligations or the still-open auxiliary boundary product (#2405).
> 
> **Overview**
> Adds **`closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap`** in `BoundaryClosing.lean`, which states the two one-sided boundary-crossing identities for \(\psi=\Gamma_{M+1}(X)\) and cyclic restriction matrices \(Y_i(\tau)\), by combining the existing wrapped/mirror window compatibility lemmas.
> 
> **`wrapped_mirror_witness_agree_of_chainGroundSpace`** in `UniqueGroundState.lean` now obtains those compatibilities via a single `obtain` on this theorem instead of inlining two separate `wrapping_window_*` proofs.
> 
> The blueprint gains lemma **Boundary-crossing equations for \(\Gamma_{M+1}(X)\)** (`lem:closure_property_boundary_crossing_equations_ground_space_map`) and the auxiliary boundary product lemma’s proof sketch now cites it for the one-sided equations, leaving only the choice of \(\rho^\pm_{j,\sigma}\) with matching \(\mu\) as the open step (#2405).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e76f5c626054d4f34a599847ba982bfc6a00be0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->