### PR TITLE
feat(MPS/MPDO): pure-state mutual-information bound I_L ≤ 4 log D

### DIFF
--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -450,3 +450,22 @@ theorem pureBlockEntropy_le (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) (hD :
         rw [Real.log_mul (by exact_mod_cast hD.ne') (by exact_mod_cast hD.ne')]; ring
 
 end MPSTensor
+
+/-- **Pure-state mutual-information area-law bound.** For the purification MPDO of
+an MPS tensor `A` (whose generated operator is the pure state `|V^{(N)}(A)⟩⟨V^{(N)}(A)|`),
+the mutual information between a block of `L` spins and the rest is bounded by
+`4 log D`, uniformly in `L` and `N`.
+
+For a pure state `I_L = 2 S_L` (the global entropy `S_N` vanishes and the block and
+its complement share the same Schmidt spectrum), so the bound follows from the
+pure-state block-entropy bound `S_L ≤ 2 log D`.
+
+For a general (mixed) MPDO the analogous bound `I_L ≤ 4 log D` is a cited external
+result (arXiv:1606.00608, line 1319, attributing it to Wolf et al.'s mutual-information
+area law); arXiv:1606.00608 itself proves only the monotonicity `I_L ≤ I_{L+1}`
+(`MPOTensor.mutualInfoChain_monotone`). -/
+theorem mutualInfoChain_doubledTensor_le (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N)
+    (hD : 0 < D) (htr : Matrix.trace (MPSTensor.pureState A N) ≠ 0) :
+    (doubledTensor A).mutualInfoChain N L hL (doubledTensor_posSemidef A N) ≤ 4 * Real.log D := by
+  rw [mutualInfoChain_doubledTensor A N L hL htr]
+  linarith [MPSTensor.pureBlockEntropy_le A N L hL hD htr]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3068,6 +3068,16 @@ the elementary trace-power identity for diagonal matrices.
     $I_L \le I_{L+1}$ after subtracting $S_N$.
 \end{proof}
 
+\begin{remark}[Boundedness of the mutual information]
+    The monotone sequence $I_L$ is bounded by a constant depending only on the
+    bond dimension, $I_L \le 4\log D$, so it converges as $L\to\infty$. For a
+    general mixed MPDO this bound is not proved in
+    \cite{Cirac2016MPDO_arXiv}; that reference attributes it (line~1319) to the
+    mutual-information area law of Wolf et al., used there as an external result.
+    The pure-state instance is formalized in
+    Proposition~\ref{prop:pure_mutual_info_bound} below.
+\end{remark}
+
 \begin{definition}[Block entropy and area-law saturation for pure states]
     \label{def:pure_sal}
     \lean{MPSTensor.pureBlockEntropy, MPSTensor.IsSAL}
@@ -3243,4 +3253,41 @@ the elementary trace-power identity for diagonal matrices.
     by Lemma~\ref{lem:operator_schmidt_rank}. By the rank bound on the entropy
     (Theorem~\ref{thm:entropy_le_log_rank}),
     $S_L^{(N)}(A) \le \log(D^2) = 2\log D$.
+\end{proof}
+
+\begin{lemma}[Pure-state mutual information is twice the block entropy]
+    \label{lem:mutual_info_doubled}
+    \lean{mutualInfoChain_doubledTensor}
+    \leanok
+    \uses{lem:schmidt_symmetry, lem:blockEntropy_doubledTensor}
+    For an MPS tensor $A$ with $V^{(N)}(A)\neq 0$, the mutual information of the
+    purification MPDO equals twice the pure-state block entropy:
+    \[
+        I_L = 2\,S_L^{(N)}(A).
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    By definition $I_L = S_L + S_{N-L} - S_N$ for the generated state. The global
+    entropy of the pure state vanishes, $S_N = 0$, and the Schmidt symmetry
+    (Lemma~\ref{lem:schmidt_symmetry}) gives $S_{N-L} = S_L$, so $I_L = 2\,S_L$.
+\end{proof}
+
+\begin{proposition}[Pure-state mutual-information bound]\label{prop:pure_mutual_info_bound}
+    \lean{mutualInfoChain_doubledTensor_le}
+    \leanok
+    \uses{prop:pure_area_upper, lem:mutual_info_doubled}
+    Let $A$ be an MPS tensor of bond dimension $D\ge 1$ with $V^{(N)}(A)\neq 0$.
+    For the purification MPDO of $A$, whose generated operator is the pure state
+    $|V^{(N)}(A)\rangle\langle V^{(N)}(A)|$, the mutual information between a block
+    of $L$ spins and the rest satisfies
+    \[
+        I_L \le 4\log D,
+    \]
+    uniformly in $L$ and $N$.
+\end{proposition}
+\begin{proof}\leanok
+    For a pure state $I_L = 2\,S_L^{(N)}(A)$, since the global entropy $S_N$
+    vanishes and a block and its complement share the same Schmidt spectrum. The
+    block-entropy bound $S_L^{(N)}(A) \le 2\log D$
+    (Proposition~\ref{prop:pure_area_upper}) then gives $I_L \le 4\log D$.
 \end{proof}


### PR DESCRIPTION
## Summary

Adds the **pure-state mutual-information area-law bound** `I_L ≤ 4 log D` and corrects the faithfulness record for the general mixed case.

`mutualInfoChain_doubledTensor_le`: for the purification MPDO of an MPS tensor `A` (generated operator = the pure state `|V^{(N)}(A)⟩⟨V^{(N)}(A)|`), the mutual information between a block of `L` spins and the rest is `≤ 4 log D`, uniformly in `L`, `N`. Immediate corollary of:
- `mutualInfoChain_doubledTensor` (#2505): `I_L = 2 S_L` for a pure state,
- `pureBlockEntropy_le` (#2518): `S_L ≤ 2 log D`.

## Faithfulness correction

While checking the source I found that arXiv:1606.00608 does **not** prove the general mixed-MPDO bound `I_L ≤ 4 log D`. Line 1319 explicitly **cites it to Wolf et al.'s mutual-information area law** (`\cite{WolfAreaLaw}`), using it as an external black box; the paper proves only the *monotonicity* `I_L ≤ I_{L+1}` in-paper (already formalized: `mutualInfoChain_monotone`, #2467). 

So the general bound is out of 1606.00608's own scope. This PR formalizes the **pure-state instance** (which §3 of the paper does treat) and adds a blueprint **remark** recording the Wolf citation, so the boundedness is not mistaken for in-paper content.

## Blueprint

- `lem:mutual_info_doubled` — fills a gap: `mutualInfoChain_doubledTensor` (`I_L = 2 S_L`, from #2505) had no blueprint entry.
- `prop:pure_mutual_info_bound` — the new `I_L ≤ 4 log D` (pure case).
- A boundedness **remark** under `prop:mutual_info_monotone` attributing the general bound to Wolf.

## Verification

- `lake build TNLean.MPS.MPDO.PureAreaLaw` ✓ (no new warnings)
- `lake exe lint-style` clean, no `sorry`/`axiom`.
- `leanblueprint checkdecls`: the two new `\lean{}` refs resolve; the unrelated pre-existing "missing" decls (IsPRFP, parentHamiltonian*) are prior blueprint debt, unchanged by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a corollary theorem and blueprint text in an already-developed pure-area-law module; no auth, data, or API surface changes.
> 
> **Overview**
> Formalizes the **pure-state** mutual-information area-law bound **\(I_L \le 4\log D\)** for the purification MPDO of an MPS tensor (`mutualInfoChain_doubledTensor_le`), by combining **`I_L = 2 S_L`** with **`S_L \le 2\log D`**.
> 
> The Lean proof is a short corollary (`rw` + `linarith`); the docstring records that the **general mixed** bound \(I_L \le 4\log D\) is **not** proved in arXiv:1606.00608 (line 1319 cites Wolf et al.); that paper only proves monotonicity in-paper.
> 
> **Blueprint** (`ch02b_mpdo.tex`): adds a **remark** under mutual-info monotonicity on boundedness and attribution; **`lem:mutual_info_doubled`** for the existing `mutualInfoChain_doubledTensor` identity; **`prop:pure_mutual_info_bound`** for the new theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600660c35e712dc55618f723c59e91c729a2f681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->