### PR TITLE
doc(parent): isolate boundary-closing first-product reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -727,6 +727,44 @@ lemma closure_property_boundary_restriction_eq_of_first_products
     hMinus j
   exact hleft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) (hProd j)).trans hright.symm)
 
+/-- Boundary-closing restrictions from first-letter product equations.
+
+If the two length-\((L_0+1)\) restrictions are represented by witnesses
+\(Y_i(\tau)\), and the first-letter boundary products agree for every
+boundary letter and physical letter, then the two cyclic restrictions used
+when closing the boundary agree for every boundary letter. This is only the
+final reduction; it does not supply the product equations themselves. -/
+lemma closure_property_boundary_restrictions_eq_of_first_products
+    {A : MPSTensor d D} {L₀ M : ℕ}
+    (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)}
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hProd : ∀ (η j : Fin d),
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j =
+        YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j) :
+    ∀ η : Fin d,
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+        cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+  intro η
+  exact closure_property_boundary_restriction_eq_of_first_products
+    (A := A) hL₀ hM η μ
+    (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+    (YAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) η μ))
+    (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+    (hYAt ⟨M + 1 - L₀, by omega⟩
+      (mirrorMiddleBackground L₀ (M + 1) η μ))
+    (hProd η)
+
 /-- Auxiliary boundary-condition product obtained from equality of the two
 closing-boundary restrictions.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2154,6 +2154,35 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     original restrictions.
 \end{proof}
 
+\begin{lemma}[Boundary restrictions from first-letter products]
+    \label{lem:closed_boundary_restrictions_from_first_letter_products}
+    \lean{MPSTensor.closure_property_boundary_restrictions_eq_of_first_products}
+    \leanok
+    \uses{lem:closed_boundary_restriction_from_right_products}
+    Let \(L_0>0\) and \(L_0\le M\). Let \(Y_i(\tau)\) represent the
+    length-\((L_0+1)\) cyclic restrictions of \(\psi\). Fix a complementary
+    word \(\mu\). If, for every boundary letter \(\eta\) and physical letter
+    \(j\),
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j,
+    \]
+    then for every \(\eta\),
+    \[
+        \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+        =
+        \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply Lemma~\ref{lem:closed_boundary_restriction_from_right_products} for
+    each boundary letter \(\eta\), using the corresponding first-letter product
+    equations.
+\end{proof}
+
 \begin{lemma}[Restriction form of the closure property]
     \label{lem:closure_property_boundary_restriction_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_chainGroundSpace}
@@ -2579,7 +2608,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         lem:closure_property_boundary_one_sided_products_ground_space_map,
         lem:closure_property_opposite_boundary_comparison_from_left_words,
         lem:closure_property_opposite_boundary_comparison_from_right_words,
-        lem:closed_boundary_restriction_from_right_products}
+        lem:closed_boundary_restrictions_from_first_letter_products}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
     $D\ge1$. Let
     \[
@@ -2646,12 +2675,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         =
         Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
     \]
-    Lemma~\ref{lem:closed_boundary_restriction_from_right_products} identifies
-    the two length-\((L_0+1)\) restrictions. The displayed left-multiplied
-    family is therefore not proved by the cancellation lemmas above; it is the
-    remaining coordinate form of the boundary-closing sentence in
-    \cite[lines~2078--2079]{Cirac2021Matrix}, and is recorded in
-    docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
+    Lemma~\ref{lem:closed_boundary_restrictions_from_first_letter_products}
+    identifies the two length-\((L_0+1)\) restrictions for all boundary letters.
+    The displayed left-multiplied family is therefore not proved by the
+    cancellation lemmas above; it is the remaining coordinate form of the
+    boundary-closing sentence in \cite[lines~2078--2079]{Cirac2021Matrix}, and
+    is recorded in docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
 \begin{lemma}[First-letter products from equal boundary restrictions]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2611,8 +2611,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \notready
     Choose matrices \(Y_i(\tau)\) representing the length-\((L_0+1)\)
-    restrictions. It is enough to prove, for every boundary letter \(\eta\),
-    physical letter \(j\), and length-\(L_0\) words \(\alpha,\sigma\), that
+    restrictions. The source-facing step still to be supplied is the following
+    coordinate comparison: for every boundary letter \(\eta\), physical letter
+    \(j\), and length-\(L_0\) words \(\alpha,\sigma\),
     \[
         A^\alpha
         \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
@@ -2620,6 +2621,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         A^\alpha
         \left(A^\mu A^jXA^\sigma\right).
     \]
+    If this comparison is known, then
     Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_left_words}
     uses \(L_0\)-block injectivity to remove the left word and gives
     \[
@@ -2628,7 +2630,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         A^\mu A^jXA^\sigma .
     \]
     Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_right_words}
-    uses \(L_0\)-block injectivity to remove the right word and gives
+    then uses \(L_0\)-block injectivity to remove the right word and gives
     \[
         Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j
         =
@@ -2646,8 +2648,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
     Lemma~\ref{lem:closed_boundary_restriction_from_right_products} identifies
     the two length-\((L_0+1)\) restrictions. The displayed left-multiplied
-    family is the remaining coordinate form of the boundary-closing sentence in
-    \cite[lines~2078--2079]{Cirac2021Matrix}; it is recorded in
+    family is therefore not proved by the cancellation lemmas above; it is the
+    remaining coordinate form of the boundary-closing sentence in
+    \cite[lines~2078--2079]{Cirac2021Matrix}, and is recorded in
     docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
@@ -2753,7 +2756,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \notready
     The representations by the matrices $Y_i(\tau)$ supply the local
     ground-space hypothesis for the preceding lemma.
-    The preceding boundary-restriction equality gives
+    Once the preceding boundary-restriction equality is proved, it gives
     \[
         \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =
@@ -2797,7 +2800,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    The comparison of the two cyclic restrictions gives
+    Once the comparison of the two cyclic restrictions is available, it gives
     \[
         A^\alpha
         \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)


### PR DESCRIPTION
## Summary

This PR isolates the final boundary-closing reduction used in the parent-Hamiltonian chapter.

- Adds the no-sorry wrapper
  `MPSTensor.closure_property_boundary_restrictions_eq_of_first_products`.
- Records in the blueprint the mathematical implication
  \[
    \left(\forall \eta,j,\;Y_M(\tau^+_\eta(\mu))A^j
      =Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\right)
    \Rightarrow
    \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
    =
    \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
  \]
- Rewrites the surrounding not-ready proof so the missing boundary equation is not hidden behind a Lean declaration name.

This does not close #2405. The remaining source-facing step is the coordinate comparison
\[
  A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
  =
  A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr),
\]
which is the formal boundary-closing sentence cited from CPGSV21.

Refs #2405.

## Checks

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosing`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `leanblueprint web` (exit code 0; existing plasTeX package-load and bibliography warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and proved refactoring only; no changes to runtime behavior or security-sensitive code.
> 
> **Overview**
> **Isolates the final “first-letter products ⇒ equal boundary restrictions” step** in the parent-Hamiltonian boundary-closing chain, without claiming the harder product identities.
> 
> Adds the no-sorry Lean lemma `MPSTensor.closure_property_boundary_restrictions_eq_of_first_products`, which quantifies over boundary letters η and delegates each case to the existing `closure_property_boundary_restriction_eq_of_first_products`. The blueprint gains a matching lemma (`lem:closed_boundary_restrictions_from_first_letter_products`) with a short proof citing the per-η lemma.
> 
> The larger lemma on equality of boundary-closing cyclic restrictions now **depends on the new forall-η wrapper** instead of the single-η lemma directly. Several **not-ready** blueprint proofs are rewritten so the **still-missing CPGSV21 coordinate comparison** (left-multiplied \(A^\alpha\) family) is stated explicitly as the open step, rather than appearing to follow from the new reduction alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6acbfc8ae29285e54db5e0f2c95602ecc5be9c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->