### PR TITLE
refactor(MPS/MPDO): extract reducedPureBlockState PSD/trace-1 lemmas

### DIFF
--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -527,6 +527,18 @@ theorem reducedPureBlockState_isHermitian (A : MPSTensor d D) (N L : ℕ) (hL : 
     (reducedPureBlockState A N L hL).IsHermitian :=
   blockReducedState_isHermitian ((normalizedPureState_isHermitian A N).submatrix _)
 
+/-- The reduced pure block state is positive semidefinite. -/
+theorem reducedPureBlockState_posSemidef (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
+    (reducedPureBlockState A N L hL).PosSemidef :=
+  blockReducedState_posSemidef ((normalizedPureState_posSemidef A N).submatrix _)
+
+/-- The reduced pure block state has unit trace when the pure state is normalizable. -/
+theorem reducedPureBlockState_trace (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N)
+    (htr : Matrix.trace (pureState A N) ≠ 0) :
+    (reducedPureBlockState A N L hL).trace = 1 := by
+  rw [reducedPureBlockState, blockReducedState_trace, Matrix.trace_submatrix_equiv,
+    normalizedPureState, Matrix.trace_smul, smul_eq_mul, inv_mul_cancel₀ htr]
+
 /-- The **pure block entropy** `S_L^{(N)}(A)`: the von Neumann entropy of the
 reduced state of the first `L` spins of the normalized pure state `σ^{(N)}(A)`.
 

--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -421,10 +421,9 @@ theorem pureBlockEntropy_le (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) (hD :
     pureBlockEntropy A N L hL ≤ 2 * Real.log D := by
   -- the reduced block state is a density matrix
   have hPSD : (reducedPureBlockState A N L hL).PosSemidef :=
-    blockReducedState_posSemidef ((normalizedPureState_posSemidef A N).submatrix _)
-  have hTr : (reducedPureBlockState A N L hL).trace = 1 := by
-    rw [reducedPureBlockState, blockReducedState_trace, Matrix.trace_submatrix_equiv,
-      normalizedPureState, Matrix.trace_smul, smul_eq_mul, inv_mul_cancel₀ htr]
+    reducedPureBlockState_posSemidef A N L hL
+  have hTr : (reducedPureBlockState A N L hL).trace = 1 :=
+    reducedPureBlockState_trace A N L hL htr
   -- its rank is positive (trace 1 ≠ 0) and at most `D²`
   have hrk_pos : 0 < (reducedPureBlockState A N L hL).rank := by
     rw [hPSD.isHermitian.rank_eq_card_non_zero_eigs, Fintype.card_pos_iff]
@@ -451,13 +450,10 @@ theorem pureBlockEntropy_le (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) (hD :
 /-- The pure-state block entropy is nonnegative. -/
 theorem pureBlockEntropy_nonneg (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N)
     (htr : Matrix.trace (pureState A N) ≠ 0) :
-    0 ≤ pureBlockEntropy A N L hL := by
-  have hPSD : (reducedPureBlockState A N L hL).PosSemidef :=
-    blockReducedState_posSemidef ((normalizedPureState_posSemidef A N).submatrix _)
-  have hTr : (reducedPureBlockState A N L hL).trace = 1 := by
-    rw [reducedPureBlockState, blockReducedState_trace, Matrix.trace_submatrix_equiv,
-      normalizedPureState, Matrix.trace_smul, smul_eq_mul, inv_mul_cancel₀ htr]
-  exact vonNeumannEntropy_nonneg_of_posSemidef_trace_one hPSD hTr
+    0 ≤ pureBlockEntropy A N L hL :=
+  vonNeumannEntropy_nonneg_of_posSemidef_trace_one
+    (reducedPureBlockState_posSemidef A N L hL)
+    (reducedPureBlockState_trace A N L hL htr)
 
 end MPSTensor
 


### PR DESCRIPTION
DRY refactor (periodic-refactor pass). `pureBlockEntropy_le` and `pureBlockEntropy_nonneg` both inlined the same positive-semidefinite and unit-trace computations for the reduced pure block state. Extracted as named lemmas next to `reducedPureBlockState_isHermitian`:

- `MPSTensor.reducedPureBlockState_posSemidef`
- `MPSTensor.reducedPureBlockState_trace` (unit trace given `V^{(N)}(A) ≠ 0`)

and replaced the two inline copies with calls to them. These are also useful standalone facts (the reduced pure block state is a density matrix).

No statement change; `lake build` ✓, `lake exe lint-style` clean, no `sorry`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor with no new assumptions or changed theorem statements; only lemma extraction and call-site simplification.
> 
> **Overview**
> Adds **`reducedPureBlockState_posSemidef`** and **`reducedPureBlockState_trace`** in `AreaLaw.lean` beside `reducedPureBlockState_isHermitian`, recording that the reduced pure block state is PSD and has trace 1 when `tr(pureState) ≠ 0`.
> 
> **`pureBlockEntropy_le`** and **`pureBlockEntropy_nonneg`** in `PureAreaLaw.lean` no longer repeat those proofs inline; they call the new lemmas instead. Theorem statements and proofs are unchanged—refactor only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f81f26e3a79cc015224f6988effc9076cbc527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->