### PR TITLE
feat(parent): package BNT direct-sum selector span

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.BNT.Construction
 import TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness
+import TNLean.MPS.MPDO.BiCFDerivation.Selectors
 
 /-!
 # BNT input for the equal-size direct-sum branch
@@ -140,6 +141,89 @@ theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEqu
     ∃ S : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S :=
   ⟨L + (L + L),
     forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
+      A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL⟩
+
+/-- BNT-separated blocks give common pairwise block-separating equations at the
+three-block length, once the direct-sum injectivity hypotheses are supplied.
+
+This is the selector-facing consequence of the direct-sum input used in
+PGVWC07, Lemma `lem:direct-sum`: the homogeneous trace separation at
+\(L+(L+L)\) is converted into equations selecting one block against another. -/
+theorem hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) (L + (L + L)))
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L) :
+    HasPairBlockSeparatingWords A (L + (L + L)) :=
+  hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt A
+    (forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
+      A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
+
+/-- BNT-separated blocks satisfy the abstract block-injectivity selector datum
+under the same explicit direct-sum injectivity hypotheses. -/
+theorem propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) (L + (L + L)))
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L) :
+    PropBlockInjective A :=
+  propBlockInjective_of_common_blockInjective_of_pairBlockSeparatingWords A hBlk
+    (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
+      A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
+
+/-- Common block injectivity and the BNT direct-sum separation input give a
+finite simultaneous block-word span.
+
+Explicitly, the length is
+\[
+  L+(r-1)(L+(L+L)),
+\]
+because the length-\(L\) block-injective prefix supplies the target matrix in a
+chosen block, and the \(r-1\) three-block selectors kill the other blocks. -/
+theorem wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) (L + (L + L)))
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L) :
+    WordTupleSpanTop A (L + (r - 1) * (L + (L + L))) :=
+  wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords A hBlk
+    (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
+      A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
+
+/-- Existential form of
+`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors`. -/
+theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) (L + (L + L)))
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L) :
+    ∃ N : ℕ, WordTupleSpanTop A N :=
+  ⟨L + (r - 1) * (L + (L + L)),
+    wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5376,6 +5376,55 @@ formulation; the passage to $\ker H_N$ is kept separate.
     pairwise equations into the full equations.
 \end{proof}
 
+\begin{lemma}[BNT direct-sum input gives a finite blockwise product span]
+    \label{lem:bnt_direct_sum_selectors_word_span}
+    \lean{MPSTensor.hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv}
+    \lean{MPSTensor.propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum}
+    \lean{MPSTensor.wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors}
+    \lean{MPSTensor.exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors}
+    \leanok
+    \uses{lem:direct_sum_two_block_dimension_step,
+        lem:pair_trace_separation_to_pairwise_selectors,
+        lem:block_selectors_from_pairwise_separators,
+        lem:product_word_span_from_bnt_selectors}
+    Let \(A^1,\ldots,A^r\) be separated BNT blocks satisfying the
+    irreducibility, left-canonicality, and normalized self-overlap hypotheses
+    used in the direct-sum comparison. Assume the direct-sum injectivity
+    hypotheses
+    \[
+        \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
+        \qquad
+        \operatorname{span}\{A^j_v:|v|=L+(L+L)\}=M_{D_j}(\mathbb C),
+    \]
+    for every block \(j\), with \(1<L\). Then for every ordered pair
+    \(k\ne j\) there are coefficients \(c^{k,j}_\omega\) such that
+    \[
+        \sum_{|\omega|=L+(L+L)} c^{k,j}_\omega A^k_\omega=I,
+        \qquad
+        \sum_{|\omega|=L+(L+L)} c^{k,j}_\omega A^j_\omega=0.
+    \]
+    Consequently the simultaneous block-word tuples at length
+    \[
+        L+(r-1)(L+(L+L))
+    \]
+    span the full product algebra
+    \[
+        \prod_{j=1}^r M_{D_j}(\mathbb C).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:direct_sum_two_block_dimension_step} gives homogeneous
+    trace separation at length \(L+(L+L)\) for every ordered pair of distinct
+    BNT blocks. Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}
+    converts these trace-separation equations into the displayed pairwise
+    block selectors. Multiplying the selectors for the \(r-1\) blocks different
+    from \(k\) gives a selector for block \(k\), and
+    Lemma~\ref{lem:product_word_span_from_bnt_selectors} then supplies the
+    displayed product span.
+\end{proof}
+
 \begin{lemma}[Blockwise boundary compatibility from traces]
     \label{lem:blockwise_boundary_compatibility_from_traces}
     \lean{MPSTensor.pgvwc07_blockwise_compatibility_of_trace_decomposition}

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -143,12 +143,14 @@ selector and product-span construction.\footnote{%
 \leanid{MPSTensor.forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv};
 \leanid{MPSTensor.exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}.}
 
-The already-injective BNT conclusion should now be stated either from
-\leanid{IsNormalCanonicalFormBNT} together with the required injective-block
-hypotheses, or directly from explicit separated-block hypotheses. In that
-form, when the selected BNT blocks are already injective at the required common
-length, the exact-length direct-sum span is a theorem rather than a remaining
-identity-padding assumption.
+The already-injective BNT conclusion is now stated directly from explicit
+separated-block hypotheses, with the required injective-block hypotheses kept
+visible. In that form, when the selected BNT blocks are already injective at
+the required common lengths, the selector datum and the resulting finite
+direct-sum span are theorems rather than identity-padding assumptions.\footnote{%
+\leanid{MPSTensor.hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv};
+\leanid{MPSTensor.propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum};
+\leanid{MPSTensor.wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors}.}
 
 The downstream consumers of the direct-sum input are threefold. The exact-length
 span of a direct-sum block family and its two-block trace-dual form are expressed


### PR DESCRIPTION
## Summary
- turn the BNT direct-sum three-block trace-separation input into pairwise block-selector equations
- package the corresponding abstract block-injectivity selector datum and the finite simultaneous block-word span at length `L + (r - 1) * (L + (L + L))`
- add a blueprint lemma and update the direct-sum paper-gap note to record this already-injective theorem surface

## Mathematical status
This does not claim the full PGVWC07 source range. The direct-sum injectivity hypotheses remain explicit; the remaining #905 bridge is still the after-blocking transport from the canonical-form/BNT sector data into these hypotheses and then into the period-window/open-segment intersection theorem.

## Checks
- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean`
- `lake build TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean`
- `leanblueprint web`
- `git diff --check`

Notes: the Lean build replays the existing `BoundaryClosingStripping.lean:214` sorry warning. Local `leanblueprint checkdecls` cannot run without generated `blueprint/lean_decls`; direct root-based `checkdecls` also does not see `BNTDirectSum`, matching the existing capstone-import pattern for older declarations in that file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only wiring of existing selector lemmas plus documentation; no runtime or security-sensitive code, with PGVWC07 range still gated on separate transport work.
> 
> **Overview**
> Wires the existing BNT direct-sum **three-block pair trace separation** into the **selector layer**: new Lean theorems in `BNTDirectSum.lean` (via `Selectors`) derive `HasPairBlockSeparatingWords`, `PropBlockInjective`, and **`WordTupleSpanTop`** at length `L + (r - 1) * (L + (L + L))` from explicit `BlocksNotGaugePhaseEquiv` and block-injectivity hypotheses.
> 
> Adds blueprint **Lemma `lem:bnt_direct_sum_selectors_word_span`** with `\leanok` links to those declarations, and updates the direct-sum paper-gap note so the already-injective branch is described as **proved** selector/span surface rather than a remaining padding assumption. Direct-sum injectivity hypotheses stay explicit; transport from canonical BNT data is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fbab39c57eef368d456d5d69f7c0b9583a6e991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->