### PR TITLE
doc(parent): record boundary-closing obstruction equations

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6499,8 +6499,10 @@ formulation; the passage to $\ker H_N$ is kept separate.
     $G_L(B)$ with the subspace denoted in the source by
     $S=\bigoplus_j\mathcal G_L^{A^j}$.
     The passage from the open-segment recursion to the periodic chain is the
-    separate closure step in \cite[Theorem~12]{PerezGarcia2007Matrix}. Under
-    $N\ge L+L_0$, this closing step gives
+    separate closure step in \cite[Theorem~12]{PerezGarcia2007Matrix}. It is
+    not the inclusion $G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)$, which fails
+    for a general open-boundary matrix crossing the periodic boundary. Under
+    $N\ge L+L_0$, the required boundary-condition comparison is
     \[
         \mathcal G_{N,L}(B)
         =

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -251,6 +251,26 @@ The missing boundary-condition statement is then
   =
   \sum_{j=1}^b \mathcal K_{N,L}(A_j).
 \end{align}
+
+The following implication is not available.  The open-boundary space
+\(\mathcal G_N^A\) is not contained in the cyclic-chain ground space
+\(\mathcal K_{N,L}(A)\) for an arbitrary boundary matrix \(X\).  If the
+cyclic window crosses the chosen virtual boundary, then a vector
+\(\Gamma_N^A(X)\) has coefficients of the form
+\begin{align}
+  \tr\!\left(A^{\omega_{\mathrm{tail}}}
+    X A^{\omega_{\mathrm{head}}} A^\rho\right),
+\end{align}
+where \(\omega_{\mathrm{tail}}\omega_{\mathrm{head}}\) is the word seen in the
+cyclic window and \(\rho\) is the complementary word.  This is not, for general
+\(X\), of the form
+\begin{align}
+  \tr\!\left(A^{\omega_{\mathrm{tail}}}
+    A^{\omega_{\mathrm{head}}}Y_\rho\right)
+\end{align}
+with one matrix \(Y_\rho\) independent of the window word.  The missing step is
+therefore a boundary-condition comparison, not the inclusion
+\(\mathcal G_N^A\subseteq\mathcal K_{N,L}(A)\).
 The corresponding capstone blueprint entries now record the multi-block
 hypothesis, the positive common injectivity length, the nonzero-weight
 hypothesis, and the conservative length range of \cite[Theorem

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -158,6 +158,26 @@ compatibility, and
 \path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:450 for the mirror
 compatibility.}
 
+This is why the open-chain containment cannot simply be reversed.  Let
+\(\Gamma_N(X)\) denote the length-\(N\) open-chain vector
+\(\Gamma_N(X)_\omega=\tr(A^\omega X)\).  A vector
+\(\Gamma_N(X)\in G_N(A)\) need not lie in the cyclic-chain ground space.  For a
+boundary-crossing window, the restriction has trace coefficients with \(X\)
+between the two parts of the window word,
+\begin{align}
+  \tr\!\left(A^{\omega_{\mathrm{tail}}}X
+    A^{\omega_{\mathrm{head}}}A^\rho\right),
+\end{align}
+whereas membership in \(G_L(A)\) would require the same coefficients to be
+written as
+\begin{align}
+  \tr\!\left(A^{\omega_{\mathrm{tail}}}
+    A^{\omega_{\mathrm{head}}}Y_\rho\right)
+\end{align}
+for a matrix \(Y_\rho\) depending only on the complementary boundary condition.
+The closure-property comparison is precisely what supplies this missing
+movement of \(X\) through the boundary-crossing word.
+
 The last algebraic step needs the two one-sided identities to use the same matrix.
 There should be a word $\mu$ on the complementary sites and matrices $Y_\mu$
 such that, for every physical letter $j$,

--- a/docs/prose_style.md
+++ b/docs/prose_style.md
@@ -85,6 +85,11 @@ without opening the `.lean` files, the prose has failed.
   `\cite[Section~2.3]{Wolf2012Quantum}`,
   `\cite[Proposition~IV.3]{Cirac2021Matrix}`, or "the commuting-form definition
   in arXiv:1606.00608". Headings should name the mathematical content.
+- **Blueprint labels as mathematical prose.** Do not write that the theorem "is
+  `thm:...`" or display a `\texttt{thm:...}` label as the content of a theorem.
+  State the mathematical assertion with equations. Use `\label{...}`,
+  `\ref{...}`, `\lean{...}`, and `\uses{...}` only as metadata or cross-reference
+  markup.
 
   Bad:
 


### PR DESCRIPTION
## Summary
- record that the proposed inclusion \(G_N(A)\subseteq\mathcal G_{N,L}(A)\) is false for a general open-boundary vector \(\Gamma_N(X)\)
- add the crossed-boundary trace equations showing where \(X\) sits between the two parts of the window word
- update the prose guide to forbid theorem-label-only prose such as displaying `thm:...` as the theorem statement

Refs #905 and #2405.

## Checks
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`

Note: `leanblueprint checkdecls` was attempted in the fresh worktree, but it stopped before checking declarations because `blueprint/lean_decls` had not been generated there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and style-guide edits only; no Lean or runtime behavior changes.
> 
> **Overview**
> Documents a **gap in the parent-Hamiltonian / block-diagonal ground-space story**: the implication \(\mathcal G_N^A \subseteq \mathcal K_{N,L}(A)\) (or the analogous \(G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)\)) is **not** generally valid when a periodic window crosses the virtual boundary.
> 
> The updates add the **crossed-boundary trace formulas** that show \(X\) sits between \(\omega_{\mathrm{tail}}\) and \(\omega_{\mathrm{head}}\), and contrast them with the form required for cyclic-chain ground-space membership—framing the missing step as a **boundary-condition comparison**, not open-chain containment. The blueprint proof in `ch14_parent_hamiltonian.tex` is aligned with that wording.
> 
> `docs/prose_style.md` gains a rule: **do not state theorems using only blueprint labels** (`thm:...`); state the math and keep labels as metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c0006376252e2deb6d4a9ab9bc7f28aec715d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->