### PR TITLE
feat(PEPS): injective_union (#1374) and the three-block resonate engine for the normal FT

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -476,3 +476,4 @@ import TNLean.PEPS.RegionBlock.BlockCoeffTransfer
 import TNLean.PEPS.RegionBlock.ThreeBlockReconcile
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate2
+import TNLean.PEPS.RegionBlock.UnionInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -481,4 +481,5 @@ import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
 import TNLean.PEPS.RegionBlock.UnionInjectivity
 import TNLean.PEPS.RegionBlock.BasisChangeIntertwine
 import TNLean.PEPS.RegionBlock.OpenLegsResonate
+import TNLean.PEPS.RegionBlock.ResonatePort
 import TNLean.PEPS.RegionBlock.ThreeBlockPhysical

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -487,3 +487,4 @@ import TNLean.PEPS.RegionBlock.ResonatePort2
 import TNLean.PEPS.RegionBlock.ThreeBlockPhysical
 import TNLean.PEPS.RegionBlock.ThreeBlockResonateAB
 import TNLean.PEPS.RegionBlock.ThreeBlockResonateAB2
+import TNLean.PEPS.RegionBlock.ThreeBlockResonateAB3

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -465,3 +465,6 @@ import TNLean.PEPS.RegionBlock.Recovery12
 -- Block-level image coincidence: under `SameState`, the range of the blocked-region
 -- tensor map of a region is `SameState`-invariant given complement-block injectivity.
 import TNLean.PEPS.RegionBlock.BlockRangeCoincidence
+-- Region-injective conditional chain: the per-edge gauge from a coefficient transfer
+-- (no single-vertex injectivity).
+import TNLean.PEPS.RegionBlock.RegionReconcile

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -476,4 +476,5 @@ import TNLean.PEPS.RegionBlock.BlockCoeffTransfer
 import TNLean.PEPS.RegionBlock.ThreeBlockReconcile
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate2
+import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
 import TNLean.PEPS.RegionBlock.UnionInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -471,3 +471,6 @@ import TNLean.PEPS.RegionBlock.RegionReconcile
 -- Block-frame coefficient transfer: the region-injective coefficient transfer from
 -- the block-level image coincidence (no single-vertex injectivity).
 import TNLean.PEPS.RegionBlock.BlockCoeffTransfer
+-- Three-block resonate engine: ports the edge-level resonate engine to the three
+-- injective region blocks (red/blue/complement) of a `NormalEdgeBlockingData`.
+import TNLean.PEPS.RegionBlock.ThreeBlockResonate

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -473,5 +473,6 @@ import TNLean.PEPS.RegionBlock.RegionReconcile
 import TNLean.PEPS.RegionBlock.BlockCoeffTransfer
 -- Three-block resonate engine: ports the edge-level resonate engine to the three
 -- injective region blocks (red/blue/complement) of a `NormalEdgeBlockingData`.
+import TNLean.PEPS.RegionBlock.ThreeBlockReconcile
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate2

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -474,3 +474,4 @@ import TNLean.PEPS.RegionBlock.BlockCoeffTransfer
 -- Three-block resonate engine: ports the edge-level resonate engine to the three
 -- injective region blocks (red/blue/complement) of a `NormalEdgeBlockingData`.
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate
+import TNLean.PEPS.RegionBlock.ThreeBlockResonate2

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -484,3 +484,4 @@ import TNLean.PEPS.RegionBlock.OpenLegsResonate
 import TNLean.PEPS.RegionBlock.ResonatePort
 import TNLean.PEPS.RegionBlock.ResonatePort2
 import TNLean.PEPS.RegionBlock.ThreeBlockPhysical
+import TNLean.PEPS.RegionBlock.ThreeBlockResonateAB

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -482,4 +482,5 @@ import TNLean.PEPS.RegionBlock.UnionInjectivity
 import TNLean.PEPS.RegionBlock.BasisChangeIntertwine
 import TNLean.PEPS.RegionBlock.OpenLegsResonate
 import TNLean.PEPS.RegionBlock.ResonatePort
+import TNLean.PEPS.RegionBlock.ResonatePort2
 import TNLean.PEPS.RegionBlock.ThreeBlockPhysical

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -486,3 +486,4 @@ import TNLean.PEPS.RegionBlock.ResonatePort
 import TNLean.PEPS.RegionBlock.ResonatePort2
 import TNLean.PEPS.RegionBlock.ThreeBlockPhysical
 import TNLean.PEPS.RegionBlock.ThreeBlockResonateAB
+import TNLean.PEPS.RegionBlock.ThreeBlockResonateAB2

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -480,3 +480,4 @@ import TNLean.PEPS.RegionBlock.ThreeBlockResonate2
 import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
 import TNLean.PEPS.RegionBlock.UnionInjectivity
 import TNLean.PEPS.RegionBlock.BasisChangeIntertwine
+import TNLean.PEPS.RegionBlock.ThreeBlockPhysical

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -468,3 +468,6 @@ import TNLean.PEPS.RegionBlock.BlockRangeCoincidence
 -- Region-injective conditional chain: the per-edge gauge from a coefficient transfer
 -- (no single-vertex injectivity).
 import TNLean.PEPS.RegionBlock.RegionReconcile
+-- Block-frame coefficient transfer: the region-injective coefficient transfer from
+-- the block-level image coincidence (no single-vertex injectivity).
+import TNLean.PEPS.RegionBlock.BlockCoeffTransfer

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -462,3 +462,6 @@ import TNLean.PEPS.RegionBlock.Recovery9
 import TNLean.PEPS.RegionBlock.Recovery10
 import TNLean.PEPS.RegionBlock.Recovery11
 import TNLean.PEPS.RegionBlock.Recovery12
+-- Block-level image coincidence: under `SameState`, the range of the blocked-region
+-- tensor map of a region is `SameState`-invariant given complement-block injectivity.
+import TNLean.PEPS.RegionBlock.BlockRangeCoincidence

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -475,6 +475,7 @@ import TNLean.PEPS.RegionBlock.BlockCoeffTransfer
 -- injective region blocks (red/blue/complement) of a `NormalEdgeBlockingData`.
 import TNLean.PEPS.RegionBlock.ThreeBlockReconcile
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate
+import TNLean.PEPS.RegionBlock.BlockRealization
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate2
 import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
 import TNLean.PEPS.RegionBlock.UnionInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -480,4 +480,5 @@ import TNLean.PEPS.RegionBlock.ThreeBlockResonate2
 import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
 import TNLean.PEPS.RegionBlock.UnionInjectivity
 import TNLean.PEPS.RegionBlock.BasisChangeIntertwine
+import TNLean.PEPS.RegionBlock.OpenLegsResonate
 import TNLean.PEPS.RegionBlock.ThreeBlockPhysical

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -479,3 +479,4 @@ import TNLean.PEPS.RegionBlock.BlockRealization
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate2
 import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
 import TNLean.PEPS.RegionBlock.UnionInjectivity
+import TNLean.PEPS.RegionBlock.BasisChangeIntertwine

--- a/TNLean/PEPS/RegionBlock/BasisChangeIntertwine.lean
+++ b/TNLean/PEPS/RegionBlock/BasisChangeIntertwine.lean
@@ -263,5 +263,133 @@ theorem rowInsertF_basisChange_eq_iff_regionInsertedCoeff_eq (A B : Tensor G d)
       exact smul_right_injective _ hne this
     exact regionBlockedTensorMap_injective_of_injective (G := G) A R hRA hblock
 
+/-! ### The full intertwining hypothesis is the coefficient transfer
+
+Quantifying the single-leg equivalence over every complement physical configuration,
+the existence (for a fixed `N`) of the intertwining at every complement leg is the
+coefficient equality `coeff_A M = coeff_B N` at every physical configuration. Adding
+the outer existential over `N` (per inserted `M`) gives the equivalence between the
+intertwining hypothesis the kernel reduction
+`isBondLocalTransferKernel_of_basisChange_intertwine`
+(`TNLean.PEPS.RegionBlock.BlockRealization`) consumes and the block-frame coefficient
+transfer the per-edge gauge needs. This closes the cross-tensor reformulation: the open
+content `V=W` is now exactly the coefficient transfer, with the intertwining a
+mechanical repackaging. -/
+
+/-- **The intertwining for a fixed `N` is the coefficient equality of `M` and `N`.**
+For a fixed matrix `N`, the first tensor's row insertion of `M` of the basis-changed
+partial-state row equals the basis change of the second tensor's row insertion of `N`
+of the partial-state row at every complement physical configuration, if and only if
+the first tensor's region-inserted coefficient of `M` equals the second tensor's of `N`
+at every physical configuration. This is the single-leg equivalence
+`rowInsertF_basisChange_eq_iff_regionInsertedCoeff_eq` quantified over the complement
+leg.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem rowInsertF_basisChange_forall_eq_iff_regionInsertedCoeff_eq (A B : Tensor G d)
+    (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    (∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+        rowInsertF (G := G) A R f M
+            (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ)) =
+          regionBasisChange (G := G) A B R hRA
+            (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ))) ↔
+      ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+        regionInsertedCoeff (G := G) A R f M σ τ =
+          regionInsertedCoeff (G := G) B R f N σ τ := by
+  constructor
+  · intro h σ τ
+    exact (rowInsertF_basisChange_eq_iff_regionInsertedCoeff_eq A B R hRA hRB hCA hCB hAB
+      hposA hposB hDim f M N τ).mp (h τ) σ
+  · intro h τ
+    exact (rowInsertF_basisChange_eq_iff_regionInsertedCoeff_eq A B R hRA hRB hCA hCB hAB
+      hposA hposB hDim f M N τ).mpr (fun σ => h σ τ)
+
+/-- **The intertwining hypothesis is the coefficient transfer.** For every inserted
+matrix `M` on the boundary edge `f` there is a matrix `N` on the second tensor's bond
+intertwining the two row insertions (the hypothesis of
+`isBondLocalTransferKernel_of_basisChange_intertwine`,
+`TNLean.PEPS.RegionBlock.BlockRealization`) if and only if for every `M` there is an
+`N` whose region-inserted coefficient matches at every physical configuration (the
+block-frame coefficient transfer the per-edge gauge consumes). Both quantify the same
+matrix `N`; the equivalence is per-`N` the single-leg reblock reformulation.
+
+This makes the residual open content of the general normal PEPS per-edge gauge exactly
+the coefficient transfer: the intertwining is its mechanical repackaging through the
+basis change, with no single-vertex injectivity.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem basisChange_intertwine_iff_coeffTransfer (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    (∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+          ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+            rowInsertF (G := G) A R f M
+                (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ)) =
+              regionBasisChange (G := G) A B R hRA
+                (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ))) ↔
+      ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+          ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+            (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+            regionInsertedCoeff (G := G) A R f M σ τ =
+              regionInsertedCoeff (G := G) B R f N σ τ := by
+  refine forall_congr' (fun M => exists_congr (fun N => ?_))
+  exact rowInsertF_basisChange_forall_eq_iff_regionInsertedCoeff_eq A B R hRA hRB hCA hCB hAB
+    hposA hposB hDim f M N
+
+/-- **Bond locality from the coefficient transfer, via the basis-change intertwining.**
+If for every inserted matrix `M` on the boundary edge `f` there is a matrix `N` whose
+region-inserted coefficient matches, then the transfer kernel is bond-local
+(`IsBondLocalTransferKernel`). The coefficient transfer gives the intertwining
+(`basisChange_intertwine_iff_coeffTransfer`), which
+`isBondLocalTransferKernel_of_basisChange_intertwine`
+(`TNLean.PEPS.RegionBlock.BlockRealization`) reads as the bond locality of the transfer
+kernel.
+
+This is the cross-tensor route to the bond locality through the basis change, parallel
+to the direct route `coeffTransfer_iff_transferCoeff_incidentForm`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`): both close once the coefficient transfer
+is supplied.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem isBondLocalTransferKernel_of_coeffTransfer (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (htransfer : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ) :
+    IsBondLocalTransferKernel (G := G) A B R hRB hCB f :=
+  isBondLocalTransferKernel_of_basisChange_intertwine A B R hRA hRB hCA hCB hAB hposA hposB
+    hDim f
+    ((basisChange_intertwine_iff_coeffTransfer A B R hRA hRB hCA hCB hAB hposA hposB hDim f).mpr
+      htransfer)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BasisChangeIntertwine.lean
+++ b/TNLean/PEPS/RegionBlock/BasisChangeIntertwine.lean
@@ -263,6 +263,50 @@ theorem rowInsertF_basisChange_eq_iff_regionInsertedCoeff_eq (A B : Tensor G d)
       exact smul_right_injective _ hne this
     exact regionBlockedTensorMap_injective_of_injective (G := G) A R hRA hblock
 
+/-! ### The basis change presents the region row as a row insertion
+
+The cross-tensor expansion exposes the first tensor's region row `regionRegionRow`
+(`TNLean.PEPS.RegionBlock.Recovery7`) — the M-independent complement weight row coupled
+through the inserted matrix `M` on the boundary edge `f` — as the interior bond multiple
+of the row insertion of `M` of the basis-changed second-tensor partial-state row. This
+is the bridge from the basis change `regionBasisChange` to the region row the three-block
+red endpoint inversion `threeBlock_invert_red`
+(`TNLean.PEPS.RegionBlock.ThreeBlockResonate2`) reads off: the basis change of the
+partial-state row plays the role of the first tensor's complement weight row across the
+comparison. -/
+
+/-- **The region row as the basis-changed row insertion.** The first tensor's region row
+`regionRegionRow A R f M τ` is the interior bond multiple of the row insertion of `M` of
+the basis change of the second tensor's partial-state row.
+
+Both sides have the same first-tensor region block image: the region row's image is the
+first tensor's region-inserted coefficient of `M` (`regionInsertedCoeff_eq_region_blockedMap`,
+`TNLean.PEPS.RegionBlock.Recovery7`), and the scaled row-insertion image is the same
+coefficient by the cross-tensor expansion (`regionInsertedCoeff_eq_crossExpansion`,
+`TNLean.PEPS.RegionBlock.BlockRealization`); injectivity of the first tensor's region
+block (`hRA`) identifies the two rows. This presents the region row the three-block red
+endpoint inversion consumes as a row insertion through the basis change.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionRegionRow_eq_smul_rowInsertF_basisChange (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hAB : SameState A B) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionRegionRow (G := G) A R f M τ =
+      (regionInteriorBondProd (G := G) A R : ℂ) •
+        rowInsertF (G := G) A R f M
+          (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ)) := by
+  apply regionBlockedTensorMap_injective_of_injective (G := G) A R hRA
+  rw [map_smul]
+  have h1 : regionBlockedTensorMap (G := G) A R (regionRegionRow (G := G) A R f M τ) =
+      fun σ => regionInsertedCoeff (G := G) A R f M σ τ := by
+    funext σ; rw [← regionInsertedCoeff_eq_region_blockedMap]
+  rw [h1, regionInsertedCoeff_eq_crossExpansion A B R hRA hRB hAB hposB f M τ]
+
 /-! ### The full intertwining hypothesis is the coefficient transfer
 
 Quantifying the single-leg equivalence over every complement physical configuration,

--- a/TNLean/PEPS/RegionBlock/BasisChangeIntertwine.lean
+++ b/TNLean/PEPS/RegionBlock/BasisChangeIntertwine.lean
@@ -1,0 +1,267 @@
+import TNLean.PEPS.RegionBlock.BlockRealization
+import TNLean.PEPS.RegionBlock.ThreeBlockReconcile
+import TNLean.PEPS.RegionBlock.UnionInjectivity
+
+/-!
+# The basis-change intertwining of the cross-tensor transfer kernel
+
+This file proves the **basis-change intertwining**, the last open obligation of the
+general normal PEPS Fundamental Theorem per-edge gauge (arXiv:1804.04964, Section 3,
+Lemma `inj_isomorph`, the step `V=W`). It is the cross-tensor content that
+`isBondLocalTransferKernel_of_basisChange_intertwine`
+(`TNLean.PEPS.RegionBlock.BlockRealization`) consumes: for every inserted matrix `M`
+on the boundary edge `f` of the red region there is a matrix `N` on the second
+tensor's bond such that the A↔B region basis change `regionBasisChange` conjugates
+the first tensor's row insertion of `M` to the second tensor's row insertion of `N`,
+on the second tensor's partial-state rows.
+
+## The reblock-level reformulation
+
+The first tensor's region blocked tensor map is injective (`hRA`), so the intertwining
+holds if and only if its two sides have the same first-tensor region block image. The
+two block images are computed directly: the row-insertion side is the interior bond
+multiple of the first tensor's region-inserted coefficient
+(`regionInsertedCoeff_eq_crossExpansion`), and the basis-change side is, on the common
+range, the second tensor's region block of its own row insertion of `N`
+(`regionBlockedTensorMap_basisChange_eq_of_mem_range`), which is the interior bond
+multiple of the second tensor's region-inserted coefficient of `N`. With matched
+interior bond products (`hDim`), the intertwining is **equivalent** to the coefficient
+equality `coeff_A M = coeff_B N` at every physical configuration. This is the
+unconditional bridge from the cross-tensor intertwining to the block-frame coefficient
+transfer the per-edge gauge consumes.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, the step `V=W`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Step 1: the basis change round-trips through the common range
+
+The first tensor's region blocked tensor map of the basis change of a second-tensor
+row whose second-tensor block image lies in the common range returns the second
+tensor's region blocked tensor map of the row. This is
+`regionBlockedTensorMap_basisChange_eq_of_mem_range`
+(`TNLean.PEPS.RegionBlock.BlockRealization`) packaged for the rows that appear in the
+intertwining: the second tensor's row insertion of `N` of the partial-state row, whose
+second-tensor block image lies in the second tensor's region range, which is the common
+range across `SameState`. -/
+
+/-- **The N-inserted partial-state row's second block image lies in the common range.**
+The second tensor's region blocked tensor map of the row insertion of `N` of the
+second tensor's partial-state row lies in the range of the first tensor's region
+blocked tensor map. Its second-tensor block image lies in the second tensor's region
+range, which coincides with the first tensor's region range across `SameState`
+(`range_regionBlockedTensorMap_eq_of_sameState`,
+`TNLean.PEPS.RegionBlock.BlockRangeCoincidence`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorMap_rowInsertF_partialStateRowB_mem_range (A B : Tensor G d)
+    (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionBlockedTensorMap (G := G) B R
+        (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ)) ∈
+      LinearMap.range (regionBlockedTensorMap (G := G) A R) := by
+  rw [range_regionBlockedTensorMap_eq_of_sameState A B R hAB hCA hCB hposA hposB hDim]
+  exact LinearMap.mem_range_self _ _
+
+/-- **The basis change reblocks the N-inserted partial-state row to the second tensor's
+block.** The first tensor's region blocked tensor map of the basis change of the second
+tensor's row insertion of `N` of the partial-state row equals the second tensor's
+region blocked tensor map of that row insertion. The basis change reads the row off the
+second tensor's region block and reblocks through the first tensor's region block; on
+the common range (where the N-inserted partial-state row's second block image lies) the
+reblocking returns the second tensor's block image.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorMap_basisChange_rowInsertF_partialStateRowB (A B : Tensor G d)
+    (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionBlockedTensorMap (G := G) A R
+        (regionBasisChange (G := G) A B R hRA
+          (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ))) =
+      regionBlockedTensorMap (G := G) B R
+        (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ)) :=
+  regionBlockedTensorMap_basisChange_eq_of_mem_range A B R hRA _
+    (regionBlockedTensorMap_rowInsertF_partialStateRowB_mem_range A B R hRB hCA hCB hAB
+      hposA hposB hDim f N τ)
+
+/-! ### Step 2: the two block images of the intertwining
+
+The first tensor's region blocked tensor map of each side of the intertwining is the
+interior bond multiple of a region-inserted coefficient. The row-insertion side is the
+first tensor's region-inserted coefficient of `M`; the basis-change side is the second
+tensor's region-inserted coefficient of `N`. -/
+
+/-- **The block image of the row-insertion side.** The first tensor's region blocked
+tensor map of the row insertion of `M` of the basis-changed second-tensor partial-state
+row, scaled by the first tensor's interior bond product, is the first tensor's
+region-inserted coefficient of `M`. This is the cross-tensor expansion
+`regionInsertedCoeff_eq_crossExpansion`
+(`TNLean.PEPS.RegionBlock.BlockRealization`) read forwards.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_smul_regionBlockedTensorMap_rowInsertF_basisChange
+    (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hAB : SameState A B) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (regionInteriorBondProd (G := G) A R : ℂ) •
+        regionBlockedTensorMap (G := G) A R
+          (rowInsertF (G := G) A R f M
+            (regionBasisChange (G := G) A B R hRA
+              (partialStateRowB (G := G) B R hRB τ))) =
+      fun σ => regionInsertedCoeff (G := G) A R f M σ τ :=
+  (regionInsertedCoeff_eq_crossExpansion A B R hRA hRB hAB hposB f M τ).symm
+
+/-- **The block image of the N-side.** The second tensor's region blocked tensor map of
+the row insertion of `N` of the second tensor's partial-state row, scaled by the second
+tensor's interior bond product, is the second tensor's region-inserted coefficient of
+`N`. This is the B-analogue of KEY IDENTITY 1
+(`blockRealizeOp_regionPartialState_eq_regionInsertedCoeff`, second tensor) with the
+partial state expanded through the second tensor's region block.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_smul_regionBlockedTensorMap_rowInsertF_partialStateRowB
+    (B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (regionInteriorBondProd (G := G) B R : ℂ) •
+        regionBlockedTensorMap (G := G) B R
+          (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ)) =
+      fun σ => regionInsertedCoeff (G := G) B R f N σ τ := by
+  rw [← blockRealizeOp_regionPartialState_eq_regionInsertedCoeff (G := G) B R hRB f N τ,
+    map_smul, blockRealizeOp_apply,
+    ← regionBlockedTensorMap_partialStateRowB (G := G) B R hRB hposB τ,
+    regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
+/-! ### The intertwining is equivalent to the coefficient equality
+
+Inverting the first tensor's region block (injective, `hRA`), the intertwining of the
+two row insertions on a partial-state row holds if and only if their two first-tensor
+region block images coincide. The block images are the interior bond multiples of the
+two region-inserted coefficients (Step 2); with matched interior bond products (`hDim`)
+the intertwining is equivalent to the coefficient equality `coeff_A M = coeff_B N` at
+every region physical configuration. This unconditional equivalence is the bridge
+between the cross-tensor intertwining and the block-frame coefficient transfer. -/
+
+/-- **The intertwining at a single complement leg is the coefficient equality there.**
+For a fixed complement physical configuration `τ`, the first tensor's row insertion of
+`M` of the basis-changed partial-state row equals the basis change of the second
+tensor's row insertion of `N` of the partial-state row, if and only if the first
+tensor's region-inserted coefficient of `M` equals the second tensor's of `N` at every
+region physical configuration with that `τ`.
+
+The forward direction reblocks both sides through the first tensor's region block
+(injective by `hRA`) and reads off the two region-inserted coefficients (Step 2,
+matched interior bond products by `hDim`); the backward direction reblocks the
+coefficient equality back through the injective region block.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem rowInsertF_basisChange_eq_iff_regionInsertedCoeff_eq (A B : Tensor G d)
+    (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    rowInsertF (G := G) A R f M
+        (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ)) =
+      regionBasisChange (G := G) A B R hRA
+        (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ)) ↔
+      ∀ σ : RegionPhysicalConfig (V := V) (d := d) R,
+        regionInsertedCoeff (G := G) A R f M σ τ =
+          regionInsertedCoeff (G := G) B R f N σ τ := by
+  -- The interior bond product is positive, hence nonzero, on the first tensor.
+  have hposA' : 0 < regionInteriorBondProd (G := G) A R :=
+    regionInteriorBondProd_pos (G := G) A R hposA
+  have hne : (regionInteriorBondProd (G := G) A R : ℂ) ≠ 0 := by exact_mod_cast hposA'.ne'
+  -- The two block images, scaled by the first tensor's interior bond product.
+  have hLHS : (regionInteriorBondProd (G := G) A R : ℂ) •
+      regionBlockedTensorMap (G := G) A R
+        (rowInsertF (G := G) A R f M
+          (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ))) =
+      fun σ => regionInsertedCoeff (G := G) A R f M σ τ :=
+    regionInteriorBondProd_smul_regionBlockedTensorMap_rowInsertF_basisChange A B R hRA hRB
+      hAB hposB f M τ
+  have hRHS : (regionInteriorBondProd (G := G) A R : ℂ) •
+      regionBlockedTensorMap (G := G) A R
+        (regionBasisChange (G := G) A B R hRA
+          (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ))) =
+      fun σ => regionInsertedCoeff (G := G) B R f N σ τ := by
+    rw [regionBlockedTensorMap_basisChange_rowInsertF_partialStateRowB A B R hRA hRB hCA hCB
+        hAB hposA hposB hDim f N τ,
+      regionInteriorBondProd_congr A B R hDim,
+      regionInteriorBondProd_smul_regionBlockedTensorMap_rowInsertF_partialStateRowB B R hRB
+        hposB f N τ]
+  constructor
+  · -- Forward: equal rows give equal block images, hence equal coefficients.
+    intro hrow
+    have hblock : regionBlockedTensorMap (G := G) A R
+        (rowInsertF (G := G) A R f M
+          (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ))) =
+      regionBlockedTensorMap (G := G) A R
+        (regionBasisChange (G := G) A B R hRA
+          (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ))) := by
+      rw [hrow]
+    have hcoeff : (fun σ => regionInsertedCoeff (G := G) A R f M σ τ) =
+        (fun σ => regionInsertedCoeff (G := G) B R f N σ τ) := by
+      rw [← hLHS, ← hRHS, hblock]
+    exact fun σ => congrFun hcoeff σ
+  · -- Backward: equal coefficients give equal block images, then invert the block.
+    intro hcoeff
+    have hcoeff' : (fun σ => regionInsertedCoeff (G := G) A R f M σ τ) =
+        (fun σ => regionInsertedCoeff (G := G) B R f N σ τ) := funext hcoeff
+    have hblock : regionBlockedTensorMap (G := G) A R
+        (rowInsertF (G := G) A R f M
+          (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ))) =
+      regionBlockedTensorMap (G := G) A R
+        (regionBasisChange (G := G) A B R hRA
+          (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ))) := by
+      have := hLHS.trans (hcoeff'.trans hRHS.symm)
+      exact smul_right_injective _ hne this
+    exact regionBlockedTensorMap_injective_of_injective (G := G) A R hRA hblock
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
@@ -131,5 +131,100 @@ theorem regionInsertedCoeff_eq_blockTransferRow (A B : Tensor G d) (R : Finset V
     rw [blockTransferRow, ← hc, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
   rw [hrow, hc]
 
+/-! ### The double-complement transport of blocked-tensor injectivity
+
+The blocked-region weight is double-complement invariant
+(`regionBlockedWeight_doubleCompl`), so the blocked tensor family of
+`univ \ (univ \ R)` is, up to the double-complement boundary-configuration
+reindexing and the double-complement physical-configuration reindexing, the
+blocked tensor family of `R`. Reindexing by an equivalence and precomposing with a
+bijective change of the physical-configuration index both preserve linear
+independence, so blocked-tensor injectivity transports from `R` to
+`univ \ (univ \ R)`. This supplies the complement-block injectivity hypothesis the
+block-level image coincidence needs when applied to the region `univ \ R`. -/
+
+/-- The double-complement physical-configuration transport as an equivalence: a
+region physical configuration on `R` corresponds to one on `univ \ (univ \ R)` by
+reading each vertex under the double-complement vertex equivalence. -/
+def regionDoubleComplPhysicalConfigEquiv (R : Finset V) :
+    RegionPhysicalConfig (V := V) (d := d) R ≃
+      RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ (Finset.univ \ R)) where
+  toFun := regionDoubleComplPhysicalConfig (V := V) (d := d) R
+  invFun σ := fun w => σ ((regionDoubleComplVertexEquiv (V := V) R).symm w)
+  left_inv σ := by
+    funext w
+    simp only [regionDoubleComplPhysicalConfig, Equiv.apply_symm_apply]
+  right_inv σ := by
+    funext w
+    simp only [regionDoubleComplPhysicalConfig, Equiv.symm_apply_apply]
+
+/-- **Double-complement transport of blocked-tensor injectivity.** If the region
+`R` is blocked-tensor injective, then so is `univ \ (univ \ R)`. The blocked tensor
+family of `univ \ (univ \ R)`, reindexed by the double-complement
+boundary-configuration equivalence and precomposed with the double-complement
+physical-configuration equivalence, is the blocked tensor family of `R`
+(`regionBlockedWeight_doubleCompl`); both reindexings preserve linear independence. -/
+theorem regionBlockedTensorInjective_doubleCompl (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R) :
+    RegionBlockedTensorInjective (G := G) A (Finset.univ \ (Finset.univ \ R)) := by
+  -- The blocked family of `R` is the double-complement family reindexed by `Ψ` and
+  -- precomposed with the physical-config equivalence `Φ`.
+  set Ψ := regionDoubleComplBoundaryConfigEquiv (G := G) A R with hΨ
+  set Φ := regionDoubleComplPhysicalConfigEquiv (V := V) (d := d) R with hΦ
+  have hfam : (LinearEquiv.funCongrLeft ℂ ℂ Φ) ∘
+        (regionBlockedTensorFamily (G := G) A (Finset.univ \ (Finset.univ \ R)) ∘ Ψ) =
+      regionBlockedTensorFamily (G := G) A R := by
+    funext bdry
+    funext σ
+    rw [Function.comp_apply, Function.comp_apply, LinearEquiv.funCongrLeft_apply,
+      LinearMap.funLeft_apply]
+    -- `Ψ bdry = regionDoubleComplBoundaryConfig bdry`, `Φ σ = regionDoubleComplPhysicalConfig σ`.
+    show regionBlockedTensorFamily (G := G) A (Finset.univ \ (Finset.univ \ R))
+        (regionDoubleComplBoundaryConfig (G := G) A R bdry)
+        (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ) =
+      regionBlockedTensorFamily (G := G) A R bdry σ
+    rw [regionBlockedTensorFamily, regionBlockedTensorFamily,
+      regionBlockedWeight_doubleCompl A R bdry σ]
+  -- `hR` gives linear independence of `regionBlockedTensorFamily A R`; transport back.
+  have hRfam : LinearIndependent ℂ
+      ((LinearEquiv.funCongrLeft ℂ ℂ Φ) ∘
+        (regionBlockedTensorFamily (G := G) A (Finset.univ \ (Finset.univ \ R)) ∘ Ψ)) := by
+    rw [hfam]; exact hR
+  -- Strip the linear iso, then the index equivalence.
+  have hΨfam : LinearIndependent ℂ
+      (regionBlockedTensorFamily (G := G) A (Finset.univ \ (Finset.univ \ R)) ∘ Ψ) :=
+    LinearIndependent.of_comp _ hRfam
+  exact (linearIndependent_equiv Ψ).mp hΨfam
+
+/-! ### Complement-block image coincidence
+
+The block-level image coincidence applied to the region `univ \ R`: its complement
+is `univ \ (univ \ R)`, which is blocked-tensor injective by the double-complement
+transport above. So the ranges of the two complement blocked tensor maps coincide
+under `SameState`. This is the complement-side companion of
+`range_regionBlockedTensorMap_eq_of_sameState`, used to read off the transfer
+kernel through the second tensor's complement block. -/
+
+/-- **Complement-block image coincidence.** Under `SameState`, with both region
+blocks `R` blocked-tensor injective and positive bond dimensions, the ranges of the
+complement blocked tensor maps of `univ \ R` coincide. This is
+`range_regionBlockedTensorMap_eq_of_sameState` applied to the region `univ \ R`,
+whose complement-block injectivity is supplied by
+`regionBlockedTensorInjective_doubleCompl`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem range_regionBlockedTensorMap_compl_eq_of_sameState (A B : Tensor G d) (R : Finset V)
+    (hAB : SameState A B)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim) :
+    LinearMap.range (regionBlockedTensorMap (G := G) A (Finset.univ \ R)) =
+      LinearMap.range (regionBlockedTensorMap (G := G) B (Finset.univ \ R)) :=
+  range_regionBlockedTensorMap_eq_of_sameState A B (Finset.univ \ R) hAB
+    (regionBlockedTensorInjective_doubleCompl A R hRA)
+    (regionBlockedTensorInjective_doubleCompl B R hRB) hposA hposB hDim
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
@@ -455,5 +455,211 @@ theorem regionInsertedCoeff_eq_of_transferCoeff_form_block (A B : Tensor G d) (R
   rw [hform μ (E ν), hE, Equiv.symm_apply_apply, regionComplementBoundaryConfigEquiv_apply]
   ring
 
+/-! ### Uniqueness of the transfer kernel
+
+The map sending a doubly-indexed kernel to the boundary-configuration double sum
+against the second tensor's region and complement blocked weights is injective:
+fixing the complement physical configuration, the region blocked tensor map of the
+second tensor is injective (`hRB`), so the inner complement-weight combination is
+determined for every region boundary configuration; fixing then the region boundary
+configuration, the complement blocked tensor map is injective (`hCB`), so the
+kernel itself is determined. This is the double-injectivity uniqueness that makes
+the transfer kernel `transferCoeff` the unique double-sum representation of a
+coefficient. -/
+
+/-- **Uniqueness of the transfer kernel.** Two doubly-indexed kernels that produce
+the same boundary-configuration double sum against the second tensor's region and
+complement blocked weights, at every region and complement physical configuration,
+are equal. This is forced by the double blocked injectivity `hRB`, `hCB` of the
+second tensor.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem doubleSum_kernel_injective (B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (K K' : RegionBoundaryConfig (G := G) B R →
+      RegionBoundaryConfig (G := G) B (Finset.univ \ R) → ℂ)
+    (heq : ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      (∑ μ : RegionBoundaryConfig (G := G) B R,
+          ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R),
+            K μ ν' * regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ *
+              regionBlockedWeight (G := G) B R μ σ) =
+        ∑ μ : RegionBoundaryConfig (G := G) B R,
+          ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R),
+            K' μ ν' * regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ *
+              regionBlockedWeight (G := G) B R μ σ) :
+    K = K' := by
+  -- For each `τ`, the two region rows agree by region injectivity.
+  have hrow : ∀ (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R))
+      (μ : RegionBoundaryConfig (G := G) B R),
+      (∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R),
+          K μ ν' * regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ) =
+        ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R),
+          K' μ ν' * regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ := by
+    intro τ
+    -- Read both double sums as region blocked tensor maps of the inner rows.
+    have hmap : regionBlockedTensorMap (G := G) B R
+          (fun μ => ∑ ν', K μ ν' * regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ) =
+        regionBlockedTensorMap (G := G) B R
+          (fun μ => ∑ ν', K' μ ν' * regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ) := by
+      funext σ
+      rw [regionBlockedTensorMap_apply, regionBlockedTensorMap_apply]
+      have := heq σ τ
+      simp only [smul_eq_mul, Finset.sum_mul]
+      simp only [smul_eq_mul] at this ⊢
+      convert this using 2 <;> rw [Finset.sum_mul]
+    exact congrFun (regionBlockedTensorMap_injective_of_injective (G := G) B R hRB hmap)
+  -- For each `μ`, the two complement rows agree by complement injectivity.
+  funext μ
+  have hmapC : regionBlockedTensorMap (G := G) B (Finset.univ \ R) (K μ) =
+      regionBlockedTensorMap (G := G) B (Finset.univ \ R) (K' μ) := by
+    funext τ
+    rw [regionBlockedTensorMap_apply, regionBlockedTensorMap_apply]
+    simp only [smul_eq_mul]
+    exact hrow τ μ
+  exact regionBlockedTensorMap_injective_of_injective (G := G) B (Finset.univ \ R) hCB hmapC
+
+/-! ### The incident-matrix kernel and its coefficient
+
+The incident-matrix kernel of a matrix `N` on the boundary bond `f` couples only
+the bond legs of the two boundary configurations, with the residual legs contracted
+by the identity (`SameAwayFromBond`). It is the candidate form of the transfer
+kernel. Its boundary-configuration double sum against the second tensor's region and
+complement blocked weights is exactly the second tensor's region-inserted
+coefficient of `N` (`regionInsertedCoeff_eq`, reindexed by the complement
+boundary-configuration equivalence). This identifies the incident-matrix kernel as
+the unique transfer kernel of the coefficient `coeff_B N`. -/
+
+open scoped Classical in
+/-- The incident-matrix kernel of a matrix `N` on the boundary bond `f`: it couples
+the bond legs `μ f`, `ν' f` of the two boundary configurations through `N` and
+contracts the residual legs by the identity. The complement boundary configuration
+`ν'` is read back to a region boundary configuration by the complement
+boundary-configuration equivalence. -/
+noncomputable def incidentKernel (B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    RegionBoundaryConfig (G := G) B R →
+      RegionBoundaryConfig (G := G) B (Finset.univ \ R) → ℂ :=
+  fun μ ν' =>
+    if SameAwayFromBond f μ ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+      N (μ f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f) else 0
+
+open scoped Classical in
+/-- **The incident-matrix kernel reproduces the second tensor's coefficient.** The
+boundary-configuration double sum of the incident-matrix kernel of `N` against the
+second tensor's region and complement blocked weights is the second tensor's
+region-inserted coefficient of `N`.
+
+This is `regionInsertedCoeff_eq` with the inner complement-boundary sum reindexed by
+the complement boundary-configuration equivalence. It identifies `incidentKernel N`
+as a transfer kernel of `coeff_B N`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem doubleSum_incidentKernel_eq_regionInsertedCoeff (B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (∑ μ : RegionBoundaryConfig (G := G) B R,
+        ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R),
+          incidentKernel (G := G) B R f N μ ν' *
+            regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ *
+            regionBlockedWeight (G := G) B R μ σ) =
+      regionInsertedCoeff (G := G) B R f N σ τ := by
+  classical
+  rw [regionInsertedCoeff_eq]
+  set E := regionComplementBoundaryConfigEquiv (G := G) B R with hE
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [← Equiv.sum_comp E
+    (fun ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R) =>
+      incidentKernel (G := G) B R f N μ ν' *
+        regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ *
+        regionBlockedWeight (G := G) B R μ σ)]
+  refine Finset.sum_congr rfl (fun ν _ => ?_)
+  rw [incidentKernel, hE, Equiv.symm_apply_apply, regionComplementBoundaryConfigEquiv_apply]
+  ring
+
+/-! ### The reconcile is the transfer
+
+The incident-matrix kernel `incidentKernel N` reproduces `coeff_B N`
+(`doubleSum_incidentKernel_eq_regionInsertedCoeff`), and the transfer kernel
+`transferCoeff M` reproduces `coeff_A M` (the block-frame double factorization
+`regionInsertedCoeff_eq_doubleSum_transferCoeff_block`). By kernel uniqueness
+(`doubleSum_kernel_injective`), the transfer kernel of `M` equals the incident-matrix
+kernel of `N` **exactly when** `coeff_A M = coeff_B N`. So the incident-matrix form
+of the transfer kernel (the reconcile) is equivalent to the existence of the
+coefficient transfer, with the bond matrix `N` shared. This reduces the per-edge
+gauge to the coefficient transfer alone. -/
+
+/-- **The reconcile is the coefficient transfer.** The transfer kernel of `M` equals
+the incident-matrix kernel of `N` if and only if the first tensor's region-inserted
+coefficient of `M` equals the second tensor's of `N`. The forward direction
+substitutes the kernel into the block-frame double factorization; the reverse
+direction is kernel uniqueness `doubleSum_kernel_injective` against the two
+coefficient readings.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem transferCoeff_eq_incidentKernel_iff_coeff_eq (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    transferCoeff (G := G) A B R hRB hCB f M = incidentKernel (G := G) B R f N ↔
+      ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+        regionInsertedCoeff (G := G) A R f M σ τ =
+          regionInsertedCoeff (G := G) B R f N σ τ := by
+  constructor
+  · intro hker σ τ
+    refine regionInsertedCoeff_eq_of_transferCoeff_form_block A B R hRA hRB hCA hCB hAB
+      hposA hposB hDim f M N (fun μ ν' => ?_) σ τ
+    have := congrFun (congrFun hker μ) ν'
+    rwa [incidentKernel] at this
+  · intro hcoeff
+    -- Both kernels reproduce the same coefficient `coeff_A M = coeff_B N`; uniqueness.
+    refine doubleSum_kernel_injective B R hRB hCB _ _ (fun σ τ => ?_)
+    rw [← regionInsertedCoeff_eq_doubleSum_transferCoeff_block A B R hRA hRB hCA hCB hAB
+        hposA hposB hDim f M σ τ,
+      doubleSum_incidentKernel_eq_regionInsertedCoeff B R f N σ τ, hcoeff σ τ]
+
+/-- **The transfer kernel of the identity is the incident kernel of the identity.**
+For the inserted identity matrix, the transfer kernel equals the incident-matrix
+kernel of the identity. The identity insertion reads the closed state coefficient
+(`regionInsertedCoeff_one_eq_stateCoeff`), which is `SameState`-invariant and equal
+on the two tensors up to the matched interior bond product, so `coeff_A 1 = coeff_B
+1`; the reconcile-is-transfer equivalence then identifies the kernels. This is the
+identity anchor of the reconcile.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem transferCoeff_one_eq_incidentKernel_one (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    transferCoeff (G := G) A B R hRB hCB f 1 =
+      incidentKernel (G := G) B R f 1 := by
+  rw [transferCoeff_eq_incidentKernel_iff_coeff_eq A B R hRA hRB hCA hCB hAB
+    hposA hposB hDim f 1 1]
+  intro σ τ
+  rw [regionInsertedCoeff_one_eq_stateCoeff (G := G) A R f σ τ,
+    regionInsertedCoeff_one_eq_stateCoeff (G := G) B R f σ τ,
+    regionInteriorBondProd_congr A B R hDim, hAB _]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
@@ -661,5 +661,111 @@ theorem transferCoeff_one_eq_incidentKernel_one (A B : Tensor G d) (R : Finset V
     regionInsertedCoeff_one_eq_stateCoeff (G := G) B R f σ τ,
     regionInteriorBondProd_congr A B R hDim, hAB _]
 
+/-! ### The transfer as the incident-matrix form of the transfer kernel
+
+By the reconcile-is-transfer bridge, the existence of a coefficient transfer for a
+matrix `M` is equivalent to the transfer kernel `transferCoeff M` having
+incident-matrix form. Packaging the two directions of the bridge over all `M`
+restates the block-frame coefficient transfer in kernel terms: the transfer
+`∀ M, ∃ N, ∀ σ τ, coeff_A M = coeff_B N` holds exactly when every transfer kernel
+has incident-matrix form. This is the precise block-frame target of the remaining
+reconcile, with no single-vertex injectivity. -/
+
+/-- **The coefficient transfer is the incident-matrix form of every transfer
+kernel.** The block-frame coefficient transfer for the boundary edge `f` holds if
+and only if, for every inserted matrix `M`, the transfer kernel `transferCoeff M`
+is the incident-matrix kernel of some bond matrix `N`. Both directions are the
+reconcile-is-transfer bridge `transferCoeff_eq_incidentKernel_iff_coeff_eq`
+quantified over `M`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_iff_transferCoeff_incidentForm (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    (∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+          ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+            (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+            regionInsertedCoeff (G := G) A R f M σ τ =
+              regionInsertedCoeff (G := G) B R f N σ τ) ↔
+      ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+          transferCoeff (G := G) A B R hRB hCB f M = incidentKernel (G := G) B R f N := by
+  refine forall_congr' (fun M => ?_)
+  refine exists_congr (fun N => ?_)
+  exact (transferCoeff_eq_incidentKernel_iff_coeff_eq A B R hRA hRB hCA hCB hAB
+    hposA hposB hDim f M N).symm
+
+/-! ### The per-edge gauge from a block-frame coefficient transfer
+
+Wiring the block-frame double factorization to the conditional per-edge gauge of
+`TNLean.PEPS.RegionBlock.RegionReconcile`. Given the two coefficient transfers and a
+multiplicative forward choice, the chosen forward per-edge matrix transfer on the
+boundary edge `f` is conjugation by an invertible gauge matrix, and the bond
+dimensions on `f` coincide. The unital field is supplied by the identity anchor; no
+single-vertex injectivity is used anywhere in the block-frame construction. The two
+transfers and the multiplicativity remain hypotheses: by
+`coeffTransfer_iff_transferCoeff_incidentForm`, the transfers are exactly the
+incident-matrix form of the transfer kernels, the open reconcile content documented
+in `docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+
+/-- **Per-edge gauge on a boundary edge from a block-frame coefficient transfer.**
+This is `exists_regionEdgeGauge_of_coeffTransfer`
+(`TNLean.PEPS.RegionBlock.RegionReconcile`) packaged with the block-frame names: from
+the two coefficient transfers and a multiplicative forward choice, with
+region/complement blocked injectivity of both tensors, positive bond dimensions,
+`SameState`, and matched bond dimensions, the forward per-edge matrix transfer on
+`f` is conjugation by an invertible gauge matrix `Z`, and the bond dimensions on `f`
+coincide. No single-vertex injectivity is used.
+
+By `coeffTransfer_iff_transferCoeff_incidentForm`, the two transfer hypotheses are
+the incident-matrix form of the transfer kernels — the remaining reconcile content
+documented in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_of_blockCoeffTransfer (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (htransferBA : ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      ∃ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) B R f N σ τ =
+            regionInsertedCoeff (G := G) A R f M σ τ)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B R f htransferAB (M * M') =
+        coeffTransferMap (G := G) A B R f htransferAB M *
+          coeffTransferMap (G := G) A B R f htransferAB M') :
+    ∃ hEdge : A.bondDim f.1 = B.bondDim f.1,
+      ∃ Z : GL (Fin (B.bondDim f.1)) ℂ,
+        ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+          (regionInsertionTransfer_of_coeffTransfer A B R f hRB hCB hAB hposB hDim
+              htransferAB htransferBA hmul).fwd M =
+            (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim f.1)) ℂ) :
+                Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :=
+  exists_regionEdgeGauge_of_coeffTransfer A B R f hRA hCA hRB hCB hAB hposA hposB hDim
+    htransferAB htransferBA hmul
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
@@ -226,5 +226,234 @@ theorem range_regionBlockedTensorMap_compl_eq_of_sameState (A B : Tensor G d) (R
     (regionBlockedTensorInjective_doubleCompl A R hRA)
     (regionBlockedTensorInjective_doubleCompl B R hRB) hposA hposB hDim
 
+/-! ### The transfer kernel through the second tensor's complement block
+
+For a fixed inserted matrix `M` and region boundary configuration `μ`, the
+region-transferred row coordinate `blockTransferRow … τ μ`, as a function of the
+complement physical configuration `τ`, lies in the range of the second tensor's
+complement blocked tensor map. The complement-block image coincidence puts each
+slice `fun τ => regionInsertedCoeff A R f M σ' τ` (a function of `τ`) in the second
+tensor's complement-block range; the row coordinate is a finite linear combination
+of these slices (the region left inverse is linear), so it lies in the same range.
+The chosen complement left inverse then reads off the transfer kernel
+`transferCoeff` (`TNLean.PEPS.RegionBlock.Recovery10`) without single-vertex
+injectivity. -/
+
+/-- **Block-frame membership of the transferred row in the complement-block range.**
+For each region boundary configuration `μ` of the second tensor, the
+region-transferred row coordinate `blockTransferRow … τ μ`, as a function of the
+complement physical configuration `τ`, lies in the range of the second tensor's
+complement blocked tensor map.
+
+Each slice `fun τ => regionInsertedCoeff A R f M σ' τ` factors through the *first*
+tensor's complement blocked tensor map (`regionInsertedCoeff_eq_complement_blockedMap`,
+vertex-free), hence lies in the second tensor's complement-block range by the
+complement-block image coincidence
+`range_regionBlockedTensorMap_compl_eq_of_sameState`. The row coordinate is the
+region left inverse of the first tensor's coefficient viewed as a function of `σ`,
+which expands as a finite linear combination of these slices over the standard basis
+of the region physical configurations; the range is a submodule.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem blockTransferRow_mem_range (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (μ : RegionBoundaryConfig (G := G) B R) :
+    (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        blockTransferRow A B R hRB f M τ μ) ∈
+      LinearMap.range (regionBlockedTensorMap (G := G) B (Finset.univ \ R)) := by
+  classical
+  -- Each coefficient slice lies in the second tensor's complement-block range.
+  have hmem : ∀ σ' : RegionPhysicalConfig (V := V) (d := d) R,
+      (fun τ => regionInsertedCoeff (G := G) A R f M σ' τ) ∈
+        LinearMap.range (regionBlockedTensorMap (G := G) B (Finset.univ \ R)) := by
+    intro σ'
+    rw [← range_regionBlockedTensorMap_compl_eq_of_sameState A B R hAB hRA hRB
+      hposA hposB hDim]
+    rw [LinearMap.mem_range]
+    exact ⟨regionComplementRow (G := G) A R f M σ',
+      (funext (fun τ =>
+        (regionInsertedCoeff_eq_complement_blockedMap A R f M σ' τ).symm))⟩
+  -- The transferred row coordinate is the linear combination of these over the basis.
+  have hexpand : (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        blockTransferRow A B R hRB f M τ μ) =
+      ∑ σ' : RegionPhysicalConfig (V := V) (d := d) R,
+        (regionBlockedLeftInverse (G := G) B R hRB
+            (fun σ => if σ = σ' then (1 : ℂ) else 0) μ) •
+          (fun τ => regionInsertedCoeff (G := G) A R f M σ' τ) := by
+    funext τ
+    rw [blockTransferRow]
+    rw [show (fun σ => regionInsertedCoeff (G := G) A R f M σ τ) =
+        ∑ σ' : RegionPhysicalConfig (V := V) (d := d) R,
+          regionInsertedCoeff (G := G) A R f M σ' τ •
+            (fun σ => if σ = σ' then (1 : ℂ) else 0) from ?_]
+    · rw [map_sum]
+      simp only [map_smul, Finset.sum_apply, Pi.smul_apply, smul_eq_mul, mul_comm]
+    · funext σ
+      rw [Finset.sum_apply, Finset.sum_eq_single σ]
+      · rw [Pi.smul_apply, if_pos rfl, smul_eq_mul, mul_one]
+      · intro σ'' _ hne
+        rw [Pi.smul_apply, if_neg (Ne.symm hne), smul_zero]
+      · intro hσ; exact absurd (Finset.mem_univ σ) hσ
+  rw [hexpand]
+  refine Submodule.sum_mem _ (fun σ' _ => ?_)
+  exact Submodule.smul_mem _ _ (hmem σ')
+
+/-- **Block-frame complement read-off.** The region-transferred row coordinate, as a
+function of the complement physical configuration, is the second tensor's complement
+blocked tensor map of the transfer kernel `transferCoeff`
+(`TNLean.PEPS.RegionBlock.Recovery10`). This is the complement read-off from the
+block-frame membership `blockTransferRow_mem_range`, without single-vertex
+injectivity.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem blockTransferRow_eq_complement_blockedMap (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (μ : RegionBoundaryConfig (G := G) B R) :
+    (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        blockTransferRow A B R hRB f M τ μ) =
+      regionBlockedTensorMap (G := G) B (Finset.univ \ R)
+        (transferCoeff (G := G) A B R hRB hCB f M μ) := by
+  obtain ⟨c, hc⟩ :=
+    blockTransferRow_mem_range A B R hRA hRB hAB hposA hposB hDim f M μ
+  -- `transferCoeff` is the complement left inverse of the transferred row coordinate,
+  -- which is `regionBlockedTensorMap B (univ \ R) c` by the membership `hc`.
+  have htc : transferCoeff (G := G) A B R hRB hCB f M μ = c := by
+    rw [transferCoeff,
+      show (fun τ => regionRowB (G := G) A B R hRB f M τ μ) =
+        (fun τ => blockTransferRow A B R hRB f M τ μ) from rfl,
+      ← hc, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+  rw [htc, hc]
+
+/-! ### The block-frame double factorization
+
+Combining the region-side reading `regionInsertedCoeff_eq_blockTransferRow` with the
+complement read-off `blockTransferRow_eq_complement_blockedMap` writes the first
+tensor's region-inserted coefficient as a boundary-configuration double sum of the
+transfer kernel against the second tensor's region and complement blocked weights.
+This is the block-frame replacement of `regionInsertedCoeff_eq_doubleSum_transferCoeff`
+(`TNLean.PEPS.RegionBlock.Recovery10`): the kernel `transferCoeff` is the same, but
+the factorization uses only the block-level image coincidence, never single-vertex
+injectivity. -/
+
+/-- **The block-frame double factorization.** The first tensor's region-inserted
+coefficient of `M` is the boundary-configuration double sum of the transfer kernel
+`transferCoeff` against the second tensor's region and complement blocked weights.
+
+The region-side reading `regionInsertedCoeff_eq_blockTransferRow` writes the
+coefficient as the second tensor's region blocked tensor map of the transferred row;
+the row, as a function of the complement physical configuration, is the second
+tensor's complement blocked tensor map of the transfer kernel
+(`blockTransferRow_eq_complement_blockedMap`). Expanding both blocked tensor maps
+gives the double sum. No single-vertex injectivity is used.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_doubleSum_transferCoeff_block (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      ∑ μ : RegionBoundaryConfig (G := G) B R,
+        ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R),
+          transferCoeff (G := G) A B R hRB hCB f M μ ν' *
+            regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ *
+            regionBlockedWeight (G := G) B R μ σ := by
+  -- The region-side reading.
+  rw [regionInsertedCoeff_eq_blockTransferRow A B R hRB hCA hCB hAB hposA hposB hDim f M σ τ,
+    regionBlockedTensorMap_apply]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  -- The transferred row coordinate is the complement blocked map of the kernel.
+  have hrow := congrFun
+    (blockTransferRow_eq_complement_blockedMap A B R hRA hRB hCB hAB hposA hposB hDim f M μ) τ
+  rw [hrow, regionBlockedTensorMap_apply, smul_eq_mul, Finset.sum_mul]
+  refine Finset.sum_congr rfl (fun ν' _ => ?_)
+  rw [smul_eq_mul]
+
+/-! ### The block-frame coefficient transfer from the incident-matrix form
+
+If the transfer kernel `transferCoeff` has the incident-matrix coupling form of a
+single matrix `N` on the boundary bond `f`, then the first tensor's region-inserted
+coefficient of `M` equals the second tensor's of `N`. This is the block-frame
+replacement of `regionInsertedCoeff_eq_of_transferCoeff_form`
+(`TNLean.PEPS.RegionBlock.Recovery10`), built on the block-frame double factorization
+above. -/
+
+open scoped Classical in
+/-- **Block-frame coefficient transfer from the incident-matrix form.** If there is a
+matrix `N` on the second tensor's bond whose incident-matrix coupling form reproduces
+the transfer kernel `transferCoeff`, then the first tensor's region-inserted
+coefficient of `M` equals the second tensor's of `N` at every physical
+configuration. No single-vertex injectivity is used.
+
+The block-frame double factorization
+`regionInsertedCoeff_eq_doubleSum_transferCoeff_block` writes the first tensor's
+coefficient as the double sum of the transfer kernel against the second tensor's
+region and complement blocked weights; substituting the incident-matrix form and
+reindexing the complement boundary-configuration sum by the complement
+boundary-configuration equivalence yields the explicit double-sum form of the second
+tensor's region-inserted coefficient (`regionInsertedCoeff_eq`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_of_transferCoeff_form_block (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hform : ∀ (μ : RegionBoundaryConfig (G := G) B R)
+        (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)),
+      transferCoeff (G := G) A B R hRB hCB f M μ ν' =
+        (if SameAwayFromBond f μ
+              ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') then
+            N (μ f) (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f) else 0))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ := by
+  classical
+  rw [regionInsertedCoeff_eq_doubleSum_transferCoeff_block A B R hRA hRB hCA hCB hAB
+      hposA hposB hDim f M σ τ,
+    regionInsertedCoeff_eq]
+  -- Reindex the second tensor's complement-boundary sum by the complement equivalence.
+  set E := regionComplementBoundaryConfigEquiv (G := G) B R with hE
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [← Equiv.sum_comp E
+    (fun ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R) =>
+      transferCoeff (G := G) A B R hRB hCB f M μ ν' *
+        regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ *
+        regionBlockedWeight (G := G) B R μ σ)]
+  refine Finset.sum_congr rfl (fun ν _ => ?_)
+  rw [hform μ (E ν), hE, Equiv.symm_apply_apply, regionComplementBoundaryConfigEquiv_apply]
+  ring
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
@@ -1,0 +1,135 @@
+import TNLean.PEPS.RegionBlock.BlockRangeCoincidence
+import TNLean.PEPS.RegionBlock.RegionReconcile
+
+/-!
+# Block-frame coefficient transfer for the normal PEPS Fundamental Theorem
+
+This file builds the **block-frame coefficient transfer** for region-injective
+tensors: from two tensors `A`, `B` generating the same state, with both the
+region block `R` and its complement `univ \ R` blocked-tensor injective and
+positive bond dimensions, the region-inserted coefficient of any matrix `M` on a
+boundary edge `f` of `R` in the first tensor is realized by a matrix `N` on the
+second tensor:
+
+> `∀ M, ∃ N, ∀ σ τ, regionInsertedCoeff A R f M σ τ = regionInsertedCoeff B R f N σ τ`.
+
+The construction uses only the **block-level image coincidence**
+`range_regionBlockedTensorMap_eq_of_sameState`
+(`TNLean.PEPS.RegionBlock.BlockRangeCoincidence`), never single-vertex
+injectivity. The single-vertex frame (which pins the recovered matrix off the
+in-region endpoint's virtual pullback) needs the vertex component to be linearly
+independent, which a single vertex of a normal tensor need not satisfy. The block
+frame inverts the whole region block and its complement instead, which are
+injective by hypothesis.
+
+## The route
+
+For a fixed inserted matrix `M`, the region-inserted coefficient as a function of
+the region physical configuration `σ` factors through the region blocked tensor
+map (`regionInsertedCoeff_eq_region_blockedMap`). The block-level image
+coincidence puts it in the range of the second tensor's region blocked tensor
+map, so the chosen region left inverse of the second tensor reads off a
+boundary-configuration coefficient row, `rowB`, with
+
+> `regionInsertedCoeff A R f M σ τ = regionBlockedTensorMap B R (rowB τ) σ`.
+
+Symmetrically in `τ`: each coefficient `rowB τ μ`, as a function of the complement
+physical configuration `τ`, factors through the second tensor's *complement*
+blocked tensor map (block-level image coincidence with the roles of `R` and
+`univ \ R` exchanged, using `univ \ (univ \ R) = R`), so the chosen complement
+left inverse reads off a complement-boundary-configuration coefficient kernel
+`K`, with
+
+> `rowB τ μ = regionBlockedTensorMap B (univ \ R) (fun ν => K μ ν) τ`.
+
+Combining the two readings expresses the coefficient as a double sum over the
+second tensor's region and complement weights with the **single kernel** `K`,
+which by the second tensor's double blocked injectivity is unique. Matching `K`
+against the explicit incident-matrix form of `regionInsertedCoeff B R f N`
+produces the transferred matrix `N`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The region-side blocked reading of the inserted coefficient
+
+For a fixed inserted matrix `M`, the region-inserted coefficient of the first
+tensor, as a function of the region physical configuration `σ`, lies in the range
+of the *second* tensor's region blocked tensor map. The block-level image
+coincidence `range_regionBlockedTensorMap_eq_of_sameState` transports the
+first-tensor factoring `regionInsertedCoeff_eq_region_blockedMap` into the second
+tensor's range, so the second tensor's region left inverse reads off a
+boundary-configuration row. -/
+
+/-- The region-side transferred row: the second tensor's region left inverse
+applied to the first tensor's region-inserted coefficient viewed as a function of
+the region physical configuration `σ`, at a fixed complement physical
+configuration `τ`. By the block-level image coincidence this row reproduces the
+coefficient through the second tensor's region blocked tensor map. -/
+noncomputable def blockTransferRow (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    RegionBoundaryConfig (G := G) B R → ℂ :=
+  regionBlockedLeftInverse (G := G) B R hRB
+    (fun σ => regionInsertedCoeff (G := G) A R f M σ τ)
+
+/-- **The region-side blocked reading.** Under `SameState`, with both complement
+blocks blocked-tensor injective and positive bond dimensions, the first tensor's
+region-inserted coefficient is the second tensor's region blocked tensor map of
+the transferred row `blockTransferRow`. The block-level image coincidence
+`range_regionBlockedTensorMap_eq_of_sameState` puts the coefficient (a function of
+`σ`) in the range of the second tensor's region blocked tensor map, and the chosen
+left inverse `regionBlockedLeftInverse B R hRB` realizes it as that map's image.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_blockTransferRow (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionBlockedTensorMap (G := G) B R (blockTransferRow A B R hRB f M τ) σ := by
+  -- The coefficient as a function of `σ` factors through the first tensor's
+  -- region blocked tensor map, hence lies in its range.
+  have hmemA : (fun σ' => regionInsertedCoeff (G := G) A R f M σ' τ) ∈
+      LinearMap.range (regionBlockedTensorMap (G := G) A R) := by
+    rw [LinearMap.mem_range]
+    exact ⟨regionRegionRow (G := G) A R f M τ,
+      (funext (fun σ' =>
+        (regionInsertedCoeff_eq_region_blockedMap A R f M σ' τ).symm))⟩
+  -- The block-level image coincidence transports it into the second tensor's range.
+  rw [range_regionBlockedTensorMap_eq_of_sameState A B R hAB hCA hCB hposA hposB hDim]
+    at hmemA
+  rw [LinearMap.mem_range] at hmemA
+  obtain ⟨c, hc⟩ := hmemA
+  -- The chosen region left inverse of the second tensor reads off `c`, which is the
+  -- transferred row, and applying the second tensor's map back reproduces the
+  -- coefficient.
+  have hrow : blockTransferRow A B R hRB f M τ = c := by
+    rw [blockTransferRow, ← hc, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+  rw [hrow, hc]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
@@ -157,5 +157,171 @@ theorem sum_regionBlockedWeight_mul_complement (A : Tensor G d) (R : Finset V)
       simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
       exact (regionBoundaryLabel_compl_eq_iff (G := G) A R μ ξ).mpr hξ
 
+/-! ### The partial state lies in the span of the blocked-region weights
+
+The interior bond multiple of a partial state is the blocked-region-weight
+combination whose coefficients are the complement weights at the fixed complement
+configuration. Since the interior bond multiplicity is a nonzero scalar, the
+partial state itself lies in the span of the blocked-region weights. -/
+
+/-- The interior bond multiple of a partial state is the blocked-region-weight
+combination of `A` over `R` with the complement weights as coefficients. This is
+`sum_regionBlockedWeight_mul_complement` read as an equality of functions of the
+region physical configuration. -/
+theorem regionInteriorBondProd_smul_regionPartialState (A : Tensor G d) (R : Finset V)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (regionInteriorBondProd (G := G) A R : ℂ) • regionPartialState (G := G) A R τ =
+      ∑ μ : RegionBoundaryConfig (G := G) A R,
+        regionBlockedWeight (G := G) A (Finset.univ \ R)
+            (regionComplementBoundaryConfig (G := G) A R μ) τ •
+          regionBlockedWeight (G := G) A R μ := by
+  funext σ
+  -- The right side, evaluated at `σ`, is the doubled-sum identity reading.
+  have hsum := sum_regionBlockedWeight_mul_complement (G := G) A R σ τ
+  simp only [nsmul_eq_mul] at hsum
+  rw [Finset.sum_apply]
+  simp only [Pi.smul_apply, smul_eq_mul]
+  -- Both sides are now the interior bond multiple of the closed state coefficient.
+  rw [show regionPartialState (G := G) A R τ σ =
+      stateCoeff A (assembleRegionσ (V := V) (d := d) R σ τ) from rfl, ← hsum]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [mul_comm]
+
+/-- **The partial state lies in the span of the blocked-region weights.** Its
+interior bond multiple is a blocked-region-weight combination
+(`regionInteriorBondProd_smul_regionPartialState`), and the interior bond
+multiplicity is a nonzero scalar (positive bond dimensions), so dividing it out
+keeps the partial state in the span. -/
+theorem regionPartialState_mem_span_regionBlockedWeight (A : Tensor G d) (R : Finset V)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionPartialState (G := G) A R τ ∈
+      Submodule.span ℂ (Set.range (fun μ : RegionBoundaryConfig (G := G) A R =>
+        regionBlockedWeight (G := G) A R μ)) := by
+  have hne : (regionInteriorBondProd (G := G) A R : ℂ) ≠ 0 := by
+    have hpos : 0 < regionInteriorBondProd (G := G) A R :=
+      Finset.prod_pos (fun e _ => hposA e)
+    exact_mod_cast hpos.ne'
+  rw [← Submodule.smul_mem_iff _ hne,
+    regionInteriorBondProd_smul_regionPartialState (G := G) A R τ]
+  refine Submodule.sum_mem _ (fun μ _ => ?_)
+  exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨μ, rfl⟩)
+
+/-! ### The blocked-region weights lie in the span of the partial states
+
+Blocked-tensor injectivity of the complement makes the complement weight family
+linearly independent, so by `span_cols_eq_top_of_linearIndependent` its columns
+span the full complement boundary-configuration space. Choosing the column
+combination realizing the standard basis vector at a boundary configuration `μ`
+extracts the single blocked-region weight of `μ` from the partial-state
+combination. -/
+
+/-- **The blocked-region weights lie in the span of the partial states.** Under
+blocked-tensor injectivity of the complement, the complement weight columns span
+the complement boundary-configuration space, so for each boundary configuration
+`μ` there is a complement-physical combination whose complement weights pick out
+the Kronecker delta at `μ`. Applying that combination to the partial-state reading
+of the interior bond multiple isolates the blocked-region weight of `μ`. -/
+theorem regionBlockedWeight_mem_span_regionPartialState (A : Tensor G d) (R : Finset V)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (μ : RegionBoundaryConfig (G := G) A R) :
+    regionBlockedWeight (G := G) A R μ ∈
+      Submodule.span ℂ
+        (Set.range (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+          regionPartialState (G := G) A R τ)) := by
+  classical
+  -- The complement weight family is linearly independent (blocked injectivity).
+  have hli : LinearIndependent ℂ (regionBlockedTensorFamily (G := G) A (Finset.univ \ R)) := hCA
+  -- Its columns span the complement boundary-configuration space.
+  have hcols := span_cols_eq_top_of_linearIndependent
+    (regionBlockedTensorFamily (G := G) A (Finset.univ \ R)) hli
+  -- The standard basis vector at `regionComplementBoundaryConfig μ` lies in the
+  -- column span, so it is a finite combination of the columns indexed by `τ`.
+  set ν₀ : RegionBoundaryConfig (G := G) A (Finset.univ \ R) :=
+    regionComplementBoundaryConfig (G := G) A R μ with hν₀
+  have hmem : Pi.single ν₀ (1 : ℂ) ∈
+      Submodule.span ℂ (Set.range
+        (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+          fun ν : RegionBoundaryConfig (G := G) A (Finset.univ \ R) =>
+            regionBlockedTensorFamily (G := G) A (Finset.univ \ R) ν τ)) := by
+    rw [hcols]; trivial
+  -- Read off the column combination as a finitely-supported coefficient family `a`.
+  rw [Finsupp.mem_span_range_iff_exists_finsupp] at hmem
+  obtain ⟨a, ha⟩ := hmem
+  -- `ha` evaluated at a complement boundary configuration `ν` reads the chosen
+  -- column combination off the Kronecker delta `Pi.single ν₀ 1 ν`.
+  have hcombo : ∀ ν : RegionBoundaryConfig (G := G) A (Finset.univ \ R),
+      (∑ τ ∈ a.support, a τ * regionBlockedWeight (G := G) A (Finset.univ \ R) ν τ) =
+        (Pi.single ν₀ (1 : ℂ) :
+          RegionBoundaryConfig (G := G) A (Finset.univ \ R) → ℂ) ν := by
+    intro ν
+    have := congrFun ha ν
+    rw [Finsupp.sum] at this
+    simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul,
+      regionBlockedTensorFamily] at this
+    exact this
+  -- `regionComplementBoundaryConfig` is injective, so the Kronecker delta at `ν₀`
+  -- read on `complBdry μ'` is the Kronecker delta at `μ` read on `μ'`.
+  have hδ : ∀ μ' : RegionBoundaryConfig (G := G) A R,
+      (Pi.single ν₀ (1 : ℂ) :
+          RegionBoundaryConfig (G := G) A (Finset.univ \ R) → ℂ)
+          (regionComplementBoundaryConfig (G := G) A R μ') =
+        (Pi.single μ (1 : ℂ) : RegionBoundaryConfig (G := G) A R → ℂ) μ' := by
+    intro μ'
+    by_cases hμ' : μ' = μ
+    · subst hμ'; rw [hν₀, Pi.single_eq_same, Pi.single_eq_same]
+    · have hne : regionComplementBoundaryConfig (G := G) A R μ' ≠ ν₀ := by
+        rw [hν₀]
+        exact fun hc => hμ' ((regionComplementBoundaryConfigEquiv (G := G) A R).injective hc)
+      rw [Pi.single_eq_of_ne hne, Pi.single_eq_of_ne hμ']
+  -- The blocked-region weight of `μ` is the same combination of the partial
+  -- states, scaled by the interior bond multiplicity.
+  have hweight : regionBlockedWeight (G := G) A R μ =
+      ∑ τ ∈ a.support,
+        ((regionInteriorBondProd (G := G) A R : ℂ) * a τ) •
+          regionPartialState (G := G) A R τ := by
+    funext σ
+    rw [Finset.sum_apply]
+    -- Pull the interior bond factor through each partial state and expand the
+    -- scaled partial state as the complement-weight combination.
+    have hstep : ∀ τ ∈ a.support,
+        (((regionInteriorBondProd (G := G) A R : ℂ) * a τ) •
+            regionPartialState (G := G) A R τ) σ =
+          ∑ μ' : RegionBoundaryConfig (G := G) A R,
+            a τ * (regionBlockedWeight (G := G) A (Finset.univ \ R)
+                (regionComplementBoundaryConfig (G := G) A R μ') τ *
+              regionBlockedWeight (G := G) A R μ' σ) := by
+      intro τ _
+      -- The interior bond multiple of the partial state is the complement-weight
+      -- combination, evaluated at `σ`.
+      have hkey := congrFun (regionInteriorBondProd_smul_regionPartialState (G := G) A R τ) σ
+      rw [Pi.smul_apply, smul_eq_mul, Finset.sum_apply] at hkey
+      simp only [Pi.smul_apply, smul_eq_mul] at hkey
+      -- Reassociate the left side, pull the bond factor onto the partial state,
+      -- and substitute the combination; then redistribute `a τ` over the sum.
+      rw [Pi.smul_apply, smul_eq_mul, mul_comm (regionInteriorBondProd (G := G) A R : ℂ) (a τ),
+        mul_assoc, hkey, Finset.mul_sum]
+    rw [Finset.sum_congr rfl hstep, Finset.sum_comm]
+    -- On each `μ'` the τ-sum collapses to the Kronecker delta via `hcombo`, `hδ`.
+    have hinner : ∀ μ' : RegionBoundaryConfig (G := G) A R,
+        (∑ τ ∈ a.support,
+            a τ * (regionBlockedWeight (G := G) A (Finset.univ \ R)
+                (regionComplementBoundaryConfig (G := G) A R μ') τ *
+              regionBlockedWeight (G := G) A R μ' σ)) =
+          (Pi.single μ (1 : ℂ) : RegionBoundaryConfig (G := G) A R → ℂ) μ' *
+            regionBlockedWeight (G := G) A R μ' σ := by
+      intro μ'
+      rw [Finset.sum_congr rfl (fun τ _ => (mul_assoc (a τ) _ _).symm), ← Finset.sum_mul,
+        hcombo (regionComplementBoundaryConfig (G := G) A R μ'), hδ μ']
+    rw [Finset.sum_congr rfl (fun μ' _ => hinner μ')]
+    -- The μ'-sum of `Pi.single μ 1 μ' * weight_R μ' σ` is `weight_R μ σ`.
+    rw [Finset.sum_eq_single μ]
+    · rw [Pi.single_eq_same, one_mul]
+    · intro μ' _ hμ'; rw [Pi.single_eq_of_ne hμ', zero_mul]
+    · intro h; exact absurd (Finset.mem_univ μ) h
+  rw [hweight]
+  refine Submodule.sum_mem _ (fun τ _ => ?_)
+  exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨τ, rfl⟩)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
@@ -82,6 +82,21 @@ theorem regionPartialState_sameState {A B : Tensor G d} (hAB : SameState A B)
   funext σ
   rw [regionPartialState, regionPartialState, hAB]
 
+/-! ### The range of the blocked-region tensor map is the span of its weights
+
+The blocked-region tensor map is the linear combination of the blocked-region
+weight family, so its range is the span of those weights. -/
+
+/-- The range of the blocked-region tensor map is the span of the blocked-region
+weights, since the map is `Fintype.linearCombination` of the weight family. -/
+theorem range_regionBlockedTensorMap_eq_span (A : Tensor G d) (R : Finset V) :
+    LinearMap.range (regionBlockedTensorMap (G := G) A R) =
+      Submodule.span ℂ
+        (Set.range (fun μ : RegionBoundaryConfig (G := G) A R =>
+          regionBlockedWeight (G := G) A R μ)) := by
+  rw [regionBlockedTensorMap, Fintype.range_linearCombination]
+  rfl
+
 /-! ### The blocked-region-weight contraction of the closed state coefficient
 
 Contracting the blocked-region weight on `R` against the blocked-region weight on
@@ -322,6 +337,78 @@ theorem regionBlockedWeight_mem_span_regionPartialState (A : Tensor G d) (R : Fi
   rw [hweight]
   refine Submodule.sum_mem _ (fun τ _ => ?_)
   exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨τ, rfl⟩)
+
+/-! ### The range of the blocked-region tensor map is the span of the partial states
+
+The two span-membership directions show that the span of the blocked-region
+weights and the span of the partial states coincide. With the range read as the
+span of the weights, the range of the blocked-region tensor map is the span of the
+partial states. -/
+
+/-- **The range of the blocked-region tensor map is the span of the partial
+states.** Combining the range-as-weight-span reading
+(`range_regionBlockedTensorMap_eq_span`) with the two span-membership directions
+(`regionPartialState_mem_span_regionBlockedWeight`,
+`regionBlockedWeight_mem_span_regionPartialState`) identifies the range with the
+span of the partial states across the region cut. -/
+theorem range_regionBlockedTensorMap_eq_span_regionPartialState (A : Tensor G d)
+    (R : Finset V)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) :
+    LinearMap.range (regionBlockedTensorMap (G := G) A R) =
+      Submodule.span ℂ
+        (Set.range (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+          regionPartialState (G := G) A R τ)) := by
+  rw [range_regionBlockedTensorMap_eq_span]
+  refine le_antisymm ?_ ?_
+  · -- Span of weights ⊆ span of partial states: each weight is a partial-state combo.
+    rw [Submodule.span_le]
+    rintro _ ⟨μ, rfl⟩
+    exact regionBlockedWeight_mem_span_regionPartialState (G := G) A R hCA μ
+  · -- Span of partial states ⊆ span of weights: each partial state is a weight combo.
+    rw [Submodule.span_le]
+    rintro _ ⟨τ, rfl⟩
+    exact regionPartialState_mem_span_regionBlockedWeight (G := G) A R hposA τ
+
+/-! ### Block-level image coincidence
+
+Under `SameState`, the partial states of the two tensors coincide
+(`regionPartialState_sameState`), so the spans of the partial states coincide.
+With each range identified as the span of the partial states, the two ranges of
+the blocked-region tensor maps coincide. This is the block-granularity analogue of
+`range_localTensorMap_eq_of_sameState`. -/
+
+/-- **Block-level image coincidence.** Under `SameState`, with both complement
+blocks blocked-tensor injective and positive bond dimensions, the ranges of the
+blocked-region tensor maps of the two tensors coincide. Both ranges equal the span
+of the partial states across the region cut
+(`range_regionBlockedTensorMap_eq_span_regionPartialState`), and the partial
+states are `SameState`-invariant (`regionPartialState_sameState`).
+
+This is the block analogue of `range_localTensorMap_eq_of_sameState`: the single
+vertex of the vertex frame need not be injective, but the block is, so the image
+coincidence holds at block granularity. It is the block-level image preservation
+the general region-injective normal PEPS Fundamental Theorem needs.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem range_regionBlockedTensorMap_eq_of_sameState (A B : Tensor G d) (R : Finset V)
+    (hAB : SameState A B)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim) :
+    LinearMap.range (regionBlockedTensorMap (G := G) A R) =
+      LinearMap.range (regionBlockedTensorMap (G := G) B R) := by
+  rw [range_regionBlockedTensorMap_eq_span_regionPartialState A R hCA hposA,
+    range_regionBlockedTensorMap_eq_span_regionPartialState B R hCB hposB]
+  congr 1
+  ext x
+  simp only [Set.mem_range]
+  constructor
+  · rintro ⟨τ, rfl⟩; exact ⟨τ, (regionPartialState_sameState hAB R τ).symm⟩
+  · rintro ⟨τ, rfl⟩; exact ⟨τ, regionPartialState_sameState hAB R τ⟩
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
@@ -1,0 +1,161 @@
+import TNLean.PEPS.RegionBlock.Recovery6
+
+/-!
+# Block-level image coincidence for the normal PEPS Fundamental Theorem
+
+This file proves the **block-level image coincidence** lemma: under `SameState`,
+the range of the blocked-region tensor map of a region `R` is the same for two
+tensors `A` and `B`, provided the *complement* block `univ \ R` of each tensor is
+blocked-tensor injective and the bond dimensions are positive and equal.
+
+This is the block-granularity analogue of the vertex-level image coincidence
+`range_localTensorMap_eq_of_sameState` of `TNLean.PEPS.RegionBlock.Recovery3`. The
+vertex frame is too weak for the general normal theorem because a single vertex
+need not be injective; the *block* `R` is the object that is injective in the
+normal setting, so the image coincidence must hold at block granularity.
+
+## The Schmidt-span argument
+
+Both ranges equal the column space of the global state across the `R` / complement
+cut, which is `SameState`-invariant. Concretely, both ranges equal the span of the
+**partial states**
+
+> `regionPartialState A R τ := fun σ => stateCoeff A (assembleRegionσ R σ τ)`
+
+as the complement physical configuration `τ` ranges. The proof mirrors the
+vertex-level proof of `TNLean.PEPS.RegionBlock.Recovery3` at block granularity:
+
+* The range of the blocked-region tensor map is the span of the blocked-region
+  weights (`Fintype.range_linearCombination`).
+* Each partial state is, up to the nonzero interior bond multiplicity, a
+  blocked-region-weight combination of `A` over `R` (the identity-insertion
+  reading of the closed state coefficient), so the partial states lie in the span
+  of the blocked-region weights.
+* Conversely, blocked-tensor injectivity of the complement
+  (`RegionBlockedTensorInjective A (univ \ R)`) makes the complement weight family
+  linearly independent, so by `span_cols_eq_top_of_linearIndependent` its columns
+  span; this realizes every blocked-region weight as a partial-state combination.
+* The partial states depend only on `stateCoeff`, so they are `SameState`-invariant.
+
+Combining these gives
+`range (regionBlockedTensorMap A R) = span τ {regionPartialState A R τ}
+  = span τ {regionPartialState B R τ} = range (regionBlockedTensorMap B R)`,
+the block analogue of `range_localTensorMap_eq_of_sameState`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The partial states across the region cut
+
+The partial state at a complement physical configuration `τ` is the closed state
+coefficient of the assembled global configuration, read as a function of the
+region physical configuration `σ`. It is the column of the global state vector
+across the `R` / complement cut at the fixed complement configuration `τ`. -/
+
+/-- The partial state across the region cut at a complement physical
+configuration `τ`: the closed state coefficient of `assembleRegionσ R σ τ`, viewed
+as a function of the region physical configuration `σ`. This is a column of the
+global state vector across the `R` / complement cut. -/
+noncomputable def regionPartialState (A : Tensor G d) (R : Finset V)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    RegionPhysicalConfig (V := V) (d := d) R → ℂ :=
+  fun σ => stateCoeff A (assembleRegionσ (V := V) (d := d) R σ τ)
+
+/-- The partial state depends on the tensor only through its closed state
+coefficient, so it is invariant under `SameState`. -/
+theorem regionPartialState_sameState {A B : Tensor G d} (hAB : SameState A B)
+    (R : Finset V) (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionPartialState (G := G) A R τ = regionPartialState (G := G) B R τ := by
+  funext σ
+  rw [regionPartialState, regionPartialState, hAB]
+
+/-! ### The blocked-region-weight contraction of the closed state coefficient
+
+Contracting the blocked-region weight on `R` against the blocked-region weight on
+`univ \ R`, summed over the boundary configuration, reads the interior bond
+multiple of the closed state coefficient. This is the edge-free form of the
+identity-insertion reading `regionInsertedCoeff_one_eq_stateCoeff`: it does not
+single out a boundary edge, so it applies to a region with no boundary edge as
+well. -/
+
+open scoped Classical in
+/-- The boundary-configuration contraction of the region weight against the
+complement weight reads the interior bond multiple of the closed state
+coefficient. This is the edge-free identity-insertion reading: it follows from the
+double-global-configuration form of the closed-state split
+(`stateCoeff_eq_regionComplement`) after expanding both weights. -/
+theorem sum_regionBlockedWeight_mul_complement (A : Tensor G d) (R : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (∑ μ : RegionBoundaryConfig (G := G) A R,
+        regionBlockedWeight (G := G) A R μ σ *
+          regionBlockedWeight (G := G) A (Finset.univ \ R)
+            (regionComplementBoundaryConfig (G := G) A R μ) τ) =
+      regionInteriorBondProd (G := G) A R •
+        stateCoeff A (assembleRegionσ (V := V) (d := d) R σ τ) := by
+  classical
+  rw [← stateCoeff_eq_regionComplement (G := G) A R σ τ]
+  -- Expand both blocked-region weights as filtered sums over global configurations.
+  simp only [regionBlockedWeight]
+  -- Distribute the products of filtered sums and reorganize into the
+  -- boundary-agreement pair sum, mirroring `regionInsertedCoeff_identity_eq_doubleSum`.
+  rw [show (∑ μ : RegionBoundaryConfig (G := G) A R,
+        (∑ ζ ∈ Finset.univ.filter
+            (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A R ζ = μ),
+          ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+          ∑ ξ ∈ Finset.univ.filter
+            (fun ξ : VirtualConfig A =>
+              regionBoundaryLabel (G := G) A (Finset.univ \ R) ξ =
+                regionComplementBoundaryConfig (G := G) A R μ),
+            ∏ w : {w : V // w ∈ Finset.univ \ R},
+              A.component w.1 (fun ie => ξ ie.1) (τ w)) =
+      ∑ μ : RegionBoundaryConfig (G := G) A R,
+        ∑ ζ ∈ Finset.univ.filter
+            (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A R ζ = μ),
+          ∑ ξ ∈ Finset.univ.filter
+            (fun ξ : VirtualConfig A => regionBoundaryLabel (G := G) A R ξ = μ),
+            (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+              ∏ w : {w : V // w ∈ Finset.univ \ R},
+                A.component w.1 (fun ie => ξ ie.1) (τ w) from ?_]
+  · -- Reindex the triple sum (μ, ζ, ξ) onto the boundary-agreement pair sum.
+    simp only [Finset.sum_filter]
+    rw [Fintype.sum_prod_type]
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun ζ _ => ?_)
+    rw [Finset.sum_eq_single (regionBoundaryLabel (G := G) A R ζ)]
+    · rw [if_pos rfl]
+      refine Finset.sum_congr rfl (fun ξ _ => ?_)
+      by_cases heq : regionBoundaryLabel (G := G) A R ζ = regionBoundaryLabel (G := G) A R ξ
+      · rw [if_pos heq.symm, if_pos heq]
+      · rw [if_neg (fun h => heq h.symm), if_neg heq]
+    · intro μ _ hμ
+      rw [if_neg (fun h => hμ h.symm)]
+    · intro h; exact absurd (Finset.mem_univ _) h
+  · -- The complement filter matches the region filter after the boundary-edge
+    -- identification, and the product of sums is the doubled sum.
+    refine Finset.sum_congr rfl (fun μ _ => ?_)
+    rw [Finset.sum_mul_sum]
+    refine Finset.sum_congr rfl (fun ζ _ => ?_)
+    refine Finset.sum_nbij' id id ?_ ?_ (fun _ _ => rfl) (fun _ _ => rfl) (fun ξ hξ => rfl)
+    · intro ξ hξ
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
+      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R μ ξ).mp hξ
+    · intro ξ hξ
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
+      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R μ ξ).mpr hξ
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockRealization.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRealization.lean
@@ -126,5 +126,273 @@ theorem regionRegionRow_eq_rowInsertF (A : Tensor G d) (R : Finset V)
   rw [regionRegionRow, rowInsertF_apply]
   rfl
 
+/-! ### The complement weight row is the region left inverse of the partial state
+
+The interior bond multiple of the partial state across the region cut is the region
+blocked tensor map of the complement weight row
+(`regionInteriorBondProd_smul_regionPartialState`,
+`TNLean.PEPS.RegionBlock.BlockRangeCoincidence`). So the chosen region left inverse
+reads the complement weight row off the interior bond multiple of the partial state.
+This connects the M-independent complement weight row to the `SameState`-invariant
+partial state. -/
+
+/-- The interior bond multiple of the partial state across the region cut is the
+region blocked tensor map of the complement weight row. This restates
+`regionInteriorBondProd_smul_regionPartialState`
+(`TNLean.PEPS.RegionBlock.BlockRangeCoincidence`) with the complement weight row
+named.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_smul_regionPartialState_eq_blockedMap (A : Tensor G d)
+    (R : Finset V) (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (regionInteriorBondProd (G := G) A R : ℂ) • regionPartialState (G := G) A R τ =
+      regionBlockedTensorMap (G := G) A R (regionComplementWeightRow (G := G) A R τ) := by
+  classical
+  rw [regionInteriorBondProd_smul_regionPartialState (G := G) A R τ]
+  funext σ
+  rw [regionBlockedTensorMap_apply, Finset.sum_apply]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [regionComplementWeightRow, Pi.smul_apply]
+
+/-- The chosen region left inverse reads the complement weight row off the interior
+bond multiple of the partial state across the region cut. -/
+theorem regionBlockedLeftInverse_regionInteriorBondProd_smul_regionPartialState
+    (A : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionBlockedLeftInverse (G := G) A R hRA
+        ((regionInteriorBondProd (G := G) A R : ℂ) • regionPartialState (G := G) A R τ) =
+      regionComplementWeightRow (G := G) A R τ := by
+  rw [regionInteriorBondProd_smul_regionPartialState_eq_blockedMap (G := G) A R τ,
+    regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
+/-! ### The block realization operator
+
+The M-insertion on the boundary edge `f`, realized as a linear endomorphism of the
+region physical functions through the first tensor's region block: invert the
+region block, apply the row insertion of `M`, reblock. This is the block-granularity
+port of the edge insertion operator `edgeRightInsertionOp`
+(`TNLean.PEPS.InsertionAlgebra`), inverting the whole region block instead of one
+vertex. -/
+
+/-- The **block realization operator** of a matrix `M` on the boundary edge `f`: the
+region blocked tensor map of the row insertion of `M` of the region left inverse.
+Applied to a region physical function lying in the range of the region blocked
+tensor map, it realizes the M-insertion on the boundary edge `f`. This is the
+block-granularity port of the edge insertion operator `edgeRightInsertionOp`,
+inverting the whole region block rather than a single vertex.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def blockRealizeOp (A : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    (RegionPhysicalConfig (V := V) (d := d) R → ℂ) →ₗ[ℂ]
+      (RegionPhysicalConfig (V := V) (d := d) R → ℂ) :=
+  (regionBlockedTensorMap (G := G) A R).comp
+    ((rowInsertF (G := G) A R f M).comp (regionBlockedLeftInverse (G := G) A R hRA))
+
+theorem blockRealizeOp_apply (A : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (g : RegionPhysicalConfig (V := V) (d := d) R → ℂ) :
+    blockRealizeOp (G := G) A R hRA f M g =
+      regionBlockedTensorMap (G := G) A R
+        (rowInsertF (G := G) A R f M
+          (regionBlockedLeftInverse (G := G) A R hRA g)) := rfl
+
+/-- **The block realization operator on the region blocked tensor map.** On the
+region blocked tensor map of any boundary-configuration coefficient `c`, the block
+realization operator reblocks the row insertion of `M` of `c`. This is the operator
+acting on the region block image, where the region left inverse cancels the region
+blocked tensor map. -/
+theorem blockRealizeOp_regionBlockedTensorMap (A : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (c : RegionBoundaryConfig (G := G) A R → ℂ) :
+    blockRealizeOp (G := G) A R hRA f M (regionBlockedTensorMap (G := G) A R c) =
+      regionBlockedTensorMap (G := G) A R (rowInsertF (G := G) A R f M c) := by
+  rw [blockRealizeOp_apply, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
+/-! ### KEY IDENTITY 1: the realization operator recovers the M-inserted coefficient
+
+Applied to the interior bond multiple of the partial state across the region cut,
+the block realization operator recovers the interior bond multiple of the first
+tensor's region-inserted coefficient of `M`, read as a function of the region
+physical configuration. The partial state is the `SameState`-invariant object
+through which the realization transports across the comparison. -/
+
+/-- **KEY IDENTITY 1.** The block realization operator of `M`, applied to the interior
+bond multiple of the partial state across the region cut, recovers the first tensor's
+region-inserted coefficient of `M`, read as a function of the region physical
+configuration. The region left inverse reads the complement weight row off the
+partial state (`regionBlockedLeftInverse_regionInteriorBondProd_smul_regionPartialState`),
+the row insertion turns it into the region row
+(`regionRegionRow_eq_rowInsertF`), and the region blocked tensor map of the region row
+is the coefficient (`regionInsertedCoeff_eq_region_blockedMap`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem blockRealizeOp_regionPartialState_eq_regionInsertedCoeff (A : Tensor G d)
+    (R : Finset V) (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    blockRealizeOp (G := G) A R hRA f M
+        ((regionInteriorBondProd (G := G) A R : ℂ) • regionPartialState (G := G) A R τ) =
+      fun σ => regionInsertedCoeff (G := G) A R f M σ τ := by
+  rw [blockRealizeOp_apply,
+    regionBlockedLeftInverse_regionInteriorBondProd_smul_regionPartialState (G := G) A R hRA τ,
+    ← regionRegionRow_eq_rowInsertF (G := G) A R f M τ]
+  funext σ
+  rw [← regionInsertedCoeff_eq_region_blockedMap A R f M σ τ]
+
+/-! ### Step 2: the M-inserted coefficient through the second tensor's partial state
+
+The partial state across the region cut is `SameState`-invariant
+(`regionPartialState_sameState`,
+`TNLean.PEPS.RegionBlock.BlockRangeCoincidence`), so KEY IDENTITY 1 also reads the
+first tensor's region-inserted coefficient of `M` off the *second* tensor's partial
+state. This is the transport across the comparison: the realization operator built
+from the first tensor acts on the second tensor's `SameState`-invariant column. -/
+
+/-- **The M-inserted coefficient through the second tensor's partial state.** The
+block realization operator of `M`, applied to the interior bond multiple of the
+second tensor's partial state across the region cut, recovers the first tensor's
+region-inserted coefficient of `M` as a function of the region physical
+configuration. The partial state is `SameState`-invariant, so the second tensor's
+column feeds the first tensor's realization operator (KEY IDENTITY 1).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem blockRealizeOp_regionPartialState_B_eq_regionInsertedCoeff (A B : Tensor G d)
+    (R : Finset V) (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hAB : SameState A B)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    blockRealizeOp (G := G) A R hRA f M
+        ((regionInteriorBondProd (G := G) A R : ℂ) • regionPartialState (G := G) B R τ) =
+      fun σ => regionInsertedCoeff (G := G) A R f M σ τ := by
+  rw [← regionPartialState_sameState hAB R τ,
+    blockRealizeOp_regionPartialState_eq_regionInsertedCoeff (G := G) A R hRA f M τ]
+
+/-! ### Step 3: expanding the second tensor's partial state through its region block
+
+The second tensor's partial state across the region cut lies in the range of the
+second tensor's region blocked tensor map
+(`regionPartialState_mem_span_regionBlockedWeight`,
+`TNLean.PEPS.RegionBlock.BlockRangeCoincidence`). Writing it as the second tensor's
+region blocked tensor map of a boundary-configuration row exposes the **A↔B basis
+change** `Φ := regionBlockedLeftInverse A R hRA ∘ regionBlockedTensorMap B R` inside
+the realization operator: the first tensor's realization of the second tensor's block
+image is the first tensor's region block of the row insertion of the basis-changed
+row. This is the cross-tensor expansion the bond-locality reconcile acts on. -/
+
+/-- The second tensor's partial state across the region cut lies in the range of the
+second tensor's region blocked tensor map. By
+`regionPartialState_mem_span_regionBlockedWeight`
+(`TNLean.PEPS.RegionBlock.BlockRangeCoincidence`), it lies in the span of the second
+tensor's region blocked weights, which is the range of the region blocked tensor map
+(`range_regionBlockedTensorMap_eq_span`). -/
+theorem regionPartialState_mem_range_regionBlockedTensorMap (B : Tensor G d)
+    (R : Finset V) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionPartialState (G := G) B R τ ∈
+      LinearMap.range (regionBlockedTensorMap (G := G) B R) := by
+  rw [range_regionBlockedTensorMap_eq_span (G := G) B R]
+  exact regionPartialState_mem_span_regionBlockedWeight (G := G) B R hposB τ
+
+/-- The chosen second-tensor region boundary-configuration row whose region blocked
+tensor map is the second tensor's partial state across the region cut. -/
+noncomputable def partialStateRowB (B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    RegionBoundaryConfig (G := G) B R → ℂ :=
+  regionBlockedLeftInverse (G := G) B R hRB (regionPartialState (G := G) B R τ)
+
+/-- The second tensor's region blocked tensor map of `partialStateRowB` is the second
+tensor's partial state across the region cut. -/
+theorem regionBlockedTensorMap_partialStateRowB (B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionBlockedTensorMap (G := G) B R (partialStateRowB (G := G) B R hRB τ) =
+      regionPartialState (G := G) B R τ := by
+  obtain ⟨c, hc⟩ := regionPartialState_mem_range_regionBlockedTensorMap (G := G) B R hposB τ
+  rw [partialStateRowB, ← hc, regionBlockedLeftInverse_apply_regionBlockedTensorMap, hc]
+
+/-- The **A↔B region basis change**: the first tensor's region left inverse of the
+second tensor's region blocked tensor map. It conjugates the row insertion inside the
+cross-tensor realization. -/
+noncomputable def regionBasisChange (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R) :
+    (RegionBoundaryConfig (G := G) B R → ℂ) →ₗ[ℂ]
+      (RegionBoundaryConfig (G := G) A R → ℂ) :=
+  (regionBlockedLeftInverse (G := G) A R hRA).comp (regionBlockedTensorMap (G := G) B R)
+
+theorem regionBasisChange_apply (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (c : RegionBoundaryConfig (G := G) B R → ℂ) :
+    regionBasisChange (G := G) A B R hRA c =
+      regionBlockedLeftInverse (G := G) A R hRA
+        (regionBlockedTensorMap (G := G) B R c) := rfl
+
+/-- **The realization operator on the second tensor's expanded partial state.** The
+block realization operator of `M`, applied to the second tensor's partial state
+across the region cut, is the first tensor's region blocked tensor map of the row
+insertion of `M` of the basis-changed second-tensor partial-state row. The
+realization operator's region left inverse meets the second tensor's region blocked
+tensor map exactly at the A↔B basis change `regionBasisChange`. -/
+theorem blockRealizeOp_regionPartialState_B_eq_basisChange (A B : Tensor G d)
+    (R : Finset V) (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    blockRealizeOp (G := G) A R hRA f M (regionPartialState (G := G) B R τ) =
+      regionBlockedTensorMap (G := G) A R
+        (rowInsertF (G := G) A R f M
+          (regionBasisChange (G := G) A B R hRA
+            (partialStateRowB (G := G) B R hRB τ))) := by
+  rw [blockRealizeOp_apply, regionBasisChange_apply,
+    regionBlockedTensorMap_partialStateRowB (G := G) B R hRB hposB τ]
+
+open scoped Classical in
+/-- **Step 3: the cross-tensor expansion.** The first tensor's region-inserted
+coefficient of `M`, read as a function of the region physical configuration, is the
+interior bond multiple of the first tensor's region blocked tensor map of the row
+insertion of `M` of the basis-changed second-tensor partial-state row.
+
+This is KEY IDENTITY 1 (through the second tensor's partial state, Step 2) with the
+second tensor's partial state expanded through its region block (Step 3): the
+realization operator's region left inverse meets the second tensor's region blocked
+tensor map exactly at the A↔B basis change `regionBasisChange`. The interior bond
+product appears because KEY IDENTITY 1 reads the realization operator on the interior
+bond multiple of the partial state.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_crossExpansion (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hAB : SameState A B) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (fun σ => regionInsertedCoeff (G := G) A R f M σ τ) =
+      (regionInteriorBondProd (G := G) A R : ℂ) •
+        regionBlockedTensorMap (G := G) A R
+          (rowInsertF (G := G) A R f M
+            (regionBasisChange (G := G) A B R hRA
+              (partialStateRowB (G := G) B R hRB τ))) := by
+  rw [← blockRealizeOp_regionPartialState_B_eq_regionInsertedCoeff A B R hRA hAB f M τ,
+    map_smul, blockRealizeOp_regionPartialState_B_eq_basisChange A B R hRA hRB hposB f M τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockRealization.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRealization.lean
@@ -92,6 +92,51 @@ open scoped Classical in
       ∑ ν : RegionBoundaryConfig (G := G) A R,
         (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) * c ν := rfl
 
+open scoped Classical in
+/-- The row insertion of two region boundary configurations is the standard basis at
+the boundary configuration: the incident-matrix coupling vanishes unless the two
+configurations agree on the boundary edge `f` as well as off it, that is, unless they
+are equal. -/
+theorem rowInsertF_coupling_eq_single (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (μ ν : RegionBoundaryConfig (G := G) A R) :
+    (if SameAwayFromBond f μ ν then (1 : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+        (μ f) (ν f) else 0) =
+      (if μ = ν then (1 : ℂ) else 0) := by
+  classical
+  by_cases hμν : μ = ν
+  · subst hμν
+    have hsame : SameAwayFromBond f μ μ := fun c _ => rfl
+    rw [if_pos hsame, Matrix.one_apply_eq, if_pos rfl]
+  · rw [if_neg hμν]
+    by_cases hsame : SameAwayFromBond f μ ν
+    · rw [if_pos hsame, Matrix.one_apply]
+      by_cases hbond : μ f = ν f
+      · exact absurd (funext (fun c => by
+          by_cases hc : c = f
+          · subst hc; exact hbond
+          · exact hsame c hc)) hμν
+      · rw [if_neg hbond]
+    · rw [if_neg hsame]
+
+open scoped Classical in
+/-- **The row insertion of the identity is the identity.** Inserting the identity
+matrix on the boundary edge `f` couples the boundary legs trivially, contracting all
+legs by the identity, so the row insertion is the identity endomorphism. This is the
+anchor `M = 1` of the row insertion. -/
+@[simp] theorem rowInsertF_one (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    rowInsertF (G := G) A R f (1 : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) =
+      LinearMap.id := by
+  classical
+  refine LinearMap.ext (fun c => funext (fun μ => ?_))
+  rw [rowInsertF_apply, LinearMap.id_apply]
+  rw [Finset.sum_eq_single μ]
+  · rw [rowInsertF_coupling_eq_single A R f μ μ, if_pos rfl, one_mul]
+  · intro ν _ hν
+    rw [rowInsertF_coupling_eq_single A R f μ ν, if_neg (Ne.symm hν), zero_mul]
+  · intro hμ; exact absurd (Finset.mem_univ μ) hμ
+
 /-- The **complement weight row**: the M-independent boundary-configuration
 coefficient family the row insertion acts on. At a region boundary configuration
 `ν`, it is the complement blocked weight of the complement boundary configuration

--- a/TNLean/PEPS/RegionBlock/BlockRealization.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRealization.lean
@@ -651,5 +651,50 @@ theorem regionInsertedCoeff_eq_of_basisChange_intertwine (A B : Tensor G d) (R :
     rw [hcross, hBside, hcongr]
   exact congrFun hfun σ
 
+/-! ### Packaging the reduction toward the bond-locality predicate
+
+Quantifying the intertwining over every inserted matrix `M` (with the matching `N`
+depending on `M`) gives the full coefficient transfer, hence — through the
+reconcile-is-transfer bridge `bondLocal_iff_coeffTransfer`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`) — the bond locality of the transfer
+kernel. This isolates the residual open content of the block-frame coefficient
+transfer as the single intertwining of the basis change with the row insertions. -/
+
+/-- **Bond locality from the basis-change intertwining.** If, for every inserted
+matrix `M` on the boundary edge `f`, the A↔B basis change intertwines the two row
+insertions for some matrix `N`, then the transfer kernel is bond-local
+(`IsBondLocalTransferKernel`). The intertwining gives the coefficient transfer
+(`regionInsertedCoeff_eq_of_basisChange_intertwine`), which the reconcile-is-transfer
+bridge `bondLocal_iff_coeffTransfer` reads as the bond locality of the transfer kernel.
+
+This is the precise reduction of the last open predicate of the general normal PEPS
+per-edge gauge to one conjugation identity for the basis change, with no single-vertex
+injectivity.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem isBondLocalTransferKernel_of_basisChange_intertwine (A B : Tensor G d)
+    (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hintertwine : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+          rowInsertF (G := G) A R f M
+              (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ)) =
+            regionBasisChange (G := G) A B R hRA
+              (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ))) :
+    IsBondLocalTransferKernel (G := G) A B R hRB hCB f := by
+  rw [bondLocal_iff_coeffTransfer A B R hRA hRB hCA hCB hAB hposA hposB hDim f]
+  intro M
+  obtain ⟨N, hN⟩ := hintertwine M
+  exact ⟨N, fun σ τ => regionInsertedCoeff_eq_of_basisChange_intertwine A B R hRA hRB hCA hCB
+    hAB hposA hposB hDim f M N hN σ τ⟩
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockRealization.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRealization.lean
@@ -439,5 +439,81 @@ theorem regionInsertedCoeff_eq_crossExpansion (A B : Tensor G d) (R : Finset V)
   rw [← blockRealizeOp_regionPartialState_B_eq_regionInsertedCoeff A B R hRA hAB f M τ,
     map_smul, blockRealizeOp_regionPartialState_B_eq_basisChange A B R hRA hRB hposB f M τ]
 
+/-! ### The anchor consistency of the basis change
+
+At the anchor `M = 1` the row insertion is the identity (`rowInsertF_one`), so the
+cross-tensor expansion reads the closed-state column off the first tensor's region
+block applied to the basis-changed second-tensor partial-state row. Reblocking the
+basis change through the first tensor's region block returns the second tensor's
+partial state, because that partial state lies in the *common* range of the two
+region blocked tensor maps (block-level image coincidence
+`range_regionBlockedTensorMap_eq_of_sameState`,
+`TNLean.PEPS.RegionBlock.BlockRangeCoincidence`). This anchors the basis change: on
+the second tensor's region block image it is the identity. -/
+
+/-- Reblocking the region left inverse of a region physical function in the range of
+the region blocked tensor map returns the function. This is the right-inverse
+property of the chosen left inverse on the range. -/
+theorem regionBlockedTensorMap_regionBlockedLeftInverse_of_mem_range (A : Tensor G d)
+    (R : Finset V) (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (g : RegionPhysicalConfig (V := V) (d := d) R → ℂ)
+    (hg : g ∈ LinearMap.range (regionBlockedTensorMap (G := G) A R)) :
+    regionBlockedTensorMap (G := G) A R
+        (regionBlockedLeftInverse (G := G) A R hRA g) = g := by
+  obtain ⟨c, hc⟩ := hg
+  rw [← hc, regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
+/-- **The basis change is the identity on the second tensor's partial state.**
+Reblocking, through the first tensor's region block, the basis change of the second
+tensor's partial-state row returns the second tensor's partial state. The basis
+change reads the partial state off the second tensor's region block and reblocks it
+through the first tensor's region block; since the partial state lies in the *common*
+range of the two region blocked tensor maps (block-level image coincidence), the
+reblocking returns it.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorMap_basisChange_partialStateRowB (A B : Tensor G d)
+    (R : Finset V) (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionBlockedTensorMap (G := G) A R
+        (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ)) =
+      regionPartialState (G := G) B R τ := by
+  rw [regionBasisChange_apply,
+    regionBlockedTensorMap_partialStateRowB (G := G) B R hRB hposB τ]
+  refine regionBlockedTensorMap_regionBlockedLeftInverse_of_mem_range (G := G) A R hRA _ ?_
+  rw [range_regionBlockedTensorMap_eq_of_sameState A B R hAB hCA hCB hposA hposB hDim]
+  exact regionPartialState_mem_range_regionBlockedTensorMap (G := G) B R hposB τ
+
+/-- **The anchor consistency.** At the inserted identity, the cross-tensor expansion
+recovers the interior bond multiple of the second tensor's partial state across the
+region cut — equivalently, the first tensor's region-inserted coefficient of the
+identity, by the closed-state reading. This confirms the basis change and the
+realization operator are aligned at the anchor `M = 1`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_one_eq_crossExpansion (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (fun σ => regionInsertedCoeff (G := G) A R f
+        (1 : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) σ τ) =
+      (regionInteriorBondProd (G := G) A R : ℂ) • regionPartialState (G := G) B R τ := by
+  rw [regionInsertedCoeff_eq_crossExpansion A B R hRA hRB hAB hposB f 1 τ, rowInsertF_one,
+    LinearMap.id_apply,
+    regionBlockedTensorMap_basisChange_partialStateRowB A B R hRA hRB hCA hCB hAB
+      hposA hposB hDim τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockRealization.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRealization.lean
@@ -515,5 +515,141 @@ theorem regionInsertedCoeff_one_eq_crossExpansion (A B : Tensor G d) (R : Finset
     regionBlockedTensorMap_basisChange_partialStateRowB A B R hRA hRB hCA hCB hAB
       hposA hposB hDim τ]
 
+/-! ### The basis change reblocks to the second tensor's block on the common range
+
+The first tensor's region blocked tensor map of the basis change of a
+boundary-configuration row equals the second tensor's region blocked tensor map of
+the row, provided the second tensor's block image of the row lies in the *common*
+range of the two region blocked tensor maps (block-level image coincidence). This is
+the structural property of the basis change `regionBasisChange`: on the common range
+it is the identity bridge between the two region blocks. -/
+
+/-- **The basis change reblocks to the second tensor's block on the common range.**
+For a second-tensor boundary-configuration row whose second-tensor region block image
+lies in the common range of the two region blocked tensor maps, the first tensor's
+region blocked tensor map of its basis change equals the second tensor's region
+blocked tensor map of the row. The basis change reads the row off the second tensor's
+region block and reblocks through the first tensor's region block; on the common
+range the reblocking returns the second tensor's block image.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorMap_basisChange_eq_of_mem_range (A B : Tensor G d)
+    (R : Finset V) (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (c : RegionBoundaryConfig (G := G) B R → ℂ)
+    (hmem : regionBlockedTensorMap (G := G) B R c ∈
+      LinearMap.range (regionBlockedTensorMap (G := G) A R)) :
+    regionBlockedTensorMap (G := G) A R (regionBasisChange (G := G) A B R hRA c) =
+      regionBlockedTensorMap (G := G) B R c := by
+  rw [regionBasisChange_apply]
+  exact regionBlockedTensorMap_regionBlockedLeftInverse_of_mem_range (G := G) A R hRA _ hmem
+
+/-! ### The B-analogue of KEY IDENTITY 1
+
+The block realization operator of the second tensor, applied to the interior bond
+multiple of the second tensor's own partial state across the region cut, recovers the
+second tensor's region-inserted coefficient. This is KEY IDENTITY 1
+(`blockRealizeOp_regionPartialState_eq_regionInsertedCoeff`) instanced at the second
+tensor, the read-off the cross-tensor reduction lands on. -/
+
+/-- The block realization operator of the second tensor, applied to the second
+tensor's region block of a boundary-configuration row, reblocks the row insertion of
+`N` of the row. This is `blockRealizeOp_regionBlockedTensorMap` instanced at the
+second tensor. -/
+theorem blockRealizeOp_B_regionBlockedTensorMap (B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (c : RegionBoundaryConfig (G := G) B R → ℂ) :
+    blockRealizeOp (G := G) B R hRB f N (regionBlockedTensorMap (G := G) B R c) =
+      regionBlockedTensorMap (G := G) B R (rowInsertF (G := G) B R f N c) :=
+  blockRealizeOp_regionBlockedTensorMap (G := G) B R hRB f N c
+
+/-! ### The cross-tensor coefficient transfer from the intertwining (the V=W reduction)
+
+The genuine step `V=W`: if the A↔B basis change `regionBasisChange` *intertwines* the
+two row insertions — the first tensor's row insertion of `M` of the basis change
+equals the basis change of the second tensor's row insertion of `N`, for a single
+matrix `N` on the second tensor's bond — then the first tensor's region-inserted
+coefficient of `M` equals the second tensor's of `N`. This is the precise content the
+three-block reconcile supplies (the basis change preserves the bond-`f`/away-from-`f`
+decomposition because the away-from-`f` couplings are pinned by the complement
+injectivity); isolating it as the intertwining hypothesis reduces the cross-tensor
+coefficient transfer to one auditable conjugation identity.
+
+The reduction is sound: under the intertwining, the cross-tensor expansion
+(`regionInsertedCoeff_eq_crossExpansion`) rewrites the first tensor's coefficient as
+the first tensor's region block of the basis change of the second tensor's row
+insertion of `N` of the partial-state row; on the common range the basis change
+reblocks to the second tensor's region block
+(`regionBlockedTensorMap_basisChange_eq_of_mem_range`), and the B-analogue of KEY
+IDENTITY 1 (`blockRealizeOp_regionPartialState_eq_regionInsertedCoeff` at the second
+tensor) reads it back as the second tensor's coefficient of `N`. The interior bond
+products of the two tensors match under `hDim` (`regionInteriorBondProd_congr`). -/
+
+/-- **The cross-tensor coefficient transfer from the intertwining.** If the A↔B basis
+change intertwines the two row insertions for a single matrix `N` — that is, the first
+tensor's row insertion of `M` of the basis change of the second tensor's partial-state
+row equals the basis change of the second tensor's row insertion of `N` of the same
+row — then the first tensor's region-inserted coefficient of `M` equals the second
+tensor's of `N` at every physical configuration. This is the precise reduction of the
+step `V=W` to one conjugation identity for the basis change.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_of_basisChange_intertwine (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hintertwine : ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+      rowInsertF (G := G) A R f M
+          (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ)) =
+        regionBasisChange (G := G) A B R hRA
+          (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ)))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ := by
+  -- The second tensor's row insertion of `N` of the partial-state row, reblocked
+  -- through the second tensor's region block, has range membership for the basis-change
+  -- reblock: it lies in the second tensor's region range, which is the common range.
+  have hmem : regionBlockedTensorMap (G := G) B R
+      (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ)) ∈
+        LinearMap.range (regionBlockedTensorMap (G := G) A R) := by
+    rw [range_regionBlockedTensorMap_eq_of_sameState A B R hAB hCA hCB hposA hposB hDim]
+    exact LinearMap.mem_range_self _ _
+  -- The interior bond multiple of the first tensor's coefficient, as a function of σ,
+  -- through the cross expansion and the intertwining.
+  have hcross : (fun σ' => regionInsertedCoeff (G := G) A R f M σ' τ) =
+      (regionInteriorBondProd (G := G) A R : ℂ) •
+        regionBlockedTensorMap (G := G) B R
+          (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ)) := by
+    rw [regionInsertedCoeff_eq_crossExpansion A B R hRA hRB hAB hposB f M τ, hintertwine τ,
+      regionBlockedTensorMap_basisChange_eq_of_mem_range A B R hRA _ hmem]
+  -- The B-side reading: the second tensor's coefficient of `N`, through the second
+  -- tensor's own block realization, is the interior bond multiple of the same B-block.
+  have hBside : (fun σ' => regionInsertedCoeff (G := G) B R f N σ' τ) =
+      (regionInteriorBondProd (G := G) B R : ℂ) •
+        regionBlockedTensorMap (G := G) B R
+          (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ)) := by
+    rw [← blockRealizeOp_regionPartialState_eq_regionInsertedCoeff (G := G) B R hRB f N τ,
+      map_smul, blockRealizeOp_apply,
+      ← regionBlockedTensorMap_partialStateRowB (G := G) B R hRB hposB τ,
+      regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+  -- Both readings are the same B-block scaled by the matched interior bond products.
+  have hcongr : (regionInteriorBondProd (G := G) A R : ℂ) =
+      (regionInteriorBondProd (G := G) B R : ℂ) := by
+    rw [regionInteriorBondProd_congr A B R hDim]
+  have hfun : (fun σ' => regionInsertedCoeff (G := G) A R f M σ' τ) =
+      (fun σ' => regionInsertedCoeff (G := G) B R f N σ' τ) := by
+    rw [hcross, hBside, hcongr]
+  exact congrFun hfun σ
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/BlockRealization.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRealization.lean
@@ -29,6 +29,30 @@ through one linear operator on the region boundary-configuration coefficients: t
 M-independent **complement weight row** exposes the insertion as a single bond-`f`
 matrix action on the boundary configurations.
 
+## The cross-tensor realization and the residual reduction
+
+* **The block realization operator** `blockRealizeOp` inverts the region block,
+  applies the row insertion, and reblocks. Applied to the interior bond multiple of
+  the partial state across the region cut, it recovers the first tensor's
+  region-inserted coefficient of `M` (`blockRealizeOp_regionPartialState_eq_…`).
+* **The transport** uses that the partial state is `SameState`-invariant, so the
+  first tensor's realization operator reads the coefficient off the *second*
+  tensor's partial state. Expanding that partial state through the second tensor's
+  region block exposes the **A↔B basis change** `regionBasisChange`, giving the
+  cross-tensor expansion `regionInsertedCoeff_eq_crossExpansion`.
+* **The anchor** `regionInsertedCoeff_one_eq_crossExpansion` confirms the basis
+  change is the identity on the second tensor's partial state.
+* **The residual reduction** `isBondLocalTransferKernel_of_basisChange_intertwine`
+  reduces the bond-locality predicate `IsBondLocalTransferKernel`
+  (`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`) to a single **intertwining**
+  identity: the basis change conjugates the first tensor's row insertion of `M` to
+  the second tensor's row insertion of a matrix `N`. This intertwining is the
+  content the three-block reconcile (`threeBlock_reconcile`,
+  `TNLean.PEPS.RegionBlock.ThreeBlockReconcile`) supplies — the basis change
+  preserves the bond-`f`/away-from-`f` decomposition because the away-from-`f`
+  couplings are pinned by the complement injectivity — and is the one remaining open
+  obligation, documented in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
 ## References
 
 - [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled

--- a/TNLean/PEPS/RegionBlock/BlockRealization.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRealization.lean
@@ -1,0 +1,130 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
+
+/-!
+# The block realization operator for the cross-tensor transfer kernel
+
+This file builds the **block realization operator** behind the cross-tensor
+transfer kernel of the normal PEPS Fundamental Theorem (arXiv:1804.04964,
+Section 3, the step `V=W`). It is the block-granularity port of the edge-level
+realization `edgeRightInsertionOp_realizes_edgeTransferMatrix`
+(`TNLean.PEPS.InsertionAlgebra`), replacing the single-vertex insertion operator
+by the blocked region operator that inverts the whole region block instead of one
+vertex.
+
+The transfer kernel `transferCoeff A B R hRB hCB f M`
+(`TNLean.PEPS.RegionBlock.Recovery10`) is the doubly-blocked read-off of the first
+tensor's region-inserted coefficient through the second tensor's region and
+complement blocks. Its bond locality — the residual content `V=W` isolated as the
+predicate `IsBondLocalTransferKernel`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`) — is what closes the per-edge gauge.
+
+## The row-insertion operator
+
+The M-dependence of the first tensor's region-inserted coefficient runs entirely
+through one linear operator on the region boundary-configuration coefficients: the
+**row insertion** `rowInsertF`. It couples the boundary legs on the boundary edge
+`f` through the matrix `M` and contracts the residual legs by the identity
+(`SameAwayFromBond`). Factoring the region row `regionRegionRow`
+(`TNLean.PEPS.RegionBlock.Recovery7`) as `rowInsertF M` applied to the
+M-independent **complement weight row** exposes the insertion as a single bond-`f`
+matrix action on the boundary configurations.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The row-insertion operator
+
+The first tensor's region-inserted coefficient of `M`, read as a function of the
+region physical configuration, is the region blocked tensor map of the region row
+`regionRegionRow A R f M τ` (`regionInsertedCoeff_eq_region_blockedMap`,
+`TNLean.PEPS.RegionBlock.Recovery7`). The region row is, in turn, the **row
+insertion** of `M` applied to the M-independent complement weight row: the M
+dependence is exactly a left multiplication by the incident-matrix coupling on the
+boundary edge `f`. -/
+
+open scoped Classical in
+/-- The **row-insertion operator** of a matrix `M` on the boundary edge `f`: it
+couples the boundary legs `μ f`, `ν f` of two region boundary configurations
+through `M` and contracts the residual legs by the identity (`SameAwayFromBond`).
+This is the M-dependent part of the region row `regionRegionRow`
+(`TNLean.PEPS.RegionBlock.Recovery7`), isolated as a linear endomorphism of the
+boundary-configuration coefficients.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def rowInsertF (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    (RegionBoundaryConfig (G := G) A R → ℂ) →ₗ[ℂ]
+      (RegionBoundaryConfig (G := G) A R → ℂ) where
+  toFun c := fun μ =>
+    ∑ ν : RegionBoundaryConfig (G := G) A R,
+      (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) * c ν
+  map_add' c c' := by
+    funext μ
+    simp only [Pi.add_apply, mul_add, Finset.sum_add_distrib]
+  map_smul' z c := by
+    funext μ
+    simp only [Pi.smul_apply, smul_eq_mul, Finset.mul_sum, RingHom.id_apply]
+    refine Finset.sum_congr rfl (fun ν _ => ?_)
+    ring
+
+open scoped Classical in
+@[simp] theorem rowInsertF_apply (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (c : RegionBoundaryConfig (G := G) A R → ℂ)
+    (μ : RegionBoundaryConfig (G := G) A R) :
+    rowInsertF (G := G) A R f M c μ =
+      ∑ ν : RegionBoundaryConfig (G := G) A R,
+        (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) * c ν := rfl
+
+/-- The **complement weight row**: the M-independent boundary-configuration
+coefficient family the row insertion acts on. At a region boundary configuration
+`ν`, it is the complement blocked weight of the complement boundary configuration
+of `ν` at the complement physical configuration `τ`. This is the part of the
+region row `regionRegionRow` that does not depend on `M`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def regionComplementWeightRow (A : Tensor G d) (R : Finset V)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    RegionBoundaryConfig (G := G) A R → ℂ :=
+  fun ν =>
+    regionBlockedWeight (G := G) A (Finset.univ \ R)
+      (regionComplementBoundaryConfig (G := G) A R ν) τ
+
+open scoped Classical in
+/-- The region row `regionRegionRow` is the row insertion of `M` applied to the
+complement weight row. This isolates the M-dependence of `regionRegionRow`
+(`TNLean.PEPS.RegionBlock.Recovery7`) as a left multiplication by the
+incident-matrix coupling on the boundary edge `f`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionRegionRow_eq_rowInsertF (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionRegionRow (G := G) A R f M τ =
+      rowInsertF (G := G) A R f M (regionComplementWeightRow (G := G) A R τ) := by
+  classical
+  funext μ
+  rw [regionRegionRow, rowInsertF_apply]
+  rfl
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/OpenLegsResonate.lean
+++ b/TNLean/PEPS/RegionBlock/OpenLegsResonate.lean
@@ -264,5 +264,38 @@ theorem isBondLocalTransferKernel_of_transferRowIsRegionRow (A B : Tensor G d)
   (isBondLocalTransferKernel_iff_transferRowIsRegionRow A B R hRA hRB hCA hCB hAB
     hposA hposB hDim f).mpr hrow
 
+/-! ### The transferred-row region-row predicate spelled out as a bond-`f` coupling
+
+The second tensor's region row `regionRegionRow B red f N τ` is the row insertion of
+`N` on the boundary edge `f` of the second tensor's complement weight row
+(`regionRegionRow_eq_rowInsertF`, `TNLean.PEPS.RegionBlock.BlockRealization`): it
+couples the two boundary configurations through their `f`-legs via `N` and contracts
+the residual legs by the identity. So the transferred-row region-row predicate is
+exactly the statement that the transferred row is a bond-`f` coupling of a single
+matrix `N` against the second tensor's complement weight row. -/
+
+/-- **The transferred-row region-row predicate as a bond-`f` coupling.** The
+transferred-row region-row predicate holds if and only if, for every inserted matrix
+`M`, there is a bond matrix `N` whose row insertion on the boundary edge `f` of the
+second tensor's complement weight row is the transferred row, at every complement
+physical leg. This spells out the predicate as the bond-`f` locality of the
+transferred row: it couples the boundary configurations through their `f`-legs only,
+through the single matrix `N`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem transferRowIsRegionRow_iff_rowInsertF (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    TransferRowIsRegionRow (G := G) A B R hRB f ↔
+      ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+          ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+            blockTransferRow A B R hRB f M τ =
+              rowInsertF (G := G) B R f N (regionComplementWeightRow (G := G) B R τ) := by
+  unfold TransferRowIsRegionRow
+  refine forall_congr' (fun M => exists_congr (fun N => forall_congr' (fun τ => ?_)))
+  rw [regionRegionRow_eq_rowInsertF B R f N τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/OpenLegsResonate.lean
+++ b/TNLean/PEPS/RegionBlock/OpenLegsResonate.lean
@@ -1,0 +1,92 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockPhysical
+
+/-!
+# The open-legs reformulation and the constructed bond matrix of the normal PEPS V=W
+
+This file isolates the genuinely cross-tensor content of the general normal PEPS
+Fundamental Theorem per-edge gauge (arXiv:1804.04964, Section 3, Lemma
+`inj_isomorph`, the step `V=W`) at the granularity of the three injective region
+blocks, reformulated on the **all-legs-open** state rather than on closed/partial
+contractions.
+
+The per-edge gauge is reduced, by the landed block-frame foundation, to the
+coefficient transfer for the boundary edge `f` of the shared red region: for every
+inserted matrix `M` on the first tensor's bond there is a matrix `N` on the second
+tensor's bond with `coeff_A M = coeff_B N` at every physical configuration
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`, `bondLocal_iff_coeffTransfer`). This
+file supplies the construction of that `N` and the reduction of the coefficient
+transfer to a single per-leg identity.
+
+## The open-legs reading
+
+The block realization operator `blockRealizeOp A red hRA f M`
+(`TNLean.PEPS.RegionBlock.BlockRealization`) is the tensor-independent physical
+operator on the red block that realizes the first tensor's red-block matrix
+insertion of `M`. Read on the **second tensor's** partial state across the region
+cut — the `SameState`-invariant object — it recovers the first tensor's
+region-inserted coefficient of `M` (`regionInsertedCoeff_eq_threeBlockOpCoeff_B`,
+`TNLean.PEPS.RegionBlock.ThreeBlockPhysical`). This is the open-legs transport: the
+realization operator built from the first tensor acts on the second tensor's column.
+
+## The constructed bond matrix
+
+The second tensor's region block is injective, so the first tensor's coefficient of
+`M`, read as a function of the region physical leg, is the second tensor's region
+blocked tensor map of a boundary-configuration row `blockTransferRow A B red f M τ`
+(`regionInsertedCoeff_eq_blockTransferRow`,
+`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`). The coefficient transfer is therefore
+equivalent to that transferred row being the second tensor's own region row
+`regionRegionRow B red f N τ` of a single bond matrix `N` on `f`, at every complement
+physical leg. This is the bond-level content of the step `V=W`, isolated here as a
+single per-leg identity of the transferred row.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, the step `V=W`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Target 1--3: the open-legs reading of the first tensor's coefficient
+
+The block realization operator built from the first tensor `A`, read on the second
+tensor's partial state across the region cut, recovers the first tensor's
+region-inserted coefficient of `M`. This is the landed transport
+`regionInsertedCoeff_eq_threeBlockOpCoeff_B` (Targets 2--3 of
+`TNLean.PEPS.RegionBlock.ThreeBlockPhysical`) restated as an identity of the
+open-legs coefficient function. The single cross-tensor step is the `SameState`
+invariance of the partial state; everything else is single-tensor block mechanics. -/
+
+/-- **The open-legs reading of the first tensor's coefficient.** The first tensor's
+region-inserted coefficient of `M`, read as a function of the region physical leg, is
+the first tensor's block realization operator of `M` applied to the interior-bond
+multiple of the **second** tensor's partial state across the region cut. This is the
+open-legs transport: the realization operator built from `A` reads `A`'s coefficient
+off `B`'s `SameState`-invariant column.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:resonate`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_blockRealizeOp_regionPartialState_B (A B : Tensor G d)
+    (R : Finset V) (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    (fun σ : RegionPhysicalConfig (V := V) (d := d) R =>
+        regionInsertedCoeff (G := G) A R f M σ τ) =
+      blockRealizeOp (G := G) A R hRA f M
+        ((regionInteriorBondProd (G := G) B R : ℂ) • regionPartialState (G := G) B R τ) := by
+  rw [← regionInteriorBondProd_congr A B R hDim,
+    blockRealizeOp_regionPartialState_B_eq_regionInsertedCoeff A B R hRA hAB f M τ]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/OpenLegsResonate.lean
+++ b/TNLean/PEPS/RegionBlock/OpenLegsResonate.lean
@@ -1,5 +1,6 @@
 import TNLean.PEPS.RegionBlock.ThreeBlockPhysical
 import TNLean.PEPS.RegionBlock.BlockCoeffTransfer
+import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
 
 /-!
 # The open-legs reformulation and the constructed bond matrix of the normal PEPS V=W
@@ -148,6 +149,120 @@ theorem coeffTransfer_iff_blockTransferRow_eq_regionRegionRow (A B : Tensor G d)
     intro hrow σ τ
     rw [regionInsertedCoeff_eq_blockTransferRow A B R hRB hCA hCB hAB hposA hposB hDim f M σ τ,
       hrow τ, ← regionInsertedCoeff_eq_region_blockedMap B R f N σ τ]
+
+/-! ### The transferred-row region-row predicate
+
+The single residual open fact of the general normal PEPS per-edge gauge, isolated as
+a per-leg identity of the transferred row. The predicate asserts that for every
+inserted matrix `M` on the boundary edge `f` of the red region there is a bond matrix
+`N` on the second tensor whose region row `regionRegionRow B red f N τ` is the
+transferred row `blockTransferRow A B red f M τ` at every complement physical leg.
+
+By `coeffTransfer_iff_blockTransferRow_eq_regionRegionRow` this predicate is exactly
+the coefficient transfer, hence (`bondLocal_iff_coeffTransfer`,
+`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`) the bond locality of the transfer
+kernel. The region row `regionRegionRow B red f N τ` is the incident-matrix coupling
+of `N` on the bond legs against the second tensor's complement weights
+(`regionRegionRow_eq_rowInsertF`,
+`TNLean.PEPS.RegionBlock.BlockRealization`), so the predicate is the bond-level
+content of the source step `V=W`: the cross-tensor transferred row couples through the
+boundary bond `f` only. -/
+
+/-- **The transferred-row region-row predicate.** For every inserted matrix `M` on the
+boundary edge `f`, there is a bond matrix `N` on the second tensor whose region row
+`regionRegionRow B red f N` is the transferred row `blockTransferRow A B red f M` at
+every complement physical leg.
+
+This is the open-legs form of the block step `V=W`: the second tensor's region left
+inverse of the first tensor's `M`-coefficient is the second tensor's own region row of
+a single bond matrix `N`, i.e. couples through the bond `f` only. -/
+def TransferRowIsRegionRow (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) : Prop :=
+  ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+    ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+        blockTransferRow A B R hRB f M τ = regionRegionRow (G := G) B R f N τ
+
+/-- **The transferred-row region-row predicate gives the coefficient transfer.** If
+every transferred row is the second tensor's region row of some bond matrix `N`, then
+for every inserted matrix `M` there is a bond matrix `N` whose region-inserted
+coefficient matches the first tensor's of `M` at every physical configuration. This
+unpacks `TransferRowIsRegionRow` through
+`coeffTransfer_iff_blockTransferRow_eq_regionRegionRow`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_of_transferRowIsRegionRow (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hrow : TransferRowIsRegionRow (G := G) A B R hRB f) :
+    ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ := by
+  intro M
+  obtain ⟨N, hN⟩ := hrow M
+  exact ⟨N, (coeffTransfer_iff_blockTransferRow_eq_regionRegionRow A B R hRB hCA hCB hAB
+    hposA hposB hDim f M N).mpr hN⟩
+
+/-- **Bond locality is the transferred-row region-row predicate.** The transfer kernel
+of every inserted matrix on the boundary edge `f` is bond-local
+(`IsBondLocalTransferKernel`) if and only if every transferred row is the second
+tensor's region row of some bond matrix `N`. Both directions are
+`coeffTransfer_iff_blockTransferRow_eq_regionRegionRow` quantified over `M`, against the
+bond-locality–coefficient-transfer equivalence `bondLocal_iff_coeffTransfer`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`).
+
+This restates the single residual open fact of the per-edge gauge as the geometric
+per-leg identity of the transferred row.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem isBondLocalTransferKernel_iff_transferRowIsRegionRow (A B : Tensor G d)
+    (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    IsBondLocalTransferKernel (G := G) A B R hRB hCB f ↔
+      TransferRowIsRegionRow (G := G) A B R hRB f := by
+  rw [bondLocal_iff_coeffTransfer A B R hRA hRB hCA hCB hAB hposA hposB hDim f]
+  refine forall_congr' (fun M => exists_congr (fun N => ?_))
+  exact coeffTransfer_iff_blockTransferRow_eq_regionRegionRow A B R hRB hCA hCB hAB
+    hposA hposB hDim f M N
+
+/-- **Bond locality from the transferred-row region-row predicate.** If every
+transferred row is the second tensor's region row of some bond matrix, then the
+transfer kernel is bond-local (`IsBondLocalTransferKernel`). This is the forward
+read-off of `isBondLocalTransferKernel_iff_transferRowIsRegionRow`, the form the
+per-edge gauge `SharedNormalEdgeBlockingData.exists_regionEdgeGauge`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`) consumes.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem isBondLocalTransferKernel_of_transferRowIsRegionRow (A B : Tensor G d)
+    (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hrow : TransferRowIsRegionRow (G := G) A B R hRB f) :
+    IsBondLocalTransferKernel (G := G) A B R hRB hCB f :=
+  (isBondLocalTransferKernel_iff_transferRowIsRegionRow A B R hRA hRB hCA hCB hAB
+    hposA hposB hDim f).mpr hrow
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/OpenLegsResonate.lean
+++ b/TNLean/PEPS/RegionBlock/OpenLegsResonate.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.RegionBlock.ThreeBlockPhysical
+import TNLean.PEPS.RegionBlock.BlockCoeffTransfer
 
 /-!
 # The open-legs reformulation and the constructed bond matrix of the normal PEPS V=W
@@ -87,6 +88,66 @@ theorem regionInsertedCoeff_eq_blockRealizeOp_regionPartialState_B (A B : Tensor
         ((regionInteriorBondProd (G := G) B R : ℂ) • regionPartialState (G := G) B R τ) := by
   rw [← regionInteriorBondProd_congr A B R hDim,
     blockRealizeOp_regionPartialState_B_eq_regionInsertedCoeff A B R hRA hAB f M τ]
+
+/-! ### Target 4: the coefficient transfer is the transferred row being a region row
+
+The first tensor's region-inserted coefficient of `M`, read as a function of the
+region physical leg, is the second tensor's region blocked tensor map of the
+transferred row `blockTransferRow A B red f M τ` (the second tensor's region left
+inverse of that coefficient, `regionInsertedCoeff_eq_blockTransferRow`,
+`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`). The second tensor's coefficient of a
+bond matrix `N` factors through the **same** injective region block, of the region
+row `regionRegionRow B red f N τ`. So the coefficient transfer `coeff_A M = coeff_B N`
+is equivalent to the transferred row coinciding with the second tensor's region row of
+`N` at every complement leg. This isolates the cross-tensor content as a single
+per-leg identity of the transferred row, with the bond matrix `N` carried directly. -/
+
+/-- **The coefficient transfer is the transferred row being a region row.** For a bond
+matrix `N`, the first tensor's region-inserted coefficient of `M` equals the second
+tensor's of `N` at every physical configuration if and only if the transferred row
+`blockTransferRow A B red f M τ` is the second tensor's region row
+`regionRegionRow B red f N τ` at every complement physical leg.
+
+Both coefficients factor through the second tensor's injective region blocked tensor
+map (`hRB`): the first tensor's of `M` of the transferred row by
+`regionInsertedCoeff_eq_blockTransferRow`, the second tensor's of `N` of the region
+row by `regionInsertedCoeff_eq_region_blockedMap`. The forward direction descends the
+coefficient equality through the injective block; the backward direction reblocks the
+row equality. This presents the coefficient transfer as the single per-leg identity of
+the transferred row — the bond-level content of the step `V=W`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_iff_blockTransferRow_eq_regionRegionRow (A B : Tensor G d)
+    (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    (∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f N σ τ) ↔
+      ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+        blockTransferRow A B R hRB f M τ = regionRegionRow (G := G) B R f N τ := by
+  constructor
+  · -- Forward: equal coefficients descend through the injective region block to equal rows.
+    intro hcoeff τ
+    have hblock : regionBlockedTensorMap (G := G) B R (blockTransferRow A B R hRB f M τ) =
+        regionBlockedTensorMap (G := G) B R (regionRegionRow (G := G) B R f N τ) := by
+      funext σ
+      rw [← regionInsertedCoeff_eq_blockTransferRow A B R hRB hCA hCB hAB hposA hposB hDim f M σ τ,
+        ← regionInsertedCoeff_eq_region_blockedMap B R f N σ τ]
+      exact hcoeff σ τ
+    exact regionBlockedTensorMap_injective_of_injective (G := G) B R hRB hblock
+  · -- Backward: equal rows reblock to equal coefficients.
+    intro hrow σ τ
+    rw [regionInsertedCoeff_eq_blockTransferRow A B R hRB hCA hCB hAB hposA hposB hDim f M σ τ,
+      hrow τ, ← regionInsertedCoeff_eq_region_blockedMap B R f N σ τ]
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/RegionReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/RegionReconcile.lean
@@ -1,0 +1,387 @@
+import TNLean.PEPS.RegionBlock.Recovery11
+
+/-!
+# Region physical-to-virtual recovery: the block-endpoint inversion (region-injective)
+
+This file ports the block-endpoint inversion of the region resonate step to the
+**region-injective** regime, with the blocked-region left inverses of `R` and of
+its set complement `univ \ R` as the two inversion tools, and *without* assuming
+single-vertex injectivity `IsVertexInjective`. It is the region-granularity port
+of `resonate_invert_right_endpoint` (`TNLean.PEPS.InsertionRealization`) and the
+first half of the open obligation of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+The contributions here are non-circular and use only blocked-region injectivity:
+
+* `regionComplementRow_eq_regionInsertionOp` reads the explicit complement row of a
+  second-tensor matrix `N` as the second tensor's own in-region endpoint operator of
+  `N.transpose` against the second tensor's region weight vectors at the endpoint
+  leg. This is `region_innerSum_eq_realized` (`TNLean.PEPS.RegionBlock.Recovery2`)
+  packaged for the complement row of `TNLean.PEPS.RegionBlock.Recovery7`.
+
+* `coeffTransfer_of_endpointOp_eq` reduces the **coefficient transfer** (matching the
+  region-inserted coefficients of `A` and `B`) to the agreement of the two in-region
+  endpoint operators on the second tensor's region weight vectors at the endpoint
+  leg. The reduction inverts the complement block through the blocked-region left
+  inverse `regionBlockedLeftInverse B (univ \ R) hCB` and is exactly the
+  block-granularity form of inverting the second tensor's complement away from the
+  in-region endpoint. It uses no single-vertex spanning.
+
+These are the region-injective replacements for the steps that
+`TNLean.PEPS.RegionBlock.Recovery9`/`Recovery10`/`Recovery11` performed with the
+single-vertex realization (which needs `IsVertexInjective` through the spanning
+`span_stateOpenCoeff_eq_top`).
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The complement row as an in-region endpoint operator
+
+The explicit complement row `regionComplementRow B R f N σ` of the second tensor
+(`TNLean.PEPS.RegionBlock.Recovery7`) is, at the complement boundary configuration
+`w`, the incident-matrix sum of `N` against the second tensor's region blocked
+weights. The inner-sum realization `region_innerSum_eq_realized`
+(`TNLean.PEPS.RegionBlock.Recovery2`) reads that sum as the second tensor's *own*
+in-region endpoint operator of `N.transpose`, applied to the second tensor's region
+weight vector at the reindexed boundary configuration, evaluated at the endpoint
+leg. This is the second-tensor counterpart of the v-side row `vSideRow`
+(`TNLean.PEPS.RegionBlock.Recovery10`), which reads the *first* tensor's operator on
+the same weight vectors; matching the two rows is the coefficient transfer. -/
+
+/-- **The complement row as the second tensor's in-region endpoint operator.** At a
+complement boundary configuration `w` of `univ \ R`, the explicit complement row of
+the matrix `N` on the second tensor equals the second tensor's in-region endpoint
+operator from `N.transpose`, applied to the second tensor's region weight vector at
+the reindexed boundary configuration, evaluated at the endpoint physical leg `σ v`.
+
+This is `region_innerSum_eq_realized` (`TNLean.PEPS.RegionBlock.Recovery2`)
+specialized to the second tensor with the boundary configuration
+`(regionComplementBoundaryConfigEquiv B R).symm w`. It exposes the complement row of
+`regionComplementRow` (`TNLean.PEPS.RegionBlock.Recovery7`) in the same form as the
+v-side row `vSideRow` (`TNLean.PEPS.RegionBlock.Recovery10`), so the coefficient
+transfer becomes the agreement of the two operators on the same weight vectors.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionComplementRow_eq_regionInsertionOp (B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (w : RegionBoundaryConfig (G := G) B (Finset.univ \ R)) :
+    regionComplementRow (G := G) B R f N σ w =
+      regionInsertionOp (G := G) B R f hvB N.transpose
+          (regionWeightVec (G := G) B R f
+            ((regionComplementBoundaryConfigEquiv (G := G) B R).symm w) σ)
+        (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+          regionBoundaryEdgeInVertex_mem (G := G) R f⟩) := by
+  classical
+  rw [regionComplementRow]
+  exact region_innerSum_eq_realized B R f hvB N
+    ((regionComplementBoundaryConfigEquiv (G := G) B R).symm w) σ
+
+/-! ### The coefficient transfer from agreement of the two endpoint operators
+
+The v-side factorization `regionInsertedCoeff_eq_complement_blockedMap_vSideRow`
+(`TNLean.PEPS.RegionBlock.Recovery10`) writes the first tensor's region-inserted
+coefficient of `M`, as a function of the complement physical configuration, as the
+second tensor's complement blocked tensor map of the v-side row `vSideRow`. The
+B-side factorization `regionInsertedCoeff_eq_complement_blockedMap`
+(`TNLean.PEPS.RegionBlock.Recovery7`) does the same for the second tensor's
+region-inserted coefficient of `N`, with row the explicit complement row
+`regionComplementRow B R f N σ`. Both factor through the *same* injective complement
+blocked tensor map (`hCB`), so the coefficient transfer is equivalent to matching
+the two rows at every region physical configuration. By
+`regionComplementRow_eq_regionInsertionOp` and the definition of `vSideRow`, the two
+rows agree exactly when the first tensor's in-region endpoint operator (from
+`M.transpose`) and the second tensor's (from `N.transpose`) agree on the second
+tensor's region weight vectors at the endpoint leg. This is the block-granularity
+inversion of the complement away from the in-region endpoint, the region port of
+`resonate_invert_right_endpoint`; it uses no single-vertex spanning. -/
+
+/-- **The coefficient transfer from endpoint-operator agreement.** If the first
+tensor's in-region endpoint operator from `M.transpose` and the second tensor's from
+`N.transpose` agree, at the endpoint physical leg, on the second tensor's region
+weight vectors at every reindexed complement boundary configuration and region
+physical configuration, then the region-inserted coefficient of `M` in the first
+tensor equals that of `N` in the second at every physical configuration.
+
+The two rows of the (shared) injective complement blocked tensor map are the v-side
+row `vSideRow A B R f hvA M σ` (the first tensor's operator on the weight vectors)
+and the explicit complement row `regionComplementRow B R f N σ` (read by
+`regionComplementRow_eq_regionInsertionOp` as the second tensor's operator on the
+same weight vectors). The hypothesis matches them, so `hCB` injectivity forces the
+coefficients equal through `regionInsertedCoeff_eq_of_complementRow_eq`
+(`TNLean.PEPS.RegionBlock.Recovery10`). The argument is region-injective: it inverts
+only the second tensor's complement block, never the single vertex `v`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_of_endpointOp_eq (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hop : ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (ν : RegionBoundaryConfig (G := G) B R),
+      regionInsertionOp (G := G) A R f hvA M.transpose
+          (regionWeightVec (G := G) B R f ν σ)
+          (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+            regionBoundaryEdgeInVertex_mem (G := G) R f⟩) =
+        regionInsertionOp (G := G) B R f hvB N.transpose
+          (regionWeightVec (G := G) B R f ν σ)
+          (σ ⟨regionBoundaryEdgeInVertex (G := G) R f,
+            regionBoundaryEdgeInVertex_mem (G := G) R f⟩))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ := by
+  refine regionInsertedCoeff_eq_of_complementRow_eq A B R f hvA hAB hDim M N (fun σ' => ?_) σ τ
+  funext w
+  rw [vSideRow, regionComplementRow_eq_regionInsertionOp B R f hvB N σ' w]
+  exact hop σ' ((regionComplementBoundaryConfigEquiv (G := G) B R).symm w)
+
+/-! ### The symmetric reduction: coefficient transfer through the region block
+
+The σ-side mirror of `regionInsertedCoeff_eq_of_complementRow_eq`
+(`TNLean.PEPS.RegionBlock.Recovery10`). Fixing the complement physical
+configuration `τ`, the first tensor's region-inserted coefficient of `M` factors, as
+a function of the region physical configuration `σ`, through the second tensor's
+region blocked tensor map with row `complSideRow A B R f hvAout M τ`
+(`regionInsertedCoeff_eq_region_blockedMap_B`, `Recovery10`); the second tensor's
+region-inserted coefficient of `N` factors through the *same* map with the explicit
+region row `regionRegionRow B R f N τ` (`regionInsertedCoeff_eq_region_blockedMap`,
+`Recovery7`). Region-block injectivity (`hRB`) forces the coefficients equal when the
+two rows agree. This is the σ-side inversion, the region port of
+`resonate_invert_left_endpoint`. -/
+
+/-- **Coefficient transfer through the region block.** If the σ-side row
+`complSideRow A B R f hvAout M τ` of the first tensor agrees with the explicit region
+row `regionRegionRow B R f N τ` of the second tensor at every complement physical
+configuration `τ`, then the region-inserted coefficient of `M` in the first tensor
+equals that of `N` in the second at every physical configuration.
+
+Both rows are rows of the same injective region blocked tensor map of `B` (`hRB`):
+the first tensor's coefficient is its map of `complSideRow` by
+`regionInsertedCoeff_eq_region_blockedMap_B` (`Recovery10`), the second tensor's of
+`regionRegionRow` by `regionInsertedCoeff_eq_region_blockedMap` (`Recovery7`). This
+is the σ-side mirror of `regionInsertedCoeff_eq_of_complementRow_eq`; it inverts only
+the second tensor's region block.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_of_regionRow_eq (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hrow : ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+      complSideRow (G := G) A B R f hvAout M τ = regionRegionRow (G := G) B R f N τ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ := by
+  have hA := congrFun
+    (regionInsertedCoeff_eq_region_blockedMap_B A B R f hvAout hAB hDim M τ) σ
+  rw [hA, hrow τ, ← regionInsertedCoeff_eq_region_blockedMap B R f N σ τ]
+
+/-! ### The region insertion transfer datum from a region-injective coefficient transfer
+
+The block-level injectivity `regionInsertedCoeff_injective`
+(`TNLean.PEPS.RegionBlock.Algebra`) is unconditional on blocked-region injectivity.
+It lets the per-edge matrix transfer maps be chosen directly from a coefficient
+transfer — for each inserted matrix a matching matrix on the other tensor — with the
+coefficient-matching fields holding by the choice and the unital field by the
+`SameState` identity insertion `regionInsertedCoeff_one_eq_stateCoeff`
+(`TNLean.PEPS.RegionBlock.Recovery`). The only remaining input is multiplicativity of
+the chosen forward transfer, which the source supplies by the homomorphism property
+of the physical realization. Isolating it as a hypothesis assembles the
+`RegionInsertionTransfer` datum region-injectively: feeding it to
+`exists_regionEdgeGauge_of_transfer` (`TNLean.PEPS.RegionBlock.Algebra`) reads off the
+per-edge gauge with no single-vertex injectivity. -/
+
+/-- A chosen forward per-edge matrix transfer from a coefficient transfer: for each
+inserted matrix `M` on the first tensor, a matrix on the second tensor whose
+region-inserted coefficient matches. The matching is the defining property
+`coeffTransferMap_coeff`. -/
+noncomputable def coeffTransferMap (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (htransfer : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ :=
+  (htransfer M).choose
+
+/-- The chosen forward transfer matches the region-inserted coefficients. -/
+theorem coeffTransferMap_coeff (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (htransfer : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) B R f (coeffTransferMap (G := G) A B R f htransfer M) σ τ :=
+  (htransfer M).choose_spec σ τ
+
+/-- The chosen forward transfer is unital, by the `SameState` identity insertion. The
+region-inserted coefficient of the identity is the interior bond product times the
+closed-state coefficient (`regionInsertedCoeff_one_eq_stateCoeff`), matched across the
+two tensors by `SameState` and equal bond dimensions. Block injectivity of the second
+tensor then forces the chosen transfer of `1` to be `1`. -/
+theorem coeffTransferMap_one (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (htransfer : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ) :
+    coeffTransferMap (G := G) A B R f htransfer 1 = 1 := by
+  refine regionInsertedCoeff_injective (G := G) B R hRB hCB hposB f _ 1 (fun σ τ => ?_)
+  rw [← coeffTransferMap_coeff A B R f htransfer 1 σ τ,
+    regionInsertedCoeff_one_eq_stateCoeff (G := G) A R f σ τ,
+    regionInsertedCoeff_one_eq_stateCoeff (G := G) B R f σ τ,
+    regionInteriorBondProd_congr A B R hDim, hAB _]
+
+/-- **Region insertion transfer datum from a region-injective coefficient transfer.**
+Given coefficient transfers in both directions (for each inserted matrix on one
+tensor a matching matrix on the other), matched bond dimensions, `SameState`,
+positive bond dimensions, region/complement blocked injectivity of both tensors, and
+multiplicativity of the chosen forward transfer, the per-edge matrix transfer maps
+assemble into a `RegionInsertionTransfer` datum.
+
+The forward and backward maps are chosen by `coeffTransferMap`; their
+coefficient-matching fields are `coeffTransferMap_coeff`; the unital field is
+`coeffTransferMap_one`; the multiplicative field is the hypothesis `hmul`. All other
+content is `regionInsertedCoeff_injective`, which is unconditional on blocked-region
+injectivity. The datum feeds `exists_regionEdgeGauge_of_transfer`
+(`TNLean.PEPS.RegionBlock.Algebra`) to read off the per-edge gauge with no
+single-vertex injectivity.
+
+**Scope (multiplicativity hypothesis):** the forward-transfer multiplicativity `hmul`
+is the only field not yet derived region-injectively. The source derives it from the
+homomorphism property of the physical realization
+(`Papers/1804.04964/paper_normal.tex`, eq. `X->O`), whose region port reads the
+recovered matrix off the single-vertex virtual pullback and so currently needs the
+in-region endpoint spanning. The block-endpoint inversions above
+(`coeffTransfer_of_endpointOp_eq`, `regionInsertedCoeff_eq_of_regionRow_eq`) supply
+the coefficient transfers `htransferAB`/`htransferBA`; the residual single-vertex
+read-off is documented in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def regionInsertionTransfer_of_coeffTransfer (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (htransferBA : ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      ∃ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) B R f N σ τ =
+            regionInsertedCoeff (G := G) A R f M σ τ)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B R f htransferAB (M * M') =
+        coeffTransferMap (G := G) A B R f htransferAB M *
+          coeffTransferMap (G := G) A B R f htransferAB M') :
+    RegionInsertionTransfer (G := G) A B R f where
+  fwd M := coeffTransferMap (G := G) A B R f htransferAB M
+  bwd N := coeffTransferMap (G := G) B A R f htransferBA N
+  fwd_coeff M σ τ := coeffTransferMap_coeff A B R f htransferAB M σ τ
+  bwd_coeff N σ τ := coeffTransferMap_coeff B A R f htransferBA N σ τ
+  fwd_mul M M' := hmul M M'
+  fwd_one := coeffTransferMap_one A B R f hRB hCB hAB hposB hDim htransferAB
+
+/-- **Per-edge gauge from a region-injective coefficient transfer.** Given coefficient
+transfers in both directions with a multiplicative forward choice, region/complement
+blocked injectivity of both tensors, positive bond dimensions, `SameState`, and
+matched bond dimensions, the chosen forward per-edge matrix transfer on the boundary
+edge `f` is conjugation by an invertible gauge matrix `Z`, and the two bond
+dimensions on `f` coincide. No single-vertex injectivity is used: the datum is
+`regionInsertionTransfer_of_coeffTransfer` and the read-off is
+`exists_regionEdgeGauge_of_transfer` (`TNLean.PEPS.RegionBlock.Algebra`).
+
+**Scope (multiplicativity hypothesis):** see
+`regionInsertionTransfer_of_coeffTransfer`.
+
+Source: arXiv:1804.04964, Section 3, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_of_coeffTransfer (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (htransferBA : ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      ∃ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) B R f N σ τ =
+            regionInsertedCoeff (G := G) A R f M σ τ)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B R f htransferAB (M * M') =
+        coeffTransferMap (G := G) A B R f htransferAB M *
+          coeffTransferMap (G := G) A B R f htransferAB M') :
+    ∃ hEdge : A.bondDim f.1 = B.bondDim f.1,
+      ∃ Z : GL (Fin (B.bondDim f.1)) ℂ,
+        ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+          (regionInsertionTransfer_of_coeffTransfer A B R f hRB hCB hAB hposB hDim
+              htransferAB htransferBA hmul).fwd M =
+            (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim f.1)) ℂ) :
+                Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :=
+  exists_regionEdgeGauge_of_transfer A B R f
+    (regionInsertionTransfer_of_coeffTransfer A B R f hRB hCB hAB hposB hDim
+      htransferAB htransferBA hmul)
+    hRA hCA hposA hRB hCB hposB
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort.lean
@@ -1,0 +1,147 @@
+import TNLean.PEPS.RegionBlock.OpenLegsResonate
+
+/-!
+# Block-granularity port of the edge resonate engine
+
+This file ports the **edge resonate engine** of `TNLean.PEPS.InsertionRealization`
+(the construction `physical_to_virtual_insertion`, lines 501--963) to the
+granularity of the three injective region blocks, closing the residual open fact of
+the general normal PEPS Fundamental Theorem per-edge gauge (arXiv:1804.04964,
+Section 3, Lemma `inj_isomorph`, the step `V=W`).
+
+The block-frame foundation (`TNLean.PEPS.RegionBlock.OpenLegsResonate`,
+`TNLean.PEPS.RegionBlock.BasisChangeIntertwine`) has reduced the predicate
+`TransferRowIsRegionRow` — equivalently `IsBondLocalTransferKernel`, equivalently the
+basis-change intertwining — to the single **coefficient transfer**: for every
+inserted matrix `M` on the boundary edge `f` of the red region there is a matrix `N`
+on the second tensor's bond with `regionInsertedCoeff A R f M = regionInsertedCoeff
+B R f N` at every physical configuration. Every reformulation is an unconditional
+repackaging of this one fact.
+
+This file supplies the port that produces that `N`. The mapping from the edge engine
+to the block frame is:
+
+* the two endpoints of the chosen edge map to the **red region** `R` and its **host**
+  `univ \ R` (the two blocked endpoints of the single boundary edge `f`);
+* the residual local configuration on an endpoint maps to the boundary configuration
+  away from the `f`-leg (the **residual boundary configuration**);
+* the per-vertex left inverse `localLeftInverseAt` maps to the **region blocked left
+  inverse** `regionBlockedLeftInverse` (`TNLean.PEPS.RegionBlock.Recovery5`);
+* the row insertion of `M` on the bond maps to `rowInsertF`
+  (`TNLean.PEPS.RegionBlock.BlockRealization`).
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, the step `V=W`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The `f`-leg split of a region boundary configuration
+
+A region boundary configuration `μ : RegionBoundaryConfig A R` assigns a virtual
+index to every edge crossing the boundary of `R`. Splitting off the distinguished
+boundary edge `f` leaves the **residual boundary configuration**: the assignment on
+the remaining boundary edges. This is the block-frame analogue of the edge engine's
+`localVirtualConfigSplitAt` (`TNLean.PEPS.VirtualInsertion`), which splits a local
+virtual configuration into the coordinate on one distinguished incident edge and the
+coordinates on the rest.
+
+Two boundary configurations agree away from `f` (`SameAwayFromBond f μ ν`) exactly
+when their residual boundary configurations coincide, so the residual configuration
+is the natural index for the residual-independence the resonate inversion supplies. -/
+
+/-- The **residual boundary configuration** of `R` at the boundary edge `f`: an
+assignment of virtual indices to every boundary edge of `R` other than `f`. This is
+the boundary-configuration analogue of the edge engine's residual local
+configuration `ResidualLocalConfig` (`TNLean.PEPS.VirtualInsertion`), which assigns
+indices to the incident edges other than the distinguished one. -/
+abbrev RegionResidualBoundaryConfig (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) : Type _ :=
+  (g : {g : {g : Edge G // IsRegionBoundaryEdge (G := G) R g} // g ≠ f}) →
+    Fin (A.bondDim g.1.1)
+
+instance instFintypeRegionResidualBoundaryConfig (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    Fintype (RegionResidualBoundaryConfig (G := G) A R f) :=
+  inferInstance
+
+/-- **The `f`-leg split of a region boundary configuration.** A region boundary
+configuration corresponds to its index on the distinguished boundary edge `f`
+together with its residual boundary configuration on the remaining boundary edges.
+This is the block-frame port of `localVirtualConfigSplitAt`
+(`TNLean.PEPS.VirtualInsertion`, line 73). -/
+noncomputable def regionBoundaryConfigSplitAt (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    RegionBoundaryConfig (G := G) A R ≃
+      Fin (A.bondDim f.1) × RegionResidualBoundaryConfig (G := G) A R f := by
+  classical
+  exact Equiv.piSplitAt f (fun g => Fin (A.bondDim g.1))
+
+omit [Fintype V] in
+@[simp] theorem regionBoundaryConfigSplitAt_apply_fst (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (μ : RegionBoundaryConfig (G := G) A R) :
+    (regionBoundaryConfigSplitAt (G := G) A R f μ).1 = μ f := by
+  classical
+  simp [regionBoundaryConfigSplitAt]
+
+omit [Fintype V] in
+@[simp] theorem regionBoundaryConfigSplitAt_apply_snd (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (μ : RegionBoundaryConfig (G := G) A R)
+    (g : {g : {g : Edge G // IsRegionBoundaryEdge (G := G) R g} // g ≠ f}) :
+    (regionBoundaryConfigSplitAt (G := G) A R f μ).2 g = μ g.1 := by
+  classical
+  simp [regionBoundaryConfigSplitAt]
+
+omit [Fintype V] in
+@[simp] theorem regionBoundaryConfigSplitAt_symm_apply_self (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (x : Fin (A.bondDim f.1) × RegionResidualBoundaryConfig (G := G) A R f) :
+    (regionBoundaryConfigSplitAt (G := G) A R f).symm x f = x.1 := by
+  classical
+  simp [regionBoundaryConfigSplitAt]
+
+omit [Fintype V] in
+@[simp] theorem regionBoundaryConfigSplitAt_symm_apply_other (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (x : Fin (A.bondDim f.1) × RegionResidualBoundaryConfig (G := G) A R f)
+    (g : {g : {g : Edge G // IsRegionBoundaryEdge (G := G) R g} // g ≠ f}) :
+    (regionBoundaryConfigSplitAt (G := G) A R f).symm x g.1 = x.2 g := by
+  classical
+  simp [regionBoundaryConfigSplitAt, g.2]
+
+omit [Fintype V] in
+/-- **The `f`-leg split characterizes `SameAwayFromBond`.** Two region boundary
+configurations agree away from the boundary edge `f` exactly when their residual
+boundary configurations — the second components of the `f`-leg split — coincide.
+This is the block-frame port of the edge engine's identification of the residual
+local configuration with the agreement away from the distinguished incident edge. -/
+theorem sameAwayFromBond_iff_split_snd_eq (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (μ ν : RegionBoundaryConfig (G := G) A R) :
+    SameAwayFromBond f μ ν ↔
+      (regionBoundaryConfigSplitAt (G := G) A R f μ).2 =
+        (regionBoundaryConfigSplitAt (G := G) A R f ν).2 := by
+  classical
+  constructor
+  · intro h
+    funext g
+    rw [regionBoundaryConfigSplitAt_apply_snd, regionBoundaryConfigSplitAt_apply_snd]
+    exact h g.1 g.2
+  · intro h g hg
+    have := congrFun h ⟨g, hg⟩
+    rwa [regionBoundaryConfigSplitAt_apply_snd, regionBoundaryConfigSplitAt_apply_snd] at this
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort.lean
@@ -143,5 +143,67 @@ theorem sameAwayFromBond_iff_split_snd_eq (A : Tensor G d) (R : Finset V)
     have := congrFun h ⟨g, hg⟩
     rwa [regionBoundaryConfigSplitAt_apply_snd, regionBoundaryConfigSplitAt_apply_snd] at this
 
+/-! ### The `f`-leg reading of the region row
+
+The first tensor's own region row `regionRegionRow A R f M τ` is, by construction, the
+row insertion of `M` on the boundary edge `f` of the complement weight row
+(`regionRegionRow_eq_rowInsertF`, `TNLean.PEPS.RegionBlock.BlockRealization`): it
+couples the boundary configurations only through their `f`-legs, through the single
+matrix `M`. Read through the `f`-leg split, the region row at a boundary configuration
+`μ` depends on `μ` only through its `f`-leg `μ f` and its residual boundary
+configuration, with `M` coupling the `f`-leg. This is the block-frame port of the
+edge engine's residual factoring of the boundary contraction. -/
+
+open scoped Classical in
+/-- **The region row through the `f`-leg split.** The first tensor's region row at a
+boundary configuration `μ`, written through the `f`-leg split, is the sum over bond
+indices `b` on `f` of `M (μ f) b` against the complement weight row of the boundary
+configuration with `f`-leg `b` and the residual of `μ`. This exposes the region row's
+`f`-locality: `μ` enters only through its `f`-leg and its residual boundary
+configuration.
+
+This is the block-frame port of the edge engine's residual reading of the boundary
+contraction (`edgeLeftLocalConfig`/`edgeRightLocalConfig` against the residual), with
+the single distinguished incident edge `f` and the residual boundary configuration in
+place of the residual local configuration.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionRegionRow_split (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R))
+    (μ : RegionBoundaryConfig (G := G) A R) :
+    regionRegionRow (G := G) A R f M τ μ =
+      ∑ b : Fin (A.bondDim f.1),
+        M (μ f) b *
+          regionComplementWeightRow (G := G) A R τ
+            ((regionBoundaryConfigSplitAt (G := G) A R f).symm
+              (b, (regionBoundaryConfigSplitAt (G := G) A R f μ).2)) := by
+  classical
+  rw [regionRegionRow_eq_rowInsertF, rowInsertF_apply]
+  -- Reindex the `ν`-sum by the `f`-leg split: `ν ↔ (ν f, residual ν)`.
+  rw [← Equiv.sum_comp (regionBoundaryConfigSplitAt (G := G) A R f).symm
+    (fun ν : RegionBoundaryConfig (G := G) A R =>
+      (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+        regionComplementWeightRow (G := G) A R τ ν)]
+  -- Split the product index over `(b, residual)`; only `residual = residual μ` survives.
+  rw [Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl (fun b _ => ?_)
+  rw [Finset.sum_eq_single (regionBoundaryConfigSplitAt (G := G) A R f μ).2]
+  · rw [regionBoundaryConfigSplitAt_symm_apply_self]
+    have hsame : SameAwayFromBond f μ
+        ((regionBoundaryConfigSplitAt (G := G) A R f).symm
+          (b, (regionBoundaryConfigSplitAt (G := G) A R f μ).2)) := by
+      rw [sameAwayFromBond_iff_split_snd_eq, Equiv.apply_symm_apply]
+    rw [if_pos hsame]
+  · intro res _ hres
+    have hne : ¬ SameAwayFromBond f μ
+        ((regionBoundaryConfigSplitAt (G := G) A R f).symm (b, res)) := by
+      rw [sameAwayFromBond_iff_split_snd_eq, Equiv.apply_symm_apply]
+      exact fun h => hres h.symm
+    rw [if_neg hne, zero_mul]
+  · intro hres; exact absurd (Finset.mem_univ _) hres
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort.lean
@@ -262,5 +262,49 @@ theorem regionInsertedCoeff_eq_blockRealizeOp_complementPartialState_B (A B : Te
   rw [regionInsertedCoeff_eq_compl A R f M σ τ]
   exact congrFun h τ
 
+/-! ### The incident kernel as the region row through the `f`-leg split
+
+The incident-matrix kernel `incidentKernel B R f N`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) and the second tensor's region row
+`regionRegionRow B R f N` are
+the same `f`-coupling read on the two boundary-configuration index sets — the
+complement boundary configuration of `R` versus the boundary configuration of
+`univ \ R` — bridged by the complement boundary-configuration equivalence. This pins
+the bond-locality predicate to the region-row predicate: the transfer kernel is the
+incident kernel of `N` exactly when the transferred row is the region row of `N`. -/
+
+open scoped Classical in
+/-- **The incident kernel is the complement blocked map of the region row.** The
+boundary-configuration sum of the incident-matrix kernel of `N` against the second
+tensor's complement blocked weights, at a region boundary configuration `μ`, is the
+second tensor's region row of `N` at `μ`, read as a function of the complement
+physical leg. This identifies the incident kernel with the region row through the
+complement block, the bridge between the bond-locality predicate and the region-row
+predicate.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem incidentKernel_complement_blockedMap_eq_regionRegionRow (B : Tensor G d)
+    (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (μ : RegionBoundaryConfig (G := G) B R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionBlockedTensorMap (G := G) B (Finset.univ \ R)
+        (incidentKernel (G := G) B R f N μ) τ =
+      regionRegionRow (G := G) B R f N τ μ := by
+  classical
+  rw [regionBlockedTensorMap_apply, regionRegionRow]
+  -- Reindex the complement-boundary `ν'`-sum of the left side by the complement
+  -- boundary-configuration equivalence to the region-boundary `ν`-sum of the region row.
+  set E := regionComplementBoundaryConfigEquiv (G := G) B R with hE
+  rw [← Equiv.sum_comp E
+    (fun ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R) =>
+      incidentKernel (G := G) B R f N μ ν' •
+        regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ)]
+  refine Finset.sum_congr rfl (fun ν _ => ?_)
+  rw [incidentKernel, smul_eq_mul, hE, Equiv.symm_apply_apply,
+    regionComplementBoundaryConfigEquiv_apply]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort.lean
@@ -205,5 +205,62 @@ theorem regionRegionRow_split (A : Tensor G d) (R : Finset V)
     rw [if_neg hne, zero_mul]
   · intro hres; exact absurd (Finset.mem_univ _) hres
 
+/-! ### The complement-side block realization operator (the blue endpoint)
+
+The block realization operator is region-polymorphic, so instantiating it at the
+**host** region `univ \ R` and the boundary edge `f' := regionBoundaryEdgeToCompl R f`
+(the same underlying edge reread on the complement) with the transposed matrix
+`Mᵀ` gives the **complement-side realization**. This is the block-frame port of the
+edge engine's left-endpoint insertion operator: where the edge engine builds the
+left-endpoint operator from the transposed matrix on the same bond, the block frame
+builds the host-block realization from `Mᵀ` on the same boundary edge.
+
+Applied to the host interior-bond multiple of the second tensor's partial state
+across the host cut at the double-complement transport of a region physical
+configuration `σ`, it recovers the first tensor's region-inserted coefficient of `M`,
+read as a function of the complement physical leg `τ`. This is the complement-side
+reading the region resonate step equates with the region-side reading
+`regionInsertedCoeff_eq_blockRealizeOp_regionPartialState_B`
+(`TNLean.PEPS.RegionBlock.OpenLegsResonate`). -/
+
+/-- **The complement-side reading of the first tensor's coefficient.** The first
+tensor's region-inserted coefficient of `M`, read as a function of the complement
+physical leg `τ`, is the host-block realization operator of `Mᵀ` (the block
+realization operator at the region `univ \ R` and the boundary edge
+`regionBoundaryEdgeToCompl R f`) applied to the host interior-bond multiple of the
+**second** tensor's partial state across the host cut at the double-complement
+transport of `σ`.
+
+This is the complement-side companion of
+`regionInsertedCoeff_eq_blockRealizeOp_regionPartialState_B`
+(`TNLean.PEPS.RegionBlock.OpenLegsResonate`): the same landed open-legs transport,
+instanced at the host region through the cast identity
+`regionInsertedCoeff_eq_compl` (`TNLean.PEPS.RegionBlock.Recovery6`). It supplies the
+blue-endpoint reading the two-endpoint reconcile equates with the red-endpoint
+reading.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:resonate`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_blockRealizeOp_complementPartialState_B (A B : Tensor G d)
+    (R : Finset V) (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        regionInsertedCoeff (G := G) A R f M σ τ) =
+      blockRealizeOp (G := G) A (Finset.univ \ R) hCA
+        (regionBoundaryEdgeToCompl (G := G) R f) M.transpose
+        ((regionInteriorBondProd (G := G) B (Finset.univ \ R) : ℂ) •
+          regionPartialState (G := G) B (Finset.univ \ R)
+            (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)) := by
+  have h := regionInsertedCoeff_eq_blockRealizeOp_regionPartialState_B A B (Finset.univ \ R)
+    hCA hAB hDim (regionBoundaryEdgeToCompl (G := G) R f) M.transpose
+    (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)
+  -- The host-region reading of the coefficient through the cast identity.
+  funext τ
+  rw [regionInsertedCoeff_eq_compl A R f M σ τ]
+  exact congrFun h τ
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort.lean
@@ -306,5 +306,95 @@ theorem incidentKernel_complement_blockedMap_eq_regionRegionRow (B : Tensor G d)
   rw [incidentKernel, smul_eq_mul, hE, Equiv.symm_apply_apply,
     regionComplementBoundaryConfigEquiv_apply]
 
+/-! ### The region-row predicate is the bond-locality of the transfer kernel
+
+The transferred row `blockTransferRow A B R f M`, as a function of the complement
+physical leg at a region boundary configuration `μ`, is the second tensor's
+complement blocked tensor map of the transfer kernel `transferCoeff … M μ`
+(`blockTransferRow_eq_complement_blockedMap`,
+`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`). The second tensor's region row
+`regionRegionRow B R f N`, as a function of the complement physical leg at `μ`, is the
+complement blocked tensor map of the incident kernel `incidentKernel B R f N μ`
+(`incidentKernel_complement_blockedMap_eq_regionRegionRow`). Since the second tensor's
+complement block is injective, the transferred row equals the region row of `N` at
+every complement leg if and only if the transfer kernel of `M` equals the incident
+kernel of `N`. This identifies the region-row predicate `TransferRowIsRegionRow` with
+the bond-locality predicate `IsBondLocalTransferKernel`, both reading the same `N`. -/
+
+/-- **The transferred row is the region row of `N` exactly when the transfer kernel is
+the incident kernel of `N`.** For a fixed bond matrix `N`, the transferred row
+`blockTransferRow A B R f M` equals the second tensor's region row
+`regionRegionRow B R f N` at every complement physical leg if and only if the transfer
+kernel `transferCoeff … M` equals the incident kernel `incidentKernel B R f N`.
+
+The transferred row, as a function of the complement physical leg at a region boundary
+configuration `μ`, is the complement blocked tensor map of `transferCoeff … M μ`; the
+region row is the complement blocked tensor map of `incidentKernel B R f N μ`. The
+second tensor's complement block is injective (`hCB`), so the two rows coincide at
+every leg if and only if the two kernels coincide.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem blockTransferRow_eq_regionRegionRow_iff_transferCoeff_eq_incidentKernel
+    (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    (∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+        blockTransferRow A B R hRB f M τ = regionRegionRow (G := G) B R f N τ) ↔
+      transferCoeff (G := G) A B R hRB hCB f M = incidentKernel (G := G) B R f N := by
+  constructor
+  · -- Equal rows reblock through the complement block to equal kernels.
+    intro hrow
+    funext μ
+    refine regionBlockedTensorMap_injective_of_injective (G := G) B (Finset.univ \ R) hCB ?_
+    funext τ
+    rw [← blockTransferRow_eq_complement_blockedMap A B R hRA hRB hCB hAB hposA hposB hDim f M μ,
+      incidentKernel_complement_blockedMap_eq_regionRegionRow B R f N μ τ]
+    exact congrFun (hrow τ) μ
+  · -- Equal kernels reblock through the complement block to equal rows.
+    intro hker τ
+    funext μ
+    have hμ := congrFun hker μ
+    have hcompl := congrFun
+      (blockTransferRow_eq_complement_blockedMap A B R hRA hRB hCB hAB hposA hposB hDim f M μ) τ
+    rw [hμ] at hcompl
+    rw [hcompl, incidentKernel_complement_blockedMap_eq_regionRegionRow B R f N μ τ]
+
+/-- **The region-row predicate is the bond-locality predicate (kernel route).** The
+transferred-row region-row predicate `TransferRowIsRegionRow` holds if and only if the
+transfer kernel is bond-local (`IsBondLocalTransferKernel`). Both quantify, over every
+inserted matrix `M`, the existence of a bond matrix `N`; per `N` the equivalence is the
+per-leg complement-block reblocking
+`blockTransferRow_eq_regionRegionRow_iff_transferCoeff_eq_incidentKernel`.
+
+This is a direct kernel-level proof of the equivalence
+`isBondLocalTransferKernel_iff_transferRowIsRegionRow`
+(`TNLean.PEPS.RegionBlock.OpenLegsResonate`), reading both predicates against the same
+witness `N` through the complement block, without passing through the coefficient
+transfer.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem transferRowIsRegionRow_iff_isBondLocalTransferKernel (A B : Tensor G d)
+    (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    TransferRowIsRegionRow (G := G) A B R hRB f ↔
+      IsBondLocalTransferKernel (G := G) A B R hRB hCB f := by
+  unfold TransferRowIsRegionRow IsBondLocalTransferKernel
+  refine forall_congr' (fun M => exists_congr (fun N => ?_))
+  exact blockTransferRow_eq_regionRegionRow_iff_transferCoeff_eq_incidentKernel A B R hRA hRB
+    hCB hAB hposA hposB hDim f M N
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort2.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort2.lean
@@ -172,5 +172,63 @@ theorem blockTransferRow_eq_basisChange_regionRegionRow (A B : Tensor G d) (R : 
   funext σ
   rw [regionInsertedCoeff_eq_region_blockedMap A R f M σ τ]
 
+/-! ### The complement-side transferred row through the basis change
+
+The symmetric companion of `blockTransferRow_eq_basisChange_regionRegionRow`. The
+**complement-side transferred row** is the second tensor's complement blocked left
+inverse of the first tensor's region-inserted coefficient of `M`, read as a function
+of the complement physical configuration. The coefficient is the first tensor's
+complement blocked tensor map of the first tensor's own bond-`f`-local complement row
+`regionComplementRow A R f M σ` (`regionInsertedCoeff_eq_complement_blockedMap`,
+`TNLean.PEPS.RegionBlock.Recovery7`), so the complement-side transferred row is the
+A↔B complement basis change `regionBasisChange B A (univ \ R)`
+(`TNLean.PEPS.RegionBlock.BlockRealization`) applied to that complement row. Both
+transferred rows are basis changes of bond-`f`-local first-tensor rows, with no
+single-vertex injectivity. -/
+
+/-- **The complement-side transferred row.** The second tensor's complement blocked
+left inverse of the first tensor's region-inserted coefficient of `M`, read as a
+function of the complement physical configuration `τ` at a fixed region physical
+configuration `σ`. This is the complement-block read-off of the coefficient — the
+read the symmetric (complement-endpoint) inversion consumes, dual to the
+region-block read-off `blockTransferRow`. -/
+noncomputable def complBlockTransferRow (A B : Tensor G d) (R : Finset V)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    RegionBoundaryConfig (G := G) B (Finset.univ \ R) → ℂ :=
+  regionBlockedLeftInverse (G := G) B (Finset.univ \ R) hCB
+    (fun τ => regionInsertedCoeff (G := G) A R f M σ τ)
+
+/-- **The complement-side transferred row is the basis change of the complement row.**
+The complement-side transferred row `complBlockTransferRow A B R f M σ` is the A↔B
+complement basis change `regionBasisChange B A (univ \ R) hCB` applied to the first
+tensor's own complement row `regionComplementRow A R f M σ`.
+
+The complement-side transferred row is the second tensor's complement blocked left
+inverse of the first tensor's coefficient (definition); the coefficient, as a function
+of `τ`, is the first tensor's complement blocked tensor map of its complement row
+(`regionInsertedCoeff_eq_complement_blockedMap`,
+`TNLean.PEPS.RegionBlock.Recovery7`), and the complement basis change is exactly the
+second tensor's complement blocked left inverse composed with the first tensor's
+complement blocked tensor map. No single-vertex injectivity is used.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem complBlockTransferRow_eq_basisChange_regionComplementRow (A B : Tensor G d)
+    (R : Finset V)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    complBlockTransferRow A B R hCB f M σ =
+      regionBasisChange (G := G) B A (Finset.univ \ R) hCB
+        (regionComplementRow (G := G) A R f M σ) := by
+  rw [complBlockTransferRow, regionBasisChange_apply]
+  congr 1
+  funext τ
+  rw [regionInsertedCoeff_eq_complement_blockedMap A R f M σ τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort2.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort2.lean
@@ -1,0 +1,91 @@
+import TNLean.PEPS.RegionBlock.ResonatePort
+
+/-!
+# Block-granularity port of the edge resonate inversion (the bond matrix `N`)
+
+This file continues `TNLean.PEPS.RegionBlock.ResonatePort`, porting the **endpoint
+inversions** and the **reconcile** of the edge resonate engine of
+`TNLean.PEPS.InsertionRealization` (the construction `physical_to_virtual_insertion`,
+lines 579--963) to the granularity of the three injective region blocks.
+
+The landed reductions (`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`,
+`TNLean.PEPS.RegionBlock.BasisChangeIntertwine`) have isolated the single residual
+open fact of the general normal PEPS Fundamental Theorem per-edge gauge
+(arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`) as the **coefficient
+transfer**: for every inserted matrix `M` on the boundary edge `f` of the red region
+there is a matrix `N` on the second tensor's bond with
+`regionInsertedCoeff A R f M = regionInsertedCoeff B R f N` at every physical
+configuration. By `coeffTransfer_iff_transferCoeff_incidentForm`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) this is equivalent to the transfer kernel
+`transferCoeff A B R f M` (`TNLean.PEPS.RegionBlock.Recovery10`) having the
+**incident-matrix coupling form** of a single bond matrix `N` on `f` — coupling the two
+boundary configurations only through their `f`-legs, contracting the residual legs by the
+identity.
+
+This file supplies that incident-matrix form, ported from the edge engine: the two
+endpoints of the chosen edge map to the **red region** `R` and its **host**
+`univ \ R`; the residual local configuration on an endpoint maps to the residual
+boundary configuration; the per-vertex left inverse `localLeftInverseAt` maps to the
+region blocked left inverse `regionBlockedLeftInverse`
+(`TNLean.PEPS.RegionBlock.Recovery5`); and the `f`-leg split
+`regionBoundaryConfigSplitAt` (`TNLean.PEPS.RegionBlock.ResonatePort`) replaces the
+edge engine's `localVirtualConfigSplitAt`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, the step `V=W`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The incident kernel through the `f`-leg split
+
+The incident-matrix kernel `incidentKernel B R f N`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) couples the two boundary configurations
+`μ` and `(complement equiv).symm ν'` through their `f`-legs via `N`, contracting the
+residual legs by the identity (`SameAwayFromBond`). Read through the `f`-leg split
+`regionBoundaryConfigSplitAt` (`TNLean.PEPS.RegionBlock.ResonatePort`), the kernel
+`incidentKernel B R f N μ ν'` depends on `μ` only through its `f`-leg `μ f` and its
+residual boundary configuration, with `N` coupling the `f`-leg. -/
+
+open scoped Classical in
+/-- **The incident kernel is bond-`f` local in `μ`.** The incident-matrix kernel of `N`
+at the complement boundary configuration `ν'`, read as a function of the region boundary
+configuration `μ`, vanishes unless `μ` has the residual boundary configuration of
+`(complement equiv).symm ν'`; on that residual it is `N (μ f)` against the `f`-leg of
+`(complement equiv).symm ν'`. This exposes the kernel's `f`-locality in the first index.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem incidentKernel_eq_split (B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (μ : RegionBoundaryConfig (G := G) B R)
+    (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)) :
+    incidentKernel (G := G) B R f N μ ν' =
+      (if (regionBoundaryConfigSplitAt (G := G) B R f μ).2 =
+            (regionBoundaryConfigSplitAt (G := G) B R f
+              ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν')).2 then
+          N (μ f)
+            (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f)
+        else 0) := by
+  classical
+  rw [incidentKernel]
+  by_cases hsame : SameAwayFromBond f μ
+      ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν')
+  · rw [if_pos hsame,
+      if_pos ((sameAwayFromBond_iff_split_snd_eq B R f μ _).mp hsame)]
+  · rw [if_neg hsame,
+      if_neg (fun h => hsame ((sameAwayFromBond_iff_split_snd_eq B R f μ _).mpr h))]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort2.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort2.lean
@@ -131,5 +131,46 @@ theorem transferCoeff_eq_incidentKernel_iff_split (A B : Tensor G d) (R : Finset
     funext μ ν'
     rw [hsplit μ ν', incidentKernel_eq_split B R f N μ ν']
 
+/-! ### The transferred row through the A↔B region basis change
+
+The block-frame transferred row `blockTransferRow A B R f M`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) is the second tensor's region blocked
+left inverse of the first tensor's region-inserted coefficient of `M`, read as a
+function of the region physical configuration. The coefficient is the first tensor's
+region blocked tensor map of the first tensor's own bond-`f`-local region row
+(`regionInsertedCoeff_eq_region_blockedMap`,
+`TNLean.PEPS.RegionBlock.Recovery7`), so the transferred row is the A↔B region basis
+change `regionBasisChange B A R hRB` (`TNLean.PEPS.RegionBlock.BlockRealization`)
+applied to that region row. This presents the transferred row — the source of the
+transfer kernel `transferCoeff` — as the basis change of a bond-`f`-local row, with no
+single-vertex injectivity. -/
+
+/-- **The transferred row is the basis change of the region row.** The block-frame
+transferred row `blockTransferRow A B R f M τ` is the A↔B region basis change
+`regionBasisChange B A R hRB` applied to the first tensor's own region row
+`regionRegionRow A R f M τ`.
+
+The transferred row is the second tensor's region blocked left inverse of the first
+tensor's coefficient (definition of `blockTransferRow`); the coefficient, as a
+function of `σ`, is the first tensor's region blocked tensor map of its region row
+(`regionInsertedCoeff_eq_region_blockedMap`), and the basis change is exactly the
+second tensor's region blocked left inverse composed with the first tensor's region
+blocked tensor map (`regionBasisChange_apply`,
+`TNLean.PEPS.RegionBlock.BlockRealization`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem blockTransferRow_eq_basisChange_regionRegionRow (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    blockTransferRow A B R hRB f M τ =
+      regionBasisChange (G := G) B A R hRB (regionRegionRow (G := G) A R f M τ) := by
+  rw [blockTransferRow, regionBasisChange_apply]
+  congr 1
+  funext σ
+  rw [regionInsertedCoeff_eq_region_blockedMap A R f M σ τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort2.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort2.lean
@@ -230,5 +230,53 @@ theorem complBlockTransferRow_eq_basisChange_regionComplementRow (A B : Tensor G
   funext τ
   rw [regionInsertedCoeff_eq_complement_blockedMap A R f M σ τ]
 
+/-! ### The reconcile target: the basis change maps one region row to the other
+
+Combining the transferred-row reading of the coefficient transfer
+(`coeffTransfer_iff_blockTransferRow_eq_regionRegionRow`,
+`TNLean.PEPS.RegionBlock.OpenLegsResonate`) with the basis-change form of the
+transferred row (`blockTransferRow_eq_basisChange_regionRegionRow`) presents the
+coefficient transfer as a single geometric statement: the A↔B region basis change
+maps the first tensor's bond-`f`-local region row of `M` to the second tensor's
+bond-`f`-local region row of a single bond matrix `N`, at every complement physical
+leg. This is the cleanly-stated reconcile target the resonate inversion must
+establish, with no single-vertex injectivity. -/
+
+/-- **The coefficient transfer as a basis-change row identity.** For a bond matrix
+`N`, the first tensor's region-inserted coefficient of `M` equals the second tensor's
+of `N` at every physical configuration if and only if the A↔B region basis change
+maps the first tensor's region row `regionRegionRow A R f M τ` to the second tensor's
+region row `regionRegionRow B R f N τ`, at every complement physical leg.
+
+This rewrites `coeffTransfer_iff_blockTransferRow_eq_regionRegionRow`
+(`TNLean.PEPS.RegionBlock.OpenLegsResonate`) through the basis-change form of the
+transferred row (`blockTransferRow_eq_basisChange_regionRegionRow`): both region rows
+are bond-`f` local (row insertions of `M`, resp. `N`, on the boundary edge `f`), so
+the identity says the basis change conjugates the `f`-leg row insertion of `M` to that
+of `N`. This is the geometric content of the step `V=W` in the block frame.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_iff_basisChange_regionRegionRow (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    (∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f N σ τ) ↔
+      ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+        regionBasisChange (G := G) B A R hRB (regionRegionRow (G := G) A R f M τ) =
+          regionRegionRow (G := G) B R f N τ := by
+  rw [coeffTransfer_iff_blockTransferRow_eq_regionRegionRow A B R hRB hCA hCB hAB
+    hposA hposB hDim f M N]
+  refine forall_congr' (fun τ => ?_)
+  rw [blockTransferRow_eq_basisChange_regionRegionRow A B R hRB f M τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ResonatePort2.lean
+++ b/TNLean/PEPS/RegionBlock/ResonatePort2.lean
@@ -87,5 +87,49 @@ theorem incidentKernel_eq_split (B : Tensor G d) (R : Finset V)
   · rw [if_neg hsame,
       if_neg (fun h => hsame ((sameAwayFromBond_iff_split_snd_eq B R f μ _).mpr h))]
 
+/-! ### The incident-form criterion through the `f`-leg split
+
+The transfer kernel `transferCoeff A B R f M`
+(`TNLean.PEPS.RegionBlock.Recovery10`) is the incident-matrix kernel of a bond matrix
+`N` exactly when, read through the `f`-leg split, it couples the two boundary
+configurations only through their `f`-legs. This packages the bond-locality target
+`transferCoeff M = incidentKernel N` as the two conditions the resonate inversion
+must establish: residual independence (the kernel vanishes off the diagonal of the two
+residual boundary configurations) and the `f`-leg value being read by `N`. -/
+
+open scoped Classical in
+/-- **The incident-form criterion.** For a bond matrix `N`, the transfer kernel of `M`
+is the incident-matrix kernel of `N` if and only if, at every pair of boundary
+configurations `(μ, ν')`, the transfer-kernel value is `N (μ f)` against the `f`-leg of
+`(complement equiv).symm ν'` when the residual boundary configurations of `μ` and of
+`(complement equiv).symm ν'` agree, and is `0` otherwise. This is the `f`-leg-split
+reading of the bond-locality target `transferCoeff M = incidentKernel N`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem transferCoeff_eq_incidentKernel_iff_split (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    transferCoeff (G := G) A B R hRB hCB f M = incidentKernel (G := G) B R f N ↔
+      ∀ (μ : RegionBoundaryConfig (G := G) B R)
+        (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)),
+        transferCoeff (G := G) A B R hRB hCB f M μ ν' =
+          (if (regionBoundaryConfigSplitAt (G := G) B R f μ).2 =
+                (regionBoundaryConfigSplitAt (G := G) B R f
+                  ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν')).2 then
+              N (μ f)
+                (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f)
+            else 0) := by
+  classical
+  constructor
+  · intro hker μ ν'
+    rw [← incidentKernel_eq_split B R f N μ ν', ← hker]
+  · intro hsplit
+    funext μ ν'
+    rw [hsplit μ ν', incidentKernel_eq_split B R f N μ ν']
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
@@ -354,5 +354,101 @@ theorem isBondLocalTransferKernel_of_blockRealizeOpAgree (A B : Tensor G d) (R :
   isBondLocalTransferKernel_of_coeffTransfer A B R hRA hRB hCA hCB hAB hposA hposB hDim f
     (coeffTransfer_of_blockRealizeOpAgree A B R hRA hRB hAB hDim f hagree)
 
+/-! ### Target 5: closing the per-edge gauge from the abstract-operator engine
+
+The shared one-edge blocking datum supplies the four block injectivities. With the
+abstract-operator V=W predicate `BlockRealizeOpAgree` in both directions (the engine's
+isolation of the block step `V=W`) and the forward multiplicativity `hmul`, the
+two-directional bond locality follows from
+`isBondLocalTransferKernel_of_blockRealizeOpAgree`, and the shared-data gauge
+`SharedNormalEdgeBlockingData.exists_regionEdgeGauge`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`) reads off the per-edge gauge.
+
+This wires Targets 1--4 (the abstract red-block operator, its A-realization, the
+`SameState` transport, and the operator-agreement characterization of the coefficient
+transfer) into the per-edge gauge of the general normal PEPS Fundamental Theorem. The
+genuinely cross-tensor content enters only through the transport (Target 3); the
+operator agreement `BlockRealizeOpAgree` is the engine's form of `V=W`. -/
+
+variable {A B : Tensor G d} {e : Edge G}
+
+/-- **Target 5: the per-edge gauge from the abstract-operator engine.** Given a shared
+one-edge blocking datum for the two tensors of `SameState A B`, positive bond
+dimensions, matched bond dimensions, the abstract-operator V=W predicate
+`BlockRealizeOpAgree` in both directions, and the forward multiplicativity, the forward
+per-edge matrix transfer on the boundary edge `f` is conjugation by an invertible gauge
+matrix `Z`, and the bond dimensions on `f` coincide.
+
+The four block injectivities come from the shared blocking data and the union lemma;
+the two coefficient transfers come from the two-directional operator agreement through
+`isBondLocalTransferKernel_of_blockRealizeOpAgree`; the read-off is
+`SharedNormalEdgeBlockingData.exists_regionEdgeGauge`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`). No single-vertex injectivity is used.
+
+The operator agreement `BlockRealizeOpAgree` and the forward multiplicativity are the
+remaining hypotheses, the open content `V=W` of the block frame, documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem SharedNormalEdgeBlockingData.exists_regionEdgeGauge_of_blockRealizeOpAgree
+    (D : SharedNormalEdgeBlockingData A B e)
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (hagreeAB : BlockRealizeOpAgree (G := G) A B D.red
+      D.regionInjective_red_A D.regionInjective_red_B f)
+    (hagreeBA : BlockRealizeOpAgree (G := G) B A D.red
+      D.regionInjective_red_B D.regionInjective_red_A f)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B D.red f
+          (D.coeffTransferAB hAB hposA hposB hDim f
+            (isBondLocalTransferKernel_of_blockRealizeOpAgree A B D.red
+              D.regionInjective_red_A D.regionInjective_red_B
+              (D.regionInjective_compl_red_A hposA) (D.regionInjective_compl_red_B hposB)
+              hAB hposA hposB hDim f hagreeAB)) (M * M') =
+        coeffTransferMap (G := G) A B D.red f
+            (D.coeffTransferAB hAB hposA hposB hDim f
+              (isBondLocalTransferKernel_of_blockRealizeOpAgree A B D.red
+                D.regionInjective_red_A D.regionInjective_red_B
+                (D.regionInjective_compl_red_A hposA) (D.regionInjective_compl_red_B hposB)
+                hAB hposA hposB hDim f hagreeAB)) M *
+          coeffTransferMap (G := G) A B D.red f
+            (D.coeffTransferAB hAB hposA hposB hDim f
+              (isBondLocalTransferKernel_of_blockRealizeOpAgree A B D.red
+                D.regionInjective_red_A D.regionInjective_red_B
+                (D.regionInjective_compl_red_A hposA) (D.regionInjective_compl_red_B hposB)
+                hAB hposA hposB hDim f hagreeAB)) M') :
+    ∃ hEdge : A.bondDim f.1 = B.bondDim f.1,
+      ∃ Z : GL (Fin (B.bondDim f.1)) ℂ,
+        ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+          (regionInsertionTransfer_of_coeffTransfer A B D.red f
+              D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) hAB hposB hDim
+              (D.coeffTransferAB hAB hposA hposB hDim f
+                (isBondLocalTransferKernel_of_blockRealizeOpAgree A B D.red
+                  D.regionInjective_red_A D.regionInjective_red_B
+                  (D.regionInjective_compl_red_A hposA) (D.regionInjective_compl_red_B hposB)
+                  hAB hposA hposB hDim f hagreeAB))
+              (D.coeffTransferBA hAB.symm hposA hposB hDim.symm f
+                (isBondLocalTransferKernel_of_blockRealizeOpAgree B A D.red
+                  D.regionInjective_red_B D.regionInjective_red_A
+                  (D.regionInjective_compl_red_B hposB) (D.regionInjective_compl_red_A hposA)
+                  hAB.symm hposB hposA hDim.symm f hagreeBA)) hmul).fwd M =
+            (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim f.1)) ℂ) :
+                Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :=
+  D.exists_regionEdgeGauge hAB hposA hposB hDim f
+    (isBondLocalTransferKernel_of_blockRealizeOpAgree A B D.red
+      D.regionInjective_red_A D.regionInjective_red_B
+      (D.regionInjective_compl_red_A hposA) (D.regionInjective_compl_red_B hposB)
+      hAB hposA hposB hDim f hagreeAB)
+    (isBondLocalTransferKernel_of_blockRealizeOpAgree B A D.red
+      D.regionInjective_red_B D.regionInjective_red_A
+      (D.regionInjective_compl_red_B hposB) (D.regionInjective_compl_red_A hposA)
+      hAB.symm hposB hposA hDim.symm f hagreeBA)
+    hmul
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
@@ -370,6 +370,58 @@ transfer) into the per-edge gauge of the general normal PEPS Fundamental Theorem
 genuinely cross-tensor content enters only through the transport (Target 3); the
 operator agreement `BlockRealizeOpAgree` is the engine's form of `V=W`. -/
 
+/-- **The diagonal anchor of the abstract-operator engine.** For a single tensor `A`,
+the block realization operators with `M` on both sides are literally equal, so the
+abstract-operator V=W predicate holds with witness `N := M`. This is the diagonal
+anchor `isBondLocalTransferKernel_self` (`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`)
+proved through the abstract-operator engine: the engine recovers the identity
+transfer, confirming it runs end-to-end on the anchor.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem blockRealizeOpAgree_self (A : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    BlockRealizeOpAgree (G := G) A A R hRA hRA f :=
+  fun M => ⟨M, fun _ => rfl⟩
+
+/-- **`BlockRealizeOpAgree` is the basis-change intertwining.** For a witness matrix
+`N`, the two block realization operators agree on every interior-bond multiple of the
+second tensor's partial state if and only if the A↔B basis change intertwines the two
+row insertions of `M` and `N` on the second tensor's partial-state rows. This connects
+the abstract-operator predicate to the basis-change intertwining content the residual
+reduction `isBondLocalTransferKernel_of_basisChange_intertwine`
+(`TNLean.PEPS.RegionBlock.BlockRealization`) consumes: both are exactly the coefficient
+transfer `coeff_A M = coeff_B N`, via `coeffTransfer_iff_blockRealizeOp_agree` and
+`rowInsertF_basisChange_forall_eq_iff_regionInsertedCoeff_eq`
+(`TNLean.PEPS.RegionBlock.BasisChangeIntertwine`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+254--582 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem blockRealizeOp_agree_iff_basisChange_intertwine (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    (∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+        blockRealizeOp (G := G) A R hRA f M
+            ((regionInteriorBondProd (G := G) B R : ℂ) • regionPartialState (G := G) B R τ) =
+          blockRealizeOp (G := G) B R hRB f N
+            ((regionInteriorBondProd (G := G) B R : ℂ) • regionPartialState (G := G) B R τ)) ↔
+      (∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+        rowInsertF (G := G) A R f M
+            (regionBasisChange (G := G) A B R hRA (partialStateRowB (G := G) B R hRB τ)) =
+          regionBasisChange (G := G) A B R hRA
+            (rowInsertF (G := G) B R f N (partialStateRowB (G := G) B R hRB τ))) := by
+  rw [← coeffTransfer_iff_blockRealizeOp_agree A B R hRA hRB hAB hDim f M N,
+    rowInsertF_basisChange_forall_eq_iff_regionInsertedCoeff_eq A B R hRA hRB hCA hCB hAB
+      hposA hposB hDim f M N]
+
 variable {A B : Tensor G d} {e : Edge G}
 
 /-- **Target 5: the per-edge gauge from the abstract-operator engine.** Given a shared

--- a/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
@@ -273,5 +273,86 @@ theorem coeffTransfer_iff_blockRealizeOp_agree (A B : Tensor G d) (R : Finset V)
     rw [threeBlockOpCoeff_apply] at hA hB
     rw [hA, congrFun (hagree τ) σ, hB]
 
+/-! ### The abstract-operator V=W predicate
+
+The genuinely cross-tensor content of the per-edge gauge, isolated by the
+abstract-operator engine: for every inserted matrix `M` on the first tensor's bond
+there is a matrix `N` on the second tensor's bond such that the two block
+realization operators — the one built from `A` with `M`, the one built from `B`
+with `N` — agree on the second tensor's partial states. By
+`coeffTransfer_iff_blockRealizeOp_agree` this operator agreement is exactly the
+coefficient transfer `coeff_A M = coeff_B N`, so the predicate is the engine's
+form of the block step `V=W`: the cross-tensor red-block operator, read on the
+second tensor's `SameState`-invariant column, is a second-tensor matrix insertion. -/
+
+/-- **The abstract-operator V=W predicate.** For every inserted matrix `M` on the
+boundary edge `f`, there is a matrix `N` on the second tensor's bond such that the
+two block realization operators agree on every interior-bond multiple of the second
+tensor's partial state across the region cut.
+
+This is the engine's isolation of the block step `V=W`: the red-block operator built
+from the first tensor, read on the second tensor's `SameState`-invariant column, is
+realized as a second-tensor matrix insertion. -/
+def BlockRealizeOpAgree (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) : Prop :=
+  ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+    ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+        blockRealizeOp (G := G) A R hRA f M
+            ((regionInteriorBondProd (G := G) B R : ℂ) • regionPartialState (G := G) B R τ) =
+          blockRealizeOp (G := G) B R hRB f N
+            ((regionInteriorBondProd (G := G) B R : ℂ) • regionPartialState (G := G) B R τ)
+
+/-- **The abstract-operator V=W predicate gives the coefficient transfer.** If the two
+block realization operators agree (for some `N` per `M`) on the second tensor's
+partial states, then for every inserted matrix `M` there is a matrix `N` whose
+region-inserted coefficient matches the first tensor's of `M` at every physical
+configuration. This unpacks `BlockRealizeOpAgree` through
+`coeffTransfer_iff_blockRealizeOp_agree`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+254--582 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_of_blockRealizeOpAgree (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hagree : BlockRealizeOpAgree (G := G) A B R hRA hRB f) :
+    ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ := by
+  intro M
+  obtain ⟨N, hN⟩ := hagree M
+  exact ⟨N, (coeffTransfer_iff_blockRealizeOp_agree A B R hRA hRB hAB hDim f M N).mpr hN⟩
+
+/-- **The abstract-operator V=W predicate gives the bond-local transfer kernel.** If
+the two block realization operators agree on the second tensor's partial states, then
+the transfer kernel `transferCoeff A B R f M` is bond-local
+(`IsBondLocalTransferKernel`). The operator agreement gives the coefficient transfer
+(`coeffTransfer_of_blockRealizeOpAgree`), which the basis-change intertwining bridge
+`isBondLocalTransferKernel_of_coeffTransfer`
+(`TNLean.PEPS.RegionBlock.BasisChangeIntertwine`) reads as the bond locality of the
+transfer kernel.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+254--582 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem isBondLocalTransferKernel_of_blockRealizeOpAgree (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hagree : BlockRealizeOpAgree (G := G) A B R hRA hRB f) :
+    IsBondLocalTransferKernel (G := G) A B R hRB hCB f :=
+  isBondLocalTransferKernel_of_coeffTransfer A B R hRA hRB hCA hCB hAB hposA hposB hDim f
+    (coeffTransfer_of_blockRealizeOpAgree A B R hRA hRB hAB hDim f hagree)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
@@ -193,5 +193,85 @@ theorem regionInsertedCoeff_eq_threeBlockOpCoeff_B (A B : Tensor G d) (R : Finse
   rw [← threeBlockOpCoeff_blockRealizeOp_eq_regionInsertedCoeff (G := G) A R hRA f M σ τ,
     threeBlockOpCoeff_transport A B R hAB hDim (blockRealizeOp (G := G) A R hRA f M) σ τ]
 
+/-! ### Target 4: the abstract-operator engine reads the matrix off the second tensor
+
+The single-tensor engine on the second tensor: the second tensor's own block
+realization operator `blockRealizeOp B R hRB f N` realizes the second tensor's
+region-inserted coefficient of `N` through the second tensor's partial state, by
+KEY IDENTITY 1 instanced at the second tensor.
+
+Combining the A-realization-through-B (`regionInsertedCoeff_eq_threeBlockOpCoeff_B`,
+the abstract operator built from `A` read on `B`'s partial state) with the B-engine,
+the coefficient transfer `coeff_A M = coeff_B N` is exactly the agreement of the two
+block realization operators — the one built from `A` with matrix `M`, the one built
+from `B` with matrix `N` — on the interior-bond multiple of the second tensor's
+partial state. This is the block port of the edge engine's reading of the matrix off
+the second tensor: the cross-tensor operator is realized as a second-tensor matrix
+insertion on the second tensor's `SameState`-invariant column. -/
+
+/-- **Target 4: the second tensor's block realization on its own partial state.** The
+abstract-operator three-block coefficient of the second tensor's block realization
+operator `blockRealizeOp B R hRB f N`, read on the second tensor's data, is the
+second tensor's region-inserted coefficient of `N`. This is Target 2 instanced at
+the second tensor: the engine on `B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockOpCoeff_B_blockRealizeOp_eq_regionInsertedCoeff (B : Tensor G d)
+    (R : Finset V) (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    threeBlockOpCoeff (G := G) B R (blockRealizeOp (G := G) B R hRB f N) σ τ =
+      regionInsertedCoeff (G := G) B R f N σ τ :=
+  threeBlockOpCoeff_blockRealizeOp_eq_regionInsertedCoeff (G := G) B R hRB f N σ τ
+
+/-- **The coefficient transfer is the agreement of the two block realization
+operators on the second tensor's partial state.** For a witness matrix `N`, the
+first tensor's region-inserted coefficient of `M` equals the second tensor's of `N`
+at every physical configuration if and only if the two block realization operators —
+the one built from `A` with matrix `M`, the one built from `B` with matrix `N` —
+agree on the interior-bond multiple of the second tensor's partial state across the
+region cut, at every complement physical configuration.
+
+The forward direction reads each coefficient through the corresponding block
+realization (the A-realization through `B`, Target 3; the B-realization, Target 4);
+the backward direction inverts the same readings. This is the block port of the edge
+engine's matrix read-off: the cross-tensor operator is realized as a second-tensor
+matrix insertion on the second tensor's `SameState`-invariant column.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+254--582 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_iff_blockRealizeOp_agree (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    (∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f N σ τ) ↔
+      (∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+        blockRealizeOp (G := G) A R hRA f M
+            ((regionInteriorBondProd (G := G) B R : ℂ) • regionPartialState (G := G) B R τ) =
+          blockRealizeOp (G := G) B R hRB f N
+            ((regionInteriorBondProd (G := G) B R : ℂ) • regionPartialState (G := G) B R τ)) := by
+  constructor
+  · intro hcoeff τ
+    funext σ
+    have hA := regionInsertedCoeff_eq_threeBlockOpCoeff_B A B R hRA hAB hDim f M σ τ
+    have hB := threeBlockOpCoeff_B_blockRealizeOp_eq_regionInsertedCoeff B R hRB f N σ τ
+    rw [threeBlockOpCoeff_apply] at hA
+    rw [threeBlockOpCoeff_apply] at hB
+    rw [← hA, hcoeff σ τ, hB]
+  · intro hagree σ τ
+    have hA := regionInsertedCoeff_eq_threeBlockOpCoeff_B A B R hRA hAB hDim f M σ τ
+    have hB := threeBlockOpCoeff_B_blockRealizeOp_eq_regionInsertedCoeff B R hRB f N σ τ
+    rw [threeBlockOpCoeff_apply] at hA hB
+    rw [hA, congrFun (hagree τ) σ, hB]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
@@ -1,0 +1,109 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockReconcile
+import TNLean.PEPS.RegionBlock.UnionInjectivity
+import TNLean.PEPS.RegionBlock.BasisChangeIntertwine
+
+/-!
+# The abstract-operator three-block engine for the normal PEPS Fundamental Theorem
+
+This file ports the **abstract physical-operator** architecture of the edge-level
+realization `physical_to_virtual_insertion` /
+`edgeRightInsertionOp_realizes_edgeTransferMatrix`
+(`TNLean.PEPS.InsertionRealization`, `TNLean.PEPS.InsertionAlgebra`) to the
+**three injective region blocks** of a `SharedNormalEdgeBlockingData`.
+
+The edge realization solves the cross-tensor problem with a tensor-independent
+physical operator: an operator on the physical legs realizes one tensor's
+matrix insertion by that tensor's injectivity, the resonate identity holds on
+the first tensor by construction, the identity transports to the second tensor
+because `SameState` makes the two global states equal and the operator acts only
+on physical legs, and the single-tensor engine then runs on the second tensor to
+read the matrix off.
+
+At block granularity the physical space of the red block is the function space
+`RegionPhysicalConfig red → ℂ`, and the tensor-independent physical operator at
+the red block is the **block realization operator** `blockRealizeOp A red f M`
+(`TNLean.PEPS.RegionBlock.BlockRealization`): a linear endomorphism of
+`RegionPhysicalConfig red → ℂ` that realizes the first tensor's red-block
+matrix insertion of `M` on the boundary edge `f`. This file:
+
+* fixes the abstract physical operator `blockRealizeOp A red f M` (Target 1/2,
+  reusing `BlockRealization.lean`);
+* proves that this operator, applied to the **second tensor's** partial state
+  across the region cut (the `SameState`-invariant object), reads off the first
+  tensor's region-inserted coefficient (the transport, Target 3); and
+* feeds the constructed `N` to the basis-change intertwining bridge
+  (`isBondLocalTransferKernel_of_coeffTransfer`,
+  `TNLean.PEPS.RegionBlock.BasisChangeIntertwine`) and the shared-blocking-data
+  per-edge gauge (`SharedNormalEdgeBlockingData.exists_regionEdgeGauge`,
+  `TNLean.PEPS.RegionBlock.ThreeBlockTransfer`) to close the kernel (Target 5).
+
+The cross-tensor content enters exactly once, in the transport step: the
+realization operator built from the first tensor acts on the second tensor's
+`SameState`-invariant partial state. Everything else is single-tensor block
+mechanics already landed in `BlockRealization.lean` and the three-block engine.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The abstract red-block physical operator and its three-block coefficient
+
+The tensor-independent physical operator at the red block is the block
+realization operator `blockRealizeOp A red f M`: a linear endomorphism of the red
+physical function space `RegionPhysicalConfig red → ℂ`. It realizes the first
+tensor's red-block matrix insertion of `M` on the boundary edge `f` by inverting
+the red block, applying the row insertion of `M`, and reblocking
+(`TNLean.PEPS.RegionBlock.BlockRealization`).
+
+The **three-block coefficient with an abstract operator** reads the red-block
+physical operator `O₁` against the fused blue/complement leg through the partial
+state across the region cut: at a complement physical configuration `τ`, the
+operator `O₁` acts on the interior-bond multiple of the partial state and is read
+at the region physical leg `σ`. With `O₁ := blockRealizeOp A red f M` this is the
+first tensor's region-inserted coefficient (`A`-realization, KEY IDENTITY 1). -/
+
+/-- **The abstract-operator three-block coefficient.** Apply the abstract red-block
+physical operator `O₁` to the interior-bond multiple of the partial state across
+the region cut (read as a function of the red physical leg) and evaluate at the
+red leg `σ`. This is the abstract analogue of `threeBlockInsertedCoeff` with the
+`M`-coupling at the red block replaced by an abstract operator on the red physical
+function space.
+
+The partial state `regionPartialState A R τ` carries the fused blue/complement leg
+through the closed-state contraction; the abstract operator `O₁` acts only on the
+red physical function space and is read at the red leg `σ`. The interior-bond
+multiple is the standing normalization of the block realization (KEY IDENTITY 1,
+`TNLean.PEPS.RegionBlock.BlockRealization`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:resonate`, lines
+254--582 of `Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def threeBlockOpCoeff (A : Tensor G d) (R : Finset V)
+    (O₁ : (RegionPhysicalConfig (V := V) (d := d) R → ℂ) →ₗ[ℂ]
+      (RegionPhysicalConfig (V := V) (d := d) R → ℂ))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) : ℂ :=
+  O₁ ((regionInteriorBondProd (G := G) A R : ℂ) • regionPartialState (G := G) A R τ) σ
+
+@[simp] theorem threeBlockOpCoeff_apply (A : Tensor G d) (R : Finset V)
+    (O₁ : (RegionPhysicalConfig (V := V) (d := d) R → ℂ) →ₗ[ℂ]
+      (RegionPhysicalConfig (V := V) (d := d) R → ℂ))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    threeBlockOpCoeff (G := G) A R O₁ σ τ =
+      O₁ ((regionInteriorBondProd (G := G) A R : ℂ) • regionPartialState (G := G) A R τ) σ :=
+  rfl
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockPhysical.lean
@@ -105,5 +105,93 @@ noncomputable def threeBlockOpCoeff (A : Tensor G d) (R : Finset V)
       O₁ ((regionInteriorBondProd (G := G) A R : ℂ) • regionPartialState (G := G) A R τ) σ :=
   rfl
 
+/-! ### Target 2: the A-realization
+
+With the abstract red-block operator instantiated as the first tensor's own block
+realization operator `blockRealizeOp A red f M`, the abstract-operator three-block
+coefficient is the first tensor's region-inserted coefficient of `M`. This is KEY
+IDENTITY 1 (`blockRealizeOp_regionPartialState_eq_regionInsertedCoeff`,
+`TNLean.PEPS.RegionBlock.BlockRealization`): the realization operator applied to
+the interior-bond multiple of the first tensor's partial state recovers the
+M-inserted coefficient. -/
+
+/-- **Target 2: the A-realization.** The abstract-operator three-block coefficient
+of the first tensor's block realization operator `blockRealizeOp A R hRA f M` is
+the first tensor's region-inserted coefficient of `M`. This realizes the abstract
+red-block operator as the first tensor's matrix insertion, by KEY IDENTITY 1.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockOpCoeff_blockRealizeOp_eq_regionInsertedCoeff (A : Tensor G d)
+    (R : Finset V) (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    threeBlockOpCoeff (G := G) A R (blockRealizeOp (G := G) A R hRA f M) σ τ =
+      regionInsertedCoeff (G := G) A R f M σ τ := by
+  rw [threeBlockOpCoeff_apply,
+    blockRealizeOp_regionPartialState_eq_regionInsertedCoeff (G := G) A R hRA f M τ]
+
+/-! ### Target 3: the resonate transport across `SameState`
+
+The abstract-operator three-block coefficient reads the tensor **only** through
+the partial state across the region cut and the interior bond product. The partial
+state is `SameState`-invariant (`regionPartialState_sameState`), and the interior
+bond products of two tensors with matched bond dimensions coincide
+(`regionInteriorBondProd_congr`). So the abstract-operator three-block coefficient
+of the **first** tensor equals that of the **second** tensor, for the *same*
+abstract red-block operator `O₁`. This is the single cross-tensor step: the
+abstract operator built from either tensor acts on the common partial state.
+
+The transport is what lets the realization operator built from the first tensor
+read the first tensor's coefficient off the *second* tensor's partial state, the
+block port of the edge-level `SameState` transport of the resonate identity. -/
+
+/-- **Target 3: the resonate transport.** The abstract-operator three-block
+coefficient is `SameState`-invariant: for the same abstract red-block operator
+`O₁`, the first tensor's abstract-operator coefficient (read through the first
+tensor's partial state and interior bond product) equals the second tensor's (read
+through the second tensor's partial state and interior bond product), under
+`SameState` and matched bond dimensions.
+
+The partial states coincide across `SameState` (`regionPartialState_sameState`)
+and the interior bond products coincide under `hDim` (`regionInteriorBondProd_congr`),
+so the operator `O₁` is applied to the *same* vector on both sides.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:resonate`, lines
+254--582 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockOpCoeff_transport (A B : Tensor G d) (R : Finset V)
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (O₁ : (RegionPhysicalConfig (V := V) (d := d) R → ℂ) →ₗ[ℂ]
+      (RegionPhysicalConfig (V := V) (d := d) R → ℂ))
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    threeBlockOpCoeff (G := G) A R O₁ σ τ = threeBlockOpCoeff (G := G) B R O₁ σ τ := by
+  rw [threeBlockOpCoeff_apply, threeBlockOpCoeff_apply,
+    regionPartialState_sameState hAB R τ, regionInteriorBondProd_congr A B R hDim]
+
+/-- **The first tensor's coefficient through the second tensor's realization.** The
+first tensor's region-inserted coefficient of `M` is the abstract-operator
+three-block coefficient of the first tensor's block realization operator read on
+the *second* tensor's partial state. This composes the A-realization (Target 2)
+with the resonate transport (Target 3): the realization operator built from the
+first tensor reads the first tensor's coefficient off the second tensor's
+`SameState`-invariant partial state.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_threeBlockOpCoeff_B (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      threeBlockOpCoeff (G := G) B R (blockRealizeOp (G := G) A R hRA f M) σ τ := by
+  rw [← threeBlockOpCoeff_blockRealizeOp_eq_regionInsertedCoeff (G := G) A R hRA f M σ τ,
+    threeBlockOpCoeff_transport A B R hAB hDim (blockRealizeOp (G := G) A R hRA f M) σ τ]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean
@@ -183,5 +183,128 @@ theorem threeBlock_blue_readoff
       fun bβ => threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ :=
   threeBlock_invert_blue (A := A) (e := e) D bdry σcompl
 
+/-! ### The fused-leg bridge to the two-block region-inserted coefficient
+
+The fused blue/complement physical leg `threeBlockComplPhysical D σblue σcompl`
+ranges over **every** complement physical leg on `univ \ red` as `σblue`, `σcompl`
+vary, because `univ \ red = blue ⊔ complement` (`sdiff_red_eq_blue_union_complement`).
+Splitting a complement leg `τ` along this cover and reading the two halves recovers
+`τ`, so the three-block inserted coefficient quantified over the three legs `σred`,
+`σblue`, `σcompl` carries exactly the same information as the two-block
+`regionInsertedCoeff` of the red region quantified over `σred`, `τ`. This bridges the
+three-block engine to the block-frame coefficient transfer the per-edge gauge consumes
+(`exists_regionEdgeGauge_of_coeffTransfer`,
+`TNLean.PEPS.RegionBlock.RegionReconcile`). -/
+
+/-- The blue half of a complement physical leg: read a complement leg `τ` on
+`univ \ red` at its blue vertices. -/
+def threeBlockBlueSplit
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ D.red)) :
+    RegionPhysicalConfig (V := V) (d := d) D.blue :=
+  fun w => τ ⟨w.1, by
+    rw [sdiff_red_eq_blue_union_complement (A := A) (e := e) D]
+    exact Finset.mem_union_left _ w.2⟩
+
+/-- The complement half of a complement physical leg: read a complement leg `τ` on
+`univ \ red` at its complement vertices. -/
+def threeBlockComplSplit
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ D.red)) :
+    RegionPhysicalConfig (V := V) (d := d) D.complement :=
+  fun w => τ ⟨w.1, by
+    rw [sdiff_red_eq_blue_union_complement (A := A) (e := e) D]
+    exact Finset.mem_union_right _ w.2⟩
+
+/-- **The fused leg recovers a split complement leg.** Fusing the blue and complement
+halves of a complement physical leg `τ` recovers `τ`. The fused leg reads a blue vertex
+off the blue half and a complement vertex off the complement half; on a vertex of
+`univ \ red` (which lies in `blue` or `complement`) both halves read `τ` at that vertex.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockComplPhysical_split
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ D.red)) :
+    threeBlockComplPhysical (A := A) (e := e) D
+        (threeBlockBlueSplit (A := A) (e := e) D τ)
+        (threeBlockComplSplit (A := A) (e := e) D τ) = τ := by
+  funext w
+  by_cases hb : w.1 ∈ D.blue
+  · rw [threeBlockComplPhysical_apply_blue (A := A) (e := e) D _ _ w hb,
+      threeBlockBlueSplit]
+  · have hwnotred : w.1 ∉ D.red := (Finset.mem_sdiff.mp w.2).2
+    have hc : w.1 ∈ D.complement := by
+      have hcover : w.1 ∈ D.red ∪ D.blue ∪ D.complement := by
+        rw [D.cover_univ]; exact Finset.mem_univ _
+      rcases Finset.mem_union.mp hcover with hrb | hc
+      · rcases Finset.mem_union.mp hrb with hr | hbl
+        · exact absurd hr hwnotred
+        · exact absurd hbl hb
+      · exact hc
+    rw [threeBlockComplPhysical_apply_not_blue (A := A) (e := e) D _ _ w hb hc,
+      threeBlockComplSplit]
+
+/-- **The three-block coefficient is the two-block region-inserted coefficient at the
+split leg.** Reading a complement physical leg `τ` of the red region through the
+blue/complement split, the two-block region-inserted coefficient of the red region at
+`σred`, `τ` is the three-block inserted coefficient at `σred` and the two split halves
+of `τ`. This is the bridge `threeBlockInsertedCoeff_eq_regionInsertedCoeff` with the
+fused leg recovered from its split (`threeBlockComplPhysical_split`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_threeBlockInsertedCoeff_split
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σred : RegionPhysicalConfig (V := V) (d := d) D.red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ D.red)) :
+    regionInsertedCoeff (G := G) A D.red f M σred τ =
+      threeBlockInsertedCoeff (A := A) (e := e) D f M σred
+        (threeBlockBlueSplit (A := A) (e := e) D τ)
+        (threeBlockComplSplit (A := A) (e := e) D τ) := by
+  rw [threeBlockInsertedCoeff_eq_regionInsertedCoeff,
+    threeBlockComplPhysical_split (A := A) (e := e) D τ]
+
+/-- **The three-block coefficient transfer is the two-block coefficient transfer
+(single tensor).** Two inserted matrices `M`, `M'` on the red crossing edge give the
+same three-block inserted coefficient at every triple of physical legs if and only if
+they give the same two-block region-inserted coefficient of the red region at every
+region and complement leg. The forward direction splits a complement leg along the
+blue/complement cover; the reverse direction fuses the blue and complement legs through
+the bridge `threeBlockInsertedCoeff_eq_regionInsertedCoeff`.
+
+This identifies the three-block engine's resonate hypothesis with the two-block
+inserted-coefficient frame `regionInsertedCoeff` of the red region, the frame the
+block-frame coefficient transfer `exists_regionEdgeGauge_of_coeffTransfer`
+(`TNLean.PEPS.RegionBlock.RegionReconcile`) consumes, with no single-vertex
+injectivity.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockInsertedCoeff_eq_iff_regionInsertedCoeff_eq
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    (∀ (σred : RegionPhysicalConfig (V := V) (d := d) D.red)
+        (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+        (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement),
+      threeBlockInsertedCoeff (A := A) (e := e) D f M σred σblue σcompl =
+        threeBlockInsertedCoeff (A := A) (e := e) D f M' σred σblue σcompl) ↔
+      (∀ (σ : RegionPhysicalConfig (V := V) (d := d) D.red)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ D.red)),
+        regionInsertedCoeff (G := G) A D.red f M σ τ =
+          regionInsertedCoeff (G := G) A D.red f M' σ τ) := by
+  constructor
+  · intro h σ τ
+    rw [regionInsertedCoeff_eq_threeBlockInsertedCoeff_split (A := A) (e := e) D f M σ τ,
+      regionInsertedCoeff_eq_threeBlockInsertedCoeff_split (A := A) (e := e) D f M' σ τ]
+    exact h σ _ _
+  · intro h σred σblue σcompl
+    rw [threeBlockInsertedCoeff_eq_regionInsertedCoeff,
+      threeBlockInsertedCoeff_eq_regionInsertedCoeff]
+    exact h σred (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean
@@ -113,5 +113,75 @@ theorem threeBlock_middle_strip_descent
     rw [← hM, ← hM', hstrip]
   exact smul_right_injective _ hne this
 
+/-! ### Step 2: the two endpoint read-offs
+
+Inverting the two endpoint blocks reads two row functions off the three-block
+inserted coefficient. Equal three-block coefficients give equal read-offs at the
+respective endpoints, the residual independence forced by the common reference.
+
+The **red read-off** inverts the σred-function and recovers the region row
+`regionRegionRow` at the fused blue/complement leg (`threeBlock_invert_red`). The
+**blue read-off** inverts the σblue-function of the complement-stripped fused host
+weight and recovers the complement coupling row `threeBlockComplCoeff`
+(`threeBlock_invert_blue`). The two read-offs live in different index spaces — the red
+row is indexed by the host residual `bdry` and reads the complement physical leg as a
+free residual, the blue row is indexed by the blue boundary configuration and reads the
+complement physical leg through the coupling — and the reconcile routes both through the
+common complement-stripped reference. -/
+
+/-- **The red endpoint read-off from a coefficient equality.** If two inserted matrices
+give the same three-block inserted coefficient at every physical configuration, then the
+red block's chosen left inverse reads off the same region row `regionRegionRow` at the
+fused blue/complement physical leg.
+
+The red left inverse of the σred-function recovers `regionRegionRow A red f M
+(threeBlockComplPhysical D σblue σcompl)` (`threeBlock_invert_red`); equal σred-functions
+give the same read-off.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:inj_O->X_argument`,
+lines 355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlock_red_readoff_eq_of_coeff_eq
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (hcoeff : ∀ σred : RegionPhysicalConfig (V := V) (d := d) D.red,
+      threeBlockInsertedCoeff (A := A) (e := e) D f M σred σblue σcompl =
+        threeBlockInsertedCoeff (A := A) (e := e) D f M' σred σblue σcompl) :
+    regionRegionRow (G := G) A D.red f M
+        (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) =
+      regionRegionRow (G := G) A D.red f M'
+        (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) := by
+  rw [← threeBlock_invert_red (A := A) (e := e) D f M σblue σcompl,
+    ← threeBlock_invert_red (A := A) (e := e) D f M' σblue σcompl]
+  exact congrArg
+    (fun g => regionBlockedLeftInverse (G := G) A D.red
+      (regionBlockedTensorInjective_red (A := A) (e := e) D) g) (funext hcoeff)
+
+/-- **The blue endpoint read-off as a function of the host residual.** The blue
+block's chosen left inverse, applied to the σblue-function of the complement-stripped
+fused host weight and scaled by the blue interior bond product, recovers the complement
+coupling row `threeBlockComplCoeff` at every host residual configuration `bdry`. This
+is `threeBlock_invert_blue` packaged as the residual-quantified read-off the reconcile
+references. The read-off is the same for any inserted matrix: the fused host weight is
+`M`-independent, so the blue endpoint reads the complement physical leg off through the
+coupling alone, providing the common reference frame against which the red read-off is
+reconciled.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:inj_O->X_argument`,
+lines 355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlock_blue_readoff
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (regionInteriorBondProd (G := G) A D.blue : ℂ) •
+        regionBlockedLeftInverse (G := G) A D.blue
+          (regionBlockedTensorInjective_blue (A := A) (e := e) D)
+          (fun σblue => regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+            (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) =
+      fun bβ => threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ :=
+  threeBlock_invert_blue (A := A) (e := e) D bdry σcompl
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean
@@ -1,0 +1,117 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockResonate2
+
+/-!
+# Three-block resonate engine: the V=W reconcile
+
+This file completes `TNLean.PEPS.RegionBlock.ThreeBlockResonate2` with the **V=W
+reconcile** of the three-block resonate engine for the normal PEPS Fundamental
+Theorem (arXiv:1804.04964, Section 3, Lemma `inj_isomorph`). The previous two files
+landed:
+
+* the core region-blocking associativity factorization and the **middle strip**
+  `threeBlock_middle_strip` (stripping the complement block while keeping the red
+  and blue residual configurations independent);
+* the **blue endpoint inversion** `threeBlock_invert_blue` (reading off the
+  complement coupling row `threeBlockComplCoeff`);
+* the **red endpoint inversion** `threeBlock_invert_red` (reading off the region row
+  `regionRegionRow`).
+
+This file ports the edge-level reconcile `resonate_endpoint_coeff_reconcile`
+(`TNLean.PEPS.InsertionRealization`) to the three blocks. The edge reconcile forces
+the matrix read by inverting one endpoint to equal the matrix read by inverting the
+other: the residual independence is forced because both inversions reference the
+**same** stripped (middle-inverted) identity. Here both endpoint inversions reference
+the same `threeBlockComplRow` (the complement-stripped row produced by the middle
+strip), so the two read-offs are pinned to the common middle-stripped reference.
+
+## Structure
+
+* `threeBlock_middle_strip_descent` descends an equality of three-block inserted
+  coefficients through the complement block: equal coefficients (for all three legs)
+  give equal `threeBlockComplRow`s.
+* `threeBlock_red_readoff_eq_of_coeff_eq` reads the red endpoint off both sides: equal
+  three-block coefficients give equal region rows `regionRegionRow` at the fused
+  blue/complement leg.
+* `threeBlock_blue_readoff_eq_of_coeff_eq` reads the blue endpoint off both sides:
+  equal complement-stripped fused host weights give equal complement coupling rows
+  `threeBlockComplCoeff`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d} {e : Edge G}
+
+/-! ### Step 1: descending an equality of three-block coefficients through the strip
+
+If two matrices `M`, `M'` inserted on the crossing edge produce the same three-block
+inserted coefficient at every triple of physical legs `σred`, `σblue`, `σcompl`, then
+they produce the same complement-stripped row `threeBlockComplRow` at every pair of
+residual legs `σred`, `σblue`. This is the structural core of the reconcile: the
+complement (middle) block is inverted on the common coefficient, pinning the two rows
+to the same middle-stripped reference. It is the region analogue of the
+middle-inversion step of `resonate_middle_inverted`
+(`TNLean.PEPS.InsertionRealization`), now applied to two coefficient families at once
+rather than the resonate identity. -/
+
+/-- **Descending a coefficient equality through the complement strip.** If two
+inserted matrices give the same three-block inserted coefficient at every physical
+configuration, then their complement-stripped rows `threeBlockComplRow` agree at every
+pair of red and blue residual legs.
+
+The complement interior bond multiple of each σcompl-function is the complement blocked
+tensor map of `threeBlockComplRow` (`regionInteriorBondProd_smul_threeBlockInsertedCoeff_eq`),
+and the complement block's chosen left inverse recovers the row
+(`threeBlock_middle_strip`). Equal coefficients give equal σcompl-functions, hence equal
+left-inverse read-offs, hence equal rows after dividing out the positive interior bond
+product.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:resonate`--
+`eq:inj_O->X_argument`, lines 355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlock_middle_strip_descent
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σred : RegionPhysicalConfig (V := V) (d := d) D.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g)
+    (hcoeff : ∀ σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement,
+      threeBlockInsertedCoeff (A := A) (e := e) D f M σred σblue σcompl =
+        threeBlockInsertedCoeff (A := A) (e := e) D f M' σred σblue σcompl) :
+    threeBlockComplRow (A := A) (e := e) D f M σred σblue =
+      threeBlockComplRow (A := A) (e := e) D f M' σred σblue := by
+  have hposC : 0 < regionInteriorBondProd (G := G) A D.complement :=
+    regionInteriorBondProd_pos (G := G) A D.complement hpos
+  have hne : (regionInteriorBondProd (G := G) A D.complement : ℂ) ≠ 0 := by
+    exact_mod_cast hposC.ne'
+  -- The σcompl-functions agree, so their middle-strip read-offs agree.
+  have hfun : (fun σcompl => threeBlockInsertedCoeff (A := A) (e := e) D f M σred σblue σcompl) =
+      (fun σcompl => threeBlockInsertedCoeff (A := A) (e := e) D f M' σred σblue σcompl) :=
+    funext hcoeff
+  have hstrip := congrArg
+    (fun g => regionBlockedLeftInverse (G := G) A D.complement
+      (regionBlockedTensorInjective_complement (A := A) (e := e) D) g) hfun
+  simp only at hstrip
+  -- Multiply both middle-strip read-offs by the interior bond product to land on rows.
+  have hM := threeBlock_middle_strip (A := A) (e := e) D f M σred σblue
+  have hM' := threeBlock_middle_strip (A := A) (e := e) D f M' σred σblue
+  have : (regionInteriorBondProd (G := G) A D.complement : ℂ) •
+        threeBlockComplRow (A := A) (e := e) D f M σred σblue =
+      (regionInteriorBondProd (G := G) A D.complement : ℂ) •
+        threeBlockComplRow (A := A) (e := e) D f M' σred σblue := by
+    rw [← hM, ← hM', hstrip]
+  exact smul_right_injective _ hne this
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean
@@ -306,5 +306,62 @@ theorem threeBlockInsertedCoeff_eq_iff_regionInsertedCoeff_eq
       threeBlockInsertedCoeff_eq_regionInsertedCoeff]
     exact h σred (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)
 
+/-! ### The three-block reconcile
+
+Packaging the middle strip and the two endpoint read-offs into the single
+residual-independence statement of the reconcile. A two-block coefficient equality of
+the red region (the frame the bridge `threeBlockInsertedCoeff_eq_iff_regionInsertedCoeff_eq`
+identifies with the three-block resonate hypothesis) forces, simultaneously,
+
+* the complement-stripped rows `threeBlockComplRow` to agree at every red and blue
+  residual (the middle strip descent), and
+* the region rows `regionRegionRow` to agree at every fused blue/complement leg (the red
+  endpoint read-off).
+
+Both read-offs are pinned to the same middle-stripped reference, the residual
+independence the edge reconcile `resonate_endpoint_coeff_reconcile`
+(`TNLean.PEPS.InsertionRealization`) supplies at edge granularity. -/
+
+/-- **The three-block reconcile.** A two-block region-inserted coefficient equality of
+the red region forces both the complement-stripped rows `threeBlockComplRow` and the
+region rows `regionRegionRow` (at the fused blue/complement leg) of the two inserted
+matrices to agree, at every residual configuration.
+
+The hypothesis is read three ways: through the bridge
+`threeBlockInsertedCoeff_eq_iff_regionInsertedCoeff_eq` it is the three-block resonate
+equality, which the middle strip descends to equal complement-stripped rows
+(`threeBlock_middle_strip_descent`) and the red endpoint reads off to equal region rows
+(`threeBlock_red_readoff_eq_of_coeff_eq`). This is the residual-independent reconcile of
+the two endpoint read-offs, the region port of the edge step `V=W`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:inj_O->X_argument`,
+lines 355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlock_reconcile
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g)
+    (hcoeff : ∀ (σ : RegionPhysicalConfig (V := V) (d := d) D.red)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ D.red)),
+      regionInsertedCoeff (G := G) A D.red f M σ τ =
+        regionInsertedCoeff (G := G) A D.red f M' σ τ) :
+    (∀ (σred : RegionPhysicalConfig (V := V) (d := d) D.red)
+        (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue),
+      threeBlockComplRow (A := A) (e := e) D f M σred σblue =
+        threeBlockComplRow (A := A) (e := e) D f M' σred σblue) ∧
+      (∀ (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+          (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement),
+        regionRegionRow (G := G) A D.red f M
+            (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) =
+          regionRegionRow (G := G) A D.red f M'
+            (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) := by
+  have hthree := (threeBlockInsertedCoeff_eq_iff_regionInsertedCoeff_eq
+    (A := A) (e := e) D f M M').mpr hcoeff
+  refine ⟨fun σred σblue => ?_, fun σblue σcompl => ?_⟩
+  · exact threeBlock_middle_strip_descent (A := A) (e := e) D f M M' σred σblue hpos
+      (fun σcompl => hthree σred σblue σcompl)
+  · exact threeBlock_red_readoff_eq_of_coeff_eq (A := A) (e := e) D f M M' σblue σcompl
+      (fun σred => hthree σred σblue σcompl)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -1,0 +1,193 @@
+import TNLean.PEPS.RegionBlock.Recovery11
+import TNLean.PEPS.NormalEdgeBlockingData
+
+/-!
+# The three-block resonate engine for the normal PEPS Fundamental Theorem
+
+This file ports the edge-level resonate engine of `TNLean.PEPS.InsertionRealization`
+(`resonate_middle_inverted`, `resonate_invert_right_endpoint`,
+`resonate_invert_left_endpoint`, `resonate_endpoint_coeff_reconcile`) to the
+**three injective region blocks** of a `NormalEdgeBlockingData`: the red region `B₁`
+(one endpoint of the crossing edge `f`), the blue region `B₂` (the other endpoint),
+and the complementary region `B₃` (the middle).
+
+The source argument (arXiv:1804.04964, Section 3, Lemma `inj_isomorph`,
+`eq:resonate`--`eq:O->X`, lines 355--486 of `Papers/1804.04964/paper_normal.tex`)
+inserts a physical operator on a particle adjacent to the crossing edge `f`. The
+state-equality `eq:resonate` is read three ways:
+
+* inverting `B₂` and `B₃` reads the left operator off as a one-bond matrix action
+  `W` on the red endpoint;
+* inverting `B₁` and `B₃` reads the right operator off as a one-bond matrix action
+  `V` on the blue endpoint;
+* injectivity of all three blocks (and in particular the *shared* middle block
+  `B₃`) forces `V = W`.
+
+The middle block `B₃` is the new structural ingredient: it is a third, separately
+invertible block disjoint from both endpoints. The two-block frame (region `R`
+against its set complement `univ \ R`) cannot state the middle-strip step
+(`threeBlock_middle_strip`), which strips the middle block while keeping the red
+and blue endpoint residual configurations quantified independently.
+
+## Structure
+
+* `threeBlockComplPhysical` fuses the blue and complement physical legs into the
+  single complement leg over `univ \ red` consumed by the two-block backbone
+  (`regionInsertedCoeff`, `regionBlockedWeight`, the blocked left inverses).
+* `threeBlockInsertedCoeff` (Target 1) is the region analogue of
+  `regionInsertedCoeff` keeping the three physical legs `σred`, `σblue`, `σcompl`
+  open.
+* `threeBlockInsertedCoeff_eq_regionInsertedCoeff` (Target 2, the bridge) reads the
+  three-block coefficient as the two-block `regionInsertedCoeff` with `R := red`,
+  unlocking the entire two-block backbone.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d} {e : Edge G}
+
+/-! ### Fusing the blue and complement physical legs
+
+The two-block backbone contracts the region `red` against its set complement
+`univ \ red`, with a single complement physical leg `τ : RegionPhysicalConfig
+(univ \ red)`. The three-block engine keeps the blue and complement legs separate.
+Since `red`, `blue`, `complement` are pairwise disjoint and cover the vertex set,
+every vertex outside `red` lies in `blue` or in `complement`, so the two legs fuse
+into the single complement leg over `univ \ red`. -/
+
+/-- The complement physical leg over `univ \ red`, fused from a blue physical leg
+and a complement physical leg.
+
+A vertex `w ∉ red` lies in `blue` (then read `σblue`) or, failing that, in
+`complement` (then read `σcompl`); the cover and disjointness of the three blocks
+make this well defined.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def threeBlockComplPhysical
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ D.red) :=
+  fun w =>
+    if hb : w.1 ∈ D.blue then σblue ⟨w.1, hb⟩
+    else σcompl ⟨w.1, by
+      have hwnotred : w.1 ∉ D.red := (Finset.mem_sdiff.mp w.2).2
+      have hcover : w.1 ∈ D.red ∪ D.blue ∪ D.complement := by
+        rw [D.cover_univ]; exact Finset.mem_univ _
+      rcases Finset.mem_union.mp hcover with hrb | hc
+      · rcases Finset.mem_union.mp hrb with hr | hbl
+        · exact absurd hr hwnotred
+        · exact absurd hbl hb
+      · exact hc⟩
+
+/-- The fused complement leg reads a blue vertex off the blue physical leg. -/
+@[simp] theorem threeBlockComplPhysical_apply_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (w : {w : V // w ∈ Finset.univ \ D.red}) (hb : w.1 ∈ D.blue) :
+    threeBlockComplPhysical (A := A) (e := e) D σblue σcompl w = σblue ⟨w.1, hb⟩ := by
+  rw [threeBlockComplPhysical, dif_pos hb]
+
+/-- The fused complement leg reads a non-blue vertex off the complement physical
+leg. -/
+@[simp] theorem threeBlockComplPhysical_apply_not_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (w : {w : V // w ∈ Finset.univ \ D.red}) (hb : w.1 ∉ D.blue)
+    (hc : w.1 ∈ D.complement) :
+    threeBlockComplPhysical (A := A) (e := e) D σblue σcompl w = σcompl ⟨w.1, hc⟩ := by
+  rw [threeBlockComplPhysical, dif_neg hb]
+
+/-! ### The boundary edge of red carrying the inserted matrix
+
+The crossing edge `f` of a `NormalEdgeBlockingData` has its left endpoint in the red
+block and its right endpoint in the blue block (`left_mem_red`, `right_mem_blue`), so
+it crosses the boundary of `red`: exactly one endpoint lies in `red`. The inserted
+matrix is placed on this edge. -/
+
+/-- The crossing edge `e` of a `NormalEdgeBlockingData` is a boundary edge of the
+red block: its left endpoint lies in `red` and (since `red` and `blue` are disjoint
+and its right endpoint lies in `blue`) its right endpoint does not.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isRegionBoundaryEdge_red_edge
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    IsRegionBoundaryEdge (G := G) D.red e := by
+  refine Or.inl ⟨D.left_mem_red, ?_⟩
+  intro hr
+  exact (Finset.disjoint_left.mp D.red_disjoint_blue) hr D.right_mem_blue
+
+/-- The crossing edge of a `NormalEdgeBlockingData`, packaged as a boundary edge of
+the red block. -/
+def redBoundaryEdge (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f} :=
+  ⟨e, isRegionBoundaryEdge_red_edge (A := A) (e := e) D⟩
+
+@[simp] theorem redBoundaryEdge_coe
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    (redBoundaryEdge (A := A) (e := e) D : Edge G) = e := rfl
+
+/-! ### The three-block inserted coefficient
+
+Insert a matrix `M` on the crossing edge `f` (a boundary edge of the red block) and
+contract the three blocks `red`, `blue`, `complement` with three open physical legs.
+The blue and complement legs are fused into the single complement leg over
+`univ \ red` consumed by the two-block backbone, so the three-block coefficient is the
+two-block `regionInsertedCoeff` with `R := red`. -/
+
+/-- **The three-block inserted coefficient.** Insert `M` on the boundary edge `f` of
+the red block, contract `red` on one side and the fused `blue ∪ complement` on the
+other, keeping the three physical legs `σred`, `σblue`, `σcompl` open.
+
+This is the region analogue of `regionInsertedCoeff` (`TNLean.PEPS.RegionBlock.Insertion`)
+with the complement leg split along the blue/complement decomposition of `univ \ red`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:resonate`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def threeBlockInsertedCoeff
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σred : RegionPhysicalConfig (V := V) (d := d) D.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) : ℂ :=
+  regionInsertedCoeff (G := G) A D.red f M σred
+    (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)
+
+/-- **The three-block bridge.** The three-block inserted coefficient is the two-block
+`regionInsertedCoeff` of the red region against its set complement `univ \ red`, with
+the blue and complement physical legs fused into the single complement leg. This
+unlocks the entire two-block backbone for the three-block engine.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockInsertedCoeff_eq_regionInsertedCoeff
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σred : RegionPhysicalConfig (V := V) (d := d) D.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    threeBlockInsertedCoeff (A := A) (e := e) D f M σred σblue σcompl =
+      regionInsertedCoeff (G := G) A D.red f M σred
+        (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) :=
+  rfl
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.RegionBlock.Recovery11
+import TNLean.PEPS.RegionBlock.BlockRangeCoincidence
 import TNLean.PEPS.NormalEdgeBlockingData
 
 /-!
@@ -381,6 +382,120 @@ theorem regionBlockedTensorInjective_complement
     RegionBlockedTensorInjective (G := G) A D.complement := by
   have h := D.complement_injective
   rwa [regionInjectivityDataOf_isInjective] at h
+
+/-! ### The core region-blocking associativity factorization
+
+The blocked-region weight of the host `univ \ red` at the fused blue/complement
+physical leg, read **as a function of the complement physical leg** `σcompl`, lies
+in the range of the complement block's blocked-region tensor map. This is the
+foundational factorization that strips the complement (middle) block while keeping
+the red and blue residual configurations independent.
+
+The route is the host-relative analogue of `stateCoeff_eq_regionComplement`. The
+constrained global-configuration sum of the fused weight
+(`regionBlockedWeight_threeBlockComplPhysical_eq`) is grouped by the complement
+boundary configuration `bc'` a global configuration induces. On each fiber the blue
+and complement vertex products **decouple**, because the free interior edges of the
+blue block (blue-interior) and of the complement block (complement-interior) are
+disjoint: the complement part becomes the complement blocked-region weight at `bc'`,
+the blue part a `bc'`-coupled coefficient `blueCoeff`. The red tensors appear only
+as bond multiplicity. The fiber multiplicity collapses to the complement interior
+bond product, a nonzero constant, which is divided out to land the function in the
+complement block image.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+
+/-- The blue vertex product reads a global configuration only through the
+blue-incident edges, so it agrees with the configuration merged along the
+complement block, provided the two merged configurations agree on the complement
+boundary. The blue-incident edges that are also complement-incident are exactly the
+blue/complement crossing edges, which are boundary edges of the complement block,
+where the agreement forces the two configurations to coincide.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem blueProd_eq_regionMerge_complement
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (p : VirtualConfig A × VirtualConfig A)
+    (hp : regionBoundaryLabel (G := G) A D.complement p.1 =
+      regionBoundaryLabel (G := G) A D.complement p.2) :
+    (∏ w : {w : V // w ∈ D.blue}, A.component w.1 (fun ie => p.2 ie.1) (σblue w)) =
+      ∏ w : {w : V // w ∈ D.blue},
+        A.component w.1 (fun ie => regionMerge (G := G) A D.complement p ie.1) (σblue w) := by
+  classical
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1
+  funext ie
+  -- `ie` is incident to `w ∈ blue`, so `w ∉ complement`.
+  have hwblue : w.1 ∈ D.blue := w.2
+  have hwnotcompl : w.1 ∉ D.complement := fun hc =>
+    (Finset.disjoint_left.mp D.blue_disjoint_complement) hwblue hc
+  have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
+  by_cases hinc : IsRegionIncidentEdge (G := G) D.complement ie.1
+  · -- `ie` is complement-incident and touches `w ∉ complement`: a boundary edge of
+    -- the complement, where `p.1` and `p.2` agree.
+    have hbdry : IsRegionBoundaryEdge (G := G) D.complement ie.1 := by
+      rcases hinc with h1 | h2
+      · rcases hwinc with hw1 | hw2
+        · exact absurd (by rw [← hw1]; exact h1) hwnotcompl
+        · refine Or.inl ⟨h1, ?_⟩; rw [hw2]; exact hwnotcompl
+      · rcases hwinc with hw1 | hw2
+        · refine Or.inr ⟨?_, h2⟩; rw [hw1]; exact hwnotcompl
+        · exact absurd (by rw [← hw2]; exact h2) hwnotcompl
+    rw [regionMerge, if_pos hinc]
+    have := congrFun hp ⟨ie.1, hbdry⟩
+    simpa [regionBoundaryLabel] using this.symm
+  · rw [regionMerge, if_neg hinc]
+
+/-- On a boundary edge of the host `univ \ red`, the blue-side global configuration
+`p.2` agrees with the configuration merged along the complement block, provided the
+pair agrees on the complement boundary. A host boundary edge has one endpoint in
+`univ \ red` and one in `red`; if it is complement-incident it is a boundary edge of
+the complement (the red endpoint lies outside the complement), where the agreement
+pins it, and otherwise the merge reads it from `p.2` directly.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem hostLabel_p2_eq_hostLabel_regionMerge_complement
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (p : VirtualConfig A × VirtualConfig A)
+    (hp : regionBoundaryLabel (G := G) A D.complement p.1 =
+      regionBoundaryLabel (G := G) A D.complement p.2) :
+    regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 =
+      regionBoundaryLabel (G := G) A (Finset.univ \ D.red)
+        (regionMerge (G := G) A D.complement p) := by
+  classical
+  funext f
+  simp only [regionBoundaryLabel_apply]
+  by_cases hinc : IsRegionIncidentEdge (G := G) D.complement f.1
+  · -- A complement-incident host boundary edge is a boundary edge of the complement.
+    have hbdry : IsRegionBoundaryEdge (G := G) D.complement f.1 := by
+      -- The host-side endpoint that lies in `univ \ red` is the complement endpoint;
+      -- the red endpoint lies outside the complement.
+      rcases f.2 with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
+      · -- `f.1.1 ∈ univ \ red`, `f.1.2 ∉ univ \ red` i.e. `f.1.2 ∈ red`.
+        have h2red : f.1.1.2 ∈ D.red := by
+          have := h2nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          exact this (Finset.mem_univ _)
+        have h2notcompl : f.1.1.2 ∉ D.complement := fun hc =>
+          (Finset.disjoint_left.mp D.red_disjoint_complement) h2red hc
+        rcases hinc with hc1 | hc2
+        · refine Or.inl ⟨hc1, h2notcompl⟩
+        · exact absurd hc2 h2notcompl
+      · have h1red : f.1.1.1 ∈ D.red := by
+          have := h1nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          exact this (Finset.mem_univ _)
+        have h1notcompl : f.1.1.1 ∉ D.complement := fun hc =>
+          (Finset.disjoint_left.mp D.red_disjoint_complement) h1red hc
+        rcases hinc with hc1 | hc2
+        · exact absurd hc1 h1notcompl
+        · refine Or.inr ⟨h1notcompl, hc2⟩
+    rw [regionMerge, if_pos hinc]
+    have := congrFun hp ⟨f.1, hbdry⟩
+    simpa [regionBoundaryLabel] using this.symm
+  · rw [regionMerge, if_neg hinc]
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -233,6 +233,33 @@ theorem prod_sdiff_red_eq_blue_mul_complement
       sdiff_red_eq_blue_union_complement (A := A) (e := e) D,
       Finset.prod_union D.blue_disjoint_complement]
 
+/-- **The fused complement weight as a blue/complement double product sum.** The
+blocked-region weight of `univ \ red` at the fused blue/complement physical leg
+unfolds to the single constrained sum over global virtual configurations of the
+blue product (read with `σblue`) times the complement product (read with
+`σcompl`). This is `regionBlockedWeight` for `univ \ red` with the vertex product
+split along `univ \ red = blue ⊔ complement`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedWeight_threeBlockComplPhysical_eq
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+        (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) =
+      ∑ ζ ∈ Finset.univ.filter
+          (fun ζ : VirtualConfig A =>
+            regionBoundaryLabel (G := G) A (Finset.univ \ D.red) ζ = bdry),
+        (∏ w : {w : V // w ∈ D.blue},
+            A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
+          ∏ w : {w : V // w ∈ D.complement},
+            A.component w.1 (fun ie => ζ ie.1) (σcompl w) := by
+  rw [regionBlockedWeight]
+  refine Finset.sum_congr rfl (fun ζ _ => ?_)
+  exact prod_sdiff_red_eq_blue_mul_complement (A := A) (e := e) D σblue σcompl ζ
+
 /-! ### The boundary edge of red carrying the inserted matrix
 
 The crossing edge `f` of a `NormalEdgeBlockingData` has its left endpoint in the red

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -497,5 +497,59 @@ theorem hostLabel_p2_eq_hostLabel_regionMerge_complement
     simpa [regionBoundaryLabel] using this.symm
   · rw [regionMerge, if_neg hinc]
 
+open scoped Classical in
+/-- **The host-relative fiber cardinality.** Among the boundary-agreeing pairs of
+global configurations whose blue-side host label is `bdry`, the fiber over a merged
+configuration `η` of the complement merge has cardinality the complement interior
+bond product when `η` itself has host label `bdry`, and is empty otherwise.
+
+The host constraint on the blue side is implied by the merge identity and the
+complement-boundary agreement (`hostLabel_p2_eq_hostLabel_regionMerge_complement`),
+so on the compatible fibers the count is the unconstrained complement fiber count
+`regionFiber_card`; on the incompatible fibers the host constraint clashes with the
+merge, emptying the fiber.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockFiber_card
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (η : VirtualConfig A) :
+    (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+        regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+          (regionBoundaryLabel (G := G) A D.complement p.1 =
+              regionBoundaryLabel (G := G) A D.complement p.2 ∧
+            regionMerge (G := G) A D.complement p = η))).card =
+      if regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry then
+        regionInteriorBondProd (G := G) A D.complement else 0 := by
+  classical
+  -- The host label of the blue side is the host label of the merge on this fiber.
+  by_cases hcompat : regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry
+  · rw [if_pos hcompat]
+    -- The host constraint is implied by the agreement and the merge identity.
+    rw [show (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            (regionBoundaryLabel (G := G) A D.complement p.1 =
+                regionBoundaryLabel (G := G) A D.complement p.2 ∧
+              regionMerge (G := G) A D.complement p = η))) =
+        Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+          (regionBoundaryLabel (G := G) A D.complement p.1 =
+              regionBoundaryLabel (G := G) A D.complement p.2 ∧
+            regionMerge (G := G) A D.complement p = η)) from ?_]
+    · exact regionFiber_card (G := G) A D.complement η
+    · refine Finset.filter_congr (fun p _ => ?_)
+      constructor
+      · rintro ⟨_, hagree, hmerge⟩; exact ⟨hagree, hmerge⟩
+      · rintro ⟨hagree, hmerge⟩
+        refine ⟨?_, hagree, hmerge⟩
+        rw [hostLabel_p2_eq_hostLabel_regionMerge_complement (A := A) (e := e) D p hagree,
+          hmerge, hcompat]
+  · rw [if_neg hcompat]
+    rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+    rintro p _ ⟨hhost, hagree, hmerge⟩
+    apply hcompat
+    rw [← hmerge,
+      ← hostLabel_p2_eq_hostLabel_regionMerge_complement (A := A) (e := e) D p hagree, hhost]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -189,5 +189,51 @@ theorem threeBlockInsertedCoeff_eq_regionInsertedCoeff
         (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) :=
   rfl
 
+/-! ### The three blocked-tensor injectivity engines
+
+The three blocks of a `NormalEdgeBlockingData` are each injective. Under the
+concrete region-injectivity predicate `regionInjectivityDataOf A`, this means each
+block is blocked-tensor injective (`RegionBlockedTensorInjective`), which is exactly
+injectivity of the corresponding blocked tensor map and so supplies the chosen
+left inverse `regionBlockedLeftInverse`. These are the three contraction-inverse
+engines the middle-strip step (inverting the complement block `B₃`) and the two
+endpoint inversions (inverting the blue block `B₂`, then the red block `B₁`) consume.
+
+This is the region analogue of the three edge-level inverses
+`edgeMiddleLeftInverse` / `localLeftInverseAt` of
+`TNLean.PEPS.InsertionRealization`, now at region-block granularity. -/
+
+/-- The red block `B₁` of a `NormalEdgeBlockingData` is blocked-tensor injective.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorInjective_red
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    RegionBlockedTensorInjective (G := G) A D.red := by
+  have h := D.red_injective
+  rwa [regionInjectivityDataOf_isInjective] at h
+
+/-- The blue block `B₂` of a `NormalEdgeBlockingData` is blocked-tensor injective.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorInjective_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    RegionBlockedTensorInjective (G := G) A D.blue := by
+  have h := D.blue_injective
+  rwa [regionInjectivityDataOf_isInjective] at h
+
+/-- The complement block `B₃` of a `NormalEdgeBlockingData` is blocked-tensor
+injective. This is the separately invertible middle block disjoint from both edge
+endpoints, the structural ingredient the two-block frame lacks.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorInjective_complement
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    RegionBlockedTensorInjective (G := G) A D.complement := by
+  have h := D.complement_injective
+  rwa [regionInjectivityDataOf_isInjective] at h
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -551,5 +551,140 @@ theorem threeBlockFiber_card
     rw [← hmerge,
       ← hostLabel_p2_eq_hostLabel_regionMerge_complement (A := A) (e := e) D p hagree, hhost]
 
+open scoped Classical in
+/-- **The host-relative merge collapse.** The boundary-agreeing double sum of the
+complement vertex product against the blue vertex product, with the blue side
+constrained to the host label `bdry`, collapses to the complement interior bond
+product times the single constrained sum of the complement against the blue product
+over global configurations with host label `bdry`. This is the multiplicity collapse
+behind the three-block factorization, mirroring `stateCoeff_eq_regionComplement` in
+the host-relative frame.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockDoubleSum_eq_smul_single
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (∑ p ∈ Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.complement p.1 =
+              regionBoundaryLabel (G := G) A D.complement p.2),
+      (∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => p.1 ie.1) (σcompl w)) *
+        ∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => p.2 ie.1) (σblue w)) =
+      regionInteriorBondProd (G := G) A D.complement •
+        ∑ ζ ∈ Finset.univ.filter
+            (fun ζ : VirtualConfig A =>
+              regionBoundaryLabel (G := G) A (Finset.univ \ D.red) ζ = bdry),
+          (∏ w : {w : V // w ∈ D.complement},
+              A.component w.1 (fun ie => ζ ie.1) (σcompl w)) *
+            ∏ w : {w : V // w ∈ D.blue},
+              A.component w.1 (fun ie => ζ ie.1) (σblue w) := by
+  classical
+  -- Read each agreeing summand through the merged configuration.
+  rw [show (∑ p ∈ Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.complement p.1 =
+              regionBoundaryLabel (G := G) A D.complement p.2),
+      (∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => p.1 ie.1) (σcompl w)) *
+        ∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => p.2 ie.1) (σblue w)) =
+      ∑ p ∈ Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.complement p.1 =
+              regionBoundaryLabel (G := G) A D.complement p.2),
+        (∏ w : {w : V // w ∈ D.complement},
+            A.component w.1 (fun ie => regionMerge (G := G) A D.complement p ie.1) (σcompl w)) *
+          ∏ w : {w : V // w ∈ D.blue},
+            A.component w.1
+              (fun ie => regionMerge (G := G) A D.complement p ie.1) (σblue w) from ?_]
+  · -- Group the agreeing pairs by their merged configuration.
+    rw [← Finset.sum_fiberwise (Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.complement p.1 =
+              regionBoundaryLabel (G := G) A D.complement p.2))
+      (fun p => regionMerge (G := G) A D.complement p)
+      (fun p =>
+        (∏ w : {w : V // w ∈ D.complement},
+            A.component w.1 (fun ie => regionMerge (G := G) A D.complement p ie.1) (σcompl w)) *
+          ∏ w : {w : V // w ∈ D.blue},
+            A.component w.1
+              (fun ie => regionMerge (G := G) A D.complement p ie.1) (σblue w))]
+    -- Compare the η-indexed sums on both sides.
+    rw [show (regionInteriorBondProd (G := G) A D.complement •
+          ∑ ζ ∈ Finset.univ.filter
+              (fun ζ : VirtualConfig A =>
+                regionBoundaryLabel (G := G) A (Finset.univ \ D.red) ζ = bdry),
+            (∏ w : {w : V // w ∈ D.complement},
+                A.component w.1 (fun ie => ζ ie.1) (σcompl w)) *
+              ∏ w : {w : V // w ∈ D.blue},
+                A.component w.1 (fun ie => ζ ie.1) (σblue w)) =
+        ∑ η : VirtualConfig A,
+          regionInteriorBondProd (G := G) A D.complement •
+            (if regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry then
+              (∏ w : {w : V // w ∈ D.complement},
+                  A.component w.1 (fun ie => η ie.1) (σcompl w)) *
+                ∏ w : {w : V // w ∈ D.blue},
+                  A.component w.1 (fun ie => η ie.1) (σblue w)
+              else 0) from ?_]
+    · refine Finset.sum_congr rfl (fun η _ => ?_)
+      rw [Finset.filter_filter,
+        Finset.sum_congr rfl (g := fun _ =>
+            (∏ w : {w : V // w ∈ D.complement},
+                A.component w.1 (fun ie => η ie.1) (σcompl w)) *
+              ∏ w : {w : V // w ∈ D.blue},
+                A.component w.1 (fun ie => η ie.1) (σblue w))
+          (fun p hp => by rw [Finset.mem_filter] at hp; rw [hp.2.2]),
+        Finset.sum_const]
+      -- The fiber count is the conditional complement interior bond product.
+      rw [show (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+            (regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+                regionBoundaryLabel (G := G) A D.complement p.1 =
+                  regionBoundaryLabel (G := G) A D.complement p.2) ∧
+              regionMerge (G := G) A D.complement p = η)) =
+          Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+            regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+              (regionBoundaryLabel (G := G) A D.complement p.1 =
+                  regionBoundaryLabel (G := G) A D.complement p.2 ∧
+                regionMerge (G := G) A D.complement p = η)) from by
+          refine Finset.filter_congr (fun p _ => ?_); tauto,
+        threeBlockFiber_card (A := A) (e := e) D bdry η]
+      by_cases hcompat : regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry
+      · rw [if_pos hcompat, if_pos hcompat]
+      · rw [if_neg hcompat, if_neg hcompat, zero_smul, smul_zero]
+    · rw [Finset.smul_sum, ← Finset.sum_filter_add_sum_filter_not Finset.univ
+          (fun η : VirtualConfig A =>
+            regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry)]
+      rw [show (∑ η ∈ Finset.univ.filter
+            (fun η : VirtualConfig A =>
+              ¬ regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry),
+          regionInteriorBondProd (G := G) A D.complement •
+            (if regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry then
+              (∏ w : {w : V // w ∈ D.complement},
+                  A.component w.1 (fun ie => η ie.1) (σcompl w)) *
+                ∏ w : {w : V // w ∈ D.blue},
+                  A.component w.1 (fun ie => η ie.1) (σblue w)
+              else 0)) = 0 from ?_,
+        add_zero]
+      · refine Finset.sum_congr rfl (fun η hη => ?_)
+        rw [Finset.mem_filter] at hη
+        rw [if_pos hη.2]
+      · refine Finset.sum_eq_zero (fun η hη => ?_)
+        rw [Finset.mem_filter] at hη
+        rw [if_neg hη.2, smul_zero]
+  · -- Each agreeing summand is the merged summand at the merged configuration.
+    refine Finset.sum_congr rfl (fun p hp => ?_)
+    rw [Finset.mem_filter] at hp
+    rw [regionProd_eq_merge (G := G) A D.complement σcompl p,
+      blueProd_eq_regionMerge_complement (A := A) (e := e) D σblue p hp.2.2]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -814,5 +814,68 @@ theorem regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical
   refine Finset.sum_congr rfl (fun bc' _ => ?_)
   rw [smul_eq_mul, mul_comm]
 
+open scoped Classical in
+/-- **The core three-block smul-factorization (as functions of `σcompl`).** The
+complement interior bond multiple of the fused host weight, read as a function of the
+complement physical leg, is the blue-coupling combination of the complement
+blocked-region weights. This is the function-level form of the pointwise factorization,
+ready for the divide-out into the complement block image.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_smul_threeBlockComplWeight_eq
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue) :
+    (regionInteriorBondProd (G := G) A D.complement : ℂ) •
+        (fun σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement =>
+          regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+            (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) =
+      ∑ bc' : RegionBoundaryConfig (G := G) A D.complement,
+        threeBlockBlueCoeff (A := A) (e := e) D bdry σblue bc' •
+          regionBlockedWeight (G := G) A D.complement bc' := by
+  funext σcompl
+  rw [Pi.smul_apply, Finset.sum_apply,
+    regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical
+      (A := A) (e := e) D bdry σblue σcompl]
+  refine Finset.sum_congr rfl (fun bc' _ => ?_)
+  rw [Pi.smul_apply]
+
+/-- **The core region-blocking associativity factorization.** The fused host weight
+`regionBlockedWeight A (univ \ red) bdry (threeBlockComplPhysical D σblue σcompl)`,
+read as a function of the complement physical leg `σcompl`, lies in the range of the
+complement block's blocked-region tensor map. This is the foundational factorization
+that strips the complement (middle) block while keeping the red and blue residual
+configurations independent, unblocking the three-block middle strip for the normal
+PEPS Fundamental Theorem.
+
+The complement interior bond multiple of the function is the blue-coupling combination
+of the complement blocked-region weights
+(`regionInteriorBondProd_smul_threeBlockComplWeight_eq`), each of which lies in the
+range (`range_regionBlockedTensorMap_eq_span`); dividing out the nonzero interior bond
+multiplicity (positive bond dimensions) lands the function itself in the range.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedWeight_threeBlockComplPhysical_mem_range
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (hpos : ∀ f : Edge G, 0 < A.bondDim f) :
+    (fun σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement =>
+        regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+          (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) ∈
+      LinearMap.range (regionBlockedTensorMap (G := G) A D.complement) := by
+  classical
+  rw [range_regionBlockedTensorMap_eq_span (G := G) A D.complement]
+  have hne : (regionInteriorBondProd (G := G) A D.complement : ℂ) ≠ 0 := by
+    have hpos' : 0 < regionInteriorBondProd (G := G) A D.complement :=
+      regionInteriorBondProd_pos (G := G) A D.complement hpos
+    exact_mod_cast hpos'.ne'
+  rw [← Submodule.smul_mem_iff _ hne,
+    regionInteriorBondProd_smul_threeBlockComplWeight_eq (A := A) (e := e) D bdry σblue]
+  refine Submodule.sum_mem _ (fun bc' _ => ?_)
+  exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨bc', rfl⟩)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -766,5 +766,53 @@ theorem threeBlockDoubleSum_eq_blueCoeff_sum
     obtain ⟨hp, hhost, hq⟩ := hpq
     exact ⟨⟨hhost, hp.trans hq.symm⟩, hp⟩
 
+open scoped Classical in
+/-- **The core three-block smul-factorization (pointwise).** The complement interior
+bond multiple of the fused host weight, at a fixed complement physical leg `σcompl`,
+is the sum over complement boundary configurations of the blue coupling coefficient
+times the complement blocked-region weight. Combines the merge collapse and the
+decoupling, after splitting the fused host weight along `univ \ red = blue ⊔
+complement` (`regionBlockedWeight_threeBlockComplPhysical_eq`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (regionInteriorBondProd (G := G) A D.complement : ℂ) •
+        regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+          (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) =
+      ∑ bc' : RegionBoundaryConfig (G := G) A D.complement,
+        threeBlockBlueCoeff (A := A) (e := e) D bdry σblue bc' •
+          regionBlockedWeight (G := G) A D.complement bc' σcompl := by
+  classical
+  -- Split the fused host weight along `univ \ red = blue ⊔ complement` and commute
+  -- the blue/complement product order to match the merge-collapse convention.
+  rw [regionBlockedWeight_threeBlockComplPhysical_eq (A := A) (e := e) D bdry σblue σcompl,
+    show (∑ ζ ∈ Finset.univ.filter
+          (fun ζ : VirtualConfig A =>
+            regionBoundaryLabel (G := G) A (Finset.univ \ D.red) ζ = bdry),
+        (∏ w : {w : V // w ∈ D.blue},
+            A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
+          ∏ w : {w : V // w ∈ D.complement},
+            A.component w.1 (fun ie => ζ ie.1) (σcompl w)) =
+      ∑ ζ ∈ Finset.univ.filter
+          (fun ζ : VirtualConfig A =>
+            regionBoundaryLabel (G := G) A (Finset.univ \ D.red) ζ = bdry),
+        (∏ w : {w : V // w ∈ D.complement},
+            A.component w.1 (fun ie => ζ ie.1) (σcompl w)) *
+          ∏ w : {w : V // w ∈ D.blue},
+            A.component w.1 (fun ie => ζ ie.1) (σblue w) from
+      Finset.sum_congr rfl (fun ζ _ => mul_comm _ _)]
+  -- The smul of the single sum is the boundary-agreeing double sum (merge collapse),
+  -- which decouples into the blue coupling against the complement weight.
+  rw [smul_eq_mul, ← nsmul_eq_mul,
+    ← threeBlockDoubleSum_eq_smul_single (A := A) (e := e) D bdry σblue σcompl,
+    threeBlockDoubleSum_eq_blueCoeff_sum (A := A) (e := e) D bdry σblue σcompl]
+  refine Finset.sum_congr rfl (fun bc' _ => ?_)
+  rw [smul_eq_mul, mul_comm]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -686,5 +686,85 @@ theorem threeBlockDoubleSum_eq_smul_single
     rw [regionProd_eq_merge (G := G) A D.complement σcompl p,
       blueProd_eq_regionMerge_complement (A := A) (e := e) D σblue p hp.2.2]
 
+open scoped Classical in
+/-- **The blue coupling coefficient.** The blue vertex product summed over all global
+configurations whose host label is `bdry` and whose complement boundary label is the
+prescribed `bc'`. This is the blue-block contraction coupled to the complement
+boundary configuration through the blue/complement crossing bonds, the coefficient of
+the complement blocked-region weight in the three-block factorization.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def threeBlockBlueCoeff
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (bc' : RegionBoundaryConfig (G := G) A D.complement) : ℂ :=
+  ∑ q ∈ Finset.univ.filter
+      (fun q : VirtualConfig A =>
+        regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+          regionBoundaryLabel (G := G) A D.complement q = bc'),
+    ∏ w : {w : V // w ∈ D.blue}, A.component w.1 (fun ie => q ie.1) (σblue w)
+
+open scoped Classical in
+/-- **The host-relative decoupling.** The boundary-agreeing double sum of the
+complement vertex product against the host-constrained blue vertex product decouples,
+grouped by the complement boundary configuration `bc'`, into the complement
+blocked-region weight at `bc'` against the blue coupling coefficient. The decoupling
+holds because the complement product reads a global configuration only through the
+complement-incident edges and the blue product only through the blue-incident edges,
+which are coupled only through the shared blue/complement crossing bonds recorded by
+`bc'`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockDoubleSum_eq_blueCoeff_sum
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (∑ p ∈ Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.complement p.1 =
+              regionBoundaryLabel (G := G) A D.complement p.2),
+      (∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => p.1 ie.1) (σcompl w)) *
+        ∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => p.2 ie.1) (σblue w)) =
+      ∑ bc' : RegionBoundaryConfig (G := G) A D.complement,
+        regionBlockedWeight (G := G) A D.complement bc' σcompl *
+          threeBlockBlueCoeff (A := A) (e := e) D bdry σblue bc' := by
+  classical
+  -- Group the agreeing pairs by the complement boundary label of the complement side.
+  rw [← Finset.sum_fiberwise (Finset.univ.filter
+      (fun p : VirtualConfig A × VirtualConfig A =>
+        regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+          regionBoundaryLabel (G := G) A D.complement p.1 =
+            regionBoundaryLabel (G := G) A D.complement p.2))
+    (fun p => regionBoundaryLabel (G := G) A D.complement p.1)
+    (fun p =>
+      (∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => p.1 ie.1) (σcompl w)) *
+        ∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => p.2 ie.1) (σblue w))]
+  refine Finset.sum_congr rfl (fun bc' _ => ?_)
+  -- On the `bc'` fiber the complement and blue constraints separate.
+  rw [regionBlockedWeight, threeBlockBlueCoeff, Finset.sum_mul_sum]
+  -- Reindex the product over `(p, q)` against the separated double sum.
+  rw [Finset.filter_filter, ← Finset.sum_product']
+  refine Finset.sum_nbij' (fun p => (p.1, p.2)) (fun p => (p.1, p.2)) ?_ ?_
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+  · -- A `bc'`-fiber pair maps to the separated product index set.
+    rintro ⟨p, q⟩ hpq
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
+    obtain ⟨⟨hhost, hagree⟩, hbc⟩ := hpq
+    exact ⟨hbc, hhost, hbc ▸ hagree.symm⟩
+  · -- A separated product index maps back to a `bc'`-fiber pair.
+    rintro ⟨p, q⟩ hpq
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
+    obtain ⟨hp, hhost, hq⟩ := hpq
+    exact ⟨⟨hhost, hp.trans hq.symm⟩, hp⟩
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -113,6 +113,126 @@ leg. -/
     threeBlockComplPhysical (A := A) (e := e) D σblue σcompl w = σcompl ⟨w.1, hc⟩ := by
   rw [threeBlockComplPhysical, dif_neg hb]
 
+/-! ### The disjoint cover of `univ \ red` by blue and complement
+
+The set complement of the red block decomposes as the disjoint union of the blue
+and complement blocks. This is the geometric fact underlying the weight
+factorization: contracting over `univ \ red` is contracting over `blue` and then
+over `complement`. -/
+
+/-- The set complement of the red block is the disjoint union of the blue and
+complement blocks.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem sdiff_red_eq_blue_union_complement
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    Finset.univ \ D.red = D.blue ∪ D.complement := by
+  ext w
+  simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_union]
+  constructor
+  · intro hwnotred
+    have hcover : w ∈ D.red ∪ D.blue ∪ D.complement := by
+      rw [D.cover_univ]; exact Finset.mem_univ _
+    rcases Finset.mem_union.mp hcover with hrb | hc
+    · rcases Finset.mem_union.mp hrb with hr | hbl
+      · exact absurd hr hwnotred
+      · exact Or.inl hbl
+    · exact Or.inr hc
+  · intro hbc hr
+    rcases hbc with hbl | hc
+    · exact (Finset.disjoint_left.mp D.red_disjoint_blue) hr hbl
+    · exact (Finset.disjoint_left.mp D.red_disjoint_complement) hr hc
+
+/-- **The vertex-product split over `univ \ red`.** For any global virtual
+configuration `ζ`, the product of the vertex tensors over `univ \ red`, read with
+the fused blue/complement physical leg, factors as the blue product (read with
+`σblue`) times the complement product (read with `σcompl`). This is the disjoint
+decomposition `univ \ red = blue ⊔ complement` applied to the contraction.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem prod_sdiff_red_eq_blue_mul_complement
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (ζ : VirtualConfig A) :
+    (∏ w : {w : V // w ∈ Finset.univ \ D.red},
+        A.component w.1 (fun ie => ζ ie.1)
+          (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl w)) =
+      (∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
+        ∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => ζ ie.1) (σcompl w) := by
+  classical
+  -- A total physical leg agreeing with `σblue` on blue and `σcompl` on complement.
+  -- The value on red vertices is never read by the products below.
+  rcases isEmpty_or_nonempty (Fin d) with hd | hd
+  · -- With no physical index, a vertex in any block forces a contradiction.
+    have hblue : IsEmpty {w : V // w ∈ D.blue} := by
+      constructor; intro w; exact hd.elim (σblue w)
+    have hcompl : IsEmpty {w : V // w ∈ D.complement} := by
+      constructor; intro w; exact hd.elim (σcompl w)
+    have hsdiff : IsEmpty {w : V // w ∈ Finset.univ \ D.red} := by
+      constructor; intro w
+      exact hd.elim (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl w)
+    rw [Finset.prod_of_isEmpty, Finset.prod_of_isEmpty, Finset.prod_of_isEmpty, one_mul]
+  · set g : V → Fin d := fun w =>
+      if hb : w ∈ D.blue then σblue ⟨w, hb⟩
+      else if hc : w ∈ D.complement then σcompl ⟨w, hc⟩
+      else Classical.arbitrary (Fin d) with hg
+    -- The fused leg on `univ \ red` agrees with `g`.
+    have hsdiff : (∏ w : {w : V // w ∈ Finset.univ \ D.red},
+          A.component w.1 (fun ie => ζ ie.1)
+            (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl w)) =
+        ∏ w : {w : V // w ∈ Finset.univ \ D.red},
+          A.component w.1 (fun ie => ζ ie.1) (g w.1) := by
+      refine Finset.prod_congr rfl (fun w _ => ?_)
+      congr 1
+      by_cases hb : w.1 ∈ D.blue
+      · rw [threeBlockComplPhysical_apply_blue (A := A) (e := e) D σblue σcompl w hb,
+          hg]
+        simp only [dif_pos hb]
+      · have hwnotred : w.1 ∉ D.red := (Finset.mem_sdiff.mp w.2).2
+        have hc : w.1 ∈ D.complement := by
+          have hcover : w.1 ∈ D.red ∪ D.blue ∪ D.complement := by
+            rw [D.cover_univ]; exact Finset.mem_univ _
+          rcases Finset.mem_union.mp hcover with hrb | hc
+          · rcases Finset.mem_union.mp hrb with hr | hbl
+            · exact absurd hr hwnotred
+            · exact absurd hbl hb
+          · exact hc
+        rw [threeBlockComplPhysical_apply_not_blue (A := A) (e := e) D σblue σcompl w hb hc,
+          hg]
+        simp only [dif_neg hb, dif_pos hc]
+    -- The blue and complement subtype products read `g` on their vertices.
+    have hblue : (∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => ζ ie.1) (σblue w)) =
+        ∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => ζ ie.1) (g w.1) := by
+      refine Finset.prod_congr rfl (fun w _ => ?_)
+      congr 1
+      rw [hg]; simp only [dif_pos w.2]
+    have hcompl : (∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => ζ ie.1) (σcompl w)) =
+        ∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => ζ ie.1) (g w.1) := by
+      refine Finset.prod_congr rfl (fun w _ => ?_)
+      congr 1
+      have hb : w.1 ∉ D.blue := fun h =>
+        (Finset.disjoint_left.mp D.blue_disjoint_complement) h w.2
+      rw [hg]; simp only [dif_neg hb, dif_pos w.2]
+    rw [hsdiff, hblue, hcompl]
+    -- Convert the three subtype products to `Finset.prod` and split the union.
+    rw [← Finset.prod_subtype (Finset.univ \ D.red) (fun x => Iff.rfl)
+        (fun w => A.component w (fun ie => ζ ie.1) (g w)),
+      ← Finset.prod_subtype D.blue (fun x => Iff.rfl)
+        (fun w => A.component w (fun ie => ζ ie.1) (g w)),
+      ← Finset.prod_subtype D.complement (fun x => Iff.rfl)
+        (fun w => A.component w (fun ie => ζ ie.1) (g w)),
+      sdiff_red_eq_blue_union_complement (A := A) (e := e) D,
+      Finset.prod_union D.blue_disjoint_complement]
+
 /-! ### The boundary edge of red carrying the inserted matrix
 
 The crossing edge `f` of a `NormalEdgeBlockingData` has its left endpoint in the red

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
@@ -609,5 +609,65 @@ theorem regionBlockedWeight_threeBlockBluePhysical_mem_range
   refine Submodule.sum_mem _ (fun bβ _ => ?_)
   exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨bβ, rfl⟩)
 
+/-! ### The blue endpoint inversion
+
+Reading the σblue-function of the fused host weight through the blue block's chosen
+left inverse reads the complement coupling coefficient `threeBlockComplCoeff` off as
+the blue inversion, at a fixed complement physical leg. This is the region analogue
+of `resonate_invert_right_endpoint` (`TNLean.PEPS.InsertionRealization`) and the
+single-block analogue of `transferCoeff_column_eq_regionBlockedLeftInverse_vSideRow`
+(`TNLean.PEPS.RegionBlock.Recovery11`), now at the blue endpoint block. -/
+
+open scoped Classical in
+/-- **The fused host weight through the blue blocked map.** The blue interior bond
+multiple of the σblue-function of the fused host weight is the blue blocked tensor
+map applied to the complement coupling row `fun bβ => threeBlockComplCoeff D bdry
+σcompl bβ`. This restates `regionInteriorBondProd_smul_threeBlockBlueWeight_eq` in
+blocked-tensor-map form, ready for the blue left inverse. -/
+theorem regionInteriorBondProd_smul_threeBlockBlueWeight_eq_blockedMap
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (regionInteriorBondProd (G := G) A D.blue : ℂ) •
+        (fun σblue : RegionPhysicalConfig (V := V) (d := d) D.blue =>
+          regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+            (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) =
+      regionBlockedTensorMap (G := G) A D.blue
+        (fun bβ => threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ) := by
+  classical
+  rw [regionInteriorBondProd_smul_threeBlockBlueWeight_eq (A := A) (e := e) D bdry σcompl]
+  funext σblue
+  rw [Finset.sum_apply, regionBlockedTensorMap_apply]
+  refine Finset.sum_congr rfl (fun bβ _ => ?_)
+  rw [Pi.smul_apply]
+
+/-- **The blue endpoint inversion.** The blue block's chosen left inverse, applied to
+the σblue-function of the fused host weight and scaled by the blue interior bond
+product, recovers the complement coupling row `fun bβ => threeBlockComplCoeff D bdry
+σcompl bβ`. This reads the complement-side contraction off through the blue block,
+keeping the complement physical leg `σcompl` and host residual `bdry` fixed.
+
+The blue interior bond multiple of the σblue-function is the blue blocked tensor map
+of the complement coupling row
+(`regionInteriorBondProd_smul_threeBlockBlueWeight_eq_blockedMap`), and the blue
+block's chosen left inverse recovers the row
+(`regionBlockedLeftInverse_apply_regionBlockedTensorMap`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:inj_O->X_argument`,
+lines 355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlock_invert_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (regionInteriorBondProd (G := G) A D.blue : ℂ) •
+        regionBlockedLeftInverse (G := G) A D.blue
+          (regionBlockedTensorInjective_blue (A := A) (e := e) D)
+          (fun σblue => regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+            (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) =
+      fun bβ => threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ := by
+  rw [← map_smul,
+    regionInteriorBondProd_smul_threeBlockBlueWeight_eq_blockedMap (A := A) (e := e) D bdry σcompl,
+    regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
@@ -183,5 +183,431 @@ theorem threeBlock_middle_strip
     regionInteriorBondProd_smul_threeBlockInsertedCoeff_eq (A := A) (e := e) D f M σred σblue,
     regionBlockedLeftInverse_apply_regionBlockedTensorMap]
 
+/-! ### The blue-block factorization of the fused host weight
+
+The fused host weight, read as a function of the *blue* physical leg `σblue` (with
+the complement leg `σcompl` fixed), lies in the range of the blue block's
+blocked-region tensor map. This is the blue-block mirror of the core factorization
+`regionBlockedWeight_threeBlockComplPhysical_mem_range`: the same host weight, now
+inverted along the blue block rather than the complement block, with the complement
+block supplying the coupling coefficient `threeBlockComplCoeff`.
+
+The development mirrors the complement collapse of `ThreeBlockResonate.lean` with the
+roles of the blue and complement blocks exchanged: the merge is taken along the blue
+block, the coupling runs through the complement vertex products, and the fiber
+multiplicity collapses to the blue interior bond product. -/
+
+/-- The complement vertex product reads a global configuration only through the
+complement-incident edges, so it agrees with the configuration merged along the blue
+block, provided the two configurations agree on the blue boundary. This is the blue
+mirror of `blueProd_eq_regionMerge_complement`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem complProd_eq_regionMerge_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (p : VirtualConfig A × VirtualConfig A)
+    (hp : regionBoundaryLabel (G := G) A D.blue p.1 =
+      regionBoundaryLabel (G := G) A D.blue p.2) :
+    (∏ w : {w : V // w ∈ D.complement}, A.component w.1 (fun ie => p.2 ie.1) (σcompl w)) =
+      ∏ w : {w : V // w ∈ D.complement},
+        A.component w.1 (fun ie => regionMerge (G := G) A D.blue p ie.1) (σcompl w) := by
+  classical
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1
+  funext ie
+  -- `ie` is incident to `w ∈ complement`, so `w ∉ blue`.
+  have hwcompl : w.1 ∈ D.complement := w.2
+  have hwnotblue : w.1 ∉ D.blue := fun hb =>
+    (Finset.disjoint_left.mp D.blue_disjoint_complement) hb hwcompl
+  have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
+  by_cases hinc : IsRegionIncidentEdge (G := G) D.blue ie.1
+  · -- `ie` is blue-incident and touches `w ∉ blue`: a boundary edge of the blue block,
+    -- where `p.1` and `p.2` agree.
+    have hbdry : IsRegionBoundaryEdge (G := G) D.blue ie.1 := by
+      rcases hinc with h1 | h2
+      · rcases hwinc with hw1 | hw2
+        · exact absurd (by rw [← hw1]; exact h1) hwnotblue
+        · refine Or.inl ⟨h1, ?_⟩; rw [hw2]; exact hwnotblue
+      · rcases hwinc with hw1 | hw2
+        · refine Or.inr ⟨?_, h2⟩; rw [hw1]; exact hwnotblue
+        · exact absurd (by rw [← hw2]; exact h2) hwnotblue
+    rw [regionMerge, if_pos hinc]
+    have := congrFun hp ⟨ie.1, hbdry⟩
+    simpa [regionBoundaryLabel] using this.symm
+  · rw [regionMerge, if_neg hinc]
+
+/-- On a boundary edge of the host `univ \ red`, the complement-side configuration
+`p.2` agrees with the configuration merged along the blue block, provided the pair
+agrees on the blue boundary. This is the blue mirror of
+`hostLabel_p2_eq_hostLabel_regionMerge_complement`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem hostLabel_p2_eq_hostLabel_regionMerge_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (p : VirtualConfig A × VirtualConfig A)
+    (hp : regionBoundaryLabel (G := G) A D.blue p.1 =
+      regionBoundaryLabel (G := G) A D.blue p.2) :
+    regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 =
+      regionBoundaryLabel (G := G) A (Finset.univ \ D.red)
+        (regionMerge (G := G) A D.blue p) := by
+  classical
+  funext f
+  simp only [regionBoundaryLabel_apply]
+  by_cases hinc : IsRegionIncidentEdge (G := G) D.blue f.1
+  · -- A blue-incident host boundary edge is a boundary edge of the blue block.
+    have hbdry : IsRegionBoundaryEdge (G := G) D.blue f.1 := by
+      rcases f.2 with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
+      · have h2red : f.1.1.2 ∈ D.red := by
+          have := h2nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          exact this (Finset.mem_univ _)
+        have h2notblue : f.1.1.2 ∉ D.blue := fun hb =>
+          (Finset.disjoint_left.mp D.red_disjoint_blue) h2red hb
+        rcases hinc with hb1 | hb2
+        · refine Or.inl ⟨hb1, h2notblue⟩
+        · exact absurd hb2 h2notblue
+      · have h1red : f.1.1.1 ∈ D.red := by
+          have := h1nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          exact this (Finset.mem_univ _)
+        have h1notblue : f.1.1.1 ∉ D.blue := fun hb =>
+          (Finset.disjoint_left.mp D.red_disjoint_blue) h1red hb
+        rcases hinc with hb1 | hb2
+        · exact absurd hb1 h1notblue
+        · refine Or.inr ⟨h1notblue, hb2⟩
+    rw [regionMerge, if_pos hinc]
+    have := congrFun hp ⟨f.1, hbdry⟩
+    simpa [regionBoundaryLabel] using this.symm
+  · rw [regionMerge, if_neg hinc]
+
+open scoped Classical in
+/-- **The host-relative blue fiber cardinality.** The blue mirror of
+`threeBlockFiber_card`: among the blue-boundary-agreeing pairs whose complement-side
+host label is `bdry`, the fiber over a blue merge `η` has cardinality the blue
+interior bond product when `η` has host label `bdry`, and is empty otherwise.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockBlueFiber_card
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (η : VirtualConfig A) :
+    (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+        regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+          (regionBoundaryLabel (G := G) A D.blue p.1 =
+              regionBoundaryLabel (G := G) A D.blue p.2 ∧
+            regionMerge (G := G) A D.blue p = η))).card =
+      if regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry then
+        regionInteriorBondProd (G := G) A D.blue else 0 := by
+  classical
+  by_cases hcompat : regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry
+  · rw [if_pos hcompat]
+    rw [show (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            (regionBoundaryLabel (G := G) A D.blue p.1 =
+                regionBoundaryLabel (G := G) A D.blue p.2 ∧
+              regionMerge (G := G) A D.blue p = η))) =
+        Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+          (regionBoundaryLabel (G := G) A D.blue p.1 =
+              regionBoundaryLabel (G := G) A D.blue p.2 ∧
+            regionMerge (G := G) A D.blue p = η)) from ?_]
+    · exact regionFiber_card (G := G) A D.blue η
+    · refine Finset.filter_congr (fun p _ => ?_)
+      constructor
+      · rintro ⟨_, hagree, hmerge⟩; exact ⟨hagree, hmerge⟩
+      · rintro ⟨hagree, hmerge⟩
+        refine ⟨?_, hagree, hmerge⟩
+        rw [hostLabel_p2_eq_hostLabel_regionMerge_blue (A := A) (e := e) D p hagree,
+          hmerge, hcompat]
+  · rw [if_neg hcompat]
+    rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+    rintro p _ ⟨hhost, hagree, hmerge⟩
+    apply hcompat
+    rw [← hmerge,
+      ← hostLabel_p2_eq_hostLabel_regionMerge_blue (A := A) (e := e) D p hagree, hhost]
+
+open scoped Classical in
+/-- **The host-relative blue merge collapse.** The blue mirror of
+`threeBlockDoubleSum_eq_smul_single`: the blue-boundary-agreeing double sum of the
+blue vertex product against the complement vertex product, with the complement side
+constrained to host label `bdry`, collapses to the blue interior bond product times
+the single constrained sum.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockDoubleSum_eq_smul_single_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (∑ p ∈ Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.blue p.1 =
+              regionBoundaryLabel (G := G) A D.blue p.2),
+      (∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => p.1 ie.1) (σblue w)) *
+        ∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => p.2 ie.1) (σcompl w)) =
+      regionInteriorBondProd (G := G) A D.blue •
+        ∑ ζ ∈ Finset.univ.filter
+            (fun ζ : VirtualConfig A =>
+              regionBoundaryLabel (G := G) A (Finset.univ \ D.red) ζ = bdry),
+          (∏ w : {w : V // w ∈ D.blue},
+              A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
+            ∏ w : {w : V // w ∈ D.complement},
+              A.component w.1 (fun ie => ζ ie.1) (σcompl w) := by
+  classical
+  rw [show (∑ p ∈ Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.blue p.1 =
+              regionBoundaryLabel (G := G) A D.blue p.2),
+      (∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => p.1 ie.1) (σblue w)) *
+        ∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => p.2 ie.1) (σcompl w)) =
+      ∑ p ∈ Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.blue p.1 =
+              regionBoundaryLabel (G := G) A D.blue p.2),
+        (∏ w : {w : V // w ∈ D.blue},
+            A.component w.1 (fun ie => regionMerge (G := G) A D.blue p ie.1) (σblue w)) *
+          ∏ w : {w : V // w ∈ D.complement},
+            A.component w.1
+              (fun ie => regionMerge (G := G) A D.blue p ie.1) (σcompl w) from ?_]
+  · rw [← Finset.sum_fiberwise (Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.blue p.1 =
+              regionBoundaryLabel (G := G) A D.blue p.2))
+      (fun p => regionMerge (G := G) A D.blue p)
+      (fun p =>
+        (∏ w : {w : V // w ∈ D.blue},
+            A.component w.1 (fun ie => regionMerge (G := G) A D.blue p ie.1) (σblue w)) *
+          ∏ w : {w : V // w ∈ D.complement},
+            A.component w.1
+              (fun ie => regionMerge (G := G) A D.blue p ie.1) (σcompl w))]
+    rw [show (regionInteriorBondProd (G := G) A D.blue •
+          ∑ ζ ∈ Finset.univ.filter
+              (fun ζ : VirtualConfig A =>
+                regionBoundaryLabel (G := G) A (Finset.univ \ D.red) ζ = bdry),
+            (∏ w : {w : V // w ∈ D.blue},
+                A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
+              ∏ w : {w : V // w ∈ D.complement},
+                A.component w.1 (fun ie => ζ ie.1) (σcompl w)) =
+        ∑ η : VirtualConfig A,
+          regionInteriorBondProd (G := G) A D.blue •
+            (if regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry then
+              (∏ w : {w : V // w ∈ D.blue},
+                  A.component w.1 (fun ie => η ie.1) (σblue w)) *
+                ∏ w : {w : V // w ∈ D.complement},
+                  A.component w.1 (fun ie => η ie.1) (σcompl w)
+              else 0) from ?_]
+    · refine Finset.sum_congr rfl (fun η _ => ?_)
+      rw [Finset.filter_filter,
+        Finset.sum_congr rfl (g := fun _ =>
+            (∏ w : {w : V // w ∈ D.blue},
+                A.component w.1 (fun ie => η ie.1) (σblue w)) *
+              ∏ w : {w : V // w ∈ D.complement},
+                A.component w.1 (fun ie => η ie.1) (σcompl w))
+          (fun p hp => by rw [Finset.mem_filter] at hp; rw [hp.2.2]),
+        Finset.sum_const]
+      rw [show (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+            (regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+                regionBoundaryLabel (G := G) A D.blue p.1 =
+                  regionBoundaryLabel (G := G) A D.blue p.2) ∧
+              regionMerge (G := G) A D.blue p = η)) =
+          Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+            regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+              (regionBoundaryLabel (G := G) A D.blue p.1 =
+                  regionBoundaryLabel (G := G) A D.blue p.2 ∧
+                regionMerge (G := G) A D.blue p = η)) from by
+          refine Finset.filter_congr (fun p _ => ?_); tauto,
+        threeBlockBlueFiber_card (A := A) (e := e) D bdry η]
+      by_cases hcompat : regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry
+      · rw [if_pos hcompat, if_pos hcompat]
+      · rw [if_neg hcompat, if_neg hcompat, zero_smul, smul_zero]
+    · rw [Finset.smul_sum, ← Finset.sum_filter_add_sum_filter_not Finset.univ
+          (fun η : VirtualConfig A =>
+            regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry)]
+      rw [show (∑ η ∈ Finset.univ.filter
+            (fun η : VirtualConfig A =>
+              ¬ regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry),
+          regionInteriorBondProd (G := G) A D.blue •
+            (if regionBoundaryLabel (G := G) A (Finset.univ \ D.red) η = bdry then
+              (∏ w : {w : V // w ∈ D.blue},
+                  A.component w.1 (fun ie => η ie.1) (σblue w)) *
+                ∏ w : {w : V // w ∈ D.complement},
+                  A.component w.1 (fun ie => η ie.1) (σcompl w)
+              else 0)) = 0 from ?_,
+        add_zero]
+      · refine Finset.sum_congr rfl (fun η hη => ?_)
+        rw [Finset.mem_filter] at hη
+        rw [if_pos hη.2]
+      · refine Finset.sum_eq_zero (fun η hη => ?_)
+        rw [Finset.mem_filter] at hη
+        rw [if_neg hη.2, smul_zero]
+  · refine Finset.sum_congr rfl (fun p hp => ?_)
+    rw [Finset.mem_filter] at hp
+    rw [regionProd_eq_merge (G := G) A D.blue σblue p,
+      complProd_eq_regionMerge_blue (A := A) (e := e) D σcompl p hp.2.2]
+
+open scoped Classical in
+/-- **The complement coupling coefficient.** The blue mirror of
+`threeBlockBlueCoeff`: the complement vertex product summed over all global
+configurations whose host label is `bdry` and whose blue boundary label is the
+prescribed `bβ`. This is the complement-block contraction coupled to the blue
+boundary configuration through the blue/complement crossing bonds.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def threeBlockComplCoeff
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (bβ : RegionBoundaryConfig (G := G) A D.blue) : ℂ :=
+  ∑ q ∈ Finset.univ.filter
+      (fun q : VirtualConfig A =>
+        regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+          regionBoundaryLabel (G := G) A D.blue q = bβ),
+    ∏ w : {w : V // w ∈ D.complement}, A.component w.1 (fun ie => q ie.1) (σcompl w)
+
+open scoped Classical in
+/-- **The host-relative blue decoupling.** The blue mirror of
+`threeBlockDoubleSum_eq_blueCoeff_sum`: the blue-boundary-agreeing double sum of the
+blue vertex product against the host-constrained complement vertex product decouples,
+grouped by the blue boundary configuration `bβ`, into the blue blocked-region weight
+at `bβ` against the complement coupling coefficient.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockDoubleSum_eq_complCoeff_sum_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (∑ p ∈ Finset.univ.filter
+        (fun p : VirtualConfig A × VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+            regionBoundaryLabel (G := G) A D.blue p.1 =
+              regionBoundaryLabel (G := G) A D.blue p.2),
+      (∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => p.1 ie.1) (σblue w)) *
+        ∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => p.2 ie.1) (σcompl w)) =
+      ∑ bβ : RegionBoundaryConfig (G := G) A D.blue,
+        regionBlockedWeight (G := G) A D.blue bβ σblue *
+          threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ := by
+  classical
+  rw [← Finset.sum_fiberwise (Finset.univ.filter
+      (fun p : VirtualConfig A × VirtualConfig A =>
+        regionBoundaryLabel (G := G) A (Finset.univ \ D.red) p.2 = bdry ∧
+          regionBoundaryLabel (G := G) A D.blue p.1 =
+            regionBoundaryLabel (G := G) A D.blue p.2))
+    (fun p => regionBoundaryLabel (G := G) A D.blue p.1)
+    (fun p =>
+      (∏ w : {w : V // w ∈ D.blue},
+          A.component w.1 (fun ie => p.1 ie.1) (σblue w)) *
+        ∏ w : {w : V // w ∈ D.complement},
+          A.component w.1 (fun ie => p.2 ie.1) (σcompl w))]
+  refine Finset.sum_congr rfl (fun bβ _ => ?_)
+  rw [regionBlockedWeight, threeBlockComplCoeff, Finset.sum_mul_sum]
+  rw [Finset.filter_filter, ← Finset.sum_product']
+  refine Finset.sum_nbij' (fun p => (p.1, p.2)) (fun p => (p.1, p.2)) ?_ ?_
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+  · rintro ⟨p, q⟩ hpq
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
+    obtain ⟨⟨hhost, hagree⟩, hbβ⟩ := hpq
+    exact ⟨hbβ, hhost, hbβ ▸ hagree.symm⟩
+  · rintro ⟨p, q⟩ hpq
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
+    obtain ⟨hp, hhost, hq⟩ := hpq
+    exact ⟨⟨hhost, hp.trans hq.symm⟩, hp⟩
+
+open scoped Classical in
+/-- **The core blue smul-factorization (pointwise).** The blue mirror of
+`regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical`: the blue
+interior bond multiple of the fused host weight, at a fixed blue physical leg, is the
+sum over blue boundary configurations of the complement coupling coefficient times
+the blue blocked-region weight.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (regionInteriorBondProd (G := G) A D.blue : ℂ) •
+        regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+          (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) =
+      ∑ bβ : RegionBoundaryConfig (G := G) A D.blue,
+        threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ •
+          regionBlockedWeight (G := G) A D.blue bβ σblue := by
+  classical
+  rw [regionBlockedWeight_threeBlockComplPhysical_eq (A := A) (e := e) D bdry σblue σcompl]
+  rw [smul_eq_mul, ← nsmul_eq_mul,
+    ← threeBlockDoubleSum_eq_smul_single_blue (A := A) (e := e) D bdry σblue σcompl,
+    threeBlockDoubleSum_eq_complCoeff_sum_blue (A := A) (e := e) D bdry σblue σcompl]
+  refine Finset.sum_congr rfl (fun bβ _ => ?_)
+  rw [smul_eq_mul, mul_comm]
+
+open scoped Classical in
+/-- **The core blue smul-factorization (as functions of `σblue`).** The blue
+interior bond multiple of the fused host weight, read as a function of the blue
+physical leg, is the complement-coupling combination of the blue blocked-region
+weights.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_smul_threeBlockBlueWeight_eq
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (regionInteriorBondProd (G := G) A D.blue : ℂ) •
+        (fun σblue : RegionPhysicalConfig (V := V) (d := d) D.blue =>
+          regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+            (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) =
+      ∑ bβ : RegionBoundaryConfig (G := G) A D.blue,
+        threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ •
+          regionBlockedWeight (G := G) A D.blue bβ := by
+  funext σblue
+  rw [Pi.smul_apply, Finset.sum_apply,
+    regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue
+      (A := A) (e := e) D bdry σblue σcompl]
+  refine Finset.sum_congr rfl (fun bβ _ => ?_)
+  rw [Pi.smul_apply]
+
+/-- **The blue-block factorization of the fused host weight.** The fused host weight,
+read as a function of the blue physical leg `σblue` (with the complement leg fixed),
+lies in the range of the blue block's blocked-region tensor map. This is the
+blue-block mirror of `regionBlockedWeight_threeBlockComplPhysical_mem_range`,
+inverting along the blue block instead of the complement block.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedWeight_threeBlockBluePhysical_mem_range
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (hpos : ∀ f : Edge G, 0 < A.bondDim f) :
+    (fun σblue : RegionPhysicalConfig (V := V) (d := d) D.blue =>
+        regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+          (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) ∈
+      LinearMap.range (regionBlockedTensorMap (G := G) A D.blue) := by
+  classical
+  rw [range_regionBlockedTensorMap_eq_span (G := G) A D.blue]
+  have hne : (regionInteriorBondProd (G := G) A D.blue : ℂ) ≠ 0 := by
+    have hpos' : 0 < regionInteriorBondProd (G := G) A D.blue :=
+      regionInteriorBondProd_pos (G := G) A D.blue hpos
+    exact_mod_cast hpos'.ne'
+  rw [← Submodule.smul_mem_iff _ hne,
+    regionInteriorBondProd_smul_threeBlockBlueWeight_eq (A := A) (e := e) D bdry σcompl]
+  refine Submodule.sum_mem _ (fun bβ _ => ?_)
+  exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨bβ, rfl⟩)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
@@ -1,0 +1,187 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockResonate
+
+/-!
+# Three-block resonate engine: the middle strip and the endpoint inversions
+
+This file continues `TNLean.PEPS.RegionBlock.ThreeBlockResonate`, building the
+**middle strip** and the **two endpoint inversions** of the three-block resonate
+engine for the normal PEPS Fundamental Theorem (arXiv:1804.04964, Section 3,
+Lemma `inj_isomorph`).
+
+The previous file landed the core region-blocking associativity factorization:
+the fused host weight `regionBlockedWeight A (univ \ red) bdry
+(threeBlockComplPhysical D σblue σcompl)`, read as a function of the complement
+physical leg, lies in the range of the complement block's blocked-region tensor
+map (`regionBlockedWeight_threeBlockComplPhysical_mem_range`), with the explicit
+complement-interior-bond multiple
+`regionInteriorBondProd_smul_threeBlockComplWeight_eq`.
+
+This file uses that factorization to:
+
+* **strip the complement (middle) block** from the three-block inserted
+  coefficient, reading it off through the complement block's chosen left inverse
+  (`threeBlock_middle_strip`). This is the region analogue of
+  `resonate_middle_inverted` (`TNLean.PEPS.InsertionRealization`): where the edge
+  engine inverts the blocked middle tensor, the three-block engine inverts the
+  complement block, keeping the red and blue residual configurations independent.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d} {e : Edge G}
+
+/-! ### The complement-block row of the three-block inserted coefficient
+
+The three-block inserted coefficient `threeBlockInsertedCoeff D f M σred σblue
+σcompl`, read as a function of the complement physical leg `σcompl`, lies in the
+range of the complement block's blocked-region tensor map. The explicit preimage
+(scaled by the complement interior bond product) is the **complement row**: the
+host complement row of the two-block backbone, coupled through the blue block's
+`threeBlockBlueCoeff`. -/
+
+open scoped Classical in
+/-- **The complement-block row of the three-block inserted coefficient.** For a
+complement boundary configuration `bc'`, the host complement row of the two-block
+backbone (`regionComplementRow` of the red region), coupled to `bc'` through the
+blue block's `threeBlockBlueCoeff`.
+
+This is the explicit preimage, scaled by the complement interior bond product, of
+the σcompl-function of `threeBlockInsertedCoeff` under the complement block's
+blocked-region tensor map (`regionInteriorBondProd_smul_threeBlockInsertedCoeff_eq`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def threeBlockComplRow
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σred : RegionPhysicalConfig (V := V) (d := d) D.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue) :
+    RegionBoundaryConfig (G := G) A D.complement → ℂ :=
+  fun bc' =>
+    ∑ w : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+      regionComplementRow (G := G) A D.red f M σred w *
+        threeBlockBlueCoeff (A := A) (e := e) D w σblue bc'
+
+open scoped Classical in
+/-- **The three-block inserted coefficient through the complement blocked map.** The
+complement interior bond multiple of the three-block inserted coefficient, read as a
+function of the complement physical leg, is the complement block's blocked-region
+tensor map applied to the complement-block row `threeBlockComplRow`.
+
+The three-block inserted coefficient is the two-block `regionInsertedCoeff` of the
+red region against its set complement, with the blue and complement legs fused
+(`threeBlockInsertedCoeff_eq_regionInsertedCoeff`); the host complement reading
+(`regionInsertedCoeff_eq_complement_blockedMap`) writes it as the host complement
+row contracted against the fused host weights. Multiplying by the complement interior
+bond product and applying the core factorization
+`regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical` to each
+fused host weight replaces it by the blue-coupled complement blocked weights, which
+reassemble into the complement blocked tensor map of `threeBlockComplRow`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_smul_threeBlockInsertedCoeff_eq
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σred : RegionPhysicalConfig (V := V) (d := d) D.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue) :
+    (regionInteriorBondProd (G := G) A D.complement : ℂ) •
+        (fun σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement =>
+          threeBlockInsertedCoeff (A := A) (e := e) D f M σred σblue σcompl) =
+      regionBlockedTensorMap (G := G) A D.complement
+        (threeBlockComplRow (A := A) (e := e) D f M σred σblue) := by
+  classical
+  funext σcompl
+  rw [Pi.smul_apply]
+  -- The complement-blocked-map reading of the fused host inserted coefficient.
+  rw [threeBlockInsertedCoeff_eq_regionInsertedCoeff,
+    regionInsertedCoeff_eq_complement_blockedMap (G := G) A D.red f M σred,
+    regionBlockedTensorMap_apply]
+  -- Distribute the bond multiple across the host complement row sum, then apply the
+  -- core factorization to each fused host weight.
+  rw [Finset.smul_sum]
+  rw [regionBlockedTensorMap_apply]
+  simp only [threeBlockComplRow]
+  -- Both sides are sums; relate them by swapping the `w`/`bc'` order on the right.
+  rw [show (∑ bc' : RegionBoundaryConfig (G := G) A D.complement,
+        (∑ w : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+            regionComplementRow (G := G) A D.red f M σred w *
+              threeBlockBlueCoeff (A := A) (e := e) D w σblue bc') •
+          regionBlockedWeight (G := G) A D.complement bc' σcompl) =
+      ∑ w : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+        ∑ bc' : RegionBoundaryConfig (G := G) A D.complement,
+          (regionComplementRow (G := G) A D.red f M σred w *
+              threeBlockBlueCoeff (A := A) (e := e) D w σblue bc') •
+            regionBlockedWeight (G := G) A D.complement bc' σcompl from by
+      rw [Finset.sum_comm]
+      refine Finset.sum_congr rfl (fun bc' _ => ?_)
+      rw [Finset.sum_smul]]
+  refine Finset.sum_congr rfl (fun w _ => ?_)
+  -- On each host complement configuration, the scaled fused host weight is the
+  -- blue-coupled complement blocked weights.
+  rw [smul_comm,
+    regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical
+      (A := A) (e := e) D w σblue σcompl,
+    Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun bc' _ => ?_)
+  rw [smul_smul, mul_comm, ← smul_smul, smul_eq_mul]
+
+/-! ### The middle strip
+
+Reading the σcompl-function of the three-block inserted coefficient through the
+complement block's chosen left inverse strips the complement (middle) block,
+recovering the complement-block row `threeBlockComplRow`, scaled by the complement
+interior bond product. This is the region analogue of `resonate_middle_inverted`
+(`TNLean.PEPS.InsertionRealization`): where the edge engine inverts the blocked
+middle tensor to strip the middle block off the resonate identity, the three-block
+engine inverts the complement block. The red and blue residual configurations
+(`σred`, `σblue`) are kept quantified independently — the structural step the
+two-block frame cannot state. -/
+
+open scoped Classical in
+/-- **The three-block middle strip.** The complement block's chosen left inverse,
+applied to the three-block inserted coefficient read as a function of the complement
+physical leg and scaled by the complement interior bond product, recovers the
+complement-block row `threeBlockComplRow`. This strips the complement (middle) block
+while keeping the red and blue residual physical legs `σred`, `σblue` independent.
+
+The complement interior bond multiple of the σcompl-function is the complement
+blocked tensor map of `threeBlockComplRow`
+(`regionInteriorBondProd_smul_threeBlockInsertedCoeff_eq`), and the complement
+block's chosen left inverse recovers the row
+(`regionBlockedLeftInverse_apply_regionBlockedTensorMap`); the bond multiple commutes
+out through the linearity of the left inverse.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:resonate`--
+`eq:inj_O->X_argument`, lines 355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlock_middle_strip
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σred : RegionPhysicalConfig (V := V) (d := d) D.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue) :
+    (regionInteriorBondProd (G := G) A D.complement : ℂ) •
+        regionBlockedLeftInverse (G := G) A D.complement
+          (regionBlockedTensorInjective_complement (A := A) (e := e) D)
+          (fun σcompl => threeBlockInsertedCoeff (A := A) (e := e) D f M σred σblue σcompl) =
+      threeBlockComplRow (A := A) (e := e) D f M σred σblue := by
+  rw [← map_smul,
+    regionInteriorBondProd_smul_threeBlockInsertedCoeff_eq (A := A) (e := e) D f M σred σblue,
+    regionBlockedLeftInverse_apply_regionBlockedTensorMap]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
@@ -669,5 +669,47 @@ theorem threeBlock_invert_blue
     regionInteriorBondProd_smul_threeBlockBlueWeight_eq_blockedMap (A := A) (e := e) D bdry σcompl,
     regionBlockedLeftInverse_apply_regionBlockedTensorMap]
 
+/-! ### The red endpoint inversion
+
+Reading the σred-function of the three-block inserted coefficient through the red
+block's chosen left inverse reads the blue-side operator off as a bond-`f` matrix
+action, at a fixed fused blue/complement physical leg. This is the region analogue of
+`resonate_invert_left_endpoint` (`TNLean.PEPS.InsertionRealization`), at the red
+endpoint block. Unlike the blue inversion, the red block is the first block of the
+two-block backbone, so no fiber collapse is needed: the σred-function factors through
+the red blocked tensor map directly (`regionInsertedCoeff_eq_region_blockedMap`). -/
+
+open scoped Classical in
+/-- **The red endpoint inversion.** The red block's chosen left inverse, applied to
+the σred-function of the three-block inserted coefficient, recovers the region row
+function `regionRegionRow` at the fused blue/complement physical leg. This reads the
+blue-side operator off as a bond-`f` matrix action against the fused host weight, at a
+fixed blue and complement physical leg (`σblue`, `σcompl`).
+
+The three-block inserted coefficient is the two-block `regionInsertedCoeff` of the red
+region against its set complement, with the blue and complement legs fused
+(`threeBlockInsertedCoeff_eq_regionInsertedCoeff`); the σred-function factors through
+the red blocked tensor map of the region row (`regionInsertedCoeff_eq_region_blockedMap`),
+and the red block's chosen left inverse recovers it
+(`regionBlockedLeftInverse_region_regionInsertedCoeff`).
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:inj_O->X_argument`,
+lines 355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlock_invert_red
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    regionBlockedLeftInverse (G := G) A D.red
+        (regionBlockedTensorInjective_red (A := A) (e := e) D)
+        (fun σred => threeBlockInsertedCoeff (A := A) (e := e) D f M σred σblue σcompl) =
+      regionRegionRow (G := G) A D.red f M
+        (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) := by
+  simp only [threeBlockInsertedCoeff_eq_regionInsertedCoeff]
+  exact regionBlockedLeftInverse_region_regionInsertedCoeff (G := G) A D.red
+    (regionBlockedTensorInjective_red (A := A) (e := e) D) f M
+    (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB.lean
@@ -1,0 +1,137 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockReconcile
+import TNLean.PEPS.RegionBlock.ThreeBlockPhysical
+import TNLean.PEPS.RegionBlock.OpenLegsResonate
+import TNLean.PEPS.RegionBlock.ResonatePort2
+
+/-!
+# The cross-tensor three-block resonate chain for the normal PEPS V=W
+
+This file builds the cross-tensor resonate chain that closes the last open step of
+the general normal PEPS Fundamental Theorem per-edge gauge (arXiv:1804.04964,
+Section 3, Lemma `inj_isomorph`, the step `V=W`).
+
+The landed block-frame foundation has reduced the per-edge gauge to a single
+**cross-tensor coefficient transfer**: for every inserted matrix `M` on the boundary
+edge `f` of the shared red region there is a matrix `N` on the second tensor's bond
+with `regionInsertedCoeff A red f M = regionInsertedCoeff B red f N` at every physical
+configuration. Equivalently (`coeffTransfer_iff_basisChange_regionRegionRow`,
+`TNLean.PEPS.RegionBlock.ResonatePort2`), the A↔B region basis change maps the first
+tensor's bond-`f`-local region row of `M` to the second tensor's bond-`f`-local region
+row of a single bond matrix `N`. The content of the step `V=W` is that this `N`
+exists: the basis change preserves the bond-`f`/away-from-`f` decomposition.
+
+The decisive geometric fact is that the red and blue blocks cross at exactly one
+edge — the distinguished edge `e`, whose endpoints are the red endpoint `e.1.1` and
+the blue endpoint `e.1.2`. The three-block structure is red / blue / complement with
+the inserted matrix `M` on the red boundary edge `f`, exactly the edge template's
+shape. The cross-tensor reading of the first tensor's coefficient through the second
+tensor's red block (`regionInsertedCoeff_eq_threeBlockOpCoeff_B`,
+`TNLean.PEPS.RegionBlock.ThreeBlockPhysical`) and through the second tensor's host
+block (`regionInsertedCoeff_eq_blockRealizeOp_complementPartialState_B`,
+`TNLean.PEPS.RegionBlock.ResonatePort`) agree because both are the first tensor's
+coefficient of `M`; this is the cross-tensor resonate identity at block granularity.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, the step `V=W`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### A1: the cross-tensor resonate identity
+
+The first tensor's region-inserted coefficient of `M`, read through the second
+tensor's `SameState`-invariant data, has two block realizations:
+
+* the **red-side** realization, the abstract-operator three-block coefficient of the
+  first tensor's red-block realization operator `blockRealizeOp A red hRA f M` read on
+  the second tensor's red partial state (`regionInsertedCoeff_eq_threeBlockOpCoeff_B`,
+  `TNLean.PEPS.RegionBlock.ThreeBlockPhysical`);
+* the **host-side** realization, the host-block realization operator of `Mᵀ` at the
+  region `univ \ red` and the boundary edge `regionBoundaryEdgeToCompl red f` read on
+  the second tensor's host partial state
+  (`regionInsertedCoeff_eq_blockRealizeOp_complementPartialState_B`,
+  `TNLean.PEPS.RegionBlock.ResonatePort`).
+
+Both realizations are the first tensor's coefficient of `M`, so they agree. This is
+the cross-tensor `eq:resonate` at block granularity. -/
+
+/-- **A1: the cross-tensor resonate identity.** The abstract-operator three-block
+coefficient of the first tensor's red-block realization operator, read on the second
+tensor's red partial state, equals the host-block realization operator of `Mᵀ` read on
+the second tensor's host partial state, both as functions of the complement physical
+leg at a fixed region physical leg `σ`. Both sides are the first tensor's
+region-inserted coefficient of `M`: the red side by
+`regionInsertedCoeff_eq_threeBlockOpCoeff_B` (and `threeBlockOpCoeff_apply`), the host
+side by `regionInsertedCoeff_eq_blockRealizeOp_complementPartialState_B`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:resonate`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockOpCoeff_resonate_AB (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) :
+    (fun τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R) =>
+        blockRealizeOp (G := G) A R hRA f M
+          ((regionInteriorBondProd (G := G) B R : ℂ) •
+            regionPartialState (G := G) B R τ) σ) =
+      blockRealizeOp (G := G) A (Finset.univ \ R) hCA
+        (regionBoundaryEdgeToCompl (G := G) R f) M.transpose
+        ((regionInteriorBondProd (G := G) B (Finset.univ \ R) : ℂ) •
+          regionPartialState (G := G) B (Finset.univ \ R)
+            (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ)) := by
+  -- Both sides equal the first tensor's region-inserted coefficient of `M`, read as a
+  -- function of the complement physical leg `τ`.
+  funext τ
+  -- Red side: the abstract three-block operator coefficient is `coeff_A M`.
+  have hred := regionInsertedCoeff_eq_threeBlockOpCoeff_B A B R hRA hAB hDim f M σ τ
+  rw [threeBlockOpCoeff_apply] at hred
+  -- Host side: the complement-side realization is `coeff_A M` as a function of `τ`.
+  have hhost := regionInsertedCoeff_eq_blockRealizeOp_complementPartialState_B A B R hCA hAB
+    hDim f M σ
+  rw [← hred, congrFun hhost τ]
+
+/-! ### B3: the M-free blue read-off coincides for A and B
+
+The complement coupling row `threeBlockComplCoeff D bdry σcompl` is `M`-free: it
+depends on the tensor only through the fused host weight (`threeBlockComplCoeff`,
+`TNLean.PEPS.RegionBlock.ThreeBlockResonate2`). The blue endpoint inversion
+`threeBlock_invert_blue` (`TNLean.PEPS.RegionBlock.ThreeBlockResonate2`) reads it off
+the blue block's chosen left inverse, scaled by the blue interior bond product. This is
+a single-tensor read-off, available at both tensors of `SameState A B`. -/
+
+/-- **B3: the M-free blue read-off.** The blue endpoint inversion of a one-edge
+blocking datum reads the complement coupling row `threeBlockComplCoeff` off the blue
+block's chosen left inverse of the fused host weight, scaled by the blue interior bond
+product. This is `threeBlock_invert_blue` (`TNLean.PEPS.RegionBlock.ThreeBlockResonate2`)
+packaged as the residual-quantified read-off the reconcile references; it is `M`-free,
+so it provides the common reference frame for the red read-off.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:inj_O->X_argument`,
+lines 355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlock_blue_readoff_AB {A : Tensor G d} {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (regionInteriorBondProd (G := G) A D.blue : ℂ) •
+        regionBlockedLeftInverse (G := G) A D.blue
+          (regionBlockedTensorInjective_blue (A := A) (e := e) D)
+          (fun σblue => regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+            (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) =
+      fun bβ => threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ :=
+  threeBlock_blue_readoff (A := A) (e := e) D bdry σcompl
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
@@ -1,0 +1,101 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockResonateAB
+
+/-!
+# The host↔blue collapse of the cross-tensor three-block resonate identity
+
+This file continues `TNLean.PEPS.RegionBlock.ThreeBlockResonateAB`, building the
+**host↔blue collapse** of the cross-tensor resonate identity for the general normal
+PEPS Fundamental Theorem per-edge gauge (arXiv:1804.04964, Section 3, Lemma
+`inj_isomorph`, the step `V=W`).
+
+The landed cross-tensor resonate identity `threeBlockOpCoeff_resonate_AB`
+(`TNLean.PEPS.RegionBlock.ThreeBlockResonateAB`) reads the first tensor's
+region-inserted coefficient of `M` through the **second** tensor's `SameState`-invariant
+partial states two ways:
+
+* the **red-side** realization, the first tensor's red-block realization operator
+  `blockRealizeOp A red hRA f M` on the second tensor's red partial state;
+* the **host-side** realization, the first tensor's host-block realization operator
+  `blockRealizeOp A (univ \ red) hCA (toCompl f) Mᵀ` on the second tensor's host partial
+  state.
+
+The decisive geometric fact is that the host block `univ \ red` is the disjoint union of
+the blue and complement blocks (`sdiff_red_eq_blue_union_complement`), and the red and
+blue blocks cross at exactly the distinguished edge `e`. So the host-side reading,
+written through the blue/complement split, carries the bond-paired structure on `e`
+inside the blue block. The complement block is the separately invertible middle; the
+landed single-tensor engine (`threeBlock_invert_blue`, `threeBlock_middle_strip`) strips
+it, leaving a **blue-block reading**.
+
+This file works entirely in **physical-configuration space** — the host complement leg
+`τ` of `univ \ red` is read as the fused blue/complement leg
+`threeBlockComplPhysical DB σblue σcompl` — to avoid the dependent-type casts of the
+boundary-configuration spaces of the two tensors.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, the step `V=W`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The cross-tensor resonate identity in the three-block frame
+
+Reading the host complement leg `τ` of `univ \ red` through the blue/complement split
+`threeBlockComplPhysical DB σblue σcompl` puts the cross-tensor resonate identity
+`threeBlockOpCoeff_resonate_AB` (`TNLean.PEPS.RegionBlock.ThreeBlockResonateAB`) into the
+frame the single-tensor three-block engine on the second tensor consumes: the host leg is
+quantified as the two separate legs `σblue`, `σcompl`. This is the substitution
+`τ := threeBlockComplPhysical DB σblue σcompl`, with the second tensor's one-edge
+blocking datum `DB` supplying the blue/complement fusing. -/
+
+/-- **The cross-tensor resonate identity in the three-block frame.** Substituting the
+fused blue/complement leg of the second tensor's one-edge blocking datum `DB` for the host
+complement leg, the cross-tensor resonate identity reads the first tensor's
+region-inserted coefficient of `M` two ways at a fixed red physical leg `σ` and split
+blue/complement legs `σblue`, `σcompl`: the first tensor's red-block realization operator
+on the second tensor's red partial state, and the first tensor's host-block realization
+operator of `Mᵀ` on the second tensor's host partial state at the fused leg.
+
+This is `threeBlockOpCoeff_resonate_AB`
+(`TNLean.PEPS.RegionBlock.ThreeBlockResonateAB`) evaluated at
+`τ := threeBlockComplPhysical DB σblue σcompl`, with `R := DB.red` the second tensor's red
+region. It puts the cross-tensor identity into the three-block frame, with the host leg
+read as the two separate legs the single-tensor engine on the second tensor inverts.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:resonate`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeBlockOpCoeff_resonate_AB_split (A B : Tensor G d) {e : Edge G}
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) B) G e)
+    (hRA : RegionBlockedTensorInjective (G := G) A DB.red)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ DB.red))
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) DB.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) DB.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) DB.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) DB.complement) :
+    blockRealizeOp (G := G) A DB.red hRA f M
+        ((regionInteriorBondProd (G := G) B DB.red : ℂ) •
+          regionPartialState (G := G) B DB.red
+            (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)) σ =
+      blockRealizeOp (G := G) A (Finset.univ \ DB.red) hCA
+        (regionBoundaryEdgeToCompl (G := G) DB.red f) M.transpose
+        ((regionInteriorBondProd (G := G) B (Finset.univ \ DB.red) : ℂ) •
+          regionPartialState (G := G) B (Finset.univ \ DB.red)
+            (regionDoubleComplPhysicalConfig (V := V) (d := d) DB.red σ))
+        (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) := by
+  have h := threeBlockOpCoeff_resonate_AB A B DB.red hRA hCA hAB hDim f M σ
+  exact congrFun h (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
@@ -253,5 +253,81 @@ theorem regionInteriorBondProd_blue_smul_regionInsertedCoeff_eq_blueCollapse
         regionBlockedWeight (G := G) B DB.red μ σ from by ring]
   rw [hblue]
 
+/-! ### The host realization operator collapses to the blue-coupled structure
+
+Combining the cross-tensor resonate identity in the three-block frame
+`threeBlockOpCoeff_resonate_AB_split` with the host↔blue collapse
+`regionInteriorBondProd_blue_smul_regionInsertedCoeff_eq_blueCollapse` reads the
+**host-side** realization operator of `A1` — the first tensor's host-block realization
+operator of `Mᵀ` on the second tensor's host partial state — directly as the blue-coupled
+structure. This is the host↔blue collapse stated on the resonate identity itself: the host
+reading of the first tensor's coefficient is the blue reading, with the residual complement
+structure carried by the M-free coupling row. -/
+
+open scoped Classical in
+/-- **The host realization operator collapses to the blue-coupled structure.** The second
+tensor's blue interior bond multiple of the host-side realization operator of the
+cross-tensor resonate identity — the first tensor's host-block realization operator of
+`Mᵀ` on the second tensor's host partial state, read at the fused blue/complement leg — is
+the host-residual double sum of the transfer kernel `transferCoeff A B red f M` against the
+second tensor's red blocked weight and the blue-coupled host structure (each host weight
+replaced by the blue blocked weight coupled through the M-free complement coupling row
+`threeBlockComplCoeff B`).
+
+This composes `threeBlockOpCoeff_resonate_AB_split` (which equates the host-side
+realization with the first tensor's coefficient at the fused leg) with the host↔blue
+collapse `regionInteriorBondProd_blue_smul_regionInsertedCoeff_eq_blueCollapse`. It states
+the collapse on the resonate identity's host side itself: what survives of the host reading
+is a blue-block reading.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:inj_O->X_argument`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_blue_smul_hostRealizeOp_eq_blueCollapse
+    (A B : Tensor G d) {e : Edge G}
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) B) G e)
+    (hRA : RegionBlockedTensorInjective (G := G) A DB.red)
+    (hRB : RegionBlockedTensorInjective (G := G) B DB.red)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ DB.red))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ DB.red))
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) DB.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) DB.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) DB.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) DB.complement) :
+    (regionInteriorBondProd (G := G) B DB.blue : ℂ) •
+        blockRealizeOp (G := G) A (Finset.univ \ DB.red) hCA
+          (regionBoundaryEdgeToCompl (G := G) DB.red f) M.transpose
+          ((regionInteriorBondProd (G := G) B (Finset.univ \ DB.red) : ℂ) •
+            regionPartialState (G := G) B (Finset.univ \ DB.red)
+              (regionDoubleComplPhysicalConfig (V := V) (d := d) DB.red σ))
+          (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) =
+      ∑ μ : RegionBoundaryConfig (G := G) B DB.red,
+        ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ DB.red),
+          transferCoeff (G := G) A B DB.red hRB hCB f M μ ν' *
+            (∑ bβ : RegionBoundaryConfig (G := G) B DB.blue,
+              threeBlockComplCoeff (A := B) (e := e) DB ν' σcompl bβ *
+                regionBlockedWeight (G := G) B DB.blue bβ σblue) *
+            regionBlockedWeight (G := G) B DB.red μ σ := by
+  classical
+  -- The host-side realization equals the first tensor's coefficient at the fused leg.
+  have hhost := (threeBlockOpCoeff_resonate_AB_split A B DB hRA hCA hAB hDim f M σ σblue
+    σcompl).symm
+  -- The red-side realization is the first tensor's coefficient.
+  have hred : blockRealizeOp (G := G) A DB.red hRA f M
+        ((regionInteriorBondProd (G := G) B DB.red : ℂ) •
+          regionPartialState (G := G) B DB.red
+            (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)) σ =
+      regionInsertedCoeff (G := G) A DB.red f M σ
+        (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) := by
+    have h := regionInsertedCoeff_eq_blockRealizeOp_regionPartialState_B A B DB.red hRA hAB hDim
+      f M (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)
+    exact (congrFun h σ).symm
+  rw [hhost, hred,
+    regionInteriorBondProd_blue_smul_regionInsertedCoeff_eq_blueCollapse A B DB hRA hRB hCA hCB
+      hAB hposA hposB hDim f M σ σblue σcompl]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
@@ -97,5 +97,161 @@ theorem threeBlockOpCoeff_resonate_AB_split (A B : Tensor G d) {e : Edge G}
   have h := threeBlockOpCoeff_resonate_AB A B DB.red hRA hCA hAB hDim f M σ
   exact congrFun h (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)
 
+/-! ### The double factorization of the first tensor's coefficient with the host weight
+split along blue and complement
+
+The block-frame double factorization
+`regionInsertedCoeff_eq_doubleSum_transferCoeff_block`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) writes the first tensor's region-inserted
+coefficient of `M` as a boundary-configuration double sum of the transfer kernel
+`transferCoeff A B red f M` against the second tensor's host and red blocked weights.
+Reading the host complement leg through the blue/complement split
+`threeBlockComplPhysical DB σblue σcompl` and unfolding each host blocked weight along
+`univ \ red = blue ⊔ complement` (`regionBlockedWeight_threeBlockComplPhysical_eq`,
+`TNLean.PEPS.RegionBlock.ThreeBlockResonate`) exposes the second tensor's blue/complement
+structure inside the first tensor's coefficient. This is the host-side expansion the blue
+read-off `threeBlock_invert_blue` (`TNLean.PEPS.RegionBlock.ThreeBlockResonate2`) acts on,
+in physical-configuration space. -/
+
+open scoped Classical in
+/-- **The first tensor's coefficient with the host weight split along blue and
+complement.** Reading the host complement leg of the second tensor's red region through
+the blue/complement split, the first tensor's region-inserted coefficient of `M` is the
+host-residual double sum of the transfer kernel `transferCoeff A B red f M` against the
+second tensor's red blocked weight and the second tensor's host blocked weight, the latter
+expanded as the constrained global-configuration sum of the blue vertex product (read with
+`σblue`) times the complement vertex product (read with `σcompl`).
+
+This is the block-frame double factorization
+`regionInsertedCoeff_eq_doubleSum_transferCoeff_block`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) at the fused leg, with each host blocked
+weight unfolded along `univ \ red = blue ⊔ complement`
+(`regionBlockedWeight_threeBlockComplPhysical_eq`,
+`TNLean.PEPS.RegionBlock.ThreeBlockResonate`). It exposes the second tensor's
+blue/complement structure inside the first tensor's coefficient.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_doubleSum_transferCoeff_blue_complement_split
+    (A B : Tensor G d) {e : Edge G}
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) B) G e)
+    (hRA : RegionBlockedTensorInjective (G := G) A DB.red)
+    (hRB : RegionBlockedTensorInjective (G := G) B DB.red)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ DB.red))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ DB.red))
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) DB.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) DB.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) DB.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) DB.complement) :
+    regionInsertedCoeff (G := G) A DB.red f M σ
+        (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) =
+      ∑ μ : RegionBoundaryConfig (G := G) B DB.red,
+        ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ DB.red),
+          transferCoeff (G := G) A B DB.red hRB hCB f M μ ν' *
+            (∑ ζ ∈ Finset.univ.filter
+                (fun ζ : VirtualConfig B =>
+                  regionBoundaryLabel (G := G) B (Finset.univ \ DB.red) ζ = ν'),
+              (∏ w : {w : V // w ∈ DB.blue},
+                  B.component w.1 (fun ie => ζ ie.1) (σblue w)) *
+                ∏ w : {w : V // w ∈ DB.complement},
+                  B.component w.1 (fun ie => ζ ie.1) (σcompl w)) *
+            regionBlockedWeight (G := G) B DB.red μ σ := by
+  classical
+  rw [regionInsertedCoeff_eq_doubleSum_transferCoeff_block A B DB.red hRA hRB hCA hCB hAB
+    hposA hposB hDim f M σ (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  refine Finset.sum_congr rfl (fun ν' _ => ?_)
+  rw [regionBlockedWeight_threeBlockComplPhysical_eq (A := B) (e := e) DB ν' σblue σcompl]
+
+/-! ### The host↔blue collapse of the first tensor's coefficient
+
+Scaling the first tensor's coefficient by the second tensor's blue interior bond product
+and applying the blue-block decoupling
+`regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue`
+(`TNLean.PEPS.RegionBlock.ThreeBlockResonate2`) to each host blocked weight at the fused
+leg replaces the host weight by the second tensor's blue blocked weight coupled through the
+**M-free** complement coupling row `threeBlockComplCoeff B`. This is the host↔blue collapse
+in physical-configuration space: the host reading of the first tensor's coefficient becomes
+a blue reading, with the residual complement structure carried by the M-free coupling row
+the blue read-off `threeBlock_invert_blue` (`TNLean.PEPS.RegionBlock.ThreeBlockResonate2`)
+inverts. The red↔blue crossing at the distinguished edge `e` survives because the blue
+blocked weight `regionBlockedWeight B blue bβ σblue` is bond-paired on the blue boundary,
+of which `e` is the distinguished crossing. -/
+
+open scoped Classical in
+/-- **The host↔blue collapse of the first tensor's coefficient.** The second tensor's blue
+interior bond multiple of the first tensor's region-inserted coefficient of `M`, read at
+the fused blue/complement leg of the second tensor's red region, is the host-residual
+double sum of the transfer kernel `transferCoeff A B red f M` against the second tensor's
+red blocked weight and the **blue**-coupled host structure: each host blocked weight is
+replaced by the sum over blue boundary configurations `bβ` of the M-free complement
+coupling row `threeBlockComplCoeff B ν' σcompl bβ` against the second tensor's blue blocked
+weight `regionBlockedWeight B blue bβ σblue`.
+
+This is `regionInsertedCoeff_eq_doubleSum_transferCoeff_blue_complement_split` after
+multiplying by the second tensor's blue interior bond product and applying the blue-block
+decoupling `regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue`
+(`TNLean.PEPS.RegionBlock.ThreeBlockResonate2`) to each host blocked weight. The host
+reading of the first tensor's coefficient is collapsed to a blue reading; the residual
+complement structure is the M-free coupling row the blue read-off
+`threeBlock_invert_blue` inverts.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, `eq:inj_O->X_argument`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_blue_smul_regionInsertedCoeff_eq_blueCollapse
+    (A B : Tensor G d) {e : Edge G}
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) B) G e)
+    (hRA : RegionBlockedTensorInjective (G := G) A DB.red)
+    (hRB : RegionBlockedTensorInjective (G := G) B DB.red)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ DB.red))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ DB.red))
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) DB.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) DB.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) DB.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) DB.complement) :
+    (regionInteriorBondProd (G := G) B DB.blue : ℂ) •
+        regionInsertedCoeff (G := G) A DB.red f M σ
+          (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) =
+      ∑ μ : RegionBoundaryConfig (G := G) B DB.red,
+        ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ DB.red),
+          transferCoeff (G := G) A B DB.red hRB hCB f M μ ν' *
+            (∑ bβ : RegionBoundaryConfig (G := G) B DB.blue,
+              threeBlockComplCoeff (A := B) (e := e) DB ν' σcompl bβ *
+                regionBlockedWeight (G := G) B DB.blue bβ σblue) *
+            regionBlockedWeight (G := G) B DB.red μ σ := by
+  classical
+  rw [regionInsertedCoeff_eq_doubleSum_transferCoeff_block A B DB.red hRA hRB hCA hCB hAB
+    hposA hposB hDim f M σ (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)]
+  rw [Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun ν' _ => ?_)
+  -- Scale the host blocked weight at the fused leg by the blue interior bond product and
+  -- decouple it into the blue-coupled complement-coupling combination.
+  have hblue := congrFun
+    (regionInteriorBondProd_smul_threeBlockBlueWeight_eq (A := B) (e := e) DB ν' σcompl) σblue
+  rw [Pi.smul_apply, smul_eq_mul, Finset.sum_apply] at hblue
+  simp only [Pi.smul_apply, smul_eq_mul] at hblue
+  -- `hblue : interior_blue * host_weight ν' (fused) = ∑ bβ, threeBlockComplCoeff · blueWeight`.
+  rw [smul_eq_mul, show (regionInteriorBondProd (G := G) B DB.blue : ℂ) *
+        (transferCoeff (G := G) A B DB.red hRB hCB f M μ ν' *
+          regionBlockedWeight (G := G) B (Finset.univ \ DB.red) ν'
+            (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) *
+          regionBlockedWeight (G := G) B DB.red μ σ) =
+      transferCoeff (G := G) A B DB.red hRB hCB f M μ ν' *
+        ((regionInteriorBondProd (G := G) B DB.blue : ℂ) *
+          regionBlockedWeight (G := G) B (Finset.univ \ DB.red) ν'
+            (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)) *
+        regionBlockedWeight (G := G) B DB.red μ σ from by ring]
+  rw [hblue]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
@@ -329,5 +329,77 @@ theorem regionInteriorBondProd_blue_smul_hostRealizeOp_eq_blueCollapse
     regionInteriorBondProd_blue_smul_regionInsertedCoeff_eq_blueCollapse A B DB hRA hRB hCA hCB
       hAB hposA hposB hDim f M σ σblue σcompl]
 
+/-! ### The second tensor's coefficient of a witness through the blue collapse
+
+The second tensor's own region-inserted coefficient of a witness matrix `N` collapses the
+same way: its double-sum reading through the incident-matrix kernel
+(`doubleSum_incidentKernel_eq_regionInsertedCoeff`,
+`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) has each host blocked weight at the fused leg
+replaced by the same blue-coupled host structure. So the witness condition
+`coeff_A M = coeff_B N` reads, after the blue collapse, as the two kernels —
+`transferCoeff A B red f M` and `incidentKernel B red f N` — paired against the **same**
+M-free blue/complement structure of the second tensor. This is the kernel-matching frame
+the witness extraction lands in. -/
+
+open scoped Classical in
+/-- **The second tensor's coefficient of a witness through the blue collapse.** The second
+tensor's blue interior bond multiple of its own region-inserted coefficient of `N`, read at
+the fused blue/complement leg, is the host-residual double sum of the incident-matrix kernel
+`incidentKernel B red f N` against the second tensor's red blocked weight and the
+blue-coupled host structure (the same blue/complement structure that appears in the first
+tensor's collapse `regionInteriorBondProd_blue_smul_regionInsertedCoeff_eq_blueCollapse`).
+
+This is `doubleSum_incidentKernel_eq_regionInsertedCoeff`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) at the fused leg, scaled by the blue interior
+bond product and with each host blocked weight decoupled along the blue/complement split.
+Comparing it with the first tensor's collapse presents the witness condition
+`coeff_A M = coeff_B N` as the kernel pairing `transferCoeff A B red f M` versus
+`incidentKernel B red f N` against the same M-free structure.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInteriorBondProd_blue_smul_regionInsertedCoeff_B_eq_blueCollapse
+    (B : Tensor G d) {e : Edge G}
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) B) G e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) DB.red f})
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) DB.red)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) DB.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) DB.complement) :
+    (regionInteriorBondProd (G := G) B DB.blue : ℂ) •
+        regionInsertedCoeff (G := G) B DB.red f N σ
+          (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) =
+      ∑ μ : RegionBoundaryConfig (G := G) B DB.red,
+        ∑ ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ DB.red),
+          incidentKernel (G := G) B DB.red f N μ ν' *
+            (∑ bβ : RegionBoundaryConfig (G := G) B DB.blue,
+              threeBlockComplCoeff (A := B) (e := e) DB ν' σcompl bβ *
+                regionBlockedWeight (G := G) B DB.blue bβ σblue) *
+            regionBlockedWeight (G := G) B DB.red μ σ := by
+  classical
+  rw [← doubleSum_incidentKernel_eq_regionInsertedCoeff B DB.red f N σ
+    (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)]
+  rw [Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun ν' _ => ?_)
+  -- Scale the host blocked weight at the fused leg by the blue interior bond product and
+  -- decouple it into the blue-coupled complement-coupling combination.
+  have hblue := congrFun
+    (regionInteriorBondProd_smul_threeBlockBlueWeight_eq (A := B) (e := e) DB ν' σcompl) σblue
+  rw [Pi.smul_apply, smul_eq_mul, Finset.sum_apply] at hblue
+  simp only [Pi.smul_apply, smul_eq_mul] at hblue
+  rw [smul_eq_mul, show (regionInteriorBondProd (G := G) B DB.blue : ℂ) *
+        (incidentKernel (G := G) B DB.red f N μ ν' *
+          regionBlockedWeight (G := G) B (Finset.univ \ DB.red) ν'
+            (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) *
+          regionBlockedWeight (G := G) B DB.red μ σ) =
+      incidentKernel (G := G) B DB.red f N μ ν' *
+        ((regionInteriorBondProd (G := G) B DB.blue : ℂ) *
+          regionBlockedWeight (G := G) B (Finset.univ \ DB.red) ν'
+            (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)) *
+        regionBlockedWeight (G := G) B DB.red μ σ from by ring]
+  rw [hblue]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB2.lean
@@ -401,5 +401,91 @@ theorem regionInteriorBondProd_blue_smul_regionInsertedCoeff_B_eq_blueCollapse
         regionBlockedWeight (G := G) B DB.red μ σ from by ring]
   rw [hblue]
 
+/-! ### The witness condition through the blue collapse
+
+Comparing the two blue collapses
+(`regionInteriorBondProd_blue_smul_regionInsertedCoeff_eq_blueCollapse` and
+`regionInteriorBondProd_blue_smul_regionInsertedCoeff_B_eq_blueCollapse`), the witness
+condition `coeff_A M = coeff_B N` at the fused leg is the pairing of the two kernels —
+`transferCoeff A B red f M` and `incidentKernel B red f N` — against the **same** M-free
+blue/complement structure of the second tensor. Since the second tensor's blue interior
+bond product is a nonzero scalar (positive bond dimensions), the witness condition at the
+fused leg is exactly the equality of the two blue-collapsed double sums.
+
+This pins the witness extraction to one statement: the transfer kernel of `M` has the
+incident-matrix coupling form of a single bond matrix `N`. By kernel uniqueness through the
+second tensor's double blocked injectivity
+(`transferCoeff_eq_incidentKernel_iff_coeff_eq`,
+`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`), this is `IsBondLocalTransferKernel`. -/
+
+open scoped Classical in
+/-- **The witness condition through the blue collapse.** For a bond matrix `N` on the
+boundary edge `f`, the transfer kernel `transferCoeff A B red f M` equals the incident-matrix
+kernel `incidentKernel B red f N` if and only if the first tensor's blue-collapsed
+coefficient of `M` equals the second tensor's blue-collapsed coefficient of `N` at every red
+physical leg `σ` and split blue/complement legs `σblue`, `σcompl`.
+
+The forward direction substitutes the kernel equality into either collapse; the backward
+direction passes from the blue-collapse equality to the fused-leg coefficient equality
+(dividing out the nonzero blue interior bond product) and reads off the kernel equation
+through the fused-leg split bridge `regionInsertedCoeff_eq_threeBlockInsertedCoeff_split`
+(`TNLean.PEPS.RegionBlock.ThreeBlockReconcile`) and kernel uniqueness
+`transferCoeff_eq_incidentKernel_iff_coeff_eq`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`). This is the precise statement the witness
+extraction must establish: the existence of a bond matrix `N` matching the blue-collapsed
+coefficient.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem transferCoeff_eq_incidentKernel_iff_blueCollapse_eq
+    (A B : Tensor G d) {e : Edge G}
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) B) G e)
+    (hRA : RegionBlockedTensorInjective (G := G) A DB.red)
+    (hRB : RegionBlockedTensorInjective (G := G) B DB.red)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ DB.red))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ DB.red))
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) DB.red f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    transferCoeff (G := G) A B DB.red hRB hCB f M = incidentKernel (G := G) B DB.red f N ↔
+      ∀ (σ : RegionPhysicalConfig (V := V) (d := d) DB.red)
+        (σblue : RegionPhysicalConfig (V := V) (d := d) DB.blue)
+        (σcompl : RegionPhysicalConfig (V := V) (d := d) DB.complement),
+        (regionInteriorBondProd (G := G) B DB.blue : ℂ) •
+            regionInsertedCoeff (G := G) A DB.red f M σ
+              (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) =
+          (regionInteriorBondProd (G := G) B DB.blue : ℂ) •
+            regionInsertedCoeff (G := G) B DB.red f N σ
+              (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl) := by
+  classical
+  -- The blue interior bond product of the second tensor is a nonzero scalar.
+  have hne : (regionInteriorBondProd (G := G) B DB.blue : ℂ) ≠ 0 := by
+    have : 0 < regionInteriorBondProd (G := G) B DB.blue :=
+      regionInteriorBondProd_pos (G := G) B DB.blue hposB
+    exact_mod_cast this.ne'
+  constructor
+  · -- The kernel equation gives the coefficient transfer, hence the blue-collapse equality.
+    intro hker σ σblue σcompl
+    have hcoeff := (transferCoeff_eq_incidentKernel_iff_coeff_eq A B DB.red hRA hRB hCA hCB hAB
+      hposA hposB hDim f M N).mp hker σ
+      (threeBlockComplPhysical (A := B) (e := e) DB σblue σcompl)
+    rw [hcoeff]
+  · -- The blue-collapse equality gives the fused-leg coefficient transfer, hence the kernel
+    -- equation.
+    intro hblue
+    rw [transferCoeff_eq_incidentKernel_iff_coeff_eq A B DB.red hRA hRB hCA hCB hAB
+      hposA hposB hDim f M N]
+    intro σ τ
+    -- Recover the fused-leg coefficient equality from the blue-collapse equality by reading
+    -- `τ` through the blue/complement split and dividing out the blue interior bond product.
+    have hsplit := hblue σ (threeBlockBlueSplit (A := B) (e := e) DB τ)
+      (threeBlockComplSplit (A := B) (e := e) DB τ)
+    rw [threeBlockComplPhysical_split (A := B) (e := e) DB τ, smul_eq_mul, smul_eq_mul]
+      at hsplit
+    exact mul_left_cancel₀ hne hsplit
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB3.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB3.lean
@@ -218,5 +218,92 @@ theorem isBondLocalTransferKernel_of_residualIndependent (A B : Tensor G d) (R :
       transferCoeff_eq_incidentKernel_witnessMatrix_of_residualIndependent A B R hRB hCB f
         hposB M (hres M)⟩
 
+/-! ### The per-edge gauge from two-directional residual independence
+
+Wiring the residual-independence read-off all the way to the per-edge gauge of the
+general normal PEPS Fundamental Theorem. With a shared one-edge blocking datum, positive
+bond dimensions, matched bond dimensions, the forward multiplicativity, and the
+residual-independence of every cross-tensor transfer kernel in both directions, the
+forward per-edge matrix transfer on the boundary edge `f` is conjugation by an
+invertible gauge matrix, and the bond dimensions on `f` coincide. The four block
+injectivities are read off the shared blocking datum; the bond locality in both
+directions is supplied by `isBondLocalTransferKernel_of_residualIndependent`; the
+read-off is `SharedNormalEdgeBlockingData.exists_regionEdgeGauge`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`).
+
+The remaining open obligation is therefore exactly the two residual-independence
+hypotheses: that every cross-tensor transfer kernel, read through the `f`-leg split,
+couples the two boundary configurations only through their `f`-legs. This is the
+block-level content of the source step `V=W`, the single fact the blue-collapse frame
+sets up. -/
+
+/-- **The per-edge gauge from two-directional residual independence.** Given a shared
+one-edge blocking datum for the two tensors of `SameState A B`, positive bond dimensions,
+matched bond dimensions, the forward multiplicativity, and residual independence of every
+cross-tensor transfer kernel in both directions, the forward per-edge matrix transfer on
+the boundary edge `f` of the shared red region is conjugation by an invertible gauge
+matrix `Z`, and the bond dimensions on `f` coincide.
+
+The four block injectivities come from the shared blocking datum; the two-directional
+bond locality is `isBondLocalTransferKernel_of_residualIndependent` applied to the two
+residual-independence hypotheses; the read-off is
+`SharedNormalEdgeBlockingData.exists_regionEdgeGauge`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`). The residual-independence hypotheses are
+the only remaining open content, the block-level form of the source step `V=W`.
+
+Source: arXiv:1804.04964, Section 3, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem SharedNormalEdgeBlockingData.exists_regionEdgeGauge_of_residualIndependent
+    {A B : Tensor G d} {e : Edge G}
+    (D : SharedNormalEdgeBlockingData A B e)
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (hresAB : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      TransferKernelResidualIndependent (G := G) A B D.red
+        D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) f hposB M)
+    (hresBA : ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      TransferKernelResidualIndependent (G := G) B A D.red
+        D.regionInjective_red_A (D.regionInjective_compl_red_A hposA) f hposA N)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B D.red f
+          (D.coeffTransferAB hAB hposA hposB hDim f
+            (isBondLocalTransferKernel_of_residualIndependent A B D.red
+              D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) f hposB hresAB))
+          (M * M') =
+        coeffTransferMap (G := G) A B D.red f
+            (D.coeffTransferAB hAB hposA hposB hDim f
+              (isBondLocalTransferKernel_of_residualIndependent A B D.red
+                D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) f hposB hresAB))
+            M *
+          coeffTransferMap (G := G) A B D.red f
+            (D.coeffTransferAB hAB hposA hposB hDim f
+              (isBondLocalTransferKernel_of_residualIndependent A B D.red
+                D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) f hposB hresAB))
+            M') :
+    ∃ hEdge : A.bondDim f.1 = B.bondDim f.1,
+      ∃ Z : GL (Fin (B.bondDim f.1)) ℂ,
+        ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+          (regionInsertionTransfer_of_coeffTransfer A B D.red f
+              D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) hAB hposB hDim
+              (D.coeffTransferAB hAB hposA hposB hDim f
+                (isBondLocalTransferKernel_of_residualIndependent A B D.red
+                  D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) f hposB hresAB))
+              (D.coeffTransferBA hAB.symm hposA hposB hDim.symm f
+                (isBondLocalTransferKernel_of_residualIndependent B A D.red
+                  D.regionInjective_red_A (D.regionInjective_compl_red_A hposA) f hposA hresBA))
+              hmul).fwd M =
+            (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim f.1)) ℂ) :
+                Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :=
+  D.exists_regionEdgeGauge hAB hposA hposB hDim f
+    (isBondLocalTransferKernel_of_residualIndependent A B D.red
+      D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) f hposB hresAB)
+    (isBondLocalTransferKernel_of_residualIndependent B A D.red
+      D.regionInjective_red_A (D.regionInjective_compl_red_A hposA) f hposA hresBA)
+    hmul
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB3.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonateAB3.lean
@@ -1,0 +1,222 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockResonateAB2
+
+/-!
+# The witness extraction for the cross-tensor three-block normal PEPS V=W
+
+This file performs the **witness extraction** that closes the residual open content of
+the general normal PEPS Fundamental Theorem per-edge gauge (arXiv:1804.04964, Section 3,
+Lemma `inj_isomorph`, the step `V=W`), given the blue-collapse frame
+`TNLean.PEPS.RegionBlock.ThreeBlockResonateAB2`.
+
+The landed block-frame foundation has reduced the per-edge gauge to a single predicate,
+`IsBondLocalTransferKernel` (`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`): for every
+inserted matrix `M` on the boundary edge `f` of the shared red region, the cross-tensor
+transfer kernel `transferCoeff A B red f M` is the incident-matrix kernel
+`incidentKernel B red f N` of some bond matrix `N` on `f`. By the `f`-leg split
+criterion `transferCoeff_eq_incidentKernel_iff_split`
+(`TNLean.PEPS.RegionBlock.ResonatePort2`), this holds with a given `N` exactly when the
+transfer kernel, read through the `f`-leg split, couples the two boundary configurations
+only through their `f`-legs through `N` — that is, it vanishes off the diagonal of the
+two residual boundary configurations and reads `N` on the matching `f`-leg.
+
+## The witness
+
+This file constructs the candidate witness `N` directly from `M`: a **reference residual
+boundary configuration** is fixed (the all-zero residual, available because every bond
+dimension is positive), and `N a b` is read off as the transfer-kernel value at the two
+boundary configurations whose `f`-legs are `a`, `b` and whose residual is the reference.
+This is the read-off the resonate inversion produces: the `f`-leg matrix entries of the
+collapsed coupling at the reference residual.
+
+The **residual-independence** equation — that the transfer kernel at *any* residual
+equals the reference value on the `f`-legs and vanishes off the residual diagonal — is
+the remaining content. With it, the witness `N` realizes the bond locality and the
+per-edge gauge follows mechanically.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, the step `V=W`, lines 355--486 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The reference residual boundary configuration
+
+A residual boundary configuration of `R` at the boundary edge `f` assigns a virtual
+index to every boundary edge other than `f`. Reading the all-zero index on each (legal
+because every bond dimension is positive) gives a distinguished **reference residual**,
+the frame at which the witness matrix is read off. This is the block-frame analogue of
+the edge engine's reference residual local configuration. -/
+
+/-- **The reference residual boundary configuration.** The residual boundary
+configuration of `R` at `f` that reads the zero index on every boundary edge other than
+`f`. The zero index is legal because every bond dimension is positive (`hpos`).
+
+This is the distinguished residual frame at which the witness matrix is read off, the
+block-frame port of the edge engine's reference residual local configuration.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+def referenceResidualBoundaryConfig (B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hpos : ∀ g : Edge G, 0 < B.bondDim g) :
+    RegionResidualBoundaryConfig (G := G) B R f :=
+  fun g => ⟨0, hpos g.1.1⟩
+
+/-- The region boundary configuration with `f`-leg `a` and the reference residual. -/
+noncomputable def referenceBoundaryConfigAt (B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hpos : ∀ g : Edge G, 0 < B.bondDim g) (a : Fin (B.bondDim f.1)) :
+    RegionBoundaryConfig (G := G) B R :=
+  (regionBoundaryConfigSplitAt (G := G) B R f).symm
+    (a, referenceResidualBoundaryConfig (G := G) B R f hpos)
+
+omit [Fintype V] in
+@[simp] theorem referenceBoundaryConfigAt_fLeg (B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hpos : ∀ g : Edge G, 0 < B.bondDim g) (a : Fin (B.bondDim f.1)) :
+    referenceBoundaryConfigAt (G := G) B R f hpos a f = a := by
+  rw [referenceBoundaryConfigAt, regionBoundaryConfigSplitAt_symm_apply_self]
+
+omit [Fintype V] in
+@[simp] theorem referenceBoundaryConfigAt_residual (B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hpos : ∀ g : Edge G, 0 < B.bondDim g) (a : Fin (B.bondDim f.1)) :
+    (regionBoundaryConfigSplitAt (G := G) B R f
+        (referenceBoundaryConfigAt (G := G) B R f hpos a)).2 =
+      referenceResidualBoundaryConfig (G := G) B R f hpos := by
+  rw [referenceBoundaryConfigAt, Equiv.apply_symm_apply]
+
+/-! ### The witness matrix
+
+The witness matrix `N` of `M` is read off the cross-tensor transfer kernel
+`transferCoeff A B red f M` at the reference residual: its `(a, b)` entry is the
+transfer-kernel value at the region boundary configuration with `f`-leg `a` and
+reference residual, against the complement boundary configuration whose underlying
+region boundary configuration has `f`-leg `b` and reference residual. This is the
+`f`-leg matrix entry the resonate inversion produces. -/
+
+/-- **The witness matrix.** The bond matrix on `f` read off the cross-tensor transfer
+kernel of `M` at the reference residual: `N a b` is the transfer-kernel value at the
+region boundary configuration with `f`-leg `a` and reference residual, against the
+complement boundary configuration of the region boundary configuration with `f`-leg `b`
+and reference residual.
+
+This is the explicit candidate witness of the step `V=W`: the `f`-leg matrix entries of
+the collapsed coupling at the reference residual frame. The residual-independence of the
+transfer kernel — that its value at any residual is read by this same `N` — is the
+remaining content the resonate inversion supplies.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def witnessMatrix (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ :=
+  fun a b =>
+    transferCoeff (G := G) A B R hRB hCB f M
+      (referenceBoundaryConfigAt (G := G) B R f hposB a)
+      (regionComplementBoundaryConfigEquiv (G := G) B R
+        (referenceBoundaryConfigAt (G := G) B R f hposB b))
+
+/-! ### The residual-independence equation
+
+The remaining content of the step `V=W` is the **residual-independence** of the
+cross-tensor transfer kernel: at every pair of boundary configurations, the kernel value
+is the reference-frame matrix entry `witnessMatrix … M` on the `f`-legs, gated by the
+agreement of the two residual boundary configurations. This is the `f`-leg-split form of
+the bond-locality target `transferCoeff M = incidentKernel N` of
+`transferCoeff_eq_incidentKernel_iff_split` (`TNLean.PEPS.RegionBlock.ResonatePort2`),
+specialized to the explicit witness `witnessMatrix`. -/
+
+/-- **The residual-independence predicate.** The cross-tensor transfer kernel of `M`, at
+every pair `(μ, ν')`, equals the witness-matrix entry on the `f`-legs of `μ` and of the
+underlying region boundary configuration of `ν'`, when the residual boundary
+configurations of `μ` and of that underlying configuration agree, and `0` otherwise.
+
+This is the `f`-leg-split bond-locality condition of `transferCoeff_eq_incidentKernel_iff_split`
+(`TNLean.PEPS.RegionBlock.ResonatePort2`) at the explicit witness `witnessMatrix`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+def TransferKernelResidualIndependent (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) : Prop :=
+  ∀ (μ : RegionBoundaryConfig (G := G) B R)
+    (ν' : RegionBoundaryConfig (G := G) B (Finset.univ \ R)),
+    transferCoeff (G := G) A B R hRB hCB f M μ ν' =
+      (if (regionBoundaryConfigSplitAt (G := G) B R f μ).2 =
+            (regionBoundaryConfigSplitAt (G := G) B R f
+              ((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν')).2 then
+          witnessMatrix (G := G) A B R hRB hCB f hposB M (μ f)
+            (((regionComplementBoundaryConfigEquiv (G := G) B R).symm ν') f)
+        else 0)
+
+/-- **The residual-independence equation gives the bond locality at the witness.** If the
+cross-tensor transfer kernel of `M` is residual-independent, then it is the
+incident-matrix kernel of the witness matrix `witnessMatrix … M`.
+
+This is the `f`-leg-split criterion `transferCoeff_eq_incidentKernel_iff_split`
+(`TNLean.PEPS.RegionBlock.ResonatePort2`) read in the reverse direction at the explicit
+witness `N := witnessMatrix … M`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem transferCoeff_eq_incidentKernel_witnessMatrix_of_residualIndependent
+    (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (hM : TransferKernelResidualIndependent (G := G) A B R hRB hCB f hposB M) :
+    transferCoeff (G := G) A B R hRB hCB f M =
+      incidentKernel (G := G) B R f (witnessMatrix (G := G) A B R hRB hCB f hposB M) :=
+  (transferCoeff_eq_incidentKernel_iff_split A B R hRB hCB f M
+    (witnessMatrix (G := G) A B R hRB hCB f hposB M)).mpr hM
+
+/-! ### Bond locality from residual independence in both directions
+
+Residual independence of every transfer kernel is exactly the bond locality predicate
+`IsBondLocalTransferKernel` (`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`), with the
+witness carried by `witnessMatrix`. Supplying it in both directions feeds the per-edge
+gauge `SharedNormalEdgeBlockingData.exists_regionEdgeGauge`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`) unconditionally. -/
+
+/-- **Bond locality from residual independence.** If every cross-tensor transfer kernel
+of an inserted matrix `M` on the boundary edge `f` is residual-independent, then the
+transfer kernel is bond-local (`IsBondLocalTransferKernel`), with the witness the
+explicit `witnessMatrix … M`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem isBondLocalTransferKernel_of_residualIndependent (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hres : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      TransferKernelResidualIndependent (G := G) A B R hRB hCB f hposB M) :
+    IsBondLocalTransferKernel (G := G) A B R hRB hCB f :=
+  fun M =>
+    ⟨witnessMatrix (G := G) A B R hRB hCB f hposB M,
+      transferCoeff_eq_incidentKernel_witnessMatrix_of_residualIndependent A B R hRB hCB f
+        hposB M (hres M)⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
@@ -207,6 +207,39 @@ theorem coeffTransfer_of_bondLocal (A B : Tensor G d) (R : Finset V)
   exact (transferCoeff_eq_incidentKernel_iff_coeff_eq A B R hRA hRB hCA hCB hAB
     hposA hposB hDim f M N).mp hN
 
+/-- **Bond locality is exactly the coefficient transfer.** The transfer kernel of
+every inserted matrix on the boundary edge `f` of the red region is bond-local if and
+only if the first tensor's region-inserted coefficient of every `M` is realized by a
+bond matrix `N` on the second tensor. Both directions are the reconcile-is-transfer
+bridge `coeffTransfer_iff_transferCoeff_incidentForm`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) read against the definition of
+`IsBondLocalTransferKernel`.
+
+This pins the residual open content of the block-frame coefficient transfer to the
+single predicate `IsBondLocalTransferKernel`: nothing weaker and nothing stronger than
+the coefficient transfer the per-edge gauge consumes.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+254--582 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem bondLocal_iff_coeffTransfer (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    IsBondLocalTransferKernel (G := G) A B R hRB hCB f ↔
+      ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+          ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+            (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+            regionInsertedCoeff (G := G) A R f M σ τ =
+              regionInsertedCoeff (G := G) B R f N σ τ :=
+  (coeffTransfer_iff_transferCoeff_incidentForm A B R hRA hRB hCA hCB hAB
+    hposA hposB hDim f).symm
+
 /-! ### The per-edge gauge from bond locality in both directions
 
 Assembling the two coefficient transfers from the two-directional bond locality and

--- a/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
@@ -142,5 +142,176 @@ theorem regionInjective_compl_red_B (D : SharedNormalEdgeBlockingData A B e)
 
 end SharedNormalEdgeBlockingData
 
+/-! ### Bond locality of the transfer kernel
+
+The one fact the block-frame foundation does not supply: the transfer kernel
+`transferCoeff A B red f M` couples the two boundary configurations only through
+their legs on the boundary edge `f`. Concretely, for every inserted matrix `M` the
+kernel is the incident-matrix kernel `incidentKernel B red f N` of some bond matrix
+`N`. This is the block-level content of the source step `V=W`, forced by the resonate
+identity and the full injectivity of both blocked endpoints. It is isolated here as
+the predicate `IsBondLocalTransferKernel`. -/
+
+/-- **Bond locality of the transfer kernel.** For every inserted matrix `M` on the
+boundary edge `f` of the red region, the transfer kernel
+`transferCoeff A B red hRB hCB f M` (the doubly-indexed kernel read off the two
+blocked left inverses of the second tensor) is the incident-matrix kernel
+`incidentKernel B red f N` of some bond matrix `N` on `f`. Equivalently, the kernel
+depends on the two boundary configurations only through their legs on `f`.
+
+This is the residual open content of the block-frame coefficient transfer
+(arXiv:1804.04964, Section 3, the step `V=W`). The reconcile-is-transfer bridge
+`transferCoeff_eq_incidentKernel_iff_coeff_eq`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) shows that this predicate is equivalent
+to the coefficient transfer `∀ M, ∃ N, ∀ σ τ, coeff_A M = coeff_B N` once the four
+block injectivities and positive bond dimensions hold.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+355--486 of `Papers/1804.04964/paper_normal.tex`. -/
+def IsBondLocalTransferKernel (A B : Tensor G d) (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) : Prop :=
+  ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+    ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      transferCoeff (G := G) A B R hRB hCB f M = incidentKernel (G := G) B R f N
+
+/-- **Bond locality gives the coefficient transfer.** If the transfer kernel of every
+inserted matrix on the boundary edge `f` of the red region is bond-local, then the
+first tensor's region-inserted coefficient of every `M` is realized by a bond matrix
+`N` on the second tensor. This is the reconcile-is-transfer bridge
+`transferCoeff_eq_incidentKernel_iff_coeff_eq`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) read in the forward direction.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_of_bondLocal (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hbond : IsBondLocalTransferKernel (G := G) A B R hRB hCB f) :
+    ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ := by
+  intro M
+  obtain ⟨N, hN⟩ := hbond M
+  refine ⟨N, ?_⟩
+  exact (transferCoeff_eq_incidentKernel_iff_coeff_eq A B R hRA hRB hCA hCB hAB
+    hposA hposB hDim f M N).mp hN
+
+/-! ### The per-edge gauge from bond locality in both directions
+
+Assembling the two coefficient transfers from the two-directional bond locality and
+feeding them, with the multiplicative forward choice, to the conditional per-edge
+gauge `exists_regionEdgeGauge_of_coeffTransfer`
+(`TNLean.PEPS.RegionBlock.RegionReconcile`). All four block injectivities come from
+the shared one-edge blocking data and positive bond dimensions; the forward
+multiplicativity `hmul` and the two-directional bond locality are the remaining
+hypotheses, the open content `V=W` of the block frame. -/
+
+/-- The forward coefficient transfer of a shared one-edge blocking datum, derived from
+the `A → B` bond locality. For each inserted matrix `M` on the boundary edge `f` of
+the shared red region there is a bond matrix `N` on the second tensor whose
+region-inserted coefficient matches. -/
+theorem SharedNormalEdgeBlockingData.coeffTransferAB
+    (D : SharedNormalEdgeBlockingData A B e)
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (hbondAB : IsBondLocalTransferKernel (G := G) A B D.red
+      D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) f) :
+    ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) D.red)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ D.red)),
+          regionInsertedCoeff (G := G) A D.red f M σ τ =
+            regionInsertedCoeff (G := G) B D.red f N σ τ :=
+  coeffTransfer_of_bondLocal A B D.red D.regionInjective_red_A D.regionInjective_red_B
+    (D.regionInjective_compl_red_A hposA) (D.regionInjective_compl_red_B hposB) hAB
+    hposA hposB hDim f hbondAB
+
+/-- The backward coefficient transfer of a shared one-edge blocking datum, derived from
+the `B → A` bond locality (the shared datum with the two tensors swapped). For each
+inserted matrix `N` on the boundary edge `f` there is a bond matrix `M` on the first
+tensor whose region-inserted coefficient matches. -/
+theorem SharedNormalEdgeBlockingData.coeffTransferBA
+    (D : SharedNormalEdgeBlockingData A B e)
+    (hBA : SameState B A)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : B.bondDim = A.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (hbondBA : IsBondLocalTransferKernel (G := G) B A D.red
+      D.regionInjective_red_A (D.regionInjective_compl_red_A hposA) f) :
+    ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      ∃ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) D.red)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ D.red)),
+          regionInsertedCoeff (G := G) B D.red f N σ τ =
+            regionInsertedCoeff (G := G) A D.red f M σ τ :=
+  coeffTransfer_of_bondLocal B A D.red D.regionInjective_red_B D.regionInjective_red_A
+    (D.regionInjective_compl_red_B hposB) (D.regionInjective_compl_red_A hposA) hBA
+    hposB hposA hDim f hbondBA
+
+/-- **The per-edge gauge from two-directional bond locality.** Given a shared one-edge
+blocking datum for the two tensors of `SameState A B`, positive bond dimensions,
+matched bond dimensions, two-directional bond locality of the transfer kernel on the
+boundary edge `f` of the shared red region, and the multiplicative forward choice, the
+forward per-edge matrix transfer on `f` is conjugation by an invertible gauge matrix
+`Z`, and the bond dimensions on `f` coincide.
+
+No single-vertex injectivity is used: the four block injectivities come from the
+shared blocking data and the union lemma, the two coefficient transfers come from the
+two-directional bond locality, and the read-off is
+`exists_regionEdgeGauge_of_coeffTransfer`
+(`TNLean.PEPS.RegionBlock.RegionReconcile`). The bond locality and the forward
+multiplicativity are the remaining hypotheses, the open content `V=W` of the block
+frame, documented in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem SharedNormalEdgeBlockingData.exists_regionEdgeGauge
+    (D : SharedNormalEdgeBlockingData A B e)
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
+    (hbondAB : IsBondLocalTransferKernel (G := G) A B D.red
+      D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) f)
+    (hbondBA : IsBondLocalTransferKernel (G := G) B A D.red
+      D.regionInjective_red_A (D.regionInjective_compl_red_A hposA) f)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B D.red f
+          (D.coeffTransferAB hAB hposA hposB hDim f hbondAB) (M * M') =
+        coeffTransferMap (G := G) A B D.red f
+            (D.coeffTransferAB hAB hposA hposB hDim f hbondAB) M *
+          coeffTransferMap (G := G) A B D.red f
+            (D.coeffTransferAB hAB hposA hposB hDim f hbondAB) M') :
+    ∃ hEdge : A.bondDim f.1 = B.bondDim f.1,
+      ∃ Z : GL (Fin (B.bondDim f.1)) ℂ,
+        ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+          (regionInsertionTransfer_of_coeffTransfer A B D.red f
+              D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) hAB hposB hDim
+              (D.coeffTransferAB hAB hposA hposB hDim f hbondAB)
+              (D.coeffTransferBA hAB.symm hposA hposB hDim.symm f hbondBA) hmul).fwd M =
+            (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim f.1)) ℂ) :
+                Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :=
+  exists_regionEdgeGauge_of_coeffTransfer A B D.red f
+    D.regionInjective_red_A (D.regionInjective_compl_red_A hposA)
+    D.regionInjective_red_B (D.regionInjective_compl_red_B hposB)
+    hAB hposA hposB hDim
+    (D.coeffTransferAB hAB hposA hposB hDim f hbondAB)
+    (D.coeffTransferBA hAB.symm hposA hposB hDim.symm f hbondBA) hmul
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
@@ -1,0 +1,108 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockReconcile
+import TNLean.PEPS.RegionBlock.UnionInjectivity
+import TNLean.PEPS.RegionBlock.BlockCoeffTransfer
+
+/-!
+# The block-frame coefficient transfer and per-edge gauge for the normal PEPS theorem
+
+This file wires the three-block engine (`TNLean.PEPS.RegionBlock.ThreeBlockReconcile`),
+the union injectivity of the host block (`TNLean.PEPS.RegionBlock.UnionInjectivity`),
+and the two-block backbone (`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`) into the
+per-edge gauge of `TNLean.PEPS.RegionBlock.RegionReconcile`, for two tensors blocked
+around the same edge into the same red/blue/complement triple.
+
+The union lemma `regionBlockedTensorInjective_compl_red`
+(`TNLean.PEPS.RegionBlock.UnionInjectivity`) supplies the host-block injectivity
+`RegionBlockedTensorInjective A (univ \ red)` that every backbone lemma of
+`TNLean.PEPS.RegionBlock.BlockCoeffTransfer` needs at the complement of the red
+region. With it, the two block-injectivity hypotheses of both tensors at `red` and
+at `univ \ red` are all available from the one-edge blocking data and positive bond
+dimensions.
+
+## The packaging
+
+A `SharedNormalEdgeBlockingData` records a one-edge blocking datum for each of two
+tensors `A`, `B` around the same edge, sharing the same red, blue, and complement
+regions. From it the four block-injectivity facts the backbone consumes —
+`RegionBlockedTensorInjective A red`, `RegionBlockedTensorInjective A (univ \ red)`,
+and the same for `B` — are read off directly: the region injectivities are the
+blocking-data fields, and the host-block injectivities are the union lemma.
+
+## The reduction to bond locality
+
+By the block-frame reconcile-is-transfer bridge
+`transferCoeff_eq_incidentKernel_iff_coeff_eq`
+(`TNLean.PEPS.RegionBlock.BlockCoeffTransfer`), the coefficient transfer
+`∀ M, ∃ N, ∀ σ τ, coeff_A M = coeff_B N` (the input `htransferAB` of the per-edge
+gauge) holds exactly when, for every inserted matrix `M`, the transfer kernel
+`transferCoeff A B red f M` is the incident-matrix kernel of some bond matrix `N` on
+the boundary edge `f`. The latter is the **bond locality** of the transfer kernel:
+the kernel couples the two boundary configurations only through their legs on `f`.
+This is the block-level content of the source step `V=W`. The single remaining open
+fact is therefore packaged here as the predicate `IsBondLocalTransferKernel`, and the
+per-edge gauge is assembled unconditionally on top of it.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Shared one-edge blocking data for two tensors
+
+The faithful two-tensor packaging of the source comparison: the two tensors `A` and
+`B` are blocked around the **same** edge into the **same** red, blue, and complement
+regions, with each region injective for each tensor. A single
+`NormalEdgeBlockingData` carries the regions and one tensor's injectivity; the
+shared datum adds the second tensor's blocking datum with equal regions. -/
+
+/-- **Shared one-edge blocking data.** A one-edge blocking datum for the first tensor
+`A` and one for the second tensor `B`, both around the edge `e`, sharing the same
+red, blue, and complement regions.
+
+The source comparison blocks both tensors of `SameState A B` around the same edge
+into the same three injective regions (arXiv:1804.04964, Section 3, proof of
+Theorem 3). The shared regions are the content of the equalities `red_eq`, `blue_eq`,
+`complement_eq`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+structure SharedNormalEdgeBlockingData (A B : Tensor G d) (e : Edge G) where
+  /-- The first tensor's one-edge blocking datum. -/
+  dataA : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e
+  /-- The second tensor's one-edge blocking datum. -/
+  dataB : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) B) G e
+  /-- The two tensors share the red region. -/
+  red_eq : dataB.red = dataA.red
+  /-- The two tensors share the blue region. -/
+  blue_eq : dataB.blue = dataA.blue
+  /-- The two tensors share the complement region. -/
+  complement_eq : dataB.complement = dataA.complement
+
+namespace SharedNormalEdgeBlockingData
+
+variable {A B : Tensor G d} {e : Edge G}
+
+/-- The shared red region. -/
+def red (D : SharedNormalEdgeBlockingData A B e) : Finset V := D.dataA.red
+
+/-- The shared blue region. -/
+def blue (D : SharedNormalEdgeBlockingData A B e) : Finset V := D.dataA.blue
+
+/-- The shared complement region. -/
+def complement (D : SharedNormalEdgeBlockingData A B e) : Finset V := D.dataA.complement
+
+end SharedNormalEdgeBlockingData
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
@@ -240,6 +240,26 @@ theorem bondLocal_iff_coeffTransfer (A B : Tensor G d) (R : Finset V)
   (coeffTransfer_iff_transferCoeff_incidentForm A B R hRA hRB hCA hCB hAB
     hposA hposB hDim f).symm
 
+/-- **The identity transfer is bond-local.** For a single tensor `A`, the transfer
+kernel `transferCoeff A A R f M` of any inserted matrix `M` is the incident-matrix
+kernel of `M` itself. This is the diagonal case of the reconcile-is-transfer bridge:
+the coefficient transfer is the reflexive `coeff_A M = coeff_A M`, so the transfer
+kernel is bond-local with bond matrix `M`. It records that the block-frame apparatus
+recovers the identity transfer, the anchor of the cross-tensor transfer.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isBondLocalTransferKernel_self (A : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    IsBondLocalTransferKernel (G := G) A A R hRA hCA f := by
+  intro M
+  refine ⟨M, ?_⟩
+  exact (transferCoeff_eq_incidentKernel_iff_coeff_eq A A R hRA hRA hCA hCA
+    (fun _ => rfl) hposA hposA rfl f M M).mpr (fun _ _ => rfl)
+
 /-! ### The per-edge gauge from bond locality in both directions
 
 Assembling the two coefficient transfers from the two-directional bond locality and

--- a/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
@@ -102,6 +102,44 @@ def blue (D : SharedNormalEdgeBlockingData A B e) : Finset V := D.dataA.blue
 /-- The shared complement region. -/
 def complement (D : SharedNormalEdgeBlockingData A B e) : Finset V := D.dataA.complement
 
+/-! ### The four block-injectivity facts the backbone consumes
+
+Every backbone lemma of `TNLean.PEPS.RegionBlock.BlockCoeffTransfer` at the red
+region needs the four blocked-tensor injectivities
+`RegionBlockedTensorInjective A red`, `RegionBlockedTensorInjective A (univ \ red)`,
+`RegionBlockedTensorInjective B red`, and `RegionBlockedTensorInjective B (univ \ red)`.
+The region injectivities are the blocking-data fields; the host-block injectivities
+are the union lemma `regionBlockedTensorInjective_compl_red`. For the second tensor
+the shared region equalities transport the read-offs to the shared red region. -/
+
+/-- The first tensor's red block is blocked-tensor injective. -/
+theorem regionInjective_red_A (D : SharedNormalEdgeBlockingData A B e) :
+    RegionBlockedTensorInjective (G := G) A D.red :=
+  regionBlockedTensorInjective_red (A := A) (e := e) D.dataA
+
+/-- The second tensor's red block is blocked-tensor injective. The shared red region
+equality transports the read-off to the shared red region. -/
+theorem regionInjective_red_B (D : SharedNormalEdgeBlockingData A B e) :
+    RegionBlockedTensorInjective (G := G) B D.red := by
+  rw [SharedNormalEdgeBlockingData.red, ← D.red_eq]
+  exact regionBlockedTensorInjective_red (A := B) (e := e) D.dataB
+
+/-- The first tensor's host block `univ \ red` is blocked-tensor injective, by the
+union lemma applied to the blue and complement blocks. -/
+theorem regionInjective_compl_red_A (D : SharedNormalEdgeBlockingData A B e)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) :
+    RegionBlockedTensorInjective (G := G) A (Finset.univ \ D.red) :=
+  regionBlockedTensorInjective_compl_red (A := A) (e := e) D.dataA hposA
+
+/-- The second tensor's host block `univ \ red` is blocked-tensor injective, by the
+union lemma applied to its blue and complement blocks, transported to the shared red
+region. -/
+theorem regionInjective_compl_red_B (D : SharedNormalEdgeBlockingData A B e)
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g) :
+    RegionBlockedTensorInjective (G := G) B (Finset.univ \ D.red) := by
+  rw [SharedNormalEdgeBlockingData.red, ← D.red_eq]
+  exact regionBlockedTensorInjective_compl_red (A := B) (e := e) D.dataB hposB
+
 end SharedNormalEdgeBlockingData
 
 end PEPS

--- a/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
@@ -1,0 +1,158 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockResonate2
+
+/-!
+# Injectivity of the union of two injective region blocks
+
+This file proves the union lemma of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`): the contraction of injective tensors over the
+union of two disjoint injective regions is again injective. The load-bearing
+instance is the union of the blue and complement blocks of a
+`NormalEdgeBlockingData`, whose union is the set complement of the red block
+(`univ \ red`). The three-block gauge chain needs the host block `univ \ red` to be
+blocked-tensor injective, which this file supplies from injectivity of the blue and
+complement blocks individually.
+
+The proof is the source's two-step inverse application. Suppose a coefficient
+family `c` annihilates the blocked-region weight family of `univ \ red`. Reading the
+physical leg of `univ \ red` as a fused blue/complement pair
+(`threeBlockComplPhysical`, a bijection onto `univ \ red` legs), the core
+factorization `regionInteriorBondProd_smul_threeBlockComplWeight_eq` rewrites the
+annihilation as a complement-block combination whose coefficients are the
+`c`-weighted blue coupling coefficients. Injectivity of the complement block removes
+the complement part, leaving `c`-weighted blue coupling coefficients that vanish for
+every complement boundary configuration. The blue coupling coefficient, read as a
+function of the blue physical leg, factors through the blue block's blocked-region
+weights; injectivity of the blue block then removes the remaining part, forcing
+`c = 0`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `injective_union`, lines 1324--1400 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d} {e : Edge G}
+
+/-! ### The blue inversion of the host annihilation
+
+A coefficient family `c` annihilating the blocked-region weight family of the host
+`univ \ red` annihilates, at every fused blue/complement physical leg, the host
+weight. Reading the resulting identity as a function of the blue physical leg and
+applying the blue block's chosen left inverse strips the blue block, leaving the
+`c`-weighted complement coupling coefficients vanishing for every complement physical
+leg and blue boundary configuration. -/
+
+open scoped Classical in
+/-- The blue block strips out of the host annihilation. If the coefficient family `c`
+annihilates the blocked-region weight family of the host `univ \ red`, then for every
+complement physical leg `σcompl` and blue boundary configuration `bβ`, the
+`c`-weighted sum of complement coupling coefficients
+`threeBlockComplCoeff D bdry σcompl bβ` vanishes.
+
+The annihilation, evaluated at the fused leg `threeBlockComplPhysical D σblue σcompl`,
+holds for every blue leg `σblue`. Scaling by the nonzero blue interior bond product
+and applying the blue smul-factorization
+(`regionInteriorBondProd_smul_threeBlockBlueWeight_eq`) rewrites the host weights as
+the complement-coupling combination of the blue blocked-region weights; the blue
+block's chosen left inverse then reads off the complement coupling row.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem complCoeff_combination_eq_zero
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (hpos : ∀ f : Edge G, 0 < A.bondDim f)
+    (c : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red) → ℂ)
+    (hc : ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+        c bdry • regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry = 0)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (bβ : RegionBoundaryConfig (G := G) A D.blue) :
+    ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+        c bdry • threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ = 0 := by
+  classical
+  -- The σblue-function obtained by `c`-combining the fused host weights.
+  set F : RegionPhysicalConfig (V := V) (d := d) D.blue → ℂ :=
+    fun σblue => ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+      c bdry • regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+        (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl) with hF
+  -- The host annihilation makes `F` vanish identically.
+  have hFzero : F = 0 := by
+    funext σblue
+    rw [hF]
+    have := congrFun hc (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)
+    simpa [Finset.sum_apply, Pi.smul_apply] using this
+  -- Scaling `F` by the blue interior bond product is the complement-coupling
+  -- combination of the blue blocked-region weights.
+  have hbluefac :
+      (regionInteriorBondProd (G := G) A D.blue : ℂ) • F =
+        regionBlockedTensorMap (G := G) A D.blue
+          (fun bβ' => ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+            c bdry • threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ') := by
+    rw [hF]
+    funext σblue
+    rw [Pi.smul_apply, regionBlockedTensorMap_apply]
+    -- Distribute the bond multiple through the `c`-combination and apply the blue
+    -- smul-factorization to each fused host weight.
+    rw [Finset.smul_sum]
+    rw [show (∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+          (regionInteriorBondProd (G := G) A D.blue : ℂ) •
+            c bdry • regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+              (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) =
+        ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+          c bdry • ((regionInteriorBondProd (G := G) A D.blue : ℂ) •
+            regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry
+              (threeBlockComplPhysical (A := A) (e := e) D σblue σcompl)) from
+        Finset.sum_congr rfl (fun bdry _ => by rw [smul_comm])]
+    rw [show (∑ μ : RegionBoundaryConfig (G := G) A D.blue,
+          (fun bβ' => ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+            c bdry • threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ') μ •
+              regionBlockedWeight (G := G) A D.blue μ σblue) =
+        ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+          c bdry • ∑ bβ' : RegionBoundaryConfig (G := G) A D.blue,
+            threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ' •
+              regionBlockedWeight (G := G) A D.blue bβ' σblue from ?_]
+    · refine Finset.sum_congr rfl (fun bdry _ => ?_)
+      congr 1
+      rw [regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue
+        (A := A) (e := e) D bdry σblue σcompl]
+    · -- Beta-reduce, distribute the `bβ'`-sum out of each `c bdry` scalar, and swap
+      -- the `bdry`/`bβ'` summation order.
+      simp only []
+      rw [show (∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+            c bdry • ∑ bβ' : RegionBoundaryConfig (G := G) A D.blue,
+              threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ' •
+                regionBlockedWeight (G := G) A D.blue bβ' σblue) =
+          ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+            ∑ bβ' : RegionBoundaryConfig (G := G) A D.blue,
+              (c bdry * threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ') •
+                regionBlockedWeight (G := G) A D.blue bβ' σblue from
+        Finset.sum_congr rfl (fun bdry _ => by
+          rw [Finset.smul_sum]
+          exact Finset.sum_congr rfl (fun bβ' _ => by rw [smul_smul]))]
+      rw [Finset.sum_comm]
+      refine Finset.sum_congr rfl (fun bβ' _ => ?_)
+      rw [Finset.sum_smul]
+      refine Finset.sum_congr rfl (fun bdry _ => ?_)
+      simp only [smul_eq_mul, mul_assoc]
+  -- The left side is zero, so the blue blocked map kills the complement coupling row;
+  -- injectivity of the blue block forces that row to vanish.
+  rw [hFzero, smul_zero] at hbluefac
+  have hrow := regionBlockedTensorMap_injective_of_injective (G := G) A D.blue
+    (regionBlockedTensorInjective_blue (A := A) (e := e) D)
+    (a₁ := fun bβ' => ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+      c bdry • threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ')
+    (a₂ := 0) (by rw [← hbluefac, map_zero])
+  have := congrFun hrow bβ
+  simpa using this
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
@@ -287,5 +287,620 @@ theorem complCoeff_combination_eq_zero
   have := congrFun hrow bβ
   simpa using this
 
+/-! ### The blue/red crossing multiplicity collapse of the complement coupling
+
+The complement coupling coefficient `threeBlockComplCoeff D bdry σcompl bβ`, read as a
+function of the complement physical leg `σcompl`, lies in the range of the complement
+block's blocked-region tensor map, with the coefficient row supported on the single
+host residual `bdry` reconstructed from `bβ` and the complement boundary configuration.
+
+The route mirrors `stateCoeff_eq_regionComplement` at the level of the constrained
+coupling sum. Grouping the global configurations of `threeBlockComplCoeff` by the
+complement boundary configuration `bc'` they induce, each inner sum runs over the
+configurations carrying the three prescribed boundary labels (host `bdry`, blue `bβ`,
+complement `bc'`). The complement blocked-region weight at `bc'` runs over the larger
+family of configurations carrying only the complement label `bc'`; the difference is
+the free virtual indices on the red/blue crossing edges, which the complement vertex
+product ignores. Projecting away those crossing indices collapses the larger sum onto
+the constrained sum with the red/blue crossing bond product as the constant fiber
+multiplicity. When no configuration carries the three labels (the host residual is not
+the one reconstructed from `bβ` and `bc'`, or `bβ` and `bc'` clash on a blue/complement
+crossing edge) the constrained sum is empty and the collapse is the zero identity. -/
+
+/-- The red/blue crossing edges: the boundary edges of the red block that are also
+boundary edges of the blue block. These are the free virtual indices distinguishing the
+complement blocked-region weight from the constrained complement coupling sum. -/
+def IsBlueRedCrossingEdge
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) (g : Edge G) :
+    Prop :=
+  IsRegionBoundaryEdge (G := G) D.red g ∧ IsRegionBoundaryEdge (G := G) D.blue g
+
+instance
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) (g : Edge G) :
+    Decidable (IsBlueRedCrossingEdge (A := A) (e := e) D g) := by
+  unfold IsBlueRedCrossingEdge; infer_instance
+
+/-- The bond-dimension product over the red/blue crossing edges: the constant fiber
+multiplicity of the complement coupling collapse. -/
+noncomputable def blueRedCrossingBondProd
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) : ℕ :=
+  ∏ g ∈ Finset.univ.filter (fun g : Edge G => IsBlueRedCrossingEdge (A := A) (e := e) D g),
+    A.bondDim g
+
+/-- A red/blue crossing edge is not incident to the complement block: each of its
+endpoints lies in the red or blue block, both disjoint from the complement. -/
+theorem not_isRegionIncidentEdge_complement_of_blueRedCrossing
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    {g : Edge G} (hg : IsBlueRedCrossingEdge (A := A) (e := e) D g) :
+    ¬ IsRegionIncidentEdge (G := G) D.complement g := by
+  -- If an endpoint were in the complement it would be outside both red and blue, so
+  -- both red and blue boundary edges would put their in-block endpoint on the other
+  -- vertex, forcing that vertex into both red and blue — impossible.
+  have key : ∀ w : V, w ∈ D.complement →
+      (g.1.1 ∈ D.red ∧ g.1.2 ∉ D.red ∨ g.1.1 ∉ D.red ∧ g.1.2 ∈ D.red) →
+      (g.1.1 ∈ D.blue ∧ g.1.2 ∉ D.blue ∨ g.1.1 ∉ D.blue ∧ g.1.2 ∈ D.blue) →
+      (w = g.1.1 ∨ w = g.1.2) → False := by
+    intro w hw hr hb hwg
+    have hwnotred : w ∉ D.red := fun h =>
+      (Finset.disjoint_left.mp D.red_disjoint_complement) h hw
+    have hwnotblue : w ∉ D.blue := fun h =>
+      (Finset.disjoint_left.mp D.blue_disjoint_complement) h hw
+    -- The other endpoint lies in both red and blue.
+    rcases hwg with hwg | hwg
+    · -- `w = g.1.1`, so `g.1.1 ∉ red, ∉ blue`; the edges put `g.1.2 ∈ red ∩ blue`.
+      have h1notred : g.1.1 ∉ D.red := hwg ▸ hwnotred
+      have h1notblue : g.1.1 ∉ D.blue := hwg ▸ hwnotblue
+      have h2red : g.1.2 ∈ D.red := (hr.resolve_left (fun h => h1notred h.1)).2
+      have h2blue : g.1.2 ∈ D.blue := (hb.resolve_left (fun h => h1notblue h.1)).2
+      exact (Finset.disjoint_left.mp D.red_disjoint_blue) h2red h2blue
+    · have h2notred : g.1.2 ∉ D.red := hwg ▸ hwnotred
+      have h2notblue : g.1.2 ∉ D.blue := hwg ▸ hwnotblue
+      have h1red : g.1.1 ∈ D.red := (hr.resolve_right (fun h => h2notred h.2)).1
+      have h1blue : g.1.1 ∈ D.blue := (hb.resolve_right (fun h => h2notblue h.2)).1
+      exact (Finset.disjoint_left.mp D.red_disjoint_blue) h1red h1blue
+  rintro (hc | hc)
+  · exact key _ hc hg.1 hg.2 (Or.inl rfl)
+  · exact key _ hc hg.1 hg.2 (Or.inr rfl)
+
+/-- The complement vertex product reads a global virtual configuration only through the
+complement-incident edges, which never include a red/blue crossing edge. Overwriting a
+configuration on the red/blue crossing edges therefore does not change the complement
+vertex product. -/
+theorem complProd_overwrite_blueRedCrossing_eq
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (ζ ζ' : VirtualConfig A)
+    (h : ∀ g : Edge G, ¬ IsBlueRedCrossingEdge (A := A) (e := e) D g → ζ g = ζ' g) :
+    (∏ w : {w : V // w ∈ D.complement}, A.component w.1 (fun ie => ζ ie.1) (σcompl w)) =
+      ∏ w : {w : V // w ∈ D.complement}, A.component w.1 (fun ie => ζ' ie.1) (σcompl w) := by
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1
+  funext ie
+  by_cases hcross : IsBlueRedCrossingEdge (A := A) (e := e) D ie.1
+  · have hinc : IsRegionIncidentEdge (G := G) D.complement ie.1 := by
+      have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
+      rcases hwinc with hw | hw
+      · exact Or.inl (by rw [hw]; exact w.2)
+      · exact Or.inr (by rw [hw]; exact w.2)
+    exact absurd hinc
+      (not_isRegionIncidentEdge_complement_of_blueRedCrossing (A := A) (e := e) D hcross)
+  · exact h ie.1 hcross
+
+open scoped Classical in
+/-- **The red/blue crossing fiber count.** Among the global configurations carrying the
+complement boundary label `bc'`, those projecting (by overwriting the red/blue crossing
+edges with a fixed witness `q₀`) onto a fixed configuration `q` are the configurations
+agreeing with `q` off the red/blue crossing edges. They biject with the free virtual
+indices on the red/blue crossing edges, so the fiber has cardinality
+`blueRedCrossingBondProd`. -/
+theorem blueRedCrossing_fiber_card
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bc' : RegionBoundaryConfig (G := G) A D.complement)
+    (q₀ q : VirtualConfig A)
+    (hq : regionBoundaryLabel (G := G) A D.complement q = bc')
+    (hq0cross : ∀ g : Edge G, IsBlueRedCrossingEdge (A := A) (e := e) D g → q g = q₀ g) :
+    (Finset.univ.filter (fun ζ : VirtualConfig A =>
+        regionBoundaryLabel (G := G) A D.complement ζ = bc' ∧
+          (fun g => if IsBlueRedCrossingEdge (A := A) (e := e) D g then q₀ g else ζ g) =
+            q)).card =
+      blueRedCrossingBondProd (A := A) (e := e) D := by
+  classical
+  rw [show blueRedCrossingBondProd (A := A) (e := e) D =
+      (Finset.univ : Finset ((g : {g : Edge G //
+          IsBlueRedCrossingEdge (A := A) (e := e) D g}) → Fin (A.bondDim g.1))).card from ?_]
+  · refine Finset.card_nbij'
+      (fun ζ g => ζ g.1)
+      (fun h g => if hg : IsBlueRedCrossingEdge (A := A) (e := e) D g then h ⟨g, hg⟩ else q g)
+      ?_ ?_ ?_ ?_
+    · -- The crossing legs land in the full assignment set.
+      intro ζ _; exact Finset.mem_univ _
+    · -- The reconstruction lands in the fiber.
+      intro h _
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and]
+      refine ⟨?_, ?_⟩
+      · -- Same complement boundary label as `q`: crossing edges are not complement
+        -- boundary edges, so the reconstruction agrees with `q` there.
+        funext f
+        simp only [regionBoundaryLabel_apply]
+        by_cases hcross : IsBlueRedCrossingEdge (A := A) (e := e) D f.1
+        · exact absurd (incident_of_boundary (G := G) D.complement f.2)
+            (not_isRegionIncidentEdge_complement_of_blueRedCrossing (A := A) (e := e) D hcross)
+        · rw [dif_neg hcross]
+          have := congrFun hq f
+          rwa [regionBoundaryLabel_apply] at this
+      · -- Projecting the reconstruction recovers `q`: off the crossing it is `q`, and on
+        -- the crossing the projection reads `q₀`, which `q` matches.
+        funext g
+        by_cases hcross : IsBlueRedCrossingEdge (A := A) (e := e) D g
+        · rw [if_pos hcross]; exact (hq0cross g hcross).symm
+        · rw [if_neg hcross, dif_neg hcross]
+    · -- Reconstructing from the crossing legs of a fiber element recovers it.
+      intro ζ hζ
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hζ
+      obtain ⟨_, hproj⟩ := hζ
+      funext g
+      by_cases hcross : IsBlueRedCrossingEdge (A := A) (e := e) D g
+      · simp only [hcross, dif_pos]
+      · simp only [hcross, dif_neg, not_false_iff]
+        have := congrFun hproj g; rw [if_neg hcross] at this; exact this.symm
+    · -- Reading the crossing legs of a reconstruction recovers them.
+      intro h _
+      funext g
+      simp only [g.2, dif_pos]
+  · rw [Finset.card_univ, Fintype.card_pi]
+    simp only [Fintype.card_fin]
+    rw [blueRedCrossingBondProd,
+      ← Finset.prod_subtype (Finset.univ.filter
+          (fun g : Edge G => IsBlueRedCrossingEdge (A := A) (e := e) D g))
+        (fun g => by simp [Finset.mem_filter]) (fun g => A.bondDim g)]
+
+/-- A host boundary edge is a red boundary edge: having one endpoint in `univ \ red`
+and one in `red` is the same as having one endpoint in `red` and one outside. -/
+theorem isRegionBoundaryEdge_red_of_host
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    {g : Edge G} (hg : IsRegionBoundaryEdge (G := G) (Finset.univ \ D.red) g) :
+    IsRegionBoundaryEdge (G := G) D.red g := by
+  rcases hg with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
+  · have h1notred : g.1.1 ∉ D.red := (Finset.mem_sdiff.mp h1host).2
+    have h2red : g.1.2 ∈ D.red := by
+      rw [Finset.mem_sdiff] at h2nothost; push_neg at h2nothost
+      exact h2nothost (Finset.mem_univ _)
+    exact Or.inr ⟨h1notred, h2red⟩
+  · have h1red : g.1.1 ∈ D.red := by
+      rw [Finset.mem_sdiff] at h1nothost; push_neg at h1nothost
+      exact h1nothost (Finset.mem_univ _)
+    have h2notred : g.1.2 ∉ D.red := (Finset.mem_sdiff.mp h2host).2
+    exact Or.inl ⟨h1red, h2notred⟩
+
+/-- A host boundary edge that is not a red/blue crossing edge is a complement boundary
+edge: its host-side endpoint lies in the complement (otherwise it would lie in the blue
+block and the edge would be a crossing edge). -/
+theorem isComplBoundary_of_hostBoundary_not_crossing
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    {g : Edge G} (hg : IsRegionBoundaryEdge (G := G) (Finset.univ \ D.red) g)
+    (hncross : ¬ IsBlueRedCrossingEdge (A := A) (e := e) D g) :
+    IsRegionBoundaryEdge (G := G) D.complement g := by
+  -- The host-side endpoint is in `blue ∪ complement`. If it were in blue, with the red
+  -- endpoint outside blue, the edge would be a blue boundary edge, making it a crossing
+  -- edge. So the host-side endpoint is in the complement.
+  rcases hostBoundary_hostVertex_mem_blue_or_compl (A := A) (e := e) D hg with
+    ⟨h1host, hbc⟩ | ⟨h2host, hbc⟩
+  · rcases hbc with hbl | hcl
+    · exact absurd ⟨isRegionBoundaryEdge_red_of_host (A := A) (e := e) D hg,
+        isBlueBoundaryEdge_of_hostBoundary_blue (A := A) (e := e) D hg
+          (Or.inl ⟨h1host, hbl⟩)⟩ hncross
+    · exact isComplBoundaryEdge_of_hostBoundary_compl (A := A) (e := e) D hg
+        (Or.inl ⟨h1host, hcl⟩)
+  · rcases hbc with hbl | hcl
+    · exact absurd ⟨isRegionBoundaryEdge_red_of_host (A := A) (e := e) D hg,
+        isBlueBoundaryEdge_of_hostBoundary_blue (A := A) (e := e) D hg
+          (Or.inr ⟨h2host, hbl⟩)⟩ hncross
+    · exact isComplBoundaryEdge_of_hostBoundary_compl (A := A) (e := e) D hg
+        (Or.inr ⟨h2host, hcl⟩)
+
+open scoped Classical in
+/-- **The per-fiber complement weight collapse.** When some global configuration `q₀`
+carries the three boundary labels (host `bdry`, blue `bβ`, complement `bc'`), the
+complement blocked-region weight at `bc'` is the red/blue crossing bond product times
+the constrained complement coupling sum over the configurations carrying the three
+labels. Grouping the complement-labelled configurations by overwriting their red/blue
+crossing indices with those of `q₀`, the complement vertex product is constant on each
+fiber and each fiber has cardinality the red/blue crossing bond product. -/
+theorem regionBlockedWeight_complement_eq_smul_constrained
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (bβ : RegionBoundaryConfig (G := G) A D.blue)
+    (bc' : RegionBoundaryConfig (G := G) A D.complement)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
+    (q₀ : VirtualConfig A)
+    (hq0host : regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q₀ = bdry)
+    (hq0blue : regionBoundaryLabel (G := G) A D.blue q₀ = bβ)
+    (hq0compl : regionBoundaryLabel (G := G) A D.complement q₀ = bc') :
+    regionBlockedWeight (G := G) A D.complement bc' σcompl =
+      blueRedCrossingBondProd (A := A) (e := e) D •
+        ∑ q ∈ Finset.univ.filter
+            (fun q : VirtualConfig A =>
+              regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+                regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+                  regionBoundaryLabel (G := G) A D.complement q = bc'),
+          ∏ w : {w : V // w ∈ D.complement},
+            A.component w.1 (fun ie => q ie.1) (σcompl w) := by
+  classical
+  -- `ζ` agrees with `q₀` on every red boundary edge whose far endpoint avoids the blue
+  -- block: those are complement boundary edges (`isComplBoundary`), pinned by `bc'`.
+  have hagree_compl : ∀ ζ : VirtualConfig A,
+      regionBoundaryLabel (G := G) A D.complement ζ = bc' →
+      ∀ g : Edge G, IsRegionBoundaryEdge (G := G) D.complement g → ζ g = q₀ g := by
+    intro ζ hζ g hg
+    have h1 := congrFun hζ ⟨g, hg⟩
+    have h2 := congrFun hq0compl ⟨g, hg⟩
+    rw [regionBoundaryLabel_apply] at h1 h2
+    rw [h1, h2]
+  -- Expand the complement weight and group its configurations by the projection.
+  rw [regionBlockedWeight]
+  set proj : VirtualConfig A → VirtualConfig A :=
+    fun ζ g => if IsBlueRedCrossingEdge (A := A) (e := e) D g then q₀ g else ζ g with hproj
+  set Sζ := Finset.univ.filter
+    (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A D.complement ζ = bc') with hSζ
+  set Sq := Finset.univ.filter
+    (fun q : VirtualConfig A =>
+      regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+        regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+          regionBoundaryLabel (G := G) A D.complement q = bc') with hSq
+  -- The projection maps `Sζ` into `Sq`.
+  have hmaps : ∀ ζ ∈ Sζ, proj ζ ∈ Sq := by
+    intro ζ hζ
+    rw [hSζ, Finset.mem_filter] at hζ
+    rw [hSq, Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_, ?_, ?_⟩
+    · -- Host label.
+      funext f
+      rw [regionBoundaryLabel_apply, hproj]
+      simp only
+      by_cases hcross : IsBlueRedCrossingEdge (A := A) (e := e) D f.1
+      · rw [if_pos hcross]; exact congrFun hq0host f
+      · rw [if_neg hcross]
+        -- `f` is a host boundary edge, not crossing, so a complement boundary edge.
+        have hcompl := isComplBoundary_of_hostBoundary_not_crossing (A := A) (e := e) D f.2 hcross
+        rw [hagree_compl ζ hζ.2 f.1 hcompl]
+        exact congrFun hq0host f
+    · -- Blue label.
+      funext f
+      rw [regionBoundaryLabel_apply, hproj]
+      simp only
+      by_cases hcross : IsBlueRedCrossingEdge (A := A) (e := e) D f.1
+      · rw [if_pos hcross]; exact congrFun hq0blue f
+      · rw [if_neg hcross]
+        -- A blue boundary edge that is not a crossing edge is a complement boundary edge:
+        -- its blue-side endpoint's neighbour lies in the complement, not red.
+        have hred : ¬ IsRegionBoundaryEdge (G := G) D.red f.1 := fun hr => hcross ⟨hr, f.2⟩
+        have hcompl : IsRegionBoundaryEdge (G := G) D.complement f.1 := by
+          -- `f` is a blue boundary edge: one endpoint in blue, one not. The non-blue
+          -- endpoint is not in red (else `f` would be a red boundary edge), so it is in
+          -- the complement.
+          rcases f.2 with ⟨h1blue, h2notblue⟩ | ⟨h1notblue, h2blue⟩
+          · have h2notred : f.1.1.2 ∉ D.red := fun h2red =>
+              hred (Or.inr ⟨fun h1red =>
+                (Finset.disjoint_left.mp D.red_disjoint_blue) h1red h1blue, h2red⟩)
+            have h2compl : f.1.1.2 ∈ D.complement := by
+              have hcover : f.1.1.2 ∈ D.red ∪ D.blue ∪ D.complement := by
+                rw [D.cover_univ]; exact Finset.mem_univ _
+              rcases Finset.mem_union.mp hcover with hrb | hc
+              · rcases Finset.mem_union.mp hrb with hr | hb
+                · exact absurd hr h2notred
+                · exact absurd hb h2notblue
+              · exact hc
+            exact Or.inr ⟨fun h1compl =>
+              (Finset.disjoint_left.mp D.blue_disjoint_complement) h1blue h1compl, h2compl⟩
+          · have h1notred : f.1.1.1 ∉ D.red := fun h1red =>
+              hred (Or.inl ⟨h1red, fun h2red =>
+                (Finset.disjoint_left.mp D.red_disjoint_blue) h2red h2blue⟩)
+            have h1compl : f.1.1.1 ∈ D.complement := by
+              have hcover : f.1.1.1 ∈ D.red ∪ D.blue ∪ D.complement := by
+                rw [D.cover_univ]; exact Finset.mem_univ _
+              rcases Finset.mem_union.mp hcover with hrb | hc
+              · rcases Finset.mem_union.mp hrb with hr | hb
+                · exact absurd hr h1notred
+                · exact absurd hb h1notblue
+              · exact hc
+            exact Or.inl ⟨h1compl, fun h2compl =>
+              (Finset.disjoint_left.mp D.blue_disjoint_complement) h2blue h2compl⟩
+        rw [hagree_compl ζ hζ.2 f.1 hcompl]
+        exact congrFun hq0blue f
+    · -- Complement label unchanged.
+      funext f
+      rw [regionBoundaryLabel_apply, hproj]
+      simp only
+      by_cases hcross : IsBlueRedCrossingEdge (A := A) (e := e) D f.1
+      · exact absurd (incident_of_boundary (G := G) D.complement f.2)
+          (not_isRegionIncidentEdge_complement_of_blueRedCrossing (A := A) (e := e) D hcross)
+      · rw [if_neg hcross]
+        have := congrFun hζ.2 f; rwa [regionBoundaryLabel_apply] at this
+  -- Group the complement-labelled sum fiberwise over the projection.
+  rw [← Finset.sum_fiberwise_of_maps_to hmaps
+    (fun ζ => ∏ w : {w : V // w ∈ D.complement},
+      A.component w.1 (fun ie => ζ ie.1) (σcompl w))]
+  rw [Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun q hq => ?_)
+  rw [hSq, Finset.mem_filter] at hq
+  -- On the fiber over `q`, the complement product is constant `∏compl(q)`.
+  rw [Finset.sum_congr rfl (g := fun _ => ∏ w : {w : V // w ∈ D.complement},
+        A.component w.1 (fun ie => q ie.1) (σcompl w))
+    (fun ζ hζ => by
+      rw [Finset.mem_filter] at hζ
+      rw [hSζ, Finset.mem_filter] at hζ
+      refine complProd_overwrite_blueRedCrossing_eq (A := A) (e := e) D σcompl ζ q
+        (fun g hg => ?_)
+      have := congrFun hζ.2 g
+      rw [hproj] at this; simp only at this; rwa [if_neg hg] at this)]
+  rw [Finset.sum_const]
+  -- `q` and `q₀` agree on the red/blue crossing edges, which are host boundary edges
+  -- where both carry the host label `bdry`.
+  have hqcross : ∀ g : Edge G, IsBlueRedCrossingEdge (A := A) (e := e) D g → q g = q₀ g := by
+    intro g hg
+    -- A crossing edge is a red boundary edge, hence a host boundary edge.
+    have hhost : IsRegionBoundaryEdge (G := G) (Finset.univ \ D.red) g := by
+      rcases hg.1 with ⟨h1red, h2notred⟩ | ⟨h1notred, h2red⟩
+      · exact Or.inr ⟨by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1red,
+          by rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, h2notred⟩⟩
+      · exact Or.inl ⟨by rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, h1notred⟩,
+          by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h2red⟩
+    have h1 := congrFun hq.2.1 ⟨g, hhost⟩
+    have h2 := congrFun hq0host ⟨g, hhost⟩
+    rw [regionBoundaryLabel_apply] at h1 h2
+    rw [h1, ← h2]
+  -- The fiber cardinality is the red/blue crossing bond product.
+  rw [show (Finset.filter (fun ζ => proj ζ = q) Sζ) =
+        Finset.univ.filter (fun ζ : VirtualConfig A =>
+          regionBoundaryLabel (G := G) A D.complement ζ = bc' ∧
+            (fun g => if IsBlueRedCrossingEdge (A := A) (e := e) D g then q₀ g else ζ g) = q)
+      from by rw [hSζ, hproj, Finset.filter_filter],
+    blueRedCrossing_fiber_card (A := A) (e := e) D bc' q₀ q hq.2.2.2 hqcross]
+
+open scoped Classical in
+/-- **The complement coupling collapse.** The red/blue crossing bond multiple of the
+complement coupling coefficient, read as a function of the complement physical leg, is
+the complement-blocked combination of the complement blocked-region weights with the
+coefficient row supported on the complement boundary configurations `bc'` that, together
+with `bβ`, are realized by a global configuration carrying host residual `bdry`.
+
+Grouping the constrained coupling sum by the complement boundary configuration and
+collapsing each group through the per-fiber identity
+`regionBlockedWeight_complement_eq_smul_constrained`, the coupling coefficient becomes a
+combination of complement blocked-region weights with the prescribed indicator
+coefficients.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem blueRedCrossingBondProd_smul_threeBlockComplCoeff_eq
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (bβ : RegionBoundaryConfig (G := G) A D.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement) :
+    (blueRedCrossingBondProd (A := A) (e := e) D : ℂ) •
+        threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ =
+      ∑ bc' : RegionBoundaryConfig (G := G) A D.complement,
+        (if ∃ q : VirtualConfig A,
+            regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+              regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+                regionBoundaryLabel (G := G) A D.complement q = bc'
+          then (1 : ℂ) else 0) •
+          regionBlockedWeight (G := G) A D.complement bc' σcompl := by
+  classical
+  -- Group the constrained coupling sum by the complement boundary configuration.
+  rw [threeBlockComplCoeff, ← Finset.sum_fiberwise_of_maps_to
+    (s := Finset.univ.filter
+      (fun q : VirtualConfig A =>
+        regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+          regionBoundaryLabel (G := G) A D.blue q = bβ))
+    (t := (Finset.univ : Finset (RegionBoundaryConfig (G := G) A D.complement)))
+    (g := fun q => regionBoundaryLabel (G := G) A D.complement q)
+    (fun q _ => Finset.mem_univ _)]
+  rw [Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun bc' _ => ?_)
+  -- Recognize the `bc'`-group as the three-label constrained set.
+  rw [show (Finset.univ.filter
+        (fun q : VirtualConfig A =>
+          regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+            regionBoundaryLabel (G := G) A D.blue q = bβ)).filter
+          (fun q => regionBoundaryLabel (G := G) A D.complement q = bc') =
+        Finset.univ.filter
+          (fun q : VirtualConfig A =>
+            regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+              regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+                regionBoundaryLabel (G := G) A D.complement q = bc')
+      from by
+        rw [Finset.filter_filter]
+        refine Finset.filter_congr (fun q _ => ?_)
+        constructor
+        · rintro ⟨⟨hh, hb⟩, hc⟩; exact ⟨hh, hb, hc⟩
+        · rintro ⟨hh, hb, hc⟩; exact ⟨⟨hh, hb⟩, hc⟩]
+  by_cases hex : ∃ q : VirtualConfig A,
+      regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+        regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+          regionBoundaryLabel (G := G) A D.complement q = bc'
+  · obtain ⟨q₀, hq0host, hq0blue, hq0compl⟩ := hex
+    rw [if_pos ⟨q₀, hq0host, hq0blue, hq0compl⟩, one_smul,
+      regionBlockedWeight_complement_eq_smul_constrained (A := A) (e := e) D bdry bβ bc'
+        σcompl q₀ hq0host hq0blue hq0compl, Nat.cast_smul_eq_nsmul]
+  · rw [if_neg hex, zero_smul]
+    -- No configuration carries the three labels: the constrained sum is empty.
+    rw [Finset.filter_eq_empty_iff.mpr (fun q _ => ?_), Finset.sum_empty, smul_zero]
+    rintro ⟨hh, hb, hc⟩
+    exact hex ⟨q, hh, hb, hc⟩
+
+/-! ### Surjectivity of the host boundary label
+
+Every host boundary configuration is realized by some global virtual configuration:
+extend the boundary values to a total configuration, reading an arbitrary index on
+the non-boundary edges, which exist because every bond dimension is positive. -/
+
+open scoped Classical in
+/-- **Realizing a host boundary configuration.** With positive bond dimensions, every
+host boundary configuration `bdry` is the host boundary label of some global virtual
+configuration: read `bdry` on the host boundary edges and an arbitrary index elsewhere.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionBoundaryLabel_host_eq
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g) :
+    ∃ q : VirtualConfig A, regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry := by
+  classical
+  refine ⟨fun g => if hg : IsRegionBoundaryEdge (G := G) (Finset.univ \ D.red) g then
+      bdry ⟨g, hg⟩
+    else ⟨0, hpos g⟩, ?_⟩
+  funext f
+  rw [regionBoundaryLabel_apply, dif_pos f.2]
+
+/-! ### The union of the blue and complement blocks is injective
+
+Assembling the blue inversion, the complement coupling collapse, and the host boundary
+surjectivity into the source's `injective_union` for the load-bearing instance: the
+host block `univ \ red`, the union of the blue and complement blocks, is blocked-tensor
+injective. -/
+
+open scoped Classical in
+/-- **The union lemma of the normal PEPS Fundamental Theorem.** The host block
+`univ \ red`, the union of the blue and complement injective blocks of a
+`NormalEdgeBlockingData`, is blocked-tensor injective.
+
+A coefficient family `c` annihilating the host blocked-region weight family is stripped
+of the blue block (`complCoeff_combination_eq_zero`), leaving the `c`-weighted complement
+coupling coefficients vanishing for every complement physical leg and blue boundary
+configuration. The complement coupling collapse
+(`blueRedCrossingBondProd_smul_threeBlockComplCoeff_eq`) reads each as a complement-blocked
+combination; injectivity of the complement block forces, for every blue and complement
+boundary configuration realized by a global configuration, the host residual coefficient
+reconstructed from them to vanish. Surjectivity of the host boundary label
+(`exists_regionBoundaryLabel_host_eq`) makes every host residual realized, so `c = 0`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorInjective_union
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (_hblue : RegionBlockedTensorInjective (G := G) A D.blue)
+    (_hcompl : RegionBlockedTensorInjective (G := G) A D.complement)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g) :
+    RegionBlockedTensorInjective (G := G) A (Finset.univ \ D.red) := by
+  classical
+  rw [RegionBlockedTensorInjective, Fintype.linearIndependent_iff]
+  intro c hc
+  -- The annihilation hypothesis as a function identity.
+  have hc0 : ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+      c bdry • regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry = 0 := hc
+  -- Strip the blue block: the `c`-weighted complement coupling row vanishes.
+  have hstrip := complCoeff_combination_eq_zero (A := A) (e := e) D c hc0
+  -- For each blue boundary configuration, the complement coupling row lies in the kernel
+  -- of the complement block, hence vanishes.
+  have hrow : ∀ bβ : RegionBoundaryConfig (G := G) A D.blue,
+      (fun bc' : RegionBoundaryConfig (G := G) A D.complement =>
+        ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+          c bdry •
+            (if ∃ q : VirtualConfig A,
+                regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+                  regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+                    regionBoundaryLabel (G := G) A D.complement q = bc'
+              then (1 : ℂ) else 0)) = 0 := by
+    intro bβ
+    -- The complement-blocked map of the coupling row is the crossing multiple of the
+    -- stripped coupling combination, which vanishes.
+    have hmap : regionBlockedTensorMap (G := G) A D.complement
+        (fun bc' => ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+          c bdry •
+            (if ∃ q : VirtualConfig A,
+                regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+                  regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+                    regionBoundaryLabel (G := G) A D.complement q = bc'
+              then (1 : ℂ) else 0)) = 0 := by
+      funext σcompl
+      rw [regionBlockedTensorMap_apply, Pi.zero_apply]
+      -- Distribute each coefficient sum over the weight, then swap the summation order.
+      rw [Finset.sum_congr rfl (g := fun bc' =>
+            ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+              (c bdry •
+                  (if ∃ q : VirtualConfig A,
+                      regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+                        regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+                          regionBoundaryLabel (G := G) A D.complement q = bc'
+                    then (1 : ℂ) else 0)) •
+                regionBlockedWeight (G := G) A D.complement bc' σcompl)
+          (fun bc' _ => Finset.sum_smul)]
+      rw [Finset.sum_comm]
+      rw [show (∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+            ∑ bc' : RegionBoundaryConfig (G := G) A D.complement,
+              (c bdry •
+                  (if ∃ q : VirtualConfig A,
+                      regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+                        regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+                          regionBoundaryLabel (G := G) A D.complement q = bc'
+                    then (1 : ℂ) else 0)) •
+                regionBlockedWeight (G := G) A D.complement bc' σcompl) =
+          ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+            c bdry •
+              ((blueRedCrossingBondProd (A := A) (e := e) D : ℂ) •
+                threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ) from ?_]
+      · -- The `c`-combination of the crossing multiples of the coupling vanishes.
+        rw [Finset.sum_congr rfl (g := fun bdry =>
+              (blueRedCrossingBondProd (A := A) (e := e) D : ℂ) •
+                (c bdry • threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ))
+            (fun bdry _ => smul_comm _ _ _),
+          ← Finset.smul_sum, hstrip σcompl bβ, smul_zero]
+      · refine Finset.sum_congr rfl (fun bdry _ => ?_)
+        rw [blueRedCrossingBondProd_smul_threeBlockComplCoeff_eq (A := A) (e := e) D bdry bβ σcompl,
+          Finset.smul_sum]
+        refine Finset.sum_congr rfl (fun bc' _ => ?_)
+        rw [smul_assoc]
+    have := regionBlockedTensorMap_injective_of_injective (G := G) A D.complement _hcompl
+      (a₁ := fun bc' => ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
+        c bdry •
+          (if ∃ q : VirtualConfig A,
+              regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
+                regionBoundaryLabel (G := G) A D.blue q = bβ ∧
+                  regionBoundaryLabel (G := G) A D.complement q = bc'
+            then (1 : ℂ) else 0))
+      (a₂ := 0) (by rw [hmap, map_zero])
+    exact this
+  -- Extract `c` at every host residual realized by a global configuration.
+  intro bdry
+  obtain ⟨q, hq⟩ := exists_regionBoundaryLabel_host_eq (A := A) (e := e) D bdry hpos
+  -- Apply the vanishing coupling row at the blue and complement labels of `q`.
+  have hq0 := congrFun (hrow (regionBoundaryLabel (G := G) A D.blue q))
+    (regionBoundaryLabel (G := G) A D.complement q)
+  simp only [Pi.zero_apply] at hq0
+  -- The indicator selects the single host residual `host q = bdry`.
+  rw [Finset.sum_eq_single (regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q)] at hq0
+  · rw [if_pos ⟨q, rfl, rfl, rfl⟩, smul_eq_mul, mul_one] at hq0
+    rw [← hq]; exact hq0
+  · intro bdry' _ hne
+    -- Any global configuration realizing the blue and complement labels of `q` has host
+    -- residual `host q`, so the indicator at `bdry' ≠ host q` is zero.
+    rw [if_neg ?_, smul_zero]
+    rintro ⟨q', hh', hb', hc'⟩
+    apply hne
+    have e1 := regionBoundaryLabel_host_eq_hostLabelFrom (A := A) (e := e) D q'
+    have e2 := regionBoundaryLabel_host_eq_hostLabelFrom (A := A) (e := e) D q
+    rw [hh', hb', hc'] at e1
+    rw [e2]
+    -- `host q' = hostLabelFrom (blue q) (compl q) = host q`, and `host q' = bdry'`.
+    rw [← e1] at e2 ⊢ <;> exact e2
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+/-- **The host block is blocked-tensor injective.** The set complement of the red block
+of a `NormalEdgeBlockingData`, the union of the blue and complement blocks, is
+blocked-tensor injective: the union lemma applied to the injectivity of the blue and
+complement blocks individually.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorInjective_compl_red
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g) :
+    RegionBlockedTensorInjective (G := G) A (Finset.univ \ D.red) :=
+  regionBlockedTensorInjective_union (A := A) (e := e) D
+    (regionBlockedTensorInjective_blue (A := A) (e := e) D)
+    (regionBlockedTensorInjective_complement (A := A) (e := e) D) hpos
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
@@ -43,6 +43,140 @@ variable {V : Type*} [Fintype V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 variable {A : Tensor G d} {e : Edge G}
 
+/-! ### Reconstructing a host boundary configuration from blue and complement data
+
+A boundary edge of the host `univ \ red` has one endpoint in `univ \ red` and one in
+`red`. The host-side endpoint lies in the blue block or in the complement block (the
+two cover `univ \ red`). When it lies in blue the edge is a boundary edge of the blue
+block (the red endpoint is outside blue); when it lies in complement the edge is a
+boundary edge of the complement block (the red endpoint is outside complement). A host
+boundary configuration is therefore the data of a blue boundary configuration on the
+blue/red crossing edges and a complement boundary configuration on the complement/red
+crossing edges, recombined by `hostLabelFrom`. -/
+
+/-- A boundary edge of the host `univ \ red` whose host-side endpoint lies in the blue
+block is a boundary edge of the blue block: the host-side endpoint is in blue, and the
+red-side endpoint lies outside blue (the blocks are disjoint). -/
+theorem isBlueBoundaryEdge_of_hostBoundary_blue
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    {f : Edge G} (hf : IsRegionBoundaryEdge (G := G) (Finset.univ \ D.red) f)
+    (hb : (f.1.1 ∈ Finset.univ \ D.red ∧ f.1.1 ∈ D.blue) ∨
+      (f.1.2 ∈ Finset.univ \ D.red ∧ f.1.2 ∈ D.blue)) :
+    IsRegionBoundaryEdge (G := G) D.blue f := by
+  rcases hf with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
+  · -- `f.1.1 ∈ univ \ red`, `f.1.2 ∈ red`.
+    have h2red : f.1.2 ∈ D.red := by
+      rw [Finset.mem_sdiff] at h2nothost; push_neg at h2nothost
+      exact h2nothost (Finset.mem_univ _)
+    have h2notblue : f.1.2 ∉ D.blue := fun hbl =>
+      (Finset.disjoint_left.mp D.red_disjoint_blue) h2red hbl
+    rcases hb with ⟨_, hb1⟩ | ⟨h2host', _⟩
+    · exact Or.inl ⟨hb1, h2notblue⟩
+    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h2red)
+  · have h1red : f.1.1 ∈ D.red := by
+      rw [Finset.mem_sdiff] at h1nothost; push_neg at h1nothost
+      exact h1nothost (Finset.mem_univ _)
+    have h1notblue : f.1.1 ∉ D.blue := fun hbl =>
+      (Finset.disjoint_left.mp D.red_disjoint_blue) h1red hbl
+    rcases hb with ⟨h1host', _⟩ | ⟨_, hb2⟩
+    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1red)
+    · exact Or.inr ⟨h1notblue, hb2⟩
+
+/-- A boundary edge of the host `univ \ red` whose host-side endpoint lies in the
+complement block is a boundary edge of the complement block. -/
+theorem isComplBoundaryEdge_of_hostBoundary_compl
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    {f : Edge G} (hf : IsRegionBoundaryEdge (G := G) (Finset.univ \ D.red) f)
+    (hc : (f.1.1 ∈ Finset.univ \ D.red ∧ f.1.1 ∈ D.complement) ∨
+      (f.1.2 ∈ Finset.univ \ D.red ∧ f.1.2 ∈ D.complement)) :
+    IsRegionBoundaryEdge (G := G) D.complement f := by
+  rcases hf with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
+  · have h2red : f.1.2 ∈ D.red := by
+      rw [Finset.mem_sdiff] at h2nothost; push_neg at h2nothost
+      exact h2nothost (Finset.mem_univ _)
+    have h2notcompl : f.1.2 ∉ D.complement := fun hcl =>
+      (Finset.disjoint_left.mp D.red_disjoint_complement) h2red hcl
+    rcases hc with ⟨_, hc1⟩ | ⟨h2host', _⟩
+    · exact Or.inl ⟨hc1, h2notcompl⟩
+    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h2red)
+  · have h1red : f.1.1 ∈ D.red := by
+      rw [Finset.mem_sdiff] at h1nothost; push_neg at h1nothost
+      exact h1nothost (Finset.mem_univ _)
+    have h1notcompl : f.1.1 ∉ D.complement := fun hcl =>
+      (Finset.disjoint_left.mp D.red_disjoint_complement) h1red hcl
+    rcases hc with ⟨h1host', _⟩ | ⟨_, hc2⟩
+    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1red)
+    · exact Or.inr ⟨h1notcompl, hc2⟩
+
+/-- The host-side endpoint of a host boundary edge lies in the blue block or in the
+complement block, by the disjoint cover `univ \ red = blue ⊔ complement`. -/
+theorem hostBoundary_hostVertex_mem_blue_or_compl
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    {f : Edge G} (hf : IsRegionBoundaryEdge (G := G) (Finset.univ \ D.red) f) :
+    (f.1.1 ∈ Finset.univ \ D.red ∧ (f.1.1 ∈ D.blue ∨ f.1.1 ∈ D.complement)) ∨
+      (f.1.2 ∈ Finset.univ \ D.red ∧ (f.1.2 ∈ D.blue ∨ f.1.2 ∈ D.complement)) := by
+  have hsplit : ∀ w : V, w ∈ Finset.univ \ D.red → w ∈ D.blue ∨ w ∈ D.complement := by
+    intro w hw
+    rw [sdiff_red_eq_blue_union_complement (A := A) (e := e) D] at hw
+    exact Finset.mem_union.mp hw
+  rcases hf with ⟨h1host, _⟩ | ⟨_, h2host⟩
+  · exact Or.inl ⟨h1host, hsplit _ h1host⟩
+  · exact Or.inr ⟨h2host, hsplit _ h2host⟩
+
+/-- The host boundary configuration reconstructed from a blue boundary configuration
+`bβ` and a complement boundary configuration `bc'`: on a host boundary edge whose
+host-side endpoint lies in the blue block, read the blue value `bβ` (the edge is a
+blue boundary edge); otherwise the host-side endpoint lies in the complement block,
+and read the complement value `bc'` (the edge is a complement boundary edge).
+
+The blue and complement values agree where both apply only through the consistency on
+shared blue/complement crossing edges; here the two pieces never overlap, since a host
+boundary edge's host-side endpoint lies in exactly one block. -/
+noncomputable def hostLabelFrom
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (bβ : RegionBoundaryConfig (G := G) A D.blue)
+    (bc' : RegionBoundaryConfig (G := G) A D.complement) :
+    RegionBoundaryConfig (G := G) A (Finset.univ \ D.red) :=
+  fun f =>
+    if hb : (f.1.1.1 ∈ Finset.univ \ D.red ∧ f.1.1.1 ∈ D.blue) ∨
+        (f.1.1.2 ∈ Finset.univ \ D.red ∧ f.1.1.2 ∈ D.blue) then
+      bβ ⟨f.1, isBlueBoundaryEdge_of_hostBoundary_blue (A := A) (e := e) D f.2 hb⟩
+    else
+      bc' ⟨f.1, isComplBoundaryEdge_of_hostBoundary_compl (A := A) (e := e) D f.2 (by
+        rcases hostBoundary_hostVertex_mem_blue_or_compl (A := A) (e := e) D f.2 with
+          ⟨h1host, hbc⟩ | ⟨h2host, hbc⟩
+        · rcases hbc with hbl | hcl
+          · exact absurd (Or.inl ⟨h1host, hbl⟩) hb
+          · exact Or.inl ⟨h1host, hcl⟩
+        · rcases hbc with hbl | hcl
+          · exact absurd (Or.inr ⟨h2host, hbl⟩) hb
+          · exact Or.inr ⟨h2host, hcl⟩)⟩
+
+/-- The host boundary label of a global virtual configuration `q` is reconstructed
+from its blue and complement boundary labels by `hostLabelFrom`. On a host boundary
+edge the reconstruction reads either the blue label or the complement label of `q` at
+that edge, both of which equal the global value of `q` there, as does the host label.
+
+This is the structural identity isolating the host residual configuration from the
+blue and complement coupling data: a global configuration's host residual is determined
+by its blue and complement residuals.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBoundaryLabel_host_eq_hostLabelFrom
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (q : VirtualConfig A) :
+    regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q =
+      hostLabelFrom (A := A) (e := e) D
+        (regionBoundaryLabel (G := G) A D.blue q)
+        (regionBoundaryLabel (G := G) A D.complement q) := by
+  funext f
+  rw [regionBoundaryLabel_apply, hostLabelFrom]
+  by_cases hb : (f.1.1.1 ∈ Finset.univ \ D.red ∧ f.1.1.1 ∈ D.blue) ∨
+      (f.1.1.2 ∈ Finset.univ \ D.red ∧ f.1.1.2 ∈ D.blue)
+  · rw [dif_pos hb, regionBoundaryLabel_apply]
+  · rw [dif_neg hb, regionBoundaryLabel_apply]
+
 /-! ### The blue inversion of the host annihilation
 
 A coefficient family `c` annihilating the blocked-region weight family of the host
@@ -70,7 +204,6 @@ Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 o
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem complCoeff_combination_eq_zero
     (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
-    (hpos : ∀ f : Edge G, 0 < A.bondDim f)
     (c : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red) → ℂ)
     (hc : ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
         c bdry • regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry = 0)

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3271,6 +3271,35 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $P_0\cup P_1\cup P_2=A\cup B$ is injective.
 \end{proof}
 
+\begin{lemma}[Union of the edge-centred blocks]%
+    \label{lem:peps_injectiveRegion_union_edgeBlocked}
+    \lean{TNLean.PEPS.regionBlockedTensorInjective_union}
+    \leanok
+    \uses{def:peps_regionInjectivityDataOf}
+    Fix an edge $e$ and a partition of the vertex set into the three
+    edge-centred blocks $R$, $B$, $C$ (red, blue, complementary) of the normal
+    PEPS proof, with the red block carrying one endpoint of $e$ and the blue
+    block the other. If the blue block $B$ and the complementary block $C$ are
+    each injective and every virtual bond dimension is positive, then their
+    union $B\cup C=V\setminus R$ is injective.
+\end{lemma}
+\begin{proof}\leanok
+    This is the union lemma~\ref{lem:peps_injectiveRegion_union} for the
+    edge-centred triple, where the two regions are the blue and complementary
+    blocks and their union is the set complement of the red block. A coefficient
+    family annihilating the blocked weights of $V\setminus R$ is stripped of the
+    blue block by its left inverse, leaving a complement-coupling combination
+    that vanishes for every blue boundary configuration. The complementary block
+    then carries each coupling coefficient, read as a function of the
+    complementary physical leg, into a combination of its blocked weights whose
+    coefficient at a boundary configuration is the host residual coefficient
+    reconstructed from the blue and complementary boundary data; injectivity of
+    the complementary block forces that coefficient to vanish wherever a global
+    configuration realizes the two boundary labels. Since every host residual is
+    realized once the bond dimensions are positive, the coefficient family is
+    zero.
+\end{proof}
+
 \begin{definition}[Injectivity predicate for blocked regions]%
     \label{def:peps_regionInjectivityData}
     \lean{TNLean.PEPS.RegionInjectivityData}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -715,6 +715,35 @@ The remaining obligations are the following.
           \(\leanid{TNLean.PEPS.transferCoeff_one_eq_incidentKernel_one}\),
           \(\leanid{TNLean.PEPS.coeffTransfer_iff_transferCoeff_incidentForm}\), and
           \(\leanid{TNLean.PEPS.exists_regionEdgeGauge_of_blockCoeffTransfer}\).}
+
+          The block-frame foundation is now assembled around the edge-blocking
+          triple. The union of two injective blocks is injective; applied to the blue
+          and complement blocks of a one-edge blocking datum, this gives injectivity of
+          the host block, the set complement of the red block, which every block-frame
+          backbone lemma needs at the complement of the red region. With it, the four
+          block injectivities of the two tensors at the red region and at its host are
+          all read off a shared one-edge blocking datum, recording that the two tensors
+          are blocked around the same edge into the same red, blue, and complement
+          regions, together with positive bond dimensions. On top of these, the
+          per-edge gauge is assembled from one predicate alone: bond locality of the
+          transfer coefficient on the boundary edge, in both directions. Bond locality
+          is proved equivalent to the coefficient transfer, so the open content of the
+          block frame is now exactly this single predicate, with the per-edge gauge and
+          all four injectivities derived from it and the shared blocking datum without
+          single-vertex injectivity. The identity transfer of a single tensor is
+          bond-local, the diagonal anchor of the cross-tensor transfer. The remaining
+          open obligation is bond locality of the cross-tensor transfer for a general
+          inserted matrix, the block-level content of the step \(V=W\); it is the only
+          fact between the assembled foundation and the per-edge gauge.\footnote{
+          Formal declarations (block frame, sorry-free):
+          \(\leanid{TNLean.PEPS.regionBlockedTensorInjective_union}\),
+          \(\leanid{TNLean.PEPS.regionBlockedTensorInjective_compl_red}\),
+          \(\leanid{TNLean.PEPS.SharedNormalEdgeBlockingData}\),
+          \(\leanid{TNLean.PEPS.IsBondLocalTransferKernel}\),
+          \(\leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer}\),
+          \(\leanid{TNLean.PEPS.coeffTransfer_of_bondLocal}\),
+          \(\leanid{TNLean.PEPS.isBondLocalTransferKernel_self}\), and
+          \(\leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}\).}
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -744,6 +744,64 @@ The remaining obligations are the following.
           \(\leanid{TNLean.PEPS.coeffTransfer_of_bondLocal}\),
           \(\leanid{TNLean.PEPS.isBondLocalTransferKernel_self}\), and
           \(\leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}\).}
+
+          The block-frame transfer kernel \(K_M(\mu,\nu')\) is the double blocked
+          left inverse of the first tensor's region-inserted coefficient of \(M\)
+          through the second tensor's region and complement blocks. Its bond locality
+          is the incident-matrix coupling form \(K_M=\text{incidentKernel}(N)\): the
+          kernel couples the two boundary configurations only through their legs on
+          the boundary edge \(f\). The criterion is now stated through the \(f\)-leg
+          split of a boundary configuration: \(K_M\) is the incident kernel of \(N\)
+          exactly when, read through the split, it vanishes off the diagonal of the
+          two residual boundary configurations and reads \(N\) on the matching \(f\)-leg.
+          The transferred row that feeds the kernel is the second tensor's region
+          blocked left inverse of the first tensor's coefficient, which is exactly the
+          \(A\leftrightarrow B\) region basis change applied to the first tensor's own
+          region row \(\text{rowInsert}_f(M)\) of the complement weight row --- a row
+          that is already bond-\(f\) local. Bond locality of \(K_M\) is therefore
+          equivalent to the region basis change preserving the bond-\(f\)/residual
+          decomposition, that is, conjugating the first tensor's \(f\)-leg row
+          insertion of \(M\) to the second tensor's \(f\)-leg row insertion of a single
+          \(N\). This is the basis-change intertwining the cross-tensor reduction
+          consumes.\footnote{
+          Formal declarations (block frame, sorry-free):
+          \(\leanid{TNLean.PEPS.incidentKernel_eq_split}\),
+          \(\leanid{TNLean.PEPS.transferCoeff_eq_incidentKernel_iff_split}\),
+          \(\leanid{TNLean.PEPS.blockTransferRow_eq_basisChange_regionRegionRow}\),
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_of_basisChange_intertwine}\),
+          \(\leanid{TNLean.PEPS.basisChange_intertwine_iff_coeffTransfer}\), and
+          \(\leanid{TNLean.PEPS.isBondLocalTransferKernel_of_coeffTransfer}\).}
+
+          The port of the edge resonate inversion to this block granularity hits one
+          structural mismatch that is not a matter of length. The edge inversion
+          \(\leanid{TNLean.PEPS.resonate_invert_right_endpoint}\) consumes the
+          bond-contracted resonate identity
+          \(\leanid{TNLean.PEPS.resonate_middle_inverted}\), which pairs the
+          left-endpoint and right-endpoint physical operators \emph{indexed by the
+          shared bond} \(k\): the two endpoints are two single vertices sharing one
+          bond, and the two operators act on the same physical space \(\mathbb C^d\).
+          In the block frame the two endpoints are the red region and its complement
+          sharing the boundary edge \(f\), and the only available factorizations of the
+          first tensor's coefficient through the second tensor's complement block in the
+          bond-\(f\)-paired form needed by the inversion --- the v-side and
+          \(\sigma\)-side blocked maps
+          (\(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_complement_blockedMap_B}\),
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_region_blockedMap_B}\)) ---
+          carry the single-vertex hypothesis \(\text{LinearIndependent}\,(A_v)\) at the
+          endpoint vertex of \(f\). The block-image coincidence
+          \(\leanid{TNLean.PEPS.range_regionBlockedTensorMap_eq_of_sameState}\) supplies
+          the full-weight-span identity through the second tensor's whole region block
+          as a single basis change, but it does not supply the per-\(f\)-leg bond
+          pairing the inversion consumes; the only block-only complement-side reading
+          of the coefficient is through the double left inverse \(K_M\) itself, which is
+          the very kernel whose bond locality is the goal. The block-frame port
+          therefore requires a vertex-injectivity-free bond-\(f\)-paired complement
+          factorization of the coefficient before the edge inversion structure
+          transfers; constructing it from the two block realizations through the second
+          tensor's partial states
+          (\(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_blockRealizeOp_regionPartialState_B}\),
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_blockRealizeOp_complementPartialState_B}\))
+          is the remaining open step.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -665,6 +665,56 @@ The remaining obligations are the following.
           \(\leanid{TNLean.PEPS.InsertionRealization}\),
           \(\leanid{TNLean.PEPS.regionInsertionTransfer_of_realizes}\), and
           \(\leanid{TNLean.PEPS.exists_regionEdgeGauge_of_transfer}\).}
+
+          The reconcile above is also reachable in a \emph{block frame} that uses no
+          single-vertex injectivity. The foundational input is the block-level image
+          coincidence: under \(\operatorname{SameState}\), with the complement block
+          blocked-tensor injective and positive bond dimensions, the range of the
+          region blocked tensor map is the same for the two tensors, because both
+          ranges equal the span of the partial states across the region cut, and the
+          partial states depend only on the closed state coefficient. The same fact
+          for the complement block follows by transporting blocked-tensor injectivity
+          across the double complement. With these two image coincidences, the first
+          tensor's region-inserted coefficient, read as a function of the region
+          physical configuration, lies in the second tensor's region block image
+          (region side), and the transferred row, as a function of the complement
+          physical configuration, lies in the second tensor's complement block image
+          (complement side); the two blocked left inverses read off the same transfer
+          coefficient as in the vertex frame, and the first tensor's coefficient is
+          the double sum of that transfer coefficient against the second tensor's two
+          blocked weights. None of this uses single-vertex injectivity.
+
+          In the block frame the remaining content is isolated cleanly. By double
+          blocked injectivity of the second tensor, the double-sum representation of a
+          coefficient by a transfer coefficient is unique, so the transfer
+          coefficient of an inserted matrix has the incident-matrix coupling form of a
+          single bond matrix if and only if the first tensor's region-inserted
+          coefficient of that inserted matrix equals the second tensor's of that bond
+          matrix. The whole open obligation is therefore equivalent to the coefficient
+          transfer alone --- for every inserted matrix on the first tensor's bond, a
+          matching bond matrix on the second tensor --- with the matching matrix
+          carried directly by the equivalence. The identity insertion is matched
+          across \(\operatorname{SameState}\), so the transfer coefficient of the
+          identity is already the incident-matrix coupling of the identity. The
+          residual open content is the incident-matrix coupling form of the transfer
+          coefficient for a general inserted matrix: the transfer coefficient must be
+          local on the boundary bond, depending on the two boundary configurations
+          only through their bond legs. This locality is the bond-level content of the
+          source step \(V=W\) and is the one fact the block-frame foundation does not
+          supply, because the block image coincidence preserves only the full weight
+          span and not the per-leg decomposition across the boundary bond.\footnote{
+          Formal declarations (block frame, sorry-free):
+          \(\leanid{TNLean.PEPS.range_regionBlockedTensorMap_eq_of_sameState}\),
+          \(\leanid{TNLean.PEPS.regionBlockedTensorInjective_doubleCompl}\),
+          \(\leanid{TNLean.PEPS.range_regionBlockedTensorMap_compl_eq_of_sameState}\),
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_blockTransferRow}\),
+          \(\leanid{TNLean.PEPS.blockTransferRow_mem_range}\),
+          \(\leanid{TNLean.PEPS.regionInsertedCoeff_eq_doubleSum_transferCoeff_block}\),
+          \(\leanid{TNLean.PEPS.doubleSum_kernel_injective}\),
+          \(\leanid{TNLean.PEPS.transferCoeff_eq_incidentKernel_iff_coeff_eq}\),
+          \(\leanid{TNLean.PEPS.transferCoeff_one_eq_incidentKernel_one}\),
+          \(\leanid{TNLean.PEPS.coeffTransfer_iff_transferCoeff_incidentForm}\), and
+          \(\leanid{TNLean.PEPS.exists_regionEdgeGauge_of_blockCoeffTransfer}\).}
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.


### PR DESCRIPTION
## What

The source-faithful **three-block (red/blue/complement) machinery** for the general
Normal PEPS Fundamental Theorem (#1373, arXiv:1804.04964 §3), including the first
tensor-level formalization of the source's **Lemma `injective_union`** (#1374). 18 new
files under `TNLean/PEPS/RegionBlock/`, all sorry-free, every headline `#print axioms`
= `[propext, Classical.choice, Quot.sound]`.

## Highlights

- **`regionBlockedTensorInjective_union`** (UnionInjectivity.lean) — the source's
  `injective_union` (paper_normal.tex:1324–1400) at the edge-blocking triple: blue +
  complement block injectivity imply injectivity of their union `univ \ red`. Proof =
  the source's two successive inverse applications, via a new fiberwise multiplicity
  collapse (the correct reconstruction indicator is "∃ a global configuration carrying
  all three boundary labels"; the multiplicity is the red↔blue crossing bond product).
  Faithful narrower blueprint entry `lem:peps_injectiveRegion_union_edgeBlocked`
  (\leanok); the general two-region node stays `\notready` per the faithfulness rule.
- **The three-block resonate engine** (ThreeBlockResonate/2, ThreeBlockReconcile):
  region-blocking associativity (the fused-host weight factors through the complement
  block alone), the middle strip (complement inverted as the third block — the step a
  two-block split cannot state), both endpoint inversions, and the single-tensor
  reconcile — the block port of the proven edge resonate engine.
- **The cross-tensor resonate identity** (`threeBlockOpCoeff_resonate_AB`,
  ThreeBlockResonateAB.lean) — the block-granularity `eq:resonate`: the red-side and
  host-side realizations of the first tensor's bond insertion agree on the second
  tensor's state, via `SameState` (the architecture the proven edge FT uses, with
  abstract physical operators).
- **The per-edge gauge assembly** (ThreeBlockTransfer.lean): two-tensor shared-blocking
  packaging + `SharedNormalEdgeBlockingData.exists_regionEdgeGauge`, the per-edge gauge
  from the coefficient-transfer predicate with **no single-vertex injectivity**; the
  block image coincidence (BlockRangeCoincidence.lean) and all kernel reformulations
  proven equivalent (BlockCoeffTransfer, BasisChangeIntertwine, OpenLegsResonate,
  ResonatePort/2).

## Remaining open step (documented)

The cross-tensor transfer-matrix witness (the source's V=W applied across `SameState`)
remains the single open hypothesis; the geometry is now verified (red and blue cross at
exactly the distinguished edge), the cross-tensor resonate identity is landed, and the
remaining work is the host↔blue fiber collapse + witness extraction in physical-config
space. Recorded with the full route analysis in
`docs/paper-gaps/peps_normal_ft_section3_route.tex`.

Refs #1373, #1374. CI `blueprint-and-prose`/`track`/`claude-review-*` failures are
non-blocking automation (cf. merged #2491/#2495/#2525).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, proof-dense additions on the normal PEPS FT critical path; errors would mis-state equivalences or gauge hypotheses, though changes are additive formal math with documented open steps.
> 
> **Overview**
> Adds **sorry-free** Lean under `TNLean/PEPS/RegionBlock/` for the normal PEPS Fundamental Theorem (arXiv:1804.04964 §3) in the **region-injective / three-block** frame, and wires the modules into the root import list in `TNLean.lean`.
> 
> **Block foundations:** `BlockRangeCoincidence` shows `SameState` tensors share the range of each region’s blocked tensor map when complement blocks are injective. `BlockCoeffTransfer` builds the **coefficient transfer** from that coincidence (double blocked read-off, kernel uniqueness, incident-matrix reconcile) and packages **per-edge gauge** via `exists_regionEdgeGauge_of_blockCoeffTransfer` when transfers are assumed.
> 
> **Cross-tensor reduction (step V=W):** `BlockRealization` introduces `rowInsertF`, `blockRealizeOp`, and `regionBasisChange`, with bond locality reduced to a **basis-change intertwining** (`isBondLocalTransferKernel_of_basisChange_intertwine`). `BasisChangeIntertwine` proves that intertwining is **equivalent** to block-frame coefficient transfer.
> 
> **Equivalent open targets:** `OpenLegsResonate` and `ResonatePort` / `ResonatePort2` reformulate the same obligation as transferred-row = region row, kernel = incident kernel, and basis-change row identities, using an **`f`-leg split** of boundary configurations (edge resonate engine port).
> 
> The cross-tensor **witness** that supplies coefficient transfer for all `M` remains an explicit hypothesis; the PR documents the remaining route in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90e9ea45b45bd1527c5c534ce909d9a7eeffeca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->