### PR TITLE
doc(parent): record BNT one-site injectivity hypothesis

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5448,6 +5448,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     used in the direct-sum comparison. Assume the direct-sum injectivity
     hypotheses
     \[
+        \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C),
+        \qquad
         \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
         \qquad
         \operatorname{span}\{A^j_v:|v|=L+(L+L)\}=M_{D_j}(\mathbb C),
@@ -5969,6 +5971,11 @@ formulation; the passage to $\ker H_N$ is kept separate.
         \qquad
         n\ge L+(r-1)(L+(L+L)).
     \]
+    In this specialization one also assumes the length-one span condition
+    \[
+        \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C)
+    \]
+    for every block \(j\).
 \end{lemma}
 
 \begin{proof}
@@ -6046,6 +6053,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     direct-sum comparison. Suppose \(1<L\), every block is injective at length
     \(L\),
     \[
+        \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C),
+        \qquad
         \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
     \]
     and every block satisfies the normalization
@@ -6105,6 +6114,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     direct-sum comparison. Suppose \(1<L\), every block is injective at length
     \(L\),
     \[
+        \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C),
+        \qquad
         \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
     \]
     and every block satisfies the normalization

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -69,6 +69,21 @@ After blocking, the corresponding word-span statement is
   \prod_{j=1}^g M_{D_j}(\mathbb C).
 \end{align}
 
+The present formal block-separation route proves a one-site-injective
+special case of this statement.\footnote{This is the hypothesis mismatch tracked
+in \href{https://github.com/LionSR/TNLean/issues/2532}{issue \#2532}.}  Besides
+the common length-\(L\) block-injectivity assumption, the formalized BNT
+block-separation lemmas use
+\begin{align}
+  \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C)
+  \qquad (j=1,\ldots,g).
+\end{align}
+This is Condition C1 at length one for each block.  The source theorem only
+requires Condition C1 after a finite blocking length.  Thus the blueprint
+entries carrying the current formal statements must display the length-one
+span condition explicitly; removing it requires a separate proof deriving the
+same block-separation equations from the source's finite blocking range.
+
 The resulting parent-Hamiltonian theorem in \cite[Section~IV.C]{Cirac2021Matrix}
 is
 \begin{align}


### PR DESCRIPTION
## Summary
- add the missing length-one span condition to the BNT block-separation blueprint statements that are backed by Lean declarations carrying `∀ k, IsInjective (A k)`
- record in the parent-Hamiltonian paper-gap note that the current formal route proves the one-site-injective subcase, whereas PGVWC07/CPGSV21 only require C1 after a finite blocking length

Closes #2532.

## Verification
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` reports chapter 14 at 426/426; it still exits nonzero on the pre-existing non-parent refs `TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData` and `...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to LaTeX blueprint and gap notes; no Lean or runtime behavior changes.
> 
> **Overview**
> **Aligns BNT block-separation blueprint text with what Lean actually proves** by adding the per-block length-one span condition \(\operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C)\) to the direct-sum injectivity hypotheses and to the lemmas on unital block separating product span, direct-sum restriction intersection, and eventual block intersection.
> 
> **Documents the hypothesis gap** in `cpgsv21_block_diagonal_parent_ground_space.tex`: the formal route is the one-site-injective subcase (issue #2532), while PGVWC07/CPGSV21 only need Condition C1 after a finite blocking length; closing that gap would need a separate proof, not removing the displayed assumption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683e8a590659ef88bd3b53bf93533aeeb25cf79c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->