### PR TITLE
feat(parent): reduce closing product to left-word comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -135,4 +135,63 @@ lemma closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_product
   exact closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products
     (A := A) hInj hL₀ hM YAt hYAt X μ hLast hMirrorPadded
 
+/-- Auxiliary boundary-condition product from the left-multiplied coordinate
+form and the one-sided boundary equations of an open-chain representation.
+
+For \(\psi=\Gamma_{M+1}(X)\), the last boundary supplies
+\[
+  Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX.
+\]
+Thus the auxiliary product equation follows once, for every pair of
+length-\(L_0\) words \(\alpha,\sigma\), the opposite boundary satisfies the
+left-multiplied coordinate comparison
+\[
+  A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
+  =
+  A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr)
+\]
+
+**Open gap:** This theorem combines the preceding reductions in the
+closure-property argument. It does not prove the displayed left-multiplied
+comparison; that comparison is the current coordinate form of the
+boundary-closing sentence in arXiv:2011.12127, Section IV.C, lines 2078--2079.
+The source does not display this coordinate equation. See
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hLeft : ∀ (η j : Fin d) (σ α : Fin L₀ → Fin d),
+      evalWord A (List.ofFn α) *
+          (YAt ⟨M + 1 - L₀, by omega⟩
+              (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) =
+        evalWord A (List.ofFn α) *
+          (evalWord A (List.ofFn μ) * A j * X *
+            evalWord A (List.ofFn σ))) :
+    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
+      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
+          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+            evalWord A (List.ofFn σ) := by
+  have hOneSided :=
+    closure_property_boundary_one_sided_products_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX YAt hYAt μ
+  exact closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
+    (A := A) hInj hL₀ hM YAt hYAt X μ hOneSided.1 hLeft
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2461,6 +2461,59 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     then gives the displayed boundary conditions and product equation.
 \end{proof}
 
+\begin{lemma}[Auxiliary product from the left-multiplied closure-property comparison]
+    \label{lem:closure_property_auxiliary_boundary_product_ground_space_left_words}
+    \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words}
+    \leanok
+    \uses{lem:closure_property_boundary_one_sided_products_ground_space_map,
+        lem:closure_property_auxiliary_product_from_opposite_boundary_left_words}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, and let
+    $L_0\le M$. Let
+    \[
+        \psi=\Gamma_{M+1}(X)
+    \]
+    be an open-chain representation, and let $Y_i(\tau)$ represent the
+    length-$(L_0+1)$ cyclic restrictions of $\psi$. Fix a complementary word
+    $\mu$. Suppose that, for every boundary letter $\eta$, physical letter
+    $j$, and length-$L_0$ words $\sigma,\alpha$,
+    \[
+        A^\alpha
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
+        =
+        A^\alpha
+        \left(A^\mu A^jXA^\sigma\right).
+    \]
+    Then there are boundary conditions $\rho^+_{j,\sigma}$ and
+    $\rho^-_{j,\sigma}$ satisfying the complementary-word equations
+    \[
+        \rho^+_{j,\sigma}(k+L_0)=\mu_k,
+        \qquad
+        \rho^-_{j,\sigma}(k+1)=\mu_k
+    \]
+    and the product equation
+    \[
+        Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+        =
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:closure_property_boundary_one_sided_products_ground_space_map}
+    gives the last-boundary equation
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
+    \]
+    The assumed left-multiplied coordinate equation and
+    Lemma~\ref{lem:closure_property_auxiliary_product_from_opposite_boundary_left_words}
+    then give the displayed boundary conditions and product equation.
+    % Source note: arXiv:2011.12127, Section IV.C, lines 2078--2079,
+    % says that the corresponding boundary-closing argument is analogous.
+    % The assumed equation is the coordinate form isolated in
+    % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
+\end{proof}
+
 \begin{lemma}[Auxiliary first-letter form of the closure property]
     \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
     \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}


### PR DESCRIPTION
## Summary

Adds a no-sorry reduction for the parent-Hamiltonian closure-property comparison.  The new theorem says that the auxiliary boundary-condition product follows from the left-multiplied coordinate equation

```tex
A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
=
A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr),
```

for all boundary letters `\eta`, physical letters `j`, and length-`L_0` words `\alpha, \sigma`.

This is a reduction only. It does not prove the displayed equation. The RMP source compresses that remaining step into the sentence that the same inverting-and-growing-back argument applies when closing the boundaries; the coordinate equation is recorded in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked by #2405.

## Changes

- Adds `MPSTensor.closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words`.
- Records the corresponding blueprint lemma with formula-first prose.
- Keeps the source distinction explicit: this is not an equation displayed in arXiv:2011.12127.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `lake build TNLean`
- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean`
- `cd blueprint && leanblueprint web` (passes with the repository's usual plasTeX and bibliography warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in MPS parent-Hamiltonian theory; no runtime, auth, or data-path changes, and the open mathematical gap is unchanged.
> 
> **Overview**
> Adds a **reduction-only** Lean theorem and matching blueprint lemma for the parent-Hamiltonian closure property: the auxiliary boundary product (`ρ^±` and the padded product equation) follows from an open-chain ground-space representation plus the **left-multiplied** coordinate hypothesis
> 
> `A^α(Y_{M+1-L₀}(τ⁻) A^j A^σ) = A^α(A^μ A^j X A^σ)`
> 
> for all boundary letters, physical letters, and length-`L₀` words `α, σ`.
> 
> The proof is a short composition of existing lemmas (`closure_property_boundary_one_sided_products_of_groundSpaceMap` and `closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products`). Docstrings and blueprint text state explicitly that this does **not** prove that comparison—it is the coordinate form of the remaining boundary-closing step in the RMP source (#2405).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0e07cea706138e7ca50c6ac81e30d03cb74e640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->