### PR TITLE
doc(parent): cite block-decomposition source theorem

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -212,7 +212,7 @@ length. Then every
   \psi=\sum_j\psi_j,\qquad \psi_j\in G_N(A_j).
 \]
 This is still an open-boundary decomposition. The remaining boundary step in
-arXiv:quant-ph/0608197, Theorem 12 is to prove
+PGVWC07, Theorem 2blocks.2, is to prove
 \(\psi_j\in\mathcal G_{N,L}(A_j)\). -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -212,7 +212,7 @@ length. Then every
   \psi=\sum_j\psi_j,\qquad \psi_j\in G_N(A_j).
 \]
 This is still an open-boundary decomposition. The remaining boundary step in
-PGVWC07, Theorem 2blocks.2, is to prove
+arXiv:quant-ph/0608197, Theorem 2blocks.2, is to prove
 \(\psi_j\in\mathcal G_{N,L}(A_j)\). -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]


### PR DESCRIPTION
## Summary
- correct the #905 BNT block-decomposition docstring from a non-existent "Theorem 12" citation to arXiv:quant-ph/0608197, Theorem 2blocks.2
- keep the remaining step described as the block-diagonal boundary-condition comparison

## Source
`Papers/quant-ph_0608197/MPSarchive.tex:1424--1456` labels the result as `2blocks.2` and proves the ground-space degeneracy by reducing to the block-diagonal boundary step.

## Checks
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`