### PR TITLE
feat(MPS/MPDO): empty-block pure-state entropy vanishes

### DIFF
--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -455,6 +455,14 @@ theorem pureBlockEntropy_nonneg (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N)
     (reducedPureBlockState_posSemidef A N L hL)
     (reducedPureBlockState_trace A N L hL htr)
 
+/-- The pure-state block entropy of the empty block vanishes: `S_0 = 0`. By the Schmidt
+symmetry it equals the full-system entropy `S_N`, which vanishes for a pure state. -/
+theorem pureBlockEntropy_empty (A : MPSTensor d D) (N : ℕ)
+    (htr : Matrix.trace (pureState A N) ≠ 0) :
+    pureBlockEntropy A N 0 (Nat.zero_le N) = 0 := by
+  rw [pureBlockEntropy_complement A N 0 (Nat.zero_le N)]
+  exact pureBlockEntropy_full A N htr
+
 end MPSTensor
 
 /-- **Pure-state mutual-information area-law bound.** For the purification MPDO of

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3530,6 +3530,20 @@ the elementary trace-power identity for diagonal matrices.
     entropy of a density matrix is nonnegative.
 \end{proof}
 
+\begin{lemma}[Empty-block pure-state entropy vanishes]
+    \label{lem:pure_block_entropy_empty}
+    \lean{MPSTensor.pureBlockEntropy_empty}
+    \leanok
+    \uses{def:pure_sal, lem:schmidt_symmetry}
+    For an MPS tensor $A$ with $V^{(N)}(A)\neq 0$, the pure-state block entropy of the
+    empty block vanishes: $S_0^{(N)}(A) = 0$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:schmidt_symmetry}
+    By the Schmidt symmetry $S_0^{(N)}(A) = S_{N}^{(N)}(A)$, and the entropy of the full
+    system vanishes for a pure state.
+\end{proof}
+
 \begin{lemma}[Pure-state mutual information is twice the block entropy]
     \label{lem:mutual_info_doubled}
     \lean{mutualInfoChain_doubledTensor}


### PR DESCRIPTION
`MPSTensor.pureBlockEntropy_empty`: $S_0^{(N)}(A) = 0$. By the Schmidt symmetry $S_0 = S_{N-0} = S_N$ (#2489) and the vanishing full-system pure-state entropy (#2505), the empty-block pure entropy is zero. Completes the pure-state boundary, mirroring the mixed `blockEntropy_zero` (#2557).

Blueprint: `lem:pure_block_entropy_empty`. Additive, no `sorry`; build ✓, lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean theorem and blueprint lemma only; no changes to existing proof logic beyond the new boundary result.
> 
> **Overview**
> Adds **`MPSTensor.pureBlockEntropy_empty`**, showing the pure-state block entropy for an empty block is **0** when the pure state is normalizable. The proof rewrites via **`pureBlockEntropy_complement`** at `L = 0` and applies **`pureBlockEntropy_full`** (`S_N = 0`), paralleling the mixed **`blockEntropy_zero`** boundary case.
> 
> The blueprint gains **`lem:pure_block_entropy_empty`** (`$S_0^{(N)}(A) = 0$`) with `\lean{MPSTensor.pureBlockEntropy_empty}` and a short proof citing Schmidt symmetry and vanishing full-system pure-state entropy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e4932243d70e69c776a69f6ba53778aaf7b660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->