### PR TITLE
doc(MPS/ParentHamiltonian): align PGVWC boundary prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -13,7 +13,7 @@ PGVWC07 one-step block-intersection identity.
 
 ## References
 
-* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12 and the
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2 and the
   direct-sum lemma used there.
 -/
 

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -13,7 +13,7 @@ parent-Hamiltonian intersection argument.
 
 ## References
 
-* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12, proof around
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2, proof around
   \(A_b C_a=D_b A_a\) and \(E=\sum_a C_a A_a^\dagger\).
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2021], Section IV.C, lines
   2120--2129.
@@ -291,7 +291,7 @@ theorem groundSpace_iSupIndep_of_wordTupleSpanTop
 decompositions in the PGVWC block-diagonal intersection proof.
 
 For fixed physical indices \(a,b\), the coefficient comparison in
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12, gives
+[Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2, gives
 \[
   \sum_j \operatorname{tr}\!\left(
     A^j_b C^j_a A^j_{i_2}\cdots A^j_{i_m}\right)
@@ -385,8 +385,8 @@ imply
 \[
   \psi\in \bigvee_j G_{n+2}(A^j).
 \]
-This is the local membership step in
-PGVWC07, Theorem 12, proof lines 1446--1452. -/
+This is the local membership step in PGVWC07, Theorem 2blocks.2, proof
+lines 1446--1452. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -427,8 +427,8 @@ the vector itself lies in
 \[
   \bigvee_j G_{n+2}(A^j).
 \]
-This is the restriction form of the open-segment step in PGVWC07, Theorem 12,
-proof lines 1442--1452. -/
+This is the restriction form of the open-segment step in PGVWC07,
+Theorem 2blocks.2, proof lines 1442--1452. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -557,7 +557,7 @@ equivalent to the two fixed-boundary conditions
   \psi(a,-)\in\bigvee_jG_{n+1}(A^j).
 \]
 This is the one-step block-intersection identity isolated from PGVWC07,
-Theorem 12, proof lines 1442--1452. -/
+Theorem 2blocks.2, proof lines 1442--1452. -/
 theorem pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -616,8 +616,8 @@ hypothesis and the normalization
 \]
 the \((n+2)\)-site block ground space is the intersection of the inverse
 images of \(S_n\) under all fixed last-letter and fixed first-letter
-restrictions.  This is the restriction-subspace form of PGVWC07, Theorem 12,
-proof lines 1442--1452. -/
+restrictions.  This is the restriction-subspace form of PGVWC07,
+Theorem 2blocks.2, proof lines 1442--1452. -/
 theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -432,14 +432,12 @@ remaining boundary-closing comparison is
   A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr).
 \]
 
-**Gap dependency:** This theorem uses
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`, namely the
-displayed comparison between the two cyclic restrictions, together with the
-one-sided last-boundary equation. That restriction equality is the local
-coordinate form of the sentence in arXiv:2011.12127, Section IV.C,
-lines 2078--2079, that the inverting-and-growing-back argument may also be
-applied when closing the boundary. See
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Gap dependency:** This theorem uses the displayed comparison between the two
+cyclic restrictions, together with the one-sided last-boundary equation. That
+restriction equality is the local coordinate form of the sentence in
+arXiv:2011.12127, Section IV.C, lines 2078--2079, that the
+inverting-and-growing-back argument may also be applied when closing the
+boundary. See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -493,10 +491,9 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
 \]
 
 **Gap dependency:** This theorem is conditional on the left-multiplied
-comparison above, which in turn depends on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. That formula is
-not displayed in the source; it is the coordinate reconstruction used here for
-arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
+comparison above. That formula is not displayed in the source; it is the
+coordinate reconstruction used here for arXiv:2011.12127, Section IV.C,
+lines 2078--2079. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -432,12 +432,14 @@ remaining boundary-closing comparison is
   A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr).
 \]
 
-**Open gap:** This theorem now follows from the displayed comparison between
-the two cyclic restrictions and the one-sided last-boundary equation. The
-first comparison is the coordinate reconstruction used here for the sentence
-in arXiv:2011.12127, Section IV.C, lines 2078--2079, that the
-inverting-and-growing-back argument may also be applied when closing the
-boundary. See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Gap dependency:** This theorem uses
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`, namely the
+displayed comparison between the two cyclic restrictions, together with the
+one-sided last-boundary equation. That restriction equality is the local
+coordinate form of the sentence in arXiv:2011.12127, Section IV.C,
+lines 2078--2079, that the inverting-and-growing-back argument may also be
+applied when closing the boundary. See
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -490,10 +492,11 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
   Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
 \]
 
-**Open gap:** This theorem is now reduced to the displayed left-multiplied
-comparison above. That formula is not displayed in the source; it is the
-coordinate reconstruction used here for arXiv:2011.12127, Section IV.C, lines
-2078--2079. -/
+**Gap dependency:** This theorem is conditional on the left-multiplied
+comparison above, which in turn depends on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. That formula is
+not displayed in the source; it is the coordinate reconstruction used here for
+arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 # Cyclic constraints and propagated subspaces
 
 This file records the abstract cyclic-local step used in the block-diagonal
-parent-Hamiltonian argument of PGVWC07, Theorem 12.
+parent-Hamiltonian argument of PGVWC07, Theorem 2blocks.2.
 -/
 
 open scoped Matrix BigOperators
@@ -24,8 +24,8 @@ If \(G_L(A)\subseteq S_L\) and the subspaces \(S_m\) satisfy
   \mathbb C^d\otimes S_m \cap S_m\otimes \mathbb C^d = S_{m+1}
 \]
 for all \(m\ge L\), then \(\mathcal G_{N,L}(A)\subseteq S_N\).  This is the
-cyclic-local part of the PGVWC07 Theorem 12 argument before the block summands
-of \(S_N\) are separated. -/
+cyclic-local part of the proof of PGVWC07, Theorem 2blocks.2, before the
+boundary-closing step. -/
 theorem chainGroundSpace_le_of_local_le_restriction_intersection_submodules
     (A : MPSTensor d D) (S : (M : ℕ) → Submodule ℂ (NSiteSpace d M))
     {L N : ℕ} (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N) [NeZero d]

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -170,7 +170,8 @@ the intersections
   \mathbb C^d\otimes S_M \cap S_M\otimes \mathbb C^d = S_{M+1}
 \]
 hold for all `M ≥ L`, then the state lies in `S N`. This is the open-segment
-iteration used in PGVWC07, Theorem 12, before the periodic-chain closure step. -/
+iteration used in PGVWC07, Theorem 2blocks.2, before the periodic-chain
+boundary-closing step. -/
 theorem contiguous_mem_of_restriction_intersection_submodules
     (S : (M : ℕ) → Submodule ℂ (NSiteSpace d M))
     {L N : ℕ} (hL : 0 < L) (hLN : L ≤ N) [NeZero d]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -726,9 +726,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     The first two identities are the cyclic first- and last-site deletion
     identities, followed by the corresponding ground-space restriction formulas.
-    For adjacent windows, equality of the completed outside configurations makes
-    the two restricted states on the common overlap equal. Injectivity of the
-    length-$L$ ground-space map then identifies their boundary matrices.
+    For adjacent windows, equality of the completed outside configurations gives
+    the common-overlap equality
+    \[
+        \Gamma_L(Y_0A^a)=\Gamma_L(A^bY_n).
+    \]
+    Injectivity of $\Gamma_L$ gives $Y_0A^a=A^bY_n$.
     Iterating the displayed adjacent identity gives the word-product identity.
 \end{proof}
 
@@ -812,13 +815,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     Choose $Z_j$ from the long left-window condition and $Y_u$ from the suffix
-    ground condition. Restricting the suffix state at its last site gives the
-    boundary matrix $A_j Y_u$, while first fixing the last site and then taking
-    the suffix gives $Z_j A^u$. The two restrictions are the same because
-    appending the fixed prefix and then the last letter gives the same
-    configuration as appending the last letter to the suffix and then placing
-    the prefix in front. Injectivity of $\Gamma_{L_0}$, obtained from
-    $L_0$-block injectivity, yields $Z_j A^u = A_j Y_u$.
+    ground condition. The two restrictions give the same vector in $G_{L_0}(A)$:
+    \[
+        \Gamma_{L_0}(Z_jA^u)=\Gamma_{L_0}(A_jY_u).
+    \]
+    Injectivity of $\Gamma_{L_0}$, obtained from $L_0$-block injectivity, gives
+    $Z_j A^u = A_j Y_u$.
 \end{proof}
 
 \begin{theorem}[Inverting step for word compatibility]%
@@ -966,9 +968,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 \begin{proof}
     \leanok
     \uses{lem:ground_space_in_left_ground}
-    Fix a cyclic window of length $L+1$ and restrict its last site. The resulting
-    length-$L$ vector is again in the ground space, so one-site peeling gives the
-    inclusion for consecutive ranges. Iteration gives the general antitonicity.
+    For every cyclic window vector $v\in G_{L+1}(A)$ and every last letter $b$,
+    \[
+        v|_{\mathrm{last}=b}\in G_L(A).
+    \]
+    Thus $\mathcal G_{N,L+1}(A)\subseteq\mathcal G_{N,L}(A)$, and iteration
+    gives the general antitonicity.
 \end{proof}
 
 \begin{theorem}[Open-chain containment from cyclic local constraints]%


### PR DESCRIPTION
### Motivation

- Lean docstrings in the parent-Hamiltonian block-intersection and cyclic-iteration files contained the stale citation "PGVWC07, Theorem 12"; the correct label in the source (arXiv:quant-ph/0608197) is `Theorem 2blocks.2` (see #905).
- Three Chapter 14 blueprint proof sketches described boundary-restriction arguments verbally without displaying the relevant equations, making the dependency structure opaque.
- Downstream boundary-closing reductions in `BoundaryClosingStripping.lean` were worded as if the local boundary-restriction equality were already proved, obscuring the outstanding `sorry` at that step; making the dependency on `closure_property_boundary_restrictions_eq_of_groundSpaceMap` explicit keeps the gap visible.
- Continues documentation alignment for the parent-Hamiltonian argument tracked in #190; does not close the live leaves #905 or #952.

### Description

- `BNTBlockIntersection.lean`, `BlockIntersectionProperty.lean`, `CyclicSubmoduleIteration.lean`: update docstrings to cite PGVWC07 `Theorem 2blocks.2` instead of the stale "Theorem 12" label; proof-line ranges are unchanged.
- `CyclicWindow.lean`: documentation update aligned with the corrected source citation.
- `BoundaryClosingStripping.lean`: reframe downstream single-block boundary-closing reductions as explicitly dependent on `closure_property_boundary_restrictions_eq_of_groundSpaceMap` (the cyclic restriction equality currently carrying a pre-existing `sorry`); no theorem statements or proof terms changed.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: three Chapter 14 proof sketches made formula-first — adjacent-window and suffix arguments now display the relevant $\Gamma_L$ overlap equalities and the last-site restriction into $G_L$ before invoking injectivity.
- No theorem statements or proofs are changed.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/CyclicWindow.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean` (pre-existing `sorry` warning at the boundary-restriction equality)
- `cd blueprint && leanblueprint web`
- `lake exe checkdecls blueprint/lean_decls`

---
Addresses #190
Refs #905
Refs #952

> [!NOTE]
> **Low Risk**
> Comments and blueprint text only; no executable logic or proof terms modified.
> 
> **Overview**
> Documentation-only alignment for the parent-Hamiltonian proof boundary: **no Lean theorem statements or proofs change.**
> 
> Lean module docstrings now cite PGVWC07 **`Theorem 2blocks.2`** instead of the stale **Theorem 12** label (proof line ranges unchanged) across block-intersection and cyclic-iteration files. In **`BoundaryClosingStripping`**, prose for downstream boundary-closing reductions is reframed from vague "open gap" wording to explicit **gap dependencies** on `closure_property_boundary_restrictions_eq_of_groundSpaceMap` (the cyclic restriction equality that still carries a `sorry`).
> 
> The blueprint Chapter 14 proof sketches are made **formula-first**: adjacent-window and suffix arguments display `\Gamma_L` overlap equalities (and cyclic antitonicity displays last-site restriction into `G_L`) before invoking injectivity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507bf375b8f2a0912e183b788a4f53dc04bd52e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and blueprint text only; no executable logic or proof terms modified.
> 
> **Overview**
> Documentation-only alignment for the parent-Hamiltonian proof trail: **no Lean theorem statements or proof terms change.**
> 
> Lean module and theorem docstrings in the block-intersection and cyclic-iteration stack now cite PGVWC07 **`Theorem 2blocks.2`** instead of the stale **Theorem 12** label (proof line ranges unchanged). **`BoundaryClosingStripping`** reframes downstream boundary-closing reductions from vague “open gap” wording to explicit **gap dependencies** on `closure_property_boundary_restrictions_eq_of_groundSpaceMap` and related coordinate comparisons—the step that still carries a pre-existing `sorry`.
> 
> **`blueprint/src/chapter/ch14_parent_hamiltonian.tex`** rewrites three proof sketches to be formula-first: adjacent-window and suffix arguments display `\Gamma_L` overlap equalities before injectivity; cyclic antitonicity displays last-site restriction into `G_L` before iteration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd48070951b06dd71ae9b2a40294d26fad729254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->