### PR TITLE
doc(parent): align left-word hypothesis list

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2467,8 +2467,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{lem:closure_property_boundary_one_sided_products_ground_space_map,
         lem:closure_property_auxiliary_product_from_opposite_boundary_left_words}
-    Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, and let
-    $L_0\le M$. Let
+    Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
+    $D\ge1$. Let
     \[
         \psi=\Gamma_{M+1}(X)
     \]


### PR DESCRIPTION
## Summary
- State the hypotheses of the left-word auxiliary product lemma in one list: \(L_0>0\), \(L_0\le M\), and \(D\ge1\).
- Keep the blueprint statement matched to the Lean theorem `MPSTensor.closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words`.

## Mathematical scope
This is a blueprint wording correction only. No Lean declaration, theorem statement, or proof term is changed.

Closes #2443.

## Checks
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- git diff --check
- leanblueprint web