### PR TITLE
feat(parent): record closing-boundary product equation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -358,135 +358,26 @@ theorem closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
         simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
           using congr_fun (hYAt ⟨M + 1 - L₀, by omega⟩ τ) σ_w)
 
-/-- Product equation obtained by moving through the \(L_0-1\) boundary-crossing
-windows from \(M+1-L_0\) to \(M\).
+/-- Product form of the boundary-crossing restrictions at the closing boundary.
 
-For a fixed boundary condition \(\rho\), the window matrices satisfy
-\[
-  Y_{M+1-L_0}(\rho)
-  A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}
-  =
-  A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho).
-\]
-For \(L_0=1\), both word products are empty.
-
-This is the fixed-boundary-condition product isolated from the
-closure-property step in arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
-theorem closure_property_boundary_condition_product_of_window_witnesses
-    {A : MPSTensor d D} {L₀ M : ℕ}
-    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
-    {ψ : NSiteSpace d (M + 1)}
-    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
-      Matrix (Fin D) (Fin D) ℂ)
-    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
-      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
-        groundSpaceMap A (L₀ + 1) (YAt i τ))
-    (ρ : Fin (M + 1) → Fin d) :
-    YAt ⟨M + 1 - L₀, by omega⟩ ρ *
-        evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
-          ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) =
-      evalWord A (List.ofFn (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩)) *
-        YAt ⟨M, by omega⟩ ρ := by
-  let i₀ : Fin (M + 1) := ⟨M + 1 - L₀, by omega⟩
-  let Y : Fin ((L₀ - 1) + 1) → Matrix (Fin D) (Fin D) ℂ :=
-    fun r => YAt (cyclicForwardSite i₀ r.val) ρ
-  have hY : ∀ r : Fin ((L₀ - 1) + 1),
-      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
-          (cyclicForwardSite i₀ r.val) ρ ψ =
-        groundSpaceMap A (L₀ + 1) (Y r) := by
-    intro r
-    exact hYAt (cyclicForwardSite i₀ r.val) ρ
-  have hprod := adjacent_cyclicRestrictₗ_witness_product_common_background_named
-    (A := A) hInj (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
-    i₀ ρ ψ Y
-    (fun r : Fin (L₀ - 1) => ρ ⟨M + 1 - L₀ + r.val, by omega⟩)
-    (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩) hY ?_ ?_
-  · have hstart : cyclicForwardSite i₀ 0 = ⟨M + 1 - L₀, by omega⟩ := by
-      ext
-      simp only [i₀, cyclicForwardSite, Fin.val_mk]
-      exact Nat.mod_eq_of_lt (by omega)
-    have hend : cyclicForwardSite i₀ (L₀ - 1) = ⟨M, by omega⟩ := by
-      ext
-      simp only [i₀, cyclicForwardSite, Fin.val_mk]
-      have hsum : M + 1 - L₀ + (L₀ - 1) = M := by omega
-      rw [hsum, Nat.mod_eq_of_lt (by omega)]
-    simpa [Y, hstart, hend] using hprod
-  · ext r
-    have hsite : cyclicForwardSite i₀ r.val =
-        ⟨M + 1 - L₀ + r.val, by omega⟩ := by
-      ext
-      simp only [i₀, cyclicForwardSite, Fin.val_mk]
-      exact Nat.mod_eq_of_lt (by omega)
-    rw [hsite]
-  · ext r
-    have hsite : cyclicForwardSite (cyclicForwardSite i₀ r.val) (L₀ + 1) =
-        ⟨r.val + 1, by omega⟩ := by
-      ext
-      simp only [i₀, cyclicForwardSite, Fin.val_mk]
-      have hsum : ((M + 1 - L₀ + r.val) % (M + 1)) + (L₀ + 1) =
-          M + 1 + (r.val + 1) := by
-        rw [Nat.mod_eq_of_lt (by omega)]
-        omega
-      rw [hsum, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
-    rw [hsite]
-
-/-- Auxiliary boundary-assignment product equation needed at the closing
-boundary.
-
-For each pair \(j,\sigma\), this states the existence of boundary assignments
-\(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) with the same complementary
-word \(\mu\) as the two canonical assignments, and satisfying
-\[
-  Y_M(\rho^+_{j,\sigma}) A^j A^\sigma
-  =
-  Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
-\]
-
-**Open gap:** This is the remaining closure-property equation from
-arXiv:2011.12127, Section IV.C, lines 2078--2090.  It is documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked in #2405. -/
-theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
-    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
-    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
-    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
-    (hψX : ψ = groundSpaceMap A (M + 1) X)
-    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
-      Matrix (Fin D) (Fin D) ℂ)
-    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
-      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
-        groundSpaceMap A (L₀ + 1) (YAt i τ))
-    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
-    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
-    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
-      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
-          (k : Fin (M + 1 - (L₀ + 1))),
-        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
-      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
-          (k : Fin (M + 1 - (L₀ + 1))),
-        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
-      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
-        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
-          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
-            evalWord A (List.ofFn σ) := by
-  sorry
-
-/-- Endpoint-word form of adjacent-window transport at the closing boundary.
-
-For the \(L_0-1\) adjacent windows from \(M+1-L_0\) to \(M\), the endpoint
-letters are indexed by
+For the \(L_0-1\) adjacent restrictions from \(M+1-L_0\) to \(M\), the two
+boundary letters are indexed by
 \[
   M+1-L_0+r,
   \qquad
   M+1-L_0+r+L_0+1 \equiv r+1 \pmod {M+1}.
 \]
-Thus the iterated transport identity is
+Thus the iterated product equation is
 \[
   Y_0(\rho)\,
   A^{\rho_{M+1-L_0}\cdots \rho_{M-1}}
   =
   A^{\rho_1\cdots\rho_{L_0-1}}\,Y_{L_0-1}(\rho).
 \]
-For \(L_0=1\) both products are empty. -/
+For \(L_0=1\) both products are empty.
+
+This is the product form of the closure-property step in arXiv:2011.12127,
+Section IV.C, lines 2078--2090. -/
 theorem boundary_closing_endpoint_word_products_common_background
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -527,5 +418,96 @@ theorem boundary_closing_endpoint_word_products_common_background
         omega
       rw [hsum, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
     rw [hsite]
+
+/-- Product equation obtained by moving through the \(L_0-1\) boundary-crossing
+windows from \(M+1-L_0\) to \(M\).
+
+For a fixed boundary condition \(\rho\), the window matrices satisfy
+\[
+  Y_{M+1-L_0}(\rho)
+  A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}
+  =
+  A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho).
+\]
+For \(L_0=1\), both word products are empty.
+
+This is the fixed-boundary-condition product isolated from the
+closure-property step in arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
+theorem closure_property_boundary_condition_product_of_window_witnesses
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (ρ : Fin (M + 1) → Fin d) :
+    YAt ⟨M + 1 - L₀, by omega⟩ ρ *
+        evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+          ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) =
+      evalWord A (List.ofFn (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩)) *
+        YAt ⟨M, by omega⟩ ρ := by
+  let i₀ : Fin (M + 1) := ⟨M + 1 - L₀, by omega⟩
+  let Y : Fin ((L₀ - 1) + 1) → Matrix (Fin D) (Fin D) ℂ :=
+    fun r => YAt (cyclicForwardSite i₀ r.val) ρ
+  have hY : ∀ r : Fin ((L₀ - 1) + 1),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (cyclicForwardSite i₀ r.val) ρ ψ =
+        groundSpaceMap A (L₀ + 1) (Y r) := by
+    intro r
+    exact hYAt (cyclicForwardSite i₀ r.val) ρ
+  have hprod := boundary_closing_endpoint_word_products_common_background
+    (A := A) hInj hL₀ hM ρ Y hY
+  have hstart : cyclicForwardSite i₀ 0 = ⟨M + 1 - L₀, by omega⟩ := by
+    ext
+    simp only [i₀, cyclicForwardSite, Fin.val_mk]
+    exact Nat.mod_eq_of_lt (by omega)
+  have hend : cyclicForwardSite i₀ (L₀ - 1) = ⟨M, by omega⟩ := by
+    ext
+    simp only [i₀, cyclicForwardSite, Fin.val_mk]
+    have hsum : M + 1 - L₀ + (L₀ - 1) = M := by omega
+    rw [hsum, Nat.mod_eq_of_lt (by omega)]
+  simpa [Y, hstart, hend] using hprod
+
+/-- Auxiliary boundary-assignment product equation needed at the closing
+boundary.
+
+For each pair \(j,\sigma\), this states the existence of boundary assignments
+\(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) with the same complementary
+word \(\mu\) as the two canonical assignments, and satisfying
+\[
+  Y_M(\rho^+_{j,\sigma}) A^j A^\sigma
+  =
+  Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
+\]
+
+**Open gap:** This is the remaining closure-property equation from
+arXiv:2011.12127, Section IV.C, lines 2078--2090.  It is documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked in #2405. -/
+theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
+    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
+      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
+          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+            evalWord A (List.ofFn σ) := by
+  sorry
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -358,6 +358,78 @@ theorem closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
         simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
           using congr_fun (hYAt ⟨M + 1 - L₀, by omega⟩ τ) σ_w)
 
+/-- Product equation obtained by moving through the \(L_0-1\) boundary-crossing
+windows from \(M+1-L_0\) to \(M\).
+
+For a fixed boundary condition \(\rho\), the window matrices satisfy
+\[
+  Y_{M+1-L_0}(\rho)
+  A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}
+  =
+  A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho).
+\]
+For \(L_0=1\), both word products are empty.
+
+This is the fixed-boundary-condition product isolated from the
+closure-property step in arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
+theorem closure_property_boundary_condition_product_of_window_witnesses
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (ρ : Fin (M + 1) → Fin d) :
+    YAt ⟨M + 1 - L₀, by omega⟩ ρ *
+        evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+          ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) =
+      evalWord A (List.ofFn (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩)) *
+        YAt ⟨M, by omega⟩ ρ := by
+  let i₀ : Fin (M + 1) := ⟨M + 1 - L₀, by omega⟩
+  let Y : Fin ((L₀ - 1) + 1) → Matrix (Fin D) (Fin D) ℂ :=
+    fun r => YAt (cyclicForwardSite i₀ r.val) ρ
+  have hY : ∀ r : Fin ((L₀ - 1) + 1),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (cyclicForwardSite i₀ r.val) ρ ψ =
+        groundSpaceMap A (L₀ + 1) (Y r) := by
+    intro r
+    exact hYAt (cyclicForwardSite i₀ r.val) ρ
+  have hprod := adjacent_cyclicRestrictₗ_witness_product_common_background_named
+    (A := A) hInj (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+    i₀ ρ ψ Y
+    (fun r : Fin (L₀ - 1) => ρ ⟨M + 1 - L₀ + r.val, by omega⟩)
+    (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩) hY ?_ ?_
+  · have hstart : cyclicForwardSite i₀ 0 = ⟨M + 1 - L₀, by omega⟩ := by
+      ext
+      simp only [i₀, cyclicForwardSite, Fin.val_mk]
+      exact Nat.mod_eq_of_lt (by omega)
+    have hend : cyclicForwardSite i₀ (L₀ - 1) = ⟨M, by omega⟩ := by
+      ext
+      simp only [i₀, cyclicForwardSite, Fin.val_mk]
+      have hsum : M + 1 - L₀ + (L₀ - 1) = M := by omega
+      rw [hsum, Nat.mod_eq_of_lt (by omega)]
+    simpa [Y, hstart, hend] using hprod
+  · ext r
+    have hsite : cyclicForwardSite i₀ r.val =
+        ⟨M + 1 - L₀ + r.val, by omega⟩ := by
+      ext
+      simp only [i₀, cyclicForwardSite, Fin.val_mk]
+      exact Nat.mod_eq_of_lt (by omega)
+    rw [hsite]
+  · ext r
+    have hsite : cyclicForwardSite (cyclicForwardSite i₀ r.val) (L₀ + 1) =
+        ⟨r.val + 1, by omega⟩ := by
+      ext
+      simp only [i₀, cyclicForwardSite, Fin.val_mk]
+      have hsum : ((M + 1 - L₀ + r.val) % (M + 1)) + (L₀ + 1) =
+          M + 1 + (r.val + 1) := by
+        rw [Nat.mod_eq_of_lt (by omega)]
+        omega
+      rw [hsum, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
+    rw [hsite]
+
 /-- Auxiliary boundary-assignment product equation needed at the closing
 boundary.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1277,6 +1277,45 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     displayed product equation.
 \end{proof}
 
+\begin{lemma}[Boundary-condition product at the closing boundary]
+    \label{lem:closure_property_boundary_condition_product_window_witnesses}
+    \lean{MPSTensor.closure_property_boundary_condition_product_of_window_witnesses}
+    \leanok
+    \uses{rem:cyclic_window_operators, lem:cyclic_window_boundary_matrix_transport}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$. Let
+    $\psi$ be a state on the chain of length $M+1$, and suppose matrices
+    $Y_i(\rho)$ represent the length-$(L_0+1)$ cyclic restrictions
+    \[
+        \operatorname{Res}^{\rho}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\rho)).
+    \]
+    Then, for every boundary condition $\rho$,
+    \[
+        Y_{M+1-L_0}(\rho)
+        A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}
+        =
+        A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho).
+    \]
+    For $L_0=1$, both products are empty.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply the adjacent-window product identity to the $L_0-1$ restrictions
+    beginning at $M+1-L_0+r$, with
+    \[
+        Y_r(\rho)=Y_{M+1-L_0+r}(\rho).
+    \]
+    With $i_0=M+1-L_0$, the site labels satisfy
+    \[
+        i_0+r=M+1-L_0+r,
+        \qquad
+        i_0+r+L_0+1\equiv r+1 \pmod {M+1}
+    \]
+    These identities give the two word products displayed above.
+\end{proof}
+
 \begin{lemma}[One matrix $Y_\mu$ from compared boundary matrices]%
     \label{lem:two_sided_middle_of_wrapped_witness_comparison}
     \lean{MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison}
@@ -2012,7 +2051,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    \uses{lem:closure_property_boundary_crossing_equations_ground_space_map}
+    \uses{lem:closure_property_boundary_crossing_equations_ground_space_map,
+        lem:closure_property_boundary_condition_product_window_witnesses}
     This is the remaining boundary-closing equation in the closure-property
     argument.  The two one-sided equations
     \[
@@ -2030,7 +2070,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Lemma~\ref{lem:closure_property_boundary_crossing_equations_ground_space_map}.
     What remains is to choose the two boundary conditions so that their
     complementary sites equal $\mu$ and their products after multiplication by
-    $A^jA^\sigma$ agree.
+    $A^jA^\sigma$ agree.  For any such boundary condition $\rho$, the
+    closing-boundary product equation available from the adjacent restrictions is
+    \[
+        Y_{M+1-L_0}(\rho)
+        A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}
+        =
+        A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho),
+    \]
+    so the unresolved point is the choice of $\rho^+_{j,\sigma}$ and
+    $\rho^-_{j,\sigma}$ that converts this equation into the displayed product
+    with right factor $A^jA^\sigma$.
 \end{proof}
 
 \begin{lemma}[Boundary-closing word equation for the closure property]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1302,8 +1302,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    Apply the adjacent-window product identity to the $L_0-1$ restrictions
-    beginning at $M+1-L_0+r$, with
+    Apply Lemma~\ref{lem:cyclic_window_boundary_matrix_transport} to the
+    $L_0-1$ restrictions beginning at $M+1-L_0+r$, with
     \[
         Y_r(\rho)=Y_{M+1-L_0+r}(\rho).
     \]
@@ -1313,7 +1313,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \qquad
         i_0+r+L_0+1\equiv r+1 \pmod {M+1}
     \]
-    These identities give the two word products displayed above.
+    hence, for $r=0,\ldots,L_0-2$,
+    \[
+        Y_{M+1-L_0+r}(\rho) A^{\rho_{M+1-L_0+r}}
+        =
+        A^{\rho_{r+1}}Y_{M+2-L_0+r}(\rho).
+    \]
+    Multiplying these $L_0-1$ equations from left to right gives the displayed
+    product equation.
 \end{proof}
 
 \begin{lemma}[One matrix $Y_\mu$ from compared boundary matrices]%


### PR DESCRIPTION
Refs #2405.

This PR isolates the fixed-boundary-condition product obtained by moving through the \(L_0-1\) boundary-crossing restrictions near the closing boundary.  In the notation of the blueprint, the new no-sorry theorem proves

\[
Y_{M+1-L_0}(\rho)
A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}
=
A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho).
\]

The Lean docstring cites arXiv:2011.12127, Section IV.C, lines 2078--2090, and the blueprint records the same equation without using a Lean label as mathematical prose.

This does not close #2405.  The remaining point is to choose the \(j,\sigma\)-dependent boundary conditions so that

\[
Y_M(\rho^+_{j,\sigma})A^jA^\sigma
=
Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
\]

Verification:
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean`
- `git diff --check`
- `leanblueprint web` exited 0 locally; the run emitted the existing local package/bibliography warnings.

The Lean builds still report the pre-existing open #2405 theorem as using `sorry`; this PR adds no new `sorry`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Incremental formalization in `BoundaryClosing.lean` with no new `sorry` and no auth or runtime behavior changes; remaining closure-property work is explicitly still open.
> 
> **Overview**
> Adds a **fully proved** Lean theorem `closure_property_boundary_condition_product_of_window_witnesses` that, for a fixed boundary condition ρ, relates window matrices at `M+1-L₀` and `M` via the iterated word product
> 
> \[
> Y_{M+1-L_0}(\rho)\,A^{\rho_{M+1-L_0}\cdots \rho_{M-1}}
> =
> A^{\rho_1}\cdots A^{\rho_{L_0-1}}\,Y_M(\rho).
> \]
> 
> The proof instantiates the existing `boundary_closing_endpoint_word_products_common_background` along the `L₀-1` adjacent cyclic windows starting at `M+1-L₀`.
> 
> The blueprint gains a matching lemma (`lem:closure_property_boundary_condition_product_window_witnesses`, `\leanok`) and the still-open auxiliary boundary-assignment lemma’s proof sketch now cites this product as available input, while **#2405** remains blocked on choosing `ρ^+_{j,σ}` / `ρ^-_{j,σ}` (the `sorry` theorem is only moved/reordered, not closed). Docstrings for the endpoint-word lemma are retitled from “transport” to “product” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe4d0aea3a787f20ee93cbfbf3745c6736faa160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->