### PR TITLE
doc(parent): align boundary-closing coordinate prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -57,7 +57,8 @@ theorem cyclicRestrictₗ_first_products_eq_of_restriction_eq
 
 /-- For the boundary-crossing interval starting at the last site, any outside
 configuration with the same complementary word gives the same restriction as the
-boundary condition \(\tau^+_\eta(\mu)\) used in the closure property. -/
+local boundary condition \(\tau^+_\eta(\mu)\) used here for a coordinate form of
+the closure property. -/
 theorem cyclicRestrictₗ_wrappedMiddleBackground_eq_of_complement_eq
     {L₀ M : ℕ} (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)} (η : Fin d)
@@ -128,8 +129,9 @@ theorem wrappedMiddleBackground_first_products_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
 
 /-- For the opposite boundary-crossing interval, any outside configuration with
-the same complementary word gives the same restriction as the boundary
-condition \(\tau^-_\eta(\mu)\) used in the closure property. -/
+the same complementary word gives the same restriction as the local boundary
+condition \(\tau^-_\eta(\mu)\) used here for a coordinate form of the closure
+property. -/
 theorem cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
     {L₀ M : ℕ} (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)} (η : Fin d)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -49,7 +49,8 @@ range \(L_0+1\) uniqueness theorem for normal tensors.
 
 ## Remaining mathematical ingredients
 
-The remaining boundary-closing ingredient is the passage from
+The remaining coordinate form of the boundary-closing ingredient is the passage
+from
 \[
   A^\mu A^j X=Y^+_{\tau^+_\eta(\mu)}A^j,\qquad
   X A^j A^\mu=A^jY^-_{\tau^-_\eta(\mu)}
@@ -58,8 +59,9 @@ to
 \[
   Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}
 \]
-for the same complementary-site word \(\mu\); see arXiv:2011.12127,
-Section IV.C, lines 2078--2090.
+for the same complementary-site word \(\mu\). The source states the
+closure-property step in arXiv:2011.12127, Section IV.C, lines 2078--2079; the
+displayed equations are the local coordinate form used in this formalization.
 
 The open-chain build-up follows the inverting-and-growing-back argument from
 arXiv:2011.12127, Section IV.C, lines 2049--2078.  The normal case also uses the
@@ -739,7 +741,7 @@ theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
 =Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\).
 **Open gap:** Inherits the boundary-closing restriction equality through the
 product equality above; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
-theorem closure_property_boundary_tensor_products_eq_of_chainGroundSpace
+theorem closure_property_boundary_right_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
@@ -807,7 +809,7 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
     (mirrorMiddleBackground L₀ (M + 1) η μ) ψ
     (hYAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) η μ)) j
-  have hProd := closure_property_boundary_tensor_products_eq_of_chainGroundSpace
+  have hProd := closure_property_boundary_right_products_eq_of_chainGroundSpace
     (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ j
   exact hLeft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) hProd).trans hRight.symm)
 
@@ -839,7 +841,7 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
     (hYAt ⟨M + 1 - L₀, by omega⟩
       (mirrorMiddleBackground L₀ (M + 1) η μ)) ?_
-  exact closure_property_boundary_tensor_products_eq_of_chainGroundSpace
+  exact closure_property_boundary_right_products_eq_of_chainGroundSpace
     (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ
 
 /-- The two boundary-condition matrix families agree once their right-products
@@ -886,7 +888,7 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     left_witness_unique_of_isNBlkInjective (A := A) hInj hL₀
       (fun a => (hMirror a τm).symm.trans (hMirrorAt a τm))
   rw [hYwrap_eq, hYmirror_eq]
-  exact closure_property_boundary_tensor_products_eq_of_chainGroundSpace
+  exact closure_property_boundary_right_products_eq_of_chainGroundSpace
     (A := A) hInj hL₀ (by omega : L₀ ≤ M) hψred hψX YAt hYAt η μ j
 
 /-- Closure-property containment

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2106,7 +2106,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{def:chain_ground_space, rem:cyclic_window_operators,
         lem:chain_ground_space_window_witnesses,
         lem:closed_boundary_restriction_from_right_products,
-        lem:boundary_closing_boundary_tensor_products_chain_ground_space}
+        lem:boundary_closing_right_products_chain_ground_space}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
     $L_0\le M$, and let
     \[
@@ -2138,7 +2138,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         \Gamma_{L_0+1}\!\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))\right).
     \]
-    Lemma~\ref{lem:boundary_closing_boundary_tensor_products_chain_ground_space}
+    Lemma~\ref{lem:boundary_closing_right_products_chain_ground_space}
     gives, for every $j$,
     \[
         Y_M(\tau^+_\eta(\mu))A^j
@@ -2717,13 +2717,13 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
-\begin{lemma}[Auxiliary first-letter form of the closure property]
+\begin{lemma}[Letterwise restriction comparison at the closing boundary]
     \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
     \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}
     \leanok
     \uses{def:chain_ground_space, rem:cyclic_window_operators,
         lem:chain_ground_space_window_witnesses,
-        lem:boundary_closing_boundary_tensor_products_chain_ground_space}
+        lem:boundary_closing_right_products_chain_ground_space}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let
     $L_0\le M$, and let
     \[
@@ -2731,21 +2731,23 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \qquad
         \psi=\Gamma_{M+1}(X).
     \]
-    The auxiliary first-letter assertion used to close the boundary is
+    Let $R_j$ denote restriction to first physical letter $j$.  For every
+    outside letter $\eta$, complementary word $\mu$, and physical letter $j$,
+    one has
     \[
-        \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
+        R_j\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =
-        \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi).
+        R_j\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
     \]
-    This is a first-letter form of the closure-property comparison discussed
-    in \cite[lines~2078--2090]{Cirac2021Matrix}.
+    This is the letterwise coordinate form of the local closure-property comparison
+    corresponding to \cite[lines~2078--2079]{Cirac2021Matrix}.
 \end{lemma}
 
 \begin{proof}
     \notready
     Let $Y_i(\tau)$ be the window witnesses of
     Lemma~\ref{lem:chain_ground_space_window_witnesses}.  By
-    Lemma~\ref{lem:boundary_closing_boundary_tensor_products_chain_ground_space},
+    Lemma~\ref{lem:boundary_closing_right_products_chain_ground_space},
     \[
         Y_M(\tau^+_\eta(\mu))A^j
         =
@@ -2754,10 +2756,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Fixing the first physical letter in the two length-$(L_0+1)$ windows gives
     \[
     \begin{aligned}
-        \operatorname{Res}^{\tau^+_{\eta,j}(\mu)}_{M+1,L_0}(\psi)
+        R_j\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         &=
         \Gamma_{L_0}\!\left(Y_M(\tau^+_\eta(\mu))A^j\right),\\
-        \operatorname{Res}^{\tau^-_{\eta,j}(\mu)}_{M+2-L_0,L_0}(\psi)
+        R_j\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)
         &=
         \Gamma_{L_0}\!\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\right).
     \end{aligned}
@@ -2873,8 +2875,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \end{proof}
 
 \begin{lemma}[Right-product equality after closing the boundary]
-    \label{lem:boundary_closing_boundary_tensor_products_chain_ground_space}
-    \lean{MPSTensor.closure_property_boundary_tensor_products_eq_of_chainGroundSpace}
+    \label{lem:boundary_closing_right_products_chain_ground_space}
+    \lean{MPSTensor.closure_property_boundary_right_products_eq_of_chainGroundSpace}
     \leanok
     \uses{lem:boundary_closing_word_equation_chain_ground_space,
         lem:padded_complement_annihilation}
@@ -2930,7 +2932,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     \uses{thm:reduced_wrapped_boundary_compatibilities,
         lem:wrapped_mirror_right_products_determine,
-        lem:boundary_closing_boundary_tensor_products_chain_ground_space}
+        lem:boundary_closing_right_products_chain_ground_space}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$, let $N\ge2$
     and $L_0<L\le N$, and let
     $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
@@ -3008,7 +3010,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu)).
     \]
     Together with the preceding identifications,
-    Lemma~\ref{lem:boundary_closing_boundary_tensor_products_chain_ground_space}
+    Lemma~\ref{lem:boundary_closing_right_products_chain_ground_space}
     gives, for every physical letter $j$,
     \[
         Y^{+}_{\tau^{+}_{\eta}(\mu)} A^j


### PR DESCRIPTION
## Summary

- describe the boundary conditions \(\tau^\pm_\eta(\mu)\) as local coordinate choices for the closure-property step, rather than as terminology appearing in the source
- rewrite the blueprint letterwise comparison as the equation
  \[
    R_j\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
    =
    R_j\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)
  \]
  instead of introducing extra \(\tau^\pm_{\eta,j}(\mu)\) notation
- rename the local “boundary tensor products” lemma to “boundary right products” in Lean and in the blueprint label

The proof scout for #2405 did not find a no-`sorry` proof of `MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap`. The remaining comparison is still the equality of the two local boundary matrices after multiplying by each physical letter. This PR is therefore a terminology and source-faithfulness cleanup, not a closure of #2405.

## Compatibility

No compatibility alias is provided. The old name used “boundary tensor products” for an equality of right multiplications by physical-letter matrices, which was misleading in this local boundary-closing context; all project references are updated in this PR.

Related: #2405.

## Verification

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `leanblueprint web`
- `lake build TNLean`

Additional local checks:

- `python3 scripts/blueprint_lean_sync.py --root . --ci` still reports existing non-parent sync issues: `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and the literal `...` tag in `ch04a_channel_representations.tex`.
- `lake exe checkdecls blueprint/lean_decls` runs after generating `blueprint/lean_decls`; it still reports existing missing declarations outside this PR. The renamed parent declaration is not among the missing declarations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment, docstring, and blueprint label/text changes only; theorem bodies are unchanged and references are updated in-repo.
> 
> **Overview**
> Aligns **parent Hamiltonian boundary-closing** prose and blueprint notation with the paper, without changing proofs or closing open gaps (#2405).
> 
> **Lean:** Renames `closure_property_boundary_tensor_products_eq_of_chainGroundSpace` to `closure_property_boundary_right_products_eq_of_chainGroundSpace` and updates all call sites. Docstrings now describe \(\tau^\pm_\eta(\mu)\) as **local coordinate choices** for the closure step and narrow the Cirac et al. citation to lines 2078–2079 for the closure step vs. the displayed coordinate equations.
> 
> **Blueprint (`ch14_parent_hamiltonian.tex`):** Renames the matching lemma label to `boundary_closing_right_products_chain_ground_space`. The letterwise comparison is restated as equality of **first-letter restrictions** \(R_j\) on \(\operatorname{Res}^{\tau^\pm_\eta(\mu)}_{\ldots}\), dropping extra \(\tau^\pm_{\eta,j}(\mu)\) notation; the former “auxiliary first-letter form” lemma is retitled accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9749e5d0c5c1d94306b173b5794ebdf9eb478a60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

