### PR TITLE
feat(MPS/MPDO): nonnegativity of the pure-state block entropy

### DIFF
--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -448,6 +448,17 @@ theorem pureBlockEntropy_le (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) (hD :
     _ = 2 * Real.log D := by
         rw [Real.log_mul (by exact_mod_cast hD.ne') (by exact_mod_cast hD.ne')]; ring
 
+/-- The pure-state block entropy is nonnegative. -/
+theorem pureBlockEntropy_nonneg (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N)
+    (htr : Matrix.trace (pureState A N) ≠ 0) :
+    0 ≤ pureBlockEntropy A N L hL := by
+  have hPSD : (reducedPureBlockState A N L hL).PosSemidef :=
+    blockReducedState_posSemidef ((normalizedPureState_posSemidef A N).submatrix _)
+  have hTr : (reducedPureBlockState A N L hL).trace = 1 := by
+    rw [reducedPureBlockState, blockReducedState_trace, Matrix.trace_submatrix_equiv,
+      normalizedPureState, Matrix.trace_smul, smul_eq_mul, inv_mul_cancel₀ htr]
+  exact vonNeumannEntropy_nonneg_of_posSemidef_trace_one hPSD hTr
+
 end MPSTensor
 
 /-- **Pure-state mutual-information area-law bound.** For the purification MPDO of

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3468,6 +3468,19 @@ the elementary trace-power identity for diagonal matrices.
     $S_L^{(N)}(A) \le \log(D^2) = 2\log D$.
 \end{proof}
 
+\begin{lemma}[Nonnegativity of the pure-state block entropy]
+    \label{lem:pure_block_entropy_nonneg}
+    \lean{MPSTensor.pureBlockEntropy_nonneg}
+    \leanok
+    \uses{def:pure_sal, thm:entropy_nonneg}
+    For an MPS tensor $A$ with $V^{(N)}(A)\neq 0$ and every block length $L\le N$,
+    the pure-state block entropy is nonnegative: $0 \le S_L^{(N)}(A)$.
+\end{lemma}
+\begin{proof}\leanok
+    The reduced state $\rho_L^{(N)}(A)$ is a density matrix, and the von Neumann
+    entropy of a density matrix is nonnegative.
+\end{proof}
+
 \begin{lemma}[Pure-state mutual information is twice the block entropy]
     \label{lem:mutual_info_doubled}
     \lean{mutualInfoChain_doubledTensor}


### PR DESCRIPTION
`MPSTensor.pureBlockEntropy_nonneg`: `0 ≤ S_L^{(N)}(A)` for an MPS tensor with `V^{(N)}(A) ≠ 0`. The reduced pure block state is a density matrix (PSD, trace 1), and von Neumann entropy of a density matrix is nonnegative.

Completes the pure-state block-entropy property set alongside monotonicity (#2489), the `2 log D` upper bound (#2518), Schmidt symmetry `S_L = S_{N-L}` (#2489), and `S_N = 0` (#2505).

Blueprint: `lem:pure_block_entropy_nonneg`. Additive, no `sorry`; `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive Lean lemma and blueprint entry; no changes to auth, data paths, or existing proof dependencies beyond reusing established density-matrix entropy facts.
> 
> **Overview**
> Adds **`MPSTensor.pureBlockEntropy_nonneg`**: for a normalizable MPS pure state (`trace (pureState A N) ≠ 0`), the block entropy satisfies **0 ≤ S_L^{(N)}(A)**. The proof reuses the same reduced-block argument as the `2 log D` bound—`reducedPureBlockState` is PSD with trace 1—then applies von Neumann nonnegativity for density matrices.
> 
> Blueprint: new **`lem:pure_block_entropy_nonneg`** (`\lean{MPSTensor.pureBlockEntropy_nonneg}`), aligned with the mixed-state **`lem:block_entropy_nonneg`** pattern. No API or proof-chain changes beyond this additive lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5149ea96586c1a140adebb626ef7c85dc4423268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->