### PR TITLE
doc(parent): align closure-property coordinate prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -606,7 +606,7 @@ then the restrictions themselves agree:
   \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
 This is a consequence of first-letter restrictions; it does not assert that the
-displayed right-product equality is already known. -/
+displayed one-site product equality is already known. -/
 lemma closure_property_boundary_restriction_eq_of_first_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -925,7 +925,7 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
   Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
 \]
 
-**Open gap:** The source does not display this auxiliary equation.  Its
+**Open gap:** The source does not display this coordinate equation.  Its
 closing-boundary paragraph is represented here by the following coordinate
 identity.  After the one-sided equation
 \[

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -32,7 +32,7 @@ proceeds as follows:
 3. The rotation gives an identity of the form
    \(X A^{\mathrm{tail}}A^{\mathrm{comp}}
      = A^{\mathrm{tail}}Y_\tau\)
-   for every boundary tail and every assignment of the complementary sites.
+   for every boundary tail and every condition on the complementary sites.
 
 4. Block injectivity extends the identity from word products to the full
    matrix algebra. Applying the same spanning argument to the complementary
@@ -537,7 +537,7 @@ take the form
 with the same word \(\mu\) on complementary sites and the same matrix
 \(Y_\mu\). -/
 
-/-- A background configuration whose cyclic-window complement is the prescribed
+/-- A boundary condition whose cyclic-window complement is the prescribed
 word on the complementary sites.
 
 For the wrapped window at the last site, the complement occupies physical sites
@@ -552,7 +552,7 @@ def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
     else
       η
 
-/-- A background configuration whose mirror-window complement is the prescribed
+/-- A boundary condition whose mirror-window complement is the prescribed
 word on the complementary sites.
 
 For the opposite wrapped window, the complement occupies physical sites

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1421,7 +1421,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Fix a physical letter $\eta$ used outside the complementary sites. Suppose
     the two one-sided boundary matrix families $Y^+$ and $Y^-$ have been
     extracted from the cyclic windows. If, for every word on the complementary sites
-    $\mu$, these boundary matrices agree on the backgrounds built from $\eta$,
+    $\mu$, these boundary matrices agree on the boundary conditions built from
+    $\eta$,
     \[
         Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)},
     \]
@@ -1436,7 +1437,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    Define $Y_\mu$ to be the first boundary matrix evaluated on the background
+    Define $Y_\mu$ to be the first boundary matrix evaluated on the boundary
+    condition
     $\tau^+_\eta(\mu)$. Lemma~\ref{lem:wrapped_middle_backgrounds} rewrites the
     first cyclic-window complement as $\mu$, while the assumed comparison at
     $\tau^-_\eta(\mu)$ rewrites the opposite boundary matrix to the same
@@ -1839,7 +1841,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         thm:ground_space_map_mpv_of_common_middle}
     Let $A$ be injective after blocking $L_0>0$ sites, and fix a physical letter
     $\eta$ used outside the complementary sites. Suppose that, for every
-    background $\tau$ and every physical letter $j$,
+    boundary condition $\tau$ and every physical letter $j$,
     \[
         C^+_\tau A^jX=Y^+_\tau A^j,
         \qquad
@@ -1926,7 +1928,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{lem:one_sided_boundary_witness_unique}
     Let $A$ be $L_0$-block-injective with $L_0>0$.  Fix two matrix
-    families $Y^+$ and $Y^-$ and the two reindexed backgrounds
+    families $Y^+$ and $Y^-$ and the two reindexed boundary conditions
     $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$.  If, for every physical letter
     $j$,
     \[
@@ -2046,7 +2048,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \qquad
         \Gamma_{L_0}(Y^-_{\eta,\mu}A^j).
     \]
-    The right-product equality gives, for every $j$,
+    The one-site product equality gives, for every $j$,
     \[
         \Gamma_{L_0}(Y^+_{\eta,\mu}A^j)
         =
@@ -2071,8 +2073,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \qquad
         \psi=\Gamma_{M+1}(X).
     \]
-    For every boundary letter $\eta$ and complementary word $\mu$, the
-    equation used for the closing-boundary argument of
+    For every boundary letter $\eta$ and complementary word $\mu$, the local
+    coordinate restriction equality representing the boundary-closing step of
     \cite[lines~2078--2090]{Cirac2021Matrix} is
     \[
         \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
@@ -2500,8 +2502,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
     \]
-    This is the right-product equality used to compare the two boundary matrices
-    after closing the boundary.
+    This is the coordinate one-site product equality used to compare the two
+    boundary matrices after closing the boundary.
 \end{lemma}
 
 \begin{proof}
@@ -2543,7 +2545,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are two families of
     matrices obtained from the two boundary-crossing local constraints used
     in the closure property, and that they satisfy,
-    for every physical letter $j$ and every background configuration $\tau$,
+    for every physical letter $j$ and every boundary condition $\tau$,
     \[
         A^{\tau_{L_0}\cdots\tau_{N-2}} A^j X
         =
@@ -2555,7 +2557,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
     For every physical letter
     $\eta\in\{0,\ldots,d-1\}$ and every word $\mu$ on the complementary sites,
-    define two background configurations by
+    define two boundary conditions by
     \[
         \tau^{+}_{\eta}(\mu)_i =
         \begin{cases}
@@ -2569,7 +2571,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
             \eta,      & \text{otherwise}.
         \end{cases}
     \]
-    Then the two families agree on these two backgrounds:
+    Then the two families agree on these two boundary conditions:
     \[
         Y^{+}_{\tau^{+}_{\eta}(\mu)}
         =


### PR DESCRIPTION
Refs #2405.

This small documentation change keeps the parent-Hamiltonian closure-property prose closer to the source terminology.  It replaces reader-facing occurrences of "background configuration" in this coordinate discussion by "boundary condition", and it describes the remaining local formulas as coordinate one-site/product equalities rather than as source-displayed theorem statements.

No Lean statements or proofs are changed.  The remaining padded coordinate identity in `MPSTensor.closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap` is still open.

Checks:
- `lake build TNLean.MPS.ParentHamiltonian.WrappingWindow TNLean.MPS.ParentHamiltonian.BoundaryClosing -q --log-level=info` (passes; existing `BoundaryClosing.lean:943` sorry warning)
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --changed-files TNLean/MPS/ParentHamiltonian/WrappingWindow.lean TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean` (Chapter 14 remains 382/382; fails only known non-parent refs `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and literal `...`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation edits only; no formal or proof changes.
> 
> **Overview**
> **Documentation-only** alignment for the parent-Hamiltonian **closure property** coordinate narrative (refs #2405). No Lean statements, proofs, or identifiers change.
> 
> In **`WrappingWindow.lean`** and **`BoundaryClosing.lean`**, reader-facing comments now say **boundary condition** instead of **background configuration** for `wrappedMiddleBackground` / `mirrorMiddleBackground`, and wording shifts from “assignment of the complementary sites” to **condition on the complementary sites**. **`BoundaryClosing`** also reframes open gaps as **coordinate** (not “auxiliary”) equations and **one-site product** equalities rather than implying the source already displays the full right-product identity.
> 
> **`blueprint/src/chapter/ch14_parent_hamiltonian.tex`** mirrors the same terminology in lemmas/theorems on wrapped witness comparison, boundary-matrix agreement, right-product determination, and the closure-property restriction step—including describing the closing-boundary step as a **local coordinate restriction equality** rather than a source-displayed auxiliary equation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb63bd9919afa0d643d36da2b728c78947a067c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->