### PR TITLE
feat(parent): add long closing-boundary product

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -470,6 +470,79 @@ theorem closure_property_boundary_condition_product_of_window_witnesses
     rw [hsum, Nat.mod_eq_of_lt (by omega)]
   simpa [Y, hstart, hend] using hprod
 
+/-- Product equation obtained by moving from the last site through the closing
+boundary to the opposite boundary-crossing support.
+
+For a fixed boundary condition \(\rho\), the window matrices satisfy
+\[
+  Y_M(\rho)A^{\rho_M}A^{\rho_0}\cdots A^{\rho_{M-L_0}}
+  =
+  A^{\rho_{L_0}}\cdots A^{\rho_M}A^{\rho_0}Y_{M+1-L_0}(\rho),
+\]
+with the products read cyclically and with \(M+2-L_0\) one-site factors on
+each side.  This is another fixed-boundary-condition product extracted from the
+adjacent closing-boundary restrictions in arXiv:2011.12127, Section IV.C,
+lines 2078--2090. -/
+lemma closure_property_boundary_condition_long_product_of_window_witnesses
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (ρ : Fin (M + 1) → Fin d) :
+    YAt ⟨M, by omega⟩ ρ *
+        evalWord A (List.ofFn (fun r : Fin (M + 2 - L₀) =>
+          ρ ⟨(M + r.val) % (M + 1), Nat.mod_lt _ (by omega)⟩)) =
+      evalWord A (List.ofFn (fun r : Fin (M + 2 - L₀) =>
+          ρ ⟨(L₀ + r.val) % (M + 1), Nat.mod_lt _ (by omega)⟩)) *
+        YAt ⟨M + 1 - L₀, by omega⟩ ρ := by
+  let i₀ : Fin (M + 1) := ⟨M, by omega⟩
+  let Y : Fin ((M + 2 - L₀) + 1) → Matrix (Fin D) (Fin D) ℂ :=
+    fun r => YAt (cyclicForwardSite i₀ r.val) ρ
+  have hY : ∀ r : Fin ((M + 2 - L₀) + 1),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (cyclicForwardSite i₀ r.val) ρ ψ =
+        groundSpaceMap A (L₀ + 1) (Y r) := by
+    intro r
+    exact hYAt (cyclicForwardSite i₀ r.val) ρ
+  have hprod := adjacent_cyclicRestrictₗ_witness_product_common_background_named
+    (A := A) hInj (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+    i₀ ρ ψ Y
+    (fun r : Fin (M + 2 - L₀) =>
+      ρ ⟨(M + r.val) % (M + 1), Nat.mod_lt _ (by omega)⟩)
+    (fun r : Fin (M + 2 - L₀) =>
+      ρ ⟨(L₀ + r.val) % (M + 1), Nat.mod_lt _ (by omega)⟩)
+    hY ?_ ?_
+  · have hstart : cyclicForwardSite i₀ 0 = ⟨M, by omega⟩ := by
+      ext
+      simp only [i₀, cyclicForwardSite, Fin.val_mk]
+      exact Nat.mod_eq_of_lt (by omega)
+    have hend : cyclicForwardSite i₀ (M + 2 - L₀) =
+        ⟨M + 1 - L₀, by omega⟩ := by
+      ext
+      simp only [i₀, cyclicForwardSite, Fin.val_mk]
+      have hsum : M + (M + 2 - L₀) = M + 1 + (M + 1 - L₀) := by omega
+      rw [hsum, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
+    simpa [Y, hstart, hend] using hprod
+  · ext r
+    have hsite : cyclicForwardSite i₀ r.val =
+        ⟨(M + r.val) % (M + 1), Nat.mod_lt _ (by omega)⟩ := by
+      ext
+      simp only [i₀, cyclicForwardSite, Fin.val_mk]
+    rw [hsite]
+  · ext r
+    have hsite : cyclicForwardSite (cyclicForwardSite i₀ r.val) (L₀ + 1) =
+        ⟨(L₀ + r.val) % (M + 1), Nat.mod_lt _ (by omega)⟩ := by
+      rw [cyclicForwardSite_forwardSite]
+      ext
+      simp only [i₀, cyclicForwardSite, Fin.val_mk]
+      have hsum : M + (r.val + (L₀ + 1)) = M + 1 + (L₀ + r.val) := by omega
+      rw [hsum, Nat.add_mod_left]
+    rw [hsite]
+
 /-- Auxiliary boundary-condition product obtained from equality of the two
 closing-boundary restrictions.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1323,6 +1323,49 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     product equation.
 \end{proof}
 
+\begin{lemma}[Long boundary-condition product at the closing boundary]
+    \label{lem:closure_property_boundary_condition_long_product_window_witnesses}
+    \lean{MPSTensor.closure_property_boundary_condition_long_product_of_window_witnesses}
+    \leanok
+    \uses{rem:cyclic_window_operators, lem:cyclic_window_boundary_matrix_transport}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$. Let
+    $\psi$ be a state on the chain of length $M+1$, and suppose matrices
+    $Y_i(\rho)$ represent the length-$(L_0+1)$ cyclic restrictions
+    \[
+        \operatorname{Res}^{\rho}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\rho)).
+    \]
+    Then, for every boundary condition $\rho$,
+    \[
+        Y_M(\rho)A^{\rho_M}A^{\rho_0}\cdots A^{\rho_{M-L_0}}
+        =
+        A^{\rho_{L_0}}\cdots A^{\rho_M}A^{\rho_0}
+        Y_{M+1-L_0}(\rho).
+    \]
+    Each side has $M+2-L_0$ one-site factors, with site labels read modulo
+    $M+1$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply Lemma~\ref{lem:cyclic_window_boundary_matrix_transport} to the
+    $M+2-L_0$ restrictions beginning at $M+r$ modulo $M+1$. With $i_0=M$, the
+    site labels satisfy
+    \[
+        i_0+r\equiv M+r,
+        \qquad
+        i_0+r+L_0+1\equiv L_0+r
+        \pmod {M+1}.
+    \]
+    The final window is
+    \[
+        i_0+M+2-L_0\equiv M+1-L_0 \pmod {M+1}.
+    \]
+    Substituting these site labels in the iterated product identity gives the
+    displayed equation.
+\end{proof}
+
 \begin{lemma}[One matrix $Y_\mu$ from compared boundary matrices]%
     \label{lem:two_sided_middle_of_wrapped_witness_comparison}
     \lean{MPSTensor.two_sided_middle_compatibility_of_wrapped_witness_comparison}


### PR DESCRIPTION
## Summary

This PR adds the no-`sorry` long product obtained by iterating the adjacent cyclic-window equations from the last site through the closing boundary:

```tex
Y_M(\rho)A^{\rho_M}A^{\rho_0}\cdots A^{\rho_{M-L_0}}
=
A^{\rho_{L_0}}\cdots A^{\rho_M}A^{\rho_0}Y_{M+1-L_0}(\rho).
```

The proof is a direct specialization of the existing adjacent-window product theorem with initial site `M` and length `M+2-L_0`. The blueprint records the same equation and the modular site identities

```tex
i_0+r\equiv M+r,
\qquad
i_0+r+L_0+1\equiv L_0+r \pmod {M+1},
\qquad
i_0+M+2-L_0\equiv M+1-L_0 \pmod {M+1}.
```

This advances the fixed-boundary equations around the closing boundary, but it does not close #2405; the remaining assertion is still the equality of the two closing-boundary restrictions.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `leanblueprint web`

`leanblueprint web` exits successfully locally, with the same local plasTeX package and bibliography warnings seen on the previous PR.