### PR TITLE
feat(parent): record BNT periodic-chain inclusions

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -115,4 +115,48 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
   · exact groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital (by omega)
 
+/-- The current normalized BNT formalization gives two inclusions for the
+block-diagonal periodic chain space.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j.
+\]
+Under the normalized BNT block-separation hypotheses and in the proved length
+range,
+\[
+  \bigvee_j \mathcal G_{N,L}(A_j)
+  \subseteq
+  \mathcal G_{N,L}(B)
+  \subseteq
+  \bigvee_j G_N(A_j),
+\]
+and the right-hand local block sum is internal. The remaining PGVWC07
+component-extraction step replaces
+\(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\). -/
+theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hInj : ∀ k : Fin r, IsInjective (A k))
+    (hL₀ : 1 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange : L₀ + (r - 1) * (L₀ + (L₀ + L₀)) + 1 ≤ L) :
+    (⨆ j : Fin r, chainGroundSpace (A j) L N) ≤
+        chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ∧
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, groundSpace (A j) N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  refine ⟨?_, ?_⟩
+  · exact iSup_chainGroundSpace_block_le_toTensorFromBlocks μ A hμ hN hLN
+  · exact chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital hN hL hLN hRange
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6314,6 +6314,35 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
 \end{proof}
 
+\begin{lemma}[Block-diagonal periodic chain inclusions]
+    \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital}
+    \leanok
+    \uses{lem:isup_chain_ground_space_block_le_assembled,
+        lem:bnt_block_diagonal_periodic_constraints_internal_sum}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}, one has
+    \[
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j)
+        \subseteq
+        \mathcal G_{N,L}\!\left(\bigoplus_{j=1}^g\mu_jA_j\right)
+        \subseteq
+        \bigvee_{j=1}^gG_N(A_j),
+    \]
+    and the sum defining the right-hand side is internal.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The first inclusion is
+    Lemma~\ref{lem:isup_chain_ground_space_block_le_assembled}. The second
+    inclusion and internal directness are
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}. The
+    claimed statement is their conjunction.
+    % The remaining PGVWC07 component-extraction step replaces
+    % $\bigvee_jG_N(A_j)$ by $\sum_j\mathcal G_{N,L}(A_j)$.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -6335,6 +6364,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:block_sum_local_ground_space,
         lem:block_diagonal_periodic_constraints_propagated_sum,
         lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
+        lem:bnt_block_diagonal_periodic_chain_inclusions,
         thm:wordspan_propagation_unital}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:


### PR DESCRIPTION
## Summary

This records the current normalized BNT periodic-chain inclusions as a Lean theorem and as a blueprint lemma:

\[
  \bigvee_j \mathcal G_{N,L}(A_j)
  \subseteq
  \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
  \subseteq
  \bigvee_j G_N(A_j),
\]

with internal directness of the right-hand local block sum. The proof packages the already-formalized blockwise periodic-chain inclusion with the existing BNT internal-sum theorem.

This is deliberately not the final PGVWC07 component-extraction identity. The remaining step is to replace the right-hand side by \(\sum_j \mathcal G_{N,L}(A_j)\) under the source hypotheses and range.

Refs #905.
Refs #2547.

## Checks

- lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
- lake build TNLean
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main
- git diff --check origin/main..HEAD
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls reports ch14_parent_hamiltonian.tex at 427/427; it still reports unrelated existing missing declarations in other chapters.
- leanblueprint checkdecls still fails on unrelated existing tags: literal ellipsis and MPOTensor.blockEntropy_nonneg.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and blueprint wiring of already-proved lemmas; no application logic, auth, or data paths.
> 
> **Overview**
> Adds a **packaging theorem** for the normalized BNT block-diagonal periodic chain: under the usual BNT unital hypotheses and length range, it records the sandwich \(\bigvee_j \mathcal G_{N,L}(A_j) \subseteq \mathcal G_{N,L}(B) \subseteq \bigvee_j G_N(A_j)\) together with internal directness of the right-hand local block sum. The Lean proof is a short conjunction of the existing blockwise inclusion `iSup_chainGroundSpace_block_le_toTensorFromBlocks` and `chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital`.
> 
> The blueprint gains **Lemma** `lem:bnt_block_diagonal_periodic_chain_inclusions` (`\leanok`, linked to the new theorem), and that lemma is listed as a dependency of the not-yet-ready block-diagonal intersection theorem. Comments note this is **not** the final PGVWC07 step that would replace \(\bigvee_j G_N(A_j)\) by \(\sum_j \mathcal G_{N,L}(A_j)\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dacbdc136f522a01e0bc58dcae4ea6c4669cac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->