### PR TITLE
doc(peps): clarify region recovery normalization

### DIFF
--- a/TNLean/PEPS/RegionBlock/Realization.lean
+++ b/TNLean/PEPS/RegionBlock/Realization.lean
@@ -6,11 +6,11 @@ import TNLean.PEPS.InsertionAlgebra
 # Region physical realization and the region insertion transfer
 
 For a boundary edge `f` of an arbitrary finite region `R`, with single in-region
-endpoint vertex `v`, this file realizes the region-inserted matrix insertion on
-`f` as a physical operator at `v` and transfers it across `SameState` to build the
-region analogue of `edgeTransferMatrix`. This supplies the data of a
-`RegionInsertionTransfer` on `f`, the last gating ingredient of the per-edge gauge
-for the normal PEPS Fundamental Theorem.
+endpoint vertex `v`, this file develops the physical realization at `v` needed
+for the region analogue of `edgeTransferMatrix`. The transfer itself is still
+the remaining physical-to-virtual step: one must show that the physical operator
+obtained from an inserted boundary-edge matrix for `A`, when carried across
+`SameState`, is again a one-edge matrix insertion for `B`.
 
 The development mirrors `TNLean.PEPS.InsertionAlgebra` piece by piece, with the
 single in-region endpoint vertex `v` playing the role of the edge's right
@@ -18,14 +18,13 @@ endpoint:
 
 * `regionBoundaryEdgeInVertex` is the in-region endpoint of a boundary edge; the
   edge is read as an incident edge `regionBoundaryEdgeInIncident` at that vertex.
-* `regionRealizationSum_eq_regionInsertedCoeff` is the region analogue of
-  `edgeRealizationSum_right_eq_sum_edgeBlockedCoeff`: the region-inserted
-  coefficient equals a realization sum over physical configurations at `v`, with
-  the inserted matrix carried by a physical operator at `v`.
-* `regionRightInsertionOp` is the region analogue of `edgeRightInsertionOp`: the
-  physical operator at `v` realizing the matrix insertion on `f`.
-* `regionTransferMatrix` is the region analogue of `edgeTransferMatrix`: the
-  matrix read off after transferring the realization across `SameState`.
+* `regionStateVec_eq_localTensorMap` is the region analogue of the endpoint
+  factorization used in the \(X\mapsto O_1,O_2\) step: the closed state
+  coefficient, with the physical leg at `v` left open, lies in the image of the
+  local tensor map at `v`.
+* The missing recovery must still read off the corresponding matrix after
+  transferring such a physical realization across `SameState`; its expected
+  output is a `RegionInsertionTransfer`.
 
 ## References
 

--- a/TNLean/PEPS/RegionBlock/Recovery.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery.lean
@@ -21,11 +21,19 @@ region side from the first and the complement side from the second
 double sum as overcounting the closed state coefficient by the bond-dimension
 product over the non-boundary edges (`regionInteriorBondProd`).
 
-The remaining step toward the region insertion transfer -- collapsing the
-boundary-agreement double sum to `regionInteriorBondProd` times the closed state
-coefficient, and the full physical realization of a boundary-edge matrix
-insertion at the in-region endpoint vertex -- is recorded as remaining obligation
-4 of `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+The identity insertion is now reduced to the equation
+\[
+  C_A(R,f,1;\sigma,\tau)
+    = \Bigl(\prod_{e\notin\partial R}D_A(e)\Bigr)\,
+      \langle \sigma,\tau \mid \Psi_A\rangle .
+\]
+Here \(D_A(e)\) is the bond dimension of the edge \(e\), and the product is over
+the edges not crossing the boundary of `R`.
+The remaining step toward the region insertion transfer is the corresponding
+physical-to-virtual recovery for an arbitrary boundary-edge matrix insertion at
+the in-region endpoint vertex, with this normalization kept visible; it is
+recorded as remaining obligation 4 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 ## References
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -386,11 +386,37 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.regionProd_eq_merge},
           \leanid{TNLean.PEPS.complementProd_eq_merge}) exhibits the double sum as
           overcounting the closed state coefficient by the bond-dimension product
-          over the non-boundary edges (\leanid{TNLean.PEPS.regionInteriorBondProd}).
-          The two outstanding pieces are the cardinality collapse of that double
-          sum to \leanid{TNLean.PEPS.regionInteriorBondProd} times the closed
-          state coefficient, and the physical realization of a boundary-edge
-          matrix insertion at the in-region endpoint vertex.
+          over the non-boundary edges
+          (\leanid{TNLean.PEPS.regionInteriorBondProd}); the cardinality collapse
+          is formalized in
+          \leanid{TNLean.PEPS.stateCoeff_eq_regionComplement}. Consequently the
+          identity insertion is now the proved equation. Here
+          \(C_A(R,f,X;\sigma,\tau)\) denotes the region inserted coefficient for
+          the tensor \(A\), the region \(R\), the boundary edge \(f\), the boundary
+          matrix \(X\), the region physical configuration \(\sigma\), and the
+          complement physical configuration \(\tau\). The symbol \(D_A(e)\)
+          denotes the bond dimension of the edge \(e\), \(\partial R\) denotes the
+          set of boundary edges of \(R\), and
+          \(\langle\sigma,\tau\mid\Psi_A\rangle\) denotes the closed-state
+          coefficient of the assembled physical configuration:
+          \[
+              C_A(R,f,1;\sigma,\tau)
+              =
+              \Bigl(\prod_{e\notin \partial R} D_A(e)\Bigr)
+              \langle \sigma,\tau \mid \Psi_A\rangle
+          \]
+          (\leanid{TNLean.PEPS.regionInsertedCoeff_one_eq_stateCoeff}). The
+          remaining piece is the matrix-insertion version of the same
+          physical-to-virtual recovery. For a second tensor \(B\), \(T_f(X)\)
+          denotes the boundary matrix assigned to \(X\) on the edge \(f\) by the
+          desired region insertion transfer. One must construct \(T_f\) from
+          \(\operatorname{SameState}(A,B)\), prove that it matches
+          \(C_A(R,f,X;\sigma,\tau)\) with \(C_B(R,f,T_f(X);\sigma,\tau)\), and
+          prove the multiplicativity and unit conditions required by
+          \leanid{TNLean.PEPS.RegionInsertionTransfer}. The identity equation
+          shows why this cannot be treated as a bare equality of closed-state
+          coefficients; the factor \(\prod_{e\notin\partial R}D_A(e)\) must be
+          accounted for in the region recovery.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.


### PR DESCRIPTION
## Summary
- replace stale prose saying the identity-insertion cardinality collapse was still open
- record the proved identity equation C_A(R,f,1;σ,τ) = (∏_{e∉∂R} D_A(e)) ⟨σ,τ | Ψ_A⟩
- state the remaining #2470 task as the matrix-insertion physical-to-virtual recovery producing RegionInsertionTransfer

## Checks
- git diff --check
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/feat/peps-region-realize --ci
- lake build TNLean.PEPS.RegionBlock.Realization -q --log-level=info

Related to #2470.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and module docstring edits only; no proof or runtime behavior changes.
> 
> **Overview**
> Updates **reader-facing documentation** so it matches the current formalization status for region boundary recovery (#2470), without changing Lean proofs.
> 
> **`Recovery.lean` and `Realization.lean` module docs** no longer treat the identity-insertion cardinality collapse or full transfer construction as open. They record the proved identity normalization \(C_A(R,f,1;\sigma,\tau) = (\prod_{e\notin\partial R} D_A(e))\,\langle\sigma,\tau \mid \Psi_A\rangle\) and frame the remaining work as **matrix-insertion** physical-to-virtual recovery (building `RegionInsertionTransfer` across `SameState`), with endpoint factorization via `regionStateVec_eq_localTensorMap` called out in `Realization.lean`.
> 
> **`peps_normal_ft_section3_route.tex`** obligation 4 is rewritten accordingly: cites `stateCoeff_eq_regionComplement` and `regionInsertedCoeff_one_eq_stateCoeff` for the identity case, and spells out what is still required for general \(X\) (construct \(T_f\) from `SameState`, coefficient matching, and `RegionInsertionTransfer` axioms), including why the interior bond-dimension product must appear in the recovery—not a bare closed-state coefficient equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3f11312834b21a3f0d30da8fac2eca317ea4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->