### PR TITLE
doc(entropy): add product entropy blueprint entry

### DIFF
--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -113,6 +113,29 @@ finite-dimensional quantum systems.
     and the entropies coincide.
 \end{proof}
 
+\begin{theorem}[Entropy of $AB$ equals entropy of $BA$]
+    \label{thm:entropy_mul_comm}
+    \lean{vonNeumannEntropy_mul_comm}
+    \leanok
+    \uses{lem:entropy_charpoly_roots}
+    For matrices $A \in M_{m \times n}(\mathbb{C})$ and
+    $B \in M_{n \times m}(\mathbb{C})$ such that $AB$ and $BA$ are Hermitian,
+    \[
+        S(AB) = S(BA).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:entropy_charpoly_roots}
+    The rectangular characteristic-polynomial identity gives
+    \[
+        X^n \chi_{AB} = X^m \chi_{BA}.
+    \]
+    Hence $AB$ and $BA$ have the same nonzero eigenvalues, with multiplicity.
+    The roots at $0$ contribute nothing because $0 \log 0 = 0$, so
+    Lemma~\ref{lem:entropy_charpoly_roots} gives $S(AB) = S(BA)$.
+\end{proof}
+
 \section{Tripartite partial traces}
 
 \begin{definition}[Partial trace over $A$]\label{def:traceA_ABC}


### PR DESCRIPTION
Closes #2478.

## Summary
- add the blueprint theorem `thm:entropy_mul_comm` for `vonNeumannEntropy_mul_comm`
- record the proof idea by the rectangular characteristic-polynomial identity and the vanishing zero-root contribution

## Verification
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `lake build TNLean.Analysis.Entropy -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `printf 'import TNLean.Analysis.Entropy\\n#check vonNeumannEntropy_mul_comm\\n' | lake env lean --stdin`\n- `leanblueprint web`\n\nGenerated `blueprint/lean_decls` contains `vonNeumannEntropy_mul_comm`. The project-wide sync/checkdecls commands still report pre-existing missing declarations outside this PR (`TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData`, `...`, and existing parent-Hamiltonian entries); the new entropy declaration is not among them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint/LaTeX sync with no runtime or proof logic changes in this diff.
> 
> **Overview**
> Documents **`thm:entropy_mul_comm`** in the entropy blueprint chapter, wired to the existing Lean declaration **`vonNeumannEntropy_mul_comm`**.
> 
> The new entry states that for rectangular \(A,B\) with Hermitian \(AB\) and \(BA\), \(S(AB)=S(BA)\), and records the proof via \(X^n\chi_{AB}=X^m\chi_{BA}\), matching nonzero eigenvalues, and ignoring zero roots in the entropy sum (Lemma on characteristic-polynomial roots). A trivial **EOF newline** fix is applied after an earlier proof’s `\end{proof}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7b985d88229652b5c53104641ca906a278f7c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->