### PR TITLE
feat(parent): add block chain ground-space inclusion

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
@@ -19,6 +19,43 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+/-- The periodic chain ground space of a single block is contained in the
+periodic chain ground space of the block-diagonal tensor.
+
+For every cyclic window, the local identity
+\[
+  G_L\!\left(\bigoplus_k\mu_kA_k\right)=\bigvee_kG_L(A_k)
+\]
+sends \(G_L(A_j)\) into the local ground space of the direct-sum tensor. -/
+theorem chainGroundSpace_block_le_toTensorFromBlocks
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {j : Fin r} (hμj : μ j ≠ 0)
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) :
+    chainGroundSpace (A j) L N ≤
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N := by
+  classical
+  intro ψ hψ
+  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ ⊢
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ ⊢
+  intro i τ
+  have hlocal : groundSpace (A j) L ≤
+      groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L := by
+    exact groundSpace_block_le_toTensorFromBlocks μ A hμj L
+  exact hlocal (hψ i τ)
+
+/-- The sum of the blockwise periodic chain ground spaces is contained in the
+periodic chain ground space of the block-diagonal tensor. -/
+theorem iSup_chainGroundSpace_block_le_toTensorFromBlocks
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) :
+    (⨆ j : Fin r, chainGroundSpace (A j) L N) ≤
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N := by
+  exact iSup_le fun j =>
+    chainGroundSpace_block_le_toTensorFromBlocks μ A (hμ j) hN hLN
+
 /-- Periodic local constraints for a block-diagonal tensor propagate to the
 linear sum of the block ground spaces.
 

--- a/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
@@ -112,6 +112,55 @@ end BlockSumGroundSpace
 
 open BlockSumGroundSpace
 
+/-- One block's local ground space is contained in the local ground space of the
+block-diagonal tensor when that block has nonzero weight.
+
+This is the single-summand direction of the local identity
+\[
+  G_L\!\left(\bigoplus_k\mu_kA_k\right)=\bigvee_kG_L(A_k).
+\] -/
+theorem groundSpace_block_le_toTensorFromBlocks
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {j : Fin r} (hμj : μ j ≠ 0) (L : ℕ) :
+    groundSpace (A j) L ≤ groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L := by
+  classical
+  intro ψ hψ
+  rw [groundSpace, LinearMap.mem_range] at hψ
+  rcases hψ with ⟨X, rfl⟩
+  rw [groundSpace, LinearMap.mem_range]
+  let Yσ : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ :=
+    Matrix.blockDiagonal' fun k : Fin r =>
+      if h : k = j then
+        (by
+          subst k
+          exact ((μ j) ^ L)⁻¹ • X)
+      else
+        0
+  refine ⟨(Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) Yσ, ?_⟩
+  ext σ
+  rw [groundSpaceMap_toTensorFromBlocks_eq_sum_diagonalBlock]
+  rw [Finset.sum_eq_single j]
+  · have hpow : (μ j) ^ L ≠ 0 := pow_ne_zero L hμj
+    have hdiag :
+        diagonalBlock ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) Yσ) j =
+          ((μ j) ^ L)⁻¹ • X := by
+      ext a b
+      simp [diagonalBlock, sigmaDiagonalBlock, Yσ]
+    rw [hdiag]
+    simp only [groundSpaceMap_apply]
+    rw [smul_smul, mul_inv_cancel₀ hpow]
+    simp
+  · intro k _ hkj
+    have hdiag :
+        diagonalBlock ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) Yσ) k = 0 := by
+      ext a b
+      simp [diagonalBlock, sigmaDiagonalBlock, Yσ, hkj]
+    rw [hdiag]
+    simp
+  · intro hj
+    exact (hj (Finset.mem_univ _)).elim
+
 /-- The local ground space of a block-diagonal tensor is the linear sum of the local
 ground spaces of its blocks:
 \[
@@ -137,41 +186,6 @@ theorem groundSpace_toTensorFromBlocks_eq_iSup
     apply Submodule.sum_mem
     intro j _
     exact Submodule.mem_iSup_of_mem j ⟨(μ j) ^ L • diagonalBlock X j, rfl⟩
-  · refine iSup_le ?_
-    intro j ψ hψ
-    rw [groundSpace, LinearMap.mem_range] at hψ
-    rcases hψ with ⟨X, rfl⟩
-    rw [groundSpace, LinearMap.mem_range]
-    let Yσ : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ :=
-      Matrix.blockDiagonal' fun k : Fin r =>
-        if h : k = j then
-          (by
-            subst k
-            exact ((μ j) ^ L)⁻¹ • X)
-        else
-          0
-    refine ⟨(Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) Yσ, ?_⟩
-    ext σ
-    rw [groundSpaceMap_toTensorFromBlocks_eq_sum_diagonalBlock]
-    rw [Finset.sum_eq_single j]
-    · have hpow : (μ j) ^ L ≠ 0 := pow_ne_zero L (hμ j)
-      have hdiag :
-          diagonalBlock ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) Yσ) j =
-            ((μ j) ^ L)⁻¹ • X := by
-        ext a b
-        simp [diagonalBlock, sigmaDiagonalBlock, Yσ]
-      rw [hdiag]
-      simp only [groundSpaceMap_apply]
-      rw [smul_smul, mul_inv_cancel₀ hpow]
-      simp
-    · intro k _ hkj
-      have hdiag :
-          diagonalBlock ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) Yσ) k = 0 := by
-        ext a b
-        simp [diagonalBlock, sigmaDiagonalBlock, Yσ, hkj]
-      rw [hdiag]
-      simp
-    · intro hj
-      exact (hj (Finset.mem_univ j)).elim
+  · exact iSup_le fun j => groundSpace_block_le_toTensorFromBlocks μ A (hμ j) L
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -4751,8 +4751,9 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{lemma}[Inclusion of a block ground space]
     \label{lem:chain_ground_space_block_le_assembled}
-    \notready
-    \uses{def:chain_ground_space}
+    \lean{MPSTensor.chainGroundSpace_block_le_toTensorFromBlocks}
+    \leanok
+    \uses{def:chain_ground_space, lem:local_ground_space_block_le_assembled}
     For each block index $j$ with $\mu_{j} \neq 0$, the chain ground space of the block
     $A_j$ embeds into the chain ground space of the direct-sum tensor:
     \[
@@ -4763,7 +4764,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 \end{lemma}
 
 \begin{proof}
-    \notready
+    \leanok
     The cyclic-window definition of the chain ground space reduces the inclusion to
     the local block-embedding statement that each ground vector of $A_j$ on the
     window of length $L$ lifts to the direct sum by the identity
@@ -4779,7 +4780,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{lemma}[Forward inclusion from the block ground spaces]
     \label{lem:isup_chain_ground_space_block_le_assembled}
-    \notready
+    \lean{MPSTensor.iSup_chainGroundSpace_block_le_toTensorFromBlocks}
+    \leanok
     \uses{def:chain_ground_space, lem:chain_ground_space_block_le_assembled}
     Assume $\mu_{j} \neq 0$ for every block index $j$. The linear sum of the
     blockwise periodic-chain ground spaces is contained in the direct-sum
@@ -4793,7 +4795,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 \end{lemma}
 
 \begin{proof}
-    \notready
+    \leanok
     Take the linear sum of the inclusions
     \[
         \mathcal G_{N,L}(A_j)
@@ -6131,11 +6133,34 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
 \end{proof}
 
+\begin{lemma}[One block in a block-diagonal local ground space]
+    \label{lem:local_ground_space_block_le_assembled}
+    \lean{MPSTensor.groundSpace_block_le_toTensorFromBlocks}
+    \leanok
+    \uses{def:ground_space_parent}
+    Let
+    \[
+        B=\bigoplus_{k=1}^g\mu_kA_k.
+    \]
+    If \(\mu_j\ne0\), then, for every length \(L\),
+    \[
+        G_L(A_j)\subseteq G_L(B).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    A vector in \(G_L(A_j)\) has the form \(\Gamma_L^{A_j}(X)\).  Put
+    \(\mu_j^{-L}X\) in the \(j\)-th diagonal block of a boundary matrix for
+    \(B\) and put zero in every other block.  Applying \(\Gamma_L^B\) gives
+    back \(\Gamma_L^{A_j}(X)\).
+\end{proof}
+
 \begin{lemma}[Local ground space of a block-diagonal tensor]
     \label{lem:block_sum_local_ground_space}
     \lean{MPSTensor.groundSpace_toTensorFromBlocks_eq_iSup}
     \leanok
-    \uses{def:ground_space_parent}
+    \uses{def:ground_space_parent, lem:local_ground_space_block_le_assembled}
     Let
     \[
         B=\bigoplus_{j=1}^g\mu_jA_j,
@@ -6157,11 +6182,9 @@ formulation; the passage to $\ker H_N$ is kept separate.
         =
         \sum_{j=1}^g\Gamma_L^{A_j}(\mu_j^LX_j).
     \]
-    This proves \(G_L(B)\subseteq\bigvee_jG_L(A_j)\). Conversely, for a vector
-    \(\Gamma_L^{A_j}(X)\), place \(\mu_j^{-L}X\) in the \(j\)-th diagonal block
-    and put zero in all other diagonal blocks. Since \(\mu_j\ne0\), applying
-    \(\Gamma_L^B\) gives back \(\Gamma_L^{A_j}(X)\). Hence every \(G_L(A_j)\)
-    lies in \(G_L(B)\), and the displayed equality follows.
+    This proves \(G_L(B)\subseteq\bigvee_jG_L(A_j)\). The reverse inclusion is
+    Lemma~\ref{lem:local_ground_space_block_le_assembled} for each block \(j\).
+    The displayed equality follows.
 \end{proof}
 
 \begin{lemma}[Periodic constraints for a block-diagonal tensor]


### PR DESCRIPTION
## Summary
- prove the local one-block inclusion
  \[
    G_L(A_j)\subseteq G_L\!\left(\bigoplus_k\mu_kA_k\right)
  \]
  under the single hypothesis \(\mu_j\ne0\)
- prove, for each block index \(j\),
  \[
    \mathcal G_{N,L}(A_j)
    \subseteq
    \mathcal G_{N,L}\!\left(\bigoplus_k \mu_k A_k\right)
  \]
  under \(0<N\), \(L\le N\), and \(\mu_j\ne0\)
- prove the corresponding supremum inclusion over all blocks under \(\forall j,\mu_j\ne0\)
- mark the matching parent-Hamiltonian blueprint entries `\leanok`

Refs #905.

## Verification
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace`
- `lake env lean --stdin` with `#check` for the new declarations
- `leanblueprint web`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean` returned no matches

`python3 scripts/blueprint_lean_sync.py --root . --ci` reports `ch14_parent_hamiltonian.tex` at 425/425. The command still exits nonzero because of pre-existing non-parent refs in `ch13a_peps_ft.tex` and `ch04a_channel_representations.tex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Mathlib proofs and blueprint wiring only; no runtime or security-sensitive code.
> 
> **Overview**
> Extracts the **single-block local inclusion** \(G_L(A_j)\subseteq G_L(\bigoplus_k\mu_kA_k)\) into `groundSpace_block_le_toTensorFromBlocks` (block-diagonal boundary matrix with \(\mu_j^{-L}X\) on block \(j\)) and reuses it in `groundSpace_toTensorFromBlocks_eq_iSup` instead of an inline proof.
> 
> Adds **periodic chain** analogues: `chainGroundSpace_block_le_toTensorFromBlocks` (via local inclusion on each cyclic window) and `iSup_chainGroundSpace_block_le_toTensorFromBlocks` (supremum over blocks).
> 
> Updates **ch14 parent-Hamiltonian blueprint**: marks the block and \(\bigvee\) chain-ground-space lemmas `\leanok`, adds `lem:local_ground_space_block_le_assembled`, and points the block-sum local ground-space proof at the new lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a299a90b848c8c3c2adfeaf1f186ed718535bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->