### PR TITLE
feat(entropy): partial-trace composition and reindex lemmas

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -302,6 +302,29 @@ theorem traceAC_ABC_isHermitian
   exact Finset.sum_congr rfl fun a _ =>
     Finset.sum_congr rfl fun c _ => hρ.apply (a, b₁, c) (a, b₂, c)
 
+/-- `traceAC_ABC` (tracing the first and third factors, keeping the middle) as a
+right partial trace, after grouping `A` and `C` on the right. -/
+theorem traceAC_eq_partialTraceRight
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ) :
+    traceAC_ABC ρ
+      = partialTraceRight (ρ.submatrix
+          (fun p : Fin dB × (Fin dA × Fin dC) => (p.2.1, p.1, p.2.2))
+          (fun p : Fin dB × (Fin dA × Fin dC) => (p.2.1, p.1, p.2.2))) := by
+  ext b₁ b₂
+  simp only [traceAC_ABC, partialTraceRight_apply, Matrix.submatrix_apply,
+    Fintype.sum_prod_type]
+
+/-- `traceA_ABC` (tracing the first factor, keeping the last two) as a right
+partial trace, after grouping `A` on the right. -/
+theorem traceA_eq_partialTraceRight
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ) :
+    traceA_ABC ρ
+      = partialTraceRight (ρ.submatrix
+          (fun p : (Fin dB × Fin dC) × Fin dA => (p.2, p.1.1, p.1.2))
+          (fun p : (Fin dB × Fin dC) × Fin dA => (p.2, p.1.1, p.1.2))) := by
+  ext bc₁ bc₂
+  simp only [traceA_ABC, partialTraceRight_apply, Matrix.submatrix_apply]
+
 end Matrix
 
 end TripartiteTrace

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -303,7 +303,7 @@ theorem traceAC_ABC_isHermitian
     Finset.sum_congr rfl fun c _ => hρ.apply (a, b₁, c) (a, b₂, c)
 
 /-- `traceAC_ABC` (tracing the first and third factors, keeping the middle) as a
-right partial trace, after grouping `A` and `C` on the right. -/
+right partial trace, after grouping the first and third factors on the right. -/
 theorem traceAC_eq_partialTraceRight
     (ρ : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ) :
     traceAC_ABC ρ
@@ -315,7 +315,7 @@ theorem traceAC_eq_partialTraceRight
     Fintype.sum_prod_type]
 
 /-- `traceA_ABC` (tracing the first factor, keeping the last two) as a right
-partial trace, after grouping `A` on the right. -/
+partial trace, after grouping the first factor on the right. -/
 theorem traceA_eq_partialTraceRight
     (ρ : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ) :
     traceA_ABC ρ

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -101,8 +101,9 @@ end GeneralRight
 
 /-- The trace is invariant under reindexing a matrix by an equivalence of its
 index type. -/
-theorem trace_submatrix_equiv {n m : Type*} [Fintype n] [Fintype m]
-    (e : m ≃ n) (M : Matrix n n ℂ) : (M.submatrix e e).trace = M.trace := by
+theorem trace_submatrix_equiv {n m R : Type*} [Fintype n] [Fintype m]
+    [AddCommMonoid R] (e : m ≃ n) (M : Matrix n n R) :
+    (M.submatrix e e).trace = M.trace := by
   simp only [Matrix.trace, Matrix.diag, Matrix.submatrix_apply]
   exact e.sum_comp fun j => M j j
 

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -99,6 +99,25 @@ theorem trace_partialTraceRight [Fintype α] (X : Matrix (α × β) (α × β) �
 
 end GeneralRight
 
+/-- The trace is invariant under reindexing a matrix by an equivalence of its
+index type. -/
+theorem trace_submatrix_equiv {n m : Type*} [Fintype n] [Fintype m]
+    (e : m ≃ n) (M : Matrix n n ℂ) : (M.submatrix e e).trace = M.trace := by
+  simp only [Matrix.trace, Matrix.diag, Matrix.submatrix_apply]
+  exact e.sum_comp fun j => M j j
+
+/-- **Composition of right partial traces.** Tracing the third factor and then
+the second equals tracing the combined `β × γ` factor after reassociating
+`α × (β × γ) ≃ (α × β) × γ`. -/
+theorem partialTraceRight_partialTraceRight {α β γ : Type*} [Fintype β] [Fintype γ]
+    (X : Matrix ((α × β) × γ) ((α × β) × γ) ℂ) :
+    partialTraceRight (partialTraceRight X)
+      = partialTraceRight (X.submatrix
+          (fun p : α × (β × γ) => ((p.1, p.2.1), p.2.2))
+          (fun p : α × (β × γ) => ((p.1, p.2.1), p.2.2))) := by
+  ext i j
+  simp only [partialTraceRight_apply, Matrix.submatrix_apply, Fintype.sum_prod_type]
+
 /-- **Partial trace over the first (left) tensor factor** (`tr_A`).
 
 For a matrix `X : M_{d·d'}(ℂ)` indexed by `(Fin d × Fin d')`, the partial


### PR DESCRIPTION
## Summary

General, reusable partial-trace / trace infrastructure, validated as the bridge between the SSA axiom's tripartite traces and the SAL block reduced states (toward Proposition 4.5, #2424).

- **`Matrix.trace_submatrix_equiv`** — `(M.submatrix e e).trace = M.trace` for `e : m ≃ n`. Trace is invariant under index reindexing.
- **`Matrix.partialTraceRight_partialTraceRight`** — composition of right partial traces: `partialTraceRight (partialTraceRight X) = partialTraceRight (X.submatrix assoc assoc)`. Tracing the third then second factor equals tracing the combined `β × γ` factor.
- **`Matrix.traceAC_eq_partialTraceRight`**, **`Matrix.traceA_eq_partialTraceRight`** — the SSA tripartite traces `traceAC_ABC`/`traceA_ABC` (which trace the *left/outer* factors) re-expressed as a single `partialTraceRight` after grouping. This unifies them with the `partialTraceRight`-based `blockReducedState`, so block-reduced-state arguments and SSA arguments speak the same partial-trace language.

## Why

These are the connective lemmas in the validated decomposition of #2424 (Prop 4.5, mutual-information monotonicity): the SSA axiom is stated on flat `Fin dA × Fin dB × Fin dC` with `traceA/C/AC_ABC`, while the SAL reduced states use `Matrix.partialTraceRight`; these lemmas let nested block reductions (`partialTraceRight_partialTraceRight`) and the outer traces (`trace*_eq_partialTraceRight`) be matched up, with `trace_submatrix_equiv` handling the trace-normalization side.

## Verification

- `lake build TNLean.Channel.PartialTrace TNLean.Analysis.Entropy` green; all `sorry`/`axiom`-free.
- Additions only; general (universe-polymorphic) statements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Mathlib-style lemmas only; no API or runtime behavior changes.
> 
> **Overview**
> Adds **reusable partial-trace lemmas** so tripartite SSA traces and SAL-style `partialTraceRight` / block reductions can be rewritten in the same language (toward Prop 4.5 / #2424).
> 
> In `PartialTrace.lean`, **`trace_submatrix_equiv`** shows trace is unchanged under `submatrix` reindexing by an equivalence, and **`partialTraceRight_partialTraceRight`** identifies nested right partial traces with a single trace over `β × γ` after associating `α × (β × γ)`.
> 
> In `Entropy.lean`, **`traceAC_eq_partialTraceRight`** and **`traceA_eq_partialTraceRight`** express `traceAC_ABC` and `traceA_ABC` as one `partialTraceRight` on a suitably grouped/reindexed matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe56000135211140e1a7916016daab92e5b25ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->