### PR TITLE
refactor(parent): isolate boundary restriction coordinate gap

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -206,6 +206,15 @@ complementary word \(\mu\). The boundary-closing step is the equality
   =
   \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
+After choosing window witnesses, the remaining coordinate reconstruction is the
+left-multiplied family
+\[
+  A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
+  =
+  A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr),
+\]
+for all boundary letters \(\eta\), physical letters \(j\), and length-\(L_0\)
+words \(\alpha,\sigma\).
 
 **Open gap:** arXiv:2011.12127, Section IV.C, lines 2078--2079 states that
 the inverting-and-growing-back argument may also be applied when closing the
@@ -224,9 +233,47 @@ theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
       cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
           (⟨M, by omega⟩ : Fin (M + 1))
           (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
-        cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
           (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
           (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+  have hLocalWitness : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+        cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+          groundSpaceMap A (L₀ + 1) Y := by
+    intro i τ
+    have hmem := hLocal i τ
+    rw [groundSpace, LinearMap.mem_range] at hmem
+    obtain ⟨Y, hY⟩ := hmem
+    exact ⟨Y, hY.symm⟩
+  choose YAt hYAt using hLocalWitness
+  suffices hLeft : ∀ (η j : Fin d) (σ α : Fin L₀ → Fin d),
+      evalWord A (List.ofFn α) *
+          (YAt ⟨M + 1 - L₀, by omega⟩
+              (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) =
+        evalWord A (List.ofFn α) *
+          (evalWord A (List.ofFn μ) * A j * X *
+            evalWord A (List.ofFn σ)) by
+    have hMirrorPadded :=
+      closure_property_mirror_padded_products_of_left_word_products
+        (A := A) hInj hL₀ hM YAt X μ hLeft
+    have hMirrorRight :=
+      closure_property_mirror_right_product_eq_of_right_word_products
+        (A := A) hInj hL₀ hM YAt X μ hMirrorPadded
+    have hLast :=
+      (closure_property_boundary_one_sided_products_of_groundSpaceMap
+        (A := A) hInj hL₀ hM hψX YAt hYAt μ).1
+    intro η
+    refine closure_property_boundary_restriction_eq_of_first_products
+      (A := A) hL₀ hM η μ
+      (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+      (YAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) η μ))
+      (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+      (hYAt ⟨M + 1 - L₀, by omega⟩
+        (mirrorMiddleBackground L₀ (M + 1) η μ)) ?_
+    intro j
+    exact (hLast η j).trans (hMirrorRight η j).symm
+  intro η j σ α
   sorry
 
 /-- Left-multiplied comparison of the two cyclic restriction coordinates from

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2575,7 +2575,11 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \label{lem:closure_property_boundary_restrictions_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}
     \leanok
-    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    \uses{def:ground_space_map, rem:cyclic_window_operators,
+        lem:closure_property_boundary_one_sided_products_ground_space_map,
+        lem:closure_property_opposite_boundary_comparison_from_left_words,
+        lem:closure_property_opposite_boundary_comparison_from_right_words,
+        lem:closed_boundary_restriction_from_right_products}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
     $D\ge1$. Let
     \[
@@ -2606,11 +2610,45 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    % The cited paragraph does not display this equality. It is the local
-    % coordinate form of the sentence in \cite[lines~2078--2079]{Cirac2021Matrix}
-    % that the same inverting-and-growing-back argument applies when closing
-    % the boundaries. Remaining gap recorded in
-    % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
+    Choose matrices \(Y_i(\tau)\) representing the length-\((L_0+1)\)
+    restrictions. It is enough to prove, for every boundary letter \(\eta\),
+    physical letter \(j\), and length-\(L_0\) words \(\alpha,\sigma\), that
+    \[
+        A^\alpha
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
+        =
+        A^\alpha
+        \left(A^\mu A^jXA^\sigma\right).
+    \]
+    Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_left_words}
+    uses \(L_0\)-block injectivity to remove the left word and gives
+    \[
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+        =
+        A^\mu A^jXA^\sigma .
+    \]
+    Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_right_words}
+    uses \(L_0\)-block injectivity to remove the right word and gives
+    \[
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j
+        =
+        A^\mu A^jX .
+    \]
+    The last-boundary one-sided equation is
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
+    \]
+    Hence
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
+    \]
+    Lemma~\ref{lem:closed_boundary_restriction_from_right_products} identifies
+    the two length-\((L_0+1)\) restrictions. The displayed left-multiplied
+    family is the remaining coordinate form of the boundary-closing sentence in
+    \cite[lines~2078--2079]{Cirac2021Matrix}; it is recorded in
+    docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
 \begin{lemma}[First-letter products from equal boundary restrictions]


### PR DESCRIPTION
## Summary
- Refines `closure_property_boundary_restrictions_eq_of_groundSpaceMap` so the proved part now extracts window witnesses and reduces the boundary restriction equality to the left-multiplied coordinate family
  \[
  A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
  =
  A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr).
  \]
- Updates the matching blueprint entry to state the same reduction and to avoid treating the downstream right-product comparison as an independent input.

## Remaining mathematical assertion
Tracking issue: #2405 remains open. The unproved input is still the displayed left-multiplied boundary-closing reconstruction for every boundary letter \(\eta\), physical letter \(j\), and length-\(L_0\) words \(\alpha,\sigma\).

## Checks
- `lake env lean TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean` passes, with the expected existing `sorry` warning on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`.
- `lake build TNLean` passes, with pre-existing warnings in PEPS, MPDO, periodic overlap files, and the same parent-Hamiltonian `sorry` warning.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` passes.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passes.
- `leanblueprint checkdecls` passes after generating the ignored `blueprint/lean_decls` file.
- `git diff --check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure and documentation only; the main theorem still admits the same `sorry` on the coordinate reconstruction, with no runtime or security impact.
> 
> **Overview**
> **Refactors** `closure_property_boundary_restrictions_eq_of_groundSpaceMap` so the boundary-closing cyclic restriction equality is proved modulo a single **left-multiplied coordinate family** (for all \(\eta, j, \alpha, \sigma\)), instead of leaving the whole statement as an opaque gap.
> 
> The Lean proof now **chooses matrix witnesses** `YAt` from local ground-space membership, **`suffices`** that family, then chains existing stripping lemmas (left-word mirror padding, right-word comparison, one-sided last-boundary products) to recover the two restrictions; only that family remains as **`sorry`**. Doc comments state this as the explicit open gap tied to the paper.
> 
> The **blueprint** lemma `lem:closure_property_boundary_restrictions_ground_space_map` is aligned: `\uses` lists the reduction lemmas, and the proof sketch walks the same witness → left-multiplied equation → injectivity stripping → first-letter products → restriction identification path (still not marked complete in Lean).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442db4062324b721af0bd265dbcfe784adf95fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->