### PR TITLE
feat(parent): reduce closing-boundary comparison to words

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -810,6 +810,109 @@ lemma closure_property_auxiliary_boundary_product_eq_of_right_products
     (hYAt ⟨M + 1 - L₀, by omega⟩
       (mirrorMiddleBackground L₀ (M + 1) η μ)) (hProd η)
 
+/-- Cancellation form of the opposite-boundary coordinate comparison.
+
+If the difference
+\[
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j - A^\mu A^jX
+\]
+vanishes after multiplication by \(A^\sigma\) on the right for every word
+\(\sigma\) of length \(L_0\), then it vanishes.  This uses \(L_0\)-block
+injectivity, so that the length-\(L_0\) word products span the full matrix
+algebra. -/
+lemma closure_property_mirror_right_product_eq_of_right_word_products
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hWord : ∀ (η j : Fin d) (σ : Fin L₀ → Fin d),
+      YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) =
+        evalWord A (List.ofFn μ) * A j * X *
+          evalWord A (List.ofFn σ)) :
+    ∀ (η j : Fin d),
+      YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j =
+        evalWord A (List.ofFn μ) * A j * X := by
+  intro η j
+  have hzero : ∀ σ : Fin L₀ → Fin d,
+      (YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j -
+          evalWord A (List.ofFn μ) * A j * X) *
+        evalWord A (List.ofFn σ) = 0 := by
+    intro σ
+    simpa [sub_mul, sub_eq_zero, Matrix.mul_assoc] using hWord η j σ
+  have hsub :
+      YAt ⟨M + 1 - L₀, by omega⟩
+            (mirrorMiddleBackground L₀ (M + 1) η μ) * A j -
+          evalWord A (List.ofFn μ) * A j * X = 0 :=
+    eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
+      (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
+  exact sub_eq_zero.mp hsub
+
+/-- Auxiliary boundary-condition product obtained from the opposite-boundary
+coordinate comparison after multiplication by length-\(L_0\) words.
+
+Suppose that the last boundary already gives
+\[
+  Y_M(\tau^+_\eta(\mu)) A^j = A^\mu A^jX
+\]
+and that the opposite boundary satisfies the comparison
+\[
+  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma
+  =
+  A^\mu A^j X A^\sigma
+\]
+for every word \(\sigma\) of length \(L_0\).  Since the length-\(L_0\) word
+products span the full matrix algebra, this comparison implies
+\[
+  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j = A^\mu A^jX .
+\]
+Together with the last-boundary equation this supplies the product equations
+needed for the auxiliary boundary-condition product. -/
+lemma closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hLast : ∀ (η j : Fin d),
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j =
+        evalWord A (List.ofFn μ) * A j * X)
+    (hMirrorPadded : ∀ (η j : Fin d) (σ : Fin L₀ → Fin d),
+      YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) =
+        evalWord A (List.ofFn μ) * A j * X *
+          evalWord A (List.ofFn σ)) :
+    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
+      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
+          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+            evalWord A (List.ofFn σ) := by
+  refine closure_property_auxiliary_boundary_product_eq_of_right_products
+    (A := A) hInj hL₀ hM YAt hYAt μ ?_
+  have hMirrorRight :=
+    closure_property_mirror_right_product_eq_of_right_word_products
+      (A := A) hInj hL₀ hM YAt X μ hMirrorPadded
+  intro η j
+  exact (hLast η j).trans (hMirrorRight η j).symm
+
 /-- Auxiliary boundary-assignment product equation needed at the closing
 boundary.
 
@@ -822,15 +925,18 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
   Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
 \]
 
-**Open gap:** The source does not display this auxiliary equation.  It says that
-the inverting and growing-back argument can be applied when closing the
-boundary.  After the one-sided equation
+**Open gap:** The source does not display this auxiliary equation.  Its
+closing-boundary paragraph is represented here by the following coordinate
+identity.  After the one-sided equation
 \[
   Y_M(\tau^+_\eta(\mu)) A^j = A^\mu A^j X
 \]
-is obtained from the last boundary, the remaining comparison is
+is obtained from the last boundary, the remaining comparison is the coordinate
+form at the opposite boundary after multiplication by a length-\(L_0\) word,
 \[
-  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j = A^\mu A^j X ,
+  Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma
+  =
+  A^\mu A^j X A^\sigma .
 \]
 documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked
 in #2405. -/
@@ -860,14 +966,14 @@ theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
   have hOneSided :=
     closure_property_boundary_one_sided_products_of_groundSpaceMap
       (A := A) hInj hL₀ hM hψX YAt hYAt μ
-  suffices hMirrorRight : ∀ (η j : Fin d),
+  suffices hMirrorPadded : ∀ (η j : Fin d) (σ : Fin L₀ → Fin d),
       YAt ⟨M + 1 - L₀, by omega⟩
-          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j =
-        evalWord A (List.ofFn μ) * A j * X by
-    refine closure_property_auxiliary_boundary_product_eq_of_right_products
-      (A := A) hInj hL₀ hM YAt hYAt μ ?_
-    intro η j
-    exact (hOneSided.1 η j).trans (hMirrorRight η j).symm
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) =
+        evalWord A (List.ofFn μ) * A j * X *
+          evalWord A (List.ofFn σ) by
+    exact closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products
+      (A := A) hInj hL₀ hM YAt hYAt X μ hOneSided.1 hMirrorPadded
   sorry
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2201,6 +2201,112 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     gives the displayed boundary conditions and product equation.
 \end{proof}
 
+\begin{lemma}[Opposite-boundary comparison after multiplication by words]
+    \label{lem:closure_property_opposite_boundary_comparison_from_right_words}
+    \lean{MPSTensor.closure_property_mirror_right_product_eq_of_right_word_products}
+    \leanok
+    \uses{def:l_blk_injective, lem:padded_complement_annihilation}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$.
+    Fix a complementary word $\mu$, a matrix $X$, and a family of matrices
+    $Y_i(\tau)$. Suppose that, for every boundary letter $\eta$, every
+    physical letter $j$, and every word $\sigma$ of length $L_0$,
+    \[
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+        =
+        A^\mu A^jXA^\sigma .
+    \]
+    Then, for every $\eta$ and $j$,
+    \[
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j
+        =
+        A^\mu A^jX .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Fix $\eta$ and $j$, and set
+    \[
+        Z_{\eta,j}
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j-A^\mu A^jX .
+    \]
+    The hypothesis gives, for every $\sigma$ with $|\sigma|=L_0$,
+    \[
+        Z_{\eta,j}A^\sigma=0.
+    \]
+    Since $A$ is $L_0$-block-injective, the products $A^\sigma$ with
+    $|\sigma|=L_0$ span the full matrix algebra.  Applying
+    Lemma~\ref{lem:padded_complement_annihilation} gives $Z_{\eta,j}=0$.
+\end{proof}
+
+\begin{lemma}[Auxiliary product from the opposite-boundary comparison]
+    \label{lem:closure_property_auxiliary_product_from_opposite_boundary_words}
+    \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products}
+    \leanok
+    \uses{lem:closure_property_opposite_boundary_comparison_from_right_words,
+        lem:closure_property_auxiliary_product_from_right_products}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$.
+    Let $\psi$ be a state on the chain of length $M+1$, and let
+    $Y_i(\tau)$ be matrices satisfying
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    Fix a complementary word $\mu$ and a matrix $X$. Suppose that, for every
+    boundary letter $\eta$ and every physical letter $j$,
+    \[
+        Y_M(\tau^+_{\eta}(\mu))A^j
+        =
+        A^\mu A^jX .
+    \]
+    Suppose also that, for every $\eta$, $j$, and every word $\sigma$ of length
+    $L_0$,
+    \[
+        Y_{M+1-L_0}(\tau^-_{\eta}(\mu))A^jA^\sigma
+        =
+        A^\mu A^jXA^\sigma .
+    \]
+    Then there are boundary conditions $\rho^+_{j,\sigma}$ and
+    $\rho^-_{j,\sigma}$ such that, for every complementary position $k$,
+    \[
+        \rho^+_{j,\sigma}(k+L_0)=\mu_k,
+        \qquad
+        \rho^-_{j,\sigma}(k+1)=\mu_k,
+    \]
+    and, for every physical letter $j$ and every word $\sigma$ of length
+    $L_0$,
+    \[
+        Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_right_words}
+    gives, for every $\eta$ and $j$,
+    \[
+        Y_{M+1-L_0}(\tau^-_{\eta}(\mu))A^j
+        =
+        A^\mu A^jX .
+    \]
+    Combining this equation with
+    \[
+        Y_M(\tau^+_{\eta}(\mu))A^j=A^\mu A^jX
+    \]
+    gives
+    \[
+        Y_M(\tau^+_{\eta}(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_{\eta}(\mu))A^j .
+    \]
+    Lemma~\ref{lem:closure_property_auxiliary_product_from_right_products}
+    then gives the displayed boundary conditions and auxiliary product.
+\end{proof}
+
 \begin{lemma}[Auxiliary first-letter form of the closure property]
     \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
     \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}
@@ -2255,7 +2361,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{def:l_blk_injective, def:ground_space_map, rem:cyclic_window_operators,
         lem:closure_property_boundary_one_sided_products_ground_space_map,
-        lem:closure_property_auxiliary_product_from_right_products}
+        lem:closure_property_auxiliary_product_from_opposite_boundary_words}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let $\psi$ be a
     state on the chain of length $M+1$ with open-chain representation
     $\psi=\Gamma_{M+1}(X)$.  Let $Y_i(\tau)$ be matrices satisfying
@@ -2290,17 +2396,17 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         A^\mu A^j X .
     \]
-    By Lemma~\ref{lem:closure_property_auxiliary_product_from_right_products},
-    it remains to prove, for every boundary letter $\eta$ and every physical
-    letter $j$, the comparison with the opposite boundary,
+    By
+    Lemma~\ref{lem:closure_property_auxiliary_product_from_opposite_boundary_words},
+    it remains to prove, for every boundary letter $\eta$, every physical
+    letter $j$, and every word $\sigma$ of length $L_0$,
     \[
-        Y_{M+1-L_0}(\tau^-_{\eta}(\mu))A^j
+        Y_{M+1-L_0}(\tau^-_{\eta}(\mu))A^jA^\sigma
         =
-        A^\mu A^j X .
+        A^\mu A^jXA^\sigma .
     \]
-    This is the remaining right-product comparison associated with the
-    sentence on closing the boundaries in
-    \cite[lines~2078--2079]{Cirac2021Matrix}.
+    This is the remaining coordinate identity for the closing-boundary paragraph
+    of \cite[lines~2078--2079]{Cirac2021Matrix}.
     % Remaining gap recorded in docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 


### PR DESCRIPTION
Summary
- Adds the no-sorry cancellation step: if (Y_{M+1-L0}(tau^-_eta(mu)) A^j - A^mu A^j X) A^sigma = 0 for every word sigma of length L0, then Y_{M+1-L0}(tau^-_eta(mu)) A^j = A^mu A^j X.
- Adds the auxiliary-product reduction using the last-boundary equation and the opposite-boundary comparison after multiplication by length-L0 words.
- Updates the parent-Hamiltonian blueprint so the remaining #2405 step is a displayed coordinate equation attached to the inverting-and-growing-back argument when closing the boundaries, without claiming that the source displays this formula.

Remaining gap
- This does not close #2405. The remaining local coordinate comparison is: Y_{M+1-L0}(tau^-_eta(mu)) A^j A^sigma = A^mu A^j X A^sigma for every eta, j, and sigma.

Validation
- lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info
- python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
- python3 scripts/check_oversized_lean_files.py --root .
- git diff --check origin/main...HEAD
- leanblueprint web

Notes
- The Lean build still reports the intended open sorry in TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean at the remaining #2405 gap.
- A full root build before the final rebase completed with existing warnings outside this change.
- lake exe checkdecls blueprint/lean_decls runs, but the global declaration list still has pre-existing missing non-parent declarations; the new parent declarations are not among them.

Refs #2405

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof refactor in parent-Hamiltonian boundary closing with no auth or runtime behavior changes; the main gap remains an explicit sorry unchanged in scope.
> 
> **Overview**
> This PR **splits the closing-boundary auxiliary product** so the only unfinished step is a **word-padded opposite-boundary identity** (still `sorry`, #2405).
> 
> It adds proved Lean lemmas: **right-multiplying by every length-\(L_0\) word** forces the unpadded mirror comparison via \(L_0\)-block injectivity, and a lemma that **combines the last-boundary one-sided equation with that padded hypothesis** to recover the auxiliary \(\rho^\pm\) product data. `closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap` now reduces to proving padded mirror equations instead of a bare right-product equality, and its docstring/blueprint text **reframe the open gap** as the displayed \(A^\sigma\)-padded coordinate equation rather than claiming the source states it outright.
> 
> The parent-Hamiltonian blueprint gains matching lemmas and updates the auxiliary boundary-product proof to cite the new reduction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804767f75a4ab2a5205845c469b838ed37ba24af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->