### PR TITLE
feat(MPS/MPDO): area-law saturation telescopes to a constant mutual information

### DIFF
--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -470,6 +470,37 @@ def IsSAL (M : MPOTensor d D) : Prop :=
       mutualInfoChain M N L (Nat.le_of_lt (hL.trans_le (Nat.div_le_self N 2))) (hMpdo N)
         = mutualInfoChain M N (L + 1) (hL.trans_le (Nat.div_le_self N 2)) (hMpdo N)
 
+/-- **Saturation telescopes.** If `M` verifies saturation of the area law then all
+mutual informations in the range `1 ≤ L ≤ ⌊N/2⌋` coincide: the consecutive
+equalities `I_L = I_{L+1}` of the definition chain into `I_L = I_{L'}` for any two
+block sizes `L, L'` in the range.
+
+Source: arXiv:1606.00608, Definition 4.6 (line 811): the saturation condition is
+written as the equality chain `I_1 = I_2 = ⋯ = I_{⌊N/2⌋}`. -/
+theorem mutualInfoChain_eq_of_isSAL (M : MPOTensor d D) (hSAL : IsSAL M)
+    {N L L' : ℕ} (hL1 : 1 ≤ L) (hLN : L ≤ N / 2) (hL'1 : 1 ≤ L') (hL'N : L' ≤ N / 2)
+    (hM : (mpo M N).PosSemidef) :
+    mutualInfoChain M N L (hLN.trans (Nat.div_le_self N 2)) hM
+      = mutualInfoChain M N L' (hL'N.trans (Nat.div_le_self N 2)) hM := by
+  obtain ⟨hMpdo, -, hstep⟩ := hSAL
+  -- Climbing `k` steps from a block size `m` stays an equality while `m + k ≤ ⌊N/2⌋`.
+  have climb : ∀ k m : ℕ, 1 ≤ m → ∀ h : m + k ≤ N / 2,
+      mutualInfoChain M N m
+          ((Nat.le_add_right m k).trans (h.trans (Nat.div_le_self N 2))) hM
+        = mutualInfoChain M N (m + k) (h.trans (Nat.div_le_self N 2)) hM := by
+    intro k
+    induction k with
+    | zero => intro m _ _; rfl
+    | succ k ih =>
+      intro m hm1 h
+      have hmk : m + k < N / 2 := by omega
+      exact (ih m hm1 (le_of_lt hmk)).trans (hstep N (m + k) (by omega) hmk)
+  rcases le_total L L' with hle | hle
+  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hle
+    exact climb k L hL1 hL'N
+  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hle
+    exact (climb k L' hL'1 hLN).symm
+
 end MPOTensor
 
 /-! ## Pure-state analogue -/

--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -3201,6 +3201,26 @@ the elementary trace-power identity for diagonal matrices.
     This is \cite[Definition~4.6, line~811]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{lemma}[Saturation telescopes to a constant mutual information]
+    \label{lem:sal_const}
+    \lean{MPOTensor.mutualInfoChain_eq_of_isSAL}
+    \leanok
+    \uses{def:is_sal}
+    If an MPO tensor $M$ saturates the area law, then all mutual informations in
+    the range $1\le L\le\lfloor N/2\rfloor$ coincide:
+    \[
+        I_L = I_{L'}
+        \qquad
+        \text{for all } 1\le L, L'\le \lfloor N/2\rfloor .
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:is_sal}
+    The defining condition supplies the single-step equalities $I_m = I_{m+1}$ for
+    $1\le m<\lfloor N/2\rfloor$. Climbing one step at a time from the smaller of $L$
+    and $L'$ up to the larger composes these into the stated equality.
+\end{proof}
+
 \begin{proposition}[Monotonicity of the mutual information]
     \label{prop:mutual_info_monotone}
     \lean{mutualInfoChain_monotone}


### PR DESCRIPTION
## Summary

The mixed-state saturation-of-the-area-law predicate `MPOTensor.IsSAL` (Definition 4.6 of arXiv:1606.00608) is stated as the chain of *consecutive* equalities $I_L = I_{L+1}$ of the mutual information, for $1 \le L < \lfloor N/2 \rfloor$. The paper writes the saturation condition as the full chain $I_1 = I_2 = \cdots = I_{\lfloor N/2 \rfloor}$.

This PR adds `mutualInfoChain_eq_of_isSAL`: under `IsSAL`, any two mutual informations in the range $1 \le L, L' \le \lfloor N/2 \rfloor$ are equal. The proof climbs one step at a time from the smaller block size to the larger (a gap induction over the consecutive SAL equalities). It is the mixed-state counterpart of the pure-state `pureBlockEntropy_eq_of_isSAL` (PR #2581), and the first consequence proved of the mixed `IsSAL` predicate.

## Faithfulness

Pure logical consequence of the source definition (Def 4.6's equality chain). No new hypotheses beyond the source; no `sorry`/`axiom`.

## Blueprint

Adds `lem:sal_const` (`\leanok`), `\uses{def:is_sal}`.

## Verification

- `lake build TNLean.MPS.MPDO.AreaLaw` succeeds (no new warnings).
- `lake exe lint-style` clean.
- No `sorry`/`admit`/`axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, self-contained formal lemma and blueprint sync; no runtime, security, or data-path changes.
> 
> **Overview**
> Adds **`mutualInfoChain_eq_of_isSAL`**, showing that mixed-state **`IsSAL`** (consecutive equalities \(I_L = I_{L+1}\)) implies **any two** mutual informations \(I_L = I_{L'}\) for \(1 \le L, L' \le \lfloor N/2\rfloor\), via a short induction that walks from the smaller block size to the larger. This is the first proved consequence of the mixed **`IsSAL`** predicate and mirrors the paper’s full constant chain (Def. 4.6).
> 
> The blueprint gains **`lem:sal_const`** (`\leanok`), linked to the Lean theorem and **`def:is_sal`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2fdc1c2fdcdfecd304f13706553c03a8456c403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->