### PR TITLE
style(blueprint): capitalize lemma reference in the edge-blocked union proof

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3284,7 +3284,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     union $B\cup C=V\setminus R$ is injective.
 \end{lemma}
 \begin{proof}\leanok
-    This is the union lemma~\ref{lem:peps_injectiveRegion_union} for the
+    This is Lemma~\ref{lem:peps_injectiveRegion_union} for the
     edge-centred triple, where the two regions are the blue and complementary
     blocks and their union is the set complement of the red block. A coefficient
     family annihilating the blocked weights of $V\setminus R$ is stripped of the


### PR DESCRIPTION
Fixes the chktex lint (Warning 44, capitalize before references) at `ch13a_peps_ft.tex:3287` introduced in #2567, which failed the load-bearing blueprint check. One-word prose fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX prose fix with no code or proof logic changes.
> 
> **Overview**
> Fixes **chktex Warning 44** (capitalize before references) in the proof of `lem:peps_injectiveRegion_union_edgeBlocked` in `ch13a_peps_ft.tex`.
> 
> The sentence that cites the union injectivity lemma now reads **Lemma~\ref{lem:peps_injectiveRegion_union}** instead of “the union lemma~\ref{...}”, matching blueprint typography rules. No mathematical or Lean content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6cc462ac63a6bf077bc126f76d7d336e991d069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->