### PR TITLE
doc(parent): narrow boundary-closing source citations

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -330,7 +330,7 @@ boundary condition \(\tau\),
 
 These are one-sided coordinate consequences of the cyclic-window constraints
 used to model the boundary-closing argument. The source paragraph in
-arXiv:2011.12127, Section IV.C, lines 2078--2090, states the corresponding
+arXiv:2011.12127, Section IV.C, lines 2078--2079, states the corresponding
 closure-property step, but does not display these coordinate equations. -/
 theorem closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -425,7 +425,7 @@ For \(L_0=1\) both products are empty.
 
 This records one adjacent-window product identity used in the coordinate proof
 of the closure property described in arXiv:2011.12127, Section IV.C,
-lines 2078--2090. -/
+lines 2078--2079. -/
 theorem boundary_closing_endpoint_word_products_common_background
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -481,7 +481,7 @@ For \(L_0=1\), both word products are empty.
 
 This records the fixed-boundary-condition product obtained from adjacent
 windows in the coordinate proof of the closure property described in
-arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
+arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
 theorem closure_property_boundary_condition_product_of_window_witnesses
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -531,7 +531,7 @@ For a fixed boundary condition \(\rho\), the window matrices satisfy
 with the products read cyclically and with \(M+2-L_0\) one-site factors on
 each side.  This is an adjacent-window product used to reconstruct the closure
 property described in arXiv:2011.12127, Section IV.C,
-lines 2078--2090. -/
+lines 2078--2079. -/
 lemma closure_property_boundary_condition_long_product_of_window_witnesses
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -440,7 +440,7 @@ After the cyclic-to-open-chain step writes a periodic-chain vector as
 boundary expose the boundary matrix \(X\) on opposite sides of the same
 length \(N-(L₀+1)\) complement word. This theorem gives the local algebraic
 output needed for the remaining boundary-closing comparison
-(arXiv:2011.12127, Section IV.C, lines 2078--2090). -/
+(arXiv:2011.12127, Section IV.C, lines 2078--2079). -/
 theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -598,7 +598,7 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_co
     (A := A) (L₀ := L₀) (m := N - (L₀ + 1)) (N := N) hInj hL₀ Y hLeft hRight
 
 /-- Closure-property step for periodic chains in arXiv:2011.12127,
-Section IV.C, lines 2078--2090.
+Section IV.C, lines 2078--2079.
 
 The cyclic-to-open-chain reduction produces a boundary matrix \(X\). The two
 boundary-crossing local constraints give
@@ -669,7 +669,7 @@ theorem wrapped_mirror_witness_agree_of_right_products
 after fixing each first physical index:
 \((\forall j,\ R_jB^+_{\eta,\mu}=R_jB^-_{\eta,\mu})
 \Rightarrow B^+_{\eta,\mu}=B^-_{\eta,\mu}\).  This is a coordinate form of
-the comparison described in arXiv:2011.12127, Section IV.C, lines 2078--2090. -/
+the comparison described in arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
 theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
     {L₀ M : ℕ} (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
     {ψ : NSiteSpace d (M + 1)}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2116,7 +2116,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
     For every boundary letter $\eta$ and complementary word $\mu$, the local
     coordinate restriction equality representing the boundary-closing step of
-    \cite[lines~2078--2090]{Cirac2021Matrix} is
+    \cite[lines~2078--2079]{Cirac2021Matrix} is
     \[
         \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
         =


### PR DESCRIPTION
## Summary
- narrow coordinate-lemma citations for the boundary-closing step from arXiv:2011.12127 lines 2078--2090 to lines 2078--2079
- keep theorem-level citations to the later theorem statement unchanged
- preserve the current #2405 proof obligation: the boundary-closing cyclic restriction equality remains the open comparison

Related to #2405.

## Checks
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `cd blueprint && leanblueprint web`
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState` (passes with the existing #2405 `sorry` warning in `BoundaryClosingStripping.lean`)
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files $changed`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (reports the pre-existing missing references `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and `...` in `ch04a_channel_representations.tex`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint citation edits only; no executable or proof logic changes.
> 
> **Overview**
> Narrows **coordinate-level** citations for the boundary-closing / closure-property step from arXiv:2011.12127 Section IV.C **lines 2078--2090** to **2078--2079**, so docstrings and the blueprint lemma track the specific source paragraph rather than the wider line span.
> 
> Updates appear in `BoundaryClosing.lean` and `UniqueGroundState.lean` doc comments (wrapped/mirror compatibilities, window products, chain boundary compatibilities, closure-property comparison) and in `blueprint/src/chapter/ch14_parent_hamiltonian.tex` (`\cite[lines~2078--2079]{Cirac2021Matrix}`). **No Lean proofs or statements change.**
> 
> Broader theorem-level references that cite the full **2078--2090** block (e.g. normal range-reduction theorems) are **left unchanged**, per the PR intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cdcf1baab65f18f2bc3f7c8e4389e2997f9f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->