### PR TITLE
doc(parent): clarify closure-property coordinate reconstruction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -925,9 +925,9 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
   Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
 \]
 
-**Open gap:** The source does not display this coordinate equation.  Its
-closing-boundary paragraph is represented here by the following coordinate
-identity.  After the one-sided equation
+**Open gap:** The source does not display this formula.  In the present
+formalization, its closing-boundary paragraph is reduced to the following
+coordinate identity.  After the one-sided equation
 \[
   Y_M(\tau^+_\eta(\mu)) A^j = A^\mu A^j X
 \]
@@ -938,7 +938,8 @@ form at the opposite boundary after multiplication by a length-\(L_0\) word,
   =
   A^\mu A^j X A^\sigma .
 \]
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+This reduction is documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -33,8 +33,8 @@ difference is zero.
 
 **Open gap:** This is only a stripping reduction. It does not prove the
 left-multiplied coordinate equation; that equation is the remaining coordinate
-form of the boundary-closing sentence in arXiv:2011.12127, Section IV.C,
-lines 2078--2079. The interpretive step is documented in
+reconstruction used here for the boundary-closing sentence in arXiv:2011.12127,
+Section IV.C, lines 2078--2079. The interpretive step is documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_mirror_padded_products_of_left_word_products
     {A : MPSTensor d D} {L₀ M : ℕ}
@@ -90,9 +90,9 @@ every length-\(L_0\) word product:
 Then the auxiliary boundary conditions \(\rho^+_{j,\sigma}\) and
 \(\rho^-_{j,\sigma}\) satisfying the required product equation exist.
 
-**Open gap:** This is a reduction toward the project's coordinate form of the
-closing-boundary sentence in arXiv:2011.12127, Section IV.C,
-lines 2078--2079. The coordinate form is not displayed in the source; it is
+**Open gap:** This is a reduction toward the coordinate reconstruction used here
+for the closing-boundary sentence in arXiv:2011.12127, Section IV.C,
+lines 2078--2079. The formula is not displayed in the source; it is
 documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
     {A : MPSTensor d D} {L₀ M : ℕ}
@@ -152,9 +152,9 @@ left-multiplied coordinate comparison
 
 **Open gap:** This theorem combines the preceding reductions in the
 closure-property argument. It does not prove the displayed left-multiplied
-comparison; that comparison is the current coordinate form of the
+comparison; that comparison is the coordinate reconstruction used here for the
 boundary-closing sentence in arXiv:2011.12127, Section IV.C, lines 2078--2079.
-The source does not display this coordinate equation. See
+The source does not display this formula. See
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2612,9 +2612,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         A^\mu A^jXA^\sigma .
     \]
-    This is the remaining coordinate identity for the closing-boundary paragraph
-    of \cite[lines~2078--2079]{Cirac2021Matrix}.
-    % Remaining gap recorded in docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
+    % The cited paragraph does not display this formula. It is the coordinate
+    % reconstruction isolated here for the closing-boundary step of
+    % \cite[lines~2078--2079]{Cirac2021Matrix}. Remaining gap recorded in
+    % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
 \begin{lemma}[Product equality after closing the boundary]


### PR DESCRIPTION
## Summary
- clarify that the remaining closure-property coordinate identities are formal reconstructions, not formulas displayed by arXiv:2011.12127
- remove wording that suggested a separate project terminology for the boundary-closing step
- add the same source-status clarification to the parent-Hamiltonian blueprint proof sketch

## Status
This leaves issue #2405 open. The remaining mathematical obligation is still the left-multiplied coordinate family, equivalently the right-multiplied opposite-boundary comparison recorded in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.

## Validation
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose only; no logic, APIs, or proof changes.
> 
> **Overview**
> This PR **only updates documentation** in the parent-Hamiltonian closure-property track. It does not change proofs or theorem statements.
> 
> Lean doc comments in `BoundaryClosing.lean` and `BoundaryClosingStripping.lean` now state explicitly that arXiv:2011.12127 **does not display** the remaining boundary-closing formulas. Wording shifts from implying a separate “project coordinate form” to describing a **coordinate reconstruction used in this formalization**, still pointing to `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` for the open mathematical gap (left-multiplied / padded opposite-boundary comparison).
> 
> The parent-Hamiltonian blueprint proof sketch gets the same clarification: the displayed identity is an **isolated reconstruction** for the closing-boundary step, not a formula quoted from the source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 792a72e9fe3d6e38a36bfbfbd5552a468a44b12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->