### PR TITLE
doc(parent): separate boundary outside letter in prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -730,13 +730,13 @@ lemma closure_property_boundary_restriction_eq_of_first_products
 /-- Auxiliary boundary-condition product obtained from equality of the two
 closing-boundary restrictions.
 
-Suppose that, for every physical letter \(j\), the two boundary conditions with
-outside letter \(j\) and complementary word \(\mu\) give the same
+Suppose that, for every outside letter \(\eta\), the two boundary conditions
+with outside letter \(\eta\) and complementary word \(\mu\) give the same
 length-\((L_0+1)\) restriction:
 \[
-  \operatorname{Res}^{\tau^+_j(\mu)}_{M,L_0+1}(\psi)
+  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
   =
-  \operatorname{Res}^{\tau^-_j(\mu)}_{M+1-L_0,L_0+1}(\psi).
+  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
 Then there are boundary conditions with the same complementary word and with
 \[

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2165,11 +2165,11 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         \Gamma_{L_0+1}(Y_i(\tau)).
     \]
-    Suppose that, for every physical letter $j$,
+    Suppose that, for every outside letter $\eta$,
     \[
-        \operatorname{Res}^{\tau^+_j(\mu)}_{M,L_0+1}(\psi)
+        \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =
-        \operatorname{Res}^{\tau^-_j(\mu)}_{M+1-L_0,L_0+1}(\psi).
+        \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
     \]
     Then there are boundary conditions $\rho^+_{j,\sigma}$ and
     $\rho^-_{j,\sigma}$ such that, for every complementary position $k$,
@@ -2189,7 +2189,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    Take $\rho^+_{j,\sigma}=\tau^+_j(\mu)$ and
+    For the product indexed by $j$ and $\sigma$, specialize the preceding
+    equality at the outside letter $\eta=j$. Take
+    $\rho^+_{j,\sigma}=\tau^+_j(\mu)$ and
     $\rho^-_{j,\sigma}=\tau^-_j(\mu)$.  The complement equations are the two
     identities of Lemma~\ref{lem:wrapped_middle_backgrounds}.  Fix $j$.  Applying
     the first-letter restriction to the displayed equality gives


### PR DESCRIPTION
## Summary
- separates the outside boundary letter from the product index in the closing-boundary auxiliary product statement
- makes the blueprint proof explicitly specialize the outside letter to the product index only at the final step

## Verification
- lake env lean TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
- git diff --check
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --ci (reports only pre-existing non-parent entries)
- cd blueprint && leanblueprint web

Refs #2405.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only and blueprint prose updates; no changes to Lean types, hypotheses, or proofs.
> 
> **Overview**
> Aligns reader-facing text for the **closing-boundary auxiliary product** lemma so the **outside boundary letter** \(\eta\) is not conflated with the **physical letter** \(j\) in the product over \(j,\sigma\).
> 
> In **`BoundaryClosing.lean`**, the docblock for `closure_property_auxiliary_boundary_product_eq_of_closing_restrictions` now states the restriction hypothesis **for every outside letter \(\eta\)** and writes \(\tau^+_\eta(\mu)\) / \(\tau^-_\eta(\mu)\) instead of indexing those boundary conditions by \(j\). The **Lean proof and hypotheses are unchanged** (still `∀ j : Fin d` in `hRestrict`).
> 
> In **`ch14_parent_hamiltonian.tex`**, the matching lemma hypothesis uses \(\eta\) the same way, and the proof **explicitly says** that for the \(j,\sigma\) product you **specialize \(\eta = j\)** before taking \(\rho^+_{j,\sigma}=\tau^+_j(\mu)\) and \(\rho^-_{j,\sigma}=\tau^-_j(\mu)\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70cddd9a69e0884f951497f5c57099e67ebc561d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->