### PR TITLE
doc(MPS/MPDO): de-backtick math in empty-block docstrings

### DIFF
--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -399,7 +399,7 @@ theorem mutualInfoChain_symm {d D : ℕ} (M : MPOTensor d D) {N L : ℕ} (hL : L
   rw [blockEntropy_congr M N (show N - (N - L) = L by omega) (Nat.sub_le N (N - L)) hL hM]
   ring
 
-/-- The block entropy of the empty block vanishes: `S_0 = 0`. The reduced state of zero
+/-- The block entropy of the empty block vanishes, $S_0 = 0$. The reduced state of zero
 spins is a one-dimensional density matrix, whose entropy is zero. -/
 theorem blockEntropy_zero {d D : ℕ} (M : MPOTensor d D) (N : ℕ)
     (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
@@ -419,7 +419,7 @@ theorem blockEntropy_zero {d D : ℕ} (M : MPOTensor d D) (N : ℕ)
   have hlower : 0 ≤ M.blockEntropy N 0 (Nat.zero_le N) hM := blockEntropy_nonneg M _ hM htr
   linarith
 
-/-- The mutual information of the empty block vanishes: `I_0 = 0`. -/
+/-- The mutual information of the empty block vanishes, $I_0 = 0$. -/
 theorem mutualInfoChain_zero {d D : ℕ} (M : MPOTensor d D) (N : ℕ)
     (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
     M.mutualInfoChain N 0 (Nat.zero_le N) hM = 0 := by


### PR DESCRIPTION
Follow-up to #2557's review (B): the docstrings of `blockEntropy_zero` and `mutualInfoChain_zero` wrapped the formulas $S_0 = 0$ and $I_0 = 0$ in backticks (reserved for Lean identifiers). Switched to inline math. Docstring only; lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits; no proofs or definitions change.
> 
> **Overview**
> **Docstring-only** follow-up to #2557: the one-line summaries for `blockEntropy_zero` and `mutualInfoChain_zero` no longer wrap $S_0 = 0$ and $I_0 = 0$ in backticks (Lean uses those for identifiers). They now use inline math, consistent with nearby docstrings such as `mutualInfoChain_nonneg`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e99b813368462ac602449a1561b4c79529828b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->