### PR TITLE
feat(PEPS): the coarse three-site route to the normal-FT kernel

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -495,4 +495,5 @@ import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap4
 import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap5
 import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap6
 import TNLean.PEPS.RegionBlock.CoarseThreeSite
+import TNLean.PEPS.RegionBlock.CoarseThreeSite2
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -482,6 +482,7 @@ import TNLean.PEPS.RegionBlock.ThreeBlockReconcile
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate2
 import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
+import TNLean.PEPS.RegionBlock.BondLocalFromReconcile
 import TNLean.PEPS.RegionBlock.UnionInjectivity
 import TNLean.PEPS.RegionBlock.UnionInjectivityGeneral
 import TNLean.PEPS.RegionBlock.UnionInjectivityGeneralBlue

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -496,4 +496,5 @@ import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap5
 import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap6
 import TNLean.PEPS.RegionBlock.CoarseThreeSite
 import TNLean.PEPS.RegionBlock.CoarseThreeSite2
+import TNLean.PEPS.RegionBlock.CoarseThreeSite3
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -494,4 +494,5 @@ import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap3b
 import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap4
 import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap5
 import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap6
+import TNLean.PEPS.RegionBlock.CoarseThreeSite
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean/PEPS/RegionBlock/BondLocalFromReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/BondLocalFromReconcile.lean
@@ -1,0 +1,171 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
+
+/-!
+# Bond locality of the transfer kernel from the region resonate reconcile
+
+This file connects the two tracks of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, Section 3, Lemma `inj_isomorph`) around the boundary edge `f`
+of the red region `R`:
+
+* the **block-frame predicate** `IsBondLocalTransferKernel`
+  (`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`): for every inserted matrix `M`,
+  the transfer kernel `transferCoeff A B R hRB hCB f M` is the incident-matrix
+  kernel of some bond matrix on `f`; this is the residual open content of the
+  block-frame coefficient transfer that the per-edge gauge consumes, and
+* the **virtual-pullback predicate** `RegionResonateReconcile`
+  (`TNLean.PEPS.RegionBlock.Recovery8`): for every inserted matrix `M`, the virtual
+  pullback `localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA
+  M.transpose)` of the transferred in-region endpoint operator is of incident-matrix
+  form on the boundary leg `f`.
+
+The bridge `isBondLocalTransferKernel_of_regionResonateReconcile` shows the first
+follows from the second: the read-off
+`transferCoeff_eq_incidentForm_of_virtualPullback_incidentForm`
+(`TNLean.PEPS.RegionBlock.Recovery11`) turns the incident-matrix form of the virtual
+pullback into the incident-matrix coupling form of the transfer kernel, which is
+exactly `IsBondLocalTransferKernel`.
+
+## What this does and does not settle
+
+The virtual-pullback predicate `RegionResonateReconcile` and the read-off it feeds
+are available only in the **vertex-injective** regime: they need the in-region
+endpoint vertex `v` of `f` to be single-vertex linearly independent (`hvA`, `hvB`)
+and both tensors vertex injective (`IsVertexInjective A`, `IsVertexInjective B`),
+because the spanning of the closed state-vector coefficients at `v`
+(`span_stateOpenCoeff_eq_top`, `TNLean.PEPS.RegionBlock.Recovery3`) — the
+image-preservation root — is currently derived only from
+`vertexComplementTensorInjective_of_isVertexInjective`. A single boundary vertex of
+a normal (region-injective, not vertex-injective) tensor need not be injective, so
+this bridge does **not** discharge `IsBondLocalTransferKernel` in the general normal
+setting. It records the precise meeting point of the two tracks: in the
+vertex-injective specialization the block-frame predicate is reachable, and the
+remaining content of the general normal theorem is exactly the endpoint-vertex
+spanning derived from blocked-region injectivity rather than single-vertex
+injectivity. This obstruction is documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--582 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The block-frame predicate from the virtual-pullback predicate
+
+The virtual-pullback predicate `RegionResonateReconcile` gives, for each inserted
+matrix `M`, a matrix `P` on the second tensor's bond with
+`localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA M.transpose) =
+localIncidentMatrixOp B (regionBoundaryEdgeInIncident R f) P`. Taking
+`N := P.transpose`, the read-off
+`transferCoeff_eq_incidentForm_of_virtualPullback_incidentForm`
+(`TNLean.PEPS.RegionBlock.Recovery11`) turns this into the incident-matrix coupling
+form of the transfer kernel, which is `transferCoeff A B R hRB hCB f M =
+incidentKernel B R f N`, the body of `IsBondLocalTransferKernel`. -/
+
+/-- **Bond locality from the region resonate reconcile.** If, for every inserted
+matrix `M`, the virtual pullback of the transferred in-region endpoint operator is of
+incident-matrix form on the boundary leg `f` (the predicate `RegionResonateReconcile`),
+then the transfer kernel `transferCoeff A B R hRB hCB f M` is the incident-matrix
+kernel of some bond matrix `N` on `f` for every `M`, that is,
+`IsBondLocalTransferKernel A B R hRB hCB f` holds.
+
+For each `M`, the reconcile supplies a matrix `P` with
+`localVirtualOpOfPhysicalOpAt B hvB (regionInsertionOp A R f hvA M.transpose) =
+localIncidentMatrixOp B (regionBoundaryEdgeInIncident R f) P`; with `N := P.transpose`
+the read-off `transferCoeff_eq_incidentForm_of_virtualPullback_incidentForm` gives the
+incident-matrix coupling form of `transferCoeff`, which is exactly
+`incidentKernel B R f N`.
+
+The hypotheses `hvA`, `hvB`, `IsVertexInjective A`, `IsVertexInjective B` are those of
+the read-off; they are the vertex-injective regime in which `RegionResonateReconcile`
+itself is available. In the general normal setting these are absent, so this is the
+meeting point of the two tracks, not a discharge of the block-frame predicate; see
+the module docstring and `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines
+254--582 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem isBondLocalTransferKernel_of_regionResonateReconcile (A B : Tensor G d)
+    (R : Finset V)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (hrec : RegionResonateReconcile (G := G) A B R f hvA hvB) :
+    IsBondLocalTransferKernel (G := G) A B R hRB hCB f := by
+  classical
+  intro M
+  obtain ⟨P, hP⟩ := hrec M
+  refine ⟨P.transpose, ?_⟩
+  -- The reconcile's incident form, with `N := P.transpose`, feeds the read-off.
+  have hform : localVirtualOpOfPhysicalOpAt B hvB
+      (regionInsertionOp (G := G) A R f hvA M.transpose) =
+      localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f)
+        P.transpose.transpose := by
+    rw [Matrix.transpose_transpose]; exact hP
+  funext μ ν'
+  rw [transferCoeff_eq_incidentForm_of_virtualPullback_incidentForm A B R hRB hCB f
+      hvA hvB hvAout hAB hA hB hposA hposB hDim M P.transpose hform μ ν',
+    incidentKernel]
+
+/-! ### The coefficient transfer from the region resonate reconcile
+
+Composing the bond-locality bridge with `coeffTransfer_of_bondLocal`
+(`TNLean.PEPS.RegionBlock.ThreeBlockTransfer`) gives the coefficient transfer
+directly from the region resonate reconcile, in the vertex-injective regime. This
+is the form the per-edge gauge consumes. -/
+
+/-- **The coefficient transfer from the region resonate reconcile.** In the
+vertex-injective regime, the region resonate reconcile yields, for every inserted
+matrix `M`, a bond matrix `N` on the second tensor whose region-inserted coefficient
+matches the first tensor's at every physical configuration.
+
+The reconcile gives `IsBondLocalTransferKernel`
+(`isBondLocalTransferKernel_of_regionResonateReconcile`), which the bond-locality
+bridge `coeffTransfer_of_bondLocal` turns into the coefficient transfer.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransfer_of_regionResonateReconcile (A B : Tensor G d) (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
+    (hvAout : LinearIndependent ℂ
+      (A.component (regionBoundaryEdgeInVertex (G := G) (Finset.univ \ R)
+        (regionBoundaryEdgeToCompl (G := G) R f))))
+    (hAB : SameState A B) (hA : IsVertexInjective A) (hB : IsVertexInjective B)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (hDim : A.bondDim = B.bondDim)
+    (hrec : RegionResonateReconcile (G := G) A B R f hvA hvB) :
+    ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ :=
+  coeffTransfer_of_bondLocal A B R hRA hRB hCA hCB hAB hposA hposB hDim f
+    (isBondLocalTransferKernel_of_regionResonateReconcile A B R hRB hCB f
+      hvA hvB hvAout hAB hA hB hposA hposB hDim hrec)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite.lean
@@ -68,5 +68,246 @@ def coarseEdgeRC : Edge coarseGraph :=
 def coarseEdgeBC : Edge coarseGraph :=
   ⟨(1, 2), by constructor <;> simp [coarseGraph]⟩
 
+/-! ### Restriction of a physical configuration to a region
+
+The coarse physical dimension `d ^ card V` is large enough to carry every region's
+physical configuration. A global physical configuration `V → Fin d` is decoded from
+a coarse physical index and then restricted to a region; the restriction is
+surjective onto every region's physical configurations (under `0 < d`), which is the
+property that makes the coarse component family linearly independent whenever the
+blocked-region family is. -/
+
+/-- The coarse uniform physical dimension `d ^ card V`. The fixed bijection
+`Fin coarseDim ≃ (V → Fin d)` decodes a coarse physical index into a global physical
+configuration. -/
+abbrev coarseDim (V : Type*) [Fintype V] (d : ℕ) : ℕ := d ^ Fintype.card V
+
+/-- The decoding bijection between coarse physical indices and global physical
+configurations. -/
+noncomputable def coarseDecodeEquiv (V : Type*) [Fintype V] [DecidableEq V] (d : ℕ) :
+    Fin (coarseDim V d) ≃ (V → Fin d) :=
+  (Fintype.equivFinOfCardEq (by rw [Fintype.card_fun, Fintype.card_fin])).symm
+
+/-- Decode a coarse physical index into a global physical configuration. -/
+noncomputable def coarseDecode (V : Type*) [Fintype V] [DecidableEq V] (d : ℕ) :
+    Fin (coarseDim V d) → (V → Fin d) :=
+  coarseDecodeEquiv V d
+
+/-- The fixed surjection from coarse physical indices to a region's physical
+configurations: decode to a global configuration, then restrict to the region.
+
+Surjectivity (under `0 < d`) is `coarseProj_surjective`; it is the property behind
+the linear independence of the coarse component family. -/
+noncomputable def coarseProj (R : Finset V) :
+    Fin (coarseDim V d) → RegionPhysicalConfig (V := V) (d := d) R :=
+  fun p w => coarseDecode V d p w.1
+
+omit [LinearOrder V] in
+/-- The decoding bijection is bijective, hence surjective. -/
+theorem coarseDecode_surjective : Function.Surjective (coarseDecode V d) :=
+  (coarseDecodeEquiv V d).surjective
+
+omit [LinearOrder V] in
+/-- Under `0 < d`, the restriction of a global physical configuration to a region is
+surjective, so the coarse projection onto a region's physical configurations is
+surjective. -/
+theorem coarseProj_surjective (hd : 0 < d) (R : Finset V) :
+    Function.Surjective (coarseProj (V := V) (d := d) R) := by
+  classical
+  haveI : Nonempty (Fin d) := ⟨⟨0, hd⟩⟩
+  intro τ
+  obtain ⟨σ, hσ⟩ :=
+    coarseDecode_surjective (V := V) (d := d)
+      (fun v => if hv : v ∈ R then τ ⟨v, hv⟩ else Classical.arbitrary _)
+  refine ⟨σ, ?_⟩
+  funext w
+  simp only [coarseProj, hσ, w.2, dif_pos]
+
+/-! ### The coarse blocking frame
+
+A coarse blocking frame records the geometric identification of the three coarse
+super-sites with the three blocked regions of a one-edge blocking. The coarse
+vertex `r=0` carries the red block, `b=1` the blue block, `c=2` the complement
+block. For each coarse vertex, an equivalence identifies the coarse virtual legs
+incident to that vertex with the region's boundary configuration. The frame
+abstracts the combinatorics "the boundary edges of the red region are the
+distinguished edge together with the red-to-complement crossings", isolating the
+edge-set geometry from the tensor construction and injectivity transport.
+
+The blocked-region injectivities (`red_injective`, `blue_injective`,
+`complement_injective`) are the normal blocking hypothesis: the super-site
+component families are injective **by hypothesis**, with no single-vertex
+injectivity. -/
+
+/-- **A coarse blocking frame** for a tensor `A` at a distinguished edge.
+
+The three regions are blocked-tensor injective (the normal blocking hypothesis),
+positive physical dimension, and for each coarse vertex an equivalence between the
+coarse virtual legs incident to that vertex and the region's boundary
+configurations. The bond dimensions of the coarse graph are recorded so that the
+per-vertex leg space matches the region boundary configuration.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+structure CoarseBlockingFrame (A : Tensor G d) where
+  /-- The red block (around the left endpoint). -/
+  red : Finset V
+  /-- The blue block (around the right endpoint). -/
+  blue : Finset V
+  /-- The complement block. -/
+  complement : Finset V
+  /-- The red block is blocked-tensor injective. -/
+  red_injective : RegionBlockedTensorInjective (G := G) A red
+  /-- The blue block is blocked-tensor injective. -/
+  blue_injective : RegionBlockedTensorInjective (G := G) A blue
+  /-- The complement block is blocked-tensor injective. -/
+  complement_injective : RegionBlockedTensorInjective (G := G) A complement
+  /-- The physical dimension is positive. -/
+  pos_dim : 0 < d
+  /-- The coarse bond dimensions on the three coarse edges. -/
+  coarseBondDim : Edge coarseGraph → ℕ
+  /-- The coarse bond dimensions are positive. -/
+  pos_coarseBondDim : ∀ f : Edge coarseGraph, 0 < coarseBondDim f
+  /-- The coarse virtual legs at `r=0` identify with the red boundary configurations. -/
+  legEquivRed :
+    ((ie : IncidentEdge coarseGraph 0) → Fin (coarseBondDim ie.1)) ≃
+      RegionBoundaryConfig (G := G) A red
+  /-- The coarse virtual legs at `b=1` identify with the blue boundary configurations. -/
+  legEquivBlue :
+    ((ie : IncidentEdge coarseGraph 1) → Fin (coarseBondDim ie.1)) ≃
+      RegionBoundaryConfig (G := G) A blue
+  /-- The coarse virtual legs at `c=2` identify with the complement boundary
+  configurations. -/
+  legEquivComplement :
+    ((ie : IncidentEdge coarseGraph 2) → Fin (coarseBondDim ie.1)) ≃
+      RegionBoundaryConfig (G := G) A complement
+
+namespace CoarseBlockingFrame
+
+variable {A : Tensor G d} (F : CoarseBlockingFrame (G := G) (d := d) A)
+
+/-- The region attached to a coarse vertex: red at `0`, blue at `1`, complement at
+`2` (and red as a harmless default elsewhere, never used on `Fin 3`). -/
+def regionOf : Fin 3 → Finset V
+  | 0 => F.red
+  | 1 => F.blue
+  | 2 => F.complement
+
+omit [DecidableEq V] in
+@[simp] theorem regionOf_zero : F.regionOf 0 = F.red := rfl
+omit [DecidableEq V] in
+@[simp] theorem regionOf_one : F.regionOf 1 = F.blue := rfl
+omit [DecidableEq V] in
+@[simp] theorem regionOf_two : F.regionOf 2 = F.complement := rfl
+
+omit [DecidableEq V] in
+/-- The blocked-tensor injectivity of the region attached to a coarse vertex. -/
+theorem regionOf_injective : ∀ v : Fin 3,
+    RegionBlockedTensorInjective (G := G) A (F.regionOf v)
+  | 0 => F.red_injective
+  | 1 => F.blue_injective
+  | 2 => F.complement_injective
+
+/-- The leg-to-boundary equivalence attached to a coarse vertex. -/
+def legEquiv : ∀ v : Fin 3,
+    ((ie : IncidentEdge coarseGraph v) → Fin (F.coarseBondDim ie.1)) ≃
+      RegionBoundaryConfig (G := G) A (F.regionOf v)
+  | 0 => F.legEquivRed
+  | 1 => F.legEquivBlue
+  | 2 => F.legEquivComplement
+
+/-! ### The coarse tensor
+
+The coarse tensor on the three-vertex complete graph. Its component at coarse
+vertex `v` is the blocked-region weight of the region attached to `v`, with the
+coarse virtual legs identified with the region boundary configuration through
+`legEquiv v` and the coarse physical index decoded and restricted to the region
+through `coarseProj`. -/
+
+/-- **The coarse three-site tensor.** A `Tensor` on the complete three-vertex graph
+whose super-site at coarse vertex `v` is the blocked-region weight of the region
+attached to `v`. The endpoint super-sites carry the red and blue blocked weights;
+the middle super-site carries the complement blocked weight.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def coarseTensor : Tensor coarseGraph (coarseDim V d) where
+  bondDim := F.coarseBondDim
+  component v legs p :=
+    regionBlockedWeight (G := G) A (F.regionOf v) (F.legEquiv v legs)
+      (coarseProj (F.regionOf v) p)
+
+@[simp] theorem coarseTensor_bondDim :
+    (F.coarseTensor).bondDim = F.coarseBondDim := rfl
+
+@[simp] theorem coarseTensor_component (v : Fin 3)
+    (legs : (ie : IncidentEdge coarseGraph v) → Fin (F.coarseBondDim ie.1))
+    (p : Fin (coarseDim V d)) :
+    (F.coarseTensor).component v legs p =
+      regionBlockedWeight (G := G) A (F.regionOf v) (F.legEquiv v legs)
+        (coarseProj (F.regionOf v) p) :=
+  rfl
+
+/-! ### Vertex injectivity of the coarse tensor
+
+Each coarse super-site component family is linearly independent. The transport is
+purely formal: the coarse family is the blocked-region tensor family of the region
+attached to the vertex, reindexed by the leg equivalence and postcomposed with the
+pullback along the surjection `coarseProj`. Reindexing by an equivalence preserves
+linear independence, and the pullback along a surjection is an injective linear map,
+so it preserves linear independence by `LinearIndependent.map'`.
+
+No single-vertex injectivity of `A` is used: the input is the **blocked-region**
+injectivity `RegionBlockedTensorInjective A (regionOf v)`, the normal blocking
+hypothesis. -/
+
+/-- The coarse component family at vertex `v`, as a family of vectors. -/
+theorem coarseTensor_component_eq (v : Fin 3) :
+    (F.coarseTensor).component v =
+      (LinearMap.funLeft ℂ ℂ (coarseProj (F.regionOf v))) ∘
+        ((regionBlockedTensorFamily (G := G) A (F.regionOf v)) ∘ F.legEquiv v) := by
+  funext legs
+  funext p
+  simp only [coarseTensor_component, Function.comp_apply, LinearMap.funLeft_apply,
+    regionBlockedTensorFamily]
+
+/-- **Vertex injectivity of the coarse tensor.** The component family at every
+coarse super-site is linearly independent, inherited from the blocked-region
+injectivity of the region attached to that vertex.
+
+This is the endpoint and middle injectivity input for the coarse three-site chain,
+supplied by the normal blocking hypothesis with no single-vertex injectivity.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coarseTensor_isVertexInjective : IsVertexInjective (F.coarseTensor) := by
+  intro v
+  rw [coarseTensor_component_eq]
+  refine LinearIndependent.map' ?_ (LinearMap.funLeft ℂ ℂ (coarseProj (F.regionOf v))) ?_
+  · exact (linearIndependent_equiv' (F.legEquiv v) rfl).mpr (F.regionOf_injective v)
+  · rw [LinearMap.ker_eq_bot]
+    exact LinearMap.funLeft_injective_of_surjective ℂ ℂ _
+      (coarseProj_surjective F.pos_dim (F.regionOf v))
+
+/-- The coarse tensor has positive bond dimensions on every coarse edge. -/
+theorem coarseTensor_pos_bondDim : ∀ f : Edge coarseGraph, 0 < (F.coarseTensor).bondDim f :=
+  F.pos_coarseBondDim
+
+/-- **The coarse three-site chain is injective at the `r-b` edge.** The endpoint
+super-sites (red and blue blocks) and the middle super-site (complement block) are
+all injective, so the edge-blocked three-site injectivity hypothesis holds for the
+coarse tensor at its `r-b` edge. This is the input to the proven injective
+three-site comparison, supplied entirely from the normal blocking hypothesis with
+no single-vertex injectivity of the original tensor.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, the three-site chain after
+`eq:block_to_mps`, lines 1449--1500 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem coarseTensor_edgeBlockedThreeSiteInjective :
+    EdgeBlockedThreeSiteInjective (G := coarseGraph) (F.coarseTensor) coarseEdgeRB :=
+  F.coarseTensor_isVertexInjective.edgeBlockedThreeSiteInjective
+    F.coarseTensor_pos_bondDim coarseEdgeRB
+
+end CoarseBlockingFrame
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite.lean
@@ -1,0 +1,72 @@
+import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
+import TNLean.PEPS.EdgeMiddlePhysical.Basic
+
+/-!
+# The coarse three-site tensor for the normal PEPS theorem
+
+The normal PEPS proof blocks a neighbourhood of each edge into three injective
+regions and then applies the injective three-site comparison to that blocking.
+The injective comparison machinery (`TNLean.PEPS.InsertionAlgebra`,
+`TNLean.PEPS.InsertionRealization`, `TNLean.PEPS.EdgeMiddlePhysical`) operates
+on a single-vertex three-site chain: its endpoint injectivity is
+`Function.Injective (localTensorMap A v)`, single-vertex linear independence.
+A normal tensor need not be vertex injective, so the comparison cannot be run on
+the original tensor at the edge endpoints.
+
+The source argument never uses the single vertex. After blocking, the three
+sites of the chain are the **blocks**: the red region around one endpoint, the
+blue region around the other, and the complement. The "component family" of each
+super-site is the blocked-region weight family, which is injective by the normal
+blocking hypothesis. This file builds the blocked chain as an honest `Tensor` on
+a three-vertex complete graph, so that the proven single-vertex three-site
+comparison applies verbatim to the super-sites.
+
+The three coarse vertices are `r`, `b`, `c`. The coarse edges are `r-b` (the
+original distinguished edge), `r-c` (the red-to-complement crossing bonds bundled
+into one), and `b-c` (the blue-to-complement crossing bonds bundled into one).
+The coarse physical dimension is the uniform padded dimension `d ^ (card V)`,
+large enough to carry every region's physical configuration through a fixed
+surjection.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1449--1500 (the blocking) and lines 254--583 (the injective
+  three-site comparison applied to the blocked chain)](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The coarse three-vertex graph
+
+The coarse graph is the complete graph on `Fin 3`. Its vertices are `0` (red
+super-site `r`), `1` (blue super-site `b`), and `2` (complement super-site `c`).
+Its three edges are `0-1`, `0-2`, and `1-2`. -/
+
+/-- The coarse three-vertex graph: the complete graph on `Fin 3`. -/
+abbrev coarseGraph : SimpleGraph (Fin 3) := ⊤
+
+instance : DecidableRel (coarseGraph).Adj := fun a b => by
+  unfold coarseGraph; simp only [SimpleGraph.top_adj]; infer_instance
+
+/-- The coarse `r-b` edge `0-1`: the image of the original distinguished edge. -/
+def coarseEdgeRB : Edge coarseGraph :=
+  ⟨(0, 1), by constructor <;> simp [coarseGraph]⟩
+
+/-- The coarse `r-c` edge `0-2`: the bundled red-to-complement crossing bonds. -/
+def coarseEdgeRC : Edge coarseGraph :=
+  ⟨(0, 2), by constructor <;> simp [coarseGraph]⟩
+
+/-- The coarse `b-c` edge `1-2`: the bundled blue-to-complement crossing bonds. -/
+def coarseEdgeBC : Edge coarseGraph :=
+  ⟨(1, 2), by constructor <;> simp [coarseGraph]⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite.lean
@@ -309,5 +309,48 @@ theorem coarseTensor_edgeBlockedThreeSiteInjective :
 
 end CoarseBlockingFrame
 
+/-! ### The coarse edge-inserted coefficient transfer
+
+Two coarse tensors blocked around the same edge (frames `F` for `A`, `F'` for `B`)
+that share the same coarse bond dimensions and generate the same coarse state admit
+the proven injective three-site comparison verbatim. The comparison
+`exists_edgeInsertedCoeff_eq` runs on the coarse `r-b` edge, whose bond space is the
+single coarse bond dimension `coarseBondDim coarseEdgeRB`. The output is the bond
+gauge on the coarse `r-b` bond: for every matrix inserted on that bond of the first
+coarse tensor there is a matrix on the second coarse tensor giving the same
+coarse edge-inserted coefficient at every coarse physical configuration.
+
+This is the entire content the proven edge machinery supplies; the descent to the
+original `IsBondLocalTransferKernel` on the original edge `e` is the bridge
+identity recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+
+/-- **The coarse edge-inserted coefficient transfer.** For two coarse frames over
+`A` and `B` with the same coarse bond dimensions and the same coarse state, the
+proven injective three-site comparison on the coarse `r-b` edge gives, for every
+matrix inserted on the coarse `r-b` bond of the first coarse tensor, a matrix on the
+second coarse tensor with equal coarse edge-inserted coefficients at every coarse
+physical configuration.
+
+No single-vertex injectivity of `A` or `B` is used: the two edge-blocked three-site
+injectivities are `coarseTensor_edgeBlockedThreeSiteInjective`, both from the
+blocked-region injectivities of the frames.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--583 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coarse_exists_edgeInsertedCoeff_eq {A B : Tensor G d}
+    (F : CoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoarseBlockingFrame (G := G) (d := d) B)
+    (hsame : SameState (F.coarseTensor) (F'.coarseTensor))
+    (M : Matrix (Fin (F.coarseBondDim coarseEdgeRB))
+        (Fin (F.coarseBondDim coarseEdgeRB)) ℂ) :
+    ∃ N : Matrix (Fin (F'.coarseBondDim coarseEdgeRB))
+        (Fin (F'.coarseBondDim coarseEdgeRB)) ℂ,
+      ∀ σ : Fin 3 → Fin (coarseDim V d),
+        edgeInsertedCoeff (G := coarseGraph) (F.coarseTensor) coarseEdgeRB σ M =
+          edgeInsertedCoeff (G := coarseGraph) (F'.coarseTensor) coarseEdgeRB σ N :=
+  exists_edgeInsertedCoeff_eq (G := coarseGraph) (F.coarseTensor) (F'.coarseTensor)
+    coarseEdgeRB F.coarseTensor_edgeBlockedThreeSiteInjective
+    F'.coarseTensor_edgeBlockedThreeSiteInjective hsame F'.coarseTensor_pos_bondDim M
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite2.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite2.lean
@@ -296,5 +296,75 @@ theorem legEquivBlue_eq_legEquivComplement_on_bc
 
 end CoherentCoarseBlockingFrame
 
+/-! ### The coarse state coefficient as a product of three region weights
+
+The coarse tensor lives on the three-vertex complete graph, so its closed-state
+coefficient is a sum over the three coarse super-bonds of the product over the three
+coarse super-sites of the coarse components. Each coarse super-site component is, by
+construction, a single original blocked-region weight read at the leg-identified
+boundary configuration. The reductions below rewrite the coarse closed-state
+coefficient as the explicit sum over coarse virtual configurations of the product of
+the red, blue, and complement original blocked-region weights. This is the entry
+point of the state gluing: what remains is the three-region merge collapse refactoring
+this sum, through the coherent bond models, as a constant times the original closed
+state coefficient. -/
+
+namespace CoarseBlockingFrame
+
+variable {A : Tensor G d} (F : CoarseBlockingFrame (G := G) (d := d) A)
+
+/-- The coarse red super-site component is the original red blocked-region weight. -/
+theorem coarseTensor_component_red
+    (legs : (ie : IncidentEdge coarseGraph 0) → Fin (F.coarseBondDim ie.1))
+    (p : Fin (coarseDim V d)) :
+    (F.coarseTensor).component 0 legs p =
+      regionBlockedWeight (G := G) A F.red (F.legEquivRed legs) (coarseProj F.red p) := by
+  rw [F.coarseTensor_component]; rfl
+
+/-- The coarse blue super-site component is the original blue blocked-region weight. -/
+theorem coarseTensor_component_blue
+    (legs : (ie : IncidentEdge coarseGraph 1) → Fin (F.coarseBondDim ie.1))
+    (p : Fin (coarseDim V d)) :
+    (F.coarseTensor).component 1 legs p =
+      regionBlockedWeight (G := G) A F.blue (F.legEquivBlue legs) (coarseProj F.blue p) := by
+  rw [F.coarseTensor_component]; rfl
+
+/-- The coarse complement super-site component is the original complement
+blocked-region weight. -/
+theorem coarseTensor_component_complement
+    (legs : (ie : IncidentEdge coarseGraph 2) → Fin (F.coarseBondDim ie.1))
+    (p : Fin (coarseDim V d)) :
+    (F.coarseTensor).component 2 legs p =
+      regionBlockedWeight (G := G) A F.complement (F.legEquivComplement legs)
+        (coarseProj F.complement p) := by
+  rw [F.coarseTensor_component]; rfl
+
+/-- **The coarse state coefficient as a sum of three-region weight products.** The
+closed-state coefficient of the coarse tensor is the sum over coarse virtual
+configurations of the product of the red, blue, and complement original
+blocked-region weights, each read at the boundary configuration its leg
+identification assigns from the coarse virtual configuration.
+
+This is the three-region form of the coarse closed state, the entry point of the
+state gluing. The remaining content is the merge collapse to a constant times the
+original closed state coefficient, documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+theorem stateCoeff_coarseTensor_eq_threeRegionSum (s : Fin 3 → Fin (coarseDim V d)) :
+    stateCoeff (F.coarseTensor) s =
+      ∑ η : VirtualConfig (F.coarseTensor),
+        regionBlockedWeight (G := G) A F.red
+            (F.legEquivRed (fun ie => η ie.1)) (coarseProj F.red (s 0)) *
+          regionBlockedWeight (G := G) A F.blue
+            (F.legEquivBlue (fun ie => η ie.1)) (coarseProj F.blue (s 1)) *
+          regionBlockedWeight (G := G) A F.complement
+            (F.legEquivComplement (fun ie => η ie.1)) (coarseProj F.complement (s 2)) := by
+  rw [stateCoeff]
+  refine Finset.sum_congr rfl (fun η _ => ?_)
+  rw [Fin.prod_univ_three]
+  rw [F.coarseTensor_component_red, F.coarseTensor_component_blue,
+    F.coarseTensor_component_complement]
+
+end CoarseBlockingFrame
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite2.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite2.lean
@@ -1,0 +1,300 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite
+
+/-!
+# Coherent coarse blocking frames for the normal PEPS theorem
+
+The coarse three-site tensor of `TNLean.PEPS.RegionBlock.CoarseThreeSite` records,
+for each coarse super-site, an *independent* equivalence `legEquiv` between the
+coarse virtual legs incident to that super-site and the region boundary
+configurations. That independence is harmless for the vertex injectivity and the
+coarse edge-inserted coefficient transfer, both of which read one super-site at a
+time. It is, however, not enough to glue the coarse state coefficient to the
+original state coefficient: each coarse super-bond is incident to **two** coarse
+super-sites, so its value is read by both incident leg identifications, and the
+state gluing needs those two readings to land on the **same** original crossing-bond
+configuration.
+
+This file records that missing compatibility. A `CoherentCoarseBlockingFrame`
+extends a `CoarseBlockingFrame` with one bond model per coarse super-edge — an
+equivalence between the coarse bond and the configurations on the original edges
+crossing between the two incident regions — and requires each super-site's leg
+identification to factor through these shared bond models on its incident
+super-edges. The geometric content is the partition of every region's boundary
+edges by the partner region across each boundary edge: a boundary edge of the red
+region crosses either to the blue region or to the complement region, and the two
+super-edges incident to the red super-site carry exactly those two crossing
+bundles.
+
+The coherence fields make the state gluing well posed: the two leg identifications
+incident to a super-edge agree on the shared crossing bonds
+(`legEquiv_agree_on_crossing`), so the three blocked-region weights are read at a
+single consistent assignment of the original crossing bonds. This is the
+well-posedness layer flagged as the first remaining obligation of the coarse
+three-site route in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1449--1500 of `Papers/1804.04964/paper_normal.tex`
+  (the blocking) and lines 1205--1210 (the one-region-against-complement
+  gluing)](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Crossing edges between two regions
+
+An original edge crosses between two regions `R` and `R'` when it is a boundary
+edge of `R` and a boundary edge of `R'`. For a partition of the vertex set into
+three regions, these crossing edges are exactly the boundary edges of `R` whose
+out-of-`R` endpoint lies in `R'`. The crossing configurations on these edges are
+the bundle of original virtual legs carried by the coarse super-edge between the
+two regions. -/
+
+/-- An original edge crosses between the regions `R` and `R'` when it is a boundary
+edge of each. For disjoint `R`, `R'` this means exactly one endpoint lies in `R`
+and the other in `R'`. -/
+def IsCrossingEdge (_A : Tensor G d) (R R' : Finset V) (g : Edge G) : Prop :=
+  IsRegionBoundaryEdge (G := G) R g ∧ IsRegionBoundaryEdge (G := G) R' g
+
+instance (A : Tensor G d) (R R' : Finset V) (g : Edge G) :
+    Decidable (IsCrossingEdge (G := G) A R R' g) := by
+  unfold IsCrossingEdge; infer_instance
+
+omit [Fintype V] [DecidableEq V] in
+/-- Crossing is symmetric in the two regions. -/
+theorem IsCrossingEdge.symm {A : Tensor G d} {R R' : Finset V} {g : Edge G}
+    (h : IsCrossingEdge (G := G) A R R' g) : IsCrossingEdge (G := G) A R' R g :=
+  ⟨h.2, h.1⟩
+
+omit [Fintype V] [DecidableEq V] in
+/-- A crossing edge between `R` and `R'` is a boundary edge of `R`. -/
+theorem IsCrossingEdge.boundary_left {A : Tensor G d} {R R' : Finset V} {g : Edge G}
+    (h : IsCrossingEdge (G := G) A R R' g) : IsRegionBoundaryEdge (G := G) R g :=
+  h.1
+
+/-- The crossing configurations between `R` and `R'`: an assignment of an original
+virtual leg to every edge crossing between the two regions. This is the bundle of
+original bonds carried by the coarse super-edge between `R` and `R'`. -/
+abbrev CrossingConfig (A : Tensor G d) (R R' : Finset V) : Type _ :=
+  (g : {g : Edge G // IsCrossingEdge (G := G) A R R' g}) → Fin (A.bondDim g.1)
+
+instance instFintypeCrossingConfig (A : Tensor G d) (R R' : Finset V) :
+    Fintype (CrossingConfig (G := G) A R R') :=
+  inferInstance
+
+/-! ### The partner region of a coarse super-edge
+
+The coarse super-edge `r-b` (`coarseEdgeRB`) bundles the red-to-blue crossings,
+`r-c` (`coarseEdgeRC`) the red-to-complement crossings, and `b-c` (`coarseEdgeBC`)
+the blue-to-complement crossings. For a coarse super-site `v` and an incident
+super-edge `f`, the partner region is the region attached to the other endpoint of
+`f`. -/
+
+namespace CoarseBlockingFrame
+
+variable {A : Tensor G d} (F : CoarseBlockingFrame (G := G) (d := d) A)
+
+/-- The two endpoints of a coarse super-edge, as the regions they attach. The coarse
+graph is the complete graph on `Fin 3`, so the endpoints of an edge are its two
+coordinate entries. -/
+def edgeRegions (f : Edge coarseGraph) : Finset V × Finset V :=
+  (F.regionOf f.1.1, F.regionOf f.1.2)
+
+omit [DecidableEq V] in
+@[simp] theorem edgeRegions_rb : F.edgeRegions coarseEdgeRB = (F.red, F.blue) := rfl
+omit [DecidableEq V] in
+@[simp] theorem edgeRegions_rc : F.edgeRegions coarseEdgeRC = (F.red, F.complement) := rfl
+omit [DecidableEq V] in
+@[simp] theorem edgeRegions_bc : F.edgeRegions coarseEdgeBC = (F.blue, F.complement) := rfl
+
+end CoarseBlockingFrame
+
+/-! ### The coherent coarse blocking frame
+
+A coherent frame fixes, for each coarse super-edge `f`, an equivalence between the
+coarse bond `Fin (coarseBondDim f)` and the crossing configurations between the two
+regions attached to the endpoints of `f`. The factoring fields then require each
+super-site's leg identification to read each incident super-bond through the shared
+bond model on the corresponding crossing edges. -/
+
+/-- **A coherent coarse blocking frame.** A coarse blocking frame together with, for
+each coarse super-edge, a bond model identifying the coarse bond with the original
+crossing configurations between the two incident regions, and the requirement that
+each super-site's leg identification factors through these shared bond models on its
+incident super-edges.
+
+The factoring fields `factor_red`, `factor_blue`, `factor_complement` say: reading a
+boundary edge `g` of the region at super-site `v`, where `g` crosses to the partner
+region across an incident super-edge `f`, the region boundary configuration assigned
+by `legEquiv v legs` equals the bond model of `f` applied to the coarse leg
+`legs ⟨f, _⟩` read at `g`. Two super-sites incident to `f` therefore read the shared
+super-bond value through the *same* bond model, so they agree on the shared crossing
+bonds (`legEquiv_agree_on_crossing`).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 and
+1205--1210 of `Papers/1804.04964/paper_normal.tex`. -/
+structure CoherentCoarseBlockingFrame (A : Tensor G d)
+    extends CoarseBlockingFrame (G := G) (d := d) A where
+  /-- For each coarse super-edge, an equivalence between the coarse bond and the
+  original crossing configurations between the two incident regions. -/
+  bondModel : (f : Edge coarseGraph) →
+    Fin (toCoarseBlockingFrame.coarseBondDim f) ≃
+      CrossingConfig (G := G) A (toCoarseBlockingFrame.edgeRegions f).1
+        (toCoarseBlockingFrame.edgeRegions f).2
+  /-- The red super-site reads each boundary edge of the red region through the bond
+  model of the incident super-edge whose partner region contains the out-of-red
+  endpoint. The two incident super-edges of the red super-site are `r-b` and `r-c`. -/
+  factor_red :
+    ∀ (legs : (ie : IncidentEdge coarseGraph 0) →
+        Fin (toCoarseBlockingFrame.coarseBondDim ie.1))
+      (b : {b : Edge G // IsRegionBoundaryEdge (G := G) toCoarseBlockingFrame.red b})
+      (hf : IsCrossingEdge (G := G) A toCoarseBlockingFrame.red toCoarseBlockingFrame.blue b.1)
+      (ie : IncidentEdge coarseGraph 0) (hie : ie.1 = coarseEdgeRB),
+      toCoarseBlockingFrame.legEquivRed legs b =
+        (bondModel coarseEdgeRB (hie ▸ legs ie)
+          ⟨b.1, hf⟩ :
+          Fin (A.bondDim b.1))
+  /-- The factoring of the red super-site at the `r-c` super-edge. -/
+  factor_red_rc :
+    ∀ (legs : (ie : IncidentEdge coarseGraph 0) →
+        Fin (toCoarseBlockingFrame.coarseBondDim ie.1))
+      (b : {b : Edge G // IsRegionBoundaryEdge (G := G) toCoarseBlockingFrame.red b})
+      (hf : IsCrossingEdge (G := G) A toCoarseBlockingFrame.red
+        toCoarseBlockingFrame.complement b.1)
+      (ie : IncidentEdge coarseGraph 0) (hie : ie.1 = coarseEdgeRC),
+      toCoarseBlockingFrame.legEquivRed legs b =
+        (bondModel coarseEdgeRC (hie ▸ legs ie)
+          ⟨b.1, hf⟩ :
+          Fin (A.bondDim b.1))
+  /-- The blue super-site reads each boundary edge of the blue region crossing to red
+  through the `r-b` bond model. -/
+  factor_blue_rb :
+    ∀ (legs : (ie : IncidentEdge coarseGraph 1) →
+        Fin (toCoarseBlockingFrame.coarseBondDim ie.1))
+      (b : {b : Edge G // IsRegionBoundaryEdge (G := G) toCoarseBlockingFrame.blue b})
+      (hf : IsCrossingEdge (G := G) A toCoarseBlockingFrame.red toCoarseBlockingFrame.blue b.1)
+      (ie : IncidentEdge coarseGraph 1) (hie : ie.1 = coarseEdgeRB),
+      toCoarseBlockingFrame.legEquivBlue legs b =
+        (bondModel coarseEdgeRB (hie ▸ legs ie)
+          ⟨b.1, hf⟩ :
+          Fin (A.bondDim b.1))
+  /-- The blue super-site reads each boundary edge of the blue region crossing to the
+  complement through the `b-c` bond model. -/
+  factor_blue_bc :
+    ∀ (legs : (ie : IncidentEdge coarseGraph 1) →
+        Fin (toCoarseBlockingFrame.coarseBondDim ie.1))
+      (b : {b : Edge G // IsRegionBoundaryEdge (G := G) toCoarseBlockingFrame.blue b})
+      (hf : IsCrossingEdge (G := G) A toCoarseBlockingFrame.blue
+        toCoarseBlockingFrame.complement b.1)
+      (ie : IncidentEdge coarseGraph 1) (hie : ie.1 = coarseEdgeBC),
+      toCoarseBlockingFrame.legEquivBlue legs b =
+        (bondModel coarseEdgeBC (hie ▸ legs ie)
+          ⟨b.1, hf⟩ :
+          Fin (A.bondDim b.1))
+  /-- The complement super-site reads each boundary edge of the complement crossing to
+  red through the `r-c` bond model (with the regions swapped). -/
+  factor_compl_rc :
+    ∀ (legs : (ie : IncidentEdge coarseGraph 2) →
+        Fin (toCoarseBlockingFrame.coarseBondDim ie.1))
+      (b : {b : Edge G //
+        IsRegionBoundaryEdge (G := G) toCoarseBlockingFrame.complement b})
+      (hf : IsCrossingEdge (G := G) A toCoarseBlockingFrame.red
+        toCoarseBlockingFrame.complement b.1)
+      (ie : IncidentEdge coarseGraph 2) (hie : ie.1 = coarseEdgeRC),
+      toCoarseBlockingFrame.legEquivComplement legs b =
+        (bondModel coarseEdgeRC (hie ▸ legs ie)
+          ⟨b.1, hf⟩ :
+          Fin (A.bondDim b.1))
+  /-- The complement super-site reads each boundary edge of the complement crossing to
+  blue through the `b-c` bond model (with the regions swapped). -/
+  factor_compl_bc :
+    ∀ (legs : (ie : IncidentEdge coarseGraph 2) →
+        Fin (toCoarseBlockingFrame.coarseBondDim ie.1))
+      (b : {b : Edge G //
+        IsRegionBoundaryEdge (G := G) toCoarseBlockingFrame.complement b})
+      (hf : IsCrossingEdge (G := G) A toCoarseBlockingFrame.blue
+        toCoarseBlockingFrame.complement b.1)
+      (ie : IncidentEdge coarseGraph 2) (hie : ie.1 = coarseEdgeBC),
+      toCoarseBlockingFrame.legEquivComplement legs b =
+        (bondModel coarseEdgeBC (hie ▸ legs ie)
+          ⟨b.1, hf⟩ :
+          Fin (A.bondDim b.1))
+
+namespace CoherentCoarseBlockingFrame
+
+variable {A : Tensor G d} (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+
+/-- The underlying coarse blocking frame. -/
+abbrev frame : CoarseBlockingFrame (G := G) (d := d) A := F.toCoarseBlockingFrame
+
+/-! ### The shared-super-bond agreement
+
+The factoring fields express each super-site's leg identification through the shared
+bond models. Their payoff is that two super-sites incident to the same super-edge,
+fed leg assignments agreeing on the shared super-bond, read every shared crossing
+edge to the same original virtual leg. These are the well-posedness lemmas the state
+gluing consumes: the red and blue blocked-region weights are evaluated at boundary
+configurations agreeing on every red-to-blue crossing edge, and likewise for the
+other two super-edges. -/
+
+omit [DecidableEq V] in
+/-- **Red and blue agree on the `r-b` crossings.** If the red and blue leg
+assignments carry the same value on the shared `r-b` super-bond, the red and blue
+boundary configurations they induce agree on every red-to-blue crossing edge. The
+crossing edge is presented once, with its red and blue boundary memberships read off
+the crossing hypothesis. -/
+theorem legEquivRed_eq_legEquivBlue_on_rb
+    (legsR : (ie : IncidentEdge coarseGraph 0) → Fin (F.frame.coarseBondDim ie.1))
+    (legsB : (ie : IncidentEdge coarseGraph 1) → Fin (F.frame.coarseBondDim ie.1))
+    (ieR : IncidentEdge coarseGraph 0) (hieR : ieR.1 = coarseEdgeRB)
+    (ieB : IncidentEdge coarseGraph 1) (hieB : ieB.1 = coarseEdgeRB)
+    (hval : (hieR ▸ legsR ieR : Fin (F.frame.coarseBondDim coarseEdgeRB)) = hieB ▸ legsB ieB)
+    (g : Edge G) (hf : IsCrossingEdge (G := G) A F.frame.red F.frame.blue g) :
+    (F.frame.legEquivRed legsR ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
+      (F.frame.legEquivBlue legsB ⟨g, hf.2⟩ : Fin (A.bondDim g)) := by
+  have hfR := F.factor_red legsR ⟨g, hf.1⟩ hf ieR hieR
+  have hfB := F.factor_blue_rb legsB ⟨g, hf.2⟩ hf ieB hieB
+  rw [hfR, hfB, hval]
+
+omit [DecidableEq V] in
+/-- **Red and complement agree on the `r-c` crossings.** -/
+theorem legEquivRed_eq_legEquivComplement_on_rc
+    (legsR : (ie : IncidentEdge coarseGraph 0) → Fin (F.frame.coarseBondDim ie.1))
+    (legsC : (ie : IncidentEdge coarseGraph 2) → Fin (F.frame.coarseBondDim ie.1))
+    (ieR : IncidentEdge coarseGraph 0) (hieR : ieR.1 = coarseEdgeRC)
+    (ieC : IncidentEdge coarseGraph 2) (hieC : ieC.1 = coarseEdgeRC)
+    (hval : (hieR ▸ legsR ieR : Fin (F.frame.coarseBondDim coarseEdgeRC)) = hieC ▸ legsC ieC)
+    (g : Edge G) (hf : IsCrossingEdge (G := G) A F.frame.red F.frame.complement g) :
+    (F.frame.legEquivRed legsR ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
+      (F.frame.legEquivComplement legsC ⟨g, hf.2⟩ : Fin (A.bondDim g)) := by
+  have hfR := F.factor_red_rc legsR ⟨g, hf.1⟩ hf ieR hieR
+  have hfC := F.factor_compl_rc legsC ⟨g, hf.2⟩ hf ieC hieC
+  rw [hfR, hfC, hval]
+
+omit [DecidableEq V] in
+/-- **Blue and complement agree on the `b-c` crossings.** -/
+theorem legEquivBlue_eq_legEquivComplement_on_bc
+    (legsB : (ie : IncidentEdge coarseGraph 1) → Fin (F.frame.coarseBondDim ie.1))
+    (legsC : (ie : IncidentEdge coarseGraph 2) → Fin (F.frame.coarseBondDim ie.1))
+    (ieB : IncidentEdge coarseGraph 1) (hieB : ieB.1 = coarseEdgeBC)
+    (ieC : IncidentEdge coarseGraph 2) (hieC : ieC.1 = coarseEdgeBC)
+    (hval : (hieB ▸ legsB ieB : Fin (F.frame.coarseBondDim coarseEdgeBC)) = hieC ▸ legsC ieC)
+    (g : Edge G) (hf : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement g) :
+    (F.frame.legEquivBlue legsB ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
+      (F.frame.legEquivComplement legsC ⟨g, hf.2⟩ : Fin (A.bondDim g)) := by
+  have hfB := F.factor_blue_bc legsB ⟨g, hf.1⟩ hf ieB hieB
+  have hfC := F.factor_compl_bc legsC ⟨g, hf.2⟩ hf ieC hieC
+  rw [hfB, hfC, hval]
+
+end CoherentCoarseBlockingFrame
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
@@ -98,9 +98,9 @@ end IsPartition
 The red, blue, and complement regions of a partitioned coarse frame form a
 `ThreeBlockGeometry`, unlocking the landed three-block factorization machinery of
 `TNLean.PEPS.RegionBlock.UnionInjectivityGeneral` for the coarse merge collapse:
-the fused complement physical leg `complPhysical`, the host vertex-product split
-`prod_sdiff_red_eq_blue_mul_complement`, and the host weight as a blue/complement
-double-product sum. -/
+the fused complement physical leg `ThreeBlockGeometry.complPhysical`, the host
+vertex-product split `ThreeBlockGeometry.prod_sdiff_red_eq_blue_mul_complement`,
+and the host weight as a blue/complement double-product sum. -/
 
 /-- **The three-block geometry of a partitioned coarse frame.** The red, blue, and
 complement regions, with their pairwise disjointness and cover, packaged as a

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
@@ -125,6 +125,126 @@ def toThreeBlockGeometry (hP : F.IsPartition) : ThreeBlockGeometry V where
 @[simp] theorem toThreeBlockGeometry_complement (hP : F.IsPartition) :
     (F.toThreeBlockGeometry hP).complement = F.complement := rfl
 
+/-! ### Crossing classification of region boundary edges
+
+Under the partition, every boundary edge of a region crosses to exactly one
+partner region: a boundary edge of `red` has its out-of-`red` endpoint in `blue`
+or in `complement`, so it is an `r-b` or an `r-c` crossing edge. This is the
+geometric content the factoring fields of a coherent frame consume: the two
+super-edges incident to a super-site carry exactly the two crossing bundles of
+its region's boundary. -/
+
+/-- A vertex outside `red` lies in `blue` or in `complement`. -/
+theorem mem_blue_or_complement_of_not_mem_red (hP : F.IsPartition) {w : V}
+    (hw : w ∉ F.red) : w ∈ F.blue ∨ w ∈ F.complement := by
+  have hbc : w ∈ F.blue ∪ F.complement := by rw [← hP.sdiff_red]; simp [hw]
+  exact Finset.mem_union.mp hbc
+
+/-- **Crossing classification at the red super-site.** A boundary edge of `red`
+is an `r-b` crossing edge or an `r-c` crossing edge: its out-of-`red` endpoint
+lies in `blue` or in `complement`. -/
+theorem isCrossingEdge_red_blue_or_red_complement (hP : F.IsPartition) {g : Edge G}
+    (hg : IsRegionBoundaryEdge (G := G) F.red g) :
+    IsCrossingEdge (G := G) A F.red F.blue g ∨
+      IsCrossingEdge (G := G) A F.red F.complement g := by
+  rcases hg with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · -- `g.1.1 ∈ red` (h1), `g.1.2 ∉ red` (h2): classify the out-of-red endpoint `g.1.2`.
+    have h1nb : g.1.1 ∉ F.blue := (Finset.disjoint_left.mp hP.red_disjoint_blue) h1
+    have h1nc : g.1.1 ∉ F.complement :=
+      (Finset.disjoint_left.mp hP.red_disjoint_complement) h1
+    rcases F.mem_blue_or_complement_of_not_mem_red hP h2 with hb | hc
+    · exact Or.inl ⟨Or.inl ⟨h1, h2⟩, Or.inr ⟨h1nb, hb⟩⟩
+    · exact Or.inr ⟨Or.inl ⟨h1, h2⟩, Or.inr ⟨h1nc, hc⟩⟩
+  · -- `g.1.1 ∉ red` (h1), `g.1.2 ∈ red` (h2): classify the out-of-red endpoint `g.1.1`.
+    have h2nb : g.1.2 ∉ F.blue := (Finset.disjoint_left.mp hP.red_disjoint_blue) h2
+    have h2nc : g.1.2 ∉ F.complement :=
+      (Finset.disjoint_left.mp hP.red_disjoint_complement) h2
+    rcases F.mem_blue_or_complement_of_not_mem_red hP h1 with hb | hc
+    · exact Or.inl ⟨Or.inr ⟨h1, h2⟩, Or.inl ⟨hb, h2nb⟩⟩
+    · exact Or.inr ⟨Or.inr ⟨h1, h2⟩, Or.inl ⟨hc, h2nc⟩⟩
+
+/-- **Crossing classification at the blue super-site.** A boundary edge of `blue`
+is an `r-b` crossing edge or a `b-c` crossing edge. -/
+theorem isCrossingEdge_red_blue_or_blue_complement (hP : F.IsPartition) {g : Edge G}
+    (hg : IsRegionBoundaryEdge (G := G) F.blue g) :
+    IsCrossingEdge (G := G) A F.red F.blue g ∨
+      IsCrossingEdge (G := G) A F.blue F.complement g := by
+  rcases hg with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · -- `g.1.1 ∈ blue` (h1), `g.1.2 ∉ blue` (h2): classify `g.1.2` as red or complement.
+    have h1nr : g.1.1 ∉ F.red := fun hr =>
+      (Finset.disjoint_left.mp hP.red_disjoint_blue) hr h1
+    have h1nc : g.1.1 ∉ F.complement := fun hc =>
+      (Finset.disjoint_left.mp hP.blue_disjoint_complement) h1 hc
+    have hbc : g.1.2 ∈ F.red ∨ g.1.2 ∈ F.complement := by
+      have hcover : g.1.2 ∈ F.red ∪ F.blue ∪ F.complement := by
+        rw [hP.cover_univ]; exact Finset.mem_univ _
+      rcases Finset.mem_union.mp hcover with hrb | hc
+      · rcases Finset.mem_union.mp hrb with hr | hbl
+        · exact Or.inl hr
+        · exact absurd hbl h2
+      · exact Or.inr hc
+    rcases hbc with hr | hc
+    · exact Or.inl ⟨Or.inr ⟨h1nr, hr⟩, Or.inl ⟨h1, h2⟩⟩
+    · exact Or.inr ⟨Or.inl ⟨h1, h2⟩, Or.inr ⟨h1nc, hc⟩⟩
+  · -- `g.1.1 ∉ blue` (h1), `g.1.2 ∈ blue` (h2): classify `g.1.1` as red or complement.
+    have h2nr : g.1.2 ∉ F.red := fun hr =>
+      (Finset.disjoint_left.mp hP.red_disjoint_blue) hr h2
+    have h2nc : g.1.2 ∉ F.complement := fun hc =>
+      (Finset.disjoint_left.mp hP.blue_disjoint_complement) h2 hc
+    have hbc : g.1.1 ∈ F.red ∨ g.1.1 ∈ F.complement := by
+      have hcover : g.1.1 ∈ F.red ∪ F.blue ∪ F.complement := by
+        rw [hP.cover_univ]; exact Finset.mem_univ _
+      rcases Finset.mem_union.mp hcover with hrb | hc
+      · rcases Finset.mem_union.mp hrb with hr | hbl
+        · exact Or.inl hr
+        · exact absurd hbl h1
+      · exact Or.inr hc
+    rcases hbc with hr | hc
+    · exact Or.inl ⟨Or.inl ⟨hr, h2nr⟩, Or.inr ⟨h1, h2⟩⟩
+    · exact Or.inr ⟨Or.inr ⟨h1, h2⟩, Or.inl ⟨hc, h2nc⟩⟩
+
+/-- **Crossing classification at the complement super-site.** A boundary edge of
+`complement` is an `r-c` crossing edge or a `b-c` crossing edge. -/
+theorem isCrossingEdge_red_complement_or_blue_complement (hP : F.IsPartition)
+    {g : Edge G} (hg : IsRegionBoundaryEdge (G := G) F.complement g) :
+    IsCrossingEdge (G := G) A F.red F.complement g ∨
+      IsCrossingEdge (G := G) A F.blue F.complement g := by
+  rcases hg with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · -- `g.1.1 ∈ complement`, `g.1.2 ∉ complement`: classify `g.1.2` as red or blue.
+    have hbc : g.1.2 ∈ F.red ∨ g.1.2 ∈ F.blue := by
+      have hcover : g.1.2 ∈ F.red ∪ F.blue ∪ F.complement := by
+        rw [hP.cover_univ]; exact Finset.mem_univ _
+      rcases Finset.mem_union.mp hcover with hrb | hc
+      · rcases Finset.mem_union.mp hrb with hr | hbl
+        · exact Or.inl hr
+        · exact Or.inr hbl
+      · exact absurd hc h2
+    -- `g.1.1 ∈ complement` (h1), so `g.1.1 ∉ red` and `g.1.1 ∉ blue`.
+    have h1nr : g.1.1 ∉ F.red := fun hr =>
+      (Finset.disjoint_left.mp hP.red_disjoint_complement) hr h1
+    have h1nb : g.1.1 ∉ F.blue := fun hb =>
+      (Finset.disjoint_left.mp hP.blue_disjoint_complement) hb h1
+    rcases hbc with hr | hb
+    · exact Or.inl ⟨Or.inr ⟨h1nr, hr⟩, Or.inl ⟨h1, h2⟩⟩
+    · exact Or.inr ⟨Or.inr ⟨h1nb, hb⟩, Or.inl ⟨h1, h2⟩⟩
+  · -- `g.1.1 ∉ complement`, `g.1.2 ∈ complement`: classify `g.1.1` as red or blue.
+    have hbc : g.1.1 ∈ F.red ∨ g.1.1 ∈ F.blue := by
+      have hcover : g.1.1 ∈ F.red ∪ F.blue ∪ F.complement := by
+        rw [hP.cover_univ]; exact Finset.mem_univ _
+      rcases Finset.mem_union.mp hcover with hrb | hc
+      · rcases Finset.mem_union.mp hrb with hr | hbl
+        · exact Or.inl hr
+        · exact Or.inr hbl
+      · exact absurd hc h1
+    -- `g.1.2 ∈ complement` (h2), so `g.1.2 ∉ red` and `g.1.2 ∉ blue`.
+    have h2nr : g.1.2 ∉ F.red := fun hr =>
+      (Finset.disjoint_left.mp hP.red_disjoint_complement) hr h2
+    have h2nb : g.1.2 ∉ F.blue := fun hb =>
+      (Finset.disjoint_left.mp hP.blue_disjoint_complement) hb h2
+    rcases hbc with hr | hb
+    · exact Or.inl ⟨Or.inl ⟨hr, h2nr⟩, Or.inr ⟨h1, h2⟩⟩
+    · exact Or.inr ⟨Or.inl ⟨hb, h2nb⟩, Or.inr ⟨h1, h2⟩⟩
+
 end CoarseBlockingFrame
 
 end PEPS

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
@@ -1,5 +1,6 @@
 import TNLean.PEPS.RegionBlock.CoarseThreeSite2
 import TNLean.PEPS.RegionBlock.Recovery
+import TNLean.PEPS.RegionBlock.UnionInjectivityGeneral
 
 /-!
 # The three-region merge collapse for the normal PEPS theorem
@@ -92,120 +93,37 @@ theorem sdiff_red (hP : F.IsPartition) :
 
 end IsPartition
 
-/-! ### The fused complement physical leg
+/-! ### The three-block geometry of a partitioned coarse frame
 
-The two-block collapse `stateCoeff_eq_regionComplement` reads the host
-`univ \ red` through a single physical leg over `univ \ red`. The blue and
-complement super-sites carry two independent physical legs, over `blue` and over
-`complement`. Under the partition `univ \ red = blue ∪ complement`, these fuse
-into one leg over `univ \ red`. -/
+The red, blue, and complement regions of a partitioned coarse frame form a
+`ThreeBlockGeometry`, unlocking the landed three-block factorization machinery of
+`TNLean.PEPS.RegionBlock.UnionInjectivityGeneral` for the coarse merge collapse:
+the fused complement physical leg `complPhysical`, the host vertex-product split
+`prod_sdiff_red_eq_blue_mul_complement`, and the host weight as a blue/complement
+double-product sum. -/
 
-/-- The fused complement physical leg over `univ \ red`, read from a blue physical
-leg and a complement physical leg: a vertex outside `red` lies in `blue` (then
-read `σblue`) or, failing that, in `complement` (then read `σcompl`). -/
-noncomputable def complPhysical (hP : F.IsPartition)
-    (σblue : RegionPhysicalConfig (V := V) (d := d) F.blue)
-    (σcompl : RegionPhysicalConfig (V := V) (d := d) F.complement) :
-    RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.red) :=
-  fun w =>
-    if hb : w.1 ∈ F.blue then σblue ⟨w.1, hb⟩
-    else σcompl ⟨w.1, by
-      have hbc : w.1 ∈ F.blue ∪ F.complement := by
-        rw [← hP.sdiff_red]; exact w.2
-      rcases Finset.mem_union.mp hbc with hbl | hc
-      · exact absurd hbl hb
-      · exact hc⟩
+/-- **The three-block geometry of a partitioned coarse frame.** The red, blue, and
+complement regions, with their pairwise disjointness and cover, packaged as a
+`ThreeBlockGeometry` so the landed three-block factorizations of
+`TNLean.PEPS.RegionBlock.UnionInjectivityGeneral` apply to the coarse blocking.
 
-/-- The fused complement leg reads a blue vertex off the blue physical leg. -/
-theorem complPhysical_apply_blue (hP : F.IsPartition)
-    (σblue : RegionPhysicalConfig (V := V) (d := d) F.blue)
-    (σcompl : RegionPhysicalConfig (V := V) (d := d) F.complement)
-    (w : {w : V // w ∈ Finset.univ \ F.red}) (hb : w.1 ∈ F.blue) :
-    F.complPhysical hP σblue σcompl w = σblue ⟨w.1, hb⟩ := by
-  rw [complPhysical, dif_pos hb]
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def toThreeBlockGeometry (hP : F.IsPartition) : ThreeBlockGeometry V where
+  red := F.red
+  blue := F.blue
+  complement := F.complement
+  red_disjoint_blue := hP.red_disjoint_blue
+  red_disjoint_complement := hP.red_disjoint_complement
+  blue_disjoint_complement := hP.blue_disjoint_complement
+  cover_univ := hP.cover_univ
 
-/-- The fused complement leg reads a non-blue vertex off the complement physical
-leg. -/
-theorem complPhysical_apply_not_blue (hP : F.IsPartition)
-    (σblue : RegionPhysicalConfig (V := V) (d := d) F.blue)
-    (σcompl : RegionPhysicalConfig (V := V) (d := d) F.complement)
-    (w : {w : V // w ∈ Finset.univ \ F.red}) (hb : w.1 ∉ F.blue)
-    (hc : w.1 ∈ F.complement) :
-    F.complPhysical hP σblue σcompl w = σcompl ⟨w.1, hc⟩ := by
-  rw [complPhysical, dif_neg hb]
-
-/-- **The vertex-product split over `univ \ red`.** For any global virtual
-configuration `ζ`, the product of the vertex tensors over `univ \ red`, read with
-the fused blue/complement physical leg, factors as the blue product (read with
-`σblue`) times the complement product (read with `σcompl`). This is the disjoint
-decomposition `univ \ red = blue ⊔ complement` applied to the contraction. -/
-theorem prod_sdiff_red_eq_blue_mul_complement (hP : F.IsPartition)
-    (σblue : RegionPhysicalConfig (V := V) (d := d) F.blue)
-    (σcompl : RegionPhysicalConfig (V := V) (d := d) F.complement)
-    (ζ : VirtualConfig A) :
-    (∏ w : {w : V // w ∈ Finset.univ \ F.red},
-        A.component w.1 (fun ie => ζ ie.1) (F.complPhysical hP σblue σcompl w)) =
-      (∏ w : {w : V // w ∈ F.blue}, A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
-        ∏ w : {w : V // w ∈ F.complement},
-          A.component w.1 (fun ie => ζ ie.1) (σcompl w) := by
-  classical
-  rcases isEmpty_or_nonempty (Fin d) with hd | hd
-  · -- With no physical index, every block subtype is empty.
-    have hblue : IsEmpty {w : V // w ∈ F.blue} := ⟨fun w => hd.elim (σblue w)⟩
-    have hcompl : IsEmpty {w : V // w ∈ F.complement} := ⟨fun w => hd.elim (σcompl w)⟩
-    have hsdiff : IsEmpty {w : V // w ∈ Finset.univ \ F.red} :=
-      ⟨fun w => hd.elim (F.complPhysical hP σblue σcompl w)⟩
-    rw [Finset.prod_of_isEmpty, Finset.prod_of_isEmpty, Finset.prod_of_isEmpty, one_mul]
-  · -- A total physical leg agreeing with `σblue` on blue and `σcompl` on complement.
-    set g : V → Fin d := fun w =>
-      if hb : w ∈ F.blue then σblue ⟨w, hb⟩
-      else if hc : w ∈ F.complement then σcompl ⟨w, hc⟩
-      else Classical.arbitrary (Fin d) with hg
-    -- The fused leg on `univ \ red` agrees with `g`.
-    have hsdiff : (∏ w : {w : V // w ∈ Finset.univ \ F.red},
-          A.component w.1 (fun ie => ζ ie.1) (F.complPhysical hP σblue σcompl w)) =
-        ∏ w : {w : V // w ∈ Finset.univ \ F.red},
-          A.component w.1 (fun ie => ζ ie.1) (g w.1) := by
-      refine Finset.prod_congr rfl (fun w _ => ?_)
-      congr 1
-      by_cases hb : w.1 ∈ F.blue
-      · rw [F.complPhysical_apply_blue hP σblue σcompl w hb, hg]
-        simp only [dif_pos hb]
-      · have hbc' : w.1 ∈ F.blue ∪ F.complement := by rw [← hP.sdiff_red]; exact w.2
-        have hc : w.1 ∈ F.complement := by
-          rcases Finset.mem_union.mp hbc' with h | h
-          · exact absurd h hb
-          · exact h
-        rw [F.complPhysical_apply_not_blue hP σblue σcompl w hb hc, hg]
-        simp only [dif_neg hb, dif_pos hc]
-    -- The blue and complement subtype products read `g` on their vertices.
-    have hblue : (∏ w : {w : V // w ∈ F.blue},
-          A.component w.1 (fun ie => ζ ie.1) (σblue w)) =
-        ∏ w : {w : V // w ∈ F.blue},
-          A.component w.1 (fun ie => ζ ie.1) (g w.1) := by
-      refine Finset.prod_congr rfl (fun w _ => ?_)
-      congr 1
-      rw [hg]; simp only [dif_pos w.2]
-    have hcompl : (∏ w : {w : V // w ∈ F.complement},
-          A.component w.1 (fun ie => ζ ie.1) (σcompl w)) =
-        ∏ w : {w : V // w ∈ F.complement},
-          A.component w.1 (fun ie => ζ ie.1) (g w.1) := by
-      refine Finset.prod_congr rfl (fun w _ => ?_)
-      congr 1
-      have hb : w.1 ∉ F.blue := fun h =>
-        (Finset.disjoint_left.mp hP.blue_disjoint_complement) h w.2
-      rw [hg]; simp only [dif_neg hb, dif_pos w.2]
-    rw [hsdiff, hblue, hcompl]
-    -- Convert the three subtype products to `Finset.prod` and split the union.
-    rw [← Finset.prod_subtype (Finset.univ \ F.red) (fun x => Iff.rfl)
-        (fun w => A.component w (fun ie => ζ ie.1) (g w)),
-      ← Finset.prod_subtype F.blue (fun x => Iff.rfl)
-        (fun w => A.component w (fun ie => ζ ie.1) (g w)),
-      ← Finset.prod_subtype F.complement (fun x => Iff.rfl)
-        (fun w => A.component w (fun ie => ζ ie.1) (g w)),
-      hP.sdiff_red,
-      Finset.prod_union (Finset.disjoint_left.mpr (fun w hbl hc =>
-        (Finset.disjoint_left.mp hP.blue_disjoint_complement) hbl hc))]
+@[simp] theorem toThreeBlockGeometry_red (hP : F.IsPartition) :
+    (F.toThreeBlockGeometry hP).red = F.red := rfl
+@[simp] theorem toThreeBlockGeometry_blue (hP : F.IsPartition) :
+    (F.toThreeBlockGeometry hP).blue = F.blue := rfl
+@[simp] theorem toThreeBlockGeometry_complement (hP : F.IsPartition) :
+    (F.toThreeBlockGeometry hP).complement = F.complement := rfl
 
 end CoarseBlockingFrame
 

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
@@ -247,5 +247,113 @@ theorem isCrossingEdge_red_complement_or_blue_complement (hP : F.IsPartition)
 
 end CoarseBlockingFrame
 
+/-! ### Incident super-edges of the coarse graph
+
+Each coarse super-site has two incident super-edges. The red super-site `0` is
+incident to `r-b` and `r-c`, the blue super-site `1` to `r-b` and `b-c`, the
+complement super-site `2` to `r-c` and `b-c`. These named incident edges feed the
+factoring fields of a coherent frame, which read a super-bond off the coarse leg
+at the corresponding incident edge. -/
+
+/-- The incident super-edge `r-b` at the red super-site `0`. -/
+def incidentRB0 : IncidentEdge coarseGraph 0 := ⟨coarseEdgeRB, Or.inl rfl⟩
+
+/-- The incident super-edge `r-c` at the red super-site `0`. -/
+def incidentRC0 : IncidentEdge coarseGraph 0 := ⟨coarseEdgeRC, Or.inl rfl⟩
+
+/-- The incident super-edge `r-b` at the blue super-site `1`. -/
+def incidentRB1 : IncidentEdge coarseGraph 1 := ⟨coarseEdgeRB, Or.inr rfl⟩
+
+/-- The incident super-edge `b-c` at the blue super-site `1`. -/
+def incidentBC1 : IncidentEdge coarseGraph 1 := ⟨coarseEdgeBC, Or.inl rfl⟩
+
+/-- The incident super-edge `r-c` at the complement super-site `2`. -/
+def incidentRC2 : IncidentEdge coarseGraph 2 := ⟨coarseEdgeRC, Or.inr rfl⟩
+
+/-- The incident super-edge `b-c` at the complement super-site `2`. -/
+def incidentBC2 : IncidentEdge coarseGraph 2 := ⟨coarseEdgeBC, Or.inr rfl⟩
+
+@[simp] theorem incidentRB0_fst : (incidentRB0).1 = coarseEdgeRB := rfl
+@[simp] theorem incidentRC0_fst : (incidentRC0).1 = coarseEdgeRC := rfl
+@[simp] theorem incidentRB1_fst : (incidentRB1).1 = coarseEdgeRB := rfl
+@[simp] theorem incidentBC1_fst : (incidentBC1).1 = coarseEdgeBC := rfl
+@[simp] theorem incidentRC2_fst : (incidentRC2).1 = coarseEdgeRC := rfl
+@[simp] theorem incidentBC2_fst : (incidentBC2).1 = coarseEdgeBC := rfl
+
+/-! ### Reading a region boundary leg off the bond models
+
+Through the factoring fields, each super-site's leg identification of a coarse
+virtual configuration `η` reads every boundary edge of its region off one of the
+two bond models on its incident super-edges. The crossing classification selects
+which model: a boundary edge of `red` crossing to `blue` is read off the `r-b`
+bond model at `η`'s `r-b` value, a boundary edge crossing to `complement` off the
+`r-c` bond model at `η`'s `r-c` value. These read-offs are the per-edge form of
+the shared-super-bond agreement; they will express each coarse blocked-region
+weight as a function of the original crossing configurations alone. -/
+
+namespace CoherentCoarseBlockingFrame
+
+variable {A : Tensor G d} (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+
+/-- **Red leg off the `r-b` bond model.** On a red boundary edge crossing to blue,
+the red super-site reads the leg of a coarse virtual configuration `η` off the
+`r-b` bond model at `η`'s `r-b` value. -/
+theorem legEquivRed_eq_bondModel_rb
+    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
+    (hf : IsCrossingEdge (G := G) A F.frame.red F.frame.blue g) :
+    (F.frame.legEquivRed (fun ie => η ie.1) ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
+      (F.bondModel coarseEdgeRB (η coarseEdgeRB) ⟨g, hf⟩ : Fin (A.bondDim g)) :=
+  F.factor_red (fun ie => η ie.1) ⟨g, hf.1⟩ hf incidentRB0 rfl
+
+/-- **Red leg off the `r-c` bond model.** On a red boundary edge crossing to the
+complement, the red super-site reads the leg of `η` off the `r-c` bond model at
+`η`'s `r-c` value. -/
+theorem legEquivRed_eq_bondModel_rc
+    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
+    (hf : IsCrossingEdge (G := G) A F.frame.red F.frame.complement g) :
+    (F.frame.legEquivRed (fun ie => η ie.1) ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
+      (F.bondModel coarseEdgeRC (η coarseEdgeRC) ⟨g, hf⟩ : Fin (A.bondDim g)) :=
+  F.factor_red_rc (fun ie => η ie.1) ⟨g, hf.1⟩ hf incidentRC0 rfl
+
+/-- **Blue leg off the `r-b` bond model.** On a blue boundary edge crossing to red,
+the blue super-site reads the leg of `η` off the `r-b` bond model. -/
+theorem legEquivBlue_eq_bondModel_rb
+    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
+    (hf : IsCrossingEdge (G := G) A F.frame.red F.frame.blue g) :
+    (F.frame.legEquivBlue (fun ie => η ie.1) ⟨g, hf.2⟩ : Fin (A.bondDim g)) =
+      (F.bondModel coarseEdgeRB (η coarseEdgeRB) ⟨g, hf⟩ : Fin (A.bondDim g)) :=
+  F.factor_blue_rb (fun ie => η ie.1) ⟨g, hf.2⟩ hf incidentRB1 rfl
+
+/-- **Blue leg off the `b-c` bond model.** On a blue boundary edge crossing to the
+complement, the blue super-site reads the leg of `η` off the `b-c` bond model. -/
+theorem legEquivBlue_eq_bondModel_bc
+    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
+    (hf : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement g) :
+    (F.frame.legEquivBlue (fun ie => η ie.1) ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
+      (F.bondModel coarseEdgeBC (η coarseEdgeBC) ⟨g, hf⟩ : Fin (A.bondDim g)) :=
+  F.factor_blue_bc (fun ie => η ie.1) ⟨g, hf.1⟩ hf incidentBC1 rfl
+
+/-- **Complement leg off the `r-c` bond model.** On a complement boundary edge
+crossing to red, the complement super-site reads the leg of `η` off the `r-c`
+bond model. -/
+theorem legEquivComplement_eq_bondModel_rc
+    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
+    (hf : IsCrossingEdge (G := G) A F.frame.red F.frame.complement g) :
+    (F.frame.legEquivComplement (fun ie => η ie.1) ⟨g, hf.2⟩ : Fin (A.bondDim g)) =
+      (F.bondModel coarseEdgeRC (η coarseEdgeRC) ⟨g, hf⟩ : Fin (A.bondDim g)) :=
+  F.factor_compl_rc (fun ie => η ie.1) ⟨g, hf.2⟩ hf incidentRC2 rfl
+
+/-- **Complement leg off the `b-c` bond model.** On a complement boundary edge
+crossing to blue, the complement super-site reads the leg of `η` off the `b-c`
+bond model. -/
+theorem legEquivComplement_eq_bondModel_bc
+    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
+    (hf : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement g) :
+    (F.frame.legEquivComplement (fun ie => η ie.1) ⟨g, hf.2⟩ : Fin (A.bondDim g)) =
+      (F.bondModel coarseEdgeBC (η coarseEdgeBC) ⟨g, hf⟩ : Fin (A.bondDim g)) :=
+  F.factor_compl_bc (fun ie => η ie.1) ⟨g, hf.2⟩ hf incidentBC2 rfl
+
+end CoherentCoarseBlockingFrame
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
@@ -353,6 +353,93 @@ theorem legEquivComplement_eq_bondModel_bc
       (F.bondModel coarseEdgeBC (η coarseEdgeBC) ⟨g, hf⟩ : Fin (A.bondDim g)) :=
   F.factor_compl_bc (fun ie => η ie.1) ⟨g, hf.2⟩ hf incidentBC2 rfl
 
+/-! ### The region boundary configs as functions of the crossing configs
+
+Assembling the per-edge read-offs with the crossing classification, each coarse
+region weight's boundary configuration is a function of the three original
+crossing configurations alone. The red boundary configuration reads each red
+boundary edge off the `r-b` bond model (if it crosses to blue) or the `r-c` bond
+model (if it crosses to complement); the classification is a genuine dichotomy
+because blue and complement are disjoint. This expresses `legEquivRed (fun ie =>
+η ie.1)` entirely through `bondModel rb (η rb)` and `bondModel rc (η rc)`, the
+form the merge collapse contracts against the original crossing edges. -/
+
+open scoped Classical in
+/-- The red boundary configuration induced by a coarse virtual configuration `η`
+is determined by the `r-b` and `r-c` bond models at `η`'s values: on a red
+boundary edge crossing to blue it reads the `r-b` model, on one crossing to the
+complement it reads the `r-c` model. Under the partition every red boundary edge
+crosses to exactly one of blue or complement. -/
+theorem legEquivRed_apply_eq (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor))
+    (b : {b : Edge G // IsRegionBoundaryEdge (G := G) F.frame.red b}) :
+    (F.frame.legEquivRed (fun ie => η ie.1) b : Fin (A.bondDim b.1)) =
+      if hb : IsCrossingEdge (G := G) A F.frame.red F.frame.blue b.1 then
+        (F.bondModel coarseEdgeRB (η coarseEdgeRB) ⟨b.1, hb⟩ : Fin (A.bondDim b.1))
+      else
+        (F.bondModel coarseEdgeRC (η coarseEdgeRC)
+          ⟨b.1, (F.frame.isCrossingEdge_red_blue_or_red_complement hP b.2).resolve_left hb⟩ :
+          Fin (A.bondDim b.1)) := by
+  by_cases hb : IsCrossingEdge (G := G) A F.frame.red F.frame.blue b.1
+  · rw [dif_pos hb]
+    have := F.legEquivRed_eq_bondModel_rb η b.1 hb
+    -- `⟨b.1, hb.1⟩ = b` as subtype elements (same edge, proof-irrelevant membership).
+    simpa using this
+  · rw [dif_neg hb]
+    have hc : IsCrossingEdge (G := G) A F.frame.red F.frame.complement b.1 :=
+      (F.frame.isCrossingEdge_red_blue_or_red_complement hP b.2).resolve_left hb
+    have := F.legEquivRed_eq_bondModel_rc η b.1 hc
+    simpa using this
+
+open scoped Classical in
+/-- The blue boundary configuration induced by `η`: on a blue boundary edge
+crossing to red it reads the `r-b` bond model, on one crossing to the complement
+it reads the `b-c` bond model. -/
+theorem legEquivBlue_apply_eq (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor))
+    (b : {b : Edge G // IsRegionBoundaryEdge (G := G) F.frame.blue b}) :
+    (F.frame.legEquivBlue (fun ie => η ie.1) b : Fin (A.bondDim b.1)) =
+      if hb : IsCrossingEdge (G := G) A F.frame.red F.frame.blue b.1 then
+        (F.bondModel coarseEdgeRB (η coarseEdgeRB) ⟨b.1, hb⟩ : Fin (A.bondDim b.1))
+      else
+        (F.bondModel coarseEdgeBC (η coarseEdgeBC)
+          ⟨b.1, (F.frame.isCrossingEdge_red_blue_or_blue_complement hP b.2).resolve_left hb⟩ :
+          Fin (A.bondDim b.1)) := by
+  by_cases hb : IsCrossingEdge (G := G) A F.frame.red F.frame.blue b.1
+  · rw [dif_pos hb]
+    have := F.legEquivBlue_eq_bondModel_rb η b.1 hb
+    simpa using this
+  · rw [dif_neg hb]
+    have hc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement b.1 :=
+      (F.frame.isCrossingEdge_red_blue_or_blue_complement hP b.2).resolve_left hb
+    have := F.legEquivBlue_eq_bondModel_bc η b.1 hc
+    simpa using this
+
+open scoped Classical in
+/-- The complement boundary configuration induced by `η`: on a complement
+boundary edge crossing to red it reads the `r-c` bond model, on one crossing to
+blue it reads the `b-c` bond model. -/
+theorem legEquivComplement_apply_eq (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor))
+    (b : {b : Edge G // IsRegionBoundaryEdge (G := G) F.frame.complement b}) :
+    (F.frame.legEquivComplement (fun ie => η ie.1) b : Fin (A.bondDim b.1)) =
+      if hb : IsCrossingEdge (G := G) A F.frame.red F.frame.complement b.1 then
+        (F.bondModel coarseEdgeRC (η coarseEdgeRC) ⟨b.1, hb⟩ : Fin (A.bondDim b.1))
+      else
+        (F.bondModel coarseEdgeBC (η coarseEdgeBC)
+          ⟨b.1, (F.frame.isCrossingEdge_red_complement_or_blue_complement hP
+            b.2).resolve_left hb⟩ :
+          Fin (A.bondDim b.1)) := by
+  by_cases hb : IsCrossingEdge (G := G) A F.frame.red F.frame.complement b.1
+  · rw [dif_pos hb]
+    have := F.legEquivComplement_eq_bondModel_rc η b.1 hb
+    simpa using this
+  · rw [dif_neg hb]
+    have hc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement b.1 :=
+      (F.frame.isCrossingEdge_red_complement_or_blue_complement hP b.2).resolve_left hb
+    have := F.legEquivComplement_eq_bondModel_bc η b.1 hc
+    simpa using this
+
 end CoherentCoarseBlockingFrame
 
 end PEPS

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
@@ -440,6 +440,46 @@ theorem legEquivComplement_apply_eq (hP : F.frame.IsPartition)
     have := F.legEquivComplement_eq_bondModel_bc η b.1 hc
     simpa using this
 
+/-! ### Single-configuration consistency
+
+For a single coarse virtual configuration `η`, the three region boundary
+configurations it induces agree on every shared crossing edge: the two super-sites
+incident to a super-edge read the same super-bond value (the one in `η`) through
+the same bond model. These are the agreement lemmas of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite2` specialized to a single `η`, the form
+the three-region merge collapse consumes when summing the three weights' product
+over one coarse configuration. -/
+
+/-- For a single `η`, the red and blue boundary configurations agree on every
+red-to-blue crossing edge. -/
+theorem legEquivRed_eq_legEquivBlue_on_rb_single
+    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
+    (hf : IsCrossingEdge (G := G) A F.frame.red F.frame.blue g) :
+    (F.frame.legEquivRed (fun ie => η ie.1) ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
+      (F.frame.legEquivBlue (fun ie => η ie.1) ⟨g, hf.2⟩ : Fin (A.bondDim g)) :=
+  F.legEquivRed_eq_legEquivBlue_on_rb (fun ie => η ie.1) (fun ie => η ie.1)
+    incidentRB0 rfl incidentRB1 rfl rfl g hf
+
+/-- For a single `η`, the red and complement boundary configurations agree on
+every red-to-complement crossing edge. -/
+theorem legEquivRed_eq_legEquivComplement_on_rc_single
+    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
+    (hf : IsCrossingEdge (G := G) A F.frame.red F.frame.complement g) :
+    (F.frame.legEquivRed (fun ie => η ie.1) ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
+      (F.frame.legEquivComplement (fun ie => η ie.1) ⟨g, hf.2⟩ : Fin (A.bondDim g)) :=
+  F.legEquivRed_eq_legEquivComplement_on_rc (fun ie => η ie.1) (fun ie => η ie.1)
+    incidentRC0 rfl incidentRC2 rfl rfl g hf
+
+/-- For a single `η`, the blue and complement boundary configurations agree on
+every blue-to-complement crossing edge. -/
+theorem legEquivBlue_eq_legEquivComplement_on_bc_single
+    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
+    (hf : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement g) :
+    (F.frame.legEquivBlue (fun ie => η ie.1) ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
+      (F.frame.legEquivComplement (fun ie => η ie.1) ⟨g, hf.2⟩ : Fin (A.bondDim g)) :=
+  F.legEquivBlue_eq_legEquivComplement_on_bc (fun ie => η ie.1) (fun ie => η ie.1)
+    incidentBC1 rfl incidentBC2 rfl rfl g hf
+
 end CoherentCoarseBlockingFrame
 
 end PEPS

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
@@ -1,0 +1,213 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite2
+import TNLean.PEPS.RegionBlock.Recovery
+
+/-!
+# The three-region merge collapse for the normal PEPS theorem
+
+The coarse three-site tensor of `TNLean.PEPS.RegionBlock.CoarseThreeSite` has its
+closed-state coefficient written, through the coherent bond models of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite2`, as a sum over coarse virtual
+configurations of a product of three original blocked-region weights
+(`stateCoeff_coarseTensor_eq_threeRegionSum`). This file collapses that triple
+sum to a constant times the original closed-state coefficient, the merge collapse
+that glues the coarse state to the original state.
+
+The route fuses the blue and complement weights into the host weight over
+`univ \ red` and then applies the landed two-block collapse
+`stateCoeff_eq_regionComplement` of `TNLean.PEPS.RegionBlock.Recovery` for the red
+region against its set complement. The constants are the interior bond products of
+the three regions, all positive under positive bond dimensions.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1205--1210 (the one-region-against-complement gluing) and
+  1449--1500 (the blocking) of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The partition hypothesis of a coarse blocking frame
+
+The merge collapse needs the three regions to partition the vertex set: the red,
+blue, and complement regions are pairwise disjoint and cover `V`. A
+`CoarseBlockingFrame` records only the three region injectivities, so the
+partition is supplied as a separate hypothesis bundle. It is the geometry of the
+source's edge blocking (arXiv:1804.04964, Section 3, the three injective regions
+of a `NormalEdgeBlockingData` partition the lattice), here detached from the
+tensor construction so the collapse reads only the partition. -/
+
+namespace CoarseBlockingFrame
+
+variable {A : Tensor G d} (F : CoarseBlockingFrame (G := G) (d := d) A)
+
+/-- **The partition of a coarse blocking frame.** The red, blue, and complement
+regions are pairwise disjoint and cover the vertex set. This is the geometry of
+the source's edge blocking (arXiv:1804.04964, Section 3, proof of Theorem 3, the
+three injective regions partition the lattice).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+structure IsPartition : Prop where
+  /-- The red and blue regions are disjoint. -/
+  red_disjoint_blue : Disjoint F.red F.blue
+  /-- The red and complement regions are disjoint. -/
+  red_disjoint_complement : Disjoint F.red F.complement
+  /-- The blue and complement regions are disjoint. -/
+  blue_disjoint_complement : Disjoint F.blue F.complement
+  /-- The three regions cover the vertex set. -/
+  cover_univ : F.red ∪ F.blue ∪ F.complement = Finset.univ
+
+namespace IsPartition
+
+variable {F}
+
+/-- The set complement of the red region is the union of the blue and complement
+regions. -/
+theorem sdiff_red (hP : F.IsPartition) :
+    Finset.univ \ F.red = F.blue ∪ F.complement := by
+  ext w
+  simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_union]
+  constructor
+  · intro hwnotred
+    have hcover : w ∈ F.red ∪ F.blue ∪ F.complement := by
+      rw [hP.cover_univ]; exact Finset.mem_univ _
+    rcases Finset.mem_union.mp hcover with hrb | hc
+    · rcases Finset.mem_union.mp hrb with hr | hbl
+      · exact absurd hr hwnotred
+      · exact Or.inl hbl
+    · exact Or.inr hc
+  · intro hbc hr
+    rcases hbc with hbl | hc
+    · exact (Finset.disjoint_left.mp hP.red_disjoint_blue) hr hbl
+    · exact (Finset.disjoint_left.mp hP.red_disjoint_complement) hr hc
+
+end IsPartition
+
+/-! ### The fused complement physical leg
+
+The two-block collapse `stateCoeff_eq_regionComplement` reads the host
+`univ \ red` through a single physical leg over `univ \ red`. The blue and
+complement super-sites carry two independent physical legs, over `blue` and over
+`complement`. Under the partition `univ \ red = blue ∪ complement`, these fuse
+into one leg over `univ \ red`. -/
+
+/-- The fused complement physical leg over `univ \ red`, read from a blue physical
+leg and a complement physical leg: a vertex outside `red` lies in `blue` (then
+read `σblue`) or, failing that, in `complement` (then read `σcompl`). -/
+noncomputable def complPhysical (hP : F.IsPartition)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) F.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) F.complement) :
+    RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.red) :=
+  fun w =>
+    if hb : w.1 ∈ F.blue then σblue ⟨w.1, hb⟩
+    else σcompl ⟨w.1, by
+      have hbc : w.1 ∈ F.blue ∪ F.complement := by
+        rw [← hP.sdiff_red]; exact w.2
+      rcases Finset.mem_union.mp hbc with hbl | hc
+      · exact absurd hbl hb
+      · exact hc⟩
+
+/-- The fused complement leg reads a blue vertex off the blue physical leg. -/
+theorem complPhysical_apply_blue (hP : F.IsPartition)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) F.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) F.complement)
+    (w : {w : V // w ∈ Finset.univ \ F.red}) (hb : w.1 ∈ F.blue) :
+    F.complPhysical hP σblue σcompl w = σblue ⟨w.1, hb⟩ := by
+  rw [complPhysical, dif_pos hb]
+
+/-- The fused complement leg reads a non-blue vertex off the complement physical
+leg. -/
+theorem complPhysical_apply_not_blue (hP : F.IsPartition)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) F.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) F.complement)
+    (w : {w : V // w ∈ Finset.univ \ F.red}) (hb : w.1 ∉ F.blue)
+    (hc : w.1 ∈ F.complement) :
+    F.complPhysical hP σblue σcompl w = σcompl ⟨w.1, hc⟩ := by
+  rw [complPhysical, dif_neg hb]
+
+/-- **The vertex-product split over `univ \ red`.** For any global virtual
+configuration `ζ`, the product of the vertex tensors over `univ \ red`, read with
+the fused blue/complement physical leg, factors as the blue product (read with
+`σblue`) times the complement product (read with `σcompl`). This is the disjoint
+decomposition `univ \ red = blue ⊔ complement` applied to the contraction. -/
+theorem prod_sdiff_red_eq_blue_mul_complement (hP : F.IsPartition)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) F.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) F.complement)
+    (ζ : VirtualConfig A) :
+    (∏ w : {w : V // w ∈ Finset.univ \ F.red},
+        A.component w.1 (fun ie => ζ ie.1) (F.complPhysical hP σblue σcompl w)) =
+      (∏ w : {w : V // w ∈ F.blue}, A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
+        ∏ w : {w : V // w ∈ F.complement},
+          A.component w.1 (fun ie => ζ ie.1) (σcompl w) := by
+  classical
+  rcases isEmpty_or_nonempty (Fin d) with hd | hd
+  · -- With no physical index, every block subtype is empty.
+    have hblue : IsEmpty {w : V // w ∈ F.blue} := ⟨fun w => hd.elim (σblue w)⟩
+    have hcompl : IsEmpty {w : V // w ∈ F.complement} := ⟨fun w => hd.elim (σcompl w)⟩
+    have hsdiff : IsEmpty {w : V // w ∈ Finset.univ \ F.red} :=
+      ⟨fun w => hd.elim (F.complPhysical hP σblue σcompl w)⟩
+    rw [Finset.prod_of_isEmpty, Finset.prod_of_isEmpty, Finset.prod_of_isEmpty, one_mul]
+  · -- A total physical leg agreeing with `σblue` on blue and `σcompl` on complement.
+    set g : V → Fin d := fun w =>
+      if hb : w ∈ F.blue then σblue ⟨w, hb⟩
+      else if hc : w ∈ F.complement then σcompl ⟨w, hc⟩
+      else Classical.arbitrary (Fin d) with hg
+    -- The fused leg on `univ \ red` agrees with `g`.
+    have hsdiff : (∏ w : {w : V // w ∈ Finset.univ \ F.red},
+          A.component w.1 (fun ie => ζ ie.1) (F.complPhysical hP σblue σcompl w)) =
+        ∏ w : {w : V // w ∈ Finset.univ \ F.red},
+          A.component w.1 (fun ie => ζ ie.1) (g w.1) := by
+      refine Finset.prod_congr rfl (fun w _ => ?_)
+      congr 1
+      by_cases hb : w.1 ∈ F.blue
+      · rw [F.complPhysical_apply_blue hP σblue σcompl w hb, hg]
+        simp only [dif_pos hb]
+      · have hbc' : w.1 ∈ F.blue ∪ F.complement := by rw [← hP.sdiff_red]; exact w.2
+        have hc : w.1 ∈ F.complement := by
+          rcases Finset.mem_union.mp hbc' with h | h
+          · exact absurd h hb
+          · exact h
+        rw [F.complPhysical_apply_not_blue hP σblue σcompl w hb hc, hg]
+        simp only [dif_neg hb, dif_pos hc]
+    -- The blue and complement subtype products read `g` on their vertices.
+    have hblue : (∏ w : {w : V // w ∈ F.blue},
+          A.component w.1 (fun ie => ζ ie.1) (σblue w)) =
+        ∏ w : {w : V // w ∈ F.blue},
+          A.component w.1 (fun ie => ζ ie.1) (g w.1) := by
+      refine Finset.prod_congr rfl (fun w _ => ?_)
+      congr 1
+      rw [hg]; simp only [dif_pos w.2]
+    have hcompl : (∏ w : {w : V // w ∈ F.complement},
+          A.component w.1 (fun ie => ζ ie.1) (σcompl w)) =
+        ∏ w : {w : V // w ∈ F.complement},
+          A.component w.1 (fun ie => ζ ie.1) (g w.1) := by
+      refine Finset.prod_congr rfl (fun w _ => ?_)
+      congr 1
+      have hb : w.1 ∉ F.blue := fun h =>
+        (Finset.disjoint_left.mp hP.blue_disjoint_complement) h w.2
+      rw [hg]; simp only [dif_neg hb, dif_pos w.2]
+    rw [hsdiff, hblue, hcompl]
+    -- Convert the three subtype products to `Finset.prod` and split the union.
+    rw [← Finset.prod_subtype (Finset.univ \ F.red) (fun x => Iff.rfl)
+        (fun w => A.component w (fun ie => ζ ie.1) (g w)),
+      ← Finset.prod_subtype F.blue (fun x => Iff.rfl)
+        (fun w => A.component w (fun ie => ζ ie.1) (g w)),
+      ← Finset.prod_subtype F.complement (fun x => Iff.rfl)
+        (fun w => A.component w (fun ie => ζ ie.1) (g w)),
+      hP.sdiff_red,
+      Finset.prod_union (Finset.disjoint_left.mpr (fun w hbl hc =>
+        (Finset.disjoint_left.mp hP.blue_disjoint_complement) hbl hc))]
+
+end CoarseBlockingFrame
+
+end PEPS
+end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1118,6 +1118,35 @@ The remaining obligations are the following.
           therefore requires a vertex-injectivity-free bond-\(f\)-paired complement
           factorization of the coefficient before the edge inversion structure
           transfers, and constructing that factorization is the remaining open step.
+
+          The two reduction tracks now meet at a single named bridge. The
+          block-frame predicate
+          \leanid{TNLean.PEPS.IsBondLocalTransferKernel} follows from the
+          virtual-pullback predicate
+          \leanid{TNLean.PEPS.RegionResonateReconcile} by reading the incident-matrix
+          form of the virtual pullback off as the incident-matrix coupling of the
+          transfer kernel
+          (\leanid{TNLean.PEPS.isBondLocalTransferKernel_of_regionResonateReconcile},
+          with its coefficient-transfer corollary
+          \leanid{TNLean.PEPS.coeffTransfer_of_regionResonateReconcile}). This bridge
+          is unconditional on top of the reconcile predicate, but the reconcile and
+          the read-off it feeds carry the single-vertex hypotheses
+          \(\text{LinearIndependent}\,(A_v)\), \(\text{LinearIndependent}\,(B_v)\) at
+          the endpoint vertex of \(f\), together with vertex injectivity of both
+          tensors, because the image-preservation root
+          \leanid{TNLean.PEPS.span_stateOpenCoeff_eq_top} --- the spanning of the
+          closed state-vector coefficients at the endpoint vertex --- is derived only
+          from \leanid{TNLean.PEPS.vertexComplementTensorInjective_of_isVertexInjective}.
+          Thus the bridge closes the bond locality precisely in the vertex-injective
+          regime, isolating the residual normal-setting content to one fact: the same
+          endpoint-vertex spanning, derived from blocked-region injectivity of the red
+          region and its complement rather than from single-vertex injectivity. The
+          endpoint vertex of \(f\) is a single vertex of a normal (region-injective,
+          not vertex-injective) tensor and need not itself be injective, so no
+          double-complement transport of the present
+          \leanid{TNLean.PEPS.range_regionBlockedTensorMap_eq_of_sameState} reaches it;
+          this endpoint-vertex spanning from blocked-region injectivity is the
+          precise remaining open step.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1217,6 +1217,39 @@ The remaining obligations are the following.
           are state-gluing combinatorics over the crossing bonds, the three-block
           extension of the existing one-region-against-complement gluing; neither
           reintroduces single-vertex spanning.
+
+          \emph{The compatibility requirement of the first obligation is now recorded.}
+          The independent per-super-site leg identifications of the plain coarse frame
+          are refined by a coherent coarse frame that fixes one bond model per coarse
+          super-edge --- an equivalence between the coarse bond and the original
+          configurations on the edges crossing between the two incident regions --- and
+          requires each super-site's leg identification to factor through these shared
+          bond models on its incident super-edges. The geometric content is that every
+          boundary edge of a region crosses to exactly one partner region, so the two
+          super-edges incident to a super-site carry exactly the two crossing bundles of
+          its region's boundary. The payoff is the shared-super-bond agreement: two
+          super-sites incident to a super-edge, fed matching super-bond values, read
+          every shared crossing edge to the same original virtual leg. This is the
+          well-posedness the state gluing needs --- the three blocked-region weights are
+          read at a single consistent assignment of the original crossing bonds. With
+          this layer in place, the residual content of both obligations is the purely
+          combinatorial three-region merge collapse: the closed-state sum over the
+          original virtual configurations refactors, through the partition of the
+          original edges into the three regions' interiors and the three crossing
+          bundles, as the boundary-coupled product of the three region weights summed
+          over the crossing bundles, with the product of the three regions' interior
+          bond dimensions as the multiplicity constant. This is the three-region port of
+          the two-block merge/fiber collapse of the landed
+          one-region-against-complement gluing; it does not reintroduce single-vertex
+          spanning and is the remaining open step of the coarse route.\footnote{Formal
+          declarations (the well-posedness layer):
+          \leanid{TNLean.PEPS.IsCrossingEdge},
+          \leanid{TNLean.PEPS.CrossingConfig},
+          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame},
+          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivRed_eq_legEquivBlue_on_rb},
+          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivRed_eq_legEquivComplement_on_rc},
+          and
+          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivBlue_eq_legEquivComplement_on_bc}.}
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1147,6 +1147,76 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.range_regionBlockedTensorMap_eq_of_sameState} reaches it;
           this endpoint-vertex spanning from blocked-region injectivity is the
           precise remaining open step.
+
+          \emph{The coarse three-site route avoids the endpoint-vertex spanning
+          entirely.} The endpoint-vertex obstruction above is an artifact of running
+          the comparison on the original single vertex at the end of the boundary
+          edge. The source never uses that vertex. After blocking, the three sites of
+          the chain are the blocks themselves, and the component family of each
+          super-site is the blocked-region weight family, injective by the blocking
+          hypothesis. Realizing this literally, the three blocks are assembled into a
+          fresh tensor on a three-vertex complete graph: the red block at one vertex,
+          the blue block at a second, the complement block at the third, with one
+          super-bond for the distinguished edge, one for the red-to-complement
+          crossings, and one for the blue-to-complement crossings, and a uniform padded
+          physical dimension carrying every region's physical configuration through a
+          fixed surjection. Each super-site's component family is the blocked-region
+          weight family reindexed by the super-site's legs and read through the padded
+          physical surjection; reindexing by a bijection and pulling back along a
+          surjection both preserve linear independence, so each super-site is injective
+          directly from the blocked-region injectivity of its block, with no
+          single-vertex hypothesis. The single-vertex three-site comparison then
+          applies to this coarse tensor verbatim: the two endpoint super-sites are
+          injective by the red and blue blocking injectivities, the middle super-site
+          is the single complement super-site, injective by the complement blocking
+          injectivity, and the proven contraction-of-injective-tensors argument
+          supplies the middle-block injectivity of the coarse chain. The coarse chain
+          is therefore edge-blocked three-site injective at its distinguished super-bond
+          with no single-vertex injectivity of the original tensor, and the proven
+          injective inserted-coefficient correspondence runs on the coarse super-bond,
+          producing, for every matrix inserted on the coarse super-bond of the first
+          coarse tensor, a matrix on the second giving the same coarse inserted
+          coefficient at every coarse physical configuration.\footnote{Formal
+          declarations:
+          \leanid{TNLean.PEPS.coarseGraph},
+          \leanid{TNLean.PEPS.CoarseBlockingFrame},
+          \leanid{TNLean.PEPS.CoarseBlockingFrame.coarseTensor},
+          \leanid{TNLean.PEPS.CoarseBlockingFrame.coarseTensor_isVertexInjective},
+          \leanid{TNLean.PEPS.CoarseBlockingFrame.coarseTensor_edgeBlockedThreeSiteInjective},
+          and \leanid{TNLean.PEPS.coarse_exists_edgeInsertedCoeff_eq}. The coarse
+          construction and the injectivity transport are unconditional on top of the
+          blocked-region injectivities, with no single-vertex spanning.}
+
+          Two obligations remain to descend the coarse super-bond correspondence to the
+          original bond locality. The first is the state gluing: the coarse state
+          coefficient must equal a positive constant times the original state
+          coefficient of the assembled physical configuration, so that the original
+          same-state hypothesis transports to the coarse tensors. The coarse state
+          coefficient is the sum over the three super-bonds of the product of the three
+          blocked-region weights, the three-block analogue of the two-block region
+          gluing already formalized for one region against its complement. This gluing
+          carries a compatibility requirement the present coarse frame does not yet
+          record: each super-bond is incident to two super-sites, so its value is read
+          by both incident per-site leg identifications, and those two identifications
+          must send the shared super-bond value to the same original crossing-bond
+          value. The distinguished super-bond is incident to the red and blue
+          super-sites, the red-to-complement super-bond to the red and complement
+          super-sites, the blue-to-complement super-bond to the blue and complement
+          super-sites; for each, the two incident leg identifications must agree on the
+          shared crossing bonds. Without this agreement the three blocked-region weights
+          are not glued along their shared crossing edges and the coarse state
+          coefficient does not factor through the original state coefficient. The second
+          obligation is the descent identity: the coarse inserted coefficient on the
+          distinguished super-bond must equal a positive constant times the original
+          region-inserted coefficient of the same matrix, the three-block analogue of
+          the landed identity reading the region-inserted coefficient of the identity as
+          a constant times the state coefficient. With the super-bond identified with
+          the original distinguished bond, this descent turns the coarse super-bond
+          correspondence into the bond locality of the original transfer kernel and
+          instantiates the per-edge gauge from the source hypotheses. Both obligations
+          are state-gluing combinatorics over the crossing bonds, the three-block
+          extension of the existing one-region-against-complement gluing; neither
+          reintroduces single-vertex spanning.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1231,25 +1231,68 @@ The remaining obligations are the following.
           super-sites incident to a super-edge, fed matching super-bond values, read
           every shared crossing edge to the same original virtual leg. This is the
           well-posedness the state gluing needs --- the three blocked-region weights are
-          read at a single consistent assignment of the original crossing bonds. With
-          this layer in place, the residual content of both obligations is the purely
-          combinatorial three-region merge collapse: the closed-state sum over the
-          original virtual configurations refactors, through the partition of the
-          original edges into the three regions' interiors and the three crossing
-          bundles, as the boundary-coupled product of the three region weights summed
-          over the crossing bundles, with the product of the three regions' interior
-          bond dimensions as the multiplicity constant. This is the three-region port of
-          the two-block merge/fiber collapse of the landed
-          one-region-against-complement gluing; it does not reintroduce single-vertex
-          spanning and is the remaining open step of the coarse route.\footnote{Formal
-          declarations (the well-posedness layer):
+          read at a single consistent assignment of the original crossing bonds.
+
+          \emph{The well-posedness layer is now fully reduced to the per-edge bond
+          models.} A partition hypothesis records that the three regions are pairwise
+          disjoint and cover the vertex set, the geometry of the source edge blocking,
+          detached from the tensor construction; from it the three regions form a
+          three-block geometry, unlocking the landed three-block factorizations (the
+          fused complement physical leg and the host vertex-product split over the
+          complement of the red region). The partition gives the crossing
+          classification: every boundary edge of a region crosses to exactly one
+          partner region, so a red boundary edge is a red-to-blue or a red-to-complement
+          crossing edge, and likewise at the blue and complement super-sites. Combined
+          with the factoring fields, this expresses each super-site's leg identification
+          of a coarse configuration entirely through the two bond models on its incident
+          super-edges: the red boundary configuration reads each red boundary edge off
+          the red-to-blue bond model (if it crosses to blue) or the red-to-complement
+          bond model (if it crosses to the complement), and symmetrically at the blue
+          and complement super-sites. For a single coarse configuration the three
+          induced boundary configurations therefore agree on every shared crossing
+          edge, the single-configuration form the merge collapse contracts against the
+          original crossing edges.\footnote{Formal declarations (the well-posedness
+          layer):
           \leanid{TNLean.PEPS.IsCrossingEdge},
           \leanid{TNLean.PEPS.CrossingConfig},
           \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame},
-          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivRed_eq_legEquivBlue_on_rb},
-          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivRed_eq_legEquivComplement_on_rc},
+          \leanid{TNLean.PEPS.CoarseBlockingFrame.IsPartition},
+          \leanid{TNLean.PEPS.CoarseBlockingFrame.toThreeBlockGeometry},
+          \leanid{TNLean.PEPS.CoarseBlockingFrame.isCrossingEdge_red_blue_or_red_complement},
+          \leanid{TNLean.PEPS.CoarseBlockingFrame.isCrossingEdge_red_blue_or_blue_complement},
+          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivRed_apply_eq},
+          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivBlue_apply_eq},
+          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivComplement_apply_eq},
           and
-          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivBlue_eq_legEquivComplement_on_bc}.}
+          \leanid{TNLean.PEPS.CoherentCoarseBlockingFrame.legEquivRed_eq_legEquivBlue_on_rb_single}.}
+
+          With this layer in place, the residual content of both obligations is the
+          purely combinatorial three-region merge collapse: the triple sum over coarse
+          virtual configurations of the boundary-coupled product of the three region
+          weights refactors, through the partition of the original edges into the three
+          regions' interiors and the three crossing bundles, as the product of the three
+          regions' interior bond dimensions times the original closed-state coefficient
+          of the assembled physical configuration. The single remaining mathematical
+          step is the \emph{global fiber-collapse bijection}: the bond models give a
+          bijection between the coarse virtual configurations and the original
+          inter-region crossing configurations, under which the triple sum's
+          pairwise-agreement constraints become the boundary-agreement of an original
+          configuration triple, and merging that triple into one global configuration
+          (region-incident edges read from the region's own configuration, the rest
+          free) collapses the sum to the closed-state coefficient with the three
+          interior bond products as multiplicity. This is the three-region extension of
+          the two-block merge/fiber collapse
+          \leanid{TNLean.PEPS.stateCoeff_eq_regionComplement} of the landed
+          one-region-against-complement gluing --- a fiber count over the
+          three regions' interiors threading the per-edge bond models --- and is the
+          remaining open step of the coarse route. It does not reintroduce single-vertex
+          spanning. Once it is supplied, the state transport (constants depend only on
+          the shared regions and bond dimensions), the inserted-coefficient descent (the
+          same collapse with a matrix carried on the coarse red-to-blue super-bond by its
+          bond model), and the kernel closure (dividing the positive interior bond
+          products and applying \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} in both
+          directions to instantiate \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge})
+          follow as assembly.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.


### PR DESCRIPTION
## What

The **coarse three-site tensor route** to the V=W kernel of the Normal PEPS FT (#1373) —
the source-faithful mechanism that structurally bypasses the endpoint-vertex spanning
obstruction every prior reduction terminated at. Three new files
(`CoarseThreeSite{,2,3}.lean`) + the track bridge (`BondLocalFromReconcile.lean`); all
sorry-free, axiom-clean; full root build green (8,830 jobs).

## The route (and why it works where the vertex frame could not)

After blocking, the source's three-site chain's sites ARE the blocks; the single endpoint
vertex never appears. This PR builds that chain as an honest `Tensor` on `K₃` with a padded
uniform physical dimension:

- **`CoarseBlockingFrame.coarseTensor`** — components = blocked-region weights composed
  with the projection; coarse bond dims: red–blue = `bondDim e` exactly (the verified
  single-crossing geometry), the others = crossing products.
- **`coarseTensor_isVertexInjective`** — coarse vertex injectivity from the THREE block
  injectivities ONLY (no single-vertex hypothesis anywhere); hence
  `EdgeBlockedThreeSiteInjective` at the coarse bond.
- **`coarse_exists_edgeInsertedCoeff_eq`** — the already-proven edge FT consumed verbatim
  at the coarse red–blue bond.
- **`CoherentCoarseBlockingFrame`** — the shared-bond-model refinement (one equivalence per
  super-edge + factoring fields) with the agreement lemmas making the state gluing
  well-posed; the gluing entry point `stateCoeff_coarseTensor_eq_threeRegionSum`.
- **The dictionary layer** (CoarseThreeSite3): the partition bridge to `ThreeBlockGeometry`
  (unlocking the landed fusion machinery), the crossing classification, the six bond-model
  read-offs, and the single-configuration consistency lemmas.
- `isBondLocalTransferKernel_of_regionResonateReconcile` — the bridge between the two
  historical reduction tracks.

## Remaining (documented)

One isolated combinatorial theorem: the **global fiber-collapse bijection** (the
three-region extension of the proven `stateCoeff_eq_regionComplement`), after which the
SameState transport, the descent, and the kernel closure are assembly. Recorded precisely
in the route note. No blueprint tags flipped (faithfulness rule).

Refs #1373. CI `blueprint-and-prose`/`track`/`claude-review-*` failures are non-blocking
automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds sorry-free formal PEPS proof scaffolding and documentation only; no runtime, auth, or data-path changes. Residual mathematical gaps are explicitly scoped in the route note rather than claimed closed.
> 
> **Overview**
> Adds the **coarse three-site route** toward the normal PEPS fundamental theorem (Section 3): four new Lean modules plus root imports, with a large update to `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
> 
> **`BondLocalFromReconcile.lean`** names the bridge between the two historical tracks: `RegionResonateReconcile` implies `IsBondLocalTransferKernel` and region coefficient transfer via the existing read-off, explicitly only in the **vertex-injective** regime (general normal setting still needs endpoint spanning from blocked-region injectivity).
> 
> **`CoarseThreeSite.lean`** builds red/blue/complement blocks as a `Tensor` on `K₃` (`coarseGraph`, padded `coarseDim`), proves super-site injectivity from **region-blocked** injectivity only, and applies the proven injective edge machinery via `coarse_exists_edgeInsertedCoeff_eq`.
> 
> **`CoarseThreeSite2.lean`** introduces `CoherentCoarseBlockingFrame` (shared `bondModel` per super-edge + factoring fields), crossing-edge vocabulary, shared-super-bond agreement lemmas, and rewrites the coarse closed state as a triple sum of blocked-region weights (`stateCoeff_coarseTensor_eq_threeRegionSum`).
> 
> **`CoarseThreeSite3.lean`** adds partition/`ThreeBlockGeometry` packaging, crossing classification on region boundaries, bond-model read-offs (`legEquiv*_apply_eq`), and single-`η` consistency lemmas—the dictionary layer before the **global fiber-collapse** merge (still documented as the remaining combinatorial step).
> 
> The route note now documents how the coarse path bypasses single-vertex spanning, what is proved vs. what remains (state transport, descent, kernel closure after fiber collapse).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2db86d33de0d557da75e1ee08e89659e0d1a5047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->