### PR TITLE
feat(MPS/ParentHamiltonian): isolate block-diagonal boundary reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -375,6 +375,72 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition
   rcases hBoundary ψ hψ with ⟨φ, hφ, rfl⟩
   exact Submodule.sum_mem _ fun j _ => Submodule.mem_iSup_of_mem j (hφ j)
 
+/-- A block-diagonal boundary representation whose components are periodic block
+ground-space vectors lies in the blockwise periodic chain sum.
+
+Let \(B=\bigoplus_j\mu_jA_j\). If a boundary condition for \(B\) is block
+diagonal, say \(X=\bigoplus_jX_j\), and every component
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)
+\]
+belongs to \(\mathcal G_{N,L}(A_j)\), then
+\[
+  \Gamma_N^B(X)\in\bigvee_j\mathcal G_{N,L}(A_j).
+\]
+This is the block-diagonal boundary-condition reduction preceding the step of
+inverting and re-growing tensors described in arXiv:2011.12127, lines
+2126--2128. -/
+theorem groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpace
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ}
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hX : ∀ j : Fin r,
+      groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N) :
+    groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∈
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  classical
+  rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+  exact Submodule.sum_mem _ fun j _ => Submodule.mem_iSup_of_mem j (hX j)
+
+/-- A block-diagonal boundary decomposition gives the reverse inclusion for the
+block-diagonal periodic chain.
+
+Let \(B=\bigoplus_j\mu_jA_j\). Suppose every
+\(\psi\in\mathcal G_{N,L}(B)\) has a block-diagonal boundary representation
+\[
+  \psi=\Gamma_N^B\!\left(\bigoplus_jX_j\right)
+\]
+whose \(j\)-th component vector
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)
+\]
+lies in \(\mathcal G_{N,L}(A_j)\). Then
+\[
+  \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j).
+\]
+The remaining PGVWC07/CPGSV21 step is to obtain such a block-diagonal periodic
+boundary representation from the periodic constraints; compare PGVWC07, Theorem
+2blocks.2, proof lines 1454--1456, and arXiv:2011.12127, lines 2126--2128. -/
+theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ}
+    (hBoundary : ∀ ψ : NSiteSpace d N,
+      ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N →
+        ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+          ∀ j : Fin r,
+            groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  intro ψ hψ
+  rcases hBoundary ψ hψ with ⟨X, hψX, hX⟩
+  rw [hψX]
+  exact groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpace μ A X hX
+
 /-- Conditional block-diagonal chain equality in the finite injectivity range.
 
 Let

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6625,6 +6625,65 @@ formulation; the passage to $\ker H_N$ is kept separate.
     $\bigvee_j\mathcal G_{N,L}(A_j)$.
 \end{proof}
 
+\begin{lemma}[Block-diagonal boundary vectors in the periodic block sum]
+    \label{lem:block_diagonal_boundary_vector_mem_chain_sum}
+    \lean{MPSTensor.groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpace}
+    \leanok
+    \uses{lem:block_diagonal_boundary_condition_sum}
+    Let $B=\bigoplus_{j=1}^g\mu_jA_j$. Fix block boundary matrices $X_j$.
+    Suppose that, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j).
+    \]
+    Then
+    \[
+        \Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right)
+        \in
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The block-diagonal boundary formula gives
+    \[
+        \Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right)
+        =
+        \sum_{j=1}^g\Gamma_N^{A_j}(\mu_j^N X_j).
+    \]
+    Each summand belongs to the corresponding periodic block ground space by
+    assumption, so the finite sum lies in the linear span of these spaces.
+\end{proof}
+
+\begin{lemma}[Block-diagonal boundary representations give the reverse inclusion]
+    \label{lem:block_diagonal_boundary_representation_inclusion}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap}
+    \leanok
+    \uses{lem:block_diagonal_boundary_vector_mem_chain_sum}
+    Let $B=\bigoplus_{j=1}^g\mu_jA_j$. Suppose every
+    $\psi\in\mathcal G_{N,L}(B)$ admits block boundary matrices $X_j$ such that
+    \[
+        \psi=\Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right),
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j).
+    \]
+    Then
+    \[
+        \mathcal G_{N,L}(B)
+        \subseteq
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply Lemma~\ref{lem:block_diagonal_boundary_vector_mem_chain_sum} to the
+    block-diagonal boundary representation of each
+    $\psi\in\mathcal G_{N,L}(B)$.
+\end{proof}
+
 \begin{lemma}[Boundary decomposition in the finite injectivity range]
     \label{lem:bnt_block_diagonal_boundary_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition}


### PR DESCRIPTION
### Motivation

Issue #905 asks for the periodic block decomposition
\[
  \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
  \subseteq \bigvee_j\mathcal G_{N,L}(A_j).
\]
The current formalization already reduces this to a boundary-decomposition hypothesis, but the boundary-condition form used in PGVWC07 and CPGSV21 was still only implicit.

This PR isolates the checked reduction for the case where the periodic vector has a block-diagonal boundary representation and each block component satisfies its own periodic constraints.

### Description

- Adds a proved Lean lemma showing that a block-diagonal boundary vector
  \[
    \Gamma_N^B\!\left(\bigoplus_j X_j\right)
  \]
  lies in \(\bigvee_j\mathcal G_{N,L}(A_j)\) when every component
  \[
    \Gamma_N^{A_j}(\mu_j^N X_j)
  \]
  lies in \(\mathcal G_{N,L}(A_j)\).
- Adds a proved Lean inclusion reducing
  \[
    \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j)
  \]
  to such block-diagonal periodic boundary representations.
- Adds matching `\leanok` Chapter 14 blueprint entries, with the block-diagonal boundary formula as the displayed calculation.

This does not close #905: the remaining mathematical step is still to obtain the block-diagonal periodic boundary representation from the cyclic constraints, as in PGVWC07 Theorem 2blocks.2 and arXiv:2011.12127 lines 2126--2128.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain` (pre-existing `BoundaryClosingStripping.lean` sorry warning only)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web` (known nonfatal `path` and missing `web.bbl` warnings)
- `git diff --check`

---
Addresses #905
Refs #190

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; proofs are short reductions from existing block-sum identities with no changes to runtime or security-sensitive code.
>
> **Overview**
> Formalizes the **block-diagonal boundary** step toward \(\mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j)\) for assembled block tensors \(B=\bigoplus_j\mu_jA_j\), distinct from the earlier sum-decomposition hypothesis `chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition`.
>
> **Lean:** Adds `groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpace`—when each block component \(\Gamma_N^{A_j}(\mu_j^N X_j)\) lies in \(\mathcal G_{N,L}(A_j)\), the assembled boundary image \(\Gamma_N^B(\bigoplus_j X_j)\) lies in \(\bigvee_j\mathcal G_{N,L}(A_j)\), via `BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal` and submodule sums. Adds `chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap`, which reduces the reverse inclusion to the hypothesis that every \(\psi\in\mathcal G_{N,L}(B)\) admits such a block-diagonal boundary representation with per-block periodic constraints.
>
> **Blueprint:** Chapter 14 gains matching `\leanok` lemmas and proofs for these steps, wired to the new declarations.
>
> Issue #905 is **not** closed: deriving block-diagonal boundary data from cyclic constraints (PGVWC07 / arXiv:2011.12127) remains open.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a4e7f3ba0f19e408e87a3e338ea1c7da0d93438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>