### PR TITLE
doc(MPS/MPDO): fix block-entropy blueprint tags

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3233,7 +3233,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{lemma}[Nonnegativity of block entropies]
     \label{lem:block_entropy_nonneg}
-    \lean{MPOTensor.blockEntropy_nonneg}
+    \lean{blockEntropy_nonneg}
     \leanok
     \uses{def:block_entropy, thm:entropy_nonneg}
     For a normalized positive semidefinite finite-chain operator, every block entropy
@@ -3283,7 +3283,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{lemma}[Empty-block entropy vanishes]
     \label{lem:block_entropy_zero}
-    \lean{MPOTensor.blockEntropy_zero}
+    \lean{blockEntropy_zero}
     \leanok
     \uses{def:block_entropy, thm:entropy_le_log_rank, lem:block_entropy_nonneg}
     For a normalized positive semidefinite finite-chain operator, the block entropy of
@@ -3298,7 +3298,7 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{lemma}[Empty-block mutual information vanishes]
     \label{lem:mutual_info_chain_zero}
-    \lean{MPOTensor.mutualInfoChain_zero}
+    \lean{mutualInfoChain_zero}
     \leanok
     \uses{def:mutual_info_chain, lem:block_entropy_zero}
     For a normalized positive semidefinite finite-chain operator, the mutual information


### PR DESCRIPTION
## Summary

This fixes the blueprint declaration tags for the MPDO block-entropy boundary lemmas in ch02b_mpdo.tex.

The affected Lean theorems are section-level declarations, not declarations under MPOTensor, so the blueprint tags should be:

- blockEntropy_nonneg
- blockEntropy_zero
- mutualInfoChain_zero

The first item is the issue #2549 target. The latter two are adjacent entries with the same namespace-prefix mistake, and fixing them removes the corresponding MPDO sync failures as well.

Closes #2549.

## Checks

- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main
- git diff --check

The sync pass no longer reports the MPDO block-entropy tags as missing; it still reports unrelated existing PEPS and literal-ellipsis tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only tag corrections in TeX; no runtime or formal proof logic changes.
> 
> **Overview**
> **Blueprint–Lean sync for MPDO block-entropy boundary lemmas** in `ch02b_mpdo.tex`: three `\lean{...}` tags are corrected so they point at section-level Lean declarations instead of wrongly prefixed `MPOTensor.*` names.
> 
> - `lem:block_entropy_nonneg` → `blockEntropy_nonneg` (issue #2549)
> - `lem:block_entropy_zero` → `blockEntropy_zero`
> - `lem:mutual_info_chain_zero` → `mutualInfoChain_zero`
> 
> No Lean or proof changes—only LaTeX blueprint metadata so `blueprint_lean_sync` can resolve these lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76120bceecddbd41f934531692a2739a4ca1a18e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->