### PR TITLE
doc(parent): align C1 prose in blueprint

### DIFF
--- a/blueprint/src/chapter/ch04a_channel_representations.tex
+++ b/blueprint/src/chapter/ch04a_channel_representations.tex
@@ -1356,9 +1356,9 @@ This section states the existence theorems from
 \cite[Section~2.3]{Wolf2012Quantum}.
 % The Wolf.* declarations referenced in this section live in
 % TNLean/Channel/LorentzNormalForm.lean, which is not in the root import
-% graph because its core minimisation lemma is still on `sorry`. The
-% `\lean{...}` tags are omitted here so that checkdecls passes; the Lean
-% names are listed in the per-entry comments below.
+% graph because its core minimisation lemma is still on `sorry`. Declaration
+% tags are omitted here so that checkdecls passes; the Lean names are listed in
+% the per-entry comments below.
 
 % Lean: Wolf.SLFiltering
 \begin{definition}[SL-filtering operation]\label{def:sl_filtering}

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -4207,7 +4207,6 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \lean{TNLean.PEPS.NormalEdgeBlockingData.injective_chain}
     \lean{TNLean.PEPS.NormalEdgeBlockingData.endpoint_disjoint_cover}
     \lean{TNLean.PEPS.NormalEdgeBlockingData.endpoint_injective_disjoint_cover}
-    \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.blockingData}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.ofBlockingData}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.ofBlockingData_blockingData}
     \lean{TNLean.PEPS.NormalEdgeBlockingHypotheses.injective_chain_at_edge}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5076,13 +5076,15 @@ formulation; the passage to $\ker H_N$ is kept separate.
     three-block length are injective. Combining the equal-dimension and
     unequal-dimension branches over all ordered block pairs gives one common
     three-block trace-separation length, and hence the positive-length
-    blockwise word span required by the block-separation argument. Since each
-    block in block-injective canonical form is one-site injective, one may take $L=2$;
-    injectivity at lengths $2$ and $6$ then follows by passing from a
-    fixed injective length to positive multiples. This length-$6$ trace
-    separation is equivalently a full homogeneous pair span; concatenating
-    one-letter words propagates fullness to all later homogeneous lengths, so
-    the block-separation conditions also give a uniform finite pair-span period window.
+    blockwise word span required by the block-separation argument. In the
+    source theorem this span is obtained from Condition C1 at a finite
+    blocking length for each block. The proved specialization records the
+    stronger length-one span condition separately; under that extra hypothesis
+    the same trace-separation argument starts at the corresponding one-block
+    length and then passes to positive multiples. This trace separation is
+    equivalently a full homogeneous pair span; concatenating words propagates
+    fullness to later homogeneous lengths, so the block-separation conditions
+    also give a uniform finite pair-span period window.
     Combining this window with the conditional period-window homogenization
     theorem gives the homogeneous blockwise word span without separately
     assuming homogeneous identity pairs. The same conclusion applies
@@ -6681,9 +6683,10 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \uses{lem:one_block_injective_of_injective,
         lem:product_word_span_from_bnt_block_separation,
         lem:conditional_block_split_from_product_word_span}
-    In block-injective canonical form, each block is one-site injective, hence
-    one-block injective by Lemma~\ref{lem:one_block_injective_of_injective}.
-    The displayed separation equations imply
+    Condition C1 gives a finite block length at which each block has the
+    required physical--virtual correspondence. In the current length-one
+    specialization, Lemma~\ref{lem:one_block_injective_of_injective} supplies
+    the corresponding one-block injectivity. The displayed separation equations imply
     \[
         \spn\{(A_1^\omega,\ldots,A_g^\omega):|\omega|=1+S\}
         =


### PR DESCRIPTION
## Summary

- Replaces blueprint prose that treated block-injective canonical form as one-site injectivity with the source hypothesis: finite Condition C1 for each block.
- Keeps the length-one span condition as the explicitly stated special case of the current proved block-separation route.
- Removes a fake declaration-looking `\lean{...}` comment and a nonessential PEPS structure-field tag so blueprint sync and `checkdecls` agree.

## Mathematical Source

PGVWC07 Condition C1 is the finite-length condition
\[
  \operatorname{span}\{A^j_u: |u|=L_0\}=M_{D_j}(\mathbb C),
\]
not the length-one condition
\[
  \operatorname{span}\{A^j_a : a=1,\ldots,d\}=M_{D_j}(\mathbb C).
\]
This PR only corrects the prose and blueprint metadata. It does not prove the finite-C1 block-separation theorem.

Refs #2547.
Refs #905.

## Checks

- `lake exe cache get`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint metadata only; no Lean proofs or runtime behavior change.
> 
> **Overview**
> **Parent Hamiltonian blueprint (ch14)** prose is corrected so block-injective / block-separation arguments cite **Condition C1**—a finite blocking length \(L_0\) with \(\operatorname{span}\{A^j_u : |u|=L_0\} = M_{D_j}(\mathbb C)\)—rather than treating canonical form as automatic **one-site** injectivity. The **length-one word-span** specialization is described explicitly as the stronger hypothesis used by the current proved route, including the matching updates in the lemma narrative and the `\notready` proof sketch.
> 
> **Blueprint–Lean hygiene:** the Lorentz-normal-form comment is rephrased (still no `\lean{...}` tags while `LorentzNormalForm` stays off the import graph); a stray **`\lean{...blockingData}`** tag is dropped from the PEPS normal edge-blocking theorem; **`\end{proof}`** gets a proper trailing newline in ch04a.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfb37d45c72935845bbd5c6f8e32d183c95beed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->