### PR TITLE
feat(parent): state block restriction intersection as subspace equality

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -536,4 +536,31 @@ theorem pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions
     exact pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
       A hSpan hUnital ψ hRestrict.1 hRestrict.2
 
+/-- Subspace form of the one-step block intersection identity.
+
+Let \(S_n=\bigvee_jG_{n+1}(A^j)\).  Under the PGVWC common word-span
+hypothesis and the normalization
+\[
+  \sum_a A^j_a A^{j\dagger}_a=I,
+\]
+the \((n+2)\)-site block ground space is the intersection of the inverse
+images of \(S_n\) under all fixed last-letter and fixed first-letter
+restrictions.  This is the restriction-subspace form of PGVWC07, Theorem 12,
+proof lines 1442--1452. -/
+theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {n : ℕ} (hSpan : WordTupleSpanTop A n)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1) :
+    ((⨅ b : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+      (⨅ a : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+      ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  classical
+  ext ψ
+  simp only [Submodule.mem_inf, Submodule.mem_iInf]
+  simpa [restrictLast, restrictFirst] using
+    (pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions A hSpan hUnital ψ).symm
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5608,6 +5608,33 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \(\bigvee_jG_{n+1}(A^j)\).
 \end{proof}
 
+\begin{lemma}[Subspace form of the one-step block intersection]
+    \label{lem:block_restriction_intersection_subspace}
+    \lean{MPSTensor.pgvwc07_iSup_groundSpace_eq_restriction_intersection}
+    \leanok
+    \uses{lem:block_restrictions_iff_block_ground_spaces}
+    Under the hypotheses of
+    Lemma~\ref{lem:block_restrictions_mem_block_ground_spaces}, set
+    \[
+        S_n:=\bigvee_jG_{n+1}(A^j).
+    \]
+    Then
+    \[
+        \left\{\psi:\forall b,\ \psi(-,b)\in S_n\right\}
+        \cap
+        \left\{\psi:\forall a,\ \psi(a,-)\in S_n\right\}
+        =
+        \bigvee_jG_{n+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:block_restrictions_iff_block_ground_spaces} gives the
+    displayed equivalence for each vector \(\psi\).  Interpreting the two sides
+    of that equivalence as subspaces gives the stated equality.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -5617,7 +5644,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:left_boundary_summands_mem_block_ground_spaces,
         lem:left_boundary_trace_decomposition_mem_block_ground_spaces,
         lem:block_restrictions_mem_block_ground_spaces,
-        lem:block_restrictions_iff_block_ground_spaces}
+        lem:block_restrictions_iff_block_ground_spaces,
+        lem:block_restriction_intersection_subspace}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[


### PR DESCRIPTION
## Summary

This PR records the subspace form of the one-step PGVWC07 block-intersection statement proved in #2497.  If
\[
  S_n=\bigvee_jG_{n+1}(A^j),
\]
then the new theorem proves
\[
  \left(\bigcap_b \operatorname{Res}_{-,b}^{-1}S_n\right)
  \cap
  \left(\bigcap_a \operatorname{Res}_{a,-}^{-1}S_n\right)
  =
  \bigvee_jG_{n+2}(A^j),
\]
under the common word-span and normalization hypotheses.

The proof is exactly the vectorwise equivalence from #2497, read as equality of subspaces.  The blueprint now records this as the immediate subspace-level input to the not-ready PGVWC07 block-diagonal intersection theorem.

Progress toward #905, #870, and #190.

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty`
- `lake exe lint_style --github`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `git diff --check`
- exact blocker scan on `TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `#print axioms MPSTensor.pgvwc07_iSup_groundSpace_eq_restriction_intersection`
- `lake exe checkdecls /tmp/tnlean_parent_subspace_intersection_decls`
- `lake build TNLean`
- `leanblueprint web`

Local full `leanblueprint checkdecls` is blocked by pre-existing stale blueprint references outside this diff; the branch-specific declaration check above passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof is a direct restatement of an existing iff lemma; blueprint linkage only, no runtime or security impact.
> 
> **Overview**
> Adds **`pgvwc07_iSup_groundSpace_eq_restriction_intersection`**, stating that \(\bigvee_j G_{n+2}(A^j)\) equals the intersection of inverse images of \(S_n=\bigvee_j G_{n+1}(A^j)\) under all `restrictLastₗ` / `restrictFirstₗ` maps. The proof is `ext ψ` plus membership in `⨅`/`⨅`/`⊓`, applied to the existing vectorwise iff **`pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions`**.
> 
> The blueprint gains Lemma **`block_restriction_intersection_subspace`** (linked to that Lean theorem) and the not-ready block-diagonal intersection theorem now **`uses`** it alongside the iff lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e73f10777dcda14f371f213170d92a8ba926d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->