### PR TITLE
feat(MPS/MPDO): diagonal tensor as a block decomposition (Prop IV.12 step 2)

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -91,6 +91,23 @@ lemma mpv_comp_reindex {d' : ℕ} (B : MPSTensor d' D) (g : Fin d → Fin d')
     mpv (fun i => B (g i)) σ = mpv B (fun k => g (σ k)) := by
   simp only [mpv, coeff, List.ofFn_comp' σ g, evalWord_map]
 
+/-- The diagonal restriction of a doubled-index block: `diagBlock B i = B (i, i)`. -/
+def diagBlock {dim : ℕ} (B : MPSTensor (d * d) dim) : MPSTensor d dim :=
+  fun i => B (finProdFinEquiv (i, i))
+
+/-- Evaluating a block-diagonal assembly of doubled-index blocks on a diagonal-paired
+configuration equals evaluating the assembly of the diagonally-restricted blocks on the
+original configuration. -/
+theorem mpv_toTensorFromBlocks_diag {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor (d * d) (dim k))
+    {N : ℕ} (σ : Fin N → Fin d) :
+    mpv (toTensorFromBlocks (d := d * d) (μ := μ) A) (fun k => finProdFinEquiv (σ k, σ k))
+      = mpv (toTensorFromBlocks (d := d) (μ := μ) (fun k => diagBlock (A k))) σ := by
+  rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  congr 1
+  exact (mpv_comp_reindex (A k) (fun i => finProdFinEquiv (i, i)) σ).symm
+
 end MPSTensor
 
 namespace MPOTensor
@@ -130,6 +147,21 @@ theorem mpv_diagonalTensor (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) 
   have htensor : diagonalTensor M = fun i => M.toMPSTensor (finProdFinEquiv (i, i)) :=
     funext (diagonalTensor_apply_eq M)
   rw [htensor, MPSTensor.mpv_comp_reindex M.toMPSTensor (fun i => finProdFinEquiv (i, i))]
+
+/-- Under a horizontal canonical-form decomposition of `M.toMPSTensor`, the diagonal
+tensor of `M` generates the same MPV family as the block-diagonal assembly, on the
+physical index `Fin d`, of the diagonally-restricted blocks. This expresses the diagonal
+tensor as a positive-weight block decomposition, the core content of Proposition IV.12. -/
+theorem mpv_diagonalTensor_eq_blocks (M : MPOTensor d D)
+    {r : ℕ} {dim : Fin r → ℕ} (μ : Fin r → ℂ)
+    (A : (k : Fin r) → MPSTensor (d * d) (dim k))
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor
+      (MPSTensor.toTensorFromBlocks (d := d * d) (μ := μ) A))
+    {N : ℕ} (σ : Fin N → Fin d) :
+    MPSTensor.mpv (diagonalTensor M) σ
+      = MPSTensor.mpv (MPSTensor.toTensorFromBlocks (d := d) (μ := μ)
+          (fun k => MPSTensor.diagBlock (A k))) σ := by
+  rw [mpv_diagonalTensor, hM, MPSTensor.mpv_toTensorFromBlocks_diag]
 
 /-- The vertical transfer map of an MPO tensor:
 `E_vert(X) = Σ_i M^{ii} X (M^{ii})†`. -/

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -998,11 +998,38 @@ strong subadditivity for a normalized three-site reduced state.
     equality.
 \end{proof}
 
+\begin{lemma}[Diagonal tensor as a block decomposition under horizontal form]
+    \label{lem:mpv_diagonal_tensor_eq_blocks}
+    \lean{MPOTensor.mpv_diagonalTensor_eq_blocks}
+    \leanok
+    \uses{lem:mpv_diagonal_tensor, def:horizontal_cf_mpdo}
+    Suppose the doubled-index tensor $\widehat{M}$ shares its matrix product vector
+    family with a block-diagonal assembly $\bigoplus_k \mu_k\, A_k$ of blocks $A_k$ on
+    the doubled index, as in a horizontal canonical form. Then the diagonal tensor of
+    $M$ generates the same matrix product vector family as the block-diagonal assembly
+    $\bigoplus_k \mu_k\, A_k^{\mathrm{diag}}$ on the single-spin index, where
+    $A_k^{\mathrm{diag}}(i) = A_k(i,i)$ is the diagonal restriction of each block:
+    \[
+        V^{(N)}\bigl(i\mapsto M^{ii}\bigr)(\sigma)
+            = V^{(N)}\Bigl(\textstyle\bigoplus_k \mu_k\, A_k^{\mathrm{diag}}\Bigr)(\sigma).
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:mpv_diagonal_tensor}
+    By Lemma~\ref{lem:mpv_diagonal_tensor} the diagonal matrix product vector equals
+    that of $\widehat{M}$ on the diagonal-paired configuration, which by hypothesis
+    equals that of the block-diagonal assembly there. Expanding the assembly as the
+    weighted sum $\sum_k \mu_k^N\, V^{(N)}(A_k)$ and restricting each block to the
+    diagonal pair gives $\sum_k \mu_k^N\, V^{(N)}(A_k^{\mathrm{diag}})$, the matrix
+    product vector of the single-spin block-diagonal assembly.
+\end{proof}
+
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
-        lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor}
+        lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor,
+        lem:mpv_diagonal_tensor_eq_blocks}
     Every MPDO in horizontal canonical form is also in vertical canonical form.
 \end{theorem}
 


### PR DESCRIPTION
Continues the `\notready` **Prop IV.12/4.13** (horizontal→vertical canonical form), building directly on the diagonal-MPV lemma from #2530.

## What this adds

- `MPSTensor.diagBlock` — diagonal restriction `B ↦ (i ↦ B (i,i))` of a doubled-index block.
- `MPSTensor.mpv_toTensorFromBlocks_diag` — a block-diagonal assembly of doubled-index blocks, evaluated on a diagonal-paired configuration, equals the assembly of the diagonally-**restricted** blocks evaluated on the original configuration. (Proof: `mpv_toTensorFromBlocks_eq_sum` + the `mpv_comp_reindex` from #2530.)
- `MPOTensor.mpv_diagonalTensor_eq_blocks` — **the core reduction of Prop IV.12**: under a horizontal canonical form of `M.toMPSTensor`, the diagonal tensor of `M` generates the same MPV family as the single-spin block-diagonal assembly `⊕_k μ_k · A_k^diag`.

So the diagonal tensor is exhibited as a positive-weight block decomposition. The remaining gap to full `IsVerticalCF` is the multiplicity flattening (`finSigmaFinEquiv`) and the BNT-normality of the restricted blocks (which needs Lemma L + Newton-Girard) — the next iterations.

## Notes

- Purely **additive** — no existing decl changed.
- Blueprint: new `lem:mpv_diagonal_tensor_eq_blocks` (`\leanok`), wired into the `\notready` theorem's `\uses`.

`lake build TNLean.MPS.MPDO.VerticalCF` ✓ (warning-free), `lake exe lint-style` clean, no `sorry`/`axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive Mathlib lemmas and blueprint wiring in MPS/MPDO vertical CF; no changes to existing APIs or security-sensitive code.
> 
> **Overview**
> Adds the **second step of Prop IV.12** (horizontal → vertical CF): under a horizontal canonical form of `M.toMPSTensor`, the **diagonal tensor** `i ↦ M^{ii}` has the same MPV family as a **single-spin** block assembly `⊕_k μ_k · diagBlock(A_k)`.
> 
> New Lean in `VerticalCF.lean`: **`MPSTensor.diagBlock`** (restrict doubled-index blocks to `(i,i)`), **`mpv_toTensorFromBlocks_diag`** (diagonal-paired evaluation of a `d×d` block assembly matches evaluating restricted blocks on `σ`, via `mpv_toTensorFromBlocks_eq_sum` and **`mpv_comp_reindex`**), and **`MPOTensor.mpv_diagonalTensor_eq_blocks`** (chains `mpv_diagonalTensor`, `SameMPV₂`, and the diag lemma).
> 
> Blueprint: new **`lem:mpv_diagonal_tensor_eq_blocks`** (`\leanok`, `\lean{MPOTensor.mpv_diagonalTensor_eq_blocks}`) and it is added to the `\uses` of the still-`\notready` **`thm:vertical_cf_of_horizontal_cf`**. Additive only; no existing declarations changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58365b019725d07cb7d82bd7f9c46f5b97493a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->