### PR TITLE
feat(MPS/MPDO): diagonal/doubled MPV bridge toward Prop IV.12

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -77,6 +77,20 @@ def FirstSiteActionAgree (A : MPSTensor d D)
     ∑ i : Fin d, Y (σ 0) i * MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ)) =
       ∑ i : Fin d, Z (σ 0) i * MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ))
 
+/-- Evaluating a reindexed word: `evalWord B (l.map g) = evalWord (B ∘ g) l`. -/
+lemma evalWord_map {d' : ℕ} (B : MPSTensor d' D) (g : Fin d → Fin d') (l : List (Fin d)) :
+    evalWord B (l.map g) = evalWord (fun i => B (g i)) l := by
+  induction l with
+  | nil => rfl
+  | cons a t ih => simp only [List.map_cons, evalWord_cons, ih]
+
+/-- Reindexing the physical legs of an MPV: composing the tensor with `g : Fin d → Fin d'`
+on the inside equals composing the configuration with `g` on the outside. -/
+lemma mpv_comp_reindex {d' : ℕ} (B : MPSTensor d' D) (g : Fin d → Fin d')
+    {N : ℕ} (σ : Fin N → Fin d) :
+    mpv (fun i => B (g i)) σ = mpv B (fun k => g (σ k)) := by
+  simp only [mpv, coeff, List.ofFn_comp' σ g, evalWord_map]
+
 end MPSTensor
 
 namespace MPOTensor
@@ -92,6 +106,30 @@ def diagonalTensor (M : MPOTensor d D) : MPSTensor d D :=
 @[simp] lemma diagonalTensor_apply (M : MPOTensor d D) (i : Fin d) :
     diagonalTensor M i = M i i :=
   rfl
+
+/-- The diagonal tensor is the doubled-index tensor restricted to the diagonal pair
+`(i, i)`: `diagonalTensor M i = M.toMPSTensor (finProdFinEquiv (i, i))`. -/
+theorem diagonalTensor_apply_eq (M : MPOTensor d D) (i : Fin d) :
+    diagonalTensor M i = M.toMPSTensor (finProdFinEquiv (i, i)) := by
+  have h : ((finProdFinEquiv (i, i) : Fin (d * d)).divNat,
+      (finProdFinEquiv (i, i) : Fin (d * d)).modNat) = (i, i) :=
+    finProdFinEquiv.symm_apply_apply (i, i)
+  have hd : (finProdFinEquiv (i, i) : Fin (d * d)).divNat = i := congrArg Prod.fst h
+  have hm : (finProdFinEquiv (i, i) : Fin (d * d)).modNat = i := congrArg Prod.snd h
+  simp only [diagonalTensor_apply, toMPSTensor]
+  rw [hd, hm]
+
+/-- **Diagonal/doubled MPV bridge.** The MPV of the diagonal tensor at a configuration
+`σ` equals the MPV of the doubled-index tensor at the diagonal-paired configuration
+`k ↦ (σ k, σ k)`. This lets the horizontal canonical form of `M.toMPSTensor` (which
+constrains all `Fin (d*d)` configurations) be specialized to the diagonal
+configurations seen by `diagonalTensor M` — the first step of Proposition IV.12. -/
+theorem mpv_diagonalTensor (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) :
+    MPSTensor.mpv (diagonalTensor M) σ
+      = MPSTensor.mpv M.toMPSTensor (fun k => finProdFinEquiv (σ k, σ k)) := by
+  have htensor : diagonalTensor M = fun i => M.toMPSTensor (finProdFinEquiv (i, i)) :=
+    funext (diagonalTensor_apply_eq M)
+  rw [htensor, MPSTensor.mpv_comp_reindex M.toMPSTensor (fun i => finProdFinEquiv (i, i))]
 
 /-- The vertical transfer map of an MPO tensor:
 `E_vert(X) = Σ_i M^{ii} X (M^{ii})†`. -/

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -972,17 +972,33 @@ strong subadditivity for a normalized three-site reduced state.
     equality of the two first-site insertions.
 \end{proof}
 
+\begin{lemma}[Diagonal matrix-product-vector bridge]
+    \label{lem:mpv_diagonal_tensor}
+    \lean{MPOTensor.mpv_diagonalTensor}
+    \leanok
+    \uses{def:mpo_to_mps}
+    For an MPO tensor $M$ and a configuration $\sigma$, the matrix product vector of
+    the diagonal tensor $i\mapsto M^{ii}$ equals the matrix product vector of the
+    doubled-index tensor evaluated on the diagonal-paired configuration
+    $k\mapsto(\sigma_k,\sigma_k)$.
+\end{lemma}
+\begin{proof}\leanok
+    At site value $i$ the diagonal tensor is $M^{ii}$, which is the doubled-index
+    tensor at the paired index $(i,i)$. Reindexing the physical legs of the matrix
+    product vector accordingly gives the claim.
+\end{proof}
+
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
-        lem:blockwise_insert_eq_of_mpv_agree}
+        lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor}
     Every MPDO in horizontal canonical form is also in vertical canonical form.
 \end{theorem}
 
 \begin{proof}
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
-        lem:blockwise_insert_eq_of_mpv_agree}
+        lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor}
     Starting from the horizontal canonical-form decomposition, one uses the MPDO
     positivity condition to compare the first-site action of the doubled-index
     tensor on the diagonal sector. Lemma~\ref{lem:blockwise_insert_eq_of_mpv_agree}


### PR DESCRIPTION
First concrete step toward the `\notready` **Prop IV.12/4.13** (`thm:vertical_cf_of_horizontal_cf`, arXiv:1606.00608) — every horizontal-CF MPDO is in vertical CF. (Lemma L, `blockwise_insert_eq_of_mpv_agree`, was already proven; this adds the other ingredient.)

## What this adds

`MPOTensor.mpv_diagonalTensor`: the MPV of the diagonal tensor `i ↦ M^{ii}` equals the MPV of the doubled-index tensor `M.toMPSTensor` on the diagonal-paired configuration `k ↦ (σ k, σ k)`. This is the formal tool for the paper's "compare the first-site action on the diagonal sector" step — it specializes the horizontal CF of `M.toMPSTensor` (which constrains *all* `Fin (d*d)` configs) to the diagonal configs that `diagonalTensor M` sees.

Supporting general, reusable lemmas:
- `MPSTensor.evalWord_map` — `evalWord B (l.map g) = evalWord (B ∘ g) l`
- `MPSTensor.mpv_comp_reindex` — reindexing the physical legs of an MPV
- `MPOTensor.diagonalTensor_apply_eq` — `diagonalTensor M i = M.toMPSTensor (finProdFinEquiv (i,i))`

## Notes

- Purely **additive** — no existing decl changed; nothing downstream affected.
- Blueprint: new `lem:mpv_diagonal_tensor` (`\leanok`), wired into the `\notready` `thm:vertical_cf_of_horizontal_cf` `\uses` so the dependency graph reflects the partial progress.

`lake build TNLean.MPS.MPDO.VerticalCF` ✓, `lake exe lint-style` clean, no `sorry`/`axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive Lean and blueprint entries; no existing APIs or proofs are modified.
> 
> **Overview**
> Adds formal infrastructure toward **horizontal → vertical** canonical form (Prop IV.12): the **diagonal/doubled MPV bridge** `MPOTensor.mpv_diagonalTensor`, which identifies MPVs of `diagonalTensor M` with MPVs of `M.toMPSTensor` on diagonal-paired configurations `k ↦ (σ k, σ k)`.
> 
> Supporting lemmas are new in `VerticalCF.lean`: `MPSTensor.evalWord_map`, `MPSTensor.mpv_comp_reindex`, and `MPOTensor.diagonalTensor_apply_eq` (diagonal entries as `toMPSTensor` at `(i,i)` via `finProdFinEquiv`).
> 
> The blueprint gains **`lem:mpv_diagonal_tensor`** (`\leanok`) and it is listed in the `\uses` of the still-`\notready` **`thm:vertical_cf_of_horizontal_cf`**, so the dependency graph records this partial step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70005b82938f84ec598cb47e3259a048e0e0486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->