### PR TITLE
feat(parent): record boundary decomposition reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -284,4 +284,89 @@ theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_
   · exact chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
 
+/-- Boundary decomposition implies the reverse block-diagonal chain inclusion.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j.
+\]
+If every \(\psi\in\mathcal G_{N,L}(B)\) admits a decomposition
+\[
+  \psi=\sum_j\psi_j,
+  \qquad
+  \psi_j\in\mathcal G_{N,L}(A_j),
+\]
+then
+\[
+  \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j).
+\] -/
+theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ}
+    (hBoundary : ∀ ψ : NSiteSpace d N,
+      ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N →
+        ∃ φ : (j : Fin r) → NSiteSpace d N,
+          (∀ j, φ j ∈ chainGroundSpace (A j) L N) ∧
+            ψ = ∑ j, φ j) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  classical
+  intro ψ hψ
+  rcases hBoundary ψ hψ with ⟨φ, hφ, rfl⟩
+  exact Submodule.sum_mem _ fun j _ => Submodule.mem_iSup_of_mem j (hφ j)
+
+/-- Conditional block-diagonal chain equality in the finite injectivity range.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j.
+\]
+Under the normalized BNT block-separation hypotheses and the finite injectivity
+range, suppose that every vector in \(\mathcal G_{N,L}(B)\) can be written
+\[
+  \psi=\sum_j\psi_j,
+  \qquad
+  \psi_j\in\mathcal G_{N,L}(A_j).
+\]
+Then
+\[
+  \mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j),
+\]
+and the sum \(\bigvee_jG_N(A_j)\) is internal. -/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hBoundary : ∀ ψ : NSiteSpace d N,
+      ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N →
+        ∃ φ : (j : Fin r) → NSiteSpace d N,
+          (∀ j, φ j ∈ chainGroundSpace (A j) L N) ∧
+            ψ = ∑ j, φ j) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  have hClose :
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, chainGroundSpace (A j) L N :=
+    chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition μ A hBoundary
+  refine ⟨?_, ?_⟩
+  · exact
+      chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing
+        μ A hμ hN hLN hClose
+  · exact
+      (chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
+        μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange).2
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6499,6 +6499,84 @@ formulation; the passage to $\ker H_N$ is kept separate.
     inclusions.
 \end{proof}
 
+\begin{lemma}[Boundary decomposition gives the block-diagonal chain inclusion]
+    \label{lem:block_diagonal_boundary_decomposition_inclusion}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition}
+    \leanok
+    Let
+    \[
+        B=\bigoplus_{j=1}^g\mu_jA_j.
+    \]
+    Suppose that every vector $\psi\in\mathcal G_{N,L}(B)$ can be written as
+    \[
+        \psi=\sum_{j=1}^g\psi_j,
+        \qquad
+        \psi_j\in\mathcal G_{N,L}(A_j).
+    \]
+    Then
+    \[
+        \mathcal G_{N,L}(B)
+        \subseteq
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    For $\psi\in\mathcal G_{N,L}(B)$, choose the displayed decomposition. Each
+    summand lies in the corresponding subspace
+    $\mathcal G_{N,L}(A_j)$, hence their finite sum lies in
+    $\bigvee_j\mathcal G_{N,L}(A_j)$.
+\end{proof}
+
+\begin{lemma}[Boundary decomposition in the finite injectivity range]
+    \label{lem:bnt_block_diagonal_boundary_decomposition_equality}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition}
+    \leanok
+    \uses{lem:block_diagonal_boundary_decomposition_inclusion,
+        lem:isup_chain_ground_space_block_le_assembled,
+        lem:bnt_block_diagonal_periodic_constraints_internal_sum}
+    Let $A_1,\ldots,A_g$ be separated normalized blocks in the basis of normal
+    tensors, and let
+    \[
+        B=\bigoplus_{j=1}^g\mu_jA_j,
+        \qquad \mu_j\ne0.
+    \]
+    Assume each block is injective at length $L_0$, assume
+    $\sum_aA^j_aA^{j\dagger}_a=I$ for every $j$, and suppose
+    \[
+        L\ge (L_0+1)+(g-1)3(L_0+1)+1,
+        \qquad
+        N\ge L.
+    \]
+    If every vector $\psi\in\mathcal G_{N,L}(B)$ can be written as
+    \[
+        \psi=\sum_{j=1}^g\psi_j,
+        \qquad
+        \psi_j\in\mathcal G_{N,L}(A_j),
+    \]
+    then
+    \[
+        \mathcal G_{N,L}(B)
+        =
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j),
+    \]
+    and the sum $\bigvee_jG_N(A_j)$ is internal.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:block_diagonal_boundary_decomposition_inclusion} gives
+    \[
+        \mathcal G_{N,L}(B)
+        \subseteq
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j).
+    \]
+    The blockwise inclusion gives the reverse containment, hence equality. The
+    internality of $\bigvee_jG_N(A_j)$ is the directness conclusion of
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}.
+\end{proof}
+
 \begin{theorem}[Block-diagonal intersection identity]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
@@ -6522,6 +6600,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
         lem:bnt_block_diagonal_periodic_chain_inclusions,
         lem:block_diagonal_boundary_closing_capstone,
+        lem:block_diagonal_boundary_decomposition_inclusion,
+        lem:bnt_block_diagonal_boundary_decomposition_equality,
         thm:wordspan_propagation_unital}
     Let $A_1,\ldots,A_g$ be the blocks in a block-injective canonical form, and
     assume that their MPV families are pairwise different:


### PR DESCRIPTION
## Summary

This records the boundary-decomposition reduction for the block-diagonal parent-Hamiltonian chain.

For
\[
  B=\bigoplus_j \mu_j A_j,
\]
it adds the elementary implication
\[
  \left(\psi\in\mathcal G_{N,L}(B)\Rightarrow
    \psi=\sum_j\psi_j,\; \psi_j\in\mathcal G_{N,L}(A_j)\right)
  \Rightarrow
  \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j).
\]

It also records the finite injectivity-range consequence: under the separated normalized block hypotheses and
\[
  L\ge (L_0+1)+(g-1)3(L_0+1)+1,
\]
the same boundary decomposition gives
\[
  \mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j),
\]
together with internality of \(\bigvee_jG_N(A_j)\).

Refs #905.

## Checks

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`

The root build still reports existing warnings in unrelated files, including the known `sorry` warnings outside this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs and blueprint sync only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds Lean and blueprint lemmas that **reduce block-diagonal chain ground-space equality** to a single **boundary decomposition** hypothesis: every \(\psi \in \mathcal G_{N,L}(B)\) splits as \(\sum_j \psi_j\) with \(\psi_j \in \mathcal G_{N,L}(A_j)\).
> 
> `chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition` proves the immediate consequence \(\mathcal G_{N,L}(B) \subseteq \bigvee_j \mathcal G_{N,L}(A_j)\) via `Submodule.sum_mem` and `mem_iSup_of_mem`. Under the existing BNT C1 / finite injectivity range, `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition` combines that reverse inclusion with `chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing` and reuses `chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1` for **equality** of periodic block chain spaces and **internality** of \(\bigvee_j G_N(A_j)\).
> 
> Chapter 14 gains matching lemmas and wires them into the not-yet-ready block-diagonal intersection theorem’s dependency list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c478c5d6fe70e81d0de27dfa46967f23756d5a55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->