### PR TITLE
feat(peps): un-orphan the PEPS Fundamental Theorem capstone into the root build (#1512)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -396,5 +396,7 @@ import TNLean.PEPS.EdgeGaugeFamily
 import TNLean.PEPS.TwoInjectiveComparison
 import TNLean.PEPS.EdgeScalarSolve
 import TNLean.PEPS.GaugeConsistencyConnectivityCounterexample
--- The PEPS fundamental theorem is an exploratory capstone with recorded
--- paper-alignment gaps; it is deliberately not part of the default root.
+-- The injective PEPS Fundamental Theorem (arXiv:1804.04964, Theorem 2) capstone:
+-- existence and uniqueness clauses, sorry-free and axiom-clean, now part of root.
+import TNLean.PEPS.FundamentalTheorem
+import TNLean.PEPS.FundamentalTheorem.Uniqueness


### PR DESCRIPTION
## Un-orphans the now-proved PEPS Fundamental Theorem

`FundamentalTheorem.lean` (arXiv:1804.04964 Theorem 2 — existence + uniqueness) was deliberately excluded from the root build while it carried paper-alignment gaps. Those gaps are now closed: the file is **sorry-free and `#print axioms`-clean** (landed on main in #2423). This wires it — and `FundamentalTheorem/Uniqueness` — into `TNLean.lean`, so the headline `fundamentalTheorem_PEPS` and `gauge_unique_mod_edge_scalars` are **CI-build-verified** as part of the default root build.

- Both capstone modules build clean off main (2702 jobs); full `lake build` is green locally.
- No proof changes — import wiring + the stale "deliberately not part of root" comment updated.

Resolves #1512 (root-audit obligation for the PEPS FT capstone).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only change to the library entrypoint; proofs are unchanged and already sorry-free on main.
> 
> **Overview**
> **Wires the proved PEPS Fundamental Theorem capstone into the default root build** so CI verifies `fundamentalTheorem_PEPS` and `gauge_unique_mod_edge_scalars` on every `lake build`.
> 
> `TNLean.lean` now imports `TNLean.PEPS.FundamentalTheorem` and `TNLean.PEPS.FundamentalTheorem.Uniqueness`, replacing the old note that the capstone was deliberately excluded from root while paper-alignment gaps remained. There are **no proof edits**—only import surface and comment updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e42d819a15a323e7cd8bc12bbd9ceedbd6e53f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->