### PR TITLE
doc(MPS/MPDO): address review on the mutual-info nonneg lemma

### DIFF
--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -375,7 +375,7 @@ theorem blockEntropy_nonneg {d D : ℕ} (M : MPOTensor d D) {N m : ℕ} (hm : m 
     (reducedBlockState_trace M N m hm htr)
 
 /-- **Nonnegativity of the mutual information.** For a normalizable periodic MPDO state,
-the mutual information of any block is nonnegative: `0 ≤ I_L`. This is subadditivity of
+the mutual information of any block is nonnegative, $0 \le I_L$. This is subadditivity of
 the von Neumann entropy applied to the bipartition into the first `L` and last `N - L`
 spins (strong subadditivity with a trivial middle subsystem). -/
 theorem mutualInfoChain_nonneg {d D : ℕ} (M : MPOTensor d D) {N L : ℕ} (hL : L ≤ N)

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3231,11 +3231,24 @@ the elementary trace-power identity for diagonal matrices.
     $I_L \le I_{L+1}$ after subtracting $S_N$.
 \end{proof}
 
+\begin{lemma}[Nonnegativity of block entropies]
+    \label{lem:block_entropy_nonneg}
+    \lean{MPOTensor.blockEntropy_nonneg}
+    \leanok
+    \uses{def:block_entropy, thm:entropy_nonneg}
+    For a normalized positive semidefinite finite-chain operator, every block entropy
+    is nonnegative: $0 \le S_m$.
+\end{lemma}
+\begin{proof}\leanok
+    The reduced state of a block is a density matrix, and the von Neumann entropy of
+    a density matrix is nonnegative.
+\end{proof}
+
 \begin{lemma}[Nonnegativity of the mutual information]
     \label{lem:mutual_info_chain_nonneg}
     \lean{mutualInfoChain_nonneg}
     \leanok
-    \uses{def:mutual_info_chain, thm:entropy_strong_subadditivity}
+    \uses{def:mutual_info_chain, thm:entropy_strong_subadditivity, lem:block_entropy_nonneg}
     Let $M$ generate an MPDO whose finite-chain operator $\rho^{(N)}(M)$ is positive
     semidefinite with nonzero trace. For every block length $L\le N$,
     \[
@@ -3243,10 +3256,11 @@ the elementary trace-power identity for diagonal matrices.
     \]
 \end{lemma}
 \begin{proof}\leanok
-    \uses{thm:entropy_strong_subadditivity, def:block_entropy}
+    \uses{thm:entropy_strong_subadditivity, def:block_entropy, lem:block_entropy_nonneg}
     Apply strong subadditivity with a trivial middle subsystem (equivalently,
     subadditivity) to the bipartition of the chain into the first $L$ and last
-    $N-L$ spins: $S_N + S_0 \le S_L + S_{N-L}$. Since $S_0 \ge 0$, rearranging gives
+    $N-L$ spins: $S_N + S_0 \le S_L + S_{N-L}$. Since $S_0 \ge 0$
+    (Lemma~\ref{lem:block_entropy_nonneg}), rearranging gives
     $I_L = S_L + S_{N-L} - S_N \ge S_0 \ge 0$.
 \end{proof}
 


### PR DESCRIPTION
Follow-up to #2546, addressing its review:

- **A.4**: Add `lem:block_entropy_nonneg` for the new `MPOTensor.blockEntropy_nonneg` theorem and wire it into `lem:mutual_info_chain_nonneg`'s `\uses` (statement + proof), completing the dependency graph.
- **B.1**: Drop backticks around the informal "0 ≤ I_L" in the docstring (inline math instead).

No Lean statement/proof change. `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint dependency wiring only; no changes to Lean proofs or statements.
> 
> **Overview**
> Documentation follow-up for mutual-information nonnegativity: the blueprint now includes **`lem:block_entropy_nonneg`** (`MPOTensor.blockEntropy_nonneg`) and **`lem:mutual_info_chain_nonneg`** cites it in `\uses` and in the proof when justifying $S_0 \ge 0$.
> 
> The **`mutualInfoChain_nonneg`** Lean docstring now uses inline math ($0 \le I_L$) instead of backticks around the informal inequality. No theorem statements or proofs change in Lean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19189eba1b6aa61f68a63936970aca7ab2e85c7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->