### PR TITLE
feat(PEPS): region-injective nonvanishing, branch-free transport injectivity, and torus reference data

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -402,7 +402,9 @@ import TNLean.PEPS.RegionTransport
 import TNLean.PEPS.RegionTransportData
 import TNLean.PEPS.RegionTransportInsertion
 import TNLean.PEPS.RegionTransferCovariance
+import TNLean.PEPS.SingletonEdgeBlockingData
 import TNLean.PEPS.TorusTranslationInvariant
+import TNLean.PEPS.TorusReferenceBlockingData
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge
 import TNLean.PEPS.TorusOrientationGauge

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -405,6 +405,7 @@ import TNLean.PEPS.RegionTransferCovariance
 import TNLean.PEPS.SingletonEdgeBlockingData
 import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.TorusRectangleRegion
+import TNLean.PEPS.TorusEdgeBlockingRegion
 import TNLean.PEPS.TorusReferenceBlockingData
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -416,6 +416,7 @@ import TNLean.PEPS.TorusOrientationGauge
 import TNLean.PEPS.TorusTINormalGauge
 import TNLean.PEPS.TorusClassAgreement
 import TNLean.PEPS.TorusEdgeGaugeCovariance
+import TNLean.PEPS.TorusConjCovarianceFamily
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -407,6 +407,7 @@ import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.TorusRectangleRegion
 import TNLean.PEPS.TorusEdgeBlockingRegion
 import TNLean.PEPS.TorusEdgeBlockingCrossing
+import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusReferenceBlockingData
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -404,6 +404,7 @@ import TNLean.PEPS.RegionTransportInsertion
 import TNLean.PEPS.RegionTransferCovariance
 import TNLean.PEPS.SingletonEdgeBlockingData
 import TNLean.PEPS.TorusTranslationInvariant
+import TNLean.PEPS.TorusRectangleRegion
 import TNLean.PEPS.TorusReferenceBlockingData
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -406,6 +406,7 @@ import TNLean.PEPS.SingletonEdgeBlockingData
 import TNLean.PEPS.TorusTranslationInvariant
 import TNLean.PEPS.TorusRectangleRegion
 import TNLean.PEPS.TorusEdgeBlockingRegion
+import TNLean.PEPS.TorusEdgeBlockingCrossing
 import TNLean.PEPS.TorusReferenceBlockingData
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -409,6 +409,7 @@ import TNLean.PEPS.TorusEdgeBlockingRegion
 import TNLean.PEPS.TorusEdgeBlockingCrossing
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleGauge
+import TNLean.PEPS.TorusRectangleWitness
 import TNLean.PEPS.TorusReferenceBlockingData
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -408,6 +408,7 @@ import TNLean.PEPS.TorusRectangleRegion
 import TNLean.PEPS.TorusEdgeBlockingRegion
 import TNLean.PEPS.TorusEdgeBlockingCrossing
 import TNLean.PEPS.TorusRectangleReferenceData
+import TNLean.PEPS.TorusRectangleGauge
 import TNLean.PEPS.TorusReferenceBlockingData
 import TNLean.PEPS.TorusBlockingData
 import TNLean.PEPS.TorusEdgeGauge

--- a/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
@@ -410,5 +410,115 @@ theorem range_regionBlockedTensorMap_eq_of_sameState (A B : Tensor G d) (R : Fin
   · rintro ⟨τ, rfl⟩; exact ⟨τ, (regionPartialState_sameState hAB R τ).symm⟩
   · rintro ⟨τ, rfl⟩; exact ⟨τ, regionPartialState_sameState hAB R τ⟩
 
+/-! ### Nonvanishing of the closed state coefficient under region injectivity
+
+The region-injective analogue of `exists_stateCoeff_ne_zero`. The vertex-injective
+proof splits the closed network at a single vertex; here the split is at an
+arbitrary blocked region `R` whose complement is also injective. Both the region
+weight family and the complement weight family are linearly independent, so the
+bilinear pairing that builds the closed state coefficient cannot vanish
+identically. -/
+
+open scoped Classical in
+/-- A region-injective PEPS with positive bond dimensions has a nonzero closed
+state coefficient.
+
+This is the region-injective analogue of `exists_stateCoeff_ne_zero`. The
+vertex-injective version splits the closed network at a single vertex and uses
+single-vertex injectivity (`localCoeff_eq_zero_of_contract_zero`); the normal
+route replaces the single vertex by an arbitrary blocked region `R` whose
+complement is also injective.
+
+Splitting at `R` (`regionInteriorBondProd_smul_regionPartialState`) writes the
+interior-bond multiple of every partial state across the region cut as the
+blocked-region tensor map of `R` applied to the complement weights at the fixed
+complement physical configuration. If every closed state coefficient vanished,
+the partial states would vanish, so for each complement configuration `τ` the
+complement weight family `μ ↦ regionBlockedWeight A (univ \ R) (compl μ) τ` would
+lie in the kernel of the blocked-region tensor map of `R`; region injectivity of
+`R` (the left inverse `regionBlockedLeftInverse`) forces it to vanish, so the
+whole complement weight family would be identically zero, contradicting linear
+independence of that family (region injectivity of the complement). The boundary
+configuration on the complement is nonempty because positive bond dimensions make
+every crossing-edge fibre nonempty. No physical-dimension hypothesis `0 < d` is
+needed: region injectivity of the complement already forces a physical
+configuration carrying nonzero weight.
+
+Source: arXiv:1804.04964, Section 3, lines 1205--1210 of
+`Papers/1804.04964/paper_normal.tex`, read at the level of the closed state
+coefficient rather than the bond-inserted coefficient. -/
+theorem exists_stateCoeff_ne_zero_of_regionInjective (A : Tensor G d) (R : Finset V)
+    (hR : RegionBlockedTensorInjective (G := G) A R)
+    (hC : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e) :
+    ∃ σ : V → Fin d, stateCoeff A σ ≠ 0 := by
+  classical
+  -- Positive bond dimensions make every crossing-edge fibre nonempty, so the
+  -- complement boundary-configuration type has a member `ν₀`.
+  have hNeBdry : Nonempty (RegionBoundaryConfig (G := G) A (Finset.univ \ R)) :=
+    ⟨fun f => ⟨0, hpos f.1⟩⟩
+  obtain ⟨ν₀⟩ := hNeBdry
+  -- The complement weight family is linearly independent, hence nonzero at `ν₀`.
+  have hne : regionBlockedTensorFamily (G := G) A (Finset.univ \ R) ν₀ ≠ 0 := hC.ne_zero ν₀
+  -- Some complement physical configuration gives a nonzero complement weight at `ν₀`.
+  obtain ⟨τ₀, hτ₀⟩ :
+      ∃ τ, regionBlockedWeight (G := G) A (Finset.univ \ R) ν₀ τ ≠ 0 := by
+    by_contra hall
+    push_neg at hall
+    exact hne (by funext τ; simpa [regionBlockedTensorFamily] using hall τ)
+  -- Suppose, for contradiction, every closed state coefficient vanishes.
+  by_contra hzero
+  push_neg at hzero
+  -- Then every partial state across the region cut vanishes.
+  have hpartial : ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+      regionPartialState (G := G) A R τ = 0 := by
+    intro τ
+    funext σ
+    rw [regionPartialState, hzero, Pi.zero_apply]
+  -- For each `τ`, the complement weights at `τ`, read through the boundary
+  -- identification, form a kernel vector of the blocked-region tensor map of `R`.
+  have hker : ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+      regionBlockedTensorMap (G := G) A R
+          (fun μ : RegionBoundaryConfig (G := G) A R =>
+            regionBlockedWeight (G := G) A (Finset.univ \ R)
+              (regionComplementBoundaryConfig (G := G) A R μ) τ) = 0 := by
+    intro τ
+    -- The map applied to those coefficients is the interior-bond multiple of the
+    -- partial state, which vanishes.
+    funext σ
+    rw [regionBlockedTensorMap_apply]
+    have hsplit := congrFun
+      (regionInteriorBondProd_smul_regionPartialState (G := G) A R τ) σ
+    rw [Pi.smul_apply, hpartial τ, Pi.zero_apply, smul_zero, Finset.sum_apply] at hsplit
+    simp only [Pi.smul_apply, smul_eq_mul] at hsplit
+    rw [Pi.zero_apply]
+    -- Match the map expansion to the split sum (both `c μ • weight μ σ`).
+    simp only [smul_eq_mul]
+    rw [← hsplit]
+  -- Region injectivity of `R` forces every such complement-weight coefficient family
+  -- to vanish (the chosen left inverse reads `0` off the kernel image).
+  have hcompZero : ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
+      (fun μ : RegionBoundaryConfig (G := G) A R =>
+        regionBlockedWeight (G := G) A (Finset.univ \ R)
+          (regionComplementBoundaryConfig (G := G) A R μ) τ) = 0 := by
+    intro τ
+    have := regionBlockedTensorMap_injective_of_injective (G := G) A R hR
+    have hzeroμ := this (a₁ := fun μ : RegionBoundaryConfig (G := G) A R =>
+        regionBlockedWeight (G := G) A (Finset.univ \ R)
+          (regionComplementBoundaryConfig (G := G) A R μ) τ)
+      (a₂ := 0) (by rw [hker τ, map_zero])
+    exact hzeroμ
+  -- The complement boundary identification is a bijection onto every complement
+  -- configuration, so the whole complement weight family is identically zero.
+  obtain ⟨μ₀, hμ₀⟩ :
+      ∃ μ₀ : RegionBoundaryConfig (G := G) A R,
+        regionComplementBoundaryConfig (G := G) A R μ₀ = ν₀ :=
+    ⟨(regionComplementBoundaryConfigEquiv (G := G) A R).symm ν₀, by
+      rw [← regionComplementBoundaryConfigEquiv_apply (G := G) A R]
+      exact (regionComplementBoundaryConfigEquiv (G := G) A R).apply_symm_apply ν₀⟩
+  have := congrFun (hcompZero τ₀) μ₀
+  rw [hμ₀, Pi.zero_apply] at this
+  exact hτ₀ this
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionTransportData.lean
+++ b/TNLean/PEPS/RegionTransportData.lean
@@ -177,6 +177,74 @@ theorem transportBlockingDataAlong_redBlue (A : Tensor G d) (φ : G ≃g G') {e 
   · rw [dif_pos hord]; exact Or.inl ⟨rfl, rfl⟩
   · rw [dif_neg hord]; exact Or.inr ⟨rfl, rfl⟩
 
+/-- The transported datum's complement block is the image of the original complement block, on
+both endpoint-order branches.  The endpoint-order flip exchanges only the red and blue blocks; the
+complement is untouched.  This is the half of the unordered-pair identity that the covariance
+chain reads off directly, since the region-inserted coefficient over the complement-side block is
+the same on both branches. -/
+theorem transportBlockingDataAlong_complement (A : Tensor G d) (φ : G ≃g G') {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    (transportBlockingDataAlong A φ D).complement = Region.map φ D.complement := by
+  classical
+  unfold transportBlockingDataAlong
+  by_cases hord : (Edge.map φ e).1.1 = φ e.1.1
+  · rw [dif_pos hord]
+  · rw [dif_neg hord]
+
+/-- **Orientation-free red/blue host injectivity of the transported datum.**
+
+On both endpoint-order branches the transported datum's set-complement host region of its red
+block `univ \ (transportBlockingDataAlong A φ D).red` is one of the two image host regions
+`univ \ Region.map φ D.red` or `univ \ Region.map φ D.blue`, both injective for `A.transport φ`.
+Since the per-edge gauge of the transported datum reads the region-inserted coefficient over its
+red block against this host, the host injectivity is available on both branches: the endpoint-order
+flip exchanges which of the two injective image blocks plays the red role, but both are injective,
+so the gauge interface input is unconditional.  This is what lets the class-agreement chain be
+stated without case-splitting on the branch. -/
+theorem regionBlockedTensorInjective_transportBlockingDataAlong_red (A : Tensor G d) (φ : G ≃g G')
+    {e : Edge G} (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) :
+    (regionInjectivityDataOf (G := G') (A.transport φ)).IsInjective
+      (transportBlockingDataAlong A φ D).red := by
+  classical
+  rcases transportBlockingDataAlong_redBlue A φ D with ⟨hr, _⟩ | ⟨hr, _⟩
+  · rw [hr]; exact regionInjectivityDataOf_transport_map A φ D.red_injective
+  · rw [hr]; exact regionInjectivityDataOf_transport_map A φ D.blue_injective
+
+/-- **Orientation-free host injectivity of the transported datum.**
+
+On both endpoint-order branches the set complement of the transported datum's red block is the
+union of the other two image blocks, both injective for `A.transport φ`, so under union closure the
+host region `univ \ (transportBlockingDataAlong A φ D).red` is itself injective.  This is the second
+host injectivity the gauge interface consumes (alongside the red injectivity
+`regionBlockedTensorInjective_transportBlockingDataAlong_red`), available unconditionally on the
+branch: whichever image block plays the red role, the remaining two cover the host and are both
+injective.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorInjective_host_transportBlockingDataAlong (A : Tensor G d) (φ : G ≃g G')
+    {e : Edge G} (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (hU : RegionInjectivityUnionClosure (regionInjectivityDataOf (G := G') (A.transport φ))) :
+    (regionInjectivityDataOf (G := G') (A.transport φ)).IsInjective
+      (Finset.univ \ (transportBlockingDataAlong A φ D).red) := by
+  classical
+  set D' := transportBlockingDataAlong A φ D with hD'
+  -- The host region of the red block is the union of the blue and complement blocks.
+  have hsdiff : Finset.univ \ D'.red = D'.blue ∪ D'.complement := by
+    have hcov := D'.cover_univ
+    ext v
+    simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_union]
+    constructor
+    · intro _
+      have hmem : v ∈ D'.red ∪ D'.blue ∪ D'.complement := by rw [hcov]; exact Finset.mem_univ v
+      simp only [Finset.mem_union] at hmem
+      tauto
+    · rintro (hb | hc)
+      · exact fun hr => Finset.disjoint_left.mp D'.red_disjoint_blue hr hb
+      · exact fun hr => Finset.disjoint_left.mp D'.red_disjoint_complement hr hc
+  rw [hsdiff]
+  exact hU.union_injective D'.blue_injective D'.complement_injective
+
 /-- **Single-crossing transport.**
 
 If the red-to-blue crossings of `D` are exactly the edge `e`, then the red-to-blue crossings of

--- a/TNLean/PEPS/SingletonEdgeBlockingData.lean
+++ b/TNLean/PEPS/SingletonEdgeBlockingData.lean
@@ -1,0 +1,166 @@
+import TNLean.PEPS.NormalEdgeBlockingData
+import TNLean.PEPS.RegionBlock.UnionClosure
+import TNLean.PEPS.RegionBlock.CoarseThreeSite2
+import TNLean.PEPS.IsoTransport
+
+/-!
+# Singleton-endpoint blocking data for a vertex-injective PEPS
+
+For a vertex-injective PEPS with positive bond dimensions, every finite vertex region is
+blocked-tensor injective (a contraction of injective tensors is injective,
+`regionBlockedTensorInjective_of_isVertexInjective`).  This removes the rectangular-cover
+bookkeeping of the open-lattice every-edge construction: at any edge `e` the singleton red block
+`{e.1.1}`, the singleton blue block `{e.1.2}`, and the complementary block `univ \ {e.1.1, e.1.2}`
+partition the vertex set, all three are injective, and the only red-to-blue crossing is `e` itself.
+
+The construction is graph-polymorphic, so it applies verbatim to the discrete torus at any
+reference edge: it produces the reference blocking datum the translation-invariant gauge family
+consumes, with the single-crossing hypothesis discharged unconditionally.  The wraparound geometry
+of the torus never enters, because singleton blocks need no room to be injective once the tensor is
+vertex injective.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 981--1009 and
+  1322--1404 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Singleton red-to-blue crossing
+
+For two distinct singleton blocks `{p}` and `{q}`, an edge crosses between them precisely when its
+two endpoints are `p` and `q` in some order, i.e. the edge is `Edge.ofAdj` on the adjacent pair.
+This is the singleton form of the single-crossing hypothesis. -/
+
+omit [Fintype V] [DecidableEq V] in
+/-- An edge crosses between the singleton blocks `{p}` and `{q}` exactly when its unordered
+endpoint pair is `{p, q}`. -/
+theorem isCrossingEdge_singleton (A : Tensor G d) {p q : V} (hpq : p ≠ q)
+    (g : Edge G) :
+    IsCrossingEdge (G := G) A ({p} : Finset V) ({q} : Finset V) g ↔
+      (g.1.1 = p ∧ g.1.2 = q) ∨ (g.1.1 = q ∧ g.1.2 = p) := by
+  classical
+  unfold IsCrossingEdge IsRegionBoundaryEdge
+  simp only [Finset.mem_singleton]
+  constructor
+  · rintro ⟨hP, hQ⟩
+    -- From the `{p}` boundary, exactly one endpoint is `p`; from `{q}`, exactly one is `q`.
+    rcases hP with ⟨h1p, h2p⟩ | ⟨h1p, h2p⟩
+    · -- `g.1.1 = p`, `g.1.2 ≠ p`.  Then the `{q}` boundary forces `g.1.2 = q`.
+      rcases hQ with ⟨h1q, _⟩ | ⟨_, h2q⟩
+      · exact absurd (h1q.symm.trans h1p) hpq.symm
+      · exact Or.inl ⟨h1p, h2q⟩
+    · -- `g.1.1 ≠ p`, `g.1.2 = p`.  Then the `{q}` boundary forces `g.1.1 = q`.
+      rcases hQ with ⟨h1q, _⟩ | ⟨_, h2q⟩
+      · exact Or.inr ⟨h1q, h2p⟩
+      · exact absurd (h2q.symm.trans h2p) hpq.symm
+  · rintro (⟨h1, h2⟩ | ⟨h1, h2⟩)
+    · -- `g.1.1 = p`, `g.1.2 = q`.
+      refine ⟨Or.inl ⟨h1, ?_⟩, Or.inr ⟨?_, h2⟩⟩
+      · rw [h2]; exact fun h => hpq h.symm
+      · rw [h1]; exact hpq
+    · -- `g.1.1 = q`, `g.1.2 = p`.
+      refine ⟨Or.inr ⟨?_, h2⟩, Or.inl ⟨h1, ?_⟩⟩
+      · rw [h1]; exact fun h => hpq h.symm
+      · rw [h2]; exact hpq
+
+omit [Fintype V] [DecidableEq V] in
+/-- The single red-to-blue crossing between `{p}` and `{q}` for adjacent distinct `p`, `q` is the
+edge `Edge.ofAdj` on the pair: an edge crosses between the two singletons iff it is that edge. -/
+theorem isCrossingEdge_singleton_eq_ofAdj (A : Tensor G d) {p q : V} (hadj : G.Adj p q)
+    (g : Edge G) :
+    IsCrossingEdge (G := G) A ({p} : Finset V) ({q} : Finset V) g ↔ g = Edge.ofAdj hadj := by
+  rw [isCrossingEdge_singleton A (G.ne_of_adj hadj) g]
+  constructor
+  · intro h
+    refine (Edge.ofAdj_eq_of_endpoints hadj g ?_).symm
+    rcases h with ⟨h1, h2⟩ | ⟨h1, h2⟩
+    · exact Or.inl ⟨h1.symm, h2.symm⟩
+    · exact Or.inr ⟨h2.symm, h1.symm⟩
+  · intro h
+    subst h
+    exact Edge.ofAdj_endpoints hadj
+
+/-! ### The singleton blocking datum -/
+
+/-- **Singleton-endpoint blocking datum.**
+
+For a vertex-injective PEPS `A` with positive bond dimensions, the edge `e` has a one-edge blocking
+datum whose red block is the singleton `{e.1.1}`, blue block the singleton `{e.1.2}`, and
+complementary block `univ \ {e.1.1, e.1.2}`.  All three regions are injective because every finite
+region is injective under vertex injectivity; the three regions partition the vertex set; the edge's
+left endpoint lies in red and right endpoint in blue.
+
+This is the cover-free reference blocking datum: it needs no rectangular geometry, so it applies on
+any graph, including the discrete torus at a reference edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 981--1009 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def singletonEdgeBlockingData (A : Tensor G d) (e : Edge G)
+    (hA : IsVertexInjective A) (hpos : ∀ f : Edge G, 0 < A.bondDim f) :
+    NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e where
+  red := {e.1.1}
+  blue := {e.1.2}
+  complement := Finset.univ \ ({e.1.1} ∪ {e.1.2})
+  left_mem_red := Finset.mem_singleton_self e.1.1
+  right_mem_blue := Finset.mem_singleton_self e.1.2
+  red_injective := by
+    rw [regionInjectivityDataOf_isInjective]
+    exact regionBlockedTensorInjective_of_isVertexInjective (G := G) A {e.1.1} hA hpos
+  blue_injective := by
+    rw [regionInjectivityDataOf_isInjective]
+    exact regionBlockedTensorInjective_of_isVertexInjective (G := G) A {e.1.2} hA hpos
+  complement_injective := by
+    rw [regionInjectivityDataOf_isInjective]
+    exact regionBlockedTensorInjective_of_isVertexInjective (G := G) A
+      (Finset.univ \ ({e.1.1} ∪ {e.1.2})) hA hpos
+  red_disjoint_blue := by
+    rw [Finset.disjoint_singleton]
+    exact (G.ne_of_adj e.2.2)
+  red_disjoint_complement := by
+    rw [Finset.disjoint_left]
+    intro x hx hxc
+    rw [Finset.mem_sdiff] at hxc
+    exact hxc.2 (Finset.mem_union_left _ hx)
+  blue_disjoint_complement := by
+    rw [Finset.disjoint_left]
+    intro x hx hxc
+    rw [Finset.mem_sdiff] at hxc
+    exact hxc.2 (Finset.mem_union_right _ hx)
+  cover_univ := by
+    rw [Finset.union_sdiff_of_subset (Finset.subset_univ _)]
+
+@[simp] theorem singletonEdgeBlockingData_red (A : Tensor G d) (e : Edge G)
+    (hA : IsVertexInjective A) (hpos : ∀ f : Edge G, 0 < A.bondDim f) :
+    (singletonEdgeBlockingData A e hA hpos).red = ({e.1.1} : Finset V) := rfl
+
+@[simp] theorem singletonEdgeBlockingData_blue (A : Tensor G d) (e : Edge G)
+    (hA : IsVertexInjective A) (hpos : ∀ f : Edge G, 0 < A.bondDim f) :
+    (singletonEdgeBlockingData A e hA hpos).blue = ({e.1.2} : Finset V) := rfl
+
+@[simp] theorem singletonEdgeBlockingData_complement (A : Tensor G d) (e : Edge G)
+    (hA : IsVertexInjective A) (hpos : ∀ f : Edge G, 0 < A.bondDim f) :
+    (singletonEdgeBlockingData A e hA hpos).complement =
+      Finset.univ \ ({e.1.1} ∪ {e.1.2}) := rfl
+
+/-- The red-to-blue crossings of the singleton blocking datum are exactly the edge `e`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isCrossingEdge_singletonEdgeBlockingData (A : Tensor G d) (e : Edge G)
+    (hA : IsVertexInjective A) (hpos : ∀ f : Edge G, 0 < A.bondDim f)
+    (g : Edge G) :
+    IsCrossingEdge (G := G) A (singletonEdgeBlockingData A e hA hpos).red
+        (singletonEdgeBlockingData A e hA hpos).blue g ↔
+      g = e := by
+  rw [singletonEdgeBlockingData_red, singletonEdgeBlockingData_blue,
+    isCrossingEdge_singleton_eq_ofAdj A e.2.2 g, Edge.ofAdj_fst_snd]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusConjCovarianceFamily.lean
+++ b/TNLean/PEPS/TorusConjCovarianceFamily.lean
@@ -1,0 +1,130 @@
+import TNLean.PEPS.TorusEdgeGaugeCovariance
+import TNLean.PEPS.TorusClassAgreement
+
+/-!
+# The conjugation covariance family from per-edge coefficient identities
+
+The orientation-uniform selection on the torus consumes the conjugation covariance `hcovH`/`hcovV`
+of `isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance`: on every horizontal
+(vertical) edge the conjugation by the per-edge gauge coincides with the conjugation by the
+transported reference matrix.  This file assembles that covariance from the per-edge coefficient
+identities, isolating the single remaining geometric obligation — producing the two matched
+coefficient-identity families at every edge — as the hypotheses `hidX`/`hidRef`.
+
+For a fixed orientation class, suppose on every edge `e` of the class there is a region `R e` with a
+single boundary edge equal to `e`, the second tensor's region and complement blocked-tensor
+injective, and two coefficient identities: one realized by the per-edge gauge `X e` and one by the
+transported reference gauge.  Then the conjugations by `X e` and by the transported reference
+coincide (`gaugeConj_eq_of_coeffIdentities_torus`), which is exactly `hcovH` (`hcovV`).  Gathering
+the two classes through the selection gives the orientation-uniform-up-to-scalar family.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- The data realizing the conjugation covariance at one edge: a region whose single boundary edge
+is `e`, the second tensor's region/complement injectivity, and a pair of coefficient identities
+realized by the per-edge gauge and the reference gauge respectively.
+
+Bundling these per edge isolates the geometric obligation (producing the identities) from the
+algebraic determinacy that turns them into the conjugation covariance.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
+`Papers/1804.04964/paper_normal.tex`. -/
+structure EdgeCoeffIdentityWitness (A B : Tensor (torusGraph width height) d)
+    (e : Edge (torusGraph width height))
+    (Z Zref : GL (Fin (B.bondDim e)) ℂ) (hE : A.bondDim e = B.bondDim e) where
+  /-- The region whose single boundary edge is `e`. -/
+  region : Finset (TorusVertex width height)
+  /-- `e` is a boundary edge of the region. -/
+  isBoundary : IsRegionBoundaryEdge (G := torusGraph width height) region e
+  /-- The second tensor's region block is blocked-tensor injective. -/
+  hRB : RegionBlockedTensorInjective (G := torusGraph width height) B region
+  /-- The second tensor's host block is blocked-tensor injective. -/
+  hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+    (Finset.univ \ region)
+  /-- The second tensor has positive bond dimensions. -/
+  hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g
+  /-- The per-edge gauge `Z` realizes the region-insertion coefficient identity by conjugation. -/
+  hidZ : ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) region)
+    (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ region)),
+    regionInsertedCoeff (G := torusGraph width height) A region ⟨e, isBoundary⟩ M σ τ =
+      regionInsertedCoeff (G := torusGraph width height) B region ⟨e, isBoundary⟩
+        ((Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+            Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+          (↑Z⁻¹ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)) σ τ
+  /-- The reference gauge `Zref` realizes the same coefficient identity by conjugation. -/
+  hidZref : ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+    (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) region)
+    (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ region)),
+    regionInsertedCoeff (G := torusGraph width height) A region ⟨e, isBoundary⟩ M σ τ =
+      regionInsertedCoeff (G := torusGraph width height) B region ⟨e, isBoundary⟩
+        ((Zref : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+            Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+          (↑Zref⁻¹ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)) σ τ
+
+/-- From an edge coefficient-identity witness, the per-edge gauge and the reference gauge induce the
+same conjugation map on every bond matrix.
+
+This is `gaugeConj_eq_of_coeffIdentities_torus` read off the bundled witness: it is the conjugation
+covariance at one edge.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem gaugeConj_eq_of_edgeCoeffIdentityWitness
+    {A B : Tensor (torusGraph width height) d}
+    {e : Edge (torusGraph width height)}
+    {Z Zref : GL (Fin (B.bondDim e)) ℂ} {hE : A.bondDim e = B.bondDim e}
+    (w : EdgeCoeffIdentityWitness A B e Z Zref hE)
+    (N : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) :
+    (Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) * N *
+        (↑Z⁻¹ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) =
+      (Zref : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) * N *
+        (↑Zref⁻¹ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) :=
+  gaugeConj_eq_of_coeffIdentities_torus w.region ⟨e, w.isBoundary⟩ w.hRB w.hCB w.hposB
+    (hE₁ := hE) (hE₂ := hE) Z Zref w.hidZ w.hidZref N
+
+/-- **The orientation-uniform-mod-scalar family from per-edge coefficient-identity witnesses.**
+
+For a torus pair `A`, `B` and a per-edge gauge family `X` over the second tensor's bond dimensions
+with orientation-uniform bond dimensions, suppose on every horizontal edge `e` the gauge `X e` and
+the transported reference gauge `glReindex (huni.horizontal he).symm Xh` both carry an edge
+coefficient-identity witness (with `X e` realizing the per-edge identity and the transported
+reference the reference identity), and likewise on every vertical edge with `Xv`.  Then `X` is
+orientation uniform up to per-edge scalars.
+
+The witnesses package the geometric production of the matched coefficient identities; their
+algebraic content (the conjugation covariance) is `gaugeConj_eq_of_edgeCoeffIdentityWitness`, and
+the assembly is `isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses
+    {A B : Tensor (torusGraph width height) d} {Dh Dv : ℕ}
+    (huni : TorusUniformBondDim B.bondDim Dh Dv)
+    (X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (Xh : GL (Fin Dh) ℂ) (Xv : GL (Fin Dv) ℂ)
+    (hE : ∀ e : Edge (torusGraph width height), A.bondDim e = B.bondDim e)
+    (witH : ∀ (e : Edge (torusGraph width height)) (he : IsHorizontalTorusEdge e),
+      EdgeCoeffIdentityWitness A B e (X e) (glReindex (huni.horizontal he).symm Xh) (hE e))
+    (witV : ∀ (e : Edge (torusGraph width height)) (he : IsVerticalTorusEdge e),
+      EdgeCoeffIdentityWitness A B e (X e) (glReindex (huni.vertical he).symm Xv) (hE e)) :
+    IsTorusOrientationUniformGaugeFamilyModScalar huni X := by
+  refine isTorusOrientationUniformGaugeFamilyModScalar_of_conjCovariance huni X Xh Xv
+    (fun e he N => gaugeConj_eq_of_edgeCoeffIdentityWitness (witH e he) N)
+    (fun e he N => gaugeConj_eq_of_edgeCoeffIdentityWitness (witV e he) N)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusEdgeBlockingCrossing.lean
+++ b/TNLean/PEPS/TorusEdgeBlockingCrossing.lean
@@ -1,0 +1,317 @@
+import TNLean.PEPS.TorusEdgeBlockingRegion
+import TNLean.PEPS.TorusTranslationInvariant
+import TNLean.PEPS.RegionBlock.CoarseThreeSite2
+
+/-!
+# The single red-to-blue crossing of the torus edge blocking
+
+The coarse three-site route discharges the per-edge gauge from the single-crossing hypothesis
+`∀ g, IsCrossingEdge A red blue g ↔ g = e`.  This file proves that hypothesis for the horizontal
+and vertical edge blockings of `TNLean/PEPS/TorusEdgeBlockingRegion.lean`, where the red and blue
+blocks meet only along the distinguished edge.
+
+The discrete-torus subtlety over the open lattice is the cyclic adjacency: a horizontal step
+`v.1 + 1 = w.1` is read in `ZMod width`.  Away from the wraparound seam the coordinate values add
+without wrapping (`val_add_of_lt`), so inside the no-wraparound window of the blocking the cyclic
+step is the ordinary coordinate step, and the open-lattice crossing argument carries over.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)] {d : ℕ}
+
+/-! ### Coordinate values of a cyclic step inside the no-wraparound window -/
+
+omit [NeZero width] [NeZero height] [Fact (1 < height)] in
+/-- A horizontal cyclic step `v.1 + 1 = w.1` reads as an ordinary coordinate step when the source
+value plus one stays below the width. -/
+theorem torus_horizontal_step_val {v w : TorusVertex width height} (h : v.1 + 1 = w.1)
+    (hlt : v.1.val + 1 < width) :
+    w.1.val = v.1.val + 1 := by
+  rw [← h, ZMod.val_add_of_lt (by rw [ZMod.val_one]; omega), ZMod.val_one]
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] in
+/-- A vertical cyclic step `v.2 + 1 = w.2` reads as an ordinary coordinate step when the source
+value plus one stays below the height. -/
+theorem torus_vertical_step_val {v w : TorusVertex width height} (h : v.2 + 1 = w.2)
+    (hlt : v.2.val + 1 < height) :
+    w.2.val = v.2.val + 1 := by
+  rw [← h, ZMod.val_add_of_lt (by rw [ZMod.val_one]; omega), ZMod.val_one]
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
+/-- The horizontal coordinate value is preserved by a vertical cyclic step. -/
+theorem torus_eq_fst_val {v w : TorusVertex width height} (h : v.1 = w.1) :
+    v.1.val = w.1.val := by rw [h]
+
+omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
+/-- The vertical coordinate value is preserved by a horizontal cyclic step. -/
+theorem torus_eq_snd_val {v w : TorusVertex width height} (h : v.2 = w.2) :
+    v.2.val = w.2.val := by rw [h]
+
+/-! ### The reference horizontal and vertical edges -/
+
+/-- The distinguished horizontal edge of the blocking at offset `(xStart, yStart)`: the edge from
+`(xStart + 1, yStart + 2)` to `(xStart + 2, yStart + 2)`.  This is the only red-to-blue crossing. -/
+def torusHorizontalReferenceEdge (xStart yStart : ℕ) : Edge (torusGraph width height) :=
+  torusRightEdge ((xStart + 1 : ℕ), (yStart + 2 : ℕ))
+
+/-- The distinguished vertical edge of the blocking at offset `(xStart, yStart)`: the edge from
+`(xStart + 2, yStart + 1)` to `(xStart + 2, yStart + 2)`.  This is the only red-to-blue crossing. -/
+def torusVerticalReferenceEdge (xStart yStart : ℕ) : Edge (torusGraph width height) :=
+  torusUpEdge ((xStart + 2 : ℕ), (yStart + 1 : ℕ))
+
+/-- Ordered endpoints of a torus right edge that avoids wraparound: the first endpoint is the lower
+horizontal coordinate. -/
+theorem torusRightEdge_endpoints_of_lt {p : TorusVertex width height}
+    (hlt : p.1.val + 1 < width) :
+    (torusRightEdge p).1.1 = p ∧ (torusRightEdge p).1.2 = (p.1 + 1, p.2) := by
+  have hadj : (torusGraph width height).Adj p (p.1 + 1, p.2) := torusGraph_adj_right p.1 p.2
+  have hcmp : p < ((p.1 + 1, p.2) : TorusVertex width height) := by
+    show toLex (p.1.val, p.2.val) < toLex ((p.1 + 1).val, p.2.val)
+    rw [Prod.Lex.toLex_lt_toLex]
+    exact Or.inl (by rw [ZMod.val_add_of_lt (by rw [ZMod.val_one]; omega), ZMod.val_one]; omega)
+  rw [torusRightEdge, Edge.ofAdj_of_lt hadj hcmp]
+  exact ⟨rfl, rfl⟩
+
+/-- Ordered endpoints of a torus up edge that avoids wraparound: the first endpoint is the lower
+vertical coordinate. -/
+theorem torusUpEdge_endpoints_of_lt {p : TorusVertex width height}
+    (hlt : p.2.val + 1 < height) :
+    (torusUpEdge p).1.1 = p ∧ (torusUpEdge p).1.2 = (p.1, p.2 + 1) := by
+  have hadj : (torusGraph width height).Adj p (p.1, p.2 + 1) := torusGraph_adj_up p.1 p.2
+  have hcmp : p < ((p.1, p.2 + 1) : TorusVertex width height) := by
+    show toLex (p.1.val, p.2.val) < toLex (p.1.val, (p.2 + 1).val)
+    rw [Prod.Lex.toLex_lt_toLex]
+    exact Or.inr ⟨rfl, by rw [ZMod.val_add_of_lt (by rw [ZMod.val_one]; omega), ZMod.val_one]; omega⟩
+  rw [torusUpEdge, Edge.ofAdj_of_lt hadj hcmp]
+  exact ⟨rfl, rfl⟩
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- Two torus vertices with equal coordinate values are equal. -/
+theorem torusVertex_eq_of_val_eq {v w : TorusVertex width height}
+    (h1 : v.1.val = w.1.val) (h2 : v.2.val = w.2.val) : v = w :=
+  Prod.ext (ZMod.val_injective width h1) (ZMod.val_injective height h2)
+
+/-- The four endpoint coordinate values of the distinguished horizontal edge, when the offset
+avoids wraparound. -/
+theorem horizontalReferenceEdge_val {xStart yStart : ℕ}
+    (hxw : xStart + 2 < width) (hyh : yStart + 2 < height) :
+    (torusHorizontalReferenceEdge (width := width) (height := height) xStart yStart).1.1.1.val =
+        xStart + 1 ∧
+      (torusHorizontalReferenceEdge (width := width) (height := height) xStart yStart).1.1.2.val =
+        yStart + 2 ∧
+      (torusHorizontalReferenceEdge (width := width) (height := height) xStart yStart).1.2.1.val =
+        xStart + 2 ∧
+      (torusHorizontalReferenceEdge (width := width) (height := height)
+        xStart yStart).1.2.2.val = yStart + 2 := by
+  have href := torusRightEdge_endpoints_of_lt (p := ((xStart + 1 : ℕ), (yStart + 2 : ℕ)))
+    (width := width) (height := height) (by rw [ZMod.val_cast_of_lt (by omega)]; omega)
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [torusHorizontalReferenceEdge, href.1]; exact ZMod.val_cast_of_lt (by omega)
+  · rw [torusHorizontalReferenceEdge, href.1]; exact ZMod.val_cast_of_lt (by omega)
+  · rw [torusHorizontalReferenceEdge, href.2]
+    show ((xStart + 1 : ℕ) + 1 : ZMod width).val = xStart + 2
+    rw [show ((xStart + 1 : ℕ) + 1 : ZMod width) = ((xStart + 2 : ℕ) : ZMod width) from by
+      push_cast; ring]
+    exact ZMod.val_cast_of_lt (by omega)
+  · rw [torusHorizontalReferenceEdge, href.2]; exact ZMod.val_cast_of_lt (by omega)
+
+/-! ### The single red-to-blue crossing of the horizontal edge blocking -/
+
+/-- **The red-to-blue crossings of the horizontal torus edge blocking are the single distinguished
+edge.**
+
+The red block (the removed vertical edge block) and the blue block (the removed horizontal edge
+block) meet only along the distinguished horizontal edge.  Hence an edge crosses between them iff it
+is that edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isCrossingEdge_torusHorizontalEdge
+    (A : Tensor (torusGraph width height) d) {xStart yStart : ℕ}
+    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (g : Edge (torusGraph width height)) :
+    IsCrossingEdge (G := torusGraph width height) A
+        (torusHorizontalEdgeRed xStart yStart) (torusHorizontalEdgeBlue xStart yStart) g ↔
+      g = torusHorizontalReferenceEdge xStart yStart := by
+  constructor
+  · rintro ⟨hRed, hBlue⟩
+    -- Both endpoints lie in the window: one in red, one in blue.
+    simp only [IsRegionBoundaryEdge, mem_torusHorizontalEdgeRed, mem_torusHorizontalEdgeBlue]
+      at hRed hBlue
+    -- Both endpoints lie in the bounding window of the hole, so their coordinate values are
+    -- below `xStart + 5 < width` and `yStart + 5 < height`, hence no cyclic step wraps.
+    have hwin : g.1.1.1.val < xStart + 5 ∧ g.1.2.1.val < xStart + 5 ∧
+        g.1.1.2.val < yStart + 5 ∧ g.1.2.2.val < yStart + 5 := by
+      rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+        rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+        (simp only [not_and, not_lt] at hrn hbn ⊢; omega)
+    obtain ⟨hw1, hw2, hw3, hw4⟩ := hwin
+    -- The ordered-endpoint convention `g.1.1 < g.1.2` in coordinate-value form.
+    have hlt : g.1.1.1.val < g.1.2.1.val ∨
+        (g.1.1.1.val = g.1.2.1.val ∧ g.1.1.2.val < g.1.2.2.val) := by
+      have hlex : (g.1.1 : TorusVertex width height) < g.1.2 := g.2.1
+      change toLex (g.1.1.1.val, g.1.1.2.val) < toLex (g.1.2.1.val, g.1.2.2.val) at hlex
+      rw [Prod.Lex.toLex_lt_toLex] at hlex
+      exact hlex
+    -- The adjacency of `g`, a horizontal or vertical cyclic step.
+    have hadj := g.2.2
+    rw [torusGraph_adj, torusHorizontalNeighbor, torusVerticalNeighbor] at hadj
+    -- Pin the four coordinate values of `g` to the distinguished edge's coordinates.
+    have hcoord : g.1.1.1.val = xStart + 1 ∧ g.1.1.2.val = yStart + 2 ∧
+        g.1.2.1.val = xStart + 2 ∧ g.1.2.2.val = yStart + 2 := by
+      rcases hadj with ⟨hrow, hcol⟩ | ⟨hcol, hrow⟩
+      · -- Horizontal step: same vertical coordinate, adjacent horizontal coordinates.
+        have hrow' := torus_eq_snd_val hrow
+        rcases hcol with hstep | hstep
+        · have hxstep := torus_horizontal_step_val hstep (by omega)
+          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+            (simp only [not_and, not_lt] at hrn hbn; omega)
+        · have hxstep := torus_horizontal_step_val hstep (by omega)
+          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+            (simp only [not_and, not_lt] at hrn hbn; omega)
+      · -- Vertical step: same horizontal coordinate, but red and blue columns are disjoint.
+        exfalso
+        have hcol' := torus_eq_fst_val hcol
+        rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+          rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+          (simp only [not_and, not_lt] at hrn hbn; omega)
+    obtain ⟨hc1, hc2, hc3, hc4⟩ := hcoord
+    -- The reference edge's endpoint coordinate values.
+    obtain ⟨hr11, hr12, hr21, hr22⟩ := horizontalReferenceEdge_val
+      (width := width) (height := height) (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega)
+    apply Subtype.ext
+    refine Prod.ext (torusVertex_eq_of_val_eq ?_ ?_) (torusVertex_eq_of_val_eq ?_ ?_)
+    · rw [hc1, hr11]
+    · rw [hc2, hr12]
+    · rw [hc3, hr21]
+    · rw [hc4, hr22]
+  · rintro rfl
+    obtain ⟨hr11, hr12, hr21, hr22⟩ := horizontalReferenceEdge_val
+      (width := width) (height := height) (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega)
+    refine ⟨Or.inl ⟨?_, ?_⟩, Or.inr ⟨?_, ?_⟩⟩
+    · rw [mem_torusHorizontalEdgeRed]; omega
+    · rw [mem_torusHorizontalEdgeRed]; omega
+    · rw [mem_torusHorizontalEdgeBlue]; omega
+    · rw [mem_torusHorizontalEdgeBlue]; omega
+
+/-- The four endpoint coordinate values of the distinguished vertical edge, when the offset avoids
+wraparound. -/
+theorem verticalReferenceEdge_val {xStart yStart : ℕ}
+    (hxw : xStart + 2 < width) (hyh : yStart + 2 < height) :
+    (torusVerticalReferenceEdge (width := width) (height := height) xStart yStart).1.1.1.val =
+        xStart + 2 ∧
+      (torusVerticalReferenceEdge (width := width) (height := height) xStart yStart).1.1.2.val =
+        yStart + 1 ∧
+      (torusVerticalReferenceEdge (width := width) (height := height) xStart yStart).1.2.1.val =
+        xStart + 2 ∧
+      (torusVerticalReferenceEdge (width := width) (height := height)
+        xStart yStart).1.2.2.val = yStart + 2 := by
+  have href := torusUpEdge_endpoints_of_lt (p := ((xStart + 2 : ℕ), (yStart + 1 : ℕ)))
+    (width := width) (height := height) (by rw [ZMod.val_cast_of_lt (by omega)]; omega)
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [torusVerticalReferenceEdge, href.1]; exact ZMod.val_cast_of_lt (by omega)
+  · rw [torusVerticalReferenceEdge, href.1]; exact ZMod.val_cast_of_lt (by omega)
+  · rw [torusVerticalReferenceEdge, href.2]; exact ZMod.val_cast_of_lt (by omega)
+  · rw [torusVerticalReferenceEdge, href.2]
+    show ((yStart + 1 : ℕ) + 1 : ZMod height).val = yStart + 2
+    rw [show ((yStart + 1 : ℕ) + 1 : ZMod height) = ((yStart + 2 : ℕ) : ZMod height) from by
+      push_cast; ring]
+    exact ZMod.val_cast_of_lt (by omega)
+
+/-! ### The single red-to-blue crossing of the vertical edge blocking -/
+
+/-- **The red-to-blue crossings of the vertical torus edge blocking are the single distinguished
+edge.**
+
+The rotated counterpart of `isCrossingEdge_torusHorizontalEdge`: the red block (the removed
+horizontal edge block) and the blue block (the removed vertical edge block) meet only along the
+distinguished vertical edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isCrossingEdge_torusVerticalEdge
+    (A : Tensor (torusGraph width height) d) {xStart yStart : ℕ}
+    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (g : Edge (torusGraph width height)) :
+    IsCrossingEdge (G := torusGraph width height) A
+        (torusVerticalEdgeRed xStart yStart) (torusVerticalEdgeBlue xStart yStart) g ↔
+      g = torusVerticalReferenceEdge xStart yStart := by
+  constructor
+  · rintro ⟨hRed, hBlue⟩
+    simp only [IsRegionBoundaryEdge, mem_torusVerticalEdgeRed, mem_torusVerticalEdgeBlue]
+      at hRed hBlue
+    have hwin : g.1.1.1.val < xStart + 5 ∧ g.1.2.1.val < xStart + 5 ∧
+        g.1.1.2.val < yStart + 5 ∧ g.1.2.2.val < yStart + 5 := by
+      rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+        rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+        (simp only [not_and, not_lt] at hrn hbn ⊢; omega)
+    obtain ⟨hw1, hw2, hw3, hw4⟩ := hwin
+    have hlt : g.1.1.1.val < g.1.2.1.val ∨
+        (g.1.1.1.val = g.1.2.1.val ∧ g.1.1.2.val < g.1.2.2.val) := by
+      have hlex : (g.1.1 : TorusVertex width height) < g.1.2 := g.2.1
+      change toLex (g.1.1.1.val, g.1.1.2.val) < toLex (g.1.2.1.val, g.1.2.2.val) at hlex
+      rw [Prod.Lex.toLex_lt_toLex] at hlex
+      exact hlex
+    have hadj := g.2.2
+    rw [torusGraph_adj, torusHorizontalNeighbor, torusVerticalNeighbor] at hadj
+    have hcoord : g.1.1.1.val = xStart + 2 ∧ g.1.1.2.val = yStart + 1 ∧
+        g.1.2.1.val = xStart + 2 ∧ g.1.2.2.val = yStart + 2 := by
+      rcases hadj with ⟨hrow, hcol⟩ | ⟨hcol, hrow⟩
+      · -- Horizontal step: same vertical coordinate, but red and blue rows are disjoint.
+        exfalso
+        have hrow' := torus_eq_snd_val hrow
+        rcases hcol with hstep | hstep
+        · have hxstep := torus_horizontal_step_val hstep (by omega)
+          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+            (simp only [not_and, not_lt] at hrn hbn; omega)
+        · have hxstep := torus_horizontal_step_val hstep (by omega)
+          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+            (simp only [not_and, not_lt] at hrn hbn; omega)
+      · -- Vertical step: same horizontal coordinate, adjacent vertical coordinates.
+        have hcol' := torus_eq_fst_val hcol
+        rcases hrow with hstep | hstep
+        · have hystep := torus_vertical_step_val hstep (by omega)
+          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+            (simp only [not_and, not_lt] at hrn hbn; omega)
+        · have hystep := torus_vertical_step_val hstep (by omega)
+          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+            (simp only [not_and, not_lt] at hrn hbn; omega)
+    obtain ⟨hc1, hc2, hc3, hc4⟩ := hcoord
+    obtain ⟨hr11, hr12, hr21, hr22⟩ := verticalReferenceEdge_val
+      (width := width) (height := height) (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega)
+    apply Subtype.ext
+    refine Prod.ext (torusVertex_eq_of_val_eq ?_ ?_) (torusVertex_eq_of_val_eq ?_ ?_)
+    · rw [hc1, hr11]
+    · rw [hc2, hr12]
+    · rw [hc3, hr21]
+    · rw [hc4, hr22]
+  · rintro rfl
+    obtain ⟨hr11, hr12, hr21, hr22⟩ := verticalReferenceEdge_val
+      (width := width) (height := height) (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega)
+    refine ⟨Or.inl ⟨?_, ?_⟩, Or.inr ⟨?_, ?_⟩⟩
+    · rw [mem_torusVerticalEdgeRed]; omega
+    · rw [mem_torusVerticalEdgeRed]; omega
+    · rw [mem_torusVerticalEdgeBlue]; omega
+    · rw [mem_torusVerticalEdgeBlue]; omega
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusEdgeBlockingRegion.lean
+++ b/TNLean/PEPS/TorusEdgeBlockingRegion.lean
@@ -1,0 +1,457 @@
+import TNLean.PEPS.TorusRectangleRegion
+
+/-!
+# The horizontal and vertical edge-blocking regions on the discrete torus
+
+The normal PEPS edge blocking around a horizontal edge partitions the torus into the removed
+vertical edge block (the red region, a contiguous $2\times3$ rectangle), the removed horizontal
+edge block (the blue region, a contiguous $3\times2$ rectangle), and the complement of these two
+removed blocks (the complementary region).  This file records those three regions on the torus,
+their membership characterizations, and the rectangular cover of the complementary region by four
+surrounding bands and two fillers.
+
+The blocking is anchored at the coordinate offset `(xStart, yStart)`: the red block sits at
+`(xStart, yStart + 2)` and the blue block at `(xStart + 2, yStart + 1)`, so the only
+nearest-neighbour pair with one endpoint in each is the edge from `(xStart + 1, yStart + 2)` to
+`(xStart + 2, yStart + 2)`.  The vertical analogue is the rotated picture, anchored so its single
+crossing is the edge from `(xStart + 2, yStart + 1)` to `(xStart + 2, yStart + 2)`.
+
+All regions stay clear of the wraparound seam: the surrounding bands are full coordinate ranges in
+one direction, which the value embedding covers without wraparound, and the removed blocks and
+fillers fit inside the coordinate window `[xStart - 1, xStart + 5) × [yStart - 1, yStart + 5)`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1500 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+
+/-! ### Horizontal edge-blocking regions -/
+
+/-- The red block (removed vertical edge block) of the horizontal torus edge blocking: the
+contiguous $2\times3$ rectangle at `(xStart, yStart + 2)`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusHorizontalEdgeRed (xStart yStart : ℕ) : Finset (TorusVertex width height) :=
+  torusContiguousRectangle xStart (yStart + 2) 2 3
+
+/-- The blue block (removed horizontal edge block) of the horizontal torus edge blocking: the
+contiguous $3\times2$ rectangle at `(xStart + 2, yStart + 1)`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusHorizontalEdgeBlue (xStart yStart : ℕ) : Finset (TorusVertex width height) :=
+  torusContiguousRectangle (xStart + 2) (yStart + 1) 3 2
+
+/-- The complementary block of the horizontal torus edge blocking: the complement of the two
+removed blocks.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusHorizontalEdgeComplement (xStart yStart : ℕ) : Finset (TorusVertex width height) :=
+  Finset.univ \ (torusHorizontalEdgeRed xStart yStart ∪ torusHorizontalEdgeBlue xStart yStart)
+
+@[simp] theorem mem_torusHorizontalEdgeRed (xStart yStart : ℕ) (v : TorusVertex width height) :
+    v ∈ torusHorizontalEdgeRed xStart yStart ↔
+      xStart ≤ v.1.val ∧ v.1.val < xStart + 2 ∧
+        yStart + 2 ≤ v.2.val ∧ v.2.val < yStart + 5 := by
+  simp only [torusHorizontalEdgeRed, mem_torusContiguousRectangle, show yStart + 2 + 3 = yStart + 5
+    from by omega]
+
+@[simp] theorem mem_torusHorizontalEdgeBlue (xStart yStart : ℕ) (v : TorusVertex width height) :
+    v ∈ torusHorizontalEdgeBlue xStart yStart ↔
+      xStart + 2 ≤ v.1.val ∧ v.1.val < xStart + 5 ∧
+        yStart + 1 ≤ v.2.val ∧ v.2.val < yStart + 3 := by
+  simp only [torusHorizontalEdgeBlue, mem_torusContiguousRectangle,
+    show xStart + 2 + 3 = xStart + 5 from by omega, show yStart + 1 + 2 = yStart + 3 from by omega]
+
+@[simp] theorem mem_torusHorizontalEdgeComplement (xStart yStart : ℕ)
+    (v : TorusVertex width height) :
+    v ∈ torusHorizontalEdgeComplement xStart yStart ↔
+      v ∉ torusHorizontalEdgeRed xStart yStart ∧ v ∉ torusHorizontalEdgeBlue xStart yStart := by
+  simp only [torusHorizontalEdgeComplement, Finset.mem_sdiff, Finset.mem_univ, true_and,
+    Finset.mem_union, not_or]
+
+/-! ### Partition by the three horizontal regions -/
+
+/-- The horizontal red and blue blocks are disjoint: the removed vertical and horizontal edge
+blocks meet only along the distinguished edge, so no vertex lies in both.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem torusHorizontalEdgeRed_disjoint_blue (xStart yStart : ℕ) :
+    Disjoint (torusHorizontalEdgeRed (width := width) (height := height) xStart yStart)
+      (torusHorizontalEdgeBlue xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hRed hBlue
+  rw [mem_torusHorizontalEdgeRed] at hRed
+  rw [mem_torusHorizontalEdgeBlue] at hBlue
+  omega
+
+/-- The horizontal red block is disjoint from the complement. -/
+theorem torusHorizontalEdgeRed_disjoint_complement (xStart yStart : ℕ) :
+    Disjoint (torusHorizontalEdgeRed (width := width) (height := height) xStart yStart)
+      (torusHorizontalEdgeComplement xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hRed hCompl
+  rw [mem_torusHorizontalEdgeComplement] at hCompl
+  exact hCompl.1 hRed
+
+/-- The horizontal blue block is disjoint from the complement. -/
+theorem torusHorizontalEdgeBlue_disjoint_complement (xStart yStart : ℕ) :
+    Disjoint (torusHorizontalEdgeBlue (width := width) (height := height) xStart yStart)
+      (torusHorizontalEdgeComplement xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hBlue hCompl
+  rw [mem_torusHorizontalEdgeComplement] at hCompl
+  exact hCompl.2 hBlue
+
+/-- The three horizontal regions cover the torus.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem torusHorizontalEdge_cover_univ (xStart yStart : ℕ) :
+    torusHorizontalEdgeRed (width := width) (height := height) xStart yStart ∪
+        torusHorizontalEdgeBlue xStart yStart ∪ torusHorizontalEdgeComplement xStart yStart =
+      Finset.univ := by
+  ext v
+  simp only [Finset.mem_union, mem_torusHorizontalEdgeComplement, Finset.mem_univ, iff_true]
+  by_cases hRed : v ∈ torusHorizontalEdgeRed xStart yStart
+  · exact Or.inl (Or.inl hRed)
+  · by_cases hBlue : v ∈ torusHorizontalEdgeBlue xStart yStart
+    · exact Or.inl (Or.inr hBlue)
+    · exact Or.inr ⟨hRed, hBlue⟩
+
+/-! ### The horizontal complementary cover -/
+
+/-- The six rectangular pieces covering the horizontal edge-complement block on the torus: four
+surrounding bands and two fillers.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusHorizontalEdgeComplementPiece (xStart yStart : ℕ) :
+    Fin 6 → Finset (TorusVertex width height)
+  | 0 => torusContiguousRectangle 0 0 width (yStart + 1)
+  | 1 => torusContiguousRectangle 0 (yStart + 5) width (height - (yStart + 5))
+  | 2 => torusContiguousRectangle 0 (yStart + 1) xStart 4
+  | 3 => torusContiguousRectangle (xStart + 5) (yStart + 1) (width - (xStart + 5)) 4
+  | 4 => torusContiguousRectangle xStart (yStart - 1) 2 3
+  | 5 => torusContiguousRectangle (xStart + 2) (yStart + 3) 3 2
+
+/-- The horizontal edge-complement block on the torus is the union of its six covering pieces, for
+an interior offset with one row and column of margin below and to the left and enough room above
+and to the right so the removed blocks are surrounded on every side.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem torusHorizontalEdgeComplement_eq_biUnion_pieces {xStart yStart : ℕ}
+    (hy0 : 1 ≤ yStart) (hxw : xStart + 5 ≤ width) (hyh : yStart + 5 ≤ height) :
+    torusHorizontalEdgeComplement (width := width) (height := height) xStart yStart =
+      (Finset.univ : Finset (Fin 6)).biUnion
+        (torusHorizontalEdgeComplementPiece xStart yStart) := by
+  ext v
+  have hvx : v.1.val < width := v.1.val_lt
+  have hvy : v.2.val < height := v.2.val_lt
+  simp only [mem_torusHorizontalEdgeComplement, mem_torusHorizontalEdgeRed,
+    mem_torusHorizontalEdgeBlue, Finset.mem_biUnion, Finset.mem_univ, true_and, not_and, not_lt]
+  constructor
+  · intro hv
+    obtain ⟨hRed, hBlue⟩ := hv
+    by_cases hb : v.2.val < yStart + 1
+    · exact ⟨0, by simp [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    by_cases ht : yStart + 5 ≤ v.2.val
+    · exact ⟨1, by simp [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    by_cases hl : v.1.val < xStart
+    · exact ⟨2, by simp [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    by_cases hr : xStart + 5 ≤ v.1.val
+    · exact ⟨3, by simp [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    -- inside the bounding box of the hole; the two fillers cover the non-hole cells
+    by_cases hf1 : v.1.val < xStart + 2
+    · exact ⟨4, by simp [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    · exact ⟨5, by simp [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+  · rintro ⟨i, hi⟩
+    fin_cases i <;>
+      · simp only [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle] at hi
+        refine ⟨fun _ _ _ => by omega, fun _ _ _ => by omega⟩
+
+namespace NormalTorusRectangleInjectivityHypotheses
+
+variable {κ : RegionInjectivityData (TorusVertex width height)}
+
+/-- The horizontal red block (removed vertical edge block) is injective under the torus
+rectangular injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1405--1444 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem horizontalEdgeRed_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 2 ≤ width) (hy : yStart + 5 ≤ height) :
+    κ.IsInjective (torusHorizontalEdgeRed (width := width) (height := height) xStart yStart) :=
+  h.rect23_injective hx (by omega)
+
+/-- The horizontal blue block (removed horizontal edge block) is injective under the torus
+rectangular injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1405--1444 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem horizontalEdgeBlue_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 5 ≤ width) (hy : yStart + 3 ≤ height) :
+    κ.IsInjective (torusHorizontalEdgeBlue (width := width) (height := height) xStart yStart) :=
+  h.rect32_injective (by omega) (by omega)
+
+/-- **The horizontal edge-complement block on the torus is injective.**
+
+When the removed L-shape sits in the interior of a large enough torus — at least one row and column
+of margin below and to the left, and enough room above and to the right — the complementary block
+is the union of four surrounding bands and two filler rectangles, each a contiguous torus rectangle.
+Rectangular injectivity together with the union-of-injective-regions lemma proves it injective.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem horizontalEdgeComplement_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart : ℕ} (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
+    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    κ.IsInjective
+      (torusHorizontalEdgeComplement (width := width) (height := height) xStart yStart) := by
+  rw [torusHorizontalEdgeComplement_eq_biUnion_pieces (by omega) (by omega) (by omega)]
+  refine hUnion.biUnion_injective ⟨0, Finset.mem_univ _⟩ _ ?_
+  intro i _
+  fin_cases i
+  · -- bottom band: width × (yStart + 1), short rectangle (width ≥ 3, yStart + 1 ≥ 2)
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- top band: width × (height - (yStart + 5)), short rectangle
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- left band: xStart × 4, wide rectangle (xStart ≥ 2, 4 ≥ 3)
+    exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- right band: (width - (xStart + 5)) × 4, wide rectangle
+    exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- first filler: 2 × 3
+    exact h.rect23_injective (by omega) (by omega)
+  · -- second filler: 3 × 2
+    exact h.rect32_injective (by omega) (by omega)
+
+end NormalTorusRectangleInjectivityHypotheses
+
+/-! ### Vertical edge-blocking regions
+
+The rotated picture: the red block (removed horizontal edge block) is the contiguous $3\times2$
+rectangle at `(xStart + 2, yStart)`, the blue block (removed vertical edge block) is the contiguous
+$2\times3$ rectangle at `(xStart + 1, yStart + 2)`, and the only nearest-neighbour pair with one
+endpoint in each is the edge from `(xStart + 2, yStart + 1)` to `(xStart + 2, yStart + 2)`. -/
+
+/-- The red block (removed horizontal edge block) of the vertical torus edge blocking: the
+contiguous $3\times2$ rectangle at `(xStart + 2, yStart)`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusVerticalEdgeRed (xStart yStart : ℕ) : Finset (TorusVertex width height) :=
+  torusContiguousRectangle (xStart + 2) yStart 3 2
+
+/-- The blue block (removed vertical edge block) of the vertical torus edge blocking: the
+contiguous $2\times3$ rectangle at `(xStart + 1, yStart + 2)`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusVerticalEdgeBlue (xStart yStart : ℕ) : Finset (TorusVertex width height) :=
+  torusContiguousRectangle (xStart + 1) (yStart + 2) 2 3
+
+/-- The complementary block of the vertical torus edge blocking: the complement of the two removed
+blocks.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusVerticalEdgeComplement (xStart yStart : ℕ) : Finset (TorusVertex width height) :=
+  Finset.univ \ (torusVerticalEdgeRed xStart yStart ∪ torusVerticalEdgeBlue xStart yStart)
+
+@[simp] theorem mem_torusVerticalEdgeRed (xStart yStart : ℕ) (v : TorusVertex width height) :
+    v ∈ torusVerticalEdgeRed xStart yStart ↔
+      xStart + 2 ≤ v.1.val ∧ v.1.val < xStart + 5 ∧
+        yStart ≤ v.2.val ∧ v.2.val < yStart + 2 := by
+  simp only [torusVerticalEdgeRed, mem_torusContiguousRectangle,
+    show xStart + 2 + 3 = xStart + 5 from by omega]
+
+@[simp] theorem mem_torusVerticalEdgeBlue (xStart yStart : ℕ) (v : TorusVertex width height) :
+    v ∈ torusVerticalEdgeBlue xStart yStart ↔
+      xStart + 1 ≤ v.1.val ∧ v.1.val < xStart + 3 ∧
+        yStart + 2 ≤ v.2.val ∧ v.2.val < yStart + 5 := by
+  simp only [torusVerticalEdgeBlue, mem_torusContiguousRectangle,
+    show xStart + 1 + 2 = xStart + 3 from by omega, show yStart + 2 + 3 = yStart + 5 from by omega]
+
+@[simp] theorem mem_torusVerticalEdgeComplement (xStart yStart : ℕ)
+    (v : TorusVertex width height) :
+    v ∈ torusVerticalEdgeComplement xStart yStart ↔
+      v ∉ torusVerticalEdgeRed xStart yStart ∧ v ∉ torusVerticalEdgeBlue xStart yStart := by
+  simp only [torusVerticalEdgeComplement, Finset.mem_sdiff, Finset.mem_univ, true_and,
+    Finset.mem_union, not_or]
+
+/-! ### Partition by the three vertical regions -/
+
+/-- The vertical red and blue blocks are disjoint.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1443 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem torusVerticalEdgeRed_disjoint_blue (xStart yStart : ℕ) :
+    Disjoint (torusVerticalEdgeRed (width := width) (height := height) xStart yStart)
+      (torusVerticalEdgeBlue xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hRed hBlue
+  rw [mem_torusVerticalEdgeRed] at hRed
+  rw [mem_torusVerticalEdgeBlue] at hBlue
+  omega
+
+/-- The vertical red block is disjoint from the complement. -/
+theorem torusVerticalEdgeRed_disjoint_complement (xStart yStart : ℕ) :
+    Disjoint (torusVerticalEdgeRed (width := width) (height := height) xStart yStart)
+      (torusVerticalEdgeComplement xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hRed hCompl
+  rw [mem_torusVerticalEdgeComplement] at hCompl
+  exact hCompl.1 hRed
+
+/-- The vertical blue block is disjoint from the complement. -/
+theorem torusVerticalEdgeBlue_disjoint_complement (xStart yStart : ℕ) :
+    Disjoint (torusVerticalEdgeBlue (width := width) (height := height) xStart yStart)
+      (torusVerticalEdgeComplement xStart yStart) := by
+  rw [Finset.disjoint_left]
+  intro v hBlue hCompl
+  rw [mem_torusVerticalEdgeComplement] at hCompl
+  exact hCompl.2 hBlue
+
+/-- The three vertical regions cover the torus.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1499 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem torusVerticalEdge_cover_univ (xStart yStart : ℕ) :
+    torusVerticalEdgeRed (width := width) (height := height) xStart yStart ∪
+        torusVerticalEdgeBlue xStart yStart ∪ torusVerticalEdgeComplement xStart yStart =
+      Finset.univ := by
+  ext v
+  simp only [Finset.mem_union, mem_torusVerticalEdgeComplement, Finset.mem_univ, iff_true]
+  by_cases hRed : v ∈ torusVerticalEdgeRed xStart yStart
+  · exact Or.inl (Or.inl hRed)
+  · by_cases hBlue : v ∈ torusVerticalEdgeBlue xStart yStart
+    · exact Or.inl (Or.inr hBlue)
+    · exact Or.inr ⟨hRed, hBlue⟩
+
+/-! ### The vertical complementary cover -/
+
+/-- The six rectangular pieces covering the vertical edge-complement block on the torus: four
+surrounding bands and two filler $2\times3$ rectangles.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusVerticalEdgeComplementPiece (xStart yStart : ℕ) :
+    Fin 6 → Finset (TorusVertex width height)
+  | 0 => torusContiguousRectangle 0 0 width yStart
+  | 1 => torusContiguousRectangle 0 (yStart + 5) width (height - (yStart + 5))
+  | 2 => torusContiguousRectangle 0 0 (xStart + 1) height
+  | 3 => torusContiguousRectangle (xStart + 5) 0 (width - (xStart + 5)) height
+  | 4 => torusContiguousRectangle xStart (yStart - 1) 2 3
+  | 5 => torusContiguousRectangle (xStart + 3) (yStart + 2) 2 3
+
+/-- The vertical edge-complement block on the torus is the union of its six covering pieces.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem torusVerticalEdgeComplement_eq_biUnion_pieces {xStart yStart : ℕ}
+    (hy0 : 1 ≤ yStart) (hxw : xStart + 5 ≤ width) (hyh : yStart + 5 ≤ height) :
+    torusVerticalEdgeComplement (width := width) (height := height) xStart yStart =
+      (Finset.univ : Finset (Fin 6)).biUnion
+        (torusVerticalEdgeComplementPiece xStart yStart) := by
+  ext v
+  have hvx : v.1.val < width := v.1.val_lt
+  have hvy : v.2.val < height := v.2.val_lt
+  simp only [mem_torusVerticalEdgeComplement, mem_torusVerticalEdgeRed,
+    mem_torusVerticalEdgeBlue, Finset.mem_biUnion, Finset.mem_univ, true_and, not_and, not_lt]
+  constructor
+  · intro hv
+    obtain ⟨hRed, hBlue⟩ := hv
+    by_cases hb : v.2.val < yStart
+    · exact ⟨0, by simp [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    by_cases ht : yStart + 5 ≤ v.2.val
+    · exact ⟨1, by simp [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    by_cases hl : v.1.val < xStart + 1
+    · exact ⟨2, by simp [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    by_cases hr : xStart + 5 ≤ v.1.val
+    · exact ⟨3, by simp [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    -- inside the bounding box of the rotated hole; the two fillers cover the non-hole cells
+    by_cases hf1 : v.2.val < yStart + 2
+    · exact ⟨4, by simp [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+    · exact ⟨5, by simp [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle]; omega⟩
+  · rintro ⟨i, hi⟩
+    fin_cases i <;>
+      · simp only [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle] at hi
+        refine ⟨fun _ _ _ => by omega, fun _ _ _ => by omega⟩
+
+namespace NormalTorusRectangleInjectivityHypotheses
+
+variable {κ : RegionInjectivityData (TorusVertex width height)}
+
+/-- The vertical red block (removed horizontal edge block) is injective under the torus rectangular
+injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1405--1444 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem verticalEdgeRed_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 5 ≤ width) (hy : yStart + 2 ≤ height) :
+    κ.IsInjective (torusVerticalEdgeRed (width := width) (height := height) xStart yStart) :=
+  h.rect32_injective (by omega) hy
+
+/-- The vertical blue block (removed vertical edge block) is injective under the torus rectangular
+injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1405--1444 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem verticalEdgeBlue_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 3 ≤ width) (hy : yStart + 5 ≤ height) :
+    κ.IsInjective (torusVerticalEdgeBlue (width := width) (height := height) xStart yStart) :=
+  h.rect23_injective (by omega) (by omega)
+
+/-- **The vertical edge-complement block on the torus is injective.**
+
+The rotated counterpart of `horizontalEdgeComplement_injective`: when the rotated removed L-shape
+sits in the interior of a large enough torus, the complementary block is the union of four
+surrounding bands and two filler rectangles, each a contiguous torus rectangle.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem verticalEdgeComplement_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart : ℕ} (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    κ.IsInjective
+      (torusVerticalEdgeComplement (width := width) (height := height) xStart yStart) := by
+  rw [torusVerticalEdgeComplement_eq_biUnion_pieces (by omega) (by omega) (by omega)]
+  refine hUnion.biUnion_injective ⟨2, Finset.mem_univ _⟩ _ ?_
+  intro i _
+  fin_cases i
+  · -- bottom band: width × yStart, short rectangle (width ≥ 3, yStart ≥ 2)
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- top band: width × (height - (yStart + 5)), short rectangle
+    exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- left band: (xStart + 1) × height, wide rectangle (xStart + 1 ≥ 2, height ≥ 3)
+    exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- right band: (width - (xStart + 5)) × height, wide rectangle
+    exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+  · -- first filler: 2 × 3
+    exact h.rect23_injective (by omega) (by omega)
+  · -- second filler: 2 × 3
+    exact h.rect23_injective (by omega) (by omega)
+
+end NormalTorusRectangleInjectivityHypotheses
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusRectangleGauge.lean
+++ b/TNLean/PEPS/TorusRectangleGauge.lean
@@ -1,0 +1,98 @@
+import TNLean.PEPS.TorusRectangleReferenceData
+import TNLean.PEPS.TorusEdgeGauge
+import TNLean.PEPS.NormalEdgeGaugeFamily
+
+/-!
+# The per-edge gauge at the torus reference edges from rectangle injectivity
+
+Two normal PEPS on the discrete torus, related by `SameState` with matched bond dimensions and both
+satisfying the rectangular-injectivity hypotheses with union closure, carry on the distinguished
+horizontal and vertical reference edges the per-edge gauge of the edge blocking: the bond
+dimensions coincide and the forward region-insertion transfer is conjugation by an invertible
+matrix, together with the region-insertion coefficient identity the conjugation realizes.
+
+This is `exists_regionEdgeGauge_torus_coeff` fed the faithful rectangle-injectivity reference datum
+of `TNLean/PEPS/TorusRectangleReferenceData.lean`, in place of the vertex-injective singleton
+datum.  The injectivity inputs are the rectangular-injectivity hypotheses for both tensors plus
+union closure for the second tensor's host block; no single-vertex injectivity is used.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- **The per-edge gauge at the torus horizontal reference edge from rectangle injectivity.**
+
+For two torus tensors `A`, `B` with the same state, matched bond dimensions, positive bonds, and
+both satisfying the rectangular-injectivity hypotheses with union closure, the distinguished
+horizontal reference edge carries the per-edge gauge: the bond dimensions coincide and the forward
+region-insertion transfer is conjugation by an invertible gauge matrix, realizing the
+region-insertion coefficient identity.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_horizontalReferenceEdgeGauge_coeff
+    {A B : Tensor (torusGraph width height) d} {xStart yStart : ℕ}
+    (hA : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hB : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
+    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
+    let e := torusHorizontalReferenceEdge xStart yStart
+    let DA := torusHorizontalRectangleBlockingDatum hA hUA hx0 hy0 hxw' hyh'
+    ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ),
+        ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+          (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) DA.red)
+          (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (Finset.univ \ DA.red)),
+          regionInsertedCoeff (G := torusGraph width height) A DA.red
+              (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e
+                (fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hA hUA hx0 hy0
+                  hxw hyh hxw' hyh' g)) M σ τ =
+            regionInsertedCoeff (G := torusGraph width height) B DA.red
+              (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e
+                (fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hA hUA hx0 hy0
+                  hxw hyh hxw' hyh' g))
+              ((Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+                  Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+                  ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+                    Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ))
+              σ τ := by
+  intro e DA
+  -- The datum for `B` over the same regions.
+  let DB := torusHorizontalRectangleBlockingDatum hB hUB hx0 hy0 hxw' hyh'
+  -- The two data share the three regions, since the regions are tensor independent.
+  have hsingle := fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hA hUA hx0 hy0
+    hxw hyh hxw' hyh' g
+  -- `B`'s red and host blocks are blocked-tensor injective.
+  have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B DA.red := by
+    have hi := hB.horizontalEdgeRed_injective (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ DA.red) :=
+    regionBlockedTensorInjective_host DB hUB
+  exact exists_regionEdgeGauge_torus_coeff DA DB rfl rfl rfl hbond hAB hd hposA hposB hsingle
+    hRB hCB
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusRectangleReferenceData.lean
+++ b/TNLean/PEPS/TorusRectangleReferenceData.lean
@@ -1,0 +1,200 @@
+import TNLean.PEPS.TorusEdgeBlockingCrossing
+import TNLean.PEPS.NormalEdgeBlockingData
+
+/-!
+# The faithful torus reference blocking datum from rectangle injectivity
+
+For a torus tensor whose contiguous $2\times3$ and $3\times2$ blocks are injective (the source's own
+blocking hypotheses) and whose region injectivity is union closed, the distinguished horizontal and
+vertical reference edges carry a one-edge blocking datum: the red block is the removed source
+rectangle, the blue block is the other removed source rectangle, and the complementary block is the
+union of four surrounding bands and two fillers.  All three are injective by rectangular injectivity
+and the union-of-injective-regions lemma, they partition the torus, and their single red-to-blue
+crossing is the reference edge.
+
+This is the source-faithful reference blocking datum the translation-invariant gauge family
+consumes.  Unlike the vertex-injective singleton datum of
+`TNLean/PEPS/TorusReferenceBlockingData.lean`, the injectivity inputs are exactly the source's
+rectangular-injectivity hypotheses, with no single-vertex injectivity.  The reference edge sits in
+the interior of the torus with enough margin that the regions avoid the wraparound seam.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1500 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-! ### The faithful horizontal reference blocking datum -/
+
+/-- **Faithful horizontal reference blocking datum on the torus.**
+
+For a torus tensor `A` whose region-injectivity predicate satisfies the rectangular-injectivity
+hypotheses and union closure, the distinguished horizontal reference edge carries the one-edge
+blocking datum whose red block is the removed vertical edge block, blue block the removed horizontal
+edge block, and complementary block the rest of the torus.  All three are injective by rectangular
+injectivity and the union-of-injective-regions lemma; they partition the torus; the edge's left
+endpoint lies in red and its right endpoint in blue.
+
+The offset `(xStart, yStart)` must place the regions clear of the wraparound seam: at least two
+columns and one row of margin below and to the left, and enough room above and to the right.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusHorizontalRectangleBlockingDatum
+    {κ : RegionInjectivityData (TorusVertex width height)} {xStart yStart : ℕ}
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
+    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    NormalEdgeBlockingData κ (torusGraph width height)
+      (torusHorizontalReferenceEdge xStart yStart) where
+  red := torusHorizontalEdgeRed xStart yStart
+  blue := torusHorizontalEdgeBlue xStart yStart
+  complement := torusHorizontalEdgeComplement xStart yStart
+  left_mem_red := by
+    obtain ⟨hr11, hr12, _, _⟩ :=
+      horizontalReferenceEdge_val (width := width) (height := height)
+        (xStart := xStart) (yStart := yStart) (by omega) (by omega)
+    rw [mem_torusHorizontalEdgeRed]; omega
+  right_mem_blue := by
+    obtain ⟨_, _, hr21, hr22⟩ :=
+      horizontalReferenceEdge_val (width := width) (height := height)
+        (xStart := xStart) (yStart := yStart) (by omega) (by omega)
+    rw [mem_torusHorizontalEdgeBlue]; omega
+  red_injective := h.horizontalEdgeRed_injective (by omega) (by omega)
+  blue_injective := h.horizontalEdgeBlue_injective (by omega) (by omega)
+  complement_injective := h.horizontalEdgeComplement_injective hUnion hx0 hy0 hxw hyh
+  red_disjoint_blue := torusHorizontalEdgeRed_disjoint_blue xStart yStart
+  red_disjoint_complement := torusHorizontalEdgeRed_disjoint_complement xStart yStart
+  blue_disjoint_complement := torusHorizontalEdgeBlue_disjoint_complement xStart yStart
+  cover_univ := torusHorizontalEdge_cover_univ xStart yStart
+
+@[simp] theorem torusHorizontalRectangleBlockingDatum_red
+    {κ : RegionInjectivityData (TorusVertex width height)} {xStart yStart : ℕ}
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
+    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).red =
+      torusHorizontalEdgeRed xStart yStart := rfl
+
+@[simp] theorem torusHorizontalRectangleBlockingDatum_blue
+    {κ : RegionInjectivityData (TorusVertex width height)} {xStart yStart : ℕ}
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
+    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).blue =
+      torusHorizontalEdgeBlue xStart yStart := rfl
+
+/-- The red-to-blue crossings of the faithful horizontal reference datum are exactly the
+distinguished horizontal reference edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isCrossingEdge_torusHorizontalRectangleBlockingDatum
+    (A : Tensor (torusGraph width height) d)
+    {xStart yStart : ℕ}
+    (h : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUnion : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
+    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (g : Edge (torusGraph width height)) :
+    IsCrossingEdge (G := torusGraph width height) A
+        (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw' hyh').red
+        (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw' hyh').blue g ↔
+      g = torusHorizontalReferenceEdge xStart yStart := by
+  rw [torusHorizontalRectangleBlockingDatum_red, torusHorizontalRectangleBlockingDatum_blue]
+  exact isCrossingEdge_torusHorizontalEdge A hxw hyh g
+
+/-! ### The faithful vertical reference blocking datum -/
+
+/-- **Faithful vertical reference blocking datum on the torus.**
+
+The vertical counterpart of `torusHorizontalRectangleBlockingDatum` at the distinguished vertical
+reference edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusVerticalRectangleBlockingDatum
+    {κ : RegionInjectivityData (TorusVertex width height)} {xStart yStart : ℕ}
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    NormalEdgeBlockingData κ (torusGraph width height)
+      (torusVerticalReferenceEdge xStart yStart) where
+  red := torusVerticalEdgeRed xStart yStart
+  blue := torusVerticalEdgeBlue xStart yStart
+  complement := torusVerticalEdgeComplement xStart yStart
+  left_mem_red := by
+    obtain ⟨hr11, hr12, _, _⟩ :=
+      verticalReferenceEdge_val (width := width) (height := height)
+        (xStart := xStart) (yStart := yStart) (by omega) (by omega)
+    rw [mem_torusVerticalEdgeRed]; omega
+  right_mem_blue := by
+    obtain ⟨_, _, hr21, hr22⟩ :=
+      verticalReferenceEdge_val (width := width) (height := height)
+        (xStart := xStart) (yStart := yStart) (by omega) (by omega)
+    rw [mem_torusVerticalEdgeBlue]; omega
+  red_injective := h.verticalEdgeRed_injective (by omega) (by omega)
+  blue_injective := h.verticalEdgeBlue_injective (by omega) (by omega)
+  complement_injective := h.verticalEdgeComplement_injective hUnion hx0 hy0 hxw hyh
+  red_disjoint_blue := torusVerticalEdgeRed_disjoint_blue xStart yStart
+  red_disjoint_complement := torusVerticalEdgeRed_disjoint_complement xStart yStart
+  blue_disjoint_complement := torusVerticalEdgeBlue_disjoint_complement xStart yStart
+  cover_univ := torusVerticalEdge_cover_univ xStart yStart
+
+@[simp] theorem torusVerticalRectangleBlockingDatum_red
+    {κ : RegionInjectivityData (TorusVertex width height)} {xStart yStart : ℕ}
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).red =
+      torusVerticalEdgeRed xStart yStart := rfl
+
+@[simp] theorem torusVerticalRectangleBlockingDatum_blue
+    {κ : RegionInjectivityData (TorusVertex width height)} {xStart yStart : ℕ}
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).blue =
+      torusVerticalEdgeBlue xStart yStart := rfl
+
+/-- The red-to-blue crossings of the faithful vertical reference datum are exactly the
+distinguished vertical reference edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isCrossingEdge_torusVerticalRectangleBlockingDatum
+    (A : Tensor (torusGraph width height) d)
+    {xStart yStart : ℕ}
+    (h : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUnion : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (g : Edge (torusGraph width height)) :
+    IsCrossingEdge (G := torusGraph width height) A
+        (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw' hyh').red
+        (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw' hyh').blue g ↔
+      g = torusVerticalReferenceEdge xStart yStart := by
+  rw [torusVerticalRectangleBlockingDatum_red, torusVerticalRectangleBlockingDatum_blue]
+  exact isCrossingEdge_torusVerticalEdge A hxw hyh g
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusRectangleRegion.lean
+++ b/TNLean/PEPS/TorusRectangleRegion.lean
@@ -1,0 +1,241 @@
+import TNLean.PEPS.InjectiveRegion
+import TNLean.PEPS.TorusLatticeGraph
+
+/-!
+# Contiguous coordinate rectangles on the discrete torus
+
+The translationally invariant normal PEPS theorem (arXiv:1804.04964, Section 3, proof of
+Theorem 3) assumes that every contiguous $2\times3$ and $3\times2$ block of the lattice is
+injective.  On the discrete torus the contiguous block at coordinate origin `(xStart, yStart)`
+with side lengths `(xLen, yLen)` is the set of vertices whose coordinate values lie in the
+half-open coordinate intervals `[xStart, xStart + xLen)` and `[yStart, yStart + yLen)`, read
+through the value embedding `ZMod.val`.  When the offsets and lengths avoid wraparound
+(`xStart + xLen ≤ width`, `yStart + yLen ≤ height`), this is exactly the contiguous block; the
+full-coordinate band (length `width` or `height`) is the whole coordinate range, which the value
+embedding covers without wraparound.
+
+These torus rectangles are the wraparound-avoiding analogue of the open-lattice contiguous
+rectangles of `TNLean/PEPS/NormalBlocking.lean`, and the rectangular-injectivity hypotheses and
+sliding-window tiling lemmas below are the torus ports of
+`TNLean/PEPS/NormalRectangleTiling.lean`.  The reference edge of the normal PEPS construction sits
+at the coordinate origin, so the construction's regions span only a few cells and stay clear of the
+wraparound seam.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+
+/-! ### The torus contiguous rectangle -/
+
+/-- A contiguous coordinate rectangle on the discrete torus: the vertices whose coordinate values
+lie in the half-open coordinate intervals `[xStart, xStart + xLen)` and `[yStart, yStart + yLen)`.
+
+When the offsets and lengths avoid wraparound (`xStart + xLen ≤ width`, `yStart + yLen ≤ height`)
+this is the contiguous block at `(xStart, yStart)`; a full-coordinate band (length `width` or
+`height`) is the whole coordinate range, which the value embedding covers without wraparound.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def torusContiguousRectangle (xStart yStart xLen yLen : ℕ) :
+    Finset (TorusVertex width height) :=
+  Finset.univ.filter fun v =>
+    xStart ≤ v.1.val ∧ v.1.val < xStart + xLen ∧
+      yStart ≤ v.2.val ∧ v.2.val < yStart + yLen
+
+@[simp] theorem mem_torusContiguousRectangle (xStart yStart xLen yLen : ℕ)
+    (v : TorusVertex width height) :
+    v ∈ torusContiguousRectangle xStart yStart xLen yLen ↔
+      xStart ≤ v.1.val ∧ v.1.val < xStart + xLen ∧
+        yStart ≤ v.2.val ∧ v.2.val < yStart + yLen := by
+  simp [torusContiguousRectangle]
+
+/-! ### Contiguous-rectangle shape predicates -/
+
+/-- Contiguous torus rectangles of width two and height three.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the theorem assumes injectivity for contiguous
+$2\times3$ rectangular blocks. -/
+def IsTwoByThreeContiguousTorusRectangle
+    (R : Finset (TorusVertex width height)) : Prop :=
+  ∃ xStart yStart : ℕ,
+    xStart + 2 ≤ width ∧ yStart + 3 ≤ height ∧
+      R = torusContiguousRectangle xStart yStart 2 3
+
+/-- Contiguous torus rectangles of width three and height two.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`, where the theorem assumes injectivity for contiguous
+$3\times2$ rectangular blocks. -/
+def IsThreeByTwoContiguousTorusRectangle
+    (R : Finset (TorusVertex width height)) : Prop :=
+  ∃ xStart yStart : ℕ,
+    xStart + 3 ≤ width ∧ yStart + 2 ≤ height ∧
+      R = torusContiguousRectangle xStart yStart 3 2
+
+/-- A bounded contiguous torus rectangle of width two and height three has the $2\times3$ source
+shape.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTwoByThreeContiguousTorusRectangle_of_bounds
+    {xStart yStart : ℕ} (hx : xStart + 2 ≤ width) (hy : yStart + 3 ≤ height) :
+    IsTwoByThreeContiguousTorusRectangle
+      (torusContiguousRectangle xStart yStart 2 3 : Finset (TorusVertex width height)) :=
+  ⟨xStart, yStart, hx, hy, rfl⟩
+
+/-- A bounded contiguous torus rectangle of width three and height two has the $3\times2$ source
+shape.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isThreeByTwoContiguousTorusRectangle_of_bounds
+    {xStart yStart : ℕ} (hx : xStart + 3 ≤ width) (hy : yStart + 2 ≤ height) :
+    IsThreeByTwoContiguousTorusRectangle
+      (torusContiguousRectangle xStart yStart 3 2 : Finset (TorusVertex width height)) :=
+  ⟨xStart, yStart, hx, hy, rfl⟩
+
+/-! ### The torus rectangular-injectivity hypotheses -/
+
+/-- The coordinate rectangular-injectivity hypotheses on the discrete torus: every contiguous
+$2\times3$ and $3\times2$ block is injective.  This is the torus specialization of the abstract
+region-injectivity hypotheses to the vertex set `TorusVertex width height`, matching the
+open-lattice `NormalSquareLatticeRectangleInjectivityHypotheses`.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3 and proof, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. -/
+structure NormalTorusRectangleInjectivityHypotheses
+    (κ : RegionInjectivityData (TorusVertex width height)) where
+  /-- Every contiguous $2\times3$ coordinate rectangle is injective. -/
+  twoByThree_injective :
+    ∀ R : Finset (TorusVertex width height),
+      IsTwoByThreeContiguousTorusRectangle R → κ.IsInjective R
+  /-- Every contiguous $3\times2$ coordinate rectangle is injective. -/
+  threeByTwo_injective :
+    ∀ R : Finset (TorusVertex width height),
+      IsThreeByTwoContiguousTorusRectangle R → κ.IsInjective R
+
+namespace NormalTorusRectangleInjectivityHypotheses
+
+variable {κ : RegionInjectivityData (TorusVertex width height)}
+
+/-- A bounded contiguous $2\times3$ coordinate rectangle is injective under the torus rectangular
+injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3 and proof, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem rect23_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 2 ≤ width) (hy : yStart + 3 ≤ height) :
+    κ.IsInjective
+      (torusContiguousRectangle xStart yStart 2 3 : Finset (TorusVertex width height)) :=
+  h.twoByThree_injective _ (isTwoByThreeContiguousTorusRectangle_of_bounds hx hy)
+
+/-- A bounded contiguous $3\times2$ coordinate rectangle is injective under the torus rectangular
+injectivity hypotheses.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3 and proof, lines 1407--1452 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem rect32_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    {xStart yStart : ℕ} (hx : xStart + 3 ≤ width) (hy : yStart + 2 ≤ height) :
+    κ.IsInjective
+      (torusContiguousRectangle xStart yStart 3 2 : Finset (TorusVertex width height)) :=
+  h.threeByTwo_injective _ (isThreeByTwoContiguousTorusRectangle_of_bounds hx hy)
+
+/-! ### Sliding-window tiling injectivity -/
+
+/-- A wide-or-tall contiguous torus rectangle is the union of contiguous source $2\times3$
+rectangles sliding over it.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1322--1430 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem contiguousRectangle_eq_biUnion_two_by_three
+    (xStart yStart xLen yLen : ℕ) (hx : 2 ≤ xLen) (hy : 3 ≤ yLen) :
+    (torusContiguousRectangle xStart yStart xLen yLen : Finset (TorusVertex width height)) =
+      (Finset.range (xLen - 1) ×ˢ Finset.range (yLen - 2)).biUnion
+        (fun p => torusContiguousRectangle (xStart + p.1) (yStart + p.2) 2 3) := by
+  ext v
+  simp only [mem_torusContiguousRectangle, Finset.mem_biUnion, Finset.mem_product,
+    Finset.mem_range]
+  constructor
+  · rintro ⟨hx0, hx1, hy0, hy1⟩
+    refine ⟨(min (v.1.val - xStart) (xLen - 2), min (v.2.val - yStart) (yLen - 3)), ⟨?_, ?_⟩, ?_⟩
+    · omega
+    · omega
+    · omega
+  · rintro ⟨⟨a, b⟩, ⟨_, _⟩, hv⟩
+    omega
+
+/-- A wide-or-tall contiguous torus rectangle is injective.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1452 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem wideRectangle_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart xLen yLen : ℕ}
+    (hx : 2 ≤ xLen) (hy : 3 ≤ yLen)
+    (hxw : xStart + xLen ≤ width) (hyh : yStart + yLen ≤ height) :
+    κ.IsInjective
+      (torusContiguousRectangle xStart yStart xLen yLen : Finset (TorusVertex width height)) := by
+  rw [contiguousRectangle_eq_biUnion_two_by_three xStart yStart xLen yLen hx hy]
+  refine hUnion.biUnion_injective ?_ _ ?_
+  · exact ⟨(0, 0), by simp [Finset.mem_product, Finset.mem_range]; omega⟩
+  · rintro ⟨a, b⟩ hab
+    simp only [Finset.mem_product, Finset.mem_range] at hab
+    exact h.rect23_injective (by omega) (by omega)
+
+/-- A wide-and-short contiguous torus rectangle is the union of contiguous source $3\times2$
+rectangles sliding over it.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1322--1430 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem contiguousRectangle_eq_biUnion_three_by_two
+    (xStart yStart xLen yLen : ℕ) (hx : 3 ≤ xLen) (hy : 2 ≤ yLen) :
+    (torusContiguousRectangle xStart yStart xLen yLen : Finset (TorusVertex width height)) =
+      (Finset.range (xLen - 2) ×ˢ Finset.range (yLen - 1)).biUnion
+        (fun p => torusContiguousRectangle (xStart + p.1) (yStart + p.2) 3 2) := by
+  ext v
+  simp only [mem_torusContiguousRectangle, Finset.mem_biUnion, Finset.mem_product,
+    Finset.mem_range]
+  constructor
+  · rintro ⟨hx0, hx1, hy0, hy1⟩
+    refine ⟨(min (v.1.val - xStart) (xLen - 3), min (v.2.val - yStart) (yLen - 2)), ⟨?_, ?_⟩, ?_⟩
+    · omega
+    · omega
+    · omega
+  · rintro ⟨⟨a, b⟩, ⟨_, _⟩, hv⟩
+    omega
+
+/-- A wide-and-short contiguous torus rectangle is injective.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1452 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem shortRectangle_injective
+    (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ)
+    {xStart yStart xLen yLen : ℕ}
+    (hx : 3 ≤ xLen) (hy : 2 ≤ yLen)
+    (hxw : xStart + xLen ≤ width) (hyh : yStart + yLen ≤ height) :
+    κ.IsInjective
+      (torusContiguousRectangle xStart yStart xLen yLen : Finset (TorusVertex width height)) := by
+  rw [contiguousRectangle_eq_biUnion_three_by_two xStart yStart xLen yLen hx hy]
+  refine hUnion.biUnion_injective ?_ _ ?_
+  · exact ⟨(0, 0), by simp [Finset.mem_product, Finset.mem_range]; omega⟩
+  · rintro ⟨a, b⟩ hab
+    simp only [Finset.mem_product, Finset.mem_range] at hab
+    exact h.rect32_injective (by omega) (by omega)
+
+end NormalTorusRectangleInjectivityHypotheses
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusRectangleWitness.lean
+++ b/TNLean/PEPS/TorusRectangleWitness.lean
@@ -1,0 +1,100 @@
+import TNLean.PEPS.TorusRectangleGauge
+import TNLean.PEPS.TorusConjCovarianceFamily
+
+/-!
+# The reference-edge coefficient-identity witness from rectangle injectivity
+
+The orientation-uniform-mod-scalar family is assembled from an `EdgeCoeffIdentityWitness` at every
+edge of each orientation class (`isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses`).
+This file produces such a witness at the distinguished horizontal reference edge from the faithful
+rectangle-injectivity reference datum: the per-edge gauge of `exists_horizontalReferenceEdgeGauge_coeff`
+realizes the region-insertion coefficient identity over the reference red region, so taking it as
+both the per-edge gauge and the reference gauge yields a witness.
+
+This is the base case of the geometric production the orientation-uniform reduction consumes.  The
+remaining step — transporting the reference witness along each class translation to obtain a witness
+at every edge against the *transported* reference matrix — is the residual obligation recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, using
+`regionInsertedCoeff_translate_coeffIdentity` and `exists_regionEdgeGauge_torus_coeff` on the
+translated blocking datum.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- **A coefficient-identity witness at the horizontal reference edge from rectangle injectivity.**
+
+For two torus tensors `A`, `B` with the same state, matched bond dimensions, positive bonds, and
+both satisfying the rectangular-injectivity hypotheses with union closure, the distinguished
+horizontal reference edge carries an `EdgeCoeffIdentityWitness` whose region is the reference red
+block and whose per-edge and reference gauges are both the per-edge gauge `Z` produced by the gauge
+engine.  Both coefficient identities are the single identity `Z` realizes, so the witness holds.
+
+This exhibits the witness interface as inhabited by the faithful rectangle-injectivity reference
+datum, the base case of the orientation-class production.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_edgeCoeffIdentityWitness_horizontalReference
+    {A B : Tensor (torusGraph width height) d} {xStart yStart : ℕ}
+    (hA : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hB : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
+    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
+    ∃ (hE : A.bondDim (torusHorizontalReferenceEdge xStart yStart) =
+        B.bondDim (torusHorizontalReferenceEdge xStart yStart))
+      (Z : GL (Fin (B.bondDim (torusHorizontalReferenceEdge xStart yStart))) ℂ),
+      Nonempty (EdgeCoeffIdentityWitness A B (torusHorizontalReferenceEdge xStart yStart) Z Z hE) := by
+  obtain ⟨hEdge, Z, hZ⟩ :=
+    exists_horizontalReferenceEdgeGauge_coeff hA hB hUA hUB hx0 hy0 hxw hyh hxw' hyh'
+      hbond hAB hd hposA hposB
+  refine ⟨hEdge, Z, ⟨?_⟩⟩
+  -- `B`'s red and host blocks are injective.
+  have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (torusHorizontalRectangleBlockingDatum hA hUA hx0 hy0 hxw' hyh').red := by
+    have hi := hB.horizontalEdgeRed_injective (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ (torusHorizontalRectangleBlockingDatum hA hUA hx0 hy0 hxw' hyh').red) :=
+    regionBlockedTensorInjective_host
+      (torusHorizontalRectangleBlockingDatum hB hUB hx0 hy0 hxw' hyh') hUB
+  -- The single boundary edge of the reference red region.
+  have hsingle := fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hA hUA hx0 hy0
+    hxw hyh hxw' hyh' g
+  exact
+    { region := (torusHorizontalRectangleBlockingDatum hA hUA hx0 hy0 hxw' hyh').red
+      isBoundary :=
+        (singleBoundaryEdge (G := torusGraph width height) A
+          (torusHorizontalRectangleBlockingDatum hA hUA hx0 hy0 hxw' hyh').red
+          (torusHorizontalRectangleBlockingDatum hA hUA hx0 hy0 hxw' hyh').blue
+          (torusHorizontalReferenceEdge xStart yStart) hsingle).2
+      hRB := hRB
+      hCB := hCB
+      hposB := hposB
+      hidZ := hZ
+      hidZref := hZ }
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusRectangleWitness.lean
+++ b/TNLean/PEPS/TorusRectangleWitness.lean
@@ -7,7 +7,8 @@ import TNLean.PEPS.TorusConjCovarianceFamily
 The orientation-uniform-mod-scalar family is assembled from an `EdgeCoeffIdentityWitness` at every
 edge of each orientation class (`isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses`).
 This file produces such a witness at the distinguished horizontal reference edge from the faithful
-rectangle-injectivity reference datum: the per-edge gauge of `exists_horizontalReferenceEdgeGauge_coeff`
+rectangle-injectivity reference datum: the per-edge gauge of
+`exists_horizontalReferenceEdgeGauge_coeff`
 realizes the region-insertion coefficient identity over the reference red region, so taking it as
 both the per-edge gauge and the reference gauge yields a witness.
 
@@ -65,7 +66,8 @@ theorem exists_edgeCoeffIdentityWitness_horizontalReference
     ∃ (hE : A.bondDim (torusHorizontalReferenceEdge xStart yStart) =
         B.bondDim (torusHorizontalReferenceEdge xStart yStart))
       (Z : GL (Fin (B.bondDim (torusHorizontalReferenceEdge xStart yStart))) ℂ),
-      Nonempty (EdgeCoeffIdentityWitness A B (torusHorizontalReferenceEdge xStart yStart) Z Z hE) := by
+      Nonempty
+        (EdgeCoeffIdentityWitness A B (torusHorizontalReferenceEdge xStart yStart) Z Z hE) := by
   obtain ⟨hEdge, Z, hZ⟩ :=
     exists_horizontalReferenceEdgeGauge_coeff hA hB hUA hUB hx0 hy0 hxw hyh hxw' hyh'
       hbond hAB hd hposA hposB

--- a/TNLean/PEPS/TorusReferenceBlockingData.lean
+++ b/TNLean/PEPS/TorusReferenceBlockingData.lean
@@ -1,0 +1,102 @@
+import TNLean.PEPS.SingletonEdgeBlockingData
+import TNLean.PEPS.TorusTranslationInvariant
+
+/-!
+# The concrete torus reference blocking datum
+
+For a vertex-injective torus tensor with positive bond dimensions, the singleton-endpoint blocking
+datum (`singletonEdgeBlockingData`) supplies a reference one-edge blocking datum at the reference
+horizontal edge `torusRightEdge 0` and the reference vertical edge `torusUpEdge 0` of the two
+orientation classes.  This is the concrete reference datum the translation-invariant gauge family
+consumes: translation carries it to every edge of its class (`translateBlockingData`), and the
+single red-to-blue crossing is the reference edge itself.
+
+The wraparound geometry of the torus never enters.  The open-lattice every-edge construction needs
+wraparound-avoiding rectangles with size bounds because it works at rectangle granularity, where
+only sufficiently large regions are injective.  Under vertex injectivity every finite region is
+injective, so singleton endpoint blocks suffice and the construction is unconditional on the torus
+dimensions beyond the nontriviality `1 < width`, `1 < height` that make the graph loopless.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 981--1009 and
+  1407--1500 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-! ### Reference horizontal blocking datum -/
+
+/-- **Reference horizontal blocking datum on the torus.**
+
+For a vertex-injective torus tensor with positive bond dimensions, the reference horizontal edge
+`torusRightEdge 0` carries the singleton-endpoint blocking datum: its red block is the left
+endpoint, its blue block the right endpoint, and its complement the rest of the torus.  All three
+are injective, they partition the torus, and the single red-to-blue crossing is the reference edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 981--1009 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def torusHorizontalReferenceBlockingDatum
+    (A : Tensor (torusGraph width height) d)
+    (hA : IsVertexInjective A)
+    (hpos : ∀ f : Edge (torusGraph width height), 0 < A.bondDim f) :
+    NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) (torusRightEdge 0) :=
+  singletonEdgeBlockingData A (torusRightEdge 0) hA hpos
+
+/-- The red-to-blue crossings of the reference horizontal blocking datum are exactly the reference
+horizontal edge `torusRightEdge 0`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isCrossingEdge_torusHorizontalReferenceBlockingDatum
+    (A : Tensor (torusGraph width height) d)
+    (hA : IsVertexInjective A)
+    (hpos : ∀ f : Edge (torusGraph width height), 0 < A.bondDim f)
+    (g : Edge (torusGraph width height)) :
+    IsCrossingEdge (G := torusGraph width height) A
+        (torusHorizontalReferenceBlockingDatum A hA hpos).red
+        (torusHorizontalReferenceBlockingDatum A hA hpos).blue g ↔
+      g = torusRightEdge 0 :=
+  isCrossingEdge_singletonEdgeBlockingData A (torusRightEdge 0) hA hpos g
+
+/-! ### Reference vertical blocking datum -/
+
+/-- **Reference vertical blocking datum on the torus.**
+
+The vertical counterpart of `torusHorizontalReferenceBlockingDatum` at the reference vertical edge
+`torusUpEdge 0`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 981--1009 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def torusVerticalReferenceBlockingDatum
+    (A : Tensor (torusGraph width height) d)
+    (hA : IsVertexInjective A)
+    (hpos : ∀ f : Edge (torusGraph width height), 0 < A.bondDim f) :
+    NormalEdgeBlockingData (regionInjectivityDataOf (G := torusGraph width height) A)
+      (torusGraph width height) (torusUpEdge 0) :=
+  singletonEdgeBlockingData A (torusUpEdge 0) hA hpos
+
+/-- The red-to-blue crossings of the reference vertical blocking datum are exactly the reference
+vertical edge `torusUpEdge 0`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isCrossingEdge_torusVerticalReferenceBlockingDatum
+    (A : Tensor (torusGraph width height) d)
+    (hA : IsVertexInjective A)
+    (hpos : ∀ f : Edge (torusGraph width height), 0 < A.bondDim f)
+    (g : Edge (torusGraph width height)) :
+    IsCrossingEdge (G := torusGraph width height) A
+        (torusVerticalReferenceBlockingDatum A hA hpos).red
+        (torusVerticalReferenceBlockingDatum A hA hpos).blue g ↔
+      g = torusUpEdge 0 :=
+  isCrossingEdge_singletonEdgeBlockingData A (torusUpEdge 0) hA hpos g
+
+end PEPS
+end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1594,6 +1594,20 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.isCrossingEdge_transportBlockingDataAlong},
           \leanid{TNLean.PEPS.translateBlockingData}, and
           \leanid{TNLean.PEPS.isCrossingEdge_translateBlockingData}.}
+          The reference blocking datum at each class's reference edge is now constructed
+          concretely.  For a vertex-injective tensor with positive bond dimensions every
+          finite vertex region is injective, so the singleton endpoint blocks and their
+          complement form a one-edge blocking datum with no rectangular geometry: the
+          left endpoint is the red block, the right endpoint the blue block, the rest of
+          the torus the complement, and the only red-to-blue crossing is the edge itself.
+          This supplies the reference datum at the reference horizontal and vertical edges
+          directly, with no wraparound-avoiding rectangle bounds, since singleton blocks
+          need no room to be injective once the tensor is vertex injective.\footnote{
+          Formal declarations:
+          \leanid{TNLean.PEPS.singletonEdgeBlockingData},
+          \leanid{TNLean.PEPS.isCrossingEdge_singletonEdgeBlockingData},
+          \leanid{TNLean.PEPS.torusHorizontalReferenceBlockingDatum}, and
+          \leanid{TNLean.PEPS.torusVerticalReferenceBlockingDatum}.}
           The per-edge gauge interface applies verbatim on the torus (it is stated
           over a general finite ordered vertex set), and the orientation-uniform
           reduction is ported to the torus, so the assembly above a class-agreement

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1693,6 +1693,50 @@ The remaining obligations are the following.
           and
           \leanid{TNLean.PEPS.regionBlockedTensorInjective_host_transportBlockingDataAlong}.}
 
+          The reference blocking datum is now produced from the source's own
+          rectangular-injectivity hypotheses on the torus, with no single-vertex
+          injectivity. Contiguous torus rectangles read the half-open coordinate
+          intervals through the value embedding, so wraparound-avoiding offsets recover
+          the contiguous block and full-coordinate bands cover the whole range; the
+          $2\times3$ and $3\times2$ shape predicates, the native rectangular-injectivity
+          hypotheses, and the sliding-window tiling are the torus ports of the open-lattice
+          development. The horizontal and vertical reference edges carry the red (removed
+          source rectangle), blue (the other removed source rectangle), and complementary
+          (the band-and-filler cover) blocks; all three are injective by rectangular
+          injectivity and union closure, they partition the torus, and the cyclic-step
+          value lemmas read a wraparound-free step as the ordinary step, so the single
+          red-to-blue crossing is the reference edge. This is the source-faithful
+          replacement for the vertex-injective singleton scaffolding.\footnote{Formal
+          declarations:
+          \leanid{TNLean.PEPS.NormalTorusRectangleInjectivityHypotheses},
+          \leanid{TNLean.PEPS.NormalTorusRectangleInjectivityHypotheses.horizontalEdgeComplement_injective},
+          \leanid{TNLean.PEPS.torusHorizontalRectangleBlockingDatum},
+          \leanid{TNLean.PEPS.torusVerticalRectangleBlockingDatum},
+          \leanid{TNLean.PEPS.isCrossingEdge_torusHorizontalEdge}, and
+          \leanid{TNLean.PEPS.isCrossingEdge_torusVerticalEdge}.}
+
+          Feeding this faithful datum to the per-edge gauge engine yields, at the reference
+          edge, the per-edge conjugation gauge realizing the region-insertion coefficient
+          identity, with the second tensor's red and host injectivities supplied by its own
+          rectangle hypotheses and union closure. The conjugation-covariance input the
+          orientation-uniform selection consumes is packaged as a per-edge coefficient-identity
+          witness — a region with single boundary edge $e$, the second tensor's
+          region and host injectivity, and the two coefficient identities the per-edge gauge
+          and the transported reference gauge realize. Each witness yields the conjugation
+          coincidence by the transfer-map determinacy, and gathering the two orientation
+          classes assembles the orientation-uniform-up-to-scalar family. The reference edge
+          inhabits this witness interface directly. What remains is exactly the
+          translation production above: transporting the reference witness along each class
+          translation to obtain a witness at every edge against the \emph{transported}
+          reference matrix, matching the translated region and boundary edge of
+          \leanid{TNLean.PEPS.regionInsertedCoeff_translate_coeffIdentity} with those read off
+          the per-edge gauge of the translated blocking datum.\footnote{Formal declarations:
+          \leanid{TNLean.PEPS.exists_horizontalReferenceEdgeGauge_coeff},
+          \leanid{TNLean.PEPS.EdgeCoeffIdentityWitness},
+          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses},
+          and
+          \leanid{TNLean.PEPS.exists_edgeCoeffIdentityWitness_horizontalReference}.}
+
           The final region comparison setup is also formalized: a region and its set
           complement are wrapped as the two blocks consumed by the two-injective
           comparison, and from matched region-inserted coefficients of the two

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1663,6 +1663,22 @@ The remaining obligations are the following.
           still depends on the open per-edge gauge of obligation~5 for the transfer maps
           themselves.
 
+          The endpoint-reordering branch is now handled at the level of the gauge-interface
+          inputs. The transported datum's complement block is always the image of the
+          reference complement, and its red block is one of the two image blocks; whichever
+          image block plays the red role, that block is injective and the union of the
+          remaining two covers the host region of the red block and is injective under
+          union closure. So both injectivity inputs the per-edge gauge consumes are
+          available on both branches, with no case split, and the region-inserted
+          coefficient is endpoint-symmetric. What is left is to route the orientation-class
+          matching through the image of the reference red region rather than the
+          possibly-swapped red slot, which the region-polymorphic coefficient covariance
+          already supplies.\footnote{Formal declarations:
+          \leanid{TNLean.PEPS.transportBlockingDataAlong_complement},
+          \leanid{TNLean.PEPS.regionBlockedTensorInjective_transportBlockingDataAlong_red},
+          and
+          \leanid{TNLean.PEPS.regionBlockedTensorInjective_host_transportBlockingDataAlong}.}
+
           The final region comparison setup is also formalized: a region and its set
           complement are wrapped as the two blocks consumed by the two-injective
           comparison, and from matched region-inserted coefficients of the two


### PR DESCRIPTION
## What

The three residuals of the TI Normal PEPS FT route (#1373). All sorry-free; `#print axioms`
= `[propext, Classical.choice, Quot.sound]`; full root build green (8,860 jobs).

## Highlights

- **`exists_stateCoeff_ne_zero_of_regionInjective`** (faithfulness-critical): the state
  nonvanishing from REGION injectivity of `R` and its complement — replacing the
  vertex-injective-only version in the λ-counting chain. Strictly stronger than scoped
  (the `0 < d` hypothesis proved unnecessary).
- **Branch-free transport injectivity**: `transportBlockingDataAlong_complement` + the
  red/host injectivity lemmas hold on BOTH orientation branches with no case split — the
  swap only changes which injective image block plays the red role (route (a) via the
  two-block swap was checked and refuted; the coefficient's endpoint symmetry makes
  route (b) clean).
- **Torus reference blocking data** (`torusHorizontal/VerticalReferenceBlockingDatum` via a
  graph-polymorphic `singletonEdgeBlockingData`): the reference datum at the canonical
  edges. **Honest scope**: constructed under vertex injectivity (singleton blocks); the
  faithful normal-route datum from rectangle hypotheses remains the documented geometry
  port.

Refs #1373. CI failures are non-blocking automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large but additive Lean formalization and documentation on the PEPS/torus path; no auth, runtime, or data-handling changes.
> 
> **Overview**
> Extends the **translation-invariant normal PEPS** formalization (arXiv:1804.04964 §3) with region-level faithfulness, transport lemmas that avoid orientation case splits, and a full torus reference-blocking stack wired into the public import surface.
> 
> **Region injectivity:** Adds `exists_stateCoeff_ne_zero_of_regionInjective`, showing a positive-bond PEPS has a nonzero closed state coefficient when an arbitrary region `R` and its complement are both region-block injective—splitting at `R` instead of a single vertex, without requiring `0 < d`.
> 
> **Transport / gauge inputs:** Proves `transportBlockingDataAlong_complement` and unconditional red/host injectivity for transported blocking data (`regionBlockedTensorInjective_transportBlockingDataAlong_red`, `regionBlockedTensorInjective_host_transportBlockingDataAlong`) so endpoint-order flips only swap which injective block is “red.”
> 
> **Torus scaffolding:** New modules define (1) **singleton** one-edge blocking under vertex injectivity (`singletonEdgeBlockingData`, `torusHorizontal/VerticalReferenceBlockingDatum`), (2) **rectangle-faithful** torus regions, horizontal/vertical edge blockings, single-crossing geometry (`TorusRectangleRegion`, `TorusEdgeBlockingRegion`, `TorusEdgeBlockingCrossing`, `torusHorizontal/VerticalRectangleBlockingDatum`), (3) reference-edge gauges and `EdgeCoeffIdentityWitness` packaging that yields orientation-uniform-mod-scalar families via `isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses`. The route doc (`peps_normal_ft_section3_route.tex`) is updated to record what is discharged vs. the remaining translation of witnesses to every edge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536dfddb55812126b02cffd1123e431aa2a4d333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->