### PR TITLE
feat(MPDO): the normalized global pure state has zero entropy (S_N = 0)

### DIFF
--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -267,3 +267,42 @@ theorem pureBlockEntropy_monotone (A : MPSTensor d D) {N L : ℕ} (hN : 2 * L + 
   rw [← blockEntropy_doubledTensor A N L (by omega),
     ← blockEntropy_doubledTensor A N (L + 1) (by omega)]
   linarith [key, s1, s2]
+
+/-! ## The global pure state has zero entropy (S_N = 0) -/
+
+open Polynomial in
+/-- **The normalized global pure state has zero von Neumann entropy** (`S_N = 0`,
+arXiv:1606.00608, Section 3, line 599). The state `|V⟩⟨V| / ‖V‖²` is a rank-one
+projector, so its characteristic polynomial is `X^{n-1}(X - 1)` and the entropy
+sum `∑ negMulLog(λ)` vanishes. -/
+theorem vonNeumannEntropy_normalizedPureState (A : MPSTensor d D) (N : ℕ)
+    (htr : Matrix.trace (MPSTensor.pureState A N) ≠ 0) :
+    vonNeumannEntropy (MPSTensor.normalizedPureState A N)
+        (MPSTensor.normalizedPureState_isHermitian A N) = 0 := by
+  set n := Fintype.card (Fin N → Fin d) with hn
+  have hcard : 1 ≤ n := by
+    rw [hn, Nat.one_le_iff_ne_zero]; intro h0
+    haveI : IsEmpty (Fin N → Fin d) := Fintype.card_eq_zero_iff.mp h0
+    exact htr (by simp [Matrix.trace, Matrix.diag, Finset.univ_eq_empty])
+  have hdotEq : (fun σ : Fin N → Fin d => MPSTensor.mpv A σ) ⬝ᵥ
+      (star (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) = Matrix.trace (MPSTensor.pureState A N) := by
+    rw [Matrix.trace]
+    simp only [Matrix.diag, MPSTensor.pureState, Matrix.vecMulVec_apply, dotProduct, Pi.star_apply]
+  have hnp : MPSTensor.normalizedPureState A N
+      = Matrix.vecMulVec ((Matrix.trace (MPSTensor.pureState A N))⁻¹ •
+          (fun σ : Fin N → Fin d => MPSTensor.mpv A σ))
+          (star (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) := by
+    rw [Matrix.smul_vecMulVec]; rfl
+  have hdot : ((Matrix.trace (MPSTensor.pureState A N))⁻¹ •
+        (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) ⬝ᵥ
+        (star (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) = 1 := by
+    rw [smul_dotProduct, hdotEq, smul_eq_mul, inv_mul_cancel₀ htr]
+  rw [vonNeumannEntropy_eq_charpoly_roots, hnp, Matrix.charpoly_vecMulVec, hdot, one_smul, ← hn]
+  have hX1 : (X - 1 : ℂ[X]) ≠ 0 := by
+    rw [show (1 : ℂ[X]) = C 1 by simp]; exact X_sub_C_ne_zero 1
+  have hfact : (X ^ n - X ^ (n - 1) : ℂ[X]) = X ^ (n - 1) * (X - 1) := by
+    rw [mul_sub, mul_one, ← pow_succ, Nat.sub_add_cancel hcard]
+  rw [hfact, Polynomial.roots_mul (mul_ne_zero (pow_ne_zero _ X_ne_zero) hX1),
+    Polynomial.roots_pow, Polynomial.roots_X,
+    show (X - 1 : ℂ[X]) = X - C 1 by simp, Polynomial.roots_X_sub_C]
+  simp [Multiset.map_nsmul, Multiset.sum_nsmul, Real.negMulLog_zero, Real.negMulLog_one]


### PR DESCRIPTION
## Summary

`vonNeumannEntropy_normalizedPureState`: the normalized global pure state
`|V^{(N)}(A)⟩⟨V^{(N)}(A)| / ‖V^{(N)}(A)‖²` has zero von Neumann entropy,
$$S_N = 0,$$
for any MPS tensor `A` with `V^{(N)}(A) ≠ 0` (arXiv:1606.00608, §3, line 599 — the `S_N=0` ingredient of the pure-state area-law argument).

## Proof

The state is `vecMulVec (c • mpv) (star mpv)` with `c = ‖V‖⁻²`, a rank-one matrix.
By `Matrix.charpoly_vecMulVec` its characteristic polynomial is
`X^n - ((c•mpv) ⬝ᵥ star mpv)·X^{n-1} = X^n - X^{n-1} = X^{n-1}(X-1)`
(the dot product is `c·‖V‖² = 1`). The roots are `0` (multiplicity `n-1`) and `1`,
and `negMulLog 0 = negMulLog 1 = 0`, so the entropy sum vanishes
(via `vonNeumannEntropy_eq_charpoly_roots`).

## Build

`lake build TNLean.MPS.MPDO.PureAreaLaw` passes; additive (no signature changes).
No `sorry`/`admit`/new `axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Mathlib proof only; no API or runtime behavior changes beyond a new theorem in the MPS/MPDO formalization.
> 
> **Overview**
> Adds **`vonNeumannEntropy_normalizedPureState`** in `PureAreaLaw.lean`, proving that when the MPS global pure state is normalizable (`trace ≠ 0`), its normalized density matrix has **von Neumann entropy zero** (`S_N = 0`), matching arXiv:1606.00608 §3.
> 
> The proof rewrites the normalized state as a scaled `vecMulVec` of the MPV vector with its conjugate, shows the bra–ket dot product is **1**, then applies `vonNeumannEntropy_eq_charpoly_roots` and `Matrix.charpoly_vecMulVec` to get characteristic polynomial `X^n - X^{n-1} = X^{n-1}(X-1)`. Eigenvalues are **0** (multiplicity `n-1`) and **1**, and `negMulLog` vanishes on both, so the entropy sum is zero. A short section header documents this as the global `S_N = 0` step for the pure-state area-law chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80aefe2bbeac8203958ee576b201b0fc5d97f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->