### PR TITLE
feat(parent): characterize block restriction step

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -472,4 +472,68 @@ theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
   exact pgvwc07_mem_iSup_groundSpace_of_trace_decomposition
     A hSpan C Dmat hUnital hCoeff ψ hψ
 
+/-- One-step block intersection as a restriction characterization.
+
+Under the PGVWC common word-span hypothesis and the normalization
+\[
+  \sum_a A^j_a A^{j\dagger}_a=I,
+\]
+membership of an \((n+2)\)-site vector in \(\bigvee_jG_{n+2}(A^j)\) is
+equivalent to the two fixed-boundary conditions
+\[
+  \psi(-,b)\in\bigvee_jG_{n+1}(A^j),
+  \qquad
+  \psi(a,-)\in\bigvee_jG_{n+1}(A^j).
+\]
+This is the one-step block-intersection identity isolated from PGVWC07,
+Theorem 12, proof lines 1442--1452. -/
+theorem pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {n : ℕ} (hSpan : WordTupleSpanTop A n)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (ψ : NSiteSpace d (n + 2)) :
+    ψ ∈ ⨆ j : Fin r, groundSpace (A j) (n + 2) ↔
+      (∀ b : Fin d,
+        restrictLast ψ b ∈ ⨆ j : Fin r, groundSpace (A j) (n + 1)) ∧
+      (∀ a : Fin d,
+        restrictFirst ψ a ∈ ⨆ j : Fin r, groundSpace (A j) (n + 1)) := by
+  classical
+  constructor
+  · intro hψ
+    constructor
+    · intro b
+      refine Submodule.iSup_induction
+        (p := fun j : Fin r => groundSpace (A j) (n + 2))
+        (motive := fun φ => restrictLast φ b ∈
+          ⨆ j : Fin r, groundSpace (A j) (n + 1))
+        (x := ψ) hψ ?_ ?_ ?_
+      · intro j φ hφ
+        exact Submodule.mem_iSup_of_mem j
+          (groundSpace_inLeftGround (A j) (n + 1) hφ b)
+      · change (0 : NSiteSpace d (n + 1)) ∈
+          ⨆ j : Fin r, groundSpace (A j) (n + 1)
+        exact Submodule.zero_mem _
+      · intro φ ξ hφ hξ
+        simpa [restrictLast, restrictLastₗ] using
+          (Submodule.add_mem (⨆ j : Fin r, groundSpace (A j) (n + 1)) hφ hξ)
+    · intro a
+      refine Submodule.iSup_induction
+        (p := fun j : Fin r => groundSpace (A j) (n + 2))
+        (motive := fun φ => restrictFirst φ a ∈
+          ⨆ j : Fin r, groundSpace (A j) (n + 1))
+        (x := ψ) hψ ?_ ?_ ?_
+      · intro j φ hφ
+        exact Submodule.mem_iSup_of_mem j
+          (groundSpace_inRightGround (A j) (n + 1) hφ a)
+      · change (0 : NSiteSpace d (n + 1)) ∈
+          ⨆ j : Fin r, groundSpace (A j) (n + 1)
+        exact Submodule.zero_mem _
+      · intro φ ξ hφ hξ
+        simpa [restrictFirst, restrictFirstₗ] using
+          (Submodule.add_mem (⨆ j : Fin r, groundSpace (A j) (n + 1)) hφ hξ)
+  · intro hRestrict
+    exact pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
+      A hSpan hUnital ψ hRestrict.1 hRestrict.2
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5570,6 +5570,44 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
 \end{proof}
 
+\begin{lemma}[One-step block intersection characterization]
+    \label{lem:block_restrictions_iff_block_ground_spaces}
+    \lean{MPSTensor.pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions}
+    \leanok
+    \uses{lem:block_restrictions_mem_block_ground_spaces}
+    Under the hypotheses of
+    Lemma~\ref{lem:block_restrictions_mem_block_ground_spaces}, an
+    \((n+2)\)-site vector satisfies
+    \[
+        \psi\in\bigvee_jG_{n+2}(A^j)
+    \]
+    if and only if
+    \[
+        \psi(a,-)\in\bigvee_jG_{n+1}(A^j),
+        \qquad
+        \psi(-,b)\in\bigvee_jG_{n+1}(A^j)
+    \]
+    for every physical index \(a,b\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The reverse implication is
+    Lemma~\ref{lem:block_restrictions_mem_block_ground_spaces}.  For the
+    forward implication, write
+    \[
+        \psi=\sum_j\gamma_j,\qquad \gamma_j\in G_{n+2}(A^j).
+    \]
+    Each \(\gamma_j\) has fixed-boundary restrictions in \(G_{n+1}(A^j)\):
+    \[
+        \gamma_j(a,-)\in G_{n+1}(A^j),
+        \qquad
+        \gamma_j(-,b)\in G_{n+1}(A^j).
+    \]
+    Taking the finite sum over \(j\) gives the two restrictions of \(\psi\) in
+    \(\bigvee_jG_{n+1}(A^j)\).
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -5578,7 +5616,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:normalized_boundary_matrix_identities,
         lem:left_boundary_summands_mem_block_ground_spaces,
         lem:left_boundary_trace_decomposition_mem_block_ground_spaces,
-        lem:block_restrictions_mem_block_ground_spaces}
+        lem:block_restrictions_mem_block_ground_spaces,
+        lem:block_restrictions_iff_block_ground_spaces}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[


### PR DESCRIPTION
## Summary

This adds the one-step block-intersection characterization obtained by combining the forward restriction property with the reverse implication from #2496:
\\[
  \\psi\in\\bigvee_jG_{n+2}(A^j)
  \\Longleftrightarrow
  \\left(
    \\forall b,\\;\\psi(-,b)\in\\bigvee_jG_{n+1}(A^j)
  \\right)
  \\wedge
  \\left(
    \\forall a,\\;\\psi(a,-)\in\\bigvee_jG_{n+1}(A^j)
  \\right),
\\]
under the same common word-span and normalization hypotheses.

The forward implication restricts each summand \\(\\gamma_j\\in G_{n+2}(A^j)\\) to \\(G_{n+1}(A^j)\\) and sums over \\(j\\).  The reverse implication is exactly the restriction-form theorem from #2496.

## Blueprint

Adds `lem:block_restrictions_iff_block_ground_spaces` and records it as another input to `thm:block_diagonal_ground_space_intersection`.

## Checks

- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty`
- `lake exe lint_style --github`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- exact blocker scan on `TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `#print axioms MPSTensor.pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions`
- `lake exe checkdecls /tmp/tnlean_parent_restriction_iff_decls`
- `lake build TNLean`
- `leanblueprint web` locally, with the repository's usual plasTeX and bibliography warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only and blueprint documentation in the parent-Hamiltonian MPS formalization; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds a **formal iff** for one-step block ground-space intersection: an \((n+2)\)-site vector lies in \(\bigvee_j G_{n+2}(A^j)\) exactly when both boundary restrictions lie in \(\bigvee_j G_{n+1}(A^j)\), under the same PGVWC word-span and normalization hypotheses.
> 
> In Lean, **`pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions`** proves the forward direction via `Submodule.iSup_induction` and existing `groundSpace_inLeftGround` / `groundSpace_inRightGround`; the reverse direction delegates to **`pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions`**.
> 
> The blueprint gains **`lem:block_restrictions_iff_block_ground_spaces`** (linked to that theorem) and lists it as an input to **`thm:block_diagonal_ground_space_intersection`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e121000e6005902c97dbd25b687d0c1755d686f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->