### PR TITLE
doc(MPS/MPDO): correct phantom witness reference in ZCL scope-restriction

### DIFF
--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -39,10 +39,14 @@ after the transfer operator is normalized so that its leading eigenvalue is `1`.
 The literal condition here is faithful only for such normalized representatives.
 For a general representative it is strictly stronger, since it forces the leading
 eigenvalue to equal `1`, whereas the source ZCL is invariant under the rescaling
-`E_M ↦ λ E_M`. The deviation is witnessed by `exists_isPRFP_not_isZCL`, where the
-purification's trace contraction drops the leading eigenvalue. The faithful
-(normalized) ZCL and the source's equivalence between PRFP and ZCL remain open. Recorded
-in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+`E_M ↦ λ E_M`. The deviation is illustrated by the rescaled purification
+`d = dK = 2`, `D = 1`, `A = [1/√2, 0, 0, 1/√2]`: it satisfies the local
+purification-RFP condition, yet its transfer map is `½ • id`, so
+`E_M ∘ E_M = ¼ • id ≠ E_M`; the trace contraction in the purification has dropped
+the leading eigenvalue from `1` to `½`. (This counterexample is not yet
+formalized.) The faithful (normalized) ZCL and the source's equivalence between
+PRFP and ZCL remain open. Recorded in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 
 See arXiv:1606.00608, lines 735–739 (and the canonical-form characterization at
 line 1248), and arXiv:2011.12127, Section II.E.2, lines 937–939. -/

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -50,9 +50,9 @@ forces the leading eigenvalue to be exactly $1$, whereas the source's ZCL is the
 \emph{normalized} (peripheral) idempotence, invariant under rescaling $E_M\mapsto
 \lambda E_M$.
 
-This deviation is witnessed in the development by
-\texttt{MPOTensor.exists\_isPRFP\_not\_isZCL}. Take $d=d_K=2$, $D'=D=1$,
-$A=[\tfrac{1}{\sqrt2},0,0,\tfrac{1}{\sqrt2}]$, which is an RFP MPS tensor
+This deviation is illustrated by the following construction (a counterexample
+recorded here but not yet formalized in the development). Take $d=d_K=2$,
+$D'=D=1$, $A=[\tfrac{1}{\sqrt2},0,0,\tfrac{1}{\sqrt2}]$, which is an RFP MPS tensor
 ($E_A=\mathrm{id}$). The induced MPDO tensor has scalar entries
 $M^{00}=M^{11}=\tfrac12$, off-diagonal $0$, so $\rho^{(N)}(M)=(\tfrac12)^N I$ is
 the (normalized) maximally mixed state --- manifestly length-independent


### PR DESCRIPTION
## Summary

Audit fix. The `MPOTensor.IsZCL` docstring and the paper-gap note `cpsv16_zcl_canonical_form_normalization.tex` (both from #2491) claimed the canonical-form deviation was **"witnessed by `exists_isPRFP_not_isZCL`"** / witnessed "in the development." No such declaration exists:

- `rg` over the whole tree finds `exists_isPRFP_not_isZCL` only as prose in the ZCL docstring — never as a `theorem`/`def`.
- The `d=dK=2, D=1, A=[1/√2,0,0,1/√2]` example was a **reviewer counterexample** in PR discussion, never formalized.
- `IsPRFP` itself was deleted / reframed to `MPOTensor.IsLocalPurificationRFP` in #2436, so even the name is stale.

## Change

Both the docstring and the paper-gap note now state the construction **inline** and mark it **explicitly as not yet formalized**, so the documentation no longer implies a Lean witness lemma exists. No code/proof changes.

Formalizing the witness — `∃ M, MPOTensor.IsLocalPurificationRFP M ∧ ¬ MPOTensor.IsZCL M`, tractable at `D=1` by scalar arithmetic (transfer map `= ½•id`, so `E_M² = ¼•id ≠ E_M`) — is left as a tracked follow-up.

## Verification

- `lake build TNLean.MPS.MPDO.ZCL` ✓
- `lake exe lint-style TNLean/MPS/MPDO/ZCL.lean` clean (the `½`/`¼`/`√` docstring unicode passes).
- Docstring/`.tex` prose only; no `sorry`/`axiom`, no signature changes.

_Side note for reviewers:_ a local `leanblueprint checkdecls` currently reports ~66 "missing" decls, but that is a **stale `blueprint/lean_decls`** (generated Jun 3, listing deleted decls like `IsPRFP` and lacking recent ones); CI regenerates it fresh, which is why `blueprint-and-prose` passes. Not addressed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only edits to docstrings and a paper-gap `.tex` file; no runtime, proof, or API changes.
> 
> **Overview**
> Documentation-only audit fix for the **canonical-form vs literal `IsZCL`** scope note in `MPOTensor.IsZCL` and `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
> 
> Both places **stopped claiming** the gap is “witnessed by `exists_isPRFP_not_isZCL`” (no such Lean declaration). They now **spell out the same `d=2`, `D=1`, `A=[1/√2,0,0,1/√2]` counterexample inline**—local purification-RFP holds, transfer map is `½•id`, so literal `IsZCL` fails—and **state explicitly that it is not yet formalized**. No definitions, theorems, or proofs changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4db1cb34248c2161e3f02c537601bb56e34d2dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->