### PR TITLE
feat(parent): add boundary coordinate stripping lemmas

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -182,7 +182,9 @@ import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
+import TNLean.MPS.ParentHamiltonian.BoundaryStripping
 import TNLean.MPS.ParentHamiltonian.BoundaryClosing
+import TNLean.MPS.ParentHamiltonian.BoundaryClosingCoordinate
 import TNLean.Axioms.Beigi
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -127,38 +127,9 @@ theorem wrappedMiddleBackground_first_products_eq_of_complement_eq
     (cyclicRestrictₗ_wrappedMiddleBackground_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
 
-/-- The previous equation remains true after right multiplication by any
-length-\(L_0\) word:
-\[
-  Y_\rho A^j A^\sigma =
-  Y_{\tau^+_\eta(\mu)} A^j A^\sigma .
-\] -/
-theorem wrappedMiddleBackground_first_products_eq_of_complement_eq_right_word
-    {A : MPSTensor d D} {L₀ M : ℕ}
-    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
-    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
-    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
-    {Yρ Yτ : Matrix (Fin D) (Fin D) ℂ}
-    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
-      ρ ⟨k.val + L₀, by omega⟩ = μ k)
-    (hYρ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
-        (⟨M, by omega⟩ : Fin (M + 1)) ρ ψ =
-      groundSpaceMap A (L₀ + 1) Yρ)
-    (hYτ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
-        (⟨M, by omega⟩ : Fin (M + 1))
-        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
-      groundSpaceMap A (L₀ + 1) Yτ) :
-    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
-      Yρ * A j * evalWord A (List.ofFn σ) =
-        Yτ * A j * evalWord A (List.ofFn σ) := by
-  intro j σ
-  exact congrArg (fun Y => Y * evalWord A (List.ofFn σ))
-    (wrappedMiddleBackground_first_products_eq_of_complement_eq
-      (A := A) hInj hL₀ hM η μ ρ hρ hYρ hYτ j)
-
 /-- For the opposite boundary-crossing interval, any outside configuration with
 the same complementary word gives the same restriction as the boundary
-assignment \(\tau^-_\eta(\mu)\) used in the closure property. -/
+condition \(\tau^-_\eta(\mu)\) used in the closure property. -/
 theorem cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
     {L₀ M : ℕ} (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)} (η : Fin d)
@@ -231,35 +202,6 @@ theorem mirrorMiddleBackground_first_products_eq_of_complement_eq
     (mirrorMiddleBackground L₀ (M + 1) η μ) ψ hYρ hYτ
     (cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
-
-/-- The opposite-boundary first-product equation remains true after right
-multiplication by any length-\(L_0\) word:
-\[
-  Y_\rho A^j A^\sigma =
-  Y_{\tau^-_\eta(\mu)} A^j A^\sigma .
-\] -/
-theorem mirrorMiddleBackground_first_products_eq_of_complement_eq_right_word
-    {A : MPSTensor d D} {L₀ M : ℕ}
-    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
-    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
-    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
-    {Yρ Yτ : Matrix (Fin D) (Fin D) ℂ}
-    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
-      ρ ⟨k.val + 1, by omega⟩ = μ k)
-    (hYρ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
-        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) ρ ψ =
-      groundSpaceMap A (L₀ + 1) Yρ)
-    (hYτ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
-        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
-        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ =
-      groundSpaceMap A (L₀ + 1) Yτ) :
-    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
-      Yρ * A j * evalWord A (List.ofFn σ) =
-        Yτ * A j * evalWord A (List.ofFn σ) := by
-  intro j σ
-  exact congrArg (fun Y => Y * evalWord A (List.ofFn σ))
-    (mirrorMiddleBackground_first_products_eq_of_complement_eq
-      (A := A) hInj hL₀ hM η μ ρ hρ hYρ hYτ j)
 
 /-- Pointwise complement reduction for the boundary-closing product equation.
 
@@ -573,27 +515,6 @@ theorem closure_property_boundary_condition_product_of_window_witnesses
     have hsum : M + 1 - L₀ + (L₀ - 1) = M := by omega
     rw [hsum, Nat.mod_eq_of_lt (by omega)]
   simpa [Y, hstart, hend] using hprod
-
-/-- The fixed-boundary-condition product equation after right multiplication
-by an arbitrary matrix. -/
-lemma closure_property_boundary_condition_product_of_window_witnesses_mul_right
-    {A : MPSTensor d D} {L₀ M : ℕ}
-    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
-    {ψ : NSiteSpace d (M + 1)}
-    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
-      Matrix (Fin D) (Fin D) ℂ)
-    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
-      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
-        groundSpaceMap A (L₀ + 1) (YAt i τ))
-    (ρ : Fin (M + 1) → Fin d) (R : Matrix (Fin D) (Fin D) ℂ) :
-    YAt ⟨M + 1 - L₀, by omega⟩ ρ *
-        evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
-          ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) * R =
-      evalWord A (List.ofFn (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩)) *
-        YAt ⟨M, by omega⟩ ρ * R := by
-  exact congrArg (fun Y => Y * R)
-    (closure_property_boundary_condition_product_of_window_witnesses
-      (A := A) hInj hL₀ hM YAt hYAt ρ)
 
 /-- Product equation obtained by moving from the last site through the closing
 boundary to the opposite boundary-crossing support.

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -7,7 +7,7 @@ import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
 
 /-!
-# Boundary assignments for the closure property
+# Boundary conditions for the closure property
 
 This file records elementary coordinate facts for the two boundary-crossing
 supports used in the closure property of the normal parent-Hamiltonian
@@ -57,7 +57,7 @@ theorem cyclicRestrictₗ_first_products_eq_of_restriction_eq
 
 /-- For the boundary-crossing interval starting at the last site, any outside
 configuration with the same complementary word gives the same restriction as the
-boundary assignment \(\tau^+_\eta(\mu)\) used in the closure property. -/
+boundary condition \(\tau^+_\eta(\mu)\) used in the closure property. -/
 theorem cyclicRestrictₗ_wrappedMiddleBackground_eq_of_complement_eq
     {L₀ M : ℕ} (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)} (η : Fin d)
@@ -126,6 +126,35 @@ theorem wrappedMiddleBackground_first_products_eq_of_complement_eq
     hYρ hYτ
     (cyclicRestrictₗ_wrappedMiddleBackground_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
+
+/-- The previous equation remains true after right multiplication by any
+length-\(L_0\) word:
+\[
+  Y_\rho A^j A^\sigma =
+  Y_{\tau^+_\eta(\mu)} A^j A^\sigma .
+\] -/
+theorem wrappedMiddleBackground_first_products_eq_of_complement_eq_right_word
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
+    {Yρ Yτ : Matrix (Fin D) (Fin D) ℂ}
+    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρ ⟨k.val + L₀, by omega⟩ = μ k)
+    (hYρ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M, by omega⟩ : Fin (M + 1)) ρ ψ =
+      groundSpaceMap A (L₀ + 1) Yρ)
+    (hYτ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M, by omega⟩ : Fin (M + 1))
+        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+      groundSpaceMap A (L₀ + 1) Yτ) :
+    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      Yρ * A j * evalWord A (List.ofFn σ) =
+        Yτ * A j * evalWord A (List.ofFn σ) := by
+  intro j σ
+  exact congrArg (fun Y => Y * evalWord A (List.ofFn σ))
+    (wrappedMiddleBackground_first_products_eq_of_complement_eq
+      (A := A) hInj hL₀ hM η μ ρ hρ hYρ hYτ j)
 
 /-- For the opposite boundary-crossing interval, any outside configuration with
 the same complementary word gives the same restriction as the boundary
@@ -203,14 +232,43 @@ theorem mirrorMiddleBackground_first_products_eq_of_complement_eq
     (cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
 
+/-- The opposite-boundary first-product equation remains true after right
+multiplication by any length-\(L_0\) word:
+\[
+  Y_\rho A^j A^\sigma =
+  Y_{\tau^-_\eta(\mu)} A^j A^\sigma .
+\] -/
+theorem mirrorMiddleBackground_first_products_eq_of_complement_eq_right_word
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
+    {Yρ Yτ : Matrix (Fin D) (Fin D) ℂ}
+    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρ ⟨k.val + 1, by omega⟩ = μ k)
+    (hYρ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) ρ ψ =
+      groundSpaceMap A (L₀ + 1) Yρ)
+    (hYτ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ =
+      groundSpaceMap A (L₀ + 1) Yτ) :
+    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      Yρ * A j * evalWord A (List.ofFn σ) =
+        Yτ * A j * evalWord A (List.ofFn σ) := by
+  intro j σ
+  exact congrArg (fun Y => Y * evalWord A (List.ofFn σ))
+    (mirrorMiddleBackground_first_products_eq_of_complement_eq
+      (A := A) hInj hL₀ hM η μ ρ hρ hYρ hYτ j)
+
 /-- Pointwise complement reduction for the boundary-closing product equation.
 
-The auxiliary boundary assignments may depend on the fixed physical letter and
-the length-\(L_0\) word. If, for each pair \(j,\sigma\), the assignments
+The auxiliary boundary conditions may depend on the fixed physical letter and
+the length-\(L_0\) word. If, for each pair \(j,\sigma\), the conditions
 \(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) carry the same complementary
 word as \(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\), respectively, then a
-product equation for those auxiliary assignments gives the corresponding
-canonical boundary-assignment equation:
+product equation for these two conditions gives the corresponding equation for
+\(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\):
 \[
   Y_M(\tau^+_\eta(\mu)) A^j A^\sigma
   =
@@ -270,18 +328,18 @@ theorem boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments
 
 /-- Complement reduction for the boundary-closing product equation.
 
-Suppose two auxiliary outside assignments have the same complementary words as
+Suppose two auxiliary boundary conditions have the same complementary words as
 \(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\), respectively.  If the desired
-product equation has already been proved for those two assignments, then it also
-holds for the canonical boundary assignments:
+product equation has already been proved for those two conditions, then it also
+holds for the displayed boundary conditions:
 \[
   Y_M(\tau^+_\eta(\mu)) A^j A^\sigma
   =
   Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma .
 \]
 
-This isolates the remaining closure-property task as an adjacent-window product
-identity between compatible outside assignments. -/
+This reduces the closure-property comparison to an adjacent-window product
+identity between compatible boundary conditions. -/
 theorem boundary_closing_product_eq_of_compatible_backgrounds
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -515,6 +573,27 @@ theorem closure_property_boundary_condition_product_of_window_witnesses
     have hsum : M + 1 - L₀ + (L₀ - 1) = M := by omega
     rw [hsum, Nat.mod_eq_of_lt (by omega)]
   simpa [Y, hstart, hend] using hprod
+
+/-- The fixed-boundary-condition product equation after right multiplication
+by an arbitrary matrix. -/
+lemma closure_property_boundary_condition_product_of_window_witnesses_mul_right
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (ρ : Fin (M + 1) → Fin d) (R : Matrix (Fin D) (Fin D) ℂ) :
+    YAt ⟨M + 1 - L₀, by omega⟩ ρ *
+        evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+          ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) * R =
+      evalWord A (List.ofFn (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩)) *
+        YAt ⟨M, by omega⟩ ρ * R := by
+  exact congrArg (fun Y => Y * R)
+    (closure_property_boundary_condition_product_of_window_witnesses
+      (A := A) hInj hL₀ hM YAt hYAt ρ)
 
 /-- Product equation obtained by moving from the last site through the closing
 boundary to the opposite boundary-crossing support.
@@ -913,10 +992,10 @@ lemma closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products
   intro η j
   exact (hLast η j).trans (hMirrorRight η j).symm
 
-/-- Auxiliary boundary-assignment product equation needed at the closing
+/-- Auxiliary boundary-condition product equation needed at the closing
 boundary.
 
-For each pair \(j,\sigma\), this states the existence of boundary assignments
+For each pair \(j,\sigma\), this states the existence of boundary conditions
 \(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) with the same complementary
 word \(\mu\) as the two displayed boundary conditions, and satisfying
 \[

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingCoordinate.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingCoordinate.lean
@@ -76,9 +76,14 @@ theorem mirrorMiddleBackground_first_products_eq_of_complement_eq_right_word
     (mirrorMiddleBackground_first_products_eq_of_complement_eq
       (A := A) hInj hL₀ hM η μ ρ hρ hYρ hYτ j)
 
-/-- The fixed-boundary-condition product equation after right multiplication
-by an arbitrary matrix. -/
-lemma closure_property_boundary_condition_product_of_window_witnesses_mul_right
+/-- The fixed-boundary-condition product equation remains true after right
+multiplication by an arbitrary matrix:
+\[
+  Y_{M+1-L_0}(\rho)A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}R
+  =
+  A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho)R .
+\] -/
+theorem closure_property_boundary_condition_product_of_window_witnesses_mul_right
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)}

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingCoordinate.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingCoordinate.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BoundaryClosing
+
+/-!
+# Coordinate consequences for closing the parent-Hamiltonian boundary
+
+This file contains formula-level consequences of the boundary-condition
+comparison lemmas in `BoundaryClosing`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The last-boundary first-product equation remains true after right
+multiplication by any length-\(L_0\) word:
+\[
+  Y_\rho A^j A^\sigma =
+  Y_{\tau^+_\eta(\mu)} A^j A^\sigma .
+\] -/
+theorem wrappedMiddleBackground_first_products_eq_of_complement_eq_right_word
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
+    {Yρ Yτ : Matrix (Fin D) (Fin D) ℂ}
+    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρ ⟨k.val + L₀, by omega⟩ = μ k)
+    (hYρ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M, by omega⟩ : Fin (M + 1)) ρ ψ =
+      groundSpaceMap A (L₀ + 1) Yρ)
+    (hYτ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M, by omega⟩ : Fin (M + 1))
+        (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+      groundSpaceMap A (L₀ + 1) Yτ) :
+    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      Yρ * A j * evalWord A (List.ofFn σ) =
+        Yτ * A j * evalWord A (List.ofFn σ) := by
+  intro j σ
+  exact congrArg (fun Y => Y * evalWord A (List.ofFn σ))
+    (wrappedMiddleBackground_first_products_eq_of_complement_eq
+      (A := A) hInj hL₀ hM η μ ρ hρ hYρ hYτ j)
+
+/-- The opposite-boundary first-product equation remains true after right
+multiplication by any length-\(L_0\) word:
+\[
+  Y_\rho A^j A^\sigma =
+  Y_{\tau^-_\eta(\mu)} A^j A^\sigma .
+\] -/
+theorem mirrorMiddleBackground_first_products_eq_of_complement_eq_right_word
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} (η : Fin d)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) (ρ : Fin (M + 1) → Fin d)
+    {Yρ Yτ : Matrix (Fin D) (Fin D) ℂ}
+    (hρ : ∀ k : Fin (M + 1 - (L₀ + 1)),
+      ρ ⟨k.val + 1, by omega⟩ = μ k)
+    (hYρ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1)) ρ ψ =
+      groundSpaceMap A (L₀ + 1) Yρ)
+    (hYτ : cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+        (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+        (mirrorMiddleBackground L₀ (M + 1) η μ) ψ =
+      groundSpaceMap A (L₀ + 1) Yτ) :
+    ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+      Yρ * A j * evalWord A (List.ofFn σ) =
+        Yτ * A j * evalWord A (List.ofFn σ) := by
+  intro j σ
+  exact congrArg (fun Y => Y * evalWord A (List.ofFn σ))
+    (mirrorMiddleBackground_first_products_eq_of_complement_eq
+      (A := A) hInj hL₀ hM η μ ρ hρ hYρ hYτ j)
+
+/-- The fixed-boundary-condition product equation after right multiplication
+by an arbitrary matrix. -/
+lemma closure_property_boundary_condition_product_of_window_witnesses_mul_right
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (ρ : Fin (M + 1) → Fin d) (R : Matrix (Fin D) (Fin D) ℂ) :
+    YAt ⟨M + 1 - L₀, by omega⟩ ρ *
+        evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+          ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) * R =
+      evalWord A (List.ofFn (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩)) *
+        YAt ⟨M, by omega⟩ ρ * R := by
+  exact congrArg (fun Y => Y * R)
+    (closure_property_boundary_condition_product_of_window_witnesses
+      (A := A) hInj hL₀ hM YAt hYAt ρ)
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryStripping.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.WrappingWindow
+
+/-!
+# Boundary-word stripping for parent-Hamiltonian closure
+
+This file records the left-handed padding form used when a full word span
+removes an unknown right boundary matrix.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- If every length-`k` word product annihilates `Z` on the left, and words of
+some longer length `n` span the full matrix algebra, then `Z = 0`. -/
+theorem eq_zero_of_evalWord_mul_eq_zero_of_wordSpan_eq_top
+    {A : MPSTensor d D} {k n : ℕ} {Z : Matrix (Fin D) (Fin D) ℂ}
+    (htop : wordSpan A n = ⊤) (hkn : k ≤ n)
+    (hzero : ∀ σ : Fin k → Fin d, evalWord A (List.ofFn σ) * Z = 0) :
+    Z = 0 := by
+  have hzero_span : ∀ M ∈ wordSpan A n, M * Z = 0 := by
+    apply Submodule.span_induction
+    · intro M hM
+      rcases hM with ⟨σ, rfl⟩
+      let w := List.ofFn σ
+      have hdrop_len : (w.drop (n - k)).length = k := by
+        rw [List.length_drop]
+        have hwlen : w.length = n := by simp [w]
+        omega
+      let σk : Fin k → Fin d := fun i =>
+        (w.drop (n - k)).get ⟨i.val, by simp [hdrop_len]⟩
+      have hσk : List.ofFn σk = w.drop (n - k) := by
+        simpa [σk, hdrop_len] using (List.ofFn_get (w.drop (n - k)))
+      have hsuffix : evalWord A (w.drop (n - k)) * Z = 0 := by
+        simpa [hσk] using hzero σk
+      calc
+        evalWord A w * Z =
+            evalWord A (w.take (n - k) ++ w.drop (n - k)) * Z := by
+          rw [List.take_append_drop (n - k) w]
+        _ = (evalWord A (w.take (n - k)) *
+              evalWord A (w.drop (n - k))) * Z := by
+          rw [evalWord_append]
+        _ = evalWord A (w.take (n - k)) *
+              (evalWord A (w.drop (n - k)) * Z) := by
+          rw [Matrix.mul_assoc]
+        _ = 0 := by rw [hsuffix, mul_zero]
+    · simp
+    · intro M₁ M₂ _ _ h₁ h₂
+      simp [Matrix.add_mul, h₁, h₂]
+    · intro c M _ hM
+      simp [hM]
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) * Z = 0 :=
+    hzero_span 1 (htop ▸ Submodule.mem_top)
+  simpa using h1
+
+/-- Block-injective left-annihilation padding variant.
+
+If `A` is `L₀`-block-injective, then a relation
+`evalWord A (List.ofFn σ) * Z = 0` for every length-`k` word already forces
+`Z = 0` whenever `k` is bounded by a positive multiple of `L₀`. -/
+theorem eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul
+    {A : MPSTensor d D} {L₀ k q : ℕ} (hInj : IsNBlkInjective A L₀)
+    (hq : 1 ≤ q) (hkq : k ≤ q * L₀) {Z : Matrix (Fin D) (Fin D) ℂ}
+    (hzero : ∀ σ : Fin k → Fin d, evalWord A (List.ofFn σ) * Z = 0) :
+    Z = 0 := by
+  exact eq_zero_of_evalWord_mul_eq_zero_of_wordSpan_eq_top
+    (A := A) (k := k) (n := q * L₀)
+    (wordSpan_top_of_mul A ((wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj) q hq)
+    hkq hzero
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryStripping.lean
@@ -62,9 +62,9 @@ theorem eq_zero_of_evalWord_mul_eq_zero_of_wordSpan_eq_top
 
 /-- Block-injective left-annihilation padding variant.
 
-If `A` is `L₀`-block-injective, then a relation
-`evalWord A (List.ofFn σ) * Z = 0` for every length-`k` word already forces
-`Z = 0` whenever `k` is bounded by a positive multiple of `L₀`. -/
+If `A` is `L₀`-block-injective, then a relation \(A^wZ=0\) for every word
+`w` of length `k` already forces \(Z=0\) whenever `k` is bounded by a positive
+multiple of `L₀`. -/
 theorem eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul
     {A : MPSTensor d D} {L₀ k q : ℕ} (hInj : IsNBlkInjective A L₀)
     (hq : 1 ≤ q) (hkq : k ≤ q * L₀) {Z : Matrix (Fin D) (Fin D) ℂ}

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -805,63 +805,6 @@ theorem eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
     (wordSpan_top_of_mul A ((wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj) q hq)
     hkq hzero
 
-/-- If every length-`k` word product annihilates `Z` on the left, and words of
-some longer length `n` span the full matrix algebra, then `Z = 0`. -/
-theorem eq_zero_of_evalWord_mul_eq_zero_of_wordSpan_eq_top
-    {A : MPSTensor d D} {k n : ℕ} {Z : Matrix (Fin D) (Fin D) ℂ}
-    (htop : wordSpan A n = ⊤) (hkn : k ≤ n)
-    (hzero : ∀ σ : Fin k → Fin d, evalWord A (List.ofFn σ) * Z = 0) :
-    Z = 0 := by
-  have hzero_span : ∀ M ∈ wordSpan A n, M * Z = 0 := by
-    apply Submodule.span_induction
-    · intro M hM
-      rcases hM with ⟨σ, rfl⟩
-      let w := List.ofFn σ
-      have hdrop_len : (w.drop (n - k)).length = k := by
-        rw [List.length_drop]
-        have hwlen : w.length = n := by simp [w]
-        omega
-      let σk : Fin k → Fin d := fun i =>
-        (w.drop (n - k)).get ⟨i.val, by simp [hdrop_len]⟩
-      have hσk : List.ofFn σk = w.drop (n - k) := by
-        simpa [σk, hdrop_len] using (List.ofFn_get (w.drop (n - k)))
-      have hsuffix : evalWord A (w.drop (n - k)) * Z = 0 := by
-        simpa [hσk] using hzero σk
-      calc
-        evalWord A w * Z =
-            evalWord A (w.take (n - k) ++ w.drop (n - k)) * Z := by
-          rw [List.take_append_drop (n - k) w]
-        _ = (evalWord A (w.take (n - k)) *
-              evalWord A (w.drop (n - k))) * Z := by
-          rw [evalWord_append]
-        _ = evalWord A (w.take (n - k)) *
-              (evalWord A (w.drop (n - k)) * Z) := by
-          rw [Matrix.mul_assoc]
-        _ = 0 := by rw [hsuffix, mul_zero]
-    · simp
-    · intro M₁ M₂ _ _ h₁ h₂
-      simp [Matrix.add_mul, h₁, h₂]
-    · intro c M _ hM
-      simp [hM]
-  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) * Z = 0 :=
-    hzero_span 1 (htop ▸ Submodule.mem_top)
-  simpa using h1
-
-/-- Block-injective left-annihilation padding variant.
-
-If `A` is `L₀`-block-injective, then a relation
-`evalWord A (List.ofFn σ) * Z = 0` for every length-`k` word already forces
-`Z = 0` whenever `k` is bounded by a positive multiple of `L₀`. -/
-theorem eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul
-    {A : MPSTensor d D} {L₀ k q : ℕ} (hInj : IsNBlkInjective A L₀)
-    (hq : 1 ≤ q) (hkq : k ≤ q * L₀) {Z : Matrix (Fin D) (Fin D) ℂ}
-    (hzero : ∀ σ : Fin k → Fin d, evalWord A (List.ofFn σ) * Z = 0) :
-    Z = 0 := by
-  exact eq_zero_of_evalWord_mul_eq_zero_of_wordSpan_eq_top
-    (A := A) (k := k) (n := q * L₀)
-    (wordSpan_top_of_mul A ((wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj) q hq)
-    hkq hzero
-
 /-- A right boundary witness is unique once its products with all one-site
 tensors are fixed.
 

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -805,6 +805,63 @@ theorem eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
     (wordSpan_top_of_mul A ((wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj) q hq)
     hkq hzero
 
+/-- If every length-`k` word product annihilates `Z` on the left, and words of
+some longer length `n` span the full matrix algebra, then `Z = 0`. -/
+theorem eq_zero_of_evalWord_mul_eq_zero_of_wordSpan_eq_top
+    {A : MPSTensor d D} {k n : ℕ} {Z : Matrix (Fin D) (Fin D) ℂ}
+    (htop : wordSpan A n = ⊤) (hkn : k ≤ n)
+    (hzero : ∀ σ : Fin k → Fin d, evalWord A (List.ofFn σ) * Z = 0) :
+    Z = 0 := by
+  have hzero_span : ∀ M ∈ wordSpan A n, M * Z = 0 := by
+    apply Submodule.span_induction
+    · intro M hM
+      rcases hM with ⟨σ, rfl⟩
+      let w := List.ofFn σ
+      have hdrop_len : (w.drop (n - k)).length = k := by
+        rw [List.length_drop]
+        have hwlen : w.length = n := by simp [w]
+        omega
+      let σk : Fin k → Fin d := fun i =>
+        (w.drop (n - k)).get ⟨i.val, by simp [hdrop_len]⟩
+      have hσk : List.ofFn σk = w.drop (n - k) := by
+        simpa [σk, hdrop_len] using (List.ofFn_get (w.drop (n - k)))
+      have hsuffix : evalWord A (w.drop (n - k)) * Z = 0 := by
+        simpa [hσk] using hzero σk
+      calc
+        evalWord A w * Z =
+            evalWord A (w.take (n - k) ++ w.drop (n - k)) * Z := by
+          rw [List.take_append_drop (n - k) w]
+        _ = (evalWord A (w.take (n - k)) *
+              evalWord A (w.drop (n - k))) * Z := by
+          rw [evalWord_append]
+        _ = evalWord A (w.take (n - k)) *
+              (evalWord A (w.drop (n - k)) * Z) := by
+          rw [Matrix.mul_assoc]
+        _ = 0 := by rw [hsuffix, mul_zero]
+    · simp
+    · intro M₁ M₂ _ _ h₁ h₂
+      simp [Matrix.add_mul, h₁, h₂]
+    · intro c M _ hM
+      simp [hM]
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) * Z = 0 :=
+    hzero_span 1 (htop ▸ Submodule.mem_top)
+  simpa using h1
+
+/-- Block-injective left-annihilation padding variant.
+
+If `A` is `L₀`-block-injective, then a relation
+`evalWord A (List.ofFn σ) * Z = 0` for every length-`k` word already forces
+`Z = 0` whenever `k` is bounded by a positive multiple of `L₀`. -/
+theorem eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul
+    {A : MPSTensor d D} {L₀ k q : ℕ} (hInj : IsNBlkInjective A L₀)
+    (hq : 1 ≤ q) (hkq : k ≤ q * L₀) {Z : Matrix (Fin D) (Fin D) ℂ}
+    (hzero : ∀ σ : Fin k → Fin d, evalWord A (List.ofFn σ) * Z = 0) :
+    Z = 0 := by
+  exact eq_zero_of_evalWord_mul_eq_zero_of_wordSpan_eq_top
+    (A := A) (k := k) (n := q * L₀)
+    (wordSpan_top_of_mul A ((wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj) q hq)
+    hkq hzero
+
 /-- A right boundary witness is unique once its products with all one-site
 tensors are fixed.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1702,9 +1702,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         MPSTensor.eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul}
     \leanok
     \uses{def:l_blk_injective}
-    If $A$ is $L_0$-block-injective and $q \ge 1$, then an operator $Z$ is zero
-    whenever it annihilates every length-$k$ word product on either side and
-    \(k \le qL_0\):
+    If $A$ is $L_0$-block-injective, $q \ge 1$, and \(k \le qL_0\), then the
+    two one-sided annihilation statements are:
     \[
         Z A^w = 0 \quad (|w|=k) \qquad\Longrightarrow\qquad Z=0.
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1100,9 +1100,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{rem:cyclic_window_operators}
     On a chain of length $N=M+1$, with $L_0\le M$, fix a physical letter $\eta$
     used outside the complementary sites and a word $\mu$ of length
-    $M+1-(L_0+1)$. Write $\tau^+_\eta(\mu)$ for the boundary assignment at the
+    $M+1-(L_0+1)$. Write $\tau^+_\eta(\mu)$ for the boundary condition at the
     support crossing the last site and $\tau^-_\eta(\mu)$ for the boundary
-    assignment at the opposite boundary-crossing support. Their exposed complements
+    condition at the opposite boundary-crossing support. Their exposed complements
     are both exactly $\mu$.
 \end{lemma}
 
@@ -1134,7 +1134,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         MPSTensor.cyclicRestrictₗ_wrappedMiddleBackground_eq_of_complement_eq,
         MPSTensor.cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq,
         MPSTensor.wrappedMiddleBackground_first_products_eq_of_complement_eq,
-        MPSTensor.mirrorMiddleBackground_first_products_eq_of_complement_eq}
+        MPSTensor.mirrorMiddleBackground_first_products_eq_of_complement_eq,
+        MPSTensor.wrappedMiddleBackground_first_products_eq_of_complement_eq_right_word,
+        MPSTensor.mirrorMiddleBackground_first_products_eq_of_complement_eq_right_word}
     \leanok
     \uses{rem:cyclic_window_operators, lem:wrapped_middle_backgrounds}
     Let $A$ be $L_0$-block-injective, with $L_0>0$, and let $L_0\le M$.
@@ -1161,6 +1163,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \Longrightarrow
         Y_\rho A^j = Y_{\tau^-_\eta(\mu)}A^j .
     \]
+    Consequently, for every word $\sigma$ of length $L_0$, the two displayed
+    implications remain true after right multiplication by $A^\sigma$.
 \end{lemma}
 
 \begin{proof}
@@ -1169,10 +1173,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     restrictions. The two resulting length-$L_0$ vectors are represented by
     $\Gamma_{L_0}(Y_\rho A^j)$ and $\Gamma_{L_0}(Y_\tau A^j)$, and block
     injectivity makes $\Gamma_{L_0}$ injective. The two displayed special cases
-    follow from Lemma~\ref{lem:wrapped_middle_backgrounds}.
+    follow from Lemma~\ref{lem:wrapped_middle_backgrounds}. The
+    length-$L_0$ word forms are obtained by multiplying these equations on the
+    right by $A^\sigma$.
 \end{proof}
 
-\begin{lemma}[Reduction to compatible boundary assignments]
+\begin{lemma}[Reduction to compatible boundary conditions]
     \label{lem:boundary_closing_product_compatible_backgrounds}
     \lean{MPSTensor.boundary_closing_product_eq_of_compatible_backgrounds}
     \leanok
@@ -1186,7 +1192,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \Gamma_{L_0+1}(Y_i(\tau)).
     \]
     Fix a boundary letter $\eta$ and a complementary word $\mu$. Let $\rho^+$
-    and $\rho^-$ be two boundary assignments satisfying
+    and $\rho^-$ be two boundary conditions satisfying
     \[
         \rho^+_{k+L_0}=\mu_k,
         \qquad
@@ -1199,7 +1205,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\rho^-)A^jA^\sigma ,
     \]
-    then the same product equation holds for the canonical boundary assignments:
+    then the same product equation holds for $\tau^+_\eta(\mu)$ and
+    $\tau^-_\eta(\mu)$:
     \[
         Y_M(\tau^+_\eta(\mu))A^jA^\sigma
         =
@@ -1221,7 +1228,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     displayed product equation.
 \end{proof}
 
-\begin{theorem}[Pointwise reduction to compatible boundary assignments]
+\begin{theorem}[Pointwise reduction to compatible boundary conditions]
     \label{thm:boundary_closing_product_pointwise_compatible_boundary_assignments}
     \lean{MPSTensor.boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments}
     \leanok
@@ -1236,7 +1243,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
     Fix a boundary letter $\eta$ and a complementary word $\mu$. Suppose that,
     for each physical letter $j$ and word $\sigma$ of length $L_0$, boundary
-    assignments $\rho^+_{j,\sigma}$ and $\rho^-_{j,\sigma}$ satisfy, for every
+    conditions $\rho^+_{j,\sigma}$ and $\rho^-_{j,\sigma}$ satisfy, for every
     complementary position $k$,
     \[
         \rho^+_{j,\sigma}(k+L_0)=\mu_k,
@@ -1315,7 +1322,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{lemma}[Boundary-condition product at the closing boundary]
     \label{lem:closure_property_boundary_condition_product_window_witnesses}
-    \lean{MPSTensor.closure_property_boundary_condition_product_of_window_witnesses}
+    \lean{MPSTensor.closure_property_boundary_condition_product_of_window_witnesses,
+        MPSTensor.closure_property_boundary_condition_product_of_window_witnesses_mul_right}
     \leanok
     \uses{rem:cyclic_window_operators, lem:cyclic_window_boundary_matrix_transport}
     Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$. Let
@@ -1334,6 +1342,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho).
     \]
     For $L_0=1$, both products are empty.
+    The same equation remains true after multiplying both sides on the right by
+    any matrix \(R\).
 \end{lemma}
 
 \begin{proof}
@@ -1356,7 +1366,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         A^{\rho_{r+1}}Y_{M+2-L_0+r}(\rho).
     \]
     Multiplying these $L_0-1$ equations from left to right gives the displayed
-    product equation.
+    product equation. The right-multiplied form follows by multiplying this
+    equality by \(R\).
 \end{proof}
 
 \begin{lemma}[Long boundary-condition product at the closing boundary]
@@ -1687,14 +1698,19 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{lemma}[Padded complement annihilation]
     \label{lem:padded_complement_annihilation}
-    \lean{MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul}
+    \lean{MPSTensor.eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul,
+        MPSTensor.eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul}
     \leanok
     \uses{def:l_blk_injective}
-    If $A$ is $L_0$-block-injective and $q \ge 1$, then an operator $Z$ that
-    annihilates every length-$k$ word product on the left is zero whenever
-    $k \le qL_0$:
+    If $A$ is $L_0$-block-injective and $q \ge 1$, then an operator $Z$ is zero
+    whenever it annihilates every length-$k$ word product on either side and
+    \(k \le qL_0\):
     \[
         Z A^w = 0 \quad (|w|=k) \qquad\Longrightarrow\qquad Z=0.
+    \]
+    The left-handed form is
+    \[
+        A^w Z = 0 \quad (|w|=k) \qquad\Longrightarrow\qquad Z=0.
     \]
 \end{lemma}
 
@@ -1704,6 +1720,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     statement at every positive multiple $qL_0$. Each length-$qL_0$ word factors
     as a length-$k$ prefix followed by padding, so $Z$ annihilates all generators
     of the full span and hence annihilates the identity.
+    For the left-handed form, factor each length-$qL_0$ word as a prefix followed
+    by a length-$k$ suffix and use the same spanning argument.
 \end{proof}
 
 \begin{lemma}[One-sided boundary witnesses are unique]
@@ -1861,7 +1879,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         thm:ground_space_map_mpv_of_wrapped_witness_comparison}
     Let $A$ be injective after blocking $L_0>0$ sites and let $D \ge 1$. Assume
     $N \ge 2$ and $L_0 < L \le N$. Suppose that, for every physical letter
-    $\eta$ used in the two boundary assignments and every boundary matrix
+    $\eta$ used in the two boundary conditions and every boundary matrix
     obtained from an $N$-site chain ground state, the identities
     \[
         A^\mu A^j X = Y^+_{\tau^+_\eta(\mu)}A^j,
@@ -2371,7 +2389,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \Gamma_{L_0+1}(Y_i(\tau)).
     \]
     If $L_0\le M$, then for every complementary word $\mu$ there are boundary
-    assignments $\rho^+_{j,\sigma}$ and $\rho^-_{j,\sigma}$, depending on the
+    conditions $\rho^+_{j,\sigma}$ and $\rho^-_{j,\sigma}$, depending on the
     physical letter $j$ and the word $\sigma$ of length $L_0$, such that, for
     every complementary position $k$,
     \[
@@ -2438,7 +2456,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{lem:closure_property_auxiliary_boundary_product_chain_ground_space,
         thm:boundary_closing_product_pointwise_compatible_boundary_assignments}
     Lemma~\ref{lem:closure_property_auxiliary_boundary_product_chain_ground_space}
-    gives boundary assignments $\rho^+_{j,\sigma}$ and
+    gives boundary conditions $\rho^+_{j,\sigma}$ and
     $\rho^-_{j,\sigma}$ satisfying
     \[
         \rho^+_{j,\sigma}(k+L_0)=\mu_k,
@@ -2452,7 +2470,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
     \]
     Theorem~\ref{thm:boundary_closing_product_pointwise_compatible_boundary_assignments}
-    replaces these auxiliary assignments by the canonical boundary assignments:
+    replaces these auxiliary conditions by the displayed boundary conditions:
     \[
         Y_M(\tau^{+}_{\eta}(\mu))A^jA^\sigma
         =
@@ -2476,7 +2494,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \Gamma_{L_0+1}(Y_i(\tau)).
     \]
     If $L_0\le M$, then for every
-    letter $\eta$ used in the two boundary assignments, every word $\mu$ on
+    letter $\eta$ used in the two boundary conditions, every word $\mu$ on
     the complementary sites, and every physical letter $j$,
     \[
         Y_M(\tau^{+}_{\eta}(\mu))A^j

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -656,7 +656,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
     with all site labels read modulo $N$. If $L\le N$, this is the same
     configuration as $\rho^{[i,i+L-1]\leftarrow\omega}$. If two boundary
-    assignments agree whenever $\delta_i(k)\ge L$, their restrictions are equal.
+    conditions agree whenever $\delta_i(k)\ge L$, their restrictions are equal.
     In particular, filling the interval inside the outside configuration leaves the
     restriction unchanged:
     \[
@@ -726,7 +726,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     The first two identities are the cyclic first- and last-site deletion
     identities, followed by the corresponding ground-space restriction formulas.
-    For adjacent windows, equality of the completed outside assignments makes
+    For adjacent windows, equality of the completed outside configurations makes
     the two restricted states on the common overlap equal. Injectivity of the
     length-$L$ ground-space map then identifies their boundary matrices.
     Iterating the displayed adjacent identity gives the word-product identity.
@@ -1151,13 +1151,13 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \[
         Y_\rho A^j = Y_\tau A^j .
     \]
-    In particular, the last-site boundary-crossing assignment satisfies
+    In particular, the last-site boundary-crossing condition satisfies
     \[
         \rho_{k+L_0}=\mu_k
         \Longrightarrow
         Y_\rho A^j = Y_{\tau^+_\eta(\mu)}A^j,
     \]
-    and the opposite boundary-crossing assignment satisfies
+    and the opposite boundary-crossing condition satisfies
     \[
         \rho_{k+1}=\mu_k
         \Longrightarrow
@@ -1565,7 +1565,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{def:chain_ground_space, def:ground_space_parent}
     If $0<N$, $L\le N$, and $\psi\in\mathcal G_{N,L}(A)$, then for every
-    cyclic window and every outside assignment there is a boundary matrix $Y$
+    cyclic window and every outside configuration there is a boundary matrix $Y$
     such that the corresponding restricted $L$-site state is $\Gamma_L(Y)$.
 \end{lemma}
 
@@ -2373,7 +2373,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     The two restrictions are therefore equal.
 \end{proof}
 
-\begin{lemma}[Auxiliary boundary-assignment product equation]
+\begin{lemma}[Auxiliary boundary-condition product equation]
     \label{lem:closure_property_auxiliary_boundary_product_chain_ground_space}
     \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap}
     \leanok

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -209,7 +209,10 @@ before taking the first-site restriction $\sigma_1=j$.\footnote{For
 traceability, this is the mathematical content recorded in
 \href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368}.}
 
-The present formal reduction has isolated a smaller coordinate identity. Let
+The present formal reduction has isolated a smaller coordinate identity. Here
+\(\Gamma_L(Y)\) denotes the length-\(L\) open-chain MPS vector with boundary
+matrix \(Y\), namely
+\(\Gamma_L(Y)_\omega=\operatorname{tr}(A^\omega Y)\). Let
 \[
   \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
   =

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -23,7 +23,9 @@ Section~IV.C of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
 range-reduction comparison is recorded in
 \href{https://github.com/LionSR/TNLean/issues/588}{issue \#588}; the
 boundary-closing comparison is recorded in
-\href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368};
+\href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368}; its current
+coordinate form is recorded in
+\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405};
 and the parent-Hamiltonian consequences are recorded in
 \href{https://github.com/LionSR/TNLean/issues/460}{issue \#460}.}
 
@@ -207,6 +209,33 @@ before taking the first-site restriction $\sigma_1=j$.\footnote{For
 traceability, this is the mathematical content recorded in
 \href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368}.}
 
+The present formal reduction has isolated a smaller coordinate identity. Let
+\[
+  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+  =
+  \Gamma_{L_0+1}\!\left(Y_M(\tau^+_\eta(\mu))\right),
+  \qquad
+  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)
+  =
+  \Gamma_{L_0+1}\!\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))\right).
+\]
+The last-site boundary gives the one-sided equation
+\[
+  Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
+\]
+After block-injective cancellation, the remaining opposite-boundary comparison
+is equivalent to proving, for every boundary letter \(\eta\), physical letter
+\(j\), and word \(\sigma\) of length \(L_0\),
+\[
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+  =
+  A^\mu A^jX A^\sigma .
+\]
+This formula is not displayed in the source. It is the coordinate form by which
+the formal proof represents the sentence that the same argument may be applied
+when closing the boundaries.\footnote{This is the current mathematical content
+of \href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}.}
+
 \section{Conclusion}
 
 The classification is an open gap. It identifies a difference between the
@@ -216,7 +245,8 @@ argument is not refuted. The source compresses two mathematical steps which the
 formal proof must keep separate: the $B$-region inverting and growing-back
 open-chain range reduction, and the boundary-closing comparison of the boundary
 matrices arising from the two boundary-crossing supports used in closing the
-boundary.
+boundary. The current open form of the latter comparison is the displayed
+right-multiplied coordinate identity above.
 
 The open-chain part has been proved under the intended block-injective
 hypotheses, though not by reusing the older single-site intersection theorem.


### PR DESCRIPTION
## Summary

This PR adds no-sorry coordinate infrastructure for the remaining parent-Hamiltonian closing-boundary comparison.

It records three small algebraic steps:

\[
  A^w Z = 0\quad (|w|=k) \Longrightarrow Z=0
\]

under \(L_0\)-block injectivity and \(k\le qL_0\), complementing the existing right-annihilation form; and

\[
  Y_\rho A^j = Y_{\tau^\pm_\eta(\mu)}A^j
  \Longrightarrow
  Y_\rho A^jA^\sigma = Y_{\tau^\pm_\eta(\mu)}A^jA^\sigma .
\]

It also adds the right-multiplied form of the fixed-boundary-condition endpoint product, and updates the paper-gap note to state the current remaining coordinate identity:

\[
  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
  =
  A^\mu A^jX A^\sigma .
\]

The prose says explicitly that this coordinate equation is not displayed in arXiv:2011.12127; it is the local formal expression of the source sentence about applying the same argument when closing the boundaries.

Refs #2405.

## Verification

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (fails only on pre-existing non-parent refs: `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and the literal `...` tag in ch04a; ch14 reports 382/382)
- `lake exe checkdecls blueprint/lean_decls` (fails on pre-existing missing declarations outside this PR; none are the new parent declarations)
- `leanblueprint web` (exit 0; local plasTeX environment emits existing renderer/bibliography warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style lemmas and documentation; no auth, runtime, or API surface changes. The parent-Hamiltonian capstone still relies on an existing sorry for the mirror padded product.
> 
> **Overview**
> Adds **sorry-free coordinate infrastructure** for the parent-Hamiltonian **closing-boundary** step, without closing the main open gap (`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap` still ends in `sorry`).
> 
> **New Lean modules:** `BoundaryStripping` proves that if every length-\(k\) word satisfies \(A^w Z = 0\), then \(Z = 0\) under block-injectivity and \(k \le qL_0\)—the **left** padding analogue of the existing right-annihilation lemmas in `WrappingWindow`. `BoundaryClosingCoordinate` derives **right multiplication by \(A^\sigma\)** from the complement first-product identities at both boundary supports, and a **right-multiplied** form of the fixed-boundary window product lemma.
> 
> **Integration:** Root imports `BoundaryStripping` and `BoundaryClosingCoordinate`; `BoundaryClosing` docstrings shift terminology from “boundary assignments” to **boundary conditions**.
> 
> **Docs:** Chapter 14 blueprint and `cpgsv21_normal_range_reduction.tex` are updated to cite the new declarations and to state the **remaining coordinate identity** explicitly: \(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma = A^\mu A^j X A^\sigma\) (issue #2405), noted as not displayed in the source paper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b919173ce0b0458ed8edc7979f385aa7fff61aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->