### PR TITLE
feat(MPS/MPDO): formalize the ZCL counterexample witness

### DIFF
--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.RFP.Defs
 
 /-!
@@ -100,5 +101,114 @@ semidefinite operator at every system size (via `IsLPDO.isMPDO`). -/
 theorem IsLocalPurificationRFP.isMPDO {M : MPOTensor d D}
     (h : IsLocalPurificationRFP M) : IsMPDO M :=
   h.isLPDO.isMPDO
+
+/-! ## A local purification-RFP tensor that is not ZCL
+
+The local purification-RFP condition does not imply the literal zero-correlation
+length condition `MPOTensor.IsZCL` (`E_M ∘ E_M = E_M`). The witness below is the
+diagonal purification at `d = d_K = 2`, `D = D' = 1`, `A = [1/√2, 0, 0, 1/√2]`:
+its purifying tensor is a pure-state renormalization fixed point, yet the ancilla
+trace contraction halves the leading eigenvalue, so the induced transfer map is
+`½ • id` and idempotence fails. See
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. -/
+
+/-- Scalar amplitudes of the diagonal purifying tensor: `1/√2` on the diagonal. -/
+noncomputable def wa (i k : Fin 2) : ℂ := if i = k then (Real.sqrt 2)⁻¹ else 0
+
+/-- The diagonal purifying tensor `A^{(i,k)}` at inner bond dimension `D' = 1`. -/
+noncomputable def witnessA : Fin 2 → Fin 2 → Matrix (Fin 1) (Fin 1) ℂ :=
+  fun i k => Matrix.of (fun _ _ => wa i k)
+
+/-- The combined spin-ancilla MPS tensor on `Fin (2 * 2)`. -/
+noncomputable def witnessAcombined : MPSTensor (2 * 2) 1 :=
+  fun p => witnessA p.divNat p.modNat
+
+/-- The ancilla-contracted MPO tensor `M^{ij}` at `D = D' = 1`. -/
+noncomputable def witnessM : MPOTensor 2 1 :=
+  fun i j => (∑ k : Fin 2,
+    (witnessA i k) ⊗ₖ ((witnessA j k).map (starRingEnd ℂ))).submatrix
+      ⇑(finProdFinEquiv (m := 1) (n := 1)).symm ⇑(finProdFinEquiv (m := 1) (n := 1)).symm
+
+private lemma sqrt2_inv_mul_self :
+    ((Real.sqrt 2 : ℂ))⁻¹ * ((Real.sqrt 2 : ℂ))⁻¹ = (2⁻¹ : ℂ) := by
+  rw [← mul_inv, ← Complex.ofReal_mul, Real.mul_self_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+  norm_num
+
+/-- The single entry of the contracted MPO tensor: `M^{ij} = ½` if `i = j`, else `0`. -/
+lemma witnessM_entry (i j : Fin 2) :
+    witnessM i j 0 0 = if i = j then (2⁻¹ : ℂ) else 0 := by
+  have wa_mul_conj : ∀ a b c : Fin 2,
+      wa a c * (starRingEnd ℂ) (wa b c) = if a = c ∧ b = c then (2⁻¹ : ℂ) else 0 := by
+    intro a b c
+    by_cases hac : a = c
+    · by_cases hbc : b = c
+      · rw [if_pos ⟨hac, hbc⟩]
+        simp only [wa, if_pos hac, if_pos hbc, map_inv₀, Complex.conj_ofReal]
+        exact sqrt2_inv_mul_self
+      · rw [if_neg (fun h => hbc h.2)]
+        simp only [wa, if_neg hbc, map_zero, mul_zero]
+    · rw [if_neg (fun h => hac h.1)]
+      simp only [wa, if_neg hac, zero_mul]
+  simp only [witnessM, Matrix.submatrix_apply, witnessA, Fin.sum_univ_two]
+  fin_cases i <;> fin_cases j <;> simp [wa_mul_conj]
+
+/-- A `1 × 1` triple matrix product evaluates entrywise. -/
+private lemma mul_triple_one (A B C : Matrix (Fin 1) (Fin 1) ℂ) (i j : Fin 1) :
+    (A * B * C) i j = A 0 0 * B 0 0 * C 0 0 := by
+  fin_cases i; fin_cases j; simp [Matrix.mul_apply]
+
+/-- The transfer map of the witness MPO is `½ • id`: its leading eigenvalue is `½`,
+not `1`, reflecting the maximally mixed reduced state. -/
+lemma transferMap_witnessM :
+    transferMap witnessM = (2⁻¹ : ℂ) • LinearMap.id := by
+  refine LinearMap.ext fun X => ?_
+  ext a b
+  obtain rfl : a = 0 := Subsingleton.elim a 0
+  obtain rfl : b = 0 := Subsingleton.elim b 0
+  rw [transferMap_apply]
+  simp only [Matrix.sum_apply, Fin.sum_univ_two, Matrix.add_apply, mul_triple_one,
+    Matrix.conjTranspose_apply, witnessM_entry, LinearMap.smul_apply, LinearMap.id_apply,
+    Matrix.smul_apply, smul_eq_mul]
+  simp only [Fin.reduceEq, ↓reduceIte, star_zero, mul_zero, zero_mul, add_zero,
+    show star (2⁻¹ : ℂ) = 2⁻¹ from by simp]
+  ring
+
+/-- The combined spin-ancilla tensor is a pure-state RFP: its transfer map is the
+identity, since the amplitudes satisfy `∑ |A|² = 1`. -/
+lemma witnessAcombined_isRFP : MPSTensor.IsRFP witnessAcombined := by
+  have h : MPSTensor.transferMap witnessAcombined = LinearMap.id := by
+    refine LinearMap.ext fun X => ?_
+    ext a b
+    obtain rfl : a = 0 := Subsingleton.elim a 0
+    obtain rfl : b = 0 := Subsingleton.elim b 0
+    rw [MPSTensor.transferMap_apply, Matrix.sum_apply, Fin.sum_univ_four]
+    have e0 : (0 : Fin (2 * 2)).divNat = 0 ∧ (0 : Fin (2 * 2)).modNat = 0 := by decide
+    have e1 : (1 : Fin (2 * 2)).divNat = 0 ∧ (1 : Fin (2 * 2)).modNat = 1 := by decide
+    have e2 : (2 : Fin (2 * 2)).divNat = 1 ∧ (2 : Fin (2 * 2)).modNat = 0 := by decide
+    have e3 : (3 : Fin (2 * 2)).divNat = 1 ∧ (3 : Fin (2 * 2)).modNat = 1 := by decide
+    simp only [mul_triple_one, Matrix.conjTranspose_apply, witnessAcombined, witnessA,
+      Matrix.of_apply, LinearMap.id_apply, e0.1, e0.2, e1.1, e1.2, e2.1, e2.2, e3.1, e3.2, wa,
+      Fin.reduceEq, ↓reduceIte, zero_mul, add_zero,
+      ← starRingEnd_apply, map_inv₀, Complex.conj_ofReal]
+    linear_combination (2 * X 0 0) * sqrt2_inv_mul_self
+  rw [MPSTensor.IsRFP, h, LinearMap.comp_id]
+
+/-- **The local purification-RFP condition is strictly weaker than zero-correlation
+length.** There is an MPO tensor satisfying `IsLocalPurificationRFP` whose literal
+transfer-map idempotence `E_M ∘ E_M = E_M` fails, because the purification's trace
+contraction drops the leading eigenvalue below `1`. This is the canonical-form
+deviation documented in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. -/
+theorem exists_isLocalPurificationRFP_not_isZCL :
+    ∃ M : MPOTensor 2 1, IsLocalPurificationRFP M ∧ ¬ IsZCL M := by
+  refine ⟨witnessM, ⟨2, 1, witnessA, (finProdFinEquiv (m := 1) (n := 1)).symm, fun _ _ => rfl,
+    witnessAcombined_isRFP⟩, ?_⟩
+  intro hZCL
+  rw [IsZCL, transferMap_witnessM] at hZCL
+  have hfun := LinearMap.congr_fun hZCL (1 : Matrix (Fin 1) (Fin 1) ℂ)
+  have hc := congrFun (congrFun hfun 0) 0
+  simp only [LinearMap.comp_apply, LinearMap.smul_apply, LinearMap.id_apply, smul_smul,
+    Matrix.smul_apply, Matrix.one_apply, ↓reduceIte] at hc
+  norm_num at hc
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -39,13 +39,13 @@ after the transfer operator is normalized so that its leading eigenvalue is `1`.
 The literal condition here is faithful only for such normalized representatives.
 For a general representative it is strictly stronger, since it forces the leading
 eigenvalue to equal `1`, whereas the source ZCL is invariant under the rescaling
-`E_M ↦ λ E_M`. The deviation is illustrated by the rescaled purification
-`d = dK = 2`, `D = 1`, `A = [1/√2, 0, 0, 1/√2]`: it satisfies the local
+`E_M ↦ λ E_M`. The deviation is witnessed by
+`MPOTensor.exists_isLocalPurificationRFP_not_isZCL`: the rescaled purification
+`d = dK = 2`, `D = 1`, `A = [1/√2, 0, 0, 1/√2]` satisfies the local
 purification-RFP condition, yet its transfer map is `½ • id`, so
 `E_M ∘ E_M = ¼ • id ≠ E_M`; the trace contraction in the purification has dropped
-the leading eigenvalue from `1` to `½`. (This counterexample is not yet
-formalized.) The faithful (normalized) ZCL and the source's equivalence between
-PRFP and ZCL remain open. Recorded in
+the leading eigenvalue from `1` to `½`. The faithful (normalized) ZCL and the
+source's equivalence between PRFP and ZCL remain open. Recorded in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 
 See arXiv:1606.00608, lines 735–739 (and the canonical-form characterization at

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -355,6 +355,28 @@ legs cyclically and taking the resulting trace.
     follows from Theorem~\ref{thm:lpdo_is_mpdo}.
 \end{proof}
 
+\begin{theorem}[Local purification RFP does not imply zero correlation length]
+    \label{thm:local_purification_rfp_not_zcl}
+    \lean{MPOTensor.exists_isLocalPurificationRFP_not_isZCL}
+    \leanok
+    \uses{def:is_local_purification_rfp, def:mpo_is_zcl}
+    There is an MPO tensor satisfying the local purification RFP condition for
+    which the literal transfer-map idempotence $\E_M\circ\E_M=\E_M$ fails.
+\end{theorem}
+
+\begin{proof}\leanok
+    Take the diagonal purification at $d=d_K=2$ and $D=D'=1$ with amplitudes
+    $A=[\tfrac{1}{\sqrt2},0,0,\tfrac{1}{\sqrt2}]$. The purifying tensor is a
+    pure-state renormalization fixed point, since $\sum|A|^2=1$ makes its transfer
+    map the identity. Contracting the ancilla gives the scalar entries
+    $M^{00}=M^{11}=\tfrac12$ (off-diagonal $0$), so the induced transfer map is
+    $\tfrac12\cdot\mathrm{id}$ and $\E_M\circ\E_M=\tfrac14\cdot\mathrm{id}\neq\E_M$.
+    The trace contraction has dropped the leading eigenvalue from $1$ to
+    $\tfrac12$; the literal zero-correlation-length condition is therefore strictly
+    stronger than the source's normalized one. See
+    \path{docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex}.
+\end{proof}
+
 \section{Pure-state recovery inside the MPO formalism}
 
 \begin{definition}[MPO transfer-map idempotence]\label{def:is_rfp_mpdo}

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -50,8 +50,8 @@ forces the leading eigenvalue to be exactly $1$, whereas the source's ZCL is the
 \emph{normalized} (peripheral) idempotence, invariant under rescaling $E_M\mapsto
 \lambda E_M$.
 
-This deviation is illustrated by the following construction (a counterexample
-recorded here but not yet formalized in the development). Take $d=d_K=2$,
+This deviation is witnessed in the development by
+\texttt{MPOTensor.exists\_isLocalPurificationRFP\_not\_isZCL}. Take $d=d_K=2$,
 $D'=D=1$, $A=[\tfrac{1}{\sqrt2},0,0,\tfrac{1}{\sqrt2}]$, which is an RFP MPS tensor
 ($E_A=\mathrm{id}$). The induced MPDO tensor has scalar entries
 $M^{00}=M^{11}=\tfrac12$, off-diagonal $0$, so $\rho^{(N)}(M)=(\tfrac12)^N I$ is


### PR DESCRIPTION
## Summary

Turns the phantom reference corrected in #2522 into a **real theorem**. `MPOTensor.exists_isLocalPurificationRFP_not_isZCL` (in `LocalPurificationRFP.lean`) proves there is an MPO tensor satisfying the local purification-RFP condition that does **not** satisfy the literal zero-correlation-length condition `IsZCL` (`E_M ∘ E_M = E_M`).

This substantiates the `IsZCL` canonical-form **scope-restriction** marker (from #2491): the literal idempotence is strictly stronger than the source's *normalized* ZCL, because the purification's trace contraction can drop the leading eigenvalue below 1.

## The construction

The diagonal purification at `d = dK = 2`, `D = D' = 1`, `A = [1/√2, 0, 0, 1/√2]`:
- `witnessAcombined_isRFP`: the purifying tensor is a pure-state RFP — `∑|A|² = 1` makes its transfer map the identity.
- `transferMap_witnessM`: contracting the ancilla gives scalar entries `M^{00}=M^{11}=½` (off-diagonal `0`), so the induced transfer map is `½•id`, hence `E_M∘E_M = ¼•id ≠ E_M`.

All scalar / `1×1`-matrix arithmetic; no `sorry`, no new axioms.

## Doc updates

- `IsZCL` docstring and the paper-gap note `cpsv16_zcl_canonical_form_normalization.tex` now **cite the witness lemma** instead of describing it as unformalized.
- Added `import TNLean.MPS.MPDO.ZCL` to `LocalPurificationRFP.lean` (no cycle — `ZCL` does not import `LocalPurificationRFP`).
- Blueprint: `thm:local_purification_rfp_not_zcl` (ch02b_mpdo).

## Verification

- `lake build TNLean.MPS.MPDO.LocalPurificationRFP` ✓ (no warnings)
- `lake exe lint-style` clean on both files; no `sorry`/`axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds self-contained Lean proofs and documentation only; no changes to core `IsZCL` semantics or runtime behavior.
> 
> **Overview**
> Formalizes the diagonal purification counterexample that **local purification-RFP does not imply literal `IsZCL`**: new witness `witnessM` at `d = 2`, `D = 1` with lemmas showing the purifying tensor is an MPS RFP while the MPO transfer map is `½ • id`, so `E_M ∘ E_M ≠ E_M`. Main theorem **`MPOTensor.exists_isLocalPurificationRFP_not_isZCL`** closes the gap noted in the `IsZCL` scope-restriction docs.
> 
> Adds **`import TNLean.MPS.MPDO.ZCL`** to `LocalPurificationRFP.lean` (for `IsZCL` in the existence proof). **`IsZCL`** docstring and **`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`** now point at the witness instead of calling it unformalized. Blueprint **`thm:local_purification_rfp_not_zcl`** in `ch02b_mpdo.tex` links to the Lean theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7890ae9395b33037ff4f2f91a516d3ac6350ba0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->