### PR TITLE
feat(PEPS): the coefficient-identity gauge and the torus conjugation-covariance reduction

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -408,6 +408,7 @@ import TNLean.PEPS.TorusEdgeGauge
 import TNLean.PEPS.TorusOrientationGauge
 import TNLean.PEPS.TorusTINormalGauge
 import TNLean.PEPS.TorusClassAgreement
+import TNLean.PEPS.TorusEdgeGaugeCovariance
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean/PEPS/TorusEdgeGauge.lean
+++ b/TNLean/PEPS/TorusEdgeGauge.lean
@@ -75,5 +75,69 @@ theorem exists_regionEdgeGauge_torus
       hsingle hRB hCB
   exact ⟨hEdge, Z, _, hZ⟩
 
+/-- **The per-edge gauge at a torus edge, with its coefficient identity.**
+
+The same conclusion as `exists_regionEdgeGauge_torus`, but exposing the region-insertion
+coefficient identity that the gauge conjugation realizes: on the single boundary edge
+`f = ⟨e, _⟩` of the red block, inserting `M` into `A` and contracting matches inserting the
+gauge conjugation `Z · (reindex M) · Z⁻¹` into `B`.  This is the defining identity of the
+forward region-insertion transfer (`RegionInsertionTransfer.fwd_coeff`), specialized through
+`Z`'s realization of that transfer.
+
+The coefficient identity is the load-bearing extra output over `exists_regionEdgeGauge_torus`:
+together with the determinacy of the region-insertion transfer map
+(`regionInsertedCoeff_transferMap_unique`), it turns the geometric covariance of the per-edge
+transfer maps under translation into the conjugation covariance the orientation-uniform
+selection consumes.
+
+No single-vertex injectivity is used; the injectivity inputs are the blocked-region
+injectivities of the data and `B`'s red and host injectivities.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_torus_coeff
+    {A B : Tensor (torusGraph width height) d} {e : Edge (torusGraph width height)}
+    (DA : NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) e)
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) B)
+      (torusGraph width height) e)
+    (hred : DA.red = DB.red) (hblue : DA.blue = DB.blue)
+    (hcompl : DA.complement = DB.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (hsingle : ∀ g : Edge (torusGraph width height),
+      IsCrossingEdge (G := torusGraph width height) A DA.red DA.blue g ↔ g = e)
+    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B DA.red)
+    (hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ DA.red)) :
+    ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ),
+        ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+          (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) DA.red)
+          (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (Finset.univ \ DA.red)),
+          regionInsertedCoeff (G := torusGraph width height) A DA.red
+              (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e hsingle) M
+              σ τ =
+            regionInsertedCoeff (G := torusGraph width height) B DA.red
+              (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e hsingle)
+              ((Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+                  Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+                  ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+                    Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ))
+              σ τ := by
+  obtain ⟨htransferAB, htransferBA, hmul, hEdge, Z, hZ⟩ :=
+    exists_regionEdgeGauge_of_blockingData DA DB hred hblue hcompl hbond hAB hd hposA hposB
+      hsingle hRB hCB
+  refine ⟨hEdge, Z, fun M σ τ => ?_⟩
+  -- The forward transfer of the region-insertion datum realizes the conjugation `conj_Z`
+  -- (`hZ`) and satisfies the coefficient identity (`fwd_coeff`); rewriting along `hZ` gives the
+  -- coefficient identity for the conjugation map.
+  have hfwd := (regionInsertionTransfer_of_coeffTransfer A B DA.red
+    (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e hsingle)
+    hRB hCB hAB hposB hbond htransferAB htransferBA hmul).fwd_coeff M σ τ
+  rw [hZ M] at hfwd
+  exact hfwd
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusEdgeGaugeCovariance.lean
+++ b/TNLean/PEPS/TorusEdgeGaugeCovariance.lean
@@ -1,0 +1,126 @@
+import TNLean.PEPS.TorusEdgeGauge
+import TNLean.PEPS.RegionTransferCovariance
+import TNLean.PEPS.TorusClassAgreement
+
+/-!
+# Conjugation covariance of the per-edge gauge on the torus
+
+The orientation-uniform selection on the torus consumes the **conjugation covariance**
+`hcovH`/`hcovV` of `isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance`: on every
+horizontal (vertical) edge the conjugation by the per-edge gauge coincides with the conjugation
+by the transported reference matrix.  This file supplies the algebraic core of that covariance.
+
+Two invertible matrices `Z` and `Z'` on the same boundary edge `f` of a region `R`, each
+realizing the region-insertion coefficient identity of `A` through `B` by conjugation
+(`regionInsertedCoeff A R f M = regionInsertedCoeff B R f (conj_Z M)`), induce the *same*
+conjugation map (`gaugeConj_eq_of_coeffIdentities`): the region-insertion transfer map is
+determined by the coefficient identity (`regionInsertedCoeff_transferMap_unique`), and both
+conjugations realize it.  Reindexing across an index-size equality commutes with conjugation
+(`reindexAlgEquiv_gaugeConj`), the matrix-algebra fact that turns the transported reference gauge
+`glReindex h Xh` into the conjugation by the reindexed reference matrix.
+
+These are the two ingredients that turn the geometric translation covariance of the coefficient
+identity (`regionInsertedCoeff_translate_coeffIdentity`) into the conjugation covariance the
+orientation-uniform selection consumes, recorded as obligation 6 of
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+  1407--1572 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+/-! ### Reindexing commutes with conjugation -/
+
+/-- **Reindexing across an index-size equality commutes with conjugation.**
+
+For an invertible matrix `Z : GL (Fin a) ℂ` and the index-size equality `h : a = b`, the
+reindexed conjugation `reindex (Z · N · Z⁻¹)` equals the conjugation by the reindexed matrix
+`glReindex h Z` applied to the reindexed `N`: `(glReindex h Z) · (reindex N) · (glReindex h Z)⁻¹`.
+Reindexing is an algebra equivalence, hence multiplicative and inverse-preserving, so it
+distributes over the triple product.
+
+This is the matrix-algebra fact that identifies the transported reference gauge `glReindex h Xh`
+with the conjugation by `Xh` reindexed across the bond-dimension equality. -/
+theorem reindexAlgEquiv_gaugeConj {a b : ℕ} (h : a = b) (Z : GL (Fin a) ℂ)
+    (N : Matrix (Fin a) (Fin a) ℂ) :
+    Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
+        ((Z : Matrix (Fin a) (Fin a) ℂ) * N *
+          (↑Z⁻¹ : Matrix (Fin a) (Fin a) ℂ)) =
+      (↑(glReindex h Z) : Matrix (Fin b) (Fin b) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr h) N *
+        (↑(glReindex h Z)⁻¹ : Matrix (Fin b) (Fin b) ℂ) := by
+  rw [map_mul, map_mul, glReindex_coe,
+    show (glReindex h Z)⁻¹ = glReindex h Z⁻¹ from (map_inv (glReindex h) Z).symm, glReindex_coe]
+
+/-! ### Conjugation agreement from the coefficient identity -/
+
+section CoeffBridge
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- **Two conjugating gauges realizing the same coefficient identity induce the same map.**
+
+Two invertible matrices `Z₁` and `Z₂` on the boundary edge `f` of a region `R`, both realizing
+the region-insertion coefficient identity of `A` through `B` by conjugation
+(`regionInsertedCoeff A R f M = regionInsertedCoeff B R f (conj_{Zᵢ} M)` for all configurations),
+induce the same conjugation map across the bond-dimension equality: for every bond matrix `M`,
+`Z₁ · (reindex M) · Z₁⁻¹ = Z₂ · (reindex M) · Z₂⁻¹`.  The region-insertion transfer map is
+determined by its coefficient identity (`regionInsertedCoeff_transferMap_unique`); both
+conjugations realize it, so they coincide.
+
+This is the determinacy step that turns the geometric translation covariance of the coefficient
+identity into the conjugation covariance the orientation-uniform selection consumes.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem gaugeConj_eq_of_coeffIdentities (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e)
+    {hE₁ hE₂ : A.bondDim f.1 = B.bondDim f.1}
+    (Z₁ Z₂ : GL (Fin (B.bondDim f.1)) ℂ)
+    (h₁ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := V) (d := d) R)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f
+          ((Z₁ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₁) M *
+            (↑Z₁⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
+    (h₂ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := V) (d := d) R)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f
+          ((Z₂ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₂) M *
+            (↑Z₂⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    (Z₁ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₁) M *
+      (↑Z₁⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) =
+    (Z₂ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₂) M *
+      (↑Z₂⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :=
+  regionInsertedCoeff_transferMap_unique A B R f hRB hCB hposB
+    (fun N => (Z₁ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₁) N *
+      (↑Z₁⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ))
+    (fun N => (Z₂ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₂) N *
+      (↑Z₂⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ))
+    h₁ h₂ M
+
+end CoeffBridge
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusEdgeGaugeCovariance.lean
+++ b/TNLean/PEPS/TorusEdgeGaugeCovariance.lean
@@ -122,5 +122,82 @@ theorem gaugeConj_eq_of_coeffIdentities (A B : Tensor G d) (R : Finset V)
 
 end CoeffBridge
 
+/-! ### The conjugation covariance on every edge from coefficient identities
+
+The two coefficient-identity families below are the **geometric input** the conjugation covariance
+needs.  On every horizontal (vertical) edge `e`, the per-edge gauge `X e` and the transported
+reference matrix `glReindex (huni.horizontal he).symm Xh` (`glReindex (huni.vertical he).symm Xv`)
+must both realize a region-insertion coefficient identity of `A` through `B`, over a common
+region `R e` and its single boundary edge on `e`.  Supplying these identities, the conjugation
+covariance — hence the orientation-uniform-mod-scalar family — follows from the determinacy
+bridge `gaugeConj_eq_of_coeffIdentities` and the surjectivity of the bond-dimension reindexing.
+
+Producing the two identity families from one reference blocking datum per orientation class, by
+transporting the reference coefficient identity along the class translations
+(`regionInsertedCoeff_translate_coeffIdentity`) and reading off the per-edge gauge from the
+transported blocking datum (`exists_regionEdgeGauge_torus_coeff`), is the residual geometric
+obligation 6 of `docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+
+section TorusFamily
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- **Single-edge conjugation covariance from two coefficient identities.**
+
+On the single boundary edge `f` of a region `R`, with `B`'s region and complement blocked-tensor
+injective and positive bonds, suppose the per-edge gauge `Z₁` and a second gauge `Z₂` (both
+invertible over `B.bondDim f.1`) each realize the region-insertion coefficient identity of `A`
+through `B` on `f` by conjugation.  Then they induce the same conjugation map on every bond
+matrix `N` over `B.bondDim f.1`.
+
+This is `gaugeConj_eq_of_coeffIdentities` read on an arbitrary target matrix: the bond-dimension
+reindexing is surjective, so every `N` is a reindexed `M`, and the determinacy applies.  Reading
+it on `N` over `B.bondDim f.1` (rather than `reindex M`) is the shape the orientation-uniform
+conjugation covariance `hcovH`/`hcovV` consumes, once `f.1` is the edge in question. -/
+theorem gaugeConj_eq_of_coeffIdentities_torus
+    {A B : Tensor (torusGraph width height) d}
+    (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B R)
+    (hCB : RegionBlockedTensorInjective (G := torusGraph width height) B (Finset.univ \ R))
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    {hE₁ hE₂ : A.bondDim f.1 = B.bondDim f.1}
+    (Z₁ Z₂ : GL (Fin (B.bondDim f.1)) ℂ)
+    (h₁ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B R f
+          ((Z₁ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₁) M *
+            (↑Z₁⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
+    (h₂ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B R f
+          ((Z₂ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₂) M *
+            (↑Z₂⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
+    (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
+    (Z₁ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) * N *
+        (↑Z₁⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) =
+      (Z₂ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) * N *
+        (↑Z₂⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) := by
+  -- Every target matrix `N` is a reindexed `M` (the reindexing is an algebra equivalence).
+  obtain ⟨M, rfl⟩ := (Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₁)).surjective N
+  have hmain := gaugeConj_eq_of_coeffIdentities A B R f hRB hCB hposB
+    (hE₁ := hE₁) (hE₂ := hE₂) Z₁ Z₂ h₁ h₂ M
+  -- The two reindexings along `hE₁` and `hE₂` coincide by proof irrelevance.
+  have hcast : (Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₁) M) =
+      (Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₂) M) := by
+    congr 1
+  rw [hcast] at hmain
+  exact hmain
+
+end TorusFamily
+
 end PEPS
 end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1640,11 +1640,28 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.regionInsertedCoeff_transferMap_unique},
           \leanid{TNLean.PEPS.regionTransferMap_eq_of_coeffIdentities}, and
           \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance}.}
-          What remains is the construction of the per-edge gauge family from the
-          reference blocking data at the two orientation classes, on top of which the
-          conjugation covariance is the transfer-map determinacy applied to each
-          translate. This still depends on the open per-edge gauge of obligation~5 for
-          the transfer maps themselves.
+          The algebraic reduction from matched coefficient identities to the conjugation
+          covariance is now in place. The per-edge gauge at a torus edge carries its
+          defining coefficient identity, so the gauge conjugation itself satisfies the
+          identity. Reindexing across a bond-dimension equality commutes with
+          conjugation, identifying the transported reference matrix with the conjugation
+          by the reindexed reference. Two gauges realizing the same coefficient identity
+          by conjugation induce the same conjugation map on every bond matrix, by the
+          transfer-map determinacy. These supply, edge by edge, the conjugation
+          coincidence the orientation-uniform selection consumes.\footnote{Formal
+          declarations: \leanid{TNLean.PEPS.exists_regionEdgeGauge_torus_coeff},
+          \leanid{TNLean.PEPS.reindexAlgEquiv_gaugeConj},
+          \leanid{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities}, and
+          \leanid{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities_torus}.}
+          What remains is the geometric production of the two matched coefficient
+          identities at every edge: reading the per-edge gauge off the reference blocking
+          datum transported along each class translation, and matching its region and
+          boundary edge with those of the transported reference identity. The transported
+          blocking datum reads its three blocks from the translation, which may reorder
+          the edge endpoints and so place the reference red region in the blue slot; the
+          orientation-class matching must account for this branch. This construction
+          still depends on the open per-edge gauge of obligation~5 for the transfer maps
+          themselves.
 
           The final region comparison setup is also formalized: a region and its set
           complement are wrapped as the two blocks consumed by the two-injective


### PR DESCRIPTION
## What

The complete algebraic reduction of the torus class agreement (TI Normal PEPS FT, #1373):
the gauge interface enriched with its **coefficient identity**, and matched identities
proven to force **equal conjugation maps** — the exact inputs of the merged
orientation-uniform assembly. All sorry-free; `#print axioms` =
`[propext, Classical.choice, Quot.sound]`; full root build green (8,858 jobs).

## Highlights

- **`exists_regionEdgeGauge_torus_coeff`** — the per-edge gauge now exposes the
  load-bearing identity `regionInsertedCoeff A … M = regionInsertedCoeff B … (Z·M·Z⁻¹)`
  the determinacy argument consumes. Region/host injectivity only.
- **`gaugeConj_eq_of_coeffIdentities(_torus)`** + `reindexAlgEquiv_gaugeConj` — two gauges
  realizing the same coefficient identity induce the same conjugation (via the merged
  determinacy), in the exact `hcovH`/`hcovV` shape of the merged
  `isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance`.

## Honest residuals (documented in the route note)

1. The concrete torus reference blocking datum (the geometric port of the interior
   rectangle apparatus).
2. The orientation branch of `transportBlockingDataAlong` (class translations that reorder
   endpoints swap red/blue — needs the swapped-region covariance variant).
3. **A faithfulness discovery:** the FT capstone's scalar counting
   (`exists_stateCoeff_ne_zero`) genuinely requires `IsVertexInjective` in its current
   form — the normal route needs its region-injective version (the blocked-weight
   linear-independence nonvanishing argument).

Refs #1373. CI failures are non-blocking automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean proofs and documentation on the PEPS normal-FT route; no runtime, auth, or data-path changes.
> 
> **Overview**
> This PR completes the **algebraic** side of torus orientation-uniform gauge reduction (obligation 6): matched region-insertion coefficient identities are shown to force equal conjugation maps, in the shape consumed by `isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance`.
> 
> **`exists_regionEdgeGauge_torus_coeff`** extends the existing torus per-edge gauge theorem by stating that conjugation by the gauge matrix realizes the defining `regionInsertedCoeff` identity (via `fwd_coeff` and the blocking-data gauge construction).
> 
> New module **`TNLean/PEPS/TorusEdgeGaugeCovariance.lean`** adds **`reindexAlgEquiv_gaugeConj`** (bond reindexing commutes with gauge conjugation), **`gaugeConj_eq_of_coeffIdentities`** (two gauges with the same coefficient identity agree, via `regionInsertedCoeff_transferMap_unique`), and the torus specialization **`gaugeConj_eq_of_coeffIdentities_torus`** (works on bond matrices over `B` using reindex surjectivity). The root import list and **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** are updated to record that this conjugation-covariance reduction is formalized; **geometric** production of matched coefficient identities at every edge (transported blocking data, red/blue slot branching) remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a49b04a25082c09c035a0ec496c7c72d7ddcc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->