### PR TITLE
feat(Analysis): von Neumann entropy is invariant under reindexing

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -85,6 +85,35 @@ noncomputable def vonNeumannEntropy
     (ρ : Matrix n n ℂ) (hρ : ρ.IsHermitian) : ℝ :=
   ∑ i, negMulLog (hρ.eigenvalues i)
 
+/-- The von Neumann entropy depends only on the characteristic polynomial: it is
+the `negMulLog`-sum of the (real parts of the) roots of `charpoly`. -/
+theorem vonNeumannEntropy_eq_charpoly_roots (ρ : Matrix n n ℂ) (hρ : ρ.IsHermitian) :
+    vonNeumannEntropy ρ hρ
+      = (ρ.charpoly.roots.map (fun z : ℂ => negMulLog z.re)).sum := by
+  rw [vonNeumannEntropy]
+  have hmap : (Finset.univ : Finset n).val.map hρ.eigenvalues
+      = ρ.charpoly.roots.map Complex.re := by
+    rw [hρ.roots_charpoly_eq_eigenvalues, Multiset.map_map]
+    exact Multiset.map_congr rfl fun x _ => by simp
+  calc ∑ i, negMulLog (hρ.eigenvalues i)
+      = (((Finset.univ : Finset n).val.map hρ.eigenvalues).map negMulLog).sum := by
+        rw [Multiset.map_map]; rfl
+    _ = ((ρ.charpoly.roots.map Complex.re).map negMulLog).sum := by rw [hmap]
+    _ = (ρ.charpoly.roots.map (fun z : ℂ => negMulLog z.re)).sum := by
+        rw [Multiset.map_map]; rfl
+
+variable {m : Type*} [Fintype m] [DecidableEq m]
+
+/-- Von Neumann entropy is invariant under reindexing a matrix by an
+equivalence of its index type (the spectrum is unchanged). -/
+theorem vonNeumannEntropy_submatrix_equiv (e : m ≃ n) (ρ : Matrix n n ℂ)
+    (hρ : ρ.IsHermitian) :
+    vonNeumannEntropy (ρ.submatrix e e) ((isHermitian_submatrix_equiv e).mpr hρ)
+      = vonNeumannEntropy ρ hρ := by
+  rw [vonNeumannEntropy_eq_charpoly_roots, vonNeumannEntropy_eq_charpoly_roots]
+  have hre : ρ.submatrix e e = reindex e.symm e.symm ρ := rfl
+  rw [hre, charpoly_reindex]
+
 end VonNeumannEntropy
 
 /-! ### Basic properties for density matrices -/

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -72,21 +72,45 @@ finite-dimensional quantum systems.
     \uses{lem:density_eigenvalues_sum, thm:density_eigenvalues_le_one}
 \end{proof}
 
+\begin{lemma}[Entropy from characteristic polynomial roots]
+    \label{lem:entropy_charpoly_roots}
+    \lean{vonNeumannEntropy_eq_charpoly_roots}
+    \leanok
+    \uses{def:von_neumann_entropy}
+    The von Neumann entropy of a Hermitian matrix is the $-x\log x$ sum over the
+    real parts of the roots of its characteristic polynomial $\chi_\rho$:
+    \[
+        S(\rho) = \sum_{\lambda \in \mathrm{roots}(\chi_\rho)}
+            \bigl({-}\operatorname{Re}(\lambda)\, \log \operatorname{Re}(\lambda)\bigr).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The eigenvalues of a Hermitian matrix are exactly the roots of its
+    characteristic polynomial, counted with multiplicity, so the eigenvalue sum
+    defining $S(\rho)$ equals the displayed sum over roots.
+\end{proof}
+
 \begin{theorem}[Entropy is invariant under reindexing]
     \label{thm:entropy_submatrix_equiv}
     \lean{vonNeumannEntropy_submatrix_equiv}
     \leanok
-    \uses{def:von_neumann_entropy}
-    For a Hermitian matrix $\rho$ and a bijection $e$ of its index set, the
-    reindexed matrix with entries $\rho_{e(i)\,e(j)}$ has the same von Neumann
-    entropy as $\rho$.
+    \uses{def:von_neumann_entropy, lem:entropy_charpoly_roots}
+    Let $\rho$ be a Hermitian matrix indexed by a finite set $J$, and let
+    $e : I \to J$ be a bijection from a finite set $I$. The reindexed matrix on
+    $I$ with entries $\rho_{e(i)\,e(j)}$ has the same von Neumann entropy as
+    $\rho$.
 \end{theorem}
 
 \begin{proof}\leanok
-    The von Neumann entropy is the $-x\log x$ sum over the roots of the
-    characteristic polynomial. Reindexing by a bijection conjugates $\rho$ by a
-    permutation matrix, which leaves the characteristic polynomial unchanged, and
-    hence leaves the spectrum and the entropy unchanged.
+    \uses{lem:entropy_charpoly_roots}
+    By Lemma~\ref{lem:entropy_charpoly_roots} the entropy depends only on the
+    characteristic polynomial. Reindexing conjugates $\rho$ by a permutation
+    matrix, so
+    \[
+        \chi_{(\rho_{e(i)\,e(j)})} = \chi_\rho,
+    \]
+    and the entropies coincide.
 \end{proof}
 
 \section{Tripartite partial traces}

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -72,6 +72,23 @@ finite-dimensional quantum systems.
     \uses{lem:density_eigenvalues_sum, thm:density_eigenvalues_le_one}
 \end{proof}
 
+\begin{theorem}[Entropy is invariant under reindexing]
+    \label{thm:entropy_submatrix_equiv}
+    \lean{vonNeumannEntropy_submatrix_equiv}
+    \leanok
+    \uses{def:von_neumann_entropy}
+    For a Hermitian matrix $\rho$ and a bijection $e$ of its index set, the
+    reindexed matrix with entries $\rho_{e(i)\,e(j)}$ has the same von Neumann
+    entropy as $\rho$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The von Neumann entropy is the $-x\log x$ sum over the roots of the
+    characteristic polynomial. Reindexing by a bijection conjugates $\rho$ by a
+    permutation matrix, which leaves the characteristic polynomial unchanged, and
+    hence leaves the spectrum and the entropy unchanged.
+\end{proof}
+
 \section{Tripartite partial traces}
 
 \begin{definition}[Partial trace over $A$]\label{def:traceA_ABC}


### PR DESCRIPTION
## Summary

Two reusable spectral lemmas in `TNLean/Analysis/Entropy.lean`, foundational for applying the (product-typed) strong-subadditivity axiom to the function-indexed reduced states of the SAL development.

- **`vonNeumannEntropy_eq_charpoly_roots`** — `S(ρ) = (ρ.charpoly.roots.map (z ↦ negMulLog z.re)).sum`. The entropy depends only on the characteristic polynomial (via Mathlib's `IsHermitian.roots_charpoly_eq_eigenvalues`).
- **`vonNeumannEntropy_submatrix_equiv`** — for `e : m ≃ n`, `S(ρ.submatrix e e) = S(ρ)`. Reindexing conjugates by a permutation matrix, preserving `charpoly` (`Matrix.charpoly_reindex`), hence the spectrum and the entropy.

Blueprint: `thm:entropy_submatrix_equiv` added to ch04b (with `\leanok`).

## Why

The axiomatized strong subadditivity (`strong_subadditivity` in `TNLean/Axioms/Entropy.lean`) is stated on a product index `Fin dA × Fin dB × Fin dC`, but the SAL reduced states (`MPOTensor.blockEntropy`, `reducedBlockState`) live on function indices `Fin L → Fin d`. Casting between the two requires `vonNeumannEntropy` to be invariant under the connecting `Equiv` — this PR supplies that step. Prerequisite for **#2424** (Proposition 4.5, mutual-information monotonicity `I_L ≤ I_{L+1}`).

## Verification

- `lake build TNLean.Analysis.Entropy` green; both lemmas `sorry`/`axiom`-free.
- Only additions to the `VonNeumannEntropy` section; no existing declarations changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive spectral lemmas in the entropy module with no changes to axioms, partial traces, or existing APIs.
> 
> **Overview**
> Adds two proved spectral lemmas in `TNLean/Analysis/Entropy.lean` and matching blueprint entries in `ch04b_entropy.tex`.
> 
> **`vonNeumannEntropy_eq_charpoly_roots`** rewrites von Neumann entropy as a `negMulLog` sum over the real parts of `charpoly` roots, using Mathlib’s link between Hermitian eigenvalues and characteristic roots.
> 
> **`vonNeumannEntropy_submatrix_equiv`** shows entropy is unchanged when a Hermitian matrix is reindexed via `ρ.submatrix e e` for `e : m ≃ n`, by reducing both sides to the charpoly-root formula and applying `charpoly_reindex`.
> 
> These are additive only; no existing declarations are modified. They support casting between product-typed SSA statements and function-indexed SAL reduced states (e.g. upcoming mutual-information monotonicity work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f882735b26522b04c129d815d41e01da4b24d684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->