### PR TITLE
feat(parent): add closing-boundary stripping reduction

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -185,6 +185,7 @@ import TNLean.MPS.ParentHamiltonian.WrappingWindow
 import TNLean.MPS.ParentHamiltonian.BoundaryStripping
 import TNLean.MPS.ParentHamiltonian.BoundaryClosing
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingCoordinate
+import TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping
 import TNLean.Axioms.Beigi
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BoundaryClosing
+import TNLean.MPS.ParentHamiltonian.BoundaryStripping
+
+/-!
+# Stripping reductions for the closing boundary
+
+This file records the left-word form of the remaining coordinate comparison in
+the closure-property argument.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Left-word stripping for the opposite-boundary coordinate comparison.
+
+Let \(Y_{M+1-L_0}(\tau^-_\eta(\mu))\) be the matrix representing the opposite
+boundary-crossing restriction. If, after fixing the physical letter \(j\) and
+the right word \(\sigma\), the difference
+\[
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+  -A^\mu A^jXA^\sigma
+\]
+is killed by left multiplication by every length-\(L_0\) word product, then the
+difference is zero.
+
+This is only a stripping reduction. It does not prove the left-multiplied
+coordinate equation; that equation is the remaining boundary-closing content
+of arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
+theorem closure_property_mirror_padded_products_of_left_word_products
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hLeft : ∀ (η j : Fin d) (σ α : Fin L₀ → Fin d),
+      evalWord A (List.ofFn α) *
+          (YAt ⟨M + 1 - L₀, by omega⟩
+              (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) =
+        evalWord A (List.ofFn α) *
+          (evalWord A (List.ofFn μ) * A j * X *
+            evalWord A (List.ofFn σ))) :
+    ∀ (η j : Fin d) (σ : Fin L₀ → Fin d),
+      YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+          evalWord A (List.ofFn σ) =
+        evalWord A (List.ofFn μ) * A j * X *
+          evalWord A (List.ofFn σ) := by
+  intro η j σ
+  let Z : Matrix (Fin D) (Fin D) ℂ :=
+    YAt ⟨M + 1 - L₀, by omega⟩
+        (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+        evalWord A (List.ofFn σ) -
+      evalWord A (List.ofFn μ) * A j * X * evalWord A (List.ofFn σ)
+  have hzero : ∀ α : Fin L₀ → Fin d, evalWord A (List.ofFn α) * Z = 0 := by
+    intro α
+    have h := hLeft η j σ α
+    dsimp [Z]
+    simpa [Matrix.mul_sub, sub_eq_zero] using h
+  have hZ : Z = 0 :=
+    eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul
+      (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
+  exact sub_eq_zero.mp hZ
+
+/-- Auxiliary boundary-condition product from the left-word form of the
+opposite-boundary coordinate comparison.
+
+Suppose the last boundary gives
+\[
+  Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX
+\]
+and the opposite-boundary difference becomes zero after left multiplication by
+every length-\(L_0\) word product:
+\[
+  A^\alpha\,Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+  =
+  A^\alpha\,A^\mu A^jXA^\sigma .
+\]
+Then the auxiliary boundary conditions \(\rho^+_{j,\sigma}\) and
+\(\rho^-_{j,\sigma}\) satisfying the required product equation exist.
+
+This is a source-faithful reduction of the coordinate form of the
+closing-boundary sentence in arXiv:2011.12127, Section IV.C,
+lines 2078--2079. -/
+lemma closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hLast : ∀ (η j : Fin d),
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j =
+        evalWord A (List.ofFn μ) * A j * X)
+    (hLeft : ∀ (η j : Fin d) (σ α : Fin L₀ → Fin d),
+      evalWord A (List.ofFn α) *
+          (YAt ⟨M + 1 - L₀, by omega⟩
+              (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) =
+        evalWord A (List.ofFn α) *
+          (evalWord A (List.ofFn μ) * A j * X *
+            evalWord A (List.ofFn σ))) :
+    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
+      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
+          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+            evalWord A (List.ofFn σ) := by
+  have hMirrorPadded :=
+    closure_property_mirror_padded_products_of_left_word_products
+      (A := A) hInj hL₀ hM YAt X μ hLeft
+  exact closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products
+    (A := A) hInj hL₀ hM YAt hYAt X μ hLast hMirrorPadded
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -31,9 +31,11 @@ the right word \(\sigma\), the difference
 is killed by left multiplication by every length-\(L_0\) word product, then the
 difference is zero.
 
-This is only a stripping reduction. It does not prove the left-multiplied
-coordinate equation; that equation is the remaining boundary-closing content
-of arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
+**Open gap:** This is only a stripping reduction. It does not prove the
+left-multiplied coordinate equation; that equation is the remaining coordinate
+form of the boundary-closing sentence in arXiv:2011.12127, Section IV.C,
+lines 2078--2079. The interpretive step is documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked in #2405. -/
 theorem closure_property_mirror_padded_products_of_left_word_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -88,9 +90,11 @@ every length-\(L_0\) word product:
 Then the auxiliary boundary conditions \(\rho^+_{j,\sigma}\) and
 \(\rho^-_{j,\sigma}\) satisfying the required product equation exist.
 
-This is a source-faithful reduction of the coordinate form of the
+**Open gap:** This is a reduction toward the project's coordinate form of the
 closing-boundary sentence in arXiv:2011.12127, Section IV.C,
-lines 2078--2079. -/
+lines 2078--2079. The coordinate form is not displayed in the source; it is
+documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked
+in #2405. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2300,6 +2300,45 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Lemma~\ref{lem:padded_complement_annihilation} gives $Z_{\eta,j}=0$.
 \end{proof}
 
+\begin{lemma}[Opposite-boundary comparison after left multiplication by words]
+    \label{lem:closure_property_opposite_boundary_comparison_from_left_words}
+    \lean{MPSTensor.closure_property_mirror_padded_products_of_left_word_products}
+    \leanok
+    \uses{def:l_blk_injective, lem:padded_complement_annihilation}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$.
+    Fix a complementary word $\mu$, a matrix $X$, and a family of matrices
+    $Y_i(\tau)$. Suppose that, for every boundary letter $\eta$, every physical
+    letter $j$, and every pair of words $\sigma,\alpha$ of length $L_0$,
+    \[
+        A^\alpha\,
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
+        =
+        A^\alpha\,\left(A^\mu A^jXA^\sigma\right).
+    \]
+    Then, for every $\eta$, $j$, and $\sigma$,
+    \[
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+        =
+        A^\mu A^jXA^\sigma .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Fix $\eta$, $j$, and $\sigma$, and set
+    \[
+        Z_{\eta,j,\sigma}
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+        -
+        A^\mu A^jXA^\sigma .
+    \]
+    The hypothesis says that \(A^\alpha Z_{\eta,j,\sigma}=0\) for every word
+    \(\alpha\) of length \(L_0\).  The left-handed form of
+    Lemma~\ref{lem:padded_complement_annihilation} gives
+    \(Z_{\eta,j,\sigma}=0\).
+\end{proof}
+
 \begin{lemma}[Auxiliary product from the opposite-boundary comparison]
     \label{lem:closure_property_auxiliary_product_from_opposite_boundary_words}
     \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products}
@@ -2365,6 +2404,61 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
     Lemma~\ref{lem:closure_property_auxiliary_product_from_right_products}
     then gives the displayed boundary conditions and auxiliary product.
+\end{proof}
+
+\begin{lemma}[Auxiliary product from the left-multiplied opposite-boundary comparison]
+    \label{lem:closure_property_auxiliary_product_from_opposite_boundary_left_words}
+    \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products}
+    \leanok
+    \uses{lem:closure_property_opposite_boundary_comparison_from_left_words,
+        lem:closure_property_auxiliary_product_from_opposite_boundary_words}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$.
+    Let $\psi$ be a state on the chain of length $M+1$, and let
+    $Y_i(\tau)$ be matrices satisfying
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)
+        =
+        \Gamma_{L_0+1}(Y_i(\tau)).
+    \]
+    Fix a complementary word $\mu$ and a matrix $X$. Suppose that, for every
+    boundary letter $\eta$ and every physical letter $j$,
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
+    \]
+    Suppose also that, for every $\eta$, $j$, and every pair of words
+    $\sigma,\alpha$ of length $L_0$,
+    \[
+        A^\alpha\,
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
+        =
+        A^\alpha\,\left(A^\mu A^jXA^\sigma\right).
+    \]
+    Then there are boundary conditions $\rho^+_{j,\sigma}$ and
+    $\rho^-_{j,\sigma}$ satisfying the complementary-word equations
+    \[
+        \rho^+_{j,\sigma}(k+L_0)=\mu_k,
+        \qquad
+        \rho^-_{j,\sigma}(k+1)=\mu_k
+    \]
+    and the product equation
+    \[
+        Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_left_words}
+    gives
+    \[
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+        =
+        A^\mu A^jXA^\sigma .
+    \]
+    Lemma~\ref{lem:closure_property_auxiliary_product_from_opposite_boundary_words}
+    then gives the displayed boundary conditions and product equation.
 \end{proof}
 
 \begin{lemma}[Auxiliary first-letter form of the closure property]


### PR DESCRIPTION
## Summary
- add `BoundaryClosingStripping`, recording the left-word stripping form of the remaining opposite-boundary coordinate comparison
- prove that left multiplication by all length-`L_0` word products reduces to the padded coordinate identity by block injectivity
- record the corresponding auxiliary boundary-condition product consequence in the blueprint

This is a reduction toward #2405. It does not close the remaining coordinate comparison

```tex
Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma = A^\mu A^jXA^\sigma.
```

The source does not display this coordinate equation; this PR treats it as the formal coordinate form of the closing-boundary sentence in arXiv:2011.12127, Section IV.C, lines 2078--2079.

## Verification
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `lake build TNLean`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `leanblueprint web` (succeeds; emits existing package/bibliography warnings)
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean TNLean.lean`

Global blueprint sync/checkdecls still report pre-existing missing declarations outside this change (`TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData`, `...`, and older missing checkdecls entries). The changed parent declarations are present in `blueprint/lean_decls` and in the Lean source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New proved lemmas and blueprint text only; no changes to auth, runtime, or existing proof obligations beyond documenting an alternate reduction path.
> 
> **Overview**
> Adds **`BoundaryClosingStripping`** to the parent-Hamiltonian closure track: a **left-word** stripping reduction parallel to the existing right-word opposite-boundary comparison.
> 
> **`closure_property_mirror_padded_products_of_left_word_products`** shows that if the padded opposite-boundary difference is annihilated by left multiplication with every length-\(L_0\) word \(A^\alpha\), then block injectivity forces the unpadded identity \(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma = A^\mu A^j X A^\sigma\). A second lemma chains that into **`closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products`** when the last-boundary equation holds, yielding the auxiliary \(\rho^\pm\) boundary product—without proving the left-multiplied hypothesis itself (still **#2405**).
> 
> The module is wired into **`TNLean.lean`**, and **chapter 14** gains matching blueprint lemmas with `\leanok` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96bd9a71f0f54507bdf4e5cc2af81bf8eae6670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->