### PR TITLE
feat(parent): split cyclic boundary comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -193,7 +193,45 @@ theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_wo
   exact closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
     (A := A) hInj hL₀ hM YAt hYAt X μ hOneSided.1 hLeft
 
-/-- Left-multiplied opposite-boundary comparison for an open-chain
+/-- Left-multiplied comparison of the two cyclic restriction coordinates.
+
+For \(\psi=\Gamma_{M+1}(X)\), after fixing a boundary letter \(\eta\), a
+physical letter \(j\), and length-\(L_0\) words \(\alpha,\sigma\), the
+boundary-closing comparison is
+\[
+  A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
+  =
+  A^\alpha\bigl(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\bigr).
+\]
+
+**Open gap:** The source does not display this formula. It is the coordinate
+reconstruction used here for the sentence in arXiv:2011.12127, Section IV.C,
+lines 2078--2079, that the inverting-and-growing-back argument may also be
+applied when closing the boundary. See
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+theorem closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
+    ∀ (η j : Fin d) (σ α : Fin L₀ → Fin d),
+      evalWord A (List.ofFn α) *
+          (YAt ⟨M + 1 - L₀, by omega⟩
+              (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) =
+        evalWord A (List.ofFn α) *
+          (YAt ⟨M, by omega⟩
+              (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) := by
+  sorry
+
+/-- Left-multiplied boundary-closing comparison for an open-chain
 representation.
 
 For \(\psi=\Gamma_{M+1}(X)\), after fixing a boundary letter \(\eta\), a
@@ -205,11 +243,12 @@ remaining boundary-closing comparison is
   A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr).
 \]
 
-**Open gap:** The source does not display this formula. It is the coordinate
-reconstruction used here for the sentence in arXiv:2011.12127, Section IV.C,
-lines 2078--2079, that the inverting-and-growing-back argument may also be
-applied when closing the boundary. See
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Open gap:** This theorem now follows from the displayed comparison between
+the two cyclic restrictions and the one-sided last-boundary equation. The
+first comparison is the coordinate reconstruction used here for the sentence
+in arXiv:2011.12127, Section IV.C, lines 2078--2079, that the
+inverting-and-growing-back argument may also be applied when closing the
+boundary. See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -229,7 +268,26 @@ theorem closure_property_mirror_left_word_products_of_groundSpaceMap
         evalWord A (List.ofFn α) *
           (evalWord A (List.ofFn μ) * A j * X *
             evalWord A (List.ofFn σ)) := by
-  sorry
+  intro η j σ α
+  have hCompare :=
+    closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX YAt hYAt μ
+  have hOneSided :=
+    closure_property_boundary_one_sided_products_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX YAt hYAt μ
+  calc
+    evalWord A (List.ofFn α) *
+          (YAt ⟨M + 1 - L₀, by omega⟩
+              (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ))
+        = evalWord A (List.ofFn α) *
+          (YAt ⟨M, by omega⟩
+              (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) := hCompare η j σ α
+    _ = evalWord A (List.ofFn α) *
+          (evalWord A (List.ofFn μ) * A j * X *
+            evalWord A (List.ofFn σ)) := by
+          rw [hOneSided.1 η j]
 
 /-- Auxiliary boundary-condition product equation needed at the closing
 boundary.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2514,10 +2514,44 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
-\begin{lemma}[Left-multiplied opposite-boundary comparison]
+\begin{lemma}[Left-multiplied comparison of two cyclic restrictions]
+    \label{lem:closure_property_wrapped_mirror_left_word_products_ground_space}
+    \lean{MPSTensor.closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap}
+    \leanok
+    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
+    $D\ge1$. Let
+    \[
+        \psi=\Gamma_{M+1}(X)
+    \]
+    be an open-chain representation, and let $Y_i(\tau)$ represent the
+    length-$(L_0+1)$ cyclic restrictions of $\psi$. Fix a complementary word
+    $\mu$. Then for every boundary letter $\eta$, physical letter $j$, and
+    length-$L_0$ words $\alpha,\sigma$,
+    \[
+        A^\alpha
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
+        =
+        A^\alpha
+        \left(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \notready
+    % The cited paragraph does not display this formula. It is the coordinate
+    % reconstruction isolated here for the closing-boundary step of
+    % \cite[lines~2078--2079]{Cirac2021Matrix}. Remaining gap recorded in
+    % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
+\end{proof}
+
+\begin{lemma}[Left-multiplied boundary-closing comparison]
     \label{lem:closure_property_mirror_left_word_products_ground_space}
     \lean{MPSTensor.closure_property_mirror_left_word_products_of_groundSpaceMap}
-    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    \leanok
+    \uses{def:ground_space_map, rem:cyclic_window_operators,
+        lem:closure_property_wrapped_mirror_left_word_products_ground_space,
+        lem:closure_property_boundary_one_sided_products_ground_space_map}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
     $D\ge1$. Let
     \[
@@ -2537,10 +2571,22 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \end{lemma}
 
 \begin{proof}
-    \notready
-    % The cited paragraph does not display this formula. It is the coordinate
-    % reconstruction isolated here for the closing-boundary step of
-    % \cite[lines~2078--2079]{Cirac2021Matrix}. Remaining gap recorded in
+    The comparison of the two cyclic restrictions gives
+    \[
+        A^\alpha
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
+        =
+        A^\alpha
+        \left(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\right).
+    \]
+    The last-boundary one-sided equation gives
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX.
+    \]
+    Substitution gives the displayed identity.
+    % The cited paragraph does not display the first comparison. It is
+    % the coordinate reconstruction isolated here for the closing-boundary step
+    % of \cite[lines~2078--2079]{Cirac2021Matrix}. Remaining gap recorded in
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -230,19 +230,21 @@ The last-site boundary gives the one-sided equation
 \[
   Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
 \]
-After block-injective cancellation, the remaining opposite-boundary comparison
-is equivalent to proving, for every boundary letter \(\eta\), physical letter
-\(j\), and word \(\sigma\) of length \(L_0\),
+The present formalization has reduced the boundary-closing step to the
+following comparison of the two cyclic restrictions. For every boundary letter
+\(\eta\), physical letter \(j\), and words \(\alpha,\sigma\) of length \(L_0\),
 \[
-  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+  A^\alpha
+  \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
   =
-  A^\mu A^jX A^\sigma .
+  A^\alpha
+  \left(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\right).
 \]
-The source does not display this formula. In the present formalization, the
-remaining comparison in
-\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405} is this
-identity. The current reductions also express it by the left-multiplied family:
-for every pair of words \(\alpha,\sigma\) of length \(L_0\),
+The source does not display this formula. This is the current remaining
+comparison in
+\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}. After
+substituting the one-sided equation above, it gives the previously isolated
+left-multiplied family
 \[
   A^\alpha
   \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
@@ -250,8 +252,16 @@ for every pair of words \(\alpha,\sigma\) of length \(L_0\),
   A^\alpha
   \left(A^\mu A^jX A^\sigma\right).
 \]
-Since the products \(A^\alpha\) with \(|\alpha|=L_0\) span the full matrix
-algebra, this family implies the displayed opposite-boundary comparison.
+Equivalently, after block-injective cancellation this yields, for every word
+\(\sigma\) of length \(L_0\),
+\[
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+  =
+  A^\mu A^jX A^\sigma .
+\]
+Thus the older right-multiplied identity is no longer the residual formal
+statement; it follows from the comparison of the two cyclic restrictions and
+the last-site one-sided equation.
 
 \section{Conclusion}
 
@@ -262,8 +272,9 @@ argument is not refuted. The source compresses two mathematical steps which the
 formalization must keep separate: the $B$-region inverting and growing-back
 open-chain range reduction, and the comparison of the boundary matrices arising
 from the two boundary-crossing supports used in closing the boundary. The
-current open form of the latter comparison is the displayed right-multiplied
-identity, equivalently the displayed left-multiplied family.
+current open form of the latter comparison is the displayed left-multiplied
+comparison of the two cyclic restrictions. The right-multiplied identity with
+\(A^\mu A^jX\) is now a derived consequence once that comparison is available.
 
 The open-chain part has been proved under the intended block-injective
 hypotheses, though not by reusing the older single-site intersection theorem.


### PR DESCRIPTION
## Summary
- isolate the remaining boundary-closing calculation as the equation comparing the two cyclic restriction coordinates
- derive the previous left-multiplied boundary-closing comparison by substituting the one-sided last-boundary equation
- update the blueprint with the displayed equations and keep the unresolved comparison marked `\notready`

Related: #2405. This PR leaves that issue open; the new cyclic-restriction comparison is the remaining unproved statement.

## Validation
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake exe checkdecls` on the two touched declaration names
- `rg -n "sorry|axiom|native_decide|unsafeCast|admit" TNLean/MPS/ParentHamiltonian`

Notes: the focused build reports the intended `sorry` at the isolated cyclic-restriction comparison; the scan also reports the pre-existing martingale gap. `leanblueprint web` completed locally but the local plasTeX run emitted package-loading warnings and did not generate `blueprint/lean_decls`, so I checked the two declaration names directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the proof decomposition of a key parent-Hamiltonian closure lemma; the mathematical gap is unchanged but mis-stated dependencies could mislead reviewers until the new `sorry` is resolved.
> 
> **Overview**
> Refactors the **boundary-closing** left-word comparison so the only unproved step is an explicit **mirror vs wrapped cyclic-restriction** identity; the older comparison to `A^μ A^j X` is now **derived**.
> 
> A new `closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap` states that left-padded products at `Y_{M+1-L₀}(τ⁻)` match those at `Y_M(τ⁺)` and remains **`sorry`**. `closure_property_mirror_left_word_products_of_groundSpaceMap` is **proved** by chaining that lemma with the existing one-sided last-boundary equation.
> 
> The blueprint chapter and `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` are updated so the user-facing text: the open gap is the two-restriction comparison; the right-multiplied / `A^μ A^j X` form is documented as a consequence once that comparison holds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524bc0b42eeeefca81b23ee447cd039aceda7a2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->