### PR TITLE
feat(MPS/MPDO): pure-state area-law upper bound S_L ≤ 2 log D

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -201,6 +201,79 @@ theorem vonNeumannEntropy_nonneg_of_posSemidef_trace_one
   exact negMulLog_nonneg (hρ.eigenvalues_nonneg i)
     (posSemidef_trace_one_eigenvalues_le_one hρ hρ_tr i)
 
+/-- Von Neumann entropy is bounded above by the logarithm of the rank.
+
+For a density matrix the entropy is at most `log` of the number of nonzero
+eigenvalues, that is `log` of the rank. This refines `vonNeumannEntropy_le_log_dim`
+(which bounds by `log` of the full dimension): the spectrum is supported on the
+range of the matrix, so Jensen's inequality applies over the `rank`-dimensional
+support with uniform weights `1/rank`.
+
+Source: [Wolf, Chapter 8, Section 8.2][Wolf2012QChannels]. -/
+theorem vonNeumannEntropy_le_log_rank
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1) :
+    vonNeumannEntropy ρ hρ.isHermitian ≤ Real.log ρ.rank := by
+  classical
+  set lam := hρ.isHermitian.eigenvalues with hlam
+  set t : Finset n := Finset.univ.filter (fun i => lam i ≠ 0) with ht
+  set k : ℕ := t.card with hk
+  -- rank = number of nonzero eigenvalues = card of the support `t`
+  have hrank : ρ.rank = k := by
+    rw [hρ.isHermitian.rank_eq_card_non_zero_eigs, hk, ht, ← hlam, Fintype.card_subtype]
+  -- the eigenvalues sum to one
+  have hsum_one : ∑ i : n, lam i = 1 := posSemidef_trace_one_eigenvalues_sum_one hρ hρ_tr
+  -- the support is nonempty, hence `k > 0`
+  have hk_pos : 0 < k := by
+    rw [hk, Finset.card_pos]
+    by_contra h
+    rw [Finset.not_nonempty_iff_eq_empty] at h
+    have hz : ∀ i, lam i = 0 := by
+      intro i
+      by_contra hi
+      have hmem : i ∈ t := by rw [ht]; exact Finset.mem_filter.mpr ⟨Finset.mem_univ i, hi⟩
+      rw [h] at hmem
+      simp at hmem
+    have : ∑ i : n, lam i = 0 := Finset.sum_eq_zero fun i _ => hz i
+    rw [this] at hsum_one
+    exact one_ne_zero hsum_one.symm
+  have hkR : (0 : ℝ) < k := by exact_mod_cast hk_pos
+  -- restrict the sums to the support (zero eigenvalues contribute nothing)
+  have hsum_t : ∑ i ∈ t, lam i = 1 := by
+    rw [← hsum_one]
+    refine Finset.sum_subset (Finset.subset_univ t) ?_
+    intro i _ hit
+    by_contra h
+    exact hit (by rw [ht]; exact Finset.mem_filter.mpr ⟨Finset.mem_univ i, h⟩)
+  have hsum_S : ∑ i ∈ t, Real.negMulLog (lam i) = vonNeumannEntropy ρ hρ.isHermitian := by
+    rw [vonNeumannEntropy, ← hlam]
+    refine Finset.sum_subset (Finset.subset_univ t) ?_
+    intro i _ hit
+    have hi0 : lam i = 0 := by
+      by_contra h
+      exact hit (by rw [ht]; exact Finset.mem_filter.mpr ⟨Finset.mem_univ i, h⟩)
+    rw [hi0, Real.negMulLog_zero]
+  -- Jensen over the support with uniform weights `1/k`
+  have hJensen := Real.concaveOn_negMulLog.le_map_sum
+      (t := t) (w := fun _ : n => ((k : ℝ)⁻¹)) (p := lam)
+      (fun i _ => by positivity)
+      (by rw [Finset.sum_const, nsmul_eq_mul, ← hk, mul_inv_cancel₀ hkR.ne'])
+      (fun i _ => hρ.eigenvalues_nonneg i)
+  rw [show (∑ i ∈ t, (k : ℝ)⁻¹ • lam i) = (k : ℝ)⁻¹ by
+        rw [← Finset.smul_sum, hsum_t, smul_eq_mul, mul_one]] at hJensen
+  have hLHS : ∑ i ∈ t, (k : ℝ)⁻¹ • Real.negMulLog (lam i)
+      = (k : ℝ)⁻¹ * vonNeumannEntropy ρ hρ.isHermitian := by
+    rw [← Finset.smul_sum, hsum_S, smul_eq_mul]
+  rw [hLHS] at hJensen
+  -- `k⁻¹ · S ≤ negMulLog(k⁻¹) = k⁻¹ · log k`, multiply by `k`
+  have hrhs : (k : ℝ) * Real.negMulLog ((k : ℝ)⁻¹) = Real.log k := by
+    rw [Real.negMulLog, Real.log_inv, neg_mul_neg, ← mul_assoc, mul_inv_cancel₀ hkR.ne', one_mul]
+  have hlhs : (k : ℝ) * ((k : ℝ)⁻¹ * vonNeumannEntropy ρ hρ.isHermitian)
+      = vonNeumannEntropy ρ hρ.isHermitian := by
+    rw [← mul_assoc, mul_inv_cancel₀ hkR.ne', one_mul]
+  have hmul := mul_le_mul_of_nonneg_left hJensen hkR.le
+  rw [hlhs, hrhs] at hmul
+  rwa [hrank]
+
 end VonNeumannEntropyDensity
 
 section VonNeumannEntropyFinD

--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -357,3 +357,96 @@ theorem mutualInfoChain_doubledTensor (A : MPSTensor d D) (N L : ℕ) (hL : L �
     blockEntropy_doubledTensor, pureBlockEntropy_full A N htr,
     ← pureBlockEntropy_complement A N L hL]
   ring
+
+
+/-! ## Operator-Schmidt rank bound and the area-law upper bound -/
+
+namespace MPSTensor
+
+theorem ofFn_blockReindex {N L : ℕ} (hL : L ≤ N) (u : Fin L → Fin d)
+    (w : Fin (N - L) → Fin d) :
+    List.ofFn ((MPOTensor.blockReindexEquiv d N L hL).symm (Fin.append u w))
+      = List.ofFn u ++ List.ofFn w := by
+  rw [blockReindexEquiv_symm_apply, ← List.ofFn_fin_append]
+  apply List.ext_getElem
+  · simp; omega
+  · intro i h1 h2
+    simp only [List.getElem_ofFn, Function.comp_apply]
+    congr 1
+
+/-- Factor the wavefunction matrix through the `D × D` bond pair: the matrix
+element `W(u, w)` is `tr(evalWord u · evalWord w)`, which decomposes as a product
+over the pair of bond indices `(a, b) ∈ Fin D × Fin D`. -/
+theorem schmidtMat_eq_mul (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
+    schmidtMat A N L hL
+      = (Matrix.of (fun (u : Fin L → Fin d) (p : Fin D × Fin D) =>
+            (evalWord A (List.ofFn u)) p.1 p.2) : Matrix (Fin L → Fin d) (Fin D × Fin D) ℂ)
+        * (Matrix.of (fun (p : Fin D × Fin D) (w : Fin (N - L) → Fin d) =>
+            (evalWord A (List.ofFn w)) p.2 p.1) :
+            Matrix (Fin D × Fin D) (Fin (N - L) → Fin d) ℂ) := by
+  ext u w
+  simp only [schmidtMat, mpv, coeff, ofFn_blockReindex, evalWord_append, Matrix.mul_apply,
+    Matrix.of_apply, Matrix.trace, Matrix.diag_apply, Fintype.sum_prod_type]
+
+/-- **Operator-Schmidt rank bound.** The reduced state of a block of an MPS pure
+state has rank at most `D²`: the wavefunction matrix factors through the two bonds
+of dimension `D` cut by the block boundary. -/
+theorem rank_reducedPureBlockState_le (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
+    (reducedPureBlockState A N L hL).rank ≤ D * D := by
+  set c := (Matrix.trace (pureState A N))⁻¹ with hc
+  set Lof : Matrix (Fin L → Fin d) (Fin D × Fin D) ℂ :=
+    Matrix.of (fun u p => (evalWord A (List.ofFn u)) p.1 p.2) with hLof
+  set Rof : Matrix (Fin D × Fin D) (Fin (N - L) → Fin d) ℂ :=
+    Matrix.of (fun p w => (evalWord A (List.ofFn w)) p.2 p.1) with hRof
+  have hLR : Lof * Rof = schmidtMat A N L hL := by
+    rw [hLof, hRof, ← schmidtMat_eq_mul]
+  have e1 : reducedPureBlockState A N L hL = (c • Lof) * (Rof * (schmidtMat A N L hL)ᴴ) := by
+    rw [reducedPureBlockState_eq_gram A N L hL, ← hc, Matrix.smul_mul, ← Matrix.mul_assoc, hLR]
+  rw [e1]
+  calc ((c • Lof) * (Rof * (schmidtMat A N L hL)ᴴ)).rank
+        ≤ (c • Lof).rank := Matrix.rank_mul_le_left _ _
+    _ ≤ Fintype.card (Fin D × Fin D) := Matrix.rank_le_card_width _
+    _ = D * D := by simp [Fintype.card_prod]
+
+/-- **Pure-state area-law upper bound.** The block entropy of an MPS pure state is
+bounded by twice the logarithm of the bond dimension, `S_L ≤ 2 log D`, uniformly
+in the block size `L` and the system size `N`.
+
+The reduced state's operator-Schmidt rank is at most `D²` (it factors through the
+two bonds cut by the block), and von Neumann entropy is bounded by the log of the
+rank.
+
+Source: arXiv:1606.00608, eq. line 599 (`S_L` bounded by a constant). -/
+theorem pureBlockEntropy_le (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) (hD : 0 < D)
+    (htr : Matrix.trace (pureState A N) ≠ 0) :
+    pureBlockEntropy A N L hL ≤ 2 * Real.log D := by
+  -- the reduced block state is a density matrix
+  have hPSD : (reducedPureBlockState A N L hL).PosSemidef :=
+    blockReducedState_posSemidef ((normalizedPureState_posSemidef A N).submatrix _)
+  have hTr : (reducedPureBlockState A N L hL).trace = 1 := by
+    rw [reducedPureBlockState, blockReducedState_trace, Matrix.trace_submatrix_equiv,
+      normalizedPureState, Matrix.trace_smul, smul_eq_mul, inv_mul_cancel₀ htr]
+  -- its rank is positive (trace 1 ≠ 0) and at most `D²`
+  have hrk_pos : 0 < (reducedPureBlockState A N L hL).rank := by
+    rw [hPSD.isHermitian.rank_eq_card_non_zero_eigs, Fintype.card_pos_iff]
+    by_contra h
+    simp only [not_nonempty_iff] at h
+    have hall : ∀ i, hPSD.isHermitian.eigenvalues i = 0 := fun i => by
+      by_contra hi; exact h.false ⟨i, hi⟩
+    have hsum := posSemidef_trace_one_eigenvalues_sum_one hPSD hTr
+    rw [Finset.sum_eq_zero (fun i _ => hall i)] at hsum
+    exact one_ne_zero hsum.symm
+  have hrk_le : (reducedPureBlockState A N L hL).rank ≤ D * D :=
+    rank_reducedPureBlockState_le A N L hL
+  -- chain the entropy bound through the rank
+  calc pureBlockEntropy A N L hL
+      = vonNeumannEntropy (reducedPureBlockState A N L hL) hPSD.isHermitian := rfl
+    _ ≤ Real.log (reducedPureBlockState A N L hL).rank :=
+        vonNeumannEntropy_le_log_rank hPSD hTr
+    _ ≤ Real.log ((D : ℝ) * D) := by
+        apply Real.log_le_log (by exact_mod_cast hrk_pos)
+        rw [← Nat.cast_mul]; exact_mod_cast hrk_le
+    _ = 2 * Real.log D := by
+        rw [Real.log_mul (by exact_mod_cast hD.ne') (by exact_mod_cast hD.ne')]; ring
+
+end MPSTensor

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3208,3 +3208,39 @@ the elementary trace-power identity for diagonal matrices.
     symmetry $S_{N-L} = S_L$ and $S_{N-L-1} = S_{L+1}$, this reduces to
     $S_L \le S_{L+1}$.
 \end{proof}
+
+\begin{lemma}[Operator-Schmidt rank bound]\label{lem:operator_schmidt_rank}
+    \lean{MPSTensor.rank_reducedPureBlockState_le}
+    \leanok
+    For an MPS tensor $A$ of bond dimension $D$ and a block length $L\le N$, the
+    reduced state $\rho_L^{(N)}(A)$ of the first $L$ spins has rank at most $D^2$.
+\end{lemma}
+\begin{proof}\leanok
+    The reduced state is $\rho_L \propto W W^\dagger$, where the amplitude matrix
+    $W(u, w) = \langle u\,w\,|\,V^{(N)}(A)\rangle = \operatorname{tr}
+    \bigl(A^{u_1}\cdots A^{u_L}\, A^{w_1}\cdots A^{w_{N-L}}\bigr)$ factors through
+    the two bond pairs cut by the block boundary. Writing the trace as a sum over
+    the bond index pair $(a, b)\in\{1,\dots,D\}^2$ exhibits $W = L'R'$ with $L'$
+    having $D^2$ columns, so $\operatorname{rank}\rho_L \le \operatorname{rank} W
+    \le D^2$.
+\end{proof}
+
+\begin{proposition}[Pure-state area-law upper bound]\label{prop:pure_area_upper}
+    \lean{MPSTensor.pureBlockEntropy_le}
+    \leanok
+    \uses{lem:operator_schmidt_rank, thm:entropy_le_log_rank}
+    Let $A$ be an MPS tensor of bond dimension $D\ge 1$ with $V^{(N)}(A)\neq 0$.
+    For every block length $L\le N$,
+    \[
+        S_L^{(N)}(A) \le 2\log D,
+    \]
+    uniformly in $L$ and $N$. This is the area law of
+    \cite[Section~3, line~599]{Cirac2016MPDO_arXiv}: the block entropy is bounded
+    by a constant independent of the block size.
+\end{proposition}
+\begin{proof}\leanok
+    The reduced state $\rho_L^{(N)}(A)$ is a density matrix of rank at most $D^2$
+    by Lemma~\ref{lem:operator_schmidt_rank}. By the rank bound on the entropy
+    (Theorem~\ref{thm:entropy_le_log_rank}),
+    $S_L^{(N)}(A) \le \log(D^2) = 2\log D$.
+\end{proof}

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -72,6 +72,28 @@ finite-dimensional quantum systems.
     \uses{lem:density_eigenvalues_sum, thm:density_eigenvalues_le_one}
 \end{proof}
 
+\begin{theorem}[Entropy bounded by log of rank]\label{thm:entropy_le_log_rank}
+    \lean{vonNeumannEntropy_le_log_rank}
+    \leanok
+    \uses{def:von_neumann_entropy}
+    For a density matrix $\rho$ of rank $r$,
+    \[
+        S(\rho) \le \log r.
+    \]
+    This refines the dimension bound: only the nonzero eigenvalues contribute to
+    the entropy, and there are exactly $r$ of them.
+\end{theorem}
+
+\begin{proof}\leanok
+    The entropy is the $-x\log x$ sum over all eigenvalues; the $D-r$ zero
+    eigenvalues contribute nothing. Jensen's inequality applied to $-x\log x$
+    over the $r$ nonzero eigenvalues, with uniform weights $1/r$, gives
+    $S(\rho) \le \log r$, the maximum attained when each nonzero eigenvalue
+    equals $1/r$. The rank equals the number of nonzero eigenvalues of the
+    Hermitian matrix $\rho$.
+    \uses{lem:density_eigenvalues_sum, thm:density_eigenvalues_le_one}
+\end{proof}
+
 \begin{lemma}[Entropy from characteristic polynomial roots]
     \label{lem:entropy_charpoly_roots}
     \lean{vonNeumannEntropy_eq_charpoly_roots}


### PR DESCRIPTION
## Summary

Formalizes the **area-law upper bound** of arXiv:1606.00608 (Section 3, line 599): the block entropy of an MPS pure state is bounded by a constant `2 log D`, independent of the block size `L` and system size `N`. This is the missing companion to the already-merged area-law *monotonicity* results (#2467 mixed, #2489 pure).

## The proof chain

1. **`vonNeumannEntropy_le_log_rank`** (`Analysis/Entropy.lean`) — a general analysis lemma: the von Neumann entropy of a density matrix is bounded by `log` of its **rank**, refining the existing `vonNeumannEntropy_le_log_dim` (which uses the full dimension). Proved by Jensen's inequality restricted to the rank-dimensional support (the nonzero eigenvalues), using `Matrix.IsHermitian.rank_eq_card_non_zero_eigs`.

2. **`MPSTensor.ofFn_blockReindex` / `schmidtMat_eq_mul`** (`MPS/MPDO/PureAreaLaw.lean`) — the block wavefunction matrix `W(u,w) = tr(A^{u}·A^{w})` factors as `W = L'·R'` through the `Fin D × Fin D` bond pair (the two bonds cut by the block boundary).

3. **`MPSTensor.rank_reducedPureBlockState_le`** — the reduced block state `ρ_L ∝ W·Wᴴ` therefore has operator-Schmidt rank `≤ D²` (`rank_mul_le_left` + `rank_le_card_width`).

4. **`MPSTensor.pureBlockEntropy_le`** — combine (1)+(3): `S_L ≤ log(rank) ≤ log(D²) = 2 log D`.

## Faithfulness

- Hypotheses are exactly bond dimension `D ≥ 1` and normalizability `V^{(N)}(A) ≠ 0` (i.e. `trace(pureState A N) ≠ 0`) — both source-faithful (a density matrix needs a nonzero, normalizable state). No extra hypotheses beyond the source statement.
- `vonNeumannEntropy_le_log_rank` is a strict generalization of the existing dimension bound; no existing signatures changed.

## Blueprint

- `thm:entropy_le_log_rank` (ch04b_entropy)
- `lem:operator_schmidt_rank` + `prop:pure_area_upper` (ch02b_mpdo)

## Verification

- `lake build TNLean.Analysis.Entropy` ✓
- `lake build TNLean.MPS.MPDO.PureAreaLaw` ✓
- `lake exe lint-style` clean on both files ✓
- No `sorry`/`axiom` introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs and blueprint text only; no changes to auth, APIs, or existing theorem signatures.
> 
> **Overview**
> Adds the **pure-state area-law upper bound** \(S_L \le 2\log D\) for MPS tensors (arXiv:1606.00608), complementing existing monotonicity results.
> 
> **Analysis:** New `vonNeumannEntropy_le_log_rank` bounds von Neumann entropy by \(\log(\mathrm{rank})\) via Jensen on the support of nonzero eigenvalues, refining the dimension bound.
> 
> **MPS:** The Schmidt matrix factors through bond indices \(D\times D\); reduced block state rank \(\le D^2\) (`rank_reducedPureBlockState_le`), then `pureBlockEntropy_le` chains rank → entropy → \(2\log D\).
> 
> **Blueprint:** Documents `thm:entropy_le_log_rank`, lemma on operator-Schmidt rank, and proposition `prop:pure_area_upper` in the MPDO and entropy chapters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01e1d7faab3402b29015d5749c552cacf14cdcc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->