### PR TITLE
feat(PEPS): inserted-coefficient covariance and the torus class agreement

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -400,6 +400,7 @@ import TNLean.PEPS.TorusTranslation
 import TNLean.PEPS.IsoTransport
 import TNLean.PEPS.RegionTransport
 import TNLean.PEPS.RegionTransportData
+import TNLean.PEPS.RegionTransportInsertion
 import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -401,6 +401,7 @@ import TNLean.PEPS.IsoTransport
 import TNLean.PEPS.RegionTransport
 import TNLean.PEPS.RegionTransportData
 import TNLean.PEPS.RegionTransportInsertion
+import TNLean.PEPS.RegionTransferCovariance
 import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -407,6 +407,7 @@ import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge
 import TNLean.PEPS.TorusOrientationGauge
 import TNLean.PEPS.TorusTINormalGauge
+import TNLean.PEPS.TorusClassAgreement
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean/PEPS/RegionTransferCovariance.lean
+++ b/TNLean/PEPS/RegionTransferCovariance.lean
@@ -1,0 +1,193 @@
+import TNLean.PEPS.RegionTransportInsertion
+import TNLean.PEPS.RegionBlock.Algebra
+import TNLean.PEPS.TorusBlockingData
+
+/-!
+# Covariance of the region-insertion transfer map under translation
+
+The per-edge gauge of the normal PEPS Fundamental Theorem is read off a region-insertion transfer
+map `fwd`, the matrix map satisfying the coefficient identity
+`regionInsertedCoeff A R f M = regionInsertedCoeff B R f (fwd M)` (the field
+`RegionInsertionTransfer.fwd_coeff`).  The gauge interface produces this map non-constructively,
+but the identity **determines** it: with the second tensor's region and complement
+blocked-tensor injective and positive bond dimensions, two maps satisfying the same coefficient
+identity coincide (`regionInsertedCoeff_transferMap_unique`), because the region-inserted
+coefficient determines the inserted matrix (`regionInsertedCoeff_injective`).
+
+This determinacy turns the geometric covariance of the region-inserted coefficient
+(`regionInsertedCoeff_transport`) into covariance of the transfer map.  On the discrete torus a
+translation-invariant tensor satisfies `A.transport (translate a b) = A`, so the coefficient
+identity at a reference edge transports to the same identity at every translate of that edge,
+with the inserted matrix carried by the bond-dimension reindexing.  The transfer map at the
+translated edge therefore agrees with the reference transfer map carried across the translation,
+which is the per-edge class agreement the orientation-uniform reduction consumes (obligation 6 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`).
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+  1407--1572 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Congruence of the region-inserted coefficient under a tensor equality -/
+
+/-- The region-inserted coefficient is congruent under an equality of tensors: equal tensors have
+equal region-inserted coefficients, with the inserted matrix carried across the (definitionally
+trivial) bond-dimension equality.  This bridges the literal tensor of a translation-invariant
+PEPS with its transported copy `A.transport φ = A`. -/
+theorem regionInsertedCoeff_congrTensor {A₁ A₂ : Tensor G d} (h : A₁ = A₂) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A₁.bondDim f.1)) (Fin (A₁.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A₁ R f M σ τ =
+      regionInsertedCoeff (G := G) A₂ R f
+        (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congrFun (congrArg Tensor.bondDim h) f.1)) M)
+        σ τ := by
+  subst h
+  simp
+
+/-! ### The transfer map is determined by the coefficient identity -/
+
+/-- **Uniqueness of the region-insertion transfer map.**
+
+Two matrix maps `g₁`, `g₂` that both realize the region-inserted coefficient of `A` through `B`
+on the boundary edge `f` --- `regionInsertedCoeff A R f M = regionInsertedCoeff B R f (gᵢ M)` for
+every region and complement physical configuration --- agree on every inserted matrix, provided
+`B`'s region and complement are blocked-tensor injective and every bond dimension of `B` is
+positive.  The region-inserted coefficient of `B` determines the inserted matrix
+(`regionInsertedCoeff_injective`), so `g₁ M` and `g₂ M` realize the same coefficient and coincide.
+
+This is the determinacy that makes the non-constructive transfer map of the gauge interface
+covariant: any two transfer maps satisfying the defining coefficient identity are equal.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_transferMap_unique (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    (g₁ g₂ : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ →
+      Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (h₁ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := V) (d := d) R)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f (g₁ M) σ τ)
+    (h₂ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := V) (d := d) R)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f (g₂ M) σ τ)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    g₁ M = g₂ M := by
+  refine regionInsertedCoeff_injective (G := G) B R hRB hCB hposB f (g₁ M) (g₂ M)
+    (fun σ τ => ?_)
+  rw [← h₁ M σ τ, ← h₂ M σ τ]
+
+/-! ### Translation covariance of the coefficient identity on the torus -/
+
+section Torus
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- The bond dimension of a translation-invariant tensor at the translated boundary edge equals
+its bond dimension at the reference boundary edge: translation carries the reference edge to its
+image, and the tensor is fixed by transport, so the bond dimension is the same. -/
+theorem bondDim_boundaryEdgeMap_translate
+    {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f}) :
+    A.bondDim (boundaryEdgeMap (translate a b) R f).1 = A.bondDim f.1 := by
+  rw [← transport_bondDim_boundaryEdgeMap A (translate a b) R f, hA a b]
+
+/-- **Translation covariance of the coefficient identity on the torus.**
+
+For translation-invariant tensors `A` and `B` on the torus, a coefficient identity at the
+reference boundary edge `f` of `R`
+(`regionInsertedCoeff A R f M = regionInsertedCoeff B R f (g M)`) transports to the same identity
+at the translated boundary edge of the translated region, for the *same* tensors `A` and `B`.
+Inserting `M'` on the translated edge and contracting the translated region of `A` gives the same
+coefficient as applying `g` to the reference-bond reindex of `M'` and reading it off on `B`.
+
+Translation invariance `A.transport (translate a b) = A` identifies the transported tensor with
+the original, so `regionInsertedCoeff_transport` carries the reference coefficient to the
+translated edge with no change of tensor.  The inserted matrix is carried between the translated
+and reference bonds, which have the same dimension (`bondDim_boundaryEdgeMap_translate`).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_translate_coeffIdentity
+    {A B : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (g : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ →
+      Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (hg : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B R f (g M) σ τ)
+    (M' : Matrix (Fin (A.bondDim (boundaryEdgeMap (translate a b) R f).1))
+      (Fin (A.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)
+    (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+    (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := torusGraph width height) A
+        (Region.map (translate a b) R) (boundaryEdgeMap (translate a b) R f) M'
+        (regionPhysicalConfigMap (translate a b) R σ)
+        (regionPhysicalConfigCongr (d := d) (Region_map_compl (translate a b) R)
+          (regionPhysicalConfigMap (translate a b) (Finset.univ \ R) τ)) =
+      regionInsertedCoeff (G := torusGraph width height) B
+        (Region.map (translate a b) R) (boundaryEdgeMap (translate a b) R f)
+        (Matrix.reindexAlgEquiv ℂ ℂ
+            (finCongr (bondDim_boundaryEdgeMap_translate hB a b R f).symm)
+          (g (Matrix.reindexAlgEquiv ℂ ℂ
+            (finCongr (bondDim_boundaryEdgeMap_translate hA a b R f)) M')))
+        (regionPhysicalConfigMap (translate a b) R σ)
+        (regionPhysicalConfigCongr (d := d) (Region_map_compl (translate a b) R)
+          (regionPhysicalConfigMap (translate a b) (Finset.univ \ R) τ)) := by
+  -- Step 1: identify the literal-`A` coefficient with the transported-`A` coefficient.
+  rw [regionInsertedCoeff_congrTensor (hA a b).symm (Region.map (translate a b) R)
+    (boundaryEdgeMap (translate a b) R f) M']
+  -- Step 2: geometric transport covariance for `A`.
+  rw [regionInsertedCoeff_transport A (translate a b) R f]
+  -- Step 3: the reference coefficient identity `hg`.
+  rw [hg]
+  -- Step 4: geometric transport covariance for `B` (reverse direction).
+  rw [show ∀ N, regionInsertedCoeff (G := torusGraph width height) B R f N σ τ =
+        regionInsertedCoeff (G := torusGraph width height) (B.transport (translate a b))
+          (Region.map (translate a b) R) (boundaryEdgeMap (translate a b) R f)
+          (Matrix.reindexAlgEquiv ℂ ℂ
+            (finCongr (transport_bondDim_boundaryEdgeMap B (translate a b) R f)).symm N)
+          (regionPhysicalConfigMap (translate a b) R σ)
+          (regionPhysicalConfigCongr (d := d) (Region_map_compl (translate a b) R)
+            (regionPhysicalConfigMap (translate a b) (Finset.univ \ R) τ)) from ?_]
+  -- Step 5: identify the transported-`B` coefficient back with the literal-`B` coefficient, and
+  -- check the inserted matrices agree.
+  rotate_left
+  · intro N
+    rw [regionInsertedCoeff_transport B (translate a b) R f]
+    congr 1
+  rw [regionInsertedCoeff_congrTensor (hB a b) (Region.map (translate a b) R)
+    (boundaryEdgeMap (translate a b) R f)]
+  congr 1
+
+end Torus
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionTransferCovariance.lean
+++ b/TNLean/PEPS/RegionTransferCovariance.lean
@@ -65,7 +65,8 @@ on the boundary edge `f` --- `regionInsertedCoeff A R f M = regionInsertedCoeff 
 every region and complement physical configuration --- agree on every inserted matrix, provided
 `B`'s region and complement are blocked-tensor injective and every bond dimension of `B` is
 positive.  The region-inserted coefficient of `B` determines the inserted matrix
-(`regionInsertedCoeff_injective`), so `g₁ M` and `g₂ M` realize the same coefficient and coincide.
+(`regionInsertedCoeff_injective`), so `g₁ M` and `g₂ M` realize the same coefficient, hence
+coincide.
 
 This is the determinacy that makes the non-constructive transfer map of the gauge interface
 covariant: any two transfer maps satisfying the defining coefficient identity are equal.

--- a/TNLean/PEPS/RegionTransportInsertion.lean
+++ b/TNLean/PEPS/RegionTransportInsertion.lean
@@ -64,6 +64,23 @@ theorem transport_bondDim_boundaryEdgeMap (A : Tensor G d) (φ : G ≃g G') (R :
     (A.transport φ).bondDim (boundaryEdgeMap φ R f).1 = A.bondDim f.1 := by
   rw [boundaryEdgeMap_coe, Tensor.transport_bondDim, Edge.map_symm_map]
 
+omit [Fintype V] [Fintype W] in
+/-- The image boundary configuration, read on the image of the distinguished boundary edge,
+recovers the original value through the bond-dimension cast. -/
+theorem regionBoundaryConfigMap_boundaryEdgeMap (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (g : RegionBoundaryConfig (G := G) A R) :
+    (regionBoundaryConfigMap A φ R g) (boundaryEdgeMap φ R f) =
+      Fin.cast (transport_bondDim_boundaryEdgeMap A φ R f).symm (g f) := by
+  have hrt : regionBoundaryEdgeMapEquiv φ R (boundaryEdgeMap φ R f) = f := by
+    rw [boundaryEdgeMap, Equiv.apply_symm_apply]
+  show g (regionBoundaryEdgeMapEquiv φ R (boundaryEdgeMap φ R f)) = _
+  -- The argument equals `f`, so the value equals `g f` up to the bond-dimension cast: the cast
+  -- preserves the underlying natural-number value, which is `(g ·).val` evaluated at equal points.
+  apply Fin.eq_of_val_eq
+  rw [Fin.val_cast]
+  exact congrArg (fun x => (g x).val) hrt
+
 /-! ### Transport of the complement-side blocked weight
 
 The region-inserted coefficient contracts the set complement `univ \ R` on the second factor.
@@ -113,6 +130,125 @@ theorem regionComplementWeight_transport (A : Tensor G d) (φ : G ≃g G') (R : 
       (regionPhysicalConfigMap φ (Finset.univ \ R) τ),
     regionBlockedWeight_transport A φ (Finset.univ \ R)
       (regionComplementBoundaryConfig (G := G) A R ν) τ]
+
+/-! ### Transport of the `SameAwayFromBond` coupling
+
+The boundary configurations of the image region reindex to those of `R` by the edge action
+(`regionBoundaryConfigMap`).  The coupling `SameAwayFromBond` on the image boundary edge is
+preserved by this reindex, since the reindex is a bijection on the boundary edges fixing the
+distinguished edge. -/
+
+omit [Fintype V] [Fintype W] in
+/-- The `SameAwayFromBond` coupling on the image boundary edge transports along the
+boundary-configuration reindex: the image configurations agree away from `boundaryEdgeMap φ R f`
+iff the original configurations agree away from `f`.  The values are compared at the image bond
+type `Fin ((A.transport φ).bondDim c'.1)`, which matches the original bond type definitionally
+through the edge action. -/
+theorem sameAwayFromBond_regionBoundaryConfigMap (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (μ ν : RegionBoundaryConfig (G := G) A R) :
+    SameAwayFromBond (boundaryEdgeMap φ R f)
+        (regionBoundaryConfigMap A φ R μ) (regionBoundaryConfigMap A φ R ν) ↔
+      SameAwayFromBond f μ ν := by
+  constructor
+  · intro h c hc
+    -- Push `c` forward to the image edge `boundaryEdgeMap φ R c`, which differs from
+    -- `boundaryEdgeMap φ R f` by injectivity of the reindex.
+    have hkey := h (boundaryEdgeMap φ R c) (fun hcontra =>
+      hc ((regionBoundaryEdgeMapEquiv φ R).symm.injective hcontra))
+    -- The two sides are, by definition of `regionBoundaryConfigMap`, `μ` and `ν` read on
+    -- `regionBoundaryEdgeMapEquiv φ R (boundaryEdgeMap φ R c) = c`.
+    have hcc : regionBoundaryEdgeMapEquiv φ R (boundaryEdgeMap φ R c) = c := by
+      rw [boundaryEdgeMap, Equiv.apply_symm_apply]
+    -- Rewrite the goal `μ c = ν c` to the roundtrip edge, where `hkey` closes it definitionally.
+    rw [← hcc]
+    exact hkey
+  · intro h c hc
+    -- Pull `c` back along the reindex; the preimage differs from `f`.
+    have hpre : regionBoundaryEdgeMapEquiv φ R c ≠ f := fun hcontra =>
+      hc (by rw [← hcontra, boundaryEdgeMap, Equiv.symm_apply_apply])
+    have := h (regionBoundaryEdgeMapEquiv φ R c) hpre
+    exact this
+
+/-! ### Covariance of the region-inserted coefficient -/
+
+open scoped Classical in
+/-- **Covariance of the region-inserted coefficient under a graph isomorphism.**
+
+For a graph isomorphism `φ : G ≃g G'`, the region-inserted coefficient of the transported tensor
+`A.transport φ` over the image region `Region.map φ R`, with a matrix `M` inserted on the image
+boundary edge `boundaryEdgeMap φ R f` and the region/complement physical configurations
+relabelled by the vertex bijection, equals the region-inserted coefficient of `A` over `R`, with
+`M` carried back to `A`'s bond on `f` through the bond-dimension equality.
+
+The double boundary-configuration sum reindexes by the edge action
+(`regionBoundaryConfigMapEquiv`), the `SameAwayFromBond` coupling is preserved
+(`sameAwayFromBond_regionBoundaryConfigMap`), and the two blocked weights transport
+(`regionBlockedWeight_transport`, `regionComplementWeight_transport`).  No endpoint orientation
+enters: the matrix is inserted between the two single boundary values on the edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_transport (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin ((A.transport φ).bondDim (boundaryEdgeMap φ R f).1))
+      (Fin ((A.transport φ).bondDim (boundaryEdgeMap φ R f).1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G') (A.transport φ) (Region.map φ R) (boundaryEdgeMap φ R f) M
+        (regionPhysicalConfigMap φ R σ)
+        (regionPhysicalConfigCongr (d := d) (Region_map_compl φ R)
+          (regionPhysicalConfigMap φ (Finset.univ \ R) τ)) =
+      regionInsertedCoeff (G := G) A R f
+        (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (transport_bondDim_boundaryEdgeMap A φ R f)) M)
+        σ τ := by
+  classical
+  rw [regionInsertedCoeff_eq, regionInsertedCoeff_eq]
+  -- Reindex the outer `μ` sum by the boundary-configuration equivalence.
+  rw [← Equiv.sum_comp (regionBoundaryConfigMapEquiv A φ R)
+    (fun μ' => ∑ ν' : RegionBoundaryConfig (G := G') (A.transport φ) (Region.map φ R),
+      (if SameAwayFromBond (boundaryEdgeMap φ R f) μ' ν' then M (μ' (boundaryEdgeMap φ R f))
+          (ν' (boundaryEdgeMap φ R f)) else 0) *
+        regionBlockedWeight (G := G') (A.transport φ) (Region.map φ R) μ'
+          (regionPhysicalConfigMap φ R σ) *
+        regionBlockedWeight (G := G') (A.transport φ) (Finset.univ \ Region.map φ R)
+          (regionComplementBoundaryConfig (G := G') (A.transport φ) (Region.map φ R) ν')
+          (regionPhysicalConfigCongr (d := d) (Region_map_compl φ R)
+            (regionPhysicalConfigMap φ (Finset.univ \ R) τ)))]
+  refine Finset.sum_congr rfl fun μ _ => ?_
+  -- Reindex the inner `ν` sum by the same equivalence.
+  rw [← Equiv.sum_comp (regionBoundaryConfigMapEquiv A φ R)
+    (fun ν' => (if SameAwayFromBond (boundaryEdgeMap φ R f)
+          (regionBoundaryConfigMapEquiv A φ R μ) ν' then
+          M ((regionBoundaryConfigMapEquiv A φ R μ) (boundaryEdgeMap φ R f))
+            (ν' (boundaryEdgeMap φ R f)) else 0) *
+        regionBlockedWeight (G := G') (A.transport φ) (Region.map φ R)
+          (regionBoundaryConfigMapEquiv A φ R μ) (regionPhysicalConfigMap φ R σ) *
+        regionBlockedWeight (G := G') (A.transport φ) (Finset.univ \ Region.map φ R)
+          (regionComplementBoundaryConfig (G := G') (A.transport φ) (Region.map φ R) ν')
+          (regionPhysicalConfigCongr (d := d) (Region_map_compl φ R)
+            (regionPhysicalConfigMap φ (Finset.univ \ R) τ)))]
+  refine Finset.sum_congr rfl fun ν _ => ?_
+  -- `regionBoundaryConfigMapEquiv A φ R μ = regionBoundaryConfigMap A φ R μ`.
+  rw [regionBoundaryConfigMapEquiv_apply, regionBoundaryConfigMapEquiv_apply]
+  -- The region weight on the `μ`-side transports.
+  rw [regionBlockedWeight_transport A φ R μ σ]
+  -- The complement weight on the `ν`-side transports.
+  rw [regionComplementWeight_transport A φ R ν τ]
+  -- Match the matrix factor and the `SameAwayFromBond` predicate.
+  refine congr_arg₂ (· * ·) (congr_arg₂ (· * ·) ?_ rfl) rfl
+  rw [show SameAwayFromBond (boundaryEdgeMap φ R f)
+        (regionBoundaryConfigMap A φ R μ) (regionBoundaryConfigMap A φ R ν) =
+      SameAwayFromBond f μ ν from
+    propext (sameAwayFromBond_regionBoundaryConfigMap A φ R f μ ν)]
+  split_ifs with hsame
+  · -- The matrix entries agree: `M` read at the image-bond values equals the reindexed `M`
+    -- read at the original-bond values, by the bond-dimension cast.
+    rw [Matrix.reindexAlgEquiv_apply, Matrix.reindex_apply, Matrix.submatrix_apply,
+      regionBoundaryConfigMap_boundaryEdgeMap A φ R f μ,
+      regionBoundaryConfigMap_boundaryEdgeMap A φ R f ν]
+    simp only [finCongr_symm, finCongr_apply, Fin.cast_eq_cast]
+  · rfl
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionTransportInsertion.lean
+++ b/TNLean/PEPS/RegionTransportInsertion.lean
@@ -1,0 +1,118 @@
+import TNLean.PEPS.RegionTransport
+import TNLean.PEPS.RegionBlock.Insertion
+import TNLean.PEPS.RegionBlock.UnionInjectivityOverlap5
+
+/-!
+# Covariance of the region-inserted coefficient under a graph isomorphism
+
+A graph isomorphism `φ : G ≃g G'` carries the region-inserted coefficient of a tensor `A`
+over a region `R` to the region-inserted coefficient of the transported tensor `A.transport φ`
+over the image region `Region.map φ R`, with the inserted matrix carried to the image bond, the
+boundary edge to its image, and the region/complement physical configurations relabelled by the
+vertex bijection (`regionInsertedCoeff_transport`).
+
+The region-inserted coefficient is the double boundary-configuration sum coupling `R` and its
+set complement through a single matrix inserted on one boundary edge `f`.  The blocked-region
+weight transports (`regionBlockedWeight_transport`), the boundary configurations reindex by the
+edge action (`regionBoundaryConfigMapEquiv`), and the `SameAwayFromBond` coupling is preserved by
+that reindex, so the whole double sum carries across.  No endpoint orientation enters: the
+coefficient inserts the matrix between the two boundary configurations' single values on the
+boundary edge, with no reference to which endpoint lies in `R`.
+
+This is the missing covariance of obligation 6 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`: together with the transport of the blocked
+weights it makes the per-edge transfer maps covariant under translation on the torus.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+  1407--1572 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V W : Type*} [Fintype V] [LinearOrder V]
+  [Fintype W] [LinearOrder W]
+  {G : SimpleGraph V} {G' : SimpleGraph W} {d : ℕ}
+variable [DecidableRel G.Adj] [DecidableRel G'.Adj]
+
+/-! ### The image boundary edge -/
+
+/-- The image of a boundary edge of `R` under the edge action of `φ`: a boundary edge of the
+image region whose underlying edge is `Edge.map φ f.1`.  This is the inverse direction of the
+boundary-edge reindexing `regionBoundaryEdgeMapEquiv`. -/
+def boundaryEdgeMap (φ : G ≃g G') (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    {f : Edge G' // IsRegionBoundaryEdge (G := G') (Region.map φ R) f} :=
+  (regionBoundaryEdgeMapEquiv φ R).symm f
+
+omit [Fintype V] [Fintype W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+@[simp] theorem boundaryEdgeMap_coe (φ : G ≃g G') (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    (boundaryEdgeMap φ R f).1 = Edge.map φ f.1 := rfl
+
+omit [Fintype V] [Fintype W] in
+/-- The bond dimension of `A.transport φ` at the image boundary edge equals the bond dimension of
+`A` at the original boundary edge. -/
+theorem transport_bondDim_boundaryEdgeMap (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    (A.transport φ).bondDim (boundaryEdgeMap φ R f).1 = A.bondDim f.1 := by
+  rw [boundaryEdgeMap_coe, Tensor.transport_bondDim, Edge.map_symm_map]
+
+/-! ### Transport of the complement-side blocked weight
+
+The region-inserted coefficient contracts the set complement `univ \ R` on the second factor.
+Under transport, the image coefficient contracts `univ \ Region.map φ R`, while the transport of
+the original complement weight lives over `Region.map φ (univ \ R)`.  These two regions agree
+(`Region_map_compl`), and the complement boundary configurations match across the region equality,
+so the image complement weight equals the original complement weight. -/
+
+
+/-- The image complement boundary configuration, read on `univ \ Region.map φ R`, agrees across
+the region equality `Region.map φ (univ \ R) = univ \ Region.map φ R` with the transport of the
+original complement boundary configuration on `Region.map φ (univ \ R)`. -/
+theorem regionComplementBoundaryConfig_transport (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (ν : RegionBoundaryConfig (G := G) A R) :
+    regionComplementBoundaryConfig (G := G') (A.transport φ) (Region.map φ R)
+        (regionBoundaryConfigMap A φ R ν) =
+      regionBoundaryConfigCongr (A := A.transport φ) (Region_map_compl φ R)
+        (regionBoundaryConfigMap A φ (Finset.univ \ R)
+          (regionComplementBoundaryConfig (G := G) A R ν)) := by
+  funext f
+  rw [regionBoundaryConfigCongr_apply]
+  -- After the congr rewrite both sides read `ν` on the same reindexed boundary edge.
+  rfl
+
+/-- **Transport of the complement-side blocked weight.**
+
+The blocked weight of `A.transport φ` over the set complement `univ \ Region.map φ R`, at the
+image complement boundary configuration and the image complement physical configuration, equals
+the blocked weight of `A` over `univ \ R`.  This bridges the region equality
+`Region.map φ (univ \ R) = univ \ Region.map φ R` (`Region_map_compl`) and then applies the
+blocked-weight transport (`regionBlockedWeight_transport`). -/
+theorem regionComplementWeight_transport (A : Tensor G d) (φ : G ≃g G') (R : Finset V)
+    (ν : RegionBoundaryConfig (G := G) A R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionBlockedWeight (G := G') (A.transport φ) (Finset.univ \ Region.map φ R)
+        (regionComplementBoundaryConfig (G := G') (A.transport φ) (Region.map φ R)
+          (regionBoundaryConfigMap A φ R ν))
+        (regionPhysicalConfigCongr (d := d) (Region_map_compl φ R)
+          (regionPhysicalConfigMap φ (Finset.univ \ R) τ)) =
+      regionBlockedWeight (G := G) A (Finset.univ \ R)
+        (regionComplementBoundaryConfig (G := G) A R ν) τ := by
+  -- Bridge the region equality, then apply the blocked-weight transport for `univ \ R`.
+  rw [regionComplementBoundaryConfig_transport,
+    ← regionBlockedWeight_congr (A := A.transport φ) (Region_map_compl φ R)
+      (regionBoundaryConfigMap A φ (Finset.univ \ R)
+        (regionComplementBoundaryConfig (G := G) A R ν))
+      (regionPhysicalConfigMap φ (Finset.univ \ R) τ),
+    regionBlockedWeight_transport A φ (Finset.univ \ R)
+      (regionComplementBoundaryConfig (G := G) A R ν) τ]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusClassAgreement.lean
+++ b/TNLean/PEPS/TorusClassAgreement.lean
@@ -1,0 +1,109 @@
+import TNLean.PEPS.TorusTINormalGauge
+
+/-!
+# Class agreement from per-edge transfer-map covariance on the torus
+
+The translation-invariant gauge reduction needs the **class-agreement input** of the capstone
+`isTorusOrientationUniformGaugeFamilyModScalar_of_translationInvariant`: that on each orientation
+class every per-edge gauge agrees, up to a nonzero scalar, with the reference orientation matrix
+transported to that edge.
+
+This file derives that agreement from per-edge transfer-map covariance.  The per-edge gauge `X e`
+realizes a forward per-edge transfer (conjugation) on the bond matrices of `A.bondDim e`.  Two
+invertible matrices realizing the same conjugation differ by a nonzero scalar
+(`edgeGauge_unique_scalar`, the center of the full matrix algebra is the scalars).  So once the
+conjugation of `X e` coincides with the conjugation of the transported reference matrix --- the
+covariance that the region-insertion transfer map satisfies under translation
+(`TNLean/PEPS/RegionTransferCovariance.lean`) --- the per-edge agreement holds with the scalar
+`edgeGauge_unique_scalar` supplies.  Gathering the two orientation classes gives the
+orientation-uniform-up-to-scalar family the capstone consumes.
+
+The covariance hypothesis `hcovH`/`hcovV` is the conjugation form of the transfer-map covariance:
+the conjugation by `X e` on every bond matrix equals the conjugation by the transported reference
+matrix.  It is what the determinacy of the region-insertion transfer map
+(`regionInsertedCoeff_transferMap_unique`) and the translation covariance of the coefficient
+identity (`regionInsertedCoeff_translate_coeffIdentity`) establish for the per-edge gauges of a
+translation-invariant pair; supplying it here as a hypothesis isolates the algebraic
+class-agreement assembly from that geometric covariance.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- **Per-edge class agreement from conjugation covariance.**
+
+If, on every horizontal (vertical) edge `e`, the conjugation by the per-edge gauge `X e` on every
+bond matrix coincides with the conjugation by the transported reference matrix
+`glReindex (huni.horizontal he).symm Xh` (`glReindex (huni.vertical he).symm Xv`), then the whole
+gauge family `X` is orientation uniform up to per-edge scalars.
+
+The conjugation coincidence forces, edge by edge, the per-edge gauge to be the transported
+reference matrix up to a nonzero scalar (`edgeGauge_unique_scalar`, the quotient lies in the
+center of the full matrix algebra, hence is a scalar).  These per-edge scalars are exactly the
+residual freedom recorded in the orientation-uniform-up-to-scalar family.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance
+    {bondDim : Edge (torusGraph width height) → ℕ} {Dh Dv : ℕ}
+    (huni : TorusUniformBondDim bondDim Dh Dv)
+    (X : (e : Edge (torusGraph width height)) → GL (Fin (bondDim e)) ℂ)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    (hcovH : ∀ (e : Edge (torusGraph width height)) (he : IsHorizontalTorusEdge e)
+      (N : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ),
+      (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) * N *
+          (↑(X e)⁻¹ : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (glReindex (huni.horizontal he).symm Xh :
+            Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) * N *
+          (↑(glReindex (huni.horizontal he).symm Xh)⁻¹ :
+            Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ))
+    (hcovV : ∀ (e : Edge (torusGraph width height)) (he : IsVerticalTorusEdge e)
+      (N : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ),
+      (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) * N *
+          (↑(X e)⁻¹ : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (glReindex (huni.vertical he).symm Xv :
+            Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) * N *
+          (↑(glReindex (huni.vertical he).symm Xv)⁻¹ :
+            Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ)) :
+    IsTorusOrientationUniformGaugeFamilyModScalar huni X := by
+  classical
+  -- On each orientation class, the conjugation coincidence gives the per-edge scalar.
+  have hH : ∀ (e : Edge (torusGraph width height)) (he : IsHorizontalTorusEdge e),
+      ∃ c : ℂˣ, (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (c : ℂ) • (glReindex (huni.horizontal he).symm Xh :
+          Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) := by
+    intro e he
+    -- Apply `gl_conj_unique_scalar` to `X e` and the transported reference, with the roles of
+    -- `Z`/`Z'` arranged so the scalar relates `X e` to the reference.
+    obtain ⟨c, hc⟩ := gl_conj_unique_scalar (glReindex (huni.horizontal he).symm Xh) (X e)
+      (fun N => (hcovH e he N).symm)
+    exact ⟨c, hc⟩
+  have hV : ∀ (e : Edge (torusGraph width height)) (he : IsVerticalTorusEdge e),
+      ∃ c : ℂˣ, (X e : Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) =
+        (c : ℂ) • (glReindex (huni.vertical he).symm Xv :
+          Matrix (Fin (bondDim e)) (Fin (bondDim e)) ℂ) := by
+    intro e he
+    obtain ⟨c, hc⟩ := gl_conj_unique_scalar (glReindex (huni.vertical he).symm Xv) (X e)
+      (fun N => (hcovV e he N).symm)
+    exact ⟨c, hc⟩
+  -- Choose the per-edge scalars and assemble through the class-agreement selection.
+  refine isTorusOrientationUniformGaugeFamilyModScalar_of_classAgreement huni X Xh Xv
+    (fun e => if he : IsHorizontalTorusEdge e then (hH e he).choose else 1)
+    (fun e => if he : IsVerticalTorusEdge e then (hV e he).choose else 1)
+    (fun e he => ?_) (fun e he => ?_)
+  · simp only [dif_pos he]; exact (hH e he).choose_spec
+  · simp only [dif_pos he]; exact (hV e he).choose_spec
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusClassAgreement.lean
+++ b/TNLean/PEPS/TorusClassAgreement.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.TorusTINormalGauge
+import TNLean.PEPS.RegionTransferCovariance
 
 /-!
 # Class agreement from per-edge transfer-map covariance on the torus
@@ -104,6 +105,43 @@ theorem isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance
     (fun e he => ?_) (fun e he => ?_)
   · simp only [dif_pos he]; exact (hH e he).choose_spec
   · simp only [dif_pos he]; exact (hV e he).choose_spec
+
+/-- **The conjugation covariance from coefficient-identity realizations.**
+
+Two matrix maps `g₁` and `g₂` that both realize the region-inserted coefficient of `A` through
+`B` on a boundary edge `f` --- the defining identity of a region-insertion transfer map --- agree
+on every inserted matrix, provided `B`'s region and complement are blocked-tensor injective with
+positive bond dimensions.  This is the determinacy
+`regionInsertedCoeff_transferMap_unique` restated on the torus: it is exactly the input that turns
+the geometric covariance of the per-edge transfer maps (their realization of the *same* coefficient
+identity at a translated edge, supplied by `regionInsertedCoeff_translate_coeffIdentity`) into the
+conjugation covariance `hcovH`/`hcovV` consumed above, since each conjugation
+`N ↦ Z · (reindex N) · Z⁻¹` is the transfer map a gauge `Z` realizes.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionTransferMap_eq_of_coeffIdentities
+    {A B : Tensor (torusGraph width height) d} (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B R)
+    (hCB : RegionBlockedTensorInjective (G := torusGraph width height) B (Finset.univ \ R))
+    (hposB : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (g₁ g₂ : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ →
+      Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
+    (h₁ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B R f (g₁ M) σ τ)
+    (h₂ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B R f (g₂ M) σ τ) :
+    g₁ = g₂ :=
+  funext (fun M =>
+    regionInsertedCoeff_transferMap_unique A B R f hRB hCB hposB g₁ g₂ h₁ h₂ M)
 
 end PEPS
 end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1606,18 +1606,45 @@ The remaining obligations are the following.
           and
           \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_translationInvariant}.}
 
-          What remains open is the class-agreement input itself: that on each
-          orientation class the per-edge transfer maps coincide after transport. The
-          per-edge transfer map is built from the region-inserted coefficients in the
-          edge's blocking window; the blocked-region weights from which those
-          coefficients are assembled now transport, but the region-inserted
-          coefficient and hence the transfer map have not yet been shown covariant,
-          and the gauge that the interface produces is non-constructive in the chosen
-          coefficient transfers. Closing the input requires the transfer-map
-          covariance under translation, after which two independently chosen per-edge
-          gauges realize the same (reindexed) conjugation map and the per-edge
-          uniqueness above supplies the constants. This still depends on the open
-          per-edge gauge of obligation~5 for the transfer maps themselves.
+          The covariance of the region-inserted coefficient is now established, and
+          with it the determinacy that closes the class-agreement input above the
+          per-edge gauge of obligation~5. The region-inserted coefficient of a tensor
+          transported along a graph isomorphism, over the image region with the
+          inserted matrix carried to the image bond and the boundary edge to its image,
+          equals the original coefficient over the original region; the boundary
+          configurations reindex by the edge action, the matrix coupling and the
+          away-from-the-bond agreement are preserved, and the region and complement
+          weights both transport. No endpoint orientation enters, since the coefficient
+          inserts the matrix between the two single boundary values on the edge.
+          \footnote{Formal declarations:
+          \leanid{TNLean.PEPS.regionComplementWeight_transport},
+          \leanid{TNLean.PEPS.sameAwayFromBond_regionBoundaryConfigMap}, and
+          \leanid{TNLean.PEPS.regionInsertedCoeff_transport}.}
+          Specialized to a translation-invariant pair, this carries the coefficient
+          identity at a reference edge to the same identity at every translate of that
+          edge, for the same two tensors, since the tensors are fixed by transport.
+          \footnote{Formal declarations:
+          \leanid{TNLean.PEPS.bondDim_boundaryEdgeMap_translate},
+          \leanid{TNLean.PEPS.regionInsertedCoeff_congrTensor}, and
+          \leanid{TNLean.PEPS.regionInsertedCoeff_translate_coeffIdentity}.}
+
+          The non-constructive transfer map of the gauge interface is determined by the
+          coefficient identity it satisfies: with the second tensor's region and
+          complement injective and positive bond dimensions, two matrix maps realizing
+          the same coefficient identity coincide. Hence the per-edge transfer map at a
+          translate equals the reference transfer map carried across the translation,
+          two independently chosen per-edge gauges realize the same conjugation map, and
+          the per-edge uniqueness up to scalar supplies the constants; gathering the two
+          orientation classes yields the orientation-uniform-up-to-scalar family.
+          \footnote{Formal declarations:
+          \leanid{TNLean.PEPS.regionInsertedCoeff_transferMap_unique},
+          \leanid{TNLean.PEPS.regionTransferMap_eq_of_coeffIdentities}, and
+          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance}.}
+          What remains is the construction of the per-edge gauge family from the
+          reference blocking data at the two orientation classes, on top of which the
+          conjugation covariance is the transfer-map determinacy applied to each
+          translate. This still depends on the open per-edge gauge of obligation~5 for
+          the transfer maps themselves.
 
           The final region comparison setup is also formalized: a region and its set
           complement are wrapped as the two blocks consumed by the two-injective


### PR DESCRIPTION
## What

The substance of route-note obligation 6 for the TI Normal PEPS FT (#1373): the
**`regionInsertedCoeff` covariance under graph isomorphisms**, the **transfer-map
determinacy** making the non-constructive gauge covariant, and the **class-agreement
assembly**. Three new files; all sorry-free; `#print axioms` =
`[propext, Classical.choice, Quot.sound]`; full root build green (8,857 jobs).

## Highlights

- **`regionInsertedCoeff_transport`** (RegionTransportInsertion.lean) — the inserted
  coefficient is covariant under any graph iso, from the merged weight covariance + the
  complement bridge + `SameAwayFromBond` preservation. Honest finding: **no transpose** in
  the coefficient covariance (the endpoint flip affects only block assignment).
- **`regionInsertedCoeff_transferMap_unique`** + the TI transport
  (RegionTransferCovariance.lean) — two maps realizing the same coefficient identity
  coincide (via the merged injectivity), and for a TI pair the identity transports to every
  translate — so the interface's non-constructive `fwd` is covariant.
- **`isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance`**
  (TorusClassAgreement.lean) — per-edge conjugation covariance + `gl_conj_unique_scalar`
  discharge the class-agreement inputs.

## Remaining (documented, narrowed)

The construction of the actual per-edge gauge family at every torus edge (via the merged
`translateBlockingData` + `exists_regionEdgeGauge_torus`), on which the covariance applies
— plus the torus port of the absorption/comparison consumers. Route-note obligation 6
updated with the nine new declarations.

Refs #1373. CI failures are non-blocking automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style PEPS formalization with no runtime, auth, or data paths; risk is Mathlib proof maintenance and downstream obligation wiring, not production behavior.
> 
> **Overview**
> Adds formal Lean proofs for **obligation 6** of the normal PEPS Section 3 route: region-inserted coefficient covariance, transfer-map determinacy, and torus class-agreement assembly.
> 
> **`RegionTransportInsertion.lean`** proves `regionInsertedCoeff_transport` — under a graph isomorphism, the region-inserted coefficient of `A.transport φ` matches the original coefficient with bond reindexing, via complement weight transport, `SameAwayFromBond` preservation, and boundary-configuration reindexing (no endpoint-orientation transpose).
> 
> **`RegionTransferCovariance.lean`** adds `regionInsertedCoeff_transferMap_unique` (two maps satisfying the same coefficient identity agree when `B`’s blocks are injective), plus torus lemmas `regionInsertedCoeff_translate_coeffIdentity` and helpers so a TI coefficient identity at a reference edge transports to every translate.
> 
> **`TorusClassAgreement.lean`** shows `isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance`: matching conjugation on every bond forces each per-edge gauge to equal the transported reference up to a scalar (`gl_conj_unique_scalar`), closing the class-agreement input modulo the conjugation-covariance hypothesis.
> 
> **`TNLean.lean`** imports the three modules; **`peps_normal_ft_section3_route.tex`** records obligation 6 as largely closed on covariance/determinacy and narrows what remains to building the per-edge gauge family (still tied to obligation 5).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 573eee570961a996e97e9ce9099056c6de2f291f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->