### PR TITLE
feat(parent): assemble period-window block intersection

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
-import TNLean.MPS.MPDO.BiCFDerivation.Core
+import TNLean.MPS.MPDO.BiCFDerivation.Selectors
 
 /-!
 # Block-diagonal intersection identities
@@ -562,5 +562,30 @@ theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection
   simp only [Submodule.mem_inf, Submodule.mem_iInf]
   simpa [restrictLast, restrictFirst] using
     (pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions A hSpan hUnital ψ).symm
+
+/-- Period-window form of the PGVWC one-step block intersection.
+
+If a positive period and a complete residue window give full homogeneous
+blockwise product spans, then the one-step block-intersection subspace equality
+holds at every sufficiently large internal word length. -/
+theorem pgvwc07_iSup_restriction_intersection_eventually_of_period_window
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {start period : ℕ} (hperiod_pos : 0 < period)
+    (hperiod : WordTupleSpanTop A period)
+    (hwindow : ∀ s : ℕ, s < period → WordTupleSpanTop A (start + s))
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1) :
+    ∃ L : ℕ, ∀ n : ℕ, n ≥ L →
+      ((⨅ b : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+        (⨅ a : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+        ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  rcases wordTupleSpanTop_eventually_of_wordTupleSpanTop_period_window
+      A hperiod_pos hperiod hwindow with
+    ⟨L, hL⟩
+  refine ⟨L, ?_⟩
+  intro n hn
+  exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A (hL n hn) hUnital
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5703,6 +5703,43 @@ formulation; the passage to $\ker H_N$ is kept separate.
     of that equivalence as subspaces gives the stated equality.
 \end{proof}
 
+\begin{lemma}[Period-window form of the block intersection identity]
+    \label{lem:period_window_block_restriction_intersection}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_period_window}
+    \leanok
+    \uses{lem:period_window_word_tuple_span_padding,
+        lem:block_restriction_intersection_subspace}
+    Let \(p>0\). Suppose the length-\(p\) simultaneous block-word tuples span
+    \(\prod_j M_{D_j}(\mathbb C)\), and suppose that for every \(0\le r<p\),
+    the length-\(s+r\) simultaneous block-word tuples span
+    \(\prod_j M_{D_j}(\mathbb C)\). Assume also the normalization
+    \[
+        \sum_a A^j_aA^{j\,\dagger}_a=I
+    \]
+    for every block \(j\). Then there is a length \(N\) such that, for every
+    \(n\ge N\), if
+    \[
+        S_n:=\bigvee_jG_{n+1}(A^j),
+    \]
+    then
+    \[
+        \left\{\psi:\forall b,\ \psi(-,b)\in S_n\right\}
+        \cap
+        \left\{\psi:\forall a,\ \psi(a,-)\in S_n\right\}
+        =
+        \bigvee_jG_{n+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:period_window_word_tuple_span_padding} gives a length \(N\)
+    such that the simultaneous block-word tuples span
+    \(\prod_j M_{D_j}(\mathbb C)\) at every length \(n\ge N\). For each such
+    \(n\), Lemma~\ref{lem:block_restriction_intersection_subspace} applies and
+    gives the displayed subspace equality.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -5713,7 +5750,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:left_boundary_trace_decomposition_mem_block_ground_spaces,
         lem:block_restrictions_mem_block_ground_spaces,
         lem:block_restrictions_iff_block_ground_spaces,
-        lem:block_restriction_intersection_subspace}
+        lem:block_restriction_intersection_subspace,
+        lem:period_window_block_restriction_intersection}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[


### PR DESCRIPTION
## Summary

This PR adds the period-window form of the one-step PGVWC block-intersection identity.

If a positive period `p` and a complete residue window `s, ..., s+p-1` give full homogeneous simultaneous block-word spans, and the blocks are in the normalization

```text
sum_a A^j_a A^{j†}_a = I,
```

then there is a length `N` such that for every `n >= N`, with

```text
S_n = \bigvee_j G_{n+1}(A^j),
```

the subspace equality

```text
(⋂_b Res_{-,b}^{-1} S_n) ∩ (⋂_a Res_{a,-}^{-1} S_n)
  = \bigvee_j G_{n+2}(A^j)
```

holds.

The new Lean declaration is:

- `MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_period_window`

The blueprint gains `lem:period_window_block_restriction_intersection` and the not-ready PGVWC07 block-diagonal theorem now cites it as the conditional period-window input.

## Relation to the parent-Hamiltonian thread

This advances #905 and #190 by connecting the period-window product-span propagation from #2500 to the subspace block-intersection equality from #2498. It is still conditional on the period-window hypotheses; the remaining source-faithful step is to instantiate the PGVWC07 admissible length range from the paper's block-injective hypotheses.

It remains upstream of #870.

## Checks

- `lake env lean TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty`
- `lake exe lint_style --github`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `git diff --check`
- blocker scan on the touched Lean and blueprint files
- `#print axioms MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_period_window`
- direct `lake exe checkdecls` on the new declaration
- `lake build TNLean`
- `leanblueprint web`

The full build only reported pre-existing warnings outside this PR. As in #2500, local `leanblueprint checkdecls` is not usable without a generated `blueprint/lean_decls`; direct `checkdecls` on the new declaration passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and blueprint wiring only; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds **`pgvwc07_iSup_restriction_intersection_eventually_of_period_window`**, which states that under a positive period, full simultaneous block-word spans on that period and on a complete residue window, plus block normalization, the PGVWC **one-step block-intersection subspace equality** holds for all large enough internal lengths `n`. The proof is a thin composition: **`wordTupleSpanTop_eventually_of_wordTupleSpanTop_period_window`** supplies `WordTupleSpanTop` eventually, then **`pgvwc07_iSup_groundSpace_eq_restriction_intersection`** applies.
> 
> The Lean import for this file switches from **`BiCFDerivation.Core`** to **`BiCFDerivation.Selectors`** so the period-window span lemma is available.
> 
> The blueprint adds **`lem:period_window_block_restriction_intersection`** (linked to the new theorem) and extends the not-ready block-diagonal ground-space intersection theorem to cite it alongside the unconditional subspace lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcfad6840536903c5138bea8edac2d7c434c7e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->