### PR TITLE
feat(parent): add BNT period-window intersection bridge

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -211,6 +211,7 @@ import TNLean.MPS.Symmetry.StringOrder
 -- Layer 5: Multi-block
 import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
+import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
 /-!
 # BNT direct-sum input for block intersections
 
-This file connects the already-injective BNT direct-sum selector span to the
+This file connects the already-injective BNT direct-sum product span to the
 PGVWC07 one-step block-intersection identity.
 
 ## References
@@ -24,14 +24,14 @@ namespace MPSTensor
 variable {d L : ℕ}
 
 /-- Already-injective BNT direct-sum data give the PGVWC one-step
-block-intersection identity at the selector length.
+block-intersection identity at the resulting product-span length.
 
 The internal word length is
 \[
   n=L+(r-1)(L+(L+L)).
 \]
-At this length the direct-sum selector theorem supplies the common blockwise
-word span required in the PGVWC07 restriction-intersection argument. -/
+At this length the direct-sum theorem supplies the common blockwise word span
+required in the PGVWC07 restriction-intersection argument. -/
 theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -55,5 +55,63 @@ theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors
     (wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
     hUnital
+
+/-- BNT block-separating equations and a homogeneous block-injectivity period
+window give the PGVWC block-intersection identity for all sufficiently large
+lengths.
+
+Let
+\[
+  S=L+(L+L),\qquad q=(r-1)S.
+\]
+The BNT direct-sum hypotheses give equations that separate each ordered pair of
+blocks at length \(S\). If the individual blocks are injective at a positive
+length \(p\) and throughout a complete window of \(p+q\) consecutive lengths,
+then the simultaneous block-word tuples span the full product algebra in a
+complete period window. The abstract period-window block-intersection theorem
+then gives the eventual intersection identity. -/
+theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_period_window
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) (L + (L + L)))
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L)
+    {start period : ℕ} (hperiod_pos : 0 < period)
+    (hBlkPeriod : ∀ k : Fin r, IsNBlkInjective (A k) period)
+    (hBlkWindow : ∀ s : ℕ, s < period + (r - 1) * (L + (L + L)) →
+      ∀ k : Fin r, IsNBlkInjective (A k) (start + s))
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1) :
+    ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
+      ((⨅ b : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+        (⨅ a : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+        ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  let S : ℕ := L + (L + L)
+  let q : ℕ := (r - 1) * S
+  have hPair : HasPairBlockSeparatingWords A S := by
+    simpa [S] using
+      (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
+        A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
+  have hPeriodSpan : WordTupleSpanTop A (period + q) := by
+    simpa [S, q] using
+      (wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords
+        A hBlkPeriod hPair)
+  have hPeriodPos : 0 < period + q := by
+    exact Nat.add_pos_left hperiod_pos q
+  have hWindowSpan : ∀ s : ℕ, s < period + q →
+      WordTupleSpanTop A ((start + q) + s) := by
+    intro s hs
+    have hSpan :=
+      wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords
+        A (hBlkWindow s (by simpa [q, S] using hs)) hPair
+    simpa [q, S, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hSpan
+  exact pgvwc07_iSup_restriction_intersection_eventually_of_period_window
+    A hPeriodPos hPeriodSpan hWindowSpan hUnital
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5789,7 +5789,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     gives the displayed subspace equality.
 \end{proof}
 
-\begin{lemma}[BNT direct-sum selectors give one block-intersection step]
+\begin{lemma}[BNT direct-sum input gives one block-intersection step]
     \label{lem:bnt_direct_sum_selector_block_intersection}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors}
     \leanok
@@ -5819,10 +5819,69 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \leanok
-    Lemma~\ref{lem:bnt_direct_sum_selectors_word_span} gives the common
-    blockwise product span at the displayed length \(n\). Substituting this
-    span into Lemma~\ref{lem:block_restriction_intersection_subspace}, together
-    with the normalization, gives the stated subspace equality.
+    Lemma~\ref{lem:bnt_direct_sum_selectors_word_span} gives
+    \[
+        \operatorname{span}\{(A^1_w,\ldots,A^r_w): |w|=n\}
+        =
+        \prod_jM_{D_j}(\mathbb C).
+    \]
+    Substituting this span into
+    Lemma~\ref{lem:block_restriction_intersection_subspace}, together with the
+    normalization, gives the stated subspace equality.
+\end{proof}
+
+\begin{lemma}[BNT direct-sum input with a block-injectivity window]
+    \label{lem:bnt_direct_sum_selector_period_window_block_intersection}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_period_window}
+    \leanok
+    \uses{lem:bnt_direct_sum_selectors_word_span,
+        lem:period_window_block_restriction_intersection}
+    Under the hypotheses of
+    Lemma~\ref{lem:bnt_direct_sum_selectors_word_span}, set
+    \[
+        S=L+(L+L),
+        \qquad
+        q=(r-1)S.
+    \]
+    Suppose that \(p>0\) and let \(s_0\) be a starting length. Assume that, for
+    every block \(j\),
+    \[
+        \operatorname{span}\{A^j_u:|u|=p\}=M_{D_j}(\mathbb C),
+    \]
+    and that, for every \(0\le s<p+q\) and every block \(j\),
+    \[
+        \operatorname{span}\{A^j_v:|v|=s_0+s\}=M_{D_j}(\mathbb C).
+    \]
+    Assume also the normalization
+    \[
+        \sum_a A^j_aA^{j\,\dagger}_a=I
+    \]
+    for every block \(j\). Then there is \(N\) such that, for every \(n\ge N\),
+    if
+    \[
+        S_n:=\bigvee_jG_{n+1}(A^j),
+    \]
+    then
+    \[
+        \left\{\psi:\forall b,\ \psi(-,b)\in S_n\right\}
+        \cap
+        \left\{\psi:\forall a,\ \psi(a,-)\in S_n\right\}
+        =
+        \bigvee_jG_{n+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The direct-sum input gives, for each ordered pair of distinct blocks,
+    length-\(S\) equations which are the identity on the first block and zero on
+    the second. Multiplying these equations over the \(r-1\) other blocks gives
+    a block-separating equation of total length \(q\). Combining this equation
+    with block injectivity at length \(p\) gives the full product span at length
+    \(p+q\). Combining it with the assumed block-injectivity window gives the
+    full product span at lengths \(s_0+q+s\), for \(0\le s<p+q\). The
+    period-window form of the block-intersection identity then gives the
+    displayed equality for all sufficiently large \(n\).
 \end{proof}
 
 \begin{theorem}[Block-diagonal intersection identity]
@@ -5837,7 +5896,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:block_restrictions_iff_block_ground_spaces,
         lem:block_restriction_intersection_subspace,
         lem:period_window_block_restriction_intersection,
-        lem:bnt_direct_sum_selector_block_intersection}
+        lem:bnt_direct_sum_selector_block_intersection,
+        lem:bnt_direct_sum_selector_period_window_block_intersection}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[


### PR DESCRIPTION
## Summary

This PR adds a conditional period-window bridge for the parent-Hamiltonian block-intersection argument. Under the already-injective BNT direct-sum hypotheses from #2502 and #2503, together with a homogeneous block-injectivity window, it proves eventual validity of the one-step identity
\[
  \left(\bigcap_b \operatorname{Res}_{-,b}^{-1} S_n\right)
  \cap
  \left(\bigcap_a \operatorname{Res}_{a,-}^{-1} S_n\right)
  =
  \bigvee_j G_{n+2}(A^j),
  \qquad S_n=\bigvee_jG_{n+1}(A^j).
\]

The new statement is deliberately conditional: it packages the direct-sum block-separating equations with a complete block-injectivity period window. It does not claim the full PGVWC07 source range
\[
  L\ge 3(b-1)(L_0+1)+1.
\]

The blueprint prose was also adjusted so that the mathematical content is expressed by span and intersection equations, not by saying that a theorem is a Lean declaration name. The term "selector" remains only as local formalization terminology in existing labels and Lean names.

## Checks

- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean`
- `lake env lean TNLean.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockIntersection TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean TNLean.lean`
- `leanblueprint web`
- `git diff --check`

Notes: `lake exe checkdecls blueprint/lean_decls` still reports existing generated-list misses for the whole direct-sum group in this local invocation. Direct `#check` after `import TNLean` resolves the new declaration and the two prior BNT direct-sum declarations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof and blueprint documentation only; no runtime or security-sensitive paths.
> 
> **Overview**
> Adds a **conditional eventual** bridge from BNT direct-sum hypotheses plus a homogeneous block-injectivity window to the PGVWC07 one-step restriction–intersection identity at all sufficiently large lengths. The new Lean theorem `pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_period_window` derives pair block-separating words from existing BNT data, builds full product spans at `period + q` and over a shifted window, then invokes the abstract `pgvwc07_iSup_restriction_intersection_eventually_of_period_window` from `BlockIntersectionProperty`.
> 
> `TNLean.lean` now imports `TNLean.MPS.ParentHamiltonian.BNTBlockIntersection`. Docstrings in the same file shift wording from “selector span” to “product span” for the one-step theorem.
> 
> The blueprint gains **Lemma** `bnt_direct_sum_selector_period_window_block_intersection`, tightens the one-step lemma proof to state the product span explicitly, renames that lemma’s title away from “selectors,” and wires the new lemma into the block-diagonal intersection theorem’s `\uses` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6214b038b412a10033a407f0f72fc89d6636f41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->