### PR TITLE
feat(parent): reduce auxiliary product to closing restrictions

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -470,6 +470,108 @@ theorem closure_property_boundary_condition_product_of_window_witnesses
     rw [hsum, Nat.mod_eq_of_lt (by omega)]
   simpa [Y, hstart, hend] using hprod
 
+/-- Auxiliary boundary-condition product obtained from equality of the two
+closing-boundary restrictions.
+
+Suppose that, for every physical letter \(j\), the two boundary conditions with
+outside letter \(j\) and complementary word \(\mu\) give the same
+length-\((L_0+1)\) restriction:
+\[
+  \operatorname{Res}^{\tau^+_j(\mu)}_{M,L_0+1}(\psi)
+  =
+  \operatorname{Res}^{\tau^-_j(\mu)}_{M+1-L_0,L_0+1}(\psi).
+\]
+Then there are boundary conditions with the same complementary word and with
+\[
+  Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+  =
+  Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
+\]
+This isolates the remaining closure-property step as the closing-boundary
+restriction equality recorded in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`, following
+arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
+lemma closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hRestrict : ∀ j : Fin d,
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) j μ) ψ =
+        cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) j μ) ψ) :
+    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
+      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
+          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+            evalWord A (List.ofFn σ) := by
+  let ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d :=
+    fun j _ => wrappedMiddleBackground L₀ (M + 1) j μ
+  let ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d :=
+    fun j _ => mirrorMiddleBackground L₀ (M + 1) j μ
+  refine ⟨ρPlus, ρMinus, ?_, ?_, ?_⟩
+  · intro j σ k
+    have h := congr_fun (wrappedMiddleBackground_complement L₀ (M + 1) j μ) k
+    simpa [ρPlus] using h
+  · intro j σ k
+    have h := congr_fun (mirrorMiddleBackground_complement L₀ (M + 1) j μ) k
+    simpa [ρMinus] using h
+  · intro j σ
+    have hfirst :
+        YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) j μ) * A j =
+          YAt ⟨M + 1 - L₀, by omega⟩
+              (mirrorMiddleBackground L₀ (M + 1) j μ) * A j := by
+      apply groundSpaceMap_injective_of_isNBlkInjective hInj
+      have hvec :
+          restrictFirst
+              (cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+                (⟨M, by omega⟩ : Fin (M + 1))
+                (wrappedMiddleBackground L₀ (M + 1) j μ) ψ) j =
+            restrictFirst
+              (cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+                (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+                (mirrorMiddleBackground L₀ (M + 1) j μ) ψ) j := by
+        rw [hRestrict j]
+      have hleft :=
+        cyclicRestrictₗ_restrictFirst_groundSpaceMap
+          (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) j μ) ψ
+          (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) j μ)) j
+      have hright :=
+        cyclicRestrictₗ_restrictFirst_groundSpaceMap
+          (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) j μ) ψ
+          (hYAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) j μ)) j
+      rw [cyclicRestrictₗ_restrictFirst
+          (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) j μ) ψ j,
+        cyclicRestrictₗ_restrictFirst
+          (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) j μ) ψ j] at hvec
+      exact hleft.symm.trans (hvec.trans hright)
+    simpa [ρPlus, ρMinus] using
+      congrArg (fun Y => Y * evalWord A (List.ofFn σ)) hfirst
+
 /-- Auxiliary boundary-assignment product equation needed at the closing
 boundary.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1978,6 +1978,66 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     two length-$(L_0+1)$ restrictions.
 \end{proof}
 
+\begin{lemma}[Auxiliary product from closing-boundary restrictions]
+    \label{lem:closure_property_auxiliary_product_from_closing_restrictions}
+    \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_closing_restrictions}
+    \leanok
+    \uses{def:l_blk_injective, def:ground_space_map,
+        rem:cyclic_window_operators, lem:ground_space_map_injective_blk,
+        lem:cyclic_window_boundary_matrix_transport,
+        lem:wrapped_middle_backgrounds}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$.
+    Let $\psi$ be a state on the chain of length $M+1$, and let
+    $Y_i(\tau)$ be matrices satisfying
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    Suppose that, for every physical letter $j$,
+    \[
+        \operatorname{Res}^{\tau^+_j(\mu)}_{M,L_0+1}(\psi)
+        =
+        \operatorname{Res}^{\tau^-_j(\mu)}_{M+1-L_0,L_0+1}(\psi).
+    \]
+    Then there are boundary conditions $\rho^+_{j,\sigma}$ and
+    $\rho^-_{j,\sigma}$ such that, for every complementary position $k$,
+    \[
+        \rho^+_{j,\sigma}(k+L_0)=\mu_k,
+        \qquad
+        \rho^-_{j,\sigma}(k+1)=\mu_k,
+    \]
+    and, for every physical letter $j$ and every word $\sigma$ of length
+    $L_0$,
+    \[
+        Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Take $\rho^+_{j,\sigma}=\tau^+_j(\mu)$ and
+    $\rho^-_{j,\sigma}=\tau^-_j(\mu)$.  The complement equations are the two
+    identities of Lemma~\ref{lem:wrapped_middle_backgrounds}.  Fix $j$.  Applying
+    the first-letter restriction to the displayed equality gives
+    \[
+        \Gamma_{L_0}\!\left(Y_M(\tau^+_j(\mu))A^j\right)
+        =
+        \Gamma_{L_0}\!\left(Y_{M+1-L_0}(\tau^-_j(\mu))A^j\right),
+    \]
+    where the two sides are identified by
+    Lemma~\ref{lem:cyclic_window_boundary_matrix_transport}.  By
+    Lemma~\ref{lem:ground_space_map_injective_blk},
+    \[
+        Y_M(\tau^+_j(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_j(\mu))A^j.
+    \]
+    Right multiplication by $A^\sigma$ gives the asserted product equation.
+\end{proof}
+
 \begin{lemma}[Auxiliary first-letter form of the closure property]
     \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
     \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}
@@ -2058,36 +2118,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    \uses{lem:closure_property_boundary_crossing_equations_ground_space_map,
-        lem:closure_property_boundary_condition_product_window_witnesses}
-    This is the remaining boundary-closing equation in the closure-property
-    argument.  The two one-sided equations
+    \uses{lem:closure_property_auxiliary_product_from_closing_restrictions}
+    By Lemma~\ref{lem:closure_property_auxiliary_product_from_closing_restrictions},
+    it is enough to prove, for every physical letter $j$,
     \[
-        A^{\rho^+_{j,\sigma,L_0}}\cdots
-        A^{\rho^+_{j,\sigma,M-1}} A^j X
+        \operatorname{Res}^{\tau^+_j(\mu)}_{M,L_0+1}(\psi)
         =
-        Y_M(\rho^+_{j,\sigma})A^j,
-        \qquad
-        X A^j A^{\rho^-_{j,\sigma,1}}\cdots
-        A^{\rho^-_{j,\sigma,M-L_0}}
-        =
-        A^jY_{M+1-L_0}(\rho^-_{j,\sigma})
+        \operatorname{Res}^{\tau^-_j(\mu)}_{M+1-L_0,L_0+1}(\psi).
     \]
-    come from
-    Lemma~\ref{lem:closure_property_boundary_crossing_equations_ground_space_map}.
-    What remains is to choose the two boundary conditions so that their
-    complementary sites equal $\mu$ and their products after multiplication by
-    $A^jA^\sigma$ agree.  For any such boundary condition $\rho$, the
-    closing-boundary product equation available from the adjacent restrictions is
-    \[
-        Y_{M+1-L_0}(\rho)
-        A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}
-        =
-        A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho),
-    \]
-    so the unresolved point is the choice of $\rho^+_{j,\sigma}$ and
-    $\rho^-_{j,\sigma}$ that converts this equation into the displayed product
-    with right factor $A^jA^\sigma$.
+    The displayed equality is the closing-boundary restriction equality
+    discussed in \cite[lines~2078--2090]{Cirac2021Matrix}.
+    % Remaining gap recorded in docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
 \begin{lemma}[Boundary-closing word equation for the closure property]


### PR DESCRIPTION
## Summary

This PR adds the formalized reduction
[
  left(orall j,
  operatorname{Res}^{	au^+_j(mu)}_{M,L_0+1}(psi)
  =
  operatorname{Res}^{	au^-_j(mu)}_{M+1-L_0,L_0+1}(psi)ight)
  Longrightarrow
  xistsho^+_{j,sigma},ho^-_{j,sigma},
  Y_M(ho^+_{j,sigma})A^jA^sigma
  =
  Y_{M+1-L_0}(ho^-_{j,sigma})A^jA^sigma .
]
The proof chooses the two boundary conditions with outside letter `j` and complementary word `mu`, restricts the equality at first letter `j`, applies `L_0`-block injectivity, and then multiplies on the right by `A^sigma`.

The blueprint now records this implication as a separate equation-led lemma and rewrites the older open auxiliary-product sketch so that the remaining assertion is exactly the closing-boundary restriction equality. This PR does not close #2405.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean`
- `git diff --check`
- `leanblueprint web`

Global `blueprint_lean_sync.py --ci` and `lake exe checkdecls blueprint/lean_decls` still report pre-existing missing declarations outside this branch; the changed-declaration coverage check above is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions and blueprint restructuring in the parent-Hamiltonian closure argument; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **formalized reduction** in `BoundaryClosing.lean`: if, for every physical letter `j`, the wrapped and mirror closing-boundary length-\((L_0+1)\) cyclic restrictions agree, then boundary assignments built from `wrappedMiddleBackground` / `mirrorMiddleBackground` satisfy the auxiliary product \(Y_M(\rho^+) A^j A^\sigma = Y_{M+1-L_0}(\rho^-) A^j A^\sigma\). The proof uses complement identities, first-letter restriction, and \(L_0\)-block injectivity of `groundSpaceMap`, then multiplies by `evalWord`.
> 
> The blueprint gains a matching lemma (`lem:closure_property_auxiliary_product_from_closing_restrictions`) with a full proof, and the still-open auxiliary boundary-assignment lemma is **rewritten** so its remaining obligation is exactly the closing-boundary restriction equality (Cirac et al. lines 2078–2090), not the older boundary-crossing product sketch. The top-level `closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap` remains `sorry` / `\notready`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd3c892a52303d95bbf6f3f76da62e0226db0ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->