### PR TITLE
feat(parent): record local block decomposition

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -23,37 +23,6 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-private theorem exists_sum_mem_of_mem_iSup_fin
-    {ι V : Type*} [Fintype ι]
-    [AddCommMonoid V] [Module ℂ V]
-    (p : ι → Submodule ℂ V) {v : V}
-    (hv : v ∈ ⨆ i, p i) :
-    ∃ x : ι → V, (∀ i, x i ∈ p i) ∧ v = ∑ i, x i := by
-  classical
-  refine Submodule.iSup_induction (p := p) (x := v) hv ?_ ?_ ?_
-  · intro i y hy
-    refine ⟨fun k => if k = i then y else 0, ?_, ?_⟩
-    · intro k
-      by_cases h : k = i
-      · subst k
-        simpa using hy
-      · simp [h]
-    · rw [Finset.sum_eq_single i]
-      · simp
-      · intro k _ hk
-        simp [hk]
-      · intro hi
-        exact (hi (Finset.mem_univ i)).elim
-  · refine ⟨fun _ => 0, ?_, by simp⟩
-    intro i
-    exact Submodule.zero_mem _
-  · intro y z hy hz
-    rcases hy with ⟨fy, hfy, rfl⟩
-    rcases hz with ⟨fz, hfz, rfl⟩
-    refine ⟨fun i => fy i + fz i, ?_, by simp [Finset.sum_add_distrib]⟩
-    intro i
-    exact Submodule.add_mem _ (hfy i) (hfz i)
-
 /-- The normalized BNT block-separation hypotheses imply that the periodic chain
 space of a block-diagonal tensor lies in the linear sum of the block local
 spaces.
@@ -235,7 +204,9 @@ Let
 \[
   B=\bigoplus_j\mu_jA_j.
 \]
-Under the finite Condition C1 hypotheses, every
+Assume the blocks are irreducible, left-canonical, normalized in self-overlap,
+pairwise not gauge-phase equivalent, unital, and injective at a common positive
+length. Then every
 \(\psi\in\mathcal G_{N,L}(B)\) has a unique decomposition
 \[
   \psi=\sum_j\psi_j,\qquad \psi_j\in G_N(A_j).

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -23,6 +23,37 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+private theorem exists_sum_mem_of_mem_iSup_fin
+    {ι V : Type*} [Fintype ι]
+    [AddCommMonoid V] [Module ℂ V]
+    (p : ι → Submodule ℂ V) {v : V}
+    (hv : v ∈ ⨆ i, p i) :
+    ∃ x : ι → V, (∀ i, x i ∈ p i) ∧ v = ∑ i, x i := by
+  classical
+  refine Submodule.iSup_induction (p := p) (x := v) hv ?_ ?_ ?_
+  · intro i y hy
+    refine ⟨fun k => if k = i then y else 0, ?_, ?_⟩
+    · intro k
+      by_cases h : k = i
+      · subst k
+        simpa using hy
+      · simp [h]
+    · rw [Finset.sum_eq_single i]
+      · simp
+      · intro k _ hk
+        simp [hk]
+      · intro hi
+        exact (hi (Finset.mem_univ i)).elim
+  · refine ⟨fun _ => 0, ?_, by simp⟩
+    intro i
+    exact Submodule.zero_mem _
+  · intro y z hy hz
+    rcases hy with ⟨fy, hfy, rfl⟩
+    rcases hz with ⟨fz, hfz, rfl⟩
+    refine ⟨fun i => fy i + fz i, ?_, by simp [Finset.sum_add_distrib]⟩
+    intro i
+    exact Submodule.add_mem _ (hfy i) (hfz i)
+
 /-- The normalized BNT block-separation hypotheses imply that the periodic chain
 space of a block-diagonal tensor lies in the linear sum of the block local
 spaces.
@@ -196,6 +227,62 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_
         μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
   · exact groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
       A hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital (by omega)
+
+/-- Open-boundary block decomposition for vectors satisfying the block-diagonal
+periodic constraints.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j.
+\]
+Under the finite Condition C1 hypotheses, every
+\(\psi\in\mathcal G_{N,L}(B)\) has a unique decomposition
+\[
+  \psi=\sum_j\psi_j,\qquad \psi_j\in G_N(A_j).
+\]
+This is still an open-boundary decomposition. The remaining PGVWC07 boundary
+step is to prove \(\psi_j\in\mathcal G_{N,L}(A_j)\). -/
+theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N) :
+    ∃ φ : (j : Fin r) → NSiteSpace d N,
+      (∀ j, φ j ∈ groundSpace (A j) N) ∧
+        ψ = ∑ j, φ j ∧
+          ∀ φ' : (j : Fin r) → NSiteSpace d N,
+            (∀ j, φ' j ∈ groundSpace (A j) N) →
+              ψ = ∑ j, φ' j → φ' = φ := by
+  classical
+  obtain ⟨hLe, hIndep⟩ :=
+    chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+  obtain ⟨φ, hφ, hψφ⟩ :=
+    exists_sum_mem_of_mem_iSup_fin (fun j : Fin r => groundSpace (A j) N) (hLe hψ)
+  refine ⟨φ, hφ, hψφ, ?_⟩
+  intro φ' hφ' hψφ'
+  apply funext
+  rw [iSupIndep_iff_finset_sum_eq_zero_imp_eq_zero] at hIndep
+  intro j
+  have hsum : ∑ i, (φ' i - φ i) = 0 := by
+    rw [Finset.sum_sub_distrib, ← hψφ', ← hψφ, sub_self]
+  have hmem : ∀ i : Fin r, i ∈ Finset.univ → φ' i - φ i ∈ groundSpace (A i) N := by
+    intro i _
+    exact Submodule.sub_mem _ (hφ' i) (hφ i)
+  have hzero := hIndep Finset.univ (fun i => φ' i - φ i) hmem hsum j (Finset.mem_univ j)
+  exact sub_eq_zero.mp hzero
 
 /-- The current normalized BNT formalization gives two inclusions for the
 block-diagonal periodic chain space.

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -211,8 +211,9 @@ length. Then every
 \[
   \psi=\sum_j\psi_j,\qquad \psi_j\in G_N(A_j).
 \]
-This is still an open-boundary decomposition. The remaining PGVWC07 boundary
-step is to prove \(\psi_j\in\mathcal G_{N,L}(A_j)\). -/
+This is still an open-boundary decomposition. The remaining boundary step in
+arXiv:quant-ph/0608197, Theorem 12 is to prove
+\(\psi_j\in\mathcal G_{N,L}(A_j)\). -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
@@ -56,7 +56,7 @@ theorem iSup_chainGroundSpace_block_le_toTensorFromBlocks
   exact iSup_le fun j =>
     chainGroundSpace_block_le_toTensorFromBlocks μ A (hμ j) hN hLN
 
-/-- Boundary-closing capstone for the block-diagonal periodic chain.
+/-- Boundary-closing equality for the block-diagonal periodic chain.
 
 Let \(B=\bigoplus_j\mu_jA_j\). If closing the periodic boundary with
 block-diagonal boundary conditions gives

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -25,7 +25,9 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-private theorem exists_sum_mem_of_mem_iSup_fin
+/-- A vector in the linear sum of finitely many subspaces can be written as a
+sum of vectors from those subspaces. -/
+theorem exists_sum_mem_of_mem_iSup_fin
     {ι V : Type*} [Fintype ι]
     [AddCommMonoid V] [Module ℂ V]
     (p : ι → Submodule ℂ V) {v : V}

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -7,9 +7,9 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 /-!
 # Uniform spectral gap for the MPS parent Hamiltonian
 
-**Root-only.** This file contains the capstone theorems that deliver the
-uniform spectral gap for the MPS parent Hamiltonian. The remaining
-Friedrichs-angle analytic estimate is the final missing proof obligation.
+**Root-only.** This file contains the final spectral-gap theorems for the MPS
+parent Hamiltonian. The remaining Friedrichs-angle analytic estimate is the
+final missing proof obligation.
 
 ## Main results
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6473,6 +6473,46 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
 \end{proof}
 
+\begin{lemma}[Block-diagonal chain vectors decompose in the local block spaces]
+    \label{lem:bnt_block_diagonal_open_boundary_decomposition}
+    \lean{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1}
+    \leanok
+    \uses{lem:bnt_block_diagonal_periodic_constraints_internal_sum}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}, every
+    vector
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_{j=1}^g\mu_jA_j\right)
+    \]
+    has a unique family \((\psi_j)_{j=1}^g\) such that
+    \[
+        \psi=\sum_{j=1}^g\psi_j,
+        \qquad
+        \psi_j\in G_N(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum} gives
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_{j=1}^g\mu_jA_j\right)
+        \subseteq
+        \bigvee_{j=1}^g G_N(A_j),
+    \]
+    and the sum on the right is internal. Thus every
+    \(\psi\in\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)\) is represented as a sum
+    \(\psi=\sum_j\psi_j\) with \(\psi_j\in G_N(A_j)\), and internality gives
+    uniqueness. The remaining boundary step in
+    \cite[Theorem~12]{PerezGarcia2007Matrix} is to prove
+    \[
+        \psi_j\in\mathcal G_{N,L}(A_j)
+    \]
+    for each \(j\), by closing the periodic boundary with block-diagonal
+    boundary conditions.
+\end{proof}
+
 \begin{lemma}[Block-diagonal periodic chain inclusions]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}
@@ -6504,7 +6544,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 \end{proof}
 
 \begin{lemma}[Boundary closing gives the block-diagonal chain equality]
-    \label{lem:block_diagonal_boundary_closing_capstone}
+    \label{lem:block_diagonal_boundary_closing_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing}
     \leanok
     \uses{lem:isup_chain_ground_space_block_le_assembled}
@@ -6634,7 +6674,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:block_diagonal_periodic_constraints_propagated_sum,
         lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
         lem:bnt_block_diagonal_periodic_chain_inclusions,
-        lem:block_diagonal_boundary_closing_capstone,
+        lem:bnt_block_diagonal_open_boundary_decomposition,
+        lem:block_diagonal_boundary_closing_equality,
         lem:block_diagonal_boundary_decomposition_inclusion,
         lem:bnt_block_diagonal_boundary_decomposition_equality,
         thm:wordspan_propagation_unital}
@@ -6841,7 +6882,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     normal tensors.  This is a conditional form of the block-diagonal
     boundary-condition step in \cite[lines~2126--2128]{Cirac2021Matrix}.
 \end{lemma}
-% The capstone ground-space theorem below uses the conservative length range of
+% The ground-space theorem below uses the conservative length range of
 % the theorem titled "Degeneracy of the ground space v2" in
 % \cite{PerezGarcia2007Matrix}.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6502,11 +6502,12 @@ formulation; the passage to $\ker H_N$ is kept separate.
         \subseteq
         \bigvee_{j=1}^g G_N(A_j),
     \]
-    and the spaces \(G_N(A_j)\) are independent: for \(x_j\in G_N(A_j)\),
+    and the spaces \(G_N(A_j)\) are independent: for every \(j\) and every
+    \(x_j\in G_N(A_j)\),
     \[
         \sum_j x_j=0
         \quad\Longrightarrow\quad
-        x_j=0\quad\text{for every }j.
+        x_j=0.
     \]
     Thus every
     \(\psi\in\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)\) has a unique

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6477,7 +6477,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \label{lem:bnt_block_diagonal_open_boundary_decomposition}
     \lean{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1}
     \leanok
-    \uses{lem:bnt_block_diagonal_periodic_constraints_internal_sum}
+    \uses{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}, every
     vector
@@ -6495,6 +6495,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \leanok
+    \uses{lem:bnt_block_diagonal_periodic_constraints_internal_sum}
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum} gives
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_{j=1}^g\mu_jA_j\right)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6502,10 +6502,16 @@ formulation; the passage to $\ker H_N$ is kept separate.
         \subseteq
         \bigvee_{j=1}^g G_N(A_j),
     \]
-    and the sum on the right is internal. Thus every
-    \(\psi\in\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)\) is represented as a sum
-    \(\psi=\sum_j\psi_j\) with \(\psi_j\in G_N(A_j)\), and internality gives
-    uniqueness. The remaining boundary step in
+    and the spaces \(G_N(A_j)\) are independent: for \(x_j\in G_N(A_j)\),
+    \[
+        \sum_j x_j=0
+        \quad\Longrightarrow\quad
+        x_j=0\quad\text{for every }j.
+    \]
+    Thus every
+    \(\psi\in\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)\) has a unique
+    decomposition \(\psi=\sum_j\psi_j\) with \(\psi_j\in G_N(A_j)\).
+    The remaining boundary step in
     \cite[Theorem~12]{PerezGarcia2007Matrix} is to prove
     \[
         \psi_j\in\mathcal G_{N,L}(A_j)

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -271,9 +271,9 @@ cyclic window and \(\rho\) is the complementary word.  This is not, for general
 with one matrix \(Y_\rho\) independent of the window word.  The missing step is
 therefore a boundary-condition comparison, not the inclusion
 \(\mathcal G_N^A\subseteq\mathcal K_{N,L}(A)\).
-The corresponding capstone blueprint entries now record the multi-block
-hypothesis, the positive common injectivity length, the nonzero-weight
-hypothesis, and the conservative length range of \cite[Theorem
+The corresponding block-diagonal boundary-closing entries now record the
+multi-block hypothesis, the positive common injectivity length, the
+nonzero-weight hypothesis, and the conservative length range of \cite[Theorem
 \emph{Degeneracy of the ground space v2}]{PerezGarcia2007MPSReps}:
 \begin{align}
   b\ge2,
@@ -292,7 +292,7 @@ For $b\ge2$ and $L_0\ge1$, the source length bound implies
 $L\ge 3L_0+4>L_0$; the inequality $L_0<L$ is displayed separately because the
 one-block uniqueness input is used in that range.
 The one-block case is the injective parent-Hamiltonian theorem rather than the
-degenerate block-injective capstone.
+degenerate block-injective boundary theorem.
 The preceding conditional boundary-reduction entries still use weaker ambient
 length inequalities, but only together with the explicit hypothesis that the
 required commuting block-diagonal boundary representation is already available.


### PR DESCRIPTION
## Summary

- prove the finite block decomposition consequence
  \[
    \psi\in\mathcal G_{N,L}\left(\bigoplus_j\mu_jA_j\right)
    \Longrightarrow
    \exists! (\psi_j)_j,\quad \psi=\sum_j\psi_j,\quad \psi_j\in G_N(A_j)
  \]
  under the existing normalized BNT Condition C1 hypotheses
- add the matching blueprint entry and state explicitly that the remaining PGVWC07 boundary step is to prove \(\psi_j\in\mathcal G_{N,L}(A_j)\)
- replace the non-source term "capstone" in the edited parent-Hamiltonian prose with boundary-closing or final-theorem wording

## Why

This records the no-sorry part of the block-diagonal parent-Hamiltonian argument without claiming the still-missing boundary-condition comparison. It also removes reader-facing terminology that is not part of the source papers.

## Checks

- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean` (existing `sorry` warning only)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds proved Lean lemmas and documentation alignment on parent-Hamiltonian ground-space formalization; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **formal Lean theorem** (`exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`) showing that under the existing normalized BNT Condition C1 hypotheses, every vector in the block-diagonal periodic chain ground space admits a **unique** sum \(\psi=\sum_j\psi_j\) with \(\psi_j\in G_N(A_j)\). The proof reuses the already-proved inclusion into \(\bigvee_j G_N(A_j)\), internal directness, and the newly public `exists_sum_mem_of_mem_iSup_fin`.
> 
> **`exists_sum_mem_of_mem_iSup_fin`** is promoted from `private` to a documented public theorem so the decomposition step is reusable.
> 
> The **blueprint** gains a matching lemma (`lem:bnt_block_diagonal_open_boundary_decomposition`) and states explicitly that the remaining PGVWC07 step is \(\psi_j\in\mathcal G_{N,L}(A_j)\). Reader-facing **“capstone”** wording is replaced with boundary-closing / final-theorem language in `BlockDiagonalChainGroundSpace.lean`, `Martingale/Gap.lean`, blueprint, and paper-gaps docs (including lemma label `block_diagonal_boundary_closing_equality`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de292d03457d9f412e05a0300cdee8a243686bf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->