### PR TITLE
feat(parent): record BNT internal block image sum

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 # Periodic constraints in the BNT block-diagonal range
 
 This file combines the normalized BNT direct-sum intersection identity with the
-block-diagonal periodic propagation lemma used in PGVWC07, Theorem `2blocks.2`.
+block-diagonal periodic propagation lemma used in PGVWC07, Theorem 2blocks.2.
 -/
 
 open scoped Matrix BigOperators
@@ -69,5 +69,44 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   have hM1 : M - 1 + 1 = M := Nat.sub_add_cancel (Nat.succ_le_iff.mpr hMpos)
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
+
+/-- The normalized BNT direct-sum hypotheses give the periodic constraint
+inclusion into the block image-space sum, and this sum is internal.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j,\qquad S_N=\bigvee_jG_N(A_j).
+\]
+In the BNT range used in PGVWC07, Theorem 2blocks.2
+(arXiv:quant-ph/0608197, proof lines 1430--1456), one has
+\[
+  \mathcal G_{N,L}(B)\subseteq S_N,
+\]
+and the summands \(G_N(A_j)\) form an internal direct sum. This does not assert
+the later component extraction from the periodic chain space to the sum of
+periodic block chain spaces. -/
+theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL₀ : 1 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange : L₀ + (r - 1) * (L₀ + (L₀ + L₀)) + 1 ≤ L) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, groundSpace (A j) N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  refine ⟨?_, ?_⟩
+  · exact chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital hN hL hLN hRange
+  · exact groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
+      A hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital (by omega)
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6229,6 +6229,55 @@ formulation; the passage to $\ker H_N$ is kept separate.
     Lemma~\ref{lem:block_diagonal_periodic_constraints_propagated_sum}.
 \end{proof}
 
+\begin{lemma}[BNT range with internal block image sum]
+    \label{lem:bnt_block_diagonal_periodic_constraints_internal_sum}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital}
+    \leanok
+    \uses{lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
+        lem:product_span_block_image_direct_sum}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}, set
+    \[
+        S_N:=\bigvee_{j=1}^gG_N(A_j).
+    \]
+    Then, for every $N\ge L$,
+    \[
+        \mathcal G_{N,L}(B)\subseteq S_N,
+    \]
+    and the sum defining \(S_N\) is internal: if
+    \[
+        \phi_j\in G_N(A_j),
+        \qquad
+        \sum_{j=1}^g\phi_j=0,
+    \]
+    then $\phi_j=0$ for every $j$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The inclusion is
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}. Since
+    $N\ge L$ and
+    \[
+        L\ge L_0+(g-1)(L_0+(L_0+L_0))+1,
+    \]
+    the product-span directness range of
+    Lemma~\ref{lem:product_span_block_image_direct_sum} applies at length
+    $N$:
+    \[
+        \operatorname{span}\{(A^1_w,\ldots,A^g_w): |w|=N\}
+        =
+        \prod_j M_{D_j}(\mathbb C)
+        \quad\Longrightarrow\quad
+        \ker\!\left(
+            \bigoplus_{j=1}^g G_N(A_j)
+            \longrightarrow (\mathbb C^d)^{\otimes N},
+            \quad
+            (\phi_j)_j\longmapsto \sum_j\phi_j
+        \right)=0.
+    \]
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready


### PR DESCRIPTION
Summary
- Add a no-sorry theorem combining the block-diagonal periodic-constraint inclusion with directness of the block image-space sum.
- The conclusion is `\mathcal G_{N,L}(\bigoplus_j \mu_j A_j) \subseteq \bigvee_j G_N(A_j)` together with `iSupIndep (fun j => groundSpace (A j) N)`.
- Add the corresponding blueprint lemma, phrased as an internal direct-sum consequence in the BNT range.
- This is a conservative PGVWC07 step: it records directness of `S_N = \bigvee_j G_N(A_j)` and does not assert the still-open extraction to `\sum_j \mathcal G_{N,L}(A_j)`.

Contributes to #905.

Verification
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `#print axioms MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital` depends only on `propext`, `Classical.choice`, and `Quot.sound`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`
- `leanblueprint web`
- `leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and blueprint documentation only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital`**, packaging the existing BNT periodic-constraint inclusion into \(\bigvee_j G_N(A_j)\) together with **`iSupIndep`** on the block ground spaces (internal direct sum). The proof is a short `refine` of the prior inclusion theorem and `groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital`; it explicitly does **not** claim extraction to per-block periodic chain spaces.
> 
> The blueprint gains **Lemma `bnt_block_diagonal_periodic_constraints_internal_sum`**, linked to that Lean theorem, stating \(\mathcal G_{N,L}(B)\subseteq S_N\) and internal directness of \(S_N=\bigvee_j G_N(A_j)\).
> 
> A one-line doc tweak normalizes the PGVWC07 theorem reference (drops backticks around `2blocks.2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152c7486d30a50129870dfe55f897454b7e48717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->