### PR TITLE
refactor(MPS/MPDO): drop deprecated Fin.coe_cast and dead simp args

### DIFF
--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -143,8 +143,7 @@ theorem mpv_comp_finRotate_pow (A : MPSTensor d D) {N : ℕ} (p : ℕ) (σ : Fin
 theorem blockReindexEquiv_symm_apply {N L : ℕ} (hL : L ≤ N) (c : Fin (L + (N - L)) → Fin d) :
     (MPOTensor.blockReindexEquiv d N L hL).symm c
       = c ∘ Fin.cast (by omega : N = L + (N - L)) := by
-  simp only [MPOTensor.blockReindexEquiv, Equiv.arrowCongr_symm, Equiv.refl_symm,
-    Equiv.arrowCongr_apply, Equiv.coe_refl, finCongr_symm, finCongr_apply]
+  simp only [MPOTensor.blockReindexEquiv, Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
   rfl
 
 /-- The mpv with the kept block last (complement form) equals the mpv with it
@@ -169,7 +168,7 @@ theorem schmidt_swap (A : MPSTensor d D) {N L : ℕ} (hL : L ≤ N)
             ((finRotate N : Fin N → Fin N)^[L] j)
           = Fin.natAdd L ⟨j.val, hj⟩ := by
         apply Fin.ext
-        rw [Fin.coe_cast, coe_finRotate_pow, Nat.mod_eq_of_lt (by omega)]
+        rw [Fin.val_cast, coe_finRotate_pow, Nat.mod_eq_of_lt (by omega)]
         simp; omega
       rw [hL2, hR2, Fin.append_left, Fin.append_right]
     · have hL2 : Fin.cast (show N = (N - L) + (N - (N - L)) by omega) j
@@ -178,7 +177,7 @@ theorem schmidt_swap (A : MPSTensor d D) {N L : ℕ} (hL : L ≤ N)
             ((finRotate N : Fin N → Fin N)^[L] j)
           = Fin.castAdd (N - L) ⟨j.val - (N - L), by omega⟩ := by
         apply Fin.ext
-        rw [Fin.coe_cast, coe_finRotate_pow, Nat.mod_eq_sub_mod (by omega),
+        rw [Fin.val_cast, coe_finRotate_pow, Nat.mod_eq_sub_mod (by omega),
           Nat.mod_eq_of_lt (by omega)]
         simp; omega
       rw [hL2, hR2, Fin.append_right, Fin.append_left, Function.comp_apply]


### PR DESCRIPTION
Small maintenance cleanup in `PureAreaLaw.lean` (part of the loop's periodic-refactor pass):

- Replace deprecated `Fin.coe_cast` → `Fin.val_cast` (2 sites in `schmidt_swap`) — removes toolchain-bump breakage risk.
- Drop 3 unused simp arguments (`Equiv.arrowCongr_apply`, `Equiv.coe_refl`, `finCongr_apply`) from `blockReindexEquiv_symm_apply`.

No proof/statement change. `lake build` ✓ (warning-free at these sites), `lake exe lint-style` clean, no `sorry`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local proof-script edits only; no API or behavioral changes to the formalized results.
> 
> **Overview**
> Proof-only maintenance in **`PureAreaLaw.lean`**: no theorem statements or mathematical content change.
> 
> In **`schmidt_swap`**, two rewrites now use **`Fin.val_cast`** instead of the deprecated **`Fin.coe_cast`**, so the proof stays aligned with current Mathlib naming and avoids future toolchain breakage.
> 
> In **`blockReindexEquiv_symm_apply`**, the **`simp only`** list is trimmed by dropping three lemmas that were not needed for the proof (**`Equiv.arrowCongr_apply`**, **`Equiv.coe_refl`**, **`finCongr_apply`**); the proof still ends with **`rfl`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a11335e3282a5fede02161614755682ae0dbc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->