### PR TITLE
fix(MPS/ParentHamiltonian): condition martingale gap on overlap estimate

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -5,15 +5,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
+import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 
 /-!
 # Martingale estimate for parent Hamiltonians
 
 This module collects the martingale estimates reducing the MPS parent-Hamiltonian
 spectral gap to a uniform Friedrichs-angle bound for adjacent local ground
-spaces. The Friedrichs-angle estimate remains separate until it is proved.
+spaces. The Friedrichs-angle estimate remains a separate hypothesis.
 
-The three components are:
+The four components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale` (quadratic form ⟹ norm bound);
@@ -21,10 +22,8 @@ The three components are:
   Hamiltonian transport, positivity, commutation, and kernel identification;
 * `Martingale.Reduction` — martingale quadratic-form reduction chain from
   ordered cross-term bounds down to concrete cyclic-window Friedrichs.
-
-The final spectral-gap pair `parentHamiltonianES_gap_bound_of_friedrichs` and
-`parentHamiltonian_gapped` remains in `Martingale.Gap`; it is not imported here
-until the Friedrichs-angle estimate is proved.
+* `Martingale.Gap` — conditional gap theorems from the overlapping
+  cyclic-window estimate.
 
 ## Argument
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -88,7 +88,7 @@ by `FrustrationFree.spectralGap_of_martingale` is automatic here because
 `H_N = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
 
 The proof below invokes
-`parentHamiltonianES_gap_bound_of_friedrichs`, which packages the already
+`parentHamiltonianES_gap_bound_of_friedrichs`, which combines the already
 formalized martingale reductions after the overlapping-window estimate is given. -/
 theorem parentHamiltonian_gapped
     (A : MPSTensor d D) (hA : IsInjective A) (L : ℕ) (hL : 1 < L)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -7,18 +7,16 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 /-!
 # Uniform spectral gap for the MPS parent Hamiltonian
 
-**Root-only.** This file contains the final spectral-gap theorems for the MPS
-parent Hamiltonian. The remaining Friedrichs-angle analytic estimate is the
-final missing proof obligation.
+**Root-only.** This file contains the final conditional spectral-gap theorems
+for the MPS parent Hamiltonian. The overlapping-window Friedrichs-angle
+estimate remains an explicit hypothesis.
 
 ## Main results
 
-* `parentHamiltonianES_gap_bound_of_friedrichs` — the MPS-specific
-  Friedrichs-angle / row-sum estimate that supplies the remaining
-  hypothesis for the reduction chain in `Martingale.Reduction`.
-* `parentHamiltonian_gapped` — uniform spectral gap for MPS parent
-  Hamiltonians on injective tensors, obtained from the Friedrichs-angle
-  bound.
+* `parentHamiltonianES_gap_bound_of_friedrichs` — the explicit gap bound
+  obtained from the overlapping-window norm-compression estimate.
+* `parentHamiltonian_gapped` — conditional uniform spectral gap for MPS parent
+  Hamiltonians on injective tensors, under the same Friedrichs input.
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -29,38 +27,40 @@ variable {d D : ℕ}
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
--- Maintainer note: the proof of `parentHamiltonianES_gap_bound_of_friedrichs` reduces to
--- a Friedrichs-angle estimate for pairs of overlapping cyclic-window projectors with the
--- coefficient required by the finite-overlap row reduction in `Martingale.Reduction`.
-/-- Friedrichs-angle and row-sum estimate for the MPS parent Hamiltonian.
+/-- Gap bound from the overlapping cyclic-window Friedrichs estimate for the
+MPS parent Hamiltonian.
 
-This is the remaining MPS-specific martingale estimate. It asks for the explicit
-uniform lower bound obtained from the Friedrichs-angle estimate for overlapping
-local ground spaces, after the finite row-counting geometry has fixed the cyclic
-window convention. The constant is intentionally part of this theorem statement;
-the comparison with the martingale paragraph in arXiv:2011.12127, Section IV.C,
-is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+The hypothesis is the precise norm-compression estimate for overlapping
+cyclic-window local projections. The finite row-counting geometry, non-overlap
+positivity, projection-geometry comparison, and spectral-theorem step are already
+formalized in `Martingale.Reduction`. The comparison between this explicit
+cyclic-window hypothesis and the martingale paragraph in arXiv:2011.12127,
+Section IV.C, is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_friedrichs
-    (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (_hL : 1 < L) :
+    (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (hL : 1 < L)
+    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            ((1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) * ‖localTermES A L i v‖) :
     0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
     ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
-  -- Remaining obligation: prove the overlapping cyclic-window Friedrichs-angle
-  -- estimate required by `parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs`.
-  -- Local projection structure, row cardinality, non-overlap positivity, kernel
-  -- identification, and the spectral-theorem conversion are already formalized above.
-  sorry
+  exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound A L hL
+    hOverlapNorm
 
 /--
-**Spectral gap for MPS parent Hamiltonians.**
+**Conditional spectral gap for MPS parent Hamiltonians.**
 
-For an injective MPS tensor `A` and interaction range `L > 1`, there exists
-a uniform gap `γ > 0` (independent of system size `N`) such that for all
-`N ≥ 2L`, every vector in the orthogonal complement of the ground space
-satisfies `γ * ‖v‖ ≤ ‖H_ES v‖`.
+For an injective MPS tensor `A` and interaction range `L > 1`, the
+overlapping-window norm-compression estimate implies the existence of a uniform
+gap `γ > 0` (independent of system size `N`). For all `N ≥ 2L`, every vector
+in the orthogonal complement of the ground space satisfies
+`γ * ‖v‖ ≤ ‖H_ES v‖`.
 
 The orthogonal complement is computed in the `EuclideanSpace` structure
 on `NSiteSpace d N ≃ Cfg d N → ℂ`.
@@ -87,16 +87,23 @@ Combined with `h_i^2 = h_i`, this yields the quadratic-form inequality
 by `FrustrationFree.spectralGap_of_martingale` is automatic here because
 `H_N = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
 
-The proof below invokes the MPS-specific Friedrichs-angle theorem
-`parentHamiltonianES_gap_bound_of_friedrichs`, whose proof is the remaining
-Friedrichs-angle and row-sum obligation. -/
+The proof below invokes
+`parentHamiltonianES_gap_bound_of_friedrichs`, which packages the already
+formalized martingale reductions after the overlapping-window estimate is given. -/
 theorem parentHamiltonian_gapped
-    (A : MPSTensor d D) (hA : IsInjective A) (L : ℕ) (hL : 1 < L) :
+    (A : MPSTensor d D) (hA : IsInjective A) (L : ℕ) (hL : 1 < L)
+    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            ((1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) * ‖localTermES A L i v‖) :
     ∃ γ > 0, ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
   obtain ⟨hγ, hgap⟩ := parentHamiltonianES_gap_bound_of_friedrichs A hA L hL
+    hOverlapNorm
   exact ⟨(1 : ℝ) / (4 * (L : ℝ)), hγ, hgap⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -4601,9 +4601,9 @@ Lucia~\cite{Kastoryano2018Martingale}.
     constants $c_{\{i,j\}}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
     Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}
     obtain this uniformity by the martingale method, invoking finite-chain-state
-    estimates to control the constants.  For the explicit cyclic-window
+    estimates to control the constants. For the explicit cyclic-window
     constants displayed here, the remaining quantitative step is the
-    overlapping-window Friedrichs-angle bound in
+    overlapping-window estimate used as a hypothesis in
     Theorem~\ref{thm:friedrichs_gap_bound}; the preceding lemmas reduce the
     martingale inequality and the spectral gap to that estimate.
     (When $L = 1$ the interaction terms have disjoint supports, so there are no
@@ -4672,8 +4672,10 @@ Lucia~\cite{Kastoryano2018Martingale}.
     % Paper-gap note: docs/paper-gaps/cpgsv21_martingale_overlap.tex.
 \end{proof}
 
-\begin{theorem}[Explicit Friedrichs-angle gap bound]
+\begin{theorem}[Gap bound from cyclic overlap compression]
     \label{thm:friedrichs_gap_bound}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs}
+    \leanok
     \uses{def:parent_ground_space_es, def:parent_hamiltonian_es,
         thm:parent_ground_space_es_kernel,
         rem:euclidean_local_projector_ingredients,
@@ -4690,12 +4692,19 @@ Lucia~\cite{Kastoryano2018Martingale}.
         lem:parent_hamiltonian_cyclic_window_friedrichs_gap,
         lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
         lem:parent_hamiltonian_cyclic_overlap_norm_gap}
-    For an injective tensor $A$ and a range $L > 1$, the theorem asserts
-    the analytic estimate with the explicit constant
+    Let $A$ be injective and let $L>1$. Suppose that, for every $N\ge2L$ and
+    every overlapping off-diagonal pair of cyclic length-$L$ windows,
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le
+        \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}
+        \|h_{i,\mathrm{ES}}v\|.
+    \]
+    Then the parent Hamiltonian has the explicit gap constant
     \[
         \gamma_{L} := \frac{1}{4L} > 0.
     \]
-    Concretely, it asserts that if $N \ge 2L$ and
+    Concretely, if $N \ge 2L$ and
     $v \in (\mathcal G_{N,L}^{\mathrm{ES}}(A))^{\perp}$, then
     \[
         \gamma_{L} \|v\| \le \|H_{N,L}^{\mathrm{ES}}(A) v\|.
@@ -4703,7 +4712,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     The local averaging, positivity, and symmetric-projection statements are now
     established in Lemmas~\ref{lem:local_term_es_average},
     \ref{lem:transported_es_positive}, and~\ref{lem:transported_es_local_projections}.
@@ -4721,31 +4730,37 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the finite-overlap
     row-cardinality bound.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap} combines
-    these ingredients with the finite-overlap reduction, so the remaining
-    analytic task is the Friedrichs-angle estimate for overlapping cyclic windows.
+    these ingredients with the finite-overlap reduction, so the only additional
+    input is the Friedrichs-angle estimate for overlapping cyclic windows.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} states the
     same overlap-only formulation, and
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} states a sufficient
-    norm-compression formulation.
+    norm-compression formulation. Applying that norm-compression formulation to
+    the displayed hypothesis gives the stated lower bound with
+    $\gamma_L=1/(4L)$.
 \end{proof}
 
-\begin{theorem}[Spectral gap for MPS parent Hamiltonians]\label{thm:parent_hamiltonian_gapped}
+\begin{theorem}[Conditional spectral gap for MPS parent Hamiltonians]
+    \label{thm:parent_hamiltonian_gapped}
+    \lean{MPSTensor.parentHamiltonian_gapped}
+    \leanok
     \uses{thm:friedrichs_gap_bound, lem:quadratic_form_to_norm_bound}
-    For an injective tensor $A$ and a range $L > 1$, there exists $\gamma > 0$ such that
-    for every $N \ge 2L$ and every vector
+    For an injective tensor $A$ and a range $L > 1$, assume the overlapping
+    cyclic-window norm-compression estimate of
+    Theorem~\ref{thm:friedrichs_gap_bound}. Then there exists $\gamma > 0$ such
+    that for every $N \ge 2L$ and every vector
     $v \in (\mathcal G_{N,L}^{\mathrm{ES}}(A))^{\perp}$ one has
     \[
         \gamma \|v\| \le \|H_{N,L}^{\mathrm{ES}}(A) v\|.
     \]
-    By Lemma~\ref{lem:quadratic_form_to_norm_bound}, this implies the usual uniform lower
-    bound on every nonzero eigenvalue of the parent Hamiltonian.
+    By Lemma~\ref{lem:quadratic_form_to_norm_bound}, this implies the usual
+    uniform lower bound on every nonzero eigenvalue of the parent Hamiltonian.
 \end{theorem}
 
 \begin{proof}
-    \notready
-    This follows immediately from Theorem~\ref{thm:friedrichs_gap_bound} by taking as
-    $\gamma$ the explicit constant produced there, which yields the required existential
-    spectral-gap constant.
+    \leanok
+    This follows immediately from Theorem~\ref{thm:friedrichs_gap_bound} by
+    taking $\gamma$ to be the explicit constant produced there.
 \end{proof}
 
 \section{Ground space of non-injective MPS}\label{sec:degenerate_ground_space}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -4744,7 +4744,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \label{thm:parent_hamiltonian_gapped}
     \lean{MPSTensor.parentHamiltonian_gapped}
     \leanok
-    \uses{thm:friedrichs_gap_bound, lem:quadratic_form_to_norm_bound}
+    \uses{thm:friedrichs_gap_bound}
     For an injective tensor $A$ and a range $L > 1$, assume the overlapping
     cyclic-window norm-compression estimate of
     Theorem~\ref{thm:friedrichs_gap_bound}. Then there exists $\gamma > 0$ such

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -126,7 +126,7 @@ argument converts those ordered estimates into the global gap bound.\footnote{Th
     and
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le}
     in \path{TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean}. The
-    remaining theorem is
+    conditional gap theorem is
     \leanid{parentHamiltonianES_gap_bound_of_friedrichs} in
     \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. The
     projection-geometry reductions used by these statements are in
@@ -172,23 +172,22 @@ The blueprint item labelled \path{lem:martingale_mps} in
 \path{blueprint/src/chapter/ch14_parent_hamiltonian.tex} now separates the
 finite-row martingale reduction from the still-open quantitative estimate.
 It does not assert that the displayed all-$L>1$ cyclic-window bound has already
-been obtained from the cited principal-angle estimates. Instead, it identifies
-Theorem \path{thm:friedrichs_gap_bound} as the remaining analytic input.
+been obtained from the cited principal-angle estimates. Instead, it states that
+bound as the hypothesis of Theorem \path{thm:friedrichs_gap_bound}.
 
 The corresponding theorem entry
 \path{thm:friedrichs_gap_bound} points to
 \leanid{parentHamiltonianES_gap_bound_of_friedrichs} in
-\path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. This is the current
-formal boundary: all finite-row, cyclic-window, non-overlap, and norm-compression
-reductions have been isolated in
-\path{TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean}, while the
-MPS-specific Friedrichs estimate remains to be proved or matched precisely to
-the cited martingale estimates.
+\path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. This theorem is now
+conditional on the norm-compression estimate (N). Thus all finite-row,
+cyclic-window, non-overlap, norm-compression, and spectral-theorem reductions are
+proved, while the MPS-specific Friedrichs estimate remains to be proved or
+matched precisely to the cited martingale estimates.
 
 Once the quantitative comparison with the cited martingale estimates is settled,
-the blueprint should say either that the all-$L$ bound follows from those
-estimates under the cyclic-window convention used here, or that the formal proof
-uses a deliberately stronger replacement estimate.
+the blueprint should say either that the all-$L$ norm-compression hypothesis
+follows from those estimates under the cyclic-window convention used here, or
+that the final MPS gap theorem uses a deliberately stronger replacement estimate.
 
 \section{Conclusion}
 


### PR DESCRIPTION
### Motivation

- The gap bound `parentHamiltonianES_gap_bound_of_friedrichs` was unconditional on the cyclic-window norm-compression estimate, making it unfaithful to arXiv:2011.12127, §IV.C, equation `eq:4:martingale-2`. The anticommutator condition with row-summable coefficients requires an all-$L$ cyclic-window bound with constant $1/(4L)$ that is not supplied by the cited source passage on its own.
- The norm-compression estimate $\|p_i p_j v\| \le (1 - 1/(4L)) \cdot (2(L-1))^{-1} \|p_i v\|$ remains open relative to the FNW/Nachtergaele/Kastoryano principal-angle estimates; it must appear as an explicit hypothesis rather than a proved intermediate step.
- Continues the parent-Hamiltonian spectral-gap formalization (arXiv:2011.12127, §IV.C); see #952.

### Description

- `TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean`: added the cyclic-window norm-compression estimate as an explicit hypothesis to `parentHamiltonianES_gap_bound_of_friedrichs` and `parentHamiltonian_gapped`; both are now proved via the existing reduction in `Martingale/Reduction.lean`.
- `TNLean/MPS/ParentHamiltonian/Martingale.lean`: imports `Martingale.Gap` through the martingale aggregate, now that the module is proof-clean.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: updated Chapter 14 to state the same mathematical boundary: the spectral gap follows from the norm-compression estimate; the estimate itself is the remaining open step.
- `docs/paper-gaps/cpgsv21_martingale_overlap.tex`: updated the paper-gap note to match the new boundary and identify the open comparison with FNW/Nachtergaele/Kastoryano.
- Source: arXiv:2011.12127, §IV.C, `eq:4:martingale-2`. The constant $1/(4L)$ under the cyclic-window convention is not directly derived from this passage; that comparison remains open and is tracked in #952.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale.lean`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint checkdecls`
- `git diff --check`

---
Related issue: #952. This PR does not close #952; the overlapping-window estimate itself remains open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public API of core spectral-gap theorems (new hypothesis, no more `sorry`) and formal documentation boundaries; logic is delegated to existing reductions rather than new analytics.
> 
> **Overview**
> **Makes the MPS parent-Hamiltonian martingale gap theorems explicitly conditional** on the overlapping cyclic-window norm-compression estimate (with coefficient \((1 - 1/(4L))/(2(L-1))\)), instead of treating that estimate as an unfinished internal proof.
> 
> In Lean, `parentHamiltonianES_gap_bound_of_friedrichs` and `parentHamiltonian_gapped` now take `hOverlapNorm` and are proved by `exact`ing the existing reduction `parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound` in `Martingale/Reduction.lean`; `Martingale.lean` imports `Martingale.Gap` now that the module is proof-clean.
> 
> Blueprint Chapter 14 and `docs/paper-gaps/cpgsv21_martingale_overlap.tex` are aligned: the gap bound follows from the norm-compression hypothesis; deriving that estimate from the cited principal-angle literature remains the open comparison (#952).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bce37776e15e26bf93a8fca2eb0084d1db284ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->