### PR TITLE
feat(parent): lift cyclic constraints to propagated subspaces

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -190,9 +190,8 @@ import TNLean.Axioms.Beigi
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.Martingale
--- The finite-chain uniqueness capstone is kept out of the default root until
--- the wrapped-window comparison and degenerate-window cases are proved.
--- It remains available as `TNLean.MPS.ParentHamiltonian.UniqueGroundState`.
+-- The finite-chain uniqueness capstone is not part of this foundational layer.
+-- Downstream files may import it when they need the periodic-chain definitions.
 
 -- Layer 4: Fundamental theorem (single block)
 import TNLean.MPS.Structure.LinearExtension
@@ -212,6 +211,7 @@ import TNLean.MPS.Symmetry.StringOrder
 import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
+import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic

--- a/TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.UniqueGroundState
+
+/-!
+# Cyclic constraints and propagated subspaces
+
+This file records the abstract cyclic-local step used in the block-diagonal
+parent-Hamiltonian argument of PGVWC07, Theorem 12.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Periodic local constraints land in a propagated sequence of subspaces.
+
+If \(G_L(A)\subseteq S_L\) and the subspaces \(S_m\) satisfy
+\[
+  \mathbb C^d\otimes S_m \cap S_m\otimes \mathbb C^d = S_{m+1}
+\]
+for all \(m\ge L\), then \(\mathcal G_{N,L}(A)\subseteq S_N\).  This is the
+cyclic-local part of the PGVWC07 Theorem 12 argument before the block summands
+of \(S_N\) are separated. -/
+theorem chainGroundSpace_le_of_local_le_restriction_intersection_submodules
+    (A : MPSTensor d D) (S : (M : ℕ) → Submodule ℂ (NSiteSpace d M))
+    {L N : ℕ} (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N) [NeZero d]
+    (hlocal : groundSpace A L ≤ S L)
+    (hstep : ∀ M : ℕ, L ≤ M →
+      ((⨅ b : Fin d, (S M).comap (restrictLastₗ b)) ⊓
+        (⨅ a : Fin d, (S M).comap (restrictFirstₗ a))) = S (M + 1)) :
+    chainGroundSpace A L N ≤ S N := by
+  intro ψ hψ
+  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
+  apply contiguous_mem_of_restriction_intersection_submodules S hL hLN hstep
+  intro s hs τ
+  rw [← cyclicRestrictₗ_eq_contiguousRestrictₗ hN hLN
+    (show (⟨s, by omega⟩ : Fin N).val + L ≤ N from hs)]
+  exact hlocal (hψ ⟨s, by omega⟩ τ)
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -924,6 +924,34 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     at the first site gives \(\psi\in S_N\).
 \end{proof}
 
+\begin{lemma}[Periodic constraints and propagated subspaces]%
+    \label{lem:periodic_constraints_propagated_subspace_sequence}
+    \lean{MPSTensor.chainGroundSpace_le_of_local_le_restriction_intersection_submodules}
+    \leanok
+    \uses{lem:open_chain_iteration_subspace_sequence, rem:cyclic_window_operators}
+    Let \(S_m\subseteq(\mathbb C^d)^{\otimes m}\) be subspaces, and let
+    \(0<L\le N\).  Suppose that \(G_L(A)\subseteq S_L\).  Suppose also that, for
+    every \(m\ge L\),
+    \[
+        \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1}.
+    \]
+    Then the periodic local constraints imply
+    \[
+        \mathcal G_{N,L}(A)\subseteq S_N.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:open_chain_iteration_subspace_sequence, rem:cyclic_window_operators}
+    If \(\psi\in\mathcal G_{N,L}(A)\), then every length-\(L\) cyclic interval of
+    \(\psi\) lies in \(G_L(A)\), and hence in \(S_L\).  A non-wrapping interval
+    is the cyclic interval starting at the same site.  Therefore all
+    non-wrapping length-\(L\) intervals lie in \(S_L\), and
+    Lemma~\ref{lem:open_chain_iteration_subspace_sequence} gives
+    \(\psi\in S_N\).
+\end{proof}
+
 \begin{lemma}[Cyclic-window range antitonicity]%
     \label{lem:cyclic_window_range_antitonicity}
     \lean{MPSTensor.chainGroundSpace_le_chainGroundSpace_succ,


### PR DESCRIPTION
## Summary

This adds the cyclic-local step following the open-chain subspace iteration from #2511.

Given subspaces \(S_m\subseteq(\mathbb C^d)^{\otimes m}\), the new theorem proves
\[
  G_L(A)\subseteq S_L,
  \qquad
  \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1}\quad(m\ge L)
  \Longrightarrow
  \mathcal G_{N,L}(A)\subseteq S_N.
\]

This is still a preparatory step toward #905. It does not prove the local block-sum equality, the source length range from PGVWC07 Condition C1, or the final periodic-chain decomposition.

## Verification

* `lake exe cache get`
* `lake build TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration`
* `lake env lean --stdin` with `#check MPSTensor.chainGroundSpace_le_of_local_le_restriction_intersection_submodules`
* `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
* `python3 scripts/check_oversized_lean_files.py --root .`
* `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
* `git diff --check`

`PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint checkdecls` was invoked, but the fresh worktree did not have the root `TNLean.olean` built, so `checkdecls` stopped before checking declarations. The generated `blueprint/lean_decls` does contain the new declaration, and the declaration was checked directly with Lean.
