### PR TITLE
feat(PEPS): region-injective coefficient-transfer chain and the vertex-frame boundary (normal-FT)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -463,3 +463,4 @@ import TNLean.PEPS.RegionBlock.Recovery10
 import TNLean.PEPS.RegionBlock.Recovery11
 import TNLean.PEPS.RegionBlock.Recovery12
 import TNLean.PEPS.RegionBlock.RegionReconcile
+import TNLean.PEPS.RegionBlock.RegionResonateInvert

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -462,3 +462,4 @@ import TNLean.PEPS.RegionBlock.Recovery9
 import TNLean.PEPS.RegionBlock.Recovery10
 import TNLean.PEPS.RegionBlock.Recovery11
 import TNLean.PEPS.RegionBlock.Recovery12
+import TNLean.PEPS.RegionBlock.RegionReconcile

--- a/TNLean/PEPS/RegionBlock/RegionReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/RegionReconcile.lean
@@ -17,7 +17,7 @@ The contributions here are non-circular and use only blocked-region injectivity:
   second-tensor matrix `N` as the second tensor's own in-region endpoint operator of
   `N.transpose` against the second tensor's region weight vectors at the endpoint
   leg. This is `region_innerSum_eq_realized` (`TNLean.PEPS.RegionBlock.Recovery2`)
-  packaged for the complement row of `TNLean.PEPS.RegionBlock.Recovery7`.
+  specialized to the complement row of `TNLean.PEPS.RegionBlock.Recovery7`.
 
 * `coeffTransfer_of_endpointOp_eq` reduces the **coefficient transfer** (matching the
   region-inserted coefficients of `A` and `B`) to the agreement of the two in-region
@@ -102,9 +102,23 @@ second tensor's complement blocked tensor map of the v-side row `vSideRow`. The
 B-side factorization `regionInsertedCoeff_eq_complement_blockedMap`
 (`TNLean.PEPS.RegionBlock.Recovery7`) does the same for the second tensor's
 region-inserted coefficient of `N`, with row the explicit complement row
-`regionComplementRow B R f N σ`. Both factor through the *same* injective complement
-blocked tensor map (`hCB`), so the coefficient transfer is equivalent to matching
-the two rows at every region physical configuration. By
+`regionComplementRow B R f N σ`. For fixed `σ` and `τ`, the two factorizations are
+\[
+  \operatorname{regionInsertedCoeff}_A(M,\sigma,\tau)
+    =
+  \operatorname{regionBlockedTensorMap}_{B,\operatorname{univ}\setminus R}
+    (\operatorname{vSideRow}_A(M,\sigma))(\tau),
+\]
+and
+\[
+  \operatorname{regionInsertedCoeff}_B(N,\sigma,\tau)
+    =
+  \operatorname{regionBlockedTensorMap}_{B,\operatorname{univ}\setminus R}
+    (\operatorname{regionComplementRow}_B(N,\sigma))(\tau).
+\]
+Both factor through the *same* injective complement blocked tensor map (`hCB`), so
+the coefficient transfer is equivalent to matching the two rows at every region
+physical configuration. By
 `regionComplementRow_eq_regionInsertionOp` and the definition of `vSideRow`, the two
 rows agree exactly when the first tensor's in-region endpoint operator (from
 `M.transpose`) and the second tensor's (from `N.transpose`) agree on the second

--- a/TNLean/PEPS/RegionBlock/RegionReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/RegionReconcile.lean
@@ -156,5 +156,52 @@ theorem coeffTransfer_of_endpointOp_eq (A B : Tensor G d) (R : Finset V)
   rw [vSideRow, regionComplementRow_eq_regionInsertionOp B R f hvB N σ' w]
   exact hop σ' ((regionComplementBoundaryConfigEquiv (G := G) B R).symm w)
 
+/-! ### The symmetric reduction: coefficient transfer through the region block
+
+The σ-side mirror of `regionInsertedCoeff_eq_of_complementRow_eq`
+(`TNLean.PEPS.RegionBlock.Recovery10`). Fixing the complement physical
+configuration `τ`, the first tensor's region-inserted coefficient of `M` factors, as
+a function of the region physical configuration `σ`, through the second tensor's
+region blocked tensor map with row `complSideRow A B R f hvAout M τ`
+(`regionInsertedCoeff_eq_region_blockedMap_B`, `Recovery10`); the second tensor's
+region-inserted coefficient of `N` factors through the *same* map with the explicit
+region row `regionRegionRow B R f N τ` (`regionInsertedCoeff_eq_region_blockedMap`,
+`Recovery7`). Region-block injectivity (`hRB`) forces the coefficients equal when the
+two rows agree. This is the σ-side inversion, the region port of
+`resonate_invert_left_endpoint`. -/
+
+/-- **Coefficient transfer through the region block.** If the σ-side row
+`complSideRow A B R f hvAout M τ` of the first tensor agrees with the explicit region
+row `regionRegionRow B R f N τ` of the second tensor at every complement physical
+configuration `τ`, then the region-inserted coefficient of `M` in the first tensor
+equals that of `N` in the second at every physical configuration.
+
+Both rows are rows of the same injective region blocked tensor map of `B` (`hRB`):
+the first tensor's coefficient is its map of `complSideRow` by
+`regionInsertedCoeff_eq_region_blockedMap_B` (`Recovery10`), the second tensor's of
+`regionRegionRow` by `regionInsertedCoeff_eq_region_blockedMap` (`Recovery7`). This
+is the σ-side mirror of `regionInsertedCoeff_eq_of_complementRow_eq`; it inverts only
+the second tensor's region block.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_of_regionRow_eq (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hrow : ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+      complSideRow (G := G) A B R f hvAout M τ = regionRegionRow (G := G) B R f N τ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ := by
+  have hA := congrFun
+    (regionInsertedCoeff_eq_region_blockedMap_B A B R f hvAout hAB hDim M τ) σ
+  rw [hA, hrow τ, ← regionInsertedCoeff_eq_region_blockedMap B R f N σ τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/RegionReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/RegionReconcile.lean
@@ -203,5 +203,185 @@ theorem regionInsertedCoeff_eq_of_regionRow_eq (A B : Tensor G d) (R : Finset V)
     (regionInsertedCoeff_eq_region_blockedMap_B A B R f hvAout hAB hDim M τ) σ
   rw [hA, hrow τ, ← regionInsertedCoeff_eq_region_blockedMap B R f N σ τ]
 
+/-! ### The region insertion transfer datum from a region-injective coefficient transfer
+
+The block-level injectivity `regionInsertedCoeff_injective`
+(`TNLean.PEPS.RegionBlock.Algebra`) is unconditional on blocked-region injectivity.
+It lets the per-edge matrix transfer maps be chosen directly from a coefficient
+transfer — for each inserted matrix a matching matrix on the other tensor — with the
+coefficient-matching fields holding by the choice and the unital field by the
+`SameState` identity insertion `regionInsertedCoeff_one_eq_stateCoeff`
+(`TNLean.PEPS.RegionBlock.Recovery`). The only remaining input is multiplicativity of
+the chosen forward transfer, which the source supplies by the homomorphism property
+of the physical realization. Isolating it as a hypothesis assembles the
+`RegionInsertionTransfer` datum region-injectively: feeding it to
+`exists_regionEdgeGauge_of_transfer` (`TNLean.PEPS.RegionBlock.Algebra`) reads off the
+per-edge gauge with no single-vertex injectivity. -/
+
+/-- A chosen forward per-edge matrix transfer from a coefficient transfer: for each
+inserted matrix `M` on the first tensor, a matrix on the second tensor whose
+region-inserted coefficient matches. The matching is the defining property
+`coeffTransferMap_coeff`. -/
+noncomputable def coeffTransferMap (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (htransfer : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ :=
+  (htransfer M).choose
+
+/-- The chosen forward transfer matches the region-inserted coefficients. -/
+theorem coeffTransferMap_coeff (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (htransfer : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f (coeffTransferMap (G := G) A B R f htransfer M) σ τ :=
+  (htransfer M).choose_spec σ τ
+
+/-- The chosen forward transfer is unital, by the `SameState` identity insertion. The
+region-inserted coefficient of the identity is the interior bond product times the
+closed-state coefficient (`regionInsertedCoeff_one_eq_stateCoeff`), matched across the
+two tensors by `SameState` and equal bond dimensions. Block injectivity of the second
+tensor then forces the chosen transfer of `1` to be `1`. -/
+theorem coeffTransferMap_one (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (htransfer : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ) :
+    coeffTransferMap (G := G) A B R f htransfer 1 = 1 := by
+  refine regionInsertedCoeff_injective (G := G) B R hRB hCB hposB f _ 1 (fun σ τ => ?_)
+  rw [← coeffTransferMap_coeff A B R f htransfer 1 σ τ,
+    regionInsertedCoeff_one_eq_stateCoeff (G := G) A R f σ τ,
+    regionInsertedCoeff_one_eq_stateCoeff (G := G) B R f σ τ,
+    regionInteriorBondProd_congr A B R hDim, hAB _]
+
+/-- **Region insertion transfer datum from a region-injective coefficient transfer.**
+Given coefficient transfers in both directions (for each inserted matrix on one
+tensor a matching matrix on the other), matched bond dimensions, `SameState`,
+positive bond dimensions, region/complement blocked injectivity of both tensors, and
+multiplicativity of the chosen forward transfer, the per-edge matrix transfer maps
+assemble into a `RegionInsertionTransfer` datum.
+
+The forward and backward maps are chosen by `coeffTransferMap`; their
+coefficient-matching fields are `coeffTransferMap_coeff`; the unital field is
+`coeffTransferMap_one`; the multiplicative field is the hypothesis `hmul`. All other
+content is `regionInsertedCoeff_injective`, which is unconditional on blocked-region
+injectivity. The datum feeds `exists_regionEdgeGauge_of_transfer`
+(`TNLean.PEPS.RegionBlock.Algebra`) to read off the per-edge gauge with no
+single-vertex injectivity.
+
+**Scope (multiplicativity hypothesis):** the forward-transfer multiplicativity `hmul`
+is the only field not yet derived region-injectively. The source derives it from the
+homomorphism property of the physical realization
+(`Papers/1804.04964/paper_normal.tex`, eq. `X->O`), whose region port reads the
+recovered matrix off the single-vertex virtual pullback and so currently needs the
+in-region endpoint spanning. The block-endpoint inversions above
+(`coeffTransfer_of_endpointOp_eq`, `regionInsertedCoeff_eq_of_regionRow_eq`) supply
+the coefficient transfers `htransferAB`/`htransferBA`; the residual single-vertex
+read-off is documented in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def regionInsertionTransfer_of_coeffTransfer (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (htransferBA : ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      ∃ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) B R f N σ τ =
+            regionInsertedCoeff (G := G) A R f M σ τ)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B R f htransferAB (M * M') =
+        coeffTransferMap (G := G) A B R f htransferAB M *
+          coeffTransferMap (G := G) A B R f htransferAB M') :
+    RegionInsertionTransfer (G := G) A B R f where
+  fwd M := coeffTransferMap (G := G) A B R f htransferAB M
+  bwd N := coeffTransferMap (G := G) B A R f htransferBA N
+  fwd_coeff M σ τ := coeffTransferMap_coeff A B R f htransferAB M σ τ
+  bwd_coeff N σ τ := coeffTransferMap_coeff B A R f htransferBA N σ τ
+  fwd_mul M M' := hmul M M'
+  fwd_one := coeffTransferMap_one A B R f hRB hCB hAB hposB hDim htransferAB
+
+/-- **Per-edge gauge from a region-injective coefficient transfer.** Given coefficient
+transfers in both directions with a multiplicative forward choice, region/complement
+blocked injectivity of both tensors, positive bond dimensions, `SameState`, and
+matched bond dimensions, the chosen forward per-edge matrix transfer on the boundary
+edge `f` is conjugation by an invertible gauge matrix `Z`, and the two bond
+dimensions on `f` coincide. No single-vertex injectivity is used: the datum is
+`regionInsertionTransfer_of_coeffTransfer` and the read-off is
+`exists_regionEdgeGauge_of_transfer` (`TNLean.PEPS.RegionBlock.Algebra`).
+
+**Scope (multiplicativity hypothesis):** see
+`regionInsertionTransfer_of_coeffTransfer`.
+
+Source: arXiv:1804.04964, Section 3, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_of_coeffTransfer (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (htransferBA : ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      ∃ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) B R f N σ τ =
+            regionInsertedCoeff (G := G) A R f M σ τ)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B R f htransferAB (M * M') =
+        coeffTransferMap (G := G) A B R f htransferAB M *
+          coeffTransferMap (G := G) A B R f htransferAB M') :
+    ∃ hEdge : A.bondDim f.1 = B.bondDim f.1,
+      ∃ Z : GL (Fin (B.bondDim f.1)) ℂ,
+        ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+          (regionInsertionTransfer_of_coeffTransfer A B R f hRB hCB hAB hposB hDim
+              htransferAB htransferBA hmul).fwd M =
+            (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim f.1)) ℂ) :
+                Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :=
+  exists_regionEdgeGauge_of_transfer A B R f
+    (regionInsertionTransfer_of_coeffTransfer A B R f hRB hCB hAB hposB hDim
+      htransferAB htransferBA hmul)
+    hRA hCA hposA hRB hCB hposB
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/RegionReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/RegionReconcile.lean
@@ -1,0 +1,160 @@
+import TNLean.PEPS.RegionBlock.Recovery11
+
+/-!
+# Region physical-to-virtual recovery: the block-endpoint inversion (region-injective)
+
+This file ports the block-endpoint inversion of the region resonate step to the
+**region-injective** regime, with the blocked-region left inverses of `R` and of
+its set complement `univ \ R` as the two inversion tools, and *without* assuming
+single-vertex injectivity `IsVertexInjective`. It is the region-granularity port
+of `resonate_invert_right_endpoint` (`TNLean.PEPS.InsertionRealization`) and the
+first half of the open obligation of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+The contributions here are non-circular and use only blocked-region injectivity:
+
+* `regionComplementRow_eq_regionInsertionOp` reads the explicit complement row of a
+  second-tensor matrix `N` as the second tensor's own in-region endpoint operator of
+  `N.transpose` against the second tensor's region weight vectors at the endpoint
+  leg. This is `region_innerSum_eq_realized` (`TNLean.PEPS.RegionBlock.Recovery2`)
+  packaged for the complement row of `TNLean.PEPS.RegionBlock.Recovery7`.
+
+* `coeffTransfer_of_endpointOp_eq` reduces the **coefficient transfer** (matching the
+  region-inserted coefficients of `A` and `B`) to the agreement of the two in-region
+  endpoint operators on the second tensor's region weight vectors at the endpoint
+  leg. The reduction inverts the complement block through the blocked-region left
+  inverse `regionBlockedLeftInverse B (univ \ R) hCB` and is exactly the
+  block-granularity form of inverting the second tensor's complement away from the
+  in-region endpoint. It uses no single-vertex spanning.
+
+These are the region-injective replacements for the steps that
+`TNLean.PEPS.RegionBlock.Recovery9`/`Recovery10`/`Recovery11` performed with the
+single-vertex realization (which needs `IsVertexInjective` through the spanning
+`span_stateOpenCoeff_eq_top`).
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The complement row as an in-region endpoint operator
+
+The explicit complement row `regionComplementRow B R f N σ` of the second tensor
+(`TNLean.PEPS.RegionBlock.Recovery7`) is, at the complement boundary configuration
+`w`, the incident-matrix sum of `N` against the second tensor's region blocked
+weights. The inner-sum realization `region_innerSum_eq_realized`
+(`TNLean.PEPS.RegionBlock.Recovery2`) reads that sum as the second tensor's *own*
+in-region endpoint operator of `N.transpose`, applied to the second tensor's region
+weight vector at the reindexed boundary configuration, evaluated at the endpoint
+leg. This is the second-tensor counterpart of the v-side row `vSideRow`
+(`TNLean.PEPS.RegionBlock.Recovery10`), which reads the *first* tensor's operator on
+the same weight vectors; matching the two rows is the coefficient transfer. -/
+
+/-- **The complement row as the second tensor's in-region endpoint operator.** At a
+complement boundary configuration `w` of `univ \ R`, the explicit complement row of
+the matrix `N` on the second tensor equals the second tensor's in-region endpoint
+operator from `N.transpose`, applied to the second tensor's region weight vector at
+the reindexed boundary configuration, evaluated at the endpoint physical leg `σ v`.
+
+This is `region_innerSum_eq_realized` (`TNLean.PEPS.RegionBlock.Recovery2`)
+specialized to the second tensor with the boundary configuration
+`(regionComplementBoundaryConfigEquiv B R).symm w`. It exposes the complement row of
+`regionComplementRow` (`TNLean.PEPS.RegionBlock.Recovery7`) in the same form as the
+v-side row `vSideRow` (`TNLean.PEPS.RegionBlock.Recovery10`), so the coefficient
+transfer becomes the agreement of the two operators on the same weight vectors.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionComplementRow_eq_regionInsertionOp (B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (w : RegionBoundaryConfig (G := G) B (Finset.univ \ R)) :
+    regionComplementRow (G := G) B R f N σ w =
+      regionInsertionOp (G := G) B R f hvB N.transpose
+          (regionWeightVec (G := G) B R f
+            ((regionComplementBoundaryConfigEquiv (G := G) B R).symm w) σ)
+        (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+          regionBoundaryEdgeInVertex_mem (G := G) R f⟩) := by
+  classical
+  rw [regionComplementRow]
+  exact region_innerSum_eq_realized B R f hvB N
+    ((regionComplementBoundaryConfigEquiv (G := G) B R).symm w) σ
+
+/-! ### The coefficient transfer from agreement of the two endpoint operators
+
+The v-side factorization `regionInsertedCoeff_eq_complement_blockedMap_vSideRow`
+(`TNLean.PEPS.RegionBlock.Recovery10`) writes the first tensor's region-inserted
+coefficient of `M`, as a function of the complement physical configuration, as the
+second tensor's complement blocked tensor map of the v-side row `vSideRow`. The
+B-side factorization `regionInsertedCoeff_eq_complement_blockedMap`
+(`TNLean.PEPS.RegionBlock.Recovery7`) does the same for the second tensor's
+region-inserted coefficient of `N`, with row the explicit complement row
+`regionComplementRow B R f N σ`. Both factor through the *same* injective complement
+blocked tensor map (`hCB`), so the coefficient transfer is equivalent to matching
+the two rows at every region physical configuration. By
+`regionComplementRow_eq_regionInsertionOp` and the definition of `vSideRow`, the two
+rows agree exactly when the first tensor's in-region endpoint operator (from
+`M.transpose`) and the second tensor's (from `N.transpose`) agree on the second
+tensor's region weight vectors at the endpoint leg. This is the block-granularity
+inversion of the complement away from the in-region endpoint, the region port of
+`resonate_invert_right_endpoint`; it uses no single-vertex spanning. -/
+
+/-- **The coefficient transfer from endpoint-operator agreement.** If the first
+tensor's in-region endpoint operator from `M.transpose` and the second tensor's from
+`N.transpose` agree, at the endpoint physical leg, on the second tensor's region
+weight vectors at every reindexed complement boundary configuration and region
+physical configuration, then the region-inserted coefficient of `M` in the first
+tensor equals that of `N` in the second at every physical configuration.
+
+The two rows of the (shared) injective complement blocked tensor map are the v-side
+row `vSideRow A B R f hvA M σ` (the first tensor's operator on the weight vectors)
+and the explicit complement row `regionComplementRow B R f N σ` (read by
+`regionComplementRow_eq_regionInsertionOp` as the second tensor's operator on the
+same weight vectors). The hypothesis matches them, so `hCB` injectivity forces the
+coefficients equal through `regionInsertedCoeff_eq_of_complementRow_eq`
+(`TNLean.PEPS.RegionBlock.Recovery10`). The argument is region-injective: it inverts
+only the second tensor's complement block, never the single vertex `v`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_of_endpointOp_eq (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hop : ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (ν : RegionBoundaryConfig (G := G) B R),
+      regionInsertionOp (G := G) A R f hvA M.transpose
+          (regionWeightVec (G := G) B R f ν σ)
+          (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+            regionBoundaryEdgeInVertex_mem (G := G) R f⟩) =
+        regionInsertionOp (G := G) B R f hvB N.transpose
+          (regionWeightVec (G := G) B R f ν σ)
+          (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+            regionBoundaryEdgeInVertex_mem (G := G) R f⟩))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ := by
+  refine regionInsertedCoeff_eq_of_complementRow_eq A B R f hvA hAB hDim M N (fun σ' => ?_) σ τ
+  funext w
+  rw [vSideRow, regionComplementRow_eq_regionInsertionOp B R f hvB N σ' w]
+  exact hop σ' ((regionComplementBoundaryConfigEquiv (G := G) B R).symm w)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
+++ b/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
@@ -1,5 +1,4 @@
 import TNLean.PEPS.RegionBlock.RegionReconcile
-import TNLean.PEPS.InsertionRealization
 
 /-!
 # Region resonate inversion: the bond-contracted endpoint-inversion engine
@@ -281,7 +280,7 @@ theorem regionInsertedCoeff_eq_of_vSideRow_incidentForm (A B : Tensor G d)
 The coefficient transfer `htransfer` (for each inserted matrix `M`, a matrix `N` on
 the other tensor matching the region-inserted coefficients) feeds
 `exists_regionEdgeGauge_of_coeffTransfer` (`TNLean.PEPS.RegionBlock.RegionReconcile`)
-to read off the per-edge gauge. Packaging the v-side-row incident form as an
+to read off the per-edge gauge. Expressing the v-side-row incident form as an
 existential — for each `M` a bond matrix `N` realizing the v-side row of `M` as the
 incident-matrix coupling of `N` — produces exactly that coefficient transfer,
 region-injectively. The single remaining input is the v-side-row incident form, the
@@ -296,7 +295,7 @@ transfer holds: for every `M` there is an `N` with matching region-inserted
 coefficients at every physical configuration.
 
 Each per-matrix coefficient match is `regionInsertedCoeff_eq_of_vSideRow_incidentForm`.
-This packages the v-side-row incident form (the endpoint-vertex inversion output) into
+This expresses the v-side-row incident form (the endpoint-vertex inversion output) as
 the coefficient-transfer hypothesis of `exists_regionEdgeGauge_of_coeffTransfer`
 (`TNLean.PEPS.RegionBlock.RegionReconcile`), region-injectively.
 

--- a/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
+++ b/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
@@ -276,5 +276,62 @@ theorem regionInsertedCoeff_eq_of_vSideRow_incidentForm (A B : Tensor G d)
     (fun μ ν' => transferCoeff_eq_incidentForm_of_vSideRow_incidentForm
       A B R hRB hCB f hvA hvAout hAB hDim M N hvrow μ ν') σ τ
 
+/-! ### The existential coefficient transfer from the v-side-row incident form
+
+The coefficient transfer `htransfer` (for each inserted matrix `M`, a matrix `N` on
+the other tensor matching the region-inserted coefficients) feeds
+`exists_regionEdgeGauge_of_coeffTransfer` (`TNLean.PEPS.RegionBlock.RegionReconcile`)
+to read off the per-edge gauge. Packaging the v-side-row incident form as an
+existential — for each `M` a bond matrix `N` realizing the v-side row of `M` as the
+incident-matrix coupling of `N` — produces exactly that coefficient transfer,
+region-injectively. The single remaining input is the v-side-row incident form, the
+output of the endpoint-vertex inversion; no single-vertex injectivity is used. -/
+
+open scoped Classical in
+/-- **The existential coefficient transfer from the v-side-row incident form.** If, for
+every inserted matrix `M`, there is a bond matrix `N` on the boundary edge `f` whose
+incident-matrix coupling against the second tensor's region blocked weights reproduces
+the v-side row of `M` at every region physical configuration, then the coefficient
+transfer holds: for every `M` there is an `N` with matching region-inserted
+coefficients at every physical configuration.
+
+Each per-matrix coefficient match is `regionInsertedCoeff_eq_of_vSideRow_incidentForm`.
+This packages the v-side-row incident form (the endpoint-vertex inversion output) into
+the coefficient-transfer hypothesis of `exists_regionEdgeGauge_of_coeffTransfer`
+(`TNLean.PEPS.RegionBlock.RegionReconcile`), region-injectively.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_of_vSideRow_incidentForm (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (hvrow : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+            (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)),
+          vSideRow (G := G) A B R f hvA M σ ν' =
+            ∑ μ : RegionBoundaryConfig (G := G) B R,
+              (if SameAwayFromBond f μ
+                    ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+                  N (μ f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f)
+                else 0) *
+                regionBlockedWeight (G := G) B R μ σ) :
+    ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ := by
+  intro M
+  obtain ⟨N, hN⟩ := hvrow M
+  exact ⟨N, fun σ τ => regionInsertedCoeff_eq_of_vSideRow_incidentForm
+    A B R hRB hCB f hvA hvAout hAB hDim M N hN σ τ⟩
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
+++ b/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
@@ -92,5 +92,52 @@ theorem doubleBlockedResonate (A B : Tensor G d) (R : Finset V)
     (regionInsertedCoeff_eq_region_blockedMap_B A B R f hvAout hAB hDim M τ) σ
   rw [← hv, hσ]
 
+/-! ### The symmetric block read-off of the transfer coefficient
+
+The doubly-inverted transfer coefficient `transferCoeff` is read off the first
+tensor's region-inserted coefficient by inverting the second tensor's region block
+and then its complement block (`vSideRow_eq_region_blockedMap_transferCoeff`,
+`TNLean.PEPS.RegionBlock.Recovery10`). The other order — invert the complement block
+first, through the σ-side row `complSideRow`, then the region block — reads off the
+same transfer coefficient. This is the region analogue of the V=W reconcile
+`resonate_endpoint_coeff_reconcile` (`TNLean.PEPS.InsertionRealization`): the matrix
+read off by inverting one endpoint equals that read off by inverting the other. Both
+orders use only the blocked-region left inverses; neither uses single-vertex
+injectivity. -/
+
+/-- **The σ-side row through the transfer coefficient.** The σ-side row at the region
+boundary configuration `μ`, as a function of the complement physical configuration, is
+the second tensor's complement blocked tensor map applied to the transfer-coefficient
+row `fun ν' => transferCoeff … μ ν'`.
+
+The σ-side row equals the region row `regionRowB` (`regionRowB_eq_complSideRow`,
+`Recovery10`); the region row, as a function of the complement physical configuration,
+is the second tensor's complement blocked tensor map of the transfer coefficient
+(`regionRowB_eq_complement_blockedMap`, `Recovery10`). This is the complement-first
+read-off, mirroring `vSideRow_eq_region_blockedMap_transferCoeff`, and uses no
+single-vertex injectivity.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem complSideRow_eq_complement_blockedMap_transferCoeff (A B : Tensor G d)
+    (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (μ : RegionBoundaryConfig (G := G) B R) :
+    (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        complSideRow (G := G) A B R f hvAout M τ μ) =
+      regionBlockedTensorMap (G := G) B (Finset.univ \ R)
+        (transferCoeff (G := G) A B R hRB hCB f M μ) := by
+  rw [← regionRowB_eq_complement_blockedMap A B R hRB hCB f hvA hAB hDim M μ]
+  funext τ
+  rw [regionRowB_eq_complSideRow A B R hRB f hvAout hAB hDim M τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
+++ b/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
@@ -1,0 +1,43 @@
+import TNLean.PEPS.RegionBlock.RegionReconcile
+import TNLean.PEPS.InsertionRealization
+
+/-!
+# Region resonate inversion: the bond-contracted endpoint-inversion engine
+
+This file ports the resonate inversion of the edge-blocked physical-to-virtual
+recovery (`TNLean.PEPS.InsertionRealization`) to **region granularity**, in the
+region-injective regime. The edge engine inverts the middle block of an
+edge-centered three-site chain (`resonate_middle_inverted`) and the two endpoint
+vertices (`resonate_invert_right_endpoint`, `resonate_invert_left_endpoint`) to
+read a matrix off the resonate identity. The region engine inverts the
+complement block of `R` (resp. the region block) through the blocked-region left
+inverses `regionBlockedLeftInverse B (univ \ R) hCB` / `regionBlockedLeftInverse
+B R hRB` (the residual analogue of the edge middle), and the two endpoint
+vertices through `localLeftInverseAt B hvB` / `localLeftInverseAt B hvBout`.
+
+The boundary edge `f` connects the in-region endpoint
+`regionBoundaryEdgeInVertex R f` and the out-of-region endpoint
+`regionBoundaryEdgeOutVertex R f`; the interior of the region/complement split is
+empty, so the two endpoint blocks are exactly the region block and the complement
+block. The resonate identity input is `region_resonate_identity`
+(`TNLean.PEPS.RegionBlock.Recovery7`), the region analogue of the edge resonate
+identity that `physical_to_virtual_insertion` consumes.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
+++ b/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
@@ -139,5 +139,142 @@ theorem complSideRow_eq_complement_blockedMap_transferCoeff (A B : Tensor G d)
   funext τ
   rw [regionRowB_eq_complSideRow A B R hRB f hvAout hAB hDim M τ]
 
+/-! ### The incident-matrix form of the transfer coefficient from the v-side row
+
+The remaining endpoint inversion of the region resonate step is the read-off of a
+single bond matrix `N` from the v-side row: the v-side row of `M` is the
+incident-matrix coupling of `N` on the boundary edge `f` against the second tensor's
+region blocked weights. Given that read-off (the hypothesis `hvrow` below, the region
+analogue of the conclusion of `resonate_invert_right_endpoint`), the transfer
+coefficient inherits the incident-matrix coupling form, region-injectively: the
+transfer-coefficient column is the region blocked left inverse of the v-side row
+(`transferCoeff_column_eq_regionBlockedLeftInverse_vSideRow`), and the left inverse
+collapses each blocked weight to its standard basis configuration
+(`regionBlockedLeftInverse_regionBlockedWeight`), reading off the coupling at `μ`.
+
+This is the region-injective replacement for
+`transferCoeff_eq_incidentForm_of_virtualPullback_incidentForm`
+(`TNLean.PEPS.RegionBlock.Recovery11`), which derives the incident form from the
+virtual pullback and so threads single-vertex injectivity through the
+image-preservation realization. The hypothesis here is the v-side-row incident form
+itself, the genuine output of the endpoint-vertex inversion. -/
+
+open scoped Classical in
+/-- **The incident-matrix form of the transfer coefficient from the v-side row.** If
+the v-side row of `M` is, at every region physical configuration `σ`, the
+incident-matrix coupling of a bond matrix `N` on `f` against the second tensor's
+region blocked weights (with the residual legs contracted by the identity), then the
+transfer coefficient has the incident-matrix coupling form of `N` on `f`.
+
+The transfer-coefficient column is the region blocked left inverse of the v-side row
+(`transferCoeff_column_eq_regionBlockedLeftInverse_vSideRow`, `Recovery11`); the
+hypothesis writes the v-side row as the region blocked tensor map of the
+incident-matrix coupling column, so the left inverse recovers the column
+(`regionBlockedLeftInverse_apply_regionBlockedTensorMap`). This uses only the
+blocked-region left inverses, no single-vertex injectivity, replacing
+`transferCoeff_eq_incidentForm_of_virtualPullback_incidentForm` (`Recovery11`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem transferCoeff_eq_incidentForm_of_vSideRow_incidentForm (A B : Tensor G d)
+    (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hvrow : ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)),
+      vSideRow (G := G) A B R f hvA M σ ν' =
+        ∑ μ : RegionBoundaryConfig (G := G) B R,
+          (if SameAwayFromBond f μ
+                ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+              N (μ f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f) else 0) *
+            regionBlockedWeight (G := G) B R μ σ)
+    (μ : RegionBoundaryConfig (G := G) B R)
+    (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)) :
+    transferCoeff (G := G) A B R hRB hCB f M μ ν' =
+      (if SameAwayFromBond f μ
+            ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+          N (μ f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f) else 0) := by
+  classical
+  have hcol := congrFun
+    (transferCoeff_column_eq_regionBlockedLeftInverse_vSideRow
+      A B R hRB hCB f hvA hvAout hAB hDim M ν') μ
+  rw [hcol]
+  -- The v-side row is the region blocked tensor map of the incident-matrix coupling column.
+  have hmap : (fun σ : RegionPhysicalConfig (V := V) (d := d) R =>
+        vSideRow (G := G) A B R f hvA M σ ν') =
+      regionBlockedTensorMap (G := G) B R
+        (fun μ' : RegionBoundaryConfig (G := G) B R =>
+          (if SameAwayFromBond f μ'
+                ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+              N (μ' f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f)
+            else 0)) := by
+    funext σ
+    rw [hvrow σ ν', regionBlockedTensorMap_apply]
+    refine Finset.sum_congr rfl (fun μ' _ => ?_)
+    rw [smul_eq_mul]
+  rw [hmap, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
+/-! ### The coefficient transfer from the v-side-row incident form
+
+Composing the incident-matrix form of the transfer coefficient
+(`transferCoeff_eq_incidentForm_of_vSideRow_incidentForm`) with the double
+factorization bridge `regionInsertedCoeff_eq_of_transferCoeff_form`
+(`TNLean.PEPS.RegionBlock.Recovery10`) closes the coefficient transfer
+region-injectively: the first tensor's region-inserted coefficient of `M` equals the
+second tensor's of `N` at every physical configuration. The only input is the
+v-side-row incident form, the output of the endpoint-vertex inversion; no
+single-vertex injectivity is used. -/
+
+open scoped Classical in
+/-- **The coefficient transfer from the v-side-row incident form.** If the v-side row
+of `M` is the incident-matrix coupling of a bond matrix `N` on `f` against the second
+tensor's region blocked weights at every region physical configuration, then the first
+tensor's region-inserted coefficient of `M` equals the second tensor's of `N` at every
+physical configuration.
+
+The transfer coefficient has the incident-matrix coupling form of `N`
+(`transferCoeff_eq_incidentForm_of_vSideRow_incidentForm`); the double factorization
+bridge `regionInsertedCoeff_eq_of_transferCoeff_form` then matches the coefficients.
+This is region-injective: it inverts only the second tensor's blocks, never the single
+endpoint vertex.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_of_vSideRow_incidentForm (A B : Tensor G d)
+    (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hvrow : ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)),
+      vSideRow (G := G) A B R f hvA M σ ν' =
+        ∑ μ : RegionBoundaryConfig (G := G) B R,
+          (if SameAwayFromBond f μ
+                ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+              N (μ f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f) else 0) *
+            regionBlockedWeight (G := G) B R μ σ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ :=
+  regionInsertedCoeff_eq_of_transferCoeff_form A B R hRB hCB f hvA hvAout hAB hDim M N
+    (fun μ ν' => transferCoeff_eq_incidentForm_of_vSideRow_incidentForm
+      A B R hRB hCB f hvA hvAout hAB hDim M N hvrow μ ν') σ τ
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
+++ b/TNLean/PEPS/RegionBlock/RegionResonateInvert.lean
@@ -39,5 +39,58 @@ namespace PEPS
 variable {V : Type*} [Fintype V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 
+/-! ### The doubly-blocked resonate identity
+
+The region analogue of the edge resonate identity `hEq` that
+`physical_to_virtual_insertion` (`TNLean.PEPS.InsertionRealization`) consumes. The
+first tensor's region-inserted coefficient of `M` factors through the second
+tensor's *complement* block (with row the v-side row `vSideRow`,
+`regionInsertedCoeff_eq_complement_blockedMap_vSideRow`) and, equally, through the
+second tensor's *region* block (with row the σ-side row `complSideRow`,
+`regionInsertedCoeff_eq_region_blockedMap_B`). Equating the two readings gives the
+doubly-blocked resonate identity: the second tensor's complement blocked tensor map
+of the v-side row equals its region blocked tensor map of the σ-side row, for every
+physical configuration.
+
+This identity reads the two tensors only through the `SameState`-invariant
+region-inserted coefficient and uses no single-vertex injectivity. The two endpoint
+blocks of `B` it equates are exactly the region and complement blocks; inverting
+them (through the blocked-region left inverses) is the residual analogue of stripping
+the edge middle, and is the starting point of the region resonate inversion. -/
+
+/-- **The doubly-blocked resonate identity.** The second tensor's complement blocked
+tensor map of the v-side row of `M`, evaluated at the complement physical
+configuration `τ`, equals the second tensor's region blocked tensor map of the σ-side
+row of `M`, evaluated at the region physical configuration `σ`.
+
+Both sides equal the first tensor's region-inserted coefficient of `M`: the left side
+by the v-side factorization
+`regionInsertedCoeff_eq_complement_blockedMap_vSideRow`, the right side by the σ-side
+factorization `regionInsertedCoeff_eq_region_blockedMap_B`. It is the region analogue
+of the edge resonate identity, expressed through the second tensor's two endpoint
+blocks, and uses no single-vertex injectivity.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem doubleBlockedResonate (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionBlockedTensorMap (G := G) B (Finset.univ \ R)
+        (vSideRow (G := G) A B R f hvA M σ) τ =
+      regionBlockedTensorMap (G := G) B R
+        (complSideRow (G := G) A B R f hvAout M τ) σ := by
+  have hv := congrFun
+    (regionInsertedCoeff_eq_complement_blockedMap_vSideRow A B R f hvA hAB hDim M σ) τ
+  have hσ := congrFun
+    (regionInsertedCoeff_eq_region_blockedMap_B A B R f hvAout hAB hDim M τ) σ
+  rw [← hv, hσ]
+
 end PEPS
 end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -832,6 +832,55 @@ reuse the injective edge-insertion route rather than duplicate it. The
 translationally invariant gauge absorption and the scalar condition remain the
 final steps of the normal theorem.
 
+\section{The vertex-frame obstruction and the block-frame route}
+
+The region insertion machinery formalized so far inserts the comparison matrix
+at the \emph{in-region endpoint vertex} $v$ of the boundary edge $f$ and
+realizes it through $v$'s tensor (\path{regionInsertionOp}). With this frame the
+coefficient transfer reduces cleanly to a single residual-frame statement: the
+$v$-side row of the first tensor is of single-bond insertion form
+(\path{coeffTransfer_of_vSideRow_incidentForm}). Every step of that reduction uses
+only blocked-region injectivity of the region and its complement
+(\path{regionInsertedCoeff_eq_of_vSideRow_incidentForm},
+\path{transferCoeff_eq_incidentForm_of_vSideRow_incidentForm},
+\path{doubleBlockedResonate}, \path{complSideRow_eq_complement_blockedMap_transferCoeff}).
+
+The remaining $v$-side row statement, however, does not close under blocked-region
+injectivity alone. Discharging it evaluates the first tensor's endpoint operator,
+which factors as
+$\Phi^A_v \circ (\text{incident insertion}) \circ \Psi^A_v$ with $\Psi^A_v$ a left
+inverse of $\Phi^A_v=\path{localTensorMap}\ A\ v$, on the \emph{second} tensor's
+region weight vectors. This requires the cross-tensor endpoint image inclusion
+$\operatorname{range}(\Phi^B_v)\subseteq\operatorname{range}(\Phi^A_v)$, i.e.\ the
+two single-vertex tensor images at $v$ coincide. That coincidence is available only
+from single-vertex spanning (\path{span_stateOpenCoeff_eq_top}, derived from
+\path{vertexComplementTensorInjective_of_isVertexInjective}), which is genuine
+\emph{vertex} injectivity. Blocked-region injectivity is linear independence of the
+blocked weight family indexed by boundary configurations; for a region with more
+than one site it does not force the single-vertex marginal at $v$ to be injective,
+and two tensors with the same global state can have distinct $v$-column spaces. The
+disanalogy with the edge argument is structural: the edge resonate identity is
+single-tensor (the abstract operators act on one family's components), whereas the
+region resonate identity reads the first tensor's operator on the second tensor's
+vectors, introducing a cross-tensor image mismatch absent at the edge level.
+
+Hence the vertex-endpoint frame closes only the \emph{vertex-injective}
+specialization, where the injective Fundamental Theorem already supplies the gauge
+(\path{fundamentalTheorem_normalPEPS_of_vertexInjective}). The source's actual
+argument is block-framed: the injective blocks play the role of super-sites, and the
+insertion is realized on the \emph{block's} open boundary leg through the blocked
+tensor, so the image-preservation step becomes the block-level range coincidence
+$\operatorname{range}(\text{blocked map of }A)=\operatorname{range}(\text{blocked map of }B)$,
+which is provable from blocked-region injectivity together with the same-state
+hypothesis (the blocked-weight analogue of
+\path{range_localTensorMap_eq_of_sameState}). The conditional chain from the
+coefficient transfer to the per-edge gauge is already block-injective-clean
+(\path{exists_regionEdgeGauge_of_coeffTransfer}, no single-vertex injectivity), so a
+block-framed proof of the coefficient transfer feeds it directly. The block-framed
+realization---a block-leg insertion operator with its own block-level resonate
+inversion---is the genuine remaining obligation for the general region-injective
+theorem and the recommended next development.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
## What

Advances the general (region-injective) **Normal PEPS Fundamental Theorem** (#1373,
arXiv:1804.04964 §3) and records the precise architectural boundary of the
vertex-endpoint frame. New files `TNLean/PEPS/RegionBlock/RegionReconcile.lean` and
`RegionResonateInvert.lean`. All declarations sorry-free, `#print axioms` =
`[propext, Classical.choice, Quot.sound]`, **no `IsVertexInjective`** anywhere in the
new chain — only `RegionBlockedTensorInjective`.

## Landed (region-injective, block-injective-clean)

- **The conditional chain `★ ⟹ per-edge gauge`** (`exists_regionEdgeGauge_of_coeffTransfer`):
  given the coefficient transfer `★` (`∀M ∃N, regionInsertedCoeff A M = regionInsertedCoeff B N`,
  both directions) plus multiplicativity, the forward per-edge transfer on a boundary edge is
  conjugation by an invertible gauge — built from `regionInsertionTransfer_of_coeffTransfer` +
  `exists_regionEdgeGauge_of_transfer`. **No single-vertex injectivity.**
- **Both block inversions** (`coeffTransfer_of_endpointOp_eq`, `regionInsertedCoeff_eq_of_regionRow_eq`)
  and the **region resonate identity + V=W reconcile** (`doubleBlockedResonate`,
  `complSideRow_eq_complement_blockedMap_transferCoeff`), which reduce `★` to a single
  residual-frame statement: the v-side row is of single-bond insertion form
  (`coeffTransfer_of_vSideRow_incidentForm`).

## The architectural boundary (documented, not a defect)

The reduction above is block-injective-clean, but the **final v-side-row statement does not close
under block-injectivity alone**: discharging it evaluates the first tensor's endpoint-*vertex*
operator on the second tensor's vectors, which needs cross-tensor image preservation at the vertex,
`range(localTensorMap A v) = range(localTensorMap B v)` — available only from single-vertex spanning
(`span_stateOpenCoeff_eq_top`), i.e. genuine **vertex** injectivity. For |R|>1 the boundary vertex
isn't injective, so the vertex-endpoint frame closes only the vertex-injective specialization (already
done via `fundamentalTheorem_normalPEPS_of_vertexInjective`).

The source's argument is **block-framed**: realize the insertion on the *block's* open leg through the
blocked tensor, making the image-preservation step the block-level range coincidence (provable from
block-injectivity + SameState). The conditional chain here feeds a block-framed `★` directly. Full
analysis + the recommended next development in `docs/paper-gaps/peps_normal_ft_section3_route.tex`
(new §"The vertex-frame obstruction and the block-frame route").

Refs #1373. CI `blueprint-and-prose`/`track`/`build` failures are non-blocking automation (cf. merged #2491).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation on the PEPS normal-FT track; no runtime, auth, or data-path changes. Residual mathematical obligations (multiplicativity, block-framed coefficient transfer) remain explicit hypotheses.
> 
> **Overview**
> Adds **region-injective** Lean infrastructure for the normal PEPS §3 route: two new modules are exported from `TNLean.lean` and prove sorry-free lemmas that use only **`RegionBlockedTensorInjective`**, not `IsVertexInjective`.
> 
> **`RegionReconcile.lean`** rewrites complement rows as in-region endpoint operators, reduces coefficient transfer to endpoint-operator agreement (`coeffTransfer_of_endpointOp_eq`) and σ-side region-row matching (`regionInsertedCoeff_eq_of_regionRow_eq`), and builds **`coeffTransferMap` → `regionInsertionTransfer_of_coeffTransfer` → `exists_regionEdgeGauge_of_coeffTransfer`** so bidirectional coefficient transfer plus multiplicativity yields per-edge gauge conjugation without vertex injectivity (multiplicativity still assumed).
> 
> **`RegionResonateInvert.lean`** adds the doubly-blocked resonate identity (`doubleBlockedResonate`), complement-first transfer read-off (`complSideRow_eq_complement_blockedMap_transferCoeff`), incident-matrix transfer coefficients from a v-side-row hypothesis (replacing the virtual-pullback path that needed vertex spanning), and closes **`coeffTransfer_of_vSideRow_incidentForm`** as the existential coefficient-transfer input to the gauge chain.
> 
> **`peps_normal_ft_section3_route.tex`** gains a section explaining why the **vertex-endpoint** v-side-row step needs cross-tensor single-vertex image coincidence, while the **block-framed** route and the new conditional gauge chain are the intended path for the general region-injective theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a8c6f2bebaeb447452ac53c5d581ee3a59aee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->