### PR TITLE
feat(Analysis/Entropy): von Neumann entropy of A*B equals that of B*A

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -114,6 +114,31 @@ theorem vonNeumannEntropy_submatrix_equiv (e : m ≃ n) (ρ : Matrix n n ℂ)
   have hre : ρ.submatrix e e = reindex e.symm e.symm ρ := rfl
   rw [hre, charpoly_reindex]
 
+/-- **Entropy of `A·B` equals entropy of `B·A`.** The von Neumann entropy is
+unchanged under the cyclic swap of a (possibly rectangular) product: the
+characteristic polynomials of `A * B` and `B * A` differ only by a power of `X`,
+i.e. by extra eigenvalues equal to `0`, which contribute `negMulLog 0 = 0`. This
+is the spectral form of the Schmidt symmetry of complementary reductions of a
+pure state. -/
+theorem vonNeumannEntropy_mul_comm (A : Matrix m n ℂ) (B : Matrix n m ℂ)
+    (hAB : (A * B).IsHermitian) (hBA : (B * A).IsHermitian) :
+    vonNeumannEntropy (A * B) hAB = vonNeumannEntropy (B * A) hBA := by
+  rw [vonNeumannEntropy_eq_charpoly_roots, vonNeumannEntropy_eq_charpoly_roots]
+  set f : ℂ → ℝ := fun z => Real.negMulLog z.re with hf
+  have hroots : (Polynomial.X ^ Fintype.card n * (A * B).charpoly).roots
+      = (Polynomial.X ^ Fintype.card m * (B * A).charpoly).roots := by
+    rw [Matrix.charpoly_mul_comm']
+  rw [Polynomial.roots_mul
+        (mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero) (Matrix.charpoly_monic _).ne_zero),
+      Polynomial.roots_mul
+        (mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero) (Matrix.charpoly_monic _).ne_zero),
+      Polynomial.roots_pow, Polynomial.roots_pow, Polynomial.roots_X] at hroots
+  have hf0 : f 0 = 0 := by simp [hf]
+  have key := congrArg (fun s => (Multiset.map f s).sum) hroots
+  simp only [Multiset.map_add, Multiset.sum_add, Multiset.map_nsmul, Multiset.sum_nsmul,
+    Multiset.map_singleton, Multiset.sum_singleton, hf0, smul_zero, zero_add] at key
+  exact key
+
 end VonNeumannEntropy
 
 /-! ### Basic properties for density matrices -/


### PR DESCRIPTION
## Summary

`vonNeumannEntropy_mul_comm`: for (possibly rectangular) `A : Matrix m n ℂ`,
`B : Matrix n m ℂ` with `A * B` and `B * A` Hermitian,
$$S(A B) = S(B A).$$

The characteristic polynomials of `A*B` and `B*A` differ only by a power of `X`
(`Matrix.charpoly_mul_comm'`: `X^|n| · χ_{AB} = X^|m| · χ_{BA}`), i.e. by extra
eigenvalues equal to `0`, which contribute `negMulLog 0 = 0` to the entropy sum
(via `vonNeumannEntropy_eq_charpoly_roots`).

## Why

This is the spectral form of the **Schmidt symmetry** `S_L = S_{N-L}` of
complementary reductions of a pure state (`ρ_A = M Mᴴ`, `ρ_B = Mᴴ M`). It is the
remaining ingredient for the arXiv:1606.00608 §3 pure-state area-law
monotonicity `S_L ≤ S_{L+1}` (which then follows from the already-merged
`ssa_block_entropy` plus the doubled-tensor purification bridge #2473).

A general, reusable addition to the entropy library.

## Build

`TNLean.Analysis.Entropy` builds; the lemma is purely additive (no signature
changes). No `sorry`/`admit`/new `axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive theorem in the entropy library with no API or axiom changes; proof relies on existing charpoly machinery.
> 
> **Overview**
> Adds **`vonNeumannEntropy_mul_comm`** to `TNLean/Analysis/Entropy.lean`: for rectangular `A : Matrix m n ℂ` and `B : Matrix n m ℂ` with Hermitian `A * B` and `B * A`, von Neumann entropy is unchanged under swapping the product order (`S(AB) = S(BA)`).
> 
> The proof rewrites both sides via `vonNeumannEntropy_eq_charpoly_roots`, then uses `Matrix.charpoly_mul_comm'` so the characteristic polynomials differ only by powers of `X` (extra zero eigenvalues). Those zeros add nothing because `negMulLog 0 = 0`.
> 
> This is documented as the spectral Schmidt symmetry for complementary reductions of a pure state and is intended to support later pure-state area-law monotonicity arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b4cd0e6e0d2da8c925dee27ace5b47aee87184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->