### PR TITLE
feat(PEPS): region transport covariance and the torus orientation-uniform gauge assembly

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -402,6 +402,7 @@ import TNLean.PEPS.RegionTransport
 import TNLean.PEPS.RegionTransportData
 import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.TorusBlockingData
+import TNLean.PEPS.TorusEdgeGauge
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -398,6 +398,7 @@ import TNLean.PEPS.SquareLatticeGraph
 import TNLean.PEPS.TorusLatticeGraph
 import TNLean.PEPS.TorusTranslation
 import TNLean.PEPS.IsoTransport
+import TNLean.PEPS.RegionTransport
 import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -403,6 +403,7 @@ import TNLean.PEPS.RegionTransportData
 import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge
+import TNLean.PEPS.TorusOrientationGauge
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -404,6 +404,7 @@ import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge
 import TNLean.PEPS.TorusOrientationGauge
+import TNLean.PEPS.TorusTINormalGauge
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -401,6 +401,7 @@ import TNLean.PEPS.IsoTransport
 import TNLean.PEPS.RegionTransport
 import TNLean.PEPS.RegionTransportData
 import TNLean.PEPS.TorusTranslationInvariant
+import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -399,6 +399,7 @@ import TNLean.PEPS.TorusLatticeGraph
 import TNLean.PEPS.TorusTranslation
 import TNLean.PEPS.IsoTransport
 import TNLean.PEPS.RegionTransport
+import TNLean.PEPS.RegionTransportData
 import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover

--- a/TNLean/PEPS/RegionTransport.lean
+++ b/TNLean/PEPS/RegionTransport.lean
@@ -171,5 +171,111 @@ theorem regionBoundaryLabel_transport_iff (A : Tensor G d) (φ : G ≃g G') (R :
   rw [regionBoundaryLabel_transport]
   exact (regionBoundaryConfigMap_injective A φ R).eq_iff
 
+/-! ### Transport of the blocked-region weight and its injectivity -/
+
+omit [Fintype V] [Fintype W] in
+/-- The vertex product of `A.transport φ` over the image region, at the transported
+configurations, equals the vertex product of `A` over `R`: each factor at `w` matches the
+factor of `A` at `φ.symm w` by `transport_component_vcEquiv`, and the vertices reindex by
+`regionVertexMapEquiv`. -/
+theorem regionVertexProd_transport (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (η : VirtualConfig A) (τ : RegionPhysicalConfig (V := V) (d := d) R) :
+    ∏ w : {w : W // w ∈ Region.map φ R},
+        (A.transport φ).component w.1
+          (fun ie => ((vcEquiv A φ).symm η) ie.1) (regionPhysicalConfigMap φ R τ w)
+      = ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => η ie.1) (τ w) := by
+  rw [← Equiv.prod_comp (regionVertexMapEquiv φ R)
+    (fun w : {w : V // w ∈ R} => A.component w.1 (fun ie => η ie.1) (τ w))]
+  refine Finset.prod_congr rfl fun w _ => ?_
+  -- The image vertex `w.1` has preimage `φ.symm w.1 = (regionVertexMapEquiv φ R w).1`.
+  have hphys : regionPhysicalConfigMap φ R τ w = τ (regionVertexMapEquiv φ R w) := rfl
+  rw [hphys]
+  -- `transport_component_vcEquiv` matches the component at `w.1` with the component of `A`
+  -- at `φ.symm w.1`, using any global physical configuration agreeing at `w.1`.
+  exact transport_component_vcEquiv A φ η
+    (fun _ => τ (regionVertexMapEquiv φ R w)) w.1
+
+open scoped Classical in
+/-- **Transport of the blocked-region weight.**
+
+The blocked-region weight of `A.transport φ` over the image region, at the transported
+boundary and physical configurations, equals the blocked-region weight of `A` over `R`.
+The open boundary legs reindex by the edge action, the contracted virtual configurations by
+`vcEquiv`, and the vertex product by `φ`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedWeight_transport (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (bdry : RegionBoundaryConfig (G := G) A R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) R) :
+    regionBlockedWeight (G := G') (A.transport φ) (Region.map φ R)
+        (regionBoundaryConfigMap A φ R bdry) (regionPhysicalConfigMap φ R τ) =
+      regionBlockedWeight (G := G) A R bdry τ := by
+  rw [regionBlockedWeight, regionBlockedWeight]
+  -- Rewrite both filtered sums as sums over all configurations with an indicator.
+  rw [Finset.sum_filter, Finset.sum_filter]
+  -- Reindex the contracted virtual configurations by `vcEquiv`.
+  rw [← Equiv.sum_comp (vcEquiv A φ).symm
+    (fun ζ : VirtualConfig (A.transport φ) =>
+      if regionBoundaryLabel (G := G') (A.transport φ) (Region.map φ R) ζ =
+          regionBoundaryConfigMap A φ R bdry then
+        ∏ w : {w : W // w ∈ Region.map φ R},
+          (A.transport φ).component w.1 (fun ie => ζ ie.1) (regionPhysicalConfigMap φ R τ w)
+      else 0)]
+  refine Finset.sum_congr rfl fun η _ => ?_
+  by_cases hb : regionBoundaryLabel (G := G) A R η = bdry
+  · rw [if_pos hb, if_pos ((regionBoundaryLabel_transport_iff A φ R η bdry).mpr hb),
+      regionVertexProd_transport]
+  · rw [if_neg hb, if_neg (fun h => hb ((regionBoundaryLabel_transport_iff A φ R η bdry).mp h))]
+
+/-- The physical-configuration equivalence induced by `φ` on the region. -/
+def regionPhysicalConfigMapEquiv (φ : G ≃g G') (R : Finset V) :
+    RegionPhysicalConfig (V := V) (d := d) R ≃
+      RegionPhysicalConfig (V := W) (d := d) (Region.map φ R) where
+  toFun := regionPhysicalConfigMap φ R
+  invFun τ' w := τ' ((regionVertexMapEquiv φ R).symm w)
+  left_inv τ := by funext w; simp [regionPhysicalConfigMap]
+  right_inv τ' := by funext w; simp [regionPhysicalConfigMap]
+
+/-- The transported blocked-region tensor family is the original family reindexed: the
+boundary index by `regionBoundaryConfigMapEquiv`, the physical-leg domain by
+`regionPhysicalConfigMapEquiv`.  This rewrites the weight transport as a composition with the
+domain-reindexing linear equivalence `LinearEquiv.funCongrLeft`. -/
+theorem regionBlockedTensorFamily_transport_comp (A : Tensor G d) (φ : G ≃g G') (R : Finset V) :
+    regionBlockedTensorFamily (G := G') (A.transport φ) (Region.map φ R) ∘
+        regionBoundaryConfigMapEquiv A φ R =
+      (LinearEquiv.funCongrLeft ℂ ℂ
+          (regionPhysicalConfigMapEquiv (d := d) φ R).symm).toLinearMap ∘
+        regionBlockedTensorFamily (G := G) A R := by
+  funext bdry
+  funext τ'
+  simp only [Function.comp_apply, LinearEquiv.coe_coe, LinearEquiv.funCongrLeft_apply,
+    LinearMap.funLeft_apply, regionBlockedTensorFamily]
+  rw [regionBoundaryConfigMapEquiv_apply,
+    ← regionBlockedWeight_transport A φ R bdry
+      ((regionPhysicalConfigMapEquiv (d := d) φ R).symm τ')]
+  congr 1
+  show τ' = regionPhysicalConfigMap φ R ((regionPhysicalConfigMapEquiv (d := d) φ R).symm τ')
+  exact ((regionPhysicalConfigMapEquiv (d := d) φ R).apply_symm_apply τ').symm
+
+/-- **Transport of blocked-region injectivity.**
+
+A finite region `R` is blocked-tensor injective for `A` iff its image region is blocked-tensor
+injective for `A.transport φ`.  The blocked weight family transports by reindexing the boundary
+configurations and the physical legs, and linear independence is invariant under such
+relabelling.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorInjective_transport (A : Tensor G d) (φ : G ≃g G') (R : Finset V) :
+    RegionBlockedTensorInjective (G := G') (A.transport φ) (Region.map φ R) ↔
+      RegionBlockedTensorInjective (G := G) A R := by
+  rw [RegionBlockedTensorInjective, RegionBlockedTensorInjective,
+    ← linearIndependent_equiv' (regionBoundaryConfigMapEquiv A φ R)
+      (regionBlockedTensorFamily_transport_comp A φ R)]
+  exact (LinearEquiv.funCongrLeft ℂ ℂ
+    (regionPhysicalConfigMapEquiv (d := d) φ R).symm).toLinearMap.linearIndependent_iff
+    (LinearEquiv.ker _)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionTransport.lean
+++ b/TNLean/PEPS/RegionTransport.lean
@@ -1,0 +1,175 @@
+import TNLean.PEPS.IsoTransport
+import TNLean.PEPS.RegionBlock.Basic
+
+/-!
+# Transport of blocked-region injectivity along a graph isomorphism
+
+A graph isomorphism `φ : G ≃g G'` carries a finite vertex region `R` of `G` to its
+image region `R.map φ.toEquiv.toEmbedding` of `G'`.  The blocked-region weight of the
+transported tensor `A.transport φ` over that image region is a relabelling of the
+blocked-region weight of `A` over `R`: the boundary edges, the open virtual legs, and
+the physical legs on the region all carry across by the edge action `Edge.map φ` and
+the vertex bijection `φ` (`regionBlockedWeight_transport`).  Linear independence is a
+relabelling invariant, so blocked-region injectivity transports
+(`regionBlockedTensorInjective_transport`).
+
+This is the geometric covariance that turns one reference blocking datum on the torus
+into blocking data at every translate of the reference edge: a translation-invariant
+tensor satisfies `A.transport (translate a b) = A`, so the transported region datum is
+a datum for the *same* tensor at the translated edge
+(`TNLean/PEPS/TorusTranslationInvariant.lean`).
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1407--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators
+
+namespace TNLean
+namespace PEPS
+
+variable {V W : Type*} [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  {G : SimpleGraph V} {G' : SimpleGraph W} {d : ℕ}
+variable [DecidableRel G.Adj] [DecidableRel G'.Adj]
+
+/-! ### The image region of a graph isomorphism -/
+
+/-- The image of a finite region `R` of `G` under the vertex bijection of `φ`. -/
+def Region.map (φ : G ≃g G') (R : Finset V) : Finset W :=
+  R.map φ.toEquiv.toEmbedding
+
+omit [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+@[simp] theorem mem_Region_map (φ : G ≃g G') (R : Finset V) (w : W) :
+    w ∈ Region.map φ R ↔ φ.symm w ∈ R := by
+  simp only [Region.map, Finset.mem_map, Equiv.coe_toEmbedding]
+  constructor
+  · rintro ⟨v, hv, rfl⟩
+    rw [show (φ.toEquiv : V → W) v = φ v from rfl,
+      show φ.symm (φ v) = v from φ.symm_apply_apply v]; exact hv
+  · intro h
+    refine ⟨φ.symm w, h, ?_⟩
+    rw [show (φ.toEquiv : V → W) (φ.symm w) = φ (φ.symm w) from rfl, φ.apply_symm_apply w]
+
+omit [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- A vertex `v` lies in `R` iff `φ v` lies in the image region. -/
+theorem mem_Region_map_apply (φ : G ≃g G') (R : Finset V) (v : V) :
+    φ v ∈ Region.map φ R ↔ v ∈ R := by
+  rw [mem_Region_map]
+  rw [show φ.symm (φ v) = v from φ.symm_apply_apply v]
+
+/-! ### Covariance of the region boundary -/
+
+omit [Fintype V] [Fintype W] [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- An edge `f` of `G` crosses the boundary of `R` iff its image `Edge.map φ f`
+crosses the boundary of the image region.  The endpoints carry across by `φ`, which
+preserves membership in `R`. -/
+theorem isRegionBoundaryEdge_map (φ : G ≃g G') (R : Finset V) (f : Edge G) :
+    IsRegionBoundaryEdge (G := G') (Region.map φ R) (Edge.map φ f) ↔
+      IsRegionBoundaryEdge (G := G) R f := by
+  have key : ∀ x : V, x ∈ R ↔ φ x ∈ Region.map φ R := fun x =>
+    (mem_Region_map_apply φ R x).symm
+  rw [IsRegionBoundaryEdge, IsRegionBoundaryEdge]
+  rcases Edge.map_endpoints φ f with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · rw [h1, h2, ← key, ← key]
+  · rw [h1, h2, ← key, ← key]; tauto
+
+/-! ### Reindexing equivalences of region index types -/
+
+/-- The boundary edges of the image region correspond to the boundary edges of `R`
+by the inverse edge action `Edge.map φ.symm`. -/
+def regionBoundaryEdgeMapEquiv (φ : G ≃g G') (R : Finset V) :
+    {f : Edge G' // IsRegionBoundaryEdge (G := G') (Region.map φ R) f} ≃
+      {f : Edge G // IsRegionBoundaryEdge (G := G) R f} where
+  toFun f := ⟨Edge.map φ.symm f.1, by
+    have h := isRegionBoundaryEdge_map φ R (Edge.map φ.symm f.1)
+    rw [Edge.map_map_symm] at h
+    exact h.mp f.2⟩
+  invFun f := ⟨Edge.map φ f.1, (isRegionBoundaryEdge_map φ R f.1).mpr f.2⟩
+  left_inv f := by apply Subtype.ext; simp [Edge.map_map_symm]
+  right_inv f := by apply Subtype.ext; simp [Edge.map_symm_map]
+
+/-- The vertices of the image region correspond to the vertices of `R` by `φ`. -/
+def regionVertexMapEquiv (φ : G ≃g G') (R : Finset V) :
+    {w : W // w ∈ Region.map φ R} ≃ {w : V // w ∈ R} where
+  toFun w := ⟨φ.symm w.1, (mem_Region_map φ R w.1).mp w.2⟩
+  invFun w := ⟨φ w.1, (mem_Region_map_apply φ R w.1).mpr w.2⟩
+  left_inv w := by apply Subtype.ext; simp
+  right_inv w := by apply Subtype.ext; simp
+
+/-! ### Transport of the blocked-region weight
+
+The blocked-region weight of `A.transport φ` over the image region is the blocked-region
+weight of `A` over `R`, after relabelling the open boundary legs by `Edge.map φ` and the
+physical legs by `φ`.  The bond dimension of `A.transport φ` at a boundary edge `f'` of the
+image region is, by definition, `A.bondDim (Edge.map φ.symm f')`, so the boundary index types
+match definitionally under `regionBoundaryEdgeMapEquiv`. -/
+
+/-- The boundary-configuration equivalence induced by the edge action: relabel the open
+boundary legs along `regionBoundaryEdgeMapEquiv`.  Built as a `piCongrLeft'`, so it is an
+honest equivalence; the bond dimensions match because
+`(A.transport φ).bondDim f' = A.bondDim (Edge.map φ.symm f')` by definition. -/
+def regionBoundaryConfigMapEquiv (A : Tensor G d) (φ : G ≃g G') (R : Finset V) :
+    RegionBoundaryConfig (G := G) A R ≃
+      RegionBoundaryConfig (G := G') (A.transport φ) (Region.map φ R) :=
+  Equiv.piCongrLeft' (fun f => Fin (A.bondDim f.1)) (regionBoundaryEdgeMapEquiv φ R).symm
+
+/-- The boundary configuration on the image region induced from one on `R` by the edge
+action.  The bond dimensions match definitionally:
+`(A.transport φ).bondDim f' = A.bondDim (Edge.map φ.symm f')`. -/
+def regionBoundaryConfigMap (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (bdry : RegionBoundaryConfig (G := G) A R) :
+    RegionBoundaryConfig (G := G') (A.transport φ) (Region.map φ R) :=
+  fun f => bdry (regionBoundaryEdgeMapEquiv φ R f)
+
+omit [Fintype V] [Fintype W] in
+/-- The boundary-configuration map is the forward direction of its equivalence. -/
+theorem regionBoundaryConfigMapEquiv_apply (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (bdry : RegionBoundaryConfig (G := G) A R) :
+    regionBoundaryConfigMapEquiv A φ R bdry = regionBoundaryConfigMap A φ R bdry :=
+  rfl
+
+/-- The physical configuration on the image region induced from one on `R` by `φ`. -/
+def regionPhysicalConfigMap (φ : G ≃g G') (R : Finset V)
+    (τ : RegionPhysicalConfig (V := V) (d := d) R) :
+    RegionPhysicalConfig (V := W) (d := d) (Region.map φ R) :=
+  fun w => τ (regionVertexMapEquiv φ R w)
+
+omit [Fintype V] [Fintype W] in
+/-- The boundary-configuration map is injective. -/
+theorem regionBoundaryConfigMap_injective (A : Tensor G d) (φ : G ≃g G') (R : Finset V) :
+    Function.Injective (regionBoundaryConfigMap A φ R) := by
+  have h : regionBoundaryConfigMap A φ R = regionBoundaryConfigMapEquiv A φ R := by
+    funext bdry; rw [regionBoundaryConfigMapEquiv_apply]
+  rw [h]; exact (regionBoundaryConfigMapEquiv A φ R).injective
+
+omit [Fintype V] [Fintype W] in
+/-- The boundary label that `(vcEquiv A φ).symm η` reads on the image region is the
+forward boundary-configuration map of the boundary label that `η` reads on `R`. -/
+theorem regionBoundaryLabel_transport (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (η : VirtualConfig A) :
+    regionBoundaryLabel (G := G') (A.transport φ) (Region.map φ R) ((vcEquiv A φ).symm η) =
+      regionBoundaryConfigMap A φ R (regionBoundaryLabel (G := G) A R η) := by
+  funext f
+  simp only [regionBoundaryLabel_apply, regionBoundaryConfigMap, vcEquiv_symm_apply]
+  rfl
+
+omit [Fintype V] [Fintype W] in
+/-- The transported virtual configuration carries the boundary label `bdry'` iff the
+original configuration carries the preimage boundary label.  Used to reindex the
+filtered sum in the blocked-region weight. -/
+theorem regionBoundaryLabel_transport_iff (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (η : VirtualConfig A) (bdry : RegionBoundaryConfig (G := G) A R) :
+    regionBoundaryLabel (G := G') (A.transport φ) (Region.map φ R) ((vcEquiv A φ).symm η) =
+        regionBoundaryConfigMap A φ R bdry ↔
+      regionBoundaryLabel (G := G) A R η = bdry := by
+  rw [regionBoundaryLabel_transport]
+  exact (regionBoundaryConfigMap_injective A φ R).eq_iff
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionTransport.lean
+++ b/TNLean/PEPS/RegionTransport.lean
@@ -63,6 +63,15 @@ theorem mem_Region_map_apply (φ : G ≃g G') (R : Finset V) (v : V) :
   rw [mem_Region_map]
   rw [show φ.symm (φ v) = v from φ.symm_apply_apply v]
 
+omit [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- The image of the set complement is the set complement of the image: the edge action carries
+`univ \ R` to `univ \ (Region.map φ R)`.  This is the bookkeeping that lets the complement-side
+contraction of the region-inserted coefficient transport. -/
+theorem Region_map_compl (φ : G ≃g G') (R : Finset V) :
+    Region.map φ (Finset.univ \ R) = Finset.univ \ Region.map φ R := by
+  ext w
+  simp only [mem_Region_map, Finset.mem_sdiff, Finset.mem_univ, true_and]
+
 /-! ### Covariance of the region boundary -/
 
 omit [Fintype V] [Fintype W] [DecidableRel G.Adj] [DecidableRel G'.Adj] in

--- a/TNLean/PEPS/RegionTransportData.lean
+++ b/TNLean/PEPS/RegionTransportData.lean
@@ -1,0 +1,216 @@
+import TNLean.PEPS.RegionTransport
+import TNLean.PEPS.NormalEdgeBlockingData
+import TNLean.PEPS.RegionBlock.CoarseThreeSite2
+import TNLean.PEPS.RegionBlock.UnionClosure
+
+/-!
+# Transport of one-edge blocking data along a graph isomorphism
+
+A one-edge blocking datum over `regionInjectivityDataOf A` at an edge `e` transports along a
+graph isomorphism `φ : G ≃g G'` to a one-edge blocking datum over
+`regionInjectivityDataOf (A.transport φ)` at the image edge `Edge.map φ e`.  Its three blocks
+are the image regions of the original blocks, blocked-tensor injective by
+`regionBlockedTensorInjective_transport`, partitioning the vertex set because images of a
+partition partition.  The endpoint memberships are read off the image-edge endpoints; the edge
+action may swap the lexicographic order of the two endpoints, so the red and blue blocks are
+exchanged exactly when the order flips, leaving the unordered datum intact
+(`transportBlockingDataAlong`).
+
+The red-to-blue crossing transports because crossing is the conjunction of two boundary-edge
+conditions, each preserved by `isRegionBoundaryEdge_map`
+(`isCrossingEdge_transportBlockingDataAlong`).
+
+This is the mechanism that carries one reference blocking datum on the discrete torus to every
+translate of the reference edge: a translation-invariant tensor satisfies
+`A.transport (translate a b) = A`, so the transported datum is a datum for the *same* tensor at
+the translated edge.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+  1407--1572 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators
+
+namespace TNLean
+namespace PEPS
+
+variable {V W : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+  [Fintype W] [DecidableEq W] [LinearOrder W]
+  {G : SimpleGraph V} {G' : SimpleGraph W} {d : ℕ}
+variable [DecidableRel G.Adj] [DecidableRel G'.Adj]
+
+/-! ### Image-partition bookkeeping -/
+
+omit [Fintype V] [DecidableEq V] [LinearOrder V] [Fintype W] [DecidableEq W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- The image of a partition under `φ` partitions the image: disjoint image regions stay
+disjoint, and the union of images covers the vertex set when the originals do. -/
+theorem Region_map_disjoint (φ : G ≃g G') {R S : Finset V} (h : Disjoint R S) :
+    Disjoint (Region.map φ R) (Region.map φ S) := by
+  rw [Finset.disjoint_left]
+  intro w hwR hwS
+  rw [mem_Region_map] at hwR hwS
+  exact Finset.disjoint_left.mp h hwR hwS
+
+omit [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- The image of a union is the union of images. -/
+theorem Region_map_union (φ : G ≃g G') (R S : Finset V) :
+    Region.map φ (R ∪ S) = Region.map φ R ∪ Region.map φ S := by
+  ext w; simp only [mem_Region_map, Finset.mem_union]
+
+omit [DecidableEq V] [LinearOrder V] [DecidableEq W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- The image of the full vertex set is the full vertex set. -/
+theorem Region_map_univ (φ : G ≃g G') :
+    Region.map φ (Finset.univ : Finset V) = (Finset.univ : Finset W) := by
+  ext w; simp only [mem_Region_map, Finset.mem_univ]
+
+/-! ### The image block is injective for the transported tensor -/
+
+omit [DecidableEq V] [DecidableEq W] in
+/-- The image of a blocked-tensor-injective region for `A` is blocked-tensor injective for
+`A.transport φ`. -/
+theorem regionInjectivityDataOf_transport_map (A : Tensor G d) (φ : G ≃g G') {R : Finset V}
+    (hR : (regionInjectivityDataOf (G := G) A).IsInjective R) :
+    (regionInjectivityDataOf (G := G') (A.transport φ)).IsInjective (Region.map φ R) := by
+  rw [regionInjectivityDataOf_isInjective] at hR ⊢
+  exact (regionBlockedTensorInjective_transport A φ R).mpr hR
+
+/-! ### Transport of a one-edge blocking datum
+
+The edge action `Edge.map φ` may swap the lexicographic order of the two endpoints.  The
+endpoint memberships of `NormalEdgeBlockingData` require the first endpoint of the image edge
+in the red block and the second in the blue block, so the red and blue blocks are exchanged
+exactly when the order flips.  Both orientations are handled by reading off `Edge.map_endpoints`.
+The crossing edge is symmetric in red and blue, so the single-crossing hypothesis transports
+either way. -/
+
+open scoped Classical in
+/-- **Transport of a one-edge blocking datum along a graph isomorphism.**
+
+A one-edge blocking datum over `regionInjectivityDataOf A` at `e` gives a one-edge blocking
+datum over `regionInjectivityDataOf (A.transport φ)` at `Edge.map φ e`.  The blocks are the
+image regions; red and blue are exchanged when the edge action flips the endpoint order, so the
+first image-edge endpoint lands in the (possibly exchanged) red block.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def transportBlockingDataAlong (A : Tensor G d) (φ : G ≃g G') {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    NormalEdgeBlockingData (regionInjectivityDataOf (G := G') (A.transport φ)) G'
+      (Edge.map φ e) :=
+  if hord : (Edge.map φ e).1.1 = φ e.1.1 then
+    { red := Region.map φ D.red
+      blue := Region.map φ D.blue
+      complement := Region.map φ D.complement
+      left_mem_red := by
+        rw [hord]; exact (mem_Region_map_apply φ D.red e.1.1).mpr D.left_mem_red
+      right_mem_blue := by
+        have h2 : (Edge.map φ e).1.2 = φ e.1.2 :=
+          (Edge.map_endpoints φ e).resolve_right (fun h => by
+            rw [h.1] at hord; exact (G.ne_of_adj e.2.2) (φ.injective hord).symm) |>.2
+        rw [h2]; exact (mem_Region_map_apply φ D.blue e.1.2).mpr D.right_mem_blue
+      red_injective := regionInjectivityDataOf_transport_map A φ D.red_injective
+      blue_injective := regionInjectivityDataOf_transport_map A φ D.blue_injective
+      complement_injective := regionInjectivityDataOf_transport_map A φ D.complement_injective
+      red_disjoint_blue := Region_map_disjoint φ D.red_disjoint_blue
+      red_disjoint_complement := Region_map_disjoint φ D.red_disjoint_complement
+      blue_disjoint_complement := Region_map_disjoint φ D.blue_disjoint_complement
+      cover_univ := by
+        rw [← Region_map_union, ← Region_map_union, D.cover_univ, Region_map_univ] }
+  else
+    { red := Region.map φ D.blue
+      blue := Region.map φ D.red
+      complement := Region.map φ D.complement
+      left_mem_red := by
+        have h1 : (Edge.map φ e).1.1 = φ e.1.2 :=
+          (Edge.map_endpoints φ e).resolve_left (fun h => hord h.1) |>.1
+        rw [h1]; exact (mem_Region_map_apply φ D.blue e.1.2).mpr D.right_mem_blue
+      right_mem_blue := by
+        have h2 : (Edge.map φ e).1.2 = φ e.1.1 :=
+          (Edge.map_endpoints φ e).resolve_left (fun h => hord h.1) |>.2
+        rw [h2]; exact (mem_Region_map_apply φ D.red e.1.1).mpr D.left_mem_red
+      red_injective := regionInjectivityDataOf_transport_map A φ D.blue_injective
+      blue_injective := regionInjectivityDataOf_transport_map A φ D.red_injective
+      complement_injective := regionInjectivityDataOf_transport_map A φ D.complement_injective
+      red_disjoint_blue := (Region_map_disjoint φ D.red_disjoint_blue).symm
+      red_disjoint_complement := Region_map_disjoint φ D.blue_disjoint_complement
+      blue_disjoint_complement := Region_map_disjoint φ D.red_disjoint_complement
+      cover_univ := by
+        rw [← Region_map_union, ← Region_map_union, Finset.union_comm D.blue D.red,
+          D.cover_univ, Region_map_univ] }
+
+/-! ### Crossing-edge transport
+
+An edge crosses between two image regions iff its preimage crosses between the original
+regions.  Crossing is the conjunction of two boundary-edge conditions, each carried across by
+`isRegionBoundaryEdge_map`. -/
+
+omit [Fintype V] [DecidableEq V] [Fintype W] [DecidableEq W] in
+/-- The crossing edges between two image regions are the images of the crossing edges between
+the originals: `Edge.map φ g'` crosses between the image regions iff `g'` crosses between the
+originals. -/
+theorem isCrossingEdge_Region_map (A : Tensor G d) (φ : G ≃g G') (R R' : Finset V)
+    (g' : Edge G) :
+    IsCrossingEdge (G := G') (A.transport φ) (Region.map φ R) (Region.map φ R')
+        (Edge.map φ g') ↔
+      IsCrossingEdge (G := G) A R R' g' := by
+  rw [IsCrossingEdge, IsCrossingEdge, isRegionBoundaryEdge_map, isRegionBoundaryEdge_map]
+
+/-- The transported datum's red and blue blocks are the image red and blue blocks, in some
+order: in either branch the unordered pair `{red, blue}` is the image of the original pair.
+This is the statement that lets the single-crossing hypothesis transport regardless of the
+endpoint-order flip. -/
+theorem transportBlockingDataAlong_redBlue (A : Tensor G d) (φ : G ≃g G') {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    ((transportBlockingDataAlong A φ D).red = Region.map φ D.red ∧
+        (transportBlockingDataAlong A φ D).blue = Region.map φ D.blue) ∨
+      ((transportBlockingDataAlong A φ D).red = Region.map φ D.blue ∧
+        (transportBlockingDataAlong A φ D).blue = Region.map φ D.red) := by
+  classical
+  unfold transportBlockingDataAlong
+  by_cases hord : (Edge.map φ e).1.1 = φ e.1.1
+  · rw [dif_pos hord]; exact Or.inl ⟨rfl, rfl⟩
+  · rw [dif_neg hord]; exact Or.inr ⟨rfl, rfl⟩
+
+/-- **Single-crossing transport.**
+
+If the red-to-blue crossings of `D` are exactly the edge `e`, then the red-to-blue crossings of
+the transported datum are exactly the image edge `Edge.map φ e`.  Crossing is symmetric in the
+two blocks, so the endpoint-order flip that may exchange the transported red and blue blocks
+does not change the crossing edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isCrossingEdge_transportBlockingDataAlong (A : Tensor G d) (φ : G ≃g G') {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A D.red D.blue g ↔ g = e)
+    (g : Edge G') :
+    IsCrossingEdge (G := G') (A.transport φ) (transportBlockingDataAlong A φ D).red
+        (transportBlockingDataAlong A φ D).blue g ↔
+      g = Edge.map φ e := by
+  -- Reduce the crossing condition to a crossing between the image red and image blue blocks.
+  have hcross : IsCrossingEdge (G := G') (A.transport φ)
+      (transportBlockingDataAlong A φ D).red (transportBlockingDataAlong A φ D).blue g ↔
+        IsCrossingEdge (G := G') (A.transport φ) (Region.map φ D.red) (Region.map φ D.blue) g := by
+    rcases transportBlockingDataAlong_redBlue A φ D with ⟨hr, hb⟩ | ⟨hr, hb⟩
+    · rw [hr, hb]
+    · rw [hr, hb]; exact ⟨IsCrossingEdge.symm, IsCrossingEdge.symm⟩
+  rw [hcross]
+  -- Carry the crossing back to the original tensor along the inverse edge action.
+  have hback : IsCrossingEdge (G := G') (A.transport φ) (Region.map φ D.red)
+      (Region.map φ D.blue) g ↔ IsCrossingEdge (G := G) A D.red D.blue (Edge.map φ.symm g) := by
+    rw [← isCrossingEdge_Region_map A φ D.red D.blue (Edge.map φ.symm g), Edge.map_map_symm]
+  rw [hback, hsingle]
+  -- `Edge.map φ.symm g = e ↔ g = Edge.map φ e` by the edge bijection.
+  constructor
+  · intro h; rw [← h, Edge.map_map_symm]
+  · intro h; rw [h, Edge.map_symm_map]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusBlockingData.lean
+++ b/TNLean/PEPS/TorusBlockingData.lean
@@ -1,0 +1,133 @@
+import TNLean.PEPS.RegionTransportData
+import TNLean.PEPS.TorusTranslationInvariant
+
+/-!
+# Translation of one-edge blocking data on the torus
+
+A translation-invariant tensor on the discrete torus satisfies
+`A.transport (translate a b) = A`, so transporting a one-edge blocking datum along the
+translation automorphism produces a one-edge blocking datum **for the same tensor** at the
+translated edge.  This carries one reference blocking datum at the reference edge of an
+orientation class to a datum at every edge of that class
+(`translateBlockingData`), and the red-to-blue crossing carries across
+(`isCrossingEdge_translateBlockingData`).
+
+This is the torus realization of the source's translation step
+(arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498): once the edge blocking is fixed at
+one edge, translation invariance reproduces it at every translate, so the per-edge gauges are
+the same across each orientation class.  The bridge from `transportBlockingDataAlong` to the
+torus is `translateEdge a b e = Edge.map (translate a b) e` and the fixed-point equation
+`A.transport (translate a b) = A`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+  1407--1572 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- For a translation-invariant tensor, the region-injectivity predicate of the translated
+tensor equals that of the tensor itself, so a blocking datum over the translated tensor is a
+blocking datum over the tensor. -/
+theorem regionInjectivityDataOf_translate_eq {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (a : ZMod width) (b : ZMod height) :
+    regionInjectivityDataOf (G := torusGraph width height) (A.transport (translate a b)) =
+      regionInjectivityDataOf (G := torusGraph width height) A := by
+  rw [hA a b]
+
+/-- **Translation of a one-edge blocking datum on the torus.**
+
+For a translation-invariant tensor `A`, a one-edge blocking datum at the edge `e` gives a
+one-edge blocking datum at the translated edge `translateEdge a b e`, for the *same* tensor.
+The three blocks are the translates of the original blocks (read off
+`transportBlockingDataAlong` of the translation automorphism); injectivity uses the fixed-point
+equation `A.transport (translate a b) = A`.
+
+The fields are stated explicitly (rather than by transporting the structure across the
+fixed-point equation) so the red, blue, and complement projections are definitional, which the
+single-crossing hypothesis and the gauge interface consume.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def translateBlockingData {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (a : ZMod width) (b : ZMod height)
+    {e : Edge (torusGraph width height)}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) e) :
+    NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) (translateEdge a b e) :=
+  let D' := transportBlockingDataAlong A (translate a b) D
+  { red := D'.red
+    blue := D'.blue
+    complement := D'.complement
+    left_mem_red := by rw [translateEdge_eq_map]; exact D'.left_mem_red
+    right_mem_blue := by rw [translateEdge_eq_map]; exact D'.right_mem_blue
+    red_injective := regionInjectivityDataOf_translate_eq hA a b ▸ D'.red_injective
+    blue_injective := regionInjectivityDataOf_translate_eq hA a b ▸ D'.blue_injective
+    complement_injective :=
+      regionInjectivityDataOf_translate_eq hA a b ▸ D'.complement_injective
+    red_disjoint_blue := D'.red_disjoint_blue
+    red_disjoint_complement := D'.red_disjoint_complement
+    blue_disjoint_complement := D'.blue_disjoint_complement
+    cover_univ := D'.cover_univ }
+
+@[simp] theorem translateBlockingData_red {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (a : ZMod width) (b : ZMod height)
+    {e : Edge (torusGraph width height)}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) e) :
+    (translateBlockingData hA a b D).red =
+      (transportBlockingDataAlong A (translate a b) D).red := rfl
+
+@[simp] theorem translateBlockingData_blue {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (a : ZMod width) (b : ZMod height)
+    {e : Edge (torusGraph width height)}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) e) :
+    (translateBlockingData hA a b D).blue =
+      (transportBlockingDataAlong A (translate a b) D).blue := rfl
+
+@[simp] theorem translateBlockingData_complement {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (a : ZMod width) (b : ZMod height)
+    {e : Edge (torusGraph width height)}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) e) :
+    (translateBlockingData hA a b D).complement =
+      (transportBlockingDataAlong A (translate a b) D).complement := rfl
+
+/-- **The single red-to-blue crossing of the translated datum is the translated edge.**
+
+If the red-to-blue crossings of the reference datum `D` are exactly the reference edge `e`,
+then the red-to-blue crossings of the translated datum are exactly the translated edge
+`translateEdge a b e`.  The translated datum's blocks are the translation images of `D`'s
+blocks, so crossing transports along the translation; the crossing condition is independent of
+the tensor, so it holds for `A` itself.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isCrossingEdge_translateBlockingData {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (a : ZMod width) (b : ZMod height)
+    {e : Edge (torusGraph width height)}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) e)
+    (hsingle : ∀ g : Edge (torusGraph width height),
+      IsCrossingEdge (G := torusGraph width height) A D.red D.blue g ↔ g = e)
+    (g : Edge (torusGraph width height)) :
+    IsCrossingEdge (G := torusGraph width height) A (translateBlockingData hA a b D).red
+        (translateBlockingData hA a b D).blue g ↔
+      g = translateEdge a b e := by
+  rw [translateBlockingData_red, translateBlockingData_blue, translateEdge_eq_map]
+  -- `IsCrossingEdge` ignores the tensor, so the crossing for `A` equals the crossing for
+  -- `A.transport (translate a b)`; the latter transports by the datum-along lemma.
+  exact isCrossingEdge_transportBlockingDataAlong A (translate a b) D hsingle g
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusEdgeGauge.lean
+++ b/TNLean/PEPS/TorusEdgeGauge.lean
@@ -6,7 +6,7 @@ import TNLean.PEPS.NormalEdgeGaugeFamily
 
 Two normal PEPS on the discrete torus, related by `SameState` and matched bond dimensions, with
 one-edge blocking data sharing the three blocks at an edge `e` and the single red-to-blue
-crossing, admit on `e` the per-edge gauge: the bond dimensions coincide and the forward
+crossing, have on `e` the per-edge gauge: the bond dimensions coincide and the forward
 region-insertion transfer is conjugation by an invertible matrix
 (`exists_regionEdgeGauge_torus`).  This is the graph-polymorphic coherent-frame gauge interface
 `exists_regionEdgeGauge_of_blockingData` specialized to the torus; the torus carries the
@@ -36,7 +36,7 @@ variable {width height d : ℕ} [NeZero width] [NeZero height]
 
 Two normal PEPS `A` and `B` on the torus with one-edge blocking data `DA`, `DB` sharing the
 three blocks at `e`, matched bond dimensions, the same state, positive bonds, the single
-red-to-blue crossing on `e`, and `B`'s red and host injectivities, admit the per-edge gauge on
+red-to-blue crossing on `e`, and `B`'s red and host injectivities, have the per-edge gauge on
 `e`: the bond dimensions of `A` and `B` on `e` coincide and the forward region-insertion
 transfer is conjugation by an invertible gauge matrix `Z`.
 

--- a/TNLean/PEPS/TorusEdgeGauge.lean
+++ b/TNLean/PEPS/TorusEdgeGauge.lean
@@ -1,0 +1,79 @@
+import TNLean.PEPS.TorusBlockingData
+import TNLean.PEPS.NormalEdgeGaugeFamily
+
+/-!
+# The per-edge gauge at a torus edge from one-edge blocking data
+
+Two normal PEPS on the discrete torus, related by `SameState` and matched bond dimensions, with
+one-edge blocking data sharing the three blocks at an edge `e` and the single red-to-blue
+crossing, admit on `e` the per-edge gauge: the bond dimensions coincide and the forward
+region-insertion transfer is conjugation by an invertible matrix
+(`exists_regionEdgeGauge_torus`).  This is the graph-polymorphic coherent-frame gauge interface
+`exists_regionEdgeGauge_of_blockingData` specialized to the torus; the torus carries the
+required `Fintype`, `LinearOrder`, and `DecidableRel` instances, so the interface applies
+verbatim.
+
+For a translation-invariant pair the reference datum at the reference edge of an orientation
+class is translated to every edge of that class
+(`TNLean/PEPS/TorusBlockingData.lean`), so this gauge is available at every edge.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines
+  254--586 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- **The per-edge gauge at a torus edge.**
+
+Two normal PEPS `A` and `B` on the torus with one-edge blocking data `DA`, `DB` sharing the
+three blocks at `e`, matched bond dimensions, the same state, positive bonds, the single
+red-to-blue crossing on `e`, and `B`'s red and host injectivities, admit the per-edge gauge on
+`e`: the bond dimensions of `A` and `B` on `e` coincide and the forward region-insertion
+transfer is conjugation by an invertible gauge matrix `Z`.
+
+This is `exists_regionEdgeGauge_of_blockingData` (the coherent-frame interface, stated over a
+general `Fintype`/`LinearOrder` vertex set) specialized to the torus; no single-vertex
+injectivity is used.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_torus
+    {A B : Tensor (torusGraph width height) d} {e : Edge (torusGraph width height)}
+    (DA : NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) e)
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) B)
+      (torusGraph width height) e)
+    (hred : DA.red = DB.red) (hblue : DA.blue = DB.blue)
+    (hcompl : DA.complement = DB.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (hsingle : ∀ g : Edge (torusGraph width height),
+      IsCrossingEdge (G := torusGraph width height) A DA.red DA.blue g ↔ g = e)
+    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B DA.red)
+    (hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ DA.red)) :
+    ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ)
+        (fwd : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ →
+          Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ),
+        ∀ M, fwd M =
+            (Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+              ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+                Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) := by
+  obtain ⟨_, _, _, hEdge, Z, hZ⟩ :=
+    exists_regionEdgeGauge_of_blockingData DA DB hred hblue hcompl hbond hAB hd hposA hposB
+      hsingle hRB hCB
+  exact ⟨hEdge, Z, _, hZ⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusOrientationGauge.lean
+++ b/TNLean/PEPS/TorusOrientationGauge.lean
@@ -1,0 +1,186 @@
+import TNLean.PEPS.TorusTranslationInvariant
+import TNLean.PEPS.EdgeGaugeFamily
+
+/-!
+# Orientation-uniform edge gauges on the torus
+
+The translationally invariant normal PEPS theorem reduces the per-edge gauges produced by the
+edge blocking to **one horizontal matrix `X` and one vertical matrix `Y`**
+(arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498:
+*"these gauges are described by the same matrix `X` (`Y`) on all horizontal (vertical) edges"*).
+
+This file records that reduction on the discrete torus, mirroring the open-lattice carrier
+`TNLean/PEPS/NormalSquareTI.lean`.  Given a torus tensor with orientation-uniform bond
+dimensions (`TorusUniformBondDim`, available for any translation-invariant tensor), a single
+horizontal matrix `Xh` and a single vertical matrix `Xv` determine a per-edge gauge family
+`torusOrientationUniformGauge`.  A family of this shape is *orientation uniform*
+(`IsTorusOrientationUniformGaugeFamily`); allowing per-edge nonzero scalars gives the
+faithful target produced by the source's uniqueness-up-to-scalar step
+(`IsTorusOrientationUniformGaugeFamilyModScalar`).
+
+The torus has no boundary, so every edge is interior and the reduction reaches every edge,
+unlike the open-lattice carrier whose interior restriction is recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+  1449--1572 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-! ### The orientation-uniform consequences of `TorusUniformBondDim` -/
+
+/-- The horizontal-edge component of orientation uniformity. -/
+theorem TorusUniformBondDim.horizontal
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    (h : TorusUniformBondDim bondDim Dh Dv)
+    {e : Edge (torusGraph width height)} (he : IsHorizontalTorusEdge e) :
+    bondDim e = Dh :=
+  h.1 e he
+
+/-- The vertical-edge component of orientation uniformity. -/
+theorem TorusUniformBondDim.vertical
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    (h : TorusUniformBondDim bondDim Dh Dv)
+    {e : Edge (torusGraph width height)} (he : IsVerticalTorusEdge e) :
+    bondDim e = Dv :=
+  h.2 e he
+
+/-! ### The gauge family built from one horizontal and one vertical matrix -/
+
+/-- The per-edge gauge family on the torus determined by a single horizontal matrix `Xh` and a
+single vertical matrix `Xv`, transported to each edge across the uniform bond-dimension
+equalities.  Every torus edge is horizontal or vertical
+(`torusEdge_horizontal_or_vertical`); the horizontal branch transports `Xh`, the vertical
+branch transports `Xv`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def torusOrientationUniformGauge
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : TorusUniformBondDim bondDim Dh Dv)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ) :
+    (e : Edge (torusGraph width height)) → GL (Fin (bondDim e)) ℂ :=
+  fun e =>
+    if he : IsHorizontalTorusEdge e then
+      glReindex (huni.horizontal he).symm Xh
+    else
+      glReindex
+        (huni.vertical ((torusEdge_horizontal_or_vertical e).resolve_left he)).symm Xv
+
+/-- On a horizontal edge, the orientation-uniform gauge is `Xh` transported across the
+bond-dimension equality. -/
+theorem torusOrientationUniformGauge_horizontal
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : TorusUniformBondDim bondDim Dh Dv)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    {e : Edge (torusGraph width height)} (he : IsHorizontalTorusEdge e) :
+    torusOrientationUniformGauge huni Xh Xv e = glReindex (huni.horizontal he).symm Xh := by
+  rw [torusOrientationUniformGauge, dif_pos he]
+
+/-- On a vertical edge, the orientation-uniform gauge is `Xv` transported across the
+bond-dimension equality. -/
+theorem torusOrientationUniformGauge_vertical
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : TorusUniformBondDim bondDim Dh Dv)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    {e : Edge (torusGraph width height)} (he : IsVerticalTorusEdge e) :
+    torusOrientationUniformGauge huni Xh Xv e = glReindex (huni.vertical he).symm Xv := by
+  have hnh : ¬ IsHorizontalTorusEdge e := fun hh =>
+    torusEdge_not_horizontal_and_vertical e ⟨hh, he⟩
+  rw [torusOrientationUniformGauge, dif_neg hnh]
+
+/-! ### Orientation-uniform gauge families up to per-edge scalars -/
+
+/-- A per-edge gauge family `X` on the torus is **orientation uniform** when there is a single
+horizontal matrix and a single vertical matrix whose transported values reproduce `X` on every
+edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498. -/
+def IsTorusOrientationUniformGaugeFamily
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : TorusUniformBondDim bondDim Dh Dv)
+    (X : (e : Edge (torusGraph width height)) → GL (Fin (bondDim e)) ℂ) : Prop :=
+  ∃ (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ),
+    X = torusOrientationUniformGauge huni Xh Xv
+
+/-- A per-edge gauge family `X` is **orientation uniform up to scalars** when there are a single
+horizontal matrix, a single vertical matrix, and a per-edge nonzero scalar `c` such that on
+every edge `X e` is the transported orientation matrix rescaled by `c e`.  The per-edge scalars
+are the residual multiplicative freedom recorded by Theorem 3's uniqueness up to a multiplicative
+constant.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498. -/
+def IsTorusOrientationUniformGaugeFamilyModScalar
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : TorusUniformBondDim bondDim Dh Dv)
+    (X : (e : Edge (torusGraph width height)) → GL (Fin (bondDim e)) ℂ) : Prop :=
+  ∃ (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    (c : Edge (torusGraph width height) → ℂˣ),
+    ∀ e : Edge (torusGraph width height),
+      (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (c e : ℂ) • (torusOrientationUniformGauge huni Xh Xv e :
+          Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ)
+
+/-- An orientation-uniform gauge family is orientation uniform up to scalars, with all scalars
+equal to one. -/
+theorem isTorusOrientationUniformGaugeFamilyModScalar_of_isUniform
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    {huni : TorusUniformBondDim bondDim Dh Dv}
+    {X : (e : Edge (torusGraph width height)) → GL (Fin (bondDim e)) ℂ}
+    (hX : IsTorusOrientationUniformGaugeFamily huni X) :
+    IsTorusOrientationUniformGaugeFamilyModScalar huni X := by
+  obtain ⟨Xh, Xv, rfl⟩ := hX
+  exact ⟨Xh, Xv, fun _ => 1, fun e => by simp⟩
+
+/-- **Orientation-uniform selection up to scalars on the torus.**
+
+Suppose every per-edge gauge agrees, up to a nonzero scalar, with one reference horizontal
+matrix on horizontal edges and one reference vertical matrix on vertical edges --- the per-edge
+content delivered by the per-edge uniqueness across each orientation class under translation
+invariance.  Then the whole gauge family is orientation uniform up to scalars.
+
+This is the assembly step of the source's line-1498 reduction on the torus: it gathers the
+per-edge "agree up to a constant" facts of the two orientation classes into one
+orientation-uniform-up-to-scalar family.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTorusOrientationUniformGaugeFamilyModScalar_of_classAgreement
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : TorusUniformBondDim bondDim Dh Dv)
+    (X : (e : Edge (torusGraph width height)) → GL (Fin (bondDim e)) ℂ)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    (cH cV : Edge (torusGraph width height) → ℂˣ)
+    (hH : ∀ (e : Edge (torusGraph width height)) (he : IsHorizontalTorusEdge e),
+      (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (cH e : ℂ) • (glReindex (huni.horizontal he).symm Xh :
+          Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ))
+    (hV : ∀ (e : Edge (torusGraph width height)) (he : IsVerticalTorusEdge e),
+      (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (cV e : ℂ) • (glReindex (huni.vertical he).symm Xv :
+          Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ)) :
+    IsTorusOrientationUniformGaugeFamilyModScalar huni X := by
+  classical
+  refine ⟨Xh, Xv, fun e => if IsHorizontalTorusEdge e then cH e else cV e, ?_⟩
+  intro e
+  simp only
+  by_cases he : IsHorizontalTorusEdge e
+  · rw [if_pos he, torusOrientationUniformGauge_horizontal huni Xh Xv he]
+    exact hH e he
+  · have hv : IsVerticalTorusEdge e :=
+      (torusEdge_horizontal_or_vertical e).resolve_left he
+    rw [if_neg he, torusOrientationUniformGauge_vertical huni Xh Xv hv]
+    exact hV e hv
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusTINormalGauge.lean
+++ b/TNLean/PEPS/TorusTINormalGauge.lean
@@ -1,0 +1,81 @@
+import TNLean.PEPS.TorusOrientationGauge
+import TNLean.PEPS.TorusEdgeGauge
+
+/-!
+# The translation-invariant gauge family on the torus
+
+This file assembles the translationally invariant gauge reduction of the normal PEPS Fundamental
+Theorem on the discrete torus (arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498).  A
+translation-invariant tensor has orientation-uniform bond dimensions
+(`torusUniformBondDim_of_translationInvariant`); on a torus every edge is interior, so the
+per-edge gauge of the edge blocking is available at every edge
+(`TNLean/PEPS/TorusEdgeGauge.lean`), and translation invariance carries the reference blocking
+datum to every edge of each orientation class (`TNLean/PEPS/TorusBlockingData.lean`).  The
+assembly into one horizontal and one vertical matrix, up to per-edge scalars, is the
+orientation-uniform selection `isTorusOrientationUniformGaugeFamilyModScalar_of_classAgreement`.
+
+The one genuinely remaining input is the **per-edge class agreement**: that each per-edge gauge
+agrees, up to a nonzero scalar, with the reference orientation matrix transported to that edge.
+This is the source's *"X and Y are unique up to a multiplicative constant"* across an orientation
+class, derived from the per-edge uniqueness (`edgeGauge_unique_scalar`) together with the
+transfer-map covariance under translation.  Establishing that covariance from the
+blocked-region-weight covariance (`regionBlockedWeight_transport`) is the residual obligation
+recorded as obligation 6 of `docs/paper-gaps/peps_normal_ft_section3_route.tex`; this capstone
+takes the per-edge agreement as a hypothesis and discharges the assembly above it.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+  1449--1572 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- **The translation-invariant gauge family on the torus, up to per-edge scalars.**
+
+For a translation-invariant tensor `A`, with reference horizontal and vertical matrices `Xh`,
+`Xv` chosen at a reference edge of each orientation class, a per-edge gauge family `X` that
+agrees on every horizontal (vertical) edge with `Xh` (`Xv`) transported to that edge up to a
+nonzero scalar is orientation uniform up to scalars: it is described by the single horizontal
+matrix `Xh` and the single vertical matrix `Xv`, with the per-edge scalars the residual
+multiplicative freedom.
+
+The orientation-uniform bond dimensions come from translation invariance
+(`torusUniformBondDim_of_translationInvariant`); the per-edge agreement hypotheses `hH`, `hV`
+are the class-agreement input, the residual obligation recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, obligation 6.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTorusOrientationUniformGaugeFamilyModScalar_of_translationInvariant
+    {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A)
+    (X : (e : Edge (torusGraph width height)) →
+      GL (Fin (A.bondDim e)) ℂ)
+    (Xh : GL (Fin (A.bondDim (torusRightEdge 0))) ℂ)
+    (Xv : GL (Fin (A.bondDim (torusUpEdge 0))) ℂ)
+    (cH cV : Edge (torusGraph width height) → ℂˣ)
+    (hH : ∀ (e : Edge (torusGraph width height)) (he : IsHorizontalTorusEdge e),
+      (X e : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
+        (cH e : ℂ) • (glReindex
+          ((torusUniformBondDim_of_translationInvariant hA).horizontal he).symm Xh :
+          Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ))
+    (hV : ∀ (e : Edge (torusGraph width height)) (he : IsVerticalTorusEdge e),
+      (X e : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
+        (cV e : ℂ) • (glReindex
+          ((torusUniformBondDim_of_translationInvariant hA).vertical he).symm Xv :
+          Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)) :
+    IsTorusOrientationUniformGaugeFamilyModScalar
+      (torusUniformBondDim_of_translationInvariant hA) X :=
+  isTorusOrientationUniformGaugeFamilyModScalar_of_classAgreement
+    (torusUniformBondDim_of_translationInvariant hA) X Xh Xv cH cV hH hV
+
+end PEPS
+end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1565,18 +1565,58 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.gaugeEquivModEdgeScalars_of_matrixScalar} and
           \leanid{TNLean.PEPS.absorbEdgeGauges_eq_of_matrixScalar}.}
 
+          The periodic lattice on which this transport lives is now formalized,
+          together with the covariance of the blocking machinery under it. The
+          discrete torus carries cyclic nearest-neighbour edges on which the
+          coordinate translations are graph automorphisms, a tensor is
+          translation invariant when fixed by transport along every translation, and
+          such a tensor has orientation-uniform bond dimensions on each
+          class.\footnote{
+          Formal declarations:
+          \leanid{TNLean.PEPS.torusGraph},
+          \leanid{TNLean.PEPS.translate},
+          \leanid{TNLean.PEPS.IsTorusTranslationInvariant},
+          \leanid{TNLean.PEPS.TorusUniformBondDim}, and
+          \leanid{TNLean.PEPS.torusUniformBondDim_of_translationInvariant}.}
+          The blocking data themselves transport: the blocked-region weight of a
+          tensor transported along a graph isomorphism is the original weight
+          reindexed by the edge action and the vertex bijection, so blocked-region
+          injectivity transports, and a one-edge blocking datum transports to a datum
+          for the transported tensor at the image edge with the single red-to-blue
+          crossing carried across. Specialized to a translation-invariant tensor,
+          this carries one reference blocking datum at the reference edge of an
+          orientation class to a datum at every translate of that edge, for the same
+          tensor.\footnote{
+          Formal declarations:
+          \leanid{TNLean.PEPS.regionBlockedWeight_transport},
+          \leanid{TNLean.PEPS.regionBlockedTensorInjective_transport},
+          \leanid{TNLean.PEPS.transportBlockingDataAlong},
+          \leanid{TNLean.PEPS.isCrossingEdge_transportBlockingDataAlong},
+          \leanid{TNLean.PEPS.translateBlockingData}, and
+          \leanid{TNLean.PEPS.isCrossingEdge_translateBlockingData}.}
+          The per-edge gauge interface applies verbatim on the torus (it is stated
+          over a general finite ordered vertex set), and the orientation-uniform
+          reduction is ported to the torus, so the assembly above a class-agreement
+          input is in place there too.\footnote{
+          Formal declarations:
+          \leanid{TNLean.PEPS.exists_regionEdgeGauge_torus},
+          \leanid{TNLean.PEPS.torusOrientationUniformGauge},
+          \leanid{TNLean.PEPS.IsTorusOrientationUniformGaugeFamilyModScalar},
+          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_classAgreement},
+          and
+          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_translationInvariant}.}
+
           What remains open is the class-agreement input itself: that on each
-          orientation class the per-edge transfer maps coincide after transport,
-          which is where translation invariance enters. The per-edge transfer map is
-          built from the inserted coefficients in the edge's blocking window; on a
-          translation-invariant lattice these coincide across translates of the same
-          orientation, so the transfer maps agree after transport and the per-edge
-          uniqueness above supplies the constants. Formalizing this transport needs
-          the periodic lattice on which translation is a graph automorphism: the
-          present open rectangular model has no such automorphism (its boundary
-          breaks translation, which is also why the every-edge blocking of
-          obligation~4 is restricted to interior edges), and the transfer machinery
-          would have to be shown covariant under it. This depends on the open
+          orientation class the per-edge transfer maps coincide after transport. The
+          per-edge transfer map is built from the region-inserted coefficients in the
+          edge's blocking window; the blocked-region weights from which those
+          coefficients are assembled now transport, but the region-inserted
+          coefficient and hence the transfer map have not yet been shown covariant,
+          and the gauge that the interface produces is non-constructive in the chosen
+          coefficient transfers. Closing the input requires the transfer-map
+          covariance under translation, after which two independently chosen per-edge
+          gauges realize the same (reindexed) conjugation map and the per-edge
+          uniqueness above supplies the constants. This still depends on the open
           per-edge gauge of obligation~5 for the transfer maps themselves.
 
           The final region comparison setup is also formalized: a region and its set


### PR DESCRIPTION
## What

The torus-side machinery of the TI Normal PEPS FT (#1373): **region covariance under graph
isomorphisms** (genuinely new), blocking-datum transport, the torus per-edge gauge, and the
orientation-uniform mod-scalar assembly with its TI capstone. Six new files; all sorry-free;
`#print axioms` = `[propext, Classical.choice, Quot.sound]`; full root build green (8,854 jobs).

## Highlights

- **`regionBlockedWeight_transport`** / **`regionBlockedTensorInjective_transport`**
  (RegionTransport.lean) — blocked-region weights and injectivity are covariant under any
  graph isomorphism (open legs by the edge action, contractions by `vcEquiv`).
- **`transportBlockingDataAlong`** / **`translateBlockingData`** — datum transport (handling
  the endpoint-order flip via red/blue exchange + crossing symmetry); for a TI tensor the
  translated datum is a datum for the SAME tensor at every edge of the class.
- **`exists_regionEdgeGauge_torus`** — the merged graph-polymorphic gauge interface applies
  to the torus verbatim.
- **`isTorusOrientationUniformGaugeFamilyModScalar_of_translationInvariant`** — TI + class
  agreement ⟹ one horizontal + one vertical matrix up to per-edge scalars (the torus port
  of the merged consumer, stated natively — the honest packaging since the torus exists to
  remove the boundary obstruction).

## Remaining (narrowed, documented)

The class-agreement input reduces to **transfer-map covariance under translation** — the
`regionInsertedCoeff` covariance (its main ingredient, the weight covariance, is landed
here) plus the uniqueness argument via the merged `edgeGauge_unique_scalar`. Recorded as the
route note's narrowed obligation 6. No blueprint flips (the open-lattice source label stays
`\notready` — faithful packaging).

Refs #1373. CI `blueprint-and-prose`/`track`/`claude-review-*` failures are non-blocking
automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style PEPS proofs with no runtime or auth paths; main risk is mathematical correctness of large formal proofs, mitigated by sorry-free build and standard axioms only.
> 
> **Overview**
> Adds **six sorry-free Lean modules** wiring torus translation-invariant (TI) normal PEPS toward the Section 3 Fundamental Theorem, and registers them on the root import surface.
> 
> **Region transport (new core):** Under a graph isomorphism, finite regions map via `Region.map`; blocked-region weights and blocked-tensor injectivity are invariant up to relabelling (`regionBlockedWeight_transport`, `regionBlockedTensorInjective_transport`). One-edge `NormalEdgeBlockingData` transports with red/blue swap when endpoint order flips (`transportBlockingDataAlong`); single red–blue crossings follow (`isCrossingEdge_transportBlockingDataAlong`).
> 
> **Torus stack:** For `IsTorusTranslationInvariant` tensors, `translateBlockingData` lifts a reference datum to every translated edge on the **same** tensor. `exists_regionEdgeGauge_torus` is the existing blocking-data gauge interface on the torus. Orientation-uniform gauge families (`torusOrientationUniformGauge`, mod-scalar predicates) assemble per-edge gauges into one horizontal and one vertical matrix; `isTorusOrientationUniformGaugeFamilyModScalar_of_translationInvariant` proves that given **class agreement** (per-edge gauges match reference matrices up to scalars).
> 
> **Route note:** `peps_normal_ft_section3_route.tex` records landed torus/transport formalization and **narrows** the open obligation to **region-inserted coefficient / transfer-map covariance under translation** (weights transport; transfer maps not yet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a51123c37e7717e210bac117f7c81b7d8d3bf7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->