### PR TITLE
feat(PEPS): gauge uniqueness up to scalar and the mod-scalar orientation-uniform assembly

### DIFF
--- a/TNLean/PEPS/NormalEdgeGaugeFamily.lean
+++ b/TNLean/PEPS/NormalEdgeGaugeFamily.lean
@@ -1,6 +1,7 @@
 import TNLean.PEPS.NormalEdgeBlockingInterior
 import TNLean.PEPS.NormalEdgeSingleCrossing
 import TNLean.PEPS.CoherentFrameInstance2
+import TNLean.Algebra.ScalarCommutant
 
 /-!
 # The per-edge gauge family at the interior edges of the square lattice
@@ -86,6 +87,76 @@ theorem regionBlockedTensorInjective_host {V : Type*} [Fintype V] [DecidableEq V
   rw [blockingData_univ_sdiff_red DB]
   have hi := hUB.union_injective DB.blue_injective DB.complement_injective
   rwa [regionInjectivityDataOf_isInjective] at hi
+
+/-! ### Uniqueness of the per-edge gauge up to a scalar
+
+The gauge realizing the forward per-edge transfer as conjugation is determined up
+to a multiplicative constant.  If two invertible matrices `Z` and `Z'` conjugate
+every bond matrix to the same value, then `Z⁻¹Z'` commutes with the whole bond
+matrix algebra, hence is a scalar (`Matrix.isScalar_of_commute_span_eq_top`,
+the center of the full matrix algebra is the scalars), so `Z'` and `Z` differ by
+a nonzero scalar.  This is the source's *"`X` and `Y` are unique up to a
+multiplicative constant"* (arXiv:1804.04964, Section 3, Theorem 3) at the level of
+a single edge.  It is the algebraic input to the orientation-uniform selection. -/
+
+/-- **Uniqueness up to scalar of a conjugating matrix.**
+
+If two invertible matrices `Z` and `Z'` of the same size induce the same
+conjugation map `N ↦ Z N Z⁻¹ = Z' N Z'⁻¹` on every matrix `N`, then they differ by
+a nonzero scalar: `Z' = c • Z` for some `c : ℂˣ`.  The matrix `Z⁻¹Z'` commutes with
+every `N`, so it lies in the center of the full matrix algebra, which is the
+scalar matrices.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3 ("`X` and `Y` are unique up to a
+multiplicative constant"), the per-edge centralizer step. -/
+theorem gl_conj_unique_scalar {n : ℕ} (Z Z' : GL (Fin n) ℂ)
+    (h : ∀ N : Matrix (Fin n) (Fin n) ℂ,
+      (Z : Matrix (Fin n) (Fin n) ℂ) * N * (↑Z⁻¹ : Matrix (Fin n) (Fin n) ℂ) =
+        (Z' : Matrix (Fin n) (Fin n) ℂ) * N * (↑Z'⁻¹ : Matrix (Fin n) (Fin n) ℂ)) :
+    ∃ c : ℂˣ, (Z' : Matrix (Fin n) (Fin n) ℂ) = (c : ℂ) • (Z : Matrix (Fin n) (Fin n) ℂ) := by
+  set Zm : Matrix (Fin n) (Fin n) ℂ := (↑Z : Matrix (Fin n) (Fin n) ℂ) with hZm
+  set Zim : Matrix (Fin n) (Fin n) ℂ := (↑Z⁻¹ : Matrix (Fin n) (Fin n) ℂ) with hZim
+  set Z'm : Matrix (Fin n) (Fin n) ℂ := (↑Z' : Matrix (Fin n) (Fin n) ℂ) with hZ'm
+  set Z'im : Matrix (Fin n) (Fin n) ℂ := (↑Z'⁻¹ : Matrix (Fin n) (Fin n) ℂ) with hZ'im
+  have hZZi : Zm * Zim = 1 := by
+    rw [hZm, hZim, ← Units.val_mul, mul_inv_cancel, Units.val_one]
+  have hZiZ : Zim * Zm = 1 := by
+    rw [hZm, hZim, ← Units.val_mul, inv_mul_cancel, Units.val_one]
+  have hZ'iZ' : Z'im * Z'm = 1 := by
+    rw [hZ'm, hZ'im, ← Units.val_mul, inv_mul_cancel, Units.val_one]
+  -- `W := Z⁻¹ Z'` commutes with every matrix.
+  set W : Matrix (Fin n) (Fin n) ℂ := Zim * Z'm with hW
+  have hcomm : ∀ N ∈ (Set.univ : Set (Matrix (Fin n) (Fin n) ℂ)), W * N = N * W := by
+    intro N _
+    have hN : N = Zim * (Z'm * N * Z'im) * Zm := by
+      rw [← h N]
+      rw [show Zim * (Zm * N * Zim) * Zm = (Zim * Zm) * N * (Zim * Zm) by
+        simp [Matrix.mul_assoc], hZiZ, Matrix.one_mul, Matrix.mul_one]
+    calc W * N = Zim * (Z'm * N) := by rw [hW, Matrix.mul_assoc]
+      _ = Zim * (Z'm * N * Z'im) * Z'm := by
+            rw [show Zim * (Z'm * N * Z'im) * Z'm = Zim * (Z'm * N) * (Z'im * Z'm) by
+              simp [Matrix.mul_assoc], hZ'iZ', Matrix.mul_one]
+      _ = Zim * (Z'm * N * Z'im) * (Zm * Zim) * Z'm := by rw [hZZi, Matrix.mul_one]
+      _ = (Zim * (Z'm * N * Z'im) * Zm) * (Zim * Z'm) := by simp [Matrix.mul_assoc]
+      _ = N * W := by rw [← hN, hW]
+  obtain ⟨c, hc⟩ := Matrix.isScalar_of_commute_span_eq_top W
+    (S := Set.univ) (by rw [Submodule.span_univ]) hcomm
+  have hscal : (Matrix.scalar (Fin n)) c = c • (1 : Matrix (Fin n) (Fin n) ℂ) := by
+    rw [← Algebra.algebraMap_eq_smul_one]; rfl
+  have hWunit : IsUnit W := by
+    rw [hW, hZim, hZ'm]; exact (Z⁻¹).isUnit.mul Z'.isUnit
+  -- The scalar is nonzero: when the bond space is empty pick `1`, else use `det W`.
+  rcases isEmpty_or_nonempty (Fin n) with hempty | hne
+  · exact ⟨1, by simp only [Units.val_one, one_smul]; exact Subsingleton.elim _ _⟩
+  · have hc0 : c ≠ 0 := by
+      rintro rfl
+      rw [hc, hscal, zero_smul] at hWunit
+      rw [Matrix.isUnit_iff_isUnit_det, Matrix.det_zero hne] at hWunit
+      exact not_isUnit_zero hWunit
+    refine ⟨Units.mk0 c hc0, ?_⟩
+    have hZ'mZmW : Z'm = Zm * W := by
+      rw [hW, ← Matrix.mul_assoc, hZZi, Matrix.one_mul]
+    rw [hZ'mZmW, hc, hscal, Matrix.mul_smul, Matrix.mul_one, Units.val_mk0]
 
 open scoped Classical in
 /-- **The per-edge gauge at a translated horizontal interior edge.**

--- a/TNLean/PEPS/NormalEdgeGaugeFamily.lean
+++ b/TNLean/PEPS/NormalEdgeGaugeFamily.lean
@@ -158,6 +158,35 @@ theorem gl_conj_unique_scalar {n : ℕ} (Z Z' : GL (Fin n) ℂ)
       rw [hW, ← Matrix.mul_assoc, hZZi, Matrix.one_mul]
     rw [hZ'mZmW, hc, hscal, Matrix.mul_smul, Matrix.mul_one, Units.val_mk0]
 
+/-- **Uniqueness up to scalar of the per-edge gauge.**
+
+Two gauges `Z` and `Z'` realizing the *same* forward per-edge transfer map `fwd`
+on one edge --- where `fwd M = Z · (reindex M) · Z⁻¹ = Z' · (reindex M) · Z'⁻¹`
+across the bond-dimension equalities `hE` and `hE'` --- differ by a nonzero
+scalar.  The reindexing is an algebra equivalence, hence surjective, so the two
+conjugation maps agree on every target bond matrix; `gl_conj_unique_scalar` then
+gives the scalar.
+
+This is the source's *"`X` and `Y` are unique up to a multiplicative constant"*
+(arXiv:1804.04964, Section 3, Theorem 3) applied at a single edge: the per-edge
+gauge produced by
+`exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge` (and its vertical
+counterpart) is determined by its transfer map up to a scalar. -/
+theorem edgeGauge_unique_scalar {a b : ℕ} (hE hE' : a = b) (Z Z' : GL (Fin b) ℂ)
+    (h : ∀ M : Matrix (Fin a) (Fin a) ℂ,
+        (Z : Matrix (Fin b) (Fin b) ℂ) * Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+            (↑Z⁻¹ : Matrix (Fin b) (Fin b) ℂ) =
+          (Z' : Matrix (Fin b) (Fin b) ℂ) * Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE') M *
+            (↑Z'⁻¹ : Matrix (Fin b) (Fin b) ℂ)) :
+    ∃ c : ℂˣ, (Z' : Matrix (Fin b) (Fin b) ℂ) = (c : ℂ) • (Z : Matrix (Fin b) (Fin b) ℂ) := by
+  refine gl_conj_unique_scalar Z Z' ?_
+  intro N
+  -- `reindexAlgEquiv` is surjective: every target matrix `N` is some `reindex M`.
+  -- The proofs `hE` and `hE'` are equal by proof irrelevance, so both reindexings
+  -- along them coincide and `h M` closes the goal directly.
+  obtain ⟨M, rfl⟩ := (Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE)).surjective N
+  exact h M
+
 open scoped Classical in
 /-- **The per-edge gauge at a translated horizontal interior edge.**
 

--- a/TNLean/PEPS/NormalSquareFundamentalTheorem.lean
+++ b/TNLean/PEPS/NormalSquareFundamentalTheorem.lean
@@ -131,5 +131,51 @@ theorem fundamentalTheorem_normalSquarePEPS
     lam ^ (width * height) = 1 :=
   lambda_pow_card_eq_one A B hA hpos hAB dataAbs.gauge hbd lam hPV
 
+/-- **Translation-invariant normal PEPS Fundamental Theorem (square lattice), from a
+scalar-carrying orientation-uniform gauge.**
+
+The same assembly as `fundamentalTheorem_normalSquarePEPS`, but consuming the gauge
+in the shape the edge blocking actually delivers: an orientation-uniform gauge `Z`
+fixed only up to vertex-balanced per-edge scalars (the per-edge multiplicative
+freedom of the uniqueness-up-to-scalar step).  The balanced scalars absorb into the
+same tensor, so the exact orientation-uniform reference assembled from `Z` carries
+`Z`'s post-absorption equality, and the per-vertex single-scalar relation against
+that reference forces `λ^{width·height} = 1`.
+
+This wires the uniqueness-up-to-scalar output (remaining obligation 6 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`) directly into the conditional
+square-lattice theorem.  It remains conditional on the open per-edge gauge of
+obligation 5 (the gauge `Z`, its post-absorption equality, and the per-vertex
+relation are the kernel inputs).
+
+Source: arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalSquarePEPS_of_modScalarGauge
+    (A B : Tensor (squareLatticeGraph width height) d) {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim B.bondDim Dh Dv)
+    (hA : IsVertexInjective A)
+    (hpos : ∀ e : Edge (squareLatticeGraph width height), 0 < A.bondDim e)
+    (hAB : SameState A B)
+    (hbd : A.bondDim = B.bondDim)
+    (Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    (c : Edge (squareLatticeGraph width height) → ℂˣ)
+    (hc : IsVertexBalanced (G := squareLatticeGraph width height) c)
+    (hZ : ∀ e : Edge (squareLatticeGraph width height),
+      (Z e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) =
+        (c e : ℂ) • (orientationUniformGauge huni Xh Xv e :
+          Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ))
+    (hPA : PostAbsorptionEdgeInsertionEquality A (absorbEdgeGauges B Z))
+    (lam : ℂ)
+    (hPV : ∀ (v : SquareLatticeVertex width height)
+      (η : (ie : IncidentEdge (squareLatticeGraph width height) v) → Fin (A.bondDim ie.1))
+      (σ : Fin d),
+      A.component v η σ =
+        lam * gaugeVertex B (orientationUniformGauge huni Xh Xv) v
+          (fun ie => Fin.cast (congr_fun hbd ie.1) (η ie)) σ) :
+    lam ^ (width * height) = 1 :=
+  fundamentalTheorem_normalSquarePEPS A B huni hA hpos hAB hbd
+    (tiNormalGaugeAbsorptionData_of_modScalar A B huni Z Xh Xv c hc hZ hPA) lam hPV
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/NormalSquareTI.lean
+++ b/TNLean/PEPS/NormalSquareTI.lean
@@ -208,5 +208,94 @@ theorem exists_orientationUniformGaugeFamily
   ⟨orientationUniformGauge huni Xh Xv,
     isOrientationUniformGaugeFamily_orientationUniformGauge huni Xh Xv⟩
 
+/-! ### Orientation uniformity up to per-edge scalars
+
+The per-edge gauges produced by the edge blocking are determined only up to a
+multiplicative constant on each edge (`edgeGauge_unique_scalar`). The reduction
+to one horizontal and one vertical matrix therefore holds only *up to per-edge
+scalars*: each per-edge gauge equals the transported orientation matrix rescaled
+by a nonzero constant. This scalar-carrying form is the faithful target produced
+by the uniqueness-up-to-scalar step; the per-edge scalars are the residual
+multiplicative freedom the source records as "`X` and `Y` are unique up to a
+multiplicative constant". -/
+
+/-- A per-edge gauge family `X` is **orientation uniform up to scalars** when
+there are a single horizontal matrix, a single vertical matrix, and a per-edge
+nonzero scalar `c` such that on every edge `X e` is the transported orientation
+matrix rescaled by `c e`. The per-edge scalars are the residual multiplicative
+freedom; without them this is `IsOrientationUniformGaugeFamily`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex` ("the same matrix `X` (`Y`) on all
+horizontal (vertical) edges"), together with Theorem 3's uniqueness up to a
+multiplicative constant. -/
+def IsOrientationUniformGaugeFamilyModScalar
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim bondDim Dh Dv)
+    (X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (bondDim e)) ℂ) : Prop :=
+  ∃ (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    (c : Edge (squareLatticeGraph width height) → ℂˣ),
+    ∀ e : Edge (squareLatticeGraph width height),
+      (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (c e : ℂ) • (orientationUniformGauge huni Xh Xv e :
+          Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ)
+
+/-- An orientation-uniform gauge family is orientation uniform up to scalars,
+with all scalars equal to one. -/
+theorem isOrientationUniformGaugeFamilyModScalar_of_isOrientationUniform
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    {huni : SquareLatticeUniformBondDim bondDim Dh Dv}
+    {X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (bondDim e)) ℂ}
+    (hX : IsOrientationUniformGaugeFamily huni X) :
+    IsOrientationUniformGaugeFamilyModScalar huni X := by
+  obtain ⟨Xh, Xv, rfl⟩ := hX
+  exact ⟨Xh, Xv, fun _ => 1, fun e => by simp⟩
+
+/-- **Orientation-uniform selection up to scalars.**
+
+Suppose every per-edge gauge agrees, up to a nonzero scalar, with one reference
+horizontal matrix on horizontal edges and one reference vertical matrix on
+vertical edges --- the per-edge content delivered by `edgeGauge_unique_scalar`
+across each orientation class under translation invariance. Then the whole gauge
+family is orientation uniform up to scalars.
+
+This is the assembly step of the source's line-1498 reduction: it gathers the
+per-edge "agree up to a constant" facts of the two orientation classes into one
+orientation-uniform-up-to-scalar family. The hypotheses `hH` and `hV` are exactly
+the per-edge conclusions of `edgeGauge_unique_scalar` applied at every edge of
+each class against the transported reference, with the scalars `cH e`, `cV e`
+collected into a single per-edge scalar.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isOrientationUniformGaugeFamilyModScalar_of_classAgreement
+    {bondDim : Edge (squareLatticeGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim bondDim Dh Dv)
+    (X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (bondDim e)) ℂ)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    (cH cV : Edge (squareLatticeGraph width height) → ℂˣ)
+    (hH : ∀ (e : Edge (squareLatticeGraph width height))
+        (he : IsHorizontalSquareLatticeEdge e),
+      (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (cH e : ℂ) • (glReindex (huni.horizontal he).symm Xh :
+          Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ))
+    (hV : ∀ (e : Edge (squareLatticeGraph width height))
+        (he : IsVerticalSquareLatticeEdge e),
+      (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (cV e : ℂ) • (glReindex (huni.vertical he).symm Xv :
+          Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ)) :
+    IsOrientationUniformGaugeFamilyModScalar huni X := by
+  classical
+  refine ⟨Xh, Xv, fun e => if IsHorizontalSquareLatticeEdge e then cH e else cV e, ?_⟩
+  intro e
+  simp only
+  by_cases he : IsHorizontalSquareLatticeEdge e
+  · rw [if_pos he, orientationUniformGauge_horizontal huni Xh Xv he]
+    exact hH e he
+  · have hv : IsVerticalSquareLatticeEdge e :=
+      (squareLatticeEdge_horizontal_or_vertical e).resolve_left he
+    rw [if_neg he, orientationUniformGauge_vertical huni Xh Xv hv]
+    exact hV e hv
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/NormalSquareTIAbsorption.lean
+++ b/TNLean/PEPS/NormalSquareTIAbsorption.lean
@@ -1,5 +1,6 @@
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.FundamentalTheorem
+import TNLean.PEPS.FundamentalTheorem.Uniqueness
 
 /-!
 # Absorbing the translation-invariant edge gauges on the square lattice
@@ -178,6 +179,85 @@ theorem exists_postAbsorption_of_vertexInjective
     ∃ Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ,
       PostAbsorptionEdgeInsertionEquality A (absorbEdgeGauges B Z) :=
   post_absorption_edge_insertion_equality A B hA hB hAB hDim hpos
+
+/-! ### Absorbing the per-edge scalars
+
+The per-edge gauges are determined only up to a multiplicative constant on each
+edge (`edgeGauge_unique_scalar`), so the orientation-uniform reduction produces an
+orientation-uniform family only *up to per-edge scalars*. When those scalars are
+vertex-balanced --- their oriented product around every vertex is one --- the
+scalar-rescaled gauge family and the underlying exact orientation-uniform family
+absorb into the *same* tensor.  This is the absorption-side reflection of the fact
+that a balanced edge-scalar reweighting leaves every local gauged tensor
+unchanged (`GaugeEquivModEdgeScalars.applyGauge_eq`); it lets the conditional
+square-lattice theorem consume an exact orientation-uniform gauge even though the
+edge blocking delivers one only up to balanced scalars.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 and lines
+1500--1519 of `Papers/1804.04964/paper_normal.tex`; the per-edge multiplicative
+freedom is the source's "`X` and `Y` are unique up to a multiplicative constant". -/
+
+section ScalarAbsorption
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj]
+
+/-- A per-edge scalar rescaling of a gauge family is a balanced-edge-scalar
+reweighting of it.  If `Z e` has matrix `c e • (Y e)` on every edge, with `c`
+vertex-balanced, then `Z` and `Y` are equivalent modulo balanced edge scalars.
+
+The proof is the matrix-level reading used in `gauge_unique_mod_edge_scalars`: the
+lower endpoint carries `c e`, the upper endpoint carries `(c e)⁻¹` through the
+transposed inverse, which is exactly `edgeScalarAt c`.
+
+Source: `docs/paper-gaps/peps_gauge_edge_scalars.tex`; the balanced edge-scalar
+quotient of the per-edge gauges. -/
+theorem gaugeEquivModEdgeScalars_of_matrixScalar (B : Tensor G d)
+    (Z Y : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
+    (c : (e : Edge G) → ℂˣ) (hc : IsVertexBalanced (G := G) c)
+    (hZY : ∀ e : Edge G,
+      (Z e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) =
+        (c e : ℂ) • (Y e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)) :
+    GaugeEquivModEdgeScalars (G := G) B Z Y := by
+  -- Inverse gauges carry the inverse scalar, exactly as in the uniqueness proof.
+  have hZYinv : ∀ e : Edge G,
+      ((Z e)⁻¹).val = ((c e)⁻¹ : ℂ) • ((Y e)⁻¹).val := by
+    intro e
+    have hcne : (c e : ℂ) ≠ 0 := (c e).ne_zero
+    have hYdet : IsUnit (Y e).val.det := (Matrix.isUnit_iff_isUnit_det _).mp (Y e).isUnit
+    rw [Matrix.coe_units_inv, Matrix.coe_units_inv]
+    refine Matrix.inv_eq_right_inv ?_
+    rw [hZY e, Matrix.smul_mul, Matrix.mul_smul, smul_smul,
+      mul_inv_cancel₀ hcne, one_smul, Matrix.mul_nonsing_inv _ hYdet]
+  refine ⟨c, hc, ?_⟩
+  intro v ie
+  unfold edgeScalarAt edgeGaugeAt
+  by_cases h : ie.1.1.1 = v
+  · simp only [if_pos h]; rw [hZY ie.1]
+  · simp only [if_neg h]
+    rw [hZYinv ie.1, Matrix.transpose_smul, Units.val_inv_eq_inv_val]
+
+/-- A balanced per-edge scalar rescaling absorbs identically: if `Z e` has matrix
+`c e • (Y e)` with `c` vertex-balanced, then `absorbEdgeGauges B Z =
+absorbEdgeGauges B Y`.
+
+This discharges the per-edge multiplicative freedom of the orientation-uniform
+reduction at the absorption step: the scalar-carrying gauge and the exact
+orientation-uniform gauge produce the same modified tensor.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1500--1519 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem absorbEdgeGauges_eq_of_matrixScalar (B : Tensor G d)
+    (Z Y : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
+    (c : (e : Edge G) → ℂˣ) (hc : IsVertexBalanced (G := G) c)
+    (hZY : ∀ e : Edge G,
+      (Z e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) =
+        (c e : ℂ) • (Y e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)) :
+    absorbEdgeGauges B Z = absorbEdgeGauges B Y :=
+  GaugeEquivModEdgeScalars.applyGauge_eq (G := G)
+    (gaugeEquivModEdgeScalars_of_matrixScalar B Z Y c hc hZY)
+
+end ScalarAbsorption
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/NormalSquareTIAbsorption.lean
+++ b/TNLean/PEPS/NormalSquareTIAbsorption.lean
@@ -259,5 +259,48 @@ theorem absorbEdgeGauges_eq_of_matrixScalar (B : Tensor G d)
 
 end ScalarAbsorption
 
+/-! ### Feeding the conditional square-lattice theorem from a scalar-carrying gauge
+
+The conditional theorem `fundamentalTheorem_normalSquarePEPS` consumes a gauge
+absorption datum built on an *exact* orientation-uniform gauge.  The edge blocking
+delivers only an orientation-uniform-up-to-scalar gauge.  When the per-edge scalars
+are vertex balanced, the two absorb into the same tensor, so the exact
+orientation-uniform reference inherits the scalar-carrying gauge's post-absorption
+equality and assembles the datum the theorem expects. -/
+
+/-- **Gauge-absorption datum from a balanced scalar-carrying orientation-uniform
+gauge.**
+
+Given a gauge family `Z` that is orientation uniform up to vertex-balanced per-edge
+scalars and whose absorption satisfies the post-absorption edge-insertion equality,
+the exact orientation-uniform reference `Y = orientationUniformGauge Xh Xv`
+extracted from `Z` carries the same absorbed tensor (the balanced scalars absorb
+identically), hence the same post-absorption equality, and so assembles a
+`TINormalGaugeAbsorptionData A B huni` --- the input of
+`fundamentalTheorem_normalSquarePEPS`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1500--1519 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def tiNormalGaugeAbsorptionData_of_modScalar
+    (A B : Tensor (squareLatticeGraph width height) d) {Dh Dv : ℕ}
+    (huni : SquareLatticeUniformBondDim B.bondDim Dh Dv)
+    (Z : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    (c : Edge (squareLatticeGraph width height) → ℂˣ)
+    (hc : IsVertexBalanced (G := squareLatticeGraph width height) c)
+    (hZ : ∀ e : Edge (squareLatticeGraph width height),
+      (Z e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) =
+        (c e : ℂ) • (orientationUniformGauge huni Xh Xv e :
+          Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ))
+    (hPA : PostAbsorptionEdgeInsertionEquality A (absorbEdgeGauges B Z)) :
+    TINormalGaugeAbsorptionData A B huni where
+  gauge := orientationUniformGauge huni Xh Xv
+  gauge_uniform := isOrientationUniformGaugeFamily_orientationUniformGauge huni Xh Xv
+  post_absorption := by
+    have heq : absorbEdgeGauges B Z =
+        absorbEdgeGauges B (orientationUniformGauge huni Xh Xv) :=
+      absorbEdgeGauges_eq_of_matrixScalar B Z (orientationUniformGauge huni Xh Xv) c hc hZ
+    rwa [heq] at hPA
+
 end PEPS
 end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1512,11 +1512,7 @@ The remaining obligations are the following.
           an orientation-uniform family into the second tensor, preserving the
           orientation-uniform bond dimensions and vertex injectivity; the
           post-absorption edge-insertion equality is taken as the conditional kernel
-          input, in the shape produced unconditionally in the vertex-injective case.
-          What remains open is the selection of \emph{which} horizontal and vertical
-          matrices reproduce the per-edge gauges supplied by the blocking, which is
-          the source's uniqueness-up-to-scalar statement and depends on the open
-          per-edge gauge of obligation~5.\footnote{
+          input, in the shape produced unconditionally in the vertex-injective case.\footnote{
           Formal declarations:
           \leanid{TNLean.PEPS.SquareLatticeUniformBondDim},
           \leanid{TNLean.PEPS.orientationUniformGauge},
@@ -1526,6 +1522,62 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.isVertexInjective_tiAbsorb},
           \leanid{TNLean.PEPS.tiNormalGaugeAbsorption}, and
           \leanid{TNLean.PEPS.exists_postAbsorption_of_vertexInjective}.}
+
+          The uniqueness-up-to-scalar step is now formalized. The conjugating
+          matrix realizing a forward per-edge transfer is determined up to a
+          multiplicative constant: if two invertible matrices induce the same
+          conjugation on every bond matrix then their quotient commutes with the
+          whole bond matrix algebra, hence lies in its center, the scalars, so the
+          two differ by a nonzero constant. Reading this through the bond-dimension
+          reindexing gives the same statement for the per-edge transfer map of an
+          edge: two gauges with the same transfer map differ by a constant. This is
+          the source's statement that the horizontal and vertical matrices are unique
+          up to a multiplicative constant, at the level of a single edge.\footnote{
+          Formal declarations:
+          \leanid{TNLean.PEPS.gl_conj_unique_scalar} and
+          \leanid{TNLean.PEPS.edgeGauge_unique_scalar}.}
+
+          Because each per-edge gauge is fixed only up to a constant, the reduction
+          to one horizontal and one vertical matrix holds only up to a per-edge
+          scalar: a gauge family is orientation uniform up to scalars when each edge
+          gauge is the transported reference matrix rescaled by a nonzero per-edge
+          constant. The assembly across the two orientation classes is formalized:
+          collecting, on each class, the per-edge ``agree with the reference up to a
+          constant'' facts produces one orientation-uniform-up-to-scalar family, with
+          the exact orientation-uniform family as the all-constants-one
+          specialization.\footnote{
+          Formal declarations:
+          \leanid{TNLean.PEPS.IsOrientationUniformGaugeFamilyModScalar},
+          \leanid{TNLean.PEPS.isOrientationUniformGaugeFamilyModScalar_of_isOrientationUniform},
+          and
+          \leanid{TNLean.PEPS.isOrientationUniformGaugeFamilyModScalar_of_classAgreement}.}
+
+          The per-edge constants are absorbed at the absorption step when they are
+          vertex balanced. A per-edge scalar rescaling whose oriented product around
+          every vertex is one is a balanced edge-scalar reweighting, and such a
+          reweighting leaves the absorbed tensor unchanged. Hence the
+          scalar-carrying orientation-uniform gauge and the underlying exact
+          orientation-uniform gauge incorporate into the same modified second tensor,
+          so the conditional square-lattice theorem may consume an exact
+          orientation-uniform gauge even though the blocking delivers one only up to
+          balanced constants.\footnote{
+          Formal declarations:
+          \leanid{TNLean.PEPS.gaugeEquivModEdgeScalars_of_matrixScalar} and
+          \leanid{TNLean.PEPS.absorbEdgeGauges_eq_of_matrixScalar}.}
+
+          What remains open is the class-agreement input itself: that on each
+          orientation class the per-edge transfer maps coincide after transport,
+          which is where translation invariance enters. The per-edge transfer map is
+          built from the inserted coefficients in the edge's blocking window; on a
+          translation-invariant lattice these coincide across translates of the same
+          orientation, so the transfer maps agree after transport and the per-edge
+          uniqueness above supplies the constants. Formalizing this transport needs
+          the periodic lattice on which translation is a graph automorphism: the
+          present open rectangular model has no such automorphism (its boundary
+          breaks translation, which is also why the every-edge blocking of
+          obligation~4 is restricted to interior edges), and the transfer machinery
+          would have to be shown covariant under it. This depends on the open
+          per-edge gauge of obligation~5 for the transfer maps themselves.
 
           The final region comparison setup is also formalized: a region and its set
           complement are wrapped as the two blocks consumed by the two-injective

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1600,12 +1600,20 @@ The remaining obligations are the following.
           $\lambda^{\,\text{width}\cdot\text{height}}=1$. The square-lattice theorem
           skeleton records the top-down assembly: from the orientation-uniform gauge
           absorption datum and the per-vertex single-scalar relation (the region
-          comparison output) the scalar condition follows. The skeleton remains
-          conditional on the open per-edge gauge of obligation~5.\footnote{
+          comparison output) the scalar condition follows. A second entry to the same
+          assembly consumes the gauge in the shape the edge blocking actually
+          delivers: an orientation-uniform gauge fixed only up to vertex-balanced
+          per-edge constants, which absorb identically, so the exact
+          orientation-uniform reference carries the post-absorption equality and the
+          per-vertex relation against it yields the same scalar condition. Both
+          skeletons remain conditional on the open per-edge gauge of
+          obligation~5.\footnote{
           Formal declarations:
           \leanid{TNLean.PEPS.card_squareLatticeVertex},
-          \leanid{TNLean.PEPS.lambda_pow_card_eq_one}, and
-          \leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS}.}
+          \leanid{TNLean.PEPS.lambda_pow_card_eq_one},
+          \leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS},
+          \leanid{TNLean.PEPS.tiNormalGaugeAbsorptionData_of_modScalar}, and
+          \leanid{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_of_modScalarGauge}.}
 \end{enumerate}
 
 \section{Source-to-formalization ledger}


### PR DESCRIPTION
## What

Obligation 6 of the Normal PEPS FT (#1373): the per-edge gauge's **uniqueness up to
scalar** and the **mod-scalar orientation-uniform assembly** feeding the square-lattice
theorem — the last mathematical layer above the merged per-edge gauge family (#2604).
All sorry-free; `#print axioms` = `[propext, Classical.choice, Quot.sound]`; full root
build green (8,844 jobs).

## Highlights

- **`gl_conj_unique_scalar`** / **`edgeGauge_unique_scalar`** — two invertible gauges
  inducing the same conjugation differ by `c : ℂˣ` (the scalar-commutant/center argument),
  in exactly the shape the merged per-edge gauges produce.
- **`IsOrientationUniformGaugeFamilyModScalar`** + the class-agreement assembler — the
  honest orientation-uniform target (per-edge gauges are fixed only up to a constant).
- **`gaugeEquivModEdgeScalars_of_matrixScalar`** / **`tiNormalGaugeAbsorptionData_of_modScalar`**
  — vertex-balanced per-edge rescalings absorb identically (reusing the balanced
  edge-scalar quotient), so a mod-scalar gauge yields the consumer's exact
  `TINormalGaugeAbsorptionData`.
- **`fundamentalTheorem_normalSquarePEPS_of_modScalarGauge`** — the end-to-end capstone:
  the square-lattice theorem consuming the gauge in the shape the edge blocking delivers,
  with `λ^{width·height}=1`.

## The structural finding (documented)

The repo has **no periodic lattice / PEPS translation-invariance predicate** — the
"translated" machinery is edge-window geometry only, and the open rectangular model's
boundary genuinely breaks translation (which is also why the every-edge blocking is
interior-only). The remaining input — class-agreement of the per-edge transfer maps —
requires the periodic-lattice infrastructure (graph automorphisms + translation
covariance of the transfer machinery), recorded as the route note's remaining obligation.
The theorems stay honestly conditional; no blueprint flips.

Refs #1373. CI `blueprint-and-prose`/`track`/`claude-review-*` failures are non-blocking
automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation on the PEPS proof route; no runtime, auth, or infrastructure changes.
> 
> **Overview**
> Formalizes **obligation 6** of the normal PEPS FT route: per-edge gauges are unique up to a scalar, and that freedom is wired through orientation-uniform assembly, absorption, and the conditional square-lattice theorem.
> 
> **`gl_conj_unique_scalar`** and **`edgeGauge_unique_scalar`** show two invertible gauges with the same conjugation action on bond matrices differ by a nonzero `ℂˣ` scalar, using the matrix-algebra center (`ScalarCommutant`).
> 
> **`IsOrientationUniformGaugeFamilyModScalar`** and **`isOrientationUniformGaugeFamilyModScalar_of_classAgreement`** express “one horizontal / one vertical matrix” only up to per-edge constants. When those constants are **vertex-balanced**, **`absorbEdgeGauges_eq_of_matrixScalar`** and **`tiNormalGaugeAbsorptionData_of_modScalar`** show they do not change the absorbed tensor, so an exact orientation-uniform reference still satisfies post-absorption equality.
> 
> **`fundamentalTheorem_normalSquarePEPS_of_modScalarGauge`** is a second entry to the same `λ^{width·height}=1` conclusion using the gauge shape edge blocking is expected to deliver. The route note is updated: uniqueness and mod-scalar absorption are recorded; **class-agreement of per-edge transfer maps under translation** (periodic lattice / obligation 5) remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87faac295276b34f99edd7214a94406637b73732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->