### PR TITLE
doc(mpdo): scope two over-broad Appendix C / Section 4.5 citations

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -845,12 +845,14 @@ strong subadditivity for a normalized three-site reduced state.
 
 \section{Fusion isometries}
 
-Following \cite[Section~4.5]{Cirac2016MPDO_arXiv}, the next definitions describe
-the transfer-map content of the fusion-isometry picture.
-For each blocked size $n \ge 1$, the doubled-index blocked tensor of an MPO
-has a blocked transfer map $E_n$ acting on bond-space matrices, and the
-support algebra is modeled by a subspace through which $E_n$ factors as a
-retract.
+The next definitions isolate the transfer-map content underlying the
+fusion-isometry picture of \cite[Section~4.5]{Cirac2016MPDO_arXiv}: they record
+when the blocked transfer map factors through its support algebra as a retract,
+which is the idempotence criterion, not the physical fusion isometry of two
+tensors into one. For each blocked size $n \ge 1$, the doubled-index blocked
+tensor of an MPO has a blocked transfer map $E_n$ acting on bond-space matrices,
+and the support algebra is modeled by a subspace through which $E_n$ factors as
+a retract.
 
 \begin{definition}[Transfer-map fusion-isometry datum]%
     \label{def:mpdo_fusion_isometry}
@@ -2486,7 +2488,10 @@ the elementary trace-power identity for diagonal matrices.
     The $\eta$-local structure itself determines a commuting-form witness for every
     chain length $N \ge 2$. In particular, the translated nearest-neighbor
     bonds commute and the MPDO at length $N$ is a positive scalar multiple of
-    their product, as in \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}.
+    their product. This is the commuting-form half of
+    \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}, taking the $\eta$-local data as
+    given; deriving that data from the saturation of the area law is the
+    deferred step recorded in Remark~\ref{rem:simple_mpdo_rfp_chain_gap}.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Summary

Addresses two citation-framing defects flagged by the vacuous-proof / faithfulness audit (#2385, Group B), where a blueprint entry cites an arXiv:1606.00608 result for a Lean statement that proves only a *downstream fragment* of it. **No `\leanok`/`\lean{}` changes** — both statements remain formalized exactly as stated; only the source attribution is narrowed to what the Lean actually establishes.

## Changes (blueprint prose only)

1. **Fusion isometries section intro.** Was: "Following [Section 4.5] … the next definitions describe the transfer-map content of the fusion-isometry picture." The formalized `FusionIsometryData` records only when the blocked transfer map factors through its support algebra as a retract (the idempotence criterion), not the physical fusion isometry of two tensors into one. Reworded to attribute only the retract content to Section 4.5.

2. **`thm:mpdo_eta_local_structure_has_commuting_form`.** Cited "Proposition C.8" while *assuming* the η-local structure as a hypothesis. Proposition C.8's actual substance is *deriving* that structure from the saturation of the area law. Reworded to "the commuting-form half of Proposition C.8, taking the η-local data as given", and cross-referenced the existing `\notready` gap remark `rem:simple_mpdo_rfp_chain_gap` that records the SAL→structure derivation as deferred.

## Audit items not requiring changes (verified already disclosed)

- **`CommutingFormData` / `GSNNCHData`** (item 2): the SAL→commuting-form gap is already disclosed by `rem:simple_mpdo_rfp_chain_gap` (`\notready`).
- **`HorizontalCFData.biCF` / `blockwise_insert_eq_of_mpv_agree`** (item 3): the lemma is a faithful, fully-proven statement; `IsHorizontalCF` and the downstream vertical-CF theorem are already `\notready`.
- **`BNTLabelTheoremWitness` / `BNTBlockedBasisLabelAssignment`** (item 5): the entry prose already states it records only definitional content, "the construction of such a witness from an MPDO tensor is the outstanding step toward Theorem IV.13(ii)".
- **`IsPRFP`** (item 1): resolved by #2420 (faithful replacement).

## Verification

- Blueprint-only; no Lean changes. Cross-reference `\ref{rem:simple_mpdo_rfp_chain_gap}` resolves (label at ch02b_mpdo.tex:2871). No `\leanok`/`\lean{}`/`\cite` keys removed, so `checkdecls` is unaffected.

Part of #2385.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only attribution fixes in the blueprint; no Lean, APIs, or runtime behavior changes.
> 
> **Overview**
> Blueprint-only prose in `ch02b_mpdo.tex` narrows two Cirac2016 citations so they match what Lean actually proves—no `\leanok`/`\lean{}` or formal statements change.
> 
> The **Fusion isometries** intro now states that the formalized `FusionIsometryData` is the **transfer-map retract / idempotence** content tied to Section 4.5, explicitly **not** the physical fusion isometry merging two tensors.
> 
> **`thm:mpdo_eta_local_structure_has_commuting_form`** is described as only the **commuting-form half** of Proposition C.8 when η-local data is **assumed**, with the SAL→η-local derivation deferred and pointed to **`rem:simple_mpdo_rfp_chain_gap`** (`\notready`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995a76eae5732dd3d639d460325b99f2afd53e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->