### PR TITLE
feat(MPS/MPDO): symmetry of the mutual information across the cut

### DIFF
--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -389,4 +389,14 @@ theorem mutualInfoChain_nonneg {d D : ℕ} (M : MPOTensor d D) {N L : ℕ} (hL :
   simp only [MPOTensor.mutualInfoChain]
   linarith [key, hS0]
 
+/-- **Symmetry of the mutual information across the cut.** The mutual information of the
+first `L` spins equals that of their complement: `I_L = I_{N-L}`. Immediate from the
+symmetric definition `I_L = S_L + S_{N-L} - S_N`. -/
+theorem mutualInfoChain_symm {d D : ℕ} (M : MPOTensor d D) {N L : ℕ} (hL : L ≤ N)
+    (hM : (mpo M N).PosSemidef) :
+    M.mutualInfoChain N L hL hM = M.mutualInfoChain N (N - L) (Nat.sub_le N L) hM := by
+  simp only [MPOTensor.mutualInfoChain]
+  rw [blockEntropy_congr M N (show N - (N - L) = L by omega) (Nat.sub_le N (N - L)) hL hM]
+  ring
+
 end Prop45

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3264,6 +3264,23 @@ the elementary trace-power identity for diagonal matrices.
     $I_L = S_L + S_{N-L} - S_N \ge S_0 \ge 0$.
 \end{proof}
 
+\begin{lemma}[Symmetry of the mutual information across the cut]
+    \label{lem:mutual_info_chain_symm}
+    \lean{mutualInfoChain_symm}
+    \leanok
+    \uses{def:mutual_info_chain}
+    For every block length $L\le N$, the mutual information of the first $L$ spins
+    equals that of their complement:
+    \[
+        I_L = I_{N-L}.
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:mutual_info_chain}
+    Both sides equal $S_L + S_{N-L} - S_N$ by the symmetric definition
+    $I_L = S_L + S_{N-L} - S_N$, using $N-(N-L) = L$.
+\end{proof}
+
 \begin{remark}[Boundedness of the mutual information]
     The monotone sequence $I_L$ is bounded by a constant depending only on the
     bond dimension, $I_L \le 4\log D$, so it converges as $L\to\infty$. For a


### PR DESCRIPTION
`MPOTensor.mutualInfoChain_symm`: `I_L = I_{N-L}` — the mutual information of the first `L` spins equals that of their complement. Immediate from the symmetric definition `I_L = S_L + S_{N-L} - S_N` (using `N-(N-L) = L`).

With the monotonicity (#2467) and nonnegativity (#2546), this pins the qualitative shape of the `I_L` sequence: **nonnegative, nondecreasing up to ⌊N/2⌋, and symmetric about the midpoint** — exactly the picture the paper's area-law discussion relies on.

Blueprint: `lem:mutual_info_chain_symm`. Additive, no `sorry`; `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive Lean proof and blueprint lemma; no changes to definitions or existing theorem statements.
> 
> **Overview**
> Adds **`mutualInfoChain_symm`**: for a PSD periodic MPDO, the chain mutual information satisfies **\(I_L = I_{N-L}\)**. The proof unfolds `mutualInfoChain` as \(S_L + S_{N-L} - S_N\) and uses `blockEntropy_congr` with \(N-(N-L)=L\), then `ring`.
> 
> The blueprint gains **`lem:mutual_info_chain_symm`** (`\lean{mutualInfoChain_symm}`), aligned with the existing monotonicity and nonnegativity lemmas. Together they describe \(I_L\) as nonnegative, nondecreasing up to \(\lfloor N/2\rfloor\), and symmetric about the midpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0090dcdb1b9498434af43c297a6a427ebd0f7c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->