### PR TITLE
doc(parent): align gap prose with source terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -35,15 +35,15 @@ until the Friedrichs-angle estimate is proved.
 3. **Intersection property** (`groundSpace_intersection`): for an injective
    MPS tensor, the kernel of the sum of two overlapping local terms equals
    the intersection of their kernels.
-4. **Martingale operator bound**: the intersection property gives a positive
-   Friedrichs angle between adjacent local ground spaces, which is the
-   quantitative content of
+4. **Martingale operator bound**: the intersection property identifies the
+   kernels of overlapping local terms. The remaining quantitative input is the
+   Friedrichs-angle estimate, equivalently the anticommutator bound
 
         `h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)`
 
-   with constants `c_{ij}` depending only on the MPS tensor, not on `N`.
+   with coefficients whose rows are summable uniformly in the chain length.
 5. **Row-sum bound** `∑_{j ≠ i} c_{ij} ≤ 1`: at most `2(L-1)` local terms
-   overlap a given local term.
+   overlap a given length-`L` cyclic window under the convention used here.
 6. **Quadratic form ⟹ norm bound**: combining these estimates with `h_i^2 = h_i`
    yields `H² ≥ γ H` as a quadratic form, which by the spectral theorem
    gives `γ ‖v‖ ≤ ‖H v‖` for `v ⊥ ker H`.

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -68,9 +68,13 @@ on `NSiteSpace d N ≃ Cfg d N → ℂ`.
 **Proof strategy (Kastoryano–Lucia 2018 / Nachtergaele 1996).** The parent
 Hamiltonian `H_N = ∑ᵢ hᵢ` is a frustration-free sum of local orthogonal
 projectors (`parentHamiltonian_frustrationFree`). The intersection property
-`groundSpace_intersection` identifies the kernels of overlapping local terms.
-The remaining Friedrichs-angle estimate supplies the martingale operator
-inequality
+`groundSpace_intersection` gives the local relation
+
+    `ker h_left ∩ ker h_right ⊆ ker h`
+
+where `h_left` and `h_right` are the two overlapping length-`L` projectors and
+`h` is the length-`L+1` projector. The remaining Friedrichs-angle estimate
+supplies the martingale operator inequality
 
     `h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)`
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -34,12 +34,12 @@ variable {d D : ℕ}
 -- coefficient required by the finite-overlap row reduction in `Martingale.Reduction`.
 /-- Friedrichs-angle and row-sum estimate for the MPS parent Hamiltonian.
 
-This is the remaining MPS-specific martingale estimate: it should produce a
-specific uniform positive lower bound for the transported parent Hamiltonian
-from the intersection property and finite-overlap geometry. The concrete
-constant is intentionally part of this theorem statement, so the public
-`parentHamiltonian_gapped` theorem only has to re-express it as an existential
-spectral gap. -/
+This is the remaining MPS-specific martingale estimate. It asks for the explicit
+uniform lower bound obtained from the Friedrichs-angle estimate for overlapping
+local ground spaces, after the finite row-counting geometry has fixed the cyclic
+window convention. The constant is intentionally part of this theorem statement;
+the comparison with the martingale paragraph in arXiv:2011.12127, Section IV.C,
+is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_friedrichs
     (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (_hL : 1 < L) :
     0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
@@ -68,20 +68,20 @@ on `NSiteSpace d N ≃ Cfg d N → ℂ`.
 **Proof strategy (Kastoryano–Lucia 2018 / Nachtergaele 1996).** The parent
 Hamiltonian `H_N = ∑ᵢ hᵢ` is a frustration-free sum of local orthogonal
 projectors (`parentHamiltonian_frustrationFree`). The intersection property
-`groundSpace_intersection` bounds the Friedrichs angle between adjacent local
-ground spaces away from zero, which provides the martingale operator
+`groundSpace_intersection` identifies the kernels of overlapping local terms.
+The remaining Friedrichs-angle estimate supplies the martingale operator
 inequality
 
     `h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)`
 
-with constants `c_{ij}` depending only on the MPS tensor (not on `N`). At most
-`2(L-1)` local terms overlap a given `h_i`, so the row-sum bound
-`∑_{j≠i} c_{ij} ≤ 1` holds uniformly in `N`. Combined with `h_i^2 = h_i`,
-this yields the quadratic-form inequality `H² ≥ γ H`, which feeds into
-the abstract lemma `FrustrationFree.spectralGap_of_martingale` to produce
-the norm bound `γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`. The `LinearMap.IsPositive`
-hypothesis required by `FrustrationFree.spectralGap_of_martingale` is
-automatic here because `H_N = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
+with row-summable coefficients. At most `2(L-1)` local terms overlap a given
+length-`L` cyclic window, so the chosen coefficients have row sum at most one.
+Combined with `h_i^2 = h_i`, this yields the quadratic-form inequality
+`H² ≥ γ H`, which feeds into the abstract lemma
+`FrustrationFree.spectralGap_of_martingale` to produce the norm bound
+`γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`. The `LinearMap.IsPositive` hypothesis required
+by `FrustrationFree.spectralGap_of_martingale` is automatic here because
+`H_N = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
 
 The proof below invokes the MPS-specific Friedrichs-angle theorem
 `parentHamiltonianES_gap_bound_of_friedrichs`, whose proof is the remaining

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -966,7 +966,7 @@ theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjec
     exact one_ne_zero h10
   simpa [mpvSubmodule] using finrank_span_singleton (K := ℂ) hmpv
 
-/-- Unique ground state for \(L₀\)-block-injective tensors at range \(2L₀\).
+/-- Unique ground state for tensors injective after blocking at range \(2L₀\).
 
 **Open gap:** This uses the normal range-reduction equality; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3287,14 +3287,14 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     forces $\Id = 0$, a contradiction. Therefore the spanning line is one-dimensional.
 \end{proof}
 
-\begin{theorem}[Unique ground state for block-injective tensors]%
+\begin{theorem}[Unique ground state after blocking]%
     \label{thm:unique_gs_injective}
     \lean{MPSTensor.parentHamiltonian_unique_gs_injective}
     \leanok
     \uses{thm:chain_ground_space_eq_mpv_normal}
-    If $A$ is $L_0$-block-injective with $L_0 > 0$ and $D \ge 1$, the parent Hamiltonian
-    with interaction range $2L_0$ has a unique ground state on every periodic chain
-    of $N \ge 2L_0$ sites.
+    If $A$ becomes injective after blocking $L_0 > 0$ sites and $D \ge 1$,
+    the parent Hamiltonian with interaction range $2L_0$ has a unique ground
+    state on every periodic chain of $N \ge 2L_0$ sites.
 \end{theorem}
 
 \begin{theorem}[Unique ground state for normal tensors at range $L_0+1$]%
@@ -3302,7 +3302,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.parentHamiltonian_unique_gs_normal}
     \leanok
     \uses{thm:unique_gs_injective}
-    If $A$ is normal (hence $L_0$-block-injective for some $L_0 > 0$),
+    If $A$ is normal (hence injective after some blocking length $L_0 > 0$),
     $D \ge 1$, then the parent Hamiltonian with interaction range $L_0 + 1$
     has a unique ground state on every periodic chain of $N \ge L_0+1$ sites.
 \end{theorem}
@@ -3740,9 +3740,10 @@ decorrelation and its connection to commuting parent Hamiltonians, following
 
 A frustration-free Hamiltonian is \emph{gapped} if the first excited
 eigenvalue is bounded away from zero uniformly in the chain length $N$.
-For MPS parent Hamiltonians, the spectral gap follows from a martingale
-criterion due to Kastoryano and
-Lucia~\cite{Kastoryano2018Martingale}.
+For MPS parent Hamiltonians, the spectral gap follows from the martingale
+method of Fannes--Nachtergaele--Werner and Nachtergaele, in the form recalled
+in the review and in the later formulation of Kastoryano and
+Lucia~\cite{Fannes1992Finitely, Nachtergaele1996Spectral, Kastoryano2018Martingale}.
 
 \begin{definition}[Transported parent ground space]\label{def:parent_ground_space_es}
     \lean{MPSTensor.parentHamiltonianGroundSpaceES}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -3302,7 +3302,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \lean{MPSTensor.parentHamiltonian_unique_gs_normal}
     \leanok
     \uses{thm:unique_gs_injective}
-    If $A$ is normal (hence injective after some blocking length $L_0 > 0$),
+    If $A$ is normal, becomes injective after blocking $L_0 > 0$ sites, and
     $D \ge 1$, then the parent Hamiltonian with interaction range $L_0 + 1$
     has a unique ground state on every periodic chain of $N \ge L_0+1$ sites.
 \end{theorem}
@@ -3741,9 +3741,11 @@ decorrelation and its connection to commuting parent Hamiltonians, following
 A frustration-free Hamiltonian is \emph{gapped} if the first excited
 eigenvalue is bounded away from zero uniformly in the chain length $N$.
 For MPS parent Hamiltonians, the spectral gap follows from the martingale
-method of Fannes--Nachtergaele--Werner and Nachtergaele, in the form recalled
-in the review and in the later formulation of Kastoryano and
-Lucia~\cite{Fannes1992Finitely, Nachtergaele1996Spectral, Kastoryano2018Martingale}.
+method of Fannes--Nachtergaele--Werner and
+Nachtergaele~\cite{Fannes1992Finitely, Nachtergaele1996Spectral}, as recalled
+by Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}
+and in the later formulation of Kastoryano and
+Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{definition}[Transported parent ground space]\label{def:parent_ground_space_es}
     \lean{MPSTensor.parentHamiltonianGroundSpaceES}


### PR DESCRIPTION
## Summary

This PR aligns the parent-Hamiltonian documentation with the source terminology and with the remaining mathematical gap.

- Replace the one-block phrase “block-injective” in the unique-ground-state prose by “injective after blocking”, since the source block-injective canonical form is multi-block and generally has degenerate periodic ground space.
- Separate the intersection-property statement from the still-open Friedrichs-angle, or anticommutator, estimate in the martingale gap docstrings.
- Attribute the martingale method to the Fannes--Nachtergaele--Werner and Nachtergaele tradition, with the later Kastoryano--Lucia formulation used in the review context.

No Lean theorem statement or proof is changed.

Refs #905
Refs #952

## Verification

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH; cd blueprint && leanblueprint web`
- `cd blueprint/src && PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --smoke-render`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and blueprint text only; no formal statements, proofs, or runtime behavior change.
> 
> **Overview**
> **Documentation-only** alignment for parent-Hamiltonian gap and uniqueness prose; **no Lean theorem statements or proofs change.**
> 
> **Martingale / spectral gap:** Docstrings in `Martingale.lean` and `Martingale/Gap.lean` now treat `groundSpace_intersection` as giving kernel relations (`ker h_left ∩ ker h_right ⊆ ker h`) and label the **Friedrichs-angle / anticommutator** estimate as the separate open quantitative step. Overlap wording is tied to **length-`L` cyclic windows** and **row-summable** coefficients; `parentHamiltonianES_gap_bound_of_friedrichs` points readers to `docs/paper-gaps/cpgsv21_martingale_overlap.tex` for comparison with Cirac et al. Section IV.C.
> 
> **Unique ground state:** The docstring for `parentHamiltonian_unique_gs_injective` says **injective after blocking** instead of “block-injective.” Blueprint `ch14_parent_hamiltonian.tex` renames the theorem to “Unique ground state after blocking,” rephrases hypotheses for injective-after-blocking and normal tensors, and in **Spectral gap** credits the martingale method to **Fannes–Nachtergaele–Werner / Nachtergaele**, with Cirac et al. and Kastoryano–Lucia cited in the review context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 782d3a0b0ae797d5dde65054e8285f18ac87e7fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->