### PR TITLE
feat(MPDO): prove Proposition 4.5 — mutual-information monotonicity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -265,6 +265,7 @@ import TNLean.PiAlgebra.GlobalSymmetry
 -- Layer 3b: MPO / MPDO / LPDO foundations
 import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.MPDO.AreaLaw
+import TNLean.MPS.MPDO.MutualInfoMonotone
 import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -122,6 +122,28 @@ theorem mpo_submatrix_rotateConfig (M : MPOTensor d D) (N : ℕ) :
   simp only [Matrix.submatrix_apply, mpo_apply, rotateConfig_apply]
   exact mpoMatrixEntry_comp_finRotate M σ τ
 
+/-- The closed-word MPO entry is invariant under a `p`-fold cyclic shift of both
+configurations (iterating the single-shift invariance). -/
+theorem mpoMatrixEntry_comp_finRotate_pow (M : MPOTensor d D) {N : ℕ}
+    (p : ℕ) (σ τ : Fin N → Fin d) :
+    mpoMatrixEntry M (σ ∘ (finRotate N : Fin N → Fin N)^[p])
+        (τ ∘ (finRotate N : Fin N → Fin N)^[p])
+      = mpoMatrixEntry M σ τ := by
+  induction p with
+  | zero => simp
+  | succ n ih =>
+      rw [Function.iterate_succ, ← Function.comp_assoc, ← Function.comp_assoc,
+        mpoMatrixEntry_comp_finRotate, ih]
+
+/-- **Translation invariance under a `p`-fold shift.** `mpo M N` is invariant
+under the simultaneous `p`-fold cyclic shift of bra and ket configurations. -/
+theorem mpo_submatrix_finRotate_pow (M : MPOTensor d D) (N p : ℕ) :
+    (mpo M N).submatrix (fun σ => σ ∘ (finRotate N : Fin N → Fin N)^[p])
+        (fun σ => σ ∘ (finRotate N : Fin N → Fin N)^[p]) = mpo M N := by
+  ext σ τ
+  simp only [Matrix.submatrix_apply, mpo_apply]
+  exact mpoMatrixEntry_comp_finRotate_pow M p σ τ
+
 end MPOTensor
 
 /-! ## Trace normalization -/

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -181,6 +181,49 @@ theorem blockReducedState_trace {d L K : ℕ}
   simp only [Matrix.trace, Matrix.diag, Matrix.submatrix_apply]
   exact (blockSplitEquiv d L K).symm.sum_comp (fun p => ρ p p)
 
+/-- The inverse block split is concatenation of the two parts via `Fin.append`. -/
+theorem blockSplitEquiv_symm_apply {d L K : ℕ} (a : Fin L → Fin d) (b : Fin K → Fin d) :
+    (blockSplitEquiv d L K).symm (a, b) = Fin.append a b := by
+  funext i
+  simp only [blockSplitEquiv, Equiv.symm_trans_apply, Equiv.sumArrowEquivProdArrow,
+    Equiv.coe_fn_symm_mk, Equiv.arrowCongr_symm, Equiv.refl_symm, Equiv.arrowCongr_apply,
+    Equiv.coe_refl, Function.comp, id_eq]
+  refine Fin.addCases (fun j => ?_) (fun j => ?_) i
+  · simp [Equiv.symm_symm, finSumFinEquiv_symm_apply_castAdd]
+  · simp [Equiv.symm_symm, finSumFinEquiv_symm_apply_natAdd]
+
+/-- Concatenating the two parts of a block split recovers the original
+configuration. -/
+theorem append_blockSplitEquiv {d K₁ K₂ : ℕ} (k : Fin (K₁ + K₂) → Fin d) :
+    Fin.append (blockSplitEquiv d K₁ K₂ k).1 (blockSplitEquiv d K₁ K₂ k).2 = k := by
+  rw [← blockSplitEquiv_symm_apply, Prod.mk.eta, Equiv.symm_apply_apply]
+
+/-- **Composition of contiguous-block reductions.** Tracing out the last `K₁`
+spins of the reduced state on the first `L + K₁` of `L + K₁ + K₂` spins equals
+tracing out the last `K₁ + K₂` spins directly (after reassociating the index).
+This is the prefix-consistency step: reducing a prefix and then a shorter prefix
+agrees with reducing to the shorter prefix in one step. -/
+theorem blockReducedState_comp {d L K₁ K₂ : ℕ}
+    (X : Matrix (Fin (L + K₁ + K₂) → Fin d) (Fin (L + K₁ + K₂) → Fin d) ℂ) :
+    blockReducedState d L K₁ (blockReducedState d (L + K₁) K₂ X)
+      = blockReducedState d L (K₁ + K₂)
+          (X.submatrix
+            (Equiv.arrowCongr (finCongr (Nat.add_assoc L K₁ K₂)) (Equiv.refl (Fin d))).symm
+            (Equiv.arrowCongr (finCongr (Nat.add_assoc L K₁ K₂)) (Equiv.refl (Fin d))).symm) := by
+  rw [blockReducedState, blockReducedState, Matrix.partialTraceRight_submatrix_left,
+    Matrix.submatrix_submatrix, Matrix.partialTraceRight_partialTraceRight,
+    Matrix.partialTraceRight_submatrix_right (blockSplitEquiv d K₁ K₂),
+    blockReducedState, Matrix.submatrix_submatrix, Matrix.submatrix_submatrix]
+  ext p i
+  simp only [partialTraceRight_apply, Matrix.submatrix_apply]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  congr 1 <;>
+  · simp only [Function.comp, Prod.map, blockSplitEquiv_symm_apply, id_eq, Fin.append_assoc,
+      append_blockSplitEquiv]
+    funext x
+    simp only [Equiv.arrowCongr_symm, Equiv.refl_symm, Equiv.arrowCongr_apply, Equiv.coe_refl,
+      id_eq, finCongr_symm, finCongr_apply, Function.comp_apply]
+
 /-! ## Normalized MPO and block entropies -/
 
 namespace MPOTensor

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -246,6 +246,20 @@ theorem blockReducedState_comp {d L K₁ K₂ : ℕ}
     simp only [Equiv.arrowCongr_symm, Equiv.refl_symm, Equiv.arrowCongr_apply, Equiv.coe_refl,
       id_eq, finCongr_symm, finCongr_apply, Function.comp_apply]
 
+/-- Reindexing the input of a block reduction by a prefix-preserving `finCongr`
+on the suffix length leaves the reduced state unchanged: it only relabels the
+traced-out spins. The suffix-length equality is `subst`ed away, after which the
+reindex collapses to the identity. -/
+theorem blockReducedState_submatrix_finCongr {d L K K' : ℕ} (h : L + K = L + K')
+    (ρ : Matrix (Fin (L + K) → Fin d) (Fin (L + K) → Fin d) ℂ) :
+    blockReducedState d L K'
+        (ρ.submatrix (Equiv.arrowCongr (finCongr h) (Equiv.refl (Fin d))).symm
+          (Equiv.arrowCongr (finCongr h) (Equiv.refl (Fin d))).symm)
+      = blockReducedState d L K ρ := by
+  have hKK' : K = K' := by omega
+  subst hKK'
+  simp
+
 /-! ## Normalized MPO and block entropies -/
 
 namespace MPOTensor

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -146,6 +146,57 @@ theorem mpo_submatrix_finRotate_pow (M : MPOTensor d D) (N p : ℕ) :
 
 end MPOTensor
 
+/-! ## Cyclic shift on configurations -/
+
+/-- `finRotate` advances the value by one modulo `N`. -/
+theorem coe_finRotate_mod {N : ℕ} (i : Fin N) :
+    ((finRotate N) i : ℕ) = (i.val + 1) % N := by
+  match N with
+  | 0 => exact i.elim0
+  | n + 1 =>
+    rw [coe_finRotate]
+    rcases eq_or_ne i (Fin.last n) with h | h
+    · subst h; simp [Fin.val_last, Nat.mod_self]
+    · rw [if_neg h]
+      have : (i : ℕ) < n := Fin.val_lt_last h
+      rw [Nat.mod_eq_of_lt (by omega)]
+
+/-- The value of the `p`-fold cyclic shift is `(i + p) mod N`. -/
+theorem coe_finRotate_pow {N : ℕ} (p : ℕ) (i : Fin N) :
+    (((finRotate N : Fin N → Fin N)^[p]) i : ℕ) = (i.val + p) % N := by
+  induction p with
+  | zero => simp [Nat.mod_eq_of_lt i.isLt]
+  | succ k ih =>
+    rw [Function.iterate_succ_apply', coe_finRotate_mod, ih, Nat.mod_add_mod, Nat.add_assoc]
+
+/-- **Cyclic shift by `p` swaps the first `p` coordinates to the back.**
+For `x : Fin p → α` and `y : Fin q → α`, shifting `append x y` by `p` yields
+`append y x` (after the `Fin (p + q) ≃ Fin (q + p)` length cast). This is the
+configuration-level form of the periodic MPDO's translation invariance. -/
+theorem append_comp_finRotate_pow {α : Type*} {p q : ℕ}
+    (x : Fin p → α) (y : Fin q → α) :
+    (Fin.append x y) ∘ ((finRotate (p + q) : Fin (p + q) → Fin (p + q))^[p])
+      = (Fin.append y x) ∘ Fin.cast (Nat.add_comm p q) := by
+  funext i
+  simp only [Function.comp_apply]
+  rcases lt_or_ge i.val q with hiq | hiq
+  · have hm : (finRotate (p + q) : Fin (p + q) → Fin (p + q))^[p] i
+        = Fin.natAdd p ⟨i.val, hiq⟩ := by
+      apply Fin.ext
+      rw [coe_finRotate_pow, Nat.mod_eq_of_lt (by omega)]
+      simp only [Fin.natAdd_mk]; omega
+    have hc : Fin.cast (Nat.add_comm p q) i = Fin.castAdd p ⟨i.val, hiq⟩ := by
+      apply Fin.ext; simp
+    rw [hm, hc, Fin.append_right, Fin.append_left]
+  · have hm : (finRotate (p + q) : Fin (p + q) → Fin (p + q))^[p] i
+        = Fin.castAdd q ⟨i.val - q, by omega⟩ := by
+      apply Fin.ext
+      rw [coe_finRotate_pow, Nat.mod_eq_sub_mod (by omega), Nat.mod_eq_of_lt (by omega)]
+      simp only [Fin.castAdd_mk]; omega
+    have hc : Fin.cast (Nat.add_comm p q) i = Fin.natAdd q ⟨i.val - q, by omega⟩ := by
+      apply Fin.ext; simp only [Fin.val_cast, Fin.natAdd_mk]; omega
+    rw [hm, hc, Fin.append_left, Fin.append_right]
+
 /-! ## Trace normalization -/
 
 namespace Matrix

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -197,6 +197,57 @@ theorem append_comp_finRotate_pow {α : Type*} {p q : ℕ}
       apply Fin.ext; simp only [Fin.val_cast, Fin.natAdd_mk]; omega
     rw [hm, hc, Fin.append_left, Fin.append_right]
 
+/-- The length cast commutes with the `p`-fold cyclic shift. -/
+theorem cast_comp_finRotate_pow {N M : ℕ} (h : N = M) (p : ℕ) :
+    (Fin.cast h) ∘ ((finRotate N : Fin N → Fin N)^[p])
+      = ((finRotate M : Fin M → Fin M)^[p]) ∘ (Fin.cast h) := by
+  funext i
+  apply Fin.ext
+  simp only [Function.comp_apply, Fin.val_cast]
+  rw [coe_finRotate_pow, coe_finRotate_pow]
+  subst h; rfl
+
+/-- **Window-to-prefix configuration identity.** Placing the `m`-block `u` at the
+front (with `z, x` after) equals placing it in the middle (with `x` before and
+`z` after) composed with the `p`-fold cyclic shift, where `p = |x|`. This is the
+configuration form of translation invariance: a block in the middle of the chain
+is the same as a block at the front after a cyclic shift. -/
+theorem window_eq_prefix_rotate {d N p m s : ℕ}
+    (x : Fin p → Fin d) (u : Fin m → Fin d) (z : Fin s → Fin d)
+    (hA : N = m + (s + p)) (hB : N = p + m + s) :
+    (Fin.append u (Fin.append z x)) ∘ Fin.cast hA
+      = ((Fin.append (Fin.append x u) z) ∘ Fin.cast hB)
+        ∘ ((finRotate N : Fin N → Fin N)^[p]) := by
+  funext j
+  simp only [Function.comp_apply]
+  rcases lt_or_ge j.val m with h1 | h1
+  · have hL : Fin.cast hA j = Fin.castAdd (s + p) ⟨j.val, h1⟩ := by
+      apply Fin.ext; simp
+    have hR : Fin.cast hB ((finRotate N : Fin N → Fin N)^[p] j)
+        = Fin.castAdd s (Fin.natAdd p ⟨j.val, h1⟩) := by
+      apply Fin.ext
+      rw [Fin.val_cast, coe_finRotate_pow, Nat.mod_eq_of_lt (by omega)]
+      simp; omega
+    rw [hL, hR, Fin.append_left, Fin.append_left, Fin.append_right]
+  · rcases lt_or_ge j.val (m + s) with h2 | h2
+    · have hL : Fin.cast hA j = Fin.natAdd m (Fin.castAdd p ⟨j.val - m, by omega⟩) := by
+        apply Fin.ext; simp; omega
+      have hR : Fin.cast hB ((finRotate N : Fin N → Fin N)^[p] j)
+          = Fin.natAdd (p + m) ⟨j.val - m, by omega⟩ := by
+        apply Fin.ext
+        rw [Fin.val_cast, coe_finRotate_pow, Nat.mod_eq_of_lt (by omega)]
+        simp; omega
+      rw [hL, hR, Fin.append_right, Fin.append_left, Fin.append_right]
+    · have hL : Fin.cast hA j = Fin.natAdd m (Fin.natAdd s ⟨j.val - m - s, by omega⟩) := by
+        apply Fin.ext; simp; omega
+      have hR : Fin.cast hB ((finRotate N : Fin N → Fin N)^[p] j)
+          = Fin.castAdd s (Fin.castAdd m ⟨j.val - m - s, by omega⟩) := by
+        apply Fin.ext
+        rw [Fin.val_cast, coe_finRotate_pow, Nat.mod_eq_sub_mod (by omega),
+          Nat.mod_eq_of_lt (by omega)]
+        simp; omega
+      rw [hL, hR, Fin.append_right, Fin.append_right, Fin.append_left, Fin.append_left]
+
 /-! ## Trace normalization -/
 
 namespace Matrix

--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -88,3 +88,17 @@ theorem traceC_corr {d a b c : ℕ}
     Equiv.symm_trans_apply, Equiv.prodCongr_symm, Equiv.refl_symm,
     Equiv.prodAssoc_symm_apply, Equiv.prodCongr_apply, Equiv.coe_refl, Prod.map, id_eq]
   exact Fintype.sum_equiv finFunctionFinEquiv.symm _ _ (fun _ => rfl)
+
+/-- **Prefix consistency for the reduced block state.** Reducing the first
+`a + b + c` spins of the normalized MPO and then keeping the first `a + b` of
+those agrees with directly keeping the first `a + b` spins. This identifies the
+`traceC`-side of `ssa_cast_ineq` (which keeps the first `a + b` of the `a+b+c`
+block) with the `a + b` block entropy. -/
+theorem reducedBlockState_prefix {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ}
+    (h3 : a + b + c ≤ N) :
+    blockReducedState d (a + b) c (MPOTensor.reducedBlockState M N (a + b + c) h3)
+      = MPOTensor.reducedBlockState M N (a + b) ((Nat.le_add_right _ c).trans h3) := by
+  rw [MPOTensor.reducedBlockState, blockReducedState_comp]
+  have h : (a + b) + (c + (N - (a + b + c))) = (a + b) + (N - (a + b)) := by omega
+  rw [← blockReducedState_submatrix_finCongr h, MPOTensor.reducedBlockState]
+  congr 1

--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -102,3 +102,78 @@ theorem reducedBlockState_prefix {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ}
   have h : (a + b) + (c + (N - (a + b + c))) = (a + b) + (N - (a + b)) := by omega
   rw [← blockReducedState_submatrix_finCongr h, MPOTensor.reducedBlockState]
   congr 1
+
+/-! ## Translation invariance of the block reduced state -/
+
+/-- The normalized periodic MPDO is invariant under a `p`-fold cyclic shift of
+both configurations. -/
+theorem normalizedMPO_comp_finRotate_pow {d D : ℕ} (M : MPOTensor d D) (N p : ℕ)
+    (C C' : Fin N → Fin d) :
+    M.normalizedMPO N (C ∘ (finRotate N : Fin N → Fin N)^[p])
+        (C' ∘ (finRotate N : Fin N → Fin N)^[p])
+      = M.normalizedMPO N C C' := by
+  have h := MPOTensor.mpo_submatrix_finRotate_pow M N p
+  simp only [MPOTensor.normalizedMPO, Matrix.smul_apply]
+  congr 1
+  have key := congrFun (congrFun h C) C'
+  simpa only [Matrix.submatrix_apply] using key
+
+/-- Closed-form entrywise expansion of the reduced block state. -/
+theorem reducedBlockState_eq_sum {d D : ℕ} (M : MPOTensor d D) {N m : ℕ} (hm : m ≤ N)
+    (u v : Fin m → Fin d) :
+    M.reducedBlockState N m hm u v
+      = ∑ w : Fin (N - m) → Fin d,
+          M.normalizedMPO N (Fin.append u w ∘ Fin.cast (show N = m + (N - m) by omega))
+            (Fin.append v w ∘ Fin.cast (show N = m + (N - m) by omega)) := by
+  rw [MPOTensor.reducedBlockState]
+  simp only [blockReducedState, partialTraceRight_apply, Matrix.submatrix_apply,
+    blockSplitEquiv_symm_apply, MPOTensor.blockReindexEquiv, Equiv.arrowCongr_symm,
+    Equiv.refl_symm, finCongr_symm]
+  rfl
+
+/-- Appending `u` to a suffix-reindexed config equals reindexing the whole
+append: `append u (w ∘ cast) ∘ cast = append u w ∘ cast`. -/
+theorem append_glue {d N m k k' : ℕ} (u : Fin m → Fin d) (w : Fin k → Fin d)
+    (h1 : k' = k) (h2 : N = m + k') (h3 : N = m + k) :
+    (Fin.append u (w ∘ Fin.cast h1)) ∘ Fin.cast h2
+      = (Fin.append u w) ∘ Fin.cast h3 := by
+  funext j
+  simp only [Function.comp_apply]
+  rcases lt_or_ge j.val m with hj | hj
+  · have hL : Fin.cast h2 j = Fin.castAdd k' ⟨j.val, hj⟩ := by apply Fin.ext; simp
+    have hR : Fin.cast h3 j = Fin.castAdd k ⟨j.val, hj⟩ := by apply Fin.ext; simp
+    rw [hL, hR, Fin.append_left, Fin.append_left]
+  · have hL : Fin.cast h2 j = Fin.natAdd m ⟨j.val - m, by omega⟩ := by apply Fin.ext; simp; omega
+    have hR : Fin.cast h3 j = Fin.natAdd m ⟨j.val - m, by omega⟩ := by apply Fin.ext; simp; omega
+    rw [hL, hR, Fin.append_right, Fin.append_right]
+    rfl
+
+/-- **Translation invariance of the block reduced state (windowed form).** The
+reduced state keeping an `m`-block with `p` spins traced out before it and `s`
+spins after equals the reduced state keeping the first `m` spins (arXiv:1606.00608,
+Prop 4.5 appendix: the entropy of a contiguous block depends only on its length). -/
+theorem window_block_entropy {d D : ℕ} (M : MPOTensor d D) {N p m s : ℕ} (hB : N = p + m + s)
+    (u v : Fin m → Fin d) :
+    ∑ x : Fin p → Fin d, ∑ z : Fin s → Fin d,
+        M.normalizedMPO N (Fin.append (Fin.append x u) z ∘ Fin.cast hB)
+          (Fin.append (Fin.append x v) z ∘ Fin.cast hB)
+      = M.reducedBlockState N m (by omega) u v := by
+  rw [reducedBlockState_eq_sum]
+  set E : (Fin p → Fin d) × (Fin s → Fin d) ≃ (Fin (N - m) → Fin d) :=
+    (Equiv.prodComm _ _).trans
+      ((blockSplitEquiv d s p).symm.trans
+        (Equiv.arrowCongr (finCongr (show s + p = N - m by omega)) (Equiv.refl (Fin d)))) with hE
+  rw [← Equiv.sum_comp E, Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl (fun x _ => Finset.sum_congr rfl (fun z _ => ?_))
+  have hEval : E (x, z) = (Fin.append z x) ∘ Fin.cast (show N - m = s + p by omega) := by
+    simp only [hE, Equiv.trans_apply, Equiv.prodComm_apply, Prod.swap_prod_mk,
+      blockSplitEquiv_symm_apply]
+    rfl
+  rw [hEval,
+    append_glue u (Fin.append z x) (show N - m = s + p by omega)
+      (show N = m + (N - m) by omega) (show N = m + (s + p) by omega),
+    append_glue v (Fin.append z x) (show N - m = s + p by omega)
+      (show N = m + (N - m) by omega) (show N = m + (s + p) by omega),
+    window_eq_prefix_rotate x u z (show N = m + (s + p) by omega) hB,
+    window_eq_prefix_rotate x v z (show N = m + (s + p) by omega) hB,
+    normalizedMPO_comp_finRotate_pow]

--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.AreaLaw
+import TNLean.Entropy.StrongSubadditivity
+import Mathlib.Algebra.BigOperators.Fin
+
+/-!
+# Strong subadditivity for contiguous blocks of an MPDO
+
+This file develops the strong-subadditivity (SSA) inequality specialised to a
+tripartite split of a configuration on `a + b + c` contiguous spins, as the core
+analytic step toward the mutual-information monotonicity of arXiv:1606.00608,
+Proposition (`PropILILp1`, line 801).
+
+The axiomatised SSA (`Entropy.strongSubadditivity`) is stated on a flat product
+index `Fin dA × Fin dB × Fin dC`. The `tripartiteSplitEquiv` cast carries a
+configuration `Fin (a + b + c) → Fin d` onto `Fin (d^a) × Fin (d^b) × Fin (d^c)`,
+and `ssa_cast_ineq` transports SSA through that cast (the entropy of the cast
+state equals the entropy of the original, by reindex invariance). `traceC_corr`
+identifies the tripartite trace over the last factor with the contiguous-block
+reduction keeping the first `a + b` spins.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Proposition
+  (`PropILILp1`, line 801), Appendix proof (line 1319).
+-/
+
+open Matrix
+open scoped Matrix ComplexOrder
+
+/-- The cast carrying a configuration on `a + b + c` contiguous spins onto the
+flat product `Fin (d^a) × Fin (d^b) × Fin (d^c)` used by the strong-subadditivity
+axiom: split into the three contiguous segments, then flatten each. -/
+noncomputable def tripartiteSplitEquiv (d a b c : ℕ) :
+    (Fin (a + b + c) → Fin d) ≃ Fin (d ^ a) × Fin (d ^ b) × Fin (d ^ c) :=
+  (blockSplitEquiv d (a + b) c).trans
+    (((blockSplitEquiv d a b).prodCongr (Equiv.refl _)).trans
+      ((Equiv.prodAssoc _ _ _).trans
+        (finFunctionFinEquiv.prodCongr
+          (finFunctionFinEquiv.prodCongr finFunctionFinEquiv))))
+
+/-- The cast carrying a configuration on `a + b` contiguous spins onto the flat
+product `Fin (d^a) × Fin (d^b)`. -/
+noncomputable def biSplitEquiv (d a b : ℕ) :
+    (Fin (a + b) → Fin d) ≃ Fin (d ^ a) × Fin (d ^ b) :=
+  (blockSplitEquiv d a b).trans (finFunctionFinEquiv.prodCongr finFunctionFinEquiv)
+
+/-- **Strong subadditivity through the contiguous-block cast.** For a trace-one
+positive semidefinite state `σ` on `a + b + c` spins, casting to the flat
+product index and applying the SSA axiom yields
+`S(σ) + S(tr_AC) ≤ S(tr_C) + S(tr_A)`, where the partial traces are taken of the
+cast state. -/
+theorem ssa_cast_ineq {d a b c : ℕ}
+    (σ : Matrix (Fin (a + b + c) → Fin d) (Fin (a + b + c) → Fin d) ℂ)
+    (hσ : σ.PosSemidef) (htr : σ.trace = 1) :
+    vonNeumannEntropy σ hσ.1
+      + vonNeumannEntropy (Matrix.traceAC_ABC (σ.submatrix (tripartiteSplitEquiv d a b c).symm
+            (tripartiteSplitEquiv d a b c).symm))
+          (Matrix.traceAC_ABC_isHermitian (hσ.submatrix _).1)
+    ≤ vonNeumannEntropy (Matrix.traceC_ABC (σ.submatrix (tripartiteSplitEquiv d a b c).symm
+            (tripartiteSplitEquiv d a b c).symm))
+          (Matrix.traceC_ABC_isHermitian (hσ.submatrix _).1)
+      + vonNeumannEntropy (Matrix.traceA_ABC (σ.submatrix (tripartiteSplitEquiv d a b c).symm
+            (tripartiteSplitEquiv d a b c).symm))
+          (Matrix.traceA_ABC_isHermitian (hσ.submatrix _).1) := by
+  set E := tripartiteSplitEquiv d a b c with hE
+  have hcast : (σ.submatrix E.symm E.symm).PosSemidef ∧ (σ.submatrix E.symm E.symm).trace = 1 :=
+    ⟨hσ.submatrix E.symm, by rw [Matrix.trace_submatrix_equiv]; exact htr⟩
+  have ssa := Entropy.strongSubadditivity (σ.submatrix E.symm E.symm) hcast
+  simp only [Entropy.vonNeumannEntropy] at ssa
+  rwa [vonNeumannEntropy_submatrix_equiv E.symm σ hσ.1] at ssa
+
+/-- The tripartite trace over the last factor of the cast state is the
+contiguous-block reduction keeping the first `a + b` spins (reindexed by the
+bi-split cast). -/
+theorem traceC_corr {d a b c : ℕ}
+    (σ : Matrix (Fin (a + b + c) → Fin d) (Fin (a + b + c) → Fin d) ℂ) :
+    Matrix.traceC_ABC (σ.submatrix (tripartiteSplitEquiv d a b c).symm
+        (tripartiteSplitEquiv d a b c).symm)
+      = (blockReducedState d (a + b) c σ).submatrix
+          (biSplitEquiv d a b).symm (biSplitEquiv d a b).symm := by
+  ext ab1 ab2
+  simp only [Matrix.traceC_ABC, Matrix.submatrix_apply, blockReducedState,
+    Matrix.partialTraceRight_apply, tripartiteSplitEquiv, biSplitEquiv,
+    Equiv.symm_trans_apply, Equiv.prodCongr_symm, Equiv.refl_symm,
+    Equiv.prodAssoc_symm_apply, Equiv.prodCongr_apply, Equiv.coe_refl, Prod.map, id_eq]
+  exact Fintype.sum_equiv finFunctionFinEquiv.symm _ _ (fun _ => rfl)

--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -177,3 +177,192 @@ theorem window_block_entropy {d D : ℕ} (M : MPOTensor d D) {N p m s : ℕ} (hB
     window_eq_prefix_rotate x u z (show N = m + (s + p) by omega) hB,
     window_eq_prefix_rotate x v z (show N = m + (s + p) by omega) hB,
     normalizedMPO_comp_finRotate_pow]
+
+/-! ## Block-entropy correspondences and Proposition 4.5 -/
+
+section Prop45
+open Function MPOTensor
+
+/-- Collapsing the last `c` spins: summing the `(a+b+c)`-block reduced state over
+the last `c` spins gives the `(a+b)`-block reduced state. -/
+theorem collapse_last {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ} (h3 : a + b + c ≤ N)
+    (U V : Fin (a + b) → Fin d) :
+    ∑ y : Fin c → Fin d,
+        M.reducedBlockState N (a + b + c) h3 (Fin.append U y) (Fin.append V y)
+      = M.reducedBlockState N (a + b) ((Nat.le_add_right _ c).trans h3) U V := by
+  rw [← reducedBlockState_prefix M h3, blockReducedState, partialTraceRight_apply]
+  simp only [Matrix.submatrix_apply, blockSplitEquiv_symm_apply]
+
+/-- Flattened-index form of `collapse_last`: the sum ranges over `Fin (d ^ c)`. -/
+theorem collapse_last' {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ} (h3 : a + b + c ≤ N)
+    (U V : Fin (a + b) → Fin d) :
+    ∑ c' : Fin (d ^ c),
+        M.reducedBlockState N (a + b + c) h3
+          (Fin.append U (finFunctionFinEquiv.symm c'))
+          (Fin.append V (finFunctionFinEquiv.symm c'))
+      = M.reducedBlockState N (a + b) ((Nat.le_add_right _ c).trans h3) U V := by
+  rw [← collapse_last M h3 U V]
+  exact Fintype.sum_equiv finFunctionFinEquiv.symm _ _ (fun _ => rfl)
+
+/-- Collapsing the first `a` spins (translation invariance): summing the
+`(a+b)`-block reduced state over the first `a` spins gives the `b`-block reduced
+state. -/
+theorem collapse_first {d D : ℕ} (M : MPOTensor d D) {N a b : ℕ} (hab : a + b ≤ N)
+    (B1 B2 : Fin b → Fin d) :
+    ∑ a' : Fin (d ^ a),
+        M.reducedBlockState N (a + b) hab
+          (Fin.append (finFunctionFinEquiv.symm a') B1)
+          (Fin.append (finFunctionFinEquiv.symm a') B2)
+      = M.reducedBlockState N b (by omega) B1 B2 := by
+  rw [← window_block_entropy M (show N = a + b + (N - (a + b)) by omega) B1 B2]
+  rw [Fintype.sum_equiv finFunctionFinEquiv.symm _
+    (fun x => M.reducedBlockState N (a + b) hab (Fin.append x B1) (Fin.append x B2))
+    (fun _ => rfl)]
+  refine Finset.sum_congr rfl (fun x _ => ?_)
+  rw [reducedBlockState_eq_sum]
+
+/-- **traceC correspondence.** Tracing the third tripartite factor of the cast
+reduced state recovers the `(a+b)`-block reduced state. -/
+theorem traceC_mat {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ} (h3 : a + b + c ≤ N) :
+    Matrix.traceC_ABC ((M.reducedBlockState N (a + b + c) h3).submatrix
+        (tripartiteSplitEquiv d a b c).symm (tripartiteSplitEquiv d a b c).symm)
+      = (M.reducedBlockState N (a + b) ((Nat.le_add_right _ c).trans h3)).submatrix
+          (biSplitEquiv d a b).symm (biSplitEquiv d a b).symm := by
+  rw [traceC_corr, reducedBlockState_prefix]
+
+/-- **traceAC correspondence.** Tracing the first and third tripartite factors of
+the cast reduced state recovers the middle `b`-block reduced state (translation
+invariance moves the middle block to the front). -/
+theorem traceAC_mat {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ} (h3 : a + b + c ≤ N) :
+    ∃ e : Fin (d ^ b) ≃ (Fin b → Fin d),
+      Matrix.traceAC_ABC ((M.reducedBlockState N (a + b + c) h3).submatrix
+        (tripartiteSplitEquiv d a b c).symm (tripartiteSplitEquiv d a b c).symm)
+      = (M.reducedBlockState N b (le_trans (by omega) h3)).submatrix e e := by
+  refine ⟨finFunctionFinEquiv.symm, ?_⟩
+  ext b1 b2
+  simp only [Matrix.submatrix_apply, Matrix.traceAC_ABC, tripartiteSplitEquiv,
+    Equiv.symm_trans_apply, Equiv.prodCongr_symm, Equiv.refl_symm, Equiv.prodAssoc_symm_apply,
+    Equiv.prodCongr_apply, Equiv.coe_refl, Prod.map, id_eq, blockSplitEquiv_symm_apply]
+  rw [Finset.sum_congr rfl (fun a' _ => collapse_last' M h3
+    (Fin.append (finFunctionFinEquiv.symm a') (finFunctionFinEquiv.symm b1))
+    (Fin.append (finFunctionFinEquiv.symm a') (finFunctionFinEquiv.symm b2)))]
+  rw [collapse_first M (by omega)]
+
+/-- Reduced block state is invariant under a length-cast of the kept config. -/
+theorem reducedBlockState_cast {d D : ℕ} (M : MPOTensor d D) {N k k' : ℕ} (h : k' = k)
+    (hk : k ≤ N) (W W' : Fin k → Fin d) :
+    M.reducedBlockState N k hk W W'
+      = M.reducedBlockState N k' (by omega) (W ∘ Fin.cast h) (W' ∘ Fin.cast h) := by
+  subst h; rfl
+
+theorem append_assoc_cast {d a b c : ℕ} (A' : Fin a → Fin d) (B1 : Fin b → Fin d)
+    (C1 : Fin c → Fin d) :
+    (Fin.append (Fin.append A' B1) C1) ∘ Fin.cast (show a + (b + c) = a + b + c by omega)
+      = Fin.append A' (Fin.append B1 C1) := by
+  rw [Fin.append_assoc]
+  funext i
+  simp only [Function.comp_apply, Fin.cast_cast, Fin.cast_eq_self]
+
+/-- **traceA correspondence.** Tracing the first tripartite factor of the cast
+reduced state recovers the `(b+c)`-block reduced state (translation invariance
+moves the kept suffix block to the front). -/
+theorem traceA_mat {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ} (h3 : a + b + c ≤ N) :
+    ∃ e : Fin (d ^ b) × Fin (d ^ c) ≃ (Fin (b + c) → Fin d),
+      Matrix.traceA_ABC ((M.reducedBlockState N (a + b + c) h3).submatrix
+        (tripartiteSplitEquiv d a b c).symm (tripartiteSplitEquiv d a b c).symm)
+      = (M.reducedBlockState N (b + c) (le_trans (by omega) h3)).submatrix e e := by
+  refine ⟨(finFunctionFinEquiv.symm.prodCongr finFunctionFinEquiv.symm).trans
+    (blockSplitEquiv d b c).symm, ?_⟩
+  ext bc1 bc2
+  obtain ⟨b1, c1⟩ := bc1
+  obtain ⟨b2, c2⟩ := bc2
+  simp only [Matrix.submatrix_apply, Matrix.traceA_ABC, tripartiteSplitEquiv,
+    Equiv.symm_trans_apply, Equiv.prodCongr_symm, Equiv.refl_symm, Equiv.prodAssoc_symm_apply,
+    Equiv.prodCongr_apply, Equiv.coe_refl, Prod.map, id_eq, blockSplitEquiv_symm_apply,
+    Equiv.trans_apply]
+  rw [Finset.sum_congr rfl (fun a' _ => by
+    rw [reducedBlockState_cast M (show a + (b + c) = a + b + c by omega),
+      append_assoc_cast, append_assoc_cast])]
+  rw [collapse_first M (a := a) (b := b + c) (by omega)]
+
+/-- von Neumann entropy congruence in the matrix argument (proof-irrelevant in the
+Hermiticity witness). -/
+theorem vonNeumannEntropy_congr {n : Type*} [Fintype n] [DecidableEq n]
+    {ρ₁ ρ₂ : Matrix n n ℂ} (h : ρ₁ = ρ₂) (hρ₁ : ρ₁.IsHermitian) (hρ₂ : ρ₂.IsHermitian) :
+    vonNeumannEntropy ρ₁ hρ₁ = vonNeumannEntropy ρ₂ hρ₂ := by
+  subst h; rfl
+
+/-- Block entropy is congruent in the block length. -/
+theorem blockEntropy_congr {d D : ℕ} (M : MPOTensor d D) (N : ℕ) {j k : ℕ} (h : j = k)
+    (hj : j ≤ N) (hk : k ≤ N) (hM : (mpo M N).PosSemidef) :
+    M.blockEntropy N j hj hM = M.blockEntropy N k hk hM := by
+  subst h; rfl
+
+/-- The reduced block state of the normalized MPO has unit trace. -/
+theorem reducedBlockState_trace {d D : ℕ} (M : MPOTensor d D) (N L : ℕ) (hL : L ≤ N)
+    (htr : (mpo M N).trace ≠ 0) :
+    (M.reducedBlockState N L hL).trace = 1 := by
+  rw [MPOTensor.reducedBlockState, blockReducedState_trace, Matrix.trace_submatrix_equiv,
+    normalizedMPO_trace M N htr]
+
+/-- **Strong subadditivity in block-entropy form.** For contiguous segments of
+sizes `a`, `b`, `c` fitting in the chain, the block entropies obey
+`S_{a+b+c} + S_b ≤ S_{a+b} + S_{b+c}`. This is one application of strong
+subadditivity to the normalized MPDO state (arXiv:1606.00608, Prop 4.5 appendix). -/
+theorem ssa_block_entropy {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ} (h3 : a + b + c ≤ N)
+    (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
+    M.blockEntropy N (a + b + c) h3 hM + M.blockEntropy N b (le_trans (by omega) h3) hM
+      ≤ M.blockEntropy N (a + b) ((Nat.le_add_right _ c).trans h3) hM
+        + M.blockEntropy N (b + c) (le_trans (by omega) h3) hM := by
+  set σ := M.reducedBlockState N (a + b + c) h3 with hσdef
+  have hσ : σ.PosSemidef := reducedBlockState_posSemidef M N (a + b + c) h3 hM
+  have htr1 : σ.trace = 1 := reducedBlockState_trace M N (a + b + c) h3 htr
+  have ssa := ssa_cast_ineq σ hσ htr1
+  obtain ⟨eAC, hAC⟩ := traceAC_mat M h3
+  obtain ⟨eA, hA⟩ := traceA_mat M h3
+  have hEσ : vonNeumannEntropy σ hσ.1 = M.blockEntropy N (a + b + c) h3 hM :=
+    vonNeumannEntropy_congr rfl _ _
+  have hEC : vonNeumannEntropy (Matrix.traceC_ABC (σ.submatrix
+        (tripartiteSplitEquiv d a b c).symm (tripartiteSplitEquiv d a b c).symm))
+        (Matrix.traceC_ABC_isHermitian (hσ.submatrix _).1)
+      = M.blockEntropy N (a + b) ((Nat.le_add_right _ c).trans h3) hM := by
+    rw [vonNeumannEntropy_congr (traceC_mat M h3) _
+      (((reducedBlockState_isHermitian M N (a + b) _ hM)).submatrix _),
+      vonNeumannEntropy_submatrix_equiv]
+    rfl
+  have hEAC : vonNeumannEntropy (Matrix.traceAC_ABC (σ.submatrix
+        (tripartiteSplitEquiv d a b c).symm (tripartiteSplitEquiv d a b c).symm))
+        (Matrix.traceAC_ABC_isHermitian (hσ.submatrix _).1)
+      = M.blockEntropy N b (le_trans (by omega) h3) hM := by
+    rw [vonNeumannEntropy_congr hAC _
+      (((reducedBlockState_isHermitian M N b _ hM)).submatrix _),
+      vonNeumannEntropy_submatrix_equiv]
+    rfl
+  have hEA : vonNeumannEntropy (Matrix.traceA_ABC (σ.submatrix
+        (tripartiteSplitEquiv d a b c).symm (tripartiteSplitEquiv d a b c).symm))
+        (Matrix.traceA_ABC_isHermitian (hσ.submatrix _).1)
+      = M.blockEntropy N (b + c) (le_trans (by omega) h3) hM := by
+    rw [vonNeumannEntropy_congr hA _
+      (((reducedBlockState_isHermitian M N (b + c) _ hM)).submatrix _),
+      vonNeumannEntropy_submatrix_equiv]
+    rfl
+  rw [hEσ, hEC, hEAC, hEA] at ssa
+  linarith [ssa]
+
+/-- **Proposition 4.5 (arXiv:1606.00608): monotonicity of the mutual information.**
+For a normalizable periodic MPDO state and `2L + 1 ≤ N` (i.e. `L < ⌊N/2⌋`), the
+mutual information of an `L`-block is nondecreasing: `I_L ≤ I_{L+1}`. -/
+theorem mutualInfoChain_monotone {d D : ℕ} (M : MPOTensor d D) {N L : ℕ} (hN : 2 * L + 1 ≤ N)
+    (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
+    M.mutualInfoChain N L (by omega) hM
+      ≤ M.mutualInfoChain N (L + 1) (by omega) hM := by
+  have key := ssa_block_entropy M (a := 1) (b := L) (c := N - 2 * L - 1) (by omega) hM htr
+  rw [blockEntropy_congr M N (show 1 + L + (N - 2 * L - 1) = N - L by omega) _
+        (Nat.sub_le N L) hM,
+      blockEntropy_congr M N (show (1 : ℕ) + L = L + 1 by omega) _ (by omega) hM,
+      blockEntropy_congr M N (show L + (N - 2 * L - 1) = N - (L + 1) by omega) _
+        (Nat.sub_le N (L + 1)) hM] at key
+  simp only [MPOTensor.mutualInfoChain]
+  linarith [key]
+
+end Prop45

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3045,7 +3045,7 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mutual_info_chain}
     Let $M$ generate an MPDO whose finite-chain operator $\rho^{(N)}(M)$ is
     positive semidefinite with nonzero trace. For every block length $L$ with
-    $2L+1\le N$, equivalently $1\le L<\lfloor N/2\rfloor$,
+    $2L+1\le N$ (covering the range $1\le L<\lfloor N/2\rfloor$),
     \[
         I_L \le I_{L+1}.
     \]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3038,6 +3038,31 @@ the elementary trace-power identity for diagonal matrices.
     This is \cite[Definition~4.6, line~811]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{proposition}[Monotonicity of the mutual information]
+    \label{prop:mutual_info_monotone}
+    \lean{mutualInfoChain_monotone}
+    \leanok
+    \uses{def:mutual_info_chain}
+    Let $M$ generate an MPDO whose finite-chain operator $\rho^{(N)}(M)$ is
+    positive semidefinite with nonzero trace. For every block length $L$ with
+    $2L+1\le N$, equivalently $1\le L<\lfloor N/2\rfloor$,
+    \[
+        I_L \le I_{L+1}.
+    \]
+    This is \cite[Proposition~4.5, line~801]{Cirac2016MPDO_arXiv}.
+\end{proposition}
+\begin{proof}\leanok
+    \uses{thm:entropy_strong_subadditivity, def:block_entropy}
+    Apply strong subadditivity to the reduced state of the first $N-L$ spins,
+    split into three contiguous segments of lengths $1$, $L$, and $N-2L-1$.
+    Tracing the appropriate segments yields the four block entropies
+    $S_{N-L}$, $S_L$, $S_{L+1}$, and $S_{N-L-1}$, where the cyclic invariance of
+    $\rho^{(N)}(M)$ identifies the entropy of a contiguous block with that of any
+    block of the same length. Strong subadditivity then gives
+    $S_{N-L} + S_L \le S_{L+1} + S_{N-L-1}$, which rearranges to
+    $I_L \le I_{L+1}$ after subtracting $S_N$.
+\end{proof}
+
 \begin{definition}[Block entropy and area-law saturation for pure states]
     \label{def:pure_sal}
     \lean{MPSTensor.pureBlockEntropy, MPSTensor.IsSAL}


### PR DESCRIPTION
## Summary

Completes **arXiv:1606.00608 Proposition 4.5** (`PropILILp1`, line 801): for a
normalizable periodic MPDO and `2L + 1 ≤ N` (i.e. `L < ⌊N/2⌋`), the `L`-block
mutual information is nondecreasing,
$$I_L \le I_{L+1}, \qquad I_L = S_L + S_{N-L} - S_N.$$

This is the last open piece of issue #2424. The proof is **sorry-free and
introduces no new axioms** (it uses the pre-existing `Entropy.strongSubadditivity`).

## Proof structure

The appendix proof applies strong subadditivity once, to the reduced state of the
first `N-L` spins split into contiguous segments of lengths `a=1`, `b=L`,
`c=N-2L-1`, and uses cyclic invariance to identify the entropy of a contiguous
block with that of any block of the same length.

- **`window_eq_prefix_rotate`** / **`append_comp_finRotate_pow`** / **`cast_comp_finRotate_pow`** —
  the configuration-level translation invariance: a middle block equals a front
  block after a cyclic shift by the prefix length (built on the existing
  `mpo_submatrix_finRotate_pow`).
- **`window_block_entropy`** — the reduced state keeping a contiguous `m`-block
  with `p` spins before and `s` after equals the reduced state keeping the first
  `m` spins.
- **`traceC_mat` / `traceAC_mat` / `traceA_mat`** — the three tripartite-trace
  sides of the SSA inequality equal the `(a+b)`-, `b`-, and `(b+c)`-block reduced
  states (traceAC/traceA via `collapse_first`, traceC via `reducedBlockState_prefix`).
- **`ssa_block_entropy`** — `S_{a+b+c} + S_b ≤ S_{a+b} + S_{b+c}` from one SSA
  application.
- **`mutualInfoChain_monotone`** — instantiates `a=1, b=L, c=N-2L-1` and rearranges.

## Faithfulness

The hypotheses are `(mpo M N).PosSemidef` and `(mpo M N).trace ≠ 0` — exactly the
standing assumption that `ρ^{(N)}(M)` is a normalizable MPDO state, matching the
source. No extra hypotheses are smuggled in.

## Blueprint

Adds `prop:mutual_info_monotone` to `ch02b_mpdo.tex` with `\lean{}`/`\leanok`;
`leanblueprint checkdecls` resolves it.

## Build

`lake build` passes (8776 jobs); no `sorry`/`admit`/new `axiom`.

Closes #2424.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New sorry-free Lean proofs on entropy/block reductions; relies on existing `Entropy.strongSubadditivity` axiom only. No auth or runtime behavior changes.
> 
> **Overview**
> Formalizes **arXiv:1606.00608 Proposition 4.5**: for a normalizable periodic MPDO with `2L + 1 ≤ N`, chain mutual information is nondecreasing, `I_L ≤ I_{L+1}`.
> 
> **`TNLean/MPS/MPDO/MutualInfoMonotone.lean`** (new) applies axiomatized strong subadditivity to a tripartite contiguous split via `tripartiteSplitEquiv`, then relates tripartite traces to `blockEntropy` through `ssa_block_entropy`. The capstone is **`mutualInfoChain_monotone`**, instantiating `a = 1`, `b = L`, `c = N - 2L - 1`.
> 
> **`AreaLaw.lean`** adds infrastructure used by that proof: `p`-fold cyclic shift invariance of MPO entries (`mpoMatrixEntry_comp_finRotate_pow`, `mpo_submatrix_finRotate_pow`); configuration lemmas (`append_comp_finRotate_pow`, `window_eq_prefix_rotate`); and contiguous-block reduction facts (`blockReducedState_comp`, `blockReducedState_submatrix_finCongr`, `blockSplitEquiv_symm_apply`).
> 
> **`TNLean.lean`** imports the new module. **Blueprint** `ch02b_mpdo.tex` adds `prop:mutual_info_monotone` linked to `mutualInfoChain_monotone`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2fa13bcf94d1683773db925ccb159bbad8e3aba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->