### PR TITLE
feat(parent): reduce boundary restriction gap to first products

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -207,14 +207,13 @@ complementary word \(\mu\). The boundary-closing step is the equality
   \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
 After choosing window witnesses, the remaining coordinate reconstruction is the
-left-multiplied family
+boundary product comparison
 \[
-  A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
+  Y_M(\tau^+_\eta(\mu))A^j
   =
-  A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr),
+  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j,
 \]
-for all boundary letters \(\eta\), physical letters \(j\), and length-\(L_0\)
-words \(\alpha,\sigma\).
+for all boundary letters \(\eta\) and physical letters \(j\).
 
 **Open gap:** arXiv:2011.12127, Section IV.C, lines 2078--2079 states that
 the inverting-and-growing-back argument may also be applied when closing the
@@ -246,34 +245,13 @@ theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     obtain ⟨Y, hY⟩ := hmem
     exact ⟨Y, hY.symm⟩
   choose YAt hYAt using hLocalWitness
-  suffices hLeft : ∀ (η j : Fin d) (σ α : Fin L₀ → Fin d),
-      evalWord A (List.ofFn α) *
-          (YAt ⟨M + 1 - L₀, by omega⟩
-              (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
-            evalWord A (List.ofFn σ)) =
-        evalWord A (List.ofFn α) *
-          (evalWord A (List.ofFn μ) * A j * X *
-            evalWord A (List.ofFn σ)) by
-    have hMirrorPadded :=
-      closure_property_mirror_padded_products_of_left_word_products
-        (A := A) hInj hL₀ hM YAt X μ hLeft
-    have hMirrorRight :=
-      closure_property_mirror_right_product_eq_of_right_word_products
-        (A := A) hInj hL₀ hM YAt X μ hMirrorPadded
-    have hLast :=
-      (closure_property_boundary_one_sided_products_of_groundSpaceMap
-        (A := A) hInj hL₀ hM hψX YAt hYAt μ).1
-    intro η
-    refine closure_property_boundary_restriction_eq_of_first_products
-      (A := A) hL₀ hM η μ
-      (YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
-      (YAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) η μ))
-      (hYAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
-      (hYAt ⟨M + 1 - L₀, by omega⟩
-        (mirrorMiddleBackground L₀ (M + 1) η μ)) ?_
-    intro j
-    exact (hLast η j).trans (hMirrorRight η j).symm
-  intro η j σ α
+  suffices hProd : ∀ η j : Fin d,
+      YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ) * A j =
+        YAt ⟨M + 1 - L₀, by omega⟩
+          (mirrorMiddleBackground L₀ (M + 1) η μ) * A j by
+    exact closure_property_boundary_restrictions_eq_of_first_products
+      (A := A) hL₀ hM YAt hYAt μ hProd
+  intro η j
   sorry
 
 /-- Left-multiplied comparison of the two cyclic restriction coordinates from


### PR DESCRIPTION
## Summary

This PR rebases the remaining boundary-closing restriction theorem on the merged first-product reduction from #2568.

In mathematical terms, the theorem now reduces directly to the boundary product comparison
\[
  Y_M(\tau^+_\eta(\mu))A^j
  =
  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j,
\]
for every boundary letter \(\eta\) and physical letter \(j\). The equality of the two cyclic restrictions is then obtained by applying `closure_property_boundary_restrictions_eq_of_first_products`.

This does not resolve #2405. The remaining source-facing step is still to prove the displayed boundary product comparison from the inverting-and-growing-back argument at the closing boundary, as in arXiv:2011.12127, Section IV.C, lines 2078--2079.

## Checks

- `lake exe cache get && lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof-structure and docstring changes only; no new completed proofs and the open gap is still explicitly sorry.
> 
> **Overview**
> **Refactors** `closure_property_boundary_restrictions_eq_of_groundSpaceMap` so the documented open step is the **boundary product comparison** \(Y_M(\tau^+_\eta(\mu))A^j = Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\) for each boundary letter \(\eta\) and physical letter \(j\), instead of the longer left-multiplied word-product family.
> 
> The proof body no longer chains mirror padded products, mirror-right, and one-sided boundary lemmas; it **`suffices`** that first-product equation and closes with `closure_property_boundary_restrictions_eq_of_first_products` from the merged reduction (#2568). The substantive gap is unchanged: proving `hProd` is still **`sorry`**, pending the paper’s inverting-and-growing-back argument at the closing boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 373d51171fc8a954d293d18d9b8c817f4b6bf67e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->