### PR TITLE
feat(parent): identify block-diagonal local ground spaces

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -212,6 +212,7 @@ import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
+import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic

--- a/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.GroundSpace
+import TNLean.MPS.SharedInfra.BlockAssembly
+
+/-!
+# Local ground spaces of block-diagonal tensors
+
+This file identifies the local parent-Hamiltonian ground space of a
+block-diagonal tensor with the linear sum of the local ground spaces of its
+blocks.
+
+## References
+
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2,
+  proof lines 1430--1434, where
+  \(S=\bigoplus_j\mathcal G_L^{A^j}\).
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+namespace BlockSumGroundSpace
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+
+/-- The diagonal block of a boundary matrix written in the dependent direct-sum
+basis. -/
+noncomputable def sigmaDiagonalBlock
+    (X : Matrix ((j : Fin r) × Fin (dim j)) ((j : Fin r) × Fin (dim j)) ℂ)
+    (j : Fin r) : Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+  X.submatrix (fun a => ⟨j, a⟩) (fun a => ⟨j, a⟩)
+
+/-- The diagonal block of a boundary matrix on the flattened direct-sum bond. -/
+noncomputable def diagonalBlock
+    (X : Matrix (Fin (∑ j : Fin r, dim j)) (Fin (∑ j : Fin r, dim j)) ℂ)
+    (j : Fin r) : Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+  sigmaDiagonalBlock ((Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm) X) j
+
+/-- A block-diagonal matrix only sees the diagonal blocks of an arbitrary
+right boundary matrix under the trace pairing. -/
+theorem trace_blockDiagonal'_mul
+    (M : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (X : Matrix ((j : Fin r) × Fin (dim j)) ((j : Fin r) × Fin (dim j)) ℂ) :
+    Matrix.trace (Matrix.blockDiagonal' M * X) =
+      ∑ j : Fin r, Matrix.trace (M j * sigmaDiagonalBlock X j) := by
+  classical
+  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply, sigmaDiagonalBlock,
+    Matrix.submatrix_apply]
+  rw [Fintype.sum_sigma]
+  refine Finset.sum_congr rfl ?_
+  intro j _
+  refine Finset.sum_congr rfl ?_
+  intro a _
+  rw [Fintype.sum_sigma]
+  rw [Finset.sum_eq_single j]
+  · simp
+  · intro k _ hkj
+    apply Finset.sum_eq_zero
+    intro b _
+    have hjk : j ≠ k := fun h => hkj h.symm
+    rw [Matrix.blockDiagonal'_apply_ne M a b hjk]
+    simp
+  · intro hj
+    exact (hj (Finset.mem_univ _)).elim
+
+/-- The boundary parametrization of a block-diagonal tensor is the sum of the block
+boundary parametrizations applied to the diagonal boundary blocks. -/
+theorem groundSpaceMap_toTensorFromBlocks_eq_sum_diagonalBlock
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j)) (L : ℕ)
+    (X : Matrix (Fin (∑ j : Fin r, dim j)) (Fin (∑ j : Fin r, dim j)) ℂ) :
+    groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) L X =
+      ∑ j : Fin r, groundSpaceMap (A j) L ((μ j) ^ L • diagonalBlock X j) := by
+  classical
+  ext σ
+  simp only [groundSpaceMap_apply, Finset.sum_apply]
+  let w := List.ofFn σ
+  have hwlen : w.length = L := by simp [w]
+  let e : ((j : Fin r) × Fin (dim j)) ≃ Fin (∑ j : Fin r, dim j) :=
+    finSigmaFinEquiv
+  let Xσ : Matrix ((j : Fin r) × Fin (dim j)) ((j : Fin r) × Fin (dim j)) ℂ :=
+    (Matrix.reindex e.symm e.symm) X
+  have hX : X = (Matrix.reindex e e) Xσ := by
+    ext a b
+    simp [Xσ, e]
+  rw [evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal μ A w, hX]
+  have hmul :
+      (Matrix.reindex e e (Matrix.blockDiagonal' fun k : Fin r =>
+          μ k ^ w.length • (A k).evalWord w)) * (Matrix.reindex e e Xσ) =
+        Matrix.reindex e e
+          ((Matrix.blockDiagonal' fun k : Fin r => μ k ^ w.length • (A k).evalWord w) *
+            Xσ) := by
+    exact Matrix.reindexLinearEquiv_mul ℂ ℂ e e e
+      (Matrix.blockDiagonal' fun k : Fin r => μ k ^ w.length • (A k).evalWord w) Xσ
+  rw [hmul, Matrix.trace_reindex e]
+  rw [trace_blockDiagonal'_mul]
+  refine Finset.sum_congr rfl ?_
+  intro j _
+  have hdiag : diagonalBlock ((Matrix.reindex e e) Xσ) j = sigmaDiagonalBlock Xσ j := by
+    ext a b
+    simp [diagonalBlock, sigmaDiagonalBlock, e]
+  rw [hdiag, hwlen]
+  rw [Matrix.smul_mul, Matrix.mul_smul]
+
+end BlockSumGroundSpace
+
+open BlockSumGroundSpace
+
+/-- The local ground space of a block-diagonal tensor is the linear sum of the local
+ground spaces of its blocks:
+\[
+  G_L\!\left(\bigoplus_j \mu_j A_j\right)=\bigvee_j G_L(A_j).
+\]
+
+The reverse inclusion uses \(\mu_j\ne0\) to insert
+\((\mu_j^L)^{-1}X\) in the \(j\)-th diagonal boundary block.  This is the
+local identity \(G_L(B)=S_L\) used in the proof of PGVWC07, Theorem
+2blocks.2. -/
+theorem groundSpace_toTensorFromBlocks_eq_iSup
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0) (L : ℕ) :
+    groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L =
+      ⨆ j : Fin r, groundSpace (A j) L := by
+  classical
+  apply le_antisymm
+  · intro ψ hψ
+    rw [groundSpace, LinearMap.mem_range] at hψ
+    rcases hψ with ⟨X, rfl⟩
+    rw [groundSpaceMap_toTensorFromBlocks_eq_sum_diagonalBlock μ A L X]
+    apply Submodule.sum_mem
+    intro j _
+    exact Submodule.mem_iSup_of_mem j ⟨(μ j) ^ L • diagonalBlock X j, rfl⟩
+  · refine iSup_le ?_
+    intro j ψ hψ
+    rw [groundSpace, LinearMap.mem_range] at hψ
+    rcases hψ with ⟨X, rfl⟩
+    rw [groundSpace, LinearMap.mem_range]
+    let Yσ : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ :=
+      Matrix.blockDiagonal' fun k : Fin r =>
+        if h : k = j then
+          (by
+            subst k
+            exact ((μ j) ^ L)⁻¹ • X)
+        else
+          0
+    refine ⟨(Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) Yσ, ?_⟩
+    ext σ
+    rw [groundSpaceMap_toTensorFromBlocks_eq_sum_diagonalBlock]
+    rw [Finset.sum_eq_single j]
+    · have hpow : (μ j) ^ L ≠ 0 := pow_ne_zero L (hμ j)
+      have hdiag :
+          diagonalBlock ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) Yσ) j =
+            ((μ j) ^ L)⁻¹ • X := by
+        ext a b
+        simp [diagonalBlock, sigmaDiagonalBlock, Yσ]
+      rw [hdiag]
+      simp only [groundSpaceMap_apply]
+      rw [smul_smul, mul_inv_cancel₀ hpow]
+      simp
+    · intro k _ hkj
+      have hdiag :
+          diagonalBlock ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) Yσ) k = 0 := by
+        ext a b
+        simp [diagonalBlock, sigmaDiagonalBlock, Yσ, hkj]
+      rw [hdiag]
+      simp
+    · intro hj
+      exact (hj (Finset.mem_univ j)).elim
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6132,6 +6132,39 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
 \end{proof}
 
+\begin{lemma}[Local ground space of a block-diagonal tensor]
+    \label{lem:block_sum_local_ground_space}
+    \lean{MPSTensor.groundSpace_toTensorFromBlocks_eq_iSup}
+    \leanok
+    \uses{def:ground_space_parent}
+    Let
+    \[
+        B=\bigoplus_{j=1}^g\mu_jA_j,
+        \qquad
+        \mu_j\ne0\quad(1\le j\le g).
+    \]
+    Then, for every length \(L\),
+    \[
+        G_L(B)=\bigvee_{j=1}^gG_L(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    A boundary matrix \(X\) for \(B\) has diagonal blocks \(X_j\), and
+    block-diagonality gives
+    \[
+        \Gamma_L^B(X)
+        =
+        \sum_{j=1}^g\Gamma_L^{A_j}(\mu_j^LX_j).
+    \]
+    This proves \(G_L(B)\subseteq\bigvee_jG_L(A_j)\). Conversely, for a vector
+    \(\Gamma_L^{A_j}(X)\), place \(\mu_j^{-L}X\) in the \(j\)-th diagonal block
+    and put zero in all other diagonal blocks. Since \(\mu_j\ne0\), applying
+    \(\Gamma_L^B\) gives back \(\Gamma_L^{A_j}(X)\). Hence every \(G_L(A_j)\)
+    lies in \(G_L(B)\), and the displayed equality follows.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -6150,6 +6183,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:product_span_block_image_direct_sum,
         lem:bnt_direct_sum_unital_block_intersection_ge,
         lem:bnt_direct_sum_unital_block_intersection,
+        lem:block_sum_local_ground_space,
         thm:wordspan_propagation_unital}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:
@@ -6306,10 +6340,12 @@ formulation; the passage to $\ker H_N$ is kept separate.
         S_{m+1}
     \]
     for every $m\ge L$. For $B=\bigoplus_j\mu_j A_j$ with every
-    $\mu_j\ne0$,
+    $\mu_j\ne0$, Lemma~\ref{lem:block_sum_local_ground_space} gives
     \[
-        G_L(B)=S_L.
+        G_L(B)=\bigvee_jG_L(A_j).
     \]
+    In the range where the block image spaces are direct, this is the source
+    notation \(G_L(B)=S_L\) with \(S_L=\bigoplus_jG_L(A_j)\).
     The passage from the open-segment recursion to the periodic chain is the
     separate closure step in \cite[Theorem~12]{PerezGarcia2007Matrix}, used
     under $N\ge L+L_0$:


### PR DESCRIPTION
## Mathematical content

This PR formalizes the local block-diagonal identity used in PGVWC07 Theorem 2blocks.2.  For

\[
  B=\bigoplus_j \mu_j A_j,\qquad \mu_j\ne0,
\]

it proves

\[
  G_L(B)=\bigvee_j G_L(A_j).
\]

The proof is the boundary-matrix calculation from the source: a block-diagonal word only pairs with the diagonal blocks of the boundary matrix, giving

\[
  \Gamma_L^B(X)=\sum_j \Gamma_L^{A_j}(\mu_j^L X_j).
\]

The reverse inclusion inserts \(\mu_j^{-L}X\) in the \(j\)-th diagonal block and zero elsewhere.

## Changes

- Adds `TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace`.
- Imports the new module from `TNLean.lean`.
- Adds the blueprint lemma `lem:block_sum_local_ground_space` next to the PGVWC07 block-diagonal intersection proof.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace -q --log-level=info`
- `lake build TNLean -q --log-level=info` passed; diagnostics were pre-existing warnings in PEPS, MPDO, `BoundaryClosingStripping`, and periodic-overlap files.
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `lake exe lint_style --github`
- `git diff --cached --check`

`leanblueprint checkdecls` still fails on the pre-existing missing declarations `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs` and `MPSTensor.parentHamiltonian_gapped`; the new declaration `MPSTensor.groundSpace_toTensorFromBlocks_eq_iSup` is present in `blueprint/lean_decls` and checks directly with `#check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs and blueprint prose only; no changes to runtime services, auth, or data paths.
> 
> **Overview**
> Adds **`TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace`** and wires it into the root import list. The main result is **`groundSpace_toTensorFromBlocks_eq_iSup`**: for \(B=\bigoplus_j \mu_j A_j\) with \(\mu_j\neq 0\), the length-\(L\) local parent ground space satisfies \(G_L(B)=\bigvee_j G_L(A_j)\).
> 
> Supporting lemmas show block-diagonal trace pairing only uses diagonal boundary blocks, and that **`groundSpaceMap`** on **`toTensorFromBlocks`** splits as a sum over blocks with \(\mu_j^L\)-scaled diagonal blocks; the reverse inclusion builds a boundary matrix with \((\mu_j^L)^{-1}X\) on the \(j\)-th diagonal block.
> 
> The blueprint gains **`lem:block_sum_local_ground_space`** (linked to the Lean theorem) and the block-diagonal intersection narrative now cites \(G_L(B)=\bigvee_j G_L(A_j)\) instead of the looser \(G_L(B)=S_L\) wording, with a note that \(S_L=\bigoplus_j G_L(A_j)\) when block images are direct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31acd529b01737ec8f055ad1df2878ec7dde0deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->