### PR TITLE
doc(MPS/MPDO): list the Proposition IV.12 progress lemmas in VerticalCF header

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -34,15 +34,35 @@ surrogate for the paper's vertical canonical form.
   doubled-index MPS tensor `M.toMPSTensor`.
 * `IsVerticalCF`:
   a flattened positive-weight BNT decomposition for `diagonalTensor M`.
+* `MPSTensor.diagBlock`:
+  the diagonal restriction `B ↦ (i ↦ B (i, i))` of a doubled-index block.
+
+## Main results (toward Proposition IV.12)
+
 * `blockwise_insert_eq_of_mpv_agree`:
-  Lemma L from the paper's appendix, proved here using the block-injective
+  Lemma L from the paper's appendix, proved using the block-injective
   canonical-form (biCF) field of `HorizontalCFData`.
+* `mpv_diagonalTensor`:
+  the MPV of `diagonalTensor M` at `σ` equals the MPV of `M.toMPSTensor` at the
+  diagonal-paired configuration `k ↦ (σ k, σ k)`.
+* `mpv_diagonalTensor_eq_blocks`:
+  under a horizontal canonical form, `diagonalTensor M` shares its MPV family with
+  the single-spin block-diagonal assembly of the diagonally-restricted blocks.
+* `mpv_diagonalTensor_eq_mpo_diag` / `mpv_diagonalTensor_nonneg`:
+  the diagonal-tensor MPV equals the density-operator diagonal `⟨σ|ρ^{(N)}(M)|σ⟩`,
+  hence is nonnegative when `M` generates an MPDO.
+* `mpv_verticalAssembledTensor_eq_sum`:
+  the MPV of the vertical-assembled tensor as a sum over the flattened
+  `(block, multiplicity)` index.
 
 The full passage from horizontal to vertical canonical form
 (Proposition IV.12 / Proposition 4.13 of arXiv:1606.00608) is still outside
 this file: its blueprint entry `thm:vertical_cf_of_horizontal_cf` is marked
-`\notready`, and the corresponding Lean statement will be introduced together
-with its proof rather than as an empty placeholder.
+`\notready`. The results above supply the matrix-product-vector and positivity
+groundwork; the remaining step is the basis-of-normal-tensors regrouping of the
+diagonally-restricted blocks (diagonal restriction does not preserve normality),
+together with the resulting weight positivity. The Lean statement will be
+introduced together with its proof rather than as an empty placeholder.
 
 ## Module location
 


### PR DESCRIPTION
Docstring-only consolidation after the Prop IV.12 series (#2530, #2534, #2539, #2542). The module header's results listing was stale (named only Lemma L). Adds a "Main results (toward Proposition IV.12)" section covering:
- the diagonal-MPV correspondence (`mpv_diagonalTensor`),
- the diagonal block decomposition (`mpv_diagonalTensor_eq_blocks`),
- the density-diagonal positivity (`mpv_diagonalTensor_eq_mpo_diag` / `_nonneg`),
- the vertical-assembled MPV formula (`mpv_verticalAssembledTensor_eq_sum`),

lists `MPSTensor.diagBlock` among the definitions, and states precisely what remains (the BNT regrouping of the diagonally-restricted blocks — diagonal restriction doesn't preserve normality — plus weight positivity).

Docstring only; `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a module docstring; no Lean proofs or APIs modified.
> 
> **Overview**
> Updates the **`VerticalCF.lean` module docstring** so it matches the Prop IV.12 lemma series already in the file. The header previously highlighted only Lemma L (`blockwise_insert_eq_of_mpv_agree`).
> 
> It adds **`MPSTensor.diagBlock`** under main definitions and a **“Main results (toward Proposition IV.12)”** section that indexes the diagonal-MPV lemmas (`mpv_diagonalTensor`, `mpv_diagonalTensor_eq_blocks`, density-diagonal / nonnegativity, and `mpv_verticalAssembledTensor_eq_sum`).
> 
> The **not-ready** note for `thm:vertical_cf_of_horizontal_cf` is expanded to say the proved lemmas supply MPV/positivity groundwork and what is still missing: **BNT regrouping** of diagonally restricted blocks (diagonal restriction does not preserve normality) plus **weight positivity**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e684c5b3325456f1e506c05a6be7ca5a6404b2aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->