### PR TITLE
doc(blueprint): add recent MPDO and block-reindex entries

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3530,25 +3530,45 @@ the elementary trace-power identity for diagonal matrices.
     entropy of a density matrix is nonnegative.
 \end{proof}
 
+\begin{lemma}[Full-block pure-state entropy vanishes]
+    \label{lem:pure_entropy_full}
+    \lean{pureBlockEntropy_full}
+    \leanok
+    \uses{def:pure_sal}
+    For an MPS tensor $A$ with $V^{(N)}(A)\neq 0$, the entropy of the whole chain
+    vanishes:
+    \[
+        S_N^{(N)}(A) = 0 .
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    The normalized operator is the rank-one pure state
+    \[
+        \frac{\ket{V^{(N)}(A)}\bra{V^{(N)}(A)}}
+             {\langle V^{(N)}(A), V^{(N)}(A)\rangle} ,
+    \]
+    after reindexing the full block. A pure state has von Neumann entropy zero.
+\end{proof}
+
 \begin{lemma}[Empty-block pure-state entropy vanishes]
     \label{lem:pure_block_entropy_empty}
     \lean{MPSTensor.pureBlockEntropy_empty}
     \leanok
-    \uses{def:pure_sal, lem:schmidt_symmetry}
+    \uses{def:pure_sal, lem:pure_entropy_full, lem:schmidt_symmetry}
     For an MPS tensor $A$ with $V^{(N)}(A)\neq 0$, the pure-state block entropy of the
     empty block vanishes: $S_0^{(N)}(A) = 0$.
 \end{lemma}
 \begin{proof}\leanok
-    \uses{lem:schmidt_symmetry}
+    \uses{lem:pure_entropy_full, lem:schmidt_symmetry}
     By the Schmidt symmetry $S_0^{(N)}(A) = S_{N}^{(N)}(A)$, and the entropy of the full
-    system vanishes for a pure state.
+    system vanishes for a pure state (Lemma~\ref{lem:pure_entropy_full}).
 \end{proof}
 
 \begin{lemma}[Pure-state mutual information is twice the block entropy]
     \label{lem:mutual_info_doubled}
     \lean{mutualInfoChain_doubledTensor}
     \leanok
-    \uses{lem:schmidt_symmetry, lem:blockEntropy_doubledTensor}
+    \uses{lem:pure_entropy_full, lem:schmidt_symmetry, lem:blockEntropy_doubledTensor}
     For an MPS tensor $A$ with $V^{(N)}(A)\neq 0$, the mutual information of the
     purification MPDO equals twice the pure-state block entropy:
     \[
@@ -3557,8 +3577,9 @@ the elementary trace-power identity for diagonal matrices.
 \end{lemma}
 \begin{proof}\leanok
     By definition $I_L = S_L + S_{N-L} - S_N$ for the generated state. The global
-    entropy of the pure state vanishes, $S_N = 0$, and the Schmidt symmetry
-    (Lemma~\ref{lem:schmidt_symmetry}) gives $S_{N-L} = S_L$, so $I_L = 2\,S_L$.
+    entropy of the pure state vanishes (Lemma~\ref{lem:pure_entropy_full}), and
+    the Schmidt symmetry (Lemma~\ref{lem:schmidt_symmetry}) gives
+    $S_{N-L} = S_L$, so $I_L = 2\,S_L$.
 \end{proof}
 
 \begin{proposition}[Pure-state mutual-information bound]\label{prop:pure_mutual_info_bound}

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -1432,6 +1432,31 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
     identical.
 \end{proof}
 
+\begin{lemma}[MPV invariance under block reindexing]\label{lem:mpv_reindex_blocks}
+    \lean{MPSTensor.mpv_toTensorFromBlocks_reindex}\leanok
+    \uses{def:block_diagonal_tensor, thm:mpv_decomposition}
+    Let $e : \{0,\ldots,r'-1\}\simeq\{0,\ldots,r-1\}$ be a bijection of block
+    indices. For weights $\mu_k$, block tensors $A_k$, word length $N$, and
+    configuration $\sigma$, the coefficient of the block-diagonal MPV is unchanged
+    by reindexing the blocks along $e$:
+    \[
+        V^{(N)}\!\left(\bigoplus_k \mu_k A_k\right)_\sigma
+        =
+        V^{(N)}\!\left(\bigoplus_k \mu_{e(k)} A_{e(k)}\right)_\sigma .
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:mpv_decomposition}
+    Expanding both sides by Theorem~\ref{thm:mpv_decomposition} gives
+    \[
+        \sum_k \mu_k^N\,V^{(N)}(A_k)_\sigma
+        \quad\text{and}\quad
+        \sum_k \mu_{e(k)}^N\,V^{(N)}(A_{e(k)})_\sigma .
+    \]
+    These sums are equal by reindexing the finite sum along the bijection $e$.
+\end{proof}
+
 \subsection{Converse: gauge equivalence implies same MPV}%
 \label{subsec:converse_gauge_mpv}
 


### PR DESCRIPTION
## Summary

- add the blueprint entry for the full-chain pure-state entropy identity `pureBlockEntropy_full`
- add the blueprint entry for block-diagonal MPV invariance under reindexing
- update the dependent `\uses{}` fields so the mutual-information and empty-block entropy arguments cite the full-chain entropy step

Close #2521.
Close #2538.

## Verification

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `lake build TNLean`
- `leanblueprint checkdecls`
- `leanblueprint web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX and `\uses{}` sync with existing Lean theorems; no runtime or proof logic changes in this diff.
> 
> **Overview**
> Adds two blueprint lemmas with Lean sync tags and wires them into existing entropy arguments.
> 
> In **`ch02b_mpdo.tex`**, documents **`lem:pure_entropy_full`** (`pureBlockEntropy_full`): the full-chain pure-state block entropy is zero. Proofs for empty-block entropy and purification mutual information now cite this lemma instead of stating that global entropy vanishes inline; related `\uses{}` lists are updated.
> 
> In **`ch13_algebraic_ft.tex`**, documents **`lem:mpv_reindex_blocks`** (`MPSTensor.mpv_toTensorFromBlocks_reindex`): reindexing blocks of a weighted block-diagonal assembly along a bijection leaves each MPV coefficient unchanged, via the MPV decomposition and finite sum reindexing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e265b160397e57afe53d3b2449c6f09caa060790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->