### PR TITLE
feat(parent): add period-window word-span padding

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -201,6 +201,50 @@ theorem wordTupleSpanTop_add_of_wordTupleSpanTop
   rw [hSpanS]
   exact Submodule.mem_top
 
+/-- A full homogeneous word-tuple span at one period extends any full base
+length along the arithmetic progression obtained by adding that period. -/
+theorem wordTupleSpanTop_add_mul_of_wordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {base period : ℕ}
+    (hbase : WordTupleSpanTop A base)
+    (hperiod : WordTupleSpanTop A period) :
+    ∀ q : ℕ, WordTupleSpanTop A (base + q * period)
+  | 0 => by
+      simpa using hbase
+  | q + 1 => by
+      have hq : WordTupleSpanTop A (base + q * period) :=
+        wordTupleSpanTop_add_mul_of_wordTupleSpanTop A hbase hperiod q
+      have hstep := wordTupleSpanTop_add_of_wordTupleSpanTop A hq hperiod
+      simpa [Nat.succ_mul, Nat.add_assoc] using hstep
+
+/-- A finite residue window of full homogeneous word-tuple spans, together with
+one positive period, gives full homogeneous word-tuple spans at every
+sufficiently large length. -/
+theorem wordTupleSpanTop_eventually_of_wordTupleSpanTop_period_window
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {start period : ℕ} (hperiod_pos : 0 < period)
+    (hperiod : WordTupleSpanTop A period)
+    (hwindow : ∀ r : ℕ, r < period → WordTupleSpanTop A (start + r)) :
+    ∃ L : ℕ, ∀ n : ℕ, n ≥ L → WordTupleSpanTop A n := by
+  refine ⟨start, ?_⟩
+  intro n hn
+  let r := (n - start) % period
+  let q := (n - start) / period
+  have hr : r < period := by
+    exact Nat.mod_lt _ hperiod_pos
+  have hbase : WordTupleSpanTop A (start + r) :=
+    hwindow r hr
+  have hpad : WordTupleSpanTop A (start + r + q * period) :=
+    wordTupleSpanTop_add_mul_of_wordTupleSpanTop A hbase hperiod q
+  have hlen : start + r + q * period = n := by
+    dsimp [r, q]
+    rw [Nat.add_assoc]
+    rw [Nat.mul_comm ((n - start) / period) period]
+    rw [Nat.mod_add_div]
+    exact Nat.add_sub_of_le hn
+  rw [← hlen]
+  exact hpad
+
 /-- The empty word is the identity on every block, so it selects a block on the
 empty target set. -/
 theorem hasBlockSelectorOn_empty

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5299,6 +5299,36 @@ formulation; the passage to $\ker H_N$ is kept separate.
     length-\(L+S\) span.
 \end{proof}
 
+\begin{lemma}[Period-window propagation for blockwise product spans]
+    \label{lem:period_window_word_tuple_span_padding}
+    \lean{MPSTensor.wordTupleSpanTop_add_mul_of_wordTupleSpanTop}
+    \lean{MPSTensor.wordTupleSpanTop_eventually_of_wordTupleSpanTop_period_window}
+    \leanok
+    \uses{def:blockwise_product_word_span,
+        lem:homogeneous_word_tuple_span_padding}
+    Let \(p>0\). Suppose the length-\(p\) simultaneous block-word tuples span
+    \(\prod_j M_{D_j}(\mathbb C)\), and suppose that for every
+    \(0\le r<p\), the length-\(s+r\) simultaneous block-word tuples span
+    \(\prod_j M_{D_j}(\mathbb C)\). Then there is a length \(N\) such that,
+    for every \(n\ge N\), the length-\(n\) simultaneous block-word tuples span
+    \(\prod_j M_{D_j}(\mathbb C)\). More concretely, one may take \(N=s\):
+    writing
+    \[
+        n=s+r+qp,\qquad 0\le r<p,
+    \]
+    the span at length \(s+r\) propagates to the span at length \(n\) by
+    multiplying \(q\) times by the period-\(p\) span.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The Euclidean division of \(n-s\) by \(p\) gives
+    \(n=s+r+qp\) with \(0\le r<p\).  The assumed residue-window span gives the
+    full product algebra at length \(s+r\). Applying homogeneous padding with
+    the length-\(p\) span once gives the full product algebra at length
+    \(s+r+p\); iterating gives the full product algebra at length \(s+r+qp\).
+\end{proof}
+
 \begin{lemma}[Blockwise word span from block-separating equations]
     \label{lem:product_word_span_from_bnt_selectors}
     \lean{MPSTensor.wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords}


### PR DESCRIPTION
## Summary

This PR adds the period-window propagation step for the blockwise product-span hypothesis used in the PGVWC07 block-diagonal parent-Hamiltonian argument.

Mathematically, if a positive period `p` gives a full homogeneous simultaneous block-word span, and a complete residue window `s, ..., s+p-1` also gives full homogeneous spans, then every length `n >= s` gives a full homogeneous simultaneous block-word span. Writing

```text
n = s + r + q p,    0 <= r < p,
```

the proof is just Euclidean division of `n-s` followed by repeated homogeneous padding.

The new Lean declarations are:

- `MPSTensor.wordTupleSpanTop_add_mul_of_wordTupleSpanTop`
- `MPSTensor.wordTupleSpanTop_eventually_of_wordTupleSpanTop_period_window`

The blueprint gains `lem:period_window_word_tuple_span_padding`, stated in equations rather than by referring to Lean names in the prose.

## Relation to the parent-Hamiltonian thread

This advances #905 and the parent-Hamiltonian tracker #190 by supplying the period-window/full-range bridge identified after #2497, #2498, and #2499. It is also upstream of #870, but it does not close #870.

The remaining PGVWC07 step is to assemble the source length-range hypotheses and apply the block-intersection equality from #2498 at the admissible lengths.

## Checks

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean`
- `lake build TNLean.MPS.MPDO.BiCFDerivation.Selectors`
- `lake exe lint_style --github`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean`
- `git diff --check`
- blocker scan on the touched Lean and blueprint files
- `#print axioms` for both new declarations
- direct `lake exe checkdecls` on both new declarations
- `lake build TNLean`
- `leanblueprint web`

`leanblueprint checkdecls` was not locally runnable because this checkout has no generated `blueprint/lean_decls` file; the changed-declaration blueprint coverage scan and direct `checkdecls` for the new declarations both passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal verification and blueprint prose; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **period-window propagation** for homogeneous `WordTupleSpanTop`: a full span at a positive period `p` plus full spans on every residue class `start + r` (`r < p`) implies full spans for all lengths `n ≥ start`.
> 
> Lean gains `wordTupleSpanTop_add_mul_of_wordTupleSpanTop` (iterate padding by `q` periods from a base length) and `wordTupleSpanTop_eventually_of_wordTupleSpanTop_period_window` (Euclidean division `n = start + r + qp`). The blueprint documents the same step as `lem:period_window_word_tuple_span_padding`, building on homogeneous word-tuple span padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef91c845c4778b00698cf2ce9820e5012e39561b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->