### PR TITLE
feat(parent): prove left-boundary summands enter block ground spaces

### DIFF
--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -41,7 +41,7 @@ For a general representative it is strictly stronger, since it forces the leadin
 eigenvalue to equal `1`, whereas the source ZCL is invariant under the rescaling
 `E_M ↦ λ E_M`. The deviation is witnessed by `exists_isPRFP_not_isZCL`, where the
 purification's trace contraction drops the leading eigenvalue. The faithful
-(normalized) ZCL and the source's `PRFP ⟺ ZCL` equivalence remain open. Recorded
+(normalized) ZCL and the source's equivalence between PRFP and ZCL remain open. Recorded
 in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 
 See arXiv:1606.00608, lines 735–739 (and the canonical-form characterization at

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -25,6 +25,91 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+/-- The left-boundary summand in the PGVWC block-diagonal intersection proof:
+\[
+  \sigma\longmapsto
+  \operatorname{tr}(A_{\sigma_{n+2}} C_{\sigma_1}
+    A_{\sigma_2}\cdots A_{\sigma_{n+1}}).
+\]
+-/
+noncomputable def pgvwc07LeftBoundaryComponent
+    (A : MPSTensor d D) (C : Fin d → Matrix (Fin D) (Fin D) ℂ) (n : ℕ) :
+    NSiteSpace d (n + 2) :=
+  fun σ => Matrix.trace
+    (A (σ (Fin.last (n + 1))) * C (σ 0) *
+      evalWord A (List.ofFn (Fin.tail (Fin.init σ))))
+
+/-- The left-boundary summand is a ground-space vector once the PGVWC boundary
+identity \(A_bC_a=A_bEA_a\) holds. -/
+theorem pgvwc07LeftBoundaryComponent_eq_groundSpaceMap
+    (A : MPSTensor d D) (C : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (E : Matrix (Fin D) (Fin D) ℂ) (n : ℕ)
+    (hACE : ∀ a b : Fin d, A b * C a = A b * E * A a) :
+    pgvwc07LeftBoundaryComponent A C n = groundSpaceMap A (n + 2) E := by
+  ext σ
+  let M := evalWord A (List.ofFn (Fin.tail (Fin.init σ)))
+  let a := σ 0
+  let b := σ (Fin.last (n + 1))
+  have hEvalInit :
+      evalWord A (List.ofFn (Fin.init σ)) = A a * M := by
+    have hinit : Fin.cons a (Fin.tail (Fin.init σ)) = Fin.init σ := by
+      dsimp [a]
+      exact Fin.cons_self_tail (Fin.init σ)
+    rw [← hinit]
+    exact evalWord_ofFn_cons A a (Fin.tail (Fin.init σ))
+  have hEval :
+      evalWord A (List.ofFn σ) = (A a * M) * A b := by
+    have hσ : Fin.snoc (Fin.init σ) b = σ := by
+      simp [b]
+    rw [← hσ]
+    calc
+      evalWord A (List.ofFn (Fin.snoc (Fin.init σ) b))
+          = evalWord A (List.ofFn (Fin.init σ)) * A b :=
+              evalWord_ofFn_snoc A (Fin.init σ) b
+      _ = (A a * M) * A b := by rw [hEvalInit]
+  change Matrix.trace (A b * C a * M) =
+    Matrix.trace (evalWord A (List.ofFn σ) * E)
+  rw [hEval]
+  calc
+    Matrix.trace (A b * C a * M)
+        = Matrix.trace ((A b * E * A a) * M) := by
+            rw [hACE a b]
+    _ = Matrix.trace ((A b * E) * (A a * M)) := by
+            rw [Matrix.mul_assoc]
+    _ = Matrix.trace ((A a * M) * (A b * E)) := by
+            rw [Matrix.trace_mul_comm]
+    _ = Matrix.trace (((A a * M) * A b) * E) := by
+            rw [← Matrix.mul_assoc]
+
+/-- The left-boundary summand belongs to \(G_{n+2}(A)\) once the PGVWC
+boundary identity \(A_bC_a=A_bEA_a\) holds. -/
+theorem pgvwc07LeftBoundaryComponent_mem_groundSpace
+    (A : MPSTensor d D) (C : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (E : Matrix (Fin D) (Fin D) ℂ) (n : ℕ)
+    (hACE : ∀ a b : Fin d, A b * C a = A b * E * A a) :
+    pgvwc07LeftBoundaryComponent A C n ∈ groundSpace A (n + 2) := by
+  rw [pgvwc07LeftBoundaryComponent_eq_groundSpaceMap A C E n hACE]
+  rw [groundSpace, LinearMap.mem_range]
+  exact ⟨E, rfl⟩
+
+/-- A finite sum of PGVWC left-boundary summands lies in the supremum of the
+corresponding block ground spaces. -/
+theorem pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    (C : (j : Fin r) → Fin d → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (E : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (n : ℕ)
+    (hACE : ∀ j : Fin r, ∀ a b : Fin d,
+      A j b * C j a = A j b * E j * A j a) :
+    (∑ j : Fin r, pgvwc07LeftBoundaryComponent (A j) (C j) n) ∈
+      ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  classical
+  apply Submodule.sum_mem
+  intro j hj
+  exact Submodule.mem_iSup_of_mem j
+    (pgvwc07LeftBoundaryComponent_mem_groundSpace (A j) (C j) (E j) n (hACE j))
+
 /-- Boundary-matrix compatibility from equality of the two coefficient
 decompositions in the PGVWC block-diagonal intersection proof.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5392,12 +5392,61 @@ formulation; the passage to $\ker H_N$ is kept separate.
     $A_bC_a=A_bEA_a$.
 \end{proof}
 
+\begin{lemma}[Left-boundary summands are ground-space vectors]
+    \label{lem:left_boundary_summands_mem_block_ground_spaces}
+    \lean{MPSTensor.pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace}
+    \leanok
+    Let \(A^1,\ldots,A^g\) be block tensors, and let
+    \(C^j_a,E^j\in M_{D_j}(\mathbb C)\) satisfy
+    \[
+        A^j_b C^j_a=A^j_bE^jA^j_a
+    \]
+    for every block \(j\) and all physical indices \(a,b\).
+    For a word \(\sigma=(\sigma_1,\ldots,\sigma_{n+2})\), define
+    \[
+        \alpha_j(\sigma)
+        =
+        \operatorname{tr}\!\left(
+            A^j_{\sigma_{n+2}} C^j_{\sigma_1}
+            A^j_{\sigma_2}\cdots A^j_{\sigma_{n+1}}
+        \right).
+    \]
+    Then
+    \[
+        \sum_j \alpha_j
+        \in
+        \bigvee_j G_{n+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Fix \(j\).  By the assumed boundary identity and cyclicity of the
+    trace,
+    \[
+        \operatorname{tr}\!\left(
+            A^j_{\sigma_{n+2}} C^j_{\sigma_1}
+            A^j_{\sigma_2}\cdots A^j_{\sigma_{n+1}}
+        \right)
+        =
+        \operatorname{tr}\!\left(
+            A^j_{\sigma_1}A^j_{\sigma_2}\cdots
+            A^j_{\sigma_{n+2}}E^j
+        \right).
+    \]
+    Thus \(\alpha_j\) is the image of \(E^j\) under the parametrization
+    of \(G_{n+2}(A^j)\).  Hence each \(\alpha_j\) lies in
+    \(G_{n+2}(A^j)\), and the finite sum lies in the supremum of these
+    subspaces.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
     \uses{def:ground_space_parent, def:chain_ground_space, def:l_blk_injective,
         def:mpv, lem:blockwise_boundary_compatibility_from_traces,
-        lem:normalized_boundary_matrix_identities}
+        lem:normalized_boundary_matrix_identities,
+        lem:left_boundary_summands_mem_block_ground_spaces}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[


### PR DESCRIPTION
## Summary
- define the PGVWC07 left-boundary summand
  \[
    \sigma \mapsto \operatorname{tr}(A_{\sigma_{n+2}} C_{\sigma_1}
      A_{\sigma_2}\cdots A_{\sigma_{n+1}})
  \]
- prove that `A_b C_a = A_b E A_a` identifies this summand with `groundSpaceMap A (n + 2) E`
- prove that a finite sum of such block summands lies in `\bigvee_j G_{n+2}(A_j)`
- add the matching blueprint lemma before the block-diagonal intersection statement

Refs #905. Refs #870. Refs #190.

## Verification
- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty`
- `lake build TNLean`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean || true`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `printf ... | lake env lean --stdin` for `#print axioms` on the new declarations: only `propext`, `Classical.choice`, `Quot.sound`
- `leanblueprint web` completed locally with the repository's usual local package/bibliography warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and blueprint sync in parent-Hamiltonian algebra; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds formal Lean support for a step in the PGVWC block-diagonal parent-Hamiltonian argument: **left-boundary trace summands** \(\sigma \mapsto \mathrm{tr}(A_{\sigma_{n+2}} C_{\sigma_1} A_{\sigma_2}\cdots A_{\sigma_{n+1}})\) are shown to lie in the block ground spaces when \(A_b C_a = A_b E A_a\).
> 
> In `BlockIntersectionProperty.lean`, the PR introduces `pgvwc07LeftBoundaryComponent`, proves it equals `groundSpaceMap A (n+2) E` under that boundary identity (via `evalWord` splitting and trace cyclicity), derives single-block membership in `groundSpace`, and extends to a **finite sum over blocks** in \(\bigvee_j G_{n+2}(A^j)\). The blueprint chapter gains the matching lemma `lem:left_boundary_summands_mem_block_ground_spaces` and wires it into the (still not-ready) block-diagonal intersection theorem’s `\uses` list.
> 
> A one-line documentation tweak in `ZCL.lean` rephrases the open PRFP/ZCL equivalence without changing definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ed68237ed7160d9209224c6a75ad8b0f9ea846c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->