### PR TITLE
doc(rfp): record pure ZCL local-orthogonality scope

### DIFF
--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -9,18 +9,22 @@ import TNLean.MPS.Core.Correlations
 /-!
 # Zero correlation length (ZCL) for MPS tensors
 
-This file defines zero-correlation-length (ZCL) conditions for MPS tensors,
-following arXiv:1606.00608 Section 3.2 (Cirac–Pérez-García–Schuch–Verstraete).
+This file defines single-block zero-correlation-length (ZCL) conditions for MPS
+tensors, following arXiv:1606.00608 Section 3.2
+(Cirac–Pérez-García–Schuch–Verstraete).
 
 Three conditions are introduced:
 
 * `IsCID A` — correlations are independent of distance.
-* `IsLocallyOrthogonal A` — the BNT components have vanishing mixed transfer
-  operators.
+* `IsLocallyOrthogonal A` — the local single-block convention used here; it is
+  transfer-map idempotence.
 * `IsZCL A` — the conjunction of local orthogonality and CID.
 
-The main result (Theorem 3.8) asserts that `IsZCL` is equivalent to having
-an idempotent transfer map (`IsRFP`).
+The proved local result identifies this single-block convention with an
+idempotent transfer map (`IsRFP`). The source theorem also has a BNT-level local
+orthogonality condition, namely vanishing mixed transfer maps between distinct
+BNT components. That mixed-sector part is not represented by this single-block
+predicate; see `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.
 -/
 
 open scoped Matrix ComplexOrder
@@ -45,14 +49,15 @@ def IsCID (A : MPSTensor d D) : Prop :=
       1 ≤ n → 1 ≤ m →
       connectedCorrelator A ρR X Y n = connectedCorrelator A ρR X Y m
 
-/-- Local orthogonality for a single BNT block: the self-transfer map is
-idempotent. For a single tensor `A`, this is equivalent to `IsRFP A`
-(see `isLocallyOrthogonal_iff_isRFP`). See arXiv:1606.00608, Definition 3.5.
+/-- Local orthogonality in the single-block convention used by this file:
+the self-transfer map is idempotent. Thus, for one tensor `A`, this is
+definitionally equivalent to `IsRFP A` (see `isLocallyOrthogonal_iff_isRFP`).
 
-In the full BNT setting, local orthogonality additionally requires that
-the *mixed* transfer operators `F_{jk}` vanish for `j ≠ k`. That
-off-diagonal condition is captured at the canonical-form level in
-`zcl_iff_idempotent_transfer`. -/
+**Scope restriction (arXiv:1606.00608, Definition 3.5):** in the source, local
+orthogonality is a BNT-level condition: for distinct BNT components `j ≠ k`, the
+mixed transfer maps vanish. This one-tensor predicate has no mixed sectors and
+does not formalize those equations. The missing BNT-level statement is recorded
+in `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 def IsLocallyOrthogonal (A : MPSTensor d D) : Prop :=
   IsRFP A
 
@@ -62,9 +67,15 @@ lemma isLocallyOrthogonal_iff_isRFP (A : MPSTensor d D) :
     IsLocallyOrthogonal A ↔ IsRFP A :=
   Iff.rfl
 
-/-- Zero correlation length: a tensor has ZCL when it is both locally
-orthogonal and has correlations independent of distance.
-See arXiv:1606.00608, Definition 3.6. -/
+/-- Zero correlation length in the single-block convention: a tensor has ZCL
+when it satisfies the local idempotence convention above and has correlations
+independent of distance.
+
+**Scope restriction (arXiv:1606.00608, Definition 3.6):** the source definition
+combines CID with BNT-level local orthogonality. Since `IsLocallyOrthogonal`
+above is the single-block idempotence convention, this predicate should not be
+read as the full source definition for a multi-block BNT family. See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 def IsZCL (A : MPSTensor d D) : Prop :=
   IsLocallyOrthogonal A ∧ IsCID A
 
@@ -106,12 +117,18 @@ theorem isCID_implies_isRFP
     Matrix.trace_mul_comm _ N, Matrix.trace_mul_comm _ N]
   exact sub_eq_zero.mpr heq
 
-/-- **Theorem 3.8** (arXiv:1606.00608): For an MPS tensor,
-ZCL is equivalent to the transfer map being idempotent (i.e. `IsRFP`).
+/-- Single-block ZCL is equivalent to transfer-map idempotence (i.e. `IsRFP`).
 
 Forward: `IsZCL → IsRFP` is immediate since `IsLocallyOrthogonal = IsRFP`.
 Reverse: `E² = E` implies `Eⁿ = E` for `n ≥ 1` by `IsIdempotentElem.pow_eq`,
-so the connected correlator is independent of separation, giving CID. -/
+so the connected correlator is independent of separation, giving CID.
+
+**Scope restriction (arXiv:1606.00608, Theorem `TheoremZCLPure`):** the source
+theorem is stated for canonical-form tensors and includes the BNT-level local
+orthogonality equations for distinct components. This result proves the
+single-block idempotence/CID equivalence under the convention above; it is not
+the full BNT-level theorem. See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 theorem zcl_iff_idempotent_transfer (A : MPSTensor d D) :
     IsZCL A ↔ IsRFP A := by
   constructor

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -492,7 +492,7 @@ and rates for the single-tensor transfer map $\E_A$.
         \operatorname{CID}(A)
     \]
     both hold. The source definition combines CID with BNT-level local
-    orthogonality, namely the equations \(\E_{j,j'}=0\) for \(j\ne j'\).
+    orthogonality, namely the equations $\E_{j,j'}=0$ for $j\ne j'$.
 \end{definition}
 
 \begin{theorem}[CID implies RFP]\label{thm:isCID_implies_isRFP}
@@ -524,7 +524,7 @@ and rates for the single-tensor transfer map $\E_A$.
     This is the idempotence/CID part of
     \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}. The full source theorem for
     canonical-form tensors also includes the BNT-level local-orthogonality
-    equations \(\E_{j,j'}=0\) for \(j\ne j'\).
+    equations $\E_{j,j'}=0$ for $j\ne j'$.
 \end{theorem}
 \begin{proof}\leanok
     The forward direction extracts the idempotence hypothesis. The reverse uses

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -298,15 +298,22 @@ and rates for the single-tensor transfer map $\E_A$.
     $\{A^j\}$, hence $\E_A^2 = \E_A$.
 \end{proof}
 
-\begin{definition}[Local orthogonality]\label{def:is_locally_orthogonal}
+\begin{definition}[Single-block local orthogonality convention]%
+    \label{def:is_locally_orthogonal}
     \lean{MPSTensor.IsLocallyOrthogonal}
     \leanok
     \uses{def:is_rfp}
-    A single BNT block is \emph{locally orthogonal} when its self-transfer map
-    is idempotent. For a single tensor this coincides with the RFP condition
-    (Definition~\ref{def:is_rfp}); in the full multi-block BNT setting, local
-    orthogonality additionally requires that mixed transfer operators vanish.
-    See \cite[Definition~3.5]{Cirac2016MPDO_arXiv}.
+    For the single-block convention used here, local orthogonality means
+    \[
+        \E_A^2=\E_A .
+    \]
+    The source local-orthogonality condition for a BNT family is instead the
+    collection of mixed-sector equations
+    \[
+        \E_{j,j'}=0 \qquad (j\ne j').
+    \]
+    Thus this definition records the one-block idempotence convention, not the
+    full BNT-level condition of \cite[Definition~3.5]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[RFP normal tensor is injective]\label{thm:rfp_nt_injective}
@@ -477,9 +484,15 @@ and rates for the single-tensor transfer map $\E_A$.
     \lean{MPSTensor.IsZCL}
     \leanok
     \uses{def:is_locally_orthogonal, def:is_cid}
-    An MPS tensor has \emph{zero correlation length} when it is both locally
-    orthogonal and correlations are independent of distance.
-    See \cite[Definition~3.6]{Cirac2016MPDO_arXiv}.
+    In the single-block convention, an MPS tensor has \emph{zero correlation
+    length} when
+    \[
+        \E_A^2=\E_A
+        \qquad\text{and}\qquad
+        \operatorname{CID}(A)
+    \]
+    both hold. The source definition combines CID with BNT-level local
+    orthogonality, namely the equations \(\E_{j,j'}=0\) for \(j\ne j'\).
 \end{definition}
 
 \begin{theorem}[CID implies RFP]\label{thm:isCID_implies_isRFP}
@@ -502,13 +515,19 @@ and rates for the single-tensor transfer map $\E_A$.
     \lean{MPSTensor.zcl_iff_idempotent_transfer}
     \leanok
     \uses{def:is_rfp, def:is_cid, def:is_locally_orthogonal}
-    An MPS tensor has zero correlation length (i.e.\ is both locally
-    orthogonal and CID) if and only if its transfer map is idempotent.
-    This is \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}.
+    Under the single-block convention above,
+    \[
+        \bigl(\E_A^2=\E_A \ \text{and}\ \operatorname{CID}(A)\bigr)
+        \quad\Longleftrightarrow\quad
+        \E_A^2=\E_A .
+    \]
+    This is the idempotence/CID part of
+    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}. The full source theorem for
+    canonical-form tensors also includes the BNT-level local-orthogonality
+    equations \(\E_{j,j'}=0\) for \(j\ne j'\).
 \end{theorem}
 \begin{proof}\leanok
-    The forward direction extracts local orthogonality (which equals
-    idempotence by definition). The reverse uses
+    The forward direction extracts the idempotence hypothesis. The reverse uses
     $\E^n = \E$ for $n \ge 1$ to show the connected correlator is
     separation-independent.
 \end{proof}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -43,6 +43,12 @@ For MPDO renormalization fixed points:
   pure-state RFP witness, but did not enforce the source's global purification
   equation and trace-preserving post-ancilla map, and therefore produced a
   counterexample contradicting CPSV16's PRFP--ZCL theorem.
+- `cpsv16_pure_zcl_local_orthogonality_scope.tex` records that the current
+  pure-MPS ZCL theorem is a single-block idempotence/CID equivalence. The
+  source theorem also includes the BNT-level local-orthogonality equations
+  between distinct blocks.
+- `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
+  normalization issue for mixed-state ZCL.
 
 For the non-periodic MPS Fundamental Theorem background:
 

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -33,6 +33,12 @@ and then defines zero correlation length as the conjunction of CID and local
 orthogonality.\footnote{Local source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:467--479}.}
 
+For a single tensor \(A\), write
+\begin{align}
+  \mathbb E_A=\sum_i A^i\otimes \overline{A^i}
+\end{align}
+for the transfer matrix.
+
 The pure-state theorem states that, for a tensor \(A\) in canonical form,
 \begin{align}
   \mathrm{ZCL}(A)

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -33,13 +33,13 @@ and then defines zero correlation length as the conjunction of CID and local
 orthogonality.\footnote{Local source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:467--479}.}
 
-For a single tensor \(A\), write
+For a single tensor $A$, write
 \begin{align}
   \mathbb E_A=\sum_i A^i\otimes \overline{A^i}
 \end{align}
 for the transfer matrix.
 
-The pure-state theorem states that, for a tensor \(A\) in canonical form,
+The pure-state theorem states that, for a tensor $A$ in canonical form,
 \begin{align}
   \mathrm{ZCL}(A)
   \quad\Longleftrightarrow\quad
@@ -47,14 +47,14 @@ The pure-state theorem states that, for a tensor \(A\) in canonical form,
   \tag{\path{TheoremZCLPure}}
 \end{align}
 In the proof, the source first identifies local orthogonality with the equations
-\(\mathbb E_{j,j'}=0\) for \(j\ne j'\).  After assuming those equations, it proves
-that \(\mathbb E_A^2=\mathbb E_A\) is equivalent to CID.\footnote{Local source:
+$\mathbb E_{j,j'}=0$ for $j\ne j'$.  After assuming those equations, it proves
+that $\mathbb E_A^2=\mathbb E_A$ is equivalent to CID.\footnote{Local source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1248--1268}.}
 
 \section{Formal boundary}
 
 The current formal predicate
-\(\leanid{MPSTensor.IsLocallyOrthogonal}\) is a one-tensor convention:
+\leanid{MPSTensor.IsLocallyOrthogonal} is a one-tensor convention:
 \begin{align}
   \leanid{MPSTensor.IsLocallyOrthogonal}(A)
   \quad:\!\!\Longleftrightarrow\quad
@@ -66,7 +66,7 @@ Consequently
   \quad:\!\!\Longleftrightarrow\quad
   \bigl(\mathbb E_A^2=\mathbb E_A\bigr)\wedge \mathrm{CID}(A).
 \end{align}
-The theorem \(\leanid{MPSTensor.zcl_iff_idempotent_transfer}\) therefore proves
+The theorem \leanid{MPSTensor.zcl_iff_idempotent_transfer} therefore proves
 the single-block equivalence
 \begin{align}
   \bigl(\mathbb E_A^2=\mathbb E_A\bigr)\wedge \mathrm{CID}(A)
@@ -77,12 +77,12 @@ Its nontrivial direction is the implication
 \[
   \mathbb E_A^2=\mathbb E_A \Longrightarrow \mathrm{CID}(A),
 \]
-obtained from \(\mathbb E_A^n=\mathbb E_A\) for all \(n\ge 1\).  The reverse
+obtained from $\mathbb E_A^n=\mathbb E_A$ for all $n\ge 1$.  The reverse
 direction of that displayed equivalence is immediate because the left-hand side
-already contains \(\mathbb E_A^2=\mathbb E_A\).
+already contains $\mathbb E_A^2=\mathbb E_A$.
 
 This is a useful local statement, but it is not the source theorem
-\(\path{TheoremZCLPure}\): the source theorem also contains the mixed-sector
+\path{TheoremZCLPure}: the source theorem also contains the mixed-sector
 local-orthogonality equations (LO).
 
 \section{Elimination plan}
@@ -109,6 +109,10 @@ The existing single-block theorem supplies only the CID consequence of
 idempotence and should remain marked as a scope restriction until the
 mixed-sector equations are part of the statement.\footnote{Tracked by
 \ghissue{2597}.}
+
+The present theorem is therefore a scope restriction: it records the one-block
+idempotence/CID consequence, while the mixed-sector local-orthogonality equations
+remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -1,0 +1,110 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Pure zero correlation length and local orthogonality in
+Cirac--Perez-Garcia--Schuch--Verstraete 2017}
+\author{}
+\date{2026-06-10}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+In Section~3.2 of \cite{Cirac2016MPDO_arXiv}, correlations independent of
+distance are defined by requiring, for separated observables, that translating
+one observable through any allowed separation does not change the expectation
+value.\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:437--445}, label
+\path{ZCL}.}  The same subsection defines local orthogonality for a
+basis-of-normal-tensors family by the mixed-sector equations
+\begin{align}
+  \mathbb E_{j,j'}=\sum_i A_j^i\otimes \overline{A_{j'}^i}=0,
+  \qquad j\ne j',
+  \tag{LO}
+\end{align}
+and then defines zero correlation length as the conjunction of CID and local
+orthogonality.\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:467--479}.}
+
+The pure-state theorem states that, for a tensor \(A\) in canonical form,
+\begin{align}
+  \mathrm{ZCL}(A)
+  \quad\Longleftrightarrow\quad
+  \mathbb E_A^2=\mathbb E_A.
+  \tag{\path{TheoremZCLPure}}
+\end{align}
+In the proof, the source first identifies local orthogonality with the equations
+\(\mathbb E_{j,j'}=0\) for \(j\ne j'\).  After assuming those equations, it proves
+that \(\mathbb E_A^2=\mathbb E_A\) is equivalent to CID.\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1248--1268}.}
+
+\section{Formal boundary}
+
+The current formal predicate
+\(\leanid{MPSTensor.IsLocallyOrthogonal}\) is a one-tensor convention:
+\begin{align}
+  \leanid{MPSTensor.IsLocallyOrthogonal}(A)
+  \quad:\!\!\Longleftrightarrow\quad
+  \mathbb E_A^2=\mathbb E_A.
+\end{align}
+Consequently
+\begin{align}
+  \leanid{MPSTensor.IsZCL}(A)
+  \quad:\!\!\Longleftrightarrow\quad
+  \bigl(\mathbb E_A^2=\mathbb E_A\bigr)\wedge \mathrm{CID}(A).
+\end{align}
+The theorem \(\leanid{MPSTensor.zcl_iff_idempotent_transfer}\) therefore proves
+the single-block equivalence
+\begin{align}
+  \bigl(\mathbb E_A^2=\mathbb E_A\bigr)\wedge \mathrm{CID}(A)
+  \quad\Longleftrightarrow\quad
+  \mathbb E_A^2=\mathbb E_A.
+\end{align}
+Its nontrivial direction is the implication
+\[
+  \mathbb E_A^2=\mathbb E_A \Longrightarrow \mathrm{CID}(A),
+\]
+obtained from \(\mathbb E_A^n=\mathbb E_A\) for all \(n\ge 1\).  The reverse
+direction of that displayed equivalence is immediate because the left-hand side
+already contains \(\mathbb E_A^2=\mathbb E_A\).
+
+This is a useful local statement, but it is not the source theorem
+\(\path{TheoremZCLPure}\): the source theorem also contains the mixed-sector
+local-orthogonality equations (LO).
+
+\section{Elimination plan}
+
+A source-faithful formalization of the pure theorem should introduce a
+BNT-family version of local orthogonality carrying the equations
+\[
+  \mathbb E_{j,j'}=0 \qquad (j\ne j'),
+\]
+and a BNT-family ZCL predicate
+\[
+  \mathrm{ZCL}_{\mathrm{BNT}}(A)
+  :=
+  \mathrm{CID}(A)\wedge
+  \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr).
+\]
+The target theorem for tensors in canonical form is then
+\[
+  \mathrm{ZCL}_{\mathrm{BNT}}(A)
+  \Longleftrightarrow
+  \mathbb E_A^2=\mathbb E_A.
+\]
+The existing single-block theorem supplies only the CID consequence of
+idempotence and should remain marked as a scope restriction until the
+mixed-sector equations are part of the statement.\footnote{Tracked by
+\ghissue{2597}.}
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation
- The Lean predicate `IsLocallyOrthogonal` is defined as single-block transfer-map idempotence, not the BNT-level mixed-sector vanishing condition ($\mathbb{E}_{j,j'}=0$ for $j\ne j'$) that defines local orthogonality in arXiv:1606.00608, `TheoremZCLPure` (line 501, Section 3).
- `MPSTensor.zcl_iff_idempotent_transfer` therefore proves a single-block equivalence rather than the full source theorem, creating a source-faithfulness gap documented in #2597.
- This PR records the scope boundary without closing the gap, keeping the full BNT-level theorem open for follow-up work.

### Description
- `TNLean/MPS/RFP/ZeroCorrelationLength.lean`: updated docstrings on `IsLocallyOrthogonal`, `IsZCL`, and `zcl_iff_idempotent_transfer` to state the single-block scope restriction explicitly.
- `blueprint/src/chapter/ch15_correlations.tex`: rewrote local-orthogonality and ZCL definitions/theorem prose using the equations $\mathbb{E}_A^2 = \mathbb{E}_A$ and mixed-sector vanishing $\mathbb{E}_{j,j'}=0$ ($j\ne j'$) instead of Lean identifier names.
- `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`: new paper-gap note comparing the source theorem to the current formalization and outlining a BNT-family elimination plan.
- `docs/paper-gaps/README.md`: indexed the new paper-gap note.
- No definitions, proofs, or Lean statements were changed; no sorrys introduced.

### Testing
- `lake build TNLean.MPS.RFP.ZeroCorrelationLength` — passes.
- `lake build TNLean` — completed successfully (pre-existing warnings in unrelated files).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`

---
Addresses #2597

> [!NOTE]
> **Low Risk**
> Documentation and docstring/blueprint prose only; no changes to definitions, proofs, or runtime behavior.
>
> **Overview**
> **Documents the gap** between the formalized pure-MPS ZCL story and CPSV16's full BNT-level `TheoremZCLPure`.
>
> Lean docstrings in `ZeroCorrelationLength.lean` now state explicitly that `IsLocallyOrthogonal` is the **single-block** convention (transfer-map idempotence, i.e. `IsRFP`), not the source's mixed-sector equations \(\mathbb E_{j,j'}=0\) for \(j\ne j'\). The same scope notes are attached to `IsZCL` and `zcl_iff_idempotent_transfer`.
>
> Blueprint chapter 15 is aligned: local orthogonality and ZCL definitions/theorems are rewritten in terms of \(\mathbb{E}_A^2=\mathbb{E}_A\) vs BNT mixed sectors, without changing the underlying Lean links.
>
> A new paper-gap note `cpsv16_pure_zcl_local_orthogonality_scope.tex` compares the source, records the formal boundary, and outlines a BNT-family elimination plan (issue #2597); `docs/paper-gaps/README.md` indexes it.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc6370f5c653cdfa5ed1c328efab98b8c3100ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstrings, blueprint prose, and paper-gap notes only; no changes to Lean statements, proofs, or runtime behavior.
> 
> **Overview**
> **Documents the scope gap** between the formalized pure-MPS ZCL story and CPSV16’s full BNT-level `TheoremZCLPure`, without changing Lean definitions or proofs.
> 
> Lean docstrings in `ZeroCorrelationLength.lean` now state that `IsLocallyOrthogonal` is the **single-block** convention (transfer-map idempotence / `IsRFP`), not the source’s mixed-sector equations \(\mathbb{E}_{j,j'}=0\) for \(j\ne j'\). Matching scope notes are added for `IsZCL` and `zcl_iff_idempotent_transfer`.
> 
> Blueprint **ch15** local-orthogonality, ZCL, and the ZCL↔idempotence theorem are rewritten in terms of \(\mathbb{E}_A^2=\mathbb{E}_A\) vs BNT mixed sectors instead of informal “locally orthogonal” wording.
> 
> A new paper-gap note `cpsv16_pure_zcl_local_orthogonality_scope.tex` compares the source, records the formal boundary, and outlines a BNT-family elimination plan (#2597); `docs/paper-gaps/README.md` indexes it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afc16aa1732f55bd6bc4f669d942af3b34e38733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->