### PR TITLE
feat(PEPS): the per-edge gauge family at every interior square-lattice edge

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -508,4 +508,5 @@ import TNLean.PEPS.RegionBlock.CoarseThreeSite10
 import TNLean.PEPS.RegionBlock.CoarseThreeSite11
 import TNLean.PEPS.CoherentFrameInstance
 import TNLean.PEPS.CoherentFrameInstance2
+import TNLean.PEPS.NormalEdgeGaugeFamily
 import TNLean.PEPS.NormalSquareInjectivity

--- a/TNLean/PEPS/CoherentFrameInstance2.lean
+++ b/TNLean/PEPS/CoherentFrameInstance2.lean
@@ -35,6 +35,58 @@ variable {V : Type*} [Fintype V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 variable {A : Tensor G d}
 
+/-! ### Decidable-equality transport of a one-edge blocking datum
+
+A square-lattice geometry layer builds its blocking data over the canonical product
+decidable equality on `Fin width × Fin height`, while the gauge interface synthesizes
+the decidable equality from the ambient linear order.  The two instances are equal as
+a subsingleton, so a datum carrying one of them transports to a datum carrying the
+other with no change of mathematical content.  This transport lets an interior datum,
+built over the product decidable equality, feed the gauge interface below. -/
+
+/-- Transport a one-edge blocking datum across two decidable-equality instances on the
+vertex set.  Decidable equality is a subsingleton, so the source and target instances
+coincide and the datum carries over verbatim.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex` (the blocking data are intrinsic to the lattice
+geometry, independent of the decidable-equality instance used to compute the
+finite unions). -/
+def transportBlockingData (inst₁ inst₂ : DecidableEq V)
+    {ι : RegionInjectivityData V} {e : Edge G}
+    (D : @NormalEdgeBlockingData V _ inst₁ _ ι G e) :
+    @NormalEdgeBlockingData V _ inst₂ _ ι G e := by
+  have h : inst₁ = inst₂ := Subsingleton.elim _ _
+  subst h
+  exact D
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem transportBlockingData_red (inst₁ inst₂ : DecidableEq V)
+    {ι : RegionInjectivityData V} {e : Edge G}
+    (D : @NormalEdgeBlockingData V _ inst₁ _ ι G e) :
+    (transportBlockingData inst₁ inst₂ D).red =
+      (@NormalEdgeBlockingData.red V _ inst₁ _ ι G e D) := by
+  obtain rfl : inst₁ = inst₂ := Subsingleton.elim _ _
+  rfl
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem transportBlockingData_blue (inst₁ inst₂ : DecidableEq V)
+    {ι : RegionInjectivityData V} {e : Edge G}
+    (D : @NormalEdgeBlockingData V _ inst₁ _ ι G e) :
+    (transportBlockingData inst₁ inst₂ D).blue =
+      (@NormalEdgeBlockingData.blue V _ inst₁ _ ι G e D) := by
+  obtain rfl : inst₁ = inst₂ := Subsingleton.elim _ _
+  rfl
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem transportBlockingData_complement (inst₁ inst₂ : DecidableEq V)
+    {ι : RegionInjectivityData V} {e : Edge G}
+    (D : @NormalEdgeBlockingData V _ inst₁ _ ι G e) :
+    (transportBlockingData inst₁ inst₂ D).complement =
+      (@NormalEdgeBlockingData.complement V _ inst₁ _ ι G e D) := by
+  obtain rfl : inst₁ = inst₂ := Subsingleton.elim _ _
+  rfl
+
 /-! ### The coherent frame of a one-edge blocking datum
 
 A one-edge blocking datum over the concrete region-injectivity predicate of a tensor

--- a/TNLean/PEPS/NormalEdgeGaugeFamily.lean
+++ b/TNLean/PEPS/NormalEdgeGaugeFamily.lean
@@ -1,0 +1,247 @@
+import TNLean.PEPS.NormalEdgeBlockingInterior
+import TNLean.PEPS.NormalEdgeSingleCrossing
+import TNLean.PEPS.CoherentFrameInstance2
+
+/-!
+# The per-edge gauge family at the interior edges of the square lattice
+
+This file assembles the per-edge gauge of two normal PEPS at every interior edge of
+the finite rectangular square lattice.  Each interior edge — a translated horizontal
+or vertical edge with two rows and columns of margin around its blocking frame —
+carries cover-free red, blue, and complementary blocking data
+(`TNLean.PEPS.NormalEdgeBlockingInterior`).  Around that edge the three blocks are
+injective, partition the lattice, and meet only along the distinguished edge
+(`TNLean.PEPS.NormalEdgeSingleCrossing`).  Feeding the two data of the two tensors to
+the coherent-frame gauge interface
+(`TNLean.PEPS.exists_regionEdgeGauge_of_blockingData`) gives, on that edge, the bond
+dimensions of the two tensors coinciding and the forward per-edge matrix transfer
+realized as conjugation by an invertible gauge matrix.
+
+The geometry layer builds its blocking data over the canonical product decidable
+equality on `Fin width × Fin height`, whereas the gauge interface synthesizes a
+decidable equality from the lattice's linear order.  These now coincide
+definitionally (`TNLean.PEPS.instLinearOrderSquareLatticeVertex` pins its
+`toDecidableEq` field to the product instance), so the interior data feed the gauge
+interface directly.
+
+**Scope restriction (interior edges):** the present open rectangular coordinate model
+admits the cover-free interior data only at edges whose blocking frame fits with two
+rows and columns of margin on every side.  Boundary edges fall outside the interior
+margin predicates; that boundary geometry is the residual open part of the every-edge
+construction, recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`,
+Section "Remaining mathematical obligations".  The translation-invariant reduction of
+these per-edge gauges to one horizontal and one vertical matrix, and the total gauge
+family over *all* edges that the orientation-uniform consumer
+(`TNLean.PEPS.IsOrientationUniformGaugeFamily`) expects, are the next mathematical
+steps above this interior gauge family, recorded in the same note.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair
+  states generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3,
+  lines 1449--1500 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ}
+
+/-- The set complement of the red block of a one-edge blocking datum is the union of
+its blue and complementary blocks.  This is the host region whose blocked-tensor
+injectivity the gauge interface consumes alongside the red injectivity.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex` (the three blocks partition the lattice). -/
+theorem blockingData_univ_sdiff_red {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+    {ι : RegionInjectivityData V} {G : SimpleGraph V} {e : Edge G}
+    (D : NormalEdgeBlockingData ι G e) :
+    Finset.univ \ D.red = D.blue ∪ D.complement := by
+  have hcov := D.cover_univ
+  ext v
+  simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_union]
+  constructor
+  · intro _
+    have hmem : v ∈ D.red ∪ D.blue ∪ D.complement := by rw [hcov]; exact Finset.mem_univ v
+    simp only [Finset.mem_union] at hmem
+    tauto
+  · rintro (hb | hc)
+    · exact fun hr => Finset.disjoint_left.mp D.red_disjoint_blue hr hb
+    · exact fun hr => Finset.disjoint_left.mp D.red_disjoint_complement hr hc
+
+/-- The host region `univ \ red` of a one-edge blocking datum over
+`regionInjectivityDataOf B` is blocked-tensor injective for `B`, derived from the blue
+and complementary injectivities through union closure.  This is the second host
+injectivity the gauge interface consumes for the second tensor.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorInjective_host {V : Type*} [Fintype V] [DecidableEq V]
+    [LinearOrder V] {G : SimpleGraph V} [DecidableRel G.Adj] {B : Tensor G d} {e : Edge G}
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) B) G e)
+    (hUB : RegionInjectivityUnionClosure (regionInjectivityDataOf (G := G) B)) :
+    RegionBlockedTensorInjective (G := G) B (Finset.univ \ DB.red) := by
+  rw [blockingData_univ_sdiff_red DB]
+  have hi := hUB.union_injective DB.blue_injective DB.complement_injective
+  rwa [regionInjectivityDataOf_isInjective] at hi
+
+open scoped Classical in
+/-- **The per-edge gauge at a translated horizontal interior edge.**
+
+Two normal PEPS `A` and `B` with the square-lattice rectangular-injectivity
+hypotheses, union closure, matched bond dimensions, the same state, positive bonds,
+and a translated horizontal blocking frame with two rows and columns of margin admit,
+on the distinguished horizontal edge `e` of that frame, the per-edge gauge.  The two
+interior data of `A` and `B` share the red, blue, and complementary blocks (the blocks
+are coordinate regions, independent of the tensor), so feeding them to
+`exists_regionEdgeGauge_of_blockingData` yields the bond dimensions of `A` and `B` on
+`e` coinciding and a forward region-insertion transfer `fwd` realized as conjugation
+by an invertible gauge matrix `Z`.  No single-vertex injectivity is used; the only
+injectivity inputs are the blocked-region injectivities of the interior data and `B`'s
+red and host injectivities.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge
+    (A B : Tensor (squareLatticeGraph width height) d) {xStart yStart : ℕ}
+    (hA : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUA : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hB : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 8 ≤ width) (hyh : yStart + 8 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (squareLatticeGraph width height), 0 < B.bondDim g)
+    (e : Edge (squareLatticeGraph width height))
+    (he : e = normalSquareHorizontalTranslatedEdge xStart yStart (by omega) (by omega)) :
+    ∃ (hEdge : A.bondDim e = B.bondDim e)
+        (Z : GL (Fin (B.bondDim e)) ℂ)
+        (fwd : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ →
+          Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ),
+        ∀ M, fwd M =
+            (Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+                Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) := by
+  classical
+  subst he
+  have hew : xStart + 3 ≤ width := by omega
+  have heh : yStart + 3 ≤ height := by omega
+  let e := normalSquareHorizontalTranslatedEdge xStart yStart hew heh
+  change ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ)
+      (fwd : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ →
+        Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ),
+      ∀ M, fwd M =
+          (Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+            Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+            ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+              Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)
+  let DA := normalSquareHorizontalTranslatedEdge_blockingDatum_interior
+      (κ := regionInjectivityDataOf A) hA hUA hx0 hy0 hxw hyh
+  let DB := normalSquareHorizontalTranslatedEdge_blockingDatum_interior
+      (κ := regionInjectivityDataOf B) hB hUB hx0 hy0 hxw hyh
+  have hDAred : DA.red = normalSquareHorizontalTranslatedEdgeRed xStart yStart := rfl
+  have hDAblue : DA.blue = normalSquareHorizontalTranslatedEdgeBlue xStart yStart := rfl
+  have hred : DA.red = DB.red := rfl
+  have hblue : DA.blue = DB.blue := rfl
+  have hcompl : DA.complement = DB.complement := rfl
+  have hsingle : ∀ g, IsCrossingEdge (G := squareLatticeGraph width height) A DA.red DA.blue g
+      ↔ g = e := by
+    intro g
+    rw [hDAred, hDAblue]
+    exact isCrossingEdge_normalSquareHorizontalTranslatedEdge (width := width) (height := height)
+      A (xStart := xStart) (yStart := yStart) hew heh g
+  have hRB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B DA.red := by
+    rw [hred]; exact regionBlockedTensorInjective_red DB
+  have hCB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
+      (Finset.univ \ DA.red) := by
+    rw [hred]; exact regionBlockedTensorInjective_host DB hUB
+  obtain ⟨_, _, _, hEdge, Z, hZ⟩ :=
+    exists_regionEdgeGauge_of_blockingData (A := A) (B := B) (e := e) DA DB
+      hred hblue hcompl hbond hAB hd hposA hposB hsingle hRB hCB
+  exact ⟨hEdge, Z, _, hZ⟩
+
+open scoped Classical in
+/-- **The per-edge gauge at a translated vertical interior edge.**
+
+The rotated counterpart of `exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge`:
+a translated vertical blocking frame with two rows and columns of margin admits, on its
+distinguished vertical edge `e`, the per-edge gauge — the bond dimensions of `A` and
+`B` on `e` coincide and a forward region-insertion transfer is conjugation by an
+invertible gauge matrix.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge
+    (A B : Tensor (squareLatticeGraph width height) d) {xStart yStart : ℕ}
+    (hA : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUA : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hB : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 8 ≤ width) (hyh : yStart + 8 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (squareLatticeGraph width height), 0 < B.bondDim g)
+    (e : Edge (squareLatticeGraph width height))
+    (he : e = normalSquareVerticalTranslatedEdge xStart yStart (by omega) (by omega)) :
+    ∃ (hEdge : A.bondDim e = B.bondDim e)
+        (Z : GL (Fin (B.bondDim e)) ℂ)
+        (fwd : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ →
+          Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ),
+        ∀ M, fwd M =
+            (Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+                Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) := by
+  classical
+  subst he
+  have hew : xStart + 3 ≤ width := by omega
+  have heh : yStart + 3 ≤ height := by omega
+  let e := normalSquareVerticalTranslatedEdge xStart yStart hew heh
+  change ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ)
+      (fwd : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ →
+        Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ),
+      ∀ M, fwd M =
+          (Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+            Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+            ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+              Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)
+  let DA := normalSquareVerticalTranslatedEdge_blockingDatum_interior
+      (κ := regionInjectivityDataOf A) hA hUA hx0 hy0 hxw hyh
+  let DB := normalSquareVerticalTranslatedEdge_blockingDatum_interior
+      (κ := regionInjectivityDataOf B) hB hUB hx0 hy0 hxw hyh
+  have hDAred : DA.red = normalSquareVerticalTranslatedEdgeRed xStart yStart := rfl
+  have hDAblue : DA.blue = normalSquareVerticalTranslatedEdgeBlue xStart yStart := rfl
+  have hred : DA.red = DB.red := rfl
+  have hblue : DA.blue = DB.blue := rfl
+  have hcompl : DA.complement = DB.complement := rfl
+  have hsingle : ∀ g, IsCrossingEdge (G := squareLatticeGraph width height) A DA.red DA.blue g
+      ↔ g = e := by
+    intro g
+    rw [hDAred, hDAblue]
+    exact isCrossingEdge_normalSquareVerticalTranslatedEdge (width := width) (height := height)
+      A (xStart := xStart) (yStart := yStart) hew heh g
+  have hRB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B DA.red := by
+    rw [hred]; exact regionBlockedTensorInjective_red DB
+  have hCB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
+      (Finset.univ \ DA.red) := by
+    rw [hred]; exact regionBlockedTensorInjective_host DB hUB
+  obtain ⟨_, _, _, hEdge, Z, hZ⟩ :=
+    exists_regionEdgeGauge_of_blockingData (A := A) (B := B) (e := e) DA DB
+      hred hblue hcompl hbond hAB hd hposA hposB hsingle hRB hCB
+  exact ⟨hEdge, Z, _, hZ⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/SquareLatticeGraph.lean
+++ b/TNLean/PEPS/SquareLatticeGraph.lean
@@ -21,12 +21,29 @@ namespace PEPS
 /-- The coordinate vertex set is ordered lexicographically.  The project-level
 `Edge` type uses an ambient linear order to orient undirected graph edges, so
 this instance lets the square-lattice graph use the same edge type as the
-general PEPS development. -/
+general PEPS development.
+
+The decidable-equality field is pinned to the canonical product decidable
+equality `instDecidableEqProd` rather than the comparison-derived one that
+`LinearOrder.lift'` would synthesize.  The square-lattice geometry layer builds
+its blocking data over the product decidable equality, while the per-edge gauge
+interface synthesizes a decidable equality from this linear order; pinning the
+field makes the two definitionally equal, so an interior blocking datum feeds the
+gauge interface with no subsingleton transport.  All other order fields are taken
+from `LinearOrder.lift'`, so the lexicographic comparison is unchanged. -/
 instance instLinearOrderSquareLatticeVertex (width height : ℕ) :
     LinearOrder (SquareLatticeVertex width height) :=
-  LinearOrder.lift' (fun v : SquareLatticeVertex width height => toLex v) (by
-    intro v w h
-    simpa using congrArg ofLex h)
+  let src : LinearOrder (SquareLatticeVertex width height) :=
+    LinearOrder.lift' (fun v : SquareLatticeVertex width height => toLex v) (by
+      intro v w h
+      simpa using congrArg ofLex h)
+  @Function.Injective.linearOrder _ _ _ src.toLE src.toLT src.toMax src.toMin src.toOrd
+    instDecidableEqProd src.toDecidableLE src.toDecidableLT
+    (fun v : SquareLatticeVertex width height => toLex v)
+    (fun v w h => by simpa using congrArg ofLex h)
+    (le := Iff.rfl) (lt := Iff.rfl)
+    (min := fun _ _ => rfl) (max := fun _ _ => rfl)
+    (compare := fun _ _ => rfl)
 
 /-- Horizontal nearest-neighbor relation in a finite rectangular square
 lattice.


### PR DESCRIPTION
## What

The per-edge gauge family of the Normal PEPS FT (#1373) at **every interior edge of the
square lattice, both orientations** — the V=W kernel (#2590) fed by the source's edge
geometry through the now-aligned instances:

- **The systemic DecidableEq fix** (SquareLatticeGraph.lean): the root cause was
  `LinearOrder.lift'` deriving its `toDecidableEq` from comparisons (not defeq to
  `instDecidableEqProd`). Rebuilt via `Function.Injective.linearOrder` with the product
  instance pinned — the two instances are now definitionally equal everywhere (`rfl`-verified),
  so the gauge interface consumes the geometry layer's data with no transport.
- **`exists_regionEdgeGauge_normalSquare{Horizontal,Vertical}TranslatedEdge`**
  (NormalEdgeGaugeFamily.lean): at each interior translated edge, A's and B's cover-free
  interior blocking data + the coordinate single-crossing + the union-closure host
  injectivity yield `∃ hEdge Z fwd, ∀ M, fwd M = Z·(reindex M)·Z⁻¹`. No single-vertex
  injectivity anywhere.
- `transportBlockingData` (a reusable instance-transport utility) + host-injectivity lemmas.

All sorry-free; `#print axioms` = `[propext, Classical.choice, Quot.sound]`; full root build
green (8,844 jobs).

## Honest deltas (pre-existing open obligations, documented)

- **Interior scope**: gauges at interior edges (frame margins); the TI layer wants all edges.
- **The orientation-uniform reduction** (route-note obligation 6): selecting one X/one Y
  needs gauge uniqueness-up-to-scalar — the next development.

Refs #1373. CI `blueprint-and-prose`/`track`/`claude-review-*` failures are non-blocking
automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New formal proofs on the normal PEPS FT path with a subtle type-class instance change; mathematical scope is explicitly interior-only, not full lattice coverage yet.
> 
> **Overview**
> Adds the **interior square-lattice per-edge gauge family** for two same-state normal PEPS: new module `NormalEdgeGaugeFamily.lean` (root-imported) proves horizontal and vertical translated interior edges admit bond-dimension equality and matrix transfer as **conjugation by an invertible gauge** via interior blocking data and `exists_regionEdgeGauge_of_blockingData`.
> 
> **DecidableEq alignment:** `instLinearOrderSquareLatticeVertex` is rebuilt so `toDecidableEq` is **definitionally** the product instance (`instDecidableEqProd`), letting geometry-layer blocking data plug into the gauge API without instance mismatch.
> 
> **Supporting lemmas:** `transportBlockingData` (+ simp for red/blue/complement) in `CoherentFrameInstance2.lean`; host-region injectivity helpers (`blockingData_univ_sdiff_red`, `regionBlockedTensorInjective_host`) in the new file.
> 
> Documented scope: **interior edges only** (margin predicates); boundary edges and orientation-uniform / all-edge families remain follow-on work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa79a520742ed445ed6732bc52799277b1544a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->