### PR TITLE
fix(parent): use finite C1 in BNT block separation

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -57,6 +57,39 @@ theorem groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge
   exact groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
     hAj_blk hAk_blk hAj_inj hAk_inj le_rfl hL ⟨N, hN, hLN, hSep⟩
 
+/-- Same-dimension BNT-separated blocks give the PGVWC directness conclusion from
+Condition C1 at a finite length \(L_0\).
+
+PGVWC07, Lemma `lem:direct-sum`, first uses Condition C1 in each block at
+length \(L_0\), then compares the spaces \(\mathcal G_{L_0+1}^{A^j}\). This
+version follows that length convention and does not assume one-site
+injectivity. -/
+theorem groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {j k : Fin r} (hjk : j ≠ k) (hdim : dim j = dim k)
+    {L₀ : ℕ}
+    (hAj_c1 : IsNBlkInjective (cast (congr_arg (MPSTensor d) hdim) (A j)) L₀)
+    (hAk_c1 : IsNBlkInjective (A k) L₀)
+    (hAj_blk : IsNBlkInjective
+      (cast (congr_arg (MPSTensor d) hdim) (A j)) (L₀ + 1))
+    (hAk_blk : IsNBlkInjective (A k) (L₀ + 1))
+    (hL₀ : 0 < L₀) :
+    groundSpace (cast (congr_arg (MPSTensor d) hdim) (A j))
+        ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ⊓
+      groundSpace (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) = ⊥ := by
+  obtain ⟨N, hNmin, hSep⟩ :=
+    exists_ge_not_forall_mpv_eq_mul_of_blocksNotGaugePhaseEquiv_of_irreducible_TP
+      A hIrr hLeft hOverlap hBlocks hjk hdim (max 2 (L₀ + 1))
+  have hN : 2 ≤ N := le_trans (Nat.le_max_left 2 (L₀ + 1)) hNmin
+  have hLN : L₀ + 1 ≤ N := le_trans (Nat.le_max_right 2 (L₀ + 1)) hNmin
+  exact groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ
+    hAj_c1 hAk_c1 hAj_blk hAk_blk le_rfl hL₀ ⟨N, hN, hLN, hSep⟩
+
 /-- Same-dimension BNT-separated blocks give homogeneous pair trace separation
 at the three-block length once the direct-sum injectivity hypotheses are
 supplied.
@@ -85,6 +118,36 @@ theorem pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of
   exact pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective
     (groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge
       A hIrr hLeft hOverlap hBlocks hjk hdim hAj_blk hAk_blk hAj_inj hAk_inj hL)
+    hAj_blk3 hAk_blk3
+
+/-- Same-dimension BNT-separated blocks give homogeneous pair trace separation
+at the PGVWC length \(3(L_0+1)\), assuming Condition C1 at \(L_0\) and the
+corresponding block injectivity at \(L_0+1\) and \(3(L_0+1)\). -/
+theorem pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {j k : Fin r} (hjk : j ≠ k) (hdim : dim j = dim k)
+    {L₀ : ℕ}
+    (hAj_c1 : IsNBlkInjective (cast (congr_arg (MPSTensor d) hdim) (A j)) L₀)
+    (hAk_c1 : IsNBlkInjective (A k) L₀)
+    (hAj_blk : IsNBlkInjective
+      (cast (congr_arg (MPSTensor d) hdim) (A j)) (L₀ + 1))
+    (hAk_blk : IsNBlkInjective (A k) (L₀ + 1))
+    (hAj_blk3 : IsNBlkInjective
+      (cast (congr_arg (MPSTensor d) hdim) (A j))
+      ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hAk_blk3 : IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀) :
+    PairTraceSeparatingAt
+      (cast (congr_arg (MPSTensor d) hdim) (A j)) (A k)
+      ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
+  exact pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective
+    (groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1
+      A hIrr hLeft hOverlap hBlocks hjk hdim hAj_c1 hAk_c1 hAj_blk hAk_blk hL₀)
     hAj_blk3 hAk_blk3
 
 /-- BNT-separated blocks give a common three-block homogeneous pair trace
@@ -121,6 +184,44 @@ theorem forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
   · exact pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_ne
       (hBlk k) (hBlk j) (hBlk3 k) (hBlk3 j) hdim
 
+/-- BNT-separated blocks give the PGVWC pair trace separation length from
+Condition C1 at \(L_0\), without the one-site special case of Condition C1.
+
+The length is \(3(L_0+1)\), written as
+\((L_0+1)+((L_0+1)+(L_0+1))\) to match the formal concatenation of the three
+blocks in PGVWC07, Lemma `lem:direct-sum`. -/
+theorem forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1))
+    (hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀) :
+    ∀ k j : Fin r, j ≠ k →
+      PairTraceSeparatingAt (A k) (A j)
+        ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
+  intro k j hjk
+  by_cases hdim : dim k = dim j
+  · apply pairTraceSeparatingAt_uncast_left hdim
+    exact pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1
+      A hIrr hLeft hOverlap hBlocks hjk.symm hdim
+      ((isNBlkInjective_cast_dim hdim (A k) L₀).2 (hBlk0 k))
+      (hBlk0 j)
+      ((isNBlkInjective_cast_dim hdim (A k) (L₀ + 1)).2 (hBlk1 k))
+      (hBlk1 j)
+      ((isNBlkInjective_cast_dim hdim (A k)
+        ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))).2 (hBlk3 k))
+      (hBlk3 j)
+      hL₀
+  · exact pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_ne
+      (hBlk1 k) (hBlk1 j) (hBlk3 k) (hBlk3 j) hdim
+
 /-- Existential common-length form of
 `forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv`.
 
@@ -142,6 +243,26 @@ theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEqu
   ⟨L + (L + L),
     forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL⟩
+
+/-- Existential common-length form of
+`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1`. -/
+theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1))
+    (hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀) :
+    ∃ S : ℕ, ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S :=
+  ⟨(L₀ + 1) + ((L₀ + 1) + (L₀ + 1)),
+    forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀⟩
 
 /-- BNT-separated blocks give common pairwise block-separating equations at the
 three-block length, once the direct-sum injectivity hypotheses are supplied.
@@ -165,6 +286,26 @@ theorem hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
     (forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
 
+/-- BNT-separated blocks give common pairwise block-separating equations at
+length \(3(L_0+1)\) from Condition C1 at \(L_0\). -/
+theorem hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1))
+    (hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀) :
+    HasPairBlockSeparatingWords A ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) :=
+  hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt A
+    (forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀)
+
 /-- BNT-separated blocks satisfy the abstract block-injectivity selector datum
 under the same explicit direct-sum injectivity hypotheses. -/
 theorem propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum
@@ -182,6 +323,25 @@ theorem propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum
   propBlockInjective_of_common_blockInjective_of_pairBlockSeparatingWords A hBlk
     (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
+
+/-- Finite-C1 version of the BNT abstract block-injectivity selector datum. -/
+theorem propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1))
+    (hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀) :
+    PropBlockInjective A :=
+  propBlockInjective_of_common_blockInjective_of_pairBlockSeparatingWords A hBlk1
+    (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀)
 
 /-- Common block injectivity and the BNT direct-sum separation input give a
 finite simultaneous block-word span.
@@ -208,6 +368,34 @@ theorem wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
     (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
 
+/-- Finite-C1 version of the BNT direct-sum product span.
+
+The simultaneous block-word tuples span the full product algebra at
+\[
+  (L_0+1)+(r-1)\,3(L_0+1).
+\]
+The proof follows PGVWC07 by using Condition C1 at \(L_0\), the source
+comparison length \(L_0+1\), and the three-block separation length
+\(3(L_0+1)\). -/
+theorem wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1))
+    (hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀) :
+    WordTupleSpanTop A
+      ((L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))) :=
+  wordTupleSpanTop_of_common_blockInjective_of_pairBlockSeparatingWords A hBlk1
+    (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀)
+
 /-- Existential form of
 `wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors`. -/
 theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
@@ -225,5 +413,25 @@ theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
   ⟨L + (r - 1) * (L + (L + L)),
     wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL⟩
+
+/-- Existential form of
+`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`. -/
+theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1))
+    (hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀) :
+    ∃ N : ℕ, WordTupleSpanTop A N :=
+  ⟨(L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))),
+    wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀⟩
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -100,6 +100,33 @@ theorem not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne
     _ = chainGroundSpace B L N := hChain
     _ = mpvSubmodule B N := hBeq
 
+/-- Finite-C1 form of the equal-size parent-Hamiltonian contradiction.
+
+PGVWC07, Lemma `lem:direct-sum`, uses Condition C1 at a length \(L_0\) and
+then compares the parent Hamiltonian whose local image space is
+\(\mathcal G_{L_0+1}\). This version uses the normal parent-Hamiltonian
+uniqueness theorem at range \(L_0+1\), rather than assuming the one-site span
+condition. -/
+theorem not_bondDim_eq_and_groundSpace_succ_eq_of_mpvSubmodule_ne
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hB : IsNBlkInjective B L₀)
+    (hL₀ : 0 < L₀) (hN : 2 ≤ N) (hLN : L₀ + 1 ≤ N)
+    (hDistinct : mpvSubmodule A N ≠ mpvSubmodule B N) :
+    ¬ (D₁ = D₂ ∧ groundSpace A (L₀ + 1) = groundSpace B (L₀ + 1)) := by
+  rintro ⟨hD, hG⟩
+  subst hD
+  have hChain : chainGroundSpace A (L₀ + 1) N = chainGroundSpace B (L₀ + 1) N :=
+    chainGroundSpace_eq_of_groundSpace_eq hG
+  have hAeq : chainGroundSpace A (L₀ + 1) N = mpvSubmodule A N :=
+    chainGroundSpace_eq_mpvSubmodule_normal ⟨L₀, hA⟩ hA hL₀ hN (by omega) hLN
+  have hBeq : chainGroundSpace B (L₀ + 1) N = mpvSubmodule B N :=
+    chainGroundSpace_eq_mpvSubmodule_normal ⟨L₀, hB⟩ hB hL₀ hN (by omega) hLN
+  apply hDistinct
+  calc
+    mpvSubmodule A N = chainGroundSpace A (L₀ + 1) N := hAeq.symm
+    _ = chainGroundSpace B (L₀ + 1) N := hChain
+    _ = mpvSubmodule B N := hBeq
+
 /-- Two-block directness from a sufficiently long pointwise non-proportional
 MPV state. -/
 theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
@@ -114,6 +141,28 @@ theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
   exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
     hAblk hBblk hD
     (not_bondDim_eq_and_groundSpace_eq_of_mpvSubmodule_ne hA hB hN hL hLN
+      (mpvSubmodule_ne_of_not_exists_mpv_eq_smul
+        (not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul hSep)))
+
+/-- Finite-C1 form of the same two-block directness statement.
+
+The source length is \(L_0+1\), where \(L_0\) is the Condition C1 length. -/
+theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    {L₀ : ℕ}
+    (hA0 : IsNBlkInjective A L₀) (hB0 : IsNBlkInjective B L₀)
+    (hAblk : IsNBlkInjective A (L₀ + 1)) (hBblk : IsNBlkInjective B (L₀ + 1))
+    (hD : D₂ ≤ D₁) (hL₀ : 0 < L₀)
+    (hDistinct :
+      ∃ N : ℕ, 2 ≤ N ∧ L₀ + 1 ≤ N ∧
+        ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
+    groundSpace A ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ⊓
+        groundSpace B ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) = ⊥ := by
+  rcases hDistinct with ⟨N, hN, hLN, hSep⟩
+  exact groundSpace_inf_eq_bot_of_not_bondDim_eq_and_groundSpace_eq_of_dim_ge
+    hAblk hBblk hD
+    (not_bondDim_eq_and_groundSpace_succ_eq_of_mpvSubmodule_ne
+      hA0 hB0 hL₀ hN hLN
       (mpvSubmodule_ne_of_not_exists_mpv_eq_smul
         (not_exists_mpv_eq_smul_of_not_exists_forall_mpv_eq_mul hSep)))
 
@@ -136,6 +185,25 @@ theorem pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_
   exact pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective
     (groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
       hAblk hBblk hA hB hD hL hDistinct)
+    hAblk3 hBblk3
+
+/-- Finite-C1 form of homogeneous pair trace separation at the PGVWC
+three-block length \(3(L_0+1)\). -/
+theorem pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
+    {L₀ : ℕ}
+    (hA0 : IsNBlkInjective A L₀) (hB0 : IsNBlkInjective B L₀)
+    (hAblk : IsNBlkInjective A (L₀ + 1)) (hBblk : IsNBlkInjective B (L₀ + 1))
+    (hAblk3 : IsNBlkInjective A ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hBblk3 : IsNBlkInjective B ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hD : D₂ ≤ D₁) (hL₀ : 0 < L₀)
+    (hDistinct :
+      ∃ N : ℕ, 2 ≤ N ∧ L₀ + 1 ≤ N ∧
+        ¬ ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ) :
+    PairTraceSeparatingAt A B ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
+  exact pairTraceSeparatingAt_of_groundSpace_inf_eq_bot_of_isNBlkInjective
+    (groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ
+      hA0 hB0 hAblk hBblk hD hL₀ hDistinct)
     hAblk3 hBblk3
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -56,6 +56,39 @@ theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
     hUnital
 
+/-- Condition-C1 version of
+`pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors`.
+
+The source length is \(L_0+1\), where \(L_0\) is the common Condition C1
+length of the blocks. -/
+theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1))
+    (hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀)
+    {n : ℕ}
+    (hn : n =
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1) :
+    ((⨅ b : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+      (⨅ a : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+      ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  subst n
+  exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
+    (wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀)
+    hUnital
+
 /-- Homogeneous span propagation gives the BNT product span at every
 sufficiently large length.
 
@@ -125,6 +158,48 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital
   exact wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords
     A hBlk hUnital hPair (by simpa [S] using hn)
 
+/-- Condition-C1 form of the BNT product span at all sufficiently large lengths.
+
+Assume Condition C1 for every block at the common length \(L_0\) and the
+normalization
+\[
+  \sum_a A^j_aA^{j\dagger}_a=I.
+\]
+The normalization propagates Condition C1 from \(L_0\) to \(L_0+1\) and
+\(3(L_0+1)\). The BNT direct-sum argument at the source length \(L_0+1\)
+then gives the simultaneous product span for every
+\[
+  n\ge (L_0+1)+(r-1)\,3(L_0+1).
+\] -/
+theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    WordTupleSpanTop A n := by
+  let S : ℕ := (L₀ + 1) + ((L₀ + 1) + (L₀ + 1))
+  have hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1) := by
+    intro k
+    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  have hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) S := by
+    intro k
+    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  have hPair : HasPairBlockSeparatingWords A S := by
+    simpa [S] using
+      (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+        A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 (by simpa [S] using hBlk3) hL₀)
+  exact wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords
+    A hBlk1 hUnital hPair (by simpa [S] using hn)
+
 /-- Under the normalized BNT block-separation hypotheses, the local spaces
 \(G_n(A^j)\) form an internal direct sum.
 
@@ -150,6 +225,27 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
   groundSpace_iSupIndep_of_wordTupleSpanTop A
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
+
+/-- Condition-C1 form of the internal-direct-sum conclusion for the block local
+spaces. -/
+theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    iSupIndep fun j : Fin r => groundSpace (A j) n :=
+  groundSpace_iSupIndep_of_wordTupleSpanTop A
+    (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn)
 
 /-- BNT block-separation conditions and PGVWC07 normalization give the one-step
 block-intersection identity at every length above the BNT block-separation
@@ -187,6 +283,32 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
   exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
+    hUnital
+
+/-- Condition-C1 form of the one-step block-intersection identity at every
+length above the BNT block-separation bound. -/
+theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    ((⨅ b : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+      (⨅ a : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+      ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
+    (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn)
     hUnital
 
 /-- Normalized BNT block-separation hypotheses give the large-length block
@@ -235,6 +357,37 @@ theorem pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital (by omega),
     pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn⟩
+
+/-- Condition-C1 form of the large-length block intersection as an internal
+direct sum. -/
+theorem pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    iSupIndep (fun j : Fin r => groundSpace (A j) (n + 1)) ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) (n + 2)) ∧
+        ((⨅ b : Fin d,
+            (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+          (⨅ a : Fin d,
+            (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+          ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  exact ⟨
+    groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital (by omega),
+    groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital (by omega),
+    pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn⟩
 
 /-- BNT block-separating equations and a homogeneous block-injectivity period
 window give the PGVWC block-intersection identity for all sufficiently large
@@ -330,5 +483,29 @@ theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital
   intro n hn
   exact pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
     A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn
+
+/-- Condition-C1 form of the eventual block-intersection identity without a
+separate one-site injectivity assumption. -/
+theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1) :
+    ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
+      ((⨅ b : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+        (⨅ a : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+        ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  refine ⟨(L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))), ?_⟩
+  intro n hn
+  exact pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
+    A hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -5474,10 +5474,10 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{lemma}[BNT block separation gives a finite blockwise product span]
     \label{lem:bnt_direct_sum_block_separation_word_span}
-    \lean{MPSTensor.hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv}
-    \lean{MPSTensor.propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum}
-    \lean{MPSTensor.wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors}
-    \lean{MPSTensor.exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors}
+    \lean{MPSTensor.hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1}
+    \lean{MPSTensor.propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum_c1}
+    \lean{MPSTensor.wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1}
+    \lean{MPSTensor.exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1}
     \leanok
     \uses{lem:direct_sum_two_block_dimension_step,
         lem:pair_trace_separation_to_pairwise_block_separation,
@@ -5485,25 +5485,32 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:product_word_span_from_bnt_block_separation}
     Let \(A^1,\ldots,A^r\) be separated BNT blocks satisfying the
     irreducibility, left-canonicality, and normalized self-overlap hypotheses
-    used in the direct-sum comparison. Assume the direct-sum injectivity
-    hypotheses
+    used in the direct-sum comparison. Fix \(L_0>0\). Assume that, for every
+    block \(j\), the map
     \[
-        \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C),
+        \Gamma_{L_0}^{A^j}:M_{D_j}(\mathbb C)\to
+        (\mathbb C^d)^{\otimes L_0},
         \qquad
-        \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
-        \qquad
-        \operatorname{span}\{A^j_v:|v|=L+(L+L)\}=M_{D_j}(\mathbb C),
+        X\longmapsto
+        \sum_{|u|=L_0}\tr(XA^j_u)\ket{u}
     \]
-    for every block \(j\), with \(1<L\). Then for every ordered pair
-    \(k\ne j\) there are coefficients \(c^{k,j}_\omega\) such that
+    is injective, and that the homogeneous word spans at the two source
+    lengths are full:
     \[
-        \sum_{|\omega|=L+(L+L)} c^{k,j}_\omega A^k_\omega=I,
+        \operatorname{span}\{A^j_u:|u|=L_0+1\}=M_{D_j}(\mathbb C),
         \qquad
-        \sum_{|\omega|=L+(L+L)} c^{k,j}_\omega A^j_\omega=0.
+        \operatorname{span}\{A^j_v:|v|=3(L_0+1)\}=M_{D_j}(\mathbb C).
+    \]
+    Then for every ordered pair \(k\ne j\) there are coefficients
+    \(c^{k,j}_\omega\) such that
+    \[
+        \sum_{|\omega|=3(L_0+1)} c^{k,j}_\omega A^k_\omega=I,
+        \qquad
+        \sum_{|\omega|=3(L_0+1)} c^{k,j}_\omega A^j_\omega=0.
     \]
     Consequently the simultaneous block-word tuples at length
     \[
-        L+(r-1)(L+(L+L))
+        (L_0+1)+(r-1)3(L_0+1)
     \]
     span the full product algebra
     \[
@@ -5514,7 +5521,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 \begin{proof}
     \leanok
     Lemma~\ref{lem:direct_sum_two_block_dimension_step} gives homogeneous
-    trace separation at length \(L+(L+L)\) for every ordered pair of distinct
+    trace separation at length \(3(L_0+1)\) for every ordered pair of distinct
     BNT blocks. Lemma~\ref{lem:pair_trace_separation_to_pairwise_block_separation}
     converts these trace-separation equations into the displayed pairwise
     block-separating equations. Multiplying the equations for the \(r-1\)
@@ -5889,7 +5896,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{lemma}[BNT block separation gives one block-intersection step]
     \label{lem:bnt_direct_sum_block_separation_block_intersection}
-    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors_c1}
     \leanok
     \uses{lem:bnt_direct_sum_block_separation_word_span,
         lem:block_restriction_intersection_subspace}
@@ -5901,7 +5908,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
     for every block \(j\). Let
     \[
-        n=L+(r-1)(L+(L+L)),
+        n=(L_0+1)+(r-1)3(L_0+1),
         \qquad
         S_n=\bigvee_jG_{n+1}(A^j).
     \]
@@ -5932,10 +5939,22 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \label{lem:bnt_direct_sum_block_separation_period_window_block_intersection}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_period_window}
     \leanok
-    \uses{lem:bnt_direct_sum_block_separation_word_span,
+    \uses{lem:direct_sum_two_block_dimension_step,
+        lem:pair_trace_separation_to_pairwise_block_separation,
+        lem:block_separating_equations_from_pairwise_separation,
         lem:period_window_block_restriction_intersection}
-    Under the hypotheses of
-    Lemma~\ref{lem:bnt_direct_sum_block_separation_word_span}, set
+    Let \(A^1,\ldots,A^r\) be separated BNT blocks satisfying the
+    irreducibility, left-canonicality, and normalized self-overlap hypotheses
+    used in the direct-sum comparison. Assume \(L>1\), and assume that, for
+    every block \(j\),
+    \[
+        \operatorname{span}\{A^j_a:a=0,\ldots,d-1\}=M_{D_j}(\mathbb C),
+        \qquad
+        \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
+        \qquad
+        \operatorname{span}\{A^j_v:|v|=L+(L+L)\}=M_{D_j}(\mathbb C).
+    \]
+    Set
     \[
         S=L+(L+L),
         \qquad
@@ -5971,24 +5990,24 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \leanok
-    The block-separation conditions give, for each ordered pair of distinct blocks,
-    length-\(S\) equations which are the identity on the first block and zero on
-    the second. Multiplying these equations over the \(r-1\) other blocks gives
-    a block-separating equation of total length \(q\). Combining this equation
-    with block injectivity at length \(p\) gives the full product span at length
-    \(p+q\). Combining it with the assumed block-injectivity window gives the
-    full product span at lengths \(s_0+q+s\), for \(0\le s<p+q\). The
-    period-window form of the block-intersection identity then gives the
-    displayed equality for all sufficiently large \(n\).
+    The direct-sum dimension step gives, for each ordered pair of distinct
+    blocks, length-\(S\) equations which are the identity on the first block and
+    zero on the second. Multiplying these equations over the \(r-1\) other
+    blocks gives a block-separating equation of total length \(q\). Combining
+    this equation with block injectivity at length \(p\) gives the full product
+    span at length \(p+q\). Combining it with the assumed block-injectivity
+    window gives the full product span at lengths \(s_0+q+s\), for
+    \(0\le s<p+q\). The period-window form of the block-intersection identity
+    then gives the displayed equality for all sufficiently large \(n\).
 \end{proof}
 
 \begin{lemma}[Normalized block-separating equations give all large product spans]
     \label{lem:unital_block_separating_product_span}
     \lean{MPSTensor.wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords}
-    \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital}
+    \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1}
     \leanok
     \uses{def:pairwise_block_separating_words,
-        lem:bnt_direct_sum_pair_separating_words,
+        lem:bnt_direct_sum_block_separation_word_span,
         thm:wordspan_propagation_unital}
     Let \(A^1,\ldots,A^r\) be blocks satisfying the normalization
     \[
@@ -6005,17 +6024,14 @@ formulation; the passage to $\ker H_N$ is kept separate.
         =
         \prod_j M_{D_j}(\mathbb C).
     \]
-    In particular, for separated BNT blocks, the same conclusion holds with
+    In particular, for separated BNT blocks satisfying the same normalization,
+    if \(L_0>0\) and \(\Gamma_{L_0}^{A^j}\) is injective for every block \(j\),
+    the same conclusion holds with
     \[
-        S=L+(L+L),
+        S=3(L_0+1),
         \qquad
-        n\ge L+(r-1)(L+(L+L)).
+        n\ge (L_0+1)+(r-1)3(L_0+1).
     \]
-    In this specialization one also assumes the length-one span condition
-    \[
-        \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C)
-    \]
-    for every block \(j\).
 \end{lemma}
 
 \begin{proof}
@@ -6029,15 +6045,17 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
     For \(n\ge L+(r-1)S\), take \(m=n-(r-1)S\). Combining the length-\(m\)
     block span with the \(r-1\) block-separating equations gives the displayed
-    product span at length \(n\).  In the BNT case,
-    Lemma~\ref{lem:bnt_direct_sum_pair_separating_words} supplies the
-    block-separating equations with \(S=L+(L+L)\).
+    product span at length \(n\). In the BNT case, the injectivity of
+    \(\Gamma_{L_0}^{A^j}\) gives the full span at length \(L_0\), and the
+    normalization propagates it to the lengths \(L_0+1\) and \(3(L_0+1)\).
+    Lemma~\ref{lem:bnt_direct_sum_block_separation_word_span} then supplies the
+    block-separating equations with \(S=3(L_0+1)\).
 \end{proof}
 
 \begin{lemma}[Product span makes the sum of local spaces direct]
     \label{lem:product_span_block_image_direct_sum}
     \lean{MPSTensor.groundSpace_iSupIndep_of_wordTupleSpanTop}
-    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital}
+    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1}
     \leanok
     \uses{def:ground_space_parent, lem:unital_block_separating_product_span}
     Suppose
@@ -6053,9 +6071,9 @@ formulation; the passage to $\ker H_N$ is kept separate.
         \sum_j\phi_j=0,
     \]
     then \(\phi_j=0\) for every \(j\).  In particular, for the normalized BNT
-    input above, this directness holds for every
+    hypotheses above, this directness holds for every
     \[
-        n\ge L+(r-1)(L+(L+L)).
+        n\ge (L_0+1)+(r-1)3(L_0+1).
     \]
 \end{lemma}
 
@@ -6079,31 +6097,29 @@ formulation; the passage to $\ker H_N$ is kept separate.
     by substituting Lemma~\ref{lem:unital_block_separating_product_span}.
 \end{proof}
 
-\begin{lemma}[Normalized BNT input gives the large-length block intersection]
+\begin{lemma}[Normalized BNT blocks give the large-length block intersection]
     \label{lem:bnt_direct_sum_unital_block_intersection_ge}
-    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital}
     \lean{MPSTensor.pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop}
-    \lean{MPSTensor.pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1}
+    \lean{MPSTensor.pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital_c1}
     \leanok
     \uses{lem:unital_block_separating_product_span,
         lem:product_span_block_image_direct_sum,
         lem:block_restriction_intersection_subspace}
     Let \(A^1,\ldots,A^r\) be separated BNT blocks satisfying the irreducibility,
     left-canonicality, and normalized self-overlap hypotheses used in the
-    direct-sum comparison. Suppose \(1<L\), every block is injective at length
-    \(L\),
+    direct-sum comparison. Suppose \(L_0>0\), and for every block \(j\) the map
     \[
-        \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C),
-        \qquad
-        \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
+        \Gamma_{L_0}^{A^j}:M_{D_j}(\mathbb C)\to
+        (\mathbb C^d)^{\otimes L_0}
     \]
-    and every block satisfies the normalization
+    is injective. Assume also the normalization
     \[
         \sum_a A^j_aA^{j\,\dagger}_a=I .
     \]
     Set
     \[
-        N=L+(r-1)(L+(L+L)).
+        N=(L_0+1)+(r-1)3(L_0+1).
     \]
     For every \(n\ge N\), set
     \[
@@ -6144,21 +6160,19 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \(n+2\) gives the two directness statements.
 \end{proof}
 
-\begin{lemma}[Normalized BNT input gives an eventual block intersection]
+\begin{lemma}[Normalized BNT blocks give an eventual block intersection]
     \label{lem:bnt_direct_sum_unital_block_intersection}
-    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital_c1}
     \leanok
     \uses{lem:bnt_direct_sum_unital_block_intersection_ge}
     Let \(A^1,\ldots,A^r\) be separated BNT blocks satisfying the irreducibility,
     left-canonicality, and normalized self-overlap hypotheses used in the
-    direct-sum comparison. Suppose \(1<L\), every block is injective at length
-    \(L\),
+    direct-sum comparison. Suppose \(L_0>0\), and for every block \(j\) the map
     \[
-        \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C),
-        \qquad
-        \operatorname{span}\{A^j_u:|u|=L\}=M_{D_j}(\mathbb C),
+        \Gamma_{L_0}^{A^j}:M_{D_j}(\mathbb C)\to
+        (\mathbb C^d)^{\otimes L_0}
     \]
-    and every block satisfies the normalization
+    is injective. Assume also the normalization
     \[
         \sum_a A^j_aA^{j\,\dagger}_a=I .
     \]
@@ -6180,7 +6194,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \leanok
     Apply Lemma~\ref{lem:bnt_direct_sum_unital_block_intersection_ge} and take
     \[
-        N=L+(r-1)(L+(L+L)).
+        N=(L_0+1)+(r-1)3(L_0+1).
     \]
 \end{proof}
 


### PR DESCRIPTION
## Summary

- Add finite-\(L_0\) variants of the BNT direct-sum and pair-separation lemmas.
- Derive the normalized parent-Hamiltonian block-intersection statements from injectivity of \(\Gamma_{L_0}^{A^j}\), with
  \[
    N=(L_0+1)+(r-1)3(L_0+1).
  \]
- Update the parent-Hamiltonian blueprint so the normalized BNT route is stated by the map \(\Gamma_{L_0}\) and equations, not by a length-one specialization or a formal declaration name.

## Mathematical point

PGVWC07 uses the finite injectivity condition: for each block \(A^j\), there is a common length \(L_0\) such that
\[
  \Gamma_{L_0}^{A^j}:M_{D_j}(\mathbb C)\to (\mathbb C^d)^{\otimes L_0}
\]
is injective.  The previous formal route required the special case
\[
  \operatorname{span}\{A_a^j:a=0,\ldots,d-1\}=M_{D_j}(\mathbb C),
\]
which is stronger than the paper's finite-length hypothesis.  The new normalized route uses unitality to propagate the full span from \(L_0\) to \(L_0+1\) and \(3(L_0+1)\), then applies the same block-separation argument.

Closes #2547.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockIntersection`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `rg -n "\\b(sorry|admit|axiom|native_decide|unsafeCast)\\b" TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean || true`

The full build reports only pre-existing warnings outside the changed files, including existing `sorry` warnings in parent-Hamiltonian and periodic-overlap modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive Lean proofs and blueprint `\lean` sync; no runtime code, though the new route still depends on existing normal parent-Hamiltonian range-reduction lemmas marked as open gaps in the codebase.
> 
> **Overview**
> Adds a parallel **finite Condition C1** route (`*_c1` theorems) alongside the existing BNT direct-sum lemmas, keyed by a common length `L₀` instead of requiring **one-site** (`IsInjective`) inputs.
> 
> **`DirectSumUniqueness.lean`** introduces parent-Hamiltonian uniqueness at **`groundSpace` range `L₀+1`** via `chainGroundSpace_eq_mpvSubmodule_normal`, then derives two-block directness and pair trace separation at length **`3(L₀+1)`**.
> 
> **`BNTDirectSum.lean`** threads that into ground-space disjointness, universal pair trace separation, block-separating words, `PropBlockInjective`, and product word spans at **`(L₀+1) + (r-1)·3(L₀+1)`**, without `hInj` on blocks.
> 
> **`BNTBlockIntersection.lean`** adds matching C1 versions of product span, internal direct sums, and PGVWC restriction–intersection identities (including eventual `N`).
> 
> The **parent-Hamiltonian blueprint** (`ch14_parent_hamiltonian.tex`) retargets `\lean{...}` links and lemma statements from length-`L` / one-site span hypotheses to **injectivity of `Γ_{L₀}^{A^j}`** and the updated length formulas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f60af04daa0f01889b0e5319fa79e5b9309b37a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->