### PR TITLE
feat(parent): move boundary gap to restriction equality

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -600,7 +600,10 @@ physical letter \(j\), their first-letter restrictions give
   Y_M(\tau^+_\eta(\mu))A^j
   =
   Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
-\] -/
+\]
+
+This boundary equality is isolated in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_boundary_first_products_of_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -589,6 +589,75 @@ lemma closure_property_boundary_condition_long_product_of_window_witnesses
       rw [hsum, Nat.add_mod_left]
     rw [hsite]
 
+/-- Equal closed-boundary restrictions determine the first-letter boundary
+products.
+
+Suppose the two length-\((L_0+1)\) restrictions at the closed boundary are
+represented by \(Y_M(\tau^+_\eta(\mu))\) and
+\(Y_{M+1-L_0}(\tau^-_\eta(\mu))\). If the restrictions agree, then their
+first-letter restrictions give
+\[
+  Y_M(\tau^+_\eta(\mu))A^j
+  =
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j
+\]
+for every physical letter \(j\). -/
+lemma closure_property_boundary_first_products_of_restrictions
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (η : Fin d) (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (YPlus YMinus : Matrix (Fin D) (Fin D) ℂ)
+    (hPlus :
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+        groundSpaceMap A (L₀ + 1) YPlus)
+    (hMinus :
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) η μ) ψ =
+        groundSpaceMap A (L₀ + 1) YMinus)
+    (hRestrict :
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+        cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) η μ) ψ) :
+    ∀ j : Fin d, YPlus * A j = YMinus * A j := by
+  intro j
+  apply groundSpaceMap_injective_of_isNBlkInjective hInj
+  have hvec :
+      restrictFirst
+          (cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+            (⟨M, by omega⟩ : Fin (M + 1))
+            (wrappedMiddleBackground L₀ (M + 1) η μ) ψ) j =
+        restrictFirst
+          (cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+            (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+            (mirrorMiddleBackground L₀ (M + 1) η μ) ψ) j := by
+    rw [hRestrict]
+  have hleft :=
+    cyclicRestrictₗ_restrictFirst_groundSpaceMap
+      (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M, by omega⟩ : Fin (M + 1))
+      (wrappedMiddleBackground L₀ (M + 1) η μ) ψ hPlus j
+  have hright :=
+    cyclicRestrictₗ_restrictFirst_groundSpaceMap
+      (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+      (mirrorMiddleBackground L₀ (M + 1) η μ) ψ hMinus j
+  rw [cyclicRestrictₗ_restrictFirst
+      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M, by omega⟩ : Fin (M + 1))
+      (wrappedMiddleBackground L₀ (M + 1) η μ) ψ j,
+    cyclicRestrictₗ_restrictFirst
+      (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
+      (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+      (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j] at hvec
+  exact hleft.symm.trans (hvec.trans hright)
+
 /-- Right-products determine the two restrictions at the closed boundary.
 
 Suppose the two length-\((L_0+1)\) restrictions at the closed boundary are
@@ -715,43 +784,13 @@ lemma closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
     have h := congr_fun (mirrorMiddleBackground_complement L₀ (M + 1) j μ) k
     simpa [ρMinus] using h
   · intro j σ
-    have hfirst :
-        YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) j μ) * A j =
-          YAt ⟨M + 1 - L₀, by omega⟩
-              (mirrorMiddleBackground L₀ (M + 1) j μ) * A j := by
-      apply groundSpaceMap_injective_of_isNBlkInjective hInj
-      have hvec :
-          restrictFirst
-              (cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
-                (⟨M, by omega⟩ : Fin (M + 1))
-                (wrappedMiddleBackground L₀ (M + 1) j μ) ψ) j =
-            restrictFirst
-              (cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
-                (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
-                (mirrorMiddleBackground L₀ (M + 1) j μ) ψ) j := by
-        rw [hRestrict j]
-      have hleft :=
-        cyclicRestrictₗ_restrictFirst_groundSpaceMap
-          (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
-          (⟨M, by omega⟩ : Fin (M + 1))
-          (wrappedMiddleBackground L₀ (M + 1) j μ) ψ
-          (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) j μ)) j
-      have hright :=
-        cyclicRestrictₗ_restrictFirst_groundSpaceMap
-          (A := A) (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
-          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
-          (mirrorMiddleBackground L₀ (M + 1) j μ) ψ
-          (hYAt ⟨M + 1 - L₀, by omega⟩
-            (mirrorMiddleBackground L₀ (M + 1) j μ)) j
-      rw [cyclicRestrictₗ_restrictFirst
-          (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
-          (⟨M, by omega⟩ : Fin (M + 1))
-          (wrappedMiddleBackground L₀ (M + 1) j μ) ψ j,
-        cyclicRestrictₗ_restrictFirst
-          (show 0 < M + 1 by omega) (show L₀ + 1 ≤ M + 1 by omega)
-          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
-          (mirrorMiddleBackground L₀ (M + 1) j μ) ψ j] at hvec
-      exact hleft.symm.trans (hvec.trans hright)
+    have hfirst := closure_property_boundary_first_products_of_restrictions
+      (A := A) hInj hL₀ hM j μ
+      (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) j μ))
+      (YAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) j μ))
+      (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) j μ))
+      (hYAt ⟨M + 1 - L₀, by omega⟩
+        (mirrorMiddleBackground L₀ (M + 1) j μ)) (hRestrict j) j
     simpa [ρPlus, ρMinus] using
       congrArg (fun Y => Y * evalWord A (List.ofFn σ)) hfirst
 

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -594,14 +594,13 @@ products.
 
 Suppose the two length-\((L_0+1)\) restrictions at the closed boundary are
 represented by \(Y_M(\tau^+_\eta(\mu))\) and
-\(Y_{M+1-L_0}(\tau^-_\eta(\mu))\). If the restrictions agree, then their
-first-letter restrictions give
+\(Y_{M+1-L_0}(\tau^-_\eta(\mu))\). If the restrictions agree, then for every
+physical letter \(j\), their first-letter restrictions give
 \[
   Y_M(\tau^+_\eta(\mu))A^j
   =
-  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j
-\]
-for every physical letter \(j\). -/
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
+\] -/
 lemma closure_property_boundary_first_products_of_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -195,11 +195,12 @@ theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_wo
 
 /-- Equality of the two cyclic restrictions used when closing the boundary.
 
-Let \(\psi=\Gamma_{M+1}(X)\). For every boundary letter \(\eta\), the two
-boundary conditions \(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\) are local
-notation for the cyclic support crossing the last site and the opposite
-boundary-crossing support, with the same complementary word \(\mu\). The
-boundary-closing step is the equality
+Let \(\psi=\Gamma_{M+1}(X)\), and suppose each length-\((L_0+1)\) cyclic
+restriction of \(\psi\) lies in \(G_{L_0+1}(A)\). For every boundary letter
+\(\eta\), the two boundary conditions \(\tau^+_\eta(\mu)\) and
+\(\tau^-_\eta(\mu)\) are local notation for the cyclic support crossing the
+last site and the opposite boundary-crossing support, with the same
+complementary word \(\mu\). The boundary-closing step is the equality
 \[
   \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
   =
@@ -215,6 +216,9 @@ theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
     (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (hLocal : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ ∈
+        groundSpace A (L₀ + 1))
     (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
     ∀ η : Fin d,
       cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
@@ -314,9 +318,16 @@ theorem closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap
           (YAt ⟨M, by omega⟩
               (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
             evalWord A (List.ofFn σ)) := by
+  have hLocal : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ ∈
+        groundSpace A (L₀ + 1) := by
+    intro i τ
+    rw [hYAt i τ]
+    rw [groundSpace, LinearMap.mem_range]
+    exact ⟨YAt i τ, rfl⟩
   have hRestrict :=
     closure_property_boundary_restrictions_eq_of_groundSpaceMap
-      (A := A) hInj hL₀ hM hψX μ
+      (A := A) hInj hL₀ hM hψX hLocal μ
   exact closure_property_wrapped_mirror_left_word_products_of_boundary_restrictions
     (A := A) hInj hL₀ hM YAt hYAt μ hRestrict
 

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -239,7 +239,10 @@ If the two cyclic restrictions agree, then their first-letter restrictions give
   Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j.
 \]
 Multiplying this equality on the left by \(A^\alpha\) and on the right by
-\(A^\sigma\) gives the displayed coordinate comparison. -/
+\(A^\sigma\) gives the displayed coordinate comparison.
+
+This left-multiplied comparison is recorded in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_wrapped_mirror_left_word_products_of_boundary_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -283,11 +283,17 @@ boundary-closing comparison is
   A^\alpha\bigl(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\bigr).
 \]
 
-**Open gap:** The source does not display this formula. It is the coordinate
-reconstruction used here for the sentence in arXiv:2011.12127, Section IV.C,
-lines 2078--2079, that the inverting-and-growing-back argument may also be
-applied when closing the boundary. See
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Gap dependency:** This comparison is derived from the boundary-closing
+restriction equality
+\[
+  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+  =
+  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+\]
+The displayed restriction equality is the remaining local form of the sentence
+in arXiv:2011.12127, Section IV.C, lines 2078--2079, that the
+inverting-and-growing-back argument may also be applied when closing the
+boundary. See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -193,6 +193,85 @@ theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_wo
   exact closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
     (A := A) hInj hL₀ hM YAt hYAt X μ hOneSided.1 hLeft
 
+/-- Equality of the two cyclic restrictions used when closing the boundary.
+
+Let \(\psi=\Gamma_{M+1}(X)\). For every boundary letter \(\eta\), the two
+boundary conditions \(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\) are local
+notation for the cyclic support crossing the last site and the opposite
+boundary-crossing support, with the same complementary word \(\mu\). The
+boundary-closing step is the equality
+\[
+  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+  =
+  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+\]
+
+**Open gap:** arXiv:2011.12127, Section IV.C, lines 2078--2079 states that
+the inverting-and-growing-back argument may also be applied when closing the
+boundary. The displayed equality is the local coordinate form recorded here.
+See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
+    ∀ η : Fin d,
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+        cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+  sorry
+
+/-- Left-multiplied comparison of the two cyclic restriction coordinates from
+equality of the two boundary-closing restrictions.
+
+If the two cyclic restrictions agree, then their first-letter restrictions give
+\[
+  Y_M(\tau^+_\eta(\mu))A^j
+  =
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j.
+\]
+Multiplying this equality on the left by \(A^\alpha\) and on the right by
+\(A^\sigma\) gives the displayed coordinate comparison. -/
+lemma closure_property_wrapped_mirror_left_word_products_of_boundary_restrictions
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hRestrict : ∀ η : Fin d,
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+        cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) η μ) ψ) :
+    ∀ (η j : Fin d) (σ α : Fin L₀ → Fin d),
+      evalWord A (List.ofFn α) *
+          (YAt ⟨M + 1 - L₀, by omega⟩
+              (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) =
+        evalWord A (List.ofFn α) *
+          (YAt ⟨M, by omega⟩
+              (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) := by
+  intro η j σ α
+  have hFirst := closure_property_boundary_first_products_of_restrictions
+    (A := A) hInj hL₀ hM η μ
+    (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+    (YAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) η μ))
+    (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+    (hYAt ⟨M + 1 - L₀, by omega⟩
+      (mirrorMiddleBackground L₀ (M + 1) η μ)) (hRestrict η) j
+  rw [← hFirst]
+
 /-- Left-multiplied comparison of the two cyclic restriction coordinates.
 
 For \(\psi=\Gamma_{M+1}(X)\), after fixing a boundary letter \(\eta\), a
@@ -229,7 +308,11 @@ theorem closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap
           (YAt ⟨M, by omega⟩
               (wrappedMiddleBackground L₀ (M + 1) η μ) * A j *
             evalWord A (List.ofFn σ)) := by
-  sorry
+  have hRestrict :=
+    closure_property_boundary_restrictions_eq_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX μ
+  exact closure_property_wrapped_mirror_left_word_products_of_boundary_restrictions
+    (A := A) hInj hL₀ hM YAt hYAt μ hRestrict
 
 /-- Left-multiplied boundary-closing comparison for an open-chain
 representation.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2544,12 +2544,85 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
+\begin{lemma}[First-letter products from equal boundary restrictions]
+    \label{lem:closure_property_boundary_first_products_restrictions}
+    \lean{MPSTensor.closure_property_boundary_first_products_of_restrictions}
+    \leanok
+    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $L_0\le M$. Let
+    $\psi$ be a vector on $M+1$ sites, and suppose the two length-$(L_0+1)$
+    boundary restrictions are represented by
+    \[
+        \Gamma_{L_0+1}(Y_M(\tau^+_\eta(\mu))),
+        \qquad
+        \Gamma_{L_0+1}(Y_{M+1-L_0}(\tau^-_\eta(\mu))).
+    \]
+    If these two restrictions are equal, then for every physical letter $j$,
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Restricting both sides to the first physical letter $j$ gives
+    \[
+        \Gamma_{L_0}\!\left(Y_M(\tau^+_\eta(\mu))A^j\right)
+        =
+        \Gamma_{L_0}\!\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\right).
+    \]
+    Since $A$ is $L_0$-block-injective, $\Gamma_{L_0}$ is injective, and the
+    displayed product equality follows.
+\end{proof}
+
+\begin{lemma}[Left-multiplied comparison from equal boundary restrictions]
+    \label{lem:closure_property_wrapped_mirror_left_word_products_boundary_restrictions}
+    \lean{MPSTensor.closure_property_wrapped_mirror_left_word_products_of_boundary_restrictions}
+    \leanok
+    \uses{def:ground_space_map, rem:cyclic_window_operators,
+        lem:closure_property_boundary_restrictions_ground_space_map,
+        lem:closure_property_boundary_first_products_restrictions}
+    Let $A$ be $L_0$-block-injective with $L_0>0$ and $L_0\le M$. Let
+    $\psi$ be a vector on $M+1$ sites, and let $Y_i(\tau)$ represent the
+    length-$(L_0+1)$ cyclic restrictions of $\psi$. Assume that for every
+    boundary letter $\eta$,
+    \[
+        \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+        =
+        \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+    \]
+    Then for every boundary letter $\eta$, physical letter $j$, and
+    length-$L_0$ words $\alpha,\sigma$,
+    \[
+        A^\alpha
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
+        =
+        A^\alpha
+        \left(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The preceding lemma gives
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
+    \]
+    Multiplying on the left by $A^\alpha$ and on the right by $A^\sigma$
+    gives the desired comparison.
+\end{proof}
+
 \begin{lemma}[Left-multiplied comparison of boundary matrices]
     \label{lem:closure_property_wrapped_mirror_left_word_products_ground_space}
     \lean{MPSTensor.closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap}
     \leanok
     \uses{def:ground_space_map, rem:cyclic_window_operators,
-        lem:closure_property_boundary_restrictions_ground_space_map}
+        lem:closure_property_boundary_restrictions_ground_space_map,
+        lem:closure_property_wrapped_mirror_left_word_products_boundary_restrictions}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
     $D\ge1$. Let
     \[
@@ -2569,15 +2642,21 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \end{lemma}
 
 \begin{proof}
-    Equality of the two boundary-closing cyclic restrictions implies equality
-    of their first-letter restrictions. In the chosen boundary matrices this is
+    The preceding boundary-restriction equality gives
     \[
-        Y_M(\tau^+_\eta(\mu))A^j
+        \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =
-        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
+        \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
     \]
-    Multiplying on the left by $A^\alpha$ and on the right by $A^\sigma$
-    gives the displayed identity.
+    Applying the left-multiplied comparison for equal boundary restrictions
+    gives
+    \[
+        A^\alpha
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
+        =
+        A^\alpha
+        \left(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\right).
+    \]
 \end{proof}
 
 \begin{lemma}[Left-multiplied boundary-closing comparison]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2642,6 +2642,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \end{lemma}
 
 \begin{proof}
+    \notready
     The preceding boundary-restriction equality gives
     \[
         \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2514,11 +2514,42 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
-\begin{lemma}[Left-multiplied comparison of two cyclic restrictions]
+\begin{lemma}[Equality of the boundary-closing cyclic restrictions]
+    \label{lem:closure_property_boundary_restrictions_ground_space_map}
+    \lean{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}
+    \leanok
+    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
+    $D\ge1$. Let
+    \[
+        \psi=\Gamma_{M+1}(X)
+    \]
+    be an open-chain representation. Fix a complementary word $\mu$. For
+    every boundary letter $\eta$, the two local boundary conditions
+    $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ have the same complementary word.
+    The boundary-closing step is the equality
+    \[
+        \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+        =
+        \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \notready
+    % The cited paragraph does not display this equality. It is the local
+    % coordinate form of the sentence in \cite[lines~2078--2079]{Cirac2021Matrix}
+    % that the same inverting-and-growing-back argument applies when closing
+    % the boundaries. Remaining gap recorded in
+    % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
+\end{proof}
+
+\begin{lemma}[Left-multiplied comparison of boundary matrices]
     \label{lem:closure_property_wrapped_mirror_left_word_products_ground_space}
     \lean{MPSTensor.closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap}
     \leanok
-    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    \uses{def:ground_space_map, rem:cyclic_window_operators,
+        lem:closure_property_boundary_restrictions_ground_space_map}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
     $D\ge1$. Let
     \[
@@ -2538,11 +2569,15 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \end{lemma}
 
 \begin{proof}
-    \notready
-    % The cited paragraph does not display this formula. It is the coordinate
-    % reconstruction isolated here for the closing-boundary step of
-    % \cite[lines~2078--2079]{Cirac2021Matrix}. Remaining gap recorded in
-    % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
+    Equality of the two boundary-closing cyclic restrictions implies equality
+    of their first-letter restrictions. In the chosen boundary matrices this is
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
+    \]
+    Multiplying on the left by $A^\alpha$ and on the right by $A^\sigma$
+    gives the displayed identity.
 \end{proof}
 
 \begin{lemma}[Left-multiplied boundary-closing comparison]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2524,11 +2524,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \[
         \psi=\Gamma_{M+1}(X)
     \]
-    be an open-chain representation, and assume every length-$(L_0+1)$ cyclic
-    restriction of $\psi$ belongs to the corresponding local ground space:
+    be an open-chain representation. Assume that for all $i$ and $\tau$,
     \[
-        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A)
-        \qquad\text{for all }i,\tau .
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A).
     \]
     Fix a complementary word $\mu$. For every boundary letter $\eta$, the two
     local boundary conditions $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ have
@@ -2587,7 +2585,6 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.closure_property_wrapped_mirror_left_word_products_of_boundary_restrictions}
     \leanok
     \uses{def:ground_space_map, rem:cyclic_window_operators,
-        lem:closure_property_boundary_restrictions_ground_space_map,
         lem:closure_property_boundary_first_products_restrictions}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $L_0\le M$. Let
     $\psi$ be a vector on $M+1$ sites, and let $Y_i(\tau)$ represent the

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2524,10 +2524,15 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \[
         \psi=\Gamma_{M+1}(X)
     \]
-    be an open-chain representation. Fix a complementary word $\mu$. For
-    every boundary letter $\eta$, the two local boundary conditions
-    $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ have the same complementary word.
-    The boundary-closing step is the equality
+    be an open-chain representation, and assume every length-$(L_0+1)$ cyclic
+    restriction of $\psi$ belongs to the corresponding local ground space:
+    \[
+        \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A)
+        \qquad\text{for all }i,\tau .
+    \]
+    Fix a complementary word $\mu$. For every boundary letter $\eta$, the two
+    local boundary conditions $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ have
+    the same complementary word. The boundary-closing step is the equality
     \[
         \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =
@@ -2643,6 +2648,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
+    The representations by the matrices $Y_i(\tau)$ supply the local
+    ground-space hypothesis for the preceding lemma.
     The preceding boundary-restriction equality gives
     \[
         \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -230,9 +230,24 @@ The last-site boundary gives the one-sided equation
 \[
   Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
 \]
-The present formalization has reduced the boundary-closing step to the
-following comparison of the two cyclic restrictions. For every boundary letter
-\(\eta\), physical letter \(j\), and words \(\alpha,\sigma\) of length \(L_0\),
+The present formalization has reduced the boundary-closing step to equality of
+the two cyclic restrictions:
+\[
+  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+  =
+  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+\]
+The source does not display this equality. It is the current remaining
+comparison in
+\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}. Taking
+first-letter restrictions gives, for every physical letter \(j\),
+\[
+  Y_M(\tau^+_\eta(\mu))A^j
+  =
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
+\]
+Multiplying on the left by \(A^\alpha\) and on the right by \(A^\sigma\)
+then gives, for words \(\alpha,\sigma\) of length \(L_0\),
 \[
   A^\alpha
   \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
@@ -240,11 +255,8 @@ following comparison of the two cyclic restrictions. For every boundary letter
   A^\alpha
   \left(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\right).
 \]
-The source does not display this formula. This is the current remaining
-comparison in
-\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}. After
-substituting the one-sided equation above, it gives the previously isolated
-left-multiplied family
+After substituting the one-sided equation above, this gives the previously
+isolated left-multiplied family
 \[
   A^\alpha
   \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
@@ -272,9 +284,10 @@ argument is not refuted. The source compresses two mathematical steps which the
 formalization must keep separate: the $B$-region inverting and growing-back
 open-chain range reduction, and the comparison of the boundary matrices arising
 from the two boundary-crossing supports used in closing the boundary. The
-current open form of the latter comparison is the displayed left-multiplied
-comparison of the two cyclic restrictions. The right-multiplied identity with
-\(A^\mu A^jX\) is now a derived consequence once that comparison is available.
+current open form of the latter comparison is the displayed equality of the two
+boundary-closing cyclic restrictions. The left-multiplied matrix comparison and
+the right-multiplied identity with \(A^\mu A^jX\) are derived consequences once
+that equality is available.
 
 The open-chain part has been proved under the intended block-injective
 hypotheses, though not by reusing the older single-site intersection theorem.

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -230,7 +230,12 @@ The last-site boundary gives the one-sided equation
 \[
   Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
 \]
-The present formalization has reduced the boundary-closing step to equality of
+Under the cyclic local ground-space conditions
+\[
+  \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A)
+  \qquad\text{for all }i,\tau ,
+\]
+the present formalization has reduced the boundary-closing step to equality of
 the two cyclic restrictions:
 \[
   \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -230,12 +230,11 @@ The last-site boundary gives the one-sided equation
 \[
   Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
 \]
-Under the cyclic local ground-space conditions
+Assume the cyclic local ground-space conditions: for all \(i\) and \(\tau\),
 \[
-  \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A)
-  \qquad\text{for all }i,\tau ,
+  \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A),
 \]
-the present formalization has reduced the boundary-closing step to equality of
+the present formalization reduces the boundary-closing step to equality of
 the two cyclic restrictions:
 \[
   \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -230,12 +230,12 @@ The last-site boundary gives the one-sided equation
 \[
   Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
 \]
-Assume the cyclic local ground-space conditions: for all \(i\) and \(\tau\),
+The cyclic local ground-space conditions are that for all \(i\) and \(\tau\),
 \[
   \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A),
 \]
-the present formalization reduces the boundary-closing step to equality of
-the two cyclic restrictions:
+and the boundary-closing step is reduced to equality of the two cyclic
+restrictions:
 \[
   \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
   =


### PR DESCRIPTION
## Summary

This moves the current residual for issue #2405 from a left-multiplied matrix-coordinate comparison to the equality of the two boundary-closing cyclic restrictions, in the closure-property context. Thus one assumes

\[
  \psi=\Gamma_{M+1}(X),
  \qquad
  \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A)
  \quad\text{for all } i,\tau,
\]

and the remaining boundary assertion is

\[
  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
  =
  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
\]

From this equality, the first-letter restrictions give

\[
  Y_M(\tau^+_\eta(\mu))A^j
  =
  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j,
\]

and multiplying by \(A^\alpha\) and \(A^\sigma\) gives the previous left-multiplied comparison. The one-sided boundary equation then gives the right-multiplied identity involving \(A^\mu A^jX\).

The blueprint and paper-gap note now present the remaining assertion in these terms. The notation \(\tau^\pm\) and \(Y_i(\tau)\) remains local coordinate notation; the source statement is the CPSV21 sentence that the same inverting-and-growing-back argument applies when closing the boundaries.

Related issue: #2405. This PR keeps the issue in progress; the residual assertion is the displayed equality of cyclic restrictions under the cyclic local ground-space conditions.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `lake build TNLean`
- `lake exe checkdecls` on the changed declaration names
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `leanblueprint web`
- `rg -n "sorry|axiom|native_decide|unsafeCast|admit" TNLean/MPS/ParentHamiltonian`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure and documentation refactor in formalized MPS parent-Hamiltonian material; the mathematical gap remains explicit as `sorry` with no runtime or security impact.
> 
> **Overview**
> **Restructures issue #2405** so the remaining open step is **equality of the two boundary-closing cyclic restrictions** (wrapped vs mirror supports), not the left-multiplied matrix comparison.
> 
> Adds proved lemmas that derive first-letter products and the left-multiplied word comparison from that restriction equality, and refactors `closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap` to use this chain instead of `sorry`. The new central theorem `closure_property_boundary_restrictions_eq_of_groundSpaceMap` is still **`sorry`**. Duplicate first-product reasoning in `BoundaryClosing.lean` is factored into `closure_property_boundary_first_products_of_restrictions`.
> 
> The blueprint (`ch14_parent_hamiltonian.tex`) and `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` are updated to state the residual gap in restriction-equality terms, with downstream comparisons marked as derived.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ccdde4b7cd1770b72c7ab3b40c1b56015b77f79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->