### PR TITLE
feat(parent): reduce closed-boundary restriction to right products

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -568,16 +568,20 @@ lemma closure_property_boundary_restriction_eq_of_first_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)}
-    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
-      Matrix (Fin D) (Fin D) ℂ)
-    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
-      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
-        groundSpaceMap A (L₀ + 1) (YAt i τ))
     (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (YPlus YMinus : Matrix (Fin D) (Fin D) ℂ)
+    (hPlus :
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+        groundSpaceMap A (L₀ + 1) YPlus)
+    (hMinus :
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) η μ) ψ =
+        groundSpaceMap A (L₀ + 1) YMinus)
     (hProd : ∀ j : Fin d,
-      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j =
-        YAt ⟨M + 1 - L₀, by omega⟩
-          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j) :
+      YPlus * A j = YMinus * A j) :
     cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
         (⟨M, by omega⟩ : Fin (M + 1))
         (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
@@ -598,13 +602,12 @@ lemma closure_property_boundary_restriction_eq_of_first_products
     (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
     (⟨M, by omega⟩ : Fin (M + 1))
     (wrappedMiddleBackground L₀ (M + 1) η μ) ψ
-    (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ)) j
+    hPlus j
   have hright := cyclicRestrictₗ_restrictFirst_groundSpaceMap
     (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
     (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
     (mirrorMiddleBackground L₀ (M + 1) η μ) ψ
-    (hYAt ⟨M + 1 - L₀, by omega⟩
-      (mirrorMiddleBackground L₀ (M + 1) η μ)) j
+    hMinus j
   exact hleft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) (hProd j)).trans hright.symm)
 
 /-- Auxiliary boundary-condition product obtained from equality of the two

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -326,8 +326,9 @@ boundary condition \(\tau\),
   X A^j A^{\tau_1\cdots\tau_{M-L_0}} = A^j Y_{M+1-L_0}(\tau).
 \]
 
-This is the one-sided part of the closure-property argument in
-arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
+These are the one-sided equations obtained from the inverting and growing-back
+argument described in arXiv:2011.12127, Section IV.C, lines 2078--2090, when
+the boundary is closed. -/
 theorem closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -376,8 +377,9 @@ Thus the iterated product equation is
 \]
 For \(L_0=1\) both products are empty.
 
-This is the product form of the closure-property step in arXiv:2011.12127,
-Section IV.C, lines 2078--2090. -/
+This records one adjacent-window product identity used in the coordinate proof
+of the closure property described in arXiv:2011.12127, Section IV.C,
+lines 2078--2090. -/
 theorem boundary_closing_endpoint_word_products_common_background
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -431,8 +433,9 @@ For a fixed boundary condition \(\rho\), the window matrices satisfy
 \]
 For \(L_0=1\), both word products are empty.
 
-This is the fixed-boundary-condition product isolated from the
-closure-property step in arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
+This records the fixed-boundary-condition product obtained from adjacent
+windows in the coordinate proof of the closure property described in
+arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
 theorem closure_property_boundary_condition_product_of_window_witnesses
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -480,8 +483,8 @@ For a fixed boundary condition \(\rho\), the window matrices satisfy
   A^{\rho_{L_0}}\cdots A^{\rho_M}A^{\rho_0}Y_{M+1-L_0}(\rho),
 \]
 with the products read cyclically and with \(M+2-L_0\) one-site factors on
-each side.  This is another fixed-boundary-condition product extracted from the
-adjacent closing-boundary restrictions in arXiv:2011.12127, Section IV.C,
+each side.  This is an adjacent-window product used to reconstruct the closure
+property described in arXiv:2011.12127, Section IV.C,
 lines 2078--2090. -/
 lemma closure_property_boundary_condition_long_product_of_window_witnesses
     {A : MPSTensor d D} {L₀ M : ℕ}
@@ -543,6 +546,67 @@ lemma closure_property_boundary_condition_long_product_of_window_witnesses
       rw [hsum, Nat.add_mod_left]
     rw [hsite]
 
+/-- Right-products determine the two restrictions at the closed boundary.
+
+Suppose the two length-\((L_0+1)\) restrictions at the closed boundary are
+represented by \(Y_M(\tau^+_\eta(\mu))\) and
+\(Y_{M+1-L_0}(\tau^-_\eta(\mu))\).  If, for every physical letter \(j\),
+\[
+  Y_M(\tau^+_\eta(\mu))A^j
+  =
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j,
+\]
+then the restrictions themselves agree:
+\[
+  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+  =
+  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+\]
+This is a consequence of first-letter restrictions; it does not assert that the
+displayed right-product equality is already known. -/
+lemma closure_property_boundary_restriction_eq_of_first_products
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hProd : ∀ j : Fin d,
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j =
+        YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M, by omega⟩ : Fin (M + 1))
+        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+  apply eq_of_forall_restrictFirst_eq
+  intro j
+  rw [cyclicRestrictₗ_restrictFirst
+      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M, by omega⟩ : Fin (M + 1))
+      (wrappedMiddleBackground L₀ (M + 1) η μ) ψ j]
+  rw [cyclicRestrictₗ_restrictFirst
+      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+      (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
+  have hleft := cyclicRestrictₗ_restrictFirst_groundSpaceMap
+    (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+    (⟨M, by omega⟩ : Fin (M + 1))
+    (wrappedMiddleBackground L₀ (M + 1) η μ) ψ
+    (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ)) j
+  have hright := cyclicRestrictₗ_restrictFirst_groundSpaceMap
+    (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+    (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+    (mirrorMiddleBackground L₀ (M + 1) η μ) ψ
+    (hYAt ⟨M + 1 - L₀, by omega⟩
+      (mirrorMiddleBackground L₀ (M + 1) η μ)) j
+  exact hleft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) (hProd j)).trans hright.symm)
+
 /-- Auxiliary boundary-condition product obtained from equality of the two
 closing-boundary restrictions.
 
@@ -560,10 +624,10 @@ Then there are boundary conditions with the same complementary word and with
   =
   Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
 \]
-This isolates the remaining closure-property step as the closing-boundary
-restriction equality recorded in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`, following
-arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
+The source says that the same inverting and growing-back argument may be used
+when closing the boundary.  In coordinates, the remaining comparison is the
+displayed restriction equality; it is recorded in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -657,9 +721,11 @@ word \(\mu\) as the two canonical assignments, and satisfying
   Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
 \]
 
-**Open gap:** This is the remaining closure-property equation from
-arXiv:2011.12127, Section IV.C, lines 2078--2090.  It is documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked in #2405. -/
+**Open gap:** The source does not display this auxiliary equation.  It says that
+the inverting and growing-back argument can be applied when closing the
+boundary.  The remaining obligation here is the displayed product equation,
+which is documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and
+tracked in #2405. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -825,10 +825,19 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
       cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
         ⟨M + 1 - L₀, by omega⟩
         (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
-  exact closure_property_boundary_restriction_eq_of_fixed_boundary_letters
-    hL₀ hM η μ fun j =>
-      closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
-        (A := A) hInj hL₀ hM hψ hψX η μ j
+  obtain ⟨YAt, hYAt⟩ :=
+    chainGroundSpace_window_witnesses A (show 0 < M + 1 by omega)
+      (show L₀ + 1 ≤ M + 1 by omega) hψ
+  refine closure_property_boundary_restriction_eq_of_first_products
+    (A := A) hL₀ hM η μ
+    (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+    (YAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) η μ))
+    (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+    (hYAt ⟨M + 1 - L₀, by omega⟩
+      (mirrorMiddleBackground L₀ (M + 1) η μ)) ?_
+  exact closure_property_boundary_tensor_products_eq_of_chainGroundSpace
+    (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ
+
 /-- The two boundary-condition matrix families agree once their right-products
 with every \(A^j\) agree:
 \(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -646,23 +646,10 @@ theorem chainGroundSpace_le_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_c
     (A := A) (L₀ := L₀) (N := N) hInj hL₀ η Ywrap Ymirror hWrap hMirror hCompare'
 
 /-- Right-products with all one-site tensors determine the compared boundary
-conditions.
-
-This is the final algebraic reduction of the closure-property comparison from
-arXiv:2011.12127, Section IV.C, lines 2078--2090.  The input is
-\[
-  Y^+_{\tau^+_\eta(\mu)} A^j
-  =
-  Y^-_{\tau^-_\eta(\mu)} A^j
-\]
-for every letter \(j\).  Since block-injectivity gives
-\[
-  \operatorname{span}\{A^w: |w|=L₀\}=M_D(\mathbb C),
-\]
-this implies
-\[
-  Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}.
-\] -/
+conditions.  If
+\(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j\) for every \(j\), then
+block-injectivity gives
+\(Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\). -/
 theorem wrapped_mirror_witness_agree_of_right_products
     {A : MPSTensor d D} {L₀ N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -675,10 +662,11 @@ theorem wrapped_mirror_witness_agree_of_right_products
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
-/-- The full boundary-closing restriction equality follows from equality after
-fixing each first physical index.  This isolates the
-closing-boundary comparison discussed in arXiv:2011.12127, Section IV.C,
-lines 2078--2090. -/
+/-- The full restriction equality at the closed boundary follows from equality
+after fixing each first physical index:
+\((\forall j,\ R_jB^+_{\eta,\mu}=R_jB^-_{\eta,\mu})
+\Rightarrow B^+_{\eta,\mu}=B^-_{\eta,\mu}\).  This is a coordinate form of
+the comparison described in arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
 theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
     {L₀ M : ℕ} (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)}
@@ -711,11 +699,15 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
       (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
   exact hfixed j
 
-/-- Boundary-closing word equation for the closure property, arXiv:2011.12127,
-Section IV.C, lines 2078--2090: the two closing-boundary conditions agree after appending
-\(A^jA^\sigma\).  **Open gap:** Relies on the auxiliary product equation in
-`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`; documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.  Elimination: prove it; #2405. -/
+/-- Product equality needed after closing the boundary:
+\[
+  Y_M(\tau^+_\eta(\mu))A^jA^\sigma
+  =
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma .
+\]
+**Open gap:** This follows from the auxiliary product equation in
+`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -740,10 +732,10 @@ theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
   exact boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments
     (A := A) hInj hL₀ hM YAt hYAt η μ ρPlus ρMinus hρPlus hρMinus hProductEq
 
-/-- Matrix form of the closure property, arXiv:2011.12127, lines 2078--2090.
-It follows from the boundary-closing word equation and block injectivity.
-
-**Open gap:** Inherits the unproved boundary-closing word equation above; see
+/-- Matrix equality obtained from the product equality and block injectivity:
+\(Y_M(\tau^+_\eta(\mu))A^j
+=Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\).
+**Open gap:** Inherits the unproved product equality above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -779,11 +771,9 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
       (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
   exact sub_eq_zero.mp hsub
 
-/-- Auxiliary first-letter form of the closure property of arXiv:2011.12127,
-lines 2078--2090. It follows by restricting the displayed matrix equation at
-the first physical index.
-
-**Open gap:** Inherits the unproved boundary-closing word equation above; see
+/-- First-letter restriction equality \(R_jB^+_{\eta,\mu}=R_jB^-_{\eta,\mu}\),
+obtained by restricting the displayed matrix equation at the first physical
+index.  **Open gap:** Inherits the unproved product equality above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -818,10 +808,9 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ j
   exact hLeft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) hProd).trans hRight.symm)
 
-/-- Restriction form of the closure property of arXiv:2011.12127,
-lines 2078--2090, obtained from the first-letter family.
-
-**Open gap:** Inherits the unproved boundary-closing word equation above; see
+/-- Restriction equality \(B^+_{\eta,\mu}=B^-_{\eta,\mu}\) at the closed
+boundary, obtained from the first-letter family.  **Open gap:** Inherits the
+unproved product equality above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -840,10 +829,11 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     hL₀ hM η μ fun j =>
       closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
         (A := A) hInj hL₀ hM hψ hψX η μ j
-/-- The two boundary-condition matrix families agree in the closure property,
-reduced to the \(Y A^j\) equation above.
-
-**Open gap:** Inherits the unproved boundary-closing word equation; see
+/-- The two boundary-condition matrix families agree once their right-products
+with every \(A^j\) agree:
+\(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j
+\Rightarrow Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
+**Open gap:** Inherits the unproved product equality at the closed boundary; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
@@ -885,11 +875,11 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
   exact closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     (A := A) hInj hL₀ (by omega : L₀ ≤ M) hψred hψX YAt hYAt η μ j
 
-/-- Closure-property containment step:
-\(\mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A)\) for \(L>L₀\).  This is
-the closure-property step of arXiv:2011.12127.
-
-**Open gap:** Depends on the closure-property boundary-condition comparison; see
+/-- Closure-property containment
+\(\mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A)\) for \(L>L₀\).  The
+source obtains this from the intersection property and closure property in
+arXiv:2011.12127, Section IV.C, lines 2078--2090.
+**Open gap:** Depends on the comparison at the closed boundary; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1993,7 +1993,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \qquad
         \Gamma_{L_0}(Y^-_{\eta,\mu}A^j).
     \]
-    The right-product equality identifies them for every $j$, and
+    The right-product equality gives, for every $j$,
+    \[
+        \Gamma_{L_0}(Y^+_{\eta,\mu}A^j)
+        =
+        \Gamma_{L_0}(Y^-_{\eta,\mu}A^j).
+    \]
     Lemma~\ref{lem:first_letter_restrictions_determine} identifies the two
     original restrictions.
 \end{proof}
@@ -2003,8 +2008,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_chainGroundSpace}
     \leanok
     \uses{def:chain_ground_space, rem:cyclic_window_operators,
-        lem:wrapped_middle_backgrounds, lem:boundary_restriction_from_fixed_letters,
-        lem:closure_property_fixed_boundary_letter_chain_ground_space}
+        lem:chain_ground_space_window_witnesses,
+        lem:closed_boundary_restriction_from_right_products,
+        lem:boundary_closing_boundary_tensor_products_chain_ground_space}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
     $L_0\le M$, and let
     \[
@@ -2024,40 +2030,27 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    For each first letter $j$, the first-letter assertion gives
+    The window-witness lemma gives matrices
+    \(Y_M(\tau^+_\eta(\mu))\) and
+    \(Y_{M+1-L_0}(\tau^-_\eta(\mu))\) such that
     \[
-        \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
+        \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =
-        \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi).
-    \]
-    The definitions of the first-letter backgrounds identify these two sides
-    with the first-letter restrictions
-    \[
-    \begin{aligned}
-        \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
-        &=
-        \left.
-        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
-        \right|_{\sigma_1=j}, \\
-        \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi)
-        &=
-        \left.
-        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi)
-        \right|_{\sigma_1=j}.
-    \end{aligned}
-    \]
-    Hence, for every $j$,
-    \[
-        \left.
-        \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
-        \right|_{\sigma_1=j}
+        \Gamma_{L_0+1}\!\left(Y_M(\tau^+_\eta(\mu))\right),
+        \qquad
+        \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)
         =
-        \left.
-        \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi)
-        \right|_{\sigma_1=j}.
+        \Gamma_{L_0+1}\!\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))\right).
     \]
-    Lemma~\ref{lem:boundary_restriction_from_fixed_letters} then identifies the
-    two length-$(L_0+1)$ restrictions.
+    Lemma~\ref{lem:boundary_closing_boundary_tensor_products_chain_ground_space}
+    gives, for every $j$,
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
+    \]
+    Lemma~\ref{lem:closed_boundary_restriction_from_right_products} identifies
+    the two length-$(L_0+1)$ restrictions.
 \end{proof}
 
 \begin{lemma}[Auxiliary product from closing-boundary restrictions]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1959,6 +1959,45 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     equalities.
 \end{proof}
 
+\begin{lemma}[Closed-boundary restriction from right products]
+    \label{lem:closed_boundary_restriction_from_right_products}
+    \lean{MPSTensor.closure_property_boundary_restriction_eq_of_first_products}
+    \leanok
+    \uses{rem:cyclic_window_operators, lem:first_letter_restrictions_determine}
+    Let $A$ be an MPS tensor, let $L_0>0$, and let $L_0\le M$. Suppose the two
+    length-$(L_0+1)$ restrictions at the closed boundary are represented by
+    boundary matrices $Y^+_{\eta,\mu}$ and $Y^-_{\eta,\mu}$:
+    \[
+        B^+_{\eta,\mu}(\psi)=\Gamma_{L_0+1}(Y^+_{\eta,\mu}),
+        \qquad
+        B^-_{\eta,\mu}(\psi)=\Gamma_{L_0+1}(Y^-_{\eta,\mu}).
+    \]
+    If, for every physical letter $j$,
+    \[
+        Y^+_{\eta,\mu}A^j
+        =
+        Y^-_{\eta,\mu}A^j,
+    \]
+    then
+    \[
+        B^+_{\eta,\mu}(\psi)=B^-_{\eta,\mu}(\psi).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Fix $j$ and take the first-letter restriction of the two displayed
+    length-$(L_0+1)$ restrictions. These are
+    \[
+        \Gamma_{L_0}(Y^+_{\eta,\mu}A^j),
+        \qquad
+        \Gamma_{L_0}(Y^-_{\eta,\mu}A^j).
+    \]
+    The right-product equality identifies them for every $j$, and
+    Lemma~\ref{lem:first_letter_restrictions_determine} identifies the two
+    original restrictions.
+\end{proof}
+
 \begin{lemma}[Restriction form of the closure property]
     \label{lem:closure_property_boundary_restriction_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_chainGroundSpace}
@@ -2169,12 +2208,13 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         \operatorname{Res}^{\tau^-_j(\mu)}_{M+1-L_0,L_0+1}(\psi).
     \]
-    The displayed equality is the closing-boundary restriction equality
-    discussed in \cite[lines~2078--2090]{Cirac2021Matrix}.
+    The displayed equality is the remaining coordinate form of the sentence on
+    closing the boundaries in
+    \cite[lines~2078--2079]{Cirac2021Matrix}.
     % Remaining gap recorded in docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
-\begin{lemma}[Boundary-closing word equation for the closure property]
+\begin{lemma}[Product equality after closing the boundary]
     \label{lem:boundary_closing_word_equation_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_closing_product_eq_of_chainGroundSpace}
     \leanok
@@ -2222,10 +2262,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^jA^\sigma,
     \]
-    which is the desired boundary-closing word equation.
+    which is the product equality needed after closing the boundary.
 \end{proof}
 
-\begin{lemma}[Matrix form of the closure property]
+\begin{lemma}[Right-product equality after closing the boundary]
     \label{lem:boundary_closing_boundary_tensor_products_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_tensor_products_eq_of_chainGroundSpace}
     \leanok
@@ -2247,8 +2287,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
     \]
-    This is the matrix equation representing the closing-boundary comparison
-    discussed in \cite[lines~2078--2090]{Cirac2021Matrix}.
+    This is the right-product equality used to compare the two boundary matrices
+    after closing the boundary.
 \end{lemma}
 
 \begin{proof}
@@ -2322,8 +2362,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y^{-}_{\tau^{-}_{\eta}(\mu)}.
     \]
-    This is the boundary-closing comparison corresponding to the closure
-    property in \cite[lines~2078--2090]{Cirac2021Matrix}.
+    This is the boundary-matrix comparison required by the closure property.
 \end{theorem}
 
 \begin{proof}
@@ -2425,8 +2464,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \qquad
         X A^j A^\mu = A^jY^-_{\tau^-_\eta(\mu)}.
     \]
-    The closing-boundary argument of
-    \cite[lines~2078--2090]{Cirac2021Matrix} supplies the equality
+    The remaining closed-boundary comparison is the equality
     \[
         Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}.
     \]


### PR DESCRIPTION
## Summary

This PR separates one proved coordinate reduction from the remaining closed-boundary comparison in the parent-Hamiltonian closure-property argument.

It adds the Lean lemma
`MPSTensor.closure_property_boundary_restriction_eq_of_first_products`, proving the implication
\[
  \bigl(\forall j,\; Y^+_{\eta,\mu}A^j=Y^-_{\eta,\mu}A^j\bigr)
  \Longrightarrow
  B^+_{\eta,\mu}(\psi)=B^-_{\eta,\mu}(\psi).
\]
Equivalently, the two length-\((L_0+1)\) restrictions at the closed boundary agree once all first-letter restrictions agree.

The blueprint and nearby docstrings are also rephrased so that arXiv:2011.12127 is cited only for its stated boundary-closing argument. The displayed product and restriction equations are now presented as coordinate reductions/remaining comparisons, not as equations explicitly displayed by the paper.

Refs #2405.

## Remaining gap

This PR does not prove the auxiliary product equality after closing the boundary. That is still the content tracked in #2405 and documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `git diff --check`
- `cd blueprint && leanblueprint web`

Known unrelated check: `lake exe checkdecls blueprint/lean_decls` still reports pre-existing missing declarations from other blueprint chapters; the changed declarations pass the local blueprint sync check above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean and blueprint documentation only; the hard auxiliary boundary product remains `sorry` and behavior of the overall argument is unchanged aside from clearer proof structure.
> 
> **Overview**
> Adds **`closure_property_boundary_restriction_eq_of_first_products`**, showing that matching right-products `Y^+_{\eta,\mu}A^j = Y^-_{\eta,\mu}A^j` for every physical letter implies equality of the two closed-boundary length-\((L_0+1)\) restrictions.
> 
> **`closure_property_boundary_restriction_eq_of_chainGroundSpace`** now goes through window witnesses and that lemma (right-product equality from the still-open gap), instead of the first-letter / fixed-boundary-letter chain.
> 
> Blueprint chapter 14 gets a matching lemma and an updated proof outline; docstrings in **`BoundaryClosing`** and **`UniqueGroundState`** reframe arXiv:2011.12127 as the boundary-closing narrative and label displayed product/restriction steps as coordinate reductions, with **#2405** unchanged for the auxiliary product.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec938c58ea5b4f4d12917e086b694d67fcef45b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->