### PR TITLE
fix(MPS/MPDO): derive SAL positivity witness

### DIFF
--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -478,16 +478,20 @@ block sizes `L, L'` in the range.
 Source: arXiv:1606.00608, Definition 4.6 (line 811): the saturation condition is
 written as the equality chain `I_1 = I_2 = ⋯ = I_{⌊N/2⌋}`. -/
 theorem mutualInfoChain_eq_of_isSAL (M : MPOTensor d D) (hSAL : IsSAL M)
-    {N L L' : ℕ} (hL1 : 1 ≤ L) (hLN : L ≤ N / 2) (hL'1 : 1 ≤ L') (hL'N : L' ≤ N / 2)
-    (hM : (mpo M N).PosSemidef) :
+    {N L L' : ℕ} (hL1 : 1 ≤ L) (hLN : L ≤ N / 2) (hL'1 : 1 ≤ L')
+    (hL'N : L' ≤ N / 2) :
+    let hM : (mpo M N).PosSemidef := (Classical.choose hSAL) N
     mutualInfoChain M N L (hLN.trans (Nat.div_le_self N 2)) hM
       = mutualInfoChain M N L' (hL'N.trans (Nat.div_le_self N 2)) hM := by
-  obtain ⟨hMpdo, -, hstep⟩ := hSAL
+  classical
+  dsimp only
+  let hMpdo : IsMPDO M := Classical.choose hSAL
+  rcases Classical.choose_spec hSAL with ⟨_, hstep⟩
   -- Climbing `k` steps from a block size `m` stays an equality while `m + k ≤ ⌊N/2⌋`.
   have climb : ∀ k m : ℕ, 1 ≤ m → ∀ h : m + k ≤ N / 2,
       mutualInfoChain M N m
-          ((Nat.le_add_right m k).trans (h.trans (Nat.div_le_self N 2))) hM
-        = mutualInfoChain M N (m + k) (h.trans (Nat.div_le_self N 2)) hM := by
+          ((Nat.le_add_right m k).trans (h.trans (Nat.div_le_self N 2))) (hMpdo N)
+        = mutualInfoChain M N (m + k) (h.trans (Nat.div_le_self N 2)) (hMpdo N) := by
     intro k
     induction k with
     | zero => intro m _ _; rfl


### PR DESCRIPTION
Addresses #2585.

## Summary

- remove the external hypothesis
  ```lean
  hM : (mpo M N).PosSemidef
  ```
  from `MPOTensor.mutualInfoChain_eq_of_isSAL`
- choose the MPDO positivity witness supplied by `IsSAL M` inside the theorem statement and proof
- leave the blueprint entry `lem:sal_const` unchanged, now with no additional source-absent hypothesis

## Why

The source statement says that saturation of the area law makes the mutual-information chain constant. In the formalization, `IsSAL M` already contains `hMpdo : IsMPDO M`, hence `(mpo M N).PosSemidef` for every `N`. Requiring a separate positivity argument made the Lean signature stricter than the blueprint statement.

## Checks

- `lake env lean TNLean/MPS/MPDO/AreaLaw.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local API and proof refactor on an SAL telescoping lemma; no auth, data, or runtime behavior changes.
> 
> **Overview**
> **`mutualInfoChain_eq_of_isSAL`** no longer takes an explicit **`(mpo M N).PosSemidef`** hypothesis. The statement introduces that witness via **`let hM := (Classical.choose hSAL) N`**, and the proof unpacks **`IsSAL`** with **`Classical.choose`** / **`Classical.choose_spec`** instead of **`obtain ⟨hMpdo, …⟩`**, feeding **`hMpdo N`** into the existing climb argument.
> 
> This matches the source/blueprint reading: saturation already assumes MPDO, so positivity at each **`N`** is internal rather than an extra caller obligation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37b4b4867f0492676d378ef115afd0a1c35d6e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->