### PR TITLE
feat(parent): isolate mirror right-product gap

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -359,6 +359,49 @@ theorem closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
         simpa [groundSpaceMap_apply, cyclicRestrictₗ_apply, hψX]
           using congr_fun (hYAt ⟨M + 1 - L₀, by omega⟩ τ) σ_w)
 
+/-- One-sided boundary equations with the shared complementary word \(\mu\).
+
+For the two displayed boundary conditions, the one-sided equations become
+\[
+  Y_M(\tau^+_\eta(\mu))A^j = A^\mu A^j X,
+  \qquad
+  X A^j A^\mu = A^jY_{M+1-L_0}(\tau^-_\eta(\mu)).
+\]
+These are the boundary-crossing equations after reindexing the complementary
+sites by the same word \(\mu\). -/
+lemma closure_property_boundary_one_sided_products_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
+    (∀ (η j : Fin d),
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j =
+        evalWord A (List.ofFn μ) * A j * X) ∧
+    (∀ (η j : Fin d),
+      X * A j * evalWord A (List.ofFn μ) =
+        A j * YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ)) := by
+  obtain ⟨hWrap, hMirror⟩ :=
+    closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX YAt hYAt
+  constructor
+  · intro η j
+    have h := hWrap j (wrappedMiddleBackground L₀ (M + 1) η μ)
+    have hcomp := wrappedMiddleBackground_complement L₀ (M + 1) η μ
+    rw [hcomp] at h
+    simpa using h.symm
+  · intro η j
+    have h := hMirror j (mirrorMiddleBackground L₀ (M + 1) η μ)
+    have hcomp := mirrorMiddleBackground_complement L₀ (M + 1) η μ
+    rw [hcomp] at h
+    simpa using h
+
 /-- Product form of the boundary-crossing restrictions at the closing boundary.
 
 For the \(L_0-1\) adjacent restrictions from \(M+1-L_0\) to \(M\), the two
@@ -712,12 +755,67 @@ lemma closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
     simpa [ρPlus, ρMinus] using
       congrArg (fun Y => Y * evalWord A (List.ofFn σ)) hfirst
 
+/-- Auxiliary boundary-condition product obtained from right-products at the
+two closing boundary matrices.
+
+Suppose that, for every boundary letter \(\eta\) and every physical letter
+\(j\),
+\[
+  Y_M(\tau^+_\eta(\mu)) A^j
+  =
+  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j .
+\]
+Then there are boundary conditions with the same complementary word and with
+\[
+  Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+  =
+  Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
+\]
+This is the composition of the right-product-to-restriction step with the
+auxiliary product extraction from equal closing-boundary restrictions. -/
+lemma closure_property_auxiliary_boundary_product_eq_of_right_products
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hProd : ∀ (η j : Fin d),
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j =
+        YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j) :
+    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
+      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
+          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+            evalWord A (List.ofFn σ) := by
+  refine closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
+    (A := A) hInj hL₀ hM YAt hYAt μ ?_
+  intro η
+  exact closure_property_boundary_restriction_eq_of_first_products
+    (A := A) hL₀ hM η μ
+    (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+    (YAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) η μ))
+    (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+    (hYAt ⟨M + 1 - L₀, by omega⟩
+      (mirrorMiddleBackground L₀ (M + 1) η μ)) (hProd η)
+
 /-- Auxiliary boundary-assignment product equation needed at the closing
 boundary.
 
 For each pair \(j,\sigma\), this states the existence of boundary assignments
 \(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) with the same complementary
-word \(\mu\) as the two canonical assignments, and satisfying
+word \(\mu\) as the two displayed boundary conditions, and satisfying
 \[
   Y_M(\rho^+_{j,\sigma}) A^j A^\sigma
   =
@@ -726,9 +824,16 @@ word \(\mu\) as the two canonical assignments, and satisfying
 
 **Open gap:** The source does not display this auxiliary equation.  It says that
 the inverting and growing-back argument can be applied when closing the
-boundary.  The remaining obligation here is the displayed product equation,
-which is documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and
-tracked in #2405. -/
+boundary.  After the one-sided equation
+\[
+  Y_M(\tau^+_\eta(\mu)) A^j = A^\mu A^j X
+\]
+is obtained from the last boundary, the remaining comparison is
+\[
+  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j = A^\mu A^j X ,
+\]
+documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked
+in #2405. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -752,6 +857,17 @@ theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
         YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
           YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
             evalWord A (List.ofFn σ) := by
+  have hOneSided :=
+    closure_property_boundary_one_sided_products_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX YAt hYAt μ
+  suffices hMirrorRight : ∀ (η j : Fin d),
+      YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j =
+        evalWord A (List.ofFn μ) * A j * X by
+    refine closure_property_auxiliary_boundary_product_eq_of_right_products
+      (A := A) hInj hL₀ hM YAt hYAt μ ?_
+    intro η j
+    exact (hOneSided.1 η j).trans (hMirrorRight η j).symm
   sorry
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1060,7 +1060,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{lem:closure_property_boundary_crossing_equations_ground_space_map,
         lem:wrapped_middle_backgrounds}
-    Let $A$ be $L_0$-block injective with $L_0>0$, $D\ge1$, and $L_0\le M$.
+    Let $A$ be $L_0$-block-injective with $L_0>0$, $D\ge1$, and $L_0\le M$.
     Suppose $\psi=\Gamma_{M+1}(X)$, and suppose matrices $Y_i(\tau)$ represent
     the length-$(L_0+1)$ cyclic restrictions
     \[
@@ -2163,6 +2163,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         \Gamma_{L_0+1}(Y_i(\tau)).
     \]
+    Fix a complementary word $\mu$ of length $M+1-(L_0+1)$.
     Suppose that, for every boundary letter $\eta$ and every physical letter
     $j$,
     \[
@@ -2188,14 +2189,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    Fix a boundary letter $\eta$.
+    For each boundary letter $\eta$,
     Lemma~\ref{lem:closed_boundary_restriction_from_right_products} gives
     \[
         \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =
         \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
     \]
-    Applying this equality for every $\eta$,
+    Applying these equalities,
     Lemma~\ref{lem:closure_property_auxiliary_product_from_closing_restrictions}
     gives the displayed boundary conditions and product equation.
 \end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1025,7 +1025,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{def:ground_space_map, rem:cyclic_window_operators,
         lem:wrapped_window_one_sided_compatibility,
         lem:mirror_wrapped_window_one_sided_compatibility}
-    Let $A$ be $L_0$-block injective with $L_0>0$, $D\ge1$, and $L_0\le M$.
+    Let $A$ be $L_0$-block-injective with $L_0>0$, $D\ge1$, and $L_0\le M$.
     Suppose $\psi=\Gamma_{M+1}(X)$, and suppose matrices $Y_i(\tau)$ represent
     the length-$(L_0+1)$ cyclic restrictions
     \[
@@ -1052,6 +1052,42 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \ref{lem:wrapped_window_one_sided_compatibility} and
     \ref{lem:mirror_wrapped_window_one_sided_compatibility} then give the two
     equations in~(\ref{eq:ph_closure_boundary_crossing_gamma_equations}).
+\end{proof}
+
+\begin{lemma}[One-sided products for a common complement word]
+    \label{lem:closure_property_boundary_one_sided_products_ground_space_map}
+    \lean{MPSTensor.closure_property_boundary_one_sided_products_of_groundSpaceMap}
+    \leanok
+    \uses{lem:closure_property_boundary_crossing_equations_ground_space_map,
+        lem:wrapped_middle_backgrounds}
+    Let $A$ be $L_0$-block injective with $L_0>0$, $D\ge1$, and $L_0\le M$.
+    Suppose $\psi=\Gamma_{M+1}(X)$, and suppose matrices $Y_i(\tau)$ represent
+    the length-$(L_0+1)$ cyclic restrictions
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    For every boundary letter $\eta$, every physical letter $j$, and every
+    complementary word $\mu$,
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j
+        =
+        A^\mu A^j X,
+        \qquad
+        X A^j A^\mu
+        =
+        A^jY_{M+1-L_0}(\tau^-_\eta(\mu)).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Substitute $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ into
+    Lemma~\ref{lem:closure_property_boundary_crossing_equations_ground_space_map}.
+    The exposed-complement identities of
+    Lemma~\ref{lem:wrapped_middle_backgrounds} identify both complementary
+    products with $A^\mu$.
 \end{proof}
 
 \begin{lemma}[Common complement word for the two boundary supports]%
@@ -2113,6 +2149,57 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Right multiplication by $A^\sigma$ gives the asserted product equation.
 \end{proof}
 
+\begin{lemma}[Auxiliary product from right products]
+    \label{lem:closure_property_auxiliary_product_from_right_products}
+    \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_right_products}
+    \leanok
+    \uses{lem:closed_boundary_restriction_from_right_products,
+        lem:closure_property_auxiliary_product_from_closing_restrictions}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$.
+    Let $\psi$ be a state on the chain of length $M+1$, and let
+    $Y_i(\tau)$ be matrices satisfying
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    Suppose that, for every boundary letter $\eta$ and every physical letter
+    $j$,
+    \[
+        Y_M(\tau^+_{\eta}(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_{\eta}(\mu))A^j .
+    \]
+    Then there are boundary conditions $\rho^+_{j,\sigma}$ and
+    $\rho^-_{j,\sigma}$ such that, for every complementary position $k$,
+    \[
+        \rho^+_{j,\sigma}(k+L_0)=\mu_k,
+        \qquad
+        \rho^-_{j,\sigma}(k+1)=\mu_k,
+    \]
+    and, for every physical letter $j$ and every word $\sigma$ of length
+    $L_0$,
+    \[
+        Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Fix a boundary letter $\eta$.
+    Lemma~\ref{lem:closed_boundary_restriction_from_right_products} gives
+    \[
+        \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+        =
+        \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+    \]
+    Applying this equality for every $\eta$,
+    Lemma~\ref{lem:closure_property_auxiliary_product_from_closing_restrictions}
+    gives the displayed boundary conditions and product equation.
+\end{proof}
+
 \begin{lemma}[Auxiliary first-letter form of the closure property]
     \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
     \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}
@@ -2165,7 +2252,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \label{lem:closure_property_auxiliary_boundary_product_chain_ground_space}
     \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap}
     \leanok
-    \uses{def:l_blk_injective, def:ground_space_map, rem:cyclic_window_operators}
+    \uses{def:l_blk_injective, def:ground_space_map, rem:cyclic_window_operators,
+        lem:closure_property_boundary_one_sided_products_ground_space_map,
+        lem:closure_property_auxiliary_product_from_right_products}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let $\psi$ be a
     state on the chain of length $M+1$ with open-chain representation
     $\psi=\Gamma_{M+1}(X)$.  Let $Y_i(\tau)$ be matrices satisfying
@@ -2193,16 +2282,23 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    \uses{lem:closure_property_auxiliary_product_from_closing_restrictions}
-    By Lemma~\ref{lem:closure_property_auxiliary_product_from_closing_restrictions},
-    it is enough to prove, for every physical letter $j$,
+    Lemma~\ref{lem:closure_property_boundary_one_sided_products_ground_space_map}
+    gives
     \[
-        \operatorname{Res}^{\tau^+_j(\mu)}_{M,L_0+1}(\psi)
+        Y_M(\tau^+_{\eta}(\mu))A^j
         =
-        \operatorname{Res}^{\tau^-_j(\mu)}_{M+1-L_0,L_0+1}(\psi).
+        A^\mu A^j X .
     \]
-    The displayed equality is the remaining coordinate form of the sentence on
-    closing the boundaries in
+    By Lemma~\ref{lem:closure_property_auxiliary_product_from_right_products},
+    it remains to prove, for every boundary letter $\eta$ and every physical
+    letter $j$, the comparison with the opposite boundary,
+    \[
+        Y_{M+1-L_0}(\tau^-_{\eta}(\mu))A^j
+        =
+        A^\mu A^j X .
+    \]
+    This is the remaining right-product comparison associated with the
+    sentence on closing the boundaries in
     \cite[lines~2078--2079]{Cirac2021Matrix}.
     % Remaining gap recorded in docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -20,7 +20,7 @@ The range-reduction step for normal matrix product states appears in
 Section~IV.C of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
 \cite{Cirac2021Matrix}.\footnote{For traceability, this note corresponds to
 \href{https://github.com/LionSR/TNLean/issues/1042}{issue \#1042}. The principal
-formal obligation is recorded in
+range-reduction comparison is recorded in
 \href{https://github.com/LionSR/TNLean/issues/588}{issue \#588}; the
 boundary-closing comparison is recorded in
 \href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368};


### PR DESCRIPTION
This PR isolates the remaining comparison in the parent-Hamiltonian boundary-closing argument.

It adds a no-sorry one-sided specialization of the boundary-crossing equations:

```tex
Y_M(\tau^+_\eta(\mu))A^j = A^\mu A^j X,
\qquad
X A^j A^\mu = A^jY_{M+1-L_0}(\tau^-_\eta(\mu)).
```

It also adds a no-sorry reduction from right-products at the two closing boundary matrices to the auxiliary product equation:

```tex
Y_M(\tau^+_\eta(\mu))A^j = Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j
\Longrightarrow
Y_M(\rho^+_{j,\sigma})A^jA^\sigma = Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma.
```

After these reductions, the only remaining local comparison in `closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap` is

```tex
Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j = A^\mu A^j X.
```

The source does not display these local coordinate equations; they are bookkeeping for the sentence on applying the inverting and growing-back argument when closing the boundaries, arXiv:2011.12127, lines 2078--2079.

Refs #2405.

Checks run:
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `PATH=/tmp/tnlean-blueprint-venv/bin:$PATH leanblueprint web`

`lake exe checkdecls blueprint/lean_decls` still reports existing missing declarations outside the parent-Hamiltonian chapter; the two new parent-Hamiltonian declarations are present in the generated declaration list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formal proof structure on the parent-Hamiltonian closure path (downstream theorems still depend on a sorry), but adds no runtime behavior and narrows rather than widens the unproved obligation.
> 
> **Overview**
> This PR **decomposes** the parent-Hamiltonian boundary-closing proof so intermediate steps are proved and the open paper gap is a single explicit comparison.
> 
> It adds **`closure_property_boundary_one_sided_products_of_groundSpaceMap`**, deriving the one-sided identities with a shared complement word \(\mu\) from the existing wrapped/mirror boundary-crossing equations and complement reindexing.
> 
> It adds **`closure_property_auxiliary_boundary_product_eq_of_right_products`**, showing that equal right-products at the two closing boundary matrices imply the auxiliary \(\rho^\pm\) product equation (via restriction equality and the existing closing-restrictions lemma).
> 
> **`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`** is rewired to combine the new one-sided lemma with that right-product reduction; it still ends in **`sorry`** for proving \(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j = A^\mu A^j X\). Blueprint chapter 14 and the normal range-reduction gap note are updated to match this proof structure and issue #2405.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ff81203d4242be338c608bc89e6f30d64d5efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->