### PR TITLE
feat(parent): propagate BNT block-diagonal constraints

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -214,6 +214,7 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
 import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
 import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
+
+/-!
+# Periodic constraints in the BNT block-diagonal range
+
+This file combines the normalized BNT direct-sum intersection identity with the
+block-diagonal periodic propagation lemma used in PGVWC07, Theorem `2blocks.2`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- The normalized BNT direct-sum hypotheses imply the periodic local constraints
+of a block-diagonal tensor lie in the linear sum of the block ground spaces.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j,\qquad S_M=\bigvee_jG_M(A_j).
+\]
+Assume the normalized BNT direct-sum hypotheses give the PGVWC one-step
+recursion in the range
+\[
+  M>L_0+(r-1)(L_0+(L_0+L_0)).
+\]
+Then, for every \(N\ge L\) in that range,
+\[
+  \mathcal G_{N,L}(B)\subseteq S_N.
+\]
+This is the inclusion into \(S_N\) in PGVWC07, Theorem `2blocks.2`
+(arXiv:quant-ph/0608197, proof lines 1430--1456). The component extraction
+needed to replace \(S_N\) by the sum of periodic block ground spaces is a
+separate step. -/
+theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL₀ : 1 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange : L₀ + (r - 1) * (L₀ + (L₀ + L₀)) + 1 ≤ L) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+      ⨆ j : Fin r, groundSpace (A j) N := by
+  classical
+  apply chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace
+    (μ := μ) (A := A) hμ hN hL hLN
+  intro M hM
+  have hMpos : 0 < M := lt_of_lt_of_le hL hM
+  have hbound : L₀ + (r - 1) * (L₀ + (L₀ + L₀)) ≤ M - 1 := by
+    omega
+  have hstep :=
+    pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
+      (d := d) (L := L₀) A hIrr hLeft hOverlap hBlocks hBlk hInj hL₀
+      hUnital (n := M - 1) hbound
+  have hM1 : M - 1 + 1 = M := Nat.sub_add_cancel (Nat.succ_le_iff.mpr hMpos)
+  rw [← hM1]
+  simpa [Nat.add_assoc] using hstep
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6197,6 +6197,41 @@ formulation; the passage to $\ker H_N$ is kept separate.
     to the sequence \(S_M\).
 \end{proof}
 
+\begin{lemma}[BNT range for the block-diagonal periodic constraints]
+    \label{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital}
+    \leanok
+    \uses{lem:bnt_direct_sum_unital_block_intersection_ge,
+        lem:block_diagonal_periodic_constraints_propagated_sum}
+    Let \(A_1,\ldots,A_g\) be separated normalized BNT blocks with common
+    injectivity length \(L_0\), and suppose the hypotheses of
+    Lemma~\ref{lem:bnt_direct_sum_unital_block_intersection_ge} hold. For
+    nonzero scalars \(\mu_j\), set
+    \[
+        B=\bigoplus_{j=1}^g\mu_jA_j,
+        \qquad
+        S_M:=\bigvee_{j=1}^gG_M(A_j).
+    \]
+    If
+    \[
+        L\ge L_0+(g-1)(L_0+(L_0+L_0))+1,
+    \]
+    then, for every \(N\ge L\),
+    \[
+        \mathcal G_{N,L}(B)\subseteq S_N.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:bnt_direct_sum_unital_block_intersection_ge} gives
+    \[
+        \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1}
+    \]
+    for every \(M\ge L\). Apply
+    Lemma~\ref{lem:block_diagonal_periodic_constraints_propagated_sum}.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -6217,6 +6252,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:bnt_direct_sum_unital_block_intersection,
         lem:block_sum_local_ground_space,
         lem:block_diagonal_periodic_constraints_propagated_sum,
+        lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
         thm:wordspan_propagation_unital}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:


### PR DESCRIPTION
## Summary

- add the BNT-range theorem
  \[
    \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
    \subseteq
    \bigvee_j G_N(A_j)
  \]
  under the normalized BNT direct-sum hypotheses and the PGVWC07 length bound
- add the corresponding blueprint lemma in source notation
- import the new parent-Hamiltonian module from `TNLean.lean`

This progresses #905 and #190. It deliberately stops at the inclusion into \(S_N=\bigvee_jG_N(A_j)\); replacing that by the sum of periodic block ground spaces is the remaining boundary-closing/component-extraction step in PGVWC07, Theorem `2blocks.2`.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `lake exe lint_style --github`
- `git diff --check`
- `#check` / `#print axioms` for the new theorem: standard axioms only (`propext`, `Classical.choice`, `Quot.sound`)

`leanblueprint checkdecls` reaches the generated declaration list and finds this new declaration, but currently fails on two older blueprint declarations unrelated to this PR: `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs` and `MPSTensor.parentHamiltonian_gapped`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive formalization (one composed theorem, blueprint lemma, root import) on an existing proof chain with no auth, runtime, or data-path changes.
> 
> **Overview**
> Adds **`BNTBlockDiagonalChain.lean`** with `chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital`, proving that under normalized BNT direct-sum hypotheses and the PGVWC07 length bound, periodic chain ground space for a block-diagonal tensor \(\bigoplus_j \mu_j A_j\) is contained in \(\bigvee_j G_N(A_j)\). The proof wires the existing block-diagonal propagation lemma to the BNT unital intersection step at each \(M \ge L\).
> 
> **Blueprint** chapter 14 gains lemma `lem:bnt_block_diagonal_periodic_constraints_propagated_sum` and the block-diagonal intersection theorem’s `\uses` list now references it. **`TNLean.lean`** imports the new parent-Hamiltonian module. Scope stops at inclusion into \(S_N\); equating that with a sum of periodic block ground spaces remains a later step in PGVWC07 Theorem `2blocks.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec6e96042a8601da71ad53c13a5a2590e94c349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->