### PR TITLE
feat(MPS/MPDO): nonnegativity of the mutual information

### DIFF
--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -366,4 +366,27 @@ theorem mutualInfoChain_monotone {d D : ℕ} (M : MPOTensor d D) {N L : ℕ} (hN
   simp only [MPOTensor.mutualInfoChain]
   linarith [key]
 
+/-- Block entropies are nonnegative. -/
+theorem blockEntropy_nonneg {d D : ℕ} (M : MPOTensor d D) {N m : ℕ} (hm : m ≤ N)
+    (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
+    0 ≤ M.blockEntropy N m hm hM :=
+  vonNeumannEntropy_nonneg_of_posSemidef_trace_one
+    (reducedBlockState_posSemidef M N m hm hM)
+    (reducedBlockState_trace M N m hm htr)
+
+/-- **Nonnegativity of the mutual information.** For a normalizable periodic MPDO state,
+the mutual information of any block is nonnegative: `0 ≤ I_L`. This is subadditivity of
+the von Neumann entropy applied to the bipartition into the first `L` and last `N - L`
+spins (strong subadditivity with a trivial middle subsystem). -/
+theorem mutualInfoChain_nonneg {d D : ℕ} (M : MPOTensor d D) {N L : ℕ} (hL : L ≤ N)
+    (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
+    0 ≤ M.mutualInfoChain N L hL hM := by
+  have key := ssa_block_entropy M (a := L) (b := 0) (c := N - L) (by omega) hM htr
+  rw [blockEntropy_congr M N (show L + 0 + (N - L) = N by omega) _ (le_refl N) hM,
+    blockEntropy_congr M N (show L + 0 = L by omega) _ hL hM,
+    blockEntropy_congr M N (show 0 + (N - L) = N - L by omega) _ (Nat.sub_le N L) hM] at key
+  have hS0 : 0 ≤ M.blockEntropy N 0 (Nat.zero_le N) hM := blockEntropy_nonneg M _ hM htr
+  simp only [MPOTensor.mutualInfoChain]
+  linarith [key, hS0]
+
 end Prop45

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3231,6 +3231,25 @@ the elementary trace-power identity for diagonal matrices.
     $I_L \le I_{L+1}$ after subtracting $S_N$.
 \end{proof}
 
+\begin{lemma}[Nonnegativity of the mutual information]
+    \label{lem:mutual_info_chain_nonneg}
+    \lean{mutualInfoChain_nonneg}
+    \leanok
+    \uses{def:mutual_info_chain, thm:entropy_strong_subadditivity}
+    Let $M$ generate an MPDO whose finite-chain operator $\rho^{(N)}(M)$ is positive
+    semidefinite with nonzero trace. For every block length $L\le N$,
+    \[
+        0 \le I_L.
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    \uses{thm:entropy_strong_subadditivity, def:block_entropy}
+    Apply strong subadditivity with a trivial middle subsystem (equivalently,
+    subadditivity) to the bipartition of the chain into the first $L$ and last
+    $N-L$ spins: $S_N + S_0 \le S_L + S_{N-L}$. Since $S_0 \ge 0$, rearranging gives
+    $I_L = S_L + S_{N-L} - S_N \ge S_0 \ge 0$.
+\end{proof}
+
 \begin{remark}[Boundedness of the mutual information]
     The monotone sequence $I_L$ is bounded by a constant depending only on the
     bond dimension, $I_L \le 4\log D$, so it converges as $L\to\infty$. For a


### PR DESCRIPTION
`MPOTensor.mutualInfoChain_nonneg`: for a normalizable periodic MPDO state, `0 ≤ I_L` for every block length `L ≤ N`.

This is subadditivity of the von Neumann entropy — strong subadditivity with a trivial middle subsystem — applied to the bipartition into the first `L` and last `N-L` spins. From the existing `ssa_block_entropy` at `b = 0`: `S_N + S_0 ≤ S_L + S_{N-L}`, so `I_L = S_L + S_{N-L} - S_N ≥ S_0 ≥ 0`.

Also adds `MPOTensor.blockEntropy_nonneg` (block entropies are nonnegative, from `vonNeumannEntropy_nonneg_of_posSemidef_trace_one`).

Together with `mutualInfoChain_monotone` (#2467), the mutual information `I_L` is now established as a **nonnegative nondecreasing** sequence — the qualitative shape the paper's area-law discussion relies on.

Blueprint: `lem:mutual_info_chain_nonneg`. Additive, no `sorry`; `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive entropy lemmas and blueprint sync only; no changes to definitions, APIs, or security-sensitive code.
> 
> **Overview**
> This PR **formalizes nonnegativity of periodic MPDO block mutual information** `I_L`, complementing the existing monotonicity result (`mutualInfoChain_monotone`).
> 
> In `MutualInfoMonotone.lean` it adds **`blockEntropy_nonneg`** (block entropies ≥ 0 from PSD reduced states with unit trace) and **`mutualInfoChain_nonneg`**, which applies **`ssa_block_entropy`** with middle length `b = 0` on the bipartition into the first `L` and last `N−L` spins. That yields `S_N + S_0 ≤ S_L + S_{N−L}`, hence `I_L = S_L + S_{N−L} − S_N ≥ S_0 ≥ 0`.
> 
> The blueprint gains **Lemma `lem:mutual_info_chain_nonneg`** (`\lean{mutualInfoChain_nonneg}`) with the same subadditivity proof. Together with monotonicity, the mutual information sequence is now **nonnegative and nondecreasing** in the formalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6fa44d2545297af0f82350ca0a5554c1294d390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->