### PR TITLE
doc(parent): record boundary comparison status

### DIFF
--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -263,7 +263,10 @@ restrictions:
 \]
 The source does not display this equality. It is the current remaining
 comparison in
-\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}. Taking
+\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}.\footnote{Formal
+declaration:
+\leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}
+in \doclink{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping}.} Taking
 first-letter restrictions gives, for every physical letter \(j\),
 \[
   Y_M(\tau^+_\eta(\mu))A^j
@@ -288,12 +291,32 @@ isolated left-multiplied family
   A^\alpha
   \left(A^\mu A^jX A^\sigma\right).
 \]
+The converse implication needed by the formal proof is also recorded: if this
+left-multiplied family holds for all \(\eta,j,\alpha,\sigma\), then the
+restriction comparison follows.\footnote{Formal declaration:
+\leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap_left_words}
+in \doclink{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping}.}
 Equivalently, after block-injective cancellation this yields, for every word
 \(\sigma\) of length \(L_0\),
 \[
   Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
   =
   A^\mu A^jX A^\sigma .
+\]
+The same comparison gives the auxiliary boundary conditions used later in the
+boundary-closing argument: for every \(j\) and \(\sigma\), there are
+\(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) satisfying, for every
+complementary position \(k\),
+\[
+  \rho^+_{j,\sigma}(k+L_0)=\mu_k,
+  \qquad
+  \rho^-_{j,\sigma}(k+1)=\mu_k,
+\]
+and
+\[
+  Y_M(\rho^+_{j,\sigma})A^jA^\sigma
+  =
+  Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
 \]
 Thus the older right-multiplied identity is no longer the residual formal
 statement; it follows from the comparison of the two cyclic restrictions and


### PR DESCRIPTION
## Summary

This PR records the current boundary-closing status in the CPGSV21 normal range-reduction gap note. The remaining unproved statement is the restriction comparison

\[
  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
  =
  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
\]

It also states explicitly that the subsequent coordinate comparisons

\[
  Y_M(\tau^+_\eta(\mu))A^j
  =
  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j
\]

and

\[
  A^\alpha
  \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
  =
  A^\alpha
  \left(A^\mu A^jX A^\sigma\right)
\]

are consequences of that comparison, not separate statements displayed in CPGSV21. This keeps the paper-gap note aligned with the current Lean reductions and with the source paragraph at lines 2078--2079.

Refs #2405.

## Checks

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

No Lean or blueprint declaration changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a LaTeX paper-gap note; no Lean or runtime code modified.
> 
> **Overview**
> The CPGSV21 normal range-reduction **paper-gap note** (`cpgsv21_normal_range_reduction.tex`) is updated so the boundary-closing narrative matches the current Lean formalization.
> 
> The open **restriction comparison** (issue #2405) is now tied to **`MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap`** in `BoundaryClosingStripping`. The note adds that the **converse** used in the proof—left-multiplied word identities imply that comparison—is **`closure_property_boundary_restrictions_eq_of_groundSpaceMap_left_words`**.
> 
> It also documents how that comparison yields the **auxiliary boundary words** \(\rho^+_{j,\sigma}\), \(\rho^-_{j,\sigma}\) and their \(Y_M/Y_{M+1-L_0}\) identity, clarifying that the older right-multiplied statement is a **derived** consequence, not the primary residual gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44074a0985a439580d592ee50326a721f12e5ea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->