### PR TITLE
refactor(MPS/MPDO): address review feedback on ZCL witness

### DIFF
--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -51,6 +51,10 @@ pure-state RFP.
   LPDO witness.
 * `MPOTensor.IsLocalPurificationRFP.isMPDO`: the local condition generates
   matrix product density operators.
+* `MPOTensor.exists_isLocalPurificationRFP_not_isZCL`: the local condition is
+  strictly weaker than the literal zero-correlation-length condition `IsZCL`,
+  witnessed by a diagonal purification whose ancilla contraction halves the
+  leading eigenvalue.
 
 ## References
 
@@ -113,11 +117,11 @@ trace contraction halves the leading eigenvalue, so the induced transfer map is
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. -/
 
 /-- Scalar amplitudes of the diagonal purifying tensor: `1/√2` on the diagonal. -/
-noncomputable def wa (i k : Fin 2) : ℂ := if i = k then (Real.sqrt 2)⁻¹ else 0
+noncomputable def witnessAmplitude (i k : Fin 2) : ℂ := if i = k then (Real.sqrt 2)⁻¹ else 0
 
 /-- The diagonal purifying tensor `A^{(i,k)}` at inner bond dimension `D' = 1`. -/
 noncomputable def witnessA : Fin 2 → Fin 2 → Matrix (Fin 1) (Fin 1) ℂ :=
-  fun i k => Matrix.of (fun _ _ => wa i k)
+  fun i k => Matrix.of (fun _ _ => witnessAmplitude i k)
 
 /-- The combined spin-ancilla MPS tensor on `Fin (2 * 2)`. -/
 noncomputable def witnessAcombined : MPSTensor (2 * 2) 1 :=
@@ -137,20 +141,21 @@ private lemma sqrt2_inv_mul_self :
 /-- The single entry of the contracted MPO tensor: `M^{ij} = ½` if `i = j`, else `0`. -/
 lemma witnessM_entry (i j : Fin 2) :
     witnessM i j 0 0 = if i = j then (2⁻¹ : ℂ) else 0 := by
-  have wa_mul_conj : ∀ a b c : Fin 2,
-      wa a c * (starRingEnd ℂ) (wa b c) = if a = c ∧ b = c then (2⁻¹ : ℂ) else 0 := by
+  have amp_mul_conj : ∀ a b c : Fin 2,
+      witnessAmplitude a c * (starRingEnd ℂ) (witnessAmplitude b c)
+        = if a = c ∧ b = c then (2⁻¹ : ℂ) else 0 := by
     intro a b c
     by_cases hac : a = c
     · by_cases hbc : b = c
       · rw [if_pos ⟨hac, hbc⟩]
-        simp only [wa, if_pos hac, if_pos hbc, map_inv₀, Complex.conj_ofReal]
+        simp only [witnessAmplitude, if_pos hac, if_pos hbc, map_inv₀, Complex.conj_ofReal]
         exact sqrt2_inv_mul_self
       · rw [if_neg (fun h => hbc h.2)]
-        simp only [wa, if_neg hbc, map_zero, mul_zero]
+        simp only [witnessAmplitude, if_neg hbc, map_zero, mul_zero]
     · rw [if_neg (fun h => hac h.1)]
-      simp only [wa, if_neg hac, zero_mul]
+      simp only [witnessAmplitude, if_neg hac, zero_mul]
   simp only [witnessM, Matrix.submatrix_apply, witnessA, Fin.sum_univ_two]
-  fin_cases i <;> fin_cases j <;> simp [wa_mul_conj]
+  fin_cases i <;> fin_cases j <;> simp [amp_mul_conj]
 
 /-- A `1 × 1` triple matrix product evaluates entrywise. -/
 private lemma mul_triple_one (A B C : Matrix (Fin 1) (Fin 1) ℂ) (i j : Fin 1) :
@@ -187,8 +192,8 @@ lemma witnessAcombined_isRFP : MPSTensor.IsRFP witnessAcombined := by
     have e2 : (2 : Fin (2 * 2)).divNat = 1 ∧ (2 : Fin (2 * 2)).modNat = 0 := by decide
     have e3 : (3 : Fin (2 * 2)).divNat = 1 ∧ (3 : Fin (2 * 2)).modNat = 1 := by decide
     simp only [mul_triple_one, Matrix.conjTranspose_apply, witnessAcombined, witnessA,
-      Matrix.of_apply, LinearMap.id_apply, e0.1, e0.2, e1.1, e1.2, e2.1, e2.2, e3.1, e3.2, wa,
-      Fin.reduceEq, ↓reduceIte, zero_mul, add_zero,
+      Matrix.of_apply, LinearMap.id_apply, e0.1, e0.2, e1.1, e1.2, e2.1, e2.2, e3.1, e3.2,
+      witnessAmplitude, Fin.reduceEq, ↓reduceIte, zero_mul, add_zero,
       ← starRingEnd_apply, map_inv₀, Complex.conj_ofReal]
     linear_combination (2 * X 0 0) * sqrt2_inv_mul_self
   rw [MPSTensor.IsRFP, h, LinearMap.comp_id]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -364,17 +364,21 @@ legs cyclically and taking the resulting trace.
     which the literal transfer-map idempotence $\E_M\circ\E_M=\E_M$ fails.
 \end{theorem}
 
+% Counterexample analysed in docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex.
 \begin{proof}\leanok
     Take the diagonal purification at $d=d_K=2$ and $D=D'=1$ with amplitudes
     $A=[\tfrac{1}{\sqrt2},0,0,\tfrac{1}{\sqrt2}]$. The purifying tensor is a
     pure-state renormalization fixed point, since $\sum|A|^2=1$ makes its transfer
-    map the identity. Contracting the ancilla gives the scalar entries
-    $M^{00}=M^{11}=\tfrac12$ (off-diagonal $0$), so the induced transfer map is
-    $\tfrac12\cdot\mathrm{id}$ and $\E_M\circ\E_M=\tfrac14\cdot\mathrm{id}\neq\E_M$.
-    The trace contraction has dropped the leading eigenvalue from $1$ to
-    $\tfrac12$; the literal zero-correlation-length condition is therefore strictly
-    stronger than the source's normalized one. See
-    \path{docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex}.
+    map the identity. The ancilla contraction
+    \[
+        M^{ij}=\sum_k A^{(i,k)}\,\overline{A^{(j,k)}}
+    \]
+    gives the scalar entries $M^{00}=M^{11}=\tfrac12$ (off-diagonal $0$), so the
+    induced transfer map is $\tfrac12\cdot\mathrm{id}$ and
+    $\E_M\circ\E_M=\tfrac14\cdot\mathrm{id}\neq\E_M$. The trace contraction has
+    dropped the leading eigenvalue from $1$ to $\tfrac12$; the literal
+    zero-correlation-length condition is therefore strictly stronger than the
+    source's normalized one.
 \end{proof}
 
 \section{Pure-state recovery inside the MPO formalism}


### PR DESCRIPTION
Follow-up to #2526, addressing the 4 polish issues from its review (the review confirmed the math is correct and blocker-free; these are quality fixes only):

1. **Rename** the cryptic public `noncomputable def wa` → `witnessAmplitude` (and the local helper `wa_mul_conj` → `amp_mul_conj`).
2. **Module docstring** now lists `exists_isLocalPurificationRFP_not_isZCL` under Main results.
3. **Blueprint** (`ch02b_mpdo`): display the ancilla-contraction identity `M^{ij} = ∑_k A^{(i,k)} conj(A^{(j,k)})` explicitly in the proof (per the tensor-network style guideline).
4. **Blueprint**: move the `docs/paper-gaps/...` pointer out of displayed proof text into a LaTeX comment.

No proof/behavioral change. `lake build` ✓, `lake exe lint-style` clean, no `sorry`/`axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and naming only; proofs and formal behavior are unchanged.
> 
> **Overview**
> Polish-only follow-up on the local purification RFP vs. ZCL witness: no proof or behavioral changes.
> 
> In **`LocalPurificationRFP.lean`**, the public witness helper `wa` is renamed to **`witnessAmplitude`** (and the local lemma helper `wa_mul_conj` → **`amp_mul_conj`**), with all dependent proofs updated. The module docstring now lists **`exists_isLocalPurificationRFP_not_isZCL`** under **Main results**.
> 
> In the blueprint **`ch02b_mpdo.tex`**, the proof of “local purification RFP does not imply ZCL” now displays the ancilla-contraction identity \(M^{ij}=\sum_k A^{(i,k)}\overline{A^{(j,k)}}\) explicitly; the pointer to `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex` is moved from the proof body into a LaTeX comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f484e1278e978a5bc9ee69609229f30d1f419e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->