### PR TITLE
ci(lint-style): exempt PEPS combining-tilde docstrings to restore the style gate

### DIFF
--- a/scripts/nolints-style.txt
+++ b/scripts/nolints-style.txt
@@ -14,3 +14,12 @@ TNLean/MPS/MPDO/VerticalCF.lean : line 1 : ERR_TWS : This line ends with some wh
 TNLean/MPS/MPDO/RFP.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
 TNLean/MPS/MPDO/PRFP.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
 TNLean/Algebra/LinearMapAux.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
+
+-- ERR_UNICODE: the combining tilde U+0303 ("B" with a tilde) appears in the
+-- docstrings of three PEPS files, matching the modified-tensor notation of the
+-- source paper arXiv:1804.04964. It is not on the Mathlib text linter allowlist.
+-- Exempted here to keep the style gate green; replace with allowlist-safe prose in
+-- a follow-up PEPS docstring cleanup.
+TNLean/PEPS/NormalSquareTIAbsorption.lean : line 1 : ERR_UNICODE : This line contains a unicode character that is not on the allowlist '̃' (U+0303). For adding new symbols see `Mathlib.Linter.TextBased.UnicodeLinter.othersInMathlib`.
+TNLean/PEPS/RegionComplementComparison.lean : line 1 : ERR_UNICODE : This line contains a unicode character that is not on the allowlist '̃' (U+0303). For adding new symbols see `Mathlib.Linter.TextBased.UnicodeLinter.othersInMathlib`.
+TNLean/PEPS/NormalSquareFundamentalTheorem.lean : line 1 : ERR_UNICODE : This line contains a unicode character that is not on the allowlist '̃' (U+0303). For adding new symbols see `Mathlib.Linter.TextBased.UnicodeLinter.othersInMathlib`.


### PR DESCRIPTION
## Problem

The `build` gate on `main` is currently **red**. The only hard failure is `lake exe lint-style`:

```
error: found 28 new style error(s)! Try `lake exe lint-style --fix` to apply automatic fixes.
```

All 28 are `ERR_UNICODE` for the combining tilde **U+0303** (the `B`-with-tilde modified-tensor notation of arXiv:1804.04964), in the docstrings of three PEPS files merged earlier today:

- `TNLean/PEPS/RegionComplementComparison.lean` (13)
- `TNLean/PEPS/NormalSquareTIAbsorption.lean` (9)
- `TNLean/PEPS/NormalSquareFundamentalTheorem.lean` (6)

The character is not on the Mathlib text-linter allowlist, which lives in the Mathlib source (`Mathlib.Linter.TextBased.UnicodeLinter`) and cannot be extended from this repository. Compilation itself passes — this is purely the style gate.

## Fix

Add three entries to `scripts/nolints-style.txt` (the repository's designated exception mechanism, per its own header comment). The linter matches exceptions by **path and character, ignoring line number** (`TextBased.compare`), so one entry per file covers every occurrence. The PEPS docstrings are left untouched; an allowlist-safe prose rewrite is deferred to a follow-up PEPS cleanup.

## Verification

`lake exe lint-style` exits `0` with no errors after this change.

## Note

This unblocks every open PR from a green `build` (the whole-repo lint runs on each).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only exception list changes with no runtime, auth, or mathematical proof logic modified.
> 
> **Overview**
> Restores a green **`lake exe lint-style`** / `build` gate on `main` by recording three **`ERR_UNICODE`** exceptions in `scripts/nolints-style.txt` for PEPS docstrings that use combining tilde **U+0303** (modified-tensor notation from arXiv:1804.04964).
> 
> The new block documents why the character is exempted and that a follow-up should rewrite those docstrings with allowlist-safe prose. **No Lean sources are edited**—only the repository’s existing style-exception list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1737045ff307c29a0402a8becfcee21333af6a77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->