### PR TITLE
feat(PEPS): region insertion machinery + vertex-injective region resonate reconcile (normal-FT)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -441,3 +441,8 @@ import TNLean.PEPS.RegionBlock.Recovery4
 -- resonate step; coincides with the in-region endpoint of `f` for the set complement.
 import TNLean.PEPS.RegionBlock.Recovery5
 import TNLean.PEPS.RegionBlock.Recovery6
+-- The region resonate identity and the out-of-region-endpoint pin: the two endpoint
+-- readings of the region-inserted coefficient agree on the second tensor's closed
+-- state vectors, the region analogue of the resonate identity behind
+-- `physical_to_virtual_insertion`.
+import TNLean.PEPS.RegionBlock.Recovery7

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -446,3 +446,8 @@ import TNLean.PEPS.RegionBlock.Recovery6
 -- state vectors, the region analogue of the resonate identity behind
 -- `physical_to_virtual_insertion`.
 import TNLean.PEPS.RegionBlock.Recovery7
+-- Incident-matrix form to the realization bundle: the region physical-to-virtual
+-- realization `RegionTransferRealizes` follows from the per-matrix incident-matrix
+-- form of the virtual pullback, isolating the region resonate reconcile as the one
+-- remaining mathematical content of the normal-PEPS recovery.
+import TNLean.PEPS.RegionBlock.Recovery8

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -440,3 +440,4 @@ import TNLean.PEPS.RegionBlock.Recovery4
 -- Out-of-region endpoint of a boundary edge: the second endpoint feeding the region
 -- resonate step; coincides with the in-region endpoint of `f` for the set complement.
 import TNLean.PEPS.RegionBlock.Recovery5
+import TNLean.PEPS.RegionBlock.Recovery6

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -455,3 +455,4 @@ import TNLean.PEPS.RegionBlock.Recovery8
 -- endpoint operator is of incident-matrix form on the boundary leg, the last gap
 -- behind the normal-PEPS Fundamental Theorem.
 import TNLean.PEPS.RegionBlock.Recovery9
+import TNLean.PEPS.RegionBlock.Recovery10

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -451,3 +451,7 @@ import TNLean.PEPS.RegionBlock.Recovery7
 -- form of the virtual pullback, isolating the region resonate reconcile as the one
 -- remaining mathematical content of the normal-PEPS recovery.
 import TNLean.PEPS.RegionBlock.Recovery8
+-- The region resonate reconcile: the virtual pullback of the transferred in-region
+-- endpoint operator is of incident-matrix form on the boundary leg, the last gap
+-- behind the normal-PEPS Fundamental Theorem.
+import TNLean.PEPS.RegionBlock.Recovery9

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -433,3 +433,7 @@ import TNLean.PEPS.RegionBlock.Recovery2
 -- duality of the vertex-complement family), and a realized matrix transfer assembles
 -- the `RegionInsertionTransfer` datum.
 import TNLean.PEPS.RegionBlock.Recovery3
+-- Incident-matrix form of the virtual pullback closes the matrix-structure hypothesis
+-- `hform`: the region transfer matrix is the read-off of the pullback, so `hform` is the
+-- read-off round-trip whenever the pullback is of incident-matrix form on the boundary leg.
+import TNLean.PEPS.RegionBlock.Recovery4

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -457,3 +457,4 @@ import TNLean.PEPS.RegionBlock.Recovery8
 import TNLean.PEPS.RegionBlock.Recovery9
 import TNLean.PEPS.RegionBlock.Recovery10
 import TNLean.PEPS.RegionBlock.Recovery11
+import TNLean.PEPS.RegionBlock.Recovery12

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -437,3 +437,6 @@ import TNLean.PEPS.RegionBlock.Recovery3
 -- `hform`: the region transfer matrix is the read-off of the pullback, so `hform` is the
 -- read-off round-trip whenever the pullback is of incident-matrix form on the boundary leg.
 import TNLean.PEPS.RegionBlock.Recovery4
+-- Out-of-region endpoint of a boundary edge: the second endpoint feeding the region
+-- resonate step; coincides with the in-region endpoint of `f` for the set complement.
+import TNLean.PEPS.RegionBlock.Recovery5

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -456,3 +456,4 @@ import TNLean.PEPS.RegionBlock.Recovery8
 -- behind the normal-PEPS Fundamental Theorem.
 import TNLean.PEPS.RegionBlock.Recovery9
 import TNLean.PEPS.RegionBlock.Recovery10
+import TNLean.PEPS.RegionBlock.Recovery11

--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -438,5 +438,79 @@ theorem regionInsertedCoeff_eq_doubleSum_transferCoeff (A B : Tensor G d) (R : F
   refine Finset.sum_congr rfl (fun ν' _ => ?_)
   rw [smul_eq_mul]
 
+/-! ### The coefficient transfer from the incident-matrix form of the transfer
+coefficient
+
+If the transfer coefficient `transferCoeff` has the incident-matrix coupling form
+of a single matrix `N` on the boundary bond `f` — coupling only the `f`-legs of the
+two boundary configurations and contracting the residual legs by the identity
+(`SameAwayFromBond`) — then the first tensor's region-inserted coefficient of `M`
+equals the second tensor's of `N`. This is the bridge from the reconcile structure
+to the coefficient transfer. -/
+
+open scoped Classical in
+/-- **The coefficient transfer from the incident-matrix form.** If there is a matrix
+`N` on the second tensor's bond whose incident-matrix coupling form reproduces the
+transfer coefficient, then the first tensor's region-inserted coefficient of `M`
+equals the second tensor's of `N` at every physical configuration.
+
+The double factorization `regionInsertedCoeff_eq_doubleSum_transferCoeff` writes the
+first tensor's coefficient as the double sum of the transfer coefficient against the
+second tensor's region and complement blocked weights; substituting the
+incident-matrix form and reindexing the complement boundary-configuration sum by the
+complement boundary-configuration equivalence yields the explicit double-sum form of
+the second tensor's region-inserted coefficient (`regionInsertedCoeff_eq`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_of_transferCoeff_form (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hform : ∀ (μ : RegionBoundaryConfig (G := G) B R)
+        (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)),
+      transferCoeff (G := G) A B R hRB hCB f M μ ν' =
+        (if SameAwayFromBond f μ
+              ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+            N (μ f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f) else 0))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ := by
+  classical
+  rw [regionInsertedCoeff_eq_doubleSum_transferCoeff A B R hRB hCB f hvA hvAout hAB hDim M σ τ,
+    regionInsertedCoeff_eq]
+  -- Reindex the second tensor's inner `ν`-sum by the complement boundary-config equivalence.
+  set E := regionComplementBoundaryConfigEquiv (G := G) B R with hE
+  rw [show (∑ μ : RegionBoundaryConfig (G := G) B R,
+        ∑ ν : RegionBoundaryConfig (G := G) B R,
+          (if SameAwayFromBond f μ ν then N (μ f) (ν f) else 0) *
+            regionBlockedWeight (G := G) B R μ σ *
+            regionBlockedWeight (G := G) B (Finset.univ \ R)
+              (regionComplementBoundaryConfig (G := G) B R ν) τ) =
+      ∑ μ : RegionBoundaryConfig (G := G) B R,
+        ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R),
+          (if SameAwayFromBond f μ (E.symm ν') then N (μ f) ((E.symm ν') f) else 0) *
+            regionBlockedWeight (G := G) B R μ σ *
+            regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ from ?_]
+  · refine Finset.sum_congr rfl (fun μ _ => Finset.sum_congr rfl (fun ν' _ => ?_))
+    rw [hform μ ν']
+    ring
+  · refine Finset.sum_congr rfl (fun μ _ => ?_)
+    rw [← Equiv.sum_comp E
+      (fun ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R) =>
+        (if SameAwayFromBond f μ (E.symm ν') then N (μ f) ((E.symm ν') f) else 0) *
+          regionBlockedWeight (G := G) B R μ σ *
+          regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ)]
+    refine Finset.sum_congr rfl (fun ν _ => ?_)
+    rw [hE, Equiv.symm_apply_apply, regionComplementBoundaryConfigEquiv_apply]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -261,5 +261,104 @@ theorem regionInsertedCoeff_eq_region_blockedMap_B (A B : Tensor G d) (R : Finse
   rw [regionBlockedTensorMap_doubleCompl B R]
   rfl
 
+/-! ### The double factorization of the first tensor's coefficient
+
+Combining the v-side and σ-side factorizations, the first tensor's region-inserted
+coefficient factors through both blocked endpoints of the second tensor at once:
+there is a doubly-indexed coefficient `K` with
+
+```
+coeff_A M σ τ = ∑_μ ∑_ν' K μ ν' · WB_R(μ, σ) · WB_Rc(ν', τ).
+```
+
+The region row `complSideRow τ` reads the coefficient off the region block
+(σ-side); as a function of `τ`, each region-row coordinate lies in the image of the
+second tensor's complement block (a finite linear combination of the v-side
+complement-image coefficients), so the complement left inverse reads off `K`. This
+is the membership the read-off rests on. -/
+
+/-- The region row read off the σ-side factorization through the second tensor's
+region block: `regionRowB A B R f hvAout M τ = regionBlockedLeftInverse B R hRB`
+applied to the first tensor's coefficient viewed as a function of `σ`. By the
+σ-side factorization it equals `complSideRow A B R f hvAout M τ`. -/
+noncomputable def regionRowB (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    RegionBoundaryConfig (G := G) B R → ℂ :=
+  regionBlockedLeftInverse (G := G) B R hRB (fun σ => regionInsertedCoeff (G := G) A R f M σ τ)
+
+/-- The region row equals the σ-side row. This is the σ-side read-off: the second
+tensor's region blocked left inverse applied to the first tensor's coefficient
+recovers the σ-side row `complSideRow`. -/
+theorem regionRowB_eq_complSideRow (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionRowB (G := G) A B R hRB f M τ = complSideRow (G := G) A B R f hvAout M τ := by
+  rw [regionRowB, regionInsertedCoeff_eq_region_blockedMap_B A B R f hvAout hAB hDim M τ,
+    regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
+/-- **Membership of the region row in the complement block image.** For each region
+boundary configuration `μ` of the second tensor, the region-row coordinate
+`regionRowB … τ μ`, as a function of the complement physical configuration `τ`,
+lies in the image of the second tensor's complement blocked tensor map.
+
+Writing the first tensor's coefficient, as a function of `σ`, over the standard
+basis, the region left inverse is linear, so the region-row coordinate is a finite
+linear combination of the coefficients `fun τ => coeff_A M σ' τ`; each of these lies
+in the complement block image by the v-side factorization
+`regionInsertedCoeff_eq_complement_blockedMap_vSideRow`, and the image is a
+submodule. -/
+theorem regionRowB_mem_range (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (μ : RegionBoundaryConfig (G := G) B R) :
+    (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        regionRowB (G := G) A B R hRB f M τ μ) ∈
+      LinearMap.range (regionBlockedTensorMap (G := G) B (Finset.univ \ R)) := by
+  classical
+  -- Each coefficient `fun τ => coeff_A M σ' τ` lies in the complement block image.
+  have hmem : ∀ σ' : RegionPhysicalConfig (V := V) (d := d) R,
+      (fun τ => regionInsertedCoeff (G := G) A R f M σ' τ) ∈
+        LinearMap.range (regionBlockedTensorMap (G := G) B (Finset.univ \ R)) := by
+    intro σ'
+    rw [regionInsertedCoeff_eq_complement_blockedMap_vSideRow A B R f hvA hAB hDim M σ']
+    exact LinearMap.mem_range_self _ _
+  -- The region-row coordinate is the linear combination of these over the basis of `σ`.
+  have hexpand : (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        regionRowB (G := G) A B R hRB f M τ μ) =
+      ∑ σ' : RegionPhysicalConfig (V := V) (d := d) R,
+        (regionBlockedLeftInverse (G := G) B R hRB
+            (fun σ => if σ = σ' then (1 : ℂ) else 0) μ) •
+          (fun τ => regionInsertedCoeff (G := G) A R f M σ' τ) := by
+    funext τ
+    rw [regionRowB]
+    rw [show (fun σ => regionInsertedCoeff (G := G) A R f M σ τ) =
+        ∑ σ' : RegionPhysicalConfig (V := V) (d := d) R,
+          regionInsertedCoeff (G := G) A R f M σ' τ •
+            (fun σ => if σ = σ' then (1 : ℂ) else 0) from ?_]
+    · rw [map_sum]
+      simp only [map_smul, Finset.sum_apply, Pi.smul_apply, smul_eq_mul, mul_comm]
+    · funext σ
+      rw [Finset.sum_apply]
+      rw [Finset.sum_eq_single σ]
+      · rw [Pi.smul_apply, if_pos rfl, smul_eq_mul, mul_one]
+      · intro σ'' _ hne
+        rw [Pi.smul_apply, if_neg (Ne.symm hne), smul_zero]
+      · intro hσ; exact absurd (Finset.mem_univ σ) hσ
+  rw [hexpand]
+  refine Submodule.sum_mem _ (fun σ' _ => ?_)
+  exact Submodule.smul_mem _ _ (hmem σ')
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -119,5 +119,64 @@ theorem regionInsertedCoeff_eq_of_complementRow_eq (A B : Tensor G d) (R : Finse
     (regionInsertedCoeff_eq_complement_blockedMap_vSideRow A B R f hvA hAB hDim M σ) τ
   rw [hA, hrow σ, ← regionInsertedCoeff_eq_complement_blockedMap B R f N σ τ]
 
+/-! ### The double-complement transport of the blocked tensor map
+
+The blocked tensor map of `univ \ (univ \ R)`, applied to a row function and
+evaluated at the double-complement transport of a region physical configuration,
+equals the blocked tensor map of `R` applied to the row precomposed with the
+double-complement boundary-configuration transport. This isolates the dependent
+reindexing `univ \ (univ \ R) = R` into a single tensor-map identity, built from
+the double-complement weight invariance `regionBlockedWeight_doubleCompl`
+(`Recovery6`). -/
+
+/-- The double-complement boundary-configuration transport as an equivalence: a
+boundary configuration on `R` corresponds to one on `univ \ (univ \ R)` by reading
+each crossing edge under the double-complement boundary-edge equivalence. -/
+def regionDoubleComplBoundaryConfigEquiv (A : Tensor G d) (R : Finset V) :
+    RegionBoundaryConfig (G := G) A R ≃
+      RegionBoundaryConfig (G := G) A (Finset.univ \ (Finset.univ \ R)) where
+  toFun := regionDoubleComplBoundaryConfig (G := G) A R
+  invFun bdry := fun e => bdry ((regionBoundaryEdgeDoubleComplEquiv (G := G) R).symm e)
+  left_inv bdry := by
+    funext e
+    simp only [regionDoubleComplBoundaryConfig]
+    congr 1
+  right_inv bdry := by
+    funext e
+    simp only [regionDoubleComplBoundaryConfig]
+    congr 1
+
+/-- **The double-complement transport of the blocked tensor map.** The blocked
+tensor map of `univ \ (univ \ R)` applied to a row `c`, evaluated at the
+double-complement transport of `σ`, equals the blocked tensor map of `R` applied to
+`c` precomposed with the double-complement boundary-configuration transport,
+evaluated at `σ`.
+
+Expanding both sides as boundary-configuration sums (`regionBlockedTensorMap_apply`)
+and reindexing the left sum by the double-complement boundary-configuration
+equivalence, each summand matches by the double-complement weight invariance
+`regionBlockedWeight_doubleCompl`. -/
+theorem regionBlockedTensorMap_doubleCompl (A : Tensor G d) (R : Finset V)
+    (c : RegionBoundaryConfig (G := G) A (Finset.univ \ (Finset.univ \ R)) → ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    regionBlockedTensorMap (G := G) A (Finset.univ \ (Finset.univ \ R)) c
+        (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ) =
+      regionBlockedTensorMap (G := G) A R
+        (fun bdry => c (regionDoubleComplBoundaryConfig (G := G) A R bdry)) σ := by
+  classical
+  rw [regionBlockedTensorMap_apply, regionBlockedTensorMap_apply]
+  rw [← Equiv.sum_comp (regionDoubleComplBoundaryConfigEquiv (G := G) A R)
+    (fun w : RegionBoundaryConfig (G := G) A (Finset.univ \ (Finset.univ \ R)) =>
+      c w • regionBlockedWeight (G := G) A (Finset.univ \ (Finset.univ \ R)) w
+        (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ))]
+  refine Finset.sum_congr rfl (fun bdry _ => ?_)
+  show c (regionDoubleComplBoundaryConfig (G := G) A R bdry) •
+      regionBlockedWeight (G := G) A (Finset.univ \ (Finset.univ \ R))
+        (regionDoubleComplBoundaryConfig (G := G) A R bdry)
+        (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ) =
+    c (regionDoubleComplBoundaryConfig (G := G) A R bdry) •
+      regionBlockedWeight (G := G) A R bdry σ
+  rw [regionBlockedWeight_doubleCompl A R bdry σ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -360,5 +360,39 @@ theorem regionRowB_mem_range (A B : Tensor G d) (R : Finset V)
   refine Submodule.sum_mem _ (fun σ' _ => ?_)
   exact Submodule.smul_mem _ _ (hmem σ')
 
+/-- The doubly-indexed transfer coefficient: the second tensor's complement blocked
+left inverse applied to the region-row coordinate viewed as a function of the
+complement physical configuration. By the membership
+`regionRowB_mem_range`, it reproduces the region-row coordinate against the
+complement block. -/
+noncomputable def transferCoeff (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (μ : RegionBoundaryConfig (G := G) B R) :
+    RegionBoundaryConfig (G := G) B (Finset.univ \ R) → ℂ :=
+  regionBlockedLeftInverse (G := G) B (Finset.univ \ R) hCB
+    (fun τ => regionRowB (G := G) A B R hRB f M τ μ)
+
+/-- The region-row coordinate, as a function of the complement physical
+configuration, is the second tensor's complement blocked tensor map applied to the
+transfer coefficient. This is the complement read-off from the membership
+`regionRowB_mem_range`. -/
+theorem regionRowB_eq_complement_blockedMap (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (μ : RegionBoundaryConfig (G := G) B R) :
+    (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        regionRowB (G := G) A B R hRB f M τ μ) =
+      regionBlockedTensorMap (G := G) B (Finset.univ \ R)
+        (transferCoeff (G := G) A B R hRB hCB f M μ) := by
+  obtain ⟨c, hc⟩ := regionRowB_mem_range A B R hRB f hvA hAB hDim M μ
+  rw [transferCoeff, ← hc, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -170,13 +170,8 @@ theorem regionBlockedTensorMap_doubleCompl (A : Tensor G d) (R : Finset V)
       c w • regionBlockedWeight (G := G) A (Finset.univ \ (Finset.univ \ R)) w
         (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ))]
   refine Finset.sum_congr rfl (fun bdry _ => ?_)
-  show c (regionDoubleComplBoundaryConfig (G := G) A R bdry) •
-      regionBlockedWeight (G := G) A (Finset.univ \ (Finset.univ \ R))
-        (regionDoubleComplBoundaryConfig (G := G) A R bdry)
-        (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ) =
-    c (regionDoubleComplBoundaryConfig (G := G) A R bdry) •
-      regionBlockedWeight (G := G) A R bdry σ
-  rw [regionBlockedWeight_doubleCompl A R bdry σ]
+  refine congrArg (c (regionDoubleComplBoundaryConfig (G := G) A R bdry) • ·) ?_
+  exact regionBlockedWeight_doubleCompl A R bdry σ
 
 /-! ### The σ-side region factorization of the first tensor's coefficient
 
@@ -520,7 +515,6 @@ complement boundary configuration. This relates the two read-offs: the v-side
 complement read-off and the σ-side region read-off agree on the transfer
 coefficient. -/
 
-set_option maxHeartbeats 800000 in
 /-- **The v-side row is the region blocked map of the transfer coefficient.** The
 v-side row at the complement boundary configuration `ν'`, as a function of the region
 physical configuration, is the second tensor's region blocked tensor map applied to

--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -178,5 +178,88 @@ theorem regionBlockedTensorMap_doubleCompl (A : Tensor G d) (R : Finset V)
       regionBlockedWeight (G := G) A R bdry σ
   rw [regionBlockedWeight_doubleCompl A R bdry σ]
 
+/-! ### The σ-side region factorization of the first tensor's coefficient
+
+The symmetric counterpart of the v-side factorization
+`regionInsertedCoeff_eq_complement_blockedMap_B`. The first tensor's
+region-inserted coefficient, as a function of the *region* physical configuration
+`σ`, is the second tensor's *region* blocked tensor map applied to a row function.
+The proof rereads the coefficient on the set complement `univ \ R` through the cast
+identity `regionInsertedCoeff_eq_compl` (`Recovery6`), applies the v-side
+factorization there (its complement is `univ \ (univ \ R)`), and transports the
+`univ \ (univ \ R)` block back to `R` by `regionBlockedTensorMap_doubleCompl`. This
+is the membership the σ-side read-off rests on: the σ-dependence runs through the
+second tensor's region block. -/
+
+/-- The σ-side row of the first tensor's region-inserted coefficient through the
+second tensor's region block: the out-of-region endpoint operator of the first
+tensor from `M.transpose`, applied to the second tensor's complement weight vector
+at the reindexed boundary configuration, evaluated at the out-of-region endpoint
+physical leg, with the boundary configuration transported across the double
+complement.
+
+This is the symmetric analogue of `vSideRow`, read off the cast identity
+`regionInsertedCoeff_eq_compl` and the v-side factorization applied to the set
+complement `univ \ R`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def complSideRow (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    RegionBoundaryConfig (G := G) B R → ℂ :=
+  fun bdry =>
+    (regionInsertionOp (G := G) A (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f) hvAout M.transpose.transpose
+        (regionWeightVec (G := G) B (Finset.univ \ R)
+          (regionBoundaryEdgeToCompl (G := G) R f)
+          ((regionComplementBoundaryConfigEquiv (G := G) B (Finset.univ \ R)).symm
+            (regionDoubleComplBoundaryConfig (G := G) B R bdry)) τ))
+      (τ ⟨regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+          (regionBoundaryEdgeToCompl (G := G) R f),
+        regionBoundaryEdgeInVertex_mem (G := G) (Finset.univ \ R)
+          (regionBoundaryEdgeToCompl (G := G) R f)⟩)
+
+/-- **The σ-side region factorization.** The first tensor's region-inserted
+coefficient of `M`, as a function of the region physical configuration `σ`, is the
+second tensor's region blocked tensor map applied to the σ-side row.
+
+The cast identity `regionInsertedCoeff_eq_compl` rereads the coefficient on the set
+complement `univ \ R`; the v-side factorization
+`regionInsertedCoeff_eq_complement_blockedMap_B` applied there writes it as the
+second tensor's `univ \ (univ \ R)` blocked tensor map of a row, evaluated at the
+double-complement transport of `σ`; and `regionBlockedTensorMap_doubleCompl`
+transports the `univ \ (univ \ R)` block back to `R`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_region_blockedMap_B (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (fun σ : RegionPhysicalConfig (V := V) (d := d) R =>
+        regionInsertedCoeff (G := G) A R f M σ τ) =
+      regionBlockedTensorMap (G := G) B R (complSideRow (G := G) A B R f hvAout M τ) := by
+  funext σ
+  -- Reread the coefficient on the set complement `univ \ R`.
+  rw [regionInsertedCoeff_eq_compl A R f M σ τ]
+  -- The v-side factorization on `univ \ R`, evaluated at the double-complement of `σ`.
+  have hv := congrFun
+    (regionInsertedCoeff_eq_complement_blockedMap_B A B (Finset.univ \ R)
+      (regionBoundaryEdgeToCompl (G := G) R f) hvAout hAB hDim M.transpose τ)
+    (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)
+  rw [hv]
+  -- Transport the `univ \ (univ \ R)` block back to `R`.
+  rw [regionBlockedTensorMap_doubleCompl B R]
+  rfl
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -512,5 +512,70 @@ theorem regionInsertedCoeff_eq_of_transferCoeff_form (A B : Tensor G d) (R : Fin
     refine Finset.sum_congr rfl (fun ν _ => ?_)
     rw [hE, Equiv.symm_apply_apply, regionComplementBoundaryConfigEquiv_apply]
 
+/-! ### The v-side row through the transfer coefficient
+
+The v-side row, as a function of the region physical configuration, is the second
+tensor's region blocked tensor map applied to the transfer coefficient at the fixed
+complement boundary configuration. This relates the two read-offs: the v-side
+complement read-off and the σ-side region read-off agree on the transfer
+coefficient. -/
+
+set_option maxHeartbeats 800000 in
+/-- **The v-side row is the region blocked map of the transfer coefficient.** The
+v-side row at the complement boundary configuration `ν'`, as a function of the region
+physical configuration, is the second tensor's region blocked tensor map applied to
+the transfer-coefficient column `fun μ => transferCoeff … μ ν'`.
+
+Both the v-side factorization and the double factorization write the first tensor's
+coefficient against the second tensor's complement block; linear independence of the
+complement blocked weights (`hCB`) forces the two complement coefficients to agree.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem vSideRow_eq_region_blockedMap_transferCoeff (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)) :
+    (fun σ : RegionPhysicalConfig (V := V) (d := d) R =>
+        vSideRow (G := G) A B R f hvA M σ ν') =
+      regionBlockedTensorMap (G := G) B R
+        (fun μ => transferCoeff (G := G) A B R hRB hCB f M μ ν') := by
+  classical
+  funext σ
+  -- The v-side row is the complement read-off of `coeff_A` at `σ`.
+  have hvrow : vSideRow (G := G) A B R f hvA M σ =
+      regionBlockedLeftInverse (G := G) B (Finset.univ \ R) hCB
+        (fun τ => regionInsertedCoeff (G := G) A R f M σ τ) := by
+    rw [regionInsertedCoeff_eq_complement_blockedMap_vSideRow A B R f hvA hAB hDim M σ,
+      regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+  -- The double factorization writes `coeff_A` at `σ` through the complement block too.
+  have hdouble : (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        regionInsertedCoeff (G := G) A R f M σ τ) =
+      regionBlockedTensorMap (G := G) B (Finset.univ \ R)
+        (fun ν'' => regionBlockedTensorMap (G := G) B R
+          (fun μ => transferCoeff (G := G) A B R hRB hCB f M μ ν'') σ) := by
+    funext τ
+    rw [regionInsertedCoeff_eq_doubleSum_transferCoeff A B R hRB hCB f hvA hvAout hAB hDim M σ τ,
+      regionBlockedTensorMap_apply, Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun ν'' _ => ?_)
+    rw [regionBlockedTensorMap_apply, smul_eq_mul, Finset.sum_mul]
+    refine Finset.sum_congr rfl (fun μ _ => ?_)
+    rw [smul_eq_mul]
+    ring
+  -- The complement read-off of `coeff_A` at `σ` is the inner region blocked map.
+  have hread : regionBlockedLeftInverse (G := G) B (Finset.univ \ R) hCB
+        (fun τ => regionInsertedCoeff (G := G) A R f M σ τ) =
+      (fun ν'' => regionBlockedTensorMap (G := G) B R
+        (fun μ => transferCoeff (G := G) A B R hRB hCB f M μ ν'') σ) := by
+    rw [hdouble, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+  rw [hvrow, hread]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -1,0 +1,123 @@
+import TNLean.PEPS.RegionBlock.Recovery9
+
+/-!
+# Region physical-to-virtual recovery: the coefficient transfer
+
+This file closes the single remaining gap of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, Section 3): the **coefficient transfer**. For every inserted
+matrix `M` on the first tensor's boundary bond there is a matrix `N` on the second
+tensor's bond whose region-inserted coefficient equals the first tensor's at every
+physical configuration. Feeding it to `regionResonateReconcile_of_coeff_transfer`
+(`TNLean.PEPS.RegionBlock.Recovery9`) yields the region resonate reconcile
+`RegionResonateReconcile`, the last open obligation of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## Strategy
+
+The v-side factorization `regionInsertedCoeff_eq_complement_blockedMap_B`
+(`Recovery9`) writes the first tensor's region-inserted coefficient, as a function
+of the complement physical configuration `τ`, as the second tensor's complement
+blocked tensor map applied to a row function `cRow σ`. The B-analogue
+`regionInsertedCoeff_eq_complement_blockedMap` (`Recovery7`) writes the *second*
+tensor's region-inserted coefficient of `N` in the same complement form, with row
+function `regionComplementRow B R f N σ`. Since the second tensor's complement
+blocked tensor map is injective (`hCB`), the coefficient transfer is equivalent to
+producing a matrix `N` whose complement row matches `cRow σ` at every `σ`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The v-side row and the reduction of the coefficient transfer
+
+The v-side row `vSideRow A B R f hvA hAB hDim M σ` is the row function reading the
+first tensor's in-region endpoint operator against the second tensor's region
+weight vectors at the endpoint leg. By the v-side factorization
+`regionInsertedCoeff_eq_complement_blockedMap_B`, the first tensor's region-inserted
+coefficient, as a function of the complement physical configuration, is the second
+tensor's complement blocked tensor map applied to this row. -/
+
+/-- The v-side row of the first tensor's region-inserted coefficient through the
+second tensor's complement block: for a complement boundary configuration `ν` of
+`univ \ R`, the first tensor's in-region endpoint operator from `M.transpose`,
+applied to the second tensor's region weight vector at the reindexed boundary
+configuration, evaluated at the endpoint physical leg `σ v`.
+
+This is the row read off by `regionBlockedLeftInverse_complement_regionInsertedCoeff_B`
+(`Recovery9`): the second tensor's complement blocked left inverse applied to the
+first tensor's region-inserted coefficient viewed as a function of the complement
+physical configuration recovers `vSideRow`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def vSideRow (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    RegionBoundaryConfig (G := G) B (Finset.univ \ R) → ℂ :=
+  fun ν =>
+    (regionInsertionOp (G := G) A R f hvA M.transpose
+        (regionWeightVec (G := G) B R f
+          ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν) σ))
+      (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+        regionBoundaryEdgeInVertex_mem (G := G) R f⟩)
+
+/-- The first tensor's region-inserted coefficient of `M`, as a function of the
+complement physical configuration `τ`, is the second tensor's complement blocked
+tensor map applied to the v-side row. This restates
+`regionInsertedCoeff_eq_complement_blockedMap_B` (`Recovery9`) with the row named. -/
+theorem regionInsertedCoeff_eq_complement_blockedMap_vSideRow (A B : Tensor G d)
+    (R : Finset V) (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        regionInsertedCoeff (G := G) A R f M σ τ) =
+      regionBlockedTensorMap (G := G) B (Finset.univ \ R)
+        (vSideRow (G := G) A B R f hvA M σ) :=
+  regionInsertedCoeff_eq_complement_blockedMap_B A B R f hvA hAB hDim M σ
+
+/-- **Reduction of the coefficient transfer to the row equality.** If there is a
+matrix `N` on the second tensor's bond whose complement row matches the v-side row
+at every region physical configuration, then the region-inserted coefficient of `M`
+in the first tensor equals that of `N` in the second at every physical configuration.
+
+The second tensor's complement blocked tensor map sends the matched rows to the two
+region-inserted coefficients (v-side `regionInsertedCoeff_eq_complement_blockedMap_B`
+for the first tensor and `regionInsertedCoeff_eq_complement_blockedMap` for the
+second), so equal rows give equal coefficients.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_of_complementRow_eq (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hrow : ∀ σ : RegionPhysicalConfig (V := V) (d := d) R,
+      vSideRow (G := G) A B R f hvA M σ = regionComplementRow (G := G) B R f N σ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ := by
+  have hA := congrFun
+    (regionInsertedCoeff_eq_complement_blockedMap_vSideRow A B R f hvA hAB hDim M σ) τ
+  rw [hA, hrow σ, ← regionInsertedCoeff_eq_complement_blockedMap B R f N σ τ]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -394,5 +394,49 @@ theorem regionRowB_eq_complement_blockedMap (A B : Tensor G d) (R : Finset V)
   obtain ⟨c, hc⟩ := regionRowB_mem_range A B R hRB f hvA hAB hDim M μ
   rw [transferCoeff, ← hc, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
 
+/-- **The double factorization.** The first tensor's region-inserted coefficient of
+`M` is the doubly-blocked contraction of the second tensor: a boundary-configuration
+double sum of the transfer coefficient against the second tensor's region and
+complement blocked weights.
+
+The σ-side factorization writes the coefficient as the second tensor's region
+blocked tensor map of the region row; the region row, as a function of the
+complement physical configuration, is the second tensor's complement blocked tensor
+map of the transfer coefficient (`regionRowB_eq_complement_blockedMap`). Expanding
+both blocked tensor maps gives the double sum.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_doubleSum_transferCoeff (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      ∑ μ : RegionBoundaryConfig (G := G) B R,
+        ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R),
+          transferCoeff (G := G) A B R hRB hCB f M μ ν' *
+            regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ *
+            regionBlockedWeight (G := G) B R μ σ := by
+  -- The σ-side factorization.
+  have hσ := congrFun
+    (regionInsertedCoeff_eq_region_blockedMap_B A B R f hvAout hAB hDim M τ) σ
+  rw [hσ, regionBlockedTensorMap_apply]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  -- `complSideRow τ μ` is the region row, which is the complement blocked map of `K`.
+  rw [← regionRowB_eq_complSideRow A B R hRB f hvAout hAB hDim M τ]
+  have hrow := congrFun
+    (regionRowB_eq_complement_blockedMap A B R hRB hCB f hvA hAB hDim M μ) τ
+  rw [hrow, regionBlockedTensorMap_apply, smul_eq_mul, Finset.sum_mul]
+  refine Finset.sum_congr rfl (fun ν' _ => ?_)
+  rw [smul_eq_mul]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery11.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery11.lean
@@ -1,0 +1,91 @@
+import TNLean.PEPS.RegionBlock.Recovery10
+
+/-!
+# Region physical-to-virtual recovery: the incident-matrix form of the transfer coefficient
+
+This file closes the final reconcile of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, Section 3): the **incident-matrix form** of the transfer
+coefficient `transferCoeff` (`TNLean.PEPS.RegionBlock.Recovery10`). This is the
+region analogue of the source step `V=W` in Lemma `inj_isomorph`, forced by the
+region resonate identity together with full injectivity of both blocked
+endpoints.
+
+Feeding the form to `regionInsertedCoeff_eq_of_transferCoeff_form`
+(`Recovery10`) yields, for each inserted matrix `M`, a matching matrix `N` whose
+region-inserted coefficient equals the first tensor's, which is the coefficient
+transfer hypothesis of `regionResonateReconcile_of_coeff_transfer`
+(`TNLean.PEPS.RegionBlock.Recovery9`), giving the region resonate reconcile
+`RegionResonateReconcile` and hence the per-edge gauge
+`exists_regionEdgeGauge_of_reconcile` (`TNLean.PEPS.RegionBlock.Recovery8`).
+
+## Strategy
+
+The transfer coefficient column `fun μ => transferCoeff … μ ν'` is the second
+tensor's region blocked left inverse of the v-side row
+`fun σ => vSideRow … σ ν'` (read off `vSideRow_eq_region_blockedMap_transferCoeff`,
+`Recovery10`). The v-side row is the first tensor's in-region endpoint operator,
+from `M.transpose`, applied to the *second* tensor's region weight vector at the
+reindexed complement boundary configuration. The region resonate inversion (the
+analogue of `resonate_invert_right_endpoint`,
+`TNLean.PEPS.InsertionRealization`) expresses this endpoint read-off as the
+incident-matrix coupling of a single matrix on the boundary bond against the
+second tensor's region blocked weights, with the residual legs contracted by the
+identity. The region blocked left inverse then collapses to the standard basis,
+exhibiting the incident-matrix form of the transfer coefficient.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The transfer-coefficient column as the region read-off of the v-side row
+
+The transfer coefficient `transferCoeff … μ ν'`, viewed as a column over the
+region boundary configuration `μ` at a fixed complement boundary configuration
+`ν'`, is the second tensor's region blocked left inverse of the v-side row
+`fun σ => vSideRow … σ ν'`. This inverts the region factorization
+`vSideRow_eq_region_blockedMap_transferCoeff` (`Recovery10`) and is the read-off
+the incident-matrix form is concluded against. -/
+
+/-- **The transfer-coefficient column is the region read-off of the v-side row.**
+The transfer coefficient column at the complement boundary configuration `ν'`,
+viewed as a function of the region boundary configuration, is the second tensor's
+region blocked left inverse applied to the v-side row at `ν'`.
+
+The v-side factorization `vSideRow_eq_region_blockedMap_transferCoeff` writes the
+v-side row as the second tensor's region blocked tensor map of the transfer
+coefficient column; the region blocked left inverse recovers the column.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem transferCoeff_column_eq_regionBlockedLeftInverse_vSideRow
+    (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)) :
+    (fun μ => transferCoeff (G := G) A B R hRB hCB f M μ ν') =
+      regionBlockedLeftInverse (G := G) B R hRB
+        (fun σ => vSideRow (G := G) A B R f hvA M σ ν') := by
+  rw [vSideRow_eq_region_blockedMap_transferCoeff A B R hRB hCB f hvA hvAout hAB hDim M ν',
+    regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery11.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery11.lean
@@ -87,5 +87,194 @@ theorem transferCoeff_column_eq_regionBlockedLeftInverse_vSideRow
   rw [vSideRow_eq_region_blockedMap_transferCoeff A B R hRB hCB f hvA hvAout hAB hDim M ν',
     regionBlockedLeftInverse_apply_regionBlockedTensorMap]
 
+/-! ### The v-side row through the virtual pullback
+
+The v-side row is the first tensor's in-region endpoint operator
+`regionInsertionOp A R f hvA M.transpose`, applied to the *second* tensor's region
+weight vector at the reindexed complement boundary configuration, read at the
+endpoint leg. The region weight vector is the second tensor's local tensor map of
+the region open coefficient, so the unconditional image-preservation realization
+`localTensorMap_localVirtualOpOfPhysicalOpAt_regionInsertionOp` (`Recovery4`)
+rewrites the endpoint operator's action as the second tensor's local tensor map of
+the virtual pullback `W` applied to the region open coefficient. This is the region
+analogue of inverting an endpoint of the resonate identity: the action of the
+first tensor's operator on the second tensor's weight vectors runs entirely through
+the virtual pullback `W`. -/
+
+/-- **The v-side row through the virtual pullback.** The v-side row equals the
+second tensor's local tensor map of the virtual pullback
+`W := localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA M.transpose)`
+applied to the second tensor's region open coefficient at the reindexed complement
+boundary configuration, read at the endpoint leg.
+
+The region weight vector is the second tensor's local tensor map of the region open
+coefficient (by definition of `regionWeightVec`), and the unconditional
+image-preservation realization
+`localTensorMap_localVirtualOpOfPhysicalOpAt_regionInsertionOp` rewrites the first
+tensor's endpoint operator on a second-tensor local tensor image as the second
+tensor's local tensor map of the virtual pullback. This holds with no matrix
+read-off, so it is non-circular.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem vSideRow_eq_localTensorMap_virtualPullback (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)) :
+    vSideRow (G := G) A B R f hvA M σ ν' =
+      localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f)
+          (localVirtualOpOfPhysicalOpAt B hvB
+            (regionInsertionOp (G := G) A R f hvA M.transpose)
+            (regionOpenCoeff (G := G) B R f
+              ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') σ))
+        (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+          regionBoundaryEdgeInVertex_mem (G := G) R f⟩) := by
+  rw [vSideRow, regionWeightVec,
+    ← localTensorMap_localVirtualOpOfPhysicalOpAt_regionInsertionOp A B R f hvA hvB hAB hA hB
+      hposA hposB M
+      (regionOpenCoeff (G := G) B R f
+        ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') σ)]
+
+/-! ### The incident-matrix form of the v-side row
+
+When the virtual pullback `W` is of incident-matrix form on the boundary leg —
+`W = localIncidentMatrixOp B inc N.transpose` for a matrix `N` on the second
+tensor's bond — the v-side row collapses to the incident-matrix coupling of `N`
+against the second tensor's region blocked weights. The local tensor map of the
+incident insertion is the second tensor's own in-region endpoint operator of
+`N.transpose` (by `regionInsertionOp_realizes`), and reading it at the endpoint leg
+is the inner-sum realization `region_innerSum_eq_realized`, the explicit
+incident-matrix sum. This is the v-side half of the region reconcile. -/
+
+open scoped Classical in
+/-- **The incident-matrix form of the v-side row.** If the virtual pullback
+`W := localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA M.transpose)`
+is of incident-matrix form `localIncidentMatrixOp B inc N.transpose`, then the
+v-side row at the complement boundary configuration `ν'` is the incident-matrix
+coupling of `N` on the boundary edge against the second tensor's region blocked
+weights, with the residual legs contracted by the identity:
+`vSideRow … σ ν' = ∑_μ (if SameAwayFromBond f μ ((E B R).symm ν') then N (μ f)
+(((E B R).symm ν') f) else 0) · WB_R(μ, σ)`.
+
+The v-side row is the second tensor's local tensor map of `W` applied to the region
+open coefficient (`vSideRow_eq_localTensorMap_virtualPullback`); substituting the
+incident-matrix form of `W` and applying `regionInsertionOp_realizes` rewrites it as
+the second tensor's in-region endpoint operator of `N.transpose` on the region
+weight vector, which the inner-sum realization `region_innerSum_eq_realized`
+expands to the incident-matrix sum.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem vSideRow_eq_incidentSum_of_virtualPullback_incidentForm (A B : Tensor G d)
+    (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hform : localVirtualOpOfPhysicalOpAt B hvB
+        (regionInsertionOp (G := G) A R f hvA M.transpose) =
+      localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)) :
+    vSideRow (G := G) A B R f hvA M σ ν' =
+      ∑ μ : RegionBoundaryConfig (G := G) B R,
+        (if SameAwayFromBond f μ
+              ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+            N (μ f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f) else 0) *
+          regionBlockedWeight (G := G) B R μ σ := by
+  classical
+  rw [vSideRow_eq_localTensorMap_virtualPullback A B R f hvA hvB hAB hA hB hposA hposB M σ ν',
+    hform,
+    ← regionInsertionOp_realizes B R f hvB N.transpose
+      (regionOpenCoeff (G := G) B R f
+        ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') σ),
+    ← regionWeightVec,
+    ← region_innerSum_eq_realized B R f hvB N
+      ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') σ]
+
+/-! ### The incident-matrix form of the transfer coefficient from the virtual pullback
+
+Combining the region read-off of the transfer-coefficient column with the
+incident-matrix form of the v-side row gives the incident-matrix form of the
+transfer coefficient itself: when the virtual pullback `W` is of incident-matrix
+form `localIncidentMatrixOp B inc N.transpose`, the transfer coefficient is the
+incident-matrix coupling of `N` on the boundary edge `f`, with the residual legs
+contracted by the identity. This is the `hform` hypothesis of
+`regionInsertedCoeff_eq_of_transferCoeff_form` (`Recovery10`), reduced to the
+incident-matrix structure of the virtual pullback. -/
+
+open scoped Classical in
+/-- **The incident-matrix form of the transfer coefficient.** If the virtual pullback
+`W := localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA M.transpose)`
+is of incident-matrix form `localIncidentMatrixOp B inc N.transpose` for a matrix
+`N` on the second tensor's bond, then the transfer coefficient has the
+incident-matrix coupling form of `N` on the boundary edge `f`:
+`transferCoeff … μ ν' = if SameAwayFromBond f μ ((E B R).symm ν') then N (μ f)
+(((E B R).symm ν') f) else 0`.
+
+The transfer-coefficient column is the second tensor's region blocked left inverse of
+the v-side row (`transferCoeff_column_eq_regionBlockedLeftInverse_vSideRow`); the
+v-side row is the incident-matrix sum of `N` against the region blocked weights
+(`vSideRow_eq_incidentSum_of_virtualPullback_incidentForm`), so the left inverse
+collapses each blocked weight to the standard basis configuration
+(`regionBlockedLeftInverse_regionBlockedWeight`), reading off the incident-matrix
+coupling at the configuration `μ`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem transferCoeff_eq_incidentForm_of_virtualPullback_incidentForm (A B : Tensor G d)
+    (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hform : localVirtualOpOfPhysicalOpAt B hvB
+        (regionInsertionOp (G := G) A R f hvA M.transpose) =
+      localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose)
+    (μ : RegionBoundaryConfig (G := G) B R)
+    (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)) :
+    transferCoeff (G := G) A B R hRB hCB f M μ ν' =
+      (if SameAwayFromBond f μ
+            ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+          N (μ f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f) else 0) := by
+  classical
+  have hcol := congrFun
+    (transferCoeff_column_eq_regionBlockedLeftInverse_vSideRow
+      A B R hRB hCB f hvA hvAout hAB hDim M ν') μ
+  rw [hcol]
+  -- The v-side row is the incident-matrix sum, i.e. the region blocked tensor map of
+  -- the incident-matrix coupling column; the region left inverse collapses it.
+  have hvrow : (fun σ : RegionPhysicalConfig (V := V) (d := d) R =>
+        vSideRow (G := G) A B R f hvA M σ ν') =
+      regionBlockedTensorMap (G := G) B R
+        (fun μ' : RegionBoundaryConfig (G := G) B R =>
+          (if SameAwayFromBond f μ'
+                ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+              N (μ' f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f)
+            else 0)) := by
+    funext σ
+    rw [vSideRow_eq_incidentSum_of_virtualPullback_incidentForm
+      A B R f hvA hvB hAB hA hB hposA hposB M N hform σ ν', regionBlockedTensorMap_apply]
+    refine Finset.sum_congr rfl (fun μ' _ => ?_)
+    rw [smul_eq_mul]
+  rw [hvrow, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery12.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery12.lean
@@ -166,5 +166,145 @@ theorem edgeLeftInsertionOp_realizes_edgeLeftTransferMatrix
   rw [hYeq]
   exact hY'left
 
+/-! ### Incident-matrix form of the transferred insertion at an arbitrary incidence
+
+The region insertion operator on a boundary edge `f` is, by definition, the
+physical realization of an incident-matrix operation on the incidence
+`regionBoundaryEdgeInIncident R f` of the bond `f.1`. The following helper works at
+an arbitrary incidence `ie` of an arbitrary vertex `v`: it shows that the virtual
+pullback of the transferred operator is again of incident-matrix form. Keeping the
+vertex `v` a free variable makes the dependence on the orientation
+(`v = ie.1.1.1` versus `v = ie.1.1.2`) a clean case split, discharged by the two
+edge realizations on the bond `ie.1`. -/
+
+/-- **Incident-matrix form of the transferred incident insertion.** For an incidence
+`ie` of a vertex `v` lying on the bond `ie.1`, the virtual pullback of the physical
+realization of `localIncidentMatrixOp A ie M`, transferred to `B` across
+`SameState`, is of incident-matrix form on the same incidence `ie`.
+
+The two orientations of `v` on the bond `ie.1` are handled by the right and left
+edge realizations on `ie.1`. This is the incidence-level core of the region
+resonate reconcile.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isIncidentMatrixForm_transferred_incidentInsertion
+    (A B : Tensor G d) {v : V} (ie : IncidentEdge G v)
+    (hvA : LinearIndependent ℂ (A.component v))
+    (hvB : LinearIndependent ℂ (B.component v))
+    (hA : EdgeBlockedThreeSiteInjective (G := G) A ie.1)
+    (hB : EdgeBlockedThreeSiteInjective (G := G) B ie.1)
+    (hAB : SameState A B) (hposB : ∀ f : Edge G, 0 < B.bondDim f)
+    (M : Matrix (Fin (A.bondDim ie.1)) (Fin (A.bondDim ie.1)) ℂ) :
+    ∃ P : Matrix (Fin (B.bondDim ie.1)) (Fin (B.bondDim ie.1)) ℂ,
+      localVirtualOpOfPhysicalOpAt B hvB
+          (physRealizeLocalOpAt A hvA (localIncidentMatrixOp A ie M)) =
+        localIncidentMatrixOp B ie P := by
+  obtain ⟨huA, hwA⟩ := hA.endpoint_linearIndependent
+  obtain ⟨huB, hwB⟩ := hB.endpoint_linearIndependent
+  obtain ⟨e, hmem⟩ := ie
+  -- With the incidence destructured, the bond `e` is independent of the vertex `v`,
+  -- so the orientation equation eliminates `v` by `subst`.
+  rcases hmem with hv | hv
+  · -- Lower endpoint: `v = e.1.1`. The incidence is `edgeLeftIncident e`
+    -- definitionally, so `edgeLeftInsertionOp` realizes the transfer matrix.
+    subst hv
+    refine ⟨edgeLeftTransferMatrix A B e huA huB hposB M, ?_⟩
+    exact localVirtualOpOfPhysicalOpAt_eq_of_realizes B hvB _ _
+      (fun c => edgeLeftInsertionOp_realizes_edgeLeftTransferMatrix A B e hA hB hAB hposB M c)
+  · -- Upper endpoint: `v = e.1.2`. The incidence is `edgeRightIncident e`
+    -- definitionally, so `edgeRightInsertionOp` realizes the transfer matrix.
+    subst hv
+    refine ⟨edgeTransferMatrix A B e hwA hwB hposB M, ?_⟩
+    exact localVirtualOpOfPhysicalOpAt_eq_of_realizes B hvB _ _
+      (fun c => edgeRightInsertionOp_realizes_edgeTransferMatrix A B e hA hB hAB hposB M c)
+
+/-! ### The region resonate reconcile
+
+Specializing the incidence-level core to the boundary incidence
+`regionBoundaryEdgeInIncident R f` discharges the region resonate reconcile. The
+bond is `f.1`, the inserted matrix is `M.transpose`, and the in-region endpoint
+vertex's edge-blocked three-site injectivity comes from vertex injectivity and
+positive bond dimensions through `IsVertexInjective.edgeBlockedThreeSiteInjective`. -/
+
+/-- **The region resonate reconcile holds.** Under `SameState`, vertex injectivity
+of both tensors, and positive bond dimensions, the region resonate reconcile
+`RegionResonateReconcile A B R f hvA hvB` of `TNLean.PEPS.RegionBlock.Recovery8`
+holds: for every inserted matrix `M`, the virtual pullback of the transferred
+in-region endpoint operator is of incident-matrix form on the boundary leg `f`.
+
+The region insertion operator on `f` is the physical realization of an
+incident-matrix operation on the incidence `regionBoundaryEdgeInIncident R f` of the
+bond `f.1`, so `isIncidentMatrixForm_transferred_incidentInsertion` applies
+directly, with the bond-`f.1` edge-blocked three-site injectivities supplied by
+`IsVertexInjective.edgeBlockedThreeSiteInjective`.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionResonateReconcile_of_sameState (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e) :
+    RegionResonateReconcile (G := G) A B R f hvA hvB := by
+  intro M
+  have hAedge : EdgeBlockedThreeSiteInjective (G := G) A
+      (regionBoundaryEdgeInIncident (G := G) R f).1 :=
+    hA.edgeBlockedThreeSiteInjective hposA _
+  have hBedge : EdgeBlockedThreeSiteInjective (G := G) B
+      (regionBoundaryEdgeInIncident (G := G) R f).1 :=
+    hB.edgeBlockedThreeSiteInjective hposB _
+  exact isIncidentMatrixForm_transferred_incidentInsertion A B
+    (regionBoundaryEdgeInIncident (G := G) R f) hvA hvB hAedge hBedge hAB hposB M.transpose
+
+/-! ### The per-edge gauge from source-level hypotheses
+
+With the region resonate reconcile now discharged in both directions, the per-edge
+gauge read-off `exists_regionEdgeGauge_of_reconcile`
+(`TNLean.PEPS.RegionBlock.Recovery8`) is available directly from `SameState`, vertex
+injectivity, positive bond dimensions, region/complement blocked injectivity, and
+matched bond dimensions, with no remaining reconcile hypothesis. -/
+
+/-- **Per-edge gauge on a boundary edge from source-level hypotheses.** Under
+`SameState`, vertex injectivity of both tensors, positive bond dimensions,
+region/complement blocked injectivity of both tensors, and matched bond
+dimensions, the per-edge matrix transfer on the boundary edge `f` is conjugation by
+an invertible gauge matrix, and the two bond dimensions on `f` coincide.
+
+The region resonate reconcile in both directions is supplied by
+`regionResonateReconcile_of_sameState`, and the gauge read-off is
+`exists_regionEdgeGauge_of_reconcile`.
+
+Source: arXiv:1804.04964, Section 3, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_of_sameState (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim) :
+    ∃ hEdge : A.bondDim f.1 = B.bondDim f.1,
+      ∃ Z : GL (Fin (B.bondDim f.1)) ℂ,
+        ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+          (regionInsertionTransfer_of_reconcile A B R f hvA hvB hAB hA hB hRB hCB
+              hposA hposB hDim
+              (regionResonateReconcile_of_sameState A B R f hvA hvB hAB hA hB hposA hposB)
+              (regionResonateReconcile_of_sameState B A R f hvB hvA hAB.symm hB hA
+                hposB hposA)).fwd M =
+            (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim f.1)) ℂ) :
+                Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :=
+  exists_regionEdgeGauge_of_reconcile A B R f hvA hvB hAB hA hB hRA hCA hRB hCB
+    hposA hposB hDim
+    (regionResonateReconcile_of_sameState A B R f hvA hvB hAB hA hB hposA hposB)
+    (regionResonateReconcile_of_sameState B A R f hvB hvA hAB.symm hB hA hposB hposA)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery12.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery12.lean
@@ -1,0 +1,170 @@
+import TNLean.PEPS.RegionBlock.Recovery8
+
+/-!
+# Region resonate reconcile from the edge Fundamental Theorem
+
+The remaining mathematical content of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, Section 3) toward `exists_regionEdgeGauge_of_reconcile`
+(`TNLean.PEPS.RegionBlock.Recovery8`) is the region resonate reconcile
+`RegionResonateReconcile`: for every inserted matrix `M`, the virtual pullback of
+the transferred in-region endpoint operator
+`regionInsertionOp A R f hvA M.transpose` is of incident-matrix form on the
+boundary leg `f`.
+
+This file discharges that obligation by the observation that the region insertion
+operator on a boundary edge `f` *is* an edge insertion operator on the bond `f.1`:
+the in-region endpoint `regionBoundaryEdgeInVertex R f` is one endpoint of `f.1`,
+and the boundary incidence `regionBoundaryEdgeInIncident R f` is that endpoint's
+incidence of `f.1`. Two incidences of the same bond at the same vertex are equal
+(both pick out `f.1`), so `regionInsertionOp` reduces to the already-proven
+edge insertion operators of `TNLean.PEPS.InsertionAlgebra`. The edge Fundamental
+Theorem then supplies the incident-matrix form of the transferred operator's
+virtual pullback, with the transfer matrix as the witness `P`.
+
+The in-region endpoint is either the lower endpoint `f.1.1.1` (when `f.1.1.1 ∈ R`)
+or the upper endpoint `f.1.1.2`, so the argument splits on orientation. The upper
+case reuses `edgeRightInsertionOp_realizes_edgeTransferMatrix`; the lower case uses
+the left-endpoint mirror `edgeLeftInsertionOp_realizes_edgeLeftTransferMatrix`
+established here from the left clause of `physical_to_virtual_insertion`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The left-endpoint insertion operator and its transfer matrix
+
+The left-endpoint mirror of `edgeRightInsertionOp`/`edgeTransferMatrix`
+(`TNLean.PEPS.InsertionAlgebra`). The right-endpoint forms realize a matrix `X`
+on the upper endpoint `e.1.2`; the left-endpoint forms realize a matrix `Y` on
+the lower endpoint `e.1.1`. The two are coupled by transposition: inserting `Y`
+on the left is the left clause of `physical_to_virtual_insertion` for the
+inserted matrix `Y.transpose`. -/
+
+/-- The physical operator on the lower-endpoint tensor obtained by inserting the
+matrix `Y` on the chosen bond and realizing it through the lower endpoint tensor.
+
+This is the lower-endpoint mirror of `edgeRightInsertionOp`. -/
+noncomputable def edgeLeftInsertionOp (A : Tensor G d) (e : Edge G)
+    (hvA : LinearIndependent ℂ (A.component e.1.1))
+    (Y : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ) :=
+  physRealizeLocalOpAt A hvA (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) Y)
+
+/-- The matrix on the second family's bond obtained by transferring the
+lower-endpoint insertion operator of the first family and reading it off through
+the virtual pullback.
+
+This is the lower-endpoint mirror of `edgeTransferMatrix`. -/
+noncomputable def edgeLeftTransferMatrix (A B : Tensor G d) (e : Edge G)
+    (hvA : LinearIndependent ℂ (A.component e.1.1))
+    (hvB : LinearIndependent ℂ (B.component e.1.1))
+    (hposB : ∀ f : Edge G, 0 < B.bondDim f)
+    (Y : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ :=
+  incidentMatrixOfLocalOp B (edgeLeftIncident (G := G) e)
+    (edgeIncidentReferenceResidual B (edgeLeftIncident (G := G) e) hposB)
+    (localVirtualOpOfPhysicalOpAt B hvB (edgeLeftInsertionOp A e hvA Y))
+
+/-- The lower-endpoint insertion operator of the first family, transferred to the
+second family across `SameState`, is realized by the matrix insertion
+`edgeLeftTransferMatrix … Y` on the second family's lower endpoint.
+
+This is the lower-endpoint mirror of `edgeRightInsertionOp_realizes_edgeTransferMatrix`.
+It applies the left clause of `physical_to_virtual_insertion` to the second family,
+with the inserted matrix `Y.transpose`, so that the lower endpoint realizes
+`(Y.transpose).transpose = Y`.
+
+Source: arXiv:1804.04964, Section 3, Lemma inj_isomorph, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeLeftInsertionOp_realizes_edgeLeftTransferMatrix
+    (A B : Tensor G d) (e : Edge G)
+    (hA : EdgeBlockedThreeSiteInjective (G := G) A e)
+    (hB : EdgeBlockedThreeSiteInjective (G := G) B e)
+    (hAB : SameState A B)
+    (hposB : ∀ f : Edge G, 0 < B.bondDim f)
+    (Y : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    ∀ c : LocalVirtualConfig B e.1.1 → ℂ,
+      edgeLeftInsertionOp A e hA.endpoint_linearIndependent.1 Y
+          (localTensorMap B e.1.1 c) =
+        localTensorMap B e.1.1
+          (localIncidentMatrixOp B (edgeLeftIncident (G := G) e)
+            (edgeLeftTransferMatrix A B e hA.endpoint_linearIndependent.1
+              hB.endpoint_linearIndependent.1 hposB Y) c) := by
+  classical
+  obtain ⟨huA, hvA⟩ := hA.endpoint_linearIndependent
+  obtain ⟨huB, hvB⟩ := hB.endpoint_linearIndependent
+  -- The active lower-endpoint operator, and the auxiliary upper-endpoint operator
+  -- for the inserted matrix `Y.transpose`.
+  set O₁ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ) := edgeLeftInsertionOp A e huA Y with hO₁def
+  set O₂ : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ) :=
+    physRealizeLocalOpAt A hvA
+      (localIncidentMatrixOp A (edgeRightIncident (G := G) e) Y.transpose) with hO₂def
+  have hO₁ : ∀ c : LocalVirtualConfig A e.1.1 → ℂ,
+      O₁ (localTensorMap A e.1.1 c) =
+        localTensorMap A e.1.1
+          (localIncidentMatrixOp A (edgeLeftIncident (G := G) e)
+            (Y.transpose).transpose c) := by
+    intro c
+    rw [Matrix.transpose_transpose]
+    exact physRealizeLocalOpAt_spec A huA
+      (localIncidentMatrixOp A (edgeLeftIncident (G := G) e) Y) c
+  have hO₂ : ∀ c : LocalVirtualConfig A e.1.2 → ℂ,
+      O₂ (localTensorMap A e.1.2 c) =
+        localTensorMap A e.1.2
+          (localIncidentMatrixOp A (edgeRightIncident (G := G) e) Y.transpose c) :=
+    fun c => physRealizeLocalOpAt_spec A hvA
+      (localIncidentMatrixOp A (edgeRightIncident (G := G) e) Y.transpose) c
+  -- Both endpoint realizations reproduce the inserted-edge coefficient of `Y.transpose`.
+  have hAleft : ∀ σ : V → Fin d,
+      edgeInsertedCoeff (G := G) A e σ Y.transpose =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          O₁ (A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β)) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            A.component e.1.2 (edgeRightLocalConfig (G := G) A e β) (σ e.1.2) := fun σ =>
+    edgeInsertedCoeff_eq_sum_left_physicalRealization (G := G) A e σ Y.transpose O₁ hO₁
+  have hAright : ∀ σ : V → Fin d,
+      edgeInsertedCoeff (G := G) A e σ Y.transpose =
+        ∑ β : EdgeBoundaryConfig (G := G) A e,
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+            O₂ (A.component e.1.2 (edgeRightLocalConfig (G := G) A e β)) (σ e.1.2) := fun σ =>
+    edgeInsertedCoeff_eq_sum_right_physicalRealization (G := G) A e σ Y.transpose O₂ hO₂
+  have hEqB : ∀ σ : V → Fin d,
+      (∑ β : EdgeBoundaryConfig (G := G) B e,
+        O₁ (B.component e.1.1 (edgeLeftLocalConfig (G := G) B e β)) (σ e.1.1) *
+          edgeOpenMiddleWeight (G := G) B e σ β.leftResidual β.rightResidual *
+          B.component e.1.2 (edgeRightLocalConfig (G := G) B e β) (σ e.1.2)) =
+        ∑ β : EdgeBoundaryConfig (G := G) B e,
+          B.component e.1.1 (edgeLeftLocalConfig (G := G) B e β) (σ e.1.1) *
+            edgeOpenMiddleWeight (G := G) B e σ β.leftResidual β.rightResidual *
+            O₂ (B.component e.1.2 (edgeRightLocalConfig (G := G) B e β)) (σ e.1.2) := by
+    intro σ
+    rw [← edgeRealizationSum_left_sameState hAB e σ O₁,
+      ← edgeRealizationSum_right_sameState hAB e σ O₂, ← hAleft σ, ← hAright σ]
+  obtain ⟨Y', hY'left, _hY'right⟩ :=
+    physical_to_virtual_insertion (G := G) B e hB hposB O₁ O₂ hEqB
+  -- The recovered matrix's transpose equals the read-off `edgeLeftTransferMatrix`.
+  have hpull : localVirtualOpOfPhysicalOpAt B huB O₁ =
+      localIncidentMatrixOp B (edgeLeftIncident (G := G) e) Y'.transpose :=
+    localVirtualOpOfPhysicalOpAt_eq_of_realizes B huB O₁
+      (localIncidentMatrixOp B (edgeLeftIncident (G := G) e) Y'.transpose) hY'left
+  have hYeq : edgeLeftTransferMatrix A B e huA huB hposB Y = Y'.transpose := by
+    rw [edgeLeftTransferMatrix, ← hO₁def, hpull,
+      incidentMatrixOfLocalOp_localIncidentMatrixOp]
+  rw [hYeq]
+  exact hY'left
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery4.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery4.lean
@@ -1,0 +1,100 @@
+import TNLean.PEPS.RegionBlock.Recovery3
+
+/-!
+# Region physical-to-virtual recovery: incident-matrix form of the virtual pullback
+
+This file isolates the last load-bearing fact behind the region physical-to-virtual
+realization `RegionTransferRealizes` for the normal PEPS Fundamental Theorem
+(remaining obligation 4 of `docs/paper-gaps/peps_normal_ft_section3_route.tex`).
+
+The conditional recovery `regionTransferRealizesAt_of_hform`
+(`TNLean.PEPS.RegionBlock.Recovery3`) reduces the realization `hreal` to the
+matrix-structure hypothesis
+
+```
+hform : localVirtualOpOfPhysicalOpAt B hvB
+            (regionInsertionOp A R f hvA M.transpose) =
+          localIncidentMatrixOp B (regionBoundaryEdgeInIncident R f)
+            (regionTransferMatrix A B R f hvA hvB hposB M).transpose
+```
+
+Because `regionTransferMatrix … M` is *defined* as the read-off
+`(incidentMatrixOfLocalOp B inc refRes W)ᵀ` of the virtual pullback
+`W := localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA M.transpose)`,
+the hypothesis `hform` holds **exactly when `W` is of incident-matrix form** on the
+boundary leg `inc`: if `W = localIncidentMatrixOp B inc P` for some matrix `P`, the
+read-off recovers `P` (`incidentMatrixOfLocalOp_localIncidentMatrixOp`) and the
+round-trip closes `hform`. This file proves that reduction unconditionally
+(`hform_of_isIncidentMatrixForm`) and packages it as the per-matrix realization
+`regionTransferRealizesAt_of_isIncidentMatrixForm`.
+
+What remains for the unconditional normal theorem is the *region resonate* step:
+showing `W` is of incident-matrix form by inverting the blocked complement endpoint
+of the boundary edge `f`. This is the region analogue of the endpoint inversion of
+`physical_to_virtual_insertion` (`TNLean.PEPS.InsertionRealization`), with the
+empty interior of the two-block region/complement split replacing the middle-tensor
+inversion.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Incident-matrix form of the virtual pullback closes `hform`
+
+The region transfer matrix is the read-off of the virtual pullback `W`. When `W`
+is already of incident-matrix form on the boundary leg, the read-off inverts it
+and `hform` is the round-trip identity. This is the unconditional reduction the
+region resonate step feeds into. -/
+
+/-- **The matrix-structure hypothesis `hform` from incident-matrix form.** If the
+virtual pullback `W := localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f
+hvA M.transpose)` of the transferred in-region endpoint operator is of
+incident-matrix form on the boundary leg `inc` — that is, `W = localIncidentMatrixOp
+B inc P` for some matrix `P` — then the matrix-structure hypothesis `hform` holds.
+
+The region transfer matrix is the read-off `(incidentMatrixOfLocalOp B inc refRes
+W)ᵀ`, so its transpose is `incidentMatrixOfLocalOp B inc refRes W`; reading off the
+incident-matrix form `W` recovers `P` (`incidentMatrixOfLocalOp_localIncidentMatrixOp`),
+and reinserting `P` returns `W`. This is the unconditional reduction of `hform` to
+the incident-matrix structure of `W`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem hform_of_isIncidentMatrixForm (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (P : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hP : localVirtualOpOfPhysicalOpAt B hvB
+        (regionInsertionOp (G := G) A R f hvA M.transpose) =
+      localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) P) :
+    localVirtualOpOfPhysicalOpAt B hvB
+        (regionInsertionOp (G := G) A R f hvA M.transpose) =
+      localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f)
+        (regionTransferMatrix (G := G) A B R f hvA hvB hposB M).transpose := by
+  classical
+  set inc := regionBoundaryEdgeInIncident (G := G) R f with hinc
+  set W := localVirtualOpOfPhysicalOpAt B hvB
+    (regionInsertionOp (G := G) A R f hvA M.transpose) with hW
+  -- The read-off recovers `P` from the incident-matrix form of `W`.
+  have hread : (regionTransferMatrix (G := G) A B R f hvA hvB hposB M).transpose = P := by
+    rw [regionTransferMatrix, Matrix.transpose_transpose, ← hW, hP,
+      incidentMatrixOfLocalOp_localIncidentMatrixOp]
+  rw [hread, hP]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery4.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery4.lean
@@ -96,5 +96,43 @@ theorem hform_of_isIncidentMatrixForm (A B : Tensor G d) (R : Finset V)
       incidentMatrixOfLocalOp_localIncidentMatrixOp]
   rw [hread, hP]
 
+/-! ### The virtual pullback realizes the transferred endpoint operator
+
+Image preservation (`regionInsertionOp_localProjectorAt_eq`, the `himage` half) makes
+the virtual pullback `W` realize the transferred in-region endpoint operator on every
+local tensor image of `B` at `v`: the chosen left inverse undoes the projection,
+because the projection fixes the output. This is the bridge from the physical
+operator `regionInsertionOp A R f hvA M.transpose` to its virtual pullback `W`. -/
+
+/-- **The virtual pullback realizes the transferred endpoint operator.** With image
+preservation (`regionInsertionOp_localProjectorAt_eq`), the local tensor map of the
+virtual pullback `W := localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA
+M.transpose)` applied to a coefficient `c` returns the transferred in-region endpoint
+operator applied to the local tensor image of `c`.
+
+This is the region analogue of the realization the chosen left inverse provides at the
+edge level: the virtual pullback agrees with the physical operator on the image of the
+local tensor map at `v`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem localTensorMap_localVirtualOpOfPhysicalOpAt_regionInsertionOp
+    (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (c : LocalVirtualConfig B (regionBoundaryEdgeInVertex (G := G) R f) → ℂ) :
+    localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f)
+        (localVirtualOpOfPhysicalOpAt B hvB
+          (regionInsertionOp (G := G) A R f hvA M.transpose) c) =
+      regionInsertionOp (G := G) A R f hvA M.transpose
+        (localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f) c) :=
+  localVirtualOpOfPhysicalOpAt_realizes_of_projector B hvB
+    (regionInsertionOp (G := G) A R f hvA M.transpose)
+    (fun c => regionInsertionOp_localProjectorAt_eq A B R f hvA hvB hAB hA hB hposA hposB M c) c
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery4.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery4.lean
@@ -48,6 +48,54 @@ open scoped BigOperators Matrix
 namespace TNLean
 namespace PEPS
 
+/-! ### Block-swap symmetry of the abstract two-block inserted coefficient
+
+The two-block inserted coefficient inserts a matrix on one shared bond and
+contracts the two blocks against each other. Swapping the two blocks, transposing
+the inserted matrix, and exchanging the external and physical arguments leaves the
+value unchanged. This is the abstract form of the symmetry between the in-region
+endpoint of a boundary edge and its out-of-region endpoint: the two contracted
+blocks `R` and its complement enter the region-inserted coefficient symmetrically,
+up to transposing the inserted matrix on the boundary edge. -/
+
+section TwoBlockSwap
+
+variable {Bond : Type*} [Fintype Bond]
+variable {bondDim : Bond → Type*} [∀ b, Fintype (bondDim b)]
+
+open scoped Classical in
+/-- **Block-swap symmetry of the two-block inserted coefficient.** Inserting `X`
+on a shared bond `b` and contracting the first block against the second equals
+inserting `Xᵀ` and contracting the second block against the first, with the
+external and physical arguments exchanged.
+
+The two summation variables are exchanged and the `SameAwayFromBond` predicate is
+symmetric, so the only change is `X (μ b) (ν b)` becoming `Xᵀ (ν b) (μ b) = X (μ b)
+(ν b)` together with the block factors swapping order. This is the abstract
+symmetry between the in-region and out-of-region endpoints of a boundary edge.
+
+Source: arXiv:1804.04964, Section 3, equation eq:lem_inj_eq_ten_2: the two
+contracted blocks of a single boundary edge enter symmetrically. -/
+theorem twoBlockInsertedCoeff_swap
+    {External₁ External₂ Physical₁ Physical₂ : Type*}
+    (A₁ : TwoBlockTensor bondDim External₁ Physical₁)
+    (A₂ : TwoBlockTensor bondDim External₂ Physical₂)
+    (b : Bond) (X : Matrix (bondDim b) (bondDim b) ℂ)
+    (η₁ : External₁) (η₂ : External₂) (σ₁ : Physical₁) (σ₂ : Physical₂) :
+    twoBlockInsertedCoeff A₁ A₂ b X η₁ η₂ σ₁ σ₂ =
+      twoBlockInsertedCoeff A₂ A₁ b X.transpose η₂ η₁ σ₂ σ₁ := by
+  classical
+  rw [twoBlockInsertedCoeff, twoBlockInsertedCoeff, Finset.sum_comm]
+  refine Finset.sum_congr rfl (fun μ _ => Finset.sum_congr rfl (fun ν _ => ?_))
+  have hsym : SameAwayFromBond b ν μ ↔ SameAwayFromBond b μ ν :=
+    ⟨fun h c hc => (h c hc).symm, fun h c hc => (h c hc).symm⟩
+  by_cases hsame : SameAwayFromBond b μ ν
+  · rw [if_pos hsame, if_pos (hsym.mpr hsame), Matrix.transpose_apply]
+    ring
+  · rw [if_neg hsame, if_neg (fun h => hsame (hsym.mp h)), zero_mul, zero_mul, zero_mul]
+
+end TwoBlockSwap
+
 variable {V : Type*} [Fintype V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 

--- a/TNLean/PEPS/RegionBlock/Recovery4.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery4.lean
@@ -144,6 +144,44 @@ theorem hform_of_isIncidentMatrixForm (A B : Tensor G d) (R : Finset V)
       incidentMatrixOfLocalOp_localIncidentMatrixOp]
   rw [hread, hP]
 
+/-! ### Complement-side reading of the region-inserted coefficient
+
+Through the abstract two-block coefficient and its block-swap symmetry, the
+region-inserted coefficient is read with the roles of the region `R` and its set
+complement exchanged: the complement block is contracted first against the
+transposed inserted matrix. This is the cast-free form of the complement-side
+realization (step (i) of the region resonate port): it avoids the dependent-type
+reindexing `univ \ (univ \ R) = R` by staying in the abstract two-block coefficient
+over `R`'s boundary-edge index set, where the complement block
+`regionComplementTwoBlock A R` carries the open legs of `univ \ R` reindexed to the
+boundary edges of `R`. -/
+
+/-- **Complement-side reading of the region-inserted coefficient.** The
+region-inserted coefficient with `M` on the boundary edge `f` equals the two-block
+inserted coefficient that contracts the complement block of `R` first, against the
+transposed matrix `Mᵀ`.
+
+This is the region-inserted coefficient read from the out-of-region endpoint of `f`:
+the two-block block-swap symmetry exchanges the region and complement blocks and
+transposes the inserted matrix on `f`. Combined with the existing v-side realization
+`regionInsertedCoeff_eq_smul_op_regionStateVec`, this is the doubled boundary-edge
+reading the region resonate identity equates.
+
+Source: arXiv:1804.04964, Section 3, lines 1205--1210 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_complementTwoBlock (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      twoBlockInsertedCoeff (Bond := {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+        (bondDim := fun f => Fin (A.bondDim f.1))
+        (regionComplementTwoBlock (G := G) A R) (regionTwoBlock (G := G) A R)
+        f M.transpose PUnit.unit PUnit.unit τ σ := by
+  rw [← twoBlockInsertedCoeff_eq_regionInsertedCoeff A R f M σ τ,
+    twoBlockInsertedCoeff_swap]
+
 /-! ### The virtual pullback realizes the transferred endpoint operator
 
 Image preservation (`regionInsertionOp_localProjectorAt_eq`, the `himage` half) makes

--- a/TNLean/PEPS/RegionBlock/Recovery5.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery5.lean
@@ -87,5 +87,76 @@ theorem regionBoundaryEdgeInVertex_compl_eq_outVertex (R : Finset V)
   · rw [if_pos h1, if_neg (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1)]
   · rw [if_neg h1, if_pos (by rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, h1⟩)]
 
+/-! ### The blocked-region tensor map and its left inverse
+
+The blocked-region weight family of a region `R` assembles into a linear map from
+boundary-configuration coefficients to region physical functions
+(`regionBlockedTensorMap`). Blocked-tensor injectivity of `R`
+(`RegionBlockedTensorInjective`) is exactly injectivity of this map, so it has a
+chosen left inverse (`regionBlockedLeftInverse`). This is the region analogue of
+the blocked-middle contraction inverse `edgeMiddleLeftInverse`: where the edge
+proof inverts the middle block to read off the recovered matrix, the region proof
+inverts the blocked endpoint block of `R` (or its complement) for the same
+purpose. The interior of the region/complement split is empty, so there is no
+middle tensor to invert; the two endpoint blocks are exactly the region block and
+the complement block, and inverting either is this left inverse. -/
+
+/-- The blocked-region tensor map: the linear combination of the blocked-region
+weight family of `R`, sending a boundary-configuration coefficient to the region
+physical function it produces.
+
+This is the region analogue of `edgeMiddleTensorMap`. Its injectivity is exactly
+the blocked-tensor injectivity of `R`. -/
+noncomputable def regionBlockedTensorMap (A : Tensor G d) (R : Finset V) :
+    (RegionBoundaryConfig (G := G) A R → ℂ) →ₗ[ℂ]
+      (RegionPhysicalConfig (V := V) (d := d) R → ℂ) :=
+  Fintype.linearCombination ℂ (regionBlockedTensorFamily (G := G) A R)
+
+/-- The blocked-region tensor map is injective when the region is blocked-tensor
+injective. This is the region analogue of
+`edgeMiddleTensorMap_injective_of_injective`. -/
+theorem regionBlockedTensorMap_injective_of_injective (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R) :
+    Function.Injective (regionBlockedTensorMap (G := G) A R) :=
+  hR.fintypeLinearCombination_injective
+
+/-- Kernel form of `regionBlockedTensorMap_injective_of_injective`. -/
+theorem regionBlockedTensorMap_ker_eq_bot_of_injective (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R) :
+    LinearMap.ker (regionBlockedTensorMap (G := G) A R) = ⊥ :=
+  LinearMap.ker_eq_bot.mpr <| regionBlockedTensorMap_injective_of_injective (G := G) A R hR
+
+/-- A chosen left inverse of the blocked-region tensor map under blocked-tensor
+injectivity. This is the region analogue of `edgeMiddleLeftInverse`, built the
+same way from `LinearMap.exists_leftInverse_of_injective`. It is the
+contraction-inverse of the blocked region block used in the region resonate step.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def regionBlockedLeftInverse (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R) :
+    (RegionPhysicalConfig (V := V) (d := d) R → ℂ) →ₗ[ℂ]
+      (RegionBoundaryConfig (G := G) A R → ℂ) :=
+  ((regionBlockedTensorMap (G := G) A R).exists_leftInverse_of_injective
+    (regionBlockedTensorMap_ker_eq_bot_of_injective (G := G) A R hR)).choose
+
+@[simp] theorem regionBlockedLeftInverse_comp_regionBlockedTensorMap (A : Tensor G d)
+    (R : Finset V) (hR : RegionBlockedTensorInjective (G := G) A R) :
+    (regionBlockedLeftInverse (G := G) A R hR).comp
+        (regionBlockedTensorMap (G := G) A R) =
+      LinearMap.id :=
+  ((regionBlockedTensorMap (G := G) A R).exists_leftInverse_of_injective
+    (regionBlockedTensorMap_ker_eq_bot_of_injective (G := G) A R hR)).choose_spec
+
+@[simp] theorem regionBlockedLeftInverse_apply_regionBlockedTensorMap (A : Tensor G d)
+    (R : Finset V) (hR : RegionBlockedTensorInjective (G := G) A R)
+    (c : RegionBoundaryConfig (G := G) A R → ℂ) :
+    regionBlockedLeftInverse (G := G) A R hR
+        (regionBlockedTensorMap (G := G) A R c) = c := by
+  change ((regionBlockedLeftInverse (G := G) A R hR).comp
+    (regionBlockedTensorMap (G := G) A R)) c = c
+  rw [regionBlockedLeftInverse_comp_regionBlockedTensorMap]
+  rfl
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery5.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery5.lean
@@ -1,0 +1,91 @@
+import TNLean.PEPS.RegionBlock.Recovery4
+
+/-!
+# Region physical-to-virtual recovery: the out-of-region endpoint of a boundary edge
+
+This file develops the out-of-region endpoint of a boundary edge `f` of a region
+`R`, the second endpoint feeding the region resonate step behind the normal PEPS
+Fundamental Theorem (remaining obligation 4 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`).
+
+A boundary edge `f` of `R` is also a boundary edge of the set complement
+`univ \ R` (`regionBoundaryEdgeToCompl`), and its in-region endpoint with respect
+to the complement is the out-of-region endpoint of `f` with respect to `R`. The
+complement-side reading of the region-inserted coefficient
+(`regionInsertedCoeff_eq_complementTwoBlock`, `TNLean.PEPS.RegionBlock.Recovery4`)
+contracts the complement block first, so realizing the inserted coefficient
+through the out-of-region endpoint is the complement-region instance of the
+v-side realization `regionInsertedCoeff_eq_smul_op_regionStateVec`.
+
+This file records the endpoint identity and the basic structural facts that the
+complement-side realization needs, isolating the dependent-type reindexing
+`univ \ (univ \ R) = R` into dedicated transport lemmas rather than threading it
+through the realization argument.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The out-of-region endpoint of a boundary edge
+
+The out-of-region endpoint of a boundary edge `f` of `R` is the unique endpoint of
+`f` lying outside `R`. It coincides with the in-region endpoint of `f` viewed as a
+boundary edge of the set complement `univ \ R`. -/
+
+/-- The out-of-region endpoint of a boundary edge `f` of `R`: the unique endpoint
+of `f` not lying in `R`. -/
+def regionBoundaryEdgeOutVertex (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) : V :=
+  if f.1.1.1 ∈ R then f.1.1.2 else f.1.1.1
+
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- The out-of-region endpoint of a boundary edge does not lie in `R`. -/
+theorem regionBoundaryEdgeOutVertex_not_mem (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    regionBoundaryEdgeOutVertex (G := G) R f ∉ R := by
+  unfold regionBoundaryEdgeOutVertex
+  rcases f.2 with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · rw [if_pos h1]; exact h2
+  · rw [if_neg h1]; exact h1
+
+omit [DecidableRel G.Adj] in
+/-- The out-of-region endpoint of a boundary edge lies in the set complement
+`univ \ R`. -/
+theorem regionBoundaryEdgeOutVertex_mem_compl (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    regionBoundaryEdgeOutVertex (G := G) R f ∈ Finset.univ \ R := by
+  rw [Finset.mem_sdiff]
+  exact ⟨Finset.mem_univ _, regionBoundaryEdgeOutVertex_not_mem (G := G) R f⟩
+
+omit [DecidableRel G.Adj] in
+/-- The out-of-region endpoint of `f` is the in-region endpoint of `f` viewed as a
+boundary edge of the set complement `univ \ R`.
+
+The complement membership predicate `w ∈ univ \ R` is `w ∉ R`, so the conditional
+defining the in-region endpoint of the complement boundary edge selects the
+endpoint of `f` outside `R`, which is the out-of-region endpoint of `f`. -/
+theorem regionBoundaryEdgeInVertex_compl_eq_outVertex (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f) =
+      regionBoundaryEdgeOutVertex (G := G) R f := by
+  rw [regionBoundaryEdgeInVertex, regionBoundaryEdgeOutVertex,
+    regionBoundaryEdgeToCompl]
+  rcases f.2 with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · rw [if_pos h1, if_neg (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1)]
+  · rw [if_neg h1, if_pos (by rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, h1⟩)]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery5.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery5.lean
@@ -158,5 +158,38 @@ noncomputable def regionBlockedLeftInverse (A : Tensor G d) (R : Finset V)
   rw [regionBlockedLeftInverse_comp_regionBlockedTensorMap]
   rfl
 
+/-- The blocked-region tensor map, expanded as the boundary-configuration sum of
+the blocked-region weights. -/
+theorem regionBlockedTensorMap_apply (A : Tensor G d) (R : Finset V)
+    (c : RegionBoundaryConfig (G := G) A R → ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) R) :
+    regionBlockedTensorMap (G := G) A R c τ =
+      ∑ μ : RegionBoundaryConfig (G := G) A R,
+        c μ • regionBlockedWeight (G := G) A R μ τ := by
+  rw [regionBlockedTensorMap, Fintype.linearCombination_apply, Finset.sum_apply]
+  rfl
+
+/-- The blocked-region tensor map sends the standard basis configuration `μ` to the
+blocked-region weight of `μ`. -/
+@[simp] theorem regionBlockedTensorMap_single (A : Tensor G d) (R : Finset V)
+    (μ : RegionBoundaryConfig (G := G) A R) :
+    regionBlockedTensorMap (G := G) A R (Pi.single μ (1 : ℂ)) =
+      regionBlockedWeight (G := G) A R μ := by
+  classical
+  rw [regionBlockedTensorMap, Fintype.linearCombination_apply_single, one_smul]
+  rfl
+
+/-- Reading the blocked-region weight of `μ` through the chosen left inverse
+recovers the standard basis configuration `μ`. This is the read-off the region
+resonate step uses: the blocked endpoint block is inverted on the physical
+function it produces. -/
+@[simp] theorem regionBlockedLeftInverse_regionBlockedWeight (A : Tensor G d)
+    (R : Finset V) (hR : RegionBlockedTensorInjective (G := G) A R)
+    (μ : RegionBoundaryConfig (G := G) A R) :
+    regionBlockedLeftInverse (G := G) A R hR
+        (regionBlockedWeight (G := G) A R μ) = Pi.single μ (1 : ℂ) := by
+  rw [← regionBlockedTensorMap_single A R μ,
+    regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery6.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery6.lean
@@ -1,0 +1,150 @@
+import TNLean.PEPS.RegionBlock.Recovery5
+
+/-!
+# Region physical-to-virtual recovery: the out-of-region-endpoint realization
+
+This file produces the complement-side realization of the region-inserted
+coefficient, the second reading the region resonate step behind the normal PEPS
+Fundamental Theorem equates (remaining obligation 4 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`).
+
+The v-side realizations `regionInsertedCoeff_eq_regionRealizationSum` and
+`regionInsertedCoeff_eq_smul_op_regionStateVec`
+(`TNLean.PEPS.RegionBlock.Recovery2`) carry the inserted matrix through the
+in-region endpoint `regionBoundaryEdgeInVertex R f`. Since both lemmas are stated
+for an arbitrary region, applying them to the set complement `univ \ R` realizes
+the inserted matrix through that region's in-region endpoint, which is the
+out-of-region endpoint `regionBoundaryEdgeOutVertex R f` of the original boundary
+edge (`regionBoundaryEdgeInVertex_compl_eq_outVertex`,
+`TNLean.PEPS.RegionBlock.Recovery5`).
+
+The bridge is the **cast identity**
+
+```
+regionInsertedCoeff A R f M σ τ = regionInsertedCoeff A (univ \ R) f' M.transpose τ σ̃
+```
+
+where `f' := regionBoundaryEdgeToCompl R f` is the boundary edge `f` reread on the
+complement, and `σ̃` transports `σ` across `univ \ (univ \ R) = R`. The
+region-inserted coefficient contracts the region against its complement
+symmetrically up to transposing the inserted matrix on the boundary edge; the
+double sum of the right side is the double sum of the left side reindexed by the
+boundary-edge identification `regionBoundaryEdgeComplEquiv` and the
+physical-configuration transport across `univ \ (univ \ R) = R`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 and 1205--1210 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Transport of a region physical configuration across the double complement
+
+The set complement of the set complement of `R` is `R` itself. A physical
+configuration on `R` transports to one on `univ \ (univ \ R)` through the
+membership equivalence of the two regions, and back. This isolates the dependent
+reindexing `univ \ (univ \ R) = R` into a single equivalence of vertex subtypes,
+so that it never threads through the realization argument. -/
+
+/-- A vertex lies in `univ \ (univ \ R)` exactly when it lies in `R`. -/
+theorem mem_compl_compl_iff (R : Finset V) (w : V) :
+    w ∈ Finset.univ \ (Finset.univ \ R) ↔ w ∈ R := by
+  simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, not_not]
+
+/-- The vertices of `univ \ (univ \ R)` are the vertices of `R`. -/
+def regionDoubleComplVertexEquiv (R : Finset V) :
+    {w : V // w ∈ Finset.univ \ (Finset.univ \ R)} ≃ {w : V // w ∈ R} :=
+  Equiv.subtypeEquivRight (mem_compl_compl_iff (V := V) R)
+
+/-- Transport of a region physical configuration on `R` to one on
+`univ \ (univ \ R)` along the double-complement vertex equivalence. -/
+def regionDoubleComplPhysicalConfig (R : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ (Finset.univ \ R)) :=
+  fun w => σ (regionDoubleComplVertexEquiv (V := V) R w)
+
+omit [DecidableRel G.Adj] in
+/-- An edge crosses the boundary of `univ \ (univ \ R)` exactly when it crosses
+the boundary of `R`. -/
+theorem isRegionBoundaryEdge_compl_compl_iff (R : Finset V) (e : Edge G) :
+    IsRegionBoundaryEdge (G := G) (Finset.univ \ (Finset.univ \ R)) e ↔
+      IsRegionBoundaryEdge (G := G) R e := by
+  rw [isRegionBoundaryEdge_compl_iff, isRegionBoundaryEdge_compl_iff]
+
+/-- The edges crossing the boundary of `univ \ (univ \ R)` are the edges crossing
+the boundary of `R`. -/
+def regionBoundaryEdgeDoubleComplEquiv (R : Finset V) :
+    {e : Edge G // IsRegionBoundaryEdge (G := G) (Finset.univ \ (Finset.univ \ R)) e} ≃
+      {e : Edge G // IsRegionBoundaryEdge (G := G) R e} :=
+  Equiv.subtypeEquivRight (fun e => isRegionBoundaryEdge_compl_compl_iff (G := G) R e)
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem regionBoundaryEdgeDoubleComplEquiv_apply_coe (R : Finset V)
+    (e : {e : Edge G // IsRegionBoundaryEdge (G := G) (Finset.univ \ (Finset.univ \ R)) e}) :
+    ((regionBoundaryEdgeDoubleComplEquiv (G := G) R e) : Edge G) = e.1 := rfl
+
+/-- Transport of a boundary configuration on `R` to one on `univ \ (univ \ R)`
+along the double-complement boundary-edge equivalence. -/
+def regionDoubleComplBoundaryConfig (A : Tensor G d) (R : Finset V)
+    (bdry : RegionBoundaryConfig (G := G) A R) :
+    RegionBoundaryConfig (G := G) A (Finset.univ \ (Finset.univ \ R)) :=
+  fun e => bdry (regionBoundaryEdgeDoubleComplEquiv (G := G) R e)
+
+/-! ### Double-complement invariance of the blocked-region weight
+
+The blocked-region weight of `univ \ (univ \ R)` at the transported configurations
+equals the blocked-region weight of `R`: the open boundary edges of the two
+regions coincide, and so do their vertices, so the constrained virtual-configuration
+sum and the contracted vertex product agree term by term. This is the cast that the
+complement-side realization carries, isolated to a single weight identity. -/
+
+/-- **Double-complement invariance of the blocked-region weight.** The blocked
+weight of `univ \ (univ \ R)` at the double-complement transports of `bdry` and `σ`
+equals the blocked weight of `R` at `bdry` and `σ`. The contraction runs over the
+same global virtual configurations; the boundary-edge filter and the contracted
+vertex product transport along the double-complement boundary-edge and vertex
+equivalences. -/
+theorem regionBlockedWeight_doubleCompl (A : Tensor G d) (R : Finset V)
+    (bdry : RegionBoundaryConfig (G := G) A R)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    regionBlockedWeight (G := G) A (Finset.univ \ (Finset.univ \ R))
+        (regionDoubleComplBoundaryConfig (G := G) A R bdry)
+        (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ) =
+      regionBlockedWeight (G := G) A R bdry σ := by
+  classical
+  rw [regionBlockedWeight, regionBlockedWeight]
+  -- The two filtered sums are over the same global virtual configurations.
+  have hfilter : (Finset.univ.filter
+        (fun ζ : VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ (Finset.univ \ R)) ζ =
+            regionDoubleComplBoundaryConfig (G := G) A R bdry)) =
+      (Finset.univ.filter
+        (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A R ζ = bdry)) := by
+    ext ζ
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    -- Both filter conditions say `ζ` restricted to the (shared) boundary edges is `bdry`,
+    -- read through the double-complement boundary-edge equivalence.
+    rw [funext_iff, funext_iff]
+    refine (Equiv.forall_congr (regionBoundaryEdgeDoubleComplEquiv (G := G) R) ?_)
+    intro g
+    rw [regionBoundaryLabel_apply, regionBoundaryLabel_apply, regionDoubleComplBoundaryConfig]
+    rfl
+  rw [hfilter]
+  -- For each global configuration the vertex products agree along the vertex equiv.
+  refine Finset.sum_congr rfl (fun ζ _ => ?_)
+  refine Fintype.prod_equiv (regionDoubleComplVertexEquiv (V := V) R) _ _ (fun w => ?_)
+  rw [regionDoubleComplPhysicalConfig]
+  rfl
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery6.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery6.lean
@@ -21,11 +21,11 @@ edge (`regionBoundaryEdgeInVertex_compl_eq_outVertex`,
 The bridge is the **cast identity**
 
 ```
-regionInsertedCoeff A R f M σ τ = regionInsertedCoeff A (univ \ R) f' M.transpose τ σ̃
+regionInsertedCoeff A R f M σ τ = regionInsertedCoeff A (univ \ R) f' M.transpose τ σ'
 ```
 
 where `f' := regionBoundaryEdgeToCompl R f` is the boundary edge `f` reread on the
-complement, and `σ̃` transports `σ` across `univ \ (univ \ R) = R`. The
+complement, and `σ'` transports `σ` across `univ \ (univ \ R) = R`. The
 region-inserted coefficient contracts the region against its complement
 symmetrically up to transposing the inserted matrix on the boundary edge; the
 double sum of the right side is the double sum of the left side reindexed by the
@@ -201,6 +201,112 @@ theorem regionComplementBoundaryConfig_compl_compl (A : Tensor G d) (R : Finset 
   rw [regionComplementBoundaryConfig, regionComplementBoundaryConfig,
     regionDoubleComplBoundaryConfig]
   rfl
+
+/-- The complement boundary-configuration reindexing preserves agreement away from
+the boundary edge `f`: two boundary configurations on `R` agree away from `f`
+exactly when their complement reindexings agree away from
+`regionBoundaryEdgeToCompl R f`. -/
+theorem sameAwayFromBond_complementBoundaryConfig (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (a b : RegionBoundaryConfig (G := G) A R) :
+    SameAwayFromBond (regionBoundaryEdgeToCompl (G := G) R f)
+        (regionComplementBoundaryConfig (G := G) A R a)
+        (regionComplementBoundaryConfig (G := G) A R b) ↔
+      SameAwayFromBond f a b := by
+  constructor
+  · intro h c hc
+    have := h (regionBoundaryEdgeToCompl (G := G) R c)
+      (fun heq => hc ((regionBoundaryEdgeComplEquiv (G := G) R).injective heq))
+    rwa [regionComplementBoundaryConfig_apply_toCompl,
+      regionComplementBoundaryConfig_apply_toCompl] at this
+  · intro h c hc
+    rw [regionComplementBoundaryConfig, regionComplementBoundaryConfig]
+    exact h ((regionBoundaryEdgeComplEquiv (G := G) R).symm c)
+      (fun heq => hc (by rw [← heq]; rfl))
+
+/-! ### The cast identity: the complement-side reading of the region-inserted coefficient
+
+The region-inserted coefficient of `M` on a boundary edge `f` of `R` equals the
+region-inserted coefficient of `Mᵀ` on `f` reread as a boundary edge of the set
+complement `univ \ R`, with the region/complement physical arguments exchanged and
+`σ` transported across `univ \ (univ \ R) = R`. The region and its complement
+enter the coefficient symmetrically up to transposing the inserted matrix; the
+double sum of the right side is the double sum of the left side reindexed by the
+complement boundary-configuration equivalence, with the complement-of-complement
+block read back through `regionBlockedWeight_doubleCompl`. This is the cast behind
+the out-of-region-endpoint realization. -/
+
+open scoped Classical in
+/-- **The complement-side cast identity.** The region-inserted coefficient of `M`
+on `f` equals the region-inserted coefficient of `Mᵀ` on `f` reread on the set
+complement `univ \ R`, with `τ` and the transported `σ` exchanged.
+
+This isolates the dependent reindexing `univ \ (univ \ R) = R` into the
+double-complement weight invariance: reindexing the complement-side double sum by
+the complement boundary-configuration equivalence turns it into the original
+double sum, with the complement-of-complement block read back to the region block.
+
+Source: arXiv:1804.04964, Section 3, lines 1205--1210 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_compl (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) A (Finset.univ \ R) (regionBoundaryEdgeToCompl (G := G) R f)
+        M.transpose τ (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ) := by
+  classical
+  set f' := regionBoundaryEdgeToCompl (G := G) R f with hf'
+  set E := regionComplementBoundaryConfigEquiv (G := G) A R with hE
+  set sigt := regionDoubleComplPhysicalConfig (V := V) (d := d) R σ with hsigt
+  rw [regionInsertedCoeff_eq, regionInsertedCoeff_eq]
+  -- The complement-side double sum, reindexed over `(μ_R, ν_R)` via `E × E`.
+  rw [show (∑ μ' : RegionBoundaryConfig (G := G) A (Finset.univ \ R),
+        ∑ ν' : RegionBoundaryConfig (G := G) A (Finset.univ \ R),
+          (if SameAwayFromBond f' μ' ν' then M.transpose (μ' f') (ν' f') else 0) *
+            regionBlockedWeight (G := G) A (Finset.univ \ R) μ' τ *
+            regionBlockedWeight (G := G) A (Finset.univ \ (Finset.univ \ R))
+              (regionComplementBoundaryConfig (G := G) A (Finset.univ \ R) ν') sigt) =
+      ∑ μ_R : RegionBoundaryConfig (G := G) A R,
+        ∑ ν_R : RegionBoundaryConfig (G := G) A R,
+          (if SameAwayFromBond f' (E μ_R) (E ν_R) then
+              M.transpose ((E μ_R) f') ((E ν_R) f') else 0) *
+            regionBlockedWeight (G := G) A (Finset.univ \ R) (E μ_R) τ *
+            regionBlockedWeight (G := G) A (Finset.univ \ (Finset.univ \ R))
+              (regionComplementBoundaryConfig (G := G) A (Finset.univ \ R) (E ν_R)) sigt from ?_]
+  · -- Each reindexed term matches a term of the left sum, after swapping the two indices.
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun ν_R _ => Finset.sum_congr rfl (fun μ_R _ => ?_))
+    -- Simplify the reindexed pieces.
+    rw [hE, regionComplementBoundaryConfigEquiv_apply, regionComplementBoundaryConfigEquiv_apply,
+      regionComplementBoundaryConfig_apply_toCompl, regionComplementBoundaryConfig_apply_toCompl,
+      regionComplementBoundaryConfig_compl_compl, regionBlockedWeight_doubleCompl]
+    -- The `SameAwayFromBond` predicate transports; the matrix entry transposes back.
+    have hpred : SameAwayFromBond f' (regionComplementBoundaryConfig (G := G) A R ν_R)
+        (regionComplementBoundaryConfig (G := G) A R μ_R) ↔ SameAwayFromBond f μ_R ν_R := by
+      rw [hf', sameAwayFromBond_complementBoundaryConfig A R f ν_R μ_R]
+      exact ⟨fun h c hc => (h c hc).symm, fun h c hc => (h c hc).symm⟩
+    by_cases hsame : SameAwayFromBond f μ_R ν_R
+    · rw [if_pos hsame, if_pos (hpred.mpr hsame), Matrix.transpose_apply]
+      ring
+    · rw [if_neg hsame, if_neg (fun h => hsame (hpred.mp h))]
+      ring
+  · -- Reindex the double sum by `E` on both indices.
+    rw [← Fintype.sum_equiv E
+      (fun μ_R => ∑ ν_R : RegionBoundaryConfig (G := G) A R,
+        (if SameAwayFromBond f' (E μ_R) (E ν_R) then
+            M.transpose ((E μ_R) f') ((E ν_R) f') else 0) *
+          regionBlockedWeight (G := G) A (Finset.univ \ R) (E μ_R) τ *
+          regionBlockedWeight (G := G) A (Finset.univ \ (Finset.univ \ R))
+            (regionComplementBoundaryConfig (G := G) A (Finset.univ \ R) (E ν_R)) sigt)
+      (fun μ' => ∑ ν' : RegionBoundaryConfig (G := G) A (Finset.univ \ R),
+        (if SameAwayFromBond f' μ' ν' then M.transpose (μ' f') (ν' f') else 0) *
+          regionBlockedWeight (G := G) A (Finset.univ \ R) μ' τ *
+          regionBlockedWeight (G := G) A (Finset.univ \ (Finset.univ \ R))
+            (regionComplementBoundaryConfig (G := G) A (Finset.univ \ R) ν') sigt)
+      (fun μ_R => ?_)]
+    refine Fintype.sum_equiv E _ _ (fun ν_R => rfl)
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery6.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery6.lean
@@ -163,13 +163,13 @@ def regionComplementBoundaryConfigEquiv (A : Tensor G d) (R : Finset V) :
   invFun bdry' := fun f => bdry' (regionBoundaryEdgeComplEquiv (G := G) R f)
   left_inv bdry := by
     funext f
-    show regionComplementBoundaryConfig (G := G) A R bdry
+    change regionComplementBoundaryConfig (G := G) A R bdry
       (regionBoundaryEdgeComplEquiv (G := G) R f) = bdry f
     rw [regionComplementBoundaryConfig]
     congr 1
   right_inv bdry' := by
     funext g
-    show regionComplementBoundaryConfig (G := G) A R
+    change regionComplementBoundaryConfig (G := G) A R
       (fun f => bdry' (regionBoundaryEdgeComplEquiv (G := G) R f)) g = bdry' g
     rw [regionComplementBoundaryConfig]
     congr 1
@@ -307,6 +307,95 @@ theorem regionInsertedCoeff_eq_compl (A : Tensor G d) (R : Finset V)
             (regionComplementBoundaryConfig (G := G) A (Finset.univ \ R) ν') sigt)
       (fun μ_R => ?_)]
     refine Fintype.sum_equiv E _ _ (fun ν_R => rfl)
+
+/-! ### The out-of-region-endpoint realization
+
+Applying the v-side realization sums of `TNLean.PEPS.RegionBlock.Recovery2` to the
+set complement `univ \ R` realizes the region-inserted coefficient through the
+in-region endpoint of `univ \ R`, which is the out-of-region endpoint
+`regionBoundaryEdgeOutVertex R f` of the original boundary edge. Combined with the
+complement-side cast identity, this is the complement reading the region resonate
+step equates with the v-side reading.
+
+The realization sums of `univ \ R` carry the inserted matrix through
+`regionInsertionOp A (univ \ R) f'`, where `f'` is `f` reread on the complement,
+and contract the rest of `univ \ R`. The in-region endpoint of `univ \ R` at `f'`
+is the out-of-region endpoint of `f` at `R`
+(`regionBoundaryEdgeInVertex_compl_eq_outVertex`). -/
+
+open scoped Classical in
+/-- **The out-of-region-endpoint realization sum.** The region-inserted coefficient
+of `M` on the boundary edge `f` of `R` is the complement region realization sum
+that carries the inserted matrix through the in-region endpoint of `univ \ R` at
+`f'`, which is the out-of-region endpoint of `f`.
+
+This is the complement instance of `regionInsertedCoeff_eq_regionRealizationSum`,
+read off the cast identity `regionInsertedCoeff_eq_compl`. Together with the v-side
+realization sum, this is the doubled boundary-edge reading the region resonate step
+equates.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_regionRealizationSum_compl (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionRealizationSum (G := G) A (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f)
+        (regionInsertionOp (G := G) A (Finset.univ \ R)
+          (regionBoundaryEdgeToCompl (G := G) R f) hvout M.transpose.transpose)
+        τ (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ) := by
+  rw [regionInsertedCoeff_eq_compl A R f M σ τ]
+  exact regionInsertedCoeff_eq_regionRealizationSum A (Finset.univ \ R)
+    (regionBoundaryEdgeToCompl (G := G) R f) hvout M.transpose τ
+    (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)
+
+open scoped Classical in
+/-- **The out-of-region-endpoint realization through the endpoint operator.** The
+region-inserted coefficient of `M` on the boundary edge `f` of `R` is the
+bond-dimension product over the non-boundary edges of `univ \ R` times the
+out-of-region-endpoint operator from `M`, applied to the (complement) closed state
+vector and evaluated at the physical leg of the out-of-region endpoint
+`regionBoundaryEdgeOutVertex R f`.
+
+This is the complement instance of `regionInsertedCoeff_eq_smul_op_regionStateVec`,
+read off the cast identity `regionInsertedCoeff_eq_compl`. The in-region endpoint of
+`univ \ R` at `f'` is the out-of-region endpoint of `f`
+(`regionBoundaryEdgeInVertex_compl_eq_outVertex`), so the evaluation point is the
+physical leg `τ` carries at the out-of-region endpoint. Together with the v-side
+realization `regionInsertedCoeff_eq_smul_op_regionStateVec`, this is the doubled
+boundary-edge reading the region resonate step equates.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_smul_op_regionStateVec_compl (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInteriorBondProd (G := G) A (Finset.univ \ R) •
+        (regionInsertionOp (G := G) A (Finset.univ \ R)
+            (regionBoundaryEdgeToCompl (G := G) R f) hvout M.transpose.transpose
+            (regionStateVec (G := G) A (Finset.univ \ R)
+              (regionBoundaryEdgeToCompl (G := G) R f) τ
+              (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)))
+          (τ ⟨regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+            (regionBoundaryEdgeToCompl (G := G) R f),
+            regionBoundaryEdgeInVertex_mem (G := G) (Finset.univ \ R)
+              (regionBoundaryEdgeToCompl (G := G) R f)⟩) := by
+  rw [regionInsertedCoeff_eq_compl A R f M σ τ]
+  exact regionInsertedCoeff_eq_smul_op_regionStateVec A (Finset.univ \ R)
+    (regionBoundaryEdgeToCompl (G := G) R f) hvout M.transpose τ
+    (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery6.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery6.lean
@@ -146,5 +146,61 @@ theorem regionBlockedWeight_doubleCompl (A : Tensor G d) (R : Finset V)
   rw [regionDoubleComplPhysicalConfig]
   rfl
 
+/-! ### The complement boundary-configuration reindexing as an equivalence
+
+The complement boundary-configuration map `regionComplementBoundaryConfig`
+precomposes a boundary configuration with the boundary-edge identification of `R`
+and its complement, so it is a bijection of boundary configurations. Recording it
+as an equivalence lets the cast identity reindex the double sum of the
+complement-side reading. -/
+
+/-- The complement boundary-configuration reindexing as an equivalence: a boundary
+configuration on `R` corresponds to one on `univ \ R` by reading each crossing edge
+under the boundary-edge identification. -/
+def regionComplementBoundaryConfigEquiv (A : Tensor G d) (R : Finset V) :
+    RegionBoundaryConfig (G := G) A R ≃ RegionBoundaryConfig (G := G) A (Finset.univ \ R) where
+  toFun := regionComplementBoundaryConfig (G := G) A R
+  invFun bdry' := fun f => bdry' (regionBoundaryEdgeComplEquiv (G := G) R f)
+  left_inv bdry := by
+    funext f
+    show regionComplementBoundaryConfig (G := G) A R bdry
+      (regionBoundaryEdgeComplEquiv (G := G) R f) = bdry f
+    rw [regionComplementBoundaryConfig]
+    congr 1
+  right_inv bdry' := by
+    funext g
+    show regionComplementBoundaryConfig (G := G) A R
+      (fun f => bdry' (regionBoundaryEdgeComplEquiv (G := G) R f)) g = bdry' g
+    rw [regionComplementBoundaryConfig]
+    congr 1
+
+@[simp] theorem regionComplementBoundaryConfigEquiv_apply (A : Tensor G d) (R : Finset V)
+    (bdry : RegionBoundaryConfig (G := G) A R) :
+    regionComplementBoundaryConfigEquiv (G := G) A R bdry =
+      regionComplementBoundaryConfig (G := G) A R bdry := rfl
+
+/-- The complement boundary configuration reads the boundary edge `f` of `R`,
+viewed on the complement as `regionBoundaryEdgeToCompl R f`, off the original
+boundary value at `f`. -/
+theorem regionComplementBoundaryConfig_apply_toCompl (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (bdry : RegionBoundaryConfig (G := G) A R) :
+    regionComplementBoundaryConfig (G := G) A R bdry (regionBoundaryEdgeToCompl (G := G) R f) =
+      bdry f := by
+  rw [regionComplementBoundaryConfig]
+  congr 1
+
+/-- Applying the complement boundary-configuration reindexing twice (for `R` and
+then for `univ \ R`) is the double-complement boundary-configuration transport. -/
+theorem regionComplementBoundaryConfig_compl_compl (A : Tensor G d) (R : Finset V)
+    (bdry : RegionBoundaryConfig (G := G) A R) :
+    regionComplementBoundaryConfig (G := G) A (Finset.univ \ R)
+        (regionComplementBoundaryConfig (G := G) A R bdry) =
+      regionDoubleComplBoundaryConfig (G := G) A R bdry := by
+  funext g
+  rw [regionComplementBoundaryConfig, regionComplementBoundaryConfig,
+    regionDoubleComplBoundaryConfig]
+  rfl
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery7.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery7.lean
@@ -1,0 +1,90 @@
+import TNLean.PEPS.RegionBlock.Recovery6
+
+/-!
+# Region physical-to-virtual recovery: the region resonate identity and endpoint pin
+
+This file assembles the two endpoint readings of the region-inserted coefficient
+(the in-region endpoint reading of `TNLean.PEPS.RegionBlock.Recovery2` and the
+out-of-region endpoint reading of `TNLean.PEPS.RegionBlock.Recovery6`) into the
+**region resonate identity**: the two endpoint operators built from the first
+tensor `A`, applied to the *second* tensor `B`'s closed state vectors, agree at the
+endpoint physical legs. This is the region analogue of the resonate identity
+`hEqB` that `edgeRightInsertionOp_realizes_edgeTransferMatrix`
+(`TNLean.PEPS.InsertionAlgebra`) derives at the edge level and feeds into
+`physical_to_virtual_insertion` (`TNLean.PEPS.InsertionRealization`).
+
+Both endpoint readings collapse, across `SameState`, to the same
+`SameState`-invariant closed-state realization sum
+(`regionInsertionOp_regionStateVec_pin`, `TNLean.PEPS.RegionBlock.Recovery3`), so
+the two readings agree. The in-region endpoint operator carries `M` through the
+in-region endpoint `v`; the out-of-region endpoint operator carries `M` through
+the out-of-region endpoint `vout`, which is the in-region endpoint of `f` viewed as
+a boundary edge of the set complement `univ \ R`
+(`regionBoundaryEdgeInVertex_compl_eq_outVertex`).
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The out-of-region-endpoint pin
+
+The in-region endpoint pin `regionInsertionOp_regionStateVec_pin` applied to the
+set complement `univ \ R` of `R`, with the inserted matrix transposed and the
+region/complement physical arguments exchanged, recovers the first tensor's
+region-inserted coefficient through the out-of-region endpoint `vout`. The cast
+identity `regionInsertedCoeff_eq_compl` (`TNLean.PEPS.RegionBlock.Recovery6`) turns
+the complement-side coefficient back into the original region-inserted coefficient. -/
+
+/-- **The out-of-region-endpoint pin.** The out-of-region endpoint operator of the
+first tensor from `M`, applied to the *second* tensor's closed state vector on the
+set complement `univ \ R` and evaluated at the out-of-region endpoint physical leg,
+recovers the first tensor's region-inserted coefficient of `M`, up to the interior
+bond product over the non-boundary edges of `univ \ R`.
+
+This is `regionInsertionOp_regionStateVec_pin` instanced at the set complement
+`univ \ R`, with the inserted matrix transposed and the region/complement physical
+arguments exchanged, read back through the complement-side cast identity
+`regionInsertedCoeff_eq_compl`. Together with the in-region-endpoint pin it is the
+doubled boundary-edge reading the region resonate identity equates.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertionOp_regionStateVec_pin_compl (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInteriorBondProd (G := G) A (Finset.univ \ R) •
+        (regionInsertionOp (G := G) A (Finset.univ \ R)
+          (regionBoundaryEdgeToCompl (G := G) R f) hvAout M.transpose.transpose
+          (regionStateVec (G := G) B (Finset.univ \ R)
+            (regionBoundaryEdgeToCompl (G := G) R f) τ
+            (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)))
+          (τ ⟨regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+            (regionBoundaryEdgeToCompl (G := G) R f),
+            regionBoundaryEdgeInVertex_mem (G := G) (Finset.univ \ R)
+              (regionBoundaryEdgeToCompl (G := G) R f)⟩) =
+      regionInsertedCoeff (G := G) A R f M σ τ := by
+  rw [regionInsertedCoeff_eq_compl A R f M σ τ]
+  exact regionInsertionOp_regionStateVec_pin A B (Finset.univ \ R)
+    (regionBoundaryEdgeToCompl (G := G) R f) hvAout hAB M.transpose τ
+    (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery7.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery7.lean
@@ -264,5 +264,47 @@ theorem regionInsertedCoeff_eq_region_blockedMap (A : Tensor G d) (R : Finset V)
   refine Finset.sum_congr rfl (fun ν _ => ?_)
   ring
 
+/-! ### Reading off the row functions through the blocked left inverses
+
+Each blocked left inverse recovers the corresponding row function from the
+region-inserted coefficient viewed as a function of the matching physical
+configuration. These are the read-off lemmas the region resonate step uses:
+the region-inserted coefficient, as a function of the complement (resp. region)
+physical configuration, lies in the image of the complement (resp. region) blocked
+tensor map, so the chosen left inverse reads off the row function. -/
+
+/-- **Complement read-off.** The chosen left inverse of the complement blocked tensor
+map, applied to the region-inserted coefficient viewed as a function of the
+complement physical configuration, recovers the complement row function. -/
+theorem regionBlockedLeftInverse_complement_regionInsertedCoeff (A : Tensor G d)
+    (R : Finset V) (hC : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    regionBlockedLeftInverse (G := G) A (Finset.univ \ R) hC
+        (fun τ => regionInsertedCoeff (G := G) A R f M σ τ) =
+      regionComplementRow (G := G) A R f M σ := by
+  have hfun : (fun τ => regionInsertedCoeff (G := G) A R f M σ τ) =
+      regionBlockedTensorMap (G := G) A (Finset.univ \ R)
+        (regionComplementRow (G := G) A R f M σ) :=
+    funext (fun τ => regionInsertedCoeff_eq_complement_blockedMap A R f M σ τ)
+  rw [hfun, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
+/-- **Region read-off.** The chosen left inverse of the region blocked tensor map,
+applied to the region-inserted coefficient viewed as a function of the region
+physical configuration, recovers the region row function. -/
+theorem regionBlockedLeftInverse_region_regionInsertedCoeff (A : Tensor G d)
+    (R : Finset V) (hR : RegionBlockedTensorInjective (G := G) A R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionBlockedLeftInverse (G := G) A R hR
+        (fun σ => regionInsertedCoeff (G := G) A R f M σ τ) =
+      regionRegionRow (G := G) A R f M τ := by
+  have hfun : (fun σ => regionInsertedCoeff (G := G) A R f M σ τ) =
+      regionBlockedTensorMap (G := G) A R (regionRegionRow (G := G) A R f M τ) :=
+    funext (fun σ => regionInsertedCoeff_eq_region_blockedMap A R f M σ τ)
+  rw [hfun, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery7.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery7.lean
@@ -86,5 +86,59 @@ theorem regionInsertionOp_regionStateVec_pin_compl (A B : Tensor G d) (R : Finse
     (regionBoundaryEdgeToCompl (G := G) R f) hvAout hAB M.transpose τ
     (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)
 
+/-! ### The region resonate identity
+
+Equating the in-region-endpoint pin and the out-of-region-endpoint pin gives the
+**region resonate identity**: the in-region and out-of-region endpoint operators of
+the first tensor, applied to the second tensor's closed state vectors at the two
+endpoints, agree (up to their respective interior bond products). This is the
+region analogue of the resonate identity `hEqB` that
+`edgeRightInsertionOp_realizes_edgeTransferMatrix` feeds into
+`physical_to_virtual_insertion`. It reads the two tensors only through the
+`SameState`-invariant closed state vectors. -/
+
+/-- **The region resonate identity.** The in-region-endpoint operator of the first
+tensor from `M`, applied to the second tensor's closed state vector and evaluated at
+the in-region endpoint leg, agrees with the out-of-region-endpoint operator from `M`,
+applied to the second tensor's complement-side closed state vector and evaluated at
+the out-of-region endpoint leg, each scaled by the interior bond product of the
+respective block.
+
+Both sides equal the first tensor's region-inserted coefficient of `M`: the left
+side by the in-region-endpoint pin `regionInsertionOp_regionStateVec_pin`, the right
+side by the out-of-region-endpoint pin
+`regionInsertionOp_regionStateVec_pin_compl`. This is the doubled boundary-edge
+reading the region resonate step equates.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem region_resonate_identity (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInteriorBondProd (G := G) A R •
+        (regionInsertionOp (G := G) A R f hvA M.transpose
+          (regionStateVec (G := G) B R f σ τ))
+          (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+            regionBoundaryEdgeInVertex_mem (G := G) R f⟩) =
+      regionInteriorBondProd (G := G) A (Finset.univ \ R) •
+        (regionInsertionOp (G := G) A (Finset.univ \ R)
+          (regionBoundaryEdgeToCompl (G := G) R f) hvAout M.transpose.transpose
+          (regionStateVec (G := G) B (Finset.univ \ R)
+            (regionBoundaryEdgeToCompl (G := G) R f) τ
+            (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)))
+          (τ ⟨regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+            (regionBoundaryEdgeToCompl (G := G) R f),
+            regionBoundaryEdgeInVertex_mem (G := G) (Finset.univ \ R)
+              (regionBoundaryEdgeToCompl (G := G) R f)⟩) := by
+  rw [regionInsertionOp_regionStateVec_pin A B R f hvA hAB M σ τ,
+    regionInsertionOp_regionStateVec_pin_compl A B R f hvAout hAB M σ τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery7.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery7.lean
@@ -140,5 +140,75 @@ theorem region_resonate_identity (A B : Tensor G d) (R : Finset V)
   rw [regionInsertionOp_regionStateVec_pin A B R f hvA hAB M σ τ,
     regionInsertionOp_regionStateVec_pin_compl A B R f hvAout hAB M σ τ]
 
+/-! ### Factoring the region-inserted coefficient through the complement blocked map
+
+Fixing the region physical configuration `σ`, the region-inserted coefficient is a
+function of the complement physical configuration `τ` that factors through the
+blocked-region tensor map of the set complement `univ \ R`. Reindexing the inner
+boundary-configuration sum by the complement boundary-configuration equivalence
+`regionComplementBoundaryConfigEquiv` exposes the τ-dependence as the complement
+blocked tensor map applied to the **complement row function**: the
+boundary-edge-coupled contraction of the region block against the inserted matrix.
+This lets the chosen left inverse of the complement block
+(`regionBlockedLeftInverse`) read off the row function, isolating the boundary-edge
+matrix entries. -/
+
+open scoped Classical in
+/-- The complement row function: for a boundary configuration `w` of `univ \ R`,
+the inserted matrix entry on the boundary edge `f` coupling `w` (reindexed back to
+`R`) to the region boundary configuration, contracted against the region block at
+`σ`. This is the coefficient of the complement block in the region-inserted
+coefficient, viewed as a function of the complement physical configuration. -/
+noncomputable def regionComplementRow (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    RegionBoundaryConfig (G := G) A (Finset.univ \ R) → ℂ :=
+  fun w =>
+    ∑ μ : RegionBoundaryConfig (G := G) A R,
+      (if SameAwayFromBond f μ
+            ((regionComplementBoundaryConfigEquiv (G := G) A R).symm w) then
+          M (μ f) (((regionComplementBoundaryConfigEquiv (G := G) A R).symm w) f) else 0) *
+        regionBlockedWeight (G := G) A R μ σ
+
+open scoped Classical in
+/-- **Factoring through the complement blocked map.** The region-inserted
+coefficient, as a function of the complement physical configuration `τ`, is the
+blocked-region tensor map of the set complement `univ \ R` applied to the complement
+row function.
+
+Reindexing the outer boundary-configuration sum of `regionInsertedCoeff` by the
+complement boundary-configuration equivalence turns the complement blocked weights
+into the standard blocked tensor map summands, with the row function carrying the
+inserted-matrix coupling and the region block. This is the factoring the complement
+left inverse acts on.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_complement_blockedMap (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionBlockedTensorMap (G := G) A (Finset.univ \ R)
+        (regionComplementRow (G := G) A R f M σ) τ := by
+  classical
+  set E := regionComplementBoundaryConfigEquiv (G := G) A R with hE
+  rw [regionInsertedCoeff_eq, regionBlockedTensorMap_apply]
+  -- Swap the order of summation: outer over `ν`, inner over `μ`.
+  rw [Finset.sum_comm]
+  -- Reindex the right `w`-sum over complement configs by `E` to the `ν`-sum.
+  rw [← Equiv.sum_comp E
+    (fun w : RegionBoundaryConfig (G := G) A (Finset.univ \ R) =>
+      regionComplementRow (G := G) A R f M σ w •
+        regionBlockedWeight (G := G) A (Finset.univ \ R) w τ)]
+  refine Finset.sum_congr rfl (fun ν _ => ?_)
+  rw [regionComplementRow, smul_eq_mul, Finset.sum_mul, hE,
+    regionComplementBoundaryConfigEquiv_apply]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [← regionComplementBoundaryConfigEquiv_apply (G := G) A R ν, Equiv.symm_apply_apply,
+    regionComplementBoundaryConfigEquiv_apply]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery7.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery7.lean
@@ -210,5 +210,59 @@ theorem regionInsertedCoeff_eq_complement_blockedMap (A : Tensor G d) (R : Finse
   rw [← regionComplementBoundaryConfigEquiv_apply (G := G) A R ν, Equiv.symm_apply_apply,
     regionComplementBoundaryConfigEquiv_apply]
 
+/-! ### Factoring the region-inserted coefficient through the region blocked map
+
+Fixing the complement physical configuration `τ`, the region-inserted coefficient is
+a function of the region physical configuration `σ` that factors through the
+blocked-region tensor map of `R`. The outer boundary-configuration sum of
+`regionInsertedCoeff` is already indexed by the region boundary configurations, so
+no reindexing is needed: the row function carries the inserted-matrix coupling and
+the complement block. This is the σ-analogue of the complement factoring, used to
+read the region-inserted coefficient off the region block via its left inverse. -/
+
+open scoped Classical in
+/-- The region row function: for a region boundary configuration `μ`, the inserted
+matrix entry on the boundary edge `f` coupling `μ` to the complement boundary
+configuration, contracted against the complement block at `τ`. This is the
+coefficient of the region block in the region-inserted coefficient, viewed as a
+function of the region physical configuration. -/
+noncomputable def regionRegionRow (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    RegionBoundaryConfig (G := G) A R → ℂ :=
+  fun μ =>
+    ∑ ν : RegionBoundaryConfig (G := G) A R,
+      (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+        regionBlockedWeight (G := G) A (Finset.univ \ R)
+          (regionComplementBoundaryConfig (G := G) A R ν) τ
+
+open scoped Classical in
+/-- **Factoring through the region blocked map.** The region-inserted coefficient,
+as a function of the region physical configuration `σ`, is the blocked-region tensor
+map of `R` applied to the region row function.
+
+The outer boundary-configuration sum of `regionInsertedCoeff` is indexed by the
+region boundary configurations, so it is already the blocked tensor map summand form
+with the row function carrying the inserted-matrix coupling and the complement block.
+This is the factoring the region left inverse acts on.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_region_blockedMap (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionBlockedTensorMap (G := G) A R
+        (regionRegionRow (G := G) A R f M τ) σ := by
+  classical
+  rw [regionInsertedCoeff_eq, regionBlockedTensorMap_apply]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [regionRegionRow, smul_eq_mul, Finset.sum_mul]
+  refine Finset.sum_congr rfl (fun ν _ => ?_)
+  ring
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery8.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery8.lean
@@ -1,0 +1,96 @@
+import TNLean.PEPS.RegionBlock.Recovery7
+
+/-!
+# Region physical-to-virtual recovery: incident-matrix form to the realization bundle
+
+This file connects the incident-matrix form of the virtual pullback to the
+realization bundle `RegionTransferRealizes` of `TNLean.PEPS.RegionBlock.Recovery3`,
+the last assembly toward the normal PEPS Fundamental Theorem (remaining obligation 4
+of `docs/paper-gaps/peps_normal_ft_section3_route.tex`).
+
+Recall the reduction chain already in place:
+
+* `hform_of_isIncidentMatrixForm` (`TNLean.PEPS.RegionBlock.Recovery4`) turns
+  incident-matrix form of the virtual pullback
+  `W := localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA M.transpose)`
+  into the matrix-structure hypothesis `hform`.
+* `regionTransferRealizesAt_of_hform` (`TNLean.PEPS.RegionBlock.Recovery3`) turns
+  `hform` into the per-matrix realization (the body of `RegionTransferRealizes`).
+
+This file packages the two into one step
+(`regionTransferRealizes_of_isIncidentMatrixForm`): from the per-matrix
+incident-matrix form of the virtual pullback, the realization bundle
+`RegionTransferRealizes` follows, and hence — in both directions — the region
+insertion transfer datum (`regionInsertionTransfer_of_realizes`).
+
+The single remaining mathematical content of obligation 4 is therefore exactly the
+hypothesis `hIncForm`: the virtual pullback `W` is of incident-matrix form on the
+boundary leg `f`. This is the region resonate reconcile (step (iv) of the route
+note): inverting both blocked endpoints through the blocked-region left inverses and
+forcing the two read-off row functions to couple through a single matrix on `f`. The
+prior files supply the resonate identity (`region_resonate_identity`), the row
+factorings (`regionInsertedCoeff_eq_region_blockedMap`,
+`regionInsertedCoeff_eq_complement_blockedMap`), and the read-offs
+(`regionBlockedLeftInverse_region_regionInsertedCoeff`,
+`regionBlockedLeftInverse_complement_regionInsertedCoeff`); what remains is the
+reconcile itself.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The realization bundle from per-matrix incident-matrix form
+
+The realization bundle `RegionTransferRealizes` is exactly the per-matrix
+realization quantified over all inserted matrices. Each per-matrix realization
+follows from incident-matrix form of the virtual pullback through the existing
+reduction `hform_of_isIncidentMatrixForm` then `regionTransferRealizesAt_of_hform`.
+Quantifying over `M` assembles the bundle. -/
+
+/-- **The realization bundle from incident-matrix form.** If, for every inserted
+matrix `M`, the virtual pullback of the transferred in-region endpoint operator is
+of incident-matrix form on the boundary leg `f`, then the region physical-to-virtual
+realization bundle `RegionTransferRealizes` holds.
+
+For each `M`, `hform_of_isIncidentMatrixForm` turns the incident-matrix form into the
+matrix-structure hypothesis `hform`, and `regionTransferRealizesAt_of_hform` (using
+the unconditional image-preservation half supplied by vertex injectivity) turns
+`hform` into the per-matrix realization, which is the body of `RegionTransferRealizes`.
+
+The hypothesis `hIncForm` is the only remaining mathematical content: it is the
+region resonate reconcile (step (iv) of remaining obligation 4 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionTransferRealizes_of_isIncidentMatrixForm (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hIncForm : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ P : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        localVirtualOpOfPhysicalOpAt B hvB
+            (regionInsertionOp (G := G) A R f hvA M.transpose) =
+          localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) P) :
+    RegionTransferRealizes (G := G) A B R f hvA hvB hposB := by
+  intro M c
+  obtain ⟨P, hP⟩ := hIncForm M
+  have hform := hform_of_isIncidentMatrixForm A B R f hvA hvB hposB M P hP
+  exact regionTransferRealizesAt_of_hform A B R f hvA hvB hAB hA hB hposA hposB M hform c
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery8.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery8.lean
@@ -92,5 +92,124 @@ theorem regionTransferRealizes_of_isIncidentMatrixForm (A B : Tensor G d) (R : F
   have hform := hform_of_isIncidentMatrixForm A B R f hvA hvB hposB M P hP
   exact regionTransferRealizesAt_of_hform A B R f hvA hvB hAB hA hB hposA hposB M hform c
 
+/-! ### The region resonate reconcile hypothesis
+
+The one remaining mathematical content of remaining obligation 4 is that, for every
+inserted matrix `M`, the virtual pullback of the transferred in-region endpoint
+operator is of incident-matrix form on the boundary leg `f`. Naming it as a
+predicate keeps the conditional assembly below readable and pins down precisely what
+the region resonate reconcile must establish. -/
+
+/-- **The region resonate reconcile.** For every inserted matrix `M`, the virtual
+pullback `localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA M.transpose)`
+of the transferred in-region endpoint operator is of incident-matrix form on the
+boundary leg `f`.
+
+This is the content of step (iv) of remaining obligation 4 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`: the region resonate reconcile
+forcing the two read-off row functions to couple through a single matrix on `f`. It
+is the region analogue of the incident-matrix form read from the edge resonate
+identity by `physical_to_virtual_insertion` (`TNLean.PEPS.InsertionRealization`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def RegionResonateReconcile (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f))) :
+    Prop :=
+  ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+    ∃ P : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      localVirtualOpOfPhysicalOpAt B hvB
+          (regionInsertionOp (G := G) A R f hvA M.transpose) =
+        localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) P
+
+/-- The region resonate reconcile gives the region physical-to-virtual realization
+bundle, by `regionTransferRealizes_of_isIncidentMatrixForm`. -/
+theorem regionTransferRealizes_of_reconcile (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hrec : RegionResonateReconcile (G := G) A B R f hvA hvB) :
+    RegionTransferRealizes (G := G) A B R f hvA hvB hposB :=
+  regionTransferRealizes_of_isIncidentMatrixForm A B R f hvA hvB hAB hA hB hposA hposB hrec
+
+/-! ### The region insertion transfer datum from the reconcile in both directions
+
+With the region resonate reconcile in both directions, the realization bundles
+follow, and `regionInsertionTransfer_of_realizes` (`TNLean.PEPS.RegionBlock.Recovery3`)
+assembles the `RegionInsertionTransfer` datum. Feeding it to
+`exists_regionEdgeGauge_of_transfer` (`TNLean.PEPS.RegionBlock.Algebra`) reads off the
+per-edge gauge matrix on the boundary edge `f`. -/
+
+/-- **Region insertion transfer datum from the reconcile.** Given the region
+resonate reconcile in both directions, matched bond dimensions, `SameState`, vertex
+injectivity, positive bonds, and region/complement blocked injectivity of `B`, the
+explicit transfer maps `regionTransferMatrix` assemble into a `RegionInsertionTransfer`
+datum.
+
+The two realization bundles come from `regionTransferRealizes_of_reconcile`, and the
+datum is `regionInsertionTransfer_of_realizes`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def regionInsertionTransfer_of_reconcile (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (hrecAB : RegionResonateReconcile (G := G) A B R f hvA hvB)
+    (hrecBA : RegionResonateReconcile (G := G) B A R f hvB hvA) :
+    RegionInsertionTransfer (G := G) A B R f :=
+  regionInsertionTransfer_of_realizes A B R f hvA hvB hAB hRB hCB hposA hposB hDim
+    (regionTransferRealizes_of_reconcile A B R f hvA hvB hAB hA hB hposA hposB hrecAB)
+    (regionTransferRealizes_of_reconcile B A R f hvB hvA hAB.symm hB hA hposB hposA hrecBA)
+
+/-- **Per-edge gauge from the region resonate reconcile.** Given the region resonate
+reconcile in both directions, together with the region/complement blocked injectivity
+of both tensors and positive bond dimensions, the per-edge matrix transfer on the
+boundary edge `f` is conjugation by an invertible gauge matrix `Z`, and the two bond
+dimensions on `f` coincide.
+
+This combines the transfer datum `regionInsertionTransfer_of_reconcile` with the
+per-edge gauge read-off `exists_regionEdgeGauge_of_transfer`
+(`TNLean.PEPS.RegionBlock.Algebra`), the region-level production of the per-edge gauge
+matrix.
+
+Source: arXiv:1804.04964, Section 3, lines 560--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_of_reconcile (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (hrecAB : RegionResonateReconcile (G := G) A B R f hvA hvB)
+    (hrecBA : RegionResonateReconcile (G := G) B A R f hvB hvA) :
+    ∃ hEdge : A.bondDim f.1 = B.bondDim f.1,
+      ∃ Z : GL (Fin (B.bondDim f.1)) ℂ,
+        ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+          (regionInsertionTransfer_of_reconcile A B R f hvA hvB hAB hA hB hRB hCB
+              hposA hposB hDim hrecAB hrecBA).fwd M =
+            (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim f.1)) ℂ) :
+                Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :=
+  exists_regionEdgeGauge_of_transfer A B R f
+    (regionInsertionTransfer_of_reconcile A B R f hvA hvB hAB hA hB hRB hCB
+      hposA hposB hDim hrecAB hrecBA)
+    hRA hCA hposA hRB hCB hposB
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery9.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery9.lean
@@ -211,5 +211,85 @@ theorem regionInsertionOp_regionStateVec_eq_of_coeff_eq (A B : Tensor G d) (R : 
   have hne : (regionInteriorBondProd (G := G) B R : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr hpos.ne'
   exact mul_left_cancel₀ hne hL
 
+/-! ### The region resonate reconcile from the coefficient transfer
+
+The region resonate reconcile reduces to the existence of a single matrix `N` on
+the second tensor whose region-inserted coefficient matches the first tensor's for
+every physical configuration. Given such an `N`, the state-vector realization
+(`regionInsertionOp_regionStateVec_eq_of_coeff_eq`) holds, the spanning extension
+(`regionInsertionOp_realizes_of_realizes_on_stateVec`) lifts it to every
+coefficient, and `localVirtualOpOfPhysicalOpAt_eq_of_realizes` reads off the
+incident-matrix form with `P = N.transpose`. This is the assembly of the region
+resonate reconcile from the coefficient transfer. -/
+
+/-- **The region resonate reconcile from the coefficient transfer.** If, for the
+inserted matrix `M`, there is a matrix `N` on the second tensor matching the
+region-inserted coefficients of the two tensors at every physical configuration,
+then the virtual pullback of the transferred in-region endpoint operator is of
+incident-matrix form on the boundary leg `f`, with read-off matrix `N.transpose`.
+
+The state-vector realization `regionInsertionOp_regionStateVec_eq_of_coeff_eq`,
+extended to all coefficients by `regionInsertionOp_realizes_of_realizes_on_stateVec`,
+is exactly the hypothesis of `localVirtualOpOfPhysicalOpAt_eq_of_realizes`, which
+reads off the incident-matrix form.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isIncidentMatrixForm_of_coeff_eq (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hB : IsVertexInjective B)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hcoeff : ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f N σ τ) :
+    localVirtualOpOfPhysicalOpAt B hvB
+        (regionInsertionOp (G := G) A R f hvA M.transpose) =
+      localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose := by
+  -- The realization on all coefficients, from the realization on the state vectors.
+  have hreal : ∀ c : LocalVirtualConfig B (regionBoundaryEdgeInVertex (G := G) R f) → ℂ,
+      regionInsertionOp (G := G) A R f hvA M.transpose
+          (localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f) c) =
+        localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f)
+          (localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose c) :=
+    regionInsertionOp_realizes_of_realizes_on_stateVec A B R f hvA hvB hB hposB M N
+      (regionInsertionOp_regionStateVec_eq_of_coeff_eq A B R f hvA hvB hAB hposB hDim M N hcoeff)
+  -- Read off the incident-matrix form of the virtual pullback.
+  exact localVirtualOpOfPhysicalOpAt_eq_of_realizes B hvB
+    (regionInsertionOp (G := G) A R f hvA M.transpose)
+    (localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose) hreal
+
+/-- **The region resonate reconcile from the coefficient transfer.** If, for every
+inserted matrix `M`, there is a matrix `N` on the second tensor matching the
+region-inserted coefficients of the two tensors at every physical configuration,
+then the region resonate reconcile `RegionResonateReconcile` holds.
+
+Each per-matrix incident-matrix form is `isIncidentMatrixForm_of_coeff_eq`, with the
+witness `P = N.transpose`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionResonateReconcile_of_coeff_transfer (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hB : IsVertexInjective B)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (htransfer : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ) :
+    RegionResonateReconcile (G := G) A B R f hvA hvB := by
+  intro M
+  obtain ⟨N, hN⟩ := htransfer M
+  exact ⟨N.transpose,
+    isIncidentMatrixForm_of_coeff_eq A B R f hvA hvB hAB hB hposB hDim M N hN⟩
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery9.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery9.lean
@@ -1,0 +1,86 @@
+import TNLean.PEPS.RegionBlock.Recovery8
+
+/-!
+# Region physical-to-virtual recovery: the region resonate reconcile
+
+This file proves the region resonate reconcile `RegionResonateReconcile`
+(`TNLean.PEPS.RegionBlock.Recovery8`), the single remaining mathematical content of
+remaining obligation 4 of `docs/paper-gaps/peps_normal_ft_section3_route.tex`: for
+every inserted matrix `M`, the virtual pullback
+`W := localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA M.transpose)`
+of the transferred in-region endpoint operator is of incident-matrix form on the
+boundary leg `f`.
+
+## Strategy
+
+The region port of `physical_to_virtual_insertion`
+(`TNLean.PEPS.InsertionRealization`). The two "endpoints" are the blocked regions
+`R` and `univ \ R`, joined by the single boundary edge `f`; there is no middle
+block (the region/complement split has empty interior). The inversion tool is the
+blocked-region left inverse `regionBlockedLeftInverse` (`Recovery5`) applied to
+each block, not the per-vertex split of the edge proof.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The leg-wise pin of the in-region endpoint operator
+
+The non-circular endpoint pin `regionInsertionOp_regionStateVec_pin` evaluates the
+in-region endpoint operator of the first tensor, applied to the second tensor's
+closed state vector, only at the endpoint physical leg `σ v`. Updating the
+in-region physical configuration at the endpoint vertex `v` to an arbitrary value
+`a` leaves the closed state vector unchanged (`regionStateVec_update_vmem`) while
+moving the evaluation leg to `a`, so the pin extends to every leg. This reads the
+*whole output vector* of the in-region endpoint operator on the second tensor's
+state vector as the region-inserted coefficient of the first tensor, scanned over
+the endpoint physical configuration. -/
+
+/-- **The leg-wise pin of the in-region endpoint operator.** The in-region endpoint
+operator of the first tensor from `M.transpose`, applied to the second tensor's
+closed state vector and evaluated at an arbitrary physical leg `a`, recovers the
+first tensor's region-inserted coefficient of `M` at the endpoint physical
+configuration updated to `a`, up to the interior bond product.
+
+This is the non-circular endpoint pin `regionInsertionOp_regionStateVec_pin`
+applied to `σ` updated at the endpoint vertex `v` to the value `a`: the state
+vector is unchanged by that update (`regionStateVec_update_vmem`), and the updated
+endpoint leg reads `a`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertionOp_regionStateVec_pin_leg (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) (a : Fin d) :
+    regionInteriorBondProd (G := G) A R •
+        (regionInsertionOp (G := G) A R f hvA M.transpose
+          (regionStateVec (G := G) B R f σ τ)) a =
+      regionInsertedCoeff (G := G) A R f M
+        (Function.update σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+          regionBoundaryEdgeInVertex_mem (G := G) R f⟩ a) τ := by
+  have hpin := regionInsertionOp_regionStateVec_pin A B R f hvA hAB M
+    (Function.update σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+      regionBoundaryEdgeInVertex_mem (G := G) R f⟩ a) τ
+  rw [regionStateVec_update_vmem B R f σ τ a] at hpin
+  rw [← hpin]
+  congr 2
+  rw [Function.update_self]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery9.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery9.lean
@@ -139,5 +139,77 @@ theorem regionInsertionOp_realizes_of_realizes_on_stateVec (A B : Tensor G d)
     exact hstate p.1 p.2
   exact LinearMap.congr_fun hEq c
 
+/-! ### The interior bond product is positive
+
+The bond-dimension product over the non-boundary edges is a product of positive
+bond dimensions, so it is positive. This lets the leg-wise pin cancel the bond
+product when comparing the two endpoint operators on the closed state vectors. -/
+
+/-- The interior bond product is positive when every bond dimension is positive. -/
+theorem regionInteriorBondProd_pos (A : Tensor G d) (R : Finset V)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) :
+    0 < regionInteriorBondProd (G := G) A R := by
+  rw [regionInteriorBondProd]
+  exact Finset.prod_pos (fun e _ => hposA e)
+
+/-! ### The state-vector realization from the coefficient transfer
+
+If a matrix `N` on the second tensor matches the region-inserted coefficients of
+the two tensors, then on the second tensor's closed state vectors the in-region
+endpoint operator of the first tensor (from `M.transpose`) agrees with the matrix
+insertion of `N.transpose` on the boundary edge. The leg-wise pin reads both sides,
+leg by leg, as the matched coefficients scaled by the interior bond product, which
+is positive and so cancels. -/
+
+/-- **The state-vector realization from the coefficient transfer.** If `N` matches
+the region-inserted coefficients of the two tensors, the in-region endpoint operator
+of the first tensor from `M.transpose`, applied to the second tensor's closed state
+vector, equals the matrix insertion of `N.transpose` on the boundary edge applied to
+the same state vector.
+
+Both sides are vectors in the endpoint physical leg. The leg-wise pin reads the left
+side as the first tensor's region-inserted coefficient and the right side (through
+the realization of `regionInsertionOp B`) as the second tensor's, each scaled by the
+interior bond product; matched coefficients and matched bond products (positive, so
+cancellable) give the vector equality.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertionOp_regionStateVec_eq_of_coeff_eq (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hcoeff : ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f N σ τ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertionOp (G := G) A R f hvA M.transpose
+        (regionStateVec (G := G) B R f σ τ) =
+      localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f)
+        (localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose
+          (stateOpenCoeff (G := G) B R f σ τ)) := by
+  -- Rewrite the right side as `regionInsertionOp B … N.transpose` on `B`'s state vector.
+  rw [← regionInsertionOp_realizes B R f hvB N.transpose (stateOpenCoeff (G := G) B R f σ τ),
+    ← regionStateVec_eq_localTensorMap B R f σ τ]
+  -- Compare the two vectors leg by leg.
+  funext a
+  have hbond : regionInteriorBondProd (G := G) A R = regionInteriorBondProd (G := G) B R :=
+    regionInteriorBondProd_congr A B R hDim
+  have hpos : 0 < regionInteriorBondProd (G := G) B R :=
+    regionInteriorBondProd_pos B R hposB
+  -- The leg-wise pins read both sides as the matched coefficients.
+  have hL := regionInsertionOp_regionStateVec_pin_leg A B R f hvA hAB M σ τ a
+  have hR := regionInsertionOp_regionStateVec_pin_leg B B R f hvB (fun _ => rfl) N σ τ a
+  -- The matched coefficients with matched (positive) bond products force the legs equal.
+  rw [hbond, hcoeff, ← hR, nsmul_eq_mul, nsmul_eq_mul] at hL
+  have hne : (regionInteriorBondProd (G := G) B R : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr hpos.ne'
+  exact mul_left_cancel₀ hne hL
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery9.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery9.lean
@@ -335,5 +335,116 @@ theorem regionInteriorBondProd_smul_regionStateVec (A : Tensor G d) (R : Finset 
     ← regionInsertedCoeff_one_eq_stateCoeff (G := G) A R f (Function.update σ vmem a) τ,
     regionInsertedCoeff_identity (G := G) A R f (Function.update σ vmem a) τ]
 
+/-! ### The v-side inversion: factoring the first tensor's coefficient through the
+second tensor's complement block
+
+The first tensor's region-inserted coefficient, transferred across
+`SameState` onto the second tensor's closed state vector by the leg-wise pin and
+the state-vector factorization, is — as a function of the complement physical
+configuration — in the image of the *second* tensor's complement blocked tensor
+map. This is the non-circular complement-block inversion: the complement
+dependence runs entirely through the second tensor's complement block (the state
+vector is built from the second tensor), so its left inverse reads off a row
+function without any membership of the first tensor's coefficient in the second
+tensor's region image. -/
+
+/-- The blocked region weight, read off the physical leg by updating the in-region
+physical configuration at the endpoint vertex, is the region weight vector. The
+open region coefficient is independent of the endpoint physical value
+(`regionOpenCoeff_update_vmem`), so the local-tensor factorization of the blocked
+region weight (`regionBlockedWeight_eq_localTensorMap`) reads the leg directly. -/
+theorem regionBlockedWeight_update_eq_regionWeightVec (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (μ : RegionBoundaryConfig (G := G) A R)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) (a : Fin d) :
+    regionBlockedWeight (G := G) A R μ
+        (Function.update σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+          regionBoundaryEdgeInVertex_mem (G := G) R f⟩ a) =
+      regionWeightVec (G := G) A R f μ σ a := by
+  rw [regionBlockedWeight_eq_localTensorMap A R f μ
+      (Function.update σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+        regionBoundaryEdgeInVertex_mem (G := G) R f⟩ a),
+    regionOpenCoeff_update_vmem A R f μ σ a, Function.update_self, regionWeightVec]
+
+/-- **The second tensor's state vector as a complement-block combination.** The
+interior bond product times the second tensor's closed state vector is the
+boundary-configuration sum of the complement blocked weights against the region
+weight vectors. This rewrites the region/complement contraction
+`regionInteriorBondProd_smul_regionStateVec` as a single vector identity in the
+endpoint leg. -/
+theorem regionInteriorBondProd_smul_regionStateVec_eq_sum (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInteriorBondProd (G := G) A R • regionStateVec (G := G) A R f σ τ =
+      ∑ μ : RegionBoundaryConfig (G := G) A R,
+        regionBlockedWeight (G := G) A (Finset.univ \ R)
+            (regionComplementBoundaryConfig (G := G) A R μ) τ •
+          regionWeightVec (G := G) A R f μ σ := by
+  funext a
+  rw [Pi.smul_apply, regionInteriorBondProd_smul_regionStateVec A R f σ τ a, Finset.sum_apply]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [Pi.smul_apply, smul_eq_mul, regionBlockedWeight_update_eq_regionWeightVec A R f μ σ a,
+    mul_comm]
+
+/-- **The v-side inversion (factoring through the complement block).** The first
+tensor's region-inserted coefficient of `M`, as a function of the complement
+physical configuration `τ`, is the second tensor's complement blocked tensor map
+applied to the row function reading the first tensor's in-region endpoint operator
+against the second tensor's region weight vectors at the endpoint leg.
+
+The leg-wise pin reads the coefficient as the first tensor's in-region endpoint
+operator on the second tensor's closed state vector at the endpoint leg; the
+state-vector factorization
+(`regionInteriorBondProd_smul_regionStateVec_eq_sum`) expands the state vector as a
+complement-block combination; linearity of the operator and the leg evaluation
+moves the operator inside; and reindexing the boundary configurations by the
+complement boundary-configuration equivalence presents the result as the complement
+blocked tensor map.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_complement_blockedMap_B (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        regionInsertedCoeff (G := G) A R f M σ τ) =
+      regionBlockedTensorMap (G := G) B (Finset.univ \ R)
+        (fun ν : RegionBoundaryConfig (G := G) B (Finset.univ \ R) =>
+          (regionInsertionOp (G := G) A R f hvA M.transpose
+              (regionWeightVec (G := G) B R f
+                ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν) σ))
+            (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+              regionBoundaryEdgeInVertex_mem (G := G) R f⟩)) := by
+  classical
+  funext τ
+  set v := regionBoundaryEdgeInVertex (G := G) R f with hv
+  set vm : {w : V // w ∈ R} := ⟨v, regionBoundaryEdgeInVertex_mem (G := G) R f⟩ with hvm
+  set O := regionInsertionOp (G := G) A R f hvA M.transpose with hO
+  set E := regionComplementBoundaryConfigEquiv (G := G) B R with hE
+  -- The pin reads the coefficient off the operator on `B`'s state vector.
+  have hpin := regionInsertionOp_regionStateVec_pin A B R f hvA hAB M σ τ
+  rw [← hpin]
+  -- Pull the interior bond product (matched across the two tensors) inside the operator.
+  have hbond : regionInteriorBondProd (G := G) A R = regionInteriorBondProd (G := G) B R :=
+    regionInteriorBondProd_congr A B R hDim
+  rw [hbond, ← Pi.smul_apply (regionInteriorBondProd (G := G) B R), ← map_nsmul,
+    regionInteriorBondProd_smul_regionStateVec_eq_sum B R f σ τ]
+  -- Distribute the operator and the leg evaluation over the boundary-configuration sum.
+  rw [map_sum, Finset.sum_apply]
+  simp only [map_smul, Pi.smul_apply, smul_eq_mul]
+  -- Present the sum as the complement blocked tensor map, reindexing by `E`.
+  rw [regionBlockedTensorMap_apply]
+  rw [← Equiv.sum_comp E
+    (fun ν : RegionBoundaryConfig (G := G) B (Finset.univ \ R) =>
+      (O (regionWeightVec (G := G) B R f (E.symm ν) σ)) (σ vm) •
+        regionBlockedWeight (G := G) B (Finset.univ \ R) ν τ)]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [hE, Equiv.symm_apply_apply, regionComplementBoundaryConfigEquiv_apply,
+    smul_eq_mul, mul_comm]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery9.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery9.lean
@@ -82,5 +82,62 @@ theorem regionInsertionOp_regionStateVec_pin_leg (A B : Tensor G d) (R : Finset 
   congr 2
   rw [Function.update_self]
 
+/-! ### Extending a realization from the state vectors to all coefficients
+
+The closed state-vector coefficients `stateOpenCoeff B σ τ` span the full local
+virtual coefficient space at the in-region endpoint `v`
+(`span_stateOpenCoeff_eq_top`). The two sides of the region physical-to-virtual
+realization equation are linear in the coefficient, so the realization on the
+state vectors alone forces the realization on every coefficient. This is the
+region analogue of the basis-expansion step that closes
+`physical_to_virtual_insertion` once the resonate inversion has pinned the action
+on the tensor vectors. -/
+
+/-- **Extending the realization from the state vectors.** If the in-region endpoint
+operator of the first tensor from `M.transpose` agrees, on the second tensor's
+closed state vectors, with the matrix insertion of `N.transpose` on the boundary
+edge `f`, then it agrees on every local tensor image of the second tensor at `v`.
+
+Both sides are linear in the coefficient, and the closed state-vector coefficients
+span the full local virtual coefficient space (`span_stateOpenCoeff_eq_top`), so
+equality on the spanning set extends to all coefficients.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertionOp_realizes_of_realizes_on_stateVec (A B : Tensor G d)
+    (R : Finset V) (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hB : IsVertexInjective B) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hstate : ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertionOp (G := G) A R f hvA M.transpose
+          (regionStateVec (G := G) B R f σ τ) =
+        localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f)
+          (localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose
+            (stateOpenCoeff (G := G) B R f σ τ)))
+    (c : LocalVirtualConfig B (regionBoundaryEdgeInVertex (G := G) R f) → ℂ) :
+    regionInsertionOp (G := G) A R f hvA M.transpose
+        (localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f) c) =
+      localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f)
+        (localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose c) := by
+  have hspan : Submodule.span ℂ
+      (Set.range (fun p : RegionPhysicalConfig (V := V) (d := d) R ×
+          RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        stateOpenCoeff (G := G) B R f p.1 p.2)) = ⊤ :=
+    span_stateOpenCoeff_eq_top B R f hB hposB
+  have hEq :
+      (regionInsertionOp (G := G) A R f hvA M.transpose).comp
+          (localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f)) =
+        (localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f)).comp
+          (localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose) := by
+    refine LinearMap.ext_on_range hspan (fun p => ?_)
+    rw [LinearMap.comp_apply, LinearMap.comp_apply,
+      ← regionStateVec_eq_localTensorMap B R f p.1 p.2]
+    exact hstate p.1 p.2
+  exact LinearMap.congr_fun hEq c
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery9.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery9.lean
@@ -446,5 +446,39 @@ theorem regionInsertedCoeff_eq_complement_blockedMap_B (A B : Tensor G d) (R : F
   rw [hE, Equiv.symm_apply_apply, regionComplementBoundaryConfigEquiv_apply,
     smul_eq_mul, mul_comm]
 
+/-- **The complement read-off of the first tensor's coefficient.** The second
+tensor's complement blocked left inverse, applied to the first tensor's
+region-inserted coefficient viewed as a function of the complement physical
+configuration, recovers the row function reading the first tensor's in-region
+endpoint operator against the second tensor's region weight vectors at the endpoint
+leg.
+
+This is the v-side inversion `regionInsertedCoeff_eq_complement_blockedMap_B`
+composed with the left inverse of the complement blocked tensor map
+(`regionBlockedLeftInverse_apply_regionBlockedTensorMap`). It is non-circular: the
+complement dependence runs through the second tensor's block, so the left inverse
+reads the row off without any membership of the first tensor's coefficient in the
+second tensor's region image.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedLeftInverse_complement_regionInsertedCoeff_B (A B : Tensor G d)
+    (R : Finset V) (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    regionBlockedLeftInverse (G := G) B (Finset.univ \ R) hCB
+        (fun τ => regionInsertedCoeff (G := G) A R f M σ τ) =
+      (fun ν : RegionBoundaryConfig (G := G) B (Finset.univ \ R) =>
+        (regionInsertionOp (G := G) A R f hvA M.transpose
+            (regionWeightVec (G := G) B R f
+              ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν) σ))
+          (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+            regionBoundaryEdgeInVertex_mem (G := G) R f⟩)) := by
+  rw [regionInsertedCoeff_eq_complement_blockedMap_B A B R f hvA hAB hDim M σ,
+    regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/Recovery9.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery9.lean
@@ -291,5 +291,49 @@ theorem regionResonateReconcile_of_coeff_transfer (A B : Tensor G d) (R : Finset
   exact ⟨N.transpose,
     isIncidentMatrixForm_of_coeff_eq A B R f hvA hvB hAB hB hposB hDim M N hN⟩
 
+/-! ### The closed state vector factors through the region and complement blocks
+
+The closed state vector at the in-region endpoint, scaled by the interior bond
+product, is the identity-inserted region coefficient at the endpoint physical
+configuration updated to the chosen leg. Reading off that identity insertion as a
+single boundary-configuration sum (`regionInsertedCoeff_identity`) exhibits the
+state vector at each leg as the diagonal contraction of the region block against
+the complement block. As a function of the complement physical configuration it
+factors through the complement blocked tensor map; as a function of the region
+physical configuration it factors through the region blocked tensor map. -/
+
+/-- **The closed state vector as a region/complement contraction.** The interior
+bond product times the closed state vector at the in-region endpoint, evaluated at
+the leg `a`, equals the single boundary-configuration sum of the region blocked
+weight (at `σ` updated to `a` at the endpoint vertex) times the complement blocked
+weight.
+
+This is the identity-insertion reading `regionInsertedCoeff_one_eq_stateCoeff`
+followed by `regionInsertedCoeff_identity`, with the endpoint physical leg supplied
+by the update at the endpoint vertex (`regionStateVec` reads the leg through that
+update).
+
+Source: arXiv:1804.04964, Section 3, lines 1205--1210 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_smul_regionStateVec (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) (a : Fin d) :
+    regionInteriorBondProd (G := G) A R • regionStateVec (G := G) A R f σ τ a =
+      ∑ μ : RegionBoundaryConfig (G := G) A R,
+        regionBlockedWeight (G := G) A R μ
+            (Function.update σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+              regionBoundaryEdgeInVertex_mem (G := G) R f⟩ a) *
+          regionBlockedWeight (G := G) A (Finset.univ \ R)
+            (regionComplementBoundaryConfig (G := G) A R μ) τ := by
+  set vmem : {w : V // w ∈ R} :=
+    ⟨regionBoundaryEdgeInVertex (G := G) R f, regionBoundaryEdgeInVertex_mem (G := G) R f⟩
+    with hvmem
+  have hstate : regionStateVec (G := G) A R f σ τ a =
+      stateCoeff A (assembleRegionσ (V := V) (d := d) R (Function.update σ vmem a) τ) := rfl
+  rw [hstate,
+    ← regionInsertedCoeff_one_eq_stateCoeff (G := G) A R f (Function.update σ vmem a) τ,
+    regionInsertedCoeff_identity (G := G) A R f (Function.update σ vmem a) τ]
+
 end PEPS
 end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -581,7 +581,37 @@ The remaining obligations are the following.
           \(\leanid{TNLean.PEPS.regionInsertionOp_realizes_of_realizes_on_stateVec}\),
           \(\leanid{TNLean.PEPS.regionInsertionOp_regionStateVec_eq_of_coeff_eq}\),
           \(\leanid{TNLean.PEPS.isIncidentMatrixForm_of_coeff_eq}\), and
-          \(\leanid{TNLean.PEPS.regionResonateReconcile_of_coeff_transfer}\).}\footnote{
+          \(\leanid{TNLean.PEPS.regionResonateReconcile_of_coeff_transfer}\).}
+
+          The coefficient transfer is itself reduced to a single structural
+          statement about a doubly-indexed transfer coefficient. The first tensor's
+          region-inserted coefficient factors through both blocked endpoints of the
+          second tensor at once: the v-side complement factorization gives the
+          coefficient as a function of the complement physical configuration, and
+          the symmetric region factorization (read off the complement-side cast
+          identity and transported across the double complement) gives it as a
+          function of the region physical configuration. Combining the two, the
+          coefficient is the double sum of a transfer coefficient against the second
+          tensor's region and complement blocked weights, with the transfer
+          coefficient read off by the two blocked-endpoint left inverses; the
+          required membership in the second tensor's complement block image holds
+          because the region row is a finite linear combination of the v-side
+          complement-image coefficients. Once the transfer coefficient is shown to
+          have the incident-matrix coupling form of a single matrix on the boundary
+          bond --- coupling only the boundary-edge legs and contracting the residual
+          legs by the identity --- that matrix is the matching matrix the
+          coefficient transfer asks for. This incident-matrix form of the transfer
+          coefficient is the only remaining content; it is the region analogue of
+          the source step \(V=W\), forced by the resonate identity together with the
+          full injectivity of both blocked endpoints.\footnote{
+          Formal declarations:
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_complement_blockedMap_B}\),
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_region_blockedMap_B}\),
+          \(\leanid{TNLean.PEPS.regionBlockedTensorMap_doubleCompl}\),
+          \(\leanid{TNLean.PEPS.regionRowB_mem_range}\),
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_doubleSum_transferCoeff}\),
+          \(\leanid{TNLean.PEPS.vSideRow_eq_region_blockedMap_transferCoeff}\), and
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_of_transferCoeff_form}\).}\footnote{
           Formal declarations:
           \(\leanid{TNLean.PEPS.RegionResonateReconcile}\),
           \(\leanid{TNLean.PEPS.regionTransferRealizes_of_isIncidentMatrixForm}\),

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -547,7 +547,24 @@ The remaining obligations are the following.
           region blocked tensor map (the membership that the resonate transfer across
           \(\operatorname{SameState}\) supplies), then matching the two read-off row
           functions and concluding incident-matrix form of the virtual pullback
-          through \(\leanid{TNLean.PEPS.hform_of_isIncidentMatrixForm}\).\footnote{
+          through \(\leanid{TNLean.PEPS.hform_of_isIncidentMatrixForm}\).
+
+          The remaining content of step (iv) is now isolated to a single predicate.
+          Incident-matrix form of the virtual pullback, for every inserted matrix,
+          assembles the realization bundle and hence the region insertion transfer
+          datum and the per-edge gauge, all unconditionally on top of that predicate.
+          The predicate names exactly the reconcile: the virtual pullback of the
+          transferred in-region endpoint operator is of single-bond insertion form on
+          the boundary edge. With it in both directions the per-edge gauge follows
+          mechanically, so the open obligation is reduced to establishing this
+          predicate from the region resonate identity and the two blocked-endpoint
+          inversions.\footnote{
+          Formal declarations:
+          \(\leanid{TNLean.PEPS.RegionResonateReconcile}\),
+          \(\leanid{TNLean.PEPS.regionTransferRealizes_of_isIncidentMatrixForm}\),
+          \(\leanid{TNLean.PEPS.regionTransferRealizes_of_reconcile}\),
+          \(\leanid{TNLean.PEPS.regionInsertionTransfer_of_reconcile}\), and
+          \(\leanid{TNLean.PEPS.exists_regionEdgeGauge_of_reconcile}\).}\footnote{
           Formal declarations:
           \(\leanid{TNLean.PEPS.regionInsertionOp_regionStateVec_pin_compl}\),
           \(\leanid{TNLean.PEPS.region_resonate_identity}\),

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -558,7 +558,30 @@ The remaining obligations are the following.
           the boundary edge. With it in both directions the per-edge gauge follows
           mechanically, so the open obligation is reduced to establishing this
           predicate from the region resonate identity and the two blocked-endpoint
-          inversions.\footnote{
+          inversions.
+
+          The reconcile predicate is in turn reduced to a single coefficient
+          identity. The leg-wise pin reads the in-region endpoint operator of the
+          first tensor, applied to the second tensor's closed state vector, leg by
+          leg as the first tensor's region-inserted coefficient scanned over the
+          endpoint physical configuration. The closed state-vector coefficients span
+          the full local virtual coefficient space at the in-region endpoint vertex,
+          so a realization on the state vectors extends to all coefficients. Together
+          these show: if for every inserted matrix on the first tensor's bond there
+          is a matrix on the second tensor's bond whose region-inserted coefficient
+          equals the first's at every physical configuration, then the reconcile
+          predicate holds, with the read-off matrix the transpose of the matching
+          matrix. The whole remaining obligation is therefore exactly this
+          coefficient transfer: producing, for each inserted matrix, a matching
+          matrix on the second tensor. This is the content the region resonate
+          identity and the two blocked-endpoint inversions must supply; it is
+          equivalent to the insertion-algebra isomorphism of the source lemma.\footnote{
+          Formal declarations:
+          \(\leanid{TNLean.PEPS.regionInsertionOp_regionStateVec_pin_leg}\),
+          \(\leanid{TNLean.PEPS.regionInsertionOp_realizes_of_realizes_on_stateVec}\),
+          \(\leanid{TNLean.PEPS.regionInsertionOp_regionStateVec_eq_of_coeff_eq}\),
+          \(\leanid{TNLean.PEPS.isIncidentMatrixForm_of_coeff_eq}\), and
+          \(\leanid{TNLean.PEPS.regionResonateReconcile_of_coeff_transfer}\).}\footnote{
           Formal declarations:
           \(\leanid{TNLean.PEPS.RegionResonateReconcile}\),
           \(\leanid{TNLean.PEPS.regionTransferRealizes_of_isIncidentMatrixForm}\),

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -603,7 +603,38 @@ The remaining obligations are the following.
           coefficient transfer asks for. This incident-matrix form of the transfer
           coefficient is the only remaining content; it is the region analogue of
           the source step \(V=W\), forced by the resonate identity together with the
-          full injectivity of both blocked endpoints.\footnote{
+          full injectivity of both blocked endpoints.
+
+          The incident-matrix form of the transfer coefficient is now reduced, by a
+          sorry-free chain, to the incident-matrix form of the virtual pullback
+          itself. The transfer-coefficient column at a fixed complement boundary
+          configuration is the second tensor's region blocked left inverse of the
+          v-side row. The v-side row is the first tensor's in-region endpoint
+          operator, from the inserted matrix, applied to the second tensor's region
+          weight vector; since that weight vector is the second tensor's local tensor
+          map of the region open coefficient, the unconditional image-preservation
+          realization rewrites the v-side row as the second tensor's local tensor map
+          of the virtual pullback applied to the region open coefficient. If the
+          virtual pullback is of incident-matrix form, the second tensor's own
+          in-region endpoint operator of that matrix realizes it, and the inner-sum
+          realization expands the v-side row to the incident-matrix sum against the
+          region blocked weights; the region blocked left inverse then collapses each
+          weight to the standard basis configuration, reading off the incident-matrix
+          coupling of the transfer coefficient. The reconcile predicate
+          \(\leanid{TNLean.PEPS.RegionResonateReconcile}\) is exactly this
+          incident-matrix form of the virtual pullback for every inserted matrix, so
+          the whole open obligation is now this single predicate. Establishing it
+          requires the out-of-region (complement-vertex) inversion of the region
+          resonate identity, the region analogue of the right-endpoint inversion that
+          supplies the residual-independence of the read-off matrix at the edge
+          level; the in-region pin alone fixes the matrix only at the reference
+          residual.\footnote{
+          Formal declarations (the sorry-free reduction):
+          \(\leanid{TNLean.PEPS.transferCoeff_column_eq_regionBlockedLeftInverse_vSideRow}\),
+          \(\leanid{TNLean.PEPS.vSideRow_eq_localTensorMap_virtualPullback}\),
+          \(\leanid{TNLean.PEPS.vSideRow_eq_incidentSum_of_virtualPullback_incidentForm}\),
+          and
+          \(\leanid{TNLean.PEPS.transferCoeff_eq_incidentForm_of_virtualPullback_incidentForm}\).}\footnote{
           Formal declarations:
           \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_complement_blockedMap_B}\),
           \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_region_blockedMap_B}\),

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -460,7 +460,22 @@ The remaining obligations are the following.
           Equivalently, the change of frame between \(A\)'s and \(B\)'s coefficient
           spaces at the in-region vertex must intertwine the single-bond
           insertions on \(f\). This is the region analogue of the incident-matrix
-          form read from the edge resonate identity, and remains open.
+          form read from the edge resonate identity.
+
+          This matrix-structure transfer is now reduced to a single structural
+          fact. Because the region transfer matrix is, by definition, the read-off
+          of the virtual pullback, the matrix-structure hypothesis holds exactly
+          when that pullback is of single-bond insertion form on \(f\); the
+          read-off then inverts the insertion and the round-trip closes the
+          hypothesis. The image-preservation half is unconditional in the
+          vertex-injective setting, so the pullback already realizes the
+          transferred endpoint operator on every local tensor image of \(B\) at the
+          in-region vertex. What remains is to show the pullback is of single-bond
+          insertion form, which is the residual-independence the edge resonate
+          identity supplies.\footnote{
+          Formal declarations:
+          \(\leanid{TNLean.PEPS.hform_of_isIncidentMatrixForm}\) and
+          \(\leanid{TNLean.PEPS.localTensorMap_localVirtualOpOfPhysicalOpAt_regionInsertionOp}\).}
 
           The pin available from the closed-state transfer alone is non-circular but
           insufficient on its own. Evaluating the transferred endpoint operator of
@@ -490,9 +505,8 @@ The remaining obligations are the following.
           complement, coupled by the inserted matrix on \(f\)). The missing steps are:
           (i) a complement-side realization, the analogue of
           the realization of the region-inserted coefficient applied to the complement
-          region with \(f\) as its boundary edge (using
-          \(\mathrm{univ}\setminus(\mathrm{univ}\setminus R)=R\) and the boundary-edge reindexing);
-          (ii) a region resonate identity equating the \(v\)-side and complement-side
+          region with \(f\) as its boundary edge; (ii) a region resonate identity
+          equating the \(v\)-side and complement-side
           realizations of \(A\)'s region-inserted coefficient, transferred to \(B\) by
           \(\operatorname{SameState}\); (iii) inverting both endpoints through the
           blocked-region left inverses (using the blocked-region
@@ -501,7 +515,20 @@ The remaining obligations are the following.
           the two read-off matrices to coincide. This is the region-granularity port
           of the edge insertion-realization argument and remains the open
           obligation. Once it is supplied, the transfer datum and the per-edge gauge
-          follow mechanically.\footnote{
+          follow mechanically.
+
+          Step (i) now has a cast-free reading. The complement-side reading is the
+          region-inserted coefficient read with the region and its set complement
+          exchanged and the inserted matrix transposed on \(f\). The exchange is the
+          block-swap symmetry of the abstract two-block inserted coefficient, which
+          stays over \(R\)'s boundary-edge index set and so avoids the dependent-type
+          reindexing \(\mathrm{univ}\setminus(\mathrm{univ}\setminus R)=R\). What still
+          requires that reindexing is factoring the complement block through the
+          out-of-region endpoint vertex's local tensor map for the inversion of step
+          (iii).\footnote{
+          Formal declarations:
+          \(\leanid{TNLean.PEPS.twoBlockInsertedCoeff_swap}\) and
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_complementTwoBlock}\).}\footnote{
           Formal declarations:
           \(\leanid{TNLean.PEPS.regionInsertedCoeff}\),
           \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_regionRealizationSum}\),

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -528,7 +528,33 @@ The remaining obligations are the following.
           (iii).\footnote{
           Formal declarations:
           \(\leanid{TNLean.PEPS.twoBlockInsertedCoeff_swap}\) and
-          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_complementTwoBlock}\).}\footnote{
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_complementTwoBlock}\).}
+
+          Steps (ii) and the inversion infrastructure of step (iii) are now
+          formalized. The out-of-region-endpoint pin reads the region-inserted
+          coefficient through the out-of-region endpoint vertex by instancing the
+          in-region pin at the set complement and casting back through the
+          complement-side cast identity. Equating it with the in-region-endpoint pin
+          gives the region resonate identity: the in-region and out-of-region endpoint
+          operators of the first tensor, applied to the second tensor's closed state
+          vectors, agree at the two endpoint legs. The region-inserted coefficient
+          factors, as a function of the complement (resp. region) physical
+          configuration, through the blocked-region tensor map of the set complement
+          (resp. of the region); each blocked-region left inverse reads off the
+          corresponding row function. What remains is the reconcile of step (iv):
+          exhibiting the first tensor's region-inserted coefficient, as a function of
+          the region physical configuration, in the image of the second tensor's
+          region blocked tensor map (the membership that the resonate transfer across
+          \(\operatorname{SameState}\) supplies), then matching the two read-off row
+          functions and concluding incident-matrix form of the virtual pullback
+          through \(\leanid{TNLean.PEPS.hform_of_isIncidentMatrixForm}\).\footnote{
+          Formal declarations:
+          \(\leanid{TNLean.PEPS.regionInsertionOp_regionStateVec_pin_compl}\),
+          \(\leanid{TNLean.PEPS.region_resonate_identity}\),
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_complement_blockedMap}\),
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_region_blockedMap}\),
+          \(\leanid{TNLean.PEPS.regionBlockedLeftInverse_complement_regionInsertedCoeff}\), and
+          \(\leanid{TNLean.PEPS.regionBlockedLeftInverse_region_regionInsertedCoeff}\).}\footnote{
           Formal declarations:
           \(\leanid{TNLean.PEPS.regionInsertedCoeff}\),
           \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_regionRealizationSum}\),


### PR DESCRIPTION
## What

Builds the **region insertion machinery** for the Normal PEPS Fundamental Theorem
(#1373, arXiv:1804.04964 §3) and closes the **region resonate reconcile** for the
**vertex-injective** case, axiom-clean. New files `TNLean/PEPS/RegionBlock/Recovery4`–`Recovery12`.

## Landed (all sorry-free, `#print axioms` = `[propext, Classical.choice, Quot.sound]`)

**Region insertion machinery (Recovery4–8, load-bearing):** `hform_of_isIncidentMatrixForm`, both
endpoint realizations, the `univ\(univ\R)=R` cast (`regionInsertedCoeff_eq_compl`), the blocked-region
inversion engine, the resonate identity, and the conditional chain
`RegionResonateReconcile ⟹ RegionTransferRealizes ⟹ datum ⟹ per-edge gauge`
(`exists_regionEdgeGauge_of_reconcile`).

**Reconcile closed for vertex-injective (Recovery12):** via a structural shortcut — `regionInsertionOp A R f hvA M.transpose`
is *definitionally* an edge insertion operator on the boundary edge `f`, so the pullback's incident-matrix
form follows from the already-proven edge FT (`edgeRightInsertionOp_realizes_edgeTransferMatrix`).
`regionResonateReconcile_of_sameState` + `exists_regionEdgeGauge_of_sameState` give the per-edge region
gauge from source-level hypotheses. New helper: `edgeLeftInsertionOp_realizes_edgeLeftTransferMatrix`
(the missing lower-endpoint orientation, from `physical_to_virtual_insertion`'s left clause).

## Scope (honest)

The reconcile shortcut routes through the **edge** FT, which needs edge-endpoint injectivity — so it closes
the **vertex-injective** region reconcile. Under vertex injectivity the gauge already follows from
`fundamentalTheorem_PEPS` (`fundamentalTheorem_normalPEPS_of_vertexInjective`), so this PR's contribution is
the **region insertion machinery + the explicit per-edge region gauge object**, not yet a new theorem.

The **general region-injective** normal theorem (the source's `normal`, lines 1576–1583) remains open: it
needs the reconcile *without* vertex injectivity (the edge-FT shortcut does not apply when endpoints are only
injective after blocking), or the blocking-to-coarse-graph route. Recorded in
`docs/paper-gaps/peps_normal_ft_section3_route.tex`.

**Note:** `Recovery9`–`Recovery11` (`transferCoeff`/`htransfer`/`vSideRow`) are an exploratory
coefficient-transfer branch superseded by the Recovery12 shortcut (Recovery12 imports only Recovery8). They
are sorry-free and retained as they may inform the general region-injective reconcile; they can be trimmed if
not reused. CI failures `blueprint-and-prose`/`track`/`claude-review-*`/`build` are non-blocking automation
(cf. merged #2491).

Refs #1373.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics additions (new Lean proofs and documentation); no runtime, auth, or data-handling changes.
> 
> **Overview**
> Adds **nine new Lean modules** (`Recovery4`–`Recovery12`) that formalize region boundary insertion, blocked-region inverses, complement/out-of-region endpoint realizations, the region resonate identity, and a conditional chain from **`RegionResonateReconcile`** to per-edge gauge (`exists_regionEdgeGauge_of_reconcile`).
> 
> **`Recovery12`** discharges the reconcile under **vertex injectivity** by identifying `regionInsertionOp` with the existing **edge** insertion machinery and invoking the edge fundamental theorem (plus a new left-endpoint mirror `edgeLeftInsertionOp_realizes_edgeLeftTransferMatrix`). **`Recovery9`–`Recovery11`** develop an alternate sorry-free **coefficient / `transferCoeff`** route that reduces reconcile to incident-matrix form of the virtual pullback.
> 
> Root imports in **`TNLean.lean`** and **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** are updated to record what is proved vs. what remains for the general region-injective normal theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe364ed89ee201eb02304930d9e4991d8d39165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->