### PR TITLE
feat(parent): add open-chain subspace iteration

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -162,6 +162,64 @@ theorem contiguous_mem_groundSpace {A : MPSTensor d D} (hA : IsInjective A)
         rw [contiguousRestrictₗ_restrictFirst]
         exact ih (by omega) (by omega) (s + 1) (by omega) _
 
+/-- Open-chain iteration for a family of subspaces.
+
+If every length-`L` contiguous interval of an `N`-site state lies in `S L`, and
+the intersections
+\[
+  \mathbb C^d\otimes S_M \cap S_M\otimes \mathbb C^d = S_{M+1}
+\]
+hold for all `M ≥ L`, then the state lies in `S N`. This is the open-segment
+iteration used in PGVWC07, Theorem 12, before the periodic-chain closure step. -/
+theorem contiguous_mem_of_restriction_intersection_submodules
+    (S : (M : ℕ) → Submodule ℂ (NSiteSpace d M))
+    {L N : ℕ} (hL : 0 < L) (hLN : L ≤ N) [NeZero d]
+    (hstep : ∀ M : ℕ, L ≤ M →
+      ((⨅ b : Fin d, (S M).comap (restrictLastₗ b)) ⊓
+        (⨅ a : Fin d, (S M).comap (restrictFirstₗ a))) = S (M + 1))
+    {ψ : NSiteSpace d N}
+    (hwindow : ∀ (s : ℕ) (hs : s + L ≤ N) (τ : Fin N → Fin d),
+      contiguousRestrictₗ s L hs τ ψ ∈ S L) :
+    ψ ∈ S N := by
+  suffices claim : ∀ (M : ℕ) (hLM : L ≤ M) (hMN : M ≤ N)
+      (s : ℕ) (hs : s + M ≤ N) (τ : Fin N → Fin d),
+        contiguousRestrictₗ s M hs τ ψ ∈ S M by
+    have h0 := claim N hLN le_rfl 0 (by omega) (fun _ => ⟨0, Fin.pos'⟩)
+    rwa [show (contiguousRestrictₗ 0 N (by omega) (fun _ => ⟨0, Fin.pos'⟩) ψ) = ψ from by
+      ext σ
+      simp [contiguousRestrictₗ_apply, contiguousCfg_zero_full]] at h0
+  intro M
+  induction M with
+  | zero => intro hLM; omega
+  | succ M ih =>
+      intro hLM hMN s hs τ
+      by_cases hbase : M + 1 ≤ L
+      · have : M + 1 = L := by omega
+        subst this
+        exact hwindow s hs τ
+      · push Not at hbase
+        have hLM' : L ≤ M := by omega
+        have hlast : ∀ b : Fin d,
+            restrictLast (contiguousRestrictₗ s (M + 1) hs τ ψ) b ∈ S M := by
+          intro b
+          rw [contiguousRestrictₗ_restrictLast]
+          exact ih hLM' (by omega) s (by omega) _
+        have hfirst : ∀ a : Fin d,
+            restrictFirst (contiguousRestrictₗ s (M + 1) hs τ ψ) a ∈ S M := by
+          intro a
+          rw [contiguousRestrictₗ_restrictFirst]
+          exact ih hLM' (by omega) (s + 1) (by omega) _
+        have hmem : contiguousRestrictₗ s (M + 1) hs τ ψ ∈
+            ((⨅ b : Fin d, (S M).comap (restrictLastₗ b)) ⊓
+              (⨅ a : Fin d, (S M).comap (restrictFirstₗ a))) := by
+          rw [Submodule.mem_inf]
+          constructor
+          · simp only [Submodule.mem_iInf, Submodule.mem_comap]
+            exact hlast
+          · simp only [Submodule.mem_iInf, Submodule.mem_comap]
+            exact hfirst
+        rwa [hstep M hLM'] at hmem
+
 /-! ### Cyclic window extraction -/
 
 /-- The site obtained by moving `r` steps clockwise from `i` on the cyclic chain. -/

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -897,6 +897,33 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     grows back the rightmost site.
 \end{proof}
 
+\begin{lemma}[Open-chain iteration for a sequence of subspaces]%
+    \label{lem:open_chain_iteration_subspace_sequence}
+    \lean{MPSTensor.contiguous_mem_of_restriction_intersection_submodules}
+    \leanok
+    \uses{rem:contiguous_window_operators}
+    Let \(S_m\subseteq(\mathbb C^d)^{\otimes m}\) be subspaces, and let
+    \(0<L\le N\). Suppose that every non-wrapping length-\(L\) interval of
+    \(\psi\), for every fixed choice of the complementary sites, lies in \(S_L\).
+    Suppose also that, for every \(m\ge L\),
+    \[
+        \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1}.
+    \]
+    Then \(\psi\in S_N\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{rem:contiguous_window_operators}
+    Induct on the length \(m\) of a non-wrapping interval.  The case \(m=L\)
+    is the assumed local condition.  If all length-\(m\) intervals lie in
+    \(S_m\), then the two one-site restrictions of a length-\(m+1\) interval are
+    adjacent length-\(m\) intervals.  Hence the length-\(m+1\) interval lies in
+    \(\mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d\), and the displayed
+    identity places it in \(S_{m+1}\).  Taking \(m=N\) and the interval starting
+    at the first site gives \(\psi\in S_N\).
+\end{proof}
+
 \begin{lemma}[Cyclic-window range antitonicity]%
     \label{lem:cyclic_window_range_antitonicity}
     \lean{MPSTensor.chainGroundSpace_le_chainGroundSpace_succ,


### PR DESCRIPTION
## Summary

This adds the abstract open-chain iteration step needed for the PGVWC07 block-diagonal parent-Hamiltonian argument.

* proves `MPSTensor.contiguous_mem_of_restriction_intersection_submodules` for a sequence of subspaces `S_m` satisfying
  \[
  \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1};
  \]
* records the corresponding blueprint lemma in mathematical form, without making the Lean declaration name part of the prose.

This is a preparatory step toward #905. It does not claim the periodic-chain closure theorem yet.

## Verification

* `lake exe cache get`
* `lake build TNLean.MPS.ParentHamiltonian.CyclicWindow`
* `lake build TNLean`
* `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
* `lake env lean --stdin` with `#check MPSTensor.contiguous_mem_of_restriction_intersection_submodules`

`PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint checkdecls` runs, but fails on two pre-existing root-import omissions unrelated to this PR:

* `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`
* `MPSTensor.parentHamiltonian_gapped`

Both declarations exist in `TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean`; `TNLean/MPS/ParentHamiltonian/Martingale.lean` explicitly says that file is not imported into the root until the Friedrichs-angle estimate is proved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal lemma and documentation only; no changes to runtime behavior, auth, or existing ground-space APIs beyond a parallel theorem.
> 
> **Overview**
> Adds the **abstract open-chain iteration** step for parent-Hamiltonian (PGVWC07, Theorem 12): from length-`L` contiguous window membership in a family `S_m` and one-site restriction intersections \(\mathbb C^d\otimes S_m \cap S_m\otimes\mathbb C^d = S_{m+1}\), conclude the full `N`-site state lies in `S_N`.
> 
> Lean introduces `MPSTensor.contiguous_mem_of_restriction_intersection_submodules` in `CyclicWindow.lean`, generalizing the existing `contiguous_mem_groundSpace` pattern to arbitrary submodules via `hstep` instead of `groundSpace_intersection`. The proof inducts on window length and uses `contiguousRestrictₗ_restrictLast` / `restrictFirst` like the ground-space theorem.
> 
> The blueprint records **Lemma (Open-chain iteration for a sequence of subspaces)** with the same mathematical statement and a short induction proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecf689f3749ad213777ca9c0655aabb1bb9d7967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->