### PR TITLE
feat(MPS/MPDO): area-law saturation telescopes to a constant block entropy

### DIFF
--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -463,6 +463,35 @@ theorem pureBlockEntropy_empty (A : MPSTensor d D) (N : ℕ)
   rw [pureBlockEntropy_complement A N 0 (Nat.zero_le N)]
   exact pureBlockEntropy_full A N htr
 
+/-- **Saturation telescopes.** If `A` saturates the area law then all block
+entropies in the range `1 ≤ L ≤ ⌊N/2⌋` coincide: the consecutive equalities
+`S_L^{(N)} = S_{L+1}^{(N)}` of the definition chain into `S_L^{(N)} = S_{L'}^{(N)}`
+for any two block sizes `L, L'` in the range.
+
+Source: arXiv:1606.00608, Definition 3.13 (line 600): the saturation condition is
+written as the equality chain `S_1^{(N)} = S_2^{(N)} = ⋯ = S_{N/2}^{(N)}`. -/
+theorem pureBlockEntropy_eq_of_isSAL (A : MPSTensor d D) (hSAL : IsSAL A)
+    {N L L' : ℕ} (hL1 : 1 ≤ L) (hLN : L ≤ N / 2) (hL'1 : 1 ≤ L') (hL'N : L' ≤ N / 2) :
+    pureBlockEntropy A N L (hLN.trans (Nat.div_le_self N 2)) =
+      pureBlockEntropy A N L' (hL'N.trans (Nat.div_le_self N 2)) := by
+  -- Climbing `k` steps from a block size `m` stays an equality while `m + k ≤ ⌊N/2⌋`.
+  have climb : ∀ k m : ℕ, 1 ≤ m → ∀ h : m + k ≤ N / 2,
+      pureBlockEntropy A N m
+          ((Nat.le_add_right m k).trans (h.trans (Nat.div_le_self N 2)))
+        = pureBlockEntropy A N (m + k) (h.trans (Nat.div_le_self N 2)) := by
+    intro k
+    induction k with
+    | zero => intro m _ _; rfl
+    | succ k ih =>
+      intro m hm1 h
+      have hmk : m + k < N / 2 := by omega
+      exact (ih m hm1 (le_of_lt hmk)).trans (hSAL N (m + k) (by omega) hmk)
+  rcases le_total L L' with hle | hle
+  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hle
+    exact climb k L hL1 hL'N
+  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hle
+    exact (climb k L' hL'1 hLN).symm
+
 end MPSTensor
 
 /-- **Pure-state mutual-information area-law bound.** For the purification MPDO of

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3564,6 +3564,27 @@ the elementary trace-power identity for diagonal matrices.
     system vanishes for a pure state (Lemma~\ref{lem:pure_entropy_full}).
 \end{proof}
 
+\begin{lemma}[Saturation telescopes to a constant block entropy]
+    \label{lem:pure_sal_const}
+    \lean{MPSTensor.pureBlockEntropy_eq_of_isSAL}
+    \leanok
+    \uses{def:pure_sal}
+    If an MPS tensor $A$ saturates the area law, then all block entropies in the
+    range $1\le L\le\lfloor N/2\rfloor$ coincide:
+    \[
+        S_L^{(N)}(A) = S_{L'}^{(N)}(A)
+        \qquad
+        \text{for all } 1\le L, L'\le \lfloor N/2\rfloor .
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:pure_sal}
+    The defining condition supplies the single-step equalities
+    $S_m^{(N)}(A) = S_{m+1}^{(N)}(A)$ for $1\le m<\lfloor N/2\rfloor$. Climbing one
+    step at a time from the smaller of $L$ and $L'$ up to the larger composes these
+    into the stated equality.
+\end{proof}
+
 \begin{lemma}[Pure-state mutual information is twice the block entropy]
     \label{lem:mutual_info_doubled}
     \lean{mutualInfoChain_doubledTensor}


### PR DESCRIPTION
## Summary

The pure-state saturation-of-the-area-law predicate `MPSTensor.IsSAL` (Definition 3.13 of arXiv:1606.00608) is stated as the chain of *consecutive* equalities $S_L^{(N)} = S_{L+1}^{(N)}$ of the pure-state block entropies, for $1 \le L < \lfloor N/2 \rfloor$. The paper writes the saturation condition as the full equality chain $S_1^{(N)} = S_2^{(N)} = \cdots = S_{N/2}^{(N)}$.

This PR adds `pureBlockEntropy_eq_of_isSAL`, which realizes that chain: under `IsSAL`, any two block entropies in the range $1 \le L, L' \le \lfloor N/2 \rfloor$ are equal. The proof climbs one step at a time from the smaller block size to the larger (a gap induction over the consecutive SAL equalities). This is the first consequence proved of the `IsSAL` predicate, which until now was only referenced in docstrings.

## Faithfulness

Pure logical consequence of the source definition (Def 3.13's equality chain). No new hypotheses beyond the source; no `sorry`/`axiom`.

## Blueprint

Adds `lem:pure_sal_const` (`\leanok`), `\uses{def:pure_sal}`.

## Verification

- `lake build TNLean.MPS.MPDO.PureAreaLaw` succeeds (no new warnings).
- `lake exe lint-style` clean for the touched file.
- No `sorry`/`admit`/`axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, local formalization plus blueprint sync; no auth, IO, or changes to the `IsSAL` definition itself.
> 
> **Overview**
> Adds **`MPSTensor.pureBlockEntropy_eq_of_isSAL`**, the first proved consequence of pure-state **`IsSAL`**: consecutive step equalities from Def. 3.13 telescope so **all** block entropies with \(1 \le L, L' \le \lfloor N/2\rfloor\) agree.
> 
> The Lean proof uses a **`climb`** helper (induction on the gap between block sizes) and **`hSAL`** at each step; the blueprint gains **`lem:pure_sal_const`** (`\leanok`, `\uses{def:pure_sal}`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e79324e03ca686e0b9879aa57b51994edcac4fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->