### PR TITLE
feat(peps): region two-block wrapping for Normal PEPS edge gauges (#1373 Phase C partial)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -385,6 +385,7 @@ import TNLean.PEPS.RegionBlock.KernelDescent
 import TNLean.PEPS.RegionBlock.UnionClosure
 import TNLean.PEPS.NormalEdgeBlockingData
 import TNLean.PEPS.NormalBlocking
+import TNLean.PEPS.NormalEdgeGauge
 import TNLean.PEPS.SquareLatticeGraph
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalEdgeBlockingCoordinate

--- a/TNLean/PEPS/NormalEdgeGauge.lean
+++ b/TNLean/PEPS/NormalEdgeGauge.lean
@@ -1,7 +1,6 @@
 import TNLean.PEPS.NormalBlocking
 import TNLean.PEPS.RegionBlock.UnionClosure
 import TNLean.PEPS.TwoInjectiveComparison
-import TNLean.PEPS.FundamentalTheorem.OneVertexComparison
 
 /-!
 # Region-two-block wrapping for the normal PEPS Fundamental Theorem
@@ -19,7 +18,7 @@ and its complement are wrapped as abstract `TwoBlockTensor`s over the bonds
 incident to the vertex; here the red, blue, and complementary regions are wrapped
 as `TwoBlockTensor`s over the edges crossing each region's boundary, and their
 injectivity is read off the concrete region-injectivity predicate
-`regionInjectivityDataOf A` of Phases A--B.
+`regionInjectivityDataOf A`.
 
 For a vertex-injective PEPS with positive bond dimensions, the concrete predicate
 `regionInjectivityDataOf A` makes *every* finite region injective
@@ -32,8 +31,11 @@ The wrapped two-block tensors and their injectivity are the region-level input t
 the abstract two-injective comparison
 (`two_injective_tensor_insertion_comparison`,
 `one_vertex_complement_comparison`) that the injective Fundamental Theorem uses
-unchanged. The remaining step toward the per-edge gauge is recorded at the end of
-this file.
+unchanged. These wrappers use the full boundary of a single region. A later
+two-region comparison must either compare a region with its complement, or choose
+the shared interface as the common boundary and keep the other boundary legs as
+external indices. The remaining step toward the per-edge gauge is recorded at the
+end of this file.
 
 ## References
 
@@ -144,7 +146,13 @@ theorem isTwoBlockInjective_regionTwoBlock_of_isVertexInjective (A : Tensor G d)
 At each edge the normal blocking supplies a red region containing the left
 endpoint, a blue region containing the right endpoint, and the complementary
 region. Each is wrapped as a region two-block tensor and is two-block injective
-under the concrete region-injectivity predicate of a vertex-injective PEPS. -/
+under the concrete region-injectivity predicate of a vertex-injective PEPS.
+
+The three wrappers below keep every edge crossing the chosen region as a boundary
+leg. They therefore record the injectivity of the individual regions. They are
+not yet a single comparison datum over one common interface for the red, blue,
+and complementary regions; such a comparison must separate the shared interface
+from the remaining external boundary legs. -/
 
 namespace NormalPEPSBlockingHypotheses
 
@@ -153,7 +161,7 @@ tensor.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
-noncomputable def redTwoBlock [DecidableEq V] (A : Tensor G d)
+noncomputable def redTwoBlock (A : Tensor G d)
     (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
     TwoBlockTensor
       (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.red e) f})
@@ -166,7 +174,7 @@ tensor.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
-noncomputable def blueTwoBlock [DecidableEq V] (A : Tensor G d)
+noncomputable def blueTwoBlock (A : Tensor G d)
     (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
     TwoBlockTensor
       (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.blue e) f})
@@ -179,7 +187,7 @@ two-block tensor.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
-noncomputable def complementTwoBlock [DecidableEq V] (A : Tensor G d)
+noncomputable def complementTwoBlock (A : Tensor G d)
     (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
     TwoBlockTensor
       (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.complement e) f})
@@ -196,7 +204,7 @@ injectivity.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
-theorem isTwoBlockInjective_redTwoBlock [DecidableEq V] (A : Tensor G d)
+theorem isTwoBlockInjective_redTwoBlock (A : Tensor G d)
     (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
     IsTwoBlockInjective
       (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.red e) f})
@@ -208,7 +216,7 @@ theorem isTwoBlockInjective_redTwoBlock [DecidableEq V] (A : Tensor G d)
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
-theorem isTwoBlockInjective_blueTwoBlock [DecidableEq V] (A : Tensor G d)
+theorem isTwoBlockInjective_blueTwoBlock (A : Tensor G d)
     (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
     IsTwoBlockInjective
       (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.blue e) f})
@@ -220,7 +228,7 @@ theorem isTwoBlockInjective_blueTwoBlock [DecidableEq V] (A : Tensor G d)
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
-theorem isTwoBlockInjective_complementTwoBlock [DecidableEq V] (A : Tensor G d)
+theorem isTwoBlockInjective_complementTwoBlock (A : Tensor G d)
     (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
     IsTwoBlockInjective
       (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.complement e) f})

--- a/TNLean/PEPS/NormalEdgeGauge.lean
+++ b/TNLean/PEPS/NormalEdgeGauge.lean
@@ -1,0 +1,234 @@
+import TNLean.PEPS.NormalBlocking
+import TNLean.PEPS.RegionBlock.UnionClosure
+import TNLean.PEPS.TwoInjectiveComparison
+import TNLean.PEPS.FundamentalTheorem.OneVertexComparison
+
+/-!
+# Region-two-block wrapping for the normal PEPS Fundamental Theorem
+
+The normal PEPS proof of arXiv:1804.04964, Section 3 first blocks the lattice
+into injective regions and then runs the *same* three-site injective-chain
+argument used for injective PEPS. The one-edge datum of that blocking is a triple
+of regions: a red region holding the left endpoint, a blue region holding the
+right endpoint, and the complementary region; the three are pairwise disjoint,
+cover the lattice, and are each injective (`NormalEdgeBlockingData`).
+
+This file performs the region analogue of the vertex-two-block wrapping of
+`TNLean.PEPS.FundamentalTheorem.OneVertexComparison`. There the selected vertex
+and its complement are wrapped as abstract `TwoBlockTensor`s over the bonds
+incident to the vertex; here the red, blue, and complementary regions are wrapped
+as `TwoBlockTensor`s over the edges crossing each region's boundary, and their
+injectivity is read off the concrete region-injectivity predicate
+`regionInjectivityDataOf A` of Phases A--B.
+
+For a vertex-injective PEPS with positive bond dimensions, the concrete predicate
+`regionInjectivityDataOf A` makes *every* finite region injective
+(`regionBlockedTensorInjective_of_isVertexInjective`); under that instantiation
+the abstract region-injectivity facts of the normal blocking hypotheses become
+the concrete linear independence of the blocked-region tensor families, which is
+exactly two-block injectivity of the wrapped regions.
+
+The wrapped two-block tensors and their injectivity are the region-level input to
+the abstract two-injective comparison
+(`two_injective_tensor_insertion_comparison`,
+`one_vertex_complement_comparison`) that the injective Fundamental Theorem uses
+unchanged. The remaining step toward the per-edge gauge is recorded at the end of
+this file.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Theorem 3
+  and the theorem labelled `normal`, lines 1407--1583 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### A finite region as an abstract two-block tensor
+
+The blocked tensor of a region `R` carries open virtual legs on the edges
+crossing the boundary of `R` and physical legs on the vertices of `R`. As an
+abstract two-block tensor the crossing edges are the shared bonds, the external
+boundary is a one-point space, and the region's physical configuration is the
+physical leg. -/
+
+/-- A finite region `R`, viewed as an abstract two-block tensor over the edges
+crossing the boundary of `R`, with a one-point external boundary and the region
+physical configuration as physical leg.
+
+This is the region analogue of `vertexTwoBlock`: the role played there by the
+single vertex and the bonds incident to it is played here by the whole region `R`
+and the edges crossing its boundary.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`, where each blocked region is compared as
+an injective block. -/
+noncomputable def regionTwoBlock (A : Tensor G d) (R : Finset V) :
+    TwoBlockTensor (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+      (fun f => Fin (A.bondDim f.1)) PUnit
+      (RegionPhysicalConfig (V := V) (d := d) R) :=
+  fun _ bdry τ => regionBlockedWeight (G := G) A R bdry τ
+
+@[simp] theorem regionTwoBlock_apply (A : Tensor G d) (R : Finset V)
+    (u : PUnit) (bdry : RegionBoundaryConfig (G := G) A R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) R) :
+    regionTwoBlock (G := G) A R u bdry τ = regionBlockedWeight (G := G) A R bdry τ := rfl
+
+/-- The region two-block tensor is two-block injective exactly when the
+blocked-region tensor family of `R` is linearly independent.
+
+The auxiliary one-point external boundary is absorbed by `Equiv.punitProd`,
+turning the abstract joint-configuration linear independence of the two-block
+tensor into the boundary-configuration linear independence of the blocked-region
+tensor family, and conversely.
+
+Source: arXiv:1804.04964, Section 3, lines 205--250 of
+`Papers/1804.04964/paper_normal.tex`, where a contraction of injective tensors
+over a region is injective. -/
+theorem isTwoBlockInjective_regionTwoBlock_iff (A : Tensor G d) (R : Finset V) :
+    IsTwoBlockInjective (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+        (bondDim := fun f => Fin (A.bondDim f.1)) (regionTwoBlock (G := G) A R) ↔
+      RegionBlockedTensorInjective (G := G) A R := by
+  unfold IsTwoBlockInjective RegionBlockedTensorInjective
+  have hequiv :
+      (fun η : PUnit × RegionBoundaryConfig (G := G) A R =>
+          fun τ : RegionPhysicalConfig (V := V) (d := d) R =>
+            regionTwoBlock (G := G) A R η.1 η.2 τ) =
+        (regionBlockedTensorFamily (G := G) A R) ∘ (Equiv.punitProd _) := by
+    funext η τ; rfl
+  rw [hequiv]
+  constructor
+  · intro h
+    have := h.comp (Equiv.punitProd _).symm (Equiv.punitProd _).symm.injective
+    simpa [Function.comp] using this
+  · intro h
+    exact h.comp _ (Equiv.punitProd _).injective
+
+/-- The region two-block tensor is two-block injective whenever the blocked-region
+tensor family of `R` is linearly independent.
+
+Source: arXiv:1804.04964, Section 3, lines 205--250 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTwoBlockInjective_regionTwoBlock (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R) :
+    IsTwoBlockInjective (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+      (bondDim := fun f => Fin (A.bondDim f.1)) (regionTwoBlock (G := G) A R) :=
+  (isTwoBlockInjective_regionTwoBlock_iff (G := G) A R).mpr hR
+
+/-- For a vertex-injective PEPS with positive bond dimensions, the region
+two-block tensor of *every* finite region is two-block injective.
+
+This is the concrete instantiation of the abstract region-injectivity predicate
+`regionInjectivityDataOf A` at the wrapped two-block tensor: Phase A's
+kernel-descent result makes every region injective, which is exactly two-block
+injectivity of the region two-block tensor.
+
+Source: arXiv:1804.04964, Section 3, lines 205--250 and 1322--1404 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTwoBlockInjective_regionTwoBlock_of_isVertexInjective (A : Tensor G d)
+    (hA : IsVertexInjective A) (hpos : ∀ e : Edge G, 0 < A.bondDim e) (R : Finset V) :
+    IsTwoBlockInjective (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+      (bondDim := fun f => Fin (A.bondDim f.1)) (regionTwoBlock (G := G) A R) :=
+  isTwoBlockInjective_regionTwoBlock (G := G) A R
+    (regionBlockedTensorInjective_of_isVertexInjective (G := G) A R hA hpos)
+
+/-! ### The three edge-centred regions as two-block tensors
+
+At each edge the normal blocking supplies a red region containing the left
+endpoint, a blue region containing the right endpoint, and the complementary
+region. Each is wrapped as a region two-block tensor and is two-block injective
+under the concrete region-injectivity predicate of a vertex-injective PEPS. -/
+
+namespace NormalPEPSBlockingHypotheses
+
+/-- The red edge-block of the normal blocking, wrapped as a region two-block
+tensor.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def redTwoBlock [DecidableEq V] (A : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
+    TwoBlockTensor
+      (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.red e) f})
+      (fun f => Fin (A.bondDim f.1)) PUnit
+      (RegionPhysicalConfig (V := V) (d := d) (h.edgeBlocking.red e)) :=
+  regionTwoBlock (G := G) A (h.edgeBlocking.red e)
+
+/-- The blue edge-block of the normal blocking, wrapped as a region two-block
+tensor.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def blueTwoBlock [DecidableEq V] (A : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
+    TwoBlockTensor
+      (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.blue e) f})
+      (fun f => Fin (A.bondDim f.1)) PUnit
+      (RegionPhysicalConfig (V := V) (d := d) (h.edgeBlocking.blue e)) :=
+  regionTwoBlock (G := G) A (h.edgeBlocking.blue e)
+
+/-- The complementary edge-block of the normal blocking, wrapped as a region
+two-block tensor.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def complementTwoBlock [DecidableEq V] (A : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
+    TwoBlockTensor
+      (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.complement e) f})
+      (fun f => Fin (A.bondDim f.1)) PUnit
+      (RegionPhysicalConfig (V := V) (d := d) (h.edgeBlocking.complement e)) :=
+  regionTwoBlock (G := G) A (h.edgeBlocking.complement e)
+
+/-- The red region two-block tensor at each edge is two-block injective.
+
+This reads the abstract injectivity of the red region supplied by the normal
+blocking hypotheses (`injective_chain_at_edge`) as the concrete linear
+independence of the red region's blocked tensor family, and wraps it as two-block
+injectivity.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTwoBlockInjective_redTwoBlock [DecidableEq V] (A : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
+    IsTwoBlockInjective
+      (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.red e) f})
+      (bondDim := fun f => Fin (A.bondDim f.1)) (redTwoBlock (G := G) A h e) :=
+  isTwoBlockInjective_regionTwoBlock (G := G) A (h.edgeBlocking.red e)
+    (h.injective_chain_at_edge e).1
+
+/-- The blue region two-block tensor at each edge is two-block injective.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTwoBlockInjective_blueTwoBlock [DecidableEq V] (A : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
+    IsTwoBlockInjective
+      (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.blue e) f})
+      (bondDim := fun f => Fin (A.bondDim f.1)) (blueTwoBlock (G := G) A h e) :=
+  isTwoBlockInjective_regionTwoBlock (G := G) A (h.edgeBlocking.blue e)
+    (h.injective_chain_at_edge e).2.1
+
+/-- The complementary region two-block tensor at each edge is two-block injective.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTwoBlockInjective_complementTwoBlock [DecidableEq V] (A : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses (regionInjectivityDataOf (G := G) A) G) (e : Edge G) :
+    IsTwoBlockInjective
+      (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) (h.edgeBlocking.complement e) f})
+      (bondDim := fun f => Fin (A.bondDim f.1)) (complementTwoBlock (G := G) A h e) :=
+  isTwoBlockInjective_regionTwoBlock (G := G) A (h.edgeBlocking.complement e)
+    (h.injective_chain_at_edge e).2.2
+
+end NormalPEPSBlockingHypotheses
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -1112,7 +1112,8 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.singletonRegionInjectivityComparison_of_isVertexInjective}
     \leanok
     \uses{def:IsVertexInjective, def:peps_singletonRegionTensor,
-        def:peps_regionInjectivityDataOf}
+        def:peps_regionInjectivityDataOf,
+        thm:peps_regionBlockedTensorInjective_of_isVertexInjective}
     Let $A$ be vertex-injective with every bond dimension positive. Then the
     concrete region-injectivity predicate of $A$ satisfies the singleton
     comparison: injectivity of a singleton blocked tensor implies injectivity of
@@ -3131,11 +3132,42 @@ injective and normal PEPS, following Theorems~2 and~3 of
     injective.
 \end{definition}
 
+\begin{theorem}[Kernel descent for blocked regions]%
+    \label{thm:peps_regionBlockedTensorInjective_of_isVertexInjective}
+    \lean{TNLean.PEPS.regionBlockedTensorInjective_of_isVertexInjective}
+    \leanok
+    \uses{def:IsVertexInjective, def:peps_regionInjectivityDataOf}
+    Let $A$ be vertex-injective, and assume that every virtual bond dimension is
+    positive. Then every finite region $R$ has an injective blocked tensor:
+    \[
+        \operatorname{inj}(R).
+    \]
+    The positive-bond restriction is recorded in
+    \texttt{docs/paper-gaps/peps\_injective\_ft\_section3\_route.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    Let $(c_\rho)_\rho$ be a finitely supported coefficient family on the
+    boundary configurations of $R$, and assume
+    \[
+        \sum_{\rho} c_\rho\,T_{A,R}^{\rho}(\tau)=0
+        \qquad\text{for every physical configuration }\tau .
+    \]
+    The kernel descent removes the vertices of $R$ one at a time and preserves
+    the vanishing contraction. After all vertices have been removed, the
+    terminal contraction gives
+    \[
+        c_\rho=0\qquad\text{for every boundary configuration }\rho .
+    \]
+    Hence the family $\{T_{A,R}^{\rho}\}_\rho$ is linearly independent, which is
+    $\operatorname{inj}(R)$.
+\end{proof}
+
 \begin{theorem}[Union closure for a vertex-injective tensor]%
     \label{thm:peps_regionInjectivityUnionClosure_of_isVertexInjective}
     \lean{TNLean.PEPS.regionInjectivityUnionClosure_of_isVertexInjective}
     \leanok
-    \uses{def:IsVertexInjective, def:peps_regionInjectivityDataOf}
+    \uses{def:IsVertexInjective, def:peps_regionInjectivityDataOf,
+        thm:peps_regionBlockedTensorInjective_of_isVertexInjective}
     Let $A$ be vertex-injective with every bond dimension positive. Then the
     concrete region-injectivity predicate of $A$ satisfies union closure: for
     any two finite regions $R$ and $S$,
@@ -3148,9 +3180,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \texttt{docs/paper-gaps/peps\_injective\_ft\_section3\_route.tex}.
 \end{theorem}
 \begin{proof}\leanok
-    Under vertex injectivity and positive bond dimensions every finite region
-    is injective, by the kernel-descent argument for the blocked-region tensor.
-    In particular $R\cup S$ is injective, so the union-closure hypothesis holds
+    The kernel descent theorem gives
+    \[
+        \operatorname{inj}(Q)
+    \]
+    for every finite region $Q$. Taking $Q=R\cup S$ gives
+    $\operatorname{inj}(R\cup S)$, so the union-closure implication holds
     independently of the injectivity of $R$ and $S$.
 \end{proof}
 


### PR DESCRIPTION
Stacked on #2447. Wraps an arbitrary region as a `TwoBlockTensor` (`regionTwoBlock`) with two-block injectivity from Phase A, and the red/blue/complement edge-centred regions (`redTwoBlock`/`blueTwoBlock`/`complementTwoBlock`, injective via `injective_chain_at_edge`). All sorry-free, `#print axioms`-clean.

**Finding:** completing the edge-gauge family needs a **region-level insertion machinery** — a region analog of `edgeInsertedCoeff` + `sameTwoBlockInsertions_of_edgeInsertedCoeff_eq` + the post-absorption identity (the region rebuild of `InsertionAlgebra`/`OneVertexComparison`). The abstract `two_injective_tensor_insertion_comparison` (#1361) then suffices for the scalar/gauge extraction. This is the next core, not assembly. Refs #1373.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib-style definitions and proofs on the PEPS track; no auth, runtime, or data-path changes—main risk is proof maintenance and future API coupling to region insertion work.
> 
> **Overview**
> Adds **`TNLean/PEPS/NormalEdgeGauge.lean`** and wires it into the root import list. This is the region-level analogue of vertex `TwoBlockTensor` wrapping: **`regionTwoBlock`** encodes a finite region’s blocked weight on boundary-crossing edges, with **`isTwoBlockInjective_regionTwoBlock_iff`** linking abstract two-block injectivity to **`RegionBlockedTensorInjective`**, and a vertex-injective + positive-bond corollary via **`regionBlockedTensorInjective_of_isVertexInjective`**.
> 
> Under **`NormalPEPSBlockingHypotheses`**, each edge’s red, blue, and complement regions get **`redTwoBlock` / `blueTwoBlock` / `complementTwoBlock`** plus injectivity from **`injective_chain_at_edge`**. The module doc notes this is partial Phase C input for the normal PEPS FT—not yet a single shared-interface comparison for the three regions (region insertion machinery still ahead).
> 
> **Blueprint (`ch13a_peps_ft.tex`)** now states **`peps_regionBlockedTensorInjective_of_isVertexInjective`** explicitly and points singleton comparison and union-closure theorems at it instead of inline kernel-descent prose in proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94943bde3db3b1f4f8ba126c929de3f3fa0bcf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->