### PR TITLE
feat(wielandt): propagate block injectivity under normalization

### DIFF
--- a/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
@@ -144,6 +144,75 @@ theorem wordSpan_mono'_of_one_mem_wordSpan_one
           wordSpan_mono_succ_of_one_mem_wordSpan_one A hone _
       _ = wordSpan A (n + (k + 1)) := by ring_nf
 
+/-! ## Part 2b: Propagation from the right-normalized identity -/
+
+/-- If
+\[
+  \sum_a A_a A_a^\dagger = I
+\]
+and the length-`n` word span is the full matrix algebra, then the length-`n+1`
+word span is again full.
+
+This is the propagation step used in PGVWC07, lines 893--898 of the local
+source. The displayed equation is
+\[
+  X = \sum_a A_a(A_a^\dagger X),
+\]
+where every \(A_a^\dagger X\) lies in the full length-`n` word span. -/
+theorem wordSpan_succ_eq_top_of_unital_of_wordSpan_eq_top
+    (A : MPSTensor d D)
+    (hUnital : ∑ a : Fin d, A a * (A a)ᴴ = 1)
+    {n : ℕ} (hTop : wordSpan A n = ⊤) :
+    wordSpan A (n + 1) = ⊤ := by
+  rw [eq_top_iff]
+  intro X _
+  have hdecomp : X = ∑ a : Fin d, A a * ((A a)ᴴ * X) := by
+    calc
+      X = (1 : Matrix (Fin D) (Fin D) ℂ) * X := by simp
+      _ = (∑ a : Fin d, A a * (A a)ᴴ) * X := by rw [hUnital]
+      _ = ∑ a : Fin d, A a * ((A a)ᴴ * X) := by
+          rw [Finset.sum_mul]
+          exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
+  rw [hdecomp]
+  refine Submodule.sum_mem _ fun a _ => ?_
+  have hLeft : A a ∈ wordSpan A 1 := by
+    simpa [evalWord] using evalWord_mem_wordSpan A ([a] : List (Fin d))
+  have hRight : (A a)ᴴ * X ∈ wordSpan A n := by
+    rw [hTop]
+    exact Submodule.mem_top
+  have hProd : A a * ((A a)ᴴ * X) ∈ wordSpan A 1 * wordSpan A n :=
+    Submodule.mul_mem_mul hLeft hRight
+  simpa [Nat.add_comm] using wordSpan_mul_le A 1 n hProd
+
+/-- Under the normalization
+\[
+  \sum_a A_a A_a^\dagger = I,
+\]
+full homogeneous word span at length `L` propagates to every larger length. -/
+theorem wordSpan_eq_top_of_ge_of_unital
+    (A : MPSTensor d D)
+    (hUnital : ∑ a : Fin d, A a * (A a)ᴴ = 1)
+    {L m : ℕ} (hL : wordSpan A L = ⊤) (hm : L ≤ m) :
+    wordSpan A m = ⊤ := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hm
+  induction k with
+  | zero =>
+      simpa using hL
+  | succ k ih =>
+      have hPrev : wordSpan A (L + k) = ⊤ := ih (by omega)
+      simpa [Nat.add_assoc] using
+        wordSpan_succ_eq_top_of_unital_of_wordSpan_eq_top A hUnital hPrev
+
+/-- PGVWC07 injectivity propagation: for a right-normalized tensor, block
+injectivity at length `L` implies block injectivity at every length `m ≥ L`. -/
+theorem isNBlkInjective_of_ge_of_unital
+    (A : MPSTensor d D)
+    (hUnital : ∑ a : Fin d, A a * (A a)ᴴ = 1)
+    {L m : ℕ} (hL : IsNBlkInjective A L) (hm : L ≤ m) :
+    IsNBlkInjective A m := by
+  rw [← wordSpan_eq_top_iff_isNBlkInjective] at hL ⊢
+  exact wordSpan_eq_top_of_ge_of_unital A hUnital hL hm
+
 /-! ## Part 3: Cumulative span equals word span under monotonicity -/
 
 /-- If `1 ∈ wordSpan A 1`, then `cumulativeSpan A n = wordSpan A n`.

--- a/blueprint/src/chapter/ch07_wielandt.tex
+++ b/blueprint/src/chapter/ch07_wielandt.tex
@@ -1760,6 +1760,42 @@ span.
     by Lemma~\ref{lem:word_span_mul}.
 \end{proof}
 
+\begin{theorem}[Homogeneous word-span propagation under normalization]%
+    \label{thm:wordspan_propagation_unital}
+    \lean{MPSTensor.wordSpan_succ_eq_top_of_unital_of_wordSpan_eq_top}
+    \lean{MPSTensor.wordSpan_eq_top_of_ge_of_unital}
+    \lean{MPSTensor.isNBlkInjective_of_ge_of_unital}
+    \leanok
+    \uses{def:word_span, def:l_blk_injective}
+    Suppose
+    \[
+        \sum_a A_aA_a^\dagger=\Id
+        \qquad\text{and}\qquad
+        S_L(A)=\MN{D}.
+    \]
+    Then, for every \(m\ge L\),
+    \[
+        S_m(A)=\MN{D}.
+    \]
+    Equivalently, \(L\)-block injectivity propagates to every larger
+    homogeneous length.
+\end{theorem}
+
+\begin{proof}\leanok\uses{lem:word_span_mul}
+    If \(S_n(A)=\MN{D}\), then for any \(X\in\MN{D}\),
+    \[
+        X
+        =
+        \left(\sum_a A_aA_a^\dagger\right)X
+        =
+        \sum_a A_a(A_a^\dagger X).
+    \]
+    Since \(A_a^\dagger X\in S_n(A)\), each summand lies in
+    \(S_1(A)S_n(A)\subseteq S_{n+1}(A)\). Thus
+    \(S_{n+1}(A)=\MN{D}\). Iterating this one-step implication gives the
+    result for all \(m\ge L\).
+\end{proof}
+
 \begin{theorem}[Cumulative span equals word span under aperiodicity]%
     \label{thm:cumspan_eq_wordspan}
     \lean{MPSTensor.cumulativeSpan_eq_wordSpan_of_one_mem_wordSpan_one}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5337,9 +5337,9 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \uses{def:blockwise_product_word_span,
         lem:block_selectors_from_pairwise_separators,
         lem:homogeneous_word_tuple_span_padding}
-    Let $J$ be a finite set of $r$ sectors, and let $(A_j)_{j\in J}$ be a
+    Let $J$ be a finite set of $r$ blocks, and let $(A_j)_{j\in J}$ be a
     finite family of tensors with common block injectivity at length $L$.
-    Suppose there are length-$S$ block-separating equations: for each sector
+    Suppose there are length-$S$ block-separating equations: for each block
     $k$,
     \[
         \sum_{|\omega|=S} c_\omega^{(k)} A_j^\omega
@@ -5358,12 +5358,12 @@ formulation; the passage to $\ker H_N$ is kept separate.
 \begin{proof}
     \leanok
     \uses{lem:block_selectors_from_pairwise_separators}
-    Block injectivity writes each target sector matrix as a length-$L$ linear
+    Block injectivity writes each target block matrix as a length-$L$ linear
     combination of word evaluations. For a target tuple $(M_j)_j$, write $M_k$
     in this form in block $k$, multiply by the block-separating equation for
     $k$, and sum over $k$. Thus, if
     $M_k=\sum_{|u|=L}a_u^{(k)}A_k^u$ and
-    $\sum_{|v|=S}b_v^{(k)}A_j^v=\delta_{j,k}I$, then for every sector $j$,
+    $\sum_{|v|=S}b_v^{(k)}A_j^v=\delta_{j,k}I$, then for every block $j$,
     \[
         M_j=
         \sum_{k\in J}\sum_{|u|=L}\sum_{|v|=S}
@@ -5419,8 +5419,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     trace separation at length \(L+(L+L)\) for every ordered pair of distinct
     BNT blocks. Lemma~\ref{lem:pair_trace_separation_to_pairwise_selectors}
     converts these trace-separation equations into the displayed pairwise
-    block selectors. Multiplying the selectors for the \(r-1\) blocks different
-    from \(k\) gives a selector for block \(k\), and
+    block-separating equations. Multiplying the equations for the \(r-1\)
+    blocks different from \(k\) gives a block-separating equation for \(k\), and
     Lemma~\ref{lem:product_word_span_from_bnt_selectors} then supplies the
     displayed product span.
 \end{proof}
@@ -5897,7 +5897,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:block_restriction_intersection_subspace,
         lem:period_window_block_restriction_intersection,
         lem:bnt_direct_sum_selector_block_intersection,
-        lem:bnt_direct_sum_selector_period_window_block_intersection}
+        lem:bnt_direct_sum_selector_period_window_block_intersection,
+        thm:wordspan_propagation_unital}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
     \[


### PR DESCRIPTION
## Summary

- Prove the PGVWC07 homogeneous word-span propagation step: from
  \[
    \sum_a A_a A_a^\dagger=I,\qquad S_L(A)=M_D(\mathbb C),
  \]
  derive \(S_m(A)=M_D(\mathbb C)\) for every \(m\ge L\).
- Expose the corresponding block-injectivity form as `MPSTensor.isNBlkInjective_of_ge_of_unital`.
- Record the same statement in the blueprint as equations, and align nearby parent-Hamiltonian prose with block-separating equations rather than local labels.

## Mathematical role

This is the propagation used in PGVWC07 lines 893--898: for any matrix \(X\),
\[
  X=\left(\sum_a A_aA_a^\dagger\right)X
   =\sum_a A_a(A_a^\dagger X).
\]
If \(S_n(A)\) is already the full matrix algebra, then each \(A_a^\dagger X\) lies in \(S_n(A)\), hence each summand lies in \(S_1(A)S_n(A)\subseteq S_{n+1}(A)\). Iteration gives all larger homogeneous lengths. This is a source-faithful support step for the PGVWC07 block-diagonal intersection range tracked in #905 and #190.

## Verification

- `lake env lean TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean`
- `lake env lean TNLean.lean`
- `lake build TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan TNLean`
- `lake exe lint_style`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean blueprint/src/chapter/ch07_wielandt.tex blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- `leanblueprint web` completed; local plasTeX emitted the existing `leanblueprint` package import warnings.
- Generated `blueprint/lean_decls` and ran `lake exe checkdecls blueprint/lean_decls`; it reached only existing missing declarations (`...`, `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`, `MPSTensor.parentHamiltonian_gapped`). The new declarations resolve.

No new `sorry`, `axiom`, `native_decide`, or `unsafeCast` is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds proved lemmas and blueprint documentation only; no changes to auth, runtime, or existing proof obligations beyond new formal results.
> 
> **Overview**
> Adds the **PGVWC07 homogeneous word-span propagation** step: under \(\sum_a A_a A_a^\dagger = I\), if \(S_L(A)=\mathbb{C}^{D\times D}\) then \(S_m(A)\) is full for every \(m \ge L\). Lean formalizes this via `wordSpan_succ_eq_top_of_unital_of_wordSpan_eq_top`, induction in `wordSpan_eq_top_of_ge_of_unital`, and the block-injectivity corollary `isNBlkInjective_of_ge_of_unital` in `CumulativeToWordSpan.lean`.
> 
> The blueprint records the same statement as **Theorem** `thm:wordspan_propagation_unital` in ch07 (linked to those Lean names). In ch14, the parent-Hamiltonian argument **cites** that theorem, and nearby prose is retitled from “sector/selectors” to **block** / **block-separating equations** for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3276f90a7474420b7524aef01ff2146f9df1ffc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->