### PR TITLE
doc(parent): use boundary-closing terminology in block chain notes

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -41,9 +41,9 @@ Then, for every \(N\ge L\) in that range,
   \mathcal G_{N,L}(B)\subseteq S_N.
 \]
 This is the inclusion into \(S_N\) in PGVWC07, Theorem 2blocks.2
-(arXiv:quant-ph/0608197, proof lines 1430--1456). The component extraction
-needed to replace \(S_N\) by the sum of periodic block ground spaces is a
-separate step. -/
+(arXiv:quant-ph/0608197, proof lines 1430--1456). The step that closes the
+boundaries with block-diagonal boundary conditions, replacing \(S_N\) by the
+sum of periodic block ground spaces, is separate. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -145,8 +145,7 @@ At the lengths used in PGVWC07, Theorem 2blocks.2
   \mathcal G_{N,L}(B)\subseteq S_N,
 \]
 and the summands \(G_N(A_j)\) form an internal direct sum. This does not assert
-the later component extraction from the periodic chain space to the sum of
-periodic block chain spaces. -/
+the later step closing the boundaries with block-diagonal boundary conditions. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -215,7 +214,7 @@ range,
   \bigvee_j G_N(A_j),
 \]
 and the right-hand local block sum is internal. The remaining PGVWC07
-component-extraction step replaces
+boundary-closing step with block-diagonal boundary conditions replaces
 \(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\). -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6406,7 +6406,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     inclusion and internal directness are
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}. The
     claimed statement is their conjunction.
-    % The remaining PGVWC07 component-extraction step replaces
+    % The remaining PGVWC07 boundary-closing step with block-diagonal boundary
+    % conditions replaces
     % $\bigvee_jG_N(A_j)$ by $\sum_j\mathcal G_{N,L}(A_j)$.
 \end{proof}
 


### PR DESCRIPTION
Refs #905. This is a terminology cleanup after #2564 and #2565.

The merged finite-C1 block-chain wrappers still used the local phrase “component extraction” in a few docstring/comment locations. The PGVWC07 and CPGSV21 source-facing description is the step that closes the boundaries with block-diagonal boundary conditions, so this PR replaces that wording without changing theorem names, statements, or proofs.

Verification:
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "component[- ]extraction|component extraction|direct-sum extraction" TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean blueprint/src/chapter/ch14_parent_hamiltonian.tex || true`
- `rg -n "\b(sorry|admit|axiom|native_decide|unsafeCast)\b" TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean || true`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`

The target module build still reports the pre-existing #2405 warning in `BoundaryClosingStripping.lean`; this documentation-only PR adds no proof obligation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and docstring edits only; no logic, API, or proof changes.
> 
> **Overview**
> Aligns reader-facing prose with PGVWC07/CPGSV21 wording by renaming the deferred PGVWC step from **“component extraction”** to **boundary closing with block-diagonal boundary conditions** (the step that replaces \(S_N\) / \(\bigvee_j G_N(A_j)\) by periodic block chain ground spaces).
> 
> Updates are **documentation only** in `BNTBlockDiagonalChain.lean` theorem docstrings and a matching `%` comment in `ch14_parent_hamiltonian.tex`; theorem names, statements, and proofs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3615d9e0570b340e05cf80fabaaae002a43ed2df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->