### PR TITLE
fix(parent): use finite C1 in block-diagonal chain propagation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -76,6 +76,62 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
 
+/-- Condition C1 gives the periodic-chain inclusion into the sum of local block
+ground spaces.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j,\qquad S_M=\bigvee_jG_M(A_j).
+\]
+Assume each block satisfies PGVWC07 Condition C1 at length \(L_0\), the blocks
+are separated normalized BNT blocks, and
+\[
+  M-1\ge (L_0+1)+(r-1)((L_0+1)+((L_0+1)+(L_0+1))).
+\]
+Then the PGVWC one-step identity for \(S_M\) holds. Consequently, for every
+\(N\ge L\) in this range,
+\[
+  \mathcal G_{N,L}(B)\subseteq S_N.
+\]
+This is the inclusion into the linear span of block local ground spaces used in
+PGVWC07, Theorem 2blocks.2 (arXiv:quant-ph/0608197, proof lines
+1430--1456). The replacement of \(S_N\) by periodic block chain spaces is the
+separate step of closing the boundaries with block-diagonal boundary
+conditions. -/
+theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+      ⨆ j : Fin r, groundSpace (A j) N := by
+  classical
+  apply chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace
+    (μ := μ) (A := A) hμ hN hL hLN
+  intro M hM
+  have hMpos : 0 < M := lt_of_lt_of_le hL hM
+  have hbound :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤
+        M - 1 := by
+    omega
+  have hstep :=
+    pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
+      (d := d) (L₀ := L₀) A hIrr hLeft hOverlap hBlocks hBlk hL₀
+      hUnital (n := M - 1) hbound
+  have hM1 : M - 1 + 1 = M := Nat.sub_add_cancel (Nat.succ_le_iff.mpr hMpos)
+  rw [← hM1]
+  simpa [Nat.add_assoc] using hstep
+
 /-- The normalized BNT block-separation hypotheses give the periodic-chain
 inclusion into \(S_N\), and \(S_N\) is a direct sum of local block spaces.
 
@@ -114,6 +170,33 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital hN hL hLN hRange
   · exact groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital (by omega)
+
+/-- Condition C1 gives the periodic-chain inclusion into \(S_N\), and \(S_N\)
+is an internal direct sum of local block ground spaces. -/
+theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, groundSpace (A j) N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  refine ⟨?_, ?_⟩
+  · exact
+      chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
+        μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+  · exact groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
+      A hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital (by omega)
 
 /-- The current normalized BNT formalization gives two inclusions for the
 block-diagonal periodic chain space.
@@ -158,5 +241,48 @@ theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_
   · exact iSup_chainGroundSpace_block_le_toTensorFromBlocks μ A hμ hN hLN
   · exact chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital hN hL hLN hRange
+
+/-- Condition C1 gives the two established inclusions for the block-diagonal
+periodic chain space.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j.
+\]
+Under the normalized BNT block-separation hypotheses and the finite Condition
+C1 range,
+\[
+  \bigvee_j \mathcal G_{N,L}(A_j)
+  \subseteq
+  \mathcal G_{N,L}(B)
+  \subseteq
+  \bigvee_j G_N(A_j),
+\]
+and the right-hand local block sum is internal. The remaining PGVWC07 step is
+to close the boundaries with block-diagonal boundary conditions. -/
+theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L) :
+    (⨆ j : Fin r, chainGroundSpace (A j) L N) ≤
+        chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ∧
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, groundSpace (A j) N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  refine ⟨?_, ?_⟩
+  · exact iSup_chainGroundSpace_block_le_toTensorFromBlocks μ A hμ hN hLN
+  · exact chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6286,14 +6286,21 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{lemma}[PGVWC propagation for the block-diagonal tensor]
     \label{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1}
     \leanok
     \uses{lem:bnt_direct_sum_unital_block_intersection_ge,
         lem:block_diagonal_periodic_constraints_propagated_sum}
-    Let \(A_1,\ldots,A_g\) be separated normalized BNT blocks with common
-    injectivity length \(L_0\), and suppose the hypotheses of
-    Lemma~\ref{lem:bnt_direct_sum_unital_block_intersection_ge} hold. For
-    nonzero scalars \(\mu_j\), set
+    Let \(A_1,\ldots,A_g\) be separated normalized BNT blocks. Suppose
+    \(L_0>0\), and for every block \(j\) the map
+    \[
+        \Gamma_{L_0}^{A^j}:M_{D_j}(\mathbb C)\to
+        (\mathbb C^d)^{\otimes L_0}
+    \]
+    is injective. Assume also the normalization
+    \[
+        \sum_a A^j_aA^{j\,\dagger}_a=I .
+    \]
+    For nonzero scalars \(\mu_j\), set
     \[
         B=\bigoplus_{j=1}^g\mu_jA_j,
         \qquad
@@ -6301,7 +6308,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
     If
     \[
-        L\ge L_0+(g-1)(L_0+(L_0+L_0))+1,
+        L\ge (L_0+1)+(g-1)3(L_0+1)+1,
     \]
     then, for every \(N\ge L\),
     \[
@@ -6311,17 +6318,23 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \leanok
-    Lemma~\ref{lem:bnt_direct_sum_unital_block_intersection_ge} gives
+    Put
+    \[
+        T=(L_0+1)+(g-1)3(L_0+1).
+    \]
+    For \(M\ge L\), one has \(M-1\ge T\). Applying
+    Lemma~\ref{lem:bnt_direct_sum_unital_block_intersection_ge} at
+    \(n=M-1\) gives
     \[
         \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1}
     \]
-    for every \(M\ge L\). Apply
-    Lemma~\ref{lem:block_diagonal_periodic_constraints_propagated_sum}.
+    for every \(M\ge L\). Lemma~\ref{lem:block_diagonal_periodic_constraints_propagated_sum}
+    then propagates the local constraint from \(L\) to \(N\).
 \end{proof}
 
 \begin{lemma}[PGVWC propagation with a direct local-space sum]
     \label{lem:bnt_block_diagonal_periodic_constraints_internal_sum}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1}
     \leanok
     \uses{lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
         lem:product_span_block_image_direct_sum}
@@ -6349,7 +6362,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}. Since
     $N\ge L$ and
     \[
-        L\ge L_0+(g-1)(L_0+(L_0+L_0))+1,
+        L\ge (L_0+1)+(g-1)3(L_0+1)+1,
     \]
     the product-span directness range of
     Lemma~\ref{lem:product_span_block_image_direct_sum} applies at length
@@ -6370,7 +6383,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{lemma}[Block-diagonal periodic chain inclusions]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}
     \leanok
     \uses{lem:isup_chain_ground_space_block_le_assembled,
         lem:bnt_block_diagonal_periodic_constraints_internal_sum}


### PR DESCRIPTION
Stacked on #2564. Refs #905; this advances the periodic block-decomposition route but does not close #905, since the later boundary-closing step for periodic block chain spaces remains separate.

This PR adds finite-Condition-C1 variants of the block-diagonal chain propagation wrappers. The new statements use injectivity of each \(\Gamma_{L_0}^{A_j}\), the PGVWC07 normalization \(\sum_a A_a^j A_a^{j\dagger}=I\), and the shifted length bound

\[
L \ge (L_0+1)+(g-1)3(L_0+1)+1.
\]

The blueprint entries for the propagated inclusion, internal local-space sum, and two established inclusions now point to these finite-C1 wrappers and state the hypotheses as equations rather than as Lean theorem labels.

Verification:
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/formalization/parent-c1-block-separation`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls` after `lake build TNLean` supplied the root oleans
- `git diff --check`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean || true`
- `lake build TNLean`

The full build still reports pre-existing warnings in unrelated PEPS/periodic-overlap files and the existing boundary-closing `sorry`; this PR adds no new proof-integrity blocker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof extensions in parent-Hamiltonian MPS theory with blueprint sync only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **finite Condition C1** Lean wrappers for block-diagonal periodic chain propagation in `BNTBlockDiagonalChain.lean`, parallel to the existing unital/injective versions.
> 
> The new `*_c1` theorems drop global **`IsInjective`** on each block, only require **`0 < L₀`** (not `1 < L₀`), and use the shifted length bound **`(L₀+1)+(r-1)((L₀+1)+2(L₀+1))+1 ≤ L`**. They delegate to `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1` and `groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1` for the PGVWC one-step identity and internal direct-sum structure.
> 
> The blueprint chapter **repoints** three lemmas (propagated inclusion, internal local-space sum, two chain inclusions) to these `*_c1` declarations and **rewrites hypotheses** as explicit equations (Γ injectivity at `L₀`, normalization ∑_a A A† = I, and the new `L` bound) instead of referencing the older Lean theorem names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be6f3ca999e96b6a9cf2910ae2f23c5cf6195f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->