### PR TITLE
doc(parent): clarify boundary-closing coordinate prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -892,9 +892,9 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     (A := A) hInj hL₀ (by omega : L₀ ≤ M) hψred hψX YAt hYAt η μ j
 
 /-- Closure-property containment
-\(\mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A)\) for \(L>L₀\).  The
-source obtains this from the intersection property and closure property in
-arXiv:2011.12127, Section IV.C, lines 2078--2090.
+\(\mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A)\) for \(L>L₀\).
+The source names the closure-property step in arXiv:2011.12127, Section IV.C,
+lines 2078--2079, and states the resulting uniqueness theorem in lines 2087--2090.
 **Open gap:** Depends on the comparison at the closed boundary; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
@@ -928,7 +928,8 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
   \mathcal G_{N,L}(A)=\mathbb C\,\Omega_N(A)
 \]
 for every \(L>L₀\), by the intersection property and closure property of
-arXiv:2011.12127, Section IV.C, lines 2078--2090.
+arXiv:2011.12127, Section IV.C, lines 2078--2079.  The resulting
+periodic-chain uniqueness theorem is stated there in lines 2087--2090.
 
 **Open gap:** The containment direction depends on the closure property; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2536,7 +2536,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \tau^-_\eta(\mu)_{k+1}=\mu_k,
     \]
     and put the letter $\eta$ on the remaining sites. These two choices have the
-    same complementary word. The boundary-closing step is the equality
+    same complementary word. The notation $\tau^\pm_\eta(\mu)$ is a local
+    coordinate device for the boundary-closing comparison; it is not notation
+    used in the source. In these coordinates the boundary-closing step is the
+    equality
     \[
         \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =


### PR DESCRIPTION
## Summary
- state explicitly that the tau^+_eta(mu) and tau^-_eta(mu) notation is local to the boundary-closing comparison, not notation from Cirac et al.
- keep the boundary-closing equality displayed as an equation rather than as a theorem-label reference
- split the Lean docstring citation between the closure-property sentence, lines 2078--2079, and the resulting uniqueness theorem, lines 2087--2090

Refs #2405.

## Checks
- git diff --check
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/check_oversized_lean_files.py --root .
- leanblueprint web
- lake exe cache get
- lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState

`python3 scripts/blueprint_lean_sync.py --root . --ci` was also run earlier. It reports the parent-Hamiltonian chapter as 393/393, but exits nonzero because of pre-existing non-parent references in `ch13a_peps_ft.tex` and `ch04a_channel_representations.tex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose only; no Lean proof or API changes.
> 
> **Overview**
> Clarifies how the formalization relates to Cirac et al. for the parent-Hamiltonian **boundary-closing** step and the **closure property**, without changing proofs.
> 
> In **blueprint** `ch14_parent_hamiltonian.tex`, reader-facing prose now states that \(\tau^\pm_\eta(\mu)\) is a **local coordinate device** for the boundary-closing comparison, not notation from the source paper.
> 
> In **`UniqueGroundState.lean`**, docstrings for `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction` and `chainGroundSpace_eq_mpvSubmodule_normal` **split the arXiv citation**: lines 2078–2079 for the closure-property step vs. lines 2087–2090 for the stated periodic-chain uniqueness theorem, replacing a single blended reference to 2078–2090.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76259bceab1d186d5abbfc32dbb376c5c22bbffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->