### PR TITLE
doc(parent): package block-boundary closing capstone

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -56,11 +56,15 @@ theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
     hUnital
 
-/-- Condition-C1 version of
-`pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors`.
+/-- Condition-C1 form of the PGVWC one-step block-intersection identity.
 
-The source length is \(L_0+1\), where \(L_0\) is the common Condition C1
-length of the blocks. -/
+Under a common Condition C1 length \(L_0\), the source length is \(L_0+1\).
+Writing \(S_m=\bigvee_j G_m(A_j)\), the identity is
+\[
+  \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1}.
+\]
+This is the equation used in PGVWC07, Theorem 2blocks.2, proof lines
+1430--1452. -/
 theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
@@ -26,7 +26,7 @@ For every cyclic window, the local identity
 \[
   G_L\!\left(\bigoplus_k\mu_kA_k\right)=\bigvee_kG_L(A_k)
 \]
-sends \(G_L(A_j)\) into the local ground space of the direct-sum tensor. -/
+sends \(G_L(A_j)\) into the local ground space of the block-diagonal tensor. -/
 theorem chainGroundSpace_block_le_toTensorFromBlocks
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -56,6 +56,31 @@ theorem iSup_chainGroundSpace_block_le_toTensorFromBlocks
   exact iSup_le fun j =>
     chainGroundSpace_block_le_toTensorFromBlocks μ A (hμ j) hN hLN
 
+/-- Boundary-closing capstone for the block-diagonal periodic chain.
+
+Let \(B=\bigoplus_j\mu_jA_j\). If closing the periodic boundary with
+block-diagonal boundary conditions gives
+\[
+  \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j),
+\]
+then the already proved blockwise inclusion gives
+\[
+  \mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j).
+\]
+This packages the remaining PGVWC07/CPGSV21 boundary-closing step as a single
+hypothesis; it does not prove that hypothesis. -/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (hClose :
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, chainGroundSpace (A j) L N) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+      ⨆ j : Fin r, chainGroundSpace (A j) L N :=
+  le_antisymm hClose (iSup_chainGroundSpace_block_le_toTensorFromBlocks μ A hμ hN hLN)
+
 /-- Periodic local constraints for a block-diagonal tensor propagate to the
 linear sum of the block ground spaces.
 
@@ -72,7 +97,9 @@ for all \(M\ge L\), then
   \mathcal G_{N,L}(B)\subseteq S_N.
 \]
 This is the conditional propagation step in the proof of PGVWC07, Theorem
-2blocks.2, before the directness of the block summands is used. -/
+2blocks.2: the one-step identities propagate cyclic local constraints to
+\(S_N\). The later source step is closing the boundaries with block-diagonal
+boundary conditions, replacing \(S_N\) by the periodic block-chain sum. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6443,6 +6443,37 @@ formulation; the passage to $\ker H_N$ is kept separate.
     % $\bigvee_jG_N(A_j)$ by $\sum_j\mathcal G_{N,L}(A_j)$.
 \end{proof}
 
+\begin{lemma}[Boundary closing gives the block-diagonal chain equality]
+    \label{lem:block_diagonal_boundary_closing_capstone}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing}
+    \leanok
+    \uses{lem:isup_chain_ground_space_block_le_assembled}
+    Let
+    \[
+        B=\bigoplus_{j=1}^g\mu_jA_j,
+        \qquad \mu_j\ne0\quad(1\le j\le g).
+    \]
+    If closing the periodic boundary with block-diagonal boundary conditions gives
+    \[
+        \mathcal G_{N,L}(B)
+        \subseteq
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j),
+    \]
+    then
+    \[
+        \mathcal G_{N,L}(B)
+        =
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The reverse inclusion is
+    Lemma~\ref{lem:isup_chain_ground_space_block_le_assembled}; combine the two
+    inclusions.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -6465,6 +6496,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:block_diagonal_periodic_constraints_propagated_sum,
         lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
         lem:bnt_block_diagonal_periodic_chain_inclusions,
+        lem:block_diagonal_boundary_closing_capstone,
         thm:wordspan_propagation_unital}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:


### PR DESCRIPTION
## Summary

This PR records the #905 boundary-closing endpoint as a single equation-level capstone.

- Adds the no-sorry theorem
  `MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing`.
- The theorem states that if closing the periodic boundary with block-diagonal boundary conditions gives
  \[
    \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
    \subseteq
    \bigvee_j\mathcal G_{N,L}(A_j),
  \]
  then the already proved reverse inclusion gives
  \[
    \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
    =
    \bigvee_j\mathcal G_{N,L}(A_j).
  \]
- Replaces two stale reader-facing phrases: the Condition C1 wrapper now states the PGVWC one-step intersection equation directly, and the chain-propagation docstring no longer says that directness is still the missing step.

This does not close #905. It packages the remaining source-facing boundary-closing inclusion so that the open step is exactly the PGVWC07/CPGSV21 block-diagonal boundary-condition argument.

Refs #905.

## Checks

- `lake build TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace TNLean.MPS.ParentHamiltonian.BNTBlockIntersection`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- `leanblueprint web` (exit code 0; existing plasTeX package-load and bibliography warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a one-line `le_antisymm` packaging theorem only; no changes to proof logic or security-sensitive code.
> 
> **Overview**
> Packages the open **#905** boundary-closing step as an explicit capstone: new theorem `chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing` turns the PGVWC07/CPGSV21 **⊆** hypothesis into equality via `le_antisymm` and the existing blockwise reverse inclusion.
> 
> The blueprint gains **Lemma** `block_diagonal_boundary_closing_capstone` (linked to that Lean decl) and the block-diagonal intersection theorem now `\uses` it. Docstrings are refreshed so the Condition C1 wrapper states the one-step intersection equation \(\mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1}\), propagation text names boundary closing (not “directness”) as the remaining source step, and wording shifts from “direct-sum” to **block-diagonal** where appropriate.
> 
> No new proofs of the boundary-closing inclusion itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b9ed491f5b491621099e510b09934150bbb30c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->