### PR TITLE
doc(mpdo): add eval-word blueprint lemmas

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -56,6 +56,63 @@ together with the virtual left and right indices.
     lengths evaluate to $0$.
 \end{definition}
 
+\begin{lemma}[Word-evaluation factorization]\label{lem:mpo_eval_word_append}
+    \lean{MPOTensor.evalWord_append}
+    \leanok
+    \uses{def:mpo_eval_word}
+    For words $u_1,v_1$ of equal length and arbitrary words $u_2,v_2$,
+    word evaluation factors as
+    \[
+        M^{u_1u_2,\,v_1v_2}=M^{u_1,v_1}M^{u_2,v_2}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok\uses{def:mpo_eval_word}
+    We argue by induction on the common length of $u_1$ and $v_1$. For the empty prefix,
+    \[
+        M^{u_2,v_2}=\Id_D\,M^{u_2,v_2}.
+    \]
+    If $u_1=iu$ and $v_1=jv$, then
+    \[
+        M^{iuu_2,\,jvv_2}
+        = M^{ij}M^{uu_2,\,vv_2}
+        = M^{ij}M^{u,v}M^{u_2,v_2}
+        = M^{iu,jv}M^{u_2,v_2},
+    \]
+    using associativity of matrix multiplication.
+\end{proof}
+
+\begin{lemma}[Trace cyclicity of the closed MPO word]\label{lem:mpo_trace_evalWord_cyclic}
+    \lean{MPOTensor.trace_evalWord_cons_eq_append}
+    \leanok
+    \uses{def:mpo_eval_word}
+    Let $a,b\in\{0,\ldots,d{-}1\}$, and let $u,v$ be words of equal length.
+    Writing $au,bv$ for adding the letters at the beginning and $ua,vb$ for
+    adding them at the end,
+    \[
+        \tr\!\left(M^{au,\,bv}\right)
+        =
+        \tr\!\left(M^{ua,\,vb}\right).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok\uses{def:mpo_eval_word, lem:mpo_eval_word_append}
+    The factorization lemma gives
+    \[
+        M^{ua,\,vb}=M^{u,v}M^{ab},
+        \qquad
+        M^{au,\,bv}=M^{ab}M^{u,v}.
+    \]
+    Hence
+    \[
+        \tr\!\left(M^{ua,\,vb}\right)
+        =\tr\!\left(M^{u,v}M^{ab}\right)
+        =\tr\!\left(M^{ab}M^{u,v}\right)
+        =\tr\!\left(M^{au,\,bv}\right),
+    \]
+    by cyclicity of the trace.
+\end{proof}
+
 \begin{definition}[MPO operator family]\label{def:mpo_family}
     \lean{MPOTensor.mpo}
     \leanok


### PR DESCRIPTION
Closes #2431.

Summary:
- Add blueprint entries for the MPO word-evaluation factorization lemma `MPOTensor.evalWord_append`.
- Add the cyclic trace lemma `MPOTensor.trace_evalWord_cons_eq_append`, stated as the equality of closed MPO words under moving one physical pair from the beginning to the end.
- Give short equation-level proofs so the prose does not refer to Lean theorem names as mathematics.

Verification:
- `lake build TNLean.MPS.MPDO.Defs`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- `leanblueprint web`

Known unrelated local check failure:
- `leanblueprint checkdecls` still fails on pre-existing non-MPDO missing declarations in the parent-Hamiltonian chapter, beginning with `MPSTensor.leftTraceWordMap` and `MPSTensor.parentHamiltonian_gapped`; the two MPDO declarations added here are not among the missing names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX/blueprint additions with no runtime or API changes.
> 
> **Overview**
> Adds two blueprint lemmas in `ch02b_mpdo.tex` immediately after **word evaluation** (`def:mpo_eval_word`), with `\lean{...}` links to `MPOTensor.evalWord_append` and `MPOTensor.trace_evalWord_cons_eq_append`.
> 
> **Word-evaluation factorization** states \(M^{u_1u_2,v_1v_2} = M^{u_1,v_1} M^{u_2,v_2}\) for equal-length prefixes, with a short induction proof using matrix associativity.
> 
> **Trace cyclicity** states \(\tr(M^{au,bv}) = \tr(M^{ua,vb})\) when one physical pair is moved from the front to the back of the ket/bra words; the proof uses the factorization lemma and cyclicity of trace.
> 
> Both entries are marked `\leanok` and include brief equation-level proofs (no Lean names in the mathematical prose).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7716bfea67ff493fbef85080ccea2e19cb358e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->