### PR TITLE
feat(channel): partial trace commutes with per-factor submatrix reindexing

### DIFF
--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -119,6 +119,26 @@ theorem partialTraceRight_partialTraceRight {α β γ : Type*} [Fintype β] [Fin
   ext i j
   simp only [partialTraceRight_apply, Matrix.submatrix_apply, Fintype.sum_prod_type]
 
+/-- The right partial trace commutes with a reindexing of the kept (first)
+factor: `(tr_β X)` reindexed by `f` on the kept index equals `tr_β` of `X`
+reindexed by `f` on the kept index (and the identity on the traced index). -/
+theorem partialTraceRight_submatrix_left {α α' β : Type*} [Fintype β]
+    (f : α' → α) (Z : Matrix (α × β) (α × β) ℂ) :
+    (partialTraceRight Z).submatrix f f
+      = partialTraceRight (Z.submatrix (Prod.map f id) (Prod.map f id)) := by
+  ext i j
+  simp only [partialTraceRight_apply, Matrix.submatrix_apply, Prod.map_apply, id_eq]
+
+/-- The right partial trace is invariant under reindexing the traced (second)
+factor by an equivalence. -/
+theorem partialTraceRight_submatrix_right {α β β' : Type*} [Fintype β] [Fintype β']
+    (g : β' ≃ β) (Z : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight Z
+      = partialTraceRight (Z.submatrix (Prod.map id g) (Prod.map id g)) := by
+  ext i j
+  simp only [partialTraceRight_apply, Matrix.submatrix_apply, Prod.map_apply, id_eq]
+  exact (g.sum_comp (fun k => Z (i, k) (j, k))).symm
+
 /-- **Partial trace over the first (left) tensor factor** (`tr_A`).
 
 For a matrix `X : M_{d·d'}(ℂ)` indexed by `(Fin d × Fin d')`, the partial

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -120,8 +120,9 @@ theorem partialTraceRight_partialTraceRight {α β γ : Type*} [Fintype β] [Fin
   simp only [partialTraceRight_apply, Matrix.submatrix_apply, Fintype.sum_prod_type]
 
 /-- The right partial trace commutes with a reindexing of the kept (first)
-factor: `(tr_β X)` reindexed by `f` on the kept index equals `tr_β` of `X`
-reindexed by `f` on the kept index (and the identity on the traced index). -/
+factor: reindexing the right partial trace by `f` on the kept index equals the
+right partial trace of the matrix reindexed by `f` on the kept index (and the
+identity on the traced index). -/
 theorem partialTraceRight_submatrix_left {α α' β : Type*} [Fintype β]
     (f : α' → α) (Z : Matrix (α × β) (α × β) ℂ) :
     (partialTraceRight Z).submatrix f f


### PR DESCRIPTION
## Summary

Two general, reusable lemmas continuing the partial-trace infrastructure (#2435), toward the contiguous-block reduction composition needed for Proposition 4.5 (#2424):

- **`Matrix.partialTraceRight_submatrix_left`** — the right partial trace commutes with a reindexing `f` of the *kept* (first) factor: `(tr_β Z).submatrix f f = tr_β (Z.submatrix (f × id) (f × id))`.
- **`Matrix.partialTraceRight_submatrix_right`** — the right partial trace is invariant under reindexing the *traced* (second) factor by an equivalence (via `Equiv.sum_comp`).

## Why

Together with `partialTraceRight_partialTraceRight` (#2435), these reduce a nested block reduction `blockReducedState d L K₁ (blockReducedState d (L+K₁) K₂ X)` to a single `blockReducedState d L (K₁+K₂)` modulo a reindexing — the "prefix consistency" step in the validated decomposition of #2424 (Prop 4.5). The remaining `Fin.append`-associativity index identity is tracked on that issue.

## Verification

- `lake build TNLean.Channel.PartialTrace` green; both `sorry`/`axiom`-free.
- Additions only; general (universe-polymorphic) statements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Mathlib lemmas in partial-trace infrastructure with no API or runtime behavior changes.
> 
> **Overview**
> Adds two **universe-polymorphic** lemmas to `TNLean/Channel/PartialTrace.lean` so `Matrix.partialTraceRight` interacts cleanly with `Matrix.submatrix` when indices are reindexed per tensor factor.
> 
> **`partialTraceRight_submatrix_left`** shows that reindexing the *kept* (first) factor before or after the trace agrees: `(tr_β Z).submatrix f f = tr_β (Z.submatrix (f × id) (f × id))`, proved by extensionality and `simp` on the trace formula.
> 
> **`partialTraceRight_submatrix_right`** shows invariance when the *traced* (second) factor is reindexed by an equivalence `g : β' ≃ β`, using `Equiv.sum_comp` on the inner sum. Together with the existing `partialTraceRight_partialTraceRight` composition lemma, this supports folding nested contiguous `blockReducedState` steps into a single trace modulo reindexing (Prop 4.5 / area-law work).
> 
> No changes to definitions or downstream callers in this diff—proof-only additions beside the prior partial-trace block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88276de17552007f0563041f7d22e88c70607741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->