### PR TITLE
doc(parent): record block-intersection source status

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5966,11 +5966,10 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \[
         \sum_j\tr(A^j_wX_j)=0.
     \]
-    Since \(\tr(A^j_wX_j)=\tr(X_jA^j_w)\), the product-span equation gives
+    Since \(\tr(A^j_wX_j)=\tr(X_jA^j_w)\), the product-span equation gives, for
+    every \((M_1,\ldots,M_r)\in\prod_jM_{D_j}(\mathbb C)\),
     \[
-        \sum_j\tr(X_jM_j)=0
-        \qquad
-        \text{for every }(M_1,\ldots,M_r)\in\prod_jM_{D_j}(\mathbb C).
+        \sum_j\tr(X_jM_j)=0.
     \]
     Taking only the \(j\)-th component nonzero and using nondegeneracy of the
     trace pairing yields \(X_j=0\), hence \(\phi_j=0\). The BNT statement follows
@@ -6001,19 +6000,21 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \[
         N=L+(r-1)(L+(L+L)).
     \]
-    Then, for every \(n\ge N\), with
+    For every \(n\ge N\), set
     \[
         S_n:=\bigvee_jG_{n+1}(A^j),
     \]
-    and both sums
+    and the two consecutive sums are internal direct sums:
     \[
-        \bigvee_jG_{n+1}(A^j),
+        \bigvee_jG_{n+1}(A^j)
+        =
+        \bigoplus_jG_{n+1}(A^j),
         \qquad
         \bigvee_jG_{n+2}(A^j)
+        =
+        \bigoplus_jG_{n+2}(A^j).
     \]
-    are direct, so these joins are the direct sums appearing in PGVWC07.
-    Moreover,
-    one has
+    With this notation,
     \[
         \left\{\psi:\forall b,\ \psi(-,b)\in S_n\right\}
         \cap
@@ -6031,7 +6032,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
         =
         \prod_jM_{D_j}(\mathbb C)
     \]
-    for every \(n\ge N\).  Substituting this product-span equation into
+    for every \(n\ge N\). Substituting this product-span equation into
     Lemma~\ref{lem:block_restriction_intersection_subspace}, together with the
     normalization equation, gives the displayed intersection identity.
     Lemma~\ref{lem:product_span_block_image_direct_sum} at lengths \(n+1\) and

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -130,26 +130,71 @@ for every $j,i_1,i_{m+1}$,
   =
   D^j_{i_{m+1}} A^j_{i_1}.
 \end{align}
-With
+The source line defines \(E^j\) without an adjoint. The following calculation
+uses instead the matrix
 \begin{align}
-  E^j=\sum_{i_1} C^j_{i_1}A^j_{i_1},
+  E^j=\sum_{k} C^j_{k}A^{j\dagger}_{k}.
 \end{align}
-and the normalization
+Together with the normalization
 \begin{align}
   \sum_{i_1} A^j_{i_1}A^{j\dagger}_{i_1}=I,
 \end{align}
-the same proof concludes
+the displayed matrix identity gives
 \begin{align}
-  A^j_{i_{m+1}} C^j_{i_1}
+  A^j_{i_{m+1}} E^j A^j_{i_1}
+  &=
+  \sum_k
+  A^j_{i_{m+1}} C^j_k A^{j\dagger}_k A^j_{i_1} \notag\\
+  &=
+  D^j_{i_{m+1}}
+  \left(\sum_k A^j_k A^{j\dagger}_k\right)
+  A^j_{i_1} \notag\\
+  &=
+  D^j_{i_{m+1}} A^j_{i_1}
   =
-  A^j_{i_{m+1}} E^j A^j_{i_1},
+  A^j_{i_{m+1}} C^j_{i_1},
 \end{align}
 which puts the vector in $\bigoplus_j \mathcal G_{m+1}^{A_j}$.
 
 \section{The remaining boundary condition}
 
-The live blueprint records the analogous statement in source notation, without
-claiming that it is proved.\footnote{Blueprint locations:
+The present Lean statements prove the one-step identity under the product-span
+hypothesis
+\begin{align}
+  \operatorname{span}
+  \{(A^1_w,\ldots,A^b_w): |w|=m\}
+  =
+  \prod_{j=1}^b M_{D_j}(\mathbb C),
+\end{align}
+and, in the normalized BNT case, give the internal direct sums
+\begin{align}
+  \bigvee_j \mathcal G_m^{A_j}
+  =
+  \bigoplus_j \mathcal G_m^{A_j},
+  \qquad
+  \bigvee_j \mathcal G_{m+1}^{A_j}
+  =
+  \bigoplus_j \mathcal G_{m+1}^{A_j}.
+\end{align}
+The proved one-step conclusion is therefore
+\begin{align}
+  \mathbb C^d\otimes\left(\bigoplus_j \mathcal G_m^{A_j}\right)
+  \cap
+  \left(\bigoplus_j \mathcal G_m^{A_j}\right)\otimes\mathbb C^d
+  =
+  \bigoplus_j \mathcal G_{m+1}^{A_j}
+\end{align}
+for all sufficiently large \(m\) satisfying the product-span hypotheses.\footnote{
+Lean declarations:
+\path{MPSTensor.pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop},
+\path{MPSTensor.groundSpace_iSupIndep_of_wordTupleSpanTop}, and
+\path{MPSTensor.pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital}.}
+What is still missing is the derivation of the PGVWC07 source range from
+\(C1\) at the common length \(L_0\), and the periodic-chain iteration beginning
+from this one-step identity.
+
+The live blueprint records that larger source statement in source notation,
+without claiming that it is proved.\footnote{Blueprint locations:
 \path{def:parent_hamiltonian_ground_space_bnt} for the block-sum chain ground
 space, \path{lem:isup_chain_ground_space_block_le_assembled} for the forward
 inclusion, \path{thm:block_diagonal_ground_space_intersection} for the
@@ -274,10 +319,34 @@ The composition gives
 
 \section{Conclusion}
 
-This is not a source-error claim. The classification is an open gap: the
-block-diagonal intersection identity and its periodic-chain iteration have not
-yet been proved in Lean. Once that theorem is available, issue \#905 supplies
-the structural decomposition needed for issue \#870, and the final degenerate
+This is not a source-error claim. The present gap is the remaining implication
+\begin{align}
+  \left[
+    \mathbb C^d\otimes S_m
+    \cap
+    S_m\otimes\mathbb C^d
+    =
+    S_{m+1}
+    \quad (m\ge L)
+  \right]
+  &\Longrightarrow
+  \mathcal K_{N,L}(\widetilde A)
+  =
+  \sum_{j=1}^b \mathcal K_{N,L}(A_j),
+  \notag\\
+  S_m&=\bigoplus_{j=1}^b \mathcal G_m^{A_j},
+\end{align}
+under
+\begin{align}
+  b\ge2,
+  \qquad
+  L_0\ge1,
+  \qquad
+  L\ge 3(b-1)(L_0+1)+1,
+  \qquad
+  N\ge L+L_0.
+\end{align}
+After this periodic-chain implication is proved, the final degenerate
 parent-Hamiltonian ground-space equality follows by applying the one-block
 uniqueness theorem to each block.
 

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -186,9 +186,9 @@ The proved one-step conclusion is therefore
 \end{align}
 for all sufficiently large \(m\) satisfying the product-span hypotheses.\footnote{
 Lean declarations:
-\path{MPSTensor.pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop},
-\path{MPSTensor.groundSpace_iSupIndep_of_wordTupleSpanTop}, and
-\path{MPSTensor.pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital}.}
+\leanid{MPSTensor.pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop},
+\leanid{MPSTensor.groundSpace_iSupIndep_of_wordTupleSpanTop}, and
+\leanid{MPSTensor.pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital}.}
 What is still missing is the derivation of the PGVWC07 source range from
 \(C1\) at the common length \(L_0\), and the periodic-chain iteration beginning
 from this one-step identity.


### PR DESCRIPTION
## Summary
- rewrite the block-intersection blueprint passage so the directness assertion is expressed by internal direct-sum equations
- record the PGVWC07 adjoint correction in the paper-gap note through the displayed identity for E^j
- distinguish the formalized one-step intersection identity from the still-open PGVWC07 source range and periodic-chain iteration

Refs #905.
Refs #190.

## Verification
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --changed-files blueprint/src/chapter/ch14_parent_hamiltonian.tex docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (reports existing unrelated PEPS chapter-13a sync issue; chapter 14 remains fully synchronized)
- `leanblueprint web` (passes with the repository's existing bibliography/package warnings)
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv21_block_diagonal_parent_ground_space.tex` from `docs/paper-gaps` (passes; existing long displays still produce overfull-box warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX documentation only; no Lean or runtime code changes.
> 
> **Overview**
> Documentation-only updates to the parent-Hamiltonian blueprint and the CPGSV21 paper-gap note so they match what Lean already proves and what remains open.
> 
> In **ch14**, a short proof is tightened (product-span quantifier phrasing), and the normalized BNT block-intersection lemma now states **internal direct-sum** equalities for the joins at lengths \(n+1\) and \(n+2\) before the restriction intersection identity, instead of describing directness in prose.
> 
> In **cpgsv21_block_diagonal_parent_ground_space.tex**, the PGVWC07 step uses \(E^j=\sum_k C^j_k A^{j\dagger}_k\) with an explicit adjoint calculation. The note separates the **formalized one-step** tensor intersection (with Lean theorem names) from the still-missing PGVWC07 source range and **periodic-chain** implication to the block-diagonal ground-space decomposition, and reframes the conclusion around that remaining implication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7089f4cf92807d74e288967549b1d092f15eda86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->