### PR TITLE
ci(prose): guard reader-facing label references

### DIFF
--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -15,6 +15,7 @@ on:
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_bibtex.py'
       - 'scripts/blueprint_lean_sync.py'
+      - 'scripts/check_reader_facing_prose.py'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -28,6 +29,7 @@ on:
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_bibtex.py'
       - 'scripts/blueprint_lean_sync.py'
+      - 'scripts/check_reader_facing_prose.py'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,6 +43,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Check reader-facing prose patterns
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags origin "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
+          python3 scripts/check_reader_facing_prose.py --root . --diff-base "$BASE_REF" --ci
 
       - name: Install blueprint system dependencies
         uses: texra-ai/lean-env-action/blueprint-system-deps@v1

--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -32,7 +32,7 @@ lemma parentInteraction_apply_mem_groundSpace (A : MPSTensor d D) (L : ℕ)
     rw [sub_eq_zero]
     exact (Submodule.starProjection_eq_self_iff.mpr hmem).symm
   -- Unfold `parentInteraction` to expose the equiv ∘ projection ∘ equiv⁻¹ structure.
-  -- This `change` is definitional; update it if `parentInteraction` is refactored.
+  -- This `change` is definitional; update it if `parentInteraction` is restated.
   change (WithLp.linearEquiv 2 ℂ (NSiteSpace d L))
     ((groundSpaceES A L)ᗮ.starProjection
       ((WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm v)) = 0

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -938,8 +938,7 @@ form at the opposite boundary after multiplication by a length-\(L_0\) word,
   =
   A^\mu A^j X A^\sigma .
 \]
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked
-in #2405. -/
+documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -35,7 +35,7 @@ difference is zero.
 left-multiplied coordinate equation; that equation is the remaining coordinate
 form of the boundary-closing sentence in arXiv:2011.12127, Section IV.C,
 lines 2078--2079. The interpretive step is documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked in #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_mirror_padded_products_of_left_word_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -93,8 +93,7 @@ Then the auxiliary boundary conditions \(\rho^+_{j,\sigma}\) and
 **Open gap:** This is a reduction toward the project's coordinate form of the
 closing-boundary sentence in arXiv:2011.12127, Section IV.C,
 lines 2078--2079. The coordinate form is not displayed in the source; it is
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and tracked
-in #2405. -/
+documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -156,7 +155,7 @@ closure-property argument. It does not prove the displayed left-multiplied
 comparison; that comparison is the current coordinate form of the
 boundary-closing sentence in arXiv:2011.12127, Section IV.C, lines 2078--2079.
 The source does not display this coordinate equation. See
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -42,7 +42,7 @@ of the parent Hamiltonian (see `UniqueGroundState.lean`).
 * [MPGSC18] arXiv:1804.04964, Section 3 (one-sided inverse)
 * [FNW92] Sections 3–4
 
-## External input — Quantum Wielandt cumulative-to-word-span
+## External input: cumulative and exact word spans
 
 This file imports `TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which supplies
 the connection from the cumulative Wielandt bound to a concrete word-span theorem:
@@ -60,12 +60,14 @@ injectivity at length 1 implies word-span fullness at all positive lengths
 via the cumulative span chain, and `CumulativeToWordSpan` upgrades the
 cumulative conclusion to an exact-length word-span theorem.
 
-The formal Lean declaration:
-
-> `Wielandt.SpanGrowth.CumulativeToWordSpan` supplies the lemma
-> `cumulativeSpan_eq_top_iff_wordSpan_eq_top` and related declarations that
-> connect cumulative and exact-length span.  These are consumed by the
-> ground-space injectivity proof `groundSpaceMap_injective`.
+The equivalence
+\[
+  S_n(A)=M_D(\mathbb C)
+  \quad\Longleftrightarrow\quad
+  \operatorname{span}\{A^w: |w|=n\}=M_D(\mathbb C)
+\]
+is the cumulative-to-exact-length implication used to prove injectivity of the
+ground-space map.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -60,14 +60,18 @@ injectivity at length 1 implies word-span fullness at all positive lengths
 via the cumulative span chain, and `CumulativeToWordSpan` upgrades the
 cumulative conclusion to an exact-length word-span theorem.
 
-The equivalence
+Under the aperiodicity hypothesis
+\[
+  I\in\operatorname{span}\{A^i: i\in[d]\},
+\]
+which follows here from injectivity at length one, the equivalence
 \[
   S_n(A)=M_D(\mathbb C)
   \quad\Longleftrightarrow\quad
   \operatorname{span}\{A^w: |w|=n\}=M_D(\mathbb C)
 \]
-is the cumulative-to-exact-length equivalence used to prove injectivity of the
-ground-space map.
+for \(n\ge 1\) is the cumulative-to-exact-length equivalence used to prove
+injectivity of the ground-space map.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -66,7 +66,7 @@ The equivalence
   \quad\Longleftrightarrow\quad
   \operatorname{span}\{A^w: |w|=n\}=M_D(\mathbb C)
 \]
-is the cumulative-to-exact-length implication used to prove injectivity of the
+is the cumulative-to-exact-length equivalence used to prove injectivity of the
 ground-space map.
 -/
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -7,15 +7,13 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 
 /-!
-# Martingale-method spectral-gap framework for parent Hamiltonians
+# Martingale estimate for parent Hamiltonians
 
-This module collects the proof-complete martingale-method infrastructure for the
-MPS parent-Hamiltonian spectral gap and is imported by the project root.  The
-Friedrichs-angle estimate needed to close `parentHamiltonian_gapped` is the
-remaining analytic step, so `Martingale.Gap` stays separate until that estimate
-is proved.
+This module collects the martingale estimates reducing the MPS parent-Hamiltonian
+spectral gap to a uniform Friedrichs-angle bound for adjacent local ground
+spaces. The Friedrichs-angle estimate remains separate until it is proved.
 
-This file collects the three proof-complete infrastructure submodules:
+The three components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale` (quadratic form ⟹ norm bound);
@@ -28,7 +26,7 @@ The final spectral-gap pair `parentHamiltonianES_gap_bound_of_friedrichs` and
 `parentHamiltonian_gapped` remains in `Martingale.Gap`; it is not imported here
 until the Friedrichs-angle estimate is proved.
 
-## Proof route
+## Argument
 
 1. **Frustration-freeness** (`parentHamiltonian_frustrationFree`): every local
    term annihilates the MPV ground state.
@@ -46,7 +44,7 @@ until the Friedrichs-angle estimate is proved.
    with constants `c_{ij}` depending only on the MPS tensor, not on `N`.
 5. **Row-sum bound** `∑_{j ≠ i} c_{ij} ≤ 1`: at most `2(L-1)` local terms
    overlap a given local term.
-6. **Quadratic form ⟹ norm bound**: combining the above with `h_i^2 = h_i`
+6. **Quadratic form ⟹ norm bound**: combining these estimates with `h_i^2 = h_i`
    yields `H² ≥ γ H` as a quadratic form, which by the spectral theorem
    gives `γ ‖v‖ ≤ ‖H v‖` for `v ⊥ ker H`.
 -/

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -41,7 +41,7 @@ implies the corresponding norm lower bound on the orthogonal complement of the
 transported ground space.
 
 This theorem isolates the operator-theoretic part of the remaining
-Friedrichs-angle route. The hypotheses already include the quantitative
+Friedrichs-angle estimate. The hypotheses already include the quantitative
 martingale/Friedrichs estimate
 
 `γ * re ⟪H_N v, v⟫ ≤ re ⟪H_N v, H_N v⟫`,

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -707,7 +707,7 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
 \]
 **Open gap:** This follows from the auxiliary product equation in
 `closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -736,7 +736,7 @@ theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
 \(Y_M(\tau^+_\eta(\mu))A^j
 =Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\).
 **Open gap:** Inherits the unproved product equality above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -774,7 +774,7 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
 /-- First-letter restriction equality \(R_jB^+_{\eta,\mu}=R_jB^-_{\eta,\mu}\),
 obtained by restricting the displayed matrix equation at the first physical
 index.  **Open gap:** Inherits the unproved product equality above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -811,7 +811,7 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
 /-- Restriction equality \(B^+_{\eta,\mu}=B^-_{\eta,\mu}\) at the closed
 boundary, obtained from the first-letter family.  **Open gap:** Inherits the
 unproved product equality above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -843,7 +843,7 @@ with every \(A^j\) agree:
 \(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j
 \Rightarrow Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
 **Open gap:** Inherits the unproved product equality at the closed boundary; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -889,7 +889,7 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 source obtains this from the intersection property and closure property in
 arXiv:2011.12127, Section IV.C, lines 2078--2090.
 **Open gap:** Depends on the comparison at the closed boundary; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -924,7 +924,7 @@ for every \(L>L₀\), by the intersection property and closure property of
 arXiv:2011.12127, Section IV.C, lines 2078--2090.
 
 **Open gap:** The containment direction depends on the closure property; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N) :
@@ -961,7 +961,7 @@ theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjec
 /-- Unique ground state for \(L₀\)-block-injective tensors at range \(2L₀\).
 
 **Open gap:** This uses the normal range-reduction equality; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) :
@@ -979,7 +979,7 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 \]
 
 **Open gap:** This depends on the normal range-reduction equality above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -4279,9 +4279,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     the principal-angle estimates cited in
     \cite{Fannes1992Finitely, Nachtergaele1996Spectral,
     Kastoryano2018Martingale}.  Either the cited estimates supply exactly this
-    bound under the cyclic-window convention, or the displayed theorem is a
-    stronger replacement estimate.
-    % Paper-gap note: docs/paper-gaps/cpgsv21_martingale_overlap.tex; issue #952.
+    bound under the cyclic-window convention, or the required cyclic-window
+    inequality is stronger than the cited principal-angle estimates.
+    % Paper-gap note: docs/paper-gaps/cpgsv21_martingale_overlap.tex.
 \end{proof}
 
 \begin{theorem}[Explicit Friedrichs-angle gap bound]

--- a/scripts/check_reader_facing_prose.py
+++ b/scripts/check_reader_facing_prose.py
@@ -55,7 +55,7 @@ def _git_diff(base_ref: str) -> str:
             "HEAD",
             "--",
             "TNLean/**/*.lean",
-            "blueprint/src/**/*.tex",
+            "blueprint/src/chapter/*.tex",
         ],
         check=True,
         stdout=subprocess.PIPE,

--- a/scripts/check_reader_facing_prose.py
+++ b/scripts/check_reader_facing_prose.py
@@ -35,13 +35,24 @@ class Finding:
     text: str
 
 
+def _merge_base(base_ref: str) -> str:
+    return subprocess.run(
+        ["git", "merge-base", base_ref, "HEAD"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
 def _git_diff(base_ref: str) -> str:
+    merge_base = _merge_base(base_ref)
     return subprocess.run(
         [
             "git",
             "diff",
             "--unified=0",
-            base_ref,
+            merge_base,
+            "HEAD",
             "--",
             "TNLean/**/*.lean",
             "blueprint/src/**/*.tex",
@@ -224,7 +235,7 @@ def main() -> int:
         "--diff-base",
         "--base-ref",
         dest="diff_base",
-        help="base ref for an added-line scan; omit for a full scan",
+        help="base ref for a merge-base added-line scan; omit for a full scan",
     )
     parser.add_argument("--ci", action="store_true", help="emit GitHub Actions annotations")
     args = parser.parse_args()

--- a/scripts/check_reader_facing_prose.py
+++ b/scripts/check_reader_facing_prose.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Reject newly added reader-facing prose that uses tracker or label shorthand."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+from typing import Iterable
+
+
+ISSUE_REF_RE = re.compile(
+    r"(?i)(?:issues?\s*)?#\d+(?:/#\d+)*|issues?\s*\\#\d+(?:/\\#\d+)*|"
+    r"Issue~\\#\d+|https://github\.com/[^\s}]+/issues/\d+"
+)
+BLUEPRINT_LABEL_TEXTTT_RE = re.compile(r"\\texttt\{(?:thm|lem|def|prop|cor|eq):[^}]*\}")
+IGNORED_TEX_MACRO_RE = re.compile(r"\\(?:label|ref|eqref|uses|lean)\{[^}]*\}")
+
+
+@dataclass(frozen=True)
+class AddedLine:
+    path: Path
+    line_no: int
+    text: str
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line_no: int
+    message: str
+    text: str
+
+
+def _git_diff(base_ref: str) -> str:
+    return subprocess.run(
+        [
+            "git",
+            "diff",
+            "--unified=0",
+            base_ref,
+            "--",
+            "TNLean/**/*.lean",
+            "blueprint/src/**/*.tex",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout
+
+
+def added_lines(diff_base: str) -> list[AddedLine]:
+    lines: list[AddedLine] = []
+    current_path: Path | None = None
+    new_line: int | None = None
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+    for raw in _git_diff(diff_base).splitlines():
+        if raw.startswith("+++ b/"):
+            current_path = Path(raw.removeprefix("+++ b/"))
+            continue
+        if raw.startswith("+++ /dev/null"):
+            current_path = None
+            continue
+        hunk_match = hunk_re.match(raw)
+        if hunk_match:
+            new_line = int(hunk_match.group(1))
+            continue
+        if current_path is None or new_line is None:
+            continue
+        if raw.startswith("+"):
+            lines.append(AddedLine(current_path, new_line, raw[1:]))
+            new_line += 1
+        elif raw.startswith("-"):
+            continue
+        elif raw.startswith(" "):
+            new_line += 1
+    return lines
+
+
+def lean_files(root: Path) -> Iterable[Path]:
+    for path in (root / "TNLean").glob("**/*.lean"):
+        if "Archive" not in path.relative_to(root).parts:
+            yield path.relative_to(root)
+
+
+def blueprint_files(root: Path) -> Iterable[Path]:
+    yield from (root / "blueprint" / "src" / "chapter").glob("*.tex")
+
+
+def lean_comment_lines(path: Path) -> set[int]:
+    """Return line numbers lying inside Lean comments or docstrings."""
+    comment_lines: set[int] = set()
+    depth = 0
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        i = 0
+        while i < len(line):
+            if depth == 0 and line.startswith("--", i):
+                comment_lines.add(line_no)
+                break
+            if line.startswith("/-", i):
+                depth += 1
+                comment_lines.add(line_no)
+                i += 2
+                continue
+            if depth > 0:
+                comment_lines.add(line_no)
+                if line.startswith("-/", i):
+                    depth -= 1
+                    i += 2
+                    continue
+            i += 1
+        if depth > 0:
+            comment_lines.add(line_no)
+    return comment_lines
+
+
+def strip_tex_comment(text: str) -> str:
+    escaped = False
+    for i, char in enumerate(text):
+        if char == "\\" and not escaped:
+            escaped = True
+            continue
+        if char == "%" and not escaped:
+            return text[:i]
+        escaped = False
+    return text
+
+
+def normalized_tex_prose(text: str) -> str:
+    return IGNORED_TEX_MACRO_RE.sub("", strip_tex_comment(text))
+
+
+def check_lean_line(path: Path, line_no: int, text: str) -> Finding | None:
+    if ISSUE_REF_RE.search(text):
+        return Finding(
+            path,
+            line_no,
+            "Lean docstrings and comments should cite the mathematical note, not an issue number.",
+            text,
+        )
+    return None
+
+
+def check_blueprint_line(path: Path, line_no: int, text: str) -> list[Finding]:
+    prose = normalized_tex_prose(text)
+    if not prose.strip():
+        return []
+    findings: list[Finding] = []
+    if ISSUE_REF_RE.search(prose):
+        findings.append(
+            Finding(
+                path,
+                line_no,
+                "Blueprint prose should not refer to issue numbers; use a LaTeX comment if needed.",
+                text,
+            )
+        )
+    if BLUEPRINT_LABEL_TEXTTT_RE.search(prose):
+        findings.append(
+            Finding(
+                path,
+                line_no,
+                "Blueprint prose should use mathematical references, not \\texttt{thm:/lem:/def:...} labels.",
+                text,
+            )
+        )
+    return findings
+
+
+def check_added_lines(lines: Iterable[AddedLine]) -> list[Finding]:
+    findings: list[Finding] = []
+    lean_comment_cache: dict[Path, set[int]] = {}
+    for added in lines:
+        if added.path.suffix == ".lean":
+            if "Archive" in added.path.parts:
+                continue
+            comment_lines = lean_comment_cache.setdefault(
+                added.path, lean_comment_lines(added.path)
+            )
+            if added.line_no in comment_lines:
+                finding = check_lean_line(added.path, added.line_no, added.text)
+                if finding is not None:
+                    findings.append(finding)
+        elif added.path.suffix == ".tex":
+            findings.extend(check_blueprint_line(added.path, added.line_no, added.text))
+    return findings
+
+
+def check_all(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for rel_path in lean_files(root):
+        path = root / rel_path
+        comment_lines = lean_comment_lines(path)
+        for line_no, text in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if line_no in comment_lines:
+                finding = check_lean_line(rel_path, line_no, text)
+                if finding is not None:
+                    findings.append(finding)
+    for path in blueprint_files(root):
+        rel_path = path.relative_to(root)
+        for line_no, text in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            findings.extend(check_blueprint_line(rel_path, line_no, text))
+    return findings
+
+
+def print_findings(findings: list[Finding], *, ci: bool) -> None:
+    for finding in findings:
+        if ci:
+            print(
+                f"::error file={finding.path},line={finding.line_no},"
+                f"title=Reader-facing prose::{finding.message}"
+            )
+        print(f"{finding.path}:{finding.line_no}: {finding.message}")
+        print(f"  {finding.text}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument(
+        "--diff-base",
+        "--base-ref",
+        dest="diff_base",
+        help="base ref for an added-line scan; omit for a full scan",
+    )
+    parser.add_argument("--ci", action="store_true", help="emit GitHub Actions annotations")
+    args = parser.parse_args()
+    root = Path(args.root).resolve()
+    os.chdir(root)
+    diff_mode = args.diff_base is not None
+    findings = check_added_lines(added_lines(args.diff_base)) if diff_mode else check_all(root)
+    if not findings:
+        if diff_mode:
+            print("✓ No newly added reader-facing prose violations found.")
+        else:
+            print("✓ No reader-facing prose violations found.")
+        return 0
+    print_findings(findings, ci=args.ci)
+    message = "Reader-facing prose violates docs/prose_style.md."
+    if args.ci:
+        print(f"::error::{message}")
+    else:
+        print(message)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_reader_facing_prose.py
+++ b/scripts/check_reader_facing_prose.py
@@ -18,6 +18,11 @@ ISSUE_REF_RE = re.compile(
 )
 BLUEPRINT_LABEL_TEXTTT_RE = re.compile(r"\\texttt\{(?:thm|lem|def|prop|cor|eq):[^}]*\}")
 IGNORED_TEX_MACRO_RE = re.compile(r"\\(?:label|ref|eqref|uses|lean)\{[^}]*\}")
+BLUEPRINT_ENTRYPOINTS = {
+    Path("blueprint/src/content.tex"),
+    Path("blueprint/src/print.tex"),
+    Path("blueprint/src/web.tex"),
+}
 
 
 @dataclass(frozen=True)
@@ -54,8 +59,12 @@ def _git_diff(base_ref: str) -> str:
             merge_base,
             "HEAD",
             "--",
-            "TNLean/**/*.lean",
-            "blueprint/src/chapter/*.tex",
+            "TNLean.lean",
+            ":(glob)TNLean/**/*.lean",
+            "blueprint/src/content.tex",
+            "blueprint/src/print.tex",
+            "blueprint/src/web.tex",
+            ":(glob)blueprint/src/chapter/*.tex",
         ],
         check=True,
         stdout=subprocess.PIPE,
@@ -92,12 +101,19 @@ def added_lines(diff_base: str) -> list[AddedLine]:
 
 
 def lean_files(root: Path) -> Iterable[Path]:
+    root_module = root / "TNLean.lean"
+    if root_module.exists():
+        yield root_module.relative_to(root)
     for path in (root / "TNLean").glob("**/*.lean"):
         if "Archive" not in path.relative_to(root).parts:
             yield path.relative_to(root)
 
 
 def blueprint_files(root: Path) -> Iterable[Path]:
+    for rel_path in BLUEPRINT_ENTRYPOINTS:
+        path = root / rel_path
+        if path.exists():
+            yield path
     yield from (root / "blueprint" / "src" / "chapter").glob("*.tex")
 
 
@@ -181,6 +197,14 @@ def check_blueprint_line(path: Path, line_no: int, text: str) -> list[Finding]:
     return findings
 
 
+def is_blueprint_prose_path(path: Path) -> bool:
+    return path in BLUEPRINT_ENTRYPOINTS or (
+        len(path.parts) == 4
+        and path.parts[:3] == ("blueprint", "src", "chapter")
+        and path.suffix == ".tex"
+    )
+
+
 def check_added_lines(lines: Iterable[AddedLine]) -> list[Finding]:
     findings: list[Finding] = []
     lean_comment_cache: dict[Path, set[int]] = {}
@@ -195,7 +219,7 @@ def check_added_lines(lines: Iterable[AddedLine]) -> list[Finding]:
                 finding = check_lean_line(added.path, added.line_no, added.text)
                 if finding is not None:
                     findings.append(finding)
-        elif added.path.suffix == ".tex":
+        elif added.path.suffix == ".tex" and is_blueprint_prose_path(added.path):
             findings.extend(check_blueprint_line(added.path, added.line_no, added.text))
     return findings
 


### PR DESCRIPTION
## Summary
- Remove issue-number references from parent-Hamiltonian Lean docstrings and comments, leaving the paper-gap note citations.
- Replace declaration-name prose in parent-Hamiltonian comments with mathematical wording, including the cumulative/exact word-span equivalence.
- Add a PR-only reader-facing prose scan for newly added issue references in Lean comments/docstrings and visible blueprint prose, and for label prose such as \texttt{thm:...} in the blueprint.

## Mathematical scope
No theorem statement or proof term is changed. This PR only changes exposition and CI linting.

## Checks
- python3 -m py_compile scripts/check_reader_facing_prose.py
- python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci
- python3 scripts/check_oversized_lean_files.py --root .
- git diff --check
- lake build TNLean.MPS.ParentHamiltonian.Basic TNLean.MPS.ParentHamiltonian.IntersectionProperty TNLean.MPS.ParentHamiltonian.Martingale TNLean.MPS.ParentHamiltonian.Martingale.Reduction TNLean.MPS.ParentHamiltonian.BoundaryClosing TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping TNLean.MPS.ParentHamiltonian.UniqueGroundState
- leanblueprint web

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI lint only; no formal mathematics or proof logic is modified.
> 
> **Overview**
> Adds **PR-only CI** via `scripts/check_reader_facing_prose.py`, wired into `lint-blueprint.yml`, which flags **newly added** reader-facing text that cites GitHub issue numbers or uses blueprint `\texttt{thm:/lem:/def:...}` labels in visible Lean comments/docstrings and blueprint chapter prose.
> 
> **Exposition-only** updates across parent-Hamiltonian Lean modules and `ch14_parent_hamiltonian.tex`: drops issue trackers (e.g. `#2405`, `#952`) in favor of `docs/paper-gaps/...` notes, tightens martingale/Wielandt docstrings into mathematical language (including the cumulative vs exact-length word-span equivalence), and minor wording fixes. **No theorem statements or proof terms change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b65a69771261f7711a4c19b3d85c7c0911e4a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->