### PR TITLE
doc(parent): align closure-property note with RMP terminology

### DIFF
--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -87,12 +87,13 @@ and
 are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
 \path{0 < L0}, \path{2 <= N}, and \path{L0 < L <= N}.}
 
-The blueprint records the same range-reduction target in the theorem
-``Normal-range reduction: containment in the MPS span'' in
-\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:1648--1686, labelled
-\path{thm:normal_range_reduction_containment}. Its proof sketch already
-separates the open-chain containment from the comparison at the periodic boundary,
-which is the same division made by the formal statements below.
+The blueprint records the corresponding closure-property step in
+``Closure-property step toward uniqueness of the ground state'' in
+\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}:3215--3251, labelled
+\path{thm:normal_range_reduction_containment}. Its proof sketch separates the
+open-chain intersection iteration from the comparison at the periodic boundary,
+matching the source distinction between the intersection property and the
+closure property.
 
 
 The first mismatch is that the available intersection theorem is not a literal


### PR DESCRIPTION
## Summary

- update the parent-Hamiltonian paper-gap note to cite the current closure-property blueprint entry
- replace the stale "normal-range reduction / MPS span" description with the RMP terminology: intersection property versus closure property
- keep the existing Lean/blueprint label as a locator only, not as mathematical prose

## Source

The relevant RMP passage is arXiv:2011.12127 §IV.C, lines 2078--2079: the review separates the iterated open-chain intersection argument from the argument used when closing the boundaries, naming them the intersection property and closure property.

## Checks

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prose in a paper-gap note; no Lean, blueprint, or runtime behavior changes.
> 
> **Overview**
> Updates the **blueprint cross-reference** in `cpgsv21_normal_range_reduction.tex` so it points at the current ch14 entry (**“Closure-property step toward uniqueness of the ground state”**, `ch14_parent_hamiltonian.tex` ~3215–3251) instead of the outdated “normal-range reduction / MPS span” wording and line range (~1648–1686).
> 
> The paragraph now describes the proof sketch as splitting **open-chain intersection iteration** from **periodic-boundary comparison**, using RMP §IV.C **intersection property** vs **closure property** language. The Lean/blueprint label `thm:normal_range_reduction_containment` is kept only as a locator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf8154c174ed1d29121f4ce5a82b9a3f8a6c541f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->