### PR TITLE
feat(parent): derive BNT intersection from normalization

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -56,6 +56,113 @@ theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
     hUnital
 
+/-- Homogeneous span propagation gives the BNT product span at every
+sufficiently large length.
+
+If the blocks are normalized by
+\[
+  \sum_a A^j_aA^{j\dagger}_a=I
+\]
+and \(S_L(A^j)=M_{D_j}(\mathbb C)\) for each block, then
+\(S_m(A^j)=M_{D_j}(\mathbb C)\) for every \(m\ge L\).  Combining this with
+block-separating equations of length \(S\) gives
+\[
+  \operatorname{span}\{(A^1_w,\ldots,A^r_w):|w|=n\}
+    =\prod_j M_{D_j}(\mathbb C)
+\]
+for \(n\ge L+(r-1)S\). -/
+theorem wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L S n : ℕ}
+    (hInj : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hUnital : ∀ k : Fin r, ∑ a : Fin d, A k a * (A k a)ᴴ = 1)
+    (hPair : HasPairBlockSeparatingWords A S)
+    (hn : L + (r - 1) * S ≤ n) :
+    WordTupleSpanTop A n := by
+  let q : ℕ := (r - 1) * S
+  have hInjTail : ∀ k : Fin r, IsNBlkInjective (A k) (n - q) := by
+    intro k
+    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hInj k) (by omega)
+  have hSpan :
+      WordTupleSpanTop A ((n - q) + (r - 1) * S) :=
+    wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords
+      A hInjTail hPair
+  have hlen : (n - q) + (r - 1) * S = n := by
+    omega
+  rwa [hlen] at hSpan
+
+/-- BNT direct-sum data and PGVWC07 normalization give the simultaneous product
+span at every length above the BNT block-separation bound.
+
+With \(S=L+(L+L)\), the conclusion is
+\[
+  \operatorname{span}\{(A^1_w,\ldots,A^r_w):|w|=n\}
+    =\prod_j M_{D_j}(\mathbb C)
+\]
+for \(n\ge L+(r-1)S\). -/
+theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ} (hn : L + (r - 1) * (L + (L + L)) ≤ n) :
+    WordTupleSpanTop A n := by
+  let S : ℕ := L + (L + L)
+  have hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) S := by
+    intro k
+    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk k) (by omega)
+  have hPair : HasPairBlockSeparatingWords A S := by
+    simpa [S] using
+      (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
+        A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
+  exact wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords
+    A hBlk hUnital hPair (by simpa [S] using hn)
+
+/-- BNT direct-sum data and PGVWC07 normalization give the one-step
+block-intersection identity at every length above the BNT block-separation
+bound.
+
+For \(S=L+(L+L)\), if \(n\ge L+(r-1)S\), then, writing
+\[
+  S_n=\bigvee_jG_{n+1}(A^j),
+\]
+one has
+\[
+  \left(\bigcap_b\operatorname{Res}_{-,b}^{-1}S_n\right)
+  \cap
+  \left(\bigcap_a\operatorname{Res}_{a,-}^{-1}S_n\right)
+  =
+  \bigvee_jG_{n+2}(A^j).
+\] -/
+theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ} (hn : L + (r - 1) * (L + (L + L)) ≤ n) :
+    ((⨅ b : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+      (⨅ a : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+      ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
+    (wordTupleSpanTop_of_ge_of_bnt_directSum_unital
+      A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
+    hUnital
+
 /-- BNT block-separating equations and a homogeneous block-injectivity period
 window give the PGVWC block-intersection identity for all sufficiently large
 lengths.
@@ -113,5 +220,42 @@ theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_period
     simpa [q, S, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hSpan
   exact pgvwc07_iSup_restriction_intersection_eventually_of_period_window
     A hPeriodPos hPeriodSpan hWindowSpan hUnital
+
+/-- BNT direct-sum input and the PGVWC07 normalization give the eventual
+block-intersection identity without separately assuming a higher-length
+block-injectivity window.
+
+The normalization
+\[
+  \sum_a A^j_aA^{j\dagger}_a=I
+\]
+propagates the full homogeneous span of each block from length \(L\) to every
+larger length. Thus the needed consecutive range of block-injectivity
+hypotheses is obtained from the equations
+\[
+  S_L(A^j)=M_{D_j}(\mathbb C),\qquad
+  S_{L+s}(A^j)=M_{D_j}(\mathbb C).
+\] -/
+theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1) :
+    ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
+      ((⨅ b : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+        (⨅ a : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+        ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  refine ⟨L + (r - 1) * (L + (L + L)), ?_⟩
+  intro n hn
+  exact pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
+    A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5884,6 +5884,139 @@ formulation; the passage to $\ker H_N$ is kept separate.
     displayed equality for all sufficiently large \(n\).
 \end{proof}
 
+\begin{lemma}[Normalized block-separating equations give all large product spans]
+    \label{lem:unital_block_separating_product_span}
+    \lean{MPSTensor.wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords}
+    \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital}
+    \leanok
+    \uses{def:pairwise_block_separating_words,
+        lem:bnt_direct_sum_pair_separating_words,
+        thm:wordspan_propagation_unital}
+    Let \(A^1,\ldots,A^r\) be blocks satisfying the normalization
+    \[
+        \sum_a A^j_aA^{j\,\dagger}_a=I
+    \]
+    and assume that every block is injective at length \(L\):
+    \[
+        \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C).
+    \]
+    If there are block-separating equations of length \(S\), then, for every
+    \(n\ge L+(r-1)S\),
+    \[
+        \operatorname{span}\{(A^1_w,\ldots,A^r_w):|w|=n\}
+        =
+        \prod_j M_{D_j}(\mathbb C).
+    \]
+    In particular, for separated BNT blocks, the same conclusion holds with
+    \[
+        S=L+(L+L),
+        \qquad
+        n\ge L+(r-1)(L+(L+L)).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    By Theorem~\ref{thm:wordspan_propagation_unital}, the normalization
+    propagates the length-\(L\) span equality to every larger homogeneous length:
+    \[
+        m\ge L
+        \quad\Longrightarrow\quad
+        \operatorname{span}\{A^j_u:|u|=m\}=M_{D_j}(\mathbb C).
+    \]
+    For \(n\ge L+(r-1)S\), take \(m=n-(r-1)S\). Combining the length-\(m\)
+    block span with the \(r-1\) block-separating equations gives the displayed
+    product span at length \(n\).  In the BNT case,
+    Lemma~\ref{lem:bnt_direct_sum_pair_separating_words} supplies the
+    block-separating equations with \(S=L+(L+L)\).
+\end{proof}
+
+\begin{lemma}[Normalized BNT input gives the large-length block intersection]
+    \label{lem:bnt_direct_sum_unital_block_intersection_ge}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital}
+    \leanok
+    \uses{lem:unital_block_separating_product_span,
+        lem:block_restriction_intersection_subspace}
+    Let \(A^1,\ldots,A^r\) be separated BNT blocks satisfying the irreducibility,
+    left-canonicality, and normalized self-overlap hypotheses used in the
+    direct-sum comparison. Suppose \(1<L\), every block is injective at length
+    \(L\),
+    \[
+        \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
+    \]
+    and every block satisfies the normalization
+    \[
+        \sum_a A^j_aA^{j\,\dagger}_a=I .
+    \]
+    Set
+    \[
+        N=L+(r-1)(L+(L+L)).
+    \]
+    Then, for every \(n\ge N\), with
+    \[
+        S_n:=\bigvee_jG_{n+1}(A^j),
+    \]
+    one has
+    \[
+        \left\{\psi:\forall b,\ \psi(-,b)\in S_n\right\}
+        \cap
+        \left\{\psi:\forall a,\ \psi(a,-)\in S_n\right\}
+        =
+        \bigvee_jG_{n+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:unital_block_separating_product_span} gives
+    \[
+        \operatorname{span}\{(A^1_w,\ldots,A^r_w):|w|=n\}
+        =
+        \prod_jM_{D_j}(\mathbb C)
+    \]
+    for every \(n\ge N\).  Substituting this product-span equation into
+    Lemma~\ref{lem:block_restriction_intersection_subspace}, together with the
+    normalization equation, gives the displayed intersection identity.
+\end{proof}
+
+\begin{lemma}[Normalized BNT input gives an eventual block intersection]
+    \label{lem:bnt_direct_sum_unital_block_intersection}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital}
+    \leanok
+    \uses{lem:bnt_direct_sum_unital_block_intersection_ge}
+    Let \(A^1,\ldots,A^r\) be separated BNT blocks satisfying the irreducibility,
+    left-canonicality, and normalized self-overlap hypotheses used in the
+    direct-sum comparison. Suppose \(1<L\), every block is injective at length
+    \(L\),
+    \[
+        \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
+    \]
+    and every block satisfies the normalization
+    \[
+        \sum_a A^j_aA^{j\,\dagger}_a=I .
+    \]
+    Then there is a length \(N\) such that, for every \(n\ge N\), with
+    \[
+        S_n:=\bigvee_jG_{n+1}(A^j),
+    \]
+    one has
+    \[
+        \left\{\psi:\forall b,\ \psi(-,b)\in S_n\right\}
+        \cap
+        \left\{\psi:\forall a,\ \psi(a,-)\in S_n\right\}
+        =
+        \bigvee_jG_{n+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply Lemma~\ref{lem:bnt_direct_sum_unital_block_intersection_ge} and take
+    \[
+        N=L+(r-1)(L+(L+L)).
+    \]
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -5898,6 +6031,9 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:period_window_block_restriction_intersection,
         lem:bnt_direct_sum_selector_block_intersection,
         lem:bnt_direct_sum_selector_period_window_block_intersection,
+        lem:unital_block_separating_product_span,
+        lem:bnt_direct_sum_unital_block_intersection_ge,
+        lem:bnt_direct_sum_unital_block_intersection,
         thm:wordspan_propagation_unital}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:


### PR DESCRIPTION
## Summary

This PR records the next parent-Hamiltonian block-intersection step after #2506.

For normalized blocks satisfying
\[
  \sum_a A^j_a A^{j\dagger}_a = I,
  \qquad
  \operatorname{span}\{A^j_u: |u|=L\}=M_{D_j}(\mathbb C),
\]
the homogeneous span propagation from #2506 gives
\[
  m\ge L
  \quad\Longrightarrow\quad
  \operatorname{span}\{A^j_u: |u|=m\}=M_{D_j}(\mathbb C).
\]
Combining this with block-separating equations of length \(S\) proves
\[
  n\ge L+(r-1)S
  \quad\Longrightarrow\quad
  \operatorname{span}\{(A^1_w,\ldots,A^r_w): |w|=n\}
  = \prod_j M_{D_j}(\mathbb C).
\]
For the BNT direct-sum input, \(S=L+(L+L)\), hence the one-step block-intersection identity now holds for every
\[
  n\ge L+(r-1)(L+(L+L)).
\]

This still does not prove the sharp PGVWC07 range
\[
  L\ge 3(b-1)(L_0+1)+1.
\]
It removes the artificial residue-window hypothesis from the existing BNT bridge by using the normalization equation.

Advances #905 and #190.

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockIntersection TNLean`
- `lake exe lint_style`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls` still fails on pre-existing missing declarations: `...`, `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`, and `MPSTensor.parentHamiltonian_gapped`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal math additions in parent-Hamiltonian MPS proofs and blueprint sync; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds Lean theorems and matching blueprint lemmas so **normalized** BNT blocks (unitality \(\sum_a A^j_a A^{j\dagger}_a = I\) plus injectivity at length \(L\)) yield the full multi-block word span and the PGVWC07 one-step restriction–intersection identity for all \(n \ge L + (r-1)(L+(L+L))\), without the older **period-window** block-injectivity hypothesis.
> 
> The proof chain uses **homogeneous span propagation** (`isNBlkInjective_of_ge_of_unital`) to lift length-\(L\) block spans to the tail length needed for existing pair block-separating words, then plugs into `wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords` and `pgvwc07_iSup_groundSpace_eq_restriction_intersection`. A new eventual theorem `pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital` fixes \(N = L + (r-1)(L+(L+L))\). Chapter 14 blueprint gains three lemmas and wires them into the block-diagonal intersection theorem’s `\uses` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff96fca7abdf5875773ecbd1d1be14cb1643bea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->