### PR TITLE
feat(MPS/MPDO): diagonal tensor = density-operator diagonal + positivity

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -163,6 +163,32 @@ theorem mpv_diagonalTensor_eq_blocks (M : MPOTensor d D)
           (fun k => MPSTensor.diagBlock (A k))) σ := by
   rw [mpv_diagonalTensor, hM, MPSTensor.mpv_toTensorFromBlocks_diag]
 
+/-- Word evaluation of the diagonal MPS tensor equals the MPO word evaluation with equal
+ket and bra words. -/
+theorem evalWord_diagonalTensor (M : MPOTensor d D) (w : List (Fin d)) :
+    MPSTensor.evalWord (diagonalTensor M) w = evalWord M w w := by
+  induction w with
+  | nil => rfl
+  | cons i t ih =>
+    simp only [MPSTensor.evalWord_cons, evalWord_cons, diagonalTensor_apply, ih]
+
+/-- **The diagonal tensor evaluates the density-operator diagonal.** The matrix product
+vector of the diagonal tensor at a configuration `σ` equals the diagonal entry
+`⟨σ|ρ^{(N)}(M)|σ⟩` of the generated operator. When `M` generates an MPDO this entry is a
+nonnegative real, which is the entry point for the positivity of the vertical weights. -/
+theorem mpv_diagonalTensor_eq_mpo_diag (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) :
+    MPSTensor.mpv (diagonalTensor M) σ = mpo M N σ σ := by
+  simp only [MPSTensor.mpv, MPSTensor.coeff, mpo_apply, mpoMatrixEntry, evalWord_diagonalTensor]
+
+/-- For a tensor generating a positive semidefinite operator, the diagonal-tensor matrix
+product vector is a nonnegative real. This is the positivity that the vertical
+canonical-form weights inherit from the MPDO. -/
+theorem mpv_diagonalTensor_nonneg (M : MPOTensor d D) {N : ℕ}
+    (hM : (mpo M N).PosSemidef) (σ : Fin N → Fin d) :
+    0 ≤ MPSTensor.mpv (diagonalTensor M) σ := by
+  rw [mpv_diagonalTensor_eq_mpo_diag]
+  exact hM.diag_nonneg
+
 /-- The vertical transfer map of an MPO tensor:
 `E_vert(X) = Σ_i M^{ii} X (M^{ii})†`. -/
 noncomputable def verticalTransferMap (M : MPOTensor d D) :

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1024,12 +1024,46 @@ strong subadditivity for a normalized three-site reduced state.
     product vector of the single-spin block-diagonal assembly.
 \end{proof}
 
+\begin{lemma}[Diagonal tensor evaluates the density-operator diagonal]
+    \label{lem:mpv_diagonal_tensor_eq_density}
+    \lean{MPOTensor.mpv_diagonalTensor_eq_mpo_diag}
+    \leanok
+    \uses{def:mpo_family}
+    For an MPO tensor $M$ and a configuration $\sigma$, the matrix product vector of
+    the diagonal tensor equals the diagonal entry of the generated operator,
+    \[
+        V^{(N)}\bigl(i\mapsto M^{ii}\bigr)(\sigma)
+            = \bigl\langle\sigma\,\big|\,\rho^{(N)}(M)\,\big|\,\sigma\bigr\rangle,
+    \]
+    since both equal $\operatorname{tr}\bigl(M^{\sigma_1\sigma_1}\cdots
+    M^{\sigma_N\sigma_N}\bigr)$.
+\end{lemma}
+\begin{proof}\leanok
+    Word evaluation of the diagonal tensor multiplies the matrices
+    $M^{\sigma_k\sigma_k}$, which is exactly the operator word evaluation with equal
+    ket and bra indices; taking the trace gives the diagonal entry.
+\end{proof}
+
+\begin{lemma}[Nonnegativity of the diagonal matrix product vector]
+    \label{lem:mpv_diagonal_tensor_nonneg}
+    \lean{MPOTensor.mpv_diagonalTensor_nonneg}
+    \leanok
+    \uses{lem:mpv_diagonal_tensor_eq_density, def:mpdo}
+    If $\rho^{(N)}(M)$ is positive semidefinite, then
+    $V^{(N)}\bigl(i\mapsto M^{ii}\bigr)(\sigma)\ge 0$ for every configuration
+    $\sigma$.
+\end{lemma}
+\begin{proof}\leanok
+    By the previous lemma the value is a diagonal entry of $\rho^{(N)}(M)$, and the
+    diagonal entries of a positive semidefinite matrix are nonnegative.
+\end{proof}
+
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
         lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor,
-        lem:mpv_diagonal_tensor_eq_blocks}
+        lem:mpv_diagonal_tensor_eq_blocks, lem:mpv_diagonal_tensor_nonneg}
     Every MPDO in horizontal canonical form is also in vertical canonical form.
 \end{theorem}
 


### PR DESCRIPTION
Brings MPDO positivity into the vertical-canonical-form picture, continuing the Prop IV.12/4.13 series (#2530, #2534, #2535):

- `MPOTensor.evalWord_diagonalTensor` — the diagonal MPS tensor's word evaluation equals the MPO word evaluation with equal ket/bra words.
- `MPOTensor.mpv_diagonalTensor_eq_mpo_diag` — **the diagonal-tensor MPV equals the diagonal entry `⟨σ|ρ^{(N)}(M)|σ⟩`** of the generated operator (both `= tr(M^{σ₁σ₁}⋯M^{σₙσₙ})`). This is the link between the vertical/diagonal picture and the density operator.
- `MPOTensor.mpv_diagonalTensor_nonneg` — if `ρ^{(N)}(M)` is positive semidefinite, the diagonal-tensor MPV is a **nonnegative real** (`PosSemidef.diag_nonneg`). This is the positivity the vertical-CF weights inherit from the MPDO — the entry point for the remaining weight-positivity content of Prop IV.12.

Blueprint: `lem:mpv_diagonal_tensor_eq_density`, `lem:mpv_diagonal_tensor_nonneg` (both `\leanok`); the latter wired into the `\notready` theorem's `\uses`.

Additive, no `sorry`; `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Mathlib proofs and blueprint documentation in the MPDO vertical-CF track; no auth, data, or behavioral runtime changes.
> 
> **Overview**
> Adds Lean bridges from the **diagonal MPS tensor** `diagonalTensor M` to the generated density operator: word evaluation matches `evalWord M w w`, the MPV at `σ` equals the diagonal matrix entry `mpo M N σ σ`, and under `(mpo M N).PosSemidef` those MPV values are **nonnegative reals** via `PosSemidef.diag_nonneg`.
> 
> The blueprint gains matching lemmas `lem:mpv_diagonal_tensor_eq_density` and `lem:mpv_diagonal_tensor_nonneg` (both `\leanok`), and the still-`\notready` theorem `thm:vertical_cf_of_horizontal_cf` now **`\uses`** the nonnegativity lemma for the vertical-CF / MPDO positivity thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0120a5d737ee7d9186167a900522f8e0e85947b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->