### PR TITLE
feat(parent): compose block trace decomposition membership

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -190,4 +190,49 @@ theorem pgvwc07_boundary_matrix_identities_of_compatibility
     A b * C a = Dmat b * A a := hCompat a b
     _ = A b * (∑ c : Fin d, C c * (A c)ᴴ) * A a := by rw [hD b]
 
+/-- The composed PGVWC open-segment step from the trace decompositions to
+membership in the supremum of block ground spaces.
+
+For a vector with left-boundary trace decomposition
+\[
+  \psi=\sum_j\alpha_j,\qquad
+  \alpha_j(i_1,\ldots,i_{n+2})
+    =\operatorname{tr}(A^j_{i_{n+2}}C^j_{i_1}A^j_{i_2}\cdots A^j_{i_{n+1}}),
+\]
+the trace-decomposition equality, the common word-span hypothesis, and the
+normalization
+\[
+  \sum_a A^j_a A^{j\dagger}_a=I
+\]
+imply
+\[
+  \psi\in \bigvee_j G_{n+2}(A^j).
+\]
+This is the local membership step in
+PGVWC07, Theorem 12, proof lines 1446--1452. -/
+theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {n : ℕ} (hSpan : WordTupleSpanTop A n)
+    (C Dmat : (j : Fin r) → Fin d → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (hCoeff : ∀ a b : Fin d, ∀ w : Fin n → Fin d,
+      (∑ j : Fin r, Matrix.trace ((A j b * C j a) * evalWord (A j) (List.ofFn w))) =
+      (∑ j : Fin r, Matrix.trace ((Dmat j b * A j a) * evalWord (A j) (List.ofFn w))))
+    (ψ : NSiteSpace d (n + 2))
+    (hψ : ψ = ∑ j : Fin r, pgvwc07LeftBoundaryComponent (A j) (C j) n) :
+    ψ ∈ ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  rw [hψ]
+  let E : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j => ∑ a : Fin d, C j a * (A j a)ᴴ
+  have hCompat :
+      ∀ j : Fin r, ∀ a b : Fin d, A j b * C j a = Dmat j b * A j a :=
+    pgvwc07_blockwise_compatibility_of_trace_decomposition A hSpan C Dmat hCoeff
+  have hACE : ∀ j : Fin r, ∀ a b : Fin d,
+      A j b * C j a = A j b * E j * A j a := by
+    intro j
+    exact (pgvwc07_boundary_matrix_identities_of_compatibility
+      (A j) (C j) (Dmat j) (hUnital j) (hCompat j)).2
+  exact pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace A C E n hACE
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5440,13 +5440,78 @@ formulation; the passage to $\ker H_N$ is kept separate.
     subspaces.
 \end{proof}
 
+\begin{lemma}[Left-boundary trace decompositions lie in the block ground spaces]
+    \label{lem:left_boundary_trace_decomposition_mem_block_ground_spaces}
+    \lean{MPSTensor.pgvwc07_mem_iSup_groundSpace_of_trace_decomposition}
+    \leanok
+    Let \(A^1,\ldots,A^g\) be block tensors with common word-span separation at
+    length \(n\), and suppose that
+    \[
+        \sum_a A^j_a A^{j\,\dagger}_a=\Id
+    \]
+    for every block \(j\).  Suppose a vector \(\psi\in(\mathbb C^d)^{\otimes(n+2)}\)
+    has the left-boundary trace decomposition
+    \[
+        \psi=\sum_j\alpha_j,
+        \qquad
+        \alpha_j(i_1,\ldots,i_{n+2})
+        =
+        \operatorname{tr}\!\left(
+            A^j_{i_{n+2}} C^j_{i_1}
+            A^j_{i_2}\cdots A^j_{i_{n+1}}
+        \right),
+    \]
+    and suppose that the two trace decompositions agree for every middle word:
+    \[
+        \sum_j
+        \operatorname{tr}\!\left(
+            A^j_b C^j_a A^j_w
+        \right)
+        =
+        \sum_j
+        \operatorname{tr}\!\left(
+            D^j_b A^j_a A^j_w
+        \right).
+    \]
+    Then
+    \[
+        \psi\in\bigvee_j G_{n+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The trace-decomposition equality and the common word-span hypothesis give
+    \[
+        A^j_bC^j_a=D^j_bA^j_a
+    \]
+    for every \(j,a,b\).  By the normalization,
+    \[
+        D^j_b
+        =
+        D^j_b\sum_a A^j_aA^{j\,\dagger}_a
+        =
+        \sum_a A^j_bC^j_aA^{j\,\dagger}_a
+        =
+        A^j_bE^j,
+        \qquad
+        E^j:=\sum_a C^j_aA^{j\,\dagger}_a.
+    \]
+    Hence \(A^j_bC^j_a=A^j_bE^jA^j_a\).  Lemma
+    \ref{lem:left_boundary_summands_mem_block_ground_spaces} then gives
+    \[
+        \psi=\sum_j\alpha_j\in\bigvee_j G_{n+2}(A^j).
+    \]
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
     \uses{def:ground_space_parent, def:chain_ground_space, def:l_blk_injective,
         def:mpv, lem:blockwise_boundary_compatibility_from_traces,
         lem:normalized_boundary_matrix_identities,
-        lem:left_boundary_summands_mem_block_ground_spaces}
+        lem:left_boundary_summands_mem_block_ground_spaces,
+        lem:left_boundary_trace_decomposition_mem_block_ground_spaces}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[


### PR DESCRIPTION
## Summary

This PR packages the PGVWC07 open-segment membership step after the three local lemmas that have now landed.

It proves that if a vector has the left-boundary decomposition
\[
  \psi=\sum_j \alpha_j,
  \qquad
  \alpha_j(i_1,\ldots,i_{n+2})
  =\operatorname{tr}(A^j_{i_{n+2}} C^j_{i_1} A^j_{i_2}\cdots A^j_{i_{n+1}}),
\]
and the two trace decompositions agree on every middle word, then the common word-span hypothesis gives
\[
  A^j_b C^j_a=D^j_bA^j_a.
\]
With the normalization \(\sum_a A^j_a A^{j\dagger}_a=I\), this gives
\[
  A^j_bC^j_a=A^j_bE^jA^j_a,
  \qquad
  E^j=\sum_a C^j_aA^{j\dagger}_a,
\]
and hence
\[
  \psi\in\bigvee_j G_{n+2}(A^j).
\]

The new Lean theorem is `MPSTensor.pgvwc07_mem_iSup_groundSpace_of_trace_decomposition`, and the blueprint records it as `lem:left_boundary_trace_decomposition_mem_block_ground_spaces`.

## Source

PGVWC07, Theorem 12, proof lines 1446--1452.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty`
- `lake build TNLean`
- `lake exe lint_style --github`
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `lake env lean <(printf '%s\n' 'import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty' '#print axioms MPSTensor.pgvwc07_mem_iSup_groundSpace_of_trace_decomposition')`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `leanblueprint web` from `blueprint/` (usual local plasTeX/package and bibliography warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof and blueprint documentation only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds the **composed PGVWC07 open-segment step**: from agreeing left-boundary trace decompositions, common word-span, and block normalization, a vector \(\psi=\sum_j \alpha_j\) is shown to lie in \(\bigvee_j G_{n+2}(A^j)\).
> 
> In Lean, new theorem `MPSTensor.pgvwc07_mem_iSup_groundSpace_of_trace_decomposition` wires trace equality → blockwise \(A^j_b C^j_a = D^j_b A^j_a\) → \(A^j_b C^j_a = A^j_b E^j A^j_a\) → existing `pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace`. The blueprint gains `lem:left_boundary_trace_decomposition_mem_block_ground_spaces` with a short proof, and the block-diagonal intersection theorem now `\uses` that lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c81bffdbfdd389e5bba2d8c8c33f3660fe43028. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->