### PR TITLE
doc(mpdo): correct Proposition 4.5 range prose

### DIFF
--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -350,8 +350,9 @@ theorem ssa_block_entropy {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ} (h3 : 
   linarith [ssa]
 
 /-- **Proposition 4.5 (arXiv:1606.00608): monotonicity of the mutual information.**
-For a normalizable periodic MPDO state and `2L + 1 ≤ N` (i.e. `L < ⌊N/2⌋`), the
-mutual information of an `L`-block is nondecreasing: `I_L ≤ I_{L+1}`. -/
+For a normalizable periodic MPDO state and `2 * L + 1 ≤ N`, the mutual information
+of an `L`-block is nondecreasing: `I_L ≤ I_{L+1}`. This condition contains the
+source range `1 ≤ L < ⌊N / 2⌋`. -/
 theorem mutualInfoChain_monotone {d D : ℕ} (M : MPOTensor d D) {N L : ℕ} (hN : 2 * L + 1 ≤ N)
     (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
     M.mutualInfoChain N L (by omega) hM

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3045,11 +3045,16 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:mutual_info_chain}
     Let $M$ generate an MPDO whose finite-chain operator $\rho^{(N)}(M)$ is
     positive semidefinite with nonzero trace. For every block length $L$ with
-    $2L+1\le N$ (covering the range $1\le L<\lfloor N/2\rfloor$),
+    $2L+1\le N$,
     \[
         I_L \le I_{L+1}.
     \]
-    This is \cite[Proposition~4.5, line~801]{Cirac2016MPDO_arXiv}.
+    The implication
+    \[
+        1\le L<\lfloor N/2\rfloor \quad\Longrightarrow\quad 2L+1\le N
+    \]
+    shows that this contains the range of
+    \cite[Proposition~4.5, line~801]{Cirac2016MPDO_arXiv}.
 \end{proposition}
 \begin{proof}\leanok
     \uses{thm:entropy_strong_subadditivity, def:block_entropy}


### PR DESCRIPTION
## Summary
- state the monotonicity range as the displayed condition \(2L+1\le N\) without identifying it with the source range
- add the implication \(1\le L<\lfloor N/2\rfloor\Rightarrow 2L+1\le N\), so the blueprint records that the formal statement contains the cited range
- make the matching Lean docstring use the same range relation rather than the false equivalence

Closes #2468.

## Checks
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `cd blueprint && leanblueprint web`
- `lake exe cache get`
- `lake build TNLean.MPS.MPDO.MutualInfoMonotone`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files $changed`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (reports the pre-existing missing references `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and `...` in `ch04a_channel_representations.tex`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX prose only; no changes to proofs, hypotheses, or runtime behavior.
> 
> **Overview**
> **Documentation alignment** for mutual-information monotonicity (Proposition 4.5 / `mutualInfoChain_monotone`): prose no longer equates the theorem’s range with the paper’s `1 ≤ L < ⌊N/2⌋`.
> 
> The **Lean docstring** on `mutualInfoChain_monotone` now states the hypothesis as **`2 * L + 1 ≤ N`** and notes that this **contains** the source range `1 ≤ L < ⌊N / 2⌋`, instead of describing `2L+1 ≤ N` as “i.e. `L < ⌊N/2⌋`”.
> 
> The **blueprint** (`ch02b_mpdo.tex`, Proposition on monotonicity) matches: the displayed condition is **`2L+1 ≤ N`**, with a separate implication **`1 ≤ L < ⌊N/2⌋ ⇒ 2L+1 ≤ N`** explaining how the formal statement **subsumes** the cited arXiv range. **No proof or type changes** in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb29b1a18ac28cdcb35799410418535e6f1611d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->