### PR TITLE
feat(MPS/MPDO): empty-block entropy and mutual information vanish

### DIFF
--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -399,4 +399,32 @@ theorem mutualInfoChain_symm {d D : ℕ} (M : MPOTensor d D) {N L : ℕ} (hL : L
   rw [blockEntropy_congr M N (show N - (N - L) = L by omega) (Nat.sub_le N (N - L)) hL hM]
   ring
 
+/-- The block entropy of the empty block vanishes: `S_0 = 0`. The reduced state of zero
+spins is a one-dimensional density matrix, whose entropy is zero. -/
+theorem blockEntropy_zero {d D : ℕ} (M : MPOTensor d D) (N : ℕ)
+    (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
+    M.blockEntropy N 0 (Nat.zero_le N) hM = 0 := by
+  have hPSD : (reducedBlockState M N 0 (Nat.zero_le N)).PosSemidef :=
+    reducedBlockState_posSemidef M N 0 (Nat.zero_le N) hM
+  have hTr : (reducedBlockState M N 0 (Nat.zero_le N)).trace = 1 :=
+    reducedBlockState_trace M N 0 (Nat.zero_le N) htr
+  have hcard : Fintype.card (Fin 0 → Fin d) = 1 := by simp
+  have hle : (reducedBlockState M N 0 (Nat.zero_le N)).rank ≤ 1 :=
+    hcard ▸ Matrix.rank_le_card_width _
+  have hupper : M.blockEntropy N 0 (Nat.zero_le N) hM ≤ 0 := by
+    have h := vonNeumannEntropy_le_log_rank hPSD hTr
+    have hlog : Real.log ((reducedBlockState M N 0 (Nat.zero_le N)).rank : ℝ) ≤ 0 :=
+      Real.log_nonpos (by positivity) (by exact_mod_cast hle)
+    exact le_trans h hlog
+  have hlower : 0 ≤ M.blockEntropy N 0 (Nat.zero_le N) hM := blockEntropy_nonneg M _ hM htr
+  linarith
+
+/-- The mutual information of the empty block vanishes: `I_0 = 0`. -/
+theorem mutualInfoChain_zero {d D : ℕ} (M : MPOTensor d D) (N : ℕ)
+    (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
+    M.mutualInfoChain N 0 (Nat.zero_le N) hM = 0 := by
+  simp only [MPOTensor.mutualInfoChain, Nat.sub_zero]
+  rw [blockEntropy_zero M N hM htr]
+  ring
+
 end Prop45

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3281,6 +3281,35 @@ the elementary trace-power identity for diagonal matrices.
     $I_L = S_L + S_{N-L} - S_N$, using $N-(N-L) = L$.
 \end{proof}
 
+\begin{lemma}[Empty-block entropy vanishes]
+    \label{lem:block_entropy_zero}
+    \lean{MPOTensor.blockEntropy_zero}
+    \leanok
+    \uses{def:block_entropy, thm:entropy_le_log_rank, lem:block_entropy_nonneg}
+    For a normalized positive semidefinite finite-chain operator, the block entropy of
+    the empty block vanishes: $S_0 = 0$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{thm:entropy_le_log_rank, lem:block_entropy_nonneg}
+    The reduced state of zero spins is one-dimensional, so its rank is one and the rank
+    bound on the entropy gives $S_0 \le \log 1 = 0$; with $S_0 \ge 0$ this forces
+    $S_0 = 0$.
+\end{proof}
+
+\begin{lemma}[Empty-block mutual information vanishes]
+    \label{lem:mutual_info_chain_zero}
+    \lean{MPOTensor.mutualInfoChain_zero}
+    \leanok
+    \uses{def:mutual_info_chain, lem:block_entropy_zero}
+    For a normalized positive semidefinite finite-chain operator, the mutual information
+    of the empty block vanishes: $I_0 = 0$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:block_entropy_zero}
+    By definition $I_0 = S_0 + S_N - S_N = S_0$, which is zero by
+    Lemma~\ref{lem:block_entropy_zero}.
+\end{proof}
+
 \begin{remark}[Boundedness of the mutual information]
     The monotone sequence $I_L$ is bounded by a constant depending only on the
     bond dimension, $I_L \le 4\log D$, so it converges as $L\to\infty$. For a


### PR DESCRIPTION
`MPOTensor.blockEntropy_zero` (`S_0 = 0`) and `MPOTensor.mutualInfoChain_zero` (`I_0 = 0`).

The reduced state of zero spins is one-dimensional, so its rank is 1; the rank bound on the entropy (`vonNeumannEntropy_le_log_rank`) gives `S_0 ≤ log 1 = 0`, and with `S_0 ≥ 0` this forces `S_0 = 0`. Then `I_0 = S_0 + S_N - S_N = S_0 = 0`.

Completes the boundary of the block-entropy / mutual-information picture (nonnegativity #2546, monotonicity #2467, symmetry #2551).

Blueprint: `lem:block_entropy_zero`, `lem:mutual_info_chain_zero`. Additive, no `sorry`; `lake build` ✓, `lake exe lint-style` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and blueprint text only; no changes to definitions or existing theorem statements.
> 
> **Overview**
> Adds **boundary cases** for MPDO block entropy and mutual information at **empty block length** (`L = 0`), alongside the existing nonnegativity, monotonicity, and symmetry results.
> 
> **Lean (`MutualInfoMonotone.lean`):** `MPOTensor.blockEntropy_zero` shows `S_0 = 0` by bounding the zero-spin reduced state (unit trace, rank ≤ 1) with `vonNeumannEntropy_le_log_rank` and squeezing against `blockEntropy_nonneg`. `MPOTensor.mutualInfoChain_zero` then gives `I_0 = 0` from `I_0 = S_0 + S_N - S_N`.
> 
> **Blueprint (`ch02b_mpdo.tex`):** Documents `lem:block_entropy_zero` and `lem:mutual_info_chain_zero` with `\leanok` proofs linked to those theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e5674eacd4bf6fc01832a0d75e5bcdac0549bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->