### PR TITLE
feat(parent): record block boundary formula

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
@@ -108,6 +108,31 @@ theorem groundSpaceMap_toTensorFromBlocks_eq_sum_diagonalBlock
   rw [hdiag, hwlen]
   rw [Matrix.smul_mul, Matrix.mul_smul]
 
+/-- The boundary parametrization of a block-diagonal tensor on a block-diagonal
+boundary condition is the sum of the corresponding block boundary
+parametrizations:
+\[
+  \Gamma_L^{\oplus_j\mu_jA_j}\!\left(\bigoplus_j X_j\right)
+  =
+  \sum_j \Gamma_L^{A_j}(\mu_j^L X_j).
+\]
+
+This is the block-diagonal boundary-condition identity used in PGVWC07,
+Theorem 2blocks.2, proof lines 1430--1434. -/
+theorem groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j)) (L : ℕ)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ) :
+    groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) L
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) =
+      ∑ j : Fin r, groundSpaceMap (A j) L ((μ j) ^ L • X j) := by
+  rw [groundSpaceMap_toTensorFromBlocks_eq_sum_diagonalBlock]
+  refine Finset.sum_congr rfl ?_
+  intro j _
+  congr 1
+  ext a b
+  simp [diagonalBlock, sigmaDiagonalBlock]
+
 end BlockSumGroundSpace
 
 open BlockSumGroundSpace

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6230,6 +6230,30 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
 \end{proof}
 
+\begin{lemma}[Block-diagonal boundary-condition formula]
+    \label{lem:block_diagonal_boundary_condition_sum}
+    \lean{MPSTensor.BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal}
+    \leanok
+    \uses{def:ground_space_parent}
+    Let
+    \[
+        B=\bigoplus_{j=1}^g\mu_jA_j.
+    \]
+    For block boundary matrices \(X_j\),
+    \[
+        \Gamma_L^B\!\left(\bigoplus_{j=1}^g X_j\right)
+        =
+        \sum_{j=1}^g\Gamma_L^{A_j}(\mu_j^LX_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is the diagonal-block trace formula specialized to a block-diagonal
+    boundary matrix.  The \(j\)-th diagonal block of
+    \(\bigoplus_kX_k\) is \(X_j\), giving the displayed sum.
+\end{proof}
+
 \begin{lemma}[One block in a block-diagonal local ground space]
     \label{lem:local_ground_space_block_le_assembled}
     \lean{MPSTensor.groundSpace_block_le_toTensorFromBlocks}
@@ -6257,7 +6281,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \label{lem:block_sum_local_ground_space}
     \lean{MPSTensor.groundSpace_toTensorFromBlocks_eq_iSup}
     \leanok
-    \uses{def:ground_space_parent, lem:local_ground_space_block_le_assembled}
+    \uses{def:ground_space_parent, lem:block_diagonal_boundary_condition_sum,
+        lem:local_ground_space_block_le_assembled}
     Let
     \[
         B=\bigoplus_{j=1}^g\mu_jA_j,


### PR DESCRIPTION
## Summary

This records the block-diagonal boundary-condition formula used in the PGVWC07 block decomposition argument. For
\[
  B=\bigoplus_j \mu_j A_j
\]
and block boundary matrices \(X_j\), the new theorem states
\[
  \Gamma_L^B\!\left(\bigoplus_j X_j\right)
  =
  \sum_j \Gamma_L^{A_j}(\mu_j^L X_j).
\]

The proof is the existing diagonal-block trace formula specialized to a block-diagonal boundary matrix. The blueprint now records this equation as its own lemma and uses it in the local block-sum ground-space entry.

Refs #905.

## Checks

- `lake build TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && python3 scripts/blueprint_lean_sync.py --root . --ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a derived Lean theorem built on existing block-sum machinery; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds **`groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal`**, stating that for a block-diagonal tensor \(B=\bigoplus_j \mu_j A_j\) and block boundary matrices \(X_j\),
> \[
> \Gamma_L^B\!\left(\bigoplus_j X_j\right) = \sum_j \Gamma_L^{A_j}(\mu_j^L X_j).
> \]
> The proof is a short specialization of the existing `groundSpaceMap_toTensorFromBlocks_eq_sum_diagonalBlock` result, using `diagonalBlock` / `sigmaDiagonalBlock` simp on each summand.
> 
> The blueprint gains a dedicated lemma **`lem:block_diagonal_boundary_condition_sum`** linked to that theorem (PGVWC07 block argument). **`lem:block_sum_local_ground_space`** now lists this lemma in `\uses` alongside the one-block inclusion lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf12375af986cb8a1ceb9941171b81af60f68efa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->