### PR TITLE
doc(parent): sync boundary gap prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -706,8 +706,9 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
   =
   Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma .
 \]
-**Open gap:** This follows from the auxiliary product equation in
-`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`; see
+**Open gap:** This follows from the boundary-closing reductions. The only
+unproved input in this chain is now the equality of the two boundary-closing
+cyclic restrictions; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -736,8 +737,8 @@ theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
 /-- Matrix equality obtained from the product equality and block injectivity:
 \(Y_M(\tau^+_\eta(\mu))A^j
 =Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\).
-**Open gap:** Inherits the unproved product equality above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Open gap:** Inherits the boundary-closing restriction equality through the
+product equality above; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -774,7 +775,8 @@ theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
 
 /-- First-letter restriction equality \(R_jB^+_{\eta,\mu}=R_jB^-_{\eta,\mu}\),
 obtained by restricting the displayed matrix equation at the first physical
-index.  **Open gap:** Inherits the unproved product equality above; see
+index.  **Open gap:** Inherits the boundary-closing restriction equality
+through the one-site product equality above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -810,8 +812,9 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
   exact hLeft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) hProd).trans hRight.symm)
 
 /-- Restriction equality \(B^+_{\eta,\mu}=B^-_{\eta,\mu}\) at the closed
-boundary, obtained from the first-letter family.  **Open gap:** Inherits the
-unproved product equality above; see
+boundary, obtained from the first-letter family.  **Open gap:** This is the
+chain-ground-space form of the boundary-closing restriction equality now
+isolated as a ground-space-map comparison; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -843,7 +846,8 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
 with every \(A^j\) agree:
 \(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j
 \Rightarrow Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
-**Open gap:** Inherits the unproved product equality at the closed boundary; see
+**Open gap:** Inherits the boundary-closing restriction equality through the
+one-site product comparison above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}


### PR DESCRIPTION
## Summary
- update downstream parent-Hamiltonian docstrings to name the current boundary-closing cyclic-restriction equality as the live input
- remove stale wording that described the inherited gap as an unproved product equality

Refs #2405.

## Validation
- lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only updates to Lean docstrings; no logic or proof changes.
> 
> **Overview**
> **Open gap** docstrings on several `closure_property_*` and `wrapped_mirror_witness_agree_of_chainGroundSpace` theorems in `UniqueGroundState.lean` are aligned with the current gap narrative in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
> 
> Stale wording that treated an **unproved product equality** (or auxiliary boundary product) as the live gap is removed. The docs now state that the remaining unproved input in the boundary-closing chain is the **equality of the two boundary-closing cyclic restrictions**, with downstream steps described as inheriting that restriction equality through product comparisons.
> 
> No theorem statements or proofs change—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7af205ddf9d8f2968dcf6ab047f4f64d50cc20a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->