### PR TITLE
feat(parent): propagate block-diagonal periodic constraints

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -213,6 +213,7 @@ import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
 import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
+import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic

--- a/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
+import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
+
+/-!
+# Chain constraints for block-diagonal tensors
+
+This file combines the local block-diagonal ground-space identity with the
+abstract cyclic-to-open propagation step used in the parent-Hamiltonian proof
+of PGVWC07, Theorem 2blocks.2.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- Periodic local constraints for a block-diagonal tensor propagate to the
+linear sum of the block ground spaces.
+
+Let \(B=\bigoplus_j\mu_jA_j\), with every \(\mu_j\ne0\), and set
+\[
+  S_M:=\bigvee_jG_M(A_j).
+\]
+If the sequence \(S_M\) satisfies
+\[
+  \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1}
+\]
+for all \(M\ge L\), then
+\[
+  \mathcal G_{N,L}(B)\subseteq S_N.
+\]
+This is the conditional propagation step in the proof of PGVWC07, Theorem
+2blocks.2, before the directness of the block summands is used. -/
+theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    {L N : ℕ} (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N) [NeZero d]
+    (hstep : ∀ M : ℕ, L ≤ M →
+      ((⨅ b : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) M).comap (restrictLastₗ b)) ⊓
+        (⨅ a : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) M).comap (restrictFirstₗ a))) =
+        ⨆ j : Fin r, groundSpace (A j) (M + 1)) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+      ⨆ j : Fin r, groundSpace (A j) N := by
+  classical
+  let S : (M : ℕ) → Submodule ℂ (NSiteSpace d M) :=
+    fun M => ⨆ j : Fin r, groundSpace (A j) M
+  apply chainGroundSpace_le_of_local_le_restriction_intersection_submodules
+    (A := toTensorFromBlocks (d := d) (μ := μ) A) (S := S) hN hL hLN
+  · rw [groundSpace_toTensorFromBlocks_eq_iSup μ A hμ L]
+  · intro M hM
+    exact hstep M hM
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6165,6 +6165,38 @@ formulation; the passage to $\ker H_N$ is kept separate.
     lies in \(G_L(B)\), and the displayed equality follows.
 \end{proof}
 
+\begin{lemma}[Periodic constraints for a block-diagonal tensor]
+    \label{lem:block_diagonal_periodic_constraints_propagated_sum}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace}
+    \leanok
+    \uses{lem:block_sum_local_ground_space,
+        lem:periodic_constraints_propagated_subspace_sequence}
+    Let
+    \[
+        B=\bigoplus_{j=1}^g\mu_jA_j,
+        \qquad \mu_j\ne0\quad(1\le j\le g).
+    \]
+    Set
+    \[
+        S_M:=\bigvee_{j=1}^gG_M(A_j).
+    \]
+    If, for every \(M\ge L\),
+    \[
+        \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1},
+    \]
+    then
+    \[
+        \mathcal G_{N,L}(B)\subseteq S_N.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:block_sum_local_ground_space} gives \(G_L(B)=S_L\).
+    Apply Lemma~\ref{lem:periodic_constraints_propagated_subspace_sequence}
+    to the sequence \(S_M\).
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -6184,6 +6216,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:bnt_direct_sum_unital_block_intersection_ge,
         lem:bnt_direct_sum_unital_block_intersection,
         lem:block_sum_local_ground_space,
+        lem:block_diagonal_periodic_constraints_propagated_sum,
         thm:wordspan_propagation_unital}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:


### PR DESCRIPTION
Partially addresses #905.

This PR isolates the next step in the proof of PGVWC07, Theorem `2blocks.2`. For
\[
  B=\bigoplus_j \mu_j A_j, \qquad \mu_j\ne0,
\]
set
\[
  S_M=\bigvee_j G_M(A_j).
\]
If
\[
  \mathbb C^d\otimes S_M\cap S_M\otimes \mathbb C^d=S_{M+1}
\]
for every \(M\ge L\), then the periodic local constraints for \(B\) give
\[
  \mathcal G_{N,L}(B)\subseteq S_N.
\]

The proof combines the local block-diagonal ground-space identity from #2513 with the cyclic-window propagation lemma from #2512.

Local checks:
- `lake build TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace TNLean -q --log-level=info`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `lake exe lint_style --github`
- `git diff --check`
- `#print axioms MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace`
