### PR TITLE
doc(MPS/MPDO): address review on the diagonal-density lemmas

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -174,8 +174,8 @@ theorem evalWord_diagonalTensor (M : MPOTensor d D) (w : List (Fin d)) :
 
 /-- **The diagonal tensor evaluates the density-operator diagonal.** The matrix product
 vector of the diagonal tensor at a configuration `σ` equals the diagonal entry
-`⟨σ|ρ^{(N)}(M)|σ⟩` of the generated operator. When `M` generates an MPDO this entry is a
-nonnegative real, which is the entry point for the positivity of the vertical weights. -/
+⟨σ|ρ^{(N)}(M)|σ⟩ of the generated operator. When `M` generates an MPDO this entry is a
+nonnegative real, which is the source of the positivity of the vertical weights. -/
 theorem mpv_diagonalTensor_eq_mpo_diag (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) :
     MPSTensor.mpv (diagonalTensor M) σ = mpo M N σ σ := by
   simp only [MPSTensor.mpv, MPSTensor.coeff, mpo_apply, mpoMatrixEntry, evalWord_diagonalTensor]

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1024,11 +1024,24 @@ strong subadditivity for a normalized three-site reduced state.
     product vector of the single-spin block-diagonal assembly.
 \end{proof}
 
+\begin{lemma}[Diagonal tensor word evaluation]
+    \label{lem:eval_word_diagonal_tensor}
+    \lean{MPOTensor.evalWord_diagonalTensor}
+    \leanok
+    \uses{def:mpo_eval_word}
+    For any word $w$, the matrix product of the diagonal tensor along $w$ equals the
+    operator word evaluation with equal ket and bra words, since both multiply the
+    matrices $M^{w_k w_k}$ site by site.
+\end{lemma}
+\begin{proof}\leanok
+    By induction on the word.
+\end{proof}
+
 \begin{lemma}[Diagonal tensor evaluates the density-operator diagonal]
     \label{lem:mpv_diagonal_tensor_eq_density}
     \lean{MPOTensor.mpv_diagonalTensor_eq_mpo_diag}
     \leanok
-    \uses{def:mpo_family}
+    \uses{def:mpo_family, lem:eval_word_diagonal_tensor}
     For an MPO tensor $M$ and a configuration $\sigma$, the matrix product vector of
     the diagonal tensor equals the diagonal entry of the generated operator,
     \[
@@ -1039,6 +1052,7 @@ strong subadditivity for a normalized three-site reduced state.
     M^{\sigma_N\sigma_N}\bigr)$.
 \end{lemma}
 \begin{proof}\leanok
+    \uses{lem:eval_word_diagonal_tensor}
     Word evaluation of the diagonal tensor multiplies the matrices
     $M^{\sigma_k\sigma_k}$, which is exactly the operator word evaluation with equal
     ket and bra indices; taking the trace gives the diagonal entry.


### PR DESCRIPTION
Follow-up to #2539, addressing its review (which confirmed the math/blueprint↔Lean equivalence was correct):

- **A.4**: Add `lem:eval_word_diagonal_tensor` for the named theorem `MPOTensor.evalWord_diagonalTensor` (previously unblueprinted but used in the proof), and wire it into the `\uses` of `lem:mpv_diagonal_tensor_eq_density` (statement + proof) so the dependency graph reflects the actual Lean proof.
- **B1**: Remove backticks around the Dirac notation ⟨σ|ρ|σ⟩ in the docstring (backticks are for Lean identifiers).
- **B2**: Replace the "entry point" computing idiom with "source".

No Lean statement/proof change. `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint `\uses` graph updates only; no changes to Lean statements or proofs.
> 
> **Overview**
> Follow-up on the MPDO vertical canonical-form **diagonal-density** lemmas: **documentation and blueprint alignment only**—no Lean theorem or proof edits.
> 
> **Blueprint (`ch02b_mpdo.tex`):** Adds **`lem:eval_word_diagonal_tensor`** for the existing `MPOTensor.evalWord_diagonalTensor` (previously used in Lean but not named in the blueprint). **`lem:mpv_diagonal_tensor_eq_density`** now `\uses` that lemma in its statement and proof so the dependency graph matches the actual `simp` proof via `evalWord_diagonalTensor`.
> 
> **Lean (`VerticalCF.lean`):** Docstring only—Dirac notation ⟨σ|ρ^{(N)}(M)|σ⟩ is no longer wrapped in backticks (reserved for Lean identifiers), and “entry point” is rephrased as **“source”** for where vertical-weight positivity comes from.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89cd9a9571633a8519fcf8231163493cd7034875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->