### PR TITLE
feat(parent): record boundary transport product identity

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingCoordinate.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingCoordinate.lean
@@ -102,4 +102,56 @@ theorem closure_property_boundary_condition_product_of_window_witnesses_mul_righ
     (closure_property_boundary_condition_product_of_window_witnesses
       (A := A) hInj hL₀ hM YAt hYAt ρ)
 
+/-- Adjacent-window transport followed by the last-boundary one-sided equation.
+
+For a boundary condition \(\rho\), the adjacent windows from \(M+1-L_0\) to
+\(M\) give
+\[
+  Y_{M+1-L_0}(\rho) A^{\rho_{M+1-L_0}\cdots\rho_{M-1}}
+  =
+  A^{\rho_1\cdots\rho_{L_0-1}}Y_M(\rho).
+\]
+Multiplying by \(A^j\) and using the last-boundary equation for
+\(\psi=\Gamma_{M+1}(X)\) gives the displayed formula below.  This is the
+transport identity supplied by the adjacent-window argument; for
+\(\rho=\tau^-_\eta(\mu)\) it is distinct from the remaining padded identity
+in the closing-boundary comparison. -/
+theorem closure_property_boundary_condition_transport_wrapped_product_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (ρ : Fin (M + 1) → Fin d) (j : Fin d) :
+    YAt ⟨M + 1 - L₀, by omega⟩ ρ *
+        evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+          ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) * A j =
+      evalWord A (List.ofFn (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩)) *
+        (evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+          ρ ⟨k.val + L₀, by omega⟩)) * A j * X) := by
+  have htransport :=
+    closure_property_boundary_condition_product_of_window_witnesses_mul_right
+      (A := A) hInj hL₀ hM YAt hYAt ρ (A j)
+  have hwrapped :=
+    (closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX YAt hYAt).1 j ρ
+  calc
+    YAt ⟨M + 1 - L₀, by omega⟩ ρ *
+          evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+            ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) * A j
+        = evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+            ρ ⟨r.val + 1, by omega⟩)) * YAt ⟨M, by omega⟩ ρ * A j := htransport
+    _ = evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+            ρ ⟨r.val + 1, by omega⟩)) * (YAt ⟨M, by omega⟩ ρ * A j) := by
+          rw [Matrix.mul_assoc]
+    _ = evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+            ρ ⟨r.val + 1, by omega⟩)) *
+          (evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+            ρ ⟨k.val + L₀, by omega⟩)) * A j * X) := by
+          rw [← hwrapped]
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1370,6 +1370,47 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     equality by \(R\).
 \end{proof}
 
+\begin{lemma}[Transport followed by the last-boundary equation]
+    \label{lem:boundary_transport_wrapped_product_ground_space_map}
+    \lean{MPSTensor.closure_property_boundary_condition_transport_wrapped_product_of_groundSpaceMap}
+    \leanok
+    \uses{lem:closure_property_boundary_condition_product_window_witnesses,
+        lem:closure_property_boundary_crossing_equations_ground_space_map}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, and let
+    $L_0\le M$.  Let $\psi=\Gamma_{M+1}(X)$, and suppose that matrices
+    $Y_i(\rho)$ represent all length-$(L_0+1)$ cyclic restrictions of $\psi$.
+    Then, for every boundary condition $\rho$ and every physical letter $j$,
+    \[
+        Y_{M+1-L_0}(\rho)
+        A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}A^j
+        =
+        A^{\rho_1}\cdots A^{\rho_{L_0-1}}
+        A^{\rho_{L_0}}\cdots A^{\rho_{M-1}}A^jX .
+    \]
+    For $\rho=\tau^-_\eta(\mu)$ this is the transport identity supplied by the
+    adjacent-window argument.  It is not the remaining padded identity, where
+    the factor after $Y_{M+1-L_0}(\tau^-_\eta(\mu))$ is \(A^jA^\sigma\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:closure_property_boundary_condition_product_window_witnesses}
+    gives
+    \[
+        Y_{M+1-L_0}(\rho)
+        A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}A^j
+        =
+        A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho)A^j .
+    \]
+    The last-boundary one-sided equation for $\psi=\Gamma_{M+1}(X)$ gives
+    \[
+        Y_M(\rho)A^j
+        =
+        A^{\rho_{L_0}}\cdots A^{\rho_{M-1}}A^jX .
+    \]
+    Substitution gives the displayed formula.
+\end{proof}
+
 \begin{lemma}[Long boundary-condition product at the closing boundary]
     \label{lem:closure_property_boundary_condition_long_product_window_witnesses}
     \lean{MPSTensor.closure_property_boundary_condition_long_product_of_window_witnesses}


### PR DESCRIPTION
Refs #2405.

This adds one no-sorry coordinate lemma for the parent-Hamiltonian closing-boundary argument.  It combines adjacent-window transport with the last-boundary one-sided equation and records the product identity that is actually available:

```tex
Y_{M+1-L_0}(\rho) A^{\rho_{M+1-L_0}}\cdots A^{\rho_{M-1}}A^j
=
A^{\rho_1}\cdots A^{\rho_{L_0-1}} A^{\rho_{L_0}}\cdots A^{\rho_{M-1}}A^jX.
```

For `\rho=\tau^-_\eta(\mu)` this is distinct from the still-open #2405 padded identity, where the factor after `Y_{M+1-L_0}(\tau^-_\eta(\mu))` is `A^jA^\sigma`.  The point of the PR is to make that mismatch explicit in Lean and in the blueprint, without adding a source-absent hypothesis and without claiming the closing-boundary comparison is finished.

Checks:
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingCoordinate -q --log-level=info` (passes; existing `BoundaryClosing.lean:943` sorry warning)
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosingCoordinate.lean` (Chapter 14 is 383/383; fails only known non-parent refs `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and literal `...`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and blueprint sync only; no runtime or auth paths, and existing sorries elsewhere are unchanged.
> 
> **Overview**
> Adds a **no-sorry** coordinate lemma for the parent-Hamiltonian closing-boundary line: adjacent-window transport, then the last-boundary one-sided equation for \(\psi=\Gamma_{M+1}(X)\), yielding
> \[
> Y_{M+1-L_0}(\rho)\,A^{\rho_{M+1-L_0}\cdots\rho_{M-1}}A^j
> =
> A^{\rho_1\cdots\rho_{L_0-1}}\,A^{\rho_{L_0}\cdots\rho_{M-1}}A^j X.
> \]
> 
> In Lean this is `MPSTensor.closure_property_boundary_condition_transport_wrapped_product_of_groundSpaceMap` in `BoundaryClosingCoordinate.lean` (proof via `closure_property_boundary_condition_product_of_window_witnesses_mul_right` and `closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap`). Chapter 14 gains matching lemma `lem:boundary_transport_wrapped_product_ground_space_map` with `\leanok`.
> 
> The blueprint text states that for \(\rho=\tau^-_\eta(\mu)\) this is the transport identity from the adjacent-window step, **not** the still-open padded identity (factor \(A^j A^\sigma\) after \(Y_{M+1-L_0}\))—making the #2405 mismatch explicit without claiming the closing comparison is finished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a2b75da90a1727f008ce307b158bad9034c52b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->