### PR TITLE
feat(MPDO): translation invariance of the periodic MPDO

### DIFF
--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -53,9 +53,10 @@ open Matrix Finset
 
 /-! ## Translation invariance of the periodic MPDO
 
-The density operator `ρ^{(N)}(M)` closes the MPO word with a bond trace, hence is
-invariant under the simultaneous cyclic shift of bra and ket configurations. This
-is the translation invariance required for the mutual-information monotonicity. -/
+The periodic MPO density operator $\rho^{(N)}(M)$ closes the MPO word with a bond
+trace, hence is invariant under the simultaneous cyclic shift of bra and ket
+configurations. This is the translation invariance required for the
+mutual-information monotonicity. -/
 
 /-- `List.ofFn` precomposed with `finRotate` is the one-step list rotation. A
 general fact about `List.ofFn`, `finRotate`, and `List.rotate`. -/

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -53,9 +53,24 @@ open Matrix Finset
 
 /-! ## Translation invariance of the periodic MPDO
 
-The operator `mpo M N` closes the MPO word with a bond trace, hence is invariant
-under the simultaneous cyclic shift of bra and ket configurations. This is the
-translation invariance required for the mutual-information monotonicity. -/
+The density operator `ρ^{(N)}(M)` closes the MPO word with a bond trace, hence is
+invariant under the simultaneous cyclic shift of bra and ket configurations. This
+is the translation invariance required for the mutual-information monotonicity. -/
+
+/-- `List.ofFn` precomposed with `finRotate` is the one-step list rotation. A
+general fact about `List.ofFn`, `finRotate`, and `List.rotate`. -/
+theorem ofFn_comp_finRotate {α : Type*} {n : ℕ} (σ : Fin (n + 1) → α) :
+    List.ofFn (σ ∘ finRotate (n + 1)) = (List.ofFn σ).rotate 1 := by
+  apply List.ext_getElem
+  · simp
+  · intro i h1 _
+    simp only [List.getElem_ofFn, Function.comp_apply, List.getElem_rotate,
+      List.length_ofFn]
+    congr 1
+    have : finRotate (n + 1) ⟨i, by simpa using h1⟩
+        = ⟨(i + 1) % (n + 1), Nat.mod_lt _ (Nat.succ_pos n)⟩ := by
+      rw [finRotate_apply]; ext; simp [Fin.add_def]
+    rw [this]
 
 namespace MPOTensor
 
@@ -78,20 +93,6 @@ theorem trace_evalWord_rotate_one (M : MPOTensor d D) :
       | cons b k =>
           rw [List.rotate_cons_succ, List.rotate_zero, List.rotate_cons_succ,
             List.rotate_zero, ← trace_evalWord_cons_eq_append M a b l k (by simpa using h)]
-
-/-- `List.ofFn` precomposed with `finRotate` is the one-step list rotation. -/
-theorem ofFn_comp_finRotate {α : Type*} {n : ℕ} (σ : Fin (n + 1) → α) :
-    List.ofFn (σ ∘ finRotate (n + 1)) = (List.ofFn σ).rotate 1 := by
-  apply List.ext_getElem
-  · simp
-  · intro i h1 _
-    simp only [List.getElem_ofFn, Function.comp_apply, List.getElem_rotate,
-      List.length_ofFn]
-    congr 1
-    have : finRotate (n + 1) ⟨i, by simpa using h1⟩
-        = ⟨(i + 1) % (n + 1), Nat.mod_lt _ (Nat.succ_pos n)⟩ := by
-      rw [finRotate_apply]; ext; simp [Fin.add_def]
-    rw [this]
 
 /-- Cyclically shifting both configurations leaves the closed-word MPO entry
 unchanged. -/

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.Defs
 import TNLean.Analysis.Entropy
+import Mathlib.Data.List.Rotate
+import Mathlib.Logic.Equiv.Fin.Rotate
 
 /-!
 # Saturation of the area law for MPDO and MPS tensors
@@ -48,6 +50,77 @@ SAL** when `I_1 = I_2 = ⋯` (Definition 4.6, line 811). Equivalently
 
 open scoped Matrix ComplexOrder BigOperators
 open Matrix Finset
+
+/-! ## Translation invariance of the periodic MPDO
+
+The operator `mpo M N` closes the MPO word with a bond trace, hence is invariant
+under the simultaneous cyclic shift of bra and ket configurations. This is the
+translation invariance required for the mutual-information monotonicity. -/
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- List-level cyclicity: rotating both equal-length words by one position
+leaves the closed-word trace unchanged. -/
+theorem trace_evalWord_rotate_one (M : MPOTensor d D) :
+    ∀ (w w' : List (Fin d)), w.length = w'.length →
+      Matrix.trace (evalWord M (w.rotate 1) (w'.rotate 1))
+        = Matrix.trace (evalWord M w w') := by
+  intro w w' h
+  cases w with
+  | nil =>
+      rw [List.length_nil, eq_comm, List.length_eq_zero_iff] at h
+      subst h; rfl
+  | cons a l =>
+      cases w' with
+      | nil => simp at h
+      | cons b k =>
+          rw [List.rotate_cons_succ, List.rotate_zero, List.rotate_cons_succ,
+            List.rotate_zero, ← trace_evalWord_cons_eq_append M a b l k (by simpa using h)]
+
+/-- `List.ofFn` precomposed with `finRotate` is the one-step list rotation. -/
+theorem ofFn_comp_finRotate {α : Type*} {n : ℕ} (σ : Fin (n + 1) → α) :
+    List.ofFn (σ ∘ finRotate (n + 1)) = (List.ofFn σ).rotate 1 := by
+  apply List.ext_getElem
+  · simp
+  · intro i h1 _
+    simp only [List.getElem_ofFn, Function.comp_apply, List.getElem_rotate,
+      List.length_ofFn]
+    congr 1
+    have : finRotate (n + 1) ⟨i, by simpa using h1⟩
+        = ⟨(i + 1) % (n + 1), Nat.mod_lt _ (Nat.succ_pos n)⟩ := by
+      rw [finRotate_apply]; ext; simp [Fin.add_def]
+    rw [this]
+
+/-- Cyclically shifting both configurations leaves the closed-word MPO entry
+unchanged. -/
+theorem mpoMatrixEntry_comp_finRotate (M : MPOTensor d D) {N : ℕ}
+    (σ τ : Fin N → Fin d) :
+    mpoMatrixEntry M (σ ∘ finRotate N) (τ ∘ finRotate N) = mpoMatrixEntry M σ τ := by
+  cases N with
+  | zero => rfl
+  | succ n =>
+      rw [mpoMatrixEntry, ofFn_comp_finRotate, ofFn_comp_finRotate, mpoMatrixEntry,
+        trace_evalWord_rotate_one M _ _ (by simp)]
+
+/-- The cyclic-shift reindexing of configurations on `N` sites:
+`rotateConfig N d σ = σ ∘ finRotate N`. -/
+def rotateConfig (N d : ℕ) : (Fin N → Fin d) ≃ (Fin N → Fin d) :=
+  Equiv.arrowCongr (finRotate N).symm (Equiv.refl (Fin d))
+
+@[simp] lemma rotateConfig_apply (N d : ℕ) (σ : Fin N → Fin d) :
+    rotateConfig N d σ = σ ∘ finRotate N := rfl
+
+/-- **Translation invariance of the periodic MPDO.** `mpo M N` is invariant under
+the simultaneous cyclic shift of bra and ket configurations. -/
+theorem mpo_submatrix_rotateConfig (M : MPOTensor d D) (N : ℕ) :
+    (mpo M N).submatrix (rotateConfig N d) (rotateConfig N d) = mpo M N := by
+  ext σ τ
+  simp only [Matrix.submatrix_apply, mpo_apply, rotateConfig_apply]
+  exact mpoMatrixEntry_comp_finRotate M σ τ
+
+end MPOTensor
 
 /-! ## Trace normalization -/
 

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -76,6 +76,32 @@ each black node denotes the same local tensor $M$, and the matrix entry
 $\rho^{(N)}(M)_{\sigma,\tau}$ is obtained by closing the outer virtual
 legs cyclically and taking the resulting trace.
 
+\begin{definition}[Cyclic-shift reindexing]\label{def:mpo_rotate_config}
+    \lean{MPOTensor.rotateConfig}
+    \leanok
+    The \emph{cyclic shift} of configurations on $N$ sites is the bijection that
+    relabels each site by one position, $\sigma \mapsto \sigma \circ r$, where
+    $r$ is the cyclic rotation $i \mapsto i + 1$ of $\{0,\ldots,N-1\}$.
+\end{definition}
+
+\begin{theorem}[Translation invariance of the periodic MPDO]
+    \label{thm:mpo_translation_invariant}
+    \lean{MPOTensor.mpo_submatrix_rotateConfig}
+    \leanok
+    \uses{def:mpo_family, def:mpo_rotate_config}
+    The operator $\rho^{(N)}(M)$ is invariant under the simultaneous cyclic shift
+    of its bra and ket configurations:
+    \[
+        \rho^{(N)}(M)_{r\sigma,\, r\tau} = \rho^{(N)}(M)_{\sigma,\tau}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Closing the word $M^{\sigma,\tau}$ with a bond trace makes the entry cyclic
+    in the site index, since the trace is invariant under cyclic permutation of
+    the matrix product.
+\end{proof}
+
 \begin{definition}[Hermitian MPO tensor]\label{def:mpo_hermitian}
     \lean{MPOTensor.IsHermitian}
     \leanok

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -97,9 +97,16 @@ legs cyclically and taking the resulting trace.
 \end{theorem}
 
 \begin{proof}\leanok
-    Closing the word $M^{\sigma,\tau}$ with a bond trace makes the entry cyclic
-    in the site index, since the trace is invariant under cyclic permutation of
-    the matrix product.
+    The entry is a closed bond trace,
+    $\rho^{(N)}(M)_{\sigma,\tau}
+        = \tr\bigl(M^{\sigma_1\tau_1} \cdots M^{\sigma_N\tau_N}\bigr)$.
+    Shifting both configurations by $r$ rotates the matrix product by one factor,
+    and the trace is invariant under that cyclic rotation,
+    \[
+        \tr\bigl(M^{\sigma_2\tau_2} \cdots M^{\sigma_N\tau_N} M^{\sigma_1\tau_1}\bigr)
+        = \tr\bigl(M^{\sigma_1\tau_1} \cdots M^{\sigma_N\tau_N}\bigr),
+    \]
+    so $\rho^{(N)}(M)_{r\sigma,\,r\tau} = \rho^{(N)}(M)_{\sigma,\tau}$.
 \end{proof}
 
 \begin{definition}[Hermitian MPO tensor]\label{def:mpo_hermitian}


### PR DESCRIPTION
## Summary

The periodic MPDO operator `mpo M N` closes the MPO word with a bond trace, so it is invariant under the simultaneous cyclic shift of bra and ket configurations. This PR formalizes that, building on the closed-word trace cyclicity from #2427.

Added to `TNLean/MPS/MPDO/AreaLaw.lean`:

- `MPOTensor.trace_evalWord_rotate_one` — rotating both equal-length words by one position leaves the closed-word trace unchanged (from `trace_evalWord_cons_eq_append`).
- `MPOTensor.ofFn_comp_finRotate` — `List.ofFn (σ ∘ finRotate (n+1)) = (List.ofFn σ).rotate 1`.
- `MPOTensor.mpoMatrixEntry_comp_finRotate` — cyclically shifting both configurations leaves the MPO entry unchanged.
- `MPOTensor.rotateConfig` (+ `_apply`) — the cyclic-shift reindexing `σ ↦ σ ∘ finRotate N` as an `Equiv`.
- `MPOTensor.mpo_submatrix_rotateConfig` — **`(mpo M N).submatrix (rotateConfig N d)(rotateConfig N d) = mpo M N`**, the translation invariance.

## Why

Translation invariance of the periodic MPDO is the property that makes the entropy of a contiguous block depend only on the block length — the hypothesis the source uses for Proposition 4.5 (mutual-information monotonicity, #2424). This is piece 4 of the validated decomposition recorded there.

## Verification

- `lake build TNLean.MPS.MPDO.AreaLaw` green; all lemmas `sorry`/`axiom`-free.
- Additions only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs and blueprint text only; no changes to runtime behavior, auth, or existing API semantics beyond new theorems.
> 
> **Overview**
> Adds **translation invariance** of the periodic MPDO `ρ^{(N)}(M)`: simultaneous cyclic shift of bra and ket configurations leaves the operator unchanged.
> 
> In `TNLean/MPS/MPDO/AreaLaw.lean`, a new section proves this by chaining **closed-word trace cyclicity** (`trace_evalWord_rotate_one`, from existing `trace_evalWord_cons_eq_append`), **`List.ofFn` vs `finRotate`** (`ofFn_comp_finRotate`), entry-level invariance (`mpoMatrixEntry_comp_finRotate`), the reindexing equiv **`rotateConfig`**, and the matrix statement **`mpo_submatrix_rotateConfig`**. Mathlib imports for list rotation and `finRotate` are added.
> 
> The blueprint **`ch02b_mpdo.tex`** documents cyclic-shift reindexing and the translation-invariance theorem, aligned with the Lean names. This supports later mutual-information / block-entropy arguments that need periodic translation symmetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44759d3a76c6f5207a0f214f3ada76d7d6ce0afb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->