### PR TITLE
doc(parent): align martingale and block-source prose

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -4590,7 +4590,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     cyclic distance on the ring (i.e.\ whose $L$-site supports share at
     least one site under periodic boundary conditions),
     the martingale condition of Theorem~\ref{thm:martingale_criterion} holds with
-    constants $c_{ij}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
+    constants $c_{\{i,j\}}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
     Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}
     obtain this uniformity by the martingale method, invoking finite-chain-state
     estimates to control the constants.  For the explicit cyclic-window
@@ -4627,11 +4627,11 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \emph{Row-sum bound.}
     Since $L \ge 2$, each site $i$ overlaps with at most $2(L-1)$
     neighbours (those $j$ with $0 < d_N(i,j) < L$).
-    Set $c_{ij} := \tfrac{1}{2(L-1)}$ for every overlapping pair
-    and $c_{ij} := 0$ otherwise. These constants depend only on the
-    cyclic distance $d_N(i,j)$ and therefore satisfy $c_{ij} = c_{ji}$.
+    Set $c_{\{i,j\}} := \tfrac{1}{2(L-1)}$ for every unordered overlapping
+    pair and $c_{\{i,j\}} := 0$ otherwise. These constants depend only on the
+    cyclic distance $d_N(i,j)$.
     Then
-    $\sum_{j \ne i} c_{ij} \le 2(L-1)\cdot\tfrac{1}{2(L-1)} = 1$,
+    $\sum_{j \ne i} c_{\{i,j\}} \le 2(L-1)\cdot\tfrac{1}{2(L-1)} = 1$,
     satisfying the row-sum hypothesis of
     Theorem~\ref{thm:martingale_criterion}.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -4523,14 +4523,18 @@ Lucia~\cite{Kastoryano2018Martingale}.
         H = \sum_{i=1}^n h_i
     \]
     with projector interaction terms ($h_i^2 = h_i$).
-    Suppose that for every pair of overlapping terms $h_i, h_j$ there
-    exist constants $c_{ij} \ge 0$ and $\gamma > 0$ satisfying
+    Suppose that for every unordered pair $\{i,j\}$ of overlapping terms there
+    exist constants $c_{\{i,j\}} \ge 0$ and $\gamma > 0$ satisfying
     \begin{equation}\label{eq:ph_martingale_condition}
         h_i h_j + h_j h_i
-        \ge -c_{ij}(1-\gamma)(h_i + h_j),
+        \ge -c_{\{i,j\}}(1-\gamma)(h_i + h_j),
     \end{equation}
-    and suppose further that $c_{ij} = c_{ji}$ for every overlapping
-    pair $(i,j)$ and that $\sum_{j:\,j \ne i} c_{ij} \le 1$ for every $i$.
+    and suppose further that the coefficients attached to the terms overlapping
+    $h_i$ satisfy
+    \[
+        \sum_{\substack{j\ne i\\ \{i,j\}\text{ overlapping}}}c_{\{i,j\}}\le1
+    \]
+    for every $i$.
     Then the smallest positive eigenvalue of $H$ satisfies
     $\lambda_{\min}^+(H) \ge \gamma$.
 \end{theorem}
@@ -4551,23 +4555,22 @@ Lucia~\cite{Kastoryano2018Martingale}.
     product $h_i h_j$ is itself a projector and hence PSD; thus the last
     sum is $\ge 0$.
     For the overlapping sum, the martingale condition~(\ref{eq:ph_martingale_condition}) gives
-    $h_i h_j + h_j h_i \ge -c_{ij}(1-\gamma)(h_i + h_j)$.
+    $h_i h_j + h_j h_i \ge -c_{\{i,j\}}(1-\gamma)(h_i + h_j)$.
     Summing over unordered pairs $\{i,j\}$:
     \[
         \sum_{\{i,j\}, \text{overlap}} (h_i h_j + h_j h_i)
         \ge -(1-\gamma) \sum_{\{i,j\}, \text{overlap}}
-        c_{ij}(h_i + h_j).
+        c_{\{i,j\}}(h_i + h_j).
     \]
-    Collecting terms for each $h_i$ and using the symmetry assumption
-    $c_{ij} = c_{ji}$:
+    Collecting terms for each $h_i$:
     \[
-        \sum_{\{i,j\}, \text{overlap}} c_{ij}(h_i + h_j)
+        \sum_{\{i,j\}, \text{overlap}} c_{\{i,j\}}(h_i + h_j)
         = \sum_i \Bigl(\sum_{\substack{j \ne i \\ \text{overlap}}}
-        c_{ij}\Bigr) h_i
+        c_{\{i,j\}}\Bigr) h_i
         \le H,
     \]
     where the last inequality uses the row-sum hypothesis
-    $\sum_{j \ne i} c_{ij} \le 1$.
+    $\sum_{j \ne i} c_{\{i,j\}} \le 1$.
     Combining, $H^2 \ge H - (1-\gamma)H = \gamma H$.
     For any eigenvector with $H\psi = \lambda\psi$ and $\lambda > 0$,
     this gives $\lambda^2 \ge \gamma\lambda$, hence
@@ -6513,8 +6516,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     Thus every
     \(\psi\in\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)\) has a unique
     decomposition \(\psi=\sum_j\psi_j\) with \(\psi_j\in G_N(A_j)\).
-    The remaining boundary step in
-    \cite[Theorem~12]{PerezGarcia2007Matrix} is to prove
+    The remaining boundary step in \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}
+    is to prove
     \[
         \psi_j\in\mathcal G_{N,L}(A_j)
     \]
@@ -6695,8 +6698,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         \quad\Longrightarrow\quad
         \exists n\ge1,\; V^{(n)}(A_j)\ne V^{(n)}(A_k).
     \]
-    Let $L_0$ be a common injectivity length. In the multi-block range of
-    \cite[Theorem~12]{PerezGarcia2007Matrix}, namely
+    Let $L_0$ be a common injectivity length. In the multi-block range used in
+    \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}, namely
     \[
         g\ge2,
         \qquad
@@ -6761,8 +6764,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         |i_1\cdots i_{m+1}\rangle.
     \]
     The direct-sum separation lemma used in
-    \cite[Theorem~12]{PerezGarcia2007Matrix}, together with injectivity of each
-    block, gives the blockwise matrix identity
+    \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}, together with injectivity
+    of each block, gives the blockwise matrix identity
     \[
         A^j_{i_{m+1}} C^j_{i_1}
         =
@@ -6851,7 +6854,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     $G_L(B)$ with the subspace denoted in the source by
     $S=\bigoplus_j\mathcal G_L^{A^j}$.
     The passage from the open-segment recursion to the periodic chain is the
-    separate closure step in \cite[Theorem~12]{PerezGarcia2007Matrix}. It is
+    separate closure step in \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}. It is
     not the inclusion $G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)$, which fails
     for a general open-boundary matrix crossing the periodic boundary. Under
     $N\ge L+L_0$, the required boundary-condition comparison is
@@ -7045,8 +7048,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \notready
-    The length hypotheses are the conservative range of
-    \cite[Theorem~12]{PerezGarcia2007Matrix}. The shorter range stated in
+    The length hypotheses are the conservative range used in
+    \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}. The shorter range stated in
     \cite[lines~2126--2128]{Cirac2021Matrix} requires the strengthened
     block-diagonal re-growing step. Since $g\ge2$ and $L_0\ge1$,
     \[

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -4570,7 +4570,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         \le H,
     \]
     where the last inequality uses the row-sum hypothesis
-    $\sum_{j \ne i} c_{\{i,j\}} \le 1$.
+    $\sum_{\substack{j\ne i\\ \{i,j\}\text{ overlapping}}}c_{\{i,j\}}\le1$.
     Combining, $H^2 \ge H - (1-\gamma)H = \gamma H$.
     For any eigenvector with $H\psi = \lambda\psi$ and $\lambda > 0$,
     this gives $\lambda^2 \ge \gamma\lambda$, hence
@@ -4631,7 +4631,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
     pair and $c_{\{i,j\}} := 0$ otherwise. These constants depend only on the
     cyclic distance $d_N(i,j)$.
     Then
-    $\sum_{j \ne i} c_{\{i,j\}} \le 2(L-1)\cdot\tfrac{1}{2(L-1)} = 1$,
+    $\sum_{\substack{j\ne i\\ \{i,j\}\text{ overlapping}}}c_{\{i,j\}}
+    \le 2(L-1)\cdot\tfrac{1}{2(L-1)} = 1$,
     satisfying the row-sum hypothesis of
     Theorem~\ref{thm:martingale_criterion}.
 


### PR DESCRIPTION
## Summary

This adjusts two reader-facing statements in Chapter 14 of the blueprint.

- The abstract martingale criterion now attaches the coefficient to the unordered overlapping pair \(\{i,j\}\) and states the row-sum condition directly, rather than imposing a separate displayed condition \(c_{ij}=c_{ji}\). This matches the review passage, where the coefficients are chosen so that the contributions add to one.
- The block-diagonal parent-Hamiltonian discussion now cites \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix} instead of \cite[Theorem~12]{PerezGarcia2007Matrix}, matching the source label used in the adjacent Lean documentation.

Refs #905.
Refs #952.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `cd blueprint/src && PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --smoke-render`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH; cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

`lake exe checkdecls blueprint/lean_decls` was attempted, but this fresh worktree had no compiled `TNLean` oleans, so checkdecls stopped at `unknown module prefix 'TNLean'`. No Lean files are changed in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits in the blueprint; no Lean or runtime code changes.
> 
> **Overview**
> Chapter 14 blueprint prose is aligned with the intended mathematical statements and source labels.
> 
> The **martingale spectral-gap criterion** and the **MPS martingale lemma** now index overlap coefficients by **unordered pairs** `c_{\{i,j\}}` instead of ordered `c_{ij}`. The row-sum hypothesis is stated only over overlapping neighbours, and the separate symmetry assumption `c_{ij}=c_{ji}` is removed from the theorem and proof (the row-sum step no longer invokes it).
> 
> All **block-diagonal / multi-block** references to Perez-Garcia 2007 are retargeted from **Theorem 12** to **Theorem 2blocks.2**, with light wording tweaks (“conservative range used in”, “multi-block range used in”) so citations match the adjacent Lean documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1a23c4c87bf1fc94cb35f16910fd93ad166e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->