### PR TITLE
feat(parent): derive block image directness from product span

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -125,6 +125,32 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital
   exact wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords
     A hBlk hUnital hPair (by simpa [S] using hn)
 
+/-- In the normalized BNT range supplied by the direct-sum input, the block image
+spaces form an internal direct sum.
+
+Let \(S=L+(L+L)\).  If \(n\ge L+(r-1)S\), then
+\[
+  G_n(A^1)+\cdots+G_n(A^r)
+\]
+is an internal direct sum: whenever \(\phi_j\in G_n(A^j)\) and
+\(\sum_j\phi_j=0\), all \(\phi_j\) vanish. -/
+theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L)
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL : 1 < L)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ} (hn : L + (r - 1) * (L + (L + L)) ≤ n) :
+    iSupIndep fun j : Fin r => groundSpace (A j) n :=
+  groundSpace_iSupIndep_of_wordTupleSpanTop A
+    (wordTupleSpanTop_of_ge_of_bnt_directSum_unital
+      A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
+
 /-- BNT direct-sum data and PGVWC07 normalization give the one-step
 block-intersection identity at every length above the BNT block-separation
 bound.

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -216,6 +216,75 @@ theorem pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace
   exact Submodule.mem_iSup_of_mem j
     (pgvwc07LeftBoundaryComponent_mem_groundSpace (A j) (C j) (E j) n (hACE j))
 
+/-- A common product span makes the block image spaces an internal direct sum.
+
+Suppose
+\[
+  \operatorname{span}\{(A^1_w,\ldots,A^r_w): |w|=n\}
+  =
+  \prod_j M_{D_j}(\mathbb C).
+\]
+If \(\phi_j\in G_n(A^j)\) and \(\sum_j\phi_j=0\), write
+\[
+  \phi_j(\sigma)=\operatorname{tr}(A^j_\sigma X_j).
+\]
+Then, for every word \(w\) of length \(n\),
+\[
+  \sum_j\operatorname{tr}(X_jA^j_w)=0.
+\]
+The product span and nondegeneracy of the product trace pairing force
+\(X_j=0\) for every \(j\), hence \(\phi_j=0\). -/
+theorem groundSpace_iSupIndep_of_wordTupleSpanTop
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {n : ℕ} (hSpan : WordTupleSpanTop A n) :
+    iSupIndep fun j : Fin r => groundSpace (A j) n := by
+  classical
+  rw [iSupIndep_iff_finset_sum_eq_zero_imp_eq_zero]
+  intro s φ hφ hsum j hj
+  have hMatrix : ∀ i : Fin r, i ∈ s →
+      ∃ X : Matrix (Fin (dim i)) (Fin (dim i)) ℂ,
+        groundSpaceMap (A i) n X = φ i := by
+    intro i hi
+    simpa [groundSpace] using hφ i hi
+  let X : (i : Fin r) → Matrix (Fin (dim i)) (Fin (dim i)) ℂ :=
+    fun i => if hi : i ∈ s then Classical.choose (hMatrix i hi) else 0
+  have hX : ∀ i : Fin r, ∀ hi : i ∈ s, groundSpaceMap (A i) n (X i) = φ i := by
+    intro i hi
+    dsimp [X]
+    rw [dif_pos hi]
+    exact Classical.choose_spec (hMatrix i hi)
+  have hsum_all : (∑ i : Fin r, groundSpaceMap (A i) n (X i)) = 0 := by
+    calc
+      (∑ i : Fin r, groundSpaceMap (A i) n (X i))
+          = s.sum (fun i => groundSpaceMap (A i) n (X i)) := by
+              symm
+              apply Finset.sum_subset (Finset.subset_univ s)
+              intro i _ hi
+              simp [X, hi]
+      _ = s.sum φ := by
+              exact Finset.sum_congr rfl fun i hi => hX i hi
+      _ = 0 := by simpa using hsum
+  have hTraceEval : ∀ w : Fin n → Fin d,
+      (∑ i : Fin r, Matrix.trace (evalWord (A i) (List.ofFn w) * X i)) = 0 := by
+    intro w
+    simpa [groundSpaceMap_apply] using congrFun hsum_all w
+  have hTrace : ∀ w : Fin n → Fin d,
+      (∑ i : Fin r, Matrix.trace (X i * evalWord (A i) (List.ofFn w))) = 0 := by
+    intro w
+    calc
+      (∑ i : Fin r, Matrix.trace (X i * evalWord (A i) (List.ofFn w)))
+          = ∑ i : Fin r, Matrix.trace (evalWord (A i) (List.ofFn w) * X i) := by
+              refine Finset.sum_congr rfl ?_
+              intro i _
+              exact Matrix.trace_mul_comm (X i) (evalWord (A i) (List.ofFn w))
+      _ = 0 := hTraceEval w
+  have hXzero : X j = 0 :=
+    block_matrices_eq_zero_of_wordTupleSpanTop_trace A hSpan X hTrace j
+  calc
+    φ j = groundSpaceMap (A j) n (X j) := (hX j hj).symm
+    _ = 0 := by simp [hXzero]
+
 /-- Boundary-matrix compatibility from equality of the two coefficient
 decompositions in the PGVWC block-diagonal intersection proof.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5931,6 +5931,52 @@ formulation; the passage to $\ker H_N$ is kept separate.
     block-separating equations with \(S=L+(L+L)\).
 \end{proof}
 
+\begin{lemma}[Product span gives directness of block image spaces]
+    \label{lem:product_span_block_image_direct_sum}
+    \lean{MPSTensor.groundSpace_iSupIndep_of_wordTupleSpanTop}
+    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital}
+    \leanok
+    \uses{def:ground_space_parent, lem:unital_block_separating_product_span}
+    Suppose
+    \[
+        \operatorname{span}\{(A^1_w,\ldots,A^r_w):|w|=n\}
+        =
+        \prod_jM_{D_j}(\mathbb C).
+    \]
+    Then the sum of the image spaces \(G_n(A^j)\) is direct: if
+    \[
+        \phi_j\in G_n(A^j),
+        \qquad
+        \sum_j\phi_j=0,
+    \]
+    then \(\phi_j=0\) for every \(j\).  In particular, for the normalized BNT
+    input above, this directness holds for every
+    \[
+        n\ge L+(r-1)(L+(L+L)).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Write
+    \[
+        \phi_j(\sigma)=\tr(A^j_\sigma X_j).
+    \]
+    Evaluating \(\sum_j\phi_j=0\) on each word \(w\) of length \(n\) gives
+    \[
+        \sum_j\tr(A^j_wX_j)=0.
+    \]
+    Since \(\tr(A^j_wX_j)=\tr(X_jA^j_w)\), the product-span equation gives
+    \[
+        \sum_j\tr(X_jM_j)=0
+        \qquad
+        \text{for every }(M_1,\ldots,M_r)\in\prod_jM_{D_j}(\mathbb C).
+    \]
+    Taking only the \(j\)-th component nonzero and using nondegeneracy of the
+    trace pairing yields \(X_j=0\), hence \(\phi_j=0\). The BNT statement follows
+    by substituting Lemma~\ref{lem:unital_block_separating_product_span}.
+\end{proof}
+
 \begin{lemma}[Normalized BNT input gives the large-length block intersection]
     \label{lem:bnt_direct_sum_unital_block_intersection_ge}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital}
@@ -6032,6 +6078,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:bnt_direct_sum_selector_block_intersection,
         lem:bnt_direct_sum_selector_period_window_block_intersection,
         lem:unital_block_separating_product_span,
+        lem:product_span_block_image_direct_sum,
         lem:bnt_direct_sum_unital_block_intersection_ge,
         lem:bnt_direct_sum_unital_block_intersection,
         thm:wordspan_propagation_unital}


### PR DESCRIPTION
## Summary

This adds the direct-sum part of the PGVWC block-image argument in the form used by the parent-Hamiltonian proof.

If
\[
\operatorname{span}\{(A^1_w,\ldots,A^r_w): |w|=n\}=\prod_j M_{D_j}(\mathbb C),
\]
then the family \(G_n(A^j)\) is internally direct: for \(\phi_j\in G_n(A^j)\),
\[
\sum_j \phi_j=0 \quad\Longrightarrow\quad \forall j,\ \phi_j=0.
\]

The proof writes \(\phi_j(\sigma)=\operatorname{tr}(A^j_\sigma X_j)\); the zero-sum equation gives
\[
\sum_j\operatorname{tr}(X_jA^j_w)=0
\]
for every length-\(n\) word. Product span and nondegeneracy of the product trace pairing force \(X_j=0\) for every block.

It also records the normalized BNT large-length corollary by substituting the existing product-span theorem:
\[
n\ge L+(r-1)(L+(L+L)).
\]
This is still the formal product-span route, not the sharp PGVWC07 range \(3(r-1)(L_0+1)+1\).

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockIntersection TNLean`
- `lake exe lint_style`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean blueprint/src/chapter/ch14_parent_hamiltonian.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint web`

`leanblueprint checkdecls` still fails only on pre-existing missing entries:

- `...`
- `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`
- `MPSTensor.parentHamiltonian_gapped`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style parent-Hamiltonian lemmas and blueprint documentation; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds the **internal directness** step for block ground spaces \(G_n(A^j)\): from a **product word span** \(\operatorname{span}\{(A^1_w,\ldots,A^r_w)\}=\prod_j M_{D_j}\), a sum \(\sum_j \phi_j=0\) with \(\phi_j\in G_n(A^j)\) forces each \(\phi_j=0\).
> 
> Lean: new `groundSpace_iSupIndep_of_wordTupleSpanTop` in `BlockIntersectionProperty.lean` (parametrize \(\phi_j\) via `groundSpaceMap`, reduce to vanishing traces on words, then `block_matrices_eq_zero_of_wordTupleSpanTop_trace`). New `groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital` in `BNTBlockIntersection.lean` plugs in the existing BNT product-span bound \(n\ge L+(r-1)(L+(L+L))\).
> 
> Blueprint: new Lemma `lem:product_span_block_image_direct_sum` with matching `\lean` links; parent-Hamiltonian chapter `\uses` updated to cite it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c388cac6977a3768b1aab09a9d5658f10c2b70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->