### PR TITLE
doc(MPS/MPDO): address blueprint review on the vertical-MPV lemma

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -1076,19 +1076,35 @@ strong subadditivity for a normalized three-site reduced state.
     \label{lem:mpv_vertical_assembled}
     \lean{MPOTensor.mpv_verticalAssembledTensor_eq_sum}
     \leanok
-    \uses{def:vertical_cf_mpdo}
-    The matrix product vector of the vertical-assembled tensor is the sum, over the
-    flattened $(\text{block},\text{multiplicity})$ index $(\alpha, j)$, of the block
-    contributions weighted by the flattened scalar weights:
+    \uses{thm:mpv_decomposition, def:block_diagonal_tensor}
+    Let $g$ be a block count, $\dim,\mult:\{1,\dots,g\}\to\mathbb N$, weights
+    $\omega_{\alpha j}\in\mathbb C$ for $j\le\mult_\alpha$, and blocks $A_\alpha$ of
+    bond dimension $\dim_\alpha$. The vertical-assembled tensor is the
+    block-diagonal assembly over the flattened index $(\alpha, j)$ that repeats
+    $A_\alpha$ with weight $\omega_{\alpha j}$, written
+    $\bigoplus_\alpha\bigoplus_j \omega_{\alpha j}\, A_\alpha$. Its matrix product
+    vector decomposes as
     \[
-        V^{(N)}\bigl(\text{vertical assembly}\bigr)(\sigma)
+        V^{(N)}\Bigl(\textstyle\bigoplus_\alpha\bigoplus_j
+            \omega_{\alpha j}\, A_\alpha\Bigr)(\sigma)
             = \sum_{\alpha}\sum_{j} (\omega_{\alpha j})^N\, V^{(N)}(A_\alpha)(\sigma).
     \]
 \end{lemma}
 \begin{proof}\leanok
-    Expand the underlying block-diagonal assembly as a weighted sum of block matrix
-    product vectors and reindex the flattened block index back to the
-    $(\alpha, j)$ sigma index.
+    \uses{thm:mpv_decomposition}
+    The vertical-assembled tensor is the block-diagonal assembly over the single
+    flattened index $q$, with flattened weights $\widetilde\omega_q$ and blocks
+    $\widetilde A_q$. By the block matrix-product-vector decomposition
+    (Theorem~\ref{thm:mpv_decomposition}),
+    \[
+        V^{(N)}\bigl(\text{assembly}\bigr)(\sigma)
+            = \sum_{q} (\widetilde\omega_q)^N\, V^{(N)}(\widetilde A_q)(\sigma).
+    \]
+    The flattening identifies $q$ with the pair $(\alpha, j)$ via the bijection
+    $\bigl(\{1,\dots,g\}\times\{1,\dots,\mult_\alpha\}\bigr)\simeq
+    \{1,\dots,\sum_\alpha\mult_\alpha\}$, under which $\widetilde\omega_q=
+    \omega_{\alpha j}$ and $\widetilde A_q = A_\alpha$. Reindexing the sum along
+    this bijection yields the double sum over $(\alpha, j)$.
 \end{proof}
 
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]


### PR DESCRIPTION
Blueprint-only follow-up to #2542, addressing its review (the Lean side was confirmed clean):

- **A.1 / B**: The lemma LHS was the text label `V(vertical assembly)` rather than a formula tied to the parameters. Replaced with the explicit direct-sum `⊕_α ⊕_j ω_{αj} A_α`, stated the parameters, and made the proof formula-driven (displays the intermediate single flattened sum and the reindexing bijection).
- **A.4**: Fixed the stale `\uses{def:vertical_cf_mpdo}` (the lemma uses the block-diagonal assembly, not `IsVerticalCF`) → `thm:mpv_decomposition` + `def:block_diagonal_tensor`.

No Lean change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX in the MPDO blueprint chapter; no code or proof obligations changed in Lean.
> 
> **Overview**
> Blueprint-only follow-up in **`lem:mpv_vertical_assembled`** (`ch02b_mpdo.tex`): the lemma is now stated with explicit parameters and a direct-sum formula instead of the vague label `V(vertical assembly)`.
> 
> The **statement** introduces block count, dimensions, multiplicities, weights \(\omega_{\alpha j}\), and blocks \(A_\alpha\), and defines the vertical-assembled object as \(\bigoplus_\alpha\bigoplus_j \omega_{\alpha j}\, A_\alpha\) with the MPV decomposition as a double sum over \((\alpha,j)\).
> 
> The **proof** is rewritten to invoke **Theorem `thm:mpv_decomposition`** on a single flattened block index, display the intermediate sum over \(q\), then reindex via the \((\alpha,j)\) bijection.
> 
> **`\uses`** is corrected from stale `def:vertical_cf_mpdo` to `thm:mpv_decomposition` and `def:block_diagonal_tensor`. No Lean changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e3d3c2c75b73da1e6284c1e642e47518b302c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->