### PR TITLE
feat(PEPS): TI gauge absorption and the conditional square-lattice normal Fundamental Theorem

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -395,6 +395,7 @@ import TNLean.PEPS.NormalBlocking
 import TNLean.PEPS.NormalEdgeGauge
 import TNLean.PEPS.RegionBlock.Insertion
 import TNLean.PEPS.SquareLatticeGraph
+import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling
 import TNLean.PEPS.NormalEdgeBlockingCoordinate

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -423,6 +423,7 @@ import TNLean.PEPS.FundamentalTheorem.Uniqueness
 -- (arXiv:1804.04964, Section 3, theorem labelled `normal`).
 import TNLean.PEPS.NormalFundamentalTheorem
 import TNLean.PEPS.NormalSquareTIAbsorption
+import TNLean.PEPS.RegionComplementComparison
 -- Region-blocked insertion-algebra isomorphism: the per-edge gauge engine for the
 -- normal PEPS Fundamental Theorem (region analogue of the injective edge gauge).
 import TNLean.PEPS.RegionBlock.Algebra

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -424,6 +424,7 @@ import TNLean.PEPS.FundamentalTheorem.Uniqueness
 import TNLean.PEPS.NormalFundamentalTheorem
 import TNLean.PEPS.NormalSquareTIAbsorption
 import TNLean.PEPS.RegionComplementComparison
+import TNLean.PEPS.NormalSquareFundamentalTheorem
 -- Region-blocked insertion-algebra isomorphism: the per-edge gauge engine for the
 -- normal PEPS Fundamental Theorem (region analogue of the injective edge gauge).
 import TNLean.PEPS.RegionBlock.Algebra

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -422,6 +422,7 @@ import TNLean.PEPS.FundamentalTheorem.Uniqueness
 -- Region-insertion lemmas toward the normal PEPS Fundamental Theorem
 -- (arXiv:1804.04964, Section 3, theorem labelled `normal`).
 import TNLean.PEPS.NormalFundamentalTheorem
+import TNLean.PEPS.NormalSquareTIAbsorption
 -- Region-blocked insertion-algebra isomorphism: the per-edge gauge engine for the
 -- normal PEPS Fundamental Theorem (region analogue of the injective edge gauge).
 import TNLean.PEPS.RegionBlock.Algebra

--- a/TNLean/PEPS/NormalSquareFundamentalTheorem.lean
+++ b/TNLean/PEPS/NormalSquareFundamentalTheorem.lean
@@ -1,0 +1,135 @@
+import TNLean.PEPS.NormalSquareTIAbsorption
+import TNLean.PEPS.RegionComplementComparison
+
+/-!
+# Square-lattice normal PEPS Fundamental Theorem (translation-invariant)
+
+This file assembles the translationally invariant normal PEPS Fundamental Theorem
+(arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`). The proof has four ingredients, built in the
+preceding files:
+
+1. the per-edge gauges from the edge blocking reduce, by translation invariance, to
+   one horizontal matrix `X` and one vertical matrix `Y`
+   (`NormalSquareTI.IsOrientationUniformGaugeFamily`);
+2. those gauges are absorbed into the second tensor, giving `B̃`
+   (`NormalSquareTIAbsorption.tiAbsorb`, `tiNormalGaugeAbsorption`);
+3. the one-site-different injective regions `R` and `S` give `A_R ∝ B̃_R` and
+   `A_S ∝ B̃_S` (`RegionComplementComparison.regionComplement_comparison`), whose
+   combination is `A ∝ B̃`;
+4. the proportionality constant `λ` satisfies `λ^{nm} = 1` (Theorem 3).
+
+The per-edge gauge family produced by the edge blocking is the open kernel piece of
+the normal route (remaining obligation 5 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`); this file is therefore
+**conditional** on that gauge family, taken with the shape it will deliver. The
+scalar condition `λ^{nm} = 1` is the square-lattice content of remaining obligation
+7. The source's Theorem 3 proof likewise consumes the output of its
+`lem:inj_isomorph` and packages the final scalar condition separately.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Theorem 3,
+  lines 1449--1572 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ} {d : ℕ}
+
+/-! ### The scalar condition `λ^{nm} = 1`
+
+In the translationally invariant case all per-vertex scalars are a single `λ`, so
+their product over the `width × height` lattice is `λ` raised to the number of
+vertices. The injective theorem forces that product to be one
+(`prod_perVertexScalar_eq_one`), giving `λ^{width·height} = 1`. -/
+
+/-- The number of vertices of the finite `width × height` square lattice. -/
+theorem card_squareLatticeVertex :
+    Fintype.card (SquareLatticeVertex width height) = width * height := by
+  simp [SquareLatticeVertex, Fintype.card_prod]
+
+/-- **The scalar condition `λ^{nm} = 1`.**
+
+If a single scalar `λ` relates `A` to the gauge action of the absorbed second
+tensor at every vertex (the translationally invariant per-vertex relation, all
+`c_v` equal to `λ`), then `λ` raised to the number of lattice sites is one:
+`λ^{width·height} = 1`.
+
+This is the square-lattice scalar condition of arXiv:1804.04964, Section 3,
+Theorem 3 (line 1471: `λ^{n·m} = 1`). It follows from
+`prod_perVertexScalar_eq_one`: under translation invariance the per-vertex scalars
+are all equal, so their product is `λ^{width·height}`.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3, line 1471 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem lambda_pow_card_eq_one
+    (A B : Tensor (squareLatticeGraph width height) d)
+    (hA : IsVertexInjective A)
+    (hpos : ∀ e : Edge (squareLatticeGraph width height), 0 < A.bondDim e)
+    (hAB : SameState A B)
+    (Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (hbd : A.bondDim = B.bondDim)
+    (lam : ℂ)
+    (hPV : ∀ (v : SquareLatticeVertex width height)
+      (η : (ie : IncidentEdge (squareLatticeGraph width height) v) → Fin (A.bondDim ie.1))
+      (σ : Fin d),
+      A.component v η σ =
+        lam * gaugeVertex B Z v (fun ie => Fin.cast (congr_fun hbd ie.1) (η ie)) σ) :
+    lam ^ (width * height) = 1 := by
+  have hprod := prod_perVertexScalar_eq_one A B hA hpos hAB Z hbd (fun _ => lam) hPV
+  rw [Finset.prod_const, Finset.card_univ, card_squareLatticeVertex] at hprod
+  exact hprod
+
+/-! ### The square-lattice Fundamental Theorem skeleton
+
+The conditional theorem records the full structure of the translationally invariant
+proof of Theorem 3 with the per-edge gauge family and the per-vertex single-scalar
+relation as the named inputs. -/
+
+/-- **Translation-invariant normal PEPS Fundamental Theorem (square lattice),
+conditional on the per-edge gauge family.**
+
+Given:
+
+* a tensor `A` and an orientation-uniform gauge absorption datum producing `B̃`
+  (the reduction of the per-edge gauges to one horizontal and one vertical matrix,
+  absorbed into the second tensor) --- `huni` records the uniform bond dimensions of
+  `B` and `dataAbs` the orientation-uniform gauge with the post-absorption
+  edge-insertion equality;
+* a single scalar `λ` whose gauge action relates `A` to the absorbed tensor at every
+  vertex (the output of the `R`/`S` region comparison, `A ∝ B̃`),
+
+then `λ` satisfies the scalar condition `λ^{width·height} = 1`.
+
+The orientation-uniform gauge family and the per-vertex single-scalar relation are
+the conditional kernel inputs (open remaining obligations 5--6 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`); the scalar condition is the
+square-lattice content of obligation 7. This theorem records the top-down
+assembly: with the kernel inputs in hand the scalar condition follows.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalSquarePEPS
+    (A B : Tensor (squareLatticeGraph width height) d) {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim B.bondDim Dh Dv)
+    (hA : IsVertexInjective A)
+    (hpos : ∀ e : Edge (squareLatticeGraph width height), 0 < A.bondDim e)
+    (hAB : SameState A B)
+    (hbd : A.bondDim = B.bondDim)
+    (dataAbs : TINormalGaugeAbsorptionData A B huni)
+    (lam : ℂ)
+    (hPV : ∀ (v : SquareLatticeVertex width height)
+      (η : (ie : IncidentEdge (squareLatticeGraph width height) v) → Fin (A.bondDim ie.1))
+      (σ : Fin d),
+      A.component v η σ =
+        lam * gaugeVertex B dataAbs.gauge v (fun ie => Fin.cast (congr_fun hbd ie.1) (η ie)) σ) :
+    lam ^ (width * height) = 1 :=
+  lambda_pow_card_eq_one A B hA hpos hAB dataAbs.gauge hbd lam hPV
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalSquareTI.lean
+++ b/TNLean/PEPS/NormalSquareTI.lean
@@ -1,0 +1,212 @@
+import TNLean.PEPS.SquareLatticeGraph
+import TNLean.PEPS.EdgeGaugeFamily
+
+/-!
+# Translation-invariant edge gauges on the square lattice
+
+The translationally invariant case of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`) reduces the per-edge gauges produced by the
+edge blocking to **one horizontal matrix `X` and one vertical matrix `Y`**:
+
+> *"Due to translation invariance, these gauges are described by the same matrix
+> `X` (`Y`) on all horizontal (vertical) edges."*  (line 1498)
+
+This file records that reduction at the level of a gauge family on the finite
+square-lattice graph. A translationally invariant tensor has, in particular, the
+same bond dimension on every horizontal edge and the same bond dimension on every
+vertical edge; this constant-bond-dimension content is captured by
+`SquareLatticeUniformBondDim`. Given that uniformity, a single horizontal matrix
+`Xh` and a single vertical matrix `Xv` determine a gauge family
+`orientationUniformGauge` whose value on each edge is the orientation matrix
+transported across the bond-dimension equality. A gauge family of this shape is
+called *orientation uniform* (`IsOrientationUniformGaugeFamily`); this is the
+formal meaning of "described by the same matrix on all horizontal/vertical edges".
+
+The selection of *which* pair `(Xh, Xv)` matches the per-edge gauges supplied by
+the edge blocking is the source's uniqueness-up-to-scalar statement
+(arXiv:1804.04964, Section 3, Theorem 3: "`X` and `Y` are unique up to a
+multiplicative constant"). That uniqueness is the open kernel piece; see the
+elimination note in `docs/paper-gaps/peps_normal_ft_section3_route.tex`, remaining
+obligation 6. This file provides the carrier construction and its defining
+properties, on which the gauge absorption is built.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1449--1572 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ}
+
+instance instDecidableIsHorizontalSquareLatticeEdge
+    (e : Edge (squareLatticeGraph width height)) :
+    Decidable (IsHorizontalSquareLatticeEdge e) := by
+  unfold IsHorizontalSquareLatticeEdge squareLatticeHorizontalNeighbor
+  infer_instance
+
+instance instDecidableIsVerticalSquareLatticeEdge
+    (e : Edge (squareLatticeGraph width height)) :
+    Decidable (IsVerticalSquareLatticeEdge e) := by
+  unfold IsVerticalSquareLatticeEdge squareLatticeVerticalNeighbor
+  infer_instance
+
+/-! ### Uniform horizontal and vertical bond dimensions
+
+A translationally invariant tensor assigns the same bond dimension to every
+horizontal edge and the same bond dimension to every vertical edge. The reduction
+to a single horizontal matrix and a single vertical matrix is well typed only when
+these two dimensions are constant across their orientation classes, so the
+constant-bond-dimension content is recorded as a standalone predicate. -/
+
+/-- The bond dimension function of a tensor on the finite square-lattice graph is
+**orientation uniform** with horizontal dimension `Dh` and vertical dimension `Dv`
+when every horizontal edge has bond dimension `Dh` and every vertical edge has bond
+dimension `Dv`. This is the constant-bond-dimension consequence of translation
+invariance used to reduce the per-edge gauges to two matrices.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`, where translation invariance makes the gauge
+"the same matrix on all horizontal (vertical) edges". -/
+def SquareLatticeUniformBondDim (bondDim : Edge (squareLatticeGraph width height) → ℕ)
+    (Dh Dv : ℕ) : Prop :=
+  (∀ e : Edge (squareLatticeGraph width height),
+      IsHorizontalSquareLatticeEdge e → bondDim e = Dh) ∧
+    (∀ e : Edge (squareLatticeGraph width height),
+      IsVerticalSquareLatticeEdge e → bondDim e = Dv)
+
+/-- The horizontal-edge component of orientation uniformity. -/
+theorem SquareLatticeUniformBondDim.horizontal
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (h : SquareLatticeUniformBondDim bondDim Dh Dv)
+    {e : Edge (squareLatticeGraph width height)} (he : IsHorizontalSquareLatticeEdge e) :
+    bondDim e = Dh :=
+  h.1 e he
+
+/-- The vertical-edge component of orientation uniformity. -/
+theorem SquareLatticeUniformBondDim.vertical
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (h : SquareLatticeUniformBondDim bondDim Dh Dv)
+    {e : Edge (squareLatticeGraph width height)} (he : IsVerticalSquareLatticeEdge e) :
+    bondDim e = Dv :=
+  h.2 e he
+
+/-! ### The gauge family built from a single horizontal and a single vertical
+matrix
+
+Given uniform bond dimensions, a single horizontal matrix `Xh : GL (Fin Dh) ℂ` and
+a single vertical matrix `Xv : GL (Fin Dv) ℂ` determine a per-edge gauge family:
+on each horizontal edge `e` the value is `Xh` transported across `bondDim e = Dh`,
+and on each vertical edge it is `Xv` transported across `bondDim e = Dv`. This is
+the formal carrier for "the same matrix `X` (`Y`) on all horizontal (vertical)
+edges". -/
+
+/-- The per-edge gauge family determined by a single horizontal matrix `Xh` and a
+single vertical matrix `Xv`, transported to each edge across the uniform
+bond-dimension equalities. Every edge of the square-lattice graph is horizontal or
+vertical (`squareLatticeEdge_horizontal_or_vertical`); the horizontal branch
+transports `Xh`, the vertical branch transports `Xv`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def orientationUniformGauge
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim bondDim Dh Dv)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ) :
+    (e : Edge (squareLatticeGraph width height)) → GL (Fin (bondDim e)) ℂ :=
+  fun e =>
+    if he : IsHorizontalSquareLatticeEdge e then
+      glReindex (huni.horizontal he).symm Xh
+    else
+      glReindex
+        (huni.vertical ((squareLatticeEdge_horizontal_or_vertical e).resolve_left he)).symm Xv
+
+/-- On a horizontal edge, the orientation-uniform gauge is the horizontal matrix
+`Xh` transported across the bond-dimension equality.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498. -/
+theorem orientationUniformGauge_horizontal
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim bondDim Dh Dv)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    {e : Edge (squareLatticeGraph width height)} (he : IsHorizontalSquareLatticeEdge e) :
+    orientationUniformGauge huni Xh Xv e = glReindex (huni.horizontal he).symm Xh := by
+  rw [orientationUniformGauge, dif_pos he]
+
+/-- On a vertical edge, the orientation-uniform gauge is the vertical matrix `Xv`
+transported across the bond-dimension equality.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498. -/
+theorem orientationUniformGauge_vertical
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim bondDim Dh Dv)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    {e : Edge (squareLatticeGraph width height)} (he : IsVerticalSquareLatticeEdge e) :
+    orientationUniformGauge huni Xh Xv e = glReindex (huni.vertical he).symm Xv := by
+  have hnh : ¬ IsHorizontalSquareLatticeEdge e := by
+    intro hh; exact squareLatticeEdge_not_horizontal_and_vertical e ⟨hh, he⟩
+  rw [orientationUniformGauge, dif_neg hnh]
+
+/-! ### Orientation-uniform gauge families
+
+A per-edge gauge family is *orientation uniform* when it equals an
+`orientationUniformGauge` for some horizontal matrix and some vertical matrix.
+This is the precise formal statement that translation invariance reduces the gauge
+to one horizontal matrix and one vertical matrix. -/
+
+/-- A per-edge gauge family `X` on the square-lattice graph is **orientation
+uniform** when there is a single horizontal matrix and a single vertical matrix
+whose transported values reproduce `X` on every edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`: the gauges are "described by the same matrix
+`X` (`Y`) on all horizontal (vertical) edges". -/
+def IsOrientationUniformGaugeFamily
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim bondDim Dh Dv)
+    (X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (bondDim e)) ℂ) : Prop :=
+  ∃ (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ),
+    X = orientationUniformGauge huni Xh Xv
+
+/-- The gauge family `orientationUniformGauge huni Xh Xv` is orientation uniform,
+witnessed by `Xh` and `Xv`. -/
+theorem isOrientationUniformGaugeFamily_orientationUniformGauge
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim bondDim Dh Dv)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ) :
+    IsOrientationUniformGaugeFamily huni (orientationUniformGauge huni Xh Xv) :=
+  ⟨Xh, Xv, rfl⟩
+
+/-- **Translation-invariant reduction of the per-edge gauges (carrier form).**
+
+Given uniform horizontal and vertical bond dimensions, every choice of a single
+horizontal matrix `Xh` and a single vertical matrix `Xv` realizes an orientation
+uniform gauge family. This is the carrier of the source step at line 1498: the
+per-edge gauges are *described by* one horizontal matrix and one vertical matrix.
+
+The complementary statement that the per-edge gauges produced by the edge blocking
+are equal to such a family --- i.e. that the same `Xh` and `Xv` work on every edge
+--- is the source's uniqueness-up-to-scalar property (Theorem 3: "`X` and `Y` are
+unique up to a multiplicative constant"), which is the open kernel piece. See
+remaining obligation 6 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_orientationUniformGaugeFamily
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim bondDim Dh Dv)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ) :
+    ∃ X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (bondDim e)) ℂ,
+      IsOrientationUniformGaugeFamily huni X :=
+  ⟨orientationUniformGauge huni Xh Xv,
+    isOrientationUniformGaugeFamily_orientationUniformGauge huni Xh Xv⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalSquareTIAbsorption.lean
+++ b/TNLean/PEPS/NormalSquareTIAbsorption.lean
@@ -1,0 +1,183 @@
+import TNLean.PEPS.NormalSquareTI
+import TNLean.PEPS.FundamentalTheorem
+
+/-!
+# Absorbing the translation-invariant edge gauges on the square lattice
+
+This file performs the absorption step of the translationally invariant normal
+PEPS Fundamental Theorem (arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+1500--1519 of `Papers/1804.04964/paper_normal.tex`):
+
+> *"Define now `B̃` by incorporating the local gauges into the tensors `B`, such
+> as in the injective case."* (line 1500)
+
+The absorption is the same construction `absorbEdgeGauges` used in the injective
+case (`TNLean.PEPS.FundamentalTheorem`). The translationally invariant input is an
+**orientation-uniform** gauge family (`IsOrientationUniformGaugeFamily`): one
+horizontal matrix on every horizontal edge and one vertical matrix on every
+vertical edge. After absorption, the modified tensor `B̃` has the same bond
+dimensions as `B` (still orientation uniform), is vertex injective whenever `B`
+is, and --- given the post-absorption edge-insertion equality supplied by the edge
+blocking --- agrees with `A` on every inserted-edge coefficient. This is the
+content needed for the final `R`/`S` comparison.
+
+## The conditional structure
+
+The per-edge gauge family produced by the edge blocking
+(`lem:inj_isomorph`/`lem:injective_union`) is the open kernel piece of the normal
+route (remaining obligation 5 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`). This file is therefore
+**conditional** on that gauge family: the post-absorption edge-insertion equality
+`PostAbsorptionEdgeInsertionEquality A (absorbEdgeGauges B Z)` is taken as a
+hypothesis with the shape the kernel will deliver --- exactly the output of
+`post_absorption_edge_insertion_equality` in the vertex-injective case. The source
+proof's Theorem 3 likewise consumes the output of `lem:inj_isomorph`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1500--1519 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ} {d : ℕ}
+
+/-! ### The absorbed tensor on the square lattice
+
+The translationally invariant `B̃` is `absorbEdgeGauges B Z` with `Z` orientation
+uniform. The two facts the comparison step needs are: `B̃` is vertex injective
+(when `B` is), and `B̃` has the same orientation-uniform bond dimensions as `B`. -/
+
+/-- The translationally invariant modified tensor `B̃`: the second PEPS tensor with
+an orientation-uniform edge-gauge family absorbed into it.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1500--1519 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def tiAbsorb (B : Tensor (squareLatticeGraph width height) d)
+    (Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ) :
+    Tensor (squareLatticeGraph width height) d :=
+  absorbEdgeGauges B Z
+
+/-- The absorbed tensor has the same bond dimensions as `B`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1500--1519. -/
+@[simp] theorem tiAbsorb_bondDim (B : Tensor (squareLatticeGraph width height) d)
+    (Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ) :
+    (tiAbsorb B Z).bondDim = B.bondDim := rfl
+
+/-- The absorbed tensor inherits the orientation-uniform bond dimensions of `B`:
+absorption changes only the component data, not the bond spaces.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1500--1519. -/
+theorem squareLatticeUniformBondDim_tiAbsorb
+    (B : Tensor (squareLatticeGraph width height) d)
+    (Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    {Dh Dv : ℕ} (huni : SquareLatticeUniformBondDim B.bondDim Dh Dv) :
+    SquareLatticeUniformBondDim (tiAbsorb B Z).bondDim Dh Dv := by
+  rw [tiAbsorb_bondDim]; exact huni
+
+/-- The absorbed tensor is vertex injective whenever `B` is.
+
+This is the square-lattice instance of `isVertexInjective_absorbEdgeGauges`: the
+oriented endpoint gauges recombine the linearly independent local family of `B` by
+an invertible product kernel, preserving linear independence.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1500: the absorbed
+family `B̃` is again injective. -/
+theorem isVertexInjective_tiAbsorb (B : Tensor (squareLatticeGraph width height) d)
+    (Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (hB : IsVertexInjective B) :
+    IsVertexInjective (tiAbsorb B Z) :=
+  isVertexInjective_absorbEdgeGauges B Z hB
+
+/-! ### The translation-invariant gauge absorption datum
+
+Bundling the absorbed tensor together with the post-absorption edge-insertion
+equality records the output of the absorption step: a second tensor `B̃`,
+orientation uniform and vertex injective, on whose inserted-edge coefficients `A`
+agrees. The post-absorption edge-insertion equality is the conditional kernel
+input (`PostAbsorptionEdgeInsertionEquality`), the analogue of
+`eq:inj_equal_edge`. -/
+
+/-- The translationally invariant gauge-absorption datum at the square lattice.
+
+This records the result of incorporating the orientation-uniform edge gauges into
+the second tensor: the absorbed tensor `Btilde`, the witness that its gauge family
+is orientation uniform (`gauge_uniform`), and the post-absorption edge-insertion
+equality with `A` (`post_absorption`). The post-absorption equality is the
+conditional kernel input; see the module docstring.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1500--1519 of
+`Papers/1804.04964/paper_normal.tex` and `eq:inj_equal_edge` at lines 1037--1065. -/
+structure TINormalGaugeAbsorptionData
+    (A B : Tensor (squareLatticeGraph width height) d) {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim B.bondDim Dh Dv) where
+  /-- The orientation-uniform edge-gauge family absorbed into `B`. -/
+  gauge : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ
+  /-- The absorbed gauge family is orientation uniform. -/
+  gauge_uniform : IsOrientationUniformGaugeFamily huni gauge
+  /-- After absorption, `A` and `B̃` agree on every inserted-edge coefficient. -/
+  post_absorption : PostAbsorptionEdgeInsertionEquality A (absorbEdgeGauges B gauge)
+
+/-- **Translation-invariant gauge absorption.**
+
+Given an orientation-uniform edge-gauge family `Z` on the square lattice and the
+post-absorption edge-insertion equality between `A` and the absorbed tensor (the
+conditional kernel input), the absorption datum is assembled: the absorbed tensor
+is orientation uniform and `A` agrees with it on every inserted-edge coefficient.
+
+The orientation-uniform gauge family is the translation-invariant reduction of the
+per-edge gauges to one horizontal and one vertical matrix
+(`NormalSquareTI.IsOrientationUniformGaugeFamily`). The post-absorption equality is
+the kernel input matching the shape produced by
+`post_absorption_edge_insertion_equality` in the vertex-injective case.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1500--1519 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def tiNormalGaugeAbsorption
+    (A B : Tensor (squareLatticeGraph width height) d) {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim B.bondDim Dh Dv)
+    (Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (hZuni : IsOrientationUniformGaugeFamily huni Z)
+    (hPA : PostAbsorptionEdgeInsertionEquality A (absorbEdgeGauges B Z)) :
+    TINormalGaugeAbsorptionData A B huni :=
+  ⟨Z, hZuni, hPA⟩
+
+/-! ### Existence of the post-absorption equality in the vertex-injective case
+
+For vertex-injective tensors with positive bond dimensions, the post-absorption
+edge-insertion equality holds for *some* per-edge gauge family `Z`. This is the
+square-lattice instance of `post_absorption_edge_insertion_equality`. It supplies
+the post-absorption equality unconditionally; the orientation uniformity of `Z`
+(the reduction to one horizontal and one vertical matrix) is the conditional
+kernel piece and is not asserted here. -/
+
+/-- For vertex-injective square-lattice tensors with matching positive bond
+dimensions and the same state, there is a per-edge gauge family `Z` whose
+absorption yields the post-absorption edge-insertion equality.
+
+This is the square-lattice instance of `post_absorption_edge_insertion_equality`.
+The orientation uniformity of `Z` --- the translationally invariant reduction to
+one horizontal and one vertical matrix --- is the open kernel piece and is *not*
+part of this statement; see remaining obligation 6 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, `eq:inj_equal_edge` (lines 1037--1065 of
+`Papers/1804.04964/paper_normal.tex`), reused in the translationally invariant
+proof of Theorem 3 at lines 1500--1519. -/
+theorem exists_postAbsorption_of_vertexInjective
+    (A B : Tensor (squareLatticeGraph width height) d)
+    (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hAB : SameState A B) (hDim : A.bondDim = B.bondDim)
+    (hpos : ∀ e : Edge (squareLatticeGraph width height), 0 < A.bondDim e) :
+    ∃ Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ,
+      PostAbsorptionEdgeInsertionEquality A (absorbEdgeGauges B Z) :=
+  post_absorption_edge_insertion_equality A B hA hB hAB hDim hpos
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionComplementComparison.lean
+++ b/TNLean/PEPS/RegionComplementComparison.lean
@@ -1,0 +1,157 @@
+import TNLean.PEPS.RegionBlock.Insertion
+import TNLean.PEPS.FundamentalTheorem
+import TNLean.PEPS.NormalEdgeGauge
+
+/-!
+# Region-versus-complement comparison for the normal PEPS Fundamental Theorem
+
+This file performs the final `R`/`S` comparison step of the normal PEPS
+Fundamental Theorem (arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+1519--1571 of `Papers/1804.04964/paper_normal.tex`).
+
+After the per-edge gauges are absorbed into the second tensor, the source compares
+two one-site-different injective regions `R` and `S`, both with injective
+complements, against the modified tensor `B̃`:
+
+> *"by `lem:inj_equal_tensors_2`, `A_R ∝ B̃_R` and `A_S ∝ B̃_S`."* (line 1544)
+
+This is the region analogue of the one-vertex-versus-complement comparison
+`one_vertex_complement_comparison` used in the injective case. The single vertex is
+replaced by an arbitrary injective region `R`, and the vertex complement by the set
+complement `univ \ R`. The two blocks are wrapped as `regionTwoBlock A R` and
+`regionComplementTwoBlock A R`, both two-block injective for a vertex-injective PEPS
+with positive bonds (`regionBlockedTensorInjective_of_isVertexInjective`). The
+generalized two-injective comparison `two_injective_tensor_insertion_comparison`
+then gives scalar proportionality `A_R ∝ B̃_R`.
+
+## The conditional structure
+
+The region-inserted-coefficient equality between `A` and `B̃` --- the source's
+statement at line 1519 that "inserting a matrix `Z` on any bond of the first PEPS
+gives the same state as inserting the same matrix on the corresponding bond of the
+second PEPS" --- is taken as a hypothesis. It is the region form of the
+post-absorption insertion equality, supplied by the per-edge gauge family that is
+the open kernel piece of the normal route (remaining obligation 5 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`). The wrapping and the
+two-injective comparison on top of it are unconditional.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1519--1571 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The region against its set complement
+
+A region `R` and its set complement `univ \ R` form a two-block pair over the edges
+crossing the boundary of `R`. The region-inserted-coefficient equality between `A`
+and the modified tensor `B̃` (transported to `A`'s bonds) gives, via
+`sameTwoBlockInsertions_of_regionInsertedCoeff_eq` and the generalized two-injective
+comparison, scalar proportionality of the region block of `A` with the region block
+of `B̃`. -/
+
+/-- **Region-versus-complement scalar proportionality.**
+
+For a region `R` whose two block tensors over `A` and over the reindexed `B̃` are
+all two-block injective, if `A` and `B̃` have matched bond dimensions and equal
+region-inserted coefficients on every boundary edge of `R`, then the region blocks
+are scalar proportional: there is a nonzero `c` with `A_R = c · B̃_R`.
+
+This is the region analogue of `one_vertex_complement_comparison`. The matched
+region-inserted coefficients are turned into equal one-bond two-block insertions by
+`sameTwoBlockInsertions_of_regionInsertedCoeff_eq`, and the scalar follows from
+`two_injective_tensor_insertion_comparison`.
+
+The region-inserted-coefficient equality is the conditional kernel input; see the
+module docstring.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1544 of
+`Papers/1804.04964/paper_normal.tex`: `A_R ∝ B̃_R`. -/
+theorem regionComplement_comparison (A Btilde : Tensor G d)
+    (R : Finset V) (hbd : A.bondDim = Btilde.bondDim)
+    [Nonempty {f : Edge G // IsRegionBoundaryEdge (G := G) R f}]
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G) (reindexTensor (G := G) Btilde hbd) R)
+    (hCB :
+      RegionBlockedTensorInjective (G := G) (reindexTensor (G := G) Btilde hbd) (Finset.univ \ R))
+    (hregion : ∀ (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+      (N : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := V) (d := d) R)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f N σ τ =
+        regionInsertedCoeff (G := G) Btilde R f
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1)) N) σ τ) :
+    ∃ c : ℂ, c ≠ 0 ∧
+      TwoBlockScalarProportional (regionTwoBlock (G := G) A R)
+        (regionTwoBlock (G := G) (reindexTensor (G := G) Btilde hbd) R) c := by
+  classical
+  rcases two_injective_tensor_insertion_comparison
+      (External₂ := PUnit.{1})
+      (Physical₂ := RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R))
+      (regionTwoBlock (G := G) A R)
+      (regionTwoBlock (G := G) (reindexTensor (G := G) Btilde hbd) R)
+      (regionComplementTwoBlock (G := G) A R)
+      (regionComplementTwoBlock (G := G) (reindexTensor (G := G) Btilde hbd) R)
+      (isTwoBlockInjective_regionTwoBlock (G := G) A R hRA)
+      (isTwoBlockInjective_regionComplementTwoBlock (G := G) A R hCA)
+      (isTwoBlockInjective_regionTwoBlock (G := G) (reindexTensor (G := G) Btilde hbd) R hRB)
+      (isTwoBlockInjective_regionComplementTwoBlock (G := G)
+        (reindexTensor (G := G) Btilde hbd) R hCB)
+      (sameTwoBlockInsertions_of_regionInsertedCoeff_eq A Btilde R hbd hregion)
+      with ⟨c, hc_ne, hregionProp, _hcomplProp⟩
+  exact ⟨c, hc_ne, hregionProp⟩
+
+/-- **Region-versus-complement comparison for vertex-injective tensors.**
+
+For vertex-injective `A` and `Btilde` with positive bond dimensions and matched
+bond dimensions, every region `R` with at least one boundary edge admits the
+region-block scalar proportionality `A_R ∝ B̃_R`, provided the region-inserted
+coefficients of `A` and `B̃` agree on every boundary edge of `R`.
+
+The four two-block injectivity hypotheses are discharged uniformly from vertex
+injectivity by `regionBlockedTensorInjective_of_isVertexInjective`, so the region
+need not be one of the special source regions. The region-inserted-coefficient
+equality is the conditional kernel input.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionComplement_comparison_of_vertexInjective (A Btilde : Tensor G d)
+    (R : Finset V) (hbd : A.bondDim = Btilde.bondDim)
+    [Nonempty {f : Edge G // IsRegionBoundaryEdge (G := G) R f}]
+    (hA : IsVertexInjective A) (hBtilde : IsVertexInjective Btilde)
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e)
+    (hregion : ∀ (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+      (N : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := V) (d := d) R)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f N σ τ =
+        regionInsertedCoeff (G := G) Btilde R f
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1)) N) σ τ) :
+    ∃ c : ℂ, c ≠ 0 ∧
+      TwoBlockScalarProportional (regionTwoBlock (G := G) A R)
+        (regionTwoBlock (G := G) (reindexTensor (G := G) Btilde hbd) R) c := by
+  have hposBt : ∀ e : Edge G, 0 < (reindexTensor (G := G) Btilde hbd).bondDim e := by
+    intro e; rw [reindexTensor_bondDim]; exact hpos e
+  have hBtreindex : IsVertexInjective (reindexTensor (G := G) Btilde hbd) :=
+    isVertexInjective_reindexTensor Btilde hbd hBtilde
+  exact regionComplement_comparison A Btilde R hbd
+    (regionBlockedTensorInjective_of_isVertexInjective (G := G) A R hA hpos)
+    (regionBlockedTensorInjective_of_isVertexInjective (G := G) A (Finset.univ \ R) hA hpos)
+    (regionBlockedTensorInjective_of_isVertexInjective (G := G)
+      (reindexTensor (G := G) Btilde hbd) R hBtreindex hposBt)
+    (regionBlockedTensorInjective_of_isVertexInjective (G := G)
+      (reindexTensor (G := G) Btilde hbd) (Finset.univ \ R) hBtreindex hposBt)
+    hregion
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -4567,6 +4567,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Translationally invariant normal gauge absorption]%
     \label{thm:peps_tiNormalGaugeAbsorption}
+    \lean{TNLean.PEPS.tiNormalGaugeAbsorption}
     \notready
     \uses{thm:peps_normalEdgeBlockingToInjectiveChain,
         thm:peps_edge_gauge_absorption}
@@ -4578,10 +4579,16 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \begin{center}
         \TNPEPSTINormalGaugeAbsorption
     \end{center}
+    The carrier of the reduction to one horizontal and one vertical matrix and
+    the absorption of such an orientation-uniform family into $\widetilde B$ are
+    formalized; the gauge family itself and its uniqueness up to scalar depend on
+    the per-edge gauge of the edge blocking, which is the open kernel piece. The
+    Lean statement is therefore conditional on that gauge family.
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for normal square-lattice PEPS]%
     \label{thm:fundamentalTheorem_normalSquarePEPS}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS}
     \notready
     \uses{thm:peps_tiNormalGaugeAbsorption,
         thm:peps_oneVertexComplementComparison,
@@ -4593,6 +4600,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $X,Y$, up to a scalar $\lambda$ satisfying
     $\lambda^{nm}=1$. This is
     \cite[Theorem~3]{Molnar2018NormalPEPS}.
+    The Lean statement records the top-down assembly conditional on the per-edge
+    gauge of the edge blocking: from the orientation-uniform gauge absorption and
+    the per-vertex single-scalar relation it derives the scalar condition
+    $\lambda^{nm}=1$. The unconditional source theorem awaits the per-edge gauge.
 \end{theorem}
 
 \begin{definition}[Normal PEPS blocking hypotheses]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1147,9 +1147,58 @@ The remaining obligations are the following.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.
+
+          The carrier of this reduction is now formalized. A square-lattice
+          bond-dimension function is orientation uniform when every horizontal edge
+          has one dimension and every vertical edge has another; given that, a single
+          horizontal matrix and a single vertical matrix determine a gauge family by
+          transport across the bond-dimension equalities, and a gauge family of this
+          shape is called orientation uniform. The absorption step incorporates such
+          an orientation-uniform family into the second tensor, preserving the
+          orientation-uniform bond dimensions and vertex injectivity; the
+          post-absorption edge-insertion equality is taken as the conditional kernel
+          input, in the shape produced unconditionally in the vertex-injective case.
+          What remains open is the selection of \emph{which} horizontal and vertical
+          matrices reproduce the per-edge gauges supplied by the blocking, which is
+          the source's uniqueness-up-to-scalar statement and depends on the open
+          per-edge gauge of obligation~5.\footnote{
+          Formal declarations:
+          \(\leanid{TNLean.PEPS.SquareLatticeUniformBondDim}\),
+          \(\leanid{TNLean.PEPS.orientationUniformGauge}\),
+          \(\leanid{TNLean.PEPS.IsOrientationUniformGaugeFamily}\),
+          \(\leanid{TNLean.PEPS.exists_orientationUniformGaugeFamily}\),
+          \(\leanid{TNLean.PEPS.tiAbsorb}\),
+          \(\leanid{TNLean.PEPS.isVertexInjective_tiAbsorb}\),
+          \(\leanid{TNLean.PEPS.tiNormalGaugeAbsorption}\), and
+          \(\leanid{TNLean.PEPS.exists_postAbsorption_of_vertexInjective}\).}
+
+          The final region comparison setup is also formalized: a region and its set
+          complement are wrapped as the two blocks consumed by the two-injective
+          comparison, and from matched region-inserted coefficients of the two
+          tensors the region blocks are scalar proportional, the region analogue of
+          the one-vertex-versus-complement comparison. For vertex-injective tensors
+          the four block-injectivity hypotheses are discharged uniformly, leaving the
+          region-inserted-coefficient equality as the only conditional input.\footnote{
+          Formal declarations:
+          \(\leanid{TNLean.PEPS.regionComplement_comparison}\) and
+          \(\leanid{TNLean.PEPS.regionComplement_comparison_of_vertexInjective}\).}
     \item Prove the scalar condition $\lambda^{nm}=1$ for the square-lattice
           theorem, and state separately the scalar freedom in the non-translation
           invariant normal theorem.
+
+          The square-lattice scalar condition is formalized: when all per-vertex
+          scalars equal a single $\lambda$, their product over the
+          $\text{width}\times\text{height}$ lattice is $\lambda$ raised to the site
+          count, which the injective theorem forces to be one, giving
+          $\lambda^{\,\text{width}\cdot\text{height}}=1$. The square-lattice theorem
+          skeleton records the top-down assembly: from the orientation-uniform gauge
+          absorption datum and the per-vertex single-scalar relation (the region
+          comparison output) the scalar condition follows. The skeleton remains
+          conditional on the open per-edge gauge of obligation~5.\footnote{
+          Formal declarations:
+          \(\leanid{TNLean.PEPS.card_squareLatticeVertex}\),
+          \(\leanid{TNLean.PEPS.lambda_pow_card_eq_one}\), and
+          \(\leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS}\).}
 \end{enumerate}
 
 \section{Source-to-formalization ledger}


### PR DESCRIPTION
## What

The translation-invariant assembly layer of the square-lattice Normal PEPS FT
(arXiv:1804.04964 §3, proof of Theorem 3, `paper_normal.tex` 1449–1572): the
orientation-uniform gauge reduction, the X/Y absorption, the R/S-style
region-complement comparison, and the **conditional `fundamentalTheorem_normalSquarePEPS`**
— the complete top-down structure of Theorem 3 with the per-edge gauge (the open V=W
kernel) as its one named input. Four new files; all sorry-free, axiom-clean; full root
build green (8839 jobs).

## Highlights

- `SquareLatticeUniformBondDim` + `orientationUniformGauge` + `exists_orientationUniformGaugeFamily`
  (NormalSquareTI.lean) — translation invariance reduces the per-edge gauges to one
  horizontal `X` and one vertical `Y` (source line 1498).
- `tiAbsorb` + `TINormalGaugeAbsorptionData` + `exists_postAbsorption_of_vertexInjective`
  (NormalSquareTIAbsorption.lean) — B̃ with the gauges absorbed, preserving orientation
  uniformity and vertex injectivity, with the post-absorption edge-insertion equality.
- `regionComplement_comparison` (RegionComplementComparison.lean) — wraps a region and its
  complement as the two-block pair and feeds the already-closed
  `two_injective_tensor_insertion_comparison` (#1361), yielding `A_R ∝ B̃_R` (source 1544)
  — the region analogue of `one_vertex_complement_comparison`.
- `fundamentalTheorem_normalSquarePEPS` + `lambda_pow_card_eq_one`
  (NormalSquareFundamentalTheorem.lean) — the assembled theorem skeleton, conditional on
  the per-edge gauge family, with the scalar condition λ^{width·height}=1 (source 1471).
- Blueprint: `thm:peps_tiNormalGaugeAbsorption` and `thm:fundamentalTheorem_normalSquarePEPS`
  get `\lean{}` carriers but **stay `\notready`** per the faithfulness rule — the
  unrestricted Theorem 3 awaits the V=W kernel (route-note obligation 5).

Refs #1373, #1375. CI `blueprint-and-prose`/`track`/`claude-review-*` failures are
non-blocking automation (cf. merged #2567/#2575/#2576/#2577).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal PEPS scaffolding that mostly composes existing injective theorems; main results are explicitly conditional on open proof obligations, with no runtime or security impact.
> 
> **Overview**
> Adds the **translation-invariant assembly layer** for the square-lattice normal PEPS Fundamental Theorem (arXiv §3 Theorem 3): four new Lean modules wired into `TNLean.lean`, plus blueprint and route-note updates.
> 
> **`NormalSquareTI`** formalizes orientation-uniform bond dimensions and per-edge gauges from one horizontal matrix `X` and one vertical matrix `Y` (`orientationUniformGauge`, `IsOrientationUniformGaugeFamily`). **`NormalSquareTIAbsorption`** defines square-lattice gauge absorption (`tiAbsorb`, `TINormalGaugeAbsorptionData`) and reuses `post_absorption_edge_insertion_equality` via `exists_postAbsorption_of_vertexInjective`. **`RegionComplementComparison`** proves region-vs-complement scalar proportionality (`regionComplement_comparison`) by feeding existing `two_injective_tensor_insertion_comparison`. **`NormalSquareFundamentalTheorem`** derives `λ^{width·height} = 1` and **`fundamentalTheorem_normalSquarePEPS`**, explicitly **conditional** on the per-edge gauge / absorption and per-vertex scalar inputs still open in the normal route.
> 
> Blueprint theorems get `\lean{}` carriers but remain `\notready` until the edge-blocking gauge kernel is closed; `peps_normal_ft_section3_route.tex` documents which obligations are now formalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041f33a71ef8b97ffe5326295e0e62c346c1d722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->