### PR TITLE
doc(MPS/MPDO): address prose review on the diagonal MPV lemma

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -119,11 +119,11 @@ theorem diagonalTensor_apply_eq (M : MPOTensor d D) (i : Fin d) :
   simp only [diagonalTensor_apply, toMPSTensor]
   rw [hd, hm]
 
-/-- **Diagonal/doubled MPV bridge.** The MPV of the diagonal tensor at a configuration
-`σ` equals the MPV of the doubled-index tensor at the diagonal-paired configuration
-`k ↦ (σ k, σ k)`. This lets the horizontal canonical form of `M.toMPSTensor` (which
-constrains all `Fin (d*d)` configurations) be specialized to the diagonal
-configurations seen by `diagonalTensor M` — the first step of Proposition IV.12. -/
+/-- **Matrix product vector of the diagonal tensor.** The MPV of the diagonal tensor at
+a configuration `σ` equals the MPV of the doubled-index tensor at the diagonal-paired
+configuration `k ↦ (σ k, σ k)`. This lets the horizontal canonical form of
+`M.toMPSTensor` (which constrains all `Fin (d*d)` configurations) be specialized to the
+diagonal configurations seen by `diagonalTensor M`, the first step of Proposition IV.12. -/
 theorem mpv_diagonalTensor (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) :
     MPSTensor.mpv (diagonalTensor M) σ
       = MPSTensor.mpv M.toMPSTensor (fun k => finProdFinEquiv (σ k, σ k)) := by

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -972,20 +972,30 @@ strong subadditivity for a normalized three-site reduced state.
     equality of the two first-site insertions.
 \end{proof}
 
-\begin{lemma}[Diagonal matrix-product-vector bridge]
+\begin{lemma}[Matrix product vector of the diagonal tensor]
     \label{lem:mpv_diagonal_tensor}
     \lean{MPOTensor.mpv_diagonalTensor}
     \leanok
     \uses{def:mpo_to_mps}
     For an MPO tensor $M$ and a configuration $\sigma$, the matrix product vector of
     the diagonal tensor $i\mapsto M^{ii}$ equals the matrix product vector of the
-    doubled-index tensor evaluated on the diagonal-paired configuration
-    $k\mapsto(\sigma_k,\sigma_k)$.
+    doubled-index tensor $\widehat{M}$ evaluated on the diagonal-paired configuration
+    $k\mapsto(\sigma_k,\sigma_k)$:
+    \[
+        V^{(N)}\bigl(i\mapsto M^{ii}\bigr)(\sigma)
+            = V^{(N)}\bigl(\widehat{M}\bigr)\bigl(k\mapsto(\sigma_k,\sigma_k)\bigr).
+    \]
 \end{lemma}
 \begin{proof}\leanok
-    At site value $i$ the diagonal tensor is $M^{ii}$, which is the doubled-index
-    tensor at the paired index $(i,i)$. Reindexing the physical legs of the matrix
-    product vector accordingly gives the claim.
+    At each site value $i$ the diagonal tensor agrees with the doubled-index tensor
+    on the diagonal pair,
+    \[
+        M^{ii} = \widehat{M}^{\,(i,i)}.
+    \]
+    The matrix product vector is multiplicative over sites, so replacing each factor
+    $M^{\sigma_k\sigma_k}$ by $\widehat{M}^{\,(\sigma_k,\sigma_k)}$ reindexes the
+    configuration from $\sigma$ to $k\mapsto(\sigma_k,\sigma_k)$, which is the stated
+    equality.
 \end{proof}
 
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]


### PR DESCRIPTION
Prose-only follow-up to #2530, addressing its review (which confirmed the math/blueprint↔Lean equivalence was correct):

- **B1/B3**: Drop the banned word "bridge" (prose style §2) from the blueprint lemma title and the Lean docstring header → "Matrix product vector of the diagonal tensor".
- **B2**: Display the site-wise equality `M^{ii} = M̂^{(i,i)}` and the resulting MPV reindexing identity in the blueprint proof, instead of a word-only argument.
- Also removed an em-dash from the docstring.

No Lean statement/proof change. `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX-only edits; no modifications to Lean definitions, theorems, or proofs.
> 
> **Overview**
> **Documentation-only** follow-up on the diagonal-tensor MPV lemma (`mpv_diagonalTensor` / `lem:mpv_diagonal_tensor`): prose and naming aligned with review, with **no change** to Lean statements or proofs.
> 
> The blueprint lemma is retitled from “Diagonal matrix-product-vector bridge” to **“Matrix product vector of the diagonal tensor”** (dropping the banned word “bridge”). The statement now uses \(\widehat{M}\) and displays the MPV reindexing identity explicitly. The proof spells out the site-wise equality \(M^{ii}=\widehat{M}^{(i,i)}\) and the multiplicative-site reindexing argument instead of a one-line reindexing claim.
> 
> The Lean docstring for `mpv_diagonalTensor` is updated to the same header wording and drops an em-dash; the theorem body is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80001e50f3bf0ae9e55feeac6ffb00ae04182bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->