### PR TITLE
feat(parent): add homogeneous word-tuple span padding

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -161,6 +161,46 @@ theorem pointwise_mul_mem_span_wordTuple_add
       rw [hEq]
       exact Submodule.smul_mem _ a hM
 
+/-- Homogeneous identity padding preserves the full word-tuple span.
+
+If the length-\(L\) simultaneous word tuples span the full product algebra, and
+the simultaneous identity tuple lies in the length-\(S\) word-tuple span, then
+the length-\(L+S\) simultaneous word tuples also span the full product algebra.
+-/
+theorem wordTupleSpanTop_add_of_identity_mem_span_wordTuple
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L S : ℕ}
+    (hSpan : WordTupleSpanTop A L)
+    (hId : (fun k : Fin r => (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∈
+      Submodule.span ℂ (Set.range (wordTuple A S))) :
+    WordTupleSpanTop A (L + S) := by
+  classical
+  unfold WordTupleSpanTop at hSpan ⊢
+  apply eq_top_iff.mpr
+  intro M _
+  have hM : M ∈ Submodule.span ℂ (Set.range (wordTuple A L)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hmul := pointwise_mul_mem_span_wordTuple_add A hM hId
+  have hprod :
+      (fun k : Fin r =>
+        M k * (fun k : Fin r => (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) k) = M := by
+    funext k
+    simp
+  simpa [hprod] using hmul
+
+/-- Two homogeneous full word-tuple spans compose by concatenating words. -/
+theorem wordTupleSpanTop_add_of_wordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L S : ℕ}
+    (hSpanL : WordTupleSpanTop A L)
+    (hSpanS : WordTupleSpanTop A S) :
+    WordTupleSpanTop A (L + S) := by
+  apply wordTupleSpanTop_add_of_identity_mem_span_wordTuple A hSpanL
+  unfold WordTupleSpanTop at hSpanS
+  rw [hSpanS]
+  exact Submodule.mem_top
+
 /-- The empty word is the identity on every block, so it selects a block on the
 empty target set. -/
 theorem hasBlockSelectorOn_empty

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5262,13 +5262,51 @@ formulation; the passage to $\ker H_N$ is kept separate.
     of the displayed block-separating equation.
 \end{proof}
 
+\begin{lemma}[Homogeneous padding for blockwise product spans]
+    \label{lem:homogeneous_word_tuple_span_padding}
+    \lean{MPSTensor.wordTupleSpanTop_add_of_identity_mem_span_wordTuple}
+    \lean{MPSTensor.wordTupleSpanTop_add_of_wordTupleSpanTop}
+    \leanok
+    \uses{def:blockwise_product_word_span}
+    Suppose the length-\(L\) simultaneous block-word tuples span
+    \(\prod_j M_{D_j}(\mathbb C)\), and suppose the simultaneous identity tuple
+    \((I,\ldots,I)\) lies in the span of the length-\(S\) simultaneous
+    block-word tuples. Then the length-\(L+S\) simultaneous block-word tuples
+    span \(\prod_j M_{D_j}(\mathbb C)\). In particular, two full homogeneous
+    spans at lengths \(L\) and \(S\) give a full homogeneous span at length
+    \(L+S\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Let \(M=(M_j)_j\) be a target tuple.  Write
+    \[
+        M_j=\sum_{|u|=L} a_u A^j_u,
+        \qquad
+        I=\sum_{|v|=S} b_v A^j_v
+    \]
+    simultaneously for every block \(j\).  Multiplying the two expansions gives
+    \[
+        M_j
+        =
+        M_j I
+        =
+        \sum_{|u|=L}\sum_{|v|=S} a_u b_v A^j_uA^j_v
+        =
+        \sum_{|u|=L}\sum_{|v|=S} a_u b_v A^j_{uv}.
+    \]
+    The words \(uv\) have length \(L+S\), so the target tuple lies in the
+    length-\(L+S\) span.
+\end{proof}
+
 \begin{lemma}[Blockwise word span from block-separating equations]
     \label{lem:product_word_span_from_bnt_selectors}
     \lean{MPSTensor.wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords}
     \lean{MPSTensor.wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords}
     \leanok
     \uses{def:blockwise_product_word_span,
-        lem:block_selectors_from_pairwise_separators}
+        lem:block_selectors_from_pairwise_separators,
+        lem:homogeneous_word_tuple_span_padding}
     Let $J$ be a finite set of $r$ sectors, and let $(A_j)_{j\in J}$ be a
     finite family of tensors with common block injectivity at length $L$.
     Suppose there are length-$S$ block-separating equations: for each sector


### PR DESCRIPTION
## Summary

This PR adds the homogeneous padding step for blockwise product spans.  If the length-`L` simultaneous block-word tuples span the full product algebra, and the simultaneous identity tuple lies in the length-`S` homogeneous span, then the length-`L+S` simultaneous tuples span the full product algebra:
\[
  \operatorname{span}\{(A_j^u)_j: |u|=L\}=\prod_j M_{D_j},
  \qquad
  (I,\ldots,I)\in \operatorname{span}\{(A_j^v)_j: |v|=S\}
\]
implies
\[
  \operatorname{span}\{(A_j^w)_j: |w|=L+S\}=\prod_j M_{D_j}.
\]
It also records the immediate corollary that two full homogeneous tuple spans compose at the sum of the lengths.

This is the identity-padding algebra needed for the PGVWC07 length-range step after #2498.

Progress toward #905, #870, and #190.

## Verification

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean`
- `lake build TNLean.MPS.MPDO.BiCFDerivation.Selectors`
- `lake exe lint_style --github`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean`
- `git diff --check`
- exact blocker scan on `TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean`
- `#print axioms MPSTensor.wordTupleSpanTop_add_of_identity_mem_span_wordTuple`
- `#print axioms MPSTensor.wordTupleSpanTop_add_of_wordTupleSpanTop`
- `lake exe checkdecls /tmp/tnlean_word_tuple_span_padding_decls`
- `lake build TNLean`
- `leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style span algebra in BiCF selectors with blueprint sync; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **homogeneous word-tuple span padding**: if length-\(L\) simultaneous block-word tuples already span the full product algebra and the simultaneous identity tuple lies in the length-\(S\) homogeneous span, then length-\(L+S\) tuples span the full algebra. Lean proves this by multiplying an arbitrary tuple \(M\) (from the \(L\)-span) with the identity tuple in the \(S\)-span via existing `pointwise_mul_mem_span_wordTuple_add`, and records the corollary that two full homogeneous spans at \(L\) and \(S\) compose at \(L+S\).
> 
> The blueprint chapter gets a matching lemma (`homogeneous_word_tuple_span_padding`) and the downstream **blockwise word span from block-separating equations** lemma now cites it in `\uses`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e625d5f8ece732829607d2d167027043500107a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->