### PR TITLE
doc(parent): sync block-diagonal gap tracking

### DIFF
--- a/audits/PARENT_HAMILTONIAN_ISSUES.md
+++ b/audits/PARENT_HAMILTONIAN_ISSUES.md
@@ -73,7 +73,7 @@ TNLean/MPS/ParentHamiltonian/
 ├── Basic.lean                  -- PH-1a,b: MPS is ground state, FF property
 ├── IntersectionProperty.lean   -- PH-2a,b: intersection + closure
 ├── UniqueGroundState.lean      -- PH-2c,d: uniqueness theorems
-├── DegenerateGS.lean           -- PH-3a: ground space = BNT span
+├── BlockIntersectionProperty.lean (planned) -- PH-3a: block-diagonal intersection identity
 ├── Martingale.lean             -- PH-4a: abstract martingale criterion
 ├── Gap.lean                    -- PH-4b,c: gap theorem
 └── Correlations.lean           -- PH-5a–d: correlator formula, decay, ξ
@@ -188,9 +188,15 @@ TNLean/MPS/ParentHamiltonian/
 📖 **Read first**: [CPGSV21] lines 2098–2140 (block structure, topological sectors); [FNW92] §4; [PGVWC07] §6
 
 - [ ] **PH-3a**: Ground space = span of BNT
-  - **Blueprint**: `\begin{theorem}[Ground space of block-injective MPS]` citing \cite{FNW92}, \cite{PGVWC07}
-  - **Lean tag**: `\lean{MPSTensor.parentHamiltonian_gs_eq_bnt_span}`
-  - **Lean**: `TNLean/MPS/ParentHamiltonian/DegenerateGS.lean`
+  - **Blueprint**: `thm:block_diagonal_ground_space_intersection`,
+    `thm:parent_ground_space_le_bnt_span`, and `thm:gs_eq_bnt_span` in
+    Chapter 14; these are currently `\notready`.
+  - **Lean tag**: no current Lean declaration proves the capstone theorem;
+    the old `MPSTensor.parentHamiltonian_gs_eq_bnt_span` target is historical.
+  - **Lean**: no current `DegenerateGS.lean` file on `main`; the expected
+    theorem is a future block-diagonal intersection theorem, likely in
+    `TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`, composed
+    with `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`.
   - **Math**: For $N \geq L_0+1$, the ground space of the parent Hamiltonian equals $\spn\{\ket{V^{(N)}(A_j)} : j = 1,\ldots,g\}$ where $\{A_j\}$ is a basis of normal tensors.
   - **Proof sketch**: Each BNT element generates a ground state (by block structure). Converse: any ground state restricted to an injective block is determined by the intersection property. Block-diagonal structure prevents mixing.
   - **Depends on**: PH-2d, `def:canonical_form_bnt` (ch10)

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -152,9 +152,11 @@ The live blueprint records the analogous statement in source notation, without
 claiming that it is proved.\footnote{Blueprint locations:
 \path{def:parent_hamiltonian_ground_space_bnt} for the block-sum chain ground
 space, \path{lem:isup_chain_ground_space_block_le_assembled} for the forward
-inclusion, \path{lem:conditional_boundary_matrix_block_split_projection_span}
-for the direct-sum boundary formula, and \path{thm:gs_eq_bnt_span} for the final
-span statement in \path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}.} Write
+inclusion, \path{thm:block_diagonal_ground_space_intersection} for the
+PGVWC07 block-diagonal intersection identity,
+\path{thm:parent_ground_space_le_bnt_span} for the parent-ground-space
+containment, and \path{thm:gs_eq_bnt_span} for the final span statement in
+\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}.} Write
 \begin{align}
   \widetilde A_i=\bigoplus_{j=1}^b\mu_j A_i^j
 \end{align}


### PR DESCRIPTION
## Summary
- Update the CPGSV21 block-diagonal parent-ground-space gap note so it names the current Chapter 14 blueprint targets, including the PGVWC07 block-diagonal intersection identity.
- Update the parent-Hamiltonian audit so the old `DegenerateGS.lean` target is historical and the expected theorem is a future block-diagonal intersection result composed with the unique-ground-state theorem.

## Checks
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

Refs #905.
Refs #870.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and LaTeX documentation updates only; no Lean, blueprint source, or runtime behavior changes.
> 
> **Overview**
> Documentation-only sync for **block-diagonal parent ground space** tracking (issues #905 / #870).
> 
> **`audits/PARENT_HAMILTONIAN_ISSUES.md`** retires the old PH-3a picture (`DegenerateGS.lean`, `MPSTensor.parentHamiltonian_gs_eq_bnt_span`) and points PH-3a at Chapter 14 `\notready` theorems (`thm:block_diagonal_ground_space_intersection`, `thm:parent_ground_space_le_bnt_span`, `thm:gs_eq_bnt_span`) plus a planned `BlockIntersectionProperty.lean` composed with `UniqueGroundState.lean`.
> 
> **`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`** updates the blueprint footnote to cite those same Chapter 14 labels (including the PGVWC07 block-diagonal intersection identity) instead of older lemma names like `lem:conditional_boundary_matrix_block_split_projection_span`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141f9aa5645da761352e9f922afbc78edb0336d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->