### PR TITLE
feat(MPDO): evalWord append factorization and closed-word trace cyclicity

### DIFF
--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -100,6 +100,38 @@ lemma evalWord_ofFn (M : MPOTensor d D) {N : ℕ} (σ τ : Fin N → Fin d) :
       congr 1
       exact ih (σ ∘ Fin.succ) (τ ∘ Fin.succ)
 
+/-- `evalWord` is multiplicative under concatenation of equal-length bra/ket
+prefixes: splitting both words at the same position factors the matrix product.
+-/
+theorem evalWord_append (M : MPOTensor d D) :
+    ∀ (l₁ k₁ l₂ k₂ : List (Fin d)), l₁.length = k₁.length →
+      evalWord M (l₁ ++ l₂) (k₁ ++ k₂) = evalWord M l₁ k₁ * evalWord M l₂ k₂ := by
+  intro l₁
+  induction l₁ with
+  | nil =>
+      intro k₁ l₂ k₂ h
+      rw [List.length_nil, eq_comm, List.length_eq_zero_iff] at h
+      subst h
+      simp [evalWord]
+  | cons i is ih =>
+      intro k₁ l₂ k₂ h
+      cases k₁ with
+      | nil => simp at h
+      | cons j js =>
+          simp only [List.cons_append, evalWord_cons]
+          rw [ih js l₂ k₂ (by simpa using h), Matrix.mul_assoc]
+
+/-- **Cyclicity of the closed MPO word trace.** Moving the first bra/ket letter
+to the end of both words leaves the trace of the matrix product unchanged, since
+`tr(M^{ab} \, P) = tr(P \, M^{ab})`. This is the translation invariance of the
+periodic MPDO at the level of a single shift. -/
+theorem trace_evalWord_cons_eq_append (M : MPOTensor d D)
+    (a b : Fin d) (l k : List (Fin d)) (h : l.length = k.length) :
+    Matrix.trace (evalWord M (a :: l) (b :: k))
+      = Matrix.trace (evalWord M (l ++ [a]) (k ++ [b])) := by
+  rw [evalWord_cons, evalWord_append M l k [a] [b] h, evalWord_cons, evalWord_nil,
+    mul_one, Matrix.trace_mul_comm]
+
 /-! ### The MPO operator family -/
 
 /-- The `(σ, τ)` matrix entry of the MPO density operator for system size `N`:


### PR DESCRIPTION
## Summary

Two reusable lemmas in `TNLean/MPS/MPDO/Defs.lean` (next to the existing `evalWord`/`evalWord_ofFn` helpers):

- **`MPOTensor.evalWord_append`** — `evalWord M (l₁++l₂)(k₁++k₂) = evalWord M l₁ k₁ * evalWord M l₂ k₂` for `|l₁| = |k₁|`. Simple joint induction.
- **`MPOTensor.trace_evalWord_cons_eq_append`** — `tr(evalWord M (a::l)(b::k)) = tr(evalWord M (l++[a])(k++[b]))` for `|l|=|k|`, i.e. cyclic rotation of the closed MPO word leaves the trace unchanged (via `evalWord_append` + `Matrix.trace_mul_comm`). This is the single-shift **translation invariance** of the periodic MPDO `mpo M N`.

## Why

`mpo M N σ τ = tr(M^{σ₀τ₀} ⋯ M^{σ_{N-1}τ_{N-1}})` is translation-invariant because the bond trace is cyclic. These lemmas make that cyclicity available at the word/trace level, which the block-entropy translation invariance (`S` of a middle contiguous block `=` `S` of the prefix block of equal size) builds on. Prerequisite for **#2424** (Proposition 4.5, mutual-information monotonicity), pieces 2–3 of the validated decomposition recorded on that issue.

## Verification

- `lake build TNLean.MPS.MPDO.Defs` green; both lemmas `sorry`/`axiom`-free.
- Additions only; no existing declarations changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive Mathlib lemmas in MPDO definitions; no API or runtime behavior changes.
> 
> **Overview**
> Adds two lemmas next to the existing `evalWord` helpers in **`TNLean/MPS/MPDO/Defs.lean`**, with no changes to prior declarations.
> 
> **`evalWord_append`** shows that for equal-length ket/bra prefixes, concatenating word pairs factors the evaluated matrix product: `evalWord` on `l₁++l₂` and `k₁++k₂` equals the product of the two prefix evaluations (joint induction on the bra list, using `Matrix.mul_assoc`).
> 
> **`trace_evalWord_cons_eq_append`** records single-step cyclicity of the closed MPO word trace: moving the leading `(a,b)` pair to the end of both lists does not change `Matrix.trace` of `evalWord`, via `evalWord_append` and `Matrix.trace_mul_comm`. This is the word-level form of periodic MPDO translation invariance for `mpo M N` entries.
> 
> These are foundational pieces for downstream block-entropy / mutual-information arguments (e.g. #2424).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b33ec4fdcd5672e82ab1371004b1fec381b62334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->