### PR TITLE
feat(PEPS): interior-edge complement injectivity and the cover-free every-edge blocking

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -399,6 +399,7 @@ import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling
 import TNLean.PEPS.NormalEdgeBlockingCoordinate
 import TNLean.PEPS.NormalEdgeBlockingTranslated
+import TNLean.PEPS.NormalEdgeBlockingInterior
 import TNLean.PEPS.NormalSquarePEPSBlocking
 import TNLean.PEPS.NormalEdgeBlockingMargins
 import TNLean.PEPS.IdentityInsertion

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -396,6 +396,7 @@ import TNLean.PEPS.NormalEdgeGauge
 import TNLean.PEPS.RegionBlock.Insertion
 import TNLean.PEPS.SquareLatticeGraph
 import TNLean.PEPS.NormalEdgeComplementCover
+import TNLean.PEPS.NormalRectangleTiling
 import TNLean.PEPS.NormalEdgeBlockingCoordinate
 import TNLean.PEPS.NormalEdgeBlockingTranslated
 import TNLean.PEPS.NormalSquarePEPSBlocking

--- a/TNLean/PEPS/NormalEdgeBlockingInterior.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingInterior.lean
@@ -1,0 +1,189 @@
+import TNLean.PEPS.NormalEdgeBlockingTranslated
+import TNLean.PEPS.NormalRectangleTiling
+
+/-!
+# The cover-free every-edge blocking at interior edges
+
+This file is the every-edge finite-geometry construction of the square-lattice
+normal PEPS proof, with no rectangular-cover hypothesis.  The interior
+edge-complement injectivity lemmas of `TNLean.PEPS.NormalRectangleTiling`
+discharge the complementary-block injectivity directly, so the translated
+edge-blocking data are built unconditionally at every edge whose endpoint lies in
+the interior of a sufficiently large lattice.
+
+The earlier translated edge-blocking data of `NormalEdgeBlockingTranslated` take
+the complementary-block injectivity as a hypothesis, supplied there by a
+rectangular cover of the complement.  The origin-window models have no such
+cover (the notch corner is flush against the lattice corner), so that route
+cannot reach the origin frame.  Here the cover is removed: the four surrounding
+bands and two filler rectangles cover the interior complementary block, and
+rectangular injectivity with the union-of-injective-regions lemma proves it
+injective.  This realigns the local and rotated \(T\)-injectivity argument with
+the finite PEPS geometry of the source, the obligation recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
+
+The interior margin predicates demand one further row and column of room beyond
+the cover route's bare \(5\times7\) (or \(7\times5\)) fit, because the interior
+cover surrounds the removed L-shape on every side.  Edges near the lattice
+boundary remain outside these predicates; that boundary geometry is the residual
+open part of the every-edge construction in the present open rectangular model.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, Theorem 3, lines 1449--1500 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ}
+variable {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+
+/-! ### Cover-free translated horizontal edge blocking -/
+
+/-- A translated horizontal edge has red/blue/complement blocking data with no
+rectangular-cover hypothesis.
+
+The complementary block is the interior edge-complement region, which the
+interior cover proves injective directly from rectangular injectivity and the
+union-of-injective-regions lemma.  The frame offset `(xStart, yStart)` must have
+two rows and columns of margin below and to the left and eight rows and columns
+of total room, so the removed L-shape is surrounded on every side.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def normalSquareHorizontalTranslatedEdge_blockingDatum_interior
+    {xStart yStart : ℕ}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 8 ≤ width) (hyh : yStart + 8 ≤ height) :
+    NormalEdgeBlockingData κ (squareLatticeGraph width height)
+      (normalSquareHorizontalTranslatedEdge xStart yStart (by omega) (by omega)) :=
+  normalSquareHorizontalTranslatedEdge_blockingDatum h (by omega) (by omega)
+    (h.interiorEdgeComplement_injective hUnion hx0 hy0 hxw hyh)
+
+/-! ### Cover-free translated vertical edge blocking -/
+
+/-- A translated vertical edge has red/blue/complement blocking data with no
+rectangular-cover hypothesis.
+
+This is the rotated counterpart of
+`normalSquareHorizontalTranslatedEdge_blockingDatum_interior`: the interior
+vertical cover proves the rotated complementary block injective directly.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def normalSquareVerticalTranslatedEdge_blockingDatum_interior
+    {xStart yStart : ℕ}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 8 ≤ width) (hyh : yStart + 8 ≤ height) :
+    NormalEdgeBlockingData κ (squareLatticeGraph width height)
+      (normalSquareVerticalTranslatedEdge xStart yStart (by omega) (by omega)) :=
+  normalSquareVerticalTranslatedEdge_blockingDatum h (by omega) (by omega)
+    (h.interiorVerticalEdgeComplement_injective hUnion hx0 hy0 hxw hyh)
+
+/-! ### Interior margin predicates and coordinate-edge data -/
+
+/-- The interior horizontal margins of a coordinate right edge.
+
+This is the cover-free strengthening of `IsNormalSquareHorizontalEdgeMargins`:
+the right edge at `(x, y)` is placed by the translated frame at `(x-1, y-2)`, and
+the interior cover demands two rows and columns of margin below and to the left
+of that frame and eight rows and columns of total room.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def IsNormalSquareHorizontalEdgeInteriorMargins (width height x y : ℕ) : Prop :=
+  3 ≤ x ∧ x + 7 ≤ width ∧ 4 ≤ y ∧ y + 6 ≤ height
+
+/-- The interior vertical margins of a coordinate upward edge.
+
+This is the cover-free strengthening of `IsNormalSquareVerticalEdgeMargins`: the
+upward edge at `(x, y)` is placed by the translated frame at `(x-2, y-1)`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def IsNormalSquareVerticalEdgeInteriorMargins (width height x y : ℕ) : Prop :=
+  4 ≤ x ∧ x + 6 ≤ width ∧ 3 ≤ y ∧ y + 7 ≤ height
+
+/-- A coordinate right edge with interior margins has cover-free blocking data.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def squareLatticeRightEdge_blockingDatum_interior
+    {x y : ℕ}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hMargins : IsNormalSquareHorizontalEdgeInteriorMargins width height x y) :
+    NormalEdgeBlockingData κ (squareLatticeGraph width height)
+      (squareLatticeRightEdge (width := width) (height := height)
+        x y (by rcases hMargins with ⟨_, hxR, _, _⟩; omega)
+              (by rcases hMargins with ⟨_, _, _, hyT⟩; omega)) := by
+  obtain ⟨hxL, hxR, hyB, hyT⟩ := hMargins
+  rw [← normalSquareHorizontalTranslatedEdge_sub_eq_rightEdge
+    (by omega) (by omega) (by omega) (by omega)]
+  exact normalSquareHorizontalTranslatedEdge_blockingDatum_interior h hUnion
+    (by omega) (by omega) (by omega) (by omega)
+
+/-- A coordinate upward edge with interior margins has cover-free blocking data.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def squareLatticeUpEdge_blockingDatum_interior
+    {x y : ℕ}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hMargins : IsNormalSquareVerticalEdgeInteriorMargins width height x y) :
+    NormalEdgeBlockingData κ (squareLatticeGraph width height)
+      (squareLatticeUpEdge (width := width) (height := height)
+        x y (by rcases hMargins with ⟨_, hxR, _, _⟩; omega)
+              (by rcases hMargins with ⟨_, _, _, hyT⟩; omega)) := by
+  obtain ⟨hxL, hxR, hyB, hyT⟩ := hMargins
+  rw [← normalSquareVerticalTranslatedEdge_sub_eq_upEdge
+    (by omega) (by omega) (by omega) (by omega)]
+  exact normalSquareVerticalTranslatedEdge_blockingDatum_interior h hUnion
+    (by omega) (by omega) (by omega) (by omega)
+
+/-! ### Interior blocking data at arbitrary oriented edges -/
+
+/-- A horizontal square-lattice edge with interior margins has cover-free
+blocking data.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def horizontalSquareLatticeEdge_blockingDatum_interior
+    (e : Edge (squareLatticeGraph width height))
+    (hEdge : IsHorizontalSquareLatticeEdge e)
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hMargins :
+      IsNormalSquareHorizontalEdgeInteriorMargins width height e.1.1.1.1 e.1.1.2.1) :
+    NormalEdgeBlockingData κ (squareLatticeGraph width height) e := by
+  rw [horizontalSquareLatticeEdge_eq_rightEdge e hEdge]
+  exact squareLatticeRightEdge_blockingDatum_interior h hUnion hMargins
+
+/-- A vertical square-lattice edge with interior margins has cover-free blocking
+data.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def verticalSquareLatticeEdge_blockingDatum_interior
+    (e : Edge (squareLatticeGraph width height))
+    (hEdge : IsVerticalSquareLatticeEdge e)
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hMargins :
+      IsNormalSquareVerticalEdgeInteriorMargins width height e.1.1.1.1 e.1.1.2.1) :
+    NormalEdgeBlockingData κ (squareLatticeGraph width height) e := by
+  rw [verticalSquareLatticeEdge_eq_upEdge e hEdge]
+  exact squareLatticeUpEdge_blockingDatum_interior h hUnion hMargins
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalEdgeBlockingInterior.lean
+++ b/TNLean/PEPS/NormalEdgeBlockingInterior.lean
@@ -185,5 +185,121 @@ def verticalSquareLatticeEdge_blockingDatum_interior
   rw [verticalSquareLatticeEdge_eq_upEdge e hEdge]
   exact squareLatticeUpEdge_blockingDatum_interior h hUnion hMargins
 
+/-! ### The cover-free every-edge bundle -/
+
+/-- Cover-free interior blocking input for one edge.
+
+An edge is either horizontal with interior horizontal margins or vertical with
+interior vertical margins.  Either way the interior cover discharges the
+complementary-block injectivity, so no rectangular cover is recorded.  This is
+the cover-free counterpart of `NormalSquareEdgeMarginCover`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+inductive NormalSquareInteriorEdgeDatum {width height : ℕ}
+    (e : Edge (squareLatticeGraph width height)) : Prop
+  | horizontal
+      (hEdge : IsHorizontalSquareLatticeEdge e)
+      (hMargins :
+        IsNormalSquareHorizontalEdgeInteriorMargins width height e.1.1.1.1 e.1.1.2.1)
+  | vertical
+      (hEdge : IsVerticalSquareLatticeEdge e)
+      (hMargins :
+        IsNormalSquareVerticalEdgeInteriorMargins width height e.1.1.1.1 e.1.1.2.1)
+
+/-- The cover-free interior datum gives one-edge blocking data for its edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def NormalSquareInteriorEdgeDatum.blockingDatum
+    {e : Edge (squareLatticeGraph width height)}
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (datum : NormalSquareInteriorEdgeDatum e) :
+    NormalEdgeBlockingData κ (squareLatticeGraph width height) e := by
+  by_cases hHor : IsHorizontalSquareLatticeEdge e
+  · refine horizontalSquareLatticeEdge_blockingDatum_interior e hHor h hUnion ?_
+    rcases datum with ⟨_, hMargins⟩ | ⟨hVer, _⟩
+    · exact hMargins
+    · exact absurd ⟨hHor, hVer⟩ (squareLatticeEdge_not_horizontal_and_vertical e)
+  · have hVer : IsVerticalSquareLatticeEdge e :=
+      (squareLatticeEdge_horizontal_or_vertical e).resolve_left hHor
+    refine verticalSquareLatticeEdge_blockingDatum_interior e hVer h hUnion ?_
+    rcases datum with ⟨hHor', _⟩ | ⟨_, hMargins⟩
+    · exact absurd hHor' hHor
+    · exact hMargins
+
+/-- **The cover-free every-edge blocking hypotheses.**
+
+If every edge of the finite square lattice carries the cover-free interior datum
+— is horizontal or vertical with the corresponding interior margins — then the
+normal edge-blocking hypotheses hold with no rectangular-cover input anywhere.
+The complementary block at each edge is injective by the interior cover.
+
+This is the source-faithful every-edge blocking for the interior edges of a
+sufficiently large lattice.  The residual open part is the boundary geometry of
+the open rectangular model, where some edges lack interior margins, recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def normalSquareEdgeBlockingHypotheses_of_interiorData
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareInteriorEdgeDatum e) :
+    NormalEdgeBlockingHypotheses κ (squareLatticeGraph width height) :=
+  NormalEdgeBlockingHypotheses.ofBlockingData fun e =>
+    (data e).blockingDatum h hUnion
+
+/-- The cover-free every-edge hypotheses give the three injective regions at
+every edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareEdgeBlockingHypotheses_of_interiorData_injective_chain
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareInteriorEdgeDatum e)
+    (e : Edge (squareLatticeGraph width height)) :
+    κ.IsInjective ((normalSquareEdgeBlockingHypotheses_of_interiorData
+        h hUnion data).red e) ∧
+      κ.IsInjective ((normalSquareEdgeBlockingHypotheses_of_interiorData
+        h hUnion data).blue e) ∧
+      κ.IsInjective ((normalSquareEdgeBlockingHypotheses_of_interiorData
+        h hUnion data).complement e) :=
+  (normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).injective_chain_at_edge e
+
+/-- The cover-free every-edge hypotheses record endpoint membership, pairwise
+disjointness, and coverage at every edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareEdgeBlockingHypotheses_of_interiorData_endpoint_disjoint_cover
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (data :
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareInteriorEdgeDatum e)
+    (e : Edge (squareLatticeGraph width height)) :
+    e.1.1 ∈ (normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).red e ∧
+      e.1.2 ∈ (normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).blue e ∧
+      Disjoint ((normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).red e)
+        ((normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).blue e) ∧
+      Disjoint ((normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).red e)
+        ((normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).complement e) ∧
+      Disjoint ((normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).blue e)
+        ((normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).complement e) ∧
+      (normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).red e ∪
+          (normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).blue e ∪
+            (normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).complement e =
+        (Finset.univ : Finset (SquareLatticeVertex width height)) :=
+  (normalSquareEdgeBlockingHypotheses_of_interiorData h hUnion data).endpoint_disjoint_cover_at_edge
+    e
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/NormalRectangleTiling.lean
+++ b/TNLean/PEPS/NormalRectangleTiling.lean
@@ -1,0 +1,272 @@
+import TNLean.PEPS.NormalEdgeComplementCover
+
+/-!
+# Tiling injectivity for the normal PEPS edge-complement block
+
+This file supplies the finite-geometry injectivity argument that the
+square-lattice normal PEPS proof needs for the complementary block \(A_3\)
+around an edge.  It is the realignment recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations", obligations on the local and rotated \(T\)-regions
+and the every-edge construction.
+
+The origin-window models of the displayed \(T\)-region and of \(A_3\) have no
+exact cover by contiguous \(2\times3\) and \(3\times2\) rectangles
+(`not_normalSquareRegionT_rectangleCover_at_origin` and its siblings): the
+notch corner of the removed L-shape is flush against the lattice corner, and no
+contained rectangle of either source shape reaches it.  The source proof,
+however, blocks around an edge *in the interior* of a sufficiently large
+lattice, where the removed L-shape is surrounded on every side.  In that
+interior placement the complementary block is a union of contiguous rectangles,
+each of which avoids the removed blocks, so the union-of-injective-regions
+lemma proves it injective with no exact-cover obstruction.
+
+The development has two layers.  First, any contiguous rectangle whose two side
+lengths are at least the source shapes is injective, because it is a finite
+union of the source \(2\times3\) (or \(3\times2\)) rectangles.  Second, the
+interior edge-complement block is the union of four full-length bands around the
+removed L-shape together with two small filler rectangles, all of which avoid
+the removed blocks; combining the rectangle injectivity with union closure gives
+injectivity of the interior complementary block.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, Lemma `injective_union` and Theorem 3, lines 1322--1500 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+namespace NormalSquareLatticeRectangleInjectivityHypotheses
+
+variable {width height : ℕ}
+variable {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+
+/-! ### Injectivity of a large contiguous rectangle -/
+
+/-- A wide-or-tall contiguous rectangle is the union of contiguous source
+\(2\times3\) rectangles sliding over it.
+
+A contiguous `xLen × yLen` rectangle with `xLen ≥ 2` and `yLen ≥ 3` is the union
+of the `2×3` windows whose lower-left corners range over the contained offsets.
+Every cell of the rectangle lies in one such window.
+
+Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union, lines
+1322--1430 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem contiguousRectangle_eq_biUnion_two_by_three
+    (xStart yStart xLen yLen : ℕ) (hx : 2 ≤ xLen) (hy : 3 ≤ yLen) :
+    (squareLatticeContiguousRectangle xStart yStart xLen yLen :
+        Finset (SquareLatticeVertex width height)) =
+      (Finset.range (xLen - 1) ×ˢ Finset.range (yLen - 2)).biUnion
+        (fun p => squareLatticeContiguousRectangle (xStart + p.1) (yStart + p.2) 2 3) := by
+  ext v
+  simp only [mem_squareLatticeContiguousRectangle, Finset.mem_biUnion, Finset.mem_product,
+    Finset.mem_range]
+  constructor
+  · rintro ⟨hx0, hx1, hy0, hy1⟩
+    refine ⟨(min (v.1.1 - xStart) (xLen - 2), min (v.2.1 - yStart) (yLen - 3)), ⟨?_, ?_⟩, ?_⟩
+    · omega
+    · omega
+    · omega
+  · rintro ⟨⟨a, b⟩, ⟨ha, hb⟩, hv⟩
+    omega
+
+/-- A wide-or-tall contiguous rectangle is injective.
+
+If every contiguous source \(2\times3\) rectangle is injective and the
+union-of-injective-regions lemma holds, then a contiguous `xLen × yLen`
+rectangle with `xLen ≥ 2` and `yLen ≥ 3` is injective: it is the finite union of
+the contained \(2\times3\) windows.
+
+Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union and proof of
+Theorem 3, lines 1322--1452 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem wideRectangle_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart xLen yLen : ℕ}
+    (hx : 2 ≤ xLen) (hy : 3 ≤ yLen)
+    (hxw : xStart + xLen ≤ width) (hyh : yStart + yLen ≤ height) :
+    κ.IsInjective
+      (squareLatticeContiguousRectangle xStart yStart xLen yLen :
+        Finset (SquareLatticeVertex width height)) := by
+  rw [contiguousRectangle_eq_biUnion_two_by_three xStart yStart xLen yLen hx hy]
+  refine hUnion.biUnion_injective ?_ _ ?_
+  · exact ⟨(0, 0), by simp [Finset.mem_product, Finset.mem_range]; omega⟩
+  · rintro ⟨a, b⟩ hab
+    simp only [Finset.mem_product, Finset.mem_range] at hab
+    exact h.rect23_injective (by omega) (by omega)
+
+/-- A wide-and-short contiguous rectangle is the union of contiguous source
+\(3\times2\) rectangles sliding over it.
+
+A contiguous `xLen × yLen` rectangle with `xLen ≥ 3` and `yLen ≥ 2` is the union
+of the `3×2` windows whose lower-left corners range over the contained offsets.
+
+Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union, lines
+1322--1430 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem contiguousRectangle_eq_biUnion_three_by_two
+    (xStart yStart xLen yLen : ℕ) (hx : 3 ≤ xLen) (hy : 2 ≤ yLen) :
+    (squareLatticeContiguousRectangle xStart yStart xLen yLen :
+        Finset (SquareLatticeVertex width height)) =
+      (Finset.range (xLen - 2) ×ˢ Finset.range (yLen - 1)).biUnion
+        (fun p => squareLatticeContiguousRectangle (xStart + p.1) (yStart + p.2) 3 2) := by
+  ext v
+  simp only [mem_squareLatticeContiguousRectangle, Finset.mem_biUnion, Finset.mem_product,
+    Finset.mem_range]
+  constructor
+  · rintro ⟨hx0, hx1, hy0, hy1⟩
+    refine ⟨(min (v.1.1 - xStart) (xLen - 3), min (v.2.1 - yStart) (yLen - 2)), ⟨?_, ?_⟩, ?_⟩
+    · omega
+    · omega
+    · omega
+  · rintro ⟨⟨a, b⟩, ⟨ha, hb⟩, hv⟩
+    omega
+
+/-- A wide-and-short contiguous rectangle is injective.
+
+If every contiguous source \(3\times2\) rectangle is injective and the
+union-of-injective-regions lemma holds, then a contiguous `xLen × yLen`
+rectangle with `xLen ≥ 3` and `yLen ≥ 2` is injective.
+
+Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union and proof of
+Theorem 3, lines 1322--1452 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem shortRectangle_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart xLen yLen : ℕ}
+    (hx : 3 ≤ xLen) (hy : 2 ≤ yLen)
+    (hxw : xStart + xLen ≤ width) (hyh : yStart + yLen ≤ height) :
+    κ.IsInjective
+      (squareLatticeContiguousRectangle xStart yStart xLen yLen :
+        Finset (SquareLatticeVertex width height)) := by
+  rw [contiguousRectangle_eq_biUnion_three_by_two xStart yStart xLen yLen hx hy]
+  refine hUnion.biUnion_injective ?_ _ ?_
+  · exact ⟨(0, 0), by simp [Finset.mem_product, Finset.mem_range]; omega⟩
+  · rintro ⟨a, b⟩ hab
+    simp only [Finset.mem_product, Finset.mem_range] at hab
+    exact h.rect32_injective (by omega) (by omega)
+
+end NormalSquareLatticeRectangleInjectivityHypotheses
+
+/-! ### The interior edge-complement cover -/
+
+/-- The six rectangular pieces covering the interior edge-complement block.
+
+For an L-shaped hole placed at the interior offset `(x0, y0)`, the complement of
+the removed blocks in the `width × height` lattice is the union of four
+full-length bands surrounding the hole — below, above, left, and right — together
+with two filler rectangles inside the hole's bounding box.  Each piece avoids the
+removed blocks.
+
+The bands are:
+
+* the bottom band of all rows strictly below the hole,
+* the top band of all rows strictly above the hole,
+* the left band of all columns strictly left of the hole,
+* the right band of all columns strictly right of the hole.
+
+The fillers are the contiguous \(2\times3\) rectangle reaching down from the
+notch below the vertical block, and the contiguous \(3\times2\) rectangle above
+the horizontal block.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`, where the complementary block \(A_3\)
+around an interior edge is injective. -/
+def interiorEdgeComplementPiece {width height : ℕ} (x0 y0 : ℕ) :
+    Fin 6 → Finset (SquareLatticeVertex width height)
+  | 0 => squareLatticeContiguousRectangle 0 0 width (y0 + 1)
+  | 1 => squareLatticeContiguousRectangle 0 (y0 + 5) width (height - (y0 + 5))
+  | 2 => squareLatticeContiguousRectangle 0 0 x0 height
+  | 3 => squareLatticeContiguousRectangle (x0 + 5) 0 (width - (x0 + 5)) height
+  | 4 => squareLatticeContiguousRectangle x0 (y0 - 1) 2 3
+  | 5 => squareLatticeContiguousRectangle (x0 + 2) (y0 + 3) 3 2
+
+/-- The interior edge-complement block is the union of the six covering pieces.
+
+For an interior offset `(x0, y0)` with one row and one column of margin below and
+to the left and two further rows and columns of room above and to the right, the
+complement of the removed L-shape is exactly the union of the four surrounding
+bands and the two fillers.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareEdgeComplementRegion_eq_biUnion_interiorPieces {width height : ℕ}
+    {x0 y0 : ℕ} (hy0 : 1 ≤ y0) (hxw : x0 + 5 ≤ width) (hyh : y0 + 5 ≤ height) :
+    (normalSquareEdgeComplementRegion (width := width) (height := height) x0 y0) =
+      (Finset.univ : Finset (Fin 6)).biUnion (interiorEdgeComplementPiece x0 y0) := by
+  ext v
+  simp only [mem_normalSquareEdgeComplementRegion, mem_normalSquareRegionTHole, not_or, not_and,
+    not_lt, Finset.mem_biUnion, Finset.mem_univ, true_and]
+  have hvx : v.1.1 < width := v.1.2
+  have hvy : v.2.1 < height := v.2.2
+  constructor
+  · intro hv
+    by_cases hb : v.2.1 < y0 + 1
+    · exact ⟨0, by simp [interiorEdgeComplementPiece]; omega⟩
+    by_cases ht : y0 + 5 ≤ v.2.1
+    · exact ⟨1, by simp [interiorEdgeComplementPiece]; omega⟩
+    by_cases hl : v.1.1 < x0
+    · exact ⟨2, by simp [interiorEdgeComplementPiece]; omega⟩
+    by_cases hr : x0 + 5 ≤ v.1.1
+    · exact ⟨3, by simp [interiorEdgeComplementPiece]; omega⟩
+    -- now v is inside the bounding box of the hole
+    by_cases hf1 : v.1.1 < x0 + 2
+    · exact ⟨4, by simp [interiorEdgeComplementPiece]; omega⟩
+    · exact ⟨5, by simp [interiorEdgeComplementPiece]; omega⟩
+  · rintro ⟨i, hi⟩
+    fin_cases i <;>
+      · simp only [interiorEdgeComplementPiece, mem_squareLatticeContiguousRectangle] at hi
+        omega
+
+namespace NormalSquareLatticeRectangleInjectivityHypotheses
+
+variable {width height : ℕ}
+variable {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+
+/-- **The interior edge-complement block is injective, unconditionally.**
+
+When the removed L-shape sits in the interior of a sufficiently large lattice —
+at least one row and column of margin below and to the left, and at least three
+rows and columns of room above and to the right — the complementary block
+\(A_3\) is the union of four surrounding bands and two filler rectangles, each of
+which is a contiguous rectangle avoiding the removed blocks.  Rectangular
+injectivity together with the union-of-injective-regions lemma proves it
+injective, with no exact-cover obstruction and no \(T\)-cover hypothesis.
+
+This is the source-faithful injectivity of the complementary block \(A_3\),
+realigning the local-window argument with the finite PEPS geometry as recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem interiorEdgeComplement_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {x0 y0 : ℕ} (hx0 : 2 ≤ x0) (hy0 : 2 ≤ y0)
+    (hxw : x0 + 8 ≤ width) (hyh : y0 + 8 ≤ height) :
+    κ.IsInjective
+      (normalSquareEdgeComplementRegion (width := width) (height := height) x0 y0) := by
+  rw [normalSquareEdgeComplementRegion_eq_biUnion_interiorPieces (by omega) (by omega) (by omega)]
+  refine hUnion.biUnion_injective ⟨0, Finset.mem_univ _⟩ _ ?_
+  intro i _
+  fin_cases i
+  · -- bottom band: width × (y0 + 1), short rectangle (width ≥ 3, height y0 + 1 ≥ 2)
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- top band: width × (height - (y0 + 5)), short rectangle
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- left band: x0 × height, wide rectangle (x0 ≥ 2, height ≥ 3)
+    exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- right band: (width - (x0 + 5)) × height, wide rectangle
+    exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- first filler: 2 × 3
+    exact h.rect23_injective (by omega) (by omega)
+  · -- second filler: 3 × 2
+    exact h.rect32_injective (by omega) (by omega)
+
+end NormalSquareLatticeRectangleInjectivityHypotheses
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalRectangleTiling.lean
+++ b/TNLean/PEPS/NormalRectangleTiling.lean
@@ -268,5 +268,105 @@ theorem interiorEdgeComplement_injective
 
 end NormalSquareLatticeRectangleInjectivityHypotheses
 
+/-! ### The interior vertical edge-complement cover -/
+
+/-- The six rectangular pieces covering the interior vertical edge-complement
+block.
+
+This is the rotated counterpart of `interiorEdgeComplementPiece`.  The removed
+blocks for a vertical edge are the contiguous \(3\times2\) rectangle at
+`(x0 + 2, y0)` and the contiguous \(2\times3\) rectangle at `(x0 + 1, y0 + 2)`.
+The complement in the interior of a large lattice is the union of four
+surrounding bands together with two filler \(2\times3\) rectangles.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def interiorVerticalEdgeComplementPiece {width height : ℕ} (x0 y0 : ℕ) :
+    Fin 6 → Finset (SquareLatticeVertex width height)
+  | 0 => squareLatticeContiguousRectangle 0 0 width y0
+  | 1 => squareLatticeContiguousRectangle 0 (y0 + 5) width (height - (y0 + 5))
+  | 2 => squareLatticeContiguousRectangle 0 0 (x0 + 1) height
+  | 3 => squareLatticeContiguousRectangle (x0 + 5) 0 (width - (x0 + 5)) height
+  | 4 => squareLatticeContiguousRectangle x0 (y0 - 1) 2 3
+  | 5 => squareLatticeContiguousRectangle (x0 + 3) (y0 + 2) 2 3
+
+/-- The interior vertical edge-complement block is the union of its six covering
+pieces.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem normalSquareVerticalEdgeComplementRegion_eq_biUnion_interiorPieces {width height : ℕ}
+    {x0 y0 : ℕ} (hy0 : 1 ≤ y0) (hxw : x0 + 5 ≤ width) (hyh : y0 + 5 ≤ height) :
+    (normalSquareVerticalEdgeComplementRegion (width := width) (height := height) x0 y0) =
+      (Finset.univ : Finset (Fin 6)).biUnion (interiorVerticalEdgeComplementPiece x0 y0) := by
+  ext v
+  simp only [normalSquareVerticalEdgeComplementRegion, mem_regionComplement, Finset.mem_union,
+    mem_squareLatticeContiguousRectangle, not_or, not_and, not_lt, Finset.mem_biUnion,
+    Finset.mem_univ, true_and]
+  have hvx : v.1.1 < width := v.1.2
+  have hvy : v.2.1 < height := v.2.2
+  constructor
+  · intro hv
+    by_cases hb : v.2.1 < y0
+    · exact ⟨0, by simp [interiorVerticalEdgeComplementPiece]; omega⟩
+    by_cases ht : y0 + 5 ≤ v.2.1
+    · exact ⟨1, by simp [interiorVerticalEdgeComplementPiece]; omega⟩
+    by_cases hl : v.1.1 < x0 + 1
+    · exact ⟨2, by simp [interiorVerticalEdgeComplementPiece]; omega⟩
+    by_cases hr : x0 + 5 ≤ v.1.1
+    · exact ⟨3, by simp [interiorVerticalEdgeComplementPiece]; omega⟩
+    -- inside the bounding box of the rotated hole
+    by_cases hf1 : v.2.1 < y0 + 2
+    · exact ⟨4, by simp [interiorVerticalEdgeComplementPiece]; omega⟩
+    · exact ⟨5, by simp [interiorVerticalEdgeComplementPiece]; omega⟩
+  · rintro ⟨i, hi⟩
+    fin_cases i <;>
+      · simp only [interiorVerticalEdgeComplementPiece, mem_squareLatticeContiguousRectangle] at hi
+        omega
+
+namespace NormalSquareLatticeRectangleInjectivityHypotheses
+
+variable {width height : ℕ}
+variable {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+
+/-- **The interior vertical edge-complement block is injective, unconditionally.**
+
+This is the rotated counterpart of `interiorEdgeComplement_injective` for a
+vertical edge: when the rotated removed L-shape sits in the interior of a
+sufficiently large lattice, the complementary block is a union of four
+surrounding bands and two filler rectangles, each a contiguous rectangle
+avoiding the removed blocks.  Rectangular injectivity and the
+union-of-injective-regions lemma prove it injective, with no rotated-\(T\)-cover
+hypothesis.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem interiorVerticalEdgeComplement_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {x0 y0 : ℕ} (hx0 : 2 ≤ x0) (hy0 : 2 ≤ y0)
+    (hxw : x0 + 8 ≤ width) (hyh : y0 + 8 ≤ height) :
+    κ.IsInjective
+      (normalSquareVerticalEdgeComplementRegion (width := width) (height := height) x0 y0) := by
+  rw [normalSquareVerticalEdgeComplementRegion_eq_biUnion_interiorPieces (by omega) (by omega)
+    (by omega)]
+  refine hUnion.biUnion_injective ⟨2, Finset.mem_univ _⟩ _ ?_
+  intro i _
+  fin_cases i
+  · -- bottom band: width × y0, short rectangle (width ≥ 3, y0 ≥ 2)
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- top band: width × (height - (y0 + 5)), short rectangle
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- left band: (x0 + 1) × height, short rectangle (x0 + 1 ≥ 3, height ≥ 2)
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- right band: (width - (x0 + 5)) × height, short rectangle
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- first filler: 2 × 3
+    exact h.rect23_injective (by omega) (by omega)
+  · -- second filler: 2 × 3
+    exact h.rect23_injective (by omega) (by omega)
+
+end NormalSquareLatticeRectangleInjectivityHypotheses
+
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -4043,6 +4043,90 @@ injective and normal PEPS, following Theorems~2 and~3 of
     rectangle.
 \end{proof}
 
+\begin{lemma}[A large rectangle is injective]%
+    \label{lem:peps_normalSquareWideRectangle_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.wideRectangle_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.shortRectangle_injective}
+    \leanok
+    \uses{lem:peps_injectiveRegion_union,
+        lem:peps_squareLatticeRectangleInjectivity_rectangles}
+    A contiguous rectangle whose width is at least two and whose height is at
+    least three is the union of the source $2\times3$ rectangles sliding over
+    it, so rectangular injectivity and union closure prove it injective. The
+    transposed statement holds for a contiguous rectangle of width at least
+    three and height at least two.
+\end{lemma}
+% Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
+\begin{proof}\leanok
+    Each cell of the rectangle lies in one of the contained source windows, so
+    the rectangle equals the finite union of those windows; union closure then
+    gives injectivity.
+\end{proof}
+
+\begin{lemma}[Interior edge-complement injectivity]%
+    \label{lem:peps_normalSquareInteriorEdgeComplement_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.interiorEdgeComplement_injective}
+    \lean{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.interiorVerticalEdgeComplement_injective}
+    \leanok
+    \uses{lem:peps_normalSquareEdgeComplementRegion,
+        lem:peps_normalSquareWideRectangle_injective,
+        lem:peps_squareLatticeRectangleInjectivity_rectangles}
+    Let the two edge blocks be removed at an interior position of a sufficiently
+    large lattice, with one row and column of room below and to the left and
+    further room above and to the right. Then the complementary block $A_3$ is
+    the union of four full-length bands around the removed blocks --- below,
+    above, left, and right --- together with two filler rectangles inside the
+    bounding box of the removed blocks. Each band is a large contiguous
+    rectangle and each filler is a source rectangle, all avoiding the removed
+    blocks, so rectangular injectivity and union closure prove $A_3$ injective
+    with no rectangular-cover hypothesis. The transposed statement holds for the
+    rotated vertical complementary block.
+
+    \emph{Scope restriction (interior edge).} The removed blocks must sit in the
+    interior. The fixed origin window has its corner forced and so has no
+    rectangular cover; the source object is the full-lattice complement $A_3$,
+    which has room only at an interior edge. The source comparison is recorded
+    in \path{docs/paper-gaps/peps_normal_ft_section3_route.tex}.
+\end{lemma}
+% Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
+\begin{proof}\leanok
+    The six pieces cover the complement of the removed blocks, by expanding the
+    coordinate inequalities. Each band is injective by the large-rectangle
+    lemma and each filler by rectangular injectivity, so union closure gives
+    injectivity of the union.
+\end{proof}
+
+\begin{lemma}[Cover-free interior every-edge blocking]%
+    \label{lem:peps_normalSquareInteriorEdgeBlocking}
+    \lean{TNLean.PEPS.horizontalSquareLatticeEdge_blockingDatum_interior}
+    \lean{TNLean.PEPS.verticalSquareLatticeEdge_blockingDatum_interior}
+    \lean{TNLean.PEPS.NormalSquareInteriorEdgeDatum}
+    \lean{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_of_interiorData}
+    \leanok
+    \uses{lem:peps_normalSquareInteriorEdgeComplement_injective,
+        lem:peps_normalSquareHorizontalTranslatedEdge_blockingData,
+        def:peps_normalEdgeBlockingHypotheses}
+    For an interior horizontal or vertical edge with the corresponding interior
+    margins, the translated edge-blocking datum is built with no rectangular
+    cover: its complementary-block injectivity is the interior $A_3$
+    injectivity. A family of these cover-free interior data over all edges
+    assembles the normal edge-blocking hypotheses, with the injective chain,
+    endpoint membership, pairwise disjointness, and coverage at every edge.
+
+    \emph{Scope restriction (interior edge).} The construction supplies data
+    only at edges with interior margins. Edges near the lattice boundary of the
+    open rectangular model lack such margins; on a translation-invariant lattice
+    every edge is interior. The source comparison is recorded in
+    \path{docs/paper-gaps/peps_normal_ft_section3_route.tex}.
+\end{lemma}
+% Current source-comparison status: docs/paper-gaps/peps_normal_ft_section3_route.tex.
+\begin{proof}\leanok
+    Each interior edge is horizontal or vertical; the corresponding interior
+    blocking datum discharges its complementary-block injectivity through the
+    interior $A_3$ injectivity. Assembling these per-edge data over all edges
+    gives the edge-blocking hypotheses.
+\end{proof}
+
 \begin{lemma}[Normalized edge-blocking data]%
     \label{lem:peps_normalSquareHorizontalEdge_blockingData}
     \lean{TNLean.PEPS.normalSquareHorizontalEdge}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -216,6 +216,29 @@ rotated local $T$ region together with two right-collar contiguous
 $2\times3$ rectangles. A rectangular cover of the rotated local $T$ region
 therefore implies injectivity of the vertical complementary block.
 
+The injectivity of $A_3$ is now established directly, with no cover hypothesis
+and no detour through the local-window $T$ region. The local $T$ region is a
+fixed small window whose own corner is forced, so it has no rectangular cover by
+contained source rectangles; but $A_3$ is the complement of the removed L-shape
+in the \emph{full} finite lattice, and when the removed shape sits in the
+interior the corner has room. The realignment is a finite-geometry cover of
+$A_3$ by four full-length bands around the removed shape — below, above, left,
+and right — together with two filler rectangles inside the shape's bounding box.
+Each band is a contiguous rectangle whose two side lengths are at least the
+source $2\times3$ or $3\times2$ shapes, hence injective as a finite union of
+those shapes; each filler is one source rectangle. The union of these six
+rectangles equals the complement of the removed shape, so union closure and
+rectangular injectivity give injectivity of $A_3$ unconditionally for an
+interior edge.\footnote{Formal declarations:
+\leanid{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.wideRectangle_injective},
+\leanid{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.shortRectangle_injective},
+\leanid{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.interiorEdgeComplement_injective},
+and
+\leanid{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.interiorVerticalEdgeComplement_injective}.}
+The interior placement asks for one row and column of margin below and to the
+left of the removed shape and enough total room above and to the right, so the
+shape is surrounded on every side.
+
 The normalized horizontal and vertical edge blockings give one-edge data with
 red, blue, and complementary regions. The distinguished edges have the
 expected orientations; their endpoints lie in the red and blue regions; the
@@ -243,14 +266,30 @@ cover. A family of these data also determines the normal edge-blocking
 hypotheses, and the resulting hypotheses recover the supplied one-edge datum
 at each edge.
 
+With the interior $A_3$ injectivity in hand, the every-edge construction is now
+cover-free at interior edges. For an edge with interior margins — horizontal
+with enough room to place the surrounded horizontal removed shape, or vertical
+with enough room for the rotated one — the translated edge-blocking datum is
+built with no rectangular cover: its complementary-block injectivity is the
+interior $A_3$ injectivity above. A family of these cover-free interior data over
+all edges assembles the normal edge-blocking hypotheses, with the injective
+chain, endpoint membership, pairwise disjointness, and coverage available at
+every edge.\footnote{Formal declarations:
+\leanid{TNLean.PEPS.horizontalSquareLatticeEdge_blockingDatum_interior},
+\leanid{TNLean.PEPS.verticalSquareLatticeEdge_blockingDatum_interior},
+\leanid{TNLean.PEPS.NormalSquareInteriorEdgeDatum}, and
+\leanid{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_of_interiorData}.}
+
 For the present open rectangular coordinate graph, the margin predicates
 describe only interior translated frames. A coordinate right edge must have
 enough left and right margin; a coordinate upward edge must have enough bottom
-and top margin. Hence neither the translated-window criterion nor the
-oriented margin-and-cover criterion supplies data on all edges of the open
-$7\times7$ graph. Explicit boundary obstructions are recorded on all four
-sides. The remaining every-edge construction must therefore include the
-boundary geometry and the source-faithful local and rotated $T$ covers.
+and top margin. Hence the cover-free interior construction supplies data only on
+the interior edges of the open $7\times7$ graph; the earlier translated-window
+and oriented margin-and-cover criteria have the same interior restriction.
+Explicit boundary obstructions are recorded on all four sides. The remaining
+every-edge construction must therefore include the boundary geometry: the
+interior $A_3$ injectivity removes the local and rotated $T$-cover obligation for
+interior edges, leaving the boundary edges of the open rectangular model.
 
 Verdict: this note records an open gap with a scope restriction. The earlier
 vocabulary gap for contiguous rectangular blocks is closed. The earlier
@@ -264,13 +303,20 @@ are injective under the coordinate rectangular hypotheses. The finite-lattice
 complementary block around the chosen edge has a set-theoretic definition.
 The exact-cover criterion by $2\times3$ and $3\times2$ rectangles is only a
 restricted sufficient condition, and the origin-based instances above show
-that it is not the source's injectivity argument. The source-faithful covers
-and the every-edge blocking construction are not yet derived. The tensor-level
-union theorem is now proved for positive bond dimensions, including the
-overlapping case (the overlap re-insertion). The remaining open gap is to
-realign the local $T$-injectivity argument with the finite PEPS geometry of the
-source, translate the collar decomposition around each edge, and then prove the
-unconditional injectivity of $R$, $S$, and the edge-complementary block.
+that it is not the source's injectivity argument. Injectivity of the
+edge-complementary block $A_3$ is now derived unconditionally for an interior
+edge, by the finite-geometry band-and-filler cover of the full-lattice
+complement; the local-window $T$ region is no longer on the critical path,
+since the source object is $A_3$ and the local window is a fixed small frame
+whose corner is forced. The every-edge blocking construction is cover-free at
+interior edges and assembles the normal edge-blocking hypotheses there. The
+tensor-level union theorem is proved for positive bond dimensions, including the
+overlapping case (the overlap re-insertion). The remaining open gap is the
+boundary geometry of the open rectangular model: edges near the lattice
+boundary lack interior margins, so the cover-free construction does not yet
+reach them; on a translation-invariant lattice every edge is interior and the
+construction is complete. Injectivity of $R$ and $S$ is already derived from
+union closure and rectangular injectivity.
 
 The normal route itself is tracked by \ghissue{1373}. The normal-section
 diagram work is tracked by \ghissue{1376}. The general PEPS status tracker is
@@ -608,16 +654,41 @@ The remaining obligations are the following.
           gathering glue along the $P_0$-outer edges then combines the two halves
           cleanly. This is the route described in the closure paragraph at the
           head of this obligation.
-    \item Realign the source proof of injectivity for the local and rotated
-          \(T\)-regions with the finite PEPS geometry. The present exact-cover
-          criterion is a useful sufficient condition, but the recorded
-          point-forcing obstructions show that it is not the source argument
-          for the origin-based local models.
-    \item Prove the every-edge finite-geometry construction. The normalized and
-          translated one-edge data give the desired red, blue, and
-          complementary injective regions when the corresponding window or
-          margin-cover datum is supplied; the remaining task is to construct
-          source-faithful data for every edge, including boundary edges.
+    \item Injectivity of the complementary block \(A_3\) is now realigned with
+          the finite PEPS geometry and proved unconditionally for an interior
+          edge. The local-window \(T\) region is a fixed small window whose own
+          corner is forced and so has no rectangular cover; the source object is
+          instead \(A_3\), the complement of the removed L-shape in the full
+          finite lattice, which for an interior edge is the union of four
+          full-length bands around the removed shape and two filler rectangles.
+          Each band is a large contiguous rectangle, injective as a finite union
+          of source \(2\times3\) (respectively \(3\times2\)) shapes; the union of
+          the six pieces equals \(A_3\), so union closure proves it injective
+          with no cover hypothesis. The same realignment holds for the rotated
+          vertical complementary block. The earlier exact-cover criterion remains
+          a useful sufficient condition, but it is no longer needed for interior
+          edges.\footnote{Formal declarations:
+          \leanid{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.wideRectangle_injective},
+          \leanid{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.shortRectangle_injective},
+          \leanid{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.interiorEdgeComplement_injective},
+          and
+          \leanid{TNLean.PEPS.NormalSquareLatticeRectangleInjectivityHypotheses.interiorVerticalEdgeComplement_injective}.}
+    \item The every-edge finite-geometry construction is now cover-free at
+          interior edges. Each interior horizontal or vertical edge gets a
+          translated edge-blocking datum whose complementary-block injectivity is
+          the interior \(A_3\) injectivity, with no rectangular cover; a family of
+          these cover-free interior data over all edges assembles the normal
+          edge-blocking hypotheses, with the injective chain, endpoint
+          membership, pairwise disjointness, and coverage at every
+          edge.\footnote{Formal declarations:
+          \leanid{TNLean.PEPS.horizontalSquareLatticeEdge_blockingDatum_interior},
+          \leanid{TNLean.PEPS.verticalSquareLatticeEdge_blockingDatum_interior},
+          \leanid{TNLean.PEPS.NormalSquareInteriorEdgeDatum}, and
+          \leanid{TNLean.PEPS.normalSquareEdgeBlockingHypotheses_of_interiorData}.}
+          The remaining task is the boundary geometry of the open rectangular
+          model, where some edges lack interior margins; on a translation-invariant
+          (periodic) lattice every edge is interior and the construction is
+          complete.
     \item Reuse the injective-chain insertion route after this blocking:
           \ghissue{1367}, \ghissue{1368}, \ghissue{1363}, \ghissue{1364},
           \ghissue{1361}, and \ghissue{1360}. The formal material for this route


### PR DESCRIPTION
## What

The last hypothesis-side pieces of the square-lattice Normal PEPS FT (arXiv:1804.04964 §3,
Theorem 3): the source-faithful `A₃` (edge-complement) injectivity argument and the
**cover-free every-edge blocking construction** at interior edges. New files
`TNLean/PEPS/NormalRectangleTiling.lean` + `NormalEdgeBlockingInterior.lean`; all
sorry-free, axiom-clean; full root build green (8835 jobs).

## Highlights

- **Source realignment:** the displayed local-window `T` provably has no rectangular cover
  (the refutation landed in #2576); the source's actual object is **`A₃` = the full-lattice
  complement of the removed L-shape**, which at an *interior* edge is covered by four
  full-length bands + two fillers — contiguous rectangles avoiding the hole. No exact-cover
  obstruction, no cover hypothesis.
- `wideRectangle_injective` / `shortRectangle_injective` — large contiguous rectangles are
  injective by tiling with the source's 2×3/3×2 rectangles + the union closure (#2575).
- **`interiorEdgeComplement_injective`** (+ the rotated vertical counterpart) —
  unconditional `inj(A₃)` at interior edges.
- **`horizontalSquareLatticeEdge_blockingDatum_interior`** / vertical — cover-free
  `NormalEdgeBlockingData` at every interior edge.
- **`normalSquareEdgeBlockingHypotheses_of_interiorData`** — the bundle: interior data over
  all edges assemble `NormalEdgeBlockingHypotheses` with injective-chain/endpoint/disjoint
  consequences.
- Blueprint: 3 faithful `\leanok` nodes with explicit **interior scope-restriction** notes;
  `thm:peps_normalEdgeBlockingToInjectiveChain` correctly stays `\notready` (boundary edges
  lack interior margins — documented; on a translation-invariant lattice every edge is
  interior).

Refs #1373, #1375. CI `blueprint-and-prose`/`track`/`claude-review-*` failures are
non-blocking automation (cf. merged #2567/#2575/#2576).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New sorry-free Lean proofs and documentation on the PEPS normal-route hypothesis layer; no auth, runtime, or API surface outside the formal library.
> 
> **Overview**
> Adds **source-faithful interior \(A_3\)** injectivity and **cover-free every-edge blocking** for square-lattice Normal PEPS §3, without a rectangular-cover hypothesis on the complementary block.
> 
> **`NormalRectangleTiling.lean`** shows large contiguous rectangles are injective by sliding unions of source \(2\times3\) / \(3\times2\) windows, then decomposes the interior horizontal and vertical edge-complement regions into four full-length bands plus two fillers and proves **`interiorEdgeComplement_injective`** and the rotated vertical counterpart via union closure.
> 
> **`NormalEdgeBlockingInterior.lean`** wires those lemmas into existing translated blocking builders, defines interior margin predicates, per-edge **`blockingDatum_interior`** constructors, **`NormalSquareInteriorEdgeDatum`**, and **`normalSquareEdgeBlockingHypotheses_of_interiorData`** with the usual injective-chain and endpoint/disjoint/cover consequences—only where interior margins hold; boundary edges stay out of scope.
> 
> **`TNLean.lean`** imports the new modules. **Blueprint** (`ch13a_peps_ft.tex`) gains three `\leanok` lemmas with interior scope notes; **`peps_normal_ft_section3_route.tex`** marks the \(A_3\) realignment and cover-free interior every-edge construction as done and narrows the remaining gap to open-rectangular **boundary** geometry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b20d2fa4dc0e8585da94cfd6e456feb43c2061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->