### PR TITLE
feat(parent): prove normalized boundary matrix identity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -210,6 +210,7 @@ import TNLean.MPS.Symmetry.StringOrder
 
 -- Layer 5: Multi-block
 import TNLean.MPS.Core.MultiBlock
+import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+
+/-!
+# Block-diagonal intersection identities
+
+This file records algebraic identities used in the block-diagonal
+parent-Hamiltonian intersection argument.
+
+## References
+
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12, proof around
+  \(A_b C_a=D_b A_a\) and \(E=\sum_a C_a A_a^\dagger\).
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2021], Section IV.C, lines
+  2120--2129.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof.
+
+Assume
+\[
+  A_b C_a=D_b A_a
+\]
+for all physical indices \(a,b\), and assume the right normalization
+\[
+  \sum_a A_aA_a^\dagger=I.
+\]
+Then, with \(E=\sum_a C_aA_a^\dagger\),
+\[
+  D_b=A_bE,\qquad A_bC_a=A_bEA_a.
+\]
+-/
+theorem pgvwc07_boundary_matrix_identities_of_compatibility
+    (A : MPSTensor d D)
+    (C Dmat : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital : ∑ a : Fin d, A a * (A a)ᴴ = 1)
+    (hCompat : ∀ a b : Fin d, A b * C a = Dmat b * A a) :
+    (∀ b : Fin d, Dmat b = A b * (∑ a : Fin d, C a * (A a)ᴴ)) ∧
+      (∀ a b : Fin d,
+        A b * C a = A b * (∑ c : Fin d, C c * (A c)ᴴ) * A a) := by
+  classical
+  have hD : ∀ b : Fin d, Dmat b = A b * (∑ a : Fin d, C a * (A a)ᴴ) := by
+    intro b
+    calc
+      Dmat b = Dmat b * 1 := by simp
+      _ = Dmat b * (∑ a : Fin d, A a * (A a)ᴴ) := by rw [hUnital]
+      _ = ∑ a : Fin d, Dmat b * (A a * (A a)ᴴ) := by
+            rw [Matrix.mul_sum]
+      _ = ∑ a : Fin d, (Dmat b * A a) * (A a)ᴴ := by
+            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
+      _ = ∑ a : Fin d, (A b * C a) * (A a)ᴴ := by
+            exact Finset.sum_congr rfl fun a _ => by rw [← hCompat a b]
+      _ = ∑ a : Fin d, A b * (C a * (A a)ᴴ) := by
+            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
+      _ = A b * (∑ a : Fin d, C a * (A a)ᴴ) := by
+            rw [Matrix.mul_sum]
+  refine ⟨hD, ?_⟩
+  intro a b
+  calc
+    A b * C a = Dmat b * A a := hCompat a b
+    _ = A b * (∑ c : Fin d, C c * (A c)ᴴ) * A a := by rw [hD b]
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5308,11 +5308,53 @@ formulation; the passage to $\ker H_N$ is kept separate.
     pairwise equations into the full equations.
 \end{proof}
 
+\begin{lemma}[Normalized boundary matrix identities]
+    \label{lem:normalized_boundary_matrix_identities}
+    \lean{MPSTensor.pgvwc07_boundary_matrix_identities_of_compatibility}
+    \leanok
+    Let $(A_a)_{a\in I}$, $(C_a)_{a\in I}$, and $(D_b)_{b\in I}$ be
+    matrices in $M_D(\mathbb C)$, indexed by a finite physical alphabet. If
+    \[
+        \sum_a A_a A_a^\dagger=\Id,
+        \qquad
+        A_b C_a=D_b A_a
+    \]
+    for all $a,b\in I$, and if
+    \[
+        E=\sum_a C_a A_a^\dagger,
+    \]
+    then
+    \[
+        D_b=A_bE,
+        \qquad
+        A_bC_a=A_bEA_a
+    \]
+    for all $a,b\in I$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Multiply $D_b$ by the normalization:
+    \[
+        D_b
+        =
+        D_b\sum_a A_aA_a^\dagger
+        =
+        \sum_a D_bA_aA_a^\dagger
+        =
+        \sum_a A_bC_aA_a^\dagger
+        =
+        A_bE .
+    \]
+    Substituting this in $A_bC_a=D_bA_a$ gives
+    $A_bC_a=A_bEA_a$.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
     \uses{def:ground_space_parent, def:chain_ground_space, def:l_blk_injective,
-        def:mpv}
+        def:mpv, lem:normalized_boundary_matrix_identities}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[
@@ -5399,6 +5441,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
     In the normalization used in the source proof,
     $\sum_a A^j_a A^{j\,\dagger}_a=\Id$, so
+    Lemma~\ref{lem:normalized_boundary_matrix_identities} gives
     \[
         D^j_b
         =


### PR DESCRIPTION
## Summary

- Adds `MPSTensor.pgvwc07_boundary_matrix_identities_of_compatibility`, proving the PGVWC07 boundary-matrix calculation
  \[
    A_b C_a=D_b A_a,\quad \sum_a A_aA_a^\dagger=I
    \quad\Longrightarrow\quad
    D_b=A_bE,\quad A_bC_a=A_bEA_a
  \]
  with \(E=\sum_a C_aA_a^\dagger\).
- Records the calculation as `lem:normalized_boundary_matrix_identities` in the parent-Hamiltonian blueprint, while keeping `thm:block_diagonal_ground_space_intersection` marked `\notready`.
- Imports the new parent-Hamiltonian helper through `TNLean.lean`.

This advances #905 and #870; it does not close either issue.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty`
- `lake build TNLean`
- `#print axioms MPSTensor.pgvwc07_boundary_matrix_identities_of_compatibility` reports only `propext`, `Classical.choice`, and `Quot.sound`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`

After regenerating `blueprint/lean_decls`, `lake exe checkdecls blueprint/lean_decls` still reports existing missing declarations outside this change; the new boundary-matrix theorem is not among them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, self-contained matrix algebra with blueprint linkage only; the main block-diagonal intersection theorem remains not ready.
> 
> **Overview**
> Adds a formal Lean proof of the **normalized boundary matrix identities** used in the PGVWC07 block-diagonal parent-Hamiltonian intersection argument: from compatibility \(A_b C_a = D_b A_a\) and \(\sum_a A_a A_a^\dagger = I\), it derives \(D_b = A_b E\) and \(A_b C_a = A_b E A_a\) for \(E = \sum_a C_a A_a^\dagger\).
> 
> The new module `TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty` is wired into the root `TNLean` import surface. The parent-Hamiltonian blueprint records the result as `lem:normalized_boundary_matrix_identities` (with `\leanok`) and cites it in the still-`\notready` block-diagonal ground-space intersection theorem instead of an inline calculation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111e0230e31167ec19f0a26647d45a3159232ef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->