### PR TITLE
doc(parent): mark boundary coordinates as local

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -326,9 +326,10 @@ boundary condition \(\tau\),
   X A^j A^{\tau_1\cdots\tau_{M-L_0}} = A^j Y_{M+1-L_0}(\tau).
 \]
 
-These are the one-sided equations obtained from the inverting and growing-back
-argument described in arXiv:2011.12127, Section IV.C, lines 2078--2090, when
-the boundary is closed. -/
+These are one-sided coordinate consequences of the cyclic-window constraints
+used to model the boundary-closing argument. The source paragraph in
+arXiv:2011.12127, Section IV.C, lines 2078--2090, states the corresponding
+closure-property step, but does not display these coordinate equations. -/
 theorem closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2528,9 +2528,15 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \[
         \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A).
     \]
-    Fix a complementary word $\mu$. For every boundary letter $\eta$, the two
-    local boundary conditions $\tau^+_\eta(\mu)$ and $\tau^-_\eta(\mu)$ have
-    the same complementary word. The boundary-closing step is the equality
+    Fix a complementary word $\mu$. For every boundary letter $\eta$, choose the
+    two local boundary conditions so that, for each complementary index $k$,
+    \[
+        \tau^+_\eta(\mu)_{k+L_0}=\mu_k,
+        \qquad
+        \tau^-_\eta(\mu)_{k+1}=\mu_k,
+    \]
+    and put the letter $\eta$ on the remaining sites. These two choices have the
+    same complementary word. The boundary-closing step is the equality
     \[
         \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =
@@ -2566,6 +2572,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
     \]
+    Thus the first-letter restriction of the preceding equality is precisely the
+    displayed product equation.
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

- clarify that the one-sided boundary equations are coordinate consequences used to model the closure-property step, not equations displayed in CPGSV21
- state in the blueprint that `tau^+_eta(mu)`, `tau^-_eta(mu)`, and the first-letter comparison are local coordinate reductions of the closure-property comparison
- keep the source terminology centered on the closure property and the inverting/growing-back paragraph of arXiv:2011.12127, Section IV.C

Refs #2405.
Refs #190.

## Source Check

- `Papers/2011.12127/TN-Review-main.tex` lines 2049--2079 uses the `A,B,C` blocking picture, boundary conditions, inverting/growing back, and the terms intersection property and closure property.
- The paper says one may “apply a similar argument when closing the boundaries”; it does not introduce the local `tau^+`, `tau^-`, `Y_i(tau)`, or first-letter notation.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX prose only; no changes to proofs, APIs, or runtime behavior.
> 
> **Overview**
> **Documentation-only** alignment for the parent-Hamiltonian **closure property** and boundary-closing story: prose now treats the one-sided matrix equations and `τ^+_η(μ)` / `τ^-_η(μ)` notation as **local coordinate reductions**, not as equations printed in CPGSV21 (arXiv:2011.12127, Section IV.C).
> 
> In **`BoundaryClosing.lean`**, the doc on `closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap` no longer describes those identities as coming directly from the paper’s inverting/growing-back paragraph; it states they are **cyclic-window coordinate consequences** used to **model** the closure-property step, while the source only states that step.
> 
> In **`ch14_parent_hamiltonian.tex`**, the lemma text **defines** how to choose the two local boundary conditions via complementary-index formulas, then notes that comparing **first-letter restrictions** yields the displayed product equation. **No Lean proofs or formal statements change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d301affa70db249f2a9646e00f470144f8c5cfc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->