### PR TITLE
feat(PEPS): the per-edge gauge from blocked-region injectivity (the normal-FT V=W kernel)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -504,4 +504,5 @@ import TNLean.PEPS.RegionBlock.CoarseThreeSite7
 import TNLean.PEPS.RegionBlock.CoarseThreeSite8
 import TNLean.PEPS.RegionBlock.CoarseThreeSite9
 import TNLean.PEPS.RegionBlock.CoarseThreeSite10
+import TNLean.PEPS.RegionBlock.CoarseThreeSite11
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -503,4 +503,5 @@ import TNLean.PEPS.RegionBlock.CoarseThreeSite6
 import TNLean.PEPS.RegionBlock.CoarseThreeSite7
 import TNLean.PEPS.RegionBlock.CoarseThreeSite8
 import TNLean.PEPS.RegionBlock.CoarseThreeSite9
+import TNLean.PEPS.RegionBlock.CoarseThreeSite10
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -497,4 +497,5 @@ import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap6
 import TNLean.PEPS.RegionBlock.CoarseThreeSite
 import TNLean.PEPS.RegionBlock.CoarseThreeSite2
 import TNLean.PEPS.RegionBlock.CoarseThreeSite3
+import TNLean.PEPS.RegionBlock.CoarseThreeSite4
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -500,4 +500,5 @@ import TNLean.PEPS.RegionBlock.CoarseThreeSite3
 import TNLean.PEPS.RegionBlock.CoarseThreeSite4
 import TNLean.PEPS.RegionBlock.CoarseThreeSite5
 import TNLean.PEPS.RegionBlock.CoarseThreeSite6
+import TNLean.PEPS.RegionBlock.CoarseThreeSite7
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -499,4 +499,5 @@ import TNLean.PEPS.RegionBlock.CoarseThreeSite2
 import TNLean.PEPS.RegionBlock.CoarseThreeSite3
 import TNLean.PEPS.RegionBlock.CoarseThreeSite4
 import TNLean.PEPS.RegionBlock.CoarseThreeSite5
+import TNLean.PEPS.RegionBlock.CoarseThreeSite6
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -498,4 +498,5 @@ import TNLean.PEPS.RegionBlock.CoarseThreeSite
 import TNLean.PEPS.RegionBlock.CoarseThreeSite2
 import TNLean.PEPS.RegionBlock.CoarseThreeSite3
 import TNLean.PEPS.RegionBlock.CoarseThreeSite4
+import TNLean.PEPS.RegionBlock.CoarseThreeSite5
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -501,4 +501,5 @@ import TNLean.PEPS.RegionBlock.CoarseThreeSite4
 import TNLean.PEPS.RegionBlock.CoarseThreeSite5
 import TNLean.PEPS.RegionBlock.CoarseThreeSite6
 import TNLean.PEPS.RegionBlock.CoarseThreeSite7
+import TNLean.PEPS.RegionBlock.CoarseThreeSite8
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -502,4 +502,5 @@ import TNLean.PEPS.RegionBlock.CoarseThreeSite5
 import TNLean.PEPS.RegionBlock.CoarseThreeSite6
 import TNLean.PEPS.RegionBlock.CoarseThreeSite7
 import TNLean.PEPS.RegionBlock.CoarseThreeSite8
+import TNLean.PEPS.RegionBlock.CoarseThreeSite9
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
@@ -171,5 +171,94 @@ theorem redBundleInsertedCoeff_bondModelMatrix_eq_configSum
   refine Finset.sum_congr rfl (fun η _ => ?_)
   ring
 
+open scoped Classical in
+/-- **The relaxed-triple merge collapse.** The M-coupled relaxed-triple sum equals the
+host-merge fiber product times the whole-bundle red inserted coefficient of the
+bond-model-conjugated matrix, with the host physical leg the fused blue/complement leg. This
+is the matrix-carrying analogue of `TNLean.PEPS.agreeingTripleSum_collapse`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 254--583 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem relaxedTripleSum_collapse
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) :
+    (∑ t ∈ (Finset.univ : Finset (VirtualConfig A × VirtualConfig A × VirtualConfig A)).filter
+        (fun t => CrossTripleAgreesAwayRB F t.1 t.2.1 t.2.2),
+      bondModelMatrix (G := G) F M
+          (crossingLabel (G := G) A F.frame.red F.frame.blue t.1)
+          (fun g => t.2.1 g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue) *
+        (∏ w : {w : V // w ∈ F.frame.red},
+            A.component w.1 (fun ie => t.1 ie.1) (σr w)) *
+        (∏ w : {w : V // w ∈ F.frame.complement},
+            A.component w.1 (fun ie => t.2.2 ie.1) (σc w)) *
+        (∏ w : {w : V // w ∈ F.frame.blue},
+            A.component w.1 (fun ie => t.2.1 ie.1) (σb w))) =
+      hostMergeFiberProd F •
+        redBundleInsertedCoeff (G := G) A F.frame.red F.frame.blue (bondModelMatrix (G := G) F M)
+          σr ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc) := by
+  classical
+  -- Replace each summand by its merged form.
+  rw [relaxedTripleSum_mergedSummand_eq F hP M σr σb σc]
+  -- Reindex the triple `(ζr, (ζb, ζc))` and split the relaxed agreement filter.
+  rw [Finset.sum_filter, Fintype.sum_prod_type]
+  rw [redBundleInsertedCoeff_bondModelMatrix_eq_configSum F hP M σr σb σc, Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun ζr _ => ?_)
+  -- For fixed `ζr`, collapse the `(ζb, ζc)` pair sum through the host merge, with the
+  -- red-to-complement agreement carried as an indicator inside the summand.
+  rw [Fintype.sum_prod_type, Finset.smul_sum]
+  -- The configuration summand of the host index, as a function of one global configuration.
+  let hostCoeff : VirtualConfig A → ℂ := fun η =>
+    (if ∀ gg : Edge G,
+          IsCrossingEdge (G := G) A F.frame.red F.frame.complement gg → ζr gg = η gg then
+        bondModelMatrix (G := G) F M
+            (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+              (regionBoundaryLabel (G := G) A F.frame.red ζr))
+            (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+              (regionBoundaryLabel (G := G) A F.frame.red η))
+      else 0) *
+      (∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w)) *
+      ∏ w : {w : V // w ∈ Finset.univ \ F.frame.red},
+        A.component w.1 (fun ie => η ie.1)
+          ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc w)
+  -- The triple sum equals the host-pair sum of `G ∘ hostMerge`; its fiberwise collapse is the
+  -- configuration sum, the host index of the configuration expansion.
+  have hpair : (∑ ζb : VirtualConfig A, ∑ ζc : VirtualConfig A,
+        (if CrossTripleAgreesAwayRB F ζr ζb ζc then
+            bondModelMatrix (G := G) F M
+                (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+                  (regionBoundaryLabel (G := G) A F.frame.red ζr))
+                (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+                  (regionBoundaryLabel (G := G) A F.frame.red (hostMerge F ζb ζc))) *
+              (∏ w : {w : V // w ∈ F.frame.red},
+                  A.component w.1 (fun ie => ζr ie.1) (σr w)) *
+              ∏ w : {w : V // w ∈ Finset.univ \ F.frame.red},
+                A.component w.1 (fun ie => hostMerge F ζb ζc ie.1)
+                  ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc w)
+          else 0)) =
+      ∑ p ∈ Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+          HostPairAgrees F p.1 p.2),
+        hostCoeff (hostMerge F p.1 p.2) := by
+    rw [Finset.sum_filter, Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl (fun ζb _ => Finset.sum_congr rfl (fun ζc _ => ?_))
+    change _ = (if HostPairAgrees F ζb ζc then hostCoeff (hostMerge F ζb ζc) else 0)
+    by_cases hbc : HostPairAgrees F ζb ζc
+    · by_cases hrh : RedHostAgrees F ζr ζb ζc
+      · rw [if_pos ((crossTripleAgreesAwayRB_iff F ζr ζb ζc).mpr ⟨hbc, hrh⟩), if_pos hbc]
+        change _ = (if ∀ gg : Edge G,
+            IsCrossingEdge (G := G) A F.frame.red F.frame.complement gg →
+              ζr gg = hostMerge F ζb ζc gg then _ else _) * _ * _
+        rw [if_pos (fun gg hgg => hrh gg hgg)]
+      · rw [if_neg (fun h => hrh ((crossTripleAgreesAwayRB_iff F ζr ζb ζc).mp h).2), if_pos hbc]
+        change _ = (if ∀ gg : Edge G,
+            IsCrossingEdge (G := G) A F.frame.red F.frame.complement gg →
+              ζr gg = hostMerge F ζb ζc gg then _ else _) * _ * _
+        rw [if_neg (fun h => hrh (fun gg hgg => h gg hgg)), zero_mul, zero_mul]
+    · rw [if_neg (fun h => hbc ((crossTripleAgreesAwayRB_iff F ζr ζb ζc).mp h).1), if_neg hbc]
+  rw [hpair, hostMerge_fiberwise_collapse F hostCoeff, Finset.smul_sum]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
@@ -1,0 +1,175 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite9
+
+/-!
+# The relaxed-triple merge collapse: the final assembly
+
+This file completes the relaxed-triple merge collapse begun in
+`TNLean.PEPS.RegionBlock.CoarseThreeSite9`. The merged-summand layer (the host merge, the
+host-merge fiber count, and the per-triple merged summand) is assembled with the
+configuration expansion of the whole-bundle red inserted coefficient into the collapse: the
+M-coupled relaxed-triple sum is the host-merge fiber product times the whole-bundle red
+inserted coefficient of the bond-model-conjugated matrix.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 254--583 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d}
+
+open scoped Classical in
+/-- **The configuration expansion of the whole-bundle red inserted coefficient.** The
+whole-bundle red inserted coefficient of the bond-model-conjugated matrix, with the host
+physical leg the fused blue/complement leg, expands as a double sum over global virtual
+configurations: the red configuration `ζr` carries the red index, a second configuration `η`
+the host index, coupled diagonally on the red-to-complement crossings by the agreement and on
+the red-to-blue crossings by the matrix.
+
+Source: arXiv:1804.04964, Section 3, lines 254--583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem redBundleInsertedCoeff_bondModelMatrix_eq_configSum
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) :
+    redBundleInsertedCoeff (G := G) A F.frame.red F.frame.blue (bondModelMatrix (G := G) F M)
+        σr ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc) =
+      ∑ ζr : VirtualConfig A, ∑ η : VirtualConfig A,
+        (if ∀ g : Edge G, IsCrossingEdge (G := G) A F.frame.red F.frame.complement g →
+              ζr g = η g then
+            bondModelMatrix (G := G) F M
+              (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+                (regionBoundaryLabel (G := G) A F.frame.red ζr))
+              (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+                (regionBoundaryLabel (G := G) A F.frame.red η))
+          else 0) *
+          (∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w)) *
+          (∏ w : {w : V // w ∈ Finset.univ \ F.frame.red},
+            A.component w.1 (fun ie => η ie.1)
+              ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc w)) := by
+  classical
+  rw [redBundleInsertedCoeff_eq]
+  -- Pull the red blocked-region weight out of the inner host sum, then group the red
+  -- configurations through `blockedWeight_as_configSum`.
+  have hred : ∀ μ : RegionBoundaryConfig (G := G) A F.frame.red,
+      (∑ ν : RegionBoundaryConfig (G := G) A F.frame.red,
+          (if SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue μ ν then
+              bondModelMatrix (G := G) F M
+                (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue μ)
+                (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue ν)
+            else 0) *
+            regionBlockedWeight (G := G) A F.frame.red μ σr *
+            regionBlockedWeight (G := G) A (Finset.univ \ F.frame.red)
+              (regionComplementBoundaryConfig (G := G) A F.frame.red ν)
+              ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc)) =
+        (∑ ν : RegionBoundaryConfig (G := G) A F.frame.red,
+            (if SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue μ ν then
+                bondModelMatrix (G := G) F M
+                  (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue μ)
+                  (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue ν)
+              else 0) *
+              regionBlockedWeight (G := G) A (Finset.univ \ F.frame.red)
+                (regionComplementBoundaryConfig (G := G) A F.frame.red ν)
+                ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc)) *
+          regionBlockedWeight (G := G) A F.frame.red μ σr := by
+    intro μ; rw [Finset.sum_mul]; refine Finset.sum_congr rfl (fun ν _ => ?_); ring
+  rw [Finset.sum_congr rfl (fun μ _ => hred μ),
+    blockedWeight_as_configSum (R := F.frame.red) σr]
+  refine Finset.sum_congr rfl (fun ζr _ => ?_)
+  -- Collapse the host boundary configuration sum to a host configuration sum, keeping the
+  -- red vertex product factored out.
+  have hhost : (∑ ν : RegionBoundaryConfig (G := G) A F.frame.red,
+        (if SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
+              (regionBoundaryLabel (G := G) A F.frame.red ζr) ν then
+            bondModelMatrix (G := G) F M
+              (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+                (regionBoundaryLabel (G := G) A F.frame.red ζr))
+              (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue ν)
+          else 0) *
+          regionBlockedWeight (G := G) A (Finset.univ \ F.frame.red)
+            (regionComplementBoundaryConfig (G := G) A F.frame.red ν)
+            ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc)) =
+      ∑ η : VirtualConfig A,
+        (if ∀ g : Edge G, IsCrossingEdge (G := G) A F.frame.red F.frame.complement g →
+              ζr g = η g then
+            bondModelMatrix (G := G) F M
+              (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+                (regionBoundaryLabel (G := G) A F.frame.red ζr))
+              (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+                (regionBoundaryLabel (G := G) A F.frame.red η))
+          else 0) *
+          ∏ w : {w : V // w ∈ Finset.univ \ F.frame.red},
+            A.component w.1 (fun ie => η ie.1)
+              ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc w) := by
+    -- Reindex the host boundary sum through the complement boundary equivalence.
+    rw [← Equiv.sum_comp (regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).symm
+      (fun ν => (if SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
+            (regionBoundaryLabel (G := G) A F.frame.red ζr) ν then
+          bondModelMatrix (G := G) F M
+            (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+              (regionBoundaryLabel (G := G) A F.frame.red ζr))
+            (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue ν)
+        else 0) *
+        regionBlockedWeight (G := G) A (Finset.univ \ F.frame.red)
+          (regionComplementBoundaryConfig (G := G) A F.frame.red ν)
+          ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc))]
+    -- Normalize the host weight argument `compl (e.symm νh) = νh`, then group.
+    rw [Finset.sum_congr rfl (g := fun νh => (if SameAwayFromRBBundle (G := G) A F.frame.red
+          F.frame.blue (regionBoundaryLabel (G := G) A F.frame.red ζr)
+          ((regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).symm νh) then
+        bondModelMatrix (G := G) F M
+          (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+            (regionBoundaryLabel (G := G) A F.frame.red ζr))
+          (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+            ((regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).symm νh))
+      else 0) *
+      regionBlockedWeight (G := G) A (Finset.univ \ F.frame.red) νh
+        ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc))
+      (fun νh _ => by
+        rw [show regionComplementBoundaryConfig (G := G) A F.frame.red
+              ((regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).symm νh) = νh from
+          (regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).apply_symm_apply νh])]
+    rw [blockedWeight_as_configSum (R := Finset.univ \ F.frame.red)
+      ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc)
+      (fun νh => (if SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
+            (regionBoundaryLabel (G := G) A F.frame.red ζr)
+            ((regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).symm νh) then
+          bondModelMatrix (G := G) F M
+            (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+              (regionBoundaryLabel (G := G) A F.frame.red ζr))
+            (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+              ((regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).symm νh))
+        else 0))]
+    refine Finset.sum_congr rfl (fun η _ => ?_)
+    -- The symm-reindexed host label of `η` is the red boundary label of `η`.
+    rw [show (regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).symm
+          (regionBoundaryLabel (G := G) A (Finset.univ \ F.frame.red) η) =
+        regionBoundaryLabel (G := G) A F.frame.red η from by
+      funext f
+      simp only [regionComplementBoundaryConfigEquiv, Equiv.coe_fn_symm_mk,
+        regionBoundaryLabel_apply, regionBoundaryEdgeComplEquiv_apply_coe]]
+    by_cases hag : SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
+        (regionBoundaryLabel (G := G) A F.frame.red ζr)
+        (regionBoundaryLabel (G := G) A F.frame.red η)
+    · rw [if_pos hag,
+        if_pos ((sameAwayFromRBBundle_regionBoundaryLabel_iff F hP ζr η).mp hag)]
+    · rw [if_neg hag,
+        if_neg (fun h => hag
+          ((sameAwayFromRBBundle_regionBoundaryLabel_iff F hP ζr η).mpr h)), zero_mul]
+  -- Multiply the host collapse by the factored red vertex product.
+  rw [hhost, Finset.sum_mul]
+  refine Finset.sum_congr rfl (fun η _ => ?_)
+  ring
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
@@ -260,5 +260,37 @@ theorem relaxedTripleSum_collapse
     · rw [if_neg (fun h => hbc ((crossTripleAgreesAwayRB_iff F ζr ζb ζc).mp h).1), if_neg hbc]
   rw [hpair, hostMerge_fiberwise_collapse F hostCoeff, Finset.smul_sum]
 
+/-! ### The inserted-coefficient descent
+
+Chaining the M-coupled three-region expansion, the relaxed-triple reindexing, and the
+relaxed-triple merge collapse: the coarse edge-inserted coefficient at the red-to-blue
+super-bond descends to the host-merge fiber product times the whole-bundle red inserted
+coefficient of the bond-model-conjugated matrix. -/
+
+open scoped Classical in
+/-- **The inserted-coefficient descent.** The coarse edge-inserted coefficient at the
+red-to-blue super-bond equals the host-merge fiber product times the whole-bundle red
+inserted coefficient of the bond-model-conjugated matrix, with the host physical leg the
+fused blue/complement leg. This is the matrix-carrying analogue of the closed-state collapse
+`TNLean.PEPS.stateCoeff_coarseTensor_collapse`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 254--583 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeInsertedCoeff_coarseTensor_descent
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (s : Fin 3 → Fin (coarseDim V d))
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ) :
+    edgeInsertedCoeff (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB s M =
+      hostMergeFiberProd F •
+        redBundleInsertedCoeff (G := G) A F.frame.red F.frame.blue (bondModelMatrix (G := G) F M)
+          (coarseProj F.frame.red (s 0))
+          ((F.frame.toThreeBlockGeometry hP).complPhysical
+            (coarseProj F.frame.blue (s 1)) (coarseProj F.frame.complement (s 2))) := by
+  rw [edgeInsertedCoeff_coarseTensor_eq_threeRegionSum F s M,
+    mCoupledThreeRegionSum_eq_relaxedTripleSum F hP s M,
+    relaxedTripleSum_collapse F hP M (coarseProj F.frame.red (s 0))
+      (coarseProj F.frame.blue (s 1)) (coarseProj F.frame.complement (s 2))]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -184,5 +184,126 @@ theorem edgeInsertedCoeff_coarseTensor_descent_single
     bondModelMatrix_eq_singletonBundleMatrix F e hsingle M,
     redBundleInsertedCoeff_singleton F.frame.red F.frame.blue e hsingle]
 
+/-! ### The single-edge coefficient transfer between two coherent frames
+
+Two coherent frames over `A` and `B` sharing the three regions, the bond dimensions, and
+the single-crossing edge `e`, with `A` and `B` generating the same state, give the
+single-edge coefficient transfer on `e`: for every matrix inserted on `e` of the first
+tensor there is a matrix on the second whose single-edge region-inserted coefficient
+matches at every red and host physical configuration. -/
+
+/-- The single-crossing hypothesis transports across coherent frames sharing the red and
+blue regions: if the red region crosses the blue region of the first frame across the
+single edge `e`, the same holds for the second frame's shared regions. -/
+theorem hsingle_transport (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B) (e : Edge G)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (g : Edge G) :
+    IsCrossingEdge (G := G) B F'.frame.red F'.frame.blue g ↔ g = e := by
+  rw [IsCrossingEdge, ← hred, ← hblue]
+  exact hsingle g
+
+open scoped Classical in
+/-- **The single-edge coefficient transfer.** Two coherent frames over `A` and `B`
+sharing the three regions, the bond dimensions, and the single-crossing edge `e`, with
+`A` and `B` generating the same state, give: for every matrix `M` inserted on `e` of `A`
+there is a matrix `N` on `B` whose single-edge region-inserted coefficient matches at
+every red physical configuration `σ` and host physical configuration `τ`.
+
+The transfer chains the single-edge descent on both frames, the coarse coefficient
+transfer `coarse_exists_edgeInsertedCoeff_eq`, and the cancellation of the shared positive
+host-merge fiber product. No single-vertex injectivity is used: the descent rests on the
+blocked-region injectivities of the frames.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--583 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionInsertedCoeff_eq_of_coherentFrames
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    ∃ N : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ,
+      ∀ (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)),
+        regionInsertedCoeff (G := G) A F.frame.red
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
+          regionInsertedCoeff (G := G) B F'.frame.red
+            (singleBoundaryEdge (G := G) B F'.frame.red F'.frame.blue e
+              (hsingle_transport F F' e hred hblue hsingle))
+            N
+            (regionPhysicalConfigCongr (d := d) hred σ)
+            (regionPhysicalConfigCongr (d := d)
+              (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ) := by
+  classical
+  -- The singleton hypothesis on the second frame.
+  set hsingle' := hsingle_transport F F' e hred hblue hsingle with hsingle'_def
+  -- Lift `M` to the coarse `r-b` super-bond of the first frame.
+  set Mcoarse := Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M with hMc
+  -- The coarse coefficient transfer gives a coarse matrix `Ncoarse` on the second frame.
+  have hsame : SameState (F.frame.coarseTensor) (F'.frame.coarseTensor) :=
+    coarseTensor_sameState_of_sameState F F' hP hP' hred hblue hcompl hbond hAB
+  obtain ⟨Ncoarse, hN⟩ := coarse_exists_edgeInsertedCoeff_eq F.frame F'.frame hsame Mcoarse
+  -- The descent recovers `M` from `Mcoarse` on the first frame.
+  have hMrecover : Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) Mcoarse = M := by
+    rw [hMc, ← Matrix.reindexAlgEquiv_symm, AlgEquiv.apply_symm_apply]
+  -- The descent's bridge-reindexed matrix on the second frame is the transfer output.
+  refine ⟨Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F' e hsingle') Ncoarse, ?_⟩
+  intro σ τ
+  -- Realize `(σ, τ)` by the descent's physical legs on the first frame.
+  obtain ⟨s, hsσ, hsτ⟩ := exists_descent_legs F hP hd σ τ
+  -- The same coarse assignment realizes the transported legs on the second frame.
+  have hsσ' : coarseProj F'.frame.red (s 0) = regionPhysicalConfigCongr (d := d) hred σ := by
+    rw [← hsσ]; funext w; rfl
+  have hsτ' : (F'.frame.toThreeBlockGeometry hP').complPhysical
+        (coarseProj F'.frame.blue (s 1)) (coarseProj F'.frame.complement (s 2)) =
+      regionPhysicalConfigCongr (d := d)
+        (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ := by
+    funext w
+    rw [regionPhysicalConfigCongr_apply, ← hsτ]
+    -- Both fused host legs read `coarseDecode` on the same branch (blue/complement shared).
+    simp only [ThreeBlockGeometry.complPhysical, coarseProj]
+    by_cases hb : w.1 ∈ F'.frame.blue
+    · rw [dif_pos (show w.1 ∈ (F'.frame.toThreeBlockGeometry hP').blue from hb),
+        dif_pos (show w.1 ∈ (F.frame.toThreeBlockGeometry hP).blue by rw [show
+          (F.frame.toThreeBlockGeometry hP).blue = F.frame.blue from rfl, hblue]; exact hb)]
+    · rw [dif_neg (show w.1 ∉ (F'.frame.toThreeBlockGeometry hP').blue from hb),
+        dif_neg (show w.1 ∉ (F.frame.toThreeBlockGeometry hP).blue by rw [show
+          (F.frame.toThreeBlockGeometry hP).blue = F.frame.blue from rfl, hblue]; exact hb)]
+  -- The host-merge fiber products of the two frames coincide and are positive.
+  have hfiber : hostMergeFiberProd (G := G) F = hostMergeFiberProd (G := G) F' :=
+    hostMergeFiberProd_eq F F' hblue hcompl hbond
+  have hfpos : 0 < hostMergeFiberProd (G := G) F := hostMergeFiberProd_pos F hpos
+  -- Cancel the shared positive fiber product after the descent on both frames.
+  refine nsmul_right_injective (M := ℂ) (Nat.pos_iff_ne_zero.mp hfpos) ?_
+  -- The descent rewrites each side to a coarse edge-inserted coefficient.
+  have hlhs : hostMergeFiberProd (G := G) F •
+        regionInsertedCoeff (G := G) A F.frame.red
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
+      edgeInsertedCoeff (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB s Mcoarse := by
+    rw [← hsσ, ← hsτ, ← hMrecover,
+      ← edgeInsertedCoeff_coarseTensor_descent_single F hP e hsingle s Mcoarse]
+  have hrhs : hostMergeFiberProd (G := G) F •
+        regionInsertedCoeff (G := G) B F'.frame.red
+          (singleBoundaryEdge (G := G) B F'.frame.red F'.frame.blue e hsingle')
+          (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F' e hsingle') Ncoarse)
+          (regionPhysicalConfigCongr (d := d) hred σ)
+          (regionPhysicalConfigCongr (d := d)
+            (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ) =
+      edgeInsertedCoeff (G := coarseGraph) (F'.frame.coarseTensor) coarseEdgeRB s Ncoarse := by
+    rw [hfiber, ← hsσ', ← hsτ',
+      ← edgeInsertedCoeff_coarseTensor_descent_single F' hP' e hsingle' s Ncoarse]
+  show hostMergeFiberProd (G := G) F • _ = hostMergeFiberProd (G := G) F • _
+  rw [hlhs, hrhs]
+  exact hN s
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -1,0 +1,143 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite10
+import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
+
+/-!
+# The single-edge inserted-coefficient transfer and the per-edge gauge
+
+This file is the final assembly of the normal-PEPS edge comparison. It chains the
+inserted-coefficient descent `TNLean.PEPS.edgeInsertedCoeff_coarseTensor_descent` of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite10`, the single-crossing specialization
+`TNLean.PEPS.redBundleInsertedCoeff_singleton` of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite8`, and the coarse coefficient transfer
+`TNLean.PEPS.coarse_exists_edgeInsertedCoeff_eq` of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite` into the single-edge coefficient transfer that
+`TNLean.PEPS.bondLocal_iff_coeffTransfer` consumes.
+
+The geometric input is the singleton hypothesis: the red region crosses to the blue
+region across the single distinguished edge `e`. It is the source's coordinate blocking
+(`Papers/1804.04964/paper_normal.tex:1449--1500`, the three injective regions around an
+edge, where the red sites surround one endpoint and the blue sites the other).
+
+## The bridge
+
+The descent reads the inserted matrix through the bond-model-conjugated matrix
+`TNLean.PEPS.bondModelMatrix` on the whole red-to-blue crossing bundle. Under the
+singleton hypothesis the bundle is a single virtual leg on `e`
+(`TNLean.PEPS.singletonCrossingEquiv`), so the bond-model-conjugated matrix is a
+single-bundle matrix `TNLean.PEPS.singletonBundleMatrix` of a single-edge matrix on `e`,
+obtained by reindexing through the composite of the bond model and the single-leg
+crossing equivalence. The single-crossing specialization then reads the descent's
+whole-bundle inserted coefficient as the ordinary single-edge region-inserted
+coefficient `TNLean.PEPS.regionInsertedCoeff` on `e`.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 254--583 (the injective three-site comparison) and 1449--1500
+  (the single-crossing blocking) of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d}
+
+/-! ### Positivity of the host-merge fiber product
+
+The host-merge fiber multiplicity `hostMergeFiberProd` is a product of bond dimensions.
+Under positive bond dimensions it is positive, so it cancels from both sides of the
+descent. -/
+
+/-- The host-merge fiber multiplicity is positive when the bond dimensions are positive:
+it is the product of the complement non-incident bond product and the free blue bond
+product, both products of positive bond dimensions. -/
+theorem hostMergeFiberProd_pos (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e) :
+    0 < hostMergeFiberProd (G := G) F := by
+  rw [hostMergeFiberProd, regionNonIncidentBondProd, hostBlueFreeBondProd]
+  exact Nat.mul_pos
+    (Finset.prod_pos (fun e _ => hpos e)) (Finset.prod_pos (fun e _ => hpos e))
+
+/-! ### The single-edge bridge matrix
+
+Under the singleton hypothesis, the coarse `r-b` super-bond `Fin (coarseBondDim
+coarseEdgeRB)` identifies with the single virtual leg `Fin (A.bondDim e)` through the
+composite of the bond model and the single-leg crossing equivalence. -/
+
+/-- The single-edge bridge equivalence: the coarse `r-b` super-bond identified with the
+single virtual leg `Fin (A.bondDim e)` through the bond model and the single-leg crossing
+equivalence. -/
+noncomputable def bridgeEquiv (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e) :
+    Fin (F.frame.coarseBondDim coarseEdgeRB) ≃ Fin (A.bondDim e) :=
+  (F.bondModel coarseEdgeRB).trans
+    (singletonCrossingEquiv (G := G) A F.frame.red F.frame.blue e hsingle)
+
+/-- The bond-model-conjugated matrix of a coarse matrix is the single-bundle matrix of
+the single-edge matrix obtained by reindexing through the bridge equivalence. -/
+theorem bondModelMatrix_eq_singletonBundleMatrix
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ) :
+    bondModelMatrix (G := G) F M =
+      singletonBundleMatrix (G := G) A F.frame.red F.frame.blue e hsingle
+        (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) M) := by
+  funext p q
+  have hbe : ∀ r : CrossingConfig (G := G) A F.frame.red F.frame.blue,
+      (bridgeEquiv (G := G) F e hsingle).symm
+          (singletonCrossingEquiv (G := G) A F.frame.red F.frame.blue e hsingle r) =
+        (F.bondModel coarseEdgeRB).symm r := by
+    intro r
+    rw [Equiv.symm_apply_eq, bridgeEquiv, Equiv.trans_apply, Equiv.apply_symm_apply]
+    rfl
+  rw [bondModelMatrix_apply, singletonBundleMatrix, Matrix.reindexAlgEquiv_apply,
+    Matrix.reindex_apply, Matrix.submatrix_apply, hbe, hbe]
+
+/-! ### The single-edge inserted-coefficient descent
+
+Chaining the inserted-coefficient descent with the single-edge bridge: the coarse
+edge-inserted coefficient at the red-to-blue super-bond descends, under the singleton
+hypothesis, to the host-merge fiber product times the single-edge region-inserted
+coefficient of the bridge-reindexed matrix on the single boundary edge `e`. -/
+
+open scoped Classical in
+/-- **The single-edge inserted-coefficient descent.** Under the singleton hypothesis,
+the coarse edge-inserted coefficient at the red-to-blue super-bond equals the host-merge
+fiber product times the single-edge region-inserted coefficient of the bridge-reindexed
+matrix on the single boundary edge `e`, with the red physical leg and the fused
+blue/complement host leg.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 254--583 and 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeInsertedCoeff_coarseTensor_descent_single
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (s : Fin 3 → Fin (coarseDim V d))
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ) :
+    edgeInsertedCoeff (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB s M =
+      hostMergeFiberProd F •
+        regionInsertedCoeff (G := G) A F.frame.red
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle)
+          (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) M)
+          (coarseProj F.frame.red (s 0))
+          ((F.frame.toThreeBlockGeometry hP).complPhysical
+            (coarseProj F.frame.blue (s 1)) (coarseProj F.frame.complement (s 2))) := by
+  rw [edgeInsertedCoeff_coarseTensor_descent F hP s M,
+    bondModelMatrix_eq_singletonBundleMatrix F e hsingle M,
+    redBundleInsertedCoeff_singleton F.frame.red F.frame.blue e hsingle]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -184,6 +184,26 @@ theorem edgeInsertedCoeff_coarseTensor_descent_single
     bondModelMatrix_eq_singletonBundleMatrix F e hsingle M,
     redBundleInsertedCoeff_singleton F.frame.red F.frame.blue e hsingle]
 
+/-! ### Region transport of the single-edge inserted coefficient
+
+The single-edge region-inserted coefficient transports along an equality of regions:
+relabel the inserted boundary edge and the two physical configurations along the
+equality. -/
+
+/-- The single-edge region-inserted coefficient is unchanged, up to relabelling the region,
+the boundary edge, and the physical configurations, along a region equality. -/
+theorem regionInsertedCoeff_congr {R R' : Finset V} (h : R = R')
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) A R' ⟨f.1, h ▸ f.2⟩ M
+        (regionPhysicalConfigCongr (d := d) h σ)
+        (regionPhysicalConfigCongr (d := d) (by rw [h]) τ) := by
+  subst h
+  rfl
+
 /-! ### The single-edge coefficient transfer between two coherent frames
 
 Two coherent frames over `A` and `B` sharing the three regions, the bond dimensions, and
@@ -304,6 +324,42 @@ theorem exists_regionInsertedCoeff_eq_of_coherentFrames
   show hostMergeFiberProd (G := G) F • _ = hostMergeFiberProd (G := G) F • _
   rw [hlhs, hrhs]
   exact hN s
+
+/-- **The single-region single-edge coefficient transfer.** Restating the coefficient
+transfer over the shared red region `R := F.frame.red`: for two coherent frames over `A`
+and `B` sharing the three regions, the bond dimensions, and the single-crossing edge `e`,
+with `A` and `B` generating the same state, every matrix inserted on `e` of `A` is matched
+by a matrix on `B` whose single-edge region-inserted coefficient over `R` agrees at every
+red and host physical configuration. This is the shape `bondLocal_iff_coeffTransfer`
+consumes.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--583 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionInsertedCoeff_eq_sharedRegion
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    ∃ N : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ,
+      ∀ (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)),
+        regionInsertedCoeff (G := G) A F.frame.red
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
+          regionInsertedCoeff (G := G) B F.frame.red
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ := by
+  obtain ⟨N, hN⟩ := exists_regionInsertedCoeff_eq_of_coherentFrames F F' hP hP' hred hblue hcompl
+    hbond hAB hd hpos e hsingle M
+  refine ⟨N, fun σ τ => ?_⟩
+  rw [hN σ τ, regionInsertedCoeff_congr (A := B) hred
+    (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ]
+  rfl
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -361,5 +361,61 @@ theorem exists_regionInsertedCoeff_eq_sharedRegion
     (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ]
   rfl
 
+/-! ### The host-block injectivity of a coherent frame
+
+The set complement of the red block, the union of the blue and complement blocks, is
+blocked-tensor injective: the disjoint union lemma applied to the blue and complement
+injectivities of the frame. -/
+
+/-- The host block `univ \ red` of a partitioned coherent frame is blocked-tensor
+injective. -/
+theorem regionInjective_compl_red (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (hpos : ∀ g : Edge G, 0 < A.bondDim g) :
+    RegionBlockedTensorInjective (G := G) A (Finset.univ \ F.frame.red) := by
+  rw [hP.sdiff_red]
+  exact regionBlockedTensorInjective_union_disjoint hP.blue_disjoint_complement
+    F.frame.blue_injective F.frame.complement_injective hpos
+
+/-! ### The bond-local transfer kernel and the per-edge gauge
+
+The single-region coefficient transfer feeds `bondLocal_iff_coeffTransfer` to give the
+bond-local transfer kernel on the single edge `e`, in both directions, and the per-edge
+gauge follows by the multiplicativity of the forward coefficient transfer. -/
+
+open scoped Classical in
+/-- **The bond-local transfer kernel of two coherent frames.** Two coherent frames over
+`A` and `B` sharing the three regions, the bond dimensions, and the single-crossing edge
+`e`, with `A` and `B` generating the same state, give the bond-local transfer kernel on the
+single boundary edge `e` of the shared red region: the transfer kernel of every inserted
+matrix is the incident-matrix kernel of some bond matrix on `e`.
+
+No single-vertex injectivity is used: the four block injectivities are the frame's
+blocked-region injectivities and the host-block disjoint union, and the coefficient
+transfer is the single-region transfer above.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the step `V=W`, lines 254--583
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem isBondLocalTransferKernel_of_coherentFrames
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (hRB : RegionBlockedTensorInjective (G := G) B F.frame.red)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ F.frame.red)) :
+    IsBondLocalTransferKernel (G := G) A B F.frame.red hRB hCB
+      (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) := by
+  rw [bondLocal_iff_coeffTransfer A B F.frame.red F.frame.red_injective hRB
+    (regionInjective_compl_red F hP hposA) hCB hAB hposA hposB hbond
+    (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle)]
+  intro M
+  exact exists_regionInsertedCoeff_eq_sharedRegion F F' hP hP' hred hblue hcompl hbond hAB
+    hd hposA e hsingle M
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -1,5 +1,6 @@
 import TNLean.PEPS.RegionBlock.CoarseThreeSite10
 import TNLean.PEPS.RegionBlock.ThreeBlockTransfer
+import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap5
 
 /-!
 # The single-edge inserted-coefficient transfer and the per-edge gauge
@@ -64,6 +65,21 @@ theorem hostMergeFiberProd_pos (F : CoherentCoarseBlockingFrame (G := G) (d := d
   exact Nat.mul_pos
     (Finset.prod_pos (fun e _ => hpos e)) (Finset.prod_pos (fun e _ => hpos e))
 
+variable {B : Tensor G d}
+
+/-- The host-merge fiber multiplicity depends only on the blue and complement regions and
+the bond dimensions: two coherent frames over `A` and `B` sharing those regions and bond
+dimensions have equal host-merge fiber multiplicities. -/
+theorem hostMergeFiberProd_eq (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hblue : F.frame.blue = F'.frame.blue) (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) :
+    hostMergeFiberProd (G := G) F = hostMergeFiberProd (G := G) F' := by
+  rw [hostMergeFiberProd, hostMergeFiberProd, regionNonIncidentBondProd,
+    regionNonIncidentBondProd, hostBlueFreeBondProd, hostBlueFreeBondProd, hcompl, hbond]
+  rw [hblue]
+  congr 1
+
 /-! ### The single-edge bridge matrix
 
 Under the singleton hypothesis, the coarse `r-b` super-bond `Fin (coarseBondDim
@@ -102,6 +118,35 @@ theorem bondModelMatrix_eq_singletonBundleMatrix
     rfl
   rw [bondModelMatrix_apply, singletonBundleMatrix, Matrix.reindexAlgEquiv_apply,
     Matrix.reindex_apply, Matrix.submatrix_apply, hbe, hbe]
+
+/-! ### Surjectivity of the descent's physical legs
+
+The descent reads the region-inserted coefficient at the red physical leg
+`coarseProj red (s 0)` and the host physical leg
+`complPhysical (coarseProj blue (s 1)) (coarseProj complement (s 2))`. As `s` varies,
+the red leg ranges over every red physical configuration (`coarseProj_surjective`) and the
+host leg over every host physical configuration (`coarseProj_surjective` on the blue and
+complement legs followed by `complPhysical_surjective`). -/
+
+/-- Every pair of a red physical configuration `σ` and a host physical configuration `τ`
+is realized by the descent's physical legs for some coarse physical assignment `s`. -/
+theorem exists_descent_legs (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (hd : 0 < d)
+    (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)) :
+    ∃ s : Fin 3 → Fin (coarseDim V d),
+      coarseProj F.frame.red (s 0) = σ ∧
+        (F.frame.toThreeBlockGeometry hP).complPhysical
+            (coarseProj F.frame.blue (s 1)) (coarseProj F.frame.complement (s 2)) = τ := by
+  obtain ⟨s0, hs0⟩ := coarseProj_surjective (V := V) (d := d) hd F.frame.red σ
+  obtain ⟨⟨σblue, σcompl⟩, hτ⟩ :=
+    (F.frame.toThreeBlockGeometry hP).complPhysical_surjective (d := d) τ
+  obtain ⟨s1, hs1⟩ := coarseProj_surjective (V := V) (d := d) hd F.frame.blue σblue
+  obtain ⟨s2, hs2⟩ := coarseProj_surjective (V := V) (d := d) hd F.frame.complement σcompl
+  refine ⟨![s0, s1, s2], hs0, ?_⟩
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons]
+  rw [hs1, hs2]; exact hτ
 
 /-! ### The single-edge inserted-coefficient descent
 

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -226,6 +226,98 @@ theorem hsingle_transport (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
   exact hsingle g
 
 open scoped Classical in
+/-- **The single-edge coefficient identity from a coarse identity.** If a coarse matrix
+`Ncoarse` on the second frame reproduces, at every coarse physical assignment, the coarse
+edge-inserted coefficient of the bond-model lift of `M`, then the single-edge
+region-inserted coefficient of `M` on `A` equals that of the bond-model image of `Ncoarse`
+on `B`, at every red and host physical configuration. The descent and the cancellation of
+the shared positive host-merge fiber product carry the coarse identity down to the single
+edge.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--583 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_eq_of_coarse_eq
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hd : 0 < d)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (Mcoarse : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ)
+    (Ncoarse : Matrix (Fin (F'.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F'.frame.coarseBondDim coarseEdgeRB)) ℂ)
+    (hN : ∀ s : Fin 3 → Fin (coarseDim V d),
+      edgeInsertedCoeff (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB s Mcoarse =
+        edgeInsertedCoeff (G := coarseGraph) (F'.frame.coarseTensor) coarseEdgeRB s Ncoarse)
+    (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)) :
+    regionInsertedCoeff (G := G) A F.frame.red
+        (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle)
+        (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) Mcoarse) σ τ =
+      regionInsertedCoeff (G := G) B F'.frame.red
+        (singleBoundaryEdge (G := G) B F'.frame.red F'.frame.blue e
+          (hsingle_transport F F' e hred hblue hsingle))
+        (Matrix.reindexAlgEquiv ℂ ℂ
+          (bridgeEquiv (G := G) F' e (hsingle_transport F F' e hred hblue hsingle)) Ncoarse)
+        (regionPhysicalConfigCongr (d := d) hred σ)
+        (regionPhysicalConfigCongr (d := d)
+          (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ) := by
+  classical
+  set hsingle' := hsingle_transport F F' e hred hblue hsingle with hsingle'_def
+  -- Realize `(σ, τ)` by the descent's physical legs on the first frame.
+  obtain ⟨s, hsσ, hsτ⟩ := exists_descent_legs F hP hd σ τ
+  -- The same coarse assignment realizes the transported legs on the second frame.
+  have hsσ' : coarseProj F'.frame.red (s 0) = regionPhysicalConfigCongr (d := d) hred σ := by
+    rw [← hsσ]; funext w; rfl
+  have hsτ' : (F'.frame.toThreeBlockGeometry hP').complPhysical
+        (coarseProj F'.frame.blue (s 1)) (coarseProj F'.frame.complement (s 2)) =
+      regionPhysicalConfigCongr (d := d)
+        (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ := by
+    funext w
+    rw [regionPhysicalConfigCongr_apply, ← hsτ]
+    -- Both fused host legs read `coarseDecode` on the same branch (blue/complement shared).
+    simp only [ThreeBlockGeometry.complPhysical, coarseProj]
+    by_cases hb : w.1 ∈ F'.frame.blue
+    · rw [dif_pos (show w.1 ∈ (F'.frame.toThreeBlockGeometry hP').blue from hb),
+        dif_pos (show w.1 ∈ (F.frame.toThreeBlockGeometry hP).blue by rw [show
+          (F.frame.toThreeBlockGeometry hP).blue = F.frame.blue from rfl, hblue]; exact hb)]
+    · rw [dif_neg (show w.1 ∉ (F'.frame.toThreeBlockGeometry hP').blue from hb),
+        dif_neg (show w.1 ∉ (F.frame.toThreeBlockGeometry hP).blue by rw [show
+          (F.frame.toThreeBlockGeometry hP).blue = F.frame.blue from rfl, hblue]; exact hb)]
+  -- The host-merge fiber products of the two frames coincide and are positive.
+  have hfiber : hostMergeFiberProd (G := G) F = hostMergeFiberProd (G := G) F' :=
+    hostMergeFiberProd_eq F F' hblue hcompl hbond
+  have hfpos : 0 < hostMergeFiberProd (G := G) F := hostMergeFiberProd_pos F hpos
+  -- Cancel the shared positive fiber product after the descent on both frames.
+  refine nsmul_right_injective (M := ℂ) (Nat.pos_iff_ne_zero.mp hfpos) ?_
+  -- The descent rewrites each side to a coarse edge-inserted coefficient.
+  have hlhs : hostMergeFiberProd (G := G) F •
+        regionInsertedCoeff (G := G) A F.frame.red
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle)
+          (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) Mcoarse) σ τ =
+      edgeInsertedCoeff (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB s Mcoarse := by
+    rw [← hsσ, ← hsτ,
+      ← edgeInsertedCoeff_coarseTensor_descent_single F hP e hsingle s Mcoarse]
+  have hrhs : hostMergeFiberProd (G := G) F •
+        regionInsertedCoeff (G := G) B F'.frame.red
+          (singleBoundaryEdge (G := G) B F'.frame.red F'.frame.blue e hsingle')
+          (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F' e hsingle') Ncoarse)
+          (regionPhysicalConfigCongr (d := d) hred σ)
+          (regionPhysicalConfigCongr (d := d)
+            (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ) =
+      edgeInsertedCoeff (G := coarseGraph) (F'.frame.coarseTensor) coarseEdgeRB s Ncoarse := by
+    rw [hfiber, ← hsσ', ← hsτ',
+      ← edgeInsertedCoeff_coarseTensor_descent_single F' hP' e hsingle' s Ncoarse]
+  show hostMergeFiberProd (G := G) F • _ = hostMergeFiberProd (G := G) F • _
+  rw [hlhs, hrhs]
+  exact hN s
+
+open scoped Classical in
 /-- **The single-edge coefficient transfer.** Two coherent frames over `A` and `B`
 sharing the three regions, the bond dimensions, and the single-crossing edge `e`, with
 `A` and `B` generating the same state, give: for every matrix `M` inserted on `e` of `A`
@@ -264,66 +356,20 @@ theorem exists_regionInsertedCoeff_eq_of_coherentFrames
             (regionPhysicalConfigCongr (d := d)
               (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ) := by
   classical
-  -- The singleton hypothesis on the second frame.
-  set hsingle' := hsingle_transport F F' e hred hblue hsingle with hsingle'_def
-  -- Lift `M` to the coarse `r-b` super-bond of the first frame.
-  set Mcoarse := Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M with hMc
   -- The coarse coefficient transfer gives a coarse matrix `Ncoarse` on the second frame.
   have hsame : SameState (F.frame.coarseTensor) (F'.frame.coarseTensor) :=
     coarseTensor_sameState_of_sameState F F' hP hP' hred hblue hcompl hbond hAB
-  obtain ⟨Ncoarse, hN⟩ := coarse_exists_edgeInsertedCoeff_eq F.frame F'.frame hsame Mcoarse
-  -- The descent recovers `M` from `Mcoarse` on the first frame.
-  have hMrecover : Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) Mcoarse = M := by
-    rw [hMc, ← Matrix.reindexAlgEquiv_symm, AlgEquiv.apply_symm_apply]
-  -- The descent's bridge-reindexed matrix on the second frame is the transfer output.
-  refine ⟨Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F' e hsingle') Ncoarse, ?_⟩
-  intro σ τ
-  -- Realize `(σ, τ)` by the descent's physical legs on the first frame.
-  obtain ⟨s, hsσ, hsτ⟩ := exists_descent_legs F hP hd σ τ
-  -- The same coarse assignment realizes the transported legs on the second frame.
-  have hsσ' : coarseProj F'.frame.red (s 0) = regionPhysicalConfigCongr (d := d) hred σ := by
-    rw [← hsσ]; funext w; rfl
-  have hsτ' : (F'.frame.toThreeBlockGeometry hP').complPhysical
-        (coarseProj F'.frame.blue (s 1)) (coarseProj F'.frame.complement (s 2)) =
-      regionPhysicalConfigCongr (d := d)
-        (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ := by
-    funext w
-    rw [regionPhysicalConfigCongr_apply, ← hsτ]
-    -- Both fused host legs read `coarseDecode` on the same branch (blue/complement shared).
-    simp only [ThreeBlockGeometry.complPhysical, coarseProj]
-    by_cases hb : w.1 ∈ F'.frame.blue
-    · rw [dif_pos (show w.1 ∈ (F'.frame.toThreeBlockGeometry hP').blue from hb),
-        dif_pos (show w.1 ∈ (F.frame.toThreeBlockGeometry hP).blue by rw [show
-          (F.frame.toThreeBlockGeometry hP).blue = F.frame.blue from rfl, hblue]; exact hb)]
-    · rw [dif_neg (show w.1 ∉ (F'.frame.toThreeBlockGeometry hP').blue from hb),
-        dif_neg (show w.1 ∉ (F.frame.toThreeBlockGeometry hP).blue by rw [show
-          (F.frame.toThreeBlockGeometry hP).blue = F.frame.blue from rfl, hblue]; exact hb)]
-  -- The host-merge fiber products of the two frames coincide and are positive.
-  have hfiber : hostMergeFiberProd (G := G) F = hostMergeFiberProd (G := G) F' :=
-    hostMergeFiberProd_eq F F' hblue hcompl hbond
-  have hfpos : 0 < hostMergeFiberProd (G := G) F := hostMergeFiberProd_pos F hpos
-  -- Cancel the shared positive fiber product after the descent on both frames.
-  refine nsmul_right_injective (M := ℂ) (Nat.pos_iff_ne_zero.mp hfpos) ?_
-  -- The descent rewrites each side to a coarse edge-inserted coefficient.
-  have hlhs : hostMergeFiberProd (G := G) F •
-        regionInsertedCoeff (G := G) A F.frame.red
-          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
-      edgeInsertedCoeff (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB s Mcoarse := by
-    rw [← hsσ, ← hsτ, ← hMrecover,
-      ← edgeInsertedCoeff_coarseTensor_descent_single F hP e hsingle s Mcoarse]
-  have hrhs : hostMergeFiberProd (G := G) F •
-        regionInsertedCoeff (G := G) B F'.frame.red
-          (singleBoundaryEdge (G := G) B F'.frame.red F'.frame.blue e hsingle')
-          (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F' e hsingle') Ncoarse)
-          (regionPhysicalConfigCongr (d := d) hred σ)
-          (regionPhysicalConfigCongr (d := d)
-            (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ) =
-      edgeInsertedCoeff (G := coarseGraph) (F'.frame.coarseTensor) coarseEdgeRB s Ncoarse := by
-    rw [hfiber, ← hsσ', ← hsτ',
-      ← edgeInsertedCoeff_coarseTensor_descent_single F' hP' e hsingle' s Ncoarse]
-  show hostMergeFiberProd (G := G) F • _ = hostMergeFiberProd (G := G) F • _
-  rw [hlhs, hrhs]
-  exact hN s
+  obtain ⟨Ncoarse, hN⟩ := coarse_exists_edgeInsertedCoeff_eq F.frame F'.frame hsame
+    (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M)
+  refine ⟨Matrix.reindexAlgEquiv ℂ ℂ
+    (bridgeEquiv (G := G) F' e (hsingle_transport F F' e hred hblue hsingle)) Ncoarse,
+    fun σ τ => ?_⟩
+  have hMrecover : Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle)
+      (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M) = M := by
+    rw [← Matrix.reindexAlgEquiv_symm, AlgEquiv.apply_symm_apply]
+  rw [← hMrecover]
+  exact regionInsertedCoeff_eq_of_coarse_eq F F' hP hP' hred hblue hcompl hbond hd hpos e
+    hsingle _ Ncoarse hN σ τ
 
 /-- **The single-region single-edge coefficient transfer.** Restating the coefficient
 transfer over the shared red region `R := F.frame.red`: for two coherent frames over `A`

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -313,7 +313,7 @@ theorem regionInsertedCoeff_eq_of_coarse_eq
       edgeInsertedCoeff (G := coarseGraph) (F'.frame.coarseTensor) coarseEdgeRB s Ncoarse := by
     rw [hfiber, ← hsσ', ← hsτ',
       ← edgeInsertedCoeff_coarseTensor_descent_single F' hP' e hsingle' s Ncoarse]
-  show hostMergeFiberProd (G := G) F • _ = hostMergeFiberProd (G := G) F • _
+  change hostMergeFiberProd (G := G) F • _ = hostMergeFiberProd (G := G) F • _
   rw [hlhs, hrhs]
   exact hN s
 
@@ -400,8 +400,8 @@ theorem exists_regionInsertedCoeff_eq_sharedRegion
             (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
           regionInsertedCoeff (G := G) B F.frame.red
             (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ := by
-  obtain ⟨N, hN⟩ := exists_regionInsertedCoeff_eq_of_coherentFrames F F' hP hP' hred hblue hcompl
-    hbond hAB hd hpos e hsingle M
+  obtain ⟨N, hN⟩ := exists_regionInsertedCoeff_eq_of_coherentFrames F F' hP hP' hred hblue
+    hcompl hbond hAB hd hpos e hsingle M
   refine ⟨N, fun σ τ => ?_⟩
   rw [hN σ τ, regionInsertedCoeff_congr (A := B) hred
     (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ]
@@ -474,7 +474,8 @@ theorem regionEdgeTransfer_regionInsertedCoeff
     (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
     (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
     F'.frame.coarseTensor_pos_bondDim Mcoarse with hNc
-  have hMrecover : Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) Mcoarse = M := by
+  have hMrecover :
+      Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) Mcoarse = M := by
     rw [hMc, ← Matrix.reindexAlgEquiv_symm, AlgEquiv.apply_symm_apply]
   have hRtransfer : regionEdgeTransfer F F' hred hblue e hsingle M =
       Matrix.reindexAlgEquiv ℂ ℂ
@@ -514,7 +515,8 @@ theorem regionEdgeTransfer_mul
   rw [regionEdgeTransfer, regionEdgeTransfer, regionEdgeTransfer]
   rw [show Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm (M * M') =
       Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M *
-        Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M' from map_mul _ _ _]
+        Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M'
+      from map_mul _ _ _]
   rw [show edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
         (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
         (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
@@ -656,6 +658,187 @@ theorem isBondLocalTransferKernel_of_coherentFrames
   intro M
   exact exists_regionInsertedCoeff_eq_sharedRegion F F' hP hP' hred hblue hcompl hbond hAB
     hd hposA e hsingle M
+
+/-! ### The per-edge gauge from two coherent frames
+
+The single-region coefficient transfers in both directions, with the multiplicative concrete
+forward transfer, feed `exists_regionEdgeGauge_of_coeffTransfer`: the forward per-edge matrix
+transfer on `e` is conjugation by an invertible gauge matrix, and the bond dimensions on `e`
+coincide. The multiplicativity of the chosen forward transfer is the concrete transfer's
+multiplicativity, transported through `regionInsertedCoeff_injective`. -/
+
+open scoped Classical in
+/-- The chosen forward coefficient transfer equals the concrete multiplicative transfer:
+both realize the same region-inserted coefficient on `B`, so block injectivity identifies
+them. -/
+theorem coeffTransferMap_eq_regionEdgeTransfer
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim
+        (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+        (Fin (A.bondDim (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+          (Fin (B.bondDim
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)),
+          regionInsertedCoeff (G := G) A F.frame.red
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
+            regionInsertedCoeff (G := G) B F.frame.red
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    coeffTransferMap (G := G) A B F.frame.red
+        (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) htransferAB M =
+      regionEdgeTransfer F F' hred hblue e hsingle M := by
+  have hRB : RegionBlockedTensorInjective (G := G) B F.frame.red := by
+    rw [hred]; exact F'.frame.red_injective
+  have hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ F.frame.red) := by
+    rw [hred]; exact regionInjective_compl_red F' hP' hposB
+  refine regionInsertedCoeff_injective (G := G) B F.frame.red hRB hCB hposB
+    (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) _ _ (fun σ τ => ?_)
+  rw [← coeffTransferMap_coeff A B F.frame.red
+      (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) htransferAB M σ τ,
+    ← regionEdgeTransfer_regionInsertedCoeff_sharedRegion F F' hP hP' hred hblue hcompl hbond
+      hAB hd hposA e hsingle M σ τ]
+
+open scoped Classical in
+/-- **The per-edge gauge from two coherent frames.** Two coherent frames over `A` and `B`
+sharing the three regions, the bond dimensions, and the single-crossing edge `e`, with `A`
+and `B` generating the same state, give a per-edge gauge on `e`: the forward per-edge matrix
+transfer is conjugation by an invertible matrix `Z`, and the bond dimensions on `e` coincide.
+
+No single-vertex injectivity is used: the four block injectivities are the frames'
+blocked-region injectivities and the host-block disjoint unions, the two coefficient transfers
+are the single-region transfers above, and the forward multiplicativity is the concrete
+transfer's multiplicativity carried through `regionInsertedCoeff_injective`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_of_coherentFrames
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e) :
+    ∀ (hRB : RegionBlockedTensorInjective (G := G) B F.frame.red)
+      (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ F.frame.red)),
+    ∃ htransferAB :
+        ∀ M : Matrix (Fin (A.bondDim
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+            (Fin (A.bondDim
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+          ∃ N : Matrix (Fin (B.bondDim
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+              (Fin (B.bondDim
+                (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+            ∀ (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+              (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)),
+              regionInsertedCoeff (G := G) A F.frame.red
+                  (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
+                regionInsertedCoeff (G := G) B F.frame.red
+                  (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ,
+      ∃ htransferBA :
+        ∀ N : Matrix (Fin (B.bondDim
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+            (Fin (B.bondDim
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+          ∃ M : Matrix (Fin (A.bondDim
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+              (Fin (A.bondDim
+                (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+            ∀ (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+              (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)),
+              regionInsertedCoeff (G := G) B F.frame.red
+                  (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ =
+                regionInsertedCoeff (G := G) A F.frame.red
+                  (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ,
+      ∃ hmul : ∀ M M' : Matrix (Fin (A.bondDim
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+            (Fin (A.bondDim
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+          coeffTransferMap (G := G) A B F.frame.red
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle)
+              htransferAB (M * M') =
+            coeffTransferMap (G := G) A B F.frame.red
+                (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) htransferAB M *
+              coeffTransferMap (G := G) A B F.frame.red
+                (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) htransferAB M',
+      ∃ hEdge : A.bondDim
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1 =
+        B.bondDim (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1,
+        ∃ Z : GL (Fin (B.bondDim
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+          ∀ M : Matrix (Fin (A.bondDim
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+              (Fin (A.bondDim
+                (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+            (regionInsertionTransfer_of_coeffTransfer A B F.frame.red
+                (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) hRB hCB hAB
+                hposB hbond htransferAB htransferBA hmul).fwd M =
+              (Z : Matrix (Fin (B.bondDim
+                  (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+                  (Fin (B.bondDim
+                    (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ) *
+                Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+                ((Z⁻¹ : GL (Fin (B.bondDim
+                  (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ) :
+                  Matrix (Fin (B.bondDim
+                    (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+                    (Fin (B.bondDim
+                      (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+                    ℂ) := by
+  intro hRB hCB
+  set f := singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle with hf
+  -- The forward coefficient transfer is the concrete transfer's coefficient identity.
+  have htransferAB :
+      ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+          ∀ (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+            (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)),
+            regionInsertedCoeff (G := G) A F.frame.red f M σ τ =
+              regionInsertedCoeff (G := G) B F.frame.red f N σ τ :=
+    fun M => exists_regionInsertedCoeff_eq_sharedRegion F F' hP hP' hred hblue hcompl hbond hAB
+      hd hposA e hsingle M
+  have htransferBA :
+      ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∃ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+          ∀ (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+            (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)),
+            regionInsertedCoeff (G := G) B F.frame.red f N σ τ =
+              regionInsertedCoeff (G := G) A F.frame.red f M σ τ :=
+    fun N => exists_regionInsertedCoeff_eq_sharedRegion_symm F F' hP hP' hred hblue hcompl hbond
+      hAB hd hposB e hsingle N
+  -- The forward multiplicativity, via the concrete transfer's multiplicativity.
+  have hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B F.frame.red f htransferAB (M * M') =
+        coeffTransferMap (G := G) A B F.frame.red f htransferAB M *
+          coeffTransferMap (G := G) A B F.frame.red f htransferAB M' := by
+    intro M M'
+    rw [coeffTransferMap_eq_regionEdgeTransfer F F' hP hP' hred hblue hcompl hbond hAB hd hposA
+        hposB e hsingle htransferAB (M * M'),
+      coeffTransferMap_eq_regionEdgeTransfer F F' hP hP' hred hblue hcompl hbond hAB hd hposA
+        hposB e hsingle htransferAB M,
+      coeffTransferMap_eq_regionEdgeTransfer F F' hP hP' hred hblue hcompl hbond hAB hd hposA
+        hposB e hsingle htransferAB M']
+    exact regionEdgeTransfer_mul F F' hP hP' hred hblue hcompl hbond hAB e hsingle M M'
+  refine ⟨htransferAB, htransferBA, hmul, ?_⟩
+  exact exists_regionEdgeGauge_of_coeffTransfer A B F.frame.red f
+    F.frame.red_injective (regionInjective_compl_red F hP hposA) hRB hCB
+    hAB hposA hposB hbond htransferAB htransferBA hmul
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -407,6 +407,136 @@ theorem exists_regionInsertedCoeff_eq_sharedRegion
     (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ]
   rfl
 
+/-! ### The concrete single-edge transfer and its multiplicativity
+
+The coarse edge-transfer matrix `edgeTransferMatrix` on the coarse `r-b` edge is an
+explicit, multiplicative coefficient transfer. Conjugating it by the bond models of the
+two frames gives an explicit single-edge transfer on `e`, multiplicative by
+`edgeTransferMatrix_mul` and the algebra-equivalence reindexing. -/
+
+/-- **The concrete single-edge transfer.** The coarse edge-transfer matrix on the coarse
+`r-b` edge, conjugated by the two frames' bond models into an explicit matrix transfer on
+the single edge `e`. -/
+noncomputable def regionEdgeTransfer
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ :=
+  Matrix.reindexAlgEquiv ℂ ℂ
+    (bridgeEquiv (G := G) F' e (hsingle_transport F F' e hred hblue hsingle))
+    (edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
+      (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+      (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+      F'.frame.coarseTensor_pos_bondDim
+      (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M))
+
+open scoped Classical in
+/-- **The concrete single-edge transfer matches the region-inserted coefficient.** The
+single-edge region-inserted coefficient of `M` on `A` equals that of the concrete transfer
+`regionEdgeTransfer M` on `B`, at every red and host physical configuration: the coarse
+edge-transfer matrix matches the coarse edge-inserted coefficient
+(`edgeTransferMatrix_edgeInsertedCoeff`), and the descent carries it down to the edge.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--583 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionEdgeTransfer_regionInsertedCoeff
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)) :
+    regionInsertedCoeff (G := G) A F.frame.red
+        (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
+      regionInsertedCoeff (G := G) B F'.frame.red
+        (singleBoundaryEdge (G := G) B F'.frame.red F'.frame.blue e
+          (hsingle_transport F F' e hred hblue hsingle))
+        (regionEdgeTransfer F F' hred hblue e hsingle M)
+        (regionPhysicalConfigCongr (d := d) hred σ)
+        (regionPhysicalConfigCongr (d := d)
+          (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ) := by
+  classical
+  have hsame : SameState (F.frame.coarseTensor) (F'.frame.coarseTensor) :=
+    coarseTensor_sameState_of_sameState F F' hP hP' hred hblue hcompl hbond hAB
+  set Mcoarse := Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M with hMc
+  set Ncoarse := edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
+    (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+    (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+    F'.frame.coarseTensor_pos_bondDim Mcoarse with hNc
+  have hMrecover : Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) Mcoarse = M := by
+    rw [hMc, ← Matrix.reindexAlgEquiv_symm, AlgEquiv.apply_symm_apply]
+  have hRtransfer : regionEdgeTransfer F F' hred hblue e hsingle M =
+      Matrix.reindexAlgEquiv ℂ ℂ
+        (bridgeEquiv (G := G) F' e (hsingle_transport F F' e hred hblue hsingle)) Ncoarse := rfl
+  rw [hRtransfer]
+  conv_lhs => rw [← hMrecover]
+  refine regionInsertedCoeff_eq_of_coarse_eq F F' hP hP' hred hblue hcompl hbond hd hpos e
+    hsingle Mcoarse Ncoarse (fun s => ?_) σ τ
+  exact edgeTransferMatrix_edgeInsertedCoeff (F.frame.coarseTensor) (F'.frame.coarseTensor)
+    coarseEdgeRB (F.frame.coarseTensor_edgeBlockedThreeSiteInjective)
+    (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective) hsame
+    F'.frame.coarseTensor_pos_bondDim Mcoarse s
+
+/-- **The concrete single-edge transfer is multiplicative.** The conjugated coarse
+edge-transfer matrix sends a product to the product of the transfers: the coarse transfer is
+multiplicative (`edgeTransferMatrix_mul`) and the bond-model reindexings are algebra
+equivalences.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, the homomorphism `X->O`, lines
+254--583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem regionEdgeTransfer_mul
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (M M' : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    regionEdgeTransfer F F' hred hblue e hsingle (M * M') =
+      regionEdgeTransfer F F' hred hblue e hsingle M *
+        regionEdgeTransfer F F' hred hblue e hsingle M' := by
+  have hsame : SameState (F.frame.coarseTensor) (F'.frame.coarseTensor) :=
+    coarseTensor_sameState_of_sameState F F' hP hP' hred hblue hcompl hbond hAB
+  rw [regionEdgeTransfer, regionEdgeTransfer, regionEdgeTransfer]
+  rw [show Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm (M * M') =
+      Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M *
+        Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M' from map_mul _ _ _]
+  rw [show edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
+        (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+        (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+        F'.frame.coarseTensor_pos_bondDim
+        (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M *
+          Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M') =
+      edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
+          (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+          (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+          F'.frame.coarseTensor_pos_bondDim
+          (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M) *
+        edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
+          (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+          (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
+          F'.frame.coarseTensor_pos_bondDim
+          (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M') from
+      edgeTransferMatrix_mul (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
+        (F.frame.coarseTensor_edgeBlockedThreeSiteInjective)
+        (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective) hsame
+        F'.frame.coarseTensor_pos_bondDim _ _]
+  exact map_mul _ _ _
+
 /-! ### The host-block injectivity of a coherent frame
 
 The set complement of the red block, the union of the blue and complement blocks, is

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -537,6 +537,34 @@ theorem regionEdgeTransfer_mul
         F'.frame.coarseTensor_pos_bondDim _ _]
   exact map_mul _ _ _
 
+/-- **The concrete single-edge transfer matches the region-inserted coefficient over the
+shared region.** Restating `regionEdgeTransfer_regionInsertedCoeff` over `R := F.frame.red`
+for both tensors. -/
+theorem regionEdgeTransfer_regionInsertedCoeff_sharedRegion
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)) :
+    regionInsertedCoeff (G := G) A F.frame.red
+        (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
+      regionInsertedCoeff (G := G) B F.frame.red
+        (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle)
+        (regionEdgeTransfer F F' hred hblue e hsingle M) σ τ := by
+  rw [regionEdgeTransfer_regionInsertedCoeff F F' hP hP' hred hblue hcompl hbond hAB hd hpos e
+    hsingle M σ τ, regionInsertedCoeff_congr (A := B) hred
+    (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle)
+    (regionEdgeTransfer F F' hred hblue e hsingle M) σ τ]
+  rfl
+
 /-! ### The host-block injectivity of a coherent frame
 
 The set complement of the red block, the union of the blue and complement blocks, is
@@ -551,6 +579,42 @@ theorem regionInjective_compl_red (F : CoherentCoarseBlockingFrame (G := G) (d :
   rw [hP.sdiff_red]
   exact regionBlockedTensorInjective_union_disjoint hP.blue_disjoint_complement
     F.frame.blue_injective F.frame.complement_injective hpos
+
+/-- **The backward single-region single-edge coefficient transfer.** The `B → A` direction
+of the single-region coefficient transfer over `R := F.frame.red`: every matrix inserted on
+`e` of `B` is matched by a matrix on `A`. -/
+theorem exists_regionInsertedCoeff_eq_sharedRegion_symm
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (N : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) :
+    ∃ M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ,
+      ∀ (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)),
+        regionInsertedCoeff (G := G) B F.frame.red
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ =
+          regionInsertedCoeff (G := G) A F.frame.red
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ := by
+  -- The transported singleton hypothesis on the second frame's regions.
+  have hsingle' := hsingle_transport F F' e hred hblue hsingle
+  -- The swapped frames give the `B → A` transfer over `F'.frame.red`.
+  obtain ⟨M, hM⟩ := exists_regionInsertedCoeff_eq_sharedRegion F' F hP' hP hred.symm hblue.symm
+    hcompl.symm hbond.symm hAB.symm hd hposB e hsingle' N
+  refine ⟨M, fun σ τ => ?_⟩
+  rw [regionInsertedCoeff_congr (A := B) hred
+      (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ,
+    regionInsertedCoeff_congr (A := A) hred
+      (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ]
+  exact hM (regionPhysicalConfigCongr (d := d) hred σ)
+    (regionPhysicalConfigCongr (d := d)
+      (show Finset.univ \ F.frame.red = Finset.univ \ F'.frame.red by rw [hred]) τ)
 
 /-! ### The bond-local transfer kernel and the per-edge gauge
 

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
@@ -116,5 +116,161 @@ def crossingTripleEquiv (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) :
         F.bondModel coarseEdgeRC (η coarseEdgeRC),
         F.bondModel coarseEdgeBC (η coarseEdgeBC)) := rfl
 
+/-! ### Crossing labels of a global configuration
+
+The crossing label of a global virtual configuration on a region pair reads its
+values on the edges crossing between the two regions. Through the partition every
+region boundary edge crosses to exactly one partner region, so a region boundary
+configuration is recovered from the two crossing labels on its incident super-edges.
+Matching a coarse configuration's induced region boundary configuration against a
+global configuration's region boundary label therefore decomposes, per super-edge,
+into matching the corresponding crossing label against the bond model. -/
+
+/-- The crossing label of a global virtual configuration on the region pair `R, R'`:
+its values on the edges crossing between the two regions. -/
+def crossingLabel (A : Tensor G d) (R R' : Finset V) (ζ : VirtualConfig A) :
+    CrossingConfig (G := G) A R R' := fun g => ζ g.1
+
+omit [DecidableEq V] [Fintype V] in
+@[simp] theorem crossingLabel_apply (A : Tensor G d) (R R' : Finset V) (ζ : VirtualConfig A)
+    (g : {g : Edge G // IsCrossingEdge (G := G) A R R' g}) :
+    crossingLabel (G := G) A R R' ζ g = ζ g.1 := rfl
+
+omit [Fintype V] [DecidableEq V] in
+/-- An edge crossing between `R` and `R''` does not also cross between `R` and `R'`
+when the three regions are pairwise disjoint: the shared out-of-`R` endpoint would
+lie in both `R'` and `R''`. -/
+theorem not_crossing_of_crossing_disjoint {R R' R'' : Finset V}
+    (hRR' : Disjoint R R') (hRR'' : Disjoint R R'') (hR'R'' : Disjoint R' R'') {g : Edge G}
+    (h : IsCrossingEdge (G := G) A R R'' g) :
+    ¬ IsCrossingEdge (G := G) A R R' g := by
+  rintro hbad
+  rcases h.1 with ⟨hR1, hR2⟩ | ⟨hR1, hR2⟩
+  · have hg1n'' : g.1.1 ∉ R'' := (Finset.disjoint_left.mp hRR'') hR1
+    have hg1n' : g.1.1 ∉ R' := (Finset.disjoint_left.mp hRR') hR1
+    have hg2'' : g.1.2 ∈ R'' := by
+      rcases h.2 with ⟨hc1, _⟩ | ⟨_, hc2⟩
+      · exact absurd hc1 hg1n''
+      · exact hc2
+    have hg2' : g.1.2 ∈ R' := by
+      rcases hbad.2 with ⟨hc1, _⟩ | ⟨_, hc2⟩
+      · exact absurd hc1 hg1n'
+      · exact hc2
+    exact (Finset.disjoint_left.mp hR'R'') hg2' hg2''
+  · have hg2n'' : g.1.2 ∉ R'' := (Finset.disjoint_left.mp hRR'') hR2
+    have hg2n' : g.1.2 ∉ R' := (Finset.disjoint_left.mp hRR') hR2
+    have hg1'' : g.1.1 ∈ R'' := by
+      rcases h.2 with ⟨hc1, _⟩ | ⟨_, hc2⟩
+      · exact hc1
+      · exact absurd hc2 hg2n''
+    have hg1' : g.1.1 ∈ R' := by
+      rcases hbad.2 with ⟨hc1, _⟩ | ⟨_, hc2⟩
+      · exact hc1
+      · exact absurd hc2 hg2n'
+    exact (Finset.disjoint_left.mp hR'R'') hg1' hg1''
+
+variable (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+
+/-- **Red boundary match, `r-b` super-bond.** If a coarse configuration's induced red
+boundary configuration equals a global configuration's red boundary label, the `r-b`
+bond model reads `η`'s `r-b` super-bond as the global configuration's red-to-blue
+crossing label. -/
+theorem bondModel_rb_eq_of_legEquivRed_eq (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor)) (ζr : VirtualConfig A)
+    (h : F.frame.legEquivRed (fun ie => η ie.1) = regionBoundaryLabel (G := G) A F.frame.red ζr) :
+    F.bondModel coarseEdgeRB (η coarseEdgeRB) =
+        crossingLabel (G := G) A F.frame.red F.frame.blue ζr := by
+  funext g
+  have hcross : IsCrossingEdge (G := G) A F.frame.red F.frame.blue g.1 := g.2
+  have hbdry : IsRegionBoundaryEdge (G := G) F.frame.red g.1 := hcross.1
+  have hkey := congrFun h ⟨g.1, hbdry⟩
+  rw [F.legEquivRed_apply_eq hP η ⟨g.1, hbdry⟩, dif_pos hcross] at hkey
+  simp only [regionBoundaryLabel_apply] at hkey
+  rw [crossingLabel]; exact hkey
+
+/-- **Red boundary match, `r-c` super-bond.** -/
+theorem bondModel_rc_eq_of_legEquivRed_eq (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor)) (ζr : VirtualConfig A)
+    (h : F.frame.legEquivRed (fun ie => η ie.1) = regionBoundaryLabel (G := G) A F.frame.red ζr) :
+    F.bondModel coarseEdgeRC (η coarseEdgeRC) =
+        crossingLabel (G := G) A F.frame.red F.frame.complement ζr := by
+  funext g
+  have hcross : IsCrossingEdge (G := G) A F.frame.red F.frame.complement g.1 := g.2
+  have hbdry : IsRegionBoundaryEdge (G := G) F.frame.red g.1 := hcross.1
+  -- This edge crosses to the complement, not to blue, so the dichotomy resolves right.
+  have hnb : ¬ IsCrossingEdge (G := G) A F.frame.red F.frame.blue g.1 :=
+    not_crossing_of_crossing_disjoint (A := A) hP.red_disjoint_blue
+      hP.red_disjoint_complement hP.blue_disjoint_complement hcross
+  have hkey := congrFun h ⟨g.1, hbdry⟩
+  rw [F.legEquivRed_apply_eq hP η ⟨g.1, hbdry⟩, dif_neg hnb] at hkey
+  simp only [regionBoundaryLabel_apply] at hkey
+  rw [crossingLabel]; exact hkey
+
+/-- **Blue boundary match, `r-b` super-bond.** -/
+theorem bondModel_rb_eq_of_legEquivBlue_eq (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor)) (ζb : VirtualConfig A)
+    (h : F.frame.legEquivBlue (fun ie => η ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.blue ζb) :
+    F.bondModel coarseEdgeRB (η coarseEdgeRB) =
+        (fun g => ζb g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue) := by
+  funext g
+  have hcross : IsCrossingEdge (G := G) A F.frame.red F.frame.blue g.1 := g.2
+  have hbdry : IsRegionBoundaryEdge (G := G) F.frame.blue g.1 := hcross.2
+  have hkey := congrFun h ⟨g.1, hbdry⟩
+  rw [F.legEquivBlue_apply_eq hP η ⟨g.1, hbdry⟩, dif_pos hcross] at hkey
+  simp only [regionBoundaryLabel_apply] at hkey
+  exact hkey
+
+/-- **Blue boundary match, `b-c` super-bond.** -/
+theorem bondModel_bc_eq_of_legEquivBlue_eq (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor)) (ζb : VirtualConfig A)
+    (h : F.frame.legEquivBlue (fun ie => η ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.blue ζb) :
+    F.bondModel coarseEdgeBC (η coarseEdgeBC) =
+        crossingLabel (G := G) A F.frame.blue F.frame.complement ζb := by
+  funext g
+  have hcross : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement g.1 := g.2
+  have hbdry : IsRegionBoundaryEdge (G := G) F.frame.blue g.1 := hcross.1
+  have hnb : ¬ IsCrossingEdge (G := G) A F.frame.red F.frame.blue g.1 := fun hbad =>
+    not_crossing_of_crossing_disjoint (A := A) hP.red_disjoint_blue.symm
+      hP.blue_disjoint_complement hP.red_disjoint_complement hcross hbad.symm
+  have hkey := congrFun h ⟨g.1, hbdry⟩
+  rw [F.legEquivBlue_apply_eq hP η ⟨g.1, hbdry⟩, dif_neg hnb] at hkey
+  simp only [regionBoundaryLabel_apply] at hkey
+  rw [crossingLabel]; exact hkey
+
+/-- **Complement boundary match, `r-c` super-bond.** -/
+theorem bondModel_rc_eq_of_legEquivComplement_eq (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor)) (ζc : VirtualConfig A)
+    (h : F.frame.legEquivComplement (fun ie => η ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.complement ζc) :
+    F.bondModel coarseEdgeRC (η coarseEdgeRC) =
+        (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.red F.frame.complement) := by
+  funext g
+  have hcross : IsCrossingEdge (G := G) A F.frame.red F.frame.complement g.1 := g.2
+  have hbdry : IsRegionBoundaryEdge (G := G) F.frame.complement g.1 := hcross.2
+  have hkey := congrFun h ⟨g.1, hbdry⟩
+  rw [F.legEquivComplement_apply_eq hP η ⟨g.1, hbdry⟩, dif_pos hcross] at hkey
+  simp only [regionBoundaryLabel_apply] at hkey
+  exact hkey
+
+/-- **Complement boundary match, `b-c` super-bond.** -/
+theorem bondModel_bc_eq_of_legEquivComplement_eq (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor)) (ζc : VirtualConfig A)
+    (h : F.frame.legEquivComplement (fun ie => η ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.complement ζc) :
+    F.bondModel coarseEdgeBC (η coarseEdgeBC) =
+        (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.blue F.frame.complement) := by
+  funext g
+  have hcross : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement g.1 := g.2
+  have hbdry : IsRegionBoundaryEdge (G := G) F.frame.complement g.1 := hcross.2
+  have hnr : ¬ IsCrossingEdge (G := G) A F.frame.red F.frame.complement g.1 := fun hbad =>
+    not_crossing_of_crossing_disjoint (A := A) hP.red_disjoint_complement.symm
+      hP.blue_disjoint_complement.symm hP.red_disjoint_blue hcross.symm hbad.symm
+  have hkey := congrFun h ⟨g.1, hbdry⟩
+  rw [F.legEquivComplement_apply_eq hP η ⟨g.1, hbdry⟩, dif_neg hnr] at hkey
+  simp only [regionBoundaryLabel_apply] at hkey
+  exact hkey
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
@@ -272,5 +272,75 @@ theorem bondModel_bc_eq_of_legEquivComplement_eq (hP : F.frame.IsPartition)
   simp only [regionBoundaryLabel_apply] at hkey
   exact hkey
 
+/-! ### Recovering the region boundary configs from the bond models
+
+The converse of the boundary matches: a coarse configuration whose two incident bond
+models read a global configuration's crossing labels induces exactly that global
+configuration's region boundary label. This is the existence half of the inner
+super-bond count: a pairwise-agreeing triple of global configurations is realised by
+a coarse configuration. -/
+
+/-- **Red boundary recovery.** If the `r-b` and `r-c` bond models of `η` read `ζr`'s
+red-to-blue and red-to-complement crossing labels, the red boundary configuration
+induced by `η` is `ζr`'s red boundary label. -/
+theorem legEquivRed_eq_of_bondModel (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor)) (ζr : VirtualConfig A)
+    (hrb : F.bondModel coarseEdgeRB (η coarseEdgeRB) =
+      crossingLabel (G := G) A F.frame.red F.frame.blue ζr)
+    (hrc : F.bondModel coarseEdgeRC (η coarseEdgeRC) =
+      crossingLabel (G := G) A F.frame.red F.frame.complement ζr) :
+    F.frame.legEquivRed (fun ie => η ie.1) = regionBoundaryLabel (G := G) A F.frame.red ζr := by
+  funext b
+  rw [F.legEquivRed_apply_eq hP η b]
+  by_cases hb : IsCrossingEdge (G := G) A F.frame.red F.frame.blue b.1
+  · rw [dif_pos hb]
+    have := congrFun hrb ⟨b.1, hb⟩
+    rw [crossingLabel_apply] at this; rw [this]; rfl
+  · rw [dif_neg hb]
+    have hc : IsCrossingEdge (G := G) A F.frame.red F.frame.complement b.1 :=
+      (F.frame.isCrossingEdge_red_blue_or_red_complement hP b.2).resolve_left hb
+    have := congrFun hrc ⟨b.1, hc⟩
+    rw [crossingLabel_apply] at this; rw [this]; rfl
+
+/-- **Blue boundary recovery.** -/
+theorem legEquivBlue_eq_of_bondModel (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor)) (ζb : VirtualConfig A)
+    (hrb : F.bondModel coarseEdgeRB (η coarseEdgeRB) =
+      (fun g => ζb g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue))
+    (hbc : F.bondModel coarseEdgeBC (η coarseEdgeBC) =
+      crossingLabel (G := G) A F.frame.blue F.frame.complement ζb) :
+    F.frame.legEquivBlue (fun ie => η ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.blue ζb := by
+  funext b
+  rw [F.legEquivBlue_apply_eq hP η b]
+  by_cases hb : IsCrossingEdge (G := G) A F.frame.red F.frame.blue b.1
+  · rw [dif_pos hb]
+    have := congrFun hrb ⟨b.1, hb⟩; rw [this]; rfl
+  · rw [dif_neg hb]
+    have hc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement b.1 :=
+      (F.frame.isCrossingEdge_red_blue_or_blue_complement hP b.2).resolve_left hb
+    have := congrFun hbc ⟨b.1, hc⟩
+    rw [crossingLabel_apply] at this; rw [this]; rfl
+
+/-- **Complement boundary recovery.** -/
+theorem legEquivComplement_eq_of_bondModel (hP : F.frame.IsPartition)
+    (η : VirtualConfig (F.frame.coarseTensor)) (ζc : VirtualConfig A)
+    (hrc : F.bondModel coarseEdgeRC (η coarseEdgeRC) =
+      (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.red F.frame.complement))
+    (hbc : F.bondModel coarseEdgeBC (η coarseEdgeBC) =
+      (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.blue F.frame.complement)) :
+    F.frame.legEquivComplement (fun ie => η ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.complement ζc := by
+  funext b
+  rw [F.legEquivComplement_apply_eq hP η b]
+  by_cases hb : IsCrossingEdge (G := G) A F.frame.red F.frame.complement b.1
+  · rw [dif_pos hb]
+    have := congrFun hrc ⟨b.1, hb⟩; rw [this]; rfl
+  · rw [dif_neg hb]
+    have hc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement b.1 :=
+      (F.frame.isCrossingEdge_red_complement_or_blue_complement hP b.2).resolve_left hb
+    have := congrFun hbc ⟨b.1, hc⟩
+    rw [this]; rfl
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
@@ -61,5 +61,60 @@ theorem coarse_virtualConfig_ext {A : Tensor G d}
   funext f
   rcases coarse_edge_cases f with h | h | h <;> subst h <;> assumption
 
+variable {A : Tensor G d}
+
+/-! ### The crossing-triple reindexing of coarse virtual configurations
+
+The bond models of a coherent frame are equivalences between the three coarse
+super-bonds and the three original inter-region crossing configurations. Since a
+coarse virtual configuration is determined by its three super-bond values, the
+bond models assemble into one product equivalence between coarse virtual
+configurations and triples of crossing configurations. This is the change of
+variables that turns the triple sum over coarse configurations into a sum over the
+original crossing data the merge collapse contracts. -/
+
+/-- **The crossing-triple reindexing.** The product equivalence between coarse
+virtual configurations and triples of original crossing configurations, one per
+coarse super-edge, assembled from the three bond models. -/
+def crossingTripleEquiv (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) :
+    VirtualConfig (F.frame.coarseTensor) ≃
+      (CrossingConfig (G := G) A F.frame.red F.frame.blue ×
+        CrossingConfig (G := G) A F.frame.red F.frame.complement ×
+        CrossingConfig (G := G) A F.frame.blue F.frame.complement) where
+  toFun η := (F.bondModel coarseEdgeRB (η coarseEdgeRB),
+              F.bondModel coarseEdgeRC (η coarseEdgeRC),
+              F.bondModel coarseEdgeBC (η coarseEdgeBC))
+  invFun t := fun f =>
+    if h : f = coarseEdgeRB then h ▸ (F.bondModel coarseEdgeRB).symm t.1
+    else if h2 : f = coarseEdgeRC then h2 ▸ (F.bondModel coarseEdgeRC).symm t.2.1
+    else if h3 : f = coarseEdgeBC then h3 ▸ (F.bondModel coarseEdgeBC).symm t.2.2
+    else absurd ((coarse_edge_cases f).resolve_left h |>.resolve_left h2) h3
+  left_inv η := by
+    funext f
+    dsimp only
+    rcases coarse_edge_cases f with h | h | h <;> subst h
+    · rw [dif_pos rfl]; exact (F.bondModel coarseEdgeRB).symm_apply_apply _
+    · rw [dif_neg (by decide), dif_pos rfl]
+      exact (F.bondModel coarseEdgeRC).symm_apply_apply _
+    · rw [dif_neg (by decide), dif_neg (by decide), dif_pos rfl]
+      exact (F.bondModel coarseEdgeBC).symm_apply_apply _
+  right_inv t := by
+    obtain ⟨a, b, c⟩ := t
+    refine Prod.ext ?_ (Prod.ext ?_ ?_)
+    · dsimp only; rw [dif_pos rfl]; exact (F.bondModel coarseEdgeRB).apply_symm_apply _
+    · dsimp only; rw [dif_neg (show coarseEdgeRC ≠ coarseEdgeRB by decide), dif_pos rfl]
+      exact (F.bondModel coarseEdgeRC).apply_symm_apply _
+    · dsimp only
+      rw [dif_neg (show coarseEdgeBC ≠ coarseEdgeRB by decide),
+        dif_neg (show coarseEdgeBC ≠ coarseEdgeRC by decide), dif_pos rfl]
+      exact (F.bondModel coarseEdgeBC).apply_symm_apply _
+
+@[simp] theorem crossingTripleEquiv_apply (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (η : VirtualConfig (F.frame.coarseTensor)) :
+    crossingTripleEquiv F η =
+      (F.bondModel coarseEdgeRB (η coarseEdgeRB),
+        F.bondModel coarseEdgeRC (η coarseEdgeRC),
+        F.bondModel coarseEdgeBC (η coarseEdgeBC)) := rfl
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
@@ -1,0 +1,65 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite3
+
+/-!
+# The global fiber-collapse bijection for the normal PEPS theorem
+
+The coarse three-site tensor of `TNLean.PEPS.RegionBlock.CoarseThreeSite` has its
+closed-state coefficient written, through the coherent bond models of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite2`, as a sum over coarse virtual
+configurations of a product of three original blocked-region weights
+(`stateCoeff_coarseTensor_eq_threeRegionSum`), and the region boundary
+configurations induced by a coarse configuration are read off the bond models
+(`TNLean.PEPS.RegionBlock.CoarseThreeSite3`). This file collapses that triple sum
+to a constant times the original closed-state coefficient.
+
+The route mirrors the landed two-block collapse
+`TNLean.PEPS.stateCoeff_eq_regionComplement`: a coarse virtual configuration `η`
+together with the three constrained inner sums of the blocked-region weights is
+reindexed by a triple of global virtual configurations of the original tensor
+`(ζ_red, ζ_blue, ζ_compl)` whose region boundary labels agree on the shared
+crossing edges; merging that triple into one global configuration (the red-incident
+edges read `ζ_red`, the remaining blue-incident edges read `ζ_blue`, the rest read
+`ζ_compl`) collapses the sum to the closed-state coefficient with the three
+regions' interior bond products as multiplicity.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1205--1210 (the one-region-against-complement gluing) and
+  1449--1500 (the blocking) of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Enumeration of the coarse super-edges
+
+The coarse graph is the complete graph on `Fin 3`; its edge set is exactly the
+three super-edges `r-b`, `r-c`, `b-c`. A coarse virtual configuration is therefore
+determined by its three super-bond values, the fact the reindexing of the triple
+sum consumes. -/
+
+/-- Every super-edge of the coarse graph is one of the three named super-edges. -/
+theorem coarse_edge_cases (f : Edge coarseGraph) :
+    f = coarseEdgeRB ∨ f = coarseEdgeRC ∨ f = coarseEdgeBC := by
+  revert f; decide
+
+/-- A coarse virtual configuration is determined by its three super-bond values. -/
+theorem coarse_virtualConfig_ext {A : Tensor G d}
+    (F : CoarseBlockingFrame (G := G) (d := d) A)
+    {η η' : VirtualConfig (F.coarseTensor)}
+    (hrb : η coarseEdgeRB = η' coarseEdgeRB)
+    (hrc : η coarseEdgeRC = η' coarseEdgeRC)
+    (hbc : η coarseEdgeBC = η' coarseEdgeBC) : η = η' := by
+  funext f
+  rcases coarse_edge_cases f with h | h | h <;> subst h <;> assumption
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
@@ -463,5 +463,182 @@ theorem coarseConfig_constraint_set (F : CoherentCoarseBlockingFrame (G := G) (d
     · rw [← bondModel_bc_eq_of_legEquivBlue_eq F hP η ζb hb,
         bondModel_bc_eq_of_legEquivComplement_eq F hP η ζc hc]
 
+/-! ### The crossing-triple reindexing of the coarse state sum
+
+The triple sum over coarse virtual configurations of the boundary-coupled product of
+the three region weights equals the sum, over triples of global virtual
+configurations agreeing on the crossing edges, of the product of the three regions'
+vertex products. The coarse super-bond sum collapses to the crossing-agreement
+indicator (`coarseConfig_constraint_set`), reindexing the coarse state sum onto the
+original crossing data the merge collapse contracts. -/
+
+/-- A product of three scalar selectors is the selector of their conjunction. -/
+theorem mul_three_ite {α : Type*} [MulZeroClass α] (P Q R : Prop)
+    [Decidable P] [Decidable Q] [Decidable R] (a b c : α) :
+    (if P then a else 0) * (if Q then b else 0) * (if R then c else 0) =
+      if P ∧ Q ∧ R then a * b * c else 0 := by
+  by_cases hP : P <;> by_cases hQ : Q <;> by_cases hR : R <;> simp [hP, hQ, hR]
+
+/-- The boundary-coupled product of the three region weights at a fixed coarse
+configuration `η`, expanded as a triple sum over global configurations with the three
+region boundary labels matched to `η`'s induced boundary configurations. -/
+theorem perEta_threeRegionProduct_eq (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (s : Fin 3 → Fin (coarseDim V d)) (η : VirtualConfig (F.frame.coarseTensor)) :
+    regionBlockedWeight (G := G) A F.frame.red
+          (F.frame.legEquivRed (fun ie => η ie.1)) (coarseProj F.frame.red (s 0)) *
+        regionBlockedWeight (G := G) A F.frame.blue
+          (F.frame.legEquivBlue (fun ie => η ie.1)) (coarseProj F.frame.blue (s 1)) *
+        regionBlockedWeight (G := G) A F.frame.complement
+          (F.frame.legEquivComplement (fun ie => η ie.1)) (coarseProj F.frame.complement (s 2)) =
+      ∑ ζr : VirtualConfig A, ∑ ζb : VirtualConfig A, ∑ ζc : VirtualConfig A,
+        (if F.frame.legEquivRed (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+            F.frame.legEquivBlue (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+            F.frame.legEquivComplement (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.complement ζc then
+          (∏ w : {w : V // w ∈ F.frame.red},
+              A.component w.1 (fun ie => ζr ie.1) (coarseProj F.frame.red (s 0) w)) *
+            (∏ w : {w : V // w ∈ F.frame.blue},
+              A.component w.1 (fun ie => ζb ie.1) (coarseProj F.frame.blue (s 1) w)) *
+            (∏ w : {w : V // w ∈ F.frame.complement},
+              A.component w.1 (fun ie => ζc ie.1) (coarseProj F.frame.complement (s 2) w))
+        else 0) := by
+  classical
+  rw [show regionBlockedWeight (G := G) A F.frame.red
+        (F.frame.legEquivRed (fun ie => η ie.1)) (coarseProj F.frame.red (s 0)) =
+      ∑ ζr : VirtualConfig A, if regionBoundaryLabel (G := G) A F.frame.red ζr =
+          F.frame.legEquivRed (fun ie => η ie.1) then
+        ∏ w : {w : V // w ∈ F.frame.red},
+          A.component w.1 (fun ie => ζr ie.1) (coarseProj F.frame.red (s 0) w) else 0 from by
+      rw [regionBlockedWeight, Finset.sum_filter],
+    show regionBlockedWeight (G := G) A F.frame.blue
+        (F.frame.legEquivBlue (fun ie => η ie.1)) (coarseProj F.frame.blue (s 1)) =
+      ∑ ζb : VirtualConfig A, if regionBoundaryLabel (G := G) A F.frame.blue ζb =
+          F.frame.legEquivBlue (fun ie => η ie.1) then
+        ∏ w : {w : V // w ∈ F.frame.blue},
+          A.component w.1 (fun ie => ζb ie.1) (coarseProj F.frame.blue (s 1) w) else 0 from by
+      rw [regionBlockedWeight, Finset.sum_filter],
+    show regionBlockedWeight (G := G) A F.frame.complement
+        (F.frame.legEquivComplement (fun ie => η ie.1)) (coarseProj F.frame.complement (s 2)) =
+      ∑ ζc : VirtualConfig A, if regionBoundaryLabel (G := G) A F.frame.complement ζc =
+          F.frame.legEquivComplement (fun ie => η ie.1) then
+        ∏ w : {w : V // w ∈ F.frame.complement},
+          A.component w.1 (fun ie => ζc ie.1) (coarseProj F.frame.complement (s 2) w)
+          else 0 from by
+      rw [regionBlockedWeight, Finset.sum_filter]]
+  rw [Finset.sum_mul, Finset.sum_mul]
+  refine Finset.sum_congr rfl (fun ζr _ => ?_)
+  rw [mul_assoc, Finset.sum_mul_sum, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun ζb _ => ?_)
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun ζc _ => ?_)
+  rw [← mul_assoc, mul_three_ite]
+  refine if_congr ?_ rfl rfl
+  rw [eq_comm (a := F.frame.legEquivRed fun ie => η ↑ie),
+    eq_comm (a := F.frame.legEquivBlue fun ie => η ↑ie),
+    eq_comm (a := F.frame.legEquivComplement fun ie => η ↑ie)]
+
+/-- **The crossing-triple reindexing of the coarse state sum.** The triple sum over
+coarse virtual configurations of the boundary-coupled product of the three region
+weights equals the sum, over triples of global virtual configurations agreeing on the
+crossing edges, of the product of the three regions' vertex products.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1205--1210 and
+1449--1500 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem threeRegionSum_eq_agreeingTripleSum
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (s : Fin 3 → Fin (coarseDim V d)) :
+    (∑ η : VirtualConfig (F.frame.coarseTensor),
+        regionBlockedWeight (G := G) A F.frame.red
+            (F.frame.legEquivRed (fun ie => η ie.1)) (coarseProj F.frame.red (s 0)) *
+          regionBlockedWeight (G := G) A F.frame.blue
+            (F.frame.legEquivBlue (fun ie => η ie.1)) (coarseProj F.frame.blue (s 1)) *
+          regionBlockedWeight (G := G) A F.frame.complement
+            (F.frame.legEquivComplement (fun ie => η ie.1))
+              (coarseProj F.frame.complement (s 2))) =
+      ∑ t ∈ (Finset.univ : Finset (VirtualConfig A × VirtualConfig A × VirtualConfig A)).filter
+          (fun t => TripleAgrees F t.1 t.2.1 t.2.2),
+        (∏ w : {w : V // w ∈ F.frame.red},
+            A.component w.1 (fun ie => t.1 ie.1) (coarseProj F.frame.red (s 0) w)) *
+          (∏ w : {w : V // w ∈ F.frame.blue},
+            A.component w.1 (fun ie => t.2.1 ie.1) (coarseProj F.frame.blue (s 1) w)) *
+          (∏ w : {w : V // w ∈ F.frame.complement},
+            A.component w.1 (fun ie => t.2.2 ie.1) (coarseProj F.frame.complement (s 2) w)) := by
+  classical
+  -- Expand each summand into the triple sum.
+  simp_rw [perEta_threeRegionProduct_eq F s]
+  -- Exchange to bring the coarse configuration sum innermost.
+  have hswap : (∑ η : VirtualConfig (F.frame.coarseTensor), ∑ ζr : VirtualConfig A,
+        ∑ ζb : VirtualConfig A, ∑ ζc : VirtualConfig A,
+        (if F.frame.legEquivRed (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+            F.frame.legEquivBlue (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+            F.frame.legEquivComplement (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.complement ζc then
+          (∏ w : {w : V // w ∈ F.frame.red},
+              A.component w.1 (fun ie => ζr ie.1) (coarseProj F.frame.red (s 0) w)) *
+            (∏ w : {w : V // w ∈ F.frame.blue},
+              A.component w.1 (fun ie => ζb ie.1) (coarseProj F.frame.blue (s 1) w)) *
+            (∏ w : {w : V // w ∈ F.frame.complement},
+              A.component w.1 (fun ie => ζc ie.1) (coarseProj F.frame.complement (s 2) w))
+        else 0)) =
+      ∑ ζr : VirtualConfig A, ∑ ζb : VirtualConfig A, ∑ ζc : VirtualConfig A,
+        ∑ η : VirtualConfig (F.frame.coarseTensor),
+        (if F.frame.legEquivRed (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+            F.frame.legEquivBlue (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+            F.frame.legEquivComplement (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.complement ζc then
+          (∏ w : {w : V // w ∈ F.frame.red},
+              A.component w.1 (fun ie => ζr ie.1) (coarseProj F.frame.red (s 0) w)) *
+            (∏ w : {w : V // w ∈ F.frame.blue},
+              A.component w.1 (fun ie => ζb ie.1) (coarseProj F.frame.blue (s 1) w)) *
+            (∏ w : {w : V // w ∈ F.frame.complement},
+              A.component w.1 (fun ie => ζc ie.1) (coarseProj F.frame.complement (s 2) w))
+        else 0) := by
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun ζr _ => ?_)
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun ζb _ => ?_)
+    rw [Finset.sum_comm]
+  rw [hswap]
+  -- Collapse the innermost coarse sum to the crossing-agreement selector, triple by triple.
+  have hcollapse : ∀ ζr ζb ζc : VirtualConfig A,
+      (∑ η : VirtualConfig (F.frame.coarseTensor),
+        (if F.frame.legEquivRed (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+            F.frame.legEquivBlue (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+            F.frame.legEquivComplement (fun ie => η ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.complement ζc then
+          (∏ w : {w : V // w ∈ F.frame.red},
+              A.component w.1 (fun ie => ζr ie.1) (coarseProj F.frame.red (s 0) w)) *
+            (∏ w : {w : V // w ∈ F.frame.blue},
+              A.component w.1 (fun ie => ζb ie.1) (coarseProj F.frame.blue (s 1) w)) *
+            (∏ w : {w : V // w ∈ F.frame.complement},
+              A.component w.1 (fun ie => ζc ie.1) (coarseProj F.frame.complement (s 2) w))
+        else 0)) =
+      if TripleAgrees F ζr ζb ζc then
+        (∏ w : {w : V // w ∈ F.frame.red},
+            A.component w.1 (fun ie => ζr ie.1) (coarseProj F.frame.red (s 0) w)) *
+          (∏ w : {w : V // w ∈ F.frame.blue},
+            A.component w.1 (fun ie => ζb ie.1) (coarseProj F.frame.blue (s 1) w)) *
+          (∏ w : {w : V // w ∈ F.frame.complement},
+            A.component w.1 (fun ie => ζc ie.1) (coarseProj F.frame.complement (s 2) w))
+      else 0 := by
+    intro ζr ζb ζc
+    rw [← Finset.sum_filter, coarseConfig_constraint_set F hP ζr ζb ζc]
+    by_cases hag : TripleAgrees F ζr ζb ζc
+    · rw [if_pos hag, if_pos hag, Finset.sum_singleton]
+    · rw [if_neg hag, if_neg hag, Finset.sum_empty]
+  simp_rw [hcollapse]
+  -- Reassemble the three sums as a selector sum over triples, then drop the selector.
+  rw [Finset.sum_filter, Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl (fun ζr _ => ?_)
+  rw [Fintype.sum_prod_type]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean
@@ -342,5 +342,126 @@ theorem legEquivComplement_eq_of_bondModel (hP : F.frame.IsPartition)
     have := congrFun hbc ⟨b.1, hc⟩
     rw [this]; rfl
 
+/-! ### The crossing-triple agreement and its realising coarse configuration
+
+A triple of global virtual configurations agrees on the crossing edges when its
+three pairwise crossing labels coincide. Such a triple is realised by exactly one
+coarse virtual configuration, recovered through the bond models. This is the
+combinatorial heart of the reindexing: the super-bond count of the boundary-coupled
+triple sum is the indicator of crossing agreement. -/
+
+/-- **Crossing agreement of a triple.** Three global virtual configurations agree on
+the crossing edges when the red and blue agree on the red-to-blue crossings, the red
+and complement on the red-to-complement crossings, and the blue and complement on the
+blue-to-complement crossings. -/
+def TripleAgrees (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb ζc : VirtualConfig A) : Prop :=
+  crossingLabel (G := G) A F.frame.red F.frame.blue ζr =
+      (fun g => ζb g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue) ∧
+    crossingLabel (G := G) A F.frame.red F.frame.complement ζr =
+      (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.red F.frame.complement) ∧
+    crossingLabel (G := G) A F.frame.blue F.frame.complement ζb =
+      (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.blue F.frame.complement)
+
+instance (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (ζr ζb ζc : VirtualConfig A) :
+    Decidable (TripleAgrees F ζr ζb ζc) := by unfold TripleAgrees; infer_instance
+
+/-- **The realising coarse configuration.** The coarse virtual configuration whose
+three super-bonds the bond models read as the three crossing labels of an agreeing
+triple. -/
+noncomputable def tripleToEta (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb : VirtualConfig A) : VirtualConfig (F.frame.coarseTensor) :=
+  (crossingTripleEquiv F).symm
+    (crossingLabel (G := G) A F.frame.red F.frame.blue ζr,
+     crossingLabel (G := G) A F.frame.red F.frame.complement ζr,
+     crossingLabel (G := G) A F.frame.blue F.frame.complement ζb)
+
+theorem tripleToEta_rb (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb : VirtualConfig A) :
+    F.bondModel coarseEdgeRB ((tripleToEta F ζr ζb) coarseEdgeRB) =
+      crossingLabel (G := G) A F.frame.red F.frame.blue ζr := by
+  unfold tripleToEta
+  have := (crossingTripleEquiv F).apply_symm_apply
+    (crossingLabel (G := G) A F.frame.red F.frame.blue ζr,
+     crossingLabel (G := G) A F.frame.red F.frame.complement ζr,
+     crossingLabel (G := G) A F.frame.blue F.frame.complement ζb)
+  rw [crossingTripleEquiv_apply] at this
+  exact congrArg (·.1) this
+
+theorem tripleToEta_rc (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb : VirtualConfig A) :
+    F.bondModel coarseEdgeRC ((tripleToEta F ζr ζb) coarseEdgeRC) =
+      crossingLabel (G := G) A F.frame.red F.frame.complement ζr := by
+  unfold tripleToEta
+  have := (crossingTripleEquiv F).apply_symm_apply
+    (crossingLabel (G := G) A F.frame.red F.frame.blue ζr,
+     crossingLabel (G := G) A F.frame.red F.frame.complement ζr,
+     crossingLabel (G := G) A F.frame.blue F.frame.complement ζb)
+  rw [crossingTripleEquiv_apply] at this
+  exact congrArg (·.2.1) this
+
+theorem tripleToEta_bc (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb : VirtualConfig A) :
+    F.bondModel coarseEdgeBC ((tripleToEta F ζr ζb) coarseEdgeBC) =
+      crossingLabel (G := G) A F.frame.blue F.frame.complement ζb := by
+  unfold tripleToEta
+  have := (crossingTripleEquiv F).apply_symm_apply
+    (crossingLabel (G := G) A F.frame.red F.frame.blue ζr,
+     crossingLabel (G := G) A F.frame.red F.frame.complement ζr,
+     crossingLabel (G := G) A F.frame.blue F.frame.complement ζb)
+  rw [crossingTripleEquiv_apply] at this
+  exact congrArg (·.2.2) this
+
+/-- **The super-bond constraint set.** For a fixed triple `(ζr, ζb, ζc)`, the coarse
+virtual configurations whose three induced region boundary configurations equal the
+triple's region boundary labels: the singleton of the realising coarse configuration
+when the triple agrees on the crossings, and empty otherwise. This is the indicator
+content of the super-bond count. -/
+theorem coarseConfig_constraint_set (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (ζr ζb ζc : VirtualConfig A) :
+    (Finset.univ.filter (fun η : VirtualConfig (F.frame.coarseTensor) =>
+        F.frame.legEquivRed (fun ie => η ie.1) =
+            regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+          F.frame.legEquivBlue (fun ie => η ie.1) =
+            regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+          F.frame.legEquivComplement (fun ie => η ie.1) =
+            regionBoundaryLabel (G := G) A F.frame.complement ζc)) =
+      if TripleAgrees F ζr ζb ζc then {tripleToEta F ζr ζb} else ∅ := by
+  by_cases hag : TripleAgrees F ζr ζb ζc
+  · rw [if_pos hag]
+    obtain ⟨hab, hac, hbc⟩ := hag
+    ext η
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_singleton]
+    constructor
+    · rintro ⟨hr, hb, hc⟩
+      apply coarse_virtualConfig_ext F.frame
+      · apply (F.bondModel coarseEdgeRB).injective
+        rw [bondModel_rb_eq_of_legEquivRed_eq F hP η ζr hr, tripleToEta_rb]
+      · apply (F.bondModel coarseEdgeRC).injective
+        rw [bondModel_rc_eq_of_legEquivRed_eq F hP η ζr hr, tripleToEta_rc]
+      · apply (F.bondModel coarseEdgeBC).injective
+        rw [bondModel_bc_eq_of_legEquivBlue_eq F hP η ζb hb, tripleToEta_bc]
+    · rintro rfl
+      refine ⟨?_, ?_, ?_⟩
+      · exact legEquivRed_eq_of_bondModel F hP _ ζr (tripleToEta_rb F ζr ζb)
+          (tripleToEta_rc F ζr ζb)
+      · refine legEquivBlue_eq_of_bondModel F hP _ ζb ?_ (tripleToEta_bc F ζr ζb)
+        rw [tripleToEta_rb]; exact hab
+      · refine legEquivComplement_eq_of_bondModel F hP _ ζc ?_ ?_
+        · rw [tripleToEta_rc]; exact hac
+        · rw [tripleToEta_bc]; exact hbc
+  · rw [if_neg hag]
+    ext η
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.notMem_empty, iff_false]
+    rintro ⟨hr, hb, hc⟩
+    apply hag
+    refine ⟨?_, ?_, ?_⟩
+    · rw [← bondModel_rb_eq_of_legEquivRed_eq F hP η ζr hr,
+        bondModel_rb_eq_of_legEquivBlue_eq F hP η ζb hb]
+    · rw [← bondModel_rc_eq_of_legEquivRed_eq F hP η ζr hr,
+        bondModel_rc_eq_of_legEquivComplement_eq F hP η ζc hc]
+    · rw [← bondModel_bc_eq_of_legEquivBlue_eq F hP η ζb hb,
+        bondModel_bc_eq_of_legEquivComplement_eq F hP η ζc hc]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
@@ -1,0 +1,196 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite4
+
+/-!
+# The three-region merge collapse for the normal PEPS theorem
+
+The coarse state sum of `TNLean.PEPS.RegionBlock.CoarseThreeSite4` is reindexed, by
+the bond models, as a sum over triples of global virtual configurations agreeing on
+the crossing edges of the product of the three regions' vertex products
+(`threeRegionSum_eq_agreeingTripleSum`). This file collapses that triple sum to a
+constant times the original closed-state coefficient.
+
+The collapse mirrors the landed two-block fiber collapse
+`TNLean.PEPS.stateCoeff_eq_regionComplement`: an agreeing triple
+`(ζ_red, ζ_blue, ζ_compl)` is merged into one global configuration reading the
+red-incident edges from `ζ_red`, the remaining blue-incident edges from `ζ_blue`, and
+the rest from `ζ_compl`. The three regions' vertex products read this merged
+configuration unchanged, and the fiber over a merged configuration is parameterised by
+the virtual indices each configuration is free to choose away from its region: the
+product of the three regions' non-incident bond products.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1205--1210 (the one-region-against-complement gluing) and
+  1449--1500 (the blocking) of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d}
+
+/-! ### Per-edge agreement of an agreeing triple
+
+The crossing-label agreement of a triple, unpacked at a single crossing edge: the two
+configurations crossing that edge carry the same virtual index there. These are the
+per-edge facts the merge product equalities consume. -/
+
+omit [DecidableEq V] in
+/-- On a red-to-blue crossing edge, an agreeing triple's red and blue configurations
+coincide. -/
+theorem TripleAgrees.rb (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    {ζr ζb ζc : VirtualConfig A} (h : TripleAgrees F ζr ζb ζc)
+    {e : Edge G} (he : IsCrossingEdge (G := G) A F.frame.red F.frame.blue e) :
+    ζr e = ζb e := by
+  have := congrFun h.1 ⟨e, he⟩; simpa [crossingLabel] using this
+
+omit [DecidableEq V] in
+/-- On a red-to-complement crossing edge, an agreeing triple's red and complement
+configurations coincide. -/
+theorem TripleAgrees.rc (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    {ζr ζb ζc : VirtualConfig A} (h : TripleAgrees F ζr ζb ζc)
+    {e : Edge G} (he : IsCrossingEdge (G := G) A F.frame.red F.frame.complement e) :
+    ζr e = ζc e := by
+  have := congrFun h.2.1 ⟨e, he⟩; simpa [crossingLabel] using this
+
+omit [DecidableEq V] in
+/-- On a blue-to-complement crossing edge, an agreeing triple's blue and complement
+configurations coincide. -/
+theorem TripleAgrees.bc (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    {ζr ζb ζc : VirtualConfig A} (h : TripleAgrees F ζr ζb ζc)
+    {e : Edge G} (he : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e) :
+    ζb e = ζc e := by
+  have := congrFun h.2.2 ⟨e, he⟩; simpa [crossingLabel] using this
+
+/-! ### Two-region incident edges are crossing edges
+
+An edge incident to two of the three regions crosses between them: its two endpoints
+lie one in each. These classify which configuration the merge reads on an edge shared
+by two regions, where the agreement forces the two configurations to coincide. -/
+
+/-- An edge incident to both red and blue is a red-to-blue crossing edge. -/
+theorem isCrossing_rb_of_incident (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) {e : Edge G}
+    (hr : IsRegionIncidentEdge (G := G) F.frame.red e)
+    (hb : IsRegionIncidentEdge (G := G) F.frame.blue e) :
+    IsCrossingEdge (G := G) A F.frame.red F.frame.blue e := by
+  rcases hr with hr1 | hr2 <;> rcases hb with hb1 | hb2
+  · exact absurd hb1 ((Finset.disjoint_left.mp hP.red_disjoint_blue) hr1)
+  · exact ⟨Or.inl ⟨hr1, (Finset.disjoint_right.mp hP.red_disjoint_blue) hb2⟩,
+      Or.inr ⟨(Finset.disjoint_left.mp hP.red_disjoint_blue) hr1, hb2⟩⟩
+  · exact ⟨Or.inr ⟨(Finset.disjoint_right.mp hP.red_disjoint_blue) hb1, hr2⟩,
+      Or.inl ⟨hb1, (Finset.disjoint_left.mp hP.red_disjoint_blue) hr2⟩⟩
+  · exact absurd hb2 ((Finset.disjoint_left.mp hP.red_disjoint_blue) hr2)
+
+/-- An edge incident to both red and complement is a red-to-complement crossing edge. -/
+theorem isCrossing_rc_of_incident (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) {e : Edge G}
+    (hr : IsRegionIncidentEdge (G := G) F.frame.red e)
+    (hc : IsRegionIncidentEdge (G := G) F.frame.complement e) :
+    IsCrossingEdge (G := G) A F.frame.red F.frame.complement e := by
+  rcases hr with hr1 | hr2 <;> rcases hc with hc1 | hc2
+  · exact absurd hc1 ((Finset.disjoint_left.mp hP.red_disjoint_complement) hr1)
+  · exact ⟨Or.inl ⟨hr1, (Finset.disjoint_right.mp hP.red_disjoint_complement) hc2⟩,
+      Or.inr ⟨(Finset.disjoint_left.mp hP.red_disjoint_complement) hr1, hc2⟩⟩
+  · exact ⟨Or.inr ⟨(Finset.disjoint_right.mp hP.red_disjoint_complement) hc1, hr2⟩,
+      Or.inl ⟨hc1, (Finset.disjoint_left.mp hP.red_disjoint_complement) hr2⟩⟩
+  · exact absurd hc2 ((Finset.disjoint_left.mp hP.red_disjoint_complement) hr2)
+
+/-- An edge incident to both blue and complement is a blue-to-complement crossing edge. -/
+theorem isCrossing_bc_of_incident (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) {e : Edge G}
+    (hb : IsRegionIncidentEdge (G := G) F.frame.blue e)
+    (hc : IsRegionIncidentEdge (G := G) F.frame.complement e) :
+    IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e := by
+  rcases hb with hb1 | hb2 <;> rcases hc with hc1 | hc2
+  · exact absurd hc1 ((Finset.disjoint_left.mp hP.blue_disjoint_complement) hb1)
+  · exact ⟨Or.inl ⟨hb1, (Finset.disjoint_right.mp hP.blue_disjoint_complement) hc2⟩,
+      Or.inr ⟨(Finset.disjoint_left.mp hP.blue_disjoint_complement) hb1, hc2⟩⟩
+  · exact ⟨Or.inr ⟨(Finset.disjoint_right.mp hP.blue_disjoint_complement) hc1, hb2⟩,
+      Or.inl ⟨hc1, (Finset.disjoint_left.mp hP.blue_disjoint_complement) hb2⟩⟩
+  · exact absurd hc2 ((Finset.disjoint_left.mp hP.blue_disjoint_complement) hb2)
+
+/-! ### The three-way merge
+
+The merge of an agreeing triple reads the red-incident edges from the red
+configuration, the remaining blue-incident edges from the blue configuration, and the
+rest from the complement configuration. Each region's vertex product reads the merge
+unchanged: on an edge incident to a second region the crossing agreement forces the
+two configurations to coincide. -/
+
+/-- **The three-way merge.** The global virtual configuration reading red-incident
+edges from `ζr`, the remaining blue-incident edges from `ζb`, and the rest from `ζc`. -/
+def triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb ζc : VirtualConfig A) : VirtualConfig A :=
+  fun e => if IsRegionIncidentEdge (G := G) F.frame.red e then ζr e
+    else if IsRegionIncidentEdge (G := G) F.frame.blue e then ζb e
+    else ζc e
+
+omit [DecidableEq V] in
+/-- The red vertex product reads the merge unchanged: red-incident edges read `ζr`. -/
+theorem redProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb ζc : VirtualConfig A)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red) :
+    (∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w)) =
+      ∏ w : {w : V // w ∈ F.frame.red},
+        A.component w.1 (fun ie => triMerge F ζr ζb ζc ie.1) (σr w) := by
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1; funext ie
+  have hrinc : IsRegionIncidentEdge (G := G) F.frame.red ie.1 := by
+    rcases ie.2 with hie | hie
+    · exact Or.inl (by rw [hie]; exact w.2)
+    · exact Or.inr (by rw [hie]; exact w.2)
+  rw [triMerge, if_pos hrinc]
+
+/-- The blue vertex product reads the merge unchanged: a blue-incident edge that is
+also red-incident is a red-to-blue crossing edge, where the agreement coincides. -/
+theorem blueProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) {ζr ζb ζc : VirtualConfig A} (h : TripleAgrees F ζr ζb ζc)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue) :
+    (∏ w : {w : V // w ∈ F.frame.blue}, A.component w.1 (fun ie => ζb ie.1) (σb w)) =
+      ∏ w : {w : V // w ∈ F.frame.blue},
+        A.component w.1 (fun ie => triMerge F ζr ζb ζc ie.1) (σb w) := by
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1; funext ie
+  have hbinc : IsRegionIncidentEdge (G := G) F.frame.blue ie.1 := by
+    rcases ie.2 with hie | hie
+    · exact Or.inl (by rw [hie]; exact w.2)
+    · exact Or.inr (by rw [hie]; exact w.2)
+  rw [triMerge]
+  by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red ie.1
+  · rw [if_pos hr]; exact (h.rb F (isCrossing_rb_of_incident F hP hr hbinc)).symm
+  · rw [if_neg hr, if_pos hbinc]
+
+/-- The complement vertex product reads the merge unchanged: a complement-incident
+edge that is red-incident is a red-to-complement crossing edge, and one that is
+blue-incident but not red-incident is a blue-to-complement crossing edge, where the
+respective agreements coincide. -/
+theorem complProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) {ζr ζb ζc : VirtualConfig A} (h : TripleAgrees F ζr ζb ζc)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) :
+    (∏ w : {w : V // w ∈ F.frame.complement}, A.component w.1 (fun ie => ζc ie.1) (σc w)) =
+      ∏ w : {w : V // w ∈ F.frame.complement},
+        A.component w.1 (fun ie => triMerge F ζr ζb ζc ie.1) (σc w) := by
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1; funext ie
+  have hcinc : IsRegionIncidentEdge (G := G) F.frame.complement ie.1 := by
+    rcases ie.2 with hie | hie
+    · exact Or.inl (by rw [hie]; exact w.2)
+    · exact Or.inr (by rw [hie]; exact w.2)
+  rw [triMerge]
+  by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red ie.1
+  · rw [if_pos hr]; exact (h.rc F (isCrossing_rc_of_incident F hP hr hcinc)).symm
+  · rw [if_neg hr]
+    by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue ie.1
+    · rw [if_pos hb]; exact (h.bc F (isCrossing_bc_of_incident F hP hb hcinc)).symm
+    · rw [if_neg hb]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
@@ -304,5 +304,177 @@ theorem sum_triMergedSummand (F : CoherentCoarseBlockingFrame (G := G) (d := d) 
   unfold stateCoeff triMergedSummand
   exact Finset.sum_congr rfl (fun η _ => (prod_assembleTri_split F hP σr σb σc η).symm)
 
+/-! ### The fiber count
+
+The agreeing triples merging to a fixed global configuration are parameterised by the
+virtual indices each configuration is free to choose away from its region: an agreeing
+triple in the fiber reads the merge on every region-incident edge, and the crossing
+agreements pin the shared edges, leaving free the values of each configuration on the
+edges not incident to its own region. The common count of these free indices is the
+product of the three regions' non-incident bond products. -/
+
+/-- The bond-dimension product over the edges not incident to `R`: the multiplicity of
+free virtual indices a configuration carries away from its own region. -/
+noncomputable def regionNonIncidentBondProd (A : Tensor G d) (R : Finset V) : ℕ :=
+  ∏ e ∈ Finset.univ.filter (fun e : Edge G => ¬ IsRegionIncidentEdge (G := G) R e),
+    A.bondDim e
+
+/-- An edge incident to neither red nor blue is incident to the complement: under the
+partition both its endpoints lie in the complement. -/
+theorem complIncident_of_not_red_not_blue (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) {e : Edge G}
+    (hr : ¬ IsRegionIncidentEdge (G := G) F.frame.red e)
+    (hb : ¬ IsRegionIncidentEdge (G := G) F.frame.blue e) :
+    IsRegionIncidentEdge (G := G) F.frame.complement e := by
+  have h1nr : e.1.1 ∉ F.frame.red := fun h => hr (Or.inl h)
+  have h1nb : e.1.1 ∉ F.frame.blue := fun h => hb (Or.inl h)
+  have h1c : e.1.1 ∈ F.frame.complement := by
+    have : e.1.1 ∈ F.frame.red ∪ F.frame.blue ∪ F.frame.complement := by
+      rw [hP.cover_univ]; exact Finset.mem_univ _
+    rcases Finset.mem_union.mp this with h | h
+    · rcases Finset.mem_union.mp h with h | h
+      · exact absurd h h1nr
+      · exact absurd h h1nb
+    · exact h
+  exact Or.inl h1c
+
+/-- The free virtual indices of an agreeing triple in a fiber: each configuration's
+values on the edges not incident to its own region. -/
+abbrev FreeLegs (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) : Type _ :=
+  ((e : {e : Edge G // ¬ IsRegionIncidentEdge (G := G) F.frame.red e}) → Fin (A.bondDim e.1)) ×
+  ((e : {e : Edge G // ¬ IsRegionIncidentEdge (G := G) F.frame.blue e}) → Fin (A.bondDim e.1)) ×
+  ((e : {e : Edge G // ¬ IsRegionIncidentEdge (G := G) F.frame.complement e}) →
+    Fin (A.bondDim e.1))
+
+/-- The free virtual indices read off a triple: each configuration restricted to the
+edges not incident to its own region. -/
+noncomputable def triFiberLegs (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (p : VirtualConfig A × VirtualConfig A × VirtualConfig A) : FreeLegs F :=
+  (fun e => p.1 e.1, fun e => p.2.1 e.1, fun e => p.2.2 e.1)
+
+/-- Reconstruct a fiber triple from its free virtual indices and the merged
+configuration: each configuration reads the merge on its region-incident edges and the
+free indices elsewhere. -/
+noncomputable def triFiberTriple (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (η : VirtualConfig A) (legs : FreeLegs F) :
+    VirtualConfig A × VirtualConfig A × VirtualConfig A :=
+  (fun e => if hr : IsRegionIncidentEdge (G := G) F.frame.red e then η e else legs.1 ⟨e, hr⟩,
+   fun e => if hb : IsRegionIncidentEdge (G := G) F.frame.blue e then η e else legs.2.1 ⟨e, hb⟩,
+   fun e => if hc : IsRegionIncidentEdge (G := G) F.frame.complement e then η e
+              else legs.2.2 ⟨e, hc⟩)
+
+/-- The free-index type has the product of the three regions' non-incident bond
+products as its cardinality. -/
+theorem freeLegs_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) :
+    Fintype.card (FreeLegs F) =
+      regionNonIncidentBondProd A F.frame.red * regionNonIncidentBondProd A F.frame.blue *
+        regionNonIncidentBondProd A F.frame.complement := by
+  classical
+  rw [Fintype.card_prod, Fintype.card_prod, Fintype.card_pi, Fintype.card_pi, Fintype.card_pi]
+  simp only [Fintype.card_fin]
+  rw [regionNonIncidentBondProd, regionNonIncidentBondProd, regionNonIncidentBondProd,
+    ← Finset.prod_subtype (Finset.univ.filter
+        (fun e : Edge G => ¬ IsRegionIncidentEdge (G := G) F.frame.red e))
+      (fun e => by simp [Finset.mem_filter]) (fun e => A.bondDim e),
+    ← Finset.prod_subtype (Finset.univ.filter
+        (fun e : Edge G => ¬ IsRegionIncidentEdge (G := G) F.frame.blue e))
+      (fun e => by simp [Finset.mem_filter]) (fun e => A.bondDim e),
+    ← Finset.prod_subtype (Finset.univ.filter
+        (fun e : Edge G => ¬ IsRegionIncidentEdge (G := G) F.frame.complement e))
+      (fun e => by simp [Finset.mem_filter]) (fun e => A.bondDim e)]
+  ring
+
+open scoped Classical in
+/-- **The fiber count.** The agreeing triples merging to a fixed global configuration
+`η` are in bijection with the free virtual indices, so their number is the product of
+the three regions' non-incident bond products. This is the three-region analogue of
+`TNLean.PEPS.regionFiber_card`.
+
+Source: arXiv:1804.04964, Section 3, lines 1205--1210 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (η : VirtualConfig A) :
+    (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A × VirtualConfig A =>
+        TripleAgrees F p.1 p.2.1 p.2.2 ∧ triMerge F p.1 p.2.1 p.2.2 = η)).card =
+      regionNonIncidentBondProd A F.frame.red * regionNonIncidentBondProd A F.frame.blue *
+        regionNonIncidentBondProd A F.frame.complement := by
+  classical
+  rw [← freeLegs_card F, ← Finset.card_univ]
+  refine Finset.card_nbij' (triFiberLegs F) (triFiberTriple F η) ?_ ?_ ?_ ?_
+  · intro p _; exact Finset.mem_univ _
+  · -- The reconstruction lands in the fiber: agreement and merge identity.
+    intro legs _
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and]
+    refine ⟨⟨?_, ?_, ?_⟩, ?_⟩
+    · funext g
+      simp only [crossingLabel, triFiberTriple]
+      have hr : IsRegionIncidentEdge (G := G) F.frame.red g.1 :=
+        isRegionBoundaryEdge_touches (G := G) F.frame.red g.2.1
+      have hb : IsRegionIncidentEdge (G := G) F.frame.blue g.1 :=
+        isRegionBoundaryEdge_touches (G := G) F.frame.blue g.2.2
+      rw [dif_pos hr, dif_pos hb]
+    · funext g
+      simp only [crossingLabel, triFiberTriple]
+      have hr : IsRegionIncidentEdge (G := G) F.frame.red g.1 :=
+        isRegionBoundaryEdge_touches (G := G) F.frame.red g.2.1
+      have hc : IsRegionIncidentEdge (G := G) F.frame.complement g.1 :=
+        isRegionBoundaryEdge_touches (G := G) F.frame.complement g.2.2
+      rw [dif_pos hr, dif_pos hc]
+    · funext g
+      simp only [crossingLabel, triFiberTriple]
+      have hb : IsRegionIncidentEdge (G := G) F.frame.blue g.1 :=
+        isRegionBoundaryEdge_touches (G := G) F.frame.blue g.2.1
+      have hc : IsRegionIncidentEdge (G := G) F.frame.complement g.1 :=
+        isRegionBoundaryEdge_touches (G := G) F.frame.complement g.2.2
+      rw [dif_pos hb, dif_pos hc]
+    · funext e
+      simp only [triMerge, triFiberTriple]
+      by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
+      · rw [if_pos hr, dif_pos hr]
+      · rw [if_neg hr]
+        by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue e
+        · rw [if_pos hb, dif_pos hb]
+        · rw [if_neg hb, dif_pos (complIncident_of_not_red_not_blue F hP hr hb)]
+  · -- Reconstructing from the free indices of a fiber triple recovers the triple.
+    intro p hp
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    obtain ⟨hag, hmerge⟩ := hp
+    have hmerge' : ∀ e, triMerge F p.1 p.2.1 p.2.2 e = η e := fun e => congrFun hmerge e
+    refine Prod.ext ?_ (Prod.ext ?_ ?_)
+    · funext e
+      simp only [triFiberTriple, triFiberLegs]
+      by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
+      · rw [dif_pos hr]
+        have := hmerge' e; rw [triMerge, if_pos hr] at this; exact this.symm
+      · rw [dif_neg hr]
+    · funext e
+      simp only [triFiberTriple, triFiberLegs]
+      by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue e
+      · rw [dif_pos hb]
+        by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
+        · have := hmerge' e; rw [triMerge, if_pos hr] at this
+          rw [← (hag.rb F (isCrossing_rb_of_incident F hP hr hb)), this]
+        · have := hmerge' e; rw [triMerge, if_neg hr, if_pos hb] at this; exact this.symm
+      · rw [dif_neg hb]
+    · funext e
+      simp only [triFiberTriple, triFiberLegs]
+      by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement e
+      · rw [dif_pos hc]
+        by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
+        · have := hmerge' e; rw [triMerge, if_pos hr] at this
+          rw [← (hag.rc F (isCrossing_rc_of_incident F hP hr hc)), this]
+        · by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue e
+          · have := hmerge' e; rw [triMerge, if_neg hr, if_pos hb] at this
+            rw [← (hag.bc F (isCrossing_bc_of_incident F hP hb hc)), this]
+          · have := hmerge' e; rw [triMerge, if_neg hr, if_neg hb] at this; exact this.symm
+      · rw [dif_neg hc]
+  · -- Reading the free indices of a reconstruction recovers them.
+    intro legs _
+    obtain ⟨lr, lb, lc⟩ := legs
+    refine Prod.ext ?_ (Prod.ext ?_ ?_)
+    · funext e; simp only [triFiberLegs, triFiberTriple]; rw [dif_neg e.2]
+    · funext e; simp only [triFiberLegs, triFiberTriple]; rw [dif_neg e.2]
+    · funext e; simp only [triFiberLegs, triFiberTriple]; rw [dif_neg e.2]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
@@ -570,5 +570,65 @@ theorem stateCoeff_coarseTensor_collapse (F : CoherentCoarseBlockingFrame (G := 
       (coarseProj F.frame.red (s 0)) (coarseProj F.frame.blue (s 1))
       (coarseProj F.frame.complement (s 2))]
 
+/-! ### Same-state transport to the coarse tensors
+
+The assembled physical configuration depends only on the three regions, not on the
+tensor, so two coherent frames sharing the same regions assemble the same global
+physical configurations. With matched bond dimensions the merge-collapse constants
+coincide, so the same-state hypothesis transports to equality of the coarse states. -/
+
+/-- The assembled physical configuration depends only on the three regions: at each
+vertex it reads the decoded coarse physical index of the region containing it. -/
+theorem assembleTri_eq_decode {A : Tensor G d}
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (s : Fin 3 → Fin (coarseDim V d)) (w : V) :
+    assembleTri F hP (coarseProj F.frame.red (s 0)) (coarseProj F.frame.blue (s 1))
+        (coarseProj F.frame.complement (s 2)) w =
+      if w ∈ F.frame.red then coarseDecode V d (s 0) w
+      else if w ∈ F.frame.blue then coarseDecode V d (s 1) w
+      else coarseDecode V d (s 2) w := by
+  rw [assembleTri]
+  by_cases hr : w ∈ F.frame.red
+  · rw [dif_pos hr, if_pos hr]; rfl
+  · rw [dif_neg hr, if_neg hr]
+    by_cases hb : w ∈ F.frame.blue
+    · rw [dif_pos hb, if_pos hb]; rfl
+    · rw [dif_neg hb, if_neg hb]; rfl
+
+open scoped Classical in
+/-- **Same-state transport to the coarse tensors.** Two coherent frames over tensors
+`A` and `B` sharing the same three regions and bond dimensions, with `A` and `B`
+generating the same state, give coarse three-site tensors generating the same coarse
+state: the merge-collapse constants coincide and the assembled physical configurations
+agree, so the original same-state hypothesis transports through the collapse.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coarseTensor_sameState_of_sameState {A B : Tensor G d}
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) :
+    SameState (F.frame.coarseTensor) (F'.frame.coarseTensor) := by
+  intro s
+  rw [stateCoeff_coarseTensor_collapse F hP s, stateCoeff_coarseTensor_collapse F' hP' s]
+  have hconst : regionNonIncidentBondProd A F.frame.red *
+        regionNonIncidentBondProd A F.frame.blue *
+        regionNonIncidentBondProd A F.frame.complement =
+      regionNonIncidentBondProd B F'.frame.red *
+        regionNonIncidentBondProd B F'.frame.blue *
+        regionNonIncidentBondProd B F'.frame.complement := by
+    rw [regionNonIncidentBondProd, regionNonIncidentBondProd, regionNonIncidentBondProd,
+      regionNonIncidentBondProd, regionNonIncidentBondProd, regionNonIncidentBondProd,
+      hred, hblue, hcompl, hbond]
+  rw [hconst]
+  congr 1
+  rw [hAB]
+  congr 1
+  funext w
+  rw [assembleTri_eq_decode, assembleTri_eq_decode, hred, hblue]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
@@ -476,5 +476,99 @@ theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     · funext e; simp only [triFiberLegs, triFiberTriple]; rw [dif_neg e.2]
     · funext e; simp only [triFiberLegs, triFiberTriple]; rw [dif_neg e.2]
 
+/-! ### The three-region merge collapse
+
+The agreeing-triple sum collapses to a constant times the closed-state coefficient of
+the assembled physical configuration: each agreeing triple's product is the merged
+summand at its merge, grouping by the merge counts each merged summand with the fiber
+multiplicity, and the merged summands sum to the closed-state coefficient. -/
+
+/-- An agreeing triple's product of region vertex products is the merged summand at its
+three-way merge. -/
+theorem agreeing_summand_eq (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement)
+    {ζr ζb ζc : VirtualConfig A} (h : TripleAgrees F ζr ζb ζc) :
+    (∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w)) *
+        (∏ w : {w : V // w ∈ F.frame.blue}, A.component w.1 (fun ie => ζb ie.1) (σb w)) *
+        (∏ w : {w : V // w ∈ F.frame.complement},
+          A.component w.1 (fun ie => ζc ie.1) (σc w)) =
+      triMergedSummand F σr σb σc (triMerge F ζr ζb ζc) := by
+  rw [triMergedSummand, ← redProd_triMerge F ζr ζb ζc σr,
+    ← blueProd_triMerge F hP h σb, ← complProd_triMerge F hP h σc]
+
+open scoped Classical in
+/-- **The three-region merge collapse.** The agreeing-triple sum of the product of the
+three regions' vertex products collapses to the product of the three regions'
+non-incident bond products, times the closed-state coefficient of the assembled
+physical configuration. This is the three-region analogue of
+`TNLean.PEPS.stateCoeff_eq_regionComplement`.
+
+Source: arXiv:1804.04964, Section 3, lines 1205--1210 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem agreeingTripleSum_collapse (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) :
+    (∑ t ∈ (Finset.univ : Finset (VirtualConfig A × VirtualConfig A × VirtualConfig A)).filter
+        (fun t => TripleAgrees F t.1 t.2.1 t.2.2),
+      (∏ w : {w : V // w ∈ F.frame.red},
+          A.component w.1 (fun ie => t.1 ie.1) (σr w)) *
+        (∏ w : {w : V // w ∈ F.frame.blue},
+          A.component w.1 (fun ie => t.2.1 ie.1) (σb w)) *
+        (∏ w : {w : V // w ∈ F.frame.complement},
+          A.component w.1 (fun ie => t.2.2 ie.1) (σc w))) =
+      (regionNonIncidentBondProd A F.frame.red * regionNonIncidentBondProd A F.frame.blue *
+          regionNonIncidentBondProd A F.frame.complement) •
+        stateCoeff A (assembleTri F hP σr σb σc) := by
+  classical
+  rw [Finset.sum_congr rfl (fun t ht => agreeing_summand_eq F hP σr σb σc
+    (by rw [Finset.mem_filter] at ht; exact ht.2))]
+  -- Group by merged configuration, count each fiber, and reassemble the closed state.
+  conv_lhs => rw [← Finset.sum_fiberwise (Finset.univ.filter
+    (fun t : VirtualConfig A × VirtualConfig A × VirtualConfig A =>
+      TripleAgrees F t.1 t.2.1 t.2.2))
+    (fun t => triMerge F t.1 t.2.1 t.2.2)
+    (fun t => triMergedSummand F σr σb σc (triMerge F t.1 t.2.1 t.2.2))]
+  rw [← sum_triMergedSummand F hP σr σb σc, Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun η _ => ?_)
+  rw [Finset.filter_filter,
+    Finset.sum_congr rfl (g := fun _ => triMergedSummand F σr σb σc η)
+      (fun p hp => by rw [Finset.mem_filter] at hp; rw [hp.2.2]),
+    Finset.sum_const, triFiber_card F hP η]
+
+open scoped Classical in
+/-- **The global fiber-collapse bijection.** The closed-state coefficient of the coarse
+three-site tensor at a coarse physical configuration `s` equals the product of the
+three regions' non-incident bond products, times the closed-state coefficient of the
+original tensor at the assembled physical configuration that decodes `s` to each
+region.
+
+The coarse state sum is written through the coherent bond models as a triple sum over
+coarse virtual configurations of the three region weights' product
+(`stateCoeff_coarseTensor_eq_threeRegionSum`), reindexed by the bond models as a sum
+over agreeing crossing triples (`threeRegionSum_eq_agreeingTripleSum`), and collapsed
+by merging each agreeing triple into one global configuration with the three regions'
+non-incident bond products as fiber multiplicity (`agreeingTripleSum_collapse`).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1205--1210 and
+1449--1500 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem stateCoeff_coarseTensor_collapse (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (s : Fin 3 → Fin (coarseDim V d)) :
+    stateCoeff (F.frame.coarseTensor) s =
+      (regionNonIncidentBondProd A F.frame.red * regionNonIncidentBondProd A F.frame.blue *
+          regionNonIncidentBondProd A F.frame.complement) •
+        stateCoeff A (assembleTri F hP
+          (coarseProj F.frame.red (s 0)) (coarseProj F.frame.blue (s 1))
+          (coarseProj F.frame.complement (s 2))) := by
+  rw [F.frame.stateCoeff_coarseTensor_eq_threeRegionSum s,
+    threeRegionSum_eq_agreeingTripleSum F hP s,
+    agreeingTripleSum_collapse F hP
+      (coarseProj F.frame.red (s 0)) (coarseProj F.frame.blue (s 1))
+      (coarseProj F.frame.complement (s 2))]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
@@ -192,5 +192,117 @@ theorem complProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     · rw [if_pos hb]; exact (h.bc F (isCrossing_bc_of_incident F hP hb hcinc)).symm
     · rw [if_neg hb]
 
+/-! ### The assembled physical configuration
+
+The three regions' physical legs glue into one global physical configuration: each
+vertex reads its own region's leg (red, then blue, then complement, under the
+partition). The closed-state coefficient of the assembled configuration is the sum
+over global virtual configurations of the merged summand. -/
+
+/-- **The assembled physical configuration.** A global physical configuration reading
+the red leg on red vertices, the blue leg on blue vertices, and the complement leg on
+complement vertices. -/
+def assembleTri (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) : V → Fin d :=
+  fun w => if hr : w ∈ F.frame.red then σr ⟨w, hr⟩
+    else if hb : w ∈ F.frame.blue then σb ⟨w, hb⟩
+    else σc ⟨w, by
+      have : w ∈ F.frame.red ∪ F.frame.blue ∪ F.frame.complement := by
+        rw [hP.cover_univ]; exact Finset.mem_univ _
+      rcases Finset.mem_union.mp this with h | h
+      · rcases Finset.mem_union.mp h with h | h
+        · exact absurd h hr
+        · exact absurd h hb
+      · exact h⟩
+
+@[simp] theorem assembleTri_red (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement)
+    (w : {w : V // w ∈ F.frame.red}) :
+    assembleTri F hP σr σb σc w.1 = σr w := by rw [assembleTri, dif_pos w.2]
+
+@[simp] theorem assembleTri_blue (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement)
+    (w : {w : V // w ∈ F.frame.blue}) :
+    assembleTri F hP σr σb σc w.1 = σb w := by
+  have hnr : w.1 ∉ F.frame.red := fun hr =>
+    (Finset.disjoint_left.mp hP.red_disjoint_blue) hr w.2
+  rw [assembleTri, dif_neg hnr, dif_pos w.2]
+
+@[simp] theorem assembleTri_compl (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement)
+    (w : {w : V // w ∈ F.frame.complement}) :
+    assembleTri F hP σr σb σc w.1 = σc w := by
+  have hnr : w.1 ∉ F.frame.red := fun hr =>
+    (Finset.disjoint_left.mp hP.red_disjoint_complement) hr w.2
+  have hnb : w.1 ∉ F.frame.blue := fun hb =>
+    (Finset.disjoint_left.mp hP.blue_disjoint_complement) hb w.2
+  rw [assembleTri, dif_neg hnr, dif_neg hnb]
+
+/-- The global vertex product of the assembled physical configuration splits as the
+product of the three regions' vertex products, at any fixed global virtual
+configuration. -/
+theorem prod_assembleTri_split (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) (η : VirtualConfig A) :
+    (∏ v : V, A.component v (fun ie => η ie.1) (assembleTri F hP σr σb σc v)) =
+      (∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => η ie.1) (σr w)) *
+        (∏ w : {w : V // w ∈ F.frame.blue}, A.component w.1 (fun ie => η ie.1) (σb w)) *
+        (∏ w : {w : V // w ∈ F.frame.complement},
+          A.component w.1 (fun ie => η ie.1) (σc w)) := by
+  classical
+  rw [show (Finset.univ : Finset V) = F.frame.red ∪ F.frame.blue ∪ F.frame.complement from
+      hP.cover_univ.symm,
+    Finset.prod_union (by
+      rw [Finset.disjoint_union_left]
+      exact ⟨hP.red_disjoint_complement, hP.blue_disjoint_complement⟩),
+    Finset.prod_union hP.red_disjoint_blue]
+  congr 1
+  · congr 1
+    · rw [Finset.prod_subtype F.frame.red (fun x => Iff.rfl)
+        (fun v => A.component v (fun ie => η ie.1) (assembleTri F hP σr σb σc v))]
+      exact Finset.prod_congr rfl (fun w _ => by rw [assembleTri_red])
+    · rw [Finset.prod_subtype F.frame.blue (fun x => Iff.rfl)
+        (fun v => A.component v (fun ie => η ie.1) (assembleTri F hP σr σb σc v))]
+      exact Finset.prod_congr rfl (fun w _ => by rw [assembleTri_blue])
+  · rw [Finset.prod_subtype F.frame.complement (fun x => Iff.rfl)
+      (fun v => A.component v (fun ie => η ie.1) (assembleTri F hP σr σb σc v))]
+    exact Finset.prod_congr rfl (fun w _ => by rw [assembleTri_compl])
+
+/-- The merged summand at a global virtual configuration: the product of the three
+regions' vertex products, all read from the one configuration. -/
+noncomputable def triMergedSummand (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) (η : VirtualConfig A) : ℂ :=
+  (∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => η ie.1) (σr w)) *
+    (∏ w : {w : V // w ∈ F.frame.blue}, A.component w.1 (fun ie => η ie.1) (σb w)) *
+    (∏ w : {w : V // w ∈ F.frame.complement}, A.component w.1 (fun ie => η ie.1) (σc w))
+
+/-- The sum of the merged summands over all global virtual configurations is the
+closed-state coefficient of the assembled physical configuration. -/
+theorem sum_triMergedSummand (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) :
+    (∑ η : VirtualConfig A, triMergedSummand F σr σb σc η) =
+      stateCoeff A (assembleTri F hP σr σb σc) := by
+  classical
+  unfold stateCoeff triMergedSummand
+  exact Finset.sum_congr rfl (fun η _ => (prod_assembleTri_split F hP σr σb σc η).symm)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite6.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite6.lean
@@ -1,0 +1,96 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite5
+
+/-!
+# The inserted-coefficient descent for the normal PEPS theorem
+
+The fiber-collapse `TNLean.PEPS.stateCoeff_coarseTensor_collapse` of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite5` glues the coarse three-site closed state to
+the original closed state: the coarse state coefficient is a constant times the
+original state coefficient of the assembled physical configuration. This file mirrors
+that collapse with a matrix inserted on the coarse `r-b` super-bond, descending the
+coarse edge-inserted coefficient to the original region-inserted coefficient of the
+red region against its set complement.
+
+The coarse `r-b` super-bond is the whole bundle of red-to-blue crossing edges
+(`CrossingConfig red blue`, the codomain of `bondModel coarseEdgeRB`), so a matrix on
+that super-bond couples every red-to-blue crossing, not a single boundary edge. The
+descent therefore lands on the whole-crossing-bundle inserted coefficient
+`crossingInsertedCoeff`, the analogue of `regionInsertedCoeff` whose inserted matrix
+acts on the whole red-to-blue crossing bundle rather than a single boundary edge.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 254--583 (the injective three-site comparison) and 1205--1210,
+  1449--1500 (the blocking) of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d}
+
+/-! ### The red-to-blue crossing-bundle agreement
+
+The fiber-collapse `agreeingTripleSum_collapse` sums the product of the three regions'
+vertex products over crossing triples that agree on *all three* super-bonds. With a
+matrix inserted on the `r-b` super-bond the red and blue configurations are no longer
+forced to agree on the red-to-blue crossings: their two crossing labels there are
+coupled through the inserted matrix instead. The remaining two agreements, on the
+red-to-complement and blue-to-complement crossings, are unchanged.
+
+This predicate records that relaxed agreement: the red and complement configurations
+agree on the red-to-complement crossings, and the blue and complement configurations
+agree on the blue-to-complement crossings, with the red-to-blue crossings left free. -/
+
+/-- **Relaxed crossing agreement of a triple.** The red and complement configurations
+agree on the red-to-complement crossings, and the blue and complement configurations
+agree on the blue-to-complement crossings; the red-to-blue crossings are left free for
+the inserted matrix to couple. -/
+def CrossTripleAgreesAwayRB (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb ζc : VirtualConfig A) : Prop :=
+  crossingLabel (G := G) A F.frame.red F.frame.complement ζr =
+      (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.red F.frame.complement) ∧
+    crossingLabel (G := G) A F.frame.blue F.frame.complement ζb =
+      (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.blue F.frame.complement)
+
+instance (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (ζr ζb ζc : VirtualConfig A) :
+    Decidable (CrossTripleAgreesAwayRB F ζr ζb ζc) := by
+  unfold CrossTripleAgreesAwayRB; infer_instance
+
+omit [DecidableEq V] in
+/-- A fully agreeing triple agrees away from the `r-b` super-bond. -/
+theorem CrossTripleAgreesAwayRB.of_tripleAgrees
+    {F : CoherentCoarseBlockingFrame (G := G) (d := d) A} {ζr ζb ζc : VirtualConfig A}
+    (h : TripleAgrees F ζr ζb ζc) : CrossTripleAgreesAwayRB F ζr ζb ζc :=
+  ⟨h.2.1, h.2.2⟩
+
+/-! ### The red-to-blue crossing label of a region boundary configuration
+
+The red region's boundary edges split, under the partition, into red-to-blue crossings
+and red-to-complement crossings. A red boundary configuration therefore restricts to a
+red-to-blue crossing configuration: its values on the boundary edges that cross to the
+blue region. The inserted matrix on the `r-b` super-bond couples two red (and host)
+boundary configurations only through these red-to-blue crossing values. -/
+
+/-- The red-to-blue crossing label of a red boundary configuration: its values on the
+boundary edges of the red region that cross to the blue region. -/
+noncomputable def redBoundaryRBCrossing (A : Tensor G d) (red blue : Finset V)
+    (μ : RegionBoundaryConfig (G := G) A red) :
+    CrossingConfig (G := G) A red blue :=
+  fun g => μ ⟨g.1, g.2.1⟩
+
+omit [Fintype V] [DecidableEq V] in
+@[simp] theorem redBoundaryRBCrossing_apply (A : Tensor G d) (red blue : Finset V)
+    (μ : RegionBoundaryConfig (G := G) A red)
+    (g : {g : Edge G // IsCrossingEdge (G := G) A red blue g}) :
+    redBoundaryRBCrossing (G := G) A red blue μ g = μ ⟨g.1, g.2.1⟩ := rfl
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite6.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite6.lean
@@ -32,7 +32,7 @@ open scoped BigOperators Matrix
 namespace TNLean
 namespace PEPS
 
-variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {V : Type*} [Fintype V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 variable {A : Tensor G d}
 
@@ -64,7 +64,6 @@ instance (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (ζr ζb ζc : Vi
     Decidable (CrossTripleAgreesAwayRB F ζr ζb ζc) := by
   unfold CrossTripleAgreesAwayRB; infer_instance
 
-omit [DecidableEq V] in
 /-- A fully agreeing triple agrees away from the `r-b` super-bond. -/
 theorem CrossTripleAgreesAwayRB.of_tripleAgrees
     {F : CoherentCoarseBlockingFrame (G := G) (d := d) A} {ζr ζb ζc : VirtualConfig A}
@@ -86,11 +85,117 @@ noncomputable def redBoundaryRBCrossing (A : Tensor G d) (red blue : Finset V)
     CrossingConfig (G := G) A red blue :=
   fun g => μ ⟨g.1, g.2.1⟩
 
-omit [Fintype V] [DecidableEq V] in
+omit [Fintype V] in
 @[simp] theorem redBoundaryRBCrossing_apply (A : Tensor G d) (red blue : Finset V)
     (μ : RegionBoundaryConfig (G := G) A red)
     (g : {g : Edge G // IsCrossingEdge (G := G) A red blue g}) :
     redBoundaryRBCrossing (G := G) A red blue μ g = μ ⟨g.1, g.2.1⟩ := rfl
+
+/-! ### The whole-bundle red inserted coefficient
+
+The descent target of the coarse edge-inserted coefficient. The coarse `r-b`
+super-bond carries the whole red-to-blue crossing bundle, so the inserted matrix
+couples two red (and host) boundary configurations through their red-to-blue crossing
+labels, with the remaining boundary edges (the red-to-complement crossings) contracted
+diagonally. This is the whole-bundle analogue of `regionInsertedCoeff`, where the
+single boundary edge of the coupling is replaced by the whole red-to-blue crossing
+bundle.
+
+Two boundary configurations agree away from the red-to-blue crossings when they carry
+the same value on every red boundary edge that does not cross to the blue region. -/
+
+/-- Two red boundary configurations agree away from the red-to-blue crossings: they
+carry the same value on every red boundary edge not crossing to the blue region. -/
+def SameAwayFromRBBundle (A : Tensor G d) (red blue : Finset V)
+    (μ ν : RegionBoundaryConfig (G := G) A red) : Prop :=
+  ∀ f : {f : Edge G // IsRegionBoundaryEdge (G := G) red f},
+    ¬ IsCrossingEdge (G := G) A red blue f.1 → μ f = ν f
+
+instance (A : Tensor G d) (red blue : Finset V)
+    (μ ν : RegionBoundaryConfig (G := G) A red) :
+    Decidable (SameAwayFromRBBundle (G := G) A red blue μ ν) := by
+  unfold SameAwayFromRBBundle; infer_instance
+
+/-- **The whole-bundle red inserted coefficient.** Insert the matrix `M` on the whole
+red-to-blue crossing bundle of the red region's boundary, contract the red region on
+one side and the host `univ \ red` on the other, with the red-to-complement crossings
+contracted diagonally. This is the descent target of the coarse edge-inserted
+coefficient at the coarse `r-b` super-bond.
+
+The sum has two red boundary configurations `μ` (read by the red region) and `ν` (read
+by the host), agreeing away from the red-to-blue crossings; `M` couples their
+red-to-blue crossing labels.
+
+Source: arXiv:1804.04964, Section 3, lines 254--583 and 1205--1210 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def redBundleInsertedCoeff (A : Tensor G d) (red blue : Finset V)
+    (M : Matrix (CrossingConfig (G := G) A red blue)
+      (CrossingConfig (G := G) A red blue) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ red)) : ℂ :=
+    ∑ μ : RegionBoundaryConfig (G := G) A red,
+      ∑ ν : RegionBoundaryConfig (G := G) A red,
+        (if SameAwayFromRBBundle (G := G) A red blue μ ν then
+            M (redBoundaryRBCrossing (G := G) A red blue μ)
+              (redBoundaryRBCrossing (G := G) A red blue ν)
+          else 0) *
+          regionBlockedWeight (G := G) A red μ σ *
+          regionBlockedWeight (G := G) A (Finset.univ \ red)
+            (regionComplementBoundaryConfig (G := G) A red ν) τ
+
+/-- Unfolding lemma for `redBundleInsertedCoeff`. -/
+theorem redBundleInsertedCoeff_eq (A : Tensor G d) (red blue : Finset V)
+    (M : Matrix (CrossingConfig (G := G) A red blue)
+      (CrossingConfig (G := G) A red blue) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ red)) :
+    redBundleInsertedCoeff (G := G) A red blue M σ τ =
+      ∑ μ : RegionBoundaryConfig (G := G) A red,
+        ∑ ν : RegionBoundaryConfig (G := G) A red,
+          (if SameAwayFromRBBundle (G := G) A red blue μ ν then
+              M (redBoundaryRBCrossing (G := G) A red blue μ)
+                (redBoundaryRBCrossing (G := G) A red blue ν)
+            else 0) *
+            regionBlockedWeight (G := G) A red μ σ *
+            regionBlockedWeight (G := G) A (Finset.univ \ red)
+              (regionComplementBoundaryConfig (G := G) A red ν) τ := by
+  rw [redBundleInsertedCoeff]
+
+/-- The whole-bundle red inserted coefficient is additive in the inserted matrix. -/
+theorem redBundleInsertedCoeff_add (A : Tensor G d) (red blue : Finset V)
+    (M M' : Matrix (CrossingConfig (G := G) A red blue)
+      (CrossingConfig (G := G) A red blue) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ red)) :
+    redBundleInsertedCoeff (G := G) A red blue (M + M') σ τ =
+      redBundleInsertedCoeff (G := G) A red blue M σ τ +
+        redBundleInsertedCoeff (G := G) A red blue M' σ τ := by
+  classical
+  rw [redBundleInsertedCoeff_eq, redBundleInsertedCoeff_eq, redBundleInsertedCoeff_eq,
+    ← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl (fun ν _ => ?_)
+  by_cases h : SameAwayFromRBBundle (G := G) A red blue μ ν
+  · simp only [if_pos h, Matrix.add_apply]; ring
+  · simp only [if_neg h]; ring
+
+/-- The whole-bundle red inserted coefficient is homogeneous in the inserted matrix. -/
+theorem redBundleInsertedCoeff_smul (A : Tensor G d) (red blue : Finset V) (c : ℂ)
+    (M : Matrix (CrossingConfig (G := G) A red blue)
+      (CrossingConfig (G := G) A red blue) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ red)) :
+    redBundleInsertedCoeff (G := G) A red blue (c • M) σ τ =
+      c * redBundleInsertedCoeff (G := G) A red blue M σ τ := by
+  classical
+  rw [redBundleInsertedCoeff_eq, redBundleInsertedCoeff_eq, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun ν _ => ?_)
+  by_cases h : SameAwayFromRBBundle (G := G) A red blue μ ν
+  · simp only [if_pos h, Matrix.smul_apply, smul_eq_mul]; ring
+  · simp only [if_neg h]; ring
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
@@ -491,7 +491,7 @@ theorem legEquivComplement_pairToEtaY (F : CoherentCoarseBlockingFrame (G := G) 
       (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.red F.frame.complement)) :
     F.frame.legEquivComplement (fun ie => (pairToEtaY (G := G) F ζr ζc ζb).1 ie.1) =
       regionBoundaryLabel (G := G) A F.frame.complement ζc := by
-  show F.frame.legEquivComplement (fun ie => (tripleToEta F ζr ζc) ie.1) =
+  change F.frame.legEquivComplement (fun ie => (tripleToEta F ζr ζc) ie.1) =
     regionBoundaryLabel (G := G) A F.frame.complement ζc
   refine legEquivComplement_eq_of_bondModel F hP _ ζc ?_ ?_
   · rw [tripleToEta_rc]; exact hrc
@@ -509,7 +509,7 @@ theorem legEquivBlue_override_pairToEtaY (F : CoherentCoarseBlockingFrame (G := 
           (pairToEtaY (G := G) F ζr ζc ζb).1 (pairToEtaY (G := G) F ζr ζc ζb).2 ie.1) =
       regionBoundaryLabel (G := G) A F.frame.blue ζb := by
   refine legEquivBlue_overrideEdge_eq_of_bondModel F hP _ _ ζb (bondModel_blueRBIndex F ζb) ?_
-  show F.bondModel coarseEdgeBC ((tripleToEta F ζr ζc) coarseEdgeBC) =
+  change F.bondModel coarseEdgeBC ((tripleToEta F ζr ζc) coarseEdgeBC) =
     crossingLabel (G := G) A F.frame.blue F.frame.complement ζb
   rw [tripleToEta_bc, hbc]; rfl
 
@@ -570,6 +570,117 @@ theorem pairConfig_constraint_set (F : CoherentCoarseBlockingFrame (G := G) (d :
       simp only [overrideEdge,
         Function.update_of_ne (show coarseEdgeBC ≠ coarseEdgeRB by decide)] at hbcBlue
       rw [← hbcBlue, bondModel_bc_eq_of_legEquivComplement_eq F hP p.1 ζc hc]
+
+/-! ### The relaxed-triple reindexing of the M-coupled descent
+
+Each per-pair M-coupled product of the three region weights is expanded as a triple
+sum over global virtual configurations matched to the pair's three induced region
+boundary configurations. Summing over the pair and collapsing the inner sum to the
+constraint-set indicator reindexes the M-coupled three-region sum onto the relaxed
+crossing data the merge collapse contracts. -/
+
+/-- The per-pair M-coupled product of the three region weights, expanded as a triple
+sum over global configurations matched to the pair's three induced region boundary
+configurations. The red and complement weights read the pair's coarse configuration;
+the blue weight reads the override. -/
+theorem perPair_threeRegionProduct_eq
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (s : Fin 3 → Fin (coarseDim V d))
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ)
+    (ηL : VirtualConfig (F.frame.coarseTensor)) (y : Fin (F.frame.coarseBondDim coarseEdgeRB)) :
+    M (ηL coarseEdgeRB) y *
+        regionBlockedWeight (G := G) A F.frame.red
+          (F.frame.legEquivRed (fun ie => ηL ie.1)) (coarseProj F.frame.red (s 0)) *
+        regionBlockedWeight (G := G) A F.frame.complement
+          (F.frame.legEquivComplement (fun ie => ηL ie.1))
+            (coarseProj F.frame.complement (s 2)) *
+        regionBlockedWeight (G := G) A F.frame.blue
+          (F.frame.legEquivBlue
+            (fun ie => overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB
+              ηL y ie.1)) (coarseProj F.frame.blue (s 1)) =
+      ∑ ζr : VirtualConfig A, ∑ ζb : VirtualConfig A, ∑ ζc : VirtualConfig A,
+        (if F.frame.legEquivRed (fun ie => ηL ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+            F.frame.legEquivBlue (fun ie =>
+                overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+            F.frame.legEquivComplement (fun ie => ηL ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.complement ζc then
+          M (ηL coarseEdgeRB) y *
+            (∏ w : {w : V // w ∈ F.frame.red},
+                A.component w.1 (fun ie => ζr ie.1) (coarseProj F.frame.red (s 0) w)) *
+            (∏ w : {w : V // w ∈ F.frame.complement},
+                A.component w.1 (fun ie => ζc ie.1) (coarseProj F.frame.complement (s 2) w)) *
+            (∏ w : {w : V // w ∈ F.frame.blue},
+                A.component w.1 (fun ie => ζb ie.1) (coarseProj F.frame.blue (s 1) w))
+        else 0) := by
+  classical
+  rw [show regionBlockedWeight (G := G) A F.frame.red
+        (F.frame.legEquivRed (fun ie => ηL ie.1)) (coarseProj F.frame.red (s 0)) =
+      ∑ ζr : VirtualConfig A, if regionBoundaryLabel (G := G) A F.frame.red ζr =
+          F.frame.legEquivRed (fun ie => ηL ie.1) then
+        ∏ w : {w : V // w ∈ F.frame.red},
+          A.component w.1 (fun ie => ζr ie.1) (coarseProj F.frame.red (s 0) w) else 0 from by
+      rw [regionBlockedWeight, Finset.sum_filter],
+    show regionBlockedWeight (G := G) A F.frame.complement
+        (F.frame.legEquivComplement (fun ie => ηL ie.1)) (coarseProj F.frame.complement (s 2)) =
+      ∑ ζc : VirtualConfig A, if regionBoundaryLabel (G := G) A F.frame.complement ζc =
+          F.frame.legEquivComplement (fun ie => ηL ie.1) then
+        ∏ w : {w : V // w ∈ F.frame.complement},
+          A.component w.1 (fun ie => ζc ie.1) (coarseProj F.frame.complement (s 2) w) else 0 from by
+      rw [regionBlockedWeight, Finset.sum_filter],
+    show regionBlockedWeight (G := G) A F.frame.blue
+        (F.frame.legEquivBlue (fun ie =>
+          overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1))
+          (coarseProj F.frame.blue (s 1)) =
+      ∑ ζb : VirtualConfig A, if regionBoundaryLabel (G := G) A F.frame.blue ζb =
+          F.frame.legEquivBlue (fun ie =>
+            overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1) then
+        ∏ w : {w : V // w ∈ F.frame.blue},
+          A.component w.1 (fun ie => ζb ie.1) (coarseProj F.frame.blue (s 1) w) else 0 from by
+      rw [regionBlockedWeight, Finset.sum_filter]]
+  classical
+  -- Fully distribute the three weight sums (giving the order blue, complement, red),
+  -- flatten both nested sums to single sums over a triple, then reindex by the cyclic
+  -- shift onto the target order red, blue, complement and compare the summands.
+  simp only [Finset.mul_sum, Finset.sum_mul]
+  rw [← Fintype.sum_prod_type', ← Fintype.sum_prod_type', ← Fintype.sum_prod_type',
+    ← Fintype.sum_prod_type']
+  refine Finset.sum_nbij' (fun t => ((t.2, t.1.1), t.1.2))
+    (fun t => ((t.1.2, t.2), t.1.1)) (fun _ _ => Finset.mem_univ _)
+    (fun _ _ => Finset.mem_univ _) (fun _ _ => rfl) (fun _ _ => rfl) ?_
+  rintro ⟨⟨ζb, ζc⟩, ζr⟩ _
+  dsimp only
+  -- Combine the three selectors and the matrix factor into one selector.
+  by_cases hr : regionBoundaryLabel (G := G) A F.frame.red ζr =
+      F.frame.legEquivRed (fun ie => ηL ie.1)
+  · by_cases hb : regionBoundaryLabel (G := G) A F.frame.blue ζb =
+        F.frame.legEquivBlue (fun ie =>
+          overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1)
+    · by_cases hc : regionBoundaryLabel (G := G) A F.frame.complement ζc =
+          F.frame.legEquivComplement (fun ie => ηL ie.1)
+      · rw [if_pos hr, if_pos hb, if_pos hc,
+          if_pos (show F.frame.legEquivRed (fun ie => ηL ie.1) =
+                regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+              F.frame.legEquivBlue (fun ie =>
+                  overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1) =
+                regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+              F.frame.legEquivComplement (fun ie => ηL ie.1) =
+                regionBoundaryLabel (G := G) A F.frame.complement ζc
+            from ⟨hr.symm, hb.symm, hc.symm⟩)]
+      · rw [if_neg hc, mul_zero, zero_mul,
+          if_neg (show ¬ (_ ∧ _ ∧ F.frame.legEquivComplement (fun ie => ηL ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.complement ζc)
+            from fun h => hc h.2.2.symm)]
+    · rw [if_neg hb, mul_zero,
+        if_neg (show ¬ (_ ∧ F.frame.legEquivBlue (fun ie =>
+              overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.blue ζb ∧ _)
+          from fun h => hb h.2.1.symm)]
+  · rw [if_neg hr, mul_zero, zero_mul, zero_mul,
+      if_neg (show ¬ (F.frame.legEquivRed (fun ie => ηL ie.1) =
+            regionBoundaryLabel (G := G) A F.frame.red ζr ∧ _)
+        from fun h => hr h.1.symm)]
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
@@ -305,5 +305,36 @@ theorem edgeInsertedCoeff_coarseTensor_eq_threeRegionSum
   rw [hred, hblue, hmiddle]
   ring
 
+/-! ### The override reads the alternate `r-b` super-bond
+
+Overriding a coarse virtual configuration on the `r-b` super-edge changes only the
+`r-b` super-bond value; every other super-bond is untouched. The blue super-site's
+leg identification reads the `r-b` crossings through the overridden value and the
+`b-c` crossings unchanged. -/
+
+/-- The override of a coarse configuration agrees with it on the `r-c` and `b-c`
+super-edges. -/
+theorem overrideEdge_coarse_rc (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ηL : VirtualConfig (F.frame.coarseTensor)) (y : Fin (F.frame.coarseBondDim coarseEdgeRB)) :
+    overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y coarseEdgeRC =
+      ηL coarseEdgeRC :=
+  overrideEdge_ne (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y
+    (by decide)
+
+/-- The override of a coarse configuration agrees with it on the `b-c` super-edge. -/
+theorem overrideEdge_coarse_bc (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ηL : VirtualConfig (F.frame.coarseTensor)) (y : Fin (F.frame.coarseBondDim coarseEdgeRB)) :
+    overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y coarseEdgeBC =
+      ηL coarseEdgeBC :=
+  overrideEdge_ne (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y
+    (by decide)
+
+/-- The override of a coarse configuration reads the alternate value on the `r-b`
+super-edge. -/
+@[simp] theorem overrideEdge_coarse_rb (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ηL : VirtualConfig (F.frame.coarseTensor)) (y : Fin (F.frame.coarseBondDim coarseEdgeRB)) :
+    overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y coarseEdgeRB = y :=
+  overrideEdge_edge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
@@ -1,0 +1,244 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite6
+
+/-!
+# The inserted-coefficient descent for the normal PEPS theorem
+
+The fiber-collapse `TNLean.PEPS.stateCoeff_coarseTensor_collapse` of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite5` glues the coarse three-site closed state to
+the original closed state. This file mirrors that collapse with a matrix inserted on
+the coarse red-to-blue super-bond, descending the coarse edge-inserted coefficient
+`TNLean.PEPS.edgeInsertedCoeff` of the coarse tensor at its `r-b` edge to the
+whole-bundle red inserted coefficient `TNLean.PEPS.redBundleInsertedCoeff` of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite6`.
+
+The coarse `r-b` super-bond carries the whole bundle of red-to-blue crossing edges
+(`TNLean.PEPS.CrossingConfig`), so a matrix on that super-bond couples every
+red-to-blue crossing. The descent therefore lands on the whole-crossing-bundle
+inserted coefficient, the analogue of `regionInsertedCoeff` whose inserted matrix
+acts on the whole red-to-blue crossing bundle.
+
+The route first records a tensor-agnostic expansion of `edgeInsertedCoeff` at an
+edge `e` as a sum over *pairs* of global virtual configurations agreeing on every
+edge other than `e`, with the inserted matrix coupling their two values on `e`
+(`edgeInsertedCoeff_eq_pairSum`). This is the open-bond generalization of
+`TNLean.PEPS.edgeBlockedCoeff_eq_stateCoeff`, where the single distinguished-edge
+index is split into an independent left and right index.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 254--583 (the injective three-site comparison) and 1205--1210,
+  1449--1500 (the blocking) of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Two global configurations agreeing off an edge
+
+The open-bond expansion of the edge-inserted coefficient couples two global virtual
+configurations that carry the same value on every edge other than the distinguished
+one. The inserted matrix couples their two values on the distinguished edge. -/
+
+/-- Two global virtual configurations agree off the edge `e` when they carry the same
+value on every edge other than `e`. -/
+def AgreeOffEdge (A : Tensor G d) (e : Edge G) (ζL ζR : VirtualConfig A) : Prop :=
+  ∀ f : Edge G, f ≠ e → ζL f = ζR f
+
+instance (A : Tensor G d) (e : Edge G) (ζL ζR : VirtualConfig A) :
+    Decidable (AgreeOffEdge (G := G) A e ζL ζR) := by
+  unfold AgreeOffEdge; infer_instance
+
+omit [DecidableRel G.Adj] in
+/-- An edge incident to a middle vertex of `e` is not `e` itself. -/
+theorem incidentMiddle_ne (e : Edge G) {v : V} (hv : v ∈ edgeMiddleVertices e)
+    (ie : IncidentEdge G v) : ie.1 ≠ e := by
+  intro hie
+  have hvne := (mem_edgeMiddleVertices_iff e v).mp hv
+  rcases ie.2 with hleft | hright
+  · exact hvne.1 (hleft.symm.trans (congrArg (fun f : Edge G => f.1.1) hie))
+  · exact hvne.2 (hright.symm.trans (congrArg (fun f : Edge G => f.1.2) hie))
+
+/-- On any edge incident to a middle vertex of `e`, two configurations agreeing off
+`e` coincide. -/
+theorem AgreeOffEdge.middle (A : Tensor G d) (e : Edge G) {ζL ζR : VirtualConfig A}
+    (h : AgreeOffEdge (G := G) A e ζL ζR) {v : V} (hv : v ∈ edgeMiddleVertices e)
+    (ie : IncidentEdge G v) : ζL ie.1 = ζR ie.1 :=
+  h ie.1 (incidentMiddle_ne (G := G) e hv ie)
+
+/-! ### The open-bond expansion of the edge-inserted coefficient
+
+The edge-inserted coefficient is the closed-state contraction with the distinguished
+bond `e` cut into an independent left and right index coupled by the inserted matrix.
+The left index is carried by a full global virtual configuration `ζL`; the right
+index `y` overrides the value of `ζL` on `e` for the right endpoint only. The middle
+and the left endpoint read `ζL`; the right endpoint reads `ζL` with `e` set to `y`.
+This is the open-bond generalization of `edgeBlockedCoeff_eq_stateCoeff`. -/
+
+/-- The right-side reading of a global virtual configuration with the distinguished
+edge index overridden by `y`: it equals `ζL` everywhere except on `e`, where it is
+`y`. -/
+noncomputable def overrideEdge (A : Tensor G d) (e : Edge G) (ζL : VirtualConfig A)
+    (y : Fin (A.bondDim e)) : VirtualConfig A :=
+  Function.update ζL e y
+
+omit [Fintype V] in
+@[simp] theorem overrideEdge_edge (A : Tensor G d) (e : Edge G) (ζL : VirtualConfig A)
+    (y : Fin (A.bondDim e)) : overrideEdge (G := G) A e ζL y e = y := by
+  simp [overrideEdge]
+
+omit [Fintype V] in
+@[simp] theorem overrideEdge_ne (A : Tensor G d) (e : Edge G) (ζL : VirtualConfig A)
+    (y : Fin (A.bondDim e)) {f : Edge G} (hf : f ≠ e) :
+    overrideEdge (G := G) A e ζL y f = ζL f := by
+  simp [overrideEdge, hf]
+
+omit [Fintype V] in
+/-- The override agrees with `ζL` off `e`. -/
+theorem agreeOffEdge_overrideEdge (A : Tensor G d) (e : Edge G) (ζL : VirtualConfig A)
+    (y : Fin (A.bondDim e)) : AgreeOffEdge (G := G) A e ζL (overrideEdge (G := G) A e ζL y) :=
+  fun _ hf => (overrideEdge_ne (G := G) A e ζL y hf).symm
+
+omit [Fintype V] in
+/-- The right endpoint local configuration reconstructed from the right index `y` and
+a full configuration's right residual is the right-incident reading of the override of
+that configuration with `y` on `e`. -/
+theorem edgeRightLocalConfig_override (A : Tensor G d) (e : Edge G) (ζL : VirtualConfig A)
+    (y : Fin (A.bondDim e)) :
+    edgeRightLocalConfig (G := G) A e
+        { edgeIndex := y
+          leftResidual := (edgeBoundaryOfVirtualConfig (G := G) A e ζL).leftResidual
+          rightResidual := (edgeBoundaryOfVirtualConfig (G := G) A e ζL).rightResidual } =
+      (fun ie : IncidentEdge G e.1.2 => overrideEdge (G := G) A e ζL y ie.1) := by
+  funext ie
+  by_cases hie : ie = edgeRightIncident (G := G) e
+  · subst ie
+    rw [edgeRightLocalConfig_edgeIndex]
+    simp only [edgeRightIncident, overrideEdge, Function.update_self]
+  · rw [edgeRightLocalConfig_residual (G := G) A e _ ⟨ie, hie⟩]
+    have hne : ie.1 ≠ e := fun h => hie (Subtype.ext h)
+    rw [overrideEdge_ne (G := G) A e ζL y hne]
+    rfl
+
+/-- **The open-bond expansion of the edge-inserted coefficient.** The edge-inserted
+coefficient is the sum, over a global virtual configuration `ζL` and an independent
+right-endpoint index `y` on the distinguished edge `e`, of the inserted matrix
+coupling `ζL`'s edge value to `y`, times the left endpoint and middle product read
+from `ζL` and the right endpoint read from `ζL` with its `e`-value overridden by `y`.
+
+This is the open-bond generalization of `edgeBlockedCoeff_eq_stateCoeff`: cutting the
+distinguished bond into an independent left value (`ζL e`) and right value (`y`)
+coupled by the inserted matrix, with everything off `e` shared.
+
+Source: arXiv:1804.04964, Section 3, the matrix insertion on the distinguished edge,
+lines 254--583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeInsertedCoeff_eq_pairSum (A : Tensor G d) (e : Edge G) (σ : V → Fin d)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    edgeInsertedCoeff (G := G) A e σ M =
+      ∑ ζL : VirtualConfig A, ∑ y : Fin (A.bondDim e),
+        A.component e.1.1 (fun ie => ζL ie.1) (σ e.1.1) *
+          M (ζL e) y *
+          (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => ζL ie.1) (σ v)) *
+          A.component e.1.2 (fun ie => overrideEdge (G := G) A e ζL y ie.1) (σ e.1.2) := by
+  classical
+  rw [edgeInsertedCoeff]
+  -- Reindex `EdgeInsertedBoundaryConfig` as `(EdgeBoundaryConfig × right index y)` and
+  -- rewrite each summand into boundary form, restoring the ordinary middle weight.
+  rw [← Equiv.sum_comp (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e)
+    (fun β => A.component e.1.1 (edgeInsertedLeftLocalConfig (G := G) A e β) (σ e.1.1) *
+      M β.leftEdgeIndex β.rightEdgeIndex *
+      edgeOpenMiddleWeight (G := G) A e σ β.leftResidual β.rightResidual *
+      A.component e.1.2 (edgeInsertedRightLocalConfig (G := G) A e β) (σ e.1.2)),
+    Fintype.sum_sigma' (fun (β0 : EdgeBoundaryConfig (G := G) A e) (y : Fin (A.bondDim e)) =>
+      A.component e.1.1 (edgeInsertedLeftLocalConfig (G := G) A e
+            (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩))
+          (σ e.1.1) *
+        M (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩).leftEdgeIndex
+          (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩).rightEdgeIndex *
+        edgeOpenMiddleWeight (G := G) A e σ
+          (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩).leftResidual
+          (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩).rightResidual *
+        A.component e.1.2 (edgeInsertedRightLocalConfig (G := G) A e
+            (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩))
+          (σ e.1.2))]
+  have hsummand : ∀ (β0 : EdgeBoundaryConfig (G := G) A e) (y : Fin (A.bondDim e)),
+      A.component e.1.1 (edgeInsertedLeftLocalConfig (G := G) A e
+            (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩))
+          (σ e.1.1) *
+        M (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩).leftEdgeIndex
+          (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩).rightEdgeIndex *
+        edgeOpenMiddleWeight (G := G) A e σ
+          (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩).leftResidual
+          (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩).rightResidual *
+        A.component e.1.2 (edgeInsertedRightLocalConfig (G := G) A e
+            (edgeBoundaryRightIndexEquivInsertedBoundaryConfig (G := G) A e ⟨β0, y⟩))
+          (σ e.1.2) =
+      A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β0) (σ e.1.1) *
+        M β0.edgeIndex y *
+        edgeMiddleWeight (G := G) A e σ β0 *
+        A.component e.1.2 (edgeRightLocalConfig (G := G) A e
+          { edgeIndex := y, leftResidual := β0.leftResidual,
+            rightResidual := β0.rightResidual }) (σ e.1.2) := by
+    intro β0 y
+    rw [edgeMiddleWeight_eq_edgeOpenMiddleWeight]
+    rfl
+  rw [Finset.sum_congr rfl (fun β0 _ => Finset.sum_congr rfl (fun y _ => hsummand β0 y))]
+  -- Expand the middle weight and reindex `(β0, middle config)` to a full config `ζL`.
+  -- Both sides are brought to `y` outer, `(β0 / ζL)` inner.
+  rw [Finset.sum_comm]
+  conv_rhs => rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl (fun y _ => ?_)
+  calc
+    (∑ β0 : EdgeBoundaryConfig (G := G) A e,
+        A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β0) (σ e.1.1) *
+          M β0.edgeIndex y *
+          edgeMiddleWeight (G := G) A e σ β0 *
+          A.component e.1.2 (edgeRightLocalConfig (G := G) A e
+            { edgeIndex := y, leftResidual := β0.leftResidual,
+              rightResidual := β0.rightResidual }) (σ e.1.2))
+        = ∑ β0 : EdgeBoundaryConfig (G := G) A e,
+            ∑ η : EdgeMiddleConfig (G := G) A e β0,
+              A.component e.1.1 (edgeLeftLocalConfig (G := G) A e β0) (σ e.1.1) *
+                M β0.edgeIndex y *
+                (∏ v ∈ edgeMiddleVertices e,
+                  A.component v (fun ie => η.1 ie.1) (σ v)) *
+                A.component e.1.2 (edgeRightLocalConfig (G := G) A e
+                  { edgeIndex := y, leftResidual := β0.leftResidual,
+                    rightResidual := β0.rightResidual }) (σ e.1.2) := by
+          refine Finset.sum_congr rfl (fun β0 _ => ?_)
+          rw [edgeMiddleWeight, Finset.mul_sum, Finset.sum_mul]
+    _ = ∑ x : (Σ β0 : EdgeBoundaryConfig (G := G) A e, EdgeMiddleConfig (G := G) A e β0),
+          A.component e.1.1 (edgeLeftLocalConfig (G := G) A e x.1) (σ e.1.1) *
+            M x.1.edgeIndex y *
+            (∏ v ∈ edgeMiddleVertices e,
+              A.component v (fun ie => x.2.1 ie.1) (σ v)) *
+            A.component e.1.2 (edgeRightLocalConfig (G := G) A e
+              { edgeIndex := y, leftResidual := x.1.leftResidual,
+                rightResidual := x.1.rightResidual }) (σ e.1.2) := by
+        rw [← Fintype.sum_sigma']
+    _ = ∑ ζL : VirtualConfig A,
+          A.component e.1.1 (fun ie => ζL ie.1) (σ e.1.1) *
+            M (ζL e) y *
+            (∏ v ∈ edgeMiddleVertices e, A.component v (fun ie => ζL ie.1) (σ v)) *
+            A.component e.1.2 (fun ie => overrideEdge (G := G) A e ζL y ie.1) (σ e.1.2) := by
+        let φ := virtualConfigEquivEdgeBoundary (G := G) A e
+        rw [← Equiv.sum_comp φ]
+        refine Finset.sum_congr rfl (fun ζL _ => ?_)
+        have hmatch : edgeBoundaryMatches (G := G) A e
+            (edgeBoundaryOfVirtualConfig (G := G) A e ζL) ζL := by simp
+        have hleft := edgeLeftLocalConfig_eq_of_boundaryMatches
+          (G := G) A e (edgeBoundaryOfVirtualConfig (G := G) A e ζL) ζL hmatch
+        have hright := edgeRightLocalConfig_override (G := G) A e ζL y
+        simp only [φ, virtualConfigEquivEdgeBoundary, Equiv.coe_fn_mk]
+        rw [hleft, hright]
+        rfl
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
@@ -682,5 +682,113 @@ theorem perPair_threeRegionProduct_eq
             regionBoundaryLabel (G := G) A F.frame.red ζr ∧ _)
         from fun h => hr h.1.symm)]
 
+/-- **The relaxed-triple reindexing of the M-coupled descent.** The M-coupled
+three-region sum over the coarse virtual configuration and the free right index equals
+the sum, over triples of global virtual configurations agreeing away from the
+red-to-blue crossings, of the inserted matrix at the two crossing labels times the
+product of the three regions' vertex products.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 254--583 and 1449--1500
+of `Papers/1804.04964/paper_normal.tex`. -/
+theorem mCoupledThreeRegionSum_eq_relaxedTripleSum
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (s : Fin 3 → Fin (coarseDim V d))
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ) :
+    (∑ ηL : VirtualConfig (F.frame.coarseTensor),
+        ∑ y : Fin (F.frame.coarseBondDim coarseEdgeRB),
+          M (ηL coarseEdgeRB) y *
+            regionBlockedWeight (G := G) A F.frame.red
+              (F.frame.legEquivRed (fun ie => ηL ie.1)) (coarseProj F.frame.red (s 0)) *
+            regionBlockedWeight (G := G) A F.frame.complement
+              (F.frame.legEquivComplement (fun ie => ηL ie.1))
+                (coarseProj F.frame.complement (s 2)) *
+            regionBlockedWeight (G := G) A F.frame.blue
+              (F.frame.legEquivBlue
+                (fun ie => overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB
+                  ηL y ie.1)) (coarseProj F.frame.blue (s 1))) =
+      ∑ t ∈ (Finset.univ : Finset (VirtualConfig A × VirtualConfig A × VirtualConfig A)).filter
+          (fun t => CrossTripleAgreesAwayRB F t.1 t.2.1 t.2.2),
+        bondModelMatrix (G := G) F M
+            (crossingLabel (G := G) A F.frame.red F.frame.blue t.1)
+            (fun g => t.2.1 g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue) *
+          (∏ w : {w : V // w ∈ F.frame.red},
+              A.component w.1 (fun ie => t.1 ie.1) (coarseProj F.frame.red (s 0) w)) *
+          (∏ w : {w : V // w ∈ F.frame.complement},
+              A.component w.1 (fun ie => t.2.2 ie.1) (coarseProj F.frame.complement (s 2) w)) *
+          (∏ w : {w : V // w ∈ F.frame.blue},
+              A.component w.1 (fun ie => t.2.1 ie.1) (coarseProj F.frame.blue (s 1) w)) := by
+  classical
+  -- Expand each pair summand into the constrained triple sum.
+  simp_rw [perPair_threeRegionProduct_eq F s M]
+  -- Bundle the coarse configuration and free index into a single pair sum.
+  have hbundle := (Fintype.sum_prod_type'
+    (f := fun (ηL : VirtualConfig (F.frame.coarseTensor))
+        (y : Fin (F.frame.coarseBondDim coarseEdgeRB)) =>
+      ∑ ζr : VirtualConfig A, ∑ ζb : VirtualConfig A, ∑ ζc : VirtualConfig A,
+        (if F.frame.legEquivRed (fun ie => ηL ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+            F.frame.legEquivBlue (fun ie =>
+                overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+            F.frame.legEquivComplement (fun ie => ηL ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.complement ζc then
+          M (ηL coarseEdgeRB) y *
+            (∏ w : {w : V // w ∈ F.frame.red},
+                A.component w.1 (fun ie => ζr ie.1) (coarseProj F.frame.red (s 0) w)) *
+            (∏ w : {w : V // w ∈ F.frame.complement},
+                A.component w.1 (fun ie => ζc ie.1) (coarseProj F.frame.complement (s 2) w)) *
+            (∏ w : {w : V // w ∈ F.frame.blue},
+                A.component w.1 (fun ie => ζb ie.1) (coarseProj F.frame.blue (s 1) w))
+        else 0)))
+  rw [← hbundle]
+  -- Collapse the innermost pair sum (after moving it inside) to the crossing-agreement
+  -- selector, giving the per-triple coupled product. Express the right side likewise.
+  rw [Finset.sum_comm]
+  rw [Finset.sum_filter, Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl (fun ζr _ => ?_)
+  rw [Finset.sum_comm, Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl (fun ζb _ => ?_)
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl (fun ζc _ => ?_)
+  dsimp only
+  -- The innermost pair sum collapses to the crossing-agreement selector.
+  by_cases hag : CrossTripleAgreesAwayRB F ζr ζb ζc
+  · rw [if_pos hag, ← Finset.sum_filter,
+      show (Finset.univ.filter (fun p : VirtualConfig (F.frame.coarseTensor) ×
+          Fin (F.frame.coarseBondDim coarseEdgeRB) =>
+          F.frame.legEquivRed (fun ie => p.1 ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+            F.frame.legEquivBlue (fun ie =>
+                overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB p.1 p.2 ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+            F.frame.legEquivComplement (fun ie => p.1 ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.complement ζc)) =
+        {pairToEtaY (G := G) F ζr ζc ζb} from by
+        rw [pairConfig_constraint_set F hP ζr ζb ζc, if_pos hag],
+      Finset.sum_singleton]
+    -- At the realizing pair, the inserted matrix factor is the conjugated matrix at the
+    -- two crossing labels.
+    rw [show (pairToEtaY (G := G) F ζr ζc ζb).1 coarseEdgeRB =
+        tripleToEta F ζr ζc coarseEdgeRB from rfl,
+      show (pairToEtaY (G := G) F ζr ζc ζb).2 = blueRBIndex (G := G) F ζb from rfl]
+    rw [show M (tripleToEta F ζr ζc coarseEdgeRB) (blueRBIndex (G := G) F ζb) =
+        bondModelMatrix (G := G) F M
+            (crossingLabel (G := G) A F.frame.red F.frame.blue ζr)
+            (fun g => ζb g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue) from by
+      rw [← bondModel_blueRBIndex F ζb, ← tripleToEta_rb F ζr ζc, bondModelMatrix_bondModel]]
+  · rw [if_neg hag, ← Finset.sum_filter,
+      show (Finset.univ.filter (fun p : VirtualConfig (F.frame.coarseTensor) ×
+          Fin (F.frame.coarseBondDim coarseEdgeRB) =>
+          F.frame.legEquivRed (fun ie => p.1 ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+            F.frame.legEquivBlue (fun ie =>
+                overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB p.1 p.2 ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+            F.frame.legEquivComplement (fun ie => p.1 ie.1) =
+              regionBoundaryLabel (G := G) A F.frame.complement ζc)) = ∅ from by
+        rw [pairConfig_constraint_set F hP ζr ζb ζc, if_neg hag],
+      Finset.sum_empty]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
@@ -513,5 +513,63 @@ theorem legEquivBlue_override_pairToEtaY (F : CoherentCoarseBlockingFrame (G := 
     crossingLabel (G := G) A F.frame.blue F.frame.complement ζb
   rw [tripleToEta_bc, hbc]; rfl
 
+/-- **The constraint set of the M-coupled descent.** For a fixed triple
+`(ζr, ζb, ζc)`, the pairs `(ηL, y)` whose three induced region boundary
+configurations equal the triple's region boundary labels (the blue one read through
+the override) form the singleton of the realizing pair when the triple agrees away
+from the red-to-blue crossings, and are empty otherwise. -/
+theorem pairConfig_constraint_set (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (ζr ζb ζc : VirtualConfig A) :
+    (Finset.univ.filter (fun p : VirtualConfig (F.frame.coarseTensor) ×
+        Fin (F.frame.coarseBondDim coarseEdgeRB) =>
+        F.frame.legEquivRed (fun ie => p.1 ie.1) =
+            regionBoundaryLabel (G := G) A F.frame.red ζr ∧
+          F.frame.legEquivBlue (fun ie =>
+              overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB p.1 p.2 ie.1) =
+            regionBoundaryLabel (G := G) A F.frame.blue ζb ∧
+          F.frame.legEquivComplement (fun ie => p.1 ie.1) =
+            regionBoundaryLabel (G := G) A F.frame.complement ζc)) =
+      if CrossTripleAgreesAwayRB F ζr ζb ζc then {pairToEtaY (G := G) F ζr ζc ζb} else ∅ := by
+  by_cases hag : CrossTripleAgreesAwayRB F ζr ζb ζc
+  · rw [if_pos hag]
+    obtain ⟨hrc, hbc⟩ := hag
+    ext p
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_singleton]
+    constructor
+    · rintro ⟨hr, hb, hc⟩
+      have hηL : p.1 = tripleToEta F ζr ζc := by
+        apply coarse_virtualConfig_ext F.frame
+        · apply (F.bondModel coarseEdgeRB).injective
+          rw [bondModel_rb_eq_of_legEquivRed_eq F hP p.1 ζr hr, tripleToEta_rb]
+        · apply (F.bondModel coarseEdgeRC).injective
+          rw [bondModel_rc_eq_of_legEquivRed_eq F hP p.1 ζr hr, tripleToEta_rc]
+        · apply (F.bondModel coarseEdgeBC).injective
+          rw [bondModel_bc_eq_of_legEquivComplement_eq F hP p.1 ζc hc, tripleToEta_bc]; rfl
+      have hy : p.2 = blueRBIndex (G := G) F ζb := by
+        apply (F.bondModel coarseEdgeRB).injective
+        have hrbBlue := bondModel_rb_eq_of_legEquivBlue_eq F hP
+          (overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB p.1 p.2) ζb hb
+        simp only [overrideEdge, Function.update_self] at hrbBlue
+        rw [bondModel_blueRBIndex, hrbBlue]
+      exact Prod.ext hηL hy
+    · rintro rfl
+      refine ⟨?_, ?_, ?_⟩
+      · exact legEquivRed_pairToEtaY F hP ζr ζc ζb
+      · exact legEquivBlue_override_pairToEtaY F hP ζr ζc ζb hbc
+      · exact legEquivComplement_pairToEtaY F hP ζr ζc ζb hrc
+  · rw [if_neg hag]
+    ext p
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.notMem_empty, iff_false]
+    rintro ⟨hr, hb, hc⟩
+    apply hag
+    refine ⟨?_, ?_⟩
+    · rw [← bondModel_rc_eq_of_legEquivRed_eq F hP p.1 ζr hr,
+        bondModel_rc_eq_of_legEquivComplement_eq F hP p.1 ζc hc]
+    · have hbcBlue := bondModel_bc_eq_of_legEquivBlue_eq F hP
+        (overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB p.1 p.2) ζb hb
+      simp only [overrideEdge,
+        Function.update_of_ne (show coarseEdgeBC ≠ coarseEdgeRB by decide)] at hbcBlue
+      rw [← hbcBlue, bondModel_bc_eq_of_legEquivComplement_eq F hP p.1 ζc hc]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
@@ -240,5 +240,70 @@ theorem edgeInsertedCoeff_eq_pairSum (A : Tensor G d) (e : Edge G) (σ : V → F
         rw [hleft, hright]
         rfl
 
+/-! ### The M-coupled three-region expansion of the coarse edge-inserted coefficient
+
+Specializing the open-bond expansion to the coarse three-site tensor at its `r-b`
+edge: the coarse super-site components are the original blocked-region weights, the
+coarse middle super-site (the complement) is the only middle vertex, and the inserted
+matrix couples the red super-site's `r-b` super-bond value to the blue super-site's.
+The red and complement super-sites read the configuration `ηL`; the blue super-site
+reads `ηL` with its `r-b` super-bond overridden by the free index `y`. -/
+
+variable {A : Tensor G d}
+
+/-- **The M-coupled three-region expansion.** The coarse edge-inserted coefficient at
+the `r-b` super-bond is the sum, over a coarse virtual configuration `ηL` and a free
+right `r-b` super-bond index `y`, of the inserted matrix coupling the two `r-b`
+super-bond values, times the red weight read from `ηL`, the complement weight read
+from `ηL`, and the blue weight read from `ηL` with its `r-b` super-bond overridden
+by `y`.
+
+Source: arXiv:1804.04964, Section 3, the matrix insertion on the distinguished edge,
+lines 254--583 and 1449--1500 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeInsertedCoeff_coarseTensor_eq_threeRegionSum
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (s : Fin 3 → Fin (coarseDim V d))
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ) :
+    edgeInsertedCoeff (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB s M =
+      ∑ ηL : VirtualConfig (F.frame.coarseTensor),
+        ∑ y : Fin (F.frame.coarseBondDim coarseEdgeRB),
+          M (ηL coarseEdgeRB) y *
+            regionBlockedWeight (G := G) A F.frame.red
+              (F.frame.legEquivRed (fun ie => ηL ie.1)) (coarseProj F.frame.red (s 0)) *
+            regionBlockedWeight (G := G) A F.frame.complement
+              (F.frame.legEquivComplement (fun ie => ηL ie.1))
+                (coarseProj F.frame.complement (s 2)) *
+            regionBlockedWeight (G := G) A F.frame.blue
+              (F.frame.legEquivBlue
+                (fun ie => overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB
+                  ηL y ie.1)) (coarseProj F.frame.blue (s 1)) := by
+  classical
+  rw [edgeInsertedCoeff_eq_pairSum]
+  refine Finset.sum_congr rfl (fun ηL _ => Finset.sum_congr rfl (fun y _ => ?_))
+  -- The coarse super-site components are the three original blocked-region weights.
+  have hred : (F.frame.coarseTensor).component coarseEdgeRB.1.1
+        (fun ie => ηL ie.1) (s coarseEdgeRB.1.1) =
+      regionBlockedWeight (G := G) A F.frame.red
+        (F.frame.legEquivRed (fun ie => ηL ie.1)) (coarseProj F.frame.red (s 0)) :=
+    F.frame.coarseTensor_component_red _ _
+  have hblue : (F.frame.coarseTensor).component coarseEdgeRB.1.2
+        (fun ie => overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1)
+        (s coarseEdgeRB.1.2) =
+      regionBlockedWeight (G := G) A F.frame.blue
+        (F.frame.legEquivBlue
+          (fun ie => overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB
+            ηL y ie.1)) (coarseProj F.frame.blue (s 1)) :=
+    F.frame.coarseTensor_component_blue _ _
+  have hmiddle : (∏ v ∈ edgeMiddleVertices (G := coarseGraph) coarseEdgeRB,
+        (F.frame.coarseTensor).component v (fun ie => ηL ie.1) (s v)) =
+      regionBlockedWeight (G := G) A F.frame.complement
+        (F.frame.legEquivComplement (fun ie => ηL ie.1))
+          (coarseProj F.frame.complement (s 2)) := by
+    rw [show edgeMiddleVertices (G := coarseGraph) coarseEdgeRB = {2} from by decide,
+      Finset.prod_singleton]
+    exact F.frame.coarseTensor_component_complement _ _
+  rw [hred, hblue, hmiddle]
+  ring
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
@@ -367,5 +367,151 @@ theorem legEquivBlue_overrideEdge_apply
   simp only [overrideEdge, Function.update_self,
     Function.update_of_ne (show coarseEdgeBC ≠ coarseEdgeRB by decide)]
 
+/-! ### The bond-model-conjugated matrix on the red-to-blue crossing bundle
+
+A matrix on the coarse `r-b` super-bond is carried, through the `r-b` bond model, to a
+matrix on the whole red-to-blue crossing bundle. This is the inserted matrix the
+whole-bundle red inserted coefficient `redBundleInsertedCoeff` reads. -/
+
+/-- **The bond-model-conjugated matrix.** A matrix on the coarse `r-b` super-bond,
+conjugated by the `r-b` bond model into a matrix on the red-to-blue crossing
+configurations. -/
+noncomputable def bondModelMatrix (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ) :
+    Matrix (CrossingConfig (G := G) A F.frame.red F.frame.blue)
+      (CrossingConfig (G := G) A F.frame.red F.frame.blue) ℂ :=
+  fun p q => M ((F.bondModel coarseEdgeRB).symm p) ((F.bondModel coarseEdgeRB).symm q)
+
+omit [DecidableEq V] in
+/-- The conjugated matrix reads the coarse matrix at the bond-model preimages of the
+two crossing labels. -/
+theorem bondModelMatrix_apply (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ)
+    (p q : CrossingConfig (G := G) A F.frame.red F.frame.blue) :
+    bondModelMatrix (G := G) F M p q =
+      M ((F.bondModel coarseEdgeRB).symm p) ((F.bondModel coarseEdgeRB).symm q) := rfl
+
+omit [DecidableEq V] in
+/-- The conjugated matrix at the bond-model images of two coarse super-bond values is
+the coarse matrix at those values. -/
+theorem bondModelMatrix_bondModel (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ)
+    (a b : Fin (F.frame.coarseBondDim coarseEdgeRB)) :
+    bondModelMatrix (G := G) F M (F.bondModel coarseEdgeRB a) (F.bondModel coarseEdgeRB b) =
+      M a b := by
+  rw [bondModelMatrix_apply, Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+
+/-! ### The `r-b` super-bond value read from a blue crossing label
+
+The free right index `y` of the open-bond expansion is recovered, through the `r-b`
+bond model, from a blue configuration's red-to-blue crossing label: the coarse `r-b`
+super-bond value whose bond model reads that crossing label. -/
+
+/-- The coarse `r-b` super-bond value whose `r-b` bond model is a blue configuration's
+red-to-blue crossing label. -/
+noncomputable def blueRBIndex (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζb : VirtualConfig A) : Fin (F.frame.coarseBondDim coarseEdgeRB) :=
+  (F.bondModel coarseEdgeRB).symm
+    (fun g => ζb g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue)
+
+omit [DecidableEq V] in
+/-- The `r-b` bond model of `blueRBIndex` is the blue configuration's red-to-blue
+crossing label. -/
+@[simp] theorem bondModel_blueRBIndex (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζb : VirtualConfig A) :
+    F.bondModel coarseEdgeRB (blueRBIndex (G := G) F ζb) =
+      (fun g => ζb g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue) := by
+  rw [blueRBIndex, Equiv.apply_symm_apply]
+
+/-! ### The blue-override boundary recovery
+
+A coarse configuration `ηL` and a free right index `y` induce, through the override,
+the blue boundary configuration of a global configuration `ζb` exactly when the `r-b`
+bond model reads `y` as `ζb`'s red-to-blue crossing label and the `b-c` bond model
+reads `ηL`'s `b-c` super-bond as `ζb`'s blue-to-complement crossing label. This is the
+override analogue of `legEquivBlue_eq_of_bondModel`. -/
+
+/-- **Blue-override boundary recovery.** If the `r-b` bond model of `y` reads `ζb`'s
+red-to-blue crossing label and the `b-c` bond model of `ηL`'s `b-c` super-bond reads
+`ζb`'s blue-to-complement crossing label, the blue boundary configuration the override
+induces is `ζb`'s blue boundary label. -/
+theorem legEquivBlue_overrideEdge_eq_of_bondModel
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (ηL : VirtualConfig (F.frame.coarseTensor)) (y : Fin (F.frame.coarseBondDim coarseEdgeRB))
+    (ζb : VirtualConfig A)
+    (hrb : F.bondModel coarseEdgeRB y =
+      (fun g => ζb g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue))
+    (hbc : F.bondModel coarseEdgeBC (ηL coarseEdgeBC) =
+      crossingLabel (G := G) A F.frame.blue F.frame.complement ζb) :
+    F.frame.legEquivBlue
+        (fun ie => overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.blue ζb := by
+  funext b
+  rw [legEquivBlue_overrideEdge_apply F hP ηL y b]
+  by_cases hb : IsCrossingEdge (G := G) A F.frame.red F.frame.blue b.1
+  · rw [dif_pos hb]
+    have := congrFun hrb ⟨b.1, hb⟩; rw [this]; rfl
+  · rw [dif_neg hb]
+    have hc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement b.1 :=
+      (F.frame.isCrossingEdge_red_blue_or_blue_complement hP b.2).resolve_left hb
+    have := congrFun hbc ⟨b.1, hc⟩
+    rw [crossingLabel_apply] at this; rw [this]; rfl
+
+/-! ### The constraint set of the M-coupled descent
+
+For a fixed triple `(ζr, ζb, ζc)`, the pairs `(ηL, y)` whose three induced region
+boundary configurations equal the triple's region boundary labels (with the blue one
+read from the override) form a singleton when the triple agrees away from the
+red-to-blue crossings, and are empty otherwise. The realizing pair is the coarse
+configuration realising the crossing labels of `(ζr, ζc)` together with the right
+index recovered from `ζb`'s red-to-blue crossing label. -/
+
+/-- The realizing pair of the M-coupled constraint set: the coarse configuration
+realising the crossing labels of the red and complement configurations, together with
+the right index recovered from the blue configuration's red-to-blue crossing label. -/
+noncomputable def pairToEtaY (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζc : VirtualConfig A) (ζb : VirtualConfig A) :
+    VirtualConfig (F.frame.coarseTensor) × Fin (F.frame.coarseBondDim coarseEdgeRB) :=
+  (tripleToEta F ζr ζc, blueRBIndex (G := G) F ζb)
+
+/-- The realizing pair's coarse configuration reads `ζr`'s red boundary label. -/
+theorem legEquivRed_pairToEtaY (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (ζr ζc ζb : VirtualConfig A) :
+    F.frame.legEquivRed (fun ie => (pairToEtaY (G := G) F ζr ζc ζb).1 ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.red ζr :=
+  legEquivRed_eq_of_bondModel F hP _ ζr (tripleToEta_rb F ζr ζc) (tripleToEta_rc F ζr ζc)
+
+/-- The realizing pair's coarse configuration reads `ζc`'s complement boundary label. -/
+theorem legEquivComplement_pairToEtaY (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (ζr ζc ζb : VirtualConfig A)
+    (hrc : crossingLabel (G := G) A F.frame.red F.frame.complement ζr =
+      (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.red F.frame.complement)) :
+    F.frame.legEquivComplement (fun ie => (pairToEtaY (G := G) F ζr ζc ζb).1 ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.complement ζc := by
+  show F.frame.legEquivComplement (fun ie => (tripleToEta F ζr ζc) ie.1) =
+    regionBoundaryLabel (G := G) A F.frame.complement ζc
+  refine legEquivComplement_eq_of_bondModel F hP _ ζc ?_ ?_
+  · rw [tripleToEta_rc]; exact hrc
+  · rw [tripleToEta_bc]; rfl
+
+/-- The realizing pair reads, through the override, `ζb`'s blue boundary label,
+provided the blue and complement configurations agree on the blue-to-complement
+crossings. -/
+theorem legEquivBlue_override_pairToEtaY (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (ζr ζc ζb : VirtualConfig A)
+    (hbc : crossingLabel (G := G) A F.frame.blue F.frame.complement ζb =
+      (fun g => ζc g.1 : CrossingConfig (G := G) A F.frame.blue F.frame.complement)) :
+    F.frame.legEquivBlue
+        (fun ie => overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB
+          (pairToEtaY (G := G) F ζr ζc ζb).1 (pairToEtaY (G := G) F ζr ζc ζb).2 ie.1) =
+      regionBoundaryLabel (G := G) A F.frame.blue ζb := by
+  refine legEquivBlue_overrideEdge_eq_of_bondModel F hP _ _ ζb (bondModel_blueRBIndex F ζb) ?_
+  show F.bondModel coarseEdgeBC ((tripleToEta F ζr ζc) coarseEdgeBC) =
+    crossingLabel (G := G) A F.frame.blue F.frame.complement ζb
+  rw [tripleToEta_bc, hbc]; rfl
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
@@ -336,5 +336,36 @@ super-edge. -/
     overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y coarseEdgeRB = y :=
   overrideEdge_edge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y
 
+/-! ### The blue boundary configuration of the override
+
+The blue super-site's leg identification of the override reads the `r-b` crossings
+through the alternate super-bond value `y` and the `b-c` crossings through the
+unchanged value. The blue boundary configuration the override induces is therefore
+the one whose `r-b` crossings come from `y` and whose `b-c` crossings come from
+`ηL`. -/
+
+variable [DecidableEq V]
+
+/-- **The blue leg identification of the override.** The blue super-site reads the
+override on a blue boundary edge crossing to red through the alternate `r-b`
+super-bond value `y`, and on a blue boundary edge crossing to the complement through
+the unchanged `b-c` super-bond value. -/
+theorem legEquivBlue_overrideEdge_apply
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (ηL : VirtualConfig (F.frame.coarseTensor)) (y : Fin (F.frame.coarseBondDim coarseEdgeRB))
+    (b : {b : Edge G // IsRegionBoundaryEdge (G := G) F.frame.blue b}) :
+    (F.frame.legEquivBlue
+        (fun ie => overrideEdge (G := coarseGraph) (F.frame.coarseTensor) coarseEdgeRB ηL y ie.1)
+        b : Fin (A.bondDim b.1)) =
+      if hb : IsCrossingEdge (G := G) A F.frame.red F.frame.blue b.1 then
+        (F.bondModel coarseEdgeRB y ⟨b.1, hb⟩ : Fin (A.bondDim b.1))
+      else
+        (F.bondModel coarseEdgeBC (ηL coarseEdgeBC)
+          ⟨b.1, (F.frame.isCrossingEdge_red_blue_or_blue_complement hP b.2).resolve_left hb⟩ :
+          Fin (A.bondDim b.1)) := by
+  rw [F.legEquivBlue_apply_eq hP _ b]
+  simp only [overrideEdge, Function.update_self,
+    Function.update_of_ne (show coarseEdgeBC ≠ coarseEdgeRB by decide)]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean
@@ -1,0 +1,189 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite7
+
+/-!
+# The single-crossing specialization of the whole-bundle inserted coefficient
+
+The whole-bundle red inserted coefficient `TNLean.PEPS.redBundleInsertedCoeff` of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite6` couples two red boundary configurations
+through the *whole* red-to-blue crossing bundle. The source's blocking is chosen so
+that the red region crosses to the blue region across a **single** edge `e` (the
+distinguished edge): the red sites surround the left endpoint, the blue sites surround
+the right endpoint, and `e` is the only edge whose endpoints split between the two.
+\footnote{arXiv:1804.04964, Section 3, the three injective regions around an edge,
+`Papers/1804.04964/paper_normal.tex:1449--1500`; the coordinate instance discharges
+the singleton hypothesis through `NormalBlocking.lean`.}
+
+This file records that single-crossing specialization. When the red-to-blue crossing
+set is the singleton `{e}`, the whole red-to-blue crossing bundle
+`TNLean.PEPS.CrossingConfig red blue` is a single virtual leg on `e`, the bundle
+agreement `TNLean.PEPS.SameAwayFromRBBundle` is the single-edge agreement
+`TNLean.PEPS.SameAwayFromBond` on `e`, and the whole-bundle red inserted coefficient
+is the ordinary single-edge region-inserted coefficient
+`TNLean.PEPS.regionInsertedCoeff` of the carried bond matrix.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 254--583 (the injective three-site comparison) and 1449--1500
+  (the single-crossing blocking) of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d}
+
+/-! ### The single red-to-blue crossing edge
+
+When the red-to-blue crossing set is the singleton `{e}`, the distinguished edge `e`
+is the sole red-to-blue crossing. It is therefore a boundary edge of the red region
+(`IsCrossingEdge.boundary_left`), and the crossing-configuration type
+`CrossingConfig red blue` carries one virtual leg, on `e`. -/
+
+/-- The single red-to-blue crossing edge, as a member of the crossing-edge subtype,
+under the hypothesis that the crossings are the singleton `{e}`. -/
+def singleCrossing (A : Tensor G d) (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e) :
+    {g : Edge G // IsCrossingEdge (G := G) A red blue g} :=
+  ⟨e, (hsingle e).mpr rfl⟩
+
+/-- The single red-to-blue crossing edge is a boundary edge of the red region. -/
+theorem isRegionBoundaryEdge_singleCrossing (A : Tensor G d) (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e) :
+    IsRegionBoundaryEdge (G := G) red e :=
+  ((hsingle e).mpr rfl).boundary_left
+
+/-- The single boundary edge `f := ⟨e, _⟩` of the red region carrying the sole
+red-to-blue crossing. -/
+def singleBoundaryEdge (A : Tensor G d) (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e) :
+    {f : Edge G // IsRegionBoundaryEdge (G := G) red f} :=
+  ⟨e, isRegionBoundaryEdge_singleCrossing (G := G) A red blue e hsingle⟩
+
+/-- Under the singleton hypothesis, the crossing-edge subtype has the single boundary
+edge as its only inhabitant. -/
+theorem crossingEdge_unique (A : Tensor G d) (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e)
+    (g : {g : Edge G // IsCrossingEdge (G := G) A red blue g}) :
+    g = singleCrossing (G := G) A red blue e hsingle :=
+  Subtype.ext ((hsingle g.1).mp g.2)
+
+/-! ### The single-leg crossing bundle equivalence
+
+When the crossings are the singleton `{e}`, evaluating a crossing configuration at the
+single crossing edge is a bijection onto the single virtual leg `Fin (A.bondDim e)`. -/
+
+/-- The single-leg crossing bundle equivalence: a crossing configuration on the
+singleton bundle `{e}` is its value on the single crossing edge `e`. -/
+noncomputable def singletonCrossingEquiv (A : Tensor G d) (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e) :
+    CrossingConfig (G := G) A red blue ≃ Fin (A.bondDim e) where
+  toFun p := p (singleCrossing (G := G) A red blue e hsingle)
+  invFun y := fun g => (crossingEdge_unique A red blue e hsingle g) ▸ y
+  left_inv p := by
+    funext g
+    obtain rfl := crossingEdge_unique A red blue e hsingle g
+    rfl
+  right_inv y := rfl
+
+/-- The single-leg crossing bundle equivalence reads a crossing configuration at the
+single crossing edge. -/
+@[simp] theorem singletonCrossingEquiv_apply (A : Tensor G d) (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e)
+    (p : CrossingConfig (G := G) A red blue) :
+    singletonCrossingEquiv (G := G) A red blue e hsingle p =
+      p (singleCrossing (G := G) A red blue e hsingle) := rfl
+
+/-! ### The single-crossing bond matrix
+
+A bond matrix on the single crossing edge `e` is carried to a matrix on the
+single-leg crossing bundle through the single-leg crossing equivalence. -/
+
+/-- The bond matrix on the single crossing edge `e`, carried to the single-leg crossing
+bundle through `singletonCrossingEquiv`. -/
+noncomputable def singletonBundleMatrix (A : Tensor G d) (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    Matrix (CrossingConfig (G := G) A red blue) (CrossingConfig (G := G) A red blue) ℂ :=
+  fun p q => M (singletonCrossingEquiv (G := G) A red blue e hsingle p)
+    (singletonCrossingEquiv (G := G) A red blue e hsingle q)
+
+/-- The single-leg crossing equivalence of the red-to-blue crossing label of a red
+boundary configuration is the configuration's value on the single crossing edge. -/
+theorem singletonCrossingEquiv_redBoundaryRBCrossing (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e)
+    (μ : RegionBoundaryConfig (G := G) A red) :
+    singletonCrossingEquiv (G := G) A red blue e hsingle
+        (redBoundaryRBCrossing (G := G) A red blue μ) =
+      μ (singleBoundaryEdge (G := G) A red blue e hsingle) := by
+  rw [singletonCrossingEquiv_apply, redBoundaryRBCrossing_apply]
+  rfl
+
+/-! ### The bundle agreement is the single-edge agreement
+
+The whole-bundle agreement `SameAwayFromRBBundle` -- the two red boundary
+configurations carry the same value on every red boundary edge not crossing to the
+blue region -- is, when the only red-to-blue crossing is the single edge `e`, the
+single-edge agreement `SameAwayFromBond` on the single boundary edge `e`. -/
+
+/-- Under the singleton hypothesis, the whole-bundle agreement is the single-edge
+agreement on the single boundary edge `e`. -/
+theorem sameAwayFromRBBundle_iff_sameAwayFromBond (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e)
+    (μ ν : RegionBoundaryConfig (G := G) A red) :
+    SameAwayFromRBBundle (G := G) A red blue μ ν ↔
+      SameAwayFromBond (singleBoundaryEdge (G := G) A red blue e hsingle) μ ν := by
+  constructor
+  · intro h f hf
+    refine h f ?_
+    intro hcross
+    exact hf (Subtype.ext ((hsingle f.1).mp hcross))
+  · intro h f hf
+    refine h f ?_
+    intro hf'
+    refine hf ?_
+    rw [hf']; exact (hsingle e).mpr rfl
+
+/-! ### The single-crossing specialization
+
+When the red-to-blue crossing set is the singleton `{e}`, the whole-bundle red
+inserted coefficient of the carried bond matrix is the ordinary single-edge
+region-inserted coefficient of that bond matrix on the single boundary edge `e`. -/
+
+open scoped Classical in
+/-- **The single-crossing specialization.** When the red region crosses to the blue
+region across the single edge `e`, the whole-bundle red inserted coefficient of the
+carried bond matrix `singletonBundleMatrix M` equals the single-edge region-inserted
+coefficient `regionInsertedCoeff` of `M` on the single boundary edge `e`.
+
+Source: arXiv:1804.04964, Section 3, the single-crossing blocking, lines 254--583 and
+1449--1500 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem redBundleInsertedCoeff_singleton (red blue : Finset V) (e : Edge G)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e)
+    (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) red)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ red)) :
+    redBundleInsertedCoeff (G := G) A red blue
+        (singletonBundleMatrix (G := G) A red blue e hsingle M) σ τ =
+      regionInsertedCoeff (G := G) A red
+        (singleBoundaryEdge (G := G) A red blue e hsingle) M σ τ := by
+  classical
+  rw [redBundleInsertedCoeff_eq, regionInsertedCoeff_eq]
+  refine Finset.sum_congr rfl (fun μ _ => Finset.sum_congr rfl (fun ν _ => ?_))
+  by_cases h : SameAwayFromRBBundle (G := G) A red blue μ ν
+  · rw [if_pos h,
+      if_pos ((sameAwayFromRBBundle_iff_sameAwayFromBond red blue e hsingle μ ν).mp h),
+      singletonBundleMatrix, singletonCrossingEquiv_redBoundaryRBCrossing,
+      singletonCrossingEquiv_redBoundaryRBCrossing]
+  · rw [if_neg h,
+      if_neg (fun h' => h
+        ((sameAwayFromRBBundle_iff_sameAwayFromBond red blue e hsingle μ ν).mpr h'))]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -624,5 +624,29 @@ theorem sameAwayFromRBBundle_iff_redHostAgrees
     rw [regionBoundaryLabel_apply, regionBoundaryLabel_apply]
     exact h f.1 hrc
 
+open scoped Classical in
+/-- The red blocked-region weight grouped over the red configurations realizing a red
+boundary label: a red-boundary-indicator config double sum collapses to the red configuration
+sum. -/
+theorem redBlockedWeight_as_configSum
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (f : RegionBoundaryConfig (G := G) A F.frame.red → ℂ) :
+    (∑ μ : RegionBoundaryConfig (G := G) A F.frame.red,
+        f μ * regionBlockedWeight (G := G) A F.frame.red μ σr) =
+      ∑ ζr : VirtualConfig A,
+        f (regionBoundaryLabel (G := G) A F.frame.red ζr) *
+          ∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w) := by
+  classical
+  rw [← Finset.sum_fiberwise (Finset.univ : Finset (VirtualConfig A))
+    (fun ζr => regionBoundaryLabel (G := G) A F.frame.red ζr)
+    (fun ζr => f (regionBoundaryLabel (G := G) A F.frame.red ζr) *
+      ∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w))]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [regionBlockedWeight, Finset.mul_sum]
+  refine Finset.sum_congr ?_ (fun ζr hζr => ?_)
+  · ext ζr; simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  · rw [Finset.mem_filter] at hζr; rw [hζr.2]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -570,5 +570,59 @@ theorem crossTripleAgreesAwayRB_iff (F : CoherentCoarseBlockingFrame (G := G) (d
       simpa [crossingLabel] using this
     · funext g; have := hbc g.1 g.2; simpa [crossingLabel] using this
 
+/-! ### The configuration expansion of the whole-bundle red inserted coefficient
+
+The whole-bundle red inserted coefficient of the bond-model-conjugated matrix, with the host
+physical leg the fused blue/complement leg, expands as a double sum over global virtual
+configurations: the red configuration carries the red index `μ`, a second configuration the
+host index `ν`, coupled diagonally on the red-to-complement crossings by the agreement and on
+the red-to-blue crossings by the matrix. -/
+
+open scoped Classical in
+/-- The red-to-blue crossing agreement of two red boundary labels through the host merge is
+the bundle agreement of their red boundary labels. -/
+theorem sameAwayFromRBBundle_iff_redHostAgrees
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (ζr ζb ζc : VirtualConfig A) :
+    SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
+        (regionBoundaryLabel (G := G) A F.frame.red ζr)
+        (regionBoundaryLabel (G := G) A F.frame.red (hostMerge F ζb ζc)) ↔
+      RedHostAgrees F ζr ζb ζc := by
+  constructor
+  · intro h g hg
+    -- A red-to-complement crossing is a red boundary edge not crossing to blue.
+    have hfb : ¬ IsCrossingEdge (G := G) A F.frame.red F.frame.blue g :=
+      not_crossing_of_crossing_disjoint (A := A) hP.red_disjoint_blue
+        hP.red_disjoint_complement hP.blue_disjoint_complement hg
+    have := h ⟨g, hg.boundary_left⟩ hfb
+    simpa [regionBoundaryLabel] using this
+  · intro h f hf
+    -- A red boundary edge not crossing to blue is a red-to-complement crossing.
+    have hrc : IsCrossingEdge (G := G) A F.frame.red F.frame.complement f.1 := by
+      refine ⟨f.2, ?_⟩
+      rcases f.2 with ⟨h1, h2⟩ | ⟨h1, h2⟩
+      · refine Or.inr ⟨(Finset.disjoint_left.mp hP.red_disjoint_complement) h1, ?_⟩
+        have : f.1.1.2 ∈ F.frame.red ∪ F.frame.blue ∪ F.frame.complement := by
+          rw [hP.cover_univ]; exact Finset.mem_univ _
+        rcases Finset.mem_union.mp this with hrb | hcc
+        · rcases Finset.mem_union.mp hrb with hr | hb
+          · exact absurd hr h2
+          · exact absurd (⟨Or.inl ⟨h1, h2⟩,
+              Or.inr ⟨(Finset.disjoint_left.mp hP.red_disjoint_blue) h1, hb⟩⟩ :
+              IsCrossingEdge (G := G) A F.frame.red F.frame.blue f.1) hf
+        · exact hcc
+      · refine Or.inl ⟨?_, (Finset.disjoint_left.mp hP.red_disjoint_complement) h2⟩
+        have : f.1.1.1 ∈ F.frame.red ∪ F.frame.blue ∪ F.frame.complement := by
+          rw [hP.cover_univ]; exact Finset.mem_univ _
+        rcases Finset.mem_union.mp this with hrb | hcc
+        · rcases Finset.mem_union.mp hrb with hr | hb
+          · exact absurd hr h1
+          · exact absurd (⟨Or.inr ⟨h1, h2⟩,
+              Or.inl ⟨hb, (Finset.disjoint_left.mp hP.red_disjoint_blue) h2⟩⟩ :
+              IsCrossingEdge (G := G) A F.frame.red F.frame.blue f.1) hf
+        · exact hcc
+    rw [regionBoundaryLabel_apply, regionBoundaryLabel_apply]
+    exact h f.1 hrc
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -362,5 +362,96 @@ theorem hostFreeLegs_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) 
           ¬ IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e))
       (fun e => by simp [Finset.mem_filter]) (fun e => A.bondDim e)]
 
+/-- The blue-to-complement agreement of a relaxed pair, unpacked at a single
+blue-to-complement crossing edge. -/
+def HostPairAgrees (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζb ζc : VirtualConfig A) : Prop :=
+  ∀ g : Edge G, IsCrossingEdge (G := G) A F.frame.blue F.frame.complement g → ζb g = ζc g
+
+instance (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (ζb ζc : VirtualConfig A) :
+    Decidable (HostPairAgrees F ζb ζc) := by unfold HostPairAgrees; infer_instance
+
+omit [DecidableEq V] in
+/-- A blue-to-complement crossing edge is incident to the complement block. -/
+theorem isRegionIncidentEdge_complement_of_crossing_bc
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    {g : Edge G} (hg : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement g) :
+    IsRegionIncidentEdge (G := G) F.frame.complement g :=
+  isRegionBoundaryEdge_touches (G := G) F.frame.complement hg.2
+
+open scoped Classical in
+/-- **The host-merge fiber count.** The relaxed pairs `(ζb, ζc)` agreeing on the
+blue-to-complement crossings whose host merge is the fixed configuration `η` are in
+bijection with the free virtual indices, so their number is the host-merge fiber product.
+This is the host-side analogue of `TNLean.PEPS.triFiber_card`.
+
+Source: arXiv:1804.04964, Section 3, lines 254--583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem hostMergeFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (η : VirtualConfig A) :
+    (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+        HostPairAgrees F p.1 p.2 ∧ hostMerge F p.1 p.2 = η)).card =
+      hostMergeFiberProd F := by
+  classical
+  rw [← hostFreeLegs_card F, ← Finset.card_univ]
+  refine Finset.card_nbij' (hostFiberLegs (G := G) F) (hostFiberPair (G := G) F η) ?_ ?_ ?_ ?_
+  · intro p _; exact Finset.mem_univ _
+  · -- The reconstruction lands in the fiber: agreement and merge identity.
+    intro legs _
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and]
+    refine ⟨?_, ?_⟩
+    · -- Agreement on the blue-to-complement crossings: both sides read `η`.
+      intro g hg
+      have hc : IsRegionIncidentEdge (G := G) F.frame.complement g :=
+        isRegionIncidentEdge_complement_of_crossing_bc F hg
+      simp only [hostFiberPair]
+      rw [dif_pos hc, dif_pos hg, dif_pos hc]
+    · -- The reconstruction merges back to `η`.
+      funext e
+      simp only [hostMerge, regionMerge, hostFiberPair]
+      by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement e
+      · rw [if_pos hc, dif_pos hc]
+      · rw [if_neg hc, dif_neg hc]
+  · -- Reconstructing from the free indices of a fiber pair recovers the pair.
+    intro p hp
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    obtain ⟨hagree, hmerge⟩ := hp
+    -- `hostMerge p.1 p.2 = regionMerge complement (p.2, p.1)`: complement-incident reads
+    -- `p.2`, the rest `p.1`.
+    have hmerge' : ∀ e : Edge G,
+        (if IsRegionIncidentEdge (G := G) F.frame.complement e then p.2 e else p.1 e) = η e := by
+      intro e; have := congrFun hmerge e; rwa [hostMerge, regionMerge] at this
+    refine Prod.ext ?_ ?_
+    · -- First component (the blue configuration `p.1`).
+      funext e
+      simp only [hostFiberPair, hostFiberLegs]
+      by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement e
+      · rw [dif_pos hc]
+        by_cases hbc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e
+        · -- On a blue-to-complement crossing the agreement and merge force `p.1 e = η e`.
+          rw [dif_pos hbc]
+          have h1 := hmerge' e; rw [if_pos hc] at h1
+          rw [hagree e hbc, h1]
+        · rw [dif_neg hbc]
+      · rw [dif_neg hc]
+        have := hmerge' e; rw [if_neg hc] at this; exact this.symm
+    · -- Second component (the complement configuration `p.2`).
+      funext e
+      simp only [hostFiberPair, hostFiberLegs]
+      by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement e
+      · rw [dif_pos hc]
+        have := hmerge' e; rw [if_pos hc] at this; exact this.symm
+      · rw [dif_neg hc]
+  · -- Reading the free indices of a reconstruction recovers them.
+    intro legs _
+    obtain ⟨lc, lb⟩ := legs
+    refine Prod.ext ?_ ?_
+    · funext e
+      simp only [hostFiberLegs, hostFiberPair]
+      rw [dif_neg e.2]
+    · funext e
+      simp only [hostFiberLegs, hostFiberPair]
+      obtain ⟨hc, hbc⟩ := e.2
+      rw [dif_pos hc, dif_neg hbc]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -167,5 +167,22 @@ theorem blueProd_hostMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     simpa [crossingLabel] using this
   · rw [hostMerge_not_complement F hc]
 
+/-- The host vertex product of the host merge, read with the fused blue/complement physical
+leg, equals the relaxed triple's complement product against its blue product. -/
+theorem hostProd_hostMerge_eq (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) {ζr ζb ζc : VirtualConfig A}
+    (h : CrossTripleAgreesAwayRB F ζr ζb ζc)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) :
+    (∏ w : {w : V // w ∈ Finset.univ \ F.frame.red},
+        A.component w.1 (fun ie => hostMerge F ζb ζc ie.1)
+          ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc w)) =
+      (∏ w : {w : V // w ∈ F.frame.complement}, A.component w.1 (fun ie => ζc ie.1) (σc w)) *
+        ∏ w : {w : V // w ∈ F.frame.blue}, A.component w.1 (fun ie => ζb ie.1) (σb w) := by
+  have hsplit := (F.frame.toThreeBlockGeometry hP).prod_sdiff_red_eq_blue_mul_complement
+    (A := A) σb σc (hostMerge F ζb ζc)
+  rw [complProd_hostMerge F ζb ζc σc, blueProd_hostMerge F hP h σb, mul_comm]
+  exact hsplit
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -1,0 +1,55 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite8
+
+/-!
+# The relaxed-triple merge collapse for the normal PEPS theorem
+
+The relaxed-triple reindexing `TNLean.PEPS.mCoupledThreeRegionSum_eq_relaxedTripleSum` of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite7` writes the coarse edge-inserted coefficient at
+the `r-b` super-bond as a sum over triples of global virtual configurations agreeing away
+from the red-to-blue crossings, with the bond-model-conjugated matrix coupling the two
+red-to-blue crossing labels. This file collapses that sum to a constant times the
+whole-bundle red inserted coefficient `TNLean.PEPS.redBundleInsertedCoeff` of
+`TNLean.PEPS.RegionBlock.CoarseThreeSite6`, the matrix-carrying analogue of the
+closed-state collapse `TNLean.PEPS.agreeingTripleSum_collapse`.
+
+The collapse is two-sided: the red configuration merges into the red boundary index `μ` of
+the whole-bundle red inserted coefficient, while the blue and complement configurations
+(agreeing on the blue-to-complement crossings) merge into the host boundary index `ν` over
+`univ \ red`. The bond-model-conjugated matrix couples `μ` and `ν` through their
+red-to-blue crossing labels.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 254--583 (the injective three-site comparison) and 1205--1210,
+  1449--1500 (the blocking) of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d}
+
+/-! ### The red-to-blue crossing label factors through the red boundary label
+
+The bond-model-conjugated matrix in the relaxed-triple sum reads a global configuration only
+through its red-to-blue crossing label, which is the red-to-blue crossing label of the
+configuration's red boundary label. -/
+
+omit [Fintype V] in
+/-- The red-to-blue crossing label of a global configuration is the red-to-blue crossing
+label of its red boundary label. -/
+theorem crossingLabel_eq_redBoundaryRBCrossing (red blue : Finset V) (ζ : VirtualConfig A) :
+    crossingLabel (G := G) A red blue ζ =
+      redBoundaryRBCrossing (G := G) A red blue (regionBoundaryLabel (G := G) A red ζ) := by
+  funext g
+  rw [crossingLabel_apply, redBoundaryRBCrossing_apply, regionBoundaryLabel_apply]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -453,5 +453,34 @@ theorem hostMergeFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A
       obtain ⟨hc, hbc⟩ := e.2
       rw [dif_pos hc, dif_neg hbc]
 
+/-! ### The host-merge fiberwise collapse
+
+A sum over relaxed pairs agreeing on the blue-to-complement crossings, of a quantity reading
+the pair only through its host merge, collapses to the host-merge fiber product times the
+sum of that quantity over all global configurations. -/
+
+open scoped Classical in
+/-- **The host-merge fiberwise collapse.** A sum over the relaxed pairs agreeing on the
+blue-to-complement crossings, of a quantity `g` reading the pair only through its host merge,
+collapses to the host-merge fiber product times the sum of `g` over all global virtual
+configurations.
+
+Source: arXiv:1804.04964, Section 3, lines 254--583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem hostMerge_fiberwise_collapse (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (g : VirtualConfig A → ℂ) :
+    (∑ p ∈ Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
+        HostPairAgrees F p.1 p.2), g (hostMerge F p.1 p.2)) =
+      hostMergeFiberProd F • ∑ η : VirtualConfig A, g η := by
+  classical
+  rw [← Finset.sum_fiberwise (Finset.univ.filter
+      (fun p : VirtualConfig A × VirtualConfig A => HostPairAgrees F p.1 p.2))
+    (fun p => hostMerge F p.1 p.2) (fun p => g (hostMerge F p.1 p.2))]
+  rw [Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun η _ => ?_)
+  rw [Finset.filter_filter,
+    Finset.sum_congr rfl (g := fun _ => g η)
+      (fun p hp => by rw [Finset.mem_filter] at hp; rw [hp.2.2]),
+    Finset.sum_const, hostMergeFiber_card F η]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -184,5 +184,71 @@ theorem hostProd_hostMerge_eq (F : CoherentCoarseBlockingFrame (G := G) (d := d)
   rw [complProd_hostMerge F ζb ζc σc, blueProd_hostMerge F hP h σb, mul_comm]
   exact hsplit
 
+/-! ### The boundary labels and matrix coupling of the host merge
+
+The red boundary label of a relaxed triple's red configuration and the red-reread host
+boundary label of the host merge agree away from the red-to-blue crossings: a red boundary
+edge not crossing to blue is a red-to-complement crossing, where the red-to-complement
+agreement and the complement-incidence of the merge force the two labels to coincide. The
+host merge's red-to-blue crossing label is the blue configuration's red-to-blue crossing
+label, the second argument the bond-model-conjugated matrix reads. -/
+
+/-- The red boundary label of `ζr` and the red-reread host boundary label of the host merge
+agree away from the red-to-blue crossings. -/
+theorem sameAwayFromRBBundle_hostMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) {ζr ζb ζc : VirtualConfig A}
+    (h : CrossTripleAgreesAwayRB F ζr ζb ζc) :
+    SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
+      (regionBoundaryLabel (G := G) A F.frame.red ζr)
+      (regionBoundaryLabel (G := G) A F.frame.red (hostMerge F ζb ζc)) := by
+  intro f hf
+  -- `f` is a red boundary edge not crossing to blue, hence a red-to-complement crossing.
+  have hrc : IsCrossingEdge (G := G) A F.frame.red F.frame.complement f.1 := by
+    refine ⟨f.2, ?_⟩
+    -- The out-of-red endpoint lies in the complement (it is not in blue, else `f` would
+    -- cross to blue).
+    rcases f.2 with ⟨h1, h2⟩ | ⟨h1, h2⟩
+    · -- `f.1.1.1 ∈ red`, `f.1.1.2 ∉ red`. The out endpoint `f.1.1.2 ∈ complement`.
+      have h2c : f.1.1.2 ∈ F.frame.complement := by
+        have : f.1.1.2 ∈ F.frame.red ∪ F.frame.blue ∪ F.frame.complement := by
+          rw [hP.cover_univ]; exact Finset.mem_univ _
+        rcases Finset.mem_union.mp this with hrb | hc
+        · rcases Finset.mem_union.mp hrb with hr | hb
+          · exact absurd hr h2
+          · exact absurd (⟨Or.inl ⟨h1, h2⟩,
+              Or.inr ⟨(Finset.disjoint_left.mp hP.red_disjoint_blue) h1, hb⟩⟩ :
+              IsCrossingEdge (G := G) A F.frame.red F.frame.blue f.1) hf
+        · exact hc
+      exact Or.inr ⟨(Finset.disjoint_left.mp hP.red_disjoint_complement) h1, h2c⟩
+    · -- `f.1.1.1 ∉ red`, `f.1.1.2 ∈ red`. The out endpoint `f.1.1.1 ∈ complement`.
+      have h1c : f.1.1.1 ∈ F.frame.complement := by
+        have : f.1.1.1 ∈ F.frame.red ∪ F.frame.blue ∪ F.frame.complement := by
+          rw [hP.cover_univ]; exact Finset.mem_univ _
+        rcases Finset.mem_union.mp this with hrb | hc
+        · rcases Finset.mem_union.mp hrb with hr | hb
+          · exact absurd hr h1
+          · exact absurd (⟨Or.inr ⟨h1, h2⟩,
+              Or.inl ⟨hb, (Finset.disjoint_left.mp hP.red_disjoint_blue) h2⟩⟩ :
+              IsCrossingEdge (G := G) A F.frame.red F.frame.blue f.1) hf
+        · exact hc
+      exact Or.inl ⟨h1c, (Finset.disjoint_left.mp hP.red_disjoint_complement) h2⟩
+  -- On the red-to-complement crossing, `ζr = ζc` and the merge reads `ζc`.
+  have hcinc : IsRegionIncidentEdge (G := G) F.frame.complement f.1 :=
+    isRegionIncidentEdge_complement_of_crossing_rc F hrc
+  rw [regionBoundaryLabel_apply, regionBoundaryLabel_apply, hostMerge_complement F hcinc]
+  have := congrFun h.1 ⟨f.1, hrc⟩
+  simpa [crossingLabel] using this
+
+/-- The red-to-blue crossing label of the host merge is the blue configuration's
+red-to-blue crossing label, the second argument the bond-model-conjugated matrix reads. -/
+theorem redBoundaryRBCrossing_hostMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) (ζb ζc : VirtualConfig A) :
+    redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+        (regionBoundaryLabel (G := G) A F.frame.red (hostMerge F ζb ζc)) =
+      (fun g => ζb g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue) := by
+  funext g
+  rw [redBoundaryRBCrossing_apply, regionBoundaryLabel_apply,
+    hostMerge_not_complement F (not_isRegionIncidentEdge_complement_of_crossing_rb F hP g.2)]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -625,28 +625,27 @@ theorem sameAwayFromRBBundle_iff_redHostAgrees
     exact h f.1 hrc
 
 open scoped Classical in
-/-- The red blocked-region weight grouped over the red configurations realizing a red
-boundary label: a red-boundary-indicator config double sum collapses to the red configuration
-sum. -/
-theorem redBlockedWeight_as_configSum
-    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
-    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
-    (f : RegionBoundaryConfig (G := G) A F.frame.red → ℂ) :
-    (∑ μ : RegionBoundaryConfig (G := G) A F.frame.red,
-        f μ * regionBlockedWeight (G := G) A F.frame.red μ σr) =
-      ∑ ζr : VirtualConfig A,
-        f (regionBoundaryLabel (G := G) A F.frame.red ζr) *
-          ∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w) := by
+/-- The blocked-region weight grouped over the configurations realizing a boundary label: a
+boundary-indicator config sum collapses the blocked-region weight to a sum over the global
+configurations, grouping by the boundary label. -/
+theorem blockedWeight_as_configSum (R : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (f : RegionBoundaryConfig (G := G) A R → ℂ) :
+    (∑ μ : RegionBoundaryConfig (G := G) A R,
+        f μ * regionBlockedWeight (G := G) A R μ σ) =
+      ∑ ζ : VirtualConfig A,
+        f (regionBoundaryLabel (G := G) A R ζ) *
+          ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w) := by
   classical
   rw [← Finset.sum_fiberwise (Finset.univ : Finset (VirtualConfig A))
-    (fun ζr => regionBoundaryLabel (G := G) A F.frame.red ζr)
-    (fun ζr => f (regionBoundaryLabel (G := G) A F.frame.red ζr) *
-      ∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w))]
+    (fun ζ => regionBoundaryLabel (G := G) A R ζ)
+    (fun ζ => f (regionBoundaryLabel (G := G) A R ζ) *
+      ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w))]
   refine Finset.sum_congr rfl (fun μ _ => ?_)
   rw [regionBlockedWeight, Finset.mul_sum]
-  refine Finset.sum_congr ?_ (fun ζr hζr => ?_)
-  · ext ζr; simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-  · rw [Finset.mem_filter] at hζr; rw [hζr.2]
+  refine Finset.sum_congr ?_ (fun ζ hζ => ?_)
+  · ext ζ; simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  · rw [Finset.mem_filter] at hζ; rw [hζ.2]
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -126,5 +126,46 @@ theorem hostMerge_not_complement (F : CoherentCoarseBlockingFrame (G := G) (d :=
     hostMerge F ζb ζc e = ζb e := by
   rw [hostMerge, regionMerge, if_neg he]
 
+/-- The complement vertex product of a relaxed triple reads the host merge unchanged:
+complement-incident edges read the complement configuration. -/
+theorem complProd_hostMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζb ζc : VirtualConfig A)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) :
+    (∏ w : {w : V // w ∈ F.frame.complement}, A.component w.1 (fun ie => ζc ie.1) (σc w)) =
+      ∏ w : {w : V // w ∈ F.frame.complement},
+        A.component w.1 (fun ie => hostMerge F ζb ζc ie.1) (σc w) := by
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1; funext ie
+  have hcinc : IsRegionIncidentEdge (G := G) F.frame.complement ie.1 := by
+    rcases ie.2 with hie | hie
+    · exact Or.inl (by rw [hie]; exact w.2)
+    · exact Or.inr (by rw [hie]; exact w.2)
+  rw [hostMerge_complement F hcinc]
+
+/-- The blue vertex product of a relaxed triple agreeing on the blue-to-complement
+crossings reads the host merge unchanged: a blue-incident edge that is also
+complement-incident is a blue-to-complement crossing, where the agreement coincides. -/
+theorem blueProd_hostMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition) {ζr ζb ζc : VirtualConfig A}
+    (h : CrossTripleAgreesAwayRB F ζr ζb ζc)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue) :
+    (∏ w : {w : V // w ∈ F.frame.blue}, A.component w.1 (fun ie => ζb ie.1) (σb w)) =
+      ∏ w : {w : V // w ∈ F.frame.blue},
+        A.component w.1 (fun ie => hostMerge F ζb ζc ie.1) (σb w) := by
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1; funext ie
+  have hbinc : IsRegionIncidentEdge (G := G) F.frame.blue ie.1 := by
+    rcases ie.2 with hie | hie
+    · exact Or.inl (by rw [hie]; exact w.2)
+    · exact Or.inr (by rw [hie]; exact w.2)
+  by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement ie.1
+  · -- A blue-incident, complement-incident edge is a blue-to-complement crossing.
+    rw [hostMerge_complement F hc]
+    have hbc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement ie.1 :=
+      isCrossing_bc_of_incident F hP hbinc hc
+    have := congrFun h.2 ⟨ie.1, hbc⟩
+    simpa [crossingLabel] using this
+  · rw [hostMerge_not_complement F hc]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -647,5 +647,48 @@ theorem blockedWeight_as_configSum (R : Finset V)
   · ext ζ; simp only [Finset.mem_filter, Finset.mem_univ, true_and]
   · rw [Finset.mem_filter] at hζ; rw [hζ.2]
 
+/-- The bundle agreement of two configurations' red boundary labels is their agreement on the
+red-to-complement crossings. -/
+theorem sameAwayFromRBBundle_regionBoundaryLabel_iff
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (ζ ζ' : VirtualConfig A) :
+    SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
+        (regionBoundaryLabel (G := G) A F.frame.red ζ)
+        (regionBoundaryLabel (G := G) A F.frame.red ζ') ↔
+      ∀ g : Edge G, IsCrossingEdge (G := G) A F.frame.red F.frame.complement g → ζ g = ζ' g := by
+  constructor
+  · intro h g hg
+    have hfb : ¬ IsCrossingEdge (G := G) A F.frame.red F.frame.blue g :=
+      not_crossing_of_crossing_disjoint (A := A) hP.red_disjoint_blue
+        hP.red_disjoint_complement hP.blue_disjoint_complement hg
+    have := h ⟨g, hg.boundary_left⟩ hfb
+    simpa [regionBoundaryLabel] using this
+  · intro h f hf
+    have hrc : IsCrossingEdge (G := G) A F.frame.red F.frame.complement f.1 := by
+      refine ⟨f.2, ?_⟩
+      rcases f.2 with ⟨h1, h2⟩ | ⟨h1, h2⟩
+      · refine Or.inr ⟨(Finset.disjoint_left.mp hP.red_disjoint_complement) h1, ?_⟩
+        have : f.1.1.2 ∈ F.frame.red ∪ F.frame.blue ∪ F.frame.complement := by
+          rw [hP.cover_univ]; exact Finset.mem_univ _
+        rcases Finset.mem_union.mp this with hrb | hcc
+        · rcases Finset.mem_union.mp hrb with hr | hb
+          · exact absurd hr h2
+          · exact absurd (⟨Or.inl ⟨h1, h2⟩,
+              Or.inr ⟨(Finset.disjoint_left.mp hP.red_disjoint_blue) h1, hb⟩⟩ :
+              IsCrossingEdge (G := G) A F.frame.red F.frame.blue f.1) hf
+        · exact hcc
+      · refine Or.inl ⟨?_, (Finset.disjoint_left.mp hP.red_disjoint_complement) h2⟩
+        have : f.1.1.1 ∈ F.frame.red ∪ F.frame.blue ∪ F.frame.complement := by
+          rw [hP.cover_univ]; exact Finset.mem_univ _
+        rcases Finset.mem_union.mp this with hrb | hcc
+        · rcases Finset.mem_union.mp hrb with hr | hb
+          · exact absurd hr h1
+          · exact absurd (⟨Or.inr ⟨h1, h2⟩,
+              Or.inl ⟨hb, (Finset.disjoint_left.mp hP.red_disjoint_blue) h2⟩⟩ :
+              IsCrossingEdge (G := G) A F.frame.red F.frame.blue f.1) hf
+        · exact hcc
+    rw [regionBoundaryLabel_apply, regionBoundaryLabel_apply]
+    exact h f.1 hrc
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -482,5 +482,52 @@ theorem hostMerge_fiberwise_collapse (F : CoherentCoarseBlockingFrame (G := G) (
       (fun p hp => by rw [Finset.mem_filter] at hp; rw [hp.2.2]),
     Finset.sum_const, hostMergeFiber_card F η]
 
+/-! ### The relaxed-triple merge collapse
+
+Assembling the merged summand, the host-merge fiberwise collapse, and the red-side
+blocked-region weight into the relaxed-triple merge collapse: the M-coupled relaxed-triple
+sum is the host-merge fiber product times the whole-bundle red inserted coefficient of the
+bond-model-conjugated matrix. -/
+
+open scoped Classical in
+/-- The relaxed-triple sum, with each summand replaced by its merged form: the
+bond-model-conjugated matrix at the two red boundary labels' red-to-blue crossing labels,
+times the red vertex product of `ζr`, times the host vertex product of the host merge. The
+filter is the relaxed crossing agreement. -/
+theorem relaxedTripleSum_mergedSummand_eq
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement) :
+    (∑ t ∈ (Finset.univ : Finset (VirtualConfig A × VirtualConfig A × VirtualConfig A)).filter
+        (fun t => CrossTripleAgreesAwayRB F t.1 t.2.1 t.2.2),
+      bondModelMatrix (G := G) F M
+          (crossingLabel (G := G) A F.frame.red F.frame.blue t.1)
+          (fun g => t.2.1 g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue) *
+        (∏ w : {w : V // w ∈ F.frame.red},
+            A.component w.1 (fun ie => t.1 ie.1) (σr w)) *
+        (∏ w : {w : V // w ∈ F.frame.complement},
+            A.component w.1 (fun ie => t.2.2 ie.1) (σc w)) *
+        (∏ w : {w : V // w ∈ F.frame.blue},
+            A.component w.1 (fun ie => t.2.1 ie.1) (σb w))) =
+      ∑ t ∈ (Finset.univ : Finset (VirtualConfig A × VirtualConfig A × VirtualConfig A)).filter
+          (fun t => CrossTripleAgreesAwayRB F t.1 t.2.1 t.2.2),
+        bondModelMatrix (G := G) F M
+            (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+              (regionBoundaryLabel (G := G) A F.frame.red t.1))
+            (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+              (regionBoundaryLabel (G := G) A F.frame.red (hostMerge F t.2.1 t.2.2))) *
+          (∏ w : {w : V // w ∈ F.frame.red},
+              A.component w.1 (fun ie => t.1 ie.1) (σr w)) *
+          (∏ w : {w : V // w ∈ Finset.univ \ F.frame.red},
+              A.component w.1 (fun ie => hostMerge F t.2.1 t.2.2 ie.1)
+                ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc w)) := by
+  classical
+  refine Finset.sum_congr rfl (fun t ht => ?_)
+  rw [Finset.mem_filter] at ht
+  exact relaxedTriple_summand_eq F hP M σr σb σc ht.2
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -346,5 +346,21 @@ noncomputable def hostFiberPair (F : CoherentCoarseBlockingFrame (G := G) (d := 
    fun e => if hc : IsRegionIncidentEdge (G := G) F.frame.complement e then η e
       else legs.1 ⟨e, hc⟩)
 
+/-- The free-index type of the relaxed host-merge fiber has the host-merge fiber product as
+its cardinality. -/
+theorem hostFreeLegs_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) :
+    Fintype.card (HostFreeLegs (G := G) F) = hostMergeFiberProd F := by
+  classical
+  rw [Fintype.card_prod, Fintype.card_pi, Fintype.card_pi]
+  simp only [Fintype.card_fin]
+  rw [hostMergeFiberProd, regionNonIncidentBondProd, hostBlueFreeBondProd,
+    ← Finset.prod_subtype (Finset.univ.filter
+        (fun e : Edge G => ¬ IsRegionIncidentEdge (G := G) F.frame.complement e))
+      (fun e => by simp [Finset.mem_filter]) (fun e => A.bondDim e),
+    ← Finset.prod_subtype (Finset.univ.filter
+        (fun e : Edge G => IsRegionIncidentEdge (G := G) F.frame.complement e ∧
+          ¬ IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e))
+      (fun e => by simp [Finset.mem_filter]) (fun e => A.bondDim e)]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -51,5 +51,48 @@ theorem crossingLabel_eq_redBoundaryRBCrossing (red blue : Finset V) (ζ : Virtu
   funext g
   rw [crossingLabel_apply, redBoundaryRBCrossing_apply, regionBoundaryLabel_apply]
 
+variable [DecidableEq V]
+
+/-! ### Geometric classification of red boundary crossings
+
+Under the partition, a red boundary edge crosses to the blue region or to the complement.
+A red-to-complement crossing edge is incident to the complement block, while a red-to-blue
+crossing edge is not: its endpoints lie in the red and blue blocks, both disjoint from the
+complement. These classify how the host-side merge along the complement reads each crossing
+edge. -/
+
+/-- A red-to-complement crossing edge is incident to the complement block. -/
+theorem isRegionIncidentEdge_complement_of_crossing_rc
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    {g : Edge G} (hg : IsCrossingEdge (G := G) A F.frame.red F.frame.complement g) :
+    IsRegionIncidentEdge (G := G) F.frame.complement g :=
+  isRegionBoundaryEdge_touches (G := G) F.frame.complement hg.2
+
+/-- A red-to-blue crossing edge is not incident to the complement block: its two endpoints
+lie one in the red block and one in the blue block, both disjoint from the complement. -/
+theorem not_isRegionIncidentEdge_complement_of_crossing_rb
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (hP : F.frame.IsPartition)
+    {g : Edge G} (hg : IsCrossingEdge (G := G) A F.frame.red F.frame.blue g) :
+    ¬ IsRegionIncidentEdge (G := G) F.frame.complement g := by
+  -- The red-to-blue crossing edge has, on each endpoint, a red and a blue boundary
+  -- condition; the two combine to place each endpoint in red or in blue.
+  have hcompl : ∀ v : V, v ∈ F.frame.red ∨ v ∈ F.frame.blue → v ∉ F.frame.complement := by
+    rintro v (hr | hb) hc
+    · exact (Finset.disjoint_left.mp hP.red_disjoint_complement) hr hc
+    · exact (Finset.disjoint_left.mp hP.blue_disjoint_complement) hb hc
+  rcases hg.1 with ⟨hr1, hr2⟩ | ⟨hr1, hr2⟩ <;> rcases hg.2 with ⟨hb1, hb2⟩ | ⟨hb1, hb2⟩
+  · -- g.1.1 ∈ red, g.1.1 ∈ blue: impossible.
+    exact absurd hb1 ((Finset.disjoint_left.mp hP.red_disjoint_blue) hr1)
+  · -- g.1.1 ∈ red, g.1.2 ∈ blue.
+    rintro (hc | hc)
+    · exact hcompl _ (Or.inl hr1) hc
+    · exact hcompl _ (Or.inr hb2) hc
+  · -- g.1.2 ∈ red, g.1.1 ∈ blue.
+    rintro (hc | hc)
+    · exact hcompl _ (Or.inr hb1) hc
+    · exact hcompl _ (Or.inl hr2) hc
+  · -- g.1.2 ∈ red, g.1.2 ∈ blue: impossible.
+    exact absurd hb2 ((Finset.disjoint_left.mp hP.red_disjoint_blue) hr2)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -250,5 +250,44 @@ theorem redBoundaryRBCrossing_hostMerge (F : CoherentCoarseBlockingFrame (G := G
   rw [redBoundaryRBCrossing_apply, regionBoundaryLabel_apply,
     hostMerge_not_complement F (not_isRegionIncidentEdge_complement_of_crossing_rb F hP g.2)]
 
+/-! ### The merged summand of a relaxed triple
+
+Each relaxed-triple summand of the M-coupled three-region sum is the merged summand at the
+two red boundary labels: the bond-model-conjugated matrix at the red and host merge boundary
+labels' red-to-blue crossing labels, times the red vertex product, times the host vertex
+product of the host merge against the fused blue/complement physical leg. -/
+
+/-- **The merged summand of a relaxed triple.** A relaxed-triple summand equals the
+bond-model-conjugated matrix at the two red boundary labels' red-to-blue crossing labels,
+times the red vertex product of `ζr`, times the host vertex product of the host merge against
+the fused blue/complement physical leg. -/
+theorem relaxedTriple_summand_eq (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (hP : F.frame.IsPartition)
+    (M : Matrix (Fin (F.frame.coarseBondDim coarseEdgeRB))
+      (Fin (F.frame.coarseBondDim coarseEdgeRB)) ℂ)
+    (σr : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+    (σb : RegionPhysicalConfig (V := V) (d := d) F.frame.blue)
+    (σc : RegionPhysicalConfig (V := V) (d := d) F.frame.complement)
+    {ζr ζb ζc : VirtualConfig A} (h : CrossTripleAgreesAwayRB F ζr ζb ζc) :
+    bondModelMatrix (G := G) F M
+        (crossingLabel (G := G) A F.frame.red F.frame.blue ζr)
+        (fun g => ζb g.1 : CrossingConfig (G := G) A F.frame.red F.frame.blue) *
+        (∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w)) *
+        (∏ w : {w : V // w ∈ F.frame.complement},
+          A.component w.1 (fun ie => ζc ie.1) (σc w)) *
+        (∏ w : {w : V // w ∈ F.frame.blue}, A.component w.1 (fun ie => ζb ie.1) (σb w)) =
+      bondModelMatrix (G := G) F M
+          (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+            (regionBoundaryLabel (G := G) A F.frame.red ζr))
+          (redBoundaryRBCrossing (G := G) A F.frame.red F.frame.blue
+            (regionBoundaryLabel (G := G) A F.frame.red (hostMerge F ζb ζc))) *
+        (∏ w : {w : V // w ∈ F.frame.red}, A.component w.1 (fun ie => ζr ie.1) (σr w)) *
+        (∏ w : {w : V // w ∈ Finset.univ \ F.frame.red},
+          A.component w.1 (fun ie => hostMerge F ζb ζc ie.1)
+            ((F.frame.toThreeBlockGeometry hP).complPhysical σb σc w)) := by
+  rw [crossingLabel_eq_redBoundaryRBCrossing, redBoundaryRBCrossing_hostMerge F hP ζb ζc,
+    hostProd_hostMerge_eq F hP h σb σc]
+  ring
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -314,5 +314,37 @@ noncomputable def hostMergeFiberProd (F : CoherentCoarseBlockingFrame (G := G) (
     ℕ :=
   regionNonIncidentBondProd A F.frame.complement * hostBlueFreeBondProd F
 
+/-- The free virtual indices of a relaxed host-merge fiber: the complement configuration on
+the edges not incident to the complement, and the blue configuration on the
+complement-incident edges that are not blue-to-complement crossings. -/
+abbrev HostFreeLegs (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) : Type _ :=
+  ((e : {e : Edge G // ¬ IsRegionIncidentEdge (G := G) F.frame.complement e}) →
+      Fin (A.bondDim e.1)) ×
+  ((e : {e : Edge G // IsRegionIncidentEdge (G := G) F.frame.complement e ∧
+        ¬ IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e}) → Fin (A.bondDim e.1))
+
+/-- The free virtual indices read off a relaxed host-merge fiber pair: the complement
+configuration off the complement, the blue configuration on the free complement-incident
+edges. -/
+noncomputable def hostFiberLegs (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (p : VirtualConfig A × VirtualConfig A) : HostFreeLegs (G := G) F :=
+  (fun e => p.2 e.1, fun e => p.1 e.1)
+
+/-- Reconstruct a relaxed host-merge fiber pair from its free virtual indices and the merged
+configuration `η`. The first component is the blue configuration: the merge `η` off the
+complement, the agreement value `η` on the blue-to-complement crossings, the free index on
+the remaining complement-incident edges. The second component is the complement
+configuration: the merge `η` on the complement-incident edges, the free index off the
+complement. -/
+noncomputable def hostFiberPair (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (η : VirtualConfig A) (legs : HostFreeLegs (G := G) F) :
+    VirtualConfig A × VirtualConfig A :=
+  (fun e => if hc : IsRegionIncidentEdge (G := G) F.frame.complement e then
+        (if hbc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e then η e
+          else legs.2 ⟨e, hc, hbc⟩)
+      else η e,
+   fun e => if hc : IsRegionIncidentEdge (G := G) F.frame.complement e then η e
+      else legs.1 ⟨e, hc⟩)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -94,5 +94,37 @@ theorem not_isRegionIncidentEdge_complement_of_crossing_rb
   · -- g.1.2 ∈ red, g.1.2 ∈ blue: impossible.
     exact absurd hb2 ((Finset.disjoint_left.mp hP.red_disjoint_blue) hr2)
 
+/-! ### The host merge of a relaxed triple's blue and complement configurations
+
+The blue and complement configurations of a relaxed triple, agreeing on the
+blue-to-complement crossings, merge into one host configuration over `univ \ red`: the
+complement-incident edges read the complement configuration, the remaining edges the blue
+configuration. The host vertex product of the merge reads the blue product against the
+complement product, and the merge reads the original blue and complement configurations on
+the host boundary through the red-to-blue and red-to-complement crossings respectively. -/
+
+/-- The host configuration merging a relaxed triple's complement configuration `ζc` (on the
+complement-incident edges) with its blue configuration `ζb` (elsewhere). This is the
+complement-side `regionMerge` of the pair `(ζc, ζb)`. -/
+noncomputable def hostMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζb ζc : VirtualConfig A) : VirtualConfig A :=
+  regionMerge (G := G) A F.frame.complement (ζc, ζb)
+
+omit [DecidableEq V] in
+/-- The host merge reads the complement configuration on a complement-incident edge. -/
+theorem hostMerge_complement (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    {ζb ζc : VirtualConfig A} {e : Edge G}
+    (he : IsRegionIncidentEdge (G := G) F.frame.complement e) :
+    hostMerge F ζb ζc e = ζc e := by
+  rw [hostMerge, regionMerge, if_pos he]
+
+omit [DecidableEq V] in
+/-- The host merge reads the blue configuration on an edge not incident to the complement. -/
+theorem hostMerge_not_complement (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    {ζb ζc : VirtualConfig A} {e : Edge G}
+    (he : ¬ IsRegionIncidentEdge (G := G) F.frame.complement e) :
+    hostMerge F ζb ζc e = ζb e := by
+  rw [hostMerge, regionMerge, if_neg he]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -289,5 +289,30 @@ theorem relaxedTriple_summand_eq (F : CoherentCoarseBlockingFrame (G := G) (d :=
     hostProd_hostMerge_eq F hP h σb σc]
   ring
 
+/-! ### The host-merge fiber count
+
+The relaxed pairs `(ζb, ζc)` agreeing on the blue-to-complement crossings whose host merge is
+a fixed global configuration `η` biject with the free virtual indices: the complement
+configuration is free on the edges not incident to the complement, and the blue configuration
+is free on the complement-incident edges that are not blue-to-complement crossings (the
+blue-to-complement crossings are pinned by the agreement). The common count is the product of
+the complement's non-incident bond product and the bond product over the complement-incident
+non-blue-to-complement-crossing edges. -/
+
+/-- The bond-dimension product over the complement-incident edges that are not
+blue-to-complement crossings: the free blue indices of the host-merge fiber. -/
+noncomputable def hostBlueFreeBondProd (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) :
+    ℕ :=
+  ∏ e ∈ Finset.univ.filter (fun e : Edge G =>
+      IsRegionIncidentEdge (G := G) F.frame.complement e ∧
+        ¬ IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e),
+    A.bondDim e
+
+/-- The host-merge fiber multiplicity: the complement non-incident bond product times the
+free blue bond product. -/
+noncomputable def hostMergeFiberProd (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) :
+    ℕ :=
+  regionNonIncidentBondProd A F.frame.complement * hostBlueFreeBondProd F
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -529,5 +529,46 @@ theorem relaxedTripleSum_mergedSummand_eq
   rw [Finset.mem_filter] at ht
   exact relaxedTriple_summand_eq F hP M σr σb σc ht.2
 
+/-! ### The red-to-complement agreement through the host merge
+
+The relaxed crossing agreement of a triple splits into the blue-to-complement agreement of
+the pair and the red-to-complement agreement of the red configuration against the host merge,
+the form in which the red and host sums decouple. -/
+
+/-- The red configuration and the host merge agree on the red-to-complement crossings. -/
+def RedHostAgrees (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb ζc : VirtualConfig A) : Prop :=
+  ∀ g : Edge G, IsCrossingEdge (G := G) A F.frame.red F.frame.complement g →
+    ζr g = hostMerge F ζb ζc g
+
+noncomputable instance (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb ζc : VirtualConfig A) : Decidable (RedHostAgrees F ζr ζb ζc) :=
+  Classical.dec _
+
+/-- The relaxed crossing agreement of a triple is the blue-to-complement agreement of the
+pair together with the red-to-complement agreement of the red configuration against the host
+merge. -/
+theorem crossTripleAgreesAwayRB_iff (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (ζr ζb ζc : VirtualConfig A) :
+    CrossTripleAgreesAwayRB F ζr ζb ζc ↔
+      HostPairAgrees F ζb ζc ∧ RedHostAgrees F ζr ζb ζc := by
+  constructor
+  · rintro ⟨hrc, hbc⟩
+    refine ⟨?_, ?_⟩
+    · intro g hg; have := congrFun hbc ⟨g, hg⟩; simpa [crossingLabel] using this
+    · intro g hg
+      have hcinc : IsRegionIncidentEdge (G := G) F.frame.complement g :=
+        isRegionIncidentEdge_complement_of_crossing_rc F hg
+      rw [hostMerge_complement F hcinc]
+      have := congrFun hrc ⟨g, hg⟩; simpa [crossingLabel] using this
+  · rintro ⟨hbc, hrh⟩
+    refine ⟨?_, ?_⟩
+    · funext g
+      have hcinc : IsRegionIncidentEdge (G := G) F.frame.complement g.1 :=
+        isRegionIncidentEdge_complement_of_crossing_rc F g.2
+      have := hrh g.1 g.2; rw [hostMerge_complement F hcinc] at this
+      simpa [crossingLabel] using this
+    · funext g; have := hbc g.1 g.2; simpa [crossingLabel] using this
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -51,8 +51,6 @@ theorem crossingLabel_eq_redBoundaryRBCrossing (red blue : Finset V) (ζ : Virtu
   funext g
   rw [crossingLabel_apply, redBoundaryRBCrossing_apply, regionBoundaryLabel_apply]
 
-variable [DecidableEq V]
-
 /-! ### Geometric classification of red boundary crossings
 
 Under the partition, a red boundary edge crosses to the blue region or to the complement.
@@ -110,7 +108,6 @@ noncomputable def hostMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A
     (ζb ζc : VirtualConfig A) : VirtualConfig A :=
   regionMerge (G := G) A F.frame.complement (ζc, ζb)
 
-omit [DecidableEq V] in
 /-- The host merge reads the complement configuration on a complement-incident edge. -/
 theorem hostMerge_complement (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     {ζb ζc : VirtualConfig A} {e : Edge G}
@@ -118,7 +115,6 @@ theorem hostMerge_complement (F : CoherentCoarseBlockingFrame (G := G) (d := d) 
     hostMerge F ζb ζc e = ζc e := by
   rw [hostMerge, regionMerge, if_pos he]
 
-omit [DecidableEq V] in
 /-- The host merge reads the blue configuration on an edge not incident to the complement. -/
 theorem hostMerge_not_complement (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     {ζb ζc : VirtualConfig A} {e : Edge G}
@@ -371,7 +367,6 @@ def HostPairAgrees (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
 instance (F : CoherentCoarseBlockingFrame (G := G) (d := d) A) (ζb ζc : VirtualConfig A) :
     Decidable (HostPairAgrees F ζb ζc) := by unfold HostPairAgrees; infer_instance
 
-omit [DecidableEq V] in
 /-- A blue-to-complement crossing edge is incident to the complement block. -/
 theorem isRegionIncidentEdge_complement_of_crossing_bc
     (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1332,25 +1332,75 @@ The remaining obligations are the following.
           matrix to couple --- is recorded by
           \leanid{TNLean.PEPS.CrossTripleAgreesAwayRB}.
 
-          The single-edge predicate \leanid{TNLean.PEPS.IsBondLocalTransferKernel} that the
-          per-edge gauge consumes, and the equivalence
-          \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} that reduces it to a single-edge
-          coefficient transfer, are stated for one boundary edge $f$. The whole-bundle
-          descent therefore needs a bundle-to-single-edge bridge: the single-edge coefficient
-          \leanid{TNLean.PEPS.regionInsertedCoeff} for an edge $f$ in the red-to-blue
-          crossing bundle is the whole-bundle coefficient at the matrix that inserts on the
-          $f$-coordinate of the bundle and contracts the rest of the bundle by the identity.
-          With that bridge, the descent on both tensors (sharing the non-incident bond
-          products under matched bond dimensions, by
+          The open-bond reindexing of the descent is now landed. The coarse edge-inserted
+          coefficient at the red-to-blue super-bond expands, through the open-bond form of the
+          matrix insertion, as a sum over a coarse virtual configuration and a free right
+          super-bond index of the matrix coupling their two super-bond values times the three
+          region weights, the blue weight read through the override of the coarse
+          configuration on the super-bond (\leanid{TNLean.PEPS.edgeInsertedCoeff_eq_pairSum},
+          \leanid{TNLean.PEPS.edgeInsertedCoeff_coarseTensor_eq_threeRegionSum}). Carrying the
+          matrix through the coherent bond models reindexes this onto the relaxed crossing
+          triples: the matrix becomes the bond-model-conjugated matrix
+          (\leanid{TNLean.PEPS.bondModelMatrix}) at the two configurations' red-to-blue
+          crossing labels, summed over triples agreeing away from the red-to-blue crossings
+          (\leanid{TNLean.PEPS.mCoupledThreeRegionSum_eq_relaxedTripleSum}, built on the
+          constraint-set collapse \leanid{TNLean.PEPS.pairConfig_constraint_set} and the
+          per-pair triple expansion \leanid{TNLean.PEPS.perPair_threeRegionProduct_eq}). This
+          is the matrix-carrying analogue of the closed-state reindexing
+          \leanid{TNLean.PEPS.threeRegionSum_eq_agreeingTripleSum}.
+
+          The bundle-to-single-edge bridge is also landed. The single-edge predicate
+          \leanid{TNLean.PEPS.IsBondLocalTransferKernel} that the per-edge gauge consumes, and
+          the equivalence \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} that reduces it to a
+          single-edge coefficient transfer, are stated for one boundary edge $f$. When the red
+          region crosses to the blue region across the single distinguished edge $e$ --- the
+          source's geometry, where the red sites surround one endpoint and the blue sites the
+          other --- the whole red-to-blue crossing bundle is one virtual leg on $e$
+          (\leanid{TNLean.PEPS.singletonCrossingEquiv}), the bundle agreement is the
+          single-edge agreement \leanid{TNLean.PEPS.SameAwayFromBond} on $e$
+          (\leanid{TNLean.PEPS.sameAwayFromRBBundle_iff_sameAwayFromBond}), and the
+          whole-bundle red inserted coefficient of the carried bond matrix is the single-edge
+          \leanid{TNLean.PEPS.regionInsertedCoeff} of that matrix on $e$
+          (\leanid{TNLean.PEPS.redBundleInsertedCoeff_singleton}). The single-crossing
+          hypothesis is the explicit assumption that the red-to-blue crossings are exactly the
+          singleton $\{e\}$, which the source's coordinate blocking discharges
+          (\path{TNLean/PEPS/NormalBlocking.lean:251--264,367--379}).
+
+          With these two landed pieces, the descent on both tensors (sharing the non-incident
+          bond products under matched bond dimensions, by
           \leanid{TNLean.PEPS.coarseTensor_sameState_of_sameState}), the coarse coefficient
           transfer \leanid{TNLean.PEPS.coarse_exists_edgeInsertedCoeff_eq}, the surjectivity
           \leanid{TNLean.PEPS.coarseProj_surjective}, and the positivity of the non-incident
-          bond products give the single-edge coefficient transfer, hence
+          bond products would give the single-edge coefficient transfer, hence
           \leanid{TNLean.PEPS.IsBondLocalTransferKernel} in both directions and the per-edge
-          gauge. The remaining steps are the collapse with the matrix coupling on the coarse
-          super-bond (the whole-bundle descent identity), the bundle-to-single-edge bridge,
-          and the forward multiplicativity field \leanid{hmul} of
-          \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}.
+          gauge.
+
+          The single remaining step is the \emph{relaxed-triple merge collapse}: assembling the
+          relaxed-triple sum \leanid{TNLean.PEPS.mCoupledThreeRegionSum_eq_relaxedTripleSum}
+          into a constant times the whole-bundle red inserted coefficient
+          \leanid{TNLean.PEPS.redBundleInsertedCoeff} of the bond-model-conjugated matrix. This
+          is the matrix-carrying analogue of \leanid{TNLean.PEPS.agreeingTripleSum_collapse},
+          but it is a \emph{two-sided} merge rather than a single global merge: the red
+          configuration $\zeta_r$ merges into the red-boundary index $\mu$ of
+          \leanid{TNLean.PEPS.redBundleInsertedCoeff} (collapsing the red fiber to
+          \leanid{TNLean.PEPS.regionBlockedWeight} of $\mu$), while the blue and complement
+          configurations $(\zeta_b,\zeta_c)$, agreeing on the blue-to-complement crossings,
+          merge into the host boundary index $\nu$ over $\mathrm{univ}\setminus\mathrm{red}$
+          (collapsing the blue-to-complement fiber, with a blue-to-complement interior bond
+          product as multiplicity). The bond-model-conjugated matrix then couples $\mu$ and
+          $\nu$ exactly through their red-to-blue crossing labels
+          (\leanid{TNLean.PEPS.redBoundaryRBCrossing}), and the red-to-complement crossing
+          agreement is the bundle agreement \leanid{TNLean.PEPS.SameAwayFromRBBundle}. The
+          two-sided merge over the four regions (red, blue, complement, and their host union)
+          reuses the single-region merge machinery \leanid{TNLean.PEPS.regionMerge},
+          \leanid{TNLean.PEPS.regionFiber_card} but requires a host-side
+          blue-plus-complement merge not yet formalized; it is the genuine remaining content
+          of the descent.
+
+          After the collapse, the forward multiplicativity field \leanid{hmul} of
+          \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge} (the coarse
+          edge transfer matrix descending, or \leanid{TNLean.PEPS.regionInsertedCoeff_injective}
+          at products) remains the final input to the per-edge gauge.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1385,24 +1385,65 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.redBundleInsertedCoeff} (collapsing the red fiber to
           \leanid{TNLean.PEPS.regionBlockedWeight} of $\mu$), while the blue and complement
           configurations $(\zeta_b,\zeta_c)$, agreeing on the blue-to-complement crossings,
-          merge into the host boundary index $\nu$ over $\mathrm{univ}\setminus\mathrm{red}$
-          (collapsing the blue-to-complement fiber, with a blue-to-complement interior bond
-          product as multiplicity). The bond-model-conjugated matrix then couples $\mu$ and
+          merge into the host boundary index $\nu$ over $\mathrm{univ}\setminus\mathrm{red}$.
+          The bond-model-conjugated matrix then couples $\mu$ and
           $\nu$ exactly through their red-to-blue crossing labels
           (\leanid{TNLean.PEPS.redBoundaryRBCrossing}), and the red-to-complement crossing
-          agreement is the bundle agreement \leanid{TNLean.PEPS.SameAwayFromRBBundle}. The
-          two-sided merge over the four regions (red, blue, complement, and their host union)
-          reuses the single-region merge machinery \leanid{TNLean.PEPS.regionMerge},
-          \leanid{TNLean.PEPS.regionFiber_card} on the red side, and the host-side
-          blue-plus-complement collapse is the landed three-block factorization
-          \leanid{TNLean.PEPS.ThreeBlockGeometry.regionBlockedWeight_complPhysical_eq},
-          \leanid{TNLean.PEPS.ThreeBlockGeometry.threeBlockFiber_card} of the partitioned
-          frame's three-block geometry. The remaining content of the descent is wiring these
-          two collapse engines together with the matrix coupling: the relaxed-triple sum
-          carries the matrix as a function of the two red-to-blue crossing labels, which the
-          red-side merge fixes on $\mu$ and the host-side blue-plus-complement merge fixes on
-          $\nu$, so the two engines run on a common fiber decomposition rather than
-          independently.
+          agreement is the bundle agreement \leanid{TNLean.PEPS.SameAwayFromRBBundle}.
+
+          The merged-summand layer of this collapse is now landed. The host configuration of a
+          relaxed triple is the complement-side merge of $(\zeta_c,\zeta_b)$:
+          complement-incident edges read $\zeta_c$, the rest $\zeta_b$
+          (\leanid{TNLean.PEPS.hostMerge}). The complement and blue vertex products read the
+          host merge unchanged --- the complement product because the complement is
+          complement-incident, the blue product because a blue-incident complement-incident
+          edge is a blue-to-complement crossing where the relaxed agreement coincides
+          (\leanid{TNLean.PEPS.complProd_hostMerge}, \leanid{TNLean.PEPS.blueProd_hostMerge})
+          --- so the host vertex product of the merge, read with the fused blue/complement
+          physical leg, is the complement product against the blue product
+          (\leanid{TNLean.PEPS.hostProd_hostMerge_eq}, built on the three-block host split
+          \leanid{TNLean.PEPS.ThreeBlockGeometry.prod_sdiff_red_eq_blue_mul_complement}). The
+          two boundary labels and the matrix coupling are also identified: the red boundary
+          label of $\zeta_r$ and the red-reread host boundary label of the merge agree away
+          from the red-to-blue crossings, because a red boundary edge not crossing to blue is a
+          red-to-complement crossing, complement-incident, where the merge reads $\zeta_c$ and
+          the red-to-complement agreement pins it
+          (\leanid{TNLean.PEPS.sameAwayFromRBBundle_hostMerge}); the merge's red-to-blue
+          crossing label is the blue configuration's red-to-blue crossing label, the second
+          argument the matrix reads (\leanid{TNLean.PEPS.redBoundaryRBCrossing_hostMerge}), and
+          the red configuration's red-to-blue crossing label is its red boundary label's
+          (\leanid{TNLean.PEPS.crossingLabel_eq_redBoundaryRBCrossing}). The complement and
+          red-to-blue crossing incidence of red boundary edges is recorded by
+          \leanid{TNLean.PEPS.isRegionIncidentEdge_complement_of_crossing_rc} and
+          \leanid{TNLean.PEPS.not_isRegionIncidentEdge_complement_of_crossing_rb}.
+
+          With the merged summand $\mathrm{matrix}(\mu_\mathrm{rb},\nu_\mathrm{rb})\cdot
+          \mathrm{redProd}\,\zeta_r\cdot\mathrm{hostProd}(\mathrm{hostMerge})$ in hand, the
+          residual content is the two-stage fibered grouping. Grouping the triples by
+          $\mu=\mathrm{redBoundaryLabel}\,\zeta_r$ collapses the red factor to
+          \leanid{TNLean.PEPS.regionBlockedWeight} of $\mu$ directly (no fiber multiplicity:
+          the blocked-region weight already sums the red product over every configuration
+          carrying the red boundary label). Grouping the pairs $(\zeta_b,\zeta_c)$ by the
+          red-reread host boundary label $\nu$ of their merge is the one new fiber count: for a
+          fixed $\nu$ with $\mathrm{SameAwayFromRBBundle}\,\mu\,\nu$, the relaxed pairs whose
+          merge carries host label $\nu$ collapse to a constant times the host blocked-region
+          weight $\mathrm{regionBlockedWeight}\,(\mathrm{univ}\setminus\mathrm{red})\,
+          (\mathrm{regionComplementBoundaryConfig}\,\nu)$. The relaxed pair constraint is the
+          blue-to-complement agreement only; the host engine
+          \leanid{TNLean.PEPS.ThreeBlockGeometry.threeBlockDoubleSum_eq_smul_single} requires
+          the full complement-boundary agreement, so the two differ by the blue configuration's
+          freedom on the red-to-complement crossings, which the relaxed summand never reads
+          (the blue product reads only blue-incident edges, and a red-to-complement crossing
+          touches neither blue nor the matrix's red-to-blue bundle). That unread freedom is the
+          red-to-blue crossing freedom already collapsed by
+          \leanid{TNLean.PEPS.ThreeBlockGeometry.blueRedCrossing_fiber_card} in the analogous
+          union-injectivity setting. The fiber multiplicity of the merge is therefore the
+          host-relative complement interior bond product
+          \leanid{TNLean.PEPS.regionInteriorBondProd} of the complement block times the
+          red-to-complement crossing bond product, both functions of the bond dimensions alone,
+          hence shared across the two tensors under the matched bond dimensions. Wiring the
+          two-stage grouping and this fiber count is the remaining content of the descent; the
+          merged-summand identities above are its inputs.
 
           After the collapse, the forward multiplicativity field \leanid{hmul} of
           \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge} (the coarse

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1375,75 +1375,49 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.IsBondLocalTransferKernel} in both directions and the per-edge
           gauge.
 
-          The single remaining step is the \emph{relaxed-triple merge collapse}: assembling the
-          relaxed-triple sum \leanid{TNLean.PEPS.mCoupledThreeRegionSum_eq_relaxedTripleSum}
-          into a constant times the whole-bundle red inserted coefficient
-          \leanid{TNLean.PEPS.redBundleInsertedCoeff} of the bond-model-conjugated matrix. This
-          is the matrix-carrying analogue of \leanid{TNLean.PEPS.agreeingTripleSum_collapse},
-          but it is a \emph{two-sided} merge rather than a single global merge: the red
-          configuration $\zeta_r$ merges into the red-boundary index $\mu$ of
-          \leanid{TNLean.PEPS.redBundleInsertedCoeff} (collapsing the red fiber to
-          \leanid{TNLean.PEPS.regionBlockedWeight} of $\mu$), while the blue and complement
+          The \emph{relaxed-triple merge collapse} is now landed
+          (\leanid{TNLean.PEPS.relaxedTripleSum_collapse}), and with it the whole
+          inserted-coefficient descent (\leanid{TNLean.PEPS.edgeInsertedCoeff_coarseTensor_descent}):
+          the coarse edge-inserted coefficient at the red-to-blue super-bond equals a constant
+          times the whole-bundle red inserted coefficient
+          \leanid{TNLean.PEPS.redBundleInsertedCoeff} of the bond-model-conjugated matrix, with
+          the host physical leg the fused blue/complement leg. The collapse is the
+          matrix-carrying analogue of \leanid{TNLean.PEPS.agreeingTripleSum_collapse}, a
+          \emph{two-sided} merge: the red configuration $\zeta_r$ merges into the red-boundary
+          index $\mu$ (collapsing to \leanid{TNLean.PEPS.regionBlockedWeight} of $\mu$ with no
+          fiber multiplicity, the blocked-region weight already summing the red product over
+          every configuration carrying the red boundary label), while the blue and complement
           configurations $(\zeta_b,\zeta_c)$, agreeing on the blue-to-complement crossings,
-          merge into the host boundary index $\nu$ over $\mathrm{univ}\setminus\mathrm{red}$.
-          The bond-model-conjugated matrix then couples $\mu$ and
-          $\nu$ exactly through their red-to-blue crossing labels
-          (\leanid{TNLean.PEPS.redBoundaryRBCrossing}), and the red-to-complement crossing
-          agreement is the bundle agreement \leanid{TNLean.PEPS.SameAwayFromRBBundle}.
+          merge into the host configuration \leanid{TNLean.PEPS.hostMerge} carrying the host
+          boundary index $\nu$ over $\mathrm{univ}\setminus\mathrm{red}$. The
+          bond-model-conjugated matrix couples $\mu$ and $\nu$ through their red-to-blue
+          crossing labels (\leanid{TNLean.PEPS.redBoundaryRBCrossing}), and the
+          red-to-complement crossing agreement is the bundle agreement
+          \leanid{TNLean.PEPS.SameAwayFromRBBundle}.
 
-          The merged-summand layer of this collapse is now landed. The host configuration of a
-          relaxed triple is the complement-side merge of $(\zeta_c,\zeta_b)$:
-          complement-incident edges read $\zeta_c$, the rest $\zeta_b$
-          (\leanid{TNLean.PEPS.hostMerge}). The complement and blue vertex products read the
-          host merge unchanged --- the complement product because the complement is
-          complement-incident, the blue product because a blue-incident complement-incident
-          edge is a blue-to-complement crossing where the relaxed agreement coincides
-          (\leanid{TNLean.PEPS.complProd_hostMerge}, \leanid{TNLean.PEPS.blueProd_hostMerge})
-          --- so the host vertex product of the merge, read with the fused blue/complement
-          physical leg, is the complement product against the blue product
-          (\leanid{TNLean.PEPS.hostProd_hostMerge_eq}, built on the three-block host split
-          \leanid{TNLean.PEPS.ThreeBlockGeometry.prod_sdiff_red_eq_blue_mul_complement}). The
-          two boundary labels and the matrix coupling are also identified: the red boundary
-          label of $\zeta_r$ and the red-reread host boundary label of the merge agree away
-          from the red-to-blue crossings, because a red boundary edge not crossing to blue is a
-          red-to-complement crossing, complement-incident, where the merge reads $\zeta_c$ and
-          the red-to-complement agreement pins it
-          (\leanid{TNLean.PEPS.sameAwayFromRBBundle_hostMerge}); the merge's red-to-blue
-          crossing label is the blue configuration's red-to-blue crossing label, the second
-          argument the matrix reads (\leanid{TNLean.PEPS.redBoundaryRBCrossing_hostMerge}), and
-          the red configuration's red-to-blue crossing label is its red boundary label's
-          (\leanid{TNLean.PEPS.crossingLabel_eq_redBoundaryRBCrossing}). The complement and
-          red-to-blue crossing incidence of red boundary edges is recorded by
-          \leanid{TNLean.PEPS.isRegionIncidentEdge_complement_of_crossing_rc} and
-          \leanid{TNLean.PEPS.not_isRegionIncidentEdge_complement_of_crossing_rb}.
-
-          With the merged summand $\mathrm{matrix}(\mu_\mathrm{rb},\nu_\mathrm{rb})\cdot
-          \mathrm{redProd}\,\zeta_r\cdot\mathrm{hostProd}(\mathrm{hostMerge})$ in hand, the
-          residual content is the two-stage fibered grouping. Grouping the triples by
-          $\mu=\mathrm{redBoundaryLabel}\,\zeta_r$ collapses the red factor to
-          \leanid{TNLean.PEPS.regionBlockedWeight} of $\mu$ directly (no fiber multiplicity:
-          the blocked-region weight already sums the red product over every configuration
-          carrying the red boundary label). Grouping the pairs $(\zeta_b,\zeta_c)$ by the
-          red-reread host boundary label $\nu$ of their merge is the one new fiber count: for a
-          fixed $\nu$ with $\mathrm{SameAwayFromRBBundle}\,\mu\,\nu$, the relaxed pairs whose
-          merge carries host label $\nu$ collapse to a constant times the host blocked-region
-          weight $\mathrm{regionBlockedWeight}\,(\mathrm{univ}\setminus\mathrm{red})\,
-          (\mathrm{regionComplementBoundaryConfig}\,\nu)$. The relaxed pair constraint is the
-          blue-to-complement agreement only; the host engine
-          \leanid{TNLean.PEPS.ThreeBlockGeometry.threeBlockDoubleSum_eq_smul_single} requires
-          the full complement-boundary agreement, so the two differ by the blue configuration's
-          freedom on the red-to-complement crossings, which the relaxed summand never reads
-          (the blue product reads only blue-incident edges, and a red-to-complement crossing
-          touches neither blue nor the matrix's red-to-blue bundle). That unread freedom is the
-          red-to-blue crossing freedom already collapsed by
-          \leanid{TNLean.PEPS.ThreeBlockGeometry.blueRedCrossing_fiber_card} in the analogous
-          union-injectivity setting. The fiber multiplicity of the merge is therefore the
-          host-relative complement interior bond product
-          \leanid{TNLean.PEPS.regionInteriorBondProd} of the complement block times the
-          red-to-complement crossing bond product, both functions of the bond dimensions alone,
-          hence shared across the two tensors under the matched bond dimensions. Wiring the
-          two-stage grouping and this fiber count is the remaining content of the descent; the
-          merged-summand identities above are its inputs.
+          The merged summand $\mathrm{matrix}(\mu_\mathrm{rb},\nu_\mathrm{rb})\cdot
+          \mathrm{redProd}\,\zeta_r\cdot\mathrm{hostProd}(\mathrm{hostMerge})$ is
+          \leanid{TNLean.PEPS.relaxedTriple_summand_eq}: the complement and blue vertex products
+          read the host merge unchanged (\leanid{TNLean.PEPS.complProd_hostMerge},
+          \leanid{TNLean.PEPS.blueProd_hostMerge}), so the host vertex product of the merge,
+          read with the fused blue/complement physical leg, is the complement product against
+          the blue product (\leanid{TNLean.PEPS.hostProd_hostMerge_eq}); the two boundary labels
+          and the matrix coupling are identified by
+          \leanid{TNLean.PEPS.sameAwayFromRBBundle_hostMerge},
+          \leanid{TNLean.PEPS.redBoundaryRBCrossing_hostMerge}, and
+          \leanid{TNLean.PEPS.crossingLabel_eq_redBoundaryRBCrossing}. The host side collapses
+          through the host-merge fiber count
+          \leanid{TNLean.PEPS.hostMergeFiber_card}: the relaxed pairs agreeing on the
+          blue-to-complement crossings whose merge is a fixed configuration biject with the free
+          virtual indices, the fiber multiplicity being
+          \leanid{TNLean.PEPS.hostMergeFiberProd} (the complement non-incident bond product times
+          the free blue bond product), a function of the bond dimensions alone and hence shared
+          across the two tensors under matched bond dimensions. The fiberwise collapse
+          \leanid{TNLean.PEPS.hostMerge_fiberwise_collapse} and the relaxed agreement split
+          \leanid{TNLean.PEPS.crossTripleAgreesAwayRB_iff} wire the two-stage grouping against the
+          configuration expansion
+          \leanid{TNLean.PEPS.redBundleInsertedCoeff_bondModelMatrix_eq_configSum} of the target
+          coefficient. The descent uses no single-vertex spanning.
 
           After the collapse, the forward multiplicativity field \leanid{hmul} of
           \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge} (the coarse

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1393,9 +1393,16 @@ The remaining obligations are the following.
           agreement is the bundle agreement \leanid{TNLean.PEPS.SameAwayFromRBBundle}. The
           two-sided merge over the four regions (red, blue, complement, and their host union)
           reuses the single-region merge machinery \leanid{TNLean.PEPS.regionMerge},
-          \leanid{TNLean.PEPS.regionFiber_card} but requires a host-side
-          blue-plus-complement merge not yet formalized; it is the genuine remaining content
-          of the descent.
+          \leanid{TNLean.PEPS.regionFiber_card} on the red side, and the host-side
+          blue-plus-complement collapse is the landed three-block factorization
+          \leanid{TNLean.PEPS.ThreeBlockGeometry.regionBlockedWeight_complPhysical_eq},
+          \leanid{TNLean.PEPS.ThreeBlockGeometry.threeBlockFiber_card} of the partitioned
+          frame's three-block geometry. The remaining content of the descent is wiring these
+          two collapse engines together with the matrix coupling: the relaxed-triple sum
+          carries the matrix as a function of the two red-to-blue crossing labels, which the
+          red-side merge fixes on $\mu$ and the host-side blue-plus-complement merge fixes on
+          $\nu$, so the two engines run on a common fiber decomposition rather than
+          independently.
 
           After the collapse, the forward multiplicativity field \leanid{hmul} of
           \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge} (the coarse

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1307,11 +1307,16 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.stateCoeff_coarseTensor_collapse}, and
           \leanid{TNLean.PEPS.coarseTensor_sameState_of_sameState}.}
 
-          What remains is the inserted-coefficient descent (the same collapse with a matrix
+          What remained was the inserted-coefficient descent (the same collapse with a matrix
           carried on the coarse red-to-blue super-bond by its bond model) and the kernel
           closure (dividing the positive non-incident bond products and applying
-          \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} in both directions to instantiate
-          \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}).
+          \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} in both directions). Both are now
+          landed; the per-edge gauge is delivered through the coherent-frame interface
+          \leanid{TNLean.PEPS.exists_regionEdgeGauge_of_coherentFrames}, which discharges the
+          three hypotheses \leanid{hbondAB}, \leanid{hbondBA}, and \leanid{hmul} of the
+          abstract \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}
+          from the two coherent frames and the single-crossing hypothesis, returning the same
+          gauge conclusion. The final assembly is recorded below.
 
           The descent is not a single-edge assembly, because of a granularity gap recorded
           here. The coarse red-to-blue super-bond carries the \emph{whole} bundle of
@@ -1717,6 +1722,26 @@ block-framed proof of the coefficient transfer feeds it directly. The block-fram
 realization---a block-leg insertion operator with its own block-level resonate
 inversion---is the genuine remaining obligation for the general region-injective
 theorem and the recommended next development.
+
+This block-framed realization is now delivered through the coarse three-site route.
+The three injective blocks are assembled into a coarse tensor on a three-vertex
+complete graph whose super-sites are injective directly from the blocked-region
+injectivities, with no single-vertex injectivity of the original tensor; the proven
+injective inserted-coefficient correspondence runs on its distinguished super-bond,
+the bond-model collapse descends the coarse coefficient to the single-edge
+region-inserted coefficient, and the shared positive fiber multiplicity cancels. The
+result is the block-framed coefficient transfer in both directions
+(\path{exists_regionInsertedCoeff_eq_sharedRegion},
+\path{exists_regionInsertedCoeff_eq_sharedRegion_symm}), the two bond-local transfer
+kernels (\path{isBondLocalTransferKernel_of_coherentFrames}), the forward
+multiplicativity (\path{regionEdgeTransfer_mul}), and hence the per-edge gauge
+(\path{exists_regionEdgeGauge_of_coherentFrames}), for two coherent frames sharing
+the three regions, the bond dimensions, and the single distinguished crossing edge.
+The block-level step $V=W$ and the forward multiplicativity --- the genuine remaining
+obligation above --- are thereby closed modulo review, conditional only on the
+coherent coarse blocking frames the source's edge geometry supplies. What remains for
+the general theorem is constructing those frames at every edge from the source's
+finite-lattice blocking, the geometry obligation recorded earlier in this note.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1311,8 +1311,46 @@ The remaining obligations are the following.
           carried on the coarse red-to-blue super-bond by its bond model) and the kernel
           closure (dividing the positive non-incident bond products and applying
           \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} in both directions to instantiate
-          \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}), which
-          follow as assembly.
+          \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}).
+
+          The descent is not a single-edge assembly, because of a granularity gap recorded
+          here. The coarse red-to-blue super-bond carries the \emph{whole} bundle of
+          red-to-blue crossing edges, not a single boundary edge: its bond model is an
+          equivalence with the red-to-blue crossing configurations
+          (\leanid{TNLean.PEPS.CrossingConfig}), and the coarse edge-inserted coefficient
+          inserts a matrix on that whole bundle. The collapse with such a matrix therefore
+          descends to a whole-bundle inserted coefficient
+          (\leanid{TNLean.PEPS.redBundleInsertedCoeff}): a doubled red-boundary sum coupling
+          the two configurations through their red-to-blue crossing labels
+          (\leanid{TNLean.PEPS.redBoundaryRBCrossing}) while the red-to-complement crossings
+          are contracted diagonally (\leanid{TNLean.PEPS.SameAwayFromRBBundle}). This
+          coefficient is additive and homogeneous in the inserted matrix
+          (\leanid{TNLean.PEPS.redBundleInsertedCoeff_add},
+          \leanid{TNLean.PEPS.redBundleInsertedCoeff_smul}). The relaxed crossing agreement
+          of a triple under the inserted matrix --- agreeing on the red-to-complement and
+          blue-to-complement crossings, with the red-to-blue crossings left free for the
+          matrix to couple --- is recorded by
+          \leanid{TNLean.PEPS.CrossTripleAgreesAwayRB}.
+
+          The single-edge predicate \leanid{TNLean.PEPS.IsBondLocalTransferKernel} that the
+          per-edge gauge consumes, and the equivalence
+          \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} that reduces it to a single-edge
+          coefficient transfer, are stated for one boundary edge $f$. The whole-bundle
+          descent therefore needs a bundle-to-single-edge bridge: the single-edge coefficient
+          \leanid{TNLean.PEPS.regionInsertedCoeff} for an edge $f$ in the red-to-blue
+          crossing bundle is the whole-bundle coefficient at the matrix that inserts on the
+          $f$-coordinate of the bundle and contracts the rest of the bundle by the identity.
+          With that bridge, the descent on both tensors (sharing the non-incident bond
+          products under matched bond dimensions, by
+          \leanid{TNLean.PEPS.coarseTensor_sameState_of_sameState}), the coarse coefficient
+          transfer \leanid{TNLean.PEPS.coarse_exists_edgeInsertedCoeff_eq}, the surjectivity
+          \leanid{TNLean.PEPS.coarseProj_surjective}, and the positivity of the non-incident
+          bond products give the single-edge coefficient transfer, hence
+          \leanid{TNLean.PEPS.IsBondLocalTransferKernel} in both directions and the per-edge
+          gauge. The remaining steps are the collapse with the matrix coupling on the coarse
+          super-bond (the whole-bundle descent identity), the bundle-to-single-edge bridge,
+          and the forward multiplicativity field \leanid{hmul} of
+          \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1280,18 +1280,38 @@ The remaining obligations are the following.
           configuration triple, and merging that triple into one global configuration
           (region-incident edges read from the region's own configuration, the rest
           free) collapses the sum to the closed-state coefficient with the three
-          interior bond products as multiplicity. This is the three-region extension of
-          the two-block merge/fiber collapse
+          non-incident bond products as multiplicity. This is the three-region extension
+          of the two-block merge/fiber collapse
           \leanid{TNLean.PEPS.stateCoeff_eq_regionComplement} of the landed
-          one-region-against-complement gluing --- a fiber count over the
-          three regions' interiors threading the per-edge bond models --- and is the
-          remaining open step of the coarse route. It does not reintroduce single-vertex
-          spanning. Once it is supplied, the state transport (constants depend only on
-          the shared regions and bond dimensions), the inserted-coefficient descent (the
-          same collapse with a matrix carried on the coarse red-to-blue super-bond by its
-          bond model), and the kernel closure (dividing the positive interior bond
-          products and applying \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} in both
-          directions to instantiate \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge})
+          one-region-against-complement gluing --- a fiber count over the three regions'
+          non-incident edges threading the per-edge bond models.
+
+          This collapse is now formalized. The bond models assemble into one product
+          equivalence between coarse virtual configurations and triples of original
+          inter-region crossing configurations, under which the coarse state sum reindexes
+          as a sum over triples of original virtual configurations agreeing on the crossing
+          edges; merging each agreeing triple into one global configuration (red-incident
+          edges read the red configuration, the remaining blue-incident edges the blue, the
+          rest the complement) collapses the sum to the closed-state coefficient, the fiber
+          over a merged configuration being parameterised by the virtual indices each
+          configuration is free to choose away from its own region. The constant is the
+          product of the three regions' non-incident bond products. The same-state
+          hypothesis transports through the collapse: the assembled physical configuration
+          depends only on the shared regions and the merge-collapse constants coincide under
+          matched bond dimensions. None of this reintroduces single-vertex spanning.\footnote{
+          Formal declarations:
+          \leanid{TNLean.PEPS.crossingTripleEquiv},
+          \leanid{TNLean.PEPS.threeRegionSum_eq_agreeingTripleSum},
+          \leanid{TNLean.PEPS.triFiber_card},
+          \leanid{TNLean.PEPS.agreeingTripleSum_collapse},
+          \leanid{TNLean.PEPS.stateCoeff_coarseTensor_collapse}, and
+          \leanid{TNLean.PEPS.coarseTensor_sameState_of_sameState}.}
+
+          What remains is the inserted-coefficient descent (the same collapse with a matrix
+          carried on the coarse red-to-blue super-bond by its bond model) and the kernel
+          closure (dividing the positive non-incident bond products and applying
+          \leanid{TNLean.PEPS.bondLocal_iff_coeffTransfer} in both directions to instantiate
+          \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge}), which
           follow as assembly.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1419,10 +1419,38 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.redBundleInsertedCoeff_bondModelMatrix_eq_configSum} of the target
           coefficient. The descent uses no single-vertex spanning.
 
-          After the collapse, the forward multiplicativity field \leanid{hmul} of
-          \leanid{TNLean.PEPS.SharedNormalEdgeBlockingData.exists_regionEdgeGauge} (the coarse
-          edge transfer matrix descending, or \leanid{TNLean.PEPS.regionInsertedCoeff_injective}
-          at products) remains the final input to the per-edge gauge.
+          The final assembly is now landed. Under the single-crossing hypothesis the
+          whole inserted-coefficient descent reads, through the bond-model and the
+          single-leg crossing equivalence, as a constant times the single-edge
+          region-inserted coefficient on $e$
+          (\leanid{TNLean.PEPS.edgeInsertedCoeff_coarseTensor_descent_single}), the
+          constant the shared positive host-merge fiber product
+          (\leanid{TNLean.PEPS.hostMergeFiberProd_pos},
+          \leanid{TNLean.PEPS.hostMergeFiberProd_eq}). Cancelling that constant after the
+          descent on both coherent frames, and feeding the coarse coefficient transfer and
+          the surjectivity of the descent's physical legs
+          (\leanid{TNLean.PEPS.exists_descent_legs}), gives the single-edge coefficient
+          transfer in both directions
+          (\leanid{TNLean.PEPS.exists_regionInsertedCoeff_eq_sharedRegion},
+          \leanid{TNLean.PEPS.exists_regionInsertedCoeff_eq_sharedRegion_symm}), hence the
+          two bond-local transfer kernels
+          (\leanid{TNLean.PEPS.isBondLocalTransferKernel_of_coherentFrames}). The forward
+          multiplicativity is the concrete single-edge transfer's multiplicativity, the
+          coarse edge transfer matrix conjugated by the two bond models
+          (\leanid{TNLean.PEPS.regionEdgeTransfer},
+          \leanid{TNLean.PEPS.regionEdgeTransfer_mul}), carried through
+          \leanid{TNLean.PEPS.regionInsertedCoeff_injective}
+          (\leanid{TNLean.PEPS.coeffTransferMap_eq_regionEdgeTransfer}). With the two
+          kernels and the forward multiplicativity, the per-edge gauge follows
+          (\leanid{TNLean.PEPS.exists_regionEdgeGauge_of_coherentFrames}): the forward
+          per-edge matrix transfer on $e$ is conjugation by an invertible gauge matrix and
+          the bond dimensions on $e$ coincide. The whole assembly uses no single-vertex
+          injectivity of the original tensor; the only injectivity input is the
+          blocked-region injectivity of the three regions, carried by the coherent coarse
+          blocking frame. This closes, modulo review, the block-level step $V=W$ and the
+          forward multiplicativity --- the last residual content of this obligation ---
+          for two coherent frames sharing the three regions, the bond dimensions, and the
+          single distinguished crossing edge.
     \item In the translationally invariant case, show that the edge gauges obtained
           after blocking reduce to one horizontal gauge $X$ and one vertical gauge
           $Y$, up to scalar.


### PR DESCRIPTION
## What

**Closes the V=W kernel of the Normal PEPS Fundamental Theorem (#1373)** — the per-edge
gauge from blocked-region injectivity, with **no single-vertex injectivity anywhere**:

```
exists_regionEdgeGauge_of_coherentFrames :
  two coherent coarse blocking frames sharing the regions and bond dims
  + SameState A B + positive bonds + the single-crossing geometry (hsingle)
  ⟹ the forward per-edge matrix transfer on e is conjugation by an invertible Z,
    and the bond dimensions on e coincide.
```

`#print axioms` = `[propext, Classical.choice, Quot.sound]` for the gauge,
`isBondLocalTransferKernel_of_coherentFrames`, the descent, and the multiplicative
transfer. Full root build green (8,839 jobs). Files `CoarseThreeSite4`–`11`
(~3,000 lines built across this arc).

## The proof (the source's block-framed inj_isomorph, arXiv:1804.04964 §3)

1. **The global fiber-collapse** (`stateCoeff_coarseTensor_collapse`): the coarse
   three-site state = (explicit host-merge fiber product) · the original state — the
   constant derived by explicit bijection.
2. **The M-coupled descent** (`edgeInsertedCoeff_coarseTensor_descent`): the coarse
   edge-inserted coefficient descends to the whole-bundle region-inserted coefficient,
   M carried through the shared bond model.
3. **The singleton bridge** (`redBundleInsertedCoeff_singleton` + Bridge A): at the
   source's verified single-crossing geometry (red/blue share exactly e), the bundle
   coefficient IS `regionInsertedCoeff`.
4. **The transfer**: the proven coarse edge FT (consumed verbatim — coarse vertex
   injectivity IS blocked-region injectivity) + the descent on both sides + the equal
   positive constants cancel ⟹ `∀M ∃N` matching region-inserted coefficients, both
   directions; multiplicativity via `regionEdgeTransfer_mul`.
5. **Skolem–Noether** (the existing consumer) ⟹ the gauge `Z`.

## Remaining for the unconditional theorem (documented)

Constructing the coherent frames at every edge from the lattice geometry — the upstream
instantiation connecting this gauge to the merged every-edge blocking bundle (#2577) and
the TI assembly (#2578). No blueprint nodes flipped (faithfulness rule); the route note
records obligation closed-modulo-review.

Refs #1373. CI `blueprint-and-prose`/`track`/`claude-review-*` failures are non-blocking
automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib/Lean formalization with no runtime, auth, or data paths; risk is proof correctness and build time, not production behavior.
> 
> **Overview**
> Adds eight new Lean modules **`CoarseThreeSite4`–`CoarseThreeSite11`** (and wires them in **`TNLean.lean`**) to finish the **normal-PEPS single-edge comparison** from arXiv:1804.04964 §3: coarse three-site blocking is glued back to the original tensor, then matrix insertions on the coarse **r–b** super-bond descend to single-edge **`regionInsertedCoeff`**.
> 
> **Fiber collapse and same-state transport** (`4`–`5`): crossing-triple reindexing, **`agreeingTripleSum_collapse`**, **`stateCoeff_coarseTensor_collapse`**, and **`coarseTensor_sameState_of_sameState`**.
> 
> **Matrix-carrying descent** (`6`–`10`): **`redBundleInsertedCoeff`**, open-bond **`edgeInsertedCoeff_eq_pairSum`**, M-coupled expansions, relaxed-triple merge **`relaxedTripleSum_collapse`**, and **`edgeInsertedCoeff_coarseTensor_descent`**.
> 
> **Singleton geometry and gauge** (`8`, `11`): when red–blue crosses only on edge **`e`**, bundle coefficients become **`regionInsertedCoeff`**; **`exists_regionInsertedCoeff_eq_*`**, concrete **`regionEdgeTransfer`**, **`isBondLocalTransferKernel_of_coherentFrames`**, and **`exists_regionEdgeGauge_of_coherentFrames`** (forward transfer = conjugation by invertible **`Z`**, using blocked-region injectivity only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d03233dd4edda82c2be4db4eab2504c9b2173962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->