### PR TITLE
feat(PEPS): the periodic lattice, translation automorphisms, and the faithful TI predicate

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -395,6 +395,7 @@ import TNLean.PEPS.NormalBlocking
 import TNLean.PEPS.NormalEdgeGauge
 import TNLean.PEPS.RegionBlock.Insertion
 import TNLean.PEPS.SquareLatticeGraph
+import TNLean.PEPS.TorusLatticeGraph
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -396,6 +396,7 @@ import TNLean.PEPS.NormalEdgeGauge
 import TNLean.PEPS.RegionBlock.Insertion
 import TNLean.PEPS.SquareLatticeGraph
 import TNLean.PEPS.TorusLatticeGraph
+import TNLean.PEPS.TorusTranslation
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -397,6 +397,7 @@ import TNLean.PEPS.RegionBlock.Insertion
 import TNLean.PEPS.SquareLatticeGraph
 import TNLean.PEPS.TorusLatticeGraph
 import TNLean.PEPS.TorusTranslation
+import TNLean.PEPS.IsoTransport
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -398,6 +398,7 @@ import TNLean.PEPS.SquareLatticeGraph
 import TNLean.PEPS.TorusLatticeGraph
 import TNLean.PEPS.TorusTranslation
 import TNLean.PEPS.IsoTransport
+import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean/PEPS/Defs.lean
+++ b/TNLean/PEPS/Defs.lean
@@ -32,6 +32,47 @@ abbrev Edge (G : SimpleGraph V) : Type _ :=
 instance instFintypeEdge (G : SimpleGraph V) [DecidableRel G.Adj] : Fintype (Edge G) :=
   inferInstance
 
+/-- The edge of `G` on an adjacent pair `(u, v)`, with the endpoints reordered into
+the `Edge` convention `·.1 < ·.2`.  Adjacency forbids `u = v`, so exactly one of
+`u < v` and `v < u` holds; the smaller endpoint is placed first.  This normalizes an
+unordered adjacent pair into the ordered-endpoint `Edge` representation, the operation
+needed to push an edge through a vertex bijection (such as a translation), where the
+bijection may swap the lexicographic order of the two endpoints. -/
+def Edge.ofAdj {G : SimpleGraph V} {u v : V} (h : G.Adj u v) : Edge G :=
+  if huv : u < v then
+    ⟨(u, v), huv, h⟩
+  else
+    ⟨(v, u), lt_of_le_of_ne (not_lt.mp huv) (G.ne_of_adj h).symm, h.symm⟩
+
+omit [Fintype V] in
+/-- On a pair already in order (`u < v`), `Edge.ofAdj` keeps the endpoints as given. -/
+theorem Edge.ofAdj_of_lt {G : SimpleGraph V} {u v : V} (h : G.Adj u v) (huv : u < v) :
+    Edge.ofAdj h = ⟨(u, v), huv, h⟩ := by
+  rw [Edge.ofAdj, dif_pos huv]
+
+omit [Fintype V] in
+/-- On a pair in reverse order (`v < u`), `Edge.ofAdj` swaps the endpoints. -/
+theorem Edge.ofAdj_of_gt {G : SimpleGraph V} {u v : V} (h : G.Adj u v) (hvu : v < u) :
+    Edge.ofAdj h =
+      ⟨(v, u), hvu, h.symm⟩ := by
+  rw [Edge.ofAdj, dif_neg (not_lt.mpr hvu.le)]
+
+omit [Fintype V] in
+/-- The unordered endpoint set of `Edge.ofAdj h` is `{u, v}`: its two endpoints are
+`u` and `v` in some order. -/
+theorem Edge.ofAdj_endpoints {G : SimpleGraph V} {u v : V} (h : G.Adj u v) :
+    ((Edge.ofAdj h).1.1 = u ∧ (Edge.ofAdj h).1.2 = v) ∨
+      ((Edge.ofAdj h).1.1 = v ∧ (Edge.ofAdj h).1.2 = u) := by
+  rcases lt_or_gt_of_ne (G.ne_of_adj h) with huv | hvu
+  · exact Or.inl ⟨by rw [Edge.ofAdj_of_lt h huv], by rw [Edge.ofAdj_of_lt h huv]⟩
+  · exact Or.inr ⟨by rw [Edge.ofAdj_of_gt h hvu], by rw [Edge.ofAdj_of_gt h hvu]⟩
+
+omit [Fintype V] in
+/-- `Edge.ofAdj` recovers an edge from either of its incidence directions. -/
+@[simp] theorem Edge.ofAdj_fst_snd {G : SimpleGraph V} (e : Edge G) :
+    Edge.ofAdj e.2.2 = e := by
+  rw [Edge.ofAdj_of_lt e.2.2 e.2.1]
+
 /-- Edges incident to a vertex `v`. -/
 abbrev IncidentEdge (G : SimpleGraph V) (v : V) : Type _ :=
   { e : Edge G // e.1.1 = v ∨ e.1.2 = v }

--- a/TNLean/PEPS/IsoTransport.lean
+++ b/TNLean/PEPS/IsoTransport.lean
@@ -70,6 +70,16 @@ theorem Edge.ofAdj_eq_of_endpoints {u v : V} (h : G.Adj u v) (e : Edge G)
     exact absurd hlt (not_lt.mpr e.2.1.le)
   · exact Prod.ext (o1.trans hv) (o2.trans hu)
 
+omit [Fintype V] in
+/-- Two `Edge.ofAdj` constructions agree when their adjacent pairs have the same
+unordered endpoints: orienting `(u, v)` and `(u', v')` gives the same edge whenever
+`{u, v} = {u', v'}`. -/
+theorem Edge.ofAdj_eq_ofAdj {u v u' v' : V} (h1 : G.Adj u v) (h2 : G.Adj u' v')
+    (H : (u = u' ∧ v = v') ∨ (u = v' ∧ v = u')) :
+    Edge.ofAdj h1 = Edge.ofAdj h2 := by
+  rw [Edge.ofAdj_eq_of_endpoints h1 (Edge.ofAdj h2)]
+  rcases Edge.ofAdj_endpoints h2 with ⟨o1, o2⟩ | ⟨o1, o2⟩ <;> rw [o1, o2] <;> tauto
+
 /-- The edge of `G'` obtained by pushing an edge of `G` through the graph
 isomorphism `φ`: apply `φ` to both endpoints and reorder them into the `Edge`
 convention with `Edge.ofAdj`.  The isomorphism may swap the order of the two

--- a/TNLean/PEPS/IsoTransport.lean
+++ b/TNLean/PEPS/IsoTransport.lean
@@ -1,0 +1,288 @@
+import Mathlib.Combinatorics.SimpleGraph.Maps
+
+import TNLean.PEPS.Defs
+
+/-!
+# Transport of PEPS tensors along a graph isomorphism
+
+A graph isomorphism `φ : G ≃g G'` carries the combinatorial data of a PEPS on `G`
+to a PEPS on `G'`: each edge maps to an edge (`Edge.map`), each edge incident to
+`v` maps to an edge incident to `φ v` (`IncidentEdge.equiv`), and a tensor `A` on
+`G` transports to a tensor `A.transport φ` on `G'` whose bond dimensions and
+components are those of `A` reindexed by `φ` (`Tensor.transport`). Transport
+turns the state coefficient into the precomposed coefficient
+(`stateCoeff_transport`), so it preserves `SameState`.
+
+This is the geometric input to translation invariance: a tensor on the torus is
+translation invariant when it is fixed by the transport along every translation
+automorphism (`TNLean/PEPS/TorusTranslationInvariant.lean`). Here the
+construction is stated for a general isomorphism so the edge action, the
+incident-edge correspondence, and the coefficient identity are available once and
+specialized to the torus translations.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1407--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators
+
+namespace TNLean
+namespace PEPS
+
+variable {V W : Type*} [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  {G : SimpleGraph V} {G' : SimpleGraph W} {d : ℕ}
+
+/-! ### The edge action of a graph isomorphism -/
+
+omit [Fintype V] [Fintype W] in
+/-- The image edge `Edge.ofAdj h` is independent of the incidence direction of the
+adjacency `h`: orienting the pair `(u, v)` and the pair `(v, u)` gives the same
+edge, since `Edge.ofAdj` places the smaller endpoint first either way. -/
+theorem Edge.ofAdj_symm {u v : V} (h : G.Adj u v) :
+    Edge.ofAdj h = Edge.ofAdj h.symm := by
+  rcases lt_or_gt_of_ne (G.ne_of_adj h) with huv | hvu
+  · rw [Edge.ofAdj_of_lt h huv, Edge.ofAdj_of_gt h.symm huv]
+  · rw [Edge.ofAdj_of_gt h hvu, Edge.ofAdj_of_lt h.symm hvu]
+
+omit [Fintype V] [Fintype W] in
+/-- An edge is determined by its unordered endpoint pair: if `(u, v)` is, in some
+order, the ordered endpoint pair of `e`, then orienting `(u, v)` with `Edge.ofAdj`
+recovers `e`.  This is the bookkeeping that makes the edge action of an
+isomorphism well defined regardless of which order the isomorphism produces. -/
+theorem Edge.ofAdj_eq_of_endpoints {u v : V} (h : G.Adj u v) (e : Edge G)
+    (H : (u = e.1.1 ∧ v = e.1.2) ∨ (u = e.1.2 ∧ v = e.1.1)) :
+    Edge.ofAdj h = e := by
+  apply Subtype.ext
+  rcases Edge.ofAdj_endpoints h with ⟨o1, o2⟩ | ⟨o1, o2⟩ <;>
+    rcases H with ⟨hu, hv⟩ | ⟨hu, hv⟩
+  · exact Prod.ext (o1.trans hu) (o2.trans hv)
+  · exfalso
+    have hlt : (Edge.ofAdj h).1.1 < (Edge.ofAdj h).1.2 := (Edge.ofAdj h).2.1
+    rw [o1, o2, hu, hv] at hlt
+    exact absurd hlt (not_lt.mpr e.2.1.le)
+  · exfalso
+    have hlt : (Edge.ofAdj h).1.1 < (Edge.ofAdj h).1.2 := (Edge.ofAdj h).2.1
+    rw [o1, o2, hu, hv] at hlt
+    exact absurd hlt (not_lt.mpr e.2.1.le)
+  · exact Prod.ext (o1.trans hv) (o2.trans hu)
+
+/-- The edge of `G'` obtained by pushing an edge of `G` through the graph
+isomorphism `φ`: apply `φ` to both endpoints and reorder them into the `Edge`
+convention with `Edge.ofAdj`.  The isomorphism may swap the order of the two
+endpoints, which `Edge.ofAdj` corrects. -/
+def Edge.map (φ : G ≃g G') (e : Edge G) : Edge G' :=
+  Edge.ofAdj ((φ.map_rel_iff').mpr e.2.2)
+
+omit [Fintype V] [Fintype W] in
+/-- The unordered endpoints of `Edge.map φ e` are the `φ`-images of the endpoints
+of `e`. -/
+theorem Edge.map_endpoints (φ : G ≃g G') (e : Edge G) :
+    ((Edge.map φ e).1.1 = φ e.1.1 ∧ (Edge.map φ e).1.2 = φ e.1.2) ∨
+      ((Edge.map φ e).1.1 = φ e.1.2 ∧ (Edge.map φ e).1.2 = φ e.1.1) :=
+  Edge.ofAdj_endpoints ((φ.map_rel_iff').mpr e.2.2)
+
+omit [Fintype V] [Fintype W] in
+/-- Pushing an edge through `φ` and then through `φ.symm` recovers the original
+edge.  The two passes return to the original unordered endpoint pair, and
+`Edge.ofAdj` re-imposes the same `<`-order, so the round trip is the identity. -/
+@[simp] theorem Edge.map_symm_map (φ : G ≃g G') (e : Edge G) :
+    Edge.map φ.symm (Edge.map φ e) = e := by
+  apply Edge.ofAdj_eq_of_endpoints
+  rcases Edge.map_endpoints φ e with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exact Or.inl ⟨by rw [h1]; simp, by rw [h2]; simp⟩
+  · exact Or.inr ⟨by rw [h1]; simp, by rw [h2]; simp⟩
+
+omit [Fintype V] [Fintype W] in
+/-- Pushing an edge through `φ.symm` and then through `φ` recovers it. -/
+@[simp] theorem Edge.map_map_symm (φ : G ≃g G') (e : Edge G') :
+    Edge.map φ (Edge.map φ.symm e) = e :=
+  Edge.map_symm_map φ.symm e
+
+/-- The edge action of `φ` as a bijection `Edge G ≃ Edge G'`. -/
+def Edge.equiv (φ : G ≃g G') : Edge G ≃ Edge G' where
+  toFun := Edge.map φ
+  invFun := Edge.map φ.symm
+  left_inv := Edge.map_symm_map φ
+  right_inv := Edge.map_map_symm φ
+
+omit [Fintype V] [Fintype W] in
+@[simp] theorem Edge.equiv_apply (φ : G ≃g G') (e : Edge G) :
+    Edge.equiv φ e = Edge.map φ e :=
+  rfl
+
+omit [Fintype V] [Fintype W] in
+@[simp] theorem Edge.equiv_symm_apply (φ : G ≃g G') (e : Edge G') :
+    (Edge.equiv φ).symm e = Edge.map φ.symm e :=
+  rfl
+
+/-! ### The incident-edge correspondence -/
+
+omit [Fintype V] [Fintype W] in
+/-- An edge incident to `v` maps, under `φ`, to an edge incident to `φ v`. -/
+theorem Edge.map_incident (φ : G ≃g G') {v : V} {e : Edge G}
+    (h : e.1.1 = v ∨ e.1.2 = v) :
+    (Edge.map φ e).1.1 = φ v ∨ (Edge.map φ e).1.2 = φ v := by
+  rcases Edge.map_endpoints φ e with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · rcases h with hv | hv
+    · exact Or.inl (by rw [h1, hv])
+    · exact Or.inr (by rw [h2, hv])
+  · rcases h with hv | hv
+    · exact Or.inr (by rw [h2, hv])
+    · exact Or.inl (by rw [h1, hv])
+
+/-- The correspondence between edges incident to `v` and edges incident to `φ v`,
+as a bijection.  The underlying map is the edge action `Edge.map φ`; the incidence
+is preserved because `φ` sends the endpoint equal to `v` to one equal to `φ v`. -/
+def IncidentEdge.equiv (φ : G ≃g G') (v : V) :
+    IncidentEdge G v ≃ IncidentEdge G' (φ v) where
+  toFun ie := ⟨Edge.map φ ie.1, Edge.map_incident φ ie.2⟩
+  invFun ie := ⟨Edge.map φ.symm ie.1, by
+    have h := Edge.map_incident φ.symm (v := φ v) ie.2
+    simpa using h⟩
+  left_inv ie := by apply Subtype.ext; simp
+  right_inv ie := by apply Subtype.ext; simp
+
+omit [Fintype V] [Fintype W] in
+@[simp] theorem IncidentEdge.equiv_coe (φ : G ≃g G') (v : V)
+    (ie : IncidentEdge G v) :
+    (IncidentEdge.equiv φ v ie).1 = Edge.map φ ie.1 :=
+  rfl
+
+/-- The edge incident to `φ.symm w` carried to an edge incident to `w` (not merely
+to `φ (φ.symm w)`).  The membership at `w` is recomputed from `Edge.map_incident`
+through `φ (φ.symm w) = w`, avoiding a transport across the incidence-vertex index.
+This is the form consumed in the transported tensor's component, where the vertex
+of `G'` is `w` and its `G`-preimage is `φ.symm w`. -/
+def IncidentEdge.toSymm (φ : G ≃g G') (w : W) (ie : IncidentEdge G (φ.symm w)) :
+    IncidentEdge G' w :=
+  ⟨Edge.map φ ie.1, by
+    have h := Edge.map_incident φ ie.2
+    rwa [φ.apply_symm_apply] at h⟩
+
+omit [Fintype V] [Fintype W] in
+@[simp] theorem IncidentEdge.toSymm_coe (φ : G ≃g G') (w : W)
+    (ie : IncidentEdge G (φ.symm w)) :
+    (IncidentEdge.toSymm φ w ie).1 = Edge.map φ ie.1 :=
+  rfl
+
+/-! ### Transport of a tensor along a graph isomorphism -/
+
+variable [DecidableRel G.Adj] [DecidableRel G'.Adj]
+
+/-- Transport of a PEPS tensor along the graph isomorphism `φ : G ≃g G'`.  Its bond
+dimension at an edge `e'` of `G'` is the bond dimension of `A` at the preimage edge
+`Edge.map φ.symm e'`, and its component at a vertex `w` is the component of `A` at
+`φ.symm w`, with the incident virtual indices supplied through the edge action.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`, where the translationally invariant theorem
+places one tensor at every site, i.e. the tensor is fixed by transport along every
+translation. -/
+noncomputable def Tensor.transport (A : Tensor G d) (φ : G ≃g G') : Tensor G' d where
+  bondDim e' := A.bondDim (Edge.map φ.symm e')
+  component w η' p :=
+    A.component (φ.symm w)
+      (fun ie : IncidentEdge G (φ.symm w) =>
+        finCongr
+          (show A.bondDim (Edge.map φ.symm (IncidentEdge.toSymm φ w ie).1) = A.bondDim ie.1 by
+            simp only [IncidentEdge.toSymm_coe, Edge.map_symm_map])
+          (η' (IncidentEdge.toSymm φ w ie))) p
+
+omit [Fintype V] [Fintype W] in
+@[simp] theorem Tensor.transport_bondDim (A : Tensor G d) (φ : G ≃g G') (e' : Edge G') :
+    (A.transport φ).bondDim e' = A.bondDim (Edge.map φ.symm e') :=
+  rfl
+
+/-- The virtual configurations of `A.transport φ` correspond to those of `A` by the
+edge action of `φ`: a configuration on the edges of `G'` is the same data as a
+configuration on the edges of `G`, since the edges and their bond dimensions are
+carried across by `φ`.  Concretely `(vcEquiv A φ).symm η e' = η (Edge.map φ.symm e')`. -/
+noncomputable def vcEquiv (A : Tensor G d) (φ : G ≃g G') :
+    VirtualConfig (A.transport φ) ≃ VirtualConfig A :=
+  Equiv.piCongrLeft (fun e : Edge G => Fin (A.bondDim e)) (Edge.equiv φ.symm)
+
+omit [Fintype V] [Fintype W] in
+@[simp] theorem vcEquiv_symm_apply (A : Tensor G d) (φ : G ≃g G')
+    (η : VirtualConfig A) (e' : Edge G') :
+    (vcEquiv A φ).symm η e' = η (Edge.map φ.symm e') :=
+  Equiv.piCongrLeft_symm_apply (fun e : Edge G => Fin (A.bondDim e)) (Edge.equiv φ.symm) η e'
+
+omit [Fintype V] [Fintype W] in
+/-- The virtual index that the transported configuration `(vcEquiv A φ).symm η`
+supplies on the edge `e'` over `e0 := Edge.map φ.symm e'` is, up to the bond-dimension
+reindexing, the original index `η e0`.  This is the bond-level content of the edge
+action: pushing a configuration forward and reading it back recovers the original
+indices.  It is the per-edge identity behind `stateCoeff_transport`. -/
+theorem finCongr_vcEquiv_symm (A : Tensor G d) (φ : G ≃g G') (η : VirtualConfig A)
+    (e' : Edge G') (e0 : Edge G) (he : Edge.map φ.symm e' = e0)
+    (h : A.bondDim (Edge.map φ.symm e') = A.bondDim e0) :
+    finCongr h (((vcEquiv A φ).symm η) e') = η e0 := by
+  subst he
+  rw [vcEquiv_symm_apply]
+  simp
+
+/-! ### The state coefficient of a transported tensor -/
+
+omit [Fintype V] [Fintype W] in
+/-- The component of `A.transport φ` at a vertex `w`, evaluated on the virtual
+indices coming from `(vcEquiv A φ).symm η`, equals the component of `A` at the
+preimage vertex `φ.symm w` evaluated on `η`.  This is the per-vertex matching used
+in `stateCoeff_transport`. -/
+theorem transport_component_vcEquiv (A : Tensor G d) (φ : G ≃g G') (η : VirtualConfig A)
+    (σ : W → Fin d) (w : W) :
+    (A.transport φ).component w (fun ie' : IncidentEdge G' w => ((vcEquiv A φ).symm η) ie'.1)
+        (σ w)
+      = A.component (φ.symm w) (fun ie => η ie.1) (σ w) := by
+  change A.component (φ.symm w)
+      (fun ie : IncidentEdge G (φ.symm w) =>
+        finCongr _ (((vcEquiv A φ).symm η) (IncidentEdge.toSymm φ w ie).1)) (σ w)
+    = A.component (φ.symm w) (fun ie => η ie.1) (σ w)
+  congr 1
+  funext ie
+  exact finCongr_vcEquiv_symm A φ η (IncidentEdge.toSymm φ w ie).1 ie.1 (by
+    rw [IncidentEdge.toSymm_coe, Edge.map_symm_map]) _
+
+/-- **Transport of the state coefficient.**
+
+The state coefficient of the transported tensor `A.transport φ` at a physical
+configuration `σ` on the vertices of `G'` equals the state coefficient of `A` at
+the precomposed configuration `σ ∘ φ` on the vertices of `G`.  Transport reindexes
+the virtual configurations by the edge action and the vertices by `φ`, leaving the
+contracted coefficient unchanged up to this relabelling.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem stateCoeff_transport (A : Tensor G d) (φ : G ≃g G') (σ : W → Fin d) :
+    stateCoeff (A.transport φ) σ = stateCoeff A (fun v => σ (φ v)) := by
+  unfold stateCoeff
+  rw [← Equiv.sum_comp (vcEquiv A φ).symm
+        (fun η' => ∏ w : W, (A.transport φ).component w (fun ie => η' ie.1) (σ w))]
+  apply Finset.sum_congr rfl
+  intro η _
+  simp only
+  rw [Finset.prod_congr rfl (fun w _ => transport_component_vcEquiv A φ η σ w)]
+  rw [← Equiv.prod_comp φ.toEquiv (fun w => A.component (φ.symm w) (fun ie => η ie.1) (σ w))]
+  apply Finset.prod_congr rfl
+  intro v _
+  simp only [RelIso.coe_fn_toEquiv]
+  rw [φ.symm_apply_apply]
+
+/-- Transport preserves `SameState`: if `A` and `B` agree on all state
+coefficients, so do `A.transport φ` and `B.transport φ`.  Each side's coefficient
+is the corresponding coefficient of `A` (respectively `B`) at the precomposed
+configuration, which agree by hypothesis.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem SameState.transport {A B : Tensor G d} (φ : G ≃g G') (h : SameState A B) :
+    SameState (A.transport φ) (B.transport φ) := by
+  intro σ
+  rw [stateCoeff_transport, stateCoeff_transport]
+  exact h _
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusLatticeGraph.lean
+++ b/TNLean/PEPS/TorusLatticeGraph.lean
@@ -1,0 +1,272 @@
+import Mathlib.Data.Prod.Lex
+import Mathlib.Data.ZMod.Basic
+
+import TNLean.PEPS.Defs
+
+/-!
+# The periodic (torus) lattice graph for the translation-invariant normal PEPS proof
+
+The translationally invariant square-lattice theorem of the normal PEPS proof
+(arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`) is stated on a lattice with **no boundary
+and no preferred origin**: one tensor is repeated at every site, and translation
+acts as a symmetry of the network. The finite model of such a lattice is the
+discrete torus: the vertex set is `ZMod width × ZMod height` with cyclic
+nearest-neighbour edges, on which the coordinate translations are graph
+automorphisms (see `TNLean/PEPS/TorusTranslation.lean`).
+
+The open rectangular model `TNLean/PEPS/SquareLatticeGraph.lean` has a boundary
+that breaks translation: its boundary edges have no interior margin, so the
+every-edge blocking construction only reaches interior edges
+(`docs/paper-gaps/peps_normal_ft_section3_route.tex`, remaining obligation 4).
+The torus removes the boundary, so on it every edge is interior and the
+construction is complete (same note, remaining obligation 6). This file records
+the torus geometry natively; the bridge transferring the merged interior-edge
+blocking machinery from the open lattice onto the torus is a separate step.
+
+The vertex coordinate ring `ZMod width` is finite and nontrivial exactly when
+`1 < width`, recorded as the instances `[NeZero width]` (finiteness) and
+`[Fact (1 < width)]` (nontriviality, hence no self-loops); likewise for the
+vertical coordinate. The torus is genuinely a cycle in each direction precisely
+under `1 < width` and `1 < height`, matching the source's large periodic lattice.
+
+## Design note on the vertex linear order
+
+The project-level `Edge` type orients an undirected edge by an ambient
+`LinearOrder` on the vertices. We give `TorusVertex width height` the
+lexicographic order through the coordinate value injection `v ↦ (v.1.val,
+v.2.val)`, mirroring the open-lattice instance
+(`TNLean.PEPS.instLinearOrderSquareLatticeVertex`). As there, the
+`toDecidableEq` field is pinned to the canonical product decidable equality
+`instDecidableEqProd` rather than the comparison-derived one that
+`LinearOrder.lift'` would synthesize, so the geometry layer (which builds its
+data over the product decidable equality) and the gauge interface (which
+synthesizes a decidable equality from the linear order) meet definitionally.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1407--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+/-- The vertex set of the discrete torus of size `width × height`: pairs of
+periodic horizontal and vertical coordinates.  Translation acts on it by
+coordinate addition (see `TNLean/PEPS/TorusTranslation.lean`).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the translationally invariant theorem
+is set on a lattice on which translation is a symmetry. -/
+abbrev TorusVertex (width height : ℕ) : Type :=
+  ZMod width × ZMod height
+
+instance instFintypeTorusVertex (width height : ℕ) [NeZero width] [NeZero height] :
+    Fintype (TorusVertex width height) :=
+  inferInstance
+
+instance instDecidableEqTorusVertex (width height : ℕ) :
+    DecidableEq (TorusVertex width height) :=
+  inferInstance
+
+/-- The torus coordinate value injection `v ↦ (v.1.val, v.2.val)` into the
+lexicographic product of `ℕ` is injective, the witness for the lexicographic
+linear order on `TorusVertex`. -/
+theorem torusVertexValLex_injective (width height : ℕ) [NeZero width] [NeZero height] :
+    Function.Injective
+      (fun v : TorusVertex width height => toLex (v.1.val, v.2.val)) := by
+  intro v w h
+  have h' := ofLex_inj.mpr h
+  simp only [ofLex_toLex, Prod.mk.injEq] at h'
+  exact Prod.ext (ZMod.val_injective width h'.1) (ZMod.val_injective height h'.2)
+
+/-- The torus vertex set is ordered lexicographically through the coordinate
+value injection `v ↦ (v.1.val, v.2.val)`.  The project-level `Edge` type uses an
+ambient linear order to orient undirected graph edges, so this instance lets the
+torus graph use the same edge type as the general PEPS development.
+
+The decidable-equality field is pinned to the canonical product decidable
+equality `instDecidableEqProd` rather than the comparison-derived one that
+`LinearOrder.lift'` would synthesize, exactly as for the open-lattice instance
+`TNLean.PEPS.instLinearOrderSquareLatticeVertex`.  All other order fields are
+taken from `LinearOrder.lift'`, so the lexicographic comparison is unchanged. -/
+instance instLinearOrderTorusVertex (width height : ℕ) [NeZero width] [NeZero height] :
+    LinearOrder (TorusVertex width height) := by
+  classical
+  exact
+    let src : LinearOrder (TorusVertex width height) :=
+      LinearOrder.lift'
+        (fun v : TorusVertex width height => toLex (v.1.val, v.2.val))
+        (torusVertexValLex_injective width height)
+    @Function.Injective.linearOrder _ _ _ src.toLE src.toLT src.toMax src.toMin src.toOrd
+      instDecidableEqProd src.toDecidableLE src.toDecidableLT
+      (fun v : TorusVertex width height => toLex (v.1.val, v.2.val))
+      (torusVertexValLex_injective width height)
+      (le := Iff.rfl) (lt := Iff.rfl)
+      (min := fun x y => by
+        show (fun v : TorusVertex width height => toLex (v.1.val, v.2.val)) (src.min x y) = _
+        rw [src.min_def]; split
+        · rw [min_eq_left ‹_›]
+        · rw [min_eq_right (not_le.mp ‹_›).le])
+      (max := fun x y => by
+        show (fun v : TorusVertex width height => toLex (v.1.val, v.2.val)) (src.max x y) = _
+        rw [src.max_def]; split
+        · rw [max_eq_right ‹_›]
+        · rw [max_eq_left (not_le.mp ‹_›).le])
+      (compare := fun _ _ => rfl)
+
+/-- Horizontal nearest-neighbour relation on the torus: equal vertical coordinate
+and horizontal coordinates differing by one, the difference taken cyclically in
+`ZMod width`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`, where the edge blocking is applied to
+horizontal and vertical lattice edges. -/
+def torusHorizontalNeighbor {width height : ℕ}
+    (v w : TorusVertex width height) : Prop :=
+  v.2 = w.2 ∧ (v.1 + 1 = w.1 ∨ w.1 + 1 = v.1)
+
+/-- Vertical nearest-neighbour relation on the torus: equal horizontal coordinate
+and vertical coordinates differing by one, the difference taken cyclically in
+`ZMod height`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusVerticalNeighbor {width height : ℕ}
+    (v w : TorusVertex width height) : Prop :=
+  v.1 = w.1 ∧ (v.2 + 1 = w.2 ∨ w.2 + 1 = v.2)
+
+instance instDecidableTorusHorizontalNeighbor {width height : ℕ}
+    (v w : TorusVertex width height) : Decidable (torusHorizontalNeighbor v w) := by
+  unfold torusHorizontalNeighbor; infer_instance
+
+instance instDecidableTorusVerticalNeighbor {width height : ℕ}
+    (v w : TorusVertex width height) : Decidable (torusVerticalNeighbor v w) := by
+  unfold torusVerticalNeighbor; infer_instance
+
+/-- The discrete torus graph with cyclic nearest-neighbour horizontal and
+vertical edges.  The nontriviality instances `[Fact (1 < width)]` and
+`[Fact (1 < height)]` make `1 ≠ 0` in each coordinate ring, so a vertex is never
+its own cyclic neighbour and the graph is loopless.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1500 of
+`Papers/1804.04964/paper_normal.tex`, where the translationally invariant theorem
+is set on a periodic lattice. -/
+def torusGraph (width height : ℕ) [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] : SimpleGraph (TorusVertex width height) where
+  Adj v w := torusHorizontalNeighbor v w ∨ torusVerticalNeighbor v w
+  symm := by
+    intro v w h
+    rcases h with ⟨hy, hx | hx⟩ | ⟨hx, hy | hy⟩
+    · exact Or.inl ⟨hy.symm, Or.inr hx⟩
+    · exact Or.inl ⟨hy.symm, Or.inl hx⟩
+    · exact Or.inr ⟨hx.symm, Or.inr hy⟩
+    · exact Or.inr ⟨hx.symm, Or.inl hy⟩
+  loopless := by
+    constructor
+    intro v h
+    rcases h with ⟨_, hx | hx⟩ | ⟨_, hy | hy⟩
+    · exact one_ne_zero (α := ZMod width)
+        (add_left_cancel (a := v.1) (b := (1 : ZMod width)) (c := 0) (by rw [add_zero]; exact hx))
+    · exact one_ne_zero (α := ZMod width)
+        (add_left_cancel (a := v.1) (b := (1 : ZMod width)) (c := 0) (by rw [add_zero]; exact hx))
+    · exact one_ne_zero (α := ZMod height)
+        (add_left_cancel (a := v.2) (b := (1 : ZMod height)) (c := 0) (by rw [add_zero]; exact hy))
+    · exact one_ne_zero (α := ZMod height)
+        (add_left_cancel (a := v.2) (b := (1 : ZMod height)) (c := 0) (by rw [add_zero]; exact hy))
+
+instance instDecidableRelTorusGraphAdj (width height : ℕ) [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] :
+    DecidableRel (torusGraph width height).Adj := by
+  intro v w
+  unfold torusGraph
+  infer_instance
+
+@[simp] theorem torusGraph_adj {width height : ℕ} [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] (v w : TorusVertex width height) :
+    (torusGraph width height).Adj v w ↔
+      torusHorizontalNeighbor v w ∨ torusVerticalNeighbor v w :=
+  Iff.rfl
+
+/-- A vertex and its cyclic right neighbour `(x + 1, y)` are adjacent.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem torusGraph_adj_right {width height : ℕ} [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] (x : ZMod width) (y : ZMod height) :
+    (torusGraph width height).Adj (x, y) (x + 1, y) :=
+  Or.inl ⟨rfl, Or.inl rfl⟩
+
+/-- A vertex and its cyclic upper neighbour `(x, y + 1)` are adjacent.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem torusGraph_adj_up {width height : ℕ} [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] (x : ZMod width) (y : ZMod height) :
+    (torusGraph width height).Adj (x, y) (x, y + 1) :=
+  Or.inr ⟨rfl, Or.inl rfl⟩
+
+/-! ### Orientation of torus edges
+
+Each edge of the torus graph is horizontal or vertical, and no edge is both.  As
+on the open lattice these orientation predicates split the per-edge data into the
+two classes "described by the same horizontal matrix" and "described by the same
+vertical matrix" of the source's translation-invariant reduction. -/
+
+/-- An edge of the torus graph is **horizontal** when its endpoints are horizontal
+cyclic neighbours.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+def IsHorizontalTorusEdge {width height : ℕ} [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] (e : Edge (torusGraph width height)) : Prop :=
+  torusHorizontalNeighbor e.1.1 e.1.2
+
+/-- An edge of the torus graph is **vertical** when its endpoints are vertical
+cyclic neighbours.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+def IsVerticalTorusEdge {width height : ℕ} [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] (e : Edge (torusGraph width height)) : Prop :=
+  torusVerticalNeighbor e.1.1 e.1.2
+
+instance instDecidableIsHorizontalTorusEdge {width height : ℕ} [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] (e : Edge (torusGraph width height)) :
+    Decidable (IsHorizontalTorusEdge e) := by
+  unfold IsHorizontalTorusEdge; infer_instance
+
+instance instDecidableIsVerticalTorusEdge {width height : ℕ} [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] (e : Edge (torusGraph width height)) :
+    Decidable (IsVerticalTorusEdge e) := by
+  unfold IsVerticalTorusEdge; infer_instance
+
+/-- Every edge of the torus graph is horizontal or vertical.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem torusEdge_horizontal_or_vertical {width height : ℕ} [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] (e : Edge (torusGraph width height)) :
+    IsHorizontalTorusEdge e ∨ IsVerticalTorusEdge e :=
+  e.2.2
+
+/-- No edge of the torus graph is both horizontal and vertical.  A horizontal edge
+keeps the vertical coordinate fixed and shifts the horizontal one by one; a
+vertical edge does the reverse.  If an edge were both, the horizontal coordinate
+would be both fixed and shifted by one, forcing `1 = 0`, impossible by
+nontriviality.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500. -/
+theorem torusEdge_not_horizontal_and_vertical {width height : ℕ} [NeZero width] [NeZero height]
+    [Fact (1 < width)] [Fact (1 < height)] (e : Edge (torusGraph width height)) :
+    ¬ (IsHorizontalTorusEdge e ∧ IsVerticalTorusEdge e) := by
+  rintro ⟨hHorizontal, hVertical⟩
+  have hxEq : e.1.1.1 = e.1.2.1 := hVertical.1
+  rcases hHorizontal.2 with hStep | hStep
+  · exact one_ne_zero (α := ZMod width)
+      (add_left_cancel (a := e.1.1.1) (b := (1 : ZMod width)) (c := 0)
+        (by rw [add_zero, hStep, ← hxEq]))
+  · exact one_ne_zero (α := ZMod width)
+      (add_left_cancel (a := e.1.2.1) (b := (1 : ZMod width)) (c := 0)
+        (by rw [add_zero, hStep, hxEq]))
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusTranslation.lean
+++ b/TNLean/PEPS/TorusTranslation.lean
@@ -1,0 +1,223 @@
+import Mathlib.Combinatorics.SimpleGraph.Maps
+
+import TNLean.PEPS.TorusLatticeGraph
+
+/-!
+# Translation automorphisms of the periodic (torus) lattice
+
+The translationally invariant normal PEPS theorem (arXiv:1804.04964, Section 3,
+proof of Theorem 3) places one tensor at every site of a lattice on which
+translation is a symmetry. On the discrete torus
+(`TNLean/PEPS/TorusLatticeGraph.lean`) translation by a coordinate offset
+`(a, b)` is the vertex map `(x, y) ↦ (x + a, y + b)`, with addition taken
+cyclically in each coordinate ring. This map is a bijection (`translateEquiv`)
+that preserves the cyclic nearest-neighbour adjacency, hence a graph
+automorphism (`translate`). It carries each edge to an edge of the same
+orientation, and the induced action on edges (`translateEdge`) reorders the
+translated endpoints back into the `Edge` convention through `Edge.ofAdj`,
+because a translation can swap the lexicographic order of the two endpoints when
+the coordinate wraps around the torus.
+
+These automorphisms are the symmetry under which a translation-invariant tensor
+is fixed (`TNLean/PEPS/TorusTranslationInvariant.lean`); their edge action is the
+input to that invariance and to the covariance of the blocked machinery.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1407--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-! ### The translation bijection -/
+
+/-- Translation of torus coordinates by the offset `(a, b)`: the bijection
+`(x, y) ↦ (x + a, y + b)`, with cyclic addition in each coordinate ring.  Its
+inverse subtracts the offset.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the translationally invariant theorem
+repeats one tensor at every site. -/
+def translateEquiv (a : ZMod width) (b : ZMod height) :
+    TorusVertex width height ≃ TorusVertex width height where
+  toFun v := (v.1 + a, v.2 + b)
+  invFun v := (v.1 - a, v.2 - b)
+  left_inv v := by simp
+  right_inv v := by simp
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
+@[simp] theorem translateEquiv_apply (a : ZMod width) (b : ZMod height)
+    (v : TorusVertex width height) :
+    translateEquiv a b v = (v.1 + a, v.2 + b) :=
+  rfl
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
+@[simp] theorem translateEquiv_symm_apply (a : ZMod width) (b : ZMod height)
+    (v : TorusVertex width height) :
+    (translateEquiv a b).symm v = (v.1 - a, v.2 - b) :=
+  rfl
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
+/-- The translation bijection preserves the horizontal cyclic-neighbour relation:
+adding the same offset to both endpoints preserves a horizontal step. -/
+theorem torusHorizontalNeighbor_translate (a : ZMod width) (b : ZMod height)
+    {v w : TorusVertex width height} :
+    torusHorizontalNeighbor (translateEquiv a b v) (translateEquiv a b w) ↔
+      torusHorizontalNeighbor v w := by
+  simp only [torusHorizontalNeighbor, translateEquiv_apply]
+  constructor
+  · rintro ⟨hy, hx | hx⟩
+    · exact ⟨add_right_cancel hy, Or.inl (add_right_cancel (by rw [add_right_comm]; exact hx))⟩
+    · exact ⟨add_right_cancel hy, Or.inr (add_right_cancel (by rw [add_right_comm]; exact hx))⟩
+  · rintro ⟨hy, hx | hx⟩
+    · exact ⟨by rw [hy], Or.inl (by rw [add_right_comm, hx])⟩
+    · exact ⟨by rw [hy], Or.inr (by rw [add_right_comm, hx])⟩
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
+/-- The translation bijection preserves the vertical cyclic-neighbour relation. -/
+theorem torusVerticalNeighbor_translate (a : ZMod width) (b : ZMod height)
+    {v w : TorusVertex width height} :
+    torusVerticalNeighbor (translateEquiv a b v) (translateEquiv a b w) ↔
+      torusVerticalNeighbor v w := by
+  simp only [torusVerticalNeighbor, translateEquiv_apply]
+  constructor
+  · rintro ⟨hx, hy | hy⟩
+    · exact ⟨add_right_cancel hx, Or.inl (add_right_cancel (by rw [add_right_comm]; exact hy))⟩
+    · exact ⟨add_right_cancel hx, Or.inr (add_right_cancel (by rw [add_right_comm]; exact hy))⟩
+  · rintro ⟨hx, hy | hy⟩
+    · exact ⟨by rw [hx], Or.inl (by rw [add_right_comm, hy])⟩
+    · exact ⟨by rw [hx], Or.inr (by rw [add_right_comm, hy])⟩
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
+/-- The horizontal cyclic-neighbour relation is symmetric. -/
+theorem torusHorizontalNeighbor_symm {v w : TorusVertex width height}
+    (h : torusHorizontalNeighbor v w) : torusHorizontalNeighbor w v :=
+  ⟨h.1.symm, h.2.imp (·) (·) |>.elim Or.inr Or.inl⟩
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
+/-- The vertical cyclic-neighbour relation is symmetric. -/
+theorem torusVerticalNeighbor_symm {v w : TorusVertex width height}
+    (h : torusVerticalNeighbor v w) : torusVerticalNeighbor w v :=
+  ⟨h.1.symm, h.2.imp (·) (·) |>.elim Or.inr Or.inl⟩
+
+/-! ### The translation graph automorphism -/
+
+/-- Translation of the torus by `(a, b)` as a graph automorphism: the coordinate
+bijection `translateEquiv a b` together with adjacency preservation in both
+directions.  Translation carries horizontal edges to horizontal edges and
+vertical edges to vertical edges, so it preserves the union adjacency.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def translate (a : ZMod width) (b : ZMod height) :
+    torusGraph width height ≃g torusGraph width height :=
+  { toEquiv := translateEquiv a b
+    map_rel_iff' := by
+      intro v w
+      change torusHorizontalNeighbor (translateEquiv a b v) (translateEquiv a b w) ∨
+          torusVerticalNeighbor (translateEquiv a b v) (translateEquiv a b w) ↔
+        torusHorizontalNeighbor v w ∨ torusVerticalNeighbor v w
+      rw [torusHorizontalNeighbor_translate, torusVerticalNeighbor_translate] }
+
+@[simp] theorem translate_apply (a : ZMod width) (b : ZMod height)
+    (v : TorusVertex width height) :
+    translate a b v = (v.1 + a, v.2 + b) :=
+  rfl
+
+/-- Translation preserves adjacency in the forward direction. -/
+theorem torusGraph_adj_translate (a : ZMod width) (b : ZMod height)
+    {v w : TorusVertex width height} (h : (torusGraph width height).Adj v w) :
+    (torusGraph width height).Adj (translate a b v) (translate a b w) :=
+  (translate a b).map_rel_iff'.mpr h
+
+/-! ### The induced action on edges
+
+An edge of the torus is an ordered pair `(u, v)` with `u < v`.  Translation may
+swap the lexicographic order of the two translated endpoints (the coordinate
+value wraps around the torus), so the edge action applies the translation to both
+endpoints and reorders the result back into the `Edge` convention through
+`Edge.ofAdj`. -/
+
+/-- The action of the translation `(a, b)` on a torus edge: apply the translation
+to both endpoints and reorder them into the `Edge` convention.  The orientation
+bookkeeping is explicit — the unordered endpoint pair is the translate of the
+original, and `Edge.ofAdj` puts the smaller endpoint first, which a wraparound
+translate may have flipped.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def translateEdge (a : ZMod width) (b : ZMod height)
+    (e : Edge (torusGraph width height)) : Edge (torusGraph width height) :=
+  Edge.ofAdj (torusGraph_adj_translate a b e.2.2)
+
+/-- The unordered endpoints of `translateEdge a b e` are the translates of the
+endpoints of `e`. -/
+theorem translateEdge_endpoints (a : ZMod width) (b : ZMod height)
+    (e : Edge (torusGraph width height)) :
+    ((translateEdge a b e).1.1 = translate a b e.1.1 ∧
+        (translateEdge a b e).1.2 = translate a b e.1.2) ∨
+      ((translateEdge a b e).1.1 = translate a b e.1.2 ∧
+        (translateEdge a b e).1.2 = translate a b e.1.1) :=
+  Edge.ofAdj_endpoints (torusGraph_adj_translate a b e.2.2)
+
+/-- The translation edge action preserves horizontal orientation: the translate of
+a horizontal edge is horizontal. -/
+theorem translateEdge_isHorizontal (a : ZMod width) (b : ZMod height)
+    {e : Edge (torusGraph width height)} (he : IsHorizontalTorusEdge e) :
+    IsHorizontalTorusEdge (translateEdge a b e) := by
+  have hadj : torusHorizontalNeighbor (translate a b e.1.1) (translate a b e.1.2) :=
+    (torusHorizontalNeighbor_translate a b).mpr he
+  rcases translateEdge_endpoints a b e with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · change torusHorizontalNeighbor _ _; rw [h1, h2]; exact hadj
+  · change torusHorizontalNeighbor _ _; rw [h1, h2]; exact torusHorizontalNeighbor_symm hadj
+
+/-- The translation edge action preserves vertical orientation: the translate of a
+vertical edge is vertical. -/
+theorem translateEdge_isVertical (a : ZMod width) (b : ZMod height)
+    {e : Edge (torusGraph width height)} (he : IsVerticalTorusEdge e) :
+    IsVerticalTorusEdge (translateEdge a b e) := by
+  have hadj : torusVerticalNeighbor (translate a b e.1.1) (translate a b e.1.2) :=
+    (torusVerticalNeighbor_translate a b).mpr he
+  rcases translateEdge_endpoints a b e with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · change torusVerticalNeighbor _ _; rw [h1, h2]; exact hadj
+  · change torusVerticalNeighbor _ _; rw [h1, h2]; exact torusVerticalNeighbor_symm hadj
+
+/-! ### The induced action on incident edges
+
+An edge incident to `v` is incident, after translation, to `translate a b v`: the
+translated edge keeps the same incidence because translation carries the endpoint
+`v` to `translate a b v`. -/
+
+/-- The translation action on edges incident to a vertex `v`, landing in the edges
+incident to `translate a b v`.  The underlying edge is `translateEdge a b`; the
+incidence is preserved because translation sends the endpoint equal to `v` to one
+equal to `translate a b v`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def translateIncidentEdge (a : ZMod width) (b : ZMod height) (v : TorusVertex width height)
+    (ie : IncidentEdge (torusGraph width height) v) :
+    IncidentEdge (torusGraph width height) (translate a b v) :=
+  ⟨translateEdge a b ie.1, by
+    rcases translateEdge_endpoints a b ie.1 with ⟨h1, h2⟩ | ⟨h1, h2⟩
+    · rcases ie.2 with hv | hv
+      · exact Or.inl (by rw [h1, hv])
+      · exact Or.inr (by rw [h2, hv])
+    · rcases ie.2 with hv | hv
+      · exact Or.inr (by rw [h2, hv])
+      · exact Or.inl (by rw [h1, hv])⟩
+
+@[simp] theorem translateIncidentEdge_coe (a : ZMod width) (b : ZMod height)
+    (v : TorusVertex width height) (ie : IncidentEdge (torusGraph width height) v) :
+    (translateIncidentEdge a b v ie).1 = translateEdge a b ie.1 :=
+  rfl
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusTranslationInvariant.lean
+++ b/TNLean/PEPS/TorusTranslationInvariant.lean
@@ -1,0 +1,272 @@
+import TNLean.PEPS.TorusTranslation
+import TNLean.PEPS.IsoTransport
+
+/-!
+# Translation-invariant PEPS tensors on the torus
+
+A PEPS on the discrete torus (`TNLean/PEPS/TorusLatticeGraph.lean`) is
+**translation invariant** when it is fixed by transport along every translation
+automorphism: `A.transport (translate a b) = A` for all coordinate offsets
+`(a, b)`.  This is the faithful formalization of the source's setting, where one
+tensor is repeated at every site of a lattice on which translation is a symmetry
+(arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`).
+
+Translation invariance has two consequences used by the source's gauge reduction.
+First, the state coefficient is invariant under the precomposed translation of the
+physical configuration (`stateCoeff_translationInvariant`).  Second, the bond
+dimension at any edge equals the bond dimension at every translate of that edge
+(`bondDim_translateEdge_of_translationInvariant`); since the translations act
+transitively on each orientation class — every horizontal edge is the translate of
+every other, and likewise for vertical edges — this is the constant-bond content
+that makes the reduction to one horizontal and one vertical matrix well typed.  The
+transitivity is supported by the normal-form characterization
+`isHorizontalTorusEdge_eq_rightEdge` writing each horizontal edge as the right edge
+of its left endpoint; the full orientation-class constancy
+(`SquareLatticeUniformBondDim`'s torus analogue) is the next step, recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, remaining obligation 6.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1407--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- A PEPS tensor on the torus is **translation invariant** when it is fixed by
+transport along every translation automorphism.  This is the faithful statement of
+the source's setting: one tensor repeated at every site, with translation a
+symmetry of the network.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def IsTorusTranslationInvariant (A : Tensor (torusGraph width height) d) : Prop :=
+  ∀ (a : ZMod width) (b : ZMod height), A.transport (translate a b) = A
+
+/-- The edge action of the translation `(a, b)` coincides with the edge action of
+the translation automorphism `translate a b`: both push the endpoints through the
+translation and reorder them into the `Edge` convention. -/
+theorem translateEdge_eq_map (a : ZMod width) (b : ZMod height)
+    (e : Edge (torusGraph width height)) :
+    translateEdge a b e = Edge.map (translate a b) e :=
+  rfl
+
+/-- The state coefficient of a translation-invariant tensor is invariant under the
+translation of the physical configuration: shifting `σ` by a translation leaves the
+coefficient unchanged.  This is the physical-level statement of translation
+invariance, obtained from `stateCoeff_transport` and the defining fixed-point
+equation.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem stateCoeff_translationInvariant {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (a : ZMod width) (b : ZMod height)
+    (σ : TorusVertex width height → Fin d) :
+    stateCoeff A (fun v => σ (translate a b v)) = stateCoeff A σ := by
+  have h := hA a b
+  calc stateCoeff A (fun v => σ (translate a b v))
+      = stateCoeff (A.transport (translate a b)) σ := (stateCoeff_transport A _ σ).symm
+    _ = stateCoeff A σ := by rw [h]
+
+/-! ### Constant bond dimension on each orientation class
+
+A translation-invariant tensor has the same bond dimension on all horizontal edges
+and the same bond dimension on all vertical edges.  The translation moving one
+horizontal edge to another carries the bond dimension across, so within each
+orientation class the bond dimension is constant.  This is the constant-bond
+content recorded abstractly by `SquareLatticeUniformBondDim` on the open lattice;
+here it is the torus analogue. -/
+
+/-- The bond dimension of a translation-invariant tensor at the translate of an
+edge equals the bond dimension at the original edge.  Transport invariance gives
+`A.bondDim (translateEdge a b e) = A.bondDim e` after reindexing through the edge
+action.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_translateEdge_of_translationInvariant
+    {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (a : ZMod width) (b : ZMod height)
+    (e : Edge (torusGraph width height)) :
+    A.bondDim (translateEdge a b e) = A.bondDim e := by
+  have h := hA a b
+  have hb : (A.transport (translate a b)).bondDim (translateEdge a b e) =
+      A.bondDim (translateEdge a b e) := by rw [h]
+  rw [Tensor.transport_bondDim] at hb
+  rw [← hb]
+  congr 1
+  -- Edge.map (translate a b).symm (translateEdge a b e) = e
+  change Edge.map (translate a b).symm (Edge.map (translate a b) e) = e
+  exact Edge.map_symm_map (translate a b) e
+
+/-! ### Normal form of horizontal and vertical torus edges
+
+Each horizontal edge is the right edge of a well-defined left endpoint `p`, the
+edge with unordered endpoints `p` and `p + (1, 0)`.  The lexicographic order may
+place either of these first (the coordinate value wraps around the torus), so the
+left endpoint is read from whichever incidence carries the `+1` step.  This normal
+form is the bookkeeping that makes the translations act transitively on the
+horizontal class: translating the left endpoint of one horizontal edge to the left
+endpoint of another carries the whole edge across. -/
+
+/-- The horizontal torus edge with left endpoint `p`, i.e. the edge on the adjacent
+pair `(p, p + (1, 0))`. -/
+def torusRightEdge (p : TorusVertex width height) : Edge (torusGraph width height) :=
+  Edge.ofAdj (torusGraph_adj_right p.1 p.2)
+
+/-- The vertical torus edge with lower endpoint `p`, i.e. the edge on the adjacent
+pair `(p, p + (0, 1))`. -/
+def torusUpEdge (p : TorusVertex width height) : Edge (torusGraph width height) :=
+  Edge.ofAdj (torusGraph_adj_up p.1 p.2)
+
+/-- Every horizontal torus edge is the right edge of a left endpoint `p`: its
+unordered endpoints are `p` and `p + (1, 0)`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isHorizontalTorusEdge_eq_rightEdge {e : Edge (torusGraph width height)}
+    (he : IsHorizontalTorusEdge e) :
+    ∃ p : TorusVertex width height, e = torusRightEdge p := by
+  have hc : e.1.1.2 = e.1.2.2 := he.1
+  rcases he.2 with h2 | h2
+  · refine ⟨e.1.1, ?_⟩
+    rw [torusRightEdge]
+    symm
+    apply Edge.ofAdj_eq_of_endpoints
+    exact Or.inl ⟨rfl, Prod.ext (by exact h2) (by simpa using hc)⟩
+  · refine ⟨e.1.2, ?_⟩
+    rw [torusRightEdge]
+    symm
+    apply Edge.ofAdj_eq_of_endpoints
+    exact Or.inr ⟨rfl, Prod.ext (by exact h2) (by simpa using hc.symm)⟩
+
+/-- Every vertical torus edge is the up edge of a lower endpoint `p`: its unordered
+endpoints are `p` and `p + (0, 1)`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isVerticalTorusEdge_eq_upEdge {e : Edge (torusGraph width height)}
+    (he : IsVerticalTorusEdge e) :
+    ∃ p : TorusVertex width height, e = torusUpEdge p := by
+  have hc : e.1.1.1 = e.1.2.1 := he.1
+  rcases he.2 with h2 | h2
+  · refine ⟨e.1.1, ?_⟩
+    rw [torusUpEdge]
+    symm
+    apply Edge.ofAdj_eq_of_endpoints
+    exact Or.inl ⟨rfl, Prod.ext (by simpa using hc) (by exact h2)⟩
+  · refine ⟨e.1.2, ?_⟩
+    rw [torusUpEdge]
+    symm
+    apply Edge.ofAdj_eq_of_endpoints
+    exact Or.inr ⟨rfl, Prod.ext (by simpa using hc.symm) (by exact h2)⟩
+
+/-! ### Transitivity of translations on each orientation class
+
+Translation carries the right edge of `p` to the right edge of the translated
+point, and likewise for up edges.  Hence any two horizontal edges (any two
+vertical edges) are related by a translation, so a translation-invariant tensor has
+the same bond dimension throughout each orientation class. -/
+
+/-- Translation carries the right edge of `p` to the right edge of `p + (a, b)`. -/
+theorem translateEdge_torusRightEdge (a : ZMod width) (b : ZMod height)
+    (p : TorusVertex width height) :
+    translateEdge a b (torusRightEdge p) = torusRightEdge (p.1 + a, p.2 + b) := by
+  rw [torusRightEdge, torusRightEdge, translateEdge_eq_map, Edge.map]
+  apply Edge.ofAdj_eq_ofAdj
+  rcases Edge.ofAdj_endpoints (torusGraph_adj_right p.1 p.2) with ⟨o1, o2⟩ | ⟨o1, o2⟩
+  · exact Or.inl ⟨by rw [o1]; apply Prod.ext <;> simp [translate_apply],
+      by rw [o2]; apply Prod.ext <;> simp [translate_apply]; ring⟩
+  · exact Or.inr ⟨by rw [o1]; apply Prod.ext <;> simp [translate_apply]; ring,
+      by rw [o2]; apply Prod.ext <;> simp [translate_apply]⟩
+
+/-- Translation carries the up edge of `p` to the up edge of `p + (a, b)`. -/
+theorem translateEdge_torusUpEdge (a : ZMod width) (b : ZMod height)
+    (p : TorusVertex width height) :
+    translateEdge a b (torusUpEdge p) = torusUpEdge (p.1 + a, p.2 + b) := by
+  rw [torusUpEdge, torusUpEdge, translateEdge_eq_map, Edge.map]
+  apply Edge.ofAdj_eq_ofAdj
+  rcases Edge.ofAdj_endpoints (torusGraph_adj_up p.1 p.2) with ⟨o1, o2⟩ | ⟨o1, o2⟩
+  · exact Or.inl ⟨by rw [o1]; apply Prod.ext <;> simp [translate_apply],
+      by rw [o2]; apply Prod.ext <;> simp [translate_apply]; ring⟩
+  · exact Or.inr ⟨by rw [o1]; apply Prod.ext <;> simp [translate_apply]; ring,
+      by rw [o2]; apply Prod.ext <;> simp [translate_apply]⟩
+
+/-- A translation-invariant tensor has the same bond dimension on every horizontal
+edge: the bond dimension of any right edge is independent of its left endpoint.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_torusRightEdge_const {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (p p' : TorusVertex width height) :
+    A.bondDim (torusRightEdge p') = A.bondDim (torusRightEdge p) := by
+  have key : translateEdge (p'.1 - p.1) (p'.2 - p.2) (torusRightEdge p) = torusRightEdge p' := by
+    rw [translateEdge_torusRightEdge]; congr 1; apply Prod.ext <;> simp
+  rw [← key]
+  exact bondDim_translateEdge_of_translationInvariant hA _ _ (torusRightEdge p)
+
+/-- A translation-invariant tensor has the same bond dimension on every vertical
+edge: the bond dimension of any up edge is independent of its lower endpoint.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem bondDim_torusUpEdge_const {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (p p' : TorusVertex width height) :
+    A.bondDim (torusUpEdge p') = A.bondDim (torusUpEdge p) := by
+  have key : translateEdge (p'.1 - p.1) (p'.2 - p.2) (torusUpEdge p) = torusUpEdge p' := by
+    rw [translateEdge_torusUpEdge]; congr 1; apply Prod.ext <;> simp
+  rw [← key]
+  exact bondDim_translateEdge_of_translationInvariant hA _ _ (torusUpEdge p)
+
+/-! ### Constant bond dimension on each orientation class
+
+The bond dimension of a translation-invariant tensor is `Dh` on every horizontal
+edge and `Dv` on every vertical edge, where `Dh` and `Dv` are read off at a
+reference edge of each class.  This is the torus analogue of
+`SquareLatticeUniformBondDim`, the constant-bond content that makes the reduction
+to one horizontal and one vertical matrix well typed.  The lattice has at least one
+edge of each orientation, so the reference dimensions exist. -/
+
+/-- The bond-dimension function of a tensor on the torus is **orientation uniform**
+with horizontal dimension `Dh` and vertical dimension `Dv` when every horizontal
+edge has bond dimension `Dh` and every vertical edge has bond dimension `Dv`.  This
+is the torus analogue of `SquareLatticeUniformBondDim`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def TorusUniformBondDim (bondDim : Edge (torusGraph width height) → ℕ) (Dh Dv : ℕ) : Prop :=
+  (∀ e : Edge (torusGraph width height), IsHorizontalTorusEdge e → bondDim e = Dh) ∧
+    (∀ e : Edge (torusGraph width height), IsVerticalTorusEdge e → bondDim e = Dv)
+
+/-- **A translation-invariant tensor has orientation-uniform bond dimensions.**
+
+Reading off the horizontal dimension `Dh` at the right edge of the origin and the
+vertical dimension `Dv` at the up edge of the origin, every horizontal edge has
+bond dimension `Dh` and every vertical edge has bond dimension `Dv`.  Each edge is
+the right edge (respectively up edge) of its endpoint by the normal form, and the
+class constancy carries the reference dimension across.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`, where translation invariance makes the gauge
+"the same matrix on all horizontal (vertical) edges". -/
+theorem torusUniformBondDim_of_translationInvariant {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) :
+    TorusUniformBondDim A.bondDim
+      (A.bondDim (torusRightEdge 0)) (A.bondDim (torusUpEdge 0)) := by
+  refine ⟨fun e he => ?_, fun e he => ?_⟩
+  · obtain ⟨p, rfl⟩ := isHorizontalTorusEdge_eq_rightEdge he
+    exact bondDim_torusRightEdge_const hA 0 p
+  · obtain ⟨p, rfl⟩ := isVerticalTorusEdge_eq_upEdge he
+    exact bondDim_torusUpEdge_const hA 0 p
+
+end PEPS
+end TNLean


### PR DESCRIPTION
## What

The **periodic-lattice foundation** for the source's translation-invariant square-lattice
Normal PEPS FT (#1373, arXiv:1804.04964 §3 Theorem 3) — the final structural input above
the merged per-edge gauge machinery. Four new files; all sorry-free; `#print axioms` =
`[propext, Classical.choice, Quot.sound]`; full root build green (8,848 jobs).

## Highlights

- **`TorusVertex`/`torusGraph`** (TorusLatticeGraph.lean): `ZMod w × ZMod h` with the cyclic
  nearest-neighbour graph, orientation predicates + partition, and the lexicographic
  `LinearOrder` with the **pinned `DecidableEq`** (the `Function.Injective.linearOrder`
  pattern — the merged instance lesson applied from the start).
- **The translation automorphisms** (TorusTranslation.lean): `translate : torusGraph ≃g
  torusGraph` with edge/incident-edge actions; the **wraparound bookkeeping** solved by a
  new generic `Edge.ofAdj` normal-form constructor (lex can flip endpoint order on
  wraparound; the unordered-pair determinism layer makes orientation-class transitivity
  hold regardless).
- **Generic iso transport** (IsoTransport.lean): `Tensor.transport (φ : G ≃g G')` with the
  load-bearing `stateCoeff_transport` and `SameState.transport`.
- **The faithful TI predicate** (TorusTranslationInvariant.lean):
  `IsTorusTranslationInvariant A := ∀ a b, A.transport (translate a b) = A` — the source's
  "one tensor repeated at every site" — with `stateCoeff_translationInvariant`, the edge
  normal forms, orientation-class transitivity, and
  `torusUniformBondDim_of_translationInvariant` (the constant-bond input to the source's
  one-X/one-Y reduction).

## Next (documented)

Port the interior-edge blocking machinery to the torus (every torus edge is interior) and
prove the per-orientation-class transfer-map agreement feeding the merged
`isOrientationUniformGaugeFamilyModScalar_of_classAgreement` — then the source's TI theorem
assembles from merged pieces.

Refs #1373. CI `blueprint-and-prose`/`track`/`claude-review-*` failures are non-blocking
automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New sorry-free PEPS foundation modules with no auth, I/O, or changes to existing theorem APIs; risk is mainly build surface and future integration with blocking/gauge code.
> 
> **Overview**
> Adds the **periodic torus PEPS layer** for the translation-invariant normal PEPS track: four new modules wired into `TNLean.lean`, plus shared edge bookkeeping in `Defs.lean`.
> 
> **`Edge.ofAdj`** in `Defs.lean` turns an adjacent pair into the ordered `Edge` type (smaller endpoint first), with lemmas so pushforward through bijections/translations is well defined when lex order flips on wraparound.
> 
> **`IsoTransport.lean`** defines **`Tensor.transport`** along `G ≃g G'`, with `Edge.map`, incident-edge equivalences, **`stateCoeff_transport`**, and **`SameState.transport`**—the generic symmetry input reused for torus translations.
> 
> **`TorusLatticeGraph.lean`** introduces `TorusVertex` / **`torusGraph`** on `ZMod × ZMod`, lex `LinearOrder` (pinned `DecidableEq`), horizontal/vertical edge classes, and adjacency/orientation lemmas.
> 
> **`TorusTranslation.lean`** builds coordinate **`translate`** as a graph automorphism and **`translateEdge`** / **`translateIncidentEdge`** via `Edge.ofAdj`.
> 
> **`TorusTranslationInvariant.lean`** defines **`IsTorusTranslationInvariant`** as fixed point under all transports, then proves state-coefficient invariance, edge normal forms, translation transitivity on each orientation class, and **`torusUniformBondDim_of_translationInvariant`** (torus analogue of `SquareLatticeUniformBondDim`).
> 
> No changes to existing gauge/blocking theorems in this diff—foundation only, ahead of porting interior-edge machinery to the torus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ecba9163eb90953be8751a30807b5f3ca10ac13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->