### PR TITLE
feat(parent): prove blockwise boundary compatibility

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -101,13 +101,15 @@ def HasBiCF
         (∑ k : Fin r, Matrix.trace (Δ k * evalWord (A k) (List.ofFn w))) = 0) →
     ∀ k, Δ k = 0
 
-/-- A finite-length spanning hypothesis implies `HasBiCF`. -/
-theorem hasBiCF_of_wordTupleSpanTop
+/-- If simultaneous word evaluations span the product algebra, then a block
+matrix family whose trace pairing vanishes on those word evaluations is zero. -/
+theorem block_matrices_eq_zero_of_wordTupleSpanTop_trace
     (A : (k : Fin r) → MPSTensor d (dim k))
-    {L : ℕ} (hSpan : WordTupleSpanTop A L) :
-    HasBiCF A := by
-  refine ⟨L, ?_⟩
-  intro Δ hΔ
+    {L : ℕ} (hSpan : WordTupleSpanTop A L)
+    (Δ : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+    (hΔ : ∀ w : Fin L → Fin d,
+      (∑ k : Fin r, Matrix.trace (Δ k * evalWord (A k) (List.ofFn w))) = 0) :
+    ∀ k, Δ k = 0 := by
   have hΔzero : Δ = 0 := by
     apply piTrace_mul_right_eq_zero
     intro N
@@ -131,6 +133,15 @@ theorem hasBiCF_of_wordTupleSpanTop
     exact hZeroOnSpan N (by rw [hSpan]; exact Submodule.mem_top)
   intro k
   simpa using congrArg (fun f => f k) hΔzero
+
+/-- A finite-length spanning hypothesis implies `HasBiCF`. -/
+theorem hasBiCF_of_wordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L : ℕ} (hSpan : WordTupleSpanTop A L) :
+    HasBiCF A := by
+  refine ⟨L, ?_⟩
+  intro Δ hΔ k
+  exact block_matrices_eq_zero_of_wordTupleSpanTop_trace A hSpan Δ hΔ k
 
 /-- A finite family of words which isolates each block: for every `k`, one can
 form a linear combination of those word evaluations that equals the identity on

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import TNLean.MPS.MPDO.BiCFDerivation.Core
 
 /-!
 # Block-diagonal intersection identities
@@ -23,6 +24,41 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d D : ℕ}
+
+/-- Boundary-matrix compatibility from equality of the two coefficient
+decompositions in the PGVWC block-diagonal intersection proof.
+
+For fixed physical indices \(a,b\), the coefficient comparison in
+[Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12, gives
+\[
+  \sum_j \operatorname{tr}\!\left(
+    A^j_b C^j_a A^j_{i_2}\cdots A^j_{i_m}\right)
+  =
+  \sum_j \operatorname{tr}\!\left(
+    D^j_b A^j_a A^j_{i_2}\cdots A^j_{i_m}\right)
+\]
+for every middle word.  Under the common word-span condition, this implies
+\[
+  A^j_b C^j_a=D^j_b A^j_a
+\]
+for every block \(j\).
+-/
+theorem pgvwc07_blockwise_compatibility_of_trace_decomposition
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {m : ℕ} (hSpan : WordTupleSpanTop A m)
+    (C Dmat : (j : Fin r) → Fin d → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hCoeff : ∀ a b : Fin d, ∀ w : Fin m → Fin d,
+      (∑ j : Fin r, Matrix.trace ((A j b * C j a) * evalWord (A j) (List.ofFn w))) =
+      (∑ j : Fin r, Matrix.trace ((Dmat j b * A j a) * evalWord (A j) (List.ofFn w)))) :
+    ∀ j : Fin r, ∀ a b : Fin d, A j b * C j a = Dmat j b * A j a := by
+  intro j a b
+  have hzero := block_matrices_eq_zero_of_wordTupleSpanTop_trace A hSpan
+    (fun k => A k b * C k a - Dmat k b * A k a) (by
+      intro w
+      simpa [Matrix.sub_mul, Matrix.trace_sub, Finset.sum_sub_distrib, sub_eq_zero]
+        using sub_eq_zero.mpr (hCoeff a b w)) j
+  exact sub_eq_zero.mp hzero
 
 /-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5308,6 +5308,48 @@ formulation; the passage to $\ker H_N$ is kept separate.
     pairwise equations into the full equations.
 \end{proof}
 
+\begin{lemma}[Blockwise boundary compatibility from traces]
+    \label{lem:blockwise_boundary_compatibility_from_traces}
+    \lean{MPSTensor.pgvwc07_blockwise_compatibility_of_trace_decomposition}
+    \leanok
+    Let \(A^1,\ldots,A^g\) be block tensors with the following common
+    word-span property: for a fixed \(m\), the simultaneous tuples
+    \[
+        w\longmapsto
+        \left(A^1_w,\ldots,A^g_w\right),
+        \qquad |w|=m,
+    \]
+    span the full product algebra
+    \(\prod_j M_{D_j}(\mathbb C)\).
+    Suppose that matrices \(C^j_a,D^j_b\in M_{D_j}(\mathbb C)\) satisfy,
+    for all physical indices \(a,b\) and all words \(w\) of length \(m\),
+    \[
+        \sum_j \operatorname{tr}\!\left(A^j_b C^j_a A^j_w\right)
+        =
+        \sum_j \operatorname{tr}\!\left(D^j_b A^j_a A^j_w\right).
+    \]
+    Then
+    \[
+        A^j_bC^j_a=D^j_bA^j_a
+    \]
+    for every block \(j\) and all \(a,b\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    For fixed \(a,b\), set
+    \[
+        \Delta_j=A^j_bC^j_a-D^j_bA^j_a .
+    \]
+    The assumed trace equality says that
+    \[
+        \sum_j \operatorname{tr}\!\left(\Delta_jA^j_w\right)=0
+    \]
+    for every word \(w\) of length \(m\).  Since the tuples
+    \((A^1_w,\ldots,A^g_w)\) span the product algebra, the product trace
+    pairing is nondegenerate and hence every \(\Delta_j\) is zero.
+\end{proof}
+
 \begin{lemma}[Normalized boundary matrix identities]
     \label{lem:normalized_boundary_matrix_identities}
     \lean{MPSTensor.pgvwc07_boundary_matrix_identities_of_compatibility}
@@ -5354,7 +5396,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
     \uses{def:ground_space_parent, def:chain_ground_space, def:l_blk_injective,
-        def:mpv, lem:normalized_boundary_matrix_identities}
+        def:mpv, lem:blockwise_boundary_compatibility_from_traces,
+        lem:normalized_boundary_matrix_identities}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[


### PR DESCRIPTION
## Summary
- prove the finite-length trace-separation lemma for block matrix families under `WordTupleSpanTop`
- formalize the PGVWC07 coefficient-comparison step
  \[
    \sum_j \operatorname{tr}(A^j_b C^j_a A^j_w)
    =
    \sum_j \operatorname{tr}(D^j_b A^j_a A^j_w)
    \Longrightarrow
    A^j_b C^j_a = D^j_b A^j_a
  \]
- add the matching blueprint lemma before the normalized boundary matrix identity

Refs #905. Refs #870.

## Verification
- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty`
- `lake build TNLean`
- `git diff --check`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean || true`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `printf ... | lake env lean --stdin` for `#print axioms` on the new declarations: only `propext`, `Classical.choice`, `Quot.sound`
- `leanblueprint web` completed locally with the repository's usual local package/bibliography warnings

`python3 scripts/blueprint_lean_sync.py --root . --ci` and `lake exe checkdecls blueprint/lean_decls` still report pre-existing missing declarations outside this diff; the changed-file blueprint sync check passes, and the new declaration is not among the missing entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean and blueprint documentation; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Extracts** the word-span trace argument from `hasBiCF_of_wordTupleSpanTop` into **`block_matrices_eq_zero_of_wordTupleSpanTop_trace`**, so `HasBiCF` is proved by delegating to that lemma instead of inlining the span induction.
> 
> **Adds** `pgvwc07_blockwise_compatibility_of_trace_decomposition` in `BlockIntersectionProperty.lean`: under `WordTupleSpanTop`, equality of summed traces over middle words for all physical indices \(a,b\) implies blockwise **`A^j_b C^j_a = D^j_b A^j_a`**, by applying the new lemma to \(\Delta_j = A^j_b C^j_a - D^j_b A^j_a\).
> 
> **Blueprint:** new Lemma `blockwise_boundary_compatibility_from_traces` (linked to the Lean theorem); block-diagonal intersection theorem now **uses** that lemma before normalized boundary matrix identities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86fb11baf3829b4bc7629df67e09467c81060a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->