### PR TITLE
doc(parent): clarify boundary-closing comparison prose

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -2701,9 +2701,9 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \notready
     Choose matrices $Y_i(\tau)$ representing the length-$(L_0+1)$
-    restrictions. The remaining step from the source is the following
-    coordinate comparison: for every boundary letter $\eta$, physical letter
-    $j$, and length-$L_0$ words $\alpha,\sigma$,
+    restrictions. It remains to establish the following coordinate comparison:
+    for every boundary letter $\eta$, physical letter $j$, and length-$L_0$
+    words $\alpha,\sigma$,
     \[
         A^\alpha
         \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
@@ -2713,9 +2713,10 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
     Lemma~\ref{lem:closure_property_boundary_restrictions_ground_space_map_left_words}
     records that these equations imply the equality of the two restrictions.
-    The displayed left-multiplied family is the remaining coordinate form of the
-    boundary-closing sentence in \cite[lines~2078--2079]{Cirac2021Matrix}, and
-    is recorded in docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
+    The displayed left-multiplied family is the coordinate form of the
+    boundary-closing sentence in \cite[lines~2078--2079]{Cirac2021Matrix} that
+    is still open in the formalization; see
+    \path{docs/paper-gaps/cpgsv21_normal_range_reduction.tex}.
 \end{proof}
 
 \begin{lemma}[First-letter products from equal boundary restrictions]
@@ -5182,8 +5183,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     unequal-dimension branches over all ordered block pairs gives one common
     three-block trace-separation length, and hence the positive-length
     blockwise word span required by the block-separation argument. In the
-    source theorem this span is obtained from Condition C1 at a finite
-    blocking length for each block. The proved specialization records the
+    source theorem this span is obtained from finite-length injectivity for
+    each block. The proved specialization records the
     stronger length-one span condition separately; under that extra hypothesis
     the same trace-separation argument starts at the corresponding one-block
     length and then passes to positive multiples. This trace separation is
@@ -7002,7 +7003,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \uses{lem:one_block_injective_of_injective,
         lem:product_word_span_from_bnt_block_separation,
         lem:conditional_block_split_from_product_word_span}
-    Condition C1 gives a finite block length at which each block has the
+    Finite-length injectivity gives a block length at which each block has the
     required physical--virtual correspondence. In the current length-one
     specialization, Lemma~\ref{lem:one_block_injective_of_injective} supplies
     the corresponding one-block injectivity. The displayed separation equations imply

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -204,7 +204,8 @@ periodic vectors''.
 
 \textbf{\Lean{} statement.}\footnote{Formal declaration:
 \leanid{periodicBasis_eventuallyLinearlyIndependent} in \leanid{Dichotomy.lean};
-blueprint label \texttt{thm:periodic\_basis\_eventually\_li}.} Only the independence
+the matching blueprint entry is in
+\path{blueprint/src/chapter/ch11b_periodic_ft.tex}.} Only the independence
 half is stated; the spanning clause is dropped. The basis condition is encoded
 directly as the pairwise non-repetition hypothesis \leanid{hNonrep} together with
 a common-period divisibility \leanid{hDiv}, rather than derived from a basis of

--- a/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
+++ b/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
@@ -36,20 +36,20 @@ is not derived later. Combined with the strict modulus ordering used by the BNT
 arrangement, it implies that the dominant block has $|\mu_1|=1$ and every
 sub-dominant block has $|\mu_k|<1$.
 
-The same paper proves the proportional Fundamental Theorem
-\cite[Theorem~\texttt{thm1} and Corollary~\texttt{II\_cor2}]{Cirac2016MPDO_arXiv}.
+The same paper proves the proportional Fundamental Theorem and its equal-MPV
+corollary \cite[Section~II]{Cirac2016MPDO_arXiv}.
 Suppose two tensors $A$ and $B$ are presented in their basis-of-normal-tensor
 expansions, with representative families $(A_j)_{j=1}^g$ and $(B_j)_{j=1}^g$
 and BNT coefficients $\mu_{j,q_a}$ and $\nu_{j,q_b}$ for
-$q_a=1,\ldots,r_{a,j}$ and $q_b=1,\ldots,r_{b,j}$. After Theorem~\texttt{thm1}
-identifies the representatives, $B_j=e^{i\phi_j}Y_j A_j Y_j^{-1}$, the
-trace-pair argument in the proof of Corollary~\texttt{II\_cor2} reduces to the
-unlabeled scalar identity
+$q_a=1,\ldots,r_{a,j}$ and $q_b=1,\ldots,r_{b,j}$. After the proportional
+Fundamental Theorem identifies the representatives,
+$B_j=e^{i\phi_j}Y_j A_j Y_j^{-1}$, the trace-pair argument in the proof of the
+equal-MPV corollary reduces to the unlabeled scalar identity
 \begin{align}
     \sum_{q=1}^{r_{a,j}}\mu_{j,q}^N
     =\sum_{q=1}^{r_{b,j}}(\nu_{j,q}e^{i\phi_j})^N,
 \end{align}
-The cited Lemma~\texttt{Lem:app\_simple} then concludes that
+The cited elementary power-sum lemma then concludes that
 $r_{a,j}=r_{b,j}=:r_j$ and that the multisets of weights coincide,
 $\mu_{j,q}=\nu_{j,q}e^{i\phi_j}$. The matching dimensions and the global gauge
 formula follow.
@@ -78,8 +78,7 @@ unit circle. Neither place imposes $|\mu_1|=1$.\footnote{%
     The BNT-separated definitions are
     \texttt{def:cf\_bnt} and \texttt{def:normal\_cf\_bnt} in
     \path{blueprint/src/chapter/ch10_bnt.tex}, lines 70--100 and 119--141,
-    respectively. The phase--modulus decomposition is
-    \texttt{thm:mpv\_normalize} in
+    respectively. The phase--modulus decomposition is recorded in
     \path{blueprint/src/chapter/ch08_canonical.tex}, lines 125--139.}
 
 The omission is mathematically meaningful, because the source definition is
@@ -123,8 +122,8 @@ becomes a condition on the powers $(\mu_j^A)^N$.
 The convergence-to-nonzero-limits hypothesis is not present in
 \cite{Cirac2016MPDO_arXiv}. It is also not present in the formalization's
 own planning record. A proof-plan memo committed on 2026-02-22 sets out the
-intended route for Theorem~\texttt{thm1} and Corollary~\texttt{II\_cor2} of
-\cite{Cirac2016MPDO_arXiv}.\footnote{%
+intended route for the proportional Fundamental Theorem and its equal-MPV
+corollary in \cite{Cirac2016MPDO_arXiv}.\footnote{%
     \path{audits/2026-02-22_thm4_4_proof_plan_ref1606.txt}, committed in
     \texttt{64c018ab} earlier the same day as the introducing implementation
     \texttt{dd54b79e}.} Its concrete recommendation is a span-equality bridge,
@@ -168,7 +167,7 @@ span-equality form proposed for the bridge. Instead it introduced, on the
 BNT bridge theorems and later in a single formal data structure, a global
 convergence hypothesis on the coefficient sequences and a separate hypothesis
 that those limits are nonzero. The mathematical object packaged by these fields is not the
-power-sum identity from the source proof of Corollary~\texttt{II\_cor2}, and
+power-sum identity from the source proof of the equal-MPV corollary, and
 it is not the eventual span equality from the memo's bridge plan. It is a
 third object, introduced without a corresponding written rationale. A later
 commit on 2026-05-09 describes the structure as ``MPV-level Newton--Girard
@@ -178,8 +177,8 @@ memo's plan was made.\footnote{%
     The introducing commit is \texttt{dd54b79e}, ``Add ScalarPowerSumIdentity,
     BNTConstruction, BNTPermutationThm44.'' Despite the name, the
     \leanid{ScalarPowerSumIdentity} module added by that commit does not
-    correspond to the memo's planned fixed-length scalar identity from
-    \cite[Lemma~\texttt{Lem:app\_simple}]{Cirac2016MPDO_arXiv}. The
+    correspond to the memo's planned fixed-length scalar identity from the
+    elementary power-sum lemma in \cite{Cirac2016MPDO_arXiv}. The
     structure refactor that bundled the limit fields is \texttt{9e096a14}
     (2026-03-22), and the post-hoc Newton--Girard description is in the message
     of \texttt{8ab1a5db} (2026-05-09).}
@@ -232,10 +231,10 @@ $N\le\max(r_{a,j},r_{b,j})$ used by the source separation lemma and by the
 
 The blueprint entries that formerly paralleled this convergence-and-nonzero-limit
 surface have been demoted or removed from the source-labelled theorem route.
-They must not be marked as formalizations of Theorem~\texttt{thm1} or
-Corollary~\texttt{II\_cor2}. The active blueprint now treats the source
-comparison as an open block-matching step whose proof must come from the BNT
-power-sum argument, not from external coefficient limits.
+They must not be marked as formalizations of the source proportional
+Fundamental Theorem or its equal-MPV corollary. The active blueprint now treats
+the source comparison as an open block-matching step whose proof must come from
+the BNT power-sum argument, not from external coefficient limits.
 
 The blueprint BNT definitions are symmetric with the formal definition: the
 strict-modulus ordering is recorded; the normalization $|\mu_1|=1$ is not.
@@ -286,8 +285,8 @@ particular no nonzero limit hypothesis on $(\mu_j^A)^N$ is required.
 
 Thus the corrected route is source-faithful at finite length: the
 multi-multiplicity version follows the finite power-sum identities from the
-proof of Corollary~\texttt{II\_cor2}
-\cite{Cirac2016MPDO_arXiv}, while the single-witness discussion is only the
+proof of the equal-MPV corollary \cite{Cirac2016MPDO_arXiv}, while the
+single-witness discussion is only the
 strict-weight specialization of that route. The circularity worry that the memo
 flagged in connection with the span-equality bridge does not arise for this
 finite-length route once the BNT linear-independence input is supplied from
@@ -328,7 +327,7 @@ explicit input until the source-faithful residual comparison theorem is
 available.
 
 What remains is the proof itself. The paper-faithful proof follows the
-block-selection step of Theorem~\texttt{thm1}
+block-selection step of the proportional Fundamental Theorem
 \cite[line~1182]{Cirac2016MPDO_arXiv}, followed in the equal-MPV corollary by
 the finite power-sum comparison and global gauge assembly
 \cite[lines~1184--1192]{Cirac2016MPDO_arXiv}. It will consume the per-$N$

--- a/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
+++ b/docs/paper-gaps/cpsv16_two_layer_sector_refinement.tex
@@ -29,7 +29,7 @@ where $\mu_{j,q} \in \mathbb{C}$ are \emph{arbitrary} complex coefficients
 (no ordering or unit-modulus condition is imposed), $X_{j,q}$ are invertible
 gauge matrices, and $A_j$ are the BNT normal blocks. The eventual linear
 independence of the BNT vectors $\lvert V^{(N)}(A_j)\rangle$ is recorded
-separately in Definition~\texttt{def:4:BNT} of
+separately in the review's definition of basis normal tensors
 \cite{Cirac2021Matrix}.
 
 \section{The retired specialization}
@@ -54,9 +54,9 @@ which are stronger than the source display:
         recorded by an explicit unit-modulus factorization condition.
         The general form \eqref{eq:bnt-general} allows $|\mu_{j,q}|$
         to vary arbitrarily within a sector. The unit-modulus factorization
-        is conceptually related to the RFP characterization in
-        \texttt{thm:charact-MPS} of~\cite{Cirac2016MPDO_arXiv}
-        (lines 543--555), which is a strict sub-class of the general BNT.
+        is conceptually related to the RFP characterization theorem of
+        \cite{Cirac2016MPDO_arXiv} (lines 543--555), which is a strict
+        sub-class of the general BNT.
 
   \item \textbf{Dominant normalization.}
         The dominant spectral level satisfies $|\lambda_0| = 1$.

--- a/docs/paper-gaps/mps_common_blocking_span_equality.tex
+++ b/docs/paper-gaps/mps_common_blocking_span_equality.tex
@@ -34,7 +34,8 @@ vectors by
       \operatorname{tr}(A^{i_1}\cdots A^{i_N})
       |i_1\rangle\otimes\cdots\otimes |i_N\rangle,
 \]
-for $N=1,2,3,\ldots$ \cite[Definition~\texttt{MPV}, lines~130--138]{Cirac2016MPDO_arXiv}.
+for $N=1,2,3,\ldots$ \cite[definition of the matrix product vector family,
+lines~130--138]{Cirac2016MPDO_arXiv}.
 After removing invariant subspaces, the same paper writes the tensor in block form
 \[
   A^i = \bigoplus_{k=1}^r \mu_k A_k^i,
@@ -87,7 +88,7 @@ The elementary power-sum lemma then recovers the multiplicities and the weights,
 and the blockwise gauges are assembled into the global conjugating matrix
 \cite[lines~1181--1192]{Cirac2016MPDO_arXiv}. The review states the resulting
 proportional and equal MPV fundamental theorems in the same form
-\cite[Theorem~\texttt{thm1} and Corollary~\texttt{II\_cor2}, lines~1891--1900]{Cirac2021Matrix}.
+\cite[lines~1891--1900]{Cirac2021Matrix}.
 
 \section{The formal argument}
 
@@ -150,10 +151,8 @@ eventual linear independence gives the coefficient identities
 Newton--Girard power-sum comparison recovers the copy weights, and the matched
 block gauges assemble into the direct-sum global gauge.\footnote{See
 \path{blueprint/src/chapter/ch11_fundamental_theorem_proof.tex:31--460},
-especially labels
-\texttt{lem:sector\_bnt\_coeff\_identity\_via\_matched\_mpv\_phase},
-\texttt{lem:sector\_bnt\_copy\_weight\_matching\_of\_coeff\_identity}, and
-\texttt{thm:sector\_bnt\_equal\_global\_gauge}. The corresponding formal
+especially the sector coefficient identity, copy-weight matching, and assembled
+global-gauge entries. The corresponding formal
 objects live in
 \path{TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean},
 \path{TNLean/MPS/FundamentalTheorem/SectorBNT/CopyWeightMatching.lean},


### PR DESCRIPTION
## Summary

- rewrite the parent-Hamiltonian boundary-closing proof sketch so the still-open step is stated as the explicit left-multiplied matrix comparison
- replace non-source-facing "Condition C1" language in the parent blueprint with finite-length injectivity language
- remove theorem-label-as-prose references from paper-gap notes, replacing them with mathematical descriptions or file references

## Mathematical Status

This PR does not close #2405. The Lean declaration `MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap` still contains the open closing-boundary comparison. The blueprint remains `\notready` at that proof and now states the required equations directly:

\[
  A^\alpha\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
  =
  A^\alpha\left(A^\mu A^jXA^\sigma\right).
\]

## Checks

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --report /tmp/parent2405-sync.json`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and citation wording only in blueprint and gap documentation; no executable or proof logic changes.
> 
> **Overview**
> Documentation-only alignment of blueprint and **paper-gap** notes with reader-facing prose rules.
> 
> In **`ch14_parent_hamiltonian.tex`**, the still-`\notready` boundary-restriction proof sketch now states the **remaining step** as the explicit left-multiplied matrix comparison (for all boundary letters, physical letters, and length-\(L_0\) words) and points to `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` instead of vague “remaining coordinate” wording. Elsewhere in the same chapter, **“Condition C1”** is renamed to **finite-length injectivity** where the source argument is described.
> 
> Across **`docs/paper-gaps/*.tex`**, citations that used paper-internal labels (`thm1`, `II_cor2`, `Lem:app_simple`, blueprint `\texttt{thm:...}`) are rewritten as **mathematical descriptions** (proportional Fundamental Theorem, equal-MPV corollary, elementary power-sum lemma, etc.) or **repository paths** (e.g. periodic-basis blueprint in `ch11b_periodic_ft.tex`). Sector-BNT and blocking-span notes drop label-as-prose in favor of named lemmas/entries.
> 
> **No Lean proofs or formal status change**—the open boundary-closing comparison and related gaps remain as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3615e8734b4d6dfd575146a25e9e096c4a6f32fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->