### PR TITLE
doc(parent): align PGVWC block-separation prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -6,10 +6,15 @@ import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 
 /-!
-# Periodic constraints in the BNT block-diagonal range
+# PGVWC block-diagonal propagation for parent-Hamiltonian local spaces
 
-This file combines the normalized BNT direct-sum intersection identity with the
-block-diagonal periodic propagation lemma used in PGVWC07, Theorem 2blocks.2.
+This file combines the normalized BNT block-separation hypotheses with the
+PGVWC07 one-step identity
+\[
+  \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1},
+  \qquad S_M=\bigvee_jG_M(A_j),
+\]
+as used in PGVWC07, Theorem 2blocks.2.
 -/
 
 open scoped Matrix BigOperators
@@ -18,14 +23,15 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- The normalized BNT direct-sum hypotheses imply the periodic local constraints
-of a block-diagonal tensor lie in the linear sum of the block ground spaces.
+/-- The normalized BNT block-separation hypotheses imply that the periodic chain
+space of a block-diagonal tensor lies in the linear sum of the block local
+spaces.
 
 Let
 \[
   B=\bigoplus_j\mu_jA_j,\qquad S_M=\bigvee_jG_M(A_j).
 \]
-Assume the normalized BNT direct-sum hypotheses give the PGVWC one-step
+Assume the normalized BNT block-separation hypotheses give the PGVWC one-step
 recursion in the range
 \[
   M>L_0+(r-1)(L_0+(L_0+L_0)).
@@ -34,7 +40,7 @@ Then, for every \(N\ge L\) in that range,
 \[
   \mathcal G_{N,L}(B)\subseteq S_N.
 \]
-This is the inclusion into \(S_N\) in PGVWC07, Theorem `2blocks.2`
+This is the inclusion into \(S_N\) in PGVWC07, Theorem 2blocks.2
 (arXiv:quant-ph/0608197, proof lines 1430--1456). The component extraction
 needed to replace \(S_N\) by the sum of periodic block ground spaces is a
 separate step. -/
@@ -70,14 +76,14 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
 
-/-- The normalized BNT direct-sum hypotheses give the periodic constraint
-inclusion into the block image-space sum, and this sum is internal.
+/-- The normalized BNT block-separation hypotheses give the periodic-chain
+inclusion into \(S_N\), and \(S_N\) is a direct sum of local block spaces.
 
 Let
 \[
   B=\bigoplus_j\mu_jA_j,\qquad S_N=\bigvee_jG_N(A_j).
 \]
-In the BNT range used in PGVWC07, Theorem 2blocks.2
+At the lengths used in PGVWC07, Theorem 2blocks.2
 (arXiv:quant-ph/0608197, proof lines 1430--1456), one has
 \[
   \mathcal G_{N,L}(B)\subseteq S_N,

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -6,7 +6,7 @@ import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 
 /-!
-# PGVWC block-diagonal propagation for parent-Hamiltonian local spaces
+# Block-diagonal propagation for parent-Hamiltonian local spaces
 
 This file combines the normalized BNT block-separation hypotheses with the
 PGVWC07 one-step identity

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -6,15 +6,15 @@ import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
 
 /-!
-# BNT direct-sum input for block intersections
+# BNT block-separation hypotheses for PGVWC block intersections
 
-This file connects the already-injective BNT direct-sum product span to the
+This file connects the already-injective BNT block-separation product span to the
 PGVWC07 one-step block-intersection identity.
 
 ## References
 
-* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12 and Lemma
-  `lem:direct-sum`.
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12 and the
+  direct-sum lemma used there.
 -/
 
 open scoped Matrix BigOperators
@@ -23,15 +23,15 @@ namespace MPSTensor
 
 variable {d L : ℕ}
 
-/-- Already-injective BNT direct-sum data give the PGVWC one-step
+/-- Already-injective BNT block-separation conditions give the PGVWC one-step
 block-intersection identity at the resulting product-span length.
 
 The internal word length is
 \[
   n=L+(r-1)(L+(L+L)).
 \]
-At this length the direct-sum theorem supplies the common blockwise word span
-required in the PGVWC07 restriction-intersection argument. -/
+At this length the block-separation theorem supplies the common blockwise word
+span required in the PGVWC07 restriction-intersection argument. -/
 theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -92,8 +92,8 @@ theorem wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSe
     omega
   rwa [hlen] at hSpan
 
-/-- BNT direct-sum data and PGVWC07 normalization give the simultaneous product
-span at every length above the BNT block-separation bound.
+/-- BNT block-separation conditions and PGVWC07 normalization give the
+simultaneous product span at every length above the BNT block-separation bound.
 
 With \(S=L+(L+L)\), the conclusion is
 \[
@@ -125,8 +125,8 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital
   exact wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords
     A hBlk hUnital hPair (by simpa [S] using hn)
 
-/-- In the normalized BNT range supplied by the direct-sum input, the block image
-spaces form an internal direct sum.
+/-- Under the normalized BNT block-separation hypotheses, the local spaces
+\(G_n(A^j)\) form an internal direct sum.
 
 Let \(S=L+(L+L)\).  If \(n\ge L+(r-1)S\), then
 \[
@@ -151,7 +151,7 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
 
-/-- BNT direct-sum data and PGVWC07 normalization give the one-step
+/-- BNT block-separation conditions and PGVWC07 normalization give the one-step
 block-intersection identity at every length above the BNT block-separation
 bound.
 
@@ -189,8 +189,8 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
     hUnital
 
-/-- Normalized BNT input gives the large-length block intersection as an
-internal direct sum.
+/-- Normalized BNT block-separation hypotheses give the large-length block
+intersection as an internal direct sum.
 
 For \(S=L+(L+L)\), if \(n\ge L+(r-1)S\), then the sums
 \[
@@ -199,7 +199,7 @@ For \(S=L+(L+L)\), if \(n\ge L+(r-1)S\), then the sums
   \bigvee_jG_{n+2}(A^j)
 \]
 are internal direct sums, and the PGVWC one-step intersection identity holds
-with these block image spaces:
+with these local spaces:
 \[
   \left(\bigcap_b\operatorname{Res}_{-,b}^{-1}
     \bigvee_jG_{n+1}(A^j)\right)
@@ -244,7 +244,7 @@ Let
 \[
   S=L+(L+L),\qquad q=(r-1)S.
 \]
-The BNT direct-sum hypotheses give equations that separate each ordered pair of
+The BNT block-separation hypotheses give equations that separate each ordered pair of
 blocks at length \(S\). If the individual blocks are injective at a positive
 length \(p\) and throughout a complete window of \(p+q\) consecutive lengths,
 then the simultaneous block-word tuples span the full product algebra in a
@@ -294,7 +294,7 @@ theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_period
   exact pgvwc07_iSup_restriction_intersection_eventually_of_period_window
     A hPeriodPos hPeriodSpan hWindowSpan hUnital
 
-/-- BNT direct-sum input and the PGVWC07 normalization give the eventual
+/-- BNT block-separation hypotheses and the PGVWC07 normalization give the eventual
 block-intersection identity without separately assuming a higher-length
 block-injectivity window.
 

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -216,7 +216,7 @@ theorem pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace
   exact Submodule.mem_iSup_of_mem j
     (pgvwc07LeftBoundaryComponent_mem_groundSpace (A j) (C j) (E j) n (hACE j))
 
-/-- A common product span makes the block image spaces an internal direct sum.
+/-- A common product span makes the local block spaces an internal direct sum.
 
 Suppose
 \[
@@ -653,7 +653,7 @@ then \(S_{n+1}\) and \(\bigvee_jG_{n+2}(A^j)\) are internal direct sums, and
   \bigvee_jG_{n+2}(A^j).
 \]
 This is the one-step PGVWC07 block-intersection formula together with the
-directness needed to read the joins as direct sums of block image spaces. -/
+directness needed to read the joins as direct sums of local block spaces. -/
 theorem pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -4993,7 +4993,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \uses{lem:three_block_trace_reduction_nonzero_middle}
     Under the hypotheses of
     Lemma~\ref{lem:three_block_trace_reduction_nonzero_middle}, the length-$L$
-    image spaces satisfy
+    spaces \(\mathcal G_L^A\) and \(\mathcal G_L^B\) satisfy
     \[
         \mathcal G_L^A \subseteq \mathcal G_L^B.
     \]
@@ -5054,15 +5054,16 @@ formulation; the passage to $\ker H_N$ is kept separate.
     equality whenever the ordering \(D_B\le D_A\) is available. If the
     inclusion comes from the strictly larger block, $D_B<D_A$, then the same
     dimension step already contradicts the existence of the three-block trace
-    relation. More generally, if an external source input rules out the
+    relation. More generally, if an external source hypothesis rules out the
     simultaneous conclusion $D_A=D_B$ and
     $\mathcal G_L^A=\mathcal G_L^B$, then the three-block local spaces
     $\mathcal G_{3L}^A$ and $\mathcal G_{3L}^B$ have zero intersection.
     With injectivity at the three-block length, the strict-size branch itself
     already gives homogeneous pair trace separation at length $3L$.
-    One such source input is non-proportionality of the periodic MPS vectors
+    One such source hypothesis is non-proportionality of the periodic MPS vectors
     at a sufficiently long chain length, equivalently distinctness of the
-    corresponding spaces $\mathbb C\,V^{(N)}(A)$: equality of the local image spaces gives
+    corresponding spaces $\mathbb C\,V^{(N)}(A)$: equality
+    \(\mathcal G_L^A=\mathcal G_L^B\) gives
     equality of the periodic-chain constraint spaces, and injective uniqueness
     identifies those spaces with the two one-dimensional MPS spans. For same-dimensional
     separated BNT blocks, the non-equivalence condition supplies such
@@ -5095,14 +5096,14 @@ formulation; the passage to $\ker H_N$ is kept separate.
     $\dim\mathcal G_L^A=D_A^2$ and $\dim\mathcal G_L^B=D_B^2$.
     Inclusion gives $D_A^2\le D_B^2$, while $D_B\le D_A$ gives the
     reverse inequality. Hence $D_A=D_B$, and equality of dimensions inside
-    the inclusion gives equality of the image spaces. In the strict-size
+    the inclusion gives \(\mathcal G_L^A=\mathcal G_L^B\). In the strict-size
     branch this contradicts $D_B<D_A$. For the conditional directness
     statement, a vector in the intersection of the two three-block local spaces
     has two boundary representations. If the first boundary matrix is zero,
     the vector is zero. Otherwise the difference of the two coefficient
     formulas is exactly the homogeneous three-block trace relation, so the
     dimension step gives the forbidden collapse. In the equal-size branch,
-    equal local image spaces impose the same cyclic local constraints on a
+    equal local spaces impose the same cyclic local constraints on a
     periodic chain. The injective uniqueness theorem then identifies both
     cyclic ground spaces with the spans of their MPV states, contradicting
     non-proportionality of those states.
@@ -5228,7 +5229,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     homogeneous pair spans, then the simultaneous identity pair lies in all
     sufficiently large homogeneous pair spans. Combined with all-length pair
     trace separation, this period-window input gives one homogeneous
-    pair trace-separation length. This does not prove the direct-sum input of
+    pair trace-separation length. This does not prove the block-separation
+    span condition of
     \cite{PerezGarcia2007Matrix} by itself: fullness of spans up to a
     bounded length is weaker than the exact homogeneous input used here.
 \end{lemma}
@@ -5428,7 +5430,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     multiply the pairwise equations into the full equations.
 \end{proof}
 
-\begin{lemma}[BNT direct-sum input gives a finite blockwise product span]
+\begin{lemma}[BNT block separation gives a finite blockwise product span]
     \label{lem:bnt_direct_sum_block_separation_word_span}
     \lean{MPSTensor.hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv}
     \lean{MPSTensor.propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum}
@@ -5841,7 +5843,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     gives the displayed subspace equality.
 \end{proof}
 
-\begin{lemma}[BNT direct-sum input gives one block-intersection step]
+\begin{lemma}[BNT block separation gives one block-intersection step]
     \label{lem:bnt_direct_sum_block_separation_block_intersection}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors}
     \leanok
@@ -5882,7 +5884,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     normalization, gives the stated subspace equality.
 \end{proof}
 
-\begin{lemma}[BNT direct-sum input with a block-injectivity window]
+\begin{lemma}[BNT block separation with a block-injectivity window]
     \label{lem:bnt_direct_sum_block_separation_period_window_block_intersection}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_period_window}
     \leanok
@@ -5925,7 +5927,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \leanok
-    The direct-sum input gives, for each ordered pair of distinct blocks,
+    The block-separation conditions give, for each ordered pair of distinct blocks,
     length-\(S\) equations which are the identity on the first block and zero on
     the second. Multiplying these equations over the \(r-1\) other blocks gives
     a block-separating equation of total length \(q\). Combining this equation

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -195,8 +195,9 @@ from this one-step identity.
 
 The live blueprint records that larger source statement in source notation,
 without claiming that it is proved.\footnote{Blueprint locations:
-\path{def:parent_hamiltonian_ground_space_bnt} for the block-sum chain ground
-space, \path{lem:isup_chain_ground_space_block_le_assembled} for the forward
+\path{def:parent_hamiltonian_ground_space_bnt} for the block-diagonal
+periodic-chain ground space,
+\path{lem:isup_chain_ground_space_block_le_assembled} for the forward
 inclusion, \path{thm:block_diagonal_ground_space_intersection} for the
 PGVWC07 block-diagonal intersection identity,
 \path{thm:parent_ground_space_le_bnt_span} for the parent-ground-space


### PR DESCRIPTION
## Summary
- replace reader-facing "direct-sum input" / "image-space" wording around the PGVWC block-intersection route by block-separation and local-space terminology
- state the relevant PGVWC propagation identity in equations:
  \[
    \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1},\qquad
    S_M=\bigvee_jG_M(A_j)
  \]
- adjust the parent-Hamiltonian blueprint and paper-gap note so the current #905 status is described without blueprint-label prose

Refs #905.

## Verification
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain TNLean.MPS.ParentHamiltonian.BNTBlockIntersection TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty`
- `lake build TNLean`
- `leanblueprint web`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- targeted scan for removed phrases: no matches

`python3 scripts/blueprint_lean_sync.py --root . --ci` still reports pre-existing non-parent issues in `ch13a_peps_ft.tex` and `ch04a_channel_representations.tex`; `lake exe checkdecls blueprint/lean_decls` correspondingly stops on the existing `...` placeholder. The parent-Hamiltonian chapter reports 423/423 in the generated sync report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation only; no Mathlib or proof logic changes.
> 
> **Overview**
> **Documentation-only** alignment of reader-facing PGVWC parent-Hamiltonian prose: **“direct-sum input”** and **“image-space”** wording is replaced by **block-separation hypotheses** and **local spaces** (\(G_n(A^j)\), \(S_M=\bigvee_j G_M(A_j)\)) in Lean module docstrings and theorem comments (`BNTBlockDiagonalChain`, `BNTBlockIntersection`, `BlockIntersectionProperty`).
> 
> `BNTBlockDiagonalChain` now states the PGVWC one-step propagation identity in equations and retitles the file topic to block-diagonal propagation for local spaces. Matching edits land in `ch14_parent_hamiltonian.tex` (lemma titles and proof prose) and `cpgsv21_block_diagonal_parent_ground_space.tex` (gap-note terminology). **Lean theorem names and proofs are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c5ff3eee67d8674415e51f15f924b3c45bce4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->