### PR TITLE
doc(peps): add region insertion blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2739,7 +2739,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
         \eta_1^c=\eta_2^c\quad\Longrightarrow\quad \eta_1=\eta_2 .
     \]
     Thus the coefficients of $T_{A,V\setminus R}$ and $B_{A,R^c}$ differ only
-    by an injective relabelling of the same boundary data.
+    by an injective relabelling of boundary configurations.
 \end{proof}
 
 \begin{definition}[Region insertion coefficient]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2733,6 +2733,13 @@ injective and normal PEPS, following Theorems~2 and~3 of
 \begin{proof}\leanok
     The one-point external boundary does not change the coefficient family, and
     the complement-boundary identification only reindexes the crossing bonds.
+    More explicitly, if $\eta_1,\eta_2$ are boundary configurations on
+    $\partial R$, then
+    \[
+        \eta_1^c=\eta_2^c\quad\Longrightarrow\quad \eta_1=\eta_2 .
+    \]
+    Thus the coefficients of $T_{A,V\setminus R}$ and $B_{A,R^c}$ differ only
+    by an injective relabelling of the same boundary data.
 \end{proof}
 
 \begin{definition}[Region insertion coefficient]%
@@ -2761,8 +2768,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.twoBlockInsertedCoeff_eq_regionInsertedCoeff}
     \leanok
     \uses{def:peps_regionInsertedCoeff, def:peps_regionTwoBlock,
-        def:peps_regionComplementTwoBlock,
-        thm:peps_twoInjectiveTensorInsertionComparison}
+        def:peps_regionComplementTwoBlock}
     The abstract two-block insertion coefficient of the pair
     $(B_{A,R},B_{A,R^c})$ is the region insertion coefficient:
     \[
@@ -2803,8 +2809,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \leanok
     \uses{thm:peps_twoBlockInsertedCoeff_eq_regionInsertedCoeff,
         thm:peps_regionInsertedCoeff_reindexTensor}
-    Suppose $A$ and $B$ have identified bond dimensions, with transport
-    $\phi_f$ on the boundary bond $f$. If
+    Suppose $A$ and $B$ have identified bond dimensions. Write $B^h$ for the
+    transported tensor, and write $\phi_f$ for the induced transport on the
+    boundary bond $f$. If
     \[
         C_A(R,f,N;\sigma,\tau)
         =
@@ -2814,15 +2821,20 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $\sigma,\tau$, then the two pairs
     \[
         (B_{A,R},B_{A,R^c}),\qquad
-        (B_{B,R},B_{B,R^c})
+        (B_{B^h,R},B_{B^h,R^c})
     \]
     have the same one-bond insertion coefficients after the same
     bond-dimension transport.
 \end{theorem}
 \begin{proof}\leanok
-    Rewrite both abstract two-block insertion coefficients as region insertion
-    coefficients, and use the displayed hypothesis together with the
-    bond-dimension transport formula.
+    Rewrite the two abstract insertion coefficients as region insertion
+    coefficients and use the bond-dimension transport formula:
+    \[
+        C_{B_{A,R},B_{A,R^c}}(f,N;*,*,\sigma,\tau)
+        = C_A(R,f,N;\sigma,\tau)
+        = C_B(R,f,\phi_f(N);\sigma,\tau)
+        = C_{B_{B^h,R},B_{B^h,R^c}}(f,N;*,*,\sigma,\tau).
+    \]
 \end{proof}
 
 \begin{definition}[Single-vertex two-block tensor]%

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -2675,6 +2675,156 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $A_2=\lambda^{-1}B_2$.
 \end{proof}
 
+\begin{definition}[Region two-block tensor]%
+    \label{def:peps_regionTwoBlock}
+    \lean{TNLean.PEPS.regionTwoBlock}
+    \leanok
+    For a finite region $R\subseteq V$, the blocked tensor of $R$ may be read
+    as a two-block tensor with a one-point external boundary and shared bonds
+    the edges crossing the boundary of $R$:
+    \[
+        B_{A,R}(*,\eta,\sigma)=T_{A,R}^{\eta}(\sigma).
+    \]
+    This is the region block used in the one-block-against-complement step of
+    \cite[Section~3]{Molnar2018NormalPEPS}.
+\end{definition}
+
+\begin{definition}[Complement-boundary identification]%
+    \label{def:peps_regionComplementBoundaryConfig}
+    \lean{TNLean.PEPS.regionBoundaryEdgeToCompl,
+        TNLean.PEPS.regionBoundaryEdgeComplEquiv,
+        TNLean.PEPS.regionComplementBoundaryConfig}
+    \leanok
+    The edges crossing the boundary of $R$ are the same edges crossing the
+    boundary of $V\setminus R$. Thus a boundary configuration $\eta$ for $R$
+    determines the boundary configuration $\eta^c$ for the complement by reading
+    the same edge labels through this identification.
+\end{definition}
+
+\begin{definition}[Complement-region two-block tensor]%
+    \label{def:peps_regionComplementTwoBlock}
+    \lean{TNLean.PEPS.regionComplementTwoBlock}
+    \leanok
+    \uses{def:peps_regionComplementBoundaryConfig}
+    For a finite region $R\subseteq V$, the complement block $V\setminus R$ is
+    a two-block tensor over the same crossing bonds:
+    \[
+        B_{A,R^c}(*,\eta,\tau)
+        =
+        T_{A,V\setminus R}^{\eta^c}(\tau).
+    \]
+    This is the complementary block in the region/complement comparison of
+    \cite[Section~3]{Molnar2018NormalPEPS}.
+\end{definition}
+
+\begin{theorem}[Injectivity of the complement-region two-block tensor]%
+    \label{thm:peps_isTwoBlockInjective_regionComplementTwoBlock}
+    \lean{TNLean.PEPS.isTwoBlockInjective_regionComplementTwoBlock}
+    \leanok
+    \uses{def:peps_regionComplementTwoBlock, def:peps_regionInjectivityData}
+    If the blocked tensor family of $V\setminus R$ is injective, then the
+    complement-region two-block tensor is injective:
+    \[
+        \operatorname{inj}(T_{A,V\setminus R})
+        \Longrightarrow
+        \operatorname{inj}(B_{A,R^c}).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    The one-point external boundary does not change the coefficient family, and
+    the complement-boundary identification only reindexes the crossing bonds.
+\end{proof}
+
+\begin{definition}[Region insertion coefficient]%
+    \label{def:peps_regionInsertedCoeff}
+    \lean{TNLean.PEPS.regionInsertedCoeff}
+    \leanok
+    \uses{def:peps_regionTwoBlock, def:peps_regionComplementTwoBlock}
+    Let $f$ be an edge crossing the boundary of $R$, and let
+    $M\in\MN{D_f}$.  The region insertion coefficient is
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        \sum_{\substack{\mu,\nu\\
+                \mu|_{\partial R\setminus\{f\}}
+                =\nu|_{\partial R\setminus\{f\}}}}
+        M_{\mu_f,\nu_f}\,
+        T_{A,R}^{\mu}(\sigma)\,
+        T_{A,V\setminus R}^{\nu^c}(\tau).
+    \]
+    It is the coefficient obtained by inserting $M$ on the boundary bond $f$
+    between the region $R$ and its complement.
+\end{definition}
+
+\begin{theorem}[Region insertion as a two-block insertion]%
+    \label{thm:peps_twoBlockInsertedCoeff_eq_regionInsertedCoeff}
+    \lean{TNLean.PEPS.twoBlockInsertedCoeff_eq_regionInsertedCoeff}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff, def:peps_regionTwoBlock,
+        def:peps_regionComplementTwoBlock,
+        thm:peps_twoInjectiveTensorInsertionComparison}
+    The abstract two-block insertion coefficient of the pair
+    $(B_{A,R},B_{A,R^c})$ is the region insertion coefficient:
+    \[
+        C_{B_{A,R},B_{A,R^c}}(f,M;*,*,\sigma,\tau)
+        =
+        C_A(R,f,M;\sigma,\tau).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Expanding the abstract two-block coefficient gives exactly the two boundary
+    sums in the displayed formula for $C_A(R,f,M;\sigma,\tau)$.
+\end{proof}
+
+\begin{theorem}[Region insertion under bond-dimension transport]%
+    \label{thm:peps_regionInsertedCoeff_reindexTensor}
+    \lean{TNLean.PEPS.regionInsertedCoeff_reindexTensor}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff}
+    If a tensor $B$ is transported along an equality of bond dimensions, then
+    the region insertion coefficient is transported by the induced
+    matrix-algebra identification on the inserted bond:
+    \[
+        C_{B^h}(R,f,N;\sigma,\tau)
+        =
+        C_B(R,f,\phi_f(N);\sigma,\tau).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Reindex both boundary-configuration sums by the bond-dimension
+    equivalences. The constraint away from $f$ and the two blocked-region
+    weights are preserved, while the inserted matrix entry becomes the
+    transported entry $\phi_f(N)$.
+\end{proof}
+
+\begin{theorem}[Same two-block insertions from region insertions]%
+    \label{thm:peps_sameTwoBlockInsertions_of_regionInsertedCoeff_eq}
+    \lean{TNLean.PEPS.sameTwoBlockInsertions_of_regionInsertedCoeff_eq}
+    \leanok
+    \uses{thm:peps_twoBlockInsertedCoeff_eq_regionInsertedCoeff,
+        thm:peps_regionInsertedCoeff_reindexTensor}
+    Suppose $A$ and $B$ have identified bond dimensions, with transport
+    $\phi_f$ on the boundary bond $f$. If
+    \[
+        C_A(R,f,N;\sigma,\tau)
+        =
+        C_B(R,f,\phi_f(N);\sigma,\tau)
+    \]
+    for every boundary edge $f$, matrix $N$, and physical configurations
+    $\sigma,\tau$, then the two pairs
+    \[
+        (B_{A,R},B_{A,R^c}),\qquad
+        (B_{B,R},B_{B,R^c})
+    \]
+    have the same one-bond insertion coefficients after the same
+    bond-dimension transport.
+\end{theorem}
+\begin{proof}\leanok
+    Rewrite both abstract two-block insertion coefficients as region insertion
+    coefficients, and use the displayed hypothesis together with the
+    bond-dimension transport formula.
+\end{proof}
+
 \begin{definition}[Single-vertex two-block tensor]%
     \label{def:peps_vertexTwoBlock}
     \lean{TNLean.PEPS.vertexTwoBlock}


### PR DESCRIPTION
## Summary

- add blueprint entries for the region two-block tensor and complement-boundary identification
- add the requested entries for `regionComplementTwoBlock`, `isTwoBlockInjective_regionComplementTwoBlock`, and `regionInsertedCoeff`
- also record the two load-bearing region insertion theorems named in #2463, together with the bond-dimension transport lemma used by the reduction

Closes #2463.

## Verification

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake exe cache get`
- `lake build TNLean.PEPS.RegionBlock.Insertion`
- `leanblueprint web`

Additional local check:

- `python3 scripts/blueprint_lean_sync.py --root . --ci` still reports existing non-this-PR sync issues: `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and the literal `...` tag in `ch04a_channel_representations.tex`. The new region insertion tags resolve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX/blueprint additions with Lean name tags; no runtime or proof logic changes in the diff.
> 
> **Overview**
> Adds a **region/complement insertion** block to the PEPS fundamental-theorems blueprint (`ch13a_peps_ft.tex`), placed before the existing single-vertex two-block material, with `\lean{}` tags wired to `TNLean.PEPS.RegionBlock.Insertion` (closes #2463).
> 
> The new entries formalize Molnár Section 3’s **one region vs complement** step: `regionTwoBlock`, complement-boundary identification (`regionComplementBoundaryConfig`), `regionComplementTwoBlock`, injectivity of the complement block from region injectivity, and **`regionInsertedCoeff`** (matrix on a crossing bond between blocked region and complement). Three supporting theorems link that coefficient to abstract two-block insertions, transport it under bond-dimension reindexing, and lift equality of region insertions to **`sameTwoBlockInsertions`** for `(B_{A,R}, B_{A,R^c})` vs transported `(B_{B^h,R}, B_{B^h,R^c})`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d56bcb06785d7ab436d407c85dd0250289e39f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->