### PR TITLE
feat(parent): isolate left-word boundary reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -193,6 +193,67 @@ theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_wo
   exact closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
     (A := A) hInj hL₀ hM YAt hYAt X μ hOneSided.1 hLeft
 
+/-- Boundary restrictions from the left-multiplied closing-boundary comparison.
+
+Let \(\psi=\Gamma_{M+1}(X)\), and let \(Y_i(\tau)\) represent the
+length-\((L_0+1)\) cyclic restrictions of \(\psi\). If, for every boundary
+letter \(\eta\), physical letter \(j\), and length-\(L_0\) words
+\(\alpha,\sigma\),
+\[
+  A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
+  =
+  A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr),
+\]
+then
+\[
+  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+  =
+  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+\]
+
+This theorem reduces the coordinate comparison to the closing-boundary equality
+in arXiv:2011.12127, Section IV.C, lines
+2078--2079. -/
+theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap_left_words
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d)
+    (hLeft : ∀ (η j : Fin d) (σ α : Fin L₀ → Fin d),
+      evalWord A (List.ofFn α) *
+          (YAt ⟨M + 1 - L₀, by omega⟩
+              (mirrorMiddleBackground L₀ (M + 1) η μ) * A j *
+            evalWord A (List.ofFn σ)) =
+        evalWord A (List.ofFn α) *
+          (evalWord A (List.ofFn μ) * A j * X *
+            evalWord A (List.ofFn σ))) :
+    ∀ η : Fin d,
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M, by omega⟩ : Fin (M + 1))
+          (wrappedMiddleBackground L₀ (M + 1) η μ) ψ =
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+          (⟨M + 1 - L₀, by omega⟩ : Fin (M + 1))
+          (mirrorMiddleBackground L₀ (M + 1) η μ) ψ := by
+  have hMirrorPadded :=
+    closure_property_mirror_padded_products_of_left_word_products
+      (A := A) hInj hL₀ hM YAt X μ hLeft
+  have hMirrorRight :=
+    closure_property_mirror_right_product_eq_of_right_word_products
+      (A := A) hInj hL₀ hM YAt X μ hMirrorPadded
+  have hOneSided :=
+    closure_property_boundary_one_sided_products_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX YAt hYAt μ
+  refine closure_property_boundary_restrictions_eq_of_first_products
+    (A := A) hL₀ hM YAt hYAt μ ?_
+  intro η j
+  exact (hOneSided.1 η j).trans (hMirrorRight η j).symm
+
 /-- Equality of the two cyclic restrictions used when closing the boundary.
 
 Let \(\psi=\Gamma_{M+1}(X)\), and suppose each length-\((L_0+1)\) cyclic

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2600,6 +2600,66 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
+\begin{lemma}[Boundary restrictions from the left-multiplied comparison]
+    \label{lem:closure_property_boundary_restrictions_ground_space_map_left_words}
+    \lean{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap_left_words}
+    \leanok
+    \uses{lem:closure_property_boundary_one_sided_products_ground_space_map,
+        lem:closure_property_opposite_boundary_comparison_from_left_words,
+        lem:closure_property_opposite_boundary_comparison_from_right_words,
+        lem:closed_boundary_restrictions_from_first_letter_products}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
+    $D\ge1$. Let
+    \[
+        \psi=\Gamma_{M+1}(X)
+    \]
+    be an open-chain representation, and let $Y_i(\tau)$ represent the
+    length-$(L_0+1)$ cyclic restrictions of $\psi$. Fix a complementary word
+    $\mu$. Suppose that, for every boundary letter $\eta$, physical letter $j$,
+    and length-$L_0$ words $\alpha,\sigma$,
+    \[
+        A^\alpha
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
+        =
+        A^\alpha
+        \left(A^\mu A^jXA^\sigma\right).
+    \]
+    Then, for every boundary letter $\eta$,
+    \[
+        \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+        =
+        \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The assumed equations and
+    Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_left_words}
+    give, for every $\eta$, $j$, and $\sigma$,
+    \[
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
+        =
+        A^\mu A^jXA^\sigma .
+    \]
+    Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_right_words}
+    removes the right word:
+    \[
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j
+        =
+        A^\mu A^jX .
+    \]
+    The last-boundary equation from
+    Lemma~\ref{lem:closure_property_boundary_one_sided_products_ground_space_map}
+    gives
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
+    \]
+    Hence the first-letter products agree, and
+    Lemma~\ref{lem:closed_boundary_restrictions_from_first_letter_products}
+    identifies the two restrictions.
+\end{proof}
+
 \begin{lemma}[Equality of the boundary-closing cyclic restrictions]
     \label{lem:closure_property_boundary_restrictions_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}
@@ -2608,7 +2668,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         lem:closure_property_boundary_one_sided_products_ground_space_map,
         lem:closure_property_opposite_boundary_comparison_from_left_words,
         lem:closure_property_opposite_boundary_comparison_from_right_words,
-        lem:closed_boundary_restrictions_from_first_letter_products}
+        lem:closed_boundary_restrictions_from_first_letter_products,
+        lem:closure_property_boundary_restrictions_ground_space_map_left_words}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
     $D\ge1$. Let
     \[
@@ -2639,10 +2700,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \notready
-    Choose matrices \(Y_i(\tau)\) representing the length-\((L_0+1)\)
-    restrictions. The source-facing step still to be supplied is the following
-    coordinate comparison: for every boundary letter \(\eta\), physical letter
-    \(j\), and length-\(L_0\) words \(\alpha,\sigma\),
+    Choose matrices $Y_i(\tau)$ representing the length-$(L_0+1)$
+    restrictions. The remaining step from the source is the following
+    coordinate comparison: for every boundary letter $\eta$, physical letter
+    $j$, and length-$L_0$ words $\alpha,\sigma$,
     \[
         A^\alpha
         \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
@@ -2650,35 +2711,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         A^\alpha
         \left(A^\mu A^jXA^\sigma\right).
     \]
-    If this comparison is known, then
-    Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_left_words}
-    uses \(L_0\)-block injectivity to remove the left word and gives
-    \[
-        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
-        =
-        A^\mu A^jXA^\sigma .
-    \]
-    Lemma~\ref{lem:closure_property_opposite_boundary_comparison_from_right_words}
-    then uses \(L_0\)-block injectivity to remove the right word and gives
-    \[
-        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j
-        =
-        A^\mu A^jX .
-    \]
-    The last-boundary one-sided equation is
-    \[
-        Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
-    \]
-    Hence
-    \[
-        Y_M(\tau^+_\eta(\mu))A^j
-        =
-        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
-    \]
-    Lemma~\ref{lem:closed_boundary_restrictions_from_first_letter_products}
-    identifies the two length-\((L_0+1)\) restrictions for all boundary letters.
-    The displayed left-multiplied family is therefore not proved by the
-    cancellation lemmas above; it is the remaining coordinate form of the
+    Lemma~\ref{lem:closure_property_boundary_restrictions_ground_space_map_left_words}
+    records that these equations imply the equality of the two restrictions.
+    The displayed left-multiplied family is the remaining coordinate form of the
     boundary-closing sentence in \cite[lines~2078--2079]{Cirac2021Matrix}, and
     is recorded in docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}


### PR DESCRIPTION
## Summary

This PR records the implication

\[
A^\alpha\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
=
A^\alpha\left(A^\mu A^jXA^\sigma\right)
\]

for all boundary letters \(\eta\), physical letters \(j\), and length-\(L_0\) words \(\alpha,\sigma\), to

\[
\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
=
\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
\]

Equivalently, once the left-multiplied coordinate comparison is known, the previously formalized cancellation lemmas and the one-sided boundary equation identify the two cyclic restrictions. The derivation of the displayed comparison from CPGSV21, Section IV.C, lines 2078--2079, remains recorded in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.

Refs #2405.

## Checks

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`

The Lean builds retain existing warnings in unrelated files, and the focused boundary build still reports the pre-existing unfinished stronger boundary theorem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in MPS parent-Hamiltonian boundary closing; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Formalizes the implication from the left-multiplied boundary coordinate comparison to equality of the two closing cyclic restrictions**, wiring existing stripping/cancellation lemmas into one Lean theorem (`closure_property_boundary_restrictions_eq_of_groundSpaceMap_left_words`) and a synced blueprint lemma.
> 
> The proof chains **left-word stripping** → **mirror right product** → **one-sided last-boundary products**, then applies **`closure_property_boundary_restrictions_eq_of_first_products`**. The blueprint chapter **replaces an inlined proof sketch** in the stronger boundary-closing lemma with a reference to the new lemma; proving the left-multiplied comparison from CPGSV21 remains an **open gap** (`\notready` / paper-gaps doc).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2b7e8e16505af9f8205fbd32aec2cf00eb903e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->