### PR TITLE
feat(MPS): block-reindexing invariance of the assembly MPV

### DIFF
--- a/TNLean/MPS/SharedInfra/BlockAssembly.lean
+++ b/TNLean/MPS/SharedInfra/BlockAssembly.lean
@@ -69,6 +69,16 @@ theorem mpv_toTensorFromBlocks_eq_sum
   rw [Matrix.trace_blockDiagonal']
   exact Finset.sum_congr rfl fun k _ => by simp [Matrix.trace_smul, hwlen]
 
+/-- The MPV of a block-diagonal assembly is invariant under reindexing the block family
+by an equivalence of the block index. -/
+theorem mpv_toTensorFromBlocks_reindex {r r' : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) (e : Fin r' ≃ Fin r)
+    {N : ℕ} (σ : Fin N → Fin d) :
+    mpv (toTensorFromBlocks (d := d) (μ := μ) A) σ
+      = mpv (toTensorFromBlocks (d := d) (μ := fun k => μ (e k)) (fun k => A (e k))) σ := by
+  rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+  exact (Equiv.sum_comp e (fun k => (μ k) ^ N • mpv (A k) σ)).symm
+
 /-- If a tensor has the same MPV family as a unit-weight block diagonal
 assembly, then each MPV coefficient is the sum of the block coefficients. -/
 theorem mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one


### PR DESCRIPTION
`MPSTensor.mpv_toTensorFromBlocks_reindex`: the MPV of a block-diagonal assembly `⊕_k μ_k A_k` is unchanged when the block family is reindexed by an equivalence `e : Fin r' ≃ Fin r`. Immediate from `mpv_toTensorFromBlocks_eq_sum` + `Equiv.sum_comp`.

General, reusable structural lemma. It's the tool that relates the plain `Fin r`-indexed block form to the multiplicity-flattened (`finSigmaFinEquiv`) form used by `verticalAssembledTensor`, on the path toward Prop IV.12/4.13 (horizontal→vertical canonical form, continuing #2530/#2534).

Lives in `BlockAssembly.lean` next to `mpv_toTensorFromBlocks_eq_sum`. Additive, no `sorry`; `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization only (new theorem next to existing MPV sum lemma); no runtime, auth, or behavioral code changes.
> 
> **Overview**
> Adds **`MPSTensor.mpv_toTensorFromBlocks_reindex`**: the MPV of a block-diagonal assembly `toTensorFromBlocks μ A` is unchanged when blocks are reindexed by an equivalence `e : Fin r' ≃ Fin r` (weights and tensors pulled back along `e`).
> 
> The proof is a two-line rewrite through the existing **`mpv_toTensorFromBlocks_eq_sum`** expansion and **`Equiv.sum_comp`**. The lemma is intended as shared infrastructure for relating plain `Fin r`-indexed block assemblies to multiplicity-flattened forms (e.g. via `finSigmaFinEquiv`) on the path to horizontal→vertical canonical-form results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 658eef7a317e9c2a3772733f75a07c0d063b7f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->