### PR TITLE
chore(peps): address PEPS FT review feedback (naming, paper-gap notes, docstrings)

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -77,7 +77,7 @@ the same finite type, then the recombined family `i ↦ ∑ j, K i j • f j` is
 linearly independent: a vanishing combination `∑ i c i • (∑ j K i j • f j) = 0`
 rearranges to `∑ j (c ᵥ* K) j • f j = 0`, whose coefficient vector `c ᵥ* K` is
 zero by independence of `f`, and right-multiplying by `K⁻¹` forces `c = 0`. -/
-theorem linindep_recombine {ι : Type*} [Fintype ι] [DecidableEq ι] {M : Type*}
+theorem linearIndependent_recombine {ι : Type*} [Fintype ι] [DecidableEq ι] {M : Type*}
     [AddCommGroup M] [Module ℂ M]
     (f : ι → M) (hf : LinearIndependent ℂ f)
     (K : Matrix ι ι ℂ) (hK : IsUnit K) :
@@ -202,7 +202,7 @@ theorem edgeGaugeAtInv_mul (B : Tensor G d) (Z : (e : Edge G) → GL (Fin (B.bon
 Each `gaugeVertex B Z v` recombines the linearly independent family
 `B.component v` by the per-edge gauge kernel, which is invertible because every
 oriented endpoint gauge `edgeGaugeAt B Z v ie` is invertible. Linear
-independence is therefore preserved (`linindep_recombine`), and the bond spaces
+independence is therefore preserved (`linearIndependent_recombine`), and the bond spaces
 are unchanged (`absorbEdgeGauges_bondDim`).
 
 Source: arXiv:1804.04964, Section 3, lines 1037--1038: the absorbed family
@@ -229,7 +229,7 @@ theorem isVertexInjective_absorbEdgeGauges (B : Tensor G d)
     exact piProductKernel_isUnit
       (fun ie => edgeGaugeAt B Z v ie) (fun ie => edgeGaugeAtInv (G := G) B Z v ie)
       (fun ie => edgeGaugeAt_mul_inv B Z v ie) (fun ie => edgeGaugeAtInv_mul B Z v ie)
-  exact linindep_recombine (B.component v) (hB v) K hKunit
+  exact linearIndependent_recombine (B.component v) (hB v) K hKunit
 
 /-! ### Gauge consistency across edges -/
 
@@ -347,7 +347,7 @@ theorem perVertexScalar (A B : Tensor G d)
   simpa only [vertexTwoBlock, reindexTensor_component, absorbEdgeGauges_component]
     using hprop (PUnit.unit : PUnit) η σ
 
-/-! ### Assembly of the global gauge from per-vertex scalars
+/-! ### Construction of the global gauge from per-vertex scalars
 
 Closing `gaugeConsistency` from `perVertexScalar` and
 `exists_edgeScalars_of_connected` absorbs the per-vertex scalars $c_v$ into one

--- a/TNLean/PEPS/FundamentalTheorem/GaugeAction.lean
+++ b/TNLean/PEPS/FundamentalTheorem/GaugeAction.lean
@@ -5,43 +5,16 @@ import TNLean.PEPS.LocalGauge
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
--- The contraction algebra is proved. The remaining converse ingredients are
--- separated by mathematical role in
--- `docs/paper-gaps/peps_injective_ft_section3_route.tex` and
--- `docs/paper-gaps/peps_gauge_edge_scalars.tex`. The hypothesis
--- `IsVertexInjective` is the linear-independence formulation from `PEPS.Defs`,
--- which gives the local left inverses used below.
-
 /-!
-# Fundamental Theorem for injective PEPS
+# Gauge action for the injective PEPS Fundamental Theorem
 
-**Root-only.** This module is currently not imported downstream — it
-records the full statement of the PEPS Fundamental Theorem
-(arXiv:1804.04964 §3, Theorem 2), with the forward bond-dimension
-obligation and converse gaps documented in the paper-gap notes cited below.
-The separate root-only audit is tracked by issue #1512.
-
-This file develops the Fundamental Theorem for injective PEPS on simple graphs
-(arXiv:1804.04964, Theorem 2, Section 3):
-
-> Two injective PEPS defined on a graph (no double edges/self-loops) generate
-> the same state iff the generating tensors are related by local gauges on each
-> edge, with uniqueness understood modulo balanced edge scalars on the graph.
-
-## Source proof shape
-
-For a chosen edge \(e=(u,v)\), the source proof blocks all vertices other than
-\(u\) and \(v\) into a middle tensor. The two endpoint tensors and this middle
-tensor form a three-site injective MPS, so the three-site isomorphism lemma of
-arXiv:1804.04964, Section 3, assigns an edge gauge. After repeating this for
-every edge and absorbing the gauges into the second tensor family, the proof
-obtains the edge-insertion equality of arXiv:1804.04964, Section 3: for every
-edge and every matrix \(X\), inserting \(X\) on that edge in the first PEPS
-gives the same state as inserting \(X\) on the same edge in the modified second
-PEPS. Blocking one vertex against its complement and applying the two-injective
-tensor comparison of arXiv:1804.04964, Section 3, gives
-\(A_v = \lambda_v \cdot \tilde{B}_v\); the scalars \(\lambda_v\) are absorbed
-into the edge gauges.
+The edge-gauge action used throughout the proof of the injective PEPS
+Fundamental Theorem (arXiv:1804.04964, Section 3): the oriented endpoint gauge
+matrices (`edgeGaugeAt`), the gauge action on a vertex tensor (`gaugeVertex`),
+the gauge applied to a whole PEPS (`applyGauge`, `absorbEdgeGauges`), the
+gauge-equivalence relation (`GaugeEquiv`), gauge invariance of the generated
+state (`applyGauge_stateCoeff`), and the open-edge gauge action on edge-inserted
+coefficients.
 
 ## References
 

--- a/docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex
+++ b/docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex
@@ -113,20 +113,21 @@ incidence product at every vertex.
   \leanid{TNLean.PEPS.gaugeConsistency} and the headline
   \leanid{TNLean.PEPS.fundamentalTheorem\_PEPS} are reduced to a single isolated
   lemma.
-\item \emph{Remaining step (state nonvanishing).} The cancellation
+\item \emph{State nonvanishing (proved).} The cancellation
   $\prod_v c_v=1$ uses one nonzero state coefficient,
   $\exists\sigma,\ \langle A\rangle_\sigma\neq 0$
   (\leanid{TNLean.PEPS.exists\_stateCoeff\_ne\_zero}). For a vertex-injective PEPS
   with positive bond dimensions this is the source's standing assumption that an
-  injective PEPS is a genuine nonzero state; the source obtains it from
-  injectivity of the blocked contraction. The faithful Lean derivation is a
-  spanning-tree leaf-peeling argument (remove a leaf whose deletion preserves
-  connectivity, factor the contraction across its single incident edge, use
-  endpoint injectivity and positive bond dimension), the PEPS analog of the
-  matrix-product nonvanishing
-  \leanid{TNLean.MPS.mpv\_ne\_zero\_of\_isNBlkInjective}. This is the only
-  remaining obligation; it needs PEPS-on-induced-subgraph restriction and a
-  leaf-edge contraction factorization that the development does not yet provide.
+  injective PEPS is a genuine nonzero state. The Lean derivation splits the state
+  coefficient at one vertex against its complement
+  (\leanid{TNLean.PEPS.stateCoeff\_eq\_vertexComplement}): the complement family
+  is linearly independent
+  (\leanid{TNLean.PEPS.vertexComplementTensorInjective\_of\_isVertexInjective}),
+  hence has no zero member, and vertex injectivity at the chosen vertex then
+  forces a nonzero coefficient; positive bond dimensions make the vertex-star
+  configuration type nonempty. No induced-subgraph or leaf-peeling
+  infrastructure is needed. This completes the reduction, so the headline
+  \leanid{TNLean.PEPS.fundamentalTheorem\_PEPS} is fully proved and axiom-clean.
 \end{itemize}
 
 This connectivity gap is distinct from the balanced-edge-scalar gap of

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -104,15 +104,16 @@ pointwise off-diagonal vanishing. The full identity-insertion specialization is
 \leanid{TNLean.PEPS.edgeBoundaryConfigEquivDiagonalInsertedBoundaryConfig} to
 reindex the finite inserted-boundary sum along the diagonal.
 
-\section{Remaining mathematical obligations}
+\section{Formalized Section 3 route}
 
-The following statements are still needed before the injective PEPS Fundamental
-Theorem can be proved in the manner of the paper.\footnote{This list and the
-ledger below are the status record referenced by the Section~3 docstrings and
-blueprint comments.}
+The following statements record how the formal proof follows the Section~3
+route.\footnote{This list and the ledger below are the status record referenced
+by the Section~3 docstrings and blueprint comments.} They form a status account:
+each item names the formal statement that carries the corresponding mathematical
+step.
 
 \begin{enumerate}
-\item Vertex injectivity must be shown to pass to the edge-blocked three-site
+\item Vertex injectivity passes to the edge-blocked three-site
   object. This is the formal version of the paper's assertion that the
   regrouped MPS is injective. The middle physical index for this regrouped
   object is now explicit as
@@ -155,7 +156,7 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedEndpointTensorMaps_injective_all},
   and
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_of_middle}
-  reduces the remaining work to the middle-block injectivity statement. Its
+  reduces the proof to the middle-block injectivity statement. Its
   all-edge form is
   \leanid{TNLean.PEPS.IsVertexInjective.edgeBlockedThreeSiteInjective_all_of_middle}.
   The
@@ -243,7 +244,7 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   These assemble into
   \leanid{TNLean.PEPS.edgeMiddleKernelDescentData} and close the target by the
   existing reductions.
-\item The two internal steps in Lemma \path{inj_isomorph} must be formalized for
+\item The two internal steps in Lemma \path{inj_isomorph} are formalized for
   the edge-blocked three-site MPS. The local endpoint part of the
   virtual-to-physical realization $X\mapsto O_1,O_2$ is formalized by
   \path{thm:peps_virtualInsertionPhysicalRealization}: vertex injectivity turns
@@ -255,7 +256,7 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   endpoint the formal statement uses the transpose of the inserted matrix,
   because the ordinary boundary supplies the right bond index. The source
   recovery $O_1,O_2\mapsto W$ is proved as
-  \leanid{TNLean.PEPS.physical_to_virtual_insertion} (issue~\#1370). The
+  \leanid{TNLean.PEPS.physical_to_virtual_insertion}. The
   middle block is contracted out by
   \leanid{TNLean.PEPS.resonate_middle_inverted}, leaving the bond-contracted
   endpoint identity. Inverting the right endpoint
@@ -275,7 +276,7 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   \leanid{TNLean.PEPS.edgePhysicalToVirtualInsertion_of_projected_realization_eq}
   records the endpoint conclusion under explicit projected-realization and
   image-preservation hypotheses.
-\item Equality of PEPS states must be upgraded to equality of edge-inserted
+\item Equality of PEPS states is upgraded to equality of edge-inserted
   coefficients after the three-site reduction. This is the step that produces
   the matrix-algebra isomorphism on the chosen bond. The inserted-coefficient
   correspondence $X\mapsto Y$ is now formalized by
@@ -316,44 +317,48 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
 
   The full positive-bond theorem
   \leanid{TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism} now proves that
-  this correspondence is a $\C$-algebra isomorphism, under the additional
+  this correspondence is a $\mathbb C$-algebra isomorphism, under the explicit
   hypotheses that every virtual bond of both tensor families has positive
-  dimension. This is a scope restriction relative to the unrestricted Section~3
-  source statement. The elimination plan is to derive these positivity
-  hypotheses from injectivity of the blocked tensors, or to state the
-  positive-bond variant separately from the unrestricted theorem. The last step
-  in the positive-bond theorem is the injectivity of the edge-inserted
-  coefficient in the inserted matrix: equal coefficients at every physical
-  configuration determine the matrix. This gives the unit law $\Phi(1)=1$ (the
-  identity insertion has the same coefficient as $\Phi(1)$ by equal states),
-  injectivity of the transfer map, and surjectivity by the symmetric
-  $A\leftrightarrow B$ construction. The injectivity is the inverse-direction
-  content of the resonate inversion used inside
+  dimension. These hypotheses make explicit the nonzero virtual spaces used in
+  Section~3, for example the reference residual configurations and the full
+  matrix algebras on the virtual bonds. They are not consequences of
+  injectivity. With a zero-dimensional bond, injectivity and state equality can hold
+  vacuously while the physical-to-virtual recovery and gauge conclusion fail.
+  This obstruction is checked in
+  \leanid{TNLean.PEPS.PhysicalToVirtualCounterexample} and in the
+  edge-middle obstruction
+  \leanid{TNLean.PEPS.not_edgeMiddleTensorInjective_of_isEmpty}. Thus the
+  positive-bond assumptions are the formal expression of the source's nonzero
+  virtual bond spaces, not an unproved consequence. The last step in
+  the positive-bond theorem is the injectivity of the edge-inserted coefficient
+  in the inserted matrix: equal coefficients at every physical configuration
+  determine the matrix. This gives the unit law $\Phi(1)=1$ (the identity
+  insertion has the same coefficient as $\Phi(1)$ by equal states), injectivity
+  of the transfer map, and surjectivity by the symmetric $A\leftrightarrow B$
+  construction. The injectivity is the inverse-direction content of the
+  resonate inversion used inside
   \leanid{TNLean.PEPS.physical_to_virtual_insertion}.
-\item The algebra isomorphism must be converted into an invertible edge gauge,
-  using the same finite-dimensional matrix-algebra argument as the
-  one-dimensional injective theorem. In the blueprint this is the
-  not-yet-formalized theorem
-  \path{thm:peps_edgeGaugeFromInsertionAlgebraIsomorphism}.
+\item The algebra isomorphism is converted into an invertible edge gauge by the
+  same finite-dimensional matrix-algebra argument as the one-dimensional
+  injective theorem. This is formalized by
+  \leanid{TNLean.PEPS.edgeGaugeFromInsertionAlgebraIsomorphism}: an algebra
+  isomorphism between two full matrix algebras first identifies their sizes and
+  is then conjugation by an invertible matrix. The per-edge gauges used in the
+  global proof are collected by
+  \leanid{TNLean.PEPS.exists_edgeGaugeFamily}.
 \item After all edge gauges have been absorbed into the second tensor family,
-  producing the modified tensors $\widetilde B_v$, the formalization must
-  prove the analog of \path{eq:inj_equal_edge}: arbitrary insertions of the
-  same matrix on the same edge give equal PEPS states for the first tensor
-  family and the modified second tensor family. In the blueprint the absorption
-  step is the not-yet-formalized theorem
-  \path{thm:peps_edgeGaugeAbsorption}, and the post-absorption insertion
-  equality target is now named formally by
-  \leanid{TNLean.PEPS.PostAbsorptionEdgeInsertionEquality}.  Constructing that
-  predicate from the absorbed edge gauges remains the not-yet-formalized theorem
-  \path{thm:peps_postAbsorptionEdgeInsertionEquality}.
+  producing the modified tensors $\widetilde B_v$, the analog of
+  \path{eq:inj_equal_edge} is formalized by
+  \leanid{TNLean.PEPS.post_absorption_edge_insertion_equality}. Its conclusion
+  constructs
+  \leanid{TNLean.PEPS.PostAbsorptionEdgeInsertionEquality}: arbitrary insertions
+  of the same matrix on the same edge give equal PEPS coefficients for the
+  first tensor family and the absorbed second tensor family.
 \item The generalized two-injective-tensor comparison from
-  \path{lem:inj_equal_tensors_2} must be formalized. It says that equality of
-  all virtual-bond insertions for two pairs of injective tensors forces
-  $A_1=\lambda B_1$ and $A_2=\lambda^{-1}B_2$. In the blueprint this is
-  split into the scalar-reduction substep
-  \path{thm:peps_twoInjectiveGaugeScalarReduction} and the formally stated
-  comparison theorem
-  \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison}. The formal
+  \path{lem:inj_equal_tensors_2} is formalized by
+  \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison}. It says that
+  equality of all virtual-bond insertions for two pairs of injective tensors
+  forces $A_1=\lambda B_1$ and $A_2=\lambda^{-1}B_2$. The formal
   statement is an abstract version with nonempty spectator external boundary
   spaces; the source lemma is recovered by taking these spaces to be one-point
   spaces. The rank-one cancellation after coefficientwise product equality is
@@ -376,11 +381,10 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   case the source does not separate the product: it inverts $A_2$, reads off the
   gauges $Z,U,W$ on three leg pairs, and uses their identity-form compatibility
   to force each gauge to be a scalar
-  (\leanid{TNLean.PEPS.threeLeg_residual_forms_scalar}, already proved;
-  \path{Papers/1804.04964/paper_normal.tex}, lines 1157--1204). The remaining
-  proof of \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison} is the
-  inversion and leg-regrouping that produce $Z,U,W$ from the one-bond
-  insertions. This is tracked by issue~\#1361.
+  (\leanid{TNLean.PEPS.threeLeg_residual_forms_scalar};
+  \path{Papers/1804.04964/paper_normal.tex}, lines 1157--1204). The inversion
+  and leg-regrouping are contained in the proved core comparison
+  \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison_core}.
 \item Both injective blocks of the one-vertex-versus-complement comparison are
   now formalized. The selected vertex block is
   \leanid{TNLean.PEPS.vertexTwoBlock} with injectivity
@@ -397,22 +401,26 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   complement vertex $j\ne v$
   (\leanid{TNLean.PEPS.vertexConfigSplitAt}), the kernel condition descends by
   the one-sided inverse at $j$, and the terminal empty-region step uses positive
-  bond dimensions to fill the interior virtual indices. What remains for this
-  step is only the coefficient identity that feeds equality of one-bond
-  insertions for the vertex/complement pair into the abstract comparison.
-\item The final two-tensor comparison must then be applied by blocking one
-  vertex against its complement. The paper uses this to prove
+  bond dimensions to fill the interior virtual indices.
+\item The final two-tensor comparison is applied by blocking one vertex against
+  its complement. The paper uses this to prove
   $A_i=\lambda_i\widetilde B_i$ at each vertex, and then incorporates the
-  scalars into the local gauges. This specialization is now represented by
+  scalars into the local gauges. This specialization is represented by
   \leanid{TNLean.PEPS.one_vertex_complement_comparison}. The formal statement
   uses the abstract two-block notation with nonempty external boundary spaces;
   the source comparison is obtained from the one-vertex and complement blocks
   after \path{eq:inj_equal_edge}.
-\item The boundary-insertion argument must remove the separate
+\item The boundary-insertion argument removes the separate
   bond-dimension-identification hypothesis in
-  \leanid{TNLean.PEPS.fundamentalTheorem_PEPS_of_bondDim}. This is the
-  remaining difference between that conditional theorem and the source theorem;
-  it is tracked by issue~\#874.
+  \leanid{TNLean.PEPS.fundamentalTheorem_PEPS_of_bondDim}. For each edge, the
+  algebra equivalence
+  \leanid{TNLean.PEPS.edgeTransferAlgEquiv} identifies the two full matrix
+  algebras of virtual insertions. The dimension count
+  \leanid{TNLean.PEPS.bondDim_eq_of_matrixAlgEquiv} forces equality of the
+  corresponding bond dimensions, and
+  \leanid{TNLean.PEPS.fundamentalTheorem_PEPS} then gives the source
+  gauge-equivalence conclusion under the standing positive-bond and
+  connectivity assumptions.
 \end{enumerate}
 
 \section{Source-to-formalization ledger}
@@ -441,11 +449,10 @@ It is meant to prevent the proof from drifting away from the source argument.
   \path{thm:peps_virtualInsertionPhysicalRealization} formalizes the endpoint
   realization, and
   \path{thm:peps_edgeInsertedCoeff_endpointPhysicalRealization} formalizes the
-  endpoint coefficient expansion. These are tracked by issues~\#1369
-  and~\#1995.
+  endpoint coefficient expansion.
 \item Lemma \path{inj_isomorph}, $O_1,O_2\mapsto W$:
   \leanid{TNLean.PEPS.physical_to_virtual_insertion} proves the source recovery
-  step (issue~\#1370). The middle block is contracted out by
+  step. The middle block is contracted out by
   \leanid{TNLean.PEPS.resonate_middle_inverted}; the two endpoints are inverted
   by \leanid{TNLean.PEPS.resonate_invert_right_endpoint} and
   \leanid{TNLean.PEPS.resonate_invert_left_endpoint}; the two extracted matrices
@@ -471,31 +478,41 @@ It is meant to prevent the proof from drifting away from the source argument.
   \leanid{TNLean.PEPS.isEdgeBlockedInsertionAlgebraIsomorphism} is now proved in
   this positive-bond scope: well-definedness, injectivity, surjectivity, and the
   homomorphism laws including multiplicativity are part of the formalized
-  statement. The unrestricted source statement still requires eliminating the
-  positive-bond hypotheses from injectivity.
+  statement. The positive-bond hypotheses express the source's nonzero virtual
+  bond spaces; they are not consequences of injectivity.
 \item Edge gauge from the algebra isomorphism:
-  \path{thm:peps_edgeGaugeFromInsertionAlgebraIsomorphism}, tracked by
-  issue~\#1368.
+  \leanid{TNLean.PEPS.edgeGaugeFromInsertionAlgebraIsomorphism} proves the
+  Skolem--Noether step from an algebra equivalence of full matrix algebras to
+  conjugation by an invertible edge matrix. The edgewise family used later is
+  \leanid{TNLean.PEPS.exists_edgeGaugeFamily}.
 \item Absorption of edge gauges into $B$:
-  \path{thm:peps_edgeGaugeAbsorption}, tracked by issue~\#1363.
+  \leanid{TNLean.PEPS.absorbEdgeGauges} defines the absorbed tensor family, and
+  \leanid{TNLean.PEPS.post_absorption_edge_insertion_equality} applies the
+  edge-gauge family to it.
 \item Equation \path{eq:inj_equal_edge}:
-  \path{thm:peps_postAbsorptionEdgeInsertionEquality}, tracked by issue~\#1364.
+  \leanid{TNLean.PEPS.post_absorption_edge_insertion_equality} constructs
+  \leanid{TNLean.PEPS.PostAbsorptionEdgeInsertionEquality}.
 \item Lemma \path{inj_equal_tensors_2}, scalar step:
-  \path{thm:peps_twoInjectiveGaugeScalarReduction}, tracked by issue~\#1362.
+  the rank-one product cancellation is
+  \leanid{TNLean.PEPS.twoBlockReciprocalScalarProportional_of_pointwise_mul_eq},
+  and the many-bond scalar forcing is
+  \leanid{TNLean.PEPS.threeLeg_residual_forms_scalar}.
 \item Lemma \path{inj_equal_tensors_2}, comparison:
   \leanid{TNLean.PEPS.two_injective_tensor_insertion_comparison} states the
   abstract two-block insertion comparison with nonempty external boundary
   spaces and reciprocal scalar proportionality. The source lemma is the
-  one-point external-boundary specialization; the proof is tracked by
-  issue~\#1361.
+  one-point external-boundary specialization.
 \item One vertex versus its complement:
   \leanid{TNLean.PEPS.one_vertex_complement_comparison} records the
   application of the generalized two-block comparison to a selected vertex and
   its complement, under the abstract nonempty external-boundary formulation.
-  The source proof is tracked by issue~\#1360.
 \item Final gauge equivalence and uniqueness:
-  \path{thm:fundamentalTheorem_PEPS_of_bondDim} and the uniqueness theorem,
-  tracked by issues~\#780, \#842, and the boundary-insertion issue~\#874.
+  \leanid{TNLean.PEPS.fundamentalTheorem_PEPS_of_bondDim} proves the
+  gauge-equivalence theorem after the bond dimensions are identified;
+  \leanid{TNLean.PEPS.fundamentalTheorem_PEPS} removes that separate hypothesis
+  by the matrix-algebra dimension count, and
+  \leanid{TNLean.PEPS.gauge_unique_mod_edge_scalars} proves uniqueness modulo
+  edge scalars.
 \end{itemize}
 
 \section{Blueprint diagrams}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -549,16 +549,19 @@ drawn as the same object.
 
 \section{Conclusion}
 
-The current formalization has reached the edge-blocked coefficient and, under
-the positive-bond-dimension restriction recorded above, has proved the
-matrix-insertion comparison as a \(\mathbb C\)-algebra isomorphism.  The
-positivity-free insertion comparison remains to be recovered by deriving
-positive bond dimensions from injectivity.  The three-site injectivity transfer,
-the resulting edge gauge construction, and the final
-one-vertex-versus-complement comparison are still open. Those are the remaining
-mathematical steps required to turn the current PEPS definitions into a proof
-of the injective PEPS Fundamental Theorem faithful to
-\cite[Section~3]{Molnar2018NormalPEPS}.
+The injective PEPS Fundamental Theorem is now formalized, faithful to
+\cite[Section~3]{Molnar2018NormalPEPS}. Under the source's standing
+positive-bond-dimension and connectivity assumptions, the existence clause
+\leanid{TNLean.PEPS.fundamentalTheorem\_PEPS} and the uniqueness clause
+\leanid{TNLean.PEPS.gauge\_unique\_mod\_edge\_scalars} are proved and
+axiom-clean. The three-site injectivity transfer, the matrix-insertion
+comparison as a \(\mathbb C\)-algebra isomorphism, the edge gauge construction,
+and the one-vertex-versus-complement comparison are all complete. The
+positive-bond-dimension and connectivity hypotheses are not removable: each is
+refuted without it by a machine-checked counterexample
+(\leanid{TNLean.PEPS.PhysicalToVirtualCounterexample} and
+\leanid{TNLean.PEPS.GaugeConsistencyConnectivityCounterexample}), so they are
+genuine standing assumptions of the source rather than steps to be discharged.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -421,8 +421,9 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   \leanid{TNLean.PEPS.bondDim_eq_of_matrixAlgEquiv} forces equality of the
   corresponding bond dimensions, and
   \leanid{TNLean.PEPS.fundamentalTheorem_PEPS} then gives the source
-  gauge-equivalence conclusion under the standing positive-bond and
-  connectivity assumptions.
+  gauge-equivalence conclusion for the connected positive-bond statement. The
+  connectivity hypothesis is the repair recorded in
+  \path{docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex}.
 \end{enumerate}
 
 \section{Source-to-formalization ledger}
@@ -568,20 +569,19 @@ drawn as the same object.
 
 \section{Conclusion}
 
-The injective PEPS Fundamental Theorem is now formalized, faithful to
-\cite[Section~3]{Molnar2018NormalPEPS}. Under the source's standing
-positive-bond-dimension and connectivity assumptions, the existence clause
-\leanid{TNLean.PEPS.fundamentalTheorem\_PEPS} and the uniqueness clause
+The connected positive-bond version of the injective PEPS Fundamental Theorem
+from \cite[Section~3]{Molnar2018NormalPEPS} is now formalized. The existence
+clause \leanid{TNLean.PEPS.fundamentalTheorem\_PEPS} and the uniqueness clause
 \leanid{TNLean.PEPS.gauge\_unique\_mod\_edge\_scalars} are proved and
 axiom-clean. The three-site injectivity transfer, the matrix-insertion
 comparison as a \(\mathbb C\)-algebra isomorphism, the edge gauge construction,
 and the one-vertex-versus-complement comparison are all complete. The
-positive-bond-dimension and connectivity hypotheses are not removable: dropping
-positivity is refuted by
-\leanid{TNLean.PEPS.FundamentalTheoremCounterexample.fundamentalTheoremPEPSStatement_false},
-and dropping connectivity is refuted by
-\leanid{TNLean.PEPS.GaugeConsistencyConnectivityCounterexample}. Thus they are
-genuine standing assumptions of the source rather than steps to be discharged.
+positive-bond-dimension hypothesis records the source's nonzero virtual bond
+spaces; dropping it is refuted by
+\leanid{TNLean.PEPS.FundamentalTheoremCounterexample.fundamentalTheoremPEPSStatement_false}.
+Connectivity is an explicit repair of the literal source statement, documented
+in \path{docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex}; dropping
+it is refuted by \leanid{TNLean.PEPS.GaugeConsistencyConnectivityCounterexample}.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -322,11 +322,13 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   dimension. These hypotheses make explicit the nonzero virtual spaces used in
   Section~3, for example the reference residual configurations and the full
   matrix algebras on the virtual bonds. They are not consequences of
-  injectivity. With a zero-dimensional bond, injectivity and state equality can hold
-  vacuously while the physical-to-virtual recovery and gauge conclusion fail.
-  This obstruction is checked in
-  \leanid{TNLean.PEPS.PhysicalToVirtualCounterexample} and in the
-  edge-middle obstruction
+  injectivity. With a zero-dimensional bond, injectivity and state equality can
+  hold vacuously while the physical-to-virtual recovery and gauge conclusion
+  fail. The theorem-level obstruction is checked in
+  \leanid{TNLean.PEPS.FundamentalTheoremCounterexample.fundamentalTheoremPEPSStatement_false};
+  the corresponding intermediate recovery failure is checked in
+  \leanid{TNLean.PEPS.PhysicalToVirtualCounterexample}, and the edge-middle
+  obstruction is
   \leanid{TNLean.PEPS.not_edgeMiddleTensorInjective_of_isEmpty}. Thus the
   positive-bond assumptions are the formal expression of the source's nonzero
   virtual bond spaces, not an unproved consequence. The last step in
@@ -574,10 +576,11 @@ positive-bond-dimension and connectivity assumptions, the existence clause
 axiom-clean. The three-site injectivity transfer, the matrix-insertion
 comparison as a \(\mathbb C\)-algebra isomorphism, the edge gauge construction,
 and the one-vertex-versus-complement comparison are all complete. The
-positive-bond-dimension and connectivity hypotheses are not removable: each is
-refuted without it by a machine-checked counterexample
-(\leanid{TNLean.PEPS.PhysicalToVirtualCounterexample} and
-\leanid{TNLean.PEPS.GaugeConsistencyConnectivityCounterexample}), so they are
+positive-bond-dimension and connectivity hypotheses are not removable: dropping
+positivity is refuted by
+\leanid{TNLean.PEPS.FundamentalTheoremCounterexample.fundamentalTheoremPEPSStatement_false},
+and dropping connectivity is refuted by
+\leanid{TNLean.PEPS.GaugeConsistencyConnectivityCounterexample}. Thus they are
 genuine standing assumptions of the source rather than steps to be discharged.
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
Post-merge follow-up addressing the review comments on #2423 (the injective PEPS FT landing). No proof changes; `lake build TNLean.PEPS.FundamentalTheorem` green (2701 jobs).

- **Naming:** `linindep_recombine` → `linearIndependent_recombine` (Mathlib naming — no "linindep" abbreviation).
- **Paper-gap notes corrected** (they shipped describing the proof #2423 lands as still open):
  - `peps_gaugeConsistency_connectivity_gap.tex`: the state-nonvanishing step is **proved** (via the vertex-complement linear-independence split `exists_stateCoeff_ne_zero`), not an open leaf-peeling obligation.
  - `peps_injective_ft_section3_route.tex`: the Conclusion now records the injective FT as **proved** (existence + uniqueness, axiom-clean), with positivity/connectivity as non-removable standing assumptions justified by machine-checked counterexamples.
- **Prose:** banned section title "Assembly" → "Construction" (`docs/prose_style.md`).
- **Docstring:** `FundamentalTheorem/GaugeAction.lean` had the entire monolithic-FT docstring copy-pasted during the file split (wrongly calling itself "root-only, not imported, the full statement"); replaced with an accurate gauge-action module docstring.

The codex P2 ("keep `\leanok` declarations root-visible") is already resolved by #2433, which un-orphaned `FundamentalTheorem` into the root build. Refs #2423.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and identifier renames only; no Mathlib proof or API logic changes beyond the theorem rename.
> 
> **Overview**
> Documentation and naming cleanup after the injective PEPS Fundamental Theorem landing (#2423). **No proof changes.**
> 
> **Lean:** Renames `linindep_recombine` → `linearIndependent_recombine` (Mathlib-style naming) and updates call sites in `FundamentalTheorem.lean`. Renames the section heading from "Assembly" to "Construction" for global gauge prose. Replaces the misplaced monolithic FT docstring on `FundamentalTheorem/GaugeAction.lean` with a short module docstring scoped to gauge action.
> 
> **Paper-gap notes:** `peps_gaugeConsistency_connectivity_gap.tex` now records state nonvanishing (`exists_stateCoeff_ne_zero` via the vertex–complement split) as **proved**, not an open leaf-peeling step, and states `fundamentalTheorem_PEPS` as fully proved. `peps_injective_ft_section3_route.tex` reframes "remaining obligations" as the **formalized Section 3 route**, updates the ledger to proved Lean names (dropping stale issue refs), and the conclusion records existence + uniqueness as **axiom-clean**, with positive bond dimension and connectivity as explicit standing assumptions justified by counterexamples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23846331f9ca3569fa960ae88f8ca7f2fd3a9538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->