### PR TITLE
feat(parent): add BNT selector block intersection

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
+import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
+
+/-!
+# BNT direct-sum input for block intersections
+
+This file connects the already-injective BNT direct-sum selector span to the
+PGVWC07 one-step block-intersection identity.
+
+## References
+
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12 and Lemma
+  `lem:direct-sum`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d L : ℕ}
+
+/-- Already-injective BNT direct-sum data give the PGVWC one-step
+block-intersection identity at the selector length.
+
+The internal word length is
+\[
+  n=L+(r-1)(L+(L+L)).
+\]
+At this length the direct-sum selector theorem supplies the common blockwise
+word span required in the PGVWC07 restriction-intersection argument. -/
+theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) (L + (L + L)))
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L)
+    {n : ℕ} (hn : n = L + (r - 1) * (L + (L + L)))
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1) :
+    ((⨅ b : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+      (⨅ a : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+      ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  subst n
+  exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
+    (wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
+      A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
+    hUnital
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5789,6 +5789,42 @@ formulation; the passage to $\ker H_N$ is kept separate.
     gives the displayed subspace equality.
 \end{proof}
 
+\begin{lemma}[BNT direct-sum selectors give one block-intersection step]
+    \label{lem:bnt_direct_sum_selector_block_intersection}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors}
+    \leanok
+    \uses{lem:bnt_direct_sum_selectors_word_span,
+        lem:block_restriction_intersection_subspace}
+    Under the hypotheses of
+    Lemma~\ref{lem:bnt_direct_sum_selectors_word_span}, assume in addition the
+    normalization
+    \[
+        \sum_a A^j_aA^{j\,\dagger}_a=I
+    \]
+    for every block \(j\). Let
+    \[
+        n=L+(r-1)(L+(L+L)),
+        \qquad
+        S_n=\bigvee_jG_{n+1}(A^j).
+    \]
+    Then
+    \[
+        \left\{\psi:\forall b,\ \psi(-,b)\in S_n\right\}
+        \cap
+        \left\{\psi:\forall a,\ \psi(a,-)\in S_n\right\}
+        =
+        \bigvee_jG_{n+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:bnt_direct_sum_selectors_word_span} gives the common
+    blockwise product span at the displayed length \(n\). Substituting this
+    span into Lemma~\ref{lem:block_restriction_intersection_subspace}, together
+    with the normalization, gives the stated subspace equality.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -5800,7 +5836,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:block_restrictions_mem_block_ground_spaces,
         lem:block_restrictions_iff_block_ground_spaces,
         lem:block_restriction_intersection_subspace,
-        lem:period_window_block_restriction_intersection}
+        lem:period_window_block_restriction_intersection,
+        lem:bnt_direct_sum_selector_block_intersection}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[


### PR DESCRIPTION
## Summary
- add a parent-Hamiltonian bridge theorem from the already-injective BNT direct-sum selector span to the PGVWC07 one-step block-intersection identity
- state the equality at the selector length `n = L + (r - 1) * (L + (L + L))` under the normalization `sum_a A^j_a A^{j†}_a = I`
- record the equation in the parent-Hamiltonian blueprint and add it to the block-diagonal intersection theorem dependencies

## Mathematical status
This is still not the full PGVWC07 source range. It packages the already-injective BNT/direct-sum specialization from #2502 into the open-segment intersection theorem; the remaining #905 work is the after-blocking transport from canonical-form/BNT sector data into the explicit direct-sum hypotheses and source-range/period-window packaging.

## Checks
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockIntersection`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean`
- `leanblueprint web`
- `git diff --check`

Notes: the focused Lean build replays the existing `BoundaryClosingStripping.lean:214` sorry warning. Local `leanblueprint web` completed with the existing local package/bibliography warnings but exit code 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal proof glue and blueprint dependency updates; no application runtime, auth, or data paths.
> 
> **Overview**
> Adds a **parent-Hamiltonian bridge** that instantiates the existing PGVWC07 one-step block-intersection identity when BNT direct-sum selector hypotheses already give full blockwise word span at a fixed length.
> 
> The new Lean theorem `pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors` is a short composition: at `n = L + (r - 1) * (L + (L + L))` it feeds `wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors` into `pgvwc07_iSup_groundSpace_eq_restriction_intersection`, under the usual block-family hypotheses plus normalization `∑_a A^j_a A^{j†}_a = I`.
> 
> The blueprint gains **Lemma** `lem:bnt_direct_sum_selector_block_intersection` (linked to that Lean name) and the not-yet-ready block-diagonal intersection theorem now **uses** this lemma alongside the period-window intersection step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a1a8e6d6a273fa5da72224f8b60bbd79907be7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->