### PR TITLE
feat(MPDO): block-reduction composition and p-fold shift invariance (Prop 4.5 foundations)

### DIFF
--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -122,6 +122,28 @@ theorem mpo_submatrix_rotateConfig (M : MPOTensor d D) (N : ℕ) :
   simp only [Matrix.submatrix_apply, mpo_apply, rotateConfig_apply]
   exact mpoMatrixEntry_comp_finRotate M σ τ
 
+/-- The closed-word MPO entry is invariant under a `p`-fold cyclic shift of both
+configurations (iterating the single-shift invariance). -/
+theorem mpoMatrixEntry_comp_finRotate_pow (M : MPOTensor d D) {N : ℕ}
+    (p : ℕ) (σ τ : Fin N → Fin d) :
+    mpoMatrixEntry M (σ ∘ (finRotate N : Fin N → Fin N)^[p])
+        (τ ∘ (finRotate N : Fin N → Fin N)^[p])
+      = mpoMatrixEntry M σ τ := by
+  induction p with
+  | zero => simp
+  | succ n ih =>
+      rw [Function.iterate_succ, ← Function.comp_assoc, ← Function.comp_assoc,
+        mpoMatrixEntry_comp_finRotate, ih]
+
+/-- **Translation invariance under a `p`-fold shift.** `mpo M N` is invariant
+under the simultaneous `p`-fold cyclic shift of bra and ket configurations. -/
+theorem mpo_submatrix_finRotate_pow (M : MPOTensor d D) (N p : ℕ) :
+    (mpo M N).submatrix (fun σ => σ ∘ (finRotate N : Fin N → Fin N)^[p])
+        (fun σ => σ ∘ (finRotate N : Fin N → Fin N)^[p]) = mpo M N := by
+  ext σ τ
+  simp only [Matrix.submatrix_apply, mpo_apply]
+  exact mpoMatrixEntry_comp_finRotate_pow M p σ τ
+
 end MPOTensor
 
 /-! ## Trace normalization -/

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -181,6 +181,49 @@ theorem blockReducedState_trace {d L K : ℕ}
   simp only [Matrix.trace, Matrix.diag, Matrix.submatrix_apply]
   exact (blockSplitEquiv d L K).symm.sum_comp (fun p => ρ p p)
 
+/-- The inverse block split is concatenation of the two parts via `Fin.append`. -/
+theorem blockSplitEquiv_symm_apply {d L K : ℕ} (a : Fin L → Fin d) (b : Fin K → Fin d) :
+    (blockSplitEquiv d L K).symm (a, b) = Fin.append a b := by
+  funext i
+  simp only [blockSplitEquiv, Equiv.symm_trans_apply, Equiv.sumArrowEquivProdArrow,
+    Equiv.coe_fn_symm_mk, Equiv.arrowCongr_symm, Equiv.refl_symm, Equiv.arrowCongr_apply,
+    Equiv.coe_refl, Function.comp, id_eq]
+  refine Fin.addCases (fun j => ?_) (fun j => ?_) i
+  · simp [Equiv.symm_symm, finSumFinEquiv_symm_apply_castAdd]
+  · simp [Equiv.symm_symm, finSumFinEquiv_symm_apply_natAdd]
+
+/-- Concatenating the two parts of a block split recovers the original
+configuration. -/
+theorem append_blockSplitEquiv {d K₁ K₂ : ℕ} (k : Fin (K₁ + K₂) → Fin d) :
+    Fin.append (blockSplitEquiv d K₁ K₂ k).1 (blockSplitEquiv d K₁ K₂ k).2 = k := by
+  rw [← blockSplitEquiv_symm_apply, Prod.mk.eta, Equiv.symm_apply_apply]
+
+/-- **Composition of contiguous-block reductions.** Tracing out the last `K₁`
+spins of the reduced state on the first `L + K₁` of `L + K₁ + K₂` spins equals
+tracing out the last `K₁ + K₂` spins directly (after reassociating the index).
+This is the prefix-consistency step: reducing a prefix and then a shorter prefix
+agrees with reducing to the shorter prefix in one step. -/
+theorem blockReducedState_comp {d L K₁ K₂ : ℕ}
+    (X : Matrix (Fin (L + K₁ + K₂) → Fin d) (Fin (L + K₁ + K₂) → Fin d) ℂ) :
+    blockReducedState d L K₁ (blockReducedState d (L + K₁) K₂ X)
+      = blockReducedState d L (K₁ + K₂)
+          (X.submatrix
+            (Equiv.arrowCongr (finCongr (Nat.add_assoc L K₁ K₂)) (Equiv.refl (Fin d))).symm
+            (Equiv.arrowCongr (finCongr (Nat.add_assoc L K₁ K₂)) (Equiv.refl (Fin d))).symm) := by
+  rw [blockReducedState, blockReducedState, Matrix.partialTraceRight_submatrix_left,
+    Matrix.submatrix_submatrix, Matrix.partialTraceRight_partialTraceRight,
+    Matrix.partialTraceRight_submatrix_right (blockSplitEquiv d K₁ K₂),
+    blockReducedState, Matrix.submatrix_submatrix, Matrix.submatrix_submatrix]
+  ext p i
+  simp only [partialTraceRight_apply, Matrix.submatrix_apply]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  congr 1 <;>
+  · simp only [Function.comp, Prod.map, blockSplitEquiv_symm_apply, id_eq, Fin.append_assoc,
+      append_blockSplitEquiv]
+    funext x
+    simp only [Equiv.arrowCongr_symm, Equiv.refl_symm, Equiv.arrowCongr_apply, Equiv.coe_refl,
+      id_eq, finCongr_symm, finCongr_apply, Function.comp_apply]
+
 /-! ## Normalized MPO and block entropies -/
 
 namespace MPOTensor


### PR DESCRIPTION
## Summary

**Stacked on #2445.** Integrates the prefix-consistency composition for contiguous-block reduced states — the key mechanical lemma toward Proposition 4.5 (#2424), previously flagged as the assembly wall and now proven clean.

- **`blockSplitEquiv_symm_apply`** — the inverse block split is concatenation: `(blockSplitEquiv d L K).symm (a, b) = Fin.append a b`. This is the unblocker: once the split is recognized as `Fin.append`, the rest follows from `Fin.append` algebra.
- **`append_blockSplitEquiv`** — concatenating the two parts of a split recovers the original configuration.
- **`blockReducedState_comp`** — `blockReducedState d L K₁ (blockReducedState d (L+K₁) K₂ X) = blockReducedState d L (K₁+K₂) (X.submatrix …)`: tracing the last `K₁` spins of the first-`(L+K₁)` reduced state equals tracing the last `K₁+K₂` directly (after reassociating).

## Proof technique

`blockReducedState_comp` reduces, via the per-factor partial-trace submatrix lemmas (`partialTraceRight_submatrix_left/right` #2445, `partialTraceRight_partialTraceRight` #2435), to `Fin.append (Fin.append p (split k).1) (split k).2 = Fin.append p k ∘ Fin.cast`, which is exactly `Fin.append_assoc` + `append_blockSplitEquiv`. **No per-index `Fin` bookkeeping** is needed.

## Why

This is the prefix-consistency step of #2424 (the `traceC → blockEntropy(a+b)` connection). The same `blockSplitEquiv_symm_apply` + `Fin.append` machinery drives the remaining position-independence and `traceA/AC` correspondences.

## Verification

- `lake build TNLean.MPS.MPDO.AreaLaw` green; all three lemmas `sorry`/`axiom`-free.
- Additions only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Mathlib lemmas in MPDO AreaLaw only; no changes to runtime APIs, auth, or data paths.
> 
> **Overview**
> Extends **periodic MPDO translation invariance** from a single cyclic shift to **`p`-fold** simultaneous bra/ket shifts via `mpoMatrixEntry_comp_finRotate_pow` and `mpo_submatrix_finRotate_pow` (induction on `mpoMatrixEntry_comp_finRotate`).
> 
> For **contiguous-block reductions**, the PR identifies `blockSplitEquiv` with **`Fin.append`**: `blockSplitEquiv_symm_apply` and `append_blockSplitEquiv`, then proves **`blockReducedState_comp`**—tracing the last `K₁` spins after an intermediate reduction on `L+K₁` matches one-shot reduction over `K₁+K₂` after `Nat.add_assoc` reindexing. The proof chains existing partial-trace submatrix lemmas and closes with `Fin.append_assoc` rather than manual index cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1a12acff8d86ff79457b10b2fc456171da6d65d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->